### PR TITLE
削除ボタンを見立たない文字リンクに変更

### DIFF
--- a/app/assets/stylesheets/blocks/card/_card-footer-actions.sass
+++ b/app/assets/stylesheets/blocks/card/_card-footer-actions.sass
@@ -2,6 +2,7 @@
   display: flex
   justify-content: center
   flex-wrap: wrap
+  align-items: flex-end
   +margin(horizontal, -.375rem)
   margin-bottom: -.625rem
 
@@ -11,6 +12,14 @@
   +media-breakpoint-up(md)
     flex: 0 0 14rem
     max-width: 50%
+    &.is-sub
+      flex: 0 0 auto
   +media-breakpoint-down(sm)
     flex-basis: 100%
     max-width: 100%
+
+.card-footer-actions__delete
+  +hover-link-reversal
+  +text-block(.875rem 1.4, $muted-text)
+  &:hover
+    color: $danger

--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -32,11 +32,10 @@
               button.card-footer-actions__action.a-button.is-md.is-primary.is-block(@click="editAnswer")
                 i.fas.fa-pen
                 | 内容修正
-            li.card-footer-actions__item(
+            li.card-footer-actions__item.is-sub(
               v-if="answer.user.id == currentUser.id || currentUser.role == 'admin'")
-              button.card-footer-actions__action.a-button.is-md.is-danger.is-block(@click="deleteAnswer")
-                i.fas.fa-trash-alt
-                | 削除
+              button.card-footer-actions__delete(@click="deleteAnswer")
+                | 削除する
             li.card-footer-actions__item(
               v-if="hasCorrectAnswer && answer.type == 'CorrectAnswer' && (currentUser.id === questionUser.id || currentUser.role === 'admin')")
               button.card-footer-actions__action.a-button.is-md.is-warning.is-block(@click="unsolveAnswer")

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -29,10 +29,9 @@
               button.card-footer-actions__action.a-button.is-md.is-primary.is-block(@click="editComment")
                 i.fas.fa-pen
                 | 編集
-            li.card-footer-actions__item
-              button.card-footer-actions__action.a-button.is-md.is-danger.is-block(@click="deleteComment")
-                i.fas.fa-trash-alt
-                | 削除
+            li.card-footer-actions__item.is-sub
+              button.card-footer-actions__delete(@click="deleteComment")
+                | 削除する
     .thread-comment-form__form.a-card(v-show="editing")
       .thread-comment-form__tabs.js-tabs
         .thread-comment-form__tab.js-tabs__tab(

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -30,10 +30,10 @@
                 = link_to new_announcement_path(id: announcement), class: 'card-footer-actions__action a-button is-md is-warning is-block' do
                   i.fas.fa-copy#copy
                   | コピー
-              li.card-footer-actions__item
-                = link_to announcement_path(announcement), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__action a-button is-md is-danger is-block' do
-                  i.fas.fa-trash-alt#delete
-                  | 削除
+              li.card-footer-actions__item.is-sub
+                = link_to announcement_path(announcement), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete' do
+                  span#delete
+                  | 削除する
 
   = render 'users/icon',
     user: announcement.user,

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -32,9 +32,9 @@
                     = link_to edit_article_path(article), class: 'card-footer-actions__action is-button-simple-md-primary is-block', id: 'js-shortcut-edit' do
                       i.fas.fa-pen#edit
                       | 内容修正
-                  li.card-footer-actions__item
-                    = link_to article_path(article), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__action is-button-simple-md-danger is-block' do
-                      i.fas.fa-trash-alt#delete
-                      | 削除
+                  li.card-footer-actions__item.is-sub
+                    = link_to article_path(article), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete' do
+                      span#delete
+                        | 削除
 
     = paginate @articles, position: 'bottom'

--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -14,7 +14,6 @@
                 = link_to edit_course_path(course), class: 'a-button is-md is-primary is-block' do
                   i.fas.fa-pen
                   | 編集
-              li.card-footer-actions__item
-                = link_to course, method: :delete, class: 'a-button is-md is-danger is-block js-delete', data: { confirm: '本当によろしいですか？' } do
-                  i.fas.fa-trash-alt
+              li.card-footer-actions__item.is-sub
+                = link_to course, method: :delete, class: 'card-footer-actions__delete js-delete', data: { confirm: '本当によろしいですか？' } do
                   | 削除

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -51,10 +51,9 @@
                 = link_to new_event_path(id: event), class: 'card-footer-actions__action a-button is-md is-warning is-block' do
                   i.fas.fa-copy#copy
                   | コピー
-              li.card-footer-actions__item
-                = link_to event_path(event), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__action a-button is-md is-danger is-block' do
-                  i.fas.fa-trash-alt#delete
-                  | 削除
+              li.card-footer-actions__item.is-sub
+                = link_to event_path(event), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete' do
+                  | 削除する
 
   = render 'users/icon',
     user: event.user,

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -73,10 +73,9 @@ header.page-header
                   i.fas.fa-pen
                   | 内容変更
               - if admin_login? || current_user == @page.user
-                li.card-footer-actions__item
-                  = link_to @page, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__action a-button is-md is-danger is-block' do
-                      i.fas.fa-trash-alt
-                      | 削除
+                li.card-footer-actions__item.is-sub
+                  = link_to @page, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete' do
+                    | 削除する
       .thread-prev-next
         .thread-prev-next__item
           = link_to :pages, class: 'thread-prev-next__item-link is-index' do

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -78,10 +78,9 @@ header.page-header
                       = link_to edit_product_path(@product), class: 'card-footer-actions_action a-button is-md is-primary is-block' do
                         i.fas.fa-pen
                         | 内容修正
-                    li.card-footer-actions__item
-                      = link_to @product, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__action a-button is-md is-danger is-block' do
-                        i.fas.fa-trash-alt
-                        | 削除
+                    li.card-footer-actions__item.is-sub
+                      = link_to @product, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete' do
+                        | 削除する
 
             - if admin_login? || adviser_login?
               #js-check(data-checkable-id="#{@product.id}" data-checkable-type='Product' data-checkable-label="#{Product.model_name.human}")

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -61,10 +61,9 @@ header.page-header
                   = link_to edit_question_path(@question), class: 'card-footer-actions__action a-button is-md is-primary is-block', id: 'js-shortcut-edit' do
                     i.fas.fa-pen#new
                     | 内容修正
-                li.card-footer-actions__item
-                  = link_to question_path(@question), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'js-delete card-footer-actions__action a-button is-md is-danger is-block' do
-                    i.fas.fa-trash-alt#delete
-                    | 削除
+                li.card-footer-actions__item.is-sub
+                  = link_to question_path(@question), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'js-delete card-footer-actions__delete' do
+                    | 削除する
 
       = render 'users/icon',
         user: @question.user,

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -72,10 +72,10 @@ header.page-header
                     = link_to new_report_path(id: @report), class: 'card-footer-actions__action a-button is-md is-warning is-block' do
                       i.fas.fa-copy#copy
                       | コピー
-                  li.card-footer-actions__item
-                    = link_to report_path(@report), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__action a-button is-md is-danger is-block' do
-                      i.fas.fa-trash-alt#delete
-                      | 削除
+                  li.card-footer-actions__item.is-sub
+                    = link_to report_path(@report), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete' do
+                      span#delete
+                        | 削除する
 
         - if admin_login? || adviser_login?
           #js-check(data-checkable-id="#{@report.id}" data-checkable-type='Report' data-checkable-label="#{Report.model_name.human}")

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -53,7 +53,6 @@ header.page-header
                   = link_to edit_work_path(@work), class: 'card-footer-actions_action a-button is-md is-primary is-block' do
                     i.fas.fa-pen
                     | 内容修正
-                li.card-footer-actions__item
-                  = link_to @work, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__action a-button is-md is-danger is-block' do
-                    i.fas.fa-trash-alt
-                    | 削除
+                li.card-footer-actions__item.is-sub
+                  = link_to @work, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete do
+                    | 削除する

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -54,5 +54,5 @@ header.page-header
                     i.fas.fa-pen
                     | 内容修正
                 li.card-footer-actions__item.is-sub
-                  = link_to @work, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete do
+                  = link_to @work, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-footer-actions__delete' do
                     | 削除する


### PR DESCRIPTION
@komagata 

issue: https://github.com/fjordllc/bootcamp/issues/1901

![image](https://user-images.githubusercontent.com/168265/107485559-45e17700-6bc7-11eb-834a-4d6b3a13caad.png)

サイト全体で削除ボタンをこのようにしました。
操作ミスで消さないようにと、消す機会がほとんどないので目立たせる必要はない、というのが変更の経緯です。