### PR TITLE
メンターだけがみれる情報の項目を日本語化しました

### DIFF
--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -14,16 +14,16 @@
             | 有料ユーザー
         - if user.free
           .user-secret-attributes__item
-            | 無料ユーザー
+            = User.human_attribute_name :free
         - if user.job
           .user-secret-attributes__item
-            = user.job
+            = t("activerecord.enums.user.job.#{user.job}")
         - if user.os
           .user-secret-attributes__item
-            = user.os
+            = t("activerecord.enums.user.os.#{user.os}")
         - if user.experience
           .user-secret-attributes__item
-            = user.experience
+            = t("activerecord.enums.user.experience.#{user.experience}")
         - if user.experience
           .user-secret-attributes__item
             = user.email

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -24,7 +24,7 @@
         - if user.experience
           .user-secret-attributes__item
             = t("activerecord.enums.user.experience.#{user.experience}")
-        - if user.experience
+        - if user.email
           .user-secret-attributes__item
             = user.email
     .user-secret-attributes__items


### PR DESCRIPTION
issue #2570
以下の４つの項目について、日本語化に対応しました。
それと、一ヶ所emailの表示条件がミスかな？と思ったところを直しました。

<img width="348" alt="ユーザー一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/66161651/114261128-e57a8480-9a13-11eb-9bd6-78482b0dfe97.png">
