### PR TITLE
sendgridの設定を変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -124,7 +124,7 @@ Rails.application.configure do
     authentication: :plain,
     user_name: ENV["SENDGRID_USERNAME"],
     password: ENV["SENDGRID_PASSWORD"],
-    domain: "heroku.com",
+    domain: "bootcamp.fjord.jp",
     enable_starttls_auto: true
   }
 


### PR DESCRIPTION
herokuのaddonから単体のアカウントに変わるため