### PR TITLE
お知らせをWIPで保存した際にもSlackに通知が飛んでしまう不具合を修正

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -38,7 +38,6 @@ class AnnouncementsController < ApplicationController
     @announcement.user_id = current_user.id
     set_wip
     if @announcement.save
-      notify_to_slack(@announcement)
       redirect_to @announcement, notice: notice_message(@announcement)
     else
       render :new
@@ -51,19 +50,6 @@ class AnnouncementsController < ApplicationController
   end
 
   private
-
-  def notify_to_slack(announcement)
-    link = "<#{url_for(announcement)}|#{announcement.title}>"
-
-    SlackNotification.notify link.to_s,
-                             username: "#{announcement.user.login_name} (#{announcement.user.name})",
-                             icon_url: announcement.user.avatar_url,
-                             channel: '#general',
-                             attachments: [{
-                               fallback: 'announcement description.',
-                               text: announcement.description
-                             }]
-  end
 
   def footprint!
     @announcement.footprints.create_or_find_by(user: current_user) if @announcement.user != current_user

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -4,6 +4,7 @@ class AnnouncementCallbacks
   def after_create(announce)
     return if announce.wip?
 
+    notify_to_slack(announce)
     send_notification(announce)
     announce.published_at = Time.current
     announce.save
@@ -12,6 +13,7 @@ class AnnouncementCallbacks
   def after_update(announce)
     return unless !announce.wip && announce.published_at.nil?
 
+    notify_to_slack(announce)
     send_notification(announce)
     announce.published_at = Time.current
     announce.save
@@ -28,6 +30,21 @@ class AnnouncementCallbacks
     target_users.each do |target|
       NotificationFacade.post_announcement(announce, target) if announce.sender != target
     end
+  end
+
+  def notify_to_slack(announce)
+    path = Rails.application.routes.url_helpers.polymorphic_path(announce)
+    url = "https://bootcamp.fjord.jp#{path}"
+    link = "<#{url}|#{announce.title}>"
+
+    SlackNotification.notify link.to_s,
+                             username: "#{announce.user.login_name} (#{announce.user.name})",
+                             icon_url: announce.user.avatar_url,
+                             channel: '#general',
+                             attachments: [{
+                               fallback: 'announcement description.',
+                               text: announce.description
+                             }]
   end
 
   def delete_notification(announce)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
+  ActiveStorage::Current.host = 'http://localhost:3000'
 end


### PR DESCRIPTION
ref #2016 
# 概要
## 目的
#2016 のPRマージ後、WIPの状態で保存した場合でも、Slackのgeneralチャンネルに通知が送られてしまうというバグが発生したため修正いたしました。

 ## 変更箇所
- `announcements_controller.rb`のcreateアクション及び、updateアクションに条件分岐を追加し「WIPではない、初投稿の場合」のみSlackに通知が飛ぶように変更しました

- `announcements_test.rb`の`show pagination`テストで、createの前に`ActiveStorage::Current.host`の設定を行い、直接DBにレコードを登録した際にも`service_url`が正常に動作するように変更しました


