### PR TITLE
提出物の担当者のときにコメントすると担当から外れる問題を修正

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -119,14 +119,15 @@ export default {
         .then(response => {
           return response.json()
         })
-        .then(json=> {
-          this.comments.push(json);
+        .then(async comment => {
+          this.comments.push(comment);
           this.description = '';
           this.tab = 'comment';
           this.buttonDisabled = false
           this.resizeTextarea()
 
-          if (this.commentableType === 'Product') {
+          if (this.commentableType === 'Product' &&
+              !(await this.isProductAssginedToSelf(Number(this.commentableId)))) {
             this.assignProductToSelf()
           }
         })
@@ -169,6 +170,27 @@ export default {
       const check = document.getElementById("js-shortcut-check")
       this.createComment()
       check.click()
+    },
+    async isProductAssginedToSelf(productId) {
+      return fetch('/api/products/self_assigned', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': this.token()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual',
+      })
+        .then(response => {
+          return response.json()
+        })
+        .then(({ products }) => {
+          return products.some(product => product.id === productId)
+        })
+        .catch(error => {
+          console.warn('Failed to parsing', error)
+        })
     },
     assignProductToSelf() {
       const params = {

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,12 +5,14 @@ require 'supports/login_helper'
 require 'supports/stripe_helper'
 require 'supports/notification_helper'
 require 'supports/report_helper'
+require 'supports/comment_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include LoginHelper
   include StripeHelper
   include NotificationHelper
   include ReportHelper
+  include CommentHelper
 
   VUEJS_WAIT_SECOND = (ENV['VUEJS_WAIT_SECOND'] || 2).to_i
 

--- a/test/supports/comment_helper.rb
+++ b/test/supports/comment_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CommentHelper
+  def post_comment(comment)
+    fill_in('new_comment[description]', with: comment)
+    click_button 'コメントする'
+    wait_for_vuejs
+  end
+end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -308,11 +308,7 @@ class ProductsTest < ApplicationSystemTestCase
     before_comment = assigned_product_count
 
     visit "/products/#{products(:product1).id}"
-    within('.thread-comment-form__form') do
-      fill_in('new_comment[description]', with: '担当者がいない提出物の場合、担当者になる')
-    end
-    click_button 'コメントする'
-    wait_for_vuejs
+    post_comment('担当者がいない提出物の場合、担当者になる')
 
     visit products_not_responded_index_path
     assert_equal before_comment + 1, assigned_product_count
@@ -337,11 +333,7 @@ class ProductsTest < ApplicationSystemTestCase
     before_comment = assigned_product_count
 
     visit show_product_path
-    within('.thread-comment-form__form') do
-      fill_in('new_comment[description]', with: '担当者がいる提出物の場合、担当者にならない')
-    end
-    click_button 'コメントする'
-    wait_for_vuejs
+    post_comment('担当者がいる提出物の場合、担当者にならない')
 
     visit products_not_responded_index_path
     assert_equal before_comment, assigned_product_count

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -307,11 +307,16 @@ class ProductsTest < ApplicationSystemTestCase
 
     before_comment = assigned_product_count
 
-    visit "/products/#{products(:product1).id}"
-    post_comment('担当者がいない提出物の場合、担当者になる')
+    [
+      '担当者がいない提出物の場合、担当者になる',
+      '自分が担当者の場合、担当者のまま'
+    ].each do |comment|
+      visit "/products/#{products(:product1).id}"
+      post_comment(comment)
 
-    visit products_not_responded_index_path
-    assert_equal before_comment + 1, assigned_product_count
+      visit products_not_responded_index_path
+      assert_equal before_comment + 1, assigned_product_count
+    end
   end
 
   test 'be not person on charge at comment on product of there are person on charge' do


### PR DESCRIPTION
issue
#2541 に対応

## 概要

自分が担当している提出物にコメントすると、その提出物の担当から外れるバグを修正しました。修正後は担当している提出物にコメントしても、何も変化せず、担当者のままです。

## 修正内容

自分が担当している提出物の場合、 担当者変更(`/api/products/checker`)のREST APIを送信しないようにしました。

### 修正前

自分が担当している場合でも担当者変更(`/api/products/checker`)のREST APIを実行してしまい、次の部分で担当に外れる処理が実行されていました。

担当を外す処理をしていたコード

https://github.com/fjordllc/bootcamp/blob/5a7aca42a004658a1af9a6e8631be9685fc75488/app/models/product.rb#L99

## 修正理由

期待通りの動作ではないから

## Viewの変更部分のgif

<details open><summary>修正後</summary>

![after](https://user-images.githubusercontent.com/43565959/113386200-ad949100-93c4-11eb-9aa6-53602aa29f9d.gif)

</details>

<details><summary>修正前</summary>

![before](https://user-images.githubusercontent.com/43565959/113386193-aa010a00-93c4-11eb-9ef5-651103c04dcd.gif)

</details>