### PR TITLE
プラクティス詳細画面下部『困ったときは、・・・くわしくはこちら』のリンク変更

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -137,4 +137,4 @@ header.page-header
 .sticky-message
   p
     | 困ったときは、質問・雑談ルームを利用しよう！
-    = link_to 'くわしくはこちら', 'https://bootcamp.fjord.jp/pages/242', target: '_blank', rel: 'noopener'
+    = link_to 'くわしくはこちら', 'https://bootcamp.fjord.jp/pages/245', target: '_blank', rel: 'noopener'


### PR DESCRIPTION
# issue
#2162 に対応
# やること
『くわしくはこちら』のリンク先が現在
https://bootcamp.fjord.jp/pages/242
になっているが
https://bootcamp.fjord.jp/pages/245
に変更する

<img width="1140" alt="スクリーンショット 2020-11-27 8 58 36" src="https://user-images.githubusercontent.com/5990045/100397759-d3b0ca00-308e-11eb-84ca-76f889bbc754.png">

