### PR TITLE
提出物一覧のキャッシュを削除

### DIFF
--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -17,8 +17,7 @@ header.page-header
       .thread-list.a-card
         = render partial: "products/product",
           collection: @products,
-          as: :product,
-          cached: true
+          as: :product
     - else
       .o-empty-massage
         .o-empty-massage__icon

--- a/app/views/products/not_responded/index.html.slim
+++ b/app/views/products/not_responded/index.html.slim
@@ -16,8 +16,7 @@ header.page-header
       .thread-list.a-card
         = render partial: "products/product",
           collection: @products,
-          as: :product,
-          cached: true
+          as: :product
         - if mentor_login?
           = render partial: "unconfirmed_links_open", locals: { label: "未返信の提出物を一括で開く" }
     - else

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -16,8 +16,7 @@ header.page-header
       .thread-list.a-card
         = render partial: "products/product",
           collection: @products,
-          as: :product,
-          cached: true
+          as: :product
         - if mentor_login?
           = render partial: "unconfirmed_links_open", locals: { label: "未チェックの提出物を一括で開く" }
     - else


### PR DESCRIPTION
返信したユーザーや確認スタンプが誤ってキャッシュされてしまうため。
改善したキャッシュは少し時間がかかるので後ほど追加予定。

Fixed: #2030