### PR TITLE
卒業生の進捗表示の変更 #3675

### DIFF
--- a/app/assets/stylesheets/blocks/user/_completed-practices-progress.sass
+++ b/app/assets/stylesheets/blocks/user/_completed-practices-progress.sass
@@ -24,5 +24,7 @@ $bar-height: .75rem
   box-shadow: rgba(black, .2) 0 .0625rem .0625rem
 
 .completed-practices-progress__number
-  +text-block(.875rem 1rem, right)
-  +size(2.5rem 1rem)
+  +text-block(.8125rem 1rem, right nowrap)
+  height: 1rem
+  min-width: 2.5rem
+  margin-left: .5rem

--- a/app/javascript/user-practice-progress.vue
+++ b/app/javascript/user-practice-progress.vue
@@ -25,7 +25,9 @@ export default {
   },
   computed: {
     roundedPercentage() {
-      return this.user.role === 'graduate' ? '100%' : Math.round(this.percentage) + '%'
+      return this.user.role === 'graduate'
+        ? '100%'
+        : Math.round(this.percentage) + '%'
     }
   },
   methods: {

--- a/app/javascript/user-practice-progress.vue
+++ b/app/javascript/user-practice-progress.vue
@@ -5,12 +5,12 @@
     .completed-practices-progress__percentage-bar(
       aria-valuemax='100',
       aria-valuemin='0',
-      :aria-valuenow='percentage',
+      :aria-valuenow='ariaValuenow()',
       role='progressbar',
       :style='`width: ${roundedPercentage}`'
     )
   .completed-practices-progress__number
-    | {{ fraction }}
+    | {{ completedPracticesProgressNumber() }}
 </template>
 <script>
 export default {
@@ -18,21 +18,22 @@ export default {
     user: { type: Object, required: true }
   },
   data() {
-    if (this.user.role === 'graduate') {
-      return {
-        percentage: 100,
-        fraction: '卒業'
-      }
-    } else {
-      return {
-        percentage: this.user.cached_completed_percentage,
-        fraction: this.user.completed_fraction
-      }
+    return {
+      percentage: this.user.cached_completed_percentage,
+      fraction: this.user.completed_fraction
     }
   },
   computed: {
     roundedPercentage() {
-      return Math.round(this.percentage) + '%'
+      return this.user.role === 'graduate' ? '100%' : Math.round(this.percentage) + '%'
+    }
+  },
+  methods: {
+    ariaValuenow() {
+      return this.user.role === 'graduate' ? 100 : this.percentage
+    },
+    completedPracticesProgressNumber() {
+      return this.user.role === 'graduate' ? '卒業' : this.fraction
     }
   }
 }

--- a/app/javascript/user-practice-progress.vue
+++ b/app/javascript/user-practice-progress.vue
@@ -18,9 +18,16 @@ export default {
     user: { type: Object, required: true }
   },
   data() {
-    return {
-      percentage: this.user.cached_completed_percentage,
-      fraction: this.user.completed_fraction
+    if (this.user.role === 'graduate') {
+      return {
+        percentage: 100,
+        fraction: '卒業'
+      }
+    } else {
+      return {
+        percentage: this.user.cached_completed_percentage,
+        fraction: this.user.completed_fraction
+      }
     }
   },
   computed: {

--- a/app/views/users/practices/_completed_practices_progress.html.slim
+++ b/app/views/users/practices/_completed_practices_progress.html.slim
@@ -1,5 +1,9 @@
-- percentage = user.cached_completed_percentage
-- fraction = user.completed_fraction
+- if user.graduated?
+  - percentage = 100
+  - fraction = "卒業(#{user.completed_practices.size})"
+- else
+  - percentage = user.cached_completed_percentage
+  - fraction = user.completed_fraction
 .completed-practices-progress
   .completed-practices-progress__bar-container
     .completed-practices-progress__bar


### PR DESCRIPTION
issue: #3675
# 概要
卒業生の進捗表示は現在、達成したプラクティス数に応じて異なっている。
卒業生の進捗表示を、達成したプラクティス数に関係なく一定の表示にする。

# 変更前
## ユーザー一覧
![スクリーンショット 2021-12-11 20 39 35](https://user-images.githubusercontent.com/73326842/145675108-736456c7-0b6b-473f-a367-937bd9e084ac.png)

## ユーザー個別
![スクリーンショット 2021-12-11 20 39 54](https://user-images.githubusercontent.com/73326842/145675113-420b2b6b-e37d-42f1-a44a-1e96df70329f.png)


# 変更後
## ユーザー一覧
![スクリーンショット 2021-12-11 20 38 34](https://user-images.githubusercontent.com/73326842/145675078-96fb8ee7-8c97-4d79-a866-45a5fd43ceb8.png)


## ユーザー個別
![スクリーンショット 2021-12-11 20 37 17](https://user-images.githubusercontent.com/73326842/145675047-4f4e8d88-52f3-4137-91a7-1d528eb072c9.png)

