### PR TITLE
slack通知処理をcontrollerからmodelに変更

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,7 +23,6 @@ class PagesController < ApplicationController
     @page.user = current_user
     set_wip
     if @page.save
-      notify_to_slack(@page)
       redirect_to @page, notice: notice_message(@page, :create)
     else
       render :new
@@ -65,17 +64,5 @@ class PagesController < ApplicationController
       when :update
         "ページを更新しました。"
       end
-    end
-
-    def notify_to_slack(page)
-      link = "<#{url_for(page)}|#{page.title}>"
-      SlackNotification.notify "#{link}",
-        username: "#{page.user.login_name} (#{page.user.full_name})",
-        icon_url: page.user.avatar_url,
-        channel: "#general",
-        attachments: [{
-          fallback: "page body.",
-          text: page.body
-        }]
     end
 end

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -4,6 +4,7 @@ class PageCallbacks
   def after_create(page)
     if !page.wip?
       send_notification(page)
+      notify_to_slack(page)
       page.published_at = Time.current
       page.save
     end
@@ -12,6 +13,7 @@ class PageCallbacks
   def after_update(page)
     if page.wip == false && page.published_at.nil?
       send_notification(page)
+      notify_to_slack(page)
       page.published_at = Time.current
       page.save
     end
@@ -25,5 +27,20 @@ class PageCallbacks
           NotificationFacade.create_page(page, receiver)
         end
       end
+    end
+
+    def notify_to_slack(page)
+      path = Rails.application.routes.url_helpers.polymorphic_path(page)
+      url = "https://bootcamp.fjord.jp#{path}"
+      link = "<#{url}|#{page.title}>"
+      binding.pry
+      SlackNotification.notify "#{link}",
+        username: "#{page.user.login_name} (#{page.user.full_name})",
+        icon_url: page.user.avatar_url,
+        channel: "#general",
+        attachments: [{
+          fallback: "page body.",
+          text: page.body
+        }]
     end
 end

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -33,7 +33,6 @@ class PageCallbacks
       path = Rails.application.routes.url_helpers.polymorphic_path(page)
       url = "https://bootcamp.fjord.jp#{path}"
       link = "<#{url}|#{page.title}>"
-      binding.pry
       SlackNotification.notify "#{link}",
         username: "#{page.user.login_name} (#{page.user.full_name})",
         icon_url: page.user.avatar_url,


### PR DESCRIPTION
#1757 の修正になります
Slack通知処理がCreateの時のみになっていたので、通知が飛ばされるタイミング（初めてDocsが作成された時）でSlackにも通知するようにしました。
本番でメール機能が上手く動かない件は9/7の雑談タイムの時に保留という風に言われたので改善していません🙇‍♂️