### PR TITLE
Docにブックマーク機能を追加

### DIFF
--- a/app/javascript/bookmark.js
+++ b/app/javascript/bookmark.js
@@ -7,16 +7,14 @@ document.addEventListener('DOMContentLoaded', () => {
   if (bookmark) {
     const bookmarkbleId = Number(bookmark.getAttribute('data-bookmarkable-id'))
     const bookmarkableType = bookmark.getAttribute('data-bookmarkable-type')
-    if (bookmark) {
-      new Vue({
-        render: (h) =>
-          h(BookmarkButton, {
-            props: {
-              bookmarkableId: bookmarkbleId,
-              bookmarkableType: bookmarkableType
-            }
-          })
-      }).$mount(selector)
-    }
+    new Vue({
+      render: (h) =>
+        h(BookmarkButton, {
+          props: {
+            bookmarkableId: bookmarkbleId,
+            bookmarkableType: bookmarkableType
+          }
+        })
+    }).$mount(selector)
   }
 })

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -7,6 +7,7 @@ class Page < ApplicationRecord
   include Reactionable
   include Commentable
   include Watchable
+  include Bookmarkable
 
   belongs_to :user
   belongs_to :practice, optional: true

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -78,6 +78,8 @@ header.page-header
               .thread-header-actions__start
                 .thread-header-actions__action
                   #js-watch-toggle(data-watchable-id="#{@page.id}", data-watchable-type='Page')
+                .thread-header-actions__action
+                  #js-bookmark(data-bookmarkable-id="#{@page.id}", data-bookmarkable-type='Page')
         - if @page.practice.present?
           .thread-category
             = link_to @page.practice, class: 'thread-category__link' do

--- a/db/fixtures/bookmarks.yml
+++ b/db/fixtures/bookmarks.yml
@@ -1,3 +1,7 @@
+bookmark30:
+  user: kimura
+  bookmarkable: page1 (Page)
+
 bookmark29:
   user: kimura
   bookmarkable: product1 (Product)

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,3 +1,7 @@
+bookmark30:
+  user: kimura
+  bookmarkable: page1 (Page)
+
 bookmark29:
   user: kimura
   bookmarkable: product1 (Product)

--- a/test/integration/api/bookmarks_test.rb
+++ b/test/integration/api/bookmarks_test.rb
@@ -70,4 +70,17 @@ class API::BookmarksTest < ActionDispatch::IntegrationTest
          headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :created
   end
+
+  test 'POST page' do
+    page = pages(:page2)
+    token = create_token('kimura', 'testtest')
+    post api_bookmarks_path(format: :json),
+         params: {
+           user: 'kimura',
+           bookmarkable_id: page.id,
+           bookmarkable_type: 'Page'
+         },
+         headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :created
+  end
 end

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -26,4 +26,12 @@ class BookmarkTest < ActiveSupport::TestCase
     Bookmark.create(user: user, bookmarkable: product)
     assert_not Bookmark.new(user: user, bookmarkable: product).valid?
   end
+
+  test 'prohibit to duplicate page registration' do
+    user = users(:kimura)
+    page = pages(:page1)
+
+    Bookmark.create(user: user, bookmarkable: page)
+    assert_not Bookmark.new(user: user, bookmarkable: page).valid?
+  end
 end

--- a/test/system/bookmark/page_test.rb
+++ b/test/system/bookmark/page_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Bookmark::PageTest < ApplicationSystemTestCase
+  setup do
+    @page = pages(:page1)
+  end
+
+  test 'show page bookmark on lists' do
+    visit_with_auth '/current_user/bookmarks', 'kimura'
+    assert_text 'ブックマーク一覧'
+    assert_text @page.title
+  end
+
+  test 'show active button when bookmarked page' do
+    visit_with_auth "/pages/#{@page.id}", 'kimura'
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+  end
+
+  test 'show inactive button when not bookmarked page' do
+    visit_with_auth "/pages/#{@page.id}", 'komagata'
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-inactive'
+    assert_no_selector '#bookmark-button.is-active'
+  end
+
+  test 'bookmark page' do
+    visit_with_auth "/pages/#{@page.id}", 'komagata'
+    find('#bookmark-button').click
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+
+    visit '/current_user/bookmarks'
+    assert_text @page.title
+  end
+
+  test 'unbookmark page' do
+    visit_with_auth "/pages/#{@page.id}", 'kimura'
+    wait_for_vuejs
+    find('#bookmark-button').click
+    wait_for_vuejs
+    assert_selector '#bookmark-button.is-inactive'
+    assert_no_selector '#bookmark-button.is-active'
+
+    visit '/current_user/bookmarks'
+    assert_no_text @page.title
+  end
+end


### PR DESCRIPTION
## 概要

- refs: #3233 
- Docsにブックマーク機能を追加する

## やったこと

- DocsページにBookmarkボタンを追加
    - UIおよびBookmark処理自体は既存のものを使用。
    - 既にBookmark導入済み機能同様、ブックマーク一覧での参照、編集が可能。
- ブックマークボタンレンダリング部分の重複している条件式を削除
    - https://github.com/fjordllc/bootcamp/pull/3466/files#diff-99e5cb3d3e0c7e383b0ae71851491a608b0981d6b038a68a98ebe2bffe521fd2L10
    - なくても動作することを確認したので、本PRで削除しました。

## UIの変更

### 変更前

![image](https://user-images.githubusercontent.com/61409641/139190562-f5d37a32-0939-402c-b633-4518f5a4d095.png)

### 変更後

![image](https://user-images.githubusercontent.com/61409641/139190195-afa55172-9d89-4703-8e7a-54d4453f3924.png)

