### PR TITLE
ユーザータグの詳細で「このタグを自分から外す」ボタンの導入

### DIFF
--- a/app/assets/stylesheets/blocks/page/_page-main-header-actions.sass
+++ b/app/assets/stylesheets/blocks/page/_page-main-header-actions.sass
@@ -1,3 +1,23 @@
 .page-main-header-actions
   +media-breakpoint-up(md)
     margin-top: -.375rem
+
+.page-main-header-actions__items
+  display: flex
+  +margin(horizontal, -.25rem)
+  justify-content: center
+
+.page-main-header-actions__item
+  +padding(horizontal, .25rem)
+  +media-breakpoint-up(md)
+    min-width: 10rem
+    display: flex
+    justify-content: center
+  +media-breakpoint-down(sm)
+    flex: 1
+  &.is-remove
+    .is-muted
+      border: solid 1px $border-more-shade
+      &:hover
+        color: $default-text
+        background-color: $base

--- a/app/controllers/users/tags_controller.rb
+++ b/app/controllers/users/tags_controller.rb
@@ -14,4 +14,11 @@ class Users::TagsController < ApplicationController
     url = URI.encode_www_form_component(params[:tag])
     redirect_to "/users/tags/#{url}"
   end
+
+  def destroy
+    current_user.tag_list.delete(params[:tag])
+    current_user.save
+    url = URI.encode_www_form_component(params[:tag])
+    redirect_to "/users/tags/#{url}"
+  end
 end

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -35,8 +35,7 @@ main.page-main
               .page-main-header-actions__items
                 .page-main-header-actions__item
                   - if current_user.tag_list.include?(params[:tag])
-                    .a-button.is-md.is-disabled
-                      | 追加済み
+                    = link_to 'このタグを自分から外す', "/users/tags/#{params[:tag]}", method: 'delete', class: 'a-button is-md is-secondary'
                   - else
                     = link_to 'このタグを自分に追加', "/users/tags/#{params[:tag]}", method: 'post', class: 'a-button is-md is-secondary'
         - else

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -33,11 +33,11 @@ main.page-main
           .page-main-header__end
             .page-main-header-actions
               .page-main-header-actions__items
-                .page-main-header-actions__item
+                .page-main-header-actions__item.is-remove
                   - if current_user.tag_list.include?(params[:tag])
-                    = link_to 'このタグを自分から外す', "/users/tags/#{params[:tag]}", method: 'delete', class: 'a-button is-md is-secondary'
+                    = link_to 'このタグを自分から外す', "/users/tags/#{params[:tag]}", method: 'delete', class: 'a-button is-md is-muted is-block'
                   - else
-                    = link_to 'このタグを自分に追加', "/users/tags/#{params[:tag]}", method: 'post', class: 'a-button is-md is-secondary'
+                    = link_to 'このタグを自分に追加', "/users/tags/#{params[:tag]}", method: 'post', class: 'a-button is-md is-secondary is-block'
         - else
           h1.page-main-header__title
             | #{t("target.#{@target}")}（#{@users.total_count}）

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,7 @@ Rails.application.routes.draw do
   get "pages/tags/:tag", to: "pages#index", as: :pages_tag, tag: /.+/
   get "questions/tags/:tag", to: "questions#index", as: :questions_tag, tag: /.+/
   get "users/tags/:tag", to: "users#index", as: :users_tag, tag: /.+/
+
   namespace :users do
     post "tags/:tag", to: "tags#update", tag: /.+/
     delete "tags/:tag", to: "tags#destroy", tag: /.+/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,10 +188,11 @@ Rails.application.routes.draw do
   get "pages/tags/:tag", to: "pages#index", as: :pages_tag, tag: /.+/
   get "questions/tags/:tag", to: "questions#index", as: :questions_tag, tag: /.+/
   get "users/tags/:tag", to: "users#index", as: :users_tag, tag: /.+/
-
   namespace :users do
     post "tags/:tag", to: "tags#update", tag: /.+/
+    delete "tags/:tag", to: "tags#destroy", tag: /.+/
   end
+
   resources :watches, only: %i(index)
   get "login" => "user_sessions#new", as: :login
   get "auth/github/callback" => "user_sessions#callback"

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -58,4 +58,22 @@ class User::TagsTest < ApplicationSystemTestCase
     assert_text '課金'
     assert_no_text 'タグ編集'
   end
+
+  test 'delete user tag on tag page' do
+    visit_with_auth '/', 'hatsuno'
+
+    %i[cat shinjuku_rb neovim_v_zero_five_zero _net_framework may_j_].each do |key|
+      name = acts_as_taggable_on_tags(key).name
+      visit "/users/tags/#{name}"
+      click_link 'このタグを自分に追加'
+      visit user_path(users(:hatsuno))
+      assert_text name
+
+      visit "/users/tags/#{name}"
+      click_link 'このタグを自分から外す'
+      assert_no_text 'このタグを自分から外す'
+      visit user_path(users(:hatsuno))
+      assert_no_text name
+    end
+  end
 end

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -60,20 +60,14 @@ class User::TagsTest < ApplicationSystemTestCase
   end
 
   test 'delete user tag on tag page' do
-    visit_with_auth '/', 'hatsuno'
+    visit_with_auth user_path(users(:hajime)), 'hajime'
+    name = acts_as_taggable_on_tags('cat').name
+    assert_text name
 
-    %i[cat shinjuku_rb neovim_v_zero_five_zero _net_framework may_j_].each do |key|
-      name = acts_as_taggable_on_tags(key).name
-      visit "/users/tags/#{name}"
-      click_link 'このタグを自分に追加'
-      visit user_path(users(:hatsuno))
-      assert_text name
-
-      visit "/users/tags/#{name}"
-      click_link 'このタグを自分から外す'
-      assert_no_text 'このタグを自分から外す'
-      visit user_path(users(:hatsuno))
-      assert_no_text name
-    end
+    visit "/users/tags/#{name}"
+    click_link 'このタグを自分から外す'
+    assert_no_text 'このタグを自分から外す'
+    visit user_path(users(:hajime))
+    assert_no_text name
   end
 end


### PR DESCRIPTION
Issue #2778 
ユーザータグの詳細で「このタグを自分から外す」ボタンの導入しました。

## 変更前
<img width="958" alt="ユーザー一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/50036730/124409772-ed806100-dd83-11eb-974f-3b64391e98b3.png">

## 変更後
<img width="943" alt="ユーザー一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/50036730/124409526-734fdc80-dd83-11eb-935f-f49fe7070663.png">
