### PR TITLE
application_controllerのinit_userメソッドを修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 
   private
     def init_user
-      @current_user = User.find(current_user.id) if current_user
+      @current_user = current_user
     end
 
     def set_available_emojis


### PR DESCRIPTION
`User.find(current_user.id)`により、下記のように同じSQL文が立て続けに発行されていることがある（プラクティス一覧ページを開いた時など）。

```
[1m[36mUser Load (2.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 301971253], ["LIMIT", 1]]
↳ app/controllers/application_controller.rb:19:in `init_user'
[1m[36mUser Load (6.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 301971253], ["LIMIT", 1]]
↳ app/controllers/application_controller.rb:19:in `init_user'
[1m[36mUser Load (5.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 301971253], ["LIMIT", 1]]
↳ app/controllers/application_controller.rb:19:in `init_user'
[1m[36mUser Load (4.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 301971253], ["LIMIT", 1]]
↳ app/controllers/application_controller.rb:19:in `init_user'
```

そのため`@current_user`に直接`current_user`を代入します。
雑談タイムで質問させていただいた件です、ご確認お願いします。🙇‍♂️