### PR TITLE
プラクティス詳細ページに同じカテゴリーのプラクティスへのリンクを追加

### DIFF
--- a/app/assets/stylesheets/blocks/practice/_practice-content.sass
+++ b/app/assets/stylesheets/blocks/practice/_practice-content.sass
@@ -1,9 +1,15 @@
 .practice-contents
-  max-width: 100%
-  width: 50rem
+  max-width: 58rem
   +margin(horizontal, auto)
+  +position(relative)
+  display: flex
+  justify-content: space-between
+  align-items: flex-start
   &:not(:first-child)
     margin-top: 2rem
+
+.practice-contents__inner
+  flex: 100
 
 .practice-contents__header
   border-bottom: solid 1px $background-shade

--- a/app/assets/stylesheets/blocks/shared/_page-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_page-nav.sass
@@ -6,29 +6,46 @@
   width: 12rem
   border: solid 1px #dadada
   border-radius: .25rem
-  opacity: .8
   transition: opacity .2s ease-in
   margin-left: 1.5rem
-  &:hover
-    opacity: 1
   +media-breakpoint-down(sm)
     display: none
+
+.page-nav__header
+  border-bottom: solid 1px $border
+
+.page-nav__title
+  +text-block(.875rem 1.4, 600)
+
+.page-nav__title-link
+  justify-content: center
+  align-items: center
+  height: 2rem
+  +flex-link
+  color: $default-text
 
 .page-nav__items
   max-height: calc(100vh - .25rem)
   overflow-y: auto
 
 .page-nav__item
-  border-bottom: solid 1px #e6e6e6
+  border-bottom: solid 1px $border
   &:last-child
     border-bottom: none
 
 .page-nav__item-link
   padding: .375rem .75rem
-  +text-block(.8125rem 1.45, block $muted-text)
+  +text-block(.8125rem 1.5, block $muted-text)
   +block-link
-  transition: all .2s ease-in
+  transition: all .1s ease-in
   background-color: transparent
+  .page-nav__item:last-child &
+    +border-radius(bottom, .25rem)
   &:hover
     color: $main
-    background-color: #fff4d5
+    text-decoration: underline
+  &.is-current
+    pointer-events: none
+    font-weight: 600
+    background-color: $main
+    color: $reversal-text

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -7,6 +7,7 @@ class PracticesController < ApplicationController
   before_action :set_practice, only: %w(show edit update destroy sort)
 
   def show
+    @category = @practice.category
   end
 
   def new

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -40,5 +40,5 @@ header.page-header
           - @categories.each do |category|
             - if category.practices.present?
               li.page-nav__item
-                a.page-nav__item-link(data-scroll href="#category-#{category.id}")
+                a.page-nav__item-link(href="#category-#{category.id}")
                   = category.name

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -24,70 +24,74 @@ header.page-header
 .page-body
   .container
     .practice-contents
-      header.practice-contents__header
-        h1.practice-contents__title
-          = @practice.title
-      section.practice-content.a-card
-        header.practice-content__header.card-header
-          h2.practice-content__title
-            = Practice.human_attribute_name :description
-        .practice-content__body.is-practice
-          .js-markdown-view.js-target-blank.is-long-text
-            = @practice.description
-        footer.card-footer
-          .card-footer-actions
-            ul.card-footer-actions__items
-              li.card-footer-actions__item
-                = link_to new_question_path, class: "a-button is-md is-primary is-block" do
-                  i.fas.fa-question-circle
-                  | 質問する
-
-      section.practice-content.a-card
-        header.practice-content__header.card-header
-          h2.practice-content__title
-            = Practice.human_attribute_name :goal
-        .practice-content__body.is-goal
-          .js-markdown-view.js-target-blank.is-long-text
-            = @practice.goal
-          - if !current_user.adviser? && @practice.open_product?
-            .practice-content__body-alert
-              p
-                | このプラクティスは、OKをもらっていなくても他の人の提出物を閲覧できます。
-                = link_to practice_products_path(@practice) do
-                  | 他の人の提出物
-                | も参考にしてください。
-        footer.card-footer
-          #js-learning(data-practice-id="#{@practice.id}")
-          - if @practice.submission
-            .card-footer__description
-              | 提出物を作成し提出し、メンターから確認をもらったら
-              br
-              | このプラクティスを完了にしてください。
-          - else
-            .card-footer__description
-              | このプラクティスに提出物のチェックは必要ありません。
-              br
-              | 終了条件をクリアしたら完了にしてください。
-
-      section.practice-content.a-card
-        = @category.name
-        ul
-          - @category.practices.each do |practice|
-            li
-              = link_to practice.title, practice_path(practice), class: "#{@practice == practice ? "is-current" : ""}"
-
-      - if current_user.admin?
+      .practice-contents__inner
+        header.practice-contents__header
+          h1.practice-contents__title
+            = @practice.title
         section.practice-content.a-card
           header.practice-content__header.card-header
-            h2.practice-content__title 管理者メニュー
+            h2.practice-content__title
+              = Practice.human_attribute_name :description
+          .practice-content__body.is-practice
+            .js-markdown-view.js-target-blank.is-long-text
+              = @practice.description
           footer.card-footer
             .card-footer-actions
               ul.card-footer-actions__items
                 li.card-footer-actions__item
-                  = link_to edit_practice_path(@practice), class: "a-button is-md is-primary is-block" do
-                    i.fas.fa-pen
-                    | 編集
-                li.card-footer-actions__item
-                  = link_to practice_path(@practice), data: { confirm: "本当によろしいですか？" }, method: :delete, class: "a-button is-md is-danger is-block" do
-                    i.fas.fa-trash-alt
-                    | 削除
+                  = link_to new_question_path, class: "a-button is-md is-primary is-block" do
+                    i.fas.fa-question-circle
+                    | 質問する
+
+        section.practice-content.a-card
+          header.practice-content__header.card-header
+            h2.practice-content__title
+              = Practice.human_attribute_name :goal
+          .practice-content__body.is-goal
+            .js-markdown-view.js-target-blank.is-long-text
+              = @practice.goal
+            - if !current_user.adviser? && @practice.open_product?
+              .practice-content__body-alert
+                p
+                  | このプラクティスは、OKをもらっていなくても他の人の提出物を閲覧できます。
+                  = link_to practice_products_path(@practice) do
+                    | 他の人の提出物
+                  | も参考にしてください。
+          footer.card-footer
+            #js-learning(data-practice-id="#{@practice.id}")
+            - if @practice.submission
+              .card-footer__description
+                | 提出物を作成し提出し、メンターから確認をもらったら
+                br
+                | このプラクティスを完了にしてください。
+            - else
+              .card-footer__description
+                | このプラクティスに提出物のチェックは必要ありません。
+                br
+                | 終了条件をクリアしたら完了にしてください。
+
+        - if current_user.admin?
+          section.practice-content.a-card
+            header.practice-content__header.card-header
+              h2.practice-content__title 管理者メニュー
+            footer.card-footer
+              .card-footer-actions
+                ul.card-footer-actions__items
+                  li.card-footer-actions__item
+                    = link_to edit_practice_path(@practice), class: "a-button is-md is-primary is-block" do
+                      i.fas.fa-pen
+                      | 編集
+                  li.card-footer-actions__item
+                    = link_to practice_path(@practice), data: { confirm: "本当によろしいですか？" }, method: :delete, class: "a-button is-md is-danger is-block" do
+                      i.fas.fa-trash-alt
+                      | 削除
+
+      nav.page-nav
+        header.page-nav__header
+          h2.page-nav__title
+            = link_to course_practices_path(current_user.course, anchor: "category-#{@category.id}"), class: "page-nav__title-link" do
+              = @category.name
+        ul.page-nav__items
+          - @category.practices.each do |practice|
+            li.page-nav__item
+              = link_to practice.title, practice_path(practice), class: "page-nav__item-link #{@practice == practice ? "is-current" : ""}"

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -69,6 +69,13 @@ header.page-header
               br
               | 終了条件をクリアしたら完了にしてください。
 
+      section.practice-content.a-card
+        = @category.name
+        ul
+          - @category.practices.each do |practice|
+            li
+              = link_to practice.title, practice_path(practice), class: "#{@practice == practice ? "is-current" : ""}"
+
       - if current_user.admin?
         section.practice-content.a-card
           header.practice-content__header.card-header

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -9,6 +9,16 @@ class PracticesTest < ApplicationSystemTestCase
     assert_equal "OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
+  test "show link to all practices with same category" do
+    login_user "hatsuno", "testtest"
+    practice = practices(:practice_1)
+    category = practice.category
+    visit "/practices/#{practice.id}"
+    category.practices.each do |practice|
+      assert has_link? practice.title
+    end
+  end
+
   test "finish a practice" do
     login_user "komagata", "testtest"
 


### PR DESCRIPTION
Ref: #965 

## 概要

プラクティス詳細ページに、そのプラクティスと同じカテゴリーに属する別のプラクティスへのリンクのリストを追加。

リンクのリストには、閲覧中のプラクティスページのリンクも含まれている。
他のリンクと区別するために、閲覧中のプラクティスリンクに`is-current`クラス属性を付与。(振り返りミーティング内でつけておいてほしいとの指示を頂きました。)

- [x] 同カテゴリのプラクティスへのリンクをプラクティス個別ページに追加
- [x] テストを作成