### PR TITLE
Docs、空のpublished_atカラムにupdated_atの値を代入

### DIFF
--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -39,6 +39,8 @@ namespace :bootcamp do
       puts "== START Cloud Build Task =="
       puts "#{User.count}件"
       puts "== END   Cloud Build Task =="
+      pages = Page.where(published_at: nil, wip: false)
+      pages.each { |page| page.update(published_at: page.updated_at) }
     end
   end
 


### PR DESCRIPTION
#2087 のissueに対応。
Docsのpublished_atカラムが空になっている物に対し、updated_atの値を代入します。