### PR TITLE
ウェルカムページのフッタの fjord.inc にリンクを貼る

### DIFF
--- a/app/assets/stylesheets/welcome/_welcome-footer.sass
+++ b/app/assets/stylesheets/welcome/_welcome-footer.sass
@@ -39,4 +39,9 @@
 
 .welcome-footer-copyright__author
   display: block
-  +margin(horizontal, .1em .5em)
+  +margin(horizontal, .5em)
+
+.welcome-footer-copyright__author-link
+  +hover-link
+  color: $default-text
+  margin-right: .5em

--- a/app/views/welcome/_welcome_footer.html.slim
+++ b/app/views/welcome/_welcome_footer.html.slim
@@ -20,5 +20,5 @@ footer.welcome-footer
     small.welcome-footer-copyright
       i.far.fa-copyright
       span.welcome-footer-copyright__author
-        = link_to 'Fjord Inc.', 'https://fjord.jp', target: '_blank', rel: 'noopener'
+        = link_to 'Fjord Inc.', 'https://fjord.jp', target: '_blank', rel: 'noopener', class: 'welcome-footer-copyright__author-link'
         | 2012 - #{Date.current.year}

--- a/app/views/welcome/_welcome_footer.html.slim
+++ b/app/views/welcome/_welcome_footer.html.slim
@@ -20,4 +20,5 @@ footer.welcome-footer
     small.welcome-footer-copyright
       i.far.fa-copyright
       span.welcome-footer-copyright__author
-        | Fjord Inc. 2012 - #{Date.current.year}
+        = link_to 'Fjord Inc.', 'https://fjord.jp', target: '_blank', rel: 'noopener'
+        | 2012 - #{Date.current.year}


### PR DESCRIPTION
## Issue
- #3751
 
## 概要
ウェルカムページのフッタの fjord.inc にリンクを貼る作業を行いました。

## 変更確認方法
1. ブランチ `feature/link-copyright-to-welcome-page`をローカルに取り込む
2. `$ rails s` でローカル環境を立ち上げる
3. フッターにfjord.incが表示されますので、今回の変更点をご確認ください。 

## 変更前
![bootcamp fjord jp_welcome](https://user-images.githubusercontent.com/69446373/151558450-3ded0d07-0430-4d94-9964-10fe250227f2.png)

## 変更後
![localhost_3000_](https://user-images.githubusercontent.com/69446373/151794122-6d92f255-20f7-4bef-a464-17e540531a4a.png)


## 参照
`app/views/application/_footer.html.slim`のフッタのリンク部分を参照しました