### PR TITLE
ユーザーの提出物のページのタイト提出物のページのタイトルに「の提出物」を削除

### DIFF
--- a/app/views/users/products/index.html.slim
+++ b/app/views/users/products/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}の提出物"
+- title @user.login_name
 header.page-header
   .container
     .page-header__inner

--- a/app/views/users/products/index.html.slim
+++ b/app/views/users/products/index.html.slim
@@ -1,9 +1,9 @@
-- title @user.login_name
+- title "#{@user.login_name}の提出物"
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        = @user.login_name
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item

--- a/app/views/users/products/index.html.slim
+++ b/app/views/users/products/index.html.slim
@@ -1,9 +1,9 @@
-- title "#{@user.login_name}の提出物"
+- title @user.login_name
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = @user.login_name
+        = title
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item

--- a/test/system/user/products_test.rb
+++ b/test/system/user/products_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class User::ProductsTest < ApplicationSystemTestCase
   test 'show listing products' do
     visit_with_auth "/users/#{users(:hatsuno).id}/products", 'komagata'
-    assert_equal 'hatsuno | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal 'hatsunoの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'products order' do

--- a/test/system/user/products_test.rb
+++ b/test/system/user/products_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class User::ProductsTest < ApplicationSystemTestCase
   test 'show listing products' do
     visit_with_auth "/users/#{users(:hatsuno).id}/products", 'komagata'
-    assert_equal 'hatsunoの提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal 'hatsuno | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'products order' do


### PR DESCRIPTION
issue #3708 

## 概要
ユーザーの提出物のページのタイト提出物のページのタイトルに「の提出物」を削除する。

## 修正前
![Screen Shot 2021-12-09 at 09 52 00](https://user-images.githubusercontent.com/91442824/145325811-82d9473c-2eb7-4856-8b4f-02d638a40524.png)

## 修正後
![Screen Shot 2021-12-09 at 09 53 00](https://user-images.githubusercontent.com/91442824/145325908-78f6b776-0705-4532-b330-d5754ee6562e.png)

