### PR TITLE
chore: meta-tags v2.16.0にアップグレード

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,8 +242,8 @@ GEM
     mentionable (0.2.1)
       activerecord
       railties
-    meta-tags (2.14.0)
-      actionpack (>= 3.2.0, < 6.2)
+    meta-tags (2.16.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mini_magick (4.11.0)
     mini_mime (1.1.1)


### PR DESCRIPTION
Rails 7.0にアップグレードする準備のため。

diff: https://github.com/kpumuk/meta-tags/compare/v2.14.0...v2.16.0