### PR TITLE
admin画面の企業一覧にページャーをつける

### DIFF
--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -4,7 +4,7 @@ class Admin::CompaniesController < AdminController
   before_action :set_company, only: %i[edit update destroy]
 
   def index
-    @companies = Company.with_attached_logo.order(:id)
+    @companies = Company.with_attached_logo.order(:id).page(params[:page])
   end
 
   def new

--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -15,6 +15,7 @@ header.page-header
   = render 'admin/admin_page_tabs'
 
 .page-body
+  = paginate @companies
   .container.is-padding-horizontal-0-sm-down
     .admin-table
       table.admin-table__table
@@ -49,3 +50,4 @@ header.page-header
                       method: :delete,
                       class: 'a-button is-sm is-danger is-icon js-delete' do
                       i.fas.fa-trash-alt
+  = paginate @companies

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -39,4 +39,13 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
     end
     assert_text '企業を削除しました。'
   end
+
+  test 'show pagination' do
+    login_user 'komagata', 'testtest'
+    26.times do
+      Company.create(name: 'test', description: 'test', website: 'test')
+    end
+    visit '/admin/companies'
+    assert_selector 'nav.pagination', count: 2
+  end
 end


### PR DESCRIPTION
issue #2808

# 概要
管理者画面の企業一覧ページにページャーを付けました。
## 変更前
![image](https://user-images.githubusercontent.com/62867257/121976290-8132c300-cdbe-11eb-91bc-1bb611b1057a.png)

## 変更後
![image](https://user-images.githubusercontent.com/62867257/121976217-55afd880-cdbe-11eb-8f66-dd748f466584.png)
