### PR TITLE
「サインイン」「サインアウト」の文言を「ログイン」「ログアウト」に変更した。

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -22,7 +22,7 @@ class UserSessionsController < ApplicationController
         password: params[:user][:password]
       )
       flash.now[:alert] = "ユーザー名かパスワードが違います。"
-      render "new", notice: "サインアウトしました。"
+      render "new", notice: "ログアウトしました。"
     end
   end
 
@@ -31,7 +31,7 @@ class UserSessionsController < ApplicationController
       save_updated_at(current_user)
       logout
     end
-    redirect_to root_url, notice: "サインアウトしました。"
+    redirect_to root_url, notice: "ログアウトしました。"
   end
 
   private

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -13,7 +13,7 @@ class UserSessionsController < ApplicationController
         redirect_to retire_path
       else
         save_updated_at(@user)
-        redirect_back_or_to root_url, notice: "サインインしました。"
+        redirect_back_or_to root_url, notice: "ログインしました。"
       end
     else
       logout

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -97,7 +97,7 @@ nav.global-nav
           = link_to logout_path, class: "global-nav-links__link" do
             .global-nav-links__link-icon
               i.fas.fa-sign-out-alt
-            .global-nav-links__link-label サインアウト
+            .global-nav-links__link-label ログアウト
         li.global-nav-links__item.is-hidden-md-up
           = link_to new_retirement_path, class: "global-nav-links__link" do
             .global-nav-links__link-icon

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -17,6 +17,6 @@
     .form-actions__items
       .form-actions__item.is-main
         = button_tag(class: "a-button is-lg is-warning is-block") do
-          | サインイン
+          | ログイン
 
 = render "forgot_password_modal"

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,4 +1,4 @@
-- title "サインイン"
+- title "ログイン"
 - content_for(:extra_body_classes, "no-header no-footer no-recent-reports no-global-nav")
 
 = image_tag("logo-lg.svg", class: "auth-form-logo-image")

--- a/test/supports/login_helper.rb
+++ b/test/supports/login_helper.rb
@@ -7,7 +7,7 @@ module LoginHelper
       fill_in("user[login_name]", with: login_name)
       fill_in("user[password]", with: password)
     end
-    click_button "サインイン"
+    click_button "ログイン"
   end
 
   def logout

--- a/test/system/password_resets_test.rb
+++ b/test/system/password_resets_test.rb
@@ -18,8 +18,8 @@ class PasswordResetTest < ApplicationSystemTestCase
     within "form[name=user_session]" do
       fill_in "user[login_name]", with: user.login_name
       fill_in "user[password]", with: "testpassword"
-      click_button "サインイン"
+      click_button "ログイン"
     end
-    assert_text "サインインしました"
+    assert_text "ログインしました"
   end
 end

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -11,7 +11,7 @@ class SignInTest < ApplicationSystemTestCase
       fill_in("user[login_name]", with: "komagata")
       fill_in("user[password]",   with: "testtest")
     end
-    click_button "ログアウト"
+    click_button "ログイン"
     assert_equal "/", current_path
   end
 
@@ -21,7 +21,7 @@ class SignInTest < ApplicationSystemTestCase
       fill_in("user[login_name]", with: "komagata")
       fill_in("user[password]",   with: "xxxxxxxx")
     end
-    click_button "ログアウト"
+    click_button "ログイン"
     assert_equal "/user_sessions", current_path
     assert_text "ユーザー名かパスワードが違います。"
   end
@@ -33,7 +33,7 @@ class SignInTest < ApplicationSystemTestCase
       fill_in("user[login_name]", with: "yameo")
       fill_in("user[password]",   with: "yameo@example.com")
     end
-    click_button "ログアウト"
+    click_button "ログイン"
     assert_equal "/user_sessions", current_path
     assert_text "ユーザー名かパスワードが違います。"
 

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -11,7 +11,7 @@ class SignInTest < ApplicationSystemTestCase
       fill_in("user[login_name]", with: "komagata")
       fill_in("user[password]",   with: "testtest")
     end
-    click_button "サインイン"
+    click_button "ログアウト"
     assert_equal "/", current_path
   end
 
@@ -21,7 +21,7 @@ class SignInTest < ApplicationSystemTestCase
       fill_in("user[login_name]", with: "komagata")
       fill_in("user[password]",   with: "xxxxxxxx")
     end
-    click_button "サインイン"
+    click_button "ログアウト"
     assert_equal "/user_sessions", current_path
     assert_text "ユーザー名かパスワードが違います。"
   end
@@ -33,7 +33,7 @@ class SignInTest < ApplicationSystemTestCase
       fill_in("user[login_name]", with: "yameo")
       fill_in("user[password]",   with: "yameo@example.com")
     end
-    click_button "サインイン"
+    click_button "ログアウト"
     assert_equal "/user_sessions", current_path
     assert_text "ユーザー名かパスワードが違います。"
 


### PR DESCRIPTION
ref: #1195 

## 変更内容
- 「サインアウト」を「ログアウト」に変更する
- 「サインイン」を「ログイン」に変更する

## キャプチャ

#### ログアウト(PC表示)
<img width="330" alt="image" src="https://user-images.githubusercontent.com/17356930/73323256-30ceca00-428a-11ea-9866-69d49cf8de80.png">

#### ログアウト(スマホ表示)
<img width="412" alt="image" src="https://user-images.githubusercontent.com/17356930/73323187-ecdbc500-4289-11ea-9073-0a39a04ff3a0.png">

#### ログアウト後
<img width="743" alt="image" src="https://user-images.githubusercontent.com/17356930/73323309-62479580-428a-11ea-9bb6-acc716f5688e.png">


#### ログイン
<img width="423" alt="image" src="https://user-images.githubusercontent.com/17356930/73323359-8c995300-428a-11ea-880d-e7d98e15e920.png">

#### ログイン後
<img width="423" alt="image" src="https://user-images.githubusercontent.com/17356930/73323399-adfa3f00-428a-11ea-9db3-c94030a29c0d.png">
