### PR TITLE
Adminメニューから「管理者用ドキュメント」のリンクを削除

### DIFF
--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -21,9 +21,6 @@
                 = link_to admin_root_path, class: 'header-dropdown__item-link' do
                   | 管理ページ
               li.header-dropdown__item
-                = link_to 'https://github.com/fjordllc/fjord/wiki/FjordBootCamp', class: 'header-dropdown__item-link', target: '_blank', rel: 'noopener' do
-                  | 管理者用ドキュメント
-              li.header-dropdown__item
                 = link_to 'https://app.redash.io/fjord-inc/public/dashboards/TR86ezvmxVWE7ScenS3yTE1z8lV4ILzvmOAyKmWY',
                   class: 'header-dropdown__item-link',
                   target: '_blank', rel: 'noopener' do


### PR DESCRIPTION
issue #2513 
ヘッダーのAdminメニューから「管理者用ドキュメント」のリンクを削除しました。

### 削除前
![image](https://user-images.githubusercontent.com/68221700/113530818-fa18e000-9601-11eb-9e95-f218bdf9dd7b.png)

### 削除後
![image](https://user-images.githubusercontent.com/68221700/113530860-19b00880-9602-11eb-935f-24745cac49e7.png)

