### PR TITLE
イベントを検索できるようにする

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -47,11 +47,10 @@
   display: flex
   align-items: center
   justify-content: center
-  +text-block(.75rem 1.3, center 600)
-  padding: .25rem
+  +text-block(.625rem 1.3, center 600)
+  padding: .5em
   +media-breakpoint-down(sm)
-    +size(2.25rem)
-    font-size: .625rem
+    +size(2.5rem)
   .thread-list-item.is-report &
     background-color: #7f6fb7
     color: $reversal-text
@@ -67,6 +66,12 @@
   .thread-list-item.is-announcement &
     background-color: #f7cd5b
     color: $default-text
+  .thread-list-item.is-event &
+    background-color: #ef9da8
+    color: $reversal-text
+  .thread-list-item.is-product &
+    background-color: #909b3c
+    color: $reversal-text
 
 .thread-list-item__author
   +position(absolute, left 0, top 0)

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -48,7 +48,6 @@
   align-items: center
   justify-content: center
   +text-block(.625rem 1.3, center 600)
-  padding: .5em
   +media-breakpoint-down(sm)
     +size(2.5rem)
   .thread-list-item.is-report &

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,6 +6,7 @@ class Event < ApplicationRecord
   include Footprintable
   include Reactionable
   include Watchable
+  include Searchable
 
   validates :title, presence: true
   validates :description, presence: true
@@ -38,6 +39,8 @@ class Event < ApplicationRecord
   has_many :participations, dependent: :destroy
   has_many :users, through: :participations
   has_many :watches, as: :watchable, dependent: :destroy
+
+  columns_for_keyword_search :title, :description
 
   def opening?
     Time.current.between?(open_start_at, open_end_at)

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -7,7 +7,8 @@ class Searcher
     ['プラクティス', :practices],
     ['日報', :reports],
     ['Q&A', :questions],
-    ['Docs', :pages]
+    ['Docs', :pages],
+    ['イベント', :events]
   ].freeze
 
   AVAILABLE_TYPES = DOCUMENT_TYPES.map(&:second) - %i[all] + %i[comments answers]

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -84,3 +84,8 @@ comment15:
   commentable: report4 (Report)
   description: ":thumbsup:"
   created_at: "2019-01-02 12:00:01"
+
+comment16:
+  user: yamada
+  commentable: event1 (Event)
+  description: "テスト用 event1へのコメント"

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -65,3 +65,14 @@ event6:
   open_start_at: 2019-12-10 9:00
   open_end_at: 2019-12-16 9:00
   user: komagata
+
+event7:
+  title: "テストのイベント"
+  description: "テストのイベントです。"
+  location: "FJORDオフィス"
+  capacity: 10
+  start_at: 2019-12-17 10:00:00
+  end_at: 2019-12-17 12:00:00
+  open_start_at: 2019-12-10 9:00
+  open_end_at: 2019-12-16 9:00
+  user: komagata

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -10,6 +10,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Practice)
     assert_includes(result, Question)
     assert_includes(result, Announcement)
+    assert_includes(result, Event)
     assert_includes(result, Comment)
     assert_includes(result, Answer)
   end
@@ -21,6 +22,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Practice)
     assert_includes(result, Question)
     assert_includes(result, Announcement)
+    assert_includes(result, Event)
     assert_includes(result, Comment)
     assert_includes(result, Answer)
   end
@@ -32,6 +34,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Practice)
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
+    assert_not_includes(result, Event)
     assert_includes(result, Comment)
     assert_not_includes(result, Answer)
   end
@@ -43,6 +46,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Practice)
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
+    assert_not_includes(result, Event)
     assert_not_includes(result, Comment)
     assert_not_includes(result, Answer)
   end
@@ -54,6 +58,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, Practice)
     assert_not_includes(result, Question)
     assert_not_includes(result, Announcement)
+    assert_not_includes(result, Event)
     assert_not_includes(result, Comment)
     assert_not_includes(result, Answer)
   end
@@ -65,6 +70,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Practice)
     assert_includes(result, Question)
     assert_not_includes(result, Announcement)
+    assert_not_includes(result, Event)
     assert_not_includes(result, Comment)
     assert_includes(result, Answer)
   end
@@ -76,6 +82,18 @@ class SearchableTest < ActiveSupport::TestCase
     assert_not_includes(result, Practice)
     assert_not_includes(result, Question)
     assert_includes(result, Announcement)
+    assert_not_includes(result, Event)
+    assert_includes(result, Comment)
+  end
+
+  test 'returns only event type when document_type argument is :events' do
+    result = Searcher.search('テスト', document_type: :events).map(&:class)
+    assert_not_includes(result, Report)
+    assert_not_includes(result, Page)
+    assert_not_includes(result, Practice)
+    assert_not_includes(result, Question)
+    assert_not_includes(result, Announcement)
+    assert_includes(result, Event)
     assert_includes(result, Comment)
   end
 
@@ -196,7 +214,8 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, comments(:comment12))
     assert_includes(result, comments(:comment13))
     assert_includes(result, comments(:comment14))
-    assert_equal(6, result.size)
+    assert_includes(result, comments(:comment16))
+    assert_equal(7, result.size)
   end
 
   test 'returns only daimyos report when user param' do

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -16,8 +16,10 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_text 'Unityでのテスト'
     assert_text 'テストの質問1'
     assert_text 'テストのお知らせ'
+    assert_text 'テストのイベント'
     assert_text 'テスト用 report1へのコメント'
     assert_text 'テスト用 announcement1へのコメント'
+    assert_text 'テスト用 event1へのコメント'
     assert_text 'テストの回答'
   end
 
@@ -32,8 +34,26 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_no_text 'Unityでのテスト'
     assert_no_text 'テストの質問1'
     assert_no_text 'テストのお知らせ'
+    assert_no_text 'テストのイベント'
     assert_text 'テスト用 report1へのコメント'
     assert_no_text 'テスト用 announcement1へのコメント'
+    assert_no_text 'テスト用 event1へのコメント'
+  end
+
+  test 'search events' do
+    within('form[name=search]') do
+      select 'イベント'
+      fill_in 'word', with: 'テスト'
+    end
+    find('#test-search').click
+    assert_text 'テストのイベント'
+    assert_no_text 'Docsページ'
+    assert_no_text 'Unityでのテスト'
+    assert_no_text 'テストの質問1'
+    assert_no_text 'テストのお知らせ'
+    assert_no_text 'テスト用 report1へのコメント'
+    assert_no_text 'テスト用 announcement1へのコメント'
+    assert_text 'テスト用 event1へのコメント'
   end
 
   test 'admin can see comment description' do


### PR DESCRIPTION
## issue
https://github.com/fjordllc/bootcamp/issues/2375 に対応

## 概要
「お知らせ」や「プラクティス」のように、「イベント」も選択して検索できるようにしました。

## スクショ

- 「イベント」を選択し「ミートアップ」で検索

![image](https://user-images.githubusercontent.com/62986803/112133636-3cf4b400-8c0f-11eb-96b3-e6568f010544.png)
