### PR TITLE
イベント一覧ページにイベント日時を載せたい

### DIFF
--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -18,8 +18,8 @@
           = link_to new_event_path(id: event), class: 'thread-list-item__actions-link' do
             i.fas.fa-copy
     .thread-list-item-meta
-      time.thread-list-item-meta__datetime(datetime="#{event.start_at.to_datetime}")
-        | 開催日時:#{l event.start_at}
+      time.thread-list-item-meta__datetime(datetime=event.start_at.to_datetime)
+        | 開催日時: #{l event.start_at}
       - if event.comments.any?
         .thread-list-item-meta__comment-count
           .thread-list-item-meta__comment-count-label

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -18,8 +18,9 @@
           = link_to new_event_path(id: event), class: 'thread-list-item__actions-link' do
             i.fas.fa-copy
     .thread-list-item-meta
-      time.thread-list-item-meta__datetime(datetime="#{event.updated_at.to_datetime}" pubdate='pubdate')
-        = l event.updated_at
+      time.thread-list-item-meta__datetime(datetime="#{event.updated_at.to_datetime}")
+        | 更新日時:#{l event.updated_at}&ensp;
+        | 開催日時:#{l event.start_at}
       - if event.comments.any?
         .thread-list-item-meta__comment-count
           .thread-list-item-meta__comment-count-label

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -18,8 +18,7 @@
           = link_to new_event_path(id: event), class: 'thread-list-item__actions-link' do
             i.fas.fa-copy
     .thread-list-item-meta
-      time.thread-list-item-meta__datetime(datetime="#{event.updated_at.to_datetime}")
-        | 更新日時:#{l event.updated_at}&ensp;
+      time.thread-list-item-meta__datetime(datetime="#{event.start_at.to_datetime}")
         | 開催日時:#{l event.start_at}
       - if event.comments.any?
         .thread-list-item-meta__comment-count


### PR DESCRIPTION
#2206 
issueに対応
## 理由
イベント詳細ページを開かなくても、イベント日時を知りたい。

## 機能説明
現状はこのようになっている。
![image](https://user-images.githubusercontent.com/50447071/110125534-bfefcf00-7e06-11eb-9fce-372844df2be7.png)

ここに表示されている最終更新日時を、イベントの開始日時に差し替える。

### 変更後のView

![image](https://user-images.githubusercontent.com/50447071/110198150-aa74b680-7e93-11eb-8b93-a0b1c33c5575.png)

## 実装方針
このイベント一覧の部分のviewのファイルは、`events.html.slim`である。
eventsテーブルには、最終更新日時を示す`updated_at`カラムと、イベント日時を示す`start_at`カラムがあるため、これを上記のviewにて差し替える。