### PR TITLE
日報の学習時間が2重に登録されてしまうバグとその日の学習時間の合計が24時間を超えてしまうバグを修正

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -72,7 +72,7 @@ class ReportsController < ApplicationController
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
     check_noticeable
-    if @report.update(report_params)
+    if @report.save
       notify_to_slack(@report) if @noticeable
       redirect_to redirect_url(@report), notice: notice_message(@report)
     else


### PR DESCRIPTION
Ref: #1267 #1194 #1260 

## 学習時間が2重に追加されるバグ

### 再現した手順

1. 日報を新規作成して保存
1. 内容修正ボタンを押下し、学習時間を追加してupdate
1. 追加した学習時間が2重に登録される

### 原因

日報修正時に新しく学習時間を追加して更新すると、ReportsController#update内の`@report.assign_attributes(report_params)`と`@report.update(report_params)`で2重に@reportに関連するLearningTimeのインスタンスが作成/保存されていた

## 学習時間が入力した時間と合わない(24時間を超えて表示される)バグ

### 再現した手順

1. 日報を新規作成する際に、学習時間を開始時間 > 終了時間にして保存
1. 内容修正ボタンを押下し、先程の学習時間を開始時間 < 終了時間にupdate
1. 1日の学習時間が24時間を超えて表示される

### 原因

日報のcreate時には`canonicalize_leaning_times`で、送信された学習時間が適切になるように修正をしているが、update時は修正をしているものの最終的には`report_params`で更新してしまっている

## 解決策

両方のバグともにReportsContoroller#update内でのデータの保存方法に問題があると考え、`update(report_params)`ではなく、`save`メソッドを利用するように修正した。