### PR TITLE
「作成日時が最新の通知」が複数ある場合でも通知元リンクごとに最新1件の通知のみ取得できるようにする

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -4,12 +4,13 @@ class API::NotificationsController < API::BaseController
   def index
     target = params[:target].presence&.to_sym
     status = params[:status]
+    latest_notifications = current_user.notifications
+                                       .by_target(target)
+                                       .by_read_status(status)
+                                       .latest_of_each_link
 
-    @notifications = current_user.notifications
-                                 .by_target(target)
-                                 .by_read_status(status)
+    @notifications = Notification.from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
                                  .order(created_at: :desc)
-
     @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -35,16 +35,9 @@ class Notification < ApplicationRecord
     assigned_as_checker: 16
   }
 
-  scope :reads, lambda {
-    latest_of_each_link.order(created_at: :desc)
-  }
-
-  scope :unreads, lambda {
-    where(read: false).latest_of_each_link.order(created_at: :desc)
-  }
-
+  scope :unreads, -> { where(read: false) }
   scope :with_avatar, -> { preload(sender: { avatar_attachment: :blob }) }
-  scope :by_read_status, ->(status) { status == 'unread' ? unreads.with_avatar.limit(99) : reads.with_avatar }
+  scope :by_read_status, ->(status) { status == 'unread' ? unreads.with_avatar.limit(99) : with_avatar }
 
   scope :by_target, lambda { |target|
     target ? where(kind: TARGETS_TO_KINDS[target]) : all

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -36,11 +36,11 @@ class Notification < ApplicationRecord
   }
 
   scope :reads, lambda {
-    where(created_at: into_one.values).order(created_at: :desc)
+    latest_of_each_link.order(created_at: :desc)
   }
 
   scope :unreads, lambda {
-    where(read: false, created_at: into_one.values).order(created_at: :desc)
+    where(read: false).latest_of_each_link.order(created_at: :desc)
   }
 
   scope :with_avatar, -> { preload(sender: { avatar_attachment: :blob }) }
@@ -49,6 +49,7 @@ class Notification < ApplicationRecord
   scope :by_target, lambda { |target|
     target ? where(kind: TARGETS_TO_KINDS[target]) : all
   }
+  scope :latest_of_each_link, -> { where(created_at: into_one.values) }
 
   def self.came_comment(comment, receiver, message)
     Notification.create!(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -489,14 +489,6 @@ class User < ApplicationRecord
     !staff? && !graduated?
   end
 
-  def unread_notifications_count
-    @unread_notifications_count ||= notifications.unreads.latest_of_each_link.size
-  end
-
-  def unread_notifications_exists?
-    unread_notifications_count.positive?
-  end
-
   def avatar_url
     default_image_path = '/images/users/avatars/default.png'
     if avatar.attached?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -490,7 +490,7 @@ class User < ApplicationRecord
   end
 
   def unread_notifications_count
-    @unread_notifications_count ||= notifications.unreads.count
+    @unread_notifications_count ||= notifications.unreads.latest_of_each_link.size
   end
 
   def unread_notifications_exists?

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -4,9 +4,9 @@
       li.page-tabs__item
         = link_to notifications_path(status: 'unread'), class: "page-tabs__item-link #{'is-active' if @target.nil?}".strip
           | 全て
-          - if current_user.notifications.unreads.count.positive?
+          - if current_user.notifications.unreads.latest_of_each_link.size.positive?
             .page-tabs__item-count.a-notification-count
-              = current_user.notifications.unreads.count
+              = current_user.notifications.unreads.latest_of_each_link.size
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip

--- a/test/models/notifications_test.rb
+++ b/test/models/notifications_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NotificationTest < ActiveSupport::TestCase
+  setup do
+    @receiver = users(:yamada)
+    @sender = users(:machida)
+    @link = 'path/to/link'
+    @now = Time.current
+  end
+
+  test '.latest_of_each_link' do
+    Notification.destroy_all
+    old_notification = Notification.create!(user: @receiver, sender: @sender, link: @link, created_at: @now)
+    new_notification = Notification.create!(user: @receiver, sender: @sender, link: @link, created_at: @now + 1)
+
+    latest_notifications_of_each_link = Notification.latest_of_each_link.to_a
+
+    assert_not_includes latest_notifications_of_each_link, old_notification
+    assert_includes latest_notifications_of_each_link, new_notification
+  end
+
+  test '.latest_of_each_link returns only one notification of the latest notifications created at the same time in the same link' do
+    Notification.destroy_all
+    notification_without_max_id_of_latests = Notification.create!(id: 1, user: @receiver, sender: @sender, link: @link, created_at: @now)
+    notification_with_max_id_of_latests = Notification.create!(id: 2, user: @receiver, sender: @sender, link: @link, created_at: @now)
+
+    latest_notifications_of_each_link = Notification.latest_of_each_link.to_a
+
+    assert_not_includes latest_notifications_of_each_link, notification_without_max_id_of_latests
+    assert_includes latest_notifications_of_each_link, notification_with_max_id_of_latests
+  end
+end


### PR DESCRIPTION
## 目的

以下のバグ修正

Refs: #3755

※ 修正過程で #3752, #3753 の対応が必要になったため、それらも併せて対応した

## やったこと

### 通知元リンクごとに最新の通知を1件のみ取得できるようにした

[PostgreSQL の DISTINCT ON](https://www.postgresql.jp/document/13/html/sql-select.html#SQL-DISTINCT) を用いて `SELECT DISTINCT ON (通知元リンク) FROM notifications WHERE ...`  のような SQL を発行することで、通知元リンクごとに1件のみ通知を取得するようにした

### 最新の通知を1件のみ取得するスコープのテストを追加した

以下2つのテストを追加した

- テストA: 「通知元リンクが同じ」通知が複数ある場合、最新の通知を返すこと
- テストB: 「通知元リンクが同じ」かつ「作成日時が最新（かつ同値）」の通知が複数ある場合でも、通知を1件に絞って返すこと

※ 修正前のクエリについては、テストAは通るけれど、テストBは通らなかった

### `reads`/`unreads` スコープから既読/未読の判別に不要なクエリ条件を除いた

Refs: #3752, #3753

最新1件の通知を取得するクエリの変更により、そのクエリをスコープに含む `reads`/`unreads` の挙動も変わるため、`reads`/`unreads` からそれら（+ 他の不要なクエリ）を除いた。除いたクエリについては、`reads`/`unreads` を使用しているコードの意図を読み取りながら、`reads`/`unreads` に続くメソッドチェーンとして必要に応じて付け足して修正した。なお、`reads` には「既読」の判別に関するクエリが含まれておらず、不要なクエリを除いた結果クエリが何も残らなかったため、スコープ自体を削除した。

## 動作確認手順

1. `$ rails db:seed` を実行
2. `$ rails s` でサーバーを起動
3. ユーザー `sotugyou` でログイン
4. 通知一覧ページの「コメント」タブを表示
    - http://127.0.0.1:3000/notifications?target=comment
5. 以下の通知A・Bのどちらか一つのメッセージのみが表示されていることを確認する
    - 通知A(のメッセージ）: komagataさんからコメントが届きました。
    - 通知B(のメッセージ）: machidaさんからコメントが届きました。

### 補足

- 通知A・Bはどちらも通知元リンクが同じ（`sotugyou`のある日報）であり、（通知元リンクが同じである複数の通知の中で）作成日時が最新かつ同値
- main ブランチで同手順を確認した場合、A・B 両方の通知が表示される

---

以下、補足説明

## 「最新の通知を1件のみ取得するクエリ」を`from` を使ってサブクエリとした理由

### 該当のコード

https://github.com/fjordllc/bootcamp/pull/3936/files#diff-128ee7af8e3628b00f1059e7b06e5126a85b005d2b1268e971ac9d14ec92086dR12-R13

### 理由

以下2つの `ORDER BY` の指定が一つにまとめられないようにするため

- `DISTINCT ON (通知元リンク) ` で取得する最初の1件の通知を指定するための `ORDER BY`
    - `latest_of_each_link` スコープの中で指定している
    - （補足）`SELECT DISTINCT ON (通知元リンク) FROM ...`という SQL は通知元リンクごとに最初の1行のレコードを取得する。その「最初の1行」は `ORDER BY`の指定順に並べたときの最初の1行となる。
- 通知一覧ページに表示する通知の順序を指定するための `ORDER BY`
    - 該当のコードの箇所では、 `.order(created_at: :desc)` としている

`from` を使わずに `Notification.latest_of_each_link.order(created_at: :desc)` のようにメソッドチェーンでつなげた場合、2つの `ORDER BY` の指定が一つにまとめられ、意図しない SQL が発行される

（参考）`from` を使う場合と使わない場合の SQL の違い

```bash
$ rails c
>> Notification.from(Notification.latest_of_each_link, :notifications).order(created_at: :desc).to_sql
=> "SELECT \"notifications\".* FROM (SELECT DISTINCT ON (link) * FROM \"notifications\" ORDER BY \"notifications\".\"link\" ASC, \"notifications\".\"created_at\" DESC, \"notifications\".\"id\" DESC) notifications ORDER BY \"notifications\".\"created_at\" DESC"
>> Notification.latest_of_each_link.order(created_at: :desc).to_sql
=> "SELECT DISTINCT ON (link) * FROM \"notifications\" ORDER BY \"notifications\".\"link\" ASC, \"notifications\".\"created_at\" DESC, \"notifications\".\"id\" DESC"
```

## 今回の修正に使用した `DISTINCT ON (通知元リンク)` がパフォーマンスを著しく損なわないと判断した理由

今回の対応に用いるクエリによっては著しくパフォーマンスを損なうこともありえそうに思ったため、実際にパフォーマンスを測定し、問題がないことを確かめた。
確かめた結果、今回使用した `DISTINCT ON (link)` は、修正前の `MAX(created_at)` より実行に時間がかかるものの、およそ体感でわかるほど顕著な差は生じないと考えられ、個人的によく目にする`ROW_NUMBER()` を使ったクエリの実行時間とも大差ないことから、パフォーマンスを著しく損なうクエリではないと判断した。

### パフォーマンスの測定方法

約2万件のレコードを持つ`notifications` テーブルを用いて、次のように [PostgreSQL の `explain`](https://www.postgresql.jp/document/13/html/sql-explain.html) を使ってクエリごとの Actual Total Time と Total Cost （説明は後述）を確認した

```bash
$ rails db
psql (14.1)

bootcamp_development=# explain (analyze, format yaml) SELECT DISTINCT ON (link) * FROM notifications ORDER BY link ASC, created_at DESC, id DESC;
                 QUERY PLAN                 
--------------------------------------------
 - Plan:                                   +
     Node Type: "Unique"                   +
     Parallel Aware: false                 +
     Async Capable: false                  +
     Startup Cost: 2287.19                 +
     Total Cost: 2387.27                   +
     Plan Rows: 112                        +
     Plan Width: 66                        +
     Actual Startup Time: 30.893           +
     Actual Total Time: 35.321             +
     Actual Rows: 113                      +
     Actual Loops: 1                       +

~省略~

   Planning Time: 0.079                    +
   Triggers:                               +
   Execution Time: 35.486
```

測定方法の補足説明

- `notifications` テーブルのレコードの作成方法について
    - seed データの範囲内でできるだけランダムな値を各カラムに設定した
- Actual Total Time (msec)
    - 実際のクエリの実行に費やした総経過時間のこと
    - 試行するたびに若干変動するため、5回試行してそれらの平均値を↓の結果の表に載せた
- Total Cost
    - すべての行を返すまでの合計コストの見積りのこと
    - 一つのクエリに対して一定の値が出力される（試行するたびに変動しない）
    - 単位を調べてみたものの、ドキュメントにも載っておらず不明

### パフォーマンスを測定した3つのクエリ

- 修正前の`MAX(created_at)`を使ったクエリ（リンクごとに1件に絞れないことがあるという問題がある。以下、 `MAX(created_at)` ）
    
    ```sql
    SELECT n1.*
    FROM   notifications AS n1
    WHERE  created_at IN (SELECT Max(created_at)
                          FROM   notifications AS n2
                          GROUP  BY link);
    ```
    
- 修正後の`DISTINCT ON (link)` を使ったクエリ（以下、 `DISTINCT ON (link)`）
    
    ```sql
    SELECT DISTINCT ON (link) *
    FROM   notifications
    ORDER  BY link ASC,
              created_at DESC,
              id DESC;
    ```
    
- `ROW_NUMBER()` を使って順位づけするクエリ（以下、`ROW_NUMBER()`）
    
    ```sql
    SELECT *
    FROM (
      SELECT *,
             ROW_NUMBER() OVER (PARTITION BY link ORDER BY created_at DESC, id DESC) AS row_number
      FROM notifications
      ) n
    WHERE row_number = 1;
    ```
    
### パフォーマンスの測定結果

| クエリの省略名     | Actual Total Time (msec) | Total Cost | 備考           |
|--------------------|:------------------------:|:----------:|----------------|
| MAX(created_at)    |                      8.4 |    1748.16 | 修正前のクエリ（リンクごとに1件に絞れないことがある） |
| DISTINCT ON (link) |                     31.5 |    2387.27 | 修正後のクエリ |
| ROW_NUMBER()       |                     28.4 |    2987.75 |                |