### PR TITLE
プラクティスページの「カテゴリー」リンクを消し、「プラクティス一覧」のリンク先をカテゴリーにする

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -13,11 +13,8 @@ header.page-header
                 i.fas.fa-plus
                 | プラクティス作成
           li.page-header-actions__item
-            = link_to course_practices_path(current_user.course), class: "a-button is-md is-secondary is-block" do
-              | プラクティス一覧
-          li.page-header-actions__item
             = link_to course_practices_path(current_user.course, anchor: "category-#{@practice.category.id}"), class: "a-button is-md is-secondary is-block" do
-              | カテゴリー
+              | プラクティス一覧
 
 = render "page_tabs", resource: @practice
 

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -78,7 +78,7 @@ class PracticesTest < ApplicationSystemTestCase
     user = users(:komagata)
     visit "/practices/#{practice.id}/"
     within ".page-header-actions" do
-      click_link "カテゴリー"
+      click_link "プラクティス一覧"
     end
     assert_current_path course_practices_path(user.course)
     assert_equal "category-#{practice.category.id}", URI.parse(current_url).fragment


### PR DESCRIPTION
Ref: #1404 

## 概要
* 「プラクティス一覧」のリンク先を、現在の「カテゴリー」リンクのリンク先に変更しました。
* 「カテゴリー」リンクを削除しました。
* 上記の変更に合わせて、UIテストでクリックするリンクを「プラクティス一覧」に変更しました。

## 動作時画面
[![Image from Gyazo](https://i.gyazo.com/3ef84d5a1997712130fceaa41361805c.gif)](https://gyazo.com/3ef84d5a1997712130fceaa41361805c)

## 備考
issue #1444 で対応中のエラーと同一のエラーがローカルで発生中ですが、本件とは独立したものと思われますので、PRを提出します。