### PR TITLE
日報一覧ページの日報の表示順を学習日の降順かつ日報作成日時の降順に変更

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -23,7 +23,7 @@ class Report < ActiveRecord::Base
   validates :reported_on, presence: true, uniqueness: { scope: :user }
   validates :learning_times, length: { minimum: 1, message: ": 学習時間を入力してください。" }
 
-  scope :default_order, -> { order(reported_on: :desc, user_id: :desc) }
+  scope :default_order, -> { order(published_at: :desc, user_id: :desc) }
 
   scope :unchecked, -> { where.not(id: Check.where(checkable_type: "Report").pluck(:checkable_id)) }
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -23,7 +23,7 @@ class Report < ActiveRecord::Base
   validates :reported_on, presence: true, uniqueness: { scope: :user }
   validates :learning_times, length: { minimum: 1, message: ": 学習時間を入力してください。" }
 
-  scope :default_order, -> { order(published_at: :desc, user_id: :desc) }
+  scope :default_order, -> { order(reported_on: :desc, created_at: :desc) }
 
   scope :unchecked, -> { where.not(id: Check.where(checkable_type: "Report").pluck(:checkable_id)) }
 

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -452,17 +452,17 @@ class ReportsTest < ApplicationSystemTestCase
 
   test "reports are ordered in descending of reported_on" do
     visit reports_path
-    precede, succeed = reports(:report_2), reports(:report_1)
+    precede, succeed = reports(:report_2).title, reports(:report_1).title
     within ".thread-list" do
-      assert body.index(precede.title) < body.index(succeed.title)
+      assert page.text.index(precede) < page.text.index(succeed)
     end
   end
 
   test "reports are ordered in descending of created_at if reported_on is same" do
     visit reports_path
-    precede, succeed = reports(:report_5), reports(:report_1)
+    precede, succeed = reports(:report_5).title, reports(:report_1).title
     within ".thread-list" do
-      assert body.index(precede.title) < body.index(succeed.title)
+      assert page.text.index(precede) < page.text.index(succeed)
     end
   end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -449,4 +449,20 @@ class ReportsTest < ApplicationSystemTestCase
     visit "/notifications"
     assert_text "kensyuさんがはじめての日報を書きました！"
   end
+
+  test "reports are ordered in descending of reported_on" do
+    visit reports_path
+    precede, succeed = reports(:report_2), reports(:report_1)
+    within ".thread-list" do
+      assert body.index(precede.title) < body.index(succeed.title)
+    end
+  end
+
+  test "reports are ordered in descending of created_at if reported_on is same" do
+    visit reports_path
+    precede, succeed = reports(:report_5), reports(:report_1)
+    within ".thread-list" do
+      assert body.index(precede.title) < body.index(succeed.title)
+    end
+  end
 end


### PR DESCRIPTION
Ref: #1196 

- [x] 日報一覧ページの日報の表示順を学習日(reported_on)の降順で、かつ日報作成日時(created_at)の降順となるように修正
参照:https://github.com/fjordllc/bootcamp/pull/1213#issuecomment-550169728
- [x] テストを追加