### PR TITLE
現役生にだけ通知で作成したお知らせを編集すると全員にお知らせのラジオボタンもチェックされているバグを修正

### DIFF
--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -21,7 +21,7 @@
         | 通知ターゲット
       ul.form-item__radio-buttons.is-half
         li.form-radio-button.is-half
-          = f.label :target, class: "form-radio-button__label is-checked"
+          = f.label :target, class: "form-radio-button__label"
             | 全員にお知らせ
             = f.radio_button :target, "all", checked: true
         li.form-radio-button.is-half


### PR DESCRIPTION
Refs: #1219 
デフォルトで「全員にお知らせ」のラジオボタンにチェックされているcssを当てていたのを修正