### PR TITLE
リタイアページを認証必須にした

### DIFF
--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RetirementController < ApplicationController
+  before_action :require_login, except: %i(show)
+
   def show
   end
 


### PR DESCRIPTION
今まで認証がかかってなかった。