### PR TITLE
プラクティス配下のDocsが0のときの表示を変更しました

### DIFF
--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -23,5 +23,8 @@ header.page-header
         = render partial: 'pages/page', collection: @pages, as: :page
       = paginate @pages
     - else
-      .a-empty-message
-        | Docsはまだありません。
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        .o-empty-message__text
+          | Docsはまだありません。


### PR DESCRIPTION
ref: #3055 

## 変更前
- プラクティスのDocsタブをクリックしたときに表示される内容が文章のみになっていた

![image](https://user-images.githubusercontent.com/168265/127358710-f58ee711-c84a-45ba-af32-ca8e97fe3d5a.png)

## 変更後
- 文章に付け加え、泣き顔を表示するようにしました

![image](https://user-images.githubusercontent.com/74460623/135813390-6c5386a8-c09e-4a7a-a786-b81e5ce372e3.png)

