### PR TITLE
activate users-nav on index action only

### DIFF
--- a/app/views/application/_nav.html.haml
+++ b/app/views/application/_nav.html.haml
@@ -4,7 +4,7 @@
       = link_to current_user do
         = gravatar_tag current_user, size: 20
         = current_user.login_name
-  %li{controller_name == 'users' ? { class: 'active' } : {}}
+  %li{(controller_name == 'users' and action_name == 'index') ? { class: 'active' } : {}}
     = link_to users_path do
       %i.icon-user
       = t('listing_users')


### PR DESCRIPTION
個別のユーザページ(users/:id)でも右上のナビゲーションでユーザー一覧が強調表示されていたのを修正しました
