### PR TITLE
Q&Aのページでもコメント欄のプレースフォルダを表示できるように修正。

### DIFF
--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
-.thread-comments-container
+.thread-comments(v-if='loaded === false')
+  commentPlaceholder(v-for='num in placeholderCount', :key='num')
+.thread-comments-container(v-else)
   h2.thread-comments-container__title 回答・コメント
   .thread-comments
     answer(
@@ -58,10 +60,12 @@
 <script>
 import Answer from './answer.vue'
 import TextareaInitializer from './textarea-initializer'
+import CommentPleaceholder from './comment-placeholder'
 
 export default {
   components: {
-    answer: Answer
+    answer: Answer,
+    commentPlaceholder: CommentPleaceholder
   },
   props: {
     questionId: { type: String, required: true },
@@ -75,7 +79,9 @@ export default {
       tab: 'answer',
       buttonDisabled: false,
       question: { correctAnswer: null },
-      defaultTextareaSize: null
+      defaultTextareaSize: null,
+      loaded: false,
+      placeholderCount: 3,
     }
   },
   computed: {
@@ -111,10 +117,13 @@ export default {
       .catch((error) => {
         console.warn('Failed to parsing', error)
       })
-  },
-  mounted: function () {
-    TextareaInitializer.initialize('#js-new-comment')
-    this.setDefaultTextareaSize()
+      .finally(() => {
+        this.loaded = true
+        this.$nextTick(() => {
+          TextareaInitializer.initialize('#js-new-comment')
+          this.setDefaultTextareaSize()
+        })
+      })
   },
   methods: {
     token() {

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -5,7 +5,7 @@
   h2.thread-comments-container__title 回答・コメント
   .thread-comments
     answer(
-      v-for='(answer, index) in answers',
+      v-for='(answer) in answers',
       :key='answer.id',
       :answer='answer',
       :currentUser='currentUser',

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -7,14 +7,28 @@ class AnswersTest < ApplicationSystemTestCase
 
   test 'answer form in questions/:id has comment tab and preview tab' do
     visit "/questions/#{questions(:question2).id}"
+    wait_for_vuejs
     within('.thread-comment-form__tabs') do
       assert_text 'コメント'
       assert_text 'プレビュー'
     end
   end
 
+  test 'post new comment for question' do
+    visit "/questions/#{questions(:question2).id}"
+    wait_for_vuejs
+    within('.thread-comment-form__form') do
+      fill_in('answer[description]', with: 'test')
+    end
+    page.all('.thread-comment-form__tab.js-tabs__tab')[1].click
+    assert_text 'test'
+    click_button 'コメントする'
+    assert_text 'test'
+  end
+
   test 'edit answer form has comment tab and preview tab' do
     visit "/questions/#{questions(:question3).id}"
+    wait_for_vuejs
     within('.thread-comment:first-child') do
       click_button '内容修正'
       assert_text 'コメント'
@@ -24,6 +38,7 @@ class AnswersTest < ApplicationSystemTestCase
 
   test 'admin can edit and delete any questions' do
     visit "/questions/#{questions(:question1).id}"
+    wait_for_vuejs
     answer_by_user = page.all('.thread-comment')[1]
     within answer_by_user do
       assert_text '内容修正'
@@ -33,6 +48,7 @@ class AnswersTest < ApplicationSystemTestCase
 
   test "admin can resolve user's question" do
     visit "/questions/#{questions(:question2).id}"
+    wait_for_vuejs
     assert_text 'ベストアンサーにする'
     accept_alert do
       click_button 'ベストアンサーにする'
@@ -42,6 +58,7 @@ class AnswersTest < ApplicationSystemTestCase
 
   test 'delete best answer' do
     visit "/questions/#{questions(:question2).id}"
+    wait_for_vuejs
     accept_alert do
       click_button 'ベストアンサーにする'
     end


### PR DESCRIPTION
[\#2739](https://github.com/fjordllc/bootcamp/issues/2739)
のisuueに対応


プラクティスや日報のページはapp/javascript/comments.vueでコメントを表示しているが、
Q&Aのページではコメント欄と回答が同じ欄として扱われているため、app/javascript/answers.vueでコメントの表示をしている。

そのためこちらだけ別途対応しました。
ファイルは違いますがコメントのプレースフォルダの表示方法については同じなので、同じ方法で実装しました。

関連isuue：ロード中のプレースフォルダが表示されるように修正[\#2750](https://github.com/fjordllc/bootcamp/pull/2750)