### PR TITLE
Discordアカウント登録時のバリデーションを設定する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,6 +133,12 @@ class User < ApplicationRecord
             }
   validates :mail_notification, inclusion: { in: [true, false] }
   validates :github_id, uniqueness: true, allow_nil: true
+  validates :discord_account,
+            format: {
+              allow_blank: true,
+              with: /\A[^\s\p{blank}].*[^\s\p{blank}]#\d{4}\z/,
+              message: 'は「ユーザー名#４桁の数字」で入力してください'
+            }
 
   validates :login_name, exclusion: { in: RESERVED_LOGIN_NAMES, message: 'に使用できない文字列が含まれています' }
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -157,6 +157,22 @@ class UserTest < ActiveSupport::TestCase
     assert user.invalid?
   end
 
+  test 'discord_account' do
+    user = users(:komagata)
+    user.discord_account = ''
+    assert user.valid?
+    user.discord_account = 'komagata#1234'
+    assert user.valid?
+    user.discord_account = 'komagata'
+    assert user.invalid?
+    user.discord_account = '#1234'
+    assert user.invalid?
+    user.discord_account = ' komagata　#1234'
+    assert user.invalid?
+    user.discord_account = 'komagata1234'
+    assert user.invalid?
+  end
+
   test 'is valid name_kana' do
     user = users(:komagata)
     user.name_kana = 'コマガタ マサキ'


### PR DESCRIPTION
issue
#2556

Discordのアカウント名は、ユーザー名と#四桁の数字で登録して欲しいが、末尾の数字を忘れる人がいるため、バリデーションを設定しました。

![image](https://user-images.githubusercontent.com/66161651/114254811-b6045180-99ec-11eb-8445-916eb20da5b1.png)

Discordのアカウント名の制限については[こちら](https://wiki.jaoafa.com/Discord#:~:text=%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E5%90%8D%E3%81%AF2%E6%96%87%E5%AD%97%E4%BB%A5%E4%B8%8A%E3%83%BB32%E6%96%87%E5%AD%97%E4%BB%A5%E5%86%85%E3%81%A7%E3%81%99%E3%80%82)。

ユーザー名のところは英数字などの制限がないので、とりあえず、2文字以上で前後に半角全角空白が入らないようにだけ考慮し、このようにしました。
`/\A[^\s\p{blank}].*[^\s\p{blank}]#\d{4}\z/`
その他入れた方がいい条件などありましたらコメントいただけたらと思います🙏