### PR TITLE
提出物に提出者最終コメント日時とメンター最終コメント日時を追加する

### DIFF
--- a/app/assets/stylesheets/atoms/_a-user-name.sass
+++ b/app/assets/stylesheets/atoms/_a-user-name.sass
@@ -2,6 +2,7 @@
   color: $muted-text
   font-size: .8125rem
   line-height: 1.4
+  white-space: nowrap
 
 a.a-user-name
   +hover-link

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -37,19 +37,15 @@
     color: $reversal-text
     border-color: #b50f38
 
-
 .thread-list-item__inner
   +position(relative)
   padding-left: 3.75rem
   +media-breakpoint-down(sm)
     padding-left: 3rem
-  .thread-list-item.has-assigned &
-    +media-breakpoint-up(md)
-      padding-right: 8.75rem
 
 .thread-list-item__assignee
   +media-breakpoint-up(md)
-    +position(absolute, right 0, top 0)
+    +position(absolute, right -.5rem, top -.25rem)
     width: 8rem
   +media-breakpoint-down(sm)
     margin-top: .75rem
@@ -118,14 +114,19 @@
     opacity: .6
 
 .thread-list-item__row-separator
-  // TODO resetに移す
-  border: none
-  margin-bottom: .25rem
   border-top: dashed 1px $border
+  height: 1px
+  +media-breakpoint-up(md)
+    +margin(vertical, .5rem)
+  +media-breakpoint-down(sm)
+    +margin(vertical, .75rem .25rem)
 
 .thread-list-item__row
   &:not(:first-child)
     margin-top: .25rem
+  .thread-list-item.has-assigned &:first-child
+    +media-breakpoint-up(md)
+      padding-right: 8.5rem
 
 .thread-list-item__show-user-detail
   +position(absolute, top 0)

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
-.thread-comments#comments(v-if='loaded === false')
+#comments.thread-comments(v-if='loaded === false')
   commentPlaceholder(v-for='num in placeholderCount', :key='num')
-.thread-comments#comments(v-else)
+#comments.thread-comments(v-else)
   comment(
     v-for='(comment, index) in comments',
     :key='comment.id',

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
-.thread-comments(v-if='loaded === false')
+.thread-comments#comments(v-if='loaded === false')
   commentPlaceholder(v-for='num in placeholderCount', :key='num')
-.thread-comments(v-else)
+.thread-comments#comments(v-else)
   comment(
     v-for='(comment, index) in comments',
     :key='comment.id',

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.thread-list-item(:class='product.wip ? "is-wip" : ""')
+.thread-list-item.has-assigned(:class='product.wip ? "is-wip" : ""')
   .thread-list-item__strip-label(v-if='notResponded || unassigned')
     .thread-list-item__elapsed-days.is-reply-warning.is-only-mentor(
       v-if='isLatestProductSubmittedJust5days'
@@ -29,56 +29,28 @@
           .thread-list-item-meta__items
             .thread-list-item-meta__item
               a.a-user-name(:href='product.user.url') {{ product.user.login_name }}
+      .thread-list-item__row
+        .thread-list-item-meta
+          .thread-list-item-meta__items
             .thread-list-item-meta__item(v-if='product.wip')
               .a-meta 提出物作成中
             .thread-list-item-meta__item(v-else-if='product.published_at')
-              time.a-meta(datetime='product.published_at_date_time')
+              time.a-meta
                 span.a-meta__label 提出日
                 | {{ product.published_at }}
             .thread-list-item-meta__item(v-else)
-              time.a-meta(datetime='product.created_at_date_time')
+              time.a-meta
                 span.a-meta__label 提出日
                 | {{ product.created_at }}
-            time.a-meta(
-              v-if='product.updated_at',
-              datetime='product.updated_at_date_time'
-            )
-              span.a-meta__label 更新
-              | {{ product.updated_at }}
-            .thread-list-item-meta__item(
-              v-if='product.self_last_comment_at_date_time && product.mentor_last_comment_at_date_time'
-            )
+            .thread-list-item-meta__item
               time.a-meta(
-                v-if='product.self_last_comment_at_date_time > product.mentor_last_comment_at_date_time',
-                datetime='product.self_last_comment_at_date_time'
+                v-if='product.updated_at',
               )
-                span.a-meta__label.self_comment 最終コメント(提出者)
-                | {{ product.self_last_comment_at }}
-              time.a-meta(
-                v-if='product.self_last_comment_at_date_time < product.mentor_last_comment_at_date_time',
-                datetime='product.mentor_last_comment_at_date_time'
-              )
-                span.a-meta__label.mentor_comment 最終コメント(メンター)
-                | {{ product.mentor_last_comment_at }}
+                span.a-meta__label 更新
+                | {{ product.updated_at }}
 
-            .thread-list-item-meta__item(
-              v-else-if='product.self_last_comment_at_date_time || product.mentor_last_comment_at_date_time'
-            )
-              time.a-meta(
-                v-if='product.self_last_comment_at_date_time',
-                datetime='product.self_last_comment_at_date_time'
-              )
-                span.a-meta__label.self_comment 最終コメント(提出者)
-                | {{ product.self_last_comment_at }}
-              time.a-meta(
-                v-else-if='product.mentor_last_comment_at_date_time',
-                datetime='product.mentor_last_comment_at_date_time'
-              )
-                span.a-meta__label.mentor_comment 最終コメント(メンター)
-                | {{ product.mentor_last_comment_at }}
-
+      hr.thread-list-item__row-separator(v-if='product.comments.size > 0')
       .thread-list-item__row(v-if='product.comments.size > 0')
-        hr.thread-list-item__row-separator
         .thread-list-item-meta
           .thread-list-item-meta__items
             .thread-list-item-meta__item
@@ -98,10 +70,37 @@
                       :src='user.avatar_url',
                       :class='[roleClass, daimyoClass]'
                     )
-                time.a-meta(
-                  datetime='product.comments.last_created_at_date_time'
-                )
-                  | 〜 {{ product.comments.last_created_at }}
+
+            .thread-list-item-meta__item(
+              v-if='product.self_last_comment_at_date_time && product.mentor_last_comment_at_date_time'
+            )
+              time.a-meta(
+                v-if='product.self_last_comment_at_date_time > product.mentor_last_comment_at_date_time'
+              )
+                | 〜 {{ product.self_last_comment_at }}（
+                strong
+                  | 提出者
+                | ）
+              time.a-meta(
+                v-if='product.self_last_comment_at_date_time < product.mentor_last_comment_at_date_time'
+              )
+                | 〜 {{ product.mentor_last_comment_at }}（メンター）
+
+            .thread-list-item-meta__item(
+              v-else-if='product.self_last_comment_at_date_time || product.mentor_last_comment_at_date_time'
+            )
+              time.a-meta(
+                v-if='product.self_last_comment_at_date_time'
+              )
+                | 〜 {{ product.self_last_comment_at }}（
+                strong
+                  | 提出者
+                |）
+              time.a-meta(
+                v-else-if='product.mentor_last_comment_at_date_time'
+              )
+                | 〜 {{ product.mentor_last_comment_at }}（メンター）
+
     .stamp.stamp-approve(v-if='product.checks.size > 0')
       h2.stamp__content.is-title 確認済
       time.stamp__content.is-created-at {{ product.checks.last_created_at }}

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -48,20 +48,32 @@
             .thread-list-item-meta__item(
               v-if='product.self_last_comment_at_date_time && product.mentor_last_comment_at_date_time'
             )
-              time.a-meta(v-if='product.self_last_comment_at_date_time > product.mentor_last_comment_at_date_time' datetime='product.self_last_comment_at_date_time')
+              time.a-meta(
+                v-if='product.self_last_comment_at_date_time > product.mentor_last_comment_at_date_time',
+                datetime='product.self_last_comment_at_date_time'
+              )
                 span.a-meta__label.self_comment 最終コメント(提出者)
                 | {{ product.self_last_comment_at }}
-              time.a-meta(v-if='product.self_last_comment_at_date_time < product.mentor_last_comment_at_date_time' datetime='product.mentor_last_comment_at_date_time')
+              time.a-meta(
+                v-if='product.self_last_comment_at_date_time < product.mentor_last_comment_at_date_time',
+                datetime='product.mentor_last_comment_at_date_time'
+              )
                 span.a-meta__label.mentor_comment 最終コメント(メンター)
                 | {{ product.mentor_last_comment_at }}
-             
+
             .thread-list-item-meta__item(
               v-else-if='product.self_last_comment_at_date_time || product.mentor_last_comment_at_date_time'
             )
-              time.a-meta(v-if='product.self_last_comment_at_date_time' datetime='product.self_last_comment_at_date_time')
+              time.a-meta(
+                v-if='product.self_last_comment_at_date_time',
+                datetime='product.self_last_comment_at_date_time'
+              )
                 span.a-meta__label.self_comment 最終コメント(提出者)
                 | {{ product.self_last_comment_at }}
-              time.a-meta(v-else-if='product.mentor_last_comment_at_date_time' datetime='product.mentor_last_comment_at_date_time')
+              time.a-meta(
+                v-else-if='product.mentor_last_comment_at_date_time',
+                datetime='product.mentor_last_comment_at_date_time'
+              )
                 span.a-meta__label.mentor_comment 最終コメント(メンター)
                 | {{ product.mentor_last_comment_at }}
 

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -43,9 +43,7 @@
                 span.a-meta__label 提出日
                 | {{ product.created_at }}
             .thread-list-item-meta__item
-              time.a-meta(
-                v-if='product.updated_at',
-              )
+              time.a-meta(v-if='product.updated_at')
                 span.a-meta__label 更新
                 | {{ product.updated_at }}
 
@@ -89,16 +87,12 @@
             .thread-list-item-meta__item(
               v-else-if='product.self_last_comment_at_date_time || product.mentor_last_comment_at_date_time'
             )
-              time.a-meta(
-                v-if='product.self_last_comment_at_date_time'
-              )
+              time.a-meta(v-if='product.self_last_comment_at_date_time')
                 | 〜 {{ product.self_last_comment_at }}（
                 strong
                   | 提出者
-                |）
-              time.a-meta(
-                v-else-if='product.mentor_last_comment_at_date_time'
-              )
+                | ）
+              time.a-meta(v-else-if='product.mentor_last_comment_at_date_time')
                 | 〜 {{ product.mentor_last_comment_at }}（メンター）
 
     .stamp.stamp-approve(v-if='product.checks.size > 0')

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -45,6 +45,14 @@
             )
               span.a-meta__label 更新
               | {{ product.updated_at }}
+            .thread-list-item-meta__item(v-if='product.self_last_comment_at_date_time')
+              time.a-date(datetime='product.self_last_comment_at_date_time')
+                span.a-date__label 提出者最終コメント
+                | {{ product.self_last_comment_at }}
+            .thread-list-item-meta__item(v-if='product.mentor_last_comment_at_date_time')
+              time.a-date(datetime='product.mentor_last_comment_at_date_time')
+                span.a-date__label メンター最終コメント
+                | {{ product.mentor_last_comment_at }}
 
       .thread-list-item__row(v-if='product.comments.size > 0')
         hr.thread-list-item__row-separator

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -48,14 +48,14 @@
             .thread-list-item-meta__item(
               v-if='product.self_last_comment_at_date_time'
             )
-              time.a-date(datetime='product.self_last_comment_at_date_time')
-                span.a-date__label 提出者最終コメント
+              time.a-meta(datetime='product.self_last_comment_at_date_time')
+                span.a-meta__label 提出者最終コメント
                 | {{ product.self_last_comment_at }}
             .thread-list-item-meta__item(
               v-if='product.mentor_last_comment_at_date_time'
             )
-              time.a-date(datetime='product.mentor_last_comment_at_date_time')
-                span.a-date__label メンター最終コメント
+              time.a-meta(datetime='product.mentor_last_comment_at_date_time')
+                span.a-meta__label メンター最終コメント
                 | {{ product.mentor_last_comment_at }}
 
       .thread-list-item__row(v-if='product.comments.size > 0')

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -45,11 +45,15 @@
             )
               span.a-meta__label 更新
               | {{ product.updated_at }}
-            .thread-list-item-meta__item(v-if='product.self_last_comment_at_date_time')
+            .thread-list-item-meta__item(
+              v-if='product.self_last_comment_at_date_time'
+            )
               time.a-date(datetime='product.self_last_comment_at_date_time')
                 span.a-date__label 提出者最終コメント
                 | {{ product.self_last_comment_at }}
-            .thread-list-item-meta__item(v-if='product.mentor_last_comment_at_date_time')
+            .thread-list-item-meta__item(
+              v-if='product.mentor_last_comment_at_date_time'
+            )
               time.a-date(datetime='product.mentor_last_comment_at_date_time')
                 span.a-date__label メンター最終コメント
                 | {{ product.mentor_last_comment_at }}

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -46,16 +46,23 @@
               span.a-meta__label 更新
               | {{ product.updated_at }}
             .thread-list-item-meta__item(
-              v-if='product.self_last_comment_at_date_time'
+              v-if='product.self_last_comment_at_date_time && product.mentor_last_comment_at_date_time'
             )
-              time.a-meta(datetime='product.self_last_comment_at_date_time')
-                span.a-meta__label 提出者最終コメント
+              time.a-meta(v-if='product.self_last_comment_at_date_time > product.mentor_last_comment_at_date_time' datetime='product.self_last_comment_at_date_time')
+                span.a-meta__label.self_comment 最終コメント(提出者)
                 | {{ product.self_last_comment_at }}
+              time.a-meta(v-if='product.self_last_comment_at_date_time < product.mentor_last_comment_at_date_time' datetime='product.mentor_last_comment_at_date_time')
+                span.a-meta__label.mentor_comment 最終コメント(メンター)
+                | {{ product.mentor_last_comment_at }}
+             
             .thread-list-item-meta__item(
-              v-if='product.mentor_last_comment_at_date_time'
+              v-else-if='product.self_last_comment_at_date_time || product.mentor_last_comment_at_date_time'
             )
-              time.a-meta(datetime='product.mentor_last_comment_at_date_time')
-                span.a-meta__label メンター最終コメント
+              time.a-meta(v-if='product.self_last_comment_at_date_time' datetime='product.self_last_comment_at_date_time')
+                span.a-meta__label.self_comment 最終コメント(提出者)
+                | {{ product.self_last_comment_at }}
+              time.a-meta(v-else-if='product.mentor_last_comment_at_date_time' datetime='product.mentor_last_comment_at_date_time')
+                span.a-meta__label.mentor_comment 最終コメント(メンター)
                 | {{ product.mentor_last_comment_at }}
 
       .thread-list-item__row(v-if='product.comments.size > 0')

--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -37,8 +37,8 @@
             .thread-list-item-meta__item
               time.a-meta {{ report.reportedOn }}
                 | の日報
+      hr.thread-list-item__row-separator
       .thread-list-item__row(v-if='report.hasAnyComments')
-        hr.thread-list-item__row-separator
         .thread-list-item-meta
           .thread-list-item-meta__items
             .thread-list-item-meta__item

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -8,6 +8,7 @@ class Comment < ApplicationRecord
   belongs_to :user, touch: true
   belongs_to :commentable, polymorphic: true
   after_create CommentCallbacks.new
+  after_update CommentCallbacks.new
   after_destroy CommentCallbacks.new
   alias sender user
 

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -23,6 +23,7 @@ class CommentCallbacks
 
   def after_destroy(comment)
     return unless comment.commentable.instance_of?(Product)
+
     delete_last_comment_at(comment.commentable.id)
     delete_product_cache(comment.commentable.id)
   end
@@ -31,10 +32,10 @@ class CommentCallbacks
 
   def delete_last_comment_at(product_id)
     product = Product.find(product_id)
-    #最終日時をリセットする
+    # 最終日時をリセットする
     product.mentor_last_comment_at = nil
     product.self_last_comment_at = nil
-    #最新日時を上書きする
+    # 最新日時を上書きする
     product.comments.each do |comment|
       if comment.user.mentor
         product.mentor_last_comment_at = comment.updated_at

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -10,12 +10,14 @@ class CommentCallbacks
     end
 
     return unless comment.commentable.instance_of?(Product)
+
     update_last_comment_at(comment)
     delete_product_cache(comment.commentable.id)
   end
 
   def after_update(comment)
     return unless comment.commentable.instance_of?(Product)
+
     update_last_comment_at(comment)
   end
 

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -30,12 +30,16 @@ class CommentCallbacks
 
   private
 
-  def delete_last_comment_at(product_id)
-    product = Product.find(product_id)
-    # 最終日時をリセットする
+  def reset_last_comment_at
     product.mentor_last_comment_at = nil
     product.self_last_comment_at = nil
-    # 最新日時を上書きする
+  end
+
+  def delete_last_comment_at(product_id)
+    product = Product.find(product_id)
+
+    reset_last_comment_at
+
     product.comments.each do |comment|
       if comment.user.mentor
         product.mentor_last_comment_at = comment.updated_at
@@ -50,11 +54,10 @@ class CommentCallbacks
     product = Product.find(comment.commentable.id)
     if comment.user.mentor
       product.mentor_last_comment_at = comment.updated_at
-      product.save!
     elsif comment.user == product.user
       product.self_last_comment_at = comment.updated_at
-      product.save!
     end
+    product.save!
   end
 
   def notify_comment(comment)

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -17,6 +17,16 @@ if product.updated_at.present?
   json.updated_at_date_time product.updated_at.to_datetime
 end
 
+if product.self_last_comment_at.present?
+  json.self_last_comment_at l(product.self_last_comment_at)
+  json.self_last_comment_at_date_time product.self_last_comment_at.to_datetime
+end
+
+if product.mentor_last_comment_at.present?
+  json.mentor_last_comment_at l(product.mentor_last_comment_at)
+  json.mentor_last_comment_at_date_time product.mentor_last_comment_at.to_datetime
+end
+
 json.user do
   json.partial! "api/users/user", user: product.user
 end

--- a/app/views/products/_report.html.slim
+++ b/app/views/products/_report.html.slim
@@ -20,8 +20,8 @@
                 = l report.reported_on
                 = 'の日報'
       - if report.comments.any?
+        hr.thread-list-item__row-separator
         .thread-list-item__row
-          hr.thread-list-item__row-separator
           .thread-list-item-meta
             .thread-list-item-meta__items
               .thread-list-item-meta__item

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -84,18 +84,18 @@ header.page-header
 
                     - if @product.self_last_comment_at.present?
                       .thread-header-metas__meta
-                        .a-date
-                          span.a-date__label
+                        .a-meta
+                          span.a-meta__label
                             | 提出者最終コメント
-                          time.a-date__value(datetime="#{@product.self_last_comment_at.to_datetime}")
+                          time.a-meta__value(datetime="#{@product.self_last_comment_at.to_datetime}")
                             = l @product.self_last_comment_at
 
                     - if @product.mentor_last_comment_at.present?
                       .thread-header-metas__meta
-                        .a-date
-                          span.a-date__label
+                        .a-meta
+                          span.a-meta__label
                             | メンター最終コメント
-                          time.a-date__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
+                          time.a-meta__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
                             = l @product.mentor_last_comment_at
               .thread-header__row
                 h1.thread-header-title(class="#{@product.wip? ? 'is-wip' : ''}")

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -49,7 +49,26 @@ header.page-header
                     .thread-header-metas__meta
                       = link_to @product.user, class: 'a-user-name' do
                         = @product.user.long_name
-
+                  .thread-header-metas__end
+                    .thread-header-metas__meta
+                      - length = @product.comments.length
+                      a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
+                        | コメント（
+                        span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
+                          = length
+                        | ）
+              .thread-header__row
+                h1.thread-header-title(class="#{@product.wip? ? 'is-wip' : ''}")
+                  - if @product.wip?
+                    span.thread-header-title__label
+                      | WIP
+                  span.thread-header-title__title
+                    - if @product.user.daimyo?
+                      | ★
+                    | #{link_to @product.practice.title, @product.practice, class: 'thread-header-title__link'}の提出物
+              .thread-header__row
+                .thread-header-metas
+                  .thread-header-metas__start
                     .thread-header-metas__meta
                       .a-meta
                         - if @product.wip?
@@ -73,58 +92,6 @@ header.page-header
                             | 更新
                           time.a-meta__value(datetime="#{@product.updated_at.to_datetime}")
                             = l @product.updated_at
-
-                    .thread-header-metas__meta
-                      - length = @product.comments.length
-                      a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
-                        | コメント（
-                        span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
-                          = length
-                        | ）
-
-                    - if @product.self_last_comment_at.present? && @product.mentor_last_comment_at.present?
-                      - if @product.self_last_comment_at > @product.mentor_last_comment_at
-                        .thread-header-metas__meta
-                          .a-meta.self_comment
-                            span.a-meta__label
-                              | 最終コメント(提出者)
-                            time.a-meta__value(datetime="#{@product.self_last_comment_at.to_datetime}")
-                              = l @product.self_last_comment_at
-
-                      - elsif @product.self_last_comment_at < @product.mentor_last_comment_at
-                        .thread-header-metas__meta
-                          .a-meta.mentor_comment
-                            span.a-meta__label
-                              | 最終コメント(メンター)
-                            time.a-meta__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
-                              = l @product.mentor_last_comment_at
-
-                    - elsif @product.self_last_comment_at.present? || @product.mentor_last_comment_at.present?
-                      - if @product.self_last_comment_at.present?
-                        .thread-header-metas__meta
-                          .a-meta.self_comment
-                            span.a-meta__label
-                              | 最終コメント(提出者)
-                            time.a-meta__value(datetime="#{@product.self_last_comment_at.to_datetime}")
-                              = l @product.self_last_comment_at
-
-                      - elsif @product.mentor_last_comment_at.present?
-                        .thread-header-metas__meta
-                          .a-meta.mentor_comment
-                            span.a-meta__label
-                              | 最終コメント(メンター)
-                            time.a-meta__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
-                              = l @product.mentor_last_comment_at
-
-              .thread-header__row
-                h1.thread-header-title(class="#{@product.wip? ? 'is-wip' : ''}")
-                  - if @product.wip?
-                    span.thread-header-title__label
-                      | WIP
-                  span.thread-header-title__title
-                    - if @product.user.daimyo?
-                      | ★
-                    | #{link_to @product.practice.title, @product.practice, class: 'thread-header-title__link'}の提出物
 
               .thread-header__row
                 .thread-header-actions

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -89,7 +89,7 @@ header.page-header
                             | 提出者最終コメント
                           time.a-date__value(datetime="#{@product.self_last_comment_at.to_datetime}")
                             = l @product.self_last_comment_at
-                    
+
                     - if @product.mentor_last_comment_at.present?
                       .thread-header-metas__meta
                         .a-date

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -82,6 +82,21 @@ header.page-header
                           = length
                         | ）
 
+                    - if @product.self_last_comment_at.present?
+                      .thread-header-metas__meta
+                        .a-date
+                          span.a-date__label
+                            | 提出者最終コメント
+                          time.a-date__value(datetime="#{@product.self_last_comment_at.to_datetime}")
+                            = l @product.self_last_comment_at
+                    
+                    - if @product.mentor_last_comment_at.present?
+                      .thread-header-metas__meta
+                        .a-date
+                          span.a-date__label
+                            | メンター最終コメント
+                          time.a-date__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
+                            = l @product.mentor_last_comment_at
               .thread-header__row
                 h1.thread-header-title(class="#{@product.wip? ? 'is-wip' : ''}")
                   - if @product.wip?

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -82,21 +82,39 @@ header.page-header
                           = length
                         | ）
 
-                    - if @product.self_last_comment_at.present?
-                      .thread-header-metas__meta
-                        .a-meta
-                          span.a-meta__label
-                            | 提出者最終コメント
-                          time.a-meta__value(datetime="#{@product.self_last_comment_at.to_datetime}")
-                            = l @product.self_last_comment_at
+                    - if @product.self_last_comment_at.present? && @product.mentor_last_comment_at.present?
+                      - if @product.self_last_comment_at > @product.mentor_last_comment_at
+                        .thread-header-metas__meta
+                          .a-meta.self_comment
+                            span.a-meta__label
+                              | 最終コメント(提出者)
+                            time.a-meta__value(datetime="#{@product.self_last_comment_at.to_datetime}")
+                              = l @product.self_last_comment_at
 
-                    - if @product.mentor_last_comment_at.present?
-                      .thread-header-metas__meta
-                        .a-meta
-                          span.a-meta__label
-                            | メンター最終コメント
-                          time.a-meta__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
-                            = l @product.mentor_last_comment_at
+                      - elsif @product.self_last_comment_at < @product.mentor_last_comment_at
+                        .thread-header-metas__meta
+                          .a-meta.mentor_comment
+                            span.a-meta__label
+                              | 最終コメント(メンター)
+                            time.a-meta__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
+                              = l @product.mentor_last_comment_at
+
+                    - elsif @product.self_last_comment_at.present? || @product.mentor_last_comment_at.present?
+                      - if @product.self_last_comment_at.present?
+                        .thread-header-metas__meta
+                          .a-meta.self_comment
+                            span.a-meta__label
+                              | 最終コメント(提出者)
+                            time.a-meta__value(datetime="#{@product.self_last_comment_at.to_datetime}")
+                              = l @product.self_last_comment_at
+
+                      - elsif @product.mentor_last_comment_at.present?
+                        .thread-header-metas__meta
+                          .a-meta.mentor_comment
+                            span.a-meta__label
+                              | 最終コメント(メンター)
+                            time.a-meta__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
+                              = l @product.mentor_last_comment_at                     
               .thread-header__row
                 h1.thread-header-title(class="#{@product.wip? ? 'is-wip' : ''}")
                   - if @product.wip?

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -114,7 +114,8 @@ header.page-header
                             span.a-meta__label
                               | 最終コメント(メンター)
                             time.a-meta__value(datetime="#{@product.mentor_last_comment_at.to_datetime}")
-                              = l @product.mentor_last_comment_at                     
+                              = l @product.mentor_last_comment_at
+
               .thread-header__row
                 h1.thread-header-title(class="#{@product.wip? ? 'is-wip' : ''}")
                   - if @product.wip?

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -39,8 +39,8 @@
                 = l report.reported_on
                 = 'の日報'
       - if report.comments.any?
+        hr.thread-list-item__row-separator
         .thread-list-item__row
-          hr.thread-list-item__row-separator
           .thread-list-item-meta
             .thread-list-item-meta__items
               .thread-list-item-meta__item

--- a/db/data/20210816082555_add_last_comment_at.rb
+++ b/db/data/20210816082555_add_last_comment_at.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddLastCommentAt < ActiveRecord::Migration[6.1]
+  def up
+    products = Product.where(self_last_comment_at: nil).where(mentor_last_comment_at: nil)
+    products.each do |product|
+      next unless product.comments.size.positive?
+
+      product.comments.each do |comment|
+        if comment.user.mentor
+          product.mentor_last_comment_at = comment.updated_at
+        elsif comment.user == product.user
+          product.self_last_comment_at = comment.updated_at
+        end
+      end
+      product.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20210805061849_add_self_last_comment_at_column_and_mentor_last_comment_at_column_to_products.rb
+++ b/db/migrate/20210805061849_add_self_last_comment_at_column_and_mentor_last_comment_at_column_to_products.rb
@@ -1,0 +1,7 @@
+class AddSelfLastCommentAtColumnAndMentorLastCommentAtColumnToProducts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :products, :self_last_comment_at, :datetime
+
+    add_column :products, :mentor_last_comment_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -322,6 +322,8 @@ ActiveRecord::Schema.define(version: 2021_08_17_055525) do
     t.boolean "wip", default: false, null: false
     t.datetime "published_at"
     t.bigint "checker_id"
+    t.datetime "self_last_comment_at"
+    t.datetime "mentor_last_comment_at"
     t.index ["practice_id"], name: "index_products_on_practice_id"
     t.index ["user_id", "practice_id"], name: "index_products_on_user_id_and_practice_id", unique: true
     t.index ["user_id"], name: "index_products_on_user_id"

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -232,29 +232,4 @@ class CommentsTest < ApplicationSystemTestCase
     find('#js-new-comment').set('@')
     assert_selector 'span.mention', text: 'mentor'
   end
-
-  test 'show last comment at' do
-    # メンターがコメントする
-    visit_with_auth "/products/#{products(:product2).id}", 'komagata'
-    within('.thread-comment-form__form') do
-      fill_in('new_comment[description]', with: 'メンターがコメント')
-    end
-    click_button 'コメントする'
-    wait_for_vuejs
-    assert_text 'メンターがコメント'
-    # 最終コメントがメンターであることを確認
-    visit current_url
-    assert_text '最終コメント(メンター)'
-    # 提出者がコメントする
-    visit_with_auth "/products/#{products(:product2).id}", 'kimura'
-    within('.thread-comment-form__form') do
-      fill_in('new_comment[description]', with: '提出者がコメント')
-    end
-    click_button 'コメントする'
-    wait_for_vuejs
-    assert_text '提出者がコメント'
-    # 最終コメントが提出者であることを確認
-    visit current_url
-    assert_text '最終コメント(提出者)'
-  end
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -232,4 +232,29 @@ class CommentsTest < ApplicationSystemTestCase
     find('#js-new-comment').set('@')
     assert_selector 'span.mention', text: 'mentor'
   end
+
+  test 'show last comment at' do
+    # メンターがコメントする
+    visit_with_auth "/products/#{products(:product2).id}", 'komagata'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'メンターがコメント')
+    end
+    click_button 'コメントする'
+    wait_for_vuejs
+    assert_text 'メンターがコメント'
+    # 最終コメントがメンターであることを確認
+    visit current_url
+    assert_text '最終コメント(メンター)'
+    # 提出者がコメントする
+    visit_with_auth "/products/#{products(:product2).id}", 'kimura'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: '提出者がコメント')
+    end
+    click_button 'コメントする'
+    wait_for_vuejs
+    assert_text '提出者がコメント'
+    # 最終コメントが提出者であることを確認
+    visit current_url
+    assert_text '最終コメント(提出者)'
+  end
 end


### PR DESCRIPTION
issue #3002 

# 概要
### 提出物に`self_last_comment_at`,`mentor_last_comment_at`の2つのカラムを追加する
それぞれは提出物に対する提出者の最終コメント日時、メンターの最終コメント日時です。
表示されるのは両者のうち最新の日時が表示されます。
この機能により提出物を確認した際にメンターのコメント待ちなのか判断が簡単にできるようになります。


- 一覧ページ
![貼り付けた画像_2021_08_10_20_53](https://user-images.githubusercontent.com/62867257/128862531-a74d8901-0f75-49cf-a7a1-e0200bffc03f.png)


- 個別ページ
![貼り付けた画像_2021_08_10_20_47](https://user-images.githubusercontent.com/62867257/128861738-c4ce609f-4e4f-4303-a0df-d8ad16c88af0.png)
### 既存の提出物にデータを挿入するdata migrationスクリプトを作成
既存の提出物にはコメントがついていますがカラムに保存されるのはこの機能の実装後にされたコメントに対してです。
そこで既存の提出物のカラムにもデータを挿入するためのdata migrationスクリプトを作成しました。
