### PR TITLE
ユーザー個別ページの日報タブに日報の合計数を表示したい

### DIFF
--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -10,7 +10,7 @@
             | ポートフォリオ
       li.page-tabs__item
         = link_to user_reports_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
-          | 日報
+          | 日報 （#{user.comments.length}）
       li.page-tabs__item
         = link_to user_comments_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('comments')}" do
           | コメント （#{user.comments.length}）

--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -10,7 +10,7 @@
             | ポートフォリオ
       li.page-tabs__item
         = link_to user_reports_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
-          | 日報 （#{user.comments.length}）
+          | 日報 （#{user.reports.length}）
       li.page-tabs__item
         = link_to user_comments_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('comments')}" do
           | コメント （#{user.comments.length}）


### PR DESCRIPTION
issue https://github.com/fjordllc/bootcamp/issues/3724

## 概要
ユーザー個別ページの日報タブに日報の合計数を表示したい

## 修正前
<img width="903" alt="スクリーンショット 2021-12-09 18 48 10" src="https://user-images.githubusercontent.com/52303699/145381397-7aae5a8a-1920-4053-9e0f-7df53e799779.png">



## 修正後
<img width="916" alt="スクリーンショット 2021-12-09 18 47 55" src="https://user-images.githubusercontent.com/52303699/145381390-40e01b5a-dc1c-4a4b-bc75-c42bf51eaa1b.png">

## 確認したこと
- WIPも含めた数字になっているのか