### PR TITLE
adminは他人のコメントを修正・削除できるように変更 

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -3,7 +3,6 @@
 class API::CommentsController < API::BaseController
   before_action :require_login
   before_action :set_my_comment, only: %i(update destroy)
-  before_action :admin_set_comment, only: %i(update destroy)
 
   def index
     @comments = commentable.comments.order(created_at: :asc)
@@ -47,9 +46,6 @@ class API::CommentsController < API::BaseController
 
     def set_my_comment
       @comment = current_user.comments.find_by(id: params[:id])
-    end
-
-    def admin_set_comment
       @comment ||= Comment.find(params[:id]) if current_user.admin?
     end
 

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -3,6 +3,7 @@
 class API::CommentsController < API::BaseController
   before_action :require_login
   before_action :set_my_comment, only: %i(update destroy)
+  before_action :admin_set_comment, only: %i(update destroy)
 
   def index
     @comments = commentable.comments.order(created_at: :asc)
@@ -45,7 +46,11 @@ class API::CommentsController < API::BaseController
     end
 
     def set_my_comment
-      @comment = current_user.comments.find(params[:id])
+      @comment = current_user.comments.find_by(id: params[:id])
+    end
+
+    def admin_set_comment
+      @comment ||= Comment.find(params[:id]) if current_user.admin?
     end
 
     def notify_to_slack(comment)

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -14,7 +14,7 @@
       reaction(
         v-bind:reactionable="comment",
         v-bind:currentUser="currentUser")
-      footer.card-footer(v-if="comment.user.id == currentUser.id")
+      footer.card-footer(v-if="comment.user.id == currentUser.id || currentUser.role == 'admin'")
         .card-footer-actions
           ul.card-footer-actions__items
             li.card-footer-actions__item


### PR DESCRIPTION
## 概要

- adminのroleが割り当てられているユーザーは、他のユーザーのコメントを修正・削除できるようにしました。

## 関連Issue

Ref: #1384 