### PR TITLE
日報に次と前が欲しい 

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,10 +14,20 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.order(created_at: :desc).order(id: :desc).where(user_id: user_id).where("created_at <= ? ", created_at).find_by("id < ?", id)
+    report = Report.order(created_at: :desc).order(id: :desc).where(user_id: user_id).where( "created_at = ? ", created_at).find_by("id < ? ", id)
+
+    if report == nil
+      report = Report.order(created_at: :desc).order(id: :desc).where(user_id: user_id).where("created_at < ? ", created_at).first
+    end
+    report
   end
 
   def next
-    Report.order(created_at: :asc).order(id: :asc).where(user_id: user_id).where("created_at >= ? ", created_at).find_by("id > ?", id)
+    report = Report.order(created_at: :asc).order(id: :asc).where(user_id: user_id).where("created_at = ? ", created_at).find_by("id > ? ", id)
+
+    if report  == nil
+      report = Report.order(created_at: :asc).order(id: :asc).where(user_id: user_id).where("created_at > ? ", created_at).first
+    end
+    report
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,11 +14,11 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.order(created_at: :desc).where(user_id: user_id).find_by("created_at > ?", created_at)
+    Report.order(created_at: :desc).where(user_id: user_id).find_by("created_at < ?", created_at)
   end
 
   def next
-    Report.order(created_at: :asc).where(user_id: user_id).find_by("created_at < ?", created_at)
+    Report.order(created_at: :asc).where(user_id: user_id).find_by("created_at > ?", created_at)
   end
   
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,10 +14,10 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.where("user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id).order(id: :DESC).first
+    Report.where("user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id).order(id: :desc).first
   end
 
   def next
-    Report.where("user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id).order(id: :ASC).first
+    Report.where("user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id).order(id: :asc).first
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,11 +14,10 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.order(created_at: :desc).where(user_id: user_id).find_by("created_at < ?", created_at)
+    Report.order(created_at: :desc).order(id: :desc).where(user_id: user_id).where("created_at <= ? ", created_at).find_by("id < ?", id)
   end
 
   def next
-    Report.order(created_at: :asc).where(user_id: user_id).find_by("created_at > ?", created_at)
+    Report.order(created_at: :asc).order(id: :asc).where(user_id: user_id).where("created_at >= ? ", created_at).find_by("id > ?", id)
   end
-  
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,10 +14,10 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.where("user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id).order(id: :DESC).first
+    Report.where("user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id).order(id: :DESC).limit(1).first
   end
 
   def next
-    Report.where("user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id).order(id: :ASC).first
+    Report.where("user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id).order(id: :ASC).limit(1).first
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,20 +14,17 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    report = Report.order(created_at: :desc).order(id: :desc).where(user_id: user_id).where( "created_at = ? ", created_at).find_by("id < ? ", id)
-
-    if report == nil
-      report = Report.order(created_at: :desc).order(id: :desc).where(user_id: user_id).where("created_at < ? ", created_at).first
-    end
-    report
+    Report
+      .where("user_id = ? AND created_at = ? AND id < ?", user_id, created_at, id)
+      .or(Report.where("user_id = ? AND created_at < ?", user_id, created_at))
+      .order("created_at DESC, id DESC")
+      .first
   end
 
   def next
-    report = Report.order(created_at: :asc).order(id: :asc).where(user_id: user_id).where("created_at = ? ", created_at).find_by("id > ? ", id)
-
-    if report  == nil
-      report = Report.order(created_at: :asc).order(id: :asc).where(user_id: user_id).where("created_at > ? ", created_at).first
-    end
-    report
+    Report.where("user_id = ? AND created_at = ? AND id > ?", user_id, created_at, id)
+      .or(Report.where("user_id = ? AND created_at > ?", user_id, created_at))
+      .order("created_at ASC, id ASC")
+      .first
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -13,12 +13,12 @@ class Report < ActiveRecord::Base
   validates :user, presence: true
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
-  def previous_report
-    Report.where("id < ?", self.id).order("id DESC").first
+  def previous
+    Report.where("created_at < ?", self.created_at).order("created_at DESC").first
   end
 
-  def next_report
-    Report.where("id > ?", self.id).order("id ASC").first
+  def next
+    Report.where("created_at > ?", self.created_at).order("created_at ASC").first
   end
   
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,11 +14,11 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.where("created_at < ?", self.created_at).order("created_at DESC").first
+    Report.order("created_at DESC").find_by("created_at < ?", self.created_at)
   end
 
   def next
-    Report.where("created_at > ?", self.created_at).order("created_at ASC").first
+    Report.order("created_at ASC").find_by("created_at < ?", self.created_at)
   end
   
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,11 +14,11 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.order("created_at DESC").find_by("created_at < ?", self.created_at)
+    Report.order(created_at: :desc).where(user_id: user_id).find_by("created_at < ?", created_at)
   end
 
   def next
-    Report.order("created_at ASC").find_by("created_at < ?", self.created_at)
+    Report.order(created_at: :asc).where(user_id: user_id).find_by("created_at < ?", created_at)
   end
   
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,7 +14,7 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.order(created_at: :desc).where(user_id: user_id).find_by("created_at < ?", created_at)
+    Report.order(created_at: :desc).where(user_id: user_id).find_by("created_at > ?", created_at)
   end
 
   def next

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,14 +14,10 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report
-      .where(["user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id])
-      .order(created_at: :asc).first
+    Report.where("user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id).order(id: :DESC).first
   end
 
   def next
-    Report
-      .where(["user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id])
-      .order(created_at: :asc).first
+    Report.where("user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id).order(id: :ASC).first
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -15,16 +15,13 @@ class Report < ActiveRecord::Base
 
   def previous
     Report
-      .where("user_id = ? AND created_at = ? AND id < ?", user_id, created_at, id)
-      .or(Report.where("user_id = ? AND created_at < ?", user_id, created_at))
-      .order("created_at DESC, id DESC")
-      .first
+      .where(["user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id])
+      .order(created_at: :asc).first
   end
 
   def next
-    Report.where("user_id = ? AND created_at = ? AND id > ?", user_id, created_at, id)
-      .or(Report.where("user_id = ? AND created_at > ?", user_id, created_at))
-      .order("created_at ASC, id ASC")
-      .first
+    Report
+      .where(["user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id])
+      .order(created_at: :asc).first
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,10 +14,10 @@ class Report < ActiveRecord::Base
   validates :reported_at, presence: true, uniqueness: { scope: :user }
 
   def previous
-    Report.where("user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id).order(id: :DESC).limit(1).first
+    Report.where("user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id).order(id: :DESC).first
   end
 
   def next
-    Report.where("user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id).order(id: :ASC).limit(1).first
+    Report.where("user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id).order(id: :ASC).first
   end
 end

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -63,11 +63,5 @@
           i.fa.fa-angle-left
           = t('to_index_of_reports')
 
-        - if report.previous != nil
-          = link_to '前', report_path(report.previous.id)
-
-
-        - if report.next != nil
-          = link_to '次', report_path(report.next.id)
   = link_to report.user, itempro: "url", class: "thread__author-link" do
     = gravatar_tag report.user, secure: true, size: 120, html: { class: "thread__author-icon" }

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -62,6 +62,10 @@
         = link_to reports_path, class: 'is-button-standard-sm-secondary' do
           i.fa.fa-angle-left
           = t('to_index_of_reports')
+        - if report.previous
+          = link_to '前', report_path(report.previous)
+        - if report.next
+          = link_to '次', report_path(report.next)
 
   = link_to report.user, itempro: "url", class: "thread__author-link" do
     = gravatar_tag report.user, secure: true, size: 120, html: { class: "thread__author-icon" }

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -59,14 +59,15 @@
               li.thread__actions-item
                 = link_to report_path(report), data: { confirm: t('are_you_sure') }, method: :delete, class: 'thread__actions-item-link is-danger' do
                   i.fa.fa-trash-o
-
-        = link_to '前', report_path(@report.previous_report)
-
         = link_to reports_path, class: 'is-button-standard-sm-secondary' do
           i.fa.fa-angle-left
           = t('to_index_of_reports')
 
-        = link_to '次', report_path(@report.next_report)
+        - if report.previous != nil
+          = link_to '前', report_path(report.previous.id)
 
+
+        - if report.next != nil
+          = link_to '次', report_path(report.next.id)
   = link_to report.user, itempro: "url", class: "thread__author-link" do
     = gravatar_tag report.user, secure: true, size: 120, html: { class: "thread__author-icon" }

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -63,9 +63,9 @@
           i.fa.fa-angle-left
           = t('to_index_of_reports')
         - if report.previous
-          = link_to '前', report_path(report.previous)
+          = link_to '前', report.previous
         - if report.next
-          = link_to '次', report_path(report.next)
+          = link_to '次', report.next
 
   = link_to report.user, itempro: "url", class: "thread__author-link" do
     = gravatar_tag report.user, secure: true, size: 120, html: { class: "thread__author-icon" }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_03_10_160849) do
+ActiveRecord::Schema.define(version: 20180310160849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,6 +85,8 @@ ActiveRecord::Schema.define(version: 2018_03_10_160849) do
     t.boolean "user_policy_agreed", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "purpose_content", null: false
+    t.datetime "purpose_deadline", null: false
   end
 
   create_table "footprints", id: :serial, force: :cascade do |t|

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -1,5 +1,4 @@
 report_1:
-  id: 1
   user: komagata
   title: "作業週1日目"
   description: |-

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -1,4 +1,5 @@
 report_1:
+  id: 1
   user: komagata
   title: "作業週1日目"
   description: |-
@@ -8,6 +9,7 @@ report_1:
   created_at: "2017-01-01 00:00:00"
 
 report_2:
+  id: 3
   user: komagata
   title: "作業週2日目"
   description: |-
@@ -17,12 +19,13 @@ report_2:
   created_at: "2017-01-02 00:00:00"
 
 report_3:
+  id: 2
   user: komagata
   title: "学習週1日目"
   description: |-
     今日は CSS の勉強をしました。デザイン難しい。。。
   reported_at: "2017-01-03"
-  created_at: "2017-01-03 00:00:00"
+  created_at: "2017-01-02 00:00:00"
 
 report_4:
   user: machida

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -8,7 +8,6 @@ report_1:
   created_at: "2017-01-01 00:00:00"
 
 report_2:
-  id: 3
   user: komagata
   title: "作業週2日目"
   description: |-
@@ -18,7 +17,6 @@ report_2:
   created_at: "2017-01-02 00:00:00"
 
 report_3:
-  id: 2
   user: komagata
   title: "学習週1日目"
   description: |-

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -5,6 +5,7 @@ report_1:
     今日はローカルで怖話を動かしてみました。
     rbenv で ruby を動かすのは初めてだったので、色々手間取りました。
   reported_at: "2017-01-01"
+  created_at: <%= 2.day.ago %>
 
 report_2:
   user: komagata
@@ -13,6 +14,7 @@ report_2:
     今日はローカルで Fjord Bootcamp を動かしてみました。
     ruby の指定バージョンが 2.2.3 だったので、 rbenv で ruby のバージョンを上げました。
   reported_at: "2017-01-02"
+  created_at: <%= 1.day.ago %>
 
 report_3:
   user: komagata
@@ -20,6 +22,7 @@ report_3:
   description: |-
     今日は CSS の勉強をしました。デザイン難しい。。。
   reported_at: "2017-01-03"
+  created_at: <%= Time.now %>
 
 report_4:
   user: machida

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -5,7 +5,7 @@ report_1:
     今日はローカルで怖話を動かしてみました。
     rbenv で ruby を動かすのは初めてだったので、色々手間取りました。
   reported_at: "2017-01-01"
-  created_at: <%= 2.day.ago %>
+  created_at: "2017-01-01 00:00:00"
 
 report_2:
   user: komagata
@@ -14,7 +14,7 @@ report_2:
     今日はローカルで Fjord Bootcamp を動かしてみました。
     ruby の指定バージョンが 2.2.3 だったので、 rbenv で ruby のバージョンを上げました。
   reported_at: "2017-01-02"
-  created_at: <%= 1.day.ago %>
+  created_at: "2017-01-02 00:00:00"
 
 report_3:
   user: komagata
@@ -22,7 +22,7 @@ report_3:
   description: |-
     今日は CSS の勉強をしました。デザイン難しい。。。
   reported_at: "2017-01-03"
-  created_at: <%= Time.now %>
+  created_at: "2017-01-03 00:00:00"
 
 report_4:
   user: machida

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class ReportTest < ActiveSupport::TestCase
+  def setup 
+    reports(:report_2).id = 3
+    reports(:report_3).id = 2
+  end
+  
   test "Should get previous report" do
     report = reports(:report_3)
     assert report.previous, reports(:report_1)

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -3,13 +3,13 @@ require "test_helper"
 class ReportTest < ActiveSupport::TestCase
   #前の日報の取得
   test "Should get previous report" do
-    report = reports(:report_2)
+    report = reports(:report_3)
     assert report.previous, reports(:report_1)
   end
   
   #次の日報の取得
   test "Should get next report" do
-    report = reports(:report_2)
-    assert report.next, reports(:report_3)
+    report = reports(:report_3)
+    assert report.next, reports(:report_2)
   end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class ReportTest < ActiveSupport::TestCase
+  #前の日報の取得
+  test "Should get previous report" do
+    report = reports(:report_2)
+    assert report.previous, reports(:report_1)
+  end
+  
+  #次の日報の取得
+  test "Should get next report" do
+    report = reports(:report_2)
+    assert report.next, reports(:report_3)
+  end
+end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -1,13 +1,11 @@
 require "test_helper"
 
 class ReportTest < ActiveSupport::TestCase
-  #前の日報の取得
   test "Should get previous report" do
     report = reports(:report_3)
     assert report.previous, reports(:report_1)
   end
   
-  #次の日報の取得
   test "Should get next report" do
     report = reports(:report_3)
     assert report.next, reports(:report_2)

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -164,14 +164,12 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text "00:30 〜 02:30"
   end
 
-  # 日報のページに前後の日報へのリンクが有る
   test "Should have links to previous & next report" do
     visit "/reports/#{reports(:report_2).id}"
     assert_text "前"
     assert_text "次"
   end
 
-  # ユーザーの最初の日報のページには"次"はあるが”前”のリンクがない
   test "Should not have a link to previous report on the first report" do
     visit "/reports/#{reports(:report_1).id}"
     assert_no_text "前"

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -176,7 +176,6 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text "次"
   end
 
-  # ユーザーの最新の日報のページには”前”はあるが”次”のリンクがない
   test "Should not have a link to  next report in the newest report" do
     visit "/reports/#{reports(:report_3).id}"
     assert_text "前"

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -163,4 +163,25 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text "22:00 〜 00:00"
     assert_text "00:30 〜 02:30"
   end
+
+  # 日報のページに前後の日報へのリンクが有る
+  test "Should have links to previous & next report" do
+    visit "/reports/#{reports(:report_2).id}"
+    assert_text "前"
+    assert_text "次"
+  end
+
+  # ユーザーの最初の日報のページには"次"はあるが”前”のリンクがない
+  test "Should not have a link to previous report on the first report" do
+    visit "/reports/#{reports(:report_1).id}"
+    assert_no_text "前"
+    assert_text "次"
+  end
+
+  # ユーザーの最新の日報のページには”前”はあるが”次”のリンクがない
+  test "Should not have a link to  next report in the newest report" do
+    visit "/reports/#{reports(:report_3).id}"
+    assert_text "前"
+    assert_no_text "次"
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -165,7 +165,7 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test "Should have links to previous & next report" do
-    visit "/reports/#{reports(:report_2).id}"
+    visit "/reports/#{reports(:report_3).id}"
     assert_text "前"
     assert_text "次"
   end
@@ -177,7 +177,7 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test "Should not have a link to  next report in the newest report" do
-    visit "/reports/#{reports(:report_3).id}"
+    visit "/reports/#{reports(:report_2).id}"
     assert_text "前"
     assert_no_text "次"
   end


### PR DESCRIPTION
fixes #395 
- [x] reportsモデルにメソッドを追加する
    - [x] 日報前後のidを持つ日報id(created_at)を取得する
    - [x] 表示中のユーザーの日報idを取得するように変更する
    - [x]  重複するデータがある場合の対応

- [x] 最初や最後の日報のページでは前後のリンクが出ないようにする
 