### PR TITLE
提出物一覧のユーザーアイコンにroleを示す枠線を表示

### DIFF
--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -2,7 +2,7 @@
   .thread-list-item__inner
     .thread-list-item__author
       = link_to product.user, class: "thread-header__author" do
-        = image_tag product.user.avatar_url, title: product.user.icon_title, class: "thread-list-item__author-icon a-user-icon"
+        = image_tag product.user.avatar_url, title: product.user.icon_title, class: "thread-list-item__author-icon a-user-icon is-#{product.user.role}"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if product.wip?


### PR DESCRIPTION
提出物一覧のユーザーアイコンに各roleを示す枠線を表示させました。
refs #1545 

## 変更前

![スクリーンショット_2020-05-18_12_13_03](https://user-images.githubusercontent.com/28076271/82171975-cfe40400-9903-11ea-99d6-e47e872a6696.png)

## 変更後

![スクリーンショット_2020-05-18_12_12_47](https://user-images.githubusercontent.com/28076271/82172000-dffbe380-9903-11ea-94d4-e8742580b4be.png)
