### PR TITLE
ユーザー > 質問一覧 に質問がない場合の表示を変更

### DIFF
--- a/app/views/users/questions/index.html.slim
+++ b/app/views/users/questions/index.html.slim
@@ -22,4 +22,4 @@ header.page-header
         .o-empty-message__icon
           i.far.fa-sad-tear
         p.o-empty-message__text
-        | 質問はまだありません。
+          | 質問はまだありません。

--- a/app/views/users/questions/index.html.slim
+++ b/app/views/users/questions/index.html.slim
@@ -22,4 +22,4 @@ header.page-header
         .o-empty-message__icon
           i.far.fa-sad-tear
         p.o-empty-message__text
-        | 質問はまだありません。  
+        | 質問はまだありません。

--- a/app/views/users/questions/index.html.slim
+++ b/app/views/users/questions/index.html.slim
@@ -14,5 +14,12 @@ header.page-header
 
 .page-body
   .container
-    .thread-list.a-card
-      = render partial: 'questions/question', collection: @questions, as: :question
+    - if @questions.present?
+      .thread-list.a-card
+        = render partial: 'questions/question', collection: @questions, as: :question
+    - else
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+        | 質問はまだありません。  


### PR DESCRIPTION
issue [#2966](https://github.com/fjordllc/bootcamp/issues/2966)
ユーザー > 質問一覧 に質問がない場合、涙目アイコンが表示されるように変更しました。

## 変更前
![125460711-f61ee4da-df00-4d78-8636-35bcb8a6c9c4](https://user-images.githubusercontent.com/52092916/126325860-77f3142f-0b0a-43e9-a946-77cecdd86478.png)


## 変更後

![image](https://user-images.githubusercontent.com/52092916/126326100-c937bd1e-c811-4933-a4cc-dd61069f8f03.png)

