### PR TITLE
[fixture][ユーザー一覧ページ]相談部屋を持たないユーザーがいた場合にユーザー一覧ページが表示されない不具合を修正した

### DIFF
--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -57,7 +57,7 @@
                 :userId='user.id',
                 :isWatching='user.isWatching'
               )
-            li.card-main-actions__item.is-only-admin(v-if='currentUser.admin')
+            li.card-main-actions__item.is-only-admin(v-if='currentUser.admin && user.talkPresence')
               a.a-button.is-secondary.is-md.is-block(:href='user.talkUrl')
                 | 相談部屋
 </template>
@@ -77,6 +77,11 @@ export default {
   props: {
     user: { type: Object, required: true },
     currentUser: { type: Object, required: true }
+  },
+  data() {
+    return {
+      talkPresence: false
+    }
   },
   computed: {
     loginName() {

--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -57,7 +57,9 @@
                 :userId='user.id',
                 :isWatching='user.isWatching'
               )
-            li.card-main-actions__item.is-only-admin(v-if='currentUser.admin && user.talkPresence')
+            li.card-main-actions__item.is-only-admin(
+              v-if='currentUser.admin && user.talkPresence'
+            )
               a.a-button.is-secondary.is-md.is-block(:href='user.talkUrl')
                 | 相談部屋
 </template>

--- a/app/javascript/user.vue
+++ b/app/javascript/user.vue
@@ -58,7 +58,7 @@
                 :isWatching='user.isWatching'
               )
             li.card-main-actions__item.is-only-admin(
-              v-if='currentUser.admin && user.talkPresence'
+              v-if='currentUser.admin && user.talkUrl'
             )
               a.a-button.is-secondary.is-md.is-block(:href='user.talkUrl')
                 | 相談部屋
@@ -79,11 +79,6 @@ export default {
   props: {
     user: { type: Object, required: true },
     currentUser: { type: Object, required: true }
-  },
-  data() {
-    return {
-      talkPresence: false
-    }
   },
   computed: {
     loginName() {

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -14,7 +14,11 @@ json.student_or_trainee user.student_or_trainee?
 json.edit_admin_user_path edit_admin_user_path(user)
 json.isFollowing current_user.following?(user)
 json.isWatching current_user.watching?(user)
-json.talkUrl talk_path(user.talk)
+
+if user.talk.present?
+  json.talkUrl talk_path(user.talk)
+  json.talkPresence true
+end
 
 json.company do
   if user.company.present?

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -17,7 +17,6 @@ json.isWatching current_user.watching?(user)
 
 if user.talk.present?
   json.talkUrl talk_path(user.talk)
-  json.talkPresence true
 end
 
 json.company do

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -166,3 +166,8 @@ talk_sotugyou-with-job:
   user: sotugyou_with_job
   unreplied: false
 
+<% 1.upto(22) do |i| %>
+marumarushain<%= i %>: # ページネーション確認のためのユーザー
+  user: marumarushain<%= i %>
+  unreplied: false
+<% end %>


### PR DESCRIPTION
## Issue
- #4263 

## 関連Issue,プルリク
- #4069 
- #4084
 
## 概要
開発環境のテスト用データのusers.ymlとtalks.ymlに差分があり、相談部屋を持たないユーザーが存在していたため、
開発環境でユーザー一覧ページ内のその「相談部屋を持たないユーザー」を含むページを表示しようとした際に「ロード中」で止まってしまうエラーが起こりました。(具体的には、マルマル企業[MaruMaru Inc.]の社員22名)

※ 本番環境では、ユーザー全員が相談部屋を持っているためこのエラーは発生していません。

## 対策
1. db/fixtures内のtalks.ymlにデータの追加を行い、users.ymlと揃える(開発環境用)
2. 相談部屋のidの取得ができない場合は相談部屋へのリンクを表示しない処理を追加する(本番環境にも適用)

## 変更確認方法
1. このブランチ `bug/modify-link-to-talk-on-user-list-only-admin`をローカルに取り込む
1. db/fixtures内のtalks.yml にデータを追加しましたので、`rails db:reset` `rails db:seed`を実行してください。
2. `$ rails s` でローカル環境を立ち上げる
3. テスト用ユーザー(管理者ロールを持っている'komagata''machida'のどちらか)でログインする
4. 左側のナビゲーションバーから「ユーザー」をクリックしてユーザー一覧ページを開く
5. それぞれのユーザーの枠内に「相談部屋」の文字と、それぞれの相談部屋へのリンクが付加されていることをご確認ください。
6. ユーザー一覧ページ内の「現役生」の2ページ目以降、「全員」の2ページ目以降をクリック
7. ページが表示されるのをご確認ください。
6. 一旦ログアウトして、次は'komagata''machida'以外のテスト用ユーザーでログインし、ユーザー一覧ページのそれぞれのユーザーの枠内に「相談部屋」の文字とリンクがないこと、「現役生」の2ページ目以降と「全員」の2ページ目以降をクリックしてページが表示されることをご確認ください。
7. 本番環境と同様にuser.ymlとtalks.ymlのデータを揃えてありますので、テストデータのユーザー全てが相談部屋を持っている設定になっています。`db/fixtures/talks.yml`内のうちのデータ数件をコメントアウトして保存後、再度`rails db:reset` `rails db:seed`を実行してから管理者でログインしてユーザー一覧ページを開き、コメントアウトしたユーザーの相談部屋へのリンクが表示されていないことをご確認ください。(お手数をおかけして申し訳ありません🙏)

## 変更【前】(「「現役生」の2ページ目に相談部屋を持たないユーザーがいるため、「ロード中」のままで止まる)のスクショ
![スクリーンショット 2022-02-18 23 16 40](https://user-images.githubusercontent.com/82434093/154706243-cc6e3585-38d3-4a84-b384-65ad068bc7c0.png)



## 変更【後】(「現役生」の2ページ目も表示される)のスクショ
![image](https://user-images.githubusercontent.com/82434093/154704885-0237cf17-5245-45ba-9a72-7df2acf486d0.png)

## 変更【後】(相談部屋を持たないユーザーの場合は「相談部屋」のリンクを表示させない)のスクショ
![image](https://user-images.githubusercontent.com/82434093/154705750-b9fc3f29-ddc5-424e-a8ca-6ba59880be46.png)
