### PR TITLE
コースの削除ボタン（機能も）取る #3716

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -30,11 +30,6 @@ class Admin::CoursesController < AdminController
     end
   end
 
-  def destroy
-    @course.destroy
-    redirect_to admin_courses_path, notice: 'コースを削除しました。'
-  end
-
   private
 
   def set_course

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::CoursesController < AdminController
-  before_action :set_course, only: %i[edit update destroy]
+  before_action :set_course, only: %i[edit update]
 
   def index
     @courses = Course.order(created_at: :desc)

--- a/app/views/admin/courses/_course.html.slim
+++ b/app/views/admin/courses/_course.html.slim
@@ -11,6 +11,3 @@ tr.admin-table__item(id="course_#{course.id}")
       li
         = link_to course_categories_path(course), class: 'a-button is-sm is-secondary is-icon is-block' do
           i.fas.fa-align-justify
-      li
-        = link_to admin_course_path(course), method: :delete, class: 'a-button is-sm is-danger is-icon is-block js-delete', data: { confirm: '本当によろしいですか？' } do
-          i.far.fa-trash-alt

--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -24,5 +24,3 @@
                   i.fas.fa-align-justify
                   | 並び替え
               li.card-main-actions__item.is-end
-                = link_to admin_course_path(course), method: :delete, class: 'card-main-actions__delete js-delete', data: { confirm: '本当によろしいですか？' } do
-                  | 削除

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
       resource :password, only: %i(edit update), controller: "users/password"
     end
     resources :categories, except: %i(show)
-    resources :courses, except: %i(show)
+    resources :courses, except: %i(show destroy)
   end
 end

--- a/test/system/admin/courses_test.rb
+++ b/test/system/admin/courses_test.rb
@@ -27,12 +27,4 @@ class Admin::CoursesTest < ApplicationSystemTestCase
     end
     assert_text 'コースを更新しました。'
   end
-
-  test 'delete course' do
-    visit_with_auth '/admin/courses', 'komagata'
-    accept_confirm do
-      find("#course_#{courses(:course3).id} .js-delete").click
-    end
-    assert_text 'コースを削除しました。'
-  end
 end

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -29,14 +29,6 @@ class CoursesTest < ApplicationSystemTestCase
     assert_text 'コースを更新しました。'
   end
 
-  test 'delete course' do
-    visit_with_auth '/courses', 'komagata'
-    accept_confirm do
-      find("#course_#{courses(:course3).id} .js-delete").click
-    end
-    assert_text 'コースを削除しました。'
-  end
-
   test 'show published courses' do
     visit_with_auth '/courses', 'yamada'
     assert_no_text courses(:course1).title


### PR DESCRIPTION
[issue3716](https://github.com/fjordllc/bootcamp/issues/3716)

## 概要
コースの削除機能が必要ないため、削除ボタンと削除機能を取り除いた

### コース一覧から削除ボタンを取り除く
path: http://localhost:3000/courses
#### 修正前
<img width="943" alt="コース一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/146380044-2f2a341c-3316-4fad-8d1f-1d8e35619e02.png">

#### 修正後
<img width="940" alt="コース一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/146380782-bec8f8b2-299e-4e8b-9a88-c553c187a4b5.png">


### 管理ページのコースにある削除ボタンを取り除く
path: http://localhost:3000/admin/courses
#### 修正前
<img width="1154" alt="管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/146380080-3b432867-d6af-43e4-a4d8-b9e5ebed1634.png">
#### 修正後
<img width="1155" alt="管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/146380649-40d7a6c8-7201-45d7-8cf6-5f0947d62e4e.png">

