### PR TITLE
提出物の個別ページに「担当になるボタン」が欲しい

### DIFF
--- a/app/assets/stylesheets/blocks/card/_card-footer-actions.sass
+++ b/app/assets/stylesheets/blocks/card/_card-footer-actions.sass
@@ -17,6 +17,8 @@
   +media-breakpoint-down(sm)
     flex-basis: 100%
     max-width: 100%
+    &.is-sub
+      text-align: right
 
 .card-footer-actions__delete
   +hover-link-reversal

--- a/app/assets/stylesheets/blocks/card/_card-footer.sass
+++ b/app/assets/stylesheets/blocks/card/_card-footer.sass
@@ -1,6 +1,9 @@
 .card-footer
-  padding: .75rem 1.25rem
   border-top: $background solid 1px
+  +media-breakpoint-up(md)
+    padding: .75rem 1.25rem
+  +media-breakpoint-down(sm)
+    padding: .75rem
   &:last-child
     +border-radius(bottom, .25rem)
   .card-header + &

--- a/app/assets/stylesheets/blocks/thread/_thread-admin-tools.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-admin-tools.sass
@@ -1,17 +1,23 @@
 .thread-admin-tools
   border-top: solid 1px $border
-  padding: .5rem 2rem
+  +media-breakpoint-up(md)
+    padding: .75rem 2rem
   +media-breakpoint-down(sm)
-    +padding(horizontal, 1rem)
+    padding: .75rem
 
 .thread-admin-tools__items
-  display: flex
-  justify-content: flex-end
-  +margin(horizontal, -.375rem)
+  +media-breakpoint-up(md)
+    display: flex
+    justify-content: center
+    +margin(horizontal, -.375rem)
 
 .thread-admin-tools__item
   +padding(horizontal, .375rem)
-  min-width: 12rem
+  +media-breakpoint-up(md)
+    min-width: 18rem
+  +media-breakpoint-down(sm)
+    &:not(:first-child)
+      margin-top: .5rem
   .a-button
     min-height: 2.375rem
     font-size: .8125rem

--- a/app/assets/stylesheets/blocks/thread/_thread-admin-tools.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-admin-tools.sass
@@ -7,12 +7,21 @@
 .thread-admin-tools__items
   display: flex
   justify-content: flex-end
+  +margin(horizontal, -.375rem)
+
+.thread-admin-tools__item
+  +padding(horizontal, .375rem)
+  min-width: 12rem
+  .a-button
+    min-height: 2.375rem
+    font-size: .8125rem
 
 .thread-check-form__action, .thread-unconfirmed-links-form__action
   &.is-text
     +hover-link-reversal
     +text-block(.875rem 1.4, $muted-text)
     cursor: pointer
+    min-height: 2.375rem
     +padding(vertical, .25rem)
     i
       margin-right: .25em

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -25,6 +25,7 @@
   border: dashed 1px $muted-text
   pointer-events: none
   color: $muted-text
+  background-color: #f6f6f6
   span
     display: block
     overflow: hidden

--- a/app/javascript/check.js
+++ b/app/javascript/check.js
@@ -8,12 +8,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const checkableId = check.getAttribute('data-checkable-id')
     const checkableType = check.getAttribute('data-checkable-type')
     const checkableLabel = check.getAttribute('data-checkable-label')
+    const checkerId = check.getAttribute('data-checker-id')
+    const checkerName = check.getAttribute('data-checker-name')
+    const currentUserId = check.getAttribute('data-current-user-id')
     new Vue({
       store,
       render: h => h(Check, { props: {
         checkableId: checkableId,
         checkableType: checkableType,
-        checkableLabel: checkableLabel
+        checkableLabel: checkableLabel,
+        checkerId: checkerId,
+        checkerName: checkerName,
+        currentUserId: currentUserId
       } })
     }).$mount('#js-check')
   }

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -15,7 +15,7 @@
         //-
         product-checker(v-show="checkableType === 'Product' && checkId === null", :checkerId="checkerId", :checkerName="checkerName", :currentUserId="currentUserId", :productId="checkableId")
       li.thread-admin-tools__item
-        button#js-shortcut-check.thread-check-form__action(:class=" checkId ? 'is-text' : 'a-button is-md is-danger' " @click="check")
+        button#js-shortcut-check.thread-check-form__action.is-block(:class=" checkId ? 'is-text' : 'a-button is-md is-danger' " @click="check")
           i.fas.fa-check
           | {{ buttonLabel }}
 </template>

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -2,15 +2,32 @@
   .thread-admin-tools
     ul.thread-admin-tools__items
       li.thread-admin-tools__item
+        //
+          v-showではなくv-ifだと "提出物を確認" => "取り消し" した際、
+          担当ボタンの表示はページ読み込み時に戻る。
+          例えば、ページ読み込み時に "担当する" ボタンだった場合、
+          クリックして "担当から外れる" ボタンに変更後、
+          "提出物を確認" => "取り消し" すると、
+          ページ読み込み時の "担当する" ボタンが表示される。
+          パフォーマンスが非常に悪くなるとかではないので、今回はv-showを利用
+          checkerIdの値がページ読み込み時の値のままではなく、
+          現状のcheckerIdを参照すれば、v-ifでも大丈夫と推測
+        //-
+        product-checker(v-show="checkableType === 'Product' && checkId === null", :checkerId="checkerId", :checkerName="checkerName", :currentUserId="currentUserId", :productId="checkableId")
+      li.thread-admin-tools__item
         button#js-shortcut-check.thread-check-form__action(:class=" checkId ? 'is-text' : 'a-button is-md is-danger' " @click="check")
           i.fas.fa-check
           | {{ buttonLabel }}
 </template>
 <script>
 import 'whatwg-fetch'
+import ProductChecker from './product_checker'
 
 export default {
-  props: ['checkableId', 'checkableType', 'checkableLabel'],
+  props: ['checkableId', 'checkableType', 'checkableLabel', 'checkerId', 'checkerName', 'currentUserId'],
+  components: {
+    'product-checker': ProductChecker,
+  },
   computed: {
     checkId() {
       return this.$store.getters.checkId

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -49,7 +49,8 @@
         h2.stamp__content.is-title 確認済
         time.stamp__content.is-created-at {{ product.checks.last_created_at }}
         .stamp__content.is-user-name {{ product.checks.last_user_login_name }}
-      product-checker(v-if="isMentor && product.checks.size == 0" :checkerId="product.checker_id", :checkerName="product.checker_name", :currentUserId="currentUserId", :productId="product.id")
+      .thread-list-item__assignee
+        product-checker(v-if="isMentor && product.checks.size == 0" :checkerId="product.checker_id", :checkerName="product.checker_name", :currentUserId="currentUserId", :productId="product.id")
 </template>
 <script>
 import ProductChecker from './product_checker'

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -1,5 +1,4 @@
 <template lang="pug">
-  .thread-list-item__assignee
     button(v-if="!checkerId || checkerId == currentUserId" :class="['a-button', 'is-sm', 'is-block', id ? 'is-danger' : 'is-primary']" @click="check")
       i(v-if="!checkerId || checkerId == currentUserId" :class="['fas', 'is-sm', id ? 'fa-times' : 'fa-hand-paper']" @click="check")
       | {{ buttonLabel }}

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-    button(v-if="!checkerId || checkerId == currentUserId" :class="['a-button', 'is-sm', 'is-block', id ? 'is-danger' : 'is-primary']" @click="check")
-      i(v-if="!checkerId || checkerId == currentUserId" :class="['fas', 'is-sm', id ? 'fa-times' : 'fa-hand-paper']" @click="check")
+    button(v-if="!checkerId || checkerId == currentUserId" :class="['a-button', 'is-sm', 'is-block', id ? 'is-warning' : 'is-secondary']" @click="check")
+      i(v-if="!checkerId || checkerId == currentUserId" :class="['fas', id ? 'fa-times' : 'fa-hand-paper']" @click="check")
       | {{ buttonLabel }}
     .a-button.is-sm.is-block.thread-list-item__assignee-name(v-else)
       span

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -27,11 +27,12 @@
           :break-view-text="null"
         )
       .thread-list.a-card(v-if="products.length > 0")
-        product(v-for="product in products"
-          :key="product.id"
-          :product="product"
-          :currentUserId="currentUserId"
-          :isMentor="isMentor")
+        .thread-list__items
+          product(v-for="product in products"
+            :key="product.id"
+            :product="product"
+            :currentUserId="currentUserId"
+            :isMentor="isMentor")
         unconfirmed-links-open-button(v-if="isMentor && selectedTab != 'all'" :label="`${unconfirmedLinksName}の提出物を一括で開く`")
       .o-empty-massage(v-else)
         .o-empty-massage__icon

--- a/app/javascript/unconfirmed_links_open_button.vue
+++ b/app/javascript/unconfirmed_links_open_button.vue
@@ -3,7 +3,7 @@
     .thread-admin-tools
       ul.thread-admin-tools__items
         li.thread-admin-tools__item
-          button.thread-unconfirmed-links-form__action(class="a-button is-md is-primary" @click="openUnconfirmedItems()") {{ label }}
+          button.thread-unconfirmed-links-form__action(class="a-button is-md is-secondary" @click="openUnconfirmedItems()") {{ label }}
 </template>
 <script>
 

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -91,7 +91,12 @@ header.page-header
                         | 削除する
 
             - if admin_login? || adviser_login?
-              #js-check(data-checkable-id="#{@product.id}" data-checkable-type='Product' data-checkable-label="#{Product.model_name.human}")
+              #js-check(data-checkable-id="#{@product.id}"
+                        data-checkable-type='Product'
+                        data-checkable-label="#{Product.model_name.human}"
+                        data-checker-id="#{@product.checker_id}"
+                        data-checker-name="#{@product.checker_name}"
+                        data-current-user-id="#{current_user.id}")
 
           .thread-prev-next
             .thread-prev-next__item

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -126,6 +126,30 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '提出物を削除しました。'
   end
 
+  test 'setting checker on show page' do
+    login_user 'komagata', 'testtest'
+    visit "/products/#{products(:product1).id}"
+    click_button '担当する'
+    assert_button '担当から外れる'
+  end
+
+  test 'unsetting checker on show page' do
+    login_user 'komagata', 'testtest'
+    visit "/products/#{products(:product1).id}"
+    click_button '担当する'
+    click_button '担当から外れる'
+    assert_button '担当する'
+  end
+
+  test 'hide checker button at product checked' do
+    login_user 'machida', 'testtest'
+    visit "/products/#{products(:product1).id}"
+    assert_button '担当する'
+    click_button '提出物を確認'
+    assert_no_button '担当する'
+    assert_no_button '担当から外れる'
+  end
+
   test 'create product as WIP' do
     login_user 'yamada', 'testtest'
     visit "/products/new?practice_id=#{practices(:practice6).id}"


### PR DESCRIPTION
issue
#2426 に対応

## 概要

提出物の個別ページに、メンターユーザー向けの担当ボタンを追加する。

ボタンの大きさや配置はレビュー完了後、 machida さんにお願いする予定です。

### Viewの変更部分のgif

実装前

![before](https://user-images.githubusercontent.com/43565959/111153226-05fe1d00-85d5-11eb-91ba-f28126cfa0f8.png)

実装後

<details open><summary>担当ボタンの切り替え</summary>

![switch-status](https://user-images.githubusercontent.com/43565959/111242082-c883a900-8641-11eb-970a-e9ec65bdbb2f.gif)


</details>

<details open><summary>提出物を確認すると担当ボタンが非表示</summary>

![hide_button](https://user-images.githubusercontent.com/43565959/111242097-cde0f380-8641-11eb-9800-1998f54e076b.gif)


</details>

<details open><summary>担当者がすでにいる場合、担当ボタンの部分に担当者名が表示</summary>

![display_name](https://user-images.githubusercontent.com/43565959/111242609-dab21700-8642-11eb-86f4-21f206306b66.gif)


</details>

<details open><summary>他の人がすでに確認済にした提出物でも担当ボタンは非表示</summary>

![other_user](https://user-images.githubusercontent.com/43565959/111242114-d5a09800-8641-11eb-8aba-76fdef70d8b2.gif)


</details>


## 追加する理由

メンターの人が欲しいため

## 追加したtestを実行したときのlog

<details>

```shell
> rails test test/system/products_test.rb:129 test/system/products_test.rb:136 test/
system/products_test.rb:144
DEPRECATION WARNING: Initialization autoloaded the constants ActiveStorage::Current,
 AnyLogin::ApplicationHelper, ActionText::ContentHelper, ActionText::TagHelper, and
AnyLogin::ApplicationController.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActiveStorage::Current, for exa
mple,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <main> at /home/hituzi_no_sippo/workspace/study/fjord_bootcamp/config/
environment.rb:7)
Run options: --seed 20104

# Running:

Capybara starting Puma...
* Version 4.3.7 , codename: Mysterious Traveller
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:46015
...

Finished in 16.215331s, 0.1850 runs/s, 0.3084 assertions/s.
3 runs, 5 assertions, 0 failures, 0 errors, 0 skips
```

</details>
