### PR TITLE
退会時にadminに通知する

### DIFF
--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -12,6 +12,11 @@ class RetirementController < ApplicationController
     current_user.retired_on = Date.current
     if current_user.save
       Subscription.destroy(current_user.subscription_id) if current_user.subscription_id
+
+      User.admins.each do |admin_user|
+        Notification.retired(current_user, admin_user)
+      end
+
       message = "<#{url_for(current_user)}|#{current_user.full_name} (#{current_user.login_name})>が退会しました。"
       SlackNotification.notify message,
         username: "#{current_user.login_name}@bootcamp.fjord.jp",

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -11,17 +11,9 @@ class RetirementController < ApplicationController
     current_user.assign_attributes(retire_reason_params)
     current_user.retired_on = Date.current
     if current_user.save
-      Subscription.destroy(current_user.subscription_id) if current_user.subscription_id
-
-      User.admins.each do |admin_user|
-        Notification.retired(current_user, admin_user)
-      end
-
-      message = "<#{url_for(current_user)}|#{current_user.full_name} (#{current_user.login_name})>が退会しました。"
-      SlackNotification.notify message,
-        username: "#{current_user.login_name}@bootcamp.fjord.jp",
-        icon_url: url_for(current_user.avatar)
-
+      destroy_subscription
+      notify_to_admins
+      notify_to_slack
       logout
       redirect_to retirement_url
     else
@@ -32,5 +24,22 @@ class RetirementController < ApplicationController
   private
     def retire_reason_params
       params.require(:user).permit(:retire_reason)
+    end
+
+    def destroy_subscription
+      Subscription.destroy(current_user.subscription_id) if current_user.subscription_id
+    end
+
+    def notify_to_admins
+      User.admins.each do |admin_user|
+        Notification.retired(current_user, admin_user)
+      end
+    end
+
+    def notify_to_slack
+      message = "<#{url_for(current_user)}|#{current_user.full_name} (#{current_user.login_name})>が退会しました。"
+      SlackNotification.notify message,
+        username: "#{current_user.login_name}@bootcamp.fjord.jp",
+        icon_url: url_for(current_user.avatar)
     end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -15,7 +15,8 @@ class Notification < ApplicationRecord
     announced:     5,
     came_question: 6,
     first_report:  7,
-    watching:      8
+    watching:      8,
+    retired:       9
   }
 
   scope :unreads, -> {
@@ -121,4 +122,15 @@ class Notification < ApplicationRecord
       read:    false
     )
   end
+
+   def self.retired(sender, reciever)
+     Notification.create!(
+       kind:    9,
+       user:    reciever,
+       sender:  sender,
+       path:    Rails.application.routes.url_helpers.polymorphic_path(sender),
+       message: "#{sender.login_name}さんが退会しました。",
+       read:    false
+     )
+   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -123,14 +123,14 @@ class Notification < ApplicationRecord
     )
   end
 
-   def self.retired(sender, reciever)
-     Notification.create!(
-       kind:    9,
-       user:    reciever,
-       sender:  sender,
-       path:    Rails.application.routes.url_helpers.polymorphic_path(sender),
-       message: "#{sender.login_name}さんが退会しました。",
-       read:    false
-     )
-   end
+  def self.retired(sender, reciever)
+    Notification.create!(
+      kind:    9,
+      user:    reciever,
+      sender:  sender,
+      path:    Rails.application.routes.url_helpers.polymorphic_path(sender),
+      message: "#{sender.login_name}さんが退会しました。",
+      read:    false
+    )
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -26,6 +26,9 @@ class UsersTest < ApplicationSystemTestCase
     page.driver.browser.switch_to.alert.accept
     assert_text "退会処理が完了しました"
     assert_equal Date.current, user.reload.retired_on
+    assert_equal "hatsunoさんが退会しました。", users(:komagata).notifications.last.message
+    assert_equal "hatsunoさんが退会しました。", users(:machida).notifications.last.message
+
     login_user "hatsuno", "testtest"
     assert_text "ログインができません"
   end


### PR DESCRIPTION
## 変更の目的
Ref: #1040

## 変更の概要
### 退会時にadminに通知する処理を追加
- 通知のpathはUser詳細ページ(退会理由が見たいので)

### RetirementControllerのリファクタリング
- 退会処理がべた書きだったのでprivateメソッドに移した
