### PR TITLE
所属組織の入力を促すメッセージを削除

### DIFF
--- a/app/helpers/required_fields_helper.rb
+++ b/app/helpers/required_fields_helper.rb
@@ -15,10 +15,6 @@ module RequiredFieldsHelper
       messages << "#{link_to "自己紹介を入力してください。", edit_current_user_path, class: "card-list__item-link"}".html_safe
     end
 
-    if !current_user.organization?
-      messages << "#{link_to "現在の所属組織を入力してください。", edit_current_user_path, class: "card-list__item-link"}".html_safe
-    end
-
     if current_user.student?
       if !current_user.github_account?
         messages << "#{link_to "GitHubアカウントを登録してください。", edit_current_user_path, class: "card-list__item-link is-github"}".html_safe


### PR DESCRIPTION
Ref: #1190 

- [x] ユーザープロフィール編集の中に所属組織の入力欄が無いので、「現在の所属組織を入力してください」と表示するメッセージを削除した
