### PR TITLE
雑談ルームのURLをmenuに追加

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -71,6 +71,9 @@
               = link_to "https://fjord.whereby.com/meeting", class: "header-dropdown__item-link", target: "_blank" do
                 | Whereby
             li.header-dropdown__item
+              = link_to "https://fjord.whereby.com/talk", class: "header-dropdown__item-link", target: "_blank" do
+                | 雑談ルーム
+            li.header-dropdown__item
               = link_to "https://suzuri.jp/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
                 | グッズ購入
             li.header-dropdown__item

--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -69,7 +69,7 @@
                 | GitHub Projects
             li.header-dropdown__item
               = link_to "https://fjord.whereby.com/meeting", class: "header-dropdown__item-link", target: "_blank" do
-                | Whereby
+                | MTGルーム
             li.header-dropdown__item
               = link_to "https://fjord.whereby.com/talk", class: "header-dropdown__item-link", target: "_blank" do
                 | 雑談ルーム


### PR DESCRIPTION
## 概要
雑談ルームのURLをmenuに追加する。下記の画像のように修正した。
Ref: #1543
![image](https://i.gyazo.com/7bd14e16efdd1dfcc767aad5088630f4.png)

## タスク
- [x] menuに雑談ルームのリンクを追加する
- [x] menuの「Whereby」を「MTGルーム」に変更する