### PR TITLE
vue.js を使っているところでも複数の role を認識出来るようにする

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -44,21 +44,21 @@
               i.fas.fa-pen
               | 内容修正
           li.card-main-actions__item(
-            v-if='!hasCorrectAnswer && answer.type != "CorrectAnswer" && (currentUser.id === questionUser.id || isRole("mentor") || isRole("admin"))'
+            v-if='!hasCorrectAnswer && answer.type != "CorrectAnswer" && (currentUser.id === questionUser.id || isRole("mentor"))'
           )
             button.card-main-actions__action.a-button.is-md.is-primary.is-block(
               @click='makeToBestAnswer'
             )
               | ベストアンサーにする
           li.card-main-actions__item(
-            v-if='hasCorrectAnswer && answer.type == "CorrectAnswer" && (currentUser.id === questionUser.id || isRole("mentor") || isRole("admin"))'
+            v-if='hasCorrectAnswer && answer.type == "CorrectAnswer" && (currentUser.id === questionUser.id || isRole("mentor"))'
           )
             button.card-main-actions__action.a-button.is-md.is-muted.is-block(
               @click='cancelBestAnswer'
             )
               | ベストアンサーを取り消す
           li.card-main-actions__item.is-sub(
-            v-if='answer.user.id == currentUser.id || isRole("mentor") || isRole("admin")'
+            v-if='answer.user.id == currentUser.id || isRole("mentor")'
           )
             button.card-main-actions__delete(@click='deleteAnswer')
               | 削除する

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -59,7 +59,7 @@
               )
                 | コメントする
             .card-main-actions__item.is-only-mentor(
-              v-if='(isRole("mentor") || isRole("admin")) && commentType && !checkId'
+              v-if='isRole("mentor") && commentType && !checkId'
             )
               button.a-button.is-md.is-danger.is-block(
                 @click='commentAndCheck',

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -71,7 +71,7 @@
           :reactionableId='`Question_${question.id}`'
         )
         footer.card-footer(
-          v-if='currentUser.id === question.user.id || isRole("mentor") || isRole("admin")'
+          v-if='currentUser.id === question.user.id || isRole("mentor")'
         )
           .card-main-actions
             ul.card-main-actions__items

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -237,11 +237,14 @@ class CommentsTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     find('#comments.loaded', wait: 10)
     first(:css, '.thread-comment__created-at').click
-    # クリップボードを直接読み取る方法がないので、未入力のテキストエリアを経由してクリップボードの値を読み取っている
-    # また、Ctrl-Vではペーストできなかったので、かわりにShift-Insertをショートカットキーとして使っている
-    # 参考 https://stackoverflow.com/a/57955123/1058763
-    find('#js-new-comment').send_keys %i[shift insert]
-    clip_text = find('#js-new-comment').value
+    # 参考：https://gist.github.com/ParamagicDev/5fe937ee60695ff1d227f18fe4b1d5c4
+    cdp_permission = {
+      origin: page.server_url,
+      permission: { name: 'clipboard-read' },
+      setting: 'granted'
+    }
+    page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
+    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
     assert_equal current_url + "#comment_#{comments(:comment1).id}", clip_text
   end
 


### PR DESCRIPTION
ref: #4025

# 要件

https://github.com/fjordllc/bootcamp/issues/4025 から引用。

> 現在はユーザーに一つの role しか認識されていないので、
(currentUser.role == "mentor" || currentUser.role == "admin")
このように書いている。
> 
> 本来であれば、komagata、machida は mentor と admin の 2つの role を持っているので、
currentUser.role == "admin" は不要。
> 
> ところが、mentor と admin の 2つの role を持っているのに、admin の方しか認識されていないので、
currentUser.role == "mentor" が true にならない。
そのため、 (currentUser.role == "mentor" || currentUser.role == "admin") と書いている。
> 
> 複数の role が認識されるようになれば、
mentor と admin の 2つの role を持っている komagata、machida でも、
currentUser.role == "mentor" が true になり、
(currentUser.role == "mentor" || currentUser.role == "admin") と書かずに、
currentUser.role == "mentor" だけで済むようになる。

**要はメンターと管理者が利用できればいい機能に対して、ログインしているアカウントの role が `menter` を含んでいるかを判断するようなコードに変更する。**

現在 `menter` を含む role を持っているアカウントは `admin` のみ。

## 補足
ref: https://discord.com/channels/715806612824260640/809595476847493192/942035335154659328

- https://github.com/fjordllc/bootcamp/issues/4025#issue-1112357516 にあるような `v-if='(currentUser.role == "mentor" || currentUser.role == "admin") && commentType && !checkId' ` に該当するコードは現在 `app/javascript/comments.vue` に存在していない
- 実装を追うと代わりに `v-if='(isRole("mentor") || isRole("admin")) && commentType && !checkId'` というロール判定のメソッドになっているようである
- 履歴を追ったところ https://github.com/fjordllc/bootcamp/pull/3979 このプルリクの実装で変更になった模様
- 上記のプルリクによって、このissueの問題は解消されているように思える（そのためおそらく if 文の修正だけで対応できる）

上記のような背景からすで複数の role を認識できるようになっているとして、if 文の修正のみの対応を行う。

# 画面イメージ
なし。

# 確認方法
1. `feature/Identify-multiple-roles-even-when-using-vuejs` ブランチをローカルに持ってくる（参考：https://qiita.com/great084/items/ad74dd064a2c2bc47cff ）
```
git fetch origin pull/{このプルリクエストのid}/head:{任意のブランチ名}
git checkout {上記でfetchした任意のブランチ名}
```
2. 管理者（`komagata` or `machida`）のアカウントでログイン
3. `app/javascript/question-edit.vue`、`app/javascript/comments.vue`、`app/javascript/answer.vue`のファイルで表示しているページにおいて、if 文が true となり対象の id や class の要素がレンダリングされていることを確認