### PR TITLE
検索する日付をレンジで渡すように修正した

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,7 +14,7 @@ class HomeController < ApplicationController
         @completed_learnings = current_user.learnings.where(status: 3).order(updated_at: :desc)
         @inactive_students = User.inactive_students_and_trainees.order(updated_at: :desc)
         cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
-        @events_coming_soon = Event.where(start_at: today_to_tomorrow).or(Event.where(start_at: tomorrow_to_tomorrow_after)).where.not(id: cookies_ids)
+        @events_coming_soon = Event.where(start_at: today_to_tomorrow).or(Event.where(start_at: tomorrow_to_day_after_tomorrow)).where.not(id: cookies_ids)
         set_required_fields
         render aciton: :index
       end
@@ -41,7 +41,7 @@ class HomeController < ApplicationController
     (Time.zone.today + 9.hours)..(Time.zone.tomorrow + 9.hours)
   end
 
-  def tomorrow_to_tomorrow_after
+  def tomorrow_to_day_after_tomorrow
     (Time.zone.tomorrow + 9.hours)..(Time.zone.tomorrow + 1.day + 9.hours)
   end
 end


### PR DESCRIPTION
#3358

## 概要
サービス内で作成したイベントが、当日または翌日になるとダッシュボードに表示されるように修正しました。

## 関連PR
#3163

## 修正点
home_controller内の当日・翌日のイベント検索するメソッドの日付の指定を、`Date.current`などからレンジで渡すように修正しました。