### PR TITLE
解決済みのQ&Aのソート順(並び)を新規コメントの作成日時順にする

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -20,14 +20,14 @@ class QuestionsController < ApplicationController
       end
     @tags = questions.all_tags
     questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
-    questions =
+    questions = questions.preload(%i[practice answers]).with_avatar.page(params[:page])
+    questions = questions.tagged_with(params[:tag]) if params[:tag]
+    @questions =
       if params[:solved].present?
         questions.includes(:answers).order('answers.updated_at DESC')
       else
         questions.order(updated_at: :desc, id: :desc)
       end
-    @questions = questions.preload(%i[practice answers]).with_avatar.page(params[:page])
-    @questions = @questions.tagged_with(params[:tag]) if params[:tag]
     @questions_property = questions_property
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -18,6 +18,7 @@ class QuestionsController < ApplicationController
       else
         Question.not_solved
       end.order(updated_at: :desc, id: :desc)
+    @tags = questions.all_tags
     @questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
     @questions = @questions.preload(%i[practice answers]).with_avatar.page(params[:page])
     @questions = @questions.tagged_with(params[:tag]) if params[:tag]

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -19,14 +19,14 @@ class QuestionsController < ApplicationController
         Question.not_solved
       end
     @tags = questions.all_tags
-    @questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
-    @questions =
+    questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
+    questions =
       if params[:solved].present?
-        @questions.includes(:answers).order('answers.updated_at DESC')
+        questions.includes(:answers).order('answers.updated_at DESC')
       else
-        @questions.order(updated_at: :desc, id: :desc)
+        questions.order(updated_at: :desc, id: :desc)
       end
-    @questions = @questions.preload(%i[practice answers]).with_avatar.page(params[:page])
+    @questions = questions.preload(%i[practice answers]).with_avatar.page(params[:page])
     @questions = @questions.tagged_with(params[:tag]) if params[:tag]
     @questions_property = questions_property
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -17,9 +17,15 @@ class QuestionsController < ApplicationController
         Question.all
       else
         Question.not_solved
-      end.order(updated_at: :desc, id: :desc)
+      end
     @tags = questions.all_tags
     @questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
+    @questions =
+      if params[:solved].present?
+        @questions.includes(:answers).order('answers.updated_at DESC')
+      else
+        @questions.order(updated_at: :desc, id: :desc)
+      end
     @questions = @questions.preload(%i[practice answers]).with_avatar.page(params[:page])
     @questions = @questions.tagged_with(params[:tag]) if params[:tag]
     @questions_property = questions_property

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -21,7 +21,7 @@ class Question < ApplicationRecord
   validates :description, presence: true
   validates :user, presence: true
 
-  scope :solved, -> { joins(:correct_answer) }
+  scope :solved, -> { where(id: CorrectAnswer.pluck(:question_id)) }
   scope :not_solved, -> { where.not(id: CorrectAnswer.pluck(:question_id)) }
 
   columns_for_keyword_search :title, :description

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -31,7 +31,7 @@ header.page-header
         - else
           .a-empty-message
             = @questions_property.empty_message
-      - if @questions.all_tags.any?
+      - if @tags.any?
         nav.page-tags-nav
           header.page-tags-nav__header
             h2.page-tags-nav__title


### PR DESCRIPTION
## issue
#2135 に対応

## やったこと
- 古い解決済みの質問に新しくタグをつけてもトップに来ないようにした。
- QAの解決済みのページのみ新着コメント順で並ぶようにした。
## しなかったこと
質問の
```ruby
questions =
      if params[:solved].present?
        Question.solved
      elsif params[:all].present?
        Question.all
      else
        Question.not_solved
      end.order(updated_at: :desc, id: :desc)
```
ここを
```ruby
questions =
      if params[:solved].present?
        Question.solved.includes(:answers).order('answers.updated_at DESC')
      elsif params[:all].present?
        Question.all.order(updated_at: :desc, id: :desc)
      else
        Question.not_solved.order(updated_at: :desc, id: :desc)
      end
```
のようにしませんでした。
何故ならば`app/views/questions/index.html.slim `の34行目で
```
#app/views/questions/index.html.slim 
 - if @questions.all_tags.any?
```
とあり、
```bash
PG::SyntaxError: ERROR:  subquery has too many columns
LINE 1: ...able_type = 'Question') AND (taggings.taggable_id IN(SELECT ...
```
となるため。
## 解決策
改めてcontrollerに`@tags`を置いて未解決、解決済み、全ての質問にtagがあるかどうか判断させ、並び替えは別で代入することにしました。
