### PR TITLE
Q&Aページ未解決タブ・左サイドバー内の未解決数からwip数を引いた数を表示

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -25,6 +25,7 @@ class Question < ApplicationRecord
   scope :solved, -> { where(id: CorrectAnswer.pluck(:question_id)) }
   scope :not_solved, -> { where.not(id: CorrectAnswer.pluck(:question_id)) }
   scope :wip, -> { where(wip: true) }
+  scope :not_wip, -> { where(wip: false) }
 
   columns_for_keyword_search :title, :description
 

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -38,9 +38,9 @@ nav.global-nav
           = link_to questions_path, class: "global-nav-links__link #{current_link(/^questions/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-question
-            - if (Question.not_solved.count - Question.wip.count).positive?
+            - if Question.not_solved.not_wip.count.positive?
               .global-nav__item-count.a-notification-count
-                = Question.not_solved.count - Question.wip.count
+                = Question.not_solved.not_wip.count
             .global-nav-links__link-label Q&A
         li.global-nav-links__item
           = link_to '/pages', class: "global-nav-links__link #{(@page&.slug != 'help') && current_link(/^pages/)}" do

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -38,9 +38,9 @@ nav.global-nav
           = link_to questions_path, class: "global-nav-links__link #{current_link(/^questions/)}" do
             .global-nav-links__link-icon
               i.fas.fa-fw.fa-question
-            - if Question.not_solved.count.positive?
+            - if (Question.not_solved.count - Question.wip.count).positive?
               .global-nav__item-count.a-notification-count
-                = Question.not_solved.count
+                = Question.not_solved.count - Question.wip.count
             .global-nav-links__link-label Q&A
         li.global-nav-links__item
           = link_to '/pages', class: "global-nav-links__link #{(@page&.slug != 'help') && current_link(/^pages/)}" do

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -4,9 +4,9 @@
       li.page-tabs__item
         = link_to polymorphic_path(:questions, practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:all].present? || params[:solved].present? ? '' : 'is-active'}" do
           | 未解決
-          - if (Question.not_solved.count - Question.wip.count).positive? && current_user.admin?
+          - if Question.not_solved.not_wip.count.positive? && current_user.admin?
             .page-tabs__item-count.a-notification-count
-              = Question.not_solved.count - Question.wip.count
+              = Question.not_solved.not_wip.count
       li.page-tabs__item
         = link_to '解決済み', polymorphic_path(:questions, solved: 'true', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:solved].present? ? 'is-active' : ''}"
       li.page-tabs__item

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -4,9 +4,9 @@
       li.page-tabs__item
         = link_to polymorphic_path(:questions, practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:all].present? || params[:solved].present? ? '' : 'is-active'}" do
           | 未解決
-          - if Question.not_solved.count.positive? && current_user.admin?
+          - if (Question.not_solved.count - Question.wip.count).positive? && current_user.admin?
             .page-tabs__item-count.a-notification-count
-              = Question.not_solved.count
+              = Question.not_solved.count - Question.wip.count
       li.page-tabs__item
         = link_to '解決済み', polymorphic_path(:questions, solved: 'true', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:solved].present? ? 'is-active' : ''}"
       li.page-tabs__item


### PR DESCRIPTION
## Issue
- #4190 

## 関連
- #3916 
- #4157 

## 概要
プルリクエスト#4157にて、Q&AページにWIP機能が追加されています。
それに追加して「未解決数」を表示しているタブ(管理者のみ)と左サイドバー(全員)の未解決数からWIP数を除いて表示する変更を行いました。

## 変更前
![image](https://user-images.githubusercontent.com/82434093/153194911-1e955aeb-326b-4497-b8ce-dbbe35970089.png)

## 変更後
![image](https://user-images.githubusercontent.com/82434093/153194659-3f4e63f0-6982-475e-8a13-46dd86966b15.png)
