### PR TITLE
Bump bootsnap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     ast (2.4.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
-    bootsnap (1.7.2)
+    bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     bullet (6.1.3)


### PR DESCRIPTION
Ruby 3.0 にアップデートするために bootsnap のアップデートが必要なため、bootsnap 1.9.3 にアップデートします。

refs:
`https://github.com/Shopify/bootsnap/issues/378`
https://github.com/fjordllc/bootcamp/pull/3458