### PR TITLE
イベント出欠席管理機能を作成

### DIFF
--- a/app/controllers/events/participations_controller.rb
+++ b/app/controllers/events/participations_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Events::ParticipationsController < ApplicationController
+  before_action :set_event
+
+  def create
+    if @event.participations.create(user: current_user)
+      redirect_to event_path(@event), notice: "出席登録が完了しました。"
+    end
+  end
+
+  def destroy
+    @event.participations.find_by(user_id: current_user.id).destroy
+    redirect_to event_path(@event), notice: "出席をキャンセルしました。"
+  end
+
+  private
+    def set_event
+      @event = Event.find(params[:event_id])
+    end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class EventsController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,7 +6,10 @@ class EventsController < ApplicationController
   before_action :set_event, only: %i(show edit update destroy)
   before_action :set_footprints, only: %i(show)
   def index
-    @events = Event.with_avatar.order(created_at: :desc).page(params[:page])
+    @events = Event.with_avatar
+                   .preload(:comments)
+                   .order(created_at: :desc)
+                   .page(params[:page])
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,24 +1,71 @@
 # frozen_string_literal: true
 
 class EventsController < ApplicationController
+  before_action :require_login
+  before_action :require_admin_login, except: %i(index show)
+  before_action :set_event, only: %i(show edit update destroy)
+  before_action :set_footprints, only: %i(show)
   def index
+    @events = Event.with_avatar.order(created_at: :desc).page(params[:page])
   end
 
   def show
+    footprint!
   end
 
   def new
+    @event = Event.new(open_start_at: Time.current.beginning_of_minute)
   end
 
   def create
+    @event = Event.new(event_params)
+    @event.user_id = current_user.id
+    if @event.save
+      redirect_to @event, notice: "イベントを作成しました。"
+    else
+      render :new
+    end
   end
 
   def edit
   end
 
   def update
+    if @event.update(event_params)
+      redirect_to @event, notice: "イベントを更新しました。"
+    else
+      render :edit
+    end
   end
 
   def destroy
+    @event.destroy
+    redirect_to events_path, notice: "イベントを削除しました。"
   end
+
+  private
+    def event_params
+      params.require(:event).permit(
+        :title,
+        :description,
+        :location,
+        :capacity,
+        :start_at,
+        :end_at,
+        :open_start_at,
+        :open_end_at
+      )
+    end
+
+    def set_event
+      @event = Event.find(params[:id])
+    end
+
+    def set_footprints
+      @footprints = @event.footprints.with_avatar.order(created_at: :desc)
+    end
+
+    def footprint!
+      @event.footprints.where(user: current_user).first_or_create if @event.user != current_user
+    end
 end

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module EventDecorator
+  def period
+    if start_at.to_date == end_at.to_date
+      "#{l start_at} 〜 #{l end_at, format: :time_only}"
+    else
+      "#{l start_at} 〜 #{l end_at}"
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Event < ApplicationRecord
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -47,8 +47,12 @@ class Event < ApplicationRecord
     Time.current > open_end_at && Time.current < end_at
   end
 
-  def has_open_period?
-    open_start_at? && open_end_at?
+  def participants
+    fcfs.limit(capacity)
+  end
+
+  def waitlist
+    fcfs - participants
   end
 
   private
@@ -78,5 +82,9 @@ class Event < ApplicationRecord
       if diff < 0
         errors.add(:open_end_at, ": 募集終了日時は終了日時よりも前の日時にしてください。")
       end
+    end
+
+    def fcfs
+      users.order("participations.created_at asc")
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -48,11 +48,11 @@ class Event < ApplicationRecord
   end
 
   def participants
-    fcfs.limit(capacity)
+    first_come_first_served.limit(capacity)
   end
 
   def waitlist
-    fcfs - participants
+    first_come_first_served - participants
   end
 
   private
@@ -84,7 +84,7 @@ class Event < ApplicationRecord
       end
     end
 
-    def fcfs
+    def first_come_first_served
       users.order("participations.created_at asc")
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,82 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
+  include WithAvatar
+  include Commentable
+  include Footprintable
+  include Reactionable
+
+  validates :title, presence: true
+  validates :description, presence: true
+  validates :location, presence: true
+  validates :capacity, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :start_at, presence: true
+  validates :end_at, presence: true
+  validates :open_start_at, presence: true
+  validates :open_end_at, presence: true
+
+  with_options if: -> { start_at && end_at } do
+    validate :end_at_be_greater_than_start_at
+  end
+
+  with_options if: -> { open_start_at && open_end_at } do
+    validate :open_end_at_be_greater_than_open_start_at
+  end
+
+  with_options if: -> { open_start_at && start_at } do
+    validate :open_start_at_be_less_than_start_at
+  end
+
+  with_options if: -> { open_end_at && end_at } do
+    validate :open_end_at_be_less_than_end_at
+  end
+
+  belongs_to :user
+  has_many :participations, dependent: :destroy
+  has_many :users, through: :participations
+
+  def is_opening?
+    Time.current.between?(open_start_at, open_end_at)
+  end
+
+  def before_opening?
+    Time.current < open_start_at
+  end
+
+  def is_closing?
+    Time.current > open_end_at && Time.current < end_at
+  end
+
+  def has_open_period?
+    open_start_at? && open_end_at?
+  end
+
+  private
+    def end_at_be_greater_than_start_at
+      diff = end_at - start_at
+      if diff <= 0
+        errors.add(:end_at, ": 終了日時は開始日時よりも後の日時にしてください。")
+      end
+    end
+
+    def open_end_at_be_greater_than_open_start_at
+      diff = open_end_at - open_start_at
+      if diff <= 0
+        errors.add(:open_end_at, ": 募集終了日時は募集開始日時よりも後の日時にしてください。")
+      end
+    end
+
+    def open_start_at_be_less_than_start_at
+      diff = start_at - open_start_at
+      if diff <= 0
+        errors.add(:open_start_at, ": 募集開始日時は開始日時よりも前の日時にしてください。")
+      end
+    end
+
+    def open_end_at_be_less_than_end_at
+      diff = end_at - open_end_at
+      if diff < 0
+        errors.add(:open_end_at, ": 募集終了日時は終了日時よりも前の日時にしてください。")
+      end
+    end
 end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,0 +1,4 @@
+class Participation < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Participation < ApplicationRecord
   belongs_to :user
   belongs_to :event

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
 
   belongs_to :company, required: false
   belongs_to :course
+  has_many :events,        dependent: :destroy
   has_many :learnings
   has_many :borrowings
   has_many :comments,      dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,6 @@ class User < ActiveRecord::Base
 
   belongs_to :company, required: false
   belongs_to :course
-  has_many :events,        dependent: :destroy
   has_many :learnings
   has_many :borrowings
   has_many :comments,      dependent: :destroy
@@ -49,6 +48,12 @@ class User < ActiveRecord::Base
   has_many :reactions,     dependent: :destroy
   has_many :works,         dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :events,        dependent: :destroy
+  has_many :participations, dependent: :destroy
+
+  has_many :participate_events,
+    through: :participations,
+    source: :event
 
   has_many :send_notifications,
     class_name:  "Notification",
@@ -328,6 +333,10 @@ SQL
 
   def generation
     (created_at.year - 2013) * 4 + (created_at.month + 2) / 3
+  end
+
+  def participating?(event)
+    participate_events.include?(event)
   end
 
   private

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -66,6 +66,11 @@ nav.global-nav
             .global-nav-links__link-icon
               i.fas.fa-users
             .global-nav-links__link-label ユーザー
+        li.global-nav-links__item
+          = link_to events_path, class: "global-nav-links__link #{current_link /^events/}" do
+            .global-nav-links__link-icon
+
+            .global-nav-links__link-label イベント
         li.global-nav-links__item.is-hidden-md-up
           = link_to courses_path, class: "global-nav-links__link #{current_link /^courses-index/}" do
             .global-nav-links__link-icon

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -23,6 +23,7 @@
           | 募集期間 : #{l event.open_start_at} 〜 #{l event.open_end_at}
       .thread__description.js-target-blank.is-long-text.js-markdown-view
         = event.description
+      = render "events/participation", event: event
       = render "reactions/reactions", reactionable: event
       - if admin_login? || event.user_id == current_user.id
         .card-footer
@@ -40,6 +41,20 @@
                 = link_to event_path(event), data: { confirm: "本当によろしいですか？" }, method: :delete, class: "card-footer-actions__action a-button is-md is-danger is-block" do
                   i.fas.fa-trash-alt#delete
                   | 削除
+    .participants
+      | 参加者
+      ul.footprints__items
+        - event.participants.each do |participant|
+          li.footprints-item
+            = link_to participant do
+              = image_tag participant.avatar_url, class: "footprints-item__checker-icon is-#{participant.login_name} is-#{participant.role}", alt: participant.login_name
+    .waitlist
+      | 補欠者
+      ul.footprints__items
+        - event.waitlist.each do |wait_user|
+          li.footprints-item
+            = link_to wait_user do
+              = image_tag wait_user.avatar_url, class: "footprints-item__checker-icon is-#{wait_user.login_name} is-#{wait_user.role}", alt: wait_user.login_name
 
   = link_to event.user, itempro: "url", class: "thread__author-link" do
     = image_tag event.user.avatar_url, class: "thread__author-icon is-#{event.user.role}"

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -1,0 +1,45 @@
+.thread
+  .thread__inner.a-card
+    header.thread-header
+      h1.thread-header__title
+        = event.title
+
+      .thread-header__lower-side
+        .thread-header__lower-side-author-name
+          = link_to event.user, class: "thread-header__lower-side-author-name-link" do
+            = event.user.login_name
+        time.thread-header__lower-side-created-at(datetime="#{event.created_at.to_datetime}" pubdate="pubdate")
+          | 書いた日 : #{l event.updated_at}
+
+    .thread__body
+      ul
+        li
+          | 会場 :  #{event.location}
+        li
+          | 定員 : #{event.capacity}名
+        li
+          | 開催日時 : #{event.period}
+        li
+          | 募集期間 : #{l event.open_start_at} 〜 #{l event.open_end_at}
+      .thread__description.js-target-blank.is-long-text.js-markdown-view
+        = event.description
+      = render "reactions/reactions", reactionable: event
+      - if admin_login? || event.user_id == current_user.id
+        .card-footer
+          .card-footer-actions
+            ul.card-footer-actions__items
+              li.card-footer-actions__item
+                = link_to edit_event_path(event), class: "card-footer-actions__action a-button is-md is-primary is-block", id: "js-shortcut-edit" do
+                  i.fas.fa-pen#new
+                  | 内容修正
+              li.card-footer-actions__item
+                = link_to new_event_path(id: event), class: "card-footer-actions__action a-button is-md is-warning is-block" do
+                  i.fas.fa-copy#copy
+                  | コピー
+              li.card-footer-actions__item
+                = link_to event_path(event), data: { confirm: "本当によろしいですか？" }, method: :delete, class: "card-footer-actions__action a-button is-md is-danger is-block" do
+                  i.fas.fa-trash-alt#delete
+                  | 削除
+
+  = link_to event.user, itempro: "url", class: "thread__author-link" do
+    = image_tag event.user.avatar_url, class: "thread__author-icon is-#{event.user.role}"

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -1,0 +1,25 @@
+.thread-list-item
+  .thread-list-item__inner
+    .thread-list-item__author
+      = image_tag event.user.avatar_url, class: "thread-list-item__author-icon "
+    header.thread-list-item__header
+      h2.thread-list-item__title(itemprop="name")
+        = link_to event, itempro: "url", class: "thread-list-item__title-link" do
+          = event.title
+      - if admin_login? || current_user == event.user
+        .thread-list-item__actions
+          = link_to edit_event_path(event), class: "thread-list-item__actions-link" do
+            i.fas.fa-pen
+          = link_to new_event_path(id: event), class: "thread-list-item__actions-link" do
+            i.fas.fa-copy
+          = link_to event_path(event), data: { confirm: "本当によろしいですか？" }, method: :delete, class: "thread-list-item__actions-link" do
+            i.fas.fa-trash-alt
+    .thread-list-item-meta
+      time.thread-list-item-meta__updated-at(datetime="#{event.updated_at.to_datetime}" pubdate="pubdate")
+        = l event.updated_at
+      - if event.comments.any?
+        .thread-list-item-meta__comment-count
+          .thread-list-item-meta__comment-count-label
+            i.fas.fa-comment
+          .thread-list-item-meta__comment-count-value
+            = event.comments.size

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -1,0 +1,47 @@
+= render "errors", object: event
+= form_with model: event, local: true do |f|
+  .form__items
+    .form__items-inner
+      .form-item
+        = f.label :title, class: "a-label"
+        = f.text_field :title, class: "a-text-input js-warning-form"
+      .form-item
+        = f.label :location, class: "a-label"
+        = f.text_field :location, class: "a-text-input js-warning-form"
+      .form-item
+        = f.label :capacity, class: "a-label"
+        = f.text_field :capacity, class: "a-text-input js-warning-form"
+      .form-item
+        = f.label :start_at, class: "a-label"
+        = f.datetime_field :start_at, class: "a-text-input js-warning-form"
+      .form-item
+        = f.label :end_at, class: "a-label"
+        = f.datetime_field :end_at, class: "a-text-input js-warning-form"
+      .form-item
+        = f.label :open_start_at, class: "a-label"
+        = f.datetime_field :open_start_at, class: "a-text-input js-warning-form"
+      div
+        = f.label :open_end_at, class: "a-label"
+        = f.datetime_field :open_end_at, class: "a-text-input js-warning-form"
+    .form-item
+      .row.js-markdown-parent
+        .col-md-6.col-xs-12
+          = f.label :description, class: "a-label"
+          = f.text_area :description, class: "a-text-input js-warning-form js-markdown markdown-form__text-area", data: { "preview": ".js-preview" }
+        .col-md-6.col-xs-12
+          .a-label
+            | プレビュー
+          .js-preview.is-long-text.markdown-form__preview
+
+  .form-actions
+    ul.form-actions__items
+      li.form-actions__item.is-main.is-help
+        - if event.new_record?
+          = f.submit "作成", class: "a-button is-lg is-warning is-block", id: "js-shortcut-submit"
+        - else
+          = f.submit "内容変更", class: "a-button is-lg is-warning is-block", id: "js-shortcut-submit"
+      li.form-actions__item
+        - if params[:action] == "new" || params[:action] == "create"
+          = link_to "キャンセル", events_path, class: "a-button is-md is-secondary"
+        - elsif params[:action] == "edit" || params[:action] == "update"
+          = link_to "キャンセル", event_path, class: "a-button is-md is-secondary"

--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -1,0 +1,13 @@
+- if event.is_opening?
+  - if current_user.participating?(event)
+    = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: "イベントの参加をキャンセルします。よろしいですか?" } do
+      | キャンセル
+  - else
+    = link_to event_participations_path(event_id: event), method: :post, data: { confirm: "イベント参加申込をします。よろしいですか?" } do
+      | 参加申込
+- elsif event.before_opening?
+  | 募集開始までお待ち下さい
+- elsif event.is_closing?
+  | 募集受付は終了しました。
+- else
+  | 本イベントは終了しました。

--- a/app/views/events/edit.html.slim
+++ b/app/views/events/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Events#edit
+p Find me in app/views/events/edit.html.slim

--- a/app/views/events/edit.html.slim
+++ b/app/views/events/edit.html.slim
@@ -1,2 +1,11 @@
-h1 Events#edit
-p Find me in app/views/events/edit.html.slim
+- title "イベント編集"
+- content_for(:extra_body_classes, "no-recent-reports")
+
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title = title
+
+.page-body
+  .container
+    = render "form", event: @event

--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -1,0 +1,2 @@
+h1 Events#index
+p Find me in app/views/events/index.html.slim

--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -1,2 +1,21 @@
-h1 Events#index
-p Find me in app/views/events/index.html.slim
+- title "イベント"
+
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      - if admin_login?
+        .page-header-actions
+          .page-header-actions__items
+            .page-header-actions__item
+              = link_to new_event_path, class: "a-button is-md is-warning is-block" do
+                i.fa.fa-plus
+                | イベント作成
+
+.page-body
+  = paginate @events, position: "top"
+  .container
+    .thread-list.a-card
+      = render partial: "events", collection: @events, as: :event
+= paginate @events, position: "bottom"

--- a/app/views/events/new.html.slim
+++ b/app/views/events/new.html.slim
@@ -1,0 +1,2 @@
+h1 Events#new
+p Find me in app/views/events/new.html.slim

--- a/app/views/events/new.html.slim
+++ b/app/views/events/new.html.slim
@@ -1,2 +1,17 @@
-h1 Events#new
-p Find me in app/views/events/new.html.slim
+- title "イベント作成"
+- content_for(:extra_body_classes, "no-recent-reports")
+
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title = title
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+            = link_to events_path, class: "a-button is-md is-secondary is-block" do
+              i.fa.fa-angle-left
+              | イベント一覧へ
+
+.page-body
+  .container
+    = render "form", event: @event

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -1,0 +1,2 @@
+h1 Events#show
+p Find me in app/views/events/show.html.slim

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -1,2 +1,23 @@
-h1 Events#show
-p Find me in app/views/events/show.html.slim
+- title @event.title
+- content_for(:extra_body_classes, "no-recent-reports")
+
+header.page-header
+  .container
+    .page-header__inner
+      h1.page-header__title = title
+      .page-header-actions
+        ul.page-header-actions__items
+          - if admin_login?
+            li.page-header-actions__item
+              = link_to new_event_path, class: "a-button is-md is-warning is-block" do
+                i.fa.fa-plus
+                | イベント作成
+          li.page-header-actions__item
+            = link_to events_path, class: "a-button is-md is-secondary is-block" do
+              | イベント一覧へ
+
+.page-body
+  .container
+    = render "event", event: @event
+    #js-comments(data-commentable-id="#{@event.id}" data-commentable-type="Event" data-current-user-id="#{current_user.id}")
+    = render "footprints/footprints", footprints: @footprints

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,6 +24,7 @@ ja:
       article: ブログ記事
       work: 作品
       book: 書籍
+      event: イベント
     attributes:
       user:
         login_name: ユーザー名
@@ -135,6 +136,15 @@ ja:
         id: ID
         title: タイトル
         isbn: ISBN-13
+      event:
+        title: タイトル
+        description: 詳細
+        location: 会場
+        capacity: 定員
+        start_at: 開始日時
+        end_at: 終了日時
+        open_start_at: 募集開始日時
+        open_end_at: 募集終了日時
     enums:
       user:
         job:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
   resource :inquiry, only: %i(new create)
 
   resources :articles
+  resources :events
   get "articles/tags/:tag", to: "articles#index", as: :tag
 
   get "login" => "user_sessions#new", as: :login

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,9 @@ Rails.application.routes.draw do
   resource :inquiry, only: %i(new create)
 
   resources :articles
-  resources :events
+  resources :events do
+    resources :participations, only: %i(create destroy), controller: "events/participations"
+  end
   get "articles/tags/:tag", to: "articles#index", as: :tag
 
   get "login" => "user_sessions#new", as: :login

--- a/db/migrate/20191210011230_create_events.rb
+++ b/db/migrate/20191210011230_create_events.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :events do |t|
+      t.string :title, null: false
+      t.text :description, null: false
+      t.string :location, null: false
+      t.integer :capacity, null: false
+      t.datetime :start_at, null: false
+      t.datetime :end_at, null: false
+      t.datetime :open_start_at, null: false
+      t.datetime :open_end_at, null: false
+      t.references :user
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191211061812_create_participations.rb
+++ b/db/migrate/20191211061812_create_participations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateParticipations < ActiveRecord::Migration[6.0]
   def change
     create_table :participations do |t|

--- a/db/migrate/20191211061812_create_participations.rb
+++ b/db/migrate/20191211061812_create_participations.rb
@@ -1,0 +1,11 @@
+class CreateParticipations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :participations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :participations, [:user_id, :event_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_082300) do
+ActiveRecord::Schema.define(version: 2019_12_10_011230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,21 @@ ActiveRecord::Schema.define(version: 2019_11_20_082300) do
     t.text "description", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description", null: false
+    t.string "location", null: false
+    t.integer "capacity", null: false
+    t.datetime "start_at", null: false
+    t.datetime "end_at", null: false
+    t.datetime "open_start_at", null: false
+    t.datetime "open_end_at", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_events_on_user_id"
   end
 
   create_table "footprints", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_10_011230) do
+ActiveRecord::Schema.define(version: 2019_12_11_061812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,6 +211,16 @@ ActiveRecord::Schema.define(version: 2019_12_10_011230) do
     t.index ["updated_at"], name: "index_pages_on_updated_at"
   end
 
+  create_table "participations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "event_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_participations_on_event_id"
+    t.index ["user_id", "event_id"], name: "index_participations_on_user_id_and_event_id", unique: true
+    t.index ["user_id"], name: "index_participations_on_user_id"
+  end
+
   create_table "practices", id: :serial, force: :cascade do |t|
     t.string "title", limit: 255, null: false
     t.text "description"
@@ -379,6 +389,8 @@ ActiveRecord::Schema.define(version: 2019_12_10_011230) do
   add_foreign_key "learning_times", "reports"
   add_foreign_key "notifications", "users"
   add_foreign_key "notifications", "users", column: "sender_id"
+  add_foreign_key "participations", "events"
+  add_foreign_key "participations", "users"
   add_foreign_key "products", "practices"
   add_foreign_key "products", "users"
   add_foreign_key "questions", "practices"

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -16,10 +16,10 @@ event_2:
   description: "募集期間中のイベントです。参加申込ができます。補欠者はまだいません。"
   location: "FJORDオフィス"
   capacity: 40
-  start_at: <%= Time.current.beginning_of_minute.next_year - 1.day %>
-  end_at: <%= Time.current.beginning_of_minute.next_year %>
-  open_start_at: <%= Time.current.beginning_of_minute%>
-  open_end_at: <%= Time.current.beginning_of_minute.next_year %>
+  start_at: <%= Time.current.next_year - 1.day %>
+  end_at: <%= Time.current.next_year %>
+  open_start_at: <%= Time.current %>
+  open_end_at: <%= Time.current.next_year %>
   user: komagata
 
 event_3:
@@ -27,10 +27,10 @@ event_3:
   description: "募集期間中のイベントです。参加申込ができます。補欠者がいます。"
   location: "FJORDオフィス"
   capacity: 1
-  start_at: <%= Time.current.beginning_of_minute.next_year - 1.day %>
-  end_at: <%= Time.current.beginning_of_minute.next_year %>
-  open_start_at: <%= Time.current.beginning_of_minute%>
-  open_end_at: <%= Time.current.beginning_of_minute.next_year %>
+  start_at: <%= Time.current.next_year - 1.day %>
+  end_at: <%= Time.current.next_year %>
+  open_start_at: <%= Time.current %>
+  open_end_at: <%= Time.current.next_year %>
   user: komagata
 
 event_4:
@@ -38,10 +38,10 @@ event_4:
   description: "募集期間前のイベントです。"
   location: "FJORDオフィス"
   capacity: 10
-  start_at: <%= Time.current.beginning_of_minute.next_year - 1.hour %>
-  end_at: <%= Time.current.beginning_of_minute.next_year %>
-  open_start_at: <%= Time.current.beginning_of_minute.next_year - 1.day %>
-  open_end_at: <%= Time.current.beginning_of_minute.next_year %>
+  start_at: <%= Time.current.next_year - 1.hour %>
+  end_at: <%= Time.current.next_year %>
+  open_start_at: <%= Time.current.next_year - 1.day %>
+  open_end_at: <%= Time.current.next_year %>
   user: komagata
 
 event_5:
@@ -49,10 +49,10 @@ event_5:
   description: "募集が終了したイベントです。"
   location: "FJORDオフィス"
   capacity: 10
-  start_at: <%= Time.current.beginning_of_minute.next_year - 1.hour %>
-  end_at: <%= Time.current.beginning_of_minute.next_year %>
-  open_start_at: <%= Time.current.beginning_of_minute.yesterday %>
-  open_end_at: <%= Time.current.beginning_of_minute.yesterday + 1.hour %>
+  start_at: <%= Time.current.next_year - 1.hour %>
+  end_at: <%= Time.current.next_year %>
+  open_start_at: <%= Time.current.yesterday %>
+  open_end_at: <%= Time.current.yesterday + 1.hour %>
   user: komagata
 
 event_6:

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,7 +1,69 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-#one:
-#  title: MyString
+event_1:
+  title: "ミートアップ"
+  description: "ミートアップを開催します。"
+  location: "FJORDオフィス"
+  capacity: 40
+  start_at: 2019-12-20 10:00
+  end_at: 2019-12-20 12:30
+  open_start_at: 2019-12-10 09:00
+  open_end_at: 2019-12-19 9:00
+  user: komagata
 
-#two:
-#  title: MyString
+event_2:
+  title: "募集期間中のイベント(補欠者なし)"
+  description: "募集期間中のイベントです。参加申込ができます。補欠者はまだいません。"
+  location: "FJORDオフィス"
+  capacity: 40
+  start_at: <%= Time.current.beginning_of_minute.next_year - 1.day %>
+  end_at: <%= Time.current.beginning_of_minute.next_year %>
+  open_start_at: <%= Time.current.beginning_of_minute%>
+  open_end_at: <%= Time.current.beginning_of_minute.next_year %>
+  user: komagata
+
+event_3:
+  title: "募集期間中のイベント(補欠者あり)"
+  description: "募集期間中のイベントです。参加申込ができます。補欠者がいます。"
+  location: "FJORDオフィス"
+  capacity: 1
+  start_at: <%= Time.current.beginning_of_minute.next_year - 1.day %>
+  end_at: <%= Time.current.beginning_of_minute.next_year %>
+  open_start_at: <%= Time.current.beginning_of_minute%>
+  open_end_at: <%= Time.current.beginning_of_minute.next_year %>
+  user: komagata
+
+event_4:
+  title: "募集期間前のイベント"
+  description: "募集期間前のイベントです。"
+  location: "FJORDオフィス"
+  capacity: 10
+  start_at: <%= Time.current.beginning_of_minute.next_year - 1.hour %>
+  end_at: <%= Time.current.beginning_of_minute.next_year %>
+  open_start_at: <%= Time.current.beginning_of_minute.next_year - 1.day %>
+  open_end_at: <%= Time.current.beginning_of_minute.next_year %>
+  user: komagata
+
+event_5:
+  title: "募集期間後のイベント"
+  description: "募集が終了したイベントです。"
+  location: "FJORDオフィス"
+  capacity: 10
+  start_at: <%= Time.current.beginning_of_minute.next_year - 1.hour %>
+  end_at: <%= Time.current.beginning_of_minute.next_year %>
+  open_start_at: <%= Time.current.beginning_of_minute.yesterday %>
+  open_end_at: <%= Time.current.beginning_of_minute.yesterday + 1.hour %>
+  user: komagata
+
+event_6:
+  title: "終了したイベント"
+  description: "終了したイベントです。"
+  location: "FJORDオフィス"
+  capacity: 10
+  start_at: 2019-12-17 10:00:00
+  end_at: 2019-12-17 12:00:00
+  open_start_at: 2019-12-10 9:00
+  open_end_at: 2019-12-16 9:00
+  user: komagata
+
+

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+#one:
+#  title: MyString
+
+#two:
+#  title: MyString

--- a/test/fixtures/participations.yml
+++ b/test/fixtures/participations.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+#one:
+#  user: one
+#  event: one
+
+#two:
+#  user: two
+#  event: two

--- a/test/fixtures/participations.yml
+++ b/test/fixtures/participations.yml
@@ -1,9 +1,11 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+participation_1:
+  user: hatsuno
+  event: event_2
 
-#one:
-#  user: one
-#  event: one
+participation_2:
+  user: hatsuno
+  event: event_3
 
-#two:
-#  user: two
-#  event: two
+participation_3:
+  user: komagata
+  event: event_3

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -7,6 +7,34 @@ class EventTest < ActiveSupport::TestCase
     assert events(:event_2).valid?
   end
 
+  test "is_opening?" do
+    event = events(:event_2)
+    assert event.is_opening?
+  end
+
+  test "before_opening?" do
+    event = events(:event_4)
+    assert event.before_opening?
+  end
+
+  test "is_closing?" do
+    event = events(:event_5)
+    assert event.is_closing?
+  end
+
+  test "participants" do
+    event = events(:event_2)
+    participants = users(:hatsuno)
+    assert_includes event.participants, participants
+  end
+
+  test "waitlist" do
+    event = events(:event_3)
+    waiting_user = users(:kimura)
+    event.participations.create(user: waiting_user)
+    assert_includes event.waitlist, waiting_user
+  end
+
   test "should be invalid when start_at >= end_at" do
     event = events(:event_1)
     event.end_at = event.start_at - 1.hour

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -3,7 +3,31 @@
 require "test_helper"
 
 class EventTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should be valid" do
+    assert events(:event_2).valid?
+  end
+
+  test "should be invalid when start_at >= end_at" do
+    event = events(:event_1)
+    event.end_at = event.start_at - 1.hour
+    assert event.invalid?
+  end
+
+  test "should be invalid when open_start_at >= open_end_at" do
+    event = events(:event_1)
+    event.open_end_at = event.open_start_at - 1.day
+    assert event.invalid?
+  end
+
+  test "should be invalid when open_start_at >= start_at" do
+    event = events(:event_1)
+    event.open_start_at = event.start_at + 1.day
+    assert event.invalid?
+  end
+
+  test "should be invalid when open_end_at > end_at" do
+    event = events(:event_1)
+    event.open_end_at = event.end_at + 1.day
+    assert event.invalid?
+  end
 end

--- a/test/models/participation_test.rb
+++ b/test/models/participation_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ParticipationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/participation_test.rb
+++ b/test/models/participation_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class ParticipationTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -178,10 +178,10 @@ class EventsTest < ApplicationSystemTestCase
     fill_in "event_description", with: "イベントの説明文"
     fill_in "event_capacity", with: 20
     fill_in "event_location", with: "FJORDオフィス"
-    fill_in "event_start_at", with: Time.current.beginning_of_minute.next_day
-    fill_in "event_end_at", with: Time.current.beginning_of_minute.next_day + 2.hour
-    fill_in "event_open_start_at", with: Time.current.beginning_of_minute
-    fill_in "event_open_end_at", with: Time.current.beginning_of_minute + 2.hour
+    fill_in "event_start_at", with: Time.current.next_day
+    fill_in "event_end_at", with: Time.current.next_day + 2.hour
+    fill_in "event_open_start_at", with: Time.current
+    fill_in "event_open_end_at", with: Time.current + 2.hour
     click_button "作成"
     accept_confirm do
       click_link "参加申込"
@@ -205,10 +205,10 @@ class EventsTest < ApplicationSystemTestCase
     fill_in "event_description", with: "イベントの説明文"
     fill_in "event_capacity", with: 1
     fill_in "event_location", with: "FJORDオフィス"
-    fill_in "event_start_at", with: Time.current.beginning_of_minute.next_day
-    fill_in "event_end_at", with: Time.current.beginning_of_minute.next_day + 2.hour
-    fill_in "event_open_start_at", with: Time.current.beginning_of_minute
-    fill_in "event_open_end_at", with: Time.current.beginning_of_minute + 2.hour
+    fill_in "event_start_at", with: Time.current.next_day
+    fill_in "event_end_at", with: Time.current.next_day + 2.hour
+    fill_in "event_open_start_at", with: Time.current
+    fill_in "event_open_end_at", with: Time.current + 2.hour
     click_button "作成"
     accept_confirm do
       click_link "参加申込"
@@ -232,10 +232,10 @@ class EventsTest < ApplicationSystemTestCase
     fill_in "event_description", with: "イベントの説明文"
     fill_in "event_capacity", with: 1
     fill_in "event_location", with: "FJORDオフィス"
-    fill_in "event_start_at", with: Time.current.beginning_of_minute.next_day
-    fill_in "event_end_at", with: Time.current.beginning_of_minute.next_day + 2.hour
-    fill_in "event_open_start_at", with: Time.current.beginning_of_minute
-    fill_in "event_open_end_at", with: Time.current.beginning_of_minute + 2.hour
+    fill_in "event_start_at", with: Time.current.next_day
+    fill_in "event_end_at", with: Time.current.next_day + 2.hour
+    fill_in "event_open_start_at", with: Time.current
+    fill_in "event_open_end_at", with: Time.current + 2.hour
     click_button "作成"
     accept_confirm do
       click_link "参加申込"

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -141,33 +141,26 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test "user can participate in an event" do
-    event = events(:event_1)
+    event = events(:event_2)
     login_user "kimura", "testtest"
     visit event_path(event)
-    travel_to Time.zone.local(2019, 12, 10, 9, 00) do
-      accept_confirm do
-        click_link "参加申込"
-      end
-      assert_difference "event.users.count", 1 do
-        assert_text "出席登録が完了しました。"
-      end
+    accept_confirm do
+      click_link "参加申込"
+    end
+    assert_difference "event.users.count", 1 do
+      assert_text "出席登録が完了しました。"
     end
   end
 
   test "user can cancel event" do
-    event = events(:event_1)
-    login_user "kimura", "testtest"
+    event = events(:event_2)
+    login_user "hatsuno", "testtest"
     visit event_path(event)
-    travel_to Time.zone.local(2019, 12, 11, 9, 00) do
-      accept_confirm do
-        click_link "参加申込"
-      end
-      accept_confirm do
-        click_link "キャンセル"
-      end
-      assert_difference "event.users.count", -1 do
-        assert_text "出席をキャンセルしました。"
-      end
+    accept_confirm do
+      click_link "キャンセル"
+    end
+    assert_difference "event.users.count", -1 do
+      assert_text "出席をキャンセルしました。"
     end
   end
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class EventsTest < ApplicationSystemTestCase
+  test "show link to create new event when user is admin" do
+    login_user "komagata", "testtest"
+    visit events_path
+    assert_link "イベント作成"
+  end
+
+  test "cannot create a new event when user is not admin" do
+    login_user "kimura", "testtest"
+    visit new_event_path
+    assert_text "管理者としてログインしてください"
+  end
+
+  test "create a new event" do
+    login_user "komagata", "testtest"
+    visit new_event_path
+    fill_in "event_title", with: "新しいイベント"
+    fill_in "event_description", with: "イベントの説明文"
+    fill_in "event_capacity", with: 20
+    fill_in "event_location", with: "FJORDオフィス"
+    fill_in "event_start_at", with: Time.zone.parse("2019-12-10 10:00")
+    fill_in "event_end_at", with: Time.zone.parse("2019-12-10 12:00")
+    fill_in "event_open_start_at", with: Time.zone.parse("2019-12-05 10:00")
+    fill_in "event_open_end_at", with: Time.zone.parse("2019-12-09 23:59")
+    assert_difference "Event.count", 1 do
+      click_button "作成"
+    end
+    assert_text "イベントを作成しました。"
+  end
+
+  test "update event" do
+    login_user "komagata", "testtest"
+    visit edit_event_path(events(:event_1))
+    fill_in "event_title", with: "ミートアップ(修正)"
+    fill_in "event_description", with: "ミートアップを開催します(修正)"
+    fill_in "event_capacity", with: 30
+    fill_in "event_location", with: "FJORDオフィス"
+    fill_in "event_start_at", with: Time.zone.parse("2019-12-21 19:00")
+    fill_in "event_end_at", with: Time.zone.parse("2019-12-21 22:30")
+    fill_in "event_open_start_at", with: Time.zone.parse("2019-12-11 9:00")
+    fill_in "event_open_end_at", with: Time.zone.parse("2019-12-20 23:59")
+    click_button "内容変更"
+    assert_text "イベントを更新しました。"
+  end
+
+  test "destroy event" do
+    login_user "komagata", "testtest"
+    visit event_path(events(:event_1))
+    accept_confirm do
+      click_link "削除"
+    end
+    assert_text "イベントを削除しました。"
+  end
+
+  test "cannot create a new event when start_at > end_at" do
+    login_user "komagata", "testtest"
+    visit new_event_path
+    fill_in "event_title", with: "開始日時 > 終了日時のイベント"
+    fill_in "event_description", with: "エラーになる"
+    fill_in "event_capacity", with: 20
+    fill_in "event_location", with: "FJORDオフィス"
+    fill_in "event_start_at", with: Time.zone.parse("2019-12-10 12:00")
+    fill_in "event_end_at", with: Time.zone.parse("2019-12-10 10:00")
+    fill_in "event_open_start_at", with: Time.zone.parse("2019-12-05 10:00")
+    fill_in "event_open_end_at", with: Time.zone.parse("2019-12-09 23:59")
+    click_button "作成"
+    assert_text "終了日時は開始日時よりも後の日時にしてください。"
+  end
+
+  test "cannot create a new event when open_start_at > open_end_at" do
+    login_user "komagata", "testtest"
+    visit new_event_path
+    fill_in "event_title", with: "募集開始日時 > 募集終了日時のイベント"
+    fill_in "event_description", with: "エラーになる"
+    fill_in "event_capacity", with: 20
+    fill_in "event_location", with: "FJORDオフィス"
+    fill_in "event_start_at", with: Time.zone.parse("2019-12-10 10:00")
+    fill_in "event_end_at", with: Time.zone.parse("2019-12-10 12:00")
+    fill_in "event_open_start_at", with: Time.zone.parse("2019-12-09 10:00")
+    fill_in "event_open_end_at", with: Time.zone.parse("2019-12-07 10:00")
+    click_button "作成"
+    assert_text "募集終了日時は募集開始日時よりも後の日時にしてください。"
+  end
+
+  test "cannot create a new event when open_start_at > start_at" do
+    login_user "komagata", "testtest"
+    visit new_event_path
+    fill_in "event_title", with: "募集開始日時 > 開始日時のイベント"
+    fill_in "event_description", with: "エラーになる"
+    fill_in "event_capacity", with: 20
+    fill_in "event_location", with: "FJORDオフィス"
+    fill_in "event_start_at", with: Time.zone.parse("2019-12-10 10:00")
+    fill_in "event_end_at", with: Time.zone.parse("2019-12-10 12:00")
+    fill_in "event_open_start_at", with: Time.zone.parse("2019-12-10 10:30")
+    fill_in "event_open_end_at", with: Time.zone.parse("2019-12-10 11:30")
+    click_button "作成"
+    assert_text "募集開始日時は開始日時よりも前の日時にしてください。"
+  end
+
+  test "cannot create a new event when open_end_at > end_at" do
+    login_user "komagata", "testtest"
+    visit new_event_path
+    fill_in "event_title", with: "募集終了日時 > 終了日時のイベント"
+    fill_in "event_description", with: "エラーになる"
+    fill_in "event_capacity", with: 20
+    fill_in "event_location", with: "FJORDオフィス"
+    fill_in "event_start_at", with: Time.zone.parse("2019-12-10 10:00")
+    fill_in "event_end_at", with: Time.zone.parse("2019-12-10 12:00")
+    fill_in "event_open_start_at", with: Time.zone.parse("2019-12-05 10:00")
+    fill_in "event_open_end_at", with: Time.zone.parse("2019-12-11 12:00")
+    click_button "作成"
+    assert_text "募集終了日時は終了日時よりも前の日時にしてください。"
+  end
+end


### PR DESCRIPTION
Ref: #1236 

## 概要

- イベントのCRUD
    - 管理者はイベントの作成/更新/削除ができる
    - 一般ユーザーは作成されたイベントの詳細の閲覧ができる
- お知らせ機能などと同様に足跡やコメント、リアクションが残せる
- イベントへの出欠席機能
    - ユーザーはイベントへの参加申込/キャンセルができる
    - 参加者のリストや補欠者のリストにユーザーのアイコンが表示される
    - イベントへの参加は先着順で、定員以上の申込があった場合は補欠リストに追加される
    - 参加リストのユーザーがイベントへの出席をキャンセルした場合、補欠リストにいる先頭のユーザーが繰り上がる
    - イベントへの参加申込ができるのは募集期間中のみで、それ以外の日時には現在日時に応じて参加申込ができない旨を知らせるメッセージが参加申込ボタンの代わりに表示される

参加リストや補欠リストに表示されるアイコン部分のCSSは足跡を表示する機能から拝借しています。
また、テスト用に`.participation`,`.waitlist`クラスを追加しています。デザインが入った際にクラス名に変更があるとテストが落ちてしまうので、デザインの際にクラス名に変更があるときはテストを修正します。