### PR TITLE
並べ替え時に列キャレットアイコンを変更する

### DIFF
--- a/app/views/admin/users/_sort_column.html.slim
+++ b/app/views/admin/users/_sort_column.html.slim
@@ -1,4 +1,7 @@
 - direction = params[:order_by] == order_by && direction == 'asc' ? 'desc' : 'asc'
 
 = link_to admin_users_path(order_by: order_by, direction: direction, target: target), class: 'a-button is-xs is-secondary is-icon' do
-  i.fas.fa-caret-up
+  - if direction == 'asc'
+    i.fas.fa-caret-up
+  - else
+    i.fas.fa-caret-down


### PR DESCRIPTION
Issue #3636 
## 概要
画像の状態で 🔼 をクリックしたら 🔽 に変わって降順ソートになります。

## 修正前
![image](https://user-images.githubusercontent.com/91442824/145748788-d3fb57b5-11a1-4cce-9761-f0ec4bed0269.png)

## 修正後
<img width="1082" alt="145748836-71883c13-4766-4064-a951-f7f210bfa29e" src="https://user-images.githubusercontent.com/91442824/145751712-3cfd01fa-2d2c-4f9e-aafc-53b812950f27.png">
