### PR TITLE
「ファイト」を「未入力」に変更

### DIFF
--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -61,4 +61,4 @@
         - if user.after_graduation_hope?
           = user.after_graduation_hope
         - else
-          | ファイト！
+          | 未入力


### PR DESCRIPTION
## Issue
- #4109

## 概要
メンターから閲覧可能な卒業後のゴールの「ファイト」を「未入力」に変更しました。

## 変更前
![localhost_3000_users_253826460 (1)](https://user-images.githubusercontent.com/69446373/152535584-38dfc39c-f41c-41ac-82ed-ca1b5e86fb8a.png)

## 変更後
![localhost_3000_users_253826460 (2)](https://user-images.githubusercontent.com/69446373/152535610-a736be67-472d-44ef-99a4-151b0c8b8f5c.png)

