### PR TITLE
textarea の表示時には autosize が実行されないので明示的に autosize.update を実行する

### DIFF
--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -19,7 +19,17 @@ export default class {
       return null
     }
 
+    // autosize
     autosize(textareas)
+    textareas.forEach((textarea) => {
+      new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.target.scrollHeight !== 0) {
+            autosize.update(entry.target)
+          }
+        })
+      }).observe(textarea)
+    })
 
     // auto-completion
     const emoji = new TextareaAutocomplteEmoji()


### PR DESCRIPTION
## やったこと

#3085 `v-show` で制御されているテキストエリアが表示されたときに `autosize` が実行されないので、`IntersectionObserver` で表示されたことを検知して `autosize` を明示的に行うようにしました。
## スクリーンキャスト

### before

![screen](https://user-images.githubusercontent.com/7645585/128442528-d789a899-5d3c-40ea-b0e0-50d9821a569d.gif)

### after

![screen](https://user-images.githubusercontent.com/7645585/128442591-443bdbd8-1c45-4b46-8433-d3871a8cb980.gif)