### PR TITLE
退会済ユーザーや就職活動中ユーザーの一覧を管理者のみアクセス可に

### DIFF
--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -1,10 +1,12 @@
 nav.tab-nav
   .container.is-padding-horizontal-0-sm-down
     ul.tab-nav__items
-      - if current_user.adviser? || current_user.mentor?
+      - if current_user.mentor?
         - targets = %w(student_and_trainee followings job_seeking mentor graduate adviser trainee all)
+      - elsif current_user.adviser?
+        - targets = %w(student_and_trainee followings job_seeking mentor graduate adviser trainee)
       - else
-        - targets = %w(student_and_trainee followings mentor graduate adviser trainee all)
+        - targets = %w(student_and_trainee followings mentor graduate adviser trainee)
       - targets.each do |target|
         li.tab-nav__item
           = link_to t("target.#{target}"), users_path(target: target), class: (@target == target ? ["is-active"] : []) << "tab-nav__item-link"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -156,4 +156,40 @@ class UsersTest < ApplicationSystemTestCase
     visit "/"
     assert_no_text "1ヶ月以上ログインのないユーザー"
   end
+
+  test "student access control" do
+    login_user "kimura", "testtest"
+    visit "/users"
+    assert_no_text "全員"
+    assert_no_text "就職活動中"
+
+    visit "users?target=retired"
+    assert_no_text "リタイア"
+    assert_no_text "退会"
+  end
+
+  test "advisor access control" do
+    login_user "advijirou", "testtest"
+    visit "/users"
+    assert_no_text "全員"
+    assert find_link("就職活動中")
+
+    visit "users?target=retired"
+    assert_no_text "リタイア"
+    assert_no_text "退会"
+  end
+
+  test "mentor access control" do
+    login_user "yamada", "testtest"
+    visit "/users"
+    assert find_link("就職活動中")
+    assert find_link("全員")
+  end
+
+  test "admin access control" do
+    login_user "komagata", "testtest"
+    visit "/users"
+    assert find_link("就職活動中")
+    assert find_link("全員")
+  end
 end


### PR DESCRIPTION
## 概要

Issue #2097 への対応

以下のターゲットを管理者のみアクセス可にしました。
- job_seeking
- retired
- inactive 
- all

※管理者(メンター含む)は全てのページを開けますが、アドバイザーは就職活動中(job_seeking)のユーザーまでです。
※アドバイザーと生徒のビュー画面から、退会済みユーザーも含む「全員(all)」ボタンはなくなりました。

## 関連Issue & PR

- Issue #2080 & PR #2093
  就職活動中のユーザーの一覧へのボタン導線を生徒画面から削除するIssue & PRへの追加的な対応です。
  ここで、アドバイザー&メンターのみ、就職活動中ユーザーの一覧ボタンが表示されるようになりました。