### PR TITLE
日報が3日連続sadのユーザーをメンターのダッシュボードに表示する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -415,6 +415,15 @@ SQL
     self.save!
   end
 
+  def is_depressed?
+    three_days_emotions = latest_reports(days: 3).map { |report| report.emotion }
+    !three_days_emotions.empty? && three_days_emotions.all? { |emotion| emotion == "sad" }
+  end
+
+  def latest_reports(days:)
+    self.reports.order(reported_on: :desc).limit(days)
+  end
+
   private
     def password_required?
       new_record? || password.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -416,12 +416,8 @@ SQL
   end
 
   def depressed?
-    three_days_emotions = latest_reports(3).pluck(:emotion)
-    !three_days_emotions.empty? && three_days_emotions.all? { |emotion| emotion == "sad" }
-  end
-
-  def latest_reports(days)
-    self.reports.order(reported_on: :desc).limit(days)
+    three_days_emotions = self.reports.order(reported_on: :desc).limit(3).pluck(:emotion)
+    !three_days_emotions.empty? && three_days_emotions.all?("sad")
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -415,12 +415,12 @@ SQL
     self.save!
   end
 
-  def is_depressed?
-    three_days_emotions = latest_reports(days: 3).map { |report| report.emotion }
+  def depressed?
+    three_days_emotions = latest_reports(3).map { |report| report.emotion }
     !three_days_emotions.empty? && three_days_emotions.all? { |emotion| emotion == "sad" }
   end
 
-  def latest_reports(days:)
+  def latest_reports(days)
     self.reports.order(reported_on: :desc).limit(days)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -416,7 +416,7 @@ SQL
   end
 
   def depressed?
-    three_days_emotions = latest_reports(3).map { |report| report.emotion }
+    three_days_emotions = latest_reports(3).pluck(:emotion)
     !three_days_emotions.empty? && three_days_emotions.all? { |emotion| emotion == "sad" }
   end
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -39,6 +39,8 @@ header.page-header
           - unless current_user.total_learning_time.zero? || current_user.mentor?
             = render "users/grass", user: current_user
           = render "users/github_grass", user: current_user
+          - if current_user.mentor?
+            = render "users/sad_emotion_report", users: User.students_and_trainees
           - if current_user.role == :student
             = render "required_field", user: current_user
           - if current_user.books.present?

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -1,0 +1,10 @@
+.a-card
+  header.card-header
+    h2.card-header__title
+      | 3日連続😢のユーザー
+  .card-list
+    ul.card-list__items
+      - users.each do |user|
+        - if user.is_depressed?
+          li.card-list__item
+            = render partial: "reports/report", collection: user.latest_reports(days: 1), as: :report

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -8,4 +8,4 @@
         - users.each do |user|
           - if user.depressed?
             li.card-list__item
-              = render partial: "reports/report", collection: user.latest_reports(1), as: :report
+              = render partial: "reports/report", collection: user.reports.order(reported_on: :desc).limit(1), as: :report

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -1,10 +1,11 @@
-.a-card
-  header.card-header
-    h2.card-header__title
-      | 3日連続😢のユーザー
-  .card-list
-    ul.card-list__items
-      - users.each do |user|
-        - if user.depressed?
-          li.card-list__item
-            = render partial: "reports/report", collection: user.latest_reports(1), as: :report
+- if users.any? { |user| user.depressed? }
+  .a-card
+    header.card-header
+      h2.card-header__title
+        | 3日連続😢のユーザー
+    .card-list
+      ul.card-list__items
+        - users.each do |user|
+          - if user.depressed?
+            li.card-list__item
+              = render partial: "reports/report", collection: user.latest_reports(1), as: :report

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -5,6 +5,6 @@
   .card-list
     ul.card-list__items
       - users.each do |user|
-        - if user.is_depressed?
+        - if user.depressed?
           li.card-list__item
-            = render partial: "reports/report", collection: user.latest_reports(days: 1), as: :report
+            = render partial: "reports/report", collection: user.latest_reports(1), as: :report

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -143,26 +143,25 @@ report_18:
   reported_on: "2020-06-01"
 
 report_19:
-  user: kensyu
+  user: hatsuno
   title: "1日目 できなかった"
   emotion: 1
   description: |-
     あまりできませんでした
   reported_on: <%= Time.current - 2.day %>
 
-report_19:
-  user: kensyu
+report_20:
+  user: hatsuno
   title: "2日目 昨日よりできなかった"
   emotion: 1
   description: |-
     昨日よりできませんでした
   reported_on: <%= Time.current - 1.day %>
 
-report_20:
-  user: kensyu
+report_21:
+  user: hatsuno
   title: "3日目 もう駄目です"
   emotion: 1
   description: |-
     全然できませんでした
   reported_on: <%= Time.current %>
->>>>>>> 8c8907f8... ３連続悲しいレポートをseedに追加

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -141,3 +141,28 @@ report_18:
   description: |-
     今日は1時間学習しました。
   reported_on: "2020-06-01"
+
+report_19:
+  user: kensyu
+  title: "1日目 できなかった"
+  emotion: 1
+  description: |-
+    あまりできませんでした
+  reported_on: <%= Time.current - 2.day %>
+
+report_19:
+  user: kensyu
+  title: "2日目 昨日よりできなかった"
+  emotion: 1
+  description: |-
+    昨日よりできませんでした
+  reported_on: <%= Time.current - 1.day %>
+
+report_20:
+  user: kensyu
+  title: "3日目 もう駄目です"
+  emotion: 1
+  description: |-
+    全然できませんでした
+  reported_on: <%= Time.current %>
+>>>>>>> 8c8907f8... ３連続悲しいレポートをseedに追加

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -85,10 +85,10 @@ class UserTest < ActiveSupport::TestCase
 
   test "#depressed?" do
     user = users(:hatsuno)
-    3.times do |i|
+    4.times do |i|
       report = Report.new(
         user_id: user.id, title: "test #{i}", description: "test",
-        wip: false, emotion: "sad", reported_on: Date.current - i
+        wip: false, emotion: "sad", reported_on: Date.current - i.days
       )
       report.learning_times << LearningTime.new(
         started_at: "2018-01-01 00:00:00", finished_at: "2018-01-01 02:00:00"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -83,7 +83,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [report: nil, date: Date.today, emotion: nil], user.reports_date_and_emotion(0)
   end
 
-  test "#is_depressed?" do
+  test "#depressed?" do
     user = users(:hatsuno)
     3.times do |i|
       report = Report.new(
@@ -95,12 +95,12 @@ class UserTest < ActiveSupport::TestCase
       )
       report.save!
     end
-    assert user.is_depressed?
+    assert user.depressed?
 
     report = user.reports.find_by(reported_on: Date.today)
     report.emotion = "smile"
     report.save!
-    assert_not user.is_depressed?
+    assert_not user.depressed?
   end
 
   test ".order_by_counts" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -88,7 +88,7 @@ class UserTest < ActiveSupport::TestCase
     3.times do |i|
       report = Report.new(
         user_id: user.id, title: "test #{i}", description: "test",
-        wip: false, emotion: "sad", reported_on: Date.today - i
+        wip: false, emotion: "sad", reported_on: Date.current - i
       )
       report.learning_times << LearningTime.new(
         started_at: "2018-01-01 00:00:00", finished_at: "2018-01-01 02:00:00"
@@ -97,7 +97,7 @@ class UserTest < ActiveSupport::TestCase
     end
     assert user.depressed?
 
-    report = user.reports.find_by(reported_on: Date.today)
+    report = user.reports.find_by(reported_on: Date.current)
     report.emotion = "smile"
     report.save!
     assert_not user.depressed?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -83,6 +83,26 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [report: nil, date: Date.today, emotion: nil], user.reports_date_and_emotion(0)
   end
 
+  test "#is_depressed?" do
+    user = users(:hatsuno)
+    3.times do |i|
+      report = Report.new(
+        user_id: user.id, title: "test #{i}", description: "test",
+        wip: false, emotion: "sad", reported_on: Date.today - i
+      )
+      report.learning_times << LearningTime.new(
+        started_at: "2018-01-01 00:00:00", finished_at: "2018-01-01 02:00:00"
+      )
+      report.save!
+    end
+    assert user.is_depressed?
+
+    report = user.reports.find_by(reported_on: Date.today)
+    report.emotion = "smile"
+    report.save!
+    assert_not user.is_depressed?
+  end
+
   test ".order_by_counts" do
     ordered_users = User.order_by_counts("report", "desc")
     more_report_user = users(:sotugyou)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -84,7 +84,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "#depressed?" do
-    user = users(:hatsuno)
+    user = users(:kimura)
     4.times do |i|
       report = Report.new(
         user_id: user.id, title: "test #{i}", description: "test",


### PR DESCRIPTION
日報が3連続😢となっているユーザーをメンターのダッシュボードに表示するように変更しました。
表示されるのは😢がついている最新の日報です。

![three_days_sad](https://user-images.githubusercontent.com/60720255/89013889-a60d7b80-d34f-11ea-9ae3-b8ae582c1a8a.png)
