### PR TITLE
「プラクティス」のページを開いた際、着手中のプラクティスのカテゴリーまでスクロールする

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -16,4 +16,9 @@ module LayoutHelper
   def display_footer?
     body_class.exclude?('no-footer')
   end
+
+  def category_has_active_practice
+    active_practice = current_user.active_practices.first
+    active_practice.categories.first
+  end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -17,7 +17,7 @@ module LayoutHelper
     body_class.exclude?('no-footer')
   end
 
-  def category_has_active_practice
+  def category_having_active_practice
     active_practice = current_user.active_practices.first
     active_practice.categories.first
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -513,11 +513,6 @@ class User < ApplicationRecord
     reported_reports.size == DEPRESSED_SIZE && reported_reports.all?(&:sad?)
   end
 
-  def active_practice
-    active_practice = active_practices.first
-    active_practice ? active_practice.id : nil
-  end
-
   def follow(other_user, watch:)
     active_relationships.create(followed: other_user, watch: watch)
   end

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -10,7 +10,7 @@ nav.global-nav
               i.fas.fa-fw.fa-bullhorn
             .global-nav-links__link-label お知らせ
         li.global-nav-links__item
-          - anchor = "category-#{current_user.category_has_active_practice.id}" if current_user.active_practice
+          - anchor = "category-#{current_user.category_having_active_practice.id}" if current_user.active_practices.present?
           = link_to course_practices_path(current_user.course, anchor: anchor), class: "global-nav-links__link #{current_link(/^(courses-practices|practices)-/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-book

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -10,7 +10,7 @@ nav.global-nav
               i.fas.fa-fw.fa-bullhorn
             .global-nav-links__link-label お知らせ
         li.global-nav-links__item
-          - anchor = "practice_#{current_user.active_practice}" if current_user.active_practice
+          - anchor = "category-#{current_user.category_has_active_practice.id}" if current_user.active_practice
           = link_to course_practices_path(current_user.course, anchor: anchor), class: "global-nav-links__link #{current_link(/^(courses-practices|practices)-/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-book

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -299,11 +299,6 @@ class UserTest < ActiveSupport::TestCase
     assert_not_includes(target, users(:yameo))
   end
 
-  test '#active_practice' do
-    assert_equal(users(:komagata).active_practice, practices(:practice1).id)
-    assert_nil(users(:machida).active_practice)
-  end
-
   test '#follow' do
     kimura = users(:kimura)
     hatsuno = users(:hatsuno)


### PR DESCRIPTION
Issue: https://github.com/fjordllc/bootcamp/issues/3647
## 確認方
- ログインして、一つのプラクティスが「着手」に変更します。
- 着手中のプラクティスがあったら、左の「プラクティス」ボタンをクリックします。
## 変更前
着手中のプラクティスへスクロールする

<img width="1436" alt="144811489-771e1ea2-51e8-4aca-af74-ec757c39e635" src="https://user-images.githubusercontent.com/38340962/144986080-95b8e8e9-a536-4775-a3bc-fee06d3e9d29.png">

## 変更後
着手中のプラクティスがあるカテゴリーにスクロールする
<img width="1439" alt="スクリーンショット 2021-12-07 14 27 48" src="https://user-images.githubusercontent.com/38340962/144986070-e540bfda-6825-441b-a377-b4ffe817bd95.png">

