### PR TITLE
ダッシュボードのブックマークのタブに合計数を表示

### DIFF
--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -19,4 +19,4 @@
       - if user.bookmarks.present?
         li.page-tabs__item
           = link_to current_user_bookmarks_path, class: "page-tabs__item-link #{current_page_tab_or_not('bookmarks')}" do
-            | ブックマーク
+            | ブックマーク（#{user.bookmarks.length}）


### PR DESCRIPTION
ref #3749 
ダッシュボードのブックマークのタブに合計数を表示するようにしました。

## 変更前
![image](https://user-images.githubusercontent.com/58052292/151691651-677ea544-dec1-4206-9a6f-0a0d9d146a8e.png)

## 変更後

![image](https://user-images.githubusercontent.com/58052292/151691735-bc1ed938-81ac-47ba-9f40-08e9a5f34091.png)


