### PR TITLE
提出物作成のflashに文言を追加する

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -137,7 +137,7 @@ class ProductsController < ApplicationController
       return "提出物をWIPとして保存しました。" if product.wip?
       case action_name
       when :create
-        "提出物を作成しました。"
+        "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
       when :update
         "提出物を更新しました。"
       end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -137,7 +137,7 @@ class ProductsController < ApplicationController
       return "提出物をWIPとして保存しました。" if product.wip?
       case action_name
       when :create
-        "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
+        "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。<br>7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
       when :update
         "提出物を更新しました。"
       end

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -5,7 +5,7 @@
       .flash__container
         label.flash__close(for="hide-flash")
         p.flash__message
-          = notice
+          = notice.html_safe
 - if alert
   input.a-toggle-checkbox#hide-flash(type="checkbox")
   .flash.is-alert

--- a/test/system/mention/products_test.rb
+++ b/test/system/mention/products_test.rb
@@ -15,7 +15,7 @@ module Mention
         fill_in("product[body]", with: "@machida test")
       end
       click_button "提出する"
-      assert_text "提出物を作成しました。"
+      assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
 
       login_user "machida", "testtest"
       visit "/notifications"

--- a/test/system/mention/products_test.rb
+++ b/test/system/mention/products_test.rb
@@ -15,7 +15,7 @@ module Mention
         fill_in("product[body]", with: "@machida test")
       end
       click_button "提出する"
-      assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
+      assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
 
       login_user "machida", "testtest"
       visit "/notifications"

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -11,7 +11,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
       fill_in("product[body]", with: "test")
     end
     click_button "提出する"
-    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
+    assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
 
     logout
     login_user "senpai", "testtest"

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -11,7 +11,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
       fill_in("product[body]", with: "test")
     end
     click_button "提出する"
-    assert_text "提出物を作成しました。"
+    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
 
     logout
     login_user "senpai", "testtest"

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -75,7 +75,7 @@ class ProductsTest < ApplicationSystemTestCase
       fill_in("product[body]", with: "test")
     end
     click_button "提出する"
-    assert_text "提出物を作成しました。"
+    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
   end
 
   test "create product change status submitted" do
@@ -85,7 +85,7 @@ class ProductsTest < ApplicationSystemTestCase
       fill_in("product[body]", with: "test")
     end
     click_button "提出する"
-    assert_text "提出物を作成しました。"
+    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
 
     visit "/practices/#{practices(:practice_5).id}"
     assert_equal first(".test-product").text, "提出物へ"
@@ -203,7 +203,7 @@ class ProductsTest < ApplicationSystemTestCase
       click_button "提出する"
       assert_match "kensyu さんが「#{practices(:practice_3).title}」の提出物を提出しました。", mock_log.to_s
     end
-    assert_text "提出物を作成しました。"
+    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
   end
 
   test "Slack notify if the create product as WIP" do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -75,7 +75,7 @@ class ProductsTest < ApplicationSystemTestCase
       fill_in("product[body]", with: "test")
     end
     click_button "提出する"
-    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
+    assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
   end
 
   test "create product change status submitted" do
@@ -85,7 +85,7 @@ class ProductsTest < ApplicationSystemTestCase
       fill_in("product[body]", with: "test")
     end
     click_button "提出する"
-    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
+    assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
 
     visit "/practices/#{practices(:practice_5).id}"
     assert_equal first(".test-product").text, "提出物へ"
@@ -203,7 +203,7 @@ class ProductsTest < ApplicationSystemTestCase
       click_button "提出する"
       assert_match "kensyu さんが「#{practices(:practice_3).title}」の提出物を提出しました。", mock_log.to_s
     end
-    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
+    assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
   end
 
   test "Slack notify if the create product as WIP" do

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -43,7 +43,7 @@ class RetirementTest < ApplicationSystemTestCase
       fill_in("product[body]", with: "test")
     end
     click_button "提出する"
-    assert_text "提出物を作成しました。"
+    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
     visit edit_current_user_path
     click_on "退会手続きへ進む"
     fill_in "user[retire_reason]", with: "辞" * 8

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -43,7 +43,7 @@ class RetirementTest < ApplicationSystemTestCase
       fill_in("product[body]", with: "test")
     end
     click_button "提出する"
-    assert_text "提出物を作成しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。"
+    assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
     visit edit_current_user_path
     click_on "退会手続きへ進む"
     fill_in "user[retire_reason]", with: "辞" * 8


### PR DESCRIPTION
#1863 の作業です。
提出物作成時の文言を変更いたしました。
少し長い文章でしたので、改行してみました。

<img width="1201" alt="スクリーンショット 2020-09-17 5 32 50" src="https://user-images.githubusercontent.com/2003287/93392943-979e0380-f8ac-11ea-9301-b89a76657829.png">
