### PR TITLE
ユーザーIDに予約語を設定した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   VALID_SORT_COLUMNS = %w(id login_name company_id updated_at created_at report comment asc desc)
   AVATAR_SIZE = "88x88>"
-  RESERVED_LOGIN_NAME = %w(adviser all graduate inactive job_seeking mentor retired student student_and_trainee trainee year_end_party)
+  RESERVED_LOGIN_NAMES = %w(adviser all graduate inactive job_seeking mentor retired student student_and_trainee trainee year_end_party)
 
   enum job: {
     student: 0,
@@ -114,7 +114,7 @@ class User < ApplicationRecord
   validates :mail_notification, inclusion: { in: [true, false] }
   validates :github_id, uniqueness: true, allow_nil: true
 
-  validates_exclusion_of :login_name, in: RESERVED_LOGIN_NAME, message: "に使用できない文字列が含まれています"
+  validates_exclusion_of :login_name, in: RESERVED_LOGIN_NAMES, message: "に使用できない文字列が含まれています"
 
   with_options if: -> { %i[create update].include? validation_context } do
     validates :login_name, presence: true, uniqueness: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   VALID_SORT_COLUMNS = %w(id login_name company_id updated_at created_at report comment asc desc)
   AVATAR_SIZE = "88x88>"
+  RESERVED_LOGIN_NAME = %w(adviser all graduate inactive job_seeking mentor retired student student_and_trainee trainee year_end_party)
 
   enum job: {
     student: 0,
@@ -112,6 +113,8 @@ class User < ApplicationRecord
     }
   validates :mail_notification, inclusion: { in: [true, false] }
   validates :github_id, uniqueness: true, allow_nil: true
+
+  validates_exclusion_of :login_name, in: RESERVED_LOGIN_NAME, message: "に使用できない文字列が含まれています"
 
   with_options if: -> { %i[create update].include? validation_context } do
     validates :login_name, presence: true, uniqueness: true,

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -167,4 +167,32 @@ class SignUpTest < ApplicationSystemTestCase
     visit "/users/new?role=trainee"
     assert has_no_field? "user[job_seeker]", visible: :all
   end
+
+  test "sign up with reserved login name" do
+    WebMock.allow_net_connect!
+
+    visit "/users/new"
+    within "form[name=user]" do
+      fill_in "user[login_name]", with: "mentor"
+      fill_in "user[email]", with: "test-#{SecureRandom.hex(16)}@example.com"
+      fill_in "user[name]", with: "テスト 太郎"
+      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[password]", with: "testtest"
+      fill_in "user[password_confirmation]", with: "testtest"
+      select "学生", from: "user[job]"
+      select "Mac", from: "user[os]"
+      select "自宅", from: "user[study_place]"
+      select "未経験", from: "user[experience]"
+    end
+
+    fill_stripe_element("4242 4242 4242 4242", "12 / 21", "111", "11122")
+
+    click_button "利用規約に同意して参加する"
+    assert_text "に使用できない文字列が含まれています"
+
+    WebMock.disable_net_connect!(
+      allow_localhost: true,
+      allow: "chromedriver.storage.googleapis.com"
+    )
+  end
 end


### PR DESCRIPTION
ref: #1933
メンターへのメンション機能が実装されましたが、万が一 "mentor" というユーザーIDを取得されたら名前が衝突してしまうため、
roleに関係する単語をユーザーIDに使用できないようvalidationを設定しました。

<img src="https://user-images.githubusercontent.com/52617472/94812569-e19cf280-0431-11eb-8c92-287c293d7f31.png" width="300">
