### PR TITLE
管理者だけでなくメンターもプラクティスの編集をできるように変更

### DIFF
--- a/.traceroute.yml
+++ b/.traceroute.yml
@@ -16,6 +16,7 @@ ignore_unreachable_actions:
   - .*#require_staff_login
   - .*#require_admin_login
   - .*#require_mentor_login
+  - .*#require_admin_or_mentor_login
   - mails#welcome
   - reports#convert_to_hour_minute
   - reports#convert_to_ceiled_hour

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -57,6 +57,12 @@ module Authentication
     redirect_to root_path, alert: '管理者としてログインしてください'
   end
 
+  def require_admin_or_mentor_login
+    return if admin_or_mentor_login?
+
+    redirect_to root_path, alert: '管理者・メンターとしてログインしてください'
+  end
+
   def require_staff_login
     return if staff_login?
 

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -3,7 +3,7 @@
 class PracticesController < ApplicationController
   before_action :require_login
   before_action :require_admin_login, only: %i[new create]
-  before_action :require_mentor_login, only: %i[edit update]
+  before_action :require_admin_or_mentor_login, only: %i[edit update]
   before_action :set_course, only: %i[new]
   before_action :set_practice, only: %i[show edit update]
 

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -2,7 +2,8 @@
 
 class PracticesController < ApplicationController
   before_action :require_login
-  before_action :require_admin_login, except: %i[show]
+  before_action :require_admin_login, only: %i[new create]
+  before_action :require_mentor_login, only: %i[edit update]
   before_action :set_course, only: %i[new]
   before_action :set_practice, only: %i[show edit update]
 

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -143,10 +143,10 @@ header.page-header
             .practice-content__body.is-memo
               .js-markdown-view.js-target-blank.is-long-text
                 = @practice.memo
-        - if current_user.admin?
+        - if current_user.mentor? || current_user.admin?
           section.a-card
             header.card-header
-              h2.card-header__title 管理者メニュー
+              h2.card-header__title 管理者・メンター用メニュー
             footer.card-footer
               .card-main-actions
                 ul.card-main-actions__items

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -143,7 +143,6 @@ header.page-header
             .practice-content__body.is-memo
               .js-markdown-view.js-target-blank.is-long-text
                 = @practice.memo
-        - if current_user.mentor? || current_user.admin?
           section.a-card
             header.card-header
               h2.card-header__title 管理者・メンター用メニュー

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -135,7 +135,7 @@ header.page-header
                 br
                 | 終了条件をクリアしたら完了にしてください。
 
-        - if current_user.mentor? || current_user.admin?
+        - if current_user.admin_or_mentor?
           section.a-card
             header.card-header
               h2.card-header__title

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -166,4 +166,24 @@ class PracticesTest < ApplicationSystemTestCase
     index2 = titles.rindex 'Debianをインストールする'
     assert index1 < index2
   end
+
+  test 'update practice in the role of mentor' do
+    practice = practices(:practice2)
+    product = products(:product3)
+    visit_with_auth "/practices/#{practice.id}/edit", 'yamada'
+    within 'form[name=practice]' do
+      fill_in 'practice[title]', with: 'テストプラクティス'
+      within '#reference_books' do
+        click_link '追加'
+        fill_in 'タイトル', with: 'プロを目指す人のためのRuby入門'
+        fill_in '価格', with: '2345'
+        fill_in 'URL', with: 'http://example.com'
+        find('.reference-books-form-item__must-read').click
+        fill_in '説明', with: 'テストの参考書籍説明'
+      end
+      click_button '更新する'
+    end
+    assert_text 'プラクティスを更新しました'
+    visit "/products/#{product.id}"
+  end
 end

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -169,7 +169,6 @@ class PracticesTest < ApplicationSystemTestCase
 
   test 'update practice in the role of mentor' do
     practice = practices(:practice2)
-    product = products(:product3)
     visit_with_auth "/practices/#{practice.id}/edit", 'yamada'
     within 'form[name=practice]' do
       fill_in 'practice[title]', with: 'テストプラクティス'
@@ -184,6 +183,8 @@ class PracticesTest < ApplicationSystemTestCase
       click_button '更新する'
     end
     assert_text 'プラクティスを更新しました'
-    visit "/products/#{product.id}"
+    visit "/practices/#{practice.id}"
+    wait_for_vuejs
+    assert_equal 'テストプラクティス | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 end


### PR DESCRIPTION
ref #3052

メンターがプラクティスを修正できるように対応いたしました。

## 対応内容

1. プラクティス個別ページの編集ボタンをメンターでも表示できるようにした
##### 変更前
![PC性能の見方を知る___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/129440779-01ecac31-de78-4864-9bf2-18a03ea4af56.png)

##### 変更後
![PC性能の見方を知る___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/129440787-99a3c319-a803-4716-bc5e-81d4a5d4f0e5.png)

2. 編集、更新処理前のログインチェックを管理者またはメンターでログインしているかに変更