### PR TITLE
Adminユーザーのトップページに未チェックの日報数/提出物数/質問数を表示させた

### DIFF
--- a/app/views/users/_unchecked_number_table.html.slim
+++ b/app/views/users/_unchecked_number_table.html.slim
@@ -1,0 +1,20 @@
+.admin-table
+  table.admin-table__table
+    thead.admin-table__header
+      tr.admin-table__labels
+        th.admin-table__label colspan=3 チェック
+
+    tbody.admin-table__items
+      tr.admin-table__labels
+        th.admin-table__label
+          | 日報
+          br
+          | #{Report.unchecked.count}
+        th.admin-table__label
+          | 提出物
+          br
+          | #{Product.unchecked.count}
+        th.admin-table__label
+          | Q&A
+          br
+          | #{Question.not_solved.count}

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -38,3 +38,6 @@ header.page-header
           - if @user.github_account
             .a-card
               = render "users/github_grass", user: @user
+          - if @user.admin?
+            .a-card
+              = render "users/unchecked"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -72,4 +72,16 @@ class UsersTest < ApplicationSystemTestCase
     assert_equal 9, all(".users-item__inner").length
     assert_text "yameo"
   end
+
+  test "admin user can see unchecked number table" do
+    login_user "komagata", "testtest"
+    visit "/users/#{users(:komagata).id}"
+    assert_equal 1, all(".admin-table").length
+  end
+
+  test "nomal user can't see unchecked number table" do
+    login_user "hatsuno", "testtest"
+    visit "/users/#{users(:hatsuno).id}"
+    assert_equal 0, all(".admin-table").length
+  end
 end


### PR DESCRIPTION
fix https://github.com/fjordllc/bootcamp/issues/735
- [ ] Adminユーザーのトップページ場合は未チェックの日報数/提出物数/質問数のテーブルを表示させる
- [ ] テスト追加