### PR TITLE
Menu > Docs一覧の最終更新者のロールが公開者と同じロールになってしまうバグを修正

### DIFF
--- a/app/javascript/page.vue
+++ b/app/javascript/page.vue
@@ -7,7 +7,7 @@
           :title='page.user.icon_title',
           :alt='page.user.icon_title',
           :src='page.user.avatar_url',
-          :class='[roleClass, daimyoClass]'
+          :class='[roleClassPublishedUser, daimyoClass]'
         )
 
     .thread-list-item__rows
@@ -53,7 +53,7 @@
                     :title='page.last_updated_user.icon_title',
                     :alt='page.last_updated_user.icon_title',
                     :src='page.last_updated_user.avatar_url',
-                    :class='[roleClass, daimyoClass]'
+                    :class='[roleClassLastUpdatedUser, daimyoClass]'
                   )
                 .thread-list-item-name
                   a.a-user-name(:href='page.last_updated_user.url')
@@ -78,8 +78,11 @@ export default {
     page: { type: Object, required: true }
   },
   computed: {
-    roleClass() {
+    roleClassPublishedUser() {
       return `is-${this.page.user.primary_role}`
+    },
+    roleClassLastUpdatedUser() {
+      return `is-${this.page.last_updated_user.primary_role}`
     },
     daimyoClass() {
       return { 'is-daimyo': this.page.user.daimyo }

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -71,3 +71,11 @@ page8:
       - 前方一致: `$ apt-cache search ^vim`
   user: komagata
   published_at: "2022-01-01 00:00:00"
+
+page9:
+  title: プラクティスに紐付いたDocs(kimura更新)
+  body: プラクティスに紐付いている(kimura更新)
+  user: komagata
+  practice: practice2
+  published_at: "2022-02-28 00:00:00"
+  last_updated_user: kimura

--- a/test/system/practice/pages_test.rb
+++ b/test/system/practice/pages_test.rb
@@ -8,10 +8,17 @@ class Practice::PagesTest < ApplicationSystemTestCase
     assert_equal 'OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
-  test 'show last updated user icon' do
+  test 'show last updated user icon and role' do
     visit_with_auth "/practices/#{practices(:practice1).id}/pages", 'hajime'
     within '.thread-list-item-meta__icon-link' do
       assert_selector 'img[alt="komagata (Komagata Masaki): 管理者、メンター"]'
+      assert_selector 'img[class="thread-list-item-meta__icon a-user-icon is-admin"]'
+    end
+
+    visit_with_auth "/practices/#{practices(:practice2).id}/pages", 'hajime'
+    within '.thread-list-item-meta__icon-link' do
+      assert_selector 'img[alt="kimura (Kimura Tadasi)"]'
+      assert_selector 'img[class="thread-list-item-meta__icon a-user-icon is-student"]'
     end
   end
 end


### PR DESCRIPTION
Ref: #4296 

プログラム修正後、最終更新者のロールがユーザーに対応したロールとなることを確認しました。

### 変更前

![image](https://user-images.githubusercontent.com/58363353/155641354-2505811c-fd5e-45f9-9bcb-59886376754f.png)

### 変更後

![image](https://user-images.githubusercontent.com/58363353/155642332-b1eafdf9-31c3-430a-9d1c-52b1ffb7eed8.png)
