### PR TITLE
日報フォロー機能の表記を「自動Watch」に変更した

### DIFF
--- a/app/javascript/following.vue
+++ b/app/javascript/following.vue
@@ -20,7 +20,7 @@ export default {
   },
   computed: {
     buttonLabel() {
-      return this.following ? 'フォローを解除' : '日報をフォロー'
+      return this.following ? '自動Watchを解除' : '日報を自動Watch'
     },
     url() {
       return this.following
@@ -32,8 +32,8 @@ export default {
     },
     errorMessage() {
       return this.following
-        ? 'フォロー解除に失敗しました'
-        : 'フォローに失敗しました'
+        ? '自動Watch解除に失敗しました'
+        : '自動Watchに失敗しました'
     }
   },
   methods: {

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -114,7 +114,7 @@ notification_following_report:
   kind: 13
   user: muryou
   sender: kensyu
-  message: kensyuさんが日報【 フォローされた日報 】を書きました！
+  message: kensyuさんが日報【 自動Watchされた日報 】を書きました！
   path: "/reports/<%= ActiveRecord::FixtureSet.identify(:report23) %>"
   read: false
 

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -181,9 +181,9 @@ report22:
 
 report23:
   user: kensyu
-  title: フォローされた日報
+  title: 自動Watchされた日報
   description:
-    フォローされました。
+    自動Watchされました。
   reported_on: "2020-11-10"
 
 report24:

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -114,7 +114,7 @@ notification_following_report:
   kind: 13
   user: muryou
   sender: kensyu
-  message: kensyuさんが日報【 フォローされた日報 】を書きました！
+  message: kensyuさんが日報【 自動Watchされた日報 】を書きました！
   path: "/reports/<%= ActiveRecord::FixtureSet.identify(:report23) %>"
   read: false
 

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -185,9 +185,9 @@ report22:
 
 report23:
   user: kensyu
-  title: フォローされた日報
+  title: 自動Watchされた日報
   description:
-    フォローされました。
+    自動Watchされました。
   reported_on: "2020-11-10"
 
 report24:

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -273,7 +273,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['muryou@fjord.jp'], email.to
-    assert_equal '[bootcamp] kensyuさんが日報【 フォローされた日報 】を書きました！', email.subject
+    assert_equal '[bootcamp] kensyuさんが日報【 自動Watchされた日報 】を書きました！', email.subject
     assert_match(/日報/, email.body.to_s)
   end
 

--- a/test/system/followings_test.rb
+++ b/test/system/followings_test.rb
@@ -5,28 +5,28 @@ require 'application_system_test_case'
 class FollowingsTest < ApplicationSystemTestCase
   test 'follow' do
     visit_with_auth user_path(users(:hatsuno)), 'kimura'
-    click_button '日報をフォロー'
-    assert_button 'フォローを解除'
+    click_button '日報を自動Watch'
+    assert_button '自動Watchを解除'
   end
 
   test 'unfollow' do
     visit_with_auth user_path(users(:hatsuno)), 'kimura'
-    click_button '日報をフォロー'
-    click_button 'フォローを解除'
-    assert_button '日報をフォロー'
+    click_button '日報を自動Watch'
+    click_button '自動Watchを解除'
+    assert_button '日報を自動Watch'
   end
 
   test 'show following lists' do
     visit_with_auth user_path(users(:hatsuno)), 'kimura'
-    click_button '日報をフォロー'
-    assert_text 'フォローを解除'
+    click_button '日報を自動Watch'
+    assert_text '自動Watchを解除'
     visit '/users?target=followings'
     assert_text users(:hatsuno).login_name
   end
 
   test 'receive a notification when following user create a report' do
     visit_with_auth user_path(users(:hatsuno)), 'kimura'
-    click_button '日報をフォロー'
+    click_button '日報を自動Watch'
 
     visit_with_auth '/reports/new', 'hatsuno'
     within('#new_report') do
@@ -49,7 +49,7 @@ class FollowingsTest < ApplicationSystemTestCase
 
   test "receive a notification when following user's report has comment" do
     visit_with_auth user_path(users(:hatsuno)), 'kimura'
-    click_button '日報をフォロー'
+    click_button '日報を自動Watch'
 
     visit_with_auth '/reports/new', 'hatsuno'
     within('#new_report') do

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -107,12 +107,12 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test '初めて提出した時だけ、フォローされているユーザーに通知する' do
+  test '初めて提出した時だけ、自動Watchされているユーザーに通知する' do
     following = Following.first
     followed_user_login_name = User.find(following.followed_id).login_name
     follower_user_login_name = User.find(following.follower_id).login_name
     title = '初めて提出した時だけ'
-    description = 'フォローされているユーザーに通知を飛ばす'
+    description = '自動Watchされているユーザーに通知を飛ばす'
     notification_message = make_write_report_notification_message(
       followed_user_login_name, title
     )


### PR DESCRIPTION
ref: https://github.com/fjordllc/bootcamp/issues/3113

## 概要
[コメント通知が来ないタイプの日報フォロー機能が欲しい](https://github.com/fjordllc/bootcamp/issues/3007) の機能追加を行う前に、既存の日報フォロー機能の表記を「自動Watch」に変更した。

## やったこと
- 画面上の「フォロー」という表記を「自動Watch」に変更
- テスト上の「フォロー」という表記を「自動Watch」に変更


変更前
<img width="318" alt="Hajime Tayo" src="https://user-images.githubusercontent.com/67262644/131292568-35161988-390f-4588-b032-64d61e3f119e.png">
変更後
<img width="319" alt="Hajime Tayo" src="https://user-images.githubusercontent.com/67262644/131292573-b7ef0781-52f8-4485-8f5f-2062eadbc99d.png">

## やらなかったこと
- `/users`の「フォロー中」ナビやフォロー案内の文言を「自動Watch」に変更
    - 「自動Watch」と「日報購読」合わせて「フォロー機能」と称する予定のため。<img width="739" alt="貼り付けた画像_2021_08_30_14_47" src="https://user-images.githubusercontent.com/67262644/131292605-fc12d710-952a-4949-96f5-918b5df61189.png">