### PR TITLE
カテゴリ別の通知既読ボタンを追加

### DIFF
--- a/app/assets/stylesheets/blocks/shared/_pill-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_pill-nav.sass
@@ -1,27 +1,27 @@
-.tab-nav
-  border-bottom: solid 1px $background-shade
+.pill-nav
+  border-bottom: none
   &:not(:last-child)
     margin-bottom: 1.5rem
 
-.tab-nav__items
+.pill-nav__items
   display: flex
   +padding(vertical, .875rem)
   overflow-x: auto
   overflow-y: hidden
+  justify-content: center
+  padding-top: 1.5rem
+  padding-bottom: 0
 
-.tab-nav__item
-  margin-right: .375rem
-  +media-breakpoint-down(sm)
-    +margin(horizontal, .25rem)
-  &:last-child
-    +media-breakpoint-up(md)
-      margin-right: 0
+.pill-nav__item
+  &:first-child .pill-nav__item-link
+    +border-radius(left, 10em)
+  &:last-child .pill-nav__item-link
+    +border-radius(right, 10em)
 
-.tab-nav__item-link
+.pill-nav__item-link
   +block-link
   +text-block(.75rem 2.3, $semi-muted-text center nowrap)
   background-color: $background-shade
-  border-radius: 20rem
   width: 7rem
   transition: all.2s ease-out
   &:hover

--- a/app/controllers/notifications/categorymarks_controller.rb
+++ b/app/controllers/notifications/categorymarks_controller.rb
@@ -4,7 +4,7 @@ class Notifications::CategorymarksController < ApplicationController
   def create
     target = params[:target].presence&.to_sym
     notifications = current_user.notifications.by_target(target)
-    notifications.update(read: true, updated_at: Time.current)
+    notifications.update(read: true)
     redirect_to notifications_path(target: target), notice: '既読にしました'
   end
 end

--- a/app/controllers/notifications/categorymarks_controller.rb
+++ b/app/controllers/notifications/categorymarks_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Notifications::CategorymarksController < ApplicationController
+  def create
+    target = params[:target].presence&.to_sym
+    @notifications = current_user.notifications.by_target(target)
+    @notifications.update(read: true, updated_at: Time.current)
+    redirect_to notifications_path(target: target), notice: '既読にしました'
+  end
+end

--- a/app/controllers/notifications/categorymarks_controller.rb
+++ b/app/controllers/notifications/categorymarks_controller.rb
@@ -3,8 +3,8 @@
 class Notifications::CategorymarksController < ApplicationController
   def create
     target = params[:target].presence&.to_sym
-    @notifications = current_user.notifications.by_target(target)
-    @notifications.update(read: true, updated_at: Time.current)
+    notifications = current_user.notifications.by_target(target)
+    notifications.update(read: true, updated_at: Time.current)
     redirect_to notifications_path(target: target), notice: '既読にしました'
   end
 end

--- a/app/controllers/notifications/categorymarks_controller.rb
+++ b/app/controllers/notifications/categorymarks_controller.rb
@@ -3,7 +3,7 @@
 class Notifications::CategorymarksController < ApplicationController
   def create
     target = params[:target].presence&.to_sym
-    notifications = current_user.notifications.by_target(target)
+    notifications = current_user.notifications.by_target(target).unreads
     notifications.update(read: true)
     redirect_to notifications_path(target: target), notice: '既読にしました'
   end

--- a/app/controllers/notifications/read_by_category_controller.rb
+++ b/app/controllers/notifications/read_by_category_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Notifications::CategorymarksController < ApplicationController
+class Notifications::ReadByCategoryController < ApplicationController
   def create
     target = params[:target].presence&.to_sym
     notifications = current_user.notifications.by_target(target).unreads

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -22,7 +22,7 @@ main.page-main
             h1.page-main-header__title
               = t("notification.#{@target}")
           .page-main-header__end
-            = link_to "#{t("notification.#{@target}")}の通知を既読にする", categorymarks_path(target: @target), method: :post,
+            = link_to "#{t("notification.#{@target}")}の通知を既読にする", read_by_category_path(target: @target), method: :post,
                     class: "a-button is-sm is-warning is-block #{current_user.notifications.by_target(@target.presence&.to_sym).unreads.empty? ? 'is-disabled' : ''}"
 
 .page-tools

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -13,17 +13,26 @@ header.page-header
 
 = render 'notifications/tabs'
 
-.page-tools
-  nav.tab-nav.is-centered
-    .container.is-padding-horizontal-0-sm-down
-      ul.tab-nav__items
-        li.tab-nav__item
-          = link_to '未読', notifications_path(status: 'unread', target: @target), class: "tab-nav__item-link #{params[:status] == 'unread' ? 'is-active' : ''}"
-        li.tab-nav__item
-          = link_to '全て', notifications_path(target: @target), class: "tab-nav__item-link #{params[:status] == 'unread' ? '' : 'is-active'}"
-
-.page-body
+main.page-main
   - if @target
-    = link_to "#{t("notification.#{@target}")}の通知を既読にする", categorymarks_path(target: @target), method: :post,
-            class: "a-button is-md is-warning is-block #{current_user.notifications.by_target(@target.presence&.to_sym).unreads.empty? ? 'is-disabled' : ''}"
-  #js-notifications(data-is-mentor="#{mentor_login?}" data-target="#{@target}")
+    header.page-main-header
+      .container
+        .page-main-header__inner
+          .page-main-header__start
+            h1.page-main-header__title
+              = t("notification.#{@target}")
+          .page-main-header__end
+            = link_to "#{t("notification.#{@target}")}の通知を既読にする", categorymarks_path(target: @target), method: :post,
+                    class: "a-button is-sm is-warning is-block #{current_user.notifications.by_target(@target.presence&.to_sym).unreads.empty? ? 'is-disabled' : ''}"
+
+.page-tools
+  nav.pill-nav
+    .container.is-padding-horizontal-0-sm-down
+      ul.pill-nav__items
+        li.pill-nav__item
+          = link_to '未読', notifications_path(status: 'unread', target: @target), class: "pill-nav__item-link #{params[:status] == 'unread' ? 'is-active' : ''}"
+        li.pill-nav__item
+          = link_to '全て', notifications_path(target: @target), class: "pill-nav__item-link #{params[:status] == 'unread' ? '' : 'is-active'}"
+
+  .page-body
+    #js-notifications(data-is-mentor="#{mentor_login?}" data-target="#{@target}")

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -23,4 +23,6 @@ header.page-header
           = link_to '全て', notifications_path(target: @target), class: "tab-nav__item-link #{params[:status] == 'unread' ? '' : 'is-active'}"
 
 .page-body
+  - if @target
+    = link_to "#{t("notification.#{@target}")}の通知を既読にする", categorymarks_path(target: @target), method: :post, class: "a-button is-md is-warning is-block #{current_user.notifications.by_target(@target.presence&.to_sym).unreads.empty? ? 'is-disabled' : ''}"
   #js-notifications(data-is-mentor="#{mentor_login?}" data-target="#{@target}")

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -24,5 +24,6 @@ header.page-header
 
 .page-body
   - if @target
-    = link_to "#{t("notification.#{@target}")}の通知を既読にする", categorymarks_path(target: @target), method: :post, class: "a-button is-md is-warning is-block #{current_user.notifications.by_target(@target.presence&.to_sym).unreads.empty? ? 'is-disabled' : ''}"
+    = link_to "#{t("notification.#{@target}")}の通知を既読にする", categorymarks_path(target: @target), method: :post,
+            class: "a-button is-md is-warning is-block #{current_user.notifications.by_target(@target.presence&.to_sym).unreads.empty? ? 'is-disabled' : ''}"
   #js-notifications(data-is-mentor="#{mentor_login?}" data-target="#{@target}")

--- a/app/views/products/self_assigned/_nav.html.slim
+++ b/app/views/products/self_assigned/_nav.html.slim
@@ -1,7 +1,7 @@
-nav.tab-nav.is-centered
+nav.pill-nav
   .container.is-padding-horizontal-0-sm-down
-    ul.tab-nav__items
+    ul.pill-nav__items
       - targets = %w[self_assigned_no_replied self_assigned_all]
       - targets.each do |target|
-        li.tab-nav__item
-          = link_to t("target.#{target}"), products_self_assigned_index_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'
+        li.pill-nav__item
+          = link_to t("target.#{target}"), products_self_assigned_index_path(target: target), class: (@target == target ? ['is-active'] : []) << 'pill-nav__item-link'

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -1,4 +1,4 @@
-- title 'レビューを担当する提出物'
+- title '提出物'
 
 header.page-header
   .container

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
   resources :notifications, only: %i(index show) do
     collection do
       resources :allmarks, only: %i(create), controller: "notifications/allmarks"
-      resources :categorymarks, only: %i(create), controller: "notifications/categorymarks"
+      resource :read_by_category, only: %i(create), controller: "notifications/read_by_category"
     end
   end
   resources :works, except: %i(index)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
   resources :notifications, only: %i(index show) do
     collection do
       resources :allmarks, only: %i(create), controller: "notifications/allmarks"
+      resources :categorymarks, only: %i(create), controller: "notifications/categorymarks"
     end
   end
   resources :works, except: %i(index)

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -273,4 +273,32 @@ class NotificationsTest < ApplicationSystemTestCase
     assert_text '未読のお知らせの通知'
     assert_no_text '既読のお知らせの通知'
   end
+
+  test 'click on the category marks button' do
+    Notification.create(message: 'お知らせのテスト通知',
+                        kind: 'announced',
+                        path: '/announcements/1',
+                        user: users(:komagata),
+                        sender: users(:machida))
+    Notification.create(message: 'コメントのテスト通知',
+                        kind: 'came_comment',
+                        path: '/reports/1',
+                        user: users(:komagata),
+                        sender: users(:machida))
+    visit_with_auth '/notifications?status=unread&target=announcement', 'komagata'
+    wait_for_vuejs
+    click_link 'お知らせの通知を既読にする'
+
+    visit_with_auth '/notifications?status=unread&target=announcement', 'komagata'
+    wait_for_vuejs
+    assert_no_text 'お知らせのテスト通知'
+
+    visit_with_auth '/notifications?status=unread&target=comment', 'komagata'
+    wait_for_vuejs
+    assert_text 'コメントのテスト通知'
+
+    visit_with_auth '/notifications?status=unread', 'komagata'
+    wait_for_vuejs
+    assert_text 'コメントのテスト通知'
+  end
 end

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -69,7 +69,7 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     product.checker_id = checker.id
     product.save
     visit_with_auth '/products/self_assigned?target=self_assigned_all', 'komagata'
-    assert_text 'レビューを担当する提出物はありません'
+    assert_text '提出物はありません'
   end
 
   test 'display no replied products if click on self-assigned-tab' do


### PR DESCRIPTION
## 目的

- refs: #3247 

## やったこと

- 「全て」を除く、通知ページの各タブに「〇〇の通知を既読にする」ボタンを実装

## UIの変更

**※デザイン反映後修正**

### 変更前

![image](https://user-images.githubusercontent.com/61409641/140740184-c206837b-a1ff-467b-9a8a-d634fb6f75fd.png)

### 変更後

![image](https://user-images.githubusercontent.com/61409641/140740064-92da35bf-0b43-46c6-a7b9-e8475ddc1a42.png)