### PR TITLE
Docsのseedデータにpublished_atを追加した

### DIFF
--- a/db/fixtures/pages.yml
+++ b/db/fixtures/pages.yml
@@ -4,6 +4,7 @@ page1:
     ## test
     test
   user: komagata
+  published_at: "2018-01-01"
 
 page2:
   title: テスト
@@ -12,6 +13,7 @@ page2:
     テスト
     [example](http://example.com)
   user: komagata
+  published_at: "2019-01-01"
 
 page3:
   title: Docsページ
@@ -19,6 +21,7 @@ page3:
     ## 存在しないDocsページ遷移テスト
     [存在しないページ](http://example.com/xxxxx)
   user: komagata
+  published_at: "2020-01-01"
 
 page4:
   title: Bootcampの作業のページ
@@ -26,8 +29,10 @@ page4:
     ## テスト
     テスト
   user: komagata
+  published_at: "2021-01-01"
 
 page5:
   title: WIPのテスト
   body: WIP
   user: komagata
+  published_at: "2021-04-01"


### PR DESCRIPTION
#2484
以下の状態から
<img width="585" alt="スクリーンショット 2021-04-21 16 54 14" src="https://user-images.githubusercontent.com/47971067/115517616-492d6900-a2c2-11eb-96ad-87c9f705d5e8.png">

published_atをseedに追加して公開日を表示できるようにしました。
![スクリーンショット 2021-04-21 16 55 26](https://user-images.githubusercontent.com/47971067/115517733-69f5be80-a2c2-11eb-93e4-df35e423beec.png)
