### PR TITLE
日報の確認しましたの通知を削除した

### DIFF
--- a/app/models/check_callbacks.rb
+++ b/app/models/check_callbacks.rb
@@ -2,7 +2,7 @@
 
 class CheckCallbacks
   def after_create(check)
-    NotificationFacade.checked(check) if check.sender != check.receiver
+    NotificationFacade.checked(check) if check.sender != check.receiver && check.checkable_type != 'Report'
 
     update_product_status(check)
     delete_report_cache(check)

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -160,12 +160,12 @@ class NotificationsTest < ApplicationSystemTestCase
     login_user 'hatsuno', 'testtest'
     report = create_report 'コメントと', '確認があった', false
 
-    login_user 'komagata', 'testtest'
+    visit_with_auth "/reports/#{report}", 'komagata'
     visit "/reports/#{report}"
     fill_in 'new_comment[description]', with: 'コメントと確認した'
     click_button '確認OKにする'
 
-    login_user 'hatsuno', 'testtest'
+    visit_with_auth "/reports/#{report}", 'hatsuno'
     find('.header-links__link.test-show-notifications').click
     wait_for_vuejs
     assert_text 'hatsunoさんの【 「コメントと」の日報 】にkomagataさんがコメントしました。'

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -168,6 +168,6 @@ class NotificationsTest < ApplicationSystemTestCase
     login_user 'hatsuno', 'testtest'
     find('.header-links__link.test-show-notifications').click
     wait_for_vuejs
-    assert_text 'komagataさんがコメントとの確認とコメントをしました。'
+    assert_text 'hatsunoさんの【 「コメントと」の日報 】にkomagataさんがコメントしました。'
   end
 end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -155,4 +155,19 @@ class NotificationsTest < ApplicationSystemTestCase
       assert active_button.has_text? '2'
     end
   end
+
+  test 'notify comment and check' do
+    login_user 'hatsuno', 'testtest'
+    report = create_report 'コメントと', '確認があった', false
+
+    login_user 'komagata', 'testtest'
+    visit "/reports/#{report}"
+    fill_in 'new_comment[description]', with: 'コメントと確認した'
+    click_button '確認OKにする'
+
+    login_user 'hatsuno', 'testtest'
+    find('.header-links__link.test-show-notifications').click
+    wait_for_vuejs
+    assert_text 'komagataさんがコメントとの確認とコメントをしました。'
+  end
 end


### PR DESCRIPTION
ref: #2779

## なぜこの変更が必要なのか
コメント通知がないとその記事を見にいかないユーザーを考慮すると、「コメント→確認」の順番でもコメントがあった旨の通知を見逃さないようになるため。
また、一定数の需要があったため。
![image](https://user-images.githubusercontent.com/75117116/120770776-76279980-c559-11eb-9830-c3116bc33574.png)

## 実装について
~~コントローラーで通知を読み込む前に、「確認された未読の通知」を取得し、その日報のコメントに確認したメンターのIDが含まれていれば、通知の文言を変更するように変更しました。
この後にさらにコメントがあれば通知は上書きされてしまう仕様になっています。~~

(追記)
一度同じ日報に確認とコメントがあった場合に、元のDBを更新することによって、確認とコメントの通知をまとめていましたが、それだと元のDBが必要になった場合に困る指摘があったので通知の仕様を
「 同じ日報に確認とコメントがあった場合まとめて通知したい」から
「日報の確認しましたの通知を削除する」に変更しています。
また提出物の通知に関しては従来通り「同じ提出物に確認とコメントがあれば一番最後の通知のみを表示させる」仕様のままです。
