### PR TITLE
プラクティス詳細画面に表示されるDocsタブをクリックすると500エラーが発生する問題を修正

### DIFF
--- a/app/views/pages/_page.html.slim
+++ b/app/views/pages/_page.html.slim
@@ -1,0 +1,65 @@
+.thread-list-item(class="#{page.wip? ? 'is-wip' : ''}")
+  .thread-list-item__inner
+    .thread-list-item__user
+      = render 'users/icon',
+              user: page.user,
+              link_class: 'a-user-name',
+              image_class: 'thread-list-item__user-icon'
+    .thread-list-item__rows
+      .thread-list-item__row
+        .thread-list-item-title
+          - if page.wip?
+            .thread-list-item-title__icon.is-wip WIP
+          h2.thread-list-item-title__title(itemprop='name')
+            = link_to page, itemprop: 'url', class: 'thread-list-item-title__link' do
+              = page.title
+      - if page.practice.present?
+        .thread-list-item__row
+          .thread-list-item-meta
+            .thread-list-item-meta__items
+              .thread-list-item-meta__item
+                .thread-list-item-sub-title
+                  = page.practice.title
+              - if page.comments.any?
+                .thread-list-item-meta__item
+                  .thread-list-item-comment
+                    .thread-list-item-comment__label
+                      | コメント
+                    .thread-list-item-comment__count
+                      | （#{page.comments.size}）
+
+      .thread-list-item__row
+        .thread-list-item-meta
+          .thread-list-item-meta__items
+            .thread-list-item-meta__item
+              - if page.wip?
+                .a-meta
+                  | Doc作成中
+              - elsif page.published_at.present?
+                time.a-meta(datetime="#{page.published_at.to_datetime}")
+                  span.a-meta__label
+                    | 公開
+                  span.a-meta__value
+                    | #{l page.published_at}
+            - if page.last_updated_user.present?
+              .thread-list-item-meta__item
+                time.a-meta(datetime="#{page.updated_at.to_datetime}")
+                  span.a-meta__label
+                    | 更新
+                  | #{l page.updated_at} by
+                  = render 'users/icon',
+                          user: page.last_updated_user,
+                          link_class: 'thread-list-item-meta__icon-link',
+                          image_class: 'thread-list-item-meta__icon'
+                  = link_to page.last_updated_user, class: 'a-user-name' do
+                    | #{page.last_updated_user.login_name}
+
+      - if page.tags.present?
+        .thread-list-item__row
+          .thread-list-item-tags
+            .thread-list-item-tags__label
+              i.fas.fa-tags
+            ul.thread-list-item-tags__items
+              - page.tags.each do |tag|
+                li.thread-list-item-tags__item
+                  = link_to tag.name, pages_tag_path(tag.name), class: 'thread-list-item-tags__item-link'

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -38,3 +38,10 @@ page6:
   title: Docsの検索結果テスト用
   body: Docsの検索結果テスト用
   user: komagata
+
+page7:
+  title: プラクティスに紐付いたDocs
+  body: プラクティスに紐付いている
+  user: komagata
+  practice: practice1
+  published_at: "2021-10-01 00:00:00"


### PR DESCRIPTION
## issue
- #3987 

## 概要
プラクティス詳細画面に表示されるDocsタブをクリックすると500エラーが発生する

## バグ説明 & 対応
プラクティス詳細画面に表示されるDocsタブをクリックすると、エラーメッセージが以下の通り表示されます。

![image](https://user-images.githubusercontent.com/66904873/150465754-acb034b6-a576-4f8f-a013-5485e21517cb.png)

エラーメッセージに書いてあるように、`app/view/pages`ディレクトリにパーシャル`_page.html.slim`が存在しませんでした。
調査した結果、[Pull Request #3852](https://github.com/fjordllc/bootcamp/pull/3852)（Docs一覧をVue.js化する）で`_page.html.slim`が削除されていたため起こった問題だと思います。
https://github.com/fjordllc/bootcamp/pull/3852/files#diff-bb6cc0d3a637a7b86108b0fa27f76af6e6d9c937c41e32bc7a291221bf1e2e12

また、テストにつきましては存在していた（`test/system/practice/pages_test.rb`）のですが、`test/fixtures/pages.yml`にプラクティスに紐づいたDocsのデータがなかったため、パーシャルがなくてもテストが通ってしまっていたようです。
こちら、issueに取り組む前に実行しました。
下のように該当するテスト（`test/system/practice/pages_test.rb`）が通ってしまいます。

```
❱ rails test test/system/practice/pages_test.rb                                                                                   
Warning: the running version of Bundler (2.2.27) is older than the version that created the lockfile (2.2.30). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.30`.
Running via Spring preloader in process 99960
Run options: --seed 41854

# Running:

Capybara starting Puma...
* Version 5.5.1 , codename: Zawgyi
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:64632
.

Finished in 7.817056s, 0.1279 runs/s, 0.1279 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

デバッグしてスクリーンショットで確認しました。
確かに表示されていることを確認できました。

![image](https://user-images.githubusercontent.com/66904873/150465211-5f01d491-84f0-40ca-ab82-d0bdc11a1a7c.png)

上記のことより、`test/fixtures/pages.yml`にプラクティスに紐づいたデータを追加し、テストが落ちることを確認しました。（`_page.html.slim`はまだ作成していない状況です。）

```
❱ rails test test/system/practice/pages_test.rb
Warning: the running version of Bundler (2.2.27) is older than the version that created the lockfile (2.2.30). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.30`.
Running via Spring preloader in process 95380
Run options: --seed 2412

# Running:

Capybara starting Puma...
* Version 5.5.1 , codename: Zawgyi
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:64081
2022-01-21 13:01:50 +0900 Rack app ("GET /practices/315059988/pages_login_name=hatsuno" - (127.0.0.1)): #<ActionView::Template::Error: Missing partial pages/_page with {:locale=>[:ja], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :slim, :coffee, :jbuilder]}. Searched in:
  * "/Users/maedaseina/Desktop/fjord/bootcamp/app/views"
  * "/Users/maedaseina/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/kaminari-core-1.2.1/app/views"
  * "/Users/maedaseina/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/any_login-1.4.4/app/views"
  * "/Users/maedaseina/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/actiontext-6.1.4.1/app/views"
  * "/Users/maedaseina/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/actionmailbox-6.1.4.1/app/views"
>
[Screenshot Image]: /Users/maedaseina/Desktop/fjord/bootcamp/tmp/screenshots/failures_test_show_listing_pages.png
F

Failure:
Practice::PagesTest#test_show_listing_pages:
--- expected
+++ actual
@@ -1 +1 @@
-"OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）"
+""


Error:
Practice::PagesTest#test_show_listing_pages:
ActionView::Template::Error: Missing partial pages/_page with {:locale=>[:ja], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :slim, :coffee, :jbuilder]}. Searched in:
  * "/Users/maedaseina/Desktop/fjord/bootcamp/app/views"
  * "/Users/maedaseina/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/kaminari-core-1.2.1/app/views"
  * "/Users/maedaseina/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/any_login-1.4.4/app/views"
  * "/Users/maedaseina/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/actiontext-6.1.4.1/app/views"
  * "/Users/maedaseina/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/actionmailbox-6.1.4.1/app/views"

    app/views/practices/pages/index.html.slim:23


rails test test/system/practice/pages_test.rb:6



Finished in 4.309734s, 0.2320 runs/s, 0.2320 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

その上で、`_page.html.slim`を復元し、テストが無事通ることを確認しました。

```
❱ rails test test/system/practice/pages_test.rb
Warning: the running version of Bundler (2.2.27) is older than the version that created the lockfile (2.2.30). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.30`.
Running via Spring preloader in process 95697
Run options: --seed 57256

# Running:

Capybara starting Puma...
* Version 5.5.1 , codename: Zawgyi
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:64113
.

Finished in 9.780706s, 0.1022 runs/s, 0.1022 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

既存のテストが用意されていたため、新たにテストは作成していませんが、既存テストを機能させるために`test/fixtures/pages.yml`にプラクティスに基づいたDocsデータの追加を行っています🙏


## 変更前

プラクティス詳細画面に表示されるDocsタブをクリックするとエラーが発生する。

![image](https://user-images.githubusercontent.com/66904873/150536160-36faf1bb-f714-42a3-82ec-f1d91096a090.png)


## 変更後

プラクティス詳細画面に表示されるDocsタブをクリックするとプラクティスに紐づいたDocsが表示される。

![image](https://user-images.githubusercontent.com/66904873/150536344-e13fe521-37a0-479d-ad30-c52de9fd7280.png)
