### PR TITLE
ポートフォリオ登録時に500エラーが返される

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -14,7 +14,7 @@ class Work < ApplicationRecord
             size: { less_than: 10.megabytes }
 
   def thumbnail_url
-    if thumbnail.attached?
+    if thumbnail.attached? && title && description && url_or_repository
       thumbnail.variant(resize: THUMBNAIL_SIZE).processed.url
     else
       image_url('/images/works/thumbnails/default.png')

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -14,7 +14,7 @@ class Work < ApplicationRecord
             size: { less_than: 10.megabytes }
 
   def thumbnail_url
-    if thumbnail.attached? && title && description && url_or_repository
+    if thumbnail.attached?
       thumbnail.variant(resize: THUMBNAIL_SIZE).processed.url
     else
       image_url('/images/works/thumbnails/default.png')

--- a/app/views/works/_form.html.slim
+++ b/app/views/works/_form.html.slim
@@ -22,7 +22,7 @@
         .form-item-file-input.js-file-input.a-file-input.is-work-thumbnail
           label.js-file-input__preview
             - if work.thumbnail.attached?
-              = image_tag work.thumbnail_url
+              = image_tag work.thumbnail
               p 画像を変更
             - else
               p 画像を選択

--- a/test/system/works_test.rb
+++ b/test/system/works_test.rb
@@ -28,6 +28,17 @@ class WorksTest < ApplicationSystemTestCase
     assert_text 'ポートフォリオに作品を追加しました'
   end
 
+  test 'vailidaiton error when create a work with thumbnail ' do
+    visit_with_auth new_work_path, 'kimura'
+    image_path = Rails.root.join('test/fixtures/files/companies/logos/1.jpg')
+    attach_file('work[thumbnail]', image_path, make_visible: true)
+    click_button '登録する'
+    assert_text '入力内容にエラーがありました'
+    assert_text 'タイトルを入力してください'
+    assert_text '説明を入力してください'
+    assert_text 'URLまたはリポジトリを入力してください'
+  end
+
   test 'update my work' do
     visit_with_auth work_path(works(:work1)), 'kimura'
     click_link '内容修正'


### PR DESCRIPTION
#3889 
ポートフォリオ登録ページにて

サムネイル画像を添付する
必須項目が1つ以上欠けている
状態で登録を行うと、バリデーションエラーにならず、500エラーページが表示されるため、バリデーションメッセージが表示されるよう変更しました。

## 変更前
<a href="https://gyazo.com/7787681e2dc35d5e6d33c3dc449c53c3"><img src="https://i.gyazo.com/7787681e2dc35d5e6d33c3dc449c53c3.gif" alt="Image from Gyazo" width="1000"/></a>

## 変更後
<a href="https://gyazo.com/7de9510f833785b5e9a40b0f4701d756"><img src="https://i.gyazo.com/7de9510f833785b5e9a40b0f4701d756.gif" alt="Image from Gyazo" width="1000"/></a>