### PR TITLE
メンターダッシュボード、確認数の集計 へのリンクを削除

### DIFF
--- a/app/views/application/_mentor_menu.html.slim
+++ b/app/views/application/_mentor_menu.html.slim
@@ -10,13 +10,3 @@
       = link_to new_article_path,
         class: 'header-dropdown__item-link' do
         | ブログ投稿
-    li.header-dropdown__item
-      = link_to ENV['REDASH_DASHBOARD_URL'],
-        class: 'header-dropdown__item-link',
-        target: '_blank', rel: 'noopener' do
-        | メンターダッシュボード
-    li.header-dropdown__item
-      = link_to ENV['REDASH_CHECK_COUNT_URL'],
-        class: 'header-dropdown__item-link',
-        target: '_blank', rel: 'noopener' do
-        | 確認数の集計


### PR DESCRIPTION
issue #3648 
## 目的
[メンターダッシュボード、確認数の集計 へのリンクを削除 #3648](https://github.com/fjordllc/bootcamp/issues/3648)
## やったこと
admin もしくはメンターでのログイン時に表示される「メンターメニュー」から、「メンターダッシュボード」と「確認数の集計」へのリンクを削除しました。
### 修正前
![スクリーンショット 2021-12-06 16 25 50](https://user-images.githubusercontent.com/46347198/144806074-1796fcf5-9f83-45b5-a7fb-30fa194cf414.png)

### 修正後
![スクリーンショット 2021-12-06 16 26 10](https://user-images.githubusercontent.com/46347198/144806104-c0f25638-ba3d-4497-af06-c4abc036308a.png)