### PR TITLE
ヘッダーリンクのGitHubという名称をGitHub Projectsに変更

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -53,7 +53,7 @@
                 | コース
             li.header-dropdown__item
               = link_to "https://github.com/fjordllc/bootcamp/projects/1", class: "header-dropdown__item-link", target: "_blank" do
-                | GitHub
+                | GitHub Projects
             li.header-dropdown__item
               = link_to "https://suzuri.jp/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
                 | Goodies


### PR DESCRIPTION
Ref: #1147

## 変更後画面

<img width="1356" alt="スクリーンショット_2019-09-25_16_13_10" src="https://user-images.githubusercontent.com/42843963/65577841-94c94500-dfaf-11e9-9209-e29adc66f33d.png">
