### PR TITLE
提出物一覧ページの「未アサイン」タブのバッジに表示する件数を適切に増減させる

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -164,6 +164,10 @@ class Product < ApplicationRecord
     checker_id.present? && checker_id.to_s != current_user_id
   end
 
+  def unassigned?
+    checker_id.nil?
+  end
+
   def checker_name
     checker_id ? User.find(checker_id).login_name : nil
   end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -14,6 +14,7 @@ class ProductCallbacks
 
     checker_id = product.checker_id || product.attribute_before_last_save('checker_id')
     Cache.delete_self_assigned_no_replied_product_count(checker_id)
+    Cache.delete_unassigned_product_count
   end
 
   def after_save(product)

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -43,7 +43,7 @@ class ProductCallbacks
     delete_notification(product)
 
     Cache.delete_unchecked_product_count
-    Cache.delete_unassigned_product_count
+    Cache.delete_unassigned_product_count if product.unassigned?
     Cache.delete_self_assigned_no_replied_product_count(product.checker_id)
   end
 

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -363,3 +363,9 @@ product63:
   body: 「自分の担当」かつ「返信済み」の提出物
   wip: false
   checker_id: <%= ActiveRecord::FixtureSet.identify(:machida) %>
+
+product64:
+  practice: practice10
+  user: kimura
+  body: 担当者のいる提出物です。
+  checker_id: "<%= ActiveRecord::FixtureSet.identify(:machida) %>"

--- a/test/models/caches/unassigned_product_count_test.rb
+++ b/test/models/caches/unassigned_product_count_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UnassignedProductCountTest < ActiveSupport::TestCase
+  test 'cached count of unassigned products increases by 1 after creating a product' do
+    assert_difference 'Cache.unassigned_product_count', 1 do
+      Product.create!(practice: practices(:practice5), user: users(:kimura), body: 'test')
+    end
+  end
+
+  test 'cached count of unassigned products decreases by 1 after destroying an unassigned product' do
+    unassigned_product = Product.not_wip.unassigned.first
+
+    assert_difference 'Cache.unassigned_product_count', -1 do
+      unassigned_product.destroy!
+    end
+  end
+
+  test 'cached count of unassigned products decreases by 1 after a mentor gets assigned to an unassigned product' do
+    unassigned_product = Product.not_wip.unassigned.first
+
+    assert_difference 'Cache.unassigned_product_count', -1 do
+      unassigned_product.update!(checker_id: users(:machida).id)
+    end
+  end
+
+  test 'cached count of unassigned products increases by 1 after a mentor gets unassigned from an assigned product' do
+    assigned_product = Product.self_assigned_product(users(:machida).id).first
+
+    assert_difference 'Cache.unassigned_product_count', 1 do
+      assigned_product.update!(checker_id: nil)
+    end
+  end
+end


### PR DESCRIPTION
## 目的

以下の Issue の対応

Refs: #3646

## やったこと

### 担当者が更新されたときに提出物の未アサイン件数のキャッシュを削除するようにした

以下2パターンで削除するようにした

1. 未アサインの（担当のいない）提出物に担当がついたとき
    - #3646 の対応がこれにあたる
1.  アサイン済みの（担当のいる）提出物から担当が外れたとき

### 未アサイン件数のキャッシュを削除する条件に「削除された提出物が『未アサイン』であること」を追加した

アサイン済み（担当のいる）の提出物が削除されたときは未アサイン件数は変わらないため、その場合はキャッシュを削除せず、「未アサイン」の場合のみキャッシュを削除するようにした。今までは「未アサイン」かどうかによらずキャッシュを削除していた。

### テストを追加した

未アサイン件数のキャッシュが増減することを確認するテストを追加

## 動作確認

### すべての確認項目に共通すること

- `$ rails dev:cache`を実行してキャッシュを有効にした状態で確認する
    - 詳細は下記の「動作確認をするときの注意事項」に記載
- 確認対象は「未アサイン」タブのバッジに表示される件数（以下、未アサイン件数）
- メンター ( `komagata` など）としてログインする
- 操作の始めに提出物一覧ページの未アサイン件数を確認する
    - http://127.0.0.1:3000/products/unassigned

### 確認項目

- [ ]  「未アサイン」の提出物の担当になったあとに画面を更新すると、未アサイン件数が1件減っていること
- [ ] 「自分の担当」の提出物の担当から外れたあとに画面を更新すると、未アサイン件数が1件増えていること
- [ ]  新しい提出物から作成されたあと、未アサイン件数が1件増えていること
- [ ]  「未アサイン」の提出物が削除されたあと、未アサイン件数が1件減っていること

---

以下、補足説明

## 未アサイン件数の表示箇所（「未アサイン」タブのバッジ）のキャプチャ

![image](https://user-images.githubusercontent.com/15713392/146523848-9391e1a1-6b2c-4b7d-877a-dce206e831e0.png)

## 動作確認をするときの注意事項

development モードと test モードの場合はデフォルトでキャッシュが無効になっているため、ローカルでサーバーを起動して動作確認するとき（development モードのとき）や `$ rails test xxx` を実行するとき（test モードのとき）は、以下のようにして事前にキャッシュを有効にしておく必要があります。

### development モード

- `$ rails dev:cache`を実行してキャッシュのオン/オフを切り替える（オンにする）
- （参考）[development環境のキャッシュ](https://railsguides.jp/caching_with_rails.html#development%E7%92%B0%E5%A2%83%E3%81%AE%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5)

### test モード

`config/environments/test.rb` を修正し、キャッシュストアとして `:memory_store` （[ActiveSupport::Cache::MemoryStore](https://railsguides.jp/caching_with_rails.html#activesupport-cache-memorystore) ）を使うように設定する
    
```
diff --git a/config/environments/test.rb b/config/environments/test.rb
index e080eba6d..c20b14524 100644
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :memory_store

   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

```

## #3646 でテストが落ちる原因

未アサイン（担当のいない）の提出物に担当がついたときに、未アサイン件数のキャッシュが削除されていないため

※ キャッシュが削除されないと、オリジナルの値に変更があっても更新されない

## 未アサイン件数が増減する（キャッシュを削除するべき）条件と、その対応の要不要

#3646 テストの手順以外にもキャッシュが削除されていないケースがないか確認するために調査した。
調査した結果、以下の表の条件で未アサイン件数が増減することがわかった。また、それぞれの条件について対応の要不要を調べた。

**凡例**
○: 対応不要（キャッシュを削除できている）
△: 対応が必要（キャッシュを削除できているけれど、削除不要なときも削除している）
×: 対応が必要（キャッシュを削除できていない）

| 条件No. | キャッシュ削除の条件                     | ○/☆/★                                       |
|---------|------------------------------------------|---------------------------------------------|
|       1 | 未アサインの提出物に担当がついたとき     | ×                                           |
|       2 | アサイン済みの提出物から担当が外れたとき | ×                                           |
|       3 | 提出物が作成されたとき（常に未アサイン） | ○                                           |
|       4 | 未アサインの提出物が削除されたとき       | △（未アサインかどうかをチェックしていない） |

## キャッシュ削除の具体的な条件

具体的にどのような条件でキャッシュを削除するか表に整理した。↑の表と同じ条件は「条件No. 」の値を同じにしている。

※表の読み方: 【モデル】のレコードを 【作成/更新/削除】するときにレコードが【条件1】かつ【条件2】かつ【条件3】... の場合はキャッシュを削除する。なお、その後はキャッシュに保持する値が【キャッシュの増減値】される。

| 条件No. | モデル  | 作成/更新/削除 | 条件1                                              | 条件2              | 増減値 |
|---------|---------|----------------|----------------------------------------------------|--------------------|--------|
|       1 | Product | 作成           | 未アサイン（作成時は未アサインなのでチェック不要） | （なし）           |     +1 |
|       2 | Product | 削除           | 未アサイン                                         | （なし）           |     -1 |
|       3 | Product | 更新           | 更新前が未アサイン                                 | 更新後がアサイン済 |     -1 |
|       4 | Product | 更新           | 更新前がアサイン済                                 | 更新後が未アサイン |     +1 |


