### PR TITLE
次回決済日時を追加

### DIFF
--- a/app/assets/stylesheets/blocks/auth-form/_next-settlement-time.sass
+++ b/app/assets/stylesheets/blocks/auth-form/_next-settlement-time.sass
@@ -1,0 +1,13 @@
+.next-settlement-time
+  +media-breakpoint-up(md)
+    display: flex
+    align-items: center
+    justify-content: center
+
+.next-settlement-time__title
+  +text-block(.875rem 1.4, 400)
+  +media-breakpoint-up(md)
+    margin-right: .5em
+
+.next-settlement-time__time
+  +text-block(1rem 1.4, 600 $danger)

--- a/app/assets/stylesheets/blocks/form/_form-notice.sass
+++ b/app/assets/stylesheets/blocks/form/_form-notice.sass
@@ -1,14 +1,15 @@
 .form-notice
-  background-color: #f8fff2
-  border: solid $success 2px
-  max-width: 100%
   width: 34rem
   +margin(horizontal, auto)
-  padding: .75rem
+  border: solid $success 2px
+  padding: 1em 1.25em
+  background-color: #f8fff2
   margin-top: 1em
   +short-text-style
-  font-size: .8125rem
+  font-size: .875rem
   +media-breakpoint-up(md)
     margin-bottom: 2rem
+    max-width: 100%
   +media-breakpoint-down(sm)
     margin-bottom: 1.5rem
+    max-width: calc(100% - 2rem)

--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -54,6 +54,8 @@
             - if !current_user.adviser? && !current_user.mentor? && !current_user.trainee?
               - if current_user.card?
                 li.header-dropdown__item
+                  = link_to "クレジットカード情報", card_path, class: "header-dropdown__item-link"
+                li.header-dropdown__item
                   = link_to "クレジットカード変更", edit_card_path, class: "header-dropdown__item-link"
               - else
                 li.header-dropdown__item

--- a/app/views/card/show.html.slim
+++ b/app/views/card/show.html.slim
@@ -18,4 +18,7 @@ header.page-header
       ul.form-actions__items
         li.form-actions__item.is-main
           = link_to "カード変更", edit_card_path, class: "a-button is-lg is-warning is-block"
+
+    h2 次回決済日時
+    p = l Time.at(current_user.subscription["current_period_end"])
 = render "notice"

--- a/app/views/card/show.html.slim
+++ b/app/views/card/show.html.slim
@@ -18,7 +18,10 @@ header.page-header
       ul.form-actions__items
         li.form-actions__item.is-main
           = link_to "カード変更", edit_card_path, class: "a-button is-lg is-warning is-block"
-
-    h2 次回決済日時
-    p = l Time.at(current_user.subscription["current_period_end"])
+  .auth-form__footer
+    .next-settlement-time
+      h2.next-settlement-time__title
+        | 次回決済日時
+      .next-settlement-time__time
+        = l Time.at(current_user.subscription["current_period_end"])
 = render "notice"


### PR DESCRIPTION
カード情報のページへのリンクをMenuに追加して、次回決済日時を表示するようにしました。

<img width="1227" alt="スクリーンショット 2020-01-22 18 52 39" src="https://user-images.githubusercontent.com/16577/72888429-81a16880-3d48-11ea-82b6-3c0d535d372b.png">