### PR TITLE
通知のタイトルを確認する Flaky なシステムテストを修正

### DIFF
--- a/test/supports/notification_helper.rb
+++ b/test/supports/notification_helper.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 module NotificationHelper
-  def open_notification
-    sleep 1
-    first('.test-bell').click
-  end
-
   def notification_message
     first('.test-notification-message').text
   end

--- a/test/system/notification/after_retirement.rb
+++ b/test/system/notification/after_retirement.rb
@@ -5,10 +5,10 @@ require 'application_system_test_case'
 class Notification::AfterRetirementTest < ApplicationSystemTestCase
   test 'three months have passed since user retired' do
     visit_with_auth '/scheduler/daily', 'komagata'
+    visit '/notifications'
 
-    visit '/'
-    open_notification
-    assert_equal 'taikai3さんが退会してから3カ月が経過しました。Discord ID: taikai#3333, ユーザーページ: https://bootcamp.fjord.jp/users/1008501353',
-                 notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_text 'taikai3さんが退会してから3カ月が経過しました。Discord ID: taikai#3333, ユーザーページ: https://bootcamp.fjord.jp/users/1008501353'
+    end
   end
 end

--- a/test/system/notification/announcements_test.rb
+++ b/test/system/notification/announcements_test.rb
@@ -20,12 +20,11 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
       click_button '作成'
     end
 
-    logout
+    visit_with_auth '/notifications', 'sotugyou'
 
-    visit_with_auth '/', 'sotugyou'
-    open_notification
-    assert_equal @notice_text, notification_message
-    logout
+    within first('.thread-list-item.is-unread') do
+      assert_text @notice_text
+    end
 
     visit_with_auth '/', 'komagata'
     refute_text @notice_text

--- a/test/system/notification/answers_test.rb
+++ b/test/system/notification/answers_test.rb
@@ -7,7 +7,7 @@ class Notification::AnswersTest < ApplicationSystemTestCase
     @notice_text = 'komagataさんから回答がありました。'
   end
 
-  test "recieve a notification when I got my question's answer" do
+  test "receive a notification when I got my question's answer" do
     visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
     within('.thread-comment-form__form') do
       fill_in('answer[description]', with: 'reduceも使ってみては？')

--- a/test/system/notification/answers_test.rb
+++ b/test/system/notification/answers_test.rb
@@ -13,13 +13,12 @@ class Notification::AnswersTest < ApplicationSystemTestCase
       fill_in('answer[description]', with: 'reduceも使ってみては？')
     end
     click_button 'コメントする'
-    wait_for_vuejs
-    logout
 
-    visit_with_auth '/', 'sotugyou'
-    open_notification
-    assert_equal @notice_text, notification_message
-    logout
+    visit_with_auth '/notifications', 'sotugyou'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text @notice_text
+    end
 
     visit_with_auth '/', 'komagata'
     refute_text @notice_text

--- a/test/system/notification/comments_test.rb
+++ b/test/system/notification/comments_test.rb
@@ -13,12 +13,11 @@ class Notification::CommentsTest < ApplicationSystemTestCase
     wait_for_vuejs
     assert_text '@machida @machida test'
 
-    logout
-    login_user 'machida', 'testtest'
+    visit_with_auth '/notifications', 'machida'
 
-    open_notification
-    assert_equal 'komagataさんの日報「作業週1日目」へのコメントでkomagataさんからメンションがきました。',
-                 notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_text 'komagataさんの日報「作業週1日目」へのコメントでkomagataさんからメンションがきました。'
+    end
     assert_selector '.header-notification-count', text: '1'
   end
 end

--- a/test/system/notification/events_test.rb
+++ b/test/system/notification/events_test.rb
@@ -9,13 +9,12 @@ class Notification::EventsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '参加を取り消す'
     end
-    sleep 1
-    logout
 
-    login_user 'hatsuno', 'testtest'
-    open_notification
-    assert_equal "#{event.title}で、補欠から参加に繰り上がりました。",
-                 notification_message
+    visit_with_auth '/notifications', 'hatsuno'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text "#{event.title}で、補欠から参加に繰り上がりました。"
+    end
   end
 
   test 'waiting user receive notification when the event capacity is increased' do
@@ -25,11 +24,11 @@ class Notification::EventsTest < ApplicationSystemTestCase
 
     fill_in 'event_capacity', with: 2
     click_button '内容変更'
-    logout
 
-    login_user 'hatsuno', 'testtest'
-    open_notification
-    assert_equal "#{event.title}で、補欠から参加に繰り上がりました。",
-                 notification_message
+    visit_with_auth '/notifications', 'hatsuno'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text "#{event.title}で、補欠から参加に繰り上がりました。"
+    end
   end
 end

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -13,17 +13,17 @@ class Notification::PagesTest < ApplicationSystemTestCase
     end
     click_button '内容を保存'
 
-    logout
-    login_user 'hatsuno', 'testtest'
-    open_notification
-    assert_equal 'komagataさんがDocsにDocsTestを投稿しました。',
-                 notification_message
+    visit_with_auth '/notifications', 'hatsuno'
 
-    logout
-    login_user 'machida', 'testtest'
-    open_notification
-    assert_equal 'komagataさんがDocsにDocsTestを投稿しました。',
-                 notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_text 'komagataさんがDocsにDocsTestを投稿しました。'
+    end
+
+    visit_with_auth '/notifications', 'machida'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text 'komagataさんがDocsにDocsTestを投稿しました。'
+    end
 
     logout
     visit_with_auth '/notifications', 'yameo'
@@ -52,10 +52,10 @@ class Notification::PagesTest < ApplicationSystemTestCase
     click_link '内容変更'
     click_button '内容を保存'
 
-    logout
-    login_user 'machida', 'testtest'
-    open_notification
-    assert_equal 'komagataさんがDocsにWIPのテストを投稿しました。',
-                 notification_message
+    visit_with_auth '/notifications', 'machida'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text 'komagataさんがDocsにWIPのテストを投稿しました。'
+    end
   end
 end

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -12,12 +12,11 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     click_button '提出する'
     assert_text "7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\nもし、7日以上経ってもレビューされない場合は、メンターにお問い合わせください。"
 
-    logout
-    login_user 'senpai', 'testtest'
+    visit_with_auth '/notifications', 'senpai'
 
-    open_notification
-    assert_equal "kensyuさんが「#{practices(:practice5).title}」の提出物を提出しました。",
-                 notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_text "kensyuさんが「#{practices(:practice5).title}」の提出物を提出しました。"
+    end
   end
 
   test 'update product notificationmessage' do
@@ -29,11 +28,11 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     end
     click_button '提出する'
     assert_text '提出物を更新しました。'
-    logout
 
-    login_user 'komagata', 'testtest'
-    open_notification
-    assert_equal 'kimuraさんの提出物が更新されました',
-                 notification_message
+    visit_with_auth '/notifications', 'komagata'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text 'kimuraさんの提出物が更新されました'
+    end
   end
 end

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -19,12 +19,12 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     first('.select2-selection--single').click
     find('li', text: '[Mac OS X] OS X Mountain Lionをクリーンインストールする').click
     click_button '登録する'
-    logout
 
-    login_user 'yamada', 'testtest'
-    open_notification
-    assert_equal @notice_text, notification_message
-    logout
+    visit_with_auth '/notifications', 'yamada'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text @notice_text
+    end
 
     assert_equal @notified_count + @mentor_count, Notification.where(kind: @notice_kind).size
   end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -185,11 +185,10 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
 
-    logout
+    visit_with_auth '/notifications', mentor
 
-    login_user mentor, 'testtest'
-    open_notification
-
-    assert_equal "#{student}さんが2回連続でsadアイコンの日報を提出しました。", notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_text "#{student}さんが2回連続でsadアイコンの日報を提出しました。"
+    end
   end
 end

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -15,11 +15,11 @@ class Notification::TalkTest < ApplicationSystemTestCase
     wait_for_vuejs
     assert_text 'test'
 
-    logout
-    login_user 'machida', 'testtest'
+    visit_with_auth '/notifications', 'machida'
 
-    open_notification
-    assert_equal 'kimuraさんからコメントが届きました。', notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_text 'kimuraさんからコメントが届きました。'
+    end
   end
 
   test 'Admin except myself receive a notification when other admin comments on a talk room' do
@@ -33,15 +33,18 @@ class Notification::TalkTest < ApplicationSystemTestCase
     click_button 'コメントする'
     wait_for_vuejs
     assert_text 'test'
-    visit '/'
-    open_notification
-    assert_no_text 'komagataさんからコメントが届きました。'
 
-    logout
-    login_user 'machida', 'testtest'
+    visit '/notifications'
 
-    open_notification
-    assert_equal 'komagataさんからコメントが届きました。', notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_no_text 'komagataさんからコメントが届きました。'
+    end
+
+    visit_with_auth '/notifications', 'machida'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text 'komagataさんからコメントが届きました。'
+    end
   end
 
   test 'Receive a notification when someone except myself comments on my talk room' do
@@ -56,10 +59,10 @@ class Notification::TalkTest < ApplicationSystemTestCase
     wait_for_vuejs
     assert_text 'test'
 
-    logout
-    login_user 'kimura', 'testtest'
+    visit_with_auth '/notifications', 'kimura'
 
-    open_notification
-    assert_equal 'komagataさんからコメントが届きました。', notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_text 'komagataさんからコメントが届きました。'
+    end
   end
 end

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -19,19 +19,18 @@ class Notification::WatchesTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: 'コメントありがとうございます。')
     end
     click_button 'コメントする'
-    wait_for_vuejs
-    logout
 
-    login_user 'kimura', 'testtest'
-    open_notification
-    assert_equal "komagataさんの【 「#{reports(:report1).title}」の日報 】にkomagataさんがコメントしました。",
-                 notification_message
+    visit_with_auth '/notifications', 'kimura'
 
-    login_user 'machida', 'testtest'
-    open_notification
+    within first('.thread-list-item.is-unread') do
+      assert_text "komagataさんの【 「#{reports(:report1).title}」の日報 】にkomagataさんがコメントしました。"
+    end
 
-    assert_equal "komagataさんの【 「#{reports(:report1).title}」の日報 】にkomagataさんがコメントしました。",
-                 notification_message
+    visit_with_auth '/notifications', 'machida'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text "komagataさんの【 「#{reports(:report1).title}」の日報 】にkomagataさんがコメントしました。"
+    end
   end
 
   test '質問作成者がコメントをした際、ウォッチ通知が飛ばないバグの再現' do
@@ -50,17 +49,17 @@ class Notification::WatchesTest < ApplicationSystemTestCase
       fill_in('answer[description]', with: '質問へのご回答ありがとうございます。')
     end
     click_button 'コメントする'
-    wait_for_vuejs
-    logout
 
-    login_user 'kimura', 'testtest'
-    open_notification
-    assert_equal "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんがコメントしました。",
-                 notification_message
+    visit_with_auth '/notifications', 'kimura'
 
-    login_user 'komagata', 'testtest'
-    open_notification
-    assert_equal "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんがコメントしました。",
-                 notification_message
+    within first('.thread-list-item.is-unread') do
+      assert_text "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんがコメントしました。"
+    end
+
+    visit_with_auth '/notifications', 'komagata'
+
+    within first('.thread-list-item.is-unread') do
+      assert_text "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんがコメントしました。"
+    end
   end
 end


### PR DESCRIPTION
## 目的

`NotificationHelper.open_notification` を使っている次のようなテストが落ちやすいため、常に成功するようにすること

https://github.com/fjordllc/bootcamp/blob/b13c596dec1caf48ec1bd46a44ecf135e93cee8c/test/system/notification/after_retirement.rb#L6-L13

## 調べたこと

### `NotificationHelper.open_notification` の処理内容

https://github.com/fjordllc/bootcamp/blob/b13c596dec1caf48ec1bd46a44ecf135e93cee8c/test/supports/notification_helper.rb#L4-L7

 画面右上のベルマークをクリックしている

![image](https://user-images.githubusercontent.com/15713392/152320825-1e72e683-e7d5-4f0a-ae11-a92628273066.png)

### `NotificationHelper.open_notification` を使うとテストが落ちやすくなる原因として考えたこと

ローカルでは再現できなかったため確かなことはわかっていないものの、このメソッドの中で `sleep 1` を実行していることから Flaky な処理であると推測でき、CI では次のように「ベルマークをクリックできていれば表示されるはずの通知」が表示されていないというエラーが起きているため、ベルマークをうまくクリックできないことがあると考えた

`Capybara::ExpectationNotMet: expected to find css ".test-notification-message" at least 1 time but there were no matches` 
引用元: https://github.com/fjordllc/bootcamp/runs/5048373741?check_suite_focus=true

## やったこと

ベルマークをクリックしなくても目的の通知のタイトルを確認できるようにした
具体的には、通知一覧ページに表示されている最初の通知のタイトルを確認するようにした