### PR TITLE
メニューから書籍一覧を削除

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -76,9 +76,6 @@
               = link_to courses_path, class: 'header-dropdown__item-link' do
                 | コース
             li.header-dropdown__item
-              = link_to books_path, class: 'header-dropdown__item-link' do
-                | 書籍一覧
-            li.header-dropdown__item
               = link_to companies_path, class: 'header-dropdown__item-link' do
                 | 企業一覧
             li.header-dropdown__item


### PR DESCRIPTION
issue #2320 
### やったこと
ヘッダーにあるメニューバーから
「書籍一覧」の文言及びリンクを削除しました。

### 理由
オフィス閉鎖で本の貸し出しがなくなったため。

### 削除後のスクショ
<img width="358" alt="スクリーンショット 2021-02-11 20 59 23" src="https://user-images.githubusercontent.com/64201542/107634075-57507f00-6cac-11eb-80a4-89ddf6337e6a.png">
