### PR TITLE
Rubyが落ちるエラーに対処

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,7 +15,10 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # folder are already added.
 Rails.application.config.assets.precompile += %w( application.css welcome.css namecards.css qrcodes.css diploma.css )
 
-# Rubyが落ちるエラーがあり、原因としてSprocketsの関係で、assetsが並列でコンパイルされていることが考えられる(ソースはPRに記載)。
+# Rubyが落ちるエラーがあり、原因としてSprocketsの関係で、assetsが並列でコンパイルされていることが考えられる。
+# ソースは以下。
+# https://github.com/rails/sprockets/issues/581
+# https://www.tmp1024.com/articles/fix-rails-6-segmentation-error
 # そのため、assetsの並列コンパイルをやめる設定を記述した。
 Rails.application.config.assets.configure do |env|
   env.export_concurrent = false

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,3 +14,7 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 Rails.application.config.assets.precompile += %w( application.css welcome.css namecards.css qrcodes.css diploma.css )
+
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false
+end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,6 +15,8 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # folder are already added.
 Rails.application.config.assets.precompile += %w( application.css welcome.css namecards.css qrcodes.css diploma.css )
 
+# Rubyが落ちるエラーがあり、原因としてSprocketsの関係で、assetsが並列でコンパイルされていることが考えられる(ソースはPRに記載)。
+# そのため、assetsの並列コンパイルをやめる設定を記述した。
 Rails.application.config.assets.configure do |env|
   env.export_concurrent = false
 end


### PR DESCRIPTION
## 変更の目的・概要

ローカルでテストを回していると、以下のようなエラーが発生することがありました。
[テストログ](https://gist.github.com/NMP300/49393934ec67ab426ac72fba31246fc1)

確実なことは分かりませんが、assetsを並列にコンパイルすることが関連していそうです。

そこで、以下を参考に、`config/initializers/assets.rb`に並列コンパイルを止める設定を追加しました。

## 参考サイト
[Rails6でセグメンテーションエラーが発生する問題を解決した](https://www.tmp1024.com/articles/fix-rails-6-segmentation-error)
[url helpers aren't thread safe · Issue \#581 · rails/sprockets](https://github.com/rails/sprockets/issues/581)