### PR TITLE
相談部屋のグローバルナビに未返信のコメント数を表示させるようにした

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -68,4 +68,7 @@ nav.global-nav
             = link_to talks_link, class: "global-nav-links__link #{current_link(/talk/)}" do
               .global-nav-links__link-icon
                 i.fas.fa-comment-alt-smile
+              - if admin_or_mentor_login? && Talk.unreplied.count.positive?
+                .global-nav__item-count.a-notification-count.is-only-mentor
+                  = Talk.unreplied.count
               .global-nav-links__link-label 相談

--- a/app/views/talks/_tabs.html.slim
+++ b/app/views/talks/_tabs.html.slim
@@ -6,3 +6,6 @@
       li.page-tabs__item
         = link_to talks_unreplied_index_path, class: "page-tabs__item-link #{current_link(/^talks-unreplied-index/)}" do
           | 未返信
+          - if admin_or_mentor_login? && Talk.unreplied.count.positive?
+            .page-tabs__item-count.a-notification-count
+              = Talk.unreplied.count

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -66,21 +66,28 @@ class Notification::TalkTest < ApplicationSystemTestCase
     end
   end
 
-  test 'The number of unreplied comments is displayed in the global navigation of the talks room' do
-    visit_with_auth '/', 'komagata'
-    within(:css, "a[href='/talks']") do
-      assert_selector '.global-nav__item-count.a-notification-count.is-only-mentor', count: 1
+  test 'The number of unreplied comments is displayed in the global navigation and unreplied tab of the talks room' do
+    visit_with_auth '/talks/unreplied', 'komagata'
+    within(:css, '.global-nav') do
+      within(:css, "a[href='/talks']") do
+        assert_selector '.global-nav__item-count.a-notification-count.is-only-mentor', count: 1
+      end
     end
+    assert_selector '.page-tabs__item-count.a-notification-count', count: 1
+
     talk_id = users(:with_hyphen).talk.id
     visit_with_auth "/talks/#{talk_id}", 'komagata'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')
     end
     click_button 'コメントする'
-    # refreshはブラウザをリロードするメソッド
-    refresh
-    within(:css, "a[href='/talks']") do
-      assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'
+
+    visit '/talks/unreplied'
+    within(:css, '.global-nav') do
+      within(:css, "a[href='/talks'") do
+        assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'
+      end
     end
+    assert_no_selector '.page-tabs__item-count.a-notification-count'
   end
 end

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -65,4 +65,22 @@ class Notification::TalkTest < ApplicationSystemTestCase
       assert_text 'komagataさんからコメントが届きました。'
     end
   end
+
+  test 'The number of unreplied comments is displayed in the global navigation of the talks room' do
+    visit_with_auth '/', 'komagata'
+    within(:css, "a[href='/talks']") do
+      assert_selector '.global-nav__item-count.a-notification-count.is-only-mentor', count: 1
+    end
+    talk_id = users(:with_hyphen).talk.id
+    visit_with_auth "/talks/#{talk_id}", 'komagata'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    click_button 'コメントする'
+    # refreshはブラウザをリロードするメソッド
+    refresh
+    within(:css, "a[href='/talks']") do
+      assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'
+    end
+  end
 end


### PR DESCRIPTION
## issue

- #4085 

## 概要

管理者でログインしたとき、相談部屋で未返信のコメントがある場合、相談部屋のグローバルナビに未返信の相談部屋数が表示されるようにする。

**※追記(2/9)**
未返信タブにも未返信の相談部屋数が表示されるようにしました。

## 変更前

未返信のコメントがある時、相談部屋のグローバルナビに未返信の相談部屋数が表示されていない。& 未返信タブにも数字が表示されていない。

![image](https://user-images.githubusercontent.com/66904873/153200000-b4b8b1f3-0034-45fc-ae27-13a193c8d40f.png)

## 変更後

- 未返信のコメントがある時、相談部屋のグローバルナビに未返信の相談部屋数が表示されている。& 未返信タブにも数字が表示されている。

![image](https://user-images.githubusercontent.com/66904873/153199542-e9e8f44a-979d-4c9b-a167-de38919baadc.png)

- 未返信のコメントがないときは表示されない。

![image](https://user-images.githubusercontent.com/66904873/153200244-acb781cb-5d68-4135-9c36-730e59fa0e2b.png)

## 確認手順

1.admin権限を持つユーザーでログイン
2.相談部屋で未返信のコメントがある時、相談部屋のグローバルナビと未返信タブに未返信の相談部屋数が表示されていることを確認する。
3.未返信のコメントがない時は、相談部屋のグローバルナビと未返信タブに未返信の相談部屋数が表示されないことを確認する。
