### PR TITLE
welcomeのフッタのcopyrightの年の表示を「2012-現在の年」に変更

### DIFF
--- a/app/views/welcome/_welcome_footer.html.slim
+++ b/app/views/welcome/_welcome_footer.html.slim
@@ -20,4 +20,4 @@ footer.welcome-footer
     small.welcome-footer-copyright
       i.far.fa-copyright
       span.welcome-footer-copyright__author
-        | Fjord Inc.2012 - #{Time.zone.today.year}
+        | Fjord Inc. 2012 - #{Time.zone.today.year}

--- a/app/views/welcome/_welcome_footer.html.slim
+++ b/app/views/welcome/_welcome_footer.html.slim
@@ -20,4 +20,4 @@ footer.welcome-footer
     small.welcome-footer-copyright
       i.far.fa-copyright
       span.welcome-footer-copyright__author
-        | Fjord Inc. 2012 - #{Time.zone.today.year}
+        | Fjord Inc. 2012 - #{Date.current.year}

--- a/app/views/welcome/_welcome_footer.html.slim
+++ b/app/views/welcome/_welcome_footer.html.slim
@@ -20,5 +20,4 @@ footer.welcome-footer
     small.welcome-footer-copyright
       i.far.fa-copyright
       span.welcome-footer-copyright__author
-        | Fjord Inc.
-      = Time.zone.today.year
+        | Fjord Inc.2012 - #{Time.zone.today.year}


### PR DESCRIPTION
ref:[#3653](https://github.com/fjordllc/bootcamp/issues/3653)

## 概要
/welcome ページのフッタのCopyright年の表示を変更
スタートを2012として右側は動的に今の年とする

## 修正前
![スクリーンショット 2021-12-09 23 16 11](https://user-images.githubusercontent.com/82434093/145421410-efe1dfce-ee75-45b9-850f-95a17f30bceb.png)

## 修正後
![スクリーンショット 2021-12-10 0 01 27](https://user-images.githubusercontent.com/82434093/145421456-b4a1ec75-8c80-4373-b5ae-98eb8cabee90.png)

