### PR TITLE
自分自身にタグが登録されていない場合に警告を表示する

### DIFF
--- a/app/views/application/_required_field.html.slim
+++ b/app/views/application/_required_field.html.slim
@@ -13,5 +13,7 @@
       ul.card-list__items
         - unless current_user.avatar.attached?
           li = link_to 'プロフィール画像を登録してください。', edit_current_user_path, class: 'card-list__item-link'
+        - if current_user.tag_list.empty?
+          li = link_to 'タグを登録してください。', edit_current_user_path, class: 'card-list__item-link'
         - @required_fields.errors.each do |error|
           = link_to error.message, edit_current_user_path, class: "card-list__item-link is-#{error.attribute}"


### PR DESCRIPTION
issue #2516

登録しているタグが 0 の場合（現役受講生のみ）は、ダッシュボードにメッセージを表示するように変更しました。

<img width="967" alt="ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/66161651/114120247-10d37580-9927-11eb-85aa-0b989cf9f770.png">
