### PR TITLE
コメントをした後にテキストエリアのサイズがリセットされるようにした

### DIFF
--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -53,7 +53,8 @@ export default {
       tab: "answer",
       buttonDisabled: false,
       question: { correctAnswer: null },
-      questionUser: {}
+      questionUser: {},
+      defaultTextareaSize: null
     };
   },
   created: function() {
@@ -117,6 +118,7 @@ export default {
   },
   mounted: function() {
     $("textarea").textareaAutoSize();
+    this.setDefaultTextareaSize()
   },
   methods: {
     token() {
@@ -157,6 +159,7 @@ export default {
           this.description = "";
           this.tab = "answer";
           this.buttonDisabled = false;
+          this.resizeTextarea()
         })
         .catch(error => {
           console.warn("Failed to parsing", error);
@@ -237,6 +240,14 @@ export default {
         .catch(error => {
           console.warn("Failed to parsing", error);
         });
+    },
+    setDefaultTextareaSize: function () {
+      const textarea = document.getElementById('js-new-comment')
+      this.defaultTextareaSize = textarea.scrollHeight
+    },
+    resizeTextarea: function () {
+      const textarea = document.getElementById('js-new-comment')
+      textarea.style.height = `${this.defaultTextareaSize}px`
     }
   },
   computed: {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -46,7 +46,8 @@ export default {
       comments: [],
       description: '',
       tab: 'comment',
-      buttonDisabled: false
+      buttonDisabled: false,
+      defaultTextareaSize: null
     }
   },
   created: function() {
@@ -90,6 +91,7 @@ export default {
   },
   mounted: function() {
     $("textarea").textareaAutoSize();
+    this.setDefaultTextareaSize()
   },
   methods: {
     token () {
@@ -129,6 +131,7 @@ export default {
           this.description = '';
           this.tab = 'comment';
           this.buttonDisabled = false
+          this.resizeTextarea()
         })
         .catch(error => {
           console.warn('Failed to parsing', error)
@@ -152,6 +155,14 @@ export default {
         .catch(error => {
           console.warn('Failed to parsing', error)
         })
+    },
+    setDefaultTextareaSize: function () {
+      const textarea = document.getElementById('js-new-comment')
+      this.defaultTextareaSize = textarea.scrollHeight
+    },
+    resizeTextarea: function () {
+      const textarea = document.getElementById('js-new-comment')
+      textarea.style.height = `${this.defaultTextareaSize}px`
     }
   },
   computed: {


### PR DESCRIPTION
Ref: #1680

## 概要
- コメントをした後にテキストエリアのサイズがリセットされるようにしました

## キャプチャ

### コメント
![](http://g.recordit.co/rPAZWtNIPb.gif)

### Q&A
![](http://g.recordit.co/c7S9cRfv6v.gif)