### PR TITLE
小さい通知に合わせて、通知一覧も同じURLのものは一つにまとめて表示する

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,7 @@ class NotificationsController < ApplicationController
 
   def index
     @notifications = current_user.notifications
-                                 .with_avatar
+                                 .reads_with_avatar
                                  .order(created_at: :desc)
                                  .page(params[:page])
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -20,12 +20,16 @@ class Notification < ApplicationRecord
     trainee_report: 10
   }
 
+  scope :reads, -> {
+    where(created_at: into_one.values).order(created_at: :desc)
+  }
+
   scope :unreads, -> {
-    into_one = select(:path).group(:path).maximum(:created_at)
     where(read: false, created_at: into_one.values).order(created_at: :desc)
   }
 
   scope :with_avatar, -> { preload(sender: { avatar_attachment: :blob }) }
+  scope :reads_with_avatar, -> { reads.with_avatar }
   scope :unreads_with_avatar, -> { unreads.with_avatar.limit(99) }
 
   def self.came_comment(comment, receiver, message)
@@ -148,4 +152,9 @@ class Notification < ApplicationRecord
       read:    false
     )
   end
+
+  private
+    def self.into_one
+      select(:path).group(:path).maximum(:created_at)
+    end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -246,6 +246,7 @@ kensyu:
   experience: rails
   organization: 研修大学
   trainee: true
+  free: true
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
 

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -26,14 +26,10 @@ class NotificationsTest < ApplicationSystemTestCase
     visit "/reports/new"
     fill_in "report_title", with: "テスト日報"
     fill_in "report_description", with: "none"
-    within(".learning-time__started-at") do
-      select "23"
-      select "30"
-    end
-    within(".learning-time__finished-at") do
-      select "01"
-      select "30"
-    end
+    select "23", from: :report_learning_times_attributes_0_started_at_4i
+    select "00", from: :report_learning_times_attributes_0_started_at_5i
+    select "00", from: :report_learning_times_attributes_0_finished_at_4i
+    select "00", from: :report_learning_times_attributes_0_finished_at_5i
     click_button "提出"
 
     find(".js-markdown").set("login_nameの補完テスト: @komagata\n")

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -26,10 +26,14 @@ class NotificationsTest < ApplicationSystemTestCase
     visit "/reports/new"
     fill_in "report_title", with: "テスト日報"
     fill_in "report_description", with: "none"
-    all(".learning-time")[0].all(".learning-time__started-at select")[0].select("23")
-    all(".learning-time")[0].all(".learning-time__started-at select")[1].select("00")
-    all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("00")
-    all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("00")
+    within(".learning-time__started-at") do
+      select "23"
+      select "30"
+    end
+    within(".learning-time__finished-at") do
+      select "01"
+      select "30"
+    end
     click_button "提出"
 
     find(".js-markdown").set("login_nameの補完テスト: @komagata\n")

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -16,4 +16,54 @@ class NotificationsTest < ApplicationSystemTestCase
       assert_not_equal "[Bootcamp] kimuraさんからコメントが届きました。", last_mail.subject
     end
   end
+
+  test "don't notify the same report" do
+    login_user "komagata", "testtest"
+    visit "/notifications"
+    click_link "全て既読にする"
+
+    login_user "kensyu", "testtest"
+    visit "/reports/new"
+    fill_in "report_title", with: "テスト日報"
+    fill_in "report_description", with: "none"
+    all(".learning-time")[0].all(".learning-time__started-at select")[0].select("23")
+    all(".learning-time")[0].all(".learning-time__started-at select")[1].select("00")
+    all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("00")
+    all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("00")
+    click_button "提出"
+
+    find(".js-markdown").set("login_nameの補完テスト: @komagata\n")
+    click_button "コメントする"
+    assert_text "login_nameの補完テスト: @komagata"
+    assert_selector :css, "a[href='/users/komagata']"
+
+    login_user "komagata", "testtest"
+    visit "/notifications"
+    assert_no_text "kensyuさんがはじめての日報を書きました！"
+    assert_text "kensyuさんからメンションがきました。"
+  end
+
+  test "don't notify the same product" do
+    login_user "komagata", "testtest"
+    visit "/notifications"
+    click_link "全て既読にする"
+
+    login_user "kensyu", "testtest"
+    visit "/products/new?practice_id=#{practices(:practice_3).id}"
+    within("#new_product") do
+      fill_in("product[body]", with: "test")
+    end
+    click_button "提出する"
+    assert_text "提出物を作成しました。"
+
+    fill_in("js-new-comment", with: "test @komagata")
+    click_button "コメントする"
+    assert_text "test @komagata"
+
+    login_user "komagata", "testtest"
+    visit "/notifications"
+    assert_no_text "kensyuさんが提出しました。"
+    assert_no_text "kensyuさんからメンションがきました。"
+    assert_text "あなたがウォッチしている【 「PC性能の見方を知る」の提出物 】にコメントが投稿されました。"
+  end
 end


### PR DESCRIPTION
Ref: #974

## 変更後画面

複数の通知が一つにまとまっている

<img width="1072" alt="スクリーンショット_2019-10-04_16_24_45" src="https://user-images.githubusercontent.com/42843963/66189124-fe3e0780-e6c3-11e9-815e-e85b54a3dbfb.png">

## 変更前画面

<img width="1081" alt="スクリーンショット_2019-10-04_16_24_26" src="https://user-images.githubusercontent.com/42843963/66189094-ebc3ce00-e6c3-11e9-9577-7edcd6a85452.png">
