### PR TITLE
日報の個別ページの確認ボタンが右にずれる問題を修正

### DIFF
--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -2,7 +2,7 @@
   .card-footer
     .card-main-actions
       ul.card-main-actions__items
-        li.card-main-actions__item
+        li.card-main-actions__item(v-if="checkableType === 'Product'")
           //
             v-showではなくv-ifだと "提出物を確認" => "取り消し" した際、
             担当ボタンの表示はページ読み込み時に戻る。
@@ -14,7 +14,7 @@
             checkerIdの値がページ読み込み時の値のままではなく、
             現状のcheckerIdを参照すれば、v-ifでも大丈夫と推測
           //-
-          product-checker(v-show="checkableType === 'Product' && checkId === null", :checkerId="checkerId", :checkerName="checkerName", :currentUserId="currentUserId", :productId="checkableId")
+          product-checker(v-show="checkId === null", :checkerId="checkerId", :checkerName="checkerName", :currentUserId="currentUserId", :productId="checkableId")
         li.card-main-actions__item
           button#js-shortcut-check.thread-check-form__action.is-block(:class=" checkId ? 'is-text' : 'a-button is-md is-danger' " @click="check")
             i.fas.fa-check

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -49,8 +49,8 @@
         h2.stamp__content.is-title 確認済
         time.stamp__content.is-created-at {{ product.checks.last_created_at }}
         .stamp__content.is-user-name {{ product.checks.last_user_login_name }}
-      .thread-list-item__assignee
-        product-checker(v-if="isMentor && product.checks.size == 0" :checkerId="product.checker_id", :checkerName="product.checker_name", :currentUserId="currentUserId", :productId="product.id")
+      .thread-list-item__assignee(v-if="isMentor && product.checks.size == 0")
+        product-checker(:checkerId="product.checker_id", :checkerName="product.checker_name", :currentUserId="currentUserId", :productId="product.id")
 </template>
 <script>
 import ProductChecker from './product_checker'


### PR DESCRIPTION
issue
#2493 に対応

## 概要

日報の個別ページの確認ボタンが右にずれて表示される。これを真ん中に表示されるように修正する。

## 修正内容

日報の個別ページ内に、担当ボタンを表示する部分の `li` が存在している(非表示になっている)のが右にずれる原因のため、これを削除する。
`li` を削除すると、確認ボタンが真ん中に表示されるようになる。

### 修正前

`v-show` で担当ボタンは非表示になっていたが、 `li` 部分はいつも表示したままだった。

https://github.com/fjordllc/bootcamp/blob/b5157cd95345f3f954eed4685dd48b5b1c498398/app/javascript/check.vue#L4-L16


## 修正理由

デザインがずれるから

## Viewの変更部分のスクリーンショット


<details open><summary>修正前</summary>

![before](https://user-images.githubusercontent.com/43565959/112590244-dc02f100-8e45-11eb-9967-6f353d2f0890.png)

</details>

<details open><summary>修正後</summary>

![after](https://user-images.githubusercontent.com/43565959/112590091-980fec00-8e45-11eb-8289-96f78defab6f.png)

</details>

## DOMの変化

### 修正前

```HTML
<ul class="thread-admin-tools__items">
    <li class="thread-admin-tools__item"><button class="a-button is-sm is-block is-secondary" style="display: none;"><i class="fas fa-hand-paper"></i>担当する</button></li>
    <li class="thread-admin-tools__item"><button id="js-shortcut-check" class="thread-check-form__action is-block a-button is-md is-danger"><i class="fas fa-check"></i>日報を確認</button></li>
</ul>
```

```HTML
<li class="thread-admin-tools__item"><button class="a-button is-sm is-block is-secondary" style="display: none;"><i class="fas fa-hand-paper"></i>担当する</button></li>
```

があるため、確認ボタンが右にずれていた。

### 修正後

```HTML
<ul class="thread-admin-tools__items">
    <!---->
    <li class="thread-admin-tools__item"><button id="js-shortcut-check" class="thread-check-form__action is-block a-button is-md is-danger"><i class="fas fa-check"></i>日報を確認</button></li>
</ul>
```

修正前と違い

```HTML
    <li class="thread-admin-tools__item"><button class="a-button is-sm is-block is-secondary" style="display: none;"><i class="fas fa-hand-paper"></i>担当する</button></li>
```

が  `<!--->` に変更されている。