### PR TITLE
ユーザーアイコンをhoverしたときに名前も表示させるよう変更

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -32,7 +32,7 @@ module UserDecorator
   end
 
   def icon_title
-    [login_name, staff_roles].reject(&:blank?)
+    [login_name, name, staff_roles].reject(&:blank?)
                              .join(': ')
   end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -33,7 +33,7 @@ module UserDecorator
 
   def icon_title
     [login_name, name, staff_roles].reject(&:blank?)
-                             .join(': ')
+                                   .join(': ')
   end
 
   def url

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -32,8 +32,10 @@ module UserDecorator
   end
 
   def icon_title
-    [login_name, name, staff_roles].reject(&:blank?)
-                                   .join(': ')
+    ["#{login_name} (#{name})", staff_roles].reject(&:blank?)
+                                            .join(': ')
+    # [login_name, name, staff_roles].reject(&:blank?)
+    #                                .join(': ')
   end
 
   def url

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -14,8 +14,8 @@ class UserDecoratorTest < ActiveSupport::TestCase
   end
 
   test 'icon_title' do
-    assert_equal 'komagata: Komagata Masaki: 管理者、メンター', @user1.icon_title
-    assert_equal 'hajime: Hajime Tayo', @user2.icon_title
+    assert_equal 'komagata (Komagata Masaki): 管理者、メンター', @user1.icon_title
+    assert_equal 'hajime (Hajime Tayo)', @user2.icon_title
   end
 
   test 'niconico_calendar' do

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -14,8 +14,8 @@ class UserDecoratorTest < ActiveSupport::TestCase
   end
 
   test 'icon_title' do
-    assert_equal 'komagata: 管理者、メンター', @user1.icon_title
-    assert_equal 'hajime', @user2.icon_title
+    assert_equal 'komagata: Komagata Masaki: 管理者、メンター', @user1.icon_title
+    assert_equal 'hajime: Hajime Tayo', @user2.icon_title
   end
 
   test 'niconico_calendar' do

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -254,7 +254,7 @@ class EventsTest < ApplicationSystemTestCase
     end
     within '.waitlist' do
       wait_user = all('img').map { |img| img['alt'] }
-      assert_equal %w[kimura:\ Kimura\ Tadasi], wait_user
+      assert_equal %w[kimura\ (Kimura\ Tadasi)], wait_user
     end
   end
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -254,7 +254,7 @@ class EventsTest < ApplicationSystemTestCase
     end
     within '.waitlist' do
       wait_user = all('img').map { |img| img['alt'] }
-      assert_equal %w[kimura], wait_user
+      assert_equal %w[kimura:\ Kimura\ Tadasi], wait_user
     end
   end
 


### PR DESCRIPTION
issue #2806

ユーザーアイコンをhoverしたときに、ユーザーIDに加えて名前も表示させるように変更しました。

## 変更前
<img width="429" alt="スクリーンショット 2021-06-27 22 23 41" src="https://user-images.githubusercontent.com/58643754/123546272-dbf0f500-d796-11eb-84b9-550a238280cb.png">

## 変更後
<img width="426" alt="スクリーンショット 2021-06-27 21 53 59" src="https://user-images.githubusercontent.com/58643754/123546281-e612f380-d796-11eb-8766-a40e69868f12.png">
