### PR TITLE
イベント個別ページのユーザーIDの後ろにユーザー名を追加

### DIFF
--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -6,7 +6,7 @@
           .thread-header-metas__start
             .thread-header-metas__meta
               = link_to event.user, class: 'a-user-name' do
-                = event.user.login_name
+                = event.user.long_name
             .thread-header-metas__meta
               .a-date
                 time.a-date__value(datetime="#{event.created_at.to_datetime}" pubdate='pubdate')

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -356,4 +356,11 @@ class EventsTest < ApplicationSystemTestCase
     end
     assert_text 'Watch中'
   end
+
+  test 'show user full_name next to user login_name' do
+    event = events(:event2)
+    login_user 'kimura', 'testtest'
+    visit event_path(event)
+    assert_text 'komagata (Komagata Masaki)'
+  end
 end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -358,9 +358,8 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'show user full_name next to user login_name' do
-    event = events(:event2)
     login_user 'kimura', 'testtest'
-    visit event_path(event)
+    visit event_path(events(:event2))
     assert_text 'komagata (Komagata Masaki)'
   end
 end


### PR DESCRIPTION
issue: #2802

## 概要
イベント個別ページのユーザーIDの後ろにユーザー名も表示されるよう変更しました。

変更前
![スクリーンショット 2021-06-14 11 16 26](https://user-images.githubusercontent.com/67262644/121840379-0b275100-cd17-11eb-8fba-92ec6d3cac0c.png)

変更後
![スクリーンショット 2021-06-14 11 16 52](https://user-images.githubusercontent.com/67262644/121840363-02367f80-cd17-11eb-8d76-87f8b431e757.png)
