### PR TITLE
お知らせの通知対象のデフォルトを「現役生のみ」に変更

### DIFF
--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -23,11 +23,11 @@
         li.form-radio-button
           label.form-radio-button__label
             | 全員にお知らせ
-            = f.radio_button :target, "all", checked: true
+            = f.radio_button :target, "all"
         li.form-radio-button
           label.form-radio-button__label
             | 現役生にのみお知らせ
-            = f.radio_button :target, "students"
+            = f.radio_button :target, "students", checked: true
         li.form-radio-button
           label.form-radio-button__label
             | 就職希望者にのみお知らせ


### PR DESCRIPTION
お知らせの新規作成ページを一部変更しました。通知ターゲットのデフォルトを「全員にお知らせ」から「現役生にのみ」にしました。

![image](https://user-images.githubusercontent.com/60137763/93308676-87027480-f83d-11ea-8eb2-d92b1e11db9c.png)
