### PR TITLE
ユーザー > ポートフォリオ のページのタイトルを変更

### DIFF
--- a/app/views/users/works/index.html.slim
+++ b/app/views/users/works/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}"
+- title @user.login_name
 header.page-header
   .container
     .page-header__inner

--- a/app/views/users/works/index.html.slim
+++ b/app/views/users/works/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}のポートフォリオ"
+- title "#{@user.login_name}"
 header.page-header
   .container
     .page-header__inner

--- a/test/system/user/works_test.rb
+++ b/test/system/user/works_test.rb
@@ -5,6 +5,6 @@ require 'application_system_test_case'
 class User::WorksTest < ApplicationSystemTestCase
   test 'show portfolio' do
     visit_with_auth "/users/#{users(:hatsuno).id}/portfolio", 'hatsuno'
-    assert_equal 'hatsunoのポートフォリオ | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal 'hatsuno | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 end


### PR DESCRIPTION
## issue #3704 

### 変更前
![image](https://user-images.githubusercontent.com/83743223/152121107-f91d9dc6-3d28-4c40-b191-21d8aef2b77a.png)

### 変更後
![image](https://user-images.githubusercontent.com/83743223/152121212-d0bf7774-0e86-4f9f-8e05-4973e71c8451.png)

### ローカルでの確認方法
- `feature/change-user-portfolio-page-title`  ブランチをローカル環境で起動する
- ユーザーログインする
- 画面右上の Me をクリック → 自分のプロフィール をクリック
- ポートフォリオ のタブをクリック