### PR TITLE
お知らせ個別ページにWatch機能を追加した

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -6,6 +6,7 @@ class Announcement < ApplicationRecord
   include Searchable
   include Reactionable
   include WithAvatar
+  include Watchable
 
   enum target: {
     all: 0,
@@ -13,6 +14,7 @@ class Announcement < ApplicationRecord
     job_seekers: 2
   }, _prefix: true
 
+  has_many :watches, as: :watchable, dependent: :destroy
   belongs_to :user
   alias sender user
 

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -5,6 +5,7 @@ class AnnouncementCallbacks
     return if announce.wip?
 
     after_first_publish(announce)
+    create_author_watch(announce)
   end
 
   def after_update(announce)
@@ -44,5 +45,9 @@ class AnnouncementCallbacks
 
   def delete_notification(announce)
     Notification.where(path: "/announcements/#{announce.id}").destroy_all
+  end
+
+  def create_author_watch(announce)
+    Watch.create!(user: announce.user, watchable: announce)
   end
 end

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -25,12 +25,14 @@ module Watchable
       "「#{self[:title]}」のイベント"
     when Page
       "「#{self[:title]}」のDocs"
+    when Announcement
+      " [#{self[:title]}]のお知らせ"
     end
   end
 
   def body
     case self
-    when Question, Event, Report
+    when Question, Event, Report, Announcement
       self[:description]
     else
       self[:body]

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -29,6 +29,8 @@
       .thread-header__row
         .thread-header-actions
           .thread-header-actions__start
+            .thread-header-actions__action
+              #js-watch-toggle(data-watchable-id="#{@announcement.id}", data-watchable-type='Announcement')
           .thread-header-actions__end
             .thread-header-actions__action
               = link_to new_announcement_path(id: announcement), class: 'a-button is-xs is-secondary is-block' do

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -188,4 +188,15 @@ class AnnouncementsTest < ApplicationSystemTestCase
     visit current_path
     assert_text "コメント（\n2\n）"
   end
+
+  test 'watching is automatically displayed when when admin create new announcement' do
+    visit_with_auth new_announcement_path, 'komagata'
+
+    fill_in 'announcement[title]', with: 'Watch中になるかのテスト'
+    fill_in 'announcement[description]', with: 'お知らせ作成時にWatch中になるかのテストです。'
+    click_button '作成'
+
+    assert_text 'お知らせを作成しました。'
+    assert_text 'Watch中'
+  end
 end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -189,7 +189,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text "コメント（\n2\n）"
   end
 
-  test 'watching is automatically displayed when when admin create new announcement' do
+  test 'watching is automatically displayed when admin create new announcement' do
     visit_with_auth new_announcement_path, 'komagata'
 
     fill_in 'announcement[title]', with: 'Watch中になるかのテスト'


### PR DESCRIPTION
ref: #3184 
お知らせ個別ページにWatch機能を追加しました。

<変更前>
![image](https://user-images.githubusercontent.com/57053236/140047790-1777d92f-4c98-4ceb-8bbe-e642235b10dd.png)


<変更後>
![image](https://user-images.githubusercontent.com/57053236/140046385-cfed95d6-e089-4f50-8651-002608ec0cf2.png)

Watchボタンを押してダッシュボードのWatch中ページに遷移すると
Watch中一覧に表示される。

https://user-images.githubusercontent.com/57053236/140047474-b7725fab-ca58-4641-8fe3-5adc09e652e2.mov

また、お知らせを作成したときに自動的にWatch中になるようにしました。
