### PR TITLE
webpackビルド時に表示される注意文に対応

### DIFF
--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -51,7 +51,8 @@
                 .thread-list-item-comment__count
                   | （{{ product.comments.size }}）
                 .thread-list-item-comment__user-icons
-                  a.thread-list-item-comment__user-icon(:href='user.url')(
+                  a.thread-list-item-comment__user-icon(
+                    :href='user.url'
                     v-for='user in product.comments.users'
                   )
                     img.a-user-icon(

--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -1,10 +1,9 @@
 <template lang="pug">
 .thread-list-item(:class='wipClass')
   .thread-list-item__inner
-    label.thread-list-item-actions__trigger(:for='report.id')(
-      v-if='currentUserId == report.user.id'
-    )
-      i.fas.fa-ellipsis-h
+    template(v-if='currentUserId == report.user.id')
+      label.thread-list-item-actions__trigger(:for='report.id')
+        i.fas.fa-ellipsis-h
     .thread-list-item__rows
       .thread-list-item__row
         header.thread-list-item-title


### PR DESCRIPTION
`./bin/webpack-dev-server`を実行すると以下のメッセージが表示されました。
```
/Users/kentaro/bootcamp_app/bootcamp/app/javascript/report.vue, line 4:
You should not have pug tags with multiple attributes.
/Users/kentaro/bootcamp_app/bootcamp/app/javascript/product.vue, line 54:
You should not have pug tags with multiple attributes.
```

`div(class='foo')(id='bar')`のようにタグに複数の属性を持たせるべきではないとのことだったので、該当部分のコードを修正しました。