### PR TITLE
メンター・アドバイザー・管理者はダッシュボードの学習時間の草を非表示にする

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -62,7 +62,7 @@ header.page-header
                     | 内容を更新
           - if (current_user.admin? || current_user.adviser?) && @job_seeking_users.present?
             = render 'job_seeking_users', users: @job_seeking_users
-          - if current_user.total_learning_time.positive? || !current_user.mentor?
+          - unless current_user.mentor? || current_user.adviser? || current_user.admin?
             #js-grass(data-user-id="#{current_user.id}")
           - if current_user.github_account.present?
             = render 'users/github_grass', user: current_user

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -62,7 +62,7 @@ header.page-header
                     | 内容を更新
           - if (current_user.admin? || current_user.adviser?) && @job_seeking_users.present?
             = render 'job_seeking_users', users: @job_seeking_users
-          - unless current_user.mentor? || current_user.adviser? || current_user.admin?
+          - if current_user.student_or_trainee?
             #js-grass(data-user-id="#{current_user.id}")
           - if current_user.github_account.present?
             = render 'users/github_grass', user: current_user

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -88,30 +88,33 @@ class HomeTest < ApplicationSystemTestCase
     assert_current_path(/niconico_calendar=#{1.month.ago.strftime('%Y-%m')}/)
   end
 
-  test 'show the grass for student and trainee' do
+  test 'show the grass for student' do
     assert users(:kimura).student?
     visit_with_auth '/', 'kimura'
     assert_selector 'h2.card-header__title', text: '学習時間'
-    logout
+  end
 
+  test 'show the grass for trainee' do
     assert users(:kensyu).trainee?
     visit_with_auth '/', 'kensyu'
     assert_selector 'h2.card-header__title', text: '学習時間'
   end
 
-  test 'not show the grass for mentor, adviser, and admin' do
+  test 'not show the grass for mentor' do
     assert users(:mentormentaro).mentor?
     visit_with_auth '/', 'mentormentaro'
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_selector 'h2.card-header__title', text: '学習時間'
-    logout
+  end
 
+  test 'not show the grass for adviser' do
     assert users(:advijirou).adviser?
     visit_with_auth '/', 'advijirou'
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_selector 'h2.card-header__title', text: '学習時間'
-    logout
+  end
 
+  test 'not show the grass for admin' do
     assert users(:komagata).admin?
     visit_with_auth '/', 'komagata'
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -88,9 +88,26 @@ class HomeTest < ApplicationSystemTestCase
     assert_current_path(/niconico_calendar=#{1.month.ago.strftime('%Y-%m')}/)
   end
 
-  test 'show the grass' do
+  test 'show the grass except for mentors, advisers, and administrators' do
     visit_with_auth '/', 'hajime'
     assert_text '学習時間'
+    logout
+
+    visit_with_auth '/', 'yamada'
+    assert_no_text '学習時間'
+    logout
+
+    visit_with_auth '/', 'advijirou'
+    assert_no_text '学習時間'
+    logout
+
+    visit_with_auth '/', 'adminonly'
+    assert_no_text '学習時間'
+  end
+
+  test 'not show the grass for administrators' do
+    visit_with_auth '/', 'komagata'
+    assert_no_text 'ニコニコカレンダー'
   end
 
   test 'show test events on dashboard' do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -89,28 +89,28 @@ class HomeTest < ApplicationSystemTestCase
   end
 
   test 'show the grass for student and trainee' do
-    # 生徒は学習時間の草を表示する
+    assert users(:kimura).student?
     visit_with_auth '/', 'kimura'
     assert_text '学習時間'
     logout
 
-    # 研修生は学習時間の草を表示する
+    assert users(:kensyu).trainee?
     visit_with_auth '/', 'kensyu'
     assert_text '学習時間'
   end
 
   test 'not show the grass for mentor, adviser, and admin' do
-    # メンターは学習時間の草を表示しない
+    assert users(:mentormentaro).mentor?
     visit_with_auth '/', 'mentormentaro'
     assert_no_text '学習時間'
     logout
 
-    # アドバイザーは学習時間の草を表示しない
+    assert users(:advijirou).adviser?
     visit_with_auth '/', 'advijirou'
     assert_no_text '学習時間'
     logout
 
-    # 管理者は学習時間の草を表示しない
+    assert users(:komagata).admin?
     visit_with_auth '/', 'komagata'
     assert_no_text '学習時間'
   end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -105,11 +105,6 @@ class HomeTest < ApplicationSystemTestCase
     assert_no_text '学習時間'
   end
 
-  test 'not show the grass for administrators' do
-    visit_with_auth '/', 'komagata'
-    assert_no_text 'ニコニコカレンダー'
-  end
-
   test 'show test events on dashboard' do
     travel_to Time.zone.local(2017, 4, 1, 10, 0, 0) do
       visit_with_auth '/', 'komagata'

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -91,12 +91,12 @@ class HomeTest < ApplicationSystemTestCase
   test 'show the grass for student and trainee' do
     assert users(:kimura).student?
     visit_with_auth '/', 'kimura'
-    assert_text '学習時間'
+    assert_selector 'h2.card-header__title', text: '学習時間'
     logout
 
     assert users(:kensyu).trainee?
     visit_with_auth '/', 'kensyu'
-    assert_text '学習時間'
+    assert_selector 'h2.card-header__title', text: '学習時間'
   end
 
   test 'not show the grass for mentor, adviser, and admin' do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -102,16 +102,19 @@ class HomeTest < ApplicationSystemTestCase
   test 'not show the grass for mentor, adviser, and admin' do
     assert users(:mentormentaro).mentor?
     visit_with_auth '/', 'mentormentaro'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text '学習時間'
     logout
 
     assert users(:advijirou).adviser?
     visit_with_auth '/', 'advijirou'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text '学習時間'
     logout
 
     assert users(:komagata).admin?
     visit_with_auth '/', 'komagata'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text '学習時間'
   end
 

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -89,8 +89,8 @@ class HomeTest < ApplicationSystemTestCase
   end
 
   test 'show the grass for student and trainee' do
-    visit_with_auth '/', 'kimura'
     # 生徒は学習時間の草を表示する
+    visit_with_auth '/', 'kimura'
     assert_text '学習時間'
     logout
 

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -88,20 +88,30 @@ class HomeTest < ApplicationSystemTestCase
     assert_current_path(/niconico_calendar=#{1.month.ago.strftime('%Y-%m')}/)
   end
 
-  test 'show the grass except for mentors, advisers, and administrators' do
-    visit_with_auth '/', 'hajime'
+  test 'show the grass for student and trainee' do
+    visit_with_auth '/', 'kimura'
+    # 生徒は学習時間の草を表示する
     assert_text '学習時間'
     logout
 
+    # 研修生は学習時間の草を表示する
+    visit_with_auth '/', 'kensyu'
+    assert_text '学習時間'
+  end
+
+  test 'not show the grass for mentor, adviser, and admin' do
+    # メンターは学習時間の草を表示しない
     visit_with_auth '/', 'yamada'
     assert_no_text '学習時間'
     logout
 
+    # アドバイザーは学習時間の草を表示しない
     visit_with_auth '/', 'advijirou'
     assert_no_text '学習時間'
     logout
 
-    visit_with_auth '/', 'adminonly'
+    # 管理者は学習時間の草を表示しない
+    visit_with_auth '/', 'komagata'
     assert_no_text '学習時間'
   end
 

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -103,19 +103,19 @@ class HomeTest < ApplicationSystemTestCase
     assert users(:mentormentaro).mentor?
     visit_with_auth '/', 'mentormentaro'
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
-    assert_no_text '学習時間'
+    assert_no_selector 'h2.card-header__title', text: '学習時間'
     logout
 
     assert users(:advijirou).adviser?
     visit_with_auth '/', 'advijirou'
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
-    assert_no_text '学習時間'
+    assert_no_selector 'h2.card-header__title', text: '学習時間'
     logout
 
     assert users(:komagata).admin?
     visit_with_auth '/', 'komagata'
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
-    assert_no_text '学習時間'
+    assert_no_selector 'h2.card-header__title', text: '学習時間'
   end
 
   test 'show test events on dashboard' do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -101,7 +101,7 @@ class HomeTest < ApplicationSystemTestCase
 
   test 'not show the grass for mentor, adviser, and admin' do
     # メンターは学習時間の草を表示しない
-    visit_with_auth '/', 'yamada'
+    visit_with_auth '/', 'mentormentaro'
     assert_no_text '学習時間'
     logout
 


### PR DESCRIPTION
issue #4110 
# 変更前
これまで、ダッシュボードの学習時間の草の表示条件は以下のようになっていました。
- 学習時間が有るユーザーなら全員表示する
- 学習時間が無ければ、メンターでない場合表示する(メンター以外は学習時間の有無に関わらず表示する)
<br>
具体的には、以下の画面になっていました。

- メンター(`mentormentaro`):学習時間があるメンターは表示 / ないメンターは非表示
(以下の画像はありの場合のものです) 

<img width="1438" alt="前：メンター(yamada)" src="https://user-images.githubusercontent.com/58052292/153705039-c25f8311-88f5-4a3d-ae65-54dbbcc94052.png">

- アドバイザー(`advijirou`):学習時間の有無に関わらず表示
<img width="1433" alt="前(草なし)：アドバイザー(advijirou)" src="https://user-images.githubusercontent.com/58052292/153708008-26a67730-04f2-4658-a9a4-c4a0480a36d2.png">

- 管理者(`adminonly`):学習時間の有無に関わらず表示
<img width="1434" alt="前：管理者(adminonly)" src="https://user-images.githubusercontent.com/58052292/153708102-f3fed566-a4ec-411f-9c13-6cbfadda1892.png">


# 変更後
以下に変更いたしました。
- メンター・アドバイザー・管理者の場合、(学習時間の有る無しに関わらず)非表示
- それ以外のユーザーは(学習時間の有る無しに関わらず)表示

具体的には、以下の画面に変更いたしました。
- メンター(`mentormentaro`)

<img width="1437" alt="後：メンター" src="https://user-images.githubusercontent.com/58052292/153708416-ba10464c-2876-4e6c-9c4c-3d7aee080dc8.png">

- アドバイザー(`advijirou`)

<img width="1437" alt="後：アドバイザー" src="https://user-images.githubusercontent.com/58052292/153708418-1ab88313-5885-44a3-86b3-7dd2ce8314a0.png">

- 管理者(`adminonly`)
<img width="1440" alt="後：管理者" src="https://user-images.githubusercontent.com/58052292/153708423-3bdc3aac-eec9-495b-a0a6-1fac706044e3.png">


# ご確認いただきたいこと3点
1. `mentormentaro`でログインした時、学習時間が有る時も無い時も、ダッシュボードに学習時間の草が無い
2. `advijirou`でログインした時、学習時間が有る時も無い時も、ダッシュボードに学習時間の草が無い
3. `adminonly`でログインした時、学習時間が有る時も無い時も、ダッシュボードに学習時間の草が無い

