### PR TITLE
wrapperのスクロールを無しにし、htmlのスクロールにした

### DIFF
--- a/app/assets/stylesheets/initializers/_reset.sass
+++ b/app/assets/stylesheets/initializers/_reset.sass
@@ -4,7 +4,7 @@
   line-height: inherit
 
 html
-  overflow-y: auto
+  //overflow-y: auto
   line-height: 1
 
 #{$all-text-inputs},

--- a/app/assets/stylesheets/shared/_base.sass
+++ b/app/assets/stylesheets/shared/_base.sass
@@ -23,7 +23,7 @@ body
 
 .wrapper
   +margin(horizontal, 5rem 14rem)
-  overflow-y: scroll
+  //overflow-y: scroll
   height: 100vh
   scroll-behavior: smooth
   -webkit-overflow-scrolling: touch


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/issues/1716 の対応。
Chrome 84 で再現。