### PR TITLE
Docsページの上部にコメント数を表示

### DIFF
--- a/app/assets/stylesheets/atoms/_a-meta.sass
+++ b/app/assets/stylesheets/atoms/_a-meta.sass
@@ -25,6 +25,15 @@
     .thread-list-item-meta__icon-link
       display: none
 
+a.a-meta
+  +hover-link
+  color: $muted-text
+  transition: all .2s ease-out
+  &:hover
+    color: $main
+  &.is-disabled
+    pointer-events: none
+
 .a-meta__label
   &::after
     content: ":"

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -55,8 +55,8 @@ header.page-header
                         = link_to @page.last_updated_user, class: 'a-user-name' do
                           | #{@page.last_updated_user.login_name}
                 .thread-header-metas__meta
-                  .a-meta
-                    - length = @page.comments.length
+                  - length = @page.comments.length
+                  a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
                     | コメント（
                     span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
                       = length

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -19,11 +19,6 @@ header.page-header
     article.thread.is-page
       .thread__inner.a-card
         header.thread-header.has-count
-          a.a-count-badge(href='#comments')
-            .a-count-badge__label
-              | コメント
-            .a-count-badge__value(class="#{@page.comments.empty? ? 'is-zero' : ''}")
-              = @page.comments.size
           .thread-header__row
             .thread-header-metas
               .thread-header-metas__start
@@ -59,6 +54,13 @@ header.page-header
                           image_class: 'thread-header__user-icon'
                         = link_to @page.last_updated_user, class: 'a-user-name' do
                           | #{@page.last_updated_user.login_name}
+                .thread-header-metas__meta
+                  .a-meta
+                    - length = @page.comments.length
+                    | コメント（
+                    span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
+                      = length
+                    | ）
               - if @page.slug.present?
                 .thread-header-metas__end
                   .thread-header-metas__meta

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -18,7 +18,12 @@ header.page-header
   .container
     article.thread.is-page
       .thread__inner.a-card
-        header.thread-header
+        header.thread-header.has-count
+          a.a-count-badge(href='#comments')
+            .a-count-badge__label
+              | コメント
+            .a-count-badge__value(class="#{@page.comments.empty? ? 'is-zero' : ''}")
+              = @page.comments.size
           .thread-header__row
             .thread-header-metas
               .thread-header-metas__start
@@ -107,4 +112,5 @@ header.page-header
           user: @page.user,
           link_class: 'thread__author-link',
           image_class: 'thread__author-icon'
+    a#comments.a-anchor
     #js-comments(data-commentable-id="#{@page.id}" data-commentable-type='Page' data-current-user-id="#{current_user.id}")

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -46,8 +46,8 @@ header.page-header
                         | 提出日
                       = l @report.published_at
                 .thread-header-metas__meta
-                  .a-meta
-                    - length = @report.comments.length
+                  - length = @report.comments.length
+                  a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
                     | コメント（
                     span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
                       = length

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -183,13 +183,13 @@ class PagesTest < ApplicationSystemTestCase
 
   test 'show comment count' do
     visit_with_auth "/pages/#{pages(:page1).id}", 'kimura'
-    assert_text "コメント\n0"
+    assert_text "コメント（\n0\n）"
 
     fill_in 'new_comment[description]', with: 'コメント数表示のテストです。'
     click_button 'コメントする'
     wait_for_vuejs
 
     visit current_path
-    assert_text "コメント\n1"
+    assert_text "コメント（\n1\n）"
   end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -180,4 +180,16 @@ class PagesTest < ApplicationSystemTestCase
     visit "/pages/#{slug}"
     assert_text 'slug付きテストページの本文'
   end
+
+  test 'show comment count' do
+    visit_with_auth "/pages/#{pages(:page1).id}", 'kimura'
+    assert_text "コメント\n0"
+
+    fill_in 'new_comment[description]', with: 'コメント数表示のテストです。'
+    click_button 'コメントする'
+    wait_for_vuejs
+
+    visit current_path
+    assert_text "コメント\n1"
+  end
 end


### PR DESCRIPTION
Ref: #2908

## 概要

Docsページ（`/pages/:slug_or_id`）の上部にコメント数の表示を追加しました。

暫定的にQ&Aの回答数の表示部分のHTMLを流用しています。見た目についてはレビュー後machidaさんに修正をお願いする予定です。

[前回のミーティング](https://github.com/fjordllc/bootcamp/wiki/%E3%81%B5%E3%82%8A%E3%81%8B%E3%81%88%E3%82%8A%E3%83%BB%E8%A8%88%E7%94%BB%E3%83%9F%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B02021%E5%B9%B407%E6%9C%8820,-21%E6%97%A5 "ふりかえり・計画ミーティング2021年07月20, 21日 · fjordllc/bootcamp Wiki")でVueではなくRails側で実装する方針となったため、コメント投稿直後はコメント数に反映されず、再読み込み後に正しいコメント数が表示されます（#2659）。

## スクリーンショット

<img src="https://user-images.githubusercontent.com/350435/127064295-65178fce-b9af-4a88-b034-31a0f19dc3fc.png" width="600" height="450">
