### PR TITLE
ユーザー一覧に企業のロゴマークをつける

### DIFF
--- a/app/assets/stylesheets/blocks/user/_users-items.sass
+++ b/app/assets/stylesheets/blocks/user/_users-items.sass
@@ -59,14 +59,14 @@
 
 .user-item__company-logo
   max-width: 5rem
-  +position(absolute, right 0, top 0)
+  +position(absolute, right 0.5rem, top 0.5rem)
   border-radius: .25rem
   border: solid 1px $border
   +media-breakpoint-down(lg)
     max-height: 3.5rem
-    +position(absolute, right -2rem, top -2rem)
+    +position(absolute, right -0.5rem, top -0.5rem)
     border-radius: 50%
   +media-breakpoint-down(sm)
     max-height: 3.5rem
-    +position(absolute, right -1.25rem, top -2rem)
+    +position(absolute, right -0.5rem, top -0.5rem)
     border-radius: 50%

--- a/app/assets/stylesheets/blocks/user/_users-items.sass
+++ b/app/assets/stylesheets/blocks/user/_users-items.sass
@@ -56,3 +56,17 @@
   text-align: center
   margin-top: -.25rem
   padding-bottom: 1rem
+
+.user-item__company-logo
+  max-width: 5rem
+  +position(absolute, right 0, top 0)
+  border-radius: .25rem
+  border: solid 1px $border
+  +media-breakpoint-down(lg)
+    max-height: 3.5rem
+    +position(absolute, right -2rem, top -2rem)
+    border-radius: 50%
+  +media-breakpoint-down(sm)
+    max-height: 3.5rem
+    +position(absolute, right -1.25rem, top -2rem)
+    border-radius: 50%

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -15,6 +15,9 @@
             li.users-item-names__item
               .users-item-names__ful-name
                 = user.name
+              - if user.company.present? && user.company.logo.attached?
+                = link_to company_path(user.company) do
+                  = image_tag user.company.logo_url, class: "user-profile__company-logo"
             - if user.slack_account.present?
               li.users-item-names__item
                 .users-item-names__slack

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -17,7 +17,7 @@
                 = user.name
               - if user.company.present? && user.company.logo.attached?
                 = link_to company_path(user.company) do
-                  = image_tag user.company.logo_url, class: "user-profile__company-logo"
+                  = image_tag user.company.logo_url, class: "user-item__company-logo"
             - if user.slack_account.present?
               li.users-item-names__item
                 .users-item-names__slack


### PR DESCRIPTION
Issue #2051 の対応。
プロフィールページと同じように、ユーザー一覧のユーザーカードにロゴを追加しました。

 <a href="https://gyazo.com/d204716811d3f5f5c94f03d4af5aca66"><img src="https://i.gyazo.com/d204716811d3f5f5c94f03d4af5aca66.png" alt="Image from Gyazo" width="374"/></a>→→→<a href="https://gyazo.com/6d655e9d80f1a2b039b0bd4f31d88edd"><img src="https://i.gyazo.com/6d655e9d80f1a2b039b0bd4f31d88edd.png" alt="Image from Gyazo" width="373"/></a>