### PR TITLE
READMEに「RakeTaskの実装方法」へのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ $ ./bin/lint
 ## その他
 
 - [nodeのバージョン切り替え](https://github.com/fjordllc/bootcamp/wiki/node%E3%81%AE%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E5%88%87%E3%82%8A%E6%9B%BF%E3%81%88)
+
+- [Rake Taskの実装方法](https://github.com/fjordllc/bootcamp/wiki/Rake-Task%E3%81%AE%E5%AE%9F%E8%A3%85%E6%96%B9%E6%B3%95)


### PR DESCRIPTION
READMEに「RakeTaskの実装方法」のwikiへのリンクを追加しました。
(雑談タイムにて決定)