### PR TITLE
プラクティス編集画面の「進捗の計算を含むようにする場合はチェック」が反映されるようにする

### DIFF
--- a/app/views/practices/_form.html.slim
+++ b/app/views/practices/_form.html.slim
@@ -55,7 +55,7 @@
         ul.checkboxes__items
           li.checkboxes__item
             label
-              = f.check_box :include_progress, { checked: "checked" }
+              = f.check_box :include_progress
               | 進捗の計算に含むようにする場合はチェック
   .form-actions
     ul.form-actions__items


### PR DESCRIPTION
## 問題
「進捗の計算を含むようにする場合はチェック」が無条件でチェックが入ってしまう状態でした。
プラクティス作成時に「進捗に含めない」に設定しても、編集するとチェックが入ってしまうため、進捗に含めない状態のプラクティスはチェックが外れた状態にしたい。
ref #1512 
## 原因
チェックがデフォルトで入る設定になっていた。
## 対処方法
該当箇所を削除
## 動作画面
### 新規プラクティス作成時
<img width="1373" alt="スクリーンショット 2020-05-12 1 04 20" src="https://user-images.githubusercontent.com/10154448/81583658-9e8fa380-93ec-11ea-971d-4944fc9a9ce0.png">

### 進捗に含めた場合の編集画面
<img width="1386" alt="スクリーンショット 2020-05-12 1 04 44" src="https://user-images.githubusercontent.com/10154448/81583702-ad765600-93ec-11ea-9b4d-b48d2112c8eb.png">

### 進捗に含めない場合の編集画面
<img width="1375" alt="スクリーンショット 2020-05-12 1 04 32" src="https://user-images.githubusercontent.com/10154448/81583785-cda61500-93ec-11ea-97f2-45313d38b7a6.png">

