### PR TITLE
ランダムに失敗するのでsleepを追加 (reports_test.rb)

### DIFF
--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -8,6 +8,10 @@ class ReportsTest < ApplicationSystemTestCase
     login_user "komagata", "testtest"
   end
 
+  def teardown
+    wait_for_vuejs
+  end
+
   test "create report as WIP" do
     visit "/reports/new"
     within("#new_report") do


### PR DESCRIPTION
ref: https://github.com/fjordllc/bootcamp/issues/1444

https://circleci.com/gh/fjordllc/bootcamp/3505 で reports_test.rb が https://github.com/fjordllc/bootcamp/issues/1444 と同じ理由で失敗していたのでsleepを入れました。