### PR TITLE
プラクティスメモが空の時に泣き顔アイコンとプラクティスメモはまだ空ですというテキストを表示する

### DIFF
--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -1,7 +1,15 @@
 <template lang="pug">
 .practice-content.is-memo
   section.a-card(v-if='!editing')
-    .practice-content__body
+    .thread-list(v-if='!memo')
+      .thread-list__inner
+        .container
+          .o-empty-message
+            .o-empty-message__icon
+              i.far.fa-sad-tear
+            .o-empty-message__text
+              | プラクティスメモはまだ空です。
+    .practice-content__body(v-else)
       .js-target-blank.is-long-text(v-html='markdownMemo')
     footer.card-footer
       .card-main-actions

--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -1,7 +1,9 @@
 <template lang="pug">
 .practice-content.is-memo
   section.a-card(v-if='!editing')
-    .thread-list(v-if='!memo')
+    .practice-content__body(v-if='memo')
+      .js-target-blank.is-long-text(v-html='markdownMemo')
+    .thread-list(v-else)
       .thread-list__inner
         .container
           .o-empty-message
@@ -9,8 +11,6 @@
               i.far.fa-sad-tear
             .o-empty-message__text
               | プラクティスメモはまだ空です。
-    .practice-content__body(v-else)
-      .js-target-blank.is-long-text(v-html='markdownMemo')
     footer.card-footer
       .card-main-actions
         ul.card-main-actions__items


### PR DESCRIPTION
issue: プラクティスメモが空のときの表示を変更。 #3837

# UIの変更
## 変更前
プラクティスメモが空の場合、何も表示されません
![スクリーンショット 2021-12-22 22 42 14](https://user-images.githubusercontent.com/52844263/147101916-e323cb56-6e42-4364-8b21-7902876b75ff.png)


## 変更後
プラクティスメモが空の場合、泣き顔とプラクティスメモはまだ空ですというテキストを表示しました
![スクリーンショット 2021-12-22 22 33 47](https://user-images.githubusercontent.com/52844263/147102086-d8bcab9a-9c3a-402e-86ee-f34bfee2d1ef.png)

# 仕様の確認方法
下記のページにアクセスし、「プラクティスメモ」のタブをクリックしてご確認ください。

* メモがない場合
    * http://localhost:3000/products/234030236

* メモがある場合
    * http://localhost:3000/products/951763706