### PR TITLE
ニコニコカレンダーの年月をページ遷移後も保持する

### DIFF
--- a/app/javascript/niconico_calendar.vue
+++ b/app/javascript/niconico_calendar.vue
@@ -220,8 +220,14 @@ export default {
         return
       }
 
-      this.calendarYear = parseInt(match[1])
-      this.calendarMonth = parseInt(match[2])
+      const year = parseInt(match[1])
+      const month = parseInt(match[2])
+      if (new Date(year, month).getTime() > Date.now()) {
+        return
+      }
+
+      this.calendarYear = year
+      this.calendarMonth = month
     },
     saveState() {
       const year = String(this.calendarYear)

--- a/app/javascript/niconico_calendar.vue
+++ b/app/javascript/niconico_calendar.vue
@@ -133,6 +133,7 @@ export default {
     }
   },
   mounted() {
+    this.loadState()
     fetch(`/api/niconico_calendars/${this.userId}.json`, {
       method: 'GET',
       headers: {
@@ -171,6 +172,7 @@ export default {
         this.calendarMonth--
       }
       this.$nextTick(() => (this.loaded = true))
+      this.saveState()
     },
     nextMonth() {
       this.loaded = false
@@ -181,6 +183,7 @@ export default {
         this.calendarMonth++
       }
       this.$nextTick(() => (this.loaded = true))
+      this.saveState()
     },
     emotionClass(date) {
       return date.emotion ? `is-${date.emotion}` : 'is-blank'
@@ -208,6 +211,24 @@ export default {
     },
     reportDate(report) {
       return Number(report.reported_on.split('-')[2])
+    },
+    loadState() {
+      const params = new URLSearchParams(location.search)
+      const yearMonth = params.get('niconico_calendar') || ''
+      const match = /(\d{4})-(\d{2})/.exec(yearMonth)
+      if (!match) {
+        return
+      }
+
+      this.calendarYear = parseInt(match[1])
+      this.calendarMonth = parseInt(match[2])
+    },
+    saveState() {
+      const year = String(this.calendarYear)
+      const month = String(this.calendarMonth).padStart(2, '0')
+      const params = new URLSearchParams(location.search)
+      params.set('niconico_calendar', `${year}-${month}`)
+      history.replaceState(history.state, '', `?${params}${location.hash}`)
     }
   }
 }

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -68,6 +68,11 @@ class HomeTest < ApplicationSystemTestCase
     find('.niconico-calendar-nav').assert_text '2020年1月'
   end
 
+  test "show current month's page of Nico Nico calendar when future date is specified in URL params" do
+    visit_with_auth "/?niconico_calendar=#{Time.current.next_month.strftime('%Y-%m')}", 'hajime'
+    find('.niconico-calendar-nav').assert_text Time.current.strftime('%Y年%-m月')
+  end
+
   test 'keep Nico Nico calendar page even when leave dashboard' do
     visit_with_auth '/', 'hajime'
     find('.niconico-calendar-nav__previous').click

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -62,4 +62,20 @@ class HomeTest < ApplicationSystemTestCase
     visit_with_auth '/', 'komagata'
     assert_no_text 'ニコニコカレンダー'
   end
+
+  test 'show Nico Nico calendar page that matches URL params' do
+    visit_with_auth '/?niconico_calendar=2020-01', 'hajime'
+    find('.niconico-calendar-nav').assert_text '2020年1月'
+  end
+
+  test 'keep Nico Nico calendar page even when leave dashboard' do
+    visit_with_auth '/', 'hajime'
+    find('.niconico-calendar-nav__previous').click
+    wait_for_vuejs
+    find('.niconico-calendar-nav').assert_text 1.month.ago.strftime('%Y年%-m月')
+    find('.niconico-calendar').click_link href: /reports/, match: :first
+    go_back
+    find('.niconico-calendar-nav').assert_text 1.month.ago.strftime('%Y年%-m月')
+    assert_current_path(/niconico_calendar=#{1.month.ago.strftime('%Y-%m')}/)
+  end
 end


### PR DESCRIPTION
Ref: #2982 

## 概要

ダッシュボード（パス：`/`）に表示されるニコニコカレンダーにおいて、他のページに遷移した後にブラウザの戻るでダッシュボードに戻ってきたとしても、遷移前に表示していた年月が表示されるようにしました。

ニコニコカレンダーのページをめくるたびに、URLのクエリパラメータとして年月を保存することで実現しています（例：`/?niconico_calendar=2021-07`）。なお、クエリパラメータで未来の年月を指定した場合、今月のカレンダーが表示されます。

### パラメータ名

`year`と`month`というパラメータ名ではなく、`niconico_calendar`というパラメータ名にしたのは、いずれダッシュボードに別のカレンダーが追加されたときに重複させないためです（#2982）。

### 参考リンク

- [History.replaceState() - Web API | MDN (mozilla.org)](https://developer.mozilla.org/ja/docs/Web/API/History/replaceState)

## 動作例

https://user-images.githubusercontent.com/350435/128818165-c873d246-a395-43e9-bef8-33451c19b3a3.mov
