### PR TITLE
Use https for docs.komagata.org

### DIFF
--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -48,7 +48,7 @@
     p ID ではなく URL を入力。
 .form-item
   = f.label :blog_url, class: 'a-form-label'
-  = f.text_field :blog_url, class: 'a-text-input', placeholder: 'http://docs.komagata.org/'
+  = f.text_field :blog_url, class: 'a-text-input', placeholder: 'https://docs.komagata.org/'
   .a-form-help
     p URL を入力。
 

--- a/app/views/welcome/_about.slim
+++ b/app/views/welcome/_about.slim
@@ -11,7 +11,7 @@ section.welcome-section.is-about.is-yellow#about
       .welcome-section__actions
         .welcome-section__actions-items
           .welcome-section__actions-item
-            = link_to '私たちの考える戦力', 'http://docs.komagata.org/5494', class: 'a-welcome-button is-md', target: '_blank', rel: 'noopener'
+            = link_to '私たちの考える戦力', 'https://docs.komagata.org/5494', class: 'a-welcome-button is-md', target: '_blank', rel: 'noopener'
 
     .welcome-small-sections.is-conditions
       h3.welcome-small-sections__title


### PR DESCRIPTION
以前、アカウント登録をした際のサンプルで http になっていたのが気になり、http://docs.komagata.org/ をみたところ https にリダイレクトしていたため予め https にしています。

別の視点としては、HTTP/2, HTTP/3 時代に向けて https をサンプルとしておいて良さそうに捉えています。