### PR TITLE
個人の日報一覧ページに「日報作成」ボタンを追加

### DIFF
--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -7,6 +7,10 @@ header.page-header
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item
+            = link_to new_report_path, class: 'a-button is-md is-warning is-block' do
+              i.fas.fa-plus
+              | 日報作成
+          li.page-header-actions__item
             = link_to 'ユーザー一覧', users_path, class: 'a-button is-md is-secondary is-block'
 
 = render 'users/page_tabs', user: @user


### PR DESCRIPTION
Issue #2034

## 概要

個人の日報一覧に「日報作成」ボタンを追加した。
詳細は、Issue #2034 を参照。

[![Image from Gyazo](https://i.gyazo.com/4d3697fb7434522bb5e252271562076a.png)](https://gyazo.com/4d3697fb7434522bb5e252271562076a)
