### PR TITLE
「日報の絞り込み」時、該当プラクティスの日報が0のときの表示を変更しました

### DIFF
--- a/app/javascript/reports.vue
+++ b/app/javascript/reports.vue
@@ -1,6 +1,12 @@
 <template lang="pug">
 .reports.is-md(v-if='reports === null')
   loadingListPlaceholder
+.reports(v-else-if='reports.length === 0')
+  .o-empty-message
+    .o-empty-message__icon
+      i.far.fa-sad-tear
+    .o-empty-message__text
+      | 日報はまだありません。
 .reports(v-else-if='reports.length > 0 || !isUncheckedReportsPage')
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')


### PR DESCRIPTION
issue: #3443 


## 概要
プラクティスで「日報の絞り込み」を行った時、該当プラクティスの日報が0件の場合は泣き顔を表示する。


## 変更前
<img width="1029" alt="スクリーンショット 2021-11-27 17 04 02" src="https://user-images.githubusercontent.com/80372144/143801817-94940a58-df72-426d-8d56-e9ceddafa568.png">



## 変更後
横線の代わりに泣き顔が表示されるようになりました。
<img width="1027" alt="スクリーンショット 2021-11-27 17 03 25" src="https://user-images.githubusercontent.com/80372144/143801868-adac9586-b267-4222-8559-fce5047ec252.png">
