### PR TITLE
全ての質問画面のタイトルを修正

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -7,6 +7,8 @@ class QuestionsController < ApplicationController
   before_action :set_categories, only: %i(new create edit update)
   before_action :set_watch, only: %i(show)
 
+  QuestionsProperty = Struct.new(:title, :empty_message)
+
   def index
     questions =
       if params[:solved].present?
@@ -19,6 +21,7 @@ class QuestionsController < ApplicationController
     @questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
     @questions = @questions.preload(%i[practice answers]).with_avatar.page(params[:page])
     @questions = @questions.tagged_with(params[:tag]) if params[:tag]
+    @questions_property = questions_property
   end
 
   def show
@@ -98,5 +101,15 @@ class QuestionsController < ApplicationController
 
     def set_watch
       @watch = Watch.new
+    end
+
+    def questions_property
+      if params[:all] == "true"
+        QuestionsProperty.new("全ての質問", "質問はまだありません。")
+      elsif params[:solved] == "true"
+        QuestionsProperty.new("解決済みの質問一覧", "解決済みの質問はまだありません。")
+      else
+        QuestionsProperty.new("未解決の質問一覧", "未解決の質問はまだありません。")
+      end
     end
 end

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -1,4 +1,4 @@
-- title params[:solved] == "true" ? "解決済みの質問一覧" : "未解決の質問一覧"
+- title @questions_property.title
 header.page-header.is-margin-bottom-0
   .container
     .page-header__inner
@@ -30,12 +30,7 @@ header.page-header.is-margin-bottom-0
             = render @questions
         - else
           .a-empty-message
-            - if params[:solved] == "true"
-              | 解決済みの質問はまだありません。
-            - elsif params[:all] == "true"
-              | 質問はまだありません。
-            - else
-              | 未解決の質問はまだありません。
+            = @questions_property.empty_message
       - if @questions.all_tags.any?
         nav.page-tags-nav
           header.page-tags-nav__header

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -17,6 +17,11 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_equal "解決済みの質問一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
+  test "show listing all questions" do
+    visit questions_path(all: "true")
+    assert_equal "全ての質問 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+  end
+
   test "show a resolved qestion" do
     question = questions(:question_3)
     visit question_path(question)


### PR DESCRIPTION
# 概要

全ての質問画面のタイトルが未解決の質問一覧になっていたので、全ての質問と表示するように修正した。

# 修正後の画面

![image](https://user-images.githubusercontent.com/13811034/95459302-6b0e7080-09ae-11eb-8d08-e9380d45b092.png)

# 関連issue

#1990