### PR TITLE
notifications.created_atにindexを追加

### DIFF
--- a/db/migrate/20211017140518_add_index_to_notifications.rb
+++ b/db/migrate/20211017140518_add_index_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddIndexToNotifications < ActiveRecord::Migration[6.1]
+  def change
+    add_index :notifications, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_09_003559) do
+ActiveRecord::Schema.define(version: 2021_10_17_140518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -248,6 +248,7 @@ ActiveRecord::Schema.define(version: 2021_10_09_003559) do
     t.boolean "read", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_notifications_on_created_at"
     t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 


### PR DESCRIPTION
notifications.created_atのSELECT MAXやORDER BYのクエリに時間がかかっていたのでindexを追加しました。
下記で対象のクエリを発行しています。

https://github.com/fjordllc/bootcamp/blob/39e4b01237f361e56b7d271e0c4c0ff9252788d3/app/models/notification.rb#L231

https://github.com/fjordllc/bootcamp/blob/39e4b01237f361e56b7d271e0c4c0ff9252788d3/app/controllers/api/notifications_controller.rb#L11