### PR TITLE
Q&Aの投稿日を表示する

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -6,7 +6,7 @@ class Answer < ApplicationRecord
   include Mentioner
 
   belongs_to :user, touch: true
-  belongs_to :question, touch: true
+  belongs_to :question, touch: false
   alias sender user
 
   after_create AnswerCallbacks.new

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -25,8 +25,8 @@
             .thread-list-item-meta__item
               = link_to question.user.long_name, question.user, class: 'a-user-name'
             .thread-list-item-meta__item
-              time.a-meta(datetime="#{question.updated_at.to_datetime}" pubdate='pubdate')
-                = l question.updated_at
+              time.a-meta(datetime="#{question.created_at.to_datetime}" pubdate='pubdate')
+                = l question.created_at
             - if question.answers.present?
               .thread-list-item-meta__item
                 .thread-list-item-comment

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -25,8 +25,8 @@
             .thread-list-item-meta__item
               = link_to question.user.long_name, question.user, class: 'a-user-name'
             .thread-list-item-meta__item
-              time.a-meta(datetime="#{question.created_at.to_datetime}" pubdate='pubdate')
-                = l question.created_at
+              time.a-meta(datetime="#{question.updated_at.to_datetime}" pubdate='pubdate')
+                = l question.updated_at
             - if question.answers.present?
               .thread-list-item-meta__item
                 .thread-list-item-comment


### PR DESCRIPTION
Issue #3689 

## 概要
Q&Aの日付がおかしい。答えの日付も表示するケースもあり、Q&Aの日付も表示するケースもあり。
具体的に：
- 答えを投稿する場合、Q&Aの日付が答えの日付になる。
- 質問を変更する場合、Q&Aの日付が質問の日付になる。

→Q&Aの投稿日を表示する

## 修正前
答えを投稿してもQ&Aの日付に反映する。

## 修正後
答えを投稿してもQ&Aの日付に反映しない。
質問を変更するだけ、Q&Aの日付に反映する。