### PR TITLE
編集中のフォームで確認ダイアログを出す項目を全て機能するようにする

### DIFF
--- a/app/javascript/warning.js
+++ b/app/javascript/warning.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const warningForm = document.querySelector('.js-warning-form')
-  if (!warningForm) { return null }
+  const warningForms = document.querySelectorAll('.js-warning-form')
+  if (warningForms.length <= 0) { return null }
 
   let submitting = false
   const commentForm = document.querySelector('#js-new-comment')
@@ -12,8 +12,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     })
   }
-  warningForm.addEventListener('keyup', onUnload, false)
-  warningForm.addEventListener('change', onUnload, false)
+  for (let warningForm of warningForms) {
+    warningForm.addEventListener('keyup', onUnload, false)
+    warningForm.addEventListener('change', onUnload, false)
+  }
   window.addEventListener('submit', () => {
     window.removeEventListener('beforeunload', onUnload, false)
     submitting = true


### PR DESCRIPTION
##  問題
`.js-warning-form`が入ってるinputが編集途中の場合にページ遷移すると「移動して大丈夫ですか？」のダイアログが表示される。
現在`.js-warning-form`が一番最初の項目にしか適用されないので、一番最初を変更しないで他の項目を変更し、ページ遷移しても確認ダイアログが表示されない。
ref #1542 
## 原因
warning.jsで一番最初のinputしか取ってこない設定になっていた。

## 解決策
`querySelectorAll()`に変更して、`js-warning-form`が入ってる項目全てに対して`beforeunload`イベントを追加する。

## 動作画面
![59b782fa0f0e9edde6e334bb1f5d33cd](https://user-images.githubusercontent.com/10154448/81587029-69398480-93f1-11ea-9ce1-d2c947940aab.gif)
