### PR TITLE
Admin画面のユーザー一覧にページャーを付ける

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,8 +11,7 @@ class Admin::UsersController < AdminController
                  .order_by_counts(params[:order_by] || 'id', @direction)
                  .users_role(@target)
                  .page(params[:page])
-    @emails = User.with_attached_avatar
-                  .preload(%i[company course])
+    @emails = User.preload(%i[company course])
                   .order_by_counts(params[:order_by] || 'id', @direction)
                   .users_role(@target)
                   .pluck(:email)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,6 +10,7 @@ class Admin::UsersController < AdminController
                  .preload(%i[company course])
                  .order_by_counts(params[:order_by] || 'id', @direction)
                  .users_role(@target)
+                 .page(params[:page])
 
     if Rails.env.production?
       @subscriptions = Subscription.new.all

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,6 +11,11 @@ class Admin::UsersController < AdminController
                  .order_by_counts(params[:order_by] || 'id', @direction)
                  .users_role(@target)
                  .page(params[:page])
+    @emails = User.with_attached_avatar
+                  .preload(%i[company course])
+                  .order_by_counts(params[:order_by] || 'id', @direction)
+                  .users_role(@target)
+                  .pluck(:email)
 
     if Rails.env.production?
       @subscriptions = Subscription.new.all

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,6 +2,7 @@
 
 class Admin::UsersController < AdminController
   before_action :set_user, only: %i[show edit update]
+  PAGER_NUMBER = 100
 
   def index
     @direction = params[:direction] || 'desc'
@@ -10,7 +11,7 @@ class Admin::UsersController < AdminController
                  .preload(%i[company course])
                  .order_by_counts(params[:order_by] || 'id', @direction)
                  .users_role(@target)
-                 .page(params[:page])
+                 .page(params[:page]).per(PAGER_NUMBER)
     @emails = User.preload(%i[company course])
                   .order_by_counts(params[:order_by] || 'id', @direction)
                   .users_role(@target)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -12,10 +12,7 @@ class Admin::UsersController < AdminController
                  .order_by_counts(params[:order_by] || 'id', @direction)
                  .users_role(@target)
                  .page(params[:page]).per(PAGER_NUMBER)
-    @emails = User.preload(%i[company course])
-                  .order_by_counts(params[:order_by] || 'id', @direction)
-                  .users_role(@target)
-                  .pluck(:email)
+    @emails = User.users_role(@target).pluck(:email)
 
     if Rails.env.production?
       @subscriptions = Subscription.new.all

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -117,4 +117,4 @@
       | 全員のメアド
   .card-body
     textarea.a-text-input
-      = @users.pluck(:email).join(',')
+      = @emails.join(',')

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -9,5 +9,7 @@ header.page-header
   = render 'nav'
 
 .page-body
+  = paginate @users
   .container.is-padding-horizontal-0-sm-down
     = render 'table', users: @users, direction: @direction
+  = paginate @users

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -152,4 +152,26 @@ class Admin::UsersTest < ApplicationSystemTestCase
     visit "/admin/users/#{user.id}/edit"
     assert_text '追加タグ'
   end
+
+  test 'show pagination users' do
+    login_user 'komagata', 'testtest'
+    user = users(:kimura)
+    26.times do |n|
+      User.create!(
+        email: "test#{n}@fjord.jp",
+        name: "test#{n}",
+        description: user[:description],
+        nda: user[:nda],
+        password: 'testtest',
+        login_name: "test#{n}",
+        name_kana: user[:name_kana],
+        course_id: user[:course_id],
+        job: user[:job],
+        os: user[:os],
+        experience: user[:experience]
+      )
+    end
+    visit '/admin/users?target=all'
+    assert_selector 'nav.pagination', count: 2
+  end
 end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -156,7 +156,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
   test 'show pagination users' do
     login_user 'komagata', 'testtest'
     user = users(:kimura)
-    26.times do |n|
+    101.times do |n|
       User.create!(
         email: "test#{n}@fjord.jp",
         name: "test#{n}",


### PR DESCRIPTION
issue: #2807

## 概要
Admin画面のユーザー一覧にページャーを付けました。
どのターゲット（現役生・卒業生など）の画面でもページャーが表示されることを目視で確認済です。


![貼り付けた画像_2021_06_15_18_10](https://user-images.githubusercontent.com/67262644/122026308-09d45200-ce05-11eb-9940-29d91c6fbb29.png)

ユーザー画面下部にある「全員のメアド」には全ページのユーザーのメアドの一覧を表示させるようにしました。
（全員のメアドを表示させること、`@emails`のデータ取得を行う必要があることはkomagataさんとmachidaさんに確認済みです）

![貼り付けた画像_2021_06_15_18_11](https://user-images.githubusercontent.com/67262644/122026603-561f9200-ce05-11eb-98a6-420fdb324df5.png)
