### PR TITLE
chore: 不要なコメントを削除

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -34,8 +34,6 @@ module UserDecorator
   def icon_title
     ["#{login_name} (#{name})", staff_roles].reject(&:blank?)
                                             .join(': ')
-    # [login_name, name, staff_roles].reject(&:blank?)
-    #                                .join(': ')
   end
 
   def url


### PR DESCRIPTION
過去のコードはGitに残っており、古いコードをコメントアウトで残す必要はないため。
参考: https://github.com/fjordllc/bootcamp/pull/2888/files#r661388495

[ci skip]