### PR TITLE
日報一覧のローディングをプレースホルダに変更しました

### DIFF
--- a/app/javascript/reports.vue
+++ b/app/javascript/reports.vue
@@ -1,9 +1,6 @@
 <template lang="pug">
-.reports(v-if='reports === null')
-  .empty
-    .fas.fa-spinner.fa-pulse
-    |
-    | ロード中
+.reports.is-md(v-if='reports === null')
+  loadingListPlaceholder
 .reports(v-else-if='reports.length > 0 || !isUncheckedReportsPage')
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')
@@ -27,12 +24,14 @@
 <script>
 import Report from './report.vue'
 import UnconfirmedLink from './unconfirmed_link.vue'
+import LoadingListPlaceholder from './loading-list-placeholder.vue'
 import Pager from './pager.vue'
 
 export default {
   components: {
     report: Report,
     'unconfirmed-link': UnconfirmedLink,
+    loadingListPlaceholder: LoadingListPlaceholder,
     pager: Pager
   },
   data() {

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -488,7 +488,7 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth reports_path, 'kimura'
     precede = reports(:report24).title
     succeed = reports(:report23).title
-    within '.thread-list' do
+    within '.thread-list__items' do
       assert page.text.index(precede) < page.text.index(succeed)
     end
   end
@@ -498,7 +498,7 @@ class ReportsTest < ApplicationSystemTestCase
     precede = reports(:report18).title
     succeed = reports(:report17).title
 
-    within '.thread-list' do
+    within '.thread-list__items' do
       assert page.text.index(precede) < page.text.index(succeed)
     end
   end


### PR DESCRIPTION
- Issue: #2818 

### 変更後
- 日報一覧のローディングが「ロード中」になっている

https://user-images.githubusercontent.com/74460623/141244713-04ce6097-1eac-4200-90ce-9d8a57fa61bc.mov

### 変更後
- 日報一覧のローディングをプレースホルダに変更した

https://user-images.githubusercontent.com/74460623/141244731-30bfe82b-1ed7-4b9a-9815-fa2168bab106.mov