### PR TITLE
アドミンがQAを解決できるようにする

### DIFF
--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -21,7 +21,7 @@
       = answer.description
     .thread-comment__actions
       ul.thread-comment__actions-items
-        - if correct_answer.blank? && answer != correct_answer && current_user == question.user
+        - if correct_answer.blank? && answer != correct_answer && current_user == question.user or admin_login?
           li.thread-comment__actions-item
             = link_to question_correct_answer_path(answer.question, answer_id: answer.id, return_to: question_path(answer.question)), data: { confirm: "本当に宜しいですか？" }, method: :post, class: 'is-button-simple-sm-warning' do
               | 解決にする

--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -21,7 +21,7 @@
       = answer.description
     .thread-comment__actions
       ul.thread-comment__actions-items
-        - if correct_answer.blank? && answer != correct_answer && current_user == question.user or admin_login?
+        - if correct_answer.blank? && answer != correct_answer && (current_user == question.user or admin_login?)
           li.thread-comment__actions-item
             = link_to question_correct_answer_path(answer.question, answer_id: answer.id, return_to: question_path(answer.question)), data: { confirm: "本当に宜しいですか？" }, method: :post, class: 'is-button-simple-sm-warning' do
               | 解決にする

--- a/test/system/correct_answer_test.rb
+++ b/test/system/correct_answer_test.rb
@@ -4,8 +4,7 @@ class CorrectAnswerTest < ApplicationSystemTestCase
 
   test "admin can resolve user's question" do
     login_user "komagata", "testtest"
-    click_link "Q&A"
-    click_link "injectとreduce"
+    visit "/questions/#{questions(:question_2).id}"
     assert_text "解決にする"
     accept_alert do
       click_link '解決にする'

--- a/test/system/correct_answer_test.rb
+++ b/test/system/correct_answer_test.rb
@@ -1,0 +1,16 @@
+require "application_system_test_case"
+
+class CorrectAnswerTest < ApplicationSystemTestCase
+
+  test "admin can resolve user's question" do
+    login_user "komagata", "testtest"
+    click_link "Q&A"
+    click_link "injectとreduce"
+    assert_text "解決にする"
+    accept_alert do
+      click_link '解決にする'
+    end
+    assert_text "正解の解答を選択しました。"
+    assert_no_text "解決にする"
+  end
+end


### PR DESCRIPTION
fix #472 

- [x] アドミンでログイン時に[解決にする]ボタンを表示する
- [x] アドミンがユーザーの投稿した質問を解決できるか確認するテストを追加する