### PR TITLE
検索結果にQ&AのAを含める

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -4,6 +4,8 @@ module SearchHelper
   def matched_document(searchable)
     if searchable.class == Comment
       document = searchable.commentable_type.constantize.find(searchable.commentable_id)
+    elsif searchable.class == Answer || searchable.class == CorrectAnswer
+      document = searchable.question
     else
       document = searchable
     end
@@ -13,6 +15,9 @@ module SearchHelper
     if searchable.class == Comment
       document = searchable.commentable_type.constantize.find(searchable.commentable_id)
       "#{polymorphic_url(document)}#comment_#{searchable.id}"
+    elsif searchable.class == Answer || searchable.class == CorrectAnswer
+      document = searchable.question
+      "#{polymorphic_url(document)}"
     else
       polymorphic_url(searchable)
     end

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -10,13 +10,15 @@ class Searcher
     ["Docs", :pages]
   ]
 
-  AVAILABLE_TYPES = DOCUMENT_TYPES.map(&:second) - [:all] + [:comments]
+  AVAILABLE_TYPES = DOCUMENT_TYPES.map(&:second) - [:all] + [:comments] + [:answers]
 
   def self.search(word, document_type: :all)
     if document_type == :all
       AVAILABLE_TYPES.flat_map { |type| result_for(type, word) }.sort_by { |result| result.created_at }.reverse
     elsif document_type.to_s.capitalize.singularize.constantize.include?(Commentable)
       [document_type, :comments].flat_map { |type| result_for(type, word, commentable_type: document_type.to_s.capitalize.singularize) }.sort_by { |result| result.created_at }.reverse
+    elsif document_type == :questions
+      [document_type, :answers].flat_map { |type| result_for(type, word) }
     else
       result_for(document_type, word).sort_by { |result| result.created_at }.reverse
     end
@@ -32,6 +34,8 @@ class Searcher
       Practice.ransack(title_or_description_or_goal_cont_all: word).result
     when :questions
       Question.ransack(title_or_description_cont_all: word).result
+    when :answers
+      Answer.ransack(description_cont_all: word).result
     when :announcements
       Announcement.ransack(title_or_description_cont_all: word).result
     when :comments

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -11,6 +11,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Question)
     assert_includes(result, Announcement)
     assert_includes(result, Comment)
+    assert_includes(result, Answer)
   end
 
   test "returns all types when document_type argument is :all" do
@@ -21,6 +22,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Question)
     assert_includes(result, Announcement)
     assert_includes(result, Comment)
+    assert_includes(result, Answer)
   end
 
   test "returns only report type when document_type argument is :reports" do
@@ -31,6 +33,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
     assert_includes(result, Comment)
+    assert_not_includes(result, Answer)
   end
 
   test "returns only page type when document_type argument is :pages" do
@@ -41,6 +44,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
     assert_not_includes(result, Comment)
+    assert_not_includes(result, Answer)
   end
 
   test "returns only practice type when document_type argument is :practices" do
@@ -51,6 +55,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
     assert_not_includes(result, Comment)
+    assert_not_includes(result, Answer)
   end
 
   test "returns only question type when document_type argument is :questions" do
@@ -61,6 +66,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Question)
     assert_not_includes(result, Announcement)
     assert_not_includes(result, Comment)
+    assert_includes(result, Answer)
   end
 
   test "returns only announcement type when document_type argument is :announcements" do
@@ -76,5 +82,6 @@ class SearchableTest < ActiveSupport::TestCase
   test "sort search results in descending order of creation date" do
     result = Searcher.search("検索結果確認用", document_type: :reports)
     assert_equal [reports(:report_12), reports(:report_14), reports(:report_13)], result
+    assert_not_includes(result, Answer)
   end
 end

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -18,6 +18,7 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_text "テストのお知らせ"
     assert_text "テスト用 report_1へのコメント"
     assert_text "テスト用 announcement_1へのコメント"
+    assert_text "テストの回答"
   end
 
   test "search reports " do
@@ -85,5 +86,6 @@ class SearchablesTest < ApplicationSystemTestCase
     find("#test-search").click
     assert_text "yamada"
     assert_css ".thread-list-item-meta__created-at"
+    assert_no_text "テストの回答"
   end
 end


### PR DESCRIPTION
ref: #1481 

* 検索時、「すべて」もしくは「Q&A」を選択して検索すると、回答も含めた検索結果を返します。
* 回答内の文章にマッチした場合、検索結果のアイコンとタイトルは、その回答が付与されている質問のものが表示されます。
  * ただし、検索結果の文章は回答のものが表示されます
* もしも質問と回答の両方、もしくは複数の回答でマッチした場合、マッチした数だけ検索結果に表示されます。

## 検索時の画面
<img width="1436" alt="_回答_の検索結果___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/48672932/77726636-bcbb6300-703b-11ea-8579-8fe6b6fb3e02.png">
