### PR TITLE
ユーザーアイコンにマウスを当てると「name: role」が表示される

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -19,17 +19,18 @@ module UserDecorator
 
   def staff_roles
     staff_roles = [
-        { role: "管理者", value: admin },
-        { role: "メンター", value: mentor },
-        { role: "アドバイザー", value: adviser }
+      { role: "管理者", value: admin },
+      { role: "メンター", value: mentor },
+      { role: "アドバイザー", value: adviser }
     ]
     staff_roles.find_all { |v| v[:value] }
-        .map { |v| v[:role] }
-        .join("、")
+               .map { |v| v[:role] }
+               .join("、")
   end
 
   def icon_title
-    [self.login_name, self.staff_roles].reject(&:blank?).join(": ")
+    [self.login_name, self.staff_roles].reject(&:blank?)
+                                       .join(": ")
   end
 
   def url

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -17,6 +17,21 @@ module UserDecorator
     roles.detect { |v| v[:value] }[:role]
   end
 
+  def staff_roles
+    staff_roles = [
+        { role: "管理者", value: admin },
+        { role: "メンター", value: mentor },
+        { role: "アドバイザー", value: adviser }
+    ]
+    staff_roles.find_all { |v| v[:value] }
+        .map { |v| v[:role] }
+        .join("、")
+  end
+
+  def icon_title
+    [self.login_name, self.staff_roles].reject(&:blank?).join(": ")
+  end
+
   def url
     user_url(self)
   end

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -2,7 +2,7 @@
   .thread-comment
     .thread-comment__author
       a.thread-comment__author-link(:href="comment.user.url" itempro="url")
-        img.thread-comment__author-icon.a-user-icon(:src="comment.user.avatar_url" v-bind:class="userRole")
+        img.thread-comment__author-icon.a-user-icon(:src="comment.user.avatar_url" :title="comment.user.icon_title"  v-bind:class="userRole")
     .thread-comment__body.a-card(v-if="!editing")
       header.thread-comment__body-header
         h2.thread-comment__title

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -9,7 +9,7 @@
         @delete="deleteComment")
       .thread-comment-form
         .thread-comment__author
-          img.thread-comment__author-icon.a-user-icon(:src="currentUser.avatar_url")
+          img.thread-comment__author-icon.a-user-icon(:src="currentUser.avatar_url" :title="currentUser.icon_title")
         .thread-comment-form__form.a-card
           .thread-comment-form__tabs.js-tabs
             .thread-comment-form__tab.js-tabs__tab(:class="{'is-active': isActive('comment')}" @click="changeActiveTab('comment')")

--- a/app/views/admin/books/_table.html.slim
+++ b/app/views/admin/books/_table.html.slim
@@ -21,7 +21,7 @@
             = book.isbn
           td.admin-table__item-value
             - if book.borrowed
-              = image_tag book.borrowing_user_avatar, class: "admin-table__user-icon a-user-icon"
+              = image_tag book.borrowing_user_avatar, title: "#{book.borrowing_user_name}", class: "admin-table__user-icon a-user-icon"
               = link_to user_path(book.users.first), target: "_blank", rel: "noopener" do
                 = book.borrowing_user_name
           td.admin-table__item-value.is-text-align-center

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -47,7 +47,7 @@
                 | 非アクティブ
             td.admin-table__item-value
               = link_to user_path(user), class: "admin-table__user", target: "_blank" do
-                = image_tag user.avatar_url, class: "admin-table__user-icon a-user-icon"
+                = image_tag user.avatar_url, title: "#{user.icon_title}", class: "admin-table__user-icon a-user-icon"
                 span.admin-table__user-login-name
                   = user.login_name
                   | （#{user.full_name}）

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -33,4 +33,4 @@
                   | 削除
 
   = link_to announcement.user, itempro: "url", class: "thread__author-link" do
-    = image_tag announcement.user.avatar_url, class: "thread__author-icon a-user-icon is-#{announcement.user.role}"
+    = image_tag announcement.user.avatar_url, title: "#{announcement.user.icon_title}", class: "thread__author-icon a-user-icon is-#{announcement.user.role}"

--- a/app/views/announcements/_announcements.slim
+++ b/app/views/announcements/_announcements.slim
@@ -1,7 +1,7 @@
 .thread-list-item
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag announcement.user.avatar_url, class: "thread-list-item__author-icon a-user-icon is-#{announcement.user.role}"
+      = image_tag announcement.user.avatar_url, title: "#{announcement.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{announcement.user.role}"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to announcement, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -4,7 +4,7 @@
 .thread-comment(class="#{answer == answer.question.correct_answer ? "is-correct_answer" : ""}")
   .thread-comment__author
     = link_to answer.user, itempro: "url", class: "thread-comment__author-link" do
-      = image_tag answer.user.avatar_url, class: "thread-comment__author-icon a-user-icon is-#{answer.user.role}"
+      = image_tag answer.user.avatar_url, title: "#{answer.user.icon_title}", class: "thread-comment__author-icon a-user-icon is-#{answer.user.role}"
   .thread-comment__body.a-card
     - if answer == correct_answer
       .answer-badge

--- a/app/views/answers/_form.html.slim
+++ b/app/views/answers/_form.html.slim
@@ -1,6 +1,6 @@
 .thread-comment-form
   .thread-comment__author
-    = image_tag current_user.avatar_url, class: "thread-comment__author-icon a-user-icon is-#{current_user.role}"
+    = image_tag current_user.avatar_url, title: "#{current_user.icon_title}", class: "thread-comment__author-icon a-user-icon is-#{current_user.role}"
   = render "errors", object: answer
   = form_with model: [question, answer], local: true, html: { class: "thread-comment-form__form a-card", name: "answer" } do |f|
     .thread-comment-form__tabs.js-tabs

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -1,2 +1,2 @@
-json.(user, :id, :login_name, :url, :role)
+json.(user, :id, :login_name, :url, :role, :icon_title)
 json.avatar_url user.avatar_url

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -6,7 +6,7 @@ nav.global-nav
       .global-nav-current-user
         = link_to user_path(current_user), class: "global-nav-current-user__link"
           .global-nav-current-user__icon
-            = image_tag current_user.avatar_url, class: "global-nav-current-user__icon a-user-icon is-#{current_user.role}"
+            = image_tag current_user.avatar_url, title: "#{current_user.icon_title}", class: "global-nav-current-user__icon a-user-icon is-#{current_user.role}"
     .global-nav-links.is-contents-links
       ul.global-nav-links__items
         li.global-nav-links__item

--- a/app/views/application/_notification_sender.html.slim
+++ b/app/views/application/_notification_sender.html.slim
@@ -1,1 +1,1 @@
-= image_tag sender.avatar_url, class: "header-notifications-item__user-icon a-user-icon"
+= image_tag sender.avatar_url, title: "#{sender.icon_title}", class: "header-notifications-item__user-icon a-user-icon"

--- a/app/views/application/_student.html.slim
+++ b/app/views/application/_student.html.slim
@@ -1,3 +1,3 @@
 .practice-started-users__item
   = link_to user, class: "practice-started-users__item-link" do
-    = image_tag user.avatar_url, class: "practice-started-users__item-icon a-user-icon #{user.active? ? "active" : "inactive"} is-#{user.role}"
+    = image_tag user.avatar_url, title: "#{user.icon_title}", class: "practice-started-users__item-icon a-user-icon #{user.active? ? "active" : "inactive"} is-#{user.role}"

--- a/app/views/books/_table.html.slim
+++ b/app/views/books/_table.html.slim
@@ -18,7 +18,7 @@
             = book.isbn
           td.admin-table__item-value
             - if book.borrowed
-              = image_tag book.borrowing_user_avatar, class: "admin-table__user-icon a-user-icon"
+              = image_tag book.borrowing_user_avatar, title: book.users.first.icon_title, class: "admin-table__user-icon a-user-icon"
               = link_to user_path(book.users.first), target: "_blank", rel: "noopener" do
                 = book.borrowing_user_name
           td.admin-table__item-value.is-text-align-center

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -47,14 +47,14 @@
         - event.participants.each do |participant|
           li.footprints-item
             = link_to participant do
-              = image_tag participant.avatar_url, class: "footprints-item__checker-icon a-user-icon is-#{participant.login_name} is-#{participant.role}", alt: participant.login_name
+              = image_tag participant.avatar_url, title: "#{participant.icon_title}", class: "footprints-item__checker-icon a-user-icon is-#{participant.login_name} is-#{participant.role}", alt: participant.login_name
     .waitlist
       | 補欠者
       ul.footprints__items
         - event.waitlist.each do |wait_user|
           li.footprints-item
             = link_to wait_user do
-              = image_tag wait_user.avatar_url, class: "footprints-item__checker-icon a-user-icon is-#{wait_user.login_name} is-#{wait_user.role}", alt: wait_user.login_name
+              = image_tag wait_user.avatar_url, title: "#{wait_user.icon_title}", class: "footprints-item__checker-icon a-user-icon is-#{wait_user.login_name} is-#{wait_user.role}", alt: wait_user.login_name
 
   = link_to event.user, itempro: "url", class: "thread__author-link" do
-    = image_tag event.user.avatar_url, class: "thread__author-icon a-user-icon is-#{event.user.role}"
+    = image_tag event.user.avatar_url, title: "#{event.user.icon_title}", class: "thread__author-icon a-user-icon is-#{event.user.role}"

--- a/app/views/footprints/_footprint.html.slim
+++ b/app/views/footprints/_footprint.html.slim
@@ -1,3 +1,3 @@
 li.footprints-item
   = link_to footprint.user, itempro: "url" do
-    = image_tag footprint.user.avatar_url, class: "footprints-item__checker-icon a-user-icon is-#{footprint.user.login_name} is-#{footprint.user.role}", alt: footprint.user.login_name
+    = image_tag footprint.user.avatar_url, title: "#{footprint.user.icon_title}", class: "footprints-item__checker-icon a-user-icon is-#{footprint.user.login_name} is-#{footprint.user.role}", alt: footprint.user.login_name

--- a/app/views/home/_announcements.html.slim
+++ b/app/views/home/_announcements.html.slim
@@ -2,7 +2,7 @@
   .thread-list-item__inner
     .thread-list-item__author
       = link_to announcement.user do
-        = image_tag announcement.user.avatar_url, class: "thread-list-item__author-icon a-user-icon is-#{announcement.user.role}"
+        = image_tag announcement.user.avatar_url, title: "#{announcement.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{announcement.user.role}"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to announcement, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item(class="#{notification.read? ? "is-read" : "is-unread"}")
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag notification.sender.avatar_url, class: "thread-list-item__author-icon a-user-icon"
+      = image_tag notification.sender.avatar_url, title: "#{notification.sender.icon_title}", class: "thread-list-item__author-icon a-user-icon"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - unless notification.read?

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item(class="#{product.wip? ? "is-wip" : ""}")
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag product.user.avatar_url, class: "thread-list-item__author-icon a-user-icon"
+      = image_tag product.user.avatar_url, title: "#{product.user.icon_title}", class: "thread-list-item__author-icon a-user-icon"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if product.wip?
@@ -22,7 +22,7 @@
         .thread-list-item-meta__comment-count
           .thread-list-item-meta__comment-count-value
             - product.checks.each do |check|
-              = image_tag check.user.avatar_url, class: "thread-list-item__checked-author-icon a-user-icon is-#{check.user.role}"
+              = image_tag check.user.avatar_url, title: "#{check.user.icon_title}", class: "thread-list-item__checked-author-icon a-user-icon is-#{check.user.role}"
         .stamp.stamp-approve
           h2.stamp__content.is-title 確認済
           time.stamp__content.is-created-at

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -65,7 +65,7 @@ header.page-header
             | プラクティスに戻る
 
       = link_to @product.user, itempro: "url", class: "thread__author-link" do
-        = image_tag @product.user.avatar_url, class: "thread__author-icon a-user-icon is-#{@product.user.role}"
+        = image_tag @product.user.avatar_url, title: "#{@product.user.icon_title}", class: "thread__author-icon a-user-icon is-#{@product.user.role}"
 
     #js-comments(data-commentable-id="#{@product.id}" data-commentable-type="Product" data-current-user-id="#{current_user.id}")
     = render "footprints/footprints", footprints: @footprints

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag question.user.avatar_url, class: "thread-list-item__author-icon a-user-icon is-#{question.user.role}"
+      = image_tag question.user.avatar_url, title: "#{question.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{question.user.role}"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to question, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -55,7 +55,7 @@ header.page-header
                     | 削除
 
       = link_to @question.user, itempro: "url", class: "thread__author-link" do
-        = image_tag @question.user.avatar_url, class: "thread__author-icon a-user-icon is-#{@question.user.role}"
+        = image_tag @question.user.avatar_url, title: "#{@question.user.icon_title}", class: "thread__author-icon a-user-icon is-#{@question.user.role}"
     .thread-comments-container
       h3.thread-comments-container__title
         | 回答・コメント

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item(class="#{report.wip? ? "is-wip" : ""}")
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag report.user.avatar_url, class: "thread-list-item__author-icon a-user-icon is-#{report.user.role}"
+      = image_tag report.user.avatar_url, title: "#{report.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{report.user.role}"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if report.wip?
@@ -28,7 +28,7 @@
       - if report.checks.any?
         .thread-list-item-meta__checkers
           - report.checks.each do |check|
-            = image_tag check.user.avatar_url, class: "thread-list-item__checked-author-icon a-user-icon is-#{check.user.role}"
+            = image_tag check.user.avatar_url, title: "#{check.user.icon_title}", class: "thread-list-item__checked-author-icon a-user-icon is-#{check.user.role}"
         .stamp.stamp-approve
           h2.stamp__content.is-title 確認済
           time.stamp__content.is-created-at

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -90,6 +90,6 @@ header.page-header
               | 次の日報
               i.fas.fa-angle-right
       = link_to @report.user, itempro: "url", class: "thread__author-link" do
-        = image_tag @report.user.avatar_url, class: "thread__author-icon a-user-icon is-#{@report.user.role}"
+        = image_tag @report.user.avatar_url, title: "#{@report.user.icon_title}", class: "thread__author-icon a-user-icon is-#{@report.user.role}"
     #js-comments(data-commentable-id="#{@report.id}" data-commentable-type="Report" data-current-user-id="#{current_user.id}")
     = render "footprints/footprints", footprints: @footprints

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -1,6 +1,6 @@
 .user-profile
   .user-profile__icon
-    = image_tag user.avatar_url, class: "user-profile__user-icon-image a-user-icon is-#{user.role}"
+    = image_tag user.avatar_url, title: "#{user.icon_title}", class: "user-profile__user-icon-image a-user-icon is-#{user.role}"
   .user-profile__names
     h1.user-profile__login-name
       = user.login_name

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -20,7 +20,7 @@
           = render "users/user_secret_attributes", user: user
           .users-item__icon
             = link_to user do
-              = image_tag user.avatar_url, class: "users-item__user-icon-image a-user-icon is-#{user.role}"
+              = image_tag user.avatar_url, title: "#{user.icon_title}", class: "users-item__user-icon-image a-user-icon is-#{user.role}"
         = render "users/sns", user: user
       .users-item__body
         .users-item__description.a-short-text

--- a/app/views/users/comments/_comment.html.slim
+++ b/app/views/users/comments/_comment.html.slim
@@ -7,7 +7,7 @@
       - if user_comments_page?
         h2.thread-list-item__title
           = link_to commentable, class: "thread-list-item__title-link" do
-            = image_tag commentable.user.avatar_url, class: "thread-comment__title-icon a-user-icon"
+            = image_tag commentable.user.avatar_url, title: "#{commentable.user.icon_title}", class: "thread-comment__title-icon a-user-icon"
             = truncate(commentable.title, length: 50)
       - else
         h2.thread-list-item__title

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -17,7 +17,7 @@ header.page-header
       .thread__inner.a-card
         header.thread-header
           = link_to user_portfolio_path(@work.user), itempro: "url", class: "thread-header__author-link" do
-            = image_tag @work.user.avatar_url, class: "thread-header__author-icon a-user-icon is-#{@work.user.role}"
+            = image_tag @work.user.avatar_url, title: "#{@work.user.icon_title}", class: "thread-header__author-icon a-user-icon is-#{@work.user.role}"
           h2.thread-header__title
             = @work.title
           .thread-header__lower-side

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UserDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @user1 = ActiveDecorator::Decorator.instance.decorate(users(:komagata))
+    @user2 = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
+  end
+
+  test "icon_title" do
+    assert_equal "komagata: 管理者、メンター", @user1.icon_title
+    assert_equal "hajime", @user2.icon_title
+  end
+end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -8,6 +8,11 @@ class UserDecoratorTest < ActiveSupport::TestCase
     @user2 = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
   end
 
+  test "staff_roles" do
+    assert_equal "管理者、メンター", @user1.staff_roles
+    assert_equal "", @user2.staff_roles
+  end
+
   test "icon_title" do
     assert_equal "komagata: 管理者、メンター", @user1.icon_title
     assert_equal "hajime", @user2.icon_title


### PR DESCRIPTION
## 変更の目的
Ref:#1261

## 変更の概要
- 全てのユーザーアイコンのimgタグに「name: role」というtitle属性を追加しました。
- `user_decorator`に「name: role」を返すメソッドを追加しました。
- 上記のメソッドに対して、単体テストを追加しました(「画像にマウスを置くと、title属性が表示される」という機能はブラウザの機能であるため、そのテストは追加しませんでした)。

## キャプチャ
[![Image from Gyazo](https://i.gyazo.com/8933b5cae32e220c6bd98527f6f70019.gif)](https://gyazo.com/8933b5cae32e220c6bd98527f6f70019)