### PR TITLE
Date gem をアップデートします

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.4'
 
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'date', '>= 3.2.1' # CVE-2021-41817対応
 gem 'image_processing', '~> 1.2'
 gem 'jbuilder', '~> 2.7'
 gem 'puma', '~> 5.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
     crass (1.0.6)
     data_migrate (6.6.0)
       rails (>= 5.0)
+    date (3.2.1)
     dead_end (1.1.7)
     declarative (0.0.20)
     declarative-option (0.1.0)
@@ -511,6 +512,7 @@ DEPENDENCIES
   coffee-rails (~> 5.0.0)
   commonmarker
   data_migrate
+  date (>= 3.2.1)
   dead_end
   diffy
   discord-notifier


### PR DESCRIPTION
CVE-2021-41817 の脆弱性が公開されたため Date gem をアップデートします。
https://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/