### PR TITLE
未返信タブのタイトルを「未返信の提出物」→「提出物」に変更

### DIFF
--- a/app/views/products/not_responded/index.html.slim
+++ b/app/views/products/not_responded/index.html.slim
@@ -1,4 +1,4 @@
-- title '未返信の提出物'
+- title '提出物'
 
 header.page-header
   .container


### PR DESCRIPTION
issue: #3417 
未返信タブのタイトルを「未返信の提出物」→「提出物」に変更しました。

## UIの変更

### 変更前
<img width="653" alt="スクリーンショット 2021-10-20 9 07 38" src="https://user-images.githubusercontent.com/52844263/138007406-80194de1-001e-4c5c-a40f-9b2fe56d39c3.png">

### 変更後
<img width="648" alt="スクリーンショット 2021-10-20 9 08 50" src="https://user-images.githubusercontent.com/52844263/138007401-589efe79-f602-435a-ae7a-d3520f6fc627.png">

