### PR TITLE
初めて日報を提出した時だけ、メンション通知とフォロワー、アドバイザーへ通知するように修正

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -48,9 +48,17 @@ class ReportsController < ApplicationController
     @report.user = current_user
     set_wip
     canonicalize_learning_times(@report)
-    check_noticeable
+    # @report.save 後、
+    # 正確には `after_save` の
+    # `report.update!(published_at: report.published_at)` 後だと、
+    # 正しい値が取得できないので @repot.save 前に実行して、
+    # 値を保存しておく
+    first_public = @report.first_public?
     if @report.save
-      notify_to_slack(@report) if @noticeable
+      # notify_to_slack は report_url(report) を利用しているため、
+      # modelのcallback(model/report_callbacks)へ簡単に移動できない
+      # 移動できれば `first_public = @report.first_public?` は必要ない
+      notify_to_slack(@report) if first_public
       redirect_to redirect_url(@report), notice: notice_message(@report)
     else
       render :new
@@ -61,10 +69,10 @@ class ReportsController < ApplicationController
     set_wip
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
-    check_noticeable
-
+    # createと同様
+    first_public = @report.first_public?
     if @report.save
-      notify_to_slack(@report) if @noticeable
+      notify_to_slack(@report) if first_public
       redirect_to redirect_url(@report), notice: notice_message(@report)
     else
       render :edit
@@ -155,13 +163,6 @@ class ReportsController < ApplicationController
 
   def set_wip
     @report.wip = params[:commit] == 'WIP'
-  end
-
-  def check_noticeable
-    return unless @report.published_at.nil? && @report.wip == false
-
-    @report.published_at = Date.current
-    @noticeable = true
   end
 
   def redirect_url(report)

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -1,21 +1,12 @@
 # frozen_string_literal: true
 
 module Mentioner
-  def after_save_mention(mentions)
-    new_mention_users.each do |receiver|
-      NotificationFacade.mentioned(self, receiver) if receiver && sender != receiver
-    end
-
-    return unless mentions.include? '@mentor'
-
-    User.mentor.each do |receiver|
-      NotificationFacade.mentioned(self, receiver) if sender != receiver
-    end
+  def after_save_mention(new_mentions)
+    notify_users_found_by_mentions(new_mentions)
   end
 
   def new_mention_users
-    names = new_mentions.map { |s| s.gsub(/@/, '') }
-    User.where(login_name: names)
+    find_users_from_login_names(extract_login_names_from_mentions(new_mentions))
   end
 
   def where_mention
@@ -34,6 +25,31 @@ module Mentioner
   end
 
   private
+
+  def notify_users_found_by_mentions(mentions)
+    notify_mentions(find_users_from_mentions(mentions))
+  end
+
+  def notify_mentions(receivers)
+    receivers.each do |receiver|
+      NotificationFacade.mentioned(self, receiver) if sender != receiver
+    end
+  end
+
+  def find_users_from_login_names(names)
+    User.where(login_name: names)
+  end
+
+  def find_users_from_mentions(mentions)
+    names = extract_login_names_from_mentions(mentions)
+    names.concat(User.mentor.map(&:login_name)) if mentions.include?('@mentor')
+    # find_users_from_login_names 内のwhereで重複は削除する
+    find_users_from_login_names(names)
+  end
+
+  def extract_login_names_from_mentions(mentions)
+    mentions.map { |s| s.gsub(/@/, '') }
+  end
 
   def target_of_comment(commentable_class, commentable)
     {

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -2,6 +2,8 @@
 
 module Mentioner
   def after_save_mention(new_mentions)
+    return if instance_of?(Report)
+
     notify_users_found_by_mentions(new_mentions)
   end
 
@@ -22,6 +24,10 @@ module Mentioner
 
   def body
     self[:body] || self[:description]
+  end
+
+  def notify_all_mention_user
+    notify_users_found_by_mentions(mentions)
   end
 
   private

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -30,6 +30,7 @@ class Report < ApplicationRecord
   validates :learning_times, length: { minimum: 1, message: ': 学習時間を入力してください。' }
   validates :emotion, presence: true
 
+  after_save   ReportCallbacks.new
   after_create ReportCallbacks.new
   after_update ReportCallbacks.new
   after_destroy ReportCallbacks.new
@@ -85,6 +86,10 @@ class Report < ApplicationRecord
           .where(user: user)
           .order(:created_at)
           .index(self) + 1
+  end
+
+  def first_public?
+    !wip && published_at.nil?
   end
 
   def set_default_emotion

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -2,7 +2,6 @@
 
 class ReportCallbacks
   def after_save(report)
-    # 何も変更がないsaveの場合はなにもしない
     return unless report.saved_changes?
 
     if report.first_public?

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -44,6 +44,7 @@ class ReportCallbacks
   def notify_users(report)
     notify_advisers(report) if report.user.trainee? && report.user.company_id?
     notify_followers(report)
+    report.notify_all_mention_user
   end
 
   def notify_advisers(report)

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -6,17 +6,8 @@ class ReportCallbacks
 
     send_first_report_notification(report) if report.user.reports.count == 1 && !report.wip?
 
-    if report.user.trainee? && report.user.company_id?
-      report.user.company.advisers.each do |adviser|
-        NotificationFacade.trainee_report(report, adviser)
-        create_advisers_watch(report, adviser)
-      end
-    end
-
-    report.user.followers.each do |follower|
-      NotificationFacade.following_report(report, follower)
-      create_following_watch(report, follower)
-    end
+    notify_advisers(report) if report.user.trainee? && report.user.company_id?
+    notify_followers(report)
 
     Cache.delete_unchecked_report_count
   end
@@ -42,6 +33,20 @@ class ReportCallbacks
     receiver_list = User.where(retired_on: nil)
     receiver_list.each do |receiver|
       NotificationFacade.first_report(report, receiver) if report.sender != receiver
+    end
+  end
+
+  def notify_advisers(report)
+    report.user.company.advisers.each do |adviser|
+      NotificationFacade.trainee_report(report, adviser)
+      create_advisers_watch(report, adviser)
+    end
+  end
+
+  def notify_followers(report)
+    report.user.followers.each do |follower|
+      NotificationFacade.following_report(report, follower)
+      create_following_watch(report, follower)
     end
   end
 

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -7,7 +7,7 @@ class ReportCallbacks
 
     if report.first_public?
       report.update!(published_at: report.updated_at)
-      notify_advisers(report) if report.user.trainee? && report.user.company_id?
+      notify_users(report)
     end
 
     Cache.delete_unchecked_report_count
@@ -17,8 +17,6 @@ class ReportCallbacks
     create_author_watch(report)
 
     send_first_report_notification(report) if report.user.reports.count == 1 && !report.wip?
-
-    notify_followers(report)
   end
 
   def after_update(report)
@@ -41,6 +39,11 @@ class ReportCallbacks
     receiver_list.each do |receiver|
       NotificationFacade.first_report(report, receiver) if report.sender != receiver
     end
+  end
+
+  def notify_users(report)
+    notify_advisers(report) if report.user.trainee? && report.user.company_id?
+    notify_followers(report)
   end
 
   def notify_advisers(report)

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -4,12 +4,12 @@ class ReportCallbacks
   def after_save(report)
     return unless report.saved_changes?
 
-    if report.first_public?
-      report.update!(published_at: report.updated_at)
-      notify_users(report)
-    end
-
     Cache.delete_unchecked_report_count
+
+    return unless report.first_public?
+
+    report.update!(published_at: report.updated_at)
+    notify_users(report)
   end
 
   def after_create(report)

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -5,7 +5,10 @@ class ReportCallbacks
     # 何も変更がないsaveの場合はなにもしない
     return unless report.saved_changes?
 
-    report.update!(published_at: report.updated_at) if report.first_public?
+    if report.first_public?
+      report.update!(published_at: report.updated_at)
+      notify_advisers(report) if report.user.trainee? && report.user.company_id?
+    end
 
     Cache.delete_unchecked_report_count
   end
@@ -15,7 +18,6 @@ class ReportCallbacks
 
     send_first_report_notification(report) if report.user.reports.count == 1 && !report.wip?
 
-    notify_advisers(report) if report.user.trainee? && report.user.company_id?
     notify_followers(report)
   end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,11 +4,13 @@ require 'test_helper'
 require 'supports/login_helper'
 require 'supports/stripe_helper'
 require 'supports/notification_helper'
+require 'supports/report_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include LoginHelper
   include StripeHelper
   include NotificationHelper
+  include ReportHelper
 
   VUEJS_WAIT_SECOND = (ENV['VUEJS_WAIT_SECOND'] || 2).to_i
 

--- a/test/supports/notification_helper.rb
+++ b/test/supports/notification_helper.rb
@@ -13,4 +13,31 @@ module NotificationHelper
   def notification_messages
     all('.test-notification-message').map(&:text)
   end
+
+  # notification_messages.include?(text)
+  # でも可能だが、notification_messagesは
+  # open_notificationを実行した(右上のベルボタンを押した)かで
+  # 戻り値が変更されるため、これを作成
+  def exists_unread_notify?(message)
+    visit unread_index_path
+    wait_for_vuejs # 通知一覧はVueでREST APIを利用して表示しているため
+    exists = page.has_selector?('span.thread-list-item__title-link-label',
+                                text: message)
+    go_back
+    exists
+  end
+
+  def link_to_page_by_unread_notify(message)
+    visit unread_index_path
+    wait_for_vuejs # 通知一覧はVueでREST APIを利用して表示しているため
+    click_link message, class: 'thread-list-item__title-link'
+  end
+
+  def make_write_report_notify_message(user_login_name, report_title)
+    "#{user_login_name}さんが日報【 #{report_title} 】を書きました！"
+  end
+
+  def make_mention_notify_message(writer_login_name)
+    "#{writer_login_name}さんからメンションがきました。"
+  end
 end

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ReportHelper
+  def create_report(title, description, wip)
+    visit new_report_path
+
+    edit_report(title, description)
+
+    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
+    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+
+    click_button(wip ? 'WIP' : '提出')
+
+    # 作成した日報のidを返す
+    Report.last.id
+  end
+
+  def update_report(id, title, description, wip)
+    visit edit_report_path(id)
+
+    edit_report(title, description)
+
+    if wip
+      click_button 'WIP'
+      return
+    end
+
+    # click_buttonでは正規表現使えない
+    click_button(page.has_button?('提出') ? '提出' : '内容変更')
+  end
+
+  def edit_report(title, description)
+    fill_in('report[title]', with: title)
+    fill_in('report[description]', with: description)
+  end
+end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -89,25 +89,20 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     end
   end
 
-  test '研修生が日報を提出したら企業のアドバイザーに通知が飛ぶ' do
-    login_user 'kensyu', 'testtest'
-    visit '/reports/new'
-    within('#new_report') do
-      fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: 'test')
-    end
-
-    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
-    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
-    click_button '提出'
-
-    logout
-
-    login_user 'senpai', 'testtest'
-    open_notification
-    assert_equal 'kensyuさんが日報【 test title 】を書きました！',
-                 notification_message
+  test '研修生が初めて提出した時だけ、企業のアドバイザーに通知する' do
+    kensyu_login_name = 'kensyu'
+    advisor_login_name = 'senpai'
+    title = '研修生が初めて提出した時だけ、'
+    description = 'アドバイザーに通知を飛ばす'
+    notify_message = make_write_report_notify_message(
+      kensyu_login_name, title
+    )
+    assert_notify_only_at_first_published_of_report(
+      notify_message,
+      kensyu_login_name,
+      advisor_login_name,
+      title,
+      description
+    )
   end
 end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -105,4 +105,22 @@ class Notification::ReportsTest < ApplicationSystemTestCase
       description
     )
   end
+
+  test '初めて提出した時だけ、フォローされているユーザーに通知する' do
+    following = Following.first
+    followed_user_login_name = User.find(following.followed_id).login_name
+    follower_user_login_name = User.find(following.follower_id).login_name
+    title = '初めて提出した時だけ'
+    description = 'フォローされているユーザーに通知を飛ばす'
+    notify_message = make_write_report_notify_message(
+      followed_user_login_name, title
+    )
+    assert_notify_only_at_first_published_of_report(
+      notify_message,
+      followed_user_login_name,
+      follower_user_login_name,
+      title,
+      description
+    )
+  end
 end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -123,4 +123,18 @@ class Notification::ReportsTest < ApplicationSystemTestCase
       description
     )
   end
+
+  test '初めて提出した時だけ、メンション通知する' do
+    mention_target_login_name = 'kimura'
+    author_login_name = 'machida'
+    title = '初めて提出したら、'
+    description = "@#{mention_target_login_name} に通知する"
+    assert_notify_only_at_first_published_of_report(
+      make_mention_notify_message(author_login_name),
+      author_login_name,
+      mention_target_login_name,
+      title,
+      description
+    )
+  end
 end


### PR DESCRIPTION
issue
#2092 に対応

ここで記載している "初めて日報を提出した時" は、 "初日報(1個目の日報)を提出した時" ではないです。

## 概要

次の日報に関する通知が、WIPの状態関係なく通知するようになっていたため、その日報を初めて提出した時に通知を送信するように修正しました。

* メンション(f7886bc)
   日報作成・更新時に新しいメンションがあったら通知をしていました。
* フォロワー(efec0f8)
  日報作成時に通知をしていました。
* アドバイザー(研修生のみ)(ea86560)
  日報作成時に通知をしていました。

`()`内の数値は修正したコミットへのリンクです。

### 例

1. 日報をWIPで作成
2. 日報を提出する(初提出)
3. 日報をWIPに戻す
4. 日報を提出する

手順4のときは通知せず、手順2のときだけ通知します。

## 修正内容

日報が初めて提出されたかを判定する関数を作成し、それが `true` なら通知を送信するように修正しました。

### 修正前

メンションは、日報作成・更新時にWIPの状態関係なく、追加されたメンションユーザーに通知していました。

<details><summary>該当コード</summary>

https://github.com/fjordllc/bootcamp/blob/ef5b07b58347b93c31d55bc7cd8c3553e6697e07/app/models/concerns/mentioner.rb#L4-L14

</details>

フォロワーとアドバイザーは、日報作成時にWIPの状態関係なく、通知していました。

<details><summary>該当コード</summary>

https://github.com/fjordllc/bootcamp/blob/ef5b07b58347b93c31d55bc7cd8c3553e6697e07/app/models/report_callbacks.rb#L9-L19

</details>

## 修正理由

日報が完成していない、WIPの時点で通知されることがあり、不便でした。

## Viewの変更部分のgif

修正後のみです。修正前の動画はとっていません。

<details open><summary>メンション</summary>

![mention](https://user-images.githubusercontent.com/43565959/112301470-52381400-8cdd-11eb-8ddc-b6e48f0e465d.gif)

</details>

<details open><summary>フォロワー</summary>

![follow](https://user-images.githubusercontent.com/43565959/112301468-5106e700-8cdd-11eb-8171-6e268c9e577a.gif)

</details>

<details open><summary>アドバイザー</summary>

![adoviser](https://user-images.githubusercontent.com/43565959/112301457-4e0bf680-8cdd-11eb-8420-fe0941a14f40.gif)

</details>