### PR TITLE
Rakeタスク名・モデル名を変更

### DIFF
--- a/app/models/link_checker.rb
+++ b/app/models/link_checker.rb
@@ -3,7 +3,7 @@
 require "uri"
 require "net/http"
 
-class CheckUrl
+class LinkChecker
   def notify_error_url
     error_url_on_page = check_url(page_contents)
     error_url_on_practice = check_url(practice_contents)

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -3,6 +3,11 @@
 require "#{Rails.root}/config/environment"
 
 namespace :bootcamp do
+  desc "Find broken links in practices, pages."
+  task :find_broken_link do
+    LinkChecker.new.notify_error_url
+  end
+
   namespace :oneshot do
     desc "Resize works."
     task :resize_all_works do

--- a/lib/tasks/check_url.rake
+++ b/lib/tasks/check_url.rake
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-task :check_url do
-  CheckUrl.new.notify_error_url
-end


### PR DESCRIPTION
Rakeタスク名を既存のルールに合わせて変更。
モデル名を名刺系に変更。