### PR TITLE
就活希望者のみにお知らせを送る機能追加

### DIFF
--- a/app/assets/stylesheets/blocks/form/_form-checkbox.sass
+++ b/app/assets/stylesheets/blocks/form/_form-checkbox.sass
@@ -1,7 +1,7 @@
 .form-checkbox__label
   +text-block(.8125rem 1.45 0 .5rem, block)
   border: solid 1px #c1c5b9
-  padding: .5rem .5rem .5rem 2rem
+  padding: .5rem 1.25rem .5rem 2rem
   cursor: pointer
   border-radius: .25rem
   +position(relative)

--- a/app/assets/stylesheets/blocks/form/_form-radio-button.sass
+++ b/app/assets/stylesheets/blocks/form/_form-radio-button.sass
@@ -26,7 +26,7 @@
 .form-radio-button__label
   +text-block(.8125rem 1.45 0 .5rem, block)
   border: solid 1px #c1c5b9
-  padding: .5rem .5rem .5rem 2rem
+  padding: .5rem 1.25rem .5rem 2rem
   cursor: pointer
   border-radius: .25rem
   transition: all .2s ease-in

--- a/app/assets/stylesheets/blocks/form/_form.sass
+++ b/app/assets/stylesheets/blocks/form/_form.sass
@@ -26,6 +26,9 @@
   &.is-sm
     width: 30rem
     max-width: 100%
+  &.is-md
+    width: 40rem
+    max-width: 100%
 
 .form-item__add-times
   margin-top: 1rem

--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -2,6 +2,6 @@
 
 class Admin::HomeController < AdminController
   def index
-    @users = User.students.where(company_id: 1)
+    @users = User.students_and_trainees.where(company_id: 1)
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,7 +5,7 @@ class Admin::UsersController < AdminController
 
   def index
     @direction = params[:direction] || "desc"
-    @target = params[:target] || "student"
+    @target = params[:target] || "student_and_trainee"
     @users = User.with_attached_avatar
                  .preload(%i[company course])
                  .order_by_counts(params[:order_by] || "id", @direction)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: %w(show)
 
   def index
-    @target = params[:target] || "student"
+    @target = params[:target] || "student_and_trainee"
     @users = User.with_attached_avatar
       .preload(:course)
       .order(updated_at: :desc)

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -9,7 +9,8 @@ class Announcement < ApplicationRecord
 
   enum target: {
     all: 0,
-    active_users: 1
+    active_users: 1,
+    job_seeker: 2
   }, _prefix: true
 
   belongs_to :user

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -10,7 +10,7 @@ class Announcement < ApplicationRecord
   enum target: {
     all: 0,
     active_users: 1,
-    job_seeker: 2
+    job_seekers: 2
   }, _prefix: true
 
   belongs_to :user

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -9,7 +9,7 @@ class Announcement < ApplicationRecord
 
   enum target: {
     all: 0,
-    active_users: 1,
+    students: 1,
     job_seekers: 2
   }, _prefix: true
 

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -11,7 +11,7 @@ class AnnouncementCallbacks
 
   private
     def send_notification(announce)
-      target_users = target_users(announce.target)
+      target_users = User.announcement(announce.target)
       target_users.each do |target|
         if announce.sender != target
           NotificationFacade.post_announcement(announce, target)
@@ -21,24 +21,5 @@ class AnnouncementCallbacks
 
     def delete_notification(announce)
       Notification.where(path: "/announcements/#{announce.id}").destroy_all
-    end
-
-    def target_users(target)
-      case target
-      when "all"
-        User.where(retired_on: nil)
-      when "active_users"
-        User.where(admin: true)
-        .or(
-          User.where(retired_on: nil, graduated_on: nil, adviser: false, mentor: false, trainee: false)
-        )
-      when "job_seeker"
-        User.admins
-        .or(
-          User.where(retired_on: nil, adviser: false, mentor: false, trainee: false, job_seeker: true)
-        )
-      else
-        User.none
-      end
     end
 end

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -32,6 +32,11 @@ class AnnouncementCallbacks
         .or(
           User.where(retired_on: nil, graduated_on: nil, adviser: false, mentor: false, trainee: false)
         )
+      when "job_seeker"
+        User.admins
+        .or(
+          User.where(retired_on: nil, adviser: false, mentor: false, trainee: false, job_seeker: true)
+        )
       else
         User.none
       end

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -11,7 +11,7 @@ class AnnouncementCallbacks
 
   private
     def send_notification(announce)
-      target_users = User.announcement(announce.target)
+      target_users = User.announcement_receiver(announce.target)
       target_users.each do |target|
         if announce.sender != target
           NotificationFacade.post_announcement(announce, target)

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -18,7 +18,7 @@ class Practice < ActiveRecord::Base
     through: :completed_learnings,
     source: :user
   has_many :started_students,
-    -> { students },
+    -> { students_and_trainees },
     through: :started_learnings,
     source: :user
   has_many :products

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,7 +144,7 @@ class User < ActiveRecord::Base
       retired_on: nil
     )
   }
-  scope :active_fjord_students, -> {
+  scope :students, -> {
     where(
       admin: false,
       mentor: false,
@@ -176,7 +176,7 @@ class User < ActiveRecord::Base
   scope :trainee, -> { where(trainee: true) }
   scope :job_seeking, -> { where(job_seeking: true) }
   scope :job_seekers, -> {
-    active_fjord_students.where(
+    students.where(
       job_seeker: true
     )
   }
@@ -391,7 +391,7 @@ SQL
     when "all"
       User.unretired
     when "active_users"
-      User.admins.or(User.active_fjord_students)
+      User.admins.or(User.students)
     when "job_seekers"
       User.admins.or(User.job_seekers)
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -386,7 +386,7 @@ SQL
          .flatten
   end
 
-  def self.announcement(target)
+  def self.announcement_receiver(target)
     case target
     when "all"
       User.unretired

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -397,7 +397,7 @@ SQL
       User.unretired
     when "active_users"
       User.admins.or(User.active_fjord_students)
-    when "job_seeker"
+    when "job_seekers"
       User.admins.or(User.job_seekers)
     else
       User.none

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,7 +173,7 @@ class User < ActiveRecord::Base
     ).order(updated_at: :desc)
   }
   scope :admins, -> { where(admin: true) }
-  scope :trainee, -> { where(trainee: true) }
+  scope :trainees, -> { where(trainee: true) }
   scope :job_seeking, -> { where(job_seeking: true) }
   scope :job_seekers, -> {
     students.where(
@@ -263,7 +263,7 @@ SQL
     when "year_end_party"
       self.year_end_party
     when "trainee"
-      self.trainee
+      self.trainees
     when "all"
       self.all
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,16 +144,12 @@ class User < ActiveRecord::Base
       retired_on: nil
     )
   }
-  scope :fjord_students, -> {
+  scope :active_fjord_students, -> {
     where(
       admin: false,
       mentor: false,
       adviser: false,
-      trainee:  false
-    )
-  }
-  scope :active_fjord_students, -> {
-    fjord_students.where(
+      trainee:  false,
       retired_on: nil,
       graduated_on: nil
     )
@@ -180,8 +176,7 @@ class User < ActiveRecord::Base
   scope :trainee, -> { where(trainee: true) }
   scope :job_seeking, -> { where(job_seeking: true) }
   scope :job_seekers, -> {
-    fjord_students.where(
-      retired_on: nil,
+    active_fjord_students.where(
       job_seeker: true
     )
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,7 +135,7 @@ class User < ActiveRecord::Base
   scope :unretired, -> { where(retired_on: nil) }
   scope :advisers, -> { where(adviser: true) }
   scope :not_advisers, -> { where(adviser: false) }
-  scope :students, -> {
+  scope :students_and_trainees, -> {
     where(
       admin: false,
       mentor: false,
@@ -246,8 +246,8 @@ SQL
 
   def self.users_role(target)
     case target
-    when "student"
-      self.students
+    when "student_and_trainee"
+      self.students_and_trainees
     when "job_seeking"
       self.job_seeking
     when "retired"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -390,7 +390,7 @@ SQL
     case target
     when "all"
       User.unretired
-    when "active_users"
+    when "students"
       User.admins.or(User.students)
     when "job_seekers"
       User.admins.or(User.job_seekers)

--- a/app/views/admin/users/_nav.html.slim
+++ b/app/views/admin/users/_nav.html.slim
@@ -1,6 +1,6 @@
 nav.tab-nav.is-in-tab
   .container.is-padding-horizontal-0-sm-down
     ul.tab-nav__items
-      - %w(all student inactive retired graduate adviser mentor trainee year_end_party).each do |target|
+      - %w(all student_and_trainee inactive retired graduate adviser mentor trainee year_end_party).each do |target|
         li.tab-nav__item
           = link_to t("target.#{target}"), admin_users_path(target: target), class: (@target == target ? ["is-active"] : []) << "tab-nav__item-link"

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -28,6 +28,10 @@
           label.form-radio-button__label
             | 現役生にのみお知らせ
             = f.radio_button :target, "active_users"
+        li.form-radio-button.is-half
+          label.form-radio-button__label
+            | 就職希望者のみお知らせ
+            = f.radio_button :target, "job_seeker"
 
   .form-actions
     ul.form-actions__items

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -31,7 +31,7 @@
         li.form-radio-button.is-half
           label.form-radio-button__label
             | 就職希望者のみお知らせ
-            = f.radio_button :target, "job_seeker"
+            = f.radio_button :target, "job_seekers"
 
   .form-actions
     ul.form-actions__items

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -27,7 +27,7 @@
         li.form-radio-button.is-half
           label.form-radio-button__label
             | 現役生にのみお知らせ
-            = f.radio_button :target, "active_users"
+            = f.radio_button :target, "students"
         li.form-radio-button.is-half
           label.form-radio-button__label
             | 就職希望者にのみお知らせ

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -16,19 +16,19 @@
           .a-label
             | プレビュー
           .js-preview.is-long-text.markdown-form__preview
-    .form-item.is-sm
+    .form-item.is-md
       label.a-label
         | 通知ターゲット
-      ul.form-item__radio-buttons.is-half
-        li.form-radio-button.is-half
+      ul.form-item__radio-buttons.is-inline
+        li.form-radio-button
           label.form-radio-button__label
             | 全員にお知らせ
             = f.radio_button :target, "all", checked: true
-        li.form-radio-button.is-half
+        li.form-radio-button
           label.form-radio-button__label
             | 現役生にのみお知らせ
             = f.radio_button :target, "students"
-        li.form-radio-button.is-half
+        li.form-radio-button
           label.form-radio-button__label
             | 就職希望者にのみお知らせ
             = f.radio_button :target, "job_seekers"

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -30,7 +30,7 @@
             = f.radio_button :target, "active_users"
         li.form-radio-button.is-half
           label.form-radio-button__label
-            | 就職希望者のみお知らせ
+            | 就職希望者にのみお知らせ
             = f.radio_button :target, "job_seekers"
 
   .form-actions

--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -1,6 +1,6 @@
 nav.tab-nav
   .container.is-padding-horizontal-0-sm-down
     ul.tab-nav__items
-      - %w(student job_seeking mentor graduate adviser trainee all).each do |target|
+      - %w(student_and_trainee job_seeking mentor graduate adviser trainee all).each do |target|
         li.tab-nav__item
           = link_to t("target.#{target}"), users_path(target: target), class: (@target == target ? ["is-active"] : []) << "tab-nav__item-link"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -178,7 +178,7 @@ ja:
           complete: 完了
           not_complete: 未完
   target:
-    student: 現役生
+    student_and_trainee: 現役生
     job_seeking: 就職活動中
     mentor: メンター
     graduate: 卒業生

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -106,13 +106,14 @@ yameo:
   twitter_account: yameo
   facebook_url: http://www.facebook.com/yameo
   blog_url: http://yameo.org
-  description: "リタイアしました。"
+  description: "リタイアしました。就職希望はしてました"
   course: course_1
   job: office_worker
   os: mac
   study_place: remote
   experience: ruby
   organization: 株式会社ヤメオ
+  job_seeker: true
   retired_on: "2015-01-01"
   updated_at: "2014-01-01 00:00:05"
   created_at: "2014-01-01 00:00:05"
@@ -328,3 +329,50 @@ osnashi: #osを持たないユーザー
   experience: rails
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
+
+jobseeker: #現役で就活希望するユーザー
+  login_name: jobseeker
+  email: jobseeker@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  first_name: のぞむ
+  last_name: 就活
+  kana_first_name: ノゾム
+  kana_last_name: シュウカツ
+  slack_account: jobseeker
+  github_account: jobseeker
+  twitter_account: jobseeker
+  facebook_url: http://www.facebook.com/exmaple
+  blog_url: http://example.org
+  description: "フィヨルドからの就職希望してます！"
+  course: course_1
+  job: office_worker
+  study_place: remote
+  experience: rails
+  job_seeker: true
+  updated_at: "2020-01-01 00:00:12"
+  created_at: "2020-01-01 00:00:12"
+
+madajobseeker: #卒業しても就活希望するユーザー
+  login_name: madajobseeker
+  email: madajobseeker@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  first_name: 就活中
+  last_name: 卒業
+  kana_first_name: シュウカツチュウ
+  kana_last_name: ソツギョウ
+  slack_account: madajobseeker
+  github_account: madajobseeker
+  twitter_account: madajobseeker
+  facebook_url: http://www.facebook.com/example
+  blog_url: http://exapmle.org
+  description: "卒業しましたが、フィヨルドからの就職まだ希望してます！"
+  course: course_1
+  job: unemployed
+  study_place: remote
+  experience: rails
+  job_seeker: true
+  graduated_on: "2020-02-25"
+  updated_at: "2020-01-01 00:00:12"
+  created_at: "2020-01-01 00:00:12"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -71,6 +71,7 @@ sotugyou:
   os: mac
   study_place: local
   experience: rails
+  job_seeker: true
   organization: 株式会社卒業
   graduated_on: "2015-01-01"
   updated_at: "2014-01-01 00:00:03"
@@ -330,7 +331,7 @@ osnashi: #osを持たないユーザー
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
 
-jobseeker: #現役で就活希望するユーザー
+jobseeker: #就活希望するユーザー
   login_name: jobseeker
   email: jobseeker@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -350,29 +351,5 @@ jobseeker: #現役で就活希望するユーザー
   study_place: remote
   experience: rails
   job_seeker: true
-  updated_at: "2020-01-01 00:00:12"
-  created_at: "2020-01-01 00:00:12"
-
-madajobseeker: #卒業しても就活希望するユーザー
-  login_name: madajobseeker
-  email: madajobseeker@fjord.jp
-  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
-  salt: zW3kQ9ubsxQQtzzzs4ap
-  first_name: 就活中
-  last_name: 卒業
-  kana_first_name: シュウカツチュウ
-  kana_last_name: ソツギョウ
-  slack_account: madajobseeker
-  github_account: madajobseeker
-  twitter_account: madajobseeker
-  facebook_url: http://www.facebook.com/example
-  blog_url: http://exapmle.org
-  description: "卒業しましたが、フィヨルドからの就職まだ希望してます！"
-  course: course_1
-  job: unemployed
-  study_place: remote
-  experience: rails
-  job_seeker: true
-  graduated_on: "2020-02-25"
   updated_at: "2020-01-01 00:00:12"
   created_at: "2020-01-01 00:00:12"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -192,8 +192,8 @@ class UserTest < ActiveSupport::TestCase
     assert_not_includes(target, users(:yameo))
   end
 
-  test "announcment for active_users " do
-    target = User.announcement("active_users")
+  test "announcment for students" do
+    target = User.announcement("students")
     assert_includes(target, users(:kimura))
     assert_includes(target, users(:komagata))
     assert_not_includes(target, users(:yameo))

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -206,8 +206,8 @@ class UserTest < ActiveSupport::TestCase
   test "announcment for job_seekers" do
     target = User.announcement("job_seekers")
     assert_includes(target, users(:jobseeker))
-    assert_includes(target, users(:madajobseeker))
     assert_includes(target, users(:komagata))
+    assert_not_includes(target, users(:sotugyou))
     assert_not_includes(target, users(:kimura))
     assert_not_includes(target, users(:yameo))
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -204,7 +204,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "announcment for job_seekers" do
-    target = User.announcement("job_seeker")
+    target = User.announcement("job_seekers")
     assert_includes(target, users(:jobseeker))
     assert_includes(target, users(:madajobseeker))
     assert_includes(target, users(:komagata))

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -187,13 +187,13 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "announcment for all" do
-    target = User.announcement("all")
+    target = User.announcement_receiver("all")
     assert_includes(target, users(:kimura))
     assert_not_includes(target, users(:yameo))
   end
 
   test "announcment for students" do
-    target = User.announcement("students")
+    target = User.announcement_receiver("students")
     assert_includes(target, users(:kimura))
     assert_includes(target, users(:komagata))
     assert_not_includes(target, users(:yameo))
@@ -204,7 +204,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "announcment for job_seekers" do
-    target = User.announcement("job_seekers")
+    target = User.announcement_receiver("job_seekers")
     assert_includes(target, users(:jobseeker))
     assert_includes(target, users(:komagata))
     assert_not_includes(target, users(:sotugyou))

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -185,4 +185,30 @@ class UserTest < ActiveSupport::TestCase
     user = users(:hajime)
     assert_equal [report: nil, date: Date.today, emotion: nil], user.reports_date_and_emotion(0)
   end
+
+  test "announcment for all" do
+    target = User.announcement("all")
+    assert_includes(target, users(:kimura))
+    assert_not_includes(target, users(:yameo))
+  end
+
+  test "announcment for active_users " do
+    target = User.announcement("active_users")
+    assert_includes(target, users(:kimura))
+    assert_includes(target, users(:komagata))
+    assert_not_includes(target, users(:yameo))
+    assert_not_includes(target, users(:sotugyou))
+    assert_not_includes(target, users(:yamada))
+    assert_not_includes(target, users(:advijirou))
+    assert_not_includes(target, users(:kensyu))
+  end
+
+  test "announcment for job_seekers" do
+    target = User.announcement("job_seeker")
+    assert_includes(target, users(:jobseeker))
+    assert_includes(target, users(:madajobseeker))
+    assert_includes(target, users(:komagata))
+    assert_not_includes(target, users(:kimura))
+    assert_not_includes(target, users(:yameo))
+  end
 end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -75,7 +75,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
 
   test "delete user" do
     user = users(:kimura)
-    visit admin_users_path(target: "student")
+    visit admin_users_path(target: "student_and_trainee")
     click_on "delete-#{user.id}"
     page.driver.browser.switch_to.alert.accept
     assert_text "#{user.full_name} さんを削除しました。"

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -98,4 +98,36 @@ class AnnouncementsTest < ApplicationSystemTestCase
     visit "/notifications"
     assert_no_text "machidaさんからお知らせです。"
   end
+
+  test "announcement notifications are only recived by job seekers" do
+    login_user "machida", "testtest"
+    visit "/announcements"
+    click_link "お知らせ作成"
+    fill_in "announcement[title]", with: "就活希望者のみお知らせします"
+    fill_in "announcement[description]", with: "合同説明会をやるのでぜひいらしてください！"
+    choose "就職希望者のみお知らせ", visible: false
+
+    click_button "作成"
+    assert_text "お知らせを作成しました"
+
+    login_user "komagata", "testtest"
+    visit "/notifications"
+    assert_text "machidaさんからお知らせです。"
+
+    login_user "jobseeker", "testtest"
+    visit "/notifications"
+    assert_text "machidaさんからお知らせです。"
+
+    login_user "madajobseeker", "testtest"
+    visit "/notifications"
+    assert_text "machidaさんからお知らせです。"
+
+    login_user "kimura", "testtest"
+    visit "/notifications"
+    assert_no_text "machidaさんからお知らせです。"
+
+    login_user "yameo", "testtest"
+    visit "/notifications"
+    assert_no_text "machidaさんからお知らせです。"
+  end
 end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -114,6 +114,10 @@ class AnnouncementsTest < ApplicationSystemTestCase
     visit "/notifications"
     assert_text "machidaさんからお知らせです。"
 
+    login_user "jobseeker", "testtest"
+    visit "/notifications"
+    assert_text "machidaさんからお知らせです。"
+
     login_user "kimura", "testtest"
     visit "/notifications"
     assert_no_text "machidaさんからお知らせです。"

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -114,19 +114,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     visit "/notifications"
     assert_text "machidaさんからお知らせです。"
 
-    login_user "jobseeker", "testtest"
-    visit "/notifications"
-    assert_text "machidaさんからお知らせです。"
-
-    login_user "madajobseeker", "testtest"
-    visit "/notifications"
-    assert_text "machidaさんからお知らせです。"
-
     login_user "kimura", "testtest"
-    visit "/notifications"
-    assert_no_text "machidaさんからお知らせです。"
-
-    login_user "yameo", "testtest"
     visit "/notifications"
     assert_no_text "machidaさんからお知らせです。"
   end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -105,7 +105,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     click_link "お知らせ作成"
     fill_in "announcement[title]", with: "就活希望者のみお知らせします"
     fill_in "announcement[description]", with: "合同説明会をやるのでぜひいらしてください！"
-    choose "就職希望者のみお知らせ", visible: false
+    choose "就職希望者にのみお知らせ", visible: false
 
     click_button "作成"
     assert_text "お知らせを作成しました"


### PR DESCRIPTION
Reff: https://github.com/fjordllc/bootcamp/issues/1419

## 概要
管理人がお知らせを就活希望者のみに通知できるよう、就活希望者用のチェックボックスを追加して、通知先を選べるように機能を追加しました。

## 備考
- 書いた人以外のadminに通知がいく
-  ~~卒業しても、就職がまだで、就活希望のチェックが入っていれば通知は届く~~
卒業生には通知がいかない
- リタイアした人が現役時代に`job_seeker`がいれてやめた場合有効になってしまうので、今回のコードでリタイアしてないを条件として入れる。
    - 将来的に退会時にjob_seekerをfalseにして、既に退会した分はバッチなどで調整する必要がある
- メンター・アドバイザー・研修生は、フロー的に`job_seeker = true`になることはないが、データ上は存在できるので、誤動作しないように今回のコードで送らないように設定しました。
- studentsの定義が広かったので整理しました

|対象|現在|変更予定|備考|
|--|--|--|--|
研修生|trainee|trainees|細かいところですが、複数を指すのに単数形で使われてるところは修正したい
研修生ではない生徒(内部生？)|fjord_students|students|
現役生(内部生＋研修生)|students|students_and_trainees|`active_students`(現役生)だとログインして活動しているactiveと混同しそうなので`students_and_trainees`が良いと判断しました

## 動作画面
<img width="1348" alt="スクリーンショット 2020-03-04 2 48 47" src="https://user-images.githubusercontent.com/10154448/75805406-204bcb00-5dc5-11ea-82f1-81961143b018.png">
