### PR TITLE
お知らせの『コピー』が機能するように直す

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -18,6 +18,14 @@ class AnnouncementsController < ApplicationController
 
   def new
     @announcement = Announcement.new(target: 'students')
+
+    return unless params[:id]
+
+    announcement = Announcement.find(params[:id])
+    @announcement.title       = announcement.title
+    @announcement.description = announcement.description
+    @announcement.target = announcement.target
+    flash.now[:notice] = 'お知らせをコピーしました。'
   end
 
   def edit

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -19,6 +19,13 @@ announcement3:
   created_at: "2018-01-03"
   target: 0
 
+announcement4:
+  user: kimura
+  title: 生徒からのお知らせ
+  description: 生徒からのお知らせ本文
+  created_at: "2018-01-03"
+  target: 0
+
 announcement_notification_active_user:
   user: machida
   title: 現役生にのみ通知するお知らせ

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -32,6 +32,22 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_selector '.thread-comment-form'
   end
 
+  test 'announcement has a copy form when user is admin' do
+    login_user 'komagata', 'testtest'
+    visit "/announcements/#{announcements(:announcement4).id}"
+    click_link 'コピー'
+
+    assert_text 'お知らせをコピーしました。'
+  end
+
+  test 'announcement has a copy form when user is author' do
+    login_user 'kimura', 'testtest'
+    visit "/announcements/#{announcements(:announcement4).id}"
+    click_link 'コピー'
+
+    assert_text 'お知らせをコピーしました。'
+  end
+
   test 'users except admin cannot publish an announcement' do
     login_user 'kimura', 'testtest'
     visit new_announcement_path


### PR DESCRIPTION
#2273
isuueに対応

### バグの理由
/bootcamp/app/controllers/announcements_controller.rb
announcementsコントローラのnewアクションにコピーするロジックの記載がそもそもなかった。
そのためコピーボタンを押しても新規作成と同じ処理になってしまっていたことが原因。
よってコピーするロジックを記載して期待通りの動きになるようにした。

#### スクショ
[![Image from Gyazo](https://i.gyazo.com/bb856083f323aa0f7e662036ecfae43c.gif)](https://gyazo.com/bb856083f323aa0f7e662036ecfae43c)
