### PR TITLE
プレビュー状態でコメント投稿したとき、新規コメントのテキストエリアを「コメント」に戻す

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -124,6 +124,7 @@ export default {
         .then(json=> {
           this.comments.push(json);
           this.description = '';
+          this.tab = 'comment';
         })
         .catch(error => {
           console.warn('Failed to parsing', error)

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -100,4 +100,17 @@ class CommentsTest < ApplicationSystemTestCase
     click_button "コメントする"
     assert_text "test"
   end
+
+  test "comment tab is active after a comment has been posted" do
+    visit "/reports/#{reports(:report_3).id}"
+    assert_equal "コメント", find(".thread-comment-form__tab.is-active").text
+    within(".thread-comment-form__form") do
+      fill_in("comment[description]", with: "test")
+    end
+    find(".thread-comment-form__tab", text: "プレビュー").click
+    assert_equal "プレビュー", find(".thread-comment-form__tab.is-active").text
+    click_button "コメントする"
+    assert_text "test"
+    assert_equal "コメント", find(".thread-comment-form__tab.is-active").text
+  end
 end


### PR DESCRIPTION
Ref #1242

## 変更内容
- プレビュー状態でコメント投稿したとき、新規コメントのテキストエリアが「プレビュー」のままだったのを、「コメント」に戻るようにした。

## 追記
- テストをどうやって書けばいいのかどうしてもわからなかったので書いていません。