### PR TITLE
提出物のタイトルタグをプラクティスのタイトルに変更

### DIFF
--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -4,7 +4,7 @@ header.page-header
   .container
     .page-header__inner
       h1.page-header__title
-        = "#{ @product.user.login_name }の提出物"
+        = "#{@product.user.login_name}の提出物"
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -1,10 +1,10 @@
-- title "#{@product.user.login_name}の提出物"
+- title "#{ @product.practice.title }の提出物"
 
 header.page-header
   .container
     .page-header__inner
       h1.page-header__title
-        = title
+        = "#{ @product.user.login_name }の提出物"
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -1,4 +1,4 @@
-- title "#{ @product.practice.title }の提出物"
+- title "#{@product.practice.title}の提出物"
 
 header.page-header
   .container

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -7,33 +7,32 @@ class ProductsTest < ApplicationSystemTestCase
   test "see my product" do
     login_user "yamada", "testtest"
     visit "/products/#{products(:product_1).id}"
-    assert_equal "yamadaの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product_1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test "admin can see a product" do
     login_user "komagata", "testtest"
     visit "/products/#{products(:product_1).id}"
-    assert_equal "yamadaの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product_1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test "adviser can see a product" do
     login_user "advijirou", "testtest"
     visit "/products/#{products(:product_1).id}"
-    assert_equal "yamadaの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product_1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test "user who completed the practice can see the other user's product" do
     login_user "kimura", "testtest"
     visit "/products/#{products(:product_1).id}"
-    assert_equal "yamadaの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product_1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test "can see other user's product if it is permitted" do
     login_user "hatsuno", "testtest"
     visit "/products/#{products(:product_3).id}"
-    assert_equal "sotugyouの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product_3).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
-
   test "can not see other user's product if it isn't permitted" do
     login_user "hatsuno", "testtest"
     visit "/products/#{products(:product_1).id}"


### PR DESCRIPTION
Ref: #1192 
- [x] 提出物の詳細ページのタイトルタグがユーザー名だったのを、プラクティスのタイトルに変更する
- [x] テストの修正

作業結果:
![image](https://user-images.githubusercontent.com/37890305/67843894-31977900-fb40-11e9-90f6-f011ff587a51.png)

提出物の閲覧についてのテスト(`system/products_test.rb`)で、タイトルタグを使ってテストしている箇所があったため、ユーザー名からプラクティスのタイトルでテストするように修正した。