### PR TITLE
フォロー機能に一意制約のバリデーションを追加

### DIFF
--- a/app/models/following.rb
+++ b/app/models/following.rb
@@ -3,6 +3,6 @@
 class Following < ApplicationRecord
   belongs_to :follower, class_name: 'User'
   belongs_to :followed, class_name: 'User'
-  validates :follower_id, presence: true
+  validates :follower_id, presence: true, uniqueness: { scope: :followed_id, message: '設定が重複しています' }
   validates :followed_id, presence: true
 end


### PR DESCRIPTION
# Issue: #3739 

## 対象
ユーザーAがユーザーBをフォローする際の操作で高速に2回クリックした場合、または、別のブラウザでユーザーBのページが開いており、片方でフォロー操作を行った後に他方でもフォロー操作を行うとDBに2回登録され、DB側で一意制約エラーが出る（月1回程度）

![image](https://user-images.githubusercontent.com/39044468/151889328-6a1382a5-f1c1-46c6-b9c6-2f022abdf4cf.png)


## 機能
フォロワーの追加に関してアプリ側にバリデーションを追加（DB側には既に一意制約が設定されています）
→上記のポップアップが出なくなりますが、以下のログの通り、2回目の登録がロールバックされます。
![image](https://user-images.githubusercontent.com/39044468/151889794-1e43075e-4a44-408a-922a-7fb0aee47bc2.png)


## テスト
なし（メニューを展開し、「コメントあり／なし」をクリックしてからメニューが閉じてしまう前に再度クリックする、というテストができないため（capybaraでダブルクリックしてみましたがダメでした））