### PR TITLE
学習日が未来の日付では投稿できないように実装

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -31,6 +31,7 @@ class Report < ApplicationRecord
   validates :user, presence: true
   validates :reported_on, presence: true, uniqueness: { scope: :user }
   validates :emotion, presence: true
+  validate :reported_on_or_before_today
 
   after_save   ReportCallbacks.new
   after_create ReportCallbacks.new
@@ -99,5 +100,9 @@ class Report < ApplicationRecord
 
   def total_learning_time
     (learning_times.sum(&:diff) / 60).to_i
+  end
+
+  def reported_on_or_before_today
+    errors.add(:reported_on, 'は今日以前の日付にしてください') if reported_on > Date.current
   end
 end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -163,7 +163,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     within('#new_report') do
       fill_in('report[title]', with: 'test title 1')
       fill_in('report[description]', with: 'test 1')
-      fill_in('report[reported_on]', with: '2021-09-01')
+      fill_in('report[reported_on]', with: Date.current.prev_day)
       find('#sad').click
     end
     all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
@@ -176,7 +176,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     within('#new_report') do
       fill_in('report[title]', with: 'test title 2')
       fill_in('report[description]', with: 'test 2')
-      fill_in('report[reported_on]', with: '2021-09-03')
+      fill_in('report[reported_on]', with: Date.current)
       find('#sad').click
     end
     all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -546,11 +546,11 @@ class ReportsTest < ApplicationSystemTestCase
   test 'cannot post a new report with future date' do
     visit_with_auth '/reports/new', 'komagata'
     within('#new_report') do
-      fill_in('report[title]', with: '未来日では日報を作成できない')
+      fill_in('report[title]', with: '学習日が未来日では日報を作成できない')
       fill_in('report[description]', with: 'エラーになる')
-      fill_in('report[reported_on]', with: Time.current.next_day)
+      fill_in('report[reported_on]', with: Date.current.next_day)
     end
     click_button '提出'
-    assert_text '未来の日付では日報を保存できません。'
+    assert_text '学習日は今日以前の日付にしてください'
   end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -542,4 +542,15 @@ class ReportsTest < ApplicationSystemTestCase
       assert_text '2'
     end
   end
+
+  test 'cannot post a new report with future date' do
+    visit_with_auth '/reports/new', 'komagata'
+    within('#new_report') do
+      fill_in('report[title]', with: '未来日では日報を作成できない')
+      fill_in('report[description]', with: 'エラーになる')
+      fill_in('report[reported_on]', with: Time.current.next_day)
+    end
+    click_button '提出'
+    assert_text '未来の日付では日報を保存できません。'
+  end
 end


### PR DESCRIPTION
issue:[\#3440](https://github.com/fjordllc/bootcamp/issues/3440)

今までは学習日が未来の日付であっても投稿ができたが、今日以前の日付でないと投稿できないように変更を行った

## エラー時のイメージ
<img width="790" alt="スクリーンショット 2021-11-03 10 53 20" src="https://user-images.githubusercontent.com/78020405/140000039-6d564523-89c8-457f-928d-ac2815a5f695.png">