### PR TITLE
企業一覧ページを作成

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -3,6 +3,10 @@
 class CompaniesController < ApplicationController
   before_action :require_login
 
+  def index
+    @companies = Company.with_attached_logo
+  end
+
   def show
     @company = Company.find(params[:id])
   end

--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -79,6 +79,9 @@
               = link_to books_path, class: "header-dropdown__item-link" do
                 | 書籍一覧
             li.header-dropdown__item
+              = link_to companies_path, class: "header-dropdown__item-link" do
+                | 企業一覧
+            li.header-dropdown__item
               = link_to "https://github.com/fjordllc/bootcamp/projects/1", class: "header-dropdown__item-link", target: "_blank" do
                 | GitHub Projects
             li.header-dropdown__item

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -4,11 +4,11 @@
       .user-data__main
         .user-profile.is-company
           .user-profile__icon
-            = link_to company_path(company.id) do
+            = link_to company do
               = image_tag company.logo_url, title: company.name, alt: company.name, class: "user-profile__user-icon-image a-user-icon"
           .user-profile__names
             h1.user-profile__login-name
-              = link_to company.name, company_path(company.id)
+              = link_to company.name, company
             .user-profile__full-name
               = company.description
 

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -1,28 +1,31 @@
-.a-card.is-user
-  .user-data__inner
-    header.user-data__header
-      .user-data__main
-        .user-profile.is-company
-          .user-profile__icon
-            = link_to company do
-              = image_tag company.logo_url, title: company.name, alt: company.name, class: "user-profile__user-icon-image a-user-icon"
+
+.col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
+  .users-item
+    .users-item__inner.a-card
+      header.users-item__header
+        .users-item__header-container
           .user-profile__names
             h1.user-profile__login-name
-              = link_to company.name, company
-            .user-profile__full-name
-              = company.description
+              = link_to company.name, company, class: "users-item__name-link"
+            ul.users-item-names
+              li.users-item-names__item
+                .users-item-names__ful-name
+                  = company.description
+          .users-item__icon
+            = link_to company do
+              = image_tag company.logo_url, title: company.name, alt: company.name, class: "users-item__user-icon-image a-user-icon is-studentn"
 
-        .user-data__sub
-          .user-metas
-            .user-metas__items
-              - if company.website?
+          .user-data__sub
+            .user-metas
+              .user-metas__items
+                - if company.website?
+                  .user-metas__item
+                    .user-metas__item-label
+                      | URL
+                    .user-metas__item-value.company_website
+                      = link_to company.name, company.website, target: "_blank"
                 .user-metas__item
                   .user-metas__item-label
-                    | URL
+                    | 人数
                   .user-metas__item-value.company_website
-                    = link_to company.name, company.website, target: "_blank"
-              .user-metas__item
-                .user-metas__item-label
-                  | 人数
-                .user-metas__item-value.company_website
-                  = company.users.size
+                    = company.users.size

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -1,4 +1,3 @@
-
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
   .users-item
     .users-item__inner.a-card

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -12,15 +12,15 @@
             .user-profile__full-name
               = company.description
 
-      - if company.website.present?
         .user-data__sub
           .user-metas
             .user-metas__items
-              .user-metas__item
-                .user-metas__item-label
-                  | URL
-                .user-metas__item-value.company_website
-                  = link_to company.name, company.website, target: "_blank"
+              - if company.website?
+                .user-metas__item
+                  .user-metas__item-label
+                    | URL
+                  .user-metas__item-value.company_website
+                    = link_to company.name, company.website, target: "_blank"
               .user-metas__item
                 .user-metas__item-label
                   | 人数

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -14,7 +14,6 @@
           .users-item__icon
             = link_to company do
               = image_tag company.logo_url, title: company.name, alt: company.name, class: "users-item__user-icon-image a-user-icon is-studentn"
-
           .user-data__sub
             .user-metas
               .user-metas__items

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -1,0 +1,28 @@
+.a-card.is-user
+  .user-data__inner
+    header.user-data__header
+      .user-data__main
+        .user-profile.is-company
+          .user-profile__icon
+            = link_to company_path(company.id) do
+              = image_tag company.logo_url, title: company.name, alt: company.name, class: "user-profile__user-icon-image a-user-icon"
+          .user-profile__names
+            h1.user-profile__login-name
+              = link_to company.name, company_path(company.id)
+            .user-profile__full-name
+              = company.description
+
+      - if company.website.present?
+        .user-data__sub
+          .user-metas
+            .user-metas__items
+              .user-metas__item
+                .user-metas__item-label
+                  | URL
+                .user-metas__item-value.company_website
+                  = link_to company.name, company.website, target: "_blank"
+              .user-metas__item
+                .user-metas__item-label
+                  | 人数
+                .user-metas__item-value.company_website
+                  = company.users.size

--- a/app/views/companies/_profile.html.slim
+++ b/app/views/companies/_profile.html.slim
@@ -20,3 +20,8 @@
                   | URL
                 .user-metas__item-value.company_website
                   = link_to company.name, company.website, target: "_blank"
+              .user-metas__item
+                .user-metas__item-label
+                  | 人数
+                .user-metas__item-value.company_website
+                  = company.users.size

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -1,0 +1,11 @@
+- title "企業一覧"
+
+header.page-header.is-margin-bottom-0
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+
+.page-body
+  .container
+    = render partial: "companies/company", collection: @companies, as: :company

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -8,4 +8,5 @@ header.page-header.is-margin-bottom-0
 
 .page-body
   .container
-    = render partial: "companies/company", collection: @companies, as: :company
+    .row.is-gutter-width-32
+      = render partial: "companies/company", collection: @companies, as: :company

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,8 +136,7 @@ Rails.application.routes.draw do
     resources :participations, only: %i(create destroy), controller: "events/participations"
   end
 
-  resources :companies, only: %i(index)
-  resources :companies, only: %i(show) do
+  resources :companies, only: %i(index show) do
     resources :users, only: %i(index), controller: "companies/users"
     resources :reports, only: %i(index), controller: "companies/reports"
     resources :products, only: %i(index), controller: "companies/products"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,6 +136,7 @@ Rails.application.routes.draw do
     resources :participations, only: %i(create destroy), controller: "events/participations"
   end
 
+  resources :companies, only: %i(index)
   resources :companies, only: %i(show) do
     resources :users, only: %i(index), controller: "companies/users"
     resources :reports, only: %i(index), controller: "companies/reports"

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -5,6 +5,11 @@ require "application_system_test_case"
 class CompaniesTest < ApplicationSystemTestCase
   setup { login_user "komagata", "testtest" }
 
+  test "GET /companies" do
+    visit "/companies"
+    assert_equal "企業一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+  end
+
   test "show company information" do
     visit "/companies/#{companies(:company_1).id}"
     assert_equal "FJORD, LLCの会社情報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -17,7 +17,7 @@ class CompaniesTest < ApplicationSystemTestCase
 
   test "show link to website if company has" do
     visit "/companies/#{companies(:company_1).id}"
-    within ".company_website" do
+    within ".user-metas__items" do
       assert_link "FJORD, LLC", href: "https://fjord.jp"
     end
   end


### PR DESCRIPTION
Ref: #2049

## 概要

企業一覧ページを作成し、Menuに「企業一覧」リンクを追加しました。
ページャーはつけていません。

## 表示（デザイン未）

仮で企業詳細ページのプロフィール（companies/profile）と同じデザインにしてあります。

<img width="910" alt="Skitch_2020-11-07_at_1_27_28" src="https://user-images.githubusercontent.com/58389623/98391182-a6798900-2099-11eb-88cf-1e48adc3a6b8.png">
