### PR TITLE
Docsのタグ一覧を常に表示するように変更

### DIFF
--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -26,15 +26,14 @@ header.page-header
       .two-columns__inner
         .thread-list.a-card
           = render partial: "pages/page", collection: @pages, as: :page
-      - if @pages.all_tags.any?
+      - if Page.all_tags.any?
         nav.page-tags-nav
           header.page-tags-nav__header
             h2.page-tags-nav__title
               | タグ一覧
           .page-tags-nav__body
             ul.page-tags-nav__items
-              - @pages.all_tags.each do |tag|
-                - if tag.present?
-                  li.page-tags-nav__item
-                    = link_to tag.name, pages_tag_path(tag.name), class: "page-tags-nav__item-link"
+              - Page.all_tags.each do |tag|
+                li.page-tags-nav__item
+                  = link_to tag.name, pages_tag_path(tag.name), class: "page-tags-nav__item-link"
     = paginate @pages, position: "bottom"


### PR DESCRIPTION
ref #1981 

全Docsのタグを常にタグ一覧に表示するようにしました。
