### PR TITLE
application.jsからrequire_treeを削除

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,3 @@
 //= require jquery_ujs
 //= require cocoon
 //= require select2/dist/js/select2.full.js
-//= require_tree .


### PR DESCRIPTION
## 概要
#1428
上記PRにて、require_treeを削除したほうがいいのでは、というご指摘を受け、assets/application.jsから``require_tree .``を削除した。