### PR TITLE
学習時間の終了時間を明日の日付にする

### DIFF
--- a/app/models/grass.rb
+++ b/app/models/grass.rb
@@ -13,9 +13,7 @@ WITH series AS (
   summary AS (
     SELECT
       reported_on AS date,
-      EXTRACT(epoch FROM
-        SUM((CASE WHEN finished_at < started_at THEN finished_at + '1 day' ELSE finished_at END) - started_at)
-      ) / 60 / 60 AS total_hour
+      EXTRACT(epoch FROM SUM(finished_at - started_at)) / 60 / 60 AS total_hour
     FROM
       learning_times JOIN reports ON learning_times.report_id = reports.id
     WHERE

--- a/app/models/learning_time.rb
+++ b/app/models/learning_time.rb
@@ -6,6 +6,8 @@ class LearningTime < ApplicationRecord
   validates :finished_at, presence: true
   validate :learning_times_finished_at_be_greater_than_started_at
 
+  before_validation :canonicalize_finished_at
+
   def diff
     default = finished_at - started_at
     default >= 0 ? default : finished_at + 1.day - started_at
@@ -14,6 +16,14 @@ class LearningTime < ApplicationRecord
   def learning_times_finished_at_be_greater_than_started_at
     if !report.wip? && diff <= 0
       errors.add(:finished_at, ": 終了時間は開始時間より後にしてください。")
+    end
+  end
+
+  private
+
+  def canonicalize_finished_at
+    if started_at > finished_at
+      self.finished_at = finished_at + 1.day
     end
   end
 end

--- a/app/models/learning_time.rb
+++ b/app/models/learning_time.rb
@@ -20,9 +20,9 @@ class LearningTime < ApplicationRecord
 
   private
 
-  def canonicalize_finished_at
-    if started_at > finished_at
-      self.finished_at = finished_at + 1.day
+    def canonicalize_finished_at
+      if started_at > finished_at
+        self.finished_at = finished_at + 1.day
+      end
     end
-  end
 end

--- a/app/models/learning_time.rb
+++ b/app/models/learning_time.rb
@@ -9,8 +9,7 @@ class LearningTime < ApplicationRecord
   before_validation :canonicalize_finished_at
 
   def diff
-    default = finished_at - started_at
-    default >= 0 ? default : finished_at + 1.day - started_at
+    finished_at - started_at
   end
 
   def learning_times_finished_at_be_greater_than_started_at

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,10 +185,10 @@ class User < ActiveRecord::Base
 SELECT
   SUM(EXTRACT(epoch from learning_times.finished_at - learning_times.started_at) / 60 / 60) AS total
 FROM
-   learning_times JOIN reports ON learning_times.report_id = reports.id
+  learning_times JOIN reports ON learning_times.report_id = reports.id
 WHERE
-   reports.user_id = :user_id
-		SQL
+  reports.user_id = :user_id
+SQL
 
     learning_time = LearningTime.find_by_sql([sql, { user_id: id }])
     learning_time.first.total || 0

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,15 +183,7 @@ class User < ActiveRecord::Base
   def total_learning_time
     sql = <<-SQL
 SELECT
-  SUM(
-    CASE
-      WHEN
-        EXTRACT(epoch from learning_times.finished_at - learning_times.started_at) < 0
-        THEN (EXTRACT(epoch FROM learning_times.finished_at - learning_times.started_at) + (60 * 60 * 24)) / 60 / 60
-      ELSE
-         EXTRACT(epoch from learning_times.finished_at - learning_times.started_at) / 60 / 60
-    END
-  ) AS total
+  SUM(EXTRACT(epoch from learning_times.finished_at - learning_times.started_at) / 60 / 60) AS total
 FROM
    learning_times JOIN reports ON learning_times.report_id = reports.id
 WHERE

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -12,7 +12,7 @@ namespace :bootcamp do
         puts "make free: #{user.login_name}"
       end
     end
-    
+
     desc "Migrate finished_at"
     task :migrate_finished_at do
       LearningTime.find_each do |learning_time|

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -12,6 +12,16 @@ namespace :bootcamp do
         puts "make free: #{user.login_name}"
       end
     end
+    
+    desc "Migrate finished_at"
+    task :migrate_finished_at do
+      LearningTime.find_each do |learning_time|
+        if learning_time.started_at > learning_time.finished_at
+          puts "Update learing_times ##{learning_time.id}"
+          learning_time.update!(finished_at: learning_time.finished_at + 1.day)
+        end
+      end
+    end
   end
 
   desc "Replace practices"

--- a/test/models/learning_time_test.rb
+++ b/test/models/learning_time_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LearningTimeTest < ActiveSupport::TestCase
+  test "学習時間が日付を跨いだ時、終了時間が次の日になる" do
+    learning_time = LearningTime.create!(report: reports(:report_8), started_at: "2018-03-11 23:00:00", finished_at: "2018-03-11 02:00:00")
+    assert learning_time.finished_at == Time.zone.parse("2018-03-12 02:00:00")
+  end
+
+  test "学習時間が日付を跨がなかった時、終了時間を変更しない" do
+    learning_time = LearningTime.create!(report: reports(:report_8), started_at: "2018-03-11 22:00:00", finished_at: "2018-03-11 23:00:00")
+    assert learning_time.finished_at == Time.zone.parse("2018-03-11 23:00:00")
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -46,8 +46,9 @@ class UserTest < ActiveSupport::TestCase
 
     report = Report.new(user_id: user.id, title: "test", reported_on: "2018-01-01", description: "test", wip: false)
     report.learning_times << LearningTime.new(started_at: "2018-01-01 00:00:00", finished_at: "2018-01-01 02:00:00")
+    report.learning_times << LearningTime.new(started_at: "2018-01-01 23:00:00", finished_at: "2018-01-02 01:00:00")
     report.save!
-    assert_equal 2, user.total_learning_time
+    assert_equal 4, user.total_learning_time
   end
 
   test "elapsed_days" do


### PR DESCRIPTION
[学習時間の終了時間を明日の日付にしたい（現状は今日の日付になっている） · Issue #895 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/895)

- [x] viewはそのままでcontrollerとかで時間をみてfinished_atを次の日の日付に変える。
- [x] 古いデータを修正するrakeタスクを書く。
- [x] 表示側でハックしてる部分を戻す。