### PR TITLE
DocsのSlack通知先をgeneralからbootcamp_notificationに変更

### DIFF
--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -36,7 +36,7 @@ class PageCallbacks
       SlackNotification.notify "#{link}",
         username: "#{page.user.login_name} (#{page.user.name})",
         icon_url: page.user.avatar_url,
-        channel: "#general",
+        channel: "#bootcamp_notification",
         attachments: [{
           fallback: "page body.",
           text: page.body


### PR DESCRIPTION
refs #1956 

Docsが投稿されたときのSlackの通知先をgeneralチャンネルからbootcamp_notificationチャンネルに変更しました。