### PR TITLE
slugがある場合はslugでアクセスできるようにリダイレクト機能を実装した

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,7 @@ class PagesController < ApplicationController
   before_action :require_login
   before_action :set_page, only: %i[show edit update destroy]
   before_action :set_categories, only: %i[new create edit update]
+  before_action :redirect_to_slug, only: %i[show edit]
 
   def index
     @pages = Page.with_avatar
@@ -85,5 +86,12 @@ class PagesController < ApplicationController
       .eager_load(:practices)
       .where.not(practices: { id: nil })
       .order('categories.position ASC, categories_practices.position ASC')
+  end
+
+  def redirect_to_slug
+    return if @page.slug.nil?
+    unless params[:slug_or_id].start_with?(/[a-z]/)
+      redirect_to request.original_url.sub(params[:slug_or_id], @page.slug)
+    end
   end
 end


### PR DESCRIPTION
ref: #3272 

Docsの文書について、slugが存在していてidでアクセスした場合は優先的にslugでアクセスできるようリダイレクトさせました。

<変更前>
![image](https://user-images.githubusercontent.com/57053236/135747327-94e4210d-515b-4de9-a418-4a4ae54c45ba.png)

<変更後>
![image](https://user-images.githubusercontent.com/57053236/135747471-6bc87ffd-114c-4a2f-96f9-89fc37ddbd94.png)
