### PR TITLE
rubocop-fjordを0.2.0にアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :development do
   gem 'letter_opener_web', '~> 1.0'
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'rubocop', require: false
-  gem 'rubocop-fjord', require: false
+  gem 'rubocop-fjord', '~> 0.2.0', require: false
   gem 'rubocop-minitest', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.8.0)
       parser (>= 3.0.1.1)
-    rubocop-fjord (0.1.4)
+    rubocop-fjord (0.2.0)
       rubocop (>= 1.0)
       rubocop-performance
     rubocop-minitest (0.11.0)
@@ -529,7 +529,7 @@ DEPENDENCIES
   ransack
   rollbar
   rubocop
-  rubocop-fjord
+  rubocop-fjord (~> 0.2.0)
   rubocop-minitest
   rubocop-performance
   rubocop-rails
@@ -556,4 +556,4 @@ RUBY VERSION
    ruby 2.6.8p205
 
 BUNDLED WITH
-   2.2.24
+   2.2.27


### PR DESCRIPTION
TargetRubyVersionがが2.5から2.6にアップデートされます。