### PR TITLE
ベストアンサーのハンコ表示のレイヤーを上に移動

### DIFF
--- a/app/assets/stylesheets/blocks/question/_answer-badge.sass
+++ b/app/assets/stylesheets/blocks/question/_answer-badge.sass
@@ -3,12 +3,13 @@
   border-radius: .75rem
   +size(4rem 3.5rem)
   padding: .125rem
-  +position(absolute, right 0, top -.125rem)
+  +position(absolute, right 0, top -.125rem, 1)
   transform: rotate(25deg)
   +text-block(.625rem 1, flex center $stamp-color)
   flex-direction: column
   align-items: center
   justify-content: center
+  pointer-events: none
   +media-breakpoint-down(sm)
     +position(absolute, left 80%, top 0)
 

--- a/app/assets/stylesheets/blocks/thread/_thread-comments.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-comments.sass
@@ -101,6 +101,7 @@ $thread-header-author: 3.5rem
       min-height: 0
     .thread-comment__created-at
       align-self: flex-end
+        
 
 .thread-comment__user-icon
   +size(2.75rem auto)


### PR DESCRIPTION
#2218 対応

![image](https://user-images.githubusercontent.com/168265/103505040-8cdb9e80-4e9c-11eb-9f90-0d9db17f0867.png)
