### PR TITLE
WIPの日報をニコニコカレンダーに反映されないように修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -495,7 +495,7 @@ class User < ApplicationRecord
 
   def reports_date_and_emotion(term)
     search_term = (Time.zone.today - term.day)..Time.zone.today
-    reports = self.reports.where(reported_on: search_term)
+    reports = self.reports.where(reported_on: search_term, wip: false)
 
     emotions = reports.index_by(&:reported_on)
 


### PR DESCRIPTION
ref: #2694

## 概要
ニコニコカレンダーに表示される日報は過去30日間の全ての日報が対象だったので、検索条件にWIPでないことを追加し対応しました。

- 日報をWIPで保存
![image](https://user-images.githubusercontent.com/75117116/119074904-d6cbb800-ba2a-11eb-8e9f-b4b2d0635976.png)


- ニコニコカレンダーに反映されていない
![image](https://user-images.githubusercontent.com/75117116/119074784-9ff5a200-ba2a-11eb-997a-0df6f79da464.png)

- WIPの日報を提出
![image](https://user-images.githubusercontent.com/75117116/119074974-f5ca4a00-ba2a-11eb-9c13-aa5d33571a80.png)


- ニコニコカレンダーに反映されている
![image](https://user-images.githubusercontent.com/75117116/119074854-bef43400-ba2a-11eb-85f7-a03fad6996ca.png)

