### PR TITLE
ER図を生成するGemfileを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ vendor/bundle/
 /node_modules
 yarn-debug.log*
 .yarn-integrity
+
+/*.pdf

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,6 @@ group :development do
   # not default
   gem "letter_opener"
   gem "xray-rails"
-  # https://github.com/voormedia/rails-erd
   gem "rails-erd"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ group :development do
   # not default
   gem "letter_opener"
   gem "xray-rails"
+  # https://github.com/voormedia/rails-erd
+  gem "rails-erd"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       xpath (~> 3.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    choice (0.2.0)
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
@@ -365,6 +366,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.5.2)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.2.1)
@@ -391,6 +397,7 @@ GEM
       actionview (~> 5.x)
     rollbar (2.18.0)
       multi_json
+    ruby-graphviz (1.2.3)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     sass (3.6.0)
@@ -515,6 +522,7 @@ DEPENDENCIES
   rack-cors
   rack-user_agent
   rails (~> 5.2.0)
+  rails-erd
   ransack
   record_tag_helper (~> 1.0)
   rollbar

--- a/README.md
+++ b/README.md
@@ -3,70 +3,41 @@
 プログラマー向けEラーニングシステム。
 
 ## インストール
-```bash
-$ brew install yarn
-$ bin/setup
-$ yarn install
-$ rails s
-```
+
+    $ brew install yarn
+    $ bin/setup
+    $ yarn install
+    $ rails s
 
 You can also launch a web server with [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler).
 
-```bash
-$ RACK_PROFILER=1 rails s
-```
-
-### インストール時エラー関係
-
-#### 以下のエラーが出た場合
-```
-An error occurred while installing pg (1.1.3), and Bundler cannot continue.
-Make sure that `gem install pg -v '1.1.3' --source 'https://rubygems.org/'` succeeds before bundling.
-```
-
-`PostgreSQL` がインストールされていない可能性がある。  
-```bash
-# インストール
-$ brew install postgresql
-# 起動
-$ brew services start postgresql
-```
-
-#### `yarn install` で引っかかる場合
-`node.js` が入っていない可能性がある。  
-`brew install node` を叩いて再実行する。
-
-----
+    $ RACK_PROFILER=1 rails s
 
 ## テスト
 
 Test with headless browser.
 
-```bash
+```
 $ ./bin/test
 ```
 
 Test with real browser.
 
-```bash
+```
 $ HEADED=1 ./bin/test
 ```
 
-----
-
 ## Lint
 
-`rubocop` と `slim-lint` を実行します。
+rubocopとslim-lintを実行します。
 
-```bash
+```
 $ ./bin/lint
 ```
 
-----
-
 ## ER図
 お使いの環境がMacである場合、以下のコマンドでER図を生成することができます。  
-オプション指定でいろいろできるみたいなので、詳しくは [こちら](https://github.com/voormedia/rails-erd) をご覧ください。
+オプション指定でいろいろできるみたいなので、詳しくは https://github.com/voormedia/rails-erd をご覧ください。
 
 **`console`**
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ $ ./bin/lint
 
 **`console`**
 ```bash
-# Gemを取ってくる
-$ bundle install
-
 # 先にローカル環境でGraphvizをインストールする
 $ brew install graphviz
 

--- a/README.md
+++ b/README.md
@@ -3,34 +3,79 @@
 プログラマー向けEラーニングシステム。
 
 ## インストール
-
-    $ brew install yarn
-    $ bin/setup
-    $ yarn install
-    $ rails s
+```bash
+$ brew install yarn
+$ bin/setup
+$ yarn install
+$ rails s
+```
 
 You can also launch a web server with [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler).
 
-    $ RACK_PROFILER=1 rails s
+```bash
+$ RACK_PROFILER=1 rails s
+```
+
+### インストール時エラー関係
+
+#### 以下のエラーが出た場合
+```
+An error occurred while installing pg (1.1.3), and Bundler cannot continue.
+Make sure that `gem install pg -v '1.1.3' --source 'https://rubygems.org/'` succeeds before bundling.
+```
+
+`PostgreSQL` がインストールされていない可能性がある。  
+```bash
+# インストール
+$ brew install postgresql
+# 起動
+$ brew services start postgresql
+```
+
+#### `yarn install` で引っかかる場合
+`node.js` が入っていない可能性がある。  
+`brew install node` を叩いて再実行する。
+
+----
 
 ## テスト
 
 Test with headless browser.
 
-```
+```bash
 $ ./bin/test
 ```
 
 Test with real browser.
 
-```
+```bash
 $ HEADED=1 ./bin/test
 ```
 
+----
+
 ## Lint
 
-rubocopとslim-lintを実行します。
+`rubocop` と `slim-lint` を実行します。
 
-```
+```bash
 $ ./bin/lint
+```
+
+----
+
+## ER図
+お使いの環境がMacである場合、以下のコマンドでER図を生成することができます。  
+オプション指定でいろいろできるみたいなので、詳しくは [こちら](https://github.com/voormedia/rails-erd) をご覧ください。
+
+**`console`**
+```bash
+# Gemを取ってくる
+$ bundle install
+
+# 先にローカル環境でGraphvizをインストールする
+$ brew install graphviz
+
+# ER図生成（生成後はプロジェクト直下にerd.pdfファイルが生成される）
+$ bundle exec erd
 ```


### PR DESCRIPTION
## 概要
ER図を生成してくれるGemfileを追加しました。
合わせて導入手順を `README.md` に追記します。

## 利点
新しくプロジェクトに参加された方が、すばやくモデル構造をキャッチアップできる。

## なぜ入れるのか？
- 新しく参加された方にER図を目にしてもらいたい
    - 早めに全体像を俯瞰できることでプロダクトの理解が早まるのではないだろうか？
- ER図を生成するにはGemだけでなく外部プラグインがいるので手順を書いておいたほうが良さそうかな？
- 自分自身が頭の中にER図を描けていなかった…
    - 概要を掴むのに時間がかかったので後から参加される方には同じ思いをしてほしくない
    - スムーズに開発に参加してもらいたい！
