### PR TITLE
カテゴリー並び替え画面でcategoriesテーブルへのN+1が発生していたのを解消した

### DIFF
--- a/app/controllers/courses/categories_controller.rb
+++ b/app/controllers/courses/categories_controller.rb
@@ -5,6 +5,9 @@ class Courses::CategoriesController < ApplicationController
 
   def index
     @course = Course.find(params[:course_id])
-    @courses_categories = @course.courses_categories.order(:position)
+    @courses_categories = @course
+                          .courses_categories
+                          .includes(:category)
+                          .order(:position)
   end
 end


### PR DESCRIPTION
タイトル通り、bulletのwarningが出ていたのでincludesでcategoriesテーブルを読み込むようにしました。