### PR TITLE
ヘルプページでアクティブとなるリンクをDocsからヘルプへ変更#2887

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -43,7 +43,7 @@ nav.global-nav
                 = Question.not_solved.count
             .global-nav-links__link-label Q&A
         li.global-nav-links__item
-          = link_to '/pages', class: "global-nav-links__link #{current_link(/^pages/)}" do
+          = link_to '/pages', class: "global-nav-links__link #{(@page&.slug != 'help') && current_link(/^pages/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-file
             .global-nav-links__link-label Docs
@@ -58,7 +58,7 @@ nav.global-nav
               i.fas.fa-fw.fa-beer
             .global-nav-links__link-label イベント
         li.global-nav-links__item
-          = link_to '/pages/334', class: "global-nav-links__link #{current_link(%r{^pages/334})}" do
+          = link_to '/pages/help', class: "global-nav-links__link #{(@page&.slug == 'help') && current_link(/^pages/)}" do
             .global-nav-links__link-icon
               i.fas.fa-hands-helping
             .global-nav-links__link-label ヘルプ


### PR DESCRIPTION
ref #2887

ヘルプトップページの際にアクティブとなるリンクをDocsからヘルプに変更しました。

## 変更前
![ヘルプのページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/127453823-fd1fc850-3980-4cc3-b4f2-f183312765f0.png)

## 変更後
![ヘルプのページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/127453909-db583a85-8637-42c7-bcc8-6b83c1778f44.png)
