### PR TITLE
提出物のfixturesの数を増やして、dbデータリセット直後からpagerを利用するように変更

### DIFF
--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -67,3 +67,233 @@ product14:
   practice: practice1
   user: daimyo
   body: 研修の提出物です。
+
+product15:
+  practice: practice1
+  user: with_hyphen
+  body: テストの提出物15です。
+
+product16:
+  practice: practice2
+  user: with_hyphen
+  body: テストの提出物16です。
+
+product17:
+  practice: practice3
+  user: with_hyphen
+  body: テストの提出物17です。
+
+product18:
+  practice: practice4
+  user: with_hyphen
+  body: テストの提出物18です。
+
+product19:
+  practice: practice5
+  user: with_hyphen
+  body: テストの提出物19です。
+
+product20:
+  practice: practice6
+  user: with_hyphen
+  body: テストの提出物20です。
+
+product21:
+  practice: practice7
+  user: with_hyphen
+  body: テストの提出物21です。
+
+product22:
+  practice: practice8
+  user: with_hyphen
+  body: テストの提出物22です。
+
+product23:
+  practice: practice9
+  user: with_hyphen
+  body: テストの提出物23です。
+
+product24:
+  practice: practice10
+  user: with_hyphen
+  body: テストの提出物24です。
+
+product25:
+  practice: practice11
+  user: with_hyphen
+  body: テストの提出物25です。
+
+product26:
+  practice: practice12
+  user: with_hyphen
+  body: テストの提出物26です。
+
+product27:
+  practice: practice13
+  user: with_hyphen
+  body: テストの提出物27です。
+
+product28:
+  practice: practice14
+  user: with_hyphen
+  body: テストの提出物28です。
+
+product29:
+  practice: practice15
+  user: with_hyphen
+  body: テストの提出物29です。
+
+product30:
+  practice: practice16
+  user: with_hyphen
+  body: テストの提出物30です。
+
+product31:
+  practice: practice17
+  user: with_hyphen
+  body: テストの提出物31です。
+
+product32:
+  practice: practice18
+  user: with_hyphen
+  body: テストの提出物32です。
+
+product33:
+  practice: practice19
+  user: with_hyphen
+  body: テストの提出物33です。
+
+product34:
+  practice: practice20
+  user: with_hyphen
+  body: テストの提出物34です。
+
+product35:
+  practice: practice21
+  user: with_hyphen
+  body: テストの提出物35です。
+
+product36:
+  practice: practice22
+  user: with_hyphen
+  body: テストの提出物36です。
+
+product37:
+  practice: practice23
+  user: with_hyphen
+  body: テストの提出物37です。
+
+product38:
+  practice: practice24
+  user: with_hyphen
+  body: テストの提出物38です。
+
+product39:
+  practice: practice25
+  user: with_hyphen
+  body: テストの提出物39です。
+
+product40:
+  practice: practice26
+  user: with_hyphen
+  body: テストの提出物40です。
+
+product41:
+  practice: practice27
+  user: with_hyphen
+  body: テストの提出物41です。
+
+product42:
+  practice: practice28
+  user: with_hyphen
+  body: テストの提出物42です。
+
+product43:
+  practice: practice29
+  user: with_hyphen
+  body: テストの提出物43です。
+
+product44:
+  practice: practice30
+  user: with_hyphen
+  body: テストの提出物44です。
+
+product45:
+  practice: practice31
+  user: with_hyphen
+  body: テストの提出物45です。
+
+product46:
+  practice: practice32
+  user: with_hyphen
+  body: テストの提出物46です。
+
+product47:
+  practice: practice33
+  user: with_hyphen
+  body: テストの提出物47です。
+
+product48:
+  practice: practice34
+  user: with_hyphen
+  body: テストの提出物48です。
+
+product49:
+  practice: practice35
+  user: with_hyphen
+  body: テストの提出物49です。
+
+product50:
+  practice: practice36
+  user: with_hyphen
+  body: テストの提出物50です。
+
+product51:
+  practice: practice37
+  user: with_hyphen
+  body: テストの提出物51です。
+
+product52:
+  practice: practice38
+  user: with_hyphen
+  body: テストの提出物52です。
+
+product53:
+  practice: practice39
+  user: with_hyphen
+  body: テストの提出物53です。
+
+product54:
+  practice: practice40
+  user: with_hyphen
+  body: テストの提出物54です。
+
+product55:
+  practice: practice41
+  user: with_hyphen
+  body: テストの提出物55です。
+
+product56:
+  practice: practice42
+  user: with_hyphen
+  body: テストの提出物56です。
+
+product57:
+  practice: practice43
+  user: with_hyphen
+  body: テストの提出物57です。
+
+product58:
+  practice: practice44
+  user: with_hyphen
+  body: テストの提出物58です。
+
+product59:
+  practice: practice45
+  user: with_hyphen
+  body: テストの提出物59です。
+
+product60:
+  practice: practice46
+  user: with_hyphen
+  body: テストの提出物60です。

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -67,3 +67,233 @@ product14:
   practice: practice1
   user: daimyo
   body: 研修の提出物です。
+
+product15:
+  practice: practice1
+  user: with_hyphen
+  body: テストの提出物15です。
+
+product16:
+  practice: practice2
+  user: with_hyphen
+  body: テストの提出物16です。
+
+product17:
+  practice: practice3
+  user: with_hyphen
+  body: テストの提出物17です。
+
+product18:
+  practice: practice4
+  user: with_hyphen
+  body: テストの提出物18です。
+
+product19:
+  practice: practice5
+  user: with_hyphen
+  body: テストの提出物19です。
+
+product20:
+  practice: practice6
+  user: with_hyphen
+  body: テストの提出物20です。
+
+product21:
+  practice: practice7
+  user: with_hyphen
+  body: テストの提出物21です。
+
+product22:
+  practice: practice8
+  user: with_hyphen
+  body: テストの提出物22です。
+
+product23:
+  practice: practice9
+  user: with_hyphen
+  body: テストの提出物23です。
+
+product24:
+  practice: practice10
+  user: with_hyphen
+  body: テストの提出物24です。
+
+product25:
+  practice: practice11
+  user: with_hyphen
+  body: テストの提出物25です。
+
+product26:
+  practice: practice12
+  user: with_hyphen
+  body: テストの提出物26です。
+
+product27:
+  practice: practice13
+  user: with_hyphen
+  body: テストの提出物27です。
+
+product28:
+  practice: practice14
+  user: with_hyphen
+  body: テストの提出物28です。
+
+product29:
+  practice: practice15
+  user: with_hyphen
+  body: テストの提出物29です。
+
+product30:
+  practice: practice16
+  user: with_hyphen
+  body: テストの提出物30です。
+
+product31:
+  practice: practice17
+  user: with_hyphen
+  body: テストの提出物31です。
+
+product32:
+  practice: practice18
+  user: with_hyphen
+  body: テストの提出物32です。
+
+product33:
+  practice: practice19
+  user: with_hyphen
+  body: テストの提出物33です。
+
+product34:
+  practice: practice20
+  user: with_hyphen
+  body: テストの提出物34です。
+
+product35:
+  practice: practice21
+  user: with_hyphen
+  body: テストの提出物35です。
+
+product36:
+  practice: practice22
+  user: with_hyphen
+  body: テストの提出物36です。
+
+product37:
+  practice: practice23
+  user: with_hyphen
+  body: テストの提出物37です。
+
+product38:
+  practice: practice24
+  user: with_hyphen
+  body: テストの提出物38です。
+
+product39:
+  practice: practice25
+  user: with_hyphen
+  body: テストの提出物39です。
+
+product40:
+  practice: practice26
+  user: with_hyphen
+  body: テストの提出物40です。
+
+product41:
+  practice: practice27
+  user: with_hyphen
+  body: テストの提出物41です。
+
+product42:
+  practice: practice28
+  user: with_hyphen
+  body: テストの提出物42です。
+
+product43:
+  practice: practice29
+  user: with_hyphen
+  body: テストの提出物43です。
+
+product44:
+  practice: practice30
+  user: with_hyphen
+  body: テストの提出物44です。
+
+product45:
+  practice: practice31
+  user: with_hyphen
+  body: テストの提出物45です。
+
+product46:
+  practice: practice32
+  user: with_hyphen
+  body: テストの提出物46です。
+
+product47:
+  practice: practice33
+  user: with_hyphen
+  body: テストの提出物47です。
+
+product48:
+  practice: practice34
+  user: with_hyphen
+  body: テストの提出物48です。
+
+product49:
+  practice: practice35
+  user: with_hyphen
+  body: テストの提出物49です。
+
+product50:
+  practice: practice36
+  user: with_hyphen
+  body: テストの提出物50です。
+
+product51:
+  practice: practice37
+  user: with_hyphen
+  body: テストの提出物51です。
+
+product52:
+  practice: practice38
+  user: with_hyphen
+  body: テストの提出物52です。
+
+product53:
+  practice: practice39
+  user: with_hyphen
+  body: テストの提出物53です。
+
+product54:
+  practice: practice40
+  user: with_hyphen
+  body: テストの提出物54です。
+
+product55:
+  practice: practice41
+  user: with_hyphen
+  body: テストの提出物55です。
+
+product56:
+  practice: practice42
+  user: with_hyphen
+  body: テストの提出物56です。
+
+product57:
+  practice: practice43
+  user: with_hyphen
+  body: テストの提出物57です。
+
+product58:
+  practice: practice44
+  user: with_hyphen
+  body: テストの提出物58です。
+
+product59:
+  practice: practice45
+  user: with_hyphen
+  body: テストの提出物59です。
+
+product60:
+  practice: practice46
+  user: with_hyphen
+  body: テストの提出物60です。

--- a/test/system/product/not_responded_test.rb
+++ b/test/system/product/not_responded_test.rb
@@ -52,11 +52,23 @@ class ProductsTest < ApplicationSystemTestCase
     visit '/products/not_responded'
 
     # 提出日の昇順で並んでいることを検証する
-    titles = all('.thread-list-item__title').map { |t| t.text.gsub('★', '') }
-    authors = all('.thread-list-item-meta .thread-header__author').map(&:text)
-    assert_equal "#{newest_product.practice.title}の提出物", titles.first
-    assert_equal newest_product.user.login_name, authors.first
-    assert_equal "#{oldest_product.practice.title}の提出物", titles.last
-    assert_equal oldest_product.user.login_name, authors.last
+    extract_all_title_on_display_page = -> { all('.thread-list-item__title').map { |t| t.text.gsub('★', '') } }
+    extract_all_author_on_display_page = ->  { all('.thread-list-item-meta .thread-header__author').map(&:text) }
+
+    assert_equal "#{newest_product.practice.title}の提出物",
+                 extract_all_title_on_display_page.call.first
+    assert_equal newest_product.user.login_name,
+                 extract_all_author_on_display_page.call.first
+
+    # ページングがあったら最後のページまで移動する
+    if has_selector?('.pagination')
+      find(class: %w[fas fa-angle-double-right], match: :first).find(:xpath, '..').click
+      wait_for_vuejs
+    end
+
+    assert_equal "#{oldest_product.practice.title}の提出物",
+                 extract_all_title_on_display_page.call.last
+    assert_equal oldest_product.user.login_name,
+                 extract_all_author_on_display_page.call.last
   end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -290,6 +290,15 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'When the number of pages is one, the pager will not be displayed' do
+    count_of_delete = Product.count - PAGINATES_PER
+    if count_of_delete.positive?
+      Product.all.each_with_index do |product, index|
+        product.delete
+
+        break if index >= count_of_delete
+      end
+    end
+
     login_user 'komagata', 'testtest'
 
     visit '/products'


### PR DESCRIPTION
#2590 に対応

## 概要

提出物のseedデータを50件より多くして、DBデータをリセット後(e.g. `rails db:seed:replant`)、すぐに提出物のページャーの動作確認をできるようにする。

50はページャーが利用される境界値

## 作業理由

DBデータをリセット後(e.g. `rails db:seed:replant`)、すぐに提出物のページャーの動作確認をできるようにしたいため。

## Viewの変更部分のgif

<details><summary>追加前の `rails db:seed:replant` 直後の提出物一覧</summary>

![now](https://user-images.githubusercontent.com/43565959/114338934-116e4500-9b8f-11eb-9540-e82e08277d31.png)

</details>

<details open><summary>追加後の `rails db:seed:replant` 直後の提出物一覧</summary>

![products](https://user-images.githubusercontent.com/43565959/114837291-80a59c80-9e0e-11eb-9ea2-9999b5de0d5b.png)
![not_responded](https://user-images.githubusercontent.com/43565959/114837295-813e3300-9e0e-11eb-8a54-0bb34792bb3c.png)
![unchecked](https://user-images.githubusercontent.com/43565959/114837296-81d6c980-9e0e-11eb-8490-d81e7fbac01c.png)


</details>