### PR TITLE
WikiのURLをタイトルからIDに変更する

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -20,7 +20,7 @@ class PagesController < ApplicationController
   def create
     @page = Page.new(page_params)
     if @page.save
-      redirect_to "/pages/#{@page.title}", notice: "ページを作成しました。"
+      redirect_to "/pages/#{@page.id}", notice: "ページを作成しました。"
     else
       render :new
     end
@@ -28,7 +28,7 @@ class PagesController < ApplicationController
 
   def update
     if @page.update(page_params)
-      redirect_to "/pages/#{@page.title}", notice: "ページを更新しました。"
+      redirect_to "/pages/#{@page.id}", notice: "ページを更新しました。"
     else
       render :edit
     end
@@ -41,8 +41,8 @@ class PagesController < ApplicationController
 
   private
     def set_page
-      @page = Page.find_by(title: params[:title])
-      redirect_to "/pages/new?title=#{params[:title]}" unless @page
+      @page = Page.find_by(id: params[:id])
+      redirect_to "/pages/new?id=#{params[:id]}" unless @page
     end
 
     def page_params

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -20,7 +20,7 @@ class PagesController < ApplicationController
   def create
     @page = Page.new(page_params)
     if @page.save
-      redirect_to "/pages/#{@page.id}", notice: "ページを作成しました。"
+      redirect_to @page, notice: "ページを作成しました。"
     else
       render :new
     end
@@ -28,7 +28,7 @@ class PagesController < ApplicationController
 
   def update
     if @page.update(page_params)
-      redirect_to "/pages/#{@page.id}", notice: "ページを更新しました。"
+      redirect_to @page, notice: "ページを更新しました。"
     else
       render :edit
     end
@@ -42,7 +42,7 @@ class PagesController < ApplicationController
   private
     def set_page
       @page = Page.find_by(id: params[:id])
-      redirect_to "/pages/new?id=#{params[:id]}" unless @page
+      redirect_to new_page_path unless @page
     end
 
     def page_params

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,6 +2,4 @@ class Page < ActiveRecord::Base
   validates :title, presence: true
   validates :body, presence: true
   paginates_per 20
-
-
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,7 +3,5 @@ class Page < ActiveRecord::Base
   validates :body, presence: true
   paginates_per 20
 
-  def to_param
-    title
-  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
   end
 
   resources :notifications, only: %i(show)
-  resources :pages, param: :title
+  resources :pages
 
   resources :questions do
     resources :answers, only: %i(edit create update destroy)

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -9,18 +9,15 @@ class PagesTest < ApplicationSystemTestCase
     assert_no_selector "nav.pagination"
   end
 
-  test "GET /pages/test1" do
-    visit "/pages/test1"
+  test "show page" do
+    id = pages(:page_1).id
+    visit "/pages/#{id}"
     assert_equal "test1 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
-  test "GET multibyte name" do
-    visit URI.escape("/pages/テスト")
-    assert_equal "テスト | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
-  end
-
-  test "GET multibyte name edit page" do
-    visit URI.escape("/pages/テスト/edit")
+  test "show edit page" do
+    id = pages(:page_2).id
+    visit URI.escape("/pages/#{id}/edit")
     assert_equal "ページ編集 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -28,8 +28,17 @@ class PagesTest < ApplicationSystemTestCase
     fill_in "page[title]", with: "半角スペースを 含んでも 正常なページに 遷移する"
     click_button "内容を保存"
     assert_equal page_path(target_page.reload), current_path
+    assert_text "ページを更新しました"
   end
 
+  test "add new page" do
+    visit new_page_path
+    assert_equal new_page_path, current_path
+    fill_in "page[title]", with: "新規ページを作成する"
+    fill_in "page[body]", with: "新規ページを作成する本文です"
+    click_button "内容を保存"
+    assert_text "ページを作成しました"
+  end
 
   test "Show pagination" do
     Page.delete_all


### PR DESCRIPTION
fixes #370 
WikiのURLをWIkiのページ名からWikiのIDへ変更します。

- [x] routesを修正して、paramsの `title` を `id`へ変更する
- [x] controllerのリダイレクトを `title` を `id`へ変更する
- [x] システムテストのURLを直す
- [x] (将来的に)`.json`等のフォーマットに対応できるような設計で
