### PR TITLE
Q&Aが投稿されたら、そのQに紐付いたプラクティス完了者に通知がいくようにしたい

### DIFF
--- a/app/models/question_callbacks.rb
+++ b/app/models/question_callbacks.rb
@@ -12,5 +12,10 @@ class QuestionCallbacks
           Notification.came_question(question, user)
         end
       end
+      question.practice.completed_learnings.each do |learning|
+        if learning.user != question.sender
+          Notification.came_question(question, learning.user)
+        end
+      end
     end
 end

--- a/app/models/question_callbacks.rb
+++ b/app/models/question_callbacks.rb
@@ -2,16 +2,20 @@
 
 class QuestionCallbacks
   def after_create(question)
-    send_notification(question)
+    send_notification_to_mentors(question)
+    send_notification_to_completed_students(question)
   end
 
   private
-    def send_notification(question)
+    def send_notification_to_mentors(question)
       User.mentor.each do |user|
         if question.sender != user
           Notification.came_question(question, user)
         end
       end
+    end
+
+    def send_notification_to_completed_students(question)
       question.practice.completed_learnings.where.not(user_id: question.sender).eager_load(:user).each do |learning|
         Notification.came_question(question, learning.user)
       end

--- a/app/models/question_callbacks.rb
+++ b/app/models/question_callbacks.rb
@@ -12,10 +12,8 @@ class QuestionCallbacks
           Notification.came_question(question, user)
         end
       end
-      question.practice.completed_learnings.each do |learning|
-        if learning.user != question.sender
-          Notification.came_question(question, learning.user)
-        end
+      question.practice.completed_learnings.where.not(user_id: question.sender).eager_load(:user).each do |learning|
+        Notification.came_question(question, learning.user)
       end
     end
 end

--- a/test/fixtures/learnings.yml
+++ b/test/fixtures/learnings.yml
@@ -27,4 +27,3 @@ learning_5:
   user: kimura
   practice: practice_1
   status_cd: 1
-   

--- a/test/fixtures/learnings.yml
+++ b/test/fixtures/learnings.yml
@@ -22,3 +22,9 @@ learning_5:
   user: tanaka
   practice: practice_2
   status_cd: 1
+
+learning_5:
+  user: kimura
+  practice: practice_1
+  status_cd: 1
+   

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -176,3 +176,26 @@ hatsuno:
   organization: 明治大学
   updated_at: "2014-01-01 00:00:08"
   created_at: "2014-01-01 00:00:08"
+
+hajime:
+  login_name: hajime
+  email: hajime@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  first_name: Tayo
+  last_name: Hajime
+  twitter_account: hajime
+  facebook_url: http://www.facebook.com/hajime
+  blog_url: http://hajime.org
+  feed_url: http://hajime.org/index.atom
+  company: company_1
+  description: "始です。"
+  course: course_1
+  job: office_worker
+  os: mac
+  study_place: remote
+  experience: inexperienced
+  how_did_you_know: 友人に聞いて
+  organization: 始大学
+  updated_at: "2014-01-01 00:00:09"
+  created_at: "2014-01-01 00:00:09" 

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -8,16 +8,19 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     @notice_kind = Notification.kinds["came_question"]
     @notified_count = Notification.where(kind: @notice_kind).size
     @mentor_count = User.mentor.size
+    practice = Practice.find_by(title: "OS X Mountain Lionをクリーンインストールする")
+    @completed_student_count = practice.completed_learnings.size
   end
 
-  test "mentor receives notification when question is posted" do
+  test "mentor and completed student receive notification when question is posted" do
     login_user "hatsuno", "testtest"
     visit "/questions/new"
     within("#new_question") do
-      find("ul", match: :first).set(true)
       fill_in("question[title]", with: "メンターに質問！！")
       fill_in("question[description]", with: "通知行ってますか？")
     end
+    first(".select2-selection--single").click
+    find("li", text: "[Mac OS X] OS X Mountain Lionをクリーンインストールする").click
     click_button "登録する"
     logout
 
@@ -27,19 +30,25 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     logout
 
     login_user "kimura", "testtest"
+    first(".test-bell").click
+    assert_text @notice_text
+    logout
+
+    login_user "hajime", "testtest"
     refute_text @notice_text
 
-    assert_equal @notified_count + @mentor_count, Notification.where(kind: @notice_kind).size
+    assert_equal @notified_count + @mentor_count + @completed_student_count, Notification.where(kind: @notice_kind).size
   end
 
   test "There is no notification to the mentor who posted" do
     login_user "yamada", "testtest"
     visit "/questions/new"
     within("#new_question") do
-      find("ul", match: :first).set(true)
       fill_in("question[title]", with: "皆さんに質問！！")
       fill_in("question[description]", with: "通知行ってますか？")
     end
+    first(".select2-selection--single").click
+    find("li", text: "[Mac OS X] OS X Mountain Lionをクリーンインストールする").click
     click_button "登録する"
     logout
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -68,10 +68,12 @@ class UsersTest < ApplicationSystemTestCase
     click_link "ユーザー"
 
     assert_equal 5, all(".tab-nav__item-link").length
-    assert_equal 2, all(".users-item__inner").length
+    assert_equal 3, all(".users-item__inner").length
     assert_text "yamada"
     assert_text "kimura"
     assert_text "hatsuno"
+    assert_text "hajime"
+
 
     assert_text "卒業生"
     click_link "卒業生"
@@ -85,7 +87,7 @@ class UsersTest < ApplicationSystemTestCase
 
     assert_text "全員"
     click_link "全員"
-    assert_equal 8, all(".users-item__inner").length
+    assert_equal 9, all(".users-item__inner").length
     assert_text "yameo"
   end
 end


### PR DESCRIPTION
fixes #528 
- [x] fixtureを追加
- [x] 通知の条件指定
- [x] テスト