### PR TITLE
GitHubの草が途中で途切れる不具合を修正

### DIFF
--- a/app/assets/stylesheets/blocks/user/_user-grass.sass
+++ b/app/assets/stylesheets/blocks/user/_user-grass.sass
@@ -2,30 +2,16 @@
   padding: 1rem
   +media-breakpoint-down(sm)
     padding: .75rem
-  a
-    display: block
-    +position(relative)
-    +media-breakpoint-down(sm)
-      height: 6.75rem
-    +media-breakpoint-up(md)
-      height: 6.75rem
-    +media-breakpoint-up(lg)
-      height: 6.75rem
-    +media-breakpoint-up(xl)
-      height: 6rem
   svg
-    +position(absolute, left 0, top -.375rem)
     font-size: .625rem
-    transform-origin: 0 0
-    max-width: 110%
-    +media-breakpoint-down(sm)
-      transform: scale(.92)
-    +media-breakpoint-up(md)
-      transform: scale(.92)
+    max-width: 100%
+    +margin(vertical, -1.75rem)
+    +media-breakpoint-only(sm)
+      +margin(vertical, 0)
+    +media-breakpoint-only(md)
+      +margin(vertical, 0)
     +media-breakpoint-up(lg)
-      transform: scale(.92)
-    +media-breakpoint-up(xl)
-      transform: scale(.90)
+      +margin(vertical, -.75rem)
 
 .user-data-grass
   margin-top: 1.5rem

--- a/app/assets/stylesheets/blocks/user/_user-grass.sass
+++ b/app/assets/stylesheets/blocks/user/_user-grass.sass
@@ -6,11 +6,11 @@
     display: block
     +position(relative)
     +media-breakpoint-down(sm)
-      height: 2.25rem
+      height: 6.75rem
     +media-breakpoint-up(md)
-      height: 6rem
+      height: 6.75rem
     +media-breakpoint-up(lg)
-      height: 6rem
+      height: 6.75rem
     +media-breakpoint-up(xl)
       height: 6rem
   svg
@@ -19,13 +19,13 @@
     transform-origin: 0 0
     max-width: 110%
     +media-breakpoint-down(sm)
-      transform: scale(.375)
+      transform: scale(.92)
     +media-breakpoint-up(md)
-      transform: scale(.69)
+      transform: scale(.92)
     +media-breakpoint-up(lg)
-      transform: scale(0.69)
+      transform: scale(.92)
     +media-breakpoint-up(xl)
-      transform: scale(0.79)
+      transform: scale(.90)
 
 .user-data-grass
   margin-top: 1.5rem

--- a/app/models/github_grass.rb
+++ b/app/models/github_grass.rb
@@ -20,7 +20,9 @@ class GithubGrass
     if Rails.env.test?
       ''
     else
-      localize(extract_svg(fetch_page)).to_s
+      svg = extract_svg(fetch_page)
+      setViewBox(svg)
+      localize(svg).to_s
     end
   rescue StandardError
     ''
@@ -54,6 +56,12 @@ class GithubGrass
       month.children = MONTHS[month.children.text.to_sym]
     end
     svg
+  end
+
+  def setViewBox(svg)
+    width = svg.attribute('width').value
+    height = svg.attribute('height').value
+    svg.attribute('viewBox', "0 0 #{width} #{height}")
   end
 
   def github_url(name)

--- a/app/models/github_grass.rb
+++ b/app/models/github_grass.rb
@@ -21,7 +21,7 @@ class GithubGrass
       ''
     else
       svg = extract_svg(fetch_page)
-      setViewBox(svg)
+      add_view_box_attribute(svg)
       localize(svg).to_s
     end
   rescue StandardError
@@ -58,7 +58,7 @@ class GithubGrass
     svg
   end
 
-  def setViewBox(svg)
+  def add_view_box_attribute(svg)
     width = svg.attribute('width').value
     height = svg.attribute('height').value
     svg.attribute('viewBox', "0 0 #{width} #{height}")


### PR DESCRIPTION
# 概要

GitHubの草が途中で途切れているので、全て表示されるように修正する。
また、草のレイアウトが全体的に縮小されているので、学習時間の草同様にレイアウトを調整する。

# 対応方法

## 草が途中で途切れる不具合について

SVGにviewBox属性を指定することで草全体を表示することができたので、
SVGを取得した時に、SVGのwidthとheight属性の値を取得し、viewBox属性を動的に設定する。

## 草のレイアウトが全体的に縮小されている事象について

草全体を表示した場合に、以下の画像のように縮小されて表示されているので、学習時間の草同様に広がって表示されるようにレイアウトを調整する。

![image](https://user-images.githubusercontent.com/13811034/108858290-56660880-762f-11eb-8999-edaa04a3f7e4.png)

また、ウィンドウサイズやモバイルでも適切に表示されるようにレイアウトを調整する。

レイアウトの調整は、以下のファイルを変更する。

[https://github.com/fjordllc/bootcamp/blob/master/app/assets/stylesheets/blocks/user/_user-grass.sass#L16-L28](https://github.com/fjordllc/bootcamp/blob/master/app/assets/stylesheets/blocks/user/_user-grass.sass#L16-L28)
```scss
  svg
    +position(absolute, left 0, top -.375rem)
    font-size: .625rem
    transform-origin: 0 0
    max-width: 110%
    +media-breakpoint-down(sm)
      transform: scale(.375)
    +media-breakpoint-up(md)
      transform: scale(.69)
    +media-breakpoint-up(lg)
      transform: scale(0.69)
    +media-breakpoint-up(xl)
      transform: scale(0.79)
```

# 関連issue

#1693 