### PR TITLE
提出物一覧をpublished_at順で並べる

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -13,7 +13,7 @@ class ProductsController < ApplicationController
         { comments: { user: :avatar_attachment } },
         { user: [{ avatar_attachment: :blob }, :company] },
         { checks: { user: [:company] } })
-      .order(created_at: :desc)
+      .order(published_at: :desc)
       .page(params[:page])
   end
 

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -20,6 +20,7 @@ class ProductCallbacks
         )
       end
       product.published_at = Time.current
+      product.save
       product.change_learning_status(:submitted)
     end
 

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -41,6 +41,8 @@ namespace :bootcamp do
       puts "== END   Cloud Build Task =="
       pages = Page.where(published_at: nil, wip: false)
       pages.each { |page| page.update(published_at: page.updated_at) }
+      products = Product.where(published_at: nil, wip: false)
+      products.each { |product| product.update(published_at: product.updated_at) }
     end
   end
 

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -41,8 +41,8 @@ namespace :bootcamp do
       puts "== END   Cloud Build Task =="
       pages = Page.where(published_at: nil, wip: false)
       pages.each { |page| page.update(published_at: page.updated_at) }
-      products = Product.where(published_at: nil, wip: false)
-      products.each { |product| product.update(published_at: product.updated_at) }
+
+      Product.where(published_at: nil, wip: false).update_all("published_at = updated_at")
     end
   end
 


### PR DESCRIPTION
ref:  #2068
published_at(提出日)カラムが1ヶ月ほど前に[こちらのPR](https://github.com/fjordllc/bootcamp/pull/1947)にて追加されたので、
提出物一覧をcreated_at順→published_at順に変更しました。

それに伴い
- published_atカラムに値が保存されない問題を修正
- 既存の提出物のpublished_at値が空になっているので、updated_at値(=提出操作した状態)を登録

作業を行いました。