### PR TITLE
プレースフォルダが表示できるように変更

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -1,4 +1,6 @@
 <template lang="pug">
+.thread-comments(v-if='loaded === false && commentableType === "Product"')
+  commentPlaceholder(v-for='num in placeholderCount', :key='num')
 .thread-comments(v-else)
   comment(
     v-for='(comment, index) in comments',
@@ -122,17 +124,17 @@ export default {
         json.forEach((c) => {
           this.comments.push(c)
         })
-        this.loaded = true
       })
       .catch((error) => {
         console.warn('Failed to parsing', error)
       })
   },
   mounted() {
-    TextareaInitializer.initialize('#js-new-comment')
-  },
-  updated() {
-    this.setDefaultTextareaSize()
+    this.loaded = true
+    this.$nextTick(function () {
+      TextareaInitializer.initialize('#js-new-comment')
+      this.setDefaultTextareaSize()
+    })
   },
   methods: {
     token() {

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -117,6 +117,16 @@ class CommentsTest < ApplicationSystemTestCase
     wait_for_vuejs
     assert_text 'test'
   end
+  
+  test 'check preview for product' do 
+    visit "/products/#{products(:product2).id}"
+    wait_for_vuejs
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: "1\n2\n3\n4\n5\n6\n7\n8\n9")
+    end
+    page.all('.thread-comment-form__tab.js-tabs__tab')[1].click
+    assert_text "1\n2\n3\n4\n5\n6\n7\n8\n9"
+  end
 
   test 'post new comment for announcement' do
     visit "/announcements/#{announcements(:announcement1).id}"

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -117,8 +117,8 @@ class CommentsTest < ApplicationSystemTestCase
     wait_for_vuejs
     assert_text 'test'
   end
-  
-  test 'check preview for product' do 
+
+  test 'check preview for product' do
     visit "/products/#{products(:product2).id}"
     wait_for_vuejs
     within('.thread-comment-form__form') do


### PR DESCRIPTION
issue
[\#2733](https://github.com/fjordllc/bootcamp/issues/2733)に対応

### 概要
提出物のページのコメント欄にプレースフォルダを表示させる。

### 実装理由
提出物のページのコメントを表示させるのに時間がかかる為、その間不安にさせないようにプレースフォルダを表示させる。

### 実装方針
コメント欄が表示されないとテキストエリアの高さが取得できないため、子のコンポーネント表示が終わるまで待つ必要がある。
```
    setDefaultTextareaSize() {
      const textarea = document.getElementById('js-new-comment')
      this.defaultTextareaSize = textarea.scrollHeight
    },
```
そしてプレースフォルダの部分は子のコンポーネントを読みこんでいるが、子のコンポーネントの読み込みタイミングは、親のcreated->子のコンポーネントの読み込み->親のmountedの順番で行われる。
よって今までは親のcreatedのところで```this.loaded = true```にしていた部分を、mountedにすることで問題なく表示できるようにした。

関連isuue
[\#2465](https://github.com/fjordllc/bootcamp/issues/2465)
