### PR TITLE
管理者が各ユーザーの日報をエクスポートできるように変更

### DIFF
--- a/app/controllers/current_user/reports_controller.rb
+++ b/app/controllers/current_user/reports_controller.rb
@@ -7,8 +7,7 @@ class CurrentUser::ReportsController < ApplicationController
   before_action :set_user
   before_action :set_reports
 
-  def index
-  end
+  def index; end
 
   private
 

--- a/app/controllers/current_user/reports_controller.rb
+++ b/app/controllers/current_user/reports_controller.rb
@@ -6,15 +6,8 @@ class CurrentUser::ReportsController < ApplicationController
   before_action :require_login
   before_action :set_user
   before_action :set_reports
-  before_action :set_export, only: %i[index]
 
   def index
-    respond_to do |format|
-      format.html
-      format.md do
-        send_reports_markdown(@reports_for_export)
-      end
-    end
   end
 
   private
@@ -29,16 +22,5 @@ class CurrentUser::ReportsController < ApplicationController
 
   def user
     @user ||= current_user
-  end
-
-  def set_export
-    @reports_for_export = user.reports.not_wip
-  end
-
-  def send_reports_markdown(reports)
-    Dir.mktmpdir do |folder_path|
-      ReportExporter.export(reports, folder_path)
-      send_data(File.read("#{folder_path}/reports.zip"), filename: '日報一覧.zip')
-    end
   end
 end

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -8,10 +8,10 @@ class Users::ReportsController < ApplicationController
 
   def index
     respond_to do |format|
-        format.html
-        format.md do
-          send_reports_markdown(@reports_for_export)
-        end
+      format.html
+      format.md do
+        send_reports_markdown(@reports_for_export)
+      end
     end
   end
 
@@ -39,5 +39,4 @@ class Users::ReportsController < ApplicationController
       send_data(File.read("#{folder_path}/reports.zip"), filename: '日報一覧.zip')
     end
   end
-
 end

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -21,6 +21,7 @@ class Users::ReportsController < ApplicationController
 
   def allow_download_reports_only_admin
     return if current_user.admin? || @report.user_id == current_user.id
+
     redirect_to root_path, alert: '自分以外の日報はダウンロードすることができません'
   end
 

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -4,8 +4,16 @@ class Users::ReportsController < ApplicationController
   before_action :require_login
   before_action :set_user
   before_action :set_reports
+  before_action :set_export
 
-  def index; end
+  def index
+    respond_to do |format|
+        format.html
+        format.md do
+          send_reports_markdown(@reports_for_export)
+        end
+    end
+  end
 
   private
 
@@ -20,4 +28,16 @@ class Users::ReportsController < ApplicationController
   def user
     @user ||= User.find(params[:user_id])
   end
+
+  def set_export
+    @reports_for_export = @user.reports.not_wip
+  end
+
+  def send_reports_markdown(reports)
+    Dir.mktmpdir do |folder_path|
+      ReportExporter.export(reports, folder_path)
+      send_data(File.read("#{folder_path}/reports.zip"), filename: '日報一覧.zip')
+    end
+  end
+
 end

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -26,7 +26,7 @@ class Users::ReportsController < ApplicationController
   end
 
   def set_user
-    @user = current_user.admin? ? @user : current_user
+    @user = User.find(params[:user_id])
   end
 
   def set_reports

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -18,7 +18,7 @@ class Users::ReportsController < ApplicationController
   private
 
   def set_user
-    @user = User.find(params[:user_id])
+    @user = current_user.admin? ? @user : current_user
   end
 
   def set_reports

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -12,7 +12,7 @@ class Users::ReportsController < ApplicationController
       format.html
       format.md do
         if allow_download_reports_only_admin
-        send_reports_markdown(@reports_for_export)
+          send_reports_markdown(@reports_for_export)
         else
           redirect_to root_path, alert: '自分以外の日報はダウンロードすることができません'
         end

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -6,7 +6,6 @@ class Users::ReportsController < ApplicationController
   before_action :set_reports
   before_action :set_report
   before_action :set_export
-  before_action :allow_download_reports_only_admin
 
   def index
     respond_to do |format|

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -4,7 +4,9 @@ class Users::ReportsController < ApplicationController
   before_action :require_login
   before_action :set_user
   before_action :set_reports
+  before_action :set_report
   before_action :set_export
+  before_action :allow_download_reports_only_admin
 
   def index
     respond_to do |format|

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -25,6 +25,10 @@ class Users::ReportsController < ApplicationController
     @reports = user.reports.list.page(params[:page])
   end
 
+  def set_report
+    @report = @reports[0]
+  end
+
   def user
     @user ||= User.find(params[:user_id])
   end

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -17,6 +17,11 @@ class Users::ReportsController < ApplicationController
 
   private
 
+  def allow_download_reports_only_admin
+    return if current_user.admin? || @report.user_id == current_user.id
+    redirect_to root_path, alert: '自分以外の日報はダウンロードすることができません'
+  end
+
   def set_user
     @user = current_user.admin? ? @user : current_user
   end

--- a/app/controllers/users/reports_controller.rb
+++ b/app/controllers/users/reports_controller.rb
@@ -12,7 +12,11 @@ class Users::ReportsController < ApplicationController
     respond_to do |format|
       format.html
       format.md do
+        if allow_download_reports_only_admin
         send_reports_markdown(@reports_for_export)
+        else
+          redirect_to root_path, alert: '自分以外の日報はダウンロードすることができません'
+        end
       end
     end
   end
@@ -20,9 +24,7 @@ class Users::ReportsController < ApplicationController
   private
 
   def allow_download_reports_only_admin
-    return if current_user.admin? || @report.user_id == current_user.id
-
-    redirect_to root_path, alert: '自分以外の日報はダウンロードすることができません'
+    current_user.admin? || @report.user_id == current_user.id
   end
 
   def set_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -152,5 +152,4 @@ class UsersController < ApplicationController
 
     redirect_to root_path, notice: 'アドバイザー・メンター・研修生登録にはTOKENが必要です。'
   end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,8 +4,7 @@ class UsersController < ApplicationController
   before_action :require_login, except: %i[new create]
   before_action :require_token, only: %i[new] if Rails.env.production?
   before_action :set_user, only: %w[show]
-  before_action :set_reports, only: %i[show]
-  before_action :set_export, only: %i[show]
+
   PAGER_NUMBER = 20
 
   def index
@@ -39,12 +38,6 @@ class UsersController < ApplicationController
                            .includes(:practice)
                            .where(status: 3)
                            .order(updated_at: :desc)
-    respond_to do |format|
-      format.html
-      format.md do
-        send_reports_markdown(@reports_for_export)
-      end
-    end
   end
 
   def new
@@ -160,18 +153,4 @@ class UsersController < ApplicationController
     redirect_to root_path, notice: 'アドバイザー・メンター・研修生登録にはTOKENが必要です。'
   end
 
-  def set_reports
-    @reports = @user.reports.list.page(params[:page])
-  end
-
-  def set_export
-    @reports_for_export = @user.reports.not_wip
-  end
-
-  def send_reports_markdown(reports)
-    Dir.mktmpdir do |folder_path|
-      ReportExporter.export(reports, folder_path)
-      send_data(File.read("#{folder_path}/reports.zip"), filename: '日報一覧.zip')
-    end
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,8 @@ class UsersController < ApplicationController
   before_action :require_login, except: %i[new create]
   before_action :require_token, only: %i[new] if Rails.env.production?
   before_action :set_user, only: %w[show]
+  before_action :set_reports, only: %i[show]
+  before_action :set_export, only: %i[show]
   PAGER_NUMBER = 20
 
   def index
@@ -37,6 +39,12 @@ class UsersController < ApplicationController
                            .includes(:practice)
                            .where(status: 3)
                            .order(updated_at: :desc)
+    respond_to do |format|
+      format.html
+      format.md do
+        send_reports_markdown(@reports_for_export)
+      end
+    end
   end
 
   def new
@@ -150,5 +158,20 @@ class UsersController < ApplicationController
     return unless !params[:token] || !ENV['TOKEN'] || params[:token] != ENV['TOKEN']
 
     redirect_to root_path, notice: 'アドバイザー・メンター・研修生登録にはTOKENが必要です。'
+  end
+
+  def set_reports
+    @reports = @user.reports.list.page(params[:page])
+  end
+
+  def set_export
+    @reports_for_export = @user.reports.not_wip
+  end
+
+  def send_reports_markdown(reports)
+    Dir.mktmpdir do |folder_path|
+      ReportExporter.export(reports, folder_path)
+      send_data(File.read("#{folder_path}/reports.zip"), filename: '日報一覧.zip')
+    end
   end
 end

--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -21,6 +21,6 @@ header.page-header
       .form-actions
         ul.form-actions__items
           li.form-actions__item.is-main
-            = link_to current_user_reports_path(format: :md), class: 'a-button is-md is-primary is-block' do
+            = link_to user_reports_path(@user, format: :md), class: 'a-button is-md is-primary is-block' do
               i.fas.fa-cloud-download-alt
               | 日報一括ダウンロード

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -22,12 +22,13 @@
             span.users-item-names__chat-value
               = user.discord_account.presence || 'Discord未設定'
     = render 'users/sns', user: user
-    .form-actions
-      ul.form-actions__items
-        li.form-actions__item.is-main
-          = link_to user_path(format: :md), class: 'a-button is-md is-primary is-block' do
-            i.fas.fa-cloud-download-alt
-            | 日報一括ダウンロード
+    - if admin_login?
+      .form-actions
+        ul.form-actions__items
+          li.form-actions__item.is-main
+            = link_to user_path(format: :md), class: 'a-button is-md is-primary is-block' do
+              i.fas.fa-cloud-download-alt
+              | 日報一括ダウンロード
   - if user.company.present? && user.company.logo.attached?
     = link_to company_path(user.company) do
       = image_tag user.company.logo_url, class: 'user-profile__company-logo'

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -22,6 +22,12 @@
             span.users-item-names__chat-value
               = user.discord_account.presence || 'Discord未設定'
     = render 'users/sns', user: user
+    .form-actions
+      ul.form-actions__items
+        li.form-actions__item.is-main
+          = link_to user_path(format: :md), class: 'a-button is-md is-primary is-block' do
+            i.fas.fa-cloud-download-alt
+            | 日報一括ダウンロード
   - if user.company.present? && user.company.logo.attached?
     = link_to company_path(user.company) do
       = image_tag user.company.logo_url, class: 'user-profile__company-logo'

--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -26,7 +26,7 @@
       .form-actions
         ul.form-actions__items
           li.form-actions__item.is-main
-            = link_to user_path(format: :md), class: 'a-button is-md is-primary is-block' do
+            = link_to user_reports_path(user, format: :md), class: 'a-button is-md is-primary is-block' do
               i.fas.fa-cloud-download-alt
               | 日報一括ダウンロード
   - if user.company.present? && user.company.logo.attached?

--- a/test/system/user/reports_test.rb
+++ b/test/system/user/reports_test.rb
@@ -9,7 +9,7 @@ class User::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'cannot access other users download reports' do
-    visit_with_auth "/users/#{users(:hatsuno).id}/reports.md", 'yamada'
+    visit_with_auth "/users/#{users(:hatsuno).id}/reports.md", 'kimura'
     assert_text '自分以外の日報はダウンロードすることができません'
   end
 end

--- a/test/system/user/reports_test.rb
+++ b/test/system/user/reports_test.rb
@@ -7,4 +7,9 @@ class User::ReportsTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{users(:hatsuno).id}/reports", 'hatsuno'
     assert_equal 'hatsuno | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
+
+  test 'cannot access other users download reports' do
+    visit_with_auth "/users/#{users(:hatsuno).id}/reports.md", 'yamada'
+    assert_text '自分以外の日報はダウンロードすることができません'
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -246,4 +246,18 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth '/users', 'kimura'
     assert_no_link '相談部屋'
   end
+
+  test 'show daily report download button' do
+    kimura = users(:kimura)
+
+    visit_with_auth "/users/#{kimura.id}", 'komagata'
+    assert_text '日報一括ダウンロード'
+  end
+
+  test 'not show daily report download button' do
+    kimura = users(:kimura)
+
+    visit_with_auth "/users/#{kimura.id}", 'hatsuno'
+    assert_no_text '日報一括ダウンロード'
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -248,16 +248,12 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test 'show daily report download button' do
-    kimura = users(:kimura)
-
-    visit_with_auth "/users/#{kimura.id}", 'komagata'
+    visit_with_auth "/users/#{users(:kimura).id}", 'komagata'
     assert_text '日報一括ダウンロード'
   end
 
   test 'not show daily report download button' do
-    kimura = users(:kimura)
-
-    visit_with_auth "/users/#{kimura.id}", 'hatsuno'
+    visit_with_auth "/users/#{users(:kimura).id}", 'hatsuno'
     assert_no_text '日報一括ダウンロード'
   end
 end


### PR DESCRIPTION
# 確認点1

画面上に日報ダウンロードボタンが表示されていること

## 変更前

アドミンでログインし、対象ユーザのページに行っても日報ダウンロードボタンが存在していない。
ユーザ: `komagata`
対象ユーザURL: `http://localhost:3000/users/655153192`

![image](https://user-images.githubusercontent.com/15277293/150661859-e1f05d94-3cf3-41fc-a3f1-17475a4fbd51.png)


## 変更後

アドミンでログインし、対象ユーザのページに移動すると日報ダウンロードボタンがあり、日報がダウンロードできる。
ユーザ: `komagata`
対象ユーザURL: `http://localhost:3000/users/655153192`

![image](https://user-images.githubusercontent.com/15277293/150661501-5c26bd2b-38d0-4d8f-ad4b-8fe1579e0d68.png)


### アドミン以外は表示されていない

アドミン以外でログインし、対象ユーザのページに行っても日報ダウンロードボタンが表示されていない。
ユーザ: `senpai`
対象ユーザURL: `http://localhost:3000/users/655153192`

![image](https://user-images.githubusercontent.com/15277293/150661481-9da4da63-4c99-4b9a-8e30-8e4a27547a0a.png)

# 確認点2

ダウンロードボタンをクリックして、各ユーザの日報がダウンロードできること

対象ユーザ1のURL: `http://localhost:3000/users/655153192`
対象ユーザ2のURL: `http://localhost:3000/users/991528156`



issue #3913 