### PR TITLE
相談部屋にコメント機能をつける

### DIFF
--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -16,6 +16,7 @@ class Users::CommentsController < ApplicationController
   def set_comments
     @comments =
       Comment
+      .where.not(commentable_type: 'Talk')
       .preload(commentable: { user: { avatar_attachment: :blob } })
       .eager_load(:user)
       .where(user_id: user)

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -76,8 +76,11 @@ class CommentCallbacks
   end
 
   def notify_comment(comment)
-    message = comment.commentable.instance_of?(Talk) ? "#{comment.sender.login_name}さんから相談部屋でコメントが届きました。" : "#{comment.sender.login_name}さんからコメントが届きました。"
-    NotificationFacade.came_comment(comment, comment.receiver, message)
+    NotificationFacade.came_comment(
+      comment,
+      comment.receiver,
+      "#{comment.sender.login_name}さんからコメントが届きました。"
+    )
   end
 
   def notify_to_watching_user(comment)
@@ -112,9 +115,12 @@ class CommentCallbacks
   end
 
   def notify_to_admins(comment)
-    message = comment.commentable.instance_of?(Talk) ? "#{comment.sender.login_name}さんが相談部屋でコメントをしました。" : "#{comment.sender.login_name}さんがコメントをしました。"
     User.admins.each do |admin_user|
-      NotificationFacade.came_comment(comment, admin_user, message)
+      NotificationFacade.came_comment(
+        comment,
+        admin_user,
+        "#{comment.sender.login_name}さんからコメントが届きました。"
+      )
     end
   end
 end

--- a/app/models/comment_callbacks.rb
+++ b/app/models/comment_callbacks.rb
@@ -76,19 +76,8 @@ class CommentCallbacks
   end
 
   def notify_comment(comment)
-    if comment.commentable.instance_of?(Talk)
-      NotificationFacade.came_comment(
-        comment,
-        comment.receiver,
-        "#{comment.sender.login_name}さんから相談部屋でコメントが届きました。"
-      )
-    else
-      NotificationFacade.came_comment(
-        comment,
-        comment.receiver,
-        "#{comment.sender.login_name}さんからコメントが届きました。"
-      )
-    end
+    message = comment.commentable.instance_of?(Talk) ? "#{comment.sender.login_name}さんから相談部屋でコメントが届きました。" : "#{comment.sender.login_name}さんからコメントが届きました。"
+    NotificationFacade.came_comment(comment, comment.receiver, message)
   end
 
   def notify_to_watching_user(comment)
@@ -123,20 +112,9 @@ class CommentCallbacks
   end
 
   def notify_to_admins(comment)
+    message = comment.commentable.instance_of?(Talk) ? "#{comment.sender.login_name}さんが相談部屋でコメントをしました。" : "#{comment.sender.login_name}さんがコメントをしました。"
     User.admins.each do |admin_user|
-      if comment.commentable.instance_of?(Talk)
-        NotificationFacade.came_comment(
-          comment,
-          admin_user,
-          "#{comment.sender.login_name}さんが相談部屋でコメントをしました。"
-        )
-      else
-        NotificationFacade.came_comment(
-          comment,
-          comment.receiver,
-          "#{comment.sender.login_name}さんからコメントが届きました。"
-        )
-      end
+      NotificationFacade.came_comment(comment, admin_user, message)
     end
   end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class Talk < ApplicationRecord
+  include Commentable
+
   belongs_to :user
 end

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -8,16 +8,16 @@ header.page-header
 
 .page-body
   .container.is-lg
-  .thread
-    .thread__inner.a-card
-      header.thread-header.has-count
-        .thread-header__row
-          h1.thread-header-title
-            = title
-      .thread__body
-        .thread__description.is-long-text
-          p
-            | ここは#{@user.name}さんと管理者のみが閲覧することのできる相談部屋です。
-            | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
+    .thread
+      .thread__inner.a-card
+        header.thread-header.has-count
+          .thread-header__row
+            h1.thread-header-title
+              = title
+        .thread__body
+          .thread__description.is-long-text
+            p
+              | ここは#{@user.name}さんと管理者のみが閲覧することのできる相談部屋です。
+              | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
     a#comments.a-anchor
     #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -1,6 +1,12 @@
 - title "#{@user.name}さんの相談部屋"
+
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
         = title
+
+.page-body
+  .container.is-lg
+    a#comments.a-anchor
+    #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -8,5 +8,16 @@ header.page-header
 
 .page-body
   .container.is-lg
+  .thread
+    .thread__inner.a-card
+      header.thread-header.has-count
+        .thread-header__row
+          h1.thread-header-title
+            = title
+      .thread__body
+        .thread__description.is-long-text
+          p
+            | ここは#{@user.name}さんと管理者のみが閲覧することのできる相談部屋です。
+            | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
     a#comments.a-anchor
     #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")

--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -13,7 +13,7 @@
           | 日報 （#{user.reports.length}）
       li.page-tabs__item
         = link_to user_comments_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('comments')} #{user.comments.length.zero? ? 'is-inactive' : ''}" do
-          | コメント （#{user.comments.length}）
+          | コメント （#{user.comments.where.not(commentable_type: 'Talk').length}）
       li.page-tabs__item
         = link_to user_products_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('products')} #{user.products.length.zero? ? 'is-inactive' : ''}" do
           | 提出物 （#{user.products.length}）

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Notification::AnswersTest < ApplicationSystemTestCase
+  test '誰かが相談部屋でコメントをした際にadminは通知を受け取る' do
+    talk_id = users(:kimura).talk.id
+    visit_with_auth "/talks/#{talk_id}", 'kimura'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    page.all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    assert_text 'test'
+    click_button 'コメントする'
+    wait_for_vuejs
+    assert_text 'test'
+
+    logout
+    login_user 'machida', 'testtest'
+
+    open_notification
+    assert_equal 'kimuraさんが相談部屋でコメントをしました。'
+                 notification_message
+  end
+
+  test '自分以外の誰かが自分の相談部屋でコメントをした際に通知を受け取る' do
+    talk_id = users(:kimura).talk.id
+    visit_with_auth "/talks/#{talk_id}", 'komagata'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    page.all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    assert_text 'test'
+    click_button 'コメントする'
+    wait_for_vuejs
+    assert_text 'test'
+
+    logout
+    login_user 'kimura', 'testtest'
+
+    open_notification
+    assert_equal 'komagataさんから相談部屋でコメントが届きました。'
+                 notification_message
+  end
+end

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -9,7 +9,7 @@ class Notification::AnswersTest < ApplicationSystemTestCase
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')
     end
-    page.all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
     wait_for_vuejs
@@ -28,7 +28,7 @@ class Notification::AnswersTest < ApplicationSystemTestCase
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')
     end
-    page.all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
     wait_for_vuejs

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -19,7 +19,7 @@ class Notification::AnswersTest < ApplicationSystemTestCase
     login_user 'machida', 'testtest'
 
     open_notification
-    assert_equal 'kimuraさんが相談部屋でコメントをしました。', notification_message
+    assert_equal 'kimuraさんからコメントが届きました。', notification_message
   end
 
   test '自分以外の誰かが自分の相談部屋でコメントをした際に通知を受け取る' do
@@ -38,6 +38,6 @@ class Notification::AnswersTest < ApplicationSystemTestCase
     login_user 'kimura', 'testtest'
 
     open_notification
-    assert_equal 'komagataさんから相談部屋でコメントが届きました。', notification_message
+    assert_equal 'komagataさんからコメントが届きました。', notification_message
   end
 end

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -19,8 +19,7 @@ class Notification::AnswersTest < ApplicationSystemTestCase
     login_user 'machida', 'testtest'
 
     open_notification
-    assert_equal 'kimuraさんが相談部屋でコメントをしました。'
-                 notification_message
+    assert_equal 'kimuraさんが相談部屋でコメントをしました。', notification_message
   end
 
   test '自分以外の誰かが自分の相談部屋でコメントをした際に通知を受け取る' do
@@ -39,7 +38,6 @@ class Notification::AnswersTest < ApplicationSystemTestCase
     login_user 'kimura', 'testtest'
 
     open_notification
-    assert_equal 'komagataさんから相談部屋でコメントが届きました。'
-                 notification_message
+    assert_equal 'komagataさんから相談部屋でコメントが届きました。', notification_message
   end
 end


### PR DESCRIPTION
issue： #3504 

# 前提
[相談部屋機能を作るというissue](https://github.com/fjordllc/bootcamp/issues/2810)を三つのissueに分けて実装を進めています。
[今回は2つ目のissue](https://github.com/fjordllc/bootcamp/issues/3504)になります。1つ目のレビューが完了し切っていないのですが、そのままこちらのレビューを進めてOKとのことです。


# 要件
* 相談部屋でコメントをできるようにする
* 相談部屋でコメントがあった場合に通知をする
    * ユーザー：自分以外の人が自分の相談部屋でコメントをしたら通知が飛ぶ。
    * 管理者：自分以外の人がどこかの相談部屋でコメントをしたら通知が飛ぶ。
* ユーザーページのコメント一覧には相談部屋でのコメントを表示しない

# 作成した画面のイメージ
## 相談部屋
<img width="1440" alt="スクリーンショット 2021-12-26 17 08 07" src="https://user-images.githubusercontent.com/52844263/147402503-23d9e1dc-d8de-4285-8473-7b79246943f2.png">

## 通知
<img width="1440" alt="スクリーンショット 2021-12-26 17 10 43" src="https://user-images.githubusercontent.com/52844263/147402589-83927368-912c-410f-9cf3-17082e808ae4.png">
<img width="1439" alt="スクリーンショット 2021-12-26 17 12 50" src="https://user-images.githubusercontent.com/52844263/147402606-a0c34709-76bc-4355-923b-8fa83cbb200b.png">


## ユーザーページのコメント一覧
相談部屋でコメントをしていてもユーザーページのコメント一覧には表示されず、コメントの数もカウントされていない
<img width="1440" alt="スクリーンショット 2021-12-26 17 09 30" src="https://user-images.githubusercontent.com/52844263/147402529-fb01a56f-6a26-4b85-8d88-ae5abeb8be16.png">



# 確認手順
## 準備
* `feature/add-comment-function-to-talk-room`ブランチを手元に持ってくる

## ユーザーがコメントした場合
1. `kimura`でログインする
1. `http://localhost:3000/talks/1054575302`にアクセスする（グローバルナビゲーションの相談タブをクリックでもOK）
1. コメントをする
1. `komagata`でログインする
1. 通知が来ていることを確認

## 管理者がコメントした場合
1. `komagata`でログインする
1. `http://localhost:3000/talks/1054575302`にアクセスする
1. コメントをする
1. `kimura`でログインする
1. 通知が来ていることを確認