### PR TITLE
モバイル表示の場合にもプラクティスの更新者のアバターアイコンが表示されるように修正

### DIFF
--- a/app/assets/stylesheets/atoms/_a-meta.sass
+++ b/app/assets/stylesheets/atoms/_a-meta.sass
@@ -20,10 +20,6 @@
         content: "（"
       &::after
         content: "）"
-  +media-breakpoint-down(sm)
-    .thread-header__user-icon-link,
-    .thread-list-item-meta__icon-link
-      display: none
 
 a.a-meta
   +hover-link

--- a/db/fixtures/pages.yml
+++ b/db/fixtures/pages.yml
@@ -77,6 +77,7 @@ page11:
   user: komagata
   practice: practice1
   published_at: "2021-10-01 00:00:00"
+  last_updated_user: komagata
 
 page12:
   title: apt

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -48,6 +48,7 @@ page7:
   user: komagata
   practice: practice1
   published_at: "2021-10-01 00:00:00"
+  last_updated_user: komagata
 
 page8:
   title: apt

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -153,4 +153,11 @@ class PagesTest < ApplicationSystemTestCase
     visit current_path
     assert_text "コメント（\n1\n）"
   end
+
+  test 'show last updated user icon' do
+    visit_with_auth "/pages/#{pages(:page7).id}", 'hajime'
+    within '.thread-header__user-icon-link' do
+      assert_selector 'img[alt="komagata (Komagata Masaki): 管理者、メンター"]'
+    end
+  end
 end

--- a/test/system/practice/pages_test.rb
+++ b/test/system/practice/pages_test.rb
@@ -7,4 +7,11 @@ class Practice::PagesTest < ApplicationSystemTestCase
     visit_with_auth "/practices/#{practices(:practice1).id}/pages", 'hatsuno'
     assert_equal 'OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
+
+  test 'show last updated user icon' do
+    visit_with_auth "/practices/#{practices(:practice1).id}/pages", 'hajime'
+    within '.thread-list-item-meta__icon-link' do
+      assert_selector 'img[alt="komagata (Komagata Masaki): 管理者、メンター"]'
+    end
+  end
 end

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -187,4 +187,11 @@ class PracticesTest < ApplicationSystemTestCase
     wait_for_vuejs
     assert_equal 'テストプラクティス | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
+
+  test 'show last updated user icon' do
+    visit_with_auth "/practices/#{practices(:practice55).id}", 'hajime'
+    within '.thread-header__user-icon-link' do
+      assert_selector 'img[alt="komagata (Komagata Masaki): 管理者、メンター"]'
+    end
+  end
 end


### PR DESCRIPTION
## Issue #3473 

プラクティス詳細ページ ( `/practices/:practice_id` ) の他に、以下の2つのページに影響あり

- プラクティス詳細 > Docsタブページ ( `/practices/:practice_id/pages` )
- Docs詳細ページ ( `/pages/:page_id` )

=> [修正対象のCSSと影響のあった箇所についてのIssueのコメント](https://github.com/fjordllc/bootcamp/issues/3473#issuecomment-963835934)

### `*/fixtures/pages.yml` の変更について
ページの最終更新者が登録されているデータがなかったため、最終更新者のアイコンを確認できるように `title: プラクティスに紐付いたDocs` のデータに `last_updated_user: komagata` を追加しています。

## プラクティス詳細ページ
修正前
![image](https://user-images.githubusercontent.com/83743223/152638887-b537fb2f-7d9d-46e3-8586-4cae548f5720.png)
修正後
![image](https://user-images.githubusercontent.com/83743223/152638933-3666f34f-ec34-4f25-9603-bb8ad1fb42a8.png)

## プラクティス詳細 > Docsタブページ
修正前
![image](https://user-images.githubusercontent.com/83743223/152638972-e173563f-2965-4f5e-9057-7807bf81e96b.png)
修正後
![image](https://user-images.githubusercontent.com/83743223/152639000-100f3d9b-613e-4db5-8c14-7eed8c9643c5.png)

## Docs詳細ページ
修正前
![image](https://user-images.githubusercontent.com/83743223/152639015-3e62f7c4-e4ff-4eb5-996a-5bd261ab6c17.png)
修正後
![image](https://user-images.githubusercontent.com/83743223/152639028-1f0ede29-b63e-4f5f-a0b9-16c4ac0aa7d1.png)

## ローカルでの確認方法

1. `bug/not-display-practice-updater-icon-in-mobile-view` ブランチで起動後、ユーザーログイン
2. デベロッパーツールを使って、画面をモバイル表示にする
3. 各ページでユーザーアイコンが表示されていることを確認する

- プラクティス詳細ページ
  - 「サーバー連携」のプラクティスに最終更新者が登録されているため、検索して該当のページへ移動し、アイコンを確認 
- プラクティス詳細 > Docsタブページ と Docs詳細ページ
  - 右上のメニューから、プラクティス > 「OS X Mountain Lionをクリーンインストールする」 > Docsタブページ へ移動し、アイコンを確認
  - Docsタブページ内の 「プラクティスに紐付いたDocs」 へ移動し、アイコンを確認

**※** ブランチ切り替え後に `rails db:seed` を実行していない場合は、「プラクティスに紐付いたDocs」に `last_updated_user` が登録されていないため、アイコンが表示されない。一度、該当のDocsを更新すれば表示される。