### PR TITLE
右カラムの最新の日報のチェックのアイコンを変更

### DIFF
--- a/app/assets/stylesheets/blocks/report/_recent-reports.sass
+++ b/app/assets/stylesheets/blocks/report/_recent-reports.sass
@@ -41,19 +41,13 @@
     color: rgba(white, .6)
 
 .recent-reports-item__user-icon
-  +size(2.75rem)
+  +size(2.125rem)
   float: left
   margin-right: .75rem
   background-color: $base
   +icon-role-style
   .recent-reports-item.is-wip &
     opacity: .6
-
-.recent-reports-item__checked
-  color: $accent
-  +position(absolute, left .25rem, top .25rem)
-  font-size: 1.5rem
-  text-shadow: $main .0625rem .0625rem 0
 
 .recent-reports__to-index
   width: 14rem

--- a/app/assets/stylesheets/blocks/report/_stamp.sass
+++ b/app/assets/stylesheets/blocks/report/_stamp.sass
@@ -20,6 +20,12 @@
     font-weight: 800
     font-family: serif
     justify-content: center
+  &.is-sm
+    +size(4.125em 2.25rem)
+    +position(absolute, right .5rem, top .5rem)
+    border-radius: .5rem
+    display: flex
+    align-items: center
 
 .stamp__content
   display: flex

--- a/app/javascript/recent_report.vue
+++ b/app/javascript/recent_report.vue
@@ -4,8 +4,9 @@
       img.recent-reports-item__user-icon.a-user-icon(:src="report.user.avatar_url" :class="[roleClass, daimyoClass]")
       h3.recent-reports-item__title {{ report.title }}
       time.recent-reports-item__date {{ report.reported_on }}
-    .recent-reports-item__checked(v-if="report.check")
-      i.fas.fa-check
+    .stamp.stamp-approve.is-sm(v-if="report.check")
+      h2.stamp__content.is-title
+        | 確認済
 </template>
 <script>
 export default {

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -60,7 +60,7 @@ class Check::ReportsTest < ApplicationSystemTestCase
     login_user 'machida', 'testtest'
     visit "/reports/#{reports(:report20).id}"
     click_button '日報を確認'
-    assert page.first('.recent-reports-item').has_css?('.recent-reports-item__checked')
+    assert page.first('.recent-reports-item').has_css?('.stamp-approve')
   end
 
   test 'success recent report checking cancel' do
@@ -69,6 +69,6 @@ class Check::ReportsTest < ApplicationSystemTestCase
     click_button '日報を確認'
     wait_for_vuejs
     click_button '日報の確認を取り消す'
-    assert page.first('.recent-reports-item').has_no_css?('.recent-reports-item__checked')
+    assert page.first('.recent-reports-item').has_no_css?('.stamp-approve')
   end
 end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -38,12 +38,14 @@ class Check::ReportsTest < ApplicationSystemTestCase
     assert_text '確認済'
   end
 
-  test 'success product checking cancel' do
+  test 'success report checking cancel' do
     login_user 'machida', 'testtest'
     visit "/reports/#{reports(:report2).id}"
     click_button '日報を確認'
     click_button '日報の確認を取り消す'
-    assert_no_text '確認済'
+    within('.thread') do
+      assert_no_text '確認済'
+    end
     assert has_button? '日報を確認'
   end
 


### PR DESCRIPTION
取り急ぎ、右カラムのチェックのデザインをメンターがチェックしたものとわかるように変更しました。右カラムにタイムライン的なものを出すなど、右カラムの使い方の変更は別で考えていきたいと思います。

![image](https://user-images.githubusercontent.com/168265/106923493-781b5080-6751-11eb-9acd-6e274c2d0438.png)

