### PR TITLE
コメントした人が分かるようにコメント通知を変更

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -87,7 +87,7 @@ class NotificationMailer < ApplicationMailer
     @user = @receiver
     path = "/#{@watchable.class.name.downcase.pluralize}/#{@watchable.id}"
     @notification = @user.notifications.find_by(path: path)
-    subject = "[bootcamp] #{@sender.login_name}さんの【 #{@watchable.title} 】にコメントが投稿されました。"
+    subject = "[bootcamp] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんがコメントしました。"
     mail to: @user.email, subject: subject
   end
 

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -12,4 +12,19 @@ module Watchable
   def watched?
     watches.present?
   end
+
+  def notification_title
+    case self
+    when Product
+      "「#{self.practice[:title]}」の提出物"
+    when Report
+      "「#{self[:title]}」の日報"
+    when Question
+      "「#{self[:title]}」のQ&A"
+    when Event
+      "「#{self[:title]}」のイベント"
+    else
+      self[:title]
+    end
+  end
 end

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -23,8 +23,6 @@ module Watchable
       "「#{self[:title]}」のQ&A"
     when Event
       "「#{self[:title]}」のイベント"
-    else
-      self[:title]
     end
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -123,13 +123,14 @@ class Notification < ApplicationRecord
   end
 
   def self.watching_notification(watchable, receiver, comment)
-    sender = watchable.user
+    watchable_user = watchable.user
+    sender = comment.user
     Notification.create!(
       kind:    8,
       user:    receiver,
       sender:  sender,
       path:    Rails.application.routes.url_helpers.polymorphic_path(watchable),
-      message: "#{sender.login_name}さんの【 #{watchable.title} 】にコメントが投稿されました。",
+      message: "#{watchable_user.login_name}さんの【 #{watchable.notification_title} 】に#{comment.user.login_name}さんがコメントしました。",
       read:    false
     )
   end

--- a/app/views/notification_mailer/watching_notification.html.slim
+++ b/app/views/notification_mailer/watching_notification.html.slim
@@ -1,2 +1,2 @@
-= render "notification_mailer_template", title: "#{@watchable.title}にコメントが投稿されました。", link_url: notification_url(@notification), link_text: "この#{@watchable.class.model_name.human}へ" do
+= render "notification_mailer_template", title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんがコメントしました。", link_url: notification_url(@notification), link_text: "この#{@watchable.class.model_name.human}へ" do
   = md2html @comment.description

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -74,7 +74,7 @@ notification_watching:
   kind: 8
   user: kimura
   sender: komagata
-  message: komagataさんの【 作業週1日目 】にコメントが投稿されました。
+  message: komagataさんの【 「作業週1日目」の日報 】にmachidaさんがコメントしました。
   path: "/reports/<%= ActiveRecord::FixtureSet.identify(:report_1) %>"
   read: false
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -194,7 +194,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ["info@fjord.jp"], email.from
     assert_equal ["kimura@fjord.jp"], email.to
-    assert_equal "[bootcamp] komagataさんの【 作業週1日目 】にコメントが投稿されました。", email.subject
+    assert_equal "[bootcamp] komagataさんの【 「作業週1日目」の日報 】にmachidaさんがコメントしました。", email.subject
   end
 
   test "retired" do

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -24,13 +24,13 @@ class Notification::WatchesTest < ApplicationSystemTestCase
 
     login_user "kimura", "testtest"
     open_notification
-    assert_equal "komagataさんの【 #{reports(:report_1).title} 】にコメントが投稿されました。",
+    assert_equal "komagataさんの【 「#{reports(:report_1).title}」の日報 】にkomagataさんがコメントしました。",
       notification_message
 
     login_user "machida", "testtest"
     open_notification
 
-    assert_equal "komagataさんの【 #{reports(:report_1).title} 】にコメントが投稿されました。",
+    assert_equal "komagataさんの【 「#{reports(:report_1).title}」の日報 】にkomagataさんがコメントしました。",
       notification_message
   end
 
@@ -55,12 +55,12 @@ class Notification::WatchesTest < ApplicationSystemTestCase
 
     login_user "kimura", "testtest"
     open_notification
-    assert_equal "machidaさんの【 #{questions(:question_1).title} 】にコメントが投稿されました。",
+    assert_equal "machidaさんの【 「#{questions(:question_1).title}」のQ&A 】にmachidaさんがコメントしました。",
       notification_message
 
     login_user "komagata", "testtest"
     open_notification
-    assert_equal "machidaさんの【 #{questions(:question_1).title} 】にコメントが投稿されました。",
+    assert_equal "machidaさんの【 「#{questions(:question_1).title}」のQ&A 】にmachidaさんがコメントしました。",
       notification_message
   end
 end


### PR DESCRIPTION
# 概要

コメントに関する通知において、現在コメント対象（日報、イベント、提出物、Q&A）の所有者のアイコンが表示されている。
これをコメントした人のアイコンを表示するように変更する。また、誰がコメントしたか分かるように通知文言にユーザー名を含める。

通知文言の詳細は、関連issueを参照。

# 関連issue
[コメントに関する通知はコメントをした人のアイコンが表示されてほしい #1774](https://github.com/fjordllc/bootcamp/issues/1774)