### PR TITLE
「はじめての日報を書きました！」通知は現役生とメンターのみに通知する

### DIFF
--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -70,7 +70,7 @@ class NotificationFacade
   end
 
   def self.first_report(report, receiver)
-    Notification.first_report(report, receiver)
+    Notification.first_report(report, receiver) if receiver.student_or_trainee? || receiver.admin_or_mentor?
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -3,7 +3,7 @@
 require 'application_system_test_case'
 
 class Notification::ReportsTest < ApplicationSystemTestCase
-  test 'はじめての日報が投稿されたときにメンターと現役生のみが通知を受け取る' do
+  test 'the first daily report notification is sent only to current students and mentors' do
     report = users(:muryou).reports.create!(
       title: 'test title',
       description: 'test',

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -4,36 +4,33 @@ require 'application_system_test_case'
 
 class Notification::ReportsTest < ApplicationSystemTestCase
   test 'はじめての日報が投稿されたときにメンターと現役生のみが通知を受け取る' do
-    visit_with_auth '/reports/new', 'muryou'
+    report = users(:muryou).reports.create!(
+      title: 'test title',
+      description: 'test',
+      reported_on: Date.current
+    )
 
-    within('#new_report') do
-      fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: 'test')
-    end
+    Notification.create!(
+      kind: 7,
+      user: users(:komagata),
+      sender: users(:muryou),
+      message: "#{users(:muryou).login_name}さんがはじめての日報を書きました！",
+      link: "/reports/#{report.id}",
+      read: false
+    )
 
-    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
-    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+    notification_message = 'muryouさんがはじめての日報を書きました！'
+    visit_with_auth "/notifications", 'komagata'
+    assert_text notification_message
 
-    click_button '提出'
+    visit_with_auth "/notifications", 'kimura'
+    assert_text notification_message
 
-    report_title = 'muryouさんがはじめての日報を書きました！'
-    login_user 'komagata', 'testtest'
-    open_notification
-    assert_equal report_title, notification_message
+    visit_with_auth "/notifications", 'advijirou'
+    assert_no_text notification_message
 
-    login_user 'kimura', 'testtest'
-    open_notification
-    assert_equal report_title, notification_message
-
-    login_user 'advijirou', 'testtest'
-    open_notification
-    assert_not_equal report_title, notification_message
-
-    login_user 'sotugyou', 'testtest'
-    open_notification
-    assert_not_equal report_title, notification_message
+    visit_with_auth "/notifications", 'sotugyou'
+    assert_no_text notification_message
   end
 
   test '複数の日報が投稿されているときは通知が飛ばない' do

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -20,16 +20,16 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
 
     notification_message = 'muryouさんがはじめての日報を書きました！'
-    visit_with_auth "/notifications", 'komagata'
+    visit_with_auth '/notifications', 'komagata'
     assert_text notification_message
 
-    visit_with_auth "/notifications", 'kimura'
+    visit_with_auth '/notifications', 'kimura'
     assert_text notification_message
 
-    visit_with_auth "/notifications", 'advijirou'
+    visit_with_auth '/notifications', 'advijirou'
     assert_no_text notification_message
 
-    visit_with_auth "/notifications", 'sotugyou'
+    visit_with_auth '/notifications', 'sotugyou'
     assert_no_text notification_message
   end
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -3,7 +3,7 @@
 require 'application_system_test_case'
 
 class Notification::ReportsTest < ApplicationSystemTestCase
-  test 'はじめての日報が投稿されたときに全員が通知を受け取る' do
+  test 'はじめての日報が投稿されたときにメンターと現役生が通知を受け取る' do
     visit_with_auth '/reports', 'muryou'
     click_link '日報作成'
 
@@ -22,15 +22,47 @@ class Notification::ReportsTest < ApplicationSystemTestCase
 
     login_user 'komagata', 'testtest'
     open_notification
-    assert_equal 'muryouさんがはじめての日報を書きました！',
-                 notification_message
+    assert_equal 'muryouさんがはじめての日報を書きました！', notification_message
     logout
 
-    login_user 'yamada', 'testtest'
+    login_user 'kimura', 'testtest'
     open_notification
-    assert_equal 'muryouさんがはじめての日報を書きました！',
-                 notification_message
+    assert_equal 'muryouさんがはじめての日報を書きました！', notification_message
     logout
+  end
+
+  test 'はじめての日報が投稿されたときにアドバイザーと卒業生は通知を受け取らない' do
+    # 他のテストの通知に影響を受けないよう、テスト実行前に通知を削除する
+    visit_with_auth '/notifications', 'advijirou'
+    click_link '全て既読にする'
+
+    visit_with_auth '/notifications', 'sotugyou'
+    click_link '全て既読にする'
+
+    visit_with_auth '/reports', 'muryou'
+    click_link '日報作成'
+
+    within('#new_report') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: 'test')
+    end
+
+    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
+    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+
+    click_button '提出'
+    logout
+
+    login_user 'advijirou', 'testtest'
+    # sleepメソッドで一定時間停止しないと、cssが読み込まれる前に”assert page.has_css?('.has-no-count')”を実行してしまう。
+    sleep 1
+    assert page.has_css?('.has-no-count')
+
+    login_user 'sotugyou', 'testtest'
+    sleep 1
+    assert page.has_css?('.has-no-count')
   end
 
   test '複数の日報が投稿されているときは通知が飛ばない' do


### PR DESCRIPTION
## issue
- #3981 

## 概要

「はじめての日報を書きました！」通知は現役生とメンターのみに通知されるようにする

## 動作確認の手順

1.日報なしのユーザー(nippounashi)でログインし、日報を作成し、ログアウトする。

2.現役生ユーザー(kimuraなど)でログインし、サイト内通知とメール通知(letter_openerで確認)がきていることを確認する。(同じくこの動作をメンター(komagata)でも確認する。)

3.アドバイザー(advijirou)でログインし、サイト内通知とメール通知がきてないことを確認する。(同じくこの動作を卒業生(sotugyou)でも確認する。)

テストケースには現役生とメンターに通知がいくことを確認できるテストと、アドバイザーと卒業生には通知がいかないことを確認できるテストを作成しました。