### PR TITLE
Avatar画像をGCSのURL直接表示に変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   before_action :init_user
   before_action :allow_cross_domain_access
+  before_action :set_host_for_disk_storage
 
   protected
     def allow_cross_domain_access
@@ -16,5 +17,11 @@ class ApplicationController < ActionController::Base
   private
     def init_user
       @current_user = User.find(current_user.id) if current_user
+    end
+
+    def set_host_for_disk_storage
+      if %i(local test).include? Rails.application.config.active_storage.service
+        ActiveStorage::Current.host = request.base_url
+      end
     end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -17,7 +17,7 @@ module UserDecorator
     roles.detect { |v| v[:value] }[:role]
   end
 
-  def avatar_image(length)
+  def avatar_image
     avatar.service_url
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -18,6 +18,6 @@ module UserDecorator
   end
 
   def avatar_image(length)
-    rails_blob_path(avatar)
+    avatar.service_url
   end
 end

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -33,4 +33,4 @@
                   | 削除
 
   = link_to announcement.user, itempro: "url", class: "thread__author-link" do
-    = image_tag announcement.user.avatar_image(120), class: "thread__author-icon is-#{announcement.user.role}"
+    = image_tag announcement.user.avatar_image, class: "thread__author-icon is-#{announcement.user.role}"

--- a/app/views/announcements/_announcements.slim
+++ b/app/views/announcements/_announcements.slim
@@ -1,7 +1,7 @@
 .thread-list-item
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag announcement.user.avatar_image(44), class: "thread-list-item__author-icon is-#{announcement.user.role}"
+      = image_tag announcement.user.avatar_image, class: "thread-list-item__author-icon is-#{announcement.user.role}"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to announcement, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -4,7 +4,7 @@
 .thread-comment(class="#{answer == answer.question.correct_answer ? "is-correct_answer" : ""}")
   .thread-comment__author
     = link_to answer.user, itempro: "url", class: "thread-comment__author-link" do
-      = image_tag answer.user.avatar_image(200), class: "thread-comment__author-icon is-#{answer.user.role}"
+      = image_tag answer.user.avatar_image, class: "thread-comment__author-icon is-#{answer.user.role}"
   .thread-comment__body.a-card
     - if answer == correct_answer
       .answer-badge

--- a/app/views/answers/_form.html.slim
+++ b/app/views/answers/_form.html.slim
@@ -1,6 +1,6 @@
 .thread-comment-form
   .thread-comment__author
-    = image_tag current_user.avatar_image(200), class: "thread-comment__author-icon is-#{current_user.role}"
+    = image_tag current_user.avatar_image, class: "thread-comment__author-icon is-#{current_user.role}"
   = form_with model: [question, answer], local: true, html: { class: "thread-comment-form__form a-card", name: "answer" } do |f|
     - if answer.errors.any?
       = error_messages_for :answer

--- a/app/views/application/_active_users.html.slim
+++ b/app/views/application/_active_users.html.slim
@@ -3,5 +3,5 @@ h4 学習中ユーザー
 - active_users.each do |user|
   p
     = link_to user do
-      = image_tag user.avatar_image(45), class: "is-#{user.role}"
+      = image_tag user.avatar_image, class: "is-#{user.role}"
       span(style="margin-left:5px") = user.login_name

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -6,7 +6,7 @@ nav.global-nav
       .global-nav-current-user
         = link_to user_path(current_user), class: "global-nav-current-user__link"
           .global-nav-current-user__icon
-            = image_tag current_user.avatar_image(320), class: "is-#{current_user.role}"
+            = image_tag current_user.avatar_image, class: "is-#{current_user.role}"
     .global-nav-links.is-contents-links
       ul.global-nav-links__items
         li.global-nav-links__item

--- a/app/views/application/_notification_sender.html.slim
+++ b/app/views/application/_notification_sender.html.slim
@@ -1,1 +1,1 @@
-= image_tag sender.avatar_image(48), class: "header-notifications-item__avatar-image"
+= image_tag sender.avatar_image, class: "header-notifications-item__avatar-image"

--- a/app/views/application/_student.html.slim
+++ b/app/views/application/_student.html.slim
@@ -1,3 +1,3 @@
 .practice-started-users__item
   = link_to user, class: "practice-started-users__item-link" do
-    = image_tag user.avatar_image(44), class: "practice-started-users__item-icon #{user.active? ? "active" : "inactive"} is-#{user.role}"
+    = image_tag user.avatar_image, class: "practice-started-users__item-icon #{user.active? ? "active" : "inactive"} is-#{user.role}"

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -2,14 +2,14 @@
 .thread-comment
   .thread-comment__author
     = link_to comment.user, itempro: "url", class: "thread-comment__author-link" do
-      = image_tag comment.user.avatar_image(200), class: "thread-comment__author-icon is-#{comment.user.role}"
+      = image_tag comment.user.avatar_image, class: "thread-comment__author-icon is-#{comment.user.role}"
   .thread-comment__body.a-card
     header.thread-comment__body-header
       - if user_comments_page?
         h2.thread-comment__title.is-user-comments
           = t("activerecord.models.#{commentable.class.to_s.tableize.singularize}")
           = link_to commentable, class: "thread-comment__title-link" do
-            = image_tag commentable.user.avatar_image(40), class: "thread-comment__title-icon is-#{commentable.user.role}"
+            = image_tag commentable.user.avatar_image, class: "thread-comment__title-icon is-#{commentable.user.role}"
             = truncate(commentable.title, length: 50)
       - else
         h2.thread-comment__title

--- a/app/views/comments/_form.html.slim
+++ b/app/views/comments/_form.html.slim
@@ -1,6 +1,6 @@
 .thread-comment-form
   .thread-comment__author
-    = image_tag current_user.avatar_image(200), class: "thread-comment__author-icon is-#{current_user.role}"
+    = image_tag current_user.avatar_image, class: "thread-comment__author-icon is-#{current_user.role}"
   = form_with model: comment, local: true, html: { class: "thread-comment-form__form a-card" } do |f|
     = f.hidden_field :commentable_type
     = f.hidden_field :commentable_id

--- a/app/views/footprints/_footprint.html.slim
+++ b/app/views/footprints/_footprint.html.slim
@@ -1,3 +1,3 @@
 li.footprints-item
   = link_to footprint.user, itempro: "url" do
-    = image_tag footprint.user.avatar_image(32), class: "footprints-item__checker-icon is-#{footprint.user.login_name} is-#{footprint.user.role}", alt: footprint.user.login_name
+    = image_tag footprint.user.avatar_image, class: "footprints-item__checker-icon is-#{footprint.user.login_name} is-#{footprint.user.role}", alt: footprint.user.login_name

--- a/app/views/home/_announcements.html.slim
+++ b/app/views/home/_announcements.html.slim
@@ -2,7 +2,7 @@
   .thread-list-item__inner
     .thread-list-item__author
       = link_to announcement.user do
-        = image_tag announcement.user.avatar_image(44), class: "thread-list-item__author-icon is-#{announcement.user.role}"
+        = image_tag announcement.user.avatar_image, class: "thread-list-item__author-icon is-#{announcement.user.role}"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to announcement, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/home/_job_seeking_users.html.slim
+++ b/app/views/home/_job_seeking_users.html.slim
@@ -9,7 +9,7 @@
           i.fas.fa-angle-down
         .thread-list-item__author
           = link_to user do
-            = image_tag user.avatar_image(44), class: "thread-list-item__author-icon is-#{user.role}"
+            = image_tag user.avatar_image, class: "thread-list-item__author-icon is-#{user.role}"
         header.thread-list-item__header
           h2.thread-list-item__title(itemprop="name")
             = link_to user, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item(class="#{notification.read? ? "is-read" : "is-unread"}")
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag notification.sender.avatar_image(48), class: "thread-list-item__author-icon"
+      = image_tag notification.sender.avatar_image, class: "thread-list-item__author-icon"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - unless notification.read?

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag product.user.avatar_image(44), class: "thread-list-item__author-icon"
+      = image_tag product.user.avatar_image, class: "thread-list-item__author-icon"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to product, itempro: "url", class: "thread-list-item__title-link" do
@@ -19,7 +19,7 @@
         .thread-list-item-meta__comment-count
           .thread-list-item-meta__comment-count-value
             - product.checks.each do |check|
-              = image_tag check.user.avatar_image(20), class: "thread-list-item__checked-author-icon is-#{check.user.role}"
+              = image_tag check.user.avatar_image, class: "thread-list-item__checked-author-icon is-#{check.user.role}"
         .stamp.stamp-approve
           h2.stamp__content.is-title 確認済
           time.stamp__content.is-created-at

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -57,7 +57,7 @@ header.page-header
             | プラクティスに戻る
 
       = link_to @product.user, itempro: "url", class: "thread__author-link" do
-        = image_tag @product.user.avatar_image(120), class: "thread__author-icon is-#{@product.user.role}"
+        = image_tag @product.user.avatar_image, class: "thread__author-icon is-#{@product.user.role}"
 
     = render "comments/comments", comments: @product.comments.order(:created_at), form_visibility: true
     = render "footprints/footprints", footprints: @footprints

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag question.user.avatar_image(44), class: "thread-list-item__author-icon is-#{question.user.role}"
+      = image_tag question.user.avatar_image, class: "thread-list-item__author-icon is-#{question.user.role}"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to question, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -53,7 +53,7 @@ header.page-header
                     | 削除
 
       = link_to @question.user, itempro: "url", class: "thread__author-link" do
-        = image_tag @question.user.avatar_image(120), class: "thread__author-icon is-#{@question.user.role}"
+        = image_tag @question.user.avatar_image, class: "thread__author-icon is-#{@question.user.role}"
     .thread-comments-container
       h3.thread-comments-container__title
         | 回答・コメント

--- a/app/views/reports/_recent_report.html.slim
+++ b/app/views/reports/_recent_report.html.slim
@@ -1,6 +1,6 @@
 .recent-reports-item(class="#{report.wip? ? "is-wip" : ""}")
   = link_to report, class: "recent-reports-item__link" do
-    = image_tag report.user.avatar_image(88), class: "recent-reports-item__user-icon is-#{report.user.role}"
+    = image_tag report.user.avatar_image, class: "recent-reports-item__user-icon is-#{report.user.role}"
     h3.recent-reports-item__title
       - if report.wip?
         span.recent-reports-item__title-icon

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item(class="#{report.wip? ? "is-wip" : ""}")
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag report.user.avatar_image(44), class: "thread-list-item__author-icon is-#{report.user.role}"
+      = image_tag report.user.avatar_image, class: "thread-list-item__author-icon is-#{report.user.role}"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if report.wip?
@@ -28,7 +28,7 @@
       - if report.checks.any?
         .thread-list-item-meta__checkers
           - report.checks.each do |check|
-            = image_tag check.user.avatar_image(20), class: "thread-list-item__checked-author-icon is-#{check.user.role}"
+            = image_tag check.user.avatar_image, class: "thread-list-item__checked-author-icon is-#{check.user.role}"
         .stamp.stamp-approve
           h2.stamp__content.is-title 確認済
           time.stamp__content.is-created-at

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -85,7 +85,7 @@ header.page-header
               | 次の日報
               i.fas.fa-angle-right
       = link_to @report.user, itempro: "url", class: "thread__author-link" do
-        = image_tag @report.user.avatar_image(120), class: "thread__author-icon is-#{@report.user.role}"
+        = image_tag @report.user.avatar_image, class: "thread__author-icon is-#{@report.user.role}"
 
     = render "comments/comments", comments: @report.comments.order(:created_at), form_visibility: true
     = render "footprints/footprints", footprints: @footprints

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -46,7 +46,7 @@
       .form-item-file-input.js-file-input.a-file-input.is-avatar
         label.js-file-input__preview
           - if f.object.avatar.attached?
-            = image_tag f.object.avatar_image(100)
+            = image_tag f.object.avatar_image
             p 画像を変更
           - else
             p 画像を選択

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -1,6 +1,6 @@
 .user-profile
   .user-profile__icon
-    = image_tag user.avatar_image(88), class: "is-#{user.role}"
+    = image_tag user.avatar_image, class: "is-#{user.role}"
   .user-profile__names
     h1.user-profile__login-name
       = user.login_name

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -14,7 +14,7 @@
                   = user.slack_account
           .users-item__icon
             = link_to user do
-              = image_tag user.avatar_image(80), class: "users-item__icon-image is-#{user.role}"
+              = image_tag user.avatar_image, class: "users-item__icon-image is-#{user.role}"
         = render "users/sns", user: user
       .users-item__body
         .users-item__description.a-short-text

--- a/app/views/users/comments/_comment.html.slim
+++ b/app/views/users/comments/_comment.html.slim
@@ -7,7 +7,7 @@
       - if user_comments_page?
         h2.thread-list-item__title
           = link_to commentable, class: "thread-list-item__title-link" do
-            = image_tag commentable.user.avatar_image(40), class: "thread-comment__title-icon"
+            = image_tag commentable.user.avatar_image, class: "thread-comment__title-icon"
             = truncate(commentable.title, length: 50)
       - else
         h2.thread-list-item__title

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -17,7 +17,7 @@ header.page-header
       .thread__inner.a-card
         header.thread-header
           = link_to user_portfolio_path(@work.user), itempro: "url", class: "thread-header__author-link" do
-            = image_tag @work.user.avatar_image(120), class: "thread-header__author-icon is-#{@work.user.role}"
+            = image_tag @work.user.avatar_image, class: "thread-header__author-icon is-#{@work.user.role}"
           h2.thread-header__title
             = @work.title
           .thread-header__lower-side


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/pull/816 のフォローアップです。
また、 `avatar_image` で使用されていなかった引数を削除しました。

Before

```
<img src="/rails/active_storage/blobs/xxx">
```

After

```
<img src="https://storage.googleapis.com/xxx">
```
