### PR TITLE
誰でもお知らせを作成できるようにする

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -17,6 +17,7 @@ class Announcement < ApplicationRecord
   alias_method :sender, :user
 
   after_create AnnouncementCallbacks.new
+  after_update AnnouncementCallbacks.new
   after_destroy AnnouncementCallbacks.new
 
   validates :title, presence: true

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -4,12 +4,16 @@ class AnnouncementCallbacks
   def after_create(announce)
     if !announce.wip?
       send_notification(announce)
+      announce.published_at = Time.current
+      announce.save
     end
   end
 
   def after_update(announce)
-    if !announce.wip?
+    if announce.wip == false && announce.published_at.nil?
       send_notification(announce)
+      announce.published_at = Time.current
+      announce.save
     end
   end
 

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -10,7 +10,7 @@ class AnnouncementCallbacks
   end
 
   def after_update(announce)
-    if announce.wip == false && announce.published_at.nil?
+    if !announce.wip && announce.published_at.nil?
       send_notification(announce)
       announce.published_at = Time.current
       announce.save

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -2,7 +2,15 @@
 
 class AnnouncementCallbacks
   def after_create(announce)
-    send_notification(announce)
+    if !announce.wip?
+      send_notification(announce)
+    end
+  end
+
+  def after_update(announce)
+    if !announce.wip?
+      send_notification(announce)
+    end
   end
 
   def after_destroy(announce)

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -2,6 +2,9 @@
   .thread__inner.a-card
     header.thread-header
       h1.thread-header__title
+        - if announcement.wip?
+          span.thread-header__title-icon
+            | WIP
         = announcement.title
 
       .thread-header__lower-side

--- a/app/views/announcements/_announcements.html.slim
+++ b/app/views/announcements/_announcements.html.slim
@@ -1,4 +1,4 @@
-.thread-list-item
+.thread-list-item(class="#{announcement.wip? ? "is-wip" : ""}")
   .thread-list-item__inner
     .thread-list-item__author
       = render "users/icon",
@@ -6,6 +6,8 @@
         link_class: "thread-header__author",
         image_class: "thread-list-item__author-icon"
     header.thread-list-item__header
+      - if announcement.wip?
+        .thread-list-item__header-icon.is-wip WIP
       h2.thread-list-item__title(itemprop="name")
         = link_to announcement, itempro: "url", class: "thread-list-item__title-link" do
           = announcement.title

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -48,3 +48,5 @@
           = link_to "キャンセル", announcements_path, class: "a-button is-md is-secondary"
         - elsif params[:action] == "edit" || params[:action] == "update"
           = link_to "キャンセル", announcement_path, class: "a-button is-md is-secondary"
+    - unless admin_login?
+      | お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -36,10 +36,13 @@
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main.is-help
-        - if announcement.new_record?
-          = f.submit "作成", class: "a-button is-lg is-warning is-block", id: "js-shortcut-submit"
-        - else
-          = f.submit "内容変更", class: "a-button is-lg is-warning is-block", id: "js-shortcut-submit"
+        = f.submit "WIP", class: "a-button is-lg is-primary is-block", id: "js-shortcut-wip"
+        - if admin_login?
+          li.form-actions__item.is-main.is-help
+            - if announcement.new_record?
+              = f.submit "作成", class: "a-button is-lg is-warning is-block", id: "js-shortcut-submit"
+            - else
+              = f.submit "内容変更", class: "a-button is-lg is-warning is-block", id: "js-shortcut-submit"
       li.form-actions__item
         - if params[:action] == "new" || params[:action] == "create"
           = link_to "キャンセル", announcements_path, class: "a-button is-md is-secondary"

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -49,4 +49,6 @@
         - elsif params[:action] == "edit" || params[:action] == "update"
           = link_to "キャンセル", announcement_path, class: "a-button is-md is-secondary"
     - unless admin_login?
-      | お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。
+      .form-actions__description.a-short-text
+        p
+          | お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。

--- a/app/views/announcements/index.html.slim
+++ b/app/views/announcements/index.html.slim
@@ -5,13 +5,12 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         = title
-      - if admin_login?
-        .page-header-actions
-          .page-header-actions__items
-            .page-header-actions__item
-              = link_to new_announcement_path, class: "a-button is-md is-warning is-block" do
-                i.fa.fa-plus
-                | お知らせ作成
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+            = link_to new_announcement_path, class: "a-button is-md is-warning is-block" do
+              i.fa.fa-plus
+              | お知らせ作成
 
 .page-body
   = paginate @announcements, position: "top"

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -6,11 +6,10 @@ header.page-header
       h1.page-header__title お知らせ
       .page-header-actions
         ul.page-header-actions__items
-          - if admin_login?
-            li.page-header-actions__item
-              = link_to new_announcement_path, class: "a-button is-md is-warning is-block" do
-                i.fa.fa-plus
-                | お知らせ作成
+          li.page-header-actions__item
+            = link_to new_announcement_path, class: "a-button is-md is-warning is-block" do
+              i.fa.fa-plus
+              | お知らせ作成
           li.page-header-actions__item
             = link_to announcements_path, class: "a-button is-md is-secondary is-block" do
               | お知らせ一覧へ

--- a/app/views/home/_announcements.html.slim
+++ b/app/views/home/_announcements.html.slim
@@ -1,11 +1,12 @@
-.thread-list-item
-  .thread-list-item__inner
-    .thread-list-item__author
-      = render "users/icon", user: announcement.user, link_class: "thread-header__author", image_class: "thread-list-item__author-icon"
-    header.thread-list-item__header
-      h2.thread-list-item__title(itemprop="name")
-        = link_to announcement, itemprop: "url", class: "thread-list-item__title-link" do
-          = announcement.title
-    .thread-list-item-meta
-      time.thread-list-item-meta__datetime(datetime="#{announcement.updated_at.to_datetime}" pubdate="pubdate")
-        = l announcement.updated_at
+- if !announcement.wip
+  .thread-list-item
+    .thread-list-item__inner
+      .thread-list-item__author
+        = render "users/icon", user: announcement.user, link_class: "thread-header__author", image_class: "thread-list-item__author-icon"
+      header.thread-list-item__header
+        h2.thread-list-item__title(itemprop="name")
+          = link_to announcement, itemprop: "url", class: "thread-list-item__title-link" do
+            = announcement.title
+      .thread-list-item-meta
+        time.thread-list-item-meta__datetime(datetime="#{announcement.updated_at.to_datetime}" pubdate="pubdate")
+          = l announcement.updated_at

--- a/db/migrate/20201016130005_add_columns_to_announcements.rb
+++ b/db/migrate/20201016130005_add_columns_to_announcements.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddColumnsToAnnouncements < ActiveRecord::Migration[6.0]
   def change
     add_column :announcements, :wip, :boolean, default: false, null: false

--- a/db/migrate/20201016130005_add_columns_to_announcements.rb
+++ b/db/migrate/20201016130005_add_columns_to_announcements.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class AddColumnsToAnnouncements < ActiveRecord::Migration[6.0]
-  def change
-    add_column :announcements, :wip, :boolean, default: false, null: false
-    add_column :announcements, :published_at, :datetime
+  change_table :announcements, bulk: true do |t|
+    t.boolean :wip, default: false, null: false
+    t.datetime :published_at
   end
 end

--- a/db/migrate/20201016130005_add_columns_to_announcements.rb
+++ b/db/migrate/20201016130005_add_columns_to_announcements.rb
@@ -1,0 +1,6 @@
+class AddColumnsToAnnouncements < ActiveRecord::Migration[6.0]
+  def change
+    add_column :announcements, :wip, :boolean, default: false, null: false
+    add_column :announcements, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,6 +43,8 @@ ActiveRecord::Schema.define(version: 2020_11_04_093315) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.integer "target", default: 0, null: false
+    t.boolean "wip", default: false, null: false
+    t.datetime "published_at"
     t.index ["user_id"], name: "index_announcements_on_user_id"
   end
 

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -50,6 +50,7 @@ namespace :bootcamp do
         end
       end
       puts "== END   Cloud Build Task =="
+      Announcement.where(published_at: nil, wip: false).update_all(published_at: Time.current)
     end
   end
 

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -9,10 +9,10 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text "お知らせ作成"
   end
 
-  test "don't show link to create new announcement when user isn't admin" do
+  test "show link to create new announcement when user isn't admin" do
     login_user "kimura", "testtest"
     visit "/announcements"
-    assert_no_text "お知らせ作成"
+    assert_text "お知らせ作成"
   end
 
   test "show pagination" do
@@ -30,6 +30,23 @@ class AnnouncementsTest < ApplicationSystemTestCase
     login_user "kimura", "testtest"
     visit "/announcements/#{announcements(:announcement_1).id}"
     assert_selector ".thread-comment-form"
+  end
+
+  test "users except admin cannot publish an announcement" do
+    login_user "kimura", "testtest"
+    visit new_announcement_path
+    page.assert_no_selector("input[value='作成']")
+  end
+
+  test "create a new announcement as wip" do
+    login_user "kimura", "testtest"
+    visit new_announcement_path
+    fill_in "announcement[title]", with: "仮のお知らせ"
+    fill_in "announcement[description]", with: "まだWIPです。"
+    assert_difference "Announcement.count", 1 do
+      click_button "WIP"
+    end
+    assert_text "お知らせをWIPとして保存しました。"
   end
 
   test "delete announcement with notification" do


### PR DESCRIPTION
ref #1957 

## 概要
### WIPの実装
- WIP機能を実装しました
- メンター以外はお知らせを公開できないようにしました
- WIPのボタン下部に公開までの手順を記述しました（要デザイン）
- ダッシュボードにはWIPのお知らせは表示されません
- published_atカラムを追加し、初回公開時のみ通知が飛ぶようにしました

**受講生の画面**
![image](https://user-images.githubusercontent.com/59789739/98003697-61075280-1e32-11eb-9c23-c6a9b2353bf3.png)


**メンターの画面**
![image](https://user-images.githubusercontent.com/59789739/96347154-a578bb80-10da-11eb-886d-0fa9a775f453.png)

**保存後の画面**
![image](https://user-images.githubusercontent.com/59789739/96347209-2a63d500-10db-11eb-83f5-17c1de9c0b63.png)

**一覧画面**
![image](https://user-images.githubusercontent.com/59789739/96347259-6b5be980-10db-11eb-9158-e825e229b388.png)

**ダッシュボード**
![image](https://user-images.githubusercontent.com/59789739/96347276-8dee0280-10db-11eb-9105-3283549bbb42.png)


