### PR TITLE
プラクティスの日報一覧画面のN+1を解消

### DIFF
--- a/app/controllers/practices/reports_controller.rb
+++ b/app/controllers/practices/reports_controller.rb
@@ -5,6 +5,6 @@ class Practices::ReportsController < ApplicationController
 
   def index
     @practice = Practice.find(params[:practice_id])
-    @reports = @practice.reports.eager_load(:user, :comments).order(updated_at: :desc, id: :desc).page(params[:page])
+    @reports = @practice.reports.list.page(params[:page])
   end
 end


### PR DESCRIPTION
## Description

bulletのwarningが出ていたので対応しました。
既存のReportモデルに定義してあるscopeを用いて対応したので、N+1の解消とともに、他の日報一覧と同じ並び順になりました。