### PR TITLE
提出物一覧のローディングをプレースホルダに変更

### DIFF
--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .page-body
-  .container(v-if='!loaded')
-    | ロード中
+  .container.is-md(v-if='!loaded')
+    loadingListPlaceholder
   .container(v-else-if='products.length === 0')
     .o-empty-message
       .o-empty-message__icon
@@ -34,12 +34,14 @@
 <script>
 import Product from './product.vue'
 import unconfirmedLinksOpenButton from './unconfirmed_links_open_button.vue'
+import LoadingListPlaceholder from './loading-list-placeholder.vue'
 import Pager from './pager.vue'
 
 export default {
   components: {
     product: Product,
     'unconfirmed-links-open-button': unconfirmedLinksOpenButton,
+    loadingListPlaceholder: LoadingListPlaceholder,
     pager: Pager
   },
   props: {


### PR DESCRIPTION
## 目的

- refs: #2817 
- 提出物一覧のローディングを「ロード中」からプレースホルダに変更する

## UIの変更

https://user-images.githubusercontent.com/61409641/140908167-bfc7506e-479d-4617-ac03-0f28ebaec39e.mov