### PR TITLE
卒業生のユーザー個別ページはニコニコカレンダーを非表示にした

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -47,7 +47,7 @@ header.page-header
           = render "users/github_grass", user: @user
           - if @user.active_practices.present?
             = render "/users/practices/active_practices", user: @user
-          - if @user.student?
+          - if @user.student? && @user.graduated_on.blank?
             = render "/users/niconico_calendar", user: @user
           - if @user.completed_practices.present?
             = render "/users/practices/completed_practices", user: @user, completed_learnings: @completed_learnings


### PR DESCRIPTION
issue: #1627 卒業生のダッシュボード、その卒業生のユーザー個別ページにはニコニコカレンダーを非表示にしたい。
卒業生のユーザー個別ページにはニコニコカレンダーを非表示にしました。（ダッシュボードはもともとニコニコカレンダーは無いため対応不要なことを町田さんに確認済みです。）
レビューをお願いいたします。