### PR TITLE
検索結果にコメントを含める

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SearchHelper
+  def matched_document(searchable)
+    if searchable.class == Comment
+      document = searchable.commentable_type.constantize.find(searchable.commentable_id)
+    else
+      document = searchable
+    end
+  end
+
+  def searchable_url(searchable)
+    if searchable.class == Comment
+      document = searchable.commentable_type.constantize.find(searchable.commentable_id)
+      "#{polymorphic_url(document)}#comment_#{searchable.id}"
+    else
+      polymorphic_url(searchable)
+    end
+  end
+
+  def filtered_message(searchable)
+    if searchable.class == Comment && searchable.commentable_type == "Product"
+      commentable = Product.find(searchable.commentable_id)
+      if policy(commentable).show? || commentable.practice.open_product?
+        searchable.description
+      else
+        "該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。"
+      end
+    else
+      searchable.description
+    end
+  end
+end

--- a/app/views/searchables/_searchable.html.slim
+++ b/app/views/searchables/_searchable.html.slim
@@ -1,30 +1,17 @@
-- if searchable.class == Comment
-  - comment = searchable
-  - commentable = comment.commentable_type.constantize.find(comment.commentable_id)
-  .thread-list-item(class="is-#{comment.commentable_type.tableize.singularize}")
-    .thread-list-item__inner
-      .thread-list-item__label
-        = t("activerecord.models.#{comment.commentable_type.tableize.singularize}")
-      header.thread-list-item__header
-        .thread-list-item__title
-          = link_to commentable.title, "#{polymorphic_url(comment.commentable)}#comment_#{comment.id}", class: "thread-list-item__title-link"
-      .thread-list-item__body
-        .thread-list-item__summury
-          - if commentable.class.to_s == "Product"
-            - if policy(commentable).show? || commentable.practice.open_product?
-              = md_summury(comment.description, 90)
-            -else
-              = "該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。"
-          - else
-            = md_summury(comment.description, 90)
-- else
-  .thread-list-item(class="is-#{searchable.class.to_s.tableize.singularize}")
-    .thread-list-item__inner
-      .thread-list-item__label
-        = t("activerecord.models.#{searchable.class.to_s.tableize.singularize}")
-      header.thread-list-item__header
-        .thread-list-item__title
-          = link_to searchable.title, searchable, class: "thread-list-item__title-link"
-      .thread-list-item__body
-        .thread-list-item__summury
-          = md_summury(searchable.description, 90)
+- document = matched_document(searchable)
+.thread-list-item(class="is-#{document.class.to_s.tableize.singularize}")
+  .thread-list-item__inner
+    .thread-list-item__label
+      = t("activerecord.models.#{document.class.to_s.tableize.singularize}")
+    header.thread-list-item__header
+      .thread-list-item__title
+        = link_to document.title, searchable_url(searchable), class: "thread-list-item__title-link"
+    .thread-list-item__body
+      .thread-list-item__summury
+        = md_summury(filtered_message(searchable), 90)
+      .thread-list-item-meta
+        .thread-list-item-meta__user
+          - if searchable.class != Practice && searchable.class != Page
+            = link_to searchable.user.login_name, searchable.user, class: "thread-header__author"
+        time.thread-list-item-meta__created-at(datetime="#{searchable.created_at.to_datetime}" pubdate="pubdate")
+          = l searchable.updated_at

--- a/app/views/searchables/_searchable.html.slim
+++ b/app/views/searchables/_searchable.html.slim
@@ -1,16 +1,30 @@
-.thread-list-item(class="is-#{searchable.class.to_s.tableize.singularize}")
-  .thread-list-item__inner
-    .thread-list-item__label
-      = t("activerecord.models.#{searchable.class.to_s.tableize.singularize}")
-    header.thread-list-item__header
-      .thread-list-item__title
-        = link_to searchable.title, searchable, class: "thread-list-item__title-link"
-    .thread-list-item__body
-      .thread-list-item__summury
-        = md_summury(searchable.description, 90)
-      .thread-list-item-meta
-        .thread-list-item-meta__user
-          - if searchable.class != Practice && searchable.class != Page
-            = link_to searchable.user.login_name, searchable.user, class: "thread-header__author"
-        time.thread-list-item-meta__created-at(datetime="#{searchable.created_at.to_datetime}" pubdate="pubdate")
-          = l searchable.updated_at
+- if searchable.class == Comment
+  - comment = searchable
+  - commentable = comment.commentable_type.constantize.find(comment.commentable_id)
+  .thread-list-item(class="is-#{comment.commentable_type.tableize.singularize}")
+    .thread-list-item__inner
+      .thread-list-item__label
+        = t("activerecord.models.#{comment.commentable_type.tableize.singularize}")
+      header.thread-list-item__header
+        .thread-list-item__title
+          = link_to commentable.title, "#{polymorphic_url(comment.commentable)}#comment_#{comment.id}", class: "thread-list-item__title-link"
+      .thread-list-item__body
+        .thread-list-item__summury
+          - if commentable.class.to_s == "Product"
+            - if policy(commentable).show? || commentable.practice.open_product?
+              = md_summury(comment.description, 90)
+            -else
+              = "該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。"
+          - else
+            = md_summury(comment.description, 90)
+- else
+  .thread-list-item(class="is-#{searchable.class.to_s.tableize.singularize}")
+    .thread-list-item__inner
+      .thread-list-item__label
+        = t("activerecord.models.#{searchable.class.to_s.tableize.singularize}")
+      header.thread-list-item__header
+        .thread-list-item__title
+          = link_to searchable.title, searchable, class: "thread-list-item__title-link"
+      .thread-list-item__body
+        .thread-list-item__summury
+          = md_summury(searchable.description, 90)

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -55,3 +55,24 @@ comment_10:
   user: yamada
   commentable: product_1 (Product)
   description: "提出物へのコメント"
+
+comment_11:
+  user: yamada
+  commentable: report_1 (Report)
+  description: "テスト用 report_1へのコメント"
+
+comment_12:
+  user: yamada
+  commentable: announcement_1 (Announcement)
+  description: "テスト用 announcement_1へのコメント"
+
+comment_13:
+  user: yamada
+  commentable: product_1 (Product)
+  description: "テスト用 product_1へのコメント"
+
+comment_14:
+  user: yamada
+  commentable: product_3 (Product)
+  description: "テスト用 product_3へのコメント"
+

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -10,6 +10,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Practice)
     assert_includes(result, Question)
     assert_includes(result, Announcement)
+    assert_includes(result, Comment)
   end
 
   test "returns all types when document_type argument is :all" do
@@ -19,6 +20,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Practice)
     assert_includes(result, Question)
     assert_includes(result, Announcement)
+    assert_includes(result, Comment)
   end
 
   test "returns only report type when document_type argument is :reports" do
@@ -28,6 +30,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Practice)
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
+    assert_includes(result, Comment)
   end
 
   test "returns only page type when document_type argument is :pages" do
@@ -37,6 +40,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Practice)
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
+    assert_not_includes(result, Comment)
   end
 
   test "returns only practice type when document_type argument is :practices" do
@@ -46,6 +50,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Practice)
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
+    assert_not_includes(result, Comment)
   end
 
   test "returns only question type when document_type argument is :questions" do
@@ -55,6 +60,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Practice)
     assert_includes(result, Question)
     assert_not_includes(result, Announcement)
+    assert_not_includes(result, Comment)
   end
 
   test "returns only announcement type when document_type argument is :announcements" do
@@ -64,6 +70,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Practice)
     assert_not_includes(result, Question)
     assert_includes(result, Announcement)
+    assert_includes(result, Comment)
   end
 
   test "sort search results in descending order of creation date" do

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -16,6 +16,8 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_text "Unityでのテスト"
     assert_text "テストの質問1"
     assert_text "テストのお知らせ"
+    assert_text "テスト用 report_1へのコメント"
+    assert_text "テスト用 announcement_1へのコメント"
   end
 
   test "search reports " do
@@ -29,6 +31,50 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_no_text "Unityでのテスト"
     assert_no_text "テストの質問1"
     assert_no_text "テストのお知らせ"
+    assert_text "テスト用 report_1へのコメント"
+    assert_no_text "テスト用 announcement_1へのコメント"
+  end
+
+  test "admin can see comment description" do
+    login_user "komagata", "testtest"
+    within("form[name=search]") do
+      select "すべて"
+      fill_in "word", with: "テスト"
+    end
+    find("#test-search").click
+    assert_text "テスト用 product_1へのコメント"
+  end
+
+  test "advisor can see comment description" do
+    login_user "advijirou", "testtest"
+    within("form[name=search]") do
+      select "すべて"
+      fill_in "word", with: "テスト"
+    end
+    find("#test-search").click
+    assert_text "テスト用 product_1へのコメント"
+  end
+
+  test "can see comment description if it is permitted" do
+    login_user "kimura", "testtest"
+    within("form[name=search]") do
+      select "すべて"
+      fill_in "word", with: "テスト"
+    end
+    find("#test-search").click
+    assert_text "テスト用 product_1へのコメント"
+    assert_text "テスト用 product_3へのコメント"
+  end
+
+  test "can not see comment description if it isn't permitted" do
+    within("form[name=search]") do
+      select "すべて"
+      fill_in "word", with: "テスト"
+    end
+    find("#test-search").click
+    assert_no_text "テスト用 product_1へのコメント"
+    assert_text "テスト用 product_3へのコメント"
+    assert_text "該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。"
   end
 
   test "show user name and created time" do


### PR DESCRIPTION
ref: #1480 

## 概要
* 検索時、「すべて」もしくはcommentableな文書を選択して検索するとコメント内の文書も含めて検索結果を返します。
* コメント内の文章にマッチした場合、検索結果のアイコンとタイトルは、そのコメントが付与されている文書のものが表示されます。
  * ただし、検索結果の文章はコメントのものが表示されます
* もしも本文とコメントの両方、もしくは複数のコメントでマッチした場合、マッチした数だけ検索結果に表示されます。
* 2020/3/27現在、検索対象に提出物は含まれていませんが、「すべて」を選択して検索した場合、提出物へのコメントも含む全てのコメントが検索対象となります。
  * 未完のプラクティスへのコメントがマッチした場合、コメントの文章の代わりに、「該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。」と表示されます。

## 検索時の画面
<img width="1432" alt="_確認_の検索結果___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/48672932/77717086-e7e58880-7022-11ea-87e7-9f8cc74a0c94.png">
