### PR TITLE
ユーザー登録時にカードを登録するように変更

### DIFF
--- a/app/assets/stylesheets/blocks/form/_form-notice.sass
+++ b/app/assets/stylesheets/blocks/form/_form-notice.sass
@@ -1,14 +1,14 @@
 .form-notice
-  max-width: 34rem
+  max-width: 100%
+  width: 34rem
   +margin(horizontal, auto)
   border: solid $success 2px
-  padding: 1rem
-  background-color: rgba(white, .4)
-  font-size: .875rem
+  padding: .75rem
+  background-color: #f8fff2
+  margin-top: 1em
   +short-text-style
-  margin-bottom: 2rem
+  font-size: .8125rem
   +media-breakpoint-up(md)
-    font-size: .875rem
+    margin-bottom: 2rem
   +media-breakpoint-down(sm)
-    font-size: .8125rem
-    +margin(horizontal, 1rem)
+    margin-bottom: 1.5rem

--- a/app/assets/stylesheets/mixins/_short-text-style.sass
+++ b/app/assets/stylesheets/mixins/_short-text-style.sass
@@ -4,7 +4,7 @@
   >*:last-child
     margin-bottom: 0
   p
-    +text-block(1em 1.6 0 1em)
+    +text-block(1em 1.6 0 .75em)
   li
     +text-block(1em 1.6 0 .125em)
   a

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,8 +40,10 @@ class UsersController < ApplicationController
         return false
       end
 
-      customer = Card.create(@user, params[:stripeToken], params[:authenticity_token])
-      subscription = Subscription.create(customer["id"], params[:authenticity_token] + "-subscription")
+      token = params[:authenticity_token] || SecureRandom.uuid
+
+      customer = Card.create(@user, params[:stripeToken], token)
+      subscription = Subscription.create(customer["id"], "#{token}-subscription")
 
       @user.customer_id = customer["id"]
       @user.subscription_id = subscription["id"]

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  if (!document.querySelector('body.card-new,body.card-edit')) {
+  if (!document.querySelector('body.users-new,body.users-create,body.card-new,body.card-edit')) {
     return null
   }
 
@@ -34,9 +34,12 @@ document.addEventListener('DOMContentLoaded', () => {
   // Add an instance of the card Element into the `card-element` <div>.
   card.mount('#card-element')
 
+  var submitButton = document.getElementById("user_submit");
+
   // Handle real-time validation errors from the card Element.
   card.addEventListener('change', function (event) {
     var displayError = document.getElementById('card-errors')
+    submitButton.disabled = false;
     if (event.error) {
       displayError.textContent = event.error.message
     } else {

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -34,12 +34,12 @@ document.addEventListener('DOMContentLoaded', () => {
   // Add an instance of the card Element into the `card-element` <div>.
   card.mount('#card-element')
 
-  var submitButton = document.getElementById("user_submit");
+  var submitButton = document.getElementById('user_submit')
 
   // Handle real-time validation errors from the card Element.
   card.addEventListener('change', function (event) {
     var displayError = document.getElementById('card-errors')
-    submitButton.disabled = false;
+    submitButton.disabled = false
     if (event.error) {
       displayError.textContent = event.error.message
     } else {

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class Card
-  def self.create(user, card_token)
-    Stripe::Customer.create(
+  def self.create(user, card_token, idempotency_key = SecureRandom.uuid)
+    Stripe::Customer.create({
       email: user.email,
       source: card_token
-    )
+    }, {
+      idempotency_key: idempotency_key
+    })
   end
 
   def self.update(customer_id, card_token)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module Subscription
-  def self.create(customer_id)
-    Stripe::Subscription.create(
+  def self.create(customer_id, idempotency_key = SecureRandom.uuid)
+    Stripe::Subscription.create({
       customer: customer_id,
       trial_end: 3.days.since.to_i,
       items: [{ plan: Plan.standard_plan.id }],
-    )
+    }, {
+      idempotency_key: idempotency_key
+    })
   end
 
   def self.destroy(subscription_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -269,7 +269,7 @@ SQL
   end
 
   def student?
-    !admin? && !adviser? && !mentor?
+    !admin? && !adviser? && !mentor? && !trainee?
   end
 
   def staff?

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,8 +1,11 @@
-= form_with model: user, url: url, local: true, html: { name: "user", autocomplete: "address-line3" } do |f|
+- if from == :new
+  = javascript_include_tag "https://js.stripe.com/v3/"
+= form_with model: user, url: url, local: true, id: "payment-form", html: { name: "user", autocomplete: "address-line3" } do |f|
   = f.hidden_field :adviser
   = f.hidden_field :trainee
   = render "errors", object: user
   .form__items
+
     = render "users/form/login_name", f: f
     = render "users/form/email", f: f, user: user
 
@@ -35,6 +38,9 @@
       h3.form__items-title 以下パスワードを変更する場合のみ入力
       = render "users/form/password", f: f
 
+  - if from == :new && user.student?
+    = render "users/form/card"
+
   - if admin_login?
     .form__items
       h3.form__items-title 以下管理者のみ操作ができます
@@ -49,7 +55,7 @@
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main
-        = f.submit user_submit_label(user, from), class: "a-button is-lg is-warning is-block"
+        = f.submit user_submit_label(user, from), id: "user_submit", class: "a-button is-lg is-warning is-block"
         - if from == :new
           .a-form-help.is-text-align-center
             = link_to "利用規約を確認（別タブで開きます）", tos_path, target: "_blank"

--- a/app/views/users/form/_avatar.html.slim
+++ b/app/views/users/form/_avatar.html.slim
@@ -1,5 +1,5 @@
 .form-item
-  = f.label :avatar, class: "a-label is-required"
+  = f.label :avatar, class: "a-label"
   .form-item-file-input.js-file-input.a-file-input.is-avatar
     label.js-file-input__preview
       - if f.object.avatar.attached?

--- a/app/views/users/form/_card.html.slim
+++ b/app/views/users/form/_card.html.slim
@@ -1,0 +1,11 @@
+.form-item
+  label.a-label(for="card-element") カード番号（対応カードブランド：Visa、Master、Diners、Amex）
+  #card-element.a-text-input
+  #card-errors(role="alert")
+.form-notice
+  p クレジットカード登録日を含む3日間はお試し期間です。お試し期間の間に退会をすれば課金されることはありません。
+  p クレジットカードに関して問題がありましたら #{mail_to "info@fjord.jp"} までお問い合わせください。
+  p
+    | クレジットカード情報は当社のサーバーには保存せず、
+    = link_to "Stripe.com", "https://stripe.com/docs/security/stripe", target: "_blank"
+    | を使用して安全に取り扱っています。

--- a/app/views/users/form/_card.html.slim
+++ b/app/views/users/form/_card.html.slim
@@ -1,11 +1,17 @@
-.form-item
-  label.a-label(for="card-element") カード番号（対応カードブランド：Visa、Master、Diners、Amex）
-  #card-element.a-text-input
-  #card-errors(role="alert")
-.form-notice
-  p クレジットカード登録日を含む3日間はお試し期間です。お試し期間の間に退会をすれば課金されることはありません。
-  p クレジットカードに関して問題がありましたら #{mail_to "info@fjord.jp"} までお問い合わせください。
-  p
-    | クレジットカード情報は当社のサーバーには保存せず、
-    = link_to "Stripe.com", "https://stripe.com/docs/security/stripe", target: "_blank"
-    | を使用して安全に取り扱っています。
+.form__items
+  .form-item
+    label.a-label(for="card-element") カード番号
+    #card-element.a-text-input
+    .a-form-help
+      p
+        | 対応ブランド：Visa、Master、Diners、Amex
+        br
+        | JCBカードは使えません。
+    #card-errors(role="alert")
+    .form-notice
+      p クレジットカード登録日を含む3日間はお試し期間です。お試し期間の間に退会をすれば課金されることはありません。
+      p クレジットカードに関して問題がありましたら #{mail_to "info@fjord.jp"} までお問い合わせください。
+      p
+        | クレジットカード情報は当社のサーバーには保存せず、
+        = link_to "Stripe.com", "https://stripe.com/docs/security/stripe", target: "_blank"
+        | を使用して安全に取り扱っています。

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,9 +2,11 @@
 
 require "test_helper"
 require "supports/login_helper"
+require "supports/stripe_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include LoginHelper
+  include StripeHelper
 
   if ENV["HEADED"]
     driven_by :selenium, using: :chrome

--- a/test/supports/stripe_helper.rb
+++ b/test/supports/stripe_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module StripeHelper
+  def fill_stripe_element(card, exp, cvc, postal)
+    card_iframe = all("iframe")[0]
+
+    within_frame card_iframe do
+      card.chars.each do |piece|
+        find_field("cardnumber").send_keys(piece)
+      end
+
+      exp.chars.each do |piece|
+        find_field("exp-date").send_keys(piece)
+      end
+
+      cvc.chars.each do |piece|
+        find_field("cvc").send_keys(piece)
+      end
+
+      postal.chars.each do |piece|
+        find_field("postal").send_keys(piece)
+      end
+    end
+  end
+end

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -4,6 +4,8 @@ require "application_system_test_case"
 
 class SignUpTest < ApplicationSystemTestCase
   test "sign up" do
+    WebMock.allow_net_connect!
+
     visit "/users/new"
     within "form[name=user]" do
       fill_in "user[login_name]", with: "foo"
@@ -19,7 +21,11 @@ class SignUpTest < ApplicationSystemTestCase
       select "自宅", from: "user[study_place]"
       select "未経験", from: "user[experience]"
     end
+
+    fill_stripe_element("4242 4242 4242 4242", "12 / 21", "111", "11122")
+
     click_button "利用規約に同意して参加する"
+    sleep 1
     assert_text "サインアップメールをお送りしました。メールからサインアップを完了させてください。"
   end
 


### PR DESCRIPTION
<img width="631" alt="スクリーンショット 2019-11-18 18 44 15" src="https://user-images.githubusercontent.com/16577/69041800-73c32480-0a33-11ea-921e-36c2368b5792.png">

旧カード登録画面は、カード未登録の人がいなくなってから削除する。