### PR TITLE
ユーザーメモが空のときの表示を変更

### DIFF
--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -10,7 +10,7 @@
             .o-empty-message__icon
               i.far.fa-sad-tear
             .o-empty-message__text
-              | プラクティスメモはまだ空です。
+              | プラクティスメモはまだありません。
     footer.card-footer
       .card-main-actions
         ul.card-main-actions__items

--- a/app/javascript/user_mentor_memo.vue
+++ b/app/javascript/user_mentor_memo.vue
@@ -54,9 +54,6 @@ section.a-card.is-memo.is-only-mentor
           .card-main-actions__item
             button.a-button.is-md.is-secondary.is-block(@click='cancel')
               | キャンセル
-
-
-
 </template>
 
 <script>

--- a/app/javascript/user_mentor_memo.vue
+++ b/app/javascript/user_mentor_memo.vue
@@ -64,8 +64,8 @@ import confirmUnload from './confirm-unload'
 export default {
   mixins: [confirmUnload],
   props: {
-    userId: {type: String, required: true},
-    productsMode: {type: Boolean, required: true}
+    userId: { type: String, required: true },
+    productsMode: { type: Boolean, required: true }
   },
   data() {
     return {
@@ -89,17 +89,17 @@ export default {
       credentials: 'same-origin',
       redirect: 'manual'
     })
-        .then((response) => {
-          return response.json()
-        })
-        .then((json) => {
-          if (json.mentor_memo) {
-            this.memo = json.mentor_memo
-          }
-        })
-        .catch((error) => {
-          console.warn('Failed to parsing', error)
-        })
+      .then((response) => {
+        return response.json()
+      })
+      .then((json) => {
+        if (json.mentor_memo) {
+          this.memo = json.mentor_memo
+        }
+      })
+      .catch((error) => {
+        console.warn('Failed to parsing', error)
+      })
   },
   mounted() {
     TextareaInitializer.initialize('#js-user-mentor-memo')
@@ -132,13 +132,13 @@ export default {
         redirect: 'manual',
         body: JSON.stringify(params)
       })
-          .then((response) => {
-            this.editing = false
-            return response
-          })
-          .catch((error) => {
-            console.warn('Failed to parsing', error)
-          })
+        .then((response) => {
+          this.editing = false
+          return response
+        })
+        .catch((error) => {
+          console.warn('Failed to parsing', error)
+        })
     },
     cancel() {
       fetch(`/api/users/${this.userId}.json`, {
@@ -149,15 +149,15 @@ export default {
         credentials: 'same-origin',
         redirect: 'manual'
       })
-          .then((response) => {
-            return response.json()
-          })
-          .then((json) => {
-            this.memo = json.mentor_memo
-          })
-          .catch((error) => {
-            console.warn('Failed to parsing', error)
-          })
+        .then((response) => {
+          return response.json()
+        })
+        .then((json) => {
+          this.memo = json.mentor_memo
+        })
+        .catch((error) => {
+          console.warn('Failed to parsing', error)
+        })
       this.editing = false
     },
     editMemo() {

--- a/app/javascript/user_mentor_memo.vue
+++ b/app/javascript/user_mentor_memo.vue
@@ -5,6 +5,11 @@ section.a-card.is-memo.is-only-mentor
       | メンター向けユーザーメモ
   .card-body(v-if='!editing')
     .js-target-blank.is-long-text(v-html='markdownMemo')
+    .o-empty-message(v-if='memo.length === 0')
+      .o-empty-message__icon
+        i.far.fa-sad-tear
+      .o-empty-message__text
+        | ユーザーメモはまだありません。
   footer.card-footer(v-if='!editing')
     .card-main-actions
       .card-main-actions__items
@@ -49,6 +54,9 @@ section.a-card.is-memo.is-only-mentor
           .card-main-actions__item
             button.a-button.is-md.is-secondary.is-block(@click='cancel')
               | キャンセル
+
+
+
 </template>
 
 <script>
@@ -59,8 +67,8 @@ import confirmUnload from './confirm-unload'
 export default {
   mixins: [confirmUnload],
   props: {
-    userId: { type: String, required: true },
-    productsMode: { type: Boolean, required: true }
+    userId: {type: String, required: true},
+    productsMode: {type: Boolean, required: true}
   },
   data() {
     return {
@@ -84,17 +92,17 @@ export default {
       credentials: 'same-origin',
       redirect: 'manual'
     })
-      .then((response) => {
-        return response.json()
-      })
-      .then((json) => {
-        if (json.mentor_memo) {
-          this.memo = json.mentor_memo
-        }
-      })
-      .catch((error) => {
-        console.warn('Failed to parsing', error)
-      })
+        .then((response) => {
+          return response.json()
+        })
+        .then((json) => {
+          if (json.mentor_memo) {
+            this.memo = json.mentor_memo
+          }
+        })
+        .catch((error) => {
+          console.warn('Failed to parsing', error)
+        })
   },
   mounted() {
     TextareaInitializer.initialize('#js-user-mentor-memo')
@@ -127,13 +135,13 @@ export default {
         redirect: 'manual',
         body: JSON.stringify(params)
       })
-        .then((response) => {
-          this.editing = false
-          return response
-        })
-        .catch((error) => {
-          console.warn('Failed to parsing', error)
-        })
+          .then((response) => {
+            this.editing = false
+            return response
+          })
+          .catch((error) => {
+            console.warn('Failed to parsing', error)
+          })
     },
     cancel() {
       fetch(`/api/users/${this.userId}.json`, {
@@ -144,15 +152,15 @@ export default {
         credentials: 'same-origin',
         redirect: 'manual'
       })
-        .then((response) => {
-          return response.json()
-        })
-        .then((json) => {
-          this.memo = json.mentor_memo
-        })
-        .catch((error) => {
-          console.warn('Failed to parsing', error)
-        })
+          .then((response) => {
+            return response.json()
+          })
+          .then((json) => {
+            this.memo = json.mentor_memo
+          })
+          .catch((error) => {
+            console.warn('Failed to parsing', error)
+          })
       this.editing = false
     },
     editMemo() {

--- a/test/system/user/memos_test.rb
+++ b/test/system/user/memos_test.rb
@@ -5,22 +5,26 @@ require 'application_system_test_case'
 class User::MemoTest < ApplicationSystemTestCase
   test 'update memo' do
     visit_with_auth user_path(users(:hatsuno)), 'komagata'
+    assert_text 'ユーザーメモはまだありません。'
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'ユーザーメンターメモ'
     click_button '保存する'
     wait_for_vuejs
     assert_text 'ユーザーメンターメモ'
+    assert_no_text 'ユーザーメモはまだありません。'
   end
 
   test 'do not update memo when cancel' do
     visit_with_auth user_path(users(:kimura)), 'komagata'
     assert_text 'kimuraさんのメモ'
+    assert_no_text 'ユーザーメモはまだありません。'
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'ユーザーメンターメモ'
     click_button 'キャンセル'
     wait_for_vuejs
     assert_no_text 'ユーザーメンターメモ'
     assert_text 'kimuraさんのメモ'
+    assert_no_text 'ユーザーメモはまだありません。'
   end
 
   test 'admin can see memo' do


### PR DESCRIPTION
[#issue3842](https://github.com/fjordllc/bootcamp/issues/3842)

## 変更前
<img width="995" alt="aptの基礎を覚えるの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/148177971-fd95887b-fa40-4ce0-8ecc-1958aedac0df.png">

## 変更後
### ユーザーメモが空のとき
<img width="993" alt="aptの基礎を覚えるの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/148178137-ed2073f7-24e5-4cd5-9fdc-4788cb0b1692.png">
### ユーザーメモが入力されているとき
<img width="995" alt="aptの基礎を覚えるの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）_と_メモ" src="https://user-images.githubusercontent.com/62058863/148178194-4310c555-2b6c-4869-9078-825fbcae965d.png">

