### PR TITLE
.rubocop.yml のアップデート

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,7 +75,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.


### PR DESCRIPTION
Rubocop のアップデートで表記が変更になっていたので、更新しました。

```
#!/bin/bash -eo pipefail
rubocop -R -c .rubocop.yml

Error: The `Layout/FirstParameterIndentation` cop has been renamed to `Layout/IndentFirstArgument`.
(obsolete configuration found in .rubocop.yml, please update it)

Exited with code 2
```