### PR TITLE
ユーザー情報編集ページでリタイアにチエックを入れたらリタイア日を記録する

### DIFF
--- a/app/assets/stylesheets/blocks/user/_user_dates.sass
+++ b/app/assets/stylesheets/blocks/user/_user_dates.sass
@@ -7,7 +7,8 @@
 .user-dates__update-at
   +text-block(.8125rem 1.45)
 
-.user-dates__graduated-at
+.user-dates__graduated-at,
+.user-dates__retired-on
   +text-block(.8125rem 1.45)
 
 .user-dates__created-at-label,
@@ -20,12 +21,14 @@
 .user-dates__update-at-value
   display: inline-block
 
-.user-dates__graduated-at-label
-  display: inline-block
-
+.user-dates__graduated-at-label,
 .user-dates__graduated-at-value
   display: inline-block
-  
+
+.user-dates__retired-on-label,
+.user-dates__retired-on-value
+  display: inline-block
+
 .user-dates__active-practices
   display: inline-block
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -21,7 +21,7 @@ class Admin::UsersController < AdminController
       when "inactive"
         @users.where(adviser: false, retire: false, graduation: false).inactive.order(:updated_at)
       when "year_end_party"
-        @users.where(retire: false)
+        @users.where(retired_on: nil)
       when "all"
         @users
       end
@@ -73,9 +73,10 @@ class Admin::UsersController < AdminController
         :find_job_assist,
         :feed_url,
         :adviser,
-        :retire,
         :nda,
-        :graduated_on
+        :graduated_on,
+        :retired_on,
+        :nda
       )
     end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:user][:login_name], params[:user][:password], params[:remember])
     if @user
-      if @user.retire?
+      if @user.retired_on?
         logout
         redirect_to retire_path
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,14 +58,14 @@ class User < ActiveRecord::Base
 
   scope :in_school, -> { where(graduated_on: nil) }
   scope :graduated, -> { where.not(graduated_on: nil) }
-  scope :retired, -> { where(retire: true) }
+  scope :retired, -> { where.not(retired_on: nil) }
   scope :advisers, -> { where(adviser: true) }
   scope :not_advisers, -> { where(adviser: false) }
-  scope :student, -> { where(mentor: false, graduated_on: nil, adviser: false, retire: false) }
+  scope :student, -> { where(mentor: false, graduated_on: nil, adviser: false, retired_on: nil) }
   scope :active, -> { where("updated_at > ?", 1.month.ago) }
   scope :inactive, -> { where("updated_at <= ?", 1.month.ago) }
   scope :mentor, -> { where(mentor: true) }
-  scope :working, -> { active.where(adviser: false, graduated_on: nil, retire: false).order(updated_at: :desc) }
+  scope :working, -> { active.where(adviser: false, graduated_on: nil, retired_on: nil).order(updated_at: :desc) }
 
   scope :admin, -> { where(email: ADMIN_EMAILS) }
 

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -74,12 +74,8 @@
             = f.check_box :adviser, class: "auth-form-checkbox__input"
             = User.human_attribute_name :adviser
     .auth-form-item
-      = f.label :retire, class: "a-sm-label"
-      ul.auth-form-item__checkboxes
-        li.auth-form-checkbox
-          label.auth-form-checkbox__label
-            = f.check_box :retire, class: "auth-form-checkbox__input"
-            = User.human_attribute_name :retire
+      = f.label :retired_on, class: "a-sm-label"
+      = f.text_field :retired_on, class: "datepicker a-text-input"
   .auth-form-action.is-sign-up-action
     ul.auth-form-action__items
       li.auth-form-action__item

--- a/app/views/users/_dates.html.slim
+++ b/app/views/users/_dates.html.slim
@@ -23,4 +23,11 @@
         = User.human_attribute_name :graduated_on
         | :
       .user-dates__graduated-at-value
-        = l @user.graduated_on.to_date
+        = l @user.graduated_on
+  - if @user.retired_on.present?
+    .user-dates__retired-on
+      .user-dates__retired-on-label
+        = User.human_attribute_name :retired_on
+        | :
+      .user-dates__retired-on-value
+        = l @user.retired_on

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -332,7 +332,7 @@ ja:
         nda: 秘密保持契約
         graduated_on: 卒業日
         adviser: アドバイザー
-        retire: リタイア
+        retired_on: リタイア日
 
       course:
         title: タイトル

--- a/db/migrate/20181120054521_add_retired_on_to_users.rb
+++ b/db/migrate/20181120054521_add_retired_on_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRetiredOnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :retired_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_20_044954) do
+ActiveRecord::Schema.define(version: 2018_11_20_054521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -251,6 +251,7 @@ ActiveRecord::Schema.define(version: 2018_11_20_044954) do
     t.datetime "face_updated_at"
     t.date "graduated_on"
     t.bigint "course_id"
+    t.date "retired_on"
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -25,6 +25,14 @@ namespace :bootcamp do
         user.update!(graduated_on: "2000-01-01")
       end
     end
+
+    desc "Set all retired_on"
+    task "set_all_riteired_on" do
+      User.where(retire: true, retired_on: nil).order(:created_at).each do |user|
+        puts "Update retired_on: #{user.login_name}"
+        user.update!(retired_on: "2000-01-01")
+      end
+    end
   end
 
   desc "Replace practices"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -80,8 +80,8 @@ yameo:
   blog_url: http://yameo.org
   company: company_1
   description: "リタイアしました。"
-  retire: true
   course: course_1
+  retired_on: "2015-01-01"
   created_at: "2014-01-01 00:00:05"
 
 yamada:

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -53,6 +53,14 @@ class UsersTest < ApplicationSystemTestCase
     assert_text "卒業日"
   end
 
+  test "retired date is displayed" do
+    login_user "komagata", "testtest"
+    visit "/users/#{users(:yameo).id}"
+    assert_text "リタイア日"
+    visit "/users/#{users(:tanaka).id}"
+    assert_no_text "リタイア日"
+  end
+
   test "user list corresponding to selected status is displayed" do
     login_user "komagata", "testtest"
 


### PR DESCRIPTION
fixes #476
- [x]  ユーザー情報編集ページでリタイアにチェックを入れて更新したら、リタイア日を記録する
- [x] ユーザー詳細ページにリタイア日が表示される
- [x] テストを書く