### PR TITLE
update_attributesをupdateに変更

### DIFF
--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -127,7 +127,7 @@ class Practice < ApplicationRecord
 
   def save_statistic(practice_id, average, median)
     learning_minute_statistic = LearningMinuteStatistic.find_or_initialize_by(practice_id: practice_id)
-    learning_minute_statistic.update_attributes(
+    learning_minute_statistic.update(
       average: average,
       median: median
     )


### PR DESCRIPTION
update_attributesはRails6.1で削除される予定のため

参考： https://edgeguides.rubyonrails.org/6_1_release_notes.html#active-record-removals