### PR TITLE
管理者でログインしたときだけ、相談部屋の個別ページにユーザーメモと、ユーザー公開情報、非公開情報を表示

### DIFF
--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -7,47 +7,48 @@ header.page-header
         = title
 
 .page-body
-  .container.is-lg
-    .thread
-      .thread__inner.a-card
-        header.thread-header.has-no-icon
-          .thread-header__row
-            h1.thread-header-title
-              = title
-        .thread__body
-          .thread__description.is-long-text
-            p
-              | ここは#{@user.login_name}さんと管理者のみが閲覧することのできる相談部屋です。
-              | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
-        .thread-footer
-          .thread-footer__inner
-            .thread-members
-              h2.thread-members__title
-                | 相談部屋にアクセスできるメンバー
-              ul.thread-members__items
-                - @members.each do |member|
-                  li.thread-members__item
-                    = render 'users/icon',
-                      user: member,
-                      link_class: 'thread-members__user-icon-link',
-                      image_class: 'thread-members__user-icon'
-                    = link_to user_path(member.id), class: 'a-user-name' do
-                      = member.login_name
-    a#comments.a-anchor
-    #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")
-
-  .is-only-mentor(class="#{current_user.admin? ? 'col-xl-5 col-xs-12 is-hidden-sm-down' : ''}")
-    - if current_user.admin?
-      .side-tabs
-        input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
-        .side-tabs-nav
-          .side-tabs-nav__items
-            .side-tabs-nav__item
-              label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'
-                | ユーザーメモ
-        .side-tabs-contents
-          .side-tabs-contents__item#side-tabs-content-1
-            .user-info
-              = render 'users/user_secret_attributes', user: @user
-              = render 'users/metas', user: @user
-            #js-user-mentor-memo(data-user-id="#{@user.id}" data-products-mode="#{true}")
+  .container.is-xxxl
+    .row.is-jc:c
+      .col-xl-7.col-xs-12
+        .thread
+          .thread__inner.a-card
+            header.thread-header.has-no-icon
+              .thread-header__row
+                h1.thread-header-title
+                  = title
+            .thread__body
+              .thread__description.is-long-text
+                p
+                  | ここは#{@user.login_name}さんと管理者のみが閲覧することのできる相談部屋です。
+                  | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
+            .thread-footer
+              .thread-footer__inner
+                .thread-members
+                  h2.thread-members__title
+                    | 相談部屋にアクセスできるメンバー
+                  ul.thread-members__items
+                    - @members.each do |member|
+                      li.thread-members__item
+                        = render 'users/icon',
+                          user: member,
+                          link_class: 'thread-members__user-icon-link',
+                          image_class: 'thread-members__user-icon'
+                        = link_to user_path(member.id), class: 'a-user-name' do
+                          = member.login_name
+        a#comments.a-anchor
+        #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")
+      .is-only-mentor(class="#{current_user.admin? ? 'col-xl-5 col-xs-12 is-hidden-sm-down' : ''}")
+        - if current_user.admin?
+          .side-tabs
+            input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
+            .side-tabs-nav
+              .side-tabs-nav__items
+                .side-tabs-nav__item
+                  label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'
+                    | ユーザーメモ
+            .side-tabs-contents
+              .side-tabs-contents__item#side-tabs-content-1
+                .user-info
+                  = render 'users/user_secret_attributes', user: @user
+                  = render 'users/metas', user: @user
+                #js-user-mentor-memo(data-user-id="#{@user.id}" data-products-mode="#{true}")

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -36,8 +36,8 @@ header.page-header
     a#comments.a-anchor
     #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")
 
-  .is-only-mentor(class="#{current_user.mentor? || current_user.admin? ? 'col-xl-5 col-xs-12 is-hidden-sm-down' : ''}")
-    - if current_user.mentor? || current_user.admin?
+  .is-only-mentor(class="#{current_user.admin? ? 'col-xl-5 col-xs-12 is-hidden-sm-down' : ''}")
+    - if current_user.admin?
       .side-tabs
         input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
         .side-tabs-nav

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -35,3 +35,19 @@ header.page-header
                       = member.login_name
     a#comments.a-anchor
     #js-comments(data-commentable-id="#{@talk.id}" data-commentable-type='Talk' data-current-user-id="#{current_user.id}")
+
+  .is-only-mentor(class="#{current_user.mentor? || current_user.admin? ? 'col-xl-5 col-xs-12 is-hidden-sm-down' : ''}")
+    - if current_user.mentor? || current_user.admin?
+      .side-tabs
+        input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
+        .side-tabs-nav
+          .side-tabs-nav__items
+            .side-tabs-nav__item
+              label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'
+                | ユーザーメモ
+        .side-tabs-contents
+          .side-tabs-contents__item#side-tabs-content-1
+            .user-info
+              = render 'users/user_secret_attributes', user: @user
+              = render 'users/metas', user: @user
+            #js-user-mentor-memo(data-user-id="#{@user}" data-products-mode="#{true}")

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -50,4 +50,4 @@ header.page-header
             .user-info
               = render 'users/user_secret_attributes', user: @user
               = render 'users/metas', user: @user
-            #js-user-mentor-memo(data-user-id="#{@user}" data-products-mode="#{true}")
+            #js-user-mentor-memo(data-user-id="#{@user.id}" data-products-mode="#{true}")

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -477,8 +477,8 @@ ActiveRecord::Schema.define(version: 2022_02_01_020526) do
     t.text "mentor_memo"
     t.string "discord_account"
     t.string "times_url"
-    t.text "after_graduation_hope"
     t.boolean "notified_retirement", default: false, null: false
+    t.text "after_graduation_hope"
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -477,8 +477,8 @@ ActiveRecord::Schema.define(version: 2022_02_01_020526) do
     t.text "mentor_memo"
     t.string "discord_account"
     t.string "times_url"
-    t.boolean "notified_retirement", default: false, null: false
     t.text "after_graduation_hope"
+    t.boolean "notified_retirement", default: false, null: false
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -99,7 +99,7 @@ class TalksTest < ApplicationSystemTestCase
     assert_text 'yameo (辞目 辞目夫) さんの相談部屋'
   end
 
-  test 'are both public information and private information displayed correctly' do
+  test 'make sure that both public and private information is displayed correctly' do
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'
     assert_no_text 'ユーザー非公開情報'

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -99,7 +99,7 @@ class TalksTest < ApplicationSystemTestCase
     assert_text 'yameo (辞目 辞目夫) さんの相談部屋'
   end
 
-  test 'Is the public information and private information displayed correctly' do
+  test 'are both public information and private information displayed correctly' do
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'
     wait_for_vuejs

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -98,4 +98,33 @@ class TalksTest < ApplicationSystemTestCase
     find('#talks.loaded', wait: 10)
     assert_text 'yameo (辞目 辞目夫) さんの相談部屋'
   end
+
+  test 'Is the public information and private information displayed correctly' do
+    user = users(:kimura)
+    visit_with_auth "/talks/#{user.talk.id}", 'kimura'
+    wait_for_vuejs
+    assert_no_text 'ユーザー非公開情報'
+    assert_no_text 'ユーザー公開情報'
+
+    logout
+    visit_with_auth '/talks', 'komagata'
+    click_link "#{user.login_name} (#{user.name}) さんの相談部屋"
+    wait_for_vuejs
+    assert_text 'ユーザー非公開情報'
+    assert_text 'ユーザー公開情報'
+  end
+
+  test 'update memo' do
+    user = users(:kimura)
+    visit_with_auth '/talks', 'komagata'
+    click_link "#{user.login_name} (#{user.name}) さんの相談部屋"
+    wait_for_vuejs
+    assert_text 'kimuraさんのメモ'
+    click_button '編集'
+    fill_in 'js-user-mentor-memo', with: '相談部屋テストメモ'
+    click_button '保存する'
+    wait_for_vuejs
+    assert_text '相談部屋テストメモ'
+    assert_no_text 'kimuraさんのメモ'
+  end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -99,7 +99,7 @@ class TalksTest < ApplicationSystemTestCase
     assert_text 'yameo (辞目 辞目夫) さんの相談部屋'
   end
 
-  test 'make sure that both public and private information is displayed correctly' do
+  test 'both public and private information is displayed' do
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'
     assert_no_text 'ユーザー非公開情報'

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -102,14 +102,12 @@ class TalksTest < ApplicationSystemTestCase
   test 'are both public information and private information displayed correctly' do
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'
-    wait_for_vuejs
     assert_no_text 'ユーザー非公開情報'
     assert_no_text 'ユーザー公開情報'
 
     logout
     visit_with_auth '/talks', 'komagata'
     click_link "#{user.login_name} (#{user.name}) さんの相談部屋"
-    wait_for_vuejs
     assert_text 'ユーザー非公開情報'
     assert_text 'ユーザー公開情報'
   end
@@ -118,12 +116,10 @@ class TalksTest < ApplicationSystemTestCase
     user = users(:kimura)
     visit_with_auth '/talks', 'komagata'
     click_link "#{user.login_name} (#{user.name}) さんの相談部屋"
-    wait_for_vuejs
     assert_text 'kimuraさんのメモ'
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: '相談部屋テストメモ'
     click_button '保存する'
-    wait_for_vuejs
     assert_text '相談部屋テストメモ'
     assert_no_text 'kimuraさんのメモ'
   end


### PR DESCRIPTION
ref: #4070

# 要件
管理者でログインしたときだけ、相談部屋の個別ページにユーザーメモと、ユーザー公開情報、非公開情報を表示する。

# 画面イメージ

## 変更前
<img height="500px;" src="https://user-images.githubusercontent.com/6190966/154690742-936f66db-510c-4b16-a293-f48e5adff5f2.png">

## 変更後

<img height="500px;" src="https://user-images.githubusercontent.com/6190966/153734118-3f2ae5d0-a901-4872-a1af-dd9df58b6fc0.png">

# 確認方法
1. `feature/display-user-notes-on-individual-pages-of-talk-room` ブランチをローカルに持ってくる（参考：https://qiita.com/great084/items/ad74dd064a2c2bc47cff ）
```
git fetch origin pull/{このプルリクエストのid}/head:{任意のブランチ名}
git checkout {上記でfetchした任意のブランチ名}
```
2. 管理者（`komagata` or `machida`）のアカウントでログイン
3. 任意の相談部屋（画面左端のタブの一番下の相談 <img height="50px;" src="https://user-images.githubusercontent.com/6190966/154691202-48701cd5-d420-4474-ae59-9c919510bc03.png">から任意の相談部屋にアクセスしてユーザーメモ、ユーザー公開情報、非公開情報が表示されていることを確認
4. ユーザーメモが編集できることを確認
![talk](https://user-images.githubusercontent.com/6190966/153734010-6b7f59bd-db18-45a0-9dc3-a944d80d1981.gif)
5. 任意の生徒のアカウントでログイン
6. 相談部屋にアクセス（画面右端の`お知らせ`、`プラクティス`）などがならんでいるタブの一番部屋の`相談`をクリック）
7. ユーザーメモ、ユーザー公開情報、非公開情報が表示されていないことを確認

※メンターや相談部屋を建てた以外の生徒のロールのアカウントでは相談部屋を確認できないので上記以外のパターンの確認は不要