### PR TITLE
担当者がいない提出物にメンターがコメントすると自動で担当者になる

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -125,6 +125,10 @@ export default {
           this.tab = 'comment';
           this.buttonDisabled = false
           this.resizeTextarea()
+
+          if (this.commentableType === 'Product') {
+            this.assignProductToSelf()
+          }
         })
         .catch(error => {
           console.warn('Failed to parsing', error)
@@ -165,7 +169,24 @@ export default {
       const check = document.getElementById("js-shortcut-check")
       this.createComment()
       check.click()
-    }
+    },
+    assignProductToSelf() {
+      const params = {
+        "product_id": this.commentableId,
+        "current_user_id": this.currentUserId,
+      }
+      fetch('/api/products/checker', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': this.token()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual',
+        body: JSON.stringify(params)
+      })
+    },
   },
   computed: {
     validation() {

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -304,4 +304,54 @@ class ProductsTest < ApplicationSystemTestCase
 
     assert_not page.has_css?('.pagination')
   end
+
+  test 'be person on charge at comment on product of there are not person on charge' do
+    login_user 'machida', 'testtest'
+
+    visit products_not_responded_index_path
+    def assigned_product_count
+      find_link('自分の担当').find('.page-tabs__item-count').text.to_i
+    end
+
+    before_comment = assigned_product_count
+
+    visit "/products/#{products(:product1).id}"
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: '担当者がいない提出物の場合、担当者になる')
+    end
+    click_button 'コメントする'
+    wait_for_vuejs
+
+    visit products_not_responded_index_path
+    assert_equal before_comment + 1, assigned_product_count
+  end
+
+  test 'be not person on charge at comment on product of there are person on charge' do
+    login_user 'komagata', 'testtest'
+
+    visit products_not_responded_index_path
+    product = find('.thread-list-item', match: :first)
+    product.click_button '担当する'
+    show_product_path = product.find_link(href: /products/)[:href]
+    logout
+
+    login_user 'machida', 'testtest'
+    visit products_not_responded_index_path
+
+    def assigned_product_count
+      find_link('自分の担当').find('.page-tabs__item-count').text.to_i
+    end
+
+    before_comment = assigned_product_count
+
+    visit show_product_path
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: '担当者がいる提出物の場合、担当者にならない')
+    end
+    click_button 'コメントする'
+    wait_for_vuejs
+
+    visit products_not_responded_index_path
+    assert_equal before_comment, assigned_product_count
+  end
 end


### PR DESCRIPTION
issue
#2385 に対応

## 概要

メンターが担当者のいない提出物にコメントすると自動で担当になるようにする。

### Viewの変更部分のgif

実装前

![before](https://user-images.githubusercontent.com/43565959/111153226-05fe1d00-85d5-11eb-91ba-f28126cfa0f8.png)

実装後

<details open><summary>担当者がいない場合</summary>

![there_is_person_in_charge](https://user-images.githubusercontent.com/43565959/111282379-4915ca00-8681-11eb-98cf-5305559a14a7.gif)


</details>

<details open><summary>担当者がいる場合</summary>

![there_is_not_person_in_charge](https://user-images.githubusercontent.com/43565959/111282401-4fa44180-8681-11eb-9902-0991a26ef84c.gif)


</details>

## 追加する理由

メンターの人が欲しいため

## 追加したtestを実行したときのlog

<details>

```shell
> rails test test/system/products_test.rb:308 test/system/products_test.rb:329
DEPRECATION WARNING: Initialization autoloaded the constants ActiveStorage::Current,
 AnyLogin::ApplicationHelper, ActionText::ContentHelper, ActionText::TagHelper, and
AnyLogin::ApplicationController.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActiveStorage::Current, for exa
mple,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <main> at /home/hituzi_no_sippo/workspace/study/fjord_bootcamp/config/
environment.rb:7)
Run options: --seed 13519

# Running:

Capybara starting Puma...
* Version 4.3.7 , codename: Mysterious Traveller
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:45673
..

Finished in 20.432593s, 0.0979 runs/s, 0.0979 assertions/s.
2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

</details>
