### PR TITLE
相談部屋ページにアクセスできるメンバーを表示

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-header.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-header.sass
@@ -4,6 +4,8 @@
     padding: 1rem 2rem .75rem
   +media-breakpoint-down(sm)
     padding: 2.25rem .75rem .5rem
+    &.has-no-icon
+      +padding(vertical, .75rem)
   .a-count-badge
     +position(absolute, right .5rem, top .5rem)
 

--- a/app/assets/stylesheets/blocks/thread/_thread-members.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-members.sass
@@ -3,11 +3,17 @@
 
 .thread-members__items
   display: flex
-  margin-top: .5rem
   gap: .75rem
+  +media-breakpoint-up(md)
+    margin-top: .75rem
+  +media-breakpoint-down(sm)
+    margin-top: .5rem
 
 .thread-members__item
-  font-size: .875rem
+  +media-breakpoint-up(md)
+    font-size: .875rem
+  +media-breakpoint-down(sm)
+    font-size: .75rem
   .a-user-name
     +text-block(1em 1.4, $default-text)
 

--- a/app/assets/stylesheets/blocks/thread/_thread-members.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-members.sass
@@ -1,0 +1,21 @@
+.thread-members__title
+  +text-block(.8125rem 1.4)
+
+.thread-members__items
+  display: flex
+  margin-top: .5rem
+  gap: .75rem
+
+.thread-members__item
+  font-size: .875rem
+  .a-user-name
+    +text-block(1em 1.4, $default-text)
+
+.thread-members__user-icon-link
+  margin-right: .25em
+
+.thread-members__user-icon
+  +media-breakpoint-up(md)
+    +size(1.5rem)
+  +media-breakpoint-down(sm)
+    +size(1rem)

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -31,7 +31,6 @@ class TalksController < ApplicationController
   end
 
   def set_members
-    admins = User.admins.order(:id)
-    @members = admins.or(User.where(id: @talk.user_id))
+    @members = User.where(id: [@talk.user_id] + User.admins.pluck(:id)).order(:id)
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -3,6 +3,7 @@
 class TalksController < ApplicationController
   before_action :set_talk, only: %i[show]
   before_action :set_user, only: %i[show]
+  before_action :set_admins, only: %i[show]
   before_action :require_admin_login, only: %i[index]
   before_action :allow_show_talk_page_only_admin, only: %i[show]
 
@@ -27,5 +28,9 @@ class TalksController < ApplicationController
 
   def set_user
     @user = current_user.admin? ? @talk.user : current_user
+  end
+
+  def set_admins
+    @admins = User.admins.order(id: :desc)
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -31,7 +31,7 @@ class TalksController < ApplicationController
   end
 
   def set_members
-    admins = User.admins.order(id: :desc).to_a
-    @members = @talk.user.admin? ? admins : admins << @talk.user
+    admins = User.admins.order(:id)
+    @members = admins.or(User.where(id: @talk.user_id))
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -3,7 +3,7 @@
 class TalksController < ApplicationController
   before_action :set_talk, only: %i[show]
   before_action :set_user, only: %i[show]
-  before_action :set_admins, only: %i[show]
+  before_action :set_members, only: %i[show]
   before_action :require_admin_login, only: %i[index]
   before_action :allow_show_talk_page_only_admin, only: %i[show]
 
@@ -30,7 +30,8 @@ class TalksController < ApplicationController
     @user = current_user.admin? ? @talk.user : current_user
   end
 
-  def set_admins
-    @admins = User.admins.order(id: :desc)
+  def set_members
+    admins = User.admins.order(id: :desc).to_a
+    @members = @talk.user.admin? ? admins : admins << @talk.user
   end
 end

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.name}さんの相談部屋"
+- title "#{@user.login_name}さんの相談部屋"
 
 header.page-header
   .container
@@ -10,23 +10,36 @@ header.page-header
   .container.is-lg
     .thread
       .thread__inner.a-card
-        header.thread-header.has-count
+        header.thread-header
           .thread-header__row
             h1.thread-header-title
               = title
         .thread__body
           .thread__description.is-long-text
             p
-              | ここは#{@user.name}さんと管理者のみが閲覧することのできる相談部屋です。
+              | ここは#{@user.login_name}さんと管理者のみが閲覧することのできる相談部屋です。
               | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
-            p
-              | 相談部屋にアクセスできるメンバー
-            - @admins.each do |admin_user|
-              = link_to user_path(admin_user.id)
-                = image_tag admin_user.avatar_url
-              = link_to admin_user.login_name, user_path(admin_user.id)
-            = link_to user_path(@user.id)
-              = image_tag @user.avatar_url
-            = link_to @user.name, user_path(@user.id)
+        .thread-footer
+          .thread-footer__inner
+            .thread-members
+              h2.thread-members__title
+                | 相談部屋にアクセスできるメンバー
+              ul.thread-members__items
+                - @admins.each do |admin_user|
+                  li.thread-members__item
+                    = render 'users/icon',
+                      user: admin_user,
+                      link_class: 'thread-members__user-icon-link',
+                      image_class: 'thread-members__user-icon'
+                    = link_to user_path(admin_user.id), class: 'a-user-name' do
+                      = admin_user.login_name
+                - unless @user.admin?
+                  li.thread-members__item
+                    = render 'users/icon',
+                      user: @user,
+                      link_class: 'thread-members__user-icon-link',
+                      image_class: 'thread-members__user-icon'
+                    = link_to user_path(@user.id), class: 'a-user-name' do
+                      = @user.login_name
     a#comments.a-anchor
     #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -25,21 +25,13 @@ header.page-header
               h2.thread-members__title
                 | 相談部屋にアクセスできるメンバー
               ul.thread-members__items
-                - @admins.each do |admin_user|
+                - @members.each do |member|
                   li.thread-members__item
                     = render 'users/icon',
-                      user: admin_user,
+                      user: member,
                       link_class: 'thread-members__user-icon-link',
                       image_class: 'thread-members__user-icon'
-                    = link_to user_path(admin_user.id), class: 'a-user-name' do
-                      = admin_user.login_name
-                - unless @user.admin?
-                  li.thread-members__item
-                    = render 'users/icon',
-                      user: @user,
-                      link_class: 'thread-members__user-icon-link',
-                      image_class: 'thread-members__user-icon'
-                    = link_to user_path(@user.id), class: 'a-user-name' do
-                      = @user.login_name
+                    = link_to user_path(member.id), class: 'a-user-name' do
+                      = member.login_name
     a#comments.a-anchor
     #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -10,7 +10,7 @@ header.page-header
   .container.is-lg
     .thread
       .thread__inner.a-card
-        header.thread-header
+        header.thread-header.has-no-icon
           .thread-header__row
             h1.thread-header-title
               = title

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -19,5 +19,14 @@ header.page-header
             p
               | ここは#{@user.name}さんと管理者のみが閲覧することのできる相談部屋です。
               | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
+            p
+              | 相談部屋にアクセスできるメンバー
+            - @admins.each do |admin_user|
+              = link_to user_path(admin_user.id)
+                = image_tag admin_user.avatar_url
+              = link_to admin_user.login_name, user_path(admin_user.id)
+            = link_to user_path(@user.id)
+              = image_tag @user.avatar_url
+            = link_to @user.name, user_path(@user.id)
     a#comments.a-anchor
     #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -17,14 +17,14 @@ class TalksTest < ApplicationSystemTestCase
     visited_user = users(:hatsuno)
     visit_user = users(:mentormentaro)
     visit_with_auth talk_path(visited_user.talk), 'mentormentaro'
-    assert_no_text "#{visited_user.name}さんの相談部屋"
-    assert_text "#{visit_user.name}さんの相談部屋"
+    assert_no_text "#{visited_user.login_name}さんの相談部屋"
+    assert_text "#{visit_user.login_name}さんの相談部屋"
   end
 
   test 'admin can access users talk page' do
     visited_user = users(:hatsuno)
     visit_with_auth talk_path(visited_user.talk), 'komagata'
-    assert_text "#{visited_user.name}さんの相談部屋"
+    assert_text "#{visited_user.login_name}さんの相談部屋"
   end
 
   test 'a talk room is shown up on unreplied tab when users except admin comments there' do


### PR DESCRIPTION
## Issue
- #4115 
 
## 概要
相談部屋個別ページにアクセスできるメンバー(admin全員とその相談部屋のユーザー)を表示しました。

ユーザーの相談がその他ユーザーに見られていない、機密性を感じてもらう意図があります。
本番環境ではuser_idの若い順(komagataさんから)に、左から表示されるようになっています。

（町田さんによって、その相談部屋ユーザーの名前がフルネームからログインネームに変更されています）

## 変更確認方法
1. ブランチ `feature/display-members-on-talkroom`をローカルに取り込む
2. `$ rails s` でローカル環境を立ち上げる
3. admin以外のユーザーでログイン(`hajime`でログインし確認しました)
4. 自身の相談部屋ページにアクセスし、今回の変更箇所をご確認ください。

## 変更前
![localhost_3000_talks_133242096 (2)](https://user-images.githubusercontent.com/69446373/152640976-9a5d5fb4-2764-4ed8-bc02-98549495171f.png)

## 変更後
![localhost_3000_talks_133242096](https://user-images.githubusercontent.com/69446373/154024597-7a6dfd33-0394-41a0-8cff-c274e7f06cb2.png)

