### PR TITLE
ci: Rubyのバージョン指定を削除

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,6 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.0
         bundler-cache: true
 
     - name: Set up Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.0
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Set up Node.js


### PR DESCRIPTION
`.ruby-version` を参照してくれるため、GitHub Actions
のYAML内でRubyのバージョンを指定する必要はありません。
参考: https://github.com/ruby/setup-ruby/tree/v1.97.0#supported-version-syntax

Rubyのアップグレード対応で変更する箇所を減らすため、削除しておきます。