### PR TITLE
質問者のコースにはないプラクティスの質問だと内容編集できない問題を修正

### DIFF
--- a/app/controllers/api/practices_controller.rb
+++ b/app/controllers/api/practices_controller.rb
@@ -8,10 +8,7 @@ class API::PracticesController < API::BaseController
   def show; end
 
   def index
-    @categories = User
-                  .find(params[:user_id])
-                  .course
-                  .categories
+    @categories = Category
                   .eager_load(:practices)
                   .where.not(practices: { id: nil })
                   .order('categories.position ASC, categories_practices.position ASC')

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -226,7 +226,7 @@ export default {
     }
   },
   created() {
-    this.fetchPractices(this.question.user.id)
+    this.fetchPractices()
   },
   mounted() {
     TextareaInitializer.initialize(`#js-question-content`)
@@ -236,8 +236,8 @@ export default {
       const meta = document.querySelector('meta[name="csrf-token"]')
       return meta ? meta.getAttribute('content') : ''
     },
-    fetchPractices(userId) {
-      fetch(`/api/practices.json?user_id=${userId}`, {
+    fetchPractices() {
+      fetch('/api/practices.json', {
         method: 'GET',
         headers: {
           'X-Requested-With': 'XMLHttpRequest',

--- a/test/integration/api/practices_test.rb
+++ b/test/integration/api/practices_test.rb
@@ -6,14 +6,11 @@ class API::PracticesTest < ActionDispatch::IntegrationTest
   fixtures :practices
 
   test 'GET /api/practices.json' do
-    user = User.find_by(login_name: 'kimura')
-    params = { user_id: user.id }
     get api_practices_path(format: :json)
     assert_response :unauthorized
 
-    token = create_token(user.login_name, 'testtest')
+    token = create_token('kimura', 'testtest')
     get api_practices_path(format: :json),
-        params: params,
         headers: { 'Authorization' => "Bearer #{token}" }
 
     assert_response :ok


### PR DESCRIPTION
issue

#2634 に対応

## 概要

質問者のコースにはないプラクティスの質問だと、質問の内容編集ができない。

## 原因

次のコードの `practices` に、質問者のコースに含まれているプラクティスだけが格納されています。質問者のコースに含まれていないプラクティスが選択されると、 `practices.find((practice) => practice.id === practiceId)` が `undefined` になり、内容編集が動かなくなります。

https://github.com/fjordllc/bootcamp/blob/83cda1433a1ae80070695659b10ec376bed843a2/app/javascript/question-edit.vue#L206-L212

## 修正内容

質問者のコースにはないプラクティスも、プラクティス一覧取得のREST APIに含めて、`practices.find((practice) => practice.id === practiceId)` で `undefined` にならないようにしました。

## 修正理由

質問編集ができず、期待通りの動作ではないから

## Viewの変更部分のgif

<details><summary>修正前</summary>

![before](https://user-images.githubusercontent.com/43565959/115127974-9df88780-a015-11eb-9f57-61e46088f228.gif)

</details>

<details open><summary>修正後</summary>

![after](https://user-images.githubusercontent.com/43565959/116485937-72a05300-a8c7-11eb-96ae-ba93b7178a5d.gif)

</details>
