### PR TITLE
イベントのコピーが行われるよう修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,16 @@ class EventsController < ApplicationController
 
   def new
     @event = Event.new(open_start_at: Time.current.beginning_of_minute)
+
+    return unless params[:id]
+
+    event              = Event.find(params[:id])
+    @event.title       = event.title
+    @event.location    = event.location
+    @event.capacity    = event.capacity
+    @event.open_start_at = Time.current.beginning_of_minute
+    @event.description = event.description
+    flash.now[:notice] = 'イベントをコピーしました。'
   end
 
   def create

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -16,13 +16,7 @@ class EventsController < ApplicationController
 
     return unless params[:id]
 
-    event              = Event.find(params[:id])
-    @event.title       = event.title
-    @event.location    = event.location
-    @event.capacity    = event.capacity
-    @event.open_start_at = Time.current.beginning_of_minute
-    @event.description = event.description
-    flash.now[:notice] = 'イベントをコピーしました。'
+    copy_event(@event)
   end
 
   def create
@@ -92,5 +86,17 @@ class EventsController < ApplicationController
     when 'update'
       event.wip? ? 'イベントをWIPとして保存しました。' : 'イベントを更新しました。'
     end
+  end
+
+  def copy_event(new_event)
+    event = Event.find(params[:id])
+    new_event.title       = event.title
+    new_event.location    = event.location
+    new_event.capacity    = event.capacity
+    new_event.open_start_at = Time.current.beginning_of_minute
+    new_event.description = event.description
+    new_event.job_hunting = event.job_hunting
+
+    flash.now[:notice] = 'イベントをコピーしました。'
   end
 end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -51,6 +51,24 @@ class EventsTest < ApplicationSystemTestCase
     assert_text 'イベントを作成しました。'
   end
 
+  test 'create copy event' do
+    event = events(:event1)
+    visit_with_auth event_path(event), 'komagata'
+    click_link 'コピー'
+    assert_text 'イベントをコピーしました'
+    within 'form[name=event]' do
+      fill_in 'event[start_at]', with: Time.current.next_day
+      fill_in 'event[end_at]', with: Time.current.next_day + 2.hours
+      fill_in 'event[open_end_at]', with: Time.current + 2.hours
+      click_button '作成'
+    end
+    assert_text 'イベントを作成しました。'
+    assert_text event.title
+    assert_text event.location
+    assert_text event.capacity
+    assert_text event.description
+  end
+
   test 'update event' do
     visit_with_auth edit_event_path(events(:event1)), 'komagata'
     within 'form[name=event]' do


### PR DESCRIPTION
#3879 

すでに存在するイベントページにて、「コピー」ボタンを押してもイベントがコピーされないバグを修正しました

## 変更前
<a href="https://gyazo.com/75a7d11f252df81e214d055decd6dc4f"><img src="https://i.gyazo.com/75a7d11f252df81e214d055decd6dc4f.gif" alt="Image from Gyazo" width="1000"/></a>

## 変更後
<a href="https://gyazo.com/4f6e441bee58cf0efec5872ef1df0eac"><img src="https://i.gyazo.com/4f6e441bee58cf0efec5872ef1df0eac.gif" alt="Image from Gyazo" width="1000"/></a>