### PR TITLE
管理者権限でユーザータグを編集できない

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -60,7 +60,8 @@ class Admin::UsersController < AdminController
       :experience, :prefecture_code, :company_id,
       :trainee, :job_seeking, :nda,
       :graduated_on, :retired_on, :free,
-      :job_seeker, :slack_participation, :github_collaborator
+      :job_seeker, :slack_participation, :github_collaborator,
+      :officekey_permission, :tag_list
     )
   end
 end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -140,4 +140,16 @@ class Admin::UsersTest < ApplicationSystemTestCase
     check 'graduation_checkbox', allow_label_click: true
     assert has_field?('user_graduated_on', with: '')
   end
+
+  test 'edit user tag' do
+    user = users(:kimura)
+    visit "/admin/users/#{user.id}/edit"
+    tag_input = find('.ti-new-tag-input')
+    tag_input.set '追加タグ'
+    tag_input.native.send_keys :enter
+    click_on '更新する'
+    wait_for_vuejs
+    visit "/admin/users/#{user.id}/edit"
+    assert_text '追加タグ'
+  end
 end


### PR DESCRIPTION
#2670 に対応

## 概要
管理者でログインをして、自分以外のアカウントのユーザー情報の編集をしたとき、そのユーザーのタグを変更しても、その変更が保存されない。

## 原因
Strong Parametersにtagの記述が抜けていたため。

## 対応
bootcamp/app/controllers/admin/users_controller.rb のuser_paramsに`tag_list`を追加する。