### PR TITLE
Q&Aのアンサーを操作できるユーザー権限を検証するテストを追加

### DIFF
--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -240,16 +240,25 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     fill_in 'answer[description]', with: 'アンサーテスト'
     click_button 'コメントする'
-    assert_text 'ベストアンサーにする'
+    within '.thread-comment__body' do
+      assert_text '内容修正'
+      assert_text 'ベストアンサーにする'
+    end
 
     login_user 'komagata', 'testtest'
     visit questions_path
     click_on 'テストの質問タイトル'
-    assert_text 'ベストアンサーにする'
+    within '.thread-comment__body' do
+      assert_text '内容修正'
+      assert_text 'ベストアンサーにする'
+    end
 
     login_user 'hatsuno', 'testtest'
     visit questions_path
     click_on 'テストの質問タイトル'
-    assert_no_text 'ベストアンサーにする'
+    within '.thread-comment__body' do
+      assert_no_text '内容修正'
+      assert_no_text 'ベストアンサーにする'
+    end
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -230,4 +230,26 @@ class QuestionsTest < ApplicationSystemTestCase
 
     assert_alert_when_enter_one_dot_only_tag
   end
+
+  test 'permission decision best answer' do
+    visit new_question_path
+    within 'form[name=question]' do
+      fill_in 'question[title]', with: 'テストの質問タイトル'
+      fill_in 'question[description]', with: 'テストの質問です。'
+      click_button '登録する'
+    end
+    fill_in 'answer[description]', with: 'アンサーテスト'
+    click_button 'コメントする'
+    assert_text 'ベストアンサーにする'
+
+    login_user 'komagata', 'testtest'
+    visit questions_path
+    click_on 'テストの質問タイトル'
+    assert_text 'ベストアンサーにする'
+
+    login_user 'hatsuno', 'testtest'
+    visit questions_path
+    click_on 'テストの質問タイトル'
+    assert_no_text 'ベストアンサーにする'
+  end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -243,6 +243,7 @@ class QuestionsTest < ApplicationSystemTestCase
     within '.thread-comment__body' do
       assert_text '内容修正'
       assert_text 'ベストアンサーにする'
+      assert_text '削除する'
     end
 
     login_user 'komagata', 'testtest'
@@ -251,6 +252,7 @@ class QuestionsTest < ApplicationSystemTestCase
     within '.thread-comment__body' do
       assert_text '内容修正'
       assert_text 'ベストアンサーにする'
+      assert_text '削除する'
     end
 
     login_user 'hatsuno', 'testtest'
@@ -259,6 +261,7 @@ class QuestionsTest < ApplicationSystemTestCase
     within '.thread-comment__body' do
       assert_no_text '内容修正'
       assert_no_text 'ベストアンサーにする'
+      assert_no_text '削除する'
     end
   end
 end


### PR DESCRIPTION
#2781 のようなバグを防ぐためテストを追加しました。