### PR TITLE
キーワード検索の結果表示の際、どの部分が該当箇所なのか（強調）表示して欲しい

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,35 +21,16 @@ module ApplicationHelper
 
   def searchable_summary(comment, word_count, word = '')
     summary = strip_tags(md2html(comment)).gsub(/[\r\n]/, '')
-    return truncate(summary, length: word_count) if word.blank?
+    words = word.split(/[[:space:]]+/).compact.reject(&:empty?) unless word.nil?
+    return truncate(summary, length: word_count) if words.blank?
 
-    words = word.split(/[[:space:]]/).compact.reject(&:empty?)
-    word_indexes = create_indexes(summary, words)
-    first_match_word_index = word_indexes.compact.min
-    return truncate(summary, length: word_count) if first_match_word_index.nil?
+    words_pattern = words.map { |keyword| Regexp.escape(keyword) }.join('|')
+    words_regexp = Regexp.new(words_pattern, Regexp::IGNORECASE)
+    match = words_regexp.match(comment)
+    return truncate(summary, length: word_count) if match.nil?
 
-    start_index = first_match_word_index - EXTRACTING_CHARACTERS
-
-    first_match_word = words[word_indexes.index(first_match_word_index)]
-    matched_characters_before_and_after_word(summary, first_match_word, start_index)
-  end
-
-  def create_indexes(summary, words)
-    words.map do |keyword|
-      summary.index(/#{keyword}/i)
-    end
-  end
-
-  def matched_characters_before_and_after_word(summary, first_match_word, start_index)
-    summary =~ /#{first_match_word}/i
-    match_before = if start_index >= 0
-                     Regexp.last_match.pre_match.slice(start_index, EXTRACTING_CHARACTERS)
-                   else
-                     Regexp.last_match.pre_match.slice(0, EXTRACTING_CHARACTERS)
-                   end
-    match_word = Regexp.last_match[0]
-    match_after = Regexp.last_match.post_match.slice(0, EXTRACTING_CHARACTERS)
-
-    match_before + match_word + match_after
+    begin_offset = (match.begin(0) - EXTRACTING_CHARACTERS).clamp(0, Float::INFINITY)
+    end_offset = match.end(0) + EXTRACTING_CHARACTERS
+    comment[begin_offset...end_offset]
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,11 +19,11 @@ module ApplicationHelper
 
   def searchable_summary(comment, word_count, word = nil)
     summary = strip_tags(md2html(comment)).gsub(/[\r\n]/, '')
-    return truncate(summary, length: word_count) if word.nil?
+    word_index = summary.index(word) unless word.nil?
+    return truncate(summary, length: word_count) if word.nil? || word_index.nil?
 
     characters_before_word = 50
     characters_after_word = 50
-    word_index = summary.index(word)
     start_index = word_index - characters_before_word
     display_characters = characters_before_word + word.size + characters_after_word
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,8 +17,20 @@ module ApplicationHelper
     simple_format(truncate(summary, length: word_count))
   end
 
-  def searchable_summary(comment, word_count)
+  def searchable_summary(comment, word_count, word = nil)
     summary = strip_tags(md2html(comment)).gsub(/[\r\n]/, '')
-    truncate(summary, length: word_count)
+    return truncate(summary, length: word_count) if word.nil?
+
+    characters_before_word = 50
+    characters_after_word = 50
+    word_index = summary.index(word)
+    start_index = word_index - characters_before_word
+    display_characters = characters_before_word + word.size + characters_after_word
+
+    if start_index >= 0
+      summary[start_index, display_characters]
+    else
+      summary[0, display_characters]
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,11 +26,11 @@ module ApplicationHelper
 
     words_pattern = words.map { |keyword| Regexp.escape(keyword) }.join('|')
     words_regexp = Regexp.new(words_pattern, Regexp::IGNORECASE)
-    match = words_regexp.match(comment)
+    match = words_regexp.match(summary)
     return truncate(summary, length: word_count) if match.nil?
 
     begin_offset = (match.begin(0) - EXTRACTING_CHARACTERS).clamp(0, Float::INFINITY)
     end_offset = match.end(0) + EXTRACTING_CHARACTERS
-    comment[begin_offset...end_offset]
+    summary[begin_offset...end_offset]
   end
 end

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -10,7 +10,7 @@
             a.thread-list-item-title__link(:href='searchable.url')
               | {{ searchable.title }}
       .thread-list-item__row
-        #summary.thread-list-item__summary(v-html='Summary')
+        .thread-list-item__summary(v-html='Summary')
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items
@@ -47,7 +47,10 @@ export default {
     Summary() {
       const word = this.word
       if (word) {
-        return this.searchable.summary.replace(word, `<strong>${word}</strong>`)
+        return this.searchable.summary.replace(
+          word,
+          `<strong class='matched_word'>${word}</strong>`
+        )
       } else {
         return this.searchable.summary
       }

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -10,8 +10,7 @@
             a.thread-list-item-title__link(:href='searchable.url')
               | {{ searchable.title }}
       .thread-list-item__row
-        .thread-list-item__summary
-          p {{ searchable.summary }}
+        #summary.thread-list-item__summary(v-html='Summary')
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items
@@ -30,7 +29,8 @@ import ja from 'dayjs/locale/ja'
 dayjs.locale(ja)
 export default {
   props: {
-    searchable: { type: Object, required: true }
+    searchable: { type: Object, required: true },
+    word: { type: String, required: true }
   },
   computed: {
     modelName() {
@@ -43,6 +43,14 @@ export default {
       return dayjs(this.searchable.updated_at).format(
         'YYYY年MM月DD日(dd) HH:mm'
       )
+    },
+    Summary() {
+      const word = this.word
+      if (word) {
+        return this.searchable.summary.replace(word, `<strong>${word}</strong>`)
+      } else {
+        return this.searchable.summary
+      }
     }
   }
 }

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -48,6 +48,7 @@ export default {
     summary() {
       const word = this.word
       const wordsPattern = word
+        .trim()
         .replaceAll(/[.*+?^=!:${}()|[\]/\\]/g, '\\$&')
         .replaceAll(/\s+/g, '|')
       const pattern = new RegExp(wordsPattern, 'gi')

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -10,7 +10,8 @@
             a.thread-list-item-title__link(:href='searchable.url')
               | {{ searchable.title }}
       .thread-list-item__row
-        .thread-list-item__summary(v-html='Summary')
+        .thread-list-item__summary
+          p(v-html='summary')
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items
@@ -44,12 +45,14 @@ export default {
         'YYYY年MM月DD日(dd) HH:mm'
       )
     },
-    Summary() {
+    summary() {
       const word = this.word
+      const wordsPattern = word.replaceAll(/[\s+]/g, '|')
+      const pattern = new RegExp(wordsPattern, 'gi')
       if (word) {
-        return this.searchable.summary.replace(
-          word,
-          `<strong class='matched_word'>${word}</strong>`
+        return this.searchable.summary.replaceAll(
+          pattern,
+          `<strong class='matched_word'>$&</strong>`
         )
       } else {
         return this.searchable.summary

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -47,7 +47,9 @@ export default {
     },
     summary() {
       const word = this.word
-      const wordsPattern = word.replaceAll(/[\s+]/g, '|')
+      const wordsPattern = word
+        .replace(/[.*+?^=!:${}()|[\]/\\]/g, '\\$&')
+        .replaceAll(/\s+/g, '|')
       const pattern = new RegExp(wordsPattern, 'gi')
       if (word) {
         return this.searchable.summary.replaceAll(

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -48,7 +48,7 @@ export default {
     summary() {
       const word = this.word
       const wordsPattern = word
-        .replace(/[.*+?^=!:${}()|[\]/\\]/g, '\\$&')
+        .replaceAll(/[.*+?^=!:${}()|[\]/\\]/g, '\\$&')
         .replaceAll(/\s+/g, '|')
       const pattern = new RegExp(wordsPattern, 'gi')
       if (word) {

--- a/app/javascript/searchables.vue
+++ b/app/javascript/searchables.vue
@@ -15,7 +15,8 @@
       searchable(
         v-for='searchable in searchables',
         :key='searchable.id',
-        :searchable='searchable'
+        :searchable='searchable',
+        :word='word'
       )
     nav.pagination(v-if='totalPages > 1')
       pager(v-bind='pagerProps')

--- a/app/javascript/searchables.vue
+++ b/app/javascript/searchables.vue
@@ -44,8 +44,11 @@ export default {
   },
   computed: {
     url() {
-      const SearchParams = new URLSearchParams(`word=${this.word}`)
-      return `/api/searchables?document_type=${this.documentType}&page=${this.currentPage}&${SearchParams}`
+      const params = new URLSearchParams()
+      params.append('document_type', this.documentType)
+      params.append('page', this.currentPage)
+      params.append('word', this.word)
+      return `/api/searchables?${params}`
     },
     pagerProps() {
       return {

--- a/app/javascript/searchables.vue
+++ b/app/javascript/searchables.vue
@@ -44,7 +44,8 @@ export default {
   },
   computed: {
     url() {
-      return `/api/searchables?document_type=${this.documentType}&page=${this.currentPage}&word=${this.word}`
+      const SearchParams = new URLSearchParams(`word=${this.word}`)
+      return `/api/searchables?document_type=${this.documentType}&page=${this.currentPage}&${SearchParams}`
     },
     pagerProps() {
       return {

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -2,7 +2,7 @@ json.title matched_document(searchable).title
 json.url searchable_url(searchable)
 json.model_name matched_document(searchable).class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{matched_document(searchable).class.to_s.tableize.singularize}")
-json.summary searchable_summary(filtered_message(searchable), 90)
+json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -72,3 +72,9 @@ question12:
   description: 解決済みの内容です。
   user: hajime
   practice: practice1
+
+question13:
+  title: 検索ワードが太字で表示されるかのテスト用の質問
+  description: こちらの質問は検索ワードの表示に関するテスト用の質問です。検索ワードが太字で表示されるかのテスト。こちらの質問は検索ワードの表示に関するテスト用の質問です。
+  user: hajime
+  practice: practice1

--- a/test/helpers/application_helper.rb
+++ b/test/helpers/application_helper.rb
@@ -59,4 +59,12 @@ class  ApplicationHelperTest < ActionView::TestCase
 
     assert_equal '09876543210987654321098765432109876543210987654321検索ワード検索単語キーワード12345678901234567890', searchable_summary(comment, word_count, word)
   end
+
+  test 'regexp in searchable_summary' do
+    comment = 'テスト! " # $ \' % & ( ) = ~ | - ^ ¥ ` { @ [ + * } ; : ] < > ? _ , . / 　テスト'
+    word_count = 90
+    word = '% テスト'
+
+    assert_equal 'テスト! " # $ \' % &amp; ( ) = ~ | - ^ ¥ ` { @ [ + * } ; ', searchable_summary(comment, word_count, word)
+  end
 end

--- a/test/helpers/application_helper.rb
+++ b/test/helpers/application_helper.rb
@@ -5,8 +5,8 @@ require 'test_helper'
 class  ApplicationHelperTest < ActionView::TestCase
   test 'searchable_summary, characters before and after word is 50 over' do
     comment = '098765432109876543210987654321098765432109876543210987654321検索ワード123456789012345678901234567890123456789012345678901234567890'
-    word_count = 90,
-                 word = '検索ワード'
+    word_count = 90
+    word = '検索ワード'
 
     assert_equal '09876543210987654321098765432109876543210987654321検索ワード12345678901234567890123456789012345678901234567890',
                  searchable_summary(comment, word_count, word)
@@ -14,25 +14,49 @@ class  ApplicationHelperTest < ActionView::TestCase
 
   test 'searchable_summary, characters before and after word is 50 under' do
     comment = '0987654321検索ワード1234567890'
-    word_count = 90,
-                 word = '検索ワード'
+    word_count = 90
+    word = '検索ワード'
 
     assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word_count, word)
   end
 
   test 'searchable_summary, comment = word' do
     comment = '検索ワード'
-    word_count = 90,
-                 word = '検索ワード'
+    word_count = 90
+    word = '検索ワード'
 
     assert_equal '検索ワード', searchable_summary(comment, word_count, word)
   end
 
   test 'searchable_summary, word is ""' do
     comment = '0987654321検索ワード1234567890'
-    word_count = 90,
-                 word = ''
+    word_count = 90
+    word = ''
 
     assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word_count, word)
+  end
+
+  test 'searchable_summary, word is space' do
+    comment = '0987654321検索ワード1234567890'
+    word_count = 90
+    word = ' '
+
+    assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word_count, word)
+  end
+
+  test 'searchable_summary, comment is 100 characters over and word is empty' do
+    comment = '09876543210987654321098765432109876543210987654321検索ワード12345678901234567890123456789012345678901234567890'
+    word_count = 90
+    word = ''
+
+    assert_equal '09876543210987654321098765432109876543210987654321検索ワード12345678901234567890123456789012...', searchable_summary(comment, word_count, word)
+  end
+
+  test 'searchable_summary, word is multiple' do
+    comment = '09876543210987654321098765432109876543210987654321検索ワード検索単語キーワード12345678901234567890'
+    word_count = 90
+    word = 'キーワード　検索ワード　単語　'
+
+    assert_equal '09876543210987654321098765432109876543210987654321検索ワード検索単語キーワード12345678901234567890', searchable_summary(comment, word_count, word)
   end
 end

--- a/test/helpers/application_helper.rb
+++ b/test/helpers/application_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class  ApplicationHelperTest < ActionView::TestCase
+  test 'searchable_summary, characters before and after word is 50 over' do
+    comment = '098765432109876543210987654321098765432109876543210987654321検索ワード123456789012345678901234567890123456789012345678901234567890'
+    word_count = 90,
+                 word = '検索ワード'
+
+    assert_equal '09876543210987654321098765432109876543210987654321検索ワード12345678901234567890123456789012345678901234567890',
+                 searchable_summary(comment, word_count, word)
+  end
+
+  test 'searchable_summary, characters before and after word is 50 under' do
+    comment = '0987654321検索ワード1234567890'
+    word_count = 90,
+                 word = '検索ワード'
+
+    assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word_count, word)
+  end
+
+  test 'searchable_summary, comment = word' do
+    comment = '検索ワード'
+    word_count = 90,
+                 word = '検索ワード'
+
+    assert_equal '検索ワード', searchable_summary(comment, word_count, word)
+  end
+
+  test 'searchable_summary, word is ""' do
+    comment = '0987654321検索ワード1234567890'
+    word_count = 90,
+                 word = ''
+
+    assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word_count, word)
+  end
+end

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -113,4 +113,14 @@ class SearchablesTest < ApplicationSystemTestCase
     find('#test-search').click
     assert_text 'kimura'
   end
+
+  test 'matched_word is in bold' do
+    visit_with_auth '/', 'komagata'
+    within('form[name=search]') do
+      select 'すべて'
+      fill_in 'word', with: '検索ワードが太字で表示されるかのテスト'
+    end
+    find('#test-search').click
+    assert_selector 'strong.matched_word', text: '検索ワードが太字で表示されるかのテスト'
+  end
 end


### PR DESCRIPTION
#3006

変更前
検索ワードがどこにヒットしたのかよく分からない。
本文中のどこにヒットしたのか判断できるようにしました。
![スクリーンショット 2021-09-09 17 41 42](https://user-images.githubusercontent.com/47971067/132665289-6a97a732-ec39-45e5-ae24-c70801a83115.png)


変更後
- 検索ワードの前後５０文字を表示にしました。
- 検索ワードを太字で表示しました。
- 検索ワードが無い時は従来通り、90文字以内で表示されるようにしてあります。

![スクリーンショット 2021-09-09 18 59 26](https://user-images.githubusercontent.com/47971067/132665867-3e68d17c-c6a3-457e-a2c5-e5cd5c75c9bc.png)
