### PR TITLE
通知ページの「全て」のタブに全件数の表示・未読の件数のバッチを表示しました

### DIFF
--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -2,7 +2,8 @@
   .container
     ul.page-tabs__items
       li.page-tabs__item
-        = link_to t('notification.all'), notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
+        = link_to notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
+          | 全て （#{current_user.notifications.length}）
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -3,8 +3,8 @@
     ul.page-tabs__items
       li.page-tabs__item
         = link_to notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
-          | 全て （#{current_user.notifications.length})
-          - if current_user.notifications.unreads.count > 0
+          | 全て （#{current_user.notifications.length}）
+          - if current_user.notifications.unreads.count.positive?
             .page-tabs__item-count.a-notification-count
               = current_user.notifications.unreads.count
       - Notification::TARGETS_TO_KINDS.each_key do |target|

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -3,7 +3,10 @@
     ul.page-tabs__items
       li.page-tabs__item
         = link_to notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
-          | 全て （#{current_user.notifications.length}）
+          | 全て （#{current_user.notifications.length})
+          - if current_user.notifications.unreads.count > 0
+            .page-tabs__item-count.a-notification-count
+              = current_user.notifications.unreads.count
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -256,7 +256,6 @@ ja:
         job_change: 転職や引っ越しなど環境の変化によって学びが継続できなくなったから
         training_end: 企業研修で利用をしていて研修期間が終了したため
   notification:
-    all: 全て
     announcement: お知らせ
     mention: メンション
     comment: コメント


### PR DESCRIPTION
issue:  [#3538](https://github.com/fjordllc/bootcamp/issues/3538)

## 概要
通知ページの『全て』のタブに全件数を表示する。
未読がある場合は未読の件数をバッチで表示する。


## 変更前
<img width="1120" alt="スクリーンショット 2021-11-22 10 42 03" src="https://user-images.githubusercontent.com/80372144/142788937-55f52ff1-926b-4fe8-ba18-1232a88615d1.png">

## 変更後
<img width="1119" alt="スクリーンショット 2021-11-22 10 44 21" src="https://user-images.githubusercontent.com/80372144/142789265-b0cd2c30-f3d5-48f9-a65e-d96bd68ee52d.png">
