### PR TITLE
[メンター向け]提出物の「自分の担当」タブのカッコの中の数字では「確認済の提出物」は含めない

### DIFF
--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -23,7 +23,7 @@
               = Cache.unassigned_product_count
       li.page-tabs__item.is-only-mentor
         = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
-          | 自分の担当 （#{Product.self_assigned_product(current_user.id).size}）
+          | 自分の担当 （#{Product.self_assigned_product(current_user.id).unchecked.size}）
           - if Cache.self_assigned_no_replied_product_count(current_user.id).positive?
             .page-tabs__item-count.a-notification-count.is-only-mentor
               = Cache.self_assigned_no_replied_product_count(current_user.id)


### PR DESCRIPTION
issue:  #3626 

## 概要
現在：メンター・管理者向けの提出物ページにある「自分の担当」タブの（）内数値は「既に確認済みの提出物」も含めた、自分が担当した（している）全ての提出物が表示される。
行うこと：「自分の担当」タブの（）内数値には「既に確認済みの提出物」は含めない。現在担当中かつまだ完了していない提出物のみの数値を表示する。

## 変更前
担当提出物数　8
確認を押してない提出物数　2
未返信提出物数　2

「自分の担当」タブの（）内数値には既に確認済の提出物も含まれている。
<img width="813" alt="スクリーンショット 2021-12-07 10 31 16" src="https://user-images.githubusercontent.com/80372144/144950113-3c57dc5e-bde8-485f-8ce0-adf921ed6c37.png">


## 変更後
担当提出物数　8
確認を押してない提出物数　2
未返信提出物数　2

「自分の担当」タブの（）内数値は「確認を押してない提出物」の数値を表示している。
<img width="748" alt="スクリーンショット 2021-12-07 10 32 40" src="https://user-images.githubusercontent.com/80372144/144951157-07eb46e0-dcf7-427c-b9b2-d98e81b5f778.png">
