### PR TITLE
WIPの日報の編集画面に「この日報は提出済です」メッセージが表示されないようにした

### DIFF
--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -51,7 +51,7 @@
 
   .form__items
     .form-item
-      - if @report.published_at
+      - if !@report.wip? && (params[:action] != 'new')
         .a-page-notice.is-danger
           .a-page-notice__inner
             p

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -51,7 +51,7 @@
 
   .form__items
     .form-item
-      - if !@report.wip? && (params[:action] != 'new')
+      - if !@report.wip? && params[:action] != 'new' && params[:action] != 'create'
         .a-page-notice.is-danger
           .a-page-notice__inner
             p

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -471,19 +471,8 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test 'change report status to wip' do
-    visit_with_auth '/reports/new', 'kimura'
-    within('#new_report') do
-      fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: 'test')
-      fill_in('report[reported_on]', with: Time.current)
-    end
-    first('.learning-time').all('.learning-time__started-at select')[0].select('09')
-    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
-    first('.learning-time').all('.learning-time__finished-at select')[0].select('12')
-    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
-
-    click_button '提出'
-    assert_text '日報を保存しました。'
+    report = reports(:report15)
+    visit_with_auth "/reports/#{report.id}", 'hajime'
 
     click_link '内容修正'
     assert_text 'この日報はすでに提出済みです。'

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -470,6 +470,28 @@ class ReportsTest < ApplicationSystemTestCase
     assert_no_text 'kimuraさんがはじめての日報を書きました！'
   end
 
+  test 'change report status to wip' do
+    visit_with_auth '/reports/new', 'kimura'
+    within('#new_report') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: 'test')
+      fill_in('report[reported_on]', with: Time.current)
+    end
+    first('.learning-time').all('.learning-time__started-at select')[0].select('09')
+    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
+    first('.learning-time').all('.learning-time__finished-at select')[0].select('12')
+    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
+
+    click_button '提出'
+    assert_text '日報を保存しました。'
+
+    click_link '内容修正'
+    assert_text 'この日報はすでに提出済みです。'
+    
+    click_button 'WIP'
+    assert_no_text 'この日報はすでに提出済みです。'
+  end
+
   test 'reports are ordered in descending of reported_on' do
     visit_with_auth reports_path, 'kimura'
     precede = reports(:report24).title

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -487,7 +487,6 @@ class ReportsTest < ApplicationSystemTestCase
 
     click_link '内容修正'
     assert_text 'この日報はすでに提出済みです。'
-    
     click_button 'WIP'
     assert_no_text 'この日報はすでに提出済みです。'
   end


### PR DESCRIPTION
issue #2934

## 概要
一度公開した日報をWIPに戻しても「この日報はすでに提出済みです。」のメッセージが表示されていましたが、表示されないように修正しました。

## 変更前
![日報編集___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/58643754/126730336-e05ec258-48d0-4ea4-8932-6a4a35e7fe5d.png)


## 変更後
![Cursor_と_日報編集___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/58643754/126730183-dbe3960c-5919-4c61-a7e0-8d0c35d652ba.png)
