### PR TITLE
footerのメニューにTwitterの#fjordbootcampへのリンクを追加

### DIFF
--- a/app/views/application/_footer.html.slim
+++ b/app/views/application/_footer.html.slim
@@ -27,6 +27,9 @@ footer.footer
           li.footer-nav__item
             = link_to companies_path, class: 'footer-nav__item-link' do
               | 企業一覧
+          li.footer-nav__item
+            = link_to 'https://twitter.com/hashtag/fjordbootcamp?src=hashtag_click&f=live', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | #fjordbootcamp
 
       small.footer__copyright
         i.far.fa-copyright


### PR DESCRIPTION
ref #3303

- footerのメニューにTwitterの#fjordbootcampへのリンクを追加する

![image](https://user-images.githubusercontent.com/73627898/134649249-373711d1-19fa-47ae-b34a-ea6acd883f54.png)

リンク先：
`https://twitter.com/hashtag/fjordbootcamp?src=hashtag_click&f=live`

補足：
`a`タグには、`target='_blank'` と `rel='noopener'` を記述する