### PR TITLE
ユーザー一覧ページの、卒業生の進捗状況が正しく表示されるように変更

### DIFF
--- a/app/javascript/user-practice-progress.vue
+++ b/app/javascript/user-practice-progress.vue
@@ -25,17 +25,17 @@ export default {
   },
   computed: {
     roundedPercentage() {
-      return this.user.role === 'graduate'
+      return this.user.graduated_on
         ? '100%'
         : Math.round(this.percentage) + '%'
     }
   },
   methods: {
     ariaValuenow() {
-      return this.user.role === 'graduate' ? 100 : this.percentage
+      return this.user.graduated_on ? 100 : this.percentage
     },
     completedPracticesProgressNumber() {
-      return this.user.role === 'graduate' ? '卒業' : this.fraction
+      return this.user.graduated_on ? '卒業' : this.fraction
     }
   }
 }

--- a/app/javascript/user-practice-progress.vue
+++ b/app/javascript/user-practice-progress.vue
@@ -25,9 +25,7 @@ export default {
   },
   computed: {
     roundedPercentage() {
-      return this.user.graduated_on
-        ? '100%'
-        : Math.round(this.percentage) + '%'
+      return this.user.graduated_on ? '100%' : Math.round(this.percentage) + '%'
     }
   },
   methods: {

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -1,4 +1,4 @@
-json.(user, :id, :login_name, :name, :discord_account, :description, :github_account, :twitter_account, :facebook_url, :blog_url, :times_url, :job_seeker, :free, :job, :os, :experience, :email, :role, :icon_title, :cached_completed_percentage, :completed_fraction)
+json.(user, :id, :login_name, :name, :discord_account, :description, :github_account, :twitter_account, :facebook_url, :blog_url, :times_url, :job_seeker, :free, :job, :os, :experience, :email, :role, :icon_title, :cached_completed_percentage, :completed_fraction, :graduated_on)
 json.tag_list user.tags.pluck(:name)
 json.url user_url(user)
 json.updated_at l(user.updated_at)

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -864,3 +864,26 @@ thuynga: # アイコンが小さい画像のユーザー
   unsubscribe_email_token: KVcUc3Ew3L6yt1Pwjdp-iQ
   updated_at: "2021-12-01 00:00:11"
   created_at: "2021-12-01 00:00:11"
+
+sotugyou-adviser: # 区分が卒業生ではない卒業したユーザー
+  login_name: sotugyou-adviser
+  email: sotugyou-adviser@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 卒業 アドバイザー
+  name_kana: ソツギョウ アドバイザー
+  twitter_account: sotugyou-adviser
+  facebook_url: http://www.facebook.com/sotugyou-adviser
+  blog_url: http://sotugyou-adviser.example.com/
+  description: "区分が卒業生ではない卒業したユーザーです"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  job_seeker: true
+  organization: 株式会社卒業
+  graduated_on: "2015-01-01"
+  adviser: true
+  unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwg
+  updated_at: "2014-01-01 00:00:03"
+  created_at: "2014-01-01 00:00:03"


### PR DESCRIPTION
issue: #3912 
## バグの原因
ユーザー一覧の卒業生タブには、「`User.graduated_on`がtrueなユーザー」が並ぶ。
一方、ユーザー一覧の進捗状況が卒業になる条件は、「`User.role`がgraduatedなユーザー」となっていた。

ユーザーの中には、「`User.graduated_on`がtrueかつ、`User.role`がgraduatedではないユーザー」もいるため、そういったユーザーは卒業生タブに並んでいるのにもかかわらず、進捗状況は卒業にならない。

## 解決策
ユーザー一覧の進捗状況が卒業になる条件を、「`User.graduated_on`がtrueなユーザー」とした(ユーザー一覧の卒業生タブに並ぶ条件と同等にした)。

## 修正前
![スクリーンショット 2022-01-06 14 11 12](https://user-images.githubusercontent.com/73326842/148332586-ca4f8b80-77c7-4bcb-b93b-3c76bb0cc038.png)

## 修正後
![スクリーンショット 2022-01-06 14 18 04](https://user-images.githubusercontent.com/73326842/148332646-43462c83-9520-496d-a3da-bb7fa92d09fb.png)

## 補足
ローカルのユーザーデータに「`User.graduated_on`がtrueかつ、`User.role`がgraduatedではないユーザー」がなかったため追加しました(sotugyou-adviser)。