### PR TITLE
「今日の気分」の並び順を変更

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,8 +11,8 @@ class Report < ApplicationRecord
   include Mentioner
 
   enum emotion: {
-    soso: 0,
-    sad: 1,
+    sad: 0,
+    soso: 1,
     happy: 2
   }
 
@@ -55,7 +55,7 @@ class Report < ApplicationRecord
 
   def self.faces
     @faces ||= emotions.keys
-                       .zip(%w[emotion/soso.svg emotion/sad.svg emotion/happy.svg])
+                       .zip(%w[emotion/sad.svg emotion/soso.svg emotion/happy.svg])
                        .to_h
                        .with_indifferent_access
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,8 +11,8 @@ class Report < ApplicationRecord
   include Mentioner
 
   enum emotion: {
-    sad: 0,
-    soso: 1,
+    sad: 1,
+    soso: 0,
     happy: 2
   }
 

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -123,7 +123,7 @@ report15:
 report16:
   user: hajime
   title: "今日は頑張れませんでした"
-  emotion: 0
+  emotion: 1
   description: |-
     頑張れませんでした
   reported_on: <%= Time.now - 2.day %>
@@ -147,7 +147,7 @@ report18:
 report19:
   user: hatsuno
   title: "<s>1日目</s> できなかった"
-  emotion: 0
+  emotion: 1
   description: |-
     あまりできませんでした
   reported_on: <%= Time.current - 2.day %>
@@ -155,7 +155,7 @@ report19:
 report20:
   user: hatsuno
   title: "2日目 昨日よりできなかった"
-  emotion: 0
+  emotion: 1
   description: |-
     昨日よりできませんでした
   reported_on: <%= Time.current - 1.day %>

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -123,7 +123,7 @@ report15:
 report16:
   user: hajime
   title: "今日は頑張れませんでした"
-  emotion: 1
+  emotion: 0
   description: |-
     頑張れませんでした
   reported_on: <%= Time.now - 2.day %>
@@ -147,7 +147,7 @@ report18:
 report19:
   user: hatsuno
   title: "<s>1日目</s> できなかった"
-  emotion: 1
+  emotion: 0
   description: |-
     あまりできませんでした
   reported_on: <%= Time.current - 2.day %>
@@ -155,7 +155,7 @@ report19:
 report20:
   user: hatsuno
   title: "2日目 昨日よりできなかった"
-  emotion: 1
+  emotion: 0
   description: |-
     昨日よりできませんでした
   reported_on: <%= Time.current - 1.day %>


### PR DESCRIPTION
## issue
#2157 に対応

## 目的
- 「soso(0)・sad(-)・happy(+)」の並び順を、 より自然な「sad(-)・soso(±0)・happy(+)」に変更する。
<img width="331" alt="スクリーンショット 2021-01-13 11 57 35" src="https://user-images.githubusercontent.com/52053239/104400935-8fbe4980-5596-11eb-8e41-1fe7aca42216.png">

## やったこと
- 並び順をsad/soso/happyに変更
<img width="339" alt="スクリーンショット 2021-01-13 11 57 18" src="https://user-images.githubusercontent.com/52053239/104400938-92b93a00-5596-11eb-9e4d-794c645e9eec.png">

- 並び順変更に付随するreports.ymlのemotionも修正