### PR TITLE
お知らせの通知にお知らせのタイトルを含める

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -63,7 +63,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def post_announcement
     @user = @receiver
     @notification = @user.notifications.find_by(path: "/announcements/#{@announcement.id}")
-    mail to: @user.email, subject: "[bootcamp] お知らせ 「#{@announcement.title}」"
+    mail to: @user.email, subject: "[bootcamp] お知らせ「#{@announcement.title}」"
   end
 
   # required params: question, receiver

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -63,7 +63,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def post_announcement
     @user = @receiver
     @notification = @user.notifications.find_by(path: "/announcements/#{@announcement.id}")
-    mail to: @user.email, subject: "[bootcamp] #{@announcement.user.login_name}さんからお知らせです。"
+    mail to: @user.email, subject: "[bootcamp] お知らせ 「#{@announcement.title}」"
   end
 
   # required params: question, receiver

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -110,7 +110,7 @@ class Notification < ApplicationRecord
       user: receiver,
       sender: announce.sender,
       path: Rails.application.routes.url_helpers.polymorphic_path(announce),
-      message: "#{announce.user.login_name}さんからお知らせです。",
+      message: "お知らせ「#{announce.title}」",
       read: false
     )
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -110,7 +110,7 @@ class Notification < ApplicationRecord
       user: receiver,
       sender: announce.sender,
       path: Rails.application.routes.url_helpers.polymorphic_path(announce),
-      message: "お知らせ「#{announce.title}」",
+      message: "お知らせ 「#{announce.title}」",
       read: false
     )
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -110,7 +110,7 @@ class Notification < ApplicationRecord
       user: receiver,
       sender: announce.sender,
       path: Rails.application.routes.url_helpers.polymorphic_path(announce),
-      message: "お知らせ 「#{announce.title}」",
+      message: "お知らせ「#{announce.title}」",
       read: false
     )
   end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -113,7 +113,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[bootcamp] komagataさんからお知らせです。', email.subject
+    assert_equal '[bootcamp] お知らせ 「お知らせ1」', email.subject
     assert_match(/お知らせ/, email.body.to_s)
   end
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -113,7 +113,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[bootcamp] お知らせ 「お知らせ1」', email.subject
+    assert_equal '[bootcamp] お知らせ「お知らせ1」', email.subject
     assert_match(/お知らせ/, email.body.to_s)
   end
 

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -75,7 +75,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'hatsuno'
-    assert_text 'お知らせ「タイトルtest」'
+    assert_text 'お知らせ 「タイトルtest」'
 
     visit_with_auth '/announcements', 'komagata'
     click_on 'タイトルtest'
@@ -85,7 +85,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを削除しました'
 
     visit_with_auth '/notifications', 'hatsuno'
-    assert_no_text 'お知らせ「タイトルtest」'
+    assert_no_text 'お知らせ 「タイトルtest」'
   end
 
   test 'announcement notification receive only active users' do
@@ -99,25 +99,25 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'komagata'
-    assert_text 'お知らせ「現役生にのみお知らせtest」'
+    assert_text 'お知らせ 「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'kimura'
-    assert_text 'お知らせ「現役生にのみお知らせtest」'
+    assert_text 'お知らせ 「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'sotugyou'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'advijirou'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'yameo'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'yamada'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'kensyu'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
   end
 
   test 'announcement notifications are only recived by job seekers' do
@@ -131,13 +131,13 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'komagata'
-    assert_text 'お知らせ「就活希望者のみお知らせします」'
+    assert_text 'お知らせ 「就活希望者のみお知らせします」'
 
     visit_with_auth '/notifications', 'jobseeker'
-    assert_text 'お知らせ「就活希望者のみお知らせします」'
+    assert_text 'お知らせ 「就活希望者のみお知らせします」'
 
     visit_with_auth '/notifications', 'kimura'
-    assert_no_text 'お知らせ「就活希望者のみお知らせします」'
+    assert_no_text 'お知らせ 「就活希望者のみお知らせします」'
   end
 
   test "general user can't edit submitted announcement" do

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -75,7 +75,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'hatsuno'
-    assert_text 'お知らせ 「タイトルtest」'
+    assert_text 'お知らせ「タイトルtest」'
 
     visit_with_auth '/announcements', 'komagata'
     click_on 'タイトルtest'
@@ -85,7 +85,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを削除しました'
 
     visit_with_auth '/notifications', 'hatsuno'
-    assert_no_text 'お知らせ 「タイトルtest」'
+    assert_no_text 'お知らせ「タイトルtest」'
   end
 
   test 'announcement notification receive only active users' do
@@ -99,25 +99,25 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'komagata'
-    assert_text 'お知らせ 「現役生にのみお知らせtest」'
+    assert_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'kimura'
-    assert_text 'お知らせ 「現役生にのみお知らせtest」'
+    assert_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'sotugyou'
-    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'advijirou'
-    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'yameo'
-    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'yamada'
-    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'kensyu'
-    assert_no_text 'お知らせ 「現役生にのみお知らせtest」'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
   end
 
   test 'announcement notifications are only recived by job seekers' do
@@ -131,13 +131,13 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'komagata'
-    assert_text 'お知らせ 「就活希望者のみお知らせします」'
+    assert_text 'お知らせ「就活希望者のみお知らせします」'
 
     visit_with_auth '/notifications', 'jobseeker'
-    assert_text 'お知らせ 「就活希望者のみお知らせします」'
+    assert_text 'お知らせ「就活希望者のみお知らせします」'
 
     visit_with_auth '/notifications', 'kimura'
-    assert_no_text 'お知らせ 「就活希望者のみお知らせします」'
+    assert_no_text 'お知らせ「就活希望者のみお知らせします」'
   end
 
   test "general user can't edit submitted announcement" do

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -75,7 +75,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'hatsuno'
-    assert_text 'komagataさんからお知らせです。'
+    assert_text 'お知らせ「タイトルtest」'
 
     visit_with_auth '/announcements', 'komagata'
     click_on 'タイトルtest'
@@ -85,7 +85,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを削除しました'
 
     visit_with_auth '/notifications', 'hatsuno'
-    assert_no_text 'komagataさんからお知らせです。'
+    assert_no_text 'お知らせ「タイトルtest」'
   end
 
   test 'announcement notification receive only active users' do
@@ -99,25 +99,25 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'komagata'
-    assert_text 'machidaさんからお知らせです。'
+    assert_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'kimura'
-    assert_text 'machidaさんからお知らせです。'
+    assert_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'sotugyou'
-    assert_no_text 'machidaさんからお知らせです。'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'advijirou'
-    assert_no_text 'machidaさんからお知らせです。'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'yameo'
-    assert_no_text 'machidaさんからお知らせです。'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'yamada'
-    assert_no_text 'machidaさんからお知らせです。'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
     visit_with_auth '/notifications', 'kensyu'
-    assert_no_text 'machidaさんからお知らせです。'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
   end
 
   test 'announcement notifications are only recived by job seekers' do
@@ -131,13 +131,13 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'komagata'
-    assert_text 'machidaさんからお知らせです。'
+    assert_text 'お知らせ「就活希望者のみお知らせします」'
 
     visit_with_auth '/notifications', 'jobseeker'
-    assert_text 'machidaさんからお知らせです。'
+    assert_text 'お知らせ「就活希望者のみお知らせします」'
 
     visit_with_auth '/notifications', 'kimura'
-    assert_no_text 'machidaさんからお知らせです。'
+    assert_no_text 'お知らせ「就活希望者のみお知らせします」'
   end
 
   test "general user can't edit submitted announcement" do

--- a/test/system/notification/announcements_test.rb
+++ b/test/system/notification/announcements_test.rb
@@ -4,7 +4,7 @@ require 'application_system_test_case'
 
 class Notification::AnnouncementsTest < ApplicationSystemTestCase
   setup do
-    @notice_text = 'お知らせ「タイトル通知用の確認です」'
+    @notice_text = 'お知らせ 「タイトル通知用の確認です」'
     @notice_kind = Notification.kinds['announced']
     @notified_count = Notification.where(kind: @notice_kind).size
     @receiver_count = User.where(retired_on: nil).size - 1 # 送信者は除くため-1

--- a/test/system/notification/announcements_test.rb
+++ b/test/system/notification/announcements_test.rb
@@ -4,7 +4,7 @@ require 'application_system_test_case'
 
 class Notification::AnnouncementsTest < ApplicationSystemTestCase
   setup do
-    @notice_text = 'komagataさんからお知らせです。'
+    @notice_text = 'お知らせ「タイトル通知用の確認です」'
     @notice_kind = Notification.kinds['announced']
     @notified_count = Notification.where(kind: @notice_kind).size
     @receiver_count = User.where(retired_on: nil).size - 1 # 送信者は除くため-1
@@ -14,7 +14,7 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
     visit_with_auth '/announcements', 'komagata'
     click_link 'お知らせ作成'
 
-    find("input[name='announcement[title]']").set('お知らせです')
+    find("input[name='announcement[title]']").set('タイトル通知用の確認です')
     find("textarea[name='announcement[description]']").set('お知らせ内容です')
     find("input[value='all']", { visible: false }).set(true)
     click_button '作成'

--- a/test/system/notification/announcements_test.rb
+++ b/test/system/notification/announcements_test.rb
@@ -4,7 +4,7 @@ require 'application_system_test_case'
 
 class Notification::AnnouncementsTest < ApplicationSystemTestCase
   setup do
-    @notice_text = 'お知らせ 「タイトル通知用の確認です」'
+    @notice_text = 'お知らせ「タイトル通知用の確認です」'
     @notice_kind = Notification.kinds['announced']
     @notified_count = Notification.where(kind: @notice_kind).size
     @receiver_count = User.where(retired_on: nil).size - 1 # 送信者は除くため-1


### PR DESCRIPTION
issue:  [#3532](https://github.com/fjordllc/bootcamp/issues/3532)

## 概要
お知らせの通知にお知らせのタイトルを含める。
サイト内通知・メールでの通知、両方を変更する。

## 変更前
お知らせ作成後の通知では「XXさんからお知らせです。」と作成者の名前が表示される仕組みになっていました。

* 通知ベル箇所
<img width="272" alt="スクリーンショット 2021-11-23 17 15 18" src="https://user-images.githubusercontent.com/80372144/143412520-58d3fbc1-bb6e-417e-8dcb-68d3456f5ace.png">

* 通知を開いた後の、「お知らせ」確認ページ
<img width="939" alt="スクリーンショット 2021-11-25 18 28 27" src="https://user-images.githubusercontent.com/80372144/143415436-fed2318b-7a68-41f5-ae5b-e82bf97a1423.png">

* メールでの通知
<img width="642" alt="スクリーンショット 2021-11-25 18 30 55" src="https://user-images.githubusercontent.com/80372144/143415811-903a6752-81ad-4451-befb-8d8ae9e36c72.png">


## 変更後
表示内容を`「XXさんからお知らせです。」`から　`お知らせ「お知らせのタイトル」`へ変更しました。
* 通知ベル箇所
<img width="284" alt="スクリーンショット 2021-11-24 18 22 38" src="https://user-images.githubusercontent.com/80372144/143413250-d3ad54a9-48d1-4018-ba5f-53e70471fcfd.png">

* 通知を開いた後の、「お知らせ」確認ページ

<img width="946" alt="スクリーンショット 2021-11-25 18 24 55" src="https://user-images.githubusercontent.com/80372144/143415032-b82558d6-6c7a-46b8-b8f6-5239237d145a.png">

* メールでの通知
<img width="410" alt="スクリーンショット 2021-11-24 16 29 34" src="https://user-images.githubusercontent.com/80372144/143416384-023de87e-88c7-4d0d-ba3d-4500c47edc54.png">



※ サイト内通知・メール通知共にテストを通過しています。