### PR TITLE
ユーザー個別ページタブのリンク先投稿数が0の際クリック不可に変更

### DIFF
--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -12,11 +12,11 @@
         = link_to user_reports_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
           | 日報 （#{user.reports.length}）
       li.page-tabs__item
-        = link_to user_comments_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('comments')}" do
+        = link_to user_comments_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('comments')} #{user.comments.length.zero? ? 'is-inactive' : ''}" do
           | コメント （#{user.comments.length}）
       li.page-tabs__item
-        = link_to user_products_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
+        = link_to user_products_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('products')} #{user.products.length.zero? ? 'is-inactive' : ''}" do
           | 提出物 （#{user.products.length}）
       li.page-tabs__item
-        = link_to user_questions_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('questions')}" do
+        = link_to user_questions_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('questions')} #{user.questions.length.zero? ? 'is-inactive' : ''}" do
           | 質問 （#{user.questions.length}）


### PR DESCRIPTION
ref:[#3732](https://github.com/fjordllc/bootcamp/issues/3732)

## 概要
ユーザー個別ページのコメント・提出物・質問タブについて、タブのリンク先の投稿数が0の場合はタブがクリックできないようにする

## 実装の概要
投稿数が0のときは aタグに`is-inactive` を付けるとクリックできなくなる

※投稿数が0のときにクリックできなくなるのは、「コメント」「提出物」「質問」の3つのタブのみとしました。
- 日報タブ内には「＋日報作成」ボタンがあり、プロフィールページ内ではこのボタンからしか日報作成できないため、投稿数が0の場合でもクリックできる現状のままにしました。
- ポートフォリオタブ内にも「作品を追加」ボタンがあるので、投稿数0でもクリックできる現状のままにしました。

## 修正前
![commentable2](https://user-images.githubusercontent.com/82434093/146881287-a779817b-a2cd-446e-99ff-ae636d19b402.png)

## 修正後
![not_commentable](https://user-images.githubusercontent.com/82434093/146881321-2d681bdb-4f8d-4c18-9050-ebdaee49d766.png)

## 今回修正対象外とした、日報タブとポートフォリオタブ内のスクショ
![report_tab](https://user-images.githubusercontent.com/82434093/146881694-aac50806-4d76-4e12-a499-d270b79c1e09.png)
![スクリーンショット 2021-12-21 13 19 46](https://user-images.githubusercontent.com/82434093/146881708-349b5ea9-4028-43c2-bcd2-548f1adfa489.png)


