### PR TITLE
日報に画像をアップロードすると、二重にアップロードが行われないように修正

### DIFF
--- a/app/javascript/report_template.vue
+++ b/app/javascript/report_template.vue
@@ -43,6 +43,7 @@ export default {
     const report = document.querySelector('#report_description')
     if (report.value === '') {
       report.value = this.registeredTemplateProp
+      TextareaInitializer.uninitialize('.js-markdown')
       TextareaInitializer.initialize('.js-markdown')
     }
     this.registeredTemplate = this.registeredTemplateProp
@@ -64,6 +65,7 @@ export default {
         confirm('日報が上書きされますが、よろしいですか？')
       ) {
         report.value = this.registeredTemplate
+        TextareaInitializer.uninitialize('.js-markdown')
         TextareaInitializer.initialize('.js-markdown')
       }
     },

--- a/app/javascript/report_template.vue
+++ b/app/javascript/report_template.vue
@@ -43,8 +43,7 @@ export default {
     const report = document.querySelector('#report_description')
     if (report.value === '') {
       report.value = this.registeredTemplateProp
-      TextareaInitializer.uninitialize('.js-markdown')
-      TextareaInitializer.initialize('.js-markdown')
+      TextareaInitializer.initialize('.js-report-content')
     }
     this.registeredTemplate = this.registeredTemplateProp
     this.editingTemplate = this.registeredTemplateProp
@@ -65,8 +64,8 @@ export default {
         confirm('日報が上書きされますが、よろしいですか？')
       ) {
         report.value = this.registeredTemplate
-        TextareaInitializer.uninitialize('.js-markdown')
-        TextareaInitializer.initialize('.js-markdown')
+        TextareaInitializer.uninitialize('.js-report-content')
+        TextareaInitializer.initialize('.js-report-content')
       }
     },
     registerTemplate(template) {

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -50,32 +50,40 @@ export default class {
     Array.from(textareas).forEach((textarea) => {
       /* eslint-disable no-new */
       new TextareaMarkdown(textarea, {
-        endPoint: '/api/image.json',
-        paramName: 'file',
-        responseKey: 'url',
-        csrfToken: token,
-        placeholder: '%filenameをアップロード中...',
-        afterPreview: () => {
-          autosize.update(textarea)
+          endPoint: '/api/image.json',
+          paramName: 'file',
+          responseKey: 'url',
+          csrfToken: token,
+          placeholder: '%filenameをアップロード中...',
+          afterPreview: () => {
+            autosize.update(textarea)
 
-          const event = new Event('input', {
-            bubbles: true,
-            cancelable: true
-          })
-          textarea.dispatchEvent(event)
-        },
-        plugins: [
-          MarkdownItEmoji,
-          MarkdownItMention,
-          MarkdownItUserIcon,
-          MarkdownItTaskLists
-        ],
-        markdownOptions: MarkdownOption
-      })
-      /* eslint-enable no-new */
+            const event = new Event('input', {
+              bubbles: true,
+              cancelable: true
+            })
+            textarea.dispatchEvent(event)
+          },
+          plugins: [
+            MarkdownItEmoji,
+            MarkdownItMention,
+            MarkdownItUserIcon,
+            MarkdownItTaskLists
+          ],
+          markdownOptions: MarkdownOption
+        })
+        /* eslint-enable no-new */
     })
 
     // user-icon
     new UserIconRenderer().render(selector)
+  }
+
+  static uninitialize(selector) {
+    const textareas = document.querySelectorAll(selector)
+    textareas.forEach((textarea) => {
+      const cloneTextarea = textarea.cloneNode(true)
+      textarea.parentNode.replaceChild(cloneTextarea, textarea)
+    })
   }
 }

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -50,29 +50,29 @@ export default class {
     Array.from(textareas).forEach((textarea) => {
       /* eslint-disable no-new */
       new TextareaMarkdown(textarea, {
-          endPoint: '/api/image.json',
-          paramName: 'file',
-          responseKey: 'url',
-          csrfToken: token,
-          placeholder: '%filenameをアップロード中...',
-          afterPreview: () => {
-            autosize.update(textarea)
+        endPoint: '/api/image.json',
+        paramName: 'file',
+        responseKey: 'url',
+        csrfToken: token,
+        placeholder: '%filenameをアップロード中...',
+        afterPreview: () => {
+          autosize.update(textarea)
 
-            const event = new Event('input', {
-              bubbles: true,
-              cancelable: true
-            })
-            textarea.dispatchEvent(event)
-          },
-          plugins: [
-            MarkdownItEmoji,
-            MarkdownItMention,
-            MarkdownItUserIcon,
-            MarkdownItTaskLists
-          ],
-          markdownOptions: MarkdownOption
-        })
-        /* eslint-enable no-new */
+          const event = new Event('input', {
+            bubbles: true,
+            cancelable: true
+          })
+          textarea.dispatchEvent(event)
+        },
+        plugins: [
+          MarkdownItEmoji,
+          MarkdownItMention,
+          MarkdownItUserIcon,
+          MarkdownItTaskLists
+        ],
+        markdownOptions: MarkdownOption
+      })
+      /* eslint-enable no-new */
     })
 
     // user-icon

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -65,7 +65,7 @@
               template-id="#{current_user.report_template&.id}"
             )
           .a-textarea-bottom-note
-            = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+            = f.text_area :description, class: 'a-text-input js-warning-form js-report-content markdown-form__text-area', data: { 'preview': '.js-preview' }
             .a-textarea-bottom-note__banner
               | 途中保存は「command + s」 マメに保存しよう。
         .col-md-6.col-xs-12


### PR DESCRIPTION
Issue #3583 

### バグの原因
`app/javascript/textarea.js`に`TextareaInitializer.initialize('.js-markdown')`コードを呼びましたが、
`app/javascript/report_template.vue`ファイルに`TextareaInitializer.initialize('.js-markdown')`コードをまた呼びますので、二重にアップロードが行われます。

### 二重アップロードになっていた原因
2回目`TextareaInitializer.initialize('.js-markdown')`コードを呼ぶ時、古いテキストを見つけて、テキストを置き換えますが、アップロードのテキストを見つけないので、新しいアップロードのテキストを追加する。

### 行なった対処方法
一回だけ、`app/javascript/textarea.js`に`TextareaInitializer.initialize('.js-markdown')`コードを呼びます。

### どういう方針で直したか
ノードのクローンを作成して、Textareaの古いノードをTextareaのノードのクローンに置き換える。

### 参考
https://stackoverflow.com/questions/9251837/how-to-remove-all-listeners-in-an-element?fbclid=IwAR38Ez130O2EVtlO-fx80NUCp__ol9h0b0a7xXrqlI0AD4ocxkXhRz8-uWk

### 編集前
日報に画像をアップロードすると、二重にアップロードが行われる。

### 編集後
日報に画像をアップロードすると、二重にアップロードが行われない。