### PR TITLE
日報のニコニコマークを絵文字から画像に変更

### DIFF
--- a/app/assets/stylesheets/_temp.sass
+++ b/app/assets/stylesheets/_temp.sass
@@ -1,0 +1,6 @@
+.niconico-calendar__emotion-image,
+.thread-header__emotion-image,
+.form-label__emotion-image,
+.continuous-sad__emotion-image
+  height: 1em
+  width: 1em

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -1,2 +1,3 @@
 @import common-imports
 @import blocks/**/*
+@import temp

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -54,7 +54,10 @@ class Report < ApplicationRecord
   }
 
   def self.faces
-    @_faces ||= emotions.keys.zip(%w(🙂 😢 😄)).to_h.with_indifferent_access
+    @_faces ||= emotions.keys
+                        .zip(%w(emotion/soso.svg emotion/sad.svg emotion/smile.svg))
+                        .to_h
+                        .with_indifferent_access
   end
 
   def previous

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -19,7 +19,7 @@
           = f.collection_radio_buttons :emotion, Report.faces, :first, :second do |b|
             li.form-radio-button.test-select-emotions
               label.form-radio-button__label.is-lg
-                = b.text
+                = image_tag b.text, id: b.value, alt: b.value, class: "form-label__emotion-image"
                 = b.radio_button
 
       .form-item#tasks

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -22,7 +22,7 @@ header.page-header
         header.thread-header
           - if @report.emotion.present?
             .thread-header__emotion
-              = Report.faces[@report.emotion]
+              = image_tag Report.faces[@report.emotion], id: @report.emotion, alt: @report.emotion, class: "thread-header__emotion-image"
           .thread-header__upper-side
             = link_to @report.user, class: "thread-header__author", title: @report.user.name do
               = @report.user.login_name

--- a/app/views/users/_niconico_calendar.html.slim
+++ b/app/views/users/_niconico_calendar.html.slim
@@ -33,7 +33,7 @@
                       - else
                         = set[:date]
                     .niconico-calendar__day-value
-                      = Report.faces[set[:emotion]]
+                      = image_tag Report.faces[set[:emotion]], alt: set[:report].emotion, class: "niconico-calendar__emotion-image"
                 - else
                   .niconico-calendar__day-inner
                     .niconico-calendar__day-label

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -2,7 +2,9 @@
   .a-card
     header.card-header
       h2.card-header__title
-        | 3日連続😢のユーザー
+        | 3日連続
+        = image_tag Report.faces["sad"], id: "sad", alt: "sad", class: "continuous-sad__emotion-image"
+        | のユーザー
     .card-list
       ul.card-list__items
         - users.each do |user|

--- a/test/system/emotions_test.rb
+++ b/test/system/emotions_test.rb
@@ -17,10 +17,10 @@ class EmotionsTest < ApplicationSystemTestCase
     all(".learning-time")[0].all(".learning-time__finished-at select")[0].select("08")
     all(".learning-time")[0].all(".learning-time__finished-at select")[1].select("30")
 
-    choose "😄", visible: false
+    find("#smile").click
 
     click_button "提出"
     assert_text "日報を保存しました。"
-    assert_text "😄"
+    assert_selector "img#smile"
   end
 end


### PR DESCRIPTION
Ref: #1753 

## 概要

絵文字は文字化けすることがあるため、画像に変更しました。

先日雑談タイムで Decorator を使う話をしたのですが、日報新規作成画面と管理者ダッシュボードの画像は、特定のReportインスタンスに紐づかないため、従来どおりクラスメソッドで実装しました。

表示されるのは以下の4箇所です。
仮のデザイン（_temp.sass）を追加しています。

## 表示（デザイン未）

### 日報新規作成ページ

<img width="408" alt="skitch48ac" src="https://user-images.githubusercontent.com/58389623/97732618-1d52d700-1b1a-11eb-8510-ea31c3c2021a.png">

### 日報詳細ページ

<img width="787" alt="skitch23ksf" src="https://user-images.githubusercontent.com/58389623/97732653-28a60280-1b1a-11eb-872a-d2f9a3d34358.png">

### ユーザー詳細ページ

<img width="499" alt="Screen Shot 2020-10-28 at 13 23 07" src="https://user-images.githubusercontent.com/58389623/97732594-175cf600-1b1a-11eb-9aae-1017659e3b60.png">

### 管理者ダッシュボード

<img width="1000" alt="skitch_1_17_25" src="https://user-images.githubusercontent.com/58389623/97732488-f1375600-1b19-11eb-8956-c3da00997660.png">
