### PR TITLE
検索結果に何もないというメッセージが表示できるようにする

### DIFF
--- a/app/views/searchables/index.html.slim
+++ b/app/views/searchables/index.html.slim
@@ -6,9 +6,23 @@ header.page-header
       h2.page-header__title
         = title
 
+- if @searchables.size.zero?
+  .page-notice
+    .container
+      .page-notice__inner
+        p
+          | '#{params[:word]}'に一致する情報は見つかりませんでした。別のキーワードをお試しください。
+
 .page-body
   .container
     = paginate @searchables, position: 'top'
-    .thread-list.a-card
-      = render partial: 'searchables/searchable', collection: @searchables, as: :searchable, locals: { words: '' }
+    - if @searchables.size.positive?
+      .thread-list.a-card
+        = render partial: 'searchables/searchable', collection: @searchables, as: :searchable, locals: { words: '' }
+    - else
+      .o-empty-massage
+        .o-empty-massage__icon
+          i.far.fa-sad-tear
+        p.o-empty-massage__text
+          | '#{params[:word]}'に一致する情報は見つかりませんでした。
     = paginate @searchables, position: 'bottom'

--- a/app/views/searchables/index.html.slim
+++ b/app/views/searchables/index.html.slim
@@ -6,13 +6,6 @@ header.page-header
       h2.page-header__title
         = title
 
-- if @searchables.size.zero?
-  .page-notice
-    .container
-      .page-notice__inner
-        p
-          | '#{params[:word]}'に一致する情報は見つかりませんでした。別のキーワードをお試しください。
-
 .page-body
   .container
     = paginate @searchables, position: 'top'


### PR DESCRIPTION
 #2138

### 概要
検索結果で何も表示されなかった場合に「検索結果がなかった」というメッセージを表示できるようにしました。

#2161 でhituzi-no-sippoさんが提案していただいた、
画面遷移なしで「検索結果なし」を表示する方法については今回の実装では見送りました。

理由としては
- 伊藤さんが #1530 でコメントしているようにかなり面倒な処理になること。
- imaizumiさんが#1530 で指摘するように既に検索結果が表示されている状態から、
検索結果なしで画面遷移しない場合、古い検索結果が表示された状態で検索結果なしが出てしまい逆にわかりづらい。
(その場合だけ画面遷移させようとするとさらに工数がかかる・・)
- Google検索では検索結果なしでも画面遷移はするので、そこまで必要性を感じなかった。

となります。
よって検索結果がなかった場合には検索結果なしのページを表示するようにしました。

### 実装理由
検索を実行しても何もヒットしなかった場合には何も表示されない。
何か内部エラーが発生して処理が中断されたような印象を受ける為。

### 実装方法
ユーザーフォローがない場合に表示される画面を参考に作成しました。
app/views/users/index.html.slimを参考に作成。

### 変更後のgif
[![Image from Gyazo](https://i.gyazo.com/64f29de34a139c10d4837d9844471814.gif)](https://gyazo.com/64f29de34a139c10d4837d9844471814)
