### PR TITLE
開発者向けにdead_end gemを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
   # not default
+  gem 'dead_end'
   gem 'pry-byebug'
   gem 'traceroute'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     crass (1.0.6)
     data_migrate (6.6.0)
       rails (>= 5.0)
+    dead_end (1.1.7)
     declarative (0.0.20)
     declarative-option (0.1.0)
     diffy (3.4.0)
@@ -497,6 +498,7 @@ DEPENDENCIES
   coffee-rails (~> 5.0.0)
   commonmarker
   data_migrate
+  dead_end
   diffy
   discord-notifier
   google-cloud-storage (~> 1.25)


### PR DESCRIPTION
## 概要
[RubyKaigi Takeout 2021](https://rubykaigi.org/2021-takeout/presentations/schneems.html)でdead_endというgemの紹介があり、開発者向けに導入をご検討いただきたくこのPRを出しました

開発中によく遭遇する `syntax error, unexpected end-of-input, expecting end` はどこで `end` が足りていないかわかりづらく、ファイルの行数が多いほどエラーの発生箇所を探すのに苦戦します。
この問題を解決するのが `dead_end` というgemです。
https://github.com/zombocom/dead_end

## 動作確認
bootcampの `app/controllers/companies_controller.rb` で試してみました

```ruby
class CompaniesController < ApplicationController
  before_action :require_login

  def index　# endが足りない

  def show
    @company = Company.find(params[:id])
  end
end
```

### before

```
Started GET "/companies" for ::1 at 2021-09-13 22:23:57 +0900
  
SyntaxError (/Users/hoguchi/sand-box/bootcamp/app/controllers/companies_controller.rb:11: syntax error, unexpected end-of-input, expecting end):
  
app/controllers/companies_controller.rb:11: syntax error, unexpected end-of-input, expecting end
```

### after

```
Started GET "/companies" for ::1 at 2021-09-13 22:30:04 +0900
   (4.6ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Run `$ dead_end /Users/hoguchi/sand-box/bootcamp/app/controllers/companies_controller.rb` for more options

DeadEnd: Missing `end` detected

This code has a missing `end`. Ensure that all
syntax keywords (`def`, `do`, etc.) have a matching `end`.

file: /Users/hoguchi/sand-box/bootcamp/app/controllers/companies_controller.rb
simplified:

       3  class CompaniesController < ApplicationController
       4    before_action :require_login
    ❯  6    def index
    ❯  8    def show
    ❯ 10    end
      11  end
```

ログの内容からエラーの発生箇所の特定がしやすくなりました。

## 補足

このgemをruby core に同梱するissueも上がっています。
https://bugs.ruby-lang.org/issues/18159
