### PR TITLE
テストの中で定数が使用されていた箇所で定数を使用しないよう修正

### DIFF
--- a/test/system/product/not_responded_test.rb
+++ b/test/system/product/not_responded_test.rb
@@ -2,7 +2,7 @@
 
 require 'application_system_test_case'
 
-class ProductsTest < ApplicationSystemTestCase
+class Product::NotRespondedTest < ApplicationSystemTestCase
   test 'non-staff user can not see listing not-responded products' do
     visit_with_auth '/products/not_responded', 'hatsuno'
     assert_text '管理者・アドバイザー・メンターとしてログインしてください'

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -3,7 +3,9 @@
 require 'application_system_test_case'
 
 class ProductsTest < ApplicationSystemTestCase
-  PAGINATES_PER = 50
+  setup do
+    PAGINATES_PER = 50
+  end
 
   test 'non-staff user can not see listing self-assigned products' do
     visit_with_auth '/products/self_assigned', 'hatsuno'

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -3,10 +3,6 @@
 require 'application_system_test_case'
 
 class ProductsTest < ApplicationSystemTestCase
-  setup do
-    PAGINATES_PER = 50
-  end
-
   test 'non-staff user can not see listing self-assigned products' do
     visit_with_auth '/products/self_assigned', 'hatsuno'
     assert_text '管理者・アドバイザー・メンターとしてログインしてください'
@@ -50,7 +46,7 @@ class ProductsTest < ApplicationSystemTestCase
     checker = users(:komagata)
     # id順で並べたときの最初と最後の提出物を、作成日順で見たときに最新と最古になるように入れ替える
     # 最古の提出物を画面上で判定するため、提出物を1ページ内に収める
-    Product.limit(PAGINATES_PER).update_all(created_at: 1.day.ago, published_at: 1.day.ago, checker_id: checker.id) # rubocop:disable Rails/SkipsModelValidations
+    Product.limit(Product.default_per_page).update_all(created_at: 1.day.ago, published_at: 1.day.ago, checker_id: checker.id) # rubocop:disable Rails/SkipsModelValidations
     newest_product = Product.self_assigned_product(checker.id).unchecked.reorder(:id).first
     newest_product.update(created_at: Time.current)
     oldest_product = Product.self_assigned_product(checker.id).unchecked.reorder(:id).last

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -2,7 +2,7 @@
 
 require 'application_system_test_case'
 
-class ProductsTest < ApplicationSystemTestCase
+class Product::SelfAssignedTest < ApplicationSystemTestCase
   test 'non-staff user can not see listing self-assigned products' do
     visit_with_auth '/products/self_assigned', 'hatsuno'
     assert_text '管理者・アドバイザー・メンターとしてログインしてください'

--- a/test/system/product/unassigned_test.rb
+++ b/test/system/product/unassigned_test.rb
@@ -2,7 +2,7 @@
 
 require 'application_system_test_case'
 
-class ProductsTest < ApplicationSystemTestCase
+class Product::UnassignedTest < ApplicationSystemTestCase
   test 'non-staff user can not see listing unassigned products' do
     visit_with_auth '/products/unassigned', 'hatsuno'
     assert_text '管理者・アドバイザー・メンターとしてログインしてください'

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -3,8 +3,6 @@
 require 'application_system_test_case'
 
 class ProductsTest < ApplicationSystemTestCase
-  PAGINATES_PER = 50
-
   test 'non-staff user can not see listing unchecked products' do
     visit_with_auth '/products/unchecked', 'hatsuno'
     assert_text '管理者・アドバイザー・メンターとしてログインしてください'
@@ -39,7 +37,7 @@ class ProductsTest < ApplicationSystemTestCase
     # id順で並べたときの最初と最後の提出物を、提出日順で見たときに最新と最古になるように入れ替える
     Product.update_all(created_at: 1.day.ago, published_at: 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
     # 最古の提出物を画面上で判定するため、提出物を1ページ内に収める
-    Product.unchecked.not_wip.limit(Product.count - PAGINATES_PER).delete_all
+    Product.unchecked.not_wip.limit(Product.count - Product.default_per_page).delete_all
     newest_product = Product.unchecked.not_wip.reorder(:id).first
     newest_product.update(published_at: Time.current)
     oldest_product = Product.unchecked.not_wip.reorder(:id).last

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -2,7 +2,7 @@
 
 require 'application_system_test_case'
 
-class ProductsTest < ApplicationSystemTestCase
+class Product::UncheckedTest < ApplicationSystemTestCase
   test 'non-staff user can not see listing unchecked products' do
     visit_with_auth '/products/unchecked', 'hatsuno'
     assert_text '管理者・アドバイザー・メンターとしてログインしてください'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -3,7 +3,9 @@
 require 'application_system_test_case'
 
 class ProductsTest < ApplicationSystemTestCase
-  PAGINATES_PER = 50
+  setup do
+    PAGINATES_PER = 50
+  end
 
   test 'see my product' do
     visit_with_auth "/products/#{products(:product1).id}", 'yamada'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -3,10 +3,6 @@
 require 'application_system_test_case'
 
 class ProductsTest < ApplicationSystemTestCase
-  setup do
-    PAGINATES_PER = 50
-  end
-
   test 'see my product' do
     visit_with_auth "/products/#{products(:product1).id}", 'yamada'
     assert_equal "#{products(:product1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
@@ -197,7 +193,7 @@ class ProductsTest < ApplicationSystemTestCase
     # id順で並べたときの最初と最後の提出物を、作成日順で見たときに最新と最古になるように入れ替える
     Product.update_all(created_at: 1.day.ago, published_at: 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
     # 最古の提出物を画面上で判定するため、提出物を1ページ内に収める
-    Product.limit(Product.count - PAGINATES_PER).delete_all
+    Product.limit(Product.count - Product.default_per_page).delete_all
     newest_product = Product.reorder(:id).first
     newest_product.update(created_at: Time.current)
     oldest_product = Product.reorder(:id).last
@@ -228,7 +224,7 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'click on the pager button' do
-    (PAGINATES_PER - Product.count + 1).times do |n|
+    (Product.default_per_page - Product.count + 1).times do |n|
       Product.create!(
         body: 'test',
         user: users(:hajime),
@@ -248,7 +244,7 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'specify the page number in the URL' do
-    (PAGINATES_PER - Product.count + 1).times do |n|
+    (Product.default_per_page - Product.count + 1).times do |n|
       Product.create!(
         body: 'test',
         user: users(:hajime),
@@ -264,7 +260,7 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'clicking the browser back button will show the previous page' do
-    (PAGINATES_PER - Product.count + 1).times do |n|
+    (Product.default_per_page - Product.count + 1).times do |n|
       Product.create!(
         body: 'test',
         user: users(:hajime),
@@ -284,7 +280,7 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'When the number of pages is one, the pager will not be displayed' do
-    count_of_delete = Product.count - PAGINATES_PER
+    count_of_delete = Product.count - Product.default_per_page
     if count_of_delete.positive?
       Product.all.each_with_index do |product, index|
         product.delete

--- a/test/system/user/products_test.rb
+++ b/test/system/user/products_test.rb
@@ -3,8 +3,6 @@
 require 'application_system_test_case'
 
 class User::ProductsTest < ApplicationSystemTestCase
-  PAGINATES_PER = 50
-
   test 'show listing products' do
     visit_with_auth "/users/#{users(:hatsuno).id}/products", 'komagata'
     assert_equal 'hatsunoの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title


### PR DESCRIPTION
定数の再定義によって発生していた以下のエラーを解消します。

```
/Users/mi/ghq/github.com/fjordllc/bootcamp/test/system/product/unassigned_test.rb:6: warning: already initialized constant ProductsTest::PAGINATES_PER
/Users/mi/ghq/github.com/fjordllc/bootcamp/test/system/product/self_assigned_test.rb:6: warning: previous definition of PAGINATES_PER was here
/Users/mi/ghq/github.com/fjordllc/bootcamp/test/system/product/unchecked_test.rb:6: warning: already initialized constant ProductsTest::PAGINATES_PER
/Users/mi/ghq/github.com/fjordllc/bootcamp/test/system/product/unassigned_test.rb:6: warning: previous definition of PAGINATES_PER was here
/Users/mi/ghq/github.com/fjordllc/bootcamp/test/system/products_test.rb:6: warning: already initialized constant ProductsTest::PAGINATES_PER
/Users/mi/ghq/github.com/fjordllc/bootcamp/test/system/product/unchecked_test.rb:6: warning: previous definition of PAGINATES_PER was here
```