### PR TITLE
提出物一覧のnotrespondedマークの表示条件変更

### DIFF
--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -188,8 +188,8 @@ export default {
     },
     notRespondedSign() {
       return (
-        this.product.self_last_comment_at_date_time >
-          this.product.mentor_last_comment_at_date_time ||
+        this.product.self_last_commented_at_date_time >
+          this.product.mentor_last_commented_at_date_time ||
         this.product.comments.size === 0
       )
     }


### PR DESCRIPTION
## Issue
- #4198 

## 概要
メンターが提出物一覧から自分の担当を確認したとき、notrespondedマークの表示条件を変更しました

notrespondedマークは、メンターが担当する提出物に未返信があることを気づくためのマークです。
カラムのタイポミスが原因だったので、その箇所の修正を行なっています。

## 変更確認方法
1. メンターでログイン(`komagata`で確認しました)
1. サイドバーの提出物＞未アサインタブ＞担当するをクリックし、[自分の担当]タブで担当となった提出物を確認
1. コメントが0件であるため、提出物に`notrespondedマーク`がついていることを確認
1. メンター側から提出物にコメントし、[自分の担当]タブに戻ると`notrespondedマーク`が消えていることを確認
1. 提出物を提出したユーザーでログインし、メンターからのコメントの次にコメント
1. 再びメンターでログインし、[自分の担当]から提出物を確認すると最終更新が提出者のものは`notrespondedマーク`がついている

## 変更前
![localhost_3000_products_self_assigned](https://user-images.githubusercontent.com/69446373/153878012-7a3d6590-6dfc-4f54-80ed-c2d51e933ad5.png)

## 変更後
![localhost_3000_products_self_assigned (1)](https://user-images.githubusercontent.com/69446373/153877987-2c34ed9c-4059-40e4-922d-c9df536c4787.png)