### PR TITLE
practicesテーブルへの余分なクエリを発行しないようにした

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -509,9 +509,8 @@ class User < ApplicationRecord
   end
 
   def active_practice
-    return unless active_practices.first
-
-    active_practices.first.id
+    active_practice = active_practices.first
+    active_practice ? active_practice.id : nil
   end
 
   def follow(other_user, watch:)


### PR DESCRIPTION
`active_practices.first`が存在する場合には`active_practices.first.id`を呼んでいましたが、その場合に`practices`テーブルへ2回クエリを発行していたので一時変数に入れることでこれを回避するようにしました。