### PR TITLE
提出物のページでコメントが表示されるまでの間、「ローディング中」を表示させる。

### DIFF
--- a/app/assets/stylesheets/atoms/_a-placeholder.sass
+++ b/app/assets/stylesheets/atoms/_a-placeholder.sass
@@ -1,0 +1,32 @@
+@keyframes loadingNow
+  0%
+    opacity: .6
+  100%
+    opacity: 1
+
+.a-placeholder
+  $placeholder: rgba(black, .075)
+  background-color: $placeholder
+  animation: loadingNow .75s ease infinite alternate
+  &.a-user-icon
+    background-color: $placeholder
+  &.is-long-text
+    background-color: transparent
+    p
+      background-color: $placeholder
+      height: 1.2em
+      margin-bottom: 0
+      &:not(:first-child)
+        margin-top: .5em
+      &:nth-child(1)
+        width: 70%
+      &:nth-child(2)
+        width: 100%
+      &:nth-child(3)
+        width: 100%
+      &:nth-child(4)
+        width: 80%
+      &:nth-child(5)
+        width: 60%
+      &:nth-child(7)
+        width: 20%

--- a/app/assets/stylesheets/blocks/thread/_thread-comments.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-comments.sass
@@ -28,11 +28,10 @@ $thread-header-author: 3.5rem
 .thread-comment__title
   +text-block(1rem 1.4)
   margin-right: .5rem
+  width: 100%
   +media-breakpoint-down(sm)
     +text-block(.875rem 1.4 0 .25rem)
     margin-right: 0
-  &
-    font-size: .9375rem
 
 .thread-comment__title-link
   color: $main
@@ -41,6 +40,9 @@ $thread-header-author: 3.5rem
   align-items: center
   .thread-comment__title.is-user-comments &
     +hover-link
+  &.a-placeholder
+    width: 15%
+    height: 1.4em
 
 .thread-comment__title-icon
   +size(1.5rem)
@@ -130,6 +132,9 @@ $thread-header-author: 3.5rem
       padding: .25rem
       +text-block(.625rem 1, $reversal-text)
       +position(absolute, left 0, top 100%)
+  &.a-placeholder
+    width: 30%
+    height: 1.4em
 
 .thread-comment__actions
   +padding(vertical, 0 1rem)

--- a/app/javascript/comment-placeholder.vue
+++ b/app/javascript/comment-placeholder.vue
@@ -1,0 +1,19 @@
+<template lang="pug">
+.thread-comment
+  .thread-comment__author
+    .thread-comment__author-icon.a-user-icon.a-placeholder
+  .thread-comment__body.a-card
+    .thread-comment__body-header
+      .thread-comment__title
+        .thread-comment__title-link.a-placeholder
+      .thread-comment__created-at.a-placeholder
+    .thread-comment__description.is-long-text.a-placeholder
+      p
+      p
+      p
+      p
+      p
+      p
+</template>
+
+<script></script>

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -130,7 +130,7 @@ export default {
         console.warn('Failed to parsing', error)
       })
   },
-  mounted() {
+  updated() {
     TextareaInitializer.initialize('#js-new-comment')
     this.setDefaultTextareaSize()
   },

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -1,53 +1,6 @@
 <template lang="pug">
 .thread-comments(v-if='loaded === false && commentableType === "Product"')
-  .thread-comment
-    .thread-comment__author
-      .thread-comment__author-icon.a-user-icon.a-placeholder
-    .thread-comment__body.a-card
-      .thread-comment__body-header
-        .thread-comment__title
-          .thread-comment__title-link.a-placeholder
-        .thread-comment__created-at.a-placeholder
-      .thread-comment__description.is-long-text.a-placeholder
-        p
-        p
-        p
-        p
-        p
-        p
-
-  .thread-comment
-    .thread-comment__author
-      .thread-comment__author-icon.a-user-icon.a-placeholder
-    .thread-comment__body.a-card
-      .thread-comment__body-header
-        .thread-comment__title
-          .thread-comment__title-link.a-placeholder
-        .thread-comment__created-at.a-placeholder
-      .thread-comment__description.is-long-text.a-placeholder
-        p
-        p
-        p
-        p
-        p
-        p
-
-  .thread-comment
-    .thread-comment__author
-      .thread-comment__author-icon.a-user-icon.a-placeholder
-    .thread-comment__body.a-card
-      .thread-comment__body-header
-        .thread-comment__title
-          .thread-comment__title-link.a-placeholder
-        .thread-comment__created-at.a-placeholder
-      .thread-comment__description.is-long-text.a-placeholder
-        p
-        p
-        p
-        p
-        p
-        p
-
+  commentPlaceholder(v-for='num in placeholderCount', :key='num')
 .thread-comments(v-else)
   comment(
     v-for='(comment, index) in comments',
@@ -111,10 +64,12 @@
 <script>
 import Comment from './comment.vue'
 import TextareaInitializer from './textarea-initializer'
+import CommentPleaceholder from './comment-placeholder'
 
 export default {
   components: {
-    comment: Comment
+    comment: Comment,
+    commentPlaceholder: CommentPleaceholder
   },
   props: {
     commentableId: { type: String, required: true },
@@ -129,7 +84,8 @@ export default {
       tab: 'comment',
       buttonDisabled: false,
       defaultTextareaSize: null,
-      loaded: false
+      loaded: false,
+      placeholderCount: 3
     }
   },
   computed: {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -1,112 +1,112 @@
 <template lang="pug">
-  .thread-comments(v-if="loaded === false && commentableType === 'Product'")
-    .thread-comment
-      .thread-comment__author
-        .thread-comment__author-icon.a-user-icon.a-placeholder
-      .thread-comment__body.a-card
-        .thread-comment__body-header
-          .thread-comment__title
-            .thread-comment__title-link.a-placeholder
-          .thread-comment__created-at.a-placeholder
-        .thread-comment__description.is-long-text.a-placeholder
-          p
-          p
-          p
-          p
-          p
-          p
+.thread-comments(v-if='loaded === false && commentableType === "Product"')
+  .thread-comment
+    .thread-comment__author
+      .thread-comment__author-icon.a-user-icon.a-placeholder
+    .thread-comment__body.a-card
+      .thread-comment__body-header
+        .thread-comment__title
+          .thread-comment__title-link.a-placeholder
+        .thread-comment__created-at.a-placeholder
+      .thread-comment__description.is-long-text.a-placeholder
+        p
+        p
+        p
+        p
+        p
+        p
 
-    .thread-comment
-      .thread-comment__author
-        .thread-comment__author-icon.a-user-icon.a-placeholder
-      .thread-comment__body.a-card
-        .thread-comment__body-header
-          .thread-comment__title
-            .thread-comment__title-link.a-placeholder
-          .thread-comment__created-at.a-placeholder
-        .thread-comment__description.is-long-text.a-placeholder
-          p
-          p
-          p
-          p
-          p
-          p
+  .thread-comment
+    .thread-comment__author
+      .thread-comment__author-icon.a-user-icon.a-placeholder
+    .thread-comment__body.a-card
+      .thread-comment__body-header
+        .thread-comment__title
+          .thread-comment__title-link.a-placeholder
+        .thread-comment__created-at.a-placeholder
+      .thread-comment__description.is-long-text.a-placeholder
+        p
+        p
+        p
+        p
+        p
+        p
 
-    .thread-comment
-      .thread-comment__author
-        .thread-comment__author-icon.a-user-icon.a-placeholder
-      .thread-comment__body.a-card
-        .thread-comment__body-header
-          .thread-comment__title
-            .thread-comment__title-link.a-placeholder
-          .thread-comment__created-at.a-placeholder
-        .thread-comment__description.is-long-text.a-placeholder
-          p
-          p
-          p
-          p
-          p
-          p
+  .thread-comment
+    .thread-comment__author
+      .thread-comment__author-icon.a-user-icon.a-placeholder
+    .thread-comment__body.a-card
+      .thread-comment__body-header
+        .thread-comment__title
+          .thread-comment__title-link.a-placeholder
+        .thread-comment__created-at.a-placeholder
+      .thread-comment__description.is-long-text.a-placeholder
+        p
+        p
+        p
+        p
+        p
+        p
 
-  .thread-comments(v-else)
-    comment(
-      v-for='(comment, index) in comments',
-      :key='comment.id',
-      :comment='comment',
-      :currentUser='currentUser',
-      :id='"comment_" + comment.id',
-      @delete='deleteComment'
-    )
-    .thread-comment-form
-      .thread-comment__author
-        img.thread-comment__author-icon.a-user-icon(
-          :src='currentUser.avatar_url',
-          :class='[roleClass, daimyoClass]',
-          :title='currentUser.icon_title'
+.thread-comments(v-else)
+  comment(
+    v-for='(comment, index) in comments',
+    :key='comment.id',
+    :comment='comment',
+    :currentUser='currentUser',
+    :id='"comment_" + comment.id',
+    @delete='deleteComment'
+  )
+  .thread-comment-form
+    .thread-comment__author
+      img.thread-comment__author-icon.a-user-icon(
+        :src='currentUser.avatar_url',
+        :class='[roleClass, daimyoClass]',
+        :title='currentUser.icon_title'
+      )
+    .thread-comment-form__form.a-card
+      .thread-comment-form__tabs.js-tabs
+        .thread-comment-form__tab.js-tabs__tab(
+          :class='{ "is-active": isActive("comment") }',
+          @click='changeActiveTab("comment")'
         )
-      .thread-comment-form__form.a-card
-        .thread-comment-form__tabs.js-tabs
-          .thread-comment-form__tab.js-tabs__tab(
-            :class='{ "is-active": isActive("comment") }',
-            @click='changeActiveTab("comment")'
+          | コメント
+        .thread-comment-form__tab.js-tabs__tab(
+          :class='{ "is-active": isActive("preview") }',
+          @click='changeActiveTab("preview")'
+        )
+          | プレビュー
+      .thread-comment-form__markdown-parent.js-markdown-parent
+        .thread-comment-form__markdown.js-tabs__content(
+          :class='{ "is-active": isActive("comment") }'
+        )
+          textarea#js-new-comment.a-text-input.js-warning-form.thread-comment-form__textarea(
+            v-model='description',
+            name='new_comment[description]',
+            data-preview='#new-comment-preview'
           )
-            | コメント
-          .thread-comment-form__tab.js-tabs__tab(
-            :class='{ "is-active": isActive("preview") }',
-            @click='changeActiveTab("preview")'
-          )
-            | プレビュー
-        .thread-comment-form__markdown-parent.js-markdown-parent
-          .thread-comment-form__markdown.js-tabs__content(
-            :class='{ "is-active": isActive("comment") }'
-          )
-            textarea#js-new-comment.a-text-input.js-warning-form.thread-comment-form__textarea(
-              v-model='description',
-              name='new_comment[description]',
-              data-preview='#new-comment-preview'
-            )
-          .thread-comment-form__markdown.js-tabs__content(
-            :class='{ "is-active": isActive("preview") }'
-          )
-            #new-comment-preview.is-long-text.thread-comment-form__preview
-        .card-footer
-          .card-main-actions
-            .card-main-actions__items
-              .card-main-actions__item
-                button#js-shortcut-post-comment.a-button.is-md.is-primary.is-block(
-                  @click='createComment',
-                  :disabled='!validation || buttonDisabled'
-                )
-                  | コメントする
-              .card-main-actions__item(
-                v-if='(currentUser.role == "admin" || currentUser.role == "adviser") && commentType && !checkId'
+        .thread-comment-form__markdown.js-tabs__content(
+          :class='{ "is-active": isActive("preview") }'
+        )
+          #new-comment-preview.is-long-text.thread-comment-form__preview
+      .card-footer
+        .card-main-actions
+          .card-main-actions__items
+            .card-main-actions__item
+              button#js-shortcut-post-comment.a-button.is-md.is-primary.is-block(
+                @click='createComment',
+                :disabled='!validation || buttonDisabled'
               )
-                button.a-button.is-md.is-danger.is-block(
-                  @click='commentAndCheck',
-                  :disabled='!validation || buttonDisabled'
-                )
-                  i.fas.fa-check
-                  | 確認OKにする
+                | コメントする
+            .card-main-actions__item(
+              v-if='(currentUser.role == "admin" || currentUser.role == "adviser") && commentType && !checkId'
+            )
+              button.a-button.is-md.is-danger.is-block(
+                @click='commentAndCheck',
+                :disabled='!validation || buttonDisabled'
+              )
+                i.fas.fa-check
+                | 確認OKにする
 </template>
 <script>
 import Comment from './comment.vue'
@@ -129,7 +129,7 @@ export default {
       tab: 'comment',
       buttonDisabled: false,
       defaultTextareaSize: null,
-      loaded: false,
+      loaded: false
     }
   },
   computed: {
@@ -164,8 +164,10 @@ export default {
       .then((response) => {
         return response.json()
       })
-      .then(json => {
-        json.forEach(c => { this.comments.push(c) });
+      .then((json) => {
+        json.forEach((c) => {
+          this.comments.push(c)
+        })
         this.loaded = true
       })
       .catch((error) => {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -1,7 +1,54 @@
 <template lang="pug">
-.thread-comments-container
-  h2.thread-comments-container__title コメント
-  .thread-comments
+  .thread-comments(v-if="loaded === false && commentableType === 'Product'")
+    .thread-comment
+      .thread-comment__author
+        .thread-comment__author-icon.a-user-icon.a-placeholder
+      .thread-comment__body.a-card
+        .thread-comment__body-header
+          .thread-comment__title
+            .thread-comment__title-link.a-placeholder
+          .thread-comment__created-at.a-placeholder
+        .thread-comment__description.is-long-text.a-placeholder
+          p
+          p
+          p
+          p
+          p
+          p
+
+    .thread-comment
+      .thread-comment__author
+        .thread-comment__author-icon.a-user-icon.a-placeholder
+      .thread-comment__body.a-card
+        .thread-comment__body-header
+          .thread-comment__title
+            .thread-comment__title-link.a-placeholder
+          .thread-comment__created-at.a-placeholder
+        .thread-comment__description.is-long-text.a-placeholder
+          p
+          p
+          p
+          p
+          p
+          p
+
+    .thread-comment
+      .thread-comment__author
+        .thread-comment__author-icon.a-user-icon.a-placeholder
+      .thread-comment__body.a-card
+        .thread-comment__body-header
+          .thread-comment__title
+            .thread-comment__title-link.a-placeholder
+          .thread-comment__created-at.a-placeholder
+        .thread-comment__description.is-long-text.a-placeholder
+          p
+          p
+          p
+          p
+          p
+          p
+
+  .thread-comments(v-else)
     comment(
       v-for='(comment, index) in comments',
       :key='comment.id',
@@ -81,7 +128,8 @@ export default {
       description: '',
       tab: 'comment',
       buttonDisabled: false,
-      defaultTextareaSize: null
+      defaultTextareaSize: null,
+      loaded: false,
     }
   },
   computed: {
@@ -116,10 +164,9 @@ export default {
       .then((response) => {
         return response.json()
       })
-      .then((json) => {
-        json.forEach((c) => {
-          this.comments.push(c)
-        })
+      .then(json => {
+        json.forEach(c => { this.comments.push(c) });
+        this.loaded = true
       })
       .catch((error) => {
         console.warn('Failed to parsing', error)


### PR DESCRIPTION
#2465
のisuueに対応

### 概要
提出物のページのコメント欄にローディング中を表示させる。

### 実装理由
提出物のページのコメントを表示させるのに時間がかかる為、その間不安にさせないようにローディングを表示させる。

### 実装方針
提出物の個別ページのコメント欄にだけ表示させる。
その為`commentableType === 'Product'`の条件分岐を加えて提出物だけに表示されるようにしている。
productsやreportsで既に実装されているローディングを参考に実装。

<details><summary>実装前のスクショ</summary><div>

[![Image from Gyazo](https://i.gyazo.com/ce2c49b1381ee73593b14765cc5d6a2b.gif)](https://gyazo.com/ce2c49b1381ee73593b14765cc5d6a2b)

</div></details>

#### 実装後のスクショ
[![Image from Gyazo](https://i.gyazo.com/0b3b109a662709edb9fb2d55a5329982.gif)](https://gyazo.com/0b3b109a662709edb9fb2d55a5329982)