### PR TITLE
StaleをGitHub Actionsで動かす

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 1 * * *"
+
+jobs:
+  stale:
+    name: stale
+    runs-on: ubuntu:latest
+    steps:
+      uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'このissue|PRは60日間更新がないため7日後にcloseします。closeしたくない場合はstaleラベルを外してください。'
+        close-issue-message: 'このissue|PRはstaleラベルを付けた後7日間更新がないためcloseしました。'
+        days-before-stale: 60
+        days-before-close: 7
+        exempt-issue-labels:
+          - pinned
+          - security
+          - release
+          - bug
+          - バグ
+        stale-issue-label: stale


### PR DESCRIPTION
現在issuesが251件あり、数年経過しているissueもある。
staleを動かすことで、長期間動きのないissue/PRをCloseして見通しをよくする。

staleは以前 https://github.com/fjordllc/bootcamp/pull/2373 で導入されていたが、 https://github.com/fjordllc/bootcamp/pull/2863 でstale.ymlが（誤って？）消えていたので復活させ、あわせて設定を見やすくするためGitHub Actionsで動かすようにする。

設定値は https://github.com/fjordllc/bootcamp/pull/2373/commits/830963081c7356fe2e4c7315041e6cd2c9c69032 を参考にした

close https://github.com/fjordllc/bootcamp/issues/2369