### PR TITLE
ユーザーの所属企業必須を廃止

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,6 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    @user.company = Company.first
     @user.course = Course.first
 
     if @user.trainee?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   include ActionView::Helpers::AssetUrlHelper
 
   authenticates_with_sorcery!
-  VALID_SORT_COLUMNS = %w(id login_name company_id updated_at created_at report comment asc desc)
+  VALID_SORT_COLUMNS = %w(id login_name updated_at created_at report comment asc desc)
 
   enum job: {
     student: 0,
@@ -32,7 +32,7 @@ class User < ActiveRecord::Base
     rails: 4
   }, _prefix: true
 
-  belongs_to :company
+  belongs_to :company, required: false
   belongs_to :course
   has_many :learnings
   has_many :borrowings

--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -30,7 +30,10 @@ header.page-header
           - @companies.each do |company|
             tr.admin-table__item(id="company_#{company.id}")
               td.admin-table__item-value
-                = company.name
+                - unless company.nil?
+                  = company.name
+                - else
+                | -
               td.admin-table__item-value
                 - if company.logo.attached?
                   = image_tag company.logo_image(100), class: "admin-table__item-logo-image"

--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -30,7 +30,7 @@ header.page-header
           - @companies.each do |company|
             tr.admin-table__item(id="company_#{company.id}")
               td.admin-table__item-value
-                - unless company.nil?
+                - if company.present?
                   = company.name
                 - else
                 | -

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -52,7 +52,7 @@
                   = user.login_name
                   | （#{user.full_name}）
             td.admin-table__item-value.is-text-align-center
-              - unless user.company.nil?
+              - if user.company.present?
                 = user.company.name
               - else
                 | -

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -52,7 +52,10 @@
                   = user.login_name
                   | （#{user.full_name}）
             td.admin-table__item-value.is-text-align-center
-              = user.company.name
+              - unless user.company.nil?
+                = user.company.name
+              - else
+                | -
             td.admin-table__item-value.is-text-align-center
               - if user.slack_account.present?
                 = user.slack_account

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -46,12 +46,14 @@
         .user-metas__item-value
           = number_with_precision(user.total_learning_time, precision: 1) + "時間 / "
           = render "users/learning_status", user: user
-    - unless user.company.id == 1
+    - unless user.company.nil?
       .user-metas__item
         .user-metas__item-label
           | 所属企業
         .user-metas__item-value
-          = user.company.name
+            = user.company.name
+    - else
+      | -
     .user-metas__item
       .user-metas__item-label
         | 区分

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -46,7 +46,7 @@
         .user-metas__item-value
           = number_with_precision(user.total_learning_time, precision: 1) + "時間 / "
           = render "users/learning_status", user: user
-    - unless user.company.nil?
+    - if user.company.present?
       .user-metas__item
         .user-metas__item-label
           | 所属企業

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -7,5 +7,5 @@
     h2.user-profile__full-name
       = user.full_name
   = render "users/sns", user: user
-  - if !user.company.nil? && user.company.logo.attached?
+  - if user.company.present? && user.company.logo.attached?
     = image_tag user.company.logo, class: "user-profile__company-logo"

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -7,5 +7,5 @@
     h2.user-profile__full-name
       = user.full_name
   = render "users/sns", user: user
-  - if user.company.logo.attached?
+  - if !user.company.nil? && user.company.logo.attached?
     = image_tag user.company.logo, class: "user-profile__company-logo"

--- a/db/migrate/20191013112837_change_datatype_company_id_of_users.rb
+++ b/db/migrate/20191013112837_change_datatype_company_id_of_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeDatatypeCompanyIdOfUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :users, :company_id, true
+    change_column_default :users, :company_id, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_16_100249) do
+ActiveRecord::Schema.define(version: 2019_10_13_112837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -299,7 +299,7 @@ ActiveRecord::Schema.define(version: 2019_08_16_100249) do
     t.string "twitter_account"
     t.string "facebook_url"
     t.string "blog_url"
-    t.integer "company_id", default: 1
+    t.integer "company_id"
     t.text "description"
     t.string "feed_url"
     t.datetime "accessed_at"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -56,7 +56,6 @@ sotugyou:
   facebook_url: http://www.facebook.com/sotugyou
   blog_url: http://sotugyou.example.com/
   feed_url: http://sotugyou.example.com/index.atom
-  company: company_1
   description: "卒業です。卒業しちゃいました。"
   course: course_1
   job: office_worker
@@ -79,7 +78,6 @@ advijirou:
   facebook_url: http://www.facebook.com/advijirou
   blog_url: http://advijirou.example.com
   feed_url: http://advijirou.example.com/index.atom
-  company: company_1
   description: "アドバイ次郎です。アドバイザーです。"
   adviser: true
   course: course_1
@@ -96,7 +94,6 @@ yameo:
   twitter_account: yameo
   facebook_url: http://www.facebook.com/yameo
   blog_url: http://yameo.org
-  company: company_1
   description: "リタイアしました。"
   course: course_1
   job: office_worker
@@ -119,7 +116,6 @@ yamada:
   facebook_url: http://www.facebook.com/yamada
   blog_url: http://yamada.com
   feed_url: http://yamada.com/index.atom
-  company: company_1
   description: "山田です。メンターです。"
   course: course_1
   job: office_worker
@@ -142,7 +138,6 @@ kimura:
   facebook_url: http://www.facebook.com/kimura
   blog_url: http://kimura.org
   feed_url: http://kimura.org/index.atom
-  company: company_1
   description: "木村です。"
   course: course_1
   job: office_worker
@@ -164,7 +159,6 @@ hatsuno:
   facebook_url: http://www.facebook.com/hatsuno
   blog_url: http://hatsuno.org
   feed_url: http://hatsuno.org/index.atom
-  company: company_1
   description: "初野です。課金しています。"
   customer_id: "cus_12345678"
   subscription_id: "sub_12345678"
@@ -188,7 +182,6 @@ hajime:
   facebook_url: http://www.facebook.com/hajime
   blog_url: http://hajime.org
   feed_url: http://hajime.org/index.atom
-  company: company_1
   description: "始です。"
   course: course_1
   job: office_worker
@@ -212,7 +205,6 @@ muryou:
   facebook_url: http://www.facebook.com/muryou
   blog_url: http://muryou.org
   feed_url: http://muryou.org/index.atom
-  company: company_1
   description: "無料の助です。趣味は野良犬剣法です。"
   course: course_1
   job: office_worker


### PR DESCRIPTION
## 変更内容
- ユーザーの所属企業必須を辞める
- 一般ユーザー登録時、所属企業をフィヨルド（`user.company_id = 1`）とするのを辞める
- Viewで所属企業が`nil`場合、`-`を表示するように変更
- テストデータで`komagata`, `machida`以外の一般ユーザーのフィヨルド所属は外す

Ref: #1088
