### PR TITLE
日報と提出物で確認完了メッセージを分ける

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -9,8 +9,8 @@ class ChecksController < ApplicationController
       checkable: checkable
     )
     if @check.save
-      redirect_to @check.checkable.path, notice: t("checkable_was_successfully_check", 
-                                         checkable: checkable.class.model_name.human)
+      redirect_to @check.checkable.path, notice: t("checkable_was_successfully_check",
+                                                 checkable: checkable.class.model_name.human)
       notify_to_slack(@check)
     else
       render "reports/report"

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -9,7 +9,8 @@ class ChecksController < ApplicationController
       checkable: checkable
     )
     if @check.save
-      redirect_to @check.checkable.path, notice: t("report_was_successfully_check")
+      redirect_to @check.checkable.path, notice: t("checkable_was_successfully_check", 
+                                         checkable: checkable.class.model_name.human)
       notify_to_slack(@check)
     else
       render "reports/report"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -256,6 +256,7 @@ ja:
       page: "Wiki"
       question: "Q&A"
       contact: "申し込みフォーム"
+      product: "提出物"
 
     enums:
       user:
@@ -511,7 +512,7 @@ ja:
   category_was_successfully_updated: "カテゴリーを更新しました。"
   category_was_successfully_deleted: "カテゴリーを削除しました。"
   contact_was_successfully_created: "お申込みを受け付けました。"
-  report_was_successfully_check: "この日報を確認しました。"
+  checkable_was_successfully_check: "この%{checkable}を確認しました。"
   learning_users: "学習中ユーザー"
   for: "%{target} 課題"
   for: "%{target} 課題"

--- a/test/system/check_product_test.rb
+++ b/test/system/check_product_test.rb
@@ -1,0 +1,18 @@
+require "application_system_test_case"
+
+class CheckProductTest < ApplicationSystemTestCase
+  test "Success Product Checking" do
+    login_user "machida", "testtest"
+    click_link "プラクティス"
+    assert_text "OS X Mountain Lionをクリーンインストールする"
+    click_link "OS X Mountain Lionをクリーンインストールする"
+    
+    page.first(".user-reports-item__link").click
+    assert has_button? "提出物を確認"
+    click_button "提出物を確認"
+    assert_not has_button? "提出物を確認"
+    assert_text "この提出物を確認しました。"
+    visit reports_path
+    assert_text "確認済"
+  end
+end


### PR DESCRIPTION
fixes #400 

- [x] 提出物を確認した旨のメッセージリテラルを追加する
- [x] 提出物と日報の判別方法を調べる
- [x] 判別方法に則り、メッセージを分岐させる