### PR TITLE
GitHubのエラーを抑制

### DIFF
--- a/app/models/github_grass.rb
+++ b/app/models/github_grass.rb
@@ -18,7 +18,7 @@ class GithubGrass
 
   def fetch
     localize(extract_svg(fetch_page)).to_s
-  rescue OpenURI::HTTPError
+  rescue
     ""
   end
 


### PR DESCRIPTION
InvalidURLのエラーを補足できていなかったため。

Ref: #1669