### PR TITLE
日報のコメントにてcommand + enterで投稿できず、過去のコメントが増えてしまう問題の修正

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -5,9 +5,7 @@
   .thread-comments-more(v-show='!loadedComment')
     .thread-comments-more__inner
       .thread-comments-more__action
-        button#js-shortcut-post-comment.a-button.is-lg.is-text.is-block(
-          @click='showComments'
-        )
+        button#a.a-button.is-lg.is-text.is-block(@click='showComments')
           | コメント（{{ commentLimit }}）をもっと見る
   comment(
     v-for='(comment, index) in comments',

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -5,7 +5,7 @@
   .thread-comments-more(v-show='!loadedComment')
     .thread-comments-more__inner
       .thread-comments-more__action
-        button#a.a-button.is-lg.is-text.is-block(@click='showComments')
+        button.a-button.is-lg.is-text.is-block(@click='showComments')
           | コメント（{{ commentLimit }}）をもっと見る
   comment(
     v-for='(comment, index) in comments',

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -237,7 +237,7 @@ class CommentsTest < ApplicationSystemTestCase
     visit_with_auth product_path(users(:hatsuno).products.first.id), 'komagata'
 
     assert_no_text '提出物のコメント1です。'
-    old_comments = find('#a.a-button.is-lg.is-text.is-block').text
+    old_comments = find('.a-button.is-lg.is-text.is-block').text
     assert_text old_comments
     assert_text '提出物のコメント13です。'
 

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -237,7 +237,7 @@ class CommentsTest < ApplicationSystemTestCase
     visit_with_auth product_path(users(:hatsuno).products.first.id), 'komagata'
 
     assert_no_text '提出物のコメント1です。'
-    old_comments = find('#js-shortcut-post-comment.a-button.is-lg.is-text.is-block').text
+    old_comments = find('#a.a-button.is-lg.is-text.is-block').text
     assert_text old_comments
     assert_text '提出物のコメント13です。'
 


### PR DESCRIPTION
# 変更前

`http://localhost:3000/reports/130279127`にて確認

![image](https://user-images.githubusercontent.com/15277293/143663874-ad5c40b4-06f5-42a4-a023-ea348bfa9987.png)

![image](https://user-images.githubusercontent.com/15277293/143663905-d195e440-cdb3-420e-a48c-554c1f18f9e7.png)
![image](https://user-images.githubusercontent.com/15277293/143663954-81c957e3-95a3-49e3-923d-27a7420c26fb.png)


# 変更後

![image](https://user-images.githubusercontent.com/15277293/143664005-7a245133-43f8-4424-8648-465bf7e6b353.png)

画像の注釈が抜けていますが、確認の際はこちらも「command + enter」で投稿をしてください。

![image](https://user-images.githubusercontent.com/15277293/143664032-f891beba-6913-4590-b759-74e99fc6e7bf.png)


# 原因
「command + enter」を実行した際、shortcut.jsを経由して[js-shortcut-post-comment](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/shortcut.js#L26)が呼ばれている。
しかし、「[コメントする](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/comments.vue#L58)」ボタンよりも前に「[コメントをもっと見る](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/comments.vue#L8)」ボタンがjs-shortcut-post-commentを参照し、実行対象となっていた。
そのため過去のコメントが再投稿されたように表示されていた（実際には何も投稿されていない）。



issue #3525 