### PR TITLE
管理者メニュー「Slack管理」を削除

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -21,9 +21,6 @@
                 = link_to admin_root_path, class: 'header-dropdown__item-link' do
                   | 管理ページ
               li.header-dropdown__item
-                = link_to 'https://fjord.slack.com/admin', class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
-                  | Slack管理
-              li.header-dropdown__item
                 = link_to 'https://github.com/fjordllc/fjord/wiki/FjordBootCamp', class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
                   | 管理者用ドキュメント
               li.header-dropdown__item


### PR DESCRIPTION
# issue
#2449 に対応
# やること
SlackからDiscordに移行したことに伴う削除。

<img width="360" alt="スクリーンショット 2021-03-14 12 39 06" src="https://user-images.githubusercontent.com/16577/111056482-70726880-84c2-11eb-9041-18917e5ae963.png">

