### PR TITLE
書籍一覧に貸出中の書籍一覧を表示

### DIFF
--- a/app/controllers/books/borrowed_controller.rb
+++ b/app/controllers/books/borrowed_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Books::BorrowedController < ApplicationController
+  def index
+    @books = Book.borrowed.order(:title).page(params[:page])
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -9,6 +9,8 @@ class Book < ApplicationRecord
   validates :borrowed, inclusion: { in: [true, false] }
   paginates_per 20
 
+  scope :borrowed, -> { where(borrowed: true) }
+
   def self.search(word)
     Book.ransack(title_cont: word).result
   end

--- a/app/views/books/_tabs.html.slim
+++ b/app/views/books/_tabs.html.slim
@@ -1,0 +1,8 @@
+.page-tabs
+  .container
+    ul.page-tabs__items
+      li.page-tabs__item
+        = link_to "全ての書籍", books_path, class: "page-tabs__item-link #{current_link /^books-index/}"
+      li.page-tabs__item
+        = link_to borrowed_index_path, class: "page-tabs__item-link #{current_link /^books-borrowed-index/}" do
+          | 貸出中

--- a/app/views/books/borrowed/index.html.slim
+++ b/app/views/books/borrowed/index.html.slim
@@ -1,4 +1,4 @@
-- title "書籍一覧"
+- title "貸出中の書籍一覧"
 
 header.page-header
   .container
@@ -13,11 +13,7 @@ header.page-header
 = render "books/tabs"
 
 .page-body
-  .page-body__description
-    .container.is-md
-      p
-        | フィヨルドオフィスにて以下の書籍を借りることができます。
   .container.is-padding-horizontal-0-sm-down
     = paginate @books, position: "top"
-    = render "table", books: @books
+    = render "books/table", books: @books
     = paginate @books, position: "bottom"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
   resources :books, only: %i(index show) do
     resources :borrowings, only: %i(create destroy)
     collection do
+      resources :borrowed, only: %i(index), controller: "books/borrowed", path: :borrowed
       resources :search_results, only: %i(index), controller: "books/search_results"
     end
   end

--- a/test/system/book/borrowed_test.rb
+++ b/test/system/book/borrowed_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class Book::BorrwedTest < ApplicationSystemTestCase
+  setup { login_user "hatsuo", "testtest" }
+
+  test "show listing borrowed books" do
+    visit "/books/borrowed"
+    assert_equal "貸出中の書籍一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+  end
+end


### PR DESCRIPTION

# 概要

書籍一覧画面に```全ての書籍```と```貸出中```とタブを表示する。
貸出中のタブ画面では、貸出中の書籍のみを一覧表示する。

## Issue番号
#1714 

