### PR TITLE
右カラムの最新の日報の表示数を20件にする

### DIFF
--- a/app/controllers/api/reports/recents_controller.rb
+++ b/app/controllers/api/reports/recents_controller.rb
@@ -6,6 +6,6 @@ class API::Reports::RecentsController < API::BaseController
                .includes(user: [{ avatar_attachment: :blob }, :company])
                .not_wip
                .order(reported_on: :desc, id: :desc)
-               .limit(10)
+               .limit(20)
   end
 end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -69,6 +69,6 @@ class Check::ReportsTest < ApplicationSystemTestCase
     click_button '日報を確認'
     wait_for_vuejs
     click_button '日報の確認を取り消す'
-    assert page.all('.recent-reports-item')[0].has_no_css?('.recent-reports-item__checked')
+    assert page.first('.recent-reports-item').has_no_css?('.recent-reports-item__checked')
   end
 end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -60,14 +60,15 @@ class Check::ReportsTest < ApplicationSystemTestCase
     login_user 'machida', 'testtest'
     visit "/reports/#{reports(:report20).id}"
     click_button '日報を確認'
-    assert page.has_css?('.recent-reports-item__checked')
+    assert page.all('.recent-reports-item')[0].has_css?('.recent-reports-item__checked')
   end
 
   test 'success recent report checking cancel' do
     login_user 'machida', 'testtest'
     visit "/reports/#{reports(:report20).id}"
     click_button '日報を確認'
+    wait_for_vuejs
     click_button '日報の確認を取り消す'
-    assert page.has_no_css?('.recent-reports-item__checked')
+    assert page.all('.recent-reports-item')[0].has_no_css?('.recent-reports-item__checked')
   end
 end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -60,7 +60,7 @@ class Check::ReportsTest < ApplicationSystemTestCase
     login_user 'machida', 'testtest'
     visit "/reports/#{reports(:report20).id}"
     click_button '日報を確認'
-    assert page.all('.recent-reports-item')[0].has_css?('.recent-reports-item__checked')
+    assert page.first('.recent-reports-item').has_css?('.recent-reports-item__checked')
   end
 
   test 'success recent report checking cancel' do


### PR DESCRIPTION
## issue
https://github.com/fjordllc/bootcamp/issues/2150 に対応

## やったこと
実装前は最新の日報の表示数が10件でしたが、20件に修正しました。