### PR TITLE
未チェックの提出物のときにglobal-navの提出物のリンクがアクティブになってない。

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ProductsHelper
+  def product_link(name)
+    current_user.admin? && Product.unchecked.exists? ? "is-active" : current_link(name)
+  end
+end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -8,11 +8,7 @@ module TagHelper
   end
 
   def active_link(name)
-    if qualified_page_name&.match?(name)
-      "is-active"
-    elsif current_user.admin? && Product.unchecked.exists?
-      "is-active"
-    end
+    current_user.admin? && Product.unchecked.exists? ? "is-active" : current_link(name)
   end
 
   def qrcode_tag(url, size: 1.8)

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -7,6 +7,14 @@ module TagHelper
     end
   end
 
+  def active_link(name)
+    if qualified_page_name&.match?(name)
+      "is-active"
+    elsif current_user.admin? && Product.unchecked.exists?
+      "is-active"
+    end
+  end
+
   def qrcode_tag(url, size: 1.8)
     RQRCode::QRCode.new(url)
       .as_svg(module_size: size).html_safe

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -7,10 +7,6 @@ module TagHelper
     end
   end
 
-  def product_link(name)
-    current_user.admin? && Product.unchecked.exists? ? "is-active" : current_link(name)
-  end
-
   def qrcode_tag(url, size: 1.8)
     RQRCode::QRCode.new(url)
       .as_svg(module_size: size).html_safe

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -7,7 +7,7 @@ module TagHelper
     end
   end
 
-  def active_link(name)
+  def product_link(name)
     current_user.admin? && Product.unchecked.exists? ? "is-active" : current_link(name)
   end
 

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -36,7 +36,7 @@ nav.global-nav
             .global-nav-links__link-label 日報
         - if staff_login?
           li.global-nav-links__item
-            = link_to products_unchecked_index_path, class: "global-nav-links__link #{active_link /^products/ }" do
+            = link_to products_unchecked_index_path, class: "global-nav-links__link #{product_link /^products/ }" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
               - if current_user.admin? && Product.unchecked.exists?

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -36,6 +36,8 @@ nav.global-nav
             .global-nav-links__link-label 日報
         - if staff_login?
           li.global-nav-links__item
+        - if current_user.admin? && Product.unchecked.count > 0
+          .global-nav-links__link.is-active
             = link_to products_unchecked_index_path, class: "global-nav-links__link #{current_link /^products-index/}" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -37,7 +37,7 @@ nav.global-nav
         - if staff_login?
           li.global-nav-links__item
         - if current_user.admin? && Product.unchecked.exists?
-          = link_to products_unchecked_index_path, class: "global-nav-links__link #{'is-active' if current_user.admin? && Product.unchecked.exists?} #{current_link /^products-index/}" do
+          = link_to products_unchecked_index_path, class: "global-nav-links__link is-active #{current_link /^products-index/}" do
             .global-nav-links__link-icon
               i.fas.fa-hand-paper
               .global-nav__item-count.a-notification-count

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -37,13 +37,16 @@ nav.global-nav
         - if staff_login?
           li.global-nav-links__item
         - if current_user.admin? && Product.unchecked.exists?
-          .global-nav-links__link.is-active
+          = link_to products_unchecked_index_path, class: "global-nav-links__link is-active #{current_link /^products-index/}" do
+              .global-nav-links__link-icon
+                i.fas.fa-hand-paper
+                .global-nav__item-count.a-notification-count
+                  = Product.unchecked.count
+              .global-nav-links__link-label 提出物
+        - else
             = link_to products_unchecked_index_path, class: "global-nav-links__link #{current_link /^products-index/}" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
-              - if current_user.admin? && Product.unchecked.exists?
-                .global-nav__item-count.a-notification-count
-                  = Product.unchecked.count
               .global-nav-links__link-label 提出物
         li.global-nav-links__item
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -36,17 +36,12 @@ nav.global-nav
             .global-nav-links__link-label 日報
         - if staff_login?
           li.global-nav-links__item
-        - if current_user.admin? && Product.unchecked.exists?
-          = link_to products_unchecked_index_path, class: "global-nav-links__link is-active #{current_link /^products-index/}" do
+          = link_to products_unchecked_index_path, class: "global-nav-links__link #{'is-active' if current_user.admin? && Product.unchecked.exists?}  #{current_link /^products-index/}" do
             .global-nav-links__link-icon
               i.fas.fa-hand-paper
-              .global-nav__item-count.a-notification-count
+            - if current_user.admin? && Product.unchecked.exists?
+              .global-nav__item-count.a-notification-count 
                 = Product.unchecked.count
-            .global-nav-links__link-label 提出物
-        - else
-          = link_to products_unchecked_index_path, class: "global-nav-links__link #{current_link /^products-index/}" do
-            .global-nav-links__link-icon
-              i.fas.fa-hand-paper
             .global-nav-links__link-label 提出物
         li.global-nav-links__item
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -36,7 +36,7 @@ nav.global-nav
             .global-nav-links__link-label 日報
         - if staff_login?
           li.global-nav-links__item
-            = link_to products_unchecked_index_path, class: "global-nav-links__link #{"is-active" if current_user.admin? && Product.unchecked.exists?}  #{current_link /^products-index/}" do
+            = link_to products_unchecked_index_path, class: "global-nav-links__link #{"is-active" if current_user.admin? && Product.unchecked.exists?} #{current_link /^products-index/}" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
               - if current_user.admin? && Product.unchecked.exists?

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -40,7 +40,7 @@ nav.global-nav
             .global-nav-links__link-icon
               i.fas.fa-hand-paper
             - if current_user.admin? && Product.unchecked.exists?
-              .global-nav__item-count.a-notification-count 
+              .global-nav__item-count.a-notification-count
                 = Product.unchecked.count
             .global-nav-links__link-label 提出物
         li.global-nav-links__item

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -30,18 +30,18 @@ nav.global-nav
           = link_to report_link, class: "global-nav-links__link #{current_link /^reports/}" do
             .global-nav-links__link-icon
               i.fas.fa-pen
-            - if current_user.admin? && Report.unchecked.not_wip.count > 0
+            - if current_user.admin? && Report.unchecked.not_wip.exists?
               .global-nav__item-count.a-notification-count
                 = Report.unchecked.not_wip.count
             .global-nav-links__link-label 日報
         - if staff_login?
           li.global-nav-links__item
-        - if current_user.admin? && Product.unchecked.count > 0
+        - if current_user.admin? && Product.unchecked.exists?
           .global-nav-links__link.is-active
             = link_to products_unchecked_index_path, class: "global-nav-links__link #{current_link /^products-index/}" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
-              - if current_user.admin? && Product.unchecked.count > 0
+              - if current_user.admin? && Product.unchecked.exists?
                 .global-nav__item-count.a-notification-count
                   = Product.unchecked.count
               .global-nav-links__link-label 提出物
@@ -49,7 +49,7 @@ nav.global-nav
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do
             .global-nav-links__link-icon
               i.fas.fa-question
-            - if current_user.admin? && Question.not_solved.count > 0
+            - if current_user.admin? && Question.not_solved.exists?
               .global-nav__item-count.a-notification-count
                 = Question.not_solved.count
             .global-nav-links__link-label Q&A

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -37,17 +37,17 @@ nav.global-nav
         - if staff_login?
           li.global-nav-links__item
         - if current_user.admin? && Product.unchecked.exists?
-          = link_to products_unchecked_index_path, class: "global-nav-links__link is-active #{current_link /^products-index/}" do
-              .global-nav-links__link-icon
-                i.fas.fa-hand-paper
-                .global-nav__item-count.a-notification-count
-                  = Product.unchecked.count
-              .global-nav-links__link-label 提出物
+          = link_to products_unchecked_index_path, class: "global-nav-links__link #{'is-active' if current_user.admin? && Product.unchecked.exists?} #{current_link /^products-index/}" do
+            .global-nav-links__link-icon
+              i.fas.fa-hand-paper
+              .global-nav__item-count.a-notification-count
+                = Product.unchecked.count
+            .global-nav-links__link-label 提出物
         - else
-            = link_to products_unchecked_index_path, class: "global-nav-links__link #{current_link /^products-index/}" do
-              .global-nav-links__link-icon
-                i.fas.fa-hand-paper
-              .global-nav-links__link-label 提出物
+          = link_to products_unchecked_index_path, class: "global-nav-links__link #{current_link /^products-index/}" do
+            .global-nav-links__link-icon
+              i.fas.fa-hand-paper
+            .global-nav-links__link-label 提出物
         li.global-nav-links__item
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do
             .global-nav-links__link-icon

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -36,7 +36,7 @@ nav.global-nav
             .global-nav-links__link-label 日報
         - if staff_login?
           li.global-nav-links__item
-            = link_to products_unchecked_index_path, class: "global-nav-links__link #{"is-active" if current_user.admin? && Product.unchecked.exists?} #{current_link /^products-index/}" do
+            = link_to products_unchecked_index_path, class: "global-nav-links__link #{active_link /^products/ }" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
               - if current_user.admin? && Product.unchecked.exists?

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -36,13 +36,13 @@ nav.global-nav
             .global-nav-links__link-label 日報
         - if staff_login?
           li.global-nav-links__item
-          = link_to products_unchecked_index_path, class: "global-nav-links__link #{'is-active' if current_user.admin? && Product.unchecked.exists?}  #{current_link /^products-index/}" do
-            .global-nav-links__link-icon
-              i.fas.fa-hand-paper
-            - if current_user.admin? && Product.unchecked.exists?
-              .global-nav__item-count.a-notification-count
-                = Product.unchecked.count
-            .global-nav-links__link-label 提出物
+            = link_to products_unchecked_index_path, class: "global-nav-links__link #{"is-active" if current_user.admin? && Product.unchecked.exists?}  #{current_link /^products-index/}" do
+              .global-nav-links__link-icon
+                i.fas.fa-hand-paper
+              - if current_user.admin? && Product.unchecked.exists?
+                .global-nav__item-count.a-notification-count
+                  = Product.unchecked.count
+              .global-nav-links__link-label 提出物
         li.global-nav-links__item
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do
             .global-nav-links__link-icon


### PR DESCRIPTION
#1397
未チェックの提出物のときにglobal-navの提出物のリンクをアクティブにしました。

以下は未チェックの提出物がある時
![ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/44915479/76698758-f8743580-66e9-11ea-9c57-fecb80902b70.png)

以下のように未チェックの提出物がない場合はglobal-navの提出物のリンクは表示されません。
![ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/44915479/76698816-8f40f200-66ea-11ea-8a1d-d594dd3b9071.png)

レビューよろしくお願いいたします。