### PR TITLE
管理者でログインしているときは会社個別プロフィールに編集リンクを表示させるようにしました

### DIFF
--- a/app/views/companies/_profile.html.slim
+++ b/app/views/companies/_profile.html.slim
@@ -19,9 +19,9 @@
           = simple_format(company.description)
 
   - if current_user.admin?
-    footer.card-footer
+    footer.card-footer.is-only-mentor
       .card-main-actions
         .card-main-actions__items
-          .card-main-actions__item.is-only-mentor
+          .card-main-actions__item
             = link_to edit_admin_company_path(company), class: 'card-main-actions__action a-button is-sm is-secondary is-block' do
               | 管理者として編集


### PR DESCRIPTION
Issue #3165 

## 変更前
- 会社プロフィールの編集は管理ページからしか編集することができず、会社個別プロフィールからは編集することができない状態になっていた

![image](https://user-images.githubusercontent.com/74460623/136665133-4b80bd16-2043-4e44-97e7-76f6c4234ad6.png)

## 変更後
- 個別プロフィールに編集リンクを表示させることで、そこからも編集先に飛べるようにしました

![image](https://user-images.githubusercontent.com/74460623/136665184-17b674b7-4af6-477b-a14a-6d57156b1a5e.png)

## 参考にしたファイル
- `app/views/users/_user.html.slim`
    - 管理者でログインしている分岐処理を参考にしました
- `app/views/reports/show.html.slim`
    - リンク表示させるクラスを参考にしました