### PR TITLE
rack-mini-profilerの設定を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@
     $ yarn install
     $ rails s
 
-You can also launch a web server with [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler).
-
-    $ RACK_PROFILER=1 rails s
-
 ## テスト
 
 Test with headless browser.

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-if Rails.env.development? && ENV.has_key?("RACK_PROFILER")
-  require "rack-mini-profiler"
-  Rack::MiniProfilerRails.initialize!(Rails.application)
-  Rack::MiniProfiler.config.position = "bottom-right"
-end


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/pull/312 で `rack-mini-profiler` が削除されていたので、設定ファイルの削除やREADMEの更新をしました。