### PR TITLE
プロフィールに分報のURLを登録できるようにする

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -24,7 +24,7 @@ class CurrentUserController < ApplicationController
       :name_kana, :email, :course_id,
       :description, :job_seeking, :discord_account,
       :github_account, :twitter_account, :facebook_url,
-      :blog_url, :password, :password_confirmation,
+      :blog_url, :times_url, :password, :password_confirmation,
       :job, :organization, :os,
       :experience, :prefecture_code, :company_id,
       :nda, :avatar, :trainee,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -127,7 +127,7 @@ class UsersController < ApplicationController
       :login_name, :name, :name_kana,
       :email, :course_id, :description,
       :discord_account, :github_account, :twitter_account,
-      :facebook_url, :blog_url, :password,
+      :facebook_url, :blog_url, :times_url, :password,
       :password_confirmation, :job, :organization,
       :os, :experience, :prefecture_code,
       :company_id, :nda, :avatar,

--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -26,6 +26,11 @@
                   i.fab.fa-discord
                 .users-item-names__chat-value
                   | {{ user.discord_account }}
+                .users-item-names__chat-times(v-if='user.times_url')
+                  | （
+                  a(:href='user.times_url')
+                    | 分報
+                  | ）
           user-secret-attributes(:user='user', :currentUser='currentUser')
           .users-item__icon
             a(:href='user.url')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,6 +145,12 @@ class User < ApplicationRecord
               with: /\A[^\s\p{blank}].*[^\s\p{blank}]#\d{4}\z/,
               message: 'は「ユーザー名#４桁の数字」で入力してください'
             }
+  validates :times_url,
+            format: {
+              allow_blank: true,
+              with: %r{\Ahttps://discord\.gg/},
+              message: 'は「https://discord.gg/」で始まる招待URLを入力してください'
+            }
 
   validates :login_name, exclusion: { in: RESERVED_LOGIN_NAMES, message: 'に使用できない文字列が含まれています' }
 

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -1,4 +1,4 @@
-json.(user, :id, :login_name, :name, :discord_account, :description, :github_account, :twitter_account, :facebook_url, :blog_url, :job_seeker, :free, :job, :os, :experience, :email, :role, :icon_title,:cached_completed_percentage)
+json.(user, :id, :login_name, :name, :discord_account, :description, :github_account, :twitter_account, :facebook_url, :blog_url, :times_url, :job_seeker, :free, :job, :os, :experience, :email, :role, :icon_title,:cached_completed_percentage)
 json.tag_list user.tags.pluck(:name)
 json.url user_url(user)
 json.updated_at l(user.updated_at)

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -40,6 +40,8 @@
         | Discordアカウント
       .user-metas__item-value
         = user.discord_account.presence || '未登録'
+        - if user.times_url?
+          | （#{link_to '分報', user.times_url}）
     - unless user.admin? || user.adviser?
       .user-metas__item
         .user-metas__item-label

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -17,6 +17,8 @@
             i.fab.fa-discord
           .users-item-names__chat-value
             = user.discord_account.presence || 'Discord未設定'
+            - if user.times_url?
+              | （#{link_to '分報', user.times_url}）
     = render 'users/sns', user: user
   - if user.company.present? && user.company.logo.attached?
     = link_to company_path(user.company) do

--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -11,6 +11,11 @@
         span.a-help
           i.fas.fa-question
 .form-item
+  = f.label :times_url, class: 'a-form-label'
+  = f.text_field :times_url, class: 'a-text-input', placeholder: 'https://discord.gg/xhGP6etJBX'
+  .a-form-help
+    p Discord の分報チャンネルの招待 URL を入力。
+.form-item
   = f.label :github_account, class: 'a-form-label'
   .form-item__mention-input
     = f.text_field :github_account, class: 'a-text-input', placeholder: 'komagata', disabled: true

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,6 +50,7 @@ ja:
         blog_url: ブログURL
         github_account: GitHubアカウント
         discord_account: Discordアカウント
+        times_url: 分報URL
         password: パスワード
         password_confirmation: パスワード（確認）
         current_password: 現在のパスワード

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -206,6 +206,7 @@ muryou:
   name_kana: ムリョウ ノスケ
   discord_account: muryou#2222
   twitter_account: muryou
+  times_url: https://discord.gg/muryou-times
   facebook_url: http://www.facebook.com/muryou
   blog_url: http://muryou.org
   description: "無料の助です。趣味は野良犬剣法です。"
@@ -229,6 +230,7 @@ kensyu:
   discord_account: kensyu#3333
   github_account: kensyu
   twitter_account: kensyu
+  times_url: https://discord.gg/kensyu-times
   facebook_url: http://www.facebook.com/kensyu
   blog_url: http://kensyu.org
   company: company2
@@ -254,6 +256,7 @@ senpai:
   discord_account: senpai#4444
   github_account: senpai
   twitter_account: senpai
+  times_url: https://discord.gg/senpai-times
   facebook_url: http://www.facebook.com/senpai
   blog_url: http://senpai.org
   company: company2
@@ -276,6 +279,7 @@ kananashi: #name_kanaを持たないユーザー
   discord_account: kananashi#6666
   github_account: kananashi
   twitter_account: kananashi
+  times_url: https://discord.gg/kananashi-times
   facebook_url: http://www.facebook.com/kananashi
   blog_url: http://kananashi.org
   description: "読み方のカナが無いユーザーです"
@@ -297,6 +301,7 @@ osnashi: #osを持たないユーザー
   discord_account: osnashi#7777
   github_account: osnashi
   twitter_account: osnashi
+  times_url: https://discord.gg/osnashi-times
   facebook_url: http://www.facebook.com/osnashi
   blog_url: http://osnashi.org
   description: "OSが無いユーザーです"
@@ -317,6 +322,7 @@ jobseeker: #就活希望するユーザー
   discord_account: jobseeker#8888
   github_account: jobseeker
   twitter_account: jobseeker
+  times_url: https://discord.gg/jobseeker-times
   facebook_url: http://www.facebook.com/exmaple
   blog_url: http://example.org
   description: "フィヨルドからの就職希望してます！"
@@ -338,6 +344,7 @@ daimyo: # 大名エンジニアカレッジに通うユーザー
   discord_account: daimyo#9999
   github_account: daimyo
   twitter_account: daimyo
+  times_url: https://discord.gg/daimyo-times
   facebook_url: http://www.facebook.com/daimyo
   blog_url: http://example.org
   company: company4
@@ -358,6 +365,7 @@ nippounashi: # 日報を投稿していないユーザー
   name_kana: ニッポウ　ナシ
   discord_account: nippounashi#0001
   twitter_account: nippounashi
+  times_url: https://discord.gg/nippounashi-times
   facebook_url: http://www.facebook.com/nippounashi
   blog_url: http://nippounashiorg
   description: "日報がないユーザーです。"
@@ -380,6 +388,7 @@ with_hyphen:
   github_account: *login_name
   discord_account: with_hyphen#1234
   twitter_account: with_hyphen
+  times_url: https://discord.gg/with_hyphen-times
   facebook_url: http://www.facebook.com/with-hyphen
   blog_url: http://with-hyphen.org
   description: "ログインネームにハイフン(-)を利用しているユーザーです。"
@@ -401,6 +410,7 @@ sumi:
   github_account: sumi
   discord_account: sumi#1234
   twitter_account: sumi
+  times_url: https://discord.gg/sumi-times
   facebook_url: http://www.facebook.com/sumi
   blog_url: http://sumi.org
   description: "testユーザーです。"
@@ -424,6 +434,7 @@ nobu:
   github_account: nobu
   discord_account: nobu#1234
   twitter_account: nobu
+  times_url: https://discord.gg/nobu-times
   facebook_url: http://www.facebook.com/nobu
   blog_url: http://nobu.org
   description: "testユーザーです。"
@@ -445,6 +456,7 @@ rie:
   github_account: rie
   discord_account: rie#1234
   twitter_account: rie
+  times_url: https://discord.gg/rie-times
   facebook_url: http://www.facebook.com/rie
   blog_url: http://rie.org
   description: "testユーザーです。"
@@ -466,6 +478,7 @@ take:
   github_account: take
   discord_account: take#1234
   twitter_account: take
+  times_url: https://discord.gg/take-times
   facebook_url: http://www.facebook.com/take
   blog_url: http://take.org
   description: "testユーザーです。"
@@ -487,6 +500,7 @@ kunimi:
   github_account: kunimi
   discord_account: kunimi#1234
   twitter_account: kunimi
+  times_url: https://discord.gg/kunimi-times
   facebook_url: http://www.facebook.com/kunimi
   blog_url: http://kunimi.org
   description: "testユーザーです。"
@@ -508,6 +522,7 @@ tomo:
   github_account: tomo
   discord_account: tomo#1234
   twitter_account: tomo
+  times_url: https://discord.gg/tomo-times
   facebook_url: http://www.facebook.com/tomo
   blog_url: http://tomo.org
   description: "testユーザーです。"
@@ -529,6 +544,7 @@ akiyosi:
   github_account: akiyosi
   discord_account: akiyosi#1234
   twitter_account: akiyosi
+  times_url: https://discord.gg/akiyosi-times
   facebook_url: http://www.facebook.com/akiyosi
   blog_url: http://akiyosi.org
   description: "testユーザーです。"
@@ -550,6 +566,7 @@ tomomi:
   github_account: tomomi
   discord_account: tomomi#1234
   twitter_account: tomomi
+  times_url: https://discord.gg/tomomi-times
   facebook_url: http://www.facebook.com/tomomi
   blog_url: http://tomomi.org
   description: "testユーザーです。"
@@ -571,6 +588,7 @@ ogaoga:
   github_account: ogaoga
   discord_account: ogaoga#1234
   twitter_account: ogaoga
+  times_url: https://discord.gg/ogaoga-times
   facebook_url: http://www.facebook.com/ogaoga
   blog_url: http://ogaoga.org
   description: "testユーザーです。"
@@ -592,6 +610,7 @@ take8:
   github_account: take8
   discord_account: take8#1234
   twitter_account: take8
+  times_url: https://discord.gg/take8-times
   facebook_url: http://www.facebook.com/take8
   blog_url: http://take8.org
   description: "testユーザーです。"
@@ -615,6 +634,7 @@ fujiyasu:
   github_account: fujiyasu
   discord_account: fujiyasu#1234
   twitter_account: fujiyasu
+  times_url: https://discord.gg/fujiyasu-times
   facebook_url: http://www.facebook.com/fujiyasu
   blog_url: http://fujiyasu.org
   description: "testユーザーです。"

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -137,6 +137,7 @@ kimura:
   salt: zW3kQ9ubsxQQtzzzs4ap
   name: Kimura Tadasi
   name_kana: キムラ タダシ
+  discord_account: kimura#1234
   twitter_account: kimura
   facebook_url: http://www.facebook.com/kimura
   blog_url: http://kimura.org

--- a/db/migrate/20210728224220_add_times_url_to_users.rb
+++ b/db/migrate/20210728224220_add_times_url_to_users.rb
@@ -1,0 +1,5 @@
+class AddTimesUrlToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :times_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_27_073459) do
+ActiveRecord::Schema.define(version: 2021_07_28_224220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -463,6 +463,7 @@ ActiveRecord::Schema.define(version: 2021_07_27_073459) do
     t.string "unsubscribe_email_token"
     t.text "mentor_memo"
     t.string "discord_account"
+    t.string "times_url"
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -138,6 +138,7 @@ kimura:
   salt: zW3kQ9ubsxQQtzzzs4ap
   name: Kimura Tadasi
   name_kana: キムラ タダシ
+  discord_account: kimura#1234
   twitter_account: kimura
   facebook_url: http://www.facebook.com/kimura
   blog_url: http://kimura.org

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -208,6 +208,7 @@ muryou:
   name_kana: ムリョウ ノスケ
   discord_account: muryou#2222
   twitter_account: muryou
+  times_url: https://discord.gg/muryou-times
   facebook_url: http://www.facebook.com/muryou
   blog_url: http://muryou.org
   description: "無料の助です。趣味は野良犬剣法です。"
@@ -231,6 +232,7 @@ kensyu:
   discord_account: kensyu#3333
   github_account: kensyu
   twitter_account: kensyu
+  times_url: https://discord.gg/kensyu-times
   facebook_url: http://www.facebook.com/kensyu
   blog_url: http://kensyu.org
   company: company2
@@ -256,6 +258,7 @@ senpai:
   discord_account: senpai#4444
   github_account: senpai
   twitter_account: senpai
+  times_url: https://discord.gg/senpai-times
   facebook_url: http://www.facebook.com/senpai
   blog_url: http://senpai.org
   company: company2
@@ -278,6 +281,7 @@ kananashi: #name_kanaを持たないユーザー
   discord_account: kananashi#6666
   github_account: kananashi
   twitter_account: kananashi
+  times_url: https://discord.gg/kananashi-times
   facebook_url: http://www.facebook.com/kananashi
   blog_url: http://kananashi.org
   description: "読み方のカナが無いユーザーです"
@@ -299,6 +303,7 @@ osnashi: #osを持たないユーザー
   discord_account: osnashi#7777
   github_account: osnashi
   twitter_account: osnashi
+  times_url: https://discord.gg/osnashi-times
   facebook_url: http://www.facebook.com/osnashi
   blog_url: http://osnashi.org
   description: "OSが無いユーザーです"
@@ -319,6 +324,7 @@ jobseeker: #就活希望するユーザー
   discord_account: jobseeker#8888
   github_account: jobseeker
   twitter_account: jobseeker
+  times_url: https://discord.gg/jobseeker-times
   facebook_url: http://www.facebook.com/exmaple
   blog_url: http://example.org
   description: "フィヨルドからの就職希望してます！"
@@ -340,6 +346,7 @@ daimyo: # 大名エンジニアカレッジに通うユーザー
   discord_account: daimyo#9999
   github_account: daimyo
   twitter_account: daimyo
+  times_url: https://discord.gg/daimyo-times
   facebook_url: http://www.facebook.com/daimyo
   blog_url: http://example.org
   company: company4
@@ -360,6 +367,7 @@ nippounashi: # 日報を投稿していないユーザー
   name_kana: ニッポウ　ナシ
   discord_account: nippounashi#0001
   twitter_account: nippounashi
+  times_url: https://discord.gg/nippounashi-times
   facebook_url: http://www.facebook.com/nippounashi
   blog_url: http://nippounashiorg
   description: "日報がないユーザーです。"
@@ -382,6 +390,7 @@ with_hyphen:
   github_account: *login_name
   discord_account: with_hyphen#1234
   twitter_account: with_hyphen
+  times_url: https://discord.gg/with_hyphen-times
   facebook_url: http://www.facebook.com/with-hyphen
   blog_url: http://with-hyphen.org
   description: "ログインネームにハイフン(-)を利用しているユーザーです。"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -191,6 +191,18 @@ class UserTest < ActiveSupport::TestCase
     assert user.invalid?
   end
 
+  test 'times_url' do
+    user = users(:komagata)
+    user.times_url = 'https://discord.gg/xhGP6etJBX'
+    assert user.valid?
+    user.times_url = ''
+    assert user.valid?
+    user.times_url = 'xhGP6etJBX'
+    assert user.invalid?
+    user.times_url = 'https://example.gg/xhGP6etJBX'
+    assert user.invalid?
+  end
+
   test 'is valid name_kana' do
     user = users(:komagata)
     user.name_kana = 'コマガタ マサキ'

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -48,4 +48,11 @@ class CurrentUserTest < ApplicationSystemTestCase
     visit_with_auth edit_current_user_path, 'komagata'
     assert_alert_when_enter_one_dot_only_tag
   end
+
+  test 'update times url with wrong url' do
+    visit_with_auth '/current_user/edit', 'komagata'
+    fill_in 'user[times_url]', with: 'https://example.gg/xhGP6etJBX'
+    click_button '更新する'
+    assert_text '分報URLは「https://discord.gg/」で始まる招待URLを入力してください'
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -221,14 +221,12 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'show times link on user list page' do
     visit_with_auth '/users', 'hatsuno'
-    wait_for_vuejs
     has_no_link?(href: 'https://discord.gg/kimura-times')
 
     kimura = users(:kimura)
     kimura.update!(times_url: 'https://discord.gg/kimura-times')
 
     visit current_path
-    wait_for_vuejs
     has_link?(href: 'https://discord.gg/kimura-times')
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -218,4 +218,17 @@ class UsersTest < ApplicationSystemTestCase
     visit current_path
     assert has_link?(href: 'https://discord.gg/kimura-times')
   end
+
+  test 'show times link on user list page' do
+    visit_with_auth '/users', 'hatsuno'
+    wait_for_vuejs
+    has_no_link?(href: 'https://discord.gg/kimura-times')
+
+    kimura = users(:kimura)
+    kimura.update!(times_url: 'https://discord.gg/kimura-times')
+
+    visit current_path
+    wait_for_vuejs
+    has_link?(href: 'https://discord.gg/kimura-times')
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -207,4 +207,15 @@ class UsersTest < ApplicationSystemTestCase
       assert_text "#{last_month.year}年#{last_month.month}月"
     end
   end
+
+  test 'show times link on user page' do
+    visit_with_auth "/users/#{users(:kimura).id}", 'hatsuno'
+    assert has_no_link?(href: 'https://discord.gg/kimura-times')
+
+    kimura = users(:kimura)
+    kimura.update!(times_url: 'https://discord.gg/kimura-times')
+
+    visit current_path
+    assert has_link?(href: 'https://discord.gg/kimura-times')
+  end
 end


### PR DESCRIPTION
Ref: #2898 

各ユーザーのDiscordの分報チャンネルに簡単にアクセスできるようにするため、ユーザーのプロフィール項目に「分報URL」を追加し、ユーザーのプロフィールページ、ユーザー一覧ページに分報へのリンクが表示されるようにしました。

見た目についてはレビュー後machidaさんに修正をお願いする予定です。

### ユーザー一覧ページ`/users`

<img src="https://user-images.githubusercontent.com/350435/126959170-ec1a7dc6-a5a6-42a3-bd8b-ef7780c2cf47.png" width="371" height="316">

### ユーザーのプロフィールページ`/users/:id`

<img src="https://user-images.githubusercontent.com/350435/126801501-7b06966a-fabc-4ab6-877b-c06ceca10917.png" width="553" height="578">

### 登録情報変更ページ`/current_user/edit`

<img src="https://user-images.githubusercontent.com/350435/126959354-cf9783aa-8c9a-4bba-a369-c26d7d91b279.png" width="582" height="329">
