### PR TITLE
プラクティス一覧画面にアクセス時のN+1を解消

### DIFF
--- a/app/controllers/api/courses/practices_controller.rb
+++ b/app/controllers/api/courses/practices_controller.rb
@@ -9,5 +9,6 @@ class API::Courses::PracticesController < API::BaseController
                          .includes(practices: [{ started_students: { avatar_attachment: :blob } }, :learning_minute_statistic])
                          .order(:position)
     @learnings = current_user.learnings
+    @completed_practices_hash = current_user.completed_practices_hash
   end
 end

--- a/app/controllers/api/courses/practices_controller.rb
+++ b/app/controllers/api/courses/practices_controller.rb
@@ -9,6 +9,6 @@ class API::Courses::PracticesController < API::BaseController
                          .includes(practices: [{ started_students: { avatar_attachment: :blob } }, :learning_minute_statistic])
                          .order(:position)
     @learnings = current_user.learnings
-    @completed_practices_hash = current_user.completed_practices_hash
+    @completed_practices_size_by_category = current_user.completed_practices_size_by_category
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -550,10 +550,6 @@ class User < ApplicationRecord
     end
   end
 
-  def completed_all_practices?(category)
-    category.practices.size == completed_practices_size(category)
-  end
-
   def practices
     course.practices.order('categories.position', 'practices.position')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -355,7 +355,7 @@ class User < ApplicationRecord
 
   def completed_practices_hash
     Practice
-      .select("count(DISTINCT practices.id) as completed_count, categories_practices.category_id")
+      .select('count(DISTINCT practices.id) as completed_count, categories_practices.category_id')
       .joins({ categories: :categories_practices }, :learnings)
       .where(
         learnings: {
@@ -363,7 +363,7 @@ class User < ApplicationRecord
           status: 'complete'
         }
       )
-      .group("categories_practices.category_id")
+      .group('categories_practices.category_id')
       .each_with_object({}) do |practice, hash|
         hash[practice.category_id] = practice.completed_count
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -353,9 +353,8 @@ class User < ApplicationRecord
     "#{completed_practices_include_progress.size}/#{practices_include_progress.size}"
   end
 
-  def completed_practices_hash
+  def completed_practices_size_by_category
     Practice
-      .select('count(DISTINCT practices.id) as completed_count, categories_practices.category_id')
       .joins({ categories: :categories_practices }, :learnings)
       .where(
         learnings: {
@@ -364,9 +363,7 @@ class User < ApplicationRecord
         }
       )
       .group('categories_practices.category_id')
-      .each_with_object({}) do |practice, hash|
-        hash[practice.category_id] = practice.completed_count
-      end
+      .count('DISTINCT practices.id')
   end
 
   def active?

--- a/app/views/api/courses/practices/index.json.jbuilder
+++ b/app/views/api/courses/practices/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.categories @categories do |category|
   json.partial! "api/courses/practices/categories", category: category
-  json.completed_all_practices category.practices.size == @completed_practices_hash[category.id]
+  json.completed_all_practices category.practices.size == @completed_practices_size_by_category[category.id]
   json.edit_admin_category_path edit_admin_category_path(category, course_id: @course.id)
 end
 

--- a/app/views/api/courses/practices/index.json.jbuilder
+++ b/app/views/api/courses/practices/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.categories @categories do |category|
   json.partial! "api/courses/practices/categories", category: category
-  json.completed_all_practices current_user.completed_all_practices?(category)
+  json.completed_all_practices category.practices.size == @completed_practices_hash[category.id]
   json.edit_admin_category_path edit_admin_category_path(category, course_id: @course.id)
 end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -365,16 +365,10 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, kimura.followees_list(watch: 'false').count
   end
 
-  test '#completed_practices_size' do
+  test '#completed_practices_hash' do
     kimura = users(:kimura)
     category2 = categories(:category2)
-    assert_equal 1, kimura.completed_practices_size(category2)
-  end
-
-  test '#completed_all_practices?' do
-    hajime = users(:hajime)
-    category11 = categories(:category11)
-    assert hajime.completed_all_practices?(category11)
+    assert_equal 1, kimura.completed_practices_hash[category2.id]
   end
 
   test "don't unfollow user when other user unfollow user" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -365,10 +365,10 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, kimura.followees_list(watch: 'false').count
   end
 
-  test '#completed_practices_hash' do
+  test '#completed_practices_size_by_category' do
     kimura = users(:kimura)
     category2 = categories(:category2)
-    assert_equal 1, kimura.completed_practices_hash[category2.id]
+    assert_equal 1, kimura.completed_practices_size_by_category[category2.id]
   end
 
   test "don't unfollow user when other user unfollow user" do


### PR DESCRIPTION
## Description

プラクティス一覧画面に遷移時、practicesテーブルにカテゴリーの数分クエリが発行されていたので、一回のクエリで済むように修正しました。
practicesテーブルからstatusがcompleteのものをカウントし、category_idでグルーピングするように変更しています。
