### PR TITLE
モバイル版のナビゲーションバーのFont Awesomeの幅を統一

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -12,19 +12,19 @@ nav.global-nav
         li.global-nav-links__item
           = link_to announcements_path, class: "global-nav-links__link #{current_link /^announcements/}" do
             .global-nav-links__link-icon
-              i.fas.fa-bullhorn
+              i.fas.fa-fw.fa-bullhorn
             .global-nav-links__link-label お知らせ
         li.global-nav-links__item
           - anchor = "practice_#{current_user.active_practice}" if current_user.active_practice
           = link_to course_practices_path(current_user.course, anchor: anchor), class: "global-nav-links__link #{current_link /^(courses-practices|practices)-/}"  do
             .global-nav-links__link-icon
-              i.fas.fa-book
+              i.fas.fa-fw.fa-book
             .global-nav-links__link-label プラクティス
         li.global-nav-links__item
           - report_link = mentor_login? ? reports_unchecked_index_path : reports_path
           = link_to report_link, class: "global-nav-links__link #{current_link /^reports/}" do
             .global-nav-links__link-icon
-              i.fas.fa-pen
+              i.fas.fa-fw.fa-pen
             - if admin_login? && Cache.unchecked_report_count > 0
               .global-nav__item-count.a-notification-count
                 = Cache.unchecked_report_count
@@ -33,7 +33,7 @@ nav.global-nav
           li.global-nav-links__item
             = link_to products_not_responded_index_path, class: "global-nav-links__link #{current_link /^products/ }" do
               .global-nav-links__link-icon
-                i.fas.fa-hand-paper
+                i.fas.fa-fw.fa-hand-paper
               - if admin_login? && Cache.not_responded_product_count > 0
                 .global-nav__item-count.a-notification-count
                   = Cache.not_responded_product_count
@@ -41,7 +41,7 @@ nav.global-nav
         li.global-nav-links__item
           = link_to questions_path, class: "global-nav-links__link #{current_link /^questions/}" do
             .global-nav-links__link-icon
-              i.fas.fa-question
+              i.fas.fa-fw.fa-question
             - if Question.not_solved.count > 0
               .global-nav__item-count.a-notification-count
                 = Question.not_solved.count
@@ -49,38 +49,38 @@ nav.global-nav
         li.global-nav-links__item
           = link_to "/pages", class: "global-nav-links__link #{current_link /^pages/}" do
             .global-nav-links__link-icon
-              i.fas.fa-file
+              i.fas.fa-fw.fa-file
             .global-nav-links__link-label Docs
         / li.global-nav-links__item
           = link_to "/reservation_calenders", class: "global-nav-links__link #{current_link /^reservation_calenders/}" do
             .global-nav-links__link-icon
-              i.fas.fa-chair
+              i.fas.fa-fw.fa-chair
             .global-nav-links__link-label 席予約
         li.global-nav-links__item
           = link_to users_path, class: "global-nav-links__link #{current_link /^users/}" do
             .global-nav-links__link-icon
-              i.fas.fa-users
+              i.fas.fa-fw.fa-users
             .global-nav-links__link-label ユーザー
         li.global-nav-links__item
           = link_to events_path, class: "global-nav-links__link #{current_link /^events/}" do
             .global-nav-links__link-icon
-              i.fas.fa-beer
+              i.fas.fa-fw.fa-beer
             .global-nav-links__link-label イベント
         li.global-nav-links__item.is-hidden-md-up
           = link_to courses_path, class: "global-nav-links__link #{current_link /^courses-index/}" do
             .global-nav-links__link-icon
-              i.fas.fa-graduation-cap
+              i.fas.fa-fw.fa-graduation-cap
             .global-nav-links__link-label コース
         li.global-nav-links__item.is-hidden-md-up
           = link_to edit_current_user_path, class: "global-nav-links__link #{current_link /^current_user/}" do
             .global-nav-links__link-icon
-              i.fas.fa-user
+              i.fas.fa-fw.fa-user
             .global-nav-links__link-label 登録情報変更
         - if !current_user.adviser? && !current_user.mentor?
           li.global-nav-links__item.is-hidden-md-up
             = link_to edit_card_path, class: "global-nav-links__link #{current_link /^card/}" do
               .global-nav-links__link-icon
-                i.fas.fa-credit-card
+                i.fas.fa-fw.fa-credit-card
               .global-nav-links__link-label クレジットカード
         - if admin_login?
           li.global-nav-links__item.is-hidden-md-up
@@ -91,15 +91,15 @@ nav.global-nav
         li.global-nav-links__item.is-hidden-md-up
           = link_to coc_path, class: "global-nav-links__link", target: "_blank" do
             .global-nav-links__link-icon
-              i.fas.fa-heart
+              i.fas.fa-fw.fa-heart
             .global-nav-links__link-label.is-sm アンチハラスメントポリシー
         li.global-nav-links__item.is-hidden-md-up
           = link_to logout_path, class: "global-nav-links__link" do
             .global-nav-links__link-icon
-              i.fas.fa-sign-out-alt
+              i.fas.fa-fw.fa-sign-out-alt
             .global-nav-links__link-label ログアウト
         li.global-nav-links__item.is-hidden-md-up
           = link_to new_retirement_path, class: "global-nav-links__link" do
             .global-nav-links__link-icon
-              i.fas.fa-sad-tear
+              i.fas.fa-fw.fa-sad-tear
             .global-nav-links__link-label 退会手続き


### PR DESCRIPTION
# やりたいこと
モバイル版のナビゲーションバーのFont Awesomeの幅が統一されておらずガタガタして見えるため、統一したい
<img src="https://user-images.githubusercontent.com/52617472/96422615-3662aa80-1233-11eb-8758-9a7d195ea576.png" width=300px>


# やったこと
`fa-fw` クラスをつけてガタガタして見えないようにしました。

<img src="https://user-images.githubusercontent.com/52617472/96422812-788bec00-1233-11eb-98be-3ea2dac27aff.png" width=300px>
