### PR TITLE
ユーザーネームで検索結果の絞り込みをできるようにした

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-list-item-meta.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item-meta.sass
@@ -64,3 +64,6 @@
 
 .thread-list-item-meta__created-at
   +text-block(.75rem 1.4, $muted-text)
+
+.thread-list-item-meta__updated-at
+  +text-block(.75rem 1.4, $muted-text)

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -8,8 +8,8 @@ module Searchable
       ransack(**params_for_keyword_search(searched_values)).result
     end
 
-    def columns_for_keyword_search(*key_names)
-      define_singleton_method(:_grouping_condition) { "#{key_names.join("_or_")}_cont_all" }
+    def columns_for_keyword_search(*column_names)
+      define_singleton_method(:_join_column_names) { "#{column_names.join("_or_")}_cont_all" }
     end
 
     private

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -41,9 +41,6 @@ module Searchable
       end
   end
 
-  included do
-  end
-
   def description
     case self
     when Page

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -24,7 +24,7 @@ module Searchable
 
       def word_to_groupings(word)
         case word
-        when /(?<=user:)+(.*)/
+        when /user:(.*)/
           create_parameter_for_search_user_id($1)
         else
           { _join_column_names => word }

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -16,13 +16,13 @@ class Searcher
     def search(word, document_type: :all)
       case document_type
       when :all
-        AVAILABLE_TYPES.flat_map { |type| result_for(type, word) }.sort_by { |result| result.created_at }.reverse
+        AVAILABLE_TYPES.flat_map { |type| result_for(type, word) }.sort_by(&:updated_at).reverse
       when commentable?
-        [document_type, :comments].flat_map { |type| result_for(type, word, commentable_type: model_name(document_type)) }.sort_by { |result| result.created_at }.reverse
+        [document_type, :comments].flat_map { |type| result_for(type, word, commentable_type: model_name(document_type)) }.sort_by(&:updated_at).reverse
       when :questions
-        [document_type, :answers].flat_map { |type| result_for(type, word) }
+        [document_type, :answers].flat_map { |type| result_for(type, word) }.sort_by(&:updated_at).reverse
       else
-        result_for(document_type, word).sort_by { |result| result.created_at }.reverse
+        result_for(document_type, word).sort_by(&:updated_at).reverse
       end
     end
 

--- a/app/views/searchables/_searchable.html.slim
+++ b/app/views/searchables/_searchable.html.slim
@@ -13,5 +13,5 @@
         .thread-list-item-meta__user
           - if searchable.class != Practice && searchable.class != Page
             = link_to searchable.user.login_name, searchable.user, class: "thread-header__author"
-        time.thread-list-item-meta__created-at(datetime="#{searchable.created_at.to_datetime}" pubdate="pubdate")
+        time.thread-list-item-meta__updated-at(datetime="#{searchable.updated_at.to_datetime}" pubdate="pubdate")
           = l searchable.updated_at

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -182,3 +182,17 @@ report_23:
   description:
     フォローされました。
   reported_on: "2020-11-10"
+
+report_24:
+  user: daimyo
+  title: 検索用の日報
+  description:
+    ユーザーネームで検索できるよ
+  reported_on: "2020-11-20"
+
+report_25:
+  user: hatsuno
+  title: 検索用の日報
+  description:
+    ユーザーネームで検索できるよ
+  reported_on: "2020-11-20"

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -79,9 +79,9 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Comment)
   end
 
-  test "sort search results in descending order of creation date" do
+  test "sort search results in descending order of updated date" do
     result = Searcher.search("検索結果確認用", document_type: :reports)
-    assert_equal [reports(:report_12), reports(:report_14), reports(:report_13)], result
+    assert_equal [reports(:report_14), reports(:report_13), reports(:report_12)], result
     assert_not_includes(result, Answer)
   end
 

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -198,4 +198,10 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, comments(:comment_14))
     assert_equal(6, result.size)
   end
+
+  test "returns only kimuras report when user param" do
+    result = Searcher.search("ユーザーネームで検索できるよ user:daimyo")
+    assert_includes(result, reports(:report_24))
+    assert_not_includes(result, reports(:report_25))
+  end
 end

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -78,14 +78,14 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_text "該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。"
   end
 
-  test "show user name and created time" do
+  test "show user name and updated time" do
     within("form[name=search]") do
       select "日報"
       fill_in "word", with: "テストの日報"
     end
     find("#test-search").click
     assert_text "yamada"
-    assert_css ".thread-list-item-meta__created-at"
+    assert_css ".thread-list-item-meta__updated-at"
     assert_no_text "テストの回答"
   end
 end


### PR DESCRIPTION
# 関連issue
https://github.com/fjordllc/bootcamp/issues/1809
https://github.com/fjordllc/bootcamp/issues/2131

# やったこと
- 検索パラメータとして `user:` を受け取れるようにしました。
- 例） `ruby user:ima1zumi` と指定すると、 `ruby` を含む `ima1zumi` の投稿だけが検索されます
- 間違ったユーザーネームを指定した場合、結果が表示されないようにしました（後述）
- 検索結果のソート順を `created_at` 降順から `updated_at` 降順に変更しました
    - #2131  
- 不要な `included` が残っていたため削除しました
- 抽象的なメソッド名を具体的なメソッド名に変更しました
    - `_grouping_condition` を `_join_column_names` に変更しました

# やらなかったこと
- `user:` を複数受け取ること
    - `テスト user:ima1zumi user:komagata` のような検索パラメータを受け取って `ima1zumi` と `komagata` の両方のデータを検索することはできません
- デザイン・説明はありません
    - 今の所、裏メニューとなっています 🤔 
    - 最終的には esa のように、検索バーの下に検索パラメータが出てきてほしいという話をしていましたが、この PR では対応しません
    - https://github.com/fjordllc/bootcamp/issues/1809#issuecomment-708171452

# 懸念点
間違ったユーザーネーム（例えば  `user:ima1zu` ）を受け取った際は検索結果を表示させたくありませんでした。この挙動は GitHub の issues の検索バーを意識しています。

![image](https://user-images.githubusercontent.com/52617472/100067305-7263dd80-2e79-11eb-85cf-2826a1a264ef.png)


同じ挙動にするために `user&.id` が `nil` の場合は `{ "user_id_eq" => 0 }` （存在しないユーザー）を検索するようにしています。

`id:0` を検索するのではなく別の方法も試してみましたが、 `{ "user_id_eq" => nil }`, `{ "user_id_eq" => false }`, `{ "user_id_eq" => "" }` で検索した場合は `user_id_eq` 検索パラメータ自体が無視されてしまいました。例えば、 `ruby user:ima1zu` と検索した場合は `ruby` の検索結果が全件表示されてしまいます。

このため、苦肉の策として `id:0` を検索するようにしています。

# スクリーンショット
![image](https://user-images.githubusercontent.com/52617472/100068159-7e9c6a80-2e7a-11eb-8556-dfa14b4581b3.png)
![image](https://user-images.githubusercontent.com/52617472/100068221-9673ee80-2e7a-11eb-974e-f7a53cee4f32.png)
