### PR TITLE
右サイドバーのユーザータグをランダム表示に変更する

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,52 +6,29 @@ class UsersController < ApplicationController
   before_action :set_user, only: %w[show]
   PAGER_NUMBER = 20
 
-  # rubocop:disable Metrics/MethodLength
   def index
-    target_allowlist = %w[student_and_trainee followings mentor graduate adviser trainee year_end_party]
-    target_allowlist.push('job_seeking') if current_user.adviser?
-    target_allowlist.concat(%w[job_seeking retired inactive all]) if current_user.mentor? || current_user.admin?
     @target = params[:target]
     @target = 'student_and_trainee' unless target_allowlist.include?(@target)
 
-    if @target == 'followings'
-      followings = Following.where(follower_id: current_user.id).select('followed_id')
-      @users = User
-               .page(params[:page]).per(PAGER_NUMBER)
-               .includes(:company, :avatar_attachment, :course, :taggings)
-               .where(id: followings)
-               .order(updated_at: :desc)
-    elsif params[:tag]
-      @users = User
-               .page(params[:page]).per(PAGER_NUMBER)
-               .with_attached_avatar
-               .preload(:course, :taggings)
-               .unretired
-               .order(updated_at: :desc)
-               .tagged_with(params[:tag])
-    else
-      @users = User
-               .page(params[:page]).per(PAGER_NUMBER)
-               .with_attached_avatar
-               .preload(:course, :taggings)
-               .order(updated_at: :desc)
-               .users_role(@target)
-    end
+    target_users =
+      if @target == 'followings'
+        followings = Following.where(follower_id: current_user.id).select('followed_id')
+        User.where(id: followings)
+      elsif params[:tag]
+        User.tagged_with(params[:tag])
+      else
+        User.users_role(@target)
+      end
 
-    users_tags = ActsAsTaggableOn::Tag
-                 .joins(:taggings)
-                 .select('tags.id, tags.name, COUNT(taggings.id) as taggings_count')
-                 .group('tags.id, tags.name, tags.taggings_count')
-                 .where(taggings: { taggable_type: 'User' })
+    @users = target_users
+             .page(params[:page]).per(PAGER_NUMBER)
+             .preload(:company, :avatar_attachment, :course, :taggings)
+             .unretired
+             .order(updated_at: :desc)
 
-    @max_counts = users_tags
-                  .order('taggings_count desc')
-                  .limit(3)
-                  .map(&:taggings_count)
-                  .uniq
-    @random_tags = users_tags.find(users_tags.pluck(:id).sample(20))
+    @random_tags = User.tags.find(User.tags.pluck(:id).sample(20))
+    @max_counts = User.tags.order('taggings_count desc').limit(3).map(&:taggings_count).uniq
   end
-  # rubocop:enable Metrics/MethodLength
 
   def show
     @completed_learnings = @user.learnings.where(status: 3).order(updated_at: :desc)
@@ -82,6 +59,13 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def target_allowlist
+    target_allowlist = %w[student_and_trainee followings mentor graduate adviser trainee year_end_party]
+    target_allowlist.push('job_seeking') if current_user.adviser?
+    target_allowlist.concat(%w[job_seeking retired inactive all]) if current_user.mentor? || current_user.admin?
+    target_allowlist
+  end
 
   def create_free_user!
     if @user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,13 +38,14 @@ class UsersController < ApplicationController
                .users_role(@target)
     end
 
-    @popular_tags = ActsAsTaggableOn::Tag
-                    .joins(:taggings)
-                    .select('tags.id, tags.name, COUNT(taggings.id) as taggings_count')
-                    .group('tags.id, tags.name, tags.taggings_count')
-                    .where(taggings: { taggable_type: 'User' })
-                    .order('taggings_count desc')
-                    .limit(20)
+    users_tags = ActsAsTaggableOn::Tag
+                .joins(:taggings)
+                .select('tags.id, tags.name, COUNT(taggings.id) as taggings_count')
+                .group('tags.id, tags.name, tags.taggings_count')
+                .where(taggings: { taggable_type: 'User' })
+
+    @max_counts = users_tags.order('taggings_count desc').limit(3).map(&:taggings_count).uniq
+    @random_tags = users_tags.find(users_tags.pluck(:id).sample(20))
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,12 +39,16 @@ class UsersController < ApplicationController
     end
 
     users_tags = ActsAsTaggableOn::Tag
-                .joins(:taggings)
-                .select('tags.id, tags.name, COUNT(taggings.id) as taggings_count')
-                .group('tags.id, tags.name, tags.taggings_count')
-                .where(taggings: { taggable_type: 'User' })
+                 .joins(:taggings)
+                 .select('tags.id, tags.name, COUNT(taggings.id) as taggings_count')
+                 .group('tags.id, tags.name, tags.taggings_count')
+                 .where(taggings: { taggable_type: 'User' })
 
-    @max_counts = users_tags.order('taggings_count desc').limit(3).map(&:taggings_count).uniq
+    @max_counts = users_tags
+                  .order('taggings_count desc')
+                  .limit(3)
+                  .map(&:taggings_count)
+                  .uniq
     @random_tags = users_tags.find(users_tags.pluck(:id).sample(20))
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -37,4 +37,25 @@ module UsersHelper
   def user_github_grass_url(user)
     "https://grass-graph.moshimo.works/images/#{user.github_account}.png?background=none"
   end
+
+  def users_tags_rank(count, max_counts)
+    if count == max_counts[0]
+      'is-first'
+    elsif count == max_counts[1]
+      'is-second'
+    elsif count == max_counts[2]
+      'is-third'
+    end
+  end
+
+  def users_tags_gradation(count, max_count)
+    gradation_size = 3
+    if count > (max_count / gradation_size * 2)
+      'is-up'
+    elsif count <= (max_count / gradation_size)
+      'is-low'
+    else
+      'is-mid'
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -291,6 +291,14 @@ class User < ApplicationRecord
         send(target)
       end
     end
+
+    def tags
+      ActsAsTaggableOn::Tag
+        .joins(:taggings)
+        .select('tags.id, tags.name, COUNT(taggings.id) as taggings_count')
+        .group('tags.id, tags.name, tags.taggings_count')
+        .where(taggings: { taggable_type: 'User' })
+    end
   end
 
   def away?

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -39,6 +39,6 @@ html.is-application lang='ja'
         = render 'footer'
     - if display_recent_reports?
       #js-recent-reports
-    - elsif @popular_tags
+    - elsif @random_tags
       = render '/users/popular_tags'
     = any_login_here if defined?(AnyLogin)

--- a/app/views/users/_popular_tags.html.slim
+++ b/app/views/users/_popular_tags.html.slim
@@ -7,7 +7,7 @@
   .popular-tags__items
     ul.popular-tags__items
       - @random_tags.each do |tag|
-        li.popular-tags__item class=("#{users_tags_gradation(tag.taggings_count, @max_counts[0])} #{users_tags_rank(tag.taggings_count, @max_counts)}")
+        li.popular-tags__item class="#{users_tags_gradation(tag.taggings_count, @max_counts[0])} #{users_tags_rank(tag.taggings_count, @max_counts)}"
           = link_to "/users/tags/#{tag.name}", class: 'popular-tags__item-link' do
             .popular-tags__item-link-inner
               .popular-tags__item-name

--- a/app/views/users/_popular_tags.html.slim
+++ b/app/views/users/_popular_tags.html.slim
@@ -6,8 +6,8 @@
           | ユーザータグ一覧
   .popular-tags__items
     ul.popular-tags__items
-      - @popular_tags.each do |tag|
-        li.popular-tags__item
+      - @random_tags.each do |tag|
+        li.popular-tags__item class=("#{users_tags_gradation(tag.taggings_count, @max_counts[0])} #{users_tags_rank(tag.taggings_count, @max_counts)}")
           = link_to "/users/tags/#{tag.name}", class: 'popular-tags__item-link' do
             .popular-tags__item-link-inner
               .popular-tags__item-name


### PR DESCRIPTION
issue #2380

右サイドバーにあるユーザータグの一覧が、今までは人気順になっていたのをランダムに表示されるように変更しました。
また、上位３位までにはそれぞれviewでクラスをふっています。
また登録者数を３段階に分けてそちらでもそれぞれviewにクラスをふっています。

rubocopでMetrics/PerceivedComplexityの警告が出るためusers_controllerを少し整理しました。
私が書いたmapが複雑性のカウント対象になっており、rubocop設定のカウント8を一つ超えました。
target_allowlistをメソッドに分割し、分岐を外に出すかたちで一応解決しています。

viewのファイル名やクラスの名前は今のところpopular_tag〜のままにしています。
デザインの方は町田さんに引継ぎます。

<img width="1205" alt="ユーザー一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/66161651/115948890-de6f6e00-a50b-11eb-9e51-b2b0cb0b561c.png">
