### PR TITLE
Searcher モデルの Flaky なテストを修正

### DIFF
--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -98,6 +98,7 @@ report12:
   description:
     今年で150歳でーす
   reported_on: "2020-01-01"
+  updated_at: "2020-01-01 00:00:00"
   created_at: "2020-01-01 00:00:00"
 
 report13:
@@ -106,6 +107,7 @@ report13:
   description:
     きたるべき20世紀
   reported_on: "1900-01-01"
+  updated_at: "1900-01-01 00:00:00"
   created_at: "1900-01-01 00:00:00"
 
 report14:
@@ -114,6 +116,7 @@ report14:
   description:
     あれから100年か
   reported_on: "2000-01-01"
+  updated_at: "2000-01-01 00:00:00"
   created_at: "2000-01-01 00:00:00"
 
 report15:

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -63,7 +63,7 @@ class SearchableTest < ActiveSupport::TestCase
 
   test 'sort search results in descending order of updated date' do
     result = Searcher.search('検索結果確認用', document_type: :reports)
-    assert_equal [reports(:report14), reports(:report13), reports(:report12)], result
+    assert_equal [reports(:report12), reports(:report14), reports(:report13)], result
     assert_not_includes(result, Answer)
   end
 


### PR DESCRIPTION
## 目的

次の Flaky なテストを常に成功させるため、検索結果の並び順が一意に定まるようにする

https://github.com/fjordllc/bootcamp/blob/b0660032c128e9724ab161525fab0a87406ca697/test/models/searcher_test.rb#L64-L68

## 調査したこと

### このテストで確認していること

検索結果が次のコードで指定されている `.sort_by(&:updated_at).reverse` の順番になっていること

https://github.com/fjordllc/bootcamp/blob/b0660032c128e9724ab161525fab0a87406ca697/app/models/searcher.rb#L56-L58

### テストが Flaky な原因

検索結果の `reports(:report12), reports(:report14), reports(:report13)` のフィクスチャに `updated_at` が設定されていないため、すべて  `updated_at` が同値となり、 `sort_by(&:updated_at)`  の結果が一意に定まらないため

## やったこと

検索結果の `reports(:report12), reports(:report14), reports(:report13)` それぞれのフィクスチャに `updated_at` の値を設定した
なお、`updated_at` の値はそれぞれの `created_at` の値と同じにした
