### PR TITLE
ファイル拡張子を含むタグの、タグ別Q&A一覧ページが正しく表示されるように修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
   resources :generations, only: %i(show index)
   get "articles/tags/:tag", to: "articles#index", as: :tag, tag: /.+/
   get "pages/tags/:tag", to: "pages#index", as: :pages_tag, tag: /.+/
-  get "questions/tags/:tag", to: "questions#index", as: :questions_tag, tag: /.+/
+  get "questions/tags/:tag", to: "questions#index", as: :questions_tag, tag: /.+/, format: "html"
   get "login" => "user_sessions#new", as: :login
   get "auth/github/callback" => "user_sessions#callback"
   post "user_sessions" => "user_sessions#create"


### PR DESCRIPTION
## 目的

以下のバグの修正
- refs: #3480

## やったこと

タグ名が拡張子で終わる場合、Rails側で拡張子がフォーマットとして認識されてしまい、次のような挙動が発生していた。
- `.js`で終わるタグの場合は、application.html.slimが読み込まれず、デザインやヘッダーが適用されていないページが表示される（参考：https://bootcamp.fjord.jp/questions/1090 ）
- `.md`のように`.js`以外の拡張子形式で終わるタグの場合は、ActionController::UnknownFormatが発生し、ページが描画できない

そのためタグ別Q&A一覧（`questions/tags/:tag`)を表示する際には、HTML固定で表示するように修正。

## UIの修正

<details>
	<summary>URLに`.js`を含むタグ</summary>

例：`http://localhost:3000/questions/tags/Vue.js?all=true`

**変更前**

![image](https://user-images.githubusercontent.com/61409641/142566941-d81c2d82-d762-4807-8f1b-dbf3a9a8389b.png)

**変更後**

![image](https://user-images.githubusercontent.com/61409641/142566794-a59dfd49-e74d-4c40-bd89-955e84a3751c.png)
</details>

<details>
	<summary>URLに`.md`など`.js`以外でファイル拡張子を含むタグ</summary>

例：`http://localhost:3000/questions/tags/hack.md?all=true`

**変更前**

![image](https://user-images.githubusercontent.com/61409641/142573639-2eb28e2d-69ac-476d-9705-badc5a0bdeeb.png)

- 開発環境の場合は`ActionController::UnknownFormat`が発生します

**変更後**

![image](https://user-images.githubusercontent.com/61409641/142566917-f0da2db7-53fa-4502-9732-cfbd567e105d.png)

</details>