### PR TITLE
プラクティス > 日報、プラクティス > 質問、プラクティス > 提出物の見出し変更

### DIFF
--- a/app/views/practices/products/index.html.slim
+++ b/app/views/practices/products/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@practice.title}の提出物"
+- title "#{@practice.title}"
 
 header.page-header
   .container

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@practice.title}の質問"
+- title "#{@practice.title}"
 header.page-header
   .container
     .page-header__inner

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@practice.title}の日報"
+- title "#{@practice.title}"
 
 header.page-header
   .container

--- a/test/system/practice/products_test.rb
+++ b/test/system/practice/products_test.rb
@@ -6,6 +6,6 @@ class Practice::ProductsTest < ApplicationSystemTestCase
   test "show listing products" do
     login_user "komagata", "testtest"
     visit "/practices/#{practices(:practice_1).id}/products"
-    assert_equal "OS X Mountain Lionをクリーンインストールするの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 end

--- a/test/system/practice/questions_test.rb
+++ b/test/system/practice/questions_test.rb
@@ -7,6 +7,6 @@ class Practice::QuestionsTest < ApplicationSystemTestCase
 
   test "show listing questions" do
     visit "/practices/#{practices(:practice_1).id}/questions"
-    assert_equal "OS X Mountain Lionをクリーンインストールするの質問 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 end

--- a/test/system/practice/reports_test.rb
+++ b/test/system/practice/reports_test.rb
@@ -7,6 +7,6 @@ class Practice::ReportsTest < ApplicationSystemTestCase
 
   test "show listing reports" do
     visit "/practices/#{practices(:practice_1).id}/reports"
-    assert_equal "OS X Mountain Lionをクリーンインストールするの日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 end


### PR DESCRIPTION
Ref: #1407

## 概要
* 個別のプラクティスページの、日報、質問、提出物タグの見出しから、"の日報"のような文言を削除しました。
* システムテストの当該箇所のアサーションも、"の日報"のような文言を削除しました。

## 作業後の画面
<img width="854" alt="OS_X_Mountain_Lionをクリーンインストールする___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/48672932/76066965-f3203800-5fd1-11ea-8401-b0e775d17108.png">
<img width="855" alt="OS_X_Mountain_Lionをクリーンインストールする___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/48672932/76067001-ffa49080-5fd1-11ea-87a4-1e862f85d758.png">
<img width="851" alt="OS_X_Mountain_Lionをクリーンインストールする___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/48672932/76067038-092df880-5fd2-11ea-8d15-3fd24084b671.png">

## 備考
issue #1444 で対応中のエラーと同一のエラーがローカルで発生中ですが、本件とは独立したものと思われますので、PRを提出します。