### PR TITLE
タグで絞ったユーザー一覧でのフォロー説明を非表示にする

### DIFF
--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -16,12 +16,13 @@ header.page-header.is-border-bottom-none
   .page-tools
     = render 'nav'
 
-.a-page-notice.page-notice
-  .container
-    .a-page-notice__inner
-      p
-        | 気になるユーザーをフォローしてみよう！自分が誰をフォローしているかを知られることはありません。
-        | #{ link_to 'くわしくはこちら', '/pages/303' }
+- unless params[:tag]
+  .page-notice
+    .container
+      .page-notice__inner
+        p
+          | 気になるユーザーをフォローしてみよう！自分が誰をフォローしているかを知られることはありません。
+          | #{ link_to 'くわしくはこちら', '/pages/303' }
 
 main.page-main
   header.page-main-header

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -17,12 +17,12 @@ header.page-header.is-border-bottom-none
     = render 'nav'
 
 - unless params[:tag]
-  .page-notice
+  .a-page-notice.page-notice
     .container
       .page-notice__inner
         p
           | 気になるユーザーをフォローしてみよう！自分が誰をフォローしているかを知られることはありません。
-          | #{ link_to 'くわしくはこちら', '/pages/303' }
+          = link_to 'くわしくはこちら', '/pages/303'
 
 main.page-main
   header.page-main-header


### PR DESCRIPTION
issue #2485

タグで絞ったユーザー一覧では、フォロー説明が表示されないように修正しました。

<img width="1025" alt="ユーザー一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/66161651/113373269-706cd680-93a5-11eb-8220-7cc24cd222a4.png">
<img width="1028" alt="ユーザー一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/66161651/113373478-db1e1200-93a5-11eb-9591-d9272a5a38a4.png">
