### PR TITLE
Googleカレンダーへのリンクを作成

### DIFF
--- a/app/assets/stylesheets/blocks/event/_event-meta.sass
+++ b/app/assets/stylesheets/blocks/event/_event-meta.sass
@@ -18,6 +18,7 @@
   line-height: 1.5
   +media-breakpoint-up(md)
     display: flex
+    align-items: center
   &:not(:first-child)
     margin-top: .5em
     padding-top: .5em
@@ -36,3 +37,13 @@
 
 .event-meta__item-value
   flex: 100
+  +media-breakpoint-up(md)
+    display: flex
+    align-items: center
+
+.event-meta__item-value-main
+  display: block
+  +media-breakpoint-up(md)
+    margin-right: .5rem
+  +media-breakpoint-down(sm)
+    margin-bottom: .25rem

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module EventsHelper
-  def google_calendar_link(event)
+  def google_calendar_url(event)
     event_query_string=
     {
       :action => "TEMPLATE", 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -2,6 +2,13 @@
 
 module EventsHelper
   def google_calendar_link(event)
-    "http://www.google.com/calendar/render?action=TEMPLATE&text=#{event.title}&dates=#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}&details=https://bootcamp.fjord.jp/events/#{event.id}"
+    event_hash =
+    {
+      :action => "TEMPLATE", 
+      :text => event.title, 
+      :dates => "#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}", 
+      :details => "https://bootcamp.fjord.jp/events/#{event.id}"
+    }.to_query
+    "http://www.google.com/calendar/render?#{event_hash}"
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -2,13 +2,13 @@
 
 module EventsHelper
   def google_calendar_link(event)
-    event_hash =
+    event_query_string=
     {
       :action => "TEMPLATE", 
       :text => event.title, 
       :dates => "#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}", 
       :details => "https://bootcamp.fjord.jp/events/#{event.id}"
     }.to_query
-    "http://www.google.com/calendar/render?#{event_hash}"
+    "http://www.google.com/calendar/render?#{event_query_string}"
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module EventsHelper
+  def google_calendar_link(event)
+    "http://www.google.com/calendar/render?action=TEMPLATE&text=#{event.title}&dates=#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}&details=https://bootcamp.fjord.jp/events/#{event.id}"
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "uri"
 module EventsHelper
   def google_calendar_url(event)
     uri = URI("http://www.google.com/calendar/render")

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
+require "uri"
 module EventsHelper
   def google_calendar_url(event)
-    event_query_string =
-    {
-      action: "TEMPLATE",
-      text: event.title,
-      dates: "#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}",
-      details: "https://bootcamp.fjord.jp/events/#{event.id}"
-    }.to_query
-    "http://www.google.com/calendar/render?#{event_query_string}"
+    uri = URI("http://www.google.com/calendar/render")
+    uri.query =
+      {
+        action: "TEMPLATE",
+        text: event.title,
+        dates: "#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}",
+        details: "https://bootcamp.fjord.jp/events/#{event.id}"
+      }.to_param
+    uri.to_s
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -2,12 +2,12 @@
 
 module EventsHelper
   def google_calendar_url(event)
-    event_query_string=
+    event_query_string =
     {
-      :action => "TEMPLATE", 
-      :text => event.title, 
-      :dates => "#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}", 
-      :details => "https://bootcamp.fjord.jp/events/#{event.id}"
+      action: "TEMPLATE",
+      text: event.title,
+      dates: "#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}",
+      details: "https://bootcamp.fjord.jp/events/#{event.id}"
     }.to_query
     "http://www.google.com/calendar/render?#{event_query_string}"
   end

--- a/app/views/events/_event_meta.html.slim
+++ b/app/views/events/_event_meta.html.slim
@@ -21,3 +21,8 @@
           | 募集期間
         dd.event-meta__item-value
           | #{l event.open_start_at} 〜 #{l event.open_end_at}
+
+  a href="http://www.google.com/calendar/render?action=TEMPLATE
+          &text=#{event.title}
+          &dates=#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}
+          &details=https://bootcamp.fjord.jp/events/#{event.id}" Googleカレンダーに追加

--- a/app/views/events/_event_meta.html.slim
+++ b/app/views/events/_event_meta.html.slim
@@ -17,7 +17,7 @@
         dd.event-meta__item-value
           span.event-meta__item-value-main
             = event.period
-          = link_to google_calendar_link(event), class: "a-button is-sm is-primary" do
+          = link_to google_calendar_url(event), class: "a-button is-sm is-primary" do
             | Googleカレンダーに追加
       .event-meta__item
         dt.event-meta__item-label

--- a/app/views/events/_event_meta.html.slim
+++ b/app/views/events/_event_meta.html.slim
@@ -22,7 +22,4 @@
         dd.event-meta__item-value
           | #{l event.open_start_at} 〜 #{l event.open_end_at}
 
-  a href="http://www.google.com/calendar/render?action=TEMPLATE
-          &text=#{event.title}
-          &dates=#{event.start_at.strftime("%Y%m%dT%H%M%S")}/#{event.end_at.strftime("%Y%m%dT%H%M%S")}
-          &details=https://bootcamp.fjord.jp/events/#{event.id}" Googleカレンダーに追加
+  a href="#{google_calendar_link(event)}" Googleカレンダーに追加

--- a/app/views/events/_event_meta.html.slim
+++ b/app/views/events/_event_meta.html.slim
@@ -15,11 +15,12 @@
         dt.event-meta__item-label
           | 開催日時
         dd.event-meta__item-value
-          = event.period
+          span.event-meta__item-value-main
+            = event.period
+          = link_to google_calendar_link(event), class: "a-button is-sm is-primary" do
+            | Googleカレンダーに追加
       .event-meta__item
         dt.event-meta__item-label
           | 募集期間
         dd.event-meta__item-value
           | #{l event.open_start_at} 〜 #{l event.open_end_at}
-
-  a href="#{google_calendar_link(event)}" Googleカレンダーに追加


### PR DESCRIPTION
#1737 
## 概要
イベント詳細ページに``Googleカレンダーに追加```のリンクを表示しました
![image](https://user-images.githubusercontent.com/58872020/88450343-46aff700-ce89-11ea-849f-f1b1d58e447a.png)

![image](https://user-images.githubusercontent.com/58872020/88450364-6515f280-ce89-11ea-9df2-049fa82479d9.png)

![image](https://user-images.githubusercontent.com/58872020/88450390-8c6cbf80-ce89-11ea-92fa-631c91b1c40f.png)

カレンダーには
- タイトル
- 日時
- 詳細欄にURL

が登録されます！