### PR TITLE
Q&Aコメントのプレビュー機能を隠す

### DIFF
--- a/app/views/answers/_form.html.slim
+++ b/app/views/answers/_form.html.slim
@@ -6,8 +6,6 @@
     .thread-comment-form__tabs.js-tabs
       .thread-comment-form__tab.js-tabs__tab.is-active
         | コメント
-      .thread-comment-form__tab.js-tabs__tab
-        | プレビュー
     .thread-comment-form__markdown-parent.js-markdown-parent
       .thread-comment-form__markdown.js-tabs__content.is-active
         = f.text_area :description, required: true, class: "a-text-input js-warning-form thread-comment-form__textarea js-markdown", data: { "preview": ".js-preview" }

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -5,23 +5,6 @@ require "application_system_test_case"
 class AnswersTest < ApplicationSystemTestCase
   setup { login_user "komagata", "testtest" }
 
-  test "answer form in questions/:id has comment tab and preview tab" do
-    visit "/questions/#{questions(:question_2).id}"
-    within(".thread-comment-form__tabs") do
-      assert_text "コメント"
-      assert_text "プレビュー"
-    end
-  end
-
-  test "answer form in questions/:question_id/answers/:id/edit has comment tab and preview tab" do
-    answer = answers(:answer_3)
-    visit "/questions/#{answer.question_id}/answers/#{answer.id}/edit"
-    within(".thread-comment-form__tabs") do
-      assert_text "コメント"
-      assert_text "プレビュー"
-    end
-  end
-
   test "admin can edit and delete any questions" do
     visit "/questions/#{questions(:question_1).id}"
     answer_by_user = page.all(".thread-comment")[1]


### PR DESCRIPTION
Q&Aコメントのプレビュー機能の対応にまだ時間がかかりそうなので、それまでいったんQ&Aコメントのプレビュー機能を隠すようにしました。

![テストの質問___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/44915479/82198948-fc197800-9937-11ea-95cc-f58270f833f4.png)
