### PR TITLE
DocsをWatchできるようにした

### DIFF
--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -23,6 +23,8 @@ module Watchable
       "「#{self[:title]}」のQ&A"
     when Event
       "「#{self[:title]}」のイベント"
+    when Page
+      "「#{self[:title]}」のDocs"
     end
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,10 +6,12 @@ class Page < ApplicationRecord
   include Taggable
   include Reactionable
   include Commentable
+  include Watchable
 
   belongs_to :user
   belongs_to :practice, optional: true
   belongs_to :last_updated_user, class_name: 'User', optional: true
+  has_many :watches, as: :watchable, dependent: :destroy
   validates :title, presence: true
   validates :body, presence: true
   validates :slug, length: { maximum: 200 }, format: { with: /\A[a-z][a-z0-9_-]*\z/ }, uniqueness: true, allow_nil: true

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -6,6 +6,7 @@ class PageCallbacks
 
     send_notification(page)
     notify_to_chat(page)
+    create_author_watch(page)
 
     page.published_at = Time.current
     page.save
@@ -16,6 +17,7 @@ class PageCallbacks
 
     send_notification(page)
     notify_to_chat(page)
+    create_author_watch(page)
 
     page.published_at = Time.current
     page.save
@@ -44,5 +46,9 @@ class PageCallbacks
       user: page.user,
       webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
     )
+  end
+
+  def create_author_watch(page)
+    Watch.create!(user: page.user, watchable: page)
   end
 end

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -66,7 +66,11 @@ header.page-header
                   | WIP
               span.thread-header-title__title
                 | #{@page.title}
-
+          .thread-header__row
+            .thread-header-actions
+              .thread-header-actions__start
+                .thread-header-actions__action
+                  #js-watch-toggle(data-watchable-id="#{@page.id}", data-watchable-type='Page')
           - if @page.practice.present?
             .thread-header__row
               .thread-practice

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -44,6 +44,7 @@ class PagesTest < ApplicationSystemTestCase
     fill_in 'page[body]', with: '新規Docを作成する本文です'
     click_button '内容を保存'
     assert_text 'ページを作成しました'
+    assert_text 'Watch中'
   end
 
   test 'create page as WIP' do


### PR DESCRIPTION
ref: #2846

# やったこと
DocsにWatch機能を追加しました。
Docsの投稿者は自動でWatch中になります。

# 変更前
![image](https://user-images.githubusercontent.com/67262644/126437964-c16b1ab6-d21e-47f6-9fcc-ecfcf57f2c9a.png)

# 変更後
![貼り付けた画像_2021_07_21_14_52](https://user-images.githubusercontent.com/67262644/126438040-3d32acf0-9c1d-42ff-87e4-28e90790eba4.png)
