### PR TITLE
アドミンのメニューにウィッシュリストを追加

### DIFF
--- a/app/views/admin/home/index.html.slim
+++ b/app/views/admin/home/index.html.slim
@@ -29,5 +29,8 @@ header.page-header
                   = link_to "https://github.com/fjordllc/fjord/wiki/FjordBootCamp", class: "card-list__item-link", target: "_blank" do
                     | 管理者用ドキュメント
                 li.card-list__item
+                  = link_to "https://www.amazon.co.jp/hz/wishlist/ls/3I571CQISBFR6?ref_=wl_share", class: "card-list__item-link", target: "_blank" do
+                    | ウィッシュリスト
+                li.card-list__item
                   = link_to welcome_path, class: "card-list__item-link" do
                     | トップページ確認

--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -31,6 +31,9 @@
                 = link_to "https://github.com/fjordllc/fjord/wiki/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
                   | 管理者用ドキュメント
               li.header-dropdown__item
+                = link_to "https://www.amazon.co.jp/hz/wishlist/ls/3I571CQISBFR6?ref_=wl_share", class: "header-dropdown__item-link", target: "_blank"  do
+                  | ウィッシュリスト
+              li.header-dropdown__item
                 = link_to welcome_path, class: "header-dropdown__item-link" do
                   | トップページ確認
     li.header-links__item


### PR DESCRIPTION
#1156 の対応
アドミンメニューと `/admin` の下から2番目に
https://www.amazon.co.jp/hz/wishlist/ls/3I571CQISBFR6?ref_=wl_share へのリンクを
`target_blank` で追加する

