### PR TITLE
他人の進捗を表示/非表示で切り替えられるようにする

### DIFF
--- a/app/assets/stylesheets/atoms/_a-help.sass
+++ b/app/assets/stylesheets/atoms/_a-help.sass
@@ -1,6 +1,6 @@
 .a-help
-  +text-block(1em 1, inline-flex $reversal-text)
-  +size(1.5em)
+  +text-block(.75em 1, inline-flex $reversal-text)
+  +size(1.75em)
   background-color: $muted-text
   vertical-align: middle
   align-items: center

--- a/app/assets/stylesheets/atoms/_a-help.sass
+++ b/app/assets/stylesheets/atoms/_a-help.sass
@@ -1,0 +1,15 @@
+.a-help
+  +text-block(1em 1, inline-flex $reversal-text)
+  +size(1.5em)
+  background-color: $muted-text
+  vertical-align: middle
+  align-items: center
+  justify-content: center
+  border-radius: 50%
+  cursor: pointer
+  transition: all .2s ease-out
+  &:hover
+    background-color: $main
+    color: $reversal-text
+  &:last-child
+    margin-left: .25em

--- a/app/assets/stylesheets/atoms/_form.sass
+++ b/app/assets/stylesheets/atoms/_form.sass
@@ -118,10 +118,22 @@ textarea.a-text-input
   overflow: hidden
   visibility: hidden
 
+=on-off-checkbox($border-width: 1px, $height: 1.5rem, $width: 4.5rem, $font-size: .8125rem)
+  span
+    +size($width calc(#{$height} + #{$border-width} * 2))
+    border: solid $border-width $input-border
+    border-radius: $height
+    font-size: $font-size
+    &::before
+      +size($height)
+    &::after
+      +size(100% calc(100% - #{$border-width} * 2))
+      +padding(horizontal, $height .75em)
+  input:checked + span
+    &::after
+      +padding(horizontal, 1em $height)
+
 .a-on-off-checkbox
-  $border-width: 1px
-  $height: 1.5rem
-  $width: 5rem
   +position(relative)
   display: block
   cursor: pointer
@@ -134,27 +146,20 @@ textarea.a-text-input
   span
     display: block
     background-color: $background
-    +size($width calc(#{$height} + #{$border-width} * 2))
-    border-radius: 1.0625rem
-    border: solid $border-width $input-border
     +position(relative)
     transition: all .2s ease-out
     &::before
       content: ""
       display: block
-      +size($height)
       border-radius: 50%
-      border: solid 1px $border
       background-color: $base
       +position(absolute, left 0, top 0)
       border: solid 1px $input-border
     &::after
       content: "OFF"
-      +text-block(.875rem 1, flex center 600)
+      +text-block(1em 1, flex center 600)
       align-items: center
       justify-content: center
-      +size(100% calc(100% - #{$border-width} * 2))
-      +padding(horizontal, $height 1em)
   input:checked + span
     background-color: $danger
     border-color: $danger
@@ -163,7 +168,11 @@ textarea.a-text-input
     &::after
       content: "ON"
       color: $reversal-text
-      +padding(horizontal, 1em $height)
+  &.is-md
+    +on-off-checkbox
+  &.is-sm
+    +on-off-checkbox($border-width: 1px, $height: 1.125rem, $width: 3.5rem, $font-size: .75rem)
+
 
 .a-form-help
   font-size: .75rem

--- a/app/assets/stylesheets/atoms/_short-text.sass
+++ b/app/assets/stylesheets/atoms/_short-text.sass
@@ -3,3 +3,9 @@
     +text-block(1em 1.6 .75em)
   *:first-child
     margin-top: 0
+  hr
+    display: block
+    +size(100% 0)
+    border: none
+    border-top: dashed 1px $border
+    +margin(vertical, 1.25em)

--- a/app/assets/stylesheets/blocks/page/_page-body.sass
+++ b/app/assets/stylesheets/blocks/page/_page-body.sass
@@ -3,6 +3,9 @@
   +media-breakpoint-down(sm)
     +padding(vertical, 1.125rem)
 
+.page-body__inner
+  position: relative
+
 .page-optional-header
   +padding(vertical, .875rem)
   border-bottom: solid 1px $border-shade

--- a/app/assets/stylesheets/blocks/page/_page-header-actions.sass
+++ b/app/assets/stylesheets/blocks/page/_page-header-actions.sass
@@ -15,6 +15,8 @@
   +padding(horizontal, .25rem)
   +media-breakpoint-up(md)
     min-width: 10rem
+    display: flex
+    justify-content: center
   +media-breakpoint-down(sm)
     flex: 1
     max-width: 50%

--- a/app/assets/stylesheets/blocks/page/_page-header-switch.sass
+++ b/app/assets/stylesheets/blocks/page/_page-header-switch.sass
@@ -2,7 +2,20 @@
   +media-breakpoint-up(md)
     display: flex
     align-items: center
+    cursor: pointer
+    transition: all .2s ease-out
+    *
+      cursor: pointer
 
 .page-header-switch__label
-  +text-block(.75rem 1.4, $muted-text center)
-  margin-right: .5em
+  +media-breakpoint-up(md)
+    +text-block(.75rem 1.4, $muted-text center)
+    margin-right: .5em
+    .a-help
+      +position(relative, top -1px)
+    &:hover
+      .page-header-switch__label-text
+        color: $main
+        text-decoration: underline
+      .a-help
+        background-color: $main

--- a/app/assets/stylesheets/blocks/page/_page-header-switch.sass
+++ b/app/assets/stylesheets/blocks/page/_page-header-switch.sass
@@ -1,0 +1,8 @@
+.page-header-switch
+  +media-breakpoint-up(md)
+    display: flex
+    align-items: center
+
+.page-header-switch__label
+  +text-block(.75rem 1.4, $muted-text center)
+  margin-right: .5em

--- a/app/assets/stylesheets/blocks/page/_page-header.sass
+++ b/app/assets/stylesheets/blocks/page/_page-header.sass
@@ -16,6 +16,10 @@
     display: block
     +padding(vertical, .5rem)
 
+.page-header__start
+  display: flex
+  align-items: center
+
 .page-header__title
   +text-block(1.25rem 1, $main 600)
   font-feature-settings: "palt"
@@ -28,6 +32,9 @@
     margin-right: .5rem
   +media-breakpoint-down(sm)
     +text-block(1rem 1.4, $side)
+  .page-header__start &
+    margin-right: .5em
+    align-self: center
 
 .page-header__action
   +media-breakpoint-down(sm)

--- a/app/assets/stylesheets/blocks/practice/_categories.sass
+++ b/app/assets/stylesheets/blocks/practice/_categories.sass
@@ -11,6 +11,9 @@
   justify-content: space-between
   align-items: flex-start
 
+.categories-items.js-is-hidden-users .categories-items__inner .practice-started-users
+  display: none
+
 .categories-items__inner
   flex: 100
 

--- a/app/assets/stylesheets/blocks/practice/_categories.sass
+++ b/app/assets/stylesheets/blocks/practice/_categories.sass
@@ -11,7 +11,7 @@
   justify-content: space-between
   align-items: flex-start
 
-.categories-items.js-is-hidden-users .categories-items__inner .practice-started-users
+.is-hidden-users .practice-started-users
   display: none
 
 .categories-items__inner

--- a/app/assets/stylesheets/blocks/practice/_categories.sass
+++ b/app/assets/stylesheets/blocks/practice/_categories.sass
@@ -11,7 +11,7 @@
   justify-content: space-between
   align-items: flex-start
 
-.is-hidden-users .practice-started-users
+.is-hidden-users .m-user-icons
   display: none
 
 .categories-items__inner

--- a/app/assets/stylesheets/mixins/_short-text-style.sass
+++ b/app/assets/stylesheets/mixins/_short-text-style.sass
@@ -3,6 +3,12 @@
     margin-top: 0
   >*:last-child
     margin-bottom: 0
+  hr
+    display: block
+    +size(100% 0)
+    border: none
+    border-top: dashed 1px $border
+    +margin(vertical, 1.5em)
   p
     +text-block(1em 1.6 0 .75em)
   li

--- a/app/javascript/checkBox.js
+++ b/app/javascript/checkBox.js
@@ -1,13 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
   const localStorage = window.localStorage
   document.querySelectorAll('input').forEach((e) => {
-    const categoriesItems = e.closest('.categories-items')
-    if (localStorage.getItem('displayProgress') === 'off' && categoriesItems) {
-      e.closest('.categories-items').classList.add('js-is-hidden-users')
-      document.getElementById('displayProgress').checked = false
-    } else if (e.checked === true && categoriesItems) {
-      e.closest('.categories-items').classList.add('js-is-show-users')
-    } else if (e.checked === true) {
+    const hasJsClass = e.hasClass('js-users-visibility__trigger')
+    if (localStorage.getItem('hidden-users') === 'on' && hasJsClass) {
+      e.closest('.js-users-visibility').classList.add('is-hidden-users')
+      e.checked = false
+    } else if (e.checked === true && !hasJsClass) {
       e.parentNode.classList.add('is-checked')
     }
   })
@@ -17,17 +15,15 @@ document.addEventListener('DOMContentLoaded', () => {
       t = c.target.type
       chk = value.checked
       if (t === 'checkbox') {
-        const categoriesItems = value.closest('.categories-items')
-        if (chk === true && categoriesItems) {
-          value.closest('.categories-items').classList.remove('js-is-hidden-users')
-          value.closest('.categories-items').classList.add('js-is-show-users')
-          localStorage.removeItem('displayProgress')
+        const hasJsClass = value.hasClass('js-users-visibility__trigger')
+        if (chk === true && hasJsClass) {
+          value.closest('.js-users-visibility').classList.remove('is-hidden-users')
+          localStorage.removeItem('hidden-users')
         } else if (chk === true) {
           value.parentNode.classList.add('is-checked')
-        } else if (chk === false && categoriesItems) {
-          value.closest('.categories-items').classList.remove('js-is-show-users')
-          value.closest('.categories-items').classList.add('js-is-hidden-users')
-          localStorage.setItem('displayProgress', 'off')
+        } else if (chk === false && hasJsClass) {
+          value.closest('.js-users-visibility').classList.add('is-hidden-users')
+          localStorage.setItem('hidden-users', 'on')
         } else {
           value.parentNode.classList.remove('is-checked')
         }

--- a/app/javascript/checkBox.js
+++ b/app/javascript/checkBox.js
@@ -1,6 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const localStorage = window.localStorage
   document.querySelectorAll('input').forEach((e) => {
-    if (e.checked === true) {
+    const categoriesItems = e.closest('.categories-items')
+    if (localStorage.getItem('displayProgress') === 'off' && categoriesItems) {
+      e.closest('.categories-items').classList.add('js-is-hidden-users')
+      document.getElementById('displayProgress').checked = false
+    } else if (e.checked === true && categoriesItems) {
+      e.closest('.categories-items').classList.add('js-is-show-users')
+    } else if (e.checked === true) {
       e.parentNode.classList.add('is-checked')
     }
   })
@@ -10,8 +17,17 @@ document.addEventListener('DOMContentLoaded', () => {
       t = c.target.type
       chk = value.checked
       if (t === 'checkbox') {
-        if (chk === true) {
+        const categoriesItems = value.closest('.categories-items')
+        if (chk === true && categoriesItems) {
+          value.closest('.categories-items').classList.remove('js-is-hidden-users')
+          value.closest('.categories-items').classList.add('js-is-show-users')
+          localStorage.removeItem('displayProgress')
+        } else if (chk === true) {
           value.parentNode.classList.add('is-checked')
+        } else if (chk === false && categoriesItems) {
+          value.closest('.categories-items').classList.remove('js-is-show-users')
+          value.closest('.categories-items').classList.add('js-is-hidden-users')
+          localStorage.setItem('displayProgress', 'off')
         } else {
           value.parentNode.classList.remove('is-checked')
         }

--- a/app/javascript/checkBox.js
+++ b/app/javascript/checkBox.js
@@ -2,10 +2,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const localStorage = window.localStorage
   document.querySelectorAll('input').forEach((e) => {
     const hasJsClass = e.hasClass('js-users-visibility__trigger')
-    if (localStorage.getItem('hidden-users') === 'on' && hasJsClass) {
+    if (localStorage.getItem('hidden-users') && hasJsClass) {
       document.querySelector('.js-users-visibility').classList.add('is-hidden-users')
       e.checked = false
-    } else if (e.checked === true && !hasJsClass) {
+    } else if (e.checked && !hasJsClass) {
       e.parentNode.classList.add('is-checked')
     }
   })
@@ -16,12 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
       chk = value.checked
       if (t === 'checkbox') {
         const hasJsClass = value.hasClass('js-users-visibility__trigger')
-        if (chk === true && hasJsClass) {
+        if (chk && hasJsClass) {
           document.querySelector('.js-users-visibility').classList.remove('is-hidden-users')
           localStorage.removeItem('hidden-users')
-        } else if (chk === true) {
+        } else if (chk) {
           value.parentNode.classList.add('is-checked')
-        } else if (chk === false && hasJsClass) {
+        } else if (!chk && hasJsClass) {
           document.querySelector('.js-users-visibility').classList.add('is-hidden-users')
           localStorage.setItem('hidden-users', 'on')
         } else {
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         return true
       } else if (t === 'radio') {
-        if (chk === true) {
+        if (chk) {
           document.querySelectorAll('ul, input').forEach(function (value) {
             if (value.type === 'radio') {
               value.parentNode.classList.remove('is-checked')

--- a/app/javascript/checkBox.js
+++ b/app/javascript/checkBox.js
@@ -1,11 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
   const localStorage = window.localStorage
   document.querySelectorAll('input').forEach((e) => {
-    const hasJsClass = e.hasClass('js-users-visibility__trigger')
-    if (localStorage.getItem('hidden-users') && hasJsClass) {
+    const jsUsersVisibilityTriggerClass = e.hasClass('js-users-visibility__trigger')
+    if (localStorage.getItem('hidden-users') && jsUsersVisibilityTriggerClass) {
       document.querySelector('.js-users-visibility').classList.add('is-hidden-users')
       e.checked = false
-    } else if (e.checked && !hasJsClass) {
+    } else if (e.checked && !jsUsersVisibilityTriggerClass) {
       e.parentNode.classList.add('is-checked')
     }
   })
@@ -15,13 +15,13 @@ document.addEventListener('DOMContentLoaded', () => {
       t = c.target.type
       chk = value.checked
       if (t === 'checkbox') {
-        const hasJsClass = value.hasClass('js-users-visibility__trigger')
-        if (chk && hasJsClass) {
+        const jsUsersVisibilityTriggerClass = value.hasClass('js-users-visibility__trigger')
+        if (chk && jsUsersVisibilityTriggerClass) {
           document.querySelector('.js-users-visibility').classList.remove('is-hidden-users')
           localStorage.removeItem('hidden-users')
         } else if (chk) {
           value.parentNode.classList.add('is-checked')
-        } else if (!chk && hasJsClass) {
+        } else if (!chk && jsUsersVisibilityTriggerClass) {
           document.querySelector('.js-users-visibility').classList.add('is-hidden-users')
           localStorage.setItem('hidden-users', 'on')
         } else {

--- a/app/javascript/checkBox.js
+++ b/app/javascript/checkBox.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('input').forEach((e) => {
     const hasJsClass = e.hasClass('js-users-visibility__trigger')
     if (localStorage.getItem('hidden-users') === 'on' && hasJsClass) {
-      e.closest('.js-users-visibility').classList.add('is-hidden-users')
+      document.querySelector('.js-users-visibility').classList.add('is-hidden-users')
       e.checked = false
     } else if (e.checked === true && !hasJsClass) {
       e.parentNode.classList.add('is-checked')
@@ -17,12 +17,12 @@ document.addEventListener('DOMContentLoaded', () => {
       if (t === 'checkbox') {
         const hasJsClass = value.hasClass('js-users-visibility__trigger')
         if (chk === true && hasJsClass) {
-          value.closest('.js-users-visibility').classList.remove('is-hidden-users')
+          document.querySelector('.js-users-visibility').classList.remove('is-hidden-users')
           localStorage.removeItem('hidden-users')
         } else if (chk === true) {
           value.parentNode.classList.add('is-checked')
         } else if (chk === false && hasJsClass) {
-          value.closest('.js-users-visibility').classList.add('is-hidden-users')
+          document.querySelector('.js-users-visibility').classList.add('is-hidden-users')
           localStorage.setItem('hidden-users', 'on')
         } else {
           value.parentNode.classList.remove('is-checked')

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -19,6 +19,9 @@ header.page-header
 .page-body
   .container
     .categories-items
+      label for="displayProgress"
+        input type="checkbox" checked="checked" id="displayProgress"
+        |みんなの進捗を表示
       .categories-items__inner
         - @categories.each do |category|
           - if category.practices.present?

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -16,11 +16,11 @@ header.page-header
                 i.fas.fa-plus
                 | プラクティス作成
 
-.page-body
+.page-body.js-users-visibility
   .container
     .categories-items
       label for="displayProgress"
-        input type="checkbox" checked="checked" id="displayProgress"
+        input type="checkbox" checked="checked" id="displayProgress" class="js-users-visibility__trigger"
         |みんなの進捗を表示
       .categories-items__inner
         - @categories.each do |category|

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -1,6 +1,6 @@
 - title "#{@course.title}コース"
 
-= render "shared/modal", id: "modal-progress", title: "みんなの進捗とは？"
+= render ’shared/modal’, id: ’modal-progress’, title: ’みんなの進捗とは？’
   .modal__description.is-md
     .a-short-text
       p
@@ -22,13 +22,13 @@ header.page-header
         ul.page-header-actions__items
           li.page-header-actions__item
             .page-header-switch.is-hidden-sm-down
-              label.page-header-switch__label(for="modal-progress")
+              label.page-header-switch__label(for=’modal-progress’)
                 span.page-header-switch__label-text
                   | みんなの進捗
                 .a-help
                   i.fas.fa-question
-              label.a-on-off-checkbox.is-sm for="displayProgress"
-                input type="checkbox" checked="checked" id="displayProgress" class="js-users-visibility__trigger"
+              label.a-on-off-checkbox.is-sm for=’displayProgress’
+                input type=’checkbox’ checked=’checked’ id=’displayProgress’ class=’js-users-visibility__trigger’
                 span
           li.page-header-actions__item
             = link_to courses_path, class: 'a-button is-md is-secondary is-block' do
@@ -60,13 +60,13 @@ header.page-header
                 .categories-item__description
                   - if current_user.admin?
                     .categories-item__edit
-                      = link_to edit_admin_category_path(category, course_id: @course.id), class: "categories-item__edit-link" do
+                      = link_to edit_admin_category_path(category, course_id: @course.id), class: ’categories-item__edit-link’ do
                         i.fas.fa-pen
                   .js-markdown-view.js-target-blank.is-long-text
                     = category.description
                 .categories-item__body
                   .category-practices.js-category-practices
-                    = render partial: "practices/practice", collection: category.practices, as: :practice, locals: { course: @course }
+                    = render partial: ’practices/practice’, collection: category.practices, as: :practice, locals: { course: @course }
 
         nav.page-nav
           ul.page-nav__items

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -1,6 +1,6 @@
 - title "#{@course.title}コース"
 
-= render ’shared/modal’, id: ’modal-progress’, title: ’みんなの進捗とは？’
+= render '/shared/modal', id: 'modal-progress', title: 'みんなの進捗とは？'
   .modal__description.is-md
     .a-short-text
       p
@@ -22,13 +22,13 @@ header.page-header
         ul.page-header-actions__items
           li.page-header-actions__item
             .page-header-switch.is-hidden-sm-down
-              label.page-header-switch__label(for=’modal-progress’)
+              label.page-header-switch__label(for = 'modal-progress')
                 span.page-header-switch__label-text
                   | みんなの進捗
                 .a-help
                   i.fas.fa-question
-              label.a-on-off-checkbox.is-sm for=’displayProgress’
-                input type=’checkbox’ checked=’checked’ id=’displayProgress’ class=’js-users-visibility__trigger’
+              label.a-on-off-checkbox.is-sm(for = 'displayProgress')
+                input.js-users-visibility__trigger#displayProgress(type = 'checkbox' checked = 'checked')
                 span
           li.page-header-actions__item
             = link_to courses_path, class: 'a-button is-md is-secondary is-block' do
@@ -60,13 +60,13 @@ header.page-header
                 .categories-item__description
                   - if current_user.admin?
                     .categories-item__edit
-                      = link_to edit_admin_category_path(category, course_id: @course.id), class: ’categories-item__edit-link’ do
+                      = link_to edit_admin_category_path(category, course_id: @course.id), class: 'categories-item__edit-link' do
                         i.fas.fa-pen
                   .js-markdown-view.js-target-blank.is-long-text
                     = category.description
                 .categories-item__body
                   .category-practices.js-category-practices
-                    = render partial: ’practices/practice’, collection: category.practices, as: :practice, locals: { course: @course }
+                    = render partial: '/practices/practice', collection: category.practices, as: :practice, locals: { course: @course }
 
         nav.page-nav
           ul.page-nav__items

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -4,7 +4,14 @@
   .modal__description.is-md
     .a-short-text
       p
-        | 他の受講者の進捗が見れると、焦ってしまう、精神的に追い詰められる、といった場合、「OFF」にすることで、他の受講者の進捗が隠れ、目に入らなくなります。
+        | こちらのページで他の受講者が今どのプラクティスを学習しているかが確認できます。
+      p
+        | 他の受講者の進捗が目に入ると焦ってしまう、精神的に追い詰められる、と感じた場合、「OFF」にすることで、他の受講者の進捗が非表示になります。逆にみんなの進捗が見れることでモチベーションアップにつながる、という方は「ON」にしてください。
+      hr
+      p
+        | フィヨルドブートキャンプは、前提の知識や経験は人によってバラバラ、どこまで掘り下げて学習をするかも人によってバラバラ、学習に使える時間もバラバラなので、学校の授業や資格取得の勉強とは全く別物です。早ければいいというものではないです。
+      p
+        | 同じくらいのプラクティスをやってる人の日報をフォローしたり、お互い日報にコメントを付け合ったり、チャットやミートアップで話してみたりするのオススメです。
 
 header.page-header
   .container
@@ -15,9 +22,10 @@ header.page-header
         ul.page-header-actions__items
           li.page-header-actions__item
             .page-header-switch.is-hidden-sm-down
-              .page-header-switch__label
-                | みんなの進捗
-                label.a-help(for="modal-progress")
+              label.page-header-switch__label(for="modal-progress")
+                span.page-header-switch__label-text
+                  | みんなの進捗
+                .a-help
                   i.fas.fa-question
               label.a-on-off-checkbox.is-sm for="displayProgress"
                 input type="checkbox" checked="checked" id="displayProgress" class="js-users-visibility__trigger"

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -1,12 +1,27 @@
-- title "#{@course.title}コースのプラクティス"
+- title "#{@course.title}コース"
+
+= render "shared/modal", id: "modal-progress", title: "みんなの進捗とは？"
+  .modal__description.is-md
+    .a-short-text
+      p
+        | 他の受講者の進捗が見れると、焦ってしまう、精神的に追い詰められる、といった場合、「OFF」にすることで、他の受講者の進捗が隠れ、目に入らなくなります。
 
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title = title
-      .page-header__action
+      .page-header__start
+        h2.page-header__title = title
       .page-header-actions
         ul.page-header-actions__items
+          li.page-header-actions__item
+            .page-header-switch.is-hidden-sm-down
+              .page-header-switch__label
+                | みんなの進捗
+                label.a-help(for="modal-progress")
+                  i.fas.fa-question
+              label.a-on-off-checkbox.is-sm for="displayProgress"
+                input type="checkbox" checked="checked" id="displayProgress" class="js-users-visibility__trigger"
+                span
           li.page-header-actions__item
             = link_to courses_path, class: 'a-button is-md is-secondary is-block' do
               | コース一覧
@@ -18,39 +33,37 @@ header.page-header
 
 .page-body.js-users-visibility
   .container
-    .categories-items
-      label for="displayProgress"
-        input type="checkbox" checked="checked" id="displayProgress" class="js-users-visibility__trigger"
-        |みんなの進捗を表示
-      .categories-items__inner
-        - @categories.each do |category|
-          - if category.practices.present?
-            .categories-item.practices.js-show-handle
-              a.categories-item__anchor(id="category-#{category.id}")
-              header.categories-item__header
-                h2.categories-item__title
-                  = category.name
-                  - if current_user.completed_all_practices?(category)
-                    span.stamp.is-circle.is-solved
-                      | 完了
-                - if current_user.admin?
-                  .categories-item__show-handle.js-show-handle__trigger
-                    i.fas.fa-cog
-              .categories-item__description
-                - if current_user.admin?
-                  .categories-item__edit
-                    = link_to edit_admin_category_path(category, course_id: @course.id), class: 'categories-item__edit-link' do
-                      i.fas.fa-pen
-                .js-markdown-view.js-target-blank.is-long-text
-                  = category.description
-              .categories-item__body
-                .category-practices.js-category-practices
-                  = render partial: 'practices/practice', collection: category.practices.order(:position), as: :practice, locals: { course: @course }
-
-      nav.page-nav
-        ul.page-nav__items
+    .page-body__inner
+      .categories-items
+        .categories-items__inner
           - @categories.each do |category|
             - if category.practices.present?
-              li.page-nav__item
-                a.page-nav__item-link(href="#category-#{category.id}")
-                  = category.name
+              .categories-item.practices.js-show-handle
+                a.categories-item__anchor(id="category-#{category.id}")
+                header.categories-item__header
+                  h2.categories-item__title
+                    = category.name
+                    - if current_user.completed_all_practices?(category)
+                      span.stamp.is-circle.is-solved
+                        | 完了
+                  - if current_user.admin?
+                    .categories-item__show-handle.js-show-handle__trigger
+                      i.fas.fa-cog
+                .categories-item__description
+                  - if current_user.admin?
+                    .categories-item__edit
+                      = link_to edit_admin_category_path(category, course_id: @course.id), class: "categories-item__edit-link" do
+                        i.fas.fa-pen
+                  .js-markdown-view.js-target-blank.is-long-text
+                    = category.description
+                .categories-item__body
+                  .category-practices.js-category-practices
+                    = render partial: "practices/practice", collection: category.practices, as: :practice, locals: { course: @course }
+
+        nav.page-nav
+          ul.page-nav__items
+            - @categories.each do |category|
+              - if category.practices.present?
+                li.page-nav__item
+                  a.page-nav__item-link(href="#category-#{category.id}")
+                    = category.name

--- a/app/views/users/form/_mail_notification.html.slim
+++ b/app/views/users/form/_mail_notification.html.slim
@@ -1,6 +1,11 @@
 .form-item#mail-notification
+<<<<<<< HEAD
   = f.label :mail_notification, class: 'a-label'
   label.a-on-off-checkbox
+=======
+  = f.label :mail_notification, class: "a-label"
+  label.a-on-off-checkbox.is-md
+>>>>>>> 839f9e15... みんなの進捗にデザイン
     = f.check_box :mail_notification
     span
   .a-form-help

--- a/app/views/users/form/_mail_notification.html.slim
+++ b/app/views/users/form/_mail_notification.html.slim
@@ -1,11 +1,6 @@
 .form-item#mail-notification
-<<<<<<< HEAD
   = f.label :mail_notification, class: 'a-label'
-  label.a-on-off-checkbox
-=======
-  = f.label :mail_notification, class: "a-label"
   label.a-on-off-checkbox.is-md
->>>>>>> 839f9e15... みんなの進捗にデザイン
     = f.check_box :mail_notification
     span
   .a-form-help

--- a/test/system/course/practices_test.rb
+++ b/test/system/course/practices_test.rb
@@ -7,6 +7,6 @@ class Course::PracticesTest < ApplicationSystemTestCase
 
   test 'show listing practices' do
     visit "/courses/#{courses(:course1).id}/practices"
-    assert_equal 'Rails Webプログラマーコースのプラクティス | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal 'Rails Webプログラマーコース | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 end


### PR DESCRIPTION
## issue
#2047 に対応。

## 変更前
- 各プラクティスごとに、着手しているユーザーのアイコンが表示されており、他人の進捗が可視化されていた

<img width="727" alt="スクリーンショット 2021-01-05 10 35 11" src="https://user-images.githubusercontent.com/52053239/103596641-ba2e5800-4f41-11eb-9cf9-24942f0590a2.png">

## 変更後
- プラクティス一覧の上部に、ユーザーのアイコン(他人の進捗)を非表示にできるボタンを配置

![進捗の表示:非表示](https://user-images.githubusercontent.com/52053239/103596930-63754e00-4f42-11eb-82cb-3edac927dd88.gif)

