### PR TITLE
自己紹介文にURLが含まれていた場合リンクにする

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -43,7 +43,7 @@ header.page-header
                   = render 'users/user_secret_attributes', user: @user
                   = render 'users/metas', user: @user
               .user-data__description
-                = simple_format h @user.description
+                = auto_link simple_format h @user.description
               .user-data__tags
                 = render 'users/tags', user: @user
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -9,6 +9,15 @@ class UsersTest < ApplicationSystemTestCase
     assert_equal 'hatsunoのプロフィール | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
+  test 'autolink profile when url is included' do
+    url = 'https://bootcamp.fjord.jp/'
+    login_user 'kimura', 'testtest'
+    visit edit_current_user_path
+    fill_in 'user_description', with: "木村です。ブートキャンプはじめました。#{url}"
+    click_button '更新する'
+    assert_link url, href: url
+  end
+
   test 'access by other users' do
     login_user 'yamada', 'testtest'
     user = users(:hatsuno)


### PR DESCRIPTION
ref: #2681 
ユーザーページの自己紹介文に`autolink`メソッドを追加しました。
また、自己紹介文のURLがリンクになっているかどうか確認するテストを作成しました。