### PR TITLE
確認済の日報を開くとコンソールエラーが発生する問題を修正

### DIFF
--- a/app/javascript/recent_reports.vue
+++ b/app/javascript/recent_reports.vue
@@ -46,7 +46,11 @@ export default {
   },
   methods: {
     updateCheckValue(reportId, { check = true }) {
-      this.reports.find((report) => report.id === reportId).check = check
+      const report = this.reports.find((report) => report.id === reportId)
+
+      if (report !== undefined) {
+        report.check = check
+      }
     }
   },
   watch: {


### PR DESCRIPTION
issue

#2624 に対応

## 概要

確認済の日報を開くと、コンソールエラーが表示される。

## 原因

undefinedの変数にプロパティを設定しようとしていた。

コンソールエラーの内容

`TypeError: Cannot set property 'check' of undefined`

## 修正内容

undefinedの場合はプロパティを設定しないようにコードを修正した。

## 修正理由

コンソールエラーを発生させないようにするため。

## Viewの変更部分のgif


<details><summary>修正前</summary>

![console_error_before](https://user-images.githubusercontent.com/43565959/115325244-37ff3200-a1c6-11eb-935a-7966d2990da6.gif)

</details>

<details open><summary>修正後</summary>

![console_error_after](https://user-images.githubusercontent.com/43565959/115325934-75b08a80-a1c7-11eb-94b8-8029eb5a59a4.gif)


</details>