### PR TITLE
Doc詳細、一覧画面に公開日（published_at）と最終更新日(updated_at) を表示する

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-header.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-header.sass
@@ -6,8 +6,6 @@
       padding-top: 3.5rem
   +media-breakpoint-down(sm)
     padding: 2.5rem .75rem .75rem
-    .thread.is-page &
-      padding-top: .75rem
 
 .thread-header__author-link
   +position(absolute, left 50%)
@@ -141,9 +139,22 @@ a.thread-header__author
   +hover-link-reversal
   color: $main
 
+.thread-header__lower-side-dates
+  +media-breakpoint-up(md)
+    display: flex
+
 .thread-header__lower-side-date
   display: flex
   color: $muted-text
+  .thread-header__lower-side-date + &
+    +media-breakpoint-up(md)
+      margin-left: .125rem
+    +media-breakpoint-down(sm)
+      margin-top: .125rem
+    &::before
+      content: "（"
+    &::after
+      content: "）"
 
 .thread-header__lower-side-label
   &::after

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,7 +7,8 @@ class PagesController < ApplicationController
 
   def index
     @pages = Page.with_avatar
-                 .includes(:comments, :practice)
+                 .includes(:comments, :practice,
+                 { last_updated_user: { avatar_attachment: :blob } })
                  .order(updated_at: :desc)
                  .page(params[:page])
     @pages = @pages.tagged_with(params[:tag]) if params[:tag]

--- a/app/views/pages/_page.slim
+++ b/app/views/pages/_page.slim
@@ -22,43 +22,23 @@
         .thread-list-item-meta__item
           - if page.wip?
             .thread-list-item-meta__datetime
-              | Doc作成中 by
-              = render "users/icon",
-                user: page.user,
-                link_class: "thread-header__user-icon-link",
-                image_class: "thread-header__user-icon"
-              = link_to page.user, class: "thread-header__user-link" do
-                | #{page.user.login_name}
+              | Doc作成中
           - elsif page.published_at.present?
             time.thread-list-item-meta__datetime(datetime="#{page.published_at.to_datetime}")
               span.thread-list-item-meta__datetime-label
-                | 公開日
-              | #{l page.published_at} by
-              = render "users/icon",
-                user: page.user,
-                link_class: "thread-header__user-icon-link",
-                image_class: "thread-header__user-icon"
-              = link_to page.user, class: "thread-header__user-link" do
-                | #{page.user.login_name}
-
-          time.thread-list-item-meta__datetime(datetime="#{page.updated_at.to_datetime}")
-            span.thread-list-item-meta__datetime-label
-              | 最終更新日
-            | #{l page.updated_at} by
-            - if page.last_updated_user.present?
+                | 公開
+              | #{l page.published_at}
+          - if page.last_updated_user.present?
+            time.thread-list-item-meta__datetime(datetime="#{page.updated_at.to_datetime}")
+              span.thread-list-item-meta__datetime-label
+                | 最終更新
+              | #{l page.updated_at} by
               = render "users/icon",
                 user: page.last_updated_user,
                 link_class: "thread-header__user-icon-link",
                 image_class: "thread-header__user-icon"
               = link_to page.last_updated_user, class: "thread-header__user-link" do
                 | #{page.last_updated_user.login_name}
-            - else
-              = render "users/icon",
-                user: page.user,
-                link_class: "thread-header__user-icon-link",
-                image_class: "thread-header__user-icon"
-              = link_to page.user, class: "thread-header__user-link" do
-                | #{page.user.login_name}
 
       - if page.comments.any?
         .thread-list-item-meta__comment-count

--- a/app/views/pages/_page.slim
+++ b/app/views/pages/_page.slim
@@ -18,8 +18,48 @@
       h3.thread-list-item__sub-title
         = page.practice.title
     .thread-list-item-meta
-      time.thread-list-item-meta__datetime(datetime="#{page.updated_at.to_datetime}" pubdate="pubdate")
-        = l page.updated_at
+      .thread-list-item-meta__items
+        .thread-list-item-meta__item
+          - if page.wip?
+            .thread-list-item-meta__datetime
+              | Doc作成中 by
+              = render "users/icon",
+                user: page.user,
+                link_class: "thread-header__user-icon-link",
+                image_class: "thread-header__user-icon"
+              = link_to page.user, class: "thread-header__user-link" do
+                | #{page.user.login_name}
+          - elsif page.published_at.present?
+            time.thread-list-item-meta__datetime(datetime="#{page.published_at.to_datetime}")
+              span.thread-list-item-meta__datetime-label
+                | 公開日
+              | #{l page.published_at} by
+              = render "users/icon",
+                user: page.user,
+                link_class: "thread-header__user-icon-link",
+                image_class: "thread-header__user-icon"
+              = link_to page.user, class: "thread-header__user-link" do
+                | #{page.user.login_name}
+
+          time.thread-list-item-meta__datetime(datetime="#{page.updated_at.to_datetime}")
+            span.thread-list-item-meta__datetime-label
+              | 最終更新日
+            | #{l page.updated_at} by
+            - if page.last_updated_user.present?
+              = render "users/icon",
+                user: page.last_updated_user,
+                link_class: "thread-header__user-icon-link",
+                image_class: "thread-header__user-icon"
+              = link_to page.last_updated_user, class: "thread-header__user-link" do
+                | #{page.last_updated_user.login_name}
+            - else
+              = render "users/icon",
+                user: page.user,
+                link_class: "thread-header__user-icon-link",
+                image_class: "thread-header__user-icon"
+              = link_to page.user, class: "thread-header__user-link" do
+                | #{page.user.login_name}
+
       - if page.comments.any?
         .thread-list-item-meta__comment-count
           .thread-list-item-meta__comment-count-label

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -29,47 +29,35 @@ header.page-header
                 | WIP
             | #{@page.title}
           .thread-header__lower-side
-            .thread-header__lower-side-date
-              - if @page.wip?
-                .thread-header__lower-side-value
-                  | Doc作成中 by
-                  = render "users/icon",
-                    user: @page.user,
-                    link_class: "thread-header__user-icon-link",
-                    image_class: "thread-header__user-icon"
-                  = link_to @page.user, class: "thread-header__user-link" do
-                    | #{@page.user.login_name}
-              - elsif @page.published_at.present?
-                span.thread-header__lower-side-label
-                  | 公開日
-                time.thread-header__lower-side-value(datetime="#{@page.published_at.to_datetime}")
-                  | #{l @page.published_at} by
-                  = render "users/icon",
-                    user: @page.user,
-                    link_class: "thread-header__user-icon-link",
-                    image_class: "thread-header__user-icon"
-                  = link_to @page.user, class: "thread-header__user-link" do
-                    | #{@page.user.login_name}
+            .thread-header__lower-side-dates
+              .thread-header__lower-side-date
+                - if @page.wip?
+                  .thread-header__lower-side-value
+                    | Doc作成中 by
+                    = render "users/icon",
+                      user: @page.user,
+                      link_class: "thread-header__user-icon-link",
+                      image_class: "thread-header__user-icon"
+                    = link_to @page.user, class: "thread-header__user-link" do
+                      | #{@page.user.login_name}
+                - elsif @page.published_at.present?
+                  span.thread-header__lower-side-label
+                    | 公開
+                  time.thread-header__lower-side-value(datetime="#{@page.published_at.to_datetime}")
+                    | #{l @page.published_at}
 
-            .thread-header__lower-side-date
-              span.thread-header__lower-side-label
-                | 最終更新日
-              time.thread-header__lower-side-value(datetime="#{@page.updated_at.to_datetime}")
-                | #{l @page.updated_at} by
-                - if @page.last_updated_user.present?
-                  = render "users/icon",
-                    user: @page.last_updated_user,
-                    link_class: "thread-header__user-icon-link",
-                    image_class: "thread-header__user-icon"
-                  = link_to @page.last_updated_user, class: "thread-header__user-link" do
-                    | #{@page.last_updated_user.login_name}
-                - else
-                  = render "users/icon",
-                    user: @page.user,
-                    link_class: "thread-header__user-icon-link",
-                    image_class: "thread-header__user-icon"
-                  = link_to @page.user, class: "thread-header__user-link" do
-                    | #{@page.user.login_name}
+              - if @page.last_updated_user.present?
+                .thread-header__lower-side-date
+                  span.thread-header__lower-side-label
+                    | 最終更新
+                  time.thread-header__lower-side-value(datetime="#{@page.updated_at.to_datetime}")
+                    | #{l @page.updated_at} by
+                    = render "users/icon",
+                      user: @page.last_updated_user,
+                      link_class: "thread-header__user-icon-link",
+                      image_class: "thread-header__user-icon"
+                    = link_to @page.last_updated_user, class: "thread-header__user-link" do
+                      | #{@page.last_updated_user.login_name}
 
         #js-page-tags(data-tags-initial-value="#{@page.tag_list.join(",")}" data-tags-param-name="page[tag_list]" data-page-id="#{@page.id}")
         .thread__body

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -30,28 +30,47 @@ header.page-header
             | #{@page.title}
           .thread-header__lower-side
             .thread-header__lower-side-date
-              - if @page.last_updated_user.present?
-                .thread-header__lower-side-label
-                  | 最終更新
-                time.thread-header__lower-side-value(datetime="#{@page.updated_at.to_datetime}" pubdate="pubdate")
-                    | #{l @page.updated_at} by
-                    = render "users/icon",
-                      user: @page.last_updated_user,
-                      link_class: "thread-header__user-icon-link",
-                      image_class: "thread-header__user-icon"
-                    = link_to @page.last_updated_user, class: "thread-header__user-link" do
-                      | #{@page.last_updated_user.login_name}
-              - else
-                .thread-header__lower-side-label
-                  | 新規作成
-                time.thread-header__lower-side-value(datetime="#{@page.created_at.to_datetime}" pubdate="pubdate")
-                    | #{l @page.created_at} by
-                    = render "users/icon",
-                      user: @page.user,
-                      link_class: "thread-header__user-icon-link",
-                      image_class: "thread-header__user-icon"
-                    = link_to @page.user, class: "thread-header__user-link" do
-                      | #{@page.user.login_name}
+              - if @page.wip?
+                .thread-header__lower-side-value
+                  | Doc作成中 by
+                  = render "users/icon",
+                    user: @page.user,
+                    link_class: "thread-header__user-icon-link",
+                    image_class: "thread-header__user-icon"
+                  = link_to @page.user, class: "thread-header__user-link" do
+                    | #{@page.user.login_name}
+              - elsif @page.published_at.present?
+                span.thread-header__lower-side-label
+                  | 公開日
+                time.thread-header__lower-side-value(datetime="#{@page.published_at.to_datetime}")
+                  | #{l @page.published_at} by
+                  = render "users/icon",
+                    user: @page.user,
+                    link_class: "thread-header__user-icon-link",
+                    image_class: "thread-header__user-icon"
+                  = link_to @page.user, class: "thread-header__user-link" do
+                    | #{@page.user.login_name}
+
+            .thread-header__lower-side-date
+              span.thread-header__lower-side-label
+                | 最終更新日
+              time.thread-header__lower-side-value(datetime="#{@page.updated_at.to_datetime}")
+                | #{l @page.updated_at} by
+                - if @page.last_updated_user.present?
+                  = render "users/icon",
+                    user: @page.last_updated_user,
+                    link_class: "thread-header__user-icon-link",
+                    image_class: "thread-header__user-icon"
+                  = link_to @page.last_updated_user, class: "thread-header__user-link" do
+                    | #{@page.last_updated_user.login_name}
+                - else
+                  = render "users/icon",
+                    user: @page.user,
+                    link_class: "thread-header__user-icon-link",
+                    image_class: "thread-header__user-icon"
+                  = link_to @page.user, class: "thread-header__user-link" do
+                    | #{@page.user.login_name}
+
         #js-page-tags(data-tags-initial-value="#{@page.tag_list.join(",")}" data-tags-param-name="page[tag_list]" data-page-id="#{@page.id}")
         .thread__body
           .thread__description.js-markdown-view.js-target-blank.is-long-text


### PR DESCRIPTION
#2095  の作業です。
Doc詳細、一覧画面に公開日（published_at）と最終更新日(updated_at) を表示するようにしました。
# 変更前

## Doc一覧画面
<img width="818" alt="スクリーンショット 2020-11-28 17 45 18" src="https://user-images.githubusercontent.com/52710925/100497889-a0129480-31a1-11eb-9c52-943d9cbea76d.png">


## Doc詳細画面

<img width="868" alt="スクリーンショット 2020-11-28 17 44 38" src="https://user-images.githubusercontent.com/52710925/100497866-6e013280-31a1-11eb-9120-ca9f90d17961.png">

# 変更後
## Doc一覧画面
<img width="840" alt="スクリーンショット 2020-11-28 17 47 47" src="https://user-images.githubusercontent.com/52710925/100497924-f089f200-31a1-11eb-89e3-1e1fbbc65a6c.png">



## Doc詳細画面
<img width="861" alt="スクリーンショット 2020-11-28 17 49 06" src="https://user-images.githubusercontent.com/52710925/100497949-12837480-31a2-11eb-84b4-8f969cdf6aec.png">



