### PR TITLE
systemテストでheadless chromeを使うように修正した

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -12,9 +12,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   caps = Selenium::WebDriver::Remote::Capabilities.chrome(chrome_opts)
 
   if ENV["HEADED"]
-    driven_by :selenium, using: :chrome
+    driven_by :selenium, using: :headless_chrome
   else
-    driven_by :selenium, using: :chrome, options: { desired_capabilities: caps }
+    driven_by :selenium, using: :headless_chrome, options: { desired_capabilities: caps }
   end
 
   setup do


### PR DESCRIPTION
## 概要
systemテストで headless chrome を使うように修正しました。修正した理由は、systemテストを実行した際に、実際のchromeブラウザが立ち上がってしまっていたためです。なお、CIのテストで3つのエラーが発生したので、これに対処していこうと思います。
![Peek 2019-08-05 01-32](https://user-images.githubusercontent.com/39484102/62426601-d3feb680-b721-11e9-9cd6-0851d255673f.gif)


## 参考
* [[Rails]雑にSystem TestでHeadless Chromeを使う](https://y-yagi.tumblr.com/post/166831012790/rails%E9%9B%91%E3%81%ABsystem-test%E3%81%A7headless-chrome%E3%82%92%E4%BD%BF%E3%81%86)