### PR TITLE
担当提出物に未返信の絞り込み機能を実装

### DIFF
--- a/app/controllers/api/products/self_assigned_controller.rb
+++ b/app/controllers/api/products/self_assigned_controller.rb
@@ -7,9 +7,15 @@ class API::Products::SelfAssignedController < API::BaseController
     @target = 'self_assigned_no_replied' unless target_allowlist.include?(@target)
     @products = case @target
                 when 'self_assigned_all'
-                  Product.self_assigned_product(current_user.id).unchecked.list.page(params[:page])
+                  Product.self_assigned_product(current_user.id)
+                         .unchecked
+                         .list
+                         .page(params[:page])
                 when 'self_assigned_no_replied'
-                  Product.self_assigned_no_replied_products(current_user.id).unchecked.list.page(params[:page])
+                  Product.self_assigned_no_replied_products(current_user.id)
+                         .unchecked
+                         .list
+                         .page(params[:page])
                 end
   end
 

--- a/app/controllers/api/products/self_assigned_controller.rb
+++ b/app/controllers/api/products/self_assigned_controller.rb
@@ -3,6 +3,19 @@
 class API::Products::SelfAssignedController < API::BaseController
   before_action :require_staff_login_for_api
   def index
-    @products = Product.self_assigned_product(current_user.id).unchecked.list.page(params[:page])
+    @target = params[:target]
+    @target = 'self_assigned_no_replied' unless target_allowlist.include?(@target)
+    @products = case @target
+                when 'self_assigned_all'
+                  Product.self_assigned_product(current_user.id).unchecked.list.page(params[:page])
+                when 'self_assigned_no_replied'
+                  Product.self_assigned_no_replied_products(current_user.id).unchecked.list.page(params[:page])
+                end
+  end
+
+  private
+
+  def target_allowlist
+    %w[self_assigned_no_replied self_assigned_all]
   end
 end

--- a/app/controllers/products/self_assigned_controller.rb
+++ b/app/controllers/products/self_assigned_controller.rb
@@ -4,12 +4,12 @@ class Products::SelfAssignedController < ApplicationController
   before_action :require_staff_login
   def index
     @target = params[:target]
-    @target = 'no_replied' unless target_allowlist.include?(@target)
+    @target = 'self_assigned_no_replied' unless target_allowlist.include?(@target)
   end
 
   private
 
   def target_allowlist
-    %w[no_replied self_assigned_all]
+    %w[self_assigned_no_replied self_assigned_all]
   end
 end

--- a/app/controllers/products/self_assigned_controller.rb
+++ b/app/controllers/products/self_assigned_controller.rb
@@ -2,5 +2,14 @@
 
 class Products::SelfAssignedController < ApplicationController
   before_action :require_staff_login
-  def index; end
+  def index
+    @target = params[:target]
+    @target = 'no_replied' unless target_allowlist.include?(@target)
+  end
+
+  private
+
+  def target_allowlist
+    %w[no_replied self_assigned_all]
+  end
 end

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -56,7 +56,8 @@ export default {
       loaded: false,
       latestProductSubmittedJust5days: null,
       latestProductSubmittedJust6days: null,
-      latestProductSubmittedOver7days: null
+      latestProductSubmittedOver7days: null,
+      params: this.getParams()
     }
   },
   computed: {
@@ -66,7 +67,8 @@ export default {
         (this.selectedTab === 'all'
           ? ''
           : '/' + this.selectedTab.replace('-', '_')) +
-        `?page=${this.currentPage}`
+        `?page=${this.currentPage}` +
+        (this.params.target ? `&target=${this.params.target}` : '')
       )
     },
     unconfirmedLinksName() {
@@ -148,6 +150,17 @@ export default {
         null,
         location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
       )
+    },
+    getParams() {
+      const params = {}
+      location.search
+        .slice(1)
+        .split('&')
+        .forEach((query) => {
+          const queryArr = query.split('=')
+          params[queryArr[0]] = queryArr[1]
+        })
+      return params
     }
   }
 }

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -42,14 +42,14 @@ class Cache
       Rails.cache.delete 'unassigned_product_count'
     end
 
-    def self_assigned_product_count(current_user_id)
-      Rails.cache.fetch("#{current_user_id}-self_assigned_product_count") do
-        Product.self_assigned_product(current_user_id).unchecked.count
+    def self_assigned_no_replied_product_count(current_user_id)
+      Rails.cache.fetch("#{current_user_id}-self_assigned_no_replied_products_count") do
+        Product.self_assigned_no_replied_products(current_user_id).unchecked.count
       end
     end
 
-    def delete_self_assigned_product_count(current_user_id)
-      Rails.cache.delete "#{current_user_id}-self_assigned_product_count"
+    def delete_self_assigned_no_replied_product_count(current_user_id)
+      Rails.cache.delete "#{current_user_id}-self_assigned_no_replied_product_count"
     end
 
     def not_solved_question_count

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -133,7 +133,6 @@ class Product < ApplicationRecord
       LEFT JOIN last_comments ON self_assigned_products.id = last_comments.commentable_id
       WHERE last_comments.id IS NULL
       OR self_assigned_products.checker_id != last_comments.user_id
-      -- WHERE NOT (self_assigned_products.checker_id = last_comments.user_id)
       ORDER BY self_assigned_products.created_at DESC
     SQL
     Product.find_by_sql(sql).map(&:id)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -109,7 +109,42 @@ class Product < ApplicationRecord
       product.save!
     end
   end
+
+  def self.self_assigned_no_replied_product_ids(current_user_id)
+    sql = <<~SQL
+      WITH last_comments AS (
+        SELECT *
+        FROM comments AS parent
+        WHERE commentable_type = 'Product' AND id = (
+          SELECT id
+          FROM comments AS child
+          WHERE parent.commentable_id = child.commentable_id
+            AND commentable_type = 'Product'
+          ORDER BY created_at DESC LIMIT 1
+        )
+      ),
+      self_assigned_products AS (
+        SELECT products.*
+        FROM products
+        WHERE checker_id = #{current_user_id}
+      )
+      SELECT self_assigned_products.id
+      FROM self_assigned_products
+      LEFT JOIN last_comments ON self_assigned_products.id = last_comments.commentable_id
+      WHERE last_comments.id IS NULL
+      OR self_assigned_products.checker_id != last_comments.user_id
+      -- WHERE NOT (self_assigned_products.checker_id = last_comments.user_id)
+      ORDER BY self_assigned_products.created_at DESC
+    SQL
+    Product.find_by_sql(sql).map(&:id)
+  end
   # rubocop:enable Metrics/MethodLength
+
+  def self.self_assigned_no_replied_products(current_user_id)
+    no_replied_product_ids = self_assigned_no_replied_product_ids(current_user_id)
+    Product.where(id: no_replied_product_ids)
+           .order(created_at: :desc)
+  end
 
   def completed?(user)
     checks.where(user: user).present?
@@ -137,7 +172,7 @@ class Product < ApplicationRecord
     return false if other_checker_exists?(current_user_id)
 
     self.checker_id = checker_id ? nil : current_user_id
-    Cache.delete_self_assigned_product_count(current_user_id)
+    Cache.delete_self_assigned_no_replied_product_count(current_user_id)
     save!
   end
 

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -7,7 +7,7 @@ class ProductCallbacks
     Cache.delete_unchecked_product_count
     Cache.delete_not_responded_product_count
     Cache.delete_unassigned_product_count
-    Cache.delete_self_assigned_product_count(product.checker_id)
+    Cache.delete_self_assigned_no_replied_product_count(product.checker_id)
   end
 
   def after_save(product)
@@ -37,7 +37,7 @@ class ProductCallbacks
     Cache.delete_unchecked_product_count
     Cache.delete_not_responded_product_count
     Cache.delete_unassigned_product_count
-    Cache.delete_self_assigned_product_count(product.checker_id)
+    Cache.delete_self_assigned_no_replied_product_count(product.checker_id)
   end
 
   private

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -25,4 +25,4 @@
         = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
           | 自分の担当
           .page-tabs__item-count.a-notification-count.is-only-mentor
-            = Cache.self_assigned_product_count(current_user.id)
+            = Cache.self_assigned_no_replied_product_count(current_user.id)

--- a/app/views/products/self_assigned/_nav.html.slim
+++ b/app/views/products/self_assigned/_nav.html.slim
@@ -1,0 +1,7 @@
+nav.tab-nav
+  .container.is-padding-horizontal-0-sm-down
+    ul.tab-nav__items
+      - targets = %w[no_replied self_assigned_all]
+      - targets.each do |target|
+        li.tab-nav__item
+          = link_to t("target.#{target}"), products_self_assigned_index_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/products/self_assigned/_nav.html.slim
+++ b/app/views/products/self_assigned/_nav.html.slim
@@ -1,7 +1,7 @@
 nav.tab-nav
   .container.is-padding-horizontal-0-sm-down
     ul.tab-nav__items
-      - targets = %w[no_replied self_assigned_all]
+      - targets = %w[self_assigned_no_replied self_assigned_all]
       - targets.each do |target|
         li.tab-nav__item
           = link_to t("target.#{target}"), products_self_assigned_index_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/products/self_assigned/_nav.html.slim
+++ b/app/views/products/self_assigned/_nav.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav.is-centered
   .container.is-padding-horizontal-0-sm-down
     ul.tab-nav__items
       - targets = %w[self_assigned_no_replied self_assigned_all]

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -10,4 +10,6 @@ header.page-header
   = render 'products/tabs'
   = render 'nav'
 
+- title 'レビューを担当する未返信の提出物' if @target == 'self_assigned_no_replied'
+
 #js-products(data-title="#{title}" data-selected-tab="self-assigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -8,5 +8,6 @@ header.page-header
 
 .page-tools
   = render 'products/tabs'
+  = render 'nav'
 
 #js-products(data-title="#{title}" data-selected-tab="self-assigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -224,6 +224,8 @@ ja:
     trainee: 研修生
     admin: 管理者
     followings: フォロー中
+    self_assigned_all: 全て
+    no_replied: 未返信
   helpers:
     submit:
       create: 登録する

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -225,7 +225,7 @@ ja:
     admin: 管理者
     followings: フォロー中
     self_assigned_all: 全て
-    no_replied: 未返信
+    self_assigned_no_replied: 未返信
   helpers:
     submit:
       create: 登録する

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -111,4 +111,16 @@ class ProductTest < ActiveSupport::TestCase
     )
     assert product.save_checker(current_user.id)
   end
+
+  test '.self_assigned_no_replied_products' do
+    current_user = users(:yamada)
+    product = Product.create!(
+      body: 'test',
+      user: users(:kimura),
+      practice: practices(:practice5),
+      checker_id: nil
+    )
+    product.save_checker(current_user.id)
+    assert_equal [product.id], Product.self_assigned_no_replied_products(current_user.id).pluck(:id)
+  end
 end

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -47,7 +47,7 @@ class ProductsTest < ApplicationSystemTestCase
     checker = users(:komagata)
     product.checker_id = checker.id
     product.save
-    visit_with_auth '/products/self_assigned', 'komagata'
+    visit_with_auth '/products/self_assigned?target=self_assigned_all', 'komagata'
     assert_text 'レビューを担当する提出物はありません'
   end
 
@@ -110,6 +110,6 @@ class ProductsTest < ApplicationSystemTestCase
     assert_equal [user.login_name], names
     visit_with_auth '/products/self_assigned', 'yamada'
     wait_for_vuejs
-    assert_text 'レビューを担当する提出物はありません'
+    assert_text 'レビューを担当する未返信の提出物はありません'
   end
 end

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -92,11 +92,11 @@ class ProductsTest < ApplicationSystemTestCase
     practice = practices(:practice5)
     user = users(:kimura)
     product = Product.create!(
-                body: 'test',
-                user: user,
-                practice: practice,
-                checker_id: checker.id
-              )
+      body: 'test',
+      user: user,
+      practice: practice,
+      checker_id: checker.id
+    )
     visit_with_auth "/products/#{product.id}", 'yamada'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -50,4 +50,66 @@ class ProductsTest < ApplicationSystemTestCase
     visit_with_auth '/products/self_assigned', 'komagata'
     assert_text 'レビューを担当する提出物はありません'
   end
+
+  test 'display no replied products if click on self-assigned-tab' do
+    checker = users(:yamada)
+    practice = practices(:practice5)
+    user = users(:kimura)
+    Product.create!(
+      body: 'test',
+      user: user,
+      practice: practice,
+      checker_id: checker.id
+    )
+    visit_with_auth '/products/self_assigned', 'yamada'
+    wait_for_vuejs
+    titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
+    names = all('.thread-list-item-meta .a-user-name').map(&:text)
+    assert_equal ["#{practice.title}の提出物"], titles
+    assert_equal [user.login_name], names
+  end
+
+  test 'display no replied products if click on no-replied-button' do
+    checker = users(:yamada)
+    practice = practices(:practice5)
+    user = users(:kimura)
+    Product.create!(
+      body: 'test',
+      user: user,
+      practice: practice,
+      checker_id: checker.id
+    )
+    visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', 'yamada'
+    wait_for_vuejs
+    titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
+    names = all('.thread-list-item-meta .a-user-name').map(&:text)
+    assert_equal ["#{practice.title}の提出物"], titles
+    assert_equal [user.login_name], names
+  end
+
+  test 'display replied products if click on self_assigned_all-button' do
+    checker = users(:yamada)
+    practice = practices(:practice5)
+    user = users(:kimura)
+    product = Product.create!(
+                body: 'test',
+                user: user,
+                practice: practice,
+                checker_id: checker.id
+              )
+    visit_with_auth "/products/#{product.id}", 'yamada'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    click_button 'コメントする'
+    visit_with_auth '/products/self_assigned?target=self_assigned_all', 'yamada'
+    wait_for_vuejs
+    titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
+    names = all('.thread-list-item-meta .a-user-name').map(&:text)
+    assert_equal ["#{practice.title}の提出物"], titles
+    assert_equal [user.login_name], names
+    visit_with_auth '/products/self_assigned', 'yamada'
+    wait_for_vuejs
+    assert_text 'レビューを担当する提出物はありません'
+  end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -285,13 +285,14 @@ class ProductsTest < ApplicationSystemTestCase
 
     [
       '担当者がいない提出物の場合、担当者になる',
-      '自分が担当者の場合、担当者のまま'
+      '自分が担当者の場合、担当者のまま',
+      'タブ上の数字は未返信の数字のため、返信するとカウントされない'
     ].each do |comment|
       visit "/products/#{products(:product1).id}"
       post_comment(comment)
 
       visit products_not_responded_index_path
-      assert_equal before_comment + 1, assigned_product_count
+      assert_equal before_comment, assigned_product_count
     end
   end
 


### PR DESCRIPTION
ref #3022 

## やったこと
メンターが使う機能について対応しました。
担当している提出物について、未返信の提出物を抽出して画面表示するように変更しました。
"自分の担当"のタブに表示される数字についても、未返信の提出物の個数に変更しました。

- 未返信提出物の抽出条件
　自分(メンター)が担当している かつ OKを出していない かつ コメントの最後が自分(メンター)ではない
- 全ての抽出条件
　自分(メンター)が担当している かつ OKを出していない
##### 変更前
- 未返信、返信にかかわらず全ての担当提出物を抽出
- タブ上の数字も全ての担当提出物の個数
![レビューを担当する提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/132356225-d2970d7e-456f-4e0b-8328-e7b066148ef5.png)


##### 変更後
- 未返信の画面
  - 未返信の提出のみを抽出
  - タブ上の数字は未返信の担当提出物の個数 
![レビューを担当する未返信の提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/132356502-d017ef02-33a3-47fc-a229-b50f4de2c076.png)

- 全ての画面
  - 未返信、返信にかかわらず全ての担当提出物を抽出
![レビューを担当する提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/57123982/132356737-3983ab50-f322-4e45-bcdf-8d76073b291a.png)
