### PR TITLE
卒業生の就職希望者を就職希望者のスコープに追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -257,7 +257,12 @@ class User < ApplicationRecord
   scope :trainees, -> { where(trainee: true) }
   scope :job_seeking, -> { where(job_seeking: true) }
   scope :job_seekers, lambda {
-    students.where(
+    where(
+      admin: false,
+      mentor: false,
+      adviser: false,
+      trainee: false,
+      retired_on: nil,
       job_seeker: true
     )
   }

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -161,3 +161,8 @@ talk_sotugyou-adviser:
 talk_otameshi:
   user: otameshi
   unreplied: false
+
+talk_sotugyou-with-job:
+  user: sotugyou_with_job
+  unreplied: false
+

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -47,6 +47,28 @@ machida:
   updated_at: "2014-01-01 00:00:02"
   created_at: "2014-01-01 00:00:02"
 
+sotugyou_with_job:
+  login_name: sotugyou-with-job
+  email: sotugyouwithjob@example.com
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 卒業 仕事し太郎
+  name_kana: ソツギョウ シゴトシタロウ
+  twitter_account: sotugyou_with_job
+  facebook_url: http://www.facebook.com/sotugyou_with_job
+  blog_url: http://sotugyou_with_job.example.com/
+  description: "卒業です。卒業しちゃいました。就職は希望していません。"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  job_seeker: false
+  organization: 株式会社卒業
+  graduated_on: "2015-01-01"
+  unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwj
+  updated_at: "2014-01-01 00:00:03"
+  created_at: "2014-01-01 00:00:03"
+
 sotugyou:
   login_name: sotugyou
   email: sotugyou@example.com
@@ -59,11 +81,9 @@ sotugyou:
   blog_url: http://sotugyou.example.com/
   description: "卒業です。卒業しちゃいました。"
   course: course1
-  job: office_worker
   os: mac
   experience: rails
   job_seeker: true
-  organization: 株式会社卒業
   graduated_on: "2015-01-01"
   unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwg
   updated_at: "2014-01-01 00:00:03"

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -52,8 +52,8 @@ sotugyou_with_job:
   email: sotugyouwithjob@example.com
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
-  name: 卒業 仕事し太郎
-  name_kana: ソツギョウ シゴトシタロウ
+  name: 卒業 就職済美
+  name_kana: ソツギョウ シュウショクズミ
   twitter_account: sotugyou_with_job
   facebook_url: http://www.facebook.com/sotugyou_with_job
   blog_url: http://sotugyou_with_job.example.com/

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -80,3 +80,7 @@ talk20:
 talk21:
   user: otameshi
   unreplied: false
+
+talk22:
+  user: sotugyou_with_job
+  unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -77,8 +77,8 @@ sotugyou_with_job:
   email: sotugyouwithjob@example.com
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
-  name: 卒業 仕事し太郎
-  name_kana: ソツギョウ シゴトシタロウ
+  name: 卒業 就職済美
+  name_kana: ソツギョウ シュウショクズミ
   twitter_account: sotugyou_with_job
   facebook_url: http://www.facebook.com/sotugyou_with_job
   blog_url: http://sotugyou_with_job.example.com/

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -72,6 +72,28 @@ adminonly: # adminのroleだけを持ったユーザー
   updated_at: "2021-02-01 00:00:30"
   created_at: "2021-02-01 00:00:30"
 
+sotugyou_with_job:
+  login_name: sotugyou-with-job
+  email: sotugyouwithjob@example.com
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 卒業 仕事し太郎
+  name_kana: ソツギョウ シゴトシタロウ
+  twitter_account: sotugyou_with_job
+  facebook_url: http://www.facebook.com/sotugyou_with_job
+  blog_url: http://sotugyou_with_job.example.com/
+  description: "卒業です。卒業しちゃいました。就職は希望していません。"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  job_seeker: false
+  organization: 株式会社卒業
+  graduated_on: "2015-01-01"
+  unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwj
+  updated_at: "2014-01-01 00:00:03"
+  created_at: "2014-01-01 00:00:03"
+
 sotugyou:
   login_name: sotugyou
   email: sotugyou@example.com
@@ -84,11 +106,9 @@ sotugyou:
   blog_url: http://sotugyou.example.com/
   description: "卒業です。卒業しちゃいました。"
   course: course1
-  job: office_worker
   os: mac
   experience: rails
   job_seeker: true
-  organization: 株式会社卒業
   graduated_on: "2015-01-01"
   unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwg
   updated_at: "2014-01-01 00:00:03"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -299,7 +299,8 @@ class UserTest < ActiveSupport::TestCase
     target = User.announcement_receiver('job_seekers')
     assert_includes(target, users(:jobseeker))
     assert_includes(target, users(:komagata))
-    assert_not_includes(target, users(:sotugyou))
+    assert_includes(target, users(:sotugyou))
+    assert_not_includes(target, users(:sotugyou_with_job))
     assert_not_includes(target, users(:kimura))
     assert_not_includes(target, users(:yameo))
   end


### PR DESCRIPTION
## Issue
- #4169 

## 変更内容
- userモデルのjob_seekersを、現役生と卒業生の就職希望者に拡張した。
- テストとDBのフィクスチャにユーザーsotugyou-with-jobを追加し（talkも追加した）、就職済の卒業生とした。
- 元々あったsotugyouは、就職希望が`true`なのに企業名が入力されている状態だったので、企業名などを削除した。
- テストにもsotugyou-with-jobを追加し、sotugyou-with-jobは就職希望者の対象に含まれず、sotugyouが就職希望者の対象に含まれることを確認するようにした。


## 変更前
https://user-images.githubusercontent.com/39044468/153428074-b3462b01-3096-4918-940f-825aa5a53076.mov

## 変更後

https://user-images.githubusercontent.com/39044468/153428162-3d9e9550-375e-4a9f-8f7b-1478f0f19dfe.mov


