### PR TITLE
リタイアの日付ボックス表示をチェックボックスで切り替わるよう追加

### DIFF
--- a/app/views/users/form/_retire.html.slim
+++ b/app/views/users/form/_retire.html.slim
@@ -1,3 +1,8 @@
-.form-item
-  = f.label :retired_on, class: "a-label"
-  = f.date_field :retired_on, class: "a-text-input"
+.form-item.js-date-input-toggler
+  .form-item__label-checkbox
+    = check_box_tag :retire_checkbox, 1, false, class: "js-date-input-toggler-checkbox"
+    = f.label :retired_on, class: "a-label", for: "retire_checkbox" do
+      | リタイア
+  .form-item__inline-form-item.js-date-input-toggler-date-area
+    .a-label = User.human_attribute_name :retired_on
+    = f.date_field :retired_on, class: "a-text-input js-date-input-toggler-date"

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -81,6 +81,36 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_text "#{user.full_name} さんを削除しました。"
   end
 
+  test "hide input for retire date when unchecked" do
+    user = users(:hatsuno)
+    visit "/admin/users/#{user.id}/edit"
+    assert has_unchecked_field?("retire_checkbox", visible: false)
+    assert_no_selector "#user_retired_on"
+  end
+
+  test "show input for retire date when checked" do
+    user = users(:hatsuno)
+    visit "/admin/users/#{user.id}/edit"
+    check "retire_checkbox", allow_label_click: true
+    assert_selector "#user_retired_on"
+  end
+
+  test "show input for retire date if user is retired" do
+    user = users(:yameo)
+    visit "/admin/users/#{user.id}/edit"
+    assert has_checked_field?("retire_checkbox", visible: false)
+    assert has_field?("user_retired_on", with: user.retired_on.to_s)
+  end
+
+  test "reset value of retire date when unchecked" do
+    user = users(:yameo)
+    visit "/admin/users/#{user.id}/edit"
+    uncheck "retire_checkbox", allow_label_click: true
+    assert has_unchecked_field?("retire_checkbox", visible: false)
+    check "retire_checkbox", allow_label_click: true
+    assert has_field?("user_retired_on", with: "")
+  end
+
   test "hide input for graduation date when unchecked" do
     user = users(:hatsuno)
     visit "/admin/users/#{user.id}/edit"


### PR DESCRIPTION
Ref: https://github.com/fjordllc/bootcamp/issues/1137

## 修正内容
リタイア日の日付フォームしかなかったのを、チェックボックスを追加して日付インプットが切り替わるようにした。
卒業UIの実装と全く一緒なのでそちらを参考に今回実装。
>卒業日の日付ボックス表示をチェックボックスで切り替わるよう追加
https://github.com/fjordllc/bootcamp/pull/1372

## 動作画面
[![Image from Gyazo](https://i.gyazo.com/86bc8733b094c11ce25bc6261c357da4.gif)](https://gyazo.com/86bc8733b094c11ce25bc6261c357da4)