### PR TITLE
メンションの通知がある場合はWatchの通知を送らないようにした

### DIFF
--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -23,11 +23,12 @@ class CommentCallbacks
 
     def notify_to_watching_user(comment)
       watchable = comment.commentable
+      mention_user_ids = comment.new_mention_users.ids
 
       if watchable.try(:watched?)
         watcher_ids = watchable.watches.pluck(:user_id)
         watcher_ids.each do |watcher_id|
-          if watcher_id != comment.sender.id
+          if watcher_id != comment.sender.id && !mention_user_ids.include?(watcher_id)
             watcher = User.find_by(id: watcher_id)
             NotificationFacade.watching_notification(watchable, watcher, comment)
           end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -2,12 +2,16 @@
 
 module Mentioner
   def after_save_mention(mentions)
-    mentions.map { |s| s.gsub(/@/, "") }.each do |mention|
-      receiver = User.find_by(login_name: mention)
+    new_mention_users.each do |receiver|
       if receiver && sender != receiver
         NotificationFacade.mentioned(self, receiver)
       end
     end
+  end
+
+  def new_mention_users
+    names = new_mentions.map { |s| s.gsub(/@/, "") }
+    User.where(login_name: names)
   end
 
   def body

--- a/test/system/notification/same_notifications_test.rb
+++ b/test/system/notification/same_notifications_test.rb
@@ -55,7 +55,7 @@ class NotificationsTest < ApplicationSystemTestCase
     find(".test-show-menu").click
     click_link "ログアウト"
     login_user "komagata", "testtest"
-    assert_equal 6, @admin.notifications.size # メンション通知, ウォッチ通知
+    assert_equal 5, @admin.notifications.size # メンション通知, ウォッチ通知
     # 通知ベルの右上に出る件数の表示
     assert_text 1, first("li.has-count .header-notification-count").text
     find(".test-show-menu").click
@@ -70,7 +70,7 @@ class NotificationsTest < ApplicationSystemTestCase
     find(".test-show-menu").click
     click_link "ログアウト"
     login_user "komagata", "testtest"
-    assert_equal 7, @admin.notifications.size # 回答通知, メンション通知, ウォッチ通知
+    assert_equal 6, @admin.notifications.size # 回答通知, メンション通知, ウォッチ通知
     # 通知ベルの右上に出る件数の表示
     assert_text 2, first("li.has-count .header-notification-count").text # 回答通知, ウォッチ通知
   end


### PR DESCRIPTION
ほぼ同じ内容の通知が2個くることになるため

Fixed: #1364