### PR TITLE
ダッシュボード配下のブックマークが0のときに.a-cardを表示させないように変更

### DIFF
--- a/app/javascript/bookmarks.vue
+++ b/app/javascript/bookmarks.vue
@@ -6,7 +6,13 @@
       |
       | ロード中
   .container.is-md(v-else)
-    .thread-list-tools(v-if='bookmarks.length')
+    .thread-list-tools(v-if='bookmarks.length === 0')
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | ブックマークしているものはありません。
+    .thread-list-tools(v-else)
       .form-item.is-inline
         label.a-form-label(for='thread-list-tools__action')
           | 編集
@@ -17,25 +23,19 @@
             v-model='checked'
           )
           span#spec-edit-mode
-    .thread-list-tools(v-else)
-      .o-empty-message
-        .o-empty-message__icon
-          i.far.fa-sad-tear
-        p.o-empty-message__text
-          | ブックマークしているものはありません。
-    nav.pagination(v-if='totalPages > 1')
-      pager(v-bind='pagerProps')
-    .thread-list.a-card
-      .thread-list__items
-        bookmark(
-          v-for='bookmark in bookmarks',
-          :key='bookmark.id',
-          :bookmark='bookmark',
-          :checked='checked',
-          @updateIndex='updateIndex'
-        )
-    nav.pagination(v-if='totalPages > 1')
-      pager(v-bind='pagerProps')
+      nav.pagination(v-if='totalPages > 1')
+        pager(v-bind='pagerProps')
+      .thread-list.a-card
+        .thread-list__items
+          bookmark(
+            v-for='bookmark in bookmarks',
+            :key='bookmark.id',
+            :bookmark='bookmark',
+            :checked='checked',
+            @updateIndex='updateIndex'
+          )
+      nav.pagination(v-if='totalPages > 1')
+        pager(v-bind='pagerProps')
 </template>
 <script>
 import Bookmark from './bookmark.vue'


### PR DESCRIPTION
issue:[\#3395](https://github.com/fjordllc/bootcamp/issues/3395)

ブックマークが0の時と、ブックマークがある時のコードが混ざっていたため、分割し``.a-card``を表示させないようにした。

## 変更前
<img width="1500" alt="136290260-9423af6f-5d4e-4b2d-8ee6-018de2631ace" src="https://user-images.githubusercontent.com/78020405/138269436-d4dcc1df-38e0-48c1-bc0b-06c1d0aed2b9.png">

## 変更後
<img width="1062" alt="スクリーンショット 2021-10-21 20 34 59" src="https://user-images.githubusercontent.com/78020405/138269466-c42f270f-a250-4f0e-8c64-7c72cdd019d6.png">


