### PR TITLE
suzuri（フィヨルドブートキャンプグッズストア）へのリンクを追加

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -42,6 +42,9 @@
                 = link_to welcome_path, class: "header-dropdown__item-link" do
                   | トップページ確認
             li.header-dropdown__item
+              = link_to "https://suzuri.jp/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
+                | Goodies
+            li.header-dropdown__item
               = link_to logout_path, class: "header-dropdown__item-link" do
                 | ログアウト
     li.header-links__item(class="#{current_user.notifications.unreads.count > 0 ? "has-count" : "has-no-count"}")


### PR DESCRIPTION
- [x] suzuri（フィヨルドブートキャンプグッズストア）へのリンクを追加した
![image](https://user-images.githubusercontent.com/48552047/56544916-cb3e0680-65b0-11e9-8d60-a05f19b0febc.png)
![image](https://user-images.githubusercontent.com/48552047/56544991-0c361b00-65b1-11e9-937a-6042f6f16bf6.png)

fixed: [#892](https://github.com/fjordllc/bootcamp/issues/892)