### PR TITLE
Q&Aの通知メールに質問タイトルを含めるようにしました

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -25,6 +25,9 @@
   <!--[if lte mso 11]><style type="text/css">  .outlook-group-fix {    width:100% !important;  }</style><![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {
+      img {
+        max-width: 100%;
+      }
       .mj-column-per-100 {
         width: 100% !important;
       }

--- a/app/views/notification_mailer/_mailer_style.html.erb
+++ b/app/views/notification_mailer/_mailer_style.html.erb
@@ -42,7 +42,7 @@
     outline: none;
     text-decoration: none;
     -ms-interpolation-mode: bicubic;
-    max-width: 100%%;
+    max-width: 100%;
   }
 
   p {

--- a/app/views/notification_mailer/came_question.html.slim
+++ b/app/views/notification_mailer/came_question.html.slim
@@ -1,5 +1,5 @@
 = render 'notification_mailer_template', title: "「#{@question.practice.title}」についての質問がありました。", link_url: notification_url(@notification), link_text: '質問へ' do
   p #{@question.user.login_name}さんから「#{@question.practice.title}」についての質問がありました。アドバイスや回答を投稿しよう！！
   div(style='border-top: solid 1px #ccc; height: 0;')
-  = @question.title
+  h4 = @question.title
   = md2html(@question.description)

--- a/app/views/notification_mailer/came_question.html.slim
+++ b/app/views/notification_mailer/came_question.html.slim
@@ -1,5 +1,7 @@
 = render 'notification_mailer_template', title: "「#{@question.practice.title}」についての質問がありました。", link_url: notification_url(@notification), link_text: '質問へ' do
   p #{@question.user.login_name}さんから「#{@question.practice.title}」についての質問がありました。アドバイスや回答を投稿しよう！！
   div(style='border-top: solid 1px #ccc; height: 0;')
+  b タイトル
   h4 = @question.title
+  b 質問文
   = md2html(@question.description)

--- a/app/views/notification_mailer/came_question.html.slim
+++ b/app/views/notification_mailer/came_question.html.slim
@@ -1,7 +1,6 @@
 = render 'notification_mailer_template', title: "「#{@question.practice.title}」についての質問がありました。", link_url: notification_url(@notification), link_text: '質問へ' do
-  p #{@question.user.login_name}さんから「#{@question.practice.title}」についての質問がありました。アドバイスや回答を投稿しよう！！
+  p #{@question.user.login_name}さんから質問がありました。アドバイスや回答を投稿しよう！！
   div(style='border-top: solid 1px #ccc; height: 0;')
-  b タイトル
-  h4 = @question.title
-  b 質問文
+  h1(style='margin-top: 1em; border-left: solid 6px #4638a0; padding: 0 0 0 1rem; font-size: 1.5em; border-bottom: none; color: #444444;')
+    = @question.title
   = md2html(@question.description)

--- a/app/views/notification_mailer/came_question.html.slim
+++ b/app/views/notification_mailer/came_question.html.slim
@@ -1,4 +1,5 @@
 = render 'notification_mailer_template', title: "「#{@question.practice.title}」についての質問がありました。", link_url: notification_url(@notification), link_text: '質問へ' do
   p #{@question.user.login_name}さんから「#{@question.practice.title}」についての質問がありました。アドバイスや回答を投稿しよう！！
   div(style='border-top: solid 1px #ccc; height: 0;')
+  = @question.title
   = md2html(@question.description)


### PR DESCRIPTION
Issue #3356 

### 変更前
- Q&Aの通知メールに質問タイトルが含まれていないので、質問内容によってはメールだけで意図を汲み取ることができない状態になっていた

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOGxwQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--f33bf8a68f8ca3248556dee205f63f33de6cf84b/image.png)

### 変更後
- 質問タイトルを表示させるように変更しました

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOHBwQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--cf7a641de06d7974b6d85c323cb84d64acd955d9/image.png)