### PR TITLE
使用OSにM1チップMacを追加した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
 
   enum os: {
     mac: 0,
+    mac_m1: 2,
     linux: 1
   }, _prefix: true
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -186,7 +186,7 @@ ja:
           unemployed: 働いていない
         os:
           windows: Windows
-          mac: Mac
+          mac: Mac(Intel)
           linux: Linux
           mac_m1: Mac(M1 chip)
         study_place:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -188,6 +188,7 @@ ja:
           windows: Windows
           mac: Mac
           linux: Linux
+          mac_m1: Mac(M1 chip)
         study_place:
           local: フィヨルドブートキャンプオフィス
           remote: 自宅

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -17,7 +17,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac', from: 'user[os]'
+      select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
     end
 
@@ -46,7 +46,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac', from: 'user[os]'
+      select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
     end
 
@@ -75,7 +75,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac', from: 'user[os]'
+      select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
     end
 
@@ -104,7 +104,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac', from: 'user[os]'
+      select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
     end
 
@@ -153,7 +153,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac', from: 'user[os]'
+      select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
     end
     click_button '利用規約に同意して参加する'
@@ -183,7 +183,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac', from: 'user[os]'
+      select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
     end
 
@@ -229,7 +229,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac', from: 'user[os]'
+      select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
     end
 


### PR DESCRIPTION
issue #2559

使用OSの選択時にM1チップMacを選択できるように追加しました。
ハッシュの順番はプルダウンの順を考慮してみました。

![image](https://user-images.githubusercontent.com/66161651/114351777-0a066600-9ba6-11eb-8e01-167352d67f14.png)

説明書きやタイトルの修正はレビューが終わり次第町田さんに引継ぎます。