### PR TITLE
タグ登録時、先頭のシャープないしハッシュ記号を無視するようにした

### DIFF
--- a/app/javascript/head-is-sharp-or-octothorpe.js
+++ b/app/javascript/head-is-sharp-or-octothorpe.js
@@ -1,0 +1,8 @@
+export default {
+  methods: {
+    headIsSharpOrOctothorpe(text) {
+      const regex = /^(#|＃|♯).*/
+      return regex.test(text)
+    }
+  }
+}

--- a/app/javascript/tags-input.vue
+++ b/app/javascript/tags-input.vue
@@ -9,17 +9,18 @@ div
     @before-adding-tag='validateTagName'
   )
   input(type='hidden', :value='tagsValue', :name='tagsParamName')
-  div(v-if='tagNameHeadIsSharpOrOctothorpe')
+  div(v-if='headIsSharpOrOctothorpe(inputTag)')
     | 先頭の記号は無視されます
 </template>
 
 <script>
 import VueTagsInput from '@johmun/vue-tags-input'
 import validateTagName from './validate-tag-name'
+import headIsSharpOrOctothorpe from './head-is-sharp-or-octothorpe'
 
 export default {
   components: { VueTagsInput },
-  mixins: [validateTagName],
+  mixins: [validateTagName, headIsSharpOrOctothorpe],
   props: {
     tagsInitialValue: { type: String, required: true },
     tagsParamName: { type: String, required: true },
@@ -40,10 +41,6 @@ export default {
           tag.text.toLowerCase().indexOf(this.inputTag.toLowerCase()) !== -1
         )
       })
-    },
-    tagNameHeadIsSharpOrOctothorpe() {
-      const regex = /^(#|＃|♯).*/
-      return regex.test(this.inputTag)
     }
   },
   mounted() {

--- a/app/javascript/tags-input.vue
+++ b/app/javascript/tags-input.vue
@@ -9,6 +9,8 @@ div
     @before-adding-tag='validateTagName'
   )
   input(type='hidden', :value='tagsValue', :name='tagsParamName')
+  div(v-if='tagNameHeadIsSharpOrOctothorpe')
+    | 先頭の記号は無視されます
 </template>
 
 <script>
@@ -38,6 +40,10 @@ export default {
           tag.text.toLowerCase().indexOf(this.inputTag.toLowerCase()) !== -1
         )
       })
+    },
+    tagNameHeadIsSharpOrOctothorpe() {
+      const regex = /^(#|＃|♯).*/
+      return regex.test(this.inputTag)
     }
   },
   mounted() {

--- a/app/javascript/tags.vue
+++ b/app/javascript/tags.vue
@@ -24,7 +24,7 @@
           :name='tagsParamName',
           :id='tagsInputId'
         )
-    div(v-if='tagNameHeadIsSharpOrOctothorpe')
+    div(v-if='headIsSharpOrOctothorpe(inputTag)')
       | 先頭の記号は無視されます
     .form-actions(v-if='tagsEditable')
       ul.form-actions__items
@@ -39,13 +39,14 @@
 <script>
 import VueTagsInput from '@johmun/vue-tags-input'
 import validateTagName from './validate-tag-name'
+import headIsSharpOrOctothorpe from './head-is-sharp-or-octothorpe'
 
 export default {
   name: 'Tags',
   components: {
     VueTagsInput
   },
-  mixins: [validateTagName],
+  mixins: [validateTagName, headIsSharpOrOctothorpe],
   props: {
     tagsInitialValue: {
       type: String,
@@ -92,10 +93,6 @@ export default {
           tag.text.toLowerCase().indexOf(this.inputTag.toLowerCase()) !== -1
         )
       })
-    },
-    tagNameHeadIsSharpOrOctothorpe() {
-      const regex = /^(#|＃|♯).*/
-      return regex.test(this.inputTag)
     }
   },
   mounted() {

--- a/app/javascript/tags.vue
+++ b/app/javascript/tags.vue
@@ -24,6 +24,8 @@
           :name='tagsParamName',
           :id='tagsInputId'
         )
+    div(v-if='tagNameHeadIsSharpOrOctothorpe')
+      | 先頭の記号は無視されます
     .form-actions(v-if='tagsEditable')
       ul.form-actions__items
         li.form-actions__item.is-main
@@ -90,6 +92,10 @@ export default {
           tag.text.toLowerCase().indexOf(this.inputTag.toLowerCase()) !== -1
         )
       })
+    },
+    tagNameHeadIsSharpOrOctothorpe() {
+      const regex = /^(#|＃|♯).*/
+      return regex.test(this.inputTag)
     }
   },
   mounted() {

--- a/app/javascript/validate-tag-name.js
+++ b/app/javascript/validate-tag-name.js
@@ -9,7 +9,6 @@ export default {
         alert('ドット1つだけのタグは作成できません') // eslint-disable-line no-undef
       } else {
         if (/^(#|＃|♯)/.test(text)) {
-          alert('先頭の記号は無視されます') // eslint-disable-line no-undef
           if (text.length === 1) {
             return
           }

--- a/app/javascript/validate-tag-name.js
+++ b/app/javascript/validate-tag-name.js
@@ -4,10 +4,17 @@ export default {
       const { text } = obj.tag
       // eslint-disable-next-line no-irregular-whitespace
       if (/ |　/.test(text)) {
-        alert('入力されたタグにスペースが含まれています') // eslint-disable-line no-undef
+        alert('スペースを含むタグは作成できません') // eslint-disable-line no-undef
       } else if (text === '.') {
         alert('ドット1つだけのタグは作成できません') // eslint-disable-line no-undef
       } else {
+        if (/^(#|＃|♯)/.test(text)) {
+          alert('先頭の記号は無視されます') // eslint-disable-line no-undef
+          if (text.length === 1) {
+            return
+          }
+          obj.tag.text = text.substr(1)
+        }
         obj.addTag()
       }
     }

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -71,4 +71,17 @@ class User::TagsTest < ApplicationSystemTestCase
     visit user_path(users(:hajime))
     assert_no_text name
   end
+
+  test 'the first letter is ignored when adding a tag whose name begins with octothorpe' do
+    visit_with_auth user_path(users(:hatsuno)), 'hatsuno'
+    page.all('.tag-links__item-edit')[0].click
+    tag_input = find('.ti-new-tag-input')
+    tag_input.set '#ハッシュハッシュ'
+    find('body').click
+    click_button '保存する'
+
+    visit_with_auth user_path(users(:hatsuno)), 'komagata'
+    assert_no_text '#ハッシュハッシュ'
+    assert_text 'ハッシュハッシュ'
+  end
 end

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -51,11 +51,12 @@ class User::TagsTest < ApplicationSystemTestCase
     visit_with_auth user_path(users(:hatsuno)), 'hatsuno'
     page.all('.tag-links__item-edit')[0].click
     tag_input = find('.ti-new-tag-input')
-    tag_input.set '課金'
+    tag_input.set 'タグタグ'
+    find('body').click
     click_button '保存する'
 
     visit_with_auth user_path(users(:hatsuno)), 'komagata'
-    assert_text '課金'
+    assert_text 'タグタグ'
     assert_no_text 'タグ編集'
   end
 


### PR DESCRIPTION
## issue
- #3202 
## 概要
- タグ名の入力時、ハッシュタグ類（`#`/`＃`/`♯`）で始まっている場合には、その記号が無視される旨を表示するようにしました。
- そのままの状態でタグ名が確定された場合、該当文字を取り除いた状態でタグが登録されるようにしました。

## 動作確認の手順
1. 任意のユーザーでログイン
1. 自分のプロフィール画面へ移動
1. 「タグ編集」をクリック
1. ハッシュタグ類を先頭に入力した場合（例：`#test`）、入力ボックスの真下に「先頭の記号は無視されます」という文言が表示されることを確認
1. エンターキーを押下すると、ハッシュタグ類が取り除かれた状態でタグ名が確定されていることを確認
1. ハッシュタグ類１文字のみ（例：`#`）を入力し、エンターキーを押下
1. 今度は何も登録されないことを確認
1. 同手順を、以下のパターンでも繰り返す
    1. 参加登録
    1. 登録情報変更（プロフィール画面から遷移）
    1. Q&A での質問作成
## スクリーンショット
### プロフィール
![スクリーンショット 2022-01-08 17 19 03](https://user-images.githubusercontent.com/46347198/148637422-2b591b22-1e57-413a-a336-60bc1458b77e.png)

### 参加登録
![スクリーンショット 2022-01-08 17 18 02](https://user-images.githubusercontent.com/46347198/148637431-841914f6-bc6e-47ba-956e-7036198f82a6.png)

### 登録情報変更
![スクリーンショット 2022-01-08 17 17 38](https://user-images.githubusercontent.com/46347198/148637449-9e536ce9-435f-41cf-8b2b-a57ef9526f75.png)

### Q&A での質問作成
![スクリーンショット 2022-01-08 17 15 17](https://user-images.githubusercontent.com/46347198/148637506-8ab7a109-030c-42fd-8f51-307eb44e99ad.png)

加えて、既存のコードに以下の変更を加えました。
1. テストにバグを発見したので、修正しました。
そのテストの内容は、「課金」タグが登録されたことを確認するものでしたが、実際にはそのタグが追加されていないにも関わらず、同ページ内の他の箇所に「課金」という文言があったため、それに`assert_text`をかけてパスしてしまっていました。
2. アラートメッセージが分かりやすくなるよう、変更を施しました。