### PR TITLE
個別の提出物ページで提出物タブをアクティブにする

### DIFF
--- a/app/helpers/page_tab_helper.rb
+++ b/app/helpers/page_tab_helper.rb
@@ -76,9 +76,7 @@ module PageTabHelper
 
     def current_page_tab?(target_name)
       paths = url_for(only_path: false).split("/")
-      if paths[-2] == "products"
-        false
-      elsif paths[-2] == target_name
+      if paths[-2] == target_name
         true
       else
         paths.last == target_name


### PR DESCRIPTION
Ref: #1406

## 概要
* 個別の提出物ページで表示されている提出物タブをアクティブにしました。

## 作業後の画面

<img width="977" alt="Terminalの基礎を覚えるの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/48672932/76286031-7c8e7d80-62e4-11ea-97de-b0eb9b004598.png">

## 備考
issue #1444 で対応中のエラーと同一のエラーがローカルで発生中ですが、本件とは独立したものと思われますので、PRを提出します。
