### PR TITLE
メンターでログインしたときだけ、その人の日報個別ページに提出物一覧を表示する

### DIFF
--- a/app/assets/stylesheets/atoms/_a-card.sass
+++ b/app/assets/stylesheets/atoms/_a-card.sass
@@ -13,7 +13,7 @@
       margin-top: 1rem
   &.is-borderd
     border: solid 4px $welcome-default-text
-  [class*=col-] + [class*=col-] &:first-child
+  [class*=col-] + [class*=col-] >&:first-child
     +media-breakpoint-down(md)
       margin-top: 1rem
   &.is-modal

--- a/app/assets/stylesheets/blocks/side/_side-tabs-nav.sass
+++ b/app/assets/stylesheets/blocks/side/_side-tabs-nav.sass
@@ -4,22 +4,20 @@
   +margin(horizontal, auto)
   max-width: 50rem
 
-#side-tabs-1:checked ~ .side-tabs-nav #side-tabs-nav-1
-  background-color: $base
-  color: $default-text
+.side-tabs-nav__item
+  min-width: 6.5rem
 
-#side-tabs-2:checked ~ .side-tabs-nav #side-tabs-nav-2
-  background-color: $base
-  color: $default-text
-
+#side-tabs-1:checked ~ .side-tabs-nav #side-tabs-nav-1,
+#side-tabs-2:checked ~ .side-tabs-nav #side-tabs-nav-2,
 #side-tabs-3:checked ~ .side-tabs-nav #side-tabs-nav-3
   background-color: $base
   color: $default-text
 
 .side-tabs-nav__item-link
-  +text-block(.8125rem 1.4, flex 600)
+  +text-block(.8125rem 1.4, flex 600 center)
+  justify-content: center
   cursor: pointer
-  padding: .75em 1.25em
+  padding: .75em 1em
   border: solid 1px $border-more-shade
   border-bottom: none
   +position(relative, bottom -1px)

--- a/app/assets/stylesheets/blocks/side/_side-tabs.sass
+++ b/app/assets/stylesheets/blocks/side/_side-tabs.sass
@@ -1,2 +1,5 @@
 .side-tabs
-  +position(sticky, top 3.125rem)
+  +media-breakpoint-up(lg)
+    +position(sticky, top 3.125rem)
+  +media-breakpoint-down(md)
+    margin-top: 1.5rem

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -17,6 +17,7 @@ class ReportsController < ApplicationController
   def index; end
 
   def show
+    @products = @report.user.products.order(published_at: :DESC)
     footprint!
     respond_to do |format|
       format.html

--- a/app/views/reports/_product.html.slim
+++ b/app/views/reports/_product.html.slim
@@ -1,0 +1,45 @@
+.thread-list-item(class="#{product.wip? ? 'is-wip' : ''}")
+  .thread-list-item__inner
+    .thread-list-item__user
+      = render 'users/icon', user: product.user, link_class: 'a-user-name', image_class: 'thread-list-item__user-icon'
+    .thread-list-item__rows
+      .thread-list-item__row
+        .thread-list-item-title
+          .thread-list-item-title__start
+            - if product.wip?
+              .thread-list-item-title__icon.is-wip WIP
+            h2.thread-list-item-title__title(itemprop="name")
+              = link_to product, itemprop: 'url', class: 'thread-list-item-title__link js-unconfirmed-link' do
+                - if product.user.daimyo?
+                  | ★
+                = product.title
+      .thread-list-item__row
+        .thread-list-item-meta
+          .thread-list-item-meta__items
+            .thread-list-item-meta__item
+              time.a-meta(datetime="#{product.published_at.to_datetime}")
+                = l product.published_at
+                = 'の提出物'
+      - if product.comments.any?
+        hr.thread-list-item__row-separator
+        .thread-list-item__row
+          .thread-list-item-meta
+            .thread-list-item-meta__items
+              .thread-list-item-meta__item
+                .thread-list-item-comment
+                  .thread-list-item-comment__label
+                    | コメント
+                  .thread-list-item-comment__count
+                    | （#{product.comments.size}）
+                  .thread-list-item-comment__user-icons
+                    = render partial: 'comments/user_icons', collection: product.comments.commented_users, as: :user
+                  time.a-meta(datetime="#{product.comments.last.updated_at.to_datetime}" pubdate='pubdate')
+                    | 〜 #{l product.comments.last.updated_at, format: :date_and_time}
+
+    - if product.checks.any?
+      .stamp.stamp-approve
+        h2.stamp__content.is-title 確認済
+        time.stamp__content.is-created-at
+          = l product.checks.last.created_at.to_date, format: :short
+        .stamp__content.is-user-name
+          = product.checks.last.user.login_name

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -153,7 +153,7 @@ header.page-header
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
                 #js-user-mentor-memo(data-user-id='#{@report.user_id}')
               .side-tabs-contents__item#side-tabs-content-3.is-only-mentor
-                thread-list.a-card
+                .thread-list.a-card
                   - if @products.present?
                     - @products.each do |product|
                       = render partial: 'product', locals: { product: product }

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -135,6 +135,7 @@ header.page-header
           .side-tabs
             input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
             input.a-toggle-checkbox#side-tabs-2 type='radio' name='side-tabs-contents'
+            input.a-toggle-checkbox#side-tabs-3 type='radio' name='side-tabs-contents'
             .side-tabs-nav.is-only-mentor
               .side-tabs-nav__items
                 .side-tabs-nav__item
@@ -143,10 +144,26 @@ header.page-header
                 .side-tabs-nav__item
                   label.side-tabs-nav__item-link#side-tabs-nav-2 for='side-tabs-2'
                     | ユーザーメモ
+                .side-tabs-nav__item
+                  label.side-tabs-nav__item-link#side-tabs-nav-3 for='side-tabs-3'
+                    | 提出物
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
                 #js-user-recent-reports(user-id="#{@report.user.id}")
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
                 #js-user-mentor-memo(data-user-id='#{@report.user_id}')
+              .side-tabs-contents__item#side-tabs-content-3.is-only-mentor
+                thread-list.a-card
+                  - if @products.present?
+                    - @products.each do |product|
+                      = render partial: 'product', locals: { product: product }
+                  - else
+                    .thread-list__inner
+                      .container
+                        .o-empty-message
+                          .o-empty-message__icon
+                            i.far.fa-sad-tear
+                          .o-empty-message__text
+                            | 提出物はまだありません。
         - else
           #js-user-recent-reports(user-id="#{@report.user.id}")

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -553,4 +553,17 @@ class ReportsTest < ApplicationSystemTestCase
     click_button '提出'
     assert_text '学習日は今日以前の日付にしてください'
   end
+
+  test 'display list of submission when mentor is access' do
+    visit_with_auth report_path(reports(:report5)), 'komagata'
+    assert_text '提出物'
+    find('#side-tabs-nav-3').click
+    assert_text 'Terminalの基礎を覚える'
+    assert_text 'PC性能の見方を知る'
+  end
+
+  test 'not display list of submission when mentor is access' do
+    visit_with_auth report_path(reports(:report5)), 'kimura'
+    assert_no_selector '#side-tabs-content-3'
+  end
 end


### PR DESCRIPTION
Issue: #3740 

## 変更前
<img width="1131" alt="スクリーンショット 2021-12-16 11 06 53" src="https://user-images.githubusercontent.com/38340962/146306468-973ce6d3-c554-4ab4-a21b-877dcff971cd.png">

## 変更後
<img width="1124" alt="スクリーンショット 2021-12-16 11 07 48" src="https://user-images.githubusercontent.com/38340962/146306504-852c757d-f13b-46f9-b544-0e5a62024d1a.png">

