### PR TITLE
ユーザー画面の学習時間のバグを修正

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -72,7 +72,7 @@ header.page-header
           - if admin_or_mentor_login?
             #js-user-mentor-memo(data-user-id='#{@user.id}')
           - unless @user.total_learning_time.zero? || @user.mentor?
-            #js-grass(data-user-id="#{current_user.id}")
+            #js-grass(data-user-id="#{@user.id}")
           - if @user.github_account.present?
             = render 'users/github_grass', user: @user
           - if @user.active_practices.present?


### PR DESCRIPTION
Ref: #3452

## 概要

ユーザのプロフィール画面に表示される学習時間のカレンダーが他のユーザーのプロフィール画面でも自分の学習時間が表示されるようにしました。

## 内容

[hajime]でログインしてる際の[hatsuno]のプロフィール画面(１枚目)
![スクリーンショット 2021-10-26 20 00 41](https://user-images.githubusercontent.com/77760087/138865083-954b638f-1f98-4d00-8958-e8830ad47681.png)



[hatsuno]でログインしてる際の[hatsuno]のプロフィール画面(２枚目)

![スクリーンショット 2021-10-26 20 05 23](https://user-images.githubusercontent.com/77760087/138865679-3de44f0f-0c5d-4285-9064-8e22b36eb247.png)



[hajime]でログインしてる際の[hajime]のプロフィール画面(３枚目) 
![スクリーンショット 2021-10-26 20 00 30](https://user-images.githubusercontent.com/77760087/138865053-22161616-68ca-4be2-992b-3a0a0273c9e3.png)

## 関連Issue

Ref: #3194
