### PR TITLE
Q&Aの「解決にする」ボタンを「ベストアンサーにする」ボタンに変える

### DIFF
--- a/app/views/answers/_answer.html.slim
+++ b/app/views/answers/_answer.html.slim
@@ -26,7 +26,7 @@
           - if correct_answer.blank? && answer != correct_answer && (current_user == question.user || admin_login?)
             li.card-footer-actions__item
               = link_to question_correct_answer_path(answer.question, answer_id: answer.id, return_to: question_path(answer.question)), data: { confirm: "本当に宜しいですか？" }, method: :post, class: "a-button is-md is-warning is-block" do
-                | 解決にする
+                | ベストアンサーにする
           - if answer.user == current_user || admin_login?
             li.card-footer-actions__item
               = link_to edit_question_answer_path(answer.question, answer, return_to: question_url(answer.question)), class: "card-footer-actions__action a-button is-md is-primary is-block", id: "js-shortcut-edit" do

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -33,23 +33,23 @@ class AnswersTest < ApplicationSystemTestCase
 
   test "admin can resolve user's question" do
     visit "/questions/#{questions(:question_2).id}"
-    assert_text "解決にする"
+    assert_text "ベストアンサーにする"
     accept_alert do
-      click_link "解決にする"
+      click_link "ベストアンサーにする"
     end
     assert_text "正解の解答を選択しました。"
-    assert_no_text "解決にする"
+    assert_no_text "ベストアンサーにする"
   end
 
   test "delete best answer" do
     visit "/questions/#{questions(:question_2).id}"
     accept_alert do
-      click_link "解決にする"
+      click_link "ベストアンサーにする"
     end
     accept_alert do
       click_link "ベストアンサーを取り消す"
     end
     assert_text "ベストアンサーを取り消しました。"
-    assert_text "解決にする"
+    assert_text "ベストアンサーにする"
   end
 end


### PR DESCRIPTION
「解決にする」ボタンを「ベストアンサーにする」ボタンに変更いたしました。
イシュー：#1496

![Screen Shot 2020-05-15 at 11 07 59](https://user-images.githubusercontent.com/28076271/82007706-daa15d80-96a5-11ea-9144-add61a9896cc.jpg)
