### PR TITLE
日報詳細画面の「次」「前」の挙動を修正

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -17,9 +17,7 @@ class ReportsController < ApplicationController
 
   def index
     @search_words = params[:word]&.squish&.split(/[[:blank:]]/)&.uniq
-    @reports = Report
-      .eager_load(:user, :comments, checks: :user)
-      .paging_with_created_at(page: params[:page], order_type: "desc")
+    @reports = Report.eager_load(:user, :comments, checks: :user).default_order.page(params[:page])
 
     if params[:practice_id].present?
       @reports = @reports.joins(:practices).where(practices: { id: params[:practice_id] })

--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -18,7 +18,7 @@ class Users::CommentsController < ApplicationController
           .preload(:commentable)
           .eager_load(:user)
           .where(user_id: user, commentable_type: "Report")
-          .paging_with_created_at(page: params[:page], order_type: "desc")
+          .default_order.page(params[:page])
     end
 
     def user

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -14,9 +14,7 @@ class Users::ReportsController < ApplicationController
     end
 
     def set_reports
-      @reports = user.reports
-        .eager_load(:user, :comments)
-        .paging_with_created_at(page: params[:page], order_type: "desc")
+      @reports = user.reports.eager_load(:user, :comments).default_order.page(params[:page])
     end
 
     def user

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,7 +9,7 @@ class Comment < ActiveRecord::Base
 
   validates :description, presence: true
 
-  scope :paging_with_created_at, -> (page:, order_type: "asc") { order(created_at: order_type.to_sym, id: :asc).page(page) }
+  scope :default_order, -> { order(created_at: :desc, id: :asc) }
 
   def reciever
     commentable.user

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -18,16 +18,16 @@ class Report < ActiveRecord::Base
   scope :paging_with_created_at, -> (page:, order_type: "asc") { order(created_at: order_type.to_sym, id: :asc).page(page) }
 
   def previous
-    Report
-      .where("user_id = ? AND created_at <= ? AND id <> ?", user_id, created_at, id)
-      .order(created_at: :desc, id: :asc)
-      .first
+    Report.where(user: user)
+          .where("reported_on < ?", reported_on)
+          .order(created_at: :desc)
+          .first
   end
 
   def next
-    Report
-      .where("user_id = ? AND created_at >= ? AND id <> ?", user_id, created_at, id)
-      .order(created_at: :desc, id: :asc)
-      .first
+    Report.where(user: user)
+          .where("reported_on > ?", reported_on)
+          .order(:reported_on)
+          .first
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -15,7 +15,7 @@ class Report < ActiveRecord::Base
   validates :user, presence: true
   validates :reported_on, presence: true, uniqueness: { scope: :user }
 
-  scope :paging_with_created_at, -> (page:, order_type: "asc") { order(created_at: order_type.to_sym, id: :asc).page(page) }
+  scope :default_order, -> { order(reported_on: :desc, user_id: :desc) }
 
   def previous
     Report.where(user: user)

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -7,7 +7,7 @@ header.page-header
 .page-body
   .container
     = render "product", product: @product
-    = render "comments/comments", comments: @product.comments.paging_with_created_at(page: params[:page]), form_visibility: true
+    = render "comments/comments", comments: @product.comments.default_order.page(params[:page]), form_visibility: true
     - if @product.user == current_user
       .form-actions
         ul.form-actions__items

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -16,7 +16,7 @@ header.page-header
 .page-body
   .container
     = render "report", report: @report
-    = render "comments/comments", comments: @report.comments.paging_with_created_at(page: params[:page]), form_visibility: true
+    = render "comments/comments", comments: @report.comments.default_order.page(params[:page]), form_visibility: true
     - if @footprints.any?
       .footprints
         h3.footprints__title = t("we_checked")

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_022628) do
   create_table "images", force: :cascade do |t|
     t.string "image_file_name"
     t.string "image_content_type"
-    t.integer "image_file_size"
+    t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.bigint "user_id"
     t.text "image_meta"
@@ -235,7 +235,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_022628) do
     t.boolean "mentor", default: false, null: false
     t.string "face_file_name"
     t.string "face_content_type"
-    t.integer "face_file_size"
+    t.bigint "face_file_size"
     t.datetime "face_updated_at"
     t.datetime "graduated_at"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -18,7 +18,7 @@ report_2:
 
 report_3:
   user: komagata
-  title: "学習週1日目"
+  title: "学習週3日目"
   description: |-
     今日は CSS の勉強をしました。デザイン難しい。。。
   reported_on: "2017-01-03"

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -186,24 +186,6 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text "00:30 〜 02:30"
   end
 
-  test "Should not have a link to previous report on the first report" do
-    visit "/reports/#{reports(:report_1).id}"
-    assert_no_text "前"
-    assert_text "次"
-  end
-
-  test "Should have links to previous & next report" do
-    visit "/reports/#{reports(:report_2).id}"
-    assert_text "前"
-    assert_text "次"
-  end
-
-  test "Should not have a link to  next report in the newest report" do
-    visit "/reports/#{reports(:report_3).id}"
-    assert_text "前"
-    assert_no_text "次"
-  end
-
   test "Reports can be copied" do
     user   = users(:komagata)
     report = user.reports.first
@@ -212,5 +194,17 @@ class ReportsTest < ApplicationSystemTestCase
       find("#copy").click
       assert_equal find("#report_reported_on").value, Date.current.strftime("%Y-%m-%d")
     end
+  end
+
+  test "previous report" do
+    visit "/reports/#{reports(:report_2).id}"
+    click_link "前の日報"
+    assert_equal "/reports/#{reports(:report_1).id}", current_path
+  end
+
+  test "next report" do
+    visit "/reports/#{reports(:report_2).id}"
+    click_link "次の日報"
+    assert_equal "/reports/#{reports(:report_3).id}", current_path
   end
 end


### PR DESCRIPTION
## 概要
#572 を解消するP/Rです。
以下の修正を行いました。
- created_atの並び=idの並びだったので集計条件を簡素化
- あわせてテストファイルを一部修正
- 並び順が担保されているかどうかのテストを追加

## 修正した点
`reports.id` がオートインクリメントである関係上、 `created_at` のorderと `id` のorderが一致するため、 `previous` `next` メソッドを簡略化しました。
また、日報の遷移する順番が担保されているかのテストを実装しました。
