### PR TITLE
ファイル拡張子を含むタグの、タグ別Docs一覧ページが正しく表示されるように修正 

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
   end
   resources :generations, only: %i(show index)
   get "articles/tags/:tag", to: "articles#index", as: :tag, tag: /.+/
-  get "pages/tags/:tag", to: "pages#index", as: :pages_tag, tag: /.+/
+  get "pages/tags/:tag", to: "pages#index", as: :pages_tag, tag: /.+/, format: "html"
   get "questions/tags/:tag", to: "questions#index", as: :questions_tag, tag: /.+/, format: "html"
   get "login" => "user_sessions#new", as: :login
   get "auth/github/callback" => "user_sessions#callback"


### PR DESCRIPTION
## 目的

以下のバグの修正。
- refs: #3607 

## やったこと

#3591 のDocs用タグ対応。以下、左記PRと同じ内容を記載

---

タグが拡張子で終わる場合、以下の事象が発生するため、HTML固定でレスポンスを返すようにする必要がある
- `.js`で終わるタグの場合は、application.html.slimが読み込まれない
- `.md`のようにテンプレートを用意していない拡張子形式で終わるタグの場合は、ActionController::UnknownFormatが発生し、ページが描画できない

## UIの修正

<details>
	<summary>URLに`.js`を含むタグ</summary>

例：`/pages/tags/sample.js`

**変更前**

![image](https://user-images.githubusercontent.com/61409641/142841603-3015ced2-7d45-479a-b25e-07cd9fb9e9a7.png)

**変更後**

![image](https://user-images.githubusercontent.com/61409641/142841529-35a94729-75b5-4bcb-a01d-183381214e39.png)

</details>

<details>
	<summary>URLに`.md`など`.js`以外でファイル拡張子を含むタグ</summary>

例：`/pages/tags/sample.md`

**変更前**

![image](https://user-images.githubusercontent.com/61409641/142573639-2eb28e2d-69ac-476d-9705-badc5a0bdeeb.png)

- 開発環境の場合は`ActionController::UnknownFormat`が発生します

**変更後**

![image](https://user-images.githubusercontent.com/61409641/142841479-04a11542-d503-42cf-a29d-04f875d528fe.png)

</details>