### PR TITLE
通知ページの「お知らせ」のタブに全件数と未読の件数のバッチを表示する

### DIFF
--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module NotificationHelper
+
+    def read_batche(target)
+        if target == 'announcement' 
+            return Cache.read_announcement_count(current_user.id)
+        end
+      end
+
+      def unread_batche(target)
+        if target == 'announcement' 
+            return Cache.unread_announcement_count(current_user.id)
+        end
+      end
+  end

--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module NotificationHelper
-  def read_batche(target)
+  def read_batche(current_user, target)
     return Cache.read_announcement_count(current_user.id) if target == 'announcement'
   end
 
-  def unread_batche(target)
+  def unread_batche(current_user, target)
     return Cache.unread_announcement_count(current_user.id) if target == 'announcement'
   end
 end

--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,16 +1,11 @@
 # frozen_string_literal: true
 
 module NotificationHelper
-
-    def read_batche(target)
-        if target == 'announcement' 
-            return Cache.read_announcement_count(current_user.id)
-        end
-      end
-
-      def unread_batche(target)
-        if target == 'announcement' 
-            return Cache.unread_announcement_count(current_user.id)
-        end
-      end
+  def read_batche(target)
+    return Cache.read_announcement_count(current_user.id) if target == 'announcement'
   end
+
+  def unread_batche(target)
+    return Cache.unread_announcement_count(current_user.id) if target == 'announcement'
+  end
+end

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -61,5 +61,25 @@ class Cache
     def delete_not_solved_question_count
       Rails.cache.delete 'not_solved_question_count'
     end
+
+    def read_announcement_count(current_user_id)
+      Rails.cache.fetch "#{current_user_id}-read_announcement_count" do
+        Notification.where(user_id: current_user_id).by_target(:announcement).reads.count
+      end
+    end
+
+    def delete_read_announcement_count(current_user_id)
+      Rails.cache.delete "#{current_user_id}-read_announcement_count"
+    end
+
+    def unread_announcement_count(current_user_id)
+      Rails.cache.fetch "#{current_user_id}-unread_announcement_count" do
+        Notification.where(user_id: current_user_id).by_target(:announcement).unreads.count
+      end
+    end
+
+    def delete_unread_announcement_count(current_user_id)
+      Rails.cache.delete "#{current_user_id}-unread_announcement_count"
+    end
   end
 end

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -6,3 +6,7 @@
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip
+          - if target.to_s == 'announcement'
+            | (#{Cache.read_announcement_count(current_user.id)})
+            - if Cache.unread_announcement_count(current_user.id).positive?
+              = Cache.unread_announcement_count(current_user.id)

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -6,7 +6,6 @@
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip
-          - if target.to_s == 'announcement'
-            | (#{Cache.read_announcement_count(current_user.id)})
-            - if Cache.unread_announcement_count(current_user.id).positive?
-              = Cache.unread_announcement_count(current_user.id)
+          = read_batche(target.to_s)
+          = unread_batche(target.to_s)
+

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -8,4 +8,3 @@
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip
           = read_batche(target.to_s)
           = unread_batche(target.to_s)
-

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -6,5 +6,5 @@
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip
-          = read_batche(target.to_s)
-          = unread_batche(target.to_s)
+          = read_batche(current_user, target.to_s)
+          = unread_batche(current_user, target.to_s)

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -125,3 +125,27 @@ notification_chose_correct_answer:
   message: hajimeさんの質問【 解決済みの質問 】でadvijirouさんの回答がベストアンサーに選ばれました。
   path: "/questions/<%= ActiveRecord::FixtureSet.identify(:question12) %>"
   read: false
+
+notification_announcement_1:
+  kind: 5
+  user: komagata
+  sender: yamada
+  message: yamadaさんからお知らせです。
+  path: "/announcements/<%= ActiveRecord::FixtureSet.identify(:announcement81) %>"
+  read: false
+
+notification_announcement_2:
+  kind: 5
+  user: komagata
+  sender: machida
+  message: machidaさんからお知らせです。
+  path: "/announcements/<%= ActiveRecord::FixtureSet.identify(:announcement82) %>"
+  read: false
+
+notification_announcement_3:
+  kind: 5
+  user: komagata
+  sender: machida
+  message: machidaさんからお知らせです。
+  path: "/announcements/<%= ActiveRecord::FixtureSet.identify(:announcement83) %>"
+  read: true


### PR DESCRIPTION
確認用URL
- 全て
  - `http://localhost:3000/notifications?target=announcement`
- 未読
  - `http://localhost:3000/notifications?status=unread&target=announcement`

# 変更前
## 全て
![image](https://user-images.githubusercontent.com/15277293/143771751-241cc6df-e657-40b6-984a-4ddf9dc4e231.png)


## 未読
![image](https://user-images.githubusercontent.com/15277293/143771712-5894f267-af11-4a78-8cb5-098e8989e510.png)


# 変更後（デザイン未適応）

## 全て
![image](https://user-images.githubusercontent.com/15277293/143771556-ea94c413-2026-4dc7-afd1-1bcee6f8e3a0.png)

## 未読

![image](https://user-images.githubusercontent.com/15277293/143771634-a99e4bf3-3cdc-46bf-a6b1-a3868934334c.png)


issue #3544