### PR TITLE
mentorへのメンション記法を追加

### DIFF
--- a/app/javascript/markdown-it-mention.js
+++ b/app/javascript/markdown-it-mention.js
@@ -1,7 +1,7 @@
 import MarkdownItRegexp from 'markdown-it-regexp'
 
 export default MarkdownItRegexp(
-  /@([a-zA-Z0-9_-]+)/,
+  /@(?!mentor)([a-zA-Z0-9_-]+)/,
 
   (match, _utils) => {
     return `<a href="/users/${match[1]}">${match[0]}</a>`

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -7,6 +7,14 @@ module Mentioner
         NotificationFacade.mentioned(self, receiver)
       end
     end
+
+    if mentions.include? "@mentor"
+      User.mentor.each do |receiver|
+        if sender != receiver
+          NotificationFacade.mentioned(self, receiver)
+        end
+      end
+    end
   end
 
   def new_mention_users


### PR DESCRIPTION
`@mentor`でメンター全員（本人のぞく）に通知するようにした。