### PR TITLE
ページャーの引数 position を CSS で使わないようにした

### DIFF
--- a/app/assets/stylesheets/blocks/shared/_pagination.sass
+++ b/app/assets/stylesheets/blocks/shared/_pagination.sass
@@ -1,15 +1,16 @@
 .pagination
   +position(relative, 1)
-  &.is-top
-    margin-top: -.5rem
+  +media-breakpoint-up(md)
     margin-bottom: 1rem
+  +media-breakpoint-down(sm)
+    margin-bottom: .5rem
+  .container + &
+    +media-breakpoint-up(md)
+      margin-top: 1rem
+      margin-bottom: 0
     +media-breakpoint-down(sm)
-      margin-bottom: .75rem
-  &.is-bottom
-    margin-top: 1rem
-    margin-bottom: -.5rem
-    +media-breakpoint-down(sm)
-      margin-top: .75rem
+      margin-top: .5rem
+      margin-bottom: 0
 
 .pagination__items
   display: flex

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,5 +1,5 @@
 = paginator.render do
-  nav.pagination(class="is-#{position}")
+  nav.pagination
     .container
       ul.pagination__items
         == first_page_tag unless current_page.first?


### PR DESCRIPTION
@komagata
ページャーの引数 position を CSS で使わないようにしました。
一覧の Vue.js 化で ページャーに position の引数を持たなくしたのですが、現状ではデザインが崩れます。
このPRを先に取り込むことで、デザイン崩れがなくなります。