### PR TITLE
メンターモードがonの時だけメンター向けメモが表示されるよう修正

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -133,14 +133,14 @@
                 | 終了条件をクリアしたら完了にしてください。
 
         - if current_user.admin_or_mentor?
-          section.a-card
+          section.a-card.is-only-mentor
             header.card-header
               h2.card-header__title
                 = Practice.human_attribute_name :memo
             .practice-content__body.is-memo
               .js-markdown-view.js-target-blank.is-long-text
                 = @practice.memo
-          section.a-card
+          section.a-card.is-only-mentor
             header.card-header
               h2.card-header__title 管理者・メンター用メニュー
             footer.card-footer

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -232,4 +232,20 @@ class PracticesTest < ApplicationSystemTestCase
       assert_selector 'img[alt="komagata (Komagata Masaki): 管理者、メンター"]'
     end
   end
+
+  test 'show/hide memo for mentor' do
+    practice = practices(:practice2)
+    visit_with_auth "/practices/#{practice.id}", 'komagata'
+    assert_text 'メンター向けメモ'
+    find(:css, '#checkbox-mentor-mode').set(false)
+    assert_no_text 'メンター向けメモ'
+  end
+
+  test 'show/hide menu for mentor' do
+    practice = practices(:practice2)
+    visit_with_auth "/practices/#{practice.id}", 'komagata'
+    assert_text '管理者・メンター用メニュー'
+    find(:css, '#checkbox-mentor-mode').set(false)
+    assert_no_text '管理者・メンター用メニュー'
+  end
 end


### PR DESCRIPTION
issue #4218

プラクティスの個別ページの、「メンター向けメモ」「管理者・メンター用メニュー」が、メンターモード「ON」の場合だけ表示されるように修正しました。

### 変更前
![Terminalの基礎を覚える___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/154003563-29bca19d-9d4d-48e3-82c2-4490dffb1999.png)

### 変更後
![Terminalの基礎を覚える___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/154002679-974c4358-c932-4711-a70b-83214584d7de.png)


