### PR TITLE
ユーザー検索でのエラーに対処した

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   end
 
   def md2html(text)
-    html = CommonMarker.render_html(text)
+    html = CommonMarker.render_html(text) unless text.nil?
     raw(html) # rubocop:disable Rails/OutputSafety
   end
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -27,12 +27,12 @@ module SearchHelper
     if searchable.instance_of?(Comment) && searchable.commentable_type == 'Product'
       commentable = Product.find(searchable.commentable_id)
       if policy(commentable).show? || commentable.practice.open_product?
-        searchable.description || ''
+        searchable.description
       else
         '該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。'
       end
     else
-      searchable.description || ''
+      searchable.description
     end
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -27,12 +27,12 @@ module SearchHelper
     if searchable.instance_of?(Comment) && searchable.commentable_type == 'Product'
       commentable = Product.find(searchable.commentable_id)
       if policy(commentable).show? || commentable.practice.open_product?
-        searchable.description
+        searchable.description || ''
       else
         '該当プラクティスを完了するまで他の人の提出物へのコメントは見れません。'
       end
     else
-      searchable.description
+      searchable.description || ''
     end
   end
 end

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -97,4 +97,15 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_text 'komagata'
     assert_no_text 'PC性能の見方を知る'
   end
+
+  test 'can search user with nil description' do
+    kimura = users(:kimura)
+    kimura.update_attribute(:description, nil) # rubocop:disable Rails/SkipsModelValidations
+    within('form[name=search]') do
+      select 'ユーザー'
+      fill_in 'word', with: 'kimura'
+    end
+    find('#test-search').click
+    assert_text 'kimura'
+  end
 end


### PR DESCRIPTION
Issue #2690

## （確認した現象）
- descriptionがnilのユーザーを検索するとログのとおりCommonMarkerのrender_htmlメソッドがエラーを投げる
- render_htmlの引数にnilを入れるとエラー

## （対策）
### 方針：引数が nilにならないようにする
1. descriptionがnilのユーザーをユーザー検索するとエラーになるよう、テストを書く
2. render_htmlの直前でnilを回避する処理を追加
3. 1のテストが通るようになる
  
## （懸念点）

- この修正によってproduction環境でのエラーが直っているかの確信はなく、デプロイ後に動作確認をする必要があります。
- nilがはいらないようにする処理をどこに置くか確信が持てませんでした。
  - 他の案： 一つ前のコミットでは、描画時にnilを空文字にしています。が、helperでnilをいれると例外を投げる方が問題と考えて、ヘルパー修正を採用しました。

## （質問）
- 本番環境のデータを見る方法がありますか？（descriptionがnilのユーザーの確認）
    - → 権限の問題でできない
- validationで弾かれないでdescription がなぜnilになったのか
    - → もともとvalidationがなかった時のユーザーがいるから