### PR TITLE
this が使用できない問題を避けるために data では arrow function ではなく function を使用する

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -121,7 +121,7 @@ export default {
     hasCorrectAnswer: { type: Boolean, required: true },
     questionUser: { type: Object, required: true }
   },
-  data: () => {
+  data() {
     return {
       description: '',
       editing: false,

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -72,7 +72,7 @@ export default {
     questionUser: { type: Object, required: true },
     currentUser: { type: Object, required: true }
   },
-  data: () => {
+  data() {
     return {
       answers: [],
       description: '',

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -98,7 +98,7 @@ export default {
     comment: { type: Object, required: true },
     currentUser: { type: Object, required: true }
   },
-  data: () => {
+  data() {
     return {
       description: '',
       editing: false,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -77,7 +77,7 @@ export default {
     currentUserId: { type: String, required: true },
     currentUser: { type: Object, required: true }
   },
-  data: () => {
+  data() {
     return {
       comments: [],
       description: '',

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -59,7 +59,7 @@ export default {
     courseId: { type: String, required: true },
     currentUser: { type: Object, required: true }
   },
-  data: () => {
+  data() {
     return {
       categories: null,
       learnings: null

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -43,7 +43,7 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 dayjs.extend(relativeTime)
 
 export default {
-  data: () => {
+  data() {
     return {
       notifications: []
     }

--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -56,7 +56,7 @@ export default {
   props: {
     practiceId: { type: String, required: true }
   },
-  data: () => {
+  data() {
     return {
       memo: '',
       tab: 'memo',

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -34,7 +34,7 @@ export default {
     currentUserId: { type: String, required: true },
     questionId: { type: String, required: true }
   },
-  data: () => {
+  data() {
     return {
       question: null,
       currentUser: null,

--- a/app/javascript/reaction.vue
+++ b/app/javascript/reaction.vue
@@ -38,7 +38,7 @@ export default {
     currentUser: { type: Object, required: true },
     reactionableId: { type: String, required: true }
   },
-  data: () => {
+  data() {
     return {
       availableEmojis: [],
       dropdown: false

--- a/app/javascript/recent_reports.vue
+++ b/app/javascript/recent_reports.vue
@@ -15,7 +15,7 @@ export default {
   components: {
     'recent-report': RecentReport
   },
-  data: () => {
+  data() {
     return {
       reports: []
     }

--- a/app/javascript/reservations.vue
+++ b/app/javascript/reservations.vue
@@ -68,7 +68,7 @@ export default {
     reservationsEndOfThisMonth: { type: String, required: true },
     currentUserId: { type: String, required: true }
   },
-  data: () => {
+  data() {
     return {
       thisMonths: [],
       reservation: [],

--- a/app/javascript/user_mentor_memo.vue
+++ b/app/javascript/user_mentor_memo.vue
@@ -65,7 +65,7 @@ export default {
     userId: { type: String, required: true },
     productsMode: { type: Boolean, required: true }
   },
-  data: () => {
+  data() {
     return {
       memo: '',
       tab: 'memo',


### PR DESCRIPTION
> data プロパティでアロー関数を使用する場合は、this はコンポーネントインスタンスになりませんが、それでも関数の第 1 引数としてアクセスすることができます:
> https://jp.vuejs.org/v2/api/#data

`data` にアロー関数を使うと `this` が使えなくなってしまうので、使いたいときに `this` を使えるよう普通の関数にしておくと良いかなと思いました。`data` にアロー関数を使っていてかつ `this` を使っているところは今のところはないので、これによって不具合が発生しているとかは特にないかなと思います。