### PR TITLE
ユーザーのオフィスの鍵情報を削除した

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -60,8 +60,7 @@ class Admin::UsersController < AdminController
       :experience, :prefecture_code, :company_id,
       :trainee, :job_seeking, :nda,
       :graduated_on, :retired_on, :free,
-      :job_seeker, :slack_participation, :github_collaborator,
-      :officekey_permission
+      :job_seeker, :slack_participation, :github_collaborator
     )
   end
 end

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -99,7 +99,7 @@
             - else
               .a-button.is-sm.is-disabled.is-icon
                 i.fab.fa-github-alt
-            - if user.retired_on? && (user.slack_participation? || user.github_collaborator? || user.officekey_permission?)
+            - if user.retired_on? && (user.slack_participation? || user.github_collaborator?)
               .admin-table__item-block-link-container
                 = link_to edit_admin_user_path(user, anchor: 'external-services') do
                   | 外部サービス設定変更

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -99,12 +99,6 @@
             - else
               .a-button.is-sm.is-disabled.is-icon
                 i.fab.fa-github-alt
-            - if user.officekey_permission?
-              = link_to 'https://play.google.com/store/apps/details?id=co.candyhouse.sesame&hl=ja', class: 'a-button is-sm is-warning is-icon', target: '_blank', rel: 'noopener' do
-                i.fas.fa-key
-            - else
-              .a-button.is-sm.is-disabled.is-icon
-                i.fas.fa-key
             - if user.retired_on? && (user.slack_participation? || user.github_collaborator? || user.officekey_permission?)
               .admin-table__item-block-link-container
                 = link_to edit_admin_user_path(user, anchor: 'external-services') do

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -5,7 +5,7 @@
   header.auth-form__header
     h1.auth-form__title
       = title
-  - if admin_login? && @user.retired_on? && (@user.slack_participation? || @user.github_collaborator? || @user.officekey_permission?)
+  - if admin_login? && @user.retired_on? && (@user.slack_participation? || @user.github_collaborator?)
     .auth-form__alert
       = link_to '#external-services' do
         | 外部サービスの設定を変更してください。

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -78,8 +78,6 @@
               = render 'users/form/slack_participation', f: f, user: user
             .form-item-block__item
               = render 'users/form/github_collaborator', f: f, user: user
-            .form-item-block__item
-              = render 'users/form/officekey_permission', f: f
         .a-form-help
           ul
             li

--- a/app/views/users/form/_officekey_permission.html.slim
+++ b/app/views/users/form/_officekey_permission.html.slim
@@ -1,5 +1,0 @@
-.form-item
-  .form-checkbox
-    label.form-checkbox__label
-      = f.check_box :officekey_permission, class: 'form-checkbox__input'
-      = User.human_attribute_name :officekey_permission

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -31,7 +31,7 @@ header.page-header
       .row
         .col-xs-12.col-lg-6.col-xxl-6
           .a-card.is-user
-            - if admin_login? && @user.retired_on? && (@user.slack_participation? || @user.github_collaborator? || @user.officekey_permission?)
+            - if admin_login? && @user.retired_on? && (@user.slack_participation? || @user.github_collaborator?)
               .a-card__alert
                 = link_to edit_admin_user_path(anchor: 'external-services') do
                   | 外部サービスの設定を変更してください。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -83,7 +83,6 @@ ja:
         job_seeker: 就職を希望する
         slack_participation: Slack参加
         github_collaborator: GitHubチーム
-        officekey_permission: オフィス鍵
         tag_list: タグ
       course:
         title: タイトル

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -19,7 +19,6 @@ komagata:
   admin: true
   mentor: true
   github_collaborator: true
-  officekey_permission: true
   unsubscribe_email_token: 037i-ef5n7V4EnPv74mtyQ
   updated_at: "2014-01-01 00:00:01"
   created_at: "2014-01-01 00:00:01"
@@ -44,7 +43,6 @@ machida:
   admin: true
   mentor: true
   github_collaborator: true
-  officekey_permission: true
   unsubscribe_email_token: MnC-Dv3HrNLs7WmfE975qA
   updated_at: "2014-01-01 00:00:02"
   created_at: "2014-01-01 00:00:02"

--- a/db/migrate/20210603024907_remove_officekey_permission_from_users.rb
+++ b/db/migrate/20210603024907_remove_officekey_permission_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveOfficekeyPermissionFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :officekey_permission, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_28_112148) do
+ActiveRecord::Schema.define(version: 2021_06_03_024907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -451,7 +451,6 @@ ActiveRecord::Schema.define(version: 2021_05_28_112148) do
     t.string "github_id"
     t.boolean "slack_participation", default: true, null: false
     t.boolean "github_collaborator", default: false, null: false
-    t.boolean "officekey_permission", default: false, null: false
     t.string "name", default: "", null: false
     t.string "name_kana", default: "", null: false
     t.integer "satisfaction"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -19,7 +19,6 @@ komagata:
   admin: true
   mentor: true
   github_collaborator: true
-  officekey_permission: true
   unsubscribe_email_token: 037i-ef5n7V4EnPv74mtyQ
   updated_at: "2014-01-01 00:00:01"
   created_at: "2014-01-01 00:00:01"
@@ -44,7 +43,6 @@ machida:
   admin: true
   mentor: true
   github_collaborator: true
-  officekey_permission: true
   unsubscribe_email_token: MnC-Dv3HrNLs7WmfE975qA
   updated_at: "2014-01-01 00:00:02"
   created_at: "2014-01-01 00:00:02"


### PR DESCRIPTION
Issue
#2747 

動作確認は、DB変更があるのでmigrateしてからお願いします。
また、管理者画面を見るので``komagata``,``testtest``でログインしてください
また、機能の消去なのでテストは書いていません。（同機能についての既存のテストもないようでした。）
（@komagata さん、テスト書かないで良いかご確認お願いします。）

見た目の確認としては、以下２点です。
### ユーザー登録ページ
``http://localhost:3000/admin/users/46191349/edit``, ``http://localhost:3000/users/new``, ``http://localhost:3000/current_user/edit``

「オフィス鍵」チェックボックスがなくなっていること
- 変更前
![image](https://user-images.githubusercontent.com/50036730/120598018-b9620980-c480-11eb-9cf6-5967ff4626de.png)

- 変更後
![image](https://user-images.githubusercontent.com/50036730/120598172-eadad500-c480-11eb-99ea-32fee2659100.png)

### 管理者のユーザー一覧ページ
``http://localhost:3000/admin/users``
「外部サービス」欄の鍵マークがなくなっていること
- 変更前
![image](https://user-images.githubusercontent.com/50036730/120598223-f928f100-c480-11eb-86c8-83b0f6397e36.png)

- 変更後
![image](https://user-images.githubusercontent.com/50036730/120598268-0940d080-c481-11eb-95fa-95cfea4c6e45.png)
