### PR TITLE
ユーザープロフィール画面遷移時のN+1を解消

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,10 +32,10 @@ class UsersController < ApplicationController
 
   def show
     @completed_learnings = @user
-                            .learnings
-                            .includes(:practice)
-                            .where(status: 3)
-                            .order(updated_at: :desc)
+                           .learnings
+                           .includes(:practice)
+                           .where(status: 3)
+                           .order(updated_at: :desc)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    @completed_learnings = @user.learnings.where(status: 3).order(updated_at: :desc)
+    @completed_learnings = @user
+                            .learnings
+                            .includes(:practice)
+                            .where(status: 3)
+                            .order(updated_at: :desc)
   end
 
   def new


### PR DESCRIPTION
## Description

ユーザープロフィール画面遷移時にpractcesテーブルへN+1が発生していたのでincludesで対処しました。

### N+1が発生していた箇所

下記の`learning.practice`でlearningの数分practicesテーブルへクエリが発行されていました。

https://github.com/fjordllc/bootcamp/blob/58f1fd6cc834856bb87104d9ed2f774ff01e7b90/app/views/users/practices/_completed_practices_list.html.slim#L3-L6