### PR TITLE
reportページのcommentの並びがおかしかったのを修正

### DIFF
--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -18,7 +18,7 @@ class Users::CommentsController < ApplicationController
           .preload(:commentable)
           .eager_load(:user)
           .where(user_id: user, commentable_type: "Report")
-          .default_order.page(params[:page])
+          .order(created_at: :desc).page(params[:page])
     end
 
     def user

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,8 +9,6 @@ class Comment < ActiveRecord::Base
 
   validates :description, presence: true
 
-  scope :default_order, -> { order(created_at: :desc, id: :asc) }
-
   def reciever
     commentable.user
   end

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -7,7 +7,7 @@ header.page-header
 .page-body
   .container
     = render "product", product: @product
-    = render "comments/comments", comments: @product.comments.default_order.page(params[:page]), form_visibility: true
+    = render "comments/comments", comments: @product.comments.order(created_at: :desc).page(params[:page]), form_visibility: true
     - if @product.user == current_user
       .form-actions
         ul.form-actions__items

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -16,7 +16,7 @@ header.page-header
 .page-body
   .container
     = render "report", report: @report
-    = render "comments/comments", comments: @report.comments.default_order.page(params[:page]), form_visibility: true
+    = render "comments/comments", comments: @report.comments.order(created_at: :desc).page(params[:page]), form_visibility: true
     - if @footprints.any?
       .footprints
         h3.footprints__title = t("we_checked")


### PR DESCRIPTION
commentはものによって並びが違うのでdefault_orderを廃止。
実装するときにしっかりと並びを意識できるようにするため。