### PR TITLE
issue#840 ユーザーに就活中フラグを追加する

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -17,6 +17,7 @@ class Admin::UsersController < AdminController
 
   def update
     if @user.update(user_params)
+      job_seeking_uncheck
       redirect_to admin_users_url, notice: "ユーザー情報を更新しました。"
     else
       render :edit
@@ -62,9 +63,16 @@ class Admin::UsersController < AdminController
         :how_did_you_know,
         :company_id,
         :trainee,
+        :job_seeking,
         :nda,
         :graduated_on,
         :retired_on
       )
+    end
+
+    def job_seeking_uncheck
+      if (@user.graduated_on || @user.retired_on) && @user.job_seeking
+        @user.update(job_seeking: false)
+      end
     end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -17,7 +17,6 @@ class Admin::UsersController < AdminController
 
   def update
     if @user.update(user_params)
-      job_seeking_uncheck
       redirect_to admin_users_url, notice: "ユーザー情報を更新しました。"
     else
       render :edit
@@ -68,11 +67,5 @@ class Admin::UsersController < AdminController
         :graduated_on,
         :retired_on
       )
-    end
-
-    def job_seeking_uncheck
-      if (@user.graduated_on || @user.retired_on) && @user.job_seeking
-        @user.update(job_seeking: false)
-      end
     end
 end

--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -26,6 +26,7 @@ class CurrentUserController < ApplicationController
         :email,
         :course_id,
         :description,
+        :job_seeking,
         :slack_account,
         :github_account,
         :twitter_account,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,7 +133,7 @@ class User < ActiveRecord::Base
   }
   scope :admins, -> { where(admin: true) }
   scope :trainee, -> { where(trainee: true) }
-  scope :job_seeker, -> { where(job_seeker: true) }
+  scope :job_seeking, -> { where(job_seeking: true) }
   scope :order_by_counts, -> (order_by, direction) {
     unless order_by.in?(VALID_SORT_COLUMNS) && direction.in?(VALID_SORT_COLUMNS)
       raise ArgumentError, "Invalid argument"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,6 +133,7 @@ class User < ActiveRecord::Base
   }
   scope :admins, -> { where(admin: true) }
   scope :trainee, -> { where(trainee: true) }
+  scope :job_seeker, -> { where(job_seeker: true) }
   scope :order_by_counts, -> (order_by, direction) {
     unless order_by.in?(VALID_SORT_COLUMNS) && direction.in?(VALID_SORT_COLUMNS)
       raise ArgumentError, "Invalid argument"

--- a/app/models/user_callbacks.rb
+++ b/app/models/user_callbacks.rb
@@ -5,5 +5,9 @@ class UserCallbacks
     if user.saved_change_to_retired_on?
       Product.where(user: user).unchecked.destroy_all
     end
+
+    if user.saved_change_to_graduated_on? || user.saved_change_to_retired_on?
+      user.update(job_seeking: false)
+    end
   end
 end

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -142,6 +142,15 @@
         p = help_text
 
     - if from == :edit
+      - unless user.adviser?
+        .auth-form-item
+          // 就職活動中
+          = f.label :job_seeking, class: "a-sm-label"
+          ul.auth-form-item__checkboxes
+            li.auth-form-checkbox
+              label.auth-form-checkbox__label
+                = f.check_box :job_seeking, class: "auth-form-checkbox__input"
+                = User.human_attribute_name :job_seeking
       .auth-form-item
         = f.label :slack_account, class: "a-sm-label"
         = f.text_field :slack_account, class: "a-sm-text-input", placeholder: "komagata"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -56,6 +56,7 @@ ja:
         graduated_on: 卒業日
         adviser: アドバイザー
         trainee: 研修生
+        job_seeking: 就職活動中
         retired_on: リタイア日
         free: 無料ユーザー
         avatar: アイコン画像

--- a/db/migrate/20190328141321_add_job_seekeing_to_users.rb
+++ b/db/migrate/20190328141321_add_job_seekeing_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddJobSeekeingToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :job_seeking, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20190328141321_add_job_seeker_to_users.rb
+++ b/db/migrate/20190328141321_add_job_seeker_to_users.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddJobSeekerToUsers < ActiveRecord::Migration[5.2]
-  def change
-    add_column :users, :job_seeker, :boolean, default: false, null: false
-  end
-end

--- a/db/migrate/20190328141321_add_job_seeker_to_users.rb
+++ b/db/migrate/20190328141321_add_job_seeker_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true.
+
+class AddJobSeekerToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :job_seeker, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20190328141321_add_job_seeker_to_users.rb
+++ b/db/migrate/20190328141321_add_job_seeker_to_users.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true.
+# frozen_string_literal: true
 
 class AddJobSeekerToUsers < ActiveRecord::Migration[5.2]
   def change

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -270,7 +270,7 @@ ActiveRecord::Schema.define(version: 2019_03_28_141321) do
     t.text "retire_reason"
     t.boolean "trainee", default: false, null: false
     t.boolean "free", default: false, null: false
-    t.boolean "job_seeker", default: false, null: false
+    t.boolean "job_seeking", default: false, null: false
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_19_152131) do
+ActiveRecord::Schema.define(version: 2019_03_28_141321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -270,6 +270,7 @@ ActiveRecord::Schema.define(version: 2019_02_19_152131) do
     t.text "retire_reason"
     t.boolean "trainee", default: false, null: false
     t.boolean "free", default: false, null: false
+    t.boolean "job_seeker", default: false, null: false
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"


### PR DESCRIPTION
操作を誤ってしまい、改めてPRをたてました。
[前PR](https://github.com/fjordllc/bootcamp/pull/862)

* [x] ユーザーに就活中の項目を追加する
* [x] アカウント設定画面・管理画面のアカウント設定画面で就活中をonにできるようにする
* [x] リタイア日・卒業日が入っている場合は、フラグが消えるようにする