### PR TITLE
secretがないときのJWT secretを設定

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -444,7 +444,7 @@ Rails.application.config.sorcery.configure do |config|
     # user.provider_uid_attribute_name =
 
     # -- jwt --
-    user.jwt_secret = Rails.application.secrets.secret_key_base
+    user.jwt_secret = Rails.application.secrets.secret_key_base || "dummy"
     # user.jwt_algorithm = "HS256" # HS256 is used by default.
     # user.session_expiry = 60 * 60 * 24 * 7 * 2 # 2 weeks is used by default.
   end


### PR DESCRIPTION
assets:precompile時に落ちるため