### PR TITLE
メンターログイン時の提出物一覧のタブの数字の表示の変更

### DIFF
--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -5,10 +5,7 @@
         = link_to '全て', products_path, class: "page-tabs__item-link #{current_link(/^products-index/)}"
       li.page-tabs__item
         = link_to products_unchecked_index_path, class: "page-tabs__item-link #{current_link(/^products-unchecked-index/)}" do
-          | 未完了
-          - if Cache.unchecked_product_count.positive?
-            .page-tabs__item-count.a-notification-count.is-only-mentor
-              = Cache.unchecked_product_count
+          | 未完了 （#{Cache.unchecked_product_count}）
       li.page-tabs__item
         = link_to products_unassigned_index_path, class: "page-tabs__item-link #{current_link(/^products-unassigned-index/)}", id: 'test-unassigned-tab' do
           | 未アサイン


### PR DESCRIPTION
ref: #3765

# 要件
提出物ページ( https://bootcamp.fjord.jp/products / http://127.0.0.1:3000/products )の`未完了`タブの件数を右上に表示される赤丸ではなく、カッコ内に件数を表示するように変更。

# 画面イメージ

![スクリーンショット 2022-01-09 22 21 45](https://user-images.githubusercontent.com/6190966/148683929-6cdca65e-c45e-4625-9f8a-d225c54f0014.png)

# 確認方法
1. `feature/change-the-display-of-numbers-in-tabs`ブランチをローカルに持ってくる
2. メンター（`komagata` / `machida`）アカウントでログイン
3. http://127.0.0.1:3000/products ページに遷移
4. `未完了`タブに赤丸ではなくカッコ内に数字が表示されていることを確認

# 備考
- 未返信タブはなくなった模様
    - https://discord.com/channels/715806612824260640/809595476847493192/929174526049259570
- issue（ref: #3765）では文字色が赤くなっているが、文字色は@machidaさんに担当いただく領域だと判断して未着手
- 他のタブだと0件のときは`（0）`という表示になっているのでそれに合わせた