### PR TITLE
確認済マークがついた日報のコピーボタンを押しやすくする

### DIFF
--- a/app/assets/stylesheets/blocks/report/_stamp.sass
+++ b/app/assets/stylesheets/blocks/report/_stamp.sass
@@ -1,6 +1,7 @@
 .stamp
   border: solid 1px $stamp-color
   border-radius: .75rem
+  pointer-events: none
   +size(4rem 3.5rem)
   +position(absolute, right 0, top -.125rem)
   transform: rotate(25deg)


### PR DESCRIPTION
ref #1806

![pointer-events-none-to-stamp](https://user-images.githubusercontent.com/50437473/94411325-67f7d100-01b3-11eb-8e76-dce2956ef9a1.gif)

@machida さん
確認済スタンプ下のボタンを押しやすくしました。
この方法では、スタンプ下のボタンの有無にかかわらず、スタンプ内のテキストを選択できなくなっています。
雑談タイムで相談させていただいた件です、ご確認お願いします。🙇‍♂️