### PR TITLE
ユーザー個別ページのプロフィールページのタイトルを変更

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}のプロフィール"
+- title @user.login_name
 header.page-header
   .container
     .page-header__inner

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -12,7 +12,7 @@ class User::TagsTest < ApplicationSystemTestCase
       click_on name
       assert_text "タグ「#{name}」のユーザー"
       assert_text user.name
-      assert_no_text "#{user.name}のプロフィール"
+      assert_no_text "プロフィール"
     end
   end
 

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -12,7 +12,7 @@ class User::TagsTest < ApplicationSystemTestCase
       click_on name
       assert_text "タグ「#{name}」のユーザー"
       assert_text user.name
-      assert_no_text "プロフィール"
+      assert_no_text 'プロフィール'
     end
   end
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class UsersTest < ApplicationSystemTestCase
   test 'show profile' do
     visit_with_auth "/users/#{users(:hatsuno).id}", 'hatsuno'
-    assert_equal 'hatsunoのプロフィール | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal 'hatsuno | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'autolink profile when url is included' do


### PR DESCRIPTION
# issue #3703
@tksmasaki さん
ユーザー個別ページのプロフィールページのタイトルを変更しました。
お手すきの際に、レビューをお願いいたします🙏

### 特記事項：
- 2回目のコミット[c840661](https://github.com/fjordllc/bootcamp/pull/4148/commits/c84066132c49f6c992dda433089af26ab2777500)は、CIのLintがFailしたので修正しました(コミット前にRubocopやらなきゃですね。。)😇

- 2回目のコミット[c840661](https://github.com/fjordllc/bootcamp/pull/4148/commits/c84066132c49f6c992dda433089af26ab2777500)で、`git commit --amend`を使えば、履歴がスッキリしたかもですが...次回に活かしたいと思います💪

- 類似のissue #3704 を参考にしたというところで、@tksmasaki さんをレビュアーに選ばせていただきました🙇🏻‍♂️

## 変更理由
UI的に、タブをクリックした後にそのタブより上のパーツで変化が起きていることがタブのメタファーに反しているため、今回の変更に至りました。また、フィヨルドブートキャンプ的にgood first issueにちょうどいい内容なので、その部分の修正は機能追加時にはあえて入れず、別issueにしてあるそうです。

詳細は、Discordを参照。
https://discord.com/channels/715806612824260640/809595476847493192/939321563633819678

## 変更方法
issue #3704 を参考にさせていただきました。
ただし、issue #3704 の2行変更に対して、本issueでは3行の変更となり、この+1行の詳細については次項で説明します。

### 変更点の確認方法
最初に当たりをつけようと思って「のプロフィール」で検索したところ、4行がマッチし、内3行が今回の変更点と判断しました。
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeldJQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--665dcdb867fee136daa26033cfa65dcd5795d6a9/image.png)

## issue #3704 に対して、+1行の変更について
タグ画面のテスト`test/system/user/tags_test.rb`が、
1. ユーザー個別ページのプロフィールページに遷移（11行目）。
2. タグ画面に遷移してテスト（12〜14行目）。
3. ユーザー個別ページのプロフィールページではないことのテスト（15行目）。

のようなテスト構成で、3番が今回の変更と関連していたため、＋1行の変更が発生しました。

今回、3番の`assert_no_text "#{user.name}のプロフィール"`を`assert_no_text "プロフィール"`に変更することで、既存のテストを成立させるようにしています。

なお、1番のあとに、`assert_text "プロフィール"`を入れてもPASSすることは確認済みです。そのまま入れておこうかとも考えましたが、他のテストを見ると`assert_no_text`の方でテストするポリシーのようですので、安易にテスト追加するのはやめておきました。ここが本issueで少し悩んだところです😅

## 目視確認

ユーザー個別ページのプロフィールページのタイトルから「のプロフィール」が削除されていることを確認済み。

### 変更前
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeXVJQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--eb24e86aaf58afb8abaf2f1b1228253cbe40b967/image.png)

### 変更後
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBenFJQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--5271d58d55479f022aee1945de60a9dccd9eb955/image.png)

### 確認方法
1. feature/change-user-profile-page-title ブランチをローカル環境で起動する。
2. ユーザーログインする。
3. ダッシュボードのマイプロフィールをクリック（issue #3743 の変更で、入口が従来のmeから変更されているので注意）。

## 自動テスト

2-testでPASSを確認済み。

```
~/work/bootcamp feature/change-user-profile-page-title*
❯ rails test test/system/user/tags_test.rb:6
Running via Spring preloader in process 57179
Run options: --seed 22612

# Running:

Capybara starting Puma...
* Version 5.6.1 , codename: Birdie's Version
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:51717
.

Finished in 9.825201s, 0.1018 runs/s, 1.5267 assertions/s.
1 runs, 15 assertions, 0 failures, 0 errors, 0 skips
```
```
~/work/bootcamp feature/change-user-profile-page-title*
❯ rails test test/system/users_test.rb:6                                                                      
Running via Spring preloader in process 57306
Run options: --seed 60994

# Running:

Capybara starting Puma...
* Version 5.6.1 , codename: Birdie's Version
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:51826
.

Finished in 5.276362s, 0.1895 runs/s, 0.1895 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```