### PR TITLE
ユーザータグ機能のユーザー一覧ページに卒業生も表示するようにしました

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,6 @@ class UsersController < ApplicationController
                .page(params[:page]).per(PAGER_NUMBER)
                .with_attached_avatar
                .preload(:course, :taggings)
-               .in_school
                .unretired
                .order(updated_at: :desc)
                .tagged_with(params[:tag])


### PR DESCRIPTION
ref: #2262

ユーザータグ機能のユーザー一覧ページに卒業生も表示するようにしました

## 変更前
![スクリーンショット 2021-02-15 12 46 16](https://user-images.githubusercontent.com/52710925/107903175-d931f800-6f8b-11eb-8d5b-51e8900f6f89.png)




## 変更後
![スクリーンショット 2021-02-15 12 36 38](https://user-images.githubusercontent.com/52710925/107902997-66288180-6f8b-11eb-8752-932962bf7796.png)










