### PR TITLE
新着のDocsをすぐに気づけるようにしたい

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,6 +23,7 @@ class PagesController < ApplicationController
     @page.user = current_user
     set_wip
     if @page.save
+      notify_to_slack(@page)
       redirect_to @page, notice: notice_message(@page, :create)
     else
       render :new
@@ -65,4 +66,17 @@ class PagesController < ApplicationController
         "ページを更新しました。"
       end
     end
+
+    def notify_to_slack(page)
+      link = "<#{url_for(page)}|#{page.title}>"
+      SlackNotification.notify "#{link}",
+        username: "#{page.user.login_name} (#{page.user.full_name})",
+        icon_url: page.user.avatar_url,
+        channel: "#general",
+        attachments: [{
+          fallback: "page body.",
+          text: page.body
+        }]
+    end
+
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -78,5 +78,4 @@ class PagesController < ApplicationController
           text: page.body
         }]
     end
-
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -17,6 +17,7 @@ class NotificationMailer < ApplicationMailer
     @watchable = params[:watchable]
     @sender = params[:sender]
     @event = params[:event]
+    @page = params[:page]
   end
 
   # required params: comment, receiver, message
@@ -111,6 +112,14 @@ class NotificationMailer < ApplicationMailer
     @user = @receiver
     @notification = @user.notifications.find_by(path: "/events/#{@event.id}")
     subject = "[bootcamp] #{@event.title}で、補欠から参加に繰り上がりました。"
+    mail to: @user.email, subject: subject
+  end
+
+  # required params: page, receiver
+  def create_page
+    @user = @receiver
+    @notification = @user.notifications.find_by(path: "/pages/#{@page.id}")
+    subject = "[bootcamp] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
     mail to: @user.email, subject: subject
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -19,7 +19,7 @@ class Notification < ApplicationRecord
     retired:         9,
     trainee_report: 10,
     moved_up_event_waiting_user: 11,
-    pages:          12
+    create_pages:   12
   }
 
   scope :reads, -> {

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -173,7 +173,7 @@ class Notification < ApplicationRecord
       user: reciever,
       sender: page.sender,
       path: Rails.application.routes.url_helpers.polymorphic_path(page),
-      message: "#{page.user.login_name}がDocsに#{page.title}を投稿しました",
+      message: "#{page.user.login_name}さんがDocsに#{page.title}を投稿しました。",
       read:    false
     )
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -18,7 +18,8 @@ class Notification < ApplicationRecord
     watching:        8,
     retired:         9,
     trainee_report: 10,
-    moved_up_event_waiting_user: 11
+    moved_up_event_waiting_user: 11,
+    pages:          12
   }
 
   scope :reads, -> {
@@ -163,6 +164,17 @@ class Notification < ApplicationRecord
       path:     Rails.application.routes.url_helpers.polymorphic_path(event),
       message:  "#{event.title}で、補欠から参加に繰り上がりました。",
       read:     false
+    )
+  end
+
+  def self.create_page(page, reciever)
+    Notification.create!(
+      kind: 12,
+      user: reciever,
+      sender: page.sender,
+      path: Rails.application.routes.url_helpers.polymorphic_path(page),
+      message: "#{page.user.login_name}がDocsに#{page.title}を投稿しました",
+      read:    false
     )
   end
 

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -119,4 +119,14 @@ class NotificationFacade
       ).moved_up_event_waiting_user.deliver_later
     end
   end
+
+  def self.create_page(page, receiver)
+    Notification.create_page(page, receiver)
+    if receiver.mail_notification? && !receiver.retired_on?
+      NotificationMailer.with(
+        page: page,
+        receiver: receiver
+      ).create_page.deliver_later
+    end
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -8,6 +8,8 @@ class Page < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
   paginates_per 20
+  alias_method :sender, :user
+  after_create PageCallbacks.new
 
   columns_for_keyword_search :title, :body
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -10,6 +10,7 @@ class Page < ApplicationRecord
   paginates_per 20
   alias_method :sender, :user
   after_create PageCallbacks.new
+  after_update PageCallbacks.new
 
   columns_for_keyword_search :title, :body
 

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -1,0 +1,15 @@
+class PageCallbacks
+  def after_create(page)
+    send_notification(page)
+  end
+
+  private
+    def send_notification(page)
+      reciever_list = User.all
+      reciever_list.each do |reciever|
+        if page.sender != reciever
+          Notification.create_page(page, reciever)
+        end
+      end
+    end
+end

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -12,19 +12,6 @@ class PageCallbacks
   end
 
   private
-  
-    def notify_to_slack(page)
-      link = "<#{url_for(page)}|#{page.title}>"
-      SlackNotification.notify "#{link}",
-        username: "#{page.user.login_name} (#{page.user.full_name})",
-        icon_url: page.user.avatar_url,
-        channel: "#general",
-        attachments: [{
-          fallback: "page body.",
-          text: page.body
-        }]
-    end
-
     def send_notification(page)
       receivers = User.where(retired_on: nil, graduated_on: nil, adviser: false, trainee: false)
       receivers.each do |receiver|
@@ -32,6 +19,5 @@ class PageCallbacks
           NotificationFacade.create_page(page, receiver)
         end
       end
-      notify_to_slack(page)
     end
 end

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -12,6 +12,19 @@ class PageCallbacks
   end
 
   private
+  
+    def notify_to_slack(page)
+      link = "<#{url_for(page)}|#{page.title}>"
+      SlackNotification.notify "#{link}",
+        username: "#{page.user.login_name} (#{page.user.full_name})",
+        icon_url: page.user.avatar_url,
+        channel: "#general",
+        attachments: [{
+          fallback: "page body.",
+          text: page.body
+        }]
+    end
+
     def send_notification(page)
       receivers = User.where(retired_on: nil, graduated_on: nil, adviser: false, trainee: false)
       receivers.each do |receiver|
@@ -19,5 +32,6 @@ class PageCallbacks
           NotificationFacade.create_page(page, receiver)
         end
       end
+      notify_to_slack(page)
     end
 end

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -13,8 +13,8 @@ class PageCallbacks
 
   private
     def send_notification(page)
-      receiver_list = User.where(retired_on: nil)
-      receiver_list.each do |receiver|
+      receivers = User.where(retired_on: nil, graduated_on: nil, adviser: false, trainee: false)
+      receivers.each do |receiver|
         if page.sender != receiver
           NotificationFacade.create_page(page, receiver)
         end

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -14,8 +14,10 @@ class PageCallbacks
   private
     def send_notification(page)
       receiver_list = User.where(retired_on: nil)
-      receiver_list.each do |reciever|
-        Notification.create_page(page, reciever)
+      receiver_list.each do |receiver|
+        if page.sender != receiver
+          NotificationFacade.create_page(page, receiver)
+        end
       end
     end
 end

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -1,15 +1,21 @@
 class PageCallbacks
   def after_create(page)
-    send_notification(page)
+    if !page.wip?
+      send_notification(page)
+    end
+  end
+
+  def after_update(page)
+    if page.wip == false
+      send_notification(page)
+    end
   end
 
   private
     def send_notification(page)
-      reciever_list = User.all
-      reciever_list.each do |reciever|
-        if page.sender != reciever
-          Notification.create_page(page, reciever)
-        end
+      receiver_list = User.where(retired_on: nil)
+      receiver_list.each do |reciever|
+        Notification.create_page(page, reciever)
       end
     end
 end

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -4,12 +4,16 @@ class PageCallbacks
   def after_create(page)
     if !page.wip?
       send_notification(page)
+      page.published_at = Date.current
+      page.save
     end
   end
 
   def after_update(page)
-    if page.wip == false
+    if page.wip == false && page.published_at.nil?
       send_notification(page)
+      page.published_at = Date.current
+      page.save
     end
   end
 

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PageCallbacks
   def after_create(page)
     if !page.wip?

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -4,7 +4,7 @@ class PageCallbacks
   def after_create(page)
     if !page.wip?
       send_notification(page)
-      page.published_at = Date.current
+      page.published_at = Time.current
       page.save
     end
   end
@@ -12,7 +12,7 @@ class PageCallbacks
   def after_update(page)
     if page.wip == false && page.published_at.nil?
       send_notification(page)
-      page.published_at = Date.current
+      page.published_at = Time.current
       page.save
     end
   end

--- a/app/views/notification_mailer/create_page.html.slim
+++ b/app/views/notification_mailer/create_page.html.slim
@@ -1,0 +1,2 @@
+= render "notification_mailer_template", title: "#{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。", link_url: notification_url(@notification), link_text: "このDocsへ" do
+  = simple_format(@page.body)

--- a/db/migrate/20200809022128_add_published_at_to_pages.rb
+++ b/db/migrate/20200809022128_add_published_at_to_pages.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToPages < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pages, :published_at, :datetime
+  end
+end

--- a/db/migrate/20200809022128_add_published_at_to_pages.rb
+++ b/db/migrate/20200809022128_add_published_at_to_pages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPublishedAtToPages < ActiveRecord::Migration[6.0]
   def change
     add_column :pages, :published_at, :datetime

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_02_011103) do
+ActiveRecord::Schema.define(version: 2020_08_09_022128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -217,6 +217,7 @@ ActiveRecord::Schema.define(version: 2020_08_02_011103) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.boolean "wip", default: false, null: false
+    t.datetime "published_at"
     t.index ["updated_at"], name: "index_pages_on_updated_at"
     t.index ["user_id"], name: "index_pages_on_user_id"
   end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -101,3 +101,11 @@ notification_moved_up_event_waiting_user:
   message: 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。
   path: "/events/<%= ActiveRecord::FixtureSet.identify(:event_3) %>"
   read: false
+
+notification_create_page:
+  kind: 12
+  user: hatsuno
+  sender: komagata
+  message: "komagataさんがDocsにBootcampの作業のページを投稿しました。"
+  path: "/pages/<%= ActiveRecord::FixtureSet.identify(:page_4) %>"
+  read: false

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -17,3 +17,8 @@ page_4:
   title: Bootcampの作業のページ
   body: "## テスト\nテスト"
   user: komagata
+
+page_5:
+  title: WIPのテスト
+  body: WIP
+  user: komagata

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -157,6 +157,26 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match %r{はじめて}, email.body.to_s
   end
 
+  test "create_page" do
+    page = pages(:page_4)
+    create_page = notifications(:notification_create_page)
+    mailer = NotificationMailer.with(
+      page: page,
+      receiver: create_page.user
+    ).create_page
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ["info@fjord.jp"], email.from
+    assert_equal ["hatsuno@fjord.jp"], email.to
+    assert_equal "[bootcamp] komagataさんがDocsにBootcampの作業のページを投稿しました。", email.subject
+    assert_match %r{Bootcamp}, email.body.to_s
+  end
+
   test "watching_notification" do
     watch = watches(:report1_watch_kimura)
     watching = notifications(:notification_watching)

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -21,5 +21,27 @@ class Notification::PagesTest < ApplicationSystemTestCase
     login_user "machida", "testtest"
     first(".test-bell").click
     assert_text "komagataさんがDocsにDocsTestを投稿しました。"
+
+    logout
+    login_user "yameo", "testtest"
+    visit "/notifications"
+    assert_no_text "komagataさんがDocsにDocsTestを投稿しました。"
+  end
+
+  test "don't notify when page is WIP" do
+    login_user "komagata", "testtest"
+    visit "/pages"
+    click_link "新規ページ"
+
+    within(".form") do
+      fill_in("page[title]", with: "DocsTest")
+      fill_in("page[body]", with: "DocsTestBody")
+    end
+    click_button "WIP"
+
+    logout
+    login_user "hatsuno", "testtest"
+    visit "/notifications"
+    assert_no_text "komagataさんがDocsにDocsTestを投稿しました。"
   end
 end

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "application_system_test_case"
 
 class Notification::PagesTest < ApplicationSystemTestCase

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -46,4 +46,18 @@ class Notification::PagesTest < ApplicationSystemTestCase
     visit "/notifications"
     assert_no_text "komagataさんがDocsにDocsTestを投稿しました。"
   end
+
+  test "Notify Docs updated from WIP" do
+    page = pages(:page_5)
+    login_user "komagata", "testtest"
+    visit page_path(page)
+
+    click_link "内容変更"
+    click_button "内容を保存"
+
+    logout
+    login_user "machida", "testtest"
+    first(".test-bell").click
+    assert_text "komagataさんがDocsにWIPのテストを投稿しました。"
+  end
 end

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -1,0 +1,25 @@
+require "application_system_test_case"
+
+class Notification::PagesTest < ApplicationSystemTestCase
+  test "Only students and mentors are notified" do
+    login_user "komagata", "testtest"
+    visit "/pages"
+    click_link "新規ページ"
+
+    within(".form") do
+      fill_in("page[title]", with: "DocsTest")
+      fill_in("page[body]", with: "DocsTestBody")
+    end
+    click_button "内容を保存"
+
+    logout
+    login_user "hatsuno", "testtest"
+    first(".test-bell").click
+    assert_text "komagataさんがDocsにDocsTestを投稿しました。"
+
+    logout
+    login_user "machida", "testtest"
+    first(".test-bell").click
+    assert_text "komagataさんがDocsにDocsTestを投稿しました。"
+  end
+end


### PR DESCRIPTION
## 変更の目的
#1739

## キャプチャ
Docsが投稿されると通知に「〇〇さんがDocsに〇〇を投稿しました。」と通知される。
![image](https://user-images.githubusercontent.com/58872020/89653468-1c871c00-d902-11ea-9a93-df36be902b81.png)

メールのキャプチャ
![image](https://user-images.githubusercontent.com/58872020/89653769-8e5f6580-d902-11ea-9da0-5dba57c3b227.png)


## 詳細
- Docsを投稿すると作成者以外の```現役生```と```メンター```に通知される
- メール、Slackのgeneralにも通知される
- 通知されるのは初めてDocsが公開された時
    - WIPから投稿するときは初めての時のみ通知される