### PR TITLE
ユーザー個別ページのコメントタブに数字を表示する

### DIFF
--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -13,7 +13,7 @@
           | 日報
       li.page-tabs__item
         = link_to user_comments_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('comments')}" do
-          | コメント
+          | コメント （#{user.products.length}）
       li.page-tabs__item
         = link_to user_products_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
           | 提出物

--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -13,7 +13,7 @@
           | 日報
       li.page-tabs__item
         = link_to user_comments_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('comments')}" do
-          | コメント （#{user.products.length}）
+          | コメント （#{user.comments.length}）
       li.page-tabs__item
         = link_to user_products_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
           | 提出物


### PR DESCRIPTION
# 変更前
## コメントタブの横に数字が表示されていない

![image](https://user-images.githubusercontent.com/15277293/141082891-41a31ee5-50f0-41de-bc0b-dd7091369e31.png)


# 変更後
## コメントタブの横に数字が表示されている

![image](https://user-images.githubusercontent.com/15277293/141080855-0e98a2bf-6a24-45fb-a6ab-d8e9d62b8c08.png)
