### PR TITLE
企業別のユーザー一覧で「卒業生」「アドバイザー」「メンター」のタブを表示

### DIFF
--- a/app/controllers/companies/users_controller.rb
+++ b/app/controllers/companies/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Companies::UsersController < ApplicationController
-  TARGETS = %w[student_and_trainee all].freeze
+  TARGETS = %w[all student_and_trainee graduate adviser mentor].freeze
   before_action :require_login
 
   def index

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -702,6 +702,75 @@ daimyo-kensyu: # 大名エンジニアカレッジの研修生
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
 
+daimyo-adviser: # 大名エンジニアカレッジのアドバイザー
+  login_name: daimyo-adviser
+  email: daimyo-adviser@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 大名 アドバイ
+  name_kana: ダイミョウ アドバイ
+  discord_account: daimyo-adviser#9999
+  github_account: daimyo-adviser
+  twitter_account: daimyo-adviser
+  facebook_url: http://www.facebook.com/adviser
+  blog_url: http://adviser.org
+  company: company4
+  description: "大名エンジニアカレッジのアドバイザーです"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  adviser: true
+  unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
+  updated_at: "2014-01-01 00:00:11"
+  created_at: "2014-01-01 00:00:11"
+
+daimyo-mentor: # 大名エンジニアカレッジのメンター
+  login_name: daimyo-mentor
+  email: daimyo-mentor@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 大名 メンター
+  name_kana: ダイミョウ メンター
+  discord_account: daimyo-mentor#9999
+  github_account: daimyo-mentor
+  twitter_account: daimyo-mentor
+  facebook_url: http://www.facebook.com/daimyo-mentor
+  blog_url: http://mentor.org
+  company: company4
+  description: "大名エンジニアカレッジのメンターです"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  mentor: true
+  unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
+  updated_at: "2014-01-01 00:00:11"
+  created_at: "2014-01-01 00:00:11"
+
+daimyo-sotugyou: # 大名エンジニアカレッジの卒業生
+  login_name: daimyo-sotugyou
+  email: daimyo-sotugyou@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 大名 卒業
+  name_kana: ダイミョウ ソツギョウ
+  discord_account: daimyo-sotugyou#9999
+  github_account: daimyo-sotugyou
+  twitter_account: daimyo-sotugyou
+  facebook_url: http://www.facebook.com/daimyo-sotugyou
+  blog_url: http://sotugyou.org
+  company: company4
+  description: "大名エンジニアカレッジの卒業生です"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  graduated_on: "2015-01-01"
+  unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
+  updated_at: "2014-01-01 00:00:11"
+  created_at: "2014-01-01 00:00:11"
+
 kensyuowata:
   login_name: kensyuowata
   email: kensyuowata@fjord.jp


### PR DESCRIPTION
issue #3520 

確認用URL
`http://localhost:3000/companies/362477616/users`

# 変更前

タブが表示されていない

![image](https://user-images.githubusercontent.com/15277293/144941460-ccdca083-6d7c-44a4-b12a-dfcba0fb2343.png)


# 変更後

「卒業生」「アドバイザー」「メンター」のタブが表示されている

![image](https://user-images.githubusercontent.com/15277293/144940723-8328c3f5-baf2-4076-af79-026497cbc6c7.png)

## 卒業生のユーザが表示されている

![image](https://user-images.githubusercontent.com/15277293/144940841-d253a523-5aab-4c9d-b47f-e5e45fc74031.png)

## アドバイザーのユーザが表示されている

![image](https://user-images.githubusercontent.com/15277293/144941077-5ade352d-2034-4c53-b859-047d6d21792f.png)

## メンターのユーザが表示されている

![image](https://user-images.githubusercontent.com/15277293/144941226-6b858bc9-9e74-4aea-a926-a15244d19508.png)
