### PR TITLE
グローバルナビにヘルプのリンクを追加

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -53,7 +53,7 @@ nav.global-nav
               i.fas.fa-fw.fa-users
             .global-nav-links__link-label ユーザー
         li.global-nav-links__item
-          = link_to events_path, class: "global-nav-links__link #{current_link(/^event/)}" do
+          = link_to events_path, class: "global-nav-links__link #{current_link(/^events/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-beer
             .global-nav-links__link-label イベント

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -60,5 +60,5 @@ nav.global-nav
         li.global-nav-links__item
           = link_to '/pages/334', class: "global-nav-links__link #{current_link(%r{^pages/334})}" do
             .global-nav-links__link-icon
-              i.fas.fa-fw.fa-hands-helping
+              i.fas.fa-question
             .global-nav-links__link-label ヘルプ

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -53,7 +53,12 @@ nav.global-nav
               i.fas.fa-fw.fa-users
             .global-nav-links__link-label ユーザー
         li.global-nav-links__item
-          = link_to events_path, class: "global-nav-links__link #{current_link(/^events/)}" do
+          = link_to events_path, class: "global-nav-links__link #{current_link(/^event/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-beer
             .global-nav-links__link-label イベント
+        li.global-nav-links__item
+          = link_to '/pages/334', class: "global-nav-links__link #{current_link(/^pages\/334/)}" do
+            .global-nav-links__link-icon
+              i.fas.fa-fw.fa-hands-helping
+            .global-nav-links__link-label ヘルプ

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -58,7 +58,7 @@ nav.global-nav
               i.fas.fa-fw.fa-beer
             .global-nav-links__link-label イベント
         li.global-nav-links__item
-          = link_to '/pages/334', class: "global-nav-links__link #{current_link(/^pages\/334/)}" do
+          = link_to '/pages/334', class: "global-nav-links__link #{current_link(%r{^pages/334})}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-hands-helping
             .global-nav-links__link-label ヘルプ


### PR DESCRIPTION
## Issue

[ヘルプへのリンクがほしい \#2487](https://github.com/fjordllc/bootcamp/issues/2487)

## 追加前

`global_nav`の以下の部分helpのリンクを追加したい。

<img src="https://tva1.sinaimg.cn/large/008eGmZEgy1gp8yyte3fpj30eu10s761.jpg" alt="image-20210405175514277"/>

## 追加後
![image](https://user-images.githubusercontent.com/68221700/113711105-7f45e700-971f-11eb-8dcf-cbed24cfb946.png)

## リンク先のページ（本番環境のみ）
[ヘルプ目次 \| FJORD BOOT CAMP（フィヨルドブートキャンプ）](https://bootcamp.fjord.jp/pages/334)
![image](https://user-images.githubusercontent.com/68221700/113856454-3a33ba80-97dc-11eb-9300-bbe6dc8f417e.png)
