### PR TITLE
Flaky なテストが成功するように、投稿の完了メッセージが表示されるまで待つようにした

### DIFF
--- a/test/system/notification/announcements_test.rb
+++ b/test/system/notification/announcements_test.rb
@@ -19,6 +19,7 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
       choose '全員にお知らせ', allow_label_click: true
       click_button '作成'
     end
+    assert_text 'お知らせを作成しました。'
 
     visit_with_auth '/notifications', 'sotugyou'
 

--- a/test/system/notification/answers_test.rb
+++ b/test/system/notification/answers_test.rb
@@ -13,6 +13,7 @@ class Notification::AnswersTest < ApplicationSystemTestCase
       fill_in('answer[description]', with: 'reduceも使ってみては？')
     end
     click_button 'コメントする'
+    assert_text '回答を投稿しました！'
 
     visit_with_auth '/notifications', 'sotugyou'
 

--- a/test/system/notification/events_test.rb
+++ b/test/system/notification/events_test.rb
@@ -9,6 +9,7 @@ class Notification::EventsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '参加を取り消す'
     end
+    assert_text '参加を取り消しました。'
 
     visit_with_auth '/notifications', 'hatsuno'
 
@@ -24,6 +25,7 @@ class Notification::EventsTest < ApplicationSystemTestCase
 
     fill_in 'event_capacity', with: 2
     click_button '内容変更'
+    assert_text 'イベントを更新しました。'
 
     visit_with_auth '/notifications', 'hatsuno'
 

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -12,6 +12,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
       fill_in('page[body]', with: 'DocsTestBody')
     end
     click_button '内容を保存'
+    assert_text 'ページを作成しました。'
 
     visit_with_auth '/notifications', 'hatsuno'
 
@@ -39,6 +40,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
       fill_in('page[body]', with: 'DocsTestBody')
     end
     click_button 'WIP'
+    assert_text 'ページをWIPとして保存しました。'
 
     logout
     visit_with_auth '/notifications', 'hatsuno'
@@ -51,6 +53,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
 
     click_link '内容変更'
     click_button '内容を保存'
+    assert_text 'ページを更新しました。'
 
     visit_with_auth '/notifications', 'machida'
 

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -19,6 +19,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     first('.select2-selection--single').click
     find('li', text: '[Mac OS X] OS X Mountain Lionをクリーンインストールする').click
     click_button '登録する'
+    assert_text '質問を作成しました。'
 
     visit_with_auth '/notifications', 'yamada'
 

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -19,6 +19,7 @@ class Notification::WatchesTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: 'コメントありがとうございます。')
     end
     click_button 'コメントする'
+    assert_text 'コメントを投稿しました！'
 
     visit_with_auth '/notifications', 'kimura'
 
@@ -49,6 +50,7 @@ class Notification::WatchesTest < ApplicationSystemTestCase
       fill_in('answer[description]', with: '質問へのご回答ありがとうございます。')
     end
     click_button 'コメントする'
+    assert_text '回答を投稿しました！'
 
     visit_with_auth '/notifications', 'kimura'
 


### PR DESCRIPTION
## 目的

「コメント等の投稿が他のユーザーへ通知されていること」を確認するテストが Flaky なので、なるべく成功するようにする

## エラーメッセージ

[Discord の「チーム開発」チャンネルの Aseiide さんのエラーメッセージ](https://discord.com/channels/715806612824260640/809595476847493192/939061238984491068) は次のようになっている

```
Error:
Notification::EventsTest#test_waiting_user_receive_notification_when_the_event_participant_cancel:
Capybara::ExpectationNotMet: expected to find css ".thread-list-item.is-unread" at least 1 time but there were no matches
    test/system/notification/events_test.rb:15:in `block in <class:EventsTest>'


rails test test/system/notification/events_test.rb:6
```

```
Failure:
Notification::WatchesTest#test_日報作成者がコメントをした際、ウォッチ通知が飛ばないバグの再現 [/Users/aseiide/development/fjordbootcamp/bootcamp/test/system/notification/watches_test.rb:26]:
expected to find text "komagataさんの【 「作業週1日目」の日報 】にkomagataさんがコメントしました。" in "未読\nsotugyouさんが「Terminalの基礎を覚える」の提出物を提出しました。\n2022年02月04日(金) 16:19"


rails test test/system/notification/watches_test.rb:6
```

## 考えたこと

上記のエラーメッセージはどちらも目的の通知が見つからないことを示しているため、通知の確認前に行っていた「目的の通知を発生させるコメント等の投稿」が完了していない可能性があると考えた

## やったこと

「目的の通知を発生させるコメント等の投稿」が完了するまで待つため、投稿後にその完了メッセージを確認するようにした