### PR TITLE
お知らせ編集画面の「内容変更」ボタンを「公開」ボタンに変更

### DIFF
--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -42,7 +42,7 @@
             - if announcement.new_record?
               = f.submit '作成', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
             - else
-              = f.submit '内容変更', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
+              = f.submit '公開', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
       li.form-actions__item
         - case params[:action]
         - when 'new', 'create'


### PR DESCRIPTION
Issue https://github.com/fjordllc/bootcamp/issues/2219 へ対応

メンターがお知らせを公開するときのアクションの文言がおかしいということで
編集画面のボタンの文言を「内容変更」ボタンから「公開」ボタンに変更。
