### PR TITLE
issue(未返信の提出物一覧に日付ごとの区切り線を入れた )の修正したプルリク

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -1,9 +1,40 @@
 .thread-list-item
-  padding: .75rem 1rem
   &:not(:last-child)
     border-bottom: solid 1px $background
+  +media-breakpoint-up(md)
+    padding: .75rem 1rem
   +media-breakpoint-down(sm)
     padding: .75rem
+
+.thread-list-item__strip-label
+  +media-breakpoint-up(md)
+    margin: -.75rem -1rem .75rem
+  +media-breakpoint-down(sm)
+    margin: -.75rem -.75rem .75rem
+
+.thread-list-item__elapsed-days
+  letter-spacing: .125em
+  text-indent: .125em
+  +media-breakpoint-up(md)
+    +text-block(1rem 1.4, 700 center)
+    padding: .5rem 1rem
+    border: dashed 3px
+  +media-breakpoint-down(sm)
+    +text-block(.875rem 1.4, 700 center)
+    padding: .5rem .75rem
+    border: dashed 2px
+  &.is-5-days
+    background-color: $warning
+    border-color: #d09a0e
+  &.is-6-days
+    background-color: #ff7500
+    color: $reversal-text
+    border-color: #d06305
+  &.is-7-days
+    background-color: $danger
+    color: $reversal-text
+    border-color: #b50f38
+
 
 .thread-list-item__inner
   +position(relative)

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -23,14 +23,14 @@
     +text-block(.875rem 1.4, 700 center)
     padding: .5rem .75rem
     border: dashed 2px
-  &.is-5-days
+  &.is-reply-warning
     background-color: $warning
     border-color: #d09a0e
-  &.is-6-days
+  &.is-reply-alert
     background-color: #ff7500
     color: $reversal-text
     border-color: #d06305
-  &.is-7-days
+  &.is-reply-deadline
     background-color: $danger
     color: $reversal-text
     border-color: #b50f38

--- a/app/assets/stylesheets/variables/_colors.sass
+++ b/app/assets/stylesheets/variables/_colors.sass
@@ -41,7 +41,7 @@ $secondary: $base
 $success: #54a739
 $info: #4cad7c
 $warning: #fabd17
-$danger: #f32c5d
+$danger: #f11c52
 $disabled: #c7c6c6
 
 $success-text: shade($success, 60%)

--- a/app/controllers/api/products/not_responded_controller.rb
+++ b/app/controllers/api/products/not_responded_controller.rb
@@ -8,8 +8,8 @@ class API::Products::NotRespondedController < API::BaseController
                 .list
                 .reorder_for_not_responded_products
                 .page(params[:page])
-    @latest_product_submitted_just_5days = @products.order(published_at: :desc).find { |product| product.submitted_just_specific_days(5) }
-    @latest_product_submitted_just_6days = @products.order(published_at: :desc).find { |product| product.submitted_just_specific_days(6) }
-    @latest_product_submitted_over_7days = @products.order(published_at: :desc).find { |product| product.submitted_over_specific_days(7) }
+    @latest_product_submitted_just_5days = @products.find { |product| product.submitted_just_specific_days(5) }
+    @latest_product_submitted_just_6days = @products.find { |product| product.submitted_just_specific_days(6) }
+    @latest_product_submitted_over_7days = @products.find { |product| product.submitted_over_specific_days(7) }
   end
 end

--- a/app/controllers/api/products/not_responded_controller.rb
+++ b/app/controllers/api/products/not_responded_controller.rb
@@ -8,5 +8,8 @@ class API::Products::NotRespondedController < API::BaseController
                 .list
                 .reorder_for_not_responded_products
                 .page(params[:page])
+    @latest_product_submitted_just_5days = @products.order(published_at: :desc).find { |product| product.submitted_just_specific_days(5) }
+    @latest_product_submitted_just_6days = @products.order(published_at: :desc).find { |product| product.submitted_just_specific_days(6) }
+    @latest_product_submitted_over_7days = @products.order(published_at: :desc).find { |product| product.submitted_over_specific_days(7) }
   end
 end

--- a/app/controllers/api/products/not_responded_controller.rb
+++ b/app/controllers/api/products/not_responded_controller.rb
@@ -8,8 +8,8 @@ class API::Products::NotRespondedController < API::BaseController
                 .list
                 .reorder_for_not_responded_products
                 .page(params[:page])
-    @latest_product_submitted_just_5days = @products.find { |product| product.submitted_just_specific_days(5) }
-    @latest_product_submitted_just_6days = @products.find { |product| product.submitted_just_specific_days(6) }
-    @latest_product_submitted_over_7days = @products.find { |product| product.submitted_over_specific_days(7) }
+    @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }
+    @latest_product_submitted_just_6days = @products.find { |product| product.elapsed_days == 6 }
+    @latest_product_submitted_over_7days = @products.find { |product| product.elapsed_days >= 7 }
   end
 end

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -1,90 +1,90 @@
 <template lang="pug">
-  .thread-list-item(:class="product.wip ? 'is-wip' : ''")
-    .thread-list-item__strip-label(v-if="notResponded")
-      .thread-list-item__elapsed-days.is-5-days(v-if="isLatestProductSubmittedJust5days")
-        | 5日経過
-      .thread-list-item__elapsed-days.is-6-days(v-else-if="isLatestProductSubmittedJust6days")
-        | 6日経過
-      .thread-list-item__elapsed-days.is-7-days(v-else-if="isLatestProductSubmittedOver7days")
-        | 7日以上経過
-      .thread-list-item__inner
-        .thread-list-item__rows
-          .thread-list-item__row
-            .thread-list-item-title
-              .thread-list-item-title__start
-                .thread-list-item-title__icon.is-wip(v-if='product.wip') WIP
-              h2.thread-list-item-title__title(itemprop='name')
-                a.thread-list-item-title__link.js-unconfirmed-link(
-                  :href='product.url',
-                  itemprop='url'
-                ) {{ practiceTitle }}
-          .thread-list-item__row
-            .thread-list-item-meta
-              .thread-list-item-meta__items
-                .thread-list-item-meta__item
-                  a.a-user-name(:href='product.user.url') {{ product.user.login_name }}
-                .thread-list-item-meta__item(v-if='product.wip')
-                  .a-date 提出物作成中
-                .thread-list-item-meta__item(v-else-if='product.published_at')
-                  time.a-date(datetime='product.published_at_date_time')
-                    span.a-date__label 提出日
-                    | {{ product.published_at }}
-                .thread-list-item-meta__item(v-else)
-                  time.a-date(datetime='product.created_at_date_time')
-                    span.a-date__label 提出日
-                    | {{ product.created_at }}
-                time.a-date(
-                  v-if='product.updated_at',
-                  datetime='product.updated_at_date_time'
-                )
-                  span.a-date__label 最終更新日
-                  | {{ product.updated_at }}
-
-          .thread-list-item__row(v-if='product.comments.size > 0')
-            hr.thread-list-item__row-separator
-            .thread-list-item-meta
-              .thread-list-item-meta__items
-                .thread-list-item-meta__item
-                  .thread-list-item-comment
-                    .thread-list-item-comment__label
-                      | コメント
-                    .thread-list-item-comment__count
-                      | （{{ product.comments.size }}）
-                    .thread-list-item-comment__user-icons
-                      a.thread-list-item-comment__user-icon(:href='user.url')(
-                        v-for='user in product.comments.users'
-                      )
-                        img.a-user-icon(
-                          :title='user.icon_title',
-                          :alt='user.icon_title',
-                          :src='user.avatar_url',
-                          :class='[roleClass, daimyoClass]'
-                        )
-                    time.a-date(
-                      datetime='product.comments.last_created_at_date_time'
-                    )
-                      | 〜 {{ product.comments.last_created_at }}
-        .stamp.stamp-approve(v-if='product.checks.size > 0')
-          h2.stamp__content.is-title 確認済
-          time.stamp__content.is-created-at {{ product.checks.last_created_at }}
-          .stamp__content.is-user-name {{ product.checks.last_user_login_name }}
-        .thread-list-item__assignee.is-only-mentor(
-          v-if='isMentor && product.checks.size == 0'
-        )
-          product-checker(
-            :checkerId='product.checker_id',
-            :checkerName='product.checker_name',
-            :currentUserId='currentUserId',
-            :productId='product.id'
-          )
-        .thread-list-item__author
-          a.a-user-name(:href='product.user.url')
-            img.thread-list-item__author-icon.a-user-icon(
-              :title='product.user.icon_title',
-              :alt='product.user.icon_title',
-              :src='product.user.avatar_url',
-              :class='[roleClass, daimyoClass]'
+.thread-list-item(:class='product.wip ? "is-wip" : ""')
+  .thread-list-item__strip-label(v-if="notResponded")
+    .thread-list-item__elapsed-days.is-5-days(v-if="isLatestProductSubmittedJust5days")
+      | 5日経過
+    .thread-list-item__elapsed-days.is-6-days(v-else-if="isLatestProductSubmittedJust6days")
+      | 6日経過
+    .thread-list-item__elapsed-days.is-7-days(v-else-if="isLatestProductSubmittedOver7days")
+      | 7日以上経過
+  .thread-list-item__inner
+    .thread-list-item__rows
+      .thread-list-item__row
+        .thread-list-item-title
+          .thread-list-item-title__start
+            .thread-list-item-title__icon.is-wip(v-if='product.wip') WIP
+          h2.thread-list-item-title__title(itemprop='name')
+            a.thread-list-item-title__link.js-unconfirmed-link(
+              :href='product.url',
+              itemprop='url'
+            ) {{ practiceTitle }}
+      .thread-list-item__row
+        .thread-list-item-meta
+          .thread-list-item-meta__items
+            .thread-list-item-meta__item
+              a.a-user-name(:href='product.user.url') {{ product.user.login_name }}
+            .thread-list-item-meta__item(v-if='product.wip')
+              .a-date 提出物作成中
+            .thread-list-item-meta__item(v-else-if='product.published_at')
+              time.a-date(datetime='product.published_at_date_time')
+                span.a-date__label 提出日
+                | {{ product.published_at }}
+            .thread-list-item-meta__item(v-else)
+              time.a-date(datetime='product.created_at_date_time')
+                span.a-date__label 提出日
+                | {{ product.created_at }}
+            time.a-date(
+              v-if='product.updated_at',
+              datetime='product.updated_at_date_time'
             )
+              span.a-date__label 最終更新日
+              | {{ product.updated_at }}
+
+      .thread-list-item__row(v-if='product.comments.size > 0')
+        hr.thread-list-item__row-separator
+        .thread-list-item-meta
+          .thread-list-item-meta__items
+            .thread-list-item-meta__item
+              .thread-list-item-comment
+                .thread-list-item-comment__label
+                  | コメント
+                .thread-list-item-comment__count
+                  | （{{ product.comments.size }}）
+                .thread-list-item-comment__user-icons
+                  a.thread-list-item-comment__user-icon(:href='user.url')(
+                    v-for='user in product.comments.users'
+                  )
+                    img.a-user-icon(
+                      :title='user.icon_title',
+                      :alt='user.icon_title',
+                      :src='user.avatar_url',
+                      :class='[roleClass, daimyoClass]'
+                    )
+                time.a-date(
+                  datetime='product.comments.last_created_at_date_time'
+                )
+                  | 〜 {{ product.comments.last_created_at }}
+    .stamp.stamp-approve(v-if='product.checks.size > 0')
+      h2.stamp__content.is-title 確認済
+      time.stamp__content.is-created-at {{ product.checks.last_created_at }}
+      .stamp__content.is-user-name {{ product.checks.last_user_login_name }}
+    .thread-list-item__assignee.is-only-mentor(
+      v-if='isMentor && product.checks.size == 0'
+    )
+      product-checker(
+        :checkerId='product.checker_id',
+        :checkerName='product.checker_name',
+        :currentUserId='currentUserId',
+        :productId='product.id'
+      )
+    .thread-list-item__author
+      a.a-user-name(:href='product.user.url')
+        img.thread-list-item__author-icon.a-user-icon(
+          :title='product.user.icon_title',
+          :alt='product.user.icon_title',
+          :src='product.user.avatar_url',
+          :class='[roleClass, daimyoClass]'
+        )
 </template>
 <script>
 import ProductChecker from './product_checker'

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
   .thread-list-item(:class="product.wip ? 'is-wip' : ''")
-    .foo(v-if="notResponded")
-      p(v-if="isLatestProductSubmittedJust5days")
+    .thread-list-item__strip-label(v-if="notResponded")
+      .thread-list-item__elapsed-days.is-5-days(v-if="isLatestProductSubmittedJust5days")
         | 5日経過
-      p(v-else-if="isLatestProductSubmittedJust6days")
+      .thread-list-item__elapsed-days.is-6-days(v-else-if="isLatestProductSubmittedJust6days")
         | 6日経過
-      p(v-else-if="isLatestProductSubmittedOver7days")
+      .thread-list-item__elapsed-days.is-7-days(v-else-if="isLatestProductSubmittedOver7days")
         | 7日以上経過
       .thread-list-item__inner
         .thread-list-item__rows

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -1,8 +1,6 @@
 <template lang="pug">
-<<<<<<< HEAD
-  .foo
-    h1 aaaaaaaaaaaaaaa
-    .thread-list-item(:class='product.wip ? "is-wip" : ""')
+  .thread-list-item(:class="product.wip ? 'is-wip' : ''")
+    .foo(v-if="notResponded")
       p(v-if="isLatestProductSubmittedJust5days")
         | 5日経過
       p(v-else-if="isLatestProductSubmittedJust6days")
@@ -108,19 +106,16 @@ export default {
         : `${this.product.practice.title}の提出物`
     },
     isLatestProductSubmittedJust5days() {
-      if (this.latestProductSubmittedJust5days !== null) {
-        return this.product.id === this.latestProductSubmittedJust5days.id
-      }
+      return this.product.id === this.latestProductSubmittedJust5days.id
     },
     isLatestProductSubmittedJust6days() {
-      if (this.latestProductSubmittedJust6days !== null) {
-        return this.product.id === this.latestProductSubmittedJust6days.id
-      }
+      return this.product.id === this.latestProductSubmittedJust6days.id
     },
     isLatestProductSubmittedOver7days() {
-      if (this.latestProductSubmittedOver7days !== null) {
-        return this.product.id === this.latestProductSubmittedOver7days.id
-      }
+      return this.product.id === this.latestProductSubmittedOver7days.id
+    },
+    notResponded() {
+      return location.pathname === "/products/not_responded"
     },
   }
 }

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -106,13 +106,19 @@ export default {
         : `${this.product.practice.title}の提出物`
     },
     isLatestProductSubmittedJust5days() {
-      return this.product.id === this.latestProductSubmittedJust5days.id
+      if (this.latestProductSubmittedJust5days !== null) {
+        return this.product.id === this.latestProductSubmittedJust5days.id
+      }
     },
     isLatestProductSubmittedJust6days() {
-      return this.product.id === this.latestProductSubmittedJust6days.id
+      if (this.latestProductSubmittedJust6days !== null) {
+        return this.product.id === this.latestProductSubmittedJust6days.id
+      }
     },
     isLatestProductSubmittedOver7days() {
-      return this.product.id === this.latestProductSubmittedOver7days.id
+      if (this.latestProductSubmittedOver7days !== null) {
+        return this.product.id === this.latestProductSubmittedOver7days.id
+      }
     },
     notResponded() {
       return location.pathname === "/products/not_responded"

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -1,89 +1,92 @@
 <template lang="pug">
-.thread-list-item(:class='product.wip ? "is-wip" : ""')
-  p(v-if="isLatestProductSubmittedJust5days")
-    | 5日経過
-  p(v-else-if="isLatestProductSubmittedJust6days")
-    | 6日経過
-  p(v-else-if="isLatestProductSubmittedOver7days")
-    | 7日以上経過
-  .thread-list-item__inner
-    .thread-list-item__rows
-      .thread-list-item__row
-        .thread-list-item-title
-          .thread-list-item-title__start
-            .thread-list-item-title__icon.is-wip(v-if='product.wip') WIP
-          h2.thread-list-item-title__title(itemprop='name')
-            a.thread-list-item-title__link.js-unconfirmed-link(
-              :href='product.url',
-              itemprop='url'
-            ) {{ practiceTitle }}
-      .thread-list-item__row
-        .thread-list-item-meta
-          .thread-list-item-meta__items
-            .thread-list-item-meta__item
-              a.a-user-name(:href='product.user.url') {{ product.user.login_name }}
-            .thread-list-item-meta__item(v-if='product.wip')
-              .a-date 提出物作成中
-            .thread-list-item-meta__item(v-else-if='product.published_at')
-              time.a-date(datetime='product.published_at_date_time')
-                span.a-date__label 提出日
-                | {{ product.published_at }}
-            .thread-list-item-meta__item(v-else)
-              time.a-date(datetime='product.created_at_date_time')
-                span.a-date__label 提出日
-                | {{ product.created_at }}
-            time.a-date(
-              v-if='product.updated_at',
-              datetime='product.updated_at_date_time'
-            )
-              span.a-date__label 最終更新日
-              | {{ product.updated_at }}
-
-      .thread-list-item__row(v-if='product.comments.size > 0')
-        hr.thread-list-item__row-separator
-        .thread-list-item-meta
-          .thread-list-item-meta__items
-            .thread-list-item-meta__item
-              .thread-list-item-comment
-                .thread-list-item-comment__label
-                  | コメント
-                .thread-list-item-comment__count
-                  | （{{ product.comments.size }}）
-                .thread-list-item-comment__user-icons
-                  a.thread-list-item-comment__user-icon(:href='user.url')(
-                    v-for='user in product.comments.users'
-                  )
-                    img.a-user-icon(
-                      :title='user.icon_title',
-                      :alt='user.icon_title',
-                      :src='user.avatar_url',
-                      :class='[roleClass, daimyoClass]'
-                    )
+<<<<<<< HEAD
+  .foo
+    h1 aaaaaaaaaaaaaaa
+    .thread-list-item(:class='product.wip ? "is-wip" : ""')
+      p(v-if="isLatestProductSubmittedJust5days")
+        | 5日経過
+      p(v-else-if="isLatestProductSubmittedJust6days")
+        | 6日経過
+      p(v-else-if="isLatestProductSubmittedOver7days")
+        | 7日以上経過
+      .thread-list-item__inner
+        .thread-list-item__rows
+          .thread-list-item__row
+            .thread-list-item-title
+              .thread-list-item-title__start
+                .thread-list-item-title__icon.is-wip(v-if='product.wip') WIP
+              h2.thread-list-item-title__title(itemprop='name')
+                a.thread-list-item-title__link.js-unconfirmed-link(
+                  :href='product.url',
+                  itemprop='url'
+                ) {{ practiceTitle }}
+          .thread-list-item__row
+            .thread-list-item-meta
+              .thread-list-item-meta__items
+                .thread-list-item-meta__item
+                  a.a-user-name(:href='product.user.url') {{ product.user.login_name }}
+                .thread-list-item-meta__item(v-if='product.wip')
+                  .a-date 提出物作成中
+                .thread-list-item-meta__item(v-else-if='product.published_at')
+                  time.a-date(datetime='product.published_at_date_time')
+                    span.a-date__label 提出日
+                    | {{ product.published_at }}
+                .thread-list-item-meta__item(v-else)
+                  time.a-date(datetime='product.created_at_date_time')
+                    span.a-date__label 提出日
+                    | {{ product.created_at }}
                 time.a-date(
-                  datetime='product.comments.last_created_at_date_time'
+                  v-if='product.updated_at',
+                  datetime='product.updated_at_date_time'
                 )
-                  | 〜 {{ product.comments.last_created_at }}
-    .stamp.stamp-approve(v-if='product.checks.size > 0')
-      h2.stamp__content.is-title 確認済
-      time.stamp__content.is-created-at {{ product.checks.last_created_at }}
-      .stamp__content.is-user-name {{ product.checks.last_user_login_name }}
-    .thread-list-item__assignee.is-only-mentor(
-      v-if='isMentor && product.checks.size == 0'
-    )
-      product-checker(
-        :checkerId='product.checker_id',
-        :checkerName='product.checker_name',
-        :currentUserId='currentUserId',
-        :productId='product.id'
-      )
-    .thread-list-item__author
-      a.a-user-name(:href='product.user.url')
-        img.thread-list-item__author-icon.a-user-icon(
-          :title='product.user.icon_title',
-          :alt='product.user.icon_title',
-          :src='product.user.avatar_url',
-          :class='[roleClass, daimyoClass]'
+                  span.a-date__label 最終更新日
+                  | {{ product.updated_at }}
+
+          .thread-list-item__row(v-if='product.comments.size > 0')
+            hr.thread-list-item__row-separator
+            .thread-list-item-meta
+              .thread-list-item-meta__items
+                .thread-list-item-meta__item
+                  .thread-list-item-comment
+                    .thread-list-item-comment__label
+                      | コメント
+                    .thread-list-item-comment__count
+                      | （{{ product.comments.size }}）
+                    .thread-list-item-comment__user-icons
+                      a.thread-list-item-comment__user-icon(:href='user.url')(
+                        v-for='user in product.comments.users'
+                      )
+                        img.a-user-icon(
+                          :title='user.icon_title',
+                          :alt='user.icon_title',
+                          :src='user.avatar_url',
+                          :class='[roleClass, daimyoClass]'
+                        )
+                    time.a-date(
+                      datetime='product.comments.last_created_at_date_time'
+                    )
+                      | 〜 {{ product.comments.last_created_at }}
+        .stamp.stamp-approve(v-if='product.checks.size > 0')
+          h2.stamp__content.is-title 確認済
+          time.stamp__content.is-created-at {{ product.checks.last_created_at }}
+          .stamp__content.is-user-name {{ product.checks.last_user_login_name }}
+        .thread-list-item__assignee.is-only-mentor(
+          v-if='isMentor && product.checks.size == 0'
         )
+          product-checker(
+            :checkerId='product.checker_id',
+            :checkerName='product.checker_name',
+            :currentUserId='currentUserId',
+            :productId='product.id'
+          )
+        .thread-list-item__author
+          a.a-user-name(:href='product.user.url')
+            img.thread-list-item__author-icon.a-user-icon(
+              :title='product.user.icon_title',
+              :alt='product.user.icon_title',
+              :src='product.user.avatar_url',
+              :class='[roleClass, daimyoClass]'
+            )
 </template>
 <script>
 import ProductChecker from './product_checker'

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -1,5 +1,11 @@
 <template lang="pug">
 .thread-list-item(:class='product.wip ? "is-wip" : ""')
+  p(v-if="isLatestProductSubmittedJust5days")
+    | 5日経過
+  p(v-else-if="isLatestProductSubmittedJust6days")
+    | 6日経過
+  p(v-else-if="isLatestProductSubmittedOver7days")
+    | 7日以上経過
   .thread-list-item__inner
     .thread-list-item__rows
       .thread-list-item__row
@@ -82,13 +88,9 @@
 <script>
 import ProductChecker from './product_checker'
 export default {
+  props: ['product', 'currentUserId', 'isMentor', 'latestProductSubmittedJust5days', 'latestProductSubmittedJust6days', 'latestProductSubmittedOver7days'],
   components: {
     'product-checker': ProductChecker
-  },
-  props: {
-    product: { type: Object, required: true },
-    isMentor: { type: Boolean, required: true },
-    currentUserId: { type: String, required: true }
   },
   computed: {
     roleClass() {
@@ -101,7 +103,22 @@ export default {
       return this.product.user.daimyo
         ? `★${this.product.practice.title}の提出物`
         : `${this.product.practice.title}の提出物`
-    }
+    },
+    isLatestProductSubmittedJust5days() {
+      if (this.latestProductSubmittedJust5days !== null) {
+        return this.product.id === this.latestProductSubmittedJust5days.id
+      }
+    },
+    isLatestProductSubmittedJust6days() {
+      if (this.latestProductSubmittedJust6days !== null) {
+        return this.product.id === this.latestProductSubmittedJust6days.id
+      }
+    },
+    isLatestProductSubmittedOver7days() {
+      if (this.latestProductSubmittedOver7days !== null) {
+        return this.product.id === this.latestProductSubmittedOver7days.id
+      }
+    },
   }
 }
 </script>

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -89,9 +89,16 @@
 <script>
 import ProductChecker from './product_checker'
 export default {
-  props: ['product', 'currentUserId', 'isMentor', 'latestProductSubmittedJust5days', 'latestProductSubmittedJust6days', 'latestProductSubmittedOver7days'],
   components: {
     'product-checker': ProductChecker
+  },
+  props: {
+    product: { type: Object, required: true },
+    isMentor: { type: Boolean, required: true },
+    currentUserId: { type: String, required: true },
+    latestProductSubmittedJust5days: { type: String, required: false, default: null },
+    latestProductSubmittedJust6days: { type: String, required: false, default: null },
+    latestProductSubmittedOver7days: { type: String, required: false, default: null },
   },
   computed: {
     roleClass() {
@@ -105,6 +112,8 @@ export default {
         ? `★${this.product.practice.title}の提出物`
         : `${this.product.practice.title}の提出物`
     },
+  },
+  methods: {
     isLatestProductSubmittedJust5days() {
       if (this.latestProductSubmittedJust5days !== null) {
         return this.product.id === this.latestProductSubmittedJust5days.id

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -111,7 +111,7 @@ export default {
           return response.json()
         })
         .then((json) => {
-          if (location.pathname == "/products/not_responded") {
+          if (location.pathname === "/products/not_responded") {
             this.latestProductSubmittedJust5days = json.latest_product_submitted_just_5days
             this.latestProductSubmittedJust6days = json.latest_product_submitted_just_6days
             this.latestProductSubmittedOver7days = json.latest_product_submitted_over_7days

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -53,7 +53,7 @@ export default {
       products: [],
       totalPages: 0,
       currentPage: Number(this.getPageValueFromParameter()) || 1,
-      loaded: false
+      loaded: false,
       latestProductSubmittedJust5days: null,
       latestProductSubmittedJust6days: null,
       latestProductSubmittedOver7days: null,

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -19,6 +19,9 @@
           :product='product',
           :currentUserId='currentUserId',
           :isMentor='isMentor'
+          :latestProductSubmittedJust5days="latestProductSubmittedJust5days"
+          :latestProductSubmittedJust6days="latestProductSubmittedJust6days"
+          :latestProductSubmittedOver7days="latestProductSubmittedOver7days"
         )
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all"',
@@ -51,6 +54,9 @@ export default {
       totalPages: 0,
       currentPage: Number(this.getPageValueFromParameter()) || 1,
       loaded: false
+      latestProductSubmittedJust5days: null,
+      latestProductSubmittedJust6days: null,
+      latestProductSubmittedOver7days: null,
     }
   },
   computed: {
@@ -105,6 +111,11 @@ export default {
           return response.json()
         })
         .then((json) => {
+          if (location.pathname == "/products/not_responded") {
+            this.latestProductSubmittedJust5days = json.latest_product_submitted_just_5days
+            this.latestProductSubmittedJust6days = json.latest_product_submitted_just_6days
+            this.latestProductSubmittedOver7days = json.latest_product_submitted_over_7days
+          }
           this.totalPages = json.total_pages
           this.products = []
           json.products.forEach((product) => {

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -113,10 +113,12 @@ class Product < ApplicationRecord
   end
 
   def submitted_just_specific_days(date)
-    published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
+    #published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
+    5
   end
 
   def submitted_over_specific_days(date)
-    published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
+    #published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
+    5
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -113,12 +113,18 @@ class Product < ApplicationRecord
   end
 
   def submitted_just_specific_days(date)
-    #published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
-    5
+    if published_at.nil?
+      created_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
+    else
+      published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
+    end
   end
 
   def submitted_over_specific_days(date)
-    #published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
-    5
+    if published_at.nil?
+      created_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
+    else
+      published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
+    end
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -112,11 +112,8 @@ class Product < ApplicationRecord
     checker_id ? User.find(checker_id).login_name : nil
   end
 
-  def submitted_just_specific_days(date)
-    published_at.nil? ? created_at.strftime('%F') == Time.zone.today.prev_day(date).to_s : published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
-  end
-
-  def submitted_over_specific_days(date)
-    published_at.nil? ? created_at.strftime('%F') == Time.zone.today.prev_day(date).to_s : published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
+  def elapsed_days
+    t = published_at || created_at
+    ((Time.current - t) / 1.day).to_i
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -112,11 +112,11 @@ class Product < ApplicationRecord
     checker_id ? User.find(checker_id).login_name : nil
   end
 
-  def submitted_specific_day_ago?(date)
+  def submitted_just_specific_days(date)
     published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
   end
 
-  def submitted_before_specific_day_ago?(date)
+  def submitted_over_specific_days(date)
     published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -113,18 +113,10 @@ class Product < ApplicationRecord
   end
 
   def submitted_just_specific_days(date)
-    if published_at.nil?
-      created_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
-    else
-      published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
-    end
+    published_at.nil? ? created_at.strftime('%F') == Time.zone.today.prev_day(date).to_s : published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
   end
 
   def submitted_over_specific_days(date)
-    if published_at.nil?
-      created_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
-    else
-      published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
-    end
+    published_at.nil? ? created_at.strftime('%F') == Time.zone.today.prev_day(date).to_s : published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -111,4 +111,16 @@ class Product < ApplicationRecord
   def checker_name
     checker_id ? User.find(checker_id).login_name : nil
   end
+
+  def self.products_at_specific_day_ago(products, date)
+    products.order(published_at: :desc).select do |product|
+      product.published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
+    end
+  end
+
+  def self.products_before_specific_day_ago(products, date)
+    products.order(published_at: :desc).select do |product|
+      product.published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
+    end
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -112,15 +112,11 @@ class Product < ApplicationRecord
     checker_id ? User.find(checker_id).login_name : nil
   end
 
-  def self.products_at_specific_day_ago(products, date)
-    products.order(published_at: :desc).select do |product|
-      product.published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
-    end
+  def submitted_specific_day_ago?(date)
+    published_at.strftime('%F') == Time.zone.today.prev_day(date).to_s
   end
 
-  def self.products_before_specific_day_ago(products, date)
-    products.order(published_at: :desc).select do |product|
-      product.published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
-    end
+  def submitted_before_specific_day_ago?(date)
+    published_at.strftime('%F') < Time.zone.today.prev_day(date - 1).to_s
   end
 end

--- a/app/views/api/products/not_responded/index.json.jbuilder
+++ b/app/views/api/products/not_responded/index.json.jbuilder
@@ -4,3 +4,6 @@ json.products do
   end
 end
 json.total_pages @products.page(1).total_pages
+json.latest_product_submitted_just_5days @latest_product_submitted_just_5days
+json.latest_product_submitted_just_6days @latest_product_submitted_just_6days
+json.latest_product_submitted_over_7days @latest_product_submitted_over_7days

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,82 +1,127 @@
-product1:
+product1: # 自分のコメントあり(2つ)
   practice: practice1
   user: yamada
   body: テストの提出物1です。
 
-product2:
+product2: # チェック済
   practice: practice1
   user: kimura
   body: テストの提出物2です。
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+  published_at: <%= 1.day.ago %>
 
-product3:
+product3: # チェック済, 他者のコメントあり
   practice: practice2
   user: sotugyou
   body: 確認済みの提出物
+  created_at: <%= 2.day.ago %>
+  updated_at: <%= 2.day.ago %>
+  published_at: <%= 2.day.ago %>
 
-product4:
+product4: # チェック済
   practice: practice2
   user: yamada
   body: テストの提出物4です。
+  created_at: <%= 3.day.ago %>
+  updated_at: <%= 3.day.ago %>
+  published_at: <%= 3.day.ago %>
 
 product5:
   practice: practice2
   user: kimura
   body: テストの提出物5です。
+  created_at: <%= 4.day.ago %>
+  updated_at: <%= 4.day.ago %>
+  published_at: <%= 4.day.ago %>
 
 product6:
   practice: practice3
   user: sotugyou
   body: 確認待ちの提出物
+  created_at: <%= 5.day.ago %>
+  updated_at: <%= 5.day.ago %>
+  published_at: <%= 5.day.ago %>
 
-product7:
+product7: # チェック済
   practice: practice3
   user: yamada
   body: テストの提出物7です。
+  created_at: <%= 6.day.ago %>
+  updated_at: <%= 6.day.ago %>
+  published_at: <%= 6.day.ago %>
 
 product8:
   practice: practice3
   user: kimura
   body: テストの提出物8です。
+  created_at: <%= 7.day.ago %>
+  updated_at: <%= 7.day.ago %>
+  published_at: <%= 7.day.ago %>
 
-product9:
+product9: # チェック済
   practice: practice4
   user: yamada
   body: テストの提出物9です。
+  created_at: <%= 8.day.ago %>
+  updated_at: <%= 8.day.ago %>
+  published_at: <%= 8.day.ago %>
 
-product10:
+product10: # 他者のコメントあり
   practice: practice4
   user: kimura
   body: テストの提出物10です。
+  created_at: <%= 9.day.ago %>
+  updated_at: <%= 9.day.ago %>
+  published_at: <%= 9.day.ago %>
 
 product11:
   practice: practice2
   user: hatsuno
   body: テストの提出物11です。
+  created_at: <%= 10.day.ago %>
+  updated_at: <%= 10.day.ago %>
+  published_at: <%= 10.day.ago %>
 
 product12:
   practice: practice5
   user: yamada
   body: リアクションテスト
+  created_at: <%= 11.day.ago %>
+  updated_at: <%= 11.day.ago %>
+  published_at: <%= 11.day.ago %>
 
 product13:
   practice: practice1
   user: kensyu
   body: 研修の提出物です。
+  created_at: <%= 12.day.ago %>
+  updated_at: <%= 12.day.ago %>
+  published_at: <%= 12.day.ago %>
 
 product14:
   practice: practice1
   user: daimyo
   body: 研修の提出物です。
+  created_at: <%= 13.day.ago %>
+  updated_at: <%= 13.day.ago %>
+  published_at: <%= 13.day.ago %>
 
 product15:
   practice: practice1
   user: with_hyphen
   body: テストの提出物15です。
+  created_at: <%= 6.day.ago %>
+  updated_at: <%= 6.day.ago %>
+  published_at: <%= 6.day.ago %>
 
 product16:
   practice: practice2
   user: with_hyphen
   body: テストの提出物16です。
+  created_at: <%= 6.day.ago %>
+  updated_at: <%= 6.day.ago %>
+  published_at: <%= 6.day.ago %>
 
 product17:
   practice: practice3

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -24,7 +24,7 @@ class ProductsTest < ApplicationSystemTestCase
     click_button '未完了の提出物を一括で開く'
 
     within_window(windows.last) do
-      assert_text 'テストの提出物60です。'
+      assert_text '提出物の検索結果テスト用'
     end
   end
 

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -24,7 +24,7 @@ class ProductsTest < ApplicationSystemTestCase
     click_button '未完了の提出物を一括で開く'
 
     within_window(windows.last) do
-      assert_text 'テストの提出物1です。'
+      assert_text 'テストの提出物60です。'
     end
   end
 


### PR DESCRIPTION
PR https://github.com/fjordllc/bootcamp/pull/2367 を修正したPRです。

## issue
https://github.com/fjordllc/bootcamp/issues/2252 に対応

## 概要
前提として、提出された提出物は7日以内にメンターが返信することがルールになっています。
未返信の提出物一覧において、提出されてから何日経過したか一目でわかるように区切り線を入れました。

## 実装した機能
- 区切り線は、「5日経過」,「6日経過」,「7日以上経過」のラベル3つ。
- それぞれの該当日に提出物がない場合は表示されない。
