### PR TITLE
日報個別ページに何回目の日報かを表示

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-header.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-header.sass
@@ -86,6 +86,9 @@ a.thread-header__author
   +text-block(.8125rem 1, $muted-text flex)
   +media-breakpoint-down(sm)
     font-size: .75rem
+  .is-important
+    color: $danger
+    font-weight: 600
 
 .thread-header__date-label
   &::after

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -66,6 +66,7 @@ class Report < ActiveRecord::Base
   def serial_number
     Report.select(:id)
           .where(user: user)
+          .order(:created_at)
           .index(self) + 1
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -63,9 +63,9 @@ class Report < ActiveRecord::Base
     @_faces ||= emotions.keys.zip(%w(🙂 😢 😄)).to_h.with_indifferent_access
   end
 
-  def count_report
-    Report.where(user: user)
-          .order(:created_at)
+  def serial_number
+    Report.select(:id)
+          .where(user: user)
           .index(self) + 1
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,4 +62,10 @@ class Report < ActiveRecord::Base
   def self.faces
     @_faces ||= emotions.keys.zip(%w(🙂 😢 😄)).to_h.with_indifferent_access
   end
+
+  def count_report
+    Report.where(user: user)
+          .order(:created_at)
+          .index(self) + 1
+  end
 end

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -32,7 +32,7 @@ header.page-header
             - if @report.wip?
               span.thread-header__title-icon
                 | WIP
-            = @report.title
+            | #{@report.count_report} #{@report.title}
           #js-check-stamp(data-checkable-id="#{@report.id}" data-checkable-type="Report")
           .thread-header__lower-side
             #js-watch(data-watchable-id="#{@report.id}", data-watchable-type="Report")

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -28,8 +28,8 @@ header.page-header
               = @report.user.login_name
             .thread-header__date
               | #{l @report.reported_on}(
-              span.thread-header__count(class="#{@report.count_report < 6 ? "is-important" : ""}")
-                | #{@report.count_report}
+              span.thread-header__count(class="#{@report.serial_number < 6 ? "is-important" : ""}")
+                | #{@report.serial_number}
               | )の日報
           h1.thread-header__title(class="#{@report.wip? ? "is-wip" : ""}")
             - if @report.wip?

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -27,12 +27,15 @@ header.page-header
             = link_to @report.user, class: "thread-header__author", title: @report.user.full_name do
               = @report.user.login_name
             .thread-header__date
-              | #{l @report.reported_on} の日報
+              | #{l @report.reported_on}(
+              span.thread-header__count(class="#{@report.count_report < 6 ? "is-important" : ""}")
+                | #{@report.count_report}
+              | )の日報
           h1.thread-header__title(class="#{@report.wip? ? "is-wip" : ""}")
             - if @report.wip?
               span.thread-header__title-icon
                 | WIP
-            | #{@report.count_report} #{@report.title}
+            | #{@report.title}
           #js-check-stamp(data-checkable-id="#{@report.id}" data-checkable-type="Report")
           .thread-header__lower-side
             #js-watch(data-watchable-id="#{@report.id}", data-watchable-type="Report")

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -18,4 +18,11 @@ class ReportTest < ActiveSupport::TestCase
     report.save(validate: false)
     assert_not_nil Watch.find_by(user: adviser, watchable: report)
   end
+
+  test "count_report" do
+    report1 = reports(:report_1)
+    report2 = reports(:report_2)
+    assert_equal report1.count_report, 1
+    assert_equal report2.count_report, 2
+  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -19,10 +19,10 @@ class ReportTest < ActiveSupport::TestCase
     assert_not_nil Watch.find_by(user: adviser, watchable: report)
   end
 
-  test "count_report" do
+  test "serial_number" do
     report1 = reports(:report_1)
     report2 = reports(:report_2)
-    assert_equal report1.count_report, 1
-    assert_equal report2.count_report, 2
+    assert_equal report1.serial_number, 1
+    assert_equal report2.serial_number, 2
   end
 end


### PR DESCRIPTION
Ref #1315 

## 変更内容
- 日報個別ページの日報タイトル横に、何回目の日報かを表示。
- 追加したメソッドのModelテストを追加。

## 追記
[@komagata さんのブログ記事](http://docs.komagata.org/5592)を読み、created_atにインデックスを貼らないと速度が遅くなるということを知りました。ただ、今回の場合にインデックスを貼るのが適切なのかどうか判断ができなかったので、とりあえず貼らないでおきました。