### PR TITLE
remove `gem 'date'`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '3.1.0'
 
 gem 'bootsnap', '>= 1.4.4', require: false
-gem 'date', '>= 3.2.1' # CVE-2021-41817対応
 gem 'image_processing', '~> 1.2'
 gem 'jbuilder', '~> 2.7'
 gem 'puma', '~> 5.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,6 @@ GEM
     data_migrate (7.0.2)
       activerecord (>= 5.0)
       railties (>= 5.0)
-    date (3.2.2)
     dead_end (3.1.1)
     declarative (0.0.20)
     diffy (3.4.0)
@@ -537,7 +536,6 @@ DEPENDENCIES
   coffee-rails (~> 5.0.0)
   commonmarker
   data_migrate
-  date (>= 3.2.1)
   dead_end
   diffy
   discord-notifier


### PR DESCRIPTION
Ruby 3.1.0 には CVE-2021-41817 対応版の date (3.2.2) が同梱されているため、
Gemfile での date gem のバージョン指定を削除します。