### PR TITLE
メンターメモを提出物個別ページにも表示できるようにした

### DIFF
--- a/app/assets/stylesheets/blocks/practice/_practice-content.sass
+++ b/app/assets/stylesheets/blocks/practice/_practice-content.sass
@@ -7,9 +7,13 @@
   align-items: flex-start
   &:not(:first-child)
     margin-top: 2rem
+  &.is-admin
+    max-width: 100%
 
 .practice-contents__inner
   flex: 100
+  .practice-contents.is-admin &
+    max-width: 50rem
 
 .practice-contents__header
   border-bottom: solid 1px $background-shade
@@ -26,6 +30,10 @@
   position: relative
   display: block
   margin-bottom: 2rem
+  &.is-memo
+    height: calc(100vh - 4.25rem)
+    +position(sticky, top 3.5rem)
+    margin-bottom: 0
 
 .practice-content__title
   +text-block(1rem 1.4, 600)
@@ -42,11 +50,14 @@
     +hover-link
     cursor: pointer
 
-
 .practice-content__body
   padding: 1.25rem
   +media-breakpoint-down(sm)
     padding: .5rem .75rem
+  .practice-content.is-memo &
+    max-height: calc(100% - 2.75rem)
+    overflow-y: auto
+    padding: 1rem 1.25rem
 
 .practice-content__body-alert
   border: solid 2px $danger

--- a/app/assets/stylesheets/shared/_base.sass
+++ b/app/assets/stylesheets/shared/_base.sass
@@ -24,7 +24,7 @@ body
 .wrapper
   +margin(horizontal, 5rem 14rem)
   //overflow-y: scroll
-  height: 100vh
+  min-height: 100vh
   scroll-behavior: smooth
   -webkit-overflow-scrolling: touch
   +media-breakpoint-down(lg)

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -85,7 +85,7 @@ header.page-header
                 br
                 | 終了条件をクリアしたら完了にしてください。
 
-        - if @practice.memo? && (current_user.mentor? || current_user.admin?)
+        - if current_user.mentor? || current_user.admin?
           section.practice-content.a-card
             header.practice-content__header.card-header
               h2.practice-content__title

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -1,4 +1,5 @@
 - title "#{@product.practice.title}の提出物"
+- content_for(:extra_body_classes, "no-recent-reports")
 
 header.page-header
   .container
@@ -19,62 +20,65 @@ header.page-header
 
 .page-body
   .container
-    .thread
-      .thread__inner.a-card
-        header.thread-header
-          .thread-header__upper-side
-            = link_to @product.user, class: "thread-header__author" do
-              = @product.user.login_name
-            .thread-header__date
-              time.thread-header__date-value(datetime="#{@product.updated_at.to_datetime}" pubdate="pubdate")
-                = l @product.updated_at
-          h1.thread-header__title(class="#{@product.wip? ? "is-wip" : ""}")
-            - if @product.wip?
-              span.thread-header__title-icon
-                | WIP
-            - if @product.user.daimyo?
-              | ★
-            | #{link_to @product.practice.title, @product.practice, class: "thread-header__title-link"}の提出物
-          .thread-header__lower-side
-            #js-watch(data-watchable-id="#{@product.id}", data-watchable-type="Product")
-            .thread-header__raw
-              = link_to "Raw", product_path(format: :md), class: "a-button is-sm is-secondary", target: "_blank"
-        #js-check-stamp(data-checkable-id="#{@product.id}" data-checkable-type="Product")
-        .thread__description.js-target-blank.is-long-text.js-markdown-view
-          =  @product.practice.goal
-        .thread__description.js-target-blank.is-long-text.js-markdown-view
-          =  @product.body
-        = render "reactions/reactions", reactionable: @product
-        - if @product.user == current_user || admin_login?
-          .card-footer
-            .card-footer-actions
-              ul.card-footer-actions__items
-                li.card-footer-actions__item
-                  = link_to edit_product_path(@product), class: "card-footer-actions_action a-button is-md is-primary is-block" do
-                    i.fas.fa-pen
-                    | 内容修正
-                li.card-footer-actions__item
-                  = link_to @product, data: { confirm: "本当によろしいですか？" }, method: :delete, class: "card-footer-actions__action a-button is-md is-danger is-block" do
-                    i.fas.fa-trash-alt
-                    | 削除
+    div(class="#{current_user.mentor? || current_user.admin? ? "row" : ""}")
+      div(class="#{current_user.mentor? || current_user.admin? ? "col-md-7 col-xs-12" : ""}")
+        .thread
+          .thread__inner.a-card
+            header.thread-header
+              .thread-header__upper-side
+                = link_to @product.user, class: "thread-header__author" do
+                  = @product.user.login_name
+                .thread-header__date
+                  time.thread-header__date-value(datetime="#{@product.updated_at.to_datetime}" pubdate="pubdate")
+                    = l @product.updated_at
+              h1.thread-header__title(class="#{@product.wip? ? "is-wip" : ""}")
+                - if @product.wip?
+                  span.thread-header__title-icon
+                    | WIP
+                - if @product.user.daimyo?
+                  | ★
+                | #{link_to @product.practice.title, @product.practice, class: "thread-header__title-link"}の提出物
+              .thread-header__lower-side
+                #js-watch(data-watchable-id="#{@product.id}", data-watchable-type="Product")
+                .thread-header__raw
+                  = link_to "Raw", product_path(format: :md), class: "a-button is-sm is-secondary", target: "_blank"
+            #js-check-stamp(data-checkable-id="#{@product.id}" data-checkable-type="Product")
+            .thread__description.js-target-blank.is-long-text.js-markdown-view
+              =  @product.practice.goal
+            .thread__description.js-target-blank.is-long-text.js-markdown-view
+              =  @product.body
+            = render "reactions/reactions", reactionable: @product
+            - if @product.user == current_user || admin_login?
+              .card-footer
+                .card-footer-actions
+                  ul.card-footer-actions__items
+                    li.card-footer-actions__item
+                      = link_to edit_product_path(@product), class: "card-footer-actions_action a-button is-md is-primary is-block" do
+                        i.fas.fa-pen
+                        | 内容修正
+                    li.card-footer-actions__item
+                      = link_to @product, data: { confirm: "本当によろしいですか？" }, method: :delete, class: "card-footer-actions__action a-button is-md is-danger is-block" do
+                        i.fas.fa-trash-alt
+                        | 削除
 
-        - if admin_login? || adviser_login?
-          #js-check(data-checkable-id="#{@product.id}" data-checkable-type="Product" data-checkable-label="#{Product.model_name.human}")
+            - if admin_login? || adviser_login?
+              #js-check(data-checkable-id="#{@product.id}" data-checkable-type="Product" data-checkable-label="#{Product.model_name.human}")
 
-      .thread-prev-next
-        .thread-prev-next__item
-          = link_to @product.practice, class: "thread-prev-next__item-link is-index" do
-            | プラクティスに戻る
+          .thread-prev-next
+            .thread-prev-next__item
+              = link_to @product.practice, class: "thread-prev-next__item-link is-index" do
+                | プラクティスに戻る
 
-      - if current_user.mentor? || current_user.admin?
-        section.practice-content.a-card
-          header.practice-content__header.card-header
-            h2.practice-content__title
-            = Practice.human_attribute_name :memo
-          .practice-content__body.is-memo
-            .js-markdown-view.js-target-blank.is-long-text
-              = @product.practice.memo
+          = render "users/icon", user: @product.user, link_class: "thread__author-link", image_class: "thread__author-icon"
+        #js-comments(data-commentable-id="#{@product.id}" data-commentable-type="Product" data-current-user-id="#{current_user.id}")
+        = render "footprints/footprints", footprints: @footprints
 
-      = render "users/icon", user: @product.user, link_class: "thread__author-link", image_class: "thread__author-icon"
-    #js-comments(data-commentable-id="#{@product.id}" data-commentable-type="Product" data-current-user-id="#{current_user.id}")
-    = render "footprints/footprints", footprints: @footprints
+      div(class="#{current_user.mentor? || current_user.admin? ? "col-md-5 col-xs-12 is-hidden-sm-down" : ""}")
+        - if current_user.mentor? || current_user.admin?
+          section.practice-content.is-memo.a-card
+            header.practice-content__header.card-header
+              h2.practice-content__title
+                = Practice.human_attribute_name :memo
+            .practice-content__body
+              .js-markdown-view.js-target-blank.is-long-text
+                = @product.practice.memo

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -66,6 +66,15 @@ header.page-header
           = link_to @product.practice, class: "thread-prev-next__item-link is-index" do
             | プラクティスに戻る
 
+      - if current_user.mentor? || current_user.admin?
+        section.practice-content.a-card
+          header.practice-content__header.card-header
+            h2.practice-content__title
+            = Practice.human_attribute_name :memo
+          .practice-content__body.is-memo
+            .js-markdown-view.js-target-blank.is-long-text
+              = @product.practice.memo
+
       = render "users/icon", user: @product.user, link_class: "thread__author-link", image_class: "thread__author-icon"
     #js-comments(data-commentable-id="#{@product.id}" data-commentable-type="Product" data-current-user-id="#{current_user.id}")
     = render "footprints/footprints", footprints: @footprints

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -2,7 +2,7 @@ practice_1:
   title: "OS X Mountain Lionをクリーンインストールする"
   description: "description..."
   goal: "OS X Mountain Lionをクリーンインストールする"
-  memo: "memo for mentors..."
+  memo: "「OS X Mountain Lionをクリーンインストールする」のメンターメモ"
   category: category_2
   position: 1
   submission: true

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -64,13 +64,17 @@ class PracticesTest < ApplicationSystemTestCase
   test "update practice" do
     login_user "komagata", "testtest"
     practice = practices(:practice_2)
+    product = products(:product_3)
     visit "/practices/#{practice.id}/edit"
     within "form[name=practice]" do
       fill_in "practice[title]", with: "テストプラクティス"
+      fill_in "practice[memo]", with: "メンター向けのメモの内容です"
       click_button "更新する"
     end
     assert_text "プラクティスを更新しました"
     assert_equal "UNIX", Practice.find(practice.id).category.name
+    visit "/products/#{product.id}"
+    assert_text "メンター向けのメモの内容です"
   end
 
   test "category button link to courses/practices#index with category fragment" do


### PR DESCRIPTION
ref #1903 
## 概要
- プラクティス詳細ページに表示しているメンターメモを提出物個別ページでも表示するように変更しました。
- こちらのレビュー完了後に #1904 に対応して本番環境にリリースするため、メンターメモが空でも表示するように変更しました。
## プラクティス詳細画面
<img width="773" alt="OS_X_Mountain_Lionをクリーンインストールする___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/56685224/94096034-102d3300-fe5e-11ea-90f9-14eb37b65167.png">

## 上記プラクティスの提出物個別ページ(町田さんのデザイン後)
[![image](https://user-images.githubusercontent.com/56685224/94100305-47084680-fe68-11ea-9f44-a4bc28abf68d.png)](https://user-images.githubusercontent.com/56685224/94100305-47084680-fe68-11ea-9f44-a4bc28abf68d.png)

