### PR TITLE
Q&A個別ページに質問者のIDとユーザー名を表示する

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -15,7 +15,7 @@
           .thread-header-metas__start
             .thread-header-metas__meta
               a.a-user-name(:href='`/users/${question.user.id}`')
-                | {{ question.user.login_name }}
+                | {{ question.user.long_name }}
             .thread-header-metas__meta
               .a-meta
                 time.thread_header_date-value(


### PR DESCRIPTION
# 変更前

![image](https://user-images.githubusercontent.com/15277293/144204718-454f3bb3-40c4-4b97-b925-1965696afe37.png)


# 変更後

![image](https://user-images.githubusercontent.com/15277293/144204366-11e484cc-f72e-4e8c-9024-2504a6ac12de.png)


issue #3153 