### PR TITLE
Watch一覧をダッシュボード配下に移動

### DIFF
--- a/app/controllers/current_user/watches_controller.rb
+++ b/app/controllers/current_user/watches_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CurrentUser::WatchesController < ApplicationController
+  before_action :require_login
+  before_action :set_user
+  before_action :set_watches
+
+  def index; end
+
+  private
+
+  def set_user
+    @user = current_user
+  end
+
+  def set_watches
+    @watches = user.watches
+  end
+
+  def user
+    @user ||= current_user
+  end
+end

--- a/app/views/application/_user_menu.html.slim
+++ b/app/views/application/_user_menu.html.slim
@@ -7,9 +7,6 @@
       = link_to user_path(current_user), class: 'header-dropdown__item-link' do
         | 自分のプロフィール
     li.header-dropdown__item
-      = link_to watches_path, class: 'header-dropdown__item-link' do
-        | Watch中一覧
-    li.header-dropdown__item
       = link_to bookmarks_path, class: 'header-dropdown__item-link' do
         | ブックマーク一覧
     li.header-dropdown__item

--- a/app/views/current_user/watches/index.html.slim
+++ b/app/views/current_user/watches/index.html.slim
@@ -1,0 +1,20 @@
+- title '自分のWatch中'
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        | ダッシュボード
+
+.page-tools
+= render 'home/page_tabs', user: @user
+
+.page-body
+  .container
+    - if @watches.present?
+      #js-watches
+    - else
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | Watch中はまだありません。

--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -12,3 +12,7 @@
         li.page-tabs__item
           = link_to current_user_products_path, class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
             | 自分の提出物
+      - if !user.staff? || user.watches.present?
+        li.page-tabs__item
+          = link_to current_user_watches_path, class: "page-tabs__item-link #{current_page_tab_or_not('watches')}" do
+            | 自分のWatch中

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
   namespace :current_user do
     resources :reports, only: %i(index)
     resources :products, only: %i(index)
+    resources :watches, only: %i(index)
   end
 
   namespace "partial" do

--- a/test/system/current_user/watches_test.rb
+++ b/test/system/current_user/watches_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class CurrentUser::WatchesTest < ApplicationSystemTestCase
+  test 'show current_user watches when current_user is student' do
+    visit_with_auth '/current_user/watches', 'kimura'
+    assert_equal '自分のWatch中 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+  end
+end


### PR DESCRIPTION
issues: [#2910](https://github.com/fjordllc/bootcamp/issues/2910)

## 概要
+ 自分のWatch一覧ページ/current_user/watchesを作成しました。
+ ダッシュボード画面に「自分のWatch中」タブを追加しました。
+ ユーザーメニュー(me)から「Watch中一覧」リンクを削除しました。

---

## 変更前
![image](https://user-images.githubusercontent.com/52092916/126763590-db446460-4262-43b4-9d40-7e73beb4076f.png)


## 変更後

![image](https://user-images.githubusercontent.com/52092916/126763523-ad5c26d6-b8c7-40af-9e63-93486d8443d5.png)

