### PR TITLE
「自分の担当」タブのバッチに表示される件数が０件の場合はバッチを表示しないように実装

### DIFF
--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -24,5 +24,6 @@
       li.page-tabs__item.is-only-mentor
         = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
           | 自分の担当 （#{Product.self_assigned_product(current_user.id).size}）
-          .page-tabs__item-count.a-notification-count.is-only-mentor
-            = Cache.self_assigned_no_replied_product_count(current_user.id)
+          - if Cache.self_assigned_no_replied_product_count(current_user.id).positive?
+            .page-tabs__item-count.a-notification-count.is-only-mentor
+              = Cache.self_assigned_no_replied_product_count(current_user.id)

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -304,14 +304,13 @@ class ProductsTest < ApplicationSystemTestCase
 
     [
       '担当者がいない提出物の場合、担当者になる',
-      '自分が担当者の場合、担当者のまま',
-      'タブ上の数字は未返信の数字のため、返信するとカウントされない'
+      '自分が担当者の場合、担当者のまま'
     ].each do |comment|
       visit "/products/#{products(:product1).id}"
       post_comment(comment)
 
       visit products_not_responded_index_path
-      assert_equal before_comment, assigned_product_count
+      assert_equal before_comment + 1, assigned_product_count
     end
   end
 

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -297,7 +297,7 @@ class ProductsTest < ApplicationSystemTestCase
   test 'be person on charge at comment on product of there are not person on charge' do
     visit_with_auth products_not_responded_index_path, 'machida'
     def assigned_product_count
-      find_link('自分の担当').find('.page-tabs__item-count').text.to_i
+      text[/自分の担当 （(\d+)）/, 1].to_i
     end
 
     before_comment = assigned_product_count
@@ -325,7 +325,7 @@ class ProductsTest < ApplicationSystemTestCase
     visit_with_auth products_not_responded_index_path, 'machida'
 
     def assigned_product_count
-      find_link('自分の担当').find('.page-tabs__item-count').text.to_i
+      text[/自分の担当 （(\d+)）/, 1].to_i
     end
 
     before_comment = assigned_product_count


### PR DESCRIPTION
Ref: #3594

# やったこと

- メンター用の提出物一覧ページにおいて、「自分の担当」タブのバッチに表示される件数が０件の場合はバッチを表示しないように実装
- 上記の実装により落ちるようになったテストの修正（詳細は↓に別途記載）
    - テストで自分の担当件数として「返信済みも含めたすべての担当件数」を取得するようにした
    - テストのアサーションで「コメントすると担当件数が1件増えること」を確認できるようにするため、[https://github.com/fjordllc/bootcamp/pull/3241/commits/38f28282db2a1eb6b263ebfde8a97c34eba06efc](https://github.com/fjordllc/bootcamp/pull/3241/commits/38f28282db2a1eb6b263ebfde8a97c34eba06efc) をリバートした

# 画面の変更内容

※画像の右側の赤枠部分

## 変更前

![Screen Shot 2021-11-26 at 13 34 43](https://user-images.githubusercontent.com/15713392/143528999-7810ee1d-1d3f-45d4-bdc8-fa6298e138bb.png)

## 変更後

![Screen Shot 2021-11-26 at 13 35 59](https://user-images.githubusercontent.com/15713392/143529006-5639f893-c606-442f-99e8-dedde1314fb1.png)

※ 1件以上の場合は今まで通り表示

![image](https://user-images.githubusercontent.com/15713392/143793652-04316eac-a088-4325-a67a-c9746136ccc6.png)

# Issue の対応により落ちるようになったテストとその対応

## 落ちるようになったテスト

### テストA

- テストで確認したいこと
    - メンターが担当者のいない提出物にコメントすると、その提出物の担当になること
- テストコード
    - [https://github.com/fjordllc/bootcamp/blob/de2e6a8778e9b4f6163cd4f2e330e5f8201d835a/test/system/products_test.rb#L297-L316](https://github.com/fjordllc/bootcamp/blob/de2e6a8778e9b4f6163cd4f2e330e5f8201d835a/test/system/products_test.rb#L297-L316)

### テストB

- テストで確認したいこと
    - メンターがすでに担当者のいる提出物にコメントしても、その提出物の担当にならないこと
- テストコード
    - [https://github.com/fjordllc/bootcamp/blob/de2e6a8778e9b4f6163cd4f2e330e5f8201d835a/test/system/products_test.rb#L318-L338](https://github.com/fjordllc/bootcamp/blob/de2e6a8778e9b4f6163cd4f2e330e5f8201d835a/test/system/products_test.rb#L318-L338)

## 対応したこと

### 対応1: テストコードで自分の担当件数として「返信済みも含めたすべての担当件数」を取得するようにした

- 修正対象
    
    テストAとテストBの両方
    
    ※ どちらのテストも、落ちるようになった原因は同じ
    
- エラーメッセージ
    
    テストA
    
    ```
    Error:
    ProductsTest#test_be_person_on_charge_at_comment_on_product_of_there_are_not_person_on_charge:
    Capybara::ElementNotFound: Unable to find css ".page-tabs__item-count" within #<Capybara::Node::Element tag="a" path="/HTML/BODY[1]/DIV[1]/MAIN[1]/DIV[1]/DIV[1]/DIV[1]/UL[1]/LI[5]/A[1]">
        test/system/products_test.rb:300:in `assigned_product_count'
        test/system/products_test.rb:303:in `block in <class:ProductsTest>'
    
    rails test test/system/products_test.rb:297
    
    ```
    
    テストB
    
    ```
    Error:
    ProductsTest#test_be_not_person_on_charge_at_comment_on_product_of_there_are_person_on_charge:
    Capybara::ElementNotFound: Unable to find css ".page-tabs__item-count" within #<Capybara::Node::Element tag="a" path="/HTML/BODY[1]/DIV[1]/MAIN[1]/DIV[1]/DIV[1]/DIV[1]/UL[1]/LI[5]/A[1]">
        test/system/products_test.rb:328:in `assigned_product_count'
        test/system/products_test.rb:331:in `block in <class:ProductsTest>'
    
    rails test test/system/products_test.rb:318
    
    ```
    
- 落ちるようになった原因
    
    テストコードにおいて担当件数が0件の時に「自分の担当」タブのバッチから担当件数が取得されており、今回の Issue の対応によりバッチが表示されなくなったことで、バッチが見つからないエラーが生じるようになったため
    
- 調査してわかったこと
    
    テストが追加された Issue #2460 を調べてみると、テストコードで「本来取得したいはずの件数」と「実際に取得している件数」が異なっているということがわかった
    
    - 本来取得したいはずの件数
        - 返信済みも含めた自分の担当の提出物すべての件数
    - 実際に取得している件数
        - 返信済みを除いた自分の担当の提出物の件数（すなわち未返信の件数）
            - 補足: 「自分の担当」タブのバッチに表示されている件数が取得されている
- 対応したこと
    
    自分の担当件数として「返信済みも含めたすべての担当件数」を取得するようにした。具体的には、「自分の担当」タブのテキストから件数を取得するようにした。
    
    - 例: 「自分の担当（2）」というテキストの場合、担当件数は「2」
    
- 対応した結果
    - テストA
        - エラーは起きなくなったけれど、テストが失敗するようになった
    - テストB
        - エラーは起きなくなり、テストも成功するようになった
   
### 対応2: テストAで本来確認したいことを確認できるようにするため、 38f2828 をリバートした

- 修正対象
    
    テストAのみ
    
- エラーメッセージ（対応1の修正後）
    
    ```
    Failure:
    ProductsTest#test_be_person_on_charge_at_comment_on_product_of_there_are_not_person_on_charge [/Users/satoudaisuke/src/github.com/fjordllc/bootcamp/test/system/products_test.rb:314]:
    Expected: 0
      Actual: 1
    
    rails test test/system/products_test.rb:297
    ```
    
- 失敗するようになった原因
    
    テストAのアサーションでは「担当者のいない提出物にコメントしても担当件数が変わらないこと」を確認しているけれど、対応1の修正によりコメントすると担当件数が1件増えるようになったため
    
- 疑問に感じたこと
    
    テストAで確認したいことは「コメントすると担当になる（件数が1件増える）こと」のはずなのに、なぜ「コメントしても担当にならない（件数が変わらない）こと」が確認されているのか？
    
- 調査してわかったこと
    
    38f2828 でテストAのアサーションが変更されていた
    
    - アサーションがどのように変更されたか
        
        「コメントしても担当件数が変わらないこと」を確認するように変更された
        
    - なぜアサーションが修正されたか
        
        PR #3241 の実装過程において、テストAが失敗するようになったため
        
        - テストAが失敗するようになった実装
            
            「自分の担当」タブのバッチに表示する件数を未返信のみに絞るようにした実装
            
        - 起きたこと
            
            担当者のいない提出物にコメントすると、その提出物は「自分の担当」かつ「返信済み」となるため、バッチに表示される件数（未返信の件数）が増えなくなった → そのためテストAが失敗するようになった
            
    - 考えたこと
        
        テストAで確認したいことは「コメントすると担当になること」なので、 38f2828 で「コメントしても担当にならないこと」を確認するようにアサーションを変えたことは、修正として不適切だったのではないのではないだろうか？
        
    - どのように修正すると適切だったか
        
        テストAで確認したいことを考慮すると、アサーションは変更せずに、対応1のような修正をした方が適切だったように思います
        
- 対応したこと
    
    テストAのアサーションで「コメントすると担当件数が1件増えること」を確認できるようにするため、 38f2828 をリバートした
    
- 対応した結果
    
    テストAが成功するようになった