### PR TITLE
コースの表示/非表示を表すカラム名を変更

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -47,7 +47,7 @@ class CoursesController < ApplicationController
     params.require(:course).permit(
       :title,
       :description,
-      :open,
+      :published,
       category_ids: []
     )
   end

--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -1,10 +1,10 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .courses-item(id="course_#{course.id}" class="#{course.open ? 'is-opened' : 'is-closed'}")
+  .courses-item(id="course_#{course.id}" class="#{course.published ? 'is-published' : 'is-closed'}")
     .courses-item__inner.a-card
       header.courses-item__header
         h3.courses-item__title
           = link_to [course, :practices], class: 'courses-item__title-link' do
-            - if admin_login? && !course.open
+            - if admin_login? && !course.published
               .courses-item__title-icon.is-closed
                 | 非表示
             span.courses-item__title-label

--- a/app/views/courses/_form.html.slim
+++ b/app/views/courses/_form.html.slim
@@ -10,8 +10,8 @@
       .col-md-6.col-xs-12
         = f.label 'コースを表示する', class: 'a-form-label'
         label.a-on-off-checkbox.is-md
-          = f.check_box :open, class: 'is-open-checkbox'
-          span#checkbox-open-course
+          = f.check_box :published, class: 'is-published-checkbox'
+          span#checkbox-published-course
   .form-item
     .row.js-markdown-parent
       .col-md-6.col-xs-12

--- a/app/views/courses/index.html.slim
+++ b/app/views/courses/index.html.slim
@@ -18,4 +18,4 @@ header.page-header
         - if current_user&.admin?
           = render @courses.order(:created_at)
         - else
-          = render @courses.where(open: true).order(:created_at)
+          = render @courses.where(published: true).order(:created_at)

--- a/db/migrate/20211009003559_rename_open_column_to_courses.rb
+++ b/db/migrate/20211009003559_rename_open_column_to_courses.rb
@@ -1,0 +1,5 @@
+class RenameOpenColumnToCourses < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :courses, :open, :published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_23_053650) do
+ActiveRecord::Schema.define(version: 2021_10_09_003559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,7 +140,7 @@ ActiveRecord::Schema.define(version: 2021_09_23_053650) do
     t.text "description", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "open", default: false, null: false
+    t.boolean "published", default: false, null: false
   end
 
   create_table "courses_categories", force: :cascade do |t|

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -22,7 +22,7 @@ class CoursesTest < ApplicationSystemTestCase
     visit_with_auth "/courses/#{courses(:course1).id}/edit", 'komagata'
     within 'form[name=course]' do
       fill_in 'course[title]', with: 'テストコース'
-      find(:css, '#checkbox-open-course').set(true)
+      find(:css, '#checkbox-published-course').set(true)
       fill_in 'course[description]', with: 'テストのコースです。'
       click_button '内容を保存'
     end


### PR DESCRIPTION
参照：[\#3326](https://github.com/fjordllc/bootcamp/issues/3326)

コースにあるカラム名を変更(``open``→``published``)。
カラム名がopenであると[Kernel\.\#open](https://docs.ruby-lang.org/ja/latest/method/Kernel/m/open.html)と被り不具合が生じる恐れがあるため。

参考PR：[#3093 (comment)](https://github.com/fjordllc/bootcamp/pull/3093#issuecomment-927229756)
