### PR TITLE
メンターへのメンションもサジェストされると嬉しい

### DIFF
--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -23,6 +23,7 @@ export default class {
 
     mention.fetchValues(json => {
       mention.values = json
+      mention.values.unshift({ 'login_name': 'mentor', 'name': 'メンター' })
       const collection = [emoji.params(), mention.params()]
       const tribute = new Tribute({
         collection: collection

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -161,4 +161,10 @@ class CommentsTest < ApplicationSystemTestCase
     clip_text = find("#js-new-comment").value
     assert_equal current_url + "#comment_#{comments(:comment_1).id}", clip_text
   end
+
+  test "suggest mention to mentor" do
+    visit "/reports/#{reports(:report_1).id}"
+    find("#js-new-comment").set("@")
+    assert_selector "span.mention", text: "mentor"
+  end
 end


### PR DESCRIPTION
#1934 の作業です。

`@mentor`をサジェストするようにしました。

添付画像は `@m`まで入力した状態ですが、`@`と入力すると一番最初に「メンター」が出るようにしてみました。
<img width="541" alt="スクリーンショット 2020-10-02 22 19 30" src="https://user-images.githubusercontent.com/2003287/94927892-d616fd80-04fd-11eb-8b07-c1ed05d4320f.png">
