### PR TITLE
00:00 を過ぎた時間を登録しても学習時間の草（青い方）を生やす

### DIFF
--- a/app/models/grass.rb
+++ b/app/models/grass.rb
@@ -13,7 +13,9 @@ WITH series AS (
   summary AS (
     SELECT
       reported_on AS date,
-      EXTRACT(epoch FROM SUM(finished_at - started_at)) / 60 / 60 AS total_hour
+      EXTRACT(epoch FROM
+        SUM((CASE WHEN finished_at < started_at THEN finished_at + '1 day' ELSE finished_at END) - started_at)
+      ) / 60 / 60 AS total_hour
     FROM
       learning_times JOIN reports ON learning_times.report_id = reports.id
     WHERE


### PR DESCRIPTION
[00:00 を過ぎた時間を登録すると学習時間の草（青い方）が生えない · Issue #747 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/747)

finished_at がおかしいが、とりあえず草を生やす為に SQL で修正したので、力技です。