### PR TITLE
未完了タブのタイトルを「未完了の提出物」→「提出物」に変更

### DIFF
--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -1,4 +1,4 @@
-- title '未完了の提出物'
+- title '提出物'
 
 header.page-header
   .container


### PR DESCRIPTION
## 概要

- Issue: #3416 
- （メンター） 提出物 > 未完了タブ のページのタイトルを「未完了の提出物」から「提出物」に変更

## UIの変更

### 変更前

![image](https://user-images.githubusercontent.com/61409641/137869665-9ee298ce-bcb2-4d93-93a0-fbc4c5c62ecf.png)

### 変更後

![image](https://user-images.githubusercontent.com/61409641/137869723-e94562d7-7d2d-4026-8a1b-4d70c88401ae.png)
