### PR TITLE
ユーザーの質問一覧画面のユーザー一覧ボタンに[<]を表示

### DIFF
--- a/app/views/users/questions/index.html.slim
+++ b/app/views/users/questions/index.html.slim
@@ -7,7 +7,7 @@ header.page-header
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item
-            = link_to 'ユーザー一覧', users_path, class: 'a-button is-md is-secondary is-block'
+            = link_to 'ユーザー一覧', users_path, class: 'a-button is-md is-secondary is-block is-back'
 
 .page-tools
   = render 'users/page_tabs', user: @user


### PR DESCRIPTION
issue #2895 

# ユーザーの質問一覧画面のユーザー一覧ボタンに[<]を表示
![スクリーンショット 2021-07-08 20 03 46](https://user-images.githubusercontent.com/58870882/124911695-04df7880-e028-11eb-95ac-8b13a5ef6d57.png)