### PR TITLE
生徒向け書籍一覧ページを追加

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,6 +3,10 @@
 class BooksController < ApplicationController
   before_action :require_login
 
+  def index
+    @books = Book.all.order(:title).page(params[:page])
+  end
+
   def show
     @book = Book.find(params[:id])
   end

--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -59,6 +59,9 @@
               = link_to courses_path, class: "header-dropdown__item-link" do
                 | コース
             li.header-dropdown__item
+              = link_to books_path, class: "header-dropdown__item-link" do
+                | 書籍一覧
+            li.header-dropdown__item
               = link_to "https://github.com/fjordllc/bootcamp/projects/1", class: "header-dropdown__item-link", target: "_blank" do
                 | GitHub Projects
             li.header-dropdown__item

--- a/app/views/books/_table.html.slim
+++ b/app/views/books/_table.html.slim
@@ -1,0 +1,26 @@
+.admin-table
+  table.admin-table__table
+    thead.admin-table__header
+      tr.admin-table__labels
+        th.admin-table__label = Book.human_attribute_name :id
+        th.admin-table__label = Book.human_attribute_name :title
+        th.admin-table__label = Book.human_attribute_name :isbn
+        th.admin-table__label 借りてる人
+        th.admin-table__label 借りてる日数
+    tbody.admin-table__items
+      - books.each do |book|
+        tr.admin-table__item(id="book_#{book.id}")
+          td.admin-table__item-value
+            = book.id
+          td.admin-table__item-value
+            = book.title
+          td.admin-table__item-value.is-text-align-center
+            = book.isbn
+          td.admin-table__item-value
+            - if book.borrowed
+              = image_tag book.borrowing_user_avatar, class: "admin-table__user-icon"
+              = link_to user_path(book.users.first), target: "_blank", rel: "noopener" do
+                = book.borrowing_user_name
+          td.admin-table__item-value.is-text-align-center
+            - if book.borrowed
+              = "#{book.borrowing_days}日"

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,0 +1,17 @@
+- title "書籍一覧"
+
+header.page-header
+  .container
+    .page-header__inner
+      h1.page-header__title = title
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+
+.page-body
+  .js-markdown-view.js-target-blank.is-long-text
+  | フィヨルドオフィスにて以下の書籍を借りることができます。
+  .container.is-padding-horizontal-0-sm-down
+    = paginate @books, position: "top"
+    = render "table", books: @books
+    = paginate @books, position: "bottom"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,7 @@ Rails.application.routes.draw do
     end
   end
   resources :works, except: %i(index)
-  resources :books, only: %i(show) do
+  resources :books, only: %i(index show) do
     resources :borrowings, only: %i(create destroy)
   end
 

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class BooksTest < ApplicationSystemTestCase
+  def setup
+    login_user "komagata", "testtest"
+  end
+
+  test "check book list" do
+    visit books_path
+    assert_text "書籍一覧"
+  end
+end


### PR DESCRIPTION
## 修正事項
- 書籍一覧ページを追加
- ハンバーガーメニューに書籍一覧ページのリンクを追加

## 文言追加
書籍一覧ページが何のために存在するか、（特にリモートの）生徒側は理解しづらいかと考え、
簡単な説明書きを一行追加`フィヨルドオフィスにて以下の書籍を借りることができます。`

## デザイン
書籍一覧自体は、管理者ページから引用してきているので問題無いかと存じます。
ただ上記の文言追加について、必要可否も含め検討修正指示等いただければ幸いです。

## テスト
ページが表示されているかを確認する簡単なテストファイル`test/system/books_test.rb`を追加
