### PR TITLE
イベントに就活イベントフラグを追加した

### DIFF
--- a/app/assets/stylesheets/blocks/form/_checkboxes.sass
+++ b/app/assets/stylesheets/blocks/form/_checkboxes.sass
@@ -49,3 +49,5 @@ $checkbox-size: .875rem
   input
     opacity: 0
     +position(absolute, left 0, top 0)
+    +size(0)
+    overflow: hidden

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -54,7 +54,8 @@ class EventsController < ApplicationController
       :start_at,
       :end_at,
       :open_start_at,
-      :open_end_at
+      :open_end_at,
+      :job_hunting
     )
   end
 

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -23,6 +23,9 @@
       .form-item
         = f.label :open_end_at, class: 'a-form-label'
         = f.datetime_field :open_end_at, class: 'a-text-input js-warning-form'
+      .form-item
+        = f.label :job_hunting, class: 'a-form-label'
+        = f.check_box :job_hunting, class: 'a-text-input js-warning-form'
   .form__items
     .form-item
       .row.js-markdown-parent

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -24,8 +24,14 @@
         = f.label :open_end_at, class: 'a-form-label'
         = f.datetime_field :open_end_at, class: 'a-text-input js-warning-form'
       .form-item
-        = f.label :job_hunting, class: 'a-form-label'
-        = f.check_box :job_hunting, class: 'a-text-input js-warning-form'
+        label.a-form-label
+          | イベント内容
+        .checkboxes
+          ul.checkboxes__items
+            li.checkboxes__item
+              = f.label :job_hunting do
+                | 就活関係のイベントの場合はチェック
+                = f.check_box :job_hunting, class: 'a-text-input js-warning-form'
   .form__items
     .form-item
       .row.js-markdown-parent

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -171,6 +171,7 @@ ja:
         end_at: イベント終了日時
         open_start_at: 募集開始日時
         open_end_at: 募集終了日時
+        job_hunting: 就活関係のイベントの場合はチェック
       reference_book:
         title: タイトル
         price: 価格

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -171,7 +171,6 @@ ja:
         end_at: イベント終了日時
         open_start_at: 募集開始日時
         open_end_at: 募集終了日時
-        job_hunting: 就活関係のイベントの場合はチェック
       reference_book:
         title: タイトル
         price: 価格

--- a/db/migrate/20211217034500_add_job_hunting_to_events.rb
+++ b/db/migrate/20211217034500_add_job_hunting_to_events.rb
@@ -1,0 +1,5 @@
+class AddJobHuntingToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :job_hunting, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_10_063403) do
+ActiveRecord::Schema.define(version: 2021_12_17_034500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(version: 2021_11_10_063403) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "wip", default: false, null: false
+    t.boolean "job_hunting", default: false, null: false
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 


### PR DESCRIPTION
issue: #3748 
# 概要
イベントのお知らせを出し分けするための準備として、イベントに就活関係のフラグを持たせたい

# 変更前
![スクリーンショット 2021-12-17 14 13 56](https://user-images.githubusercontent.com/73326842/146492605-e12f8aca-3de1-4ca1-b63c-05ccf9f2ff3b.png)
# 変更後
![スクリーンショット 2021-12-17 14 14 38](https://user-images.githubusercontent.com/73326842/146492673-1fb42bda-d76a-4c6c-8774-1ef01606a7e1.png)

「就活関係のイベントの場合はチェック」をチェックしてWIPすると、`job_hunting`属性がtrueのイベントデータが作成されます。`job_hunting`属性のデフォルトはfalseです。

