### PR TITLE
期一覧ページに2020年12月31日開始者のアイコンが表示されない

### DIFF
--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -23,12 +23,13 @@ class Generation
     m = @number - y * 4
     year = y + 2013
     month = m * 3 - 2
-    Date.new(year, month, 1)
+    Time.zone.local(year, month, 1)
   end
 
   def end_date
     next_generation = Generation.new(@number + 1)
-    next_generation.start_date - 1
+    end_date = next_generation.start_date - 1
+    end_date.end_of_day
   end
 
   def users

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 class Generation
+  START_YEAR = 2013
+
   class << self
     def generations
-      (1..max_generation_number).map { |n| Generation.new(n) }
+      (1..latest_generation_number).map { |n| Generation.new(n) }
     end
 
-    def max_generation_number
+    def latest_generation_number
       now_time = Time.zone.now
-      (now_time.year - 2013) * 4 + (now_time.month + 2) / 3
+      (now_time.year - START_YEAR) * 4 + (now_time.month + 2) / 3
     end
   end
 
@@ -18,21 +20,21 @@ class Generation
     @number = number
   end
 
-  def start_date
-    y = (@number - 1) / 4
-    m = @number - y * 4
-    year = y + 2013
-    month = m * 3 - 2
-    Time.zone.local(year, month, 1)
+  def start_of_fisrt_day
+    add_year = (@number - 1) / 4
+    year = add_year + START_YEAR
+    quarter = @number - add_year * 4
+    first_month = quarter * 3 - 2
+    Time.zone.local(year, first_month, 1)
   end
 
-  def end_date
+  def last_of_end_day
     next_generation = Generation.new(@number + 1)
-    end_date = next_generation.start_date - 1
+    end_date = next_generation.start_of_fisrt_day - 1
     end_date.end_of_day
   end
 
   def users
-    User.with_attached_avatar.same_generations(start_date, end_date)
+    User.with_attached_avatar.same_generations(start_of_fisrt_day, last_of_end_day)
   end
 end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -20,7 +20,7 @@ class Generation
     @number = number
   end
 
-  def start_of_fisrt_day
+  def start_date
     add_year = (@number - 1) / 4
     year = add_year + START_YEAR
     quarter = @number - add_year * 4
@@ -28,13 +28,12 @@ class Generation
     Time.zone.local(year, first_month, 1)
   end
 
-  def last_of_end_day
+  def end_date
     next_generation = Generation.new(@number + 1)
-    end_date = next_generation.start_of_fisrt_day - 1
-    end_date.end_of_day
+    (next_generation.start_date - 1).end_of_day
   end
 
   def users
-    User.with_attached_avatar.same_generations(start_of_fisrt_day, last_of_end_day)
+    User.with_attached_avatar.same_generations(start_date, end_date)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -255,8 +255,8 @@ class User < ApplicationRecord
       order(order_by.to_sym => direction.to_sym, created_at: :asc)
     end
   }
-  scope :same_generations, lambda { |start_of_fisrt_day, last_of_end_day|
-    where(created_at: start_of_fisrt_day..last_of_end_day)
+  scope :same_generations, lambda { |start_date, end_date|
+    where(created_at: start_date..end_date)
       .unretired
       .order(:created_at)
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -255,8 +255,8 @@ class User < ApplicationRecord
       order(order_by.to_sym => direction.to_sym, created_at: :asc)
     end
   }
-  scope :same_generations, lambda { |start_date, end_date|
-    where(created_at: start_date..end_date)
+  scope :same_generations, lambda { |start_of_fisrt_day, last_of_end_day|
+    where(created_at: start_of_fisrt_day..last_of_end_day)
       .unretired
       .order(:created_at)
   }

--- a/app/views/generations/_generation.html.slim
+++ b/app/views/generations/_generation.html.slim
@@ -6,7 +6,7 @@
           span.generations-item__title-label
             | #{generation.number}期生
           date.generations-item__date
-            | #{l generation.start_date} ~ #{l generation.end_date}
+            | #{l generation.start_of_fisrt_day.to_date} ~ #{l generation.last_of_end_day.to_date}
     .m-user-icons
       .m-user-icons__items
         = render partial: 'generations/user', collection: generation.users, as: :user

--- a/app/views/generations/_generation.html.slim
+++ b/app/views/generations/_generation.html.slim
@@ -6,7 +6,7 @@
           span.generations-item__title-label
             | #{generation.number}期生
           date.generations-item__date
-            | #{l generation.start_of_fisrt_day.to_date} ~ #{l generation.last_of_end_day.to_date}
+            | #{l generation.start_date.to_date} ~ #{l generation.end_date.to_date}
     .m-user-icons
       .m-user-icons__items
         = render partial: 'generations/user', collection: generation.users, as: :user

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -4,12 +4,22 @@ require 'test_helper'
 
 class GenerationTest < ActiveSupport::TestCase
   test '#start_date' do
-    assert_equal Date.new(2013, 1, 1), Generation.new(1).start_date
-    assert_equal Date.new(2013, 4, 1), Generation.new(2).start_date
+    assert_equal Time.zone.local(2013, 1, 1), Generation.new(1).start_date
+    assert_equal Time.zone.local(2013, 4, 1), Generation.new(2).start_date
+  end
+
+  test '#end_date' do
+    assert_equal Time.zone.local(2013, 3, 31).end_of_day, Generation.new(1).end_date
+    assert_equal Time.zone.local(2013, 6, 30).end_of_day, Generation.new(2).end_date
+    assert_equal Time.zone.local(2020, 12, 31).end_of_day, Generation.new(32).end_date
   end
 
   test '#users' do
     assert_includes Generation.new(5).users, users(:komagata)
     assert_includes Generation.new(29).users, users(:daimyo)
+    users(:komagata).created_at = Time.zone.local(2020, 12, 31, 23, 59, 59)
+    users(:komagata).save
+    assert_includes Generation.new(32).users, users(:komagata)
+    assert_not_includes Generation.new(33).users, users(:komagata)
   end
 end

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -3,15 +3,15 @@
 require 'test_helper'
 
 class GenerationTest < ActiveSupport::TestCase
-  test '#start_date' do
-    assert_equal Time.zone.local(2013, 1, 1), Generation.new(1).start_date
-    assert_equal Time.zone.local(2013, 4, 1), Generation.new(2).start_date
+  test '#start_of_fisrt_day' do
+    assert_equal Time.zone.local(2013, 1, 1), Generation.new(1).start_of_fisrt_day
+    assert_equal Time.zone.local(2013, 4, 1), Generation.new(2).start_of_fisrt_day
   end
 
-  test '#end_date' do
-    assert_equal Time.zone.local(2013, 3, 31).end_of_day, Generation.new(1).end_date
-    assert_equal Time.zone.local(2013, 6, 30).end_of_day, Generation.new(2).end_date
-    assert_equal Time.zone.local(2020, 12, 31).end_of_day, Generation.new(32).end_date
+  test '#last_of_end_day' do
+    assert_equal Time.zone.local(2013, 3, 31).end_of_day, Generation.new(1).last_of_end_day
+    assert_equal Time.zone.local(2013, 6, 30).end_of_day, Generation.new(2).last_of_end_day
+    assert_equal Time.zone.local(2020, 12, 31).end_of_day, Generation.new(32).last_of_end_day
   end
 
   test '#users' do

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -3,12 +3,12 @@
 require 'test_helper'
 
 class GenerationTest < ActiveSupport::TestCase
-  test '#start_of_fisrt_day' do
+  test '#start_date' do
     assert_equal Time.zone.local(2013, 1, 1), Generation.new(1).start_date
     assert_equal Time.zone.local(2013, 4, 1), Generation.new(2).start_date
   end
 
-  test '#last_of_end_day' do
+  test '#end_date' do
     assert_equal Time.zone.local(2013, 3, 31).end_of_day, Generation.new(1).end_date
     assert_equal Time.zone.local(2013, 6, 30).end_of_day, Generation.new(2).end_date
     assert_equal Time.zone.local(2020, 12, 31).end_of_day, Generation.new(32).end_date

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -4,14 +4,14 @@ require 'test_helper'
 
 class GenerationTest < ActiveSupport::TestCase
   test '#start_of_fisrt_day' do
-    assert_equal Time.zone.local(2013, 1, 1), Generation.new(1).start_of_fisrt_day
-    assert_equal Time.zone.local(2013, 4, 1), Generation.new(2).start_of_fisrt_day
+    assert_equal Time.zone.local(2013, 1, 1), Generation.new(1).start_date
+    assert_equal Time.zone.local(2013, 4, 1), Generation.new(2).start_date
   end
 
   test '#last_of_end_day' do
-    assert_equal Time.zone.local(2013, 3, 31).end_of_day, Generation.new(1).last_of_end_day
-    assert_equal Time.zone.local(2013, 6, 30).end_of_day, Generation.new(2).last_of_end_day
-    assert_equal Time.zone.local(2020, 12, 31).end_of_day, Generation.new(32).last_of_end_day
+    assert_equal Time.zone.local(2013, 3, 31).end_of_day, Generation.new(1).end_date
+    assert_equal Time.zone.local(2013, 6, 30).end_of_day, Generation.new(2).end_date
+    assert_equal Time.zone.local(2020, 12, 31).end_of_day, Generation.new(32).end_date
   end
 
   test '#users' do


### PR DESCRIPTION
issue #2598 

# 概要
[期一覧 \| FJORD BOOT CAMP（フィヨルドブートキャンプ）](https://bootcamp.fjord.jp/generations)のページで2020年12月31日開始者のアイコンが表示されない。

![image](https://user-images.githubusercontent.com/68221700/115146081-04ba8700-a090-11eb-8ad3-afdab9ad97e5.png)
本来なら32期にkamiokanさんとkasai441さんが表示されているはず。

##  バグの原因
`models/generation.rb`で
~~~ruby
  def start_date
    y = (@number - 1) / 4
    m = @number - y * 4
    year = y + 2013
    month = m * 3 - 2
    Date.new(year, month, 1)
  end

  def end_date
    next_generation = Generation.new(@number + 1)
    next_generation.start_date - 1
  end

  def users
    User.with_attached_avatar.same_generations(start_date, end_date)
  end
~~~
期一覧では期毎に最初の日`start_date`と最後の日`end_date`取得して、その間の日に開始した`users`を取得していた。しかしこれだと`end_date`がその日の0:00:00までに開始した登録者しか取得できず、それ以降の時刻に開始したものを取得できていなかったのが原因。なので12月31日に限らず各期の最終日に開始した人は期一覧に表示されていない。

## 修正内容
下記のように
- `start_date`を時刻まで取得するように修正
- `end_date`を`end_of_day`メソッドを使い、その日の最終時刻を取得するように修正
~~~ruby
  def start_date
    add_year = (@number - 1) / 4
    year = add_year + START_YEAR
    quarter = @number - add_year * 4
    first_month = quarter * 3 - 2
    Time.zone.local(year, first_month, 1)
  end

  def end_date
    next_generation = Generation.new(@number + 1)
    (next_generation.start_of_fisrt_day - 1).end_of_day
  end

  def users
    User.with_attached_avatar.same_generations(start_date, end_date)
  end
~~~
また、メソッド名、変数名を意味が明確になるように修正を行った。