### PR TITLE
通知ページの「watch中」のタブに全件数と未読の件数のバッチが欲しい

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -11,7 +11,7 @@ class NotificationsController < ApplicationController
   def show
     path = @notification.read_attribute :path
     @notifications = current_user.notifications.where(path: path)
-    @notifications.update_all(read: true) # rubocop:disable Rails/SkipsModelValidations
+    @notifications.update(read: true)
     redirect_to path
   end
 

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -61,5 +61,25 @@ class Cache
     def delete_not_solved_question_count
       Rails.cache.delete 'not_solved_question_count'
     end
+
+    def notification_all_count(user, kind)
+      Rails.cache.fetch "#{user.id}-notification_all_count" do
+        user.notifications.by_target(kind.to_sym).by_read_status('read').count
+      end
+    end
+
+    def notification_unread_count(user, kind)
+      Rails.cache.fetch "#{user.id}-notification_unread_count" do
+        user.notifications.by_target(kind.to_sym).by_read_status('unread').count
+      end
+    end
+
+    def delete_notification_all_count(user_id)
+      Rails.cache.delete "#{user_id}-notification_all_count"
+    end
+
+    def delete_notification_unread_count(user_id)
+      Rails.cache.delete "#{user_id}-notification_unread_count"
+    end
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -34,6 +34,9 @@ class Notification < ApplicationRecord
     consecutive_sad_report: 15
   }
 
+  after_create NotificationCallbacks.new
+  after_update NotificationCallbacks.new
+
   scope :reads, lambda {
     where(created_at: into_one.values).order(created_at: :desc)
   }

--- a/app/models/notification_callbacks.rb
+++ b/app/models/notification_callbacks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class NotificationCallbacks
+  def after_create(notification)
+    return if notification.kind != 'watching'
+
+    Cache.delete_notification_all_count(notification.user.id)
+    Cache.delete_notification_unread_count(notification.user.id)
+  end
+
+  def after_update(notification)
+    return if notification.kind != 'watching'
+
+    Cache.delete_notification_unread_count(notification.user.id)
+  end
+end

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -7,9 +7,9 @@
         li.page-tabs__item
           = link_to notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip do
             - if target == :watching
-              | #{t("notification.#{target}")} (#{Cache.notification_all_count(current_user, "watching")})
-              - if Cache.notification_unread_count(current_user, "watching").positive?
+              | #{t("notification.#{target}")} (#{Cache.notification_all_count(current_user, 'watching')})
+              - if Cache.notification_unread_count(current_user, 'watching').positive?
               .page-tabs__item-count.a-notification-count
-                = Cache.notification_unread_count(current_user, "watching")
+                = Cache.notification_unread_count(current_user, 'watching')
             - else
               = t("notification.#{target}")

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -2,7 +2,14 @@
   .container
     ul.page-tabs__items
       li.page-tabs__item
-        = link_to t('notification.all'), notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
+       = link_to t('notification.all'), notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
-          = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip
+          = link_to notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip do
+            - if target == :watching
+              | #{t("notification.#{target}")} (#{Cache.notification_all_count(current_user, "watching")})
+              - if Cache.notification_unread_count(current_user, "watching").positive?
+              .page-tabs__item-count.a-notification-count
+                = Cache.notification_unread_count(current_user, "watching")
+            - else
+              = t("notification.#{target}")

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -9,7 +9,7 @@
             - if target == :watching
               | #{t("notification.#{target}")} (#{Cache.notification_all_count(current_user, 'watching')})
               - if Cache.notification_unread_count(current_user, 'watching').positive?
-              .page-tabs__item-count.a-notification-count
-                = Cache.notification_unread_count(current_user, 'watching')
+                .page-tabs__item-count.a-notification-count
+                  = Cache.notification_unread_count(current_user, 'watching')
             - else
               = t("notification.#{target}")

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -133,3 +133,19 @@ notification_consecutive_sad_report:
   message: hajimeさんが2回連続でsadアイコンの日報を提出しました。
   path: "/reports/<%= ActiveRecord::FixtureSet.identify(:report16) %>"
   read: false
+
+notification_watching_unread:
+  kind: 8
+  user: sotugyou
+  sender: hajime
+  message: sotugyouさんの【 「学習週1日目」の日報 】にhajimeさんがコメントしました
+  path: "/reports/<%= ActiveRecord::FixtureSet.identify(:report5) %>"
+  read: false
+
+notification_watching_read:
+  kind: 8
+  user: sotugyou
+  sender: kensyu
+  message: sotugyouさんの【 「学習週2日目」の日報 】にkensyuさんがコメントしました
+  path: "/reports/<%= ActiveRecord::FixtureSet.identify(:report6) %>"
+  read: true

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -339,7 +339,7 @@ class NotificationsTest < ApplicationSystemTestCase
     total_number_unread_watching = users(:sotugyou).notifications.by_target(:watching).by_read_status('unread').count
 
     within '.page-tabs__item', text: 'Watch中' do
-      assert_equal total_number_unread_watching, find('.a-notification-count').text.to_i
+      assert_no_selector('.a-notification-count')
     end
   end
 end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -336,8 +336,6 @@ class NotificationsTest < ApplicationSystemTestCase
     click_link 'sotugyouさんの【 「学習週1日目」の日報 】にhajimeさんがコメントしました'
     visit_with_auth '/notifications?status=unread&target=watching', 'sotugyou'
 
-    total_number_unread_watching = users(:sotugyou).notifications.by_target(:watching).by_read_status('unread').count
-
     within '.page-tabs__item', text: 'Watch中' do
       assert_no_selector('.a-notification-count')
     end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -301,4 +301,45 @@ class NotificationsTest < ApplicationSystemTestCase
     wait_for_vuejs
     assert_text 'コメントのテスト通知'
   end
+
+  test 'show total number watching' do
+    total_number_watching = users(:sotugyou).notifications.by_target(:watching).by_read_status('read').count
+
+    visit_with_auth '/notifications?status=unread&target=watching', 'sotugyou'
+    assert_text "Watch中 (#{total_number_watching})"
+  end
+
+  test 'show total number unread watching' do
+    total_number_unread_watching = users(:sotugyou).notifications.by_target(:watching).by_read_status('unread').count
+
+    visit_with_auth '/notifications?status=unread&target=watching', 'sotugyou'
+    within '.page-tabs__item', text: 'Watch中' do
+      assert_equal total_number_unread_watching, find('.a-notification-count').text.to_i
+    end
+  end
+
+  test 'create notification total number watching' do
+    Notification.create(message: 'sotugyouさんの【 「学習週3日目」の日報 】にmachidaさんがコメントしました',
+                        kind: 'watching',
+                        path: '/reports/3',
+                        user: users(:sotugyou),
+                        sender: users(:machida))
+
+    total_number_watching = users(:sotugyou).notifications.by_target(:watching).by_read_status('read').count
+
+    visit_with_auth '/notifications?status=unread&target=watching', 'sotugyou'
+    assert_text "Watch中 (#{total_number_watching})"
+  end
+
+  test 'update notification total number unread watching' do
+    visit_with_auth '/notifications?status=unread&target=watching', 'sotugyou'
+    click_link 'sotugyouさんの【 「学習週1日目」の日報 】にhajimeさんがコメントしました'
+    visit_with_auth '/notifications?status=unread&target=watching', 'sotugyou'
+
+    total_number_unread_watching = users(:sotugyou).notifications.by_target(:watching).by_read_status('unread').count
+
+    within '.page-tabs__item', text: 'Watch中' do
+      assert_equal total_number_unread_watching, find('.a-notification-count').text.to_i
+    end
+  end
 end


### PR DESCRIPTION
issue https://github.com/fjordllc/bootcamp/issues/3542

## 概要
通知ページの「watch中」のタブに全件数と未読の件数のバッチが欲しい
- 通知の件数を取得するときはキャッシュするように
- noticationが作成、更新される度にキャッシュを削除するように（watchingのみの場合に）
  - cashe.rbにメソッドを定義 
  - createとupdate時にコールバックが動くようにnoticationモデルに記述
- update_allだとコールバックが動作してくれないので、updateに変更した
- テストの記述
  - 全件数と未読件数の数が一致しているかのシステムテスト
  - 通知が作成された時と未読から既読になった時の件数の変化の確認をするテスト

## 修正前
<img width="1593" alt="スクリーンショット 2021-12-21 16 10 05" src="https://user-images.githubusercontent.com/52303699/146887045-a7165fd2-dfa3-4dae-b43a-3a41e976f61e.png">


## 修正後
<img width="1792" alt="スクリーンショット 2021-12-21 16 09 46" src="https://user-images.githubusercontent.com/52303699/146887058-67d83d39-a6fb-4e60-b39e-af89a2cb1542.png">
