### PR TITLE
日報一覧に投稿日時ではなく、何月何日の日報なのかを表示するように変更

### DIFF
--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -19,7 +19,7 @@
             i.fas.fa-trash-alt
     .thread-list-item-meta
       = link_to report.user.login_name, report.user, class: "thread-header__author"
-      time.thread-list-item-meta__updated-at(datetime="#{report.reported_on.to_datetime}" pubdate="pubdate")
+      time.thread-list-item-meta__updated-at(datetime="#{report.reported_on.to_datetime}")
         = l report.reported_on
         = "の日報"
     - if report.comments.any?

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -19,8 +19,9 @@
             i.fas.fa-trash-alt
     .thread-list-item-meta
       = link_to report.user.login_name, report.user, class: "thread-header__author"
-      time.thread-list-item-meta__updated-at(datetime="#{report.updated_at.to_datetime}" pubdate="pubdate")
-        = l report.updated_at
+      time.thread-list-item-meta__updated-at(datetime="#{report.reported_on.to_datetime}" pubdate="pubdate")
+        = l report.reported_on
+        = "の日報"
     - if report.comments.any?
       .thread-list-item-meta
         .thread-list-item-meta__label


### PR DESCRIPTION
## 概要
日報一覧に表示されていた日時が、今までは更新日時だったのですが、何月何日の日報なのかを表示するように変更しました。


## 変更後
![image](https://user-images.githubusercontent.com/53965479/82987147-0ae7e500-a032-11ea-8713-ed883464c9b1.png)

## 関連Isuue
#1518 