### PR TITLE
subscription_idを持っていないユーザーが退会するとエラーになる

### DIFF
--- a/app/controllers/users/retirement_controller.rb
+++ b/app/controllers/users/retirement_controller.rb
@@ -13,8 +13,7 @@ class Users::RetirementController < ApplicationController
     @user.assign_attributes(retire_reason_params)
     @user.retired_on = Date.current
     if @user.save(context: :retire_reason_presence)
-      Subscription.destroy(@user.subscription_id)
-
+      Subscription.destroy(@user.subscription_id) if @user.subscription_id
       message = "<#{url_for(@user)}|#{@user.full_name} (#{@user.login_name})>が退会しました。"
       SlackNotification.notify message,
         username: "#{@user.login_name}@bootcamp.fjord.jp",


### PR DESCRIPTION
retirement_controller.rbにsubscription_idがない分岐を追加する