### PR TITLE
ユーザー個別ページの日報が空の場合の文言を記載

### DIFF
--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -23,6 +23,9 @@ header.page-header
       .thread-list.a-card
         = render partial: 'reports/report', collection: @reports, as: :report
     - else
-      .a-empty-message
-        | 日報はまだありません。
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | 日報はまだありません。
     = paginate @reports, position: 'bottom'

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -22,4 +22,7 @@ header.page-header
     - if @reports.present?
       .thread-list.a-card
         = render partial: 'reports/report', collection: @reports, as: :report
+    - else
+      .a-empty-message
+        | 日報はまだありません。
     = paginate @reports, position: 'bottom'


### PR DESCRIPTION
ref: #2642

## 概要 
ユーザー個別ページの日報が空の場合の文言を記載し、顔マークの表示を実装しました。


## 実装前
![image](https://user-images.githubusercontent.com/75117116/118393650-1edd8a00-b67b-11eb-8efb-a0ff70fc278e.png)


## 実装後
![image](https://user-images.githubusercontent.com/75117116/118393634-09686000-b67b-11eb-8f33-a2585b623063.png)


