### PR TITLE
GitHubアカウントがない時はカード自体非表示にした

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -41,7 +41,7 @@ header.page-header
               = render "reserved_seats_today", reservations: @reservations_for_today
           - unless current_user.total_learning_time.zero? || current_user.mentor?
             = render "users/grass", user: current_user
-          - unless current_user.github_account.nil?
+          - if current_user.github_account.present?
             = render "users/github_grass", user: current_user
           - if current_user.mentor?
             = render "users/sad_emotion_report", users: User.students_and_trainees

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -41,7 +41,8 @@ header.page-header
               = render "reserved_seats_today", reservations: @reservations_for_today
           - unless current_user.total_learning_time.zero? || current_user.mentor?
             = render "users/grass", user: current_user
-          = render "users/github_grass", user: current_user
+          - unless current_user.github_account.nil?
+            = render "users/github_grass", user: current_user
           - if current_user.mentor?
             = render "users/sad_emotion_report", users: User.students_and_trainees
           - if current_user.role == :student

--- a/app/views/users/_github_grass.html.slim
+++ b/app/views/users/_github_grass.html.slim
@@ -2,8 +2,5 @@
   .card-header.is-sm
     h2.card-header__title GitHub
   .user-grass
-    - if user.github_account
-      = link_to user_github_url(user), target: "_blank", class: "user-grass__link" do
-        .js-github-grass(data-name="#{user.github_account}")
-    - else
-      .user-grass__empty GitHubアカウントは未登録です。
+    = link_to user_github_url(user), target: "_blank", class: "user-grass__link" do
+      .js-github-grass(data-name="#{user.github_account}")

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -44,7 +44,7 @@ header.page-header
         .col-xs-12.col-lg-7.col-xxl-6
           - unless @user.total_learning_time.zero? || @user.mentor?
             = render "users/grass", user: @user
-          - unless @user.github_account.nil?
+          - if @user.github_account.present?
             = render "users/github_grass", user: @user
           - if @user.active_practices.present?
             = render "/users/practices/active_practices", user: @user

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -44,7 +44,8 @@ header.page-header
         .col-xs-12.col-lg-7.col-xxl-6
           - unless @user.total_learning_time.zero? || @user.mentor?
             = render "users/grass", user: @user
-          = render "users/github_grass", user: @user
+          - unless @user.github_account.nil?
+            = render "users/github_grass", user: @user
           - if @user.active_practices.present?
             = render "/users/practices/active_practices", user: @user
           - if @user.student? && @user.graduated_on.blank?


### PR DESCRIPTION
ref #1812 

## 概要
- ダッシュボード、ユーザーページそれぞれでGitHubアカウントがなければGitHubのカード自体を非表示にしました。
- GitHubのカード自体の表示/非表示に変更したため、GitHubカード内の`GitHubアカウントは未登録です。`のメッセージは削除しました。
## GitHubアカウントがないユーザー(kimura)
- ダッシュボード
[![image](https://user-images.githubusercontent.com/56685224/93410805-a6001580-f8d4-11ea-8b5c-a97ad7eed5d7.png)](https://user-images.githubusercontent.com/56685224/93410805-a6001580-f8d4-11ea-8b5c-a97ad7eed5d7.png)

- ユーザーページ
[![image](https://user-images.githubusercontent.com/56685224/93410756-8a950a80-f8d4-11ea-8c25-5937bec5bddc.png)](https://user-images.githubusercontent.com/56685224/93410756-8a950a80-f8d4-11ea-8c25-5937bec5bddc.png)

## GitHubアカウントがあるユーザー(jobseeker)
- ダッシュボード
[![image](https://user-images.githubusercontent.com/56685224/93410896-de9fef00-f8d4-11ea-8d61-8b7137f0767c.png)](https://user-images.githubusercontent.com/56685224/93410896-de9fef00-f8d4-11ea-8d61-8b7137f0767c.png)

- ユーザーページ
[![image](https://user-images.githubusercontent.com/56685224/93410962-0727e900-f8d5-11ea-9cc4-703e4eac034a.png)](https://user-images.githubusercontent.com/56685224/93410962-0727e900-f8d5-11ea-9cc4-703e4eac034a.png)

