### PR TITLE
Q&Aをブックマークできるように

### DIFF
--- a/app/assets/stylesheets/atoms/_a-bookmark-button.sass
+++ b/app/assets/stylesheets/atoms/_a-bookmark-button.sass
@@ -1,0 +1,9 @@
+.a-bookmark-button
+  border: none
+  &:hover
+    border: none
+  &.is-inactive
+    color: $semi-muted-text
+    &:hover
+      color: $default-text
+      background-color: $background-shade

--- a/app/assets/stylesheets/blocks/thread/_thread-header-actions.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-header-actions.sass
@@ -1,15 +1,29 @@
 .thread-header-actions
+  padding-top: .25rem
   display: flex
   justify-content: space-between
-  padding-top: .25rem
 
 .thread-header-actions__start,
 .thread-header-actions__end
   display: flex
+  flex: 1
+  +media-breakpoint-up(md)
+    +margin(horizontal, -.25rem)
+  +media-breakpoint-down(sm)
+    +margin(horizontal, -.125rem)
+
+.thread-header-actions__start
+  justify-content: flex-start
+
+.thread-header-actions__end
+  justify-content: flex-end
 
 .thread-header-actions__action
+  +media-breakpoint-up(md)
+    +padding(horizontal, .25rem)
+    min-width: 6rem
+  +media-breakpoint-down(sm)
+    +padding(horizontal, .125rem)
+    width: 50%
   .a-button
-    min-width: 5.25rem
     +padding(horizontal, 0)
-  &:not(:last-child)
-    margin-right: .5rem

--- a/app/javascript/bookmark-button.vue
+++ b/app/javascript/bookmark-button.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-#bookmark-button.a-button.is-xs(
+#bookmark-button.a-bookmark-button.a-button.is-xs(
   :class='isBookmark ? "is-active is-main" : "is-inactive is-muted"',
   @click='push'
 )

--- a/app/javascript/bookmark-button.vue
+++ b/app/javascript/bookmark-button.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 #bookmark-button.a-bookmark-button.a-button.is-xs(
-  :class='isBookmark ? "is-active is-main" : "is-inactive is-muted"',
+  :class='bookmarkId ? "is-active is-main" : "is-inactive is-muted"',
   @click='push'
 )
   | {{ bookmarkLabel }}
@@ -9,13 +9,16 @@
 export default {
   props: {
     bookmarkableId: { type: Number, required: true },
-    bookmarkableType: { type: String, required: true }
+    bookmarkableType: { type: String, required: true },
+    checked: { type: Boolean, required: false, default: false },
+    bookmarkIndexId: { type: Number, required: false, default: 0 }
   },
   data() {
     return {
       bookmarkId: null,
       bookmarkLabel: 'Bookmark',
-      isBookmark: false
+      totalPages: 0,
+      bookmarkValue: null
     }
   },
   created() {
@@ -27,39 +30,43 @@ export default {
       return meta ? meta.getAttribute('content') : ''
     },
     push() {
-      if (this.isBookmark) {
+      if (this.bookmarkId) {
         this.unbookmark()
       } else {
         this.bookmark()
       }
     },
     getBookmark() {
-      fetch(
-        `/api/bookmarks.json?bookmarkable_type=${this.bookmarkableType}&bookmarkable_id=${this.bookmarkableId}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-            'X-Requested-With': 'XMLHttpRequest',
-            'X-CSRF-Token': this.token()
-          },
-          credentials: 'same-origin',
-          redirect: 'manual'
-        }
-      )
-        .then((response) => {
-          return response.json()
-        })
-        .then((json) => {
-          if (json.bookmarks.length) {
-            this.bookmarkId = json.bookmarks[0].id
-            this.bookmarkLabel = 'Bookmark中'
-            this.isBookmark = true
-          }
-        })
-        .catch((error) => {
-          console.warn('Failed to parsing', error)
-        })
+      if (this.checked) {
+        this.bookmarkId= this.bookmarkIndexId
+        this.bookmarkLabel = '削除'
+      } else {
+        fetch(
+            `/api/bookmarks.json?bookmarkable_type=${this.bookmarkableType}&bookmarkable_id=${this.bookmarkableId}`,
+            {
+              method: 'GET',
+              headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                'X-Requested-With': 'XMLHttpRequest',
+                'X-CSRF-Token': this.token()
+              },
+              credentials: 'same-origin',
+              redirect: 'manual'
+            }
+        )
+            .then((response) => {
+              return response.json()
+            })
+            .then((json) => {
+              if (json.bookmarks.length) {
+                this.bookmarkId = json.bookmarks[0].id
+                this.bookmarkLabel = 'Bookmark中'
+              }
+            })
+            .catch((error) => {
+              console.warn('Failed to parsing', error)
+            })
+      }
     },
     bookmark() {
       fetch(
@@ -81,7 +88,6 @@ export default {
         .then((json) => {
           this.bookmarkId = json.id
           this.bookmarkLabel = 'Bookmark中'
-          this.isBookmark = true
         })
         .catch((error) => {
           console.warn('Failed to parsing', error)
@@ -101,7 +107,9 @@ export default {
         .then(() => {
           this.bookmarkId = null
           this.bookmarkLabel = 'Bookmark'
-          this.isBookmark = false
+        })
+        .then(()=>{
+          this.$emit('update-index')
         })
         .catch((error) => {
           console.warn('Failed to parsing', error)
@@ -110,3 +118,4 @@ export default {
   }
 }
 </script>
+<style scoped></style>

--- a/app/javascript/bookmark-button.vue
+++ b/app/javascript/bookmark-button.vue
@@ -108,7 +108,7 @@ export default {
           this.bookmarkId = null
           this.bookmarkLabel = 'Bookmark'
         })
-        .then(()=>{
+        .then(() => {
           this.$emit('update-index')
         })
         .catch((error) => {

--- a/app/javascript/bookmark-button.vue
+++ b/app/javascript/bookmark-button.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-#bookmark-button.a-bookmark-button.a-button.is-xs(
+#bookmark-button.a-bookmark-button.a-button.is-xs.is-block(
   :class='bookmarkId ? "is-active is-main" : "is-inactive is-muted"',
   @click='push'
 )

--- a/app/javascript/bookmark.vue
+++ b/app/javascript/bookmark.vue
@@ -17,14 +17,14 @@
           .thread-list-item-meta__item
             a.a-user-name(:href='bookmark.authorUrl')
               | {{ bookmark.author }}
-          .thread-list-item-meta__item(v-if='bookmark.modelName == "Report"')
-            time.a-date(:datetime='bookmark.reportedOn')
-              | {{ bookmark.reportedOn }}
-          .thread-list-item-meta__item(v-else)
-            time.a-date(:datetime='bookmark.createdAt')
-              | {{ bookmark.createdAt }}
+          .thread-list-item-meta__item
+            time.a-date(:datetime='bookmark.updated_at')
+              | {{ createdAt }}
 </template>
 <script>
+import dayjs from 'dayjs'
+import ja from 'dayjs/locale/ja'
+dayjs.locale(ja)
 export default {
   props: {
     bookmark: { type: Object, required: true }
@@ -32,6 +32,12 @@ export default {
   computed: {
     isBookmarkClassName(){
      return `is-${this.bookmark.bookmark_class_name}`
+    },
+    createdAt() {
+      const date = this.bookmark.reported_on || this.bookmark.created_at
+      return dayjs(date).format(
+          'YYYY年MM月DD日(dd) HH:mm'
+      )
     }
   }
 }

--- a/app/javascript/bookmark.vue
+++ b/app/javascript/bookmark.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.thread-list-item(:class='modelName')
+.thread-list-item(:class='isBookmarkClassName')
   .thread-list-item__inner
     .thread-list-item__label
       | {{ bookmark.modelNameI18n }}
@@ -27,6 +27,9 @@ export default {
     bookmark: { type: Object, required: true }
   },
   computed: {
+    isBookmarkClassName(){
+     return `is-${this.bookmark.bookmark_class_name}`
+    },
     modelName() {
       return `is-${this.bookmark.modelName}`
     }

--- a/app/javascript/bookmark.vue
+++ b/app/javascript/bookmark.vue
@@ -10,6 +10,9 @@
             a.thread-list-item-title__link(:href='bookmark.url')
               | {{ bookmark.title }}
       .thread-list-item__row
+        .thread-list-item__summary
+            p {{ bookmark.summary }}
+      .thread-list-item__row
         .thread-list-item-meta__items
           .thread-list-item-meta__item
             a.a-user-name(:href='bookmark.authorUrl')

--- a/app/javascript/bookmark.vue
+++ b/app/javascript/bookmark.vue
@@ -13,21 +13,35 @@
         .thread-list-item__summary
             p {{ bookmark.summary }}
       .thread-list-item__row
-        .thread-list-item-meta__items
-          .thread-list-item-meta__item
-            a.a-user-name(:href='bookmark.authorUrl')
-              | {{ bookmark.author }}
-          .thread-list-item-meta__item
-            time.a-date(:datetime='bookmark.updated_at')
-              | {{ createdAt }}
+        .thread-list-item-meta
+          .thread-list-item-meta__items
+            .thread-list-item-meta__item
+              a.a-user-name(:href='bookmark.authorUrl')
+                | {{ bookmark.author }}
+            .thread-list-item-meta__item
+              time.a-date(:datetime='bookmark.updated_at')
+                | {{ createdAt }}
+    .thread-list-item__option(v-if="checked")
+      bookmarkButton(
+        :checked='checked'
+        :bookmarkableType='bookmark.modelName',
+        :bookmarkableId='bookmark.bookmarkable_id',
+        :bookmarkIndexId='bookmark.id'
+        @update-index="$listeners['updateIndex']",
+      )
 </template>
 <script>
 import dayjs from 'dayjs'
 import ja from 'dayjs/locale/ja'
+import bookmarkButton from './bookmark-button.vue'
 dayjs.locale(ja)
 export default {
+  components: {
+    bookmarkButton: bookmarkButton
+  },
   props: {
-    bookmark: { type: Object, required: true }
+    bookmark: { type: Object, required: true },
+    checked: { type: Boolean }
   },
   computed: {
     isBookmarkClassName(){

--- a/app/javascript/bookmark.vue
+++ b/app/javascript/bookmark.vue
@@ -16,7 +16,10 @@
               | {{ bookmark.author }}
           .thread-list-item-meta__item(v-if='bookmark.modelName == "Report"')
             time.a-date(:datetime='bookmark.reportedOn')
-              | {{ bookmark.reportedOn }}の日報
+              | {{ bookmark.reportedOn }}
+          .thread-list-item-meta__item(v-else)
+            time.a-date(:datetime='bookmark.createdAt')
+              | {{ bookmark.createdAt }}
 </template>
 <script>
 export default {

--- a/app/javascript/bookmark.vue
+++ b/app/javascript/bookmark.vue
@@ -32,9 +32,6 @@ export default {
   computed: {
     isBookmarkClassName(){
      return `is-${this.bookmark.bookmark_class_name}`
-    },
-    modelName() {
-      return `is-${this.bookmark.modelName}`
     }
   }
 }

--- a/app/javascript/bookmarks.vue
+++ b/app/javascript/bookmarks.vue
@@ -1,24 +1,35 @@
 <template lang="pug">
 .page-body
-  nav.pagination(v-if='totalPages > 1')
-    pager(v-bind='pagerProps')
-  .container
-    .empty(v-if='!loaded')
+  .container.is-md(v-if='!loaded')
+    .empty
       .fas.fa-spinner.fa-pulse
       |
       | ロード中
-    .o-empty-message(v-else-if='bookmarks.length == 0')
-      p.o-empty-message__text
-      | ブックマークしているものはありません。
-    .thread-list.a-card(v-else)
+  .container.is-md(v-else)
+    .thread-list-tools(v-if='bookmarks.length')
+      .form-item.is-inline
+        label.a-form-label(for='thread-list-tools__action')
+          | 編集
+        label.a-on-off-checkbox.is-sm
+          input(type='checkbox', name='thread-list-tools__action', id='thread-list-tools__action', v-model="checked")
+          span#spec-edit-mode
+    .thread-list-tools(v-else)
+      .o-empty-message
+        p.o-empty-message__text
+        | ブックマークしているものはありません。
+    nav.pagination(v-if='totalPages > 1')
+      pager(v-bind='pagerProps')
+    .thread-list.a-card
       .thread-list__items
         bookmark(
           v-for='bookmark in bookmarks',
           :key='bookmark.id',
-          :bookmark='bookmark'
+          :bookmark='bookmark',
+          :checked='checked',
+          @updateIndex="updateIndex"
         )
-  nav.pagination(v-if='totalPages > 1')
-    pager(v-bind='pagerProps')
+    nav.pagination(v-if='totalPages > 1')
+      pager(v-bind='pagerProps')
 </template>
 <script>
 import Bookmark from './bookmark.vue'
@@ -34,7 +45,8 @@ export default {
       bookmarks: [],
       totalPages: 0,
       currentPage: Number(this.getPageValueFromParameter()) || 1,
-      loaded: false
+      loaded: false,
+      checked: false
     }
   },
   computed: {
@@ -76,11 +88,11 @@ export default {
           return response.json()
         })
         .then((json) => {
-          this.totalPages = json.totalPages
           this.bookmarks = []
           json.bookmarks.forEach((bookmark) => {
             this.bookmarks.push(bookmark)
           })
+          this.totalPages = parseInt(json.totalPages)
           this.loaded = true
         })
         .catch((error) => {
@@ -100,6 +112,9 @@ export default {
         null,
         location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
       )
+    },
+    updateIndex(){
+      this.getBookmarks()
     }
   }
 }

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -42,7 +42,7 @@
               BookmarkButton(:bookmarkableId='question.id', bookmarkableType='Question')
           .thread-header-actions__end
             .thread-header-actions__action
-              a.a-button.is-sm.is-secondary(
+              a.a-button.is-sm.is-secondary.is-block(
                 :href='`/questions/${question.id}.md`',
                 target='_blank'
               )

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -38,6 +38,8 @@
           .thread-header-actions__start
             .thread-header-actions__action
               WatchToggle(:watchableId='question.id', watchableType='Question')
+            .thread-header-actions__action
+              BookmarkButton(:bookmarkableId='question.id', bookmarkableType='Question')
           .thread-header-actions__end
             .thread-header-actions__action
               a.a-button.is-sm.is-secondary(
@@ -163,6 +165,7 @@
 <script>
 import Reaction from './reaction.vue'
 import WatchToggle from './watch-toggle.vue'
+import BookmarkButton from './bookmark-button.vue'
 import MarkdownInitializer from './markdown-initializer'
 import TextareaInitializer from './textarea-initializer'
 import Tags from './question_tags.vue'
@@ -174,6 +177,7 @@ dayjs.locale(ja)
 export default {
   components: {
     WatchToggle: WatchToggle,
+    BookmarkButton: BookmarkButton,
     tags: Tags,
     reaction: Reaction,
     userIcon: UserIcon

--- a/app/javascript/watch-toggle.vue
+++ b/app/javascript/watch-toggle.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-#watch-button.a-watch-button.a-button.is-xs(
+#watch-button.a-watch-button.a-button.is-xs.is-block(
   :class='watchId ? "is-active is-main" : "is-inactive is-muted"',
   @click='buttonClick'
 )

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,6 +7,7 @@ class Question < ApplicationRecord
   include WithAvatar
   include Taggable
   include Mentioner
+  include Bookmarkable
 
   belongs_to :practice, optional: true
   belongs_to :user, touch: true

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -10,3 +10,4 @@ json.createdAt l(bookmarkable.created_at)
 json.updatedAt l(bookmarkable.updated_at)
 json.reportedOn l(bookmarkable.reported_on) if bookmark.bookmarkable_type == "Report"
 json.bookmark_class_name bookmark.bookmarkable_type.to_s.tableize.chop
+json.summary searchable_summary(filtered_message(bookmark.bookmarkable), 90)

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -6,8 +6,8 @@ json.author bookmarkable.user.name
 json.authorUrl bookmarkable.user.url
 json.url polymorphic_url(bookmarkable)
 json.title bookmarkable.title
-json.createdAt l(bookmarkable.created_at)
-json.updatedAt l(bookmarkable.updated_at)
-json.reportedOn l(bookmarkable.reported_on) if bookmark.bookmarkable_type == "Report"
+json.created_at matched_document(bookmark.bookmarkable).created_at
+json.updated_at matched_document(bookmark.bookmarkable).updated_at
+json.reported_on matched_document(bookmark.bookmarkable).reported_on if bookmark.bookmarkable_type == "Report"
 json.bookmark_class_name bookmark.bookmarkable_type.to_s.tableize.chop
 json.summary searchable_summary(filtered_message(bookmark.bookmarkable), 90)

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -9,3 +9,4 @@ json.title bookmarkable.title
 json.createdAt l(bookmarkable.created_at)
 json.updatedAt l(bookmarkable.updated_at)
 json.reportedOn l(bookmarkable.reported_on) if bookmark.bookmarkable_type == "Report"
+json.bookmark_class_name bookmark.bookmarkable_type.to_s.tableize.chop

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -6,4 +6,6 @@ json.author bookmarkable.user.name
 json.authorUrl bookmarkable.user.url
 json.url polymorphic_url(bookmarkable)
 json.title bookmarkable.title
+json.createdAt l(bookmarkable.created_at)
+json.updatedAt l(bookmarkable.updated_at)
 json.reportedOn l(bookmarkable.reported_on) if bookmark.bookmarkable_type == "Report"

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -1,5 +1,6 @@
 bookmarkable = bookmark.bookmarkable
 json.id bookmark.id
+json.bookmarkable_id bookmark.bookmarkable_id
 json.modelName bookmark.bookmarkable_type
 json.modelNameI18n t("activerecord.models.#{bookmarkable.class.to_s.tableize.singularize}")
 json.author bookmarkable.user.name

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -81,8 +81,8 @@ header.page-header
                     .thread-header-actions__action
                       #js-watch-toggle(data-watchable-id="#{@product.id}", data-watchable-type='Product')
                   .thread-header-actions__end
-                    .thread-header__raw
-                      = link_to 'Raw', product_path(format: :md), class: 'a-button is-sm is-secondary', target: '_blank', rel: 'noopener'
+                    .thread-header__action
+                      = link_to 'Raw', product_path(format: :md), class: 'a-button is-sm is-secondary is-block', target: '_blank', rel: 'noopener'
             - if @product.wip?
               .thread__warning-message
                 | まだ提出されていません。<br class='is-hidden-md-up'>完成したら「提出する」をクリック！

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -68,7 +68,7 @@ header.page-header
                       i.fas.fa-copy#copy
                       | コピー
                 .thread-header-actions__action
-                  = link_to 'Raw', report_path(format: :md), class: 'a-button is-xs is-secondary', target: '_blank', rel: 'noopener'
+                  = link_to 'Raw', report_path(format: :md), class: 'a-button is-xs is-secondary is-block', target: '_blank', rel: 'noopener'
         - if @report.practices.present?
           .thread__tags
             .tag-links

--- a/db/fixtures/bookmarks.yml
+++ b/db/fixtures/bookmarks.yml
@@ -1,6 +1,6 @@
 bookmark28:
   user: kimura
-  bookmarkable: question1 (Question
+  bookmarkable: question1 (Question)
 
 <% (1..27).each do |id| %>
 bookmark<%= id %>:

--- a/db/fixtures/bookmarks.yml
+++ b/db/fixtures/bookmarks.yml
@@ -1,3 +1,7 @@
+bookmark28:
+  user: kimura
+  bookmarkable: question1 (Question
+
 <% (1..27).each do |id| %>
 bookmark<%= id %>:
   user: komagata

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,3 +1,7 @@
+bookmark28:
+  user: kimura
+  bookmarkable: question1 (Question)
+
 <% (1..27).each do |id| %>
 bookmark<%= id %>:
   user: komagata

--- a/test/integration/api/bookmarks_test.rb
+++ b/test/integration/api/bookmarks_test.rb
@@ -44,4 +44,17 @@ class API::BookmarksTest < ActionDispatch::IntegrationTest
            headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :no_content
   end
+
+  test 'POST question' do
+    question = questions(:question2)
+    token = create_token('kimura', 'testtest')
+    post api_bookmarks_path(format: :json),
+         params: {
+           user: 'kimura',
+           bookmarkable_id: question.id,
+           bookmarkable_type: 'Question'
+         },
+         headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :created
+  end
 end

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -10,4 +10,12 @@ class BookmarkTest < ActiveSupport::TestCase
     Bookmark.create(user: user, bookmarkable: report)
     assert_not Bookmark.new(user: user, bookmarkable: report).valid?
   end
+
+  test 'prohibit to duplicate question registration' do
+    user = users(:kimura)
+    question = questions(:question1)
+
+    Bookmark.create(user: user, bookmarkable: question)
+    assert_not Bookmark.new(user: user, bookmarkable: question).valid?
+  end
 end

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -93,4 +93,27 @@ class BookmarksTest < ApplicationSystemTestCase
     visit '/bookmarks'
     assert_no_text @question.title
   end
+
+  test 'edit bookmarks' do
+    visit_with_auth bookmarks_path, 'kimura'
+    assert_no_selector '.thread-list-item__option'
+    find(:css, '#spec-edit-mode').set(true)
+    wait_for_vuejs
+    assert_selector '.thread-list-item__option'
+  end
+
+  test 'delete bookmark from bookmarks' do
+    visit_with_auth report_path(@report), 'komagata'
+    wait_for_vuejs
+    assert_text 'Bookmark中'
+    visit bookmarks_path
+    assert_text '作業週1日目'
+    find(:css, '#spec-edit-mode').set(true)
+    assert_selector '.thread-list-item__option'
+    first('#bookmark-button').click
+    wait_for_vuejs
+    assert_no_text '作業週1日目'
+    visit report_path(@report)
+    assert_text 'Bookmark'
+  end
 end

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -5,34 +5,51 @@ require 'application_system_test_case'
 class BookmarksTest < ApplicationSystemTestCase
   setup do
     @report = reports(:report1)
+    @question = questions(:question1)
   end
 
   test 'show my bookmark lists' do
-    login_user 'komagata', 'testtest'
-    visit '/bookmarks'
+    visit_with_auth '/bookmarks', 'komagata'
     assert_text 'ブックマーク一覧'
     assert_text @report.title
   end
 
+  test 'show question bookmark on lists' do
+    visit_with_auth '/bookmarks', 'kimura'
+    assert_text 'ブックマーク一覧'
+    assert_text @question.title
+  end
+
   test 'show my bookmark report' do
-    login_user 'komagata', 'testtest'
-    visit "/reports/#{@report.id}"
+    visit_with_auth "/reports/#{@report.id}", 'komagata'
     wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
   end
 
   test 'show not bookmark report' do
-    login_user 'machida', 'testtest'
-    visit "/reports/#{@report.id}"
+    visit_with_auth "/reports/#{@report.id}", 'machida'
     wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
   end
 
+  test 'show active button when bookmarked question' do
+    visit_with_auth "/questions/#{@question.id}", 'kimura'
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+  end
+
+  test 'show inactive button when not bookmarked question' do
+    visit_with_auth "/questions/#{@question.id}", 'hajime'
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+  end
+
   test 'bookmark' do
-    login_user 'machida', 'testtest'
-    visit "/reports/#{@report.id}"
+    visit_with_auth "/reports/#{@report.id}", 'machida'
     find('#bookmark-button').click
     wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
@@ -43,8 +60,7 @@ class BookmarksTest < ApplicationSystemTestCase
   end
 
   test 'unbookmark' do
-    login_user 'komagata', 'testtest'
-    visit "/reports/#{@report.id}"
+    visit_with_auth "/reports/#{@report.id}", 'komagata'
     wait_for_vuejs
     find('#bookmark-button').click
     wait_for_vuejs
@@ -53,5 +69,28 @@ class BookmarksTest < ApplicationSystemTestCase
 
     visit '/bookmarks'
     assert_no_text @report.title
+  end
+
+  test 'bookmark question' do
+    visit_with_auth "/questions/#{@question.id}", 'hatsuno'
+    find('#bookmark-button').click
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+
+    visit '/bookmarks'
+    assert_text @question.title
+  end
+
+  test 'unbookmark question' do
+    visit_with_auth "/questions/#{@question.id}", 'kimura'
+    wait_for_vuejs
+    find('#bookmark-button').click
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-inactive'
+    assert_no_selector '#bookmark-button.is-active'
+
+    visit '/bookmarks'
+    assert_no_text @question.title
   end
 end

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -14,12 +14,6 @@ class BookmarksTest < ApplicationSystemTestCase
     assert_text @report.title
   end
 
-  test 'show question bookmark on lists' do
-    visit_with_auth '/bookmarks', 'kimura'
-    assert_text 'ブックマーク一覧'
-    assert_text @question.title
-  end
-
   test 'show my bookmark report' do
     visit_with_auth "/reports/#{@report.id}", 'komagata'
     wait_for_vuejs
@@ -29,20 +23,6 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'show not bookmark report' do
     visit_with_auth "/reports/#{@report.id}", 'machida'
-    wait_for_vuejs
-    assert_selector '#bookmark-button.is-inactive'
-    assert_no_selector '#bookmark-button.is-active'
-  end
-
-  test 'show active button when bookmarked question' do
-    visit_with_auth "/questions/#{@question.id}", 'kimura'
-    wait_for_vuejs
-    assert_selector '#bookmark-button.is-active'
-    assert_no_selector '#bookmark-button.is-inactive'
-  end
-
-  test 'show inactive button when not bookmarked question' do
-    visit_with_auth "/questions/#{@question.id}", 'hajime'
     wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
@@ -69,6 +49,26 @@ class BookmarksTest < ApplicationSystemTestCase
 
     visit '/bookmarks'
     assert_no_text @report.title
+  end
+
+  test 'show question bookmark on lists' do
+    visit_with_auth '/bookmarks', 'kimura'
+    assert_text 'ブックマーク一覧'
+    assert_text @question.title
+  end
+
+  test 'show active button when bookmarked question' do
+    visit_with_auth "/questions/#{@question.id}", 'kimura'
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+  end
+
+  test 'show inactive button when not bookmarked question' do
+    visit_with_auth "/questions/#{@question.id}", 'hajime'
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-inactive'
+    assert_no_selector '#bookmark-button.is-active'
   end
 
   test 'bookmark question' do

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -44,8 +44,8 @@ class BookmarksTest < ApplicationSystemTestCase
   test 'show inactive button when not bookmarked question' do
     visit_with_auth "/questions/#{@question.id}", 'hajime'
     wait_for_vuejs
-    assert_selector '#bookmark-button.is-active'
-    assert_no_selector '#bookmark-button.is-inactive'
+    assert_selector '#bookmark-button.is-inactive'
+    assert_no_selector '#bookmark-button.is-active'
   end
 
   test 'bookmark' do


### PR DESCRIPTION
Issue #1722, #2897
## Q&Aもブックマークできるように
<img width="841" alt="テストの質問5___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/50036730/124427005-c9357c00-dda5-11eb-9630-d733a1604292.png">

## 一覧に削除機能を追加
<img width="844" alt="ブックマーク一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/50036730/124427150-f6822a00-dda5-11eb-9cef-dc5487b4f6a1.png">

## チェック観点
すでに日報ブックマークは先週に実装されているので、そこに上記新機能２つを加える形でコーディングしました。
新しい機能を加える際に、watchの実装を参考にしました。下記の対応関係です。
- watches.vue : bookmarks.vue
- watch.vue : bookmark.vue
- watch-toggle.vue : bookmark-button.vue

bookmarkとwatchはほぼ同じ機能ですがvueのコードは違いがあるようにみえました。そこで、もともとのbookmarkの実装をあまり変えずに、見た目だけ揃えるように実装しました。
- 一覧で表示されている内容はwatchとsearchが揃っていたので大幅にそちらに寄せました。（summaryを加えたり日付フォーマットを加えたりしています。）
- APIのHTTPリクエスト部分は両者でやや違いがありますが、ほぼ元々の実装のまま変えていません。