### PR TITLE
イベントページの上部にコメント数を表示

### DIFF
--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -11,6 +11,13 @@
               .a-meta
                 time.a-meta__value(datetime="#{event.created_at.to_datetime}" pubdate='pubdate')
                   = l event.updated_at
+            .thread-header-metas__meta
+              - length = event.comments.length
+              a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
+                | コメント（
+                span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
+                  = length
+                | ）
 
       .thread-header__row
         h1.thread-header-title


### PR DESCRIPTION
issue: #2907 

## UIの変更
### 変更前
<img width="1111" alt="スクリーンショット 2021-10-27 18 56 40" src="https://user-images.githubusercontent.com/52844263/139044019-6785dfcb-62ab-4361-9e23-b3a2f6a62d46.png">


### 変更後
<img width="1109" alt="スクリーンショット 2021-10-27 18 56 10" src="https://user-images.githubusercontent.com/52844263/139044007-c5a63f13-3985-4e80-929b-f286a6baf082.png">

## 参考にした実装
お知らせと日報で全く同じ実装がされているのでそちらを参考にしました。
* お知らせ
    * https://github.com/fjordllc/bootcamp/blob/3e1f4e1087edbc8261e710aa30119d6fa55b9edb/app/views/announcements/_announcement.html.slim#L21-L25
* 日報
    * https://github.com/fjordllc/bootcamp/blob/548cb738f7e58bc713eed72a2567e59dff251044/app/views/reports/show.html.slim#L48-L54