### PR TITLE
日報のテキストエリアの高さが自動で大きくなることを確認するテストを追加

### DIFF
--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -597,4 +597,27 @@ class ReportsTest < ApplicationSystemTestCase
       assert_selector 'h1', text: 'h1'
     end
   end
+
+  test 'textarea-of-new-report-automatically-resize' do
+    visit_with_auth '/reports/new', 'komagata'
+    fill_in('report[description]', with: 'test')
+    height = find('#report_description').style('height')['height'][/\d+/].to_i
+
+    fill_in('report[description]', with: "\n1\n2\n3\n4\n5\n6\7\n8\n9\n10\n11\n12\n13\n14\n15")
+    after_height = find('#report_description').style('height')['height'][/\d+/].to_i
+
+    assert height < after_height
+  end
+
+  test 'textarea-of-edit-report-automatically-resize' do
+    visit_with_auth report_path(reports(:report1)), 'komagata'
+    click_link '内容修正'
+
+    height = find('#report_description').style('height')['height'][/\d+/].to_i
+
+    fill_in('report[description]', with: "\n1\n2\n3\n4\n5\n6\7\n8\n9\n10\n11\n12\n13\n14\n15")
+    after_height = find('#report_description').style('height')['height'][/\d+/].to_i
+
+    assert height < after_height
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -598,7 +598,7 @@ class ReportsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'textarea-of-new-report-automatically-resize' do
+  test 'automatically resizes textarea of a new report' do
     visit_with_auth '/reports/new', 'komagata'
     fill_in('report[description]', with: 'test')
     height = find('#report_description').style('height')['height'][/\d+/].to_i
@@ -609,7 +609,7 @@ class ReportsTest < ApplicationSystemTestCase
     assert height < after_height
   end
 
-  test 'textarea-of-edit-report-automatically-resize' do
+  test 'automatically resizes textarea of an edit report' do
     visit_with_auth report_path(reports(:report1)), 'komagata'
     click_link '内容修正'
 


### PR DESCRIPTION
[#issue4057](https://github.com/fjordllc/bootcamp/issues/4057)
### 概要
日報のテキストエリアの高さが、文字数に応じて自動で大きくなることを確認するテストを追加しました。
以前に日報がnew以外のときにmarkdownが効かなくなったことがあるようなので（[こちらのPR](https://github.com/fjordllc/bootcamp/pull/3964))、新規作成時と編集時のテストを追加しています。

