### PR TITLE
通知一覧画面の「メンション」タブにメンションありの通知の全件数と未読件数を表示

### DIFF
--- a/app/controllers/notifications/allmarks_controller.rb
+++ b/app/controllers/notifications/allmarks_controller.rb
@@ -4,6 +4,7 @@ class Notifications::AllmarksController < ApplicationController
   def create
     @notifications = current_user.notifications
     @notifications.update_all(read: true, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    Cache.delete_mentioned_and_unread_notification_count(current_user.id) # 全ての通知件数分のコールバックが実行されるとサーバーに負荷をかけすぎることもありそうなため、コールバックを使わずにキャッシュを削除する
     redirect_to notifications_path, notice: '全て既読にしました'
   end
 end

--- a/app/controllers/notifications/allmarks_controller.rb
+++ b/app/controllers/notifications/allmarks_controller.rb
@@ -2,9 +2,7 @@
 
 class Notifications::AllmarksController < ApplicationController
   def create
-    @notifications = current_user.notifications
-    @notifications.update_all(read: true, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
-    Cache.delete_mentioned_and_unread_notification_count(current_user.id) # 全ての通知件数分のコールバックが実行されるとサーバーに負荷をかけすぎることもありそうなため、コールバックを使わずにキャッシュを削除する
+    current_user.mark_all_as_read_and_delete_cache_of_unreads
     redirect_to notifications_path, notice: '全て既読にしました'
   end
 end

--- a/app/controllers/notifications/read_by_category_controller.rb
+++ b/app/controllers/notifications/read_by_category_controller.rb
@@ -4,7 +4,7 @@ class Notifications::ReadByCategoryController < ApplicationController
   def create
     target = params[:target].presence&.to_sym
     notifications = current_user.notifications.by_target(target).unreads
-    notifications.update(read: true)
+    current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: notifications)
     redirect_to notifications_path(target: target), notice: '既読にしました'
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -11,7 +11,7 @@ class NotificationsController < ApplicationController
   def show
     link = @notification.read_attribute :link
     @notifications = current_user.notifications.where(link: link)
-    @notifications.update(read: true)
+    current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: @notifications)
     redirect_to link
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -11,7 +11,7 @@ class NotificationsController < ApplicationController
   def show
     link = @notification.read_attribute :link
     @notifications = current_user.notifications.where(link: link)
-    @notifications.update_all(read: true) # rubocop:disable Rails/SkipsModelValidations
+    @notifications.update(read: true)
     redirect_to link
   end
 

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -54,7 +54,7 @@ class Cache
 
     def mentioned_notification_count(user)
       Rails.cache.fetch "#{user.id}-mentioned_notification_count" do
-        user.notifications.by_target(:mention).count
+        user.notifications.by_target(:mention).latest_of_each_link.size
       end
     end
 
@@ -64,7 +64,7 @@ class Cache
 
     def mentioned_and_unread_notification_count(user)
       Rails.cache.fetch "#{user.id}-mentioned_and_unread_notification_count" do
-        user.notifications.by_target(:mention).where(read: false).count
+        user.notifications.by_target(:mention).unreads.latest_of_each_link.size
       end
     end
 

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -54,7 +54,7 @@ class Cache
 
     def mentioned_notification_count(user)
       Rails.cache.fetch "#{user.id}-mentioned_notification_count" do
-        user.notifications.where(kind: :mentioned).count
+        user.notifications.by_target(:mention).count
       end
     end
 
@@ -64,7 +64,7 @@ class Cache
 
     def mentioned_and_unread_notification_count(user)
       Rails.cache.fetch "#{user.id}-mentioned_and_unread_notification_count" do
-        user.notifications.where(kind: :mentioned, read: false).count
+        user.notifications.by_target(:mention).where(read: false).count
       end
     end
 

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -51,5 +51,17 @@ class Cache
     def delete_not_solved_question_count
       Rails.cache.delete 'not_solved_question_count'
     end
+
+    def mentioned_notification_count(user)
+      Rails.cache.fetch "#{user.id}-mentioned_notification_count" do
+        user.notifications.where(kind: :mentioned).count
+      end
+    end
+
+    def mentioned_and_unread_notification_count(user)
+      Rails.cache.fetch "#{user.id}-mentioned_and_unread_notification_count" do
+        user.notifications.where(kind: :mentioned, read: false).count
+      end
+    end
   end
 end

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -58,10 +58,18 @@ class Cache
       end
     end
 
+    def delete_mentioned_notification_count(user_id)
+      Rails.cache.delete "#{user_id}-mentioned_notification_count"
+    end
+
     def mentioned_and_unread_notification_count(user)
       Rails.cache.fetch "#{user.id}-mentioned_and_unread_notification_count" do
         user.notifications.where(kind: :mentioned, read: false).count
       end
+    end
+
+    def delete_mentioned_and_unread_notification_count(user_id)
+      Rails.cache.delete "#{user_id}-mentioned_and_unread_notification_count"
     end
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -47,203 +47,213 @@ class Notification < ApplicationRecord
     select('DISTINCT ON (link) *').order(link: :asc, created_at: :desc, id: :desc) # 「作成日時が最新の通知」が複数ある場合に取得する1件の通知を一定にするため、ORDER BY の最後に id の降順を指定した
   }
 
-  def self.came_comment(comment, receiver, message)
-    Notification.create!(
-      kind: kinds[:came_comment],
-      user: receiver,
-      sender: comment.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(comment.commentable),
-      message: message,
-      read: false
-    )
+  after_create NotificationCallbacks.new
+  after_update NotificationCallbacks.new
+  after_destroy NotificationCallbacks.new
+
+  class << self
+    def came_comment(comment, receiver, message)
+      Notification.create!(
+        kind: kinds[:came_comment],
+        user: receiver,
+        sender: comment.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(comment.commentable),
+        message: message,
+        read: false
+      )
+    end
+
+    def checked(check)
+      Notification.create!(
+        kind: kinds[:checked],
+        user: check.receiver,
+        sender: check.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(check.checkable),
+        message: "#{check.sender.login_name}さんが#{check.checkable.title}を確認しました。",
+        read: false
+      )
+    end
+
+    def mentioned(mentionable, receiver)
+      Notification.create!(
+        kind: kinds[:mentioned],
+        user: receiver,
+        sender: mentionable.sender,
+        link: mentionable.path,
+        message: "#{mentionable.sender.login_name}さんからメンションがきました。",
+        read: false
+      )
+    end
+
+    def submitted(subject, receiver, message)
+      Notification.create!(
+        kind: kinds[:submitted],
+        user: receiver,
+        sender: subject.user,
+        link: Rails.application.routes.url_helpers.polymorphic_path(subject),
+        message: message,
+        read: false
+      )
+    end
+
+    def came_answer(answer)
+      Notification.create!(
+        kind: kinds[:answered],
+        user: answer.receiver,
+        sender: answer.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
+        message: "#{answer.user.login_name}さんから回答がありました。",
+        read: false
+      )
+    end
+
+    def post_announcement(announce, receiver)
+      Notification.create!(
+        kind: kinds[:announced],
+        user: receiver,
+        sender: announce.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(announce),
+        message: "お知らせ「#{announce.title}」",
+        read: false
+      )
+    end
+
+    def came_question(question, receiver)
+      Notification.create!(
+        kind: kinds[:came_question],
+        user: receiver,
+        sender: question.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(question),
+        message: "#{question.user.login_name}さんから質問がありました。",
+        read: false
+      )
+    end
+
+    def first_report(report, receiver)
+      Notification.create!(
+        kind: kinds[:first_report],
+        user: receiver,
+        sender: report.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(report),
+        message: "#{report.user.login_name}さんがはじめての日報を書きました！",
+        read: false
+      )
+    end
+
+    def watching_notification(watchable, receiver, comment)
+      watchable_user = watchable.user
+      sender = comment.user
+      Notification.create!(
+        kind: kinds[:watching],
+        user: receiver,
+        sender: sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(watchable),
+        message: "#{watchable_user.login_name}さんの【 #{watchable.notification_title} 】に#{comment.user.login_name}さんがコメントしました。",
+        read: false
+      )
+    end
+
+    def retired(sender, receiver)
+      Notification.create!(
+        kind: kinds[:retired],
+        user: receiver,
+        sender: sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(sender),
+        message: "#{sender.login_name}さんが退会しました。",
+        read: false
+      )
+    end
+
+    def three_months_after_retirement(sender, receiver)
+      Notification.create!(
+        kind: kinds[:retired],
+        user: receiver,
+        sender: sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(sender),
+        message: "#{I18n.t('.retire_notice', user: sender.login_name)}Discord ID: #{sender.discord_account}, ユーザーページ: https://bootcamp.fjord.jp/users/#{sender.id}",
+        read: false
+      )
+    end
+
+    def trainee_report(report, receiver)
+      Notification.create!(
+        kind: kinds[:trainee_report],
+        user: receiver,
+        sender: report.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(report),
+        message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
+        read: false
+      )
+    end
+
+    def moved_up_event_waiting_user(event, receiver)
+      Notification.create!(
+        kind: kinds[:moved_up_event_waiting_user],
+        user: receiver,
+        sender: event.user,
+        link: Rails.application.routes.url_helpers.polymorphic_path(event),
+        message: "#{event.title}で、補欠から参加に繰り上がりました。",
+        read: false
+      )
+    end
+
+    def create_page(page, reciever)
+      Notification.create!(
+        kind: kinds[:create_pages],
+        user: reciever,
+        sender: page.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(page),
+        message: "#{page.user.login_name}さんがDocsに#{page.title}を投稿しました。",
+        read: false
+      )
+    end
+
+    def following_report(report, receiver)
+      Notification.create!(
+        kind: kinds[:following_report],
+        user: receiver,
+        sender: report.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(report),
+        message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
+        read: false
+      )
+    end
+
+    def chose_correct_answer(answer, receiver)
+      Notification.create!(
+        kind: kinds[:chose_correct_answer],
+        user: receiver,
+        sender: answer.receiver,
+        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
+        message: "#{answer.receiver.login_name}さんの質問【 #{answer.question.title} 】で#{answer.sender.login_name}さんの回答がベストアンサーに選ばれました。",
+        read: false
+      )
+    end
+
+    def consecutive_sad_report(report, receiver)
+      Notification.create!(
+        kind: kinds[:consecutive_sad_report],
+        user: receiver,
+        sender: report.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(report),
+        message: "#{report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。",
+        read: false
+      )
+    end
+
+    def assigned_as_checker(product, receiver)
+      Notification.create!(
+        kind: 16,
+        user: receiver,
+        sender: product.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(product),
+        message: "#{product.user.login_name}さんの提出物#{product.title}の担当になりました。",
+        read: false
+      )
+    end
   end
 
-  def self.checked(check)
-    Notification.create!(
-      kind: kinds[:checked],
-      user: check.receiver,
-      sender: check.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(check.checkable),
-      message: "#{check.sender.login_name}さんが#{check.checkable.title}を確認しました。",
-      read: false
-    )
-  end
-
-  def self.mentioned(mentionable, receiver)
-    Notification.create!(
-      kind: kinds[:mentioned],
-      user: receiver,
-      sender: mentionable.sender,
-      link: mentionable.path,
-      message: "#{mentionable.sender.login_name}さんからメンションがきました。",
-      read: false
-    )
-  end
-
-  def self.submitted(subject, receiver, message)
-    Notification.create!(
-      kind: kinds[:submitted],
-      user: receiver,
-      sender: subject.user,
-      link: Rails.application.routes.url_helpers.polymorphic_path(subject),
-      message: message,
-      read: false
-    )
-  end
-
-  def self.came_answer(answer)
-    Notification.create!(
-      kind: kinds[:answered],
-      user: answer.receiver,
-      sender: answer.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
-      message: "#{answer.user.login_name}さんから回答がありました。",
-      read: false
-    )
-  end
-
-  def self.post_announcement(announce, receiver)
-    Notification.create!(
-      kind: kinds[:announced],
-      user: receiver,
-      sender: announce.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(announce),
-      message: "お知らせ「#{announce.title}」",
-      read: false
-    )
-  end
-
-  def self.came_question(question, receiver)
-    Notification.create!(
-      kind: kinds[:came_question],
-      user: receiver,
-      sender: question.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(question),
-      message: "#{question.user.login_name}さんから質問がありました。",
-      read: false
-    )
-  end
-
-  def self.first_report(report, receiver)
-    Notification.create!(
-      kind: kinds[:first_report],
-      user: receiver,
-      sender: report.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(report),
-      message: "#{report.user.login_name}さんがはじめての日報を書きました！",
-      read: false
-    )
-  end
-
-  def self.watching_notification(watchable, receiver, comment)
-    watchable_user = watchable.user
-    sender = comment.user
-    Notification.create!(
-      kind: kinds[:watching],
-      user: receiver,
-      sender: sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(watchable),
-      message: "#{watchable_user.login_name}さんの【 #{watchable.notification_title} 】に#{comment.user.login_name}さんがコメントしました。",
-      read: false
-    )
-  end
-
-  def self.retired(sender, receiver)
-    Notification.create!(
-      kind: kinds[:retired],
-      user: receiver,
-      sender: sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(sender),
-      message: "#{sender.login_name}さんが退会しました。",
-      read: false
-    )
-  end
-
-  def self.three_months_after_retirement(sender, receiver)
-    Notification.create!(
-      kind: kinds[:retired],
-      user: receiver,
-      sender: sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(sender),
-      message: "#{I18n.t('.retire_notice', user: sender.login_name)}Discord ID: #{sender.discord_account}, ユーザーページ: https://bootcamp.fjord.jp/users/#{sender.id}",
-      read: false
-    )
-  end
-
-  def self.trainee_report(report, receiver)
-    Notification.create!(
-      kind: kinds[:trainee_report],
-      user: receiver,
-      sender: report.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(report),
-      message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
-      read: false
-    )
-  end
-
-  def self.moved_up_event_waiting_user(event, receiver)
-    Notification.create!(
-      kind: kinds[:moved_up_event_waiting_user],
-      user: receiver,
-      sender: event.user,
-      link: Rails.application.routes.url_helpers.polymorphic_path(event),
-      message: "#{event.title}で、補欠から参加に繰り上がりました。",
-      read: false
-    )
-  end
-
-  def self.create_page(page, reciever)
-    Notification.create!(
-      kind: kinds[:create_pages],
-      user: reciever,
-      sender: page.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(page),
-      message: "#{page.user.login_name}さんがDocsに#{page.title}を投稿しました。",
-      read: false
-    )
-  end
-
-  def self.following_report(report, receiver)
-    Notification.create!(
-      kind: kinds[:following_report],
-      user: receiver,
-      sender: report.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(report),
-      message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
-      read: false
-    )
-  end
-
-  def self.chose_correct_answer(answer, receiver)
-    Notification.create!(
-      kind: kinds[:chose_correct_answer],
-      user: receiver,
-      sender: answer.receiver,
-      link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
-      message: "#{answer.receiver.login_name}さんの質問【 #{answer.question.title} 】で#{answer.sender.login_name}さんの回答がベストアンサーに選ばれました。",
-      read: false
-    )
-  end
-
-  def self.consecutive_sad_report(report, receiver)
-    Notification.create!(
-      kind: kinds[:consecutive_sad_report],
-      user: receiver,
-      sender: report.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(report),
-      message: "#{report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。",
-      read: false
-    )
-  end
-
-  def self.assigned_as_checker(product, receiver)
-    Notification.create!(
-      kind: 16,
-      user: receiver,
-      sender: product.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(product),
-      message: "#{product.user.login_name}さんの提出物#{product.title}の担当になりました。",
-      read: false
-    )
+  def unread?
+    !read
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -256,4 +256,15 @@ class Notification < ApplicationRecord
   def unread?
     !read
   end
+
+  def unique?(scope: [])
+    !other_duplicates(scope: scope).exists?
+  end
+
+  private
+
+  def other_duplicates(scope: [])
+    duplicates = scope.inject(Notification.all) { |notifications, scope_item| notifications.where(scope_item => self[scope_item]) }
+    duplicates.where.not(id: id)
+  end
 end

--- a/app/models/notification_callbacks.rb
+++ b/app/models/notification_callbacks.rb
@@ -2,22 +2,32 @@
 
 class NotificationCallbacks
   def after_create(notification)
-    return unless notification.mentioned?
+    return unless notification.mentioned? && notification.unique?(scope: %i[link user_id kind])
 
     Cache.delete_mentioned_notification_count(notification.user.id)
+
+    return unless notification.unread? && notification.unique?(scope: %i[link user_id kind read])
+
     Cache.delete_mentioned_and_unread_notification_count(notification.user.id)
   end
 
   def after_update(notification)
-    return unless notification.mentioned? && notification.saved_change_to_attribute?('read')
+    return unless notification.mentioned? && notification.saved_change_to_attribute?('read', from: false, to: true)
+
+    notification.assign_attributes(read: false)
+
+    return unless notification.unique?(scope: %i[link user_id kind read])
 
     Cache.delete_mentioned_and_unread_notification_count(notification.user.id)
   end
 
   def after_destroy(notification)
-    return unless notification.mentioned?
+    return unless notification.mentioned? && notification.unique?(scope: %i[link user_id kind])
 
     Cache.delete_mentioned_notification_count(notification.user.id)
-    Cache.delete_mentioned_and_unread_notification_count(notification.user.id) if notification.unread?
+
+    return unless notification.unread? && notification.unique?(scope: %i[link user_id kind read])
+
+    Cache.delete_mentioned_and_unread_notification_count(notification.user.id)
   end
 end

--- a/app/models/notification_callbacks.rb
+++ b/app/models/notification_callbacks.rb
@@ -2,20 +2,20 @@
 
 class NotificationCallbacks
   def after_create(notification)
-    return unless notification.kind == 'mentioned'
+    return unless notification.mentioned?
 
     Cache.delete_mentioned_notification_count(notification.user.id)
     Cache.delete_mentioned_and_unread_notification_count(notification.user.id)
   end
 
   def after_update(notification)
-    return unless notification.kind == 'mentioned' && notification.saved_change_to_attribute?('read')
+    return unless notification.mentioned? && notification.saved_change_to_attribute?('read')
 
     Cache.delete_mentioned_and_unread_notification_count(notification.user.id)
   end
 
   def after_destroy(notification)
-    return unless notification.kind == 'mentioned'
+    return unless notification.mentioned?
 
     Cache.delete_mentioned_notification_count(notification.user.id)
     Cache.delete_mentioned_and_unread_notification_count(notification.user.id) if notification.unread?

--- a/app/models/notification_callbacks.rb
+++ b/app/models/notification_callbacks.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class NotificationCallbacks
+  def after_create(notification)
+    return unless notification.kind == 'mentioned'
+
+    Cache.delete_mentioned_notification_count(notification.user.id)
+    Cache.delete_mentioned_and_unread_notification_count(notification.user.id)
+  end
+
+  def after_update(notification)
+    return unless notification.kind == 'mentioned' && notification.saved_change_to_attribute?('read')
+
+    Cache.delete_mentioned_and_unread_notification_count(notification.user.id)
+  end
+
+  def after_destroy(notification)
+    return unless notification.kind == 'mentioned'
+
+    Cache.delete_mentioned_notification_count(notification.user.id)
+    Cache.delete_mentioned_and_unread_notification_count(notification.user.id) if notification.unread?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -592,6 +592,12 @@ class User < ApplicationRecord
     end
   end
 
+  def mark_all_as_read_and_delete_cache_of_unreads(target_notifications: nil)
+    target_notifications ||= notifications
+    target_notifications.update_all(read: true, updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    Cache.delete_mentioned_and_unread_notification_count(id)
+  end
+
   private
 
   def password_required?

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -12,7 +12,8 @@
           = link_to notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip do
             - if target == :mention
               | #{t('notification.mention')} （#{current_user.notifications.where(kind: :mentioned).count}）
-              .page-tabs__item-count.a-notification-count
-                = current_user.notifications.where(kind: :mentioned, read: false).count
+              - if current_user.notifications.where(kind: :mentioned, read: false).count.positive?
+                .page-tabs__item-count.a-notification-count
+                  = current_user.notifications.where(kind: :mentioned, read: false).count
             - else
               = t("notification.#{target}")

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -9,4 +9,10 @@
               = current_user.notifications.unreads.latest_of_each_link.size
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
-          = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip
+          = link_to notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip do
+            - if target == :mention
+              | #{t('notification.mention')} （#{current_user.notifications.where(kind: :mentioned).count}）
+              .page-tabs__item-count.a-notification-count
+                = current_user.notifications.where(kind: :mentioned, read: false).count
+            - else
+              = t("notification.#{target}")

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -11,9 +11,9 @@
         li.page-tabs__item
           = link_to notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip do
             - if target == :mention
-              | #{t('notification.mention')} （#{current_user.notifications.where(kind: :mentioned).count}）
-              - if current_user.notifications.where(kind: :mentioned, read: false).count.positive?
+              | #{t('notification.mention')} （#{Cache.mentioned_notification_count(current_user)}）
+              - if Cache.mentioned_and_unread_notification_count(current_user).positive?
                 .page-tabs__item-count.a-notification-count
-                  = current_user.notifications.where(kind: :mentioned, read: false).count
+                  = Cache.mentioned_and_unread_notification_count(current_user)
             - else
               = t("notification.#{target}")

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -103,8 +103,18 @@ comment17:
   commentable: product63 (Product)
   description: "自分が担当する提出物に返信する"
 
+comment18:
+  user: hajime
+  commentable: report7 (Report)
+  description: "@kimura 1つ目のメンションありの未読通知を発生させる"
+
+comment19:
+  user: yamada
+  commentable: report7 (Report)
+  description: "@kimura 2つ目のメンションありの未読通知を発生させる"
+
 <% (1..20).each do |i| %>
-comment<%= i + 17 %>:
+comment<%= i + 19 %>:
   user: komagata
   commentable: product11 (Product)
   description: <%= "提出物のコメント#{i}です。" %>

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -22,6 +22,30 @@ notification_mentioned:
   link: "/reports/<%= ActiveRecord::FixtureSet.identify(:report5) %>#comment_<%= ActiveRecord::FixtureSet.identify(:comment9)%>"
   read: false
 
+notification_mentioned_and_already_read:
+  kind: 2
+  user: kimura
+  sender: machida
+  message: machidaさんからメンションがきました。
+  link: "/reports/<%= ActiveRecord::FixtureSet.identify(:report6) %>#comment_<%= ActiveRecord::FixtureSet.identify(:comment17)%>"
+  read: true
+
+notification_mentioned_and_unread_1:
+  kind: 2
+  user: kimura
+  sender: hajime
+  message: hajimeさんからメンションがきました。
+  link: "/reports/<%= ActiveRecord::FixtureSet.identify(:report7) %>#comment_<%= ActiveRecord::FixtureSet.identify(:comment18)%>"
+  read: false
+
+notification_mentioned_and_unread_2:
+  kind: 2
+  user: kimura
+  sender: yamada
+  message: yamadaさんからメンションがきました。
+  link: "/reports/<%= ActiveRecord::FixtureSet.identify(:report8) %>#comment_<%= ActiveRecord::FixtureSet.identify(:comment19)%>"
+  read: false
+
 notification_read:
   kind: 0
   user: sotugyou

--- a/test/models/caches/mentioned_and_unread_notification_count_of_each_user_test.rb
+++ b/test/models/caches/mentioned_and_unread_notification_count_of_each_user_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MentionedAndUnreadNotificationCountOfEachUserTest < ActiveSupport::TestCase
+  test 'cached count of unread mentions increases by 1 after creating a mention with new link' do
+    receiver = users(:kimura)
+
+    assert_difference -> { Cache.mentioned_and_unread_notification_count(receiver) }, 1 do
+      Notification.create!(kind: :mentioned, user: receiver, sender: users(:machida), link: 'path/to/new/link', read: false)
+    end
+  end
+
+  test 'cached count of unread mentions decreases by 1 after reading an unread mention with unique link' do
+    receiver = users(:kimura)
+    unread_mention_with_unique_link = Notification.create!(kind: :mentioned, user: receiver, sender: users(:machida), link: 'path/to/unique/link', read: false)
+
+    assert_difference -> { Cache.mentioned_and_unread_notification_count(receiver) }, -1 do
+      unread_mention_with_unique_link.update!(read: true)
+    end
+  end
+
+  test 'cached count of unread mentions decreases by 1 after destroying an unread mention with unique link' do
+    receiver = users(:kimura)
+    unread_mention_with_unique_link = Notification.create!(kind: :mentioned, user: receiver, sender: users(:machida), link: 'path/to/unique/link', read: false)
+
+    assert_difference -> { Cache.mentioned_and_unread_notification_count(receiver) }, -1 do
+      unread_mention_with_unique_link.destroy!
+    end
+  end
+end

--- a/test/models/caches/mentioned_notification_count_of_each_user_test.rb
+++ b/test/models/caches/mentioned_notification_count_of_each_user_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MentionedNotificationCountOfEachUserTest < ActiveSupport::TestCase
+  test 'cached count of mentioned notifications increases by 1 after creating a mentioned notification with new link' do
+    receiver = users(:kimura)
+
+    assert_difference -> { Cache.mentioned_notification_count(receiver) }, 1 do
+      Notification.create!(kind: :mentioned, user: receiver, sender: users(:machida), link: 'path/to/new/link')
+    end
+  end
+
+  test 'cached count of mentioned notifications decreases by 1 after destroying an mentioned notification with unique link' do
+    receiver = users(:kimura)
+    mentioned_notification_with_unique_link = Notification.create!(kind: :mentioned, user: receiver, sender: users(:machida), link: 'path/to/unique/link')
+
+    assert_difference -> { Cache.mentioned_notification_count(receiver) }, -1 do
+      mentioned_notification_with_unique_link.destroy!
+    end
+  end
+end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -333,7 +333,7 @@ class NotificationsTest < ApplicationSystemTestCase
 
   test 'show the total number of mentions on the mentioned tab' do
     user = users(:kimura)
-    expected_total_number_of_mentions = user.notifications.where(kind: :mentioned).count
+    expected_total_number_of_mentions = user.notifications.by_target(:mention).count
 
     visit_with_auth '/notifications', user.login_name
 
@@ -344,7 +344,7 @@ class NotificationsTest < ApplicationSystemTestCase
 
   test 'show the number of unread mentions on the badge of the mentioned tab' do
     user = users(:kimura)
-    expected_number_of_unread_mentions = user.notifications.where(kind: :mentioned, read: false).count
+    expected_number_of_unread_mentions = user.notifications.by_target(:mention).where(read: false).count
 
     visit_with_auth '/notifications', user.login_name
 
@@ -357,7 +357,7 @@ class NotificationsTest < ApplicationSystemTestCase
 
   test 'don\'t show the badge on the mentioned tab if no unread mentions' do
     user = users(:kimura)
-    user.notifications.where(kind: :mentioned, read: false).update_all(read: true) # rubocop:disable Rails/SkipsModelValidations
+    user.notifications.by_target(:mention).where(read: false).update_all(read: true) # rubocop:disable Rails/SkipsModelValidations
 
     visit_with_auth '/notifications', user.login_name
 

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -330,4 +330,39 @@ class NotificationsTest < ApplicationSystemTestCase
     wait_for_vuejs
     assert_no_text "yamadaさんの提出物#{products(:product1).title}の担当になりました。"
   end
+
+  test 'show the total number of mentions on the mentioned tab' do
+    user = users(:kimura)
+    expected_total_number_of_mentions = user.notifications.where(kind: :mentioned).count
+
+    visit_with_auth '/notifications', user.login_name
+
+    within '.page-tabs__item', text: 'メンション' do
+      assert_text format('メンション （%d）', expected_total_number_of_mentions)
+    end
+  end
+
+  test 'show the number of unread mentions on the badge of the mentioned tab' do
+    user = users(:kimura)
+    expected_number_of_unread_mentions = user.notifications.where(kind: :mentioned, read: false).count
+
+    visit_with_auth '/notifications', user.login_name
+
+    within '.page-tabs__item', text: 'メンション' do
+      actual_number_of_unread_mentions = find('.a-notification-count').text.to_i
+
+      assert_equal expected_number_of_unread_mentions, actual_number_of_unread_mentions
+    end
+  end
+
+  test 'don\'t show the badge on the mentioned tab if no unread mentions' do
+    user = users(:kimura)
+    user.notifications.where(kind: :mentioned, read: false).update_all(read: true) # rubocop:disable Rails/SkipsModelValidations
+
+    visit_with_auth '/notifications', user.login_name
+
+    within '.page-tabs__item', text: 'メンション' do
+      assert_no_selector '.a-notification-count'
+    end
+  end
 end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -333,7 +333,7 @@ class NotificationsTest < ApplicationSystemTestCase
 
   test 'show the total number of mentions on the mentioned tab' do
     user = users(:kimura)
-    expected_total_number_of_mentions = user.notifications.by_target(:mention).count
+    expected_total_number_of_mentions = user.notifications.by_target(:mention).latest_of_each_link.size
 
     visit_with_auth '/notifications', user.login_name
 
@@ -344,7 +344,7 @@ class NotificationsTest < ApplicationSystemTestCase
 
   test 'show the number of unread mentions on the badge of the mentioned tab' do
     user = users(:kimura)
-    expected_number_of_unread_mentions = user.notifications.by_target(:mention).where(read: false).count
+    expected_number_of_unread_mentions = user.notifications.by_target(:mention).unreads.latest_of_each_link.size
 
     visit_with_auth '/notifications', user.login_name
 


### PR DESCRIPTION
## 目的

Ref: #3543

## やったこと

### 通知一覧画面の「メンション」タブに全件数と未読件数を表示

- 全件数
    - メンションありの通知すべての件数のこと
    - 「メンション」タブのテキストに表示
    - 例: 全件数が2件の場合、「メンション （2）」とタブに表示
- 未読件数
    - メンションありの通知の未読件数のこと
    - 「メンション」タブのバッジに表示
    - 未読件数が 0 件の場合はバッジを表示しないようにした

### キャッシュの保持

全件数・未読件数をユーザー単位でキャッシュに保持するようにした

### キャッシュの削除

全件数・未読件数が増減したときにキャッシュを削除するようにした

※ キャッシュを削除する具体的な条件は↓の表に記載

### テストの追加

- 全件数・未読件数を表示できていることを確認するシステムテストを追加
- キャッシュを更新できていることを確認するモデルテストを追加

## 画面の変更内容

**変更前**

![Screen Shot 2021-11-30 at 17 35 57](https://user-images.githubusercontent.com/15713392/144013404-c87e7e38-d3aa-495d-a667-cebf6a9d1a19.png)

**変更後**

![Screen Shot 2021-11-30 at 17 36 31](https://user-images.githubusercontent.com/15713392/144013442-d478aced-947f-42fb-8344-f0032edee00a.png)

※ 未読が0件の場合はバッジを表示しない

![image](https://user-images.githubusercontent.com/15713392/144361382-ae5cb00a-7d29-4259-9769-0ae48d0debdd.png)

## 動作確認

### すべての確認項目に共通すること

- `$ rails dev:cache`を実行してキャッシュを有効にした状態で確認する
    - 詳細は下記の「動作確認をするときの注意事項」に記載
- 確認対象は「メンション」タブの全件数（以下、メンション全件数）もしくはバッジの未読件数（以下、メンション未読件数）
- 操作の始めに通知一覧ページのメンション全件数もしくは未読件数を確認する
    - http://127.0.0.1:3000/notifications
- 通知の受信者のログイン名は `komagata`、送信者は `komagata` 以外
- 「送信者がコメントするページ」もしくは「受信者が既読にする未読のメンション通知」それぞれ、受信者の既存のメンション通知の中で唯一の通知元リンクであること
    - 他のメンション通知と通知元リンクが重複している場合、メンションの全件数と未読件数どちらも増減しない

### 確認項目

- [ ] 送信者が受信者へメンションありのコメントをしたあと、受信者のメンション全件数が1件増えていること
- [ ] 送信者が受信者へメンションありのコメントをしたあと、受信者のメンション未読件数が1件増えていること
- [ ] 受信者が未読のメンションを既読したあと、受信者のメンション未読件数が1件減っていること
- [ ] 受信者が未読のメンションをすべて既読したあと、受信者の「メンション」タブにバッジが表示されていないこと

--- 

以下、補足説明

## 動作確認をするときの注意事項

development モードと test モードの場合はデフォルトでキャッシュが無効になっているため、ローカルでサーバーを起動して動作確認するとき（development モードのとき）や `$ rails test xxx` を実行するとき（test モードのとき）は、以下のようにして事前にキャッシュを有効にしておく必要があります。

### development モード

- `$ rails dev:cache`を実行してキャッシュのオン/オフを切り替える（オンにする）
- （参考）[development環境のキャッシュ](https://railsguides.jp/caching_with_rails.html#development%E7%92%B0%E5%A2%83%E3%81%AE%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5)

### test モード

`config/environments/test.rb` を修正し、キャッシュストアとして `:memory_store` （[ActiveSupport::Cache::MemoryStore](https://railsguides.jp/caching_with_rails.html#activesupport-cache-memorystore) ）を使うように設定する
    
```
diff --git a/config/environments/test.rb b/config/environments/test.rb
index e080eba6d..c20b14524 100644
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :memory_store

   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

```

## キャッシュを削除する条件

以下の表の条件でキャッシュを削除するようにした。

※表の読み方: 【モデル】のレコードを 【作成/更新/削除】するときにレコードが【条件1】かつ【条件2】かつ【条件3】... の場合はキャッシュを削除する。なお、その後はキャッシュに保持する値が【キャッシュの増減値】される。

### 全件数のキャッシュを削除する条件

| モデル       | 作成/更新/削除 | 条件1            | 条件2                                                                      | キャッシュの増減値 |
|--------------|----------------|------------------|----------------------------------------------------------------------------|--------------------|
| Notification | 作成           | 種類がメンション | 通知元リンクが受信者の全てのメンション通知の通知元リンクと重複しない |                 +1 |
| Notification | 削除           | 種類がメンション | 通知元リンクが受信者の他のメンション通知の通知元リンクと重複しない   |                 -1 |
|              |                |                  |                                                                            |                    |

### 未読件数のキャッシュを削除する条件

| モデル       | 作成/更新/削除 | 条件1            | 条件2                                                                            | 条件3        | 条件4        | キャッシュの増減値 |
|--------------|----------------|------------------|----------------------------------------------------------------------------------|--------------|--------------|--------------------|
| Notification | 作成           | 種類がメンション | 通知元リンクが受信者の全ての未読のメンション通知の通知元リンクと重複しない | 未読         | （なし）     | +1                |
| Notification | 更新           | 種類がメンション | 通知元リンクが受信者の他の未読のメンション通知の通知元リンクと重複しない   | 更新前は未読 | 更新後は既読 | -1                 |
| Notification | 削除           | 種類がメンション | 通知元リンクが受信者の他の未読のメンション通知の通知元リンクと重複しない   | 未読         | （なし）     | -1                 |

※ 複数の通知を一度に既読へ更新する際は、コールバックを使わずに（すなわち↑の表の条件とは別に）「既読への更新」と「キャッシュの削除」をまとめたメソッドを使うようにして対応した

<details><summary>懸念事項（解消済み）</summary><div>

# 懸念事項

※ こちらの懸念事項は 2021/12/01(水)の「ふりかえり・計画ミーティング」で komagata さんに相談し、「 `update` に変更して大丈夫」という旨の返事をいただきました。
※ 2021/12/06 追記: 「ログインユーザーに紐づく全ての通知の一括更新」の際は `update_all` を `update` に変更せず、 `update_all` の後にキャッシュの削除処理を追加するようにしました。判断理由等の詳細は https://github.com/fjordllc/bootcamp/pull/3642#discussion_r761721220 に記載しています。
※ 2021/12/16 追記: `update_all` とキャッシュの削除の処理をまとめたメソッドを追加し、複数の通知を既読へ更新している箇所ではそのメソッドを使用することとした（つまり `update_all` を `update` に変えることがなくなった）ため、この懸念事項については考慮する必要がなくなった

## `update_all` を `update` に変更したことに伴う影響を許容できるかどうか

### `update_all` で一括更新されている対象

通知元の URL（リンク）が同じ未読通知
※通知をたどってその URL を開いたときに既読へ一括更新される

### 変更した理由

通知を既読へ更新するときにコールバックが実行されるようにするため
※ `update_all` ではコールバックが実行されないため、 `update` を使うようにした

### 変更に伴う影響

- 複数レコードの更新の仕方が変更
    - 一括更新ではなく一つずつ更新するようになった
- 更新する時に処理が追加
    - コールバックの実行
    - バリデーションの実行
    - `updated_at` カラムの更新

### 気になっていること

`update` に変えたことで、以下のような問題が生じないだろうか？

- 更新の処理が重たくならないか？
    - 以下のようなケースで処理が重たくなるかもしれない？
        - 同じページにあるメンションありのコメントから発生している未読の通知がたくさん溜まっているユーザーがそのページを表示するとき
- 通知の日時として更新日時を表示する箇所において、意図しない日時が表示されるようにならないか？
    - もともと Notification モデルの `updated_at` カラムは画面の表示に使用されてなさそうだったので、大丈夫そう？
    - 以前、日時として更新日時を表示していたことはあったみたい
        - その箇所は、以下の PR で更新日時ではなく登録日時を表示するように変更された
            - [https://github.com/fjordllc/bootcamp/pull/1724](https://github.com/fjordllc/bootcamp/pull/1724)
- 目的とするコールバック以外にも実行されてしまうコールバックはないか？
    - もともと Notification モデルにはコールバックを利用した処理は実装されていなかった
      - そのため起こり得るコールバックは、この PR で追加したコールバックのみ
    - この PR の実装では、目的とするコールバックのみが実行されているので、問題はなさそう
</div></details>