### PR TITLE
コメントの日時のlinkのクリック時、is-activeというclassが付いて、4秒後にそのclassが消えて欲しい

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -12,7 +12,7 @@
         h2.thread-comment__title
           a.thread-comment__title-link(:href="answer.user.url" itempro="url")
             | {{ answer.user.login_name }}
-        time.thread-comment__created-at(:datetime="answerCreatedAt" pubdate="pubdate" @click="copyAnswerURLToClipboard(answer.id)")
+        time.thread-comment__created-at(:class="{'is-active': activating}" :datetime="answerCreatedAt" pubdate="pubdate" @click="copyAnswerURLToClipboard(answer.id)")
           | {{ updatedAt }}
       .thread-comment__description.js-target-blank.is-long-text(v-html="markdownDescription")
       reaction(
@@ -84,6 +84,7 @@ export default {
       isCopied: false,
       tab: "answer",
       question: [],
+      activating: false
     };
   },
   created: function() {
@@ -179,6 +180,8 @@ export default {
       textBox.select();
       document.execCommand("copy");
       document.body.removeChild(textBox);
+      this.activating = true;
+      setTimeout(() => {this.activating = false}, 4000);
     }
   },
   computed: {

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -157,7 +157,7 @@ export default {
       document.execCommand('copy');
       document.body.removeChild(textBox);
       this.activating = true;
-      setTimeout(() => {this.activating = false, 4000});
+      setTimeout(() => {this.activating = false}, 4000);
     }
   },
   computed: {

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -8,7 +8,7 @@
         h2.thread-comment__title
           a.thread-comment__title-link(:href="comment.user.url" itempro="url")
             | {{ comment.user.login_name }}
-        time.thread-comment__created-at(:datetime="commentableCreatedAt" pubdate="pubdate" @click="copyCommentURLToClipboard(comment.id)")
+        time.thread-comment__created-at(:class="{'is-active': activating}" :datetime="commentableCreatedAt" pubdate="pubdate" @click="copyCommentURLToClipboard(comment.id)")
           | {{ updatedAt }}
       .thread-comment__description.js-target-blank.is-long-text(v-html="markdownDescription")
       reaction(
@@ -72,6 +72,7 @@ export default {
       editing: false,
       isCopied: false,
       tab: 'comment',
+      activating: false
     }
   },
   created: function() {
@@ -155,6 +156,8 @@ export default {
       textBox.select();
       document.execCommand('copy');
       document.body.removeChild(textBox);
+      this.activating = true;
+      setTimeout(() => {this.activating = false, 4000});
     }
   },
   computed: {

--- a/app/models/github_grass.rb
+++ b/app/models/github_grass.rb
@@ -18,7 +18,7 @@ class GithubGrass
 
   def fetch
     localize(extract_svg(fetch_page)).to_s
-  rescue
+  rescue OpenURI::HTTPError
     ""
   end
 

--- a/app/models/github_grass.rb
+++ b/app/models/github_grass.rb
@@ -18,7 +18,7 @@ class GithubGrass
 
   def fetch
     localize(extract_svg(fetch_page)).to_s
-  rescue OpenURI::HTTPError
+  rescue
     ""
   end
 


### PR DESCRIPTION
#1502

以下のように、現在はコメントの日時のlinkのクリック時、is-activeというclassが付いて、すぐにそのclassが消えます。
[![Screenshot from Gyazo](https://gyazo.com/510541fcba0cea26e23cb40e1bf9a054/raw)](https://gyazo.com/510541fcba0cea26e23cb40e1bf9a054)

なのでクリック後すぐにis-activeのclassが消えるのではなく4秒待ってから消えるようにします。