### PR TITLE
ホームページへのリンクをスマホ用メニューに追加

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -95,6 +95,11 @@ nav.global-nav
               i.fas.fa-fw.fa-heart
             .global-nav-links__link-label.is-sm アンチハラスメントポリシー
         li.global-nav-links__item.is-hidden-md-up
+          = link_to welcome_path, class: 'global-nav-links__link', target: '_blank', rel: 'noopener' do
+            .global-nav-links__link-icon
+              i.fas.fa-fw.fa-home
+            .global-nav-links__link-label ホームページ
+        li.global-nav-links__item.is-hidden-md-up
           = link_to logout_path, class: 'global-nav-links__link' do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-sign-out-alt


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/pull/2392 でスマホ用メニューにリンクを付けるのを忘れていました🙇‍♂️
See also https://github.com/fjordllc/bootcamp/issues/2384

<img width="313" alt="Screen Shot 2021-03-02 at 5 43 19" src="https://user-images.githubusercontent.com/1148320/109556722-85421a00-7b1a-11eb-9ae9-18d27e58f4e6.png">
