### PR TITLE
コメントが0件のとき「コメントはありません。」と表示する。

### DIFF
--- a/app/views/admin/books/index.html.slim
+++ b/app/views/admin/books/index.html.slim
@@ -16,9 +16,9 @@ header.page-header
 
 .page-body
   .container.is-padding-horizontal-0-sm-down
-    = paginate @books, position: 'top'
+    = paginate @books
     = render 'table', books: @books
-    = paginate @books, position: 'bottom'
+    = paginate @books
     .card-footer
       .card-main-actions
         .card-main-actions__items

--- a/app/views/books/borrowed/index.html.slim
+++ b/app/views/books/borrowed/index.html.slim
@@ -14,6 +14,6 @@ header.page-header
 
 .page-body
   .container.is-padding-horizontal-0-sm-down
-    = paginate @books, position: 'top'
+    = paginate @books
     = render 'books/table', books: @books
-    = paginate @books, position: 'bottom'
+    = paginate @books

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -18,6 +18,6 @@ header.page-header
       p
         | フィヨルドオフィスにて以下の書籍を借りることができます。
   .container.is-padding-horizontal-0-sm-down
-    = paginate @books, position: 'top'
+    = paginate @books
     = render 'table', books: @books
-    = paginate @books, position: 'bottom'
+    = paginate @books

--- a/app/views/books/search_results/index.html.slim
+++ b/app/views/books/search_results/index.html.slim
@@ -12,6 +12,6 @@ header.page-header
 
 .page-body
   .container.is-padding-horizontal-0-sm-down
-    = paginate @search_results, position: 'top'
+    = paginate @search_results
     = render 'books/table', books: @search_results if @search_results.any?
-    = paginate @search_results, position: 'bottom'
+    = paginate @search_results

--- a/app/views/companies/products/index.html.slim
+++ b/app/views/companies/products/index.html.slim
@@ -10,8 +10,8 @@ header.page-header
 
 .page-body
   .container
-    = paginate @products, position: 'top'
+    = paginate @products
     - if @products.present?
       .thread-list.a-card
         = render partial: 'products/product', collection: @products, as: :product
-    = paginate @products, position: 'bottom'
+    = paginate @products

--- a/app/views/companies/reports/index.html.slim
+++ b/app/views/companies/reports/index.html.slim
@@ -10,8 +10,8 @@ header.page-header
 
 .page-body
   .container
-    = paginate @reports, position: 'top'
+    = paginate @reports
     - if @reports.present?
       .thread-list.a-card
         = render partial: 'reports/report', collection: @reports, as: :report
-    = paginate @reports, position: 'bottom'
+    = paginate @reports

--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -13,8 +13,8 @@ header.page-header
               | イベント作成
 
 .page-body
-  = paginate @events, position: 'top'
+  = paginate @events
   .container
     .thread-list.a-card
       = render partial: 'events', collection: @events, as: :event
-= paginate @events, position: 'bottom'
+= paginate @events

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -21,7 +21,7 @@ header.page-header
             i.fas.fa-times.fa-fw
 .page-body
   .container
-    = paginate @pages, position: 'top'
+    = paginate @pages
     .two-columns
       .two-columns__inner
         .thread-list.a-card
@@ -36,4 +36,4 @@ header.page-header
               - Page.all_tags.each do |tag|
                 li.page-tags-nav__item
                   = link_to tag.name, pages_tag_path(tag.name), class: 'page-tags-nav__item-link'
-    = paginate @pages, position: 'bottom'
+    = paginate @pages

--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -17,11 +17,11 @@ header.page-header
 
 .page-body
   .container
-    = paginate @pages, position: 'top'
+    = paginate @pages
     - if @pages.present?
       .thread-list.a-card
         = render partial: 'pages/page', collection: @pages, as: :page
-      = paginate @pages, position: 'bottom'
+      = paginate @pages
     - else
       .a-empty-message
         | Docsはまだありません。

--- a/app/views/practices/products/index.html.slim
+++ b/app/views/practices/products/index.html.slim
@@ -23,10 +23,10 @@ header.page-header
 
 .page-body
   .container
-    = paginate @products, position: 'top'
+    = paginate @products
     - if @products.present?
       .thread-list.a-card
         = render partial: 'products/product',
           collection: @products,
           as: :product
-    = paginate @products, position: 'bottom'
+    = paginate @products

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -17,11 +17,11 @@ header.page-header
 
 .page-body
   .container
-    = paginate @reports, position: 'top'
+    = paginate @reports
     - if @reports.present?
       .thread-list.a-card
         = render partial: 'reports/report', collection: @reports, as: :report
-      = paginate @reports, position: 'bottom'
+      = paginate @reports
     - else
       .a-empty-message
         | 日報はまだありません。

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -22,7 +22,7 @@ header.page-header
 
 .page-body
   .container
-    = paginate @questions, position: 'top'
+    = paginate @questions
     .two-columns
       .two-columns__inner
         - if @questions.present?
@@ -42,4 +42,4 @@ header.page-header
                 - if tag.present?
                   li.page-tags-nav__item
                     = link_to tag.name, questions_tag_path(tag.name, all: 'true'), class: 'page-tags-nav__item-link'
-    = paginate @questions, position: 'bottom'
+    = paginate @questions

--- a/app/views/searchables/index.html.slim
+++ b/app/views/searchables/index.html.slim
@@ -8,7 +8,7 @@ header.page-header
 
 .page-body
   .container
-    = paginate @searchables, position: 'top'
+    = paginate @searchables
     - if @searchables.size.positive?
       .thread-list.a-card
         = render partial: 'searchables/searchable', collection: @searchables, as: :searchable, locals: { words: '' }
@@ -18,4 +18,4 @@ header.page-header
           i.far.fa-sad-tear
         p.o-empty-message__text
           | '#{params[:word]}'に一致する情報は見つかりませんでした。
-    = paginate @searchables, position: 'bottom'
+    = paginate @searchables

--- a/app/views/users/comments/index.html.slim
+++ b/app/views/users/comments/index.html.slim
@@ -16,6 +16,10 @@ header.page-header
 .page-body
   .container
     = paginate @comments, position: 'top'
-    .thread-list.a-card
-      = render 'comments', comments: @comments
-    = paginate @comments, position: 'bottom'
+    - if @comments.present?
+      .thread-list.a-card
+        = render 'comments', comments: @comments
+      = paginate @comments, position: 'bottom'
+    - else
+      .a-empty-message
+        | コメントはありません。

--- a/app/views/users/comments/index.html.slim
+++ b/app/views/users/comments/index.html.slim
@@ -15,11 +15,11 @@ header.page-header
 
 .page-body
   .container
-    = paginate @comments, position: 'top'
+    = paginate @comments
     - if @comments.present?
       .thread-list.a-card
         = render 'comments', comments: @comments
-      = paginate @comments, position: 'bottom'
+      = paginate @comments
     - else
       .a-empty-message
         | コメントはありません。

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -43,7 +43,7 @@ main.page-main
           h1.page-main-header__title
             | #{t("target.#{@target}")}（#{@users.total_count}）
   .page-body
-    = paginate @users, position: 'top'
+    = paginate @users
     .container
       .users
         .row.is-gutter-width-32
@@ -59,4 +59,4 @@ main.page-main
                 - else
                   = t("target.#{@target}")
                 | のユーザーはいません
-    = paginate @users, position: 'bottom'
+    = paginate @users

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -18,7 +18,7 @@ header.page-header
 
 .page-body
   .container
-    = paginate @reports, position: 'top'
+    = paginate @reports
     - if @reports.present?
       .thread-list.a-card
         = render partial: 'reports/report', collection: @reports, as: :report
@@ -28,4 +28,4 @@ header.page-header
           i.far.fa-sad-tear
         p.o-empty-message__text
           | 日報はまだありません。
-    = paginate @reports, position: 'bottom'
+    = paginate @reports

--- a/app/views/watches/index.html.slim
+++ b/app/views/watches/index.html.slim
@@ -6,7 +6,7 @@ header.page-header
         = title
 
 .page-body
-  = paginate @watches, position: 'top'
+  = paginate @watches
 .container
   .thread-list.a-card
     = render partial: 'watch', collection: @watches


### PR DESCRIPTION
issue [\#2506](https://github.com/fjordllc/bootcamp/issues/2506)
## 概要
ユーザー個別ページ > コメント一覧

このページでコメントがない場合、
![image](https://user-images.githubusercontent.com/68221700/114966974-923e8100-9eae-11eb-93fc-cc0f6b9bc5d1.png)
このような表示になってしまっているので、`.thread-list.a-card`は表示しないようにしたい。

![image](https://user-images.githubusercontent.com/68221700/114967118-d2056880-9eae-11eb-8cea-e058e60b48a8.png)

## 修正後
![image](https://user-images.githubusercontent.com/68221700/114967223-037e3400-9eaf-11eb-8cd4-feb5c98a6b0c.png)

![image](https://user-images.githubusercontent.com/68221700/114967362-44764880-9eaf-11eb-9ce2-1d21ab25198b.png)
