### PR TITLE
ユーザー名orメールアドレスでログインできるように変更

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   end
 
   def create
-    @user = login(params[:user][:login_name], params[:user][:password], params[:remember])
+    @user = login(params[:user][:login], params[:user][:password], params[:remember])
     if @user
       if @user.retired_on?
         logout

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -13,7 +13,11 @@ class UserSessionsController < ApplicationController
         redirect_to retire_path
       else
         save_updated_at(@user)
-        redirect_back_or_to root_url, notice: "ログインしました。"
+        if /\A[0-9a-zA-Z]+\z/.match?(@user.login_name)
+          redirect_back_or_to root_url, notice: "ログインしました。"
+        else
+          redirect_to edit_current_user_path
+        end
       end
     else
       logout

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,10 +87,18 @@ class User < ActiveRecord::Base
 
   after_update UserCallbacks.new
 
+  attr_accessor :login
+
   validates :email,      presence: true, uniqueness: true
   validates :first_name, presence: true
   validates :last_name,  presence: true
-  validates :login_name, presence: true, uniqueness: true
+  validates :login_name,
+    presence: true,
+    uniqueness: true,
+    format: {
+    with: /\A[0-9a-zA-Z]+\z/,
+    message: "は半角英数字のみが使用できます"
+  }
   validates :nda, presence: true
   validates :password, length: { minimum: 4 }, confirmation: true, if: :password_required?
   validates :twitter_account,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,8 +87,6 @@ class User < ActiveRecord::Base
 
   after_update UserCallbacks.new
 
-  attr_accessor :login
-
   validates :email,      presence: true, uniqueness: true
   validates :first_name, presence: true
   validates :last_name,  presence: true

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -14,3 +14,11 @@
         label.flash__close(for="hide-flash")
         p.flash__message
           = alert
+- if logged_in? && !/\A[0-9a-zA-Z]+\z/.match?(current_user.login_name)
+  input.a-toggle-checkbox#hide-flash(type="checkbox")
+  .flash.is-alert
+    .container
+      .flash__container
+        label.flash__close(for="hide-flash")
+        p.flash__message
+          = link_to "ユーザー名を半角英数字に変更してください。", edit_current_user_path

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -1,8 +1,8 @@
 = form_for user, url: user_sessions_path, html: { id: "sign-in-form", class: "form", name: "user_session" }  do |f|
   .form__items
     .form-item
-      = f.label :login_name, class: "a-label"
-      = f.text_field :login_name, class: "a-text-input"
+      = f.label :login, "ユーザー名orメールアドレス", class: "a-label"
+      = f.text_field :login, class: "a-text-input"
     .form-item
       = f.label :password, class: "a-label"
       = f.password_field :password, class: "a-text-input"

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -1,8 +1,8 @@
 = form_for user, url: user_sessions_path, html: { id: "sign-in-form", class: "form", name: "user_session" }  do |f|
   .form__items
     .form-item
-      = f.label :login, "ユーザー名orメールアドレス", class: "a-label"
-      = f.text_field :login, class: "a-text-input"
+      = label_tag "user_login", "ユーザー名orメールアドレス", class: "a-label"
+      = text_field_tag "user[login]", "", class: "a-text-input", id: "user_login"
     .form-item
       = f.label :password, class: "a-label"
       = f.password_field :password, class: "a-text-input"

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -192,7 +192,7 @@ Rails.application.config.sorcery.configure do |config|
     # specify username attributes, for example: [:username, :email].
     # Default: `[:email]`
     #
-    user.username_attribute_names = [:login_name]
+    user.username_attribute_names = [:login_name, :email]
 
     # change *virtual* password attribute, the one which is used until an encrypted one is generated.
     # Default: `:password`

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -324,3 +324,25 @@ osnashi: #osを持たないユーザー
   experience: rails
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
+
+nihongo:
+  login_name: 日本語
+  email: nihongo@example.com
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  first_name: 日本語
+  last_name: 日本
+  kana_first_name: ニホンゴ
+  kana_last_name: ニホン
+  twitter_account: nihongo
+  facebook_url: http://www.facebook.com/nihongo
+  blog_url: http://nihongo.org
+  description: "ユーザー名が日本語のユーザーです"
+  course: course_1
+  job: office_worker
+  os: mac
+  study_place: remote
+  experience: ruby
+  organization: 日本語大学
+  updated_at: "2014-01-01 00:00:12"
+  created_at: "2014-01-01 00:00:12"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -73,6 +73,22 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "宮城県", users(:hatsuno).prefecture_name
   end
 
+  test "login_name" do
+    Bootcamp::Setup.attachment
+
+    user = users(:komagata)
+    user.login_name = "azAZ09"
+    assert user.valid?
+    user.login_name = "_@-"
+    assert user.invalid?
+    user.login_name = "あ"
+    assert user.invalid?
+    user.login_name = "ａｚＡＺ０９"
+    assert user.invalid?
+    user.login_name = users(:machida).login_name
+    assert user.invalid?
+  end
+
   test "twitter_account" do
     Bootcamp::Setup.attachment
 

--- a/test/supports/login_helper.rb
+++ b/test/supports/login_helper.rb
@@ -4,7 +4,7 @@ module LoginHelper
   def login_user(login_name, password)
     visit "/login"
     within("#sign-in-form") do
-      fill_in("user[login_name]", with: login_name)
+      fill_in("user[login]", with: login_name)
       fill_in("user[password]", with: password)
     end
     click_button "ログイン"

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -67,7 +67,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
     user = users(:hatsuno)
     visit "/admin/users/#{user.id}/edit"
     within "form[name=user]" do
-      fill_in "user[login_name]", with: "hatsuno-1"
+      fill_in "user[login_name]", with: "hatsuno1"
       click_on "更新する"
     end
     assert_text "ユーザー情報を更新しました。"

--- a/test/system/password_resets_test.rb
+++ b/test/system/password_resets_test.rb
@@ -16,7 +16,7 @@ class PasswordResetTest < ApplicationSystemTestCase
 
     visit login_url
     within "form[name=user_session]" do
-      fill_in "user[login_name]", with: user.login_name
+      fill_in "user[login]", with: user.login_name
       fill_in "user[password]", with: "testpassword"
       click_button "ログイン"
     end

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -5,10 +5,20 @@ require "application_system_test_case"
 class SignInTest < ApplicationSystemTestCase
   fixtures :users
 
-  test "sign in" do
+  test "sign in with login_name" do
     visit "/login"
     within("#sign-in-form") do
       fill_in("user[login]", with: "komagata")
+      fill_in("user[password]",   with: "testtest")
+    end
+    click_button "ログイン"
+    assert_equal "/", current_path
+  end
+
+  test "sign in with email" do
+    visit "/login"
+    within("#sign-in-form") do
+      fill_in("user[login]", with: "komagata@fjord.jp")
       fill_in("user[password]",   with: "testtest")
     end
     click_button "ログイン"

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -8,7 +8,7 @@ class SignInTest < ApplicationSystemTestCase
   test "sign in" do
     visit "/login"
     within("#sign-in-form") do
-      fill_in("user[login_name]", with: "komagata")
+      fill_in("user[login]", with: "komagata")
       fill_in("user[password]",   with: "testtest")
     end
     click_button "ログイン"
@@ -18,7 +18,7 @@ class SignInTest < ApplicationSystemTestCase
   test "sign in with wrong password" do
     visit "/login"
     within("#sign-in-form") do
-      fill_in("user[login_name]", with: "komagata")
+      fill_in("user[login]", with: "komagata")
       fill_in("user[password]",   with: "xxxxxxxx")
     end
     click_button "ログイン"
@@ -30,7 +30,7 @@ class SignInTest < ApplicationSystemTestCase
     logout
     visit "/login"
     within("#sign-in-form") do
-      fill_in("user[login_name]", with: "yameo")
+      fill_in("user[login]", with: "yameo")
       fill_in("user[password]",   with: "yameo@example.com")
     end
     click_button "ログイン"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -16,6 +16,14 @@ class UsersTest < ApplicationSystemTestCase
     assert_text "管理者としてログインしてください"
   end
 
+  test "ask user to change login_name when login_name is japanese" do
+    login_user "nihongo@example.com", "testtest"
+    assert_text "ユーザー名を半角英数字に変更してください"
+
+    visit root_path
+    assert_text "ユーザー名を半角英数字に変更してください"
+  end
+
   test "retire user" do
     stub_subscription_destroy!
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -16,12 +16,15 @@ class UsersTest < ApplicationSystemTestCase
     assert_text "管理者としてログインしてください"
   end
 
-  test "ask user to change login_name when login_name is japanese" do
-    login_user "nihongo@example.com", "testtest"
-    assert_text "ユーザー名を半角英数字に変更してください"
+  test "redirect to edit page when login_name is japanese" do
+    login_user "日本語", "testtest"
+    assert_text "登録情報変更"
+  end
 
+  test "always ask to change japanese login_name" do
+    login_user "日本語", "testtest"
     visit root_path
-    assert_text "ユーザー名を半角英数字に変更してください"
+    assert_text "ユーザー名を半角英数字に変更してください。"
   end
 
   test "retire user" do


### PR DESCRIPTION
## 概要

- ユーザー名だけでなく、メールアドレスでもログインできるようにしました。
- ユーザー名は半角英数字縛りにしました。
- メールアドレスでログイン後、ユーザー名が日本語の場合はユーザー情報編集画面に飛ぶようにしました。
- ログイン後でも、ユーザー名が日本語の場合は常に「ユーザー名を変更してください」と表示されるようにしました。

## 関連Issue

Ref: #1258 
