### PR TITLE
WIPではない提出物を更新したら担当メンターに通知する

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -134,7 +134,6 @@ class ProductsController < ApplicationController
 
   def notice_product_update
     @checker_id = @product.checker_id
-    # return unless @checker_id && admin_or_mentor_login? && (@checker_id != current_user.id) && !@product.wip?
     NotificationFacade.product_update(@product, User.find(@checker_id))
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -134,6 +134,7 @@ class ProductsController < ApplicationController
 
   def notice_product_update
     @checker_id = @product.checker_id
+    return if admin_or_mentor_login? || @product.wip?
     NotificationFacade.product_update(@product, User.find(@checker_id))
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -50,6 +50,7 @@ class ProductsController < ApplicationController
     if @product.update(product_params)
       redirect_to @product, notice: notice_message(@product, :update)
       notice_another_mentor_assined_as_checker
+      notice_product_update
     else
       render :edit
     end
@@ -129,5 +130,11 @@ class ProductsController < ApplicationController
     return unless @checker_id && admin_or_mentor_login? && (@checker_id != current_user.id) && !@product.wip?
 
     NotificationFacade.assigned_as_checker(@product, User.find(@checker_id))
+  end
+
+  def notice_product_update
+    @checker_id = @product.checker_id
+    # return unless @checker_id && admin_or_mentor_login? && (@checker_id != current_user.id) && !@product.wip?
+    NotificationFacade.product_update(@product, User.find(@checker_id))
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -50,7 +50,7 @@ class ProductsController < ApplicationController
     if @product.update(product_params)
       redirect_to @product, notice: notice_message(@product, :update)
       notice_another_mentor_assined_as_checker
-      notice_product_update
+      notice_product_update if @product.checker_id.present?
     else
       render :edit
     end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -135,6 +135,7 @@ class ProductsController < ApplicationController
   def notice_product_update
     @checker_id = @product.checker_id
     return if admin_or_mentor_login? || @product.wip?
+
     NotificationFacade.product_update(@product, User.find(@checker_id))
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,7 +5,7 @@ class Notification < ApplicationRecord
     announcement: [:announced],
     mention: [:mentioned],
     comment: %i[came_comment answered],
-    check: %i[checked assigned_as_checker],
+    check: %i[checked assigned_as_checker product_update],
     watching: [:watching],
     following_report: [:following_report]
   }.freeze
@@ -32,7 +32,8 @@ class Notification < ApplicationRecord
     following_report: 13,
     chose_correct_answer: 14,
     consecutive_sad_report: 15,
-    assigned_as_checker: 16
+    assigned_as_checker: 16,
+    product_update: 17
   }
 
   scope :unreads, -> { where(read: false) }
@@ -243,6 +244,17 @@ class Notification < ApplicationRecord
       sender: product.sender,
       link: Rails.application.routes.url_helpers.polymorphic_path(product),
       message: "#{product.user.login_name}さんの提出物#{product.title}の担当になりました。",
+      read: false
+    )
+  end
+
+  def self.product_update(product, receiver)
+    Notification.create!(
+      kind: 17,
+      user: receiver,
+      sender: product.user,
+      link: Rails.application.routes.url_helpers.polymorphic_path(product),
+      message: "#{product.user.login_name}さんの提出物が更新されました",
       read: false
     )
   end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -20,6 +20,11 @@ class NotificationFacade
     NotificationMailer.with(check: check).checked.deliver_later(wait: 5)
   end
 
+  def self.product_update(product, receiver)
+    Notification.product_update(product, receiver)
+    return if receiver.retired?
+  end
+
   def self.mentioned(mentionable, receiver)
     Notification.mentioned(mentionable, receiver)
     return unless receiver.mail_notification? && !receiver.retired?

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -11,6 +11,7 @@ product2: # チェック済
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
   published_at: <%= 1.day.ago %>
+  checker_id: "<%= ActiveRecord::FixtureSet.identify(:komagata) %>"
 
 product3: # チェック済, 他者のコメントあり
   practice: practice2

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -17,6 +17,22 @@ class Notification::ProductsTest < ApplicationSystemTestCase
 
     open_notification
     assert_equal "kensyuさんが「#{practices(:practice5).title}」の提出物を提出しました。",
-                 notification_message
+      notification_message
+  end
+
+  test 'update product notificationmessage' do
+    binding.pry
+    product = products(:product2)
+    visit_with_auth "/products/#{product.id}/edit", 'kimura'
+    within('form[name=product]') do
+      fill_in('product[body]', with: 'test')
+    end
+    click_button '提出する'
+    assert_text '提出物を更新しました。'
+    logout
+    login_user 'komagata', 'testtest'
+    open_notification
+    assert_equal 'kimuraさんの提出物が更新されました',
+      notification_message
   end
 end

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -17,12 +17,12 @@ class Notification::ProductsTest < ApplicationSystemTestCase
 
     open_notification
     assert_equal "kensyuさんが「#{practices(:practice5).title}」の提出物を提出しました。",
-      notification_message
+                 notification_message
   end
 
   test 'update product notificationmessage' do
-    binding.pry
     product = products(:product2)
+
     visit_with_auth "/products/#{product.id}/edit", 'kimura'
     within('form[name=product]') do
       fill_in('product[body]', with: 'test')
@@ -30,9 +30,10 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     click_button '提出する'
     assert_text '提出物を更新しました。'
     logout
+
     login_user 'komagata', 'testtest'
     open_notification
     assert_equal 'kimuraさんの提出物が更新されました',
-      notification_message
+                 notification_message
   end
 end


### PR DESCRIPTION
[#3845 ](https://github.com/fjordllc/bootcamp/issues/3845)

## 変更前
- 担当している提出物が更新される
<img width="1036" alt="aptの基礎を覚えるの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/150341940-fda32787-aab9-4c57-a577-57c140c97c41.png">

- 通知されてない（kimuraの提出物）
<img width="962" alt="ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/150341989-30b7aab4-93f7-4bd5-bd67-5963dd74c1ec.png">

## 変更後
- 提出物が更新される
<img width="1036" alt="aptの基礎を覚えるの提出物___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/150341940-fda32787-aab9-4c57-a577-57c140c97c41.png">

- 通知される
<img width="506" alt="ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/62058863/150342252-4c06ac28-4f55-41eb-b443-23c6650db3be.png">

