### PR TITLE
席予約ページの予約したユーザー名をクリックするとユーザーのプロフィールページに移動する

### DIFF
--- a/app/assets/stylesheets/blocks/form/_reservations.sass
+++ b/app/assets/stylesheets/blocks/form/_reservations.sass
@@ -75,7 +75,6 @@
     box-shadow: inset rgba($primary, .5) 0 0 0 1px
   &.is-reserved.is-not-me
     background-color: rgba(black, .05)
-    pointer-events: none
   &.is-reserved.is-me
     background-color: $danger
     color: $reversal-text

--- a/app/javascript/reservation.vue
+++ b/app/javascript/reservation.vue
@@ -4,7 +4,7 @@
       #cancel-reservation.reservations__seat-action.is-reserved.is-me(@click="deleteReservation")
         | {{ this.label }}
     template(v-else)
-      #cancel-reservation.reservations__seat-action.is-reserved.is-not-me
+      #cancel-reservation.reservations__seat-action.is-reserved.is-not-me(@click="linkToUser")
         | {{ this.label }}
 </template>
 <script>
@@ -15,6 +15,9 @@ export default {
       if (confirm('予約を削除しますか？')) {
         this.$emit('delete', this.id);
       }
+    },
+    linkToUser: function() {
+      location.href=`/users/${this.parentReservation.user_id}`
     }
   },
   computed: {


### PR DESCRIPTION
席予約のページで予約しているユーザーの名前をクリックするとユーザーのプロフィールページに移動するように変更しました。
名前が入っていないマスと自分の名前が入っているマスについては今までと変更ありません。空白マスのクリックで予約、自分の名前をクリックすると予約解除ができます。
レビューをお願いします。

<img src="http://g.recordit.co/MvyGHmVtdq.gif" width="500" height="300" /> 
