### PR TITLE
Learningsテーブルにユニークインデックスを追加

### DIFF
--- a/db/migrate/20200927015349_add_index_to_learnings.rb
+++ b/db/migrate/20200927015349_add_index_to_learnings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToLearnings < ActiveRecord::Migration[6.0]
+  def change
+    add_index :learnings, [:user_id, :practice_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_21_182111) do
+ActiveRecord::Schema.define(version: 2020_09_27_015349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,6 +198,7 @@ ActiveRecord::Schema.define(version: 2020_09_21_182111) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["user_id", "practice_id"], name: "index_learnings_on_user_id_and_practice_id", unique: true
   end
 
   create_table "memos", force: :cascade do |t|


### PR DESCRIPTION
画像のようなバグを引き起こさないようにLearningsテーブルの`user_id`と`practice_id`の組み合わせが一意になるようにインデックスを追加しました。
![image](https://user-images.githubusercontent.com/60137763/94353224-66da7d00-00a9-11eb-8bfb-1c99e0b53172.png)