### PR TITLE
コメント機能のシステムテストが失敗する問題に対処

### DIFF
--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -139,10 +139,12 @@ class CommentsTest < ApplicationSystemTestCase
   end
 
   test "comment url is copied when click its updated_time" do
-    page.driver.browser.execute_cdp("Browser.grantPermissions", origin: page.server_url, permissions: ["clipboardRead", "clipboardWrite"])
     visit "/reports/#{reports(:report_1).id}"
     first(:css, ".thread-comment__created-at").click
-    clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
+    # Google Chromeのバージョンが上がり従来のテストではエラーが発生したため、以下のように修正
+    # 詳細:https://gitmemory.com/issue/marp-team/marp-cli/190/564376272
+    find("#js-new-comment").send_keys [:shift, :insert]
+    clip_text = find("#js-new-comment").value
     assert_equal current_url + "#comment_#{comments(:comment_1).id}", clip_text
   end
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -141,8 +141,9 @@ class CommentsTest < ApplicationSystemTestCase
   test "comment url is copied when click its updated_time" do
     visit "/reports/#{reports(:report_1).id}"
     first(:css, ".thread-comment__created-at").click
-    # Google Chromeのバージョンが上がり従来のテストではエラーが発生したため、以下のように修正
-    # 詳細:https://gitmemory.com/issue/marp-team/marp-cli/190/564376272
+    # クリップボードを直接読み取る方法がないので、未入力のテキストエリアを経由してクリップボードの値を読み取っている
+    # また、Ctrl-Vではペーストできなかったので、かわりにShift-Insertをショートカットキーとして使っている
+    # 参考 https://stackoverflow.com/a/57955123/1058763
     find("#js-new-comment").send_keys [:shift, :insert]
     clip_text = find("#js-new-comment").value
     assert_equal current_url + "#comment_#{comments(:comment_1).id}", clip_text


### PR DESCRIPTION
## 変更の目的・概要
ref: #1513

コメントのURLをクリップボードにコピーする機能をテストする際に、"clipboardRead"にpermissionを与えるという処理を行っていたことが原因でした。
Google Chromeのバージョンが81に上がり、"clipboardRead"のpermissionが廃止され、従来の方法が使用できなくなったため、その方法を用いないようにコメント機能のシステムテストを修正しました。

## 参考サイト
https://gitmemory.com/issue/marp-team/marp-cli/190/564376272