### PR TITLE
就職相談のプラクティスを開始したとき運営のチャットに通知が飛ぶようにした

### DIFF
--- a/app/controllers/api/practices/learning_controller.rb
+++ b/app/controllers/api/practices/learning_controller.rb
@@ -29,7 +29,7 @@ class API::Practices::LearningController < API::BaseController
     status = learning.new_record? ? :created : :ok
 
     if learning.save
-      notify_to_chat_for_employment_counseling(learning) if status == :created && learning.practice_id == 163
+      notify_to_chat_for_employment_counseling(learning) if status == :created && learning.practice.title == '就職相談部屋を作る'
       head status
     else
       render json: learning.errors, status: :unprocessable_entity

--- a/app/controllers/api/practices/learning_controller.rb
+++ b/app/controllers/api/practices/learning_controller.rb
@@ -41,7 +41,7 @@ class API::Practices::LearningController < API::BaseController
   def notify_to_chat_for_employment_counseling(learning)
     ChatNotifier.message(
       "お知らせ：#{learning.user.name}がプラクティス「#{learning.practice.title}」に進みました。",
-      webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
+      webhook_url: ENV['DISCORD_EMPLOYMENT_COUNSELING_WEBHOOK_URL']
     )
   end
 end

--- a/app/controllers/api/practices/learning_controller.rb
+++ b/app/controllers/api/practices/learning_controller.rb
@@ -29,9 +29,19 @@ class API::Practices::LearningController < API::BaseController
     status = learning.new_record? ? :created : :ok
 
     if learning.save
+      notify_to_chat_for_employment_counseling(learning) if status == :created && learning.practice_id == 163
       head status
     else
       render json: learning.errors, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def notify_to_chat_for_employment_counseling(learning)
+    ChatNotifier.message(
+      "お知らせ：#{learning.user.name}がプラクティス「#{learning.practice.title}」に進みました。",
+      webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
+    )
   end
 end


### PR DESCRIPTION
ref: #3369 

就職相談のプラクティス→「就職相談部屋を作る」
開始したとき→プラクティスのステータスが「着手」または「完了になったとき」（初回のみ）

## 開発環境での通知の確かめ方
**開発環境ではチャットに通知が飛ぶかどうかの確認を以下のようにしました。**
1. Discordサーバーを追加し、通知テスト用のチャンネルを作成する(参考：https://bootcamp.fjord.jp/reports/41272)

2. `gem 'dotenv-rails'`をインストール
3.  アプリケーション直下に`.env`ファイルを作成。DiscordのウェブフックURLを環境変数に設定する
4. `app/controller/api/practices/learning_controller`の環境変数を2で設定した環境変数に変える
```ruby
def notify_to_chat_for_employment_counseling(learning)
  ChatNotifier.message(
    "お知らせ：#{learning.user.name}がプラクティス「#{learning.practice.title}」に進みました。",
    webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL'] # <= ここを変更する
  )
end
```
5. `app/controller/api/practices/learning_controller'のupdateアクションの中にあるpractice_idを任意のidに変える
```ruby
def update
# 省略
if learning.save
    # 開発環境にある任意のプラクティスIDに変更する
    notify_to_chat_for_employment_counseling(learning) if status == :created && learning.practice_id == 163   #<= 変更
    head status
  else
    render json: learning.errors, status: :unprocessable_entity
  end
end
``` 
5. `app/model/chat_norifier.rb`のクラスメソッド`message`に通知を飛ばす処理を挟む

```ruby
def self.message(
  message,
  username: 'ピヨルド',
  webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
  )

  if Rails.env.production?
    Discord::Notifier.message(message, username: username, url: webhook_url)
  else
    Discord::Notifier.message(message, username: username, url: webhook_url) # <= 通知を飛ばす処理を追加
    Rails.logger.info 'Message to Discord.'
  end
end
```
以下が実行結果です。（開発環境では「viをインストールする」で確かめました)
![image](https://user-images.githubusercontent.com/57053236/139280898-29185de8-4f1f-4870-942d-e19a2de040a1.png)