### PR TITLE
ユーザー別の分報ページを作成

### DIFF
--- a/app/channels/timelines_channel.rb
+++ b/app/channels/timelines_channel.rb
@@ -19,8 +19,10 @@ class TimelinesChannel < ApplicationCable::Channel
     @timeline.user_id = current_user.id
     if @timeline.save
       broadcast_to_timelines_channel("create_timeline", @timeline)
+      broadcast_to_user_timelines_channel("create_timeline", @timeline)
     else
       broadcast_to_timelines_channel("failed_to_create_timeline", nil)
+      broadcast_to_user_timelines_channel("failed_to_create_timeline", nil)
     end
   end
 
@@ -29,8 +31,10 @@ class TimelinesChannel < ApplicationCable::Channel
     @timeline = Timeline.find_by(id: data["id"])
     if @timeline.update(permitted(data))
       broadcast_to_timelines_channel("update_timeline", @timeline)
+      broadcast_to_user_timelines_channel("update_timeline", @timeline)
     else
       broadcast_to_timelines_channel("failed_to_update_timeline", nil)
+      broadcast_to_user_timelines_channel("failed_to_update_timeline", nil)
     end
   end
 
@@ -39,8 +43,10 @@ class TimelinesChannel < ApplicationCable::Channel
     @timeline = Timeline.find_by(id: data["id"])
     if @timeline.destroy
       broadcast_to_timelines_channel("delete_timeline", @timeline)
+      broadcast_to_user_timelines_channel("delete_timeline", @timeline)
     else
       broadcast_to_timelines_channel("failed_to_delete_timeline", nil)
+      broadcast_to_user_timelines_channel("failed_to_delete_timeline", nil)
     end
   end
 
@@ -53,6 +59,10 @@ class TimelinesChannel < ApplicationCable::Channel
 
     def broadcast_to_timelines_channel(event, timeline)
       ActionCable.server.broadcast "timelines_channel", { event: event, timeline: decorated(timeline).format_to_channel }
+    end
+
+    def broadcast_to_user_timelines_channel(event, timeline)
+      ActionCable.server.broadcast "user_#{current_user.id}_timelines_channel", { event: event, timeline: decorated(timeline).format_to_channel }
     end
 
     def decorated(obj)

--- a/app/channels/users/timelines_channel.rb
+++ b/app/channels/users/timelines_channel.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Users::TimelinesChannel < TimelinesChannel
+  def subscribed
+    stream_from "user_#{params[:user_id]}_timelines_channel"
+    if !subscription_rejected?
+      transmit({ event: "subscribe", current_user: decorated(current_user).format_to_channel, timelines: formatted_timelines })
+    else
+      transmit({ event: "failed_to_subscribe" })
+    end
+  end
+
+  private
+    def formatted_timelines
+      Timeline.where(user_id: params[:user_id]).order(created_at: :asc).map { |timeline| decorated(timeline).format_to_channel }
+    end
+end

--- a/app/controllers/users/timelines_controller.rb
+++ b/app/controllers/users/timelines_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Users::TimelinesController < ApplicationController
+  before_action :require_login
+  before_action :set_user
+
+  def index
+  end
+
+  private
+    def set_user
+      @user = User.find(params[:user_id])
+    end
+end

--- a/app/javascript/channels/timelines-channel.vue
+++ b/app/javascript/channels/timelines-channel.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   .thread-timeline-container
-    .thread-timeline-form.a-card
+    .thread-timeline-form.a-card(v-show="currentUrl === '/timelines' || userId === currentUser.id")
       .thread-timeline__author
         img.thread-timeline__author-icon.a-user-icon(:src="currentUser.avatar_url" :title="currentUser.icon_title")
       .thread-timeline-form__form.a-card
@@ -37,7 +37,7 @@
       }
     },
     created () {
-      this.timelinesChannel = this.$cable.subscriptions.create("TimelinesChannel", {
+      this.timelinesChannel = this.$cable.subscriptions.create({channel: this.selectChannel(), user_id: this.userId}, {
         connected: () => {
           console.log('connected successfully');
         },
@@ -100,11 +100,24 @@
       },
       deleteTimeline: function (data) {
         this.timelinesChannel.perform('delete_timeline', data);
+      },
+      selectChannel: function () {
+        if (location.pathname === '/timelines') {
+          return 'TimelinesChannel'
+        } else {
+          return 'Users::TimelinesChannel'
+        }
       }
     },
     computed: {
       validation: function () {
         return this.description.length > 0
+      },
+      currentUrl: function () {
+        return location.pathname
+      },
+      userId: function () {
+        return parseInt(location.pathname.match(/[0-9]+/))
       }
     }
   }

--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -17,3 +17,6 @@
       li.page-tabs__item
         = link_to user_products_path(user), class: "page-tabs__item-link #{current_page_tab_or_not("products")}" do
           | 提出物
+      li.page-tabs__item
+        = link_to user_timelines_path(user), class: "page-tabs__item-link #{current_page_tab_or_not("timelines")}" do
+          | 分報

--- a/app/views/users/timelines/index.html.slim
+++ b/app/views/users/timelines/index.html.slim
@@ -1,0 +1,17 @@
+- title "#{@user.login_name}のタイムライン"
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to "ユーザー一覧", users_path, class: "a-button is-md is-secondary is-block"
+
+.page-tools
+  = render "users/page_tabs", user: @user
+
+.page-body
+  .container
+    #js-timelines

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     resources :reports, only: %i(index), controller: "users/reports"
     resources :comments, only: %i(index), controller: "users/comments"
     resources :products, only: %i(index), controller: "users/products"
+    resources :timelines, only: %i(index), controller: "users/timelines"
     get "portfolio" => "users/works#index", as: :portfolio
     patch "graduation", to: "graduation#update", as: :graduation
   end

--- a/test/channels/users/timelines_channel_test.rb
+++ b/test/channels/users/timelines_channel_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TimelinesChannelTest < ActionCable::Channel::TestCase
+class Users::TimelinesChannelTest < ActionCable::Channel::TestCase
   def setup
     @user = users(:hajime)
     @timeline = timelines(:timeline_1)
@@ -10,39 +10,39 @@ class TimelinesChannelTest < ActionCable::Channel::TestCase
   end
 
   test "transmit timelines when subscribed" do
-    subscribe channel: "timelines_channel"
+    subscribe channel: "user_#{@user.id}_timelines_channel"
 
     assert subscription.confirmed?
     assert_equal "subscribe", transmissions.last["event"]
   end
 
   test "#create_timeline" do
-    subscribe channel: "timelines_channel"
+    subscribe channel: "user_#{@user.id}_timelines_channel", user_id: @user.id
 
-    assert_broadcasts("timelines_channel", 1) do
+    assert_broadcasts("user_#{@user.id}_timelines_channel", 1) do
       perform :create_timeline,  { timeline: { description: "今は勉強中です" } }
     end
 
-    assert_broadcasts("user_#{@user.id}_timelines_channel", 1)
+    assert_broadcasts("timelines_channel", 1)
   end
 
   test "#update_timeline" do
-    subscribe channel: "timelines_channel"
+    subscribe channel: "user_#{@user.id}_timelines_channel", user_id: @user.id
 
-    assert_broadcasts("timelines_channel", 1) do
+    assert_broadcasts("user_#{@user.id}_timelines_channel", 1) do
       perform :update_timeline, { id: @timeline.id,  timeline: { description: "今はミーティング中です" } }
     end
 
-    assert_broadcasts("user_#{@user.id}_timelines_channel", 1)
+    assert_broadcasts("timelines_channel", 1)
   end
 
   test "#delete_timeline" do
-    subscribe channel: "timelines_channel"
+    subscribe channel: "user_#{@user.id}_timelines_channel", user_id: @user.id
 
-    assert_broadcasts("timelines_channel", 1) do
+    assert_broadcasts("user_#{@user.id}_timelines_channel", 1) do
       perform :delete_timeline,  { id: @timeline.id }
     end
 
-    assert_broadcasts("user_#{@user.id}_timelines_channel", 1)
+    assert_broadcasts("timelines_channel", 1)
   end
 end

--- a/test/system/user/timelines_test.rb
+++ b/test/system/user/timelines_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class User::TimelinesTest < ApplicationSystemTestCase
+  setup { login_user "kimura", "testtest" }
+
+  test "can see the past timelines when visit the user timelines page" do
+    visit "/users/#{users(:hajime).id}/timelines"
+    assert_text "今は勉強中です"
+  end
+
+  test "if post a timeline to timelines page, it will be posted to user timelines page" do
+    visit "/users/#{users(:hajime).id}/timelines"
+
+    Capybara.session_name = :new_window
+    login_user "hajime", "testtest"
+    visit "/timelines"
+
+    fill_in("new_timeline[description]", with: "初めての分報投稿です")
+    click_button "投稿する"
+
+    Capybara.session_name = :default
+
+    assert_text "初めての分報投稿です"
+  end
+
+  test "if post a timeline to user timelines page, it will be posted to timelines page" do
+    visit "/timelines"
+
+    Capybara.session_name = :new_window
+    login_user "hajime", "testtest"
+    visit "/users/#{users(:hajime).id}/timelines"
+
+    fill_in("new_timeline[description]", with: "初めての分報投稿です")
+    click_button "投稿する"
+
+    Capybara.session_name = :default
+
+    assert_text "初めての分報投稿です"
+  end
+
+  test "if edit the timeline on timelines page, it will also be edited on user timelines page" do
+    visit "/users/#{users(:hajime).id}/timelines"
+    assert_text "今は勉強中です"
+
+    Capybara.session_name = :new_window
+    login_user "hajime", "testtest"
+    visit "/timelines"
+
+    within(".thread-timeline:first-child") do
+      click_button "編集"
+      within(:css, ".thread-timeline-form__form") do
+        fill_in("timeline[description]", with: "勉強中でしたが、休憩します")
+      end
+      click_button "保存する"
+    end
+
+    Capybara.session_name = :default
+    assert_text "勉強中でしたが、休憩します"
+  end
+
+  test "if edit the timeline on user timelines page, it will also be edited on timelines page" do
+    visit "/timelines"
+    assert_text "今は勉強中です"
+
+    Capybara.session_name = :new_window
+    login_user "hajime", "testtest"
+    visit "/users/#{users(:hajime).id}/timelines"
+
+    within(".thread-timeline:first-child") do
+      click_button "編集"
+      within(:css, ".thread-timeline-form__form") do
+        fill_in("timeline[description]", with: "勉強中でしたが、休憩します")
+      end
+      click_button "保存する"
+    end
+
+    Capybara.session_name = :default
+    assert_text "勉強中でしたが、休憩します"
+  end
+
+  test "if delete the timeline on timelines page, it will also be deleted on user timelines page" do
+    visit "/users/#{users(:hajime).id}/timelines"
+    assert_text "今は勉強中です"
+
+    Capybara.session_name = :new_window
+    login_user "hajime", "testtest"
+    visit "/timelines"
+
+    within(".thread-timeline:first-child") do
+      accept_alert do
+        click_button("削除")
+      end
+    end
+
+    Capybara.session_name = :default
+    assert_no_text "今は勉強中です"
+  end
+
+  test "if delete the timeline on user timelines page, it will also be deleted on timelines page" do
+    visit "/timelines"
+    assert_text "今は勉強中です"
+
+    Capybara.session_name = :new_window
+    login_user "hajime", "testtest"
+    visit "/users/#{users(:hajime).id}/timelines"
+
+    within(".thread-timeline:first-child") do
+      accept_alert do
+        click_button("削除")
+      end
+    end
+
+    Capybara.session_name = :default
+    assert_no_text "今は勉強中です"
+  end
+
+  test "other user cannot edit and destroy timeline on user timelines page" do
+    visit "/users/#{users(:hajime).id}/timelines"
+    assert_no_selector "button", text: "編集"
+    assert_no_selector "button", text: "削除"
+  end
+
+  test "other user cannot see timeline form on user timelines page" do
+    visit "/users/#{users(:hajime).id}/timelines"
+    assert_no_selector "thread-timeline-form"
+  end
+
+  test "it won't be posted to other users timeline page." do
+    visit "/users/#{users(:kimura).id}/timelines"
+    assert_no_text "hajimeです"
+
+    Capybara.session_name = :new_window
+    login_user "hajime", "testtest"
+    visit "/timelines"
+
+    fill_in("new_timeline[description]", with: "hajimeです")
+    click_button "投稿する"
+
+    Capybara.session_name = :default
+
+    assert_no_text "hajimeです"
+  end
+end


### PR DESCRIPTION
Ref: #1639

## 概要
- ユーザー別の分報ページを作成しました
- みんなのタイムラインに投稿をすると、その投稿したユーザーのタイムラインにも投稿が流れるようにしました
- ユーザーのタイムラインで投稿をすると、みんなのタイムラインにそのユーザーの投稿が流れるようにしました

## キャプチャ
### みんなのタイムラインに投稿すると、そのユーザーのタイムラインに投稿が流れる(左:kimura, 右:hajime)
![](http://g.recordit.co/e8cL5cYirQ.gif)
### ユーザーのタイムラインに投稿すると、みんなのタイムラインに投稿が流れる(左:kimura, 右:hajime)
![](http://g.recordit.co/4JS0WAEpTW.gif)
### みんなのタイムラインで投稿を編集・削除すると、そのユーザーのタイムラインの投稿も編集・削除される(左:kimura, 右:hajime)
![](http://g.recordit.co/z2zmtNsYGO.gif)
### ユーザーのタイムラインで投稿を編集・削除すると、みんなのタイムラインの投稿も編集・削除される(左:kimura, 右:hajime)
![](http://g.recordit.co/zjWy6LVBbf.gif)
### みんなのタイムラインに投稿をしても他のユーザーのタイムラインには投稿が流れることはない(左:kimura, 右:hajime)
![](http://g.recordit.co/itLSwdrJjQ.gif)
### ユーザーのタイムラインに投稿をしても他のユーザーのタイムラインには投稿が流れることはない(左:kimura, 右:hajime)
![](http://g.recordit.co/oVn0NVCg93.gif)