### PR TITLE
test/models/link_checker/client_test.rb のe-words.jpのURLをhttpからhttpsに変更

### DIFF
--- a/test/models/link_checker/client_test.rb
+++ b/test/models/link_checker/client_test.rb
@@ -8,7 +8,7 @@ module LinkChecker
       assert_equal 200, Client.request('http://example.com/')
       assert_equal 404, Client.request('https://fjord.jp/foo')
       assert_equal false, Client.request('http://foofoofoo.com/')
-      assert_equal 200, Client.request('http://e-words.jp/w/単体テスト.html')
+      assert_equal 200, Client.request('https://e-words.jp/w/単体テスト.html')
       assert_equal 200, Client.request('https://developer.mozilla.org/ja/docs/Web/JavaScript#Tutorials')
     end
 
@@ -16,7 +16,7 @@ module LinkChecker
       assert_equal 200, Client.new('http://example.com/').request
       assert_equal 404, Client.new('https://fjord.jp/foo').request
       assert_equal false, Client.new('http://foofoofoo.com/').request
-      assert_equal 200, Client.new('http://e-words.jp/w/単体テスト.html').request
+      assert_equal 200, Client.new('https://e-words.jp/w/単体テスト.html').request
       assert_equal 200, Client.new('https://developer.mozilla.org/ja/docs/Web/JavaScript#Tutorials').request
     end
   end


### PR DESCRIPTION
## 変更の概要
<code> test/models/link_checker/client_test.rb</code>の<code>e-words.jp</code>のURLを、httpからhttpsに変更しました。

## 変更の経緯
CI・開発環境で以下の様に<code>test/models/link_checker/client_test.rb </code>の<code>e-words.jp</code>のテストが落ちることを確認しました。
- 開発環境
```
F

Failure:
LinkChecker::ClientTest#test_#request [/Users/mashio/Desktop/bootcamp/test/models/link_checker/client_test.rb:19]:
Expected: 200
  Actual: 301


rails test test/models/link_checker/client_test.rb:15

F

Failure:
LinkChecker::ClientTest#test_.request [/Users/mashio/Desktop/bootcamp/test/models/link_checker/client_test.rb:11]:
Expected: 200
  Actual: 301


rails test test/models/link_checker/client_test.rb:7
```
- CI
https://app.circleci.com/pipelines/github/fjordllc/bootcamp/1491/workflows/a517d13e-1678-440d-ba3b-9108fd5ea4bd/jobs/5307


<code>http://e-words.jp/w/単体テスト.html</code>へのアクセスが<code>https://e-words.jp/w/単体テスト.html</code>へリダイレクトされることを、curlコマンドを使って確認しました。
```
mashio@sanomashionoMacBook-Air:~/Desktop/bootcamp (change-ewords-url-from-http-to-https *)
$ curl -i http://e-words.jp/w/%E5%8D%98%E4%BD%93%E3%83%86%E3%82%B9%E3%83%88.html
HTTP/1.1 301 Moved Permanently
Cache-Control: private
Content-Length: 0
Content-Type: text/html
Location: https://e-words.jp/w/%E5%8D%98%E4%BD%93%E3%83%86%E3%82%B9%E3%83%88.html
Server: Microsoft-IIS/7.5
X-Powered-By: ASP.NET
Date: Fri, 01 Jan 2021 06:02:54 GMT

mashio@sanomashionoMacBook-Air:~/Desktop/bootcamp (change-ewords-url-from-http-to-https *)
$ curl -i https://e-words.jp/w/%E5%8D%98%E4%BD%93%E3%83%86%E3%82%B9%E3%83%88.html
HTTP/1.1 200 OK
Cache-Control: private
Content-Length: 0
Content-Type: text/html
Server: Microsoft-IIS/7.5
X-Powered-By: ASP.NET
Date: Fri, 01 Jan 2021 06:03:07 GMT
```
e-words.jpのURLをhttpからhttpsに変更することで、レスポンスコード200を期待するテストが通るように修正しました。

