### PR TITLE
Cloud Build 用タスクで #3936 の動作確認に必要なテストデータを作成できるようにした

### DIFF
--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -37,7 +37,27 @@ namespace :bootcamp do
     desc 'Cloud Build Task'
     task cloudbuild: :environment do
       puts '== START Cloud Build Task =='
-      # code ...
+
+      receiver_login_name = if Rails.env.development? || ENV['DB_NAME'] == 'bootcamp_staging'
+                              'komagata'
+                            elsif Rails.env.production?
+                              'AudioStakes'
+                            end
+      receiver = User.find_by(login_name: receiver_login_name)
+      sender = User.find_by(login_name: 'machida')
+      link = Product.first.path
+      now = Time.current
+
+      2.times do |i|
+        Notification.create!(
+          user: receiver,
+          sender: sender,
+          message: "【動作確認用】「通知元リンクが同じ」通知のなかで「作成日時が最新かつ同値」である通知#{i + 1}つ目",
+          link: link,
+          created_at: now
+        )
+      end
+
       puts '== END   Cloud Build Task =='
     end
   end


### PR DESCRIPTION
Ref: #3755

## やったこと

### Cloud Build で実行可能な Rake タスクで #3936 の動作確認用テストデータを作成できるようにした

#3936 の動作確認には「通知元リンクが同じ」かつ「作成日時が最新かつ同値」である複数の通知が必要であるものの、それらは画面の操作では作成できないため、ステージング環境と本番環境での動作確認ができずにいました。
そのため、Cloud Build で実行可能な（ステージング環境と本番環境で実行可能な） Rake タスク `'bootcamp:oneshot:cloudbuild'` でそれらのテストデータを作成できるようにしました。