### PR TITLE
タグとプロフィール画像のみが未登録の時にもメッセージボックスを表示する

### DIFF
--- a/app/views/application/_required_field.html.slim
+++ b/app/views/application/_required_field.html.slim
@@ -1,4 +1,4 @@
-- unless @required_fields.valid?
+- unless @required_fields.valid? && current_user.avatar.attached? && !current_user.tag_list.empty?
   .a-card
     header.card-header.is-sm
       h2.card-header__title


### PR DESCRIPTION
issue #2608

未登録情報の登録を促すメッセージボックスを表示する条件が、SNSアカウントと自己紹介の未登録のみに限られていたため、タグとプロフィール画像のみが未登録の時はメッセージボックス自体が表示されないようになっていたのを修正しました。

<img width="971" alt="ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/66161651/114961171-784b7100-9ea3-11eb-811f-a27774d6ad6a.png">
