### PR TITLE
提出物のページの上部にコメント数を表示

### DIFF
--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -74,6 +74,14 @@ header.page-header
                           time.a-meta__value(datetime="#{@product.updated_at.to_datetime}")
                             = l @product.updated_at
 
+                    .thread-header-metas__meta
+                      .a-meta
+                        - length = @product.comments.length
+                        | コメント（
+                        span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
+                          = length
+                        | ）
+
               .thread-header__row
                 h1.thread-header-title(class="#{@product.wip? ? 'is-wip' : ''}")
                   - if @product.wip?

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -75,8 +75,8 @@ header.page-header
                             = l @product.updated_at
 
                     .thread-header-metas__meta
-                      .a-meta
-                        - length = @product.comments.length
+                      - length = @product.comments.length
+                      a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
                         | コメント（
                         span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
                           = length

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -392,4 +392,11 @@ class ProductsTest < ApplicationSystemTestCase
     click_button '保存する'
     assert_text '編集後のユーザーメモです。'
   end
+
+  test 'show number of comments' do
+    visit_with_auth "/products/#{products(:product1).id}", 'komagata'
+    within(:css, '.is-emphasized') do
+      assert_text '2'
+    end
+  end
 end


### PR DESCRIPTION
isuue #2905 
提出物のページの上部にコメント数を表示いたしました。

before

![スクリーンショット 2021-08-08 0 15 26](https://user-images.githubusercontent.com/77760087/128605079-6b6f7529-0b68-4ced-ab66-691f9a8e1d35.png)

after

![スクリーンショット 2021-08-08 0 14 51](https://user-images.githubusercontent.com/77760087/128605084-b6162246-0fbe-4150-84bd-6de4602fe549.png)

