### PR TITLE
質問作成ページに「上手な質問のしかたについて」のリンクを作成

### DIFF
--- a/app/assets/stylesheets/blocks/page/_page-notice.sass
+++ b/app/assets/stylesheets/blocks/page/_page-notice.sass
@@ -1,0 +1,10 @@
+.page-notice
+  background-color: $info
+
+.page-notice__inner
+  +padding(vertical, .5rem)
+  p
+    +text-block(.875rem 1.4, $reversal-text center)
+  a
+    color: $reversal-text
+    +hover-link-reversal

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -1,4 +1,5 @@
 = render "errors", object: question
+= link_to  "このドキュメントを参考にして質問をしてみよう！", "https://bootcamp.fjord.jp/pages/240", target: "_blank", class: "a-label"
 = form_with model: question, local: true, class: "form", html: { name: "question" } do |f|
   .form__items
     .form-item

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -1,6 +1,4 @@
 = render "errors", object: question
-= link_to "このドキュメントを参考にして質問をしてみよう！",
-"https://bootcamp.fjord.jp/pages/240", target: "_blank", rel: "noopener noreferrer", class: "a-label"
 = form_with model: question, local: true, class: "form", html: { name: "question" } do |f|
   .form__items
     .form-item

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -1,5 +1,5 @@
 = render "errors", object: question
-= link_to  "このドキュメントを参考にして質問をしてみよう！", "https://bootcamp.fjord.jp/pages/240", target: "_blank", class: "a-label"
+= link_to "このドキュメントを参考にして質問をしてみよう！", "https://bootcamp.fjord.jp/pages/240", target: "_blank", class: "a-label"
 = form_with model: question, local: true, class: "form", html: { name: "question" } do |f|
   .form__items
     .form-item

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -1,5 +1,6 @@
 = render "errors", object: question
-= link_to "このドキュメントを参考にして質問をしてみよう！", "https://bootcamp.fjord.jp/pages/240", target: "_blank", class: "a-label"
+= link_to "このドキュメントを参考にして質問をしてみよう！",
+"https://bootcamp.fjord.jp/pages/240", target: "_blank", rel: "noopener noreferrer", class: "a-label"
 = form_with model: question, local: true, class: "form", html: { name: "question" } do |f|
   .form__items
     .form-item

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -12,6 +12,13 @@ header.page-header
             = link_to questions_path, class: "a-button is-md is-secondary is-block" do
               i.fas.fa-angle-left
               | Q&A一覧へ
+
+.page-notice
+  .container
+    .page-notice__inner
+      p
+        = link_to "/pages/240", target: "_blank", class: "page-notice__link" do
+          | このドキュメントを参考にして質問をしてみよう！
 .page-body
   .container
     = render "form", question: @question, categories: @categories

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -17,7 +17,7 @@ header.page-header
   .container
     .page-notice__inner
       p
-        = link_to "/pages/240", target: "_blank", class: "page-notice__link" do
+        = link_to "/pages/240", target: "_blank", class: "page-notice__link", rel: "noopener noreferrer" do
           | このドキュメントを参考にして質問をしてみよう！
 .page-body
   .container


### PR DESCRIPTION
ref [#1866](https://github.com/fjordllc/bootcamp/issues/1866)

- 質問作成ページに[上手な質問のしかたについて](https://bootcamp.fjord.jp/pages/240)のリンクを追加しました。
[![image](https://user-images.githubusercontent.com/56685224/93314921-64745980-f845-11ea-9e30-0f3ed0606a4d.png)](https://user-images.githubusercontent.com/56685224/93314921-64745980-f845-11ea-9e30-0f3ed0606a4d.png)
