### PR TITLE
ユーザーページに回答タブを追加

### DIFF
--- a/app/controllers/users/answers_controller.rb
+++ b/app/controllers/users/answers_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Users::AnswersController < ApplicationController
+  before_action :require_login
+
+  def index
+    @user = User.find(params[:user_id])
+    @answers = @user.answers.order(created_at: :desc)
+  end
+end

--- a/app/controllers/users/answers_controller.rb
+++ b/app/controllers/users/answers_controller.rb
@@ -5,6 +5,16 @@ class Users::AnswersController < ApplicationController
 
   def index
     @user = User.find(params[:user_id])
-    @answers = @user.answers.order(created_at: :desc)
+    @answers = @user.answers.includes(
+      {
+        question: [
+          :correct_answer,
+          { user: [:company, { avatar_attachment: :blob }] },
+          :practice,
+          :tag_taggings,
+          :tags
+        ]
+      }
+    ).order(created_at: :desc)
   end
 end

--- a/app/controllers/users/questions_controller.rb
+++ b/app/controllers/users/questions_controller.rb
@@ -5,6 +5,6 @@ class Users::QuestionsController < ApplicationController
 
   def index
     @user = User.find(params[:user_id])
-    @questions = @user.questions.order(created_at: :desc)
+    @questions = @user.questions.includes(%i[correct_answer practice answers tag_taggings tags]).order(created_at: :desc)
   end
 end

--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -20,3 +20,7 @@
       li.page-tabs__item
         = link_to user_questions_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('questions')}" do
           | 質問 （#{user.questions.length}）
+      li.page-tabs__item
+        = link_to user_answers_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('answers')}" do
+          | 回答（#{user.answers.length}）
+

--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -23,4 +23,3 @@
       li.page-tabs__item
         = link_to user_answers_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('answers')}" do
           | 回答（#{user.answers.length}）
-

--- a/app/views/users/answers/_answer.html.slim
+++ b/app/views/users/answers/_answer.html.slim
@@ -1,0 +1,25 @@
+.thread-list-item
+  .thread-list-item__inner
+    .thread-list-item__user
+      = render 'users/icon',
+              user: answer.user,
+              link_class: 'a-user-name',
+              image_class: 'thread-list-item__user-icon'
+    .thread-list-item__rows
+      .thread-list-item__row
+        .thread-list-item-title
+          h1.thread-list-item-title__title(itemprop='name')
+            = link_to answer, itemprop: 'url', class: 'thread-list-item-title__link' do
+              = answer.description
+      .thread-list-item__row
+        .thread-list-item-meta
+          .thread-list-item-meta__items
+            .thread-list-item-meta__item
+              = link_to answer.user.long_name, answer.user, class: 'a-user-name'
+            .thread-list-item-meta__item
+              time.a-meta(datetime="#{answer.updated_at.to_datetime}" pubdate='pubdate')
+                = l answer.updated_at
+              .thread-list-item-meta__item
+                .thread-list-item-comment
+                  .thread-list-item-comment__label
+                    |（#{answer.description}）

--- a/app/views/users/answers/_answer.html.slim
+++ b/app/views/users/answers/_answer.html.slim
@@ -1,25 +1,46 @@
-.thread-list-item
+.thread-list-item(class="#{answer.question.correct_answer.present? ? 'is-solved' : ''}")
   .thread-list-item__inner
     .thread-list-item__user
       = render 'users/icon',
-              user: answer.user,
+              user: answer.question.user,
               link_class: 'a-user-name',
               image_class: 'thread-list-item__user-icon'
     .thread-list-item__rows
       .thread-list-item__row
         .thread-list-item-title
           h1.thread-list-item-title__title(itemprop='name')
-            = link_to answer, itemprop: 'url', class: 'thread-list-item-title__link' do
-              = answer.description
+            = link_to answer.question, itemprop: 'url', class: 'thread-list-item-title__link' do
+              = answer.question.title
+      - if answer.question.practice
+        .thread-list-item__row
+          .thread-list-item-meta
+            .thread-list-item-meta__items
+              .thread-list-item-meta__item
+                .thread-list-item-sub-title
+                  = answer.question.practice.title
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items
             .thread-list-item-meta__item
-              = link_to answer.user.long_name, answer.user, class: 'a-user-name'
+              = link_to answer.question.user.long_name, answer.question.user, class: 'a-user-name'
             .thread-list-item-meta__item
               time.a-meta(datetime="#{answer.updated_at.to_datetime}" pubdate='pubdate')
                 = l answer.updated_at
-              .thread-list-item-meta__item
-                .thread-list-item-comment
-                  .thread-list-item-comment__label
-                    |（#{answer.description}）
+            - if answer.question.tags.present?
+              .thread-list-item__row
+                .thread-list-item-tags
+                  .thread-list-item-tags__label
+                    i.fas.fa-tags
+                  ul.thread-list-item-tags__items
+                    - question.tags.each do |tag|
+                      li.thread-list-item-tags__item
+                        = link_to tag.name, questions_tag_path(tag.name, all: 'true'), class: 'thread-list-item-tags__item-link'
+            - if answer.type == 'CorrectAnswer'
+              .answer-badge
+                .answer-badge__icon
+                  i.fas.fa-star
+                .answer-badge__label ベストアンサー
+            .thread-list-item-meta__item
+              .thread-list-item-comment
+                .thread-list-item-comment__label
+                  |#{answer.description}

--- a/app/views/users/answers/index.html.slim
+++ b/app/views/users/answers/index.html.slim
@@ -1,0 +1,25 @@
+- title "#{@user.login_name}の質問"
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to 'ユーザー一覧', users_path, class: 'a-button is-md is-secondary is-block is-back'
+
+.page-tools
+  = render 'users/page_tabs', user: @user
+
+.page-body
+  .container.is-md
+    - if @answers.present?
+      .thread-list.a-card
+        = render partial: 'users/answers/answer', collection: @answers, as: :answer
+    - else
+      .o-empty-message
+        .o-empty-message__icon
+          i.far.fa-sad-tear
+        p.o-empty-message__text
+          | 回答はまだありません。

--- a/app/views/users/answers/index.html.slim
+++ b/app/views/users/answers/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}の質問"
+- title "#{@user.login_name}の回答"
 header.page-header
   .container
     .page-header__inner

--- a/config/routes/users.rb
+++ b/config/routes/users.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     resources :comments, only: %i(index), controller: "users/comments"
     resources :products, only: %i(index), controller: "users/products"
     resources :questions, only: %i(index), controller: "users/questions"
+    resources :answers, only: %i(index), controller: "users/answers"
     get "portfolio" => "users/works#index", as: :portfolio
     patch "graduation", to: "graduation#update", as: :graduation
     get "mail_notification", to: "mail_notification#update", as: :mail_notification

--- a/test/system/user/answers_test.rb
+++ b/test/system/user/answers_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class User::AnswersTest < ApplicationSystemTestCase
+  test 'show listing answers' do
+    visit_with_auth "/users/#{users(:sotugyou).id}/answers", 'sotugyou'
+    assert_equal 'sotugyouの回答 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+  end
+end


### PR DESCRIPTION
issue #1459 

## 目的
- ユーザーが自分の回答を確認しやすくする
- ユーザーごとの回答の活動状況を可視化

## 実装の概要
- ユーザーページに回答タブを追加
- 回答タブの遷移先にて、回答一覧を表示
  - 回答がベストアンサーの場合、バッジを表示
  - 回答がない場合は、その旨を泣き顔と共に表示

## 確認手順の例
1. `komagata` でログイン
2. [プロフィールページ](http://localhost:3000/users/459775584) に移動
    - 回答タブが確認できる
![スクリーンショット 2021-12-14 17 58 34](https://user-images.githubusercontent.com/46347198/145966373-f0802271-5a77-44d7-bb01-f14a919e90ea.png)

3.  回答タブをクリック
    - 回答一覧が表示される
![スクリーンショット 2021-12-14 17 36 35](https://user-images.githubusercontent.com/46347198/145966439-94bbdf8b-9bef-491e-94c7-dba98ba9bf86.png)

4. ログアウト → `jobseeker` でログイン
5. [回答ページ](http://localhost:3000/users/138009375/answers) に移動
    - 回答がない旨が表示される
![スクリーンショット 2021-12-14 17 55 07](https://user-images.githubusercontent.com/46347198/145966501-cf1958ca-c9da-43be-a0b5-fcc49ce8d384.png)

