### PR TITLE
就職関係のイベントの場合、ダッシュボードでのイベント通知は就職希望者にのみにする

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,13 +7,14 @@ class HomeController < ApplicationController
         logout
         redirect_to retire_path
       else
-        @announcements = Announcement.with_avatar.where(wip: false).order(published_at: :desc).limit(5)
+        @announcements = Announcement.with_avatar
+                                     .where(wip: false)
+                                     .order(published_at: :desc)
+                                     .limit(5)
         @completed_learnings = current_user.learnings.where(status: 3).includes(:practice).order(updated_at: :desc)
         @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.order(updated_at: :desc)
         @job_seeking_users = User.with_attached_avatar.job_seeking.includes(:reports, :products, :works, :course, :company)
-        cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
-        @events_coming_soon = Event.where(start_at: today_to_tomorrow).or(Event.where(start_at: tomorrow_to_day_after_tomorrow)).where.not(id: cookies_ids)
-        @events_coming_soon_except_job_hunting = @events_coming_soon.where.not(job_hunting: true)
+        display_events_on_dashboard
         set_required_fields
         render aciton: :index
       end
@@ -44,5 +45,11 @@ class HomeController < ApplicationController
 
   def tomorrow_to_day_after_tomorrow
     (Time.zone.tomorrow + 9.hours)..(Time.zone.tomorrow + 1.day + 9.hours)
+  end
+
+  def display_events_on_dashboard
+    cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
+    @events_coming_soon = Event.where(start_at: today_to_tomorrow).or(Event.where(start_at: tomorrow_to_day_after_tomorrow)).where.not(id: cookies_ids)
+    @events_coming_soon_except_job_hunting = @events_coming_soon.where.not(job_hunting: true)
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,15 +7,13 @@ class HomeController < ApplicationController
         logout
         redirect_to retire_path
       else
-        @announcements = Announcement.with_avatar
-                                     .where(wip: false)
-                                     .order(published_at: :desc)
-                                     .limit(5)
+        @announcements = Announcement.with_avatar.where(wip: false).order(published_at: :desc).limit(5)
         @completed_learnings = current_user.learnings.where(status: 3).includes(:practice).order(updated_at: :desc)
         @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.order(updated_at: :desc)
         @job_seeking_users = User.with_attached_avatar.job_seeking.includes(:reports, :products, :works, :course, :company)
         cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
         @events_coming_soon = Event.where(start_at: today_to_tomorrow).or(Event.where(start_at: tomorrow_to_day_after_tomorrow)).where.not(id: cookies_ids)
+        @events_except_job_hunting_coming_soon = @events_coming_soon.where.not(job_hunting: true)
         set_required_fields
         render aciton: :index
       end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,7 +13,7 @@ class HomeController < ApplicationController
         @job_seeking_users = User.with_attached_avatar.job_seeking.includes(:reports, :products, :works, :course, :company)
         cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
         @events_coming_soon = Event.where(start_at: today_to_tomorrow).or(Event.where(start_at: tomorrow_to_day_after_tomorrow)).where.not(id: cookies_ids)
-        @events_except_job_hunting_coming_soon = @events_coming_soon.where.not(job_hunting: true)
+        @events_coming_soon_except_job_hunting = @events_coming_soon.where.not(job_hunting: true)
         set_required_fields
         render aciton: :index
       end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -13,10 +13,14 @@ header.page-header
     .container.is-lg
       = render 'welcome_message'
 .page-body
-  - if @events_coming_soon.present?
+  - if @events_coming_soon.present? && current_user.job_seeker
     #events_on_dashboard.confirmed_event
       .page-notices
         = render partial: 'event', collection: @events_coming_soon, as: :event
+  - if @events_except_job_hunting_coming_soon.present? && !current_user.job_seeker
+    #events_on_dashboard.confirmed_event
+      .page-notices
+        = render partial: 'event', collection: @events_except_job_hunting_coming_soon, as: :event
   .container.is-xxl
     .columns
       .row

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -17,10 +17,10 @@ header.page-header
     #events_on_dashboard.confirmed_event
       .page-notices
         = render partial: 'event', collection: @events_coming_soon, as: :event
-  - if @events_except_job_hunting_coming_soon.present? && !current_user.job_seeker
+  - if @events_coming_soon_except_job_hunting.present? && !current_user.job_seeker
     #events_on_dashboard.confirmed_event
       .page-notices
-        = render partial: 'event', collection: @events_except_job_hunting_coming_soon, as: :event
+        = render partial: 'event', collection: @events_coming_soon_except_job_hunting, as: :event
   .container.is-xxl
     .columns
       .row

--- a/db/fixtures/events.yml
+++ b/db/fixtures/events.yml
@@ -124,3 +124,14 @@ event28:
   open_start_at: 2019-12-10 9:00
   open_end_at: 2019-12-16 9:00
   user: komagata
+
+event29:
+  title: "就職関係かつ直近イベントの表示テスト用"
+  description: "就職関係かつ直近イベントの表示テスト用"
+  location: "FJORDオフィス"
+  capacity: 10
+  start_at: <%= Date.tomorrow %>
+  end_at: 2019-12-17 12:00:00
+  open_start_at: 2019-12-10 9:00
+  open_end_at: 2019-12-16 9:00
+  user: komagata

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -124,3 +124,15 @@ event28:
   open_start_at: 2017-3-26 9:00
   open_end_at: 2017-4-02 9:00
   user: komagata
+
+event29:
+  title: "就職関係かつ直近イベントの表示テスト用"
+  description: "就職関係かつ直近イベントの表示テスト用"
+  location: "FJORDオフィス"
+  capacity: 10
+  start_at: 2017-04-02 00:00:00
+  end_at: 2017-4-2 12:00:00
+  open_start_at: 2017-3-26 9:00
+  open_end_at: 2017-4-02 9:00
+  job_hunting: true
+  user: komagata

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -96,4 +96,19 @@ class HomeTest < ApplicationSystemTestCase
       assert_text '直近イベントの表示テスト用(翌日)'
     end
   end
+
+  test 'show job events on dashboard for only job seeker' do
+    travel_to Time.zone.local(2017, 4, 1, 10, 0, 0) do
+      visit_with_auth '/', 'jobseeker'
+      assert_text '直近イベントの表示テスト用(当日)'
+      assert_text '直近イベントの表示テスト用(翌日)'
+      assert_text '就職関係かつ直近イベントの表示テスト用'
+      logout
+
+      visit_with_auth '/', 'komagata'
+      assert_text '直近イベントの表示テスト用(当日)'
+      assert_text '直近イベントの表示テスト用(翌日)'
+      assert_no_text '就職関係かつ直近イベントの表示テスト用'
+    end
+  end
 end


### PR DESCRIPTION
Issue #3833 

## 概要
イベントの開催日とその前日にはダッシュボードにイベントのお知らせが出ます。
就職に関連するイベントの場合は、「就職希望者」にのみダッシュボードにイベントのお知らせが表示されるよう変更しました。

## 変更前

*「就職希望者」ではないユーザー（`komagata`）にも就職関連イベントが表示される

<img width="1118" alt="スクリーンショット 2021-12-24 13 52 44" src="https://user-images.githubusercontent.com/80372144/147318042-c8973673-c29b-4a26-ac93-0c5de9fe286a.png">


## 変更後

* 「就職希望者」ではないユーザー（`komagata`）には就職関連イベントは表示されない

<img width="1120" alt="スクリーンショット 2021-12-24 13 45 15" src="https://user-images.githubusercontent.com/80372144/147317396-71e76016-8053-44a5-9cfc-f856a948ea60.png">

* 「就職希望者」のユーザー（`jobseeker`）には就職関連のイベントと通常のイベントの両方が表示される

<img width="1119" alt="スクリーンショット 2021-12-24 13 47 20" src="https://user-images.githubusercontent.com/80372144/147317712-ec8848bc-7de5-427f-9fcb-8945714cc62a.png">

