### PR TITLE
ブログ記事の編集リンクが機能しなかったのを修正

### DIFF
--- a/app/assets/stylesheets/article.sass
+++ b/app/assets/stylesheets/article.sass
@@ -116,6 +116,19 @@
   br + a img
     margin-top: 1.5em !important
 
+.article__actions
+  margin-top: 2rem
+  border-top: dashed 2px $border
+  padding-top: 1rem
+  ul
+    display: flex
+    justify-content: center
+    align-items: center
+    +margin(horizontal, -.5rem)
+  li
+    +padding(horizontal, .5rem)
+    flex: 1
+
 
 ////////////////////
 // .bootcamp-ad

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -15,14 +15,15 @@
             .article__meta
               .article__published-at
                 = l(@article.created_at)
-        .article__body.js-markdown-view.is-long-text
-          = @article.body
+        .article__body
+          .js-markdown-view.is-long-text
+            = @article.body
           - if admin_login?
-            ul
-              li
-                = link_to '内容修正', edit_article_path(@article)
-              li
-                = link_to '削除',
-                  article_path(@article),
-                  data: { confirm: '本当によろしいですか？' },
-                  method: :delete
+            .article__actions
+              ul
+                li
+                  = link_to edit_article_path(@article), class: 'a-button is-secondary is-md is-block' do
+                    | 内容修正
+                li
+                  = link_to article_path(@article), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'a-button is-secondary is-md is-block' do
+                    | 削除


### PR DESCRIPTION
admin にだけ表示されるリンクが機能してなかったのを修正しました。

## ステージング

<img width="815" alt="貼り付けた画像_2021_08_20_17_36" src="https://user-images.githubusercontent.com/168265/130205621-5069298b-b6ad-40a8-950c-08c1a5a1e10e.png">

## 修正後

![image](https://user-images.githubusercontent.com/168265/130205746-4d4a2b39-1ad6-462e-9ab8-b153d66eef89.png)
