### PR TITLE
お知らせのAPI（CRUD）が欲しい

### DIFF
--- a/app/controllers/api/announcements_controller.rb
+++ b/app/controllers/api/announcements_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class API::AnnouncementsController < API::BaseController
+  protect_from_forgery except: %i[create]
+  before_action :set_announcement, only: %i[show update destroy]
+
+  def index
+    @announcements = Announcement.with_avatar
+                                 .preload(:comments)
+                                 .order(published_at: :desc, created_at: :desc)
+                                 .page(params[:page])
+  end
+
+  def new
+    @announcement = Announcement.new(target: 'students')
+  end
+
+  def edit
+    @announcement.user_id = current_user.id
+  end
+
+  def update
+    if @announcement.update(announcement_params)
+      head :ok
+    else
+      head :bad_request
+    end
+  end
+
+  def create
+    @announcement = Announcement.new(announcement_params)
+    @announcement.user_id = current_user.id
+    if @announcement.save
+      render :create, status: :created
+    else
+      head :bad_request
+    end
+  end
+
+  def destroy
+    @announcement.destroy
+  end
+
+  private
+
+  def announcement_params
+    params.require(:announcement).permit(:title, :description, :target, :wip)
+  end
+
+  def set_announcement
+    @announcement = Announcement.find(params[:id])
+  end
+end

--- a/app/controllers/api/announcements_controller.rb
+++ b/app/controllers/api/announcements_controller.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class API::AnnouncementsController < API::BaseController
-  protect_from_forgery except: %i[create]
+  before_action :require_admin_login_for_api, only: %i[destroy]
   before_action :set_announcement, only: %i[show update destroy]
+  protect_from_forgery except: %i[create update]
 
   def index
     @announcements = Announcement.with_avatar
@@ -13,16 +14,12 @@ class API::AnnouncementsController < API::BaseController
 
   def show; end
 
-  def new
-    @announcement = Announcement.new(target: 'students')
-  end
-
-  def edit
-    @announcement.user_id = current_user.id
-  end
-
   def update
-    if @announcement.update(announcement_params)
+    if !current_user.admin? \
+      && (announcement_params['wip'] == 'false' \
+      || announcement_params['wip'].nil?)
+      head :bad_request
+    elsif @announcement.update(announcement_params)
       head :ok
     else
       head :bad_request
@@ -32,6 +29,7 @@ class API::AnnouncementsController < API::BaseController
   def create
     @announcement = Announcement.new(announcement_params)
     @announcement.user_id = current_user.id
+    @announcement.wip = true unless current_user.admin?
     if @announcement.save
       render :create, status: :created
     else
@@ -46,7 +44,7 @@ class API::AnnouncementsController < API::BaseController
   private
 
   def announcement_params
-    params.permit(:title, :description, :target, :wip)
+    params.fetch(:announcement).permit(:title, :description, :target, :wip)
   end
 
   def set_announcement

--- a/app/controllers/api/announcements_controller.rb
+++ b/app/controllers/api/announcements_controller.rb
@@ -11,6 +11,8 @@ class API::AnnouncementsController < API::BaseController
                                  .page(params[:page])
   end
 
+  def show; end
+
   def new
     @announcement = Announcement.new(target: 'students')
   end

--- a/app/controllers/api/announcements_controller.rb
+++ b/app/controllers/api/announcements_controller.rb
@@ -46,7 +46,7 @@ class API::AnnouncementsController < API::BaseController
   private
 
   def announcement_params
-    params.require(:announcement).permit(:title, :description, :target, :wip)
+    params.permit(:title, :description, :target, :wip)
   end
 
   def set_announcement

--- a/app/views/api/announcements/_announcement.json.jbuilder
+++ b/app/views/api/announcements/_announcement.json.jbuilder
@@ -1,18 +1,17 @@
 json.id announcement.id
-json.user announcement.user.login_name
+json.user do
+  json.partial! "api/users/user", user: announcement.user
+end
 json.title announcement.title
 json.description announcement.description
 json.target announcement.target
 json.wip announcement.wip
 json.created_at l(announcement.created_at)
 json.created_at_date_time announcement.created_at.to_datetime
+json.updated_at l(announcement.updated_at)
+json.updated_at_date_time announcement.updated_at.to_datetime
 
 if announcement.published_at.present?
   json.published_at l(announcement.published_at)
   json.published_at_date_time announcement.published_at.to_datetime
-end
-
-if announcement.updated_at.present?
-  json.updated_at l(announcement.updated_at)
-  json.updated_at_date_time announcement.updated_at.to_datetime
 end

--- a/app/views/api/announcements/_announcement.json.jbuilder
+++ b/app/views/api/announcements/_announcement.json.jbuilder
@@ -1,0 +1,18 @@
+json.id announcement.id
+json.user announcement.user.login_name
+json.title announcement.title
+json.description announcement.description
+json.target announcement.target
+json.wip announcement.wip
+json.created_at l(announcement.created_at)
+json.created_at_date_time announcement.created_at.to_datetime
+
+if announcement.published_at.present?
+  json.published_at l(announcement.published_at)
+  json.published_at_date_time announcement.published_at.to_datetime
+end
+
+if announcement.updated_at.present?
+  json.updated_at l(announcement.updated_at)
+  json.updated_at_date_time announcement.updated_at.to_datetime
+end

--- a/app/views/api/announcements/create.json.jbuilder
+++ b/app/views/api/announcements/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "api/announcements/announcement", announcement: @announcement

--- a/app/views/api/announcements/index.json.jbuilder
+++ b/app/views/api/announcements/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.announcements do
+  json.array! @announcements do |announcement|
+    json.partial! "api/announcements/announcement", announcement: announcement
+  end
+end

--- a/app/views/api/announcements/show.json.jbuilder
+++ b/app/views/api/announcements/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "api/announcements/announcement", announcement: @announcement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
     namespace :categories_practices do
       resources :position, only: %i(update)
     end
-  resources :announcements
+  resources :announcements, except: %i(new edit)
   end
 
   namespace :admin do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
     namespace :categories_practices do
       resources :position, only: %i(update)
     end
+  resources :announcements
   end
 
   namespace :admin do

--- a/test/integration/api/announcements_test.rb
+++ b/test/integration/api/announcements_test.rb
@@ -15,19 +15,19 @@ class API::AnnouncementsTest < ActionDispatch::IntegrationTest
 
     token = create_token('hatsuno', 'testtest')
     get api_announcements_path(format: :json),
-          headers: { 'Authorization' => "Bearer #{token}" }
+        headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
   end
 
   test 'POST /api/announcements.json' do
     post api_announcements_path(format: :json),
-          params: { title: 'test', description: 'postのテストです', target: 'students', wip: false }
+         params: { title: 'test', description: 'postのテストです', target: 'students', wip: false }
     assert_response :unauthorized
 
     token = create_token('hatsuno', 'testtest')
     post api_announcements_path(format: :json),
-          params: { title: 'test', description: 'postのテストです', target: 'students', wip: false },
-          headers: { 'Authorization' => "Bearer #{token}" }
+         params: { title: 'test', description: 'postのテストです', target: 'students', wip: false },
+         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :created
   end
 
@@ -37,7 +37,7 @@ class API::AnnouncementsTest < ActionDispatch::IntegrationTest
 
     token = create_token('hatsuno', 'testtest')
     get api_announcement_path(@announcement.id, format: :json),
-          headers: { 'Authorization' => "Bearer #{token}" }
+        headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
   end
 
@@ -59,7 +59,7 @@ class API::AnnouncementsTest < ActionDispatch::IntegrationTest
 
     token = create_token('hatsuno', 'testtest')
     delete api_announcement_path(@announcement.id, format: :json),
-          headers: { 'Authorization' => "Bearer #{token}" }
+           headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :no_content
   end
 end

--- a/test/integration/api/announcements_test.rb
+++ b/test/integration/api/announcements_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::AnnouncementsTest < ActionDispatch::IntegrationTest
+  fixtures :announcements
+
+  setup do
+    @announcement = announcements(:announcement1)
+  end
+
+  test 'GET /api/announcements.json' do
+    get api_announcements_path(format: :json)
+    assert_response :unauthorized
+
+    token = create_token('hatsuno', 'testtest')
+    get api_announcements_path(format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
+  test 'POST /api/announcements.json' do
+    post api_announcements_path(format: :json),
+          params: { title: 'test', description: 'postのテストです', target: 'students', wip: false }
+    assert_response :unauthorized
+
+    token = create_token('hatsuno', 'testtest')
+    post api_announcements_path(format: :json),
+          params: { title: 'test', description: 'postのテストです', target: 'students', wip: false },
+          headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :created
+  end
+
+  test 'GET /api/announcements/1234.json' do
+    get api_announcement_path(@announcement.id, format: :json)
+    assert_response :unauthorized
+
+    token = create_token('hatsuno', 'testtest')
+    get api_announcement_path(@announcement.id, format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
+  test 'PATCH /api/announcements/1234.json' do
+    patch api_announcement_path(@announcement.id, format: :json),
+          params: { title: 'test', description: 'patchのテストです', target: 'students', wip: false }
+    assert_response :unauthorized
+
+    token = create_token('hatsuno', 'testtest')
+    patch api_announcement_path(@announcement.id, format: :json),
+          params: { title: 'test', description: 'patchのテストです', target: 'students', wip: false },
+          headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
+  test 'DELETE /api/announcements/1234.json' do
+    delete api_announcement_path(@announcement.id, format: :json)
+    assert_response :unauthorized
+
+    token = create_token('hatsuno', 'testtest')
+    delete api_announcement_path(@announcement.id, format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :no_content
+  end
+end


### PR DESCRIPTION
issue #2378
---
## 作業内容
- 「お知らせの」APIを新規作成
`controller`,`jbuilder`を追加

- テストを追加
CRUD機能と、一般ユーザーがお知らせの「公開」「削除」が出来ないことを確認

## 目的
- 「GitHubと連携して次週のリリースノートを作成する」などがやりたい。
- 「お知らせ」のVue.js化の為

## 期待する動作

ログインした状態で、

|method|url|動作|
|-|-|-|
|GET|`/api/announcements.json`|一覧表示|
|POST|`/api/announcements.json`|新規作成|
|GET|`/api/announcements/1234.json`|個別に取得|
|PATCH|`/api/announcements/1234.json`|更新(編集)|
|DELETE|`/api/announcements/1234.json`|削除|


### 権限
一般ユーザー(admin以外)は、お知らせの「削除」と「公開」が出来ない。
(管理者ユーザーであれば、「公開」か「更新(編集)」の時に、`"wip": false`で公開が可能です。)

## スクリーンショット

## 一覧
[![Image from Gyazo](https://i.gyazo.com/d486077db81ecb2ec083beb647ae6a3b.gif)](https://gyazo.com/d486077db81ecb2ec083beb647ae6a3b)

## 新規作成
[![Image from Gyazo](https://i.gyazo.com/878e26b3e6957000a9883849ec101aed.gif)](https://gyazo.com/878e26b3e6957000a9883849ec101aed)

## 個別に取得
[![Image from Gyazo](https://i.gyazo.com/236b8e41c004993aa23ba2a8dc7eab8c.gif)](https://gyazo.com/236b8e41c004993aa23ba2a8dc7eab8c)

## 更新(編集)
[![Image from Gyazo](https://i.gyazo.com/16ac9cf758557680b0b59e0c48f8335e.gif)](https://gyazo.com/16ac9cf758557680b0b59e0c48f8335e)

## 削除
[![Image from Gyazo](https://i.gyazo.com/bbef53826123a4e2125722958e94ed3e.gif)](https://gyazo.com/bbef53826123a4e2125722958e94ed3e)

## 作成して公開
[![Image from Gyazo](https://i.gyazo.com/ea5fb450100762802c74b4e4f5113345.gif)](https://gyazo.com/ea5fb450100762802c74b4e4f5113345)

### 参考
こちらのツールを使っています → [Talend API Tester](https://chrome.google.com/webstore/detail/talend-api-tester-free-ed/aejoelaoggembcahagimdiliamlcdmfm)

使い方がよくわからなかった → [POSTMAN](https://www.postman.com/)

駒形さんが使っていたツール → [Insomnia](https://insomnia.rest/)