### PR TITLE
テストでタグの編集後に「保存する」ボタンを見つけらないエラーが起きないように修正

### DIFF
--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -52,7 +52,7 @@ class User::TagsTest < ApplicationSystemTestCase
     page.all('.tag-links__item-edit')[0].click
     tag_input = find('.ti-new-tag-input')
     tag_input.set 'タグタグ'
-    find('body').click
+    tag_input.native.send_keys :return
     click_button '保存する'
 
     visit_with_auth user_path(users(:hatsuno)), 'komagata'
@@ -77,7 +77,7 @@ class User::TagsTest < ApplicationSystemTestCase
     page.all('.tag-links__item-edit')[0].click
     tag_input = find('.ti-new-tag-input')
     tag_input.set '#ハッシュハッシュ'
-    find('body').click
+    tag_input.native.send_keys :return
     click_button '保存する'
 
     visit_with_auth user_path(users(:hatsuno)), 'komagata'


### PR DESCRIPTION
Ref: #3982

## やったこと

#3982 に記載の「テストの修正案」のとおり、タグの編集を完了する手段を「画面のクリック」から「エンターキーの押下」に変更し、テストが成功するように修正しました。

### 補足

タグを編集する他のテストにおいても、タグの編集を完了する手段としてエンターキーの押下が使われているようです（以下はその例）

https://github.com/fjordllc/bootcamp/blob/9af540bd122cba095a558e6bdca78152ab715751/test/system/page/tags_test.rb#L34-L43