### PR TITLE
ロード中があるとプラクティス選択のデザインが期待通りではない問題を修正

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -89,7 +89,7 @@
                 .empty
                   .fas.fa-spinner.fa-pulse
                   | ロード中
-              .select-practices(v-else)
+              .select-practices(v-show="practices !== null")
                 select.js-select2(
                   v-model="edited.practiceId",
                   v-select2,


### PR DESCRIPTION
issue

#2580 に対応

## 概要

質問編集ボタンを押したときに、プラクティスがロード中で、ロードが終わりプラクティス選択ができるようになったときのデザインが期待通りのデザインではない。

## 原因

`select2` の対象のHTML要素がなく `select2` が実行されないのが原因です。
CSSは `select2` で生成されるHTML要素を対象としているので、 `select2` が実行されないと期待通りのデザインになりません。

`select2` は編集ボタンを押したときに呼ばれます。

## 修正内容

`select2` の対象のHTML要素を `v-show` (display: none) で非表示するようにして、 `select2` が実行されるときに対象のHTML要素が必ず存在するようにしました。

## 修正理由

期待通りのデザインではないから

## Viewの変更部分のgif

プラクティスを取得するREST APIのサーバー側に3秒のsleep処理を追加して、必ずロード中が発生するようにしました。

<details><summary>修正前</summary>

![before](https://user-images.githubusercontent.com/43565959/115127974-9df88780-a015-11eb-9f57-61e46088f228.gif)


</details>

<details open><summary>修正後</summary>

![fix](https://user-images.githubusercontent.com/43565959/115127973-9afd9700-a015-11eb-9077-3e85ef68514c.gif)


</details>
