### PR TITLE
質問編集時のプラクティス選択の並びを修正

### DIFF
--- a/app/controllers/api/practices_controller.rb
+++ b/app/controllers/api/practices_controller.rb
@@ -8,8 +8,13 @@ class API::PracticesController < API::BaseController
   def show; end
 
   def index
-    @practices = Practice.all
-    @course = User.find(params[:user_id]).course
+    @categories = User
+                  .find(params[:user_id])
+                  .course
+                  .categories
+                  .eager_load(:practices)
+                  .where.not(practices: { id: nil })
+                  .order('categories.position ASC, categories_practices.position ASC')
   end
 
   def update

--- a/app/views/api/practices/index.json.jbuilder
+++ b/app/views/api/practices/index.json.jbuilder
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-
-json.array! @practices do |practice|
-  json.(practice, :id, :title)
-  json.category practice.category(@course).name
+@categories.flat_map do |category|
+  json.array! category.practices do |practice|
+    json.(practice, :id, :title)
+    json.category category.name
+  end
 end


### PR DESCRIPTION
issue

#2584 に対応

## 概要

質問編集時のプラクティス選択の並びがカテゴリの位置順になっていないので修正しました。

## 原因

質問編集時に利用している、プラクティス一覧をカテゴリの位置に並び替えしていないからです。

## 修正内容

プラクティス一覧をカテゴリの位置順に並び替えるように修正しました。

## 修正理由

期待通りの動作ではないから

## Viewの変更部分のgif

<details open><summary>修正前</summary>

位置順になっていないから、[Mac OS X] => [UNIX] => [Mac OS X] => [UNIX] の順になっている

![before](https://user-images.githubusercontent.com/43565959/115136655-1f730880-a05c-11eb-9629-4086502197f4.gif)

</details>

<details open><summary>修正後</summary>

修正したから、[Mac OS X] => [Mac OS X] => [UNIX] => [UNIX] の順になっている

![after](https://user-images.githubusercontent.com/43565959/115136660-2732ad00-a05c-11eb-9de7-bf24d64c4b56.gif)


</details>
