### PR TITLE
フィヨルドブートキャンプの中身へのリンクを追加

### DIFF
--- a/app/assets/stylesheets/atoms/_a-button.sass
+++ b/app/assets/stylesheets/atoms/_a-button.sass
@@ -119,6 +119,9 @@ input[type="button"]
   border-radius: 8px
   cursor: pointer
   text-decoration: none
+  transition: all .2s ease-out
+  &:hover
+    background-color: #fff98f
   &.is-md
     height: 3.25rem
   &.is-sm

--- a/app/assets/stylesheets/welcome/_welcome-section.sass
+++ b/app/assets/stylesheets/welcome/_welcome-section.sass
@@ -10,6 +10,11 @@
     +padding(vertical, 2.25rem)
     +media-breakpoint-down(md)
       +padding(vertical, 2rem)
+  &.is-substance
+    background-color: #b4dbfd
+    +padding(vertical, 2.25rem)
+    +media-breakpoint-down(md)
+      +padding(vertical, 2rem)
   .tos
     th
       white-space: nowrap

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -14,4 +14,10 @@
   = render 'welcome/tutorials'
   = render 'welcome/eligibility'
   = render 'welcome/process'
+
+  section.welcome-section.is-administrator.is-bird
+    .container.is-xl
+      h2.welcome-section__title
+        = link_to 'フィヨルドブートキャンプの中身', article_path(34)
+
   = render 'welcome/administrator'

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -15,9 +15,24 @@
   = render 'welcome/eligibility'
   = render 'welcome/process'
 
-  section.welcome-section.is-administrator.is-bird
+  section.welcome-section.is-substance
     .container.is-xl
       h2.welcome-section__title
-        = link_to 'フィヨルドブートキャンプの中身', article_path(34)
+        | フィヨルドブートキャンプの<br>中身を見てみよう！
+      .welcome-section__description
+        p
+          | 実際にどうやって学習を進めるの？
+          | 学習アプリってどんな画面？
+          | わからないときはどうやって質問するの？
+          | どんなイベントが開催されてる？
+          | 学習アプリを受講者が開発してるって本当？
+          | ...などについて書いています。
+          | これを読めば、フィヨルドブートキャンプに入会するとどんなことが
+          | 待っているかわかりますので、ぜひ見てみてください。
+      .welcome-section__actions
+        .welcome-section__actions-items
+          .welcome-section__actions-item
+            = link_to article_path(34), class: 'a-welcome-button is-md' do
+              | 中身を見てみる
 
   = render 'welcome/administrator'


### PR DESCRIPTION
メンターミーティングで話した「サイトを訪れた人がブートキャンプの中身が全くわからない（イベントの発表資料では何度も説明してるやつ）問題」を解決するために「フィヨルドブートキャンプの中身」というエントリーを下記に書きました。

[フィヨルドブートキャンプの中身 | FJORD BOOT CAMP（フィヨルドブートキャンプ）](https://bootcamp.fjord.jp/articles/34)

<img width="982" alt="スクリーンショット 2021-09-14 22 02 26" src="https://user-images.githubusercontent.com/16577/133262562-3891f961-6c92-4154-bb8e-b993c353bf73.png">
