### PR TITLE
「完了したプラクティス」が100%を超えることがあるのを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -335,7 +335,14 @@ class User < ApplicationRecord
   end
 
   def completed_percentage
-    completed_practices.where(include_progress: true).size.to_f / course.practices.where(include_progress: true).count * 100
+    course.practices
+      .where(include_progress: true)
+      .map(&:learnings)
+      .flatten
+      .select {|learning|
+        learning.user_id == id &&
+        learning.complete?
+    }.size.to_f / course.practices.where(include_progress: true).count * 100
   end
 
   def completed_practices_size(category)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -65,13 +65,29 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 29, User.new(created_at: '2020-01-10 00:00:00').generation
   end
 
-  test '#completed_percentage' do
+  test '#completed_percentage don\'t calculate practice that include_progress: false' do
     user = users(:komagata)
     old_percentage = user.completed_percentage
     user.completed_practices << practices(:practice5)
+
     assert_not_equal old_percentage, user.completed_percentage
+
     old_percentage = user.completed_percentage
     user.completed_practices << practices(:practice53)
+
+    assert_equal old_percentage, user.completed_percentage
+  end
+
+  test '#completed_percentage don\'t calculate practice unrelated cource' do
+    user = users(:komagata)
+    old_percentage = user.completed_percentage
+    user.completed_practices << practices(:practice5)
+
+    assert_not_equal old_percentage, user.completed_percentage
+
+    old_percentage = user.completed_percentage
+    user.completed_practices << practices(:practice52)
+
     assert_equal old_percentage, user.completed_percentage
   end
 


### PR DESCRIPTION
ref. #1506

## 問題点
- 完了したプラクティスの割合を計算する際の分子の値に自分が所属しないコースの完了プラクティスも含まれていた
- 上記の結果 100% を超える可能性があった

## 変更点
- 完了したプラクティスの割合を計算する際の分子の値を自分が所属するコースの完了プラクティスのみに変更
