### PR TITLE
sadがついた日報の提出時にヘルプへ誘導するモーダルを表示

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -141,7 +141,7 @@ class ReportsController < ApplicationController
   end
 
   def params_hash(report)
-    { notify_qa: !report.wip? && report.sad? }
+    { notify_help: !report.wip? && report.sad? }
   end
 
   def set_watch

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -51,7 +51,7 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
     if @report.save
-      redirect_to redirect_url(@report, notify_qa_hash(@report)), notice: notice_message(@report)
+      redirect_to redirect_url(@report, params_hash(@report)), notice: notice_message(@report)
     else
       render :new
     end
@@ -63,7 +63,7 @@ class ReportsController < ApplicationController
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
     if @report.save
-      redirect_to redirect_url(@report, notify_qa_hash(@report)), notice: notice_message(@report)
+      redirect_to redirect_url(@report, params_hash(@report)), notice: notice_message(@report)
     else
       render :edit
     end
@@ -132,7 +132,7 @@ class ReportsController < ApplicationController
     @report.wip = params[:commit] == 'WIP'
   end
 
-  def redirect_url(report, params_hash)
+  def redirect_url(report, params_hash = {})
     report.wip? ? edit_report_url(report) : report_url(report, **params_hash)
   end
 
@@ -140,7 +140,7 @@ class ReportsController < ApplicationController
     report.wip? ? '日報をWIPとして保存しました。' : '日報を保存しました。'
   end
 
-  def notify_qa_hash(report)
+  def params_hash(report)
     { notify_qa: report.wip? ? false : report.sad? }
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -51,7 +51,7 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
     if @report.save
-      redirect_to redirect_url(@report), notice: notice_message(@report)
+      redirect_to redirect_url(@report, notify_qa_hash(@report)), notice: notice_message(@report)
     else
       render :new
     end
@@ -63,7 +63,7 @@ class ReportsController < ApplicationController
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
     if @report.save
-      redirect_to redirect_url(@report), notice: notice_message(@report)
+      redirect_to redirect_url(@report, notify_qa_hash(@report)), notice: notice_message(@report)
     else
       render :edit
     end
@@ -132,12 +132,16 @@ class ReportsController < ApplicationController
     @report.wip = params[:commit] == 'WIP'
   end
 
-  def redirect_url(report)
-    report.wip? ? edit_report_url(report) : report
+  def redirect_url(report, params_hash)
+    report.wip? ? edit_report_url(report) : report_url(report, **params_hash)
   end
 
   def notice_message(report)
     report.wip? ? '日報をWIPとして保存しました。' : '日報を保存しました。'
+  end
+
+  def notify_qa_hash(report)
+    { notify_qa: report.wip? ? false : report.sad? }
   end
 
   def set_watch

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -141,7 +141,7 @@ class ReportsController < ApplicationController
   end
 
   def params_hash(report)
-    { notify_qa: report.wip? ? false : report.sad? }
+    { notify_qa: !report.wip? && report.sad? }
   end
 
   def set_watch

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -51,7 +51,7 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
     if @report.save
-      redirect_to redirect_url(@report, params_hash(@report)), notice: notice_message(@report)
+      redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :new
     end
@@ -63,7 +63,7 @@ class ReportsController < ApplicationController
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
     if @report.save
-      redirect_to redirect_url(@report, params_hash(@report)), notice: notice_message(@report)
+      redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :edit
     end
@@ -132,15 +132,15 @@ class ReportsController < ApplicationController
     @report.wip = params[:commit] == 'WIP'
   end
 
-  def redirect_url(report, params_hash = {})
-    report.wip? ? edit_report_url(report) : report_url(report, **params_hash)
+  def redirect_url(report)
+    report.wip? ? edit_report_url(report) : report_url(report)
   end
 
   def notice_message(report)
     report.wip? ? '日報をWIPとして保存しました。' : '日報を保存しました。'
   end
 
-  def params_hash(report)
+  def flash_contents(report)
     { notify_help: !report.wip? && report.sad? }
   end
 

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -172,9 +172,13 @@ header.page-header
           #js-reports(data-user-id="#{@report.user.id}" data-limit="10")
 
 - if params[:notify_qa].eql?('true')
-    = render '/shared/modal', id: 'modal-notify-qa', title: '今日も学習お疲れ様でした！', auto_show: true
+    = render '/shared/modal', id: 'modal-notify-qa', title: '🍵 今日も学習お疲れ様でした！', auto_show: true
       .modal__description.is-md
-        .a-short-text
+        .a-long-text
           p
-            a href='https://bootcamp.fjord.jp/pages/help' ヘルプページ
-            | には学習のヒントになる情報が載っているので困った時はぜひのぞいてみてください。
+            = link_to '/pages/help' do
+              | ヘルプページ
+            | には学習のヒントになる情報が載っています。
+            | 困った時はぜひのぞいてみてください。
+            | ヘルプページは左のナビゲーションにリンクがあるので、
+            | いつでもそこからアクセスができます。

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -170,3 +170,11 @@ header.page-header
                             | 提出物はまだありません。
         - else
           #js-reports(data-user-id="#{@report.user.id}" data-limit="10")
+
+- if params[:notify_qa].eql?('true')
+    = render '/shared/modal', id: 'modal-notify-qa', title: '今日も学習お疲れ様でした！', auto_show: true
+      .modal__description.is-md
+        .a-short-text
+          p
+            a href='https://bootcamp.fjord.jp/pages/help' ヘルプページ
+            | には学習のヒントになる情報が載っているので困った時はぜひのぞいてみてください。

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -172,7 +172,7 @@ header.page-header
           #js-reports(data-user-id="#{@report.user.id}" data-limit="10")
 
 - if params[:notify_help].eql?('true')
-    = render '/shared/modal', id: 'modal-notify-qa', title: '🍵 今日も学習お疲れ様でした！', auto_show: true
+    = render '/shared/modal', id: 'modal-notify-help', title: '🍵 今日も学習お疲れ様でした！', auto_show: true
       .modal__description.is-md
         .a-long-text
           p

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -171,7 +171,7 @@ header.page-header
         - else
           #js-reports(data-user-id="#{@report.user.id}" data-limit="10")
 
-- if params[:notify_qa].eql?('true')
+- if params[:notify_help].eql?('true')
     = render '/shared/modal', id: 'modal-notify-qa', title: '🍵 今日も学習お疲れ様でした！', auto_show: true
       .modal__description.is-md
         .a-long-text

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -172,7 +172,7 @@ header.page-header
           #js-reports(data-user-id="#{@report.user.id}" data-limit="10")
 
 - if flash[:notify_help]
-    = render '/shared/modal', id: 'modal-notify-help', title: '🍵 今日も学習お疲れ様でした！', auto_show: true
+    = render '/shared/modal', id: 'modal-notify-help', modal_title: '🍵 今日も学習お疲れ様でした！', auto_show: true
       .modal__description.is-md
         .a-long-text
           p

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -171,7 +171,7 @@ header.page-header
         - else
           #js-reports(data-user-id="#{@report.user.id}" data-limit="10")
 
-- if params[:notify_help].eql?('true')
+- if flash[:notify_help]
     = render '/shared/modal', id: 'modal-notify-help', title: '🍵 今日も学習お疲れ様でした！', auto_show: true
       .modal__description.is-md
         .a-long-text

--- a/app/views/shared/_modal.html.slim
+++ b/app/views/shared/_modal.html.slim
@@ -1,4 +1,7 @@
-input.a-toggle-checkbox(id="#{id}" type="checkbox")
+- if defined?(auto_show) && auto_show
+  input.a-toggle-checkbox(id="#{id}" type="checkbox" checked)
+- else
+  input.a-toggle-checkbox(id="#{id}" type="checkbox")
 .modal
   label.modal__overlay(for="#{id}")
   .modal-content

--- a/test/system/emotions_test.rb
+++ b/test/system/emotions_test.rb
@@ -21,4 +21,23 @@ class EmotionsTest < ApplicationSystemTestCase
     assert_text '日報を保存しました。'
     assert_selector 'img#happy'
   end
+  test 'create a report with the sad emotion' do
+    visit_with_auth '/reports/new', 'komagata'
+    within('#new_report') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: 'test')
+    end
+
+    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
+    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+
+    find('#happy').click
+
+    click_button '提出'
+    assert_text '日報を保存しました。'
+    assert_selector 'img#happy'
+    assert_text '困った時は'
+  end
 end

--- a/test/system/emotions_test.rb
+++ b/test/system/emotions_test.rb
@@ -21,6 +21,7 @@ class EmotionsTest < ApplicationSystemTestCase
     assert_text '日報を保存しました。'
     assert_selector 'img#happy'
   end
+
   test 'create a report with the sad emotion' do
     visit_with_auth '/reports/new', 'komagata'
     within('#new_report') do

--- a/test/system/emotions_test.rb
+++ b/test/system/emotions_test.rb
@@ -33,11 +33,11 @@ class EmotionsTest < ApplicationSystemTestCase
     all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
     all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
 
-    find('#happy').click
+    find('#sad').click
 
     click_button '提出'
     assert_text '日報を保存しました。'
-    assert_selector 'img#happy'
+    assert_selector 'img#sad'
     assert_text '困った時は'
   end
 end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -175,6 +175,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
     all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
+    find('.modal-header__close').click
 
     click_link '日報作成'
     within('#new_report') do
@@ -188,6 +189,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
     all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
+    find('.modal-header__close').click
 
     visit_with_auth '/notifications', mentor
 


### PR DESCRIPTION
- #3996 
## 機能
sadがついた日報を提出する→日報の内容を表示する画面（show）にリダイレクト→モーダルが表示される。

https://user-images.githubusercontent.com/39044468/154169634-2d773b33-0c70-436d-af24-7232df2239f0.mp4


