### PR TITLE
ユーザー一覧ページに進捗バーを表示

### DIFF
--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -12,6 +12,7 @@
       .users-item__body
         .users-item__description
           p = truncate(user.description, length: 200)
+      = render "users/practices/completed_practices_progress", user: user
       - if current_user.admin?
         footer.card-footer
           .card-footer-actions

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -117,4 +117,10 @@ class UsersTest < ApplicationSystemTestCase
       assert_text "退会処理が完了しました"
     end
   end
+
+  test "show progress bar" do
+    login_user "hajime", "testtest"
+    visit "/users"
+    assert_selector ".completed-practices-progress"
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -117,10 +117,4 @@ class UsersTest < ApplicationSystemTestCase
       assert_text "退会処理が完了しました"
     end
   end
-
-  test "show progress bar" do
-    login_user "hajime", "testtest"
-    visit "/users"
-    assert_selector ".completed-practices-progress"
-  end
 end


### PR DESCRIPTION
- [x] app/views/users/_user.html.slim で、進捗バーを読み込む。

Issue: https://github.com/fjordllc/bootcamp/issues/760#issuecomment-486185735