### PR TITLE
日報、提出物、QA一覧にユーザー名を表示したい #1409

### DIFF
--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -10,8 +10,7 @@
           = link_to product, itempro: "url", class: "thread-list-item__title-link" do
             | #{product.practice.title}の提出物
     .thread-list-item-meta
-      = link_to product.user, class: "thread-header__author" do
-        = product.user.login_name
+      = link_to product.user.login_name, product.user, class: "thread-header__author"
       time.thread-list-item-meta__updated-at(datetime="#{product.updated_at.to_datetime}" pubdate="pubdate")
         = l product.updated_at
       - if product.comments.any?

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -10,6 +10,8 @@
           = link_to product, itempro: "url", class: "thread-list-item__title-link" do
             | #{product.practice.title}の提出物
     .thread-list-item-meta
+      = link_to product.user, class: "thread-header__author" do
+        = product.user.login_name
       time.thread-list-item-meta__updated-at(datetime="#{product.updated_at.to_datetime}" pubdate="pubdate")
         = l product.updated_at
       - if product.comments.any?

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -16,8 +16,7 @@
       h3.thread-list-item__sub-title
         = question.practice.title
     .thread-list-item-meta
-      = link_to question.user, class: "thread-header__author" do
-        = question.user.login_name
+      = link_to question.user.login_name, question.user, class: "thread-header__author"
       time.thread-list-item-meta__updated-at(datetime="#{question.updated_at.to_datetime}" pubdate="pubdate")
         = l question.updated_at
       - if question.answers.present?

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -16,6 +16,8 @@
       h3.thread-list-item__sub-title
         = question.practice.title
     .thread-list-item-meta
+      = link_to question.user, class: "thread-header__author" do
+        = question.user.login_name
       time.thread-list-item-meta__updated-at(datetime="#{question.updated_at.to_datetime}" pubdate="pubdate")
         = l question.updated_at
       - if question.answers.present?

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -17,6 +17,8 @@
           = link_to report_path(report), data: { confirm: "本当によろしいですか？" }, method: :delete, class: "thread-list-item__actions-link" do
             i.fas.fa-trash-alt
     .thread-list-item-meta
+      = link_to report.user, class: "thread-header__author", title: report.user.full_name do
+        = report.user.login_name
       time.thread-list-item-meta__updated-at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
         = l report.updated_at
       - if report.comments.any?

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -17,8 +17,7 @@
           = link_to report_path(report), data: { confirm: "本当によろしいですか？" }, method: :delete, class: "thread-list-item__actions-link" do
             i.fas.fa-trash-alt
     .thread-list-item-meta
-      = link_to report.user, class: "thread-header__author", title: report.user.full_name do
-        = report.user.login_name
+      = link_to report.user.login_name, report.user, class: "thread-header__author"
       time.thread-list-item-meta__updated-at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
         = l report.updated_at
       - if report.comments.any?


### PR DESCRIPTION
## Q&A一覧にユーザー名を表示させました。
![未解決の質問一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/44915479/76728515-40529580-679a-11ea-82d1-c20ddef8a4c7.png)

## 日報一覧にユーザー名を表示させました。
![未チェックの日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/44915479/76728642-a93a0d80-679a-11ea-84ef-92bfd015d687.png)


## 提出物一覧にユーザー名を表示させました。
![未チェックの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/44915479/76728870-2b2a3680-679b-11ea-8281-72c65ada5a30.png)

## ユーザー名のリンクをクリックするとユーザー個別ページへとびます。
![hajimeのプロフィール___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/44915479/76729054-a25fca80-679b-11ea-97a3-859656a6bf1a.png)

レビューよろしくお願いします🙇‍♂️
