### PR TITLE
issue #360 日報の学習時間の差異修正

### DIFF
--- a/app/decorators/report_decorator.rb
+++ b/app/decorators/report_decorator.rb
@@ -5,7 +5,7 @@ module ReportDecorator
     end
 
     total_minute = total_time / 60
-    hour = (total_minute / 60).round
+    hour = (total_minute / 60).to_i
     minute = (total_minute % 60).round
 
     if minute == 0

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -21,4 +21,104 @@ class ReportsTest < ApplicationSystemTestCase
     report_practices = page.all(".select-practices__label-title").map { |e| e.text }
     assert_equal practices, report_practices
   end
+ 
+  test "issue #360 duplicate" do
+    visit "/reports/new"
+    fill_in "report_title", with: "テスト日報"
+    fill_in "report_description", with: "不具合再現の結合テストコード"
+
+    selects = all("select")
+    select "07", from: selects[0]["id"]
+    select "50", from: selects[1]["id"]
+    select "08", from: selects[2]["id"]
+    select "50", from: selects[3]["id"]
+
+    click_link "学習時間追加"
+    selects = all("select")
+    select "08", from: selects[4]["id"]
+    select "50", from: selects[5]["id"]
+    select "09", from: selects[6]["id"]
+    select "50", from: selects[7]["id"]
+
+    click_link "学習時間追加"
+    selects = all("select")
+    select "19", from: selects[8]["id"]
+    select "30", from: selects[9]["id"]
+    select "20", from: selects[10]["id"]
+    select "10", from: selects[11]["id"]
+
+    click_button "登録する"
+
+    assert_text "2時間40分"
+    assert_text "07:50 〜 08:50"
+    assert_text "08:50 〜 09:50"
+    assert_text "19:30 〜 20:10"
+  end
+
+  test "register learning_times 2h" do
+    visit "/reports/new"
+    fill_in "report_title", with: "テスト日報 成功"
+    fill_in "report_description", with: "不具合再現の結合テストコード"
+
+    selects = all("select")
+    select "07", from: selects[0]["id"]
+    select "50", from: selects[1]["id"]
+    select "08", from: selects[2]["id"]
+    select "50", from: selects[3]["id"]
+
+    click_link "学習時間追加"
+    selects = all("select")
+    select "08", from: selects[4]["id"]
+    select "50", from: selects[5]["id"]
+    select "09", from: selects[6]["id"]
+    select "50", from: selects[7]["id"]
+
+    click_button "登録する"
+
+    assert_text "2時間\n"
+    assert_text "07:50 〜 08:50"
+    assert_text "08:50 〜 09:50"
+  end
+  
+  test "register learning_times 1h40m" do
+    visit "/reports/new"
+    fill_in "report_title", with: "テスト日報 成功"
+    fill_in "report_description", with: "不具合再現の結合テストコード"
+
+    selects = all("select")
+    select "07", from: selects[0]["id"]
+    select "50", from: selects[1]["id"]
+    select "08", from: selects[2]["id"]
+    select "50", from: selects[3]["id"]
+
+    click_link "学習時間追加"
+    selects = all("select")
+    select "19", from: selects[4]["id"]
+    select "30", from: selects[5]["id"]
+    select "20", from: selects[6]["id"]
+    select "10", from: selects[7]["id"]
+
+    click_button "登録する"
+
+    assert_text "1時間40分\n"
+    assert_text "07:50 〜 08:50"
+    assert_text "19:30 〜 20:10"
+  end
+
+  test "register learning_time 40m" do
+    visit "/reports/new"
+    fill_in "report_title", with: "テスト日報 成功"
+    fill_in "report_description", with: "不具合再現の結合テストコード"
+
+    selects = all("select")
+    select "19", from: selects[0]["id"]
+    select "30", from: selects[1]["id"]
+    select "20", from: selects[2]["id"]
+    select "10", from: selects[3]["id"]
+
+    click_button "登録する"
+
+    assert_text "40分\n"
+    assert_text "19:30 〜 20:10"
+  end
 end


### PR DESCRIPTION
登録した日報の合計学習時間に差異が出る問題。
原因は合計時間の時間算出時にroundが使われていたためでした。
欲しいのは整数部分（時間部分）のため、to_iに変更して対応致しました。

コードレビュー宜しくお願い致します。
またGitコメントやテスト名称も気になるのでご指摘あれば宜しくお願いします。
