### PR TITLE
通知タイトルを確認する Flaky なテストが成功するように、新着 Doc を通知するレコード作成時の N+1 を解消した

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -198,15 +198,22 @@ class Notification < ApplicationRecord
       )
     end
 
-    def create_page(page, reciever)
-      Notification.create!(
-        kind: kinds[:create_pages],
-        user: reciever,
-        sender: page.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(page),
-        message: "#{page.user.login_name}さんがDocsに#{page.title}を投稿しました。",
-        read: false
-      )
+    def notify_all_receivers_of_new_page(page, receivers)
+      now = Time.current
+      notification_records = receivers.map do |receiver|
+        {
+          kind: kinds[:create_pages],
+          user_id: receiver.id,
+          sender_id: page.sender.id,
+          link: Rails.application.routes.url_helpers.polymorphic_path(page),
+          message: "#{page.user.login_name}さんがDocsに#{page.title}を投稿しました。",
+          read: false,
+          created_at: now,
+          updated_at: now
+        }
+      end
+
+      Notification.insert_all!(notification_records) # rubocop:disable Rails/SkipsModelValidations
     end
 
     def following_report(report, receiver)

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -145,14 +145,17 @@ class NotificationFacade
     ).moved_up_event_waiting_user.deliver_later(wait: 5)
   end
 
-  def self.create_page(page, receiver)
-    Notification.create_page(page, receiver)
-    return unless receiver.mail_notification? && !receiver.retired?
+  def self.notify_all_receivers_of_new_page(page, receivers)
+    Notification.notify_all_receivers_of_new_page(page, receivers)
 
-    NotificationMailer.with(
-      page: page,
-      receiver: receiver
-    ).create_page.deliver_later(wait: 5)
+    receivers.each do |receiver|
+      next unless receiver.mail_notification? && !receiver.retired?
+
+      NotificationMailer.with(
+        page: page,
+        receiver: receiver
+      ).create_page.deliver_later(wait: 5)
+    end
   end
 
   def self.chose_correct_answer(answer, receiver)

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -26,10 +26,8 @@ class PageCallbacks
   private
 
   def send_notification(page)
-    receivers = User.where(retired_on: nil, graduated_on: nil, adviser: false, trainee: false)
-    receivers.each do |receiver|
-      NotificationFacade.create_page(page, receiver) if page.sender != receiver
-    end
+    receivers = User.where(retired_on: nil, graduated_on: nil, adviser: false, trainee: false).where.not(id: page.sender.id)
+    NotificationFacade.notify_all_receivers_of_new_page(page, receivers)
   end
 
   def notify_to_chat(page)


### PR DESCRIPTION
## 目的

新着 Doc の通知を確認する次のテストが Flaky なため、なるべく成功するように修正する

https://github.com/fjordllc/bootcamp/blob/3ea14294068d3906c5aab1f8820c2cdcc2140a60/test/system/notification/pages_test.rb#L50-L63

## エラーメッセージ

```
Error:
Notification::PagesTest#test_Notify_Docs_updated_from_WIP:
Capybara::ExpectationNotMet: expected to find css ".thread-list-item.is-unread" at least 1 time but there were no matches
    test/system/notification/pages_test.rb:60:in `block in <class:PagesTest>'

rails test test/system/notification/pages_test.rb:50
```

未読の通知がない（すなわち新着 Doc の通知が見つからない）というエラー

引用元: https://github.com/fjordllc/bootcamp/runs/5087339029?check_suite_focus=true

## 調べたこと

新着 Doc の通知レコードを作成する次の処理において、受取人（おそらく現役受講生とメンター？）の人数分の INSERT の SQL が発行されている（すなわちN+1になっている）

https://github.com/fjordllc/bootcamp/blob/2e1d236e61881a692a2aa7020b3a3aca317e702f/app/models/page_callbacks.rb#L28-L33

## テストが失敗する原因として考えたこと

「新着 Doc の通知レコードの作成開始」から「新着 Doc 通知が画面に表示されていることの確認」までに、 N+1の処理が終わっていない（すなわち目的の通知のレコードが作成されていない）可能性があると考えた

## やったこと

新着 Doc の通知レコードの作成を 1つの SQL で行うようにして、N+1 を解消した

