### PR TITLE
メンションの通知メールの本文をHTMLに変換

### DIFF
--- a/app/views/notification_mailer/mentioned.html.slim
+++ b/app/views/notification_mailer/mentioned.html.slim
@@ -1,2 +1,2 @@
 = render 'notification_mailer_template', title: "#{@mentionable.user.login_name}さんからメンションがありました", link_url: notification_url(@notification), link_text: 'このメンションへ' do
-  = simple_format(@mentionable.body)
+  = md2html @mentionable.body


### PR DESCRIPTION
ref: #2594 
MailerのビューでメンションのmarkdownがHTMLに変換されるように修正しました。