### PR TITLE
OmniAuthのGitHub連携の権限を必要最低限にした

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"], scope: "user"
+  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"]
 end


### PR DESCRIPTION
ref: #2941 

`config/initializers/omniauth.rb`でGitHub連携の権限を`scope`で設定できます。
特に設定しない場合、アプリ側が取得できるのは公開されてる情報のみ（読み取り専用）になります。
https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes

bootcampの`user_sessions_controller.rb`で使っている`auth[:uid]`と`auth[:info][:nickname]`はローカルで確認したところ`scope`の設定なしでも取得できたので、`scope`を削除しました。