### PR TITLE
お知らせのAPIで一般ユーザーの「公開」を制限

### DIFF
--- a/app/controllers/api/announcements_controller.rb
+++ b/app/controllers/api/announcements_controller.rb
@@ -15,6 +15,8 @@ class API::AnnouncementsController < API::BaseController
   def show; end
 
   def update
+    # announcement_params['wip']はユーザーが入力をするので、(文字列で'false'入力した場合等)
+    #「boolean型のtrueの時」のみ「更新」が出来る様、明示的にtureを書き込んでいます。
     if !current_user.admin? && announcement_params['wip'] != true
       head :bad_request
     elsif @announcement.update(announcement_params)

--- a/app/controllers/api/announcements_controller.rb
+++ b/app/controllers/api/announcements_controller.rb
@@ -16,7 +16,7 @@ class API::AnnouncementsController < API::BaseController
 
   def update
     # announcement_params['wip']はユーザーが入力をするので、(文字列で'false'入力した場合等)
-    #「boolean型のtrueの時」のみ「更新」が出来る様、明示的にtureを書き込んでいます。
+    # boolean型のtrueの時のみ「更新」が出来る様、明示的にtureを書き込んでいます。
     if !current_user.admin? && announcement_params['wip'] != true
       head :bad_request
     elsif @announcement.update(announcement_params)

--- a/app/controllers/api/announcements_controller.rb
+++ b/app/controllers/api/announcements_controller.rb
@@ -15,9 +15,7 @@ class API::AnnouncementsController < API::BaseController
   def show; end
 
   def update
-    if !current_user.admin? \
-      && (announcement_params['wip'] == 'false' \
-      || announcement_params['wip'].nil?)
+    if !current_user.admin? && announcement_params['wip'] != true
       head :bad_request
     elsif @announcement.update(announcement_params)
       head :ok

--- a/test/integration/api/announcements_test.rb
+++ b/test/integration/api/announcements_test.rb
@@ -67,8 +67,18 @@ class API::AnnouncementsTest < ActionDispatch::IntegrationTest
           params: {
             announcement: {
               title: 'test',
-              description: 'patchのテストです',
-              'wip': true
+              description: 'patchのテストです'
+            }
+          },
+          headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :bad_request
+
+    token = create_token('komagata', 'testtest')
+    patch api_announcement_path(@my_announcement.id, format: :json),
+          params: {
+            announcement: {
+              title: 'test',
+              description: 'patchのテストです'
             }
           },
           headers: { 'Authorization' => "Bearer #{token}" }
@@ -129,18 +139,6 @@ class API::AnnouncementsTest < ActionDispatch::IntegrationTest
           },
           headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :bad_request
-
-    token = create_token('kimura', 'testtest')
-    patch api_announcement_path(@my_announcement.id, format: :json),
-          params: {
-            announcement: {
-              title: 'test',
-              description: 'patchのテストです',
-              wip: true
-            }
-          },
-          headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :ok
 
     token = create_token('komagata', 'testtest')
     patch api_announcement_path(@my_announcement.id, format: :json),


### PR DESCRIPTION
#2469 
---
お知らせAPIを使って、一般ユーザーで「公開」が出来るタイミングは、「作成時」と「更新(編集)時」です。(`create`,`update`)

## バグの原因
updateアクションのif文の条件式が不十分だった。

`app/controller/api/announcements_controller`
```
  def update
    if !current_user.admin? \
      && (announcement_params['wip'] == 'false' \
      || announcement_params['wip'].nil?)
      head :bad_request
    elsif @announcement.update(announcement_params)
      head :ok
    else
      head :bad_request
    end
  end
```

テストが間違っていた
`test/integration/api/announcements_test.rb`
```
patch api_announcement_path(@my_announcement.id, format: :json),
          params: {
            announcement: {
              title: 'test',
              description: 'patchのテストです',
              wip: true
            }
          },
          headers: { 'Authorization' => "Bearer #{token}" }
    assert_response :bad_request

```

テストで`wip: true`と指定しても、String型になりちゃんと判定出来ていなかった。

---

APIのリクエストボディは、

```
{
  "title": "タイトル",
  "description": "内容",
  "wip": true
}
```

この様に指定していて、`wip: true`の`true`はboolean型(真偽値)で指定するのですが、'wip: false'等で指定すると、一般ユーザーでも「公開」が出来てしまいます。

一般ユーザーが「公開」出来ない様にするには、「管理者以外のユーザーは`wip: true`で指定した時以外は「更新(編集)」が出来ない」という条件にすれば良かったのですが、

上記のupdate時の条件だと、「管理者以外のユーザーは`wip: 〇〇`を、`"false"`(文字列)か`nill`で指定した時のみ「更新(編集)」が出来ない」という条件になっていたので、

逆に言うと、`"false"`(文字列)か`nill`以外なら出来てしまうので、例えば、`wip: false`(真偽値)で指定した時に、「公開」が出来てしまっていた。というのがこのバグの原因でした。

関連するPR
[お知らせのAPI（CRUD）が欲しい](https://github.com/fjordllc/bootcamp/pull/2416)