### PR TITLE
Daimyoユーザー以外の提出物、日報はアドバイザーが確認を出来ないようにした

### DIFF
--- a/app/assets/stylesheets/blocks/event/_event-meta.sass
+++ b/app/assets/stylesheets/blocks/event/_event-meta.sass
@@ -39,6 +39,9 @@
   +media-breakpoint-up(md)
     display: flex
     align-items: center
+  a
+    +default-link
+    +hover-link-reversal
 
 .event-meta__item-value-main
   display: block

--- a/app/assets/stylesheets/variables/_colors.sass
+++ b/app/assets/stylesheets/variables/_colors.sass
@@ -7,7 +7,6 @@ $background-tint: #eceeef
 $background-more-tint: #f7f7f9
 $hover-background: $background-more-tint
 
-
 $default-text: #403f47
 $reversal-text: white
 $muted-text: #9da4a7
@@ -40,12 +39,12 @@ $welcome-pink: #ef6085
 $stamp-color: #ed5151
 $badge-color: #e54724
 
-$primary: #229bcc
+$primary: #3383d6
 $secondary: $base
 $success: #54a739
 $info: #4cad7c
 $warning: #fabd17
-$danger: #f11c52
+$danger: #f54667
 $disabled: #c7c6c6
 
 $danger-shade: #fff1f4
@@ -57,9 +56,9 @@ $input-border: #c1c5b9
 
 =default-link
   transition: color .2s ease-in
-  color: #4e3fad
+  color: #2e2088
   &:link
-    color: #4e3fad
+    color: #2e2088
   &:visited
     color: #6f78b7
   &:hover

--- a/app/views/home/_job_seeking_users.html.slim
+++ b/app/views/home/_job_seeking_users.html.slim
@@ -12,7 +12,7 @@
         header.thread-list-item-title
           h2.thread-list-item-title__title(itemprop='name')
             = link_to user, itemprop: 'url', class: 'thread-list-item-title__link' do
-              | #{user.name}（#{user.login_name}）
+              | #{user.login_name} （#{user.name}）
 
         .thread-list-item-meta
           .thread-list-item-meta__items

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -128,7 +128,7 @@ header.page-header
                       = link_to @product, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__delete' do
                         | 削除する
 
-            - if staff_login?
+            - if (@product.user.daimyo? && staff_login?) || admin_or_mentor_login?
               #js-check(data-checkable-id="#{@product.id}"
                         data-checkable-type='Product'
                         data-checkable-label="#{Product.model_name.human}"

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -106,7 +106,7 @@ header.page-header
                           span#delete
                             | 削除する
 
-            - if staff_login?
+            - if (@report.user.daimyo? && staff_login?) || admin_or_mentor_login?
               #js-check(data-checkable-id="#{@report.id}" data-checkable-type='Report' data-checkable-label="#{Report.model_name.human}")
 
           .thread-prev-next

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -17,6 +17,7 @@
                     .thread-list-item-title
                       h2.thread-list-item-title__title(itemprop='name')
                         = link_to user, itemprop: 'url', class: 'thread-list-item-title__link' do
+                          = user.id
                           = user.name
                   .thread-list-item__row
                     .thread-list-item-meta

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -17,8 +17,7 @@
                     .thread-list-item-title
                       h2.thread-list-item-title__title(itemprop='name')
                         = link_to user, itemprop: 'url', class: 'thread-list-item-title__link' do
-                          = user.id
-                          = user.name
+                          | #{user.login_name} （#{user.name}）
                   .thread-list-item__row
                     .thread-list-item-meta
                       time.a-meta

--- a/test/system/api/check/products_test.rb
+++ b/test/system/api/check/products_test.rb
@@ -15,13 +15,6 @@ class Check::ProductsTest < ApplicationSystemTestCase
     assert has_button? '提出物の確認を取り消す'
   end
 
-  test "success adviser's product checking" do
-    visit_with_auth "/products/#{products(:product1).id}", 'advijirou'
-    click_button '提出物を確認'
-    assert_text '確認済'
-    assert has_button? '提出物の確認を取り消す'
-  end
-
   test 'when product checked learning status to complete' do
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
     click_button '提出物を確認'

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -22,19 +22,6 @@ class Check::ReportsTest < ApplicationSystemTestCase
     assert_text '確認済'
   end
 
-  test "success adviser's report checking" do
-    visit_with_auth '/', 'advijirou'
-    assert_equal '/', current_path
-    click_link '日報'
-    assert_text '作業週2日目'
-    click_link '作業週2日目'
-    assert has_button? '日報を確認'
-    click_button '日報を確認'
-    assert has_button? '日報の確認を取り消す'
-    visit reports_path
-    assert_text '確認済'
-  end
-
   test 'success report checking cancel' do
     visit_with_auth "/reports/#{reports(:report2).id}", 'komagata'
     click_button '日報を確認'


### PR DESCRIPTION
## 現状

アドバイザーがすべての 提出物、日報 を確認できてしまう。

## 修正

Daimyoユーザー以外の提出物、日報 以外、アドバイザーは確認できないようにした。