### PR TITLE
作品ページのユーザー名リンクの遷移先をプロフィールページに修正

### DIFF
--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -22,7 +22,7 @@ header.page-header
             = @work.title
           .thread-header__lower-side
             .thread-header__lower-side-author-name
-              = link_to @work.title, class: "thread-header__lower-side-author-name-link" do
+              = link_to @work.user, class: "thread-header__lower-side-author-name-link" do
                 = @work.user.login_name
             .thread-header__lower-side-date
               .thread-header__lower-side-label

--- a/test/system/works_test.rb
+++ b/test/system/works_test.rb
@@ -18,7 +18,7 @@ class WorksTest < ApplicationSystemTestCase
   test "show user's profile link" do
     login_user "kimura", "testtest"
     visit work_path(works(:work_1))
-    assert_link "kimura", href: "/users/991528156"
+    assert_link "kimura", href: "/users/#{users(:kimura).id}"
   end
 
   test "create a work" do

--- a/test/system/works_test.rb
+++ b/test/system/works_test.rb
@@ -15,6 +15,12 @@ class WorksTest < ApplicationSystemTestCase
     assert_text "hatsuno's app"
   end
 
+  test "show user's profile link" do
+    login_user "kimura", "testtest"
+    visit work_path(works(:work_1))
+    assert_link "kimura", href: "/users/991528156"
+  end
+
   test "create a work" do
     login_user "kimura", "testtest"
     visit new_work_path


### PR DESCRIPTION
refs #1950 

作品ページのユーザー名リンクをクリックしたときに404エラーのページではなく、ユーザーのプロフィールページに遷移するように修正しました。

[![Image from Gyazo](https://i.gyazo.com/a42727af708f8c2423db39578c4c111b.gif)](https://gyazo.com/a42727af708f8c2423db39578c4c111b)