### PR TITLE
マークダウンで不要なリンクの生成を修正

### DIFF
--- a/app/javascript/markdown-it-linking-image.js
+++ b/app/javascript/markdown-it-linking-image.js
@@ -1,17 +1,15 @@
 export default function (md) {
+  const defaultRender = md.renderer.rules.image
+
   md.renderer.rules.image = function (tokens, idx, options, env, self) {
+    if (tokens.some(token => token.type === 'link_open')) {
+      return defaultRender(tokens, idx, options, env, self)
+    }
+
     const imageToken = tokens[idx]
     const imageIndex = imageToken.attrIndex('src')
     const imageUrl = imageToken.attrs[imageIndex][1]
     const alt = md.utils.escapeHtml(imageToken.content)
-    const linkToken = tokens.find(token => token.type === 'link_open')
-    let linkUrl = imageUrl
-
-    if (linkToken) {
-      const linkSrcIndex = linkToken.attrIndex('href')
-      linkUrl = linkToken.attrs[linkSrcIndex][1]
-    }
-
-    return `<a href='${linkUrl}' target='_blank' rel='noopener noreferrer'><img src='${imageUrl}' alt='${alt}'></a>`
+    return `<a href='${imageUrl}' target='_blank' rel='noopener noreferrer'><img src='${imageUrl}' alt='${alt}'></a>`
   }
 }

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -83,7 +83,7 @@ class CommentsTest < ApplicationSystemTestCase
     find('#js-new-comment').set('[![Image](https://example.com/test.png)](https://example.com)')
     click_button 'コメントする'
     wait_for_vuejs
-    assert_match '<a href="https://example.com" target="_blank" rel="noopener noreferrer"><img src="https://example.com/test.png" alt="Image"></a>', page.body
+    assert_match '<a href="https://example.com"><img src="https://example.com/test.png" alt="Image"></a>', page.body
   end
 
   test 'edit the comment for report' do


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/pull/2195 でマークダウン内の画像にリンクを追加しましたが、下記のような画像にリンクを設定している時にリンクが2つ生成されてしまっていたので、修正しました :bow:

#### Markdown

```
[![image.png](https://example.com/xxx.png)](https://www.google.com)
```

#### Before

```
<p>
  <a href="https://www.google.com"></a>
  <a href="https://www.google.com" target="_blank" rel="noopener noreferrer">
    <img src="https://example.com/xxx.png" alt="image.png">
  </a>
</p>
```

#### After

```
<p>
  <a href="https://www.google.com">
    <img src="https://example.com/xxx.png" alt="image.png">
  </a>
</p>
```