### PR TITLE
MenuにGoogle Meetを追加

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -55,6 +55,9 @@
               = link_to "https://github.com/fjordllc/bootcamp/projects/1", class: "header-dropdown__item-link", target: "_blank" do
                 | GitHub
             li.header-dropdown__item
+              = link_to "https://meet.google.com/obe-tbcj-kne", class: "header-dropdown__item-link", target: "_blank" do
+                | Google Meet
+            li.header-dropdown__item
               = link_to "https://suzuri.jp/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
                 | Goodies
             li.header-dropdown__item


### PR DESCRIPTION
Ref: #1144

## 変更後画面

<img width="1131" alt="スクリーンショット 2019-09-25 17 52 15" src="https://user-images.githubusercontent.com/42843963/65585351-4f137900-dfbd-11e9-952d-7ce80588e1e4.png">

## スッキリしていないところ

### 問題
ローカル環境で`localhost:3000`からアクセスした場合、HTTPのエラーコード`500 Internal Server Error`が表示された。日報にURLを貼り付けてリンクした場合も同様。本番環境の日報からのリンクでは、問題なく表示された。

### 結論
`127.0.0.1:3000`からGoogle Meetにアクセスした場合、問題なく表示されたので本番環境でも問題なく表示できると判断した。

### HTTPのエラーコード500になった際の画像

<img width="1000" alt="スクリーンショット 2019-09-25 17 52 29" src="https://user-images.githubusercontent.com/42843963/65585359-5044a600-dfbd-11e9-97d8-4eb89248cefd.png">
