### PR TITLE
日報の『プラクティス』を一度選択して保存すると、その後消しても反映されないバグを修正

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -59,7 +59,7 @@ class ReportsController < ApplicationController
 
   def update
     set_wip
-    @report.practice_ids = nil if params[:report][:practice_ids].nil? 
+    @report.practice_ids = nil if params[:report][:practice_ids].nil?
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
     check_noticeable

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -59,6 +59,7 @@ class ReportsController < ApplicationController
 
   def update
     set_wip
+    @report.practice_ids = nil if params[:report][:practice_ids].nil? 
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
     check_noticeable

--- a/test/fixtures/learning_times.yml
+++ b/test/fixtures/learning_times.yml
@@ -32,3 +32,8 @@ learning_time7:
   report: report22
   started_at: 2020-09-10 12:00:00
   finished_at: 2020-09-10 13:15:00
+
+learning_time８:
+  report: report10
+  started_at: 2020-09-10 12:00:00
+  finished_at: 2020-09-10 13:15:00

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -73,7 +73,10 @@ report10:
   title: 初日報です
   description:
     学習の準備をしました。
+  practices: practice2
+  emotion: 1
   reported_on: "2019-01-01"
+  created_at: "2019-01-01 00:00:00"
 
 report11:
   user: kensyu

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -41,6 +41,29 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text 'Watch中'
   end
 
+  test 'practices are displayed when updating with selecting a practice' do
+    login_user 'hajime', 'testtest'
+    report = reports(:report10)
+    visit "/reports/#{report.id}"
+    click_link '内容修正'
+
+    click_button '内容変更'
+    assert_text 'Terminalの基礎を覚える'
+    assert_text '日報を保存しました。'
+  end
+
+  test 'practices are not displayed when updating without selecting a practice' do
+    login_user 'hajime', 'testtest'
+    report = reports(:report10)
+    visit "/reports/#{report.id}"
+    click_link '内容修正'
+    first('.select2-selection__choice__remove').click
+
+    click_button '内容変更'
+    assert_no_text 'Terminalの基礎を覚える'
+    assert_text '日報を保存しました。'
+  end
+
   test 'create a report without company as trainee' do
     user = users(:kensyu)
     user.update!(company: nil)


### PR DESCRIPTION
 #2277
のisuueに対応

### 概要
日報で一度プラクティスを選択した場合、プラクティスを消して更新をしても反映されないバグが発生する。
なお初めからプラクティスなしで保存した場合には、正常にプラクティスなしで保存できる。
また、複数プラクティスを選択し、その後プラクティスを一つに減らす処理をした場合には反映されることを確認。
プラクティスの全削除だけが反映できない。

### バグの原因
日報のプラクティスを消して更新する場合には"practice_ids"にnilが入っていることを期待するが、実際にはparameterとして"practice_ids"が渡されていない為、更新が行われないことが原因となる。

### 対応策１
プラクティスが選択されていない場合にnilを追加する。
メリット：直感的で選択ボックスを押す手間がいらない。
```
  def update
    set_wip
    @report.practice_ids = nil if params[:report][:practice_ids].nil?  #この行を追加
    @report.assign_attributes(report_params)
    ...
```

#### スクショ
[![Image from Gyazo](https://i.gyazo.com/4b2df3cc29b2497bd8b0f8ac1179f151.gif)](https://gyazo.com/4b2df3cc29b2497bd8b0f8ac1179f151)

### 対応策2
include_blankを追加することでnilを選択できるようにする。
メリット：form_forの機能を使って作成している為安心。操作がわかりやすい。

```
.select-practices
  = f.select(:practice_ids, practice_options(categories), { include_hidden: false ,include_blank: "プラクティスを空欄にする"}, { multiple: true, class: 'js-select2' })
```

#### スクショ
<img width="819" alt="スクリーンショット 2021-03-18 21 17 21" src="https://user-images.githubusercontent.com/64201542/111624749-6dafa480-882f-11eb-8bc6-13aa0cd35eb0.png">
