### PR TITLE
予約できる座席数を5日分に限定

### DIFF
--- a/app/javascript/reservation.vue
+++ b/app/javascript/reservation.vue
@@ -1,10 +1,10 @@
 <template lang="pug">
   .reservation
     template(v-if="this.currentUserId == this.userId")
-      .reservations__seat-action.is-reserved.is-me(@click="deleteReservation")
+      #cancel-reservation.reservations__seat-action.is-reserved.is-me(@click="deleteReservation")
         | {{ this.loginName }}
     template(v-else)
-      .reservations__seat-action.is-reserved.is-not-me
+      #cancel-reservation.reservations__seat-action.is-reserved.is-not-me
         | {{ this.loginName }}
 </template>
 <script>

--- a/app/javascript/reservations.vue
+++ b/app/javascript/reservations.vue
@@ -13,7 +13,7 @@
           .reservations__day-item.date(v-for="one_day in this_months" v-bind:class="is_holiday(reservationsHolidayJps[one_day['ymd']])")
             .reservations__day-item-value.reservations__day.is-day {{ one_day['d_jp'] }}
             .reservations__day-item-value.reservations__seat.is-seat(v-for="seat in seats" :key="seat.id" v-bind:id="reservation_hash_id(one_day['ymd'],(seat.id))")
-              .reservations__seat-action(v-if="reservations[`${one_day['ymd']}-${seat.id}`] === undefined" @click="createReservation(one_day['ymd'], seat.id)")
+              #reserve-seat.reservations__seat-action(v-if="reservations[`${one_day['ymd']}-${seat.id}`] === undefined" @click="createReservation(one_day['ymd'], seat.id)")
                 |
               reservation(v-else :currentUserId="currentUserId", :parentReservation="reservations[`${one_day['ymd']}-${seat.id}`]", @delete="deleteReservation")
             .reservations__day-item-value(v-if="admin_login == 1" v-bind:id="memoId(one_day['ymd'])").is-memo

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -6,11 +6,26 @@ class Reservation < ApplicationRecord
 
   validates :seat_id, uniqueness: { scope: :date }
   validate :after_a_month
+  validate :limit_reservations_to_five, unless: :admin_or_trainee?
 
   private
     def after_a_month
       if date > (Date.today.next_month)
         errors.add(:date, "は一ヶ月先までしか予約できません")
       end
+    end
+
+    def limit_reservations_to_five
+      if date > Date.today && already_five_reservations?
+        errors.add(:base, "明日以降の座席は最大５つまでしか予約できません")
+      end
+    end
+
+    def admin_or_trainee?
+      user.admin? || user.trainee?
+    end
+
+    def already_five_reservations?
+      user.reservations.count { |reservation| reservation.date > Date.today } >= 5
     end
 end

--- a/app/views/reservation_calenders/show.html.slim
+++ b/app/views/reservation_calenders/show.html.slim
@@ -13,12 +13,12 @@ header.page-header
       header.calender-header
         .calender-header__inner
           .calender-header__nav
-            = link_to reservation_calender_path(l(@prev_month, format: :ym)), class: "a-button is-md is-secondary is-icon is-block" do
+            = link_to reservation_calender_path(l(@prev_month, format: :ym)), id: "previous-month", class: "a-button is-md is-secondary is-icon is-block" do
               i.fas.fa-angle-left
           h2.calender-header__title
             = l(@this_month, format: :ym_jp)
           .calender-header__nav
-            = link_to reservation_calender_path(l(@next_month, format: :ym)), class: "a-button is-md is-secondary is-icon is-block" do
+            = link_to reservation_calender_path(l(@next_month, format: :ym)), id: "next-month", class: "a-button is-md is-secondary is-icon is-block" do
               i.fas.fa-angle-right
       .calender__body
         #js-reservations(data-reservations-beggining-of-this-month="#{@this_month}" data-reservations-end-of-this-month="#{@this_month.end_of_month}" data-current-user-id="#{current_user.id}")

--- a/test/system/api/memos_test.rb
+++ b/test/system/api/memos_test.rb
@@ -12,6 +12,7 @@ class API::MemosTest < ApplicationSystemTestCase
     assert_equal "席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
 
     within("#memo-2019-11-01") do
+      find('label[for="2019-11-01"]').click
       fill_in "memo[body]", with: "イベント：潮干狩り"
       click_button "作成"
     end
@@ -25,6 +26,7 @@ class API::MemosTest < ApplicationSystemTestCase
     assert_equal "席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
 
     within("#memo-2019-11-01") do
+      find('label[for="2019-11-01"]').click
       fill_in "memo[body]", with: "イベント：潮干狩り"
       click_button "作成"
     end
@@ -38,6 +40,7 @@ class API::MemosTest < ApplicationSystemTestCase
     assert_equal "席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
 
     within("#memo-#{memos(:memo_1).date}") do
+      find('label[for="' + "#{memos(:memo_1).date}" + '"]').click
       fill_in "memo[body]", with: "イベント：潮干狩り"
       click_button "更新"
     end
@@ -51,6 +54,7 @@ class API::MemosTest < ApplicationSystemTestCase
     assert_equal "席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
 
     within("#memo-#{memos(:memo_1).date}") do
+      find('label[for="' + "#{memos(:memo_1).date}" + '"]').click
       click_button "削除"
     end
     within("#memo-#{memos(:memo_1).date}") do
@@ -64,7 +68,7 @@ class API::MemosTest < ApplicationSystemTestCase
     assert_equal "席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
 
     within("#memo-#{memos(:memo_1).date}") do
-      assert_no_text "削除"
+      assert_no_selector("#memo")
     end
   end
 end

--- a/test/system/reservation_calenders_test.rb
+++ b/test/system/reservation_calenders_test.rb
@@ -14,7 +14,7 @@ class ReservationCalendersTest < ApplicationSystemTestCase
 
   test "show next month of 2019/10 reservation calender" do
     visit "/reservation_calenders/201910"
-    click_on "来月"
+    click_link "next-month"
     assert_text "2019年11月"
   end
 end

--- a/test/system/reservations_test.rb
+++ b/test/system/reservations_test.rb
@@ -12,7 +12,7 @@ class ReservationsTest < ApplicationSystemTestCase
     assert_equal "席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
 
     within("#reservation-2019-11-02-#{seats(:seat_2).id}") do
-      click_button
+      find("#reserve-seat").click
     end
     within("#reservation-2019-11-02-#{seats(:seat_2).id}") do
       assert_text "komagata"
@@ -25,7 +25,7 @@ class ReservationsTest < ApplicationSystemTestCase
 
     accept_confirm do
       within("#reservation-#{reservations(:reservation_1).date}-#{reservations(:reservation_1).seat.id}") do
-        click_button
+        find("#cancel-reservation").click
       end
     end
     within("#reservation-#{reservations(:reservation_1).date}-#{reservations(:reservation_1).seat.id}") do
@@ -36,16 +36,16 @@ class ReservationsTest < ApplicationSystemTestCase
   test "reservations beyond one month cannot be made" do
     visit "/reservation_calenders"
     assert_equal "席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
-    click_on "来月"
+    click_link "next-month"
 
     reservation_date = Date.current.next_month.tomorrow
 
     if (Date.current.month + 2) <= reservation_date.month
-      click_on "来月"
+      click_link "next-month"
     end
     accept_confirm do
       within("#reservation-#{reservation_date}-#{seats(:seat_2).id}") do
-        click_button
+        find("#reserve-seat").click
       end
     end
 


### PR DESCRIPTION
## 概要

- 明日以降に予約できる座席数を5日分に限定し、それ以上は予約できないようにしました。

## 関連Issue

Ref: #1420 
