### PR TITLE
Rubocopのインストールと更新

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5.1
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ end
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "rubocop"
 
   # not default
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    ast (2.4.0)
     autoprefixer-rails (9.4.3)
       execjs
     babel-source (5.8.35)
@@ -142,6 +143,7 @@ GEM
     i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
+    jaro_winkler (1.5.2)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -208,13 +210,18 @@ GEM
     oulu (0.18.3)
       rake
       thor (~> 0.19)
+    parallel (1.14.0)
+    parser (2.6.0.0)
+      ast (~> 2.4.0)
     pg (1.1.3)
+    powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
+    psych (3.1.0)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -258,6 +265,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.2)
     ransack (2.0.1)
       actionpack (>= 5.0)
@@ -276,9 +284,19 @@ GEM
     retriable (3.1.2)
     rollbar (2.18.0)
       multi_json
+    rubocop (0.65.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      psych (>= 3.1.0)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
     ruby-enum (0.7.2)
       i18n
     ruby-graphviz (1.2.3)
+    ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     sass (3.7.2)
@@ -353,6 +371,7 @@ GEM
     uber (0.1.0)
     uglifier (4.1.19)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.4.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -414,6 +433,7 @@ DEPENDENCIES
   ransack
   record_tag_helper (~> 1.0)
   rollbar
+  rubocop
   sass-rails
   sassc-rails
   selenium-webdriver
@@ -436,4 +456,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
下記でエラーになったので、RubocopのインストールとRubocopのRubyのバージョンを更新しました。

```
% bundle exec rubocop --auto-correct
rbenv: rubocop: command not found

The `rubocop' command exists in these Ruby versions:
  2.4.4
```