### PR TITLE
通知ページの「全て」以外のタブに未読数を表示する

### DIFF
--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,0 +1,5 @@
+module NotificationHelper
+  def ensure_notifications?
+    current_user.notifications.by_target(@target).unreads.latest_of_each_link.size.positive?
+  end
+end

--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module NotificationHelper
-  def ensure_notifications?
-    current_user.notifications.by_target(@target).unreads.latest_of_each_link.size.positive?
+  def ensure_notifications?(target)
+    current_user.notifications.by_target(target).unreads.latest_of_each_link.size.positive?
   end
 end

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -17,3 +17,6 @@
                   = Cache.mentioned_and_unread_notification_count(current_user)
             - else
               = t("notification.#{target}")
+              - if current_user.notifications.by_target(target).unreads.latest_of_each_link.size.positive?
+                .page-tabs__item-count.a-notification-count
+                  = current_user.notifications.by_target(target).unreads.latest_of_each_link.size

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -17,6 +17,6 @@
                   = Cache.mentioned_and_unread_notification_count(current_user)
             - else
               = t("notification.#{target}")
-              - if current_user.notifications.by_target(target).unreads.latest_of_each_link.size.positive?
+              - if ensure_notifications?
                 .page-tabs__item-count.a-notification-count
                   = current_user.notifications.by_target(target).unreads.latest_of_each_link.size

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -17,6 +17,6 @@
                   = Cache.mentioned_and_unread_notification_count(current_user)
             - else
               = t("notification.#{target}")
-              - if ensure_notifications?
+              - if ensure_notifications?(target)
                 .page-tabs__item-count.a-notification-count
                   = current_user.notifications.by_target(target).unreads.latest_of_each_link.size

--- a/test/system/notification/tabs_badges_test.rb
+++ b/test/system/notification/tabs_badges_test.rb
@@ -57,29 +57,30 @@ class Notification::TabsBadgesTest < ApplicationSystemTestCase
       read: false
     )
   end
+  
   test 'unread badges are displayed' do
     visit_with_auth '/notifications', 'sotugyou'
 
-    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(1) > a > div' do
-      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    within first('.page-tabs__item:nth-child(1)') do
+      find('div', text: '10')
     end
-    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(2) > a > div' do
-      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    within first('.page-tabs__item:nth-child(2)') do
+      find('div', text: '2')
     end
-    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(3) > a > div' do
-      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    within first('.page-tabs__item:nth-child(3)') do
+      find('div', text: '2')
     end
-    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(4) > a > div' do
-      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    within first('.page-tabs__item:nth-child(4)') do
+      find('div', text: '3')
     end
-    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(5) > a > div' do
-      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    within first('.page-tabs__item:nth-child(5)') do
+      find('div', text: '2')
     end
-    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(6) > a > div' do
-      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    within first('.page-tabs__item:nth-child(6)') do
+      find('div', text: '1')
     end
-    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(7) > a > div' do
-      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    within first('.page-tabs__item:nth-child(7)') do
+      find('div', text: '1')
     end
   end
 
@@ -89,26 +90,26 @@ class Notification::TabsBadgesTest < ApplicationSystemTestCase
 
     visit_with_auth '/notifications', 'sotugyou'
 
-    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(1) > a > div' do
-      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    within all('.page-tabs__item')[0] do
+      assert_no_selector '.page-tabs__item-count'
     end
-    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(2) > a > div' do
-      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    within all('.page-tabs__item')[1] do
+      assert_no_selector '.page-tabs__item-count'
     end
-    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(3) > a > div' do
-      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    within all('.page-tabs__item')[2] do
+      assert_no_selector '.page-tabs__item-count'
     end
-    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(4) > a > div' do
-      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    within all('.page-tabs__item')[3] do
+      assert_no_selector '.page-tabs__item-count'
     end
-    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(5) > a > div' do
-      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    within all('.page-tabs__item')[4] do
+      assert_no_selector '.page-tabs__item-count'
     end
-    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(6) > a > div' do
-      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    within all('.page-tabs__item')[5] do
+      assert_no_selector '.page-tabs__item-count'
     end
-    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(7) > a > div' do
-      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    within all('.page-tabs__item')[6] do
+      assert_no_selector '.page-tabs__item-count'
     end
   end
 end

--- a/test/system/notification/tabs_badges_test.rb
+++ b/test/system/notification/tabs_badges_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Notification::TabsBadgesTest < ApplicationSystemTestCase
+  test 'unread badges are displayed' do
+    Notification.create!(
+      message: 'watch中',
+      kind: 8,
+      link: '/notifications/1',
+      user: users(:sotugyou),
+      sender: users(:komagata)
+    )
+    Notification.create!(
+      message: 'フォロー中',
+      kind: 13,
+      link: '/notifications/1',
+      user: users(:sotugyou),
+      sender: users(:komagata)
+    )
+
+    visit_with_auth '/notifications', 'sotugyou'
+
+    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(1) > a > div' do
+      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(2) > a > div' do
+      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(3) > a > div' do
+      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(4) > a > div' do
+      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(5) > a > div' do
+      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(6) > a > div' do
+      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(7) > a > div' do
+      assert_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+  end
+
+  test 'unread badges are not displayed' do
+    visit_with_auth '/notifications', 'machida'
+
+    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(1) > a > div' do
+      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(2) > a > div' do
+      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(3) > a > div' do
+      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(4) > a > div' do
+      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(5) > a > div' do
+      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(6) > a > div' do
+      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+    assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(7) > a > div' do
+      assert_no_selector 'div.page-tabs__item-count.a-notification-count'
+    end
+  end
+end

--- a/test/system/notification/tabs_badges_test.rb
+++ b/test/system/notification/tabs_badges_test.rb
@@ -3,22 +3,61 @@
 require 'application_system_test_case'
 
 class Notification::TabsBadgesTest < ApplicationSystemTestCase
-  test 'unread badges are displayed' do
+  setup do
+    Notification.create!(
+      message: 'お知らせ',
+      kind: 5,
+      link: '/notifications/1',
+      user: users(:sotugyou),
+      sender: users(:komagata),
+      read: false
+    )
+
+    Notification.create!(
+      message: 'メンション',
+      kind: 2,
+      link: '/notifications/2',
+      user: users(:sotugyou),
+      sender: users(:komagata),
+      read: false
+    )
+
+    Notification.create!(
+      message: 'コメント',
+      kind: 0,
+      link: '/notifications/3',
+      user: users(:sotugyou),
+      sender: users(:komagata),
+      read: false
+    )
+
+    Notification.create!(
+      message: '提出物の確認',
+      kind: 1,
+      link: '/notifications/4',
+      user: users(:sotugyou),
+      sender: users(:komagata),
+      read: false
+    )
+
     Notification.create!(
       message: 'watch中',
       kind: 8,
-      link: '/notifications/1',
+      link: '/notifications/5',
       user: users(:sotugyou),
-      sender: users(:komagata)
+      sender: users(:komagata),
+      read: false
     )
     Notification.create!(
       message: 'フォロー中',
       kind: 13,
-      link: '/notifications/1',
+      link: '/notifications/6',
       user: users(:sotugyou),
-      sender: users(:komagata)
+      sender: users(:komagata),
+      read: false
     )
-
+  end
+  test 'unread badges are displayed' do
     visit_with_auth '/notifications', 'sotugyou'
 
     assert_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(1) > a > div' do
@@ -45,7 +84,10 @@ class Notification::TabsBadgesTest < ApplicationSystemTestCase
   end
 
   test 'unread badges are not displayed' do
-    visit_with_auth '/notifications', 'machida'
+    user = users(:sotugyou)
+    user.notifications.unreads.update_all(read: true) # rubocop:disable Rails/SkipsModelValidations
+
+    visit_with_auth '/notifications', 'sotugyou'
 
     assert_no_selector '#body > div.wrapper > main > div > div > ul > li:nth-child(1) > a > div' do
       assert_no_selector 'div.page-tabs__item-count.a-notification-count'

--- a/test/system/notification/tabs_badges_test.rb
+++ b/test/system/notification/tabs_badges_test.rb
@@ -57,7 +57,7 @@ class Notification::TabsBadgesTest < ApplicationSystemTestCase
       read: false
     )
   end
-  
+
   test 'unread badges are displayed' do
     visit_with_auth '/notifications', 'sotugyou'
 


### PR DESCRIPTION
- #3907 

# 実装内容

通知ページのタブに未読数を表示するようにしました。
「全て」のタブに関しては、 #3590 で既に実装されておりましたので、自分は「全て」以外のタブに未読数を表示するように変更しました。

## 変更前
再現手順
1. アカウント: muryou でログイン
2. 通知ページ`/notifications`にアクセス
3. コメントに未読が1件あるのに、タブに未読数がついていない

![pr-description](https://user-images.githubusercontent.com/45246171/150905128-ca86fa7f-71a9-4f5f-a597-9f22eb6c9263.png)

## 変更後

再現手順
1. アカウント: muryou でログイン
2. 通知ページ`/notifications`にアクセス
3. コメントに未読数が1件で、タブにも1と表示できている
![pr-description02](https://user-images.githubusercontent.com/45246171/150905419-5233027c-e869-43e4-bfff-1ab58c93437e.png)


### 他のアカウントでも確認

アカウント: senpai
![pr-description04](https://user-images.githubusercontent.com/45246171/150906543-02e46874-f32e-4bcb-8a70-b9ddedb1a535.png)

**1/25 14:53追記**
以下に再現手順を示します。

1. anyloginを使って`senpai`アカウントでログイン
2. 通知ページ`/notifications`にアクセス
3. ↑のスクリーンショットと同じ画面で、各タブに未読数が表示されていることが確認できると思います。



# レビューしてほしい点

実装したものの、テストについて以下の点が気になっているのでレビューしていただけますと幸いです。

現在書いているテストでは、未読数に該当するテストのhtml要素が存在するか、しないか、ということでテストを記述しています。
全てを含めて、タブは7個あり、その全てについてテストができていない状態です。
このテストでいいのか、別の書き方をしたほうがいいのか、わからなかったです。

# その他: PR#3947がcloseしてる件について

issue着手時に実装方針がわからず、急ぎで相談したときに#3947を作成しました。ペアプロ時に別のブランチを切って実装を進めてしまったため、#3947はcloseしています。