### PR TITLE
現役受講生以外はニコニコカレンダーを非表示にする

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -46,7 +46,8 @@ header.page-header
             = render "users/grass", user: @user
           - if @user.active_practices.present?
             = render "/users/practices/active_practices", user: @user
-          = render "/users/niconico_calendar", user: @user
+          - if @user.student?
+            = render "/users/niconico_calendar", user: @user
           - if @user.completed_practices.present?
             = render "/users/practices/completed_practices", user: @user
           - if @user.books.present?


### PR DESCRIPTION
## 変更の目的
ref: #1503

## キャプチャ

現役受講生の「hatsuno」の個別ページでは、ニコニコカレンダーが表示されますが、メンターの「yamada」のページでは表示されません。

[![Image from Gyazo](https://i.gyazo.com/5d7d535cfe9626f27cf6ecacbac314e8.gif)](https://gyazo.com/5d7d535cfe9626f27cf6ecacbac314e8)