### PR TITLE
検索結果のロード中に日報一覧と同じプレースホルダを表示する

### DIFF
--- a/app/javascript/searchables.vue
+++ b/app/javascript/searchables.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .page-body
   .container(v-if='!loaded')
-    | ロード中
+    loadingListPlaceholder
   .container(v-else-if='searchables.length === 0')
     .o-empty-message
       .o-empty-message__icon
@@ -25,9 +25,11 @@
 <script>
 import Searchable from './searchable.vue'
 import Pager from './pager.vue'
+import LoadingListPlaceholder from './loading-list-placeholder.vue'
 export default {
   components: {
     searchable: Searchable,
+    loadingListPlaceholder: LoadingListPlaceholder,
     pager: Pager
   },
   props: {


### PR DESCRIPTION
#3846
検索結果のロード中画面を　ロード中の表示からプレースホルダに変更しました。
## 変更前
<img width="681" alt="スクリーンショット 2021-12-23 17 30 26" src="https://user-images.githubusercontent.com/82350582/147214897-6945baaa-2ce8-42fe-81a2-715df368f401.png">


## 変更後
<img width="670" alt="スクリーンショット 2021-12-23 17 46 04" src="https://user-images.githubusercontent.com/82350582/147214921-b869adf8-3ce2-4ab0-96e5-45567d9386a5.png">
