### PR TITLE
日報個別ページにユーザー名を表示

### DIFF
--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -30,7 +30,7 @@ header.page-header
                       | WIP
                 .thread-header-metas__meta
                   = link_to @report.user, class: 'a-user-name', title: @report.user.name do
-                    = @report.user.login_name
+                    = @report.user.long_name
                 .thread-header-metas__meta
                   .a-meta
                     = l @report.reported_on


### PR DESCRIPTION
ref #3154

- 日報個別ページ(例: http://127.0.0.1:3000/reports/48577180) で表示名が「ログイン名」のみなのを「ログイン名＋(ユーザー名)」に変更する
![image](https://user-images.githubusercontent.com/73627898/134468162-8e6fe8cf-41ff-4197-88bd-dd6f6a337f81.png)
↓
![image](https://user-images.githubusercontent.com/73627898/134468082-ae782058-6b9d-4b8b-87d2-cbe51410304a.png)