### PR TITLE
未返信の提出物が提出日の昇順で並ぶように修正

### DIFF
--- a/app/controllers/api/products/not_responded_controller.rb
+++ b/app/controllers/api/products/not_responded_controller.rb
@@ -3,6 +3,10 @@
 class API::Products::NotRespondedController < API::BaseController
   before_action :require_staff_login
   def index
-    @products = Product.not_responded_products.list.reorder_for_not_responded_products.page(params[:page])
+    @products = Product
+                .not_responded_products
+                .list
+                .reorder_for_not_responded_products
+                .page(params[:page])
   end
 end

--- a/app/controllers/api/products/not_responded_controller.rb
+++ b/app/controllers/api/products/not_responded_controller.rb
@@ -3,6 +3,6 @@
 class API::Products::NotRespondedController < API::BaseController
   before_action :require_staff_login
   def index
-    @products = Product.not_responded_products.list.page(params[:page])
+    @products = Product.not_responded_products.list.reorder_for_not_responded_products.page(params[:page])
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -37,6 +37,7 @@ class Product < ApplicationRecord
       .preload([:practice, :comments, { checks: { user: { avatar_attachment: :blob } } }])
       .order(created_at: :desc)
   }
+  scope :reorder_for_not_responded_products, -> { reorder(published_at: :desc, id: :desc) }
 
   # rubocop:disable Metrics/MethodLength
   def self.not_responded_products

--- a/test/system/product/not_responded_test.rb
+++ b/test/system/product/not_responded_test.rb
@@ -32,7 +32,27 @@ class ProductsTest < ApplicationSystemTestCase
     click_button '未返信の提出物を一括で開く'
 
     within_window(windows.last) do
-      assert_text 'テストの提出物1です。'
+      assert_text Product.not_responded_products.reorder_for_not_responded_products.first.body
     end
+  end
+
+  test 'products order' do
+    # id順で並べたときの最初と最後の提出物を、提出日順で見たときに最新と最古になるように入れ替える
+    Product.update_all(published_at: 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
+    newest_product = Product.not_responded_products.reorder(:id).first
+    newest_product.update(published_at: Time.current)
+    oldest_product = Product.not_responded_products.reorder(:id).last
+    oldest_product.update(published_at: 2.days.ago)
+
+    login_user 'komagata', 'testtest'
+    visit '/products/not_responded'
+
+    # 提出日の昇順で並んでいることを検証する
+    titles = all('.thread-list-item__title').map { |t| t.text.gsub('★', '') }
+    authors = all('.thread-list-item-meta .thread-header__author').map(&:text)
+    assert_equal "#{newest_product.practice.title}の提出物", titles.first
+    assert_equal newest_product.user.login_name, authors.first
+    assert_equal "#{oldest_product.practice.title}の提出物", titles.last
+    assert_equal oldest_product.user.login_name, authors.last
   end
 end

--- a/test/system/product/not_responded_test.rb
+++ b/test/system/product/not_responded_test.rb
@@ -32,7 +32,11 @@ class ProductsTest < ApplicationSystemTestCase
     click_button '未返信の提出物を一括で開く'
 
     within_window(windows.last) do
-      assert_text Product.not_responded_products.reorder_for_not_responded_products.first.body
+      newest_product = Product
+                       .not_responded_products
+                       .reorder_for_not_responded_products
+                       .first
+      assert_text newest_product.body
     end
   end
 


### PR DESCRIPTION
最終的には未返信タブのあり方そのものが変わると思いますが、現状の仕様だとメンターとして日常業務で神経を使うので、さくっと直せそうな形でいったん修正してみました。あくまで応急処置です。

参考 https://github.com/fjordllc/bootcamp/pull/2280/files#r585987542