### PR TITLE
相談部屋のコメントをDiscordチャットに通知する

### DIFF
--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -11,6 +11,7 @@ class Comment::AfterCreateCallback
 
     if comment.commentable.instance_of?(Talk)
       notify_to_admins(comment)
+      notify_to_chat(comment) unless comment.sender.admin?
       update_unreplied(comment)
     end
 
@@ -106,5 +107,13 @@ class Comment::AfterCreateCallback
   def update_unreplied(comment)
     unreplied = !comment.user.admin
     comment.commentable.update!(unreplied: unreplied)
+  end
+
+  def notify_to_chat(comment)
+    ChatNotifier.message(<<~TEXT, webhook_url: ENV['DISCORD_ADMIN_WEBHOOK_URL'])
+      相談部屋にて#{comment.user.login_name}さんからコメントがありました。
+      本文： #{comment.description}
+      URL： https://bootcamp.fjord.jp/talks/#{comment.commentable_id}
+    TEXT
   end
 end


### PR DESCRIPTION
## Issue
- #4093 

## 概要
相談部屋に受講生（その相談部屋の主）からコメントがあったら、Discordの運営のチャンネルに通知が来るようにしました。
- Discordの運営のチャンネルは管理者のユーザーが見れるプライベートチャンネルのようです。
- `admin`のユーザーがコメントした場合は通知されないようにしています。

運営チャンネルのウェブフックは`DISCORD_ADMIN_WEBHOOK_URL`に統一されているようなので、それに沿う形にしました。
通知内容に関しては、町田さんより本文とURLを含めてほしいとのコメントをいただきましたので、そのような仕様しました。

## 前提
Discordへの通知に関しては #3471 を参考にして書いています。
今回のIssueはDiscord通知において開発環境と本番環境で実装する内容が変わってくるため、変更分をそのままマージすることができません。
なのでレビューで動作確認をする際は下でまとめた確認方法の手順を行っていただく必要があります。

ローカルでの動作確認方法にお手間を取らせてしまいますが、ご確認のほどよろしくお願いします🙏

## 確認方法
1. ブランチ feature/notify-admin-chat-of-talkroom-commentをローカルに取り込む

2. `dotenv-rails`というgemをGemfileに追記(Gemfile`82`行目)し、インストール
```
# Gemfile
group :development do 
# not default
gem 'view_source_map'
+ gem 'dotenv-rails' # view_source_mapの下に追加して下さい
```
- 参考：[Railsで使える環境変数を管理できるgem(dotenv-rails)や.envの導入方法 - Qiita](https://qiita.com/ryosuketter/items/ceb592dc6b23a20e51b5)
```
% bundle install
```

3. .envファイルをbootcampディレクトリ配下に作成する
```
% touch .env
```

4. 自分用のDiscordサーバーを作成する
- 参考：[Discord – サーバーの作り方と削除する方法 \| 設定Lab](https://setup-lab.net/discord-server-creation-delete/#toc1)

5. 4で作成したサーバーのウェブフックURLを [こちらの手順](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks)に従ってコピーしておく
日本語版ではサーバー設定＞連携サービス＞ウェブフックを作成＞ウェブフックURLをコピー

6. コピーしたウェブフックURLを環境変数として使いたいので、作成した.envファイルには下の内容を追記する
```
DISCORD_ADMIN_WEBHOOK_URL = コピーしたウェブフックURL
```

7. app/model/chat_norifier.rbのmessageメソッドの記述を変更する

```ruby
# app/model/chat_norifier.rb
class ChatNotifier
  def self.message(
    message,
    username: 'ピヨルド',
    webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
  )

-   if Rails.env.production?
+   if Rails.env.development?
      Discord::Notifier.message(message, username: username, url: webhook_url)
    else
      Rails.logger.info 'Message to Discord.'
    end
  end
..
```

Rails.env.development?にすることでtrueの分岐を実行することができます。
参考：[【Rails】 envメソッドで環境を確認する方法と各コマンドの指定方法 - Pikawaka](https://pikawaka.com/rails/env)

8. 動作確認をする
    (1) admin以外のユーザーでログイン(`kimura`でログインしました)
    (2) 自身の相談部屋からコメントします。
    (3) 自分で作成したDiscordチャンネルに通知がきます。
    <img width="415" alt="image" src="https://user-images.githubusercontent.com/69446373/153561081-a9e60c2f-d8bc-4285-a040-0bb14824b83b.png">
    (4) adminのユーザーで同じ相談部屋にコメントすると通知は来ません(`komagata`で確認)

以上となっております。
お困りのことなどありましたら、何なりとお申し付けください🙏