### PR TITLE
WIPの提出物の場合、提出物個別ページにも提出ボタンを表示

### DIFF
--- a/app/assets/stylesheets/blocks/side/_side-tabs-nav.sass
+++ b/app/assets/stylesheets/blocks/side/_side-tabs-nav.sass
@@ -2,6 +2,8 @@
   display: flex
   +position(relative, 2)
   margin-bottom: -1px
+  +margin(horizontal, auto)
+  max-width: 50rem
 
 #side-tabs-1:checked ~ .side-tabs-nav #side-tabs-nav-1
   background-color: $base

--- a/app/assets/stylesheets/blocks/thread/_thread.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread.sass
@@ -55,3 +55,14 @@ $thread-header-author: 6rem
   & + .thread__description,
   .thread-header + &
     border-top: solid 1px $background
+
+.thread__warning-message
+  background-color: $warning
+  +padding(vertical, .5rem)
+  +text-block(1em 1.4, center)
+  +media-breakpoint-up(md)
+    font-size: .875rem
+    +padding(horizontal, 2rem)
+  +media-breakpoint-down(sm)
+    font-size: .75rem
+    +padding(horizontal, 1rem)

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -74,6 +74,11 @@ header.page-header
               .card-footer
                 .card-footer-actions
                   ul.card-footer-actions__items
+                    - if @product.wip?
+                      li.card-footer-actions__item
+                        = form_for @product do |f|
+                          = f.hidden_field :body
+                          = f.submit '提出する', class: 'a-button is-md is-warning is-block'
                     li.card-footer-actions__item
                       = link_to edit_product_path(@product), class: 'card-footer-actions_action a-button is-md is-primary is-block' do
                         i.fas.fa-pen

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -64,6 +64,9 @@ header.page-header
                 #js-watch(data-watchable-id="#{@product.id}", data-watchable-type='Product')
                 .thread-header__raw
                   = link_to 'Raw', product_path(format: :md), class: 'a-button is-sm is-secondary', target: '_blank', rel: 'noopener'
+            - if @product.wip?
+              .thread__warning-message
+                | まだ提出されていません。<br class='is-hidden-md-up'>完成したら「提出する」をクリック！
             #js-check-stamp(data-checkable-id="#{@product.id}" data-checkable-type='Product')
             .thread__description.js-target-blank.is-long-text.js-markdown-view
               =  @product.practice.goal

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -157,6 +157,16 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '提出物を更新しました。'
   end
 
+  test 'update product if product page is WIP' do
+    login_user 'yamada', 'testtest'
+    product = products(:product1)
+    visit "/products/#{product.id}/edit"
+    click_button 'WIP'
+    visit "/products/#{product.id}"
+    click_button '提出する'
+    assert_text '提出物を更新しました。'
+  end
+
   test 'delete product' do
     login_user 'yamada', 'testtest'
     product = products(:product1)


### PR DESCRIPTION
Issue #2359

## 概要
提出物がWIPの時には提出物個別ページにも提出ボタンを表示
<img width="872" alt="貼り付けた画像_2021_02_16_16_06" src="https://user-images.githubusercontent.com/168265/108029573-05737480-7071-11eb-84c5-086384993d65.png">

## 目的
提出のし忘れを防止する為。

## やったこと
1. 提出物個別ページ(app/views/products/show.html.slim)に以下を追加
- wipの場合だけ表示する様に、`if @product.wip?`を追加
- `form_for`で提出するボタンを追加。

2. 提出した事を確認するテストを追加

## form_forにした理由
- 統一したかった
- form以外の実装方法が分からなかった😅

rails5.1からは、form系ヘルパーメソッドには、`form_with`が推奨されているそうでしたが、`views/products/_form.html.slim`では`form_for`を使っている為、統一しました。

それと、`form_for`以外で`link_to ~~, method: :patch`でも実装できるかと思ったのですが、Strong Parametersの設定なのか、上手い具合にparamsが渡りませんでした。(paramsが無い、と怒られる)

以上の理由と、駒形さんにご相談させて頂いた際に、formを作って送信するのもアリ。との事だったので、今回は`form_for`で実装しました！

## スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/76020cc9e11b2fa86729fbb96b098054.gif)](https://gyazo.com/76020cc9e11b2fa86729fbb96b098054)

※デザインはまだです！