### PR TITLE
chore: テストでPumaの起動ログを表示しない

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,3 +28,7 @@ class ActionDispatch::IntegrationTest
   include Sorcery::TestHelpers::Rails::Integration
   include APIHelper
 end
+
+ActiveSupport.on_load(:action_dispatch_system_test_case) do
+  ActionDispatch::SystemTesting::Server.silence_puma = true
+end


### PR DESCRIPTION
テストを実行したとき、以下のようなPumaの起動ログが表示
されますが、邪魔なので表示しないように設定します。

```
Capybara starting Puma...
* Version 5.6.1 , codename: Birdie's Version
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:45611
```

参考: https://github.com/rails/rails/pull/29561