### PR TITLE
「プロフィール画像」表記を「ユーザーアイコン」表記に変更

### DIFF
--- a/app/views/application/_required_field.html.slim
+++ b/app/views/application/_required_field.html.slim
@@ -12,7 +12,7 @@
             | が終わりましたら、以下の項目を埋めてください。
       ul.card-list__items
         - unless current_user.avatar.attached?
-          li = link_to 'プロフィール画像を登録してください。', edit_current_user_path, class: 'card-list__item-link'
+          li = link_to 'ユーザーアイコンを登録してください。', edit_current_user_path, class: 'card-list__item-link'
         - if current_user.tag_list.empty?
           li = link_to 'タグを登録してください。', edit_current_user_path, class: 'card-list__item-link'
         - @required_fields.errors.each do |error|

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -74,7 +74,7 @@ ja:
         job_seeking: 就職活動中
         retired_on: リタイア日
         free: 無料ユーザー
-        avatar: プロフィール画像
+        avatar: ユーザーアイコン
         retire_reason: 退会理由
         satisfaction: 満足度
         opinion: ご意見


### PR DESCRIPTION
[プロフィール画像をユーザーアイコンに変えたい #2560](https://github.com/fjordllc/bootcamp/issues/2560)

![スクリーンショット 2021-04-19 15 42 29](https://user-images.githubusercontent.com/47971067/115192511-e1dab200-a125-11eb-8155-e096d877d429.png)

表記の変更のみ行いました。