### PR TITLE
faqの学習場所に関する項目を削除

### DIFF
--- a/app/views/welcome/_faq.slim
+++ b/app/views/welcome/_faq.slim
@@ -70,15 +70,6 @@
               .faqs-item__inner
                 h3.faqs-item__title
                   = image_tag("question.svg", class: "faqs-item__title-icon")
-                  | 自宅からのリモートではなくオフィスに通って学習をしたいのですが可能ですか？
-                .faqs-item__body
-                  p
-                    | 事前に座席の予約をしてからの利用になりますので、予約を取れた場合は可能です。
-          .col-md-4
-            section.faqs-item
-              .faqs-item__inner
-                h3.faqs-item__title
-                  = image_tag("question.svg", class: "faqs-item__title-icon")
                   | 現在、大学に在学中なのですが、参加できますか？
                 .faqs-item__body
                   p


### PR DESCRIPTION
ref #1986 

## 概要
- FAQに残っていた学習場所に関する以下の項目を削除しました

![image](https://user-images.githubusercontent.com/59789739/96159877-26577c00-0f50-11eb-9b4a-3f9c756944e5.png)
