### PR TITLE
会社を指定してユーザー登録できるようにした

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,6 +25,7 @@ class UsersController < ApplicationController
     when "trainee"
       @user.trainee = true
     end
+    @user.company_id = params[:company_id]
   end
 
   def create

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -3,6 +3,7 @@
 = form_with model: user, url: url, local: true, id: "payment-form", html: { name: "user", autocomplete: "address-line3" } do |f|
   = f.hidden_field :adviser
   = f.hidden_field :trainee
+  = f.hidden_field :company_id
   = hidden_field_tag :idempotency_token, SecureRandom.uuid
   = render "errors", object: user
   .form__items

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -189,4 +189,22 @@ class SignUpTest < ApplicationSystemTestCase
       allow: "chromedriver.storage.googleapis.com"
     )
   end
+
+  test "sign up as adviser with company_id" do
+    visit "/users/new?role=adviser&company_id=#{companies(:company_2).id}"
+
+    email = "test-#{SecureRandom.hex(16)}@example.com"
+
+    within "form[name=user]" do
+      fill_in "user[login_name]", with: "foo"
+      fill_in "user[email]", with: email
+      fill_in "user[name]", with: "テスト 太郎"
+      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[password]", with: "testtest"
+      fill_in "user[password_confirmation]", with: "testtest"
+    end
+    click_button "アドバイザー登録"
+    assert_text "サインアップメールをお送りしました。メールからサインアップを完了させてください。"
+    assert_equal User.find_by(email: email).company_id, companies(:company_2).id
+  end
 end

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -9,6 +9,7 @@ class SignUpTest < ApplicationSystemTestCase
     visit "/users/new"
     within "form[name=user]" do
       fill_in "user[login_name]", with: "foo"
+      # 決め打ちメールアドレスにした場合テストを複数回実行すると失敗するため、ランダムでメールアドレスを生成する 詳細はissue#2035参照
       fill_in "user[email]", with: "test-#{SecureRandom.hex(16)}@example.com"
       fill_in "user[name]", with: "テスト 太郎"
       fill_in "user[name_kana]", with: "テスト タロウ"

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -38,9 +38,9 @@ class SignUpTest < ApplicationSystemTestCase
     visit "/users/new"
     within "form[name=user]" do
       fill_in "user[login_name]", with: "foo"
-      fill_in "user[email]", with: "test-#{SecureRandom.hex(16)}@example.com"
-      fill_in "user[name]", with: "テスト 太郎"
-      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[email]", with: "jiro@example.com"
+      fill_in "user[name]", with: "テスト 次郎"
+      fill_in "user[name_kana]", with: "テスト ジロウ"
       fill_in "user[password]", with: "testtest"
       fill_in "user[password_confirmation]", with: "testtest"
       select "学生", from: "user[job]"
@@ -66,9 +66,9 @@ class SignUpTest < ApplicationSystemTestCase
     visit "/users/new"
     within "form[name=user]" do
       fill_in "user[login_name]", with: "foo"
-      fill_in "user[email]", with: "test-#{SecureRandom.hex(16)}@example.com"
-      fill_in "user[name]", with: "テスト 太郎"
-      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[email]", with: "saburo@example.com"
+      fill_in "user[name]", with: "テスト 三郎"
+      fill_in "user[name_kana]", with: "テスト サブロウ"
       fill_in "user[password]", with: "testtest"
       fill_in "user[password_confirmation]", with: "testtest"
       select "学生", from: "user[job]"
@@ -94,9 +94,9 @@ class SignUpTest < ApplicationSystemTestCase
     visit "/users/new"
     within "form[name=user]" do
       fill_in "user[login_name]", with: "foo"
-      fill_in "user[email]", with: "test-#{SecureRandom.hex(16)}@example.com"
-      fill_in "user[name]", with: "テスト 太郎"
-      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[email]", with: "hanako@example.com"
+      fill_in "user[name]", with: "テスト 花子"
+      fill_in "user[name_kana]", with: "テスト ハナコ"
       fill_in "user[password]", with: "testtest"
       fill_in "user[password_confirmation]", with: "testtest"
       select "学生", from: "user[job]"
@@ -119,13 +119,13 @@ class SignUpTest < ApplicationSystemTestCase
   test "sign up as adviser" do
     visit "/users/new?role=adviser"
 
-    email = "test-#{SecureRandom.hex(16)}@example.com"
+    email = "haruko@example.com"
 
     within "form[name=user]" do
       fill_in "user[login_name]", with: "foo"
       fill_in "user[email]", with: email
-      fill_in "user[name]", with: "テスト 太郎"
-      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[name]", with: "テスト 春子"
+      fill_in "user[name_kana]", with: "テスト ハルコ"
       fill_in "user[password]", with: "testtest"
       fill_in "user[password_confirmation]", with: "testtest"
     end
@@ -137,13 +137,13 @@ class SignUpTest < ApplicationSystemTestCase
   test "sign up as trainee" do
     visit "/users/new?role=trainee"
 
-    email = "test-#{SecureRandom.hex(16)}@example.com"
+    email = "natsumi@example.com"
 
     within "form[name=user]" do
       fill_in "user[login_name]", with: "foo"
       fill_in "user[email]", with: email
-      fill_in "user[name]", with: "テスト 太郎"
-      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[name]", with: "テスト 夏美"
+      fill_in "user[name_kana]", with: "テスト ナツミ"
       fill_in "user[password]", with: "testtest"
       fill_in "user[password_confirmation]", with: "testtest"
       select "学生", from: "user[job]"
@@ -170,9 +170,9 @@ class SignUpTest < ApplicationSystemTestCase
     visit "/users/new"
     within "form[name=user]" do
       fill_in "user[login_name]", with: "mentor"
-      fill_in "user[email]", with: "test-#{SecureRandom.hex(16)}@example.com"
-      fill_in "user[name]", with: "テスト 太郎"
-      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[email]", with: "akiko@example.com"
+      fill_in "user[name]", with: "テスト 秋子"
+      fill_in "user[name_kana]", with: "テスト アキコ"
       fill_in "user[password]", with: "testtest"
       fill_in "user[password_confirmation]", with: "testtest"
       select "学生", from: "user[job]"
@@ -194,13 +194,13 @@ class SignUpTest < ApplicationSystemTestCase
   test "sign up as adviser with company_id" do
     visit "/users/new?role=adviser&company_id=#{companies(:company_2).id}"
 
-    email = "test-#{SecureRandom.hex(16)}@example.com"
+    email = "fuyuko@example.com"
 
     within "form[name=user]" do
       fill_in "user[login_name]", with: "foo"
       fill_in "user[email]", with: email
-      fill_in "user[name]", with: "テスト 太郎"
-      fill_in "user[name_kana]", with: "テスト タロウ"
+      fill_in "user[name]", with: "テスト ふゆこ"
+      fill_in "user[name_kana]", with: "テスト フユコ"
       fill_in "user[password]", with: "testtest"
       fill_in "user[password_confirmation]", with: "testtest"
     end


### PR DESCRIPTION
## やりたいこと
現在、ユーザー登録後に管理者が手動で企業を登録している。
新規ユーザー登録時に、パラメータとして `company_id` を受け取れるようにする。

ref: https://github.com/fjordllc/bootcamp/issues/1978

## やったこと
- `/users/new?role=adviser&company_id=123` のように company_id を指定してユーザー登録することができる
- `role` に関係なく `company_id` は登録することができる
    - 一般ユーザーでも `company_id` は受け取ることができる

## やらなかったこと
- `company_id` を受け取ったことは画面上に表示されない
- `company_id` が正しいかどうかはチェックしない
    - ref: https://github.com/fjordllc/bootcamp/issues/1978#issuecomment-711454842
