### PR TITLE
12/31だけ落ちる席予約のテストを修正

### DIFF
--- a/test/system/reservations_test.rb
+++ b/test/system/reservations_test.rb
@@ -34,21 +34,20 @@ class ReservationsTest < ApplicationSystemTestCase
   end
 
   test 'reservations beyond one month cannot be made' do
-    visit '/reservation_calenders'
-    assert_equal '席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
-    click_link 'next-month'
+    travel_to Time.zone.local(2020, 1, 1, 0, 0, 0) do
+      reservation_date = Date.current.next_month.tomorrow
+      visit "/reservation_calenders/#{reservation_date.strftime('%Y%m')}/"
+      assert_equal '席予約一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
 
-    reservation_date = Date.current.next_month.tomorrow
-
-    click_link 'next-month' if (Date.current.month + 2) <= reservation_date.month
-    accept_confirm do
-      within("#reservation-#{reservation_date}-#{seats(:seat2).id}") do
-        find('#reserve-seat').click
+      accept_confirm do
+        within("#reservation-#{reservation_date}-#{seats(:seat2).id}") do
+          find('#reserve-seat').click
+        end
       end
-    end
 
-    within("#reservation-#{reservation_date}-#{seats(:seat2).id}") do
-      assert_no_text 'hatsuno'
+      within("#reservation-#{reservation_date}-#{seats(:seat2).id}") do
+        assert_no_text 'hatsuno'
+      end
     end
   end
 end


### PR DESCRIPTION
12/31だけ落ちる席予約のテストを修正しました。


12/31にこのテストを実行すると、以下の条件がfalseになり、「次の月へ」ボタンをクリックできず、テストが落ちていました。
https://github.com/fjordllc/bootcamp/blob/5d0a547a68229890d5e8913cab6ab184a7e85733/test/system/reservations_test.rb#L43
このテストでは現在の日付から1ヶ月を超える日付の座席は予約できないことをテストできれば良いので、以下のようにテストを修正しました。
1. <code>trave_to</code>メソッドを使って日付を固定する
2. 条件分岐の記述をなくす

