### PR TITLE
seedデータの会社名を架空のものに変更した。

### DIFF
--- a/db/fixtures/companies.yml
+++ b/db/fixtures/companies.yml
@@ -1,6 +1,6 @@
 company1:
-  name: "Okamoto Electric Co."
-  description: "有限会社岡本電気"
+  name: "MaruMaru Inc."
+  description: "◯◯株式会社"
   website: "http://example.com/ben/"
   tos: "秘密保持契約書 　　　__COMPANY_NAME__（以下「甲」という）と__USER_NAME__（以下「乙」という）とは、甲が業務を乙に委託し、乙がこれを実施する事に関連して、甲から乙に対しまたは乙から甲に対し開示される秘密情報、個人情報の取扱いに関し、次の通り契約を締結する。
 
@@ -50,19 +50,19 @@ company1:
   created_at: 2000-01-01 00:00:01
 
 company2:
-  name: "Ishikawa Gas Joint-Stock Company"
-  description: "石川ガス合名会社"
+  name: "BatsuBatsu Inc"
+  description: "××株式会社"
   website: "http://example.com/ignacio/"
   created_at: 2000-01-01 00:00:02
 
 company3:
-  name: "株式会社中野農林"
-  description: "Nakano Norin Inc."
+  name: "ShikakuShikaku Inc"
+  description: "□□株式会社"
   website: "http://example.com/zada.schumm"
   created_at: 2000-01-01 00:00:03
 
 company4:
-  name: "Kinoshita Printing Inc."
-  description: "木下印刷株式会社"
+  name: "SankakuSankaku Inc"
+  description: "△△株式会社"
   website: "http://example.com/loriann"
   created_at: 2000-01-01 00:00:04

--- a/db/fixtures/companies.yml
+++ b/db/fixtures/companies.yml
@@ -1,7 +1,7 @@
 company1:
-  name: "Fjord Inc."
-  description: "株式会社フィヨルド"
-  website: "https://fjord.jp"
+  name: "Okamoto Electric Co."
+  description: "有限会社岡本電気"
+  website: "http://example.com/ben/"
   tos: "秘密保持契約書 　　　__COMPANY_NAME__（以下「甲」という）と__USER_NAME__（以下「乙」という）とは、甲が業務を乙に委託し、乙がこれを実施する事に関連して、甲から乙に対しまたは乙から甲に対し開示される秘密情報、個人情報の取扱いに関し、次の通り契約を締結する。
 
   第１条（秘密情報）
@@ -50,19 +50,19 @@ company1:
   created_at: 2000-01-01 00:00:01
 
 company2:
-  name: "root inc."
-  description: "株式会社ルート"
-  website: "http://ic-root.com/"
+  name: "Ishikawa Gas Joint-Stock Company"
+  description: "石川ガス合名会社"
+  website: "http://example.com/ignacio/"
   created_at: 2000-01-01 00:00:02
 
 company3:
-  name: "esm inc."
-  description: "株式会社永和システムマネジメント"
-  website: "http://www.esm.co.jp/"
+  name: "株式会社中野農林"
+  description: "Nakano Norin Inc."
+  website: "http://example.com/zada.schumm"
   created_at: 2000-01-01 00:00:03
 
 company4:
-  name: "DAIMYO Engineer College"
-  description: "大名エンジニアカレッジ"
-  website: "https://daimyo-college.pepabo.com/"
+  name: "Kinoshita Printing Inc."
+  description: "木下印刷株式会社"
+  website: "http://example.com/loriann"
   created_at: 2000-01-01 00:00:04


### PR DESCRIPTION
ref: #3302 

seedデータ`seeds.rb`に紐づいている`companies.yml`の会社情報(name, description, website)を架空のものに変更しました。