### PR TITLE
Q&Aの詳細ページにあるタグのURLを、エスケープして表示するように変更

### DIFF
--- a/app/javascript/question_tags.vue
+++ b/app/javascript/question_tags.vue
@@ -2,7 +2,7 @@
 .tag-links
   ul.tag-links__items(v-if='!editing')
     li.tag-links__item(v-for='tag in tags')
-      a.tag-links__item-link(:href='`/questions/tags/${tag.text}?all=true`')
+      a.tag-links__item-link(:href='`/questions/tags/${encodeURIComponent(tag.text)}?all=true`')
         | {{ tag.text }}
     li.tag-links__item
       .tag-links__item-edit(@click='editTag')

--- a/app/javascript/question_tags.vue
+++ b/app/javascript/question_tags.vue
@@ -2,7 +2,9 @@
 .tag-links
   ul.tag-links__items(v-if='!editing')
     li.tag-links__item(v-for='tag in tags')
-      a.tag-links__item-link(:href='`/questions/tags/${encodeURIComponent(tag.text)}?all=true`')
+      a.tag-links__item-link(
+        :href='`/questions/tags/${encodeURIComponent(tag.text)}?all=true`'
+      )
         | {{ tag.text }}
     li.tag-links__item
       .tag-links__item-edit(@click='editTag')


### PR DESCRIPTION
# 概要
- issue: #3592 
- ref: #3606 
- `Q&Aの詳細ページ`で、`#`、`?`、`%`のようなURLの予約語が含まれているタグを押すと、意図しないページへ遷移してしまう。それを回避するため、URLをエスケープして表示する
- 同様の「URLの予約語が含まれているタグを押すと、意図しないページへ遷移してしまう問題」は、これまでに、`ユーザープロフィールページ`、`ユーザー一覧ページ`、`Docs`、`Q&Aの一覧ページ`でも生じていたが、それらは修正済

# 修正方法
- `Q&Aの詳細ページ`は、.vueファイルで出力されている。同様に.vueファイルで出力されている`ユーザープロフィールページ`で行われた修正方法を踏襲した。

# 修正前
<img width="672" alt="スクリーンショット 2021-12-18 19 01 56" src="https://user-images.githubusercontent.com/73326842/146637100-9adc9935-5d5f-4ab5-b30a-2de2e3678ab6.png">

# 修正後
<img width="544" alt="スクリーンショット 2021-12-18 19 02 32" src="https://user-images.githubusercontent.com/73326842/146637119-fa0b13d0-b3f6-4174-ace9-6d8dbdcf3225.png">
