### PR TITLE
Railsのallowed hostの設定を曖昧なドメイン名指定をやめて環境変数で実行されるサーバのドメインを指定するようにした

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -64,6 +64,7 @@ steps:
       - '--set-env-vars=RAILS_ENV=production'
       - '--set-env-vars=RACK_ENV=production'
       - '--set-env-vars=APP_HOST_NAME=$_APP_HOST_NAME'
+      - '--set-env-vars=CLOUD_RUN_HOST_NAME=$_CLOUD_RUN_HOST_NAME'
       - '--set-env-vars=RAILS_MASTER_KEY=$_RAILS_MASTER_KEY'
       - '--set-env-vars=DB_NAME=$_DB_NAME'
       - '--set-env-vars=DB_USER=$_DB_USER'
@@ -100,6 +101,7 @@ substitutions:
   _CLOUD_SQL_HOST: _
   _RAILS_MASTER_KEY: _
   _APP_HOST_NAME: _
+  _CLOUD_RUN_HOST_NAME: _
   _DB_NAME: _
   _DB_USER: _
   _DB_PASS: _

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,8 +128,6 @@ Rails.application.configure do
    config.action_mailer.delivery_method = :postmark
    config.action_mailer.postmark_settings = { api_token: ENV["POSTMARK_API_TOKEN"] }
 
-   config.hosts << ".a.run.app"
-   if app_host_name = ENV["APP_HOST_NAME"]
-     config.hosts << app_host_name
-   end
+   config.hosts << ENV["CLOUD_RUN_HOST_NAME"] if ENV["CLOUD_RUN_HOST_NAME"]
+   config.hosts << ENV["APP_HOST_NAME"] if ENV["APP_HOST_NAME"]
 end


### PR DESCRIPTION
@komagata @JunichiIto 

allowed hostで曖昧なドメインの場合にセキュリティの問題があり、Rails 6.1.4.1で修正された。
https://weblog.rubyonrails.org/2021/8/19/Rails-6-0-4-1-and-6-1-4-1-have-been-released/

これを受けて @JunichiIto が下記のPRにてRailsのアップデート対応のPRを作成済み

- #3188

Cloud Runでは`.a.run.app`というドメインでURLが自動で発行されるためallowed hostに指定していたが、曖昧なドメインを使うのは避けたほうがベターなので環境変数からドメイン指定できるようにして、Cloud Buildのデプロイ時に設定するように変更しました。Cloud Buildの方の設定も変更済みです。


