### PR TITLE
お知らせの並び順を修正

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -8,7 +8,7 @@ class AnnouncementsController < ApplicationController
   def index
     @announcements = Announcement.with_avatar
                                  .preload(:comments)
-                                 .order(published_at: :desc)
+                                 .order(published_at: :desc, created_at: :desc)
                                  .page(params[:page])
   end
 


### PR DESCRIPTION
published_atの並び順が同じ時にcreated_atも考慮するようにした。