### PR TITLE
卒業した日付を記録したい

### DIFF
--- a/app/assets/stylesheets/blocks/user/_user_dates.sass
+++ b/app/assets/stylesheets/blocks/user/_user_dates.sass
@@ -7,6 +7,9 @@
 .user-dates__update-at
   +text-block(.8125rem 1.45)
 
+.user-dates__graduated-at
+  +text-block(.8125rem 1.45)
+
 .user-dates__created-at-label,
 .user-dates__created-at-value
   display: inline-block
@@ -17,6 +20,12 @@
 .user-dates__update-at-value
   display: inline-block
 
+.user-dates__graduated-at-label
+  display: inline-block
+
+.user-dates__graduated-at-value
+  display: inline-block
+  
 .user-dates__active-practices
   display: inline-block
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,8 @@ class User < ActiveRecord::Base
     source:    :practice,
     dependent: :destroy
 
+  before_update UserCallbacks.new
+
   validates :company_id, presence: true
   validates :email,      presence: true, uniqueness: true
   validates :first_name, presence: true

--- a/app/models/user_callbacks.rb
+++ b/app/models/user_callbacks.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UserCallbacks
+  def before_update(user)
+    if user.graduation_changed?(from: false, to: true)
+      user.graduated_at = Time.current
+    elsif user.graduation_changed?(from: true, to: false)
+      user.graduated_at = nil
+    end
+  end
+end

--- a/app/views/users/_dates.html.slim
+++ b/app/views/users/_dates.html.slim
@@ -17,3 +17,10 @@
       | :
     .user-dates__update-at-value
       = user.slack_account
+  - if @user.graduated_at.present?
+    .user-dates__graduated-at
+      .user-dates__graduated-at-label
+        = t("helpers.label.user.graduated_at")
+        | :
+      .user-dates__graduated-at-value
+        = l @user.graduated_at, format: :long

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -194,6 +194,7 @@ ja:
         company: "会社"
         created_at: "開始日"
         updated_at: "最終活動日時"
+        graduated_at: "卒業日時"
         nda: 秘密保持契約
 
       learning:

--- a/db/migrate/20180906065209_add_graduated_at_to_users.rb
+++ b/db/migrate/20180906065209_add_graduated_at_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGraduatedAtToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :graduated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -239,6 +239,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_022628) do
     t.string "face_content_type"
     t.integer "face_file_size"
     t.datetime "face_updated_at"
+    t.datetime "graduated_at"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end

--- a/test/system/user_graduation_date_test.rb
+++ b/test/system/user_graduation_date_test.rb
@@ -6,7 +6,7 @@ class UserGraduationDate < ApplicationSystemTestCase
   test "graduation date is displayed" do
     login_user "komagata", "testtest"
 
-    all("a")[9].click
+    click_link "管理"
     click_link "ユーザー一覧"
     click_link "yamada（Yamada Taro）"
     switch_to_window(windows.last)
@@ -14,6 +14,7 @@ class UserGraduationDate < ApplicationSystemTestCase
     click_link "管理者として情報変更"
     find("#user_graduation", visible: false).click
     click_button "更新する"
+    click_link "卒業生"
     click_link "yamada（Yamada Taro）"
     switch_to_window(windows.last)
     assert_text "卒業日時"

--- a/test/system/user_graduation_date_test.rb
+++ b/test/system/user_graduation_date_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class UserGraduationDate < ApplicationSystemTestCase
+  test "graduation date is displayed" do
+    login_user "komagata", "testtest"
+
+    all("a")[9].click
+    click_link "ユーザー一覧"
+    click_link "yamada（Yamada Taro）"
+    switch_to_window(windows.last)
+    assert_no_text "卒業日時"
+    click_link "管理者として情報変更"
+    find("#user_graduation", visible: false).click
+    click_button "更新する"
+    click_link "yamada（Yamada Taro）"
+    switch_to_window(windows.last)
+    assert_text "卒業日時"
+  end
+end


### PR DESCRIPTION
fixes #477 
- [x] 管理者のユーザー情報編集ページの卒業チェックボックスにチェックを入れて更新したらその日の日付をDBに保存し、卒業日とする
- [x] ユーザー情報に卒業日時を持つ
- [x] ユーザーの個別ページに卒業日時を出す（卒業してた場合のみ）
- [x] テストを書く