### PR TITLE
リタイア済アカウントでログインした場合はセッションを破棄し未ログイン状態とした

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,15 +6,14 @@ class UserSessionsController < ApplicationController
 
   def create
     @user = login(params[:user][:login_name], params[:user][:password], params[:remember])
-
-    unless active_user?(@user)
+    if @user && !@user.retire?
+      save_updated_at(@user)
+      redirect_back_or_to :users, notice: t("sign_in_successful")
+    else
       logout
       flash.now[:alert] = t("invalid_email_or_password")
-      return render "new"
+      render "new"
     end
-
-    save_updated_at(@user)
-    redirect_back_or_to :users, notice: t("sign_in_successful")
   end
 
   def destroy
@@ -24,11 +23,6 @@ class UserSessionsController < ApplicationController
   end
 
   private
-
-    def active_user?(user)
-      user.present? && !user.retire?
-    end
-
     def save_updated_at(user)
       user.updated_at = Time.current
       user.save!

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,13 +6,15 @@ class UserSessionsController < ApplicationController
 
   def create
     @user = login(params[:user][:login_name], params[:user][:password], params[:remember])
-    if @user && !@user.retire?
-      save_updated_at(@user)
-      redirect_back_or_to :users, notice: t("sign_in_successful")
-    else
+
+    unless active_user?(@user)
+      logout
       flash.now[:alert] = t("invalid_email_or_password")
-      render "new"
+      return render "new"
     end
+
+    save_updated_at(@user)
+    redirect_back_or_to :users, notice: t("sign_in_successful")
   end
 
   def destroy
@@ -22,6 +24,11 @@ class UserSessionsController < ApplicationController
   end
 
   private
+
+    def active_user?(user)
+      user.present? && !user.retire?
+    end
+
     def save_updated_at(user)
       user.updated_at = Time.current
       user.save!

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -25,4 +25,18 @@ class SignInTest < ApplicationSystemTestCase
     assert_equal "/user_sessions", current_path
     assert_text "ユーザー名かパスワードが違います。"
   end
+
+  test "sign in with retire account" do
+    visit "/login"
+    within("#sign-in-form") do
+      fill_in("user[login_name]", with: "yameo")
+      fill_in("user[password]",   with: "yameo@example.com")
+    end
+    click_button "サインイン"
+    assert_equal "/user_sessions", current_path
+    assert_text "ユーザー名かパスワードが違います。"
+
+    visit "/users"
+    assert_equal root_path, current_path
+  end
 end


### PR DESCRIPTION
## Description

リタイア済アカウントでログインした場合はセッションを破棄し未ログイン状態とした

## 問題

リタイアアカウントでもトップページにアクセス出来てしまう

## 原因

リタイアアカウントがログインに失敗してもセッションが残っている為

## 再現
リタイアアカウントでログインするとログインに失敗するが、URLで https://bootcamp.fjord.jp を入力するとトップページが見れてしまう

## 解決策

リタイアアカウントがログインに失敗する時にセッションを放棄して未ログイン状態にする

## Todo

- [x] user_sessions_controller.rb
  - リタイアアカウントがログインに失敗するタイミングでログアウトさせる

## 備考

現在、リタイア済アカウントでも受講者のページが見れてしまう問題のみを解決しました。
これから先リタイア済アカウントでログインした場合は通常のログイン失敗の処理とは別の処理、または別のメッセージ、遷移先などが考えられるのでガード節(*1)を使いました。

(*1)
https://qiita.com/kouyan/items/7b8b456b626447a1e24e
  
## Issue

リタイア後のアカウントでもトップページにアクセス出来てしまう

- #498