### PR TITLE
textareでのEnter時にガクッとなるのを固定されるようにした

### DIFF
--- a/app/assets/stylesheets/shared/_base.sass
+++ b/app/assets/stylesheets/shared/_base.sass
@@ -89,3 +89,6 @@ body
 
 [class*=a-button]:not(input)
   +padding(vertical, 0)
+
+textarea
+  overflow-anchor: none


### PR DESCRIPTION
[【Chrome】textareaの改行時にカーソル位置がガタっとずれる問題の対処法](https://zenn.dev/catnose99/articles/e0d42812c7588c)
詳細は、上記を参照

問題の再現方法がわからなかったのですが、
改行しようとEnterキーを押したタイミングで、
カーソルのある位置が上部に来るようにスクロールが移動してしまうという問題があり、
その問題を解決するためのPRです。