### PR TITLE
終了したイベントに「終了」と表示する

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-list-item-actions.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item-actions.sass
@@ -1,17 +1,20 @@
 .thread-list-item-actions__trigger
-  +position(absolute, right -.75rem, top -.5rem, 2)
   +size(2.25rem)
   display: flex
   align-items: center
   justify-content: center
   cursor: pointer
   color: $muted-text
-  //border: solid 1px $border
-  border-radius: .25rem
+  align-self: flex-start
+  +media-breakpoint-up(md)
+    margin-top: -.5rem
+    margin-right: -.5rem
+  +media-breakpoint-down(sm)
+    +position(absolute, left 0, top 2.75rem)
 
 .thread-list-item-actions__inner
   display: none
-  +position(absolute, right 0, top 0, 3)
+  +position(absolute, right -.5rem, top -.5rem, 3)
   input:checked + &
     display: block
 
@@ -27,7 +30,7 @@
     border-top: dashed 1px $border
 
 .thread-list-item-actions__action
-  +text-block(.875rem, $default-text)
+  +text-block(.8125rem, $default-text)
   +flex-link
   align-items: center
   background-color: $base

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item-title.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item-title.sass
@@ -14,18 +14,19 @@
   height: 1.125rem
   margin-right: .5rem
   border-radius: .75rem
+  align-self: flex-start
   align-items: center
   justify-content: center
   +media-breakpoint-down(sm)
     float: left
   &.is-wip
-    background-color: #e9ebef
+    background-color: $background-tint
   &.is-unread
     background-color: $danger
     color: $reversal-text
     font-size: .625rem
   &.is-ended
-    background-color: $danger
+    background-color: #bbbbbb
     color: $reversal-text
 
 .thread-list-item-title__start
@@ -35,6 +36,9 @@
     flex: 1
   +media-breakpoint-down(sm)
     width: 100%
+
+.thread-list-item-title__end
+  align-self: flex-start
 
 .thread-list-item-title__title
   +text-block(.875rem 1.5, 600)

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item-title.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item-title.sass
@@ -24,7 +24,7 @@
     background-color: $danger
     color: $reversal-text
     font-size: .625rem
-  &.is-closing
+  &.is-ended
     background-color: $danger
     color: $reversal-text
 

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item-title.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item-title.sass
@@ -24,6 +24,9 @@
     background-color: $danger
     color: $reversal-text
     font-size: .625rem
+  &.is-closing
+    background-color: $danger
+    color: $reversal-text
 
 .thread-list-item-title__start
   +media-breakpoint-up(md)

--- a/app/javascript/event.vue
+++ b/app/javascript/event.vue
@@ -11,7 +11,7 @@
       .thread-list-item__row
         .thread-list-item-title
           .thread-list-item-title__icon.is-wip(v-if='event.wip') WIP
-          .thread-list-item-title__icon.is-ended(v-if='event.ended') 終了
+          .thread-list-item-title__icon.is-ended(v-else-if='event.ended') 終了
           h2.thread-list-item-title__title(itemprop='name')
             a.thread-list-item-title__link(:href='event.url', itemprop='url')
               | {{ event.title }}

--- a/app/javascript/event.vue
+++ b/app/javascript/event.vue
@@ -11,7 +11,7 @@
       .thread-list-item__row
         .thread-list-item-title
           .thread-list-item-title__icon.is-wip(v-if='event.wip') WIP
-          .thread-list-item-title__icon.is-closing(v-if='event.is_closing') 終了
+          .thread-list-item-title__icon.is-ended(v-if='event.ended') 終了
           h2.thread-list-item-title__title(itemprop='name')
             a.thread-list-item-title__link(:href='event.url', itemprop='url')
               | {{ event.title }}

--- a/app/javascript/event.vue
+++ b/app/javascript/event.vue
@@ -11,6 +11,7 @@
       .thread-list-item__row
         .thread-list-item-title
           .thread-list-item-title__icon.is-wip(v-if='event.wip') WIP
+          .thread-list-item-title__icon.is-closing(v-if='event.is_closing') 終了
           h2.thread-list-item-title__title(itemprop='name')
             a.thread-list-item-title__link(:href='event.url', itemprop='url')
               | {{ event.title }}

--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -10,7 +10,9 @@
               a.thread-list-item-title__link.js-unconfirmed-link(
                 :href='report.url'
               ) {{ report.user.daimyo ? "★" + report.title : report.title }}
-            .thread-list-item-title__end(v-if='currentUserId == report.user.id')
+            .thread-list-item-title__end(
+              v-if='currentUserId == report.user.id'
+            )
               label.thread-list-item-actions__trigger(:for='report.id')
                 i.fas.fa-ellipsis-h
               .thread-list-item-actions
@@ -18,7 +20,9 @@
                 .thread-list-item-actions__inner
                   ul.thread-list-item-actions__items
                     li.thread-list-item-actions__item
-                      a.thread-list-item-actions__action(:href='report.editURL')
+                      a.thread-list-item-actions__action(
+                        :href='report.editURL'
+                      )
                         i.fas.fa-pen
                         | 内容変更
                     li.thread-list-item-actions__item

--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -1,9 +1,6 @@
 <template lang="pug">
 .thread-list-item(:class='wipClass')
   .thread-list-item__inner
-    template(v-if='currentUserId == report.user.id')
-      label.thread-list-item-actions__trigger(:for='report.id')
-        i.fas.fa-ellipsis-h
     .thread-list-item__rows
       .thread-list-item__row
         header.thread-list-item-title
@@ -13,21 +10,22 @@
               a.thread-list-item-title__link.js-unconfirmed-link(
                 :href='report.url'
               ) {{ report.user.daimyo ? "★" + report.title : report.title }}
-
-          .thread-list-item-title__end
-            .thread-list-item-actions(v-if='currentUserId == report.user.id')
-              input.a-toggle-checkbox(type='checkbox', :id='report.id')
-              .thread-list-item-actions__inner
-                ul.thread-list-item-actions__items
-                  li.thread-list-item-actions__item
-                    a.thread-list-item-actions__action(:href='report.editURL')
-                      i.fas.fa-pen
-                      | 内容変更
-                  li.thread-list-item-actions__item
-                    a.thread-list-item-actions__action(:href='report.newURL')
-                      i.fas.fa-copy
-                      | コピー
-                label.a-overlay(:for='report.id')
+            .thread-list-item-title__end(v-if='currentUserId == report.user.id')
+              label.thread-list-item-actions__trigger(:for='report.id')
+                i.fas.fa-ellipsis-h
+              .thread-list-item-actions
+                input.a-toggle-checkbox(type='checkbox', :id='report.id')
+                .thread-list-item-actions__inner
+                  ul.thread-list-item-actions__items
+                    li.thread-list-item-actions__item
+                      a.thread-list-item-actions__action(:href='report.editURL')
+                        i.fas.fa-pen
+                        | 内容変更
+                    li.thread-list-item-actions__item
+                      a.thread-list-item-actions__action(:href='report.newURL')
+                        i.fas.fa-copy
+                        | コピー
+                  label.a-overlay(:for='report.id')
 
       .thread-list-item__row
         .thread-list-item-meta

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -54,6 +54,10 @@ class Event < ApplicationRecord
     Time.current > open_end_at && Time.current < end_at
   end
 
+  def ended?
+    Time.current >= end_at
+  end
+
   def participants
     first_come_first_served.limit(capacity)
   end

--- a/app/views/api/events/_event.json.jbuilder
+++ b/app/views/api/events/_event.json.jbuilder
@@ -3,3 +3,4 @@ json.start_at_localized l(event.start_at)
 json.comments_count event.comments.size
 json.url event_url(event)
 json.user event.user, partial: "api/users/user", as: :user
+json.is_closing event.closing?

--- a/app/views/api/events/_event.json.jbuilder
+++ b/app/views/api/events/_event.json.jbuilder
@@ -3,4 +3,4 @@ json.start_at_localized l(event.start_at)
 json.comments_count event.comments.size
 json.url event_url(event)
 json.user event.user, partial: "api/users/user", as: :user
-json.is_closing event.closing?
+json.ended event.ended?

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -1,8 +1,5 @@
 .thread-list-item(class="#{report.wip? ? 'is-wip' : ''}")
   .thread-list-item__inner
-    - if current_user == report.user
-      label.thread-list-item-actions__trigger(for="#{report.id}")
-        i.fas.fa-ellipsis-h
     .thread-list-item__user
       = render 'users/icon', user: report.user, link_class: 'a-user-name', image_class: 'thread-list-item__user-icon'
     .thread-list-item__rows
@@ -18,6 +15,8 @@
                 = report.title
           - if current_user == report.user
             .thread-list-item-title__end
+              label.thread-list-item-actions__trigger(for="#{report.id}")
+                i.fas.fa-ellipsis-h
               .thread-list-item-actions
                 input.a-toggle-checkbox(type="checkbox" id=="#{report.id}")
                 .thread-list-item-actions__inner

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -18,6 +18,11 @@ class EventTest < ActiveSupport::TestCase
     assert event.closing?
   end
 
+  test '#ended?' do
+    event = events(:event6)
+    assert event.ended?
+  end
+
   test '#participants' do
     event = events(:event2)
     participants = users(:hatsuno)


### PR DESCRIPTION
Issue #3747 

## 概要
イベント一覧で修了したイベントには「終了」と表示します。

## 修正前
<img width="1168" alt="Screen Shot 2021-12-14 at 09 32 29" src="https://user-images.githubusercontent.com/91442824/145922600-b849e275-741a-47d7-ab74-697b3d7a64bf.png">


## 修正後
<img width="1201" alt="Screen Shot 2021-12-14 at 09 33 41" src="https://user-images.githubusercontent.com/91442824/145922622-4f024901-6d52-46d3-b7dd-c8f4287c7442.png">
