### PR TITLE
1ヶ月以上ログインのないユーザーの横に数字を出す

### DIFF
--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -2,8 +2,8 @@
   .a-card
     header.card-header
       h2.card-header__title
-        | 1ヶ月以上ログインのないユーザー  
-        = '(' + users.size.to_s + ')'
+        | 1ヶ月以上ログインのないユーザー
+        = "(#{users.size})"
     .card-list
       ul.card-list__items
         - users.each do |user|

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -2,7 +2,8 @@
   .a-card
     header.card-header
       h2.card-header__title
-        | 1ヶ月以上ログインのないユーザー
+        | 1ヶ月以上ログインのないユーザー  
+        = '(' + users.size.to_s + ')'
     .card-list
       ul.card-list__items
         - users.each do |user|


### PR DESCRIPTION
# issue
### #2432 に対応

# やること
### 管理者でログインした時のダッシュボードの中で、1ヶ月以上ログインのないユーザーの横に該当者数を表示する。
![貼り付けた画像_2021_03_16_12_57](https://user-images.githubusercontent.com/168265/111253966-6d5cb100-8657-11eb-848e-d8bd71750a7e.png)
