### PR TITLE
提出物の提出、更新の通知にプラクティス名を追加

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -63,7 +63,7 @@ class ProductsController < ApplicationController
       link = "<#{url_for(product)}|#{product.title}>"
 
       if product.user.trainee? && product.user.company.slack_channel?
-        SlackNotification.notify "#{name} さんが提出物を提出しました。 #{link}",
+        SlackNotification.notify "#{name} さんが#{product.title}を提出しました。 #{link}",
           username: "#{product.user.login_name} (#{product.user.full_name})",
           icon_url: product.user.avatar_url,
           channel: product.user.company.slack_channel,

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -6,7 +6,7 @@ class ProductCallbacks
       send_notification(
         product: product,
         receivers: User.admins,
-        message: "#{product.user.login_name}さんが提出しました。"
+        message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
       )
       create_watch(
         watchers: User.admins,
@@ -17,7 +17,7 @@ class ProductCallbacks
         send_notification(
           product: product,
           receivers: product.user.company.advisers,
-          message: "#{product.user.login_name}さんが提出しました。"
+          message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
         )
         create_watch(
           watchers: product.user.company.advisers,
@@ -32,7 +32,7 @@ class ProductCallbacks
       send_notification(
         product: product,
         receivers: User.admins,
-      message: "#{product.user.login_name}さんが提出物を更新しました。"
+      message: "#{product.user.login_name}さんが#{product.title}を更新しました。"
       )
     end
   end

--- a/app/views/notification_mailer/submitted.html.slim
+++ b/app/views/notification_mailer/submitted.html.slim
@@ -1,2 +1,2 @@
-= render "notification_mailer_template", title: "#{@product.title}を#{@message}", link_url: notification_url(@notification), link_text: "提出物へ" do
+= render "notification_mailer_template", title: "#{@message}", link_url: notification_url(@notification), link_text: "提出物へ" do
   = simple_format(@product.body)

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -34,7 +34,7 @@ notification_submitted:
   kind: 3
   user: komagata
   sender: sotugyou
-  message: sogugyouさんが提出しました。
+  message: sogugyouさんが「Terminalの基礎を覚える」の提出物を提出しました。
   path: "/products/<%= ActiveRecord::FixtureSet.identify(:product_3) %>"
   read: false
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -51,13 +51,13 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = NotificationMailer.submitted(
       product,
       submitted.user,
-      "#{product.user.login_name}さんが提出しました。"
+      "#{product.user.login_name}さんが「#{product.title}」を提出しました。"
     ).deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal ["info@fjord.jp"], email.from
     assert_equal ["komagata@fjord.jp"], email.to
-    assert_equal "[bootcamp] sotugyouさんが提出しました。", email.subject
+    assert_equal "[bootcamp] sotugyouさんが「#{product.title}」を提出しました。", email.subject
     assert_match %r{提出}, email.body.to_s
   end
 

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -17,10 +17,10 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     login_user "komagata", "testtest"
 
     first(".test-bell").click
-    assert_text "yamadaさんが提出しました。"
+    assert_text "yamadaさんが「#{practices(:practice_5).title}」の提出物を提出しました。"
 
     # 提出物を作成したとき、管理者からウォッチがつく
-    click_link  "yamadaさんが提出しました。"
+    click_link  "yamadaさんが「#{practices(:practice_5).title}」の提出物を提出しました。"
     assert_text "Watch中"
   end
 
@@ -37,7 +37,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     login_user "komagata", "testtest"
 
     first(".test-bell").click
-    assert_text "yamadaさんが提出物を更新しました。"
+    assert_text "yamadaさんが#{products(:product_1).title}を更新しました。"
   end
 
   test "send adviser a notification when trainee create product" do
@@ -54,6 +54,6 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     login_user "senpai", "testtest"
 
     first(".test-bell").click
-    assert_text "kensyuさんが提出しました。"
+    assert_text "kensyuさんが「#{practices(:practice_5).title}」の提出物を提出しました。"
   end
 end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -62,7 +62,7 @@ class NotificationsTest < ApplicationSystemTestCase
 
     login_user "komagata", "testtest"
     visit "/notifications"
-    assert_no_text "kensyuさんが提出しました。"
+    assert_no_text "kensyuさんが「#{practices(:practice_3).title}」を提出しました。"
     assert_no_text "kensyuさんからメンションがきました。"
     assert_text "あなたがウォッチしている【 「PC性能の見方を知る」の提出物 】にコメントが投稿されました。"
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -124,7 +124,7 @@ class ProductsTest < ApplicationSystemTestCase
 
     login_user "komagata", "testtest"
     visit "/notifications"
-    assert_no_text "kensyuさんが提出しました。"
+    assert_no_text "kensyuさんが「#{practices(:practice_3).id}」の提出物を提出しました。"
   end
 
   test "Notify if the update product" do
@@ -147,7 +147,7 @@ class ProductsTest < ApplicationSystemTestCase
 
     login_user "komagata", "testtest"
     visit "/notifications"
-    assert_text "kensyuさんが提出物を更新しました。"
+    assert_text "kensyuさんが「#{practices(:practice_3).title}」の提出物を更新しました。"
   end
 
   test "Don't notify if update product as WIP" do
@@ -170,7 +170,7 @@ class ProductsTest < ApplicationSystemTestCase
 
     login_user "komagata", "testtest"
     visit "/notifications"
-    assert_no_text "kensyuさんが提出しました。"
+    assert_no_text "kensyuさんが「#{practices(:practice_3).title}」の提出物を提出しました。"
   end
 
   test "Slack notify if the create product" do
@@ -184,7 +184,7 @@ class ProductsTest < ApplicationSystemTestCase
 
     Rails.logger.stub(:info, stub_info) do
       click_button "提出する"
-      assert_match "kensyu さんが提出物を提出しました", mock_log.to_s
+      assert_match "kensyu さんが「#{practices(:practice_3).title}」の提出物を提出しました。", mock_log.to_s
     end
     assert_text "提出物を作成しました。"
   end
@@ -200,7 +200,7 @@ class ProductsTest < ApplicationSystemTestCase
 
     Rails.logger.stub(:info, stub_info) do
       click_button "WIP"
-      assert_no_match "kensyu さんが提出物を提出しました", mock_log.to_s
+      assert_no_match "kensyu さんが「#{practices(:practice_3).title}」の提出物を提出しました。", mock_log.to_s
     end
     assert_text "提出物をWIPとして保存しました。"
   end


### PR DESCRIPTION
ユーザーがプラクティスの提出物を提出、更新したさいの通知にプラクティスのタイトルを追加する
![image](https://user-images.githubusercontent.com/2524168/66904502-26702380-f03f-11e9-9fc6-f8da7a0c12eb.png)
