### PR TITLE
別ページから戻った場合、コメントフォームに一つ目のコメントが勝手に入るバグ修正

### DIFF
--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -33,7 +33,7 @@
           | プレビュー
       .thread-comment-form__markdown-parent.js-markdown-parent
         .thread-comment-form__markdown.js-tabs__content(v-bind:class="{'is-active': isActive('comment')}")
-          markdown-textarea(v-model="description" :class="classCommentId" class="a-text-input js-warning-form thread-comment-form__textarea js-comment-markdown" name="comment[description]")
+          markdown-textarea(v-model="description" :class="classCommentId" class="a-text-input js-warning-form thread-comment-form__textarea js-comment-markdown")
         .thread-comment-form__markdown.js-tabs__content(v-bind:class="{'is-active': isActive('preview')}")
           .js-preview.is-long-text.thread-comment-form__preview(v-html="markdownDescription")
       .thread-comment-form__actions

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -33,7 +33,7 @@
           | プレビュー
       .thread-comment-form__markdown-parent.js-markdown-parent
         .thread-comment-form__markdown.js-tabs__content(v-bind:class="{'is-active': isActive('comment')}")
-          markdown-textarea(v-model="description" :class="classCommentId" class="a-text-input js-warning-form thread-comment-form__textarea js-comment-markdown")
+          markdown-textarea(v-model="description" :class="classCommentId" class="a-text-input js-warning-form thread-comment-form__textarea js-comment-markdown" name="comment[description]")
         .thread-comment-form__markdown.js-tabs__content(v-bind:class="{'is-active': isActive('preview')}")
           .js-preview.is-long-text.thread-comment-form__preview(v-html="markdownDescription")
       .thread-comment-form__actions

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -18,7 +18,7 @@
               | プレビュー
           .thread-comment-form__markdown-parent.js-markdown-parent
             .thread-comment-form__markdown.js-tabs__content(:class="{'is-active': isActive('comment')}")
-              markdown-textarea(v-model="description" id="js-new-comment" class="a-text-input js-warning-form thread-comment-form__textarea js-markdown" name="comment[description]")
+              markdown-textarea(v-model="description" id="js-new-comment" class="a-text-input js-warning-form thread-comment-form__textarea js-markdown" name="new_comment[description]")
             .thread-comment-form__markdown.js-tabs__content(:class="{'is-active': isActive('preview')}")
               .js-preview.is-long-text.thread-comment-form__preview(v-html="markdownDescription")
           .thread-comment-form__actions

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -66,7 +66,7 @@ class CommentsTest < ApplicationSystemTestCase
     within(".thread-comment:first-child") do
       click_button "編集"
       within(:css, ".thread-comment-form__form") do
-        fill_in("comment[description]", with: "edit test")
+        find("textarea.thread-comment-form__textarea").set "edit test"
       end
       click_button "保存する"
     end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -12,12 +12,12 @@ class CommentsTest < ApplicationSystemTestCase
 
   test "comment form not found in /users/:user_id/comments" do
     visit user_comments_path(users(:komagata))
-    assert has_no_field?("comment[description]")
+    assert has_no_field?("new_comment[description]")
   end
 
   test "comment form found in /reports/:report_id" do
     visit report_path(users(:komagata).reports.first)
-    assert has_field?("comment[description]")
+    assert has_field?("new_comment[description]")
   end
 
   test "comment form in reports/:id has comment tab and preview tab" do
@@ -40,7 +40,7 @@ class CommentsTest < ApplicationSystemTestCase
   test "post new comment for report" do
     visit "/reports/#{reports(:report_1).id}"
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
+      fill_in("new_comment[description]", with: "test")
     end
     click_button "コメントする"
     assert_text "test"
@@ -66,7 +66,7 @@ class CommentsTest < ApplicationSystemTestCase
     within(".thread-comment:first-child") do
       click_button "編集"
       within(:css, ".thread-comment-form__form") do
-        find("textarea.thread-comment-form__textarea").set "edit test"
+        fill_in("comment[description]", with: "edit test")
       end
       click_button "保存する"
     end
@@ -86,7 +86,7 @@ class CommentsTest < ApplicationSystemTestCase
   test "post new comment for product" do
     visit "/products/#{products(:product_1).id}"
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
+      fill_in("new_comment[description]", with: "test")
     end
     click_button "コメントする"
     assert_text "test"
@@ -95,7 +95,7 @@ class CommentsTest < ApplicationSystemTestCase
   test "post new comment for announcement" do
     visit "/announcements/#{announcements(:announcement_1).id}"
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
+      fill_in("new_comment[description]", with: "test")
     end
     click_button "コメントする"
     assert_text "test"
@@ -105,7 +105,7 @@ class CommentsTest < ApplicationSystemTestCase
     visit "/reports/#{reports(:report_3).id}"
     assert_equal "コメント", find(".thread-comment-form__tab.is-active").text
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
+      fill_in("new_comment[description]", with: "test")
     end
     find(".thread-comment-form__tab", text: "プレビュー").click
     assert_equal "プレビュー", find(".thread-comment-form__tab.is-active").text
@@ -117,7 +117,7 @@ class CommentsTest < ApplicationSystemTestCase
   test "prevent double submit" do
     visit report_path(users(:komagata).reports.first)
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
+      fill_in("new_comment[description]", with: "test")
     end
     assert_raises Selenium::WebDriver::Error::ElementClickInterceptedError do
       find("#js-shortcut-post-comment", text: "コメントする").click.click
@@ -127,12 +127,12 @@ class CommentsTest < ApplicationSystemTestCase
   test "submit_button is enabled after a post is done" do
     visit report_path(users(:komagata).reports.first)
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
+      fill_in("new_comment[description]", with: "test")
     end
     click_button "コメントする"
     assert_text "test"
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "testtest")
+      fill_in("new_comment[description]", with: "testtest")
     end
     click_button "コメントする"
     assert_text "testtest"

--- a/test/system/notification/comments_test.rb
+++ b/test/system/notification/comments_test.rb
@@ -8,7 +8,7 @@ class Notification::CommentsTest < ApplicationSystemTestCase
     visit "/reports/#{reports(:report_1).id}"
 
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "@machida @machida test")
+      fill_in("new_comment[description]", with: "@machida @machida test")
     end
     click_button "コメントする"
     assert_text "@machida @machida test"

--- a/test/system/notification/same_notifications_test.rb
+++ b/test/system/notification/same_notifications_test.rb
@@ -26,7 +26,7 @@ class NotificationsTest < ApplicationSystemTestCase
     find(".global-nav").click_link("日報")
     click_link "Rubyの基礎"
     click_button "日報を確認"
-    fill_in "comment[description]", with: "今日の日報を確認しました"
+    fill_in "new_comment[description]", with: "今日の日報を確認しました"
     click_button "コメントする"
     find(".test-show-menu").click
     click_link "ログアウト"
@@ -50,7 +50,7 @@ class NotificationsTest < ApplicationSystemTestCase
     # ユーザーからコメントが来た時(admin)
     click_link "日報"
     click_link "Rubyの基礎"
-    fill_in "comment[description]", with: "@komagata ユーザーからのコメント"
+    fill_in "new_comment[description]", with: "@komagata ユーザーからのコメント"
     click_button "コメントする"
     find(".test-show-menu").click
     click_link "ログアウト"

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -9,7 +9,7 @@ class Notification::WatchesTest < ApplicationSystemTestCase
     login_user "machida", "testtest"
     visit "/reports/#{reports(:report_1).id}"
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "いい日報ですね。")
+      fill_in("new_comment[description]", with: "いい日報ですね。")
     end
     click_button "コメントする"
     logout
@@ -17,7 +17,7 @@ class Notification::WatchesTest < ApplicationSystemTestCase
     login_user "komagata", "testtest"
     visit "/reports/#{reports(:report_1).id}"
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "コメントありがとうございます。")
+      fill_in("new_comment[description]", with: "コメントありがとうございます。")
     end
     click_button "コメントする"
     logout

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -7,7 +7,7 @@ class NotificationsTest < ApplicationSystemTestCase
     login_user "kimura", "testtest"
     visit "/reports/#{reports(:report_8).id}"
     within(".thread-comment-form__form") do
-      fill_in("comment[description]", with: "test")
+      fill_in("new_comment[description]", with: "test")
     end
     click_button "コメントする"
 


### PR DESCRIPTION
## 問題
コメントがあるページから別のページに移動し、ブラウザバックで戻るとコメントフォームに最初のコメントが入力されてる状態になる。
Ref: https://github.com/fjordllc/bootcamp/issues/1374
## 原因
新規のコメントと既存のコメント（編集するためtextareaを持ってる）が全て`name="comment[description]"`と同じnameを持っている状態だった。
vueでコンポーネント化してるためか、bfcacheが既存と新規のコメントフォームを区別せず、同じ`name="comment[description]"`の配列(?)が利用される。
<img width="762" alt="スクリーンショット_2020-02-28_21_17_11" src="https://user-images.githubusercontent.com/10154448/75554783-58c66e80-5a7e-11ea-8280-94ea28d3dd60.png">

そのため進むか戻るを行うと、おそらく参照先が一緒のため、bfcacheによって既存コメントの1番目が新規コメントの中に補完される。

## 対処方法
既存コメントのtextareaにname属性が入っていたが、コードを見る限りテスト以外で使われていなかったので削除しました。（中の値はvue側が処理してrails側と非同期で処理してる）
テストで使っている部分は別の方法で要素を見つけるように修正しました。

## 動作画面
![2ef62ebb903489f2b4410778fd2d4753](https://user-images.githubusercontent.com/10154448/75555346-64666500-5a7f-11ea-9220-da1d929cc511.gif)
