### PR TITLE
プラクティスメモの編集時に不要なダイアログが表示されないようにする

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -78,7 +78,7 @@
       .thread-comment-form__markdown.js-tabs__content(
         v-bind:class='{ "is-active": isActive("answer") }'
       )
-        textarea.a-text-input.js-warning-form.thread-comment-form__textarea(
+        textarea.a-text-input.thread-comment-form__textarea(
           v-model='description',
           :id='`js-comment-${this.answer.id}`',
           :data-preview='`#js-comment-preview-${this.answer.id}`',
@@ -107,6 +107,7 @@
 import Reaction from './reaction.vue'
 import MarkdownInitializer from './markdown-initializer'
 import TextareaInitializer from './textarea-initializer'
+import confirmUnload from './confirm-unload'
 import dayjs from 'dayjs'
 import ja from 'dayjs/locale/ja'
 dayjs.locale(ja)
@@ -115,6 +116,7 @@ export default {
   components: {
     reaction: Reaction
   },
+  mixins: [confirmUnload],
   props: {
     answer: { type: Object, required: true },
     currentUser: { type: Object, required: true },

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -56,7 +56,7 @@
       .thread-comment-form__markdown.js-tabs__content(
         v-bind:class='{ "is-active": isActive("comment") }'
       )
-        textarea.a-text-input.js-warning-form.thread-comment-form__textarea(
+        textarea.a-text-input.thread-comment-form__textarea(
           :id='`js-comment-${this.comment.id}`',
           :data-preview='`#js-comment-preview-${this.comment.id}`',
           v-model='description',
@@ -85,6 +85,7 @@
 import Reaction from './reaction.vue'
 import MarkdownInitializer from './markdown-initializer'
 import TextareaInitializer from './textarea-initializer'
+import confirmUnload from './confirm-unload'
 import autosize from 'autosize'
 import dayjs from 'dayjs'
 import ja from 'dayjs/locale/ja'
@@ -94,6 +95,7 @@ export default {
   components: {
     reaction: Reaction
   },
+  mixins: [confirmUnload],
   props: {
     comment: { type: Object, required: true },
     currentUser: { type: Object, required: true }

--- a/app/javascript/confirm-unload.js
+++ b/app/javascript/confirm-unload.js
@@ -1,0 +1,21 @@
+export default {
+  watch: {
+    editing(newEditing) {
+      if (newEditing) {
+        window.addEventListener('beforeunload', this.handleBeforeUnload, false)
+      } else {
+        window.removeEventListener(
+          'beforeunload',
+          this.handleBeforeUnload,
+          false
+        )
+      }
+    }
+  },
+  methods: {
+    handleBeforeUnload(event) {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+  }
+}

--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -28,7 +28,7 @@
       .thread-comment-form__markdown.is-editor.js-tabs__content(
         :class='{ "is-active": isActive("memo") }'
       )
-        textarea.a-text-input.js-warning-form.thread-comment-form__textarea(
+        textarea.a-text-input.thread-comment-form__textarea(
           :id='`js-practice-memo`',
           data-preview='#practice-memo-preview',
           v-model='memo',
@@ -51,8 +51,10 @@
 <script>
 import TextareaInitializer from './textarea-initializer'
 import MarkdownInitializer from './markdown-initializer'
+import confirmUnload from './confirm-unload'
 
 export default {
+  mixins: [confirmUnload],
   props: {
     practiceId: { type: String, required: true }
   },

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -118,7 +118,7 @@
             .form-item
               .a-form-label
                 | タイトル
-              input.a-text-input.js-warning-form(
+              input.a-text-input(
                 v-model='edited.title',
                 name='question[title]'
               )
@@ -138,7 +138,7 @@
                 .form-tabs-item__markdown.js-tabs__content(
                   :class='{ "is-active": isActive("question") }'
                 )
-                  textarea#js-question-content.a-text-input.js-warning-form.form-tabs-item__textarea(
+                  textarea#js-question-content.a-text-input.form-tabs-item__textarea(
                     v-model='edited.description',
                     data-preview='#js-question-preview',
                     name='question[description]'
@@ -172,6 +172,7 @@ import MarkdownInitializer from './markdown-initializer'
 import TextareaInitializer from './textarea-initializer'
 import Tags from './question_tags.vue'
 import UserIcon from './user-icon.vue'
+import confirmUnload from './confirm-unload'
 import dayjs from 'dayjs'
 import ja from 'dayjs/locale/ja'
 dayjs.locale(ja)
@@ -193,6 +194,7 @@ export default {
       }
     }
   },
+  mixins: [confirmUnload],
   props: {
     question: { type: Object, required: true },
     answerCount: { type: Number, required: true },

--- a/app/javascript/user_mentor_memo.vue
+++ b/app/javascript/user_mentor_memo.vue
@@ -35,7 +35,7 @@ section.a-card.is-memo.is-only-mentor
       .thread-comment-form__markdown.is-editor.js-tabs__content(
         :class='{ "is-active": isActive("memo") }'
       )
-        textarea.a-text-input.js-warning-form.thread-comment-form__textarea(
+        textarea.a-text-input.thread-comment-form__textarea(
           :id='`js-user-mentor-memo`',
           data-preview='#user-mentor-memo-preview',
           v-model='memo',
@@ -59,8 +59,10 @@ section.a-card.is-memo.is-only-mentor
 <script>
 import TextareaInitializer from './textarea-initializer'
 import MarkdownInitializer from './markdown-initializer'
+import confirmUnload from './confirm-unload'
 
 export default {
+  mixins: [confirmUnload],
   props: {
     userId: { type: String, required: true },
     productsMode: { type: Boolean, required: true }


### PR DESCRIPTION
## やったこと

#3044 でプラクティスメモの編集時に不要なダイアログが表示されていたので表示されないようにしました。合わせて本来の挙動である「編集中にページ離脱しようとするとダイアログが表示される」をプラクティスメモでもユーザーメモでも実現するようにしました。

![screen](https://user-images.githubusercontent.com/7645585/128348698-1d14c84a-dc3c-4e28-955d-979857d7d2a1.gif)

### 原因

`warning.js` で設定しているイベントリスナーが Vue.js の要素に設定されてしまっており、Vue.js 側での操作時 (保存する・キャンセル) には `submit` イベントが発火されないため、`beforeunload` イベントのイベントリスナーが適切に削除されていないことが原因です。この現象がプラクティスメモでは起きており、ユーザーメモで起きていないように見えるのは、`DOMContentLoaded` イベントの発火時にプラクティスメモのレンダリングだけが完了していて、そちらにだけイベントリスナーが設定されているためだと思われます。

https://github.com/fjordllc/bootcamp/blob/646ea49c3aa147a47a8ed7bec79b6b3dad4ca177/app/javascript/warning.js#L1-L2
https://github.com/fjordllc/bootcamp/blob/646ea49c3aa147a47a8ed7bec79b6b3dad4ca177/app/javascript/warning.js#L22-L25

### 対処

Vue.js のレンダリング完了は `DOMContentLoaded` では検知できないので `warning.js` の処理を `warning.js` でやるのではく Vue.js の中でやるようにしました。

### 推測

恐らくもともと HTML + JS で実装していたものを Vue.js に引っ越してきたのではないかと。そのときに `.js-warning-form` もそのまま一緒に引っ越されてきたのではないかと思います。これは後述の「Vue.js で .js-nantoka-kantoka を使っているところ」とも関連してきそうです。

## 相談したいこと

2 点ほどあります。

### Vue.js で .js-warning-form を使っている他のコンポーネント

恐らく他のコンポーネントの `.js-warning-form` のところもうまく動いていないと思われます。この PR の mixin で良さそうであれば横展開できると良いかもです。この PR で続きをやってもよければやります！

### Vue.js で .js-nantoka-kantoka を使っているところ

`.js-warning-form` と同じように、`.js-nantoka-kantoka` と `DOMContentLoaded` を使っているところはうまく動いていない可能性があります。別 issue として切り出して対応したほうが良いかもです。