### PR TITLE
回答先の質問にタグ付けがされている場合に回答タブページで 500 エラーが出る問題を修正

### DIFF
--- a/app/views/users/answers/_answer.html.slim
+++ b/app/views/users/answers/_answer.html.slim
@@ -32,7 +32,7 @@
                   .thread-list-item-tags__label
                     i.fas.fa-tags
                   ul.thread-list-item-tags__items
-                    - question.tags.each do |tag|
+                    - answer.question.tags.each do |tag|
                       li.thread-list-item-tags__item
                         = link_to tag.name, questions_tag_path(tag.name, all: 'true'), class: 'thread-list-item-tags__item-link'
             - if answer.type == 'CorrectAnswer'

--- a/test/system/user/answers_test.rb
+++ b/test/system/user/answers_test.rb
@@ -4,7 +4,7 @@ require 'application_system_test_case'
 
 class User::AnswersTest < ApplicationSystemTestCase
   test 'show listing answers' do
-    visit_with_auth "/users/#{users(:sotugyou).id}/answers", 'sotugyou'
-    assert_equal 'sotugyouの回答 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    visit_with_auth "/users/#{users(:komagata).id}/answers", 'komagata'
+    assert_equal 'komagataの回答 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 end


### PR DESCRIPTION
## 関連 PR
- #3768

## 発生していたエラー
ステージング環境にて、ユーザーの回答タブページ（`/users/XXXXXXXXX/answers`）を開いた際、500 エラーが発生していました。

## 原因
回答先の質問にタグ付けがされている場合、そのタグを取得する処理に不足がありました。

## やったこと
1. 処理の修正
1. テストにて確認する回答ページを、タグ付きの質問に回答を行っているユーザーのものに変更

## エラー内容のスクリーンショット 
![Unknown](https://user-images.githubusercontent.com/16577/148020390-b003b3b8-242a-4bd7-8c94-c9a116bc79a0.png)