### PR TITLE
初日報がsadだったときに3日連続sadのユーザーに表示されるバグを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -518,8 +518,8 @@ class User < ApplicationRecord
   end
 
   def depressed?
-    three_days_emotions = reports.order(reported_on: :desc).limit(3).pluck(:emotion)
-    !three_days_emotions.empty? && three_days_emotions.all?('sad')
+    three_days_reports = reports.order(reported_on: :desc).limit(3)
+    three_days_reports.size == 3 && three_days_reports.all?(&:sad?)
   end
 
   def active_practice

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -82,7 +82,7 @@ class UserTest < ActiveSupport::TestCase
 
   test '#depressed?' do
     user = users(:kimura)
-    4.times do |i|
+    2.times do |i|
       report = Report.new(
         user_id: user.id, title: "test #{i}", description: 'test',
         wip: false, emotion: 'sad', reported_on: Date.current - i.days
@@ -92,6 +92,16 @@ class UserTest < ActiveSupport::TestCase
       )
       report.save!
     end
+    assert_not user.depressed?
+
+    report = Report.new(
+      user_id: user.id, title: 'test 2', description: 'test',
+      wip: false, emotion: 'sad', reported_on: Date.current - 2.days
+    )
+    report.learning_times << LearningTime.new(
+      started_at: '2018-01-01 00:00:00', finished_at: '2018-01-01 02:00:00'
+    )
+    report.save!
     assert user.depressed?
 
     report = user.reports.find_by(reported_on: Date.current)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -83,25 +83,17 @@ class UserTest < ActiveSupport::TestCase
   test '#depressed?' do
     user = users(:kimura)
     2.times do |i|
-      report = Report.new(
+      Report.create!(
         user_id: user.id, title: "test #{i}", description: 'test',
-        wip: false, emotion: 'sad', reported_on: Date.current - i.days
+        wip: false, emotion: 'sad', reported_on: i.days.ago, no_learn: true
       )
-      report.learning_times << LearningTime.new(
-        started_at: '2018-01-01 00:00:00', finished_at: '2018-01-01 02:00:00'
-      )
-      report.save!
     end
     assert_not user.depressed?
 
-    report = Report.new(
+    Report.create!(
       user_id: user.id, title: 'test 2', description: 'test',
-      wip: false, emotion: 'sad', reported_on: Date.current - 2.days
+      wip: false, emotion: 'sad', reported_on: 2.days.ago, no_learn: true
     )
-    report.learning_times << LearningTime.new(
-      started_at: '2018-01-01 00:00:00', finished_at: '2018-01-01 02:00:00'
-    )
-    report.save!
     assert user.depressed?
 
     report = user.reports.find_by(reported_on: Date.current)


### PR DESCRIPTION
ref: #2663

## 概要
初日報がsadだったときに3日連続sadのユーザーに表示されていたバグを修正しました。

## 変更点
3日連続sadの日報であるかを判定するメソッドが、ユーザーが1回目の日報をsad、もしくは1回目と2回目の日報をsadで提出する場合でも誤判定してしまうため条件式を変更しました。

## 気になった点
~「3日連続sadのユーザー」と表記していますが厳密には「3回連続sadで日報を提出したユーザー」なので修正すべきか迷いました。~
(追記)
改めて考えてみると日報は「日」単位で出すものなので特に問題ないと思いました。