### PR TITLE
プラクティス個別ページにタブを追加し、そのプラクティスに関連するDocの一覧ページを作成

### DIFF
--- a/app/controllers/practices/pages_controller.rb
+++ b/app/controllers/practices/pages_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Practices::PagesController < ApplicationController
+  before_action :require_login
+
+  def index
+    @practice = Practice.find(params[:practice_id])
+    @pages = @practice.pages.with_avatar
+                .includes(:comments,
+                { last_updated_user: { avatar_attachment: :blob } })
+                .order(updated_at: :desc)
+                .page(params[:page])
+  end
+end

--- a/app/helpers/page_tab_helper.rb
+++ b/app/helpers/page_tab_helper.rb
@@ -20,6 +20,7 @@ module PageTabHelper
         root_tab(resource),
         reports_tab(resource),
         questions_tab(resource),
+        pages_tab(resource),
         products_tab(resource)
       ]
     end
@@ -46,7 +47,8 @@ module PageTabHelper
         practices: "プラクティス",
         reports: "日報",
         questions: "質問",
-        products: "提出物",
+        pages: "Docs",
+        products: "提出物"
       }
     end
 
@@ -71,6 +73,11 @@ module PageTabHelper
 
     def comments_tab(resource)
       tab_name = :comments
+      page_tab_member(tab_path(resource, tab_name), tab_name)
+    end
+
+    def pages_tab(resource)
+      tab_name = :pages
       page_tab_member(tab_path(resource, tab_name), tab_name)
     end
 

--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -1,0 +1,25 @@
+- title @practice.title
+
+header.page-header
+  .container
+    .page-header__inner
+      h1.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to course_practices_path(current_user.course, anchor: "category-#{@practice.category.id}"), class: "a-button is-md is-secondary is-block" do
+              | プラクティス一覧
+
+= render "page_tabs", resource: @practice
+
+.page-body
+  .container
+    = paginate @pages, position: "top"
+    - if @pages.present?
+      .thread-list.a-card
+        = render partial: "pages/page", collection: @pages, as: :page
+      = paginate @pages, position: "bottom"
+    - else
+      .a-empty-message
+        | Docsはまだありません。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ Rails.application.routes.draw do
     resources :reports, only: %i(index), controller: "practices/reports"
     resources :questions, only: %i(index), controller: "practices/questions"
     resources :products, only: %i(index), controller: "practices/products"
+    resources :pages, only: %i(index), controller: "practices/pages"
   end
   namespace :products do
     resources :unchecked, only: %i(index)

--- a/test/system/practice/pages_test.rb
+++ b/test/system/practice/pages_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class Practice::PagesTest < ApplicationSystemTestCase
+  setup { login_user "hatsuno", "testtest" }
+
+  test "show listing pages" do
+    visit "/practices/#{practices(:practice_1).id}/pages"
+    assert_equal "OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+  end
+end


### PR DESCRIPTION
#2127  の作業です
プラクティス個別ページにタブを追加し、そのプラクティスに関連するDocの一覧ページを作成しました。

## プラクティス詳細画面
<img width="1212" alt="スクリーンショット 2020-12-01 18 15 26" src="https://user-images.githubusercontent.com/52710925/100720498-69d35000-3401-11eb-9038-1db6e32248b7.png">



## プラクティスに関連するDocの一覧ページ
<img width="1219" alt="スクリーンショット 2020-12-01 18 22 41" src="https://user-images.githubusercontent.com/52710925/100721069-3644f580-3402-11eb-81dd-7bcd5239103d.png">



1ページに表示されるDocの件数は20件になります。
