### PR TITLE
文字列をダブルクォートではなくシングルクォートで囲むように修正

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -89,7 +89,7 @@
                 .empty
                   .fas.fa-spinner.fa-pulse
                   | ロード中
-              .select-practices(v-show="practices !== null")
+              .select-practices(v-show='practices !== null')
                 select.js-select2(
                   v-model='edited.practiceId',
                   v-select2,


### PR DESCRIPTION
## 概要

mainのコードにコーディングスタイル違反があり、そのせいで、CIが失敗するので修正する

## コーディングスタイル違反がmainに含まれた理由

#2617 のPRのマージで、コーディングスタイル違反のコードがmainに含まれました。
このPRのCIにはコーディングスタイルのeslintが含まれておらず、コーディングスタイル違反が含まれても、CIにはじかれませんでした。

## 修正内容

文字列をシングルクォートではなく、ダブルクォートで囲むように修正しました。

## 修正理由

コーディングスタイル違反 & CIが失敗するから

## Viewの変更部分のgif

コーディングスタイル違反の修正だからないです。