### PR TITLE
一度公開したお知らせを誰でも公開の状態で保存できるように変更

### DIFF
--- a/app/assets/stylesheets/blocks/card/_card-main-actions.sass
+++ b/app/assets/stylesheets/blocks/card/_card-main-actions.sass
@@ -26,7 +26,8 @@
     &.is-sub
       text-align: right
 
-.card-main-actions__delete
+.card-main-actions__delete,
+.card-main-actions__muted-action
   +hover-link-reversal
   +text-block(.875rem 1.4, $muted-text)
   &:hover

--- a/app/assets/stylesheets/blocks/card/_card-main-actions.sass
+++ b/app/assets/stylesheets/blocks/card/_card-main-actions.sass
@@ -5,14 +5,21 @@
 .card-main-actions__items
   display: flex
   gap: .75rem
-  +position(relative)
-  justify-content: center
-  flex-wrap: wrap
   +media-breakpoint-up(md)
-    min-height: 1.875rem
+    +position(relative)
+    justify-content: center
+    flex-wrap: wrap
     align-items: flex-end
+    min-height: 1.875rem
   +media-breakpoint-down(sm)
     flex-direction: column
+  &.is-sub-actions
+    justify-content: flex-end
+    +media-breakpoint-down(sm)
+      flex-direction: row
+    .card-main-actions__item.is-sub
+      position: static
+      flex: 0 0 auto
 
 .card-main-actions__item
   +media-breakpoint-up(md)

--- a/app/assets/stylesheets/blocks/card/_card-main-actions.sass
+++ b/app/assets/stylesheets/blocks/card/_card-main-actions.sass
@@ -33,7 +33,6 @@
     &.is-sub
       text-align: right
 
-.card-main-actions__delete,
 .card-main-actions__muted-action
   +hover-link-reversal
   +text-block(.875rem 1.4, $muted-text)

--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -60,7 +60,7 @@
           li.card-main-actions__item.is-sub(
             v-if='answer.user.id == currentUser.id || isRole("mentor")'
           )
-            button.card-main-actions__delete(@click='deleteAnswer')
+            button.card-main-actions__muted-action(@click='deleteAnswer')
               | 削除する
   .thread-comment-form__form.a-card(v-show='editing')
     .a-form-tabs.js-tabs

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -25,7 +25,7 @@
         )
       li.card-main-actions__item(:class='checkId ? "is-sub" : ""')
         button#js-shortcut-check.is-block(
-          :class='checkId ? "card-main-actions__delete" : "a-button is-md is-danger"',
+          :class='checkId ? "card-main-actions__muted-action" : "a-button is-md is-danger"',
           @click='checkSad'
         )
           | {{ buttonLabel }}

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -38,7 +38,7 @@
               i.fas.fa-pen
               | 編集
           li.card-main-actions__item.is-sub
-            button.card-main-actions__delete(@click='deleteComment')
+            button.card-main-actions__muted-action(@click='deleteComment')
               | 削除する
   .thread-comment-form__form.a-card(v-show='editing')
     .a-form-tabs.js-tabs

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -87,7 +87,7 @@
                 // - いい実装方法ではないが、
                 // - Rails特定の属性(data-confirm, data-method)を付与して、
                 // - 確認ダイアログとDELETE methodのリンクを実装する
-                a.js-delete.card-main-actions__delete(
+                a.js-delete.card-main-actions__muted-action(
                   :href='`/questions/${question.id}`',
                   data-confirm='本当によろしいですか？',
                   data-method='delete'

--- a/app/javascript/report_template_modal.vue
+++ b/app/javascript/report_template_modal.vue
@@ -44,7 +44,7 @@
               @click.prevent='updateTemplate'
             ) 変更
           li.card-main-actions__item.is-sub
-            .card-main-actions__delete(@click.prevent='closeModal') キャンセル
+            .card-main-actions__muted-action(@click.prevent='closeModal') キャンセル
 </template>
 <script>
 import MarkdownInitializer from './markdown-initializer'

--- a/app/javascript/tag-edit-modal.vue
+++ b/app/javascript/tag-edit-modal.vue
@@ -18,7 +18,7 @@
             )
               | 変更
           li.card-main-actions__item.is-sub
-            .card-main-actions__delete(@click.prevent='closeModal')
+            .card-main-actions__muted-action(@click.prevent='closeModal')
               | キャンセル
 </template>
 <script>

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -44,13 +44,10 @@
       .card-footer
         .card-main-actions
           ul.card-main-actions__items
-            // 要デザイン（ここから）
             - if announcement.published_at
-              li.card-main-actions__item
-                = link_to edit_announcement_path(announcement), class: 'card-main-actions__delete' do
-                  i.fas.fa-pen#new
+              li.card-main-actions__item.is-sub
+                = link_to edit_announcement_path(announcement), class: 'card-main-actions__muted-action' do
                   | 内容修正
-            // 要デザイン（ここまで）
             - else
               li.card-main-actions__item
                 = link_to edit_announcement_path(announcement), class: 'card-main-actions__action a-button is-md is-secondary is-block', id: 'js-shortcut-edit' do

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -44,7 +44,14 @@
       .card-footer
         .card-main-actions
           ul.card-main-actions__items
-            - if @announcement.wip || admin_or_mentor_login? || @announcement.user_id == current_user.id
+            // 要デザイン（ここから）
+            - if announcement.published_at
+              li.card-main-actions__item
+                = link_to edit_announcement_path(announcement), class: 'card-main-actions__delete' do
+                  i.fas.fa-pen#new
+                  | 内容修正
+            // 要デザイン（ここまで）
+            - else
               li.card-main-actions__item
                 = link_to edit_announcement_path(announcement), class: 'card-main-actions__action a-button is-md is-secondary is-block', id: 'js-shortcut-edit' do
                   i.fas.fa-pen#new

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -43,7 +43,7 @@
       = render 'reactions/reactions', reactionable: @announcement
       .card-footer
         .card-main-actions
-          ul.card-main-actions__items
+          ul.card-main-actions__items(class="#{announcement.published_at ? 'is-sub-actions' : ''}")
             - if announcement.published_at
               li.card-main-actions__item.is-sub
                 = link_to edit_announcement_path(announcement), class: 'card-main-actions__muted-action' do

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -55,7 +55,7 @@
                   | 内容修正
             - if admin_or_mentor_login? || @announcement.user_id == current_user.id
               li.card-main-actions__item.is-sub
-                = link_to announcement_path(announcement), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__delete' do
+                = link_to announcement_path(announcement), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                   span#delete
                   | 削除する
 

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -39,19 +39,19 @@
     ul.form-actions__items
       li.form-actions__item.is-main
         = f.submit 'WIP', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-wip'
-      - if admin_or_mentor_login?
+      - if admin_or_mentor_login? && announcement.new_record?
         li.form-actions__item.is-main.is-help
-          - if announcement.new_record?
-            = f.submit '作成', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
-          - else
-            = f.submit '公開', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
+          = f.submit '作成', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
+      - if admin_or_mentor_login? || announcement.published_at
+        li.form-actions__item.is-main.is-help
+          = f.submit '公開', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
       li.form-actions__item.is-sub
         - case params[:action]
         - when 'new', 'create'
           = link_to 'キャンセル', announcements_path, class: 'a-button is-md is-secondary is-block'
         - when 'edit', 'update'
           = link_to 'キャンセル', announcement_path, class: 'a-button is-md is-secondary is-block'
-    - unless admin_or_mentor_login?
+    - unless admin_or_mentor_login? || announcement.published_at
       .form-actions__description.a-short-text
         p
           | お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -71,7 +71,7 @@
                   i.fas.fa-pen#new
                   | 内容修正
               li.card-main-actions__item.is-sub
-                = link_to event_path(event), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__delete' do
+                = link_to event_path(event), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                   | 削除する
 
   = render 'users/icon',

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -106,7 +106,7 @@ header.page-header
                   | 内容変更
               - if admin_or_mentor_login? || current_user == @page.user
                 li.card-main-actions__item.is-sub
-                  = link_to @page, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__delete' do
+                  = link_to @page, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                     | 削除する
       .thread-prev-next
         .thread-prev-next__item

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -129,7 +129,7 @@ header.page-header
                         i.fas.fa-pen
                         | 内容修正
                     li.card-main-actions__item.is-sub
-                      = link_to @product, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__delete' do
+                      = link_to @product, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                         | 削除する
 
             - if (@product.user.daimyo? && staff_login?) || admin_or_mentor_login?

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -103,7 +103,7 @@ header.page-header
                         i.fas.fa-pen#new
                         | 内容修正
                     li.card-main-actions__item.is-sub
-                      = link_to report_path(@report), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__delete' do
+                      = link_to report_path(@report), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                         span#delete
                           | 削除する
 

--- a/app/views/shared/_modal_learning_completion.html.slim
+++ b/app/views/shared/_modal_learning_completion.html.slim
@@ -14,5 +14,5 @@
           li.card-main-actions__item
             = link_to '喜びを Tweet する！', tweet_url, class: 'a-button is-md is-primary is-block', target: '_blank', rel: 'noopener'
           li.card-main-actions__item.is-sub
-            label.card-main-actions__delete(for="#{id}")
+            label.card-main-actions__muted-action(for="#{id}")
               | 閉じる

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -61,5 +61,5 @@ header.page-header
                     i.fas.fa-pen
                     | 内容修正
                 li.card-main-actions__item.is-sub
-                  = link_to @work, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__delete' do
+                  = link_to @work, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                     | 削除する

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -140,20 +140,51 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_no_text 'お知らせ「就活希望者のみお知らせします」'
   end
 
-  test "general user can't edit submitted announcement" do
-    announcement = announcements(:announcement1)
-    visit_with_auth announcement_path(announcement), 'kimura'
-    within '.thread__inner' do
-      assert_no_text '内容修正'
-    end
+  test "general user can't create announcement" do
+    visit_with_auth '/announcements', 'kimura'
+    click_link 'お知らせ作成'
+    assert has_no_button? '作成'
+    assert_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
 
-  test 'general user can edit wip announcement' do
+  test 'admin user can publish wip announcement' do
+    announcement = announcements(:announcement_wip)
+    visit_with_auth announcement_path(announcement), 'komagata'
+    within '.thread__inner' do
+      click_link '内容修正'
+    end
+    assert has_button? '公開'
+    assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
+  end
+
+  test "general user can't publish wip announcement" do
     announcement = announcements(:announcement_wip)
     visit_with_auth announcement_path(announcement), 'kimura'
     within '.thread__inner' do
-      assert_text '内容修正'
+      click_link '内容修正'
     end
+    assert has_no_button? '公開'
+    assert_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
+  end
+
+  test 'adimin user can publish submitted announcement' do
+    announcement = announcements(:announcement1)
+    visit_with_auth announcement_path(announcement), 'komagata'
+    within '.thread__inner' do
+      click_link '内容修正'
+    end
+    assert has_button? '公開'
+    assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
+  end
+
+  test 'general user can publish submitted announcement' do
+    announcement = announcements(:announcement1)
+    visit_with_auth announcement_path(announcement), 'kimura'
+    within '.thread__inner' do
+      click_link '内容修正'
+    end
+    assert has_button? '公開'
+    assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
 
   test 'general user can copy submitted announcement' do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -52,7 +52,7 @@ class ProductsTest < ApplicationSystemTestCase
 
   # test 'not display learning completion message when a user of the completed product visits after the second time' do
   #   visit_with_auth "/products/#{products(:product65).id}", 'kimura'
-  #   find('label.card-main-actions__delete').click
+  #   find('label.card-main-actions__muted-action').click
   #   visit current_path
   #   assert_no_text '喜びを Tweet する！'
   # end


### PR DESCRIPTION
# Issue [#4127](https://github.com/fjordllc/bootcamp/issues/4127)

一度公開したお知らせをメンター・管理者以外が編集しても、公開の状態で保存できるように変更しました。
なお、本変更で条件分岐をきちんと作り込まないと、新たなバグを作り込むかもしれないため、デシジョンテーブルを作って条件を導出してみました。（テスト技法のプラクティスの提出物で学んだ内容を活かしました🙌）

## 変更理由
- 現在、お知らせはメンター・管理者しか公開ができない。この仕様はこのままでいいが、一度公開したお知らせをメンター・管理者以外が編集した場合、WIPの状態で保存しなくてはならず、公開の状態で保存することができない。

- (町田さんからの追加要求対応)
公開されたお知らせの編集ボタンは、メンター・管理者以外には表示されないため、編集画面に入るためにURLを直打ちしていた。URLを直打ちする運用はよくないので、公開されたお知らせにも編集ボタンを表示するように変更したい。

- (町田さんからの追加要求対応)
公開されたお知らせに表示する編集ボタンはほとんどの人にとっては不要なリンクなので、目立たないデザインを入れたい。もし、従来の編集ボタンのままだったら、操作ミスが発生する可能性があるのと(お知らせには変更履歴の情報がないので戻せない)、逆になんでお知らせが自分も編集できるようになっていますがバグですか？という質問が殺到しそうなので、公開済みのお知らせのみ目立たないボタンに変更したい。

## 変更点
1. (下表/パターン6)管理者・メンター以外が、詳細画面から編集画面に遷移できるように「内容修正ボタン」を表示。
2. (下表/パターン6)公開されたお知らせの詳細画面の「内容修正ボタン」について、目立たないデザインに変更。
3. (下表/パターン6)管理者・メンター以外が、公開されたお知らせを公開したままにできるように「公開ボタン」を表示。
4. (下表/パターン6)「WIPボタン下部の公開までの手順表示」を非表示に変更。
5. (下表/パターン2〜6)仕様を担保するための自動テストを追加。パターン1については既存のテストで網羅。

### 変更前(*が変更点)
|      | パターン                                 | 1 | 2 | 3 | 4  | 5 | 6  |
|------|------------------------------------------|---|---|---|----|---|----|
| 条件 | メンター・管理者がログイン                         | Y | N | Y | N  | Y | N  |
|      | メンター・管理者以外がログイン                     | N | Y | N | Y  | N | Y  |
|      | お知らせ作成・コピー ボタン押下          | Y | Y | N | N  | N | N  |
|      | 未公開のお知らせの内容修正ボタン押下     | N | N | Y | Y | N | N  |
|      | 一度公開したお知らせの内容修正ボタン押下 | N | N | N | N  | Y | N* |
| 期待値 | WIPボタン表示                                      | X | X | X | X  | X | X  |
|      | 作成ボタン表示                           | X | - | - | -  | - | -  |
|      | 公開ボタン表示                           | - | - | X | -  | X | -* |
|      | WIPボタン下部の公開までの手順表示        | - | X | - | X  | - | X* |

### 変更後(*が変更点)
|      | パターン                                 | 1 | 2 | 3 | 4  | 5 | 6  |
|------|------------------------------------------|---|---|---|----|---|----|
| 条件 | メンター・管理者がログイン                         | Y | N | Y | N  | Y | N  |
|      | メンター・管理者以外がログイン                     | N | Y | N | Y  | N | Y  |
|      | お知らせ作成・コピー ボタン押下          | Y | Y | N | N  | N | N  |
|      | 未公開のお知らせの内容修正ボタン押下     | N | N | Y | Y | N | N  |
|      | 一度公開したお知らせの内容修正ボタン押下 | N | N | N | N  | Y | Y* |
| 期待値 | WIPボタン表示                                      | X | X | X | X  | X | X  |
|      | 作成ボタン表示                           | X | - | - | -  | - | -  |
|      | 公開ボタン表示                           | - | - | X | -  | X | X* |
|      | WIPボタン下部の公開までの手順表示        | - | X | - | X  | - | -* |

## 目視確認
### 動作確認手順
1. feature/change-anyone-can-republish-announcement ブランチをローカル環境で起動する。
2. ユーザーログインする。（管理者・メンター：komagataさん、管理者・メンター以外：kimuraさん）
3. 最左列の中からお知らせをクリックし、上の表のパターン1〜6を実行し、期待値と結果の一致を確認する。
4. 一度公開したお知らせの「内容修正ボタン」が、未公開のものより目立たないデザインとなっていることを確認する。

パターン1〜6について、期待値と一致することを確認した。確認結果のエビデンスについては、パターン6を代表で示す。

### パターン6 修正前
公開されたお知らせの詳細画面の「内容修正ボタン」が表示されない。
![image](https://user-images.githubusercontent.com/58363353/153740426-db964040-c2c9-4858-94b7-b273f97b5d0a.png)

URLの末尾に`/edit`を直打ちして編集画面に入ってみると「公開ボタン」も表示されない。WIPボタンは使えるので、WIPボタン下の公開までの手順は表示される。
![image](https://user-images.githubusercontent.com/58363353/153740667-cf90e833-be61-4721-ab57-812b0fa04616.png)

### パターン6 修正後
公開されたお知らせの詳細画面の「内容修正ボタン」が目立たないボタンで表示されている。
**注：「内容修正ボタン」は別途、町田さんの方でデザインされるため、仮のボタンで表現。**
![image](https://user-images.githubusercontent.com/58363353/153740212-6e14f6ec-0d46-4cd8-bf69-cb6be90d5958.png)

同お知らせの編集画面の「公開ボタン」が表示される。また、公開済みのため、WIPボタン下の公開までの手順は表示しない。
![image](https://user-images.githubusercontent.com/58363353/153740305-32410a36-8fe6-461b-885e-9f0e13a4cc35.png)

## 自動テスト
`announcements_test.rb` ファイル単体でテストしてALL-Passを確認済み。
(期待値を反転させてのFail確認も済み)

```
~/work/bootcamp feature/change-anyone-can-republish-announcement* 16s
❯ rails test test/system/announcements_test.rb
Run options: --seed 41327

# Running:

......................

Finished in 13.860856s, 1.5872 runs/s, 3.1023 assertions/s.
22 runs, 43 assertions, 0 failures, 0 errors, 0 skips
```