### PR TITLE
マークダウンの見出しにanchorを入れる

### DIFF
--- a/app/assets/stylesheets/blocks/base/_body.sass
+++ b/app/assets/stylesheets/blocks/base/_body.sass
@@ -1,6 +1,9 @@
 html
   font-family: $basic-serif
   color: $default-text
+  &.is-application
+    +media-breakpoint-up(md)
+      scroll-padding-top: 3.75rem
 
 body
   background-color: $background

--- a/app/assets/stylesheets/modules/_markdown_it.sass
+++ b/app/assets/stylesheets/modules/_markdown_it.sass
@@ -32,5 +32,6 @@ h6
   align-items: center
   justify-content: flex-start
   +position(absolute, left -1.25rem, bottom 0)
-  opacity: 0
   transition: opacity .2s ease-out
+  body.is-production &
+    opacity: 0

--- a/app/assets/stylesheets/modules/_markdown_it.sass
+++ b/app/assets/stylesheets/modules/_markdown_it.sass
@@ -1,8 +1,36 @@
 .js-markdown-view
-  h1::before, h2::before, h3::before, h4::before, h5::before, h6::before
-    display: block
-    content: " "
-    margin-top: -60px
-    height: 60px
-    visibility: hidden
-    pointer-events: none
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6
+    &::before
+      display: block
+      content: " "
+      margin-top: -3.75rem
+      height: 3.75rem
+      visibility: hidden
+      pointer-events: none
+h1,
+h2,
+h3,
+h4,
+h5,
+h6
+  cursor: pointer
+  position: relative
+  &:hover
+    .header-anchor
+      opacity: 1
+
+.header-anchor
+  display: flex
+  +text-block(1rem, 400)
+  text-decoration: none !important
+  +size(#{calc(100% + 1.25rem)} 2.75rem)
+  align-items: center
+  justify-content: flex-start
+  +position(absolute, left -1.25rem, bottom 0)
+  opacity: 0
+  transition: opacity .2s ease-out

--- a/app/assets/stylesheets/modules/_markdown_it.sass
+++ b/app/assets/stylesheets/modules/_markdown_it.sass
@@ -5,11 +5,11 @@
   h4,
   h5,
   h6
+    scroll-snap-align: start
+    scroll-snap-stop: always
     &::before
       display: block
       content: " "
-      margin-top: -3.75rem
-      height: 3.75rem
       visibility: hidden
       pointer-events: none
 h1,
@@ -33,5 +33,4 @@ h6
   justify-content: flex-start
   +position(absolute, left -1.25rem, bottom 0)
   transition: opacity .2s ease-out
-  body.is-production &
-    opacity: 0
+  opacity: 0

--- a/app/assets/stylesheets/modules/_markdown_it.sass
+++ b/app/assets/stylesheets/modules/_markdown_it.sass
@@ -1,0 +1,8 @@
+.js-markdown-view
+  h1::before, h2::before, h3::before, h4::before, h5::before, h6::before
+    display: block
+    content: " "
+    margin-top: -60px
+    height: 60px
+    visibility: hidden
+    pointer-events: none

--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -10,6 +10,7 @@ import MarkdownItTaskListsInitializer from './markdown-it-task-lists-initializer
 import MarkdownItHeadings, {
   initMarkdownItHeadings
 } from './markdown-it-headings'
+import MarkdownItHeadings from './markdown-it-headings'
 
 export default class {
   replace(selector) {
@@ -24,12 +25,8 @@ export default class {
     })
 
     new UserIconRenderer().render(selector)
-
-<<<<<<< HEAD
     MarkdownItTaskListsInitializer.initialize()
-=======
     initMarkdownItHeadings()
->>>>>>> d3c3d4bae (マックダウンの見出しにanchorを入れる)
   }
 
   render(text) {

--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -23,7 +23,6 @@ export default class {
 
     new UserIconRenderer().render(selector)
     MarkdownItTaskListsInitializer.initialize()
-    initMarkdownItHeadings()
   }
 
   render(text) {

--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -7,9 +7,6 @@ import MarkdownItLinkingImage from './markdown-it-linking-image'
 import MarkdownOption from './markdown-it-option'
 import UserIconRenderer from './user-icon-renderer'
 import MarkdownItTaskListsInitializer from './markdown-it-task-lists-initializer'
-import MarkdownItHeadings, {
-  initMarkdownItHeadings
-} from './markdown-it-headings'
 import MarkdownItHeadings from './markdown-it-headings'
 
 export default class {

--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -7,6 +7,9 @@ import MarkdownItLinkingImage from './markdown-it-linking-image'
 import MarkdownOption from './markdown-it-option'
 import UserIconRenderer from './user-icon-renderer'
 import MarkdownItTaskListsInitializer from './markdown-it-task-lists-initializer'
+import MarkdownItHeadings, {
+  initMarkdownItHeadings
+} from './markdown-it-headings'
 
 export default class {
   replace(selector) {
@@ -22,7 +25,11 @@ export default class {
 
     new UserIconRenderer().render(selector)
 
+<<<<<<< HEAD
     MarkdownItTaskListsInitializer.initialize()
+=======
+    initMarkdownItHeadings()
+>>>>>>> d3c3d4bae (マックダウンの見出しにanchorを入れる)
   }
 
   render(text) {
@@ -32,6 +39,7 @@ export default class {
     md.use(MarkdownItUserIcon)
     md.use(MarkdownItLinkingImage)
     md.use(MarkdownItTaskLists)
+    md.use(MarkdownItHeadings)
 
     return md.render(text)
   }

--- a/app/javascript/markdown-it-headings.js
+++ b/app/javascript/markdown-it-headings.js
@@ -1,0 +1,49 @@
+import plugin from 'markdown-it-github-headings'
+
+const options = {
+  enableHeadingLinkIcons: true,
+  prefixHeadingIds: true,
+  prefix: 'user-content-',
+  className: 'md-headings',
+  linkIcon:
+    '<svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg>',
+  resetSlugger: true,
+  headerHeight: 60,
+  delayScroll: 1000
+}
+
+function scrollOutHeader(target) {
+  target.scrollIntoView(true)
+  const scrolledY = window.scrollY
+  if (scrolledY) {
+    window.scroll(0, scrolledY - options.headerHeight)
+  }
+}
+
+function addMarkdownHeadingsClickListener() {
+  const targets = document.getElementsByClassName(options.className)
+
+  for (let i = 0; i < targets.length; i++) {
+    targets[i].addEventListener('click', function () {
+      scrollOutHeader(targets[i])
+    })
+  }
+}
+
+function scrollToLocationHashMarkdownHeading() {
+  if (!location.hash) return
+  if (document.querySelector(':target')) return
+  const postfix = decodeURI(location.hash.slice(1))
+  const name = options.prefix + postfix
+  const target = document.getElementById(name)
+  scrollOutHeader(target)
+}
+
+export function initMarkdownItHeadings() {
+  addMarkdownHeadingsClickListener()
+  setTimeout(scrollToLocationHashMarkdownHeading, options.delayScroll)
+}
+
+export default function (md) {
+  return plugin(md, options)
+}

--- a/app/javascript/markdown-it-headings.js
+++ b/app/javascript/markdown-it-headings.js
@@ -1,47 +1,13 @@
-import plugin from 'markdown-it-github-headings'
+import plugin from 'markdown-it-anchor'
+import slugify from '@sindresorhus/slugify'
 
 const options = {
-  enableHeadingLinkIcons: true,
-  prefixHeadingIds: true,
-  prefix: 'user-content-',
-  className: 'md-headings',
-  linkIcon:
-    '<svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg>',
-  resetSlugger: true,
-  headerHeight: 60,
-  delayScroll: 1000
-}
-
-function scrollOutHeader(target) {
-  target.scrollIntoView(true)
-  const scrolledY = window.scrollY
-  if (scrolledY) {
-    window.scroll(0, scrolledY - options.headerHeight)
-  }
-}
-
-function addMarkdownHeadingsClickListener() {
-  const targets = document.getElementsByClassName(options.className)
-
-  for (let i = 0; i < targets.length; i++) {
-    targets[i].addEventListener('click', function () {
-      scrollOutHeader(targets[i])
-    })
-  }
-}
-
-function scrollToLocationHashMarkdownHeading() {
-  if (!location.hash) return
-  if (document.querySelector(':target')) return
-  const postfix = decodeURI(location.hash.slice(1))
-  const name = options.prefix + postfix
-  const target = document.getElementById(name)
-  scrollOutHeader(target)
-}
-
-export function initMarkdownItHeadings() {
-  addMarkdownHeadingsClickListener()
-  setTimeout(scrollToLocationHashMarkdownHeading, options.delayScroll)
+  permalink: plugin.permalink.linkInsideHeader({
+    symbol: '<i class="fas fa-link"></i>',
+    placement: 'before',
+    ariaHidden: true
+  }),
+  slugify: (s) => slugify(s)
 }
 
 export default function (md) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lodash.template": "^4.5.0",
     "markdown-it": "^12.3.2",
     "markdown-it-emoji": "^1.4.0",
+    "markdown-it-github-headings": "^2.0.0",
     "markdown-it-regexp": "^0.4.0",
     "markdown-it-task-lists": "^2.1.1",
     "mem": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@johmun/vue-tags-input": "^2.0.1",
     "@rails/webpacker": "5.3.0",
+    "@sindresorhus/slugify": "^2.1.0",
     "autosize": "^4.0.2",
     "css-loader": "^5.0.1",
     "dayjs": "^1.10.4",
@@ -17,8 +18,8 @@
     "lodash": "^4.17.19",
     "lodash.template": "^4.5.0",
     "markdown-it": "^12.3.2",
+    "markdown-it-anchor": "^8.4.1",
     "markdown-it-emoji": "^1.4.0",
-    "markdown-it-github-headings": "^2.0.0",
     "markdown-it-regexp": "^0.4.0",
     "markdown-it-task-lists": "^2.1.1",
     "mem": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,6 +3490,11 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
+github-slugger@^1.1.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.4.0.tgz#206eb96cdb22ee56fdc53a28d5a302338463444e"
+  integrity sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -3729,7 +3734,7 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
-html-entities@^1.3.1:
+html-entities@^1.2.0, html-entities@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
   integrity sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==
@@ -3924,6 +3929,13 @@ ini@^1.3.4, ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+innertext@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/innertext/-/innertext-1.0.3.tgz#f1a8767592bcdcce2ea94e686ed41a86ba4e8df0"
+  integrity sha512-ZC410b7IbrTrmt8bQb27xUOJgXkJu+XL6MVncb9FGyxjRIHyQqNjpSDY20zvSUttkAiYj0dait/67/sXyWvwYg==
+  dependencies:
+    html-entities "^1.2.0"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -4604,6 +4616,14 @@ markdown-it-emoji@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
   integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
+
+markdown-it-github-headings@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-github-headings/-/markdown-it-github-headings-2.0.0.tgz#f8d21ed438c4921d594e32c285ecb58b638615ce"
+  integrity sha512-7ET0QiS2UWCM4hZraWVT9Df0PzuTQwK//3XM1q8vtXImUCRNGwG4bapa6ToDL8M4jkPeYSMrTiTvdJqwJifC4Q==
+  dependencies:
+    github-slugger "^1.1.1"
+    innertext "^1.0.1"
 
 markdown-it-regexp@^0.4.0:
   version "0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,6 +973,22 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
+"@sindresorhus/slugify@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/slugify/-/slugify-2.1.0.tgz#1e252117008cd1121e4cdea9fc67767dd1653d25"
+  integrity sha512-gU3Gdm/V167BmUwIn8APHZ3SeeRVRUSOdXxnt7Q/JkUHLXaaTA/prYmoRumwsSitJZWUDYMzDWdWgrOdvE8IRQ==
+  dependencies:
+    "@sindresorhus/transliterate" "^1.0.0"
+    escape-string-regexp "^5.0.0"
+
+"@sindresorhus/transliterate@^1.0.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/transliterate/-/transliterate-1.5.0.tgz#841109db51fe3158787c42a91c45c3ffea7589be"
+  integrity sha512-/sfSkoNelLq5riqNRp5uBjHIKBi1MWZk9ubRT1WiBQuTfmDf7BeQkph2DJzRB83QagMPHk2VDjuvpy0VuwyzdA==
+  dependencies:
+    escape-string-regexp "^5.0.0"
+    lodash.deburr "^4.1.0"
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -2887,6 +2903,11 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
+
 eslint-config-prettier@^8.2.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
@@ -3490,11 +3511,6 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-github-slugger@^1.1.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.4.0.tgz#206eb96cdb22ee56fdc53a28d5a302338463444e"
-  integrity sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==
-
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -3734,7 +3750,7 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
-html-entities@^1.2.0, html-entities@^1.3.1:
+html-entities@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
   integrity sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==
@@ -3929,13 +3945,6 @@ ini@^1.3.4, ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
-
-innertext@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/innertext/-/innertext-1.0.3.tgz#f1a8767592bcdcce2ea94e686ed41a86ba4e8df0"
-  integrity sha512-ZC410b7IbrTrmt8bQb27xUOJgXkJu+XL6MVncb9FGyxjRIHyQqNjpSDY20zvSUttkAiYj0dait/67/sXyWvwYg==
-  dependencies:
-    html-entities "^1.2.0"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -4506,6 +4515,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.deburr@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
+  integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
+
 lodash.get@^4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -4612,18 +4626,15 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it-anchor@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz#29e560593f5edb80b25fdab8b23f93ef8a91b31e"
+  integrity sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==
+
 markdown-it-emoji@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
   integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
-
-markdown-it-github-headings@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-github-headings/-/markdown-it-github-headings-2.0.0.tgz#f8d21ed438c4921d594e32c285ecb58b638615ce"
-  integrity sha512-7ET0QiS2UWCM4hZraWVT9Df0PzuTQwK//3XM1q8vtXImUCRNGwG4bapa6ToDL8M4jkPeYSMrTiTvdJqwJifC4Q==
-  dependencies:
-    github-slugger "^1.1.1"
-    innertext "^1.0.1"
 
 markdown-it-regexp@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Issue #3687 

## 概要
見出しのページ内リンクつきのURLを共有する。

## 修正前
<img width="1552" alt="Screen Shot 2021-12-17 at 15 59 47" src="https://user-images.githubusercontent.com/91442824/146517790-8a631895-188d-406b-b798-6a8b097a5304.png">


## 修正後
<img width="1552" alt="Screen Shot 2021-12-17 at 15 52 46" src="https://user-images.githubusercontent.com/91442824/146517681-86ad60b2-92f6-4a16-ac80-7237b64674cb.png">

## 動作確認方法
1. 見出しがあるマークダウンを作成する
  - 「日報」とか「Docs」とかを作成する
2. `anchor` をクリックする時
  - 作成したマークダウンがあるページにアクセスする
  - `h1`~`h3` の見出しの前アイコンをクリックする
  - → ブラウザのURLが変更されて、クリックした見出しにスクロールされる。
3. 見出しのページ内リンクつきのURLにアクセス時
  - → 見出しにスクロールされる。