### PR TITLE
ナビゲーションの文言を変更 退会手続きから退会・休会手続きへ

### DIFF
--- a/app/views/application/_user_menu.html.slim
+++ b/app/views/application/_user_menu.html.slim
@@ -23,4 +23,4 @@
         | ログアウト
     li.header-dropdown__item
       = link_to new_retirement_path, class: 'header-dropdown__item-link' do
-        | 退会手続き
+        | 退会・休会手続き


### PR DESCRIPTION
issue #3823 
ナビゲーションの文言を　退会手続き　から　退会・休会手続き　に変更しました。
## 変更前
<img width="290" alt="スクリーンショット 2021-12-22 16 55 17" src="https://user-images.githubusercontent.com/82350582/147056323-592e08e9-396c-420b-9fe0-5b5680f1e083.png">

## 変更後
<img width="294" alt="スクリーンショット 2021-12-22 16 54 32" src="https://user-images.githubusercontent.com/82350582/147056507-6e4a1d47-23fd-462e-80aa-9f2afbc6867f.png">
