### PR TITLE
プラクティスページから「質問する」を押したときは、対象のプラクティスが選択された状態で質問するページが開く

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -77,7 +77,7 @@ header.page-header
             .card-main-actions
               ul.card-main-actions__items
                 li.card-main-actions__item
-                  = link_to new_question_path, class: 'a-button is-md is-primary is-block' do
+                  = link_to new_question_path(practice_id: params[:id]), class: 'a-button is-md is-primary is-block' do
                     i.fas.fa-question-circle
                     | 質問する
 

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -8,7 +8,7 @@
             .form-item
               = f.label :practice, class: 'a-form-label'
               .select-practices
-                = f.select(:practice_id, practice_options(categories), {}, { class: 'js-select2' })
+                = f.select(:practice_id, practice_options(categories), { selected: params[:practice_id] }, { class: 'js-select2' })
 
       .form-item
         .row.js-markdown-parent

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -255,5 +255,10 @@ class QuestionsTest < ApplicationSystemTestCase
     find('#select2-practice_id-container').click
     selects_size = users(:kimura).course.practices.size + 1
     assert_selector '.select2-results__option', count: selects_size
+    
+  test 'select practice title when question create page' do
+    visit_with_auth "/practices/#{practices(:practice23).id}", 'hatsuno'
+    click_on '質問する'
+    assert_text '[Ruby] rubyをインストールする'
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -255,8 +255,8 @@ class QuestionsTest < ApplicationSystemTestCase
     find('#select2-practice_id-container').click
     selects_size = users(:kimura).course.practices.size + 1
     assert_selector '.select2-results__option', count: selects_size
-    
-  test 'select practice title when push question botton on practice page' do
+
+  test 'select practice title when push question button on practice page' do
     visit_with_auth "/practices/#{practices(:practice23).id}", 'hatsuno'
     click_on '質問する'
     assert_text '[Ruby] rubyをインストールする'

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -255,6 +255,7 @@ class QuestionsTest < ApplicationSystemTestCase
     find('#select2-practice_id-container').click
     selects_size = users(:kimura).course.practices.size + 1
     assert_selector '.select2-results__option', count: selects_size
+  end
 
   test 'select practice title when push question button on practice page' do
     visit_with_auth "/practices/#{practices(:practice23).id}", 'hatsuno'

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -256,7 +256,7 @@ class QuestionsTest < ApplicationSystemTestCase
     selects_size = users(:kimura).course.practices.size + 1
     assert_selector '.select2-results__option', count: selects_size
     
-  test 'select practice title when question create page' do
+  test 'select practice title when push question botton on practice page' do
     visit_with_auth "/practices/#{practices(:practice23).id}", 'hatsuno'
     click_on '質問する'
     assert_text '[Ruby] rubyをインストールする'


### PR DESCRIPTION
issue #2867 

# 概要
プラクティスページから「質問する」を押したときは、対象のプラクティスが選択された状態で質問するページが開くようにしました。

![https://i.gyazo.com/f7cbc29c9d240b7c85548929bb08b45f.gif](https://i.gyazo.com/f7cbc29c9d240b7c85548929bb08b45f.gif)