### PR TITLE
プラクティスページ表示時に着手中プラクティスがない場合、最上段の未着手プラクティスのカテゴリーを表示する

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -23,6 +23,17 @@ module LayoutHelper
   end
 
   def category_having_top_unstarted_practice
+    top_unstarted_practice = practices.last
     current_user.top_unstarted_practice.categories.first
   end
+
+  def category_active_or_unstarted_practice
+    if current_user.active_practices.present?
+      category_having_active_practice
+    elsif current_user.top_unstarted_practice.present?
+      category_having_top_unstarted_practice
+    end
+  end
 end
+
+

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -21,4 +21,8 @@ module LayoutHelper
     active_practice = current_user.active_practices.first
     active_practice.categories.first
   end
+
+  def category_having_top_unstarted_practice
+    current_user.top_unstarted_practice.categories.first
+  end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -22,16 +22,16 @@ module LayoutHelper
     active_practice.categories.first
   end
 
-  def category_having_top_unstarted_practice
-    top_unstarted_practice = practices.last
-    current_user.top_unstarted_practice.categories.first
+  def category_having_unstarted_practice
+    unstarted_practice = current_user.unstarted_practices.first
+    unstarted_practice.categories.first
   end
 
   def category_active_or_unstarted_practice
     if current_user.active_practices.present?
       category_having_active_practice
-    elsif current_user.top_unstarted_practice.present?
-      category_having_top_unstarted_practice
+    elsif current_user.unstarted_practices.present?
+      category_having_unstarted_practice
     end
   end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -16,22 +16,4 @@ module LayoutHelper
   def display_footer?
     body_class.exclude?('no-footer')
   end
-
-  def category_having_active_practice
-    active_practice = current_user.active_practices.first
-    active_practice.categories.first
-  end
-
-  def category_having_unstarted_practice
-    unstarted_practice = current_user.unstarted_practices.first
-    unstarted_practice.categories.first
-  end
-
-  def category_active_or_unstarted_practice
-    if current_user.active_practices.present?
-      category_having_active_practice
-    elsif current_user.unstarted_practices.present?
-      category_having_unstarted_practice
-    end
-  end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -35,5 +35,3 @@ module LayoutHelper
     end
   end
 end
-
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -556,17 +556,6 @@ class User < ApplicationRecord
     course.practices.order('categories.position', 'practices.position')
   end
 
-  def top_unstarted_practice
-    # practices
-    not_unstarted_practices = practices.joins(:learnings)
-                                       .merge(Learning.complete.where(user_id: id))
-                                      #  .merge(Learning.started.where(user_id: id))
-                                      #  .merge(Learning.submitted.where(user_id: id))
-    practices.each do |practice|
-      break if not_unstarted_practices.find_by_id(practice.id).nil?
-    end
-  end
-
   def update_mentor_memo(new_memo)
     # ユーザーの「最終ログイン」にupdated_at値が利用されるため
     # メンターor管理者によるmemoカラムのupdateの際は、updated_at値の変更を防ぐ
@@ -591,6 +580,13 @@ class User < ApplicationRecord
     else
       logger.error "[Discord API] チャンネルURLを取得できません: #{login_name} (#{res.code} #{res.message})"
     end
+  end
+
+  def unstarted_practices
+    practices -
+      practices.joins(:learnings).where(learnings: { user_id: id, status: 1 })
+               .or(practices.joins(:learnings).where(learnings: { user_id: id, status: 2 }))
+               .or(practices.joins(:learnings).where(learnings: { user_id: id, status: 3 }))
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -556,6 +556,17 @@ class User < ApplicationRecord
     course.practices.order('categories.position', 'practices.position')
   end
 
+  def top_unstarted_practice
+    # practices
+    not_unstarted_practices = practices.joins(:learnings)
+                                       .merge(Learning.complete.where(user_id: id))
+                                      #  .merge(Learning.started.where(user_id: id))
+                                      #  .merge(Learning.submitted.where(user_id: id))
+    practices.each do |practice|
+      break if not_unstarted_practices.find_by_id(practice.id).nil?
+    end
+  end
+
   def update_mentor_memo(new_memo)
     # ユーザーの「最終ログイン」にupdated_at値が利用されるため
     # メンターor管理者によるmemoカラムのupdateの際は、updated_at値の変更を防ぐ

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -613,12 +613,10 @@ class User < ApplicationRecord
   end
 
   def category_having_active_practice
-    active_practice = active_practices&.first
-    active_practice.categories&.first
+    active_practices&.first&.categories&.first
   end
 
   def category_having_unstarted_practice
-    unstarted_practice = unstarted_practices&.first
-    unstarted_practice.categories&.first
+    unstarted_practices&.first&.categories&.first
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -589,6 +589,14 @@ class User < ApplicationRecord
                .or(practices.joins(:learnings).where(learnings: { user_id: id, status: 3 }))
   end
 
+  def category_active_or_unstarted_practice
+    if active_practices.present?
+      category_having_active_practice
+    elsif unstarted_practices.present?
+      category_having_unstarted_practice
+    end
+  end
+
   private
 
   def password_required?
@@ -602,5 +610,15 @@ class User < ApplicationRecord
   def completed_practices_include_progress
     practices_include_progress.joins(:learnings)
                               .merge(Learning.complete.where(user_id: id))
+  end
+
+  def category_having_active_practice
+    active_practice = active_practices.first
+    active_practice.categories.first
+  end
+
+  def category_having_unstarted_practice
+    unstarted_practice = unstarted_practices.first
+    unstarted_practice.categories.first
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -613,10 +613,12 @@ class User < ApplicationRecord
   end
 
   def category_having_active_practice
-    active_practices.first.categories.first
+    active_practice = active_practices&.first
+    active_practice.categories&.first
   end
 
   def category_having_unstarted_practice
-    unstarted_practices.first.categories.first
+    unstarted_practice = unstarted_practices&.first
+    unstarted_practice.categories&.first
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -582,13 +582,6 @@ class User < ApplicationRecord
     end
   end
 
-  def unstarted_practices
-    practices -
-      practices.joins(:learnings).where(learnings: { user_id: id, status: 1 })
-               .or(practices.joins(:learnings).where(learnings: { user_id: id, status: 2 }))
-               .or(practices.joins(:learnings).where(learnings: { user_id: id, status: 3 }))
-  end
-
   def category_active_or_unstarted_practice
     if active_practices.present?
       category_having_active_practice
@@ -612,13 +605,18 @@ class User < ApplicationRecord
                               .merge(Learning.complete.where(user_id: id))
   end
 
+  def unstarted_practices
+    practices -
+      practices.joins(:learnings).where(learnings: { user_id: id, status: :started })
+               .or(practices.joins(:learnings).where(learnings: { user_id: id, status: :submitted }))
+               .or(practices.joins(:learnings).where(learnings: { user_id: id, status: :complete }))
+  end
+
   def category_having_active_practice
-    active_practice = active_practices.first
-    active_practice.categories.first
+    active_practices.first.categories.first
   end
 
   def category_having_unstarted_practice
-    unstarted_practice = unstarted_practices.first
-    unstarted_practice.categories.first
+    unstarted_practices.first.categories.first
   end
 end

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -10,15 +10,7 @@ nav.global-nav
               i.fas.fa-fw.fa-bullhorn
             .global-nav-links__link-label お知らせ
         li.global-nav-links__item
-          - anchor = "category-#{current_user.category_having_active_practice.id}" if current_user.active_practices.present?
-          / - anchor = "category-#{current_user.category_having_top_unstarted_practice.id}" if current_user.unstarted_practices.present?
-          / - anchor = ( current_user.active_practices.present? ? "category-#{current_user.category_having_active_practice.id}" : "category-#{current_user.category_having_top_unstarted_practice.id}" )
-          / - binding.pry
-          / - if current_user.active_practices.present?
-          /   - anchor = "category-#{current_user.category_having_active_practice.id}"
-          / - elsif current_user.top_unstarted_practice.present?
-            - anchor = "category-#{current_user.category_having_top_unstarted_practice.id}"
-          / - anchor = "category-#{current_user.category_active_or_unstarted_practice.id}"
+          - anchor = "category-#{current_user.category_active_or_unstarted_practice.id}"  if (current_user.active_practices.present? | current_user.unstarted_practices.present?)
           = link_to course_practices_path(current_user.course, anchor: anchor), class: "global-nav-links__link #{current_link(/^(courses-practices|practices)-/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-book

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -10,7 +10,7 @@ nav.global-nav
               i.fas.fa-fw.fa-bullhorn
             .global-nav-links__link-label お知らせ
         li.global-nav-links__item
-          - anchor = "category-#{current_user.category_active_or_unstarted_practice.id}"  if (current_user.active_practices.present? | current_user.unstarted_practices.present?)
+          - anchor = "category-#{current_user.category_active_or_unstarted_practice.id}" if current_user.active_practices.present? | current_user.unstarted_practices.present?
           = link_to course_practices_path(current_user.course, anchor: anchor), class: "global-nav-links__link #{current_link(/^(courses-practices|practices)-/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-book

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -10,7 +10,7 @@ nav.global-nav
               i.fas.fa-fw.fa-bullhorn
             .global-nav-links__link-label お知らせ
         li.global-nav-links__item
-          - anchor = "category-#{current_user.category_active_or_unstarted_practice.id}" if current_user.active_practices.present? | current_user.unstarted_practices.present?
+          - anchor = "category-#{current_user.category_active_or_unstarted_practice.id}" if current_user.category_active_or_unstarted_practice.present?
           = link_to course_practices_path(current_user.course, anchor: anchor), class: "global-nav-links__link #{current_link(/^(courses-practices|practices)-/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-book

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -10,7 +10,15 @@ nav.global-nav
               i.fas.fa-fw.fa-bullhorn
             .global-nav-links__link-label お知らせ
         li.global-nav-links__item
-          - anchor = "category-#{current_user.category_having_active_practice.id}" if current_user.active_practices.present?
+          / - anchor = "category-#{current_user.category_having_active_practice.id}" if current_user.active_practices.present?
+          / - anchor = "category-#{current_user.category_having_top_unstarted_practice.id}" if current_user.unstarted_practices.present?
+          / - anchor = ( current_user.active_practices.present? ? "category-#{current_user.category_having_active_practice.id}" : "category-#{current_user.category_having_top_unstarted_practice.id}" )
+          / - binding.pry
+          - if current_user.active_practices.present
+          ?
+            - anchor = "category-#{current_user.category_having_active_practice.id}"
+          - elsif current_user.top_unstarted_practice.present?
+            - anchor = "category-#{current_user.category_having_top_unstarted_practice.id}"
           = link_to course_practices_path(current_user.course, anchor: anchor), class: "global-nav-links__link #{current_link(/^(courses-practices|practices)-/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-book

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -10,15 +10,15 @@ nav.global-nav
               i.fas.fa-fw.fa-bullhorn
             .global-nav-links__link-label お知らせ
         li.global-nav-links__item
-          / - anchor = "category-#{current_user.category_having_active_practice.id}" if current_user.active_practices.present?
+          - anchor = "category-#{current_user.category_having_active_practice.id}" if current_user.active_practices.present?
           / - anchor = "category-#{current_user.category_having_top_unstarted_practice.id}" if current_user.unstarted_practices.present?
           / - anchor = ( current_user.active_practices.present? ? "category-#{current_user.category_having_active_practice.id}" : "category-#{current_user.category_having_top_unstarted_practice.id}" )
           / - binding.pry
-          - if current_user.active_practices.present
-          ?
-            - anchor = "category-#{current_user.category_having_active_practice.id}"
-          - elsif current_user.top_unstarted_practice.present?
+          / - if current_user.active_practices.present?
+          /   - anchor = "category-#{current_user.category_having_active_practice.id}"
+          / - elsif current_user.top_unstarted_practice.present?
             - anchor = "category-#{current_user.category_having_top_unstarted_practice.id}"
+          / - anchor = "category-#{current_user.category_active_or_unstarted_practice.id}"
           = link_to course_practices_path(current_user.course, anchor: anchor), class: "global-nav-links__link #{current_link(/^(courses-practices|practices)-/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-book

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -494,4 +494,18 @@ class UserTest < ActiveSupport::TestCase
     worried_users = User.delayed.order(completed_at: :asc)
     assert_equal worried_users.where(id: user.id).size, 0
   end
+
+  test 'get category active or unstarted practice' do
+    komagata = users(:komagata)
+    assert_equal 917_504_053, komagata.category_active_or_unstarted_practice.id
+
+    machida = users(:machida)
+    practice1 = practices(:practice1)
+    Learning.create!(
+      user: machida,
+      practice: practice1,
+      status: :complete
+    )
+    assert_equal 685_020_562, machida.category_active_or_unstarted_practice.id
+  end
 end


### PR DESCRIPTION
ref: [プラクティス一覧ページにて、着手中のプラクティスがない場合、次に手を付けるべきプラクティスのカテゴリーが自動で表示されない · Issue \#3783](https://github.com/fjordllc/bootcamp/issues/3783)

## 概要
- プラクティスページを開いた際にどのカテゴリーを自動的に表示するかを変更します。
- 現在は着手中プラクティスの所属カテゴリーを表示する設定のみで、「着手中」が「提出」や「完了」に変わるとページの最上段が表示されています。
- 今回、着手中プラクティスがない場合は「最上段の未着手のプラクティス」が所属するカテゴリーまでスクロールしてから表示されるように変更しました。

## 変更前
プラクティスページ表示時、着手中がない場合は「ページの最上段」が表示される
![スクリーンショット 2022-01-08 22 31 47](https://user-images.githubusercontent.com/82434093/148646608-4cb3d232-eecc-4766-9ef8-03e8867c2b0d.png)

## 変更後
プラクティスページ表示時、「最上段の未着手のプラクティスが所属するカテゴリー」までスクロールして表示
![スクリーンショット 2022-01-08 22 32 08](https://user-images.githubusercontent.com/82434093/148646620-2db778c9-925d-4c56-bf0d-9868987c5031.png)

