### PR TITLE
テストが落ちないようにするため、otameshi ユーザーの talk をフィクスチャに追加

### DIFF
--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -157,3 +157,7 @@ talk_thuynga:
 talk_sotugyou-adviser:
   user: sotugyou-adviser
   unreplied: false
+
+talk_otameshi:
+  user: otameshi
+  unreplied: false

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -76,3 +76,7 @@ talk19:
 talk20:
   user: adminonly
   unreplied: false
+
+talk21:
+  user: otameshi
+  unreplied: false


### PR DESCRIPTION
## 目的

main ブランチの CI でテストが次のようなエラーで落ちるため、その修正をする

```
Error:
CurrentUserTest#test_update_user_tags:
ActionView::Template::Error: No route matches {:action=>"show", :controller=>"talks", :id=>nil}, missing required keys: [:id]
    app/views/api/users/_list_user.json.jbuilder:17
    app/views/api/users/index.json.jbuilder:2
    app/views/api/users/index.json.jbuilder:1

rails test test/system/current_user_test.rb:18
```

## 調べたこと

エラー内容は、あるユーザーの talk の id が指定されていないというエラー。
調べてみると、以下のユーザー otameshi が新たにフィクスチャへ追加されたものの、その talks がフィクスチャへ追加されていなかった。

https://github.com/fjordllc/bootcamp/blob/4c5e00eefd1b4e8e43ad307de4aefd6da82389a5/db/fixtures/users.yml#L915-L916

https://github.com/fjordllc/bootcamp/blob/4c5e00eefd1b4e8e43ad307de4aefd6da82389a5/test/fixtures/users.yml#L501-L502

## やったこと

otameshi ユーザーの talks をフィクスチャに追加した