### PR TITLE
Q&Aを両方管理者は変更・削除できるようにする

### DIFF
--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -27,7 +27,7 @@
             li.card-footer-actions__item
               = link_to question_correct_answer_path(answer.question, answer_id: answer.id, return_to: question_path(answer.question)), data: { confirm: "本当に宜しいですか？" }, method: :post, class: "a-button is-md is-warning is-block" do
                 | 解決にする
-          - if answer.user == current_user
+          - if answer.user == current_user || admin_login?
             li.card-footer-actions__item
               = link_to edit_question_answer_path(answer.question, answer, return_to: question_url(answer.question)), class: "card-footer-actions__action a-button is-md is-primary is-block", id: "js-shortcut-edit" do
                 i.fas.fa-pen#new

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -41,7 +41,7 @@ header.page-header
           .thread__description.js-markdown-view.js-target-blank.is-long-text
             = @question.description
           = render "reactions/reactions", reactionable: @question
-        - if @question.user_id == current_user.id
+        - if @question.user_id == current_user.id || admin_login?
           .card-footer
             .card-footer-actions
               ul.card-footer-actions__items

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -22,6 +22,15 @@ class AnswersTest < ApplicationSystemTestCase
     end
   end
 
+  test "admin can edit and delete any questions" do
+    visit "/questions/#{questions(:question_1).id}"
+    answer_by_user = page.all(".thread-comment")[1]
+    within answer_by_user do
+      assert_text "内容修正"
+      assert_text "削除"
+    end
+  end
+
   test "admin can resolve user's question" do
     visit "/questions/#{questions(:question_2).id}"
     assert_text "解決にする"

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -79,4 +79,14 @@ class QuestionsTest < ApplicationSystemTestCase
     visit "/notifications"
     assert_no_text "kimuraさんから質問がありました。"
   end
+
+  test "admin can update and delete any questions" do
+    login_user "komagata", "testtest"
+    question = questions(:question_8)
+    visit question_path(question)
+    within ".thread__inner" do
+      assert_text "内容修正"
+      assert_text "削除"
+    end
+  end
 end


### PR DESCRIPTION
Ref: #1341 

# 変更内容
- 管理者であれば、Q&Aを両方変更・削除できるようにした。
- 上記機能のsystemテストを追加した。

# スクリーンショット
## login_user "komagata"
![image](https://user-images.githubusercontent.com/50227745/74007917-dbe62e80-49c2-11ea-97b6-5468dc91d34c.png)


![image](https://user-images.githubusercontent.com/50227745/74007885-c7a23180-49c2-11ea-832c-15c97ab283d2.png)

