### PR TITLE
開発環境で相談部屋一覧が表示されないバグを修正

### DIFF
--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -119,7 +119,7 @@ talk_ringo:
   unreplied: false
 
 talk_daimyo-adviser:
-  user: dimyo-adviser
+  user: daimyo-adviser
   unreplied: false
 
 talk_daimyo-kensyu:


### PR DESCRIPTION
## issue

- #4097 

## 概要

管理者でログインし、相談部屋をクリックすると、相談部屋一覧が表示されるようにする。

## 確認手順

1.`bug/the-list-of-talks-rooms-is-not-displayed`ブランチでcheckoutまたは、任意のブランチにpullする。
2.`rails db:seed`を行う。
3.管理者でログインする。
4.「相談部屋」をクリックする。
5.相談部屋一覧が表示されることを確認する。

## 修正前

管理者でログインし、相談部屋をクリックすると、相談部屋一覧が表示されない。

![image](https://user-images.githubusercontent.com/66904873/151762683-6abb1683-2438-4818-8b77-cbf7beb0e7b2.png)

## 修正後

管理者でログインし、相談部屋をクリックすると、相談部屋一覧が表示される。

![image](https://user-images.githubusercontent.com/66904873/151762554-bcb88b94-2b49-4e17-900b-58eacaa45856.png)
