### PR TITLE
pager componentを作成して、pager部分を共通化

### DIFF
--- a/app/javascript/announcements.vue
+++ b/app/javascript/announcements.vue
@@ -2,29 +2,9 @@
   .page-body
     .container(v-if="loaded")
       nav.pagination
-        pager-top(
+        pager(
           v-if="totalPages > 1 && announcements.length > 0"
-          v-model='currentPage'
-          :page-count="totalPages"
-          :page-range=5
-          :prev-text="`<i class='fas fa-angle-left'></i>`"
-          :next-text="`<i class='fas fa-angle-right'></i>`"
-          :first-button-text="`<i class='fas fa-angle-double-left'></i>`"
-          :last-button-text="`<i class='fas fa-angle-double-right'></i>`"
-          :click-handler="paginateClickCallback"
-          :container-class="'pagination__items'"
-          :page-class="'pagination__item'"
-          :page-link-class="'pagination__item-link'"
-          :disabled-class="'is-disabled'"
-          :active-class="'is-active'"
-          :prev-class="'is-prev pagination__item'"
-          :prev-link-class="'is-prev pagination__item-link'"
-          :next-class="'is-next pagination__item'"
-          :next-link-class="'is-next pagination__item-link'"
-          :first-last-button="true"
-          :hide-prev-next="true"
-          :margin-pages="0"
-          :break-view-text="null"
+          v-bind="pagerProps"
         )
       .thread-list.a-card(v-if="announcements.length > 0")
         announcement(v-for="announcement in announcements"
@@ -38,29 +18,9 @@
         p.o-empty-message__text
           | {{ title }}はありません
       nav.pagination
-        pager-bottom(
+        pager(
           v-if="totalPages > 1 && announcements.length > 0"
-          v-model='currentPage'
-          :page-count="totalPages"
-          :page-range=5
-          :prev-text="`<i class='fas fa-angle-left'></i>`"
-          :next-text="`<i class='fas fa-angle-right'></i>`"
-          :first-button-text="`<i class='fas fa-angle-double-left'></i>`"
-          :last-button-text="`<i class='fas fa-angle-double-right'></i>`"
-          :click-handler="paginateClickCallback"
-          :container-class="'pagination__items'"
-          :page-class="'pagination__item'"
-          :page-link-class="'pagination__item-link'"
-          :disabled-class="'is-disabled'"
-          :active-class="'is-active'"
-          :prev-class="'is-prev pagination__item'"
-          :prev-link-class="'is-prev pagination__item-link'"
-          :next-class="'is-next pagination__item'"
-          :next-link-class="'is-next pagination__item-link'"
-          :first-last-button="true"
-          :hide-prev-next="true"
-          :margin-pages="0"
-          :break-view-text="null"
+          v-bind="pagerProps"
         )
     .container(v-else)
       .fas.fa-spinner.fa-pulse
@@ -69,32 +29,38 @@
 
 <script>
 import Announcement from './announcement.vue'
-import VueJsPaginate from 'vuejs-paginate'
+import Pager from './pager.vue'
 
 export default {
   props: ['title', 'currentUserId'],
   components: {
     'announcement': Announcement,
-    'pager-top': VueJsPaginate,
-    'pager-bottom': VueJsPaginate
+    pager: Pager
   },
-  data: () => {
+  data() {
     return {
       announcements: [],
       totalPages: 0,
-      currentPage: 1,
+      currentPage: Number(this.getPageValueFromParameter()) || 1,
       loaded: false,
       currentUser: {}
     }
   },
   computed: {
-    url() { return `/api/announcements?page=${this.currentPage}` }
+    url() { return `/api/announcements?page=${this.currentPage}` },
+    pagerProps() {
+      return {
+        initialPageNumber: this.currentPage,
+        pageCount: this.totalPages,
+        pageRange: 5,
+        clickHandle: this.paginateClickCallback
+      }
+    }
   },
   created() {
     window.onpopstate = function(){
       location.replace(location.href);
     }
-    this.currentPage = Number(this.getPageValueFromParameter()) || 1
     this.getAnnouncementsPerPage()
     this.getCurrentUser()
   },
@@ -129,22 +95,20 @@ export default {
         console.warn('Failed to parsing', error)
       })
     },
-    updateCurrentUrl() {
-      let url = location.pathname
-      if (this.currentPage != 1) {
-        url += `?page=${this.currentPage}`
-      }
-      history.pushState(null, null, url)
-    },
     getPageValueFromParameter() {
       let url = location.href
       let results= url.match(/\?page=(\d+)/)
       if (!results) return null;
       return results[1]
     },
-    paginateClickCallback() {
+    paginateClickCallback(pageNumber) {
+      this.currentPage = pageNumber
       this.getAnnouncementsPerPage()
-      this.updateCurrentUrl()
+      history.pushState(
+        null,
+        null,
+        location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`),
+      )
     },
     getCurrentUser() {
       fetch(`/api/users/${this.currentUserId}.json`, {

--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -1,58 +1,14 @@
 <template lang="pug">
   .container(v-if="loaded && notifications.length > 0")
     nav.pagination(v-if="totalPages > 1")
-      pager-top(
-        v-model="currentPage"
-        :page-count="totalPages"
-        :page-range="5"
-        :prev-text="`<i class='fas fa-angle-left'></i>`"
-        :next-text="`<i class='fas fa-angle-right'></i>`"
-        :first-button-text="`<i class='fas fa-angle-double-left'></i>`"
-        :last-button-text="`<i class='fas fa-angle-double-right'></i>`"
-        :click-handler="paginateClickCallback"
-        :container-class="'pagination__items'"
-        :page-class="'pagination__item'"
-        :page-link-class="'pagination__item-link'"
-        :disabled-class="'is-disabled'"
-        :active-class="'is-active'"
-        :prev-class="'is-prev pagination__item'"
-        :prev-link-class="'is-prev pagination__item-link'"
-        :next-class="'is-next pagination__item'"
-        :next-link-class="'is-next pagination__item-link'"
-        :first-last-button="true"
-        :hide-prev-next="true"
-        :margin-pages="0"
-        :break-view-text=null
-      )
+      pager(v-bind="pagerProps")
     .thread-list.a-card
       notification(v-for="notification in notifications"
         :key="notification.id"
         :notification="notification")
       unconfirmed-links-open-button(v-if="isMentor && isUnreadPage" label="未読の通知を一括で開く")
     nav.pagination(v-if="totalPages > 1")
-      pager-bottom(
-        v-model="currentPage"
-        :page-count="totalPages"
-        :page-range="5"
-        :prev-text="`<i class='fas fa-angle-left'></i>`"
-        :next-text="`<i class='fas fa-angle-right'></i>`"
-        :first-button-text="`<i class='fas fa-angle-double-left'></i>`"
-        :last-button-text="`<i class='fas fa-angle-double-right'></i>`"
-        :click-handler="paginateClickCallback"
-        :container-class="'pagination__items'"
-        :page-class="'pagination__item'"
-        :page-link-class="'pagination__item-link'"
-        :disabled-class="'is-disabled'"
-        :active-class="'is-active'"
-        :prev-class="'is-prev pagination__item'"
-        :prev-link-class="'is-prev pagination__item-link'"
-        :next-class="'is-next pagination__item'"
-        :next-link-class="'is-next pagination__item-link'"
-        :first-last-button="true"
-        :hide-prev-next="true"
-        :margin-pages="0"
-        :break-view-text=null
-      )
+      pager(v-bind="pagerProps")
   .container(v-else-if="loaded")
     .o-empty-message
       .o-empty-message__icon
@@ -67,7 +23,7 @@
 
 <script>
 import Notification from './notification.vue'
-import VueJsPaginate from 'vuejs-paginate'
+import Pager from './pager.vue'
 import UnconfirmedLinksOpenButton from './unconfirmed_links_open_button'
 
 export default {
@@ -78,15 +34,14 @@ export default {
   },
   components: {
     'notification': Notification,
-    'pager-top': VueJsPaginate,
-    'pager-bottom': VueJsPaginate,
+    pager: Pager,
     'unconfirmed-links-open-button': UnconfirmedLinksOpenButton
   },
-  data: () => {
+  data() {
     return {
       notifications: [],
       totalPages: 0,
-      currentPage: null,
+      currentPage: Number(this.getPageValueFromParameter()) || 1,
       loaded: false
     }
   },
@@ -95,7 +50,6 @@ export default {
     window.onpopstate = function() {
       location.replace(location.href);
     }
-    this.currentPage = Number(this.getPageValueFromParameter()) || 1
     this.getNotificationsPerPage()
   },
   computed: {
@@ -108,6 +62,14 @@ export default {
     },
     isUnreadPage() {
       return location.pathname.includes('unread')
+    },
+    pagerProps() {
+      return {
+        initialPageNumber: this.currentPage,
+        pageCount: this.totalPages,
+        pageRange: 5,
+        clickHandle: this.paginateClickCallback
+      }
     }
   },
   methods: {
@@ -131,16 +93,14 @@ export default {
           console.warn('Failed to parsing', error)
         })
     },
-    updateCurrentUrl: function() {
-      let url = location.pathname
-      if (this.currentPage !== 1) {
-        url += `?page=${this.currentPage}`
-      }
-      history.pushState(null, null, url)
-    },
-    paginateClickCallback: function() {
+    paginateClickCallback: function(pageNumber) {
+      this.currentPage = pageNumber
       this.getNotificationsPerPage()
-      this.updateCurrentUrl()
+      history.pushState(
+        null,
+        null,
+        location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`),
+      )
     },
     getPageValueFromParameter: function() {
       let url = location.href

--- a/app/javascript/pager.vue
+++ b/app/javascript/pager.vue
@@ -1,0 +1,45 @@
+<template lang="pug">
+pager(
+  :value='initialPageNumber'
+  :page-count='pageCount'
+  :page-range='pageRange',
+  :prev-text='makeITag("left")',
+  :next-text='makeITag("right")',
+  :click-handler='clickHandle',
+  :first-button-text='makeITag("double-left")',
+  :last-button-text='makeITag("double-right")',
+  :margin-pages=0,
+  first-last-button,
+  hide-prev-next,
+  container-class='pagination__items',
+  page-class='pagination__item',
+  page-link-class='pagination__item-link',
+  prev-class='pagination__item is-prev',
+  prev-link-class='pagination__item-link is-prev',
+  next-class='pagination__item is-next',
+  next-link-class='pagination__item-link is-next',
+  active-class='is-active',
+  disabled-class='is-disabled',
+)
+</template>
+
+<script>
+import VuejsPaginate from 'vuejs-paginate'
+
+export default {
+  props: {
+    initialPageNumber: { type: Number, required: true },
+    pageCount: { type: Number, required: true },
+    pageRange: { type: Number, required: true },
+    clickHandle: { type: Function, required: true },
+  },
+  components: {
+    pager: VuejsPaginate
+  },
+  methods: {
+    makeITag(iconName) {
+      return `<i class='fas fa-angle-${iconName}'></i>`
+    }
+  }
+}
+</script>

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -2,29 +2,9 @@
   .page-body
     .container(v-if="loaded")
       nav.pagination
-        pager-top(
+        pager(
           v-if="totalPages > 1 && products.length > 0"
-          v-model='currentPage'
-          :page-count="totalPages"
-          :page-range=5
-          :prev-text="`<i class='fas fa-angle-left'></i>`"
-          :next-text="`<i class='fas fa-angle-right'></i>`"
-          :first-button-text="`<i class='fas fa-angle-double-left'></i>`"
-          :last-button-text="`<i class='fas fa-angle-double-right'></i>`"
-          :click-handler="paginateClickCallback"
-          :container-class="'pagination__items'"
-          :page-class="'pagination__item'"
-          :page-link-class="'pagination__item-link'"
-          :disabled-class="'is-disabled'"
-          :active-class="'is-active'"
-          :prev-class="'is-prev pagination__item'"
-          :prev-link-class="'is-prev pagination__item-link'"
-          :next-class="'is-next pagination__item'"
-          :next-link-class="'is-next pagination__item-link'"
-          :first-last-button="true"
-          :hide-prev-next="true"
-          :margin-pages="0"
-          :break-view-text="null"
+          v-bind="pagerProps"
         )
       .thread-list.a-card(v-if="products.length > 0")
         .thread-list__items
@@ -40,29 +20,9 @@
         p.o-empty-message__text
           | {{ title }}はありません
       nav.pagination
-        pager-bottom(
+        pager(
           v-if="totalPages > 1 && products.length > 0"
-          v-model='currentPage'
-          :page-count="totalPages"
-          :page-range=5
-          :prev-text="`<i class='fas fa-angle-left'></i>`"
-          :next-text="`<i class='fas fa-angle-right'></i>`"
-          :first-button-text="`<i class='fas fa-angle-double-left'></i>`"
-          :last-button-text="`<i class='fas fa-angle-double-right'></i>`"
-          :click-handler="paginateClickCallback"
-          :container-class="'pagination__items'"
-          :page-class="'pagination__item'"
-          :page-link-class="'pagination__item-link'"
-          :disabled-class="'is-disabled'"
-          :active-class="'is-active'"
-          :prev-class="'is-prev pagination__item'"
-          :prev-link-class="'is-prev pagination__item-link'"
-          :next-class="'is-next pagination__item'"
-          :next-link-class="'is-next pagination__item-link'"
-          :first-last-button="true"
-          :hide-prev-next="true"
-          :margin-pages="0"
-          :break-view-text="null"
+          v-bind="pagerProps"
         )
     .container(v-else)
       | ロード中
@@ -71,21 +31,20 @@
 <script>
 import Product from './product.vue'
 import unconfirmedLinksOpenButton from './unconfirmed_links_open_button.vue'
-import VueJsPaginate from 'vuejs-paginate'
+import Pager from './pager.vue'
 
 export default {
   props: ['title', 'selectedTab', 'isMentor', 'currentUserId'],
   components: {
     'product': Product,
     'unconfirmed-links-open-button': unconfirmedLinksOpenButton,
-    'pager-top': VueJsPaginate,
-    'pager-bottom': VueJsPaginate
+    pager: Pager
   },
-  data: () => {
+  data() {
     return {
       products: [],
       totalPages: 0,
-      currentPage: 1,
+      currentPage: Number(this.getPageValueFromParameter()) || 1,
       loaded: false
     }
   },
@@ -103,13 +62,20 @@ export default {
         'not-responded': '未返信',
         'self-assigned': '自分の担当',
       }[this.selectedTab]
+    },
+    pagerProps() {
+      return {
+        initialPageNumber: this.currentPage,
+        pageCount: this.totalPages,
+        pageRange: 5,
+        clickHandle: this.paginateClickCallback
+      }
     }
   },
   created () {
     window.onpopstate = function(){
       location.replace(location.href);
     }
-    this.currentPage = Number(this.getPageValueFromParameter()) || 1
     this.getProductsPerPage()
   },
   methods: {
@@ -143,22 +109,20 @@ export default {
         console.warn('Failed to parsing', error)
       })
     },
-    updateCurrentUrl() {
-      let url = location.pathname
-      if (this.currentPage != 1) {
-        url += `?page=${this.currentPage}`
-      }
-      history.pushState(null, null, url)
-    },
     getPageValueFromParameter() {
       let url = location.href
       let results= url.match(/\?page=(\d+)/)
       if (!results) return null;
       return results[1]
     },
-    paginateClickCallback () {
+    paginateClickCallback (pageNumber) {
+      this.currentPage = pageNumber
       this.getProductsPerPage()
-      this.updateCurrentUrl()
+      history.pushState(
+        null,
+        null,
+        location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`),
+      )
     }
   }
 }

--- a/app/javascript/reports.vue
+++ b/app/javascript/reports.vue
@@ -5,29 +5,7 @@
       |  ロード中
   .reports(v-else-if="reports.length > 0 || !isUncheckedReportsPage")
     nav.pagination(v-if="totalPages > 1")
-      paginate(
-        v-model="currentPage"
-        :page-count="totalPages"
-        :page-range="9"
-        :margin-pages="0"
-        :click-handler="clickCallback"
-        :prev-text="`<i class='fas fa-angle-left'></i>`"
-        :next-text="`<i class='fas fa-angle-right'></i>`"
-        :break-view-text="''"
-        :first-last-button="true"
-        :first-button-text="`<i class='fas fa-angle-double-left'></i>`"
-        :last-button-text="`<i class='fas fa-angle-double-right'></i>`"
-        :container-class="'pagination__items'"
-        :page-class="'pagination__item'"
-        :page-link-class="'pagination__item-link'"
-        :disabled-class="'is-disabled'"
-        :prev-class="'pagination__item is-prev'"
-        :prev-link-class="'pagination__item-link is-prev'"
-        :next-class="'pagination__item is-next'"
-        :next-link-class="'pagination__item-link is-next'"
-        :active-class="'is-active'"
-        :active-link-class="'is-active'"
-        :hide-prev-next="true")
+      pager(v-bind="pagerProps")
     .thread-list.a-card
       .thread-list__items
         report(
@@ -39,29 +17,7 @@
         v-if="isUncheckedReportsPage"
         label="未チェックの日報を一括で開く")
     nav.pagination(v-if="totalPages > 1")
-      paginate(
-        v-model="currentPage"
-        :page-count="totalPages"
-        :page-range="9"
-        :margin-pages="0"
-        :click-handler="clickCallback"
-        :prev-text="`<i class='fas fa-angle-left'></i>`"
-        :next-text="`<i class='fas fa-angle-right'></i>`"
-        :break-view-text="''"
-        :first-last-button="true"
-        :first-button-text="`<i class='fas fa-angle-double-left'></i>`"
-        :last-button-text="`<i class='fas fa-angle-double-right'></i>`"
-        :container-class="'pagination__items'"
-        :page-class="'pagination__item'"
-        :page-link-class="'pagination__item-link'"
-        :disabled-class="'is-disabled'"
-        :prev-class="'pagination__item is-prev'"
-        :prev-link-class="'pagination__item-link is-prev'"
-        :next-class="'pagination__item is-next'"
-        :next-link-class="'pagination__item-link is-next'"
-        :active-class="'is-active'"
-        :active-link-class="'is-active'"
-        :hide-prev-next="true")
+      pager(v-bind="pagerProps")
   .o-empty-message(v-else)
     .o-empty-message__icon
       i.far.fa-smile
@@ -71,16 +27,18 @@
 <script>
 import Report from './report.vue'
 import UnconfirmedLink from './unconfirmed_link.vue'
+import Pager from './pager.vue'
 
 export default {
   components: {
     'report': Report,
-    'unconfirmed-link': UnconfirmedLink
+    'unconfirmed-link': UnconfirmedLink,
+    pager: Pager
   },
-  data: () => {
+  data() {
     return {
       reports: null,
-      currentPage: null,
+      currentPage: this.pageParam(),
       totalPages: null,
       currentUserId: null,
     }
@@ -90,7 +48,6 @@ export default {
       this.currentPage = this.pageParam()
       this.getReports()
     }
-    this.currentPage = this.pageParam()
     this.getReports()
   },
   methods: {
@@ -100,7 +57,7 @@ export default {
       return parseInt(page || 1)
     },
     clickCallback(pageNum){
-      this.currentPage = parseInt(pageNum)
+      this.currentPage = pageNum
       history.pushState(null, null, this.newURL)
       this.getReports()
     },
@@ -143,6 +100,14 @@ export default {
         return `/api/reports/unchecked.json?${params}`
       }else{
         return `/api/reports.json?${params}`
+      }
+    },
+    pagerProps() {
+      return {
+        initialPageNumber: this.currentPage,
+        pageCount: this.totalPages,
+        pageRange: 9,
+        clickHandle: this.clickCallback
       }
     }
   }


### PR DESCRIPTION
#2610 に関連

## 概要

Vueのpager部分が共通化できるので、pager componentを作成して、共通化した。

## 作業を行なう理由

* #2597 でprettierの修正(`prettier --write 'app/javascript/**/*.{js,vue}'`)を行なうと、このPRで変更したコードがシンタックスエラーになる。
* 共通化することにより、コードが短かくなり、読みやすくなる