### PR TITLE
確認済スタンプが表示されないバグの修正

### DIFF
--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class API::ChecksController < API::BaseController
-  before_action :require_staff_login
+  before_action :require_staff_login, only: %i(create destroy)
 
   def index
     @checks = Check.where(

--- a/test/system/api/check/products_test.rb
+++ b/test/system/api/check/products_test.rb
@@ -3,10 +3,17 @@
 require "application_system_test_case"
 
 class Check::ProductsTest < ApplicationSystemTestCase
+  test "user can see stamp" do
+    login_user "sotugyou", "testtest"
+    visit "/products/#{products(:product_3).id}"
+    assert_text "確認済"
+  end
+
   test "success product checking" do
     login_user "machida", "testtest"
     visit "/products/#{products(:product_1).id}"
     click_button "提出物を確認"
+    assert_text "確認済"
     assert has_button? "提出物の確認を取り消す"
   end
 
@@ -14,6 +21,7 @@ class Check::ProductsTest < ApplicationSystemTestCase
     login_user "advijirou", "testtest"
     visit "/products/#{products(:product_1).id}"
     click_button "提出物を確認"
+    assert_text "確認済"
     assert has_button? "提出物の確認を取り消す"
   end
 
@@ -22,6 +30,7 @@ class Check::ProductsTest < ApplicationSystemTestCase
     visit "/products/#{products(:product_1).id}"
     click_button "提出物を確認"
     click_button "提出物の確認を取り消す"
+    assert_no_text "確認済"
     assert has_button? "提出物を確認"
   end
 end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -9,6 +9,12 @@ class Check::ReportsTest < ApplicationSystemTestCase
     assert_not has_button? "日報を確認"
   end
 
+  test "user can see stamp" do
+    login_user "sotugyou", "testtest"
+    visit "/reports/#{reports(:report_1).id}"
+    assert_text "確認済"
+  end
+
   test "success report checking" do
     login_user "machida", "testtest"
     visit  "/reports/#{reports(:report_2).id}"
@@ -37,6 +43,7 @@ class Check::ReportsTest < ApplicationSystemTestCase
     visit "/reports/#{reports(:report_2).id}"
     click_button "日報を確認"
     click_button "日報の確認を取り消す"
+    assert_no_text "確認済"
     assert has_button? "日報を確認"
   end
 end


### PR DESCRIPTION
管理者以外が見た場合、 確認スタンプが表示されないバグを修正する