### PR TITLE
ユーザー退会時、管理者へ退会のメール通知が届くように修正

### DIFF
--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -35,6 +35,7 @@ class RetirementController < ApplicationController
   def notify_to_admins(current_user)
     User.admins.each do |admin_user|
       Notification.retired(current_user, admin_user)
+      NotificationFacade.retired(current_user, admin_user)
     end
   end
 end

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -14,7 +14,7 @@ class RetirementController < ApplicationController
       user = current_user
       UserMailer.retire(user).deliver_now
       destroy_subscription
-      notify_to_admins
+      notify_to_admins(user)
       logout
       redirect_to retirement_url
     else
@@ -32,7 +32,7 @@ class RetirementController < ApplicationController
     Subscription.new.destroy(current_user.subscription_id) if current_user.subscription_id
   end
 
-  def notify_to_admins
+  def notify_to_admins(current_user)
     User.admins.each do |admin_user|
       Notification.retired(current_user, admin_user)
     end

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -34,7 +34,6 @@ class RetirementController < ApplicationController
 
   def notify_to_admins
     User.admins.each do |admin_user|
-      Notification.retired(current_user, admin_user)
       NotificationFacade.retired(current_user, admin_user)
     end
   end

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -14,7 +14,7 @@ class RetirementController < ApplicationController
       user = current_user
       UserMailer.retire(user).deliver_now
       destroy_subscription
-      notify_to_admins(user)
+      notify_to_admins
       logout
       redirect_to retirement_url
     else
@@ -32,7 +32,7 @@ class RetirementController < ApplicationController
     Subscription.new.destroy(current_user.subscription_id) if current_user.subscription_id
   end
 
-  def notify_to_admins(current_user)
+  def notify_to_admins
     User.admins.each do |admin_user|
       Notification.retired(current_user, admin_user)
       NotificationFacade.retired(current_user, admin_user)


### PR DESCRIPTION
Issue #3782

## 概要
ユーザーが退会すると「XXさんが退会しました。」の文面の退会通知メールが管理者宛に届くようになる。

## 変更前
ユーザーが退会すると「XXさんが退会しました。」の文面のメールが管理者宛に届くはずだが、現状ではメールが届かない。（サイト内通知は来ます）

![image](https://user-images.githubusercontent.com/80372144/146325329-ea5730d6-ac26-4a73-bfb6-5207defb9c50.png)

## 変更後

ユーザーが退会するとサイト内通知と同様にメール通知が来ます。

* サイト内通知
<img width="310" alt="スクリーンショット 2021-12-16 16 26 49" src="https://user-images.githubusercontent.com/80372144/146326822-1eb2df4b-2753-4741-880f-0e251075f8fd.png">

* メール通知
<img width="786" alt="スクリーンショット 2021-12-16 16 27 02" src="https://user-images.githubusercontent.com/80372144/146326914-a95eb3f0-df8c-4808-ace9-42cbcc7a11be.png">


## ローカルでの動作確認方法

### メールが届かないことを確認
手元にある`main`ブランチ（または他のブランチ）にてユーザー退会時に「XXさんが退会しました。」の文面の退会通知メールが来ないことを確認する。

1. `kimura`でログイン
退会手続きから退会処理を行う

<img width="318" alt="スクリーンショット 2021-12-16 16 31 39" src="https://user-images.githubusercontent.com/80372144/146327358-ce49e15d-d063-4c47-86a3-4b6e6d6f38fd.png">

<img width="513" alt="スクリーンショット 2021-12-16 16 32 34" src="https://user-images.githubusercontent.com/80372144/146327494-10e43f4d-0a65-4deb-b6e9-0fed42d50eec.png">

2. 退会処理後、管理者（`komagata`）としてログイン
サイト内通知にて「退会しました」の通知が来ていることを確認

3. `http://localhost:3000/letter_opener`にアクセスし、メール通知は来ていないことを確認

## メールが届くことを確認
1. 手元に本ブランチを持ってくる
2. `with_hyphen`でログイン後、退会手続きから退会処理を行う
3. 退会処理後、管理者（`komagata`）としてログイン
サイト内通知にて「退会しました」の通知が来ていることを確認
4.  `http://localhost:3000/letter_opener`にアクセスし、メール通知も来ていることを確認


