### PR TITLE
コメントの日付クリックでそのコメントへのリンクがクリップボードにコピーされる

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-comments.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-comments.sass
@@ -113,8 +113,23 @@ $thread-header-author: 3.5rem
 .thread-comment__created-at
   display: block
   +text-block(.8125rem 1.4, $muted-text nowrap)
+  +hover-link-reversal
+  cursor: pointer
+  +position(relative)
   +media-breakpoint-down(sm)
     font-size: .75rem
+  &:active,
+  &:focus,
+  &.is-active
+    color: $danger
+    &::after
+      content: "Copied!"
+      display: block
+      background-color: rgba(black, .4)
+      border-radius: .125rem
+      padding: .25rem
+      +text-block(.625rem 1, $reversal-text)
+      +position(absolute, left 0, top 100%)
 
 .thread-comment__actions
   +padding(vertical, 0 1rem)

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -86,10 +86,12 @@ export default {
       tribute.attach(textareas)
     })
 
-    this.$nextTick( () => {
-      const commentAnchor = location.hash;
-      commentAnchor ? location.href = location.href : null;
-    })
+    const commentAnchor = location.hash;
+    if(commentAnchor) {
+      this.$nextTick( () => {
+        location.href = location.href;
+      })
+    }
   },
   methods: {
     token () {

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -67,7 +67,8 @@ export default {
     return {
       description: '',
       editing: false,
-      tab: 'comment'
+      isCopied: false,
+      tab: 'comment',
     }
   },
   created: function() {
@@ -115,7 +116,7 @@ export default {
       })
     },
     updateComment: function() {
-      if (this.description.length < 1) {　return null　}
+      if (this.description.length < 1) { return null }
       let params = {
         'comment': { 'description': this.description }
       }
@@ -143,7 +144,7 @@ export default {
       }
     },
     copyCommentURLToClipboard(commentId) {
-      const commentURL　= location.href.split("#")[0] + "#comment_" + commentId;
+      const commentURL = location.href.split("#")[0] + "#comment_" + commentId;
       const textBox = document.createElement("textarea");
       textBox.setAttribute("type", "hidden");
       textBox.textContent = commentURL;

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -85,6 +85,11 @@ export default {
       const tribute = new Tribute({ collection: collection })
       tribute.attach(textareas)
     })
+
+    this.$nextTick( () => {
+      const commentAnchor = location.hash;
+      commentAnchor ? location.href = location.href : null;
+    })
   },
   methods: {
     token () {

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -8,7 +8,7 @@
         h2.thread-comment__title
           a.thread-comment__title-link(:href="comment.user.url" itempro="url")
             | {{ comment.user.login_name }}
-        time.thread-comment__created-at(:datetime="commentableCreatedAt" pubdate="pubdate")
+        time.thread-comment__created-at(:datetime="commentableCreatedAt" pubdate="pubdate" @click="copyCommentURLToClipboard(comment.id)")
           | {{ updatedAt }}
       .thread-comment__description.js-target-blank.is-long-text(v-html="markdownDescription")
       reaction(
@@ -134,6 +134,16 @@ export default {
       if (window.confirm('削除してよろしいですか？')) {
         this.$emit('delete', this.comment.id);
       }
+    },
+    copyCommentURLToClipboard(commentId) {
+      const commentURL　= location.href.split("#")[0] + "#comment_" + commentId;
+      const textBox = document.createElement("textarea");
+      textBox.setAttribute("type", "hidden");
+      textBox.textContent = commentURL;
+      document.body.appendChild(textBox);
+      textBox.select();
+      document.execCommand('copy');
+      document.body.removeChild(textBox);
     }
   },
   computed: {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -6,7 +6,7 @@
         :key="comment.id"
         :comment="comment",
         :currentUser="currentUser",
-        :id="index",
+        :id="'comment_' + comment.id",
         @delete="deleteComment")
       .thread-comment-form
         .thread-comment__author

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -90,13 +90,6 @@ export default {
   },
   mounted: function() {
     $("textarea").textareaAutoSize();
-    // issue#1462: mount直後だとページ内リンクが動作しないようなので１秒遅延を入れています
-    const commentAnchor = location.href.split("#")[1]
-    if(commentAnchor){
-      setTimeout(() => {
-        location.href = location.href;
-        }, 1000) 
-    }
   },
   methods: {
     token () {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -90,6 +90,13 @@ export default {
   },
   mounted: function() {
     $("textarea").textareaAutoSize();
+    // issue#1462: mount直後だとページ内リンクが動作しないようなので１秒遅延を入れています
+    const commentAnchor = location.href.split("#")[1]
+    if(commentAnchor){
+      setTimeout(() => {
+        location.href = location.href;
+        }, 1000) 
+    }
   },
   methods: {
     token () {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -6,6 +6,7 @@
         :key="comment.id"
         :comment="comment",
         :currentUser="currentUser",
+        :id="index",
         @delete="deleteComment")
       .thread-comment-form
         .thread-comment__author

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -137,4 +137,12 @@ class CommentsTest < ApplicationSystemTestCase
     click_button "コメントする"
     assert_text "testtest"
   end
+
+  test "comment url is copied when click its updated_time" do
+    page.driver.browser.execute_cdp("Browser.grantPermissions", origin: page.server_url, permissions: ["clipboardRead", "clipboardWrite"])
+    visit "/reports/#{reports(:report_1).id}"
+    first(:css, ".thread-comment__created-at").click
+    clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
+    assert_equal current_url + "#comment_#{comments(:comment_1).id}", clip_text
+  end
 end


### PR DESCRIPTION
Ref: #1462

## 概要
* 個々のコメントのHTMLにid属性を付与しました
  * id属性の形式は、現在Slackに配信されているURLに準拠し、"comment_[comment.id?]"という形式にしました
* コメントの日付をクリックすると、そのコメントのリンクがコピーされるようにしました。
* 当該機能のUIテストを追加しました。

## 作業後の動作
[![Image from Gyazo](https://i.gyazo.com/056e4e05eabd11b7f98f0718c97b61a5.gif)](https://gyazo.com/056e4e05eabd11b7f98f0718c97b61a5)