### PR TITLE
N+1潰し(1/6) | パーシャル周り

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :development do
   gem "rubocop", require: false
   gem "rubocop-performance"
   gem "slim_lint"
+  gem "bullet"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
+    bullet (6.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     capybara (3.26.0)
       addressable
@@ -367,6 +370,7 @@ GEM
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.0)
+    uniform_notifier (1.12.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -403,6 +407,7 @@ DEPENDENCIES
   acts_as_list
   autoprefixer-rails
   bootsnap (>= 1.1.0)
+  bullet
   byebug
   capybara (>= 2.15, < 4.0)
   cocoon

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -65,7 +65,7 @@ class AnnouncementsController < ApplicationController
     end
 
     def set_footprints
-      @footprints = @announcement.footprints.order(created_at: :desc)
+      @footprints = @announcement.footprints.with_avatar.order(created_at: :desc)
     end
 
     def announcement_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -87,7 +87,7 @@ class ProductsController < ApplicationController
     end
 
     def find_footprints
-      find_product.footprints.order(created_at: :desc)
+      find_product.footprints.with_avatar.order(created_at: :desc)
     end
 
     def footprint!

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -123,7 +123,7 @@ class ReportsController < ApplicationController
     end
 
     def set_footprints
-      @footprints = @report.footprints.order(created_at: :desc)
+      @footprints = @report.footprints.with_avatar.order(created_at: :desc)
     end
 
     def set_categories

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -2,7 +2,10 @@
 
 module ReportsHelper
   def recent_reports
-    @recent_reports ||= Report.eager_load(:user, :checks).order(updated_at: :desc, id: :desc).limit(15)
+    @recent_reports ||= Report.with_avatar
+                              .preload(:checks)
+                              .order(updated_at: :desc, id: :desc)
+                              .limit(15)
   end
 
   def practice_options(categories)

--- a/app/models/footprint.rb
+++ b/app/models/footprint.rb
@@ -4,4 +4,6 @@ class Footprint < ApplicationRecord
   belongs_to :user
   belongs_to :footprintable, polymorphic: true
   validates :user_id, presence: true
+
+  scope :with_avatar, -> { preload(user: { avatar_attachment: :blob }) }
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -28,6 +28,7 @@ class Report < ActiveRecord::Base
 
   scope :wip, -> { where(wip: true) }
   scope :not_wip, -> { where(wip: false) }
+  scope :with_avatar, -> { preload(user: { avatar_attachment: :blob }) }
 
   after_create ReportCallbacks.new
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,4 +66,9 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   config.action_mailer.asset_host = "http://localhost:3000"
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.add_footer = true
+  end
 end


### PR DESCRIPTION
Ref: #1078 

## 変更の概要
### Bulletの導入
development環境では、N+1があると画面左下に警告が出るようになります。

<img width="1914" alt="ss 39" src="https://user-images.githubusercontent.com/3048057/62293855-79a4f200-b4a4-11e9-8a90-f630a05218f9.png">

### N+1潰し
修正は下記の4箇所です。

| ページ                 | path               |
|------------------------|--------------------|
| 右サイドバーの日報一覧 | /(他にも色んなページで使われます)   |
| 日報詳細               | /reports/:id       |
| 提出物詳細             | /products/:id      |
| お知らせ詳細           | /announcements/:id |


`report -> user -> avatar_attachment -> blob`のような関連に対して、`preload`で事前にレコードを取得するようにしました。

Railsでeager_loadingする方法はいくつかあると思いますが、`preload`を優先して使い、絞り込み等が必要で`preload`が使えない場合に`eager_load`を使います。`includes`は使いません。


## 計測
簡単にですが、どれくらい速くなったか計測します。
ChromeのDevToolsでキャッシュをオフにして、HTMLが返ってくる時間を測ります。
Production環境のデプロイ前後で比較します。

| ページ                 | URL                                         | 改善前の時間 | 改善後の時間 |
|------------------------|---------------------------------------------|--------------|--------------|
| ダッシュボード<br>(右サイドバーの日報一覧 )| https://bootcamp.fjord.jp/                  |              |              |
| 日報詳細<br>(下部の足跡一覧)               | https://bootcamp.fjord.jp/reports/5895      |              |              |
| 提出物詳細<br>(下部の足跡一覧)             | https://bootcamp.fjord.jp/products/1469     |              |              |
| お知らせ詳細<br>(下部の足跡一覧)           | https://bootcamp.fjord.jp/announcements/126 |              |              |

