### PR TITLE
ユーザー名orメールアドレスでログインできるように変更

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   end
 
   def create
-    @user = login(params[:user][:login_name], params[:user][:password], params[:remember])
+    @user = login(params[:user][:login], params[:user][:password], params[:remember])
     if @user
       if @user.retired_on?
         logout

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -1,8 +1,8 @@
 = form_for user, url: user_sessions_path, html: { id: "sign-in-form", class: "form", name: "user_session" }  do |f|
   .form__items
     .form-item
-      = f.label :login_name, class: "a-label"
-      = f.text_field :login_name, class: "a-text-input"
+      = label_tag "user_login", "ユーザー名orメールアドレス", class: "a-label"
+      = text_field_tag "user[login]", "", class: "a-text-input", id: "user_login"
     .form-item
       = f.label :password, class: "a-label"
       = f.password_field :password, class: "a-text-input"

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -192,7 +192,7 @@ Rails.application.config.sorcery.configure do |config|
     # specify username attributes, for example: [:username, :email].
     # Default: `[:email]`
     #
-    user.username_attribute_names = [:login_name]
+    user.username_attribute_names = [:login_name, :email]
 
     # change *virtual* password attribute, the one which is used until an encrypted one is generated.
     # Default: `:password`

--- a/test/supports/login_helper.rb
+++ b/test/supports/login_helper.rb
@@ -4,7 +4,7 @@ module LoginHelper
   def login_user(login_name, password)
     visit "/login"
     within("#sign-in-form") do
-      fill_in("user[login_name]", with: login_name)
+      fill_in("user[login]", with: login_name)
       fill_in("user[password]", with: password)
     end
     click_button "ログイン"

--- a/test/system/password_resets_test.rb
+++ b/test/system/password_resets_test.rb
@@ -16,7 +16,7 @@ class PasswordResetTest < ApplicationSystemTestCase
 
     visit login_url
     within "form[name=user_session]" do
-      fill_in "user[login_name]", with: user.login_name
+      fill_in "user[login]", with: user.login_name
       fill_in "user[password]", with: "testpassword"
       click_button "ログイン"
     end

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -5,10 +5,20 @@ require "application_system_test_case"
 class SignInTest < ApplicationSystemTestCase
   fixtures :users
 
-  test "sign in" do
+  test "sign in with login_name" do
     visit "/login"
     within("#sign-in-form") do
-      fill_in("user[login_name]", with: "komagata")
+      fill_in("user[login]", with: "komagata")
+      fill_in("user[password]",   with: "testtest")
+    end
+    click_button "ログイン"
+    assert_equal "/", current_path
+  end
+
+  test "sign in with email" do
+    visit "/login"
+    within("#sign-in-form") do
+      fill_in("user[login]", with: "komagata@fjord.jp")
       fill_in("user[password]",   with: "testtest")
     end
     click_button "ログイン"
@@ -18,7 +28,7 @@ class SignInTest < ApplicationSystemTestCase
   test "sign in with wrong password" do
     visit "/login"
     within("#sign-in-form") do
-      fill_in("user[login_name]", with: "komagata")
+      fill_in("user[login]", with: "komagata")
       fill_in("user[password]",   with: "xxxxxxxx")
     end
     click_button "ログイン"
@@ -30,7 +40,7 @@ class SignInTest < ApplicationSystemTestCase
     logout
     visit "/login"
     within("#sign-in-form") do
-      fill_in("user[login_name]", with: "yameo")
+      fill_in("user[login]", with: "yameo")
       fill_in("user[password]",   with: "yameo@example.com")
     end
     click_button "ログイン"


### PR DESCRIPTION
## 概要

- ユーザー名だけでなく、メールアドレスでもログインできるようにしました。

## 関連Issue

Ref: #1258 