### PR TITLE
ユーザ名に加えてフルネームを画面表示する

### DIFF
--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -33,7 +33,7 @@
         .thread-list-item-meta
           .thread-list-item-meta__items
             .thread-list-item-meta__item
-              a.a-user-name(:href='report.user.url') {{ report.user.login_name }}
+              a.a-user-name(:href='report.user.url') {{ report.user.long_name }}
             .thread-list-item-meta__item
               time.a-meta {{ report.reportedOn }}
                 | の日報


### PR DESCRIPTION
# 変更前

※赤線は変更箇所の強調のためであり、実画面では表示されない

![image](https://user-images.githubusercontent.com/15277293/141663144-2ee356a5-cb03-446e-9d4a-b0d4eb9bc9d4.png)


# 変更後

※赤線は変更箇所の強調のためであり、実画面では表示されない

![image](https://user-images.githubusercontent.com/15277293/141663126-fcfbdbf8-41d7-4219-af3e-8e2e9f0c294a.png)

issue #3155 