### PR TITLE
管理者かメンターでログイン時、サイドバーの提出物をクリックしたときに開くタブを未返信から未アサインにする

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -26,7 +26,7 @@ nav.global-nav
             .global-nav-links__link-label 日報
         - if staff_login?
           li.global-nav-links__item
-            - products_link = admin_or_mentor_login? ? products_not_responded_index_path : products_path
+            - products_link = admin_or_mentor_login? ? products_unassigned_index_path : products_path
             = link_to products_link, class: "global-nav-links__link #{current_link(/^products/)}" do
               .global-nav-links__link-icon
                 i.fas.fa-fw.fa-hand-paper


### PR DESCRIPTION
# 概要
issue: 【メンター向け】サイドバーの「提出物」をクリックしたら未アサインタブを開いてほしい ( https://github.com/fjordllc/bootcamp/issues/3173 )

# 変更内容
管理者かメンターでログイン時、サイドバー の提出物をクリックしたときに開くタブを「未返信」から「未アサイン」に変更しました。
![af44f8f910e9a4f5c26ebeca65d82750](https://user-images.githubusercontent.com/52844263/137925999-5371afba-34fa-4891-97d1-305f0dac5885.gif)

