### PR TITLE
WIPで提出物を提出した場合は通知されないように変更

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -33,8 +33,9 @@ class ProductsController < ApplicationController
     @product.practice = @practice
     @product.user = current_user
     set_wip
+    check_noticeable
     if @product.save
-      notify_to_slack(@product)
+      notify_to_slack(@product) if @noticeable
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new
@@ -120,6 +121,10 @@ class ProductsController < ApplicationController
 
     def set_wip
       @product.wip = params[:commit] == "WIP"
+    end
+
+    def check_noticeable
+      @noticeable = true if @product.wip == false
     end
 
     def notice_message(product, action_name)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -34,7 +34,7 @@ class ProductsController < ApplicationController
     @product.user = current_user
     set_wip
     if @product.save
-      notify_to_slack(@product) unless @product.wip
+      notify_to_slack(@product) unless @product.wip?
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -33,9 +33,8 @@ class ProductsController < ApplicationController
     @product.practice = @practice
     @product.user = current_user
     set_wip
-    check_noticeable
     if @product.save
-      notify_to_slack(@product) if @noticeable
+      notify_to_slack(@product) unless @product.wip
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new
@@ -121,10 +120,6 @@ class ProductsController < ApplicationController
 
     def set_wip
       @product.wip = params[:commit] == "WIP"
-    end
-
-    def check_noticeable
-      @noticeable = true if @product.wip == false
     end
 
     def notice_message(product, action_name)

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -2,7 +2,7 @@
 
 class ProductCallbacks
   def after_create(product)
-    unless product.wip
+    unless product.wip?
       send_notification(
         product: product,
         receivers: User.admins,
@@ -28,7 +28,7 @@ class ProductCallbacks
   end
 
   def after_update(product)
-    unless product.wip
+    unless product.wip?
       send_notification(
         product: product,
         receivers: User.admins,

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -2,8 +2,7 @@
 
 class ProductCallbacks
   def after_create(product)
-    check_noticeable(product)
-    if @noticeable
+    unless product.wip
       send_notification(
         product: product,
         receivers: User.admins,
@@ -29,8 +28,7 @@ class ProductCallbacks
   end
 
   def after_update(product)
-    check_noticeable(product)
-    if @noticeable
+    unless product.wip
       send_notification(
         product: product,
         receivers: User.admins,
@@ -58,12 +56,5 @@ class ProductCallbacks
 
     def delete_notification(product)
       Notification.where(path: "/products/#{product.id}").destroy_all
-    end
-
-    def check_noticeable(product)
-      @noticeable = false
-      if product.wip == false
-        @noticeable = true
-      end
     end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -246,6 +246,7 @@ kensyu:
   experience: rails
   organization: 研修大学
   trainee: true
+  free: true
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
 

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -140,12 +140,10 @@ class ProductsTest < ApplicationSystemTestCase
     click_button "WIP"
     assert_text "提出物をWIPとして保存しました。"
 
-
     click_link "内容修正"
     fill_in("product[body]", with: "test update")
     click_button "提出する"
     assert_text "提出物を更新しました。"
-
 
     login_user "komagata", "testtest"
     visit "/notifications"
@@ -165,12 +163,10 @@ class ProductsTest < ApplicationSystemTestCase
     click_button "WIP"
     assert_text "提出物をWIPとして保存しました。"
 
-
     click_link "内容修正"
     fill_in("product[body]", with: "test update")
     click_button "WIP"
     assert_text "提出物をWIPとして保存しました。"
-
 
     login_user "komagata", "testtest"
     visit "/notifications"


### PR DESCRIPTION
Ref: #1111

## 変更後の状態

<img width="1373" alt="スクリーンショット_2019-10-02_17_43_29" src="https://user-images.githubusercontent.com/42843963/66030609-ac1eaa00-e53c-11e9-8b31-f8cad3b9dd82.png">

## 備考

テストの際、テストデータの研修生ユーザーで提出物を提出しようとしたところクレジットカード番号の入力が求められたため、研修生ユーザー（`kensyu`）に無料フラグ（`free: true`）を追加中