### PR TITLE
自分のコメントを一覧できる機能の追加

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-comments.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-comments.sass
@@ -10,6 +10,8 @@ $thread-header-author: 3.5rem
   border-radius: .25rem
   margin-bottom: 2rem
   padding-left: $thread-header-author + 1.25rem
+  &.is-no-author-icon
+    padding-left: 0
   +media-breakpoint-down(sm)
     padding-left: 0
     margin-bottom: 1rem
@@ -24,12 +26,26 @@ $thread-header-author: 3.5rem
   +size(100% auto)
   border-radius: 50%
 
-.thread-comment__login-name
+.thread-comment__title
+  line-height: 1.4
   +media-breakpoint-down(sm)
     margin-bottom: .25rem
 
-.thread-comment__login-name-link
+.thread-comment__title-link
   color: $main-color
+
+.thread-comment__title-label
+  +text-block(.8125rem, $muted-text block 400)
+  margin-bottom: .125rem
+  i
+    margin-right: .1875rem
+
+.thread-comment__title-count
+  +text-block(.8125rem, inline-block $muted-text  400)
+  margin-left: .5rem
+  i
+    margin-right: .125rem
+    +top(-1px)
 
 .thread-comment__body
   background-color: $base
@@ -41,6 +57,9 @@ $thread-header-author: 3.5rem
   +balloon-tail(left $base .75rem 1rem, false, top 1.5rem)
   &::after
     margin-left: -1.4375rem
+  .thread-comment.is-no-author-icon &::before,
+  .thread-comment.is-no-author-icon &::after
+    content: none
   +media-breakpoint-down(sm)
     &::before,
     &::after
@@ -62,10 +81,27 @@ $thread-header-author: 3.5rem
     flex-direction: column
     align-items: flex-start
     padding-bottom: .25rem
+  &.is-icon
+    +position(relative)
+    padding-left: 3.5rem
+    min-height: 4.25rem
+    +media-breakpoint-down(sm)
+      padding-left: 0
+      min-height: 0
+    .thread-comment__created-at
+      align-self: flex-end
+
+.thread-comment__user-icon
+  +size(2.75rem auto)
+  border-radius: 50%
+  +position(absolute, left 0, top 0)
+  +margin(vertical, .75rem)
+  +media-breakpoint-down(sm)
+    display: none
 
 .thread-comment__created-at
   display: block
-  +text-block(.875rem 1.4, $muted-text)
+  +text-block(.875rem 1.4, $muted-text nowrap)
   +media-breakpoint-down(sm)
     font-size: .75rem
 

--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -1,0 +1,21 @@
+class Users::CommentsController < ApplicationController
+  before_action :set_user
+  before_action :set_comments
+
+  def index
+  end
+
+  private
+    def set_user
+      @user = User.find(params[:user_id])
+    end
+
+    def set_comments
+      @comments =
+        Comment
+          .preload(:commentable)
+          .eager_load(:user)
+          .where(user_id: @user, commentable_type: 'Report')
+          .order(created_at: :desc)
+    end
+end

--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -15,7 +15,7 @@ class Users::CommentsController < ApplicationController
         Comment
           .preload(:commentable)
           .eager_load(:user)
-          .where(user_id: @user, commentable_type: 'Report')
+          .where(user_id: @user, commentable_type: "Report")
           .order(created_at: :desc)
     end
 end

--- a/app/helpers/page_tab_helper.rb
+++ b/app/helpers/page_tab_helper.rb
@@ -40,10 +40,11 @@ module PageTabHelper
 
     def display_tab_names
       {
-        practices: 'プラクティス',
-        reports: '日報',
-        products: '提出物',
-        users: 'ユーザー'
+        practices: "プラクティス",
+        reports: "日報",
+        products: "提出物",
+        users: "ユーザー",
+        comments: "コメント"
       }
     end
 
@@ -66,12 +67,18 @@ module PageTabHelper
         root_tab(resource),
         practices_tab(resource),
         reports_tab(resource),
+        comments_tab(resource),
         products_tab(resource)
       ]
     end
 
     def practices_tab(resource)
       tab_name = :practices
+      page_tab_member(tab_path(resource, tab_name), tab_name)
+    end
+
+    def comments_tab(resource)
+      tab_name = :comments
       page_tab_member(tab_path(resource, tab_name), tab_name)
     end
 

--- a/app/helpers/page_tab_helper.rb
+++ b/app/helpers/page_tab_helper.rb
@@ -9,7 +9,7 @@ module PageTabHelper
   end
 
   def current_page_tab_or_not(target_name)
-    current_page_tab?(target_name) ? 'is-current' : ''
+    current_page_tab?(target_name) ? "is-current" : ""
   end
 
   private
@@ -83,7 +83,7 @@ module PageTabHelper
     end
 
     def current_page_tab?(target_name)
-      paths = request.fullpath.split('/')
+      paths = request.fullpath.split("/")
       if paths[-2] == target_name
         true
       else

--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -12,8 +12,8 @@
         .answer-badge__label
           = t("best_answer_html")
     header.thread-comment__body-header
-      h2.thread-comment__login-name
-        = link_to answer.user, itempro: 'url', class: 'thread-comment__login-name-link' do
+      h2.thread-comment__title
+        = link_to answer.user, itempro: 'url', class: 'thread-comment__title-link' do
           = answer.user.login_name
       time.thread-comment__created-at(datetime='#{answer.created_at.to_datetime}' pubdate='pubdate')
         = l answer.updated_at, format: :date_long_with_time

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,0 +1,23 @@
+.thread-comment
+  .thread-comment__author
+    = link_to report, itempro: 'url', class: 'thread-comment__author-link' do
+      = gravatar_tag comment.user, secure: true, size: 200, html: { class: "thread-comment__author-icon"}
+  .thread-comment__body
+    header.thread-comment__body-header
+      h2.thread-comment__login-name
+        = link_to report, itempro: 'url', class: 'thread-comment__login-name-link' do
+          = report.title
+        = gravatar_tag report.user, secure: true, size: 30, html: { class: "recent-reports-item__user-icon"}
+      time.thread-comment__created-at(datetime='#{report.created_at.to_datetime}' pubdate='pubdate')
+        = l comment.updated_at, format: :date_long_with_time
+    .thread-comments__description.js-markdown-view.js-target-blank.is-long-text-style
+      = comment.description
+    - if comment.user == current_user
+      .thread-comment__actions
+        ul.thread-comment__actions-items
+          li.thread-comment__actions-item
+            = link_to [:edit, report, comment], class: 'thread-comment__actions-item-link' do
+              i.fa.fa-pencil
+          li.thread-comment__actions__item
+            = link_to [report, comment], data: { confirm: t('are_you_sure') }, method: :delete, class: 'thread-comment__actions-item-link' do
+              i.fa.fa-trash-o

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,13 +1,16 @@
-.thread-comment
-  .thread-comment__author
-    = link_to report, itempro: 'url', class: 'thread-comment__author-link' do
-      = gravatar_tag comment.user, secure: true, size: 200, html: { class: "thread-comment__author-icon"}
+.thread-comment.is-no-author-icon
   .thread-comment__body
-    header.thread-comment__body-header
-      h2.thread-comment__login-name
-        = link_to report, itempro: 'url', class: 'thread-comment__login-name-link' do
+    header.thread-comment__body-header.is-icon
+      = gravatar_tag report.user, secure: true, size: 88, html: { class: "thread-comment__user-icon"}
+      h2.thread-comment__title
+        = link_to report, itempro: 'url', class: 'thread-comment__title-link' do
+          span.thread-comment__title-label
+            | #{report.user.login_name}さんの#{l report.created_at, format: :date_default}の日報
           = report.title
-        = gravatar_tag report.user, secure: true, size: 30, html: { class: "recent-reports-item__user-icon"}
+          .thread-comment__title-count
+            i.fa.fa-comment-o
+            = report.comments.size
+
       time.thread-comment__created-at(datetime='#{report.created_at.to_datetime}' pubdate='pubdate')
         = l comment.updated_at, format: :date_long_with_time
     .thread-comments__description.js-markdown-view.js-target-blank.is-long-text-style

--- a/app/views/comments/_comments.html.slim
+++ b/app/views/comments/_comments.html.slim
@@ -1,0 +1,8 @@
+.thread-comments-container
+  h2.thread-comments-container__title
+    = "コメント"
+    span.thread-comments-container__title-count
+      = comments.count
+  .thread-comments
+    - comments.each do |comment|
+      = render "comments/comment", report: comment.commentable, comment: comment

--- a/app/views/products/comments/_comment.html.slim
+++ b/app/views/products/comments/_comment.html.slim
@@ -4,8 +4,8 @@
       = gravatar_tag comment.user, secure: true, size: 200, html: { class: "thread-comment__author-icon"}
   .thread-comment__body
     header.thread-comment__body-header
-      h2.thread-comment__login-name
-        = link_to comment.user, itempro: 'url', class: 'thread-comment__login-name-link' do
+      h2.thread-comment__title
+        = link_to comment.user, itempro: 'url', class: 'thread-comment__title-link' do
           = comment.user.login_name
       time.thread-comment__created-at(datetime='#{product.created_at.to_datetime}' pubdate='pubdate')
         = l comment.updated_at, format: :date_long_with_time

--- a/app/views/reports/_report_comment.slim
+++ b/app/views/reports/_report_comment.slim
@@ -4,8 +4,8 @@
       = gravatar_tag comment.user, secure: true, size: 200, html: { class: "thread-comment__author-icon"}
   .thread-comment__body
     header.thread-comment__body-header
-      h2.thread-comment__login-name
-        = link_to comment.user, itempro: 'url', class: 'thread-comment__login-name-link' do
+      h2.thread-comment__title
+        = link_to comment.user, itempro: 'url', class: 'thread-comment__title-link' do
           = comment.user.login_name
       time.thread-comment__created-at(datetime='#{report.created_at.to_datetime}' pubdate='pubdate')
         = l comment.updated_at, format: :date_long_with_time

--- a/app/views/users/comments/index.html.slim
+++ b/app/views/users/comments/index.html.slim
@@ -1,0 +1,14 @@
+- title @user.login_name
+header.page-header
+  .container
+    .page-header__container
+      h2.page-header__title= @user.login_name
+      ul.page-header-actions__items
+        li.page-header-actions__item
+          = link_to "ユーザー一覧", users_path, class: "is-button-simple-md-secondary"
+
+= render "page_tabs", resource: @user
+
+.page-body
+  .container
+    = render 'comments/comments', comments: @comments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   resources :users do
     resources :practices, only: %i(index), controller: "users/practices"
     resources :reports, only: %i(index), controller: "users/reports"
+    resources :comments, only: %i(index), controller: "users/comments"
     resources :products, only: %i(index), controller: "users/products"
   end
 

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -40,3 +40,8 @@ comment_7:
   user: komagata
   commentable: report_4 (Report)
   description: ":thumbsup:"
+
+comment_8:
+  user: komagata
+  commentable: product_10 (Product)
+  description: "提出物のコメントです。"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,7 +7,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "full_name" do
-    assert_equal users(:komagata).full_name, "Komagata Masaki"
+    assert_equal "Komagata Masaki", users(:komagata).full_name
   end
 
   test "active?" do

--- a/test/system/check_report_test.rb
+++ b/test/system/check_report_test.rb
@@ -8,7 +8,7 @@ class CheckReportTest < ApplicationSystemTestCase
       fill_in("user[password]", with: "testtest")
     end
     click_button "サインイン"
-    assert_equal current_path, "/users"
+    assert_equal "/users", current_path
     click_link "日報"
     assert_text "作業週2日目"
     click_link "作業週2日目"
@@ -22,7 +22,7 @@ class CheckReportTest < ApplicationSystemTestCase
       fill_in("user[password]", with: "testtest")
     end
     click_button "サインイン"
-    assert_equal current_path, "/users"
+    assert_equal "/users", current_path
     click_link "日報"
     assert_text "作業週2日目"
     click_link "作業週2日目"

--- a/test/system/footprint_test.rb
+++ b/test/system/footprint_test.rb
@@ -8,7 +8,7 @@ class FootprintTest < ApplicationSystemTestCase
       fill_in("user[password]", with: "testtest")
     end
     click_button "サインイン"
-    assert_equal current_path, "/users"
+    assert_equal "/users", current_path
     click_link "日報"
     assert_text "作業週2日目"
     click_link "作業週2日目"
@@ -23,7 +23,7 @@ class FootprintTest < ApplicationSystemTestCase
       fill_in("user[password]", with: "testtest")
     end
     click_button "サインイン"
-    assert_equal current_path, "/users"
+    assert_equal "/users", current_path
     click_link "日報"
     assert_text "学習週3日目"
     click_link "学習週3日目"

--- a/test/system/page_tabs_test.rb
+++ b/test/system/page_tabs_test.rb
@@ -1,7 +1,7 @@
 require "application_system_test_case"
 
 class PageTabsTest < ApplicationSystemTestCase
-  test "when login user is admin, practices tab members are practice and reports and products" do
+  test "when login user is admin, practice's tab members are practice and reports and products" do
     login_user "machida", "testtest"
 
     assert_text "プラクティス"
@@ -38,12 +38,12 @@ class PageTabsTest < ApplicationSystemTestCase
 
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "提出物"
-    expected_products_counts = Practice.find(practice_id).products.size
-    actual_products_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_products_counts, expected_products_counts
+    expected_product_counts = Practice.find(practice_id).products.size
+    actual_product_counts = all(".thread-list-item__title-link").size
+    assert_equal actual_product_counts, expected_product_counts
   end
 
-  test "when login user is adviser, practices tab members are practice and reports and products" do
+  test "when login user is adviser, practice's tab members are practice and reports and products" do
     login_user "mineo", "testtest"
 
     assert_text "プラクティス"
@@ -80,12 +80,12 @@ class PageTabsTest < ApplicationSystemTestCase
 
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "提出物"
-    expected_products_counts = Practice.find(practice_id).products.size
-    actual_products_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_products_counts, expected_products_counts
+    expected_product_counts = Practice.find(practice_id).products.size
+    actual_product_counts = all(".thread-list-item__title-link").size
+    assert_equal actual_product_counts, expected_product_counts
   end
 
-  test "when login user is student and has a checked product, practices tab members are practice and reports and products" do
+  test "when login user is student and has a checked product, practice's tab members are practice and reports and products" do
     login_user "yamada", "testtest"
 
     assert_text "プラクティス"
@@ -122,12 +122,12 @@ class PageTabsTest < ApplicationSystemTestCase
 
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "提出物"
-    expected_products_counts = Practice.find(practice_id).products.size
-    actual_products_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_products_counts, expected_products_counts
+    expected_product_counts = Practice.find(practice_id).products.size
+    actual_product_counts = all(".thread-list-item__title-link").size
+    assert_equal actual_product_counts, expected_product_counts
   end
 
-  test "when login user is student and doesn't have a checked product, practices tab members are practice and reports" do
+  test "when login user is student and doesn't have a checked product, practice's tab members are practice and reports" do
     login_user "kimura", "testtest"
 
     assert_text "プラクティス"
@@ -160,7 +160,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal actual_report_counts, expected_report_counts
   end
 
-  test "when login user is admin, users tab members are user and practices and reports and products" do
+  test "when login user is admin, user's tab members are user and practices and reports and comments and products" do
     login_user "machida", "testtest"
 
     assert_text "ユーザー"
@@ -175,11 +175,12 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal first(".is-current").text, "ユーザー"
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 4
+    assert_equal page_tabs.size, 5
     assert_equal page_tabs[0].text, "ユーザー"
     assert_equal page_tabs[1].text, "プラクティス"
     assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "提出物"
+    assert_equal page_tabs[3].text, "コメント"
+    assert_equal page_tabs[4].text, "提出物"
 
     user_id = current_path.split("/").last.to_i
 
@@ -206,13 +207,21 @@ class PageTabsTest < ApplicationSystemTestCase
     all(".page-tabs__item-link")[3].click
 
     assert_equal all(".is-current").length, 1
+    assert_equal first(".is-current").text, "コメント"
+    expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
+    actual_comment_counts = all(".thread-comment__author").size
+    assert_equal actual_comment_counts, expected_comment_counts
+
+    all(".page-tabs__item-link")[4].click
+
+    assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "提出物"
-    expected_products_counts = User.find(user_id).products.size
-    actual_products_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_products_counts, expected_products_counts
+    expected_product_counts = User.find(user_id).products.size
+    actual_product_counts = all(".thread-list-item__title-link").size
+    assert_equal actual_product_counts, expected_product_counts
   end
 
-  test "when login user is adviser, users tab members are user and practices and reports and products" do
+  test "when login user is adviser, user's tab members are user and practices and reports and comments and products" do
     login_user "mineo", "testtest"
 
     assert_text "ユーザー"
@@ -227,11 +236,12 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal first(".is-current").text, "ユーザー"
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 4
+    assert_equal page_tabs.size, 5
     assert_equal page_tabs[0].text, "ユーザー"
     assert_equal page_tabs[1].text, "プラクティス"
     assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "提出物"
+    assert_equal page_tabs[3].text, "コメント"
+    assert_equal page_tabs[4].text, "提出物"
 
     user_id = current_path.split("/").last.to_i
 
@@ -258,13 +268,21 @@ class PageTabsTest < ApplicationSystemTestCase
     all(".page-tabs__item-link")[3].click
 
     assert_equal all(".is-current").length, 1
+    assert_equal first(".is-current").text, "コメント"
+    expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
+    actual_comment_counts = all(".thread-comment__author").size
+    assert_equal actual_comment_counts, expected_comment_counts
+
+    all(".page-tabs__item-link")[4].click
+
+    assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "提出物"
-    expected_products_counts = User.find(user_id).products.size
-    actual_products_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_products_counts, expected_products_counts
+    expected_product_counts = User.find(user_id).products.size
+    actual_product_counts = all(".thread-list-item__title-link").size
+    assert_equal actual_product_counts, expected_product_counts
   end
 
-  test "when login user is student and target user is current user, users tab members are user and practices and reports and products" do
+  test "when login user is student and target user is current user, user's tab members are user and practices and reports and comments and products" do
     login_user "hatsuno", "testtest"
 
     assert_text "ユーザー"
@@ -279,11 +297,12 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal first(".is-current").text, "ユーザー"
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 4
+    assert_equal page_tabs.size, 5
     assert_equal page_tabs[0].text, "ユーザー"
     assert_equal page_tabs[1].text, "プラクティス"
     assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "提出物"
+    assert_equal page_tabs[3].text, "コメント"
+    assert_equal page_tabs[4].text, "提出物"
 
     user_id = current_path.split("/").last.to_i
 
@@ -310,13 +329,21 @@ class PageTabsTest < ApplicationSystemTestCase
     all(".page-tabs__item-link")[3].click
 
     assert_equal all(".is-current").length, 1
+    assert_equal first(".is-current").text, "コメント"
+    expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
+    actual_comment_counts = all(".thread-comment__author").size
+    assert_equal actual_comment_counts, expected_comment_counts
+
+    all(".page-tabs__item-link")[4].click
+
+    assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "提出物"
-    expected_products_counts = User.find(user_id).products.select(&:checked?).size
-    actual_products_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_products_counts, expected_products_counts
+    expected_product_counts = User.find(user_id).products.select(&:checked?).size
+    actual_product_counts = all(".thread-list-item__title-link").size
+    assert_equal actual_product_counts, expected_product_counts
   end
 
-  test "when login user is student and target user has a checked product and login user also has it, users tab members are user and practices and reports and products" do
+  test "when login user is student and target user has a checked product and login user also has it, user's tab members are user and practices and reports and comments and products" do
     login_user "tanaka", "testtest"
 
     assert_text "ユーザー"
@@ -331,11 +358,12 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal first(".is-current").text, "ユーザー"
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 4
+    assert_equal page_tabs.size, 5
     assert_equal page_tabs[0].text, "ユーザー"
     assert_equal page_tabs[1].text, "プラクティス"
     assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "提出物"
+    assert_equal page_tabs[3].text, "コメント"
+    assert_equal page_tabs[4].text, "提出物"
 
     user_id = current_path.split("/").last.to_i
 
@@ -362,11 +390,19 @@ class PageTabsTest < ApplicationSystemTestCase
     all(".page-tabs__item-link")[3].click
 
     assert_equal all(".is-current").length, 1
+    assert_equal first(".is-current").text, "コメント"
+    expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
+    actual_comment_counts = all(".thread-comment__author").size
+    assert_equal actual_comment_counts, expected_comment_counts
+
+    all(".page-tabs__item-link")[4].click
+
+    assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "提出物"
     assert_equal all(".thread-list-item__title-link").size, 1
   end
 
-  test "when login user is student and target user has a checked product but login user doesn't have it, users tab members are user and practices and reports" do
+  test "when login user is student and target user has a checked product but login user doesn't have it, user's tab members are user and practices and reports" do
     login_user "kimura", "testtest"
 
     assert_text "ユーザー"
@@ -384,10 +420,11 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal first(".is-current").text, "ユーザー"
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 3
+    assert_equal page_tabs.size, 4
     assert_equal page_tabs[0].text, "ユーザー"
     assert_equal page_tabs[1].text, "プラクティス"
     assert_equal page_tabs[2].text, "日報"
+    assert_equal page_tabs[3].text, "コメント"
 
     user_id = current_path.split("/").last.to_i
 
@@ -410,9 +447,17 @@ class PageTabsTest < ApplicationSystemTestCase
     expected_report_counts = User.find(user_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
     assert_equal actual_report_counts, expected_report_counts
+
+    all(".page-tabs__item-link")[3].click
+
+    assert_equal all(".is-current").length, 1
+    assert_equal first(".is-current").text, "コメント"
+    expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
+    actual_comment_counts = all(".thread-comment__author").size
+    assert_equal actual_comment_counts, expected_comment_counts
   end
 
-  test "when login user is student and target user doesn't have a checked product, users tab members are user and practices and reports" do
+  test "when login user is student and target user doesn't have a checked product, user's tab members are user and practices and reports and commnets" do
     login_user "yamada", "testtest"
 
     assert_text "ユーザー"
@@ -427,10 +472,11 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal first(".is-current").text, "ユーザー"
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 3
+    assert_equal page_tabs.size, 4
     assert_equal page_tabs[0].text, "ユーザー"
     assert_equal page_tabs[1].text, "プラクティス"
     assert_equal page_tabs[2].text, "日報"
+    assert_equal page_tabs[3].text, "コメント"
 
     user_id = current_path.split("/").last.to_i
 
@@ -453,5 +499,13 @@ class PageTabsTest < ApplicationSystemTestCase
     expected_report_counts = User.find(user_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
     assert_equal actual_report_counts, expected_report_counts
+
+    all(".page-tabs__item-link")[3].click
+
+    assert_equal all(".is-current").length, 1
+    assert_equal first(".is-current").text, "コメント"
+    expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
+    actual_comment_counts = all(".thread-comment__author").size
+    assert_equal actual_comment_counts, expected_comment_counts
   end
 end

--- a/test/system/page_tabs_test.rb
+++ b/test/system/page_tabs_test.rb
@@ -209,7 +209,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "コメント"
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
-    actual_comment_counts = all(".thread-comment__author").size
+    actual_comment_counts = all(".thread-comment__title-link").size
     assert_equal actual_comment_counts, expected_comment_counts
 
     all(".page-tabs__item-link")[4].click
@@ -270,7 +270,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "コメント"
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
-    actual_comment_counts = all(".thread-comment__author").size
+    actual_comment_counts = all(".thread-comment__title-link").size
     assert_equal actual_comment_counts, expected_comment_counts
 
     all(".page-tabs__item-link")[4].click
@@ -331,7 +331,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "コメント"
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
-    actual_comment_counts = all(".thread-comment__author").size
+    actual_comment_counts = all(".thread-comment__title-link").size
     assert_equal actual_comment_counts, expected_comment_counts
 
     all(".page-tabs__item-link")[4].click
@@ -392,7 +392,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "コメント"
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
-    actual_comment_counts = all(".thread-comment__author").size
+    actual_comment_counts = all(".thread-comment__title-link").size
     assert_equal actual_comment_counts, expected_comment_counts
 
     all(".page-tabs__item-link")[4].click
@@ -453,7 +453,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "コメント"
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
-    actual_comment_counts = all(".thread-comment__author").size
+    actual_comment_counts = all(".thread-comment__title-link").size
     assert_equal actual_comment_counts, expected_comment_counts
   end
 
@@ -505,7 +505,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal all(".is-current").length, 1
     assert_equal first(".is-current").text, "コメント"
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
-    actual_comment_counts = all(".thread-comment__author").size
+    actual_comment_counts = all(".thread-comment__title-link").size
     assert_equal actual_comment_counts, expected_comment_counts
   end
 end

--- a/test/system/page_tabs_test.rb
+++ b/test/system/page_tabs_test.rb
@@ -9,38 +9,38 @@ class PageTabsTest < ApplicationSystemTestCase
     first(".category-practices-item__title-link").click
 
     assert_text "終了条件"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 3
-    assert_equal page_tabs[0].text, "プラクティス"
-    assert_equal page_tabs[1].text, "日報"
-    assert_equal page_tabs[2].text, "提出物"
+    assert_equal 3, page_tabs.size
+    assert_equal "プラクティス", page_tabs[0].text
+    assert_equal "日報", page_tabs[1].text
+    assert_equal "提出物", page_tabs[2].text
 
     practice_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "終了条件"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = Practice.find(practice_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "提出物"
+    assert_equal 1, all(".is-current").length
+    assert_equal "提出物", first(".is-current").text
     expected_product_counts = Practice.find(practice_id).products.size
     actual_product_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_product_counts, expected_product_counts
+    assert_equal expected_product_counts, actual_product_counts
   end
 
   test "when login user is adviser, practice's tab members are practice and reports and products" do
@@ -51,38 +51,38 @@ class PageTabsTest < ApplicationSystemTestCase
     first(".category-practices-item__title-link").click
 
     assert_text "終了条件"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 3
-    assert_equal page_tabs[0].text, "プラクティス"
-    assert_equal page_tabs[1].text, "日報"
-    assert_equal page_tabs[2].text, "提出物"
+    assert_equal 3, page_tabs.size
+    assert_equal "プラクティス", page_tabs[0].text
+    assert_equal "日報", page_tabs[1].text
+    assert_equal "提出物", page_tabs[2].text
 
     practice_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "終了条件"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = Practice.find(practice_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "提出物"
+    assert_equal 1, all(".is-current").length
+    assert_equal "提出物", first(".is-current").text
     expected_product_counts = Practice.find(practice_id).products.size
     actual_product_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_product_counts, expected_product_counts
+    assert_equal expected_product_counts, actual_product_counts
   end
 
   test "when login user is student and has a checked product, practice's tab members are practice and reports and products" do
@@ -93,38 +93,38 @@ class PageTabsTest < ApplicationSystemTestCase
     all(".category-practices-item__title-link")[1].click
 
     assert_text "終了条件"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 3
-    assert_equal page_tabs[0].text, "プラクティス"
-    assert_equal page_tabs[1].text, "日報"
-    assert_equal page_tabs[2].text, "提出物"
+    assert_equal 3, page_tabs.size
+    assert_equal "プラクティス", page_tabs[0].text
+    assert_equal "日報", page_tabs[1].text
+    assert_equal "提出物", page_tabs[2].text
 
     practice_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "終了条件"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = Practice.find(practice_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "提出物"
+    assert_equal 1, all(".is-current").length
+    assert_equal "提出物", first(".is-current").text
     expected_product_counts = Practice.find(practice_id).products.size
     actual_product_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_product_counts, expected_product_counts
+    assert_equal expected_product_counts, actual_product_counts
   end
 
   test "when login user is student and doesn't have a checked product, practice's tab members are practice and reports" do
@@ -135,29 +135,29 @@ class PageTabsTest < ApplicationSystemTestCase
     first(".category-practices-item__title-link").click
 
     assert_text "終了条件"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 2
-    assert_equal page_tabs[0].text, "プラクティス"
-    assert_equal page_tabs[1].text, "日報"
+    assert_equal 2, page_tabs.size
+    assert_equal "プラクティス", page_tabs[0].text
+    assert_equal "日報", page_tabs[1].text
 
     practice_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "終了条件"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = Practice.find(practice_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
   end
 
   test "when login user is admin, user's tab members are user and practices and reports and comments and products" do
@@ -167,58 +167,58 @@ class PageTabsTest < ApplicationSystemTestCase
     click_link "ユーザー"
 
     last_displayed_student = all(".users-item__name-link").last
-    assert_equal last_displayed_student.text, "kimura"
+    assert_equal "kimura", last_displayed_student.text
     last_displayed_student.click
 
     assert_text "Kimura Tadasi"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 5
-    assert_equal page_tabs[0].text, "ユーザー"
-    assert_equal page_tabs[1].text, "プラクティス"
-    assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "コメント"
-    assert_equal page_tabs[4].text, "提出物"
+    assert_equal 5, page_tabs.size
+    assert_equal "ユーザー", page_tabs[0].text
+    assert_equal "プラクティス", page_tabs[1].text
+    assert_equal "日報", page_tabs[2].text
+    assert_equal "コメント", page_tabs[3].text
+    assert_equal "提出物", page_tabs[4].text
 
     user_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "Kimura Tadasi"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
     assert_text "完了したプラクティス"
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = User.find(user_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[3].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "コメント"
+    assert_equal 1, all(".is-current").length
+    assert_equal "コメント", first(".is-current").text
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
     actual_comment_counts = all(".thread-comment__title-link").size
-    assert_equal actual_comment_counts, expected_comment_counts
+    assert_equal expected_comment_counts, actual_comment_counts
 
     all(".page-tabs__item-link")[4].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "提出物"
+    assert_equal 1, all(".is-current").length
+    assert_equal "提出物", first(".is-current").text
     expected_product_counts = User.find(user_id).products.size
     actual_product_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_product_counts, expected_product_counts
+    assert_equal expected_product_counts, actual_product_counts
   end
 
   test "when login user is adviser, user's tab members are user and practices and reports and comments and products" do
@@ -228,58 +228,58 @@ class PageTabsTest < ApplicationSystemTestCase
     click_link "ユーザー"
 
     last_displayed_student = all(".users-item__name-link").last
-    assert_equal last_displayed_student.text, "kimura"
+    assert_equal "kimura", last_displayed_student.text
     last_displayed_student.click
 
     assert_text "Kimura Tadasi"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 5
-    assert_equal page_tabs[0].text, "ユーザー"
-    assert_equal page_tabs[1].text, "プラクティス"
-    assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "コメント"
-    assert_equal page_tabs[4].text, "提出物"
+    assert_equal 5, page_tabs.size
+    assert_equal "ユーザー", page_tabs[0].text
+    assert_equal "プラクティス", page_tabs[1].text
+    assert_equal "日報", page_tabs[2].text
+    assert_equal "コメント", page_tabs[3].text
+    assert_equal "提出物", page_tabs[4].text
 
     user_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "Kimura Tadasi"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
     assert_text "完了したプラクティス"
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = User.find(user_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[3].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "コメント"
+    assert_equal 1, all(".is-current").length
+    assert_equal "コメント", first(".is-current").text
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
     actual_comment_counts = all(".thread-comment__title-link").size
-    assert_equal actual_comment_counts, expected_comment_counts
+    assert_equal expected_comment_counts, actual_comment_counts
 
     all(".page-tabs__item-link")[4].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "提出物"
+    assert_equal 1, all(".is-current").length
+    assert_equal "提出物", first(".is-current").text
     expected_product_counts = User.find(user_id).products.size
     actual_product_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_product_counts, expected_product_counts
+    assert_equal expected_product_counts, actual_product_counts
   end
 
   test "when login user is student and target user is current user, user's tab members are user and practices and reports and comments and products" do
@@ -289,58 +289,58 @@ class PageTabsTest < ApplicationSystemTestCase
     click_link "ユーザー"
 
     first_displayed_student = first(".users-item__name-link")
-    assert_equal first_displayed_student.text, "hatsuno"
+    assert_equal "hatsuno", first_displayed_student.text
     first_displayed_student.click
 
     assert_text "Hatsuno Shinji"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 5
-    assert_equal page_tabs[0].text, "ユーザー"
-    assert_equal page_tabs[1].text, "プラクティス"
-    assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "コメント"
-    assert_equal page_tabs[4].text, "提出物"
+    assert_equal 5, page_tabs.size
+    assert_equal "ユーザー", page_tabs[0].text
+    assert_equal "プラクティス", page_tabs[1].text
+    assert_equal "日報", page_tabs[2].text
+    assert_equal "コメント", page_tabs[3].text
+    assert_equal "提出物", page_tabs[4].text
 
     user_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "Hatsuno Shinji"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
     assert_text "完了したプラクティス"
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = User.find(user_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[3].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "コメント"
+    assert_equal 1, all(".is-current").length
+    assert_equal "コメント", first(".is-current").text
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
     actual_comment_counts = all(".thread-comment__title-link").size
-    assert_equal actual_comment_counts, expected_comment_counts
+    assert_equal expected_comment_counts, actual_comment_counts
 
     all(".page-tabs__item-link")[4].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "提出物"
+    assert_equal 1, all(".is-current").length
+    assert_equal "提出物", first(".is-current").text
     expected_product_counts = User.find(user_id).products.select(&:checked?).size
     actual_product_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_product_counts, expected_product_counts
+    assert_equal expected_product_counts, actual_product_counts
   end
 
   test "when login user is student and target user has a checked product and login user also has it, user's tab members are user and practices and reports and comments and products" do
@@ -350,56 +350,56 @@ class PageTabsTest < ApplicationSystemTestCase
     click_link "ユーザー"
 
     first_displayed_student = first(".users-item__name-link")
-    assert_equal first_displayed_student.text, "yamada"
+    assert_equal "yamada", first_displayed_student.text
     first_displayed_student.click
 
     assert_text "Yamada Taro"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 5
-    assert_equal page_tabs[0].text, "ユーザー"
-    assert_equal page_tabs[1].text, "プラクティス"
-    assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "コメント"
-    assert_equal page_tabs[4].text, "提出物"
+    assert_equal 5, page_tabs.size
+    assert_equal "ユーザー", page_tabs[0].text
+    assert_equal "プラクティス", page_tabs[1].text
+    assert_equal "日報", page_tabs[2].text
+    assert_equal "コメント", page_tabs[3].text
+    assert_equal "提出物", page_tabs[4].text
 
     user_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "Yamada Taro"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
     assert_text "完了したプラクティス"
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = User.find(user_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[3].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "コメント"
+    assert_equal 1, all(".is-current").length
+    assert_equal "コメント", first(".is-current").text
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
     actual_comment_counts = all(".thread-comment__title-link").size
-    assert_equal actual_comment_counts, expected_comment_counts
+    assert_equal expected_comment_counts, actual_comment_counts
 
     all(".page-tabs__item-link")[4].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "提出物"
-    assert_equal all(".thread-list-item__title-link").size, 1
+    assert_equal 1, all(".is-current").length
+    assert_equal "提出物", first(".is-current").text
+    assert_equal 1, all(".thread-list-item__title-link").size
   end
 
   test "when login user is student and target user has a checked product but login user doesn't have it, user's tab members are user and practices and reports" do
@@ -412,49 +412,49 @@ class PageTabsTest < ApplicationSystemTestCase
     click_link "卒業生"
 
     first_displayed_student = first(".users-item__name-link")
-    assert_equal first_displayed_student.text, "tanaka"
+    assert_equal "tanaka", first_displayed_student.text
     first_displayed_student.click
 
     assert_text "Tanaka Taro"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 4
-    assert_equal page_tabs[0].text, "ユーザー"
-    assert_equal page_tabs[1].text, "プラクティス"
-    assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "コメント"
+    assert_equal 4, page_tabs.size
+    assert_equal "ユーザー", page_tabs[0].text
+    assert_equal "プラクティス", page_tabs[1].text
+    assert_equal "日報", page_tabs[2].text
+    assert_equal "コメント", page_tabs[3].text
 
     user_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "Tanaka Taro"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
     assert_text "完了したプラクティス"
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = User.find(user_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[3].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "コメント"
+    assert_equal 1, all(".is-current").length
+    assert_equal "コメント", first(".is-current").text
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
     actual_comment_counts = all(".thread-comment__title-link").size
-    assert_equal actual_comment_counts, expected_comment_counts
+    assert_equal expected_comment_counts, actual_comment_counts
   end
 
   test "when login user is student and target user doesn't have a checked product, user's tab members are user and practices and reports and commnets" do
@@ -464,48 +464,48 @@ class PageTabsTest < ApplicationSystemTestCase
     click_link "ユーザー"
 
     last_displayed_student = all(".users-item__name-link").last
-    assert_equal last_displayed_student.text, "kimura"
+    assert_equal "kimura", last_displayed_student.text
     last_displayed_student.click
 
     assert_text "Kimura Tadasi"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal page_tabs.size, 4
-    assert_equal page_tabs[0].text, "ユーザー"
-    assert_equal page_tabs[1].text, "プラクティス"
-    assert_equal page_tabs[2].text, "日報"
-    assert_equal page_tabs[3].text, "コメント"
+    assert_equal 4, page_tabs.size
+    assert_equal "ユーザー", page_tabs[0].text
+    assert_equal "プラクティス", page_tabs[1].text
+    assert_equal "日報", page_tabs[2].text
+    assert_equal "コメント", page_tabs[3].text
 
     user_id = current_path.split("/").last.to_i
 
     all(".page-tabs__item-link")[0].click
 
     assert_text "Kimura Tadasi"
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "ユーザー"
+    assert_equal 1, all(".is-current").length
+    assert_equal "ユーザー", first(".is-current").text
 
     all(".page-tabs__item-link")[1].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "プラクティス"
+    assert_equal 1, all(".is-current").length
+    assert_equal "プラクティス", first(".is-current").text
     assert_text "完了したプラクティス"
 
     all(".page-tabs__item-link")[2].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "日報"
+    assert_equal 1, all(".is-current").length
+    assert_equal "日報", first(".is-current").text
     expected_report_counts = User.find(user_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
-    assert_equal actual_report_counts, expected_report_counts
+    assert_equal expected_report_counts, actual_report_counts
 
     all(".page-tabs__item-link")[3].click
 
-    assert_equal all(".is-current").length, 1
-    assert_equal first(".is-current").text, "コメント"
+    assert_equal 1, all(".is-current").length
+    assert_equal "コメント", first(".is-current").text
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
     actual_comment_counts = all(".thread-comment__title-link").size
-    assert_equal actual_comment_counts, expected_comment_counts
+    assert_equal expected_comment_counts, actual_comment_counts
   end
 end

--- a/test/system/practice_page_complete_button_test.rb
+++ b/test/system/practice_page_complete_button_test.rb
@@ -8,7 +8,7 @@ class PracticePageCompleteButtonTest < ApplicationSystemTestCase
       fill_in("user[password]", with: "testtest")
     end
     click_button "サインイン"
-    assert_equal current_path, "/users"
+    assert_equal "/users", current_path
     click_link "プラクティス"
     click_link "PC性能の見方を知る"
     assert has_link? "完了"

--- a/test/system/reset_password_test.rb
+++ b/test/system/reset_password_test.rb
@@ -27,7 +27,7 @@ class ResetPasswordTest < ApplicationSystemTestCase
     assert_match /#{password_resets_url}/, mail.body.to_s
     assert_match /#{I18n.t("the_password_will_not_be_changed_until_you_access_the_link_above_and_set_a_new_password")}/, mail.body.to_s
 
-    assert_equal current_path, "/login"
+    assert_equal "/login", current_path
     assert_text I18n.t("instruction_have_been_sent")
   end
 
@@ -42,7 +42,7 @@ class ResetPasswordTest < ApplicationSystemTestCase
       click_button "パスワードをリセットする"
     end
 
-    assert_equal current_path, "/login"
+    assert_equal "/login", current_path
     assert_text I18n.t("invalid_email_or_password")
   end
 end

--- a/test/system/search_reports_test.rb
+++ b/test/system/search_reports_test.rb
@@ -18,7 +18,7 @@ class SearchReportsTest < ApplicationSystemTestCase
       fill_in("user[password]", with: "testtest")
     end
     click_button "サインイン"
-    assert_equal current_path, "/users"
+    assert_equal "/users", current_path
 
     fill_in "word", with: "作業 2"
     find(".header-search__submit").click

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -10,7 +10,7 @@ class SignInTest < ApplicationSystemTestCase
       fill_in("user[password]",   with: "testtest")
     end
     click_button "サインイン"
-    assert_equal current_path, "/users"
+    assert_equal "/users", current_path
   end
 
   test "sign in with wrong password" do
@@ -20,7 +20,7 @@ class SignInTest < ApplicationSystemTestCase
       fill_in("user[password]",   with: "xxxxxxxx")
     end
     click_button "サインイン"
-    assert_equal current_path, "/user_sessions"
+    assert_equal "/user_sessions", current_path
     assert_text "ユーザー名かパスワードが違います。"
   end
 end

--- a/test/system/user_comment_list_test.rb
+++ b/test/system/user_comment_list_test.rb
@@ -1,0 +1,9 @@
+require "application_system_test_case"
+
+class UserCommentListTest < ApplicationSystemTestCase
+  test "show all comments for reports of the target user" do
+    login_user "komagata", "testtest"
+    visit polymorphic_path([users(:komagata), :comments])
+    assert_equal users(:komagata).comments.where(commentable_type: "Report").size, 3
+  end
+end

--- a/test/system/user_comment_list_test.rb
+++ b/test/system/user_comment_list_test.rb
@@ -4,6 +4,6 @@ class UserCommentListTest < ApplicationSystemTestCase
   test "show all comments for reports of the target user" do
     login_user "komagata", "testtest"
     visit polymorphic_path([users(:komagata), :comments])
-    assert_equal users(:komagata).comments.where(commentable_type: "Report").size, 3
+    assert_equal 3, users(:komagata).comments.where(commentable_type: "Report").size
   end
 end

--- a/test/system/user_list_test.rb
+++ b/test/system/user_list_test.rb
@@ -7,31 +7,31 @@ class UserListTest < ApplicationSystemTestCase
     assert_text "ユーザー"
     click_link "ユーザー"
 
-    assert_equal all(".tab-nav__item-link").length, 5
-    assert_equal all(".users-item__inner").length, 3
+    assert_equal 5, all(".tab-nav__item-link").length
+    assert_equal 3, all(".users-item__inner").length
     assert_text "yamada"
     assert_text "kimura"
     assert_text "hatsuno"
 
     assert_text "メンター"
     click_link "メンター"
-    assert_equal all(".users-item__inner").length, 2
+    assert_equal 2, all(".users-item__inner").length
     assert_text "komagata"
     assert_text "machida"
 
     assert_text "卒業生"
     click_link "卒業生"
-    assert_equal all(".users-item__inner").length, 1
+    assert_equal 1, all(".users-item__inner").length
     assert_text "tanaka"
 
     assert_text "アドバイザー"
     click_link "アドバイザー"
-    assert_equal all(".users-item__inner").length, 1
+    assert_equal 1, all(".users-item__inner").length
     assert_text "mineo"
 
     assert_text "全員"
     click_link "全員"
-    assert_equal all(".users-item__inner").length, 8
+    assert_equal 8, all(".users-item__inner").length
     assert_text "yameo"
   end
 end


### PR DESCRIPTION
fixes #426 

- [x] 自分がコメントした日報を取得するメソッドの追加
- [x] 自分のコメントを一覧できるページの追加
- [x] デザインの修正
- [x] テストを追加