### PR TITLE
提出物に提出者の直近の日報を表示

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,6 +465,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   active_decorator
@@ -536,4 +537,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.1.4
+   2.2.2

--- a/app/assets/stylesheets/blocks/practice/_practice-content.sass
+++ b/app/assets/stylesheets/blocks/practice/_practice-content.sass
@@ -31,9 +31,6 @@
   display: block
   margin-bottom: 2rem
   &.is-memo
-    height: calc(100vh - 4.25rem)
-    +position(sticky, top 3.5rem)
-    margin-bottom: 0
     .a-card
       height: 100%
     .thread-comment-form__markdown-parent
@@ -43,8 +40,6 @@
       margin-bottom: 0
     .thread-comment-form__markdown.is-preview
       overflow: auto
-    .thread-comment-form__textarea
-      height: calc(100% - 1rem) !important
 
 .practice-content__title
   +text-block(1rem 1.4, 600)
@@ -66,8 +61,6 @@
   +media-breakpoint-down(sm)
     padding: .5rem .75rem
   .practice-content.is-memo &
-    height: 100%
-    max-height: calc(100% - 6.75rem)
     overflow-y: auto
     padding: 1rem 1.25rem
 

--- a/app/assets/stylesheets/blocks/side/_side-tabs-contents.sass
+++ b/app/assets/stylesheets/blocks/side/_side-tabs-contents.sass
@@ -1,0 +1,13 @@
+.side-tabs-contents
+  +position(relative, 1)
+  
+.side-tabs-contents__item
+  display: none
+  .a-card
+    border-top-left-radius: 0
+
+#side-tabs-1:checked ~ .side-tabs-contents #side-tabs-content-1
+  display: block
+
+#side-tabs-2:checked ~ .side-tabs-contents #side-tabs-content-2
+  display: block

--- a/app/assets/stylesheets/blocks/side/_side-tabs-nav.sass
+++ b/app/assets/stylesheets/blocks/side/_side-tabs-nav.sass
@@ -1,0 +1,26 @@
+.side-tabs-nav
+
+.side-tabs-nav__items
+  display: flex
+
+#side-tabs-1:checked ~ .side-tabs-nav #side-tabs-nav-1
+  background-color: $base
+  color: $default-text
+
+#side-tabs-2:checked ~ .side-tabs-nav #side-tabs-nav-2
+  background-color: $base
+  color: $default-text
+
+.side-tabs-nav__item-link
+  +text-block(.875rem 1.4, flex)
+  cursor: pointer
+  padding: .75em 1.25em
+  border: solid 1px $border-shade
+  +position(relative, bottom -1px)
+  +border-radius(top, .25rem)
+  color: $muted-text
+  transition: all .2s ease-out
+  .side-tabs-nav__item:not(:first-child) &
+    margin-left: -1px
+  &:hover
+    color: $default-text

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -20,6 +20,7 @@ class ProductsController < ApplicationController
 
   def show
     @product = find_product
+    @reports = @product.user.reports.limit(10).order(reported_on: :DESC)
     @practice = find_practice
     @footprints = find_footprints
     footprint!

--- a/app/javascript/mentor_memo.vue
+++ b/app/javascript/mentor_memo.vue
@@ -1,8 +1,6 @@
 <template lang="pug">
   .practice-content.is-memo
     section.a-card(v-if="!editing")
-      header.practice-content__header.card-header
-        h2.practice-content__title メンター向けメモ
       .practice-content__body
         .js-target-blank.is-long-text(
           v-html="markdownMemo")

--- a/app/views/products/_report.html.slim
+++ b/app/views/products/_report.html.slim
@@ -1,0 +1,35 @@
+.thread-list-item(class="#{report.wip? ? "is-wip" : ""}")
+  .thread-list-item__inner
+    .thread-list-item__author
+      = render "users/icon", user: report.user, link_class: "thread-header__author", image_class: "thread-list-item__author-icon"
+    header.thread-list-item__header
+      .thread-list-item__header-title-container
+        - if report.wip?
+          .thread-list-item__header-icon.is-wip WIP
+        h2.thread-list-item__title(itemprop="name")
+          = link_to report, itemprop: "url", class: "thread-list-item__title-link js-unconfirmed-link" do
+            - if report.user.daimyo?
+              | ★
+            = report.title
+    .thread-list-item-meta
+      time.thread-list-item-meta__datetime(datetime="#{report.reported_on.to_datetime}")
+        = l report.reported_on
+        = "の日報"
+    - if report.comments.any?
+      .thread-list-item-meta
+        .thread-list-item-meta__label
+          | コメント
+        .thread-list-item-meta__comment-count
+          .thread-list-item-meta__comment-count-value
+            | （#{report.comments.size}）
+        = render partial: "comments/user_icons", collection: report.comments.commented_users, as: :user
+        time.thread-list-item-meta__datetime(datetime="#{report.comments.last.updated_at.to_datetime}" pubdate="pubdate")
+          | 〜 #{l report .comments.last.updated_at, format: :date_and_time}
+
+    - if report.checks.any?
+      .stamp.stamp-approve
+        h2.stamp__content.is-title 確認済
+        time.stamp__content.is-created-at
+          = l report.checks.last.created_at.to_date, format: :short
+        .stamp__content.is-user-name
+          = report.checks.last.user.login_name

--- a/app/views/products/_report.html.slim
+++ b/app/views/products/_report.html.slim
@@ -24,7 +24,7 @@
             | （#{report.comments.size}）
         = render partial: 'comments/user_icons', collection: report.comments.commented_users, as: :user
         time.thread-list-item-meta__datetime(datetime="#{report.comments.last.updated_at.to_datetime}" pubdate='pubdate')
-          | 〜 #{l report .comments.last.updated_at, format: :date_and_time}
+          | 〜 #{l report.comments.last.updated_at, format: :date_and_time}
 
     - if report.checks.any?
       .stamp.stamp-approve

--- a/app/views/products/_report.html.slim
+++ b/app/views/products/_report.html.slim
@@ -1,20 +1,20 @@
-.thread-list-item(class="#{report.wip? ? "is-wip" : ""}")
+.thread-list-item(class="#{report.wip? ? 'is-wip' : ''}")
   .thread-list-item__inner
     .thread-list-item__author
-      = render "users/icon", user: report.user, link_class: "thread-header__author", image_class: "thread-list-item__author-icon"
+      = render 'users/icon', user: report.user, link_class: 'thread-header__author', image_class: 'thread-list-item__author-icon'
     header.thread-list-item__header
       .thread-list-item__header-title-container
         - if report.wip?
           .thread-list-item__header-icon.is-wip WIP
         h2.thread-list-item__title(itemprop="name")
-          = link_to report, itemprop: "url", class: "thread-list-item__title-link js-unconfirmed-link" do
+          = link_to report, itemprop: 'url', class: 'thread-list-item__title-link js-unconfirmed-link' do
             - if report.user.daimyo?
               | ★
             = report.title
     .thread-list-item-meta
       time.thread-list-item-meta__datetime(datetime="#{report.reported_on.to_datetime}")
         = l report.reported_on
-        = "の日報"
+        = 'の日報'
     - if report.comments.any?
       .thread-list-item-meta
         .thread-list-item-meta__label
@@ -22,8 +22,8 @@
         .thread-list-item-meta__comment-count
           .thread-list-item-meta__comment-count-value
             | （#{report.comments.size}）
-        = render partial: "comments/user_icons", collection: report.comments.commented_users, as: :user
-        time.thread-list-item-meta__datetime(datetime="#{report.comments.last.updated_at.to_datetime}" pubdate="pubdate")
+        = render partial: 'comments/user_icons', collection: report.comments.commented_users, as: :user
+        time.thread-list-item-meta__datetime(datetime="#{report.comments.last.updated_at.to_datetime}" pubdate='pubdate')
           | 〜 #{l report .comments.last.updated_at, format: :date_and_time}
 
     - if report.checks.any?

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -112,6 +112,6 @@ header.page-header
               .side-tabs-contents__item#side-tabs-content-1
                 .thread-list.a-card
                   - @reports.each do |report|
-                    = render partial: "report", locals: { report: report }
+                    = render partial: 'report', locals: { report: report }
               .side-tabs-contents__item#side-tabs-content-2
                 #js-mentor-memo(data-practice-id="#{@product.practice_id}")

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -97,4 +97,6 @@ header.page-header
 
       div(class="#{current_user.mentor? || current_user.admin? ? 'col-md-5 col-xs-12 is-hidden-sm-down' : ''}")
         - if current_user.mentor? || current_user.admin?
+          - @reports.each do |report|
+            = render partial: "report", locals: { report: report }
           #js-mentor-memo(data-practice-id="#{@product.practice_id}")

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -97,6 +97,21 @@ header.page-header
 
       div(class="#{current_user.mentor? || current_user.admin? ? 'col-md-5 col-xs-12 is-hidden-sm-down' : ''}")
         - if current_user.mentor? || current_user.admin?
-          - @reports.each do |report|
-            = render partial: "report", locals: { report: report }
-          #js-mentor-memo(data-practice-id="#{@product.practice_id}")
+          .side-tabs
+            input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents'
+            input.a-toggle-checkbox#side-tabs-2 type='radio' name='side-tabs-contents' checked='checked'
+            .side-tabs-nav
+              .side-tabs-nav__items
+                .side-tabs-nav__item
+                  label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'
+                    | 直近の日報
+                .side-tabs-nav__item
+                  label.side-tabs-nav__item-link#side-tabs-nav-2 for='side-tabs-2'
+                    | メンターメモ
+            .side-tabs-contents
+              .side-tabs-contents__item#side-tabs-content-1
+                .thread-list.a-card
+                  - @reports.each do |report|
+                    = render partial: "report", locals: { report: report }
+              .side-tabs-contents__item#side-tabs-content-2
+                #js-mentor-memo(data-practice-id="#{@product.practice_id}")


### PR DESCRIPTION
Issue #2126 への対応

メンターが提出物をレビューするときに日報がすぐ見れるといいという要望から、
直近の日報10件のリンクをつけることとなったので、そのようにつけました。

自分がしたのはビューについて基本的にそのまま日報の一覧を持ってきただけなので、デザインの変更などが必要です。
(メンターメモがあった場所に直近の日報一覧をつけてるので、メンターメモが下の方にいってます)
[![Image from Gyazo](https://i.gyazo.com/18ce4710c902ee9e1be70b76ce3b1734.png)](https://gyazo.com/18ce4710c902ee9e1be70b76ce3b1734)