### PR TITLE
マイグレーションリセットしたときに例外が発生していたのを修正

### DIFF
--- a/db/migrate/20151022011615_create_reports.rb
+++ b/db/migrate/20151022011615_create_reports.rb
@@ -6,8 +6,6 @@ class CreateReports < ActiveRecord::Migration[4.2]
       t.integer :user_id, null: false
       t.string :title, null: false, limit: 255
       t.text :description, null: true
-      t.datetime :created_at
-      t.datetime :updated_at
       t.timestamps
     end
   end

--- a/db/migrate/20161212065808_create_contacts.rb
+++ b/db/migrate/20161212065808_create_contacts.rb
@@ -19,8 +19,6 @@ class CreateContacts < ActiveRecord::Migration[4.2]
       t.string :github_account
       t.text :application_reason,           null: false
       t.boolean :user_policy_agreed,        default: false, null: false
-      t.datetime :created_at
-      t.datetime :updated_at
 
       t.timestamps
     end


### PR DESCRIPTION
## 概要

Rails6にバージョンアップしたことで、マイグレーションファイルにカラム名が重複して記述されているときに例外が発生するようになり、マイグレーションリセットができなくなってしまっていたのを修正した。

## 発生したエラー

```
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

you can't define an already defined column 'created_at'.
/Users/akira/RubymineProjects/bootcamp/db/migrate/20151022011615_create_reports.rb:11:in `block in change'
/Users/akira/RubymineProjects/bootcamp/db/migrate/20151022011615_create_reports.rb:5:in `change'
bin/rails:6:in `<main>'

Caused by:
ArgumentError: you can't define an already defined column 'created_at'.
/Users/akira/RubymineProjects/bootcamp/db/migrate/20151022011615_create_reports.rb:11:in `block in change'
/Users/akira/RubymineProjects/bootcamp/db/migrate/20151022011615_create_reports.rb:5:in `change'
bin/rails:6:in `<main>'
Tasks: TOP => db:migrate:reset => db:migrate

```

## 参考

[Ruby on Rails 6.0 リリースノート - Rails ガイド](https://railsguides.jp/6_0_release_notes.html#active-record-%E4%B8%BB%E3%81%AA%E5%A4%89%E6%9B%B4)
> マイグレーションでカラム定義が重複した場合に例外をraiseするようになった([Pull Request](https://github.com/rails/rails/pull/33029))