### PR TITLE
提出物編集ページでメンターは担当者を変更できるようにする

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -98,7 +98,9 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).permit(:body)
+    keys = %i[body]
+    keys << :checker_id if mentor_login?
+    params.require(:product).permit(*keys)
   end
 
   def set_watch

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -12,6 +12,13 @@
           .a-form-label
             | プレビュー
           .js-preview.is-long-text.markdown-form__preview
+    .form-item
+      - if admin_login?
+        .col-md-3.col-xs-6
+          .a-form-label
+            | 担当者
+            .select-mentors
+              = f.select(:checker_id, User.where(mentor: true).where(retired_on: nil).pluck(:login_name, :id).sort, { include_blank: true }, { class: 'js-select2' })
 
   .form-actions
     ul.form-actions__items.is-ais-flex-start

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -128,6 +128,15 @@ class ProductsTest < ApplicationSystemTestCase
     assert_no_button '担当から外れる'
   end
 
+  test 'change checker on edit page' do
+    visit_with_auth "/products/#{products(:product1).id}", 'komagata'
+    click_button '担当する'
+    click_link '内容修正'
+    select 'machida', from: 'product_checker_id'
+    click_button '提出する'
+    assert_text 'machida'
+  end
+
   test 'create product as WIP' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'yamada'
     within('#new_product') do


### PR DESCRIPTION
issue: [#2964](https://github.com/fjordllc/bootcamp/issues/2964)
メンターの場合に、/products/:id/editのページで担当者を変更できるようにプルダウンを追加しました。

# 変更前
![image](https://user-images.githubusercontent.com/52092916/129646206-6d73b27b-4324-403d-8bae-ab9cc8e06410.png)


# 変更後

![image](https://user-images.githubusercontent.com/52092916/129645957-4c23157b-fae5-4939-a2c6-f28994f3f9a3.png)
