### PR TITLE
質問の削除、編集のリンクはログインしているユーザーが質問作成者もしくはAdminの時にのみ表示するように修正

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -70,7 +70,9 @@
           :currentUser='currentUser',
           :reactionableId='`Question_${question.id}`'
         )
-        footer.card-footer
+        footer.card-footer(
+          v-if='currentUser.id === question.user.id || currentUser.role === "admin"'
+        )
           .card-main-actions
             ul.card-main-actions__items
               li.card-main-actions__item

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -154,6 +154,15 @@ class QuestionsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'not admin or not question author can not delete any questions' do
+    question = questions(:question8)
+    visit_with_auth question_path(question), 'hatsuno'
+    within '.thread__inner' do
+      assert_no_text '内容修正'
+      assert_no_text '削除'
+    end
+  end
+
   test 'search questions by tag' do
     visit_with_auth questions_url, 'kimura'
     click_on '質問する'


### PR DESCRIPTION
他の人が作成した質問の削除、編集が誰でもできてしまうので、削除、編集のリンクはログインしているユーザーが質問作成者もしくはAdminの時にのみ表示するように修正しました。

### 変更前
生徒ユーザーhatsunoでログイン
<img width="666" alt="スクリーンショット 2021-10-17 10 23 08" src="https://user-images.githubusercontent.com/52710925/137606618-89cd1bad-03a1-4a36-ba64-baf58293ac69.png">
## 変更後
生徒ユーザーhatsunoでログイン
<img width="685" alt="スクリーンショット 2021-10-17 10 20 59" src="https://user-images.githubusercontent.com/52710925/137606555-14f1becf-09f5-4ac1-8b3b-492e48038563.png">
