### PR TITLE
ダッシュボード画面にアクセス時のN+1を改善

### DIFF
--- a/app/controllers/api/reports/recents_controller.rb
+++ b/app/controllers/api/reports/recents_controller.rb
@@ -3,7 +3,7 @@
 class API::Reports::RecentsController < API::BaseController
   def index
     @reports = Report
-               .includes([{ user: [{ avatar_attachment: :blob }, :company] }, :checks])
+               .includes(:checks, user: [{ avatar_attachment: :blob }, :company])
                .not_wip
                .order(reported_on: :desc, id: :desc)
                .limit(20)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,6 +14,7 @@ class HomeController < ApplicationController
         @completed_learnings = current_user.learnings.where(status: 3).includes(:practice).order(updated_at: :desc)
         @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.order(updated_at: :desc)
         @job_seeking_users = User.with_attached_avatar.job_seeking.includes(:reports, :products, :works, :course, :company)
+        @depressed_reports = User.depressed_reports(User.with_attached_avatar.students_and_trainees)
         display_events_on_dashboard
         set_required_fields
         render aciton: :index

--- a/app/models/depressed_report.rb
+++ b/app/models/depressed_report.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class DepressedReport
+  class << self
+    def reports(users, depressed_size)
+      reports = nil
+
+      depressed_size.times do |i|
+        sub_query_name = "sub_reports_#{i}"
+        max_reported_on = "max_reported_on_#{i}"
+
+        if i.zero?
+          reports = query(users, max_reported_on)
+        else
+          reports = query_after_second(reports, sub_query_name, max_reported_on)
+          sub_query_name = "sub_reports_#{i + 1}" # サブクエリの名前が重複しないよう連続にしたいので、ここでindexを1すすめる
+        end
+
+        reports = query_with_sad(reports, sub_query_name, max_reported_on)
+      end
+
+      query_by_latest(reports)
+    end
+
+    private
+
+    def query(users, max_reported_on)
+      # max関数を使うと、emotionを同時に取得できないので、まずuser_idと最新のreported_onだけを取得する
+      # また最後に、最新のreportsを返すため、最新のreported_onをlatest_max_reported_onとして、すべてのサブクエリに渡す
+      Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'max(reports.reported_on) AS latest_max_reported_on')
+            .where('user_id in (:user_ids)', user_ids: users.ids)
+            .group(:user_id)
+    end
+
+    def query_after_second(reports, sub_query_name, max_reported_on)
+      # 2回目以降は前回のサブクエリのreported_onより小さい（以前）の日付を取得することで連続したreported_onを取得する
+      Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'latest_max_reported_on')
+            .from(reports, sub_query_name)
+            .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.reported_on > reports.reported_on")
+            .group('reports.user_id, latest_max_reported_on')
+    end
+
+    def query_with_sad(reports, sub_query_name, max_reported_on)
+      # 直前のクエリ結果をサブクエリとして読み込み、emotion: sadで絞り込む
+      Report.select('reports.*', 'latest_max_reported_on')
+            .from(reports, sub_query_name)
+            .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.#{max_reported_on} = reports.reported_on")
+            .where('reports.emotion': Report.emotions[:sad])
+            .order('reports.reported_on': :desc)
+    end
+
+    def query_by_latest(reports)
+      # 最新のlatest_max_reported_onで絞り込んで、返却する
+      Report.select('reports.*')
+            .from(reports, 'last_sub_query')
+            .joins('JOIN reports ON last_sub_query.user_id = reports.user_id AND last_sub_query.latest_max_reported_on = reports.reported_on')
+            .order('reports.reported_on': :desc)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -353,6 +353,47 @@ class User < ApplicationRecord
     def tags
       unretired.all_tag_counts(order: 'count desc, name asc')
     end
+
+    def depressed_reports(users)
+      reports = nil
+
+      DEPRESSED_SIZE.times do |i|
+        sub_query_name = "sub_reports_#{i}"
+        max_reported_on = "max_reported_on_#{i}"
+
+        if (i.zero?)
+          # max関数を使うと、emotionを同時に取得できないので、まずuser_idと最新のreported_onだけを取得する
+          # また最後に、最新のreportsを返すため、最新のreported_onをlatest_max_reported_onとして、すべてのサブクエリに渡す
+          reports = Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'max(reports.reported_on) AS latest_max_reported_on')
+                          .where('reported_on > :date AND user_id in (:user_ids)', {
+                            date: Time.current.ago(6.months),
+                            user_ids: users.ids
+                          })
+                          .group(:user_id)
+        else
+          # 2回目以降は前回のサブクエリのreported_onより小さい（以前）の日付を取得することで連続したreported_onを取得する
+          reports = Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'latest_max_reported_on')
+                          .from(reports, sub_query_name)
+                          .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.reported_on > reports.reported_on GROUP BY reports.user_id, latest_max_reported_on")
+
+          # サブクエリの名前が重複しないよう連続にしたいので、ここでindexを1すすめる
+          sub_query_name = "sub_reports_#{i + 1}"
+        end
+
+        # 直前のクエリ結果をサブクエリとして読み込み、emotion: sadで絞り込む
+        reports = Report.select('reports.*', 'latest_max_reported_on')
+                        .from(reports, sub_query_name)
+                        .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.#{max_reported_on} = reports.reported_on")
+                        .where('reports.emotion': Report.emotions[:sad])
+                        .order('reports.reported_on': :desc)
+      end
+
+      # 最新のlatest_max_reported_onで絞り込んで、返却する
+      Report.select('reports.*')
+            .from(reports, 'last_sub_query')
+            .joins("JOIN reports ON last_sub_query.user_id = reports.user_id AND last_sub_query.latest_max_reported_on = reports.reported_on")
+            .order('reports.reported_on': :desc)
+    end
   end
 
   def retired_three_months_ago_and_notification_not_sent?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -355,58 +355,7 @@ class User < ApplicationRecord
     end
 
     def depressed_reports(users)
-      reports = nil
-
-      DEPRESSED_SIZE.times do |i|
-        sub_query_name = "sub_reports_#{i}"
-        max_reported_on = "max_reported_on_#{i}"
-
-        if i.zero?
-          reports = depressed_reports_on_first(users, max_reported_on)
-        else
-          reports = depressed_reports_on_after_second(reports, sub_query_name, max_reported_on)
-          sub_query_name = "sub_reports_#{i + 1}" # サブクエリの名前が重複しないよう連続にしたいので、ここでindexを1すすめる
-        end
-
-        reports = depressed_reports_with_sad(reports, sub_query_name, max_reported_on)
-      end
-
-      last_depressed_reports(reports)
-    end
-
-    private
-
-    def depressed_reports_on_first(users, max_reported_on)
-      # max関数を使うと、emotionを同時に取得できないので、まずuser_idと最新のreported_onだけを取得する
-      # また最後に、最新のreportsを返すため、最新のreported_onをlatest_max_reported_onとして、すべてのサブクエリに渡す
-      Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'max(reports.reported_on) AS latest_max_reported_on')
-            .where('user_id in (:user_ids)', user_ids: users.ids)
-            .group(:user_id)
-    end
-
-    def depressed_reports_on_after_second(reports, sub_query_name, max_reported_on)
-      # 2回目以降は前回のサブクエリのreported_onより小さい（以前）の日付を取得することで連続したreported_onを取得する
-      Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'latest_max_reported_on')
-            .from(reports, sub_query_name)
-            .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.reported_on > reports.reported_on")
-            .group('reports.user_id, latest_max_reported_on')
-    end
-
-    def depressed_reports_with_sad(reports, sub_query_name, max_reported_on)
-      # 直前のクエリ結果をサブクエリとして読み込み、emotion: sadで絞り込む
-      Report.select('reports.*', 'latest_max_reported_on')
-            .from(reports, sub_query_name)
-            .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.#{max_reported_on} = reports.reported_on")
-            .where('reports.emotion': Report.emotions[:sad])
-            .order('reports.reported_on': :desc)
-    end
-
-    def last_depressed_reports(reports)
-      # 最新のlatest_max_reported_onで絞り込んで、返却する
-      Report.select('reports.*')
-            .from(reports, 'last_sub_query')
-            .joins('JOIN reports ON last_sub_query.user_id = reports.user_id AND last_sub_query.latest_max_reported_on = reports.reported_on')
-            .order('reports.reported_on': :desc)
+      DepressedReport.reports(users, DEPRESSED_SIZE)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -361,37 +361,49 @@ class User < ApplicationRecord
         sub_query_name = "sub_reports_#{i}"
         max_reported_on = "max_reported_on_#{i}"
 
-        if (i.zero?)
-          # max関数を使うと、emotionを同時に取得できないので、まずuser_idと最新のreported_onだけを取得する
-          # また最後に、最新のreportsを返すため、最新のreported_onをlatest_max_reported_onとして、すべてのサブクエリに渡す
-          reports = Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'max(reports.reported_on) AS latest_max_reported_on')
-                          .where('reported_on > :date AND user_id in (:user_ids)', {
-                            date: Time.current.ago(6.months),
-                            user_ids: users.ids
-                          })
-                          .group(:user_id)
+        if i.zero?
+          reports = User.depressed_reports_on_first(users, max_reported_on)
         else
-          # 2回目以降は前回のサブクエリのreported_onより小さい（以前）の日付を取得することで連続したreported_onを取得する
-          reports = Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'latest_max_reported_on')
-                          .from(reports, sub_query_name)
-                          .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.reported_on > reports.reported_on GROUP BY reports.user_id, latest_max_reported_on")
-
-          # サブクエリの名前が重複しないよう連続にしたいので、ここでindexを1すすめる
-          sub_query_name = "sub_reports_#{i + 1}"
+          reports = User.depressed_reports_on_after_second(reports, sub_query_name, max_reported_on)
+          sub_query_name = "sub_reports_#{i + 1}" # サブクエリの名前が重複しないよう連続にしたいので、ここでindexを1すすめる
         end
 
-        # 直前のクエリ結果をサブクエリとして読み込み、emotion: sadで絞り込む
-        reports = Report.select('reports.*', 'latest_max_reported_on')
-                        .from(reports, sub_query_name)
-                        .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.#{max_reported_on} = reports.reported_on")
-                        .where('reports.emotion': Report.emotions[:sad])
-                        .order('reports.reported_on': :desc)
+        reports = User.depressed_reports_with_sad(reports, sub_query_name, max_reported_on)
       end
 
+      User.last_depressed_reports(reports)
+    end
+
+    def depressed_reports_on_first(users, max_reported_on)
+      # max関数を使うと、emotionを同時に取得できないので、まずuser_idと最新のreported_onだけを取得する
+      # また最後に、最新のreportsを返すため、最新のreported_onをlatest_max_reported_onとして、すべてのサブクエリに渡す
+      Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'max(reports.reported_on) AS latest_max_reported_on')
+            .where('reported_on > :date AND user_id in (:user_ids)', date: Time.current.ago(6.months), user_ids: users.ids)
+            .group(:user_id)
+    end
+
+    def depressed_reports_on_after_second(reports, sub_query_name, max_reported_on)
+      # 2回目以降は前回のサブクエリのreported_onより小さい（以前）の日付を取得することで連続したreported_onを取得する
+      Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'latest_max_reported_on')
+            .from(reports, sub_query_name)
+            .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.reported_on > reports.reported_on")
+            .group('reports.user_id, latest_max_reported_on')
+    end
+
+    def depressed_reports_with_sad(reports, sub_query_name, max_reported_on)
+      # 直前のクエリ結果をサブクエリとして読み込み、emotion: sadで絞り込む
+      Report.select('reports.*', 'latest_max_reported_on')
+            .from(reports, sub_query_name)
+            .joins("JOIN reports ON #{sub_query_name}.user_id = reports.user_id AND #{sub_query_name}.#{max_reported_on} = reports.reported_on")
+            .where('reports.emotion': Report.emotions[:sad])
+            .order('reports.reported_on': :desc)
+    end
+
+    def last_depressed_reports(reports)
       # 最新のlatest_max_reported_onで絞り込んで、返却する
       Report.select('reports.*')
             .from(reports, 'last_sub_query')
-            .joins("JOIN reports ON last_sub_query.user_id = reports.user_id AND last_sub_query.latest_max_reported_on = reports.reported_on")
+            .joins('JOIN reports ON last_sub_query.user_id = reports.user_id AND last_sub_query.latest_max_reported_on = reports.reported_on')
             .order('reports.reported_on': :desc)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -362,17 +362,19 @@ class User < ApplicationRecord
         max_reported_on = "max_reported_on_#{i}"
 
         if i.zero?
-          reports = User.depressed_reports_on_first(users, max_reported_on)
+          reports = depressed_reports_on_first(users, max_reported_on)
         else
-          reports = User.depressed_reports_on_after_second(reports, sub_query_name, max_reported_on)
+          reports = depressed_reports_on_after_second(reports, sub_query_name, max_reported_on)
           sub_query_name = "sub_reports_#{i + 1}" # サブクエリの名前が重複しないよう連続にしたいので、ここでindexを1すすめる
         end
 
-        reports = User.depressed_reports_with_sad(reports, sub_query_name, max_reported_on)
+        reports = depressed_reports_with_sad(reports, sub_query_name, max_reported_on)
       end
 
-      User.last_depressed_reports(reports)
+      last_depressed_reports(reports)
     end
+
+    private
 
     def depressed_reports_on_first(users, max_reported_on)
       # max関数を使うと、emotionを同時に取得できないので、まずuser_idと最新のreported_onだけを取得する

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -378,7 +378,7 @@ class User < ApplicationRecord
       # max関数を使うと、emotionを同時に取得できないので、まずuser_idと最新のreported_onだけを取得する
       # また最後に、最新のreportsを返すため、最新のreported_onをlatest_max_reported_onとして、すべてのサブクエリに渡す
       Report.select('reports.user_id', "max(reports.reported_on) AS #{max_reported_on}", 'max(reports.reported_on) AS latest_max_reported_on')
-            .where('reported_on > :date AND user_id in (:user_ids)', date: Time.current.ago(6.months), user_ids: users.ids)
+            .where('user_id in (:user_ids)', user_ids: users.ids)
             .group(:user_id)
     end
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -55,7 +55,8 @@ header.page-header
           - if current_user.student?
             #js-niconico_calendar(data-user-id="#{current_user.id}")
           - if current_user.mentor?
-            = render 'users/sad_emotion_report', users: User.students_and_trainees
+            = render 'users/sad_emotion_report', depressed_reports: @depressed_reports
+          - if current_user.mentor?
             = render 'users/inactive_users', users: @inactive_students
           - if current_user.role == :student
             = render 'required_field', user: current_user

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -1,13 +1,12 @@
-- if users.any?(&:depressed?)
+- if depressed_reports.present?
   .a-card.is-only-mentor
     header.card-header
       h2.card-header__title
-        | 2回連続
+        | #{User::DEPRESSED_SIZE}回連続
         = image_tag Report.faces['sad'], id: 'sad', alt: 'sad', class: 'card-header__title-emotion-image'
         | のユーザー
     .card-list
       .card-list__items
-        - users.each do |user|
-          - if user.depressed?
-            .card-list__item
-              = render partial: 'reports/report', collection: user.reports.order(reported_on: :desc).limit(1), as: :report
+        - depressed_reports.each do |report|
+          .card-list__item
+            = render partial: 'reports/report', locals: { report: report }

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -277,3 +277,19 @@ report<%= i + 31 %>:
     - テスト
   reported_on: <%= Time.now - 1.month + i.day %>
 <% end %>
+
+report37:
+  user: kensyu
+  title: "悲しい顔アイコンの日報1"
+  emotion: 1
+  description: |-
+    難しかったです
+  reported_on: "2020-11-11"
+
+report38:
+  user: kensyu
+  title: "悲しい顔アイコンの日報2"
+  emotion: 1
+  description: |-
+    やっぱり難しいです。
+  reported_on: "2020-11-13"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -243,3 +243,19 @@ report30:
   description: |-
     頑張れませんでした
   reported_on: <%= Time.now - 1.month - 1.day %>
+
+report31:
+  user: kensyu
+  title: "悲しい顔アイコンの日報1"
+  emotion: 1
+  description: |-
+    難しかったです
+  reported_on: <%= Time.now - 3.day %>
+
+report32:
+  user: kensyu
+  title: "悲しい顔アイコンの日報2"
+  emotion: 1
+  description: |-
+    やっぱり難しいです。
+  reported_on: <%= Time.now - 1.day %>

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -250,7 +250,7 @@ report31:
   emotion: 1
   description: |-
     難しかったです
-  reported_on: <%= Time.now - 3.day %>
+  reported_on: "2020-11-11"
 
 report32:
   user: kensyu
@@ -258,4 +258,4 @@ report32:
   emotion: 1
   description: |-
     やっぱり難しいです。
-  reported_on: <%= Time.now - 1.day %>
+  reported_on: "2020-11-13"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -144,15 +144,22 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test '.depressed_reports' do
-    ids = users(:komagata, :hatsuno, :kensyu).map(&:id)
+    no_depressed_user = users(:kimura)
+    first_depressed_user = users(:hatsuno)
+    second_depressed_user = users(:kensyu)
+
+    ids = [
+      no_depressed_user.id,
+      first_depressed_user.id,
+      second_depressed_user.id
+    ]
     users = User.where(id: ids)
     reports = User.depressed_reports(users)
     assert_equal 2, reports.size
 
     kensyu = users.find_by(login_name: 'kensyu')
-    latest_report = kensyu.reports.order(reported_on: :asc).last
-    latest_report.emotion = 'happy'
-    latest_report.save!
+    latest_report = kensyu.reports.order(reported_on: :desc).first
+    latest_report.update!(emotion: 'happy')
 
     reports = User.depressed_reports(users)
     assert_equal 1, reports.size

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -143,6 +143,21 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.depressed?
   end
 
+  test '.depressed_reports' do
+    ids = users(:komagata, :hatsuno, :kensyu).map(&:id)
+    users = User.where(id: ids)
+    reports = User.depressed_reports(users)
+    assert_equal 2, reports.size
+
+    kensyu = users.find_by(login_name: 'kensyu')
+    latest_report = kensyu.reports.order(reported_on: :asc).last
+    latest_report.emotion = 'happy'
+    latest_report.save!
+
+    reports = User.depressed_reports(users)
+    assert_equal 1, reports.size
+  end
+
   test '.order_by_counts' do
     ordered_users = User.order_by_counts('report', 'desc')
     more_report_user = users(:sotugyou)

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -14,7 +14,20 @@ class Check::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'success report checking' do
-    visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
+    visit_with_auth "/reports/#{reports(:report2).id}", 'komagata'
+    assert has_button? '日報を確認'
+    click_button '日報を確認'
+    assert has_button? '日報の確認を取り消す'
+    visit reports_path
+    assert_text '確認済'
+  end
+
+  test "success adviser's report checking" do
+    visit_with_auth '/', 'advijirou'
+    assert_equal '/', current_path
+    click_link '日報'
+    assert_text '今日は頑張りました'
+    click_link '今日は頑張りました'
     assert has_button? '日報を確認'
     accept_alert do
       wait_for_vuejs


### PR DESCRIPTION
ref: #3276

# 概要
issueの通り、管理者 / メンターでダッシュボード画面を開くとN+1が発生している

![スクリーンショット 2021-09-28 11 02 44](https://user-images.githubusercontent.com/1329464/135010294-e9ca849d-15a4-48cf-90eb-07a7d4458595.png)

## 「2回連続悲しい顔ユーザー」に表示される条件
- 直近2回連続で`report.emotion == Report.emotions[:sad]`が設定されているレポートが存在するユーザー
  - 上記条件を `depressed_user` とする

### 例
2日連続ではなく、2回連続が対象となる

ユーザー ＼ reported_on） | 2021-09-01 | 2021-09-02 | 2021-09-03 | depressed_userか
-- | -- | -- | -- | --
user_1 | sad | happy | sad | No
user_2 | happy | sad | sad | Yes
user_3 | sad | - | sad | Yes

## issueの現象
- issueのテンプレートでは
  - `depressed_user` が存在するか 
  - どのユーザーが`depressed_user`か
  - `depressed_user`の`reports`を取得

の3条件で各userごとにqueryが発行されていたため、3重でN+1のような処理になっていた

# 修正方針
- Ruby（ActiveRecord）上で条件判定するのではなく、SQLレイヤーで条件絞り込みを実施し、必要な`reports`を取得できるようにした

## SQL
まずはSQLで組み立て。考え方は以下の通り。
- `X`のqueryで、まずは最新の日報とuser_idを取得（max関数を利用しているので、この時点でemotionは取れない）
- `Y`のqueryで、reportsを自己結合し、Xのuser_idでemotion = 1のreportsを取得する
- `Z`のqueryで、Yで取得したreported_onより小さいreported_onの最新の日報（つまり、最新から2番目の日報）を取得する
- 最後のqueryで、reportsを自己結合し、Zのuser_idでemotion = 1のreportsを取得する
```
WITH
  X AS (
    SELECT user_id, max(reported_on) AS A FROM reports GROUP BY user_id
  ),
  Y AS (
    SELECT
      reports.user_id, reports.emotion, reports.reported_on
    FROM X
    JOIN reports ON X.user_id = reports.user_id and A = reports.reported_on WHERE reports.emotion = 1 ORDER BY reports.user_id
  ),
  Z AS (
    SELECT
      reports.user_id, max(reports.reported_on) AS B
    FROM Y
    JOIN reports ON Y.user_id = reports.user_id and Y.reported_on > reports.reported_on GROUP BY reports.user_id ORDER BY reports.user_id
  )
SELECT
  reports.*
FROM Z
JOIN reports ON Z.user_id = reports.user_id and B = reports.reported_on WHERE reports.emotion = 1 ORDER BY reports.user_id;
```

## ActiveRecord
- 上記SQLをActiveRecordに置き換え
  - 対象となる`users`を`IN`句で渡せるように変更
  - 最後のクエリのとき、最新のreportを表示したいので、`latest_max_reported_on` をサブクエリに渡し、最後に絞り込む

https://github.com/fjordllc/bootcamp/blob/8cf86b0053dbd7888f01e5060294b97610e460fd/app/models/user.rb#L333-L384

- 以下定数で対象件数を変更できる
https://github.com/fjordllc/bootcamp/blob/8cf86b0053dbd7888f01e5060294b97610e460fd/app/models/user.rb#L13

## その他
- 本issue以外にもbulletでのwarnigsがでていた部分を `includes` or `with_attached_avatar` で解消した
- 以下メソッドはreportの新規作成のときに利用しているので、そのまま残す
https://github.com/fjordllc/bootcamp/blob/8cf86b0053dbd7888f01e5060294b97610e460fd/app/models/user.rb#L559-L562