### PR TITLE
お知らせ一覧ページにユーザー名を表示する

### DIFF
--- a/app/javascript/announcement.vue
+++ b/app/javascript/announcement.vue
@@ -17,6 +17,10 @@
             a.thread-list-item-title__link(:href='announcement.url')
               | {{ announcement.title }}
       .thread-list-item__row
+        .thread-list-item-name
+          a.a-user-name(:href='announcement.user.url')
+            | {{ announcement.user.long_name }}
+      .thread-list-item__row
         .thread-list-item-meta__items
           .thread-list-item-meta__item
             .thread-list-item-meta(v-if='announcement.wip')


### PR DESCRIPTION
issue: #2805 

お知らせ一覧ページにユーザー名を表示しました。

## UIの変更
### 変更前
<img width="1440" alt="スクリーンショット 2021-11-02 20 30 42" src="https://user-images.githubusercontent.com/52844263/139838709-b5252fd7-695e-4a18-8be7-23c0c55ea3b5.png">

### 変更後
<img width="1440" alt="スクリーンショット 2021-11-02 20 30 16" src="https://user-images.githubusercontent.com/52844263/139838687-3227637f-c48e-4c07-b9d2-aec245bbb4ae.png">


## 参考にした実装
イベントページの実装を参考にしました
https://github.com/fjordllc/bootcamp/blob/76a2d6b9c66e03aa8a7f64a95c130d2d466763f6/app/javascript/event.vue#L17-L20