### PR TITLE
Participationのuser_idとevent_idの一意の検証を追加

### DIFF
--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -6,6 +6,8 @@ class Participation < ApplicationRecord
 
   scope :disabled, -> { where(enable: false) }
 
+  validates :user_id, uniqueness: { scope: [:event_id] }
+
   def waited?
     saved_change_to_attribute?('enable', from: false, to: true)
   end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -6,7 +6,7 @@ class Participation < ApplicationRecord
 
   scope :disabled, -> { where(enable: false) }
 
-  validates :user_id, uniqueness: { scope: [:event_id] }
+  validates :user_id, uniqueness: { scope: :event_id }
 
   def waited?
     saved_change_to_attribute?('enable', from: false, to: true)


### PR DESCRIPTION
Issue #3757 

## バグの再現
1. ログインしたユーザーとして http://localhost:3000 を開く
2. 「イベント」をクリックする
3. 「募集期間中のイベント(補欠者なし)」のイベントのブラウザタブを2つ開く
4. 2つのタブの両方で「参加申込」ボタンをクリックする

## 修正前
![Screen Shot 2021-12-16 at 10 05 09](https://user-images.githubusercontent.com/91442824/146300756-a5d4f291-1351-42ef-a562-a72ca94326eb.png)

## 修正後
![Screen Shot 2021-12-16 at 10 06 47](https://user-images.githubusercontent.com/91442824/146300915-99ff0407-8069-4290-9aa9-2ad23c1d1136.png)
