### PR TITLE
足跡のレコードが重複しないようにした

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -64,7 +64,7 @@ class AnnouncementsController < ApplicationController
     end
 
     def footprint!
-      @announcement.footprints.where(user: current_user).first_or_create if @announcement.user != current_user
+      @announcement.footprints.create_or_find_by(user: current_user) if @announcement.user != current_user
     end
 
     def set_footprints

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -71,6 +71,6 @@ class EventsController < ApplicationController
     end
 
     def footprint!
-      @event.footprints.where(user: current_user).first_or_create if @event.user != current_user
+      @event.footprints.create_or_find_by(user: current_user) if @event.user != current_user
     end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -111,7 +111,7 @@ class ProductsController < ApplicationController
 
     def footprint!
       if find_product.user != current_user
-        find_product.footprints.where(user: current_user).first_or_create
+        find_product.footprints.create_or_find_by(user: current_user)
       end
     end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -87,7 +87,7 @@ class ReportsController < ApplicationController
 
   private
     def footprint!
-      @report.footprints.where(user: current_user).first_or_create if @report.user != current_user
+      @report.footprints.create_or_find_by(user: current_user) if @report.user != current_user
     end
 
     def report_params


### PR DESCRIPTION
ref #1814 

## 概要
足跡のレコード作成時に`create_or_find_by`メソッドを用いることで足跡のレコードが重複しないようにしました。
変更前の`first_or_create`メソッドではSQL発行時にSELECTとINSERTの競合が発生する場合があるようで、重複したレコードができてしまっていると考えてこちらの実装を致しました。
## 参考
- [create\_or\_find\_by\(attributes, &block\)](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-create_or_find_by)
- [ruby on rails 3 \- First\_or\_create yet ERROR: duplicate key value violates unique constraint \- Stack Overflow](https://stackoverflow.com/questions/25372334/first-or-create-yet-error-duplicate-key-value-violates-unique-constraint)