### PR TITLE
Q&Aの一覧画面にコメント数(回答数)を表示させました

### DIFF
--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -32,6 +32,12 @@
               :datetime='question.updated_at.datetime',
               pubdate='pubdate'
             ) {{ question.updated_at.locale }}
+          .thread-list-item-meta__item(v-if='question.answers.size > 0')
+            .thread-list-item-comment
+              .thread-list-item-comment__label
+                | 回答・コメント
+              .thread-list-item-comment__count
+                | （{{ question.answers.size }}）
 
     .thread-list-item__row(v-if='question.tags.length > 0')
       .thread-list-item-tags

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -22,3 +22,8 @@ answer5:
   description: テストの回答5です。
   user: komagata
   question: question6
+
+answer6:
+  description: コメント(回答)数表示テスト用の回答です。
+  user: machida
+  question: question14

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -23,7 +23,7 @@ answer5:
   user: komagata
   question: question6
 
-answer6:
+answer_for_comment_count:
   description: コメント(回答)数表示テスト用の回答です。
   user: machida
-  question: question14
+  question: question_for_comment_count

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -79,7 +79,7 @@ question13:
   user: hajime
   practice: practice1
 
-question14:
+question_for_comment_count:
   title: コメント数表示テスト用の質問
   description: こちらの質問はQ&A一覧ページでコメント(回答)がついているものにのみ「回答・コメント（コメント数）」という表示がついているかどうかのテスト用の質問です。
   user: komagata

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -78,3 +78,9 @@ question13:
   description: こちらの質問は検索ワードの表示に関するテスト用の質問です。検索ワードが太字で表示されるかのテスト。こちらの質問は検索ワードの表示に関するテスト用の質問です。
   user: hajime
   practice: practice1
+
+question14:
+  title: コメント数表示テスト用の質問
+  description: こちらの質問はQ&A一覧ページでコメント(回答)がついているものにのみ「回答・コメント（コメント数）」という表示がついているかどうかのテスト用の質問です。
+  user: komagata
+  practice: practice1

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -179,7 +179,7 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, comments(:comment13))
     assert_includes(result, comments(:comment14))
     assert_includes(result, comments(:comment16))
-    assert_equal(27, result.size)
+    assert_equal(29, result.size)
   end
 
   test 'returns only daimyos report when user param' do

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -258,9 +258,12 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_text 'Watch中'
   end
 
-  test 'number of comments' do
-    question = questions(:question6)
+  test 'show number of comments' do
     visit_with_auth questions_path, 'kimura'
-    assert_equal 1, question.answers.size
+    assert_text 'コメント数表示テスト用の質問'
+    element = all('.thread-list-item').find { |component| component.has_text?('コメント数表示テスト用の質問') }
+    within element do
+      assert_selector '.thread-list-item-comment__count', text: '（1）'
+    end
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -257,4 +257,10 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     assert_text 'Watch中'
   end
+
+  test 'number of comments' do
+    question = questions(:question6)
+    visit_with_auth questions_path, 'kimura'
+    assert_equal 1, question.answers.size
+  end
 end


### PR DESCRIPTION
## Issue
- #4036
 
## 概要
Q＆A一覧ページのそれぞれの質問についたコメント数(回答数)を表示させる変更作業を行いました。

## 変更確認方法
1. ブランチ `feature/add-number-of-comments-to-questions-list`をローカルに取り込む
2. `$ rails s` でローカル環境を立ち上げる
3. テスト用ユーザー(誰でもOK)でログインする
4. 左側のナビゲーションバーから「Q&A」をクリックしてQ&A一覧ページを開きます。
5. コメント(回答)がついている質問のみに「回答・コメント(コメント数)」が表示されますので、今回の変更点をご確認ください。 

## 変更【前】(「回答・コメント数」が表示されていなかった)のスクショ
- 未解決の質問一覧
![image](https://user-images.githubusercontent.com/82434093/151106267-f5fe4754-0541-4720-8bd9-69eed034c660.png)
- 解決済の質問一覧
![image](https://user-images.githubusercontent.com/82434093/151106367-1dfac027-0160-41af-9a8e-04aca44001fd.png)


## 変更【後】(コメントが付いている質問にのみ「回答・コメント数」が表示されるようになった)のスクショ
- 未解決の質問一覧
![image](https://user-images.githubusercontent.com/82434093/151106403-4bad93b7-2620-43bf-8ebe-5a8784237dbf.png)


- 解決済の質問一覧
![image](https://user-images.githubusercontent.com/82434093/151106238-b8ffa237-4554-4495-a96f-30d018658833.png)

## 表示の形式
今回のIssueでは下記のように吹き出しアイコンでご要望いただきましたが、
![image](https://user-images.githubusercontent.com/82434093/151789283-f677095d-decb-4d1b-8e48-67910237ed95.png)
以前のようにコメント数を表示させることを今回の修正ポイントとして、文字での「回答・コメント(n)」と表示しています。


