### PR TITLE
提出物のコメントの各種JSとプレビューが効かない問題を修正

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -1,6 +1,4 @@
 <template lang="pug">
-.thread-comments(v-if='loaded === false && commentableType === "Product"')
-  commentPlaceholder(v-for='num in placeholderCount', :key='num')
 .thread-comments(v-else)
   comment(
     v-for='(comment, index) in comments',


### PR DESCRIPTION
Fixed #2725

緊急での修正なので一時的に提出物のローディング処理を外しました。（今回リリースされたこれがあると動かなくなっていたので外しました）