### PR TITLE
APIのCSRF対策の設定を修正

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 class API::BaseController < ApplicationController
-  protect_from_forgery with: :null_session
   before_action :require_login
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@
 class ApplicationController < ActionController::Base
   include Authentication
   include PolicyHelper
-  protect_from_forgery
+  protect_from_forgery with: :exception
   before_action :init_user
   before_action :allow_cross_domain_access
   before_action :set_host_for_disk_storage


### PR DESCRIPTION
Ref: #1463 
## 概要
APIのCSRF対策について、API::BaseController内の記述を削除しました
(親クラスであるApplicationControllerで、すでに同一の設定がなされているため）