### PR TITLE
お知らせに足跡機能が欲しい #519

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,6 @@ GEM
       sass (>= 3.4.19)
     builder (3.2.3)
     byebug (10.0.2)
-    callsite (0.0.11)
     capybara (3.8.2)
       addressable
       mini_mime (>= 0.1.3)
@@ -94,7 +93,6 @@ GEM
     crass (1.0.4)
     curb (0.8.8)
     diffy (3.2.1)
-    docile (1.3.1)
     dry-inflector (0.1.2)
     dynamic_form (1.1.4)
     erubi (1.7.1)
@@ -300,10 +298,6 @@ GEM
       mimemagic (~> 0.3.2)
     meta-tags (2.10.0)
       actionpack (>= 3.2.0, < 5.3)
-    meta_request (0.6.0)
-      callsite (~> 0.0, >= 0.0.11)
-      rack-contrib (>= 1.1, < 3)
-      railties (>= 3.0.0, < 6)
     method_source (0.9.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -348,8 +342,6 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
-    rack-contrib (2.1.0)
-      rack (~> 2.0)
     rack-cors (1.0.2)
     rack-proxy (0.6.5)
       rack
@@ -431,11 +423,6 @@ GEM
       activesupport (>= 4.0.0)
     simple_seed (0.0.2)
       activerecord (>= 4.0)
-    simplecov (0.16.1)
-      docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
     slack-notifier (2.3.2)
     slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
@@ -523,7 +510,6 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   meta-tags
-  meta_request
   minitest (~> 5.10, != 5.10.2)
   newrelic_rpm
   oauth2
@@ -544,7 +530,6 @@ DEPENDENCIES
   selenium-webdriver
   simple_enum
   simple_seed
-  simplecov
   slack-notifier
   slim-rails
   sorcery

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -3,12 +3,14 @@
 class AnnouncementsController < ApplicationController
   before_action :require_admin_login, except: %i(index show)
   before_action :set_announcement, only: %i(show edit update destroy)
+  before_action :set_footprints, only: %i(show)
 
   def index
     @announcements = Announcement.order(created_at: :desc).page(params[:page])
   end
 
   def show
+    footprint!
   end
 
   def new
@@ -43,6 +45,14 @@ class AnnouncementsController < ApplicationController
   end
 
   private
+    def footprint!
+      @announcement.footprints.where(user: current_user).first_or_create if @announcement.user != current_user
+    end
+
+    def set_footprints
+      @footprints = @announcement.footprints.order(created_at: :desc)
+    end
+
     def announcement_params
       params.require(:announcement).permit(:title, :description)
     end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -31,8 +31,6 @@ class ReportsController < ApplicationController
   end
 
   def show
-    @footprint.user = current_user
-    @footprint.report = @report
     footprint!
   end
 
@@ -81,9 +79,7 @@ class ReportsController < ApplicationController
 
   private
     def footprint!
-      if @report.user != current_user
-        @footprints.where(user: @footprint.user).first_or_create
-      end
+      @report.footprints.where(user: current_user).first_or_create if @report.user != current_user
     end
 
     def report_params
@@ -125,7 +121,7 @@ class ReportsController < ApplicationController
     end
 
     def set_footprints
-      @footprints = Footprint.where(report_id: report.id).order(created_at: :desc)
+      @footprints = @report.footprints.order(created_at: :desc)
     end
 
     def set_comment

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Announcement < ApplicationRecord
+  include Footprintable
+
   belongs_to :user
   alias_method :sender, :user
 

--- a/app/models/concerns/footprintable.rb
+++ b/app/models/concerns/footprintable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Footprintable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :footprints, as: :footprintable, dependent: :delete_all
+  end
+end

--- a/app/models/footprint.rb
+++ b/app/models/footprint.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Footprint < ApplicationRecord
-  belongs_to :user, touch: true
+  belongs_to :user
   belongs_to :footprintable, polymorphic: true
   validates :user_id, presence: true
 end

--- a/app/models/footprint.rb
+++ b/app/models/footprint.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class Footprint < ApplicationRecord
-  belongs_to :user
-  belongs_to :report
+  belongs_to :user, touch: true
+  belongs_to :footprintable, polymorphic: true
   validates :user_id, presence: true
-  validates :report_id, presence: true
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,8 +3,8 @@
 class Report < ActiveRecord::Base
   include Commentable
   include Checkable
+  include Footprintable
 
-  has_many :footprints
   has_many :learning_times, dependent: :destroy, inverse_of: :report
   accepts_nested_attributes_for :learning_times, reject_if: :all_blank, allow_destroy: true
   has_and_belongs_to_many :practices

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -17,3 +17,10 @@ header.page-header
 .page-body
   .container
     = render "announcement", announcement: @announcement
+    - if @footprints.any?
+      .footprints
+        h3.footprints__title
+          = t("we_checked")
+        ul.footprints__items
+          - @footprints.each do |check|
+            = render "reports/report_check", report: @announcement, check: check

--- a/db/migrate/20181105020951_change_footprintable_to_footprints.rb
+++ b/db/migrate/20181105020951_change_footprintable_to_footprints.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeFootprintableToFootprints < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :footprints, :report_id, :footprintable_id
+    add_column :footprints, :footprintable_type, :string, default: "Report"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_29_030938) do
+ActiveRecord::Schema.define(version: 2018_11_05_020951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -95,17 +95,16 @@ ActiveRecord::Schema.define(version: 2018_10_29_030938) do
     t.boolean "user_policy_agreed", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "purpose_content", null: false
-    t.datetime "purpose_deadline", null: false
   end
 
   create_table "footprints", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
-    t.integer "report_id", null: false
+    t.integer "footprintable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["report_id"], name: "index_footprints_on_report_id"
-    t.index ["user_id", "report_id"], name: "index_footprints_on_user_id_and_report_id", unique: true
+    t.string "footprintable_type", default: "Report"
+    t.index ["footprintable_id"], name: "index_footprints_on_footprintable_id"
+    t.index ["user_id", "footprintable_id"], name: "index_footprints_on_user_id_and_footprintable_id", unique: true
     t.index ["user_id"], name: "index_footprints_on_user_id"
   end
 

--- a/test/system/footprint_test.rb
+++ b/test/system/footprint_test.rb
@@ -3,16 +3,34 @@
 require "application_system_test_case"
 
 class FootprintTest < ApplicationSystemTestCase
-  test "should be create footprint" do
+  test "should be create footprint in /reports/:id" do
     login_user "tanaka", "testtest"
-    visit "/reports/#{reports(:report_2).id}"
+    report = users(:komagata).reports.first
+    visit report_path(report)
     assert_text "見たよ"
     assert page.has_css?(".footprints-item__checker-icon.is-tanaka")
   end
 
-  test "should not footpoint with my report" do
+  test "should not footpoint with my own report" do
     login_user "tanaka", "testtest"
-    visit "/reports/#{reports(:report_7).id}"
+    report = users(:tanaka).reports.first
+    visit report_path(report)
+    assert_no_text "見たよ"
+    assert_not page.has_css?(".footprints-item__checker-icon.is-tanaka")
+  end
+
+  test "should be create footprint in /announcements/:id" do
+    login_user "tanaka", "testtest"
+    announce = users(:komagata).announcements.first
+    visit announcement_path(announce)
+    assert_text "見たよ"
+    assert page.has_css?(".footprints-item__checker-icon.is-tanaka")
+  end
+
+  test "should not footpoint with my own announcement" do
+    login_user "komagata", "testtest"
+    announce = users(:komagata).announcements.first
+    visit announcement_path(announce)
     assert_no_text "見たよ"
     assert_not page.has_css?(".footprints-item__checker-icon.is-tanaka")
   end


### PR DESCRIPTION
## 何を解決するのか
お知らせ画面に足跡機能を実装します。
現在のモデル構造だと `[report]--has_many-->[footprints]` の関係ですが、 `[announcement]--has_many-->[footprints]` …と、モデルが増えるたびにテーブル・リレーションが増えていくという問題を有しております。
そこで `polymorphic` を定義することで1つの `footprint` テーブルで全ての足跡を管理するようにしました。
これによって今後の機能拡張がスムーズに行えるようになります。