### PR TITLE
[メンター向け]進捗が遅れている方を確認できるようにする

### DIFF
--- a/app/controllers/mentors/home_controller.rb
+++ b/app/controllers/mentors/home_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Mentors::HomeController < AdminController
+  def index; end
+end

--- a/app/controllers/mentors_controller.rb
+++ b/app/controllers/mentors_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class MentorsController < ApplicationController
+  before_action :require_mentor_login
+end

--- a/app/views/mentors/_mentor_page_tabs.html.slim
+++ b/app/views/mentors/_mentor_page_tabs.html.slim
@@ -1,0 +1,7 @@
+.page-tabs
+  .container.is-padding-horizontal-0-sm-down
+    ul.page-tabs__items
+      li.page-tabs__item
+        = link_to 'メンターページ',
+          mentors_root_path,
+          class: "page-tabs__item-link #{current_link(/^mentors-home/)}"

--- a/app/views/mentors/home/index.html.slim
+++ b/app/views/mentors/home/index.html.slim
@@ -1,0 +1,12 @@
+- title 'メンターページ'
+
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+
+.page-tools
+  = render 'mentors/mentor_page_tabs'
+
+#js-mentors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,10 @@ Rails.application.routes.draw do
     resources :courses, except: %i(show)
   end
 
+  namespace :mentors do
+    root to: "home#index", as: :root
+  end
+
   namespace :current_user do
     resources :reports, only: %i(index)
     resources :products, only: %i(index)


### PR DESCRIPTION
ref #3344

![image](https://user-images.githubusercontent.com/73627898/136013097-14bbc691-cc64-4b67-b7cb-addb27f8b8a9.png)

- メンターだけが見れるページを /mentorに作る。（/adminと似た作りにする）
- プラクティスを最後に完了してから二週間以上経っている人を表示する。
- プラクティスを最後に完了してからの経過時間が大きい順に表示する。