### PR TITLE
コメントを編集するときにテキストエリアの縦幅を行数に揃える

### DIFF
--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -103,9 +103,9 @@ export default {
     },
     editComment: function() {
       this.editing = true;
-      setTimeout(function() {
-       $('textarea').trigger('input');
-    },0);
+      this.$nextTick(function() {
+        $('textarea').trigger('input');
+      })
     },
     updateComment: function() {
       if (this.description.length < 1) {　return null　}

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -104,7 +104,7 @@ export default {
     editComment: function() {
       this.editing = true;
       this.$nextTick(function() {
-        $('textarea').trigger('input');
+        $(`.comment-id-${this.comment.id}`).trigger('input');
       })
     },
     updateComment: function() {

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -103,6 +103,9 @@ export default {
     },
     editComment: function() {
       this.editing = true;
+      setTimeout(function() {
+       $('textarea').trigger('input');
+    },0);
     },
     updateComment: function() {
       if (this.description.length < 1) {　return null　}


### PR DESCRIPTION
## 概要
- 長文のコメントを編集するときに、テキストエリアの縦幅が狭くなってしまう問題を解消。

ref: #1241 

## スクリーンショット
![image](https://user-images.githubusercontent.com/50227745/74494471-76d98e00-4f18-11ea-8d0e-52581bd1f2c9.png)

![image](https://user-images.githubusercontent.com/50227745/74494374-3b3ec400-4f18-11ea-8059-7749f2fd1125.png)
