### PR TITLE
プラクティス > Docs一覧のVue.js化後にテストでエラーとなるバグを修正

### DIFF
--- a/app/javascript/page.vue
+++ b/app/javascript/page.vue
@@ -48,7 +48,7 @@
                 span.a-meta__label
                   | 更新
                 | {{ page.updated_at }} by
-                a.a-user-name(:href='page.last_updated_user.url')
+                a.thread-list-item-meta__icon-link(:href='page.last_updated_user.url')
                   img.thread-list-item__user-icon.a-user-icon(
                     :title='page.last_updated_user.icon_title',
                     :alt='page.last_updated_user.icon_title',


### PR DESCRIPTION
Ref: #4297

バグ修正後に、テストがPassすることを確認しました。
マージ先となる、プラクティス > Docs一覧のVue.js化(#4293)の方でも追記してみてPass確認済みです。

テストログ
```
~/work/bootcamp bug/convert-practices-docs-lists-to-vuejs-after-test-error
❯ rails test test/system/practice/pages_test.rb:11
Run options: --seed 32014

# Running:

.

Finished in 6.657307s, 0.1502 runs/s, 0.1502 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```