### PR TITLE
他人の提出物が見れる人でもページネーションにより移動してしまうと注意文が表示されてしまう現象の修正

### DIFF
--- a/app/assets/stylesheets/blocks/page/_page-notice.sass
+++ b/app/assets/stylesheets/blocks/page/_page-notice.sass
@@ -4,11 +4,17 @@
     +margin(vertical, -.5rem 1rem)
   .page-tools + &
     margin-top: -1px
+  .page-tabs + &
+    margin-top: 1rem
 
 .page-notice__inner
   +padding(vertical, .5rem)
   p
-    +text-block(.875rem 1.4, $reversal-text center)
+    +text-block(1em 1.4, $reversal-text center)
+    +media-breakpoint-up(md)
+      font-size: .875rem
+    +media-breakpoint-down(sm)
+      font-size: .75rem
   a
     color: $reversal-text
     +hover-link-reversal

--- a/app/controllers/practices/products_controller.rb
+++ b/app/controllers/practices/products_controller.rb
@@ -15,6 +15,6 @@ class Practices::ProductsController < ApplicationController
                 .where(practice: @practice)
                 .order(created_at: :desc)
                 .page(params[:page])
-    @my_product = @products.find_by(user: current_user)
+    @my_product = Product.where(practice: @practice).find_by(user: current_user)
   end
 end

--- a/app/views/practices/products/index.html.slim
+++ b/app/views/practices/products/index.html.slim
@@ -16,8 +16,10 @@ header.page-header
 = render 'page_tabs', resource: @practice
 
 - if current_user.student_or_trainee? && !@practice.open_product? && (@my_product.nil? || @my_product.checks.empty?)
-  div
-    p プラクティスを完了するまで他の人の提出物は見れません。
+  .page-notice
+    .container
+      .page-notice__inner
+        p プラクティスを完了するまで他の人の提出物は見れません。
 
 .page-body
   .container

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -37,6 +37,12 @@ header.page-header
               span.thread-header__title-icon.is-solved.is-danger
                 | 未解決
             = @question.title
+            - if @question.answers.present?
+              .thread-list-item-meta__comment-count
+                .thread-list-item-meta__comment-count-label
+                  i.fas.fa-comment
+                .thread-list-item-meta__comment-count-value
+                  = @question.answers.size
           .thread-header__lower-side
             #js-watch(data-watchable-id="#{@question.id}", data-watchable-type='Question')
             .thread-header__raw


### PR DESCRIPTION
#2502
isuueに対応

### 概要
現在提出物のページで他人の提出物が見れない人には注意文が表示される。
しかし、他人の提出物が見れる人でもページネーションにより移動してしまうと注意文が表示されてしまう。

### 期待される振る舞い
ページネーションによりページを移動させても、他の提出物が見れる人には警告文が表示されない。

### バグの原因
ログインしているユーザーの提出物をページネーションされたものから探すようにしていた為、
ページネーションによりページ移動すると@my_productがnilになってしまうことが原因。

/app/controllers/practices/products_controller.rb
```
  @products = Product
                .includes(
                  :practice,
                  :comments,
                  :checks,
                  user: [:company, { avatar_attachment: :blob }]
                )
                .where(practice: @practice)
                .order(created_at: :desc)
                .page(params[:page])
    @my_product = @products.find_by(user: current_user)
```

### 修正後のスクショ
[![Image from Gyazo](https://i.gyazo.com/b462e24d049147a44f34822845c2e8c0.gif)](https://gyazo.com/b462e24d049147a44f34822845c2e8c0)

### 関連issue
#2364
