### PR TITLE
日報のプレビュー機能のテストを追加

### DIFF
--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -243,10 +243,3 @@ report30:
   description: |-
     頑張れませんでした
   reported_on: <%= Time.now - 1.month - 1.day %>
-
-report31:
-  user: kimura
-  title: "プレビュー用のテスト"
-  description:
-    プレビュー用のテストです。
-  reported_on: "2020-11-10"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -243,3 +243,10 @@ report30:
   description: |-
     頑張れませんでした
   reported_on: <%= Time.now - 1.month - 1.day %>
+
+report31:
+  user: kimura
+  title: "プレビュー用のテスト"
+  description:
+    プレビュー用のテストです。
+  reported_on: "2020-11-10"

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -567,7 +567,7 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test 'description of the daily report is previewed' do
-    visit_with_auth '/reports/new', 'kimura'
+    visit_with_auth '/reports/new', 'komagata'
     within('#new_report') do
       fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
     end
@@ -577,10 +577,9 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test 'description of the daily report is previewed when editing' do
-    report = reports(:report31)
-    visit_with_auth report_path(report), 'kimura'
+    visit_with_auth report_path(reports(:report1)), 'komagata'
     click_link '内容修正'
-    within("#edit_report_#{report.id}") do
+    within("#edit_report_#{reports(:report1).id}") do
       fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
     end
     assert_selector '.js-preview.is-long-text.markdown-form__preview', text: 'Markdown入力するとプレビューにHTMLで表示されている。' do
@@ -589,8 +588,7 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test 'description of the daily report is previewed when copied' do
-    report = reports(:report31)
-    visit_with_auth report_path(report), 'kimura'
+    visit_with_auth report_path(reports(:report1)), 'komagata'
     click_link 'コピー'
     within('#new_report') do
       fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -565,4 +565,14 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth report_path(reports(:report5)), 'kimura'
     assert_no_selector '#side-tabs-content-3'
   end
+
+  test 'description of the daily report is previewed' do
+    visit_with_auth '/reports/new', 'kimura'
+    within('#new_report') do
+      fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
+    end
+    assert_selector '.js-preview.is-long-text.markdown-form__preview', text: 'Markdown入力するとプレビューにHTMLで表示されている。' do
+      assert_selector 'h1', text: 'h1'
+    end
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -575,4 +575,28 @@ class ReportsTest < ApplicationSystemTestCase
       assert_selector 'h1', text: 'h1'
     end
   end
+
+  test 'description of the daily report is previewed when editing' do
+    report = reports(:report31)
+    visit_with_auth report_path(report), 'kimura'
+    click_link '内容修正'
+    within("#edit_report_#{report.id}") do
+      fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
+    end
+    assert_selector '.js-preview.is-long-text.markdown-form__preview', text: 'Markdown入力するとプレビューにHTMLで表示されている。' do
+      assert_selector 'h1', text: 'h1'
+    end
+  end
+
+  test 'description of the daily report is previewed when copied' do
+    report = reports(:report31)
+    visit_with_auth report_path(report), 'kimura'
+    click_link 'コピー'
+    within('#new_report') do
+      fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
+    end
+    assert_selector '.js-preview.is-long-text.markdown-form__preview', text: 'Markdown入力するとプレビューにHTMLで表示されている。' do
+      assert_selector 'h1', text: 'h1'
+    end
+  end
 end


### PR DESCRIPTION
## issue
- #3969 

## 概要
日報の不具合が再発しないようにテストを追加する。

## 不具合について
- [[解決済]🙇‍♂️ 日報編集画面で不具合が発生しています | FJORD BOOT CAMP（フィヨルドブートキャンプ）](https://bootcamp.fjord.jp/announcements/603)

## やったこと
「日報にMarkdownを入力すると、プレビューにHTMLで表示されている。」というシステムテストを追加しました。