### PR TITLE
ページのページネーションをクリックしたら次のページの先頭に飛ぶ

### DIFF
--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -159,6 +159,7 @@ export default {
         url.searchParams.set('page', pageNumber)
       }
       history.pushState(history.state, '', url)
+      window.scrollTo(0, 0)
     }
   }
 }

--- a/app/javascript/announcements.vue
+++ b/app/javascript/announcements.vue
@@ -112,6 +112,7 @@ export default {
         null,
         location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
       )
+      window.scrollTo(0, 0)
     },
     getCurrentUser() {
       fetch(`/api/users/${this.currentUserId}.json`, {

--- a/app/javascript/bookmarks.vue
+++ b/app/javascript/bookmarks.vue
@@ -118,6 +118,7 @@ export default {
         null,
         location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
       )
+      window.scrollTo(0, 0)
     },
     updateIndex() {
       this.getBookmarks()

--- a/app/javascript/company-users.vue
+++ b/app/javascript/company-users.vue
@@ -129,6 +129,7 @@ export default {
       this.currentPage = pageNumber
       this.getUsers()
       history.pushState(null, null, this.newUrl(pageNumber))
+      window.scrollTo(0, 0)
     },
     newUrl(pageNumber) {
       if (this.params.target) {

--- a/app/javascript/events.vue
+++ b/app/javascript/events.vue
@@ -90,6 +90,7 @@ export default {
         url.searchParams.set('page', pageNumber)
       }
       history.pushState(history.state, '', url)
+      window.scrollTo(0, 0)
     }
   }
 }

--- a/app/javascript/generation-users.vue
+++ b/app/javascript/generation-users.vue
@@ -128,6 +128,7 @@ export default {
       this.currentPage = pageNumber
       this.getUsers()
       history.pushState(null, null, this.newUrl(pageNumber))
+      window.scrollTo(0, 0)
     },
     newUrl(pageNumber) {
       if (this.params.target) {

--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -115,6 +115,7 @@ export default {
         null,
         location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
       )
+      window.scrollTo(0, 0)
     },
     getPageValueFromParameter: function () {
       const url = location.href

--- a/app/javascript/pages.vue
+++ b/app/javascript/pages.vue
@@ -77,6 +77,7 @@ export default {
       history.pushState(null, null, this.newURL)
       this.pages = null
       this.getPages()
+      window.scrollTo(0, 0)
     },
     getPages() {
       fetch(this.pagesAPI, {

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -147,6 +147,7 @@ export default {
       this.currentPage = pageNumber
       this.getProductsPerPage()
       history.pushState(null, null, this.newUrl(pageNumber))
+      window.scrollTo(0, 0)
     },
     newUrl(pageNumber) {
       if (this.params.target) {

--- a/app/javascript/questions.vue
+++ b/app/javascript/questions.vue
@@ -83,6 +83,7 @@ export default {
       history.pushState(null, null, this.newURL)
       this.questions = null
       this.getQuestions()
+      window.scrollTo(0, 0)
     },
     getQuestions() {
       fetch(this.questionsAPI, {

--- a/app/javascript/reports.vue
+++ b/app/javascript/reports.vue
@@ -123,6 +123,7 @@ export default {
       this.currentPage = pageNum
       history.pushState(null, null, this.newURL)
       this.getReports()
+      window.scrollTo(0, 0)
     },
     async getReports() {
       const response = await fetch(this.reportsAPI, {

--- a/app/javascript/searchables.vue
+++ b/app/javascript/searchables.vue
@@ -115,6 +115,7 @@ export default {
           (pageNumber === 1 ? '' : `&page=${pageNumber}`) +
           `&word=${this.word}`
       )
+      window.scrollTo(0, 0)
     }
   }
 }

--- a/app/javascript/talks.vue
+++ b/app/javascript/talks.vue
@@ -77,6 +77,7 @@ export default {
       this.currentPage = pageNum
       history.pushState(null, null, this.newURL)
       this.getTalks()
+      window.scrollTo(0, 0)
     },
     token() {
       const meta = document.querySelector('meta[name="csrf-token"]')

--- a/app/javascript/users.vue
+++ b/app/javascript/users.vue
@@ -125,6 +125,7 @@ export default {
       this.currentPage = pageNumber
       this.getUsers()
       history.pushState(null, null, this.newUrl(pageNumber))
+      window.scrollTo(0, 0)
     },
     newUrl(pageNumber) {
       if (this.params.target) {

--- a/app/javascript/watches.vue
+++ b/app/javascript/watches.vue
@@ -88,6 +88,7 @@ export default {
       this.currentPage = pageNum
       history.pushState(null, null, this.newURL)
       this.getWatches()
+      window.scrollTo(0, 0)
     },
     async getWatches() {
       const response = await fetch(this.watchesAPI, {


### PR DESCRIPTION
[#2677](https://github.com/fjordllc/bootcamp/issues/2677)
## 要件
Vue.jsで表示されるページのページネーションをクリックしたら次のページの先頭に飛ぶようにする。
## 変更前
![Screen Recording 2022-02-14 at 00 13 44 (1)](https://user-images.githubusercontent.com/34033366/153766861-ace3e0fe-d0aa-4d9b-9788-1496e321226d.gif)

## 変更後
![Screen Recording 2022-02-14 at 00 14 54](https://user-images.githubusercontent.com/34033366/153766809-07a12a3f-e571-4e75-b4dc-4549d8fd54a4.gif)

## 確認手順
- `feature/move-to-top-of-page-when-click-pagination`ブランチを手元に持ってくる。
- ページネーションがあるページを確認する。
`http://localhost:3000/reports` (日報リストページ)
`http://localhost:3000/products` (提出リストページ)
`http://localhost:3000/users` (ユーザーリストページ)
`http://localhost:3000/announcements` (お知らせページ)
`http://localhost:3000/events` (イベントリストページ)
`http://localhost:3000/searchables?document_type=all&page=3&word=a` (検索の結果ページ)
`http://localhost:3000/talks` (相談部屋ページ)
`http://localhost:3000/notifications` (通知リストページ)
`http://localhost:3000/pages` (Docsリストページ)
`http://localhost:3000/questions` (Q&Aリストページ)
`http://localhost:3000/admin/companies` (会社リストページ)
`http://localhost:3000/companies/company-id/users?target=all`(会社の社員リストページ)
`http://localhost:3000/current_user/bookmarks`(ユーザーのブックマークリストページ)
`http://localhost:3000/generations/:id`(期生別によるユーザーのリストページ)
`http://localhost:3000/current_user/watches`(Watch中ページ)