### PR TITLE
卒業生でもホーム画面、プロフィール画面でカレンダーを表示

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -46,7 +46,7 @@ header.page-header
             = render 'users/grass', user: current_user
           - if current_user.github_account.present?
             = render 'users/github_grass', user: current_user
-          - if current_user.student? && current_user.graduated_on.blank?
+          - if current_user.student?
             #js-niconico_calendar(data-user-id="#{current_user.id}")
           - if current_user.mentor?
             = render 'users/sad_emotion_report', users: User.students_and_trainees

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -77,7 +77,7 @@ header.page-header
             = render 'users/github_grass', user: @user
           - if @user.active_practices.present?
             = render '/users/practices/active_practices', user: @user
-          - if @user.student? && @user.graduated_on.blank?
+          - if @user.student?
             #js-niconico_calendar(data-user-id="#{@user.id}")
           - if @user.completed_practices.present?
             - cache [@user, @completed_learnings] do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -53,9 +53,9 @@ class HomeTest < ApplicationSystemTestCase
     assert_text 'ニコニコカレンダー'
   end
 
-  test 'not show the Nico Nico calendar for graduates' do
+  test 'show the Nico Nico calendar for graduates' do
     visit_with_auth '/', 'sotugyou'
-    assert_no_text 'ニコニコカレンダー'
+    assert_text 'ニコニコカレンダー'
   end
 
   test 'not show the Nico Nico calendar for administrators' do


### PR DESCRIPTION
# 対象issue
#2983

# やったこと
卒業生でもカレンダーを表示すること
プロフィール画面
![image](https://user-images.githubusercontent.com/63279587/128586447-3ec7407f-a63b-4f33-acd8-84a6ca504be5.png)

ホーム画面
![image](https://user-images.githubusercontent.com/63279587/128586466-560917d6-7515-4827-a207-eb732f68e6ac.png)

# 確認してほしい事
- きちんと表示が変わっているか
## 確認手順
1. 卒業生アカウント(id: sotugyou)でログイン
2. ダッシュボード( http://localhost:3000/ )にてニコニコカレンダーが表示されることを確認
3. そのまま、もしくは他のアカウントで再度ログインしてsotugyouさんのプロフィール( http://localhost:3000/users/609827778 )に移動
4. ニコニコカレンダーが表示されることを確認

- スタイル等崩れていないか
- コードにおかしなところがないか

よろしくお願いいたします。