### PR TITLE
提出物に一度もメンターからコメントがない場合は、提出物個別ページに7日待ってくださいのメッセージを表示する

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -114,7 +114,7 @@ class ProductsController < ApplicationController
 
     case action_name
     when :create
-      '提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。<br>7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。'
+      '提出物を提出しました。'
     when :update
       '提出物を更新しました。'
     end

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -27,6 +27,14 @@ header.page-header
         .a-page-notice__inner
           p
             | このプラクティスは、OKをもらっていなくても他の人の提出物を閲覧できます。
+  - if @product.user == current_user && !@product.wip? && @product.commented_users.mentor.empty?
+    .a-page-notice.page-notice
+      .container
+        .a-page-notice__inner
+          p
+            | 提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。
+            br
+            | 7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。
   .container
     div(class="#{current_user.mentor? || current_user.admin? ? 'row is-jc:c' : ''}")
       div(class="#{current_user.mentor? || current_user.admin? ? 'col-md-7 col-xs-12' : ''}")

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -27,7 +27,7 @@ header.page-header
         .a-page-notice__inner
           p
             | このプラクティスは、OKをもらっていなくても他の人の提出物を閲覧できます。
-  - if @product.user == current_user && !@product.wip? && @product.commented_users.mentor.empty?
+  - if @product.user == current_user && !@product.wip? && !@product.checked? && @product.commented_users.mentor.empty?
     .a-page-notice.page-notice
       .container
         .a-page-notice__inner

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -30,10 +30,11 @@ product4: # チェック済
 product5:
   practice: practice2
   user: kimura
-  body: テストの提出物5です。
+  body: WIPの提出物です。
   created_at: <%= 4.day.ago %>
   updated_at: <%= 4.day.ago %>
   published_at: <%= 4.day.ago %>
+  wip: true
 
 product6:
   practice: practice3

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -335,6 +335,11 @@ class ProductsTest < ApplicationSystemTestCase
     assert_no_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
   end
 
+  test "don't show review schedule message on product page if product is checked" do
+    visit_with_auth "/products/#{products(:product2).id}", 'kimura'
+    assert_no_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
+  end
+
   test "don't show review schedule message on product page if product is WIP" do
     visit_with_auth "/products/#{products(:product5).id}", 'kimura'
     assert_no_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -334,4 +334,9 @@ class ProductsTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{products(:product10).id}", 'kimura'
     assert_no_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
   end
+
+  test "don't show review schedule message on product page if product is WIP" do
+    visit_with_auth "/products/#{products(:product5).id}", 'kimura'
+    assert_no_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
+  end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -324,4 +324,14 @@ class ProductsTest < ApplicationSystemTestCase
     visit "/products/#{products(:product3).id}"
     assert_text 'このプラクティスは、OKをもらっていなくても他の人の提出物を閲覧できます。'
   end
+
+  test 'show review schedule message on product page' do
+    visit_with_auth "/products/#{products(:product8).id}", 'kimura'
+    assert_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
+  end
+
+  test "don't show review schedule message on product page if mentor comments" do
+    visit_with_auth "/products/#{products(:product10).id}", 'kimura'
+    assert_no_text "提出物を提出しました。7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\n7日以上待ってもレビューされない場合は、気軽にメンターにメンションを送ってください。"
+  end
 end


### PR DESCRIPTION
Ref: #2914 

## 変更点

提出物を提出したとき、提出物ページにflashで「7日以内にメンターがレビューしますので、次のプラクティスにお進みください。」というメッセージが表示されていましたが、ページを開き直したときにはそのメッセージは表示されませんでした。

このPRによって、提出直後でなくても「7日以内に…」のメッセージが表示されるようになります。なお、「確認済み」もしくは「メンターがコメント済み」の提出物には、このメッセージは表示されません。

## 変更前

<details>
<summary>提出直後</summary>

「7日以内に…」がflashで表示されます。

![image](https://user-images.githubusercontent.com/350435/126233184-3013ab77-d6ee-4178-998d-96e55c78807a.png)

</details>

<details>
<summary>再読み込み</summary>

提出直後以外は「7日以内に…」が表示されません。

![image](https://user-images.githubusercontent.com/350435/126233226-9791335d-c358-481d-83f7-fa3ae5fcac19.png)

</details>

## 変更後

<details>
<summary>提出直後</summary>

「提出物を提出しました」がflashとして表示され、「7日以内に…」が固定メッセージとして表示されます。

![image](https://user-images.githubusercontent.com/350435/126232528-01b9b5e7-fbc6-4e0f-bf54-3d3152c48e4d.png)

</details>

<details>
<summary>再読み込み</summary>

メンターがコメントするまで、「7日以内に…」が固定メッセージとして表示されます。

![image](https://user-images.githubusercontent.com/350435/126232803-c0085889-4c87-44cb-84d5-e25177f8065c.png)

</details>