### PR TITLE
プラクティスメモを保存する時にtoastを表示

### DIFF
--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -52,9 +52,10 @@
 import TextareaInitializer from './textarea-initializer'
 import MarkdownInitializer from './markdown-initializer'
 import confirmUnload from './confirm-unload'
+import toast from './toast'
 
 export default {
-  mixins: [confirmUnload],
+  mixins: [confirmUnload, toast],
   props: {
     practiceId: { type: String, required: true }
   },
@@ -145,6 +146,7 @@ export default {
       })
         .then(() => {
           this.editing = false
+          this.toast('保存しました！')
         })
         .catch((error) => {
           console.warn('Failed to parsing', error)


### PR DESCRIPTION
Isuue: [\#3394](https://github.com/fjordllc/bootcamp/issues/3394)

提出物個別ページにあるプラクティスメモ（メンター機能）を保存する時にtoastを表示させた。
## 変更内容
https://user-images.githubusercontent.com/78020405/137488159-4896649f-aebb-45b1-93bd-b276919f377a.mp4


