### PR TITLE
既存のCategoryのposition値を連番にする（データ移行）

### DIFF
--- a/db/data/20210115022107_change_category_position_to_sequential.rb
+++ b/db/data/20210115022107_change_category_position_to_sequential.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ChangeCategoryPositionToSequential < ActiveRecord::Migration[6.0]
+  def up
+    ActiveRecord::Base.transaction do
+      Category.acts_as_list_no_update do
+        Category.order(:position).each.with_index(1) do |category, index|
+          category.update!(position: index)
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
#2208 のPRは、Categoryのposition値が連番になっていることを前提としていますが、当初positionカラムが作られたとき、category.idを代入したため、現在は連番になっていない可能性が高いです。
acts_as_listの仕様としても連番の方が都合がよいため、`1`からの連番になるようにします。