### PR TITLE
mentor_last_comment_at を mentor_last_commented_at に変更

### DIFF
--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -70,25 +70,25 @@
                     )
 
             .thread-list-item-meta__item(
-              v-if='product.self_last_comment_at_date_time && product.mentor_last_comment_at_date_time'
+              v-if='product.self_last_commented_at_date_time && product.mentor_last_comment_at_date_time'
             )
               time.a-meta(
-                v-if='product.self_last_comment_at_date_time > product.mentor_last_comment_at_date_time'
+                v-if='product.self_last_commented_at_date_time > product.mentor_last_comment_at_date_time'
               )
-                | 〜 {{ product.self_last_comment_at }}（
+                | 〜 {{ product.self_last_commented_at }}（
                 strong
                   | 提出者
                 | ）
               time.a-meta(
-                v-if='product.self_last_comment_at_date_time < product.mentor_last_comment_at_date_time'
+                v-if='product.self_last_commented_at_date_time < product.mentor_last_comment_at_date_time'
               )
                 | 〜 {{ product.mentor_last_comment_at }}（メンター）
 
             .thread-list-item-meta__item(
-              v-else-if='product.self_last_comment_at_date_time || product.mentor_last_comment_at_date_time'
+              v-else-if='product.self_last_commented_at_date_time || product.mentor_last_comment_at_date_time'
             )
-              time.a-meta(v-if='product.self_last_comment_at_date_time')
-                | 〜 {{ product.self_last_comment_at }}（
+              time.a-meta(v-if='product.self_last_commented_at_date_time')
+                | 〜 {{ product.self_last_commented_at }}（
                 strong
                   | 提出者
                 | ）

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -70,30 +70,30 @@
                     )
 
             .thread-list-item-meta__item(
-              v-if='product.self_last_commented_at_date_time && product.mentor_last_comment_at_date_time'
+              v-if='product.self_last_commented_at_date_time && product.mentor_last_commented_at_date_time'
             )
               time.a-meta(
-                v-if='product.self_last_commented_at_date_time > product.mentor_last_comment_at_date_time'
+                v-if='product.self_last_commented_at_date_time > product.mentor_last_commented_at_date_time'
               )
                 | 〜 {{ product.self_last_commented_at }}（
                 strong
                   | 提出者
                 | ）
               time.a-meta(
-                v-if='product.self_last_commented_at_date_time < product.mentor_last_comment_at_date_time'
+                v-if='product.self_last_commented_at_date_time < product.mentor_last_commented_at_date_time'
               )
-                | 〜 {{ product.mentor_last_comment_at }}（メンター）
+                | 〜 {{ product.mentor_last_commented_at }}（メンター）
 
             .thread-list-item-meta__item(
-              v-else-if='product.self_last_commented_at_date_time || product.mentor_last_comment_at_date_time'
+              v-else-if='product.self_last_commented_at_date_time || product.mentor_last_commented_at_date_time'
             )
               time.a-meta(v-if='product.self_last_commented_at_date_time')
                 | 〜 {{ product.self_last_commented_at }}（
                 strong
                   | 提出者
                 | ）
-              time.a-meta(v-else-if='product.mentor_last_comment_at_date_time')
-                | 〜 {{ product.mentor_last_comment_at }}（メンター）
+              time.a-meta(v-else-if='product.mentor_last_commented_at_date_time')
+                | 〜 {{ product.mentor_last_commented_at }}（メンター）
 
     .stamp.stamp-approve(v-if='product.checks.size > 0')
       h2.stamp__content.is-title 確認済

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -92,7 +92,9 @@
                 strong
                   | 提出者
                 | ）
-              time.a-meta(v-else-if='product.mentor_last_commented_at_date_time')
+              time.a-meta(
+                v-else-if='product.mentor_last_commented_at_date_time'
+              )
                 | 〜 {{ product.mentor_last_commented_at }}（メンター）
 
     .stamp.stamp-approve(v-if='product.checks.size > 0')

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -34,7 +34,7 @@ class CommentCallbacks
   private
 
   def reset_last_comment_at(product)
-    product.mentor_last_comment_at = nil
+    product.mentor_last_commented_at = nil
     product.self_last_commented_at = nil
   end
 
@@ -45,7 +45,7 @@ class CommentCallbacks
 
     product.comments.each do |comment|
       if comment.user.mentor
-        product.mentor_last_comment_at = comment.updated_at
+        product.mentor_last_commented_at = comment.updated_at
       elsif comment.user == product.user
         product.self_last_commented_at = comment.updated_at
       end
@@ -56,7 +56,7 @@ class CommentCallbacks
   def update_last_comment_at(comment)
     product = Product.find(comment.commentable.id)
     if comment.user.mentor
-      product.mentor_last_comment_at = comment.updated_at
+      product.mentor_last_commented_at = comment.updated_at
     elsif comment.user == product.user
       product.self_last_commented_at = comment.updated_at
     end

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -35,7 +35,7 @@ class CommentCallbacks
 
   def reset_last_comment_at(product)
     product.mentor_last_comment_at = nil
-    product.self_last_comment_at = nil
+    product.self_last_commented_at = nil
   end
 
   def delete_last_comment_at(product_id)
@@ -47,7 +47,7 @@ class CommentCallbacks
       if comment.user.mentor
         product.mentor_last_comment_at = comment.updated_at
       elsif comment.user == product.user
-        product.self_last_comment_at = comment.updated_at
+        product.self_last_commented_at = comment.updated_at
       end
     end
     product.save!
@@ -58,7 +58,7 @@ class CommentCallbacks
     if comment.user.mentor
       product.mentor_last_comment_at = comment.updated_at
     elsif comment.user == product.user
-      product.self_last_comment_at = comment.updated_at
+      product.self_last_commented_at = comment.updated_at
     end
     product.save!
   end

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -11,7 +11,7 @@ class CommentCallbacks
 
     return unless comment.commentable.instance_of?(Product)
 
-    update_last_comment_at(comment)
+    update_last_commented_at(comment)
     update_commented_at(comment)
     delete_product_cache(comment.commentable.id)
   end
@@ -19,29 +19,29 @@ class CommentCallbacks
   def after_update(comment)
     return unless comment.commentable.instance_of?(Product)
 
-    update_last_comment_at(comment)
+    update_last_commented_at(comment)
     update_commented_at(comment)
   end
 
   def after_destroy(comment)
     return unless comment.commentable.instance_of?(Product)
 
-    delete_last_comment_at(comment.commentable.id)
+    delete_last_commented_at(comment.commentable.id)
     delete_commented_at(comment)
     delete_product_cache(comment.commentable.id)
   end
 
   private
 
-  def reset_last_comment_at(product)
+  def reset_last_commented_at(product)
     product.mentor_last_commented_at = nil
     product.self_last_commented_at = nil
   end
 
-  def delete_last_comment_at(product_id)
+  def delete_last_commented_at(product_id)
     product = Product.find(product_id)
 
-    reset_last_comment_at(product)
+    reset_last_commented_at(product)
 
     product.comments.each do |comment|
       if comment.user.mentor
@@ -53,7 +53,7 @@ class CommentCallbacks
     product.save!
   end
 
-  def update_last_comment_at(comment)
+  def update_last_commented_at(comment)
     product = Product.find(comment.commentable.id)
     if comment.user.mentor
       product.mentor_last_commented_at = comment.updated_at

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -17,9 +17,9 @@ if product.updated_at.present?
   json.updated_at_date_time product.updated_at.to_datetime
 end
 
-if product.self_last_comment_at.present?
-  json.self_last_comment_at l(product.self_last_comment_at)
-  json.self_last_comment_at_date_time product.self_last_comment_at.to_datetime
+if product.self_last_commented_at.present?
+  json.self_last_commented_at l(product.self_last_commented_at)
+  json.self_last_commented_at_date_time product.self_last_commented_at.to_datetime
 end
 
 if product.mentor_last_comment_at.present?

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -22,9 +22,9 @@ if product.self_last_commented_at.present?
   json.self_last_commented_at_date_time product.self_last_commented_at.to_datetime
 end
 
-if product.mentor_last_comment_at.present?
-  json.mentor_last_comment_at l(product.mentor_last_comment_at)
-  json.mentor_last_comment_at_date_time product.mentor_last_comment_at.to_datetime
+if product.mentor_last_commented_at.present?
+  json.mentor_last_commented_at l(product.mentor_last_commented_at)
+  json.mentor_last_commented_at_date_time product.mentor_last_commented_at.to_datetime
 end
 
 json.user do

--- a/db/migrate/20211110061152_rename_self_last_comment_at_to_products.rb
+++ b/db/migrate/20211110061152_rename_self_last_comment_at_to_products.rb
@@ -1,0 +1,5 @@
+class RenameSelfLastCommentAtToProducts < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :products, :self_last_comment_at, :self_last_commented_at
+  end
+end

--- a/db/migrate/20211110063403_rename_mentor_last_comment_at_to_products.rb
+++ b/db/migrate/20211110063403_rename_mentor_last_comment_at_to_products.rb
@@ -1,0 +1,5 @@
+class RenameMentorLastCommentAtToProducts < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :products, :mentor_last_comment_at, :mentor_last_commented_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_23_050713) do
+ActiveRecord::Schema.define(version: 2021_11_10_061152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -315,7 +315,7 @@ ActiveRecord::Schema.define(version: 2021_10_23_050713) do
     t.boolean "wip", default: false, null: false
     t.datetime "published_at"
     t.bigint "checker_id"
-    t.datetime "self_last_comment_at"
+    t.datetime "self_last_commented_at"
     t.datetime "mentor_last_comment_at"
     t.datetime "commented_at"
     t.index ["commented_at"], name: "index_products_on_commented_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_10_061152) do
+ActiveRecord::Schema.define(version: 2021_11_10_063403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -316,7 +316,7 @@ ActiveRecord::Schema.define(version: 2021_11_10_061152) do
     t.datetime "published_at"
     t.bigint "checker_id"
     t.datetime "self_last_commented_at"
-    t.datetime "mentor_last_comment_at"
+    t.datetime "mentor_last_commented_at"
     t.datetime "commented_at"
     t.index ["commented_at"], name: "index_products_on_commented_at"
     t.index ["practice_id"], name: "index_products_on_practice_id"


### PR DESCRIPTION
## 目的

- refs: #3270 
- #3111 で追加されたカラムを、Railsの標準および英文法に則り、名称変更する。
    - mentor_last_comment_at → mentor_last_comment`ed`_at
    - self_last_comment_at を self_last_comment`ed`_at