### PR TITLE
プロフィールの自己紹介を入力必須にする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,7 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true
   validates :name, presence: true
+  validates :description, presence: true
   validates :nda, presence: true
   validates :password, length: { minimum: 4 }, confirmation: true, if: :password_required?
   validates :twitter_account,

--- a/app/views/users/form/_description.html.slim
+++ b/app/views/users/form/_description.html.slim
@@ -7,7 +7,7 @@
       placeholder = 'XXXXと申します。月・水・金の 10:00 〜 19:00 に活動します。XXXXと考えたため、プログラマーとして就職することを決意しました。今はXXXXで働いています。XXXXが好きでよくXXXXしています。XXXXが好きな方、仲良くしてください！！'
       help_text = 'この情報は他のフィヨルドブートキャンプ参加者に公開されます。あとからでも内容を変更することができます。'
     end
-  = f.label :description, class: 'a-label'
+  = f.label :description, class: 'a-label is-required'
   = f.text_area :description, class: 'a-text-input is-sm', placeholder: placeholder
   .a-form-help
     p = help_text

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -28,4 +28,13 @@ class CurrentUserTest < ApplicationSystemTestCase
     click_on 'タグ1'
     assert_text '「タグ1」のユーザー'
   end
+
+  test 'update user description with blank' do
+    login_user 'kimura', 'testtest'
+    visit '/current_user/edit'
+    fill_in 'user[description]', with: ''
+    click_on '更新する'
+    assert_text '自己紹介を入力してください'
+  end
+
 end

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -36,5 +36,4 @@ class CurrentUserTest < ApplicationSystemTestCase
     click_on '更新する'
     assert_text '自己紹介を入力してください'
   end
-
 end

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -216,4 +216,32 @@ class SignUpTest < ApplicationSystemTestCase
     assert_text 'サインアップメールをお送りしました。メールからサインアップを完了させてください。'
     assert_equal User.find_by(email: email).company_id, companies(:company2).id
   end
+
+  test 'sign up with empty description ' do
+    WebMock.allow_net_connect!
+
+    visit '/users/new'
+    within 'form[name=user]' do
+      fill_in 'user[login_name]', with: 'foo'
+      fill_in 'user[email]', with: 'siro@example.com'
+      fill_in 'user[name]', with: 'テスト 四郎'
+      fill_in 'user[name_kana]', with: 'テスト シロウ'
+      fill_in 'user[password]', with: 'testtest'
+      fill_in 'user[password_confirmation]', with: 'testtest'
+      select '学生', from: 'user[job]'
+      select 'Mac', from: 'user[os]'
+      select '未経験', from: 'user[experience]'
+    end
+
+    fill_stripe_element('5555 5555 5555 4444', '12 / 21', '111', '11122')
+
+    click_button '利用規約に同意して参加する'
+    sleep 1
+    assert_text '自己紹介を入力してください'
+
+    WebMock.disable_net_connect!(
+      allow_localhost: true,
+      allow: 'chromedriver.storage.googleapis.com'
+    )
+  end
 end

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -13,6 +13,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[email]', with: "test-#{SecureRandom.hex(16)}@example.com"
       fill_in 'user[name]', with: 'テスト 太郎'
       fill_in 'user[name_kana]', with: 'テスト タロウ'
+      fill_in 'user[description]', with: 'テスト太郎です。'
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
@@ -41,6 +42,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[email]', with: 'jiro@example.com'
       fill_in 'user[name]', with: 'テスト 次郎'
       fill_in 'user[name_kana]', with: 'テスト ジロウ'
+      fill_in 'user[description]', with: 'テスト次郎です。'
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
@@ -69,6 +71,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[email]', with: 'saburo@example.com'
       fill_in 'user[name]', with: 'テスト 三郎'
       fill_in 'user[name_kana]', with: 'テスト サブロウ'
+      fill_in 'user[description]', with: 'テスト三郎です。'
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
@@ -97,6 +100,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[email]', with: 'hanako@example.com'
       fill_in 'user[name]', with: 'テスト 花子'
       fill_in 'user[name_kana]', with: 'テスト ハナコ'
+      fill_in 'user[description]', with: 'テスト花子です。'
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
@@ -126,6 +130,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[email]', with: email
       fill_in 'user[name]', with: 'テスト 春子'
       fill_in 'user[name_kana]', with: 'テスト ハルコ'
+      fill_in 'user[description]', with: 'テスト春子です。'
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
     end
@@ -144,6 +149,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[email]', with: email
       fill_in 'user[name]', with: 'テスト 夏美'
       fill_in 'user[name_kana]', with: 'テスト ナツミ'
+      fill_in 'user[description]', with: 'テスト夏美です。'
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
@@ -173,6 +179,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[email]', with: 'akiko@example.com'
       fill_in 'user[name]', with: 'テスト 秋子'
       fill_in 'user[name_kana]', with: 'テスト アキコ'
+      fill_in 'user[description]', with: 'テスト秋子です。'
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
@@ -201,6 +208,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[email]', with: email
       fill_in 'user[name]', with: 'テスト ふゆこ'
       fill_in 'user[name_kana]', with: 'テスト フユコ'
+      fill_in 'user[description]', with: 'テストふゆこです。'
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
     end


### PR DESCRIPTION
## issue
 https://github.com/fjordllc/bootcamp/issues/2140 に対応

## 目的
自己紹介文もないと、その人の人となりがわからず、どういう素性の人がどういう目的で参加してきたのか不明で少し不安になるから。

## やったこと
- 自己紹介にバリデーションを追加
- 入力必須の赤アスタリスクを表示
- 自己紹介を空欄で作成、更新した場合のテストを作成