### PR TITLE
日報をチェックしたらリアルタイムで右側の最新の日報もチェックされた状態にする

### DIFF
--- a/app/assets/stylesheets/blocks/report/_recent-reports.sass
+++ b/app/assets/stylesheets/blocks/report/_recent-reports.sass
@@ -7,6 +7,9 @@
   +media-breakpoint-down(lg)
     display: none
 
+.recent-reports-item
+  +position(relative)
+
 .recent-reports-item__link
   color: $reversal-text
   +block-link

--- a/app/javascript/check-store.js
+++ b/app/javascript/check-store.js
@@ -7,18 +7,24 @@ export default new Vuex.Store({
   state: {
     checkId: null,
     userName: null,
-    craetedAt: null
+    createdAt: null,
+    checkableId: null,
+    checkableType: null
   },
   getters: {
     checkId: state => state.checkId,
     userName: state => state.userName,
-    createdAt: state => state.createdAt
+    createdAt: state => state.createdAt,
+    checkableId: state => state.checkableId,
+    checkableType: state => state.checkableType
   },
   mutations: {
-    setCheckable (state, { checkId, userName, createdAt }) {
+    setCheckable (state, { checkId, userName, createdAt, checkableId, checkableType }) {
       state.checkId = checkId
       state.userName = userName
       state.createdAt = createdAt
+      state.checkableId = checkableId
+      state.checkableType = checkableType
     }
   },
   actions: {
@@ -40,13 +46,17 @@ export default new Vuex.Store({
             commit('setCheckable', {
               checkId: json[0]['id'],
               createdAt: json[0]['created_at'],
-              userName: json[0]['user']['login_name']
+              userName: json[0]['user']['login_name'],
+              checkableId: checkableId,
+              checkableType: checkableType
             })
           } else {
             commit('setCheckable', {
               checkId: null,
               createdAt: null,
-              userName: null
+              userName: null,
+              checkableId: checkableId,
+              checkableType: checkableType
             })
           }
         })

--- a/app/javascript/recent_report.vue
+++ b/app/javascript/recent_report.vue
@@ -4,7 +4,7 @@
       img.recent-reports-item__user-icon.a-user-icon(:src="report.user.avatar_url" :class="[roleClass, daimyoClass]")
       h3.recent-reports-item__title {{ report.title }}
       time.recent-reports-item__date {{ report.reported_on }}
-    .recent-reports-item__checked(v-if="report.check == 'true'")
+    .recent-reports-item__checked(v-if="report.check")
       i.fas.fa-check
 </template>
 <script>

--- a/app/javascript/recent_reports.js
+++ b/app/javascript/recent_reports.js
@@ -1,11 +1,13 @@
 import Vue from 'vue'
 import RecentReports from './recent_reports.vue'
+import store from './check-store.js'
 
 document.addEventListener('DOMContentLoaded', () => {
   const selector = '#js-recent-reports'
   const recentReports = document.querySelector(selector)
   if (recentReports) {
     new Vue({
+      store,
       render: h => h(RecentReports)
     }).$mount(selector)
   }

--- a/app/javascript/recent_reports.vue
+++ b/app/javascript/recent_reports.vue
@@ -34,6 +34,33 @@ export default {
         .catch(error => {
           console.warn('Failed to parsing', error)
         })
+  },
+  computed: {
+    checkId: function () {
+      return this.$store.getters.checkId
+    }
+  },
+  methods: {
+    updateCheckValue(reportId, {check = true}){
+      this.reports.map( function (report) {
+        if (report.id == reportId) {
+          report.check = check
+        }
+      })
+    }
+  },
+  watch: {
+    checkId (checkId) {
+      let checkableType = this.$store.getters.checkableType
+      if (checkableType == "Report") {
+        let reportId = this.$store.getters.checkableId
+        if (checkId) {
+          this.updateCheckValue(reportId, {check: true})
+        } else {
+          this.updateCheckValue(reportId, {check: false})
+        }
+      }
+    }
   }
 }
 </script>

--- a/app/views/api/reports/recents/index.json.jbuilder
+++ b/app/views/api/reports/recents/index.json.jbuilder
@@ -3,6 +3,7 @@ json.array! @reports do |report|
   json.title truncate(raw(report.title), length: 46)
   json.reported_on l(report.reported_on)
   json.url report_url(report)
+  json.check report.checks.present?
   json.user do
     json.partial! "api/users/user", user: report.user
   end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -55,4 +55,19 @@ class Check::ReportsTest < ApplicationSystemTestCase
     assert_text '確認済'
     assert_text '日報でcomment+確認OKにするtest'
   end
+
+  test 'success recent report checking' do
+    login_user 'machida', 'testtest'
+    visit "/reports/#{reports(:report20).id}"
+    click_button '日報を確認'
+    assert page.has_css?('.recent-reports-item__checked')
+  end
+
+  test 'success recent report checking cancel' do
+    login_user 'machida', 'testtest'
+    visit "/reports/#{reports(:report20).id}"
+    click_button '日報を確認'
+    click_button '日報の確認を取り消す'
+    assert page.has_no_css?('.recent-reports-item__checked')
+  end
 end


### PR DESCRIPTION
#2179  の作業です
日報を確認したらリアルタイムで右側の最新の日報にチェックマークがつくようにしました。
コメントの投稿と同時に日報を確認する場合も、同様にチェックマークがつきます。
日報の確認を取り消すとリアルタイムで右側の最新の日報のチェックマークが外れます。

## GIF動画
[![Image from Gyazo](https://i.gyazo.com/4e868db43ac00b1635929450057f911e.gif)](https://gyazo.com/4e868db43ac00b1635929450057f911e)


## 実装方法
日報の確認ボタンのコンポーネント(Check)と、右側に表示されている最新の日報のコンポーネント(RecentReports)の連携にVuexを使用しました。
理由としては、日報の確認ボタンのコンポーネント(Check)と、確認スタンプのコンポーネント(CheckStamp)がVuexで連携しているからです。
### コードの説明
ストアで管理するステートに<code>checkableId</code>と<code>checkableType</code>を追加します。
これによりストア全体で、確認した日報/確認を取り消した日報のIDを管理できます。
https://github.com/fjordllc/bootcamp/blob/b45db71729de83d09b4db2fa204f7ef636fc324e/app/javascript/check-store.js#L6-L13
確認ボタン押下によりCheckが作成されたらステートのcheckIdにIDが入り、確認を取り消すとnullが入ります。
https://github.com/fjordllc/bootcamp/blob/b45db71729de83d09b4db2fa204f7ef636fc324e/app/javascript/check-store.js#L45-L61
この性質を利用してrecent_reports.vue内でwatchを使ってcheckIdの変更を監視し、checkIdの値が変更される度に日報の配列を(reports)を更新するようにしました。
checkIdに値が入っていれば、最新のレポートの配列からreportIdにマッチするreportのcheckをtrueに変更し配列を返します。
checkIdに値が入っていなければ、最新のレポートの配列からreportIdにマッチするreportのcheckをfalseに変更し配列を返します。
https://github.com/fjordllc/bootcamp/blob/b45db71729de83d09b4db2fa204f7ef636fc324e/app/javascript/recent_reports.vue#L38-L64


