### PR TITLE
トップページ確認をadminのナビゲーションから削除

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -27,9 +27,6 @@
                 = link_to 'https://github.com/fjordllc/fjord/wiki/FjordBootCamp', class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
                   | 管理者用ドキュメント
               li.header-dropdown__item
-                = link_to welcome_path, class: 'header-dropdown__item-link' do
-                  | トップページ確認
-              li.header-dropdown__item
                 = link_to 'https://app.redash.io/fjord-inc/public/dashboards/TR86ezvmxVWE7ScenS3yTE1z8lV4ILzvmOAyKmWY',
                   class: 'header-dropdown__item-link',
                   target: '_blank', rel: 'noopener' do


### PR DESCRIPTION
issue
#2431  に対応

## 概要

Adminの `トップページ確認` リンクを削除する。

### Viewの変更部分のスクリーンショット

赤い枠で囲まれた部分を削除

before
![before](https://user-images.githubusercontent.com/43565959/110594441-2a668d80-81c0-11eb-85ef-1b32df59856d.png)

after

![after](https://user-images.githubusercontent.com/43565959/110594447-2c305100-81c0-11eb-8f6f-31fac8f64390.png)

## 削除理由

e75db15d6d589a123e8c05b7511370d649a692a0 でMenuにホームページのリンク(`/welcome`)が追加され、同じページ(`/welcome`)先のリンク `トップページ確認` がいらなくなった。

![homepage_link](https://user-images.githubusercontent.com/43565959/110597694-3bb19900-81c4-11eb-803b-cfac4b5ecd34.gif)

