### PR TITLE
rake taskのbootcamp:statistics:save_learning_minute_statisticの処理をSchedulerで実行するようにした

### DIFF
--- a/app/controllers/scheduler/statistics_controller.rb
+++ b/app/controllers/scheduler/statistics_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Scheduler::StatisticsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def update
+    unless ENV["TOKEN"] == params[:token]
+      return head :unauthorized
+    end
+
+    Practice.save_learning_minute_statistics
+    head :ok
+  end
+end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -36,6 +36,21 @@ class Practice < ApplicationRecord
 
   columns_for_keyword_search :title, :description, :goal
 
+  class << self
+    def save_learning_minute_statistics
+      Practice.all.each do |practice|
+        practice_id = practice.id
+        learning_minute_list = practice.learning_minute_per_user
+
+        if learning_minute_list.sum > 0
+          average_learning_minute = practice.average_learning_minute(learning_minute_list)
+          median_learning_minute = practice.median_learning_minute(learning_minute_list)
+          practice.save_statistic(practice_id, average_learning_minute, median_learning_minute)
+        end
+      end
+    end
+  end
+
   def status(user)
     learnings = Learning.where(
       user_id: user.id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
   get "law", to: "welcome#law", as: "law"
   get "coc", to: "welcome#coc", as: "coc"
 
+  namespace :scheduler do
+    resource :statistics, only: %i(update)
+  end
+
   namespace "api" do
     resource :image, controller: "image", only: %i(create)
     resources :grasses, only: %i(show)

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -41,21 +41,4 @@ namespace :bootcamp do
       puts "== END   Cloud Build Task =="
     end
   end
-
-  namespace :statistics do
-    desc "save learning minute statistics"
-    task :save_learning_minute_statistics do
-      practices = Practice.all
-      practices.each do |practice|
-        practice_id = practice.id
-        learning_minute_list = practice.learning_minute_per_user
-
-        if learning_minute_list.sum > 0
-          average_learning_minute = practice.average_learning_minute(learning_minute_list)
-          median_learning_minute = practice.median_learning_minute(learning_minute_list)
-          practice.save_statistic(practice_id, average_learning_minute, median_learning_minute)
-        end
-      end
-    end
-  end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -38,4 +38,14 @@ class PracticeTest < ActiveSupport::TestCase
     assert ordered_practices.index(earlier) < ordered_practices.index(middle)
     assert ordered_practices.index(middle) < ordered_practices.index(later)
   end
+
+  test ".save_learning_minute_statistics" do
+    LearningMinuteStatistic.delete_all
+    assert LearningMinuteStatistic.count.zero?
+
+    Practice.save_learning_minute_statistics
+
+    practice_ids = Practice.joins(:reports).merge(Report.not_wip).distinct.pluck(:id)
+    assert LearningMinuteStatistic.count == practice_ids.size
+  end
 end


### PR DESCRIPTION
Heroku Schedulerでrake taskのbootcamp:statistics:save_learning_minute_statisticを実行するようにしていましたが、Google Cloud Schedulerで処理できるようにしました。

rake taskは消しました。認証は環境変数のTOKENのチェックにしました。

Cloud Schedulerの設定は下記のような感じで設定してあります。

```shell
gcloud scheduler jobs create http production-statistics \
--time-zone "Asia/Tokyo" \
--schedule="0 0 * * *" \
--uri="https://https://bootcamp.fjord.jp/scheduler/statistics" \
--headers="Content-Type=application/json" \
--http-method="PATCH" \
--message-body="{\"token\":\"xxxx\"}"
```