### PR TITLE
生徒向け書籍一覧ページに検索窓を追加

### DIFF
--- a/app/assets/stylesheets/blocks/page/_page-body.sass
+++ b/app/assets/stylesheets/blocks/page/_page-body.sass
@@ -2,3 +2,12 @@
   +padding(vertical, 1.5rem)
   +media-breakpoint-down(sm)
     +padding(vertical, 1.125rem)
+
+.page-body__description
+  +short-text-style
+  +media-breakpoint-up(md)
+    font-size: .875rem
+  +media-breakpoint-down(sm)
+    font-size: .8125rem
+  &:not(:last-child)
+    margin-bottom: 1.5em

--- a/app/assets/stylesheets/blocks/shared/_page-search.sass
+++ b/app/assets/stylesheets/blocks/shared/_page-search.sass
@@ -1,0 +1,23 @@
+.page-search
+  +padding(vertical, .75rem)
+  border-bottom: solid 1px $background-shade
+  .page-tabs + &
+    +padding(vertical, 0)
+
+.page-search__form
+  width: 30rem
+  max-width: 100%
+  +margin(horizontal, auto)
+  display: flex
+  height: 100%
+  align-items: center
+  padding-right: .75rem
+
+.page-search__text-input
+  height: 2rem
+  +border-radius(right, 0)
+  border-right: none
+
+.is-icon.page-search__submit
+  height: 2rem
+  +border-radius(left, 0)

--- a/app/controllers/books/search_results_controller.rb
+++ b/app/controllers/books/search_results_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Books::SearchResultsController < ApplicationController
+  before_action :require_login
+
+  def index
+    @search_results = Book.search(params[:word]).page(params[:page])
+  end
+end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -4,7 +4,7 @@ class BooksController < ApplicationController
   before_action :require_login
 
   def index
-    @books = Book.all.order(:title).page(params[:page])
+    @books = Book.order(:title).page(params[:page])
   end
 
   def show

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,6 +3,10 @@
 class BooksController < ApplicationController
   before_action :require_login
 
+  def index
+    @books = Book.all.order(:title).page(params[:page])
+  end
+
   def show
     @book = Book.find(params[:id])
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,4 +8,8 @@ class Book < ApplicationRecord
   validates :isbn, presence: true
   validates :borrowed, inclusion: { in: [true, false] }
   paginates_per 20
+
+  def self.search(word)
+    Book.ransack(title_cont: word).result
+  end
 end

--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -59,6 +59,9 @@
               = link_to courses_path, class: "header-dropdown__item-link" do
                 | コース
             li.header-dropdown__item
+              = link_to books_path, class: "header-dropdown__item-link" do
+                | 書籍一覧
+            li.header-dropdown__item
               = link_to "https://github.com/fjordllc/bootcamp/projects/1", class: "header-dropdown__item-link", target: "_blank" do
                 | GitHub Projects
             li.header-dropdown__item

--- a/app/views/books/_search_bar.html.slim
+++ b/app/views/books/_search_bar.html.slim
@@ -1,0 +1,7 @@
+.page-tools
+  nav.page-search
+    .container
+      = form_tag search_results_path, method: "get", class: "page-search__form", name: "book_search" do
+        = text_field_tag "word", params[:word], class: "a-xs-text-input page-search__text-input", placeholder: "書籍タイトルで検索"
+        button.a-button.is-sm.is-secondary.is-icon.page-search__submit#book-search(type="submit")
+          i.fas.fa-search

--- a/app/views/books/_table.html.slim
+++ b/app/views/books/_table.html.slim
@@ -1,0 +1,26 @@
+.admin-table
+  table.admin-table__table
+    thead.admin-table__header
+      tr.admin-table__labels
+        th.admin-table__label = Book.human_attribute_name :id
+        th.admin-table__label = Book.human_attribute_name :title
+        th.admin-table__label = Book.human_attribute_name :isbn
+        th.admin-table__label 借りてる人
+        th.admin-table__label 借りてる日数
+    tbody.admin-table__items
+      - books.each do |book|
+        tr.admin-table__item(id="book_#{book.id}")
+          td.admin-table__item-value
+            = book.id
+          td.admin-table__item-value
+            = book.title
+          td.admin-table__item-value.is-text-align-center
+            = book.isbn
+          td.admin-table__item-value
+            - if book.borrowed
+              = image_tag book.borrowing_user_avatar, class: "admin-table__user-icon"
+              = link_to user_path(book.users.first), target: "_blank", rel: "noopener" do
+                = book.borrowing_user_name
+          td.admin-table__item-value.is-text-align-center
+            - if book.borrowed
+              = "#{book.borrowing_days}日"

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -8,13 +8,7 @@ header.page-header
         .page-header-actions__items
           .page-header-actions__item
 
-.page-tools
-  nav.page-search
-    .container
-      = form_tag search_results_path, method: "get", class: "page-search__form", name: "book_search" do
-        = text_field_tag "word", params[:word], class: "a-xs-text-input page-search__text-input", placeholder: "書籍タイトルで検索"
-        button.a-button.is-sm.is-secondary.is-icon.page-search__submit#book-search(type="submit")
-          i.fas.fa-search
+= render "books/search_bar"
 
 .page-body
   .page-body__description

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -8,13 +8,19 @@ header.page-header
         .page-header-actions__items
           .page-header-actions__item
 
+.page-tools
+  nav.page-search
+    .container
+      = form_tag search_results_path, method: "get", class: "page-search__form", name: "book_search" do
+        = text_field_tag "word", params[:word], class: "a-xs-text-input page-search__text-input", placeholder: "書籍タイトルで検索"
+        button.a-button.is-sm.is-secondary.is-icon.page-search__submit#book-search(type="submit")
+          i.fas.fa-search
+
 .page-body
-  .js-markdown-view.js-target-blank.is-long-text
-  | フィヨルドオフィスにて以下の書籍を借りることができます。
-  = form_tag search_results_path, method: "get", class: "header-search", name: "book_search" do
-    = text_field_tag "word", params[:word], class: "a-xs-text-input header-search__text-input", placeholder: "書籍タイトルで検索"
-    button.a-button.is-sm.is-secondary.is-icon.header-search__submit#book-search(type="submit")
-      i.fas.fa-search
+  .page-body__description
+    .container.is-md
+      p
+        | フィヨルドオフィスにて以下の書籍を借りることができます。
   .container.is-padding-horizontal-0-sm-down
     = paginate @books, position: "top"
     = render "table", books: @books

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,0 +1,17 @@
+- title "書籍一覧"
+
+header.page-header
+  .container
+    .page-header__inner
+      h1.page-header__title = title
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+
+.page-body
+  .js-markdown-view.js-target-blank.is-long-text
+  | フィヨルドオフィスにて以下の書籍を借りることができます。
+  .container.is-padding-horizontal-0-sm-down
+    = paginate @books, position: "top"
+    = render "table", books: @books
+    = paginate @books, position: "bottom"

--- a/app/views/books/search_results/index.html.slim
+++ b/app/views/books/search_results/index.html.slim
@@ -8,11 +8,9 @@ header.page-header
         .page-header-actions__items
           .page-header-actions__item
 
+= render "books/search_bar"
+
 .page-body
-  = form_tag search_results_path, method: "get", class: "header-search", name: "book_search" do
-    = text_field_tag "word", params[:word], class: "a-xs-text-input header-search__text-input", placeholder: "書籍タイトルで検索"
-    button.a-button.is-sm.is-secondary.is-icon.header-search__submit#book-search(type="submit")
-      i.fas.fa-search
   .container.is-padding-horizontal-0-sm-down
     = paginate @search_results, position: "top"
     = render "books/table", books: @search_results if @search_results.any?

--- a/app/views/books/search_results/index.html.slim
+++ b/app/views/books/search_results/index.html.slim
@@ -1,4 +1,4 @@
-- title "書籍一覧"
+- title "'#{params[:word]}'の検索結果"
 
 header.page-header
   .container
@@ -9,13 +9,11 @@ header.page-header
           .page-header-actions__item
 
 .page-body
-  .js-markdown-view.js-target-blank.is-long-text
-  | フィヨルドオフィスにて以下の書籍を借りることができます。
   = form_tag search_results_path, method: "get", class: "header-search", name: "book_search" do
     = text_field_tag "word", params[:word], class: "a-xs-text-input header-search__text-input", placeholder: "書籍タイトルで検索"
     button.a-button.is-sm.is-secondary.is-icon.header-search__submit#book-search(type="submit")
       i.fas.fa-search
   .container.is-padding-horizontal-0-sm-down
-    = paginate @books, position: "top"
-    = render "table", books: @books
-    = paginate @books, position: "bottom"
+    = paginate @search_results, position: "top"
+    = render "books/table", books: @search_results if @search_results.any?
+    = paginate @search_results, position: "bottom"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,7 @@ Rails.application.routes.draw do
     end
   end
   resources :works, except: %i(index)
-  resources :books, only: %i(show) do
+  resources :books, only: %i(index show) do
     resources :borrowings, only: %i(create destroy)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,9 @@ Rails.application.routes.draw do
   resources :works, except: %i(index)
   resources :books, only: %i(index show) do
     resources :borrowings, only: %i(create destroy)
+    collection do
+      resources :search_results, only: %i(index), controller: "books/search_results"
+    end
   end
 
   resources :questions do

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -3,12 +3,19 @@
 require "application_system_test_case"
 
 class BooksTest < ApplicationSystemTestCase
-  def setup
-    login_user "komagata", "testtest"
-  end
+  setup { login_user "hatsuno", "testtest" }
 
-  test "check book list" do
+  test "show listing books" do
     visit books_path
     assert_text "書籍一覧"
+  end
+
+  test "search books" do
+    visit books_path
+    within("form[name=book_search]") do
+      fill_in "word", with: "現場"
+    end
+    find("#book-search").click
+    assert_text "'現場'の検索結果"
   end
 end

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class BooksTest < ApplicationSystemTestCase
+  def setup
+    login_user "komagata", "testtest"
+  end
+
+  test "check book list" do
+    visit books_path
+    assert_text "書籍一覧"
+  end
+end


### PR DESCRIPTION
## 修正事項
- 生徒向け書籍一覧ページに検索窓を追加
- 検索後、検索結果一覧ページに遷移
- 検索結果が該当しない場合テーブルごと非表示

## ブランチ
- （生徒向け書籍一覧ページを追加）プルリク内容を引き継いでブランチ作成

## デザイン
検索窓の配置箇所や長さなど調整いただければ幸いです。

## テスト
テストファイル`test/system/books_test.rb`に追加

## 追記
rubocop を通し忘れていたため、修正し再pushしました。