### PR TITLE
期生別一覧を新しい期順に並ぶようにした

### DIFF
--- a/app/controllers/generations_controller.rb
+++ b/app/controllers/generations_controller.rb
@@ -9,6 +9,6 @@ class GenerationsController < ApplicationController
   end
 
   def index
-    @generations = Generation.descending_order_generations
+    @generations = Generation.generations.reverse
   end
 end

--- a/app/controllers/generations_controller.rb
+++ b/app/controllers/generations_controller.rb
@@ -9,6 +9,6 @@ class GenerationsController < ApplicationController
   end
 
   def index
-    @generations = Generation.generations.reverse
+    @generations = Generation.descending_order_generations
   end
 end

--- a/app/controllers/generations_controller.rb
+++ b/app/controllers/generations_controller.rb
@@ -9,6 +9,6 @@ class GenerationsController < ApplicationController
   end
 
   def index
-    @generations = Generation.generations
+    @generations = Generation.generations.reverse
   end
 end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -6,10 +6,6 @@ class Generation
       (1..max_generation_number).map { |n| Generation.new(n) }
     end
 
-    def descending_order_generations
-      generations.reverse
-    end
-
     def max_generation_number
       now_time = Time.zone.now
       (now_time.year - 2013) * 4 + (now_time.month + 2) / 3

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -6,6 +6,10 @@ class Generation
       (1..max_generation_number).map { |n| Generation.new(n) }
     end
 
+    def descending_order_generations
+      generations.reverse
+    end
+
     def max_generation_number
       now_time = Time.zone.now
       (now_time.year - 2013) * 4 + (now_time.month + 2) / 3


### PR DESCRIPTION
issue: https://github.com/fjordllc/bootcamp/issues/2177 に対応

今までは1期生から並ぶ昇順になっていましたが、新しい期から並ぶ降順に並び替えました。