### PR TITLE
Slackの正式名称が大文字のSなので修正

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -34,7 +34,7 @@
                   | 管理
               li.header-dropdown__item
                 = link_to "https://fjord.slack.com/admin", class: "header-dropdown__item-link", target: "_blank" do
-                  | slack管理
+                  | Slack管理
               li.header-dropdown__item
                 = link_to "https://github.com/fjordllc/fjord/wiki/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
                   | 管理者用ドキュメント


### PR DESCRIPTION
htmlの小文字の's'を大文字の'S'に修正