### PR TITLE
卒業したらプロフィールの開始日にある xxx日目 が卒業日で止まるようにする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -355,7 +355,11 @@ class User < ApplicationRecord
   end
 
   def elapsed_days
-    (Date.current - created_at.to_date).to_i
+    if graduated_on.present?
+      (graduated_on.to_date - created_at.to_date).to_i
+    else
+      (Date.current - created_at.to_date).to_i
+    end
   end
 
   def customer

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -43,8 +43,13 @@ class UserTest < ActiveSupport::TestCase
   test '#elapsed_days' do
     user = users(:komagata)
     user.created_at = Time.zone.local(2019, 1, 1, 0, 0, 0)
+    graduated_user = users(:sotugyou)
+    graduated_user.created_at = Time.zone.local(2019, 1, 1, 0, 0, 0)
+    graduated_user.graduated_on = Time.zone.local(2019, 5, 31, 0, 0, 0)
     travel_to Time.zone.local(2020, 1, 1, 0, 0, 0) do
       assert_equal 365, user.elapsed_days
+      assert_equal 150, graduated_user.elapsed_days
+      assert_not_equal 365, graduated_user.elapsed_days
     end
   end
 


### PR DESCRIPTION
issue #2582 

# 概要
卒業してもプロフィール欄にある開始日のカウントが止まっていない。卒業した日でこのカウントを止まるようにしたい。
![image](https://user-images.githubusercontent.com/68221700/115371689-29843b00-a205-11eb-896d-b109ad804494.png)

## バグの原因
`app/models/user.rb`

~~~ruby
  def elapsed_days
    (Date.current - created_at.to_date).to_i
  end
~~~

上記が単純に今日の日付と登録日の差分になっているのが原因。

## バグの修正方針
卒業日`guraduated_on`が存在するユーザーは卒業日と登録日の差分を表示するように修正。