### PR TITLE
ユーザー > コメント一覧 にコメントがない場合の表示を変更

### DIFF
--- a/app/views/users/comments/index.html.slim
+++ b/app/views/users/comments/index.html.slim
@@ -21,5 +21,8 @@ header.page-header
         = render 'comments', comments: @comments
       = paginate @comments
     - else
-      .a-empty-message
-        | コメントはありません。
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | コメントはまだありません。


### PR DESCRIPTION
コメント一覧にコメントがない場合、涙目アイコンが表示されるように変更しました。

## 変更前
![スクリーンショット 2021-07-10 10 17 56](https://user-images.githubusercontent.com/58870882/125147746-25aee780-e168-11eb-9599-bbdfc6301b4a.png)

## 変更後
![スクリーンショット 2021-07-10 10 15 27](https://user-images.githubusercontent.com/58870882/125147702-e7b1c380-e167-11eb-92b9-1b6c1a436056.png)
