### PR TITLE
Notificationsのfixtureのtypoを修正

### DIFF
--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -34,7 +34,7 @@ notification_submitted:
   kind: 3
   user: komagata
   sender: sotugyou
-  message: sogugyouさんが「Terminalの基礎を覚える」の提出物を提出しました。
+  message: sotugyouさんが「Terminalの基礎を覚える」の提出物を提出しました。
   link: "/products/<%= ActiveRecord::FixtureSet.identify(:product3) %>"
   read: false
 

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -34,7 +34,7 @@ notification_submitted:
   kind: 3
   user: komagata
   sender: sotugyou
-  message: sogugyouさんが「Terminalの基礎を覚える」の提出物を提出しました。
+  message: sotugyouさんが「Terminalの基礎を覚える」の提出物を提出しました。
   link: "/products/<%= ActiveRecord::FixtureSet.identify(:product3) %>"
   read: false
 


### PR DESCRIPTION
## やったこと

- 通知のfixturesのTypoを修正（so`gu`gyou → so`tu`gyou）
- このfixturesの文言を参照しているテストはないため、単純なtypo修正になります。