### PR TITLE
お知らせ個別ページのタイトルを「お知らせ」に変更

### DIFF
--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -3,7 +3,7 @@
 header.page-header
   .container
     .page-header__inner
-      h1.page-header__title = title
+      h1.page-header__title = "お知らせ"
       .page-header-actions
         ul.page-header-actions__items
           - if admin_login?

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -3,7 +3,7 @@
 header.page-header
   .container
     .page-header__inner
-      h1.page-header__title = "お知らせ"
+      h1.page-header__title お知らせ
       .page-header-actions
         ul.page-header-actions__items
           - if admin_login?


### PR DESCRIPTION
## 概要

お知らせ個別ページのタイトルを、「お知らせのタイトル」から「お知らせ」に変更しました。

## 関連Issue

Ref: #1344 