### PR TITLE
「前の日報」リンクが、直近の日付でないバグの修正

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -65,7 +65,7 @@ class Report < ApplicationRecord
   def previous
     Report.where(user: user)
           .where('reported_on < ?', reported_on)
-          .order(created_at: :desc)
+          .order(reported_on: 'DESC')
           .first
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -65,7 +65,7 @@ class Report < ApplicationRecord
   def previous
     Report.where(user: user)
           .where('reported_on < ?', reported_on)
-          .order(reported_on: 'DESC')
+          .order(reported_on: :desc)
           .first
   end
 

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -136,6 +136,7 @@ report17:
     今日は1時間学習しました。
   practices: practice1
   reported_on: "2020-06-01"
+  created_at: "2020-06-01 17:00:00"
 
 report18:
   user: daimyo
@@ -143,6 +144,7 @@ report18:
   description: |-
     今日は1時間学習しました。
   reported_on: "2020-06-01"
+  created_at: "2020-06-01 18:00:00"
 
 report19:
   user: hatsuno

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -175,6 +175,7 @@ report22:
     卒業しました。
   practices: practice2
   reported_on: "2020-09-10"
+  created_at: "2020-09-10 01:00:00"
 
 report23:
   user: kensyu
@@ -196,3 +197,19 @@ report25:
   description:
     ユーザーネームで検索できるよ
   reported_on: "2020-11-20"
+
+report26:
+  user: sotugyou
+  title: 卒業の翌日の日報
+  description:
+    「前の日報」をクリックすれば、前日の日報にちゃんと行ける
+  reported_on: "2020-09-11"
+  created_at: "2020-09-11 01:00:00"
+
+report27:
+  user: sotugyou
+  title: 卒業の前日(遡って日報を作成)
+  description:
+    遡って作成しましたが、卒業の前日の分の日報です。
+  reported_on: "2020-09-09"
+  created_at: "2020-09-12 01:00:00"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -136,6 +136,7 @@ report17:
     今日は1時間学習しました。
   practices: practice1
   reported_on: "2020-06-01"
+  created_at: "2020-06-01 17:00:00"
 
 report18:
   user: daimyo
@@ -143,6 +144,7 @@ report18:
   description: |-
     今日は1時間学習しました。
   reported_on: "2020-06-01"
+  created_at: "2020-06-01 18:00:00"
 
 report19:
   user: hatsuno

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -175,6 +175,7 @@ report22:
     卒業しました。
   practices: practice2
   reported_on: "2020-09-10"
+  created_at: "2020-09-10 01:00:00"
 
 report23:
   user: kensyu
@@ -196,3 +197,19 @@ report25:
   description:
     ユーザーネームで検索できるよ
   reported_on: "2020-11-20"
+
+report26:
+  user: sotugyou
+  title: 卒業の翌日の日報
+  description:
+    「前の日報」をクリックすれば、前日の日報にちゃんと行ける
+  reported_on: "2020-09-11"
+  created_at: "2020-09-11 01:00:00"
+
+report27:
+  user: sotugyou
+  title: 卒業の前日(遡って日報を作成)
+  description:
+    遡って作成しましたが、卒業の前日の分の日報です。
+  reported_on: "2020-09-09"
+  created_at: "2020-09-12 01:00:00"

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -5,6 +5,8 @@ require 'test_helper'
 class ReportTest < ActiveSupport::TestCase
   test '#previous' do
     assert_equal reports(:report1), reports(:report2).previous
+    assert_equal reports(:report22), reports(:report26).previous
+    assert_equal reports(:report27), reports(:report22).previous
   end
 
   test '#next' do

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -558,8 +558,8 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'reports are ordered in descending of reported_on' do
     visit reports_path
-    precede = reports(:report2).title
-    succeed = reports(:report1).title
+    precede = reports(:report24).title
+    succeed = reports(:report23).title
     within '.thread-list' do
       assert page.text.index(precede) < page.text.index(succeed)
     end
@@ -567,8 +567,9 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'reports are ordered in descending of created_at if reported_on is same' do
     visit reports_path
-    precede = reports(:report5).title
-    succeed = reports(:report1).title
+    precede = reports(:report18).title
+    succeed = reports(:report17).title
+
     within '.thread-list' do
       assert page.text.index(precede) < page.text.index(succeed)
     end


### PR DESCRIPTION
Issue #2406

早めに直してもらいため、PRだします。

`previous`メソッドが`next`メソッドの対になるよう、順序の指定カラムを報告対象日(`reported_on`)に修正しました。

また、これに合わせてテストを追加したため、日報の件数が25件を越し、
1ページ目にあって日報が2ページにいき、順番のテストで日報が見つからず失敗するものがでたため、
簡易的にテスト対象の日報を変更しています。