### PR TITLE
Admin画面のカテゴリー一覧にページャーをつける

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -4,7 +4,7 @@ class Admin::CategoriesController < AdminController
   before_action :set_category, only: %i[edit update destroy]
 
   def index
-    @categories = Category.order('position')
+    @categories = Category.page(params[:page]).order('position')
   end
 
   def new

--- a/app/views/admin/categories/index.html.slim
+++ b/app/views/admin/categories/index.html.slim
@@ -15,4 +15,6 @@ header.page-header
   = render 'admin/admin_page_tabs'
 
 .page-body
+  = paginate @categories
   #js-categories(data-categories="#{@categories.to_json}")
+  = paginate @categories

--- a/test/system/admin/categories_test.rb
+++ b/test/system/admin/categories_test.rb
@@ -56,4 +56,14 @@ class Admin::CategoriesTest < ApplicationSystemTestCase
     end
     assert_no_text '学習の準備'
   end
+
+  test 'show pagination' do
+    login_user 'komagata', 'testtest'
+    Announcement.delete_all
+    26.times do
+      Category.create(name: 'test', slug: 'test', description: 'test')
+    end
+    visit '/admin/categories'
+    assert_selector 'nav.pagination', count: 2
+  end
 end

--- a/test/system/admin/categories_test.rb
+++ b/test/system/admin/categories_test.rb
@@ -59,7 +59,7 @@ class Admin::CategoriesTest < ApplicationSystemTestCase
 
   test 'show pagination' do
     login_user 'komagata', 'testtest'
-    Announcement.delete_all
+    Category.delete_all
     26.times do
       Category.create(name: 'test', slug: 'test', description: 'test')
     end

--- a/test/system/admin/categories_test.rb
+++ b/test/system/admin/categories_test.rb
@@ -59,7 +59,6 @@ class Admin::CategoriesTest < ApplicationSystemTestCase
 
   test 'show pagination' do
     login_user 'komagata', 'testtest'
-    Category.delete_all
     26.times do
       Category.create(name: 'test', slug: 'test', description: 'test')
     end


### PR DESCRIPTION
issue #2808
# 概要
adminのカテゴリー一覧ページにページャーを付けました。
- 変更前
![image](https://user-images.githubusercontent.com/62867257/121630934-141ae700-cab9-11eb-8ddf-a41ca2186eb1.png)

- 変更後

![image](https://user-images.githubusercontent.com/62867257/121631102-6c51e900-cab9-11eb-91b8-cef454c324fe.png)
