### PR TITLE
ユーザー登録画面と編集画面でヘルプテキストの表示を分岐するようにしました

### DIFF
--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -32,12 +32,12 @@
 
   - else
     .form__items
-      = render "users/form/password", f: f
+      = render "users/form/password", f: f, is_register: true
 
   - if from == :edit
     .form__items
       h3.form__items-title 以下パスワードを変更する場合のみ入力
-      = render "users/form/password", f: f
+      = render "users/form/password", f: f, is_register: false
 
   - if from == :new && user.student?
     = render "users/form/card"

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -32,12 +32,12 @@
 
   - else
     .form__items
-      = render "users/form/password", f: f, is_register: true
+      = render "users/form/password", f: f, from: from
 
   - if from == :edit
     .form__items
       h3.form__items-title 以下パスワードを変更する場合のみ入力
-      = render "users/form/password", f: f, is_register: false
+      = render "users/form/password", f: f, from: from
 
   - if from == :new && user.student?
     = render "users/form/card"

--- a/app/views/users/form/_password.html.slim
+++ b/app/views/users/form/_password.html.slim
@@ -1,10 +1,10 @@
 .form-item
-  = f.label :password, class: is_register ? "a-label is-required" : "a-label"
+  = f.label :password, class: from == :new ? "a-label is-required" : "a-label"
   = f.password_field :password, class: "a-text-input", autocomplete: "address-line3"
   .a-form-help
-    p = (is_register ? "パスワードを入力してください。" : "パスワードを変更する場合のみ入力してください。")
+    p = (from == :new ? "パスワードを入力してください。" : "パスワードを変更する場合のみ入力してください。")
 .form-item
-  = f.label :password_confirmation, class: is_register ? "a-label is-required" : "a-label"
+  = f.label :password_confirmation, class: from == :new ? "a-label is-required" : "a-label"
   = f.password_field :password_confirmation, class: "a-text-input", autocomplete: "address-line3"
   .a-form-help
     p パスワードをもう一度入力してください。

--- a/app/views/users/form/_password.html.slim
+++ b/app/views/users/form/_password.html.slim
@@ -1,10 +1,10 @@
 .form-item
-  = f.label :password, class: "a-label is-required"
+  = f.label :password, class: is_register ? 'a-label is-required' : 'a-label'
   = f.password_field :password, class: "a-text-input", autocomplete: "address-line3"
   .a-form-help
-    p パスワードを変更する場合のみ入力してください。
+    p= (is_register ? 'パスワードを入力してください。' : 'パスワードを変更する場合のみ入力してください。')
 .form-item
-  = f.label :password_confirmation, class: "a-label is-required"
+  = f.label :password_confirmation, class: is_register ? 'a-label is-required' : 'a-label'
   = f.password_field :password_confirmation, class: "a-text-input", autocomplete: "address-line3"
   .a-form-help
-    p パスワードをもう一度入力。
+    p パスワードをもう一度入力してください。

--- a/app/views/users/form/_password.html.slim
+++ b/app/views/users/form/_password.html.slim
@@ -1,10 +1,10 @@
 .form-item
-  = f.label :password, class: is_register ? 'a-label is-required' : 'a-label'
+  = f.label :password, class: is_register ? "a-label is-required" : "a-label"
   = f.password_field :password, class: "a-text-input", autocomplete: "address-line3"
   .a-form-help
-    p= (is_register ? 'パスワードを入力してください。' : 'パスワードを変更する場合のみ入力してください。')
+    p = (is_register ? "パスワードを入力してください。" : "パスワードを変更する場合のみ入力してください。")
 .form-item
-  = f.label :password_confirmation, class: is_register ? 'a-label is-required' : 'a-label'
+  = f.label :password_confirmation, class: is_register ? "a-label is-required" : "a-label"
   = f.password_field :password_confirmation, class: "a-text-input", autocomplete: "address-line3"
   .a-form-help
     p パスワードをもう一度入力してください。


### PR DESCRIPTION
ref: https://github.com/fjordllc/bootcamp/issues/1251

|ユーザー登録画面<br> `/users/new` |ユーザー編集画面<br> `/current_user/edit`|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/24952964/69430202-6d58e380-0d78-11ea-8d9e-9921f79f3fb1.png) | ![image](https://user-images.githubusercontent.com/24952964/69430062-4c908e00-0d78-11ea-8e8b-d674ea8bd9af.png) |
