### PR TITLE
お知らせページの上部にコメント数を表示

### DIFF
--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -1,6 +1,6 @@
 .thread
   .thread__inner.a-card
-    header.thread-header
+    header.thread-header.has-count
       .thread-header__row
         .thread-header-metas
           .thread-header-metas__start
@@ -16,6 +16,13 @@
                 span.a-meta__label
                   | 書いた日
                 = l announcement.updated_at
+            .thread-header-metas__meta
+              - length = @announcement.comments.length
+              a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
+                | コメント（
+                span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
+                  = length
+                |）
       .thread-header__row
         h1.thread-header-title(class="#{announcement.wip? ? 'is-wip' : ''}")
           = announcement.title

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -22,7 +22,7 @@
                 | コメント（
                 span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
                   = length
-                |）
+                | ）
       .thread-header__row
         h1.thread-header-title(class="#{announcement.wip? ? 'is-wip' : ''}")
           = announcement.title

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -17,5 +17,6 @@ header.page-header
 .page-body
   .container.is-lg
     = render 'announcement', announcement: @announcement
+    a#comments.a-anchor
     #js-comments(data-commentable-id="#{@announcement.id}" data-commentable-type='Announcement' data-current-user-id="#{current_user.id}")
     = render 'footprints/footprints', footprints: @footprints

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -176,4 +176,16 @@ class AnnouncementsTest < ApplicationSystemTestCase
     visit_with_auth "/announcements/#{announcements(:announcement1).id}", 'kimura'
     assert_text 'komagata (Komagata Masaki)'
   end
+
+  test 'show comment count' do
+    visit_with_auth "/announcements/#{announcements(:announcement1).id}", 'kimura'
+    assert_text "コメント（\n1\n）"
+
+    fill_in 'new_comment[description]', with: 'コメント数表示のテストです。'
+    click_button 'コメントする'
+    wait_for_vuejs
+
+    visit current_path
+    assert_text "コメント（\n2\n）"
+  end
 end


### PR DESCRIPTION
ref #2906 

お知らせ個別ページの上部にコメント数を表示しました。
当issueとしてはDoc個別ページ(#3034)と同様にRails側で実装するという方針にしております。

また、デザインについてはレビュー後machidaさんに修正をお願いする予定です。

## 変更前
![お知らせ1___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/128627440-0cc36532-9132-43fb-97c5-86541af88c98.png)

## 変更後
![お知らせ1___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/128627448-cd038e7b-0273-4d15-8161-2ba93c8149fe.png)
