### PR TITLE
提出物一覧に提出物がない場合の表示を変更

### DIFF
--- a/app/views/users/products/index.html.slim
+++ b/app/views/users/products/index.html.slim
@@ -15,5 +15,12 @@ header.page-header
 
 .page-body
   .container
-    .thread-list.a-card
-      = render partial: 'products/product', collection: @products, as: :product
+    - if @products.present?
+      .thread-list.a-card
+        = render partial: 'products/product', collection: @products, as: :product
+    - else
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | 提出物はまだありません。


### PR DESCRIPTION
issue #2852
ユーザの提出物一覧に提出物がない場合、涙アイコンが表示されるようにしました。

## 変更前
![tomoの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/58643754/122710068-800c0500-d29a-11eb-96b5-355184e74af3.png)


## 変更後
![tomoの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）-2](https://user-images.githubusercontent.com/58643754/122710092-8bf7c700-d29a-11eb-802e-bc36dd3f7fe1.png)
