### PR TITLE
ユーザー名ホバーでtooltipに氏名を表示

### DIFF
--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -24,7 +24,7 @@ header.page-header
             .thread-header__emotion
               = Report.faces[@report.emotion]
           .thread-header__upper-side
-            = link_to @report.user, class: "thread-header__author" do
+            = link_to @report.user, class: "thread-header__author", title: @report.user.full_name do
               = @report.user.login_name
             .thread-header__date
               | #{l @report.reported_on} の日報


### PR DESCRIPTION
### issue
https://github.com/fjordllc/bootcamp/issues/1216

### 変更点
ユーザー名ホバーでtooltipに氏名を表示するようにしました。
軽微な修正のため、テストは追加していません。