### PR TITLE
ダッシュボード＞ブックマークのタイトルを「ダッシュボード」に変更

### DIFF
--- a/app/views/current_user/bookmarks/index.html.slim
+++ b/app/views/current_user/bookmarks/index.html.slim
@@ -3,7 +3,7 @@ header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        | ダッシュボード
 
 = render 'home/page_tabs', user: @user
 

--- a/test/system/bookmark/page_test.rb
+++ b/test/system/bookmark/page_test.rb
@@ -9,7 +9,6 @@ class Bookmark::PageTest < ApplicationSystemTestCase
 
   test 'show page bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_equal 'ブックマーク一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
     assert_text @page.title
   end
 

--- a/test/system/bookmark/page_test.rb
+++ b/test/system/bookmark/page_test.rb
@@ -9,7 +9,7 @@ class Bookmark::PageTest < ApplicationSystemTestCase
 
   test 'show page bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_text 'ブックマーク一覧'
+    assert_text 'ダッシュボード'
     assert_text @page.title
   end
 

--- a/test/system/bookmark/page_test.rb
+++ b/test/system/bookmark/page_test.rb
@@ -9,7 +9,7 @@ class Bookmark::PageTest < ApplicationSystemTestCase
 
   test 'show page bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_text 'ダッシュボード'
+    assert_equal 'ブックマーク一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
     assert_text @page.title
   end
 

--- a/test/system/bookmark/products_test.rb
+++ b/test/system/bookmark/products_test.rb
@@ -9,7 +9,7 @@ class Bookmark::ProductTest < ApplicationSystemTestCase
 
   test 'show product bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_text 'ダッシュボード'
+    assert_equal 'ブックマーク一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
     assert_text @product.title
   end
 

--- a/test/system/bookmark/products_test.rb
+++ b/test/system/bookmark/products_test.rb
@@ -9,7 +9,6 @@ class Bookmark::ProductTest < ApplicationSystemTestCase
 
   test 'show product bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_equal 'ブックマーク一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
     assert_text @product.title
   end
 

--- a/test/system/bookmark/products_test.rb
+++ b/test/system/bookmark/products_test.rb
@@ -9,7 +9,7 @@ class Bookmark::ProductTest < ApplicationSystemTestCase
 
   test 'show product bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_text 'ブックマーク一覧'
+    assert_text 'ダッシュボード'
     assert_text @product.title
   end
 

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -10,7 +10,7 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'show my bookmark lists' do
     visit_with_auth '/current_user/bookmarks', 'komagata'
-    assert_text 'ブックマーク一覧'
+    assert_text 'ダッシュボード'
     assert_text @report.title
   end
 
@@ -53,7 +53,7 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'show question bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_text 'ブックマーク一覧'
+    assert_text 'ダッシュボード'
     assert_text @question.title
   end
 

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -10,7 +10,7 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'show my bookmark lists' do
     visit_with_auth '/current_user/bookmarks', 'komagata'
-    assert_text 'ダッシュボード'
+    assert_equal 'ブックマーク一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
     assert_text @report.title
   end
 
@@ -53,7 +53,7 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'show question bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_text 'ダッシュボード'
+    assert_equal 'ブックマーク一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
     assert_text @question.title
   end
 

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -53,7 +53,6 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'show question bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'kimura'
-    assert_equal 'ブックマーク一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
     assert_text @question.title
   end
 


### PR DESCRIPTION
# Issue: #3750 
## バグ内容
ダッシュボードから[ブックマーク]タブを選択した際にタブの外のタイトルまで「ブックマーク一覧」に変化していた

![image](https://user-images.githubusercontent.com/39044468/149140324-01c4ad4c-a96b-4d59-b836-7aba385f7722.png)

## 修正内容
- [ブックマーク]タブで表示されるslimで該当箇所を「ダッシュボード」に変更
- 上記変更により該当するページ内では「ブックマーク一覧」が表示されなくなるため、テストの該当箇所も同様に変更

![image](https://user-images.githubusercontent.com/39044468/149140701-73a11642-a566-4f40-9578-ed99005b8bd7.png)
