### PR TITLE
Docs一覧画面でtagsテーブルへのN+1が発生していたのを解消した

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,7 @@ class PagesController < ApplicationController
 
   def index
     @pages = Page.with_avatar
-                 .includes(:comments, :practice,
+                 .includes(:comments, :practice, :tags,
                            { last_updated_user: { avatar_attachment: :blob } })
                  .order(updated_at: :desc)
                  .page(params[:page])


### PR DESCRIPTION
タイトル通り、bulletのwarningが出ていたのでincludesでtagsテーブルを読み込むようにしました。