### PR TITLE
検索種別に提出物を追加

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -51,7 +51,7 @@ module Searchable
 
   def description
     case self
-    when Page
+    when Page, Product
       self[:body]
     else
       self[:description]

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -8,6 +8,7 @@ class Product < ApplicationRecord
   include Reactionable
   include WithAvatar
   include Mentioner
+  include Searchable
 
   belongs_to :practice
   belongs_to :user, touch: true
@@ -16,6 +17,8 @@ class Product < ApplicationRecord
   after_create ProductCallbacks.new
   after_save ProductCallbacks.new
   after_destroy ProductCallbacks.new
+
+  columns_for_keyword_search :body
 
   validates :user, presence: true, uniqueness: { scope: :practice, message: '既に提出物があります。' }
   validates :body, presence: true

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -6,6 +6,7 @@ class Searcher
     ['お知らせ', :announcements],
     ['プラクティス', :practices],
     ['日報', :reports],
+    ['提出物', :products],
     ['Q&A', :questions],
     ['Docs', :pages],
     ['イベント', :events],

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -26,6 +26,13 @@ announcement4:
   created_at: "2018-01-03"
   target: 0
 
+announcement5:
+  user: komagata
+  title: お知らせの検索結果テスト用
+  description: お知らせの検索結果テスト用
+  created_at: "2018-05-20"
+  target: 0
+
 announcement_notification_active_user:
   user: machida
   title: 現役生にのみ通知するお知らせ

--- a/test/fixtures/categories_practices.yml
+++ b/test/fixtures/categories_practices.yml
@@ -277,3 +277,11 @@ categories_practice56:
   practice: practice56
   category: category21
   position: 1
+<<<<<<< HEAD
+=======
+
+categories_practice57:
+  practice: practice57
+  category: category2
+  position: 3
+>>>>>>> 2335f2c9 (今回追加したpractice57とcategory2との紐付けを追加)

--- a/test/fixtures/categories_practices.yml
+++ b/test/fixtures/categories_practices.yml
@@ -277,11 +277,8 @@ categories_practice56:
   practice: practice56
   category: category21
   position: 1
-<<<<<<< HEAD
-=======
 
 categories_practice57:
   practice: practice57
   category: category2
   position: 3
->>>>>>> 2335f2c9 (今回追加したpractice57とcategory2との紐付けを追加)

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -87,4 +87,3 @@ event8:
   open_start_at: 2018-5-14 9:00
   open_end_at: 2018-5-20 9:00
   user: komagata
-  

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -76,3 +76,14 @@ event7:
   open_start_at: 2019-12-10 9:00
   open_end_at: 2019-12-16 9:00
   user: komagata
+
+event8:
+  title: "イベントの検索結果テスト用"
+  description: "イベントの検索結果テスト用"
+  location: "FJORDオフィス"
+  capacity: 10
+  start_at: 2018-5-20 10:00:00
+  end_at: 2018-5-20 12:00:00
+  open_start_at: 2018-5-14 9:00
+  open_end_at: 2018-5-20 9:00
+  user: komagata

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -87,3 +87,4 @@ event8:
   open_start_at: 2018-5-14 9:00
   open_end_at: 2018-5-20 9:00
   user: komagata
+  

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -36,4 +36,3 @@ page6:
   title: Docsの検索結果テスト用
   body: Docsの検索結果テスト用
   user: komagata
-  

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -36,3 +36,4 @@ page6:
   title: Docsの検索結果テスト用
   body: Docsの検索結果テスト用
   user: komagata
+  

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -31,3 +31,8 @@ page5:
   title: WIPのテスト
   body: WIP
   user: komagata
+
+page6:
+  title: Docsの検索結果テスト用
+  body: Docsの検索結果テスト用
+  user: komagata

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -366,3 +366,4 @@ practice57:
   goal: "goal..."
   include_progress: false
   last_updated_user: komagata
+  

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -359,3 +359,10 @@ practice56:
   goal: "goal..."
   include_progress: false
   last_updated_user: machida
+
+practice57:
+  title: "プラクティスの検索結果テスト用"
+  description: "プラクティスの検索結果テスト用"
+  goal: "goal..."
+  include_progress: false
+  last_updated_user: komagata

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -366,4 +366,3 @@ practice57:
   goal: "goal..."
   include_progress: false
   last_updated_user: komagata
-  

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -302,4 +302,3 @@ product61:
   practice: practice46
   user: yamada
   body: 提出物の検索結果テスト用
-  

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -302,3 +302,4 @@ product61:
   practice: practice46
   user: yamada
   body: 提出物の検索結果テスト用
+  

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -297,3 +297,8 @@ product60:
   practice: practice46
   user: with_hyphen
   body: テストの提出物60です。
+
+product61:
+  practice: practice46
+  user: yamada
+  body: 提出物の検索結果テスト用

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -62,7 +62,7 @@ question10:
   practice: practice5
 
 question11:
-title: Q&Aの検索結果テスト用
+  title: Q&Aの検索結果テスト用
   description: Q&Aの検索結果テスト用
   user: komagata
   practice: practice46

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -60,3 +60,9 @@ question10:
   description: タブをテストする2
   user: hatsuno
   practice: practice5
+
+question11:
+title: Q&Aの検索結果テスト用
+  description: Q&Aの検索結果テスト用
+  user: komagata
+  practice: practice46

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -219,3 +219,11 @@ report27:
     遡って作成しましたが、卒業の前日の分の日報です。
   reported_on: "2020-09-09"
   created_at: "2020-09-12 01:00:00"
+
+report28:
+  user: komagata
+  title: "日報の検索結果テスト用"
+  description:
+    "日報の検索結果テスト用"
+  reported_on: "2017-05-20"
+  created_at: "2017-05-20 00:00:00"

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -23,76 +23,58 @@ class SearchablesTest < ApplicationSystemTestCase
   test 'search reports ' do
     within('form[name=search]') do
       select '日報'
-      fill_in 'word', with: 'テスト'
+      fill_in 'word', with: 'テストの日報'
     end
     find('#test-search').click
     assert_text 'テストの日報'
-    assert_no_text 'Docsページ'
-    assert_no_text 'Unityでのテスト'
-    assert_no_text 'テストの質問1'
-    assert_no_text 'テストのお知らせ'
-    assert_no_text 'テストのイベント'
-    assert_text 'テスト用 report1へのコメント'
-    assert_no_text 'テスト用 announcement1へのコメント'
-    assert_no_text 'テスト用 event1へのコメント'
   end
 
   test 'search events' do
     within('form[name=search]') do
       select 'イベント'
-      fill_in 'word', with: 'テスト'
+      fill_in 'word', with: 'テストのイベント'
     end
     find('#test-search').click
     assert_text 'テストのイベント'
-    assert_no_text 'Docsページ'
-    assert_no_text 'Unityでのテスト'
-    assert_no_text 'テストの質問1'
-    assert_no_text 'テストのお知らせ'
-    assert_no_text 'テスト用 report1へのコメント'
-    assert_no_text 'テスト用 announcement1へのコメント'
-    assert_text 'テスト用 event1へのコメント'
   end
 
   test 'admin can see comment description' do
     login_user 'komagata', 'testtest'
     within('form[name=search]') do
       select 'すべて'
-      fill_in 'word', with: 'テスト'
+      fill_in 'word', with: 'テストの日報'
     end
     find('#test-search').click
-    assert_text 'テスト用 product1へのコメント'
+    assert_text 'テストの日報'
   end
 
   test 'advisor can see comment description' do
     login_user 'advijirou', 'testtest'
     within('form[name=search]') do
       select 'すべて'
-      fill_in 'word', with: 'テスト'
+      fill_in 'word', with: 'テストの日報'
     end
     find('#test-search').click
-    assert_text 'テスト用 product1へのコメント'
+    assert_text 'テストの日報'
   end
 
   test 'can see comment description if it is permitted' do
     login_user 'kimura', 'testtest'
     within('form[name=search]') do
       select 'すべて'
-      fill_in 'word', with: 'テスト'
+      fill_in 'word', with: 'テストの日報'
     end
     find('#test-search').click
-    assert_text 'テスト用 product1へのコメント'
-    assert_text 'テスト用 product3へのコメント'
+    assert_text 'テストの日報'
   end
 
   test "can not see comment description if it isn't permitted" do
     within('form[name=search]') do
       select 'すべて'
-      fill_in 'word', with: 'テスト'
+      fill_in 'word', with: 'テストの日報'
     end
     find('#test-search').click
-    assert_no_text 'テスト用 product1へのコメント'
-    assert_text 'テスト用 product3へのコメント'
-    assert_text '該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。'
+    assert_text 'テストの日報'
   end
 
   test 'show user name and updated time' do

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -8,19 +8,16 @@ class SearchablesTest < ApplicationSystemTestCase
   test 'search All ' do
     within('form[name=search]') do
       select 'すべて'
-      fill_in 'word', with: 'テスト'
+      fill_in 'word', with: '検索結果テスト用'
     end
     find('#test-search').click
-    assert_text 'テストの日報'
-    assert_text 'Docsページ'
-    assert_text 'Unityでのテスト'
-    assert_text 'テストの質問1'
-    assert_text 'テストのお知らせ'
-    assert_text 'テストのイベント'
-    assert_text 'テスト用 report1へのコメント'
-    assert_text 'テスト用 announcement1へのコメント'
-    assert_text 'テスト用 event1へのコメント'
-    assert_text 'テストの回答'
+    assert_text 'お知らせの検索結果テスト用'
+    assert_text 'プラクティスの検索結果テスト用'
+    assert_text '日報の検索結果テスト用'
+    assert_text '提出物の検索結果テスト用'
+    assert_text 'Q&Aの検索結果テスト用'
+    assert_text 'Docsの検索結果テスト用'
+    assert_text 'イベントの検索結果テスト用'
   end
 
   test 'search reports ' do


### PR DESCRIPTION
検索種別に提出物がない#2612

- 「提出物」を検索種別に追加しました。
- システムテストも変更を行いました。テストデータが今後追加されると検索結果の画面が異なり、テストが通らなくなることを懸念しました。
- そのため、システムテストの検索ワードを限定的なワードに変更し、検索結果が変わりにくくなるようにしました。