### PR TITLE
お知らせ一覧ページの編集リンクを削除

### DIFF
--- a/app/views/announcements/_announcements.html.slim
+++ b/app/views/announcements/_announcements.html.slim
@@ -13,8 +13,6 @@
           = announcement.title
       - if admin_login? || current_user == announcement.user
         .thread-list-item__actions
-          = link_to edit_announcement_path(announcement), class: 'thread-list-item__actions-link' do
-            i.fas.fa-pen
           = link_to new_announcement_path(id: announcement), class: 'thread-list-item__actions-link' do
             i.fas.fa-copy
     .thread-list-item-meta


### PR DESCRIPTION
#2316

### やったこと
お知らせのページから編集リンクを削除。

### 理由
編集は個別ページから行いたい為、一覧ページから編集ページへ移動できないようにしたい。

### 削除後のスクショ
<img width="947" alt="スクリーンショット 2021-02-14 14 50 40" src="https://user-images.githubusercontent.com/64201542/107869695-1c309480-6ed4-11eb-8f96-39dd0344047b.png">

