### PR TITLE
日報新規作成・編集画面で発生していたN+1を解消

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -11,7 +11,7 @@ class ReportsController < ApplicationController
   before_action :set_footprints, only: %i[show]
   before_action :set_footprint, only: %i[show]
   before_action :set_user, only: %i[show]
-  before_action :set_categories, only: %i[new create edit update]
+  before_action :set_categories, only: %i[create update]
   before_action :set_watch, only: %i[show]
 
   def index; end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -10,7 +10,8 @@ module ReportsHelper
   end
 
   def practice_options_within_course
-    current_user.course.categories.flat_map do |category|
+    user_course_categories = current_user.course.categories.includes(:practices)
+    user_course_categories.flat_map do |category|
       category.practices.map do |practice|
         ["[#{category.name}] #{practice.title}", practice.id]
       end

--- a/app/views/reports/edit.html.slim
+++ b/app/views/reports/edit.html.slim
@@ -8,4 +8,4 @@ header.page-header
         = title
 .page-body
   .container.is-xxxl
-    = render 'form', report: @report, categories: @categories
+    = render 'form', report: @report

--- a/app/views/reports/new.html.slim
+++ b/app/views/reports/new.html.slim
@@ -13,4 +13,4 @@ header.page-header
 
 .page-body
   .container.is-xxxl
-    = render 'form', report: @report, categories: @categories
+    = render 'form', report: @report


### PR DESCRIPTION
日報新規作成画面と編集画面で共通で呼ばれるpartialでN+1が発生していたので解消しました。
また、過去の変更の際に不要となったbefore_actionでのカテゴリーのselectがそのままで余分なクエリを発行していたので、新規作成画面・編集画面ではこのメソッドを呼び出さないようにしました。
