### PR TITLE
メンターのダッシュボードの学習時間を非表示にした

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -32,7 +32,7 @@ header.page-header
           - if current_user.admin? || current_user.adviser?
             - if User.all.job_seeking.present?
               = render "job_seeking_users", users: User.all.job_seeking
-          - unless current_user.total_learning_time.zero?
+          - unless current_user.total_learning_time.zero? || current_user.mentor?
             = render "users/grass", user: current_user
           = render "users/github_grass", user: current_user
           - if current_user.role == :student

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -42,7 +42,7 @@ header.page-header
                       - elsif admin_login?
                         = link_to "管理者として情報変更", edit_admin_user_path, class: "card-footer-actions__action a-button is-md is-secondary is-block"
         .col-xs-12.col-lg-7.col-xxl-6
-          - unless @user.total_learning_time.zero?
+          - unless @user.total_learning_time.zero? || @user.mentor?
             = render "users/grass", user: @user
           = render "users/github_grass", user: @user
           - if @user.active_practices.present?

--- a/test/fixtures/learning_times.yml
+++ b/test/fixtures/learning_times.yml
@@ -17,3 +17,8 @@ learning_time_4:
   report: sotugyou
   started_at: 2018-12-11 10:00:00
   finished_at: 2018-12-11 15:00:00
+
+learning_time_5:
+  report: report_17
+  started_at: 2020-06-01 10:00:00
+  finished_at: 2020-06-01 11:00:00

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -126,3 +126,11 @@ report_16:
   description: |-
     頑張れませんでした
   reported_on: <%= Time.now - 2.day %>
+
+report_17:
+  user: yamada
+  title: 1時間だけ学習
+  description: |-
+    yamadaです、メンターです。
+    今日は1時間学習しました。
+  reported_on: "2020-06-01"


### PR DESCRIPTION
## 概要
Ref: #1607

## 補足
メンター(yamada)の合計学習時間がゼロだったため、このままですと、合計学習時間がゼロであるから学習時間(草)が表示されないのか、それとも、メンターであるから表示されないのかの判断がつかないため、それを防ぐためfixturesに1時間学習した日報を追加し、合計学習時間を1時間増やしました。

## キャプチャ
### メンター(yamada)でログイン、トップページとプロフィールページ(yamada)
![image](https://user-images.githubusercontent.com/50286474/83740170-71ec4600-a691-11ea-9485-1596b8ed02e7.png)

![image](https://user-images.githubusercontent.com/50286474/83752985-6bb39500-a6a4-11ea-91bc-12dbfff8de1d.png)
