### PR TITLE
タグ機能で絞り込んだ時にユーザー区分のフィルターが表示されないように修正。

### DIFF
--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -12,8 +12,9 @@ header.page-header.is-border-bottom-none
 
 = render 'lg_page_tabs'
 
-.page-tools
-  = render 'nav'
+- unless params[:tag]
+  .page-tools
+    = render 'nav'
 
 .page-notice
   .container


### PR DESCRIPTION
#2263
のisuueに対応

### 修正理由
現在ユーザータグで絞り込むと、生徒からメンターまで全てのユーザーからタグに一致したものを表示する仕様になっている。
しかし現役生などのフィルタリングの欄が表示されているため、タグで絞り込んだうちさらに「現役生」でフィルタリングされているように見えてしまい誤解を招く。

### 修正方針
タグで絞り込んだ時は現役生などのフィルタリングの欄を消して対応。

### 修正後のスクショ
[![Image from Gyazo](https://i.gyazo.com/0fdcfec2a56b592305b32451b0891a7f.gif)](https://gyazo.com/0fdcfec2a56b592305b32451b0891a7f)



