### PR TITLE
HTMLのclass名をダブルクオートで囲った

### DIFF
--- a/app/views/notification_mailer/_notification_mailer_template.html.erb
+++ b/app/views/notification_mailer/_notification_mailer_template.html.erb
@@ -10,7 +10,7 @@
   </tr>
   <tr>
     <td style="word-wrap:break-word;font-size:0px;padding:16px 24px 16px 24px;" align="left">
-      <div style="cursor:auto; font-family:sans-serif; font-size:14px; text-align:left;" class='a-long-text'>
+      <div class="a-long-text">
         <%= yield %>
       </div>
     </td>


### PR DESCRIPTION
class名がメールから消えてしまったので、これを試してみる。