### PR TITLE
課題をクリアしていない場合には、提出物一覧画面に警告メッセージを表示するようにした。

### DIFF
--- a/app/controllers/practices/products_controller.rb
+++ b/app/controllers/practices/products_controller.rb
@@ -15,5 +15,6 @@ class Practices::ProductsController < ApplicationController
                 .where(practice: @practice)
                 .order(created_at: :desc)
                 .page(params[:page])
+    @my_product = @products.find_by(user: current_user)
   end
 end

--- a/app/views/practices/products/index.html.slim
+++ b/app/views/practices/products/index.html.slim
@@ -15,6 +15,10 @@ header.page-header
 
 = render 'page_tabs', resource: @practice
 
+- if current_user.student? && (@my_product.nil? || @my_product.checks.empty?)
+  div
+    p プラクティスを完了するまで他の人の提出物は見れません。
+
 .page-body
   .container
     = paginate @products, position: 'top'

--- a/app/views/practices/products/index.html.slim
+++ b/app/views/practices/products/index.html.slim
@@ -15,7 +15,7 @@ header.page-header
 
 = render 'page_tabs', resource: @practice
 
-- if current_user.student? && (@my_product.nil? || @my_product.checks.empty?)
+- if current_user.student_or_trainee? && !@practice.open_product? && (@my_product.nil? || @my_product.checks.empty?)
   div
     p プラクティスを完了するまで他の人の提出物は見れません。
 


### PR DESCRIPTION
#2313 に対応

### 概要
課題をクリアしていない者でも提出物一覧の画面をみることができる状態は維持しつつ、
flash風の警告メッセージを表示しておくようにした。

### 実装理由
課題をクリアしていない者が提出物一覧の画面を見ようとすると、トップページに飛ばされ警告のflashメッセージが表示される。この処理が重たい、不便な為変更する。
[![Image from Gyazo](https://i.gyazo.com/5fd313db61d23cba6fd9c0b6c4303949.gif)](https://gyazo.com/5fd313db61d23cba6fd9c0b6c4303949)

### 実装後スクショ(デザイン前)
<img width="1026" alt="スクリーンショット 2021-02-21 22 02 03" src="https://user-images.githubusercontent.com/64201542/108626988-7f9f6100-7496-11eb-93b6-a6a4c6226108.png">
