### PR TITLE
検索結果の種類アイコンを日本語にする

### DIFF
--- a/app/views/searchables/_searchable.html.slim
+++ b/app/views/searchables/_searchable.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item(class="is-#{searchable.class.to_s.tableize.singularize}")
   .thread-list-item__inner
     .thread-list-item__label
-      = t(searchable.class.to_s.tableize.singularize)
+      = t("activerecord.models.#{searchable.class.to_s.tableize.singularize}")
     header.thread-list-item__header
       .thread-list-item__title
         = link_to searchable.title, searchable, class: "thread-list-item__title-link"


### PR DESCRIPTION
[検索結果の種類アイコンが英語になっている（日本語にしたい） · Issue #783 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/783)

- [x] 検索結果の種類アイコンを日本語にする