### PR TITLE
未解決の質問が０個のときの文言の変更

### DIFF
--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -31,7 +31,13 @@ nav.tab-nav
           = render 'questions/question', question: question
     - else
       .o-empty-message
-        .o-empty-message__icon
-          i.far.fa-sad-tear
-        p.o-empty-message__text
-          | 質問はまだありません。
+        - if params[:solved]
+          .o-empty-message__icon
+            i.far.fa-sad-tear
+          p.o-empty-message__text
+            | 質問はまだありません。
+        - else
+          .o-empty-message__icon
+            i.far.fa-smile
+          p.o-empty-message__text
+            | 未解決の質問はありません。

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -35,7 +35,7 @@ nav.tab-nav
           .o-empty-message__icon
             i.far.fa-sad-tear
           p.o-empty-message__text
-            | 質問はまだありません。
+            | 解決済みの質問はまだありません。
         - else
           .o-empty-message__icon
             i.far.fa-smile


### PR DESCRIPTION
issue #3430 

## 概要
プラクティス個別ページ配下の質問タブの質問が0個のときの「質問はまだありません」と言う文言を「未解決の質問はありません」に変更する

## 修正前
![Screen Shot 2021-12-09 at 10 06 30](https://user-images.githubusercontent.com/91442824/145327363-afed802f-e642-4fb5-90e9-f999f10db9e3.png)

## 修正後
![Screen Shot 2021-12-09 at 10 06 16](https://user-images.githubusercontent.com/91442824/145327350-303a6d57-3d56-4db0-b6dd-58818a8d1fea.png)
