### PR TITLE
params[:page]に値が指定されている場合のみpageを指定するようにした

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -9,6 +9,7 @@ class API::NotificationsController < API::BaseController
                                  .by_target(target)
                                  .by_read_status(status)
                                  .order(created_at: :desc)
-                                 .page(params[:page])
+
+    @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications
   end
 end

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -2,7 +2,7 @@
   .container
     ul.page-tabs__items
       li.page-tabs__item
-        = link_to t('notofication.all'), notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
+        = link_to t('notification.all'), notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -171,6 +171,30 @@ class NotificationsTest < ApplicationSystemTestCase
     assert_text 'hatsunoさんの【 「コメントと」の日報 】にkomagataさんがコメントしました。'
   end
 
+  test 'show notification count' do
+    Notification.create(message: 'machidaさんからメンションが届きました',
+                        created_at: '2040-01-18 06:06:42',
+                        kind: 'mentioned',
+                        path: '/reports/20400118',
+                        user: users(:yamada),
+                        sender: users(:machida))
+
+    visit_with_auth '/notifications', 'yamada'
+    wait_for_vuejs
+    assert_selector '.header-notification-count', text: '1'
+
+    20.times do |n|
+      Notification.create(message: "machidaさんからメンションが届きました#{n}",
+                          kind: 'mentioned',
+                          path: "/reports/#{n}",
+                          user: users(:yamada),
+                          sender: users(:machida))
+    end
+    visit_with_auth '/notifications', 'yamada'
+    wait_for_vuejs
+    assert_selector '.header-notification-count', text: '21'
+  end
+
   test 'show listing unread notification' do
     visit_with_auth '/notifications?status=unread', 'hatsuno'
     assert_equal '通知 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title


### PR DESCRIPTION
Ref: https://github.com/fjordllc/bootcamp/issues/3258

## やったこと
params[:page]に値が指定されていない場合にデータが最大20件しか取得できないバグの修正
 