### PR TITLE
メンター・アドバイザーでないユーザーは就活中のユーザーのタブを非表示に変更

### DIFF
--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -1,6 +1,10 @@
 nav.tab-nav
   .container.is-padding-horizontal-0-sm-down
     ul.tab-nav__items
-      - %w(student_and_trainee followings job_seeking mentor graduate adviser trainee all).each do |target|
+      - if current_user.adviser? || current_user.mentor?
+        - targets = %w(student_and_trainee followings job_seeking mentor graduate adviser trainee all)
+      - else
+        - targets = %w(student_and_trainee followings mentor graduate adviser trainee all)
+      - targets.each do |target|
         li.tab-nav__item
           = link_to t("target.#{target}"), users_path(target: target), class: (@target == target ? ["is-active"] : []) << "tab-nav__item-link"


### PR DESCRIPTION
#2080  の作業です。
メンター・アドバイザーでないユーザーは就活中のユーザーのタブを非表示に変更しました。

変更前
<img width="1084" alt="スクリーンショット 2020-11-12 16 17 34" src="https://user-images.githubusercontent.com/52710925/98907806-c4fcdb80-2502-11eb-8cc2-2cbc1d5ee799.png">

変更後
<img width="1089" alt="スクリーンショット 2020-11-12 16 16 29" src="https://user-images.githubusercontent.com/52710925/98907782-bc0c0a00-2502-11eb-9238-ccd715857e0c.png">







