### PR TITLE
ブログのpublished_at=nilかつwip=falseでもindexとshowが表示されるようにする

### DIFF
--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -25,4 +25,9 @@
                         = article.user.login_name
                     .articles__item-meta
                       .articles__item-published-at
-                        = article.wip? ? '執筆中' : l(article.published_at)
+                        - if article.wip?
+                          = '執筆中'
+                        - elsif article.published_at.nil?
+                          = l(article.created_at)
+                        - else
+                          = l(article.published_at)

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -17,7 +17,12 @@
                 = @article.user.login_name
             .article__meta
               .article__published-at
-                = @article.wip? ? '執筆中' : l(@article.published_at)
+                - if @article.wip?
+                  = '執筆中'
+                - elsif @article.published_at.nil?
+                  = l(@article.created_at)
+                - else
+                  = l(@article.published_at)
         .article__body
           .js-markdown-view.is-long-text
             = @article.body

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -40,6 +40,11 @@ namespace :bootcamp do
 
       User.all.each(&:create_talk!)
 
+      Article.where(wip: false).where(published_at: nil).find_each do |article|
+        article.published_at = article.created_at
+        article.save!(validate: false)
+      end
+
       puts '== END   Cloud Build Task =='
     end
   end

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -40,9 +40,11 @@ namespace :bootcamp do
 
       User.all.each(&:create_talk!)
 
-      Article.where(wip: false).where(published_at: nil).find_each do |article|
-        article.published_at = article.created_at
-        article.save!(validate: false)
+      if ENV['DB_NAME'] == 'bootcamp_staging'
+        Article.where(wip: false).where(published_at: nil).find_each do |article|
+          article.published_at = article.created_at
+          article.save!(validate: false)
+        end
       end
 
       puts '== END   Cloud Build Task =='

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -17,3 +17,10 @@ article3:
   body: 本文３
   user: komagata
   wip: true
+
+# published_at=nilかつwip=false
+article4:
+  title: タイトル４
+  body: 本文４
+  user: komagata
+  wip: false


### PR DESCRIPTION
## 該当のPR
- https://github.com/fjordllc/bootcamp/pull/4095

## 経緯
ブログにWIP機能をつけた際、published_atカラムを追加し、一覧画面に表示されるのがpublished_atになりました。
## 考えられる原因
ステージング環境ではデータマイグレーションが行われないとのことで、wip=false&&published_at=nilとなり、エラーが発生していると考えられます。
## 対策内容
- published_at=nil&&wip=falseでも表示されるようにする
- ステージングでだけ動かすdata migrationというのはできないので（data migrationを動かすと過去の他のステージングでは動かないdata migrationが全部動いてしまうため）、rake taskとして以下に実装
https://github.com/fjordllc/bootcamp/blob/main/lib/tasks/bootcamp.rake#L39


