### PR TITLE
企業情報にTechブログのURLを登録する機能を実装した

### DIFF
--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -47,7 +47,8 @@ class Admin::CompaniesController < AdminController
       :name,
       :description,
       :website,
-      :logo
+      :logo,
+      :blog_url
     )
   end
 end

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -10,6 +10,9 @@
       = f.label :website, class: 'a-form-label'
       = f.text_field :website, class: 'a-text-input'
     .form-item
+      = f.label :blog_url, class: 'a-form-label'
+      = f.text_field :blog_url, class: 'a-text-input'
+    .form-item
       = f.label 'ロゴ', class: 'a-form-label'
       .form-item-file-input.js-file-input.a-file-input
         label.js-file-input__preview(for='company_logo')

--- a/app/views/companies/_links.html.slim
+++ b/app/views/companies/_links.html.slim
@@ -4,3 +4,7 @@ nav.company-links
       li.company-links__item
         = link_to company.website, target: '_blank', rel: 'noopener', class: 'a-button is-xs is-secondary is-block' do
           | 企業ページ
+    - if company.blog_url?
+      li.company-links__item
+        = link_to company.blog_url, target: '_blank', rel: 'noopener', class: 'a-button is-xs is-secondary is-block' do
+          | Techブログ

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -109,6 +109,7 @@ ja:
         description: 詳細
         website: ウェブサイト
         logo: ロゴ
+        blog_url: Techブログ
       category:
         name: 名前
         slug: URLスラッグ

--- a/db/fixtures/companies.yml
+++ b/db/fixtures/companies.yml
@@ -48,6 +48,7 @@ company1:
   第１１条（協議）
   本契約に定めのない事項に関しては、甲乙別途協議のうえ円満に解決を図るものとする。 "
   created_at: 2000-01-01 00:00:01
+  blog_url: "https://tech.sample.com/"
 
 company2:
   name: "BatsuBatsu Inc"

--- a/db/fixtures/companies.yml
+++ b/db/fixtures/companies.yml
@@ -48,7 +48,7 @@ company1:
   第１１条（協議）
   本契約に定めのない事項に関しては、甲乙別途協議のうえ円満に解決を図るものとする。 "
   created_at: 2000-01-01 00:00:01
-  blog_url: "https://tech.sample.com/"
+  blog_url: "https://tech.sample.com"
 
 company2:
   name: "BatsuBatsu Inc"

--- a/db/migrate/20211021225338_add_blog_url_to_companies.rb
+++ b/db/migrate/20211021225338_add_blog_url_to_companies.rb
@@ -1,0 +1,5 @@
+class AddBlogUrlToCompanies < ActiveRecord::Migration[6.1]
+  def change
+    add_column :companies, :blog_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_17_140518) do
+ActiveRecord::Schema.define(version: 2021_10_21_225338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,7 @@ ActiveRecord::Schema.define(version: 2021_10_17_140518) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "tos"
+    t.string "blog_url"
   end
 
   create_table "courses", force: :cascade do |t|

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -48,7 +48,7 @@ company1:
   第１１条（協議）
   本契約に定めのない事項に関しては、甲乙別途協議のうえ円満に解決を図るものとする。 "
   created_at: 2000-01-01 00:00:01
-  blog_url: "https://tech.sample.com/"
+  blog_url: "https://tech.sample.com"
 
 company2:
   name: "root inc."

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -48,6 +48,7 @@ company1:
   第１１条（協議）
   本契約に定めのない事項に関しては、甲乙別途協議のうえ円満に解決を図るものとする。 "
   created_at: 2000-01-01 00:00:01
+  blog_url: "https://tech.sample.com/"
 
 company2:
   name: "root inc."

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -14,6 +14,7 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
       fill_in 'company[name]', with: 'テスト企業'
       fill_in 'company[description]', with: 'テストの企業です。'
       fill_in 'company[website]', with: 'https://example.com'
+      fill_in 'company[blog_url]', with: 'https://example.com'
       click_button '登録する'
     end
     assert_text '企業を作成しました。'
@@ -25,6 +26,7 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
       fill_in 'company[name]', with: 'テスト企業'
       fill_in 'company[description]', with: 'テストの企業です。'
       fill_in 'company[website]', with: 'https://example.com'
+      fill_in 'company[blog_url]', with: 'https://example.com'
       click_button '更新する'
     end
     assert_text '企業を更新しました。'

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -22,8 +22,8 @@ class CompaniesTest < ApplicationSystemTestCase
 
   test 'show link to blog url if company has' do
     visit_with_auth "/companies/#{companies(:company1).id}", 'komagata'
-    within '.company-blog-links' do
-      assert_link 'Techブログ', href: 'https://tech.sample.com/'
+    within '.company-links' do
+      assert_link 'Techブログ', href: 'https://tech.sample.com'
     end
   end
 end

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -19,4 +19,11 @@ class CompaniesTest < ApplicationSystemTestCase
       assert_link '企業ページ', href: 'https://fjord.jp'
     end
   end
+
+  test 'show link to blog url if company has' do
+    visit_with_auth "/companies/#{companies(:company1).id}", 'komagata'
+    within '.company-blog-links' do
+      assert_link 'Techブログ', href: 'https://tech.sample.com/'
+    end
+  end
 end


### PR DESCRIPTION
issue:[\#3379](https://github.com/fjordllc/bootcamp/issues/3379)

## 変更点
### 編集画面（管理者のみ可能）
url:``/admin/companies/{id}/edit``
<img width="824" alt="編集" src="https://user-images.githubusercontent.com/78020405/138410785-9c525a18-48cf-4ade-82ac-a98e09aa1ec4.png">
### 企業個別ページ
url:``/companies/{id}``
<img width="478" alt="個別" src="https://user-images.githubusercontent.com/78020405/138411042-b71246a9-d44b-4f5f-af91-9f6c93583708.png">
### 企業一覧ページ
url:``/companies``
<img width="1095" alt="一覧" src="https://user-images.githubusercontent.com/78020405/138411280-c8979875-06b2-4bdb-b1dd-d74afe741af7.png">


