### PR TITLE
退会理由をメンター、管理者が見れるようにし、メンターモードOFFの場合は非表示にした

### DIFF
--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -73,8 +73,8 @@
           = User.human_attribute_name :retired_on
         .user-metas__item-value
           = l user.retired_on
-    - if user.retired? && current_user.admin?
-      .user-metas__item
+    - if user.retired? && current_user.adviser_or_mentor?
+      .user-metas__item.is-only-mentor-flex
         .user-metas__item-label
           = User.human_attribute_name :retire_reason
         .user-metas__item-value


### PR DESCRIPTION
@komagata 
https://github.com/fjordllc/bootcamp/issues/2915
こちら（ 退会日、退会理由の項目が見えてしまっている。 ）の対応をしました。