### PR TITLE
【メンター向け機能】左メニューの提出物ボタンに表示される数を未アサインの提出物数に変更

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/ClassLength:
     - app/models/notification_facade.rb
     - app/models/practice.rb
     - app/models/user.rb
+    - app/models/product.rb
 
 AllCops:
   Exclude:

--- a/app/controllers/api/products/unassigned_controller.rb
+++ b/app/controllers/api/products/unassigned_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class API::Products::UnassignedController < API::BaseController
+  before_action :require_staff_login_for_api
+  def index
+    @products = Product.unassigned.unchecked.not_wip.list.page(params[:page])
+    @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }
+    @latest_product_submitted_just_6days = @products.find { |product| product.elapsed_days == 6 }
+    @latest_product_submitted_over_7days = @products.find { |product| product.elapsed_days >= 7 }
+  end
+end

--- a/app/controllers/products/unassigned_controller.rb
+++ b/app/controllers/products/unassigned_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Products::UnassignedController < ApplicationController
+  before_action :require_staff_login
+  def index; end
+end

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .thread-list-item(:class='product.wip ? "is-wip" : ""')
-  .thread-list-item__strip-label(v-if='notResponded')
+  .thread-list-item__strip-label(v-if='notResponded || unassigned')
     .thread-list-item__elapsed-days.is-reply-warning.is-only-mentor(
       v-if='isLatestProductSubmittedJust5days'
     )
@@ -155,6 +155,9 @@ export default {
     },
     notResponded() {
       return location.pathname === '/products/not_responded'
+    },
+    unassigned() {
+      return location.pathname === '/products/unassigned'
     }
   }
 }

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -73,7 +73,8 @@ export default {
       return {
         unchecked: '未完了',
         'not-responded': '未返信',
-        'self-assigned': '自分の担当'
+        'self-assigned': '自分の担当',
+        unassigned: '未アサイン'
       }[this.selectedTab]
     },
     pagerProps() {
@@ -111,7 +112,10 @@ export default {
           return response.json()
         })
         .then((json) => {
-          if (location.pathname === '/products/not_responded') {
+          if (
+            location.pathname === '/products/not_responded' ||
+            location.pathname === '/products/unassigned'
+          ) {
             this.latestProductSubmittedJust5days =
               json.latest_product_submitted_just_5days
             this.latestProductSubmittedJust6days =

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -32,6 +32,16 @@ class Cache
       Rails.cache.delete 'not_responded_product_count'
     end
 
+    def unassigned_product_count
+      Rails.cache.fetch 'unassigned_product_count' do
+        Product.unassigned.unchecked.not_wip.count
+      end
+    end
+
+    def delete_unassigned_product_count
+      Rails.cache.delete 'unassigned_product_count'
+    end
+
     def self_assigned_product_count(current_user_id)
       Rails.cache.fetch("#{current_user_id}-self_assigned_product_count") do
         Product.self_assigned_product(current_user_id).unchecked.count

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -31,6 +31,7 @@ class Product < ApplicationRecord
         ->(user) { where(practice: user.practices_with_checked_product).checked.pluck(:id) }
 
   scope :unchecked, -> { where.not(id: Check.where(checkable_type: 'Product').pluck(:checkable_id)) }
+  scope :unassigned, -> { where(checker_id: nil) }
   scope :self_assigned_product, ->(current_user_id) { where(checker_id: current_user_id) }
 
   scope :wip, -> { where(wip: true) }

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -6,6 +6,7 @@ class ProductCallbacks
 
     Cache.delete_unchecked_product_count
     Cache.delete_not_responded_product_count
+    Cache.delete_unassigned_product_count
     Cache.delete_self_assigned_product_count(product.checker_id)
   end
 
@@ -35,6 +36,7 @@ class ProductCallbacks
 
     Cache.delete_unchecked_product_count
     Cache.delete_not_responded_product_count
+    Cache.delete_unassigned_product_count
     Cache.delete_self_assigned_product_count(product.checker_id)
   end
 

--- a/app/views/api/products/unassigned/index.json.jbuilder
+++ b/app/views/api/products/unassigned/index.json.jbuilder
@@ -1,0 +1,9 @@
+json.products do
+  json.array! @products do |product|
+    json.partial! "api/products/product", product: product
+  end
+end
+json.total_pages @products.page(1).total_pages
+json.latest_product_submitted_just_5days @latest_product_submitted_just_5days
+json.latest_product_submitted_just_6days @latest_product_submitted_just_6days
+json.latest_product_submitted_over_7days @latest_product_submitted_over_7days

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -30,9 +30,9 @@ nav.global-nav
             = link_to products_link, class: "global-nav-links__link #{current_link(/^products/)}" do
               .global-nav-links__link-icon
                 i.fas.fa-fw.fa-hand-paper
-              - if admin_or_mentor_login? && Cache.not_responded_product_count.positive?
+              - if admin_login? || mentor_login? && Cache.unassigned_product_count.positive?
                 .global-nav__item-count.a-notification-count.is-only-mentor
-                  = Cache.not_responded_product_count
+                  = Cache.unassigned_product_count
               .global-nav-links__link-label 提出物
         li.global-nav-links__item
           = link_to questions_path, class: "global-nav-links__link #{current_link(/^questions/)}" do

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -15,6 +15,12 @@
           - if Cache.not_responded_product_count.positive?
             .page-tabs__item-count.a-notification-count.is-only-mentor
               = Cache.not_responded_product_count
+      li.page-tabs__item
+        = link_to products_unassigned_index_path, class: "page-tabs__item-link #{current_link(/^products-unassigned-index/)}" do
+          | 未アサイン
+          - if Cache.unassigned_product_count.positive?
+            .page-tabs__item-count.a-notification-count
+              = Cache.unassigned_product_count
       li.page-tabs__item.is-only-mentor
         = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
           | 自分の担当

--- a/app/views/products/unassigned/index.html.slim
+++ b/app/views/products/unassigned/index.html.slim
@@ -1,0 +1,12 @@
+- title '未アサインの提出物'
+
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+
+.page-tools
+  = render 'products/tabs'
+
+#js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
     namespace :products do
       resources :unchecked, only: %i(index)
       resources :not_responded, only: %i(index)
+      resources :unassigned, only: %i(index)
       resources :self_assigned, only: %i(index)
       resource :checker, only: %i(update), controller: 'checker'
       resource :passed, only: %i(show), controller: 'passed'
@@ -150,6 +151,7 @@ Rails.application.routes.draw do
   namespace :products do
     resources :unchecked, only: %i(index)
     resources :not_responded, only: %i(index)
+    resources :unassigned, only: %i(index)
     resources :self_assigned, only: %i(index)
   end
   resources :products

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -390,6 +390,30 @@ class ProductsTest < ApplicationSystemTestCase
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: '編集後のユーザーメモです。'
     click_button '保存する'
-    assert_text '編集後のユーザーメモです。'
+  end
+
+  test 'can see unassigned-tab' do
+    visit_with_auth products_path, 'komagata'
+    assert find('.page-tabs__item-link', text: '未アサイン')
+  end
+
+  test 'can access unassigned products page after click unassigned-tab' do
+    visit_with_auth products_path, 'komagata'
+    find('.page-tabs__item-link', text: '未アサイン').click
+    assert find('h2.page-header__title', text: '未アサインの提出物')
+  end
+
+  test 'show unassigned products counter and can change counter after click assignee-button on unassigned-tab' do
+    visit_with_auth products_path, 'komagata'
+    unassigned_tab = find('.page-tabs__item-link', text: '未アサイン')
+    assert unassigned_tab.text.include? '55'
+
+    assignee_buttons = all('.a-button.is-block.is-secondary.is-sm', text: '担当する')
+    assignee_buttons.first(3).each(&:click)
+
+    unassigned_tab.click
+    wait_for_vuejs
+    unassigned_tab = find('.page-tabs__item-link.is-active', text: '未アサイン')
+    assert unassigned_tab.text.include? '52'
   end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -406,14 +406,18 @@ class ProductsTest < ApplicationSystemTestCase
   test 'show unassigned products counter and can change counter after click assignee-button on unassigned-tab' do
     visit_with_auth products_path, 'komagata'
     unassigned_tab = find('.page-tabs__item-link', text: '未アサイン')
-    assert unassigned_tab.text.include? '55'
+    within(unassigned_tab) do
+      assert_selector('.page-tabs__item-count.a-notification-count')
+    end
+
+    initial_counter = unassigned_tab.text
 
     assignee_buttons = all('.a-button.is-block.is-secondary.is-sm', text: '担当する')
     assignee_buttons.first(3).each(&:click)
 
     unassigned_tab.click
     wait_for_vuejs
-    unassigned_tab = find('.page-tabs__item-link.is-active', text: '未アサイン')
-    assert unassigned_tab.text.include? '52'
+    operated_counter = find('.page-tabs__item-link.is-active', text: '未アサイン').text
+    assert_not_equal initial_counter, operated_counter
   end
 end


### PR DESCRIPTION
ref: [#3048](https://github.com/fjordllc/bootcamp/issues/3048)

「[【メンター向け機能】提出物に未アサインタブを追加 by FUGA0618 · Pull Request \#3027 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/pull/3027)」が前提となるPRなので、向き先をそちらにしています。

## やったこと
左側メニューの「提出物」ボタンに表示されている提出物数は、現状ですと「未返信の提出物数」ですが、「**未アサインの提出物数**」に変更しています（メンターのみ表示される）。

<img width="797" alt="スクリーンショット 2021-07-30 21 49 12" src="https://user-images.githubusercontent.com/58870882/127661597-54a474f2-1780-46d5-8a33-c2f708bc5a47.png">