### PR TITLE
variables/_colors.sassのimportを追加

### DIFF
--- a/app/assets/stylesheets/article.sass
+++ b/app/assets/stylesheets/article.sass
@@ -1,3 +1,5 @@
+@import variables/_colors
+
 body
   background-color: #ececec
 


### PR DESCRIPTION
`app/assets/stylesheets/article.sass`でコンパイルエラー(Undefined variable)が発生していたため、変数の定義元である``app/assets/stylesheets/variables/_colors.sass`をimportするように変更しました。