### PR TITLE
schema.rb の並び順を $ rails db:migrate:reset 直後の並び順に修正

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,6 +85,14 @@ ActiveRecord::Schema.define(version: 2022_01_27_083838) do
     t.index ["bookmarkable_type", "bookmarkable_id"], name: "index_bookmarks_on_bookmarkable"
   end
 
+  create_table "campaigns", force: :cascade do |t|
+    t.datetime "start_at", null: false
+    t.datetime "end_at", null: false
+    t.string "title", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "slug"
@@ -170,14 +178,6 @@ ActiveRecord::Schema.define(version: 2022_01_27_083838) do
     t.boolean "wip", default: false, null: false
     t.boolean "job_hunting", default: false, null: false
     t.index ["user_id"], name: "index_events_on_user_id"
-  end
-
-  create_table "campaigns", force: :cascade do |t|
-    t.datetime "start_at", null: false
-    t.datetime "end_at", null: false
-    t.string "title", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "followings", force: :cascade do |t|
@@ -474,8 +474,8 @@ ActiveRecord::Schema.define(version: 2022_01_27_083838) do
     t.text "mentor_memo"
     t.string "discord_account"
     t.string "times_url"
-    t.boolean "notified_retirement", default: false, null: false
     t.text "after_graduation_hope"
+    t.boolean "notified_retirement", default: false, null: false
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true


### PR DESCRIPTION
## 目的

`$ bin/setup` や `$ rails db:migrate:reset` の実行後に、schema ファイルのテーブルやカラムの並び順の diff が生じないようにすること

## 並び順の diff が生じる原因として考えたこと

### `campaigns` テーブル

もともとは  `extended_trials` というテーブル名で schema に追加されたものの、その後に テーブル名を `campaigns` に変更したため、テーブルの位置が並び順と異なるようになったと考えられる

https://github.com/fjordllc/bootcamp/pull/4030/commits/42c3fc99c536504883d768246c6c096d269e96c6#diff-0be067478caaa68b2a1692038616c1f33ecd6374cd9a445bf3cbbed5ca21ee16R3

### `users` テーブルの `after_graduation_hope` カラム

`after_graduation_hope` カラムと `notified_retirement` カラムについて、「マイグレーションファイルを作成した日時」と「それぞれの PR がマージされた順番」が前後したことにより、カラムの位置が前後した可能性がある

## やったこと

`$ rails db:migrate:reset` の実行直後の並び順をコミットした

## 動作確認手順

1. `$ git checkout chore/fix-order-of-campaign-table-and-a-column-of-user-table-in-schema`
1. `$ rails db:migrate:reset`
1. schema ファイルに diff が生じていないことを確認