### PR TITLE
イベント一覧ページで投稿者の名前が表示されるようにした

### DIFF
--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -15,8 +15,7 @@
               = event.title
       .thread-list-item__row
         .thread-list-item-name
-          = link_to event.user, class: 'a-user-name' do
-            = event.user.long_name
+          = link_to event.user.long_name, event.user, class: 'a-user-name'
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -16,8 +16,7 @@
       .thread-list-item__row
         .thread-list-item-name
           = link_to event.user, class: 'a-user-name' do
-            | #{event.user.long_name}
-            span
+            = event.user.long_name
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -14,6 +14,11 @@
             = link_to event, itemprop: 'url', class: 'thread-list-item-title__link' do
               = event.title
       .thread-list-item__row
+        .thread-list-item-name
+          = link_to event.user, class: 'a-user-name' do
+            | #{event.user.long_name}
+            span
+      .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items
             .thread-list-item-meta__item

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -334,5 +334,4 @@ class EventsTest < ApplicationSystemTestCase
     visit event_path(events(:event2))
     assert_text 'komagata (Komagata Masaki)'
   end
-
 end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -328,7 +328,11 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'show user full_name next to user login_name' do
-    visit_with_auth event_path(events(:event2)), 'kimura'
+    login_user 'kimura', 'testtest'
+    visit '/events'
+    assert_text 'komagata (Komagata Masaki)'
+    visit event_path(events(:event2))
     assert_text 'komagata (Komagata Masaki)'
   end
+
 end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -328,10 +328,12 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'show user full_name next to user login_name' do
-    login_user 'kimura', 'testtest'
-    visit '/events'
+    visit_with_auth event_path(events(:event2)), 'kimura'
     assert_text 'komagata (Komagata Masaki)'
-    visit event_path(events(:event2))
+  end
+
+  test 'show user full name on list page' do
+    visit_with_auth '/events', 'kimura'
     assert_text 'komagata (Komagata Masaki)'
   end
 end


### PR DESCRIPTION
issue #2804 

# 概要
イベント一覧ページにイベント投稿者の名前が表示されるようにしました！

## 変更前
![image](https://user-images.githubusercontent.com/62867257/122719691-8655ad80-d2a9-11eb-9ff1-1e12f8e1d9b5.png)

## 変更後
![貼り付けた画像_2021_06_21_16_00](https://user-images.githubusercontent.com/62867257/122720075-f7956080-d2a9-11eb-8efd-b641918693c2.png)
