### PR TITLE
担当していないのに自分の担当タブが表示される

### DIFF
--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -6,7 +6,6 @@
     .a-button.is-sm.is-block.thread-list-item__assignee-name(v-else)
       span
         | {{ this.name }}
-    
 </template>
 <script>
 export default {

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -33,13 +33,13 @@ class Cache
     end
 
     def self_assigned_product_count(current_user_id)
-      Rails.cache.fetch("#{current_user_id}/self_assigned_product_count") do
+      Rails.cache.fetch("#{current_user_id}-self_assigned_product_count") do
         Product.self_assigned_product(current_user_id).unchecked.count
       end
     end
 
     def delete_self_assigned_product_count(current_user_id)
-      Rails.cache.delete ("#{current_user_id}/self_assigned_product_count")
+      Rails.cache.delete "#{current_user_id}-self_assigned_product_count"
     end
 
     def not_solved_question_count

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -33,13 +33,13 @@ class Cache
     end
 
     def self_assigned_product_count(current_user_id)
-      Rails.cache.fetch 'self_assigned_product_count' do
+      Rails.cache.fetch("#{current_user_id}/self_assigned_product_count") do
         Product.self_assigned_product(current_user_id).unchecked.count
       end
     end
 
-    def delete_self_assigned_product_count
-      Rails.cache.delete 'self_assigned_product_count'
+    def delete_self_assigned_product_count(current_user_id)
+      Rails.cache.delete ("#{current_user_id}/self_assigned_product_count")
     end
 
     def not_solved_question_count

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -96,7 +96,8 @@ class Product < ApplicationRecord
     return false if other_checker_exists?(current_user_id)
 
     self.checker_id = checker_id ? nil : current_user_id
-    save
+    Cache.delete_self_assigned_product_count(current_user_id)
+    save!
   end
 
   def other_checker_exists?(current_user_id)

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -28,7 +28,6 @@ class ProductCallbacks
     end
 
     Cache.delete_unchecked_product_count
-    Cache.delete_self_assigned_product_count(product.checker_id)
   end
 
   def after_destroy(product)

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -6,7 +6,7 @@ class ProductCallbacks
 
     Cache.delete_unchecked_product_count
     Cache.delete_not_responded_product_count
-    Cache.delete_self_assigned_product_count
+    Cache.delete_self_assigned_product_count(product.checker_id)
   end
 
   def after_save(product)
@@ -28,7 +28,7 @@ class ProductCallbacks
     end
 
     Cache.delete_unchecked_product_count
-    Cache.delete_self_assigned_product_count
+    Cache.delete_self_assigned_product_count(product.checker_id)
   end
 
   def after_destroy(product)
@@ -36,7 +36,7 @@ class ProductCallbacks
 
     Cache.delete_unchecked_product_count
     Cache.delete_not_responded_product_count
-    Cache.delete_self_assigned_product_count
+    Cache.delete_self_assigned_product_count(product.checker_id)
   end
 
   private

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -18,6 +18,5 @@
       li.page-tabs__item
         = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
           | 自分の担当
-          - if Cache.self_assigned_product_count(current_user.id).positive?
-            .page-tabs__item-count.a-notification-count
-              = Cache.self_assigned_product_count(current_user.id)
+          .page-tabs__item-count.a-notification-count
+            = Cache.self_assigned_product_count(current_user.id)

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -28,3 +28,6 @@ header.page-header
           = title
           | はありません
     = paginate @products, position: 'bottom'
+
+    p= Cache.self_assigned_product_count(current_user.id)
+    p= Product.self_assigned_product(current_user.id).unchecked.count

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -28,6 +28,3 @@ header.page-header
           = title
           | はありません
     = paginate @products, position: 'bottom'
-
-    p= Cache.self_assigned_product_count(current_user.id)
-    p= Product.self_assigned_product(current_user.id).unchecked.count


### PR DESCRIPTION
##issue
https://github.com/fjordllc/bootcamp/issues/2284 に対応

## 概要
自分の担当タブに表示される数と実際に担当している提出物数が一致しない。
![image](https://user-images.githubusercontent.com/62986803/107606337-1c812380-6c79-11eb-91f8-58a3e409baf6.png)

- 原因
同じキャッシュキー(`self_assigned_product_count`)を全てのメンターで使っていたため。

## やったこと
メンターはそれぞれ個々にキャッシュキーを持てるようにした。
キャッシュキーはuser_idを含む、`#{current_user_id}-self_assigned_product_count`で設定した。
