### PR TITLE
プロフィール画面のslackアカウントを正式名称の大文字に修正

### DIFF
--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -33,7 +33,7 @@
         = user.completed_practices.size
     .user-metas__item
       .user-metas__item-label
-        | slackアカウント
+        | Slackアカウント
       .user-metas__item-value
         - if user.slack_account.present?
           = user.slack_account


### PR DESCRIPTION
正式名称が大文字のSなので修正しました。