### PR TITLE
日報・提出物・イベントのコメント通知をWatchに変更

### DIFF
--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -2,7 +2,7 @@
 
 class CommentCallbacks
   def after_create(comment)
-    if [Report, Product, Event].include?(comment.commentable.class)
+    if comment.commentable.class.include?(Watchable)
       create_watch(comment)
       notify_to_watching_user(comment)
     else

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -2,13 +2,13 @@
 
 class CommentCallbacks
   def after_create(comment)
-    if comment.sender != comment.receiver
-      notify_comment(comment)
-    end
-
     if [Report, Product, Event].include?(comment.commentable.class)
       create_watch(comment)
       notify_to_watching_user(comment)
+    else
+      if comment.sender != comment.receiver
+        notify_comment(comment)
+      end
     end
 
     if comment.commentable.class == Product

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,6 +16,8 @@ class Event < ApplicationRecord
   validates :open_start_at, presence: true
   validates :open_end_at, presence: true
 
+  after_create EventCallbacks.new
+
   with_options if: -> { start_at && end_at } do
     validate :end_at_be_greater_than_start_at
   end

--- a/app/models/event_callbacks.rb
+++ b/app/models/event_callbacks.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class EventCallbacks
+  def after_create(event)
+    create_author_watch(event)
+  end
+
+  private
+    def create_author_watch(event)
+      Watch.create!(user: event.user, watchable: event)
+    end
+end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -2,6 +2,8 @@
 
 class ProductCallbacks
   def after_create(product)
+    create_author_watch(product)
+
     Cache.delete_unchecked_product_count
     Cache.delete_not_responded_product_count
   end
@@ -35,6 +37,10 @@ class ProductCallbacks
   end
 
   private
+    def create_author_watch(product)
+      Watch.create!(user: product.user, watchable: product)
+    end
+
     def send_notification(product:, receivers:, message:)
       receivers.each do |receiver|
         NotificationFacade.submitted(product, receiver, message)

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -2,6 +2,8 @@
 
 class ReportCallbacks
   def after_create(report)
+    create_author_watch(report)
+
     if report.user.reports.count == 1 && !report.wip?
       send_first_report_notification(report)
     end
@@ -35,6 +37,10 @@ class ReportCallbacks
   end
 
   private
+    def create_author_watch(report)
+      Watch.create!(user: report.user, watchable: report)
+    end
+
     def send_first_report_notification(report)
       receiver_list = User.where(retired_on: nil)
       receiver_list.each do |receiver|

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -38,6 +38,15 @@ namespace :bootcamp do
     task :cloudbuild do
       puts "== START Cloud Build Task =="
       puts "#{User.count}件"
+      Report.includes(:user, :watches).each do |report|
+        Watch.find_or_create_by!(user: report.user, watchable: report)
+      end
+      Product.includes(:user, :watches).each do |product|
+        Watch.find_or_create_by!(user: product.user, watchable: product)
+      end
+      Event.includes(:user, :watches).each do |event|
+        Watch.find_or_create_by!(user: event.user, watchable: event)
+      end
       puts "== END   Cloud Build Task =="
       pages = Page.where(published_at: nil, wip: false)
       pages.each { |page| page.update(published_at: page.updated_at) }

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -38,20 +38,18 @@ namespace :bootcamp do
     task :cloudbuild do
       puts "== START Cloud Build Task =="
       puts "#{User.count}件"
-      Report.includes(:user, :watches).each do |report|
-        Watch.find_or_create_by!(user: report.user, watchable: report)
-      end
-      Product.includes(:user, :watches).each do |product|
-        Watch.find_or_create_by!(user: product.user, watchable: product)
-      end
-      Event.includes(:user, :watches).each do |event|
-        Watch.find_or_create_by!(user: event.user, watchable: event)
+      ActiveRecord::Base.transaction do
+        Report.includes(:user, :watches).each do |report|
+          Watch.find_or_create_by!(user: report.user, watchable: report)
+        end
+        Product.includes(:user, :watches).each do |product|
+          Watch.find_or_create_by!(user: product.user, watchable: product)
+        end
+        Event.includes(:user, :watches).each do |event|
+          Watch.find_or_create_by!(user: event.user, watchable: event)
+        end
       end
       puts "== END   Cloud Build Task =="
-      pages = Page.where(published_at: nil, wip: false)
-      pages.each { |page| page.update(published_at: page.updated_at) }
-
-      Product.where(published_at: nil, wip: false).update_all("published_at = updated_at")
     end
   end
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -37,6 +37,7 @@ class EventsTest < ApplicationSystemTestCase
     end
     assert_text "イベントをWIPとして保存しました。"
     assert_text "公開されるまでお待ちください。"
+    assert_text "Watch中"
   end
 
   test "create a new event" do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -83,6 +83,7 @@ class ProductsTest < ApplicationSystemTestCase
     end
     click_button "提出する"
     assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
+    assert_text "Watch中"
   end
 
   test "create product change status submitted" do

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -38,6 +38,7 @@ class ReportsTest < ApplicationSystemTestCase
     click_button "提出"
     assert_text "日報を保存しました。"
     assert_text Time.current.strftime("%Y年%m月%d日")
+    assert_text "Watch中"
   end
 
   test "create and update learning times in a report" do


### PR DESCRIPTION
Ref: #2013 

## 概要

「日報・提出物・イベント」を作成したときに、作成者が自動的にWatchするようにしました。

これまで、Watchとは関係なく、「日報・提出物・イベント」にコメントがつくと作成者にコメント通知が送られていたので、この通知は送られないように変更しました。

既存の「日報・提出物・イベント」について、作成者がWatch中になるよう rake task を作成しました。