### PR TITLE
docsにslugを付けてアクセスできるように

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -55,7 +55,7 @@ class PagesController < ApplicationController
   private
 
   def set_page
-    @page = Page.find_by(slug: params[:slug_or_id]) || Page.find(params[:slug_or_id])
+    @page = Page.search_by_slug_or_id(params[:slug_or_id])
   end
 
   def page_params

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -55,11 +55,11 @@ class PagesController < ApplicationController
   private
 
   def set_page
-    @page = Page.find(params[:id])
+    @page = Page.find_by(slug: params[:slug_or_id]) || Page.find(params[:slug_or_id])
   end
 
   def page_params
-    keys = %i[title body tag_list practice_id]
+    keys = %i[title body tag_list practice_id slug]
     keys << :user_id if admin_login?
     params.require(:page).permit(*keys)
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -12,12 +12,21 @@ class Page < ApplicationRecord
   belongs_to :last_updated_user, class_name: 'User', optional: true
   validates :title, presence: true
   validates :body, presence: true
+  validates :slug, length: { maximum: 200 }, format: { with: /\A[a-z][a-z0-9_-]*\z/ }, uniqueness: true, allow_nil: true
   paginates_per 20
   alias sender user
   after_create PageCallbacks.new
   after_update PageCallbacks.new
 
   columns_for_keyword_search :title, :body
+
+  before_validation :empty_slug_to_nil
+
+  private
+
+  def empty_slug_to_nil
+    self.slug = nil if slug && slug.empty?
+  end
 
   scope :wip, -> { where(wip: true) }
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -22,6 +22,10 @@ class Page < ApplicationRecord
 
   before_validation :empty_slug_to_nil
 
+  def self.search_by_slug_or_id(params)
+    Page.find_by(slug: params) || Page.find(params)
+  end
+
   private
 
   def empty_slug_to_nil

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -23,7 +23,8 @@ class Page < ApplicationRecord
   before_validation :empty_slug_to_nil
 
   def self.search_by_slug_or_id(params)
-    Page.find_by(slug: params) || Page.find(params)
+    attr_name = params.start_with?(/[a-z]/) ? :slug : :id
+    Page.find_by(attr_name => params)
   end
 
   private

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -18,6 +18,12 @@
           .select-users
             = f.select(:user_id, User.where(retired_on: nil).pluck(:login_name, :id).sort, { include_blank: (page.user || current_user).login_name }, { class: 'js-select2' })
   .form-item
+    .row
+      .col-md-6.col-xs-12
+        = f.label :slug, class: 'a-form-label'
+        = f.text_field :slug, class: 'a-text-input js-warning-form'
+        p アルファベットから始まる半角英数字とハイフン(-)、アンダーバー(_)が使えます
+  .form-item
     .row.js-markdown-parent
       .col-md-6.col-xs-12
         = f.label :body, class: 'a-form-label'

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -54,6 +54,9 @@ header.page-header
                           image_class: 'thread-header__user-icon'
                         = link_to @page.last_updated_user, class: 'a-user-name' do
                           | #{@page.last_updated_user.login_name}
+                - unless @page.slug.blank?
+                  .thread-header-metas__meta
+                    | #{@page.slug}
           .thread-header__row
             h1.thread-header-title(class="#{@page.wip? ? 'is-wip' : ''}")
               - if @page.wip?

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -54,7 +54,7 @@ header.page-header
                           image_class: 'thread-header__user-icon'
                         = link_to @page.last_updated_user, class: 'a-user-name' do
                           | #{@page.last_updated_user.login_name}
-                - unless @page.slug.blank?
+                - if @page.slug.present?
                   .thread-header-metas__meta
                     | #{@page.slug}
           .thread-header__row

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -56,7 +56,7 @@ header.page-header
                           | #{@page.last_updated_user.login_name}
                 - if @page.slug.present?
                   .thread-header-metas__meta
-                    | #{@page.slug}
+                    = @page.slug
           .thread-header__row
             h1.thread-header-title(class="#{@page.wip? ? 'is-wip' : ''}")
               - if @page.wip?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -144,6 +144,7 @@ ja:
         user: ユーザー
         body: 本文
         tag_list: タグ
+        slug: スラッグ
       question:
         practice: プラクティス
         title: タイトル

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,7 +152,7 @@ Rails.application.routes.draw do
     resources :unchecked, only: %i(index)
   end
   resources :reports
-  resources :pages
+  resources :pages, param: :slug_or_id
   resources :notifications, only: %i(index show) do
     collection do
       resources :allmarks, only: %i(create), controller: "notifications/allmarks"

--- a/db/migrate/20210607171344_add_slug_column_to_pages.rb
+++ b/db/migrate/20210607171344_add_slug_column_to_pages.rb
@@ -1,0 +1,6 @@
+class AddSlugColumnToPages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :pages, :slug, :string, limit: 200, default: nil
+    add_index :pages, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_05_082712) do
+ActiveRecord::Schema.define(version: 2021_06_07_171344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -355,8 +355,6 @@ ActiveRecord::Schema.define(version: 2021_06_05_082712) do
     t.bigint "practice_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "must_read", default: false, null: false
-    t.text "description"
     t.index ["practice_id"], name: "index_reference_books_on_practice_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -270,7 +270,9 @@ ActiveRecord::Schema.define(version: 2021_06_05_082712) do
     t.datetime "published_at"
     t.integer "last_updated_user_id"
     t.bigint "practice_id"
+    t.string "slug", limit: 200
     t.index ["practice_id"], name: "index_pages_on_practice_id"
+    t.index ["slug"], name: "index_pages_on_slug", unique: true
     t.index ["updated_at"], name: "index_pages_on_updated_at"
     t.index ["user_id"], name: "index_pages_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -355,6 +355,8 @@ ActiveRecord::Schema.define(version: 2021_06_05_082712) do
     t.bigint "practice_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "must_read", default: false, null: false
+    t.text "description"
     t.index ["practice_id"], name: "index_reference_books_on_practice_id"
   end
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -168,4 +168,15 @@ class PagesTest < ApplicationSystemTestCase
     find('.tag-links__item-edit').click
     assert_alert_when_enter_one_dot_only_tag
   end
+
+  test 'add new page with slug and visit page' do
+    slug = 'test-page-slug1'
+    visit new_page_path
+    fill_in 'page[title]', with: 'ページタイトル'
+    fill_in 'page[slug]', with: slug
+    fill_in 'page[body]', with: 'slug付きテストページの本文'
+    click_button '内容を保存'
+    visit "/pages/#{slug}"
+    assert_text 'slug付きテストページの本文'
+  end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -171,7 +171,7 @@ class PagesTest < ApplicationSystemTestCase
 
   test 'add new page with slug and visit page' do
     slug = 'test-page-slug1'
-    visit new_page_path
+    visit_with_auth new_page_path, 'kimura'
     fill_in 'page[title]', with: 'ページタイトル'
     fill_in 'page[slug]', with: slug
     fill_in 'page[body]', with: 'slug付きテストページの本文'


### PR DESCRIPTION
ref: #2751 
- slugカラムを追加、`/pages/[スラッグもしくはid]`でアクセスできるようにしました。スラッグの字数制限はWordPressのスラッグが最大200文字みたいだったので、とりあえず同じにしてみました。
- `postgresql`にunique制限をつけると空のslugが複数あった場合エラーになる（`nil`は大丈夫）ので、`before_validation`で空のslugを`nil`にするメソッドを呼び出しています！
- 編集ページ、個別ページでスラッグを編集、確認できるようになっています！