### PR TITLE
日報の保存忘れを極力なくすため、途中保存のメッセージを追加

### DIFF
--- a/app/assets/stylesheets/atoms/_a-textarea-bottom-note.sass
+++ b/app/assets/stylesheets/atoms/_a-textarea-bottom-note.sass
@@ -1,0 +1,13 @@
++media-breakpoint-up(lg)
+  .a-textarea-bottom-note
+    position: relative
+    .a-text-input
+      padding-bottom: 3rem
+
+  .a-textarea-bottom-note__banner
+    background-color: $background-shade
+    +position(absolute, left 1px, bottom 1px, right 1px)
+    +border-radius(bottom, 3px)
+    padding: .5rem
+    +text-block(.8125rem 1.4, center)
+    border-top: solid 1px $border-more-shade

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -8,7 +8,9 @@
           = f.select(:practice_ids, practice_options(categories), { include_hidden: false }, { multiple: true, class: 'js-select2' })
       .form-item
         = f.label :title, class: 'a-form-label'
-        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '主にやったことをタイトルにしよう'
+        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'display: inline-block の挙動の調査を進めた'
+        .a-form-help
+          | 後で探しやすくなるタイトルがオススメ
       .form-item
         = f.label :reported_on, class: 'a-form-label'
         = f.date_field :reported_on, class: 'a-text-input'
@@ -57,7 +59,10 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+          .a-textarea-bottom-note
+            = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+            .a-textarea-bottom-note__banner.is-hidden-md-down
+              | command + s で途中保存ができます。間違って消さないようにマメに保存しよう。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー


### PR DESCRIPTION
Issue: #570

日報のフォームでPCのときだけこれを表示するようにしました。

<img width="773" alt="貼り付けた画像_2021_06_15_11_57" src="https://user-images.githubusercontent.com/168265/121986067-e0013800-cdd0-11eb-8674-03fd54550088.png">

プレースホルダーには、例文を入れました。

![image](https://user-images.githubusercontent.com/168265/121986309-35d5e000-cdd1-11eb-957e-97736e9e81bb.png)

