### PR TITLE
ユーザー情報フォームに都道府県を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem "commonmarker"
 gem "stripe", "~> 4.5.0"
 gem "acts-as-taggable-on"
 gem "rqrcode"
+gem "jp_prefecture"
 
 group :production, :staging do
   gem "newrelic_rpm"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    jp_prefecture (0.10.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -423,6 +424,7 @@ DEPENDENCIES
   google-cloud-storage (~> 1.3)
   heavens_door
   jbuilder (~> 2.5)
+  jp_prefecture
   jquery-rails
   kaminari
   letter_opener

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -59,6 +59,7 @@ class Admin::UsersController < AdminController
         :os,
         :study_place,
         :experience,
+        :prefecture,
         :company_id,
         :trainee,
         :job_seeking,

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -59,7 +59,7 @@ class Admin::UsersController < AdminController
         :os,
         :study_place,
         :experience,
-        :prefecture,
+        :prefecture_code,
         :company_id,
         :trainee,
         :job_seeking,

--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -40,7 +40,7 @@ class CurrentUserController < ApplicationController
         :os,
         :study_place,
         :experience,
-        :prefecture,
+        :prefecture_code,
         :company_id,
         :nda,
         :avatar,

--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -17,7 +17,6 @@ class CurrentUserController < ApplicationController
   end
 
   private
-
     def user_params
       params.require(:user).permit(
         :adviser,
@@ -41,6 +40,7 @@ class CurrentUserController < ApplicationController
         :os,
         :study_place,
         :experience,
+        :prefecture,
         :company_id,
         :nda,
         :avatar,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,6 +72,7 @@ class UsersController < ApplicationController
         :os,
         :study_place,
         :experience,
+        :prefecture,
         :company_id,
         :nda,
         :avatar,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,7 +43,6 @@ class UsersController < ApplicationController
   end
 
   private
-
     def notify_to_slack!
       SlackNotification.notify "<#{url_for(@user)}|#{@user.full_name} (#{@user.login_name})>が#{User.count}番目の仲間としてBootcampにJOINしました。",
         username: "#{@user.login_name}@bootcamp.fjord.jp",
@@ -72,7 +71,7 @@ class UsersController < ApplicationController
         :os,
         :study_place,
         :experience,
-        :prefecture,
+        :prefecture_code,
         :company_id,
         :nda,
         :avatar,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,10 +223,10 @@ SQL
   end
 
   def prefecture_name
-    if prefecture.nil?
+    if prefecture_code.nil?
       "未登録"
     else
-      pref = JpPrefecture::Prefecture.find prefecture
+      pref = JpPrefecture::Prefecture.find prefecture_code
       pref.name
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,6 +222,15 @@ SQL
     end
   end
 
+  def prefecture_name
+    if prefecture.nil?
+      "未登録"
+    else
+      pref = JpPrefecture::Prefecture.find prefecture
+      pref.name
+    end
+  end
+
   def elapsed_days
     (Date.current - self.created_at.to_date).to_i
   end

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -12,13 +12,13 @@
     = render "users/form/name", f: f, user: user
     = render "users/form/avatar", f: f, user: user
     = render "users/form/description", f: f, user: user
-
     - unless user.adviser?
       = render "users/form/course", f: f
       = render "users/form/job", f: f
       = render "users/form/os", f: f
       = render "users/form/study_place", f: f
       = render "users/form/experience", f: f
+      = render "users/form/prefecture", f: f
 
   - if from == :edit
     .form__items

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -17,8 +17,8 @@
       = render "users/form/job", f: f
       = render "users/form/os", f: f
       = render "users/form/study_place", f: f
-      = render "users/form/experience", f: f
       = render "users/form/prefecture", f: f
+      = render "users/form/experience", f: f
 
   - if from == :edit
     .form__items

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -13,6 +13,11 @@
         = l user.updated_at
     .user-metas__item
       .user-metas__item-label
+        | 都道府県
+      .user-metas__item-value
+        = user.prefecture_name
+    .user-metas__item
+      .user-metas__item-label
         | コース
       .user-metas__item-value
         = user.course.title

--- a/app/views/users/form/_prefecture.html.slim
+++ b/app/views/users/form/_prefecture.html.slim
@@ -1,7 +1,7 @@
 .form-item
-  = f.label :prefecture, class: "a-label"
+  = f.label :prefecture_code, class: "a-label"
   .a-button.is-md.is-secondary.is-select.is-block
-    = f.collection_select :prefecture, JpPrefecture::Prefecture.all, :code, :name, include_blank: "都道府県を選択してください"
+    = f.collection_select :prefecture_code, JpPrefecture::Prefecture.all, :code, :name, include_blank: "都道府県を選択してください"
   .a-form-help
     p
       | 就職先企業の紹介やテック系イベントの紹介時の参考にします。

--- a/app/views/users/form/_prefecture.html.slim
+++ b/app/views/users/form/_prefecture.html.slim
@@ -1,0 +1,8 @@
+.form-item
+  = f.label :prefecture, class: "a-label"
+  .a-button.is-md.is-secondary.is-select.is-block
+    = f.collection_select :prefecture, JpPrefecture::Prefecture.all, :code, :name, include_blank: "都道府県を選択してください"
+  .a-form-help
+    p
+      | 都道府県を選択すると就職活動時に企業紹介の目安となります。
+      | 現在のお住まいと就職活動をする地域が異なる場合はお知らせください。

--- a/app/views/users/form/_prefecture.html.slim
+++ b/app/views/users/form/_prefecture.html.slim
@@ -4,5 +4,5 @@
     = f.collection_select :prefecture, JpPrefecture::Prefecture.all, :code, :name, include_blank: "都道府県を選択してください"
   .a-form-help
     p
-      | 都道府県を選択すると就職活動時に企業紹介の目安となります。
-      | 現在のお住まいと就職活動をする地域が異なる場合はお知らせください。
+      | 就職先企業の紹介やテック系イベントの紹介時の参考にします。
+      | この情報は他のフィヨルドブートキャンプ参加者にも公開されますが、選択必須ではありません。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,6 +50,7 @@ ja:
         os: 利用OS
         study_place: 主な学習場所
         experience: プログラミング経験
+        prefecture: 都道府県
         organization: 現在の所属組織
         company: 会社
         created_at: 開始日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,7 +50,7 @@ ja:
         os: 利用OS
         study_place: 主な学習場所
         experience: プログラミング経験
-        prefecture: お住まいの都道府県
+        prefecture_code: お住まいの都道府県
         organization: 現在の所属組織
         company: 会社
         created_at: 開始日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,7 +50,7 @@ ja:
         os: 利用OS
         study_place: 主な学習場所
         experience: プログラミング経験
-        prefecture: 都道府県
+        prefecture: お住まいの都道府県
         organization: 現在の所属組織
         company: 会社
         created_at: 開始日

--- a/db/migrate/20191016093832_add_prefectures_to_users.rb
+++ b/db/migrate/20191016093832_add_prefectures_to_users.rb
@@ -2,6 +2,6 @@
 
 class AddPrefecturesToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :prefecture, :integer, null: true
+    add_column :users, :prefecture_code, :integer, null: true
   end
 end

--- a/db/migrate/20191016093832_add_prefectures_to_users.rb
+++ b/db/migrate/20191016093832_add_prefectures_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrefecturesToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :prefecture, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -327,7 +327,7 @@ ActiveRecord::Schema.define(version: 2019_10_16_093832) do
     t.boolean "job_seeking", default: false, null: false
     t.string "subscription_id"
     t.boolean "mail_notification", default: true, null: false
-    t.integer "prefecture"
+    t.integer "prefecture_code"
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_13_112837) do
+ActiveRecord::Schema.define(version: 2019_10_16_093832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -327,6 +327,7 @@ ActiveRecord::Schema.define(version: 2019_10_13_112837) do
     t.boolean "job_seeking", default: false, null: false
     t.string "subscription_id"
     t.boolean "mail_notification", default: true, null: false
+    t.integer "prefecture"
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -144,7 +144,7 @@ kimura:
   os: mac
   study_place: remote
   experience: inexperienced
-  prefecture: 13
+  prefecture_code: 13
   organization: 木村大学
   updated_at: "2014-01-01 00:00:07"
   created_at: "2014-01-01 00:00:07"
@@ -168,7 +168,7 @@ hatsuno:
   os: mac
   study_place: remote
   experience: inexperienced
-  prefecture: 4
+  prefecture_code: 4
   organization: 明治大学
   updated_at: "2014-01-01 00:00:08"
   created_at: "2014-01-01 00:00:08"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -144,6 +144,7 @@ kimura:
   os: mac
   study_place: remote
   experience: inexperienced
+  prefecture: 13
   organization: 木村大学
   updated_at: "2014-01-01 00:00:07"
   created_at: "2014-01-01 00:00:07"
@@ -167,6 +168,7 @@ hatsuno:
   os: mac
   study_place: remote
   experience: inexperienced
+  prefecture: 4
   organization: 明治大学
   updated_at: "2014-01-01 00:00:08"
   created_at: "2014-01-01 00:00:08"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -27,6 +27,12 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "prefecture_name" do
+    assert_equal "未登録", users(:komagata).prefecture_name
+    assert_equal "東京都", users(:kimura).prefecture_name
+    assert_equal "宮城県", users(:hatsuno).prefecture_name
+  end
+
   test "twitter_account" do
     Bootcamp::Setup.attachment
 


### PR DESCRIPTION
Ref: #1173 

* ユーザー情報に都道府県を追加する
* 新規作成時、プロフィール変更時に都道府県を設定・変更可能にする