### PR TITLE
fix capybara version to pass test using capybara-webkit #38

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'capybara'
+  gem 'capybara', '~> 2.0.3'
   gem 'rspec-rails', '~> 2.13.0'
   gem 'factory_girl_rails'
   gem 'capybara-webkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,15 +54,18 @@ GEM
     bootstrap-sass (2.3.0.1)
       sass (~> 3.2)
     builder (3.1.4)
-    capybara (2.1.0)
+    capybara (2.0.3)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      selenium-webdriver (~> 2.0)
+      xpath (~> 1.0.0)
     capybara-webkit (0.14.2)
       capybara (~> 2.0, >= 2.0.2)
       json
+    childprocess (0.3.9)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.0.9)
     coffee-rails (4.0.0)
       coffee-script (>= 2.2.0)
@@ -86,6 +89,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.8.7)
       multipart-post (~> 1.1)
+    ffi (1.8.1)
     flat-ui-rails (0.0.2)
     font-awesome-sass-rails (3.0.0.1)
       railties (>= 3.1.1)
@@ -185,12 +189,18 @@ GEM
       rspec-mocks (~> 2.13.0)
     ruby_parser (3.1.3)
       sexp_processor (~> 4.1)
+    rubyzip (0.9.9)
     sass (3.2.8)
     sass-rails (4.0.0.rc1)
       railties (>= 4.0.0.beta, < 5.0)
       sass (>= 3.1.10)
       sprockets-rails (~> 2.0.0.rc0)
       tilt (~> 1.3)
+    selenium-webdriver (2.32.1)
+      childprocess (>= 0.2.5)
+      multi_json (~> 1.0)
+      rubyzip
+      websocket (~> 1.0.4)
     sexp_processor (4.2.1)
     simple_enum (1.6.4)
       activesupport (>= 3.0.0)
@@ -219,7 +229,8 @@ GEM
     uglifier (2.0.1)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
-    xpath (2.0.0)
+    websocket (1.0.7)
+    xpath (1.0.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
@@ -228,7 +239,7 @@ PLATFORMS
 DEPENDENCIES
   active_decorator!
   bootstrap-sass (~> 2.3.0.1)
-  capybara
+  capybara (~> 2.0.3)
   capybara-webkit
   coffee-rails (~> 4.0.0.beta1)
   dynamic_form


### PR DESCRIPTION
https://github.com/fjordllc/interns/issues/38
のため、capybaraのバージョンを2.0.3に固定
