### PR TITLE
日報のフォームにおける「今日の気分」項目をプルダウンからラジオボタンに変更

### DIFF
--- a/app/assets/stylesheets/blocks/form/_form-radio-button.sass
+++ b/app/assets/stylesheets/blocks/form/_form-radio-button.sass
@@ -5,15 +5,23 @@
     display: flex
     flex-wrap: wrap
     +margin(horizontal, -.5rem)
+  &.is-inline
+    margin-bottom: -.5rem
+    display: flex
+    flex-wrap: wrap
+    +margin(horizontal, -.5rem)
 
 .form-radio-button
-  &.is-half
+  .form-item__radio-buttons.is-half &
     flex: 0 0 50%
     max-width: 50%
     +padding(horizontal, .5rem)
     +media-breakpoint-down(sm)
       flex: 100%
       max-width: 100%
+  .form-item__radio-buttons.is-inline &
+    +padding(horizontal, .5rem)
+
 
 .form-radio-button__label
   +text-block(.8125rem 1.45 0 .5rem, block)
@@ -23,7 +31,9 @@
   border-radius: .25rem
   transition: all .2s ease-in
   +position(relative)
-  .form-radio-button.is-half &
+  &.is-lg
+    font-size: 1.5rem
+  .form-item__radio-buttons.is-half &
     margin-bottom: .5rem
   &::before
     content: ''

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -12,10 +12,15 @@
       .form-item
         = f.label :reported_on, class: "a-label"
         = f.date_field :reported_on, class: "a-text-input"
-      .form-item
-        = f.label :emotion, class: "a-label"
-        .a-button.is-md.is-secondary.is-select.test-select-emotions
-          = f.select(:emotion, Report.faces.invert, prompt: "選択してください")
+      .form-item.is-sm
+        label.a-label
+          = f.label :emotion
+        ul.form-item__radio-buttons.is-half
+          li.form-radio-button.test-select-emotions
+            = f.collection_radio_buttons :emotion, Report.faces, :first, :second do |b|
+              label.form-radio-button__label
+                = b.text
+                = b.radio_button
 
       .form-item#tasks
         label.a-label

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -15,10 +15,10 @@
       .form-item.is-sm
         label.a-label
           = f.label :emotion
-        ul.form-item__radio-buttons.is-half
-          li.form-radio-button.test-select-emotions
-            = f.collection_radio_buttons :emotion, Report.faces, :first, :second do |b|
-              label.form-radio-button__label
+        ul.form-item__radio-buttons.is-inline
+          = f.collection_radio_buttons :emotion, Report.faces, :first, :second do |b|
+            li.form-radio-button.test-select-emotions
+              label.form-radio-button__label.is-lg
                 = b.text
                 = b.radio_button
 

--- a/test/system/emotions_test.rb
+++ b/test/system/emotions_test.rb
@@ -17,7 +17,7 @@ class EmotionsTest < ApplicationSystemTestCase
     all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("08")
     all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("30")
 
-    first(".test-select-emotions").select("😄")
+    choose "😄", visible: false
 
     click_button "提出"
     assert_text "日報を保存しました。"


### PR DESCRIPTION
## デザイン
お知らせ作成時のラジオボタンとひとまず同様デザインを適用していますが、
ベストではないように見えるので要検討かと存じます。

## コード
@komagata のご指摘を受け、`.collection_radio_buttons`を使用

## テスト
テスト以下ファイルについて修正しました
`test/system/emotions_test.rb`