### PR TITLE
提出物・日報のユーザーメモタブにユーザー情報2種類を表示

### DIFF
--- a/app/assets/stylesheets/blocks/card/_card-body.sass
+++ b/app/assets/stylesheets/blocks/card/_card-body.sass
@@ -1,8 +1,9 @@
 .card-body
   padding: 1rem
+  font-size: .8125rem
   +media-breakpoint-down(sm)
     padding: .75rem
   &:not(:last-child)
       border-bottom: solid 1px $background
   p
-    +text-block(.8125rem 1.6)
+    +text-block(1em 1.6)

--- a/app/assets/stylesheets/blocks/form/_form-tabs.sass
+++ b/app/assets/stylesheets/blocks/form/_form-tabs.sass
@@ -4,7 +4,7 @@
   border-bottom: solid 1px $border
   .a-card > &:first-child,
   .a-card__inner > &:first-child
-    margin-top: 1rem
+    padding-top: 1rem
 
 .form-tabs__tab
   width: 5.5rem

--- a/app/assets/stylesheets/blocks/practice/_practice-content.sass
+++ b/app/assets/stylesheets/blocks/practice/_practice-content.sass
@@ -17,10 +17,6 @@
   padding: 1.25rem
   +media-breakpoint-down(sm)
     padding: .5rem .75rem
-  .practice-content.is-memo &
-    overflow-y: auto
-    padding: 1rem 1.25rem
-    max-height: calc(100vh - 181px)
 
 .practice-content__body-notice
   border: solid 1px $info

--- a/app/assets/stylesheets/blocks/side/_side-tabs-contents.sass
+++ b/app/assets/stylesheets/blocks/side/_side-tabs-contents.sass
@@ -1,15 +1,6 @@
 .side-tabs-contents
   +position(relative, 1)
 
-.side-tabs-contents__item
-  display: none
-  .a-card
-    border-top-left-radius: 0
-    max-height: calc(100vh - 100px)
-    overflow-y: auto
-  .card-header
-    display: none
-
 #side-tabs-1:checked ~ .side-tabs-contents #side-tabs-content-1
   display: block
 
@@ -18,3 +9,62 @@
 
 #side-tabs-3:checked ~ .side-tabs-contents #side-tabs-content-3
   display: block
+
+.side-tabs-contents__item
+  display: none
+  .a-card
+    border-top-left-radius: 0
+  .user-info + .a-card
+    border-top-right-radius: 0
+  .card-header
+    display: none
+  .card-body
+    max-height: calc(100vh - 181px)
+    overflow-y: auto
+  .user-info + .a-card .card-body
+    max-height: calc(100vh - 330px)
+  .user-info
+    padding: 1rem
+    background-color: $base
+    border: solid 1px $border-more-shade
+    border-bottom: none
+    height: 11rem
+    overflow: auto
+  .user-metas
+    margin-top: 0
+    & + .user-metas
+      margin-top: -1px
+  .user-metas__title
+    padding: .25rem .5rem
+    font-size: .625rem
+    background-color: $background
+  .user-metas__items
+    display: flex
+    flex-wrap: wrap
+    padding: .25rem .5rem
+  .user-metas__item
+    flex: 0 0 auto
+    +text-block(.75rem 1.6)
+    padding: 0
+    border: none
+    &:not(:last-child)::after
+      content: '、'
+  .user-metas__item:not(:last-child)
+    border: none
+  .user-metas__item:nth-child(even)
+    background-color: $base
+  .user-metas__item-label,
+  .user-metas__item-value
+    padding: 0
+  .user-metas__item-label
+    border-right: none
+    flex: 0 0 auto
+    &::after
+      content: ':'
+      +margin(horizontal, .125rem)
+  .form-tabs
+    margin-bottom: 0
+  .a-markdown-input
+    +padding(horizontal, 0)
+  .is-long-text
+    font-size: .8125rem

--- a/app/assets/stylesheets/blocks/user/_user-metas.sass
+++ b/app/assets/stylesheets/blocks/user/_user-metas.sass
@@ -6,7 +6,7 @@
   margin-bottom: -1px
   padding: .375rem .75rem
   +text-block(.75rem 1.4, 600)
-  background-color: $background-shade
+  background-color: $background
   position: relative
 
 .user-metas__items

--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
-.practice-content.is-memo
-  section.a-card(v-if='!editing')
-    .practice-content__body(v-if='memo')
+div
+  .a-card(v-if='!editing')
+    .card-body
       .js-target-blank.is-long-text(v-html='markdownMemo')
     .thread-list(v-else)
       .thread-list__inner
@@ -32,20 +32,21 @@
         @click='changeActiveTab("preview")'
       )
         | プレビュー
-    .a-markdown-input.js-markdown-parent
-      .a-markdown-input__inner.is-editor.js-tabs__content(
-        :class='{ "is-active": isActive("memo") }'
-      )
-        textarea.a-text-input.a-markdown-input__textarea(
-          :id='`js-practice-memo`',
-          data-preview='#practice-memo-preview',
-          v-model='memo',
-          name='practice[memo]'
+    .card-body
+      .a-markdown-input.js-markdown-parent
+        .a-markdown-input__inner.is-editor.js-tabs__content(
+          :class='{ "is-active": isActive("memo") }'
         )
-      .a-markdown-input__inner.is-preview.js-tabs__content(
-        :class='{ "is-active": isActive("preview") }'
-      )
-        .is-long-text.a-markdown-input__preview(v-html='markdownMemo')
+          textarea.a-text-input.a-markdown-input__textarea(
+            :id='`js-practice-memo`',
+            data-preview='#practice-memo-preview',
+            v-model='memo',
+            name='practice[memo]'
+          )
+        .a-markdown-input__inner.is-preview.js-tabs__content(
+          :class='{ "is-active": isActive("preview") }'
+        )
+          .is-long-text.a-markdown-input__preview(v-html='markdownMemo')
     .card-footer
       .card-main-actions
         .card-main-actions__items

--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
-div
-  .a-card(v-if='!editing')
-    .card-body
+.a-card
+  div(v-if='!editing')
+    .card-body(v-if='memo')
       .js-target-blank.is-long-text(v-html='markdownMemo')
     .thread-list(v-else)
       .thread-list__inner
@@ -20,7 +20,7 @@ div
             )
               i.fas.fa-pen
               | 編集
-  .a-card(v-show='editing')
+  div(v-show='editing')
     .form-tabs.js-tabs
       .form-tabs__tab.js-tabs__tab(
         :class='{ "is-active": isActive("memo") }',
@@ -32,21 +32,20 @@ div
         @click='changeActiveTab("preview")'
       )
         | プレビュー
-    .card-body
-      .a-markdown-input.js-markdown-parent
-        .a-markdown-input__inner.is-editor.js-tabs__content(
-          :class='{ "is-active": isActive("memo") }'
+    .a-markdown-input.js-markdown-parent
+      .a-markdown-input__inner.is-editor.js-tabs__content(
+        :class='{ "is-active": isActive("memo") }'
+      )
+        textarea.a-text-input.a-markdown-input__textarea(
+          :id='`js-practice-memo`',
+          data-preview='#practice-memo-preview',
+          v-model='memo',
+          name='practice[memo]'
         )
-          textarea.a-text-input.a-markdown-input__textarea(
-            :id='`js-practice-memo`',
-            data-preview='#practice-memo-preview',
-            v-model='memo',
-            name='practice[memo]'
-          )
-        .a-markdown-input__inner.is-preview.js-tabs__content(
-          :class='{ "is-active": isActive("preview") }'
-        )
-          .is-long-text.a-markdown-input__preview(v-html='markdownMemo')
+      .a-markdown-input__inner.is-preview.js-tabs__content(
+        :class='{ "is-active": isActive("preview") }'
+      )
+        .is-long-text.a-markdown-input__preview(v-html='markdownMemo')
     .card-footer
       .card-main-actions
         .card-main-actions__items

--- a/app/javascript/user_mentor_memo.vue
+++ b/app/javascript/user_mentor_memo.vue
@@ -14,18 +14,18 @@ section.a-card.is-memo.is-only-mentor
           )
             i.fas.fa-pen
             | 編集
-  .a-card__inner(v-show='editing')
-    .form-tabs.js-tabs
-      .form-tabs__tab.js-tabs__tab(
-        :class='{ "is-active": isActive("memo") }',
-        @click='changeActiveTab("memo")'
-      )
-        | メモ
-      .form-tabs__tab.js-tabs__tab(
-        :class='{ "is-active": isActive("preview") }',
-        @click='changeActiveTab("preview")'
-      )
-        | プレビュー
+  .form-tabs.js-tabs(v-show='editing')
+    .form-tabs__tab.js-tabs__tab(
+      :class='{ "is-active": isActive("memo") }',
+      @click='changeActiveTab("memo")'
+    )
+      | メモ
+    .form-tabs__tab.js-tabs__tab(
+      :class='{ "is-active": isActive("preview") }',
+      @click='changeActiveTab("preview")'
+    )
+      | プレビュー
+  .card-body(v-show='editing')
     .a-markdown-input.js-markdown-parent
       .a-markdown-input__inner.is-editor.js-tabs__content(
         :class='{ "is-active": isActive("memo") }'
@@ -40,15 +40,15 @@ section.a-card.is-memo.is-only-mentor
         :class='{ "is-active": isActive("preview") }'
       )
         .is-long-text.a-markdown-input__preview(v-html='markdownMemo')
-    .card-footer
-      .card-main-actions
-        .card-main-actions__items
-          .card-main-actions__item
-            button.a-button.is-md.is-warning.is-block(@click='updateMemo')
-              | 保存する
-          .card-main-actions__item
-            button.a-button.is-md.is-secondary.is-block(@click='cancel')
-              | キャンセル
+  .card-footer(v-show='editing')
+    .card-main-actions
+      .card-main-actions__items
+        .card-main-actions__item
+          button.a-button.is-md.is-warning.is-block(@click='updateMemo')
+            | 保存する
+        .card-main-actions__item
+          button.a-button.is-md.is-secondary.is-block(@click='cancel')
+            | キャンセル
 </template>
 
 <script>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -563,7 +563,7 @@ class User < ApplicationRecord
   end
 
   def update_mentor_memo(new_memo)
-    # ユーザーの「最終ログイン日時」にupdated_at値が利用されるため
+    # ユーザーの「最終ログイン」にupdated_at値が利用されるため
     # メンターor管理者によるmemoカラムのupdateの際は、updated_at値の変更を防ぐ
     self.record_timestamps = false
     update!(mentor_memo: new_memo)

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -180,4 +180,6 @@ header.page-header
               .side-tabs-contents__item#side-tabs-content-2
                 #js-practice-memo(data-practice-id="#{@product.practice_id}")
               .side-tabs-contents__item#side-tabs-content-3
+                = render 'users/user_secret_attributes', user: @product.user
+                = render 'users/metas', user: @product.user
                 #js-user-mentor-memo(data-user-id="#{@product.user.id}" data-products-mode="#{true}")

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -180,6 +180,7 @@ header.page-header
               .side-tabs-contents__item#side-tabs-content-2
                 #js-practice-memo(data-practice-id="#{@product.practice_id}")
               .side-tabs-contents__item#side-tabs-content-3
-                = render 'users/user_secret_attributes', user: @product.user
-                = render 'users/metas', user: @product.user
+                .user-info
+                  = render 'users/user_secret_attributes', user: @product.user
+                  = render 'users/metas', user: @product.user
                 #js-user-mentor-memo(data-user-id="#{@product.user.id}" data-products-mode="#{true}")

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -151,6 +151,8 @@ header.page-header
               .side-tabs-contents__item#side-tabs-content-1
                 #js-user-recent-reports(user-id="#{@report.user.id}")
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
+                = render 'users/user_secret_attributes', user: @report.user
+                = render 'users/metas', user: @report.user
                 #js-user-mentor-memo(data-user-id='#{@report.user_id}')
               .side-tabs-contents__item#side-tabs-content-3.is-only-mentor
                 .thread-list.a-card

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -151,8 +151,9 @@ header.page-header
               .side-tabs-contents__item#side-tabs-content-1
                 #js-user-recent-reports(user-id="#{@report.user.id}")
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
-                = render 'users/user_secret_attributes', user: @report.user
-                = render 'users/metas', user: @report.user
+                .side-tabs-contents__item-metas
+                  = render 'users/user_secret_attributes', user: @report.user
+                  = render 'users/metas', user: @report.user
                 #js-user-mentor-memo(data-user-id='#{@report.user_id}')
               .side-tabs-contents__item#side-tabs-content-3.is-only-mentor
                 .thread-list.a-card

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -151,7 +151,7 @@ header.page-header
               .side-tabs-contents__item#side-tabs-content-1
                 #js-user-recent-reports(user-id="#{@report.user.id}")
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
-                .side-tabs-contents__item-metas
+                .user-info
                   = render 'users/user_secret_attributes', user: @report.user
                   = render 'users/metas', user: @report.user
                 #js-user-mentor-memo(data-user-id='#{@report.user_id}')

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -4,7 +4,7 @@
   .user-metas__items
     .user-metas__item
       .user-metas__item-label
-        | メールアドレス
+        | メール
       .user-metas__item-value
         = user.email
     .user-metas__item
@@ -12,15 +12,17 @@
         | 課金状況
       .user-metas__item-value
         - if user.card?
-          | 有料ユーザー
+          | 課金中
         - elsif user.free
           = User.human_attribute_name :free
+        - else
+          | 要確認
     .user-metas__item
       .user-metas__item-label
-        | 就職について
+        | 就職
       .user-metas__item-value
         - if user.job_seeker
-          | 就職を希望
+          | 就職希望
         - else
           | 就職を希望しない
     .user-metas__item
@@ -41,7 +43,7 @@
           | 回答なし
     .user-metas__item
       .user-metas__item-label
-        | プラグラミング経験
+        | 経験
       .user-metas__item-value
         - if user.experience
           = t("activerecord.enums.user.experience.#{user.experience}")
@@ -49,6 +51,6 @@
           | 回答なし
     .user-metas__item
       .user-metas__item-label
-        = User.human_attribute_name :updated_at
+        | 最終ログイン
       .user-metas__item-value
         = l user.updated_at

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -65,7 +65,7 @@ ja:
         organization: 現在の所属組織
         company: 企業
         created_at: 開始日
-        updated_at: 最終ログイン日時
+        updated_at: 最終ログイン
         nda: 秘密保持契約
         graduated_on: 卒業日
         adviser: アドバイザー

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -72,7 +72,7 @@ ja:
         trainee: 研修生
         job_seeking: 就職活動中
         retired_on: 退会日
-        free: 無料ユーザー
+        free: 無料
         avatar: ユーザーアイコン
         retire_reasons: 選択入力の退会理由
         retire_reason: 自由記入の退会理由

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -83,10 +83,10 @@ class UsersTest < ApplicationSystemTestCase
     end
 
     visit_with_auth "/users/#{users(:kimura).id}", 'komagata'
-    assert_text '最終ログイン日時'
+    assert_text '最終ログイン'
 
     visit_with_auth "/users/#{users(:kimura).id}", 'hatsuno'
-    assert_no_text '最終ログイン日時'
+    assert_no_text '最終ログイン'
   end
 
   test 'show inactive message on users page' do


### PR DESCRIPTION
ref:[#3741](https://github.com/fjordllc/bootcamp/issues/3741)

## 概要
メンターでログインした時だけ見れる提出物・日報のユーザーメモタブにユーザー非公開情報・公開情報の２種類を表示させる

## [修正前]
### 提出物ページ
![スクリーンショット 2022-01-05 22 43 48](https://user-images.githubusercontent.com/82434093/148335576-de167eca-db4d-4cf9-bee4-deadf66c9e97.png)
### 日報ページ
![スクリーンショット 2022-01-05 22 42 58](https://user-images.githubusercontent.com/82434093/148335631-d89b49a9-ef47-4f0f-9ea9-d7fc670a032d.png)
-----
## [修正とデザイン適用後]
### 提出物ページ
![スクリーンショット 2022-01-04 20 42 11](https://user-images.githubusercontent.com/82434093/148055312-773017e3-103b-414f-b38b-65a2751f6898.png)
### 日報ページ
![スクリーンショット 2022-01-06 15 06 10](https://user-images.githubusercontent.com/82434093/148336731-dff57f51-661e-4480-9cfa-1c4315a8b586.png)

