### PR TITLE
退会者のアンケート結果を退会者個別ページに全て表示

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -3,8 +3,10 @@
     border-bottom: solid 1px $background
   +media-breakpoint-up(md)
     padding: .75rem 1rem
+    min-height: 3.875rem
   +media-breakpoint-down(sm)
     padding: .75rem
+    min-height: 3.5rem
 
 .thread-list-item__strip-label
   +media-breakpoint-up(md)

--- a/app/assets/stylesheets/blocks/user/_user-metas.sass
+++ b/app/assets/stylesheets/blocks/user/_user-metas.sass
@@ -1,6 +1,14 @@
 .user-metas
   margin-top: 1rem
 
+.user-metas__title
+  border: solid 1px $border-more-shade
+  margin-bottom: -1px
+  padding: .375rem .75rem
+  +text-block(.75rem 1.4, 600)
+  background-color: $background-shade
+  position: relative
+
 .user-metas__items
   border: solid 1px $background-shade
 
@@ -8,7 +16,7 @@
   +text-block(.75rem 1.4, flex)
   +media-breakpoint-down(sm)
     display: block
-  &:nth-child(odd)
+  &:nth-child(even)
     background-color: #fafafa
   &:not(:last-child)
     border-bottom: solid 1px $background-shade
@@ -16,7 +24,7 @@
 .user-metas__item-label
   text-align: right
   border-right: dashed 1px $background-shade
-  flex: 0 0 8rem
+  flex: 0 0 9rem
   padding: .375rem .5rem
   +media-breakpoint-down(sm)
     text-align: left
@@ -24,5 +32,5 @@
     border-bottom: dashed 1px $background-shade
 
 .user-metas__item-value
-  flex: 100
+  flex: 1
   padding: .375rem .5rem

--- a/app/assets/stylesheets/helpers/_state.sass
+++ b/app/assets/stylesheets/helpers/_state.sass
@@ -30,3 +30,12 @@ html
 .is-only-mentor
   body:not(.is-mentor-mode) &
     display: none !important
+
+.is-only-adviser
+  body:not(.is-adviser-mode) &
+    display: none !important
+
+
+body.is-mentor-mode .is-only-mentor.is-only-adviser,
+body.is-adviser-mode .is-only-mentor.is-only-adviser
+  display: block !important

--- a/app/helpers/body_class_helper.rb
+++ b/app/helpers/body_class_helper.rb
@@ -18,6 +18,12 @@ module BodyClassHelper
     end
   end
 
+  def adviser_mode
+    if adviser_login?
+      'is-adviser-mode'
+    end
+  end
+
   def page_area
     if controller.controller_path.include?('admin/')
       'admin-page'
@@ -35,7 +41,7 @@ module BodyClassHelper
   def body_class(options = {})
     extra_body_classes_symbol = options[:extra_body_classes_symbol] || :extra_body_classes
     qualified_controller_name = controller.controller_path.tr('/', '-')
-    basic_body_class = "#{qualified_controller_name} #{qualified_controller_name}-#{controller.action_name} is-#{page_category} is-#{page_area} is-#{Rails.env}"
+    basic_body_class = "#{qualified_controller_name} #{qualified_controller_name}-#{controller.action_name} is-#{page_category} is-#{page_area} is-#{Rails.env} #{adviser_mode}"
 
     if content_for?(extra_body_classes_symbol)
       [basic_body_class, content_for(extra_body_classes_symbol)].join(' ')

--- a/app/helpers/body_class_helper.rb
+++ b/app/helpers/body_class_helper.rb
@@ -19,9 +19,7 @@ module BodyClassHelper
   end
 
   def adviser_mode
-    if adviser_login?
-      'is-adviser-mode'
-    end
+    'is-adviser-mode' if adviser_login?
   end
 
   def page_area
@@ -41,7 +39,8 @@ module BodyClassHelper
   def body_class(options = {})
     extra_body_classes_symbol = options[:extra_body_classes_symbol] || :extra_body_classes
     qualified_controller_name = controller.controller_path.tr('/', '-')
-    basic_body_class = "#{qualified_controller_name} #{qualified_controller_name}-#{controller.action_name} is-#{page_category} is-#{page_area} is-#{Rails.env} #{adviser_mode}"
+    controller_class = "#{qualified_controller_name} #{qualified_controller_name}-#{controller.action_name}"
+    basic_body_class = "#{controller_class} is-#{page_category} is-#{page_area} is-#{Rails.env} #{adviser_mode}"
 
     if content_for?(extra_body_classes_symbol)
       [basic_body_class, content_for(extra_body_classes_symbol)].join(' ')

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.card-footer.is-only-mentor
+.card-footer.is-only-mentor.is-only-adviser
   .card-main-actions
     ul.card-main-actions__items
       li.card-main-actions__item(v-if='checkableType === "Product"')

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -1,15 +1,15 @@
 <template lang="pug">
 .thread-list-item(:class='product.wip ? "is-wip" : ""')
   .thread-list-item__strip-label(v-if='notResponded')
-    .thread-list-item__elapsed-days.is-reply-warning(
+    .thread-list-item__elapsed-days.is-reply-warning.is-only-mentor(
       v-if='isLatestProductSubmittedJust5days'
     )
       | 5日経過
-    .thread-list-item__elapsed-days.is-reply-alert(
+    .thread-list-item__elapsed-days.is-reply-alert.is-only-mentor(
       v-else-if='isLatestProductSubmittedJust6days'
     )
       | 6日経過
-    .thread-list-item__elapsed-days.is-reply-deadline(
+    .thread-list-item__elapsed-days.is-reply-deadline.is-only-mentor(
       v-else-if='isLatestProductSubmittedOver7days'
     )
       | 7日以上経過

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -447,6 +447,10 @@ class User < ApplicationRecord
     staff? || paid?
   end
 
+  def admin_or_mentor?
+    admin? || mentor?
+  end
+
   def adviser_or_mentor?
     adviser? || mentor?
   end
@@ -461,6 +465,10 @@ class User < ApplicationRecord
 
   def student_or_trainee?
     !staff? && !retired? && !graduated?
+  end
+
+  def student_or_trainee_or_retired?
+    !staff? && !graduated?
   end
 
   def unread_notifications_count

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -20,18 +20,18 @@ nav.global-nav
           = link_to report_link, class: "global-nav-links__link #{current_link(/^reports/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-pen
-            - if admin_login? && Cache.unchecked_report_count.positive?
+            - if current_user.admin_or_mentor? && Cache.unchecked_report_count.positive?
               .global-nav__item-count.a-notification-count.is-only-mentor
                 = Cache.unchecked_report_count
             .global-nav-links__link-label 日報
         - if staff_login?
-          li.global-nav-links__item.is-only-mentor
+          li.global-nav-links__item
             - products_link = admin_login? || mentor_login? ? products_not_responded_index_path : products_path
             = link_to products_link, class: "global-nav-links__link #{current_link(/^products/)}" do
               .global-nav-links__link-icon
                 i.fas.fa-fw.fa-hand-paper
-              - if admin_login? && Cache.not_responded_product_count.positive?
-                .global-nav__item-count.a-notification-count
+              - if admin_login? || mentor_login? && Cache.not_responded_product_count.positive?
+                .global-nav__item-count.a-notification-count.is-only-mentor
                   = Cache.not_responded_product_count
               .global-nav-links__link-label 提出物
         li.global-nav-links__item

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -14,7 +14,7 @@ header.header
             - if current_user.admin?
               span.a-user-role__label(class='is-admin') 管理者
 
-        - if current_user.mentor? || current_user.adviser?
+        - if current_user.admin_or_mentor?
           .switch.is-hidden-sm-down
             label.switch__label(for='modal-mentor-mode')
               span.switch__label-text

--- a/app/views/application/_header_links.html.slim
+++ b/app/views/application/_header_links.html.slim
@@ -25,7 +25,7 @@
             = render 'user_menu'
             - if current_user.admin?
               = render 'admin_menu'
-            - if current_user.mentor?
+            - if current_user.admin_or_mentor?
               = render 'mentor_menu'
       li.header-links__item.is-hidden-md-up
         label.header-links__link.test-show-menu(for='mobile-nav')

--- a/app/views/home/_job_seeking_users.html.slim
+++ b/app/views/home/_job_seeking_users.html.slim
@@ -1,4 +1,4 @@
-.a-card.is-only-mentor
+.a-card(class="#{current_user.admin_or_mentor? ? 'is-only-mentor' : ''}")
   header.card-header.is-sm
     h2.card-header__title
       | 就職活動中のユーザー

--- a/app/views/home/_job_seeking_users.html.slim
+++ b/app/views/home/_job_seeking_users.html.slim
@@ -1,4 +1,4 @@
-.a-card(class="#{current_user.admin_or_mentor? ? 'is-only-mentor' : ''}")
+.a-card.is-only-mentor.is-only-adviser
   header.card-header.is-sm
     h2.card-header__title
       | 就職活動中のユーザー

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -38,9 +38,9 @@ header.page-header
             = render '/users/practices/completed_practices', user: current_user, completed_learnings: @completed_learnings
 
         .col-xs-12.col-xl-6.col-xxl-6
-          - if (current_user.admin? || current_user.adviser?) && User.all.job_seeking.present?
+          - if current_user.staff? && User.all.job_seeking.present?
             = render 'job_seeking_users', users: User.all.job_seeking
-          - if (current_user.admin? || current_user.adviser?) && @reservations_for_today.present?
+          - if current_user.staff? && @reservations_for_today.present?
             = render 'reserved_seats_today', reservations: @reservations_for_today
           - unless current_user.total_learning_time.zero? || current_user.mentor?
             = render 'users/grass', user: current_user

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -7,16 +7,16 @@
         = link_to products_unchecked_index_path, class: "page-tabs__item-link #{current_link(/^products-unchecked-index/)}" do
           | 未完了
           - if Cache.unchecked_product_count.positive?
-            .page-tabs__item-count.a-notification-count
+            .page-tabs__item-count.a-notification-count.is-only-mentor
               = Cache.unchecked_product_count
       li.page-tabs__item
         = link_to products_not_responded_index_path, class: "page-tabs__item-link #{current_link(/^products-not_responded-index/)}" do
           | 未返信
           - if Cache.not_responded_product_count.positive?
-            .page-tabs__item-count.a-notification-count
+            .page-tabs__item-count.a-notification-count.is-only-mentor
               = Cache.not_responded_product_count
-      li.page-tabs__item
+      li.page-tabs__item.is-only-mentor
         = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
           | 自分の担当
-          .page-tabs__item-count.a-notification-count
+          .page-tabs__item-count.a-notification-count.is-only-mentor
             = Cache.self_assigned_product_count(current_user.id)

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -1,6 +1,6 @@
 - if users.present?
   .a-card.is-only-mentor
-    header.card-header
+    header.card-header.is-sm
       h2.card-header__title
         | 1ヶ月以上ログインのないユーザー
         = "(#{users.size})"

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -75,7 +75,7 @@
         .user-metas__item-value
           ul
             - user.retire_reasons.to_human.each do |reason|
-              li= reason
+              li = reason
       .user-metas__item.is-only-mentor
         .user-metas__item-label
           = User.human_attribute_name :retire_reason

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -1,4 +1,6 @@
 .user-metas
+  h2.user-metas__title.is-only-mentor
+    | ユーザー公開情報
   .user-metas__items
     .user-metas__item
       .user-metas__item-label
@@ -62,22 +64,3 @@
           = User.human_attribute_name :graduated_on
         .user-metas__item-value
           = l user.graduated_on
-    - if user.retired?
-      .user-metas__item
-        .user-metas__item-label
-          = User.human_attribute_name :retired_on
-        .user-metas__item-value
-          = l user.retired_on
-    - if user.retired? && staff_login?
-      .user-metas__item.is-only-mentor
-        .user-metas__item-label
-          = User.human_attribute_name :retire_reasons
-        .user-metas__item-value
-          ul
-            - user.retire_reasons.to_human.each do |reason|
-              li = reason
-      .user-metas__item.is-only-mentor
-        .user-metas__item-label
-          = User.human_attribute_name :retire_reason
-        .user-metas__item-value
-          = user.retire_reason

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -71,6 +71,13 @@
     - if user.retired? && staff_login?
       .user-metas__item.is-only-mentor
         .user-metas__item-label
+          = User.human_attribute_name :retire_reasons
+        .user-metas__item-value
+          ul
+            - user.retire_reasons.to_human.each do |reason|
+              li= reason
+      .user-metas__item.is-only-mentor
+        .user-metas__item-label
           = User.human_attribute_name :retire_reason
         .user-metas__item-value
           = user.retire_reason

--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -7,5 +7,5 @@ nav.tab-nav
       - elsif current_user.adviser?
         - targets += %w[job_seeking]
       - targets.each do |target|
-        li.tab-nav__item(class="#{%w[job_seeking all].include?(target) ? 'is-only-mentor' : ''}")
+        li.tab-nav__item(class="#{%w[job_seeking all].include?(target) ? 'is-only-mentor is-only-adviser' : ''}")
           = link_to t("target.#{target}"), users_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/users/_retire_info.html.slim
+++ b/app/views/users/_retire_info.html.slim
@@ -1,0 +1,21 @@
+.user-metas.is-only-mentor
+  h2.user-metas__title
+    | 退会情報（非公開）
+  .user-metas__items
+    .user-metas__item
+      .user-metas__item-label
+        = User.human_attribute_name :retired_on
+      .user-metas__item-value
+        = l user.retired_on
+    .user-metas__item
+      .user-metas__item-label
+        = User.human_attribute_name :retire_reasons
+      .user-metas__item-value
+        ul
+          - user.retire_reasons.to_human.each do |reason|
+            li = reason
+    .user-metas__item
+      .user-metas__item-label
+        = User.human_attribute_name :retire_reason
+      .user-metas__item-value
+        = user.retire_reason

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -25,7 +25,8 @@
                     i.fab.fa-discord
                   .users-item-names__chat-value
                     = user.discord_account
-          = render 'users/user_secret_attributes', user: user
+          - if current_user.admin_or_mentor? && user.student_or_trainee?
+            = render 'users/user_secret_attributes', user: user
           .users-item__icon
             = render 'users/icon',
               user: user,

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -1,35 +1,54 @@
-- if current_user.mentor? && user.student_or_trainee?
-  .user-secret-attributes.is-only-mentor
-    .user-secret-attributes__title
-      | メンターだけが見れる情報
-    - if user.student?
-      .user-secret-attributes__items
-        .user-secret-attributes__item
-          - if user.job_seeker
-            | 就職を希望
-          - else
-            | 就職を希望しない
+.user-metas.is-only-mentor
+  h2.user-metas__title
+    | ユーザー非公開情報
+  .user-metas__items
+    .user-metas__item
+      .user-metas__item-label
+        | メールアドレス
+      .user-metas__item-value
+        = user.email
+    .user-metas__item
+      .user-metas__item-label
+        | 課金状況
+      .user-metas__item-value
         - if user.card?
-          .user-secret-attributes__item
-            | 有料ユーザー
-        - if user.free
-          .user-secret-attributes__item
-            = User.human_attribute_name :free
+          | 有料ユーザー
+        - elsif user.free
+          = User.human_attribute_name :free
+    .user-metas__item
+      .user-metas__item-label
+        | 就職について
+      .user-metas__item-value
+        - if user.job_seeker
+          | 就職を希望
+        - else
+          | 就職を希望しない
+    .user-metas__item
+      .user-metas__item-label
+        | 職業
+      .user-metas__item-value
         - if user.job
-          .user-secret-attributes__item
-            = t("activerecord.enums.user.job.#{user.job}")
+          = t("activerecord.enums.user.job.#{user.job}")
+        - else
+          | 回答なし
+    .user-metas__item
+      .user-metas__item-label
+        | マシンのOS
+      .user-metas__item-value
         - if user.os
-          .user-secret-attributes__item
-            = t("activerecord.enums.user.os.#{user.os}")
+          = t("activerecord.enums.user.os.#{user.os}")
+        - else
+          | 回答なし
+    .user-metas__item
+      .user-metas__item-label
+        | プラグラミング経験
+      .user-metas__item-value
         - if user.experience
-          .user-secret-attributes__item
-            = t("activerecord.enums.user.experience.#{user.experience}")
-        - if user.email
-          .user-secret-attributes__item
-            = user.email
-    .user-secret-attributes__items
-      .user-secret-attributes__item
-        .user-secret-attributes__item-label
-          = User.human_attribute_name :updated_at
-        .user-secret-attributes__item-value(class="#{'is-important' unless user.active?}")
-          = l user.updated_at
+          = t("activerecord.enums.user.experience.#{user.experience}")
+        - else
+          | 回答なし
+    .user-metas__item
+      .user-metas__item-label
+        = User.human_attribute_name :updated_at
+      .user-metas__item-value
+        = l user.updated_at

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -32,7 +32,7 @@ header.page-header
         .col-xs-12.col-lg-6.col-xxl-6
           .a-card.is-user
             - if admin_login? && @user.retired_on? && @user.github_collaborator?
-              .a-card__alert
+              .a-card__alert.is-only-mentor
                 = link_to edit_admin_user_path(anchor: 'external-services') do
                   | 外部サービスの設定を変更してください。
             .user-data
@@ -40,7 +40,10 @@ header.page-header
                 .user-data__main
                   = render 'users/profile', user: @user
                 .user-data__sub
-                  = render 'users/user_secret_attributes', user: @user
+                  - if current_user.admin_or_mentor? && @user.retired?
+                    = render 'users/retire_info', user: @user
+                  - if current_user.admin_or_mentor? && @user.student_or_trainee_or_retired?
+                    = render 'users/user_secret_attributes', user: @user
                   = render 'users/metas', user: @user
               .user-data__description
                 = auto_link simple_format h @user.description

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -75,7 +75,8 @@ ja:
         retired_on: 退会日
         free: 無料ユーザー
         avatar: ユーザーアイコン
-        retire_reason: 退会理由
+        retire_reasons: 選択入力の退会理由
+        retire_reason: 自由記入の退会理由
         satisfaction: 満足度
         opinion: ご意見
         mail_notification: メール通知

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -105,6 +105,7 @@ yameo:
   job_seeker: true
   unsubscribe_email_token: mzx5kXfsGmR1u0gOaXMseg
   retired_on: "2015-01-01"
+  retire_reasons: "31"
   retire_reason: "内容が難しかった"
   updated_at: "2014-01-01 00:00:05"
   created_at: "2014-01-01 00:00:05"

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -88,4 +88,24 @@ class RetirementTest < ApplicationSystemTestCase
     assert_text '転職や引っ越しなど環境の変化によって学びが継続できなくなったから'
     assert_text '企業研修で利用をしていて研修期間が終了したため'
   end
+
+  test 'メンター以外に退会理由が表示されていないか' do
+    visit_with_auth "/users/#{users(:yameo).id}", 'hatsuno'
+    assert_no_text '退会理由'
+    assert_no_text '受講したいカリキュラムを全て受講したから'
+    assert_no_text '学ぶ必要がなくなったから'
+    assert_no_text '他のスクールに通うことにしたから'
+    assert_no_text '学習時間を取ることが難しくなったから'
+    assert_no_text '学ぶ意欲が落ちたから'
+  end
+
+  test '退会していないユーザーに退会理由が表示されていないか' do
+    visit_with_auth "/users/#{users(:hatsuno).id}", 'komagata'
+    assert_no_text '退会理由'
+    assert_no_text '受講したいカリキュラムを全て受講したから'
+    assert_no_text '学ぶ必要がなくなったから'
+    assert_no_text '他のスクールに通うことにしたから'
+    assert_no_text '学習時間を取ることが難しくなったから'
+    assert_no_text '学ぶ意欲が落ちたから'
+  end
 end

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -74,7 +74,7 @@ class RetirementTest < ApplicationSystemTestCase
     end
   end
 
-  test '退会理由がすべて表示されているか' do
+  test 'show all reasons for retirement' do
     visit_with_auth new_retirement_path, 'kananashi'
     assert_text '受講したいカリキュラムを全て受講したから'
     assert_text '学ぶ必要がなくなったから'
@@ -89,7 +89,7 @@ class RetirementTest < ApplicationSystemTestCase
     assert_text '企業研修で利用をしていて研修期間が終了したため'
   end
 
-  test 'メンター以外に退会理由が表示されていないか' do
+  test 'show reasons for retirement only to mentor' do
     visit_with_auth "/users/#{users(:yameo).id}", 'hatsuno'
     assert_no_text '退会理由'
     assert_no_text '受講したいカリキュラムを全て受講したから'
@@ -99,7 +99,7 @@ class RetirementTest < ApplicationSystemTestCase
     assert_no_text '学ぶ意欲が落ちたから'
   end
 
-  test '退会していないユーザーに退会理由が表示されていないか' do
+  test 'show reasons for retirement only retirement users' do
     visit_with_auth "/users/#{users(:hatsuno).id}", 'komagata'
     assert_no_text '退会理由'
     assert_no_text '受講したいカリキュラムを全て受講したから'


### PR DESCRIPTION
ref: [#2912](https://github.com/fjordllc/bootcamp/issues/2912)

## やったこと
退会時にチェックボックスで選択する退会理由を、退会したユーザーの詳細ページで全て表示するように項目を追加しました（表示されるのはメンターのみ）。

### 変更前
![スクリーンショット 2021-07-18 11 59 02](https://user-images.githubusercontent.com/58870882/126054252-8f64b901-b97e-4749-8d3a-342d423f89bf.png)

### 変更後
![スクリーンショット 2021-07-18 11 57 27](https://user-images.githubusercontent.com/58870882/126054256-4dca844f-39dd-4c17-ad42-8a12be1c78f0.png)