### PR TITLE
Rubocop の Lint/IneffectiveAccessModifier の警告に対応

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -252,6 +252,17 @@ class Notification < ApplicationRecord
         read: false
       )
     end
+
+    def product_update(product, receiver)
+      Notification.create!(
+        kind: 17,
+        user: receiver,
+        sender: product.user,
+        link: Rails.application.routes.url_helpers.polymorphic_path(product),
+        message: "#{product.user.login_name}さんの提出物が更新されました",
+        read: false
+      )
+    end
   end
 
   def unread?
@@ -267,16 +278,5 @@ class Notification < ApplicationRecord
   def other_duplicates(scope: [])
     duplicates = scope.inject(Notification.all) { |notifications, scope_item| notifications.where(scope_item => self[scope_item]) }
     duplicates.where.not(id: id)
-  end
-
-  def self.product_update(product, receiver)
-    Notification.create!(
-      kind: 17,
-      user: receiver,
-      sender: product.user,
-      link: Rails.application.routes.url_helpers.polymorphic_path(product),
-      message: "#{product.user.login_name}さんの提出物が更新されました",
-      read: false
-    )
   end
 end


### PR DESCRIPTION
Rubocop のチェックが通らなくて CI が通らないようになっているため、対応しました。


## やったこと

次のメソッド `Notification.product_update` が public なクラスメソッドと扱われるようにメソッドの定義場所を移した

https://github.com/fjordllc/bootcamp/blob/40b23bc617069869ce325b2ac6966a19976087ca/app/models/notification.rb#L272-L281

## Rubocop を実行したときのログ

### 修正前

```
$ bundle exec rubocop -A app/models/notification.rb
Inspecting 1 file
W

Offenses:

app/models/notification.rb:272:3: W: Lint/IneffectiveAccessModifier: private (on line 265) does not make singleton methods private. Use private_class_method or private inside a class << self block instead.
  def self.product_update(product, receiver)
  ^^^

1 file inspected, 1 offense detected
```

### 修正後

```
$ bundle exec rubocop -A app/models/notification.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```

## 考えたこと

Rubocop のチェックが通らなかった [Lint/IneffectiveAccessModifier](https://docs.rubocop.org/rubocop/cops_lint.html#lintineffectiveaccessmodifier) では `private` なクラスメソッドの定義の仕方について指摘されている。
しかしその対象のメソッド `Notification.product_update` は、次のコードのとおり外から呼び出されているため、 `private` として扱いたいという意図はないと考えた。

https://github.com/fjordllc/bootcamp/blob/40b23bc617069869ce325b2ac6966a19976087ca/app/models/notification_facade.rb#L23-L26

そのため Lint/IneffectiveAccessModifier の警告どおりには修正せず（つまり private としてではなく）public なクラスメソッドとして扱われるようにメソッドの定義場所を移した。