### PR TITLE
ユーザー個別ページで30日分のニコニコカレンダーが表示できる

### DIFF
--- a/app/assets/stylesheets/blocks/user/_niconico-calendar.sass
+++ b/app/assets/stylesheets/blocks/user/_niconico-calendar.sass
@@ -1,0 +1,45 @@
+.niconico-calendar
+  width: 100%
+  table-layout: fixed
+  th,
+  td
+    border: solid 1px $border-shade
+
+.niconico-calendar__header
+  background-color: $background-tint
+
+.niconico-calendar__header-day
+  width: calc(100% / 7)
+  +text-block(.75rem 1, center)
+  +padding(vertical, .25em)
+  &.is-sunday
+    color: $danger
+  &.is-saturday
+    color: $main
+
+.niconico-calendar__day-inner
+  +block-link
+  +padding(vertical, .25rem .125rem)
+  +size(100%)
+  .niconico-calendar__day.is-blank &
+    background-color: $background-more-tint
+
+a.niconico-calendar__day-inner
+  transition: all .2s ease-out
+  &:hover
+    background-color: rgba($warning, .1)
+
+.niconico-calendar__day-label
+  +text-block(.625rem 1, center $default-text)
+  margin-bottom: .125rem
+  .niconico-calendar__day.is-blank &
+    color: $muted-text
+
+.niconico-calendar__day-value
+  +text-block(1.75rem 1, center flex)
+  align-items: center
+  justify-content: center
+  +size(100% 1.875rem)
+  .niconico-calendar__day.is-blank &
+    color: $muted-text
+    font-size: 1.25rem

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -2,6 +2,7 @@
 
 module UserDecorator
   DAYS_IN_WEEK = 7
+  CALENDAR_TERM = 30
 
   def twitter_url
     "https://twitter.com/#{twitter_account}"
@@ -39,8 +40,8 @@ module UserDecorator
     user_url(self)
   end
 
-  def niconico_calendar(term)
-    emotions_and_date = self.set_emotions_and_dates(term)
+  def niconico_calendar
+    emotions_and_date = self.set_emotions_and_dates(CALENDAR_TERM)
     last_wday = emotions_and_date.first[:date].wday
 
     blanks = last_wday.times.map { { date: nil, emotion: nil } }

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module UserDecorator
+  DAYS_IN_WEEK = 7
+
   def twitter_url
     "https://twitter.com/#{twitter_account}"
   end
@@ -35,5 +37,18 @@ module UserDecorator
 
   def url
     user_url(self)
+  end
+
+  def niconico_calendar(term)
+    emotions_and_date = self.set_emotions_and_dates(term)
+    last_wday = emotions_and_date.first[:date].wday
+
+    blanks = []
+    last_wday.times do
+      blanks << { date: nil, emotion: nil }
+    end
+
+    [ *blanks, *emotions_and_date ].each_slice(DAYS_IN_WEEK)
+                                   .to_a
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -41,12 +41,12 @@ module UserDecorator
   end
 
   def niconico_calendar
-    emotions_and_date = self.set_emotions_and_dates(CALENDAR_TERM)
-    last_wday = emotions_and_date.first[:date].wday
+    reports_date_and_emotion = self.reports_date_and_emotion(CALENDAR_TERM)
+    last_wday = reports_date_and_emotion.first[:date].wday
 
-    blanks = last_wday.times.map { { date: nil, emotion: nil } }
+    blanks = last_wday.times.map { { report: nil, date: nil, emotion: nil } }
 
-    [ *blanks, *emotions_and_date ].each_slice(DAYS_IN_WEEK)
-                                   .to_a
+    [ *blanks, *reports_date_and_emotion].each_slice(DAYS_IN_WEEK)
+                                         .to_a
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -43,10 +43,7 @@ module UserDecorator
     emotions_and_date = self.set_emotions_and_dates(term)
     last_wday = emotions_and_date.first[:date].wday
 
-    blanks = []
-    last_wday.times do
-      blanks << { date: nil, emotion: nil }
-    end
+    blanks = last_wday.times.map { { date: nil, emotion: nil } }
 
     [ *blanks, *emotions_and_date ].each_slice(DAYS_IN_WEEK)
                                    .to_a

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -356,17 +356,17 @@ SQL
     participate_events.include?(event)
   end
 
-  def set_emotions_and_dates(term)
+  def reports_date_and_emotion(term)
     search_term = (Date.today - term.day)..Date.today
     reports = self.reports.where(reported_on: search_term)
 
-    emotions = reports.map { |report| [report.reported_on, report.emotion] }.to_h
+    emotions = reports.map { |report| [report.reported_on, report] }.to_h
 
     dates = search_term.map { |day| [day, nil] }.to_h
 
     dates.merge(emotions)
          .to_a
-         .map { |set| [date: set[0], emotion: set[1]] }
+         .map { |set| [report: set[1], date: set[0], emotion: set[1]&.emotion] }
          .flatten
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -356,6 +356,20 @@ SQL
     participate_events.include?(event)
   end
 
+  def set_emotions_and_dates(term)
+    search_term = (Date.today - term.day)..Date.today
+    reports = self.reports.where(reported_on: search_term)
+
+    emotions = reports.map { |report| [report.reported_on, report.emotion] }.to_h
+
+    dates = search_term.map { |day| [day, nil] }.to_h
+
+    dates.merge(emotions)
+         .to_a
+         .map { |set| [date: set[0], emotion: set[1]] }
+         .flatten
+  end
+
   private
     def password_required?
       new_record? || password.present?

--- a/app/views/users/_niconico_calendar.html.slim
+++ b/app/views/users/_niconico_calendar.html.slim
@@ -26,7 +26,7 @@
             - week.each do |set|
               td.niconico-calendar__day(class="is-#{set[:emotion].present? ? set[:emotion] : "blank"}")
                 - if set[:emotion].present?
-                  = link_to report_path(user.reports.find_by(reported_on: set[:date])), class: "niconico-calendar__day-inner" do
+                  = link_to report_path(set[:report]), class: "niconico-calendar__day-inner" do
                     .niconico-calendar__day-label
                       - if set[:date]
                         = l(set[:date], format: :sm)

--- a/app/views/users/_niconico_calendar.html.slim
+++ b/app/views/users/_niconico_calendar.html.slim
@@ -6,29 +6,40 @@
     table.niconico-calendar
       thead.niconico-calendar__header
         tr
-          th
+          th.niconico-calendar__header-day.is-sunday
             | 日
-          th
+          th.niconico-calendar__header-day
             | 月
-          th
+          th.niconico-calendar__header-day
             | 火
-          th
+          th.niconico-calendar__header-day
             | 水
-          th
+          th.niconico-calendar__header-day
             | 木
-          th
+          th.niconico-calendar__header-day
             | 金
-          th
+          th.niconico-calendar__header-day.is-saturday
             | 土
       tbody.niconico-calendar__body
         - user.niconico_calendar(30).each do |week|
           tr.niconico-calendar__week
             - week.each do |set|
-              td.niconico-calendar__day(class="is-#{set[:emotion]}")
-                - if set[:date]
-                  = l(set[:date], format: :md)
+              td.niconico-calendar__day(class="is-#{set[:emotion].present? ? set[:emotion] : "blank"}")
+                - if set[:emotion].present?
+                  = link_to report_path(user.reports.find_by(reported_on: set[:date])), class: "niconico-calendar__day-inner" do
+                    .niconico-calendar__day-label
+                      - if set[:date]
+                        = l(set[:date], format: :sm)
+                      - else
+                        = set[:date]
+                    .niconico-calendar__day-value
+                      = Report.faces[set[:emotion]]
                 - else
-                  = set[:date]
-                br
-                  - if set[:emotion]
-                    = link_to Report.faces[set[:emotion]], report_path(user.reports.find_by(reported_on: set[:date]))
+                  .niconico-calendar__day-inner
+                    .niconico-calendar__day-label
+                      - if set[:date]
+                        = l(set[:date], format: :sm)
+                      - else
+                        = set[:date]
+                    .niconico-calendar__day-value
+                      i.fas.fa-times

--- a/app/views/users/_niconico_calendar.html.slim
+++ b/app/views/users/_niconico_calendar.html.slim
@@ -21,7 +21,7 @@
           th.niconico-calendar__header-day.is-saturday
             | 土
       tbody.niconico-calendar__body
-        - user.niconico_calendar(30).each do |week|
+        - user.niconico_calendar.each do |week|
           tr.niconico-calendar__week
             - week.each do |set|
               td.niconico-calendar__day(class="is-#{set[:emotion].present? ? set[:emotion] : "blank"}")

--- a/app/views/users/_niconico_calendar.html.slim
+++ b/app/views/users/_niconico_calendar.html.slim
@@ -1,0 +1,34 @@
+.a-card
+  header.card-header.is-sm
+    h2.card-header__title
+      | ニコニコカレンダー
+  .card-body
+    table.niconico-calendar
+      thead.niconico-calendar__header
+        tr
+          th
+            | 日
+          th
+            | 月
+          th
+            | 火
+          th
+            | 水
+          th
+            | 木
+          th
+            | 金
+          th
+            | 土
+      tbody.niconico-calendar__body
+        - user.niconico_calendar(30).each do |week|
+          tr.niconico-calendar__week
+            - week.each do |set|
+              td.niconico-calendar__day(class="is-#{set[:emotion]}")
+                - if set[:date]
+                  = l(set[:date], format: :md)
+                - else
+                  = set[:date]
+                br
+                  - if set[:emotion]
+                    = link_to Report.faces[set[:emotion]], report_path(user.reports.find_by(reported_on: set[:date]))

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -46,6 +46,7 @@ header.page-header
             = render "users/grass", user: @user
           - if @user.active_practices.present?
             = render "/users/practices/active_practices", user: @user
+          = render "/users/niconico_calendar", user: @user
           - if @user.completed_practices.present?
             = render "/users/practices/completed_practices", user: @user
           - if @user.books.present?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     formats:
       default: "%Y年%m月%d日"
       short: "%Y/%m/%d"
+      md: "%m月%d日"
   time:
     formats:
       default: "%Y年%m月%d日(%a) %H:%M"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
       default: "%Y年%m月%d日"
       short: "%Y/%m/%d"
       md: "%m月%d日"
+      sm: "%m/%d"
   time:
     formats:
       default: "%Y年%m月%d日(%a) %H:%M"

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -19,8 +19,7 @@ class UserDecoratorTest < ActiveSupport::TestCase
   end
 
   test "niconico_calendar" do
-    blanks = [ { date: nil, emotion: nil } ] * Date.today.wday
-    expected_result = [[ *blanks, { date: Date.today, emotion: nil }]]
-    assert_equal expected_result, @user2.niconico_calendar(0)
+    days_in_weeks = 7
+    assert_equal days_in_weeks, @user2.niconico_calendar.first.count
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -6,6 +6,7 @@ class UserDecoratorTest < ActiveSupport::TestCase
   def setup
     @user1 = ActiveDecorator::Decorator.instance.decorate(users(:komagata))
     @user2 = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
+    @user3 = ActiveDecorator::Decorator.instance.decorate(users(:advijirou))
   end
 
   test "staff_roles" do
@@ -16,5 +17,12 @@ class UserDecoratorTest < ActiveSupport::TestCase
   test "icon_title" do
     assert_equal "komagata: 管理者、メンター", @user1.icon_title
     assert_equal "hajime", @user2.icon_title
+  end
+
+  test "niconico_calendar" do
+    blanks = [ { date: nil, emotion: nil } ] * Date.today.wday
+    expected_result = [[ *blanks, { date: Date.today, emotion: nil }]]
+
+    assert_equal expected_result, @user3.niconico_calendar(0)
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -6,7 +6,6 @@ class UserDecoratorTest < ActiveSupport::TestCase
   def setup
     @user1 = ActiveDecorator::Decorator.instance.decorate(users(:komagata))
     @user2 = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
-    @user3 = ActiveDecorator::Decorator.instance.decorate(users(:advijirou))
   end
 
   test "staff_roles" do
@@ -22,7 +21,6 @@ class UserDecoratorTest < ActiveSupport::TestCase
   test "niconico_calendar" do
     blanks = [ { date: nil, emotion: nil } ] * Date.today.wday
     expected_result = [[ *blanks, { date: Date.today, emotion: nil }]]
-
-    assert_equal expected_result, @user3.niconico_calendar(0)
+    assert_equal expected_result, @user2.niconico_calendar(0)
   end
 end

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -112,16 +112,16 @@ report_14:
   created_at: "2000-01-01 00:00:00"
 
 report_15:
-  user: advijirou
-  title: "emotionのテスト_1"
+  user: hajime
+  title: "今日は頑張りました"
   emotion: 2
   description: |-
     頑張りました
   reported_on: <%= Time.now - 1.day %>
 
 report_16:
-  user: advijirou
-  title: "emotionのテスト_2"
+  user: hajime
+  title: "今日は頑張れませんでした"
   emotion: 1
   description: |-
     頑張れませんでした

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -113,14 +113,16 @@ report_14:
 
 report_15:
   user: advijirou
-  title: emotionのテスト_1
+  title: "emotionのテスト_1"
   emotion: 2
-  description: 頑張りました
+  description: |-
+    頑張りました
   reported_on: <%= Time.now - 1.day %>
 
 report_16:
   user: advijirou
-  title: emotionのテスト_2
+  title: "emotionのテスト_2"
   emotion: 1
-  description: 頑張れませんでした
+  description: |-
+    頑張れませんでした
   reported_on: <%= Time.now - 2.day %>

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -110,3 +110,17 @@ report_14:
     あれから100年か
   reported_on: "2000-01-01"
   created_at: "2000-01-01 00:00:00"
+
+report_15:
+  user: advijirou
+  title: emotionのテスト_1
+  emotion: 2
+  description: 頑張りました
+  reported_on: <%= Time.now - 1.day %>
+
+report_16:
+  user: advijirou
+  title: emotionのテスト_2
+  emotion: 1
+  description: 頑張れませんでした
+  reported_on: <%= Time.now - 2.day %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -181,8 +181,8 @@ class UserTest < ActiveSupport::TestCase
     assert_equal old_percentage, user.completed_percentage
   end
 
-  test "set_emotions_and_dates" do
+  test "dates_emotion_and_reports" do
     user = users(:hajime)
-    assert_equal [date: Date.today, emotion: nil], user.set_emotions_and_dates(0)
+    assert_equal [report: nil, date: Date.today, emotion: nil], user.reports_date_and_emotion(0)
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -182,8 +182,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "set_emotions_and_dates" do
-    user = users(:advijirou)
-
+    user = users(:hajime)
     assert_equal [date: Date.today, emotion: nil], user.set_emotions_and_dates(0)
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -180,4 +180,10 @@ class UserTest < ActiveSupport::TestCase
     user.completed_practices << practices(:practice_53)
     assert_equal old_percentage, user.completed_percentage
   end
+
+  test "set_emotions_and_dates" do
+    user = users(:advijirou)
+
+    assert_equal [date: Date.today, emotion: nil], user.set_emotions_and_dates(0)
+  end
 end


### PR DESCRIPTION
## 変更の目的

ref: #1439

## 変更の概要

- ユーザー個別ページで、30日分のニコニコカレンダーを表示しました。
- ニコニコカレンダーの絵文字部分には、該当する日報のリンクを追加しました。

## スクリーンショット
ユーザー個別ページでニコニコカレンダーが表示されているのを確認。そして、絵文字部分をクリックすると、該当する日報にリンクを辿れます。

[![Image from Gyazo](https://i.gyazo.com/052458ab9abeb58a7bfe029c3ebb9a74.gif)](https://gyazo.com/052458ab9abeb58a7bfe029c3ebb9a74)