### PR TITLE
chore: bullet v7.0.1にアップグレード

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
-    bullet (6.1.3)
+    bullet (7.0.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     bundle_outdated_formatter (0.7.0)


### PR DESCRIPTION
Rails 7.0に対応しているバージョンにアップグレードします。

diff: https://github.com/flyerhzm/bullet/compare/6.1.3...7.0.1