### PR TITLE
updateをsaveに変更

### DIFF
--- a/db/data/20201124023746_add_unsubscribe_email_token.rb
+++ b/db/data/20201124023746_add_unsubscribe_email_token.rb
@@ -4,7 +4,8 @@ class AddUnsubscribeEmailToken < ActiveRecord::Migration[6.0]
   def up
     User.transaction do
       User.where(unsubscribe_email_token: nil).find_each do |user|
-        user.update!(unsubscribe_email_token: SecureRandom.urlsafe_base64)
+        user.unsubscribe_email_token = SecureRandom.urlsafe_base64
+        user.save!(validate: false)
       end
     end
   end

--- a/db/data/20210616072230_add_empty_string_to_nil_description.rb
+++ b/db/data/20210616072230_add_empty_string_to_nil_description.rb
@@ -3,7 +3,10 @@
 class AddEmptyStringToNilDescription < ActiveRecord::Migration[6.1]
   def up
     User.find_each do |user|
-      user.update!(description: '自己紹介文はありません。') if user.description.nil?
+      if user.description.nil?
+        user.description = '自己紹介文はありません。'
+        user.save!(validate: false)
+      end
     end
   end
 

--- a/db/data/20211208002045_convert_report_emotion_null_to_soso.rb
+++ b/db/data/20211208002045_convert_report_emotion_null_to_soso.rb
@@ -3,7 +3,8 @@
 class ConvertReportEmotionNullToSoso < ActiveRecord::Migration[6.1]
   def up
     Report.where(emotion: nil).find_each do |report|
-      report.update!(emotion: Report.emotions[:soso])
+      report.emotion = Report.emotions[:soso]
+      report.save!(validate: false)
     end
   end
 


### PR DESCRIPTION
updateメソッドではvalidationをかけないということができず、
既存のデータを更新するときにvalidationに引っ掛かってしまうため。

Ref: #3692