### PR TITLE
イベント作成ページにおいて、イベントの開始時刻の設定に合わせ、同一時刻がイベント終了時刻と募集終了時刻に反映される機能を実装

### DIFF
--- a/app/javascript/events.js
+++ b/app/javascript/events.js
@@ -10,13 +10,22 @@ document.addEventListener('DOMContentLoaded', () => {
     }).$mount(selector)
   }
 
-  const eventSets = [
-    ['event_start_at', 'event_end_at'],
-    ['event_open_start_at', 'event_open_end_at']
-  ]
-  eventSets.forEach((eventSet) => {
-    document.getElementById(eventSet[0]).addEventListener('blur', (event) => {
-      document.getElementById(eventSet[1]).value = event.target.value
+  document
+    .getElementById('event_start_at')
+    .addEventListener('blur', (event) => {
+      const eventStartAtDate = event.target.value
+      const idsToSubstituteDate = ['event_end_at', 'event_open_end_at']
+      idsToSubstituteDate.forEach((idToSubstituteDate) => {
+        substituteDate(
+          eventStartAtDate,
+          document.getElementById(idToSubstituteDate)
+        )
+      })
     })
-  })
+
+  function substituteDate(date, destElement) {
+    if (destElement.value === '') {
+      destElement.value = date
+    }
+  }
 })

--- a/app/javascript/events.js
+++ b/app/javascript/events.js
@@ -9,4 +9,14 @@ document.addEventListener('DOMContentLoaded', () => {
       render: (h) => h(Events)
     }).$mount(selector)
   }
+
+  const eventSets = [
+    ['event_start_at', 'event_end_at'],
+    ['event_open_start_at', 'event_open_end_at']
+  ]
+  eventSets.forEach((eventSet) => {
+    document.getElementById(eventSet[0]).addEventListener('blur', (event) => {
+      document.getElementById(eventSet[1]).value = event.target.value
+    })
+  })
 })

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -353,4 +353,20 @@ class EventsTest < ApplicationSystemTestCase
     visit_with_auth '/events', 'kimura'
     assert_selector 'nav.pagination', count: 2
   end
+
+  test 'dates of target events get filled automatically only when they are empty' do
+    visit_with_auth new_event_path, 'komagata'
+    within 'form[name=event]' do
+      fill_in 'event[start_at]', with: Time.zone.local(2050, 12, 24, 23, 59)
+    end
+    find('body').click
+    assert_equal find('#event_end_at').value, '2050-12-24T23:59'
+    assert_equal find('#event_open_end_at').value, '2050-12-24T23:59'
+    within 'form[name=event]' do
+      fill_in 'event[start_at]', with: Time.zone.local(2050, 12, 24, 11, 11)
+    end
+    find('body').click
+    assert_equal find('#event_end_at').value, '2050-12-24T23:59'
+    assert_equal find('#event_open_end_at').value, '2050-12-24T23:59'
+  end
 end


### PR DESCRIPTION
issue #3723 
## 目的
イベント作成時のイベント終了日時とイベント募集終了日時の設定に要する手間の省略

## やったこと
イベント作成ページにおいて、イベントの開始時刻を設定すると、フォーカスが外れた際に、未入力のイベント終了時刻 / 募集終了時刻に、イベント開始時刻と同一の時刻が反映されるようにしました。

## 確認手順
1. 任意のユーザーでのログイン後、[「イベント作成」ページ](http://localhost:3000/events/new) を開く
2. 「イベント開始日時」のフォームにて、任意の時刻を設定（直接打ち込むか、右側にあるカレンダーアイコンをクリック後にカレンダーから選択）
![スクリーンショット 2021-12-14 12 44 30](https://user-images.githubusercontent.com/46347198/145929795-ab67f7db-f684-4e34-944e-e3f8923ea9c6.png)

3. 枠外をクリックするなどしてフォームからフォーカスを外すと、「イベント終了日時」と「募集終了日時」に同一時刻が設定されるのを確認
![スクリーンショット 2021-12-14 12 47 04](https://user-images.githubusercontent.com/46347198/145929841-f5e71320-37e6-4f2b-a2d5-0bd96ff93689.png)

4. 「イベント開始日時」の時刻を変更する
5. 今度は、「イベント終了日時」にも「募集終了日時」にも、時刻が反映されないのを確認