### PR TITLE
Kanikoキャッシュでdocker buildを高速化した

### DIFF
--- a/cloudbuild-reset.yaml
+++ b/cloudbuild-reset.yaml
@@ -1,15 +1,10 @@
 steps:
-  - id: Build
-    name: gcr.io/cloud-builders/docker
+  - id: Docker Build and Push
+    name: gcr.io/kaniko-project/executor:latest
     args:
-      - 'build'
-      - '--cache-from'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-      - '-t'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-      - '.'
-      - '-f'
-      - 'Dockerfile'
+      - --destination=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+      - --dockerfile=Dockerfile
+      - --cache=true
   - id: SqlProxy
     name: "gcr.io/cloudsql-docker/gce-proxy:1.16"
     waitFor: ["-"]
@@ -19,7 +14,7 @@ steps:
     args: ["/cloud_sql_proxy", "-dir=/cloudsql", "-instances=$_CLOUD_SQL_HOST"]
   - id: Task
     name: "asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"
-    waitFor: ["Build"]
+    waitFor: ["Docker Build and Push"]
     volumes:
       - name: db
         path: "/cloudsql"
@@ -36,7 +31,6 @@ steps:
     waitFor: ["Task"]
     entrypoint: "sh"
     args: ["-c", 'docker kill -s TERM $(docker ps -q --filter "volume=db")']
-images: ['asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
 options:
   substitutionOption: ALLOW_LOOSE
 substitutions:

--- a/cloudbuild-task.yaml
+++ b/cloudbuild-task.yaml
@@ -1,15 +1,10 @@
 steps:
-  - id: Build
-    name: gcr.io/cloud-builders/docker
+  - id: Docker Build and Push
+    name: gcr.io/kaniko-project/executor:latest
     args:
-      - 'build'
-      - '--cache-from'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-      - '-t'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-      - '.'
-      - '-f'
-      - 'Dockerfile'
+      - --destination=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+      - --dockerfile=Dockerfile
+      - --cache=true
   - id: SqlProxy
     name: "gcr.io/cloudsql-docker/gce-proxy:1.16"
     waitFor: ["-"]
@@ -19,7 +14,7 @@ steps:
     args: ["/cloud_sql_proxy", "-dir=/cloudsql", "-instances=$_CLOUD_SQL_HOST"]
   - id: Task
     name: "asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"
-    waitFor: ["Build"]
+    waitFor: ["Docker Build and Push"]
     volumes:
       - name: db
         path: "/cloudsql"
@@ -36,7 +31,6 @@ steps:
     waitFor: ["Task"]
     entrypoint: "sh"
     args: ["-c", 'docker kill -s TERM $(docker ps -q --filter "volume=db")']
-images: ['asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
 options:
   substitutionOption: ALLOW_LOOSE
 substitutions:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,19 +1,11 @@
 steps:
-  - id: Fetch
-    name: 'gcr.io/cloud-builders/docker'
-    entrypoint: 'bash'
-    args: ['-c', 'docker pull asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest || exit 0']
-  - id: Build
-    name: gcr.io/cloud-builders/docker
-    args: ['build',
-           '-t', 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
-           '-t', 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
-           '--cache-from', 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
-           '.',
-           '-f', 'Dockerfile']
-  - id: Push
-    name: gcr.io/cloud-builders/docker
-    args: ['push', 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
+  - id: Docker Build and Push
+    name: gcr.io/kaniko-project/executor:latest
+    args:
+      - --destination=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+      - --destination=asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+      - --dockerfile=Dockerfile
+      - --cache=true
   - id: SqlProxy
     name: "gcr.io/cloudsql-docker/gce-proxy:1.16"
     waitFor: ["-"]
@@ -23,7 +15,7 @@ steps:
     args: ["/cloud_sql_proxy", "-dir=/cloudsql", "-instances=$_CLOUD_SQL_HOST"]
   - id: DB_Migrate
     name: "asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"
-    waitFor: ["Build"]
+    waitFor: ["Docker Build and Push"]
     volumes:
       - name: db
         path: "/cloudsql"
@@ -87,8 +79,6 @@ steps:
     env:
       - DB_NAME=$_DB_NAME
       - DEPLOY_NOTIFY_WEBHOOK_URL=$_DEPLOY_NOTIFY_WEBHOOK_URL
-images:
-  - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
 options:
   substitutionOption: ALLOW_LOOSE
 substitutions:


### PR DESCRIPTION
## できるようになったこと

- kaniko-executorを使って、初回以降のdocker buildでlayer cacheを利用できるようにした

| before | after |
| --- | --- |
| <img width="400" alt="スクリーンショット 2021-06-02 17 36 14" src="https://user-images.githubusercontent.com/1464572/120449827-bf95ae80-c3ca-11eb-92ee-713c7fecc9a0.png"> |  |

## 参考

[Kaniko キャッシュの使用](https://cloud.google.com/build/docs/kaniko-cache?hl=ja#kaniko-build)
