### PR TITLE
軽いcssのバグを修正

### DIFF
--- a/app/assets/stylesheets/atoms/_a-page-notice.sass
+++ b/app/assets/stylesheets/atoms/_a-page-notice.sass
@@ -3,11 +3,21 @@
   color: $reversal-text
   &.is-danger
     background-color: $danger
+  .page-body &
+    +margin(vertical, -.5rem 1rem)
+  .page-tools + &
+    margin-top: -1px
+  .page-tabs + &
+    margin-top: 1rem
 
 .a-page-notice__inner
   +padding(vertical, .5rem)
   p
-    +text-block(.875rem 1.4, $reversal-text center)
+    +text-block(1em 1.4, $reversal-text center)
+    +media-breakpoint-up(md)
+      font-size: .875rem
+    +media-breakpoint-down(sm)
+      font-size: .75rem
   a
     color: $reversal-text
     +hover-link-reversal

--- a/app/assets/stylesheets/blocks/header/_header.sass
+++ b/app/assets/stylesheets/blocks/header/_header.sass
@@ -1,9 +1,11 @@
 .header
   background-color: $base
-  +position(relative, 2)
+  z-index: 3
   border-bottom: solid 1px $background
   +media-breakpoint-up(md)
     +position(sticky, top 0)
+  +media-breakpoint-down(sm)
+    position: relative
 
 .header__container
   display: flex

--- a/app/assets/stylesheets/blocks/page/_page-main-header.sass
+++ b/app/assets/stylesheets/blocks/page/_page-main-header.sass
@@ -12,7 +12,7 @@
   +media-breakpoint-down(sm)
     display: block
 
-  .page-notice + .page-main &
+  .a-page-notice + .page-main &
     padding-top: .5em
 
 .page-main-header__start

--- a/app/assets/stylesheets/blocks/page/_page-notice.sass
+++ b/app/assets/stylesheets/blocks/page/_page-notice.sass
@@ -1,4 +1,4 @@
-.page-notice
+.a-page-notice
   .page-body &
     +margin(vertical, -.5rem 1rem)
   .page-tools + &
@@ -6,7 +6,7 @@
   .page-tabs + &
     margin-top: 1rem
 
-.page-notice__inner
+.a-page-notice__inner
   +padding(vertical, .5rem)
   p
     +text-block(1em 1.4, $reversal-text center)

--- a/app/assets/stylesheets/blocks/practice/_sticky-message.sass
+++ b/app/assets/stylesheets/blocks/practice/_sticky-message.sass
@@ -2,7 +2,7 @@
   +media-breakpoint-up(md)
     background-color: $info
     width: 100%
-    +position(fixed, left 0, bottom 0)
+    +position(fixed, left 0, bottom 0, 1)
     +padding(vertical, .5rem)
     +text-block(1rem 1.4, center $reversal-text)
     a

--- a/app/views/practices/products/index.html.slim
+++ b/app/views/practices/products/index.html.slim
@@ -16,9 +16,9 @@ header.page-header
 = render 'page_tabs', resource: @practice
 
 - if current_user.student_or_trainee? && !@practice.open_product? && (@my_product.nil? || @my_product.checks.empty?)
-  .page-notice
+  .a-page-notice
     .container
-      .page-notice__inner
+      .a-page-notice__inner
         p プラクティスを完了するまで他の人の提出物は見れません。
 
 .page-body

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -17,7 +17,7 @@ header.page-header.is-border-bottom-none
 - unless params[:tag]
   .a-page-notice.page-notice
     .container
-      .page-notice__inner
+      .a-page-notice__inner
         p
           | 気になるユーザーをフォローしてみよう！自分が誰をフォローしているかを知られることはありません。
           = link_to 'くわしくはこちら', '/pages/303'


### PR DESCRIPTION
- 日報一覧で、通知を押すと下のみつぽちが透けて見えるのを修正
- 困ったときは、のメッセージが学習ステータスの下に配置されてしまうのを修正
- page-noticeの背景色が消えてるのを修正