### PR TITLE
JCBカードが使えるという文言を追加

### DIFF
--- a/app/views/card/_form.html.slim
+++ b/app/views/card/_form.html.slim
@@ -8,9 +8,9 @@
       #card-element.a-text-input
       .a-form-help
         p
-          | 対応ブランド：Visa、Master、Diners、Amex
+          | 対応ブランド：Visa、Master、JCB、Diners、Amex
           br
-          | JCBカードは使えません。プリペイドのクレジットカードは登録できない場合があります。
+          | プリペイドのクレジットカードは登録できない場合があります。
       #card-errors(role="alert")
   .form-actions
     ul.form-actions__items

--- a/app/views/users/form/_card.html.slim
+++ b/app/views/users/form/_card.html.slim
@@ -4,8 +4,8 @@
     #card-element.a-text-input
     .a-form-help
       p
-        | 対応ブランド：Visa、Master、Diners、Amex
+        | 対応ブランド：Visa、Master、JCB、Diners、Amex
         br
-        | JCBカードは使えません。プリペイドのクレジットカードは登録できない場合があります。
+        | プリペイドのクレジットカードは登録できない場合があります。
     #card-errors(role="alert")
     = render "/card/notice"


### PR DESCRIPTION
クレジットカードの対応ブランドにJCBカードを追加しました。

![Screen Shot 2020-05-14 at 18 04 09](https://user-images.githubusercontent.com/28076271/81917188-d4f93880-960f-11ea-9fce-dda13c0bb035.jpg)
