### PR TITLE
卒業生に通知がいかないように修正 & テストの修正

### DIFF
--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.container.is-md(v-if='!loaded')
+#notifications.container.is-md.loaing(v-if='!loaded')
   loadingListPlaceholder
 .container(v-else-if='notifications.length === 0')
   .o-empty-message
@@ -9,7 +9,7 @@
       | 未読の通知はありません
     p.o-empty-message__text(v-else)
       | 通知はありません
-.container.is-md(v-else)
+#notifications.container.is-md.loaded(v-else)
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')
   .thread-list.a-card

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -75,7 +75,7 @@ class NotificationFacade
   end
 
   def self.first_report(report, receiver)
-    Notification.first_report(report, receiver) if (receiver.student_or_trainee? && !receiver.graduated?) || receiver.admin_or_mentor?
+    Notification.first_report(report, receiver) if (receiver.student_or_trainee? && !receiver.graduated? && !receiver.retired?) || receiver.admin_or_mentor?
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -75,7 +75,7 @@ class NotificationFacade
   end
 
   def self.first_report(report, receiver)
-    Notification.first_report(report, receiver) if receiver.current_student?
+    Notification.first_report(report, receiver) if receiver.current_student? || receiver.admin_or_mentor?
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -75,7 +75,7 @@ class NotificationFacade
   end
 
   def self.first_report(report, receiver)
-    Notification.first_report(report, receiver) if receiver.current_student? || receiver.admin_or_mentor?
+    Notification.first_report(report, receiver) if receiver.current_student?
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -75,7 +75,7 @@ class NotificationFacade
   end
 
   def self.first_report(report, receiver)
-    Notification.first_report(report, receiver) if (receiver.student_or_trainee? && !receiver.graduated? && !receiver.retired?) || receiver.admin_or_mentor?
+    Notification.first_report(report, receiver) if receiver.current_student? || receiver.admin_or_mentor?
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -75,7 +75,7 @@ class NotificationFacade
   end
 
   def self.first_report(report, receiver)
-    Notification.first_report(report, receiver) if receiver.student_or_trainee? || receiver.admin_or_mentor?
+    Notification.first_report(report, receiver) if receiver.student_or_trainee_or_retired? || receiver.admin_or_mentor?
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -75,7 +75,7 @@ class NotificationFacade
   end
 
   def self.first_report(report, receiver)
-    Notification.first_report(report, receiver) if receiver.student_or_trainee_or_retired? || receiver.admin_or_mentor?
+    Notification.first_report(report, receiver) if (receiver.student_or_trainee? && !receiver.graduated?) || receiver.admin_or_mentor?
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -459,6 +459,10 @@ class User < ApplicationRecord
     !admin? && !adviser? && !mentor? && !trainee?
   end
 
+  def current_student?
+    student_or_trainee? && !graduated? && !retired?
+  end
+
   def staff?
     admin? || mentor? || adviser?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -460,7 +460,7 @@ class User < ApplicationRecord
   end
 
   def current_student?
-    student_or_trainee? && !graduated? && !retired?
+    !admin? && !adviser? && !mentor? && !graduated? && !retired?
   end
 
   def staff?

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -4,7 +4,7 @@ header.header
       .header__start
         = link_to root_path, class: 'header__title' do
           = image_tag('pjord-face.svg', alt: 'プログラミングスクール', class: 'header__title-image')
-          - unless current_user.student_or_trainee?
+          - unless current_user.current_student?
             .a-user-role.is-header
               - if current_user.graduated_on?
                 span.a-user-role__label(class='is-graduate') 卒業生

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -21,15 +21,19 @@ class Notification::ReportsTest < ApplicationSystemTestCase
 
     notification_message = 'muryouさんがはじめての日報を書きました！'
     visit_with_auth '/notifications', 'komagata'
+    wait_for_vuejs
     assert_text notification_message
 
     visit_with_auth '/notifications', 'kimura'
+    wait_for_vuejs
     assert_text notification_message
 
     visit_with_auth '/notifications', 'advijirou'
+    wait_for_vuejs
     assert_no_text notification_message
 
     visit_with_auth '/notifications', 'sotugyou'
+    wait_for_vuejs
     assert_no_text notification_message
   end
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -5,8 +5,8 @@ require 'application_system_test_case'
 class Notification::ReportsTest < ApplicationSystemTestCase
   test 'the first daily report notification is sent only to current students and mentors' do
     report = users(:muryou).reports.create!(
-      title: 'test title',
-      description: 'test',
+      title: '初日報です',
+      description: '初日報の内容です',
       reported_on: Date.current
     )
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -21,19 +21,19 @@ class Notification::ReportsTest < ApplicationSystemTestCase
 
     notification_message = 'muryouさんがはじめての日報を書きました！'
     visit_with_auth '/notifications', 'machida'
-    wait_for_vuejs
+    find('#notifications.loaded', wait: 10)
     assert_text notification_message
 
     visit_with_auth '/notifications', 'kimura'
-    wait_for_vuejs
+    find('#notifications.loaded', wait: 10)
     assert_text notification_message
 
     visit_with_auth '/notifications', 'advijirou'
-    wait_for_vuejs
+    find('#notifications.loaded', wait: 10)
     assert_no_text notification_message
 
     visit_with_auth '/notifications', 'sotugyou'
-    wait_for_vuejs
+    find('#notifications.loaded', wait: 10)
     assert_no_text notification_message
   end
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -20,7 +20,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
 
     notification_message = 'muryouさんがはじめての日報を書きました！'
-    visit_with_auth '/notifications', 'komagata'
+    visit_with_auth '/notifications', 'machida'
     wait_for_vuejs
     assert_text notification_message
 


### PR DESCRIPTION
## issue

- #3981 

## 修正PR

- #4012 

## 概要

#4012 のPRに不備があり、卒業生に「はじめての日報を書きました！」通知がいってしまっていたのでその修正を行いました。

## 変更内容

`app/models/notification_facade.rb:78`の`if receiver.student_or_trainee?`の`student_or_trainee`メソッドでは卒業生も対象になってしまっていたので、そちらのメソッドを`student_or_trainee_or_retired?`に変更しました。
また、`test/system/reports_test.rb:6`の卒業生のテストが機能していなかったため、機能させるために`wait_for_vuejs`メソッドを追加しておきました。


