### PR TITLE
Docs一覧ページにWIP中のDocも表示するように修正

### DIFF
--- a/app/javascript/page.vue
+++ b/app/javascript/page.vue
@@ -37,7 +37,7 @@
               .a-meta(v-if='page.wip')
                 | Doc作成中
               time.a-meta(:datetime='page.published_at.to_datetime')(
-                else-if='page.published_at'
+                v-else-if='page.published_at'
               )
                 span.a-meta__label
                   | 公開

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -160,4 +160,14 @@ class PagesTest < ApplicationSystemTestCase
       assert_selector 'img[alt="komagata (Komagata Masaki): 管理者、メンター"]'
     end
   end
+
+  test 'show a WIP Doc on Docs list page' do
+    visit_with_auth pages_path, 'kimura'
+    assert_text 'WIPのテスト'
+    element = all('.thread-list-item__rows').find { |component| component.has_text?('WIPのテスト') }
+    within element do
+      assert_selector '.thread-list-item-title__icon.is-wip', text: 'WIP'
+      assert_selector '.a-meta', text: 'Doc作成中'
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #4286 
 
## 概要
Docを作成してWIPで保存したあと、Docs一覧ページを表示させるとWIP保存中のDocが表示されていなかったため修正を行いました。

## 対策
Vueファイル内の条件分岐の記述が`else-if`となっていたため、Vueの条件付きレンダリングの記述方法に則って`v-else-if`に修正したところ、WIPのDocも一覧に表示されるようになりました。

## 変更確認方法
1. このブランチ `bug/display-wip-doc-on-docs-list-page`をローカルに取り込む
2. `$ rails s` でローカル環境を立ち上げて、テスト用ユーザー(誰でも)でログインする
4. 左側のナビゲーションバーから「Docs」をクリックしてDocs一覧ページを開く
5. 右上の[+Doc作成]をクリックすると入力フォームが開くので、必要事項を入力して[WIP]をクリックしてWIP保存する
6. 「WIPとして保存しました」というメッセージとともにDoc個別ページが表示される(WIPとして表示されている)
7. 左側のナビゲーションバーから「Docs」をクリックしてDocs一覧ページを開く
8. WIP保存したDocが一覧に表示されているのをご確認お願いします。

## 変更【前】(WIPで保存したDocがDocs一覧ページに表示されない)のスクショ
![image](https://user-images.githubusercontent.com/82434093/155137734-7d6730d9-ac21-4bc4-b4c5-57d8d3ac4ccb.png)
![image](https://user-images.githubusercontent.com/82434093/155137761-e023fdb8-ec57-42fd-aaa7-346a9568ed47.png)

## 変更【後】(WIPで保存したDocがDocs一覧ページに表示されるようになった)のスクショ
![image](https://user-images.githubusercontent.com/82434093/155137806-6a103c6f-552b-4902-bc10-bf06ed5400cb.png)
