### PR TITLE
ヘッダーのナビゲーションメニュー内におけるGoogleMeetをWherebyにリンクと共に修正

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -62,8 +62,8 @@
               = link_to "https://github.com/fjordllc/bootcamp/projects/1", class: "header-dropdown__item-link", target: "_blank" do
                 | GitHub Projects
             li.header-dropdown__item
-              = link_to "https://meet.google.com/obe-tbcj-kne", class: "header-dropdown__item-link", target: "_blank" do
-                | Google Meet
+              = link_to "https://whereby.com/fjordbootcamp", class: "header-dropdown__item-link", target: "_blank" do
+                | Whereby
             li.header-dropdown__item
               = link_to "https://suzuri.jp/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
                 | グッズ購入


### PR DESCRIPTION
ヘッダーのナビゲーションメニューにおけるGoogleMeetを以下に修正しました。
- 文言：Whereby
- リンク：https://whereby.com/fjordbootcamp

既存のテストをざっと拝見しましたが、
本メニューのリンクを確認するテストが無かった為、特にテスト追記などはしていません。
既存のテスト自体は通しています。