### PR TITLE
Fixtureに「何かのプラクティスに着手中」のユーザーを2名作成

### DIFF
--- a/test/fixtures/learnings.yml
+++ b/test/fixtures/learnings.yml
@@ -60,3 +60,13 @@ learning_11:
   status: "complete"
   created_at: "2020-04-22 14:05:53.782503"
   updated_at: "2020-04-22 14:05:53.782503"
+
+learning_12:
+  user: hajime
+  practice: practice_1
+  status: "started"
+
+learning_13:
+  user: kananashi
+  practice: practice_3
+  status: "started"


### PR DESCRIPTION
ref #1880 

# 概要
Fixtureに管理者やアドバイザー以外の「何かのプラクティスに着手中のユーザー」を2名作成しました。
対象ユーザーは`hajime`と`kananashi`です。
# ローカルでの画面(hajimeでログイン)
## プラクティス一覧画面
[![image](https://user-images.githubusercontent.com/56685224/93735332-8d1a9b80-fc17-11ea-9d75-ed71d954517f.png)](https://user-images.githubusercontent.com/56685224/93735332-8d1a9b80-fc17-11ea-9d75-ed71d954517f.png)

## プロフィールページ
### hajime
<img width="852" alt="hajimeのプロフィール___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/56685224/93735410-c6530b80-fc17-11ea-8262-6eafcca37abb.png">

### kananashi
<img width="850" alt="kananashiのプロフィール___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/56685224/93735485-f8fd0400-fc17-11ea-8e2e-f1d60c9c9967.png">
