### PR TITLE
イベント一覧に参加者、補欠者の数字を表示

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,7 @@ class EventsController < ApplicationController
 
   def index
     @events = Event.with_avatar
-                   .preload(:comments, :users)
+                   .includes(:comments, :users)
                    .order(created_at: :desc)
                    .page(params[:page])
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,7 @@ class EventsController < ApplicationController
 
   def index
     @events = Event.with_avatar
-                   .preload(:comments)
+                   .preload(:comments, :users)
                    .order(created_at: :desc)
                    .page(params[:page])
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -57,6 +57,14 @@ class Event < ApplicationRecord
     first_come_first_served - participants
   end
 
+  def participants_count
+    users.size > capacity ? capacity : users.size
+  end
+
+  def waitlist_count
+    users.size > capacity ? users.size - capacity : 0
+  end
+
   def can_participate?
     first_come_first_served.count < capacity
   end

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -26,3 +26,10 @@
             i.fas.fa-comment
           .thread-list-item-meta__comment-count-value
             = event.comments.size
+      .thread-list-item-meta__comment-count
+        .thread-list-item-meta__comment-count-value
+          | 参加者(#{event.participants_count}名/#{event.capacity}名)
+      - if event.waitlist_count > 0
+        .thread-list-item-meta__comment-count
+          .thread-list-item-meta__comment-count-value
+            | 補欠者(#{event.waitlist_count}名)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -31,6 +31,20 @@ class EventTest < ActiveSupport::TestCase
     assert_includes event.waitlist, waiting_user
   end
 
+  test "#participants_count" do
+    waited_event = events(:event_3)
+    assert_equal waited_event.participants_count, 1
+    not_waited_event = events(:event_2)
+    assert_equal not_waited_event.participants_count, 2
+  end
+
+  test "#waitlist_count" do
+    waited_event = events(:event_3)
+    assert_equal waited_event.waitlist_count, 2
+    not_waited_event = events(:event_2)
+    assert_equal not_waited_event.waitlist_count, 0
+  end
+
   test "#can_participate?" do
     event = events(:event_3)
     assert_not event.can_participate?


### PR DESCRIPTION
ref #1769

<img width="671" alt="イベント___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/50437473/92116921-6db9fb00-ee2f-11ea-96c3-f6402f616d5a.png">

- commentsと同様にusersを`preload`しました。

- 参加者数、補欠者数ともに条件によって異なるため、Eventモデルに`#participants_count`と`#waitlist_count`を追加しました。なお追加したメソッド内では`users.size`を用いて、usersがロード済の場合にSQL文を発行しないようにしました。
参考：https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-size

- 暫定的にコメント用のCSSを適用しました。

以上、ご確認お願いします。🙏