### PR TITLE
通知一覧の表示日時が閲覧日時となるバグを修正

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -14,7 +14,7 @@ class NotificationsController < ApplicationController
   def show
     path = @notification.read_attribute :path
     @notifications = current_user.notifications.where(path: path)
-    @notifications.update_all(read: true, updated_at: Time.current)
+    @notifications.update_all(read: true)
     redirect_to path
   end
 

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -12,5 +12,5 @@
             span.thread-list-item__title-link-label
               = notification.message
     .thread-list-item-meta
-      time.thread-list-item-meta__updated-at(datetime="#{notification.updated_at.to_datetime}" pubdate="pubdate")
-        = l notification.updated_at
+      time.thread-list-item-meta__created-at(datetime="#{notification.created_at.to_datetime}" pubdate="pubdate")
+        = l notification.created_at


### PR DESCRIPTION
## 概要
#1434 通知一覧の表示日時は「通知された日時」を保持してほしい の対応をしました。

## バグの要因
通知の内容を表示するたびに更新日時が現在の時刻に上書きされていました。
``` ruby
  def show
    # ~省略~
    @notifications.update_all(read: true, updated_at: Time.current)
    redirect_to path
  end
```

## 対応内容
通知の内容を表示するときに更新日時を変更しないように修正しました。
``` ruby
  def show
    # ~省略~
    @notifications.update_all(read: true)
    redirect_to path
  end
```

## 動作確認
テストは全てパス済みです。
通知の内容を見た後に表示日時が変更されないことを確認しました。

### 修正前の場合
![修正前](https://user-images.githubusercontent.com/60720255/87840009-6c149200-c8d8-11ea-94c6-7b6bcc11877f.png)

通知内容を確認
![コメント日](https://user-images.githubusercontent.com/60720255/87840052-a4b46b80-c8d8-11ea-8719-3755417ded7c.png)

通知に戻ると通知の日時が変更される
![日時変更](https://user-images.githubusercontent.com/60720255/87840089-cada0b80-c8d8-11ea-887c-18f419eb5e6a.png)

### 修正後
![表示前_修正版](https://user-images.githubusercontent.com/60720255/87840161-1e4c5980-c8d9-11ea-83f7-33a5d136503c.png)

通知内容を確認
![コメント日_修正版](https://user-images.githubusercontent.com/60720255/87840173-34f2b080-c8d9-11ea-99de-b75c22c56fbc.png)

通知に戻っても通知の日時は変更されない
![修正版](https://user-images.githubusercontent.com/60720255/87840211-69666c80-c8d9-11ea-814e-37db6370c8a4.png)