### PR TITLE
管理者への提出物のコメント通知はWatch機能での実装にしたい #977

### DIFF
--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -14,8 +14,6 @@ class CommentCallbacks
       create_watch(comment)
       notify_to_watching_user(comment)
     end
-
-    notify_admin(comment)
   end
 
   private
@@ -34,18 +32,6 @@ class CommentCallbacks
         comment.reciever,
         "#{comment.sender.login_name}さんからコメントが届きました。"
       )
-    end
-
-    def notify_admin(comment)
-      return false if comment.commentable.class != Product
-
-      User.admins.where.not(id: comment.user.id).each do |user|
-        Notification.came_comment(
-          comment,
-          user,
-          "#{comment.sender.login_name}さんが提出物にコメントしました。"
-        )
-      end
     end
 
     def notify_to_watching_user(comment)

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -3,6 +3,7 @@
 class ProductCallbacks
   def after_create(product)
     send_notification(product, "#{product.user.login_name}さんが提出しました。")
+    create_admin_watch(product)
   end
 
   def after_update(product)
@@ -17,6 +18,16 @@ class ProductCallbacks
     def send_notification(product, message)
       User.admins.each do |user|
         Notification.submitted(product, user, message)
+      end
+    end
+
+    def create_admin_watch(product)
+      User.admins.each do |admin|
+        @watch = Watch.new(
+          user: admin,
+          watchable: product
+        )
+        @watch.save!
       end
     end
 

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -18,6 +18,10 @@ class Notification::ProductsTest < ApplicationSystemTestCase
 
     first(".test-bell").click
     assert_text "yamadaさんが提出しました。"
+
+    # 提出物を作成したとき、管理者からウォッチがつく
+    click_link  "yamadaさんが提出しました。"
+    assert_text "Unwatch"
   end
 
   test "recieve a notification when product is updated" do
@@ -34,22 +38,5 @@ class Notification::ProductsTest < ApplicationSystemTestCase
 
     first(".test-bell").click
     assert_text "yamadaさんが提出物を更新しました。"
-  end
-
-  test "recieve a notification when posted a comment to product" do
-    login_user "yamada", "testtest"
-    visit "/products/#{products(:product_1).id}"
-
-    within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
-    end
-    click_button "コメントする"
-    assert_text "コメントを投稿しました。"
-
-    logout
-    login_user "komagata", "testtest"
-
-    first(".test-bell").click
-    assert_text "yamadaさんが提出物にコメントしました。"
   end
 end


### PR DESCRIPTION

# なぜやるか
- 提出物の作成者がコメントをつけた場合、
「○○さんが提出物にコメントしました」というコメント通知と、
「あなたがウォッチしている××にコメントが投稿されました」というウォッチ通知が両方とも飛ぶ。
- 管理者への提出物のコメント通知機能は、Watch機能での実装にしたい。
