### PR TITLE
ユーザーのdescriptionがnilの場合「自己紹介文はありません。」と挿入する

### DIFF
--- a/db/data/20210616072230_add_empty_string_to_nil_description.rb
+++ b/db/data/20210616072230_add_empty_string_to_nil_description.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 class AddEmptyStringToNilDescription < ActiveRecord::Migration[6.1]
   def up
     User.find_each do |user|
       if user.description.nil?
-        user.description = "*自己紹介文はありません*"
+        user.description = '自己紹介文はありません。'
         user.save!
       end
     end
   end
 
   def down
-    puts "down"
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/data/20210616072230_add_empty_string_to_nil_description.rb
+++ b/db/data/20210616072230_add_empty_string_to_nil_description.rb
@@ -1,0 +1,14 @@
+class AddEmptyStringToNilDescription < ActiveRecord::Migration[6.1]
+  def up
+    User.find_each do |user|
+      if user.description.nil?
+        user.description = "*自己紹介文はありません*"
+        user.save!
+      end
+    end
+  end
+
+  def down
+    puts "down"
+  end
+end

--- a/db/data/20210616072230_add_empty_string_to_nil_description.rb
+++ b/db/data/20210616072230_add_empty_string_to_nil_description.rb
@@ -2,9 +2,12 @@
 
 class AddEmptyStringToNilDescription < ActiveRecord::Migration[6.1]
   def up
-    now = Time.current
-
-    User.where(description: nil).update_all(description: '自己紹介文はありません。', updated_at: now)
+    User.find_each do |user|
+      if user.description.nil?
+        user.description = '自己紹介文はありません。'
+        user.save!
+      end
+    end
   end
 
   def down

--- a/db/data/20210616072230_add_empty_string_to_nil_description.rb
+++ b/db/data/20210616072230_add_empty_string_to_nil_description.rb
@@ -3,10 +3,7 @@
 class AddEmptyStringToNilDescription < ActiveRecord::Migration[6.1]
   def up
     User.find_each do |user|
-      if user.description.nil?
-        user.description = '自己紹介文はありません。'
-        user.save!
-      end
+      user.update!(description: '自己紹介文はありません。') if user.description.nil?
     end
   end
 

--- a/db/data/20210616072230_add_empty_string_to_nil_description.rb
+++ b/db/data/20210616072230_add_empty_string_to_nil_description.rb
@@ -2,12 +2,9 @@
 
 class AddEmptyStringToNilDescription < ActiveRecord::Migration[6.1]
   def up
-    User.find_each do |user|
-      if user.description.nil?
-        user.description = '自己紹介文はありません。'
-        user.save!
-      end
-    end
+    now = Time.current
+
+    User.where(description: nil).update_all(description: '自己紹介文はありません。', updated_at: now)
   end
 
   def down


### PR DESCRIPTION
issue #2798 
# 概要
現在ユーザーの中には自己紹介欄がnilの方がいます。
以前はnilの許可されていましたが現在はバリデーションで許可されていないためnilの方には「*自己紹介文はありません*」という文言を挿入するようにしました。

こちらは`data-migrate`gemを用いて実装しています。
[DBのデータをmigrateする方法](https://github.com/fjordllc/bootcamp/wiki/DB%E3%81%AE%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92migrate%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
以前はデータを挿入するためにrake taskを作成、デプロイした後に手動で行なっていましたが現在はデプロイ時に自動でrake taskが走るようになっています！

開発環境で
- テストデータ（自己紹介欄がnilのユーザー）を作成
- `data-migrate`gemで作成したファイルを実行
```
rake data_migrate:up VERSION=20210616072230
```
- テストデータ（自己紹介欄がnilのユーザー）に「自己紹介文はありません。」とデータが挿入される

以上のことを確認しました！

![貼り付けた画像_2021_06_18_9_52](https://user-images.githubusercontent.com/62867257/122489659-1d590600-d01b-11eb-937d-9b03eaed8458.png)


