### PR TITLE
ユーザー個別のコメント一覧に、日報以外（Q&A、提出物）のコメントも含めて出るようにした

### DIFF
--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -17,7 +17,7 @@ class Users::CommentsController < ApplicationController
         Comment
           .preload(:commentable)
           .eager_load(:user)
-          .where(user_id: user, commentable_type: "Report")
+          .where(user_id: user)
           .order(created_at: :desc).page(params[:page])
     end
 


### PR DESCRIPTION
fix https://github.com/fjordllc/bootcamp/issues/741
- [ ] ユーザー個別のコメント一覧に、日報以外（Q&A、提出物）のコメントも含めて出るようにした