### PR TITLE
席予約一覧をコメントアウト

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -50,7 +50,7 @@ nav.global-nav
             .global-nav-links__link-icon
               i.fas.fa-file
             .global-nav-links__link-label Docs
-        li.global-nav-links__item
+        / li.global-nav-links__item
           = link_to "/reservation_calenders", class: "global-nav-links__link #{current_link /^reservation_calenders/}" do
             .global-nav-links__link-icon
               i.fas.fa-chair


### PR DESCRIPTION
#1887 の作業です。
席予約のリンクをコメントアウトしました。

PC
<img width="380" alt="スクリーンショット 2020-09-17 13 20 29" src="https://user-images.githubusercontent.com/2003287/93422786-888c7500-f8ef-11ea-907d-5dbf51f2571b.png">

モバイル
<img width="362" alt="スクリーンショット 2020-09-17 13 20 56" src="https://user-images.githubusercontent.com/2003287/93422802-90e4b000-f8ef-11ea-8356-5f0d31e592f8.png">
