### PR TITLE
通知に「全て別タブで開く」ボタンを追加

### DIFF
--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -95,7 +95,6 @@ export default {
       const links = document.querySelectorAll(
         '.header-dropdown__item-link.unconfirmed_link'
       )
-      console.log(links)
       links.forEach((link) => {
         window.open(link.href, '_target', 'noopener')
       })

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -20,7 +20,9 @@ li.header-links__item(v-bind:class='hasCountClass')
     .header-dropdown__inner.is-notification
       ul.header-dropdown__items
         li.header-dropdown__item(v-for='notification in notifications')
-          a.header-dropdown__item-link.unconfirmed_link(:href='notification.path')
+          a.header-dropdown__item-link.unconfirmed_link(
+            :href='notification.path'
+          )
             .header-notifications-item__body
               img.header-notifications-item__user-icon.a-user-icon(
                 :src='notification.sender.avatar_url'
@@ -36,7 +38,7 @@ li.header-links__item(v-bind:class='hasCountClass')
           ref='nofollow',
           data-method='post'
         ) 全て既読にする
-        button.header-dropdown__footer-link(@click="openUnconfirmedItems()") 全て別タブで開く
+        button.header-dropdown__footer-link(@click='openUnconfirmedItems()') 全て別タブで開く
 </template>
 <script>
 import dayjs from 'dayjs'

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -20,7 +20,7 @@ li.header-links__item(v-bind:class='hasCountClass')
     .header-dropdown__inner.is-notification
       ul.header-dropdown__items
         li.header-dropdown__item(v-for='notification in notifications')
-          a.header-dropdown__item-link(:href='notification.path')
+          a.header-dropdown__item-link.unconfirmed_link(:href='notification.path')
             .header-notifications-item__body
               img.header-notifications-item__user-icon.a-user-icon(
                 :src='notification.sender.avatar_url'
@@ -36,6 +36,7 @@ li.header-links__item(v-bind:class='hasCountClass')
           ref='nofollow',
           data-method='post'
         ) 全て既読にする
+        button.header-dropdown__footer-link(@click="openUnconfirmedItems()") 全て別タブで開く
 </template>
 <script>
 import dayjs from 'dayjs'
@@ -89,6 +90,15 @@ export default {
     },
     createdAtFromNow(createdAt) {
       return dayjs(createdAt).fromNow()
+    },
+    openUnconfirmedItems() {
+      const links = document.querySelectorAll(
+        '.header-dropdown__item-link.unconfirmed_link'
+      )
+      console.log(links)
+      links.forEach((link) => {
+        window.open(link.href, '_target', 'noopener')
+      })
     }
   }
 }


### PR DESCRIPTION
issue #2936 

# 概要
ヘッダーの通知ボタンに「全て別タブで開く」ボタンを実装しました。
このボタンを押すことで未読の物を全て別タブで開くことができます。

<img width="465" alt="貼り付けた画像_2021_07_26_11_38" src="https://user-images.githubusercontent.com/62867257/126925686-5cd71363-a73e-44d4-81cf-64955203b5cb.png">

通知から「全て別タブで開く」を押すと未読の物が別タブで開かれます。

![https://i.gyazo.com/5f420f19add141b1d51ed39b94f87eff.gif](https://i.gyazo.com/5f420f19add141b1d51ed39b94f87eff.gif)