### PR TITLE
管理画面の企業一覧にあるDescriptionを削除

### DIFF
--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -23,7 +23,6 @@ header.page-header
           tr.admin-table__labels
             th.admin-table__label = Company.human_attribute_name :name
             th.admin-table__label = Company.human_attribute_name :logo
-            th.admin-table__label = Company.human_attribute_name :description
             th.admin-table__label = Company.human_attribute_name :website
             th.admin-table__label.actions リンク
             th.admin-table__label.actions 操作
@@ -36,8 +35,6 @@ header.page-header
               td.admin-table__item-value.is-text-align-center
                 - if company.logo.attached?
                   = image_tag company.logo_url, class: 'admin-table__item-logo-image'
-              td.admin-table__item-value
-                = company.description
               td.admin-table__item-value
                 = company.website
               td.admin-table__item-value.is-text-align-center


### PR DESCRIPTION
issue #3650 

## 目的
[管理画面・企業一覧でDescriptionを削除したい #3650](https://github.com/fjordllc/bootcamp/issues/3650)

## やったこと
管理画面にある企業一覧のDescriptionを削除しました。

### 修正前
<img width="855" alt="管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/144693538-542c6d8d-2f4e-47c9-a83e-e528681c9dd2.png">

### 修正後
<img width="861" alt="管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/144693550-610b68d8-98ef-414b-91ac-b75b5859ca66.png">


