### PR TITLE
日報の個別ページで、プラクティス部分の表示が崩れる

### DIFF
--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -46,12 +46,13 @@ header.page-header
             .thread-header__raw
               = link_to 'Raw', report_path(format: :md), class: 'a-button is-sm is-secondary', target: '_blank', rel: 'noopener'
         - if @report.practices.present?
-          .tag-links
-            ul.tag-links__items
-              - @report.practices.order(:position).each do |practice|
-                li.tag-links__item
-                  = link_to practice, class: 'tag-links__item-link' do
-                    = practice.title
+          .thread__tags
+            .tag-links
+              ul.tag-links__items
+                - @report.practices.order(:position).each do |practice|
+                  li.tag-links__item
+                    = link_to practice, class: 'tag-links__item-link' do
+                      = practice.title
 
         = render 'reports/learning_times', report: @report
 


### PR DESCRIPTION
Ref #2239 

日報の個別ページ表示にて、タグ部分のレイアウトを修正いたしました。

ユーザーハッシュタグ機能 #2128 を反映していただいた際に発生いたしました。
タグレイアウト変更に関連する箇所の、修正と動作確認が不足しておりました🙇‍♀️

（修正後）
<img width="300" alt="スクリーンショット 2021-01-08 5 44 13" src="https://user-images.githubusercontent.com/2003287/103945752-ff889a80-5178-11eb-9d85-68c5c2915f1c.png">
