### PR TITLE
アドバイザーでログインしているときに自社の研修生には「自社研修生」が表示されていること

### DIFF
--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -52,7 +52,7 @@
         .card-main-actions
           ul.card-main-actions__items
             li.card-main-actions__item(
-              v-if='currentUser.id != user.id && currentUser.adviser == true && user.company && currentUser.company_id == user.company.id'
+              v-if='currentUser.id != user.id && currentUser.adviser && user.company && currentUser.company_id == user.company.id'
             )
               .a-button.is-disabled.is-md.is-block
                 i.fas.fa-check

--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -51,7 +51,11 @@
       footer.card-footer
         .card-main-actions
           ul.card-main-actions__items
-            li.card-main-actions__item(v-if='currentUser.id != user.id')
+            li.card-main-actions__item(
+              v-if='currentUser.id != user.id && currentUser.adviser == true && user.company && currentUser.company_id == user.company.id'
+            )
+              | 自社研修生
+            li.card-main-actions__item(v-else-if='currentUser.id != user.id')
               following(
                 :isFollowing='user.isFollowing',
                 :userId='user.id',

--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -54,7 +54,10 @@
             li.card-main-actions__item(
               v-if='currentUser.id != user.id && currentUser.adviser == true && user.company && currentUser.company_id == user.company.id'
             )
-              | 自社研修生
+              .a-button.is-disabled.is-md.is-block
+                i.fas.fa-check
+                span
+                  | 自社研修生
             li.card-main-actions__item(v-else-if='currentUser.id != user.id')
               following(
                 :isFollowing='user.isFollowing',

--- a/app/views/api/users/index.json.jbuilder
+++ b/app/views/api/users/index.json.jbuilder
@@ -5,6 +5,8 @@ end
 json.currentUser do
   json.id current_user.id
   json.mentor current_user.mentor?
+  json.adviser current_user.adviser
+  json.company_id current_user.company_id
   json.admin current_user.admin
 end
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -62,12 +62,17 @@ header.page-header
             footer.card-footer
               .card-main-actions
                 ul.card-main-actions__items
-                  - unless current_user == @user
-                    li.card-main-actions__item
-                      .js-following(data-is-following="#{current_user.following?(@user)}" data-user-id="#{@user.id}" data-is-watching="#{current_user.watching?(@user)}")
                   - if current_user == @user
                     li.card-main-actions__item
                       = link_to '登録情報変更', edit_current_user_path, class: 'card-main-actions__action a-button is-md is-secondary is-block'
+                  - elsif current_user != @user && current_user.adviser? == false || current_user.adviser? != @user.trainee
+                    li.card-main-actions__item
+                      .js-following(data-is-following="#{current_user.following?(@user)}" data-user-id="#{@user.id}" data-is-watching="#{current_user.watching?(@user)}")
+                  - elsif current_user != @user && current_user.adviser? == true && current_user.adviser? == @user.trainee
+                    li.card-main-actions__item
+                      div
+                        = "自社研修生"
+
                   - elsif admin_login?
                     li.card-main-actions__item
                       = link_to '管理者として情報変更', edit_admin_user_path, class: 'card-main-actions__action a-button is-sm is-secondary is-block'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -68,7 +68,7 @@ header.page-header
                   - elsif admin_login?
                     li.card-main-actions__item
                       = link_to '管理者として情報変更', edit_admin_user_path, class: 'card-main-actions__action a-button is-sm is-secondary is-block'
-                  - elsif current_user != @user && current_user.adviser? == true && current_user.company_id == @user.company_id
+                  - elsif current_user != @user && current_user.adviser? == true && current_user.company_id == @user.company_id && @user.trainee == true
                     li.card-main-actions__item
                       div
                         = '自社研修生'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -71,12 +71,10 @@ header.page-header
                   - elsif current_user != @user && current_user.adviser? == true && current_user.adviser? == @user.trainee
                     li.card-main-actions__item
                       div
-                        = "自社研修生"
-
+                        = '自社研修生'
                   - elsif admin_login?
                     li.card-main-actions__item
                       = link_to '管理者として情報変更', edit_admin_user_path, class: 'card-main-actions__action a-button is-sm is-secondary is-block'
-
         .col-xs-12.col-lg-6.col-xxl-6
           - if admin_or_mentor_login?
             #js-user-mentor-memo(data-user-id='#{@user.id}')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -68,13 +68,13 @@ header.page-header
                   - elsif admin_login?
                     li.card-main-actions__item
                       = link_to '管理者として情報変更', edit_admin_user_path, class: 'card-main-actions__action a-button is-sm is-secondary is-block'
-                  - elsif current_user != @user && current_user.adviser? == false || current_user.adviser? != @user.trainee
-                    li.card-main-actions__item
-                      .js-following(data-is-following="#{current_user.following?(@user)}" data-user-id="#{@user.id}" data-is-watching="#{current_user.watching?(@user)}")
-                  - elsif current_user != @user && current_user.adviser? == true && current_user.adviser? == @user.trainee
+                  - elsif current_user != @user && current_user.adviser? == true && current_user.company_id == @user.company_id
                     li.card-main-actions__item
                       div
                         = '自社研修生'
+                  - elsif current_user != @user
+                    li.card-main-actions__item
+                      .js-following(data-is-following="#{current_user.following?(@user)}" data-user-id="#{@user.id}" data-is-watching="#{current_user.watching?(@user)}")
         .col-xs-12.col-lg-6.col-xxl-6
           - if admin_or_mentor_login?
             #js-user-mentor-memo(data-user-id='#{@user.id}')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -70,8 +70,10 @@ header.page-header
                       = link_to '管理者として情報変更', edit_admin_user_path, class: 'card-main-actions__action a-button is-sm is-secondary is-block'
                   - elsif current_user != @user && current_user.adviser? == true && current_user.company_id == @user.company_id && @user.trainee == true
                     li.card-main-actions__item
-                      div
-                        = '自社研修生'
+                      .a-button.is-disabled.is-md.is-block
+                        i.fas.fa-check
+                        span
+                          | 自社研修生
                   - else
                     li.card-main-actions__item
                       .js-following(data-is-following="#{current_user.following?(@user)}" data-user-id="#{@user.id}" data-is-watching="#{current_user.watching?(@user)}")

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -65,6 +65,9 @@ header.page-header
                   - if current_user == @user
                     li.card-main-actions__item
                       = link_to '登録情報変更', edit_current_user_path, class: 'card-main-actions__action a-button is-md is-secondary is-block'
+                  - elsif admin_login?
+                    li.card-main-actions__item
+                      = link_to '管理者として情報変更', edit_admin_user_path, class: 'card-main-actions__action a-button is-sm is-secondary is-block'
                   - elsif current_user != @user && current_user.adviser? == false || current_user.adviser? != @user.trainee
                     li.card-main-actions__item
                       .js-following(data-is-following="#{current_user.following?(@user)}" data-user-id="#{@user.id}" data-is-watching="#{current_user.watching?(@user)}")
@@ -72,9 +75,6 @@ header.page-header
                     li.card-main-actions__item
                       div
                         = '自社研修生'
-                  - elsif admin_login?
-                    li.card-main-actions__item
-                      = link_to '管理者として情報変更', edit_admin_user_path, class: 'card-main-actions__action a-button is-sm is-secondary is-block'
         .col-xs-12.col-lg-6.col-xxl-6
           - if admin_or_mentor_login?
             #js-user-mentor-memo(data-user-id='#{@user.id}')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -72,7 +72,7 @@ header.page-header
                     li.card-main-actions__item
                       div
                         = '自社研修生'
-                  - elsif current_user != @user
+                  - else
                     li.card-main-actions__item
                       .js-following(data-is-following="#{current_user.following?(@user)}" data-user-id="#{@user.id}" data-is-watching="#{current_user.watching?(@user)}")
         .col-xs-12.col-lg-6.col-xxl-6

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -68,7 +68,7 @@ header.page-header
                   - elsif admin_login?
                     li.card-main-actions__item
                       = link_to '管理者として情報変更', edit_admin_user_path, class: 'card-main-actions__action a-button is-sm is-secondary is-block'
-                  - elsif current_user != @user && current_user.adviser? == true && current_user.company_id == @user.company_id && @user.trainee == true
+                  - elsif current_user != @user && current_user.adviser? && current_user.company_id == @user.company_id && @user.trainee
                     li.card-main-actions__item
                       .a-button.is-disabled.is-md.is-block
                         i.fas.fa-check

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -304,8 +304,7 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test 'show users trainees for adviser' do
-    visit_with_auth "/users?target=trainee", 'senpai'
+    visit_with_auth '/users?target=trainee', 'senpai'
     assert_text '自社研修生'
   end
-
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -282,7 +282,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_text '登録情報変更'
   end
 
-  test 'show Students' do
+  test 'show students' do
     visit_with_auth "/users/#{users(:kensyu).id}", 'hatsuno'
     assert_no_text '自社研修生'
     assert_text 'フォローする'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -274,5 +274,32 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{hatsuno.id}", 'kimura'
     assert_text 'プロフィール'
     assert_no_link '相談部屋'
+    
+  test 'show trainees for adviser' do
+    visit_with_auth "/users/#{users(:kensyu).id}", 'senpai'
+    assert_text '自社研修生'
+    assert_no_text 'フォローする'
+    assert_no_text '登録情報変更'
+  end
+
+  test 'show Students' do
+    visit_with_auth "/users/#{users(:kensyu).id}", 'yamada'
+    assert_no_text '自社研修生'
+    assert_text 'フォローする'
+    assert_no_text '登録情報変更'
+  end
+
+  test 'show no trainees for adviser' do
+    visit_with_auth "/users/#{users(:yamada).id}", 'senpai'
+    assert_no_text '自社研修生'
+    assert_text 'フォローする'
+    assert_no_text '登録情報変更'
+  end
+
+  test 'show myself' do
+    visit_with_auth "/users/#{users(:kensyu).id}", 'kensyu'
+    assert_no_text '自社研修生'
+    assert_no_text 'フォローする'
+    assert_text '登録情報変更'
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -274,6 +274,7 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{hatsuno.id}", 'kimura'
     assert_text 'プロフィール'
     assert_no_link '相談部屋'
+  end
     
   test 'show trainees for adviser' do
     visit_with_auth "/users/#{users(:kensyu).id}", 'senpai'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -275,7 +275,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_text 'プロフィール'
     assert_no_link '相談部屋'
   end
-    
+
   test 'show trainees for adviser' do
     visit_with_auth "/users/#{users(:kensyu).id}", 'senpai'
     assert_text '自社研修生'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -283,14 +283,14 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test 'show Students' do
-    visit_with_auth "/users/#{users(:kensyu).id}", 'yamada'
+    visit_with_auth "/users/#{users(:kensyu).id}", 'hatsuno'
     assert_no_text '自社研修生'
     assert_text 'フォローする'
     assert_no_text '登録情報変更'
   end
 
   test 'show no trainees for adviser' do
-    visit_with_auth "/users/#{users(:yamada).id}", 'senpai'
+    visit_with_auth "/users/#{users(:hatsuno).id}", 'senpai'
     assert_no_text '自社研修生'
     assert_text 'フォローする'
     assert_no_text '登録情報変更'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -302,4 +302,10 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_text 'フォローする'
     assert_text '登録情報変更'
   end
+
+  test 'show users trainees for adviser' do
+    visit_with_auth "/users?target=trainee", 'senpai'
+    assert_text '自社研修生'
+  end
+
 end


### PR DESCRIPTION
# 確認点1

ユーザ`senpai`でユーザ`kensyu`[ページ](http://127.0.0.1:3000/users/301971253)にアクセスする

## 変更前

ユーザ**詳細**画面にて、自社の研修生に対してフォローするボタンが表示されている

![image](https://user-images.githubusercontent.com/15277293/153005269-9a17f681-7a13-4c70-98f8-db198b74b7b2.png)


## 変更後

ユーザ**詳細**画面にて、自社の研修生に対して`自社研修生`が表示されている（デザインはmachidaさんに実施していただくので文字のみ）

![image](https://user-images.githubusercontent.com/15277293/153004695-63fe7943-dc81-4612-a3ed-1a907fab596b.png)


# 確認点2

ユーザ`senpai`で[ユーザ一覧ページ(研修生タブ)](http://127.0.0.1:3000/users?target=trainee)にアクセスする
※`http://localhost:3000`だとユーザ一覧のデータを取得できず表示されないので、`http://127.0.0.1:3000`でアクセスすること

## 変更前

ユーザ**一覧**画面にて、自社の研修生に対してフォローするボタンが表示されている

![image](https://user-images.githubusercontent.com/15277293/153530538-b60a9720-7bca-492b-ad2f-d822396d306a.png)


## 変更後

ユーザ**一覧**画面にて、自社の研修生に対して`自社研修生`が表示されている（デザインはmachidaさんに実施していただくので文字のみ）

![image](https://user-images.githubusercontent.com/15277293/153530327-d4d5b663-7972-4b0c-b21a-1323b3e0485c.png)

issue #2992 