### PR TITLE
ダッシュボードの自分の提出物タブに提出物数を表示

### DIFF
--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -11,7 +11,7 @@
       - if !user.staff? || user.products.present?
         li.page-tabs__item
           = link_to current_user_products_path, class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
-            | 自分の提出物
+            | 自分の提出物 （#{user.products.length}）
       - if !user.staff? || user.watches.present?
         li.page-tabs__item
           = link_to current_user_watches_path, class: "page-tabs__item-link #{current_page_tab_or_not('watches')}" do


### PR DESCRIPTION
#3839 

ダッシュボードの 自分の提出物タブ に提出物数を表示するよう変更しました。
## 変更前
<img width="515" alt="スクリーンショット 2021-12-23 16 35 01" src="https://user-images.githubusercontent.com/82350582/147205592-582e9568-f9f8-41c4-8483-7ffdc7458dcc.png">

## 変更後
<img width="536" alt="スクリーンショット 2021-12-23 16 24 15" src="https://user-images.githubusercontent.com/82350582/147205622-01e269a2-f08f-4c02-89c0-e8178c085389.png">

