### PR TITLE
ユーザーが卒業したらSlackに通知を送るようにした

### DIFF
--- a/app/models/user_callbacks.rb
+++ b/app/models/user_callbacks.rb
@@ -10,5 +10,19 @@ class UserCallbacks
     if user.saved_change_to_retired_on?
       user.update(job_seeking: false)
     end
+
+    if user.saved_change_to_graduated_on? && user.graduated?
+      notify_to_slack(user)
+    end
   end
+
+  private
+    def notify_to_slack(user)
+      path = Rails.application.routes.url_helpers.user_path(user)
+      url = "https://bootcamp.fjord.jp#{path}"
+      SlackNotification.notify "<#{url}|#{user.login_name}>さんが卒業しました！おめでとうございます🎉",
+        username: "#{user.login_name} (#{user.name})",
+        icon_url: user.avatar_url,
+        channel: "#fjord"
+    end
 end


### PR DESCRIPTION
Ref: #1920 

ユーザーのステータスが卒業に変更されたときに、メッセージとユーザーのプロフィールページのURLをSlackの#fjordチャンネルに通知するようにしました。