### PR TITLE
WIkiをDocsに名前を変更する

### DIFF
--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -7,7 +7,7 @@ class Searcher
     ["プラクティス", :practices],
     ["日報", :reports],
     ["Q&A", :questions],
-    ["Wiki", :pages]
+    ["Docs", :pages]
   ]
 
   AVAILABLE_TYPES = DOCUMENT_TYPES.map(&:second) - [:all]

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -53,7 +53,7 @@ nav.global-nav
           = link_to "/pages", class: "global-nav-links__link #{current_link /^pages/}" do
             .global-nav-links__link-icon
               i.fas.fa-file
-            .global-nav-links__link-label Wiki
+            .global-nav-links__link-label Docs
         li.global-nav-links__item.is-hidden-md-up
           = link_to "https://docs.google.com/spreadsheets/d/1tRexM59inK1u5unRrNFNUNXXltiRQDNZZJf7X-M_G1E/edit#gid=2063800206", class: "global-nav-links__link", target: "_blank" do
             .global-nav-links__link-icon

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -1,4 +1,4 @@
-- title "Wiki"
+- title "Docs"
 header.page-header
   .container
     .page-header__container

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,7 +17,7 @@ ja:
       comment: コメント
       report: 日報
       learning_time: 学習時間
-      page: Wiki
+      page: Docs
       question: Q&A
       product: 提出物
       announcement: お知らせ

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -7,8 +7,8 @@ page_2:
   body: "## テスト\nテスト"
 
 page_3:
-  title: Wikiページ
-  body: "## 存在しないWikiページ遷移テスト\n[存在しないページ](http://localhost:3000/pages/5555555)"
+  title: Docsページ
+  body: "## 存在しないDocsページ遷移テスト\n[存在しないページ](http://localhost:3000/pages/5555555)"
 
 page_4:
   title: Bootcmapの作業のページ

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -7,7 +7,7 @@ class PagesTest < ApplicationSystemTestCase
 
   test "GET /pages" do
     visit "/pages"
-    assert_equal "Wiki | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "Docs | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
     assert_no_selector "nav.pagination"
   end
 
@@ -90,7 +90,7 @@ class PagesTest < ApplicationSystemTestCase
     assert_equal 25, user.reports.page(3).size
   end
 
-  test "If you click the link of a nonexistent page, it will not transition to wiki create page" do
+  test "If you click the link of a nonexistent page, it will not transition to docs create page" do
     id = pages(:page_3).id
     visit "/pages/#{id}"
     click_link "存在しないページ"

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -12,7 +12,7 @@ class SearchablesTest < ApplicationSystemTestCase
     end
     find("#test-search").click
     assert_text "テストの日報"
-    assert_text "Wikiページ"
+    assert_text "Docsページ"
     assert_text "Unityでのテスト"
     assert_text "テストの質問1"
     assert_text "テストのお知らせ"
@@ -25,7 +25,7 @@ class SearchablesTest < ApplicationSystemTestCase
     end
     find("#test-search").click
     assert_text "テストの日報"
-    assert_no_text "Wikiページ"
+    assert_no_text "Docsページ"
     assert_no_text "Unityでのテスト"
     assert_no_text "テストの質問1"
     assert_no_text "テストのお知らせ"


### PR DESCRIPTION
- [x] Wiki となっている文字列を Docs に変更する。
- [x] 該当するテストを実行する。

ディレクトリで文字列の検索をかけたところ、10箇所が該当しました。
10箇所を変更して、該当するテストを実行すれば大丈夫なのではと思います。
![Screenshot from 2019-03-20 19-55-35](https://user-images.githubusercontent.com/39484102/54679294-46dc0c00-4b4a-11e9-9283-101afee8dcfc.png)
