### PR TITLE
[WIP] Rails 7.0のアップグレード準備

### DIFF
--- a/.github/workflows/test_rails_70.yml
+++ b/.github/workflows/test_rails_70.yml
@@ -18,6 +18,7 @@ jobs:
       DATABASE_URL: "postgres://postgres:postgres@localhost/ci_test"
       TZ: 'Asia/Tokyo'
       BUNDLE_GEMFILE: 'gemfiles/rails_70.gemfile'
+      BUNDLE_DEPLOYMENT: "false"
       DISABLE_SPRING: "1"
 
     services:
@@ -36,7 +37,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: ruby/setup-ruby@v1
+    - name: Copy Gemfile.lock to gemfiles directory
+      run: cp Gemfile.lock ${{ env.BUNDLE_GEMFILE }}.lock
+
+    - uses: sinsoku/setup-ruby@respect_bundle_deployment
       with:
         bundler-cache: true
 

--- a/.github/workflows/test_rails_70.yml
+++ b/.github/workflows/test_rails_70.yml
@@ -1,0 +1,58 @@
+name: Test Rails 7
+
+on:
+  push:
+    branches: rails7
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://postgres:postgres@localhost/ci_test"
+      TZ: 'Asia/Tokyo'
+      BUNDLE_GEMFILE: 'gemfiles/rails_70.gemfile'
+      DISABLE_SPRING: "1"
+
+    services:
+      postgres:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: Cache node modules
+      uses: actions/cache@v2.1.4
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: yarn install
+      run:  yarn install --check-files
+
+    - name: Setup test DB
+      run: bundle exec rails db:setup
+
+    - name: Run tests
+      run: bundle exec rails test:all

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ storage/
 yarn-debug.log*
 .yarn-integrity
 .envrc
+gemfiles/*.lock

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,11 @@ class ApplicationController < ActionController::Base
   def set_host_for_disk_storage
     return unless %i[local test].include? Rails.application.config.active_storage.service
 
-    ActiveStorage::Current.host = request.base_url
+    if Rails::VERSION::STRING.start_with?('7.0')
+      ActiveSupport::Deprecation.silence { ActiveStorage::Current.host = request.base_url }
+    else
+      ActiveStorage::Current.host = request.base_url
+    end
   end
 
   def require_card

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,9 +80,11 @@ Rails.application.configure do
    config.action_controller.asset_host = "http://localhost:3000"
    config.action_mailer.asset_host = "http://localhost:3000"
 
-   config.after_initialize do
-     Bullet.enable = true
-     Bullet.add_footer = true
-     Bullet.bullet_logger = true
-   end
+  unless Rails::VERSION::STRING.start_with?("7.0")
+    config.after_initialize do
+      Bullet.enable = true
+      Bullet.add_footer = true
+      Bullet.bullet_logger = true
+    end
+  end
 end

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -2,40 +2,15 @@
 
 eval_gemfile File.expand_path('../Gemfile', __dir__)
 
-# gemをGitHubから取得し、tmp/repos/に置く
-git_clone = lambda do |repo|
-  github_uri = "https://github.com/#{repo}.git"
-  name = repo.split('/').last
-  dest = File.expand_path("../tmp/repos/#{name}", __dir__)
-
-  system "git clone --depth 1 #{github_uri} #{dest}" unless File.exist?(dest)
-  dest
-end
-
-# Rails 7.0.alpha2でも使えるようにgemspecを書き換え
-replace_deps = lambda do |name, path|
-  spec_path = File.expand_path("#{name}.gemspec", path)
-  new_content = File.read(spec_path).gsub('< 6.2', '< 7.0')
-  File.write(spec_path, new_content)
-end
-
 # 依存関係を上書きするため、一度gemの依存を削除
 overwrite_gems = %w[rails acts-as-taggable-on meta-tags zeitwerk data_migrate ransack bullet any_login]
 dependencies.delete_if { |d| overwrite_gems.include?(d.name) }
 
-gem 'rails', github: 'rails/rails', tag: 'v7.0.0.alpha2'
+gem 'rails', github: 'rails/rails', tag: 'v7.0.1'
 
 gem 'any_login', github: 'igorkasyanchuk/any_login'
-gem 'data_migrate', github: 'podia/data-migrate', branch: 'rails-7'
-gem 'ransack', github: 'activerecord-hackery/ransack'
-gem 'zeitwerk', github: 'fxn/zeitwerk', tag: 'v2.5.0.beta3'
-
-# gemspecを上書きする
-repos = {
-  'acts-as-taggable-on' => git_clone['mbleigh/acts-as-taggable-on'],
-  'meta-tags' => git_clone['kpumuk/meta-tags']
-}
-repos.each { |name, path| replace_deps[name, path] }
-
-gem 'acts-as-taggable-on', path: repos['acts-as-taggable-on']
-gem 'meta-tags', path: repos['meta-tags']
+gem 'data_migrate', '7.0.2'
+gem 'ransack', '2.5.0'
+gem 'zeitwerk', '2.5.4'
+gem 'acts-as-taggable-on', '9.0.1'
+gem 'meta-tags', '2.16.0'

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+# gemをGitHubから取得し、tmp/repos/に置く
+git_clone = lambda do |repo|
+  github_uri = "https://github.com/#{repo}.git"
+  name = repo.split('/').last
+  dest = File.expand_path("../tmp/repos/#{name}", __dir__)
+
+  system "git clone --depth 1 #{github_uri} #{dest}" unless File.exist?(dest)
+  dest
+end
+
+# Rails 7.0.alpha2でも使えるようにgemspecを書き換え
+replace_deps = lambda do |name, path|
+  spec_path = File.expand_path("#{name}.gemspec", path)
+  new_content = File.read(spec_path).gsub('< 6.2', '< 7.0')
+  File.write(spec_path, new_content)
+end
+
+# 依存関係を上書きするため、一度gemの依存を削除
+overwrite_gems = %w[rails acts-as-taggable-on meta-tags zeitwerk data_migrate ransack bullet any_login]
+dependencies.delete_if { |d| overwrite_gems.include?(d.name) }
+
+gem 'rails', github: 'rails/rails', tag: 'v7.0.0.alpha2'
+
+gem 'any_login', github: 'igorkasyanchuk/any_login'
+gem 'data_migrate', github: 'podia/data-migrate', branch: 'rails-7'
+gem 'ransack', github: 'activerecord-hackery/ransack'
+gem 'zeitwerk', github: 'fxn/zeitwerk', tag: 'v2.5.0.beta3'
+
+# gemspecを上書きする
+repos = {
+  'acts-as-taggable-on' => git_clone['mbleigh/acts-as-taggable-on'],
+  'meta-tags' => git_clone['kpumuk/meta-tags']
+}
+repos.each { |name, path| replace_deps[name, path] }
+
+gem 'acts-as-taggable-on', path: repos['acts-as-taggable-on']
+gem 'meta-tags', path: repos['meta-tags']


### PR DESCRIPTION
Rails 7.0のアップグレードで対応の必要な箇所を明確にするため、CIの設定を追加するところまで実装してみました。

## Rails 7.0 アップグレードに必要な作業

- [x] Ruby 2.7 以上へのアップグレード
- Rails 7.0に対応していないgemの対応
    - [ ] spring: テスト実行時にエラーでる
    - [ ] any_login: gemのアップグレード
    - [ ] data_migrate: https://github.com/ilyakatz/data-migrate/issues/191
    - [ ] ransack: https://github.com/activerecord-hackery/ransack/issues/1251
    - [ ] zeitwerk: gemのアップグレード
    - [ ] acts-as-taggable-on: gemspecの依存の修正だけかも
    - [x] meta-tags: gemspecの依存の修正だけかも
    - [x] bullet: 未対応

未対応のgemは対応されるのを待つか、フィヨルド生で直す必要がある。

## Rails 7.0のテストの実行結果

forkしているので、こちらで確認できる。
https://github.com/sinsoku/bootcamp/runs/3647737645

### テストで出ている警告

```
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.
```

```
/home/runner/work/bootcamp/bootcamp/app/models/link_checker/checker.rb:34: warning: URI.escape is obsolete
```