### PR TITLE
adminは他人のコメントを修正・削除できるように変更

### DIFF
--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -14,7 +14,7 @@
       reaction(
         v-bind:reactionable="comment",
         v-bind:currentUser="currentUser")
-      footer.card-footer(v-if="comment.user.id == currentUser.id")
+      footer.card-footer(v-if="comment.user.id == currentUser.id || currentUser.role == 'admin'")
         .card-footer-actions
           ul.card-footer-actions__items
             li.card-footer-actions__item


### PR DESCRIPTION
## 概要

- adminのroleが割り当てられているユーザーは、他のユーザーのコメントを修正・削除できるようにしました。

## 関連Issue

Ref: #1384 