### PR TITLE
日付のフォームを追加

### DIFF
--- a/app/views/reports/_learning_time_fields.html.slim
+++ b/app/views/reports/_learning_time_fields.html.slim
@@ -7,12 +7,12 @@
         .form-selects.learning-time__started-at
           .form-selects__item
             .is-button-simple-md-secondary.is-select.is-block
-              = f.time_select :started_at, time_separator: tag, minute_step: 15
+              = f.datetime_select :started_at, time_separator: tag, minute_step: 15
       .form-item__time
         = f.label :finished_at, class: "a-label"
         .form-selects.learning-time__finished-at
           .form-selects__item
             .is-button-simple-md-secondary.is-select.is-block
-              = f.time_select :finished_at, time_separator: tag, minute_step: 15
+              = f.datetime_select :finished_at, time_separator: tag, minute_step: 15
       .form-item__times-action
         = link_to_remove_association "削除", f, class: "is-button-simple-md-secondary"

--- a/app/views/reports/_learning_times.html.slim
+++ b/app/views/reports/_learning_times.html.slim
@@ -6,4 +6,4 @@
     ul.learning-times__items
       - @report.learning_times.each do |learning_time|
         li.learning-times__item
-          | #{l learning_time.started_at, format: :time_only} 〜 #{l learning_time.finished_at, format: :time_only}
+          | #{l learning_time.started_at, format: :short} 〜 #{l learning_time.finished_at, format: :short}

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -24,8 +24,7 @@ header.page-header
             | #{l @report.reported_on} の日報
           h1.thread-header__title(class="#{@report.wip? ? "is-wip" : ""}")
             - if @report.wip?
-              span.thread-header__title-icon
-                | WIP
+              span.thread-header__title-icon WIP
             = @report.title
             - if @checks.any?
               .stamp.stamp-approve

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,7 +7,6 @@ ja:
     formats:
       default: "%Y年%m月%d日(%a) %H:%M"
       short: "%Y/%m/%d %H:%M"
-      time_only: "%H:%M"
   activerecord:
     models:
       user: ユーザー


### PR DESCRIPTION
[![Image from Gyazo](https://i.gyazo.com/7dc66dc23e77af7c42b98b95be691764.png)](https://gyazo.com/7dc66dc23e77af7c42b98b95be691764)

学習時間に日付を追加。

0時以降の時間を登録できるようにするため。