### PR TITLE
涙マークの日報が2回続いた場合、メンターに通知する

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -138,4 +138,12 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     subject = "[bootcamp] #{@answer.receiver.login_name}さんの質問【 #{@answer.question.title} 】で#{@answer.sender.login_name}さんの回答がベストアンサーに選ばれました。"
     mail to: @user.email, subject: subject
   end
+
+  # required params: report, receiver
+  def twice_sad_report
+    @user = @receiver
+    @notification = @user.notifications.find_by(path: "/reports/#{@report.id}")
+    mail to: @user.email,
+         subject: "[bootcamp] #{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。"
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -140,7 +140,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   end
 
   # required params: report, receiver
-  def twice_sad_report
+  def consecutive_sad_report
     @user = @receiver
     @notification = @user.notifications.find_by(path: "/reports/#{@report.id}")
     mail to: @user.email,

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -144,6 +144,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @user = @receiver
     @notification = @user.notifications.find_by(path: "/reports/#{@report.id}")
     mail to: @user.email,
-         subject: "[bootcamp] #{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。"
+         subject: "[bootcamp] #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。"
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -22,7 +22,7 @@ class Notification < ApplicationRecord
     create_pages: 12,
     following_report: 13,
     chose_correct_answer: 14,
-    twice_sad_report: 15
+    consecutive_sad_report: 15
   }
 
   scope :reads, lambda {
@@ -204,7 +204,7 @@ class Notification < ApplicationRecord
     )
   end
 
-  def self.twice_sad_report(report, receiver)
+  def self.consecutive_sad_report(report, receiver)
     Notification.create!(
       kind: 15,
       user: receiver,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -21,7 +21,8 @@ class Notification < ApplicationRecord
     moved_up_event_waiting_user: 11,
     create_pages: 12,
     following_report: 13,
-    chose_correct_answer: 14
+    chose_correct_answer: 14,
+    twice_sad_report: 15
   }
 
   scope :reads, lambda {
@@ -199,6 +200,17 @@ class Notification < ApplicationRecord
       sender: answer.receiver,
       path: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
       message: "#{answer.receiver.login_name}さんの質問【 #{answer.question.title} 】で#{answer.sender.login_name}さんの回答がベストアンサーに選ばれました。",
+      read: false
+    )
+  end
+
+  def self.twice_sad_report(report, receiver)
+    Notification.create!(
+      kind: 15,
+      user: receiver,
+      sender: report.sender,
+      path: Rails.application.routes.url_helpers.polymorphic_path(report),
+      message: "#{report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。",
       read: false
     )
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -210,7 +210,7 @@ class Notification < ApplicationRecord
       user: receiver,
       sender: report.sender,
       path: Rails.application.routes.url_helpers.polymorphic_path(report),
-      message: "#{report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。",
+      message: "#{report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。",
       read: false
     )
   end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -152,7 +152,11 @@ class NotificationFacade
 
   def self.twice_sad_report(report, receiver)
     Notification.twice_sad_report(report, receiver)
+    return unless receiver.mail_notification? && !receiver.retired_on?
 
-    # TODO: メール送信を実装
+    NotificationMailer.with(
+      report: report,
+      receiver: receiver
+    ).twice_sad_report.deliver_later(wait: 5)
   end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -149,4 +149,10 @@ class NotificationFacade
       receiver: receiver
     ).chose_correct_answer.deliver_later(wait: 5)
   end
+
+  def self.twice_sad_report(report, receiver)
+    Notification.twice_sad_report(report, receiver)
+
+    # TODO: メール送信を実装
+  end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -150,13 +150,13 @@ class NotificationFacade
     ).chose_correct_answer.deliver_later(wait: 5)
   end
 
-  def self.twice_sad_report(report, receiver)
-    Notification.twice_sad_report(report, receiver)
+  def self.consecutive_sad_report(report, receiver)
+    Notification.consecutive_sad_report(report, receiver)
     return unless receiver.mail_notification? && !receiver.retired_on?
 
     NotificationMailer.with(
       report: report,
       receiver: receiver
-    ).twice_sad_report.deliver_later(wait: 5)
+    ).consecutive_sad_report.deliver_later(wait: 5)
   end
 end

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -37,7 +37,7 @@ class ReportCallbacks
   def notify_users(report)
     notify_first_report(report) if report.first?
     notify_advisers(report) if report.user.trainee? && report.user.company_id?
-    notify_twice_sad_report(report) if report.user.depressed?
+    notify_consecutive_sad_report(report) if report.user.depressed?
     notify_followers(report)
     report.notify_all_mention_user
   end
@@ -56,9 +56,9 @@ class ReportCallbacks
     end
   end
 
-  def notify_twice_sad_report(report)
+  def notify_consecutive_sad_report(report)
     User.mentor.each do |receiver|
-      NotificationFacade.twice_sad_report(report, receiver)
+      NotificationFacade.consecutive_sad_report(report, receiver)
     end
   end
 

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -37,6 +37,7 @@ class ReportCallbacks
   def notify_users(report)
     notify_first_report(report) if report.first?
     notify_advisers(report) if report.user.trainee? && report.user.company_id?
+    notify_twice_sad_report(report) if report.user.depressed?
     notify_followers(report)
     report.notify_all_mention_user
   end
@@ -52,6 +53,12 @@ class ReportCallbacks
     report.user.followers.each do |follower|
       NotificationFacade.following_report(report, follower)
       create_following_watch(report, follower)
+    end
+  end
+
+  def notify_twice_sad_report(report)
+    User.mentor.each do |receiver|
+      NotificationFacade.twice_sad_report(report, receiver)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -523,8 +523,8 @@ class User < ApplicationRecord
   end
 
   def depressed?
-    three_days_reports = reports.order(reported_on: :desc).limit(3)
-    three_days_reports.size == 3 && three_days_reports.all?(&:sad?)
+    two_days_reports = reports.order(reported_on: :desc).limit(2)
+    two_days_reports.size == 2 && two_days_reports.all?(&:sad?)
   end
 
   def active_practice

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   AVATAR_SIZE = '88x88>'
   RESERVED_LOGIN_NAMES = %w[adviser all graduate inactive job_seeking mentor retired student student_and_trainee trainee year_end_party].freeze
   MAX_PERCENTAGE = 100
+  DEPRESSED_SIZE = 2
 
   enum job: {
     student: 0,
@@ -523,8 +524,8 @@ class User < ApplicationRecord
   end
 
   def depressed?
-    two_days_reports = reports.order(reported_on: :desc).limit(2)
-    two_days_reports.size == 2 && two_days_reports.all?(&:sad?)
+    reported_reports = reports.order(reported_on: :desc).limit(DEPRESSED_SIZE)
+    reported_reports.size == DEPRESSED_SIZE && reported_reports.all?(&:sad?)
   end
 
   def active_practice

--- a/app/views/notification_mailer/consecutive_sad_report.html.slim
+++ b/app/views/notification_mailer/consecutive_sad_report.html.slim
@@ -1,0 +1,4 @@
+= render 'notification_mailer_template', title: "#{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。", link_url: notification_url(@notification), link_text: 'この日報へ' do
+  p #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。メンターのみなさんはフォローいただけると幸いです。
+  div(style='border-top: solid 1px #ccc; height: 0;')
+  = md2html(@report.description)

--- a/app/views/notification_mailer/twice_sad_report.html.slim
+++ b/app/views/notification_mailer/twice_sad_report.html.slim
@@ -1,4 +1,4 @@
-= render 'notification_mailer_template', title: "#{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。", link_url: report_url(@report), link_text: 'この日報へ' do
+= render 'notification_mailer_template', title: "#{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。", link_url: notification_url(@notification), link_text: 'この日報へ' do
   p #{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。メンターのみなさんはフォローいただけると幸いです。
   div(style='border-top: solid 1px #ccc; height: 0;')
   = md2html(@report.description)

--- a/app/views/notification_mailer/twice_sad_report.html.slim
+++ b/app/views/notification_mailer/twice_sad_report.html.slim
@@ -1,0 +1,4 @@
+= render 'notification_mailer_template', title: "#{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。", link_url: report_url(@report), link_text: 'この日報へ' do
+  p #{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。メンターのみなさんはフォローいただけると幸いです。
+  div(style='border-top: solid 1px #ccc; height: 0;')
+  = md2html(@report.description)

--- a/app/views/notification_mailer/twice_sad_report.html.slim
+++ b/app/views/notification_mailer/twice_sad_report.html.slim
@@ -1,4 +1,0 @@
-= render 'notification_mailer_template', title: "#{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。", link_url: notification_url(@notification), link_text: 'この日報へ' do
-  p #{@report.user.login_name}さんが2回連続でsadアイコンの日報を提出しました。メンターのみなさんはフォローいただけると幸いです。
-  div(style='border-top: solid 1px #ccc; height: 0;')
-  = md2html(@report.description)

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -2,7 +2,7 @@
   .a-card.is-only-mentor
     header.card-header
       h2.card-header__title
-        | 2日連続
+        | 2回連続
         = image_tag Report.faces['sad'], id: 'sad', alt: 'sad', class: 'card-header__title-emotion-image'
         | のユーザー
     .card-list

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -2,7 +2,7 @@
   .a-card.is-only-mentor
     header.card-header
       h2.card-header__title
-        | 3日連続
+        | 2日連続
         = image_tag Report.faces['sad'], id: 'sad', alt: 'sad', class: 'card-header__title-emotion-image'
         | のユーザー
     .card-list

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -126,7 +126,7 @@ notification_chose_correct_answer:
   path: "/questions/<%= ActiveRecord::FixtureSet.identify(:question12) %>"
   read: false
 
-notification_twice_sad_report:
+notification_consecutive_sad_report:
   kind: 15
   user: komagata
   sender: hajime

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -125,3 +125,11 @@ notification_chose_correct_answer:
   message: hajimeさんの質問【 解決済みの質問 】でadvijirouさんの回答がベストアンサーに選ばれました。
   path: "/questions/<%= ActiveRecord::FixtureSet.identify(:question12) %>"
   read: false
+
+notification_twice_sad_report:
+  kind: 15
+  user: komagata
+  sender: hajime
+  message: hajimeさんが2回連続でsadアイコンの日報を提出しました。
+  path: "/reports/<%= ActiveRecord::FixtureSet.identify(:report16) %>"
+  read: false

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -297,13 +297,13 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/回答/, email.body.to_s)
   end
 
-  test 'twice_sad_report' do
+  test 'consecutive_sad_report' do
     report = reports(:report16)
-    twice_sad_report = notifications(:notification_twice_sad_report)
+    consecutive_sad_report = notifications(:notification_consecutive_sad_report)
     mailer = NotificationMailer.with(
       report: report,
-      receiver: twice_sad_report.user
-    ).twice_sad_report
+      receiver: consecutive_sad_report.user
+    ).consecutive_sad_report
 
     perform_enqueued_jobs do
       mailer.deliver_later

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -296,4 +296,24 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal '[bootcamp] hajimeさんの質問【 解決済みの質問 】でadvijirouさんの回答がベストアンサーに選ばれました。', email.subject
     assert_match(/回答/, email.body.to_s)
   end
+
+  test 'twice_sad_report' do
+    report = reports(:report16)
+    twice_sad_report = notifications(:notification_twice_sad_report)
+    mailer = NotificationMailer.with(
+      report: report,
+      receiver: twice_sad_report.user
+    ).twice_sad_report
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[bootcamp] hajimeさんが2回連続でsadアイコンの日報を提出しました。', email.subject
+    assert_match(/2回連続/, email.body.to_s)
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -117,4 +117,11 @@ class NotificationMailerPreview < ActionMailer::Preview
 
     NotificationMailer.with(answer: answer, receiver: receiver).chose_correct_answer
   end
+
+  def twice_sad_report
+    report = Report.find(ActiveRecord::FixtureSet.identify(:report16))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
+
+    NotificationMailer.with(report: report, receiver: receiver).twice_sad_report
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -118,10 +118,10 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.with(answer: answer, receiver: receiver).chose_correct_answer
   end
 
-  def twice_sad_report
+  def consecutive_sad_report
     report = Report.find(ActiveRecord::FixtureSet.identify(:report16))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
 
-    NotificationMailer.with(report: report, receiver: receiver).twice_sad_report
+    NotificationMailer.with(report: report, receiver: receiver).consecutive_sad_report
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -93,17 +93,16 @@ class UserTest < ActiveSupport::TestCase
 
   test '#depressed?' do
     user = users(:kimura)
-    2.times do |i|
-      Report.create!(
-        user_id: user.id, title: "test #{i}", description: 'test',
-        wip: false, emotion: 'sad', reported_on: i.days.ago, no_learn: true
-      )
-    end
+
+    Report.create!(
+      user_id: user.id, title: 'test 1', description: 'test',
+      wip: false, emotion: 'sad', reported_on: Date.current, no_learn: true
+    )
     assert_not user.depressed?
 
     Report.create!(
       user_id: user.id, title: 'test 2', description: 'test',
-      wip: false, emotion: 'sad', reported_on: 2.days.ago, no_learn: true
+      wip: false, emotion: 'sad', reported_on: 1.days.ago, no_learn: true
     )
     assert user.depressed?
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -102,7 +102,7 @@ class UserTest < ActiveSupport::TestCase
 
     Report.create!(
       user_id: user.id, title: 'test 2', description: 'test',
-      wip: false, emotion: 'sad', reported_on: 1.days.ago, no_learn: true
+      wip: false, emotion: 'sad', reported_on: 1.day.ago, no_learn: true
     )
     assert user.depressed?
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -152,4 +152,36 @@ class Notification::ReportsTest < ApplicationSystemTestCase
       description
     )
   end
+
+  test 'sadアイコンの日報を2回続けて提出した場合、メンターに通知する' do
+    student = 'hajime'
+    mentor = 'yamada'
+
+    visit_with_auth '/reports', student
+
+    [1, 3].each do |i|
+      click_link '日報作成'
+
+      within('#new_report') do
+        fill_in('report[title]', with: 'test title')
+        fill_in('report[description]', with: 'test')
+        fill_in('report[reported_on]', with: "2021/09/0#{i}")
+        find('#sad').click
+      end
+
+      all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
+      all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
+      all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
+      all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+
+      click_button '提出'
+    end
+
+    logout
+
+    login_user mentor, 'testtest'
+    open_notification
+
+    assert_equal "#{student}さんが2回連続でsadアイコンの日報を提出しました。", notification_message
+  end
 end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -154,28 +154,36 @@ class Notification::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'sadアイコンの日報を2回続けて提出した場合、メンターに通知する' do
-    student = 'hajime'
+    student = 'kimura'
     mentor = 'yamada'
 
     visit_with_auth '/reports', student
 
-    [1, 3].each do |i|
-      click_link '日報作成'
-
-      within('#new_report') do
-        fill_in('report[title]', with: 'test title')
-        fill_in('report[description]', with: 'test')
-        fill_in('report[reported_on]', with: "2021/09/0#{i}")
-        find('#sad').click
-      end
-
-      all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
-      all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
-      all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
-      all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
-
-      click_button '提出'
+    click_link '日報作成'
+    within('#new_report') do
+      fill_in('report[title]', with: 'test title 1')
+      fill_in('report[description]', with: 'test 1')
+      fill_in('report[reported_on]', with: '2021-09-01')
+      find('#sad').click
     end
+    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
+    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+    click_button '提出'
+
+    click_link '日報作成'
+    within('#new_report') do
+      fill_in('report[title]', with: 'test title 2')
+      fill_in('report[description]', with: 'test 2')
+      fill_in('report[reported_on]', with: '2021-09-03')
+      find('#sad').click
+    end
+    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
+    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+    click_button '提出'
 
     logout
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -153,7 +153,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test 'sadアイコンの日報を2回続けて提出した場合、メンターに通知する' do
+  test 'notify to mentors when a student submitted reports with sad icon at twice in a row' do
     student = 'kimura'
     mentor = 'yamada'
 


### PR DESCRIPTION
ref: #1894

# 概要
日報が2回以上連続でsadアイコンで提出された場合、以下のタスクを実行する

1. ダッシュボードに該当ユーザーを表示する
2. メンターに該当ユーザーの日報を通知する
3. メンターに該当ユーザーの日報をメール通知する

# スクリーンショット

No | 画像
--- | ---
1 | ![スクリーンショット 2021-09-08 19 49 01](https://user-images.githubusercontent.com/1329464/132496951-0edf7d90-fd39-4a4f-aff5-f6bd15acfcce.png)
2 | ![スクリーンショット 2021-09-08 19 50 36](https://user-images.githubusercontent.com/1329464/132496978-64c100a1-c121-4754-b989-899691ba0d41.png)
3 | ![スクリーンショット 2021-09-08 19 51 54](https://user-images.githubusercontent.com/1329464/132497003-b8ba0fc8-e3c2-4e3a-831b-6fecc10ef4b9.png)




