### PR TITLE
fix a bug (can't open individual practice page when not logined)

### DIFF
--- a/app/views/practices/show.html.haml
+++ b/app/views/practices/show.html.haml
@@ -5,7 +5,8 @@
 .practice= simple_format rendering(@practice.description)
 %h2= t('helpers.label.practice.goal')
 .goal= simple_format rendering(@practice.goal)
-= @practice.learning_status(current_user.id)
+- if current_user.present?
+  = @practice.learning_status(current_user.id)
 = link_to t('edit'), edit_practice_path(@practice), class: 'btn btn-primary'
 = link_to t('destroy'), practice_path(@practice), data: { confirm: t('are_you_sure') }, method: :delete, class: 'btn btn-danger'
 


### PR DESCRIPTION
[昼のコミット](https://github.com/fjordllc/interns/commit/6d67a4235cf5e37a34a157759b03589c4f8e39c5)によって未ログイン時に/practices/:id ページがエラーにより開けなくなっていたのを修正しました。
