### PR TITLE
ユーザーアイコンのキャッシュを削除

### DIFF
--- a/app/views/users/_icon.html.slim
+++ b/app/views/users/_icon.html.slim
@@ -8,7 +8,5 @@ ruby:
     alt: user.icon_title,
     class: user.icon_classes(image_class)
   }
-
-- cache [link_options, image_options, user] do
-  = link_to user, link_options do
-    = image_tag user.avatar_url, image_options
+= link_to user, link_options do
+  = image_tag user.avatar_url, image_options


### PR DESCRIPTION
最近活動のないユーザーの画像が出ないので一旦キャッシュを削除。