### PR TITLE
登録日時でユーザー一覧を並ぶ

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -266,6 +266,8 @@ class User < ApplicationRecord
       left_outer_joins(order_by.pluralize.to_sym)
         .group('users.id')
         .order(Arel.sql("count(#{order_by.pluralize}.id) #{direction}, users.created_at"))
+    elsif order_by == 'created_at'
+      order(order_by.to_sym => direction.to_sym)
     else
       order(order_by.to_sym => direction.to_sym, created_at: :asc)
     end


### PR DESCRIPTION
Issue #3874 

## 概要
登録日時の横のボタンを押してもソートが降順になりません。

## バグの原因
`user.rb` では `User#order_by_counts` のスコープにいつも`created_at: :asc` で並んでいるので、「登録日時」で並ぶことができませんでした。

## 修正後
![Screen Shot 2021-12-27 at 13 59 49 (2)](https://user-images.githubusercontent.com/91442824/147444214-01406e99-e964-418b-b708-7696ff4a61fb.png)
![Screen Shot 2021-12-27 at 13 59 52 (2)](https://user-images.githubusercontent.com/91442824/147444231-c0793475-8c78-4c1f-9306-b5a7a4bf2008.png)
