### PR TITLE
Failed to Parsingという文法のミスを含んだエラーメッセージを一掃した

### DIFF
--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -114,7 +114,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     destroy(company) {

--- a/app/javascript/announcements.vue
+++ b/app/javascript/announcements.vue
@@ -95,7 +95,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     getPageValueFromParameter() {
@@ -131,7 +131,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -225,7 +225,7 @@ export default {
           this.editing = false
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     deleteAnswer: function () {

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -121,7 +121,7 @@ export default {
         this.updateAnswerCount()
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
       .finally(() => {
         this.loaded = true
@@ -176,7 +176,7 @@ export default {
           this.toast('回答を投稿しました！')
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     deleteAnswer: function (id) {
@@ -207,7 +207,7 @@ export default {
           this.updateAnswerCount()
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     updateAnswer(description, id) {
@@ -247,7 +247,7 @@ export default {
           this.$emit('solveQuestion', answer)
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     cancelBestAnswer: function (id) {
@@ -258,7 +258,7 @@ export default {
           this.$emit('cancelSolveQuestion')
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     updateAnswerCount: function () {

--- a/app/javascript/bookmark-button.vue
+++ b/app/javascript/bookmark-button.vue
@@ -68,7 +68,7 @@ export default {
             }
           })
           .catch((error) => {
-            console.warn('Failed to parsing', error)
+            console.warn(error)
           })
       }
     },
@@ -95,7 +95,7 @@ export default {
           this.toast('Bookmarkしました！')
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     unbookmark() {
@@ -118,7 +118,7 @@ export default {
           this.$emit('update-index')
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/bookmarks.vue
+++ b/app/javascript/bookmarks.vue
@@ -102,7 +102,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     getPageValueFromParameter() {

--- a/app/javascript/categories-practice.vue
+++ b/app/javascript/categories-practice.vue
@@ -73,7 +73,7 @@ export default {
             }
           })
           .catch((error) => {
-            console.warn('Failed to parsing', error)
+            console.warn(error)
           })
       }
     }

--- a/app/javascript/categories.vue
+++ b/app/javascript/categories.vue
@@ -67,7 +67,7 @@ export default {
             }
           })
           .catch((error) => {
-            console.warn('Failed to parsing', error)
+            console.warn(error)
           })
       }
     }

--- a/app/javascript/category-select.js
+++ b/app/javascript/category-select.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   }
 

--- a/app/javascript/check-store.js
+++ b/app/javascript/check-store.js
@@ -67,7 +67,7 @@ export default new Vuex.Store({
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -100,7 +100,7 @@ export default {
           })
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     checkSad() {

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -196,7 +196,7 @@ export default {
           this.editing = false
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     deleteComment() {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -159,7 +159,7 @@ export default {
           this.commentTotalCount = json.comment_total_count
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
         .finally(() => {
           if (this.loaded === false) {
@@ -213,7 +213,7 @@ export default {
           this.toast('コメントを投稿しました！')
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     deleteComment(id) {
@@ -234,7 +234,7 @@ export default {
           })
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     updateComment(description, id) {
@@ -277,7 +277,7 @@ export default {
           return response.json()
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
           return null
         })
     },

--- a/app/javascript/companies.vue
+++ b/app/javascript/companies.vue
@@ -47,7 +47,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/company-users.vue
+++ b/app/javascript/company-users.vue
@@ -107,7 +107,7 @@ export default {
           this.totalPages = json.totalPages
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     getParams() {

--- a/app/javascript/courses-categories.vue
+++ b/app/javascript/courses-categories.vue
@@ -78,7 +78,7 @@ export default {
             }
           })
           .catch((error) => {
-            console.warn('Failed to parsing', error)
+            console.warn(error)
           })
       }
     }

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -112,7 +112,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/events.vue
+++ b/app/javascript/events.vue
@@ -71,7 +71,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     getCurrentPage() {

--- a/app/javascript/following.vue
+++ b/app/javascript/following.vue
@@ -132,7 +132,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
         .finally(() => {
           this.$refs.followingDetailsRef.open = false
@@ -162,7 +162,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
         .finally(() => {
           this.$refs.followingDetailsRef.open = false

--- a/app/javascript/generation-users.vue
+++ b/app/javascript/generation-users.vue
@@ -106,7 +106,7 @@ export default {
           this.totalPages = json.totalPages
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     getParams() {

--- a/app/javascript/github_grass.js
+++ b/app/javascript/github_grass.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
           grass.innerHTML = text
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     })
   }

--- a/app/javascript/learning-status.vue
+++ b/app/javascript/learning-status.vue
@@ -83,7 +83,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/learning.vue
+++ b/app/javascript/learning.vue
@@ -57,7 +57,7 @@ export default {
         }
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   },
   methods: {
@@ -87,7 +87,7 @@ export default {
           this.complete = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/markdown-it-task-lists-initializer.js
+++ b/app/javascript/markdown-it-task-lists-initializer.js
@@ -61,7 +61,7 @@ export default class {
         })
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   }
 }

--- a/app/javascript/memo.vue
+++ b/app/javascript/memo.vue
@@ -104,7 +104,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     updateMemo: function () {
@@ -142,7 +142,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     deleteMemo: function () {
@@ -167,7 +167,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/niconico_calendar.vue
+++ b/app/javascript/niconico_calendar.vue
@@ -153,7 +153,7 @@ export default {
         this.loaded = true
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   },
   methods: {

--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -104,7 +104,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     paginateClickCallback: function (pageNumber) {

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -81,7 +81,7 @@ export default {
         })
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   },
   methods: {

--- a/app/javascript/pages.vue
+++ b/app/javascript/pages.vue
@@ -96,7 +96,7 @@ export default {
           this.totalPages = parseInt(json.totalPages)
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/practice-select.vue
+++ b/app/javascript/practice-select.vue
@@ -57,7 +57,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     submit() {

--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -98,7 +98,7 @@ export default {
         }
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   },
   mounted() {
@@ -131,7 +131,7 @@ export default {
           this.memo = json.memo
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
       this.editing = false
     },
@@ -157,7 +157,7 @@ export default {
           this.toast('保存しました！')
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     editMemo() {

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -134,7 +134,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     getPageValueFromParameter() {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -273,7 +273,7 @@ export default {
           })
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     startEditing() {
@@ -334,7 +334,7 @@ export default {
           this.finishEditing(true)
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     cancel() {

--- a/app/javascript/question-page.vue
+++ b/app/javascript/question-page.vue
@@ -63,7 +63,7 @@ export default {
           this.question = question
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     fetchUser(id) {
@@ -82,7 +82,7 @@ export default {
           this.currentUser = user
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     solveQuestion(answer) {

--- a/app/javascript/question_tags.vue
+++ b/app/javascript/question_tags.vue
@@ -86,7 +86,7 @@ export default {
         this.autocompleteTags.push(...suggestions)
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   },
   methods: {
@@ -135,7 +135,7 @@ export default {
           this.editing = false
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     cancel() {

--- a/app/javascript/questions.vue
+++ b/app/javascript/questions.vue
@@ -102,7 +102,7 @@ export default {
           this.totalPages = parseInt(json.totalPages)
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/reaction.vue
+++ b/app/javascript/reaction.vue
@@ -101,7 +101,7 @@ export default {
           })
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     destroyReaction: function (kind) {
@@ -146,7 +146,7 @@ export default {
           )
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     footerReaction: function (kind) {

--- a/app/javascript/searchables.vue
+++ b/app/javascript/searchables.vue
@@ -95,7 +95,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     getPageValueFromParameter() {

--- a/app/javascript/subscription-status.js
+++ b/app/javascript/subscription-status.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
         })
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   }
 })

--- a/app/javascript/tags-input.vue
+++ b/app/javascript/tags-input.vue
@@ -69,7 +69,7 @@ export default {
         this.autocompleteTags.push(...suggestions)
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   },
   methods: {

--- a/app/javascript/tags.vue
+++ b/app/javascript/tags.vue
@@ -140,7 +140,7 @@ export default {
         redirect: 'manual',
         body: JSON.stringify(params)
       }).catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
     },
     token() {
@@ -165,7 +165,7 @@ export default {
       })
     },
     parseTagsError(error) {
-      console.warn('Failed to parsing', error)
+      console.warn(error)
     },
     editTag() {
       this.editing = true

--- a/app/javascript/talks.vue
+++ b/app/javascript/talks.vue
@@ -68,7 +68,7 @@ export default {
           this.loaded = true
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/user_mentor_memo.vue
+++ b/app/javascript/user_mentor_memo.vue
@@ -98,7 +98,7 @@ export default {
         }
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   },
   mounted() {
@@ -137,7 +137,7 @@ export default {
           return response
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     cancel() {
@@ -156,7 +156,7 @@ export default {
           this.memo = json.mentor_memo
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
       this.editing = false
     },

--- a/app/javascript/users.vue
+++ b/app/javascript/users.vue
@@ -103,7 +103,7 @@ export default {
           this.totalPages = json.totalPages
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     getParams() {

--- a/app/javascript/watch-toggle.vue
+++ b/app/javascript/watch-toggle.vue
@@ -51,7 +51,7 @@ export default {
           }
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   },
@@ -92,7 +92,7 @@ export default {
           this.toast('Watchしました！')
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     },
     unwatch() {
@@ -114,7 +114,7 @@ export default {
           this.$emit('update-index')
         })
         .catch((error) => {
-          console.warn('Failed to parsing', error)
+          console.warn(error)
         })
     }
   }

--- a/app/javascript/worried-users.vue
+++ b/app/javascript/worried-users.vue
@@ -56,7 +56,7 @@ export default {
         this.loaded = true
       })
       .catch((error) => {
-        console.warn('Failed to parsing', error)
+        console.warn(error)
       })
   },
   methods: {


### PR DESCRIPTION
- #3920 

# 変更前

![console warn(failed to parse, error)](https://user-images.githubusercontent.com/45246171/152644746-fe0ba6fe-68f7-438e-bf8d-9f4fc5f5c339.png)

chrome devtoolのコンソールのスクショ
![_4076のconsole_warn__Failed_to_parsing___error_と書いたとき](https://user-images.githubusercontent.com/45246171/152644487-288e6082-6cc6-4362-b4e9-0effd9b084ed.png)


# 変更後

![console warn(error)](https://user-images.githubusercontent.com/45246171/152644763-3fb26c4f-49d6-429d-86dd-a80496628877.png)

chrome devtoolのコンソールのスクショ
![_4076のconsole_warn_error_と書いたとき](https://user-images.githubusercontent.com/45246171/152644493-3dc8f155-5fd0-4e61-a071-fa20bc5f8331.png)

# 上記を確認するための再現方法

ファイルを一部改変してわざとエラーを起こすことで確認することができます
1. `app/javascript/announcements.vue` の `93行目`を`this.announcements.push(announcement)`から`this.announcements(announcement)` に一部改変する
`announcement.vue`でなくても任意のファイルを一部改変で大丈夫です
2. ChromeのDevToolのコンソール画面でスクショのようなエラー画面が確認できます

# やったこと

- jsファイルやvueファイルで使われているエラーを出す部分を、不要な部分を削って`console.warn(error)`となるように変更しました。

もともとはエラーメッセージを`Failed to Parse`に書き換える、というissueだったのですが[こちら](https://github.com/fjordllc/bootcamp/issues/3920#issuecomment-1021919886)のコメントのように、`Failed to Parse`すらも不要ということでしたので、`console.warn(error)` というふうに書き換えを行いました。