### PR TITLE
担当になるボタンを表示するページでサイズを選択できるようにしたい

### DIFF
--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -13,7 +13,7 @@
           checkerIdの値がページ読み込み時の値のままではなく、
           現状のcheckerIdを参照すれば、v-ifでも大丈夫と推測
         //-
-        product-checker(v-show="checkableType === 'Product' && checkId === null", :checkerId="checkerId", :checkerName="checkerName", :currentUserId="currentUserId", :productId="checkableId",:checkableType="checkableType",)
+        product-checker(v-show="checkableType === 'Product' && checkId === null", :checkerId="checkerId", :checkerName="checkerName", :currentUserId="currentUserId", :productId="checkableId",:checkableType="checkableType")
       li.thread-admin-tools__item
         button#js-shortcut-check.thread-check-form__action.is-block(:class=" checkId ? 'is-text' : 'a-button is-md is-danger' " @click="check")
           i.fas.fa-check
@@ -24,7 +24,7 @@ import 'whatwg-fetch'
 import ProductChecker from './product_checker'
 
 export default {
-  props: ['checkableId', 'checkableType', 'checkableLabel', 'checkerId', 'checkerName', 'currentUserId','checkableType',],
+  props: ['checkableId', 'checkableType', 'checkableLabel', 'checkerId', 'checkerName', 'currentUserId'],
   components: {
     'product-checker': ProductChecker,
   },

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -13,7 +13,7 @@
           checkerIdの値がページ読み込み時の値のままではなく、
           現状のcheckerIdを参照すれば、v-ifでも大丈夫と推測
         //-
-        product-checker(v-show="checkableType === 'Product' && checkId === null", :checkerId="checkerId", :checkerName="checkerName", :currentUserId="currentUserId", :productId="checkableId")
+        product-checker(v-show="checkableType === 'Product' && checkId === null", :checkerId="checkerId", :checkerName="checkerName", :currentUserId="currentUserId", :productId="checkableId",:checkableType="checkableType",)
       li.thread-admin-tools__item
         button#js-shortcut-check.thread-check-form__action.is-block(:class=" checkId ? 'is-text' : 'a-button is-md is-danger' " @click="check")
           i.fas.fa-check
@@ -24,7 +24,7 @@ import 'whatwg-fetch'
 import ProductChecker from './product_checker'
 
 export default {
-  props: ['checkableId', 'checkableType', 'checkableLabel', 'checkerId', 'checkerName', 'currentUserId'],
+  props: ['checkableId', 'checkableType', 'checkableLabel', 'checkerId', 'checkerName', 'currentUserId','checkableType',],
   components: {
     'product-checker': ProductChecker,
   },

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-    button(v-if="!checkerId || checkerId == currentUserId" :class="['a-button', 'is-sm', 'is-block', id ? 'is-warning' : 'is-secondary']" @click="check")
+    button(v-if="!checkerId || checkerId == currentUserId" :class="['a-button', 'is-block', id ? 'is-warning' : 'is-secondary' ,checkableType? 'is-md' : 'is-sm']" @click="check")
       i(v-if="!checkerId || checkerId == currentUserId" :class="['fas', id ? 'fa-times' : 'fa-hand-paper']" @click="check")
       | {{ buttonLabel }}
     .a-button.is-sm.is-block.thread-list-item__assignee-name(v-else)
@@ -8,7 +8,7 @@
 </template>
 <script>
 export default {
-  props: ['checkerId', 'checkerName', 'currentUserId', 'productId'],
+  props: ['checkerId', 'checkerName', 'currentUserId', 'productId','checkableType'],
   data () {
     return {
       id: this.checkerId,


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/issues/2483
に対応

## 概要
メンターでログインしたとき、

提出物一覧、

<img width="851" alt="貼り付けた画像_2021_03_24_12_29" src="https://user-images.githubusercontent.com/168265/112250355-90f9aa00-8c9c-11eb-9459-7961b60057c6.png">

提出物個別、

<img width="896" alt="貼り付けた画像_2021_03_24_12_30" src="https://user-images.githubusercontent.com/168265/112250461-c1d9df00-8c9c-11eb-831a-b5a2538e9d23.png">

両方に担当になるボタンがありますが、機能は同じですが、サイズが違います。

現在、提出物個別のときに、サイズをCSSで無理やり大きくしているが、この対応をやめる。

-----

提出物一覧のときのボタンは、`is-sm` というclassが付いている。

<img width="677" alt="貼り付けた画像_2021_03_24_12_33" src="https://user-images.githubusercontent.com/168265/112250680-2b59ed80-8c9d-11eb-8929-1f72e9b132de.png">

提出物個別のときも、`is-sm` というclassが付いていますが、この `is-sm` を `is-md` に変更すると、サイズをCSSで無理やり大きくする必要がなくなります。

<img width="609" alt="貼り付けた画像_2021_03_24_12_34" src="https://user-images.githubusercontent.com/168265/112250786-5e03e600-8c9d-11eb-99af-f44da654d0fb.png">

----

なので、

- 提出物一覧のときのボタンは、`is-sm` というclassが付く
- 提出物個別のときのボタンは、`is-md` というclassが付く

ようにする。

***

## 実装方針
「担当する」ボタンが表示されるまでの流れ
提出物一覧は
views/product/index.html.slim→js-products→products.vue→product.vue→product-checker.vue
提出物個別は
views/product/show.html.slim→js-check→check.vue→product-checker
という流れである。

よって、check.vueで受け渡して、product.vueでは受け渡さないものをproduct-checkerに渡して、その真偽値でクラスを変更する。
この場合`checkableType`が当てはまるため、それを利用します。
`checkableType`をcheck.vueからproduct-checkerに渡します。
`checkableType`が存在する時は個別ページなので`is-md`を適用し、存在しない時は一覧ページなので`is-sm`を適用します。



