### PR TITLE
メンターの提出物一覧の「未チェック」を「未完了」に変更

### DIFF
--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -65,7 +65,7 @@ export default {
     },
     unconfirmedLinksName() {
       return {
-        unchecked: '未チェック',
+        unchecked: '未完了',
         'not-responded': '未返信',
         'self-assigned': '自分の担当'
       }[this.selectedTab]

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -5,7 +5,7 @@
         = link_to '全て', products_path, class: "page-tabs__item-link #{current_link(/^products-index/)}"
       li.page-tabs__item
         = link_to products_unchecked_index_path, class: "page-tabs__item-link #{current_link(/^products-unchecked-index/)}" do
-          | 未チェック
+          | 未完了
           - if Cache.unchecked_product_count.positive?
             .page-tabs__item-count.a-notification-count
               = Cache.unchecked_product_count

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -16,7 +16,7 @@ header.page-header
           - if current_user.admin?
             li.page-header-actions__item
               = link_to products_unchecked_index_path, class: 'a-button is-md is-secondary is-block is-back' do
-                | 未チェック一覧
+                | 未完了一覧
 
 = render 'page_tabs', resource: @product.practice
 

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -1,4 +1,4 @@
-- title '未チェックの提出物'
+- title '未完了の提出物'
 
 header.page-header
   .container

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -40,7 +40,7 @@ class ProductsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'renamed unchecked to incomplete' do
+  test 'show incomplete' do
     login_user 'komagata', 'testtest'
     visit '/products/unchecked'
     assert_link '未完了'

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -9,12 +9,12 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'advisor can not see listing unchecked products' do
-    visit_with_auth 'products', 'advijirou'
+    visit_with_auth '/products', 'advijirou'
     assert_no_link '未完了'
   end
 
   test 'mentor can see a button to open to open all unchecked products' do
-    visit_with_auth 'products/unchecked', 'komagata'
+    visit_with_auth '/products/unchecked', 'komagata'
     assert_button '未完了の提出物を一括で開く'
   end
 

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -27,4 +27,17 @@ class ProductsTest < ApplicationSystemTestCase
       assert_text 'テストの提出物1です。'
     end
   end
+
+  test 'renamed unchecked to incomplete' do
+    login_user 'komagata', 'testtest'
+    visit '/products/unchecked'
+    assert_link '未完了'
+    assert_text '未完了の提出物'
+  end
+
+  test 'button name is incomplete list' do
+    login_user 'komagata', 'testtest'
+    visit "/products/#{products(:product1).id}"
+    assert_link '未完了一覧'
+  end
 end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -9,15 +9,6 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'advisor can not see listing unchecked products' do
-<<<<<<< HEAD
-    visit_with_auth '/products', 'advijirou'
-    assert_no_link '未チェック'
-  end
-
-  test 'mentor can see a button to open to open all unchecked products' do
-    visit_with_auth '/products/unchecked', 'komagata'
-    assert_button '未チェックの提出物を一括で開く'
-=======
     login_user 'advijirou', 'testtest'
     visit '/products'
     assert_no_link '未完了'
@@ -27,7 +18,6 @@ class ProductsTest < ApplicationSystemTestCase
     login_user 'komagata', 'testtest'
     visit '/products/unchecked'
     assert_button '未完了の提出物を一括で開く'
->>>>>>> 0b552d5c (「未チェックの提出物を一括で開く」ボタンも未完了に変更&テストを修正)
   end
 
   test 'click on open all unchecked submissions button' do

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -9,14 +9,12 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'advisor can not see listing unchecked products' do
-    login_user 'advijirou', 'testtest'
-    visit '/products'
+    visit_with_auth 'products', 'advijirou'
     assert_no_link '未完了'
   end
 
   test 'mentor can see a button to open to open all unchecked products' do
-    login_user 'komagata', 'testtest'
-    visit '/products/unchecked'
+    visit_with_auth 'products', 'komagata'
     assert_button '未完了の提出物を一括で開く'
   end
 
@@ -31,15 +29,13 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'show incomplete' do
-    login_user 'komagata', 'testtest'
-    visit '/products/unchecked'
+    visit_with_auth '/products/unchecked', 'komagata'
     assert_link '未完了'
     assert_text '未完了の提出物'
   end
 
   test 'button name is incomplete list' do
-    login_user 'komagata', 'testtest'
-    visit "/products/#{products(:product1).id}"
+    visit_with_auth "/products/#{products(:product1).id}", 'komagata'
     assert_link '未完了一覧'
   end
 end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -9,6 +9,7 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'advisor can not see listing unchecked products' do
+<<<<<<< HEAD
     visit_with_auth '/products', 'advijirou'
     assert_no_link '未チェック'
   end
@@ -16,12 +17,23 @@ class ProductsTest < ApplicationSystemTestCase
   test 'mentor can see a button to open to open all unchecked products' do
     visit_with_auth '/products/unchecked', 'komagata'
     assert_button '未チェックの提出物を一括で開く'
+=======
+    login_user 'advijirou', 'testtest'
+    visit '/products'
+    assert_no_link '未完了'
+  end
+
+  test 'mentor can see a button to open to open all unchecked products' do
+    login_user 'komagata', 'testtest'
+    visit '/products/unchecked'
+    assert_button '未完了の提出物を一括で開く'
+>>>>>>> 0b552d5c (「未チェックの提出物を一括で開く」ボタンも未完了に変更&テストを修正)
   end
 
   test 'click on open all unchecked submissions button' do
     visit_with_auth '/products/unchecked', 'komagata'
 
-    click_button '未チェックの提出物を一括で開く'
+    click_button '未完了の提出物を一括で開く'
 
     within_window(windows.last) do
       assert_text 'テストの提出物1です。'

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -14,7 +14,7 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'mentor can see a button to open to open all unchecked products' do
-    visit_with_auth 'products', 'komagata'
+    visit_with_auth 'products/unchecked', 'komagata'
     assert_button '未完了の提出物を一括で開く'
   end
 


### PR DESCRIPTION
issue #2811 

# 概要
管理者の提出物一覧の「未チェック」を「未完了」変更しました。
「未チェック」となっているボタンの箇所も同時に変更しました。
## 変更前
![image](https://user-images.githubusercontent.com/62867257/121849513-60b72a00-cd26-11eb-8cb8-8326b23fd9ee.png)
![image](https://user-images.githubusercontent.com/62867257/121849580-775d8100-cd26-11eb-91b7-217963a7a689.png)
![image](https://user-images.githubusercontent.com/62867257/121849625-85ab9d00-cd26-11eb-8f99-c9f26480b6b3.png)

## 変更後

![image](https://user-images.githubusercontent.com/62867257/121849443-4aa96980-cd26-11eb-96d5-f3a3dfddc8e2.png)
![image](https://user-images.githubusercontent.com/62867257/121849831-d3c0a080-cd26-11eb-81d5-7c57af21b73e.png)
![image](https://user-images.githubusercontent.com/62867257/121849879-e20ebc80-cd26-11eb-8a5b-dabb667690aa.png)
