### PR TITLE
検索結果に文書の作成者と作成日時の情報を加える

### DIFF
--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -14,9 +14,9 @@ class Searcher
 
   def self.search(word, document_type: :all)
     if document_type == :all
-      AVAILABLE_TYPES.flat_map { |type| result_for(type, word) }
+      AVAILABLE_TYPES.flat_map { |type| result_for(type, word) }.sort_by { |result| result.created_at }.reverse
     else
-      result_for(document_type, word)
+      result_for(document_type, word).sort_by { |result| result.created_at }.reverse
     end
   end
 

--- a/app/views/searchables/_searchable.html.slim
+++ b/app/views/searchables/_searchable.html.slim
@@ -10,7 +10,7 @@
         = md_summury(searchable.description, 90)
       .thread-list-item-meta
         .thread-list-item-meta__user
-          - if searchable.class != Practice && searchable.class!= Page
+          - if searchable.class != Practice && searchable.class != Page
             = link_to searchable.user.login_name, searchable.user, class: "thread-header__author"
         time.thread-list-item-meta__created-at(datetime="#{searchable.created_at.to_datetime}" pubdate="pubdate")
           = l searchable.updated_at

--- a/app/views/searchables/_searchable.html.slim
+++ b/app/views/searchables/_searchable.html.slim
@@ -8,3 +8,9 @@
     .thread-list-item__body
       .thread-list-item__summury
         = md_summury(searchable.description, 90)
+      .thread-list-item-meta
+        .thread-list-item-meta__user
+          - if searchable.class != Practice && searchable.class!= Page
+            = link_to searchable.user.login_name, searchable.user, class: "thread-header__author"
+        time.thread-list-item-meta__created-at(datetime="#{searchable.created_at.to_datetime}" pubdate="pubdate")
+          = l searchable.updated_at

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -86,3 +86,27 @@ sotugyou:
   title: テストの日報
   description: いろいろやりました
   reported_on: "2018-02-01"
+
+report_12:
+  user: yamada
+  title: 検索結果確認用-C
+  description:
+    今年で150歳でーす
+  reported_on: "2020-01-01"
+  created_at: "2020-01-01 00:00:00"
+
+report_13:
+  user: yamada
+  title: 検索結果確認用-A
+  description:
+    きたるべき20世紀
+  reported_on: "1900-01-01"
+  created_at: "1900-01-01 00:00:00"
+
+report_14:
+  user: yamada
+  title: 検索結果確認用-B
+  description:
+    あれから100年か
+  reported_on: "2000-01-01"
+  created_at: "2000-01-01 00:00:00"

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -65,4 +65,11 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Question)
     assert_includes(result, Announcement)
   end
+
+  test "sort search results in descending order of creation date" do
+    result = Searcher.search("検索結果確認用", document_type: :reports)
+    assert result[0] == reports(:report_12)
+    assert result[1] == reports(:report_14)
+    assert result[2] == reports(:report_13)
+  end
 end

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -68,8 +68,6 @@ class SearchableTest < ActiveSupport::TestCase
 
   test "sort search results in descending order of creation date" do
     result = Searcher.search("検索結果確認用", document_type: :reports)
-    assert result[0] == reports(:report_12)
-    assert result[1] == reports(:report_14)
-    assert result[2] == reports(:report_13)
+    assert_equal [reports(:report_12), reports(:report_14), reports(:report_13)], result
   end
 end

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -38,6 +38,6 @@ class SearchablesTest < ApplicationSystemTestCase
     end
     find("#test-search").click
     assert_text "yamada"
-    assert (has_css? ".thread-list-item-meta__created-at")
+    assert_css ".thread-list-item-meta__created-at"
   end
 end

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -30,4 +30,14 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_no_text "テストの質問1"
     assert_no_text "テストのお知らせ"
   end
+
+  test "show user name and created time" do
+    within("form[name=search]") do
+      select "日報"
+      fill_in "word", with: "テストの日報"
+    end
+    find("#test-search").click
+    assert_text "yamada"
+    assert (has_css? ".thread-list-item-meta__created-at")
+  end
 end


### PR DESCRIPTION
ref: #1466 

## 概要
* 検索結果に作成者とcreated_atを表示するように変更しました。
  * プラクティスとDocsについては作成者の情報がないので、created_atのみ表示させました。
  * 管理者用の日報一覧画面を参考に、既存のCSSクラスを付与しました。
* 検索結果をcreated_atの逆順にソートしました。
* 上記変更点のテストを追加しました。

## 変更後の画面
<img width="1440" alt="_1_の検索結果___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/48672932/77399693-49241680-6ded-11ea-86fb-0ce1e031fb82.png">

