### PR TITLE
コメントの二重投稿を防ぐ

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -23,7 +23,7 @@
               .js-preview.is-long-text.thread-comment-form__preview(v-html="markdownDescription")
           .thread-comment-form__actions
             .thread-comment-form__action
-              button#js-shortcut-post-comment.a-button.is-lg.is-warning.is-block(@click="createComment(); preventDoubleSubmit()" :disabled="!validation || bePushed")
+              button#js-shortcut-post-comment.a-button.is-lg.is-warning.is-block(@click="createComment" :disabled="!validation || buttonDisabled")
                 | コメントする
 </template>
 <script>
@@ -45,7 +45,7 @@ export default {
       comments: [],
       description: '',
       tab: 'comment',
-      bePushed: false
+      buttonDisabled: false
     }
   },
   created: function() {
@@ -103,7 +103,7 @@ export default {
     },
     createComment: function(event) {
       if (this.description.length < 1) {　return null　}
-
+      this.buttonDisabled = true
       let params = {
         'comment': { 'description': this.description },
         'commentable_type': this.commentableType,
@@ -127,7 +127,7 @@ export default {
           this.comments.push(json);
           this.description = '';
           this.tab = 'comment';
-          this.bePushed = false
+          this.buttonDisabled = false
         })
         .catch(error => {
           console.warn('Failed to parsing', error)
@@ -151,9 +151,6 @@ export default {
         .catch(error => {
           console.warn('Failed to parsing', error)
         })
-    },
-    preventDoubleSubmit: function() {
-      this.bePushed = true;
     }
   },
   computed: {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -102,6 +102,9 @@ export default {
     },
     createComment: function(event) {
       if (this.description.length < 1) {　return null　}
+      const obj = document.getElementById('js-shortcut-post-comment')
+      obj.disabled = true;
+
       let params = {
         'comment': { 'description': this.description },
         'commentable_type': this.commentableType,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -23,7 +23,7 @@
               .js-preview.is-long-text.thread-comment-form__preview(v-html="markdownDescription")
           .thread-comment-form__actions
             .thread-comment-form__action
-              button#js-shortcut-post-comment.a-button.is-lg.is-warning.is-block(@click="createComment" :disabled="!validation")
+              button#js-shortcut-post-comment.a-button.is-lg.is-warning.is-block(@click="createComment(); preventDoubleSubmit()" :disabled="!validation || bePushed")
                 | コメントする
 </template>
 <script>
@@ -44,7 +44,8 @@ export default {
       currentUser: {},
       comments: [],
       description: '',
-      tab: 'comment'
+      tab: 'comment',
+      bePushed: false
     }
   },
   created: function() {
@@ -102,8 +103,6 @@ export default {
     },
     createComment: function(event) {
       if (this.description.length < 1) {　return null　}
-      const obj = document.getElementById('js-shortcut-post-comment')
-      obj.disabled = true;
 
       let params = {
         'comment': { 'description': this.description },
@@ -128,6 +127,7 @@ export default {
           this.comments.push(json);
           this.description = '';
           this.tab = 'comment';
+          this.bePushed = false
         })
         .catch(error => {
           console.warn('Failed to parsing', error)
@@ -151,6 +151,9 @@ export default {
         .catch(error => {
           console.warn('Failed to parsing', error)
         })
+    },
+    preventDoubleSubmit: function() {
+      this.bePushed = true;
     }
   },
   computed: {

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -113,4 +113,14 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text "test"
     assert_equal "コメント", find(".thread-comment-form__tab.is-active").text
   end
+
+  test "prevent double submit" do
+    visit report_path(users(:komagata).reports.first)
+    within(".thread-comment-form__form") do
+      fill_in("comment[description]", with: "test")
+    end
+    assert_raises Selenium::WebDriver::Error::ElementClickInterceptedError do
+      find("#js-shortcut-post-comment", text: "コメントする").click.click
+    end
+  end
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -123,4 +123,18 @@ class CommentsTest < ApplicationSystemTestCase
       find("#js-shortcut-post-comment", text: "コメントする").click.click
     end
   end
+
+  test "submit_button is enabled after a post is done" do
+    visit report_path(users(:komagata).reports.first)
+    within(".thread-comment-form__form") do
+      fill_in("comment[description]", with: "test")
+    end
+    click_button "コメントする"
+    assert_text "test"
+    within(".thread-comment-form__form") do
+      fill_in("comment[description]", with: "testtest")
+    end
+    click_button "コメントする"
+    assert_text "testtest"
+  end
 end


### PR DESCRIPTION
Ref: #1282 

# 変更内容
- コメントの二重投稿を防ぐために、コメント投稿ボタンをクリックした後、ボタンが一時的にdisabledになるようにした。
- 上記機能のテストを追加した。

# 備考
- 自分でダブルクリックしただけでは二重投稿を再現できませんでしたが、エンターとクリックを同時に押すことで二重投稿になりました。
- 上記の機能を追加することでおそらく二重投稿を防げていると思うのですが、手動ではいつも二重投稿を再現できるわけではないので、確信が持てませんでした。
- テストでも一応二重投稿を再現できたと思うのですが、他にもっといいやり方がありましたらご教示お願いいたします。