### PR TITLE
通知一覧を「全て」と「未読」に分ける

### DIFF
--- a/app/controllers/notifications/unread_controller.rb
+++ b/app/controllers/notifications/unread_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Notifications::UnreadController < ApplicationController
+  def index
+    @notifications = current_user.notifications
+                                 .unreads_with_avatar
+                                 .order(created_at: :desc)
+                                 .page(params[:page])
+  end
+end

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -124,7 +124,6 @@ export default {
         .then(json=> {
           this.comments.push(json);
           this.description = '';
-          this.tab = 'comment';
         })
         .catch(error => {
           console.warn('Failed to parsing', error)

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -124,6 +124,7 @@ export default {
         .then(json=> {
           this.comments.push(json);
           this.description = '';
+          this.tab = 'comment';
         })
         .catch(error => {
           console.warn('Failed to parsing', error)

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -1,0 +1,8 @@
+.page-tabs
+  .container
+    ul.page-tabs__items
+      li.page-tabs__item
+        = link_to "全て", notifications_path, class: "page-tabs__item-link #{current_link /^notifications-index/}"
+      li.page-tabs__item
+        = link_to unread_index_path, class: "page-tabs__item-link #{current_link /^notifications-unread-index/}" do
+          | 未読

--- a/app/views/notifications/unread/index.html.slim
+++ b/app/views/notifications/unread/index.html.slim
@@ -1,4 +1,4 @@
-- title "通知"
+- title "未読の通知"
 
 header.page-header
   .container

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
   resources :notifications, only: %i(index show) do
     collection do
       resources :allmarks, only: %i(create), controller: "notifications/allmarks"
+      resources :unread, only: %i(index), controller: "notifications/unread", path: :unread
     end
   end
   resources :works, except: %i(index)

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -100,17 +100,4 @@ class CommentsTest < ApplicationSystemTestCase
     click_button "コメントする"
     assert_text "test"
   end
-
-  test "comment tab is active after a comment has been posted" do
-    visit "/reports/#{reports(:report_3).id}"
-    assert_equal "コメント", find(".thread-comment-form__tab.is-active").text
-    within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
-    end
-    find(".thread-comment-form__tab", text: "プレビュー").click
-    assert_equal "プレビュー", find(".thread-comment-form__tab.is-active").text
-    click_button "コメントする"
-    assert_text "test"
-    assert_equal "コメント", find(".thread-comment-form__tab.is-active").text
-  end
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -100,4 +100,17 @@ class CommentsTest < ApplicationSystemTestCase
     click_button "コメントする"
     assert_text "test"
   end
+
+  test "comment tab is active after a comment has been posted" do
+    visit "/reports/#{reports(:report_3).id}"
+    assert_equal "コメント", find(".thread-comment-form__tab.is-active").text
+    within(".thread-comment-form__form") do
+      fill_in("comment[description]", with: "test")
+    end
+    find(".thread-comment-form__tab", text: "プレビュー").click
+    assert_equal "プレビュー", find(".thread-comment-form__tab.is-active").text
+    click_button "コメントする"
+    assert_text "test"
+    assert_equal "コメント", find(".thread-comment-form__tab.is-active").text
+  end
 end

--- a/test/system/notification/unread_test.rb
+++ b/test/system/notification/unread_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class Notification::UnreadTest < ApplicationSystemTestCase
+  setup { login_user "sotugyou", "testtest" }
+
+  test "show listing unread notification" do
+    visit "/notifications/unread"
+    assert_equal "未読の通知 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+  end
+end

--- a/test/system/notification/unread_test.rb
+++ b/test/system/notification/unread_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class Notification::UnreadTest < ApplicationSystemTestCase
-  setup { login_user "sotugyou", "testtest" }
+  setup { login_user "komagata", "testtest" }
 
   test "show listing unread notification" do
     visit "/notifications/unread"

--- a/test/system/notification/unread_test.rb
+++ b/test/system/notification/unread_test.rb
@@ -3,7 +3,7 @@
 require "application_system_test_case"
 
 class Notification::UnreadTest < ApplicationSystemTestCase
-  setup { login_user "komagata", "testtest" }
+  setup { login_user "hatsuno", "testtest" }
 
   test "show listing unread notification" do
     visit "/notifications/unread"


### PR DESCRIPTION
Ref #1322 

## 変更内容
- 通知一覧に「全て」と「未読」のタブを加える。
- 未読の通知が表示されているかを確かめるテストを加える。

## キャプチャ
### 未読一覧
![image](https://user-images.githubusercontent.com/50227745/72947119-6a07c580-3dc4-11ea-9cb1-e94a2c5c60d6.png)
### 全て
![image](https://user-images.githubusercontent.com/50227745/72947156-8277e000-3dc4-11ea-86ac-d1369453057b.png)
