### PR TITLE
コメントを編集する時、コメントが見つからない場合はエラーを出すように修正

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -45,8 +45,7 @@ class API::CommentsController < API::BaseController
     end
 
     def set_my_comment
-      @comment = current_user.comments.find_by(id: params[:id])
-      @comment ||= Comment.find(params[:id]) if current_user.admin?
+      @comment = current_user.admin? ? Comment.find(params[:id]) : current_user.comments.find(params[:id])
     end
 
     def notify_to_slack(comment)


### PR DESCRIPTION
## 概要

@bluerabbit に指摘してもらった点を修正しました。
コメントを編集する時、`find_by`メソッドでコメントを取得していたため、取得できない時は404ステータスが返ってきます。
そこを`find`メソッドに変更することにより、コメントが見つからない時はエラーが出て500ステータスが返ってくるように変更しました。

## 関連Issue

Ref: #1384 
