### PR TITLE
未チェックの提出物・日報・未返信の提出物の一覧ページはメンター、管理者、アドバイザー以外のユーザーはアクセスできないようにした

### DIFF
--- a/app/controllers/products/not_responded_controller.rb
+++ b/app/controllers/products/not_responded_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Products::NotRespondedController < ApplicationController
+  before_action :require_staff_login
   def index
     @products = Product.not_responded_products.list.page(params[:page])
   end

--- a/app/controllers/products/unchecked_controller.rb
+++ b/app/controllers/products/unchecked_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Products::UncheckedController < ApplicationController
+  before_action :require_staff_login
   def index
     @products = Product.unchecked.not_wip.list.page(params[:page])
   end

--- a/app/controllers/reports/unchecked_controller.rb
+++ b/app/controllers/reports/unchecked_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Reports::UncheckedController < ApplicationController
+  before_action :require_staff_login
   def index
     @reports = Report.unchecked.not_wip.list.page(params[:page])
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -51,10 +51,10 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text "プラクティスを完了するまで他の人の提出物は見れません。"
   end
 
-  test "non-mentor can not see a button to open all unchecked products" do
+  test "non-staff user can not see listing unchecked products" do
     login_user "hatsuno", "testtest"
     visit "/products/unchecked"
-    assert_no_button "未チェックの提出物を一括で開く"
+    assert_text "管理者・アドバイザー・メンターとしてログインしてください"
   end
 
   test "mentor can see a button to open to open all unchecked products" do
@@ -63,10 +63,10 @@ class ProductsTest < ApplicationSystemTestCase
     assert_button "未チェックの提出物を一括で開く"
   end
 
-  test "non-mentor can not see a button to open all not-responded products" do
+  test "non-staff user can not see listing not-responded products" do
     login_user "hatsuno", "testtest"
     visit "/products/not_responded"
-    assert_no_button "未返信の提出物を一括で開く"
+    assert_text "管理者・アドバイザー・メンターとしてログインしてください"
   end
 
   test "mentor can see a button to open to open all not-responded products" do

--- a/test/system/report/unchecked_test.rb
+++ b/test/system/report/unchecked_test.rb
@@ -6,13 +6,14 @@ class Report::UncheckedTest < ApplicationSystemTestCase
   setup { login_user "hatsuo", "testtest" }
 
   test "show listing unchecked reports" do
+    login_user "komagata", "testtest"
     visit "/reports/unchecked"
     assert_equal "未チェックの日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
-  test "non-mentor can not see a button to open all unchecked reports" do
+  test "non-staff user can not see listing unchecked reports" do
     visit "/reports/unchecked"
-    assert_no_button "未チェックの日報を一括で開く"
+    assert_text "管理者・アドバイザー・メンターとしてログインしてください"
   end
 
   test "mentor can see a button to open all unchecked reports" do


### PR DESCRIPTION
#2088 の作業です

メンター、管理者、アドバイザー以外のユーザーは以下のページにアクセスできないようにしました。

未チェックの提出物
https://bootcamp.fjord.jp/products/unchecked

未返信の提出物
https://bootcamp.fjord.jp/products/not_responded

未チェックの日報
https://bootcamp.fjord.jp/reports/unchecked