### PR TITLE
ユーザープロフィールにあるタグのURLを、エスケープして表示するように変更

### DIFF
--- a/app/javascript/tags.vue
+++ b/app/javascript/tags.vue
@@ -2,7 +2,7 @@
 .tag-links
   ul.tag-links__items(v-if='!editing')
     li.tag-links__item(v-for='tag in tags')
-      a.tag-links__item-link(:href='`tags/${tag.text}`')
+      a.tag-links__item-link(:href='`tags/${encodeURIComponent(tag.text)}`')
         | {{ tag.text }}
     li.tag-links__item(v-if='tagsEditable')
       .tag-links__item-edit(@click='editTag')

--- a/app/javascript/user-tags.vue
+++ b/app/javascript/user-tags.vue
@@ -2,7 +2,7 @@
 .tag-links
   ul.tag-links__items(v-if='tags.length !== 0')
     li.tag-links__item(v-for='tag in tags', :key='tag')
-      a.tag-links__item-link(:href='`/users/tags/${tag}`')
+      a.tag-links__item-link(:href='`/users/tags/${encodeURIComponent(tag)}`')
         | {{ tag }}
 </template>
 <script>


### PR DESCRIPTION
## 目的

- refs: #3597 
- ユーザープロフィールは、ユーザ詳細ページ（`/users/:id`）とユーザ一覧ページ（`/users`）にあり、いずれのタグのURLもエスケープされるように修正する

## UIの修正

URLに含まれる文字（`#`、`?`、`%`）による挙動の違いは、 #3605 と同じため割愛します。以下は`#`を含むタグでの変更確認です。
またユーザー一覧ページからでも、ユーザー詳細ページからでも遷移先は同じであるため、スクリーンショットは変更前と変更後でそれぞれ一つずつです。

**変更前**

![image](https://user-images.githubusercontent.com/61409641/142818233-62740066-bc24-42d6-8a86-4ba37fe7ba75.png)

**変更後**

![image](https://user-images.githubusercontent.com/61409641/142817941-0063f23d-226f-4788-b185-b242f5db02e7.png)