### PR TITLE
企業管理画面にアドバイザーサインアップURLを追加

### DIFF
--- a/app/decorators/company_decorator.rb
+++ b/app/decorators/company_decorator.rb
@@ -4,4 +4,12 @@ module CompanyDecorator
   def logo_image(_length)
     rails_blob_path(logo)
   end
+
+  def adviser_sign_up_url
+    new_user_url(
+      role: 'adviser',
+      company_id: id,
+      token: ENV['TOKEN'] || 'token'
+    )
+  end
 end

--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -25,6 +25,7 @@ header.page-header
             th.admin-table__label = Company.human_attribute_name :logo
             th.admin-table__label = Company.human_attribute_name :description
             th.admin-table__label = Company.human_attribute_name :website
+            th.admin-table__label.actions リンク
             th.admin-table__label.actions 操作
         tbody.admin-table__items
           - @companies.each do |company|
@@ -39,6 +40,11 @@ header.page-header
                 = company.description
               td.admin-table__item-value
                 = company.website
+              td.admin-table__item-value.is-text-align-center
+                = link_to company.adviser_sign_up_url,
+                  title: 'アドバイザーサインアップURL',
+                  class: 'a-button is-sm is-secondary is-icon' do
+                  i.fas.fa-user-plus
               td.admin-table__item-value.is-text-align-center
                 ul.is-button-group
                   li

--- a/test/decorators/company_decorator_test.rb
+++ b/test/decorators/company_decorator_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CompanyDecoratorTest < ActiveSupport::TestCase
+  def setup
+    controller = ApplicationController.new
+    controller.request = ActionDispatch::TestRequest.create
+    ActiveDecorator::ViewContext.push controller.view_context
+    @company1 = ActiveDecorator::Decorator.instance.decorate(companies(:company1))
+  end
+
+  test '#adviser_sign_up_url' do
+    expected = "http://test.host/users/new?company_id=#{@company1.id}&role=adviser&token=token"
+    assert_equal expected, @company1.adviser_sign_up_url
+  end
+end


### PR DESCRIPTION
企業向けにアドバイザーの登録が増えてきたので、URLを渡す機会が増えたため。

Ref: #2938 