### PR TITLE
管理画面にコース作成・編集・削除機能の追加

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -35,6 +35,8 @@ class Admin::CoursesController < AdminController
     redirect_to admin_courses_path, notice: 'コースを削除しました。'
   end
 
+  private
+
   def set_course
     @course = Course.find(params[:id])
   end

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -1,7 +1,49 @@
 # frozen_string_literal: true
 
 class Admin::CoursesController < AdminController
+  before_action :set_course, only: %i[edit update destroy]
+  
   def index
     @courses = Course.order(created_at: :desc)
+  end
+
+  def new
+    @course = Course.new
+  end
+
+  def edit; end
+
+  def create
+    @course = Course.new(course_params)
+    if @course.save
+      redirect_to admin_courses_path, notice: 'コースを作成しました。'
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @course.update(course_params)
+      redirect_to admin_courses_path, notice: 'コースを更新しました。'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @course.destroy
+    redirect_to admin_courses_path, notice: 'コースを削除しました。'
+  end
+
+  def set_course
+    @course = Course.find(params[:id])
+  end
+
+  def course_params
+    params.require(:course).permit(
+      :title,
+      :description,
+      category_ids: []
+    )
   end
 end

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -2,7 +2,7 @@
 
 class Admin::CoursesController < AdminController
   before_action :set_course, only: %i[edit update destroy]
-  
+
   def index
     @courses = Course.order(created_at: :desc)
   end

--- a/app/views/admin/courses/_course.html.slim
+++ b/app/views/admin/courses/_course.html.slim
@@ -6,11 +6,11 @@ tr.admin-table__item(id="course_#{course.id}")
   td.admin-table__item-value.admin-table__item-value.is-text-align-center
     ul.is-inline-buttons
       li
-        = link_to edit_course_path(course), class: 'a-button is-sm is-secondary is-icon is-block' do
+        = link_to edit_admin_course_path(course), class: 'a-button is-sm is-secondary is-icon is-block' do
           i.fas.fa-pen
       li
         = link_to course_categories_path(course), class: 'a-button is-sm is-secondary is-icon is-block' do
           i.fas.fa-align-justify
       li
-        = link_to course, method: :delete, class: 'a-button is-sm is-danger is-icon is-block js-delete', data: { confirm: '本当によろしいですか？' } do
+        = link_to admin_course_path(course), method: :delete, class: 'a-button is-sm is-danger is-icon is-block js-delete', data: { confirm: '本当によろしいですか？' } do
           i.far.fa-trash-alt

--- a/app/views/admin/courses/_form.html.slim
+++ b/app/views/admin/courses/_form.html.slim
@@ -1,0 +1,31 @@
+= form_with model: [:admin, @course], local: true, class: 'form', html: { name: 'course' } do |f|
+  = render 'errors', object: course
+  .form-item
+    .row
+      .col-md-6.col-xs-12
+        = f.label :title, class: 'a-form-label'
+        = f.text_field :title, class: 'a-text-input js-warning-form'
+  .form-item
+    .row.js-markdown-parent
+      .col-md-6.col-xs-12
+        = f.label :description, class: 'a-form-label'
+        = f.text_area :description, class: 'a-text-input js-warning-form markdown-form__text-area js-markdown', data: { 'preview': '.js-preview' }
+      .col-md-6.col-xs-12
+        .a-form-label
+          | プレビュー
+        .js-preview.is-long-text.markdown-form__preview
+  .form-item
+    .row
+      .col-md-6.col-xs-12
+        .checkboxes
+          ul.checkboxes__items
+            = f.collection_check_boxes :category_ids, Category.all, :id, :name, class: 'label-checkbox' do |b|
+              li.checkboxes__item
+                = b.label { b.check_box + b.text }
+  .form-actions
+    ul.form-actions__items
+      li.form-actions__item.is-main
+        button.a-button.is-lg.is-warning.is-block
+          | 内容を保存
+      li.form-actions__item.is-sub
+        = link_to 'キャンセル', :back, class: 'a-button is-md is-secondary is-block'

--- a/app/views/admin/courses/edit.html.slim
+++ b/app/views/admin/courses/edit.html.slim
@@ -1,0 +1,16 @@
+- content_for(:extra_body_classes, 'no-recent-reports')
+- title 'コース編集'
+
+.page-header
+  .container
+    .page-header__inner
+      h1.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to admin_courses_path, class: 'a-button is-md is-secondary is-block' do
+              | コース一覧
+.page-body
+  .container.is-xxl
+    = render 'form', course: @course

--- a/app/views/admin/courses/index.html.slim
+++ b/app/views/admin/courses/index.html.slim
@@ -6,7 +6,7 @@ header.page-header
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item
-            = link_to new_course_path, class: 'a-button is-md is-secondary is-block' do
+            = link_to new_admin_course_path, class: 'a-button is-md is-secondary is-block' do
               i.fas.fa-plus
               | コース作成
 

--- a/app/views/admin/courses/index.html.slim
+++ b/app/views/admin/courses/index.html.slim
@@ -26,4 +26,4 @@ header.page-header
             th.admin-table__label
               | 操作
         tbody.admin-table__items
-          = render @courses.order(:created_at)
+          = render @courses

--- a/app/views/admin/courses/new.html.slim
+++ b/app/views/admin/courses/new.html.slim
@@ -1,0 +1,16 @@
+- content_for(:extra_body_classes, 'no-recent-reports')
+- title 'コース作成'
+
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to admin_courses_path, class: 'a-button is-md is-secondary is-block' do
+              | コース一覧
+.page-body
+  .container
+    = render 'form', course: @course

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,7 @@ Rails.application.routes.draw do
       resource :password, only: %i(edit update), controller: "users/password"
     end
     resources :categories, except: %i(show)
-    resources :courses, only: %i(index)
+    resources :courses, except: %i(show)
   end
 
   namespace :current_user do

--- a/test/system/admin/courses_test.rb
+++ b/test/system/admin/courses_test.rb
@@ -4,7 +4,35 @@ require 'application_system_test_case'
 
 class Admin::CoursesTest < ApplicationSystemTestCase
   test 'show listing courses' do
-    visit_with_auth 'admin/courses', 'komagata'
+    visit_with_auth '/admin/courses', 'komagata'
     assert_equal 'コース一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+  end
+
+  test 'create course' do
+    visit_with_auth '/admin/courses/new', 'komagata'
+    within 'form[name=course]' do
+      fill_in 'course[title]', with: 'テストコース'
+      fill_in 'course[description]', with: 'テストのコースです。'
+      click_button '内容を保存'
+    end
+    assert_text 'コースを作成しました。'
+  end
+
+  test 'update course' do
+    visit_with_auth "/admin/courses/#{courses(:course1).id}/edit", 'komagata'
+    within 'form[name=course]' do
+      fill_in 'course[title]', with: 'テストコース'
+      fill_in 'course[description]', with: 'テストのコースです。'
+      click_button '内容を保存'
+    end
+    assert_text 'コースを更新しました。'
+  end
+
+  test 'delete course' do
+    visit_with_auth '/admin/courses', 'komagata'
+    accept_confirm do
+      find("#course_#{courses(:course3).id} .js-delete").click
+    end
+    assert_text 'コースを削除しました。'
   end
 end


### PR DESCRIPTION
issue:  [2902](https://github.com/fjordllc/bootcamp/issues/2902)
### 概要
```/admin/courses/:id/~```で作成・編集・削除機能を追加しました。
※並べ替え機能部分については、```/courses/:id/categories``` に遷移します。


### 参考
![image](https://user-images.githubusercontent.com/52092916/132359709-7a6886bc-0b93-4b2e-a25a-464b43c86109.png)
