### PR TITLE
ダッシュボードの日報タブに日報の合計数を表示させるようにした

### DIFF
--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -7,7 +7,7 @@
       - if !user.staff? || user.reports.present?
         li.page-tabs__item
           = link_to current_user_reports_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
-            | 自分の日報
+            | 自分の日報 （#{user.reports.length}）
       - if !user.staff? || user.products.present?
         li.page-tabs__item
           = link_to current_user_products_path, class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do


### PR DESCRIPTION
## issue
- issue #3838 

## 概要
ダッシュボードの日報タブに自分の日報の合計数を表示させる。

## 変更前
ダッシュボードの日報タブに自分の日報の合計数が表示されていない。

![image](https://user-images.githubusercontent.com/66904873/149280357-e66f07d1-2ad3-4a76-80d7-5bce801da63a.png)

## 変更後
ダッシュボードの日報タブに自分の日報の合計数が表示されている。

![image](https://user-images.githubusercontent.com/66904873/149280601-5bad2481-6222-4fa0-bd27-1652c24f7f02.png)

