### PR TITLE
滅多に使わないネガティブなリアクションを消す

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -3,9 +3,9 @@
 class Reaction < ApplicationRecord
   enum kind: {
     thumbsup: 0,
-    thumbsdown: 1,
+    raised_hands: 1,
     smile: 2,
-    confused: 3,
+    pray: 3,
     tada: 4,
     heart: 5,
     rocket: 6,
@@ -22,7 +22,7 @@ class Reaction < ApplicationRecord
   validates :user_id, uniqueness: { scope: %i[reactionable_id reactionable_type kind] }
 
   def self.emojis
-    @emojis ||= kinds.keys.zip(%w[👍 👎 😄 😕 🎉 ❤️ 🚀 👀 💯 💪 🙆‍♀️ 😭]).to_h.with_indifferent_access
+    @emojis ||= kinds.keys.zip(%w[👍 🙌 😄 🙏 🎉 ❤️ 🚀 👀 💯 💪 🙆‍♀️ 😭]).to_h.with_indifferent_access
   end
 
   def self.available_emojis

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -15,7 +15,7 @@ class Reaction < ApplicationRecord
     okwoman: 10,
     loudlycrying: 11,
     raised_hands: 12,
-    pray: 13,
+    pray: 13
   }
 
   belongs_to :user
@@ -24,7 +24,8 @@ class Reaction < ApplicationRecord
   validates :user_id, uniqueness: { scope: %i[reactionable_id reactionable_type kind] }
 
   def self.emojis
-    @emojis ||= kinds.keys.zip(%w[👍 👎 😄 😕 🎉 ❤️ 🚀 👀 💯 💪 🙆‍♀️ 😭 🙌 🙏]).to_h.with_indifferent_access
+    negative_emojis = %w[thumbsdown confused]
+    @emojis ||= kinds.keys.zip(%w[👍 👎 😄 😕 🎉 ❤️ 🚀 👀 💯 💪 🙆‍♀️ 😭 🙌 🙏]).to_h.with_indifferent_access.filter { |e| !negative_emojis.include?(e) }
   end
 
   def self.available_emojis

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -3,9 +3,9 @@
 class Reaction < ApplicationRecord
   enum kind: {
     thumbsup: 0,
-    raised_hands: 1,
+    thumbsdown: 1,
     smile: 2,
-    pray: 3,
+    confused: 3,
     tada: 4,
     heart: 5,
     rocket: 6,
@@ -13,7 +13,9 @@ class Reaction < ApplicationRecord
     hundred: 8,
     flexed: 9,
     okwoman: 10,
-    loudlycrying: 11
+    loudlycrying: 11,
+    raised_hands: 12,
+    pray: 13,
   }
 
   belongs_to :user
@@ -22,7 +24,7 @@ class Reaction < ApplicationRecord
   validates :user_id, uniqueness: { scope: %i[reactionable_id reactionable_type kind] }
 
   def self.emojis
-    @emojis ||= kinds.keys.zip(%w[👍 🙌 😄 🙏 🎉 ❤️ 🚀 👀 💯 💪 🙆‍♀️ 😭]).to_h.with_indifferent_access
+    @emojis ||= kinds.keys.zip(%w[👍 👎 😄 😕 🎉 ❤️ 🚀 👀 💯 💪 🙆‍♀️ 😭 🙌 🙏]).to_h.with_indifferent_access
   end
 
   def self.available_emojis


### PR DESCRIPTION
# issue
issue: #2214 に対応
# やること
<img width="222" alt="スクリーンショット 2021-02-09 12 21 30" src="https://user-images.githubusercontent.com/52342576/107311268-5f07fc00-6ad1-11eb-9a72-8ab5f22bedfb.png">
日報等で使用するリアクションボタンの「👎」と「:confused:」を「🙏」と「🙌」に置き換える。