### PR TITLE
N+1潰し(2/6) | Courseのサブリソース周り

### DIFF
--- a/app/controllers/courses/practices_controller.rb
+++ b/app/controllers/courses/practices_controller.rb
@@ -8,6 +8,7 @@ class Courses::PracticesController < ApplicationController
     @categories = @course.categories
                          .preload(practices: { started_students: { avatar_attachment: :blob } })
                          .order(:position)
+    @learnings = current_user.learnings
 
     # TODO: リタイアした人のセッションが切れたら外す
     if current_user.retired_on?

--- a/app/controllers/courses/practices_controller.rb
+++ b/app/controllers/courses/practices_controller.rb
@@ -5,6 +5,9 @@ class Courses::PracticesController < ApplicationController
 
   def index
     @course = Course.find(params[:course_id])
+    @categories = @course.categories
+                         .preload(practices: { started_students: { avatar_attachment: :blob } })
+                         .order(:position)
 
     # TODO: リタイアした人のセッションが切れたら外す
     if current_user.retired_on?

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -45,7 +45,7 @@ class Practice < ActiveRecord::Base
   end
 
   def status_by_learnings(learnings)
-    learning = learnings.find { |lerning| id == lerning.practice_id }
+    learning = learnings.detect { |lerning| id == lerning.practice_id }
     learning&.status || "not_complete"
   end
 

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -44,6 +44,11 @@ class Practice < ActiveRecord::Base
     end
   end
 
+  def status_by_learnings(learnings)
+    learning = learnings.find { |lerning| id == lerning.practice_id }
+    learning&.status || "not_complete"
+  end
+
   def completed?(user)
     Learning.exists?(
       user:        user,

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -17,6 +17,10 @@ class Practice < ActiveRecord::Base
   has_many :completed_users,
     through: :completed_learnings,
     source: :user
+  has_many :started_students,
+    -> { students },
+    through: :started_learnings,
+    source: :user
   has_many :products
   has_many :questions
   belongs_to :category

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -20,7 +20,7 @@ header.page-header
   .container
     .categories-items
       .categories-items__inner
-        - @course.categories.order(:position).each do |category|
+        - @categories.each do |category|
           - if category.practices.present?
             .categories-item.practices.js-show-handle(id="category-#{category.id}")
               header.categories-item__header
@@ -37,7 +37,7 @@ header.page-header
 
       nav.page-nav
         ul.page-nav__items
-          - @course.categories.order(:position).each do |category|
+          - @categories.each do |category|
             - if category.practices.present?
               li.page-nav__item
                 a.page-nav__item-link(data-scroll href="#category-#{category.id}")

--- a/app/views/practices/_practice.html.slim
+++ b/app/views/practices/_practice.html.slim
@@ -8,10 +8,10 @@
         - status = practice.status(current_user)
         .js-learning-status(data-practice-id="#{practice.id}" data-status="#{status}")
 
-  - if practice.started_users.students.exists?
+  - if practice.started_students.any?
     .practice-started-users
       .practice-started-users__items
-        = render partial: "student", collection: practice.started_users.students, as: :user
+        = render partial: "student", collection: practice.started_students, as: :user
   - if current_user.admin?
     .category-practices-item__handle.js-show-handle__target
       ul.is-button-group

--- a/app/views/practices/_practice.html.slim
+++ b/app/views/practices/_practice.html.slim
@@ -5,7 +5,7 @@
         = practice.title
     - if current_user
       .practice-status
-        - status = practice.status(current_user)
+        - status = practice.status_by_learnings(@learnings)
         .js-learning-status(data-practice-id="#{practice.id}" data-status="#{status}")
 
   - if practice.started_students.any?

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -15,6 +15,15 @@ class PracticeTest < ActiveSupport::TestCase
       "not_complete"
   end
 
+  test "status_by_learnings(learnings)" do
+    learnings = users(:komagata).learnings
+
+    assert_equal practices(:practice_1).status_by_learnings(learnings), "started"
+    assert_equal practices(:practice_2).status_by_learnings(learnings), "complete"
+    assert_equal practices(:practice_3).status_by_learnings(learnings), "not_complete"
+    assert_equal practices(:practice_4).status_by_learnings(learnings), "not_complete"
+  end
+
   test "exists_learning?(user)" do
     assert practices(:practice_1).exists_learning?(users(:komagata))
     assert_not practices(:practice_1).exists_learning?(users(:machida))


### PR DESCRIPTION
Ref: https://github.com/fjordllc/bootcamp/issues/1079

## 修正箇所
| 画面 | URL |
|------|---|
|指定コースの、プラクティス一覧|http://localhost:3000/courses/86912251/practices|

## 修正内容
1. `categories -> practices -> learnings -> user -> avatar_attachment -> blob`に対して`preload`するように修正
1.  ステータス表示でpractice毎にlearningの取得を行っていた箇所を、事前に一括で取得するように修正