### PR TITLE
ホームページへのリンクをメニューに追加しました。

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -88,6 +88,9 @@
               = link_to coc_path, class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
                 | アンチハラスメントポリシー
             li.header-dropdown__item
+              = link_to welcome_path, class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
+                | ホームページ
+            li.header-dropdown__item
               = link_to logout_path, class: 'header-dropdown__item-link' do
                 | ログアウト
             li.header-dropdown__item


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/issues/2384 の解決案です。

<img width="341" alt="Screen Shot 2021-02-28 at 14 58 49" src="https://user-images.githubusercontent.com/1148320/109409412-cda3ef80-79d5-11eb-9599-620907e109cd.png">
