### PR TITLE
[HotFix] プラクティス一覧の所要時間の目安の単位（時間）を出すようにした

### DIFF
--- a/app/javascript/courses-practice.vue
+++ b/app/javascript/courses-practice.vue
@@ -12,7 +12,7 @@
     )
       | {{ translate(practices.practice.id) }}
   .category-practices-item__learning-time(v-if='practiceTime')
-    | 所要時間の目安: {{ practiceTime.median }}
+    | 所要時間の目安: {{ convertToHourMinute(practiceTime.median) }}
     | （平均: {{ convertToHourMinute(practiceTime.average) }})
   .m-user-icons(v-if='practices.started_students.length')
     .m-user-icons__items


### PR DESCRIPTION
@komagata 
プラクティス一覧の「所要時間の目安」に単位（時間）が出ていないバグがあったので、修正をしました。
こちら、HotFixとしてデプロイをお願いしたいです🙏