### PR TITLE
管理画面にコース一覧を追加

### DIFF
--- a/app/assets/stylesheets/atoms/_a-button.sass
+++ b/app/assets/stylesheets/atoms/_a-button.sass
@@ -99,6 +99,14 @@ input[type="button"]
     .a-button
       border-radius: 0
 
+.is-inline-buttons
+  display: flex
+  +margin(horizontal, -.25rem)
+  .is-text-align-center &
+    justify-content: center
+  >li
+    +padding(horizontal, .25rem)
+
 .a-welcome-button
   +size(auto 4rem)
   +text-block(1.125rem 1, flex 700 $welcome-default-text)

--- a/app/assets/stylesheets/blocks/admin/_admin-table.sass
+++ b/app/assets/stylesheets/blocks/admin/_admin-table.sass
@@ -14,8 +14,8 @@
   width: 100%
 
 .admin-table__header
-  background-color: $background
-  border: solid 1px #aaaaaa
+  background-color: $background-shade
+  border: solid 1px #bbbbbb
   +border-radius(top, .25rem)
 
 .admin-table__items
@@ -26,7 +26,7 @@
 
 .admin-table__label
   +text-block(.75rem 1.4, $main center 600)
-  border: solid 1px #aaaaaa
+  border: solid 1px #bbbbbb
   white-space: nowrap
   height: 2rem
   +padding(horizontal, .5rem)
@@ -36,7 +36,8 @@
     font-size: .75rem
     margin-left: .5rem
     +padding(horizontal, .375rem)
-    background-color: #dedede
+    background-color: $base
+    border-color: #bbbbbb
     color: $default-text
 
 .admin-table__item
@@ -48,6 +49,7 @@
     +border-radius(bottom, .25rem)
   &.sortable-chosen
     background-color: tint($warning, 80%)
+  &:hover,
   .admin-table.is-grab &:hover
     background-color: tint($warning, 90%)
   &[draggable="false"]
@@ -70,7 +72,7 @@
 
 .admin-table__item-logo-image
   border: solid 1px $border
-  width: 5rem
+  width: 2.5rem
   border-radius: .25rem
 
 .admin-table-item__body

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Admin::CoursesController < AdminController
+  def index
+    @courses = Course.order(created_at: :desc)
+  end
+end

--- a/app/javascript/categories.vue
+++ b/app/javascript/categories.vue
@@ -20,7 +20,7 @@
           td.admin-table__item-value
             | {{ category.slug }}
           td.admin-table__item-value.is-text-align-center
-            ul.is-button-group
+            ul.is-inline-buttons
               li
                 a.a-button.is-sm.is-secondary.is-icon.spec-edit(
                   :href='`/admin/categories/${category.id}/edit`'

--- a/app/views/admin/_admin_page_tabs.html.slim
+++ b/app/views/admin/_admin_page_tabs.html.slim
@@ -14,6 +14,10 @@
           admin_categories_path,
           class: "page-tabs__item-link #{current_link(/^admin-categories/)}"
       li.page-tabs__item
+        = link_to 'コース',
+          admin_courses_path,
+          class: "page-tabs__item-link #{current_link(/^admin-courses/)}"
+      li.page-tabs__item
         = link_to '企業',
           admin_companies_path,
           class: "page-tabs__item-link #{current_link(/^admin-companies/)}"

--- a/app/views/admin/books/_table.html.slim
+++ b/app/views/admin/books/_table.html.slim
@@ -31,7 +31,7 @@
             = link_to admin_books_qrcode_path(book), class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener' do
               i.fas.fa-print
           td.admin-table__item-value.is-text-align-center
-            ul.is-button-group
+            ul.is-inline-buttons
               li
                 = link_to edit_admin_book_path(book), class: 'a-button is-sm is-secondary is-icon' do
                   i.fas.fa-pen

--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -33,7 +33,7 @@ header.page-header
               td.admin-table__item-value
                 - if company.present?
                   = company.name
-              td.admin-table__item-value
+              td.admin-table__item-value.is-text-align-center
                 - if company.logo.attached?
                   = image_tag company.logo_url, class: 'admin-table__item-logo-image'
               td.admin-table__item-value
@@ -46,7 +46,7 @@ header.page-header
                   class: 'a-button is-sm is-secondary is-icon' do
                   i.fas.fa-user-plus
               td.admin-table__item-value.is-text-align-center
-                ul.is-button-group
+                ul.is-inline-buttons
                   li
                     = link_to edit_admin_company_path(company), class: 'a-button is-sm is-secondary is-icon' do
                       i.fas.fa-pen

--- a/app/views/admin/courses/_course.html.slim
+++ b/app/views/admin/courses/_course.html.slim
@@ -1,0 +1,23 @@
+.col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
+  .courses-item(id="course_#{course.id}")
+    .courses-item__inner.a-card
+      header.courses-item__header
+        h3.courses-item__title
+          = link_to course.title, [course, :practices], class: 'courses-item__title-link'
+      .courses-item__description
+        = simple_format(course.description)
+
+      footer.card-footer
+        .card-main-actions
+          ul.card-main-actions__items
+            li.card-main-actions__item
+              = link_to edit_course_path(course), class: 'a-button is-md is-secondary is-block' do
+                i.fas.fa-pen
+                | 編集
+            li.card-main-actions__item
+              = link_to course_categories_path(course), class: 'a-button is-md is-secondary is-block' do
+                i.fas.fa-align-justify
+                | 並び替え
+            li.card-main-actions__item.is-end
+              = link_to course, method: :delete, class: 'card-main-actions__delete js-delete', data: { confirm: '本当によろしいですか？' } do
+                | 削除

--- a/app/views/admin/courses/_course.html.slim
+++ b/app/views/admin/courses/_course.html.slim
@@ -2,7 +2,7 @@ tr.admin-table__item(id="course_#{course.id}")
   td.admin-table__item-value
     = link_to course.title, [course, :practices], class: 'courses-item__title-link'
   td.admin-table__item-value
-    = simple_format(course.description)
+    = course.description.truncate(100)
   td.admin-table__item-value.admin-table__item-value.is-text-align-center
     ul.is-inline-buttons
       li

--- a/app/views/admin/courses/_course.html.slim
+++ b/app/views/admin/courses/_course.html.slim
@@ -1,23 +1,16 @@
-.col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .courses-item(id="course_#{course.id}")
-    .courses-item__inner.a-card
-      header.courses-item__header
-        h3.courses-item__title
-          = link_to course.title, [course, :practices], class: 'courses-item__title-link'
-      .courses-item__description
-        = simple_format(course.description)
-
-      footer.card-footer
-        .card-main-actions
-          ul.card-main-actions__items
-            li.card-main-actions__item
-              = link_to edit_course_path(course), class: 'a-button is-md is-secondary is-block' do
-                i.fas.fa-pen
-                | 編集
-            li.card-main-actions__item
-              = link_to course_categories_path(course), class: 'a-button is-md is-secondary is-block' do
-                i.fas.fa-align-justify
-                | 並び替え
-            li.card-main-actions__item.is-end
-              = link_to course, method: :delete, class: 'card-main-actions__delete js-delete', data: { confirm: '本当によろしいですか？' } do
-                | 削除
+tr.admin-table__item(id="course_#{course.id}")
+  td.admin-table__item-value
+    = link_to course.title, [course, :practices], class: 'courses-item__title-link'
+  td.admin-table__item-value
+    = simple_format(course.description)
+  td.admin-table__item-value.admin-table__item-value.is-text-align-center
+    ul.is-inline-buttons
+      li
+        = link_to edit_course_path(course), class: 'a-button is-sm is-secondary is-icon is-block' do
+          i.fas.fa-pen
+      li
+        = link_to course_categories_path(course), class: 'a-button is-sm is-secondary is-icon is-block' do
+          i.fas.fa-align-justify
+      li
+        = link_to course, method: :delete, class: 'a-button is-sm is-danger is-icon is-block js-delete', data: { confirm: '本当によろしいですか？' } do
+          i.far.fa-trash-alt

--- a/app/views/admin/courses/index.html.slim
+++ b/app/views/admin/courses/index.html.slim
@@ -14,7 +14,16 @@ header.page-header
   = render 'admin/admin_page_tabs'
 
 .page-body
-  .container
-    .courses-items
-      .row
-        = render @courses.order(:created_at)
+  .container.is-padding-horizontal-0-sm-down
+    .admin-table
+      table.admin-table__table
+        thead.admin-table__header
+          tr.admin-table__labels
+            th.admin-table__label
+              | コース名
+            th.admin-table__label
+              | 説明文
+            th.admin-table__label
+              | 操作
+        tbody.admin-table__items
+          = render @courses.order(:created_at)

--- a/app/views/admin/courses/index.html.slim
+++ b/app/views/admin/courses/index.html.slim
@@ -1,0 +1,20 @@
+- title 'コース一覧'
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to new_course_path, class: 'a-button is-md is-secondary is-block' do
+              i.fas.fa-plus
+              | コース作成
+
+.page-tools
+  = render 'admin/admin_page_tabs'
+
+.page-body
+  .container
+    .courses-items
+      .row
+        = render @courses.order(:created_at)

--- a/app/views/admin/seats/_table.html.slim
+++ b/app/views/admin/seats/_table.html.slim
@@ -10,7 +10,7 @@
           td.admin-table__item-value
             = seat.name
           td.admin-table__item-value.is-text-align-center
-            ul.is-button-group
+            ul.is-inline-buttons
               li
                 = link_to edit_admin_seat_path(seat), class: 'a-button is-sm is-secondary is-icon' do
                   i.fas.fa-pen

--- a/app/views/courses/edit.html.slim
+++ b/app/views/courses/edit.html.slim
@@ -12,5 +12,5 @@
             = link_to courses_path, class: 'a-button is-md is-secondary is-block' do
               | コース一覧
 .page-body
-  .container
+  .container.is-xxl
     = render 'form', course: @course

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
       resource :password, only: %i(edit update), controller: "users/password"
     end
     resources :categories, except: %i(show)
-
+    resources :courses, only: %i(index)
     namespace :books do
       resources :qrcodes, only: %i(index show)
     end

--- a/test/system/admin/courses_test.rb
+++ b/test/system/admin/courses_test.rb
@@ -4,7 +4,7 @@ require 'application_system_test_case'
 
 class Admin::CoursesTest < ApplicationSystemTestCase
   test 'show listing courses' do
-    visit_with_auth '/courses', 'komagata'
+    visit_with_auth 'admin/courses', 'komagata'
     assert_equal 'コース一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 end

--- a/test/system/admin/courses_test.rb
+++ b/test/system/admin/courses_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Admin::CoursesTest < ApplicationSystemTestCase
+  test 'show listing courses' do
+    visit_with_auth '/courses', 'komagata'
+    assert_equal 'コース一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+  end
+end


### PR DESCRIPTION
# 概要
issue: [2901](https://github.com/fjordllc/bootcamp/issues/2901)
メンターの場合に、管理画面にコース一覧```/admin/courses```を追加しました。

**※備考**：作成・編集・削除について、```/courses/:id/~ ```となりますが、issue  [2902](https://github.com/fjordllc/bootcamp/issues/2902) で```/admin/courses/:id/~```で作成・編集・削除ができるように変更します。

# 変更前
![image](https://user-images.githubusercontent.com/52092916/129872853-d95784bd-0115-4136-be61-ddd471b80bcb.png)


# 変更後

![image](https://user-images.githubusercontent.com/52092916/129872406-7249a009-91d9-4a79-8356-9ee0fc6cc5e8.png)
