### PR TITLE
お知らせ個別ページのデザイン崩れを修正

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-header-actions.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-header-actions.sass
@@ -23,6 +23,7 @@
   justify-content: flex-end
 
 .thread-header-actions__action
+  min-width: 5.5rem
   +media-breakpoint-up(md)
     +padding(horizontal, .25rem)
     min-width: 7rem


### PR DESCRIPTION
issue: #3431 

スマホ閲覧時のボタンのスタイル崩れを修正しました

## 修正前
<img width="360" src="https://user-images.githubusercontent.com/52844263/138280943-7a841af0-cabc-4804-ad26-55a796b154b4.png">

## 修正後
<img width="360" src="https://user-images.githubusercontent.com/52844263/138280970-3a6bafae-bedc-4652-88b6-dfcb0d7697ab.png">

