### PR TITLE
ユーザー > 日報 のページのタイトルを変更

### DIFF
--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}"
+- title @user.login_name
 header.page-header
   .container
     .page-header__inner

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}の日報"
+- title "#{@user.login_name}"
 header.page-header
   .container
     .page-header__inner

--- a/test/system/user/reports_test.rb
+++ b/test/system/user/reports_test.rb
@@ -5,6 +5,6 @@ require 'application_system_test_case'
 class User::ReportsTest < ApplicationSystemTestCase
   test 'show listing reports' do
     visit_with_auth "/users/#{users(:hatsuno).id}/reports", 'hatsuno'
-    assert_equal 'hatsunoの日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal 'hatsuno | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 end


### PR DESCRIPTION
[#3705](https://github.com/fjordllc/bootcamp/issues/3705)
ユーザー > 日報のページのタイトルを変更しました。

## 変更前
<img width="1167" alt="Screen Shot 2022-01-27 at 22 33 03" src="https://user-images.githubusercontent.com/34033366/151390717-e75b5c7d-5261-495a-9163-76017a1efde0.png">

## 変更後
<img width="1163" alt="Screen Shot 2022-01-27 at 22 33 39" src="https://user-images.githubusercontent.com/34033366/151390824-2fde68eb-3fff-487f-99a5-9bdd538e8ee2.png">

## テスト
<img width="480" alt="Screen Shot 2022-01-27 at 22 34 15" src="https://user-images.githubusercontent.com/34033366/151390937-13d6dc5d-790e-47d6-b925-49692d2538d9.png">
