### PR TITLE
通知一覧のローディングをプレースホルダに変更しました

### DIFF
--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .container.is-md(v-if='!loaded')
-  | ロード中
+  loadingListPlaceholder
 .container(v-else-if='notifications.length === 0')
   .o-empty-message
     .o-empty-message__icon
@@ -28,12 +28,14 @@
 
 <script>
 import Notification from './notification.vue'
+import LoadingListPlaceholder from './loading-list-placeholder.vue'
 import Pager from './pager.vue'
 import UnconfirmedLinksOpenButton from './unconfirmed_links_open_button'
 
 export default {
   components: {
     notification: Notification,
+    loadingListPlaceholder: LoadingListPlaceholder,
     pager: Pager,
     'unconfirmed-links-open-button': UnconfirmedLinksOpenButton
   },


### PR DESCRIPTION
## Issue
- #2814 

## 変更前
- 通知一覧のローディングが「ロード中」になっている
![demo](https://gyazo.com/a202be603695abe5dfb5513ef208aa74/raw)

## 変更後
- 通知一覧のローディングをプレースホルダに変更した
![demo](https://gyazo.com/7a721a398e629ec908a2f3da9ce8f985/raw)
