### PR TITLE
提出物詳細画面で余分なクエリを削除しました

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -89,13 +89,13 @@ class ProductsController < ApplicationController
   end
 
   def find_footprints
-    find_product.footprints.with_avatar.order(created_at: :desc)
+    @product.footprints.with_avatar.order(created_at: :desc)
   end
 
   def footprint!
-    return unless find_product.user != current_user
+    return unless @product.user != current_user
 
-    find_product.footprints.create_or_find_by(user: current_user)
+    @product.footprints.create_or_find_by(user: current_user)
   end
 
   def check_permission!

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -10,7 +10,11 @@ class ProductsController < ApplicationController
 
   def show
     @product = find_product
-    @reports = @product.user.reports.limit(10).order(reported_on: :DESC)
+    @reports = @product.user
+                       .reports
+                       .limit(10)
+                       .includes(:comments, :checks)
+                       .order(reported_on: :DESC)
     @practice = find_practice
     @footprints = find_footprints
     footprint!


### PR DESCRIPTION
## やったこと

提出物詳細画面でN+1の解消と、余分に発行されるクエリを削減しました。
修正した`find_footprints`メソッドと`footprint!`メソッドはProductsController#showでのみ呼ばれるメソッドなので、直前にselectしている`@products`を呼んでクエリを発行しないようにしています。