### PR TITLE
通知ページのWatch中タブに未読数を表示したい 

### DIFF
--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -7,6 +7,10 @@
           - if current_user.notifications.unreads.count.positive?
             .page-tabs__item-count.a-notification-count
               = current_user.notifications.unreads.count
+          
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip
+          - if current_user.notifications.unreads.count.positive?
+            .page-tabs__item-count.a-notification-count
+              = current_user.notifications.unreads.count


### PR DESCRIPTION
# 聞きたいこと・相談事

- #3907 

こちらのissueに関して、実装方法がわからず困っています。
通知ページの「全て」に関しては実装できそうだが、別のタブに未読数を表示する方法が分かりませんでした。

# ソースコード

![](https://i.imgur.com/FgFjcQz.png)

まず、通知ページに該当するviewでは以下のようになっています
https://github.com/fjordllc/bootcamp/blob/d44cfa67b5f0990bf53dec0cf903756962ba561e/app/views/notifications/_tabs.html.slim#L10

```ruby
- Notification::TARGETS_TO_KINDS.each_key do |target|
    li.page-tabs__item
      = link_to t("notification.#{target}"), notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip
```

watch中に関してはeach文の中で表示されている、ということが分かりました。

また、`app/models/notification.rb`の以下の部分を使えば、未読数も取れるのかな?と思っております。
https://github.com/fjordllc/bootcamp/blob/d44cfa67b5f0990bf53dec0cf903756962ba561e/app/models/notification.rb#L49

```ruby
  scope :by_target, lambda { |target|
    target ? where(kind: TARGETS_TO_KINDS[target]) : all
  }
```

# 自分で試したこと

今回の変更のように実装して未読数を表示する、というのは試してみました。
今回の変更によるスクリーンショット

![](https://i.imgur.com/HB3VLH4.png)

# 聞きたいこと

- viewのeach文の中で、特定のタブ(要素)だけに未読数を表示する方法がわからないので聞きたい
    - 「全て」以外のタブに未読数を表示する、とかはできそう
- issueとして難しそうなので可能であれば別の1ポイントissueをいただけると嬉しい
    - machidaさんkomagataさんの判断で、「そこまで難しくないのでは?」ということであれば実装のヒントをもらった上で実装したいと考えています。


と思っております。分かりづらい部分があればコメントくださいませ。
よろしくお願いいたします。