### PR TITLE
就活中のユーザが日報、提出物、ポートフォリオをそれぞれ1件ずつ持つように開発データを変更#3010

### DIFF
--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -105,3 +105,16 @@ product<%= i %>:
   published_at: <%= (now - i).to_s(:db) %>
   created_at: <%= (now - i).to_s(:db) %>
 <% end %>
+
+product61:
+  practice: practice1
+  user: sumi
+  body: テストの提出物61です。
+  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
+
+product62:
+  practice: practice1
+  user: take8
+  body: テストの提出物62です。
+  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -231,3 +231,19 @@ report29:
   description: |-
     頑張れませんでした
   reported_on: <%= Time.now - 1.month - 1.day %>
+
+report30:
+  user: sumi
+  title: "365日目の日報"
+  emotion: 2
+  description: |-
+    Vue.jsが楽しかったです
+  reported_on: <%= Time.now - 1.month - 1.day %>
+
+report31:
+  user: take8
+  title: "366日目の日報"
+  emotion: 1
+  description: |-
+    エレベーターピッチ難しいです。
+  reported_on: <%= Time.now - 1.month - 1.day %>

--- a/db/fixtures/works.yml
+++ b/db/fixtures/works.yml
@@ -12,3 +12,16 @@ work2:
   repository: https://hatsunosapp.repository.com
   user: hatsuno
 
+work3:
+  title: sumi's app
+  description: "澄がつくったアプリです"
+  url: https://sumisapp.com
+  repository: https://sumisapp.repository.com
+  user: sumi
+
+work4:
+  title: take8's app
+  description: "武井がつくったアプリです"
+  url: https://take8sapp.com
+  repository: https://take8sapp.repository.com
+  user: take8


### PR DESCRIPTION
ref #3010
標記の通り修正いたしました。

## 変更前
日報、提出物、ポートフォリオのデータがなく、表示されていません。
![ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/127866482-2f796c4d-3634-4427-8dd2-136c67d9c98c.png)

## 変更後
日報、提出物、ポートフォリオを持つように変更したため、表示されるようになりました
![ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/127865251-079c78e8-ede1-4981-96ab-03e4b06fe00b.png)
