### PR TITLE
非表示になっている古いコメントの数を表示するようにしました

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -8,7 +8,7 @@
         button#js-shortcut-post-comment.a-button.is-lg.is-text.is-block(
           @click='showComments'
         )
-          | 古いコメントを表示する
+          | コメント（{{ commentLimit }}）をもっと見る
   comment(
     v-for='(comment, index) in comments',
     :key='comment.id',

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -233,7 +233,7 @@ class CommentsTest < ApplicationSystemTestCase
     assert_selector 'span.mention', text: 'mentor'
   end
 
-  test 'clicking "show old comments" will display old comments' do
+  test 'clicking "see more comments" will display old comments' do
     visit_with_auth product_path(users(:hatsuno).products.first.id), 'komagata'
 
     assert_no_text '提出物のコメント1です。'

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -237,13 +237,14 @@ class CommentsTest < ApplicationSystemTestCase
     visit_with_auth product_path(users(:hatsuno).products.first.id), 'komagata'
 
     assert_no_text '提出物のコメント1です。'
-    assert_text '古いコメントを表示する'
+    old_comments = find('#js-shortcut-post-comment.a-button.is-lg.is-text.is-block').text
+    assert_text old_comments
     assert_text '提出物のコメント13です。'
 
-    click_button '古いコメントを表示する'
+    click_button old_comments
 
     assert_text '提出物のコメント1です。'
-    assert_no_text '古いコメントを表示する'
+    assert_no_text old_comments
     assert_text '提出物のコメント13です。'
   end
 end


### PR DESCRIPTION
- Issue: #3464 

### 変更前
- 古いコメントを表示する部分の文面が下のようになっているので、コメントの数を表示させて分かりやすくさせたい

![image](https://user-images.githubusercontent.com/74460623/140258251-2a8662cf-560c-4762-ae45-4e858bd69a43.png)

### 変更後
- コメントの数を表示させて、古いコメントが何件あるか分かるようにしました

![image](https://user-images.githubusercontent.com/74460623/140258352-09b9437a-e207-499c-98b6-5b2dbc58c3e4.png)

### 補足
本PRの確認をする際に、`rails db:seed`を実行することで変更後で実装した表示を確認するためのテストデータが作成されます。これについては元々あったテストデータを活用させていただきました。
詳細は、db/fixtures/comments.ymlファイルの96行目に記述されています。
```yml
# db/fixtures/comments.yml
..
<% (1..20).each do |i| %>
comment<%= i + 16 %>:
  user: komagata
  commentable: product10 (Product)
  description: <%= "提出物のコメント#{i}です。" %>
  created_at: <%= Time.current + i.minutes %>
  updated_at: <%= Time.current + i.minutes %>
<% end %
```

上記のコマンドを実行後に以下の提出物にアクセスすると表示の確認をすることができると思います。
http://localhost:3000/products/1033498648