### PR TITLE
日報一覧リンクの遷移先をユーザーの日報一覧に変更

### DIFF
--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -92,7 +92,7 @@ header.page-header
               i.fas.fa-angle-left
               | 前の日報
         .thread-prev-next__item
-          = link_to reports_path, class: "thread-prev-next__item-link is-index" do
+          = link_to user_reports_path(@report.user_id), class: "thread-prev-next__item-link is-index" do
             | 日報一覧
         .thread-prev-next__item
           - if @report.next


### PR DESCRIPTION
遷移先を reports から /users/:user_id/reports に変更した。