### PR TITLE
Q&A個別ページで回答数がローディングのときは 0 ではなく、ロード中アイコンを出して欲しい 

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -8,7 +8,7 @@
           | 回答
         .a-count-badge__value(v-if='!loaded')
           i.fas.fa-spinner
-        .a-count-badge__value(v-else,:class='answerCount === 0 ? "is-zero" : ""')
+        .a-count-badge__value(v-else, :class='answerCount === 0 ? "is-zero" : ""')
           | {{ answerCount }}
       .thread-header__row
         .thread-header-metas

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -206,7 +206,7 @@ export default {
       displayedUpdateMessage: false,
       tab: 'question',
       practices: null,
-      loaded: false
+      loaded: false,
     }
   },
   computed: {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -6,7 +6,9 @@
       a.a-count-badge(href='#comments')
         .a-count-badge__label
           | 回答
-        .a-count-badge__value(:class='answerCount === 0 ? "is-zero" : ""')
+        .a-count-badge__value(v-if='!loaded')
+          i.fas.fa-spinner
+        .a-count-badge__value(v-else,:class='answerCount === 0 ? "is-zero" : ""')
           | {{ answerCount }}
       .thread-header__row
         .thread-header-metas
@@ -203,7 +205,8 @@ export default {
       editing: false,
       displayedUpdateMessage: false,
       tab: 'question',
-      practices: null
+      practices: null,
+      loaded: false
     }
   },
   computed: {
@@ -235,6 +238,9 @@ export default {
       return title.length > 0 && description.length > 0
     }
   },
+  beforeCreate(){
+    this.loaded = true
+  },
   created() {
     this.fetchPractices()
   },
@@ -263,6 +269,7 @@ export default {
             practice.categoryAndPracticeName = `[${practice.category}] ${practice.title}`
             return practice
           })
+          this.loaded = true
         })
         .catch((error) => {
           console.warn('Failed to parsing', error)

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -238,9 +238,6 @@ export default {
       return title.length > 0 && description.length > 0
     }
   },
-  beforeCreate(){
-    this.loaded = true
-  },
   created() {
     this.fetchPractices()
   },

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -189,7 +189,7 @@ export default {
   },
   props: {
     question: { type: Object, required: true },
-    answerCount: { type: Number },
+    answerCount: { type: Number, required:false },
     currentUser: { type: Object, required: true }
   },
   data() {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -206,7 +206,7 @@ export default {
       editing: false,
       displayedUpdateMessage: false,
       tab: 'question',
-      practices: null,
+      practices: null
     }
   },
   computed: {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -6,7 +6,7 @@
       a.a-count-badge(href='#comments')
         .a-count-badge__label
           | 回答
-        .a-count-badge__value(v-if='!updatedAnswerCount')
+        .a-count-badge__value(v-if='!isAnswerCountUpdated')
           i.fas.fa-spinner
         .a-count-badge__value(:class='answerCount === 0 ? "is-zero" : ""')
           | {{ answerCount }}
@@ -190,7 +190,7 @@ export default {
   props: {
     question: { type: Object, required: true },
     answerCount: { type: Number, required: true },
-    updatedAnswerCount: { type: Boolean, required: true },
+    isAnswerCountUpdated: { type: Boolean, required: true },
     currentUser: { type: Object, required: true }
   },
   data() {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -6,7 +6,7 @@
       a.a-count-badge(href='#comments')
         .a-count-badge__label
           | 回答
-        .a-count-badge__value(v-if='!loaded')
+        .a-count-badge__value(v-if='!updatedAnswerCount')
           i.fas.fa-spinner
         .a-count-badge__value(:class='answerCount === 0 ? "is-zero" : ""')
           | {{ answerCount }}
@@ -189,7 +189,8 @@ export default {
   },
   props: {
     question: { type: Object, required: true },
-    answerCount: { type: Number, required:false },
+    answerCount: { type: Number, required: true },
+    updatedAnswerCount: { type: Boolean, required: true },
     currentUser: { type: Object, required: true }
   },
   data() {
@@ -206,7 +207,6 @@ export default {
       displayedUpdateMessage: false,
       tab: 'question',
       practices: null,
-      loaded: false,
     }
   },
   computed: {
@@ -266,7 +266,6 @@ export default {
             practice.categoryAndPracticeName = `[${practice.category}] ${practice.title}`
             return practice
           })
-          this.loaded = true
         })
         .catch((error) => {
           console.warn('Failed to parsing', error)

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -8,7 +8,7 @@
           | 回答
         .a-count-badge__value(v-if='!loaded')
           i.fas.fa-spinner
-        .a-count-badge__value(v-else, :class='answerCount === 0 ? "is-zero" : ""')
+        .a-count-badge__value(:class='answerCount === 0 ? "is-zero" : ""')
           | {{ answerCount }}
       .thread-header__row
         .thread-header-metas
@@ -189,7 +189,7 @@ export default {
   },
   props: {
     question: { type: Object, required: true },
-    answerCount: { type: Number, required: true },
+    answerCount: { type: Number },
     currentUser: { type: Object, required: true }
   },
   data() {

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -37,7 +37,7 @@ export default {
     return {
       question: null,
       currentUser: null,
-      answerCount: 0
+      answerCount: null
     }
   },
   created() {

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -8,7 +8,7 @@
     questionEdit(
       :question='question',
       :answerCount='answerCount',
-      :isAnswerCountUpdated='isAnswerCountUpdated'
+      :isAnswerCountUpdated='isAnswerCountUpdated',
       :currentUser='currentUser'
     )
     a#comments.a-anchor

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -8,7 +8,7 @@
     questionEdit(
       :question='question',
       :answerCount='answerCount',
-      :updatedAnswerCount='updatedAnswerCount'
+      :isAnswerCountUpdated='isAnswerCountUpdated'
       :currentUser='currentUser'
     )
     a#comments.a-anchor
@@ -39,7 +39,7 @@ export default {
       question: null,
       currentUser: null,
       answerCount: 0,
-      updatedAnswerCount: false
+      isAnswerCountUpdated: false
     }
   },
   created() {
@@ -97,7 +97,7 @@ export default {
     },
     updateAnswerCount(count) {
       this.answerCount = count
-      this.updatedAnswerCount = true
+      this.isAnswerCountUpdated = true
     }
   }
 }

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -8,6 +8,7 @@
     questionEdit(
       :question='question',
       :answerCount='answerCount',
+      :updatedAnswerCount='updatedAnswerCount'
       :currentUser='currentUser'
     )
     a#comments.a-anchor
@@ -37,7 +38,8 @@ export default {
     return {
       question: null,
       currentUser: null,
-      answerCount: null
+      answerCount: 0,
+      updatedAnswerCount: false
     }
   },
   created() {
@@ -95,6 +97,7 @@ export default {
     },
     updateAnswerCount(count) {
       this.answerCount = count
+      this.updatedAnswerCount = true
     }
   }
 }


### PR DESCRIPTION
## 対応issue
#2773 

## 概要
<img width="891" alt="貼り付けた画像_2021_06_03_15_28" src="https://user-images.githubusercontent.com/168265/120597724-5f614400-c480-11eb-88ba-3ce3af2094bc.png">

この部分の数字が、回答を読み込み終わるまで「0」 と出てしまっている。
回答の読み込みに時間がかかった場合、回答はまだ来ていないものと勘違いしてページを離脱してしまう可能性がある。
それを防ぐために、ローディング中は「0」ではなく、ロード中のアイコンを表示したい。

## 実装方針
- ロード中はロードアイコンを表示するように条件分岐を追加。
    -  ロード中は変数`loaded`をfalseにして、API通信後に`loaded`をtrueにする。
## 修正後
[![Image from Gyazo](https://gyazo.com/93a59ca25877a8427ab12259ba5f143b.gif)](https://gyazo.com/93a59ca25877a8427ab12259ba5f143b)

### (修正前)
[![Image from Gyazo](https://gyazo.com/2a1c3369b3abd16960d6402545953fa2.gif)](https://gyazo.com/2a1c3369b3abd16960d6402545953fa2)


## 追記
ロードアイコンの設定はデザイナーが対応