### PR TITLE
ユーザーの最終アクセス日時をプロフィール画面に表示したい

### DIFF
--- a/app/assets/stylesheets/blocks/user/_user-profile.sass
+++ b/app/assets/stylesheets/blocks/user/_user-profile.sass
@@ -30,7 +30,7 @@
   +word-wrap
 
 .user-profile__full-name
-  +text-block(.875rem 1.45 0 .625rem, 400)
+  +text-block(.875rem 1.45 0 .125rem, 400)
 
 .user-profile__kana-full-name
   color: $muted-text

--- a/app/assets/stylesheets/blocks/user/_user-secret-attributes.sass
+++ b/app/assets/stylesheets/blocks/user/_user-secret-attributes.sass
@@ -1,14 +1,35 @@
 .user-secret-attributes
   font-size: .75rem
+  border: solid 1px $border
+  padding: .75em 1em
   &:not(:first-child)
     margin-top: .25em
+
+.user-secret-attributes__title
+  +text-block(.75rem 1.4, 700)
+  margin-bottom: .25em
 
 .user-secret-attributes__items
   display: flex
   flex-wrap: wrap
+  color: $muted-text
+  & + .user-secret-attributes__items
+    margin-top: .125rem
 
 .user-secret-attributes__item
   line-height: 1.4
+  display: flex
+  align-items: center
   &:not(:first-child)
     &::before
       content: "、"
+
+.user-secret-attributes__item-label
+  &::after
+    content: ":"
+    margin-right: .25rem
+
+.user-secret-attributes__item-value
+  &.is-important
+    font-weight: 700
+    color: $danger

--- a/app/assets/stylesheets/blocks/user/_users-item-names.sass
+++ b/app/assets/stylesheets/blocks/user/_users-item-names.sass
@@ -12,6 +12,7 @@
 
 .users-item-names__slack
   display: flex
+  align-items: center
 
 .users-item-names__slack-label
   font-size: 1.125em

--- a/app/assets/stylesheets/blocks/user/_users-items.sass
+++ b/app/assets/stylesheets/blocks/user/_users-items.sass
@@ -2,12 +2,11 @@
   padding-bottom: 1.5rem
   height: 100%
 
-.users-item.inactive .a-card
-  background-color: $background-more-tint
-  .users-item__name,
-  .users-item__description,
-  .users-item__user-icon-image
-    opacity: .6
+.users-item__inactive-message
+  background-color: $danger
+  +text-block(.75rem 1.4, center $reversal-text)
+  padding: .25rem
+  margin-bottom: .25rem
 
 .users-item__inner
   height: 100%
@@ -15,6 +14,8 @@
 .users-item__header
   +position(relative)
   padding-left: 3.5rem
+  padding-right: 1rem
+  padding-top: .5rem
   border-bottom: solid 1px $background
   padding-bottom: .5rem
   +media-breakpoint-down(sm)
@@ -33,7 +34,6 @@
 .users-item__name-link
   color: $main
   display: block
-  padding-top: .5rem
   +hover-link
 
 .users-item__user-icon-image

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -373,6 +373,14 @@ SQL
     retired_on?
   end
 
+  def graduated?
+    graduated_on?
+  end
+
+  def student_or_trainee?
+    !staff? && !retired? && !graduated?
+  end
+
   def unread_notifications_count
     @unread_notifications_count ||= notifications.unreads.count
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,6 +186,16 @@ class User < ApplicationRecord
       graduated_on: nil
     )
   }
+  scope :inactive_students_and_trainees, -> {
+    where(
+      updated_at: Date.new..1.month.ago,
+      admin: false,
+      mentor: false,
+      adviser: false,
+      retired_on: nil,
+      graduated_on: nil
+    )
+  }
   scope :year_end_party, -> { where(retired_on: nil) }
   scope :mentor, -> { where(mentor: true) }
   scope :working, -> {

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -45,6 +45,8 @@ header.page-header
             = render "users/github_grass", user: current_user
           - if current_user.mentor?
             = render "users/sad_emotion_report", users: User.students_and_trainees
+          - if current_user.mentor?
+            = render "users/inactive_users", users: User.students_and_trainees
           - if current_user.role == :student
             = render "required_field", user: current_user
           - if current_user.books.present?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -46,7 +46,7 @@ header.page-header
           - if current_user.mentor?
             = render "users/sad_emotion_report", users: User.students_and_trainees
           - if current_user.mentor?
-            = render "users/inactive_users", users: User.students_and_trainees
+            = render "users/inactive_users", users: User.inactive_students_and_trainees
           - if current_user.role == :student
             = render "required_field", user: current_user
           - if current_user.books.present?

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -1,4 +1,4 @@
-- if users.any? { |user| !user.active? }
+- if users.present?
   .a-card
     header.card-header
       h2.card-header__title
@@ -6,17 +6,16 @@
     .card-list
       ul.card-list__items
         - users.each do |user|
-          - unless user.active?
-            li.card-list__item
-              .thread-list-item
-                .thread-list-item__inner
-                  .thread-list-item__author
-                    = render "users/icon", user: user, link_class: "thread-header__author", image_class: "thread-list-item__author-icon"
-                  header.thread-list-item__header
-                    h2.thread-list-item__title(itemprop="name")
-                      = link_to user, itemprop: "url", class: "thread-list-item__title-link" do
-                        = user.name
-                    .thread-list-item__header-title-container
-                  .thread-list-item-meta
-                    time.thread-list-item-meta__updated-at
-                      = l user.updated_at
+          li.card-list__item
+            .thread-list-item
+              .thread-list-item__inner
+                .thread-list-item__author
+                  = render "users/icon", user: user, link_class: "thread-header__author", image_class: "thread-list-item__author-icon"
+                header.thread-list-item__header
+                  h2.thread-list-item__title(itemprop="name")
+                    = link_to user, itemprop: "url", class: "thread-list-item__title-link" do
+                      = user.name
+                  .thread-list-item__header-title-container
+                .thread-list-item-meta
+                  time.thread-list-item-meta__updated-at
+                    = l user.updated_at

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -1,0 +1,23 @@
+- if users.any? { |user| !user.active? }
+  .a-card
+    header.card-header
+      h2.card-header__title
+        | 1ヶ月以上ログインのないユーザー
+    .card-list
+      ul.card-list__items
+        - users.each do |user|
+          - unless user.active?
+            li.card-list__item
+              .thread-list-item
+                .thread-list-item__inner
+                  .thread-list-item__author
+                    = render "users/icon", user: user, link_class: "thread-header__author", image_class: "thread-list-item__author-icon"
+                  header.thread-list-item__header
+                    h2.thread-list-item__title(itemprop="name")
+                      = link_to user, itemprop: "url", class: "thread-list-item__title-link" do
+                        = user.full_name
+                    .thread-list-item__header-title-container
+                  .thread-list-item-meta
+                    .thread-list-item-meta__items
+                      .thread-list-item-meta__item
+                        = l user.updated_at

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -18,6 +18,5 @@
                         = user.full_name
                     .thread-list-item__header-title-container
                   .thread-list-item-meta
-                    .thread-list-item-meta__items
-                      .thread-list-item-meta__item
-                        = l user.updated_at
+                    time.thread-list-item-meta__updated-at
+                      = l user.updated_at

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -15,7 +15,7 @@
                   header.thread-list-item__header
                     h2.thread-list-item__title(itemprop="name")
                       = link_to user, itemprop: "url", class: "thread-list-item__title-link" do
-                        = user.full_name
+                        = user.name
                     .thread-list-item__header-title-container
                   .thread-list-item-meta
                     time.thread-list-item-meta__updated-at

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -18,4 +18,6 @@
                   .thread-list-item__header-title-container
                 .thread-list-item-meta
                   time.thread-list-item-meta__updated-at
+                    = User.human_attribute_name :updated_at
+                    | :&nbsp;
                     = l user.updated_at

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -8,11 +8,12 @@
         | &nbsp;#{user.elapsed_days}日目&nbsp;
         = link_to generation_path(user.generation)
           | #{user.generation}期生
-    .user-metas__item
-      .user-metas__item-label
-        = User.human_attribute_name :updated_at
-      .user-metas__item-value
-        = l user.updated_at
+    - if current_user.mentor?
+      .user-metas__item
+        .user-metas__item-label
+          = User.human_attribute_name :updated_at
+        .user-metas__item-value(class="#{"is-important" unless user.active?}")
+          = l user.updated_at
     .user-metas__item
       .user-metas__item-label
         | 都道府県

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -8,12 +8,6 @@
         | &nbsp;#{user.elapsed_days}日目&nbsp;
         = link_to generation_path(user.generation)
           | #{user.generation}期生
-    - if current_user.mentor?
-      .user-metas__item
-        .user-metas__item-label
-          = User.human_attribute_name :updated_at
-        .user-metas__item-value(class="#{"is-important" unless user.active?}")
-          = l user.updated_at
     .user-metas__item
       .user-metas__item-label
         | 都道府県

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -10,6 +10,16 @@
       = user.name
       span.user-profile__kana-full-name
         = user.name_kana
+    ul.users-item-names
+      li.users-item-names__item
+        .users-item-names__slack
+          .users-item-names__slack-label
+            i.fab.fa-slack
+          .users-item-names__slack-value
+            - if user.slack_account.present?
+              = user.slack_account
+            - else
+              | Slack未設定
   = render "users/sns", user: user
   - if user.company.present? && user.company.logo.attached?
     = link_to company_path(user.company) do

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -1,5 +1,5 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .users-item(class="#{"active" if user.active?}")
+  .users-item
     .users-item__inner.a-card
       header.users-item__header
         .users-item__header-container

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -1,8 +1,11 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .users-item(class="#{user.active? ? "active" : "inactive"}")
+  .users-item(class="#{"active" if user.active?}")
     .users-item__inner.a-card
       header.users-item__header
         .users-item__header-container
+          - if current_user.mentor? && !user.active?
+            .users-item__active-message
+              | 1ヶ月ログインがありません
           .users-item__name
             = link_to user, class: "users-item__name-link" do
               - if user.daimyo?

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -4,7 +4,7 @@
       header.users-item__header
         .users-item__header-container
           - if current_user.mentor? && !user.active?
-            .users-item__active-message
+            .users-item__inactive-message
               | 1ヶ月ログインがありません
           .users-item__name
             = link_to user, class: "users-item__name-link" do

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -3,7 +3,7 @@
     .users-item__inner.a-card
       header.users-item__header
         .users-item__header-container
-          - if current_user.mentor? && !user.active?
+          - if current_user.mentor? && user.student_or_trainee? && !user.active?
             .users-item__inactive-message
               | 1ヶ月ログインがありません
           .users-item__name

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -1,31 +1,32 @@
-- if current_user.admin? && user.student?
+- if current_user.mentor? && user.student_or_trainee?
   .user-secret-attributes
     .user-secret-attributes__title
       | メンターだけが見れる情報
-    .user-secret-attributes__items
-      .user-secret-attributes__item
-        - if user.job_seeker
-          | 就職を希望
-        - else
-          | 就職を希望しない
-      - if user.card?
+    - if user.student?
+      .user-secret-attributes__items
         .user-secret-attributes__item
-          | 有料ユーザー
-      - if user.free
-        .user-secret-attributes__item
-          | 無料ユーザー
-      - if user.job
-        .user-secret-attributes__item
-          = user.job
-      - if user.os
-        .user-secret-attributes__item
-          = user.os
-      - if user.experience
-        .user-secret-attributes__item
-          = user.experience
-      - if user.experience
-        .user-secret-attributes__item
-          = user.email
+          - if user.job_seeker
+            | 就職を希望
+          - else
+            | 就職を希望しない
+        - if user.card?
+          .user-secret-attributes__item
+            | 有料ユーザー
+        - if user.free
+          .user-secret-attributes__item
+            | 無料ユーザー
+        - if user.job
+          .user-secret-attributes__item
+            = user.job
+        - if user.os
+          .user-secret-attributes__item
+            = user.os
+        - if user.experience
+          .user-secret-attributes__item
+            = user.experience
+        - if user.experience
+          .user-secret-attributes__item
+            = user.email
     .user-secret-attributes__items
       .user-secret-attributes__item
         .user-secret-attributes__item-label

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -1,15 +1,19 @@
 - if current_user.admin? && user.student?
   .user-secret-attributes
+    .user-secret-attributes__title
+      | メンターだけが見れる情報
     .user-secret-attributes__items
-      - if user.job_seeker
-        .user-secret-attributes__item
-          | 就職希望
+      .user-secret-attributes__item
+        - if user.job_seeker
+          | 就職を希望
+        - else
+          | 就職を希望しない
       - if user.card?
         .user-secret-attributes__item
-          | 課金
+          | 有料ユーザー
       - if user.free
         .user-secret-attributes__item
-          | 無料
+          | 無料ユーザー
       - if user.job
         .user-secret-attributes__item
           = user.job
@@ -19,6 +23,12 @@
       - if user.experience
         .user-secret-attributes__item
           = user.experience
-      - unless user.prefecture_code.nil?
+      - if user.experience
         .user-secret-attributes__item
-          = user.prefecture_name
+          = user.email
+    .user-secret-attributes__items
+      .user-secret-attributes__item
+        .user-secret-attributes__item-label
+          = User.human_attribute_name :updated_at
+        .user-secret-attributes__item-value(class="#{"is-important" unless user.active?}")
+          = l user.updated_at

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -65,7 +65,7 @@ ja:
         organization: 現在の所属組織
         company: 会社
         created_at: 開始日
-        updated_at: 最終活動日時
+        updated_at: 最終ログイン日時
         nda: 秘密保持契約
         graduated_on: 卒業日
         adviser: アドバイザー

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -98,6 +98,10 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test "show last active date only to mentors" do
+    travel_to Time.new(2014, 1, 1, 0, 0, 0) do
+      login_user "kimura", "testtest"
+    end
+
     login_user "komagata", "testtest"
 
     visit "/users/#{users(:kimura).id}"
@@ -111,5 +115,21 @@ class UsersTest < ApplicationSystemTestCase
     login_user "hatsuno", "testtest"
     visit "/users/#{users(:hatsuno).id}"
     assert_no_text "最終ログイン日時"
+  end
+
+  test "show inactive message on users page" do
+    travel_to Time.new(2014, 1, 1, 0, 0, 0) do
+      login_user "kimura", "testtest"
+    end
+
+    login_user "komagata", "testtest"
+    visit "/users"
+    assert_no_selector "div.users-item.inactive"
+    assert_text "1ヶ月ログインがありません"
+
+    login_user "hatsuno", "testtest"
+    visit "/users"
+    assert_no_selector "div.users-item.inactive"
+    assert_no_text "1ヶ月ログインがありません"
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -96,4 +96,20 @@ class UsersTest < ApplicationSystemTestCase
     visit "/"
     assert_no_text "予約しています"
   end
+
+  test "show last active date only to mentors" do
+    login_user "komagata", "testtest"
+
+    visit "/users/#{users(:kimura).id}"
+    assert_text "最終ログイン日時"
+    assert_selector "div.user-metas__item-value.is-important"
+
+    visit "/users/#{users(:komagata).id}"
+    assert_text "最終ログイン日時"
+    assert_no_selector "div.user-metas__item-value.is-important"
+
+    login_user "hatsuno", "testtest"
+    visit "/users/#{users(:hatsuno).id}"
+    assert_no_text "最終ログイン日時"
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -103,17 +103,11 @@ class UsersTest < ApplicationSystemTestCase
     end
 
     login_user "komagata", "testtest"
-
     visit "/users/#{users(:kimura).id}"
     assert_text "最終ログイン日時"
-    assert_selector "div.user-metas__item-value.is-important"
-
-    visit "/users/#{users(:komagata).id}"
-    assert_text "最終ログイン日時"
-    assert_no_selector "div.user-metas__item-value.is-important"
 
     login_user "hatsuno", "testtest"
-    visit "/users/#{users(:hatsuno).id}"
+    visit "/users/#{users(:kimura).id}"
     assert_no_text "最終ログイン日時"
   end
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -132,4 +132,34 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_selector "div.users-item.inactive"
     assert_no_text "1ヶ月ログインがありません"
   end
+
+  test "show inactive users only to mentors" do
+    travel_to Date.current do
+      login_user "kimura", "testtest"
+      login_user "hatsuno", "testtest"
+      login_user "hajime", "testtest"
+      login_user "muryou", "testtest"
+      login_user "kensyu", "testtest"
+      login_user "kananashi", "testtest"
+      login_user "osnashi", "testtest"
+      login_user "jobseeker", "testtest"
+      login_user "daimyo", "testtest"
+    end
+
+    login_user "komagata", "testtest"
+    visit "/"
+    assert_no_text "1ヶ月以上ログインのないユーザー"
+
+    travel_to Time.new(2020, 1, 1, 0, 0, 0) do
+      login_user "kimura", "testtest"
+    end
+
+    login_user "komagata", "testtest"
+    visit "/"
+    assert_text "1ヶ月以上ログインのないユーザー"
+
+    login_user "hatsuno", "testtest"
+    visit "/"
+    assert_no_text "1ヶ月以上ログインのないユーザー"
+  end
 end


### PR DESCRIPTION
#1893 の作業です。

以下の3つを実装しました。

1. ユーザープロフィールの最終活動日時の表示を変更
2. ユーザー一覧の最終活動日時の表示を変更
3. メンターのダッシュボードに、1ヶ月以上ログインのないユーザー一覧を追加

## 1. ユーザープロフィールの最終活動日時の表示を変更

- 「最終活動日時」を「最終ログイン日時」に文言変更しました。
- 「メンターだけに表示される情報」を追加しました。

#### メンターの場合

<img width="300" alt="スクリーンショット 2020-10-23 0 28 13" src="https://user-images.githubusercontent.com/2003287/96896281-4941dd00-14c8-11eb-90c4-d5425c6f8572.png">

#### その他ユーザの場合

最終ログイン日時などの情報は表示されません。

<img width="300" alt="スクリーンショット 2020-10-23 0 27 57" src="https://user-images.githubusercontent.com/2003287/96896482-83ab7a00-14c8-11eb-959e-66a7b0d67c9c.png">


## 2. ユーザー一覧の最終活動日時の表示を変更

- ユーザー一覧のclass属性から`active`/`inactive`を削除しました。
- メンターの場合に「メンターだけに表示される情報」と「1ヶ月ログインがありません」を表示します。

#### メンターの場合

<img width="600" alt="スクリーンショット 2020-10-23 0 01 33" src="https://user-images.githubusercontent.com/2003287/96896661-be151700-14c8-11eb-91a9-dbc070d1c566.png">

#### その他ユーザの場合

<img width="600" alt="スクリーンショット 2020-10-23 0 33 46" src="https://user-images.githubusercontent.com/2003287/96896685-c5d4bb80-14c8-11eb-969c-ecf44d6e8861.png">


## 3. メンターのダッシュボードに、1ヶ月以上ログインのないユーザー一覧を追加

#### PC

<img width="600" alt="スクリーンショット 2020-10-23 0 17 25" src="https://user-images.githubusercontent.com/2003287/96896814-edc41f00-14c8-11eb-8742-d01810a164ae.png">

#### スマホ

<img width="250" alt="スクリーンショット 2020-10-23 0 44 05" src="https://user-images.githubusercontent.com/2003287/96896837-f4529680-14c8-11eb-9014-0f7637421abf.png">
