### PR TITLE
ダッシュボードのお知らせ一覧の日付をpublished_atに変更

### DIFF
--- a/app/views/home/_announcements.html.slim
+++ b/app/views/home/_announcements.html.slim
@@ -7,5 +7,5 @@
         = link_to announcement, itemprop: 'url', class: 'thread-list-item-title__link' do
           = announcement.title
     .thread-list-item-meta
-      time.a-meta(datetime="#{announcement.updated_at.to_datetime}" pubdate='pubdate')
-        = l announcement.updated_at
+      time.a-meta(datetime="#{announcement.published_at.to_datetime}" pubdate='pubdate')
+        = l announcement.published_at


### PR DESCRIPTION
issue #3011 

 - ダッシュボードのお知らせ一覧の日付をupdated_atからpublished_atに変更いたしました。

### 変更前(updated_at)

![スクリーンショット 2021-08-13 7 59 55](https://user-images.githubusercontent.com/77760087/129281018-16511967-7b10-489b-b2ca-57395f06ad62.png)

### 変更後(published_at)

![スクリーンショット 2021-08-13 7 58 52](https://user-images.githubusercontent.com/77760087/129281027-c72d26fa-be89-459c-ba93-6fd07a957eef.png)
