### PR TITLE
ダッシュボードに自分のニコニコカレンダーを表示

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -46,6 +46,8 @@ header.page-header
             = render 'users/grass', user: current_user
           - if current_user.github_account.present?
             = render 'users/github_grass', user: current_user
+          - if current_user.student? && current_user.graduated_on.blank?
+            #js-niconico_calendar(data-user-id="#{current_user.id}")
           - if current_user.mentor?
             = render 'users/sad_emotion_report', users: User.students_and_trainees
           - if current_user.mentor?

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -48,17 +48,17 @@ class HomeTest < ApplicationSystemTestCase
     assert_no_text 'wipのお知らせ'
   end
 
-  test '現役生の場合にニコニコカレンダーが表示されているか' do
+  test 'show the Nico Nico calendar for students' do
     visit_with_auth '/', 'hajime'
     assert_text 'ニコニコカレンダー'
   end
 
-  test '卒業生の場合にニコニコカレンダーが表示されていないか' do
+  test 'not show the Nico Nico calendar for graduates' do
     visit_with_auth '/', 'sotugyou'
     assert_no_text 'ニコニコカレンダー'
   end
 
-  test '管理者の場合にニコニコカレンダーが表示されていないか' do
+  test 'not show the Nico Nico calendar for administrators' do
     visit_with_auth '/', 'komagata'
     assert_no_text 'ニコニコカレンダー'
   end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -47,4 +47,19 @@ class HomeTest < ApplicationSystemTestCase
     assert_text '後から公開されたお知らせ'
     assert_no_text 'wipのお知らせ'
   end
+
+  test '現役生の場合にニコニコカレンダーが表示されているか' do
+    visit_with_auth '/', 'hajime'
+    assert_text 'ニコニコカレンダー'
+  end
+
+  test '卒業生の場合にニコニコカレンダーが表示されていないか' do
+    visit_with_auth '/', 'sotugyou'
+    assert_no_text 'ニコニコカレンダー'
+  end
+
+  test '管理者の場合にニコニコカレンダーが表示されていないか' do
+    visit_with_auth '/', 'komagata'
+    assert_no_text 'ニコニコカレンダー'
+  end
 end


### PR DESCRIPTION
ref: [#2965](https://github.com/fjordllc/bootcamp/issues/2965)

## やったこと
- ダッシュボードにも自分のニコニコカレンダーが表示されるようにしました(現役生のみ)。
- ニコニコカレンダーの表示に関するテストを追加しました。

## 変更前
<img width="1237" alt="スクリーンショット 2021-07-19 16 04 28" src="https://user-images.githubusercontent.com/58870882/126117199-a09fb98a-94e2-440a-a93b-f183c2549dc1.png">

## 変更後
<img width="1237" alt="スクリーンショット 2021-07-19 15 59 49" src="https://user-images.githubusercontent.com/58870882/126117334-9bdb04df-f010-4758-9b3d-86a670a0dc75.png">