### PR TITLE
footer_copyrightの年の表示を変更

### DIFF
--- a/app/views/application/_footer.html.slim
+++ b/app/views/application/_footer.html.slim
@@ -37,4 +37,4 @@ footer.footer
       small.footer__copyright
         i.far.fa-copyright
         = link_to 'Fjord Inc.', 'https://fjord.jp', class: 'footer__copyright-link'
-        = Time.zone.today.year
+        | 2012 - #{Time.zone.today.year}


### PR DESCRIPTION
issue https://github.com/fjordllc/bootcamp/issues/3652


## 概要
footer_copyrightの年の表示を変更
右側の数字は動的に今年の数字が表示されるように

## 修正前
<img width="1087" alt="スクリーンショット 2021-12-09 15 57 40" src="https://user-images.githubusercontent.com/52303699/145348940-525bba83-0e83-4a95-bcf1-34601144abdd.png">


## 修正後
<img width="1040" alt="スクリーンショット 2021-12-09 15 58 09" src="https://user-images.githubusercontent.com/52303699/145348951-5d2305d9-58fd-4c09-9cbb-5eaef3f5af1c.png">


