### PR TITLE
ユーザプロフィールの質問タブに、該当ユーザの質問した数を表示

### DIFF
--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -19,4 +19,4 @@
           | 提出物
       li.page-tabs__item
         = link_to user_questions_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('questions')}" do
-          | 質問
+          | 質問 （#{user.questions.length}）


### PR DESCRIPTION
## 概要

- refs: #3424 
- ユーザプロフィールの質問タブに、該当ユーザの質問した数を表示する。
- 質問数を囲む`()`は全角指定です。

## UIの変更

### 変更前

![image](https://user-images.githubusercontent.com/61409641/138252442-866aeb03-7bc3-48ac-9966-61c70c926ae6.png)

### 変更後

![image](https://user-images.githubusercontent.com/61409641/138256589-9d43abe0-805d-466b-9250-9aed32c9a49a.png)

質問が1件もない場合
![image](https://user-images.githubusercontent.com/61409641/138256504-b20576f1-5287-4bbe-bfb8-6bac9f655aeb.png)


## 申し送り事項
- 参考（プラクティスの質問タブ）：https://github.com/fjordllc/bootcamp/blob/2cb5d269cb23458003a9e6c503ded517902ff68b/app/views/application/_page_tab.html.slim#L4