### PR TITLE
asset_hostをbootcamp.fjord.jp固定になってるのを環境変数で変更できるようにした

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,9 +114,9 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  config.action_mailer.default_url_options = { host: "bootcamp.fjord.jp", protocol: "https" }
-  config.action_mailer.asset_host = "https://bootcamp.fjord.jp"
-  config.action_controller.asset_host = "https://bootcamp.fjord.jp"
+  config.action_mailer.default_url_options = { host: ENV["APP_HOST_NAME"], protocol: "https" }
+  config.action_mailer.asset_host = "https://#{ENV["APP_HOST_NAME"]}"
+  config.action_controller.asset_host = "https://#{ENV["APP_HOST_NAME"]}"
 
   config.action_mailer.delivery_method = :postmark
   config.action_mailer.postmark_settings = { api_token: ENV["POSTMARK_API_TOKEN"] }


### PR DESCRIPTION
#2023 の対応です。

asset_hostを環境変数のAPP_HOST_NAMEを元に設定するようにしました。