### PR TITLE
質問編集時、プラクティス変更が反映されない

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -90,7 +90,10 @@
                   .fas.fa-spinner.fa-pulse
                   | ロード中
               .select-practices(v-else)
-                select.js-select2(v-model="edited.practiceId")
+                select.js-select2(
+                  v-model="edited.practiceId",
+                  name="question[practice]"
+                )
                   option(
                     v-for="practice in practices",
                     :key="practice.id",

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -92,6 +92,7 @@
               .select-practices(v-else)
                 select.js-select2(
                   v-model="edited.practiceId",
+                  v-select2,
                   name="question[practice]"
                 )
                   option(
@@ -160,6 +161,15 @@ export default {
     tags: Tags,
     reaction: Reaction,
     userIcon: UserIcon,
+  },
+  directives: {
+    select2: {
+      inserted(el) {
+        $(el).on('select2:select', () => {
+          el.dispatchEvent(new Event('change'));
+        });
+      }
+    }
   },
   props: {
     question: { type: Object, required: true },

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -62,7 +62,12 @@ class QuestionsTest < ApplicationSystemTestCase
       click_button '更新する'
     end
 
-    updated_question.each_value { |text| assert_text text }
+    wait_for_vuejs # Vueが実行したREST APIがDBに反映されるのを待つ
+    question.reload
+    updated_question.each do |key, val|
+      assert_equal val, question[key]
+      assert_text val
+    end
     assert_text '質問を更新しました'
   end
 

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -50,15 +50,19 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'update a question' do
     question = questions(:question8)
     visit question_path(question)
+    updated_question = {
+      title: 'テストの質問（修正）',
+      description: 'テストの質問です。（修正）'
+    }
     wait_for_vuejs
     click_button '内容修正'
     within 'form[name=question]' do
-      fill_in 'question[title]', with: 'テストの質問（修正）'
-      fill_in 'question[description]', with: 'テストの質問です。（修正）'
+      fill_in 'question[title]', with: updated_question[:title]
+      fill_in 'question[description]', with: updated_question[:description]
       click_button '更新する'
     end
-    assert_text 'テストの質問（修正）'
-    assert_text 'テストの質問です。（修正）'
+
+    updated_question.each_value { |text| assert_text text }
     assert_text '質問を更新しました'
   end
 

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -52,21 +52,24 @@ class QuestionsTest < ApplicationSystemTestCase
     visit question_path(question)
     updated_question = {
       title: 'テストの質問（修正）',
-      description: 'テストの質問です。（修正）'
+      description: 'テストの質問です。（修正）',
+      practice: Practice.where.not(id: question.practice.id).first
     }
     wait_for_vuejs
     click_button '内容修正'
     within 'form[name=question]' do
       fill_in 'question[title]', with: updated_question[:title]
       fill_in 'question[description]', with: updated_question[:description]
+      select updated_question[:practice].title, from: 'question[practice]'
       click_button '更新する'
     end
 
     wait_for_vuejs # Vueが実行したREST APIがDBに反映されるのを待つ
     question.reload
     updated_question.each do |key, val|
-      assert_equal val, question[key]
-      assert_text val
+      is_practice_value = key == :practice
+      assert_equal val, is_practice_value ? question.practice : question[key]
+      assert_text is_practice_value ? question.practice.title : val
     end
     assert_text '質問を更新しました'
   end


### PR DESCRIPTION
issue
#2572 に対応

## 概要

質問編集時、プラクティス変更が反映されない

## 原因

[jQueryのselect2](https://select2.org/)が動作し、Vueの `change` イベントが実行されず、プラクティスの値が更新されない

## 修正内容

select2のイベント時に `dispatchEvent(new Event('change')` を実行するようにして、Vueの `change` イベントを実行するようにした。これにより、プラクティスの値が反映される。

`select2` を削除するという案はできませんでした。`select2` によって生成されるHTMLを対象にscssが書かれているのが理由です。 

https://github.com/fjordllc/bootcamp/blob/f685af2560d88a3e2adeddf8b02b5ed504647504/app/assets/stylesheets/modules/_select2.sass#L10

### 修正前

select2のイベントだけ実行され、vueの `change` イベントは実行されず、プラクティスの値が更新されませんでした

## 修正理由

プラクティスが反映されず、期待通りの動作ではないから

## Viewの変更部分のgif

<details><summary>修正前</summary>

![before](https://user-images.githubusercontent.com/43565959/113946832-481d2600-9844-11eb-9abf-21d763b74e8c.gif)

</details>

<details open><summary>修正後</summary>

![fix](https://user-images.githubusercontent.com/43565959/113946851-4f443400-9844-11eb-9677-def8641eb685.gif)

</details>

## 参考資料

[Binding a Select2 select to a Vue js model data \- Stack Overflow](https://stackoverflow.com/questions/31608076/binding-a-select2-select-to-a-vue-js-model-data)