### PR TITLE
ユーザー登録時のSlack通知のチャンネルを変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -98,7 +98,8 @@ class UsersController < ApplicationController
     def notify_to_slack!
       SlackNotification.notify "<#{url_for(@user)}|#{@user.name} (#{@user.login_name})>が#{User.count}番目の仲間としてBootcampにJOINしました。",
         username: "#{@user.login_name}@bootcamp.fjord.jp",
-        icon_url: @user.avatar_url
+        icon_url: @user.avatar_url,
+        channel: "#fjord"
       redirect_to root_url, notice: "サインアップメールをお送りしました。メールからサインアップを完了させてください。"
     end
 


### PR DESCRIPTION
Ref: #1995 

ユーザー新規登録時のSlack通知のチャンネルを、#learning_notification から #fjord に変更しました。