### PR TITLE
GitHubの草が真っ黒の不具合を修正

### DIFF
--- a/app/assets/stylesheets/modules/_github.sass
+++ b/app/assets/stylesheets/modules/_github.sass
@@ -450,3 +450,42 @@
   --color-pr-state-closed-text: #fff
   --color-pr-state-closed-bg: #d73a49
   --color-pr-state-closed-border: transparent
+
+.ContributionCalendar-day,
+.ContributionCalendar-day[data-level="0"] 
+  fill: var(--color-calendar-graph-day-bg)
+  shape-rendering: geometricPrecision
+  outline: 1px solid var(--color-calendar-graph-day-border)
+  outline-offset: -1px
+
+.ContributionCalendar-day[data-level="1"] 
+  fill: var(--color-calendar-graph-day-L1-bg)
+  outline: 1px solid var(--color-calendar-graph-day-L1-border)
+
+.ContributionCalendar-day[data-level="2"] 
+  fill: var(--color-calendar-graph-day-L2-bg)
+  outline: 1px solid var(--color-calendar-graph-day-L2-border)
+
+.ContributionCalendar-day[data-level="3"] 
+  fill: var(--color-calendar-graph-day-L3-bg)
+  outline: 1px solid var(--color-calendar-graph-day-L3-border)
+
+.ContributionCalendar-day[data-level="4"] 
+  fill: var(--color-calendar-graph-day-L4-bg)
+  outline: 1px solid var(--color-calendar-graph-day-L4-border)
+
+.ContributionCalendar[data-holiday="halloween"]
+  &.ContributionCalendar-day[data-level="1"] 
+    fill: var(--color-calendar-halloween-graph-day-L1-bg)
+
+.ContributionCalendar[data-holiday="halloween"]
+  &.ContributionCalendar-day[data-level="2"] 
+    fill: var(--color-calendar-halloween-graph-day-L2-bg)
+
+.ContributionCalendar[data-holiday="halloween"]
+  &.ContributionCalendar-day[data-level="3"]
+    fill: var(--color-calendar-halloween-graph-day-L3-bg)
+
+.ContributionCalendar[data-holiday="halloween"]
+  &.ContributionCalendar-day[data-level="4"]
+    fill: var(--color-calendar-halloween-graph-day-L4-bg)

--- a/app/assets/stylesheets/modules/_github.sass
+++ b/app/assets/stylesheets/modules/_github.sass
@@ -436,6 +436,10 @@
   --color-calendar-graph-day-L3-border: rgba(27,31,35,0.06)
   --color-calendar-graph-day-L2-border: rgba(27,31,35,0.06)
   --color-calendar-graph-day-L1-border: rgba(27,31,35,0.06)
+  --color-calendar-halloween-graph-day-L1-bg: #ffee4a
+  --color-calendar-halloween-graph-day-L2-bg: #ffc501
+  --color-calendar-halloween-graph-day-L3-bg: #fe9600
+  --color-calendar-halloween-graph-day-L4-bg: #03001c
   --color-footer-invertocat-octicon: #d1d5da
   --color-footer-invertocat-octicon-hover: #6a737d
   --color-pr-state-draft-text: #fff


### PR DESCRIPTION
# 概要

GitHubの草が真っ黒になっている状態を正常に戻す。

# 対策方法

GitHubがdata-level属性をもとに色を決定するようになっているため、GitHub側のスタイルを移植する。
念の為、ハロウィン仕様のスタイルも同時に移植する。

# 修正後の画像

![image](https://user-images.githubusercontent.com/13811034/108854451-3cc2c200-762b-11eb-8fec-bb381c6b47d4.png)

# 備考

草画像が途切れる不具合については、別PRで対応する。

# 関連issue

#2293 