### PR TITLE
提出物に関するSlack通知のテキストを修正する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,26 +25,19 @@ class ApplicationController < ActionController::Base
     end
 
   private
-    class NoOpHTTPClient
-      def self.post uri, params={}
-        Rails.logger.info "Notify\nwebhook_uri:#{uri}\nparams:#{params.to_s}"
-      end
-    end
+
     def init_user
       @current_user = User.find(current_user.id) if current_user
     end
 
     def notify(text, options = {})
-
-      icon_url = options[:icon_url] || "http://i.gyazo.com/a8afa9d690ff4bbd87459709bbfe8be9.png"
-      attachments = options[:attachments] || [{}]
-      username = options[:username] || "Bootcamp"
       if Rails.env.production?
+        icon_url = options[:icon_url] || "http://i.gyazo.com/a8afa9d690ff4bbd87459709bbfe8be9.png"
+        attachments = options[:attachments] || [{}]
+        username = options[:username] || "Bootcamp"
+
         notifier = Slack::Notifier.new ENV["SLACK_WEBHOOK_URL"], username: username
-      else
-        notifier = Slack::Notifier.new ENV["SLACK_WEBHOOK_URL"], username: username, http_client: NoOpHTTPClient
-      end
         notifier.ping text, icon_url: icon_url, attachments: attachments
-    
+      end
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,8 @@ class ApplicationController < ActionController::Base
 
         notifier = Slack::Notifier.new ENV["SLACK_WEBHOOK_URL"], username: username
         notifier.ping text, icon_url: icon_url, attachments: attachments
+      else
+        Rails.logger.info "Notify\ntext:#{text}\nparams:#{options}"
       end
     end
 end

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -10,7 +10,7 @@ module Commentable
     when Report
       self[:title]
     when Product
-      self.practice[:title]
+      I18n.translate("practice's_product", practice: self.practice[:title])
     end
   end
 

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -10,7 +10,7 @@ module Commentable
     when Report
       self[:title]
     when Product
-      self[:body][0, 50]
+      self.practice[:title]
     end
   end
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -489,6 +489,7 @@ ja:
   back: "戻る"
   copy: "コピー"
   "bob's_practices": "%{name}のプラクティス"
+  "practice's_product": "「%{practice}」の提出物"
   invalid_email_or_password: "ユーザー名かパスワードが違います。"
   status_for_all_practices: "全てのプラクティスの状態"
   sign_in_successful: "サインインしました。"


### PR DESCRIPTION
fixes #409 
SlackのメッセージAPIでは独自記法をサポートしています。  
[Basic message formatting | Slack](https://api.slack.com/docs/message-formatting)  

提出物のコメント、確認時にこの記法が崩れるのでキャプチャのように修正します。  
![2018-07-25 10 27 50](https://user-images.githubusercontent.com/2727257/43174519-77c9dd6c-8ff5-11e8-9317-3e907e04884e.png)

- [x] 通知文言の修正
- [x] :development時に通知テキストを確認可能にする
