### PR TITLE
提出物のupdateで@practiceを定義

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -45,6 +45,7 @@ class ProductsController < ApplicationController
 
   def update
     @product = find_my_product
+    @practice = @product.practice
     set_wip
     if @product.update(product_params)
       redirect_to @product, notice: notice_message(@product, :update)

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -158,7 +158,7 @@ class ProductsTest < ApplicationSystemTestCase
     product = products(:product1)
     visit_with_auth "/products/#{product.id}/edit", 'yamada'
     within('form[name=product]') do
-      fill_in('product[body]', with: 'test')
+      fill_in('product[body]', with: '')
     end
     click_button 'WIP'
     assert_text '本文を入力してください'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -154,6 +154,16 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '提出物をWIPとして保存しました。'
   end
 
+  test 'update product as WIP with blank body to fail update and successfully get back to editor' do
+    product = products(:product1)
+    visit_with_auth "/products/#{product.id}/edit", 'yamada'
+    within('form[name=product]') do
+      fill_in('product[body]', with: 'test')
+    end
+    click_button 'WIP'
+    assert_text '本文を入力してください'
+  end
+
   test "Don't notify if create product as WIP" do
     visit_with_auth '/notifications', 'komagata'
     click_link '全て既読にする'


### PR DESCRIPTION
# Issue: #3939 
## バグ内容
products_controller.rbのupdateで@practiceが定義されておらず、updateに失敗してeditに戻る際にエラーが出ていた。
![image](https://user-images.githubusercontent.com/39044468/149440984-82c5be69-27f5-4ff6-99ae-3d5e5ab0178a.png)

![image](https://user-images.githubusercontent.com/39044468/149440847-fa27c6b5-8102-4e64-8062-f9d397088168.png)

## 修正内容
products_controller.rbのupdateで@practiceを定義した。
本文空欄でupdateしたらeditorに戻ってエラーが表示されることを確認するテストを作成した。


## 修正後
updateに失敗しても正常にeditに戻れるようになった。
![image](https://user-images.githubusercontent.com/39044468/149440380-d096b448-460a-417a-a52a-bbda685690d8.png)
