### PR TITLE
adminのroleだけを持ったテストユーザーの作成

### DIFF
--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -114,8 +114,8 @@ talk_fujiyasu:
   user: fujiyasu
   unreplied: false
 
-talk_ringo:
-  user: ringo
+talk_adminonly:
+  user: adminonly
   unreplied: false
 
 talk_daimyo-adviser:

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -632,23 +632,23 @@ fujiyasu:
   updated_at: "2021-01-01 00:00:28"
   created_at: "2021-01-01 00:00:28"
 
-ringo:
-  login_name: ringo
-  email: ringo@fjord.jp
+adminonly: # adminのroleだけを持ったユーザー
+  login_name: adminonly
+  email: adminonly@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
-  name: ringo apple
-  name_kana: 林檎 アップル
-  twitter_account: ringo
-  facebook_url: http://www.facebook.com/ringo
-  github_account: ringo
-  blog_url: http://ringo.org
-  description: "mentorではないadminユーザーです。"
+  name: アドミン 能美代
+  name_kana: アドミン ノミヨ
+  twitter_account: adminonly
+  facebook_url: http://www.facebook.com/adminonly
+  github_account: adminonly
+  blog_url: http://adminonly.org
+  description: "管理者権限のみを持つユーザーです(メンターではない)"
   course: course1
   job: office_worker
   os: mac
   experience: rails
-  organization: 株式会社りんご
+  organization: アドミン株式会社
   admin: true
   mentor: false
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -72,3 +72,7 @@ talk18:
 talk19:
   user: kensyuowata
   unreplied: false
+
+talk20:
+  user: adminonly
+  unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -49,6 +49,29 @@ machida:
   updated_at: "2014-01-01 00:00:02"
   created_at: "2014-01-01 00:00:02"
 
+adminonly: # adminのroleだけを持ったユーザー
+  login_name: adminonly
+  email: adminonly@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: アドミン 能美代
+  name_kana: アドミン ノミヨ
+  twitter_account: adminonly
+  facebook_url: http://www.facebook.com/adminonly
+  github_account: adminonly
+  blog_url: http://adminonly.org
+  description: "管理者権限のみを持つユーザーです(メンターではない)"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  organization: アドミン株式会社
+  admin: true
+  mentor: false
+  unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
+  updated_at: "2021-02-01 00:00:30"
+  created_at: "2021-02-01 00:00:30"
+
 sotugyou:
   login_name: sotugyou
   email: sotugyou@example.com


### PR DESCRIPTION
## Issue
- #4042 

## 概要
adminのroleだけを持ったテストユーザーを作成を作成しました。

- 元々`ringo`という名のadminのroleだけを持ったテストユーザーが既に存在したので、こちらを管理者のみと分かる`adminonly`という名前に変更しました。
- issueより今後テストを追加していく予定とのことで、``test/fixtures/users.yml``の方にもユーザーを追加しました。

## 変更確認方法
1. ブランチ `feature/rename-user-with-admin-only-roles-to-test-data`をローカルに取り込む
2.  `bin/setup`と`rails db:seed`を実行するとDBの内容が開発環境に反映されます
3. `$ rails s` でローカル環境を立ち上げる
4. テスト用ユーザー('komagata'で確認しました)でログインする
5. 検索ワードで`adminonly`と入力し、プロフィールページへのリンクが表示され`adminonly`というユーザーが確認できると思います。
(ユーザー一覧からは管理者のみというロールがないので注意が必要です)

## 変更前
![localhost_3000_users_921082810](https://user-images.githubusercontent.com/69446373/151702316-7f5936cd-96bf-4783-ac26-2bc77ee44c2d.png)

## 変更後
![localhost_3000_users_464878050 (1)](https://user-images.githubusercontent.com/69446373/151702328-d11d36e1-df1c-4085-bffb-7dd1b30a554a.png)

