### PR TITLE
管理者のユーザーページで会社でソートするとエラーになるバグを解決

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   include ActionView::Helpers::AssetUrlHelper
 
   authenticates_with_sorcery!
-  VALID_SORT_COLUMNS = %w(id login_name updated_at created_at report comment asc desc)
+  VALID_SORT_COLUMNS = %w(id login_name company_id updated_at created_at report comment asc desc)
 
   enum job: {
     student: 0,


### PR DESCRIPTION
## 関連

https://github.com/fjordllc/bootcamp/pull/1170

## 修正箇所

![スクリーンショット_2019-10-23_17_16_01](https://user-images.githubusercontent.com/42843963/67372742-55dfdc80-f5b9-11e9-83db-847575e28546.jpg)
