### PR TITLE
ダッシュボードの「1ヶ月以上ログインのないユーザー」を降順ソートで表示

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,7 +12,7 @@ class HomeController < ApplicationController
                                      .order(published_at: :desc)
                                      .limit(5)
         @completed_learnings = current_user.learnings.where(status: 3).order(updated_at: :desc)
-        @ordered_inactive_students_and_trainees = User.inactive_students_and_trainees.order(updated_at: :desc)
+        @inactive_students = User.inactive_students_and_trainees.order(updated_at: :desc)
         set_required_fields
         render aciton: :index
       end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,6 +12,7 @@ class HomeController < ApplicationController
                                      .order(published_at: :desc)
                                      .limit(5)
         @completed_learnings = current_user.learnings.where(status: 3).order(updated_at: :desc)
+        @ordered_inactive_students_and_trainees = User.inactive_students_and_trainees.order(updated_at: :desc)
         set_required_fields
         render aciton: :index
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -239,7 +239,7 @@ class User < ApplicationRecord
       adviser: false,
       retired_on: nil,
       graduated_on: nil
-    )
+    ).order(updated_at: :desc)
   }
   scope :year_end_party, -> { where(retired_on: nil) }
   scope :mentor, -> { where(mentor: true) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -239,7 +239,7 @@ class User < ApplicationRecord
       adviser: false,
       retired_on: nil,
       graduated_on: nil
-    ).order(updated_at: :desc)
+    )
   }
   scope :year_end_party, -> { where(retired_on: nil) }
   scope :mentor, -> { where(mentor: true) }

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -49,6 +49,6 @@ header.page-header
           - if current_user.mentor?
             = render 'users/sad_emotion_report', users: User.students_and_trainees
           - if current_user.mentor?
-            = render 'users/inactive_users', users: @ordered_inactive_students_and_trainees
+            = render 'users/inactive_users', users: @inactive_students
           - if current_user.role == :student
             = render 'required_field', user: current_user

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -49,6 +49,6 @@ header.page-header
           - if current_user.mentor?
             = render 'users/sad_emotion_report', users: User.students_and_trainees
           - if current_user.mentor?
-            = render 'users/inactive_users', users: User.inactive_students_and_trainees
+            = render 'users/inactive_users', users: User.inactive_students_and_trainees.order(updated_at: :desc)
           - if current_user.role == :student
             = render 'required_field', user: current_user

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -49,6 +49,6 @@ header.page-header
           - if current_user.mentor?
             = render 'users/sad_emotion_report', users: User.students_and_trainees
           - if current_user.mentor?
-            = render 'users/inactive_users', users: User.inactive_students_and_trainees.order(updated_at: :desc)
+            = render 'users/inactive_users', users: @ordered_inactive_students_and_trainees
           - if current_user.role == :student
             = render 'required_field', user: current_user


### PR DESCRIPTION
ref #3071

- ダッシュボードの「1ヶ月以上ログインのないユーザー」を降順ソートで表示する

※ 修正前
![image](https://user-images.githubusercontent.com/73627898/135078879-5659daab-30e0-4f7d-92ab-d4cb61db1ca3.png)

※ 修正後イメージ
![image](https://user-images.githubusercontent.com/73627898/135078906-b4a2fc9f-2bfb-4771-8a70-09ad017ead24.png)

- Userテーブルの`updated_at`が最終ログイン日時として扱われているので、`updated_at`を降順ソートする
