### PR TITLE
Q&A内のコメント欄でも大名エンジニア参加生のアイコンが黄緑色になるように実装

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -2,7 +2,7 @@
   .thread-comment
     .thread-comment__author
       a.thread-comment__author-link(:href="answer.user.url" itemprop="url")
-        img.thread-comment__author-icon.a-user-icon(:src="answer.user.avatar_url" :title="answer.user.icon_title"  v-bind:class="userRole")
+        img.thread-comment__author-icon.a-user-icon(:src="answer.user.avatar_url" :title="answer.user.icon_title"  :class="[roleClass, daimyoClass]")
     .thread-comment__body.a-card(v-if="!editing")
       .answer-badge(v-if="hasCorrectAnswer && answer.type == 'CorrectAnswer'")
         .answer-badge__icon
@@ -193,8 +193,11 @@ export default {
     updatedAt: function() {
       return moment(this.answer.updated_at).format("YYYY年MM月DD日(dd) HH:mm");
     },
-    userRole: function() {
+    roleClass: function() {
       return `is-${this.answer.user.role}`;
+    },
+    daimyoClass: function() {
+      return { 'is-daimyo': this.answer.user.daimyo }
     },
     validation: function() {
       return this.description.length > 0;


### PR DESCRIPTION
ref #2006 

# 概要
- Q&Aに大名エンジニア参加生がコメントした際に、アイコンの色が黄緑色に変わるように実装しました

![image](https://user-images.githubusercontent.com/59789739/96558550-ce759800-12f6-11eb-9b2e-a64e6d1966a9.png)



