### PR TITLE
ダッシュボード配下に自分の提出物一覧をページを作成

### DIFF
--- a/app/controllers/current_user/products/index.html.slim
+++ b/app/controllers/current_user/products/index.html.slim
@@ -1,0 +1,26 @@
+- title "#{@user.login_name}の提出物"
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | ユーザー一覧
+
+.page-tools
+  = render 'home/page_tabs', user: @current_user
+
+.page-body
+  .container
+    - if @products.present?
+      .thread-list.a-card
+        = render partial: 'products/product', collection: @products, as: :product
+    - else
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | 提出物はまだありません。

--- a/app/controllers/current_user/products_controller.rb
+++ b/app/controllers/current_user/products_controller.rb
@@ -1,0 +1,4 @@
+class CurrentUser::ProductsController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/current_user/products_controller.rb
+++ b/app/controllers/current_user/products_controller.rb
@@ -1,4 +1,23 @@
+# frozen_string_literal: true
+
 class CurrentUser::ProductsController < ApplicationController
-  def index
+  before_action :require_login
+  before_action :set_user
+  before_action :set_products
+
+  def index; end
+
+  private
+
+  def set_user
+    @user = current_user
+  end
+
+  def set_products
+    @products = user.products.list
+  end
+
+  def user
+    @user ||= current_user
   end
 end

--- a/app/views/current_user/products/index.html.slim
+++ b/app/views/current_user/products/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}の提出物"
+- title '自分の提出物'
 header.page-header
   .container
     .page-header__inner

--- a/app/views/current_user/products/index.html.slim
+++ b/app/views/current_user/products/index.html.slim
@@ -11,7 +11,7 @@ header.page-header
               | ユーザー一覧
 
 .page-tools
-  = render 'users/page_tabs', user: @user
+  = render 'home/page_tabs', user: @user
 
 .page-body
   .container

--- a/app/views/current_user/products/index.html.slim
+++ b/app/views/current_user/products/index.html.slim
@@ -3,12 +3,7 @@ header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
-      .page-header-actions
-        ul.page-header-actions__items
-          li.page-header-actions__item
-            = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | ユーザー一覧
+        | ダッシュボード
 
 .page-tools
   = render 'home/page_tabs', user: @user

--- a/app/views/current_user/products/index.html.slim
+++ b/app/views/current_user/products/index.html.slim
@@ -1,2 +1,26 @@
-h1 CurrentUser::Products#index
-p Find me in app/views/current_user/products/index.html.slim
+- title "#{@user.login_name}の提出物"
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | ユーザー一覧
+
+.page-tools
+  = render 'users/page_tabs', user: @user
+
+.page-body
+  .container
+    - if @products.present?
+      .thread-list.a-card
+        = render partial: 'products/product', collection: @products, as: :product
+    - else
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | 提出物はまだありません。

--- a/app/views/current_user/products/index.html.slim
+++ b/app/views/current_user/products/index.html.slim
@@ -1,0 +1,2 @@
+h1 CurrentUser::Products#index
+p Find me in app/views/current_user/products/index.html.slim

--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -8,3 +8,7 @@
         li.page-tabs__item
           = link_to current_user_reports_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
             | 自分の日報
+      - if !user.staff? || user.products.present?
+        li.page-tabs__item
+          = link_to current_user_products_path, class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
+            | 自分の提出物

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,10 @@ Rails.application.routes.draw do
     get "tags", to: "tags#index"
   end
 
+  namespace :current_user do
+    resources :products
+  end
+
   resources :announcements
   resource :retirement, only: %i(show new create), controller: "retirement"
   resources :users, only: %i(index show new create) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
 
   namespace :current_user do
     resources :reports, only: %i(index)
+    resources :products, only: %i(index)
   end
 
   namespace "partial" do
@@ -103,10 +104,6 @@ Rails.application.routes.draw do
 
   namespace :users do
     get "tags", to: "tags#index"
-  end
-
-  namespace :current_user do
-    resources :products, only: %i(index)
   end
 
   resources :announcements

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Rails.application.routes.draw do
   end
 
   namespace :current_user do
-    resources :products
+    resources :products, only: %i(index)
   end
 
   resources :announcements

--- a/test/system/current_user/products_test.rb
+++ b/test/system/current_user/products_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class CurrentUser::ProductsTest < ApplicationSystemTestCase
+  test 'show current_user products when current_user is student' do
+    visit_with_auth '/current_user/products', 'kimura'
+    assert_equal '自分の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+  end
+end


### PR DESCRIPTION
# issue #2843

ダッシュボードに自分の提出物一覧のタブを作成しました。

## 変更前
![Cursor_と_ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/58643754/125873387-99cb1a0b-1be3-4a14-ad7a-8f15ea2f6d35.png)


## 変更後
![ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/58643754/125873311-12eab937-134f-4fcc-b70b-0e13e9f4667a.png)
