### PR TITLE
日報作成画面から日報一覧に戻るボタンの文言を変更

### DIFF
--- a/app/views/reports/new.html.slim
+++ b/app/views/reports/new.html.slim
@@ -8,8 +8,8 @@ header.page-header
       .page-header-actions
         .page-header-actions__items
           .page-header-actions__item
-            = link_to reports_path, class: 'a-button is-md is-secondary is-block' do
-              | 日報
+            = link_to reports_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | 日報一覧
 
 .page-body
   .container


### PR DESCRIPTION
issue #2854

日報作成画面から日報一覧に戻るボタンの文言を変更しました。

## 変更前
![日報作成___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/58643754/122550113-40f96c00-d06e-11eb-8b81-49b84113a2dd.png)


## 変更後
![](https://i.imgur.com/ukVG9L6.png)