### PR TITLE
管理メニューの「ブログ記事作成」へリンクを削除したい

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -21,9 +21,6 @@
                 = link_to admin_root_path, class: 'header-dropdown__item-link' do
                   | 管理ページ
               li.header-dropdown__item
-                = link_to new_article_path, class: 'header-dropdown__item-link' do
-                  | ブログ記事作成
-              li.header-dropdown__item
                 = link_to 'https://fjord.slack.com/admin', class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
                   | Slack管理
               li.header-dropdown__item


### PR DESCRIPTION
#2411 
issueに対応

## 理由
ブログ機能は未リリースのため。

## やること
下記画像の「ブログ記事作成」を削除する
![image](https://user-images.githubusercontent.com/50447071/109804798-022dda80-7c66-11eb-895b-86bd007d3094.png)

## 実装方針
bootcamp/app/views/application/_header_links.html.slim
ここがヘッダーのリンク部分のviewのため、
ここからブログ記事作成へのリンク部分を削除する。