### PR TITLE
bundle update mimemagic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN apk add --no-cache imagemagick bash pngcrush optipng=0.7.7-r0 ghostscript-fo
 COPY package.json yarn.lock ./
 RUN yarn install --production --ignore-engines
 
+# mimemagic
+RUN apk add --no-cache shared-mime-info
+
 # Install gems
 COPY Gemfile Gemfile.lock ./
 RUN CFLAGS="-Wno-cast-function-type" BUNDLE_BUILD__SASSC="--disable-march-tune-native" BUNDLE_FORCE_RUBY_PLATFORM=1 bundle install -j4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,9 @@ GEM
     meta-tags (2.14.0)
       actionpack (>= 3.2.0, < 6.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -502,6 +504,7 @@ DEPENDENCIES
   listen (~> 3.2)
   mentionable (~> 0.2)
   meta-tags
+  mimemagic (~> 0.3.9)
   oauth2
   omniauth (~> 1.9.1)
   omniauth-github (~> 1.4.0)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 ## インストール
 
+### 依存ライブラリ
+
+mimemagic をインストールするために `shared-mime-info` が必要です。
+macOS の場合は、 `brew install shared-mime-info` でインストールできます。
+
+### セットアップ
+
 ```
 $ bin/setup
 $ rails server


### PR DESCRIPTION
mimemagic 0.3.5 は yank されたためローカルで bundle install ができなくなっています。そのため、 bundle update mimemagic しました。
それに伴い、shared-mime-infoのインストールが必須となったためREADMEに追記しました。

参考：https://hackmd.io/@mametter/mimemagic-info-ja