### PR TITLE
就職活動中のユーザー一覧に卒業した人も含める 

### DIFF
--- a/app/models/user_callbacks.rb
+++ b/app/models/user_callbacks.rb
@@ -7,7 +7,7 @@ class UserCallbacks
       Report.where(user: user).wip.destroy_all
     end
 
-    if user.saved_change_to_graduated_on? || user.saved_change_to_retired_on?
+    if user.saved_change_to_retired_on?
       user.update(job_seeking: false)
     end
   end


### PR DESCRIPTION
Ref: #1467

## 概要
ユーザーが「卒業」に変更されたときに動作するコールバックを修正し、卒業しても「就職活動中」を維持するように変更しました。