### PR TITLE
提出物個別ページにタブを追加

### DIFF
--- a/app/helpers/page_tab_helper.rb
+++ b/app/helpers/page_tab_helper.rb
@@ -76,7 +76,9 @@ module PageTabHelper
 
     def current_page_tab?(target_name)
       paths = url_for(only_path: false).split("/")
-      if paths[-2] == target_name
+      if paths[-2] == "products"
+        false
+      elsif paths[-2] == target_name
         true
       else
         paths.last == target_name

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -14,6 +14,9 @@ header.page-header
             li.page-header-actions__item
               = link_to products_unchecked_index_path, class: "a-button is-md is-secondary is-block" do
                 | 未チェック一覧
+
+= render "page_tabs", resource: @product.practice
+
 .page-body
   .container
     .thread


### PR DESCRIPTION
## 概要

- 提出物個別ページにタブを表示するようにしました。
- 提出物個別ページにいる時は、「提出物タブ」が選択されていない状態になるようにしました。

## 関連Issue

Ref: #1353 