### PR TITLE
「未返信の提出物」のページングを削除

### DIFF
--- a/app/controllers/api/products/not_responded_controller.rb
+++ b/app/controllers/api/products/not_responded_controller.rb
@@ -7,7 +7,6 @@ class API::Products::NotRespondedController < API::BaseController
                 .not_responded_products
                 .list
                 .reorder_for_not_responded_products
-                .page(params[:page])
     @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }
     @latest_product_submitted_just_6days = @products.find { |product| product.elapsed_days == 6 }
     @latest_product_submitted_over_7days = @products.find { |product| product.elapsed_days >= 7 }

--- a/app/views/api/products/not_responded/index.json.jbuilder
+++ b/app/views/api/products/not_responded/index.json.jbuilder
@@ -3,7 +3,7 @@ json.products do
     json.partial! "api/products/product", product: product
   end
 end
-json.total_pages @products.page(1).total_pages
+json.total_pages 1
 json.latest_product_submitted_just_5days @latest_product_submitted_just_5days
 json.latest_product_submitted_just_6days @latest_product_submitted_just_6days
 json.latest_product_submitted_over_7days @latest_product_submitted_over_7days

--- a/test/system/product/not_responded_test.rb
+++ b/test/system/product/not_responded_test.rb
@@ -43,23 +43,17 @@ class ProductsTest < ApplicationSystemTestCase
     visit_with_auth '/products/not_responded', 'komagata'
 
     # 提出日の昇順で並んでいることを検証する
-    extract_all_title_on_display_page = -> { all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') } }
-    extract_all_author_on_display_page = ->  { all('.thread-list-item-meta .a-user-name').map(&:text) }
+    titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
+    names = all('.thread-list-item-meta .a-user-name').map(&:text)
+    assert_equal "#{newest_product.practice.title}の提出物", titles.first
+    assert_equal newest_product.user.login_name, names.first
+    assert_equal "#{oldest_product.practice.title}の提出物", titles.last
+    assert_equal oldest_product.user.login_name, names.last
+  end
 
-    assert_equal "#{newest_product.practice.title}の提出物",
-                 extract_all_title_on_display_page.call.first
-    assert_equal newest_product.user.login_name,
-                 extract_all_author_on_display_page.call.first
-
-    # ページングがあったら最後のページまで移動する
-    if has_selector?('.pagination')
-      find(class: %w[fas fa-angle-double-right], match: :first).find(:xpath, '..').click
-      wait_for_vuejs
-    end
-
-    assert_equal "#{oldest_product.practice.title}の提出物",
-                 extract_all_title_on_display_page.call.last
-    assert_equal oldest_product.user.login_name,
-                 extract_all_author_on_display_page.call.last
+  test 'show all not responded products without pagination' do
+    visit_with_auth '/products/not_responded', 'komagata'
+    assert_selector '.thread-list-item', count: Product.not_responded_products.size
+    assert_no_selector '.pagination'
   end
 end


### PR DESCRIPTION
Ref: #2998

## 概要

未返信の提出物ページ（`/products/not_responded`）は件数が51件以上の場合ページングされていましたが、一度に全件を俯瞰できるようにページングを削除しました。

また、ページングを前提としていた既存のテストも修正しました。
（参考：[提出物のfixturesの数を増やして、dbデータリセット直後からpagerを利用するように変更 · fjordllc/bootcamp@df3dbda (github.com)](https://github.com/fjordllc/bootcamp/commit/df3dbda978164eea29ff5ec2e2ade189048cdda4#diff-4fbd9c58467a4d217ba6e263050dce191910dc8b57ca07ab04905bee323d3f25)）

## 変更前

<img src="https://user-images.githubusercontent.com/350435/127769442-e7ed9db0-4ac1-40b0-b78a-f656497b3819.png" width="800" height="600">

## 変更後

<img src="https://user-images.githubusercontent.com/350435/127769466-58042410-6de5-4dd2-bc11-f8bb27def18b.png" width="800" height="600">
