### PR TITLE
ニコニコカレンダー上で「今日」を強調

### DIFF
--- a/app/assets/stylesheets/blocks/user/_niconico-calendar.sass
+++ b/app/assets/stylesheets/blocks/user/_niconico-calendar.sass
@@ -52,7 +52,11 @@
   &.is-soso
     background-color: #fff9e8
   &.is-today
-    border: solid 2px #f11c52
+    .niconico-calendar__day-inner
+      border: dashed 2px $info
+    .niconico-calendar__day-label
+      font-weight: 600
+      color: $info
 
 .niconico-calendar__day-inner
   +block-link

--- a/app/assets/stylesheets/blocks/user/_niconico-calendar.sass
+++ b/app/assets/stylesheets/blocks/user/_niconico-calendar.sass
@@ -51,6 +51,8 @@
     background-color: #ecf3f7
   &.is-soso
     background-color: #fff9e8
+  &.is-today
+    border: solid 2px #f11c52
 
 .niconico-calendar__day-inner
   +block-link

--- a/app/javascript/niconico_calendar.vue
+++ b/app/javascript/niconico_calendar.vue
@@ -44,7 +44,7 @@
           td.niconico-calendar__day(
             v-for='date in week.value',
             :key='date.weekDay',
-            :class='emotionClass(date)'
+            :class='[emotionClass(date), todayClass(date)]'
           )
             a.niconico-calendar__day-inner(
               v-if='date.id',
@@ -74,6 +74,7 @@ export default {
       currentMonth: this.getCurrentMonth(),
       calendarYear: this.getCurrentYear(),
       calendarMonth: this.getCurrentMonth(),
+      today: this.getCurrentDay(),
       loaded: null
     }
   },
@@ -185,6 +186,14 @@ export default {
     emotionClass(date) {
       return date.emotion ? `is-${date.emotion}` : 'is-blank'
     },
+    todayClass(date) {
+      if (
+        this.calendarYear !== this.currentYear ||
+        this.calendarMonth !== this.currentMonth
+      )
+        return
+      if (date.date === this.today) return 'is-today'
+    },
     oldestMonth() {
       const firstReportDate = this.reports[0].reported_on
       const firstReportYear = Number(firstReportDate.split('-')[0])
@@ -205,6 +214,9 @@ export default {
     },
     getCurrentMonth() {
       return new Date().getMonth() + 1
+    },
+    getCurrentDay() {
+      return new Date().getDate()
     },
     reportDate(report) {
       return Number(report.reported_on.split('-')[2])

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -208,6 +208,23 @@ class UsersTest < ApplicationSystemTestCase
     end
   end
 
+  test 'show mark to today on niconico_calendar' do
+    today = Time.current
+    visit_with_auth root_path, 'hatsuno'
+    visit user_path(users(:hajime).id)
+    assert_selector '.niconico-calendar__day.is-today'
+    target_day = find('.niconico-calendar__day.is-today').text
+    assert_equal today.day.to_s, target_day
+  end
+
+  test 'not show mark to today on niconico_calendar' do
+    visit_with_auth root_path, 'hatsuno'
+    visit user_path(users(:hajime).id)
+    find('.niconico-calendar-nav__previous').click
+    wait_for_vuejs
+    assert_no_selector '.niconico-calendar__day.is-today'
+  end
+
   test 'show times link on user page' do
     visit_with_auth "/users/#{users(:kimura).id}", 'hatsuno'
     assert has_no_link?(href: 'https://discord.gg/kimura-times')


### PR DESCRIPTION
ref: [#2991](https://github.com/fjordllc/bootcamp/issues/2991)

## やったこと
ニコニコカレンダー上で「今日」が一目でわかるように印をつけました。

### 変更前
<img width="599" alt="スクリーンショット 2021-07-31 21 21 53" src="https://user-images.githubusercontent.com/58870882/127739727-c70b8ab9-f25b-4c3c-ba8a-9202160432bc.png">

### 変更後
<img width="599" alt="スクリーンショット 2021-08-02 20 38 04" src="https://user-images.githubusercontent.com/58870882/127856122-ba398740-37aa-4ae3-9e3c-17cecb71ff41.png">
