### PR TITLE
CIでよく落ちるテストの修正

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -19,7 +19,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   setup do
-    Bootcamp::Setup.attachment
     stub_github!
     stub_subscription_all!
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -108,15 +108,12 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'is valid with 8 or more characters' do
-    Bootcamp::Setup.attachment
     user = users(:hatsuno)
     user.retire_reason = '辞' * 8
     assert user.save(context: :retire_reason_presence)
   end
 
   test 'is valid username' do
-    Bootcamp::Setup.attachment
-
     user = users(:komagata)
     user.login_name = 'abcdABCD1234'
     assert user.valid?
@@ -145,8 +142,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'twitter_account' do
-    Bootcamp::Setup.attachment
-
     user = users(:komagata)
     user.twitter_account = ''
     assert user.valid?
@@ -163,8 +158,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'is valid name_kana' do
-    Bootcamp::Setup.attachment
-
     user = users(:komagata)
     user.name_kana = 'コマガタ マサキ'
     assert user.valid?

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -191,6 +191,7 @@ class CommentsTest < ApplicationSystemTestCase
 
   test 'suggest mention to mentor' do
     visit "/reports/#{reports(:report1).id}"
+    sleep 1 # NOTE: ここでsleepしないとテストが失敗する
     find('#js-new-comment').set('@')
     assert_selector 'span.mention', text: 'mentor'
   end

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -6,16 +6,19 @@ class CompaniesTest < ApplicationSystemTestCase
   setup { login_user 'komagata', 'testtest' }
 
   test 'GET /companies' do
+    Bootcamp::Setup.attachment
     visit '/companies'
     assert_equal '企業一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'show company information' do
+    Bootcamp::Setup.attachment
     visit "/companies/#{companies(:company1).id}"
     assert_equal 'Fjord Inc.の会社情報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'show link to website if company has' do
+    Bootcamp::Setup.attachment
     visit "/companies/#{companies(:company1).id}"
     within '.user-metas__items' do
       assert_link 'Fjord Inc.', href: 'https://fjord.jp'

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -59,11 +59,6 @@ class Notification::ReportsTest < ApplicationSystemTestCase
 
     login_user 'muryou', 'testtest'
     assert page.has_css?('.has-no-count')
-    logout
-
-    login_user 'yamada', 'testtest'
-    assert page.has_css?('.has-no-count')
-    logout
   end
 
   test '研修生が日報を提出したら企業のアドバイザーに通知が飛ぶ' do

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -35,6 +35,11 @@ class Notification::ReportsTest < ApplicationSystemTestCase
   end
 
   test '複数の日報が投稿されているときは通知が飛ばない' do
+    # 他のテストの通知に影響を受けないよう、テスト実行前に通知を削除する
+    login_user 'muryou', 'testtest'
+    visit '/notifications'
+    click_link '全て既読にする'
+
     login_user 'komagata', 'testtest'
     visit '/reports'
     click_link '日報作成'


### PR DESCRIPTION
## 背景
`test/application_system_test_case.rb` の `setup` で `Bootcamp::Setup.attachment` が呼ばれていた。
`Bootcamp::Setup.attachment` は IO が走る比較的重い処理である。
全テストで `Bootcamp::Setup.attachment` が呼ばれていたためテストが重くなり、またランダムでテストが落ちる原因になっていた。
このため、必要な箇所だけで `Bootcamp::Setup.attachment` を呼ぶよう修正した。

## やったこと
- `Bootcamp::Setup.attachment` を `test/application_system_test_case.rb` の `setup` から削除
- `Bootcamp::Setup.attachment` を必要なテストで呼ぶように修正
- `Bootcamp::Setup.attachment` を削除した影響でCIで落ちやすくなるテストが発生したため、個別で修正した
- 不要な `assert` を削除した

## やらなかったこと
- `Bootcamp::Setup.attachment` 自体のリファクタリングはしていない
    - 影響範囲が不明だったため

## ref
https://github.com/fjordllc/bootcamp/issues/2014