### PR TITLE
就職関連のイベントの場合、企業研修生は参加不可と表示した

### DIFF
--- a/app/assets/stylesheets/blocks/event/_event-main-actions.sass
+++ b/app/assets/stylesheets/blocks/event/_event-main-actions.sass
@@ -10,16 +10,18 @@
     background-color: #f8fff2
     +border(vertical, 1px solid $success)
     color: #4e732e
-  &.is-unparticipationed
-    +border(vertical, 1px solid)
-    &.is-available
-      border-color: $primary
-      background-color: #e9f9ff
-      color: #116e94
-    &.is-capacity-over
-      border-color: $warning
-      background-color: #fff9e7
-      color: #6f5819
+  &.is-unparticipationed.is-available
+    +border(vertical, 1px solid $primary)
+    background-color: #e9f9ff
+    color: #116e94
+  &.is-unparticipationed.is-capacity-over
+    +border(vertical, 1px solid $warning)
+    background-color: #fff9e7
+    color: #6f5819
+  &.is-non-participationed
+    +border(vertical, 1px solid $danger)
+    background-color: $danger-shade
+    color: $danger
 
 .event-main-actions__description
   +text-block(.8125rem 1.4, center)

--- a/app/assets/stylesheets/blocks/shared/_errors.sass
+++ b/app/assets/stylesheets/blocks/shared/_errors.sass
@@ -1,5 +1,5 @@
 .errors
-  background-color: #fff3f6
+  background-color: $danger-shade
   border: solid 1px $danger
   margin-bottom: 1.25rem
   padding: 1rem 1.5rem
@@ -10,12 +10,12 @@
     padding: .875rem 1rem
 
 .errors__title
-  +text-block(.875rem 1.45 0 .8em, center 600 #711329)
+  +text-block(.875rem 1.45 0 .8em, center 600 $danger)
   +media-breakpoint-down(sm)
     font-size: .8125rem
 
 .errors__item
-  +text-block(.8125rem 1.6 0 .2em, #711329)
+  +text-block(.8125rem 1.6 0 .2em, $danger)
   +media-breakpoint-down(sm)
     font-size: .75rem
 

--- a/app/controllers/events/participations_controller.rb
+++ b/app/controllers/events/participations_controller.rb
@@ -4,6 +4,8 @@ class Events::ParticipationsController < ApplicationController
   before_action :set_event
 
   def create
+    return if current_user.trainee && @event.job_hunting
+
     return unless @event.participations.create(user: current_user, enable: @event.can_participate?)
 
     create_watch

--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -1,6 +1,12 @@
 - if current_user.trainee && event.job_hunting
-  p
-    | 参加できません
+  .event-main-actions.is-non-participationed
+    .event-main-actions__description
+      p
+        | 企業研修で参加されている方はこのイベントに参加できません。
+    ul.event-main-actions__items
+      li.event-main-actions__item
+        .a-button.is-disabled.is-lg.is-block
+          | 参加申込
 - elsif current_user.participating?(event)
   .event-main-actions.is-participationed
     .event-main-actions__description

--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -1,32 +1,31 @@
 - if current_user.trainee && event.job_hunting
   p
     | 参加できません
-- else
-  - if current_user.participating?(event)
-    .event-main-actions.is-participationed
-      .event-main-actions__description
+- elsif current_user.participating?(event)
+  .event-main-actions.is-participationed
+    .event-main-actions__description
+      p
+        | 参加登録しています。
+    ul.event-main-actions__items
+      li.event-main-actions__item
+        = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+          | 参加を取り消す
+- elsif event.opening?
+  .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
+    .event-main-actions__description
+      - if event.capacity > event.participants.count
+        // TODO helprtにしてわかりやすくしたい↑
         p
-          | 参加登録しています。
-      ul.event-main-actions__items
-        li.event-main-actions__item
-          = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
-            | 参加を取り消す
-  - elsif event.opening?
-    .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
-      .event-main-actions__description
+          | あと#{event.capacity - event.participants.count}名が参加できます。
+      - else
+        p
+          | 参加者が定員を超えているので補欠での登録になります。
+    ul.event-main-actions__items
+      li.event-main-actions__item
         - if event.capacity > event.participants.count
           // TODO helprtにしてわかりやすくしたい↑
-          p
-            | あと#{event.capacity - event.participants.count}名が参加できます。
+          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-lg is-block' do
+            | 参加申込
         - else
-          p
-            | 参加者が定員を超えているので補欠での登録になります。
-      ul.event-main-actions__items
-        li.event-main-actions__item
-          - if event.capacity > event.participants.count
-            // TODO helprtにしてわかりやすくしたい↑
-            = link_to event_participations_path(event_id: event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-lg is-block' do
-              | 参加申込
-          - else
-            = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠としてイベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-lg is-block' do
-              | 補欠登録
+          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠としてイベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-lg is-block' do
+            | 補欠登録

--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -1,28 +1,28 @@
-- if current_user.participating?(event)
-  .event-main-actions.is-participationed
-    .event-main-actions__description
-      p
-        | 参加登録しています。
-    ul.event-main-actions__items
-      li.event-main-actions__item
-        = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
-          | 参加を取り消す
-- elsif event.opening?
-  .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
-    .event-main-actions__description
-      - if event.capacity > event.participants.count
-        // TODO helprtにしてわかりやすくしたい↑
+- if current_user.trainee && event.job_hunting
+  p
+    | 参加できません
+- else
+  - if current_user.participating?(event)
+    .event-main-actions.is-participationed
+      .event-main-actions__description
         p
-          | あと#{event.capacity - event.participants.count}名が参加できます。
-      - else
-        p
-          | 参加者が定員を超えているので補欠での登録になります。
-    ul.event-main-actions__items
-      li.event-main-actions__item
-        - if current_user.trainee && event.job_hunting
+          | 参加登録しています。
+      ul.event-main-actions__items
+        li.event-main-actions__item
+          = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+            | 参加を取り消す
+  - elsif event.opening?
+    .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
+      .event-main-actions__description
+        - if event.capacity > event.participants.count
+          // TODO helprtにしてわかりやすくしたい↑
           p
-            | 参加できません
+            | あと#{event.capacity - event.participants.count}名が参加できます。
         - else
+          p
+            | 参加者が定員を超えているので補欠での登録になります。
+      ul.event-main-actions__items
+        li.event-main-actions__item
           - if event.capacity > event.participants.count
             // TODO helprtにしてわかりやすくしたい↑
             = link_to event_participations_path(event_id: event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-lg is-block' do

--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -19,10 +19,14 @@
           | 参加者が定員を超えているので補欠での登録になります。
     ul.event-main-actions__items
       li.event-main-actions__item
-        - if event.capacity > event.participants.count
-          // TODO helprtにしてわかりやすくしたい↑
-          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-lg is-block' do
-            | 参加申込
+        - if current_user.trainee && event.job_hunting
+          p
+            | 参加できません
         - else
-          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠としてイベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-lg is-block' do
-            | 補欠登録
+          - if event.capacity > event.participants.count
+            // TODO helprtにしてわかりやすくしたい↑
+            = link_to event_participations_path(event_id: event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-lg is-block' do
+              | 参加申込
+          - else
+            = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠としてイベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-lg is-block' do
+              | 補欠登録


### PR DESCRIPTION
# Issue概要
- #4216

ログインユーザーが研修生の場合、就職関連イベントへのイベント参加リンクが表示されないようにした。
※就職関連以外のイベントへは参加リンクが表示される。

# 変更前
研修生でログインしていても、就職関連イベントへの参加申し込みリンクが表示され、参加申し込みができてしまう。
![_development__就職イベント___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/63531341/155823946-f3ac0a30-2d40-4c5a-af0f-adbcac65579a.png)


# 変更後
- 研修生でログインしている場合は、就職関連イベントへの参加申し込みリンクが表示されず、参加申し込みができないようにした。
![_development__就職イベント___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/63531341/155823711-8aba0c58-d3a2-4476-bc80-8af082c90fef.png)

- 就職関連以外のイベントの場合、研修生でログインしていても参加申し込みリンクが表示され、参加申し込みができる。
![_development__募集期間中のイベント_補欠者なし____FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/63531341/155823776-65953e2d-58ac-400f-8cd4-2e93eba1bb3f.png)

- 研修生以外でログインしている場合は、就職関連イベントへの参加申し込みリンクが表示され、参加申し込みができる。
![_development__就職イベント___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/63531341/155823660-22a4a004-d973-4285-8242-2b8e428713a6.png)

# 動作確認手順
1. ブランチ`feature/disable-trainee-to-perticipate-jobhunting-event`をローカルに取り込む
1. `bin/setup`を実行する
1. `bin/rails s`でサーバーを立ち上げる
1. `komagata`(管理者)でログインし、イベントページから「就活関係のイベントの場合」にチェックを入れたイベントを作成する
1. `hatsuno`(研修生でないユーザー)でログインし、先ほど作成した就職関連のイベントページにアクセスし、参加申込リンクが表示されていることを確認
1. `kensyu`(研修生)でログインし、先ほど作成した就職関連のイベントページにアクセスし、参加申込リンクが**表示されていない**ことを確認
1. `kensyu`(研修生)でログインしたまま、「募集期間中のイベント(補欠者なし)」のイベントページにアクセスし、参加申込リンクが表示されていることを確認