### PR TITLE
ダッシュボード配下に自分の日報一覧ページを作る

### DIFF
--- a/app/controllers/current_user/reports_controller.rb
+++ b/app/controllers/current_user/reports_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CurrentUser::ReportsController < ApplicationController
+  before_action :require_login
+  before_action :set_user
+  before_action :set_reports
+
+  def index; end
+
+  private
+
+  def set_user
+    @user = current_user
+  end
+
+  def set_reports
+    @reports = user.reports.list.page(params[:page])
+  end
+
+  def user
+    @user ||= current_user
+  end
+end

--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -1,0 +1,28 @@
+- title "#{@user.login_name}の日報"
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+              i.fas.fa-plus
+              | 日報作成
+
+= render 'home/page_tabs', user: @user
+
+.page-body
+  .container
+    = paginate @reports
+    - if @reports.present?
+      .thread-list.a-card
+        = render partial: 'reports/report', collection: @reports, as: :report
+    - else
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | 日報はまだありません。
+    = paginate @reports

--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -1,9 +1,9 @@
-- title "#{@user.login_name}の日報"
+- title "自分の日報"
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        | ダッシュボード
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item

--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -1,4 +1,4 @@
-- title "自分の日報"
+- title '自分の日報'
 header.page-header
   .container
     .page-header__inner

--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -1,0 +1,9 @@
+.page-tabs
+  .container
+    ul.page-tabs__items
+      li.page-tabs__item
+        = link_to root_path, class: "page-tabs__item-link #{current_page_tab_or_not('')}" do
+          | ダッシュボード
+      li.page-tabs__item
+        = link_to root_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
+          | 自分の日報

--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -4,6 +4,7 @@
       li.page-tabs__item
         = link_to root_path, class: "page-tabs__item-link #{current_page_tab_or_not('')}" do
           | ダッシュボード
-      li.page-tabs__item
-        = link_to current_user_reports_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
-          | 自分の日報
+      - if !user.staff? || user.reports.present?
+        li.page-tabs__item
+          = link_to current_user_reports_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
+            | 自分の日報

--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -5,5 +5,5 @@
         = link_to root_path, class: "page-tabs__item-link #{current_page_tab_or_not('')}" do
           | ダッシュボード
       li.page-tabs__item
-        = link_to root_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
+        = link_to current_user_reports_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
           | 自分の日報

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -5,6 +5,9 @@ header.page-header
     .page-header__inner
       h2.page-header__title = title
       = render 'reports/new_report'
+
+= render 'page_tabs', user: current_user
+
 - if @my_seat_today
   = render 'my_seat_today', my_seat_today: @my_seat_today
 .page-body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,10 @@ Rails.application.routes.draw do
     resources :seats, except: %i(show)
   end
 
+  namespace :current_user do
+    resources :reports, only: %i(index)
+  end
+
   namespace "partial" do
     resource :git_hub_grass, only: %i(show), controller: "git_hub_grass"
   end

--- a/test/system/current_user/reports_test.rb
+++ b/test/system/current_user/reports_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class CurrentUser::ReportsTest < ApplicationSystemTestCase
+  test 'show current_user reports when current_user is student' do
+    visit_with_auth '/current_user/reports', 'hatsuno'
+    assert_equal 'hatsunoの日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+  end
+end

--- a/test/system/current_user/reports_test.rb
+++ b/test/system/current_user/reports_test.rb
@@ -5,6 +5,6 @@ require 'application_system_test_case'
 class CurrentUser::ReportsTest < ApplicationSystemTestCase
   test 'show current_user reports when current_user is student' do
     visit_with_auth '/current_user/reports', 'hatsuno'
-    assert_equal 'hatsunoの日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal '自分の日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 end


### PR DESCRIPTION
issue : #2844

## 概要

自分の日報一覧ページ`/current_user/reports`を作成しました。
また、ダッシュボード(home)画面に「ダッシュボード」と「自分の日報」タブを表示しました。

### 自分の日報一覧ページ`/current_user/reports`画面
![Pasted Graphic 5](https://user-images.githubusercontent.com/67262644/123604718-11005480-d836-11eb-8e19-6caf73913ca2.png)
### ダッシュボード画面

変更前
![Pasted Graphic 7](https://user-images.githubusercontent.com/67262644/123604751-18bff900-d836-11eb-80ca-3b83ca940194.png)

変更後
![貼り付けた画像_2021_06_28_17_27](https://user-images.githubusercontent.com/67262644/123604893-3db46c00-d836-11eb-9653-95c850c43b4b.png)
