### PR TITLE
users/:user_id/reportsの順序が昇順になっていたので降順に変更した

### DIFF
--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -16,7 +16,7 @@ class Users::ReportsController < ApplicationController
     def set_reports
       @reports = user.reports
         .eager_load(:user, :comments)
-        .paging_with_created_at(page: params[:page])
+        .paging_with_created_at(page: params[:page], order_type: "desc")
     end
 
     def user


### PR DESCRIPTION
## 概要
#551 の対応で順序を逆にしていたため、本来降順で表示されるべき日報一覧画面が昇順で表示されていたバグを修正するP/Rです。