### PR TITLE
個別のDocsページのヘッダをDocsにする

### DIFF
--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -3,7 +3,7 @@ header.page-header
   .container
     .page-header__inner
       h1.page-header__title
-        = title
+        = "Docs"
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item


### PR DESCRIPTION
Ref: #1398
## 概要
* 個別のDocsページのヘッダに表示される文字列を、記事のタイトルから"Docs"に変更しました

## 作業後の画面
<img width="807" alt="test1___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/48672932/76271940-5dc8c080-62bd-11ea-8779-b9af8474b525.png">

## 備考
issue #1444 で対応中のエラーと同一のエラーがローカルで発生中ですが、本件とは独立したものと思われますので、PRを提出します。