### PR TITLE
ユーザータグの日本語リダイレクトのバグ修正

### DIFF
--- a/app/controllers/users/tags_controller.rb
+++ b/app/controllers/users/tags_controller.rb
@@ -9,6 +9,7 @@ class Users::TagsController < ApplicationController
   def update
     current_user.tag_list.add(params[:tag])
     current_user.save
-    redirect_to "/users/tags/#{params[:tag]}"
+    url = URI.encode_www_form_component(params[:tag])
+    redirect_to "/users/tags/#{url}"
   end
 end


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/issues/2646
ローカルのDevelopment環境で再現しないですが、
ステージング・本番で問題のあるユーザータグのリダイレクトについてです。
タグ登録できないユーザーがいる件については、このPRで対処してないです。

日本語だけで問題が起きているので、エンコードすればアスキー文字に変換されて、
期待通りにリダイレクトされると睨んでいます。

なお、この変更でローカルでの動作は変わらず問題ありません。