### PR TITLE
お知らせの個別ページにIDとニックネームを併記する

### DIFF
--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -10,7 +10,7 @@
                   | WIP
             .thread-header-metas__meta
               = link_to announcement.user, class: 'a-user-name' do
-                = announcement.user.login_name
+                = announcement.user.long_name
             .thread-header-metas__meta
               time.a-date(datetime="#{announcement.created_at.to_datetime}" pubdate='pubdate')
                 span.a-date__label

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -200,4 +200,10 @@ class AnnouncementsTest < ApplicationSystemTestCase
       assert_text 'コピー'
     end
   end
+
+  test 'show user full_name next to user login_name' do
+    login_user 'kimura', 'testtest'
+    visit "/announcements/#{announcements(:announcement1).id}"
+    assert_text 'komagata (Komagata Masaki)'
+  end
 end


### PR DESCRIPTION
issue: #2801
# 概要
- お知らせの個別ページにユーザー名も表示されるようにしました。

変更前：ユーザーID
変更後：ユーザーID（ユーザー名）

![image](https://user-images.githubusercontent.com/62867257/121610559-47e21680-ca91-11eb-990a-967e7bc4af3b.png)
