### PR TITLE
管理者はDocのユーザーを変更できる

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,7 +24,11 @@ class PagesController < ApplicationController
 
   def create
     @page = Page.new(page_params)
-    @page.user = current_user
+    if @page.user
+      @page.last_updated_user = current_user
+    else
+      @page.user = current_user
+    end
     set_wip
     if @page.save
       redirect_to @page, notice: notice_message(@page, :create)
@@ -54,7 +58,11 @@ class PagesController < ApplicationController
     end
 
     def page_params
-      params.require(:page).permit(:title, :body, :tag_list)
+      if admin_login?
+        params.require(:page).permit(:title, :body, :tag_list, :user_id)
+      else
+        params.require(:page).permit(:title, :body, :tag_list)
+      end
     end
 
     def set_wip

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -5,6 +5,11 @@
       .col-md-6.col-xs-12
         = f.label :title, class: "a-label"
         = f.text_field :title, class: "a-text-input js-warning-form"
+      - if admin_login?
+        .col-md-3.col-xs-6
+          = f.label :user, class: "a-label"
+          .select-users
+            = f.select(:user_id, User.where(retired_on: nil).pluck(:login_name, :id).sort, { include_blank: (page.user || current_user).login_name }, { class: "js-select2" })
   .form-item
     .row.js-markdown-parent
       .col-md-6.col-xs-12

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -133,6 +133,7 @@ ja:
         finished_at: 終了時間
       page:
         title: タイトル
+        user: ユーザー
         body: 本文
         tag_list: タグ
       question:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_10_14_114543) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -402,15 +403,15 @@ ActiveRecord::Schema.define(version: 2020_10_14_114543) do
     t.boolean "mail_notification", default: true, null: false
     t.integer "prefecture_code"
     t.boolean "job_seeker", default: false, null: false
+    t.string "github_id"
     t.boolean "slack_participation", default: true, null: false
     t.boolean "github_collaborator", default: false, null: false
     t.boolean "officekey_permission", default: false, null: false
-    t.string "github_id"
+    t.string "name", default: "", null: false
+    t.string "name_kana", default: "", null: false
     t.integer "satisfaction"
     t.text "opinion"
     t.bigint "retire_reasons", default: 0, null: false
-    t.string "name", default: "", null: false
-    t.string "name_kana", default: "", null: false
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_10_14_114543) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -403,15 +402,15 @@ ActiveRecord::Schema.define(version: 2020_10_14_114543) do
     t.boolean "mail_notification", default: true, null: false
     t.integer "prefecture_code"
     t.boolean "job_seeker", default: false, null: false
-    t.string "github_id"
     t.boolean "slack_participation", default: true, null: false
     t.boolean "github_collaborator", default: false, null: false
     t.boolean "officekey_permission", default: false, null: false
-    t.string "name", default: "", null: false
-    t.string "name_kana", default: "", null: false
+    t.string "github_id"
     t.integer "satisfaction"
     t.text "opinion"
     t.bigint "retire_reasons", default: 0, null: false
+    t.string "name", default: "", null: false
+    t.string "name_kana", default: "", null: false
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"


### PR DESCRIPTION
Issue #1751 への対応

管理者がdocのユーザーを変更できるようにしました。
※この管理者は、adminのみで、メンターは含まれてないです。
Issueでの指定通り、日報のプラクティス選択等と同じようにselect2を用いています。
[![Image from Gyazo](https://i.gyazo.com/a567b7a65ac43963fb282338a71dc340.gif)](https://gyazo.com/a567b7a65ac43963fb282338a71dc340)