### PR TITLE
メンター向けメモに記述がなければ非表示になるようにした

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -69,7 +69,7 @@ header.page-header
                 br
                 | 終了条件をクリアしたら完了にしてください。
 
-        - if @practice.memo && (current_user.mentor? || current_user.admin?)
+        - if @practice.memo? && (current_user.mentor? || current_user.admin?)
           section.practice-content.a-card
             header.practice-content__header.card-header
               h2.practice-content__title

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -69,7 +69,7 @@ header.page-header
                 br
                 | 終了条件をクリアしたら完了にしてください。
 
-        - if current_user.mentor? || current_user.admin?
+        - if @practice.memo && (current_user.mentor? || current_user.admin?)
           section.practice-content.a-card
             header.practice-content__header.card-header
               h2.practice-content__title

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -469,7 +469,7 @@ practice_56:
   title: "Unityでのテスト"
   description: "description..."
   goal: "goal..."
-  memo: "memo for mentors..."
+  memo:
   category: category_21
   position: 56
   include_progress: false


### PR DESCRIPTION
## 概要
Ref: #1593

## 補足
test/fixtures/practices.yml内にmemoが空のpracticeが無かったため、practice_56のmemoを空にしました。

## キャプチャ
![image](https://user-images.githubusercontent.com/50286474/83738518-5d0eb300-a68f-11ea-81fc-027a5a2ec2ee.png)

