### PR TITLE
[お試し延長]管理ページのお試し延長タブのコンテンツ全てのタイトルを管理ページに変更

### DIFF
--- a/app/views/admin/campaigns/edit.html.slim
+++ b/app/views/admin/campaigns/edit.html.slim
@@ -1,4 +1,4 @@
-- title 'お試し延長'
+- title '管理ページ'
 
 header.page-header
   .container

--- a/app/views/admin/campaigns/index.html.slim
+++ b/app/views/admin/campaigns/index.html.slim
@@ -1,4 +1,4 @@
-- title 'お試し延長'
+- title '管理ページ'
 
 header.page-header
   .container

--- a/app/views/admin/campaigns/new.html.slim
+++ b/app/views/admin/campaigns/new.html.slim
@@ -1,4 +1,4 @@
-- title 'お試し延長'
+- title '管理ページ'
 
 header.page-header
   .container


### PR DESCRIPTION
- issue #4197
- [お試し延長]管理ページのお試し延長タブのコンテンツ全てのタイトルを、管理ページに変更しました。

### 変更前
![お試し延長___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/153854680-1a2529e4-9434-4940-b436-650cc26bf92b.png)
### 変更後
![管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/153854718-fe55ef31-d1aa-4a49-904d-593c3ee17f7f.png)

