### PR TITLE
相談部屋の未返信のコメントページにアクセスできるユーザーを管理者のみとした

### DIFF
--- a/app/controllers/talks/unreplied_controller.rb
+++ b/app/controllers/talks/unreplied_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Talks::UnrepliedController < ApplicationController
-  before_action :require_staff_login
+  before_action :require_admin_login
   def index; end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -13,6 +13,11 @@ class TalksTest < ApplicationSystemTestCase
     assert_text '管理者としてログインしてください'
   end
 
+  test 'non-admin user cannot access talks unreplied page' do
+    visit_with_auth '/talks/unreplied', 'mentormentaro'
+    assert_text '管理者としてログインしてください'
+  end
+
   test 'cannot access other users talk page' do
     visited_user = users(:hatsuno)
     visit_user = users(:mentormentaro)


### PR DESCRIPTION
## Issue
- #4230 
 
## 概要
管理者の権限を持っていない【アドバイザー】と【メンター】が相談部屋の未返信のコメントページにアクセスできてしまうバグを修正しました。
現在、未返信のコメントページにアクセスできるのは【管理者】の権限があるユーザーのみとなっています。

## 変更確認方法
1. ブランチ `bug/fix-administrator-restrictions-on-talks-unreplied-page`をローカルに取り込む
2. `$ rails s` でローカル環境を立ち上げる
3. `advijirou`(アドバイザーのみのユーザー)、`mentormentaro`(メンターのみのユーザー)でログイン
4. `/talks/unreplied`にアクセスし今回の変更箇所をご確認ください。

## 変更後
https://user-images.githubusercontent.com/69446373/155068817-e18602fa-41bf-4a63-a50d-a0d556143017.mov

(メンターのユーザーの場合です)