### PR TITLE
個別Q＆Aページの質問の横に既回答数を表記する。

### DIFF
--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -37,6 +37,12 @@ header.page-header
               span.thread-header__title-icon.is-solved.is-danger
                 | 未解決
             = @question.title
+            - if @question.answers.present?
+              .thread-list-item-meta__comment-count
+                .thread-list-item-meta__comment-count-label
+                  i.fas.fa-comment
+                .thread-list-item-meta__comment-count-value
+                  = @question.answers.size
           .thread-header__lower-side
             #js-watch(data-watchable-id="#{@question.id}", data-watchable-type='Question')
             .thread-header__raw


### PR DESCRIPTION
# issue
## #2244 に対応
# やること
## 個別Q＆Aページの質問の横に既回答数を表記
一覧ページからではなく、直接Q&Aの質問・回答ページに遷移した場合、画面をスクロールしないと何件回答があったのかわからない。件数が表示されていればページを開いた瞬間に把握できる。

Before
![スクリーンショット 2021-03-22 17 30 02](https://user-images.githubusercontent.com/39847087/111961304-3f361000-8b34-11eb-86a5-87beee7c4c05.png)

After
![image](https://user-images.githubusercontent.com/39847087/111961565-8d4b1380-8b34-11eb-9133-406906aa269f.png)

