### PR TITLE
質問一覧ページにあるタグ一覧が全て見れないバグを修正

### DIFF
--- a/app/assets/stylesheets/blocks/shared/_page-tags-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_page-tags-nav.sass
@@ -1,5 +1,5 @@
 .page-tags-nav
-  +position(right 0, top 0)
+  +position(right 0, top 3.5rem)
   flex: 0 0 16rem
   position: sticky
   background-color: $base
@@ -24,7 +24,7 @@
   text-overflow: ellipsis
 
 .page-tags-nav__body
-  max-height: calc(100vh - .25rem)
+  max-height: calc(100vh - 6.5rem)
   padding: .5rem .75rem
   overflow-y: auto
 


### PR DESCRIPTION
@komagata 

質問一覧ページにあるタグ一覧が全て見れないバグを修正しました。
変更箇所は css だけになります。

<img width="1043" alt="貼り付けた画像_2021_02_09_12_13" src="https://user-images.githubusercontent.com/168265/107310698-46e3ad00-6ad0-11eb-9227-da373ce61ff0.png">
