### PR TITLE
Q&Aの質問がなかったときの文面の修正とスマイルマークの追加を行いました

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -89,11 +89,11 @@ class QuestionsController < ApplicationController
 
   def questions_property
     if params[:all] == 'true'
-      QuestionsProperty.new('全ての質問', '質問はまだありません。')
+      QuestionsProperty.new('全ての質問', '質問はありません。')
     elsif params[:solved] == 'true'
-      QuestionsProperty.new('解決済みの質問一覧', '解決済みの質問はまだありません。')
+      QuestionsProperty.new('解決済みの質問一覧', '解決済みの質問はありません。')
     else
-      QuestionsProperty.new('未解決の質問一覧', '未解決の質問はまだありません。')
+      QuestionsProperty.new('未解決の質問一覧', '未解決の質問はありません。')
     end
   end
 

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -29,8 +29,11 @@ header.page-header
           .thread-list.a-card
             = render @questions
         - else
-          .a-empty-message
-            = @questions_property.empty_message
+          .o-empty-message
+            .o-empty-message__icon
+              i.far.fa-smile
+            p.o-empty-message__text
+              = @questions_property.empty_message
       - if @tags.any?
         nav.page-tags-nav
           header.page-tags-nav__header


### PR DESCRIPTION
Issue #3119 

## 変更前
- Q&Aに質問が投稿されていなかったときに表示される内容が文章のみになっていた

![image](https://user-images.githubusercontent.com/74460623/136565639-1685ea28-24db-4ecd-819c-610382924221.png)

## 変更後
- もともとあった文章を修正後、スマイルマークを追加し表示するようにしました

![Image from Gyazo](https://gyazo.com/c83cd4de28af3f8914718400e91178a9.gif)
