### PR TITLE
GemfileとGemfile.lockの内容に相違があったので修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,6 @@ GEM
       sass (>= 3.4.19)
     builder (3.2.3)
     byebug (10.0.2)
-    callsite (0.0.11)
     capybara (3.8.2)
       addressable
       mini_mime (>= 0.1.3)
@@ -93,7 +92,6 @@ GEM
     crass (1.0.4)
     curb (0.8.8)
     diffy (3.2.1)
-    docile (1.3.1)
     dry-inflector (0.1.2)
     dynamic_form (1.1.4)
     erubi (1.7.1)
@@ -299,10 +297,6 @@ GEM
       mimemagic (~> 0.3.2)
     meta-tags (2.10.0)
       actionpack (>= 3.2.0, < 5.3)
-    meta_request (0.6.0)
-      callsite (~> 0.0, >= 0.0.11)
-      rack-contrib (>= 1.1, < 3)
-      railties (>= 3.0.0, < 6)
     method_source (0.9.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -347,8 +341,6 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
-    rack-contrib (2.1.0)
-      rack (~> 2.0)
     rack-cors (1.0.2)
     rack-proxy (0.6.5)
       rack
@@ -424,11 +416,6 @@ GEM
       activesupport (>= 4.0.0)
     simple_seed (0.0.2)
       activerecord (>= 4.0)
-    simplecov (0.16.1)
-      docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
     slack-notifier (2.3.2)
     slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
@@ -516,7 +503,6 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   meta-tags
-  meta_request
   minitest (~> 5.10, != 5.10.2)
   newrelic_rpm
   oauth2
@@ -536,7 +522,6 @@ DEPENDENCIES
   selenium-webdriver
   simple_enum
   simple_seed
-  simplecov
   slack-notifier
   slim-rails
   sorcery


### PR DESCRIPTION
## 概要
#553 の修正P/Rになります。
`Gemfile` を変更した際に `bundle install` を行っておらず、結果 `Gemfile.lock` との相違が生まれたようです。
`master` へマージする際にコケたため、このP/Rで修正します。