### PR TITLE
Menuから「MTGルーム」を削除し「質問・雑談ルーム」を「Whereby」に変更

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -82,11 +82,8 @@
               = link_to "https://github.com/fjordllc/bootcamp/projects/1", class: "header-dropdown__item-link", target: "_blank" do
                 | GitHub Projects
             li.header-dropdown__item
-              = link_to "https://fjord.whereby.com/meeting", class: "header-dropdown__item-link", target: "_blank" do
-                | MTGルーム
-            li.header-dropdown__item
               = link_to "https://fjord.whereby.com/talk", class: "header-dropdown__item-link", target: "_blank" do
-                | 質問・雑談ルーム
+                | Whereby
             li.header-dropdown__item
               = link_to "https://suzuri.jp/FjordBootCamp", class: "header-dropdown__item-link", target: "_blank" do
                 | グッズ購入


### PR DESCRIPTION
MTGと質問・雑談ルームがWherebyからZoomに移行したため。
ref: #2031 