### PR TITLE
ユーザー個別のコメント一覧で提出物のタイトルを出す

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem "rails-i18n"
 gem "google-cloud-storage", "~> 1.3", require: false
 gem "mini_magick"
 gem "activestorage-validator"
+gem "commonmarker"
 
 group :production, :staging do
   gem "newrelic_rpm"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    commonmarker (0.18.2)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
     curb (0.8.8)
@@ -274,6 +276,8 @@ GEM
     retriable (3.1.2)
     rollbar (2.18.0)
       multi_json
+    ruby-enum (0.7.2)
+      i18n
     ruby-graphviz (1.2.3)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
@@ -381,6 +385,7 @@ DEPENDENCIES
   chromedriver-helper
   cocoon
   coffee-rails (~> 4.2)
+  commonmarker
   curb (~> 0.8.8)
   diffy
   dynamic_form

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -63,6 +63,7 @@
   display: flex
   align-items: center
   margin-bottom: .125rem
+  justify-content: space-between
   +media-breakpoint-down(sm)
     flex-direction: column
     align-items: flex-start
@@ -119,7 +120,7 @@
   +text-block(.75rem 1.4, block $muted-text inline-block)
 
 .thread-list-item__body
-  +text-block(.875rem 1.8)
+  +text-block(.875rem 1.6)
 
 .thread-list-item-meta__created-at
   +text-block(.75rem 1.4, $muted-text)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -4,4 +4,14 @@ module CommentsHelper
   def user_comments_page?
     controller_path == "users/comments" && action_name == "index"
   end
+
+  def md2html(text)
+    html = CommonMarker.render_html(text)
+    raw(html)
+  end
+
+  def comment_summury(comment, word_count)
+    summury = strip_tags(md2html(comment)).gsub(/[\r\n]/,"")
+    simple_format(truncate(summury, length: word_count))
+  end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -11,7 +11,7 @@ module CommentsHelper
   end
 
   def comment_summury(comment, word_count)
-    summury = strip_tags(md2html(comment)).gsub(/[\r\n]/,"")
+    summury = strip_tags(md2html(comment)).gsub(/[\r\n]/, "")
     simple_format(truncate(summury, length: word_count))
   end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -4,10 +4,4 @@ module CommentsHelper
   def user_comments_page?
     controller_path == "users/comments" && action_name == "index"
   end
-
-  def comment_title(commentable)
-    if commentable.is_a?(Report)
-      commentable.title
-    end
-  end
 end

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -10,7 +10,7 @@
           = t("activerecord.models.#{commentable.class.to_s.tableize.singularize}")
           = link_to commentable, class: "thread-comment__title-link" do
             = image_tag commentable.user.avatar.variant(resize: "40x40"), class: "thread-comment__title-icon"
-            = truncate(comment_title(commentable), length: 50)
+            = truncate(commentable.title, length: 50)
       - else
         h2.thread-comment__title
           = link_to comment.user, itempro: "url", class: "thread-comment__title-link" do

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -7,6 +7,7 @@
     header.thread-comment__body-header
       - if user_comments_page?
         h2.thread-comment__title.is-user-comments
+          = t("activerecord.models.#{commentable.class.to_s.tableize.singularize}")
           = link_to commentable, class: "thread-comment__title-link" do
             = image_tag commentable.user.avatar.variant(resize: "40x40"), class: "thread-comment__title-icon"
             = truncate(comment_title(commentable), length: 50)

--- a/app/views/searchables/_searchable.html.slim
+++ b/app/views/searchables/_searchable.html.slim
@@ -6,4 +6,4 @@
       .thread-list-item__title
         = link_to searchable.title, searchable, class: "thread-list-item__title-link"
     .thread-list-item__body
-      p = truncate searchable.description, length: 50
+      = comment_summury(searchable.description, 90)

--- a/app/views/users/comments/_comment.html.slim
+++ b/app/views/users/comments/_comment.html.slim
@@ -1,0 +1,19 @@
+- commentable = comment.commentable
+.thread-list-item(class="is-#{commentable.class.to_s.tableize.singularize}")
+  .thread-list-item__inner
+    .thread-list-item__label
+      = t("activerecord.models.#{commentable.class.to_s.tableize.singularize}")
+    header.thread-list-item__header
+      - if user_comments_page?
+        h2.thread-list-item__title
+          = link_to commentable, class: "thread-list-item__title-link" do
+            = image_tag commentable.user.avatar.variant(resize: "40x40"), class: "thread-comment__title-icon"
+            = truncate(commentable.title, length: 50)
+      - else
+        h2.thread-list-item__title
+          = link_to comment.user, itempro: "url", class: "thread-list-item__title-link" do
+            = comment.user.login_name
+      time.thread-comment__created-at(datetime="#{commentable.created_at.to_datetime}" pubdate="pubdate")
+        = l comment.updated_at
+    .thread-list-item__body
+      = comment_summury(comment.description, 90)

--- a/app/views/users/comments/_comments.html.slim
+++ b/app/views/users/comments/_comments.html.slim
@@ -1,0 +1,3 @@
+.thread-comments-container
+  .thread-comments
+    = render partial: "comment", collection: comments.order(:created_at), as: :comment

--- a/app/views/users/comments/index.html.slim
+++ b/app/views/users/comments/index.html.slim
@@ -14,5 +14,6 @@ header.page-header
 .page-body
   .container
     = paginate @comments, position: "top"
-    = render "comments/comments", comments: @comments
+    .thread-list.a-card
+      = render "comments", comments: @comments
     = paginate @comments, position: "bottom"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -38,6 +38,3 @@ header.page-header
           - if @user.github_account
             .a-card
               = render "users/github_grass", user: @user
-          - if @user.admin?
-            .a-card
-              = render "users/unchecked"

--- a/test/system/page_tabs_test.rb
+++ b/test/system/page_tabs_test.rb
@@ -491,7 +491,7 @@ class PageTabsTest < ApplicationSystemTestCase
     assert_equal 1, all(".page-tabs__item-link.is-active").length
     assert_equal "コメント", first(".page-tabs__item-link.is-active").text
     expected_comment_counts = User.find(user_id).comments.where(commentable_type: "Report").size
-    actual_comment_counts = all(".thread-comment__title-link").size
+    actual_comment_counts = all(".thread-list-item__title-link").size
     assert_equal expected_comment_counts, actual_comment_counts
   end
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -88,12 +88,6 @@ class UsersTest < ApplicationSystemTestCase
     assert_text "kensyu"
   end
 
-  test "admin user can see unchecked number table" do
-    login_user "komagata", "testtest"
-    visit "/users/#{users(:komagata).id}"
-    assert_equal 1, all(".admin-table").length
-  end
-
   test "nomal user can't see unchecked number table" do
     login_user "hatsuno", "testtest"
     visit "/users/#{users(:hatsuno).id}"


### PR DESCRIPTION
[ユーザー個別のコメント一覧で提出物のタイトルも出したい · Issue #782 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/782)

- [x] ユーザー個別のコメント一覧で提出物のタイトルを出す
- [x] 日報なのか提出物なのかのアイコンを出す