### PR TITLE
wiki で存在しないページの挙動変更

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,8 +12,7 @@ class PagesController < ApplicationController
   end
 
   def new
-    title = params[:title] || ""
-    @page = Page.new(title: title)
+    @page = Page.new
   end
 
   def edit
@@ -43,8 +42,7 @@ class PagesController < ApplicationController
 
   private
     def set_page
-      @page = Page.find_by(id: params[:id])
-      redirect_to new_page_path unless @page
+      @page = Page.find(params[:id])
     end
 
     def page_params

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -5,3 +5,7 @@ page_1:
 page_2:
   title: テスト
   body: "## テスト\nテスト"
+
+page_3:
+  title: Wikiページ
+  body: "## 存在しないWikiページ遷移テスト\n[存在しないページ](http://localhost:3000/pages/5555555)"

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -84,4 +84,13 @@ class PagesTest < ApplicationSystemTestCase
     visit user_reports_path([users(:komagata)], page: 3)
     assert_equal 10, user.reports.page(3).size
   end
+
+  test "If you click the link of a nonexistent page, it will not transition to wiki create page" do
+    id = pages(:page_3).id
+    visit "/pages/#{id}"
+
+    click_link "存在しないページ"
+
+    assert_no_text "ページ作成"
+  end
 end


### PR DESCRIPTION
refs #474 

- [x]  wiki で存在しないページのリンクにアクセス時、新規作成ではなく404エラーへ遷移する。 
- [x] 上記テストコード