### PR TITLE
Q&Aの一覧ページから編集リンクを削除

### DIFF
--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -10,10 +10,6 @@
       h2.thread-list-item__title(itemprop='name')
         = link_to question, itemprop: 'url', class: 'thread-list-item__title-link' do
           = question.title
-      .thread-list-item__actions
-        - if current_user == question.user
-          = link_to edit_question_path(question), class: 'thread-list-item__actions-link' do
-            i.fas.fa-pen
     - if question.practice
       h3.thread-list-item__sub-title
         = question.practice.title


### PR DESCRIPTION
#2317

### やったこと
Q&Aの一覧ページから編集リンクを削除

### 理由 
編集は個別ページから行うようにする為

### 削除後のスクショ
<img width="936" alt="スクリーンショット 2021-02-13 20 13 03" src="https://user-images.githubusercontent.com/64201542/107848598-ffdf1a00-6e37-11eb-8743-d44229ed687f.png">
