### PR TITLE
「このタグを自分にも追加」ボタンを作成

### DIFF
--- a/app/controllers/users/tags_controller.rb
+++ b/app/controllers/users/tags_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Users::TagsController < ApplicationController
+  def update
+    current_user.tag_list.add(params[:tag])
+    current_user.save
+    redirect_to "/users/tags/#{params[:tag]}"
+  end
+end

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -27,6 +27,8 @@ main.page-main
         h1.page-main-header__title
           - if params[:tag]
             | タグ「#{params[:tag]}」のユーザー（#{@users.total_count}）
+            - unless current_user.tag_list.include?(params[:tag])
+              = link_to 'このタグを自分にも追加', "/users/tags/#{params[:tag]}", method: 'post', class: 'a-button is-sm is-secondary'
           - else
             | #{t("target.#{@target}")}（#{@users.total_count}）
   .page-body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,10 @@ Rails.application.routes.draw do
   get "questions/tags/:tag", to: "questions#index", as: :questions_tag
   get "users/tags/:tag", to: "users#index", as: :users_tag
 
+  namespace :users do
+    post "tags/:tag", to: "tags#update"
+  end
+
   get "login" => "user_sessions#new", as: :login
   get "auth/github/callback" => "user_sessions#callback"
   post "user_sessions" => "user_sessions#create"

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class User::TagsTest < ApplicationSystemTestCase
+  setup { login_user 'hatsuno', 'testtest' }
+
+  test 'add user tag' do
+    visit user_path(users(:hatsuno))
+    assert_no_text '猫'
+
+    visit '/users/tags/猫'
+    click_on 'このタグを自分にも追加'
+    assert_no_text 'このタグを自分にも追加'
+
+    visit user_path(users(:hatsuno))
+    assert_text '猫'
+  end
+end


### PR DESCRIPTION
Issue #2266

特定のタグで絞ったユーザーの一覧画面で、「このタグを自分に追加する」ボタンを作成。
このボタンを押すと、自分自身に同じタグが追加される。

[![Image from Gyazo](https://i.gyazo.com/fec6257cceab7a728cf05b69ec5f4135.gif)](https://gyazo.com/fec6257cceab7a728cf05b69ec5f4135)

Vue.jsで非同期にすると作業が増える割には、嬉しいことが少なかったので、非同期にはしてません。
(自分を増やすだけでなく、今後の右サイドバーの並びも変更する必要もありそうと思う等したため)

デザインはmachidaさんがされると思います。