### PR TITLE
イベントの申込み期限が過ぎていてもキャンセルできるようにしました

### DIFF
--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -1,4 +1,4 @@
-- if event.opening?
+- if event.opening? || event.closing?
   - if current_user.participating?(event)
     .event-main-actions.is-participationed
       .event-main-actions__description
@@ -8,7 +8,7 @@
         li.event-main-actions__item
           = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
             | 参加を取り消す
-  - else
+  - elsif event.opening?
     .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
       .event-main-actions__description
         - if event.capacity > event.participants.count

--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -1,29 +1,28 @@
-- if event.opening? || event.closing?
-  - if current_user.participating?(event)
-    .event-main-actions.is-participationed
-      .event-main-actions__description
+- if current_user.participating?(event)
+  .event-main-actions.is-participationed
+    .event-main-actions__description
+      p
+        | 参加登録しています。
+    ul.event-main-actions__items
+      li.event-main-actions__item
+        = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+          | 参加を取り消す
+- elsif event.opening?
+  .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
+    .event-main-actions__description
+      - if event.capacity > event.participants.count
+        // TODO helprtにしてわかりやすくしたい↑
         p
-          | 参加登録しています。
-      ul.event-main-actions__items
-        li.event-main-actions__item
-          = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
-            | 参加を取り消す
-  - elsif event.opening?
-    .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
-      .event-main-actions__description
+          | あと#{event.capacity - event.participants.count}名が参加できます。
+      - else
+        p
+          | 参加者が定員を超えているので補欠での登録になります。
+    ul.event-main-actions__items
+      li.event-main-actions__item
         - if event.capacity > event.participants.count
           // TODO helprtにしてわかりやすくしたい↑
-          p
-            | あと#{event.capacity - event.participants.count}名が参加できます。
+          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-lg is-block' do
+            | 参加申込
         - else
-          p
-            | 参加者が定員を超えているので補欠での登録になります。
-      ul.event-main-actions__items
-        li.event-main-actions__item
-          - if event.capacity > event.participants.count
-            // TODO helprtにしてわかりやすくしたい↑
-            = link_to event_participations_path(event_id: event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-lg is-block' do
-              | 参加申込
-          - else
-            = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠としてイベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-lg is-block' do
-              | 補欠登録
+          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠としてイベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-lg is-block' do
+            | 補欠登録

--- a/test/fixtures/participations.yml
+++ b/test/fixtures/participations.yml
@@ -25,3 +25,8 @@ participation5:
   user: sotugyou
   event: event2
   enable: true
+
+participation6:
+  user: kimura
+  event: event5
+  enable: true

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -181,6 +181,18 @@ class EventsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'user can cancel event even if deadline has passed' do
+    event = events(:event5)
+    visit_with_auth event_path(event), 'kimura'
+    accept_confirm do
+      click_link '参加を取り消す'
+    end
+    assert_difference 'event.users.count', -1 do
+      assert_text '参加を取り消しました。'
+    end
+    assert_no_link '参加申込'
+  end
+
   test 'autolink location when url is included' do
     url = 'https://bootcamp.fjord.jp/'
     visit_with_auth new_event_path, 'komagata'


### PR DESCRIPTION
- Issue: #3483 

### 変更前
- イベントの募集期間が終了してしまうとキャンセルができないため、直前でキャンセルしたいケースがあったときにキャンセルができない状態になっている

![image](https://user-images.githubusercontent.com/74460623/140641716-a397fc03-02ca-4ee0-ac3a-90558564a47c.png)

### 変更後
- イベントの募集期間が終了してもキャンセルできるようにしました
- 募集期間は過ぎているので、このキャンセルをすると再度参加登録することはできません

![image](https://user-images.githubusercontent.com/74460623/140641730-74664ab7-627f-4356-af67-d0012708d483.png)