### PR TITLE
メンションの通知メールにメンションの詳細が表示されるように変更。

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -41,7 +41,7 @@ class NotificationMailer < ApplicationMailer
   def mentioned
     @user = @receiver
     @notification = @user.notifications.find_by(path: @mentionable.path)
-    subject = "[bootcamp] #{@mentionable.sender.login_name}さんからメンションがきました。"
+    subject = "[bootcamp] #{@mentionable.where_mention}で#{@mentionable.sender.login_name}さんからメンションがありました。"
     mail to: @user.email, subject: subject
   end
 

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -14,12 +14,19 @@ module Mentioner
     User.where(login_name: names)
   end
 
-  def body
+  def where_mention
     case self
     when Product
-      self[:body]
-    else
-      self[:description]
+      "#{self.user.login_name}さんの「#{self.practice[:title]}」の提出物"
+    when Report
+      "#{self.user.login_name}さんの「#{self[:title]}」の日報"
+    when Comment
+
+      "#{self.commentable.user.login_name}さんの#{self.commentable.title}のコメント"
     end
+  end
+
+  def body
+    self[:body] || self[:description]
   end
 end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -21,7 +21,6 @@ module Mentioner
     when Report
       "#{self.user.login_name}さんの「#{self[:title]}」の日報"
     when Comment
-
       "#{self.commentable.user.login_name}さんの#{self.commentable.title}のコメント"
     end
   end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -15,7 +15,8 @@ module Mentioner
   end
 
   def body
-    if respond_to? :body
+    case self
+    when Product
       self[:body]
     else
       self[:description]

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -19,13 +19,25 @@ module Mentioner
     when Product
       "#{self.user.login_name}さんの「#{self.practice[:title]}」の提出物"
     when Report
-      "#{self.user.login_name}さんの「#{self[:title]}」の日報"
+      "#{self.user.login_name}さんの日報「#{self[:title]}」"
     when Comment
-      "#{self.commentable.user.login_name}さんの#{self.commentable.title}のコメント"
+      select_message(self.commentable.class, self.commentable) + "へのコメント"
     end
   end
 
   def body
     self[:body] || self[:description]
   end
+
+  private
+
+    def select_message(commentable_class, commentable)
+      {
+        Report: "#{commentable.user.login_name}さんの日報「#{self.commentable.title}」",
+        Product: "#{commentable.user.login_name}さんの#{self.commentable.title}",
+        Event: "イベント「#{commentable.title}」",
+        Page: "Docs「#{commentable.title}」",
+        Announcement: "お知らせ「#{commentable.title}」"
+      }[:"#{commentable_class}"]
+    end
 end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -21,7 +21,7 @@ module Mentioner
     when Report
       "#{self.user.login_name}さんの日報「#{self[:title]}」"
     when Comment
-      select_message(self.commentable.class, self.commentable) + "へのコメント"
+      target_of_comment(self.commentable.class, self.commentable) + "へのコメント"
     end
   end
 
@@ -31,10 +31,10 @@ module Mentioner
 
   private
 
-    def select_message(commentable_class, commentable)
+    def target_of_comment(commentable_class, commentable)
       {
-        Report: "#{commentable.user.login_name}さんの日報「#{self.commentable.title}」",
-        Product: "#{commentable.user.login_name}さんの#{self.commentable.title}",
+        Report: "#{commentable.user.login_name}さんの日報「#{commentable.title}」",
+        Product: "#{commentable.user.login_name}さんの#{commentable.title}",
         Event: "イベント「#{commentable.title}」",
         Page: "Docs「#{commentable.title}」",
         Announcement: "お知らせ「#{commentable.title}」"

--- a/app/views/notification_mailer/mentioned.html.slim
+++ b/app/views/notification_mailer/mentioned.html.slim
@@ -1,2 +1,5 @@
 = render "notification_mailer_template", title: "#{@mentionable.user.login_name}からメンションがありました", link_url: notification_url(@notification), link_text: "このメンションへ" do
-  = simple_format(@mentionable.body)
+  -if @mentionable.body
+    = simple_format(@mentionable.body)
+  -else
+    = simple_format(@mentionable.description)

--- a/app/views/notification_mailer/mentioned.html.slim
+++ b/app/views/notification_mailer/mentioned.html.slim
@@ -1,5 +1,2 @@
 = render "notification_mailer_template", title: "#{@mentionable.user.login_name}さんからメンションがありました", link_url: notification_url(@notification), link_text: "このメンションへ" do
-  -if @mentionable.body
-    = simple_format(@mentionable.body)
-  -else
-    = simple_format(@mentionable.description)
+  = simple_format(@mentionable.body)

--- a/app/views/notification_mailer/mentioned.html.slim
+++ b/app/views/notification_mailer/mentioned.html.slim
@@ -1,4 +1,4 @@
-= render "notification_mailer_template", title: "#{@mentionable.user.login_name}からメンションがありました", link_url: notification_url(@notification), link_text: "このメンションへ" do
+= render "notification_mailer_template", title: "#{@mentionable.user.login_name}さんからメンションがありました", link_url: notification_url(@notification), link_text: "このメンションへ" do
   -if @mentionable.body
     = simple_format(@mentionable.body)
   -else

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -56,7 +56,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ["noreply@bootcamp.fjord.jp"], email.from
     assert_equal ["sotugyou@example.com"], email.to
-    assert_equal "[bootcamp] komagataさんからメンションがきました。", email.subject
+    assert_equal "[bootcamp] sotugyouさんの日報「学習週1日目」へのコメントでkomagataさんからメンションがありました。", email.subject
     assert_match %r{メンション}, email.body.to_s
   end
 


### PR DESCRIPTION
ref #1726 
## 変更点
- メンションの通知メールの件名で、メンションの詳細を表示するようにしました。
- メンションの通知メールの本文で、メンションが含まれる文章を表示するようにしました。

## 提出物本文中にメンションがあった場合
### 提出物
[![image](https://user-images.githubusercontent.com/56685224/93702823-49119300-fb52-11ea-9a00-2a9541cbe911.png)](https://user-images.githubusercontent.com/56685224/93702823-49119300-fb52-11ea-9a00-2a9541cbe911.png)

### メール
[![image](https://user-images.githubusercontent.com/56685224/93702952-53339180-fb52-11ea-9aa1-34e9001f6c32.png)](https://user-images.githubusercontent.com/56685224/93702952-53339180-fb52-11ea-9aa1-34e9001f6c32.png)


## コメントにメンションがあった場合
### コメント
[![image](https://user-images.githubusercontent.com/56685224/93703588-9d1c7780-fb52-11ea-9c67-2031ed77f381.png)](https://user-images.githubusercontent.com/56685224/93703588-9d1c7780-fb52-11ea-9c67-2031ed77f381.png)

### メール
[![image](https://user-images.githubusercontent.com/56685224/93704320-db199b80-fb52-11ea-9600-79d85b6e61eb.png)](https://user-images.githubusercontent.com/56685224/93704320-db199b80-fb52-11ea-9600-79d85b6e61eb.png)

## 日報本文内にメンションがあった場合
### 日報
[![image](https://user-images.githubusercontent.com/56685224/93704792-174cfc00-fb53-11ea-8039-2aeb02de31b9.png)](https://user-images.githubusercontent.com/56685224/93704792-174cfc00-fb53-11ea-8039-2aeb02de31b9.png)

### メール
[![image](https://user-images.githubusercontent.com/56685224/93704899-2df35300-fb53-11ea-8118-274593610f11.png)](https://user-images.githubusercontent.com/56685224/93704899-2df35300-fb53-11ea-8118-274593610f11.png)
