### PR TITLE
通知ページの全てのタブの通知合計数を削除

### DIFF
--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -3,7 +3,7 @@
     ul.page-tabs__items
       li.page-tabs__item
         = link_to notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
-          | 全て （#{current_user.notifications.length}）
+          | 全て
           - if current_user.notifications.unreads.count.positive?
             .page-tabs__item-count.a-notification-count
               = current_user.notifications.unreads.count


### PR DESCRIPTION
通知ページの「全て」タブの通知合計数を表示しないように変更。
ref: #3909

# 要件
- 通知ページ( https://bootcamp.fjord.jp/notifications / http://127.0.0.1:3000/notifications )の`全て`タブの、
    -  `全て`の文字の右側に表示されるカッコでの通知合計数の文字列を表示しないように修正
    - `全て`タブの右上の未確認通知の合計は継続して表示
 
# 画面イメージ
![スクリーンショット 2022-01-09 22 10 26](https://user-images.githubusercontent.com/6190966/148683503-b4c34de9-be8e-40ce-96af-a4903eb84d7b.png)

# 確認手順
1. `feature/delete-the-total-number-of-notifications-in-all-tabs`ブランチをローカルに持ってくる
2. 任意のアカウントでログイン
3. http://127.0.0.1:3000/notifications などの通知が確認できるページへ遷移
4. `全て`タブ上にカッコでの通知合計数が表示されていないことを確認する
