### PR TITLE
日報の最初の学習時間は削除できないように作成

### DIFF
--- a/app/assets/javascripts/learningTime.js
+++ b/app/assets/javascripts/learningTime.js
@@ -1,0 +1,3 @@
+$(function() {
+  $('.form-item__times-action > a.remove_fields.dynamic').first().hide();
+});


### PR DESCRIPTION
Issue: https://github.com/fjordllc/bootcamp/issues/1047

最初の学習時間は削除できないように作成しました。
bootcamp の日報の学習時間の入力フォームには、デフォルトで削除ボタンが表示されており、この削除ボタンを誤って押してしまうと、学習時間の入力フォームが消えてしまいます。消えた学習時間の入力フォームは、「学習時間を追加」ボタンを押すことで、入力フォームを表示させることができます。しかし、最初の学習時間の入力フォームは、消えないほうがユーザーが戸惑わなくて済むと考えたため、PRを作成しました。（追加した学習時間は削除可能）
レビューをよろしくお願いします。

![Screenshot from 2019-07-22 14-20-43](https://user-images.githubusercontent.com/39484102/61608217-e6421480-ac8c-11e9-8a53-eb31ead2c8da.png)

