### PR TITLE
ファイル拡張子を含むタグの、タグ別ユーザー一覧ページが正しく表示されるように修正

### DIFF
--- a/config/routes/users.rb
+++ b/config/routes/users.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
     get "mail_notification", to: "mail_notification#update", as: :mail_notification
   end
 
-  get "users/tags/:tag", to: "users#index", as: :users_tag, tag: /.+/
+  get "users/tags/:tag", to: "users#index", as: :users_tag, tag: /.+/, format: "html"
 
   namespace :users do
     post "tags/:tag", to: "tags#update", tag: /.+/


### PR DESCRIPTION
## 目的

- 以下のバグの修正。いずれもファイル拡張子を含むタグの、タグ別ユーザー一覧ページを表示しようとすると、正しく表示されないという内容である（上2つは同一issue）
    - refs: #3479
    - refs: #2446 
    - refs: #2447 

## やったこと

#3591 のユーザー用タグ対応。以下、左記PRと同じ内容を記載

---

タグが拡張子で終わる場合、以下の事象が発生するため、HTML固定でレスポンスを返すようにする必要がある
- `.js`で終わるタグの場合は、application.html.slimが読み込まれない
- `.md`のようにテンプレートを用意していない拡張子形式で終わるタグの場合は、ActionController::UnknownFormatが発生し、ページが描画できない

## UIの修正

<details>
	<summary>URLに`.js`を含むタグ</summary>

例：`/users/tags/sample.js`

**変更前**

![image](https://user-images.githubusercontent.com/61409641/142839327-4c406b9a-4ea9-472c-a356-680553eb5a2a.png)

**変更後**

![image](https://user-images.githubusercontent.com/61409641/142839267-e7955078-f2aa-4c2b-8923-b878e672d787.png)

</details>

<details>
	<summary>URLに`.md`など`.js`以外でファイル拡張子を含むタグ</summary>

例：`/users/tags/sample.md`

**変更前**

![image](https://user-images.githubusercontent.com/61409641/142573639-2eb28e2d-69ac-476d-9705-badc5a0bdeeb.png)

- 開発環境の場合は`ActionController::UnknownFormat`が発生します

**変更後**

![image](https://user-images.githubusercontent.com/61409641/142839408-2d1940a5-8d40-4a17-a27d-398ef32be47f.png)

</details>
