### PR TITLE
data_migrateでunsubscribe_email_token追加時にvalidationをスキップするようにした

### DIFF
--- a/db/data/20201124023746_add_unsubscribe_email_token.rb
+++ b/db/data/20201124023746_add_unsubscribe_email_token.rb
@@ -5,7 +5,7 @@ class AddUnsubscribeEmailToken < ActiveRecord::Migration[6.0]
     User.transaction do
       User.where(unsubscribe_email_token: nil).find_each do |user|
         user.unsubscribe_email_token = SecureRandom.urlsafe_base64
-        user.save!
+        user.save!(validate: false)
       end
     end
   end


### PR DESCRIPTION
data_migrateでunsubscribe_email_tokenに値を追加しようとするとvalidationでエラーになるため、スキップするように修正しました。

※ [1クリックで配信停止するリンクをメールに追加 by hogucc · Pull Request #2078](https://github.com/fjordllc/bootcamp/pull/2078)で実装したdata-migrateの、実行時に発生したエラーに対する修正です