### PR TITLE
プラクティス詳細画面の質問一覧画面で発生していたN+1を解消

### DIFF
--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -2,28 +2,18 @@
 
 class Practices::QuestionsController < ApplicationController
   before_action :require_login
-  before_action :set_practice
-  before_action :set_questions
 
-  def index; end
-
-  private
-
-  def set_practice
+  def index
     @practice = Practice.find(params[:practice_id])
-  end
-
-  def set_questions
-    questions = practice.questions.eager_load(:user, :answers)
-    @questions =
+    questions =
       if params[:solved].present?
-        questions.solved
+        @practice.questions.solved
       else
-        questions.not_solved
-      end.order(updated_at: :desc, id: :desc)
-  end
-
-  def practice
-    @practice ||= Practice.find(params[:practice_id])
+        @practice.questions.not_solved
+      end
+    @questions = questions
+                 .with_avatar
+                 .includes(:answers, :tags, :correct_answer, user: :company)
+                 .order(updated_at: :desc, id: :desc)
   end
 end


### PR DESCRIPTION
bulletのwarningで出ていたN+1を解消しました。
修正するにあたり、before_actionの呼び出し順に依存していて可読性が良くないと判断しアクションのメソッド内で処理をするようにしています。

- 空白を除いた差分
    - https://github.com/fjordllc/bootcamp/pull/3989/files?w=1