### PR TITLE
コメントと同時に日報や提出物を確認のテストを追加

### DIFF
--- a/test/system/api/check/products_test.rb
+++ b/test/system/api/check/products_test.rb
@@ -46,7 +46,7 @@ class Check::ProductsTest < ApplicationSystemTestCase
   test 'comment and check product by mentor' do
     visit_with_auth "/products/#{products(:product1).id}", 'yamada'
     fill_in 'new_comment[description]', with: '提出物でcomment+確認OKにするtest'
-    page.accept_confirm do
+    accept_confirm do
       click_on '確認OKにする'
     end
     assert_text '確認済'
@@ -56,7 +56,7 @@ class Check::ProductsTest < ApplicationSystemTestCase
   test 'comment and check product by admin' do
     visit_with_auth "/products/#{products(:product1).id}", 'adminonly'
     fill_in 'new_comment[description]', with: '提出物でcomment+確認OKにするtest'
-    page.accept_confirm do
+    accept_confirm do
       click_on '確認OKにする'
     end
     assert_text '確認済'

--- a/test/system/api/check/products_test.rb
+++ b/test/system/api/check/products_test.rb
@@ -44,19 +44,9 @@ class Check::ProductsTest < ApplicationSystemTestCase
   end
 
   test 'comment and check product by mentor' do
-    visit_with_auth "/products/#{products(:product1).id}", 'yamada'
+    visit_with_auth "/products/#{products(:product1).id}", 'mentormentaro'
     fill_in 'new_comment[description]', with: '提出物でcomment+確認OKにするtest'
-    accept_confirm do
-      click_on '確認OKにする'
-    end
-    assert_text '確認済'
-    assert_text '提出物でcomment+確認OKにするtest'
-  end
-
-  test 'comment and check product by admin' do
-    visit_with_auth "/products/#{products(:product1).id}", 'adminonly'
-    fill_in 'new_comment[description]', with: '提出物でcomment+確認OKにするtest'
-    accept_confirm do
+    page.accept_confirm do
       click_on '確認OKにする'
     end
     assert_text '確認済'

--- a/test/system/api/check/products_test.rb
+++ b/test/system/api/check/products_test.rb
@@ -42,4 +42,24 @@ class Check::ProductsTest < ApplicationSystemTestCase
     assert_text '確認済'
     assert_text '提出物でcomment+確認OKにするtest'
   end
+
+  test 'comment and check product by mentor' do
+    visit_with_auth "/products/#{products(:product1).id}", 'yamada'
+    fill_in 'new_comment[description]', with: '提出物でcomment+確認OKにするtest'
+    page.accept_confirm do
+      click_on '確認OKにする'
+    end
+    assert_text '確認済'
+    assert_text '提出物でcomment+確認OKにするtest'
+  end
+
+  test 'comment and check product by admin' do
+    visit_with_auth "/products/#{products(:product1).id}", 'adminonly'
+    fill_in 'new_comment[description]', with: '提出物でcomment+確認OKにするtest'
+    page.accept_confirm do
+      click_on '確認OKにする'
+    end
+    assert_text '確認済'
+    assert_text '提出物でcomment+確認OKにするtest'
+  end
 end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -47,21 +47,9 @@ class Check::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'comment and check report by mentor' do
-    visit_with_auth "/reports/#{reports(:report20).id}", 'yamada'
+    visit_with_auth "/reports/#{reports(:report20).id}", 'mentormentaro'
     fill_in 'new_comment[description]', with: '日報でcomment+確認OKにするtest'
-    accept_confirm do
-      click_on '確認OKにする'
-    end
-    assert_text '確認済'
-    assert_text '日報でcomment+確認OKにするtest'
-  end
-
-  test 'comment and check report by admin' do
-    visit_with_auth "/reports/#{reports(:report20).id}", 'adminonly'
-    fill_in 'new_comment[description]', with: '日報でcomment+確認OKにするtest'
-    accept_confirm do
-      click_on '確認OKにする'
-    end
+    click_button '確認OKにする'
     assert_text '確認済'
     assert_text '日報でcomment+確認OKにするtest'
   end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -49,7 +49,7 @@ class Check::ReportsTest < ApplicationSystemTestCase
   test 'comment and check report by mentor' do
     visit_with_auth "/reports/#{reports(:report20).id}", 'yamada'
     fill_in 'new_comment[description]', with: '日報でcomment+確認OKにするtest'
-    page.accept_confirm do
+    accept_confirm do
       click_on '確認OKにする'
     end
     assert_text '確認済'
@@ -59,7 +59,7 @@ class Check::ReportsTest < ApplicationSystemTestCase
   test 'comment and check report by admin' do
     visit_with_auth "/reports/#{reports(:report20).id}", 'adminonly'
     fill_in 'new_comment[description]', with: '日報でcomment+確認OKにするtest'
-    page.accept_confirm do
+    accept_confirm do
       click_on '確認OKにする'
     end
     assert_text '確認済'

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -45,4 +45,24 @@ class Check::ReportsTest < ApplicationSystemTestCase
     assert_text '確認済'
     assert_text '日報でcomment+確認OKにするtest'
   end
+
+  test 'comment and check report by mentor' do
+    visit_with_auth "/reports/#{reports(:report20).id}", 'yamada'
+    fill_in 'new_comment[description]', with: '日報でcomment+確認OKにするtest'
+    page.accept_confirm do
+      click_on '確認OKにする'
+    end
+    assert_text '確認済'
+    assert_text '日報でcomment+確認OKにするtest'
+  end
+
+  test 'comment and check report by admin' do
+    visit_with_auth "/reports/#{reports(:report20).id}", 'adminonly'
+    fill_in 'new_comment[description]', with: '日報でcomment+確認OKにするtest'
+    page.accept_confirm do
+      click_on '確認OKにする'
+    end
+    assert_text '確認済'
+    assert_text '日報でcomment+確認OKにするtest'
+  end
 end


### PR DESCRIPTION
[#4039](https://github.com/fjordllc/bootcamp/issues/4039)
# 要件
![image](https://user-images.githubusercontent.com/34033366/153717414-d4d39eba-0746-4071-a73b-e675f1cb170f.png)
MentorでログインしたときとAdminでログインしたときに、コメントと同時に日報や提出物を確認するボタンのテスト（上記のボタン）を追加する。
# 二つのテストを実施したイメージ
<img width="473" alt="Screen Shot 2022-02-12 at 22 32 06" src="https://user-images.githubusercontent.com/34033366/153717536-6ad404af-b145-4581-8065-d4c6bf54b4b2.png">

