### PR TITLE
ユーザー個別ページの完了したプラクティスのページに今日は学習開始から何日目かを出した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -182,6 +182,10 @@ WHERE
     learning_time.first.total || 0
   end
 
+  def dates_from_start_fjord
+    (Date.today - self.created_at.to_date).to_i
+  end
+
   private
     def password_required?
       new_record? || password.present?

--- a/app/views/users/practices/_completed_practices.html.slim
+++ b/app/views/users/practices/_completed_practices.html.slim
@@ -1,6 +1,7 @@
 .completed-practices.a-card
   header.card-header
     h2.completed-practices__title 完了したプラクティス
+    = "学習開始から#{@user.dates_from_start_fjord}日目"
   .completed-practices__body
     = render "completed_practices_progress", user: @user
     = render "completed_practices_list", user: @user

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -59,4 +59,12 @@ class UserTest < ActiveSupport::TestCase
     report.save!
     assert_equal 2, user.total_learning_time
   end
+
+  test "dates_from_start_fjord" do
+    user = users(:komagata)
+    user.created_at = Time.new(2019, 1, 1, 0, 0, 0)
+    travel_to Time.new(2020, 1, 1, 0, 0, 0) do
+      assert_equal 365, user.dates_from_start_fjord
+    end
+  end
 end


### PR DESCRIPTION
fix https://github.com/fjordllc/bootcamp/issues/736
- [ ] 今日は学習開始から何日目かを取得するメソッドを実装
- [ ] ユーザー個別ページの完了したプラクティスのページに今日は学習開始から何日目かを出した
- [ ] テストを追加