### PR TITLE
開発環境をDockerで動かす方法を追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,35 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/v0.205.1/containers/ruby/.devcontainer/base.Dockerfile
+
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+ARG VARIANT=2.7-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="lts/*"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# Install OS packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends imagemagick pngcrush optipng gsfonts
+
+# Install bundler
+RUN gem install --no-document bundler -v 2.2.27
+
+# Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
+# The value is a comma-separated list of allowed domains
+ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev"
+
+# Add Chrome
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
+      && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
+      && apt update \
+      && apt install -y google-chrome-stable
+
+# Add chromedriver
+RUN CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` \
+    && curl -sO https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
+    && unzip chromedriver_linux64.zip \
+    && mv chromedriver /usr/bin/chromedriver
+
+# Set TZ
+RUN cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+bin/setup
+bin/rails db:test:prepare

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "App",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+
+  "extensions": [
+    "rebornix.Ruby"
+  ],
+
+  "postCreateCommand": ".devcontainer/boot.sh",
+
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: "postgres://postgres:postgres@db:5432"
+      EDITOR: "code"
+      RAILS_MASTER_KEY:
+
+  db:
+    image: postgres:12-alpine
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+volumes:
+  postgres-data:

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,9 @@
 /db/*.sqlite3
 
 # Ignore all logfiles and tempfiles.
-/log/*.log
+/log/*
 /tmp
+!/log/.keep
 
 vendor/bundle/
 
@@ -43,3 +44,4 @@ storage/
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.envrc

--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ $ prettier app/javascript/**/*.{js,vue} --write
 - [nodeのバージョン切り替え](https://github.com/fjordllc/bootcamp/wiki/node%E3%81%AE%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E5%88%87%E3%82%8A%E6%9B%BF%E3%81%88)
 
 - [Rake Taskの実装方法](https://github.com/fjordllc/bootcamp/wiki/Rake-Task%E3%81%AE%E5%AE%9F%E8%A3%85%E6%96%B9%E6%B3%95)
+
+- [Develop環境をDockerで動かす方法](doc/development_on_docker.md)

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  url: <%= ENV['DATABASE_URL'] %>
 
 development:
   <<: *default

--- a/doc/development_on_docker.md
+++ b/doc/development_on_docker.md
@@ -1,0 +1,83 @@
+# Develop環境をDockerで動かす方法
+
+Dockerと[direnv](https://github.com/direnv/direnv)が必要なので、事前にインストールを済ませてください。
+
+## 構築手順
+
+`.envrc` に以下の行を追加します。
+
+```bash
+export COMPOSE_PROJECT_NAME=bootcamp
+export COMPOSE_FILE=.devcontainer/docker-compose.yml:docker-compose.darwin.yml
+```
+
+`direnv allow` を実行して`docker-compose` コマンドでコンテナを起動します。
+
+```bash
+$ direnv allow
+direnv: loading ~/ghq/github.com/fjordllc/bootcamp/.envrc
+direnv: export +COMPOSE_FILE +COMPOSE_PROJECT_NAME
+
+$ docker-compose up -d
+Creating network "bootcamp_default" with the default driver
+Creating volume "bootcamp_postgres-data" with default driver
+Creating volume "bootcamp_bundle" with default driver
+Creating volume "bootcamp_node_modules" with default driver
+Creating volume "bootcamp_rails_cache" with default driver
+Creating volume "bootcamp_packs" with default driver
+Creating volume "bootcamp_packs_test" with default driver
+Creating bootcamp_db_1 ... done
+Creating bootcamp_app_1 ... done
+```
+
+初期設定を行うため、コンテナ内で `bin/setup` と `bin/rails db:test:prepare` を実行します。
+
+```bash
+$ docker-compose exec app bash
+
+root ➜ /workspace (main) $ bin/setup
+
+root ➜ /workspace (main) $ bin/rails db:test:prepare
+```
+
+## サーバの起動
+
+コンテナ内で `bin/rails s` を実行してください。
+
+```bash
+$ docker-compose exec app bash
+
+root ➜ /workspace (main) $ bin/rails s
+=> Booting Puma
+=> Rails 6.1.4.1 application starting in development
+=> Run `bin/rails server --help` for more startup options
+Puma starting in single mode...
+* Puma version: 5.5.1 (ruby 2.7.4-p191) ("Zawgyi")
+*  Min threads: 5
+*  Max threads: 5
+*  Environment: development
+*          PID: 3496
+* Listening on http://0.0.0.0:3000
+Use Ctrl-C to stop
+```
+
+ブラウザで http://localhost:3000/ を表示できます。
+
+## テストの実行
+
+コンテナ内で `bin/rails test` を実行してください。
+
+```bash
+$ docker-compose exec app bash
+
+root ➜ /workspace (main) $ bin/rails test
+Running via Spring preloader in process 3527
+Run options: --seed 54803
+
+# Running:
+
+...................................................................................................................................................................................................
+
+Finished in 21.972606s, 8.8747 runs/s, 36.1814 assertions/s.
+195 runs, 795 assertions, 0 failures, 0 errors, 0 skips
+```

--- a/docker-compose.darwin.yml
+++ b/docker-compose.darwin.yml
@@ -1,0 +1,28 @@
+version: "3"
+services:
+  app:
+    image: bootcamp:1.0.0
+    volumes:
+      - bundle:/workspace/vendor/bundle
+      - node_modules:/workspace/node_modules
+      - rails_cache:/workspace/tmp/cache
+      - packs:/workspace/public/packs
+      - packs_test:/workspace/public/packs-test
+    environment:
+      EDITOR: "vi"
+      BUNDLE_PATH: "vendor/bundle"
+      BOOTSNAP_CACHE_DIR: "vendor/bundle"
+      HISTFILE: "log/.bash_history"
+      BINDING: "0.0.0.0"
+    tmpfs:
+      - /tmp
+    expose: ["3000"]
+    ports: ["3000:3000"]
+    working_dir: /workspace
+
+volumes:
+  bundle:
+  node_modules:
+  rails_cache:
+  packs:
+  packs_test:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -21,7 +21,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   if ENV['HEADED']
     driven_by :selenium, using: :chrome
   else
-    driven_by :selenium, using: :headless_chrome
+    driven_by(:selenium, using: :headless_chrome) do |driver_option|
+      driver_option.add_argument('--no-sandbox')
+    end
   end
 
   def wait_for_vuejs


### PR DESCRIPTION
Dockerで開発環境を構築できるようになると、すばやく開発環境が構築できるようになります。
フィヨルドの学習内容にDockerは含まれていないため、この変更は **メンター・アドバイザー向け** です。

## 変更内容

- Codespacesで動かすための設定を追加
    - Orgで使う場合の費用は [About billing for Codespaces](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-codespaces) です
    - Orgでデフォルトは無効化されているため、費用は発生しません
    - fork すれば個人アカウントでCodespacesの利用は可能（ただし、まだbeta）
- 開発環境をDockerで動かす方法を追加
    - 使い方は `doc/development_on_docker.md` を参照してください

## レビューして欲しい点

- Macの開発環境に影響がないか？
- Dockerで開発環境が問題なく動くか？