### PR TITLE
メンターはデフォルトでQ&AをWatch中にする

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -98,7 +98,7 @@ class QuestionsController < ApplicationController
   end
 
   def create_mentors_watch
-    Watch.insert_all(watch_records)
+    Watch.insert_all(watch_records) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def watch_records

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -41,6 +41,7 @@ class QuestionsController < ApplicationController
     @question = Question.new(question_params)
     @question.user = current_user
     if @question.save
+      create_mentors_watch
       notify_to_chat(@question)
       redirect_to @question, notice: '質問を作成しました。'
     else
@@ -93,6 +94,22 @@ class QuestionsController < ApplicationController
       QuestionsProperty.new('解決済みの質問一覧', '解決済みの質問はまだありません。')
     else
       QuestionsProperty.new('未解決の質問一覧', '未解決の質問はまだありません。')
+    end
+  end
+
+  def create_mentors_watch
+    Watch.insert_all(watch_records)
+  end
+
+  def watch_records
+    User.mentor.map do |mentor|
+      {
+        watchable_type: 'Question',
+        watchable_id: @question.id,
+        created_at: Time.current,
+        updated_at: Time.current,
+        user_id: mentor.id
+      }
     end
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -277,4 +277,14 @@ class QuestionsTest < ApplicationSystemTestCase
     click_link '2', match: :first
     assert_selector '.thread-list-item', count: 25
   end
+
+  test 'mentor create a question' do
+    visit_with_auth new_question_path, 'komagata'
+    within 'form[name=question]' do
+      fill_in 'question[title]', with: 'メンターのみ投稿された質問が"Watch中"になるテスト'
+      fill_in 'question[description]', with: 'メンターのみ投稿された質問が"Watch中"になるテスト'
+      click_button '登録する'
+    end
+    assert_text 'Watch中'
+  end
 end


### PR DESCRIPTION
#2874

機能
どのユーザーが質問を保存しても、メンターさんのみ自動的に「Watch中」になります。

修正点
- questions_controllerを修正しました。
- createメソッド内に「watch中」にする「change_to_watching_for_mentor_only」メソッドを追加しました。
- 質問が保存された後に、メンターさんをUserテーブルから検索します。
- 検索したメンターさんと質問を紐付けます。