### PR TITLE
フォローした人の日報通知メール送信時にtrainee_reportメソッドを使用していたため修正

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -122,4 +122,12 @@ class NotificationMailer < ApplicationMailer
     subject = "[bootcamp] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
     mail to: @user.email, subject: subject
   end
+
+  # required params: report, receiver
+  def following_report
+    @user = @receiver
+    @notification = @user.notifications.find_by(path: "/reports/#{@report.id}")
+    subject = "[bootcamp] #{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！"
+    mail to: @user.email, subject: subject
+  end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -116,7 +116,7 @@ class NotificationFacade
       NotificationMailer.with(
         report: report,
         receiver: receiver
-      ).trainee_report.deliver_later(wait: 5)
+      ).following_report.deliver_later(wait: 5)
     end
   end
 

--- a/app/views/notification_mailer/following_report.html.slim
+++ b/app/views/notification_mailer/following_report.html.slim
@@ -1,0 +1,2 @@
+= render "notification_mailer_template", title: "#{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！", link_url: notification_url(@notification), link_text: "この日報へ" do
+  = simple_format(@report.description)

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -109,3 +109,11 @@ notification_create_page:
   message: "komagataさんがDocsにBootcampの作業のページを投稿しました。"
   path: "/pages/<%= ActiveRecord::FixtureSet.identify(:page_4) %>"
   read: false
+
+notification_following_report:
+  kind: 13
+  user: muryou
+  sender: kensyu
+  message: kensyuさんが日報【 フォローされた日報 】を書きました！
+  path: "/reports/<%= ActiveRecord::FixtureSet.identify(:report_23) %>"
+  read: false

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -175,3 +175,10 @@ report_22:
     卒業しました。
   practices: practice_2
   reported_on: "2020-09-10"
+
+report_23:
+  user: kensyu
+  title: フォローされた日報
+  description:
+    フォローされました。
+  reported_on: "2020-11-10"

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -256,4 +256,24 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal "[bootcamp] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。", email.subject
     assert_match %r{イベント}, email.body.to_s
   end
+
+  test "following_report" do
+    report = reports(:report_23)
+    notification = notifications(:notification_following_report)
+    mailer = NotificationMailer.with(
+      report: report,
+      receiver: notification.user
+    ).following_report
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ["noreply@bootcamp.fjord.jp"], email.from
+    assert_equal ["muryou@fjord.jp"], email.to
+    assert_equal "[bootcamp] kensyuさんが日報【 フォローされた日報 】を書きました！", email.subject
+    assert_match %r{日報}, email.body.to_s
+  end
 end


### PR DESCRIPTION
バグ修正。

https://github.com/fjordllc/bootcamp/pull/2015/commits/7a7de381ac63bf04e318c5d61fd8c3ea8f9c5585#diff-7dd23e5d12471797eb1bc89c8024e4532332f9e9ed0120d459950858ab144568R119

で `trainee_report` メソッドを使用してメール送信してしまっていたため、 `following_report` を作成した。
また、メール送信テストを追加した。

ref: https://github.com/fjordllc/bootcamp/pull/2015
