### PR TITLE
rubocopの自動修正を反映

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -4,7 +4,7 @@ class Answer < ActiveRecord::Base
   belongs_to :user, touch: true
   belongs_to :question
   alias_method :sender, :user
-  
+
   after_create AnswerCallbacks.new
 
   validates :description, presence: true

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AnswerCallbacks
   def after_create(answer)
     send_notification(answer)

--- a/test/system/notification/answers_test.rb
+++ b/test/system/notification/answers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class Notification::AnswersTest < ApplicationSystemTestCase


### PR DESCRIPTION
CircleCIにて、masterに #525 マージ後のデプロイでエラーを起こしていた修正です。

ブランチ作成時のrubocop条件が古かったため、master更新後のrubocopでエラーが発生しました。
最新条件のrubocop自動修正で対応できました。