### PR TITLE
複数キーワードでの検索機能の追加

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -21,4 +21,20 @@ class Announcement < ApplicationRecord
   validates :title, presence: true
   validates :description, presence: true
   validates :target, presence: true
+
+  concerning :KeywordSearch do
+    class_methods do
+      private
+
+        def params_for_keyword_search(searched_values = {})
+          { groupings: groupings(split_keyword_by_blank(searched_values[:word])) }
+        end
+
+        def groupings(words)
+          words.map do |word|
+            { title_or_description_cont_all: word }
+          end
+        end
+    end
+  end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,6 +2,7 @@
 
 class Answer < ActiveRecord::Base
   include Reactionable
+  include Searchable
 
   belongs_to :user, touch: true
   belongs_to :question
@@ -11,6 +12,22 @@ class Answer < ActiveRecord::Base
 
   validates :description, presence: true
   validates :user, presence: true
+
+  concerning :KeywordSearch do
+    class_methods do
+      private
+
+        def params_for_keyword_search(searched_values = {})
+          { groupings: groupings(split_keyword_by_blank(searched_values[:word])) }
+        end
+
+        def groupings(words)
+          words.map do |word|
+            { description_cont_all: word }
+          end
+        end
+    end
+  end
 
   def receiver
     self.question.user

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,6 +2,7 @@
 
 class Comment < ActiveRecord::Base
   include Reactionable
+  include Searchable
 
   belongs_to :user, touch: true
   belongs_to :commentable, polymorphic: true
@@ -10,6 +11,22 @@ class Comment < ActiveRecord::Base
   alias_method :sender, :user
 
   validates :description, presence: true
+
+  concerning :KeywordSearch do
+    class_methods do
+      private
+
+        def params_for_keyword_search(searched_values = {})
+          { commentable_type_eq: searched_values[:commentable_type], groupings: groupings(split_keyword_by_blank(searched_values[:word])) }
+        end
+
+        def groupings(words)
+          words.map do |word|
+            { description_cont_all: word }
+          end
+        end
+    end
+  end
 
   def receiver
     commentable.user

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -3,6 +3,18 @@
 module Searchable
   extend ActiveSupport::Concern
 
+  class_methods do
+    def search_by_keywords(searched_values = {})
+      ransack(**params_for_keyword_search(searched_values)).result
+    end
+
+    private
+
+      def split_keyword_by_blank(word)
+        word.split(/[[:blank:]]/)
+      end
+  end
+
   included do
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,4 +6,20 @@ class Page < ActiveRecord::Base
   validates :title, presence: true
   validates :body, presence: true
   paginates_per 20
+
+  concerning :KeywordSearch do
+    class_methods do
+      private
+
+        def params_for_keyword_search(searched_values = {})
+          { groupings: groupings(split_keyword_by_blank(searched_values[:word])) }
+        end
+
+        def groupings(words)
+          words.map do |word|
+            { title_or_body_cont_all: word }
+          end
+        end
+    end
+  end
 end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -32,6 +32,22 @@ class Practice < ActiveRecord::Base
 
   scope :category_order, -> { includes(:category).order("categories.position").order(:position) }
 
+  concerning :KeywordSearch do
+    class_methods do
+      private
+
+        def params_for_keyword_search(searched_values = {})
+          { groupings: groupings(split_keyword_by_blank(searched_values[:word])) }
+        end
+
+        def groupings(words)
+          words.map do |word|
+            { title_or_description_or_goal_cont_all: word }
+          end
+        end
+    end
+  end
+
   def status(user)
     learnings = Learning.where(
       user_id: user.id,

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -22,4 +22,20 @@ class Question < ActiveRecord::Base
 
   scope :solved, -> { joins(:correct_answer) }
   scope :not_solved, -> { where.not(id: CorrectAnswer.pluck(:question_id)) }
+
+  concerning :KeywordSearch do
+    class_methods do
+      private
+
+        def params_for_keyword_search(searched_values = {})
+          { groupings: groupings(split_keyword_by_blank(searched_values[:word])) }
+        end
+
+        def groupings(words)
+          words.map do |word|
+            { title_or_description_cont_all: word }
+          end
+        end
+    end
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -39,6 +39,22 @@ class Report < ActiveRecord::Base
   after_update ReportCallbacks.new
   after_destroy ReportCallbacks.new
 
+  concerning :KeywordSearch do
+    class_methods do
+      private
+
+        def params_for_keyword_search(searched_values = {})
+          { groupings: groupings(split_keyword_by_blank(searched_values[:word])) }
+        end
+
+        def groupings(words)
+          words.map do |word|
+            { title_or_description_cont_all: word }
+          end
+        end
+    end
+  end
+
   def previous
     Report.where(user: user)
           .where("reported_on < ?", reported_on)

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -27,19 +27,19 @@ class Searcher
   def self.result_for(type, word, commentable_type: nil)
     case type
     when :reports
-      Report.ransack(title_or_description_cont_all: word).result
+      Report.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_description_cont_all: w } }).result
     when :pages
-      Page.ransack(title_or_body_cont_all: word).result
+      Page.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_body_cont_all: w } }).result
     when :practices
-      Practice.ransack(title_or_description_or_goal_cont_all: word).result
+      Practice.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_description_or_goal_cont_all: w } }).result
     when :questions
-      Question.ransack(title_or_description_cont_all: word).result
+      Question.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_description_cont_all: w } }).result
     when :answers
-      Answer.ransack(description_cont_all: word).result
+      Answer.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { description_cont_all: w } }).result
     when :announcements
-      Announcement.ransack(title_or_description_cont_all: word).result
+      Announcement.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_description_cont_all: w } }).result
     when :comments
-      Comment.ransack(commentable_type_eq: commentable_type, description_cont_all: word).result
+      Comment.ransack(commentable_type_eq: commentable_type, groupings: word.split(/[[:blank:]]/).map { |w| { description_cont_all: w } }).result
     else
       []
     end

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -12,36 +12,28 @@ class Searcher
 
   AVAILABLE_TYPES = DOCUMENT_TYPES.map(&:second) - [:all] + [:comments] + [:answers]
 
-  def self.search(word, document_type: :all)
-    if document_type == :all
-      AVAILABLE_TYPES.flat_map { |type| result_for(type, word) }.sort_by { |result| result.created_at }.reverse
-    elsif document_type.to_s.capitalize.singularize.constantize.include?(Commentable)
-      [document_type, :comments].flat_map { |type| result_for(type, word, commentable_type: document_type.to_s.capitalize.singularize) }.sort_by { |result| result.created_at }.reverse
-    elsif document_type == :questions
-      [document_type, :answers].flat_map { |type| result_for(type, word) }
-    else
-      result_for(document_type, word).sort_by { |result| result.created_at }.reverse
+  class << self
+    def search(word, document_type: :all)
+      if document_type == :all
+        AVAILABLE_TYPES.flat_map { |type| result_for(type, word) }.sort_by { |result| result.created_at }.reverse
+      elsif document_type.to_s.capitalize.singularize.constantize.include?(Commentable)
+        [document_type, :comments].flat_map { |type| result_for(type, word, commentable_type: document_type.to_s.capitalize.singularize) }.sort_by { |result| result.created_at }.reverse
+      elsif document_type == :questions
+        [document_type, :answers].flat_map { |type| result_for(type, word) }
+      else
+        result_for(document_type, word).sort_by { |result| result.created_at }.reverse
+      end
     end
-  end
 
-  def self.result_for(type, word, commentable_type: nil)
-    case type
-    when :reports
-      Report.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_description_cont_all: w } }).result
-    when :pages
-      Page.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_body_cont_all: w } }).result
-    when :practices
-      Practice.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_description_or_goal_cont_all: w } }).result
-    when :questions
-      Question.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_description_cont_all: w } }).result
-    when :answers
-      Answer.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { description_cont_all: w } }).result
-    when :announcements
-      Announcement.ransack(groupings: word.split(/[[:blank:]]/).map { |w| { title_or_description_cont_all: w } }).result
-    when :comments
-      Comment.ransack(commentable_type_eq: commentable_type, groupings: word.split(/[[:blank:]]/).map { |w| { description_cont_all: w } }).result
-    else
-      []
-    end
+    private
+
+      def result_for(type, word, commentable_type: nil)
+        return [] unless available_type?(type)
+        type.to_s.capitalize.singularize.constantize.search_by_keywords(word: word, commentable_type: commentable_type)
+      end
+
+      def available_type?(type)
+        AVAILABLE_TYPES.find { |available_type| available_type == type }.present?
+      end
   end
 end

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -16,8 +16,8 @@ class Searcher
     def search(word, document_type: :all)
       if document_type == :all
         AVAILABLE_TYPES.flat_map { |type| result_for(type, word) }.sort_by { |result| result.created_at }.reverse
-      elsif document_type.to_s.capitalize.singularize.constantize.include?(Commentable)
-        [document_type, :comments].flat_map { |type| result_for(type, word, commentable_type: document_type.to_s.capitalize.singularize) }.sort_by { |result| result.created_at }.reverse
+      elsif model(document_type).include?(Commentable)
+        [document_type, :comments].flat_map { |type| result_for(type, word, commentable_type: model_name(document_type)) }.sort_by { |result| result.created_at }.reverse
       elsif document_type == :questions
         [document_type, :answers].flat_map { |type| result_for(type, word) }
       else
@@ -34,6 +34,14 @@ class Searcher
 
       def available_type?(type)
         AVAILABLE_TYPES.find { |available_type| available_type == type }.present?
+      end
+
+      def model(type)
+        model_name(type).constantize
+      end
+
+      def model_name(type)
+        type.to_s.capitalize.singularize
       end
   end
 end

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -11,5 +11,5 @@ page_3:
   body: "## 存在しないDocsページ遷移テスト\n[存在しないページ](http://localhost:3000/pages/5555555)"
 
 page_4:
-  title: Bootcmapの作業のページ
+  title: Bootcampの作業のページ
   body: "## テスト\nテスト"

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -84,4 +84,102 @@ class SearchableTest < ActiveSupport::TestCase
     assert_equal [reports(:report_12), reports(:report_14), reports(:report_13)], result
     assert_not_includes(result, Answer)
   end
+
+  test "returns only reports having all keywords" do
+    result = Searcher.search("日報", document_type: :reports)
+    assert_includes(result, reports(:report_9))
+    assert_includes(result, reports(:report_8))
+
+    result = Searcher.search("日報 WIP", document_type: :reports)
+    assert_includes(result, reports(:report_9))
+    assert_not_includes(result, reports(:report_8))
+
+    result = Searcher.search("日報　WIP", document_type: :reports)
+    assert_includes(result, reports(:report_9))
+    assert_not_includes(result, reports(:report_8))
+  end
+
+  test "returns only pages having all keywords" do
+    result = Searcher.search("テスト", document_type: :pages)
+    assert_includes(result, pages(:page_4))
+    assert_includes(result, pages(:page_3))
+
+    result = Searcher.search("テスト Bootcamp", document_type: :pages)
+    assert_includes(result, pages(:page_4))
+    assert_not_includes(result, pages(:page_3))
+
+    result = Searcher.search("テスト　Bootcamp", document_type: :pages)
+    assert_includes(result, pages(:page_4))
+    assert_not_includes(result, pages(:page_3))
+  end
+
+  test "returns only practices having all keywords" do
+    result = Searcher.search("OS", document_type: :practices)
+    assert_includes(result, practices(:practice_1))
+    assert_includes(result, practices(:practice_3))
+
+    result = Searcher.search("OS クリーンインストール", document_type: :practices)
+    assert_includes(result, practices(:practice_1))
+    assert_not_includes(result, practices(:practice_3))
+
+    result = Searcher.search("OS　クリーンインストール", document_type: :practices)
+    assert_includes(result, practices(:practice_1))
+    assert_not_includes(result, practices(:practice_3))
+  end
+
+  test "returns only questions having all keywords" do
+    result = Searcher.search("使う", document_type: :questions)
+    assert_includes(result, questions(:question_2))
+    assert_includes(result, questions(:question_1))
+
+    result = Searcher.search("使う エディター", document_type: :questions)
+    assert_includes(result, questions(:question_1))
+    assert_not_includes(result, questions(:question_2))
+
+    result = Searcher.search("使う　エディター", document_type: :questions)
+    assert_includes(result, questions(:question_1))
+    assert_not_includes(result, questions(:question_2))
+  end
+
+  test "returns only answers of questions having all keywords" do
+    result = Searcher.search("です", document_type: :questions)
+    assert_includes(result, answers(:answer_1))
+    assert_includes(result, answers(:answer_5))
+
+    result = Searcher.search("です atom", document_type: :questions)
+    assert_includes(result, answers(:answer_1))
+    assert_not_includes(result, answers(:answer_5))
+
+    result = Searcher.search("です　atom", document_type: :questions)
+    assert_includes(result, answers(:answer_1))
+    assert_not_includes(result, answers(:answer_5))
+  end
+
+  test "returns only announcements having all keywords" do
+    result = Searcher.search("お知らせ", document_type: :announcements)
+    assert_includes(result, announcements(:announcement_3))
+    assert_includes(result, announcements(:announcement_notification_active_user))
+
+    result = Searcher.search("お知らせ 通知", document_type: :announcements)
+    assert_includes(result, announcements(:announcement_notification_active_user))
+    assert_not_includes(result, announcements(:announcement_3))
+
+    result = Searcher.search("お知らせ　通知", document_type: :announcements)
+    assert_includes(result, announcements(:announcement_notification_active_user))
+    assert_not_includes(result, announcements(:announcement_3))
+  end
+
+  test "returns only comments having all keywords" do
+    result = Searcher.search("report_id", document_type: :reports)
+    assert_includes(result, comments(:comment_6))
+    assert_includes(result, comments(:comment_5))
+
+    result = Searcher.search("report_id typo", document_type: :reports)
+    assert_includes(result, comments(:comment_6))
+    assert_not_includes(result, comments(:comment_5))
+
+    result = Searcher.search("report_id　typo", document_type: :reports)
+    assert_includes(result, comments(:comment_6))
+    assert_not_includes(result, comments(:comment_5))
+  end
 end


### PR DESCRIPTION
refs #1510 

### 概要
以下の仕様で複数キーワードでの検索を実装した

- スペースで区切られた単語は別のキーワードとみなす
- 半角・全角スペースともに区切り文字とみなす

また、併せて `Searcher.rb` に対してのリファクタリングも行った

### スクリーンショット
#### 修正前
[![Image from Gyazo](https://i.gyazo.com/d89eaa6f11844116d4987cd8d28088c6.gif)](https://gyazo.com/d89eaa6f11844116d4987cd8d28088c6)

#### 修正後
[![Image from Gyazo](https://i.gyazo.com/d90fecbfa7e1aa8d006cf59607207396.gif)](https://gyazo.com/d90fecbfa7e1aa8d006cf59607207396)