### PR TITLE
メール本文の背景色を白に指定

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -147,7 +147,7 @@
                     <tr>
                       <td style="vertical-align:top;width:600px;">
                 <![endif]-->
-                <div class="mj-column-per-100 outlook-group-fix" style="vertical-align:top; display:inline-block; direction:ltr; font-size:14px; text-align:left; width:100%;">
+                <div class="mj-column-per-100 outlook-group-fix" style="vertical-align:top; display:inline-block; direction:ltr; font-size:14px; text-align:left; width:100%; background-color: white;">
                   <table role="presentation" cellpadding="0" cellspacing="0" style="vertical-align:top;" width="100%"
                     border="0">
                     <tbody>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59789739/94924179-0491da00-04f8-11eb-8742-9704197b81d1.png)
Macのメールアプリでメールを表示したときに、ダークモードだと上のように内容が表示される部分が黒く表示されてしまっていたため、該当箇所のHTMLに白の背景色を追加しました。

開発環境からダークモードでの表示を確認することが困難だったため、町田さんに相談しletter opener上でデベロッパーツールを使用し、背景を黒に設定して表示を確認する方法を取りました。

![image](https://user-images.githubusercontent.com/59789739/94925584-69e6ca80-04fa-11eb-9642-2aab343eee36.png)

結果的に内容表示箇所の背景が黒くなることはありませんでしたが、Macのダークモード上での表示は未検証となっています。

