### PR TITLE
管理者で入った相談部屋一覧にユーザーのステータスで絞り込みができるようにする

### DIFF
--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class API::TalksController < API::BaseController
-  TARGETS = %w[student_and_trainee graduate adviser mentor trainee retired all].freeze
+  TARGETS = %w[student_and_trainee mentor graduate adviser trainee retired all].freeze
   PAGER_NUMBER = 20
 
   def index

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -7,8 +7,8 @@ class API::TalksController < API::BaseController
   def index
     @target = params[:target]
     @target = 'student_and_trainee' unless TARGETS.include?(@target)
-    @users_talk = Talk.joins(:user).merge(User.users_role(@target))
-                      .page(params[:page]).per(PAGER_NUMBER)
-                      .order(updated_at: :desc)
+    @users_talks = Talk.joins(:user).merge(User.users_role(@target))
+                       .page(params[:page]).per(PAGER_NUMBER)
+                       .order(updated_at: :desc)
   end
 end

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 class API::TalksController < API::BaseController
+  TARGETS = %w[student_and_trainee graduate adviser mentor trainee retired all].freeze
+  PAGER_NUMBER = 20
+
   def index
-    @talks = Talk.page(params[:page])
+    @target = params[:target]
+    @target = 'student_and_trainee' unless TARGETS.include?(@target)
+    @users_talk = Talk.joins(:user).merge(User.users_role(@target))
+                      .page(params[:page]).per(PAGER_NUMBER)
+                      .order(updated_at: :desc)
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TalksController < ApplicationController
-  TARGETS = %w[student_and_trainee graduate adviser mentor trainee retired all].freeze
+  TARGETS = %w[student_and_trainee mentor graduate adviser trainee retired all].freeze
   before_action :set_talk, only: %i[show]
   before_action :set_user, only: %i[show]
   before_action :require_admin_login, only: %i[index]

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 class TalksController < ApplicationController
+  TARGETS = %w[student_and_trainee graduate adviser mentor trainee retired all].freeze
   before_action :set_talk, only: %i[show]
   before_action :set_user, only: %i[show]
   before_action :require_admin_login, only: %i[index]
   before_action :allow_show_talk_page_only_admin, only: %i[show]
 
-  def index; end
+  def index
+    @target = params[:target]
+    @target = 'student_and_trainee' unless TARGETS.include?(@target)
+    @users_talk = Talk.joins(:user).merge(User.users_role(@target))
+  end
 
-  def show;  end
+  def show; end
 
   private
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class TalksController < ApplicationController
-  TARGETS = %w[student_and_trainee mentor graduate adviser trainee retired all].freeze
   before_action :set_talk, only: %i[show]
   before_action :set_user, only: %i[show]
   before_action :require_admin_login, only: %i[index]
@@ -9,7 +8,7 @@ class TalksController < ApplicationController
 
   def index
     @target = params[:target]
-    @target = 'student_and_trainee' unless TARGETS.include?(@target)
+    @target = 'student_and_trainee' unless API::TalksController::TARGETS.include?(@target)
     @users_talk = Talk.joins(:user).merge(User.users_role(@target))
   end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -9,7 +9,6 @@ class TalksController < ApplicationController
   def index
     @target = params[:target]
     @target = 'student_and_trainee' unless API::TalksController::TARGETS.include?(@target)
-    @users_talk = Talk.joins(:user).merge(User.users_role(@target))
   end
 
   def show; end

--- a/app/javascript/talks.vue
+++ b/app/javascript/talks.vue
@@ -1,10 +1,10 @@
 <template lang="pug">
 .page-body
-  .container.is-md(v-if='!loaded')
+  #talks.container.is-md.loading(v-if='!loaded')
     loadingListPlaceholder
   .container(v-else-if='talks.length === 0')
     | 未返信の相談部屋はありません
-  .container.is-md(v-else)
+  #talks.container.is-md.loaded(v-else)
     nav.pagination(v-if='totalPages > 1')
       pager(v-bind='pagerProps')
     .thread-list.a-card

--- a/app/javascript/talks.vue
+++ b/app/javascript/talks.vue
@@ -1,9 +1,12 @@
 <template lang="pug">
-.page-body
+.talks
   #talks.container.is-md.loading(v-if='!loaded')
     loadingListPlaceholder
-  .container(v-else-if='talks.length === 0')
-    | 未返信の相談部屋はありません
+  .o-empty-message(v-else-if='talks.length === 0')
+    .o-empty-message__icon
+      i.far.fa-smile
+    p.o-empty-message__text
+      | 未返信の相談部屋はありません
   #talks.container.is-md.loaded(v-else)
     nav.pagination(v-if='totalPages > 1')
       pager(v-bind='pagerProps')

--- a/app/views/api/talks/index.json.jbuilder
+++ b/app/views/api/talks/index.json.jbuilder
@@ -1,8 +1,8 @@
 json.talks do
-  json.array! @users_talk do |talk|
+  json.array! @users_talks do |talk|
     json.partial! "api/talks/talk", talk: talk
   end
 end
 
 json.target t("target.#{@target}")
-json.totalPages @users_talk.total_pages
+json.totalPages @users_talks.total_pages

--- a/app/views/api/talks/index.json.jbuilder
+++ b/app/views/api/talks/index.json.jbuilder
@@ -5,3 +5,4 @@ json.talks do
 end
 
 json.target t("target.#{@target}")
+json.totalPages @users_talk.total_pages

--- a/app/views/api/talks/index.json.jbuilder
+++ b/app/views/api/talks/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.talks do
-  json.array! @talks do |talk|
+  json.array! @users_talk do |talk|
     json.partial! "api/talks/talk", talk: talk
   end
 end
 
-json.totalPages @talks.total_pages
+json.target t("target.#{@target}")

--- a/app/views/talks/_nav.html.slim
+++ b/app/views/talks/_nav.html.slim
@@ -1,6 +1,6 @@
 nav.tab-nav
   .container.is-padding-horizontal-0-sm-down
     ul.tab-nav__items
-      - TalksController::TARGETS.each do |target|
+      - API::TalksController::TARGETS.each do |target|
         li.tab-nav__item
         = link_to t("target.#{target}"), talks_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/talks/_nav.html.slim
+++ b/app/views/talks/_nav.html.slim
@@ -1,0 +1,5 @@
+nav.tab-nav
+  .container.is-padding-horizontal-0-sm-down
+    ul.tab-nav__items
+      - TalksController::TARGETS.each do |target|
+        = link_to t("target.#{target}"), talks_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/talks/_nav.html.slim
+++ b/app/views/talks/_nav.html.slim
@@ -2,4 +2,5 @@ nav.tab-nav
   .container.is-padding-horizontal-0-sm-down
     ul.tab-nav__items
       - TalksController::TARGETS.each do |target|
+        li.tab-nav__item
         = link_to t("target.#{target}"), talks_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/talks/index.html.slim
+++ b/app/views/talks/index.html.slim
@@ -7,8 +7,6 @@ header.page-header
         = title
 
 = render 'talks/tabs'
-
-.page-tools
 = render 'talks/nav'
 
 .page-body

--- a/app/views/talks/index.html.slim
+++ b/app/views/talks/index.html.slim
@@ -11,51 +11,6 @@ header.page-header
 .page-tools
 = render 'talks/nav'
 
-- @users_talk.each do |talk|
-  .page-body
-    .container
-      .users
-        .row.is-gutter-width-32
-          .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-            .users-item
-              .users-item__inner.a-card
-                header.users-item__header
-                  .users-item__header-container
-                    .users-item__name
-                      = link_to talk_path(id: talk.id), class: 'users-item__name-link' do
-                        - if talk.user.daimyo?
-                          | ★
-                        = talk.user.login_name
-                    ul.users-item-names
-                      li.users-item-names__item
-                        .users-item-names__ful-name
-                          = talk.user.name
-                        - if talk.user.company.present? && talk.user.company.logo.attached?
-                          = link_to company_path(talk.user.company) do
-                            = image_tag talk.user.company.logo_url, class: 'user-item__company-logo'
-                      li.users-item-names__item
-                        .users-item-names__chat
-                          .users-item-names__chat-label
-                            i.fab.fa-discord
-                          - if talk.user.times_url?
-                            = link_to talk.user.times_url, class: 'users-item-names__chat-value' do
-                              = talk.user.discord_account.presence || 'Discord未設定'
-                          - else
-                            span.users-item-names__chat-value
-                              = talk.user.discord_account.presence || 'Discord未設定'
-                    - if admin_or_mentor_login? && talk.user.student_or_trainee?
-                      = render 'users/user_secret_attributes', user: talk.user
-                    .users-item__icon
-                      = render 'users/icon',
-                              user: talk.user,
-                              image_class: 'users-item__user-icon-image'
-                  = render 'users/sns', user: talk.user
-                .users-item__body
-                  .users-item__description.a-short-text
-                    = simple_format h truncate talk.user.description, length: 200
-
-/ ここの#js-talks以外の部分は、talksコントローラでできているから、
-/ talks contorollerが必要なのかも。
 .page-body
   .container.is-md
     #js-talks

--- a/app/views/talks/index.html.slim
+++ b/app/views/talks/index.html.slim
@@ -8,6 +8,54 @@ header.page-header
 
 = render 'talks/tabs'
 
+.page-tools
+= render 'talks/nav'
+
+- @users_talk.each do |talk|
+  .page-body
+    .container
+      .users
+        .row.is-gutter-width-32
+          .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
+            .users-item
+              .users-item__inner.a-card
+                header.users-item__header
+                  .users-item__header-container
+                    .users-item__name
+                      = link_to talk_path(id: talk.id), class: 'users-item__name-link' do
+                        - if talk.user.daimyo?
+                          | ★
+                        = talk.user.login_name
+                    ul.users-item-names
+                      li.users-item-names__item
+                        .users-item-names__ful-name
+                          = talk.user.name
+                        - if talk.user.company.present? && talk.user.company.logo.attached?
+                          = link_to company_path(talk.user.company) do
+                            = image_tag talk.user.company.logo_url, class: 'user-item__company-logo'
+                      li.users-item-names__item
+                        .users-item-names__chat
+                          .users-item-names__chat-label
+                            i.fab.fa-discord
+                          - if talk.user.times_url?
+                            = link_to talk.user.times_url, class: 'users-item-names__chat-value' do
+                              = talk.user.discord_account.presence || 'Discord未設定'
+                          - else
+                            span.users-item-names__chat-value
+                              = talk.user.discord_account.presence || 'Discord未設定'
+                    - if admin_or_mentor_login? && talk.user.student_or_trainee?
+                      = render 'users/user_secret_attributes', user: talk.user
+                    .users-item__icon
+                      = render 'users/icon',
+                              user: talk.user,
+                              image_class: 'users-item__user-icon-image'
+                  = render 'users/sns', user: talk.user
+                .users-item__body
+                  .users-item__description.a-short-text
+                    = simple_format h truncate talk.user.description, length: 200
+
+/ ここの#js-talks以外の部分は、talksコントローラでできているから、
+/ talks contorollerが必要なのかも。
 .page-body
   .container.is-md
     #js-talks

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -57,4 +57,40 @@ class TalksTest < ApplicationSystemTestCase
     find('.page-tabs__item-link', text: '未返信').click
     assert_no_text "#{user.login_name} (#{user.name}) さんの相談部屋"
   end
+
+  test 'a list of current students is displayed' do
+    visit_with_auth '/talks?target=student_and_trainee', 'komagata'
+    find('#talks.loaded', wait: 10)
+    assert_text 'kimura (Kimura Tadasi) さんの相談部屋'
+  end
+
+  test 'a list of graduates is displayed' do
+    visit_with_auth '/talks?target=graduate', 'komagata'
+    find('#talks.loaded', wait: 10)
+    assert_text 'sotugyou (卒業 太郎) さんの相談部屋'
+  end
+
+  test 'a list of advisers is displayed' do
+    visit_with_auth '/talks?target=adviser', 'komagata'
+    find('#talks.loaded', wait: 10)
+    assert_text 'advijirou (アドバイ 次郎) さんの相談部屋'
+  end
+
+  test 'a list of mentors is displayed' do
+    visit_with_auth '/talks?target=mentor', 'komagata'
+    find('#talks.loaded', wait: 10)
+    assert_text 'machida (Machida Teppei) さんの相談部屋'
+  end
+
+  test 'a list of trainees is displayed' do
+    visit_with_auth '/talks?target=trainee', 'komagata'
+    find('#talks.loaded', wait: 10)
+    assert_text 'kensyu (Kensyu Seiko) さんの相談部屋'
+  end
+
+  test 'a list of retire users is displayed' do
+    visit_with_auth '/talks?target=retired', 'komagata'
+    find('#talks.loaded', wait: 10)
+    assert_text 'yameo (辞目 辞目夫) さんの相談部屋'
+  end
 end


### PR DESCRIPTION
## issue
- #4067 

## 概要

管理者で入った相談部屋一覧に、ユーザーのステータス（ロール）で相談部屋を絞り込みができるようにする。

## 変更前

- 相談部屋一覧において、相談部屋をユーザーのステータス（ロール）で絞り込む機能がない。

<img width="1384" alt="image" src="https://user-images.githubusercontent.com/66904873/154017009-c30fdef6-6671-4f22-82dc-6ed1d6d036e7.png">


## 変更後

- 相談部屋一覧において、相談部屋をユーザーのロールで絞り込む機能を実装。
- 各ページがVueで表示されるように実装。

<img width="1378" alt="image" src="https://user-images.githubusercontent.com/66904873/154023061-6c6ce377-7575-4d72-a19c-53900b67cacc.png">

[![Image from Gyazo](https://i.gyazo.com/e2ab6431125a6e135cb7cff9ecd51849.gif)](https://gyazo.com/e2ab6431125a6e135cb7cff9ecd51849)

## 確認手順
1.`feature/categorize-the-list-of-users-in-the-talks-room-by-their-status`をローカルに取り込む・ローカルでcheckoutする。
2.adminでログインし、相談部屋一覧（`/talks`）にアクセスする。
3.相談部屋をユーザーのロールで絞り込めること（`/talks?target=graduate`など）を確認し、かつ相談部屋一覧がVueで表示されていることを確認する。
4.相談部屋一覧で「〇〇さんの相談部屋」リンクをクリックすると、その人の相談部屋詳細に遷移することを確認する。
5.admin以外ではURL（`/talks?target=graduate`など）からもアクセスできないことを確認する。