### PR TITLE
Userモデルに設定していたignored_columnsを削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,6 @@ class User < ApplicationRecord
   include Taggable
   include Searchable
 
-  self.ignored_columns = %i[slack_account slack_participation]
-
   authenticates_with_sorcery!
   VALID_SORT_COLUMNS = %w[id login_name company_id updated_at created_at report comment asc desc].freeze
   AVATAR_SIZE = '88x88>'


### PR DESCRIPTION
ref: [#2744](https://github.com/fjordllc/bootcamp/issues/2744)

## やったこと
1. [UsersテーブルからSlack関連情報を削除 by FUGA0618 · Pull Request \#3039 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/pull/3039)
1. [Slack関連情報を削除 by FUGA0618 · Pull Request \#2957 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/pull/2957)

の続きです。
Userモデルに設定していた`ignored_columns`を削除しました。

Slack関連情報を削除するための、一連の作業はこれで完了です。