### PR TITLE
フォロー解除で他のユーザーのフォローを解除するバグを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -486,7 +486,7 @@ class User < ApplicationRecord
   end
 
   def unfollow(other_user)
-    Following.find_by(followed_id: other_user.id).destroy
+    following.delete(other_user)
   end
 
   def following?(other_user)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -250,4 +250,15 @@ class UserTest < ActiveSupport::TestCase
     category11 = categories(:category11)
     assert hajime.completed_all_practices?(category11)
   end
+
+  test 'dont unfollow user when other user unfollow user' do
+    kimura = users(:kimura)
+    hatsuno = users(:hatsuno)
+    kimura.follow(hatsuno)
+    daimyo = users(:daimyo)
+    daimyo.follow(hatsuno)
+    assert Following.find_by(follower_id: kimura.id, followed_id: hatsuno.id)
+    daimyo.unfollow(hatsuno)
+    assert Following.find_by(follower_id: kimura.id, followed_id: hatsuno.id)
+  end
 end


### PR DESCRIPTION
ref: #2220
フォロー解除の際に自分のユーザーIDを指定せずにFollowings全体から削除していたため、他人のフォローを解除してしまうことがあった。
自分のフォロー一覧からフォロー解除するように修正し、テストを追加した。