### PR TITLE
メンション付きコメントでメンションされた人に「コメントしました」という通知が来ないように修正

### DIFF
--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -24,11 +24,13 @@ class AnswerCallbacks
 
   def notify_to_watching_user(answer)
     question = Question.find(answer.question_id)
+    mention_user_ids = answer.new_mention_users.ids
 
     retrun unless question.try(:watched?)
+
     watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
     watcher_ids.each do |watcher_id|
-      if watcher_id != answer.sender.id
+      if watcher_id != answer.sender.id && !mention_user_ids.include?(watcher_id)
         watcher = User.find_by(id: watcher_id)
         NotificationFacade.watching_notification(question, watcher, answer)
       end

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -26,7 +26,7 @@ class AnswerCallbacks
     question = Question.find(answer.question_id)
     mention_user_ids = answer.new_mention_users.ids
 
-    retrun unless question.try(:watched?)
+    return unless question.try(:watched?)
 
     watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
     watcher_ids.each do |watcher_id|


### PR DESCRIPTION
issue #2595 

# 概要
ウォッチ中のQ&Aにメンション付きコメントをすると、ウォッチしている人にメンションとコメントの両方の通知（＋メール）が行ってしまう。

issue参考のこと
> https://bootcamp.fjord.jp/questions/873 の通知メールの例。
![image](https://user-images.githubusercontent.com/68221700/116506255-dcd0ec00-a8f7-11eb-8ca7-d3c8cd8c0070.png)
![image](https://user-images.githubusercontent.com/68221700/116506297-f40fd980-a8f7-11eb-8b8e-680cadc03ea4.png)

## 修正の方針
メンションだけ通知（＋メール）をするように修正する。

## 修正概要
ほぼ同様のissueあったため、そちらを参考にメンションがあったユーザーはコメントの通知時に除外するように修正。
[メンションの通知がある場合はWatchの通知を送らないようにした by komagata · Pull Request \#1728 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/pull/1728)

