### PR TITLE
日報、提出物、QA一覧にユーザー個別へのリンクを貼りたい

### DIFF
--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -2,7 +2,7 @@
   .thread-list-item__inner
     .thread-list-item__author
       = link_to product.user, class: "thread-header__author" do
-        = image_tag product.user.avatar_url, title: "#{product.user.icon_title}", class: "thread-list-item__author-icon a-user-icon"
+        = image_tag product.user.avatar_url, title: product.user.icon_title, class: "thread-list-item__author-icon a-user-icon"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if product.wip?

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -1,7 +1,8 @@
 .thread-list-item(class="#{product.wip? ? "is-wip" : ""}")
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag product.user.avatar_url, title: "#{product.user.icon_title}", class: "thread-list-item__author-icon a-user-icon"
+      = link_to product.user, class: "thread-header__author" do
+        = image_tag product.user.avatar_url, title: "#{product.user.icon_title}", class: "thread-list-item__author-icon a-user-icon"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if product.wip?

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -1,7 +1,8 @@
 .thread-list-item
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag question.user.avatar_url, title: "#{question.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{question.user.role}"
+      = link_to question.user, class: "thread-header__author" do
+        = image_tag question.user.avatar_url, title: "#{question.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{question.user.role}"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to question, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -2,7 +2,7 @@
   .thread-list-item__inner
     .thread-list-item__author
       = link_to question.user, class: "thread-header__author" do
-        = image_tag question.user.avatar_url, title: "#{question.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{question.user.role}"
+        = image_tag question.user.avatar_url, title: question.user.icon_title, class: "thread-list-item__author-icon a-user-icon is-#{question.user.role}"
     header.thread-list-item__header
       h2.thread-list-item__title(itemprop="name")
         = link_to question, itempro: "url", class: "thread-list-item__title-link" do

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -1,7 +1,8 @@
 .thread-list-item(class="#{report.wip? ? "is-wip" : ""}")
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag report.user.avatar_url, title: "#{report.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{report.user.role}"
+      = link_to report.user, class: "thread-header__author" do
+        = image_tag report.user.avatar_url, title: "#{report.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{report.user.role}"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if report.wip?

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -2,7 +2,7 @@
   .thread-list-item__inner
     .thread-list-item__author
       = link_to report.user, class: "thread-header__author" do
-        = image_tag report.user.avatar_url, title: "#{report.user.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{report.user.role}"
+        = image_tag report.user.avatar_url, title: report.user.icon_title, class: "thread-list-item__author-icon a-user-icon is-#{report.user.role}"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if report.wip?


### PR DESCRIPTION
#1408
日報、提出物、QA一覧のユーザーのアイコンをクリックするとユーザー個別ページへとぶようにリンクを貼りました。
# 日報
[![Screenshot from Gyazo](https://gyazo.com/bfe4e5e982e94010101b59b2b3d9b806/raw)](https://gyazo.com/bfe4e5e982e94010101b59b2b3d9b806)

# 提出物
[![Screenshot from Gyazo](https://gyazo.com/6b7fa5b4be8bdabcfdf8038463de44c0/raw)](https://gyazo.com/6b7fa5b4be8bdabcfdf8038463de44c0)

# QA
[![Screenshot from Gyazo](https://gyazo.com/ad966f585953dc195e47022160b876fb/raw)](https://gyazo.com/ad966f585953dc195e47022160b876fb)