### PR TITLE
practice-selectでsubmitのhrefを編集

### DIFF
--- a/app/javascript/practice-select.vue
+++ b/app/javascript/practice-select.vue
@@ -62,7 +62,7 @@ export default {
     },
     submit() {
       this.$nextTick(() => {
-        location.href = `${location.pathname}?solved=${this.solved}&practice_id=${this.selected.id}&title=${this.selected.title}`
+        location.href = `${location.pathname}?all=true&solved=${this.solved}&practice_id=${this.selected.id}&title=${this.selected.title}`
       })
     }
   }


### PR DESCRIPTION
[#3306](https://github.com/fjordllc/bootcamp/issues/3306)
Q&A一覧の「全ての質問」タブでプラクティスによる絞り込みをすると、「未解決」タブに遷移してしまう問題
practice-selectでsubmitのhrefを編集した。

## 変更前
![134517439-b338caa8-a163-4de4-ba54-876c650cadb1](https://user-images.githubusercontent.com/34033366/152644297-d4ba3287-dbcd-4c36-bb3d-109ee69e4930.gif)

## 変更後
![Screen Recording 2022-02-05 at 20 55 02](https://user-images.githubusercontent.com/34033366/152644955-e6025b73-f709-4677-bda7-ac4464575cc0.gif)

