### PR TITLE
Checkモデルにuser_id,checkable_id,checkable_typeの一意性バリデーションを付加

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -7,6 +7,8 @@ class Check < ApplicationRecord
   after_destroy CheckCallbacks.new
   alias sender user
 
+  validates :user_id, uniqueness: { scope: %i[checkable_id checkable_type] }
+
   def receiver
     checkable.user
   end


### PR DESCRIPTION
ref:[#3820](https://github.com/fjordllc/bootcamp/issues/3820)

## 概要
メンターが日報と課題のチェックをクリックする際のユーザーID、チェックID、チェック種類の一意性制約を付加します。
Checkモデルに重複を防ぐvalidatesを記述しました。

※DB側のユニーク設定は既に`db/migrate/20181002051214_change_checkable_index.rb` にて行われていました。

## バグ現象の再現
確認ボタンを複数画面から同時にクリックする必要があるため、本バグの再現はできませんでした。
