### PR TITLE
AdminのナビゲーションからWishlistを削除

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -30,9 +30,6 @@
                 = link_to 'https://github.com/fjordllc/fjord/wiki/FjordBootCamp', class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
                   | 管理者用ドキュメント
               li.header-dropdown__item
-                = link_to 'https://www.amazon.co.jp/hz/wishlist/ls/3I571CQISBFR6?ref_=wl_share', class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
-                  | ウィッシュリスト
-              li.header-dropdown__item
                 = link_to welcome_path, class: 'header-dropdown__item-link' do
                   | トップページ確認
               li.header-dropdown__item


### PR DESCRIPTION
 #2322
issueに対応
## 理由
ミートアップがオンラインになったため、スポンサー企業からのビールの提供が不要になったので削除

## やること
赤枠部分の削除
![image](https://user-images.githubusercontent.com/50447071/110117979-00e2e600-7dfd-11eb-8e88-8d87a832e09a.png)

## 実装方針
bootcamp/app/views/application/_header_links.html.slim
ここがAdminのナビゲーションが含まれるヘッダーのリンク部分のviewのため、
ここからウィッシュリストを削除する。