### PR TITLE
User詳細ページに退会理由の項目を追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -251,6 +251,10 @@ SQL
     adviser? || mentor?
   end
 
+  def retired?
+    retired_on?
+  end
+
   private
     def password_required?
       new_record? || password.present?

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -63,9 +63,15 @@
           = User.human_attribute_name :graduated_on
         .user-metas__item-value
           = l user.graduated_on
-    - if user.retired_on.present?
+    - if user.retired?
       .user-metas__item
         .user-metas__item-label
           = User.human_attribute_name :retired_on
         .user-metas__item-value
           = l user.retired_on
+    - if user.retired? && current_user.admin?
+      .user-metas__item
+        .user-metas__item-label
+          = User.human_attribute_name :retire_reason
+        .user-metas__item-value
+          = user.retire_reason

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -8,6 +8,11 @@ class UserTest < ActiveSupport::TestCase
     assert users(:machida).admin?
   end
 
+  test "retired?" do
+    assert users(:yameo).retired?
+    assert_not users(:komagata).retired?
+  end
+
   test "full_name" do
     assert_equal "Komagata Masaki", users(:komagata).full_name
   end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -48,6 +48,20 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_text "リタイア日"
   end
 
+  test "retire reason is displayed when login user is admin" do
+    login_user "komagata", "testtest"
+    visit "/users/#{users(:yameo).id}"
+    assert_text "退会理由"
+    visit "/users/#{users(:sotugyou).id}"
+    assert_no_text "退会理由"
+  end
+
+  test "retire reason isn't displayed when login user isn't admin" do
+    login_user "kimura", "testtest"
+    visit "/users/#{users(:yameo).id}"
+    assert_no_text "退会理由"
+  end
+
   test "normal user can't see unchecked number table" do
     login_user "hatsuno", "testtest"
     visit "/users/#{users(:hatsuno).id}"


### PR DESCRIPTION
## 変更の目的
Ref: #1060

## 変更の概要
- ユーザー個別ページ(`/users/:user_id`)に退会理由の項目を追加する（管理者のみに表示）
- 管理者だけしか見れない、というSystemテストを書く