### PR TITLE
左メニューの提出物の所に未返信の数を表示するようにした

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -39,9 +39,9 @@ nav.global-nav
             = link_to products_unchecked_index_path, class: "global-nav-links__link #{current_link /^products/ }" do
               .global-nav-links__link-icon
                 i.fas.fa-hand-paper
-              - if current_user.admin? && Product.unchecked.exists?
+              - if current_user.admin? && Product.not_responded_products.count > 0
                 .global-nav__item-count.a-notification-count
-                  = Product.unchecked.count
+                  = Product.not_responded_products.count
               .global-nav-links__link-label 提出物
         li.global-nav-links__item
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do


### PR DESCRIPTION
## 概要
管理者画面の左メニューの提出物の所に未返信の数を表示するように変更しました。

## 変更後の画面
![image](https://user-images.githubusercontent.com/53965479/83653716-153c4d00-a5f7-11ea-9e09-efcf8b1bfe67.png)


## 関連Issue
#1612 