### PR TITLE
Q&Aの解決したQには解決済スタンプを表示したい

### DIFF
--- a/app/assets/stylesheets/blocks/report/_stamp.sass
+++ b/app/assets/stylesheets/blocks/report/_stamp.sass
@@ -9,6 +9,16 @@
   letter-spacing: 0
   +media-breakpoint-down(sm)
     +position(absolute, left 80%, top 0)
+  &.is-circle
+    +size(3.5rem)
+    border-radius: 50%
+  &.is-solved
+    display: flex
+    flex-direction: column
+    font-size: 1.5rem
+    font-weight: 800
+    font-family: serif
+    justify-content: center
 
 .stamp__content
   display: flex

--- a/app/assets/stylesheets/blocks/thread/_thread-header.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-header.sass
@@ -60,9 +60,14 @@
   +position(relative, top -2px)
   border-radius: .75rem
   vertical-align: middle
-  height: 1rem
-  +media-breakpoint-down(sm)
-    height: 1rem
+  height: 1.125rem
+  &.is-solved
+    color: $reversal-text
+    padding: 0 .625rem
+    &.is-success
+      background-color: $success
+    &.is-danger
+      background-color: $danger
 
 .thread-header__upper-side
   +text-block(.8125rem 1 0 .75rem, $muted-text flex)

--- a/app/assets/stylesheets/variables/_colors.sass
+++ b/app/assets/stylesheets/variables/_colors.sass
@@ -36,14 +36,14 @@ $badge-color: #e54724
 
 $primary: #229bcc
 $secondary: $base
-$success: #4cbb27
+$success: #54a739
 $info: #4cad7c
 $warning: #fabd17
 $danger: #f32c5d
 $disabled: #c7c6c6
 
-$success-text: shade(#4cbb27, 60%)
-$success-shade: tint(#4cbb27, 90%)
+$success-text: shade($success, 60%)
+$success-shade: tint($success, 90%)
 
 $input-border: #c1c5b9
 

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -26,3 +26,7 @@
             i.fas.fa-comment
           .thread-list-item-meta__comment-count-value
             = question.answers.size
+    - if question.correct_answer.present?
+      .stamp.is-circle.is-solved
+        .stamp__content.is-icon 解
+        .stamp__content.is-icon 決

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -19,8 +19,6 @@ header.page-header
     .thread
       .thread__inner.a-card
         header.thread-header
-        - if @question.correct_answer.present?
-          | 解決済み
           .thread-header__upper-side
             = link_to @question.user, class: "thread-header__author" do
               = @question.user.login_name
@@ -28,6 +26,12 @@ header.page-header
               time.thread-header__date-value(datetime="#{@question.updated_at.to_datetime}" pubdate="pubdate")
                 = l @question.updated_at
           h1.thread-header__title
+            - if @question.correct_answer.present?
+              span.thread-header__title-icon.is-solved.is-success
+                | 解決済
+            - else
+              span.thread-header__title-icon.is-solved.is-danger
+                | 未解決
             = @question.title
           .thread-header__lower-side
             #js-watch(data-watchable-id="#{@question.id}", data-watchable-type="Question")

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -19,6 +19,8 @@ header.page-header
     .thread
       .thread__inner.a-card
         header.thread-header
+        - if @question.correct_answer.present?
+          | 解決済み
           .thread-header__upper-side
             = link_to @question.user, class: "thread-header__author" do
               = @question.user.login_name

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -17,6 +17,12 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_equal "解決済みの質問一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
+  test "show a resolved qestion" do
+    question = questions(:question_3)
+    visit question_path(question)
+    assert_text "解決済み"
+  end
+
   test "show a question" do
     question = questions(:question_8)
     visit question_path(question)

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -20,7 +20,7 @@ class QuestionsTest < ApplicationSystemTestCase
   test "show a resolved qestion" do
     question = questions(:question_3)
     visit question_path(question)
-    assert_text "解決済み"
+    assert_text "解決済"
   end
 
   test "show a question" do


### PR DESCRIPTION
#1574 
## 概要
解決済みの質問に日報や課題と同じように```解決済み```とスタンプを表示する

![image](https://user-images.githubusercontent.com/58872020/88446859-8adecf80-ce68-11ea-8f47-2d04112aa5e0.png)
