### PR TITLE
メンションが二回飛ぶ問題を修正

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -33,6 +33,6 @@ class Comment < ActiveRecord::Base
 
   private
     def extract_mentions(text)
-      text.scan(/@\w+/).map { |s| s.gsub(/@/, "") }
+      text.scan(/@\w+/).uniq.map { |s| s.gsub(/@/, "") }
     end
 end

--- a/test/system/notification/comments_test.rb
+++ b/test/system/notification/comments_test.rb
@@ -1,0 +1,21 @@
+require "application_system_test_case"
+
+class Notification::CommentsTest < ApplicationSystemTestCase
+  test "recieve only one notificaiton if you send two mentions in one comment" do
+    login_user "komagata", "testtest"
+    visit "/reports/#{reports(:report_1).id}"
+
+    within("#new_comment") do
+      fill_in("comment[description]", with: "@machida @machida test")
+    end
+    click_button "コメントを投稿"
+    assert_text "コメントを投稿しました。"
+
+    logout
+    login_user "machida", "testtest"
+
+    first(".test-bell").click
+    assert_text "komagataさんからメンションがきました。"
+    assert_selector ".header-notification-count", text: "1"
+  end
+end


### PR DESCRIPTION
一コメントにメンションが二箇所書かれていたら二回通知が飛んでしまう
問題を修正。