### PR TITLE
UsersテーブルからSlack関連情報を削除

### DIFF
--- a/db/migrate/20210727073459_remove_slack_account_and_slack_participation_from_users.rb
+++ b/db/migrate/20210727073459_remove_slack_account_and_slack_participation_from_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveSlackAccountAndSlackParticipationFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :slack_account, :string
+    remove_column :users, :slack_participation, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_171344) do
+ActiveRecord::Schema.define(version: 2021_07_27_073459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -432,7 +432,6 @@ ActiveRecord::Schema.define(version: 2021_06_07_171344) do
     t.string "github_account"
     t.boolean "adviser", default: false, null: false
     t.boolean "nda", default: true, null: false
-    t.string "slack_account"
     t.string "reset_password_token"
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
@@ -455,7 +454,6 @@ ActiveRecord::Schema.define(version: 2021_06_07_171344) do
     t.integer "prefecture_code"
     t.boolean "job_seeker", default: false, null: false
     t.string "github_id"
-    t.boolean "slack_participation", default: true, null: false
     t.boolean "github_collaborator", default: false, null: false
     t.string "name", default: "", null: false
     t.string "name_kana", default: "", null: false


### PR DESCRIPTION
ref: [#2744](https://github.com/fjordllc/bootcamp/issues/2744)

## やったこと
[Slack関連情報を削除 · Pull Request \#2957](https://github.com/fjordllc/bootcamp/pull/2957)の続きの作業です。
Usersテーブルから

- slack_account
- slack_participation

の2つのカラムを削除するmigrationを作成しました。

## 今後の方針
次回のリリース時に、[こちら](https://github.com/fjordllc/bootcamp/pull/2957/commits/c7bb2242cad890f06585e28deb6f177c9e8b35d8)で追加した`ignored_columns`の削除をして完了となります。