### PR TITLE
日報一覧と最新の日報一覧のHTML特殊文字をエスケープしないように変更

### DIFF
--- a/app/views/api/reports/_report.json.jbuilder
+++ b/app/views/api/reports/_report.json.jbuilder
@@ -1,5 +1,5 @@
 json.id report.id
-json.title truncate(raw(report.title), length: 46)
+json.title truncate(report.title, {length: 46, escape: false})
 json.reportedOn l(report.reported_on)
 json.url report_url(report)
 json.editURL edit_report_path(report)

--- a/app/views/api/reports/recents/index.json.jbuilder
+++ b/app/views/api/reports/recents/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.array! @reports do |report|
   json.id report.id
-  json.title truncate(raw(report.title), length: 46)
+  json.title truncate(report.title, {length: 46, escape: false})
   json.reported_on l(report.reported_on)
   json.url report_url(report)
   json.check report.checks.present?


### PR DESCRIPTION
## 目的

- Refs: #3613 

## バグの原因

日報一覧および最新の日報一覧に表示するタイトルは、46文字を超える場合、短縮して表示する（`truncate`）

`truncate`のデフォルトの戻り値は必ずHTMLエスケープされた値である。
タイトルが46文字以下の場合は、`raw`で取得したタイトルは加工されず、`truncate`によるエスケープの影響を受けない形式になっている（Class: `ActiveSupport::SafeBuffer`）。
一方、タイトルが46文字を超える場合は、新たに短縮した文字列を生成するため、`truncate`によるエスケープの対象になってしまう。

そのため、同じHTML特殊文字を含むタイトルでも、46文字を境にしてエスケープがされている/いない状況が発生していた。

参考：https://github.com/rails/rails/blob/main/actionview/lib/action_view/helpers/text_helper.rb#L74

## やったこと

- `ActionView::Helpers::TextHelper#truncate`の`:escape`オプションを利用して、いかなる場合でもHTMLがエスケープされないようにする。
- 既存の`raw`によるエスケープ回避は、今回実装したものと内容が重複するため削除する。

## UIの修正

**変更前**

![image](https://user-images.githubusercontent.com/61409641/144091608-172fe7bf-64c9-49ab-8685-bd31a628079f.png)


**変更後**

![image](https://user-images.githubusercontent.com/61409641/144091662-b0563d20-c6ae-4fda-825a-95200e5f06a2.png)
