### PR TITLE
お問い合わせにプライバシーポリシーに同意のチェックボックスを追加

### DIFF
--- a/app/assets/stylesheets/atoms/_form.sass
+++ b/app/assets/stylesheets/atoms/_form.sass
@@ -211,3 +211,38 @@ textarea.a-text-input
   padding: .5rem
   border: solid 1px $input-border
   border-radius: .25rem
+
+.a-checkbox
+  +position(relative)
+  input[type="checkbox"]
+    +position(absolute, left 0, top 0)
+    visibility: hidden
+    opacity: 0
+  span
+    +position(relative)
+    display: inline-block
+    margin-bottom: 0
+    padding-left: 1.5em
+    cursor: pointer
+    &::before
+      content: ''
+      display: block
+      +size(.875rem)
+      border: solid 1px #bbbbbb
+      border-radius: .1875rem
+      +position(absolute, left 0, top 50%)
+      margin-top: -.4375rem
+      box-shadow: rgba(black, .1) 0 1px 2px inset
+      background-color: $base
+  input:checked + span::after
+    +fa(fas '\f00c')
+    +text-block(.75rem .875rem, center block #4193e9)
+    +size(.875rem)
+    +position(absolute, left 0, top 50%)
+    margin-top: -.4375rem
+  &:hover
+    span
+      text-decoration: underline
+      &::before,
+      &::after
+        text-decoration: none

--- a/app/assets/stylesheets/blocks/form/_form.sass
+++ b/app/assets/stylesheets/blocks/form/_form.sass
@@ -30,6 +30,9 @@
     width: 40rem
     max-width: 100%
 
+.form-item__pp
+  margin-top: .75rem
+
 .form-item__add-times
   margin-top: 1rem
   +media-breakpoint-down(sm)
@@ -67,12 +70,9 @@
   #tasks .form-item:first-child &
     display: none
 
-.form-item__remember-me
+.form-item__one-checkbox
   +text-block(.875rem)
   cursor: pointer
-
-.form-item__remember-me-input
-  margin-right: .25rem
 
 .form-item__pp
   p

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -18,6 +18,6 @@ class InquiriesController < ApplicationController
 
   private
     def inquiry_params
-      params.require(:inquiry).permit(:name, :email, :body)
+      params.require(:inquiry).permit(:name, :email, :body, :privacy_policy)
     end
 end

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -9,4 +9,5 @@ class Inquiry < ApplicationRecord
       message: "Emailに使える文字のみ入力してください"
     }
   validates :body, presence: true
+  validates :privacy_policy, acceptance: { message: "に同意してください" }
 end

--- a/app/views/inquiries/_form.html.slim
+++ b/app/views/inquiries/_form.html.slim
@@ -16,6 +16,9 @@
         | 個人情報の取り扱いについて
       .a-form-frame.form-item__pp
         = render("pp")
+    .form-item
+      = f.check_box :privacy_policy
+      | 個人情報の取り扱いに同意する
 
   .form-actions
     ul.form-actions__items

--- a/app/views/inquiries/_form.html.slim
+++ b/app/views/inquiries/_form.html.slim
@@ -14,13 +14,14 @@
     .form-item
       .a-label
         | 個人情報の取り扱いについて
+      label.form-item__one-checkbox.a-checkbox
+        = f.check_box :privacy_policy
+        span
+          | 下記の個人情報の取り扱いに同意する
       .a-form-frame.form-item__pp
         = render("pp")
-    .form-item
-      = f.check_box :privacy_policy
-      | 個人情報の取り扱いに同意する
 
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main
-        = f.submit "上記内容に同意して送信", class: "a-button is-lg is-warning is-block"
+        = f.submit "送信", class: "a-button is-lg is-warning is-block"

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -6,13 +6,14 @@
     .form-item
       = f.label :password, class: "a-label"
       = f.password_field :password, class: "a-text-input"
-    .form-item
-      label.form-item__remember-me.a-checkbox
-        = check_box_tag :remember, params[:remember], true, class: "form-item__remember-me-input"
-        | 次回から自動的にログイン
       .a-form-help.is-text-align-right
         label.a-form-help-link(for="forgot-password-modal")
           | パスワードを忘れた
+    .form-item
+      label.form-item__one-checkbox.a-checkbox
+        = check_box_tag :remember, params[:remember], true, class: "form-item__remember-me-input"
+        span
+          | 次回から自動的にログイン
   .form-actions
     .form-actions__items
       .form-actions__item.is-main

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -146,6 +146,7 @@ ja:
         name: 名前
         email: メールアドレス
         body: 内容
+        privacy_policy: 個人情報の取り扱い
       article:
         title: タイトル
         body: 本文


### PR DESCRIPTION
## 概要
- [お問い合わせ](https://bootcamp.fjord.jp/inquiry/new)に、「下記の個人情報の取り扱いに同意する」というチェックボックスを追加しました。

- チェックボックスにチェックを入れないで`上記内容に同意して送信`ボタンを押した場合、「個人情報の取り扱いに同意してください」というエラーメッセージが表示されるようにしました。

## 変更後のスクリーンショット
![image](https://user-images.githubusercontent.com/53965479/82725325-2f348080-9d17-11ea-8bce-85dcfcd776e0.png)


![image](https://user-images.githubusercontent.com/53965479/82685605-7119e400-9c8f-11ea-9494-dbc7923e7369.png)

## 関連Issue
#962 