### PR TITLE
ヘッダーリンクのGoodiesという名称をグッズ購入に変更

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -56,7 +56,7 @@
                 | GitHub
             li.header-dropdown__item
               = link_to "https://suzuri.jp/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
-                | Goodies
+                | グッズ購入
             li.header-dropdown__item
               = link_to logout_path, class: "header-dropdown__item-link" do
                 | ログアウト


### PR DESCRIPTION
Ref: #1146

## 変更後画面

<img width="1351" alt="スクリーンショット_2019-09-25_16_36_56" src="https://user-images.githubusercontent.com/42843963/65579491-cee81600-dfb2-11e9-9ee9-f6ec6f538383.png">
