### PR TITLE
Docに関連プラクティスを保存できるように修正

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -60,9 +60,9 @@ class PagesController < ApplicationController
 
   def page_params
     if admin_login?
-      params.require(:page).permit(:title, :body, :tag_list, :user_id)
+      params.require(:page).permit(:title, :body, :tag_list, :user_id, :practice_id)
     else
-      params.require(:page).permit(:title, :body, :tag_list)
+      params.require(:page).permit(:title, :body, :tag_list, :practice_id)
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -59,11 +59,9 @@ class PagesController < ApplicationController
   end
 
   def page_params
-    if admin_login?
-      params.require(:page).permit(:title, :body, :tag_list, :user_id, :practice_id)
-    else
-      params.require(:page).permit(:title, :body, :tag_list, :practice_id)
-    end
+    keys = %i[title body tag_list practice_id]
+    keys << :user_id if admin_login?
+    params.require(:page).permit(*keys)
   end
 
   def set_wip

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -143,4 +143,14 @@ class PagesTest < ApplicationSystemTestCase
     click_on '内容変更'
     assert_no_selector '.select-users'
   end
+
+  test 'doc can relate practice' do
+    visit new_page_path
+    fill_in 'page[title]', with: 'Docに関連プラクティスを指定'
+    fill_in 'page[body]', with: 'Docに関連プラクティスを指定'
+    first('.select2-container').click
+    find('li.select2-results__option[role="option"]', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
+    click_button '内容を保存'
+    assert_text 'Linuxのファイル操作の基礎を覚える'
+  end
 end


### PR DESCRIPTION
ref: #2222

<code>page_params</code>に<code>practice_id</code>を追加し、Docに関連プラクティスを保存できるように修正しました。
テストも追加しました。