### PR TITLE
管理者でログイン時にユーザー一覧の各ユーザーに相談部屋へのリンクを表示

### DIFF
--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -57,6 +57,10 @@
                 :userId='user.id',
                 :isWatching='user.isWatching'
               )
+          a.users-item__linkto_talk.is-only-admin(:href='user.talkurl')(
+            v-if='currentUser.admin'
+          )
+            | 相談部屋
 </template>
 <script>
 import Following from './following.vue'

--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -57,10 +57,9 @@
                 :userId='user.id',
                 :isWatching='user.isWatching'
               )
-          a.users-item__linkto_talk.is-only-admin(:href='user.talkurl')(
-            v-if='currentUser.admin'
-          )
-            | 相談部屋
+            li.card-main-actions__item.is-only-admin(v-if='currentUser.admin')
+              a.a-button.is-secondary.is-md.is-block(:href='user.talkurl')
+                | 相談部屋
 </template>
 <script>
 import Following from './following.vue'

--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -58,7 +58,7 @@
                 :isWatching='user.isWatching'
               )
             li.card-main-actions__item.is-only-admin(v-if='currentUser.admin')
-              a.a-button.is-secondary.is-md.is-block(:href='user.talkurl')
+              a.a-button.is-secondary.is-md.is-block(:href='user.talkUrl')
                 | 相談部屋
 </template>
 <script>

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -14,6 +14,7 @@ json.student_or_trainee user.student_or_trainee?
 json.edit_admin_user_path edit_admin_user_path(user)
 json.isFollowing current_user.following?(user)
 json.isWatching current_user.watching?(user)
+json.talkurl talk_path(user.talk)
 
 json.company do
   if user.company.present?

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -14,7 +14,7 @@ json.student_or_trainee user.student_or_trainee?
 json.edit_admin_user_path edit_admin_user_path(user)
 json.isFollowing current_user.following?(user)
 json.isWatching current_user.watching?(user)
-json.talkurl talk_path(user.talk)
+json.talkUrl talk_path(user.talk)
 
 json.company do
   if user.company.present?

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -236,4 +236,14 @@ class UsersTest < ApplicationSystemTestCase
     visit current_path
     assert_link(href: 'https://discord.com/channels/715806612824260640/123456789000000007')
   end
+
+  test 'only admin can see link to talk on user list page' do
+    visit_with_auth '/users', 'komagata'
+    assert_link '相談部屋'
+  end
+
+  test 'not admin cannot see link to talk on user list page' do
+    visit_with_auth '/users', 'kimura'
+    assert_no_link '相談部屋'
+  end
 end


### PR DESCRIPTION
## Issue
- #4069
 
## 概要
管理者でログインしたときのみ、ユーザー一覧ページのそれぞれのユーザーの枠内に相談部屋へのリンクを表示させる変更作業を行いました。

## お知らせ
このブランチの名前について、`feature/add-link-to-talk-on-user-list-only-mentor`となっていますが、最後のところは`only-admin`とするべきでした。間違いに気づいたのが遅かったためブランチ名を変更できませんでした。何とぞご了承ください。

## 変更確認方法
1. ブランチ `feature/add-link-to-talk-on-user-list-only-mentor`をローカルに取り込む
2. `$ rails s` でローカル環境を立ち上げる
3. テスト用ユーザー(管理者ロールを持っている'komagata''machida'のどちらか)でログインする
4. 左側のナビゲーションバーから「ユーザー」をクリックしてユーザー一覧ページを開きます。
5. それぞれのユーザーの枠内に「相談部屋」の文字と、それぞれの相談部屋へのリンクが付加されていることをご確認ください。
6. 一旦ログアウトして、次は'komagata''machida'以外のテスト用ユーザーでログインし、ユーザー一覧ページのそれぞれのユーザーの枠内に「相談部屋」の文字とリンクがないこともご確認ください。

## 変更【前】(「相談部屋」へのリンクが表示されていなかった)のスクショ
![image](https://user-images.githubusercontent.com/82434093/151663068-d77b8a94-462a-4811-85bb-f21947bbc545.png)

## 変更【後】(「相談部屋」へのリンクが表示されている)のスクショ
![image](https://user-images.githubusercontent.com/82434093/151797757-37f93e09-150c-4337-a491-aecd690f05a3.png)

