### PR TITLE
お知らせ一覧の公開日をpublished_at値に変更し、並び順もpublished_at順にする

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -8,7 +8,7 @@ class AnnouncementsController < ApplicationController
   def index
     @announcements = Announcement.with_avatar
                                  .preload(:comments)
-                                 .order(created_at: :desc)
+                                 .order(published_at: :desc)
                                  .page(params[:page])
   end
 

--- a/app/views/announcements/_announcements.html.slim
+++ b/app/views/announcements/_announcements.html.slim
@@ -18,11 +18,17 @@
           = link_to new_announcement_path(id: announcement), class: "thread-list-item__actions-link" do
             i.fas.fa-copy
     .thread-list-item-meta
-      time.thread-list-item-meta__datetime(datetime="#{announcement.updated_at.to_datetime}" pubdate="pubdate")
-        = l announcement.updated_at
-      - if announcement.comments.any?
-      .thread-list-item-meta__comment-count
-        .thread-list-item-meta__comment-count-label
-          i.fas.fa-comment
-        .thread-list-item-meta__comment-count-value
-          = announcement.comments.size
+      - if announcement.wip?
+        .thread-list-item-meta__datetime
+          | お知らせ作成中
+      - elsif announcement.published_at.present?
+        time.thread-list-item-meta__datetime(datetime="#{announcement.published_at.to_datetime}")
+          span.span.thread-list-item-meta__datetime-label
+            | 公開
+          | #{l announcement.published_at}
+        - if announcement.comments.any?
+        .thread-list-item-meta__comment-count
+          .thread-list-item-meta__comment-count-label
+            i.fas.fa-comment
+          .thread-list-item-meta__comment-count-value
+            = announcement.comments.size


### PR DESCRIPTION
issue #2084 に対応。
## 変更内容
お知らせ(announcements)に、新規カラム`published_at`が追加されました。(カラムの追加は[こちらのPR](https://github.com/fjordllc/bootcamp/pull/2016)にて)
それに伴い以下3点の変更をいたしました。

- 公開日として表示する日時を`published_at`値に変更し、「公開：XX年年XX月XX日」と表示
- wipの場合は`published_at`値が空のため、「お知らせ作成中」と表示
- お知らせの並び順を`published_at`順に変更


<img width="1082" alt="スクリーンショット_2020-12-02_20_34_12" src="https://user-images.githubusercontent.com/52053239/100867669-dc196280-34dd-11eb-8f66-1017e47112b7.png">

ご確認よろしくお願いいたします！