### PR TITLE
他ユーザーのポートフォリオページを開いた場合、「＋作品を追加」ボタンを表示しないように修正

### DIFF
--- a/app/views/users/works/index.html.slim
+++ b/app/views/users/works/index.html.slim
@@ -31,7 +31,8 @@ header.page-header
           | 自分の作ったGemや登壇した際の発表資料、自分で作ったWebサービス、自分が書いた書籍など、作品を登録していきましょう。
     .page-body-actions
       ul.page-body-actions__items
-        li.page-body-actions__item
-          = link_to new_work_path, class: "a-button is-lg is-warning is-block" do
-            i.fas.fa-plus
-            | 作品を追加
+        - if current_user == @user
+          li.page-body-actions__item
+            = link_to new_work_path, class: "a-button is-lg is-warning is-block" do
+              i.fas.fa-plus
+              | 作品を追加

--- a/test/system/works_test.rb
+++ b/test/system/works_test.rb
@@ -13,6 +13,7 @@ class WorksTest < ApplicationSystemTestCase
     login_user "kimura", "testtest"
     visit work_path(works(:work_2))
     assert_text "hatsuno's app"
+    assert_no_text "作品を追加"
   end
 
   test "create a work" do


### PR DESCRIPTION
refs #1922 

他ユーザーのポートフォリオを開いたときに、「＋作品を追加」ボタンを表示しないようにしました。