### PR TITLE
メンターが提出物の「担当する」ボタンをクリックしたら、toastで「担当になりました」の通知を追加する

### DIFF
--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -76,9 +76,11 @@ export default {
           } else {
             this.id = json.checker_id
             this.name = json.checker_name
-            this.buttonLabel === '担当する'
-              ? this.toast('担当から外れました。')
-              : this.toast('担当になりました。')
+            if (this.buttonLabel === '担当する') {
+              this.toast('担当から外れました。')
+            } else {
+              this.toast('担当になりました。')
+            }
           }
         })
     }

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -76,9 +76,9 @@ export default {
           } else {
             this.id = json.checker_id
             this.name = json.checker_name
-            this.buttonLabel !== '担当する'
-              ? this.toast('担当になりました。')
-              : this.toast('担当から外れました。')
+            this.buttonLabel === '担当する'
+              ? this.toast('担当から外れました。')
+              : this.toast('担当になりました。')
           }
         })
     }

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -19,7 +19,10 @@ button(
     | {{ this.name }}
 </template>
 <script>
+import toast from './toast'
+
 export default {
+  mixins: [toast],
   props: {
     checkerId: { type: Number, required: false, default: null },
     checkerName: { type: String, required: false, default: null },
@@ -73,6 +76,9 @@ export default {
           } else {
             this.id = json.checker_id
             this.name = json.checker_name
+            this.buttonLabel !== '担当する'
+              ? this.toast('担当になりました。')
+              : this.toast('担当から外れました。')
           }
         })
     }


### PR DESCRIPTION
Issue: #3684 

## 概要
メンターが提出物の「担当する」ボタンをクリックしたら、何も通知されないので、通知を追加します。
## 変更前
通知がない。
## 変更後
<img width="1145" alt="スクリーンショット 2021-12-09 22 40 59" src="https://user-images.githubusercontent.com/38340962/145427790-2ee29f89-e0c8-40ac-a29d-fdcf2cce2d91.png">
<img width="1149" alt="スクリーンショット 2021-12-09 22 40 44" src="https://user-images.githubusercontent.com/38340962/145427797-c5f08a02-8fe1-4c14-b893-7d43105d38db.png">
<img width="1148" alt="スクリーンショット 2021-12-09 22 41 53" src="https://user-images.githubusercontent.com/38340962/145427804-33b46fd3-8ddc-448c-9b94-7c45de478633.png">
<img width="1145" alt="スクリーンショット 2021-12-09 22 42 08" src="https://user-images.githubusercontent.com/38340962/145427812-7eeadc61-f306-4e84-a119-b796b72344af.png">

