### PR TITLE
タグ別ユーザ一覧ページへのURLを、文字列からPath Helperを使った表現に変更

### DIFF
--- a/app/views/tags/_tag.html.slim
+++ b/app/views/tags/_tag.html.slim
@@ -1,7 +1,7 @@
 .user-group class="#{users_tags_gradation(tag.count, @top3_tags_counts[0])}"
   header.user-group__header
     h2.user-group__title.is-inline
-      = link_to "/users/tags/#{tag.name}", class: 'user-group__title-link'
+      = link_to users_tag_path(tag.name), class: 'user-group__title-link'
         - rank = users_tags_rank(tag.count, @top3_tags_counts)
         - if rank.present?
           span.user-group__title-icon(class="#{users_tags_rank(tag.count, @top3_tags_counts)}")


### PR DESCRIPTION
## 目的

- refs: #3596 
- ユーザ一覧ページのタグ別タブにある、各タグの個別のリンクがHTMLエスケープされていないため修正。

## UIの修正

![image](https://user-images.githubusercontent.com/61409641/142808682-d602a928-066b-49e8-9f97-5653349fdde3.png)

`users/tags`から各タグにアクセスして動作確認

### `#`（URLロケーション）を含むタグ

<details>
	<summary>変更前</summary>

![image](https://user-images.githubusercontent.com/61409641/142808949-b631423d-9d2a-465b-bd89-2fdf51782a0d.png)

</details>

<details>
	<summary>変更後</summary>

![image](https://user-images.githubusercontent.com/61409641/142808569-8642ae8a-af2a-4c1a-aa07-a6544fe4cb94.png)

</details>

### `?`（クエリパラメータ）を含むタグ

<details>
	<summary>変更前</summary>

![image](https://user-images.githubusercontent.com/61409641/142809060-1b8fdf24-abef-4586-b5dc-dca600e6c68b.png)

</details>

<details>
	<summary>変更後</summary>

![image](https://user-images.githubusercontent.com/61409641/142808814-926a52ce-d1b7-498a-ba56-f3a4819f7ba1.png)

</details>

### `%`（パーセントエンコーディング）を含むタグ

<details>
	<summary>変更前</summary>

![image](https://user-images.githubusercontent.com/61409641/142809132-34931d1a-bfcf-4f36-9a7d-5cfc6bbf03da.png)

</details>

<details>
	<summary>変更後</summary>

![image](https://user-images.githubusercontent.com/61409641/142808878-0f296a38-de77-49b7-afd1-9f3d8b204227.png)

</details>
