### PR TITLE
rack-dev-markというgemを追加し開発環境での作業時に目印が出るようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :development do
   gem 'bullet'
   gem 'bundle_outdated_formatter'
   gem 'letter_opener_web', '~> 1.0'
+  gem 'rack-dev-mark'
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'rubocop', require: false
   gem 'rubocop-fjord', '~> 0.2.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,8 @@ GEM
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-dev-mark (0.7.9)
+      rack (>= 1.1, < 2.3)
     rack-mini-profiler (2.3.3)
       rack (>= 1.2.0)
     rack-proxy (0.7.2)
@@ -561,6 +563,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.6)
   rack-cors
+  rack-dev-mark
   rack-mini-profiler (~> 2.0)
   rack-user_agent
   rails (~> 6.1.4.4)

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module Bootcamp
 
     config.active_storage.resolve_model_to_route = :rails_storage_proxy
 
+    config.rack_dev_mark.enable = !Rails.env.production?
     config.rack_dev_mark.theme = [:title, Rack::DevMark::Theme::GithubForkRibbon.new(position: 'right-bottom')]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,8 +28,5 @@ module Bootcamp
      end
 
     config.active_storage.resolve_model_to_route = :rails_storage_proxy
-
-    config.rack_dev_mark.enable = !Rails.env.production?
-    config.rack_dev_mark.theme = [:title, Rack::DevMark::Theme::GithubForkRibbon.new(position: 'right-bottom')]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module Bootcamp
        html_tag.html_safe
      end
 
-     config.active_storage.resolve_model_to_route = :rails_storage_proxy
+    config.active_storage.resolve_model_to_route = :rails_storage_proxy
+
+    config.rack_dev_mark.theme = [:title, Rack::DevMark::Theme::GithubForkRibbon.new(position: 'right-bottom')]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,6 @@ module Bootcamp
        html_tag.html_safe
      end
 
-    config.active_storage.resolve_model_to_route = :rails_storage_proxy
+     config.active_storage.resolve_model_to_route = :rails_storage_proxy
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,15 +18,15 @@ module Bootcamp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-     config.time_zone = "Tokyo"
-     config.i18n.default_locale = :ja
+    config.time_zone = "Tokyo"
+    config.i18n.default_locale = :ja
 
-     config.paths.add "lib", eager_load: true
+    config.paths.add "lib", eager_load: true
 
-     config.action_view.field_error_proc = Proc.new do |html_tag, instance|
-       html_tag.html_safe
-     end
+    config.action_view.field_error_proc = Proc.new do |html_tag, instance|
+      html_tag.html_safe
+    end
 
-     config.active_storage.resolve_model_to_route = :rails_storage_proxy
+    config.active_storage.resolve_model_to_route = :rails_storage_proxy
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,16 +75,16 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-   config.action_mailer.delivery_method = :letter_opener_web
-   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-   config.action_controller.asset_host = "http://localhost:3000"
-   config.action_mailer.asset_host = "http://localhost:3000"
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_controller.asset_host = "http://localhost:3000"
+  config.action_mailer.asset_host = "http://localhost:3000"
 
-   config.after_initialize do
-     Bullet.enable = true
-     Bullet.add_footer = true
-     Bullet.bullet_logger = true
-   end
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.add_footer = true
+    Bullet.bullet_logger = true
+  end
 
   config.rack_dev_mark.enable = true
   config.rack_dev_mark.theme = [:title, Rack::DevMark::Theme::GithubForkRibbon.new(position: 'right-bottom')]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,4 +85,7 @@ Rails.application.configure do
      Bullet.add_footer = true
      Bullet.bullet_logger = true
    end
+
+  config.rack_dev_mark.enable = true
+  config.rack_dev_mark.theme = [:title, Rack::DevMark::Theme::GithubForkRibbon.new(position: 'right-bottom')]
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,6 +85,4 @@ Rails.application.configure do
      Bullet.add_footer = true
      Bullet.bullet_logger = true
    end
-
-  config.rack_dev_mark.enable = true
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,4 +85,6 @@ Rails.application.configure do
      Bullet.add_footer = true
      Bullet.bullet_logger = true
    end
+
+  config.rack_dev_mark.enable = true
 end


### PR DESCRIPTION
## issue
- #4035 

## 概要
[rack-dev-mark](https://github.com/dtaniwaki/rack-dev-mark)というgemを入れて、どの環境でbootpcampアプリが動いているのかを表示できるようにしました。

## 変更確認方法
1. ブランチ`feature/add-rack-dev-mark-gem`をローカルに取り込む
2. `$ rails s`でローカル環境を立ち上げる
3. テスト用ユーザーでログイン

## 変更前
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeEtKQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--acf440b04a5a2a0e3794af7326b823e52508e279/image.png)

## 変更後

![image](https://user-images.githubusercontent.com/63531341/153740970-4e45bb08-40c9-4ed9-bbc8-bb1bf51d0de7.png)