### PR TITLE
イベント申し込み後のflashの文言を変更したい

### DIFF
--- a/app/controllers/events/participations_controller.rb
+++ b/app/controllers/events/participations_controller.rb
@@ -7,7 +7,7 @@ class Events::ParticipationsController < ApplicationController
     return unless @event.participations.create(user: current_user, enable: @event.can_participate?)
 
     create_watch
-    redirect_to event_path(@event), notice: '出席登録が完了しました。'
+    redirect_to event_path(@event), notice: '参加登録しました。'
   end
 
   def destroy

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -185,7 +185,7 @@ class EventsTest < ApplicationSystemTestCase
       click_link '参加申込'
     end
     assert_difference 'event.users.count', 1 do
-      assert_text '出席登録が完了しました。'
+      assert_text '参加登録しました。'
     end
   end
 


### PR DESCRIPTION
# issue
#2248 に対応
# やること
イベントを申し込んだ後の表記変更
変更前「出席登録が完了しました」
変更後「参加登録しました」