### PR TITLE
入力途中でブラウザバックしたとき、確認ダイアログが出るようにした(コメント欄、Q＆Aの回答欄）

### DIFF
--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -43,7 +43,7 @@
               v-model='description',
               name='answer[description]',
               data-preview='#new-comment-preview',
-              @keyup='editAnswer'
+              @input='editAnswer'
             )
           .thread-comment-form__markdown.js-tabs__content(
             :class='{ "is-active": isActive("preview") }'

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -43,7 +43,7 @@
               v-model='description',
               name='answer[description]',
               data-preview='#new-comment-preview',
-              @keyup="editAnswer"
+              @keyup='editAnswer'
             )
           .thread-comment-form__markdown.js-tabs__content(
             :class='{ "is-active": isActive("preview") }'

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -147,6 +147,7 @@ export default {
         return null
       }
       this.buttonDisabled = true
+      this.editing = false
       const params = {
         answer: { description: this.description },
         question_id: this.questionId

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -42,7 +42,8 @@
             textarea#js-new-comment.a-text-input.js-warning-form.thread-comment-form__textarea(
               v-model='description',
               name='answer[description]',
-              data-preview='#new-comment-preview'
+              data-preview='#new-comment-preview',
+              @keyup="editAnswer"
             )
           .thread-comment-form__markdown.js-tabs__content(
             :class='{ "is-active": isActive("preview") }'
@@ -62,6 +63,7 @@
 import Answer from './answer.vue'
 import TextareaInitializer from './textarea-initializer'
 import CommentPleaceholder from './comment-placeholder'
+import confirmUnload from './confirm-unload'
 import toast from './toast'
 
 export default {
@@ -69,7 +71,7 @@ export default {
     answer: Answer,
     commentPlaceholder: CommentPleaceholder
   },
-  mixins: [toast],
+  mixins: [toast, confirmUnload],
   props: {
     questionId: { type: String, required: true },
     questionUser: { type: Object, required: true },
@@ -84,6 +86,7 @@ export default {
       question: { correctAnswer: null },
       defaultTextareaSize: null,
       loaded: false,
+      editing: false,
       placeholderCount: 3
     }
   },
@@ -267,6 +270,9 @@ export default {
     resizeTextarea: function () {
       const textarea = document.getElementById('js-new-comment')
       textarea.style.height = `${this.defaultTextareaSize}px`
+    },
+    editAnswer() {
+      this.editing = true
     }
   }
 }

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -273,7 +273,9 @@ export default {
       textarea.style.height = `${this.defaultTextareaSize}px`
     },
     editAnswer() {
-      this.editing = true
+      if (this.description.length > 0) {
+        this.editing = true
+      }
     }
   }
 }

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -45,7 +45,7 @@
             v-model='description',
             name='new_comment[description]',
             data-preview='#new-comment-preview',
-            @keyup="editComment"
+            @keyup='editComment'
           )
         .thread-comment-form__markdown.js-tabs__content(
           :class='{ "is-active": isActive("preview") }'

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -185,6 +185,7 @@ export default {
         return null
       }
       this.buttonDisabled = true
+      this.editing = false
       const params = {
         comment: { description: this.description },
         commentable_type: this.commentableType,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -45,7 +45,7 @@
             v-model='description',
             name='new_comment[description]',
             data-preview='#new-comment-preview',
-            @keyup='editComment'
+            @input='editComment'
           )
         .thread-comment-form__markdown.js-tabs__content(
           :class='{ "is-active": isActive("preview") }'
@@ -326,7 +326,9 @@ export default {
       })
     },
     editComment() {
-      this.editing = true
+      if (this.description.length > 0) {
+        this.editing = true
+      }
     }
   }
 }

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -44,7 +44,8 @@
           textarea#js-new-comment.a-text-input.js-warning-form.thread-comment-form__textarea(
             v-model='description',
             name='new_comment[description]',
-            data-preview='#new-comment-preview'
+            data-preview='#new-comment-preview',
+            @keyup="editComment"
           )
         .thread-comment-form__markdown.js-tabs__content(
           :class='{ "is-active": isActive("preview") }'
@@ -73,6 +74,7 @@
 import Comment from './comment.vue'
 import TextareaInitializer from './textarea-initializer'
 import CommentPleaceholder from './comment-placeholder'
+import confirmUnload from './confirm-unload'
 import toast from './toast'
 
 export default {
@@ -80,7 +82,7 @@ export default {
     comment: Comment,
     commentPlaceholder: CommentPleaceholder
   },
-  mixins: [toast],
+  mixins: [toast, confirmUnload],
   props: {
     commentableId: { type: String, required: true },
     commentableType: { type: String, required: true },
@@ -95,6 +97,7 @@ export default {
       buttonDisabled: false,
       defaultTextareaSize: null,
       loaded: false,
+      editing: false,
       placeholderCount: 3,
       commentLimit: 8,
       commentOffset: 0,
@@ -320,6 +323,9 @@ export default {
         redirect: 'manual',
         body: JSON.stringify(params)
       })
+    },
+    editComment() {
+      this.editing = true
     }
   }
 }


### PR DESCRIPTION
ref: #2272 

コメント欄とQ＆Aの回答欄でブラウザバックなどでページを離脱するとき確認ダイアログが出るようにしました。

日報コメント欄
![image](https://user-images.githubusercontent.com/57053236/138028454-d889206a-ff4c-4557-a764-99321a37cd57.png)

Q＆A回答欄
![image](https://user-images.githubusercontent.com/57053236/138028594-9c8b2b0e-ef4b-4f56-bbf7-d5d982582d67.png)
