### PR TITLE
Q&Aで質問者にメンション付き回答を送ると、「メンション」と「Watch」両方の通知（＋メール）が来ないように修正した

### DIFF
--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -2,8 +2,7 @@
 
 class AnswerCallbacks
   def after_create(answer)
-    notify_answer(answer) if answer.sender != answer.receiver
-
+    notify_answer(answer)
     create_watch(answer)
     notify_to_watching_user(answer)
   end
@@ -21,6 +20,15 @@ class AnswerCallbacks
   private
 
   def notify_answer(answer)
+    question = answer.question
+    questioner = question.user_id
+    watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
+    mention_user_ids = answer.new_mention_users.ids
+
+    return unless answer.sender != answer.receiver
+    return if mention_user_ids.include?(questioner)
+    return if watcher_ids.include?(questioner)
+
     NotificationFacade.came_answer(answer)
   end
 

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -21,13 +21,12 @@ class AnswerCallbacks
 
   def notify_answer(answer)
     question = answer.question
-    questioner = question.user_id
     watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
     mention_user_ids = answer.new_mention_users.ids
 
     return unless answer.sender != answer.receiver
-    return if mention_user_ids.include?(questioner)
-    return if watcher_ids.include?(questioner)
+    return if mention_user_ids.include?(answer.receiver.id)
+    return if watcher_ids.include?(answer.receiver.id)
 
     NotificationFacade.came_answer(answer)
   end

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -20,15 +20,12 @@ class AnswerCallbacks
   private
 
   def notify_answer(answer)
+    return if answer.sender == answer.receiver
+
     question = answer.question
     watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
     mention_user_ids = answer.new_mention_users.ids
-
-    return unless answer.sender != answer.receiver
-    return if mention_user_ids.include?(answer.receiver.id)
-    return if watcher_ids.include?(answer.receiver.id)
-
-    NotificationFacade.came_answer(answer)
+    NotificationFacade.came_answer(answer) if watcher_ids.concat(mention_user_ids).exclude?(answer.receiver.id)
   end
 
   def notify_to_watching_user(answer)


### PR DESCRIPTION
issue:[\#2696](https://github.com/fjordllc/bootcamp/issues/2696)

Q&Aで質問者にメンション付き回答を送ると、「メンション」と「Watch」両方の通知（＋メール）が来ないようにした。

通知及びメールを１回答に１つのみ届くようにした。

## 回答者の通知状況
質問者:kimura
回答者:hatuno
質問タイトル:通知テスト
### 質問者が質問をwatchしている

| メンションの宛先 | メンション | メール |
| --- | --- | --- |
| なし | kimuraさんの【 「通知テスト」のQ&A 】にhatsunoさんがコメントしました。 | 「通知テスト」のQ&Aにhatsunoさんがコメントしました。|
| 質問者あて | hatsunoさんからメンションがきました。 | hatsunoさんからメンションがありました |
| 他ユーザーあて | kimuraさんの【 「通知テスト」のQ&A 】にhatsunoさんがコメントしました。 | 「通知テスト」のQ&Aにhatsunoさんがコメントしました。 |

### 質問者が質問をwatchしていない

| メンションの宛先 | メンション | メール |
| --- | --- | --- |
| なし | hatsunoさんから回答がありました。 | 質問「通知テスト」にhatsunoさんが回答しました。 |
| 質問者あて | hatsunoさんからメンションがきました。 | hatsunoさんからメンションがありました |
| 他ユーザーあて | hatsunoさんから回答がありました。 | 質問「通知テスト」にhatsunoさんが回答しました。 |
