### PR TITLE
通知ベルにプレースホルダを実装した

### DIFF
--- a/app/assets/stylesheets/blocks/header/_header-notification-icon.sass
+++ b/app/assets/stylesheets/blocks/header/_header-notification-icon.sass
@@ -6,11 +6,6 @@
       color: $default-text
 
 .header-notification-count
-  background-color: $badge-color
-  +text-block(.625rem 1, center $reversal-text flex)
-  align-items: center
-  justify-content: center
-  border-radius: 1rem
   position: absolute
   +media-breakpoint-up(md)
     +size(1.25rem .875rem)
@@ -18,6 +13,24 @@
   +media-breakpoint-down(sm)
     +size(1.125rem .75rem)
     +position(right .125rem, top .125rem)
+  &.is-loading::before
+    content: ' .'
+    color: $default-text
+    animation: dots 1s steps(5, end) infinite
+    +text-block(1rem 1)
+    +position(absolute, left .25rem, bottom .25rem)
+
+@keyframes dots
+  0%, 20%
+    color: rgba(0,0,0,0)
+    text-shadow: .25em 0 0 rgba(0,0,0,0), .5em 0 0 rgba(0,0,0,0)
+  40%
+    color: $default-text
+    text-shadow: .25em 0 0 rgba(0,0,0,0), .5em 0 0 rgba(0,0,0,0)
+  60%
+    text-shadow: .25em 0 0 $default-text, .5em 0 0 rgba(0,0,0,0)
+  80%, 100%
+    text-shadow: .25em 0 0 $default-text, .5em 0 0 $default-text
 
 .header-notifications-item__body
   width: 100%

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -12,5 +12,6 @@ class API::NotificationsController < API::BaseController
     @notifications = Notification.from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
                                  .order(created_at: :desc)
     @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications
+    sleep 3
   end
 end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -12,6 +12,5 @@ class API::NotificationsController < API::BaseController
     @notifications = Notification.from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
                                  .order(created_at: :desc)
     @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications
-    sleep 3
   end
 end

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -9,7 +9,7 @@ li.header-links__item(v-bind:class='hasCountClass')
         .header-notification-count.a-notification-count.test-notification-count(
           v-show='notificationExist'
         ) {{ this.notificationCount }}
-        .loadding-notifications-bell(v-if='loading')
+        .header-loadding-notifications-bell(v-if='loading')
           | loading
         i.fas.fa-bell
         .header-links__link-label 通知

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -9,8 +9,7 @@ li.header-links__item(v-bind:class='hasCountClass')
         .header-notification-count.a-notification-count.test-notification-count(
           v-show='notificationExist'
         ) {{ this.notificationCount }}
-        .header-loadding-notifications-bell(v-if='loading')
-          | loading
+        .header-notification-count.is-loading(v-if='loading')
         i.fas.fa-bell
         .header-links__link-label 通知
   input#header-notification-pc.a-toggle-checkbox(

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -9,6 +9,8 @@ li.header-links__item(v-bind:class='hasCountClass')
         .header-notification-count.a-notification-count.test-notification-count(
           v-show='notificationExist'
         ) {{ this.notificationCount }}
+        .loadding-notifications-bell(v-if='loading')
+          | loading
         i.fas.fa-bell
         .header-links__link-label 通知
   input#header-notification-pc.a-toggle-checkbox(
@@ -48,7 +50,8 @@ dayjs.extend(relativeTime)
 export default {
   data() {
     return {
-      notifications: []
+      notifications: [],
+      loading: false
     }
   },
   computed: {
@@ -64,6 +67,7 @@ export default {
     }
   },
   created() {
+    this.loading = true
     fetch(`/api/notifications.json?status=unread`, {
       method: 'GET',
       headers: {
@@ -82,6 +86,9 @@ export default {
       })
       .catch((error) => {
         console.warn(error)
+      })
+      .finally(() => {
+        this.loading = false
       })
   },
   methods: {


### PR DESCRIPTION
 # issue・概要
- ref: #4137 
- 通知ベルにローディング中にぐるぐるを表示するようにしました

# 変更前
ローディング時に何も表示されない

https://user-images.githubusercontent.com/45246171/154898413-56112b87-8b1e-4710-ad10-d421167d2a68.mov

# 変更後
ローディング中に何かを表示している(町田さんデザイン前)

https://user-images.githubusercontent.com/45246171/154899053-6c167037-209a-487f-b6f9-e9a1a445a503.mov

# 確認手順

1. どれかのユーザーでログインする
2. どのページでも良いのでページ遷移orリロードをする
3. 通知ベルのところにプレースホルダが出る

一瞬でわかりにくいので、動作確認の際は`app/controllers/api/notifications_controller.rb`の15行目に`sleep 5`などの処理を入れると、5秒後に処理が返ってくるので確認しやすいかと思います。
