### PR TITLE
マークダウン内の画像にリンクを追加

### DIFF
--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -2,6 +2,7 @@ import MarkdownIt from 'markdown-it'
 import MarkdownItEmoji from 'markdown-it-emoji'
 import MarkdownItTaskLists from 'markdown-it-task-lists'
 import MarkdownItMention from './markdown-it-mention'
+import MarkdownItLinkingImage from './markdown-it-linking-image'
 import MarkdownOption from './markdown-it-option'
 
 export default class {
@@ -19,6 +20,7 @@ export default class {
     const md = new MarkdownIt(MarkdownOption)
     md.use(MarkdownItEmoji)
     md.use(MarkdownItMention)
+    md.use(MarkdownItLinkingImage)
     md.use(MarkdownItTaskLists)
 
     return md.render(text)

--- a/app/javascript/markdown-it-linking-image.js
+++ b/app/javascript/markdown-it-linking-image.js
@@ -1,0 +1,17 @@
+export default function (md) {
+  md.renderer.rules.image = function (tokens, idx, options, env, self) {
+    const imageToken = tokens[idx]
+    const imageIndex = imageToken.attrIndex('src')
+    const imageUrl = imageToken.attrs[imageIndex][1]
+    const alt = md.utils.escapeHtml(imageToken.content)
+    const linkToken = tokens.find(token => token.type === 'link_open')
+    let linkUrl = imageUrl
+
+    if (linkToken) {
+      const linkSrcIndex = linkToken.attrIndex('href')
+      linkUrl = linkToken.attrs[linkSrcIndex][1]
+    }
+
+    return `<a href='${linkUrl}' target='_blank' rel='noopener noreferrer'><img src='${imageUrl}' alt='${alt}'></a>`
+  }
+}

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -66,6 +66,26 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text '絵文字の補完テスト: 😺'
   end
 
+  test 'post new comment with image for report' do
+    visit "/reports/#{reports(:report1).id}"
+    sleep 1
+    find('#js-new-comment').set("![Image](https://example.com/test.png)'")
+    click_button 'コメントする'
+    wait_for_vuejs
+    assert_match '<a href="https://example.com/test.png" target="_blank" rel="noopener noreferrer"><img src="https://example.com/test.png" alt="Image"></a>',
+                 page.body
+  end
+
+  test 'post new comment with linked image for report' do
+    visit "/reports/#{reports(:report1).id}"
+    sleep 1
+
+    find('#js-new-comment').set('[![Image](https://example.com/test.png)](https://example.com)')
+    click_button 'コメントする'
+    wait_for_vuejs
+    assert_match '<a href="https://example.com" target="_blank" rel="noopener noreferrer"><img src="https://example.com/test.png" alt="Image"></a>', page.body
+  end
+
   test 'edit the comment for report' do
     visit "/reports/#{reports(:report3).id}"
     within('.thread-comment:first-child') do


### PR DESCRIPTION
マークダウン内の画像にリンクを追加して、画像をクリックすると別タブで画像を開くように修正しました。

---

https://github.com/fjordllc/bootcamp/issues/1683