### PR TITLE
提出物作成時の通知を削除

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -37,10 +37,6 @@ class ProductsController < ApplicationController
     @product.user = current_user
     set_wip
     if @product.save
-      unless @product.wip?
-        notify_to_slack(@product)
-        notify_to_chat(@product)
-      end
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new
@@ -64,27 +60,6 @@ class ProductsController < ApplicationController
   end
 
   private
-
-  def notify_to_slack(product)
-    name = product.user.login_name.to_s
-    link = "<#{url_for(product)}|#{product.title}>"
-
-    return unless product.user.trainee? && product.user.company.slack_channel?
-
-    SlackNotification.notify "#{name} さんが#{product.title}を提出しました。 #{link}",
-                             username: "#{product.user.login_name} (#{product.user.name})",
-                             icon_url: product.user.avatar_url,
-                             channel: product.user.company.slack_channel,
-                             attachments: [{
-                               fallback: 'product body.',
-                               text: product.body
-                             }]
-  end
-
-  def notify_to_chat(product)
-    name = product.user.login_name.to_s
-    ChatNotifier.message("#{name}さんが提出物：#{product.title}を提出しました。\r#{url_for(product)}")
-  end
 
   def find_product
     Product.find(params[:id])

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -188,38 +188,6 @@ class ProductsTest < ApplicationSystemTestCase
     assert_no_text "kensyuさんが「#{practices(:practice3).title}」の提出物を提出しました。"
   end
 
-  test 'Slack notify if the create product' do
-    login_user 'kensyu', 'testtest'
-    visit "/products/new?practice_id=#{practices(:practice3).id}"
-    within('#new_product') do
-      fill_in('product[body]', with: 'test')
-    end
-    mock_log = []
-    stub_info = proc { |i| mock_log << i }
-
-    Rails.logger.stub(:info, stub_info) do
-      click_button '提出する'
-      assert_match "kensyu さんが「#{practices(:practice3).title}」の提出物を提出しました。", mock_log.to_s
-    end
-    assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
-  end
-
-  test 'Slack notify if the create product as WIP' do
-    login_user 'kensyu', 'testtest'
-    visit "/products/new?practice_id=#{practices(:practice3).id}"
-    within('#new_product') do
-      fill_in('product[body]', with: 'test')
-    end
-    mock_log = []
-    stub_info = proc { |i| mock_log << i }
-
-    Rails.logger.stub(:info, stub_info) do
-      click_button 'WIP'
-      assert_no_match "kensyu さんが「#{practices(:practice3).title}」の提出物を提出しました。", mock_log.to_s
-    end
-    assert_text '提出物をWIPとして保存しました。'
-  end
-
   test 'setting checker' do
     login_user 'komagata', 'testtest'
     visit products_path


### PR DESCRIPTION
チャットに通知する必要はないため。
（通知だらけで有名無実化するので）