### PR TITLE
【メンター向け】提出物の自分の担当物は「最後にコメントした日時順」へ変更

### DIFF
--- a/app/controllers/api/products/self_assigned_controller.rb
+++ b/app/controllers/api/products/self_assigned_controller.rb
@@ -10,13 +10,12 @@ class API::Products::SelfAssignedController < API::BaseController
                   Product.self_assigned_product(current_user.id)
                          .unchecked
                          .list
-                         .order_for_list
+                         .order_for_self_assigned_list
                          .page(params[:page])
                 when 'self_assigned_no_replied'
                   Product.self_assigned_no_replied_products(current_user.id)
                          .unchecked
                          .list
-                         .order_for_list
                          .page(params[:page])
                 end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -47,6 +47,7 @@ class Product < ApplicationRecord
   }
   scope :order_for_list, -> { order(created_at: :desc, id: :desc) }
   scope :order_for_not_wip_list, -> { order(published_at: :desc, id: :desc) }
+  scope :order_for_self_assigned_list, -> { order(commented_at: :desc, published_at: :desc) }
 
   def self.add_latest_commented_at
     Product.all.includes(:comments).find_each do |product|
@@ -118,7 +119,7 @@ class Product < ApplicationRecord
   def self.self_assigned_no_replied_products(current_user_id)
     no_replied_product_ids = self_assigned_no_replied_product_ids(current_user_id)
     Product.where(id: no_replied_product_ids)
-           .order(created_at: :desc)
+           .order(commented_at: :desc, published_at: :desc)
   end
 
   def self.unchecked_no_replied_products(current_user_id)

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -42,27 +42,6 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     end
   end
 
-  test 'products order on self assigned tab' do
-    checker = users(:komagata)
-    # id順で並べたときの最初と最後の提出物を、作成日順で見たときに最新と最古になるように入れ替える
-    # 最古の提出物を画面上で判定するため、提出物を1ページ内に収める
-    Product.limit(Product.default_per_page).update_all(created_at: 1.day.ago, published_at: 1.day.ago, checker_id: checker.id) # rubocop:disable Rails/SkipsModelValidations
-    newest_product = Product.self_assigned_product(checker.id).unchecked.reorder(:id).first
-    newest_product.update(created_at: Time.current)
-    oldest_product = Product.self_assigned_product(checker.id).unchecked.reorder(:id).last
-    oldest_product.update(created_at: 2.days.ago)
-
-    visit_with_auth '/products/self_assigned', 'komagata'
-
-    # 作成日の降順で並んでいることを検証する
-    titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
-    names = all('.thread-list-item-meta .a-user-name').map(&:text)
-    assert_equal "#{newest_product.practice.title}の提出物", titles.first
-    assert_equal newest_product.user.login_name, names.first
-    assert_equal "#{oldest_product.practice.title}の提出物", titles.last
-    assert_equal oldest_product.user.login_name, names.last
-  end
-
   test 'not display products in listing self-assigned if self-assigned products all checked' do
     product = products(:product3)
     checker = users(:komagata)


### PR DESCRIPTION
Issue #3758

## 概要

提出物の「自分の担当物」の並び順を
```
上
コメントがなくて提出日が新しい
コメントがなくて提出日が古い
コメントがあって、最後のコメントが新しい
コメントがあって、最後のコメントが古い
下
```
に変更しました。

## 変更前
提出物の「自分の担当物」の並び順は提出物の作成日順になっていた。

<img width="537" alt="スクリーンショット 2022-01-10 11 06 06" src="https://user-images.githubusercontent.com/80372144/148710858-513b2420-080e-43ab-be4e-a9b2f8979d11.png">


## 変更後

1. コメントがあるかないか
2.  提出日が古いか新しいか

上記の基準で提出物の順番を変更しています。

<img width="544" alt="スクリーンショット 2022-01-10 10 38 15" src="https://user-images.githubusercontent.com/80372144/148710756-4232e491-88b7-4cd9-ac08-688e6129cb56.png">
