### PR TITLE
公開コースが存在しない場合、「コース一覧」にて「公開コースはありません」という文言と泣き顔を表示するように変更

### DIFF
--- a/app/views/courses/index.html.slim
+++ b/app/views/courses/index.html.slim
@@ -16,6 +16,14 @@ header.page-header
     .courses-items
       .row
         - if current_user&.admin?
-          = render @courses.order(:created_at)
+          - courses_to_show = @courses
         - else
-          = render @courses.where(published: true).order(:created_at)
+          - courses_to_show = @courses.where(published: true)
+        - if courses_to_show.empty?
+          .o-empty-message
+            .o-empty-message__icon
+              i.far.fa-sad-tear
+            p.o-empty-message__text
+              | 公開コースはありません。
+        - else
+          = render courses_to_show.order(:created_at)

--- a/app/views/courses/index.html.slim
+++ b/app/views/courses/index.html.slim
@@ -15,12 +15,21 @@ header.page-header
   .container
     .courses-items
       .row
-        - courses_to_show = current_user&.admin? ? @courses : @courses.where(published: true)
-        - if courses_to_show.empty?
-          .o-empty-message
-            .o-empty-message__icon
-              i.far.fa-sad-tear
-            p.o-empty-message__text
-              | 公開コースはありません。
+        - if current_user&.admin?
+          - if @courses.present?
+            = render @courses.order(:created_at)
+          - else
+            .o-empty-message
+              .o-empty-message__icon
+                i.far.fa-sad-tear
+              p.o-empty-message__text
+                | 公開コースはありません。
         - else
-          = render courses_to_show.order(:created_at)
+          - if @courses.where(published: true).present?
+            = render @courses.where(published: true).order(:created_at)
+          - else
+            .o-empty-message
+              .o-empty-message__icon
+                i.far.fa-sad-tear
+              p.o-empty-message__text
+                | 公開コースはありません。

--- a/app/views/courses/index.html.slim
+++ b/app/views/courses/index.html.slim
@@ -15,20 +15,12 @@ header.page-header
   .container
     .courses-items
       .row
-        - if current_user&.admin?
-          - if @courses.present?
-            = render @courses.order(:created_at)
-          - else
-            .o-empty-message
-              .o-empty-message__icon
-                i.far.fa-sad-tear
-              p.o-empty-message__text
-                | 公開コースはありません。
+        - if current_user&.admin? && @courses.present?
+          = render @courses.order(:created_at)
+        - elsif !current_user&.admin? && @courses.where(published: true).present?
+          = render @courses.where(published: true).order(:created_at)
         - else
-          - if @courses.where(published: true).present?
-            = render @courses.where(published: true).order(:created_at)
-          - else
-            .o-empty-message
+          .o-empty-message
               .o-empty-message__icon
                 i.far.fa-sad-tear
               p.o-empty-message__text

--- a/app/views/courses/index.html.slim
+++ b/app/views/courses/index.html.slim
@@ -15,10 +15,7 @@ header.page-header
   .container
     .courses-items
       .row
-        - if current_user&.admin?
-          - courses_to_show = @courses
-        - else
-          - courses_to_show = @courses.where(published: true)
+        - courses_to_show = current_user&.admin? ? @courses : @courses.where(published: true)
         - if courses_to_show.empty?
           .o-empty-message
             .o-empty-message__icon


### PR DESCRIPTION
issue #3595

## 目的
公開コースが存在しない場合、コース一覧ページでの表示が空の状態だと閲覧者に混乱を招きかねないため、それを避けるためにコースが存在しないことを明示する

## やったこと
公開コースが存在しない場合には、「コース一覧」にて「公開コースはありません。」という文言と泣き顔を表示するように変更しました。

## 修正前
![スクリーンショット 2021-12-07 10 01 06](https://user-images.githubusercontent.com/46347198/144950272-dd4298a4-84d7-4ed4-a6fc-32248f296ea9.png)

## 修正後
![スクリーンショット 2021-12-07 10 02 09](https://user-images.githubusercontent.com/46347198/144950293-bac16fc6-76db-4611-9511-5b5b66a7abb3.png)