### PR TITLE
【メンター向け機能】提出物の担当者にアイコンが出るようにする

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -52,15 +52,23 @@
   +media-breakpoint-down(sm)
     margin-top: .75rem
 
-.thread-list-item__assignee-name.a-button
+.thread-list-item__assignee-button.a-button
   border: dashed 1px $muted-text
   pointer-events: none
   color: $muted-text
   background-color: #f6f6f6
-  span
-    display: block
-    overflow: hidden
-    text-overflow: ellipsis
+
+.thread-list-item__assignee-image
+  flex: 0 0 1.25rem
+  .a-user-icon
+    +size(1.25rem)
+
+.thread-list-item__assignee-name
+  display: block
+  overflow: hidden
+  text-overflow: ellipsis
+  flex: 1
+  text-align: center
 
 .thread-list-item__label
   +position(absolute, left 0, top 0)

--- a/app/javascript/check.js
+++ b/app/javascript/check.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const checkableLabel = check.getAttribute('data-checkable-label')
     const checkerId = Number(check.getAttribute('data-checker-id'))
     const checkerName = check.getAttribute('data-checker-name')
+    const checkerAvatar = check.getAttribute('data-checker-avatar')
     const currentUserId = check.getAttribute('data-current-user-id')
     new Vue({
       store,
@@ -21,6 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
             checkableLabel: checkableLabel,
             checkerId: checkerId,
             checkerName: checkerName,
+            checkerAvatar: checkerAvatar,
             currentUserId: currentUserId
           }
         })

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -18,6 +18,7 @@
           v-show='checkId === null',
           :checkerId='checkerId',
           :checkerName='checkerName',
+          :checkerAvatar='checkerAvatar',
           :currentUserId='currentUserId',
           :productId='checkableId',
           :checkableType='checkableType'
@@ -43,6 +44,7 @@ export default {
     checkableLabel: { type: String, required: true },
     checkerId: { type: Number, required: true },
     checkerName: { type: String, required: false, default: null },
+    checkerAvatar: { type: String, required: false, default: null },
     currentUserId: { type: String, required: false, default: null }
   },
   computed: {

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -75,6 +75,7 @@
       product-checker(
         :checkerId='product.checker_id',
         :checkerName='product.checker_name',
+        :checkerAvatar='product.checker_avatar',
         :currentUserId='currentUserId',
         :productId='product.id'
       )

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -12,6 +12,7 @@ button(
   | {{ buttonLabel }}
 .a-button.is-sm.is-block.thread-list-item__assignee-name.is-only-mentor(v-else)
   span
+    img.a-user-icon(:src="checkerAvatar" width="30" length="30")
     | {{ this.name }}
 </template>
 <script>
@@ -21,7 +22,8 @@ export default {
     checkerName: { type: String, required: false, default: null },
     currentUserId: { type: String, required: true },
     productId: { type: Number, required: true },
-    checkableType: {type: String,}
+    checkableType: {type: String,},
+    checkerAvatar: { type: String, required: false, default: null }
   },
   data() {
     return {

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -10,9 +10,10 @@ button(
     @click='check'
   )
   | {{ buttonLabel }}
-.a-button.is-sm.is-block.thread-list-item__assignee-name.is-only-mentor(v-else)
-  span
-    img.a-user-icon(:src="checkerAvatar" width="30" length="30")
+.a-button.is-sm.is-block.thread-list-item__assignee-button.is-only-mentor(v-else)
+  span.thread-list-item__assignee-image
+    img.a-user-icon(:src="checkerAvatar" width="20" length="20")
+  span.thread-list-item__assignee-name
     | {{ this.name }}
 </template>
 <script>

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -22,7 +22,7 @@ export default {
     checkerName: { type: String, required: false, default: null },
     currentUserId: { type: String, required: true },
     productId: { type: Number, required: true },
-    checkableType: {type: String,},
+    checkableType: { type: String },
     checkerAvatar: { type: String, required: false, default: null }
   },
   data() {

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -120,4 +120,8 @@ class Product < ApplicationRecord
     t = published_at || created_at
     ((Time.current - t) / 1.day).to_i
   end
+  
+  def checker_avatar
+    checker_id ? User.find(checker_id).avatar_url : nil  
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -120,8 +120,8 @@ class Product < ApplicationRecord
     t = published_at || created_at
     ((Time.current - t) / 1.day).to_i
   end
-  
+
   def checker_avatar
-    checker_id ? User.find(checker_id).avatar_url : nil  
+    checker_id ? User.find(checker_id).avatar_url : nil
   end
 end

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -1,6 +1,7 @@
 json.id product.id
 json.checker_id product.checker_id
 json.checker_name product.checker_name
+json.checker_avatar product.checker_avatar
 json.wip product.wip
 json.url product_url(product)
 json.created_at l(product.created_at)

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -114,6 +114,7 @@ header.page-header
                         data-checkable-label="#{Product.model_name.human}"
                         data-checker-id="#{@product.checker_id}"
                         data-checker-name="#{@product.checker_name}"
+                        data-checker-avatar="#{@product.checker_avatar}"
                         data-current-user-id="#{current_user.id}")
 
           .thread-prev-next


### PR DESCRIPTION
issue #2274 

# 概要
提出物一覧画面で「担当する」ボタンを押すと担当者のlogin_nameが表示されます。
今回は担当者のlogin_nameの横に担当者のアイコンが表示されるようにしました。

## 変更前
![image](https://user-images.githubusercontent.com/62867257/126465837-f4cc76f5-58ca-4a72-b699-64f08d2d8fa6.png)


## 変更後
![image](https://user-images.githubusercontent.com/62867257/126465608-60ed392c-368c-46d6-8151-fa2e06051c0f.png)

