### PR TITLE
日報一覧の絞り込みの文言を折り返さないようにした

### DIFF
--- a/app/assets/stylesheets/blocks/shared/_sort-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_sort-nav.sass
@@ -14,6 +14,7 @@
 .sort-nav__label
   +text-block(.8125rem 1.45)
   margin-right: .5rem
+  white-space: nowrap
   +media-breakpoint-down(sm)
     margin-right: 0
     margin-bottom: .25rem


### PR DESCRIPTION
issue:  [#3574](https://github.com/fjordllc/bootcamp/issues/3574)

## 概要
日報一覧のTOP画面にある『プラクティスで絞り込む』の文言が折り返しで表示されている。
絞り込みの文言を折り返さないように修正を行う。

![image](https://user-images.githubusercontent.com/80372144/142130084-283853bb-0126-40e7-9395-a9a6f3c6713b.png)

## 注意点
修正前の日報一覧画面を確認すると既に『プラクティスで絞り込む』の文言が折り返しされていない状態にありました。

<img width="1113" alt="スクリーンショット 2021-11-16 16 18 44" src="https://user-images.githubusercontent.com/80372144/142130516-cde116c3-a59b-4711-ba14-0dcf76b8a9c7.png">

町田さんに確認したところ、『折り返されてない状態に既に修正済み』だとしても
該当する sass ファイルに

```
white-space: nowrap
 ```
を追記して欲しいとのことでしたので、`white-space: nowrap`のコードを追記しています。

※見た目は実装前と実装後で変化はありません。

## 実装後

<img width="1125" alt="スクリーンショット 2021-11-17 11 19 35" src="https://user-images.githubusercontent.com/80372144/142131040-f3a2e485-2cd3-4ebf-92d9-ec6b1dc16efc.png">



