### PR TITLE
ダッシュボードのお知らせ一覧の表示を公開日順にする

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,8 +8,9 @@ class HomeController < ApplicationController
         redirect_to retire_path
       else
         @announcements = Announcement.with_avatar
+                                     .where(wip: false)
+                                     .order(published_at: :desc)
                                      .limit(5)
-                                     .order(created_at: :desc)
         @completed_learnings = current_user.learnings.where(status: 3).order(updated_at: :desc)
         @my_seat_today = current_user.reservations.find_by(date: Date.current)&.seat&.name
         @reservations_for_today = Reservation.where(date: Date.current).to_a

--- a/app/views/home/_announcements.html.slim
+++ b/app/views/home/_announcements.html.slim
@@ -1,12 +1,11 @@
-- unless announcement.wip
-  .thread-list-item
-    .thread-list-item__inner
-      .thread-list-item__author
-        = render 'users/icon', user: announcement.user, link_class: 'a-user-name', image_class: 'thread-list-item__author-icon'
-      header.thread-list-item-title
-        h2.thread-list-item-title__title(itemprop='name')
-          = link_to announcement, itemprop: 'url', class: 'thread-list-item-title__link' do
-            = announcement.title
-      .thread-list-item-meta
-        time.a-date(datetime="#{announcement.updated_at.to_datetime}" pubdate='pubdate')
-          = l announcement.updated_at
+.thread-list-item
+  .thread-list-item__inner
+    .thread-list-item__author
+      = render 'users/icon', user: announcement.user, link_class: 'a-user-name', image_class: 'thread-list-item__author-icon'
+    header.thread-list-item-title
+      h2.thread-list-item-title__title(itemprop='name')
+        = link_to announcement, itemprop: 'url', class: 'thread-list-item-title__link' do
+          = announcement.title
+    .thread-list-item-meta
+      time.a-date(datetime="#{announcement.updated_at.to_datetime}" pubdate='pubdate')
+        = l announcement.updated_at

--- a/db/fixtures/announcements.yml
+++ b/db/fixtures/announcements.yml
@@ -661,3 +661,11 @@ announcement_wip:
   created_at: "2018-01-05"
   target: 0
   wip: true
+
+announcement_published_later:
+  user: komagata
+  title: 後から公開されたお知らせ
+  description: 後から公開されたお知らせ本文
+  created_at: "2020-12-31"
+  published_at: "2021-01-11"
+  target: 0

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -3,6 +3,7 @@ announcement1:
   title: お知らせ1
   description: お知らせ本文1
   created_at: "2018-01-01"
+  published_at: "2018-01-01"
   target: 0
 
 announcement2:
@@ -10,6 +11,7 @@ announcement2:
   title: お知らせ2
   description: お知らせ本文2
   created_at: "2018-01-02"
+  published_at: "2018-01-02"
   target: 0
 
 announcement3:
@@ -17,6 +19,7 @@ announcement3:
   title: テストのお知らせ
   description: テストのお知らせ本文
   created_at: "2018-01-03"
+  published_at: "2018-01-03"
   target: 0
 
 announcement4:
@@ -24,6 +27,7 @@ announcement4:
   title: 生徒からのお知らせ
   description: 生徒からのお知らせ本文
   created_at: "2018-01-03"
+  published_at: "2018-01-03"
   target: 0
 
 announcement5:
@@ -31,6 +35,7 @@ announcement5:
   title: お知らせの検索結果テスト用
   description: お知らせの検索結果テスト用
   created_at: "2018-05-20"
+  published_at: "2018-05-20"
   target: 0
 
 announcement_notification_active_user:
@@ -38,6 +43,7 @@ announcement_notification_active_user:
   title: 現役生にのみ通知するお知らせ
   description: 現役生にのみ通知するお知らせの本文
   created_at: "2018-01-04"
+  published_at: "2018-01-04"
   target: 1
 
 announcement_wip:

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -53,3 +53,11 @@ announcement_wip:
   created_at: "2018-01-05"
   target: 0
   wip: true
+
+announcement_published_later:
+  user: komagata
+  title: 後から公開されたお知らせ
+  description: 後から公開されたお知らせ本文
+  created_at: "2017-12-31"
+  published_at: "2018-01-11"
+  target: 0

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -41,4 +41,10 @@ class HomeTest < ApplicationSystemTestCase
     visit_with_auth '/', 'hajime'
     assert_no_selector '.card-list__item-link.is-discord_account'
   end
+
+  test 'show latest announcements on dashboard' do
+    visit_with_auth '/', 'hajime'
+    assert_text '後から公開されたお知らせ'
+    assert_no_text 'wipのお知らせ'
+  end
 end


### PR DESCRIPTION
Ref: #2956

## 変更点

ダッシュボード (`/`) に表示されるお知らせ一覧を「作成日時順」ではなく「公開日時順」で表示されるように変更しました。

### お知らせ一覧 (`/announcements`) の状態

![announcements](https://user-images.githubusercontent.com/350435/125961339-43aa92bb-0eaf-4d3d-b3ff-579ae883805c.png)

### 変更前のダッシュボード (`/`) の状態

![dashboard_announcements_before](https://user-images.githubusercontent.com/350435/125961492-8d7a751b-75eb-4e4f-b466-b2f981e089b9.png)

### 変更後のダッシュボード (`/`) の状態

![dashboard_announcements_after](https://user-images.githubusercontent.com/350435/125961529-a1d8ce0c-35c4-47e5-aa91-541cc021a18f.png)

## メモ

以前はWIPのお知らせがあった場合にお知らせの表示件数が5件未満になることがありましたが、今回の変更により常に5件表示されるようになりました（#2956 参照）。