### PR TITLE
N+1潰し(3/6) | root周り

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -7,7 +7,10 @@ class AnnouncementsController < ApplicationController
   before_action :set_footprints, only: %i(show)
 
   def index
-    @announcements = Announcement.order(created_at: :desc).page(params[:page])
+    @announcements = Announcement.with_avatar
+                                 .preload(:comments)
+                                 .order(created_at: :desc)
+                                 .page(params[:page])
   end
 
   def show

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,7 +7,9 @@ class HomeController < ApplicationController
         logout
         redirect_to retire_path
       else
-        @announcements = Announcement.limit(5).order(created_at: :desc)
+        @announcements = Announcement.with_avatar
+                                     .limit(5)
+                                     .order(created_at: :desc)
         render aciton: :index
       end
     else

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,7 +5,10 @@ class NotificationsController < ApplicationController
   before_action :set_my_notification, only: %i(show)
 
   def index
-    @notifications = current_user.notifications.order(created_at: :desc).page(params[:page])
+    @notifications = current_user.notifications
+                                 .with_avatar
+                                 .order(created_at: :desc)
+                                 .page(params[:page])
   end
 
   def show

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -15,6 +15,7 @@ class QuestionsController < ApplicationController
         Question.not_solved
       end.order(updated_at: :desc, id: :desc)
     @questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
+    @questions = @questions.preload(%i[practice answers]).with_avatar
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,10 +5,11 @@ class UsersController < ApplicationController
   before_action :set_user, only: %w(show)
 
   def index
-    @categories = Category.order("position")
-    @users = User.order(updated_at: :desc)
     @target = params[:target] || "student"
-    @users = @users.users_role(@target)
+    @users = User.with_attached_avatar
+                 .preload(:course)
+                 .order(updated_at: :desc)
+                 .users_role(@target)
   end
 
   def show

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -13,6 +13,6 @@ class WelcomeController < ApplicationController
   end
 
   def practices
-    @categories = Course.first.categories
+    @categories = Course.first.categories.preload(:practices).order(:position)
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -13,4 +13,6 @@ class Announcement < ApplicationRecord
 
   validates :title, presence: true
   validates :description, presence: true
+
+  scope :with_avatar, -> { preload(user: { avatar_attachment: :blob }) }
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -5,6 +5,7 @@ class Announcement < ApplicationRecord
   include Footprintable
   include Searchable
   include Reactionable
+  include WithAvatar
 
   belongs_to :user
   alias_method :sender, :user
@@ -13,6 +14,4 @@ class Announcement < ApplicationRecord
 
   validates :title, presence: true
   validates :description, presence: true
-
-  scope :with_avatar, -> { preload(user: { avatar_attachment: :blob }) }
 end

--- a/app/models/concerns/with_avatar.rb
+++ b/app/models/concerns/with_avatar.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WithAvatar
+  extend ActiveSupport::Concern
+
+  included do
+    scope :with_avatar, -> { preload(user: { avatar_attachment: :blob }) }
+  end
+end

--- a/app/models/footprint.rb
+++ b/app/models/footprint.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Footprint < ApplicationRecord
+  include WithAvatar
+
   belongs_to :user
   belongs_to :footprintable, polymorphic: true
   validates :user_id, presence: true
-
-  scope :with_avatar, -> { preload(user: { avatar_attachment: :blob }) }
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -23,6 +23,7 @@ class Notification < ApplicationRecord
     into_one = select(:path).group(:path).maximum(:created_at)
     where(read: false, created_at: into_one.values).order(created_at: :desc)
   }
+  scope :with_avatar, -> { preload(sender: { avatar_attachment: :blob }) }
 
   def self.came_comment(comment, reciever, message)
     Notification.create!(

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,6 +4,7 @@ class Question < ActiveRecord::Base
   include Searchable
   include Reactionable
   include Watchable
+  include WithAvatar
 
   belongs_to :practice, optional: true
   belongs_to :user, touch: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -7,6 +7,7 @@ class Report < ActiveRecord::Base
   include Searchable
   include Reactionable
   include Watchable
+  include WithAvatar
 
   has_many :learning_times, -> { order(:started_at) }, dependent: :destroy, inverse_of: :report
   validates_associated :learning_times
@@ -28,7 +29,6 @@ class Report < ActiveRecord::Base
 
   scope :wip, -> { where(wip: true) }
   scope :not_wip, -> { where(wip: false) }
-  scope :with_avatar, -> { preload(user: { avatar_attachment: :blob }) }
 
   after_create ReportCallbacks.new
 

--- a/app/views/welcome/practices.html.slim
+++ b/app/views/welcome/practices.html.slim
@@ -7,7 +7,7 @@ section.welcome-section
   .container
     .welcome-small-sections
       .row.is-gutter-widtd-32
-        - @categories.order(:position).each do |category|
+        - @categories.each do |category|
           .col-xs-12.col-md-4
             .welcome-small-section
               h3.welcome-small-section__title = category.name


### PR DESCRIPTION
Ref: #1080 

## 修正箇所
| 画面 | URL |
|------|---|
|ダッシュボード|http://localhost:3000/|
|ユーザー一覧|http://localhost:3000/users|
|Q&A一覧|http://localhost:3000/questions|
|お知らせ一覧|http://localhost:3000/announcements|
|通知一覧|http://localhost:3000/notifications|
|プラクティス一覧（学習内容）|http://localhost:3000/practices|
## 注意点
一連のN+1潰しでは、bulletで警告されるN+1だけに対応しています。具体的にはビューでN+1が発生している場合です。

モデルやヘルパーで、ループの度に同じ様なクエリを発行するケースには対応していません。N+1潰しの途中で気づきましたが、こちらも結構あります。一応SQLキャッシュが効くケースもありますが、Bootcampを遅くしている原因の1つです。こちらも修正するとさらに速度が上がりますが、影響範囲が広いのと書き直しが必要になるので、N+1潰しより大変そうです。こちらは今回は修正していません。

## 不安な点・レビューしてほしい点

### activestorageのテーブルをpreloadしてもよいですか？

[activestorageのテーブルをincludeするのをやめた](https://github.com/fjordllc/bootcamp/pull/809) というPRを見つけました。前回・今回のPRでactivestorageのテーブルをpreloadする処理がいくつか入っています。既にリリース済みの右サイドバーの日報一覧にもこの処理が入っています。そちらは速くなっているのでおそらく問題ないかなーとは思うのですが、activestorageのテーブルをpreloadしてもよいですか？

### activestorageをpreloadする処理をConcernにしてよいですか？

1つ目の質問に関連しますが、activestorageをpreloadする処理はよく出てくるのでConcernにしました。

```rb
# frozen_string_literal: true

module WithAvatar
  extend ActiveSupport::Concern

  included do
    scope :with_avatar, -> { preload(user: { avatar_attachment: :blob }) }
  end
end
```

- Concernをこういった用途で使ってよいでしょうか？
- ネーミングはこれで大丈夫でしょうか？

レビュー、よろしくおねがいします🙇