### PR TITLE
提出物を提出したときと提出物にOKが入った時にプラクティスのステータスを更新するように修正

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -72,11 +72,11 @@ ORDER BY unchecked_products.created_at DESC
   end
 
   def change_learning_status(status)
-    Learning.find_or_initialize_by(
+    learning = Learning.find_or_initialize_by(
       user_id: user.id,
       practice_id: practice.id,
-      status: status
-    ).save
+    )
+    learning.update(status: status)
   end
 
   def last_commented_user

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -23,4 +23,19 @@ class ProductTest < ActiveSupport::TestCase
     product.save!
     assert_not_nil Watch.find_by(user: adviser, watchable: product)
   end
+
+  test "#change_learning_status" do
+    user = users(:kimura)
+    practice = practices(:practice_5)
+    product = Product.create!(
+      body: "test",
+      user: user,
+      practice: practice
+    )
+    assert Learning.find_by(user: user, practice: practice, status: :submitted)
+
+    status = :complete
+    product.change_learning_status(status)
+    assert Learning.find_by(user: user, practice: practice, status: :complete)
+  end
 end


### PR DESCRIPTION
Refs: #1771 #1899

#1211 で作成した機能が動いていなかったため修正しテストを追加した。

## 提出するとステータスが「提出」に変わる
![submit](https://user-images.githubusercontent.com/52617472/94462449-7ddab580-01f6-11eb-8a16-0f09c09dad39.gif)

## 提出物にOKが入るとステータスが「完了」に変わる
![complete](https://user-images.githubusercontent.com/52617472/94464068-e6c32d00-01f8-11eb-8815-4dfce8cc4032.gif)



