### PR TITLE
メニューのアイコンに未確認の数を表示する

### DIFF
--- a/app/assets/stylesheets/blocks/shared/_global-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_global-nav.sass
@@ -46,6 +46,7 @@ $global-nav-width: 5rem
   border-bottom: solid 1px $side-border
 
 .global-nav-links__link
+  position: relative
   display: flex
   flex-direction: column
   white-space: nowrap
@@ -78,6 +79,5 @@ $global-nav-width: 5rem
     font-size: .875rem
 
 .global-nav__item-count
-  &.a-notification-count
-    margin-left: 1.4rem
-    margin-top: -1.6rem
+  right: 0.0625rem
+  top: 0.0625rem

--- a/app/assets/stylesheets/blocks/shared/_global-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_global-nav.sass
@@ -76,3 +76,7 @@ $global-nav-width: 5rem
   +text-block(.625rem 1.45, center)
   +media-breakpoint-down(sm)
     font-size: .875rem
+
+.a-notification-count
+  margin-left: 1.4rem
+  margin-top: -1.6rem

--- a/app/assets/stylesheets/blocks/shared/_global-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_global-nav.sass
@@ -77,6 +77,7 @@ $global-nav-width: 5rem
   +media-breakpoint-down(sm)
     font-size: .875rem
 
-.a-notification-count
-  margin-left: 1.4rem
-  margin-top: -1.6rem
+.global-nav__item-count
+  &.a-notification-count
+    margin-left: 1.4rem
+    margin-top: -1.6rem

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -21,17 +21,26 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
           = link_to reports_path, class: "global-nav-links__link #{current_link /^reports/}" do
             .global-nav-links__link-icon
               i.fas.fa-pen
+            -if Report.unchecked.not_wip.count > 0 && current_user.admin?
+              .gloval-nav__item-count.a-notification-count
+                = Report.unchecked.not_wip.count
             .global-nav-links__link-label 日報
         - if admin_adviser_or_mento_login?
           li.global-nav-links__item
             = link_to products_path, class: "global-nav-links__link #{current_link /^products-index/}" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
+              -if Product.unchecked.count > 0 && current_user.admin?
+                .gloval-nav__item-count.a-notification-count
+                  = Product.unchecked.count
               .global-nav-links__link-label 提出物
         li.global-nav-links__item
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do
             .global-nav-links__link-icon
               i.fas.fa-question
+            - if Question.not_solved.count > 0 && current_user.admin?
+              .groval-nav__item-count.a-notification-count
+                = Question.not_solved.count
             .global-nav-links__link-label Q&A
         li.global-nav-links__item
           = link_to users_path, class: "global-nav-links__link #{current_link /^users/}" do

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -39,7 +39,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
             .global-nav-links__link-icon
               i.fas.fa-question
             - if Question.not_solved.count > 0 && current_user.admin?
-              .grobal-nav__item-count.a-notification-count
+              .global-nav__item-count.a-notification-count
                 = Question.not_solved.count
             .global-nav-links__link-label Q&A
         li.global-nav-links__item

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -21,7 +21,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
           = link_to reports_path, class: "global-nav-links__link #{current_link /^reports/}" do
             .global-nav-links__link-icon
               i.fas.fa-pen
-            - if Report.unchecked.not_wip.count > 0 && current_user.admin?
+            - if current_user.admin? && Report.unchecked.not_wip.count > 0
               .global-nav__item-count.a-notification-count
                 = Report.unchecked.not_wip.count
             .global-nav-links__link-label 日報
@@ -30,7 +30,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
             = link_to products_path, class: "global-nav-links__link #{current_link /^products-index/}" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
-              - if Product.unchecked.count > 0 && current_user.admin?
+              - if current_user.admin? && Product.unchecked.count > 0
                 .global-nav__item-count.a-notification-count
                   = Product.unchecked.count
               .global-nav-links__link-label 提出物
@@ -38,7 +38,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do
             .global-nav-links__link-icon
               i.fas.fa-question
-            - if Question.not_solved.count > 0 && current_user.admin?
+            - if current_user.admin? && Question.not_solved.count > 0
               .global-nav__item-count.a-notification-count
                 = Question.not_solved.count
             .global-nav-links__link-label Q&A

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -21,7 +21,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
           = link_to reports_path, class: "global-nav-links__link #{current_link /^reports/}" do
             .global-nav-links__link-icon
               i.fas.fa-pen
-            -if Report.unchecked.not_wip.count > 0 && current_user.admin?
+            - if Report.unchecked.not_wip.count > 0 && current_user.admin?
               .global-nav__item-count.a-notification-count
                 = Report.unchecked.not_wip.count
             .global-nav-links__link-label 日報
@@ -30,7 +30,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
             = link_to products_path, class: "global-nav-links__link #{current_link /^products-index/}" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
-              -if Product.unchecked.count > 0 && current_user.admin?
+              - if Product.unchecked.count > 0 && current_user.admin?
                 .global-nav__item-count.a-notification-count
                   = Product.unchecked.count
               .global-nav-links__link-label 提出物

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -22,7 +22,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
             .global-nav-links__link-icon
               i.fas.fa-pen
             -if Report.unchecked.not_wip.count > 0 && current_user.admin?
-              .gloval-nav__item-count.a-notification-count
+              .global-nav__item-count.a-notification-count
                 = Report.unchecked.not_wip.count
             .global-nav-links__link-label 日報
         - if admin_adviser_or_mento_login?
@@ -31,7 +31,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
               -if Product.unchecked.count > 0 && current_user.admin?
-                .gloval-nav__item-count.a-notification-count
+                .global-nav__item-count.a-notification-count
                   = Product.unchecked.count
               .global-nav-links__link-label 提出物
         li.global-nav-links__item
@@ -39,7 +39,7 @@ nav.global-nav.js-show-mobile-nav__target.js-show-mobile-nav
             .global-nav-links__link-icon
               i.fas.fa-question
             - if Question.not_solved.count > 0 && current_user.admin?
-              .groval-nav__item-count.a-notification-count
+              .grobal-nav__item-count.a-notification-count
                 = Question.not_solved.count
             .global-nav-links__link-label Q&A
         li.global-nav-links__item

--- a/test/system/notification/same_notifications_test.rb
+++ b/test/system/notification/same_notifications_test.rb
@@ -19,7 +19,7 @@ class NotificationsTest < ApplicationSystemTestCase
     click_button "提出"
     click_link "ログアウト"
     login_user "komagata", "testtest"
-    click_link "日報"
+    find(".global-nav").click_link("日報")
     click_link "Rubyの基礎"
     click_button "日報を確認する"
     fill_in "comment[description]", with: "今日の日報を確認しました"


### PR DESCRIPTION
[メニューのアイコンに未確認の数が表示されてほしい · Issue #788 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/788)

- [x] メニューのアイコンに未確認の数が表示する
- [x] デザイン : 未確認の数の表示位置を右上にする