### PR TITLE
日報で、ニコニコカレンダーがsadのときにコメント0で確認ボタンを押すと警告がでるように追加する

### DIFF
--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -104,12 +104,15 @@ export default {
         })
     },
     checkSad() {
-      if(this.checkHasSadEmotion && !this.checkHasComment && !this.checkId){
-        if(window.confirm('今日の気分は「sad」ですが、コメント無しで確認しますか？')){
+      if (this.checkHasSadEmotion && !this.checkHasComment && !this.checkId) {
+        if (
+          window.confirm(
+            '今日の気分は「sad」ですが、コメント無しで確認しますか？'
+          )
+        ) {
           this.check()
         }
-      }
-      else {
+      } else {
         this.check()
       }
     }

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -64,11 +64,11 @@ export default {
     },
     checkHasSadEmotion() {
       const sadEmotion = document.querySelector('#sad')
-      return sadEmotion !== undefined ? 1 : 0
+      return sadEmotion !== undefined
     },
     checkHasComment() {
       const comment = document.querySelector('.thread-comment')
-      return comment !== null ? 1 : 0
+      return comment !== null
     }
   },
   methods: {

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -26,7 +26,7 @@
       li.card-main-actions__item(:class='checkId ? "is-sub" : ""')
         button#js-shortcut-check.is-block(
           :class='checkId ? "card-main-actions__delete" : "a-button is-md is-danger"',
-          @click='check'
+          @click='checkSad'
         )
           | {{ buttonLabel }}
 </template>
@@ -61,6 +61,14 @@ export default {
     },
     method() {
       return this.checkId ? 'DELETE' : 'POST'
+    },
+    checkHasSadEmotion() {
+      const sadEmotion = document.querySelector('#sad')
+      return sadEmotion !== undefined ? 1 : 0
+    },
+    checkHasComment() {
+      const comment = document.querySelector('.thread-comment')
+      return comment !== null ? 1 : 0
     }
   },
   methods: {
@@ -94,6 +102,16 @@ export default {
         .catch((error) => {
           console.warn('Failed to parsing', error)
         })
+    },
+    checkSad() {
+      if(this.checkHasSadEmotion && !this.checkHasComment && !this.checkId){
+        if(window.confirm('今日の気分は「sad」ですが、コメント無しで確認しますか？')){
+          this.check()
+        }
+      }
+      else {
+        this.check()
+      }
     }
   }
 }

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -64,7 +64,7 @@ export default {
     },
     checkHasSadEmotion() {
       const sadEmotion = document.querySelector('#sad')
-      return sadEmotion !== undefined
+      return sadEmotion !== null
     },
     checkHasComment() {
       const comment = document.querySelector('.thread-comment')

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -16,7 +16,10 @@ class Check::ReportsTest < ApplicationSystemTestCase
   test 'success report checking' do
     visit_with_auth "/reports/#{reports(:report2).id}", 'komagata'
     assert has_button? '日報を確認'
-    click_button '日報を確認'
+    wait_for_vuejs
+    accept_alert do
+      click_button '日報を確認'
+    end
     assert has_button? '日報の確認を取り消す'
     visit reports_path
     assert_text '確認済'
@@ -24,7 +27,10 @@ class Check::ReportsTest < ApplicationSystemTestCase
 
   test 'success report checking cancel' do
     visit_with_auth "/reports/#{reports(:report2).id}", 'komagata'
-    click_button '日報を確認'
+    wait_for_vuejs
+    accept_alert do
+      click_button '日報を確認'
+    end
     click_button '日報の確認を取り消す'
     within('.thread') do
       assert_no_text '確認済'
@@ -35,20 +41,29 @@ class Check::ReportsTest < ApplicationSystemTestCase
   test 'comment and check report' do
     visit_with_auth "/reports/#{reports(:report2).id}", 'komagata'
     fill_in 'new_comment[description]', with: '日報でcomment+確認OKにするtest'
-    click_button '確認OKにする'
+    wait_for_vuejs
+    accept_alert do
+      click_button '確認OKにする'
+    end
     assert_text '確認済'
     assert_text '日報でcomment+確認OKにするtest'
   end
 
   test 'success recent report checking' do
     visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
-    click_button '日報を確認'
+    wait_for_vuejs
+    accept_alert do
+      click_button '日報を確認'
+    end
     assert page.first('.recent-reports-item').has_css?('.stamp-approve')
   end
 
   test 'success recent report checking cancel' do
     visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
-    click_button '日報を確認'
+    wait_for_vuejs
+    accept_alert do
+      click_button '日報を確認'
+    end
     wait_for_vuejs
     click_button '日報の確認を取り消す'
     assert page.first('.recent-reports-item').has_no_css?('.stamp-approve')

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -14,10 +14,10 @@ class Check::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'success report checking' do
-    visit_with_auth "/reports/#{reports(:report2).id}", 'komagata'
+    visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
     assert has_button? '日報を確認'
-    wait_for_vuejs
     accept_alert do
+      wait_for_vuejs
       click_button '日報を確認'
     end
     assert has_button? '日報の確認を取り消す'
@@ -26,9 +26,9 @@ class Check::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'success report checking cancel' do
-    visit_with_auth "/reports/#{reports(:report2).id}", 'komagata'
-    wait_for_vuejs
+    visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
     accept_alert do
+      wait_for_vuejs
       click_button '日報を確認'
     end
     click_button '日報の確認を取り消す'
@@ -39,10 +39,10 @@ class Check::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'comment and check report' do
-    visit_with_auth "/reports/#{reports(:report2).id}", 'komagata'
+    visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
     fill_in 'new_comment[description]', with: '日報でcomment+確認OKにするtest'
-    wait_for_vuejs
     accept_alert do
+      wait_for_vuejs
       click_button '確認OKにする'
     end
     assert_text '確認済'
@@ -51,8 +51,8 @@ class Check::ReportsTest < ApplicationSystemTestCase
 
   test 'success recent report checking' do
     visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
-    wait_for_vuejs
     accept_alert do
+      wait_for_vuejs
       click_button '日報を確認'
     end
     assert page.first('.recent-reports-item').has_css?('.stamp-approve')
@@ -60,8 +60,8 @@ class Check::ReportsTest < ApplicationSystemTestCase
 
   test 'success recent report checking cancel' do
     visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
-    wait_for_vuejs
     accept_alert do
+      wait_for_vuejs
       click_button '日報を確認'
     end
     wait_for_vuejs

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -163,10 +163,7 @@ class NotificationsTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{report}", 'komagata'
     visit "/reports/#{report}"
     fill_in 'new_comment[description]', with: 'コメントと確認した'
-    wait_for_vuejs
-    accept_alert do
-      click_button '確認OKにする'
-    end
+    click_button '確認OKにする'
 
     visit_with_auth "/reports/#{report}", 'hatsuno'
     find('.header-links__link.test-show-notifications').click

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -163,7 +163,10 @@ class NotificationsTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{report}", 'komagata'
     visit "/reports/#{report}"
     fill_in 'new_comment[description]', with: 'コメントと確認した'
-    click_button '確認OKにする'
+    wait_for_vuejs
+    accept_alert do
+      click_button '確認OKにする'
+    end
 
     visit_with_auth "/reports/#{report}", 'hatsuno'
     find('.header-links__link.test-show-notifications').click


### PR DESCRIPTION
Isssue: #3674
## 概要
日報で、ニコニコカレンダーがsadのときにコメント0で確認ボタンを押すと警告がでないので、警告を追加する。
## 変更前
警告がでない。
## 変更後
<img width="1437" alt="スクリーンショット 2021-12-09 10 05 22" src="https://user-images.githubusercontent.com/38340962/145327600-eaaade78-30de-4d90-8232-ca58c0df6065.png">

