### PR TITLE
補完機能を使ってすぐにプレビューした時にsafariで表示されないバグを修正

### DIFF
--- a/app/javascript/user-icon-renderer.js
+++ b/app/javascript/user-icon-renderer.js
@@ -9,7 +9,7 @@ export default class {
     this.urls = await response.json()
     this._callbackFunc()
     Array.from(textareas).forEach((textarea) => {
-      textarea.addEventListener('change', () => {
+      textarea.addEventListener('input', () => {
         this._callbackFunc()
       })
     })


### PR DESCRIPTION
ref: #2958
[![Image from Gyazo](https://i.gyazo.com/e9ab5260d785f4c9aa92c48a426f7655.gif)](https://gyazo.com/e9ab5260d785f4c9aa92c48a426f7655)

テキストエリアのイベントが`change`だと補完機能を使った場合にsafariでイベント判定が出なかったため、`input`に修正しました。