### PR TITLE
完了したプラクティスを完了日の降順に並べる

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,6 +10,7 @@ class HomeController < ApplicationController
         @announcements = Announcement.with_avatar
                                      .limit(5)
                                      .order(created_at: :desc)
+        @completed_learnings = current_user.learnings.where(status: 3).order(updated_at: :desc)
         render aciton: :index
       end
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @completed_learnings = current_user.learnings.where(status: 3).order(updated_at: :desc)
   end
 
   def new

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -24,7 +24,7 @@ header.page-header
           - if current_user.active_practices.present?
             = render "/users/practices/active_practices", user: current_user
           - if current_user.completed_practices.present?
-            = render "/users/practices/completed_practices", user: current_user
+            = render "/users/practices/completed_practices", user: current_user, completed_learnings: @completed_learnings
 
         .col-xs-12.col-xl-6.col-xxl-6
           - if current_user.admin? || current_user.adviser?

--- a/app/views/users/practices/_completed_practices.html.slim
+++ b/app/views/users/practices/_completed_practices.html.slim
@@ -5,4 +5,4 @@
       = render "users/learning_status", user: user
   .completed-practices__body
     = render "users/practices/completed_practices_progress", user: user
-    = render "users/practices/completed_practices_list", user: user
+    = render "users/practices/completed_practices_list", user: user, completed_learnings: completed_learnings

--- a/app/views/users/practices/_completed_practices_list.html.slim
+++ b/app/views/users/practices/_completed_practices_list.html.slim
@@ -1,10 +1,10 @@
 .card-list.is-completed
   ul.card-list__items
-    - user.completed_practices.each do |practice|
+    - completed_learnings.each do |learning|
       li.card-list__item
-        = link_to practice, class: "card-list__item-link" do
-          = practice.title
+        = link_to learning.practice, class: "card-list__item-link" do
+          = learning.practice.title
           .card-list__item-link-date
             .card-list__item-link-date-label
               | 完了日
-            = l practice.learning(user).updated_at.to_date
+            = l learning.updated_at.to_date

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -50,6 +50,6 @@ header.page-header
           - if @user.student?
             = render "/users/niconico_calendar", user: @user
           - if @user.completed_practices.present?
-            = render "/users/practices/completed_practices", user: @user
+            = render "/users/practices/completed_practices", user: @user, completed_learnings: @completed_learnings
           - if @user.books.present?
             = render "/users/borrowing_books", user: @user

--- a/test/fixtures/learnings.yml
+++ b/test/fixtures/learnings.yml
@@ -34,28 +34,28 @@ learning_7:
   status: "submitted"
 
 learning_8:
-  user: komagata
+  user: machida
   practice: practice_5
   status: "complete"
   created_at: "2020-04-12 14:05:53.782503"
   updated_at: "2020-04-12 14:05:53.782503"
 
 learning_9:
-  user: komagata
+  user: machida
   practice: practice_6
   status: "complete"
   created_at: "2020-04-10 14:05:53.782503"
   updated_at: "2020-04-10 14:05:53.782503"
 
 learning_10:
-  user: komagata
+  user: machida
   practice: practice_7
   status: "complete"
   created_at: "2020-04-19 14:05:53.782503"
   updated_at: "2020-04-19 14:05:53.782503"
 
 learning_11:
-  user: komagata
+  user: machida
   practice: practice_8
   status: "complete"
   created_at: "2020-04-22 14:05:53.782503"

--- a/test/fixtures/learnings.yml
+++ b/test/fixtures/learnings.yml
@@ -32,3 +32,31 @@ learning_7:
   user: komagata
   practice: practice_4
   status: "submitted"
+
+learning_8:
+  user: komagata
+  practice: practice_5
+  status: "complete"
+  created_at: "2020-04-12 14:05:53.782503"
+  updated_at: "2020-04-12 14:05:53.782503"
+
+learning_9:
+  user: komagata
+  practice: practice_6
+  status: "complete"
+  created_at: "2020-04-10 14:05:53.782503"
+  updated_at: "2020-04-10 14:05:53.782503"
+
+learning_10:
+  user: komagata
+  practice: practice_7
+  status: "complete"
+  created_at: "2020-04-19 14:05:53.782503"
+  updated_at: "2020-04-19 14:05:53.782503"
+
+learning_11:
+  user: komagata
+  practice: practice_8
+  status: "complete"
+  created_at: "2020-04-22 14:05:53.782503"
+  updated_at: "2020-04-22 14:05:53.782503"


### PR DESCRIPTION
## 概要
- ダッシュボード画面とユーザーのプロフィール画面に表示される完了したプラクティス一覧を、完了日の降順に表示されるようにしました。

## 変更後のスクリーンショット
![image](https://user-images.githubusercontent.com/53965479/82789095-acd9c700-9ea4-11ea-917d-e281c9d67a2c.png)

## 関連Issue
#1515 