### PR TITLE
WIPでも企業Slackに日報が飛んでしまう

### DIFF
--- a/db/migrate/20190706023755_add_published_at_to_reports.rb
+++ b/db/migrate/20190706023755_add_published_at_to_reports.rb
@@ -1,5 +1,5 @@
 class AddPublishedAtToReports < ActiveRecord::Migration[5.2]
   def change
-    add_column :reports, :publised_at, :datetime
+    add_column :reports, :published_at, :datetime
   end
 end

--- a/db/migrate/20190706023755_add_published_at_to_reports.rb
+++ b/db/migrate/20190706023755_add_published_at_to_reports.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reports, :publised_at, :datetime
+  end
+end

--- a/db/migrate/20190706023755_add_published_at_to_reports.rb
+++ b/db/migrate/20190706023755_add_published_at_to_reports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPublishedAtToReports < ActiveRecord::Migration[5.2]
   def change
     add_column :reports, :published_at, :datetime

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_25_092312) do
+ActiveRecord::Schema.define(version: 2019_07_06_023755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -240,6 +240,7 @@ ActiveRecord::Schema.define(version: 2019_06_25_092312) do
     t.date "reported_on"
     t.boolean "wip", default: false, null: false
     t.integer "emotion"
+    t.datetime "published_at"
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -373,4 +373,13 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text Time.current.strftime("%Y年%m月%d日")
     assert_no_match "kensyu さんが日報を提出しました", mock_log.to_s
   end
+
+  test "unwatch" do
+    login_user "kimura", "testtest"
+    visit report_path(reports(:report_1))
+    assert_difference("Watch.count", -1) do
+      find("div.thread-meta__watch-button", text: "Watch中").click
+      sleep 0.5
+    end
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -300,13 +300,8 @@ class ReportsTest < ApplicationSystemTestCase
     all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("08")
     all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("30")
 
-<<<<<<< d9bac289f419e7f79dfa2d4b9224d4c839b2971f
     mock_log = []
     stub_info = Proc.new { |i| mock_log << i }
-=======
-    @mock_log = []
-    stub_info = Proc.new { |i| @mock_log << i }
->>>>>>> fixed rubocop
 
     Rails.logger.stub(:info, stub_info) do
       click_button "提出"

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -374,7 +374,7 @@ class ReportsTest < ApplicationSystemTestCase
     assert_no_match "kensyu さんが日報を提出しました", mock_log.to_s
   end
 
-  test "unwatch" do
+  test "click unwatch" do
     login_user "kimura", "testtest"
     visit report_path(reports(:report_1))
     assert_difference("Watch.count", -1) do

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "application_system_test_case"
-require 'minitest/mock'
+require "minitest/mock"
 
 class ReportsTest < ApplicationSystemTestCase
   def setup
@@ -300,8 +300,13 @@ class ReportsTest < ApplicationSystemTestCase
     all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("08")
     all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("30")
 
+<<<<<<< d9bac289f419e7f79dfa2d4b9224d4c839b2971f
     mock_log = []
     stub_info = Proc.new { |i| mock_log << i }
+=======
+    @mock_log = []
+    stub_info = Proc.new { |i| @mock_log << i }
+>>>>>>> fixed rubocop
 
     Rails.logger.stub(:info, stub_info) do
       click_button "提出"

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "application_system_test_case"
+require 'minitest/mock'
 
 class ReportsTest < ApplicationSystemTestCase
   def setup
@@ -283,5 +284,93 @@ class ReportsTest < ApplicationSystemTestCase
       find("div.thread-meta__watch-button", text: "Watch中").click
       sleep 0.5
     end
+  end
+
+  test "その日報を初めて提出した時にslackに通知がいく" do
+    login_user "kensyu", "testtest"
+    visit "/reports/new"
+    within("#new_report") do
+      fill_in("report[title]", with: "test title")
+      fill_in("report[description]",   with: "test")
+      fill_in("report[reported_on]", with: Time.current)
+    end
+
+    all(".learning-time")[0].all(".learning-time__started-at select")[0].select("07")
+    all(".learning-time")[0].all(".learning-time__started-at select")[1].select("30")
+    all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("08")
+    all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("30")
+
+    mock_log = []
+    stub_info = Proc.new { |i| mock_log << i }
+
+    Rails.logger.stub(:info, stub_info) do
+      click_button "提出"
+    end
+
+    assert_text "日報を保存しました。"
+    assert_text Time.current.strftime("%Y年%m月%d日")
+    assert_match "kensyu さんが日報を提出しました", mock_log.to_s
+  end
+
+  test "WIPで保存した日報を初めて提出した時にだけslackに通知がいく" do
+    login_user "kensyu", "testtest"
+    visit "/reports/new"
+    within("#new_report") do
+      fill_in("report[title]", with: "test title")
+      fill_in("report[description]",   with: "test")
+      fill_in("report[reported_on]", with: Time.current)
+    end
+
+    all(".learning-time")[0].all(".learning-time__started-at select")[0].select("07")
+    all(".learning-time")[0].all(".learning-time__started-at select")[1].select("30")
+    all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("08")
+    all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("30")
+
+    mock_log = []
+    stub_info = Proc.new { |i| mock_log << i }
+
+    Rails.logger.stub(:info, stub_info) do
+      click_button "WIP"
+      assert_text "日報をWIPとして保存しました。"
+      assert_no_match "kensyu さんが日報を提出しました", mock_log.to_s
+      click_button "提出"
+    end
+
+    assert_text "日報を保存しました。"
+    assert_text Time.current.strftime("%Y年%m月%d日")
+    assert_match "kensyu さんが日報を提出しました", mock_log.to_s
+  end
+
+  test "最初の日報を提出した時にだけslackに通知がいく" do
+    login_user "kensyu", "testtest"
+    visit "/reports/new"
+    within("#new_report") do
+      fill_in("report[title]", with: "test title")
+      fill_in("report[description]",   with: "test")
+      fill_in("report[reported_on]", with: Time.current)
+    end
+
+    all(".learning-time")[0].all(".learning-time__started-at select")[0].select("07")
+    all(".learning-time")[0].all(".learning-time__started-at select")[1].select("30")
+    all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("08")
+    all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("30")
+
+    mock_log = []
+    stub_info = Proc.new { |i| mock_log << i }
+
+    Rails.logger.stub(:info, stub_info) do
+      click_button "提出"
+      assert_match "kensyu さんが日報を提出しました", mock_log.to_s
+      mock_log = []
+      click_link "内容修正"
+      click_button "WIP"
+      assert_text "日報をWIPとして保存しました。"
+      assert_no_match "kensyu さんが日報を提出しました", mock_log.to_s
+      click_button "提出"
+    end
+
+    assert_text "日報を保存しました。"
+    assert_text Time.current.strftime("%Y年%m月%d日")
+    assert_no_match "kensyu さんが日報を提出しました", mock_log.to_s
   end
 end


### PR DESCRIPTION
* テストをかく
* published_atカラムを追加する
* 日報を初めて提出する時に、published_atカラムに値が入るようにする
* publised_atカラムに値が入るとslackに通知がいく
