### PR TITLE
Watch中一覧の読み込み中にプレースホルダーが表示されるよう変更

### DIFF
--- a/app/javascript/watches.vue
+++ b/app/javascript/watches.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .page-body
   .container.is-md(v-if='!loaded')
-    | ロード中
+    loadingListPlaceholder
   .container.is-md(v-else)
     .thread-list-tools(v-if='watches.length')
       .form-item.is-inline
@@ -32,10 +32,12 @@
 <script>
 import watch from './watch.vue'
 import Pager from './pager.vue'
+import LoadingListPlaceholder from './loading-list-placeholder.vue'
 
 export default {
   components: {
     watch: watch,
+    loadingListPlaceholder: LoadingListPlaceholder,
     pager: Pager
   },
   data() {


### PR DESCRIPTION
issue #3761

## 実装内容
ダッシュボードからアクセスできる「Watch中」にて、読み込み中に、プレースホルダーが表示されるようにしました。

## 変更前
「ロード中」とのみ表示される
![スクリーンショット 2021-12-15 12 44 46](https://user-images.githubusercontent.com/46347198/146120620-d044cf87-338d-4bb9-a54d-0accf7c8ca18.png)

## 変更後
![スクリーンショット 2021-12-15 12 39 36](https://user-images.githubusercontent.com/46347198/146120649-ff287c43-34ec-428d-854a-dbd4ca30d662.png)

## 確認手順例
1. `kimura` でログイン（watch 対象が多く、今回の仕様の確認に適している）
2. [「Watch中」一覧]([http://localhost:3000/current_user/watches](http://localhost:3000/current_user/watches))へジャンプ
→ （１秒以下ではあるが）プレースホルダーが目視できる