### PR TITLE
新規Doc作成の文言変更

### DIFF
--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -9,7 +9,7 @@ header.page-header
           li.page-header-actions__item
             = link_to [:new, :page], class: 'a-button is-md is-secondary is-block' do
               i.fas.fa-plus
-              | 新規Doc作成
+              | Doc作成
 
 - if params[:tag]
   .page-optional-header

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -9,7 +9,7 @@ header.page-header
           li.page-header-actions__item
             = link_to [:new, :page], class: 'a-button is-md is-secondary is-block' do
               i.fas.fa-plus
-              | 新規Doc作成
+              | Doc作成
           li.page-header-actions__item
             = link_to :pages, class: 'a-button is-md is-secondary is-block' do
               | Docs

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class Notification::PagesTest < ApplicationSystemTestCase
   test 'Only students and mentors are notified' do
     visit_with_auth '/pages', 'komagata'
-    click_link '新規Doc作成'
+    click_link 'Doc作成'
 
     within('.form') do
       fill_in('page[title]', with: 'DocsTest')

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -32,7 +32,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
 
   test "don't notify when page is WIP" do
     visit_with_auth '/pages', 'komagata'
-    click_link '新規Doc作成'
+    click_link 'Doc作成'
 
     within('.form') do
       fill_in('page[title]', with: 'DocsTest')

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -69,7 +69,7 @@ class PagesTest < ApplicationSystemTestCase
 
   test 'search pages by tag' do
     visit_with_auth pages_url, 'kimura'
-    click_on '新規Doc作成'
+    click_on 'Doc作成'
     tag_list = ['tag1',
                 'ドットつき.タグ',
                 'ドットが.2つ以上の.タグ',


### PR DESCRIPTION
 -  Doc一覧ページ(http://localhost:3000/pages) の"新規Doc作成"を"Doc作成"に変更

![image](https://user-images.githubusercontent.com/168265/128191709-816bf2d7-b2ba-4a7c-9180-bf1677a37f50.png)

↓

![image](https://user-images.githubusercontent.com/168265/128191811-d3e45e4b-f134-44de-850b-d8e840806d8c.png)

 - 個別Docの閲覧ページ(例 http://localhost:3000/pages/650268778) の"新規Doc作成"を"Doc作成"に変更

![スクリーンショット 2021-08-07 1 05 37](https://user-images.githubusercontent.com/77760087/128540525-b9e22fbe-f22e-421c-a409-3cfb8e9bb476.png)


↓

![スクリーンショット 2021-08-07 1 04 58](https://user-images.githubusercontent.com/77760087/128540473-40b57201-c411-4728-ac66-181db8e01f46.png)

 - 文言の変更に伴いtestの文言も変更