### PR TITLE
プラクティス詳細ページの「困ったときは、…」がコピーライト表記に被るのを修正

### DIFF
--- a/app/assets/stylesheets/blocks/practice/_sticky-message.sass
+++ b/app/assets/stylesheets/blocks/practice/_sticky-message.sass
@@ -2,7 +2,7 @@
   +media-breakpoint-up(md)
     background-color: $info
     width: 100%
-    +position(fixed, left 0, bottom 0, 1)
+    +position(sticky, left 0, bottom 0, 1)
     +padding(vertical, .5rem)
     +text-block(1rem 1.4, center $reversal-text)
     a


### PR DESCRIPTION
#2919 こちらを対応。

これ以上下に行かないようにした。

![image](https://user-images.githubusercontent.com/168265/124222012-d51e0580-db3b-11eb-9b11-5fc5cd12bbdd.png)
