### PR TITLE
Q＆AのQとAの両方でメンションが聞いてない

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -3,6 +3,7 @@
 class Answer < ApplicationRecord
   include Reactionable
   include Searchable
+  include Mentioner
 
   belongs_to :user, touch: true
   belongs_to :question
@@ -16,6 +17,8 @@ class Answer < ApplicationRecord
   validates :user, presence: true
 
   columns_for_keyword_search :description
+
+  mentionable_as :description
 
   def receiver
     question.user

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,6 +6,7 @@ class Question < ApplicationRecord
   include Watchable
   include WithAvatar
   include Taggable
+  include Mentioner
 
   belongs_to :practice, optional: true
   belongs_to :user, touch: true
@@ -24,4 +25,6 @@ class Question < ApplicationRecord
   scope :not_solved, -> { where.not(id: CorrectAnswer.pluck(:question_id)) }
 
   columns_for_keyword_search :title, :description
+
+  mentionable_as :description
 end

--- a/test/system/mention/answers_test.rb
+++ b/test/system/mention/answers_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module Mention
+  class AnswersTest < ApplicationSystemTestCase
+    setup do
+      login_user 'komagata', 'testtest'
+    end
+
+    test "recieve a notification when I got my question's answer" do
+      visit "/questions/#{questions(:question8).id}"
+      within('.thread-comment-form__form') do
+        fill_in('answer[description]', with: '@hatsuno test')
+      end
+      click_button 'コメントする'
+      wait_for_vuejs
+      logout
+  
+      login_user 'hatsuno', 'testtest'
+      visit '/notifications'
+      assert_text 'komagataさんからメンションがきました。'
+    end
+  end
+end

--- a/test/system/mention/answers_test.rb
+++ b/test/system/mention/answers_test.rb
@@ -8,15 +8,13 @@ module Mention
       login_user 'komagata', 'testtest'
     end
 
-    test "recieve a notification when I got my question's answer" do
+    test 'mention from a answer' do
       visit "/questions/#{questions(:question8).id}"
       within('.thread-comment-form__form') do
         fill_in('answer[description]', with: '@hatsuno test')
       end
       click_button 'コメントする'
-      wait_for_vuejs
-      logout
-  
+
       login_user 'hatsuno', 'testtest'
       visit '/notifications'
       assert_text 'komagataさんからメンションがきました。'

--- a/test/system/mention/answers_test.rb
+++ b/test/system/mention/answers_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 module Mention
   class AnswersTest < ApplicationSystemTestCase
     setup do
-      login_user 'komagata', 'testtest'
+      login_user 'kimura', 'testtest'
     end
 
     test 'mention from a answer' do
@@ -17,7 +17,7 @@ module Mention
 
       login_user 'hatsuno', 'testtest'
       visit '/notifications'
-      assert_text 'komagataさんからメンションがきました。'
+      assert_text 'kimuraさんからメンションがきました。'
     end
   end
 end

--- a/test/system/mention/questions_test.rb
+++ b/test/system/mention/questions_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+module Mention
+  class QuestionsTest < ApplicationSystemTestCase
+    setup do
+      login_user 'kimura', 'testtest'
+    end
+
+    test 'mention from a question' do
+      visit '/questions/new'
+      fill_in 'question_title', with: 'テスト質問'
+      fill_in 'question_description', with: '@hatsuno test'
+      click_button '登録する'
+
+      login_user 'hatsuno', 'testtest'
+      visit '/notifications'
+      assert_text 'kimuraさんからメンションがきました。'
+    end
+  end
+end


### PR DESCRIPTION
issue #2361
バグの修正


## やったこと

- Q&Aでメンションが効く様に修正
- Q&Aでメンションが効くことを確認するテストを追加

## Q&Aでメンションが効く様に修正

`app/models/report.rb`を参考にしました。

`app/models/concerns/mentioner.rb`にメンションを扱うためのmoduleがあるので、それをQ&Aのモデルにincludeしました。

駒形さんが作ってくれた[mentionable gem](https://docs.komagata.org/5742)があって、それを扱うために
```ruby
mentionable_as :description
```
の記述をしました。

> モデルのカラムにmentionが含まれる文章が保存される場合、mentionable_asでそのカラムを指定したらデフォルトでafter_save_mentionメソッドが呼ばれる

## スクリーンショット

### 質問でメンション
[![Image from Gyazo](https://i.gyazo.com/3896db1c8127db55cb878003cff404ea.gif)](https://gyazo.com/3896db1c8127db55cb878003cff404ea)

### 回答でメンション
[![Image from Gyazo](https://i.gyazo.com/ffae579941176c926db7adc89bc211a7.gif)](https://gyazo.com/ffae579941176c926db7adc89bc211a7)

### メール通知も確認
[![Image from Gyazo](https://i.gyazo.com/4060705d4011a35fb9c19a3873ea7ed7.gif)](https://gyazo.com/4060705d4011a35fb9c19a3873ea7ed7)