### PR TITLE
通知の権限所持user画像にborder追加

### DIFF
--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,7 +1,7 @@
 .thread-list-item(class="#{notification.read? ? "is-read" : "is-unread"}")
   .thread-list-item__inner
     .thread-list-item__author
-      = image_tag notification.sender.avatar_url, title: "#{notification.sender.icon_title}", class: "thread-list-item__author-icon a-user-icon"
+      = image_tag notification.sender.avatar_url, title: "#{notification.sender.icon_title}", class: "thread-list-item__author-icon a-user-icon is-#{notification.sender.role}"
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - unless notification.read?


### PR DESCRIPTION
* URL `/notifications`の画面で、権限所持しているuserの画像にborderが付いていないのを、付くように修正。

![image](https://user-images.githubusercontent.com/39234092/86546196-7cd71680-bf6e-11ea-861c-a6d3270d06c0.png)
