### PR TITLE
ユーザーネーム検索の対象カラムに最終更新者を追加

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -39,7 +39,7 @@ module Searchable
 
     def create_parameter_for_search_user_id(name)
       user = User.find_by(login_name: name)
-      { 'user_id_eq' => user&.id || 0 }
+      { 'user_id_or_last_updated_user_id_eq' => user&.id || 0 }
     end
   end
   # rubocop:enable Metrics/BlockLength

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -457,16 +457,18 @@ practice54:
 
 practice55:
   title: "サーバー連携"
-  description: "description..."
+  description: "ユーザーネーム（最終更新者）で検索できるよ"
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category20
   position: 55
+  last_updated_user: komagata
 
 practice56:
   title: "Unityでのテスト"
-  description: "description..."
+  description: "ユーザーネーム（最終更新者）で検索できるよ"
   goal: "goal..."
   categories: category21
   position: 56
   include_progress: false
+  last_updated_user: machida

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -199,7 +199,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_equal(6, result.size)
   end
 
-  test 'returns only kimuras report when user param' do
+  test 'returns only daimyos report when user param' do
     result = Searcher.search('ユーザーネームで検索できるよ user:daimyo')
     assert_includes(result, reports(:report24))
     assert_not_includes(result, reports(:report25))

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -204,4 +204,10 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, reports(:report24))
     assert_not_includes(result, reports(:report25))
   end
+
+  test 'returns only updated-by-komagata practice when user param' do
+    result = Searcher.search('ユーザーネーム（最終更新者）で検索できるよ user:komagata')
+    assert_includes(result, practices(:practice55))
+    assert_not_includes(result, practices(:practice56))
+  end
 end


### PR DESCRIPTION
関連PR: #2141

変更前：ユーザーネームが `user` に合致する結果を表示
変更後：ユーザーネームが `user` もしくは `last_updated_user` に合致する結果を表示

これにより https://bootcamp.fjord.jp/reports/22781 にある「プラクティスは投稿者に関わらずヒットしてしまう」というバグが修正されます。

@komagata さん、@ima1zumi さん、ご確認お願いします🙏