### PR TITLE
package.json で Node.js のバージョンを指定するようにした

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,11 @@ jobs:
         ruby-version: 2.7.4
         bundler-cache: true
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16.13.0'
+
     - name: Cache node modules
       uses: actions/cache@v2.1.4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
         ruby-version: 2.7.4
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16.13.0'
+
     - name: Cache node modules
       uses: actions/cache@v2.1.4
       with:

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "prettier-config-standard": "^4.0.0",
     "webpack-dev-server": "^3.11.2"
   },
+  "engines": {
+    "node": "^16.13.0"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
ローカルの Node.js が 17.0.1 になっていて webpack がうまく動かないという現象に遭遇したので、package.json で Node.js のバージョンを 16 系 LTS に固定するようにしました。Node.js が指定されたバージョンのものではないときは、以下のようなエラーが出るようになります。GitHub Actions で使用される Node.js のバージョンも `.node-version` と `.nvmrc` を参考に固定しておきました。

<img width="683" alt="Screen Shot 2022-01-23 at 21 38 40" src="https://user-images.githubusercontent.com/7645585/150678760-4b782702-acfb-4fa5-8bb7-bb29666ac8a2.png">