### PR TITLE
「提出物をWIPで保存してから公開にすると通知が飛ばない」バグを修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -51,6 +51,10 @@ class ProductsController < ApplicationController
     @product = find_my_product
     set_wip
     if @product.update(product_params)
+      unless @product.wip? && @product.published_at.nil?
+        notify_to_slack(@product)
+        notify_to_chat(@product)
+      end
       redirect_to @product, notice: notice_message(@product, :update)
     else
       render :edit


### PR DESCRIPTION
#2379 
---
## やった事
- 提出物を、WIPで保存後に提出し、SlackとDiscordに通知が飛ぶ様に修正
- `create`時にDiscordへの通知を確認するテストがなかった為、テスト名に「Discord」を追加し、通知が飛んでいる事を確認するテストを追加
- `update`時にもSlackとDiscordに通知が飛んでいる事を確認するテストを新規追加

## 本番環境以外で「通知が飛んでいる」としている状態
開発環境では、実際にSlackやDiscordで通知が飛ぶ訳ではなく、`Rails.logger.info`でログに出していて、このログに期待する文字列があればOKとしています。なので、テストでもログの内容に該当の文字列が含まれているかで判断しています。

参考
- [Rails.logger.infoについて](https://railsguides.jp/debugging_rails_applications.html#%E3%83%AD%E3%82%AC%E3%83%BC%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)

- [日報(駒形さんの助言があります)](https://bootcamp.fjord.jp/reports/27226)


Slack(`app/jobs/notice_slack_job.rb`)

```ruby
    if Rails.env.production?
      icon_url = options[:icon_url] || 'https://i.gyazo.com/7099977680d8d8c2d72a3f14ddf14cc6.png'
      attachments = options[:attachments] || [{}]
      username = options[:username] || 'Bootcamp'
      channel = options[:channel] || 'learning_notification'

      notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL'], username: username
      notifier.ping text, icon_url: icon_url, attachments: attachments, channel: channel
    else
      Rails.logger.info "Notify\ntext:#{text}\nparams:#{options}"
    end
```

Discord(`app/models/chat_notifier.rb`)

```ruby
    if Rails.env.production?
      Discord::Notifier.message(message, username: username, url: webhook_url)
    else
      Rails.logger.info 'Message to Discord.'
    end
```

## サイト内通知について
現状だと提出物を提出した際に、サイト内通知はしていないので、今回はSlackとDiscordに通知するロジックをupdateに組み込んだだけになります。
ただ、研修生が提出物を提出した際にアドバイザーに通知する様になっているみたいで、こちらは要検討で別issueでの対応との事です。

関連すると思われるPR
[提出物をWIP状態から提出すると、ステータスが「提出」に変更されない、アドバイザーに通知されない](https://github.com/fjordllc/bootcamp/pull/1947)