### PR TITLE
Vue.jsで表示する際にプラクティスの説明文が表示できるようにする

### DIFF
--- a/app/assets/stylesheets/blocks/practice/_categories.sass
+++ b/app/assets/stylesheets/blocks/practice/_categories.sass
@@ -81,8 +81,6 @@
     +text-block(.875rem 1.6 0 .6em)
   *:last-child
     margin-bottom: 0
-  .is-practices-description
-    display: block
 
 .categories-item__edit
   float: right

--- a/app/assets/stylesheets/blocks/practice/_categories.sass
+++ b/app/assets/stylesheets/blocks/practice/_categories.sass
@@ -81,6 +81,8 @@
     +text-block(.875rem 1.6 0 .6em)
   *:last-child
     margin-bottom: 0
+  .js-markdown-view.js-target-blank.is-long-text
+    display: block
 
 .categories-item__edit
   float: right

--- a/app/assets/stylesheets/blocks/practice/_categories.sass
+++ b/app/assets/stylesheets/blocks/practice/_categories.sass
@@ -81,7 +81,7 @@
     +text-block(.875rem 1.6 0 .6em)
   *:last-child
     margin-bottom: 0
-  .js-markdown-view.js-target-blank.is-long-text
+  .is-practices-description
     display: block
 
 .categories-item__edit

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -102,7 +102,9 @@ export default {
           const count = location.href.search('#')
           const hash = location.href.slice(count + 1)
           const element = document.getElementById(hash)
-          element.scrollIntoView()
+          if (element) {
+            element.scrollIntoView()
+          }
         })
         .catch((error) => {
           console.warn('Failed to parsing', error)

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -24,8 +24,9 @@
               :href='`${category.edit_admin_category_path}`'
             )
               i.fas.fa-pen
-          .is-long-text
-            p {{ category.description }}
+          .is-long-text(
+            v-html='markdownDescription'
+          )
         .categories-item__body
           .category-practices.js-category-practices
             courses-practice(
@@ -48,6 +49,7 @@
 
 <script>
 import CoursesPractice from './courses-practice.vue'
+import MarkdownInitializer from './markdown-initializer'
 
 export default {
   components: {
@@ -64,6 +66,10 @@ export default {
     }
   },
   computed: {
+    markdownDescription: function () {
+      const markdownInitializer = new MarkdownInitializer()
+      return markdownInitializer.render(this.description)
+    },
     url() {
       return `/api/courses/${this.courseId}/practices`
     },

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -61,9 +61,6 @@ export default {
     return {
       categories: null,
       learnings: null,
-      styleObject: {
-        display: 'block'
-      }
     }
   },
   computed: {

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -60,10 +60,7 @@ export default {
   data: () => {
     return {
       categories: null,
-      learnings: null,
-      styleObject: {
-        display: 'block'
-      }
+      learnings: null
     }
   },
   computed: {

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -60,7 +60,7 @@ export default {
   data: () => {
     return {
       categories: null,
-      learnings: null,
+      learnings: null
     }
   },
   computed: {

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -60,7 +60,10 @@ export default {
   data: () => {
     return {
       categories: null,
-      learnings: null
+      learnings: null,
+      styleObject: {
+        display: 'block'
+      }
     }
   },
   computed: {

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -24,7 +24,7 @@
               :href='`${category.edit_admin_category_path}`'
             )
               i.fas.fa-pen
-          .is-long-text(v-html='markdownDescription')
+          .is-long-text(v-html='markdownDescription(category.description)')
         .categories-item__body
           .category-practices.js-category-practices
             courses-practice(
@@ -66,7 +66,9 @@ export default {
   computed: {
     markdownDescription: function () {
       const markdownInitializer = new MarkdownInitializer()
-      return markdownInitializer.render(this.description)
+      return function (description) {
+        return markdownInitializer.render(description)
+      }
     },
     url() {
       return `/api/courses/${this.courseId}/practices`

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -24,9 +24,7 @@
               :href='`${category.edit_admin_category_path}`'
             )
               i.fas.fa-pen
-          .is-long-text(
-            v-html='markdownDescription'
-          )
+          .is-long-text(v-html='markdownDescription')
         .categories-item__body
           .category-practices.js-category-practices
             courses-practice(

--- a/app/views/admin/categories/_form.html.slim
+++ b/app/views/admin/categories/_form.html.slim
@@ -15,11 +15,11 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown practices-edit__input'
+          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown practices-edit__input', data: { 'preview': '.js-preview' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー
-          .js-markdown-preview.is-long-text.practices-edit__input.practices-edit__preview
+          .js-preview.is-long-text.practices-edit__input.markdown-form__preview
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main


### PR DESCRIPTION
 #2667
のissueに対応

### 発生した現象
ステージング環境でプラクティスの説明文が表示されない。

<img width="1106" alt="スクリーンショット 2021-05-06 20 24 06" src="https://user-images.githubusercontent.com/64201542/117291322-cbfd1900-aea9-11eb-9172-27fe98d6d011.png">

### 原因
ステージング環境では以下の部分が機能していないためスタイルが崩れ表示されなくなっていた。
```
app/javascript/courses-practices.vue

<style scoped>
.js-markdown-view.js-target-blank.is-long-text {
  display: block;
}
</style>
```

[Usage](https://github.com/rails/webpacker#usage)
[Webpacker:Vue component styles do not work \#987](https://github.com/rails/webpacker/issues/987)

webpackでvue-loaderを使用する場合には、javascriptとは別に読み込む設定をしてあげないとstyle部分が機能していないとのことです。
本アプリでは下記記述がなかったため本番環境ではstyle部分が読み込めなかったかと思われます。　

```
<%= stylesheet_pack_tag 'application' %>
```

### 対応方法
今回は動的にstyleが変更しないため、vueでstyleの設定をする必要がないと考え、css側で対応しました。

関連issue
[プラクティス一覧をvue\.jsで表示できるようにした \#2537](https://github.com/fjordllc/bootcamp/pull/2537)