### PR TITLE
プラクティスに関連する日報が存在しない場合にアイコンを追加

### DIFF
--- a/app/assets/stylesheets/blocks/page/_o-empty-message.sass
+++ b/app/assets/stylesheets/blocks/page/_o-empty-message.sass
@@ -5,7 +5,6 @@
   color: $semi-muted-text
 
 .o-empty-message__icon
-  margin-bottom: 1rem
   +text-block(5rem 1)
 
 .o-empty-message__text

--- a/app/assets/stylesheets/blocks/page/_o-empty-message.sass
+++ b/app/assets/stylesheets/blocks/page/_o-empty-message.sass
@@ -5,6 +5,7 @@
   color: $semi-muted-text
 
 .o-empty-message__icon
+  margin-bottom: 1rem
   +text-block(5rem 1)
 
 .o-empty-message__text

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -26,5 +26,5 @@ header.page-header
       .o-empty-message
         .o-empty-message__icon
           i.far.fa-sad-tear
-      .o-empty-message
+      .o-empty-message__text
         | 日報はまだありません。

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -26,5 +26,5 @@ header.page-header
       .o-empty-message
         .o-empty-message__icon
           i.far.fa-sad-tear
-      .o-empty-message__text
-        | 日報はまだありません。
+        .o-empty-message__text
+          | 日報はまだありません。

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -23,5 +23,8 @@ header.page-header
         = render partial: 'reports/report', collection: @reports, as: :report
       = paginate @reports
     - else
-      .a-empty-message
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+      .o-empty-message
         | 日報はまだありません。


### PR DESCRIPTION
# やったこと

プラクティスに関連する日報が存在しない場合に「日報が存在しません。」の前にアイコンを表示するようにしました。
スタイルをa-empty～のものからo-empty～～のものに変えています
before: 
![image](https://user-images.githubusercontent.com/63279587/128210571-d995dae7-86a2-455d-ae76-59f5059b573b.png)

after: 
![image](https://user-images.githubusercontent.com/63279587/128208627-113a4f3b-3911-4180-a9ac-86df748b4f8d.png)

タスク: https://github.com/fjordllc/bootcamp/issues/3053

# 見てほしいこと

1. 表示の確認: 上記画像のように、きちんとアイコンが表示されているか ( http://localhost:3000/practices/841731997/reports )で確認できると思います
2. 使用しているスタイルの指定は適切か




