### PR TITLE
提出物とQAにマークダウン表示を追加

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -15,6 +15,10 @@ class ProductsController < ApplicationController
     @practice = find_practice
     @footprints = find_footprints
     footprint!
+    respond_to do |format|
+      format.html
+      format.md
+    end
   end
 
   def new

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -19,6 +19,10 @@ class QuestionsController < ApplicationController
   end
 
   def show
+    respond_to do |format|
+      format.html
+      format.md
+    end
   end
 
   def new

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -32,6 +32,8 @@ header.page-header
             | #{link_to @product.practice.title, @product.practice, class: "thread-header__title-link"}の提出物
           .thread-header__lower-side
             #js-watch(data-watchable-id="#{@product.id}", data-watchable-type="Product")
+            .thread-header__raw
+              = link_to "Raw", product_path(format: :md), class: "a-button is-sm is-secondary", target: "_blank"
         #js-check-stamp(data-checkable-id="#{@product.id}" data-checkable-type="Product")
         .thread__description.js-target-blank.is-long-text.js-markdown-view
           =  @product.practice.goal

--- a/app/views/products/show.md.slim
+++ b/app/views/products/show.md.slim
@@ -1,0 +1,1 @@
+= @product.body.html_safe

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -29,6 +29,8 @@ header.page-header
             = @question.title
           .thread-header__lower-side
             #js-watch(data-watchable-id="#{@question.id}", data-watchable-type="Question")
+            .thread-header__raw
+              = link_to "Raw", question_path(format: :md), class: "a-button is-sm is-secondary", target: "_blank"
         - if @question.practice.present?
           .report-practices
             ul.report-practices__items

--- a/app/views/questions/show.md.slim
+++ b/app/views/questions/show.md.slim
@@ -1,0 +1,1 @@
+= @question.description.html_safe


### PR DESCRIPTION
Ref #1244 

## 変更内容
提出物とQAでも生のマークダウンが見られる機能を追加。

## キャプチャ
![image](https://user-images.githubusercontent.com/50227745/72584035-d64d7980-392b-11ea-9eb7-01d581264b56.png)

![image](https://user-images.githubusercontent.com/50227745/72584067-eebd9400-392b-11ea-937d-9f491ee3eec1.png)
