### PR TITLE
検索結果がコメントだった際に元の投稿者と投稿日時を併せて表示する

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-list-item-meta.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item-meta.sass
@@ -8,18 +8,19 @@
   margin-bottom: -.25rem
   +media-breakpoint-up(md)
     display: flex
-    +margin(horizontal, -.375rem)
+    +margin(horizontal, -.25rem)
 
 .thread-list-item-meta__item
   margin-bottom: .25rem
   +media-breakpoint-up(md)
-    +padding(horizontal, .375rem)
+    +padding(horizontal, .25rem)
   .a-user-icon
     +size(1rem)
   .a-meta .a-user-icon
     +margin(horizontal, .5em)
   .thread-list-item-comment__user-icons .a-user-icon
     +margin(horizontal, .125em)
+
 .thread-list-item-meta__item-link
   +hover-link-reversal
   color: $main-text

--- a/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-list-item.sass
@@ -113,6 +113,37 @@
     background-color: #7cbd9c
     color: $reversal-text
 
+.thread-list-item__label-option
+  +position(absolute)
+  +media-breakpoint-up(md)
+    +position(left -.125rem, right -.125rem, bottom -.375rem)
+  +media-breakpoint-down(sm)
+    +position(left -.5rem, right -.5rem, bottom -.375rem)
+    transform: scale(.8)
+  background-color: $base
+  +text-block(.625rem 1.4, flex center)
+  align-items: center
+  justify-content: center
+  border: solid 1px
+  border-radius: 1rem
+  .thread-list-item.is-report &
+    color: #7f6fb7
+  .thread-list-item.is-practice &
+    color: #79bcc3
+  .thread-list-item.is-question &
+    color: #de9172
+  .thread-list-item.is-page &
+    color: #9fc593
+  .thread-list-item.is-announcement &
+    color: #a9831c
+    border-color: #f7cd5b
+  .thread-list-item.is-event &
+    color: #ef9da8
+  .thread-list-item.is-product &
+    color: #909b3c
+  .thread-list-item.is-user &
+    color: #7cbd9c
+
 .thread-list-item__user
   +position(absolute, left 0, top 0)
   .has-no-author-image &

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -35,4 +35,8 @@ module SearchHelper
       searchable.description
     end
   end
+
+  def comment_or_answer?(searchable)
+    searchable.is_a?(Comment) || searchable.is_a?(Answer)
+  end
 end

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -32,8 +32,9 @@
             )
               .a-meta
                 | （
-                a.a-user-name(:href='documentAuthorUserUrl')
-                  | {{ searchable.document_author_login_name }} {{ searchable.model_name_with_i18n }}
+                a.a-user-name(:href='contributorUserUrl')
+                  | {{ searchable.document_author_login_name }}
+                | &nbsp;{{ searchable.model_name_with_i18n }}
                 | ）
 </template>
 <script>

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -2,7 +2,7 @@
 .thread-list-item(:class='modelName')
   .thread-list-item__inner
     .thread-list-item__label(
-      v-if='["comment", "answer"].includes(searchable.model_name_original)'
+      v-if='["comment", "answer", "correct_answer"].includes(searchable.model_name_original)'
     )
       | {{ searchable.model_name_with_i18n }}
       .thread-list-item__label-option
@@ -30,12 +30,13 @@
               time.a-meta(:datetime='searchable.updated_at', pubdate='pubdate')
                 | {{ updatedAt }}
             .thread-list-item-meta__item(
-              v-if='["comment", "answer"].includes(searchable.model_name_original)'
+              v-if='["comment", "answer", "correct_answer"].includes(searchable.model_name_original)'
             )
               .a-meta
                 | （
-                a.a-user-name(:href='contributorUserUrl')
-                  | {{ searchable.contributor_login_name }} {{ searchable.model_name_with_i18n }}
+                a.a-user-name(:href='documentAuthorUserUrl')
+                  | {{ searchable.document_author_login_name }}
+                | {{ searchable.model_name_with_i18n }}
                 | ）
 </template>
 <script>
@@ -57,8 +58,8 @@ export default {
     userUrl() {
       return `/users/${this.searchable.user_id}`
     },
-    contributorUserUrl() {
-      return `/users/${this.searchable.contributor_user_id}`
+    documentAuthorUserUrl() {
+      return `/users/${this.searchable.document_author_user_id}`
     },
     updatedAt() {
       return dayjs(this.searchable.updated_at).format(

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -4,7 +4,9 @@
     .thread-list-item__label(
       v-if='["comment", "answer"].includes(searchable.model_name_original)'
     )
-      | {{ searchable.model_name_with_i18n }}コメント
+      | {{ searchable.model_name_with_i18n }}
+      .thread-list-item__label-option
+        | コメント
     .thread-list-item__label(v-else)
       | {{ searchable.model_name_with_i18n }}
     .thread-list-item__rows
@@ -16,20 +18,6 @@
       .thread-list-item__row
         .thread-list-item__summary
           p(v-html='summary')
-      .thread-list-item__row(
-        v-if='["comment", "answer"].includes(searchable.model_name_original)'
-      )
-        .thread-list-item-meta
-          .thread-list-item-meta__items
-            .thread-list-item-meta__item
-              a.a-user-name(:href='contributorUserUrl')
-                | [↓がコメントだった場合の元の投稿]{{ searchable.contributor_login_name }}
-            .thread-list-item-meta__item
-              time.a-meta(
-                :datetime='searchable.created_at_original',
-                pubdate='pubdate'
-              )
-                | {{ createdAtOriginal }}
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items
@@ -37,10 +25,18 @@
               v-if='!["practice", "page", "user"].includes(searchable.model_name)'
             )
               a.a-user-name(:href='userUrl')
-                | [検索結果]{{ searchable.login_name }}
+                | {{ searchable.login_name }}
             .thread-list-item-meta__item
               time.a-meta(:datetime='searchable.updated_at', pubdate='pubdate')
                 | {{ updatedAt }}
+            .thread-list-item-meta__item(
+              v-if='["comment", "answer"].includes(searchable.model_name_original)'
+            )
+              .a-meta
+                | （
+                a.a-user-name(:href='contributorUserUrl')
+                  | {{ searchable.contributor_login_name }} {{ searchable.model_name_with_i18n }}
+                | ）
 </template>
 <script>
 import dayjs from 'dayjs'

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -1,7 +1,11 @@
 <template lang="pug">
 .thread-list-item(:class='modelName')
   .thread-list-item__inner
-    .thread-list-item__label
+    .thread-list-item__label(
+      v-if='["comment", "answer"].includes(searchable.model_name_original)'
+    )
+      | {{ searchable.model_name_with_i18n }}コメント
+    .thread-list-item__label(v-else)
       | {{ searchable.model_name_with_i18n }}
     .thread-list-item__rows
       .thread-list-item__row
@@ -12,6 +16,20 @@
       .thread-list-item__row
         .thread-list-item__summary
           p(v-html='summary')
+      .thread-list-item__row(
+        v-if='["comment", "answer"].includes(searchable.model_name_original)'
+      )
+        .thread-list-item-meta
+          .thread-list-item-meta__items
+            .thread-list-item-meta__item
+              a.a-user-name(:href='contributorUserUrl')
+                | [↓がコメントだった場合の元の投稿]{{ searchable.contributor_login_name }}
+            .thread-list-item-meta__item
+              time.a-meta(
+                :datetime='searchable.created_at_original',
+                pubdate='pubdate'
+              )
+                | {{ createdAtOriginal }}
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items
@@ -19,7 +37,7 @@
               v-if='!["practice", "page", "user"].includes(searchable.model_name)'
             )
               a.a-user-name(:href='userUrl')
-                | {{ searchable.login_name }}
+                | [検索結果]{{ searchable.login_name }}
             .thread-list-item-meta__item
               time.a-meta(:datetime='searchable.updated_at', pubdate='pubdate')
                 | {{ updatedAt }}
@@ -37,11 +55,22 @@ export default {
     modelName() {
       return `is-${this.searchable.model_name}`
     },
+    modelNameOriginal() {
+      return `is-${this.searchable.model_name_original}`
+    },
     userUrl() {
       return `/users/${this.searchable.user_id}`
     },
+    contributorUserUrl() {
+      return `/users/${this.searchable.contributor_user_id}`
+    },
     updatedAt() {
       return dayjs(this.searchable.updated_at).format(
+        'YYYY年MM月DD日(dd) HH:mm'
+      )
+    },
+    createdAtOriginal() {
+      return dayjs(this.searchable.created_at_original).format(
         'YYYY年MM月DD日(dd) HH:mm'
       )
     },

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -1,9 +1,7 @@
 <template lang="pug">
 .thread-list-item(:class='modelName')
   .thread-list-item__inner
-    .thread-list-item__label(
-      v-if='["comment", "answer", "correct_answer"].includes(searchable.model_name_original)'
-    )
+    .thread-list-item__label(v-if='searchable.is_comment_or_answer')
       | {{ searchable.model_name_with_i18n }}
       .thread-list-item__label-option
         | コメント
@@ -30,13 +28,12 @@
               time.a-meta(:datetime='searchable.updated_at', pubdate='pubdate')
                 | {{ updatedAt }}
             .thread-list-item-meta__item(
-              v-if='["comment", "answer", "correct_answer"].includes(searchable.model_name_original)'
+              v-if='searchable.is_comment_or_answer'
             )
               .a-meta
                 | （
                 a.a-user-name(:href='documentAuthorUserUrl')
-                  | {{ searchable.document_author_login_name }}
-                | {{ searchable.model_name_with_i18n }}
+                  | {{ searchable.document_author_login_name }} {{ searchable.model_name_with_i18n }}
                 | ）
 </template>
 <script>
@@ -51,9 +48,6 @@ export default {
   computed: {
     modelName() {
       return `is-${this.searchable.model_name}`
-    },
-    modelNameOriginal() {
-      return `is-${this.searchable.model_name_original}`
     },
     userUrl() {
       return `/users/${this.searchable.user_id}`

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -65,11 +65,6 @@ export default {
         'YYYY年MM月DD日(dd) HH:mm'
       )
     },
-    createdAtOriginal() {
-      return dayjs(this.searchable.created_at_original).format(
-        'YYYY年MM月DD日(dd) HH:mm'
-      )
-    },
     summary() {
       const word = this.word
       const wordsPattern = word

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -32,7 +32,7 @@
             )
               .a-meta
                 | （
-                a.a-user-name(:href='contributorUserUrl')
+                a.a-user-name(:href='documentAuthorUserUrl')
                   | {{ searchable.document_author_login_name }}
                 | &nbsp;{{ searchable.model_name_with_i18n }}
                 | ）
@@ -54,7 +54,7 @@ export default {
       return `/users/${this.searchable.user_id}`
     },
     documentAuthorUserUrl() {
-      return `/users/${this.searchable.document_author_user_id}`
+      return `/users/${this.searchable.document_author_id}`
     },
     updatedAt() {
       return dayjs(this.searchable.updated_at).format(

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -1,10 +1,14 @@
 json.title matched_document(searchable).title
 json.url searchable_url(searchable)
 json.model_name matched_document(searchable).class.to_s.tableize.singularize
+json.model_name_original searchable.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{matched_document(searchable).class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
+json.created_at_original matched_document(searchable).created_at
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id
+  json.contributor_login_name matched_document(searchable).user.login_name
+  json.contributor_user_id matched_document(searchable).user.id
 end

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -1,15 +1,16 @@
-json.title matched_document(searchable).title
+document = matched_document(searchable)
+json.title document.title
 json.url searchable_url(searchable)
-json.model_name matched_document(searchable).class.to_s.tableize.singularize
-p 's126' + '=' * 30
-pp json.model_name_original searchable.class.to_s.tableize.singularize
-p 'e' + '=' * 30
-json.model_name_with_i18n t("activerecord.models.#{matched_document(searchable).class.to_s.tableize.singularize}")
+json.model_name document.class.to_s.tableize.singularize
+json.is_comment_or_answer comment_or_answer?(searchable)
+json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id
-  json.document_author_login_name matched_document(searchable).user.login_name
-  json.document_author_user_id matched_document(searchable).user.id
+end
+if comment_or_answer?(searchable)
+  json.document_author_login_name document.user.login_name
+  json.document_author_id document.user.id
 end

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -1,13 +1,15 @@
 json.title matched_document(searchable).title
 json.url searchable_url(searchable)
 json.model_name matched_document(searchable).class.to_s.tableize.singularize
-json.model_name_original searchable.class.to_s.tableize.singularize
+p 's126' + '=' * 30
+pp json.model_name_original searchable.class.to_s.tableize.singularize
+p 'e' + '=' * 30
 json.model_name_with_i18n t("activerecord.models.#{matched_document(searchable).class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id
-  json.contributor_login_name matched_document(searchable).user.login_name
-  json.contributor_user_id matched_document(searchable).user.id
+  json.document_author_login_name matched_document(searchable).user.login_name
+  json.document_author_user_id matched_document(searchable).user.id
 end

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -5,7 +5,6 @@ json.model_name_original searchable.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{matched_document(searchable).class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
-json.created_at_original matched_document(searchable).created_at
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -2,7 +2,6 @@ document = matched_document(searchable)
 json.title document.title
 json.url searchable_url(searchable)
 json.model_name document.class.to_s.tableize.singularize
-json.is_comment_or_answer comment_or_answer?(searchable)
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
@@ -10,6 +9,7 @@ if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id
 end
+json.is_comment_or_answer comment_or_answer?(searchable)
 if comment_or_answer?(searchable)
   json.document_author_login_name document.user.login_name
   json.document_author_id document.user.id

--- a/db/fixtures/answers.yml
+++ b/db/fixtures/answers.yml
@@ -22,3 +22,8 @@ answer5:
   description: テストの回答5です。
   user: komagata
   question: question6
+
+answer6:
+  description: Q&Aのコメントです。(ベストアンサーではない)
+  user: machida
+  question: question6

--- a/db/fixtures/comments.yml
+++ b/db/fixtures/comments.yml
@@ -101,3 +101,13 @@ comment<%= i + 16 %>:
   created_at: <%= Time.current + i.minutes %>
   updated_at: <%= Time.current + i.minutes %>
 <% end %>
+
+comment37:
+  user: machida
+  commentable: page10 (Page)
+  description: "Docsのコメントです。"
+
+comment38:
+  user: machida
+  commentable: event1 (Event)
+  description: "イベントのコメントです。"

--- a/db/fixtures/comments.yml
+++ b/db/fixtures/comments.yml
@@ -53,7 +53,7 @@ comment7:
 comment8:
   user: komagata
   commentable: product10 (Product)
-  description: "提出物のコメントです。"
+  description: "提出物のコメント0です。"
 
 comment9:
   user: komagata
@@ -104,10 +104,25 @@ comment<%= i + 16 %>:
 
 comment37:
   user: machida
-  commentable: page10 (Page)
-  description: "Docsのコメントです。"
+  commentable: report1 (Report)
+  description: "日報のコメントです。"
 
 comment38:
   user: machida
+  commentable: product1 (Product)
+  description: "提出物のコメントです。"
+
+comment39:
+  user: machida
+  commentable: page1 (Page)
+  description: "Docsのコメントです。"
+
+comment40:
+  user: machida
   commentable: event1 (Event)
   description: "イベントのコメントです。"
+
+comment41:
+  user: machida
+  commentable: announcement1 (Announcement)
+  description: "お知らせのコメントです。"

--- a/db/fixtures/correct_answers.yml
+++ b/db/fixtures/correct_answers.yml
@@ -9,3 +9,9 @@ correct_answer2:
   user: advijirou
   question: question12
   type: "CorrectAnswer"
+
+correct_answer3:
+  description: Q&Aのコメントです。(ベストアンサー)
+  user: machida
+  question: question1
+  type: "CorrectAnswer"

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -123,4 +123,16 @@ class SearchablesTest < ApplicationSystemTestCase
     find('#test-search').click
     assert_selector 'strong.matched_word', text: '検索ワードが太字で表示されるかのテスト'
   end
+
+  test 'returns document author name when comment' do
+    visit_with_auth '/', 'hatsuno'
+    within('form[name=search]') do
+      select 'すべて'
+      fill_in 'word', with: '提出物のコメントです。'
+    end
+    find('#test-search').click
+    assert_text 'komagata'
+    assert_text 'kimura'
+    assert_no_text 'machida'
+  end
 end


### PR DESCRIPTION
## Issue
- #1507
 
## 概要
現在は検索結果の一覧の表示で「日報・提出物・Q&A・Docs・お知らせ・イベント」へのコメントが検索に引っかかると「コメントの発言者と発言日時」が表示されています。この際にコメント発言者がその「日報・提出物・Q&A・Docs・お知らせ・イベント」を投稿したように見えてしまうという不満がありました。
このため、「日報・提出物・Q&A・Docs・お知らせ・イベント」のコメントが検索された場合には、元となる「日報・提出物・Q&A・Docs・お知らせ・イベント」の投稿者と投稿種類を表示する変更作業を行いました。

## コード修正のポイント
検索結果の文書タイプがCommentとAnswerの場合には、元となる投稿に遡って投稿タイトルを取得する仕様となっていたため、この際に投稿者名を取得し、表示に活用しました。

## 変更確認方法
1. ブランチ `feature/add-contributor-name-and-time-to-search-results`をローカルに取り込む
1. `$ rails db:seed` で変更確認用のデータが作成されます。
2. `$ rails s` でローカル環境を立ち上げる
3. テスト用ユーザー(誰でもOK)でログインする
4. 検索キーワード欄に「のコメントです。」と入力して検索対象を「すべて」にして検索を行ってください。
5. 「日報・提出物・Q&A(ベストアンサー)・Q&A(ベストアンサー以外)・Docs・お知らせ・イベント」の検索結果が表示されますので、今回の変更点をご確認ください。 
6. その他任意のキーワードで検索を行っていただき、コメントではなく本投稿が検索に引っかかった場合は、以前と同じ表示になっていることをご確認いただけますと幸いです。

## 各種コメントが検索に引っかかった場合の変更【前】のスクショ
![スクリーンショット 2022-01-21 1 01 37](https://user-images.githubusercontent.com/82434093/150377923-aa73c646-7450-433a-9a70-83d85c926157.png)

## 各種コメントが検索に引っかかった場合の変更【後】のスクショ
【ご連絡】町田さんのデザイン適用により、Issueでの希望表示形式とは表示データと表示位置が異なっています。
![SCR-20220121-q7](https://user-images.githubusercontent.com/82434093/150378047-74d43ac5-0cf0-4dd5-89fa-b3d58ab117a1.png)

