### PR TITLE
`User.company==nil`の時はプロフィール画面で`-`ではなく非表示

### DIFF
--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -32,8 +32,6 @@ header.page-header
               td.admin-table__item-value
                 - if company.present?
                   = company.name
-                - else
-                | -
               td.admin-table__item-value
                 - if company.logo.attached?
                   = image_tag company.logo_image(100), class: "admin-table__item-logo-image"

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -52,8 +52,6 @@
           | 所属企業
         .user-metas__item-value
             = user.company.name
-    - else
-      | -
     .user-metas__item
       .user-metas__item-label
         | 区分


### PR DESCRIPTION
Ref: #1171

## 備考

#1088 で発生したbug

## 画面から削除される内容

- 画面上の`-`が削除される

<img width="743" alt="スクリーンショット_2019-10-16_19_00_41" src="https://user-images.githubusercontent.com/42843963/66909470-caf66380-f047-11e9-93b0-839bd3a91cc0.png">
<img width="828" alt="スクリーンショット_2019-10-16_19_00_48" src="https://user-images.githubusercontent.com/42843963/66909501-d5b0f880-f047-11e9-8d24-d375e8f9d7a2.png">
