### PR TITLE
自動でかんばんに追加されるワークフローを追加

### DIFF
--- a/.github/workflows/create-issue-register-kanban.yml
+++ b/.github/workflows/create-issue-register-kanban.yml
@@ -1,0 +1,15 @@
+name: register issues in Kanban
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.7.1
+        with:
+          project: 開発
+          column: いつかやる
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
issue #2685 

## 概要
新たなissueを登録すると、自動で「開発プロジェクト」の「いつかやる」レーンに登録したissueがかんばんに登録されるようなワークフローを追加しました。

### 使ったgithub action
[GitHub Project Automation\+ · Actions · GitHub Marketplace](https://github.com/marketplace/actions/github-project-automation)

こちらでも実装可能だけど更新頻度、スターの数、コントリビュータの数で上記を選択。
[Create Project Card Action · Actions · GitHub Marketplace](https://github.com/marketplace/actions/create-project-card-action)
