### PR TITLE
日報のemotionがnilの場合、sosoに置換

### DIFF
--- a/db/data/20201122113956_change_komagata.rb
+++ b/db/data/20201122113956_change_komagata.rb
@@ -3,8 +3,7 @@
 class ChangeKomagata < ActiveRecord::Migration[6.0]
   def up
     user = User.find_by(login_name: 'komagata')
-    user.name += 'test'
-    user.save!
+    user.update!(name: "#{user.name}test")
   end
 
   def down

--- a/db/data/20201124023746_add_unsubscribe_email_token.rb
+++ b/db/data/20201124023746_add_unsubscribe_email_token.rb
@@ -4,8 +4,7 @@ class AddUnsubscribeEmailToken < ActiveRecord::Migration[6.0]
   def up
     User.transaction do
       User.where(unsubscribe_email_token: nil).find_each do |user|
-        user.unsubscribe_email_token = SecureRandom.urlsafe_base64
-        user.save!(validate: false)
+        user.update!(unsubscribe_email_token: SecureRandom.urlsafe_base64)
       end
     end
   end

--- a/db/data/20210616072230_add_empty_string_to_nil_description.rb
+++ b/db/data/20210616072230_add_empty_string_to_nil_description.rb
@@ -4,8 +4,7 @@ class AddEmptyStringToNilDescription < ActiveRecord::Migration[6.1]
   def up
     User.find_each do |user|
       if user.description.nil?
-        user.description = '自己紹介文はありません。'
-        user.save!(validate: false)
+        user.update!(description: '自己紹介文はありません。')
       end
     end
   end

--- a/db/data/20210616072230_add_empty_string_to_nil_description.rb
+++ b/db/data/20210616072230_add_empty_string_to_nil_description.rb
@@ -3,9 +3,7 @@
 class AddEmptyStringToNilDescription < ActiveRecord::Migration[6.1]
   def up
     User.find_each do |user|
-      if user.description.nil?
-        user.update!(description: '自己紹介文はありません。')
-      end
+      user.update!(description: '自己紹介文はありません。') if user.description.nil?
     end
   end
 

--- a/db/data/20211208002045_convert_report_emotion_null_to_soso.rb
+++ b/db/data/20211208002045_convert_report_emotion_null_to_soso.rb
@@ -3,8 +3,7 @@
 class ConvertReportEmotionNullToSoso < ActiveRecord::Migration[6.1]
   def up
     Report.where(emotion: nil).find_each do |report|
-      report.emotion = Report.emotions[:soso]
-      report.save!(validate: false)
+      report.update!(emotion: Report.emotions[:soso])
     end
   end
 

--- a/db/data/20211208002045_convert_report_emotion_null_to_soso.rb
+++ b/db/data/20211208002045_convert_report_emotion_null_to_soso.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ConvertReportEmotionNullToSoso < ActiveRecord::Migration[6.1]
+  def up
+    Report.where(emotion: nil).find_each do |report|
+      report.emotion = Report.emotions[:soso]
+      report.save!(validate: false)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
issue #2987 
## 概要
日報にて「今日の気分」が未選択の場合、プロフィールページに表示されるニコニコカレンダーにて、表示が「データなし」のものになってしまっていました。
対処として、DB にて、`Report`のうち`emotion`が`nil`の場合、`soso`に置換しました。
なお、[wiki](https://github.com/fjordllc/bootcamp/wiki/DB%E3%81%AE%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92migrate%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95) の指示に従い、[data-migrate](https://github.com/ilyakatz/data-migrate) という gem を使用しています。

## 修正前
![スクリーンショット 2021-12-08 11 57 57](https://user-images.githubusercontent.com/46347198/145141485-8d659ae3-9cb8-4a46-bcb1-9ffa6639efb2.png)

## 修正後
![スクリーンショット 2021-12-08 11 58 57](https://user-images.githubusercontent.com/46347198/145141497-7a7fd127-d658-443a-b61a-110c8e07dabb.png)

## ローカルでの動作確認方法の例
1. `daimyo`ユーザーでログイン
2. [こちら](http://127.0.0.1:3000/users/589622432?niconico_calendar=2020-11)（= プロフィールページのニコニコカレンダーの、2020 年 11 月分）にアクセス
→ 20 日分に「データなし」の状態が表示される
3. `rake data:migrate:up VERSION=20211208002045`コマンドを実行した後で、再確認
→ `soso`の状態が表示される