### PR TITLE
QAとプラクティスを紐付ける機能を追加

### DIFF
--- a/app/assets/stylesheets/blocks/page/_page-header-actions.sass
+++ b/app/assets/stylesheets/blocks/page/_page-header-actions.sass
@@ -1,6 +1,9 @@
 .page-header-actions
   +media-breakpoint-down(sm)
     margin-top: .75rem
+    padding-top: .75rem
+    +margin(horizontal, -1rem)
+    border-top: solid 1px $background-color
 
 .page-header-actions__items
   display: flex

--- a/app/assets/stylesheets/blocks/shared/_tab-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_tab-nav.sass
@@ -1,6 +1,8 @@
 .tab-nav
   margin-bottom: 1.5rem
   border-bottom: solid 1px $background-color-shade
+  &.is-delete-margin-top
+    margin-top: -1.5rem
 
 .tab-nav__items
   display: flex

--- a/app/assets/stylesheets/blocks/thread/_threads.sass
+++ b/app/assets/stylesheets/blocks/thread/_threads.sass
@@ -6,6 +6,10 @@
   +margin(horizontal, auto)
   +media-breakpoint-down(sm)
     margin-bottom: 2rem
+  &.is-empty
+    background-color: transparent
+    box-shadow: none
+    +text-block(1rem 1.4, center)
 
 .thread-list-item
   padding: .75rem 1rem
@@ -19,6 +23,15 @@
   padding-left: 4rem
   +media-breakpoint-down(sm)
     padding-left: 3rem
+
+.thread-list-item__sub-title
+  +text-block(.75rem 1.4 .125rem, 400)
+  +media-breakpoint-down(sm)
+    margin-left: -3rem
+
+.thread-list-item__sub-title-link
+  +hover-link
+  color: $default-text
 
 .thread-list-item__author
   +position(absolute, left 0, top 0)

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -42,7 +42,11 @@ class AnswersController < ApplicationController
     end
 
     def set_answer
-      @answer = @question.answers.find(params[:id])
+      @answer = question.answers.find(params[:id])
+    end
+
+    def question
+      @question ||= Question.find(params[:question_id])
     end
 
     def answer_params
@@ -50,7 +54,7 @@ class AnswersController < ApplicationController
     end
 
     def set_return_to
-      @return_to = params[:return_to].present? ? params[:return_to] : question_url(@question)
+      @return_to = params[:return_to].present? ? params[:return_to] : question_url(question)
     end
 
     def notify_to_slack(answer)

--- a/app/controllers/practices/products_controller.rb
+++ b/app/controllers/practices/products_controller.rb
@@ -13,8 +13,13 @@ class Practices::ProductsController < ApplicationController
     end
 
     def set_products
-      if product_displayable?(practice: @practice)
-        @products = @practice.products.eager_load(:user, :comments).order(updated_at: :desc)
-      end
+      @products =
+        if product_displayable?(practice: practice)
+           practice.products.eager_load(:user, :comments).order(updated_at: :desc)
+        end
+    end
+
+    def practice
+      @practice ||= Practice.find(params[:practice_id])
     end
 end

--- a/app/controllers/practices/products_controller.rb
+++ b/app/controllers/practices/products_controller.rb
@@ -15,7 +15,7 @@ class Practices::ProductsController < ApplicationController
     def set_products
       @products =
         if product_displayable?(practice: practice)
-           practice.products.eager_load(:user, :comments).order(updated_at: :desc)
+          practice.products.eager_load(:user, :comments).order(updated_at: :desc)
         end
     end
 

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -1,0 +1,23 @@
+class Practices::QuestionsController < ApplicationController
+  before_action :set_practice
+  before_action :set_questions
+
+  def index
+  end
+
+  private
+    def set_practice
+      @practice = Practice.find(params[:practice_id])
+    end
+
+    def set_questions
+      questions = @practice.questions.eager_load(:user, :answers)
+      @questions =
+        if params[:solved].present?
+          questions.joins(:correct_answer)
+        else
+          question_ids = CorrectAnswer.pluck(:question_id)
+          questions.where.not(id: question_ids)
+        end.order(updated_at: :desc, id: :desc)
+    end
+end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -14,10 +14,9 @@ class Practices::QuestionsController < ApplicationController
       questions = @practice.questions.eager_load(:user, :answers)
       @questions =
         if params[:solved].present?
-          questions.joins(:correct_answer)
+          questions.solved
         else
-          question_ids = CorrectAnswer.pluck(:question_id)
-          questions.where.not(id: question_ids)
+          questions.not_solved
         end.order(updated_at: :desc, id: :desc)
     end
 end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -11,12 +11,16 @@ class Practices::QuestionsController < ApplicationController
     end
 
     def set_questions
-      questions = @practice.questions.eager_load(:user, :answers)
+      questions = practice.questions.eager_load(:user, :answers)
       @questions =
         if params[:solved].present?
           questions.solved
         else
           questions.not_solved
         end.order(updated_at: :desc, id: :desc)
+    end
+
+    def practice
+      @practice ||= Practice.find(params[:practice_id])
     end
 end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Practices::QuestionsController < ApplicationController
   before_action :set_practice
   before_action :set_questions

--- a/app/controllers/practices/reports_controller.rb
+++ b/app/controllers/practices/reports_controller.rb
@@ -13,6 +13,10 @@ class Practices::ReportsController < ApplicationController
     end
 
     def set_reports
-      @reports = @practice.reports.eager_load(:user, :comments).order(updated_at: :desc, id: :desc)
+      @reports = practice.reports.eager_load(:user, :comments).order(updated_at: :desc, id: :desc)
+    end
+
+    def practice
+      @practice ||= Practice.find(params[:practice_id])
     end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -46,11 +46,16 @@ class ProductsController < ApplicationController
     end
 
     def set_my_product
-      if product_displayable?(practice: @practice)
-        @product = @practice.products.find_by(id: params[:id])
-      else
-        @product = @practice.products.find_by(id: params[:id], user: current_user)
-      end
+      @product =
+        if product_displayable?(practice: practice)
+          practice.products.find_by(id: params[:id])
+        else
+          practice.products.find_by(id: params[:id], user: current_user)
+        end
+    end
+
+    def practice
+      @practice ||= Practice.find(params[:practice_id])
     end
 
     def product_params

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -8,13 +8,14 @@ class QuestionsController < ApplicationController
   before_action :set_categories, only: %i(new edit)
 
   def index
-    @questions =
+    questions =
       if params[:solved].present?
         Question.joins(:correct_answer)
       else
         question_ids = CorrectAnswer.pluck(:question_id)
         Question.where.not(id: question_ids)
-      end
+      end.order(updated_at: :desc, id: :desc)
+    @questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
   end
 
   def show

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,7 +5,7 @@ class QuestionsController < ApplicationController
   include Gravatarify::Helper
   before_action :require_login
   before_action :set_question, only: %i(show edit update destroy)
-  before_action :set_categories, only: %i(new edit)
+  before_action :set_categories, only: %i(new create edit update)
 
   def index
     questions =

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,6 +5,7 @@ class QuestionsController < ApplicationController
   include Gravatarify::Helper
   before_action :require_login
   before_action :set_question, only: %i(show edit update destroy)
+  before_action :set_categories, only: %i(new edit)
 
   def index
     @questions =
@@ -55,12 +56,21 @@ class QuestionsController < ApplicationController
       @question = Question.find(params[:id])
     end
 
+    def set_categories
+      @categories =
+        Category
+          .eager_load(:practices)
+          .where.not(practices: { id: nil })
+          .order("categories.position ASC, practices.position ASC")
+    end
+
     def question_params
       params.require(:question).permit(
         :title,
         :description,
         :user_id,
-        :resolve
+        :resolve,
+        :practice_id
       )
     end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -10,10 +10,9 @@ class QuestionsController < ApplicationController
   def index
     questions =
       if params[:solved].present?
-        Question.joins(:correct_answer)
+        Question.solved
       else
-        question_ids = CorrectAnswer.pluck(:question_id)
-        Question.where.not(id: question_ids)
+        Question.not_solved
       end.order(updated_at: :desc, id: :desc)
     @questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -13,7 +13,7 @@ class ReportsController < ApplicationController
   before_action :set_footprints, only: %i(show)
   before_action :set_footprint, only: %i(show)
   before_action :set_user, only: %i(show)
-  before_action :set_categories, only: %i(new create edit)
+  before_action :set_categories, only: %i(new create edit update)
 
   def index
     @search_words = params[:word]&.squish&.split(/[[:blank:]]/)&.uniq

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -110,8 +110,12 @@ class ReportsController < ApplicationController
       @check = Check.new
     end
 
+    def report
+      @report ||= Report.find(params[:id])
+    end
+
     def set_checks
-      @checks = @report.checks.order(created_at: :desc)
+      @checks = report.checks.order(created_at: :desc)
     end
 
     def set_footprint
@@ -119,7 +123,7 @@ class ReportsController < ApplicationController
     end
 
     def set_footprints
-      @footprints = Footprint.where(report_id: @report.id).order(created_at: :desc)
+      @footprints = Footprint.where(report_id: report.id).order(created_at: :desc)
     end
 
     def set_comment

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,16 +5,15 @@ class ReportsController < ApplicationController
   include Rails.application.routes.url_helpers
   include Gravatarify::Helper
   before_action :require_login
-  before_action :set_report, only: %w(show)
+  before_action :set_report, only: %i(show)
   before_action :set_my_report, only: %i(edit update destroy)
-  before_action :set_comments, only: %w(show edit update destroy)
-  before_action :set_comment, only: %w(show edit update destroy)
-  before_action :set_checks, only: %w(show)
-  before_action :set_check, only: %w(show)
-  before_action :set_footprints, only: %w(show)
-  before_action :set_footprint, only: %w(show)
-  before_action :set_user, only: :show
-  before_action :set_categories, only: %w(new create edit update)
+  before_action :set_comment, only: %i(show)
+  before_action :set_checks, only: %i(show)
+  before_action :set_check, only: %i(show)
+  before_action :set_footprints, only: %i(show)
+  before_action :set_footprint, only: %i(show)
+  before_action :set_user, only: %i(show)
+  before_action :set_categories, only: %i(new create edit)
 
   def index
     @search_words = params[:word]&.squish&.split(/[[:blank:]]/)&.uniq
@@ -125,10 +124,6 @@ class ReportsController < ApplicationController
 
     def set_comment
       @comment = Comment.new
-    end
-
-    def set_comments
-      @comments = Comment.where(report_id: @report.id).order(created_at: :asc)
     end
 
     def set_categories

--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -17,7 +17,11 @@ class Users::CommentsController < ApplicationController
         Comment
           .preload(:commentable)
           .eager_load(:user)
-          .where(user_id: @user, commentable_type: "Report")
+          .where(user_id: user, commentable_type: "Report")
           .order(created_at: :desc)
+    end
+
+    def user
+      @user ||= User.find(params[:user_id])
     end
 end

--- a/app/controllers/users/products_controller.rb
+++ b/app/controllers/users/products_controller.rb
@@ -13,14 +13,18 @@ class Users::ProductsController < ApplicationController
     end
 
     def set_products
-      if admin_login? || adviser_login? || current_user == @user
-        @products = @user.products.eager_load(:user, :comments, :practice).order(updated_at: :desc)
-      elsif @user.has_checked_product_of?(current_user.practices_with_checked_product)
-        @products =
+      @products =
+        if admin_login? || adviser_login? || current_user == user
+          user.products.eager_load(:user, :comments, :practice).order(updated_at: :desc)
+        elsif user.has_checked_product_of?(current_user.practices_with_checked_product)
           Product
             .eager_load(:user, :comments, :practice)
-            .where(id: @user.products.ids_of_common_checked_with(current_user))
+            .where(id: user.products.ids_of_common_checked_with(current_user))
             .order(updated_at: :desc)
-      end
+        end
+    end
+
+    def user
+      @user ||= User.find(params[:user_id])
     end
 end

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -14,6 +14,10 @@ class Users::ReportsController < ApplicationController
     end
 
     def set_reports
-      @reports = @user.reports.eager_load(:user, :comments).order(updated_at: :desc)
+      @reports = user.reports.eager_load(:user, :comments).order(updated_at: :desc)
+    end
+
+    def user
+      @user ||= User.find(params[:user_id])
     end
 end

--- a/app/helpers/page_tab_helper.rb
+++ b/app/helpers/page_tab_helper.rb
@@ -19,6 +19,7 @@ module PageTabHelper
       [
         root_tab(resource),
         reports_tab(resource),
+        questions_tab(resource),
         products_tab(resource)
       ]
     end
@@ -44,6 +45,7 @@ module PageTabHelper
       {
         practices: "プラクティス",
         reports: "日報",
+        questions: "質問",
         products: "提出物",
         users: "ユーザー",
         comments: "コメント"
@@ -57,6 +59,11 @@ module PageTabHelper
 
     def tab_path(resource, tab_name)
       [resource, tab_name]
+    end
+
+    def questions_tab(resource)
+      tab_name = :questions
+      page_tab_member(tab_path(resource, tab_name), tab_name)
     end
 
     def products_tab(resource)

--- a/app/helpers/page_tab_helper.rb
+++ b/app/helpers/page_tab_helper.rb
@@ -92,7 +92,7 @@ module PageTabHelper
     end
 
     def current_page_tab?(target_name)
-      paths = url_for(only_path: false, overwrite_params: nil).split("/")
+      paths = url_for(only_path: false).split("/")
       if paths[-2] == target_name
         true
       else

--- a/app/helpers/page_tab_helper.rb
+++ b/app/helpers/page_tab_helper.rb
@@ -92,7 +92,7 @@ module PageTabHelper
     end
 
     def current_page_tab?(target_name)
-      paths = request.fullpath.split("/")
+      paths = url_for(only_path: false, overwrite_params: nil).split("/")
       if paths[-2] == target_name
         true
       else

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -16,6 +16,7 @@ class Practice < ActiveRecord::Base
     through: :completed_learnings,
     source: :user
   has_many :products
+  has_many :questions
   belongs_to :category
   acts_as_list scope: :category
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -9,4 +9,7 @@ class Question < ActiveRecord::Base
   validates :title, presence: true, length: { maximum: 256 }
   validates :description, presence: true
   validates :user, presence: true
+
+  scope :solved, -> { joins(:correct_answer) }
+  scope :not_solved, -> { where.not(id: CorrectAnswer.pluck(:question_id)) }
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,6 +4,7 @@ class Question < ActiveRecord::Base
   belongs_to :user, touch: true
   has_many :answers
   has_one :correct_answer
+  belongs_to :practice, optional: true
 
   validates :title, presence: true, length: { maximum: 256 }
   validates :description, presence: true

--- a/app/views/application/_page_tab.html.slim
+++ b/app/views/application/_page_tab.html.slim
@@ -1,3 +1,3 @@
 li.page-tabs__item
-  = link_to member[:path], class: "page-tabs__item-link #{current_page_tab_or_not(member[:target_name])}" do
-    = member[:display_name]
+  = link_to tab[:path], class: "page-tabs__item-link #{current_page_tab_or_not(tab[:target_name])}" do
+    = tab[:display_name]

--- a/app/views/application/_page_tabs.html.slim
+++ b/app/views/application/_page_tabs.html.slim
@@ -1,13 +1,13 @@
 .page-tabs
   .container
     ul.page-tabs__items
-      - page_tab_members(resource).each do |member|
-        - if member[:is_products_tab]
+      - page_tab_members(resource).each do |tab|
+        - if tab[:is_products_tab]
           - if resource.is_a?(User)
             - if product_displayable?(user: resource)
-              = render "page_tab", member: member
+              = render "page_tab", tab: tab
           - elsif resource.is_a?(Practice)
             - if product_displayable?(practice: resource)
-              = render "page_tab", member: member
+              = render "page_tab", tab: tab
         - else
-          = render "page_tab", member: member
+          = render "page_tab", tab: tab

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -1,0 +1,26 @@
+- title @practice.title
+header.page-header
+  .container
+    .page-header__container
+      h2.page-header__title
+        = @practice.title
+      .page-header__action
+        = link_to practices_path, class: "is-button-simple-md-secondary" do
+          i.fa.fa-angle-left
+          = t("practices")
+
+= render "page_tabs", resource: @practice
+
+.page-body
+  nav.tab-nav
+    .container.is-xs-horizontal-padding-0
+      ul.tab-nav__items
+        li.tab-nav__item
+          = link_to "未解決", [@practice, :questions], class: "tab-nav__item-link #{params[:solved].present? ? "": "is-active"}"
+        li.tab-nav__item
+          = link_to "解決済み", polymorphic_path([@practice, :questions], solved: "true"), class: "tab-nav__item-link #{params[:solved].present? ? "is-active" : ""}"
+
+  .container
+    .thread-list
+      - @questions.each do |question|
+        = render "questions/question", question: question

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -12,7 +12,7 @@ header.page-header
 = render "page_tabs", resource: @practice
 
 .page-body
-  nav.tab-nav
+  nav.tab-nav.is-delete-margin-top
     .container.is-xs-horizontal-padding-0
       ul.tab-nav__items
         li.tab-nav__item

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -16,7 +16,7 @@ header.page-header
     .container.is-xs-horizontal-padding-0
       ul.tab-nav__items
         li.tab-nav__item
-          = link_to "未解決", [@practice, :questions], class: "tab-nav__item-link #{params[:solved].present? ? "": "is-active"}"
+          = link_to "未解決", [@practice, :questions], class: "tab-nav__item-link #{params[:solved].present? ? "" : "is-active"}"
         li.tab-nav__item
           = link_to "解決済み", polymorphic_path([@practice, :questions], solved: "true"), class: "tab-nav__item-link #{params[:solved].present? ? "is-active" : ""}"
 

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -21,6 +21,10 @@ header.page-header
           = link_to "解決済み", polymorphic_path([@practice, :questions], solved: "true"), class: "tab-nav__item-link #{params[:solved].present? ? "is-active" : ""}"
 
   .container
-    .thread-list
-      - @questions.each do |question|
-        = render "questions/question", question: question
+    - if @questions.present?
+      .thread-list
+        - @questions.each do |question|
+          = render "questions/question", question: question
+    - else
+      .thread-list.is-empty
+        | 質問はまだありません。

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -4,6 +4,19 @@
   .form__items
     .form-item
       .form-item
+        .row
+          .col-lg-9.col-xs-12
+            .form-item
+              = f.label :practice, class: "a-label"
+              .select-practices
+                ul
+                  - categories.each do |category|
+                    - category.practices.each do |practice|
+                      label.select-practices__label
+                        = radio_button_tag "question[practice_id]", practice.id, question.practice == practice, id: "question_practice_ids_#{practice.id}", class: "select-practices__input"
+                        => "[#{category.name}]"
+                        span.select-practices__label-title= practice.title
+      .form-item
         .row.js-markdown-parent
           .col-md-6.col-xs-12
             = f.label :title, class: "a-label"

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -15,7 +15,8 @@
                       label.select-practices__label
                         = radio_button_tag "question[practice_id]", practice.id, question.practice == practice, id: "question_practice_ids_#{practice.id}", class: "select-practices__input"
                         => "[#{category.name}]"
-                        span.select-practices__label-title= practice.title
+                        span.select-practices__label-title
+                          = practice.title
       .form-item
         .row.js-markdown-parent
           .col-md-6.col-xs-12

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -12,6 +12,10 @@
             i.fas.fa-pen
           = link_to question_path(question), data: { confirm: t("are_you_sure") }, method: :delete, class: "thread-list-item__actions-link" do
             i.fas.fa-trash-alt
+    - if question.practice
+      h3.thread-list-item__sub-title
+        = link_to question.practice, class: "thread-list-item__sub-title-link" do
+          = question.practice.title
     .thread-list-item-meta
       time.thread-list-item-meta__updated-at(datetime="#{question.updated_at.to_datetime}" pubdate="pubdate")
         = l question.updated_at, format: :semi_long

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -8,4 +8,4 @@ header.page-header
         = t("to_index_of_questions")
 .page-body
   .container
-      = render "form", question: @question
+    = render "form", question: @question, categories: @categories

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -18,12 +18,12 @@ header.page-header.is-margin-bottom-0
           = hidden_field_tag :solved, params[:solved]
           = label_tag :practice_id, "プラクティスで絞り込む:", class: "sort-nav__label"
           .is-button-simple-md-secondary.is-select.sort-nav__select
-            = select_tag :practice_id, options_from_collection_for_select(Practice.all, :id, :title, { selected: params[:practice_id] }), include_blank: "全ての質問を表示", onchange: "this.form.submit()"
+            = select_tag :practice_id, options_from_collection_for_select(Practice.all, :id, :title, selected: params[:practice_id]), include_blank: "全ての質問を表示", onchange: "this.form.submit()"
     nav.tab-nav.is-delete-margin-top
       .container.is-xs-horizontal-padding-0
         ul.tab-nav__items
           li.tab-nav__item
-            = link_to "未解決", polymorphic_path(:questions, practice_id: params[:practice_id]), class: "tab-nav__item-link #{params[:solved].present? ? "": "is-active"}"
+            = link_to "未解決", polymorphic_path(:questions, practice_id: params[:practice_id]), class: "tab-nav__item-link #{params[:solved].present? ? "" : "is-active"}"
           li.tab-nav__item
             = link_to "解決済み", polymorphic_path(:questions, solved: "true", practice_id: params[:practice_id]), class: "tab-nav__item-link #{params[:solved].present? ? "is-active" : ""}"
 

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -19,7 +19,7 @@ header.page-header.is-margin-bottom-0
           = label_tag :practice_id, "プラクティスで絞り込む:", class: "sort-nav__label"
           .is-button-simple-md-secondary.is-select.sort-nav__select
             = select_tag :practice_id, options_from_collection_for_select(Practice.all, :id, :title, { selected: params[:practice_id] }), include_blank: "全ての質問を表示", onchange: "this.form.submit()"
-    nav.tab-nav
+    nav.tab-nav.is-delete-margin-top
       .container.is-xs-horizontal-padding-0
         ul.tab-nav__items
           li.tab-nav__item

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -28,5 +28,9 @@ header.page-header.is-margin-bottom-0
             = link_to "解決済み", polymorphic_path(:questions, solved: "true", practice_id: params[:practice_id]), class: "tab-nav__item-link #{params[:solved].present? ? "is-active" : ""}"
 
   .container
-    .thread-list
-      = render @questions
+    - if @questions.present?
+      .thread-list
+        = render @questions
+    - else
+      .thread-list.is-empty
+        | 質問はまだありません。

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -11,13 +11,21 @@ header.page-header.is-margin-bottom-0
               = t("new_question")
 
 .page-body
-  nav.tab-nav
-    .container.is-xs-horizontal-padding-0
-      ul.tab-nav__items
-        li.tab-nav__item
-          = link_to "未解決", questions_path, class: "tab-nav__item-link #{params[:solved].present? ? "" : "is-active"}"
-        li.tab-nav__item
-          = link_to "解決済み", questions_path(solved: "true"), class: "tab-nav__item-link #{params[:solved].present? ? "is-active" : ""}"
+  = form_tag :questions, method: "get" do
+    nav.sort-nav
+      .container
+        .sort-nav__inner
+          = hidden_field_tag :solved, params[:solved]
+          = label_tag :practice_id, "プラクティスで絞り込む:", class: "sort-nav__label"
+          .is-button-simple-md-secondary.is-select.sort-nav__select
+            = select_tag :practice_id, options_from_collection_for_select(Practice.all, :id, :title, { selected: params[:practice_id] }), include_blank: "全ての質問を表示", onchange: "this.form.submit()"
+    nav.tab-nav
+      .container.is-xs-horizontal-padding-0
+        ul.tab-nav__items
+          li.tab-nav__item
+            = link_to "未解決", polymorphic_path(:questions, practice_id: params[:practice_id]), class: "tab-nav__item-link #{params[:solved].present? ? "": "is-active"}"
+          li.tab-nav__item
+            = link_to "解決済み", polymorphic_path(:questions, solved: "true", practice_id: params[:practice_id]), class: "tab-nav__item-link #{params[:solved].present? ? "is-active" : ""}"
 
   .container
     .thread-list

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -9,4 +9,4 @@ header.page-header
         = t("to_index_of_questions")
 .page-body
   .container
-    = render "form", question: @question
+    = render "form", question: @question, categories: @categories

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -9,7 +9,7 @@ header.page-header
           li.page-header-actions__item
             = link_to new_question_path, class: "is-button-simple-md-warning" do
               i.fas.fa-plus
-              | みんなに聞いてみる
+              | みんなに聞く
           li.page-header-actions__item
             = link_to questions_path, class: "is-button-simple-md-secondary" do
               i.fas.fa-angle-left

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -488,7 +488,7 @@ ja:
   editing_question: 質問編集
   editing_answer: 回答編集
   new_category: "カテゴリー追加"
-  new_question: "みんなに聞いてみる"
+  new_question: "みんなに聞く"
   show: "表示"
   back: "戻る"
   copy: "コピー"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -357,6 +357,7 @@ ja:
         body: 本文
 
       question:
+        practice: プラクティス
         title: タイトル
         description: 詳細
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     resource :learning, only: %i(create update destroy)
     resource :position, only: %i(update)
     resources :reports, only: %i(index), controller: "practices/reports"
+    resources :questions, only: %i(index), controller: "practices/questions"
     resources :products, only: %i(index), controller: "practices/products"
   end
   resources :practices do

--- a/db/migrate/20181016030635_add_practice_id_to_questions.rb
+++ b/db/migrate/20181016030635_add_practice_id_to_questions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPracticeIdToQuestions < ActiveRecord::Migration[5.2]
   def change
     add_reference :questions, :practice, foreign_key: true, index: true

--- a/db/migrate/20181016030635_add_practice_id_to_questions.rb
+++ b/db/migrate/20181016030635_add_practice_id_to_questions.rb
@@ -1,0 +1,5 @@
+class AddPracticeIdToQuestions < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :questions, :practice, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2018_10_16_030635) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_02_051214) do
+ActiveRecord::Schema.define(version: 2018_10_16_030635) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -179,6 +178,8 @@ ActiveRecord::Schema.define(version: 2018_10_02_051214) do
     t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.bigint "practice_id"
+    t.index ["practice_id"], name: "index_questions_on_practice_id"
     t.index ["user_id"], name: "index_questions_on_user_id"
   end
 
@@ -236,4 +237,5 @@ ActiveRecord::Schema.define(version: 2018_10_02_051214) do
   add_foreign_key "notifications", "users", column: "sender_id"
   add_foreign_key "products", "practices"
   add_foreign_key "products", "users"
+  add_foreign_key "questions", "practices"
 end

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -17,3 +17,8 @@ answer_4:
   description: テストの回答4です。
   user: komagata
   question: question_3
+
+answer_5:
+  description: テストの回答5です。
+  user: komagata
+  question: question_6

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -15,6 +15,7 @@ question_3:
   title: テストの質問1
   description: テスト1の内容です。
   user: komagata
+  practice: practice_1
 
 question_4:
   title: テストの質問2
@@ -25,3 +26,15 @@ question_5:
   title: テストの質問3
   description: テスト3の内容です。
   user: komagata
+
+question_6:
+  title: テストの質問4
+  description: テスト1の内容です。
+  user: komagata
+  practice: practice_1
+
+question_7:
+  title: テストの質問5
+  description: テスト1の内容です。
+  user: komagata
+  practice: practice_1

--- a/test/system/check_product_test.rb
+++ b/test/system/check_product_test.rb
@@ -26,7 +26,7 @@ class CheckProductTest < ApplicationSystemTestCase
     assert_text "OS X Mountain Lionをクリーンインストールする"
     click_link "OS X Mountain Lionをクリーンインストールする"
 
-    page.all(".page-tabs__item-link")[2].click
+    page.all(".page-tabs__item-link")[3].click
     page.first(".thread-list-item__title-link").click
 
     assert has_button? "提出物を確認"

--- a/test/system/check_product_test.rb
+++ b/test/system/check_product_test.rb
@@ -9,7 +9,7 @@ class CheckProductTest < ApplicationSystemTestCase
     assert_text "OS X Mountain Lionをクリーンインストールする"
     click_link "OS X Mountain Lionをクリーンインストールする"
 
-    page.all(".page-tabs__item-link")[2].click
+    page.all(".page-tabs__item-link")[3].click
     page.first(".thread-list-item__title-link").click
 
     assert has_button? "提出物を確認"

--- a/test/system/page_tabs_test.rb
+++ b/test/system/page_tabs_test.rb
@@ -15,7 +15,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal "プラクティス", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal 3, page_tabs.size
+    assert_equal 4, page_tabs.size
     assert_equal "プラクティス", page_tabs[0].text
     assert_equal "日報", page_tabs[1].text
     assert_equal "提出物", page_tabs[2].text
@@ -57,7 +57,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal "プラクティス", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal 3, page_tabs.size
+    assert_equal 4, page_tabs.size
     assert_equal "プラクティス", page_tabs[0].text
     assert_equal "日報", page_tabs[1].text
     assert_equal "提出物", page_tabs[2].text
@@ -99,7 +99,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal "プラクティス", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal 3, page_tabs.size
+    assert_equal 4, page_tabs.size
     assert_equal "プラクティス", page_tabs[0].text
     assert_equal "日報", page_tabs[1].text
     assert_equal "提出物", page_tabs[2].text
@@ -141,7 +141,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal "プラクティス", first(".is-current").text
 
     page_tabs = all(".page-tabs__item-link")
-    assert_equal 2, page_tabs.size
+    assert_equal 3, page_tabs.size
     assert_equal "プラクティス", page_tabs[0].text
     assert_equal "日報", page_tabs[1].text
 

--- a/test/system/page_tabs_test.rb
+++ b/test/system/page_tabs_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class PageTabsTest < ApplicationSystemTestCase
-  test "when login user is admin, practice's tab members are practice and reports and products" do
+  test "when login user is admin, practice's tab members are practice and reports and questions and products" do
     login_user "machida", "testtest"
 
     assert_text "プラクティス"
@@ -18,7 +18,8 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal 4, page_tabs.size
     assert_equal "プラクティス", page_tabs[0].text
     assert_equal "日報", page_tabs[1].text
-    assert_equal "提出物", page_tabs[2].text
+    assert_equal "質問", page_tabs[2].text
+    assert_equal "提出物", page_tabs[3].text
 
     practice_id = current_path.split("/").last.to_i
 
@@ -39,13 +40,21 @@ class PageTabsTest < ApplicationSystemTestCase
     all(".page-tabs__item-link")[2].click
 
     assert_equal 1, all(".is-current").length
+    assert_equal "質問", first(".is-current").text
+    expected_question_counts = Practice.find(practice_id).questions.not_solved.size
+    actual_question_counts = all(".thread-list-item__title-link").size
+    assert_equal expected_question_counts, actual_question_counts
+
+    all(".page-tabs__item-link")[3].click
+
+    assert_equal 1, all(".is-current").length
     assert_equal "提出物", first(".is-current").text
     expected_product_counts = Practice.find(practice_id).products.size
     actual_product_counts = all(".thread-list-item__title-link").size
     assert_equal expected_product_counts, actual_product_counts
   end
 
-  test "when login user is adviser, practice's tab members are practice and reports and products" do
+  test "when login user is adviser, practice's tab members are practice and reports and questions and products" do
     login_user "mineo", "testtest"
 
     assert_text "プラクティス"
@@ -60,7 +69,8 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal 4, page_tabs.size
     assert_equal "プラクティス", page_tabs[0].text
     assert_equal "日報", page_tabs[1].text
-    assert_equal "提出物", page_tabs[2].text
+    assert_equal "質問", page_tabs[2].text
+    assert_equal "提出物", page_tabs[3].text
 
     practice_id = current_path.split("/").last.to_i
 
@@ -81,13 +91,21 @@ class PageTabsTest < ApplicationSystemTestCase
     all(".page-tabs__item-link")[2].click
 
     assert_equal 1, all(".is-current").length
+    assert_equal "質問", first(".is-current").text
+    expected_question_counts = Practice.find(practice_id).questions.not_solved.size
+    actual_question_counts = all(".thread-list-item__title-link").size
+    assert_equal expected_question_counts, actual_question_counts
+
+    all(".page-tabs__item-link")[3].click
+
+    assert_equal 1, all(".is-current").length
     assert_equal "提出物", first(".is-current").text
     expected_product_counts = Practice.find(practice_id).products.size
     actual_product_counts = all(".thread-list-item__title-link").size
     assert_equal expected_product_counts, actual_product_counts
   end
 
-  test "when login user is student and has a checked product, practice's tab members are practice and reports and products" do
+  test "when login user is student and has a checked product, practice's tab members are practice and reports and questions and products" do
     login_user "yamada", "testtest"
 
     assert_text "プラクティス"
@@ -102,7 +120,8 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal 4, page_tabs.size
     assert_equal "プラクティス", page_tabs[0].text
     assert_equal "日報", page_tabs[1].text
-    assert_equal "提出物", page_tabs[2].text
+    assert_equal "質問", page_tabs[2].text
+    assert_equal "提出物", page_tabs[3].text
 
     practice_id = current_path.split("/").last.to_i
 
@@ -123,13 +142,21 @@ class PageTabsTest < ApplicationSystemTestCase
     all(".page-tabs__item-link")[2].click
 
     assert_equal 1, all(".is-current").length
+    assert_equal "質問", first(".is-current").text
+    expected_question_counts = Practice.find(practice_id).questions.not_solved.size
+    actual_question_counts = all(".thread-list-item__title-link").size
+    assert_equal expected_question_counts, actual_question_counts
+
+    all(".page-tabs__item-link")[3].click
+
+    assert_equal 1, all(".is-current").length
     assert_equal "提出物", first(".is-current").text
     expected_product_counts = Practice.find(practice_id).products.size
     actual_product_counts = all(".thread-list-item__title-link").size
     assert_equal expected_product_counts, actual_product_counts
   end
 
-  test "when login user is student and doesn't have a checked product, practice's tab members are practice and reports" do
+  test "when login user is student and doesn't have a checked product, practice's tab members are practice and reports and questions" do
     login_user "kimura", "testtest"
 
     assert_text "プラクティス"
@@ -144,6 +171,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal 3, page_tabs.size
     assert_equal "プラクティス", page_tabs[0].text
     assert_equal "日報", page_tabs[1].text
+    assert_equal "質問", page_tabs[2].text
 
     practice_id = current_path.split("/").last.to_i
 
@@ -160,6 +188,14 @@ class PageTabsTest < ApplicationSystemTestCase
     expected_report_counts = Practice.find(practice_id).reports.size
     actual_report_counts = all(".thread-list-item__title-link").size
     assert_equal expected_report_counts, actual_report_counts
+
+    all(".page-tabs__item-link")[2].click
+
+    assert_equal 1, all(".is-current").length
+    assert_equal "質問", first(".is-current").text
+    expected_question_counts = Practice.find(practice_id).questions.not_solved.size
+    actual_question_counts = all(".thread-list-item__title-link").size
+    assert_equal expected_question_counts, actual_question_counts
   end
 
   test "when login user is admin, user's tab members are user and practices and reports and comments and products" do

--- a/test/system/question_list_test.rb
+++ b/test/system/question_list_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class QuestionListTest < ApplicationSystemTestCase
@@ -81,5 +83,4 @@ class QuestionListTest < ApplicationSystemTestCase
 
     assert_equal target_practice.questions.solved.size, all(".thread-list-item__title-link").size
   end
-
 end

--- a/test/system/question_list_test.rb
+++ b/test/system/question_list_test.rb
@@ -1,0 +1,85 @@
+require "application_system_test_case"
+
+class QuestionListTest < ApplicationSystemTestCase
+  test "question page show message when question does not exist" do
+    Question.delete_all
+    login_user "machida", "testtest"
+    visit questions_path
+
+    assert_equal 0, all(".thread-list-item__title-link").size
+    assert_text "質問はまだありません。"
+
+    click_link "解決済み"
+
+    assert_equal 0, all(".thread-list-item__title-link").size
+    assert_text "質問はまだありません。"
+  end
+
+  test "question page show all of not solved questions or all of solved questions" do
+    login_user "machida", "testtest"
+    visit questions_path
+
+    assert_equal Question.not_solved.size, all(".thread-list-item__title-link").size
+
+    click_link "解決済み"
+
+    assert_equal Question.solved.size, all(".thread-list-item__title-link").size
+  end
+
+  test "question page show message when target practice does not have solved questions or not solved question" do
+    login_user "machida", "testtest"
+    visit questions_path
+
+    select "Terminalの基礎を覚える"
+
+    assert_equal 0, all(".thread-list-item__title-link").size
+    assert_text "質問はまだありません。"
+
+    click_link "解決済み"
+
+    assert_equal 0, all(".thread-list-item__title-link").size
+    assert_text "質問はまだありません。"
+  end
+
+  test "question page show all of solved questions or all of solved questions with target practice" do
+    login_user "machida", "testtest"
+    visit questions_path
+
+    select "OS X Mountain Lionをクリーンインストールする"
+
+    target_practice = practices(:practice_1)
+
+    assert_equal target_practice.questions.not_solved.size, all(".thread-list-item__title-link").size
+
+    click_link "解決済み"
+
+    assert_equal target_practice.questions.solved.size, all(".thread-list-item__title-link").size
+  end
+
+  test "practice's question page show message when target practice does not have solved questions or not solved question" do
+    login_user "machida", "testtest"
+    target_practice = practices(:practice_2)
+    visit polymorphic_path([target_practice, :questions])
+
+    assert_equal 0, all(".thread-list-item__title-link").size
+    assert_text "質問はまだありません。"
+
+    click_link "解決済み"
+
+    assert_equal 0, all(".thread-list-item__title-link").size
+    assert_text "質問はまだありません。"
+  end
+
+  test "practice's question page show all of solved questions or all of solved questions with target practice" do
+    login_user "machida", "testtest"
+    target_practice = practices(:practice_1)
+    visit polymorphic_path([target_practice, :questions])
+
+    assert_equal target_practice.questions.not_solved.size, all(".thread-list-item__title-link").size
+
+    click_link "解決済み"
+
+    assert_equal target_practice.questions.solved.size, all(".thread-list-item__title-link").size
+  end
+
+end


### PR DESCRIPTION
fixes #214 

- [x] QAとプラクティスの紐づけ
  - [x] マイグレーションの追加
  - [x] モデルの修正
    - [x] Practice
    - [x] Question
- [x] QA画面の修正
  - [x] 画面の修正
    - [x] 一覧画面の修正（必要ない）
    - [x] 詳細画面の修正（必要ない）
    - [x] フォームの修正
  - [x] コントローラの修正
    - [x] Questions
- [x] QAのプラクティスでの絞り込み機能の追加
  - [x] QA一覧画面の修正
  - [x] コントローラの修正
    - [x] Questions
- [x] プラクティスページにQA一覧機能を追加
  - [x] ルーティングの修正
  - [x] QA一覧画面の追加
  - [x] コントローラの追加
    - [x] Practices::Questions
  - [x] ヘルパーの修正
     - [x] PageTab
- [x] テストの追加