### PR TITLE
表記を「リタイア」から「退会」に変更

### DIFF
--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -34,7 +34,7 @@
             - elsif user.trainee
               | 研修生
             - elsif user.retired_on?
-              | リタイア
+              | 退会
             - elsif user.graduated_on?
               | 卒業生
             - elsif user.active?

--- a/app/views/users/_learning_status.html.slim
+++ b/app/views/users/_learning_status.html.slim
@@ -1,7 +1,7 @@
 - if user.graduated_on.present?
   | #{l user.graduated_on} 卒業
 - elsif user.retired_on.present?
-  | #{l user.retired_on} リタイア
+  | #{l user.retired_on} 退会済
 - else
   | 学習開始から
   strong

--- a/app/views/users/form/_retire.html.slim
+++ b/app/views/users/form/_retire.html.slim
@@ -2,7 +2,7 @@
   .form-item__label-checkbox
     = check_box_tag :retire_checkbox, 1, false, class: 'js-date-input-toggler-checkbox'
     = f.label :retired_on, class: 'a-form-label', for: 'retire_checkbox' do
-      | リタイア
+      | 退会
   .form-item__inline-form-item.js-date-input-toggler-date-area
     .a-form-label = User.human_attribute_name :retired_on
     = f.date_field :retired_on, class: 'a-text-input js-date-input-toggler-date'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -72,7 +72,7 @@ ja:
         adviser: アドバイザー
         trainee: 研修生
         job_seeking: 就職活動中
-        retired_on: リタイア日
+        retired_on: 退会日
         free: 無料ユーザー
         avatar: ユーザーアイコン
         retire_reason: 退会理由
@@ -218,7 +218,7 @@ ja:
     graduate: 卒業生
     adviser: アドバイザー
     all: 全員
-    retired: リタイア
+    retired: 退会
     inactive: 非アクティブ
     year_end_party: 忘年会
     trainee: 研修生

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -98,7 +98,7 @@ yameo:
   twitter_account: yameo
   facebook_url: http://www.facebook.com/yameo
   blog_url: http://yameo.org
-  description: "リタイアしました。就職希望はしてました"
+  description: "退会しました。就職希望はしてました"
   course: course1
   job: office_worker
   os: mac

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -98,7 +98,7 @@ yameo:
   twitter_account: yameo
   facebook_url: http://www.facebook.com/yameo
   blog_url: http://yameo.org
-  description: "リタイアしました。就職希望はしてました"
+  description: "退会しました。就職希望はしてました"
   course: course1
   job: office_worker
   os: mac

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -166,7 +166,6 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_text '就職活動中'
 
     visit 'users?target=retired'
-    assert_no_text 'リタイア'
     assert_no_text '退会'
   end
 
@@ -177,7 +176,6 @@ class UsersTest < ApplicationSystemTestCase
     assert find_link('就職活動中')
 
     visit 'users?target=retired'
-    assert_no_text 'リタイア'
     assert_no_text '退会'
   end
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -29,9 +29,9 @@ class UsersTest < ApplicationSystemTestCase
   test 'retired date is displayed' do
     login_user 'komagata', 'testtest'
     visit "/users/#{users(:yameo).id}"
-    assert_text 'リタイア日'
+    assert_text '退会日'
     visit "/users/#{users(:sotugyou).id}"
-    assert_no_text 'リタイア日'
+    assert_no_text '退会日'
   end
 
   test 'retire reason is displayed when login user is admin' do


### PR DESCRIPTION
ref #2651

## 変更の理由

256intern時代と現在のフィヨルドブートキャンプの間の期間は、就職を目指す人のためのトレーニングが目的だったので、卒業して就職か、断念の二択しかなかったので、リタイアと付けられていたが、現在のフィヨルドブートキャンプは就職や卒業が目的ではなくなり、リタイアは相応しくなくなったため。

## 変更点
ロケールファイルを変更しました。
退会を英訳すると`withdraw`なのですが`retire`でも同じような意味を持ち、わかりやすいと判断したので日本語のみ変更しています。