### PR TITLE
日報が0件の場合、日報ダウンロードボタンを非表示に修正

### DIFF
--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -16,9 +16,10 @@ header.page-header
 .page-body
   .container.is-md
     #js-reports(data-user-id="#{current_user.id}")
-    .form-actions
-      ul.form-actions__items
-        li.form-actions__item.is-main
-          = link_to current_user_reports_path(format: :md), class: 'a-button is-md is-primary is-block' do
-            i.fas.fa-cloud-download-alt
-            | 日報一括ダウンロード
+    - if current_user.reports.present?
+      .form-actions
+        ul.form-actions__items
+          li.form-actions__item.is-main
+            = link_to current_user_reports_path(format: :md), class: 'a-button is-md is-primary is-block' do
+              i.fas.fa-cloud-download-alt
+              | 日報一括ダウンロード

--- a/test/system/current_user/reports_test.rb
+++ b/test/system/current_user/reports_test.rb
@@ -8,13 +8,13 @@ class CurrentUser::ReportsTest < ApplicationSystemTestCase
     assert_equal '自分の日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
-  test 'show reports download btn when reports exist' do
+  test 'show reports download button when reports exist' do
     # 日報があるユーザーでログイン
     visit_with_auth '/current_user/reports', 'hatsuno'
     assert_text '日報一括ダウンロード'
   end
 
-  test 'not show reports download btn when no reports' do
+  test 'not show reports download button when no reports' do
     # 日報がないユーザーでログイン
     visit_with_auth '/current_user/reports', 'nippounashi'
     assert_no_text '日報一括ダウンロード'

--- a/test/system/current_user/reports_test.rb
+++ b/test/system/current_user/reports_test.rb
@@ -7,4 +7,16 @@ class CurrentUser::ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/current_user/reports', 'hatsuno'
     assert_equal '自分の日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
+
+  test 'show reports download btn when reports is present' do
+    # 日報があるユーザーでログイン
+    visit_with_auth '/current_user/reports', 'hatsuno'
+    assert_text '日報一括ダウンロード'
+  end
+
+  test 'not show reports download btn when no reports' do
+    # 日報がないユーザーでログイン
+    visit_with_auth '/current_user/reports', 'nippounashi'
+    assert_no_text '日報一括ダウンロード'
+  end
 end

--- a/test/system/current_user/reports_test.rb
+++ b/test/system/current_user/reports_test.rb
@@ -8,7 +8,7 @@ class CurrentUser::ReportsTest < ApplicationSystemTestCase
     assert_equal '自分の日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
-  test 'show reports download btn when reports is present' do
+  test 'show reports download btn when reports exist' do
     # 日報があるユーザーでログイン
     visit_with_auth '/current_user/reports', 'hatsuno'
     assert_text '日報一括ダウンロード'


### PR DESCRIPTION
## Issue #4113
### 変更前
![image](https://user-images.githubusercontent.com/83743223/152472174-9ef8b465-16e4-4b5f-8a32-383db6a17493.png)

### 変更後
![image](https://user-images.githubusercontent.com/83743223/152472222-c83d225c-1160-49a5-9404-6314c57195dc.png)

### ローカル環境での確認方法
- `feature/not-display-report-dl-btn-when-no-reports` ブランチをローカル環境で起動する
- 日報ダウンロードボタンの表示を確認
  -  ユーザー `hajime` でログイン
  - ダッシュボード > 自分の日報 を確認
- 日報ダウンロードボタンの非表示を確認
  -  ユーザー `kananashi` でログイン
  - ダッシュボード > 自分の日報 を確認