### PR TITLE
プロフィールの未入力項目ブロックが正常に表示されるように修正

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -34,9 +34,11 @@ class HomeController < ApplicationController
 
   def set_required_fields
     @required_fields = RequiredField.new(
-      description: current_user.description,
-      github_account: current_user.github_account,
-      discord_account: current_user.discord_account
+      avatar_attached: current_user.avatar.attached?,
+      tag_list_count: current_user.tag_list.size,
+      after_graduation_hope: current_user.after_graduation_hope,
+      discord_account: current_user.discord_account,
+      github_account: current_user.github_account
     )
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -38,7 +38,8 @@ class HomeController < ApplicationController
       tag_list_count: current_user.tag_list.size,
       after_graduation_hope: current_user.after_graduation_hope,
       discord_account: current_user.discord_account,
-      github_account: current_user.github_account
+      github_account: current_user.github_account,
+      blog_url: current_user.blog_url
     )
   end
 

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -15,7 +15,8 @@ module HomeHelper
       tag_list_count: 'form-tag-list',
       after_graduation_hope: 'form-after-graduation-hope',
       discord_account: 'form-discord-account',
-      github_account: 'form-github-account'
+      github_account: 'form-github-account',
+      blog_url: 'form-blog-url'
     }[attribute]
   end
 end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -8,4 +8,14 @@ module HomeHelper
       '明日'
     end
   end
+
+  def anchor_to_required_field(attribute)
+    {
+      avatar_attached: 'form-user-avatar',
+      tag_list_count: 'form-tag-list',
+      after_graduation_hope: 'form-after-graduation-hope',
+      discord_account: 'form-discord-account',
+      github_account: 'form-github-account'
+    }[attribute]
+  end
 end

--- a/app/models/required_field.rb
+++ b/app/models/required_field.rb
@@ -4,11 +4,15 @@ class RequiredField
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :description, :string
-  attribute :github_account, :string
+  attribute :avatar_attached, :boolean
+  attribute :tag_list_count, :integer
+  attribute :after_graduation_hope, :string
   attribute :discord_account, :string
+  attribute :github_account, :string
 
-  validates :description, presence: true
-  validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
+  validates :avatar_attached, presence: { message: 'ユーザーアイコンを登録してください。' }
+  validates :tag_list_count, numericality: { greater_than: 0, message: 'タグを登録してください。' }
+  validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }
   validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
+  validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
 end

--- a/app/models/required_field.rb
+++ b/app/models/required_field.rb
@@ -9,10 +9,12 @@ class RequiredField
   attribute :after_graduation_hope, :string
   attribute :discord_account, :string
   attribute :github_account, :string
+  attribute :blog_url, :string
 
   validates :avatar_attached, presence: { message: 'ユーザーアイコンを登録してください。' }
   validates :tag_list_count, numericality: { greater_than: 0, message: 'タグを登録してください。' }
   validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }
   validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
   validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
+  validates :blog_url, presence: { message: 'ブログURLを登録してください。' }
 end

--- a/app/views/application/_required_field.html.slim
+++ b/app/views/application/_required_field.html.slim
@@ -1,4 +1,4 @@
-- unless @required_fields.valid? && current_user.avatar.attached? && !current_user.tag_list.empty?
+- unless @required_fields.valid?
   .a-card
     header.card-header.is-sm
       h2.card-header__title
@@ -11,12 +11,6 @@
             = link_to '学習の準備', 'https://bootcamp.fjord.jp/courses/1/practices#category-1'
             | が終わりましたら、以下の項目を埋めてください。
       ul.card-list__items
-        - unless current_user.avatar.attached?
-          li.card-list__item
-            = link_to 'ユーザーアイコンを登録してください。', edit_current_user_path(anchor: 'form-user-avater'), class: 'card-list__item-link'
-        - if current_user.student? && current_user.after_graduation_hope.blank?
-          li.card-list__item
-            = link_to 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。', edit_current_user_path(anchor: 'form-after-graduation-hope'), class: 'card-list__item-link'
         - @required_fields.errors.each do |error|
           li.card-list__item
-            = link_to error.message, edit_current_user_path, class: "card-list__item-link is-#{error.attribute}"
+            = link_to error.message, edit_current_user_path(anchor: anchor_to_required_field(error.attribute)), class: "card-list__item-link is-#{error.attribute}"

--- a/app/views/users/form/_after_graduation_hope.html.slim
+++ b/app/views/users/form/_after_graduation_hope.html.slim
@@ -1,4 +1,4 @@
-.a-anchor#after_graduation_hope
+.a-anchor#form-after-graduation-hope
 .form-item
   = f.label :after_graduation_hope, 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください', class: 'a-form-label'
   = f.text_area :after_graduation_hope, class: 'a-text-input is-sm', placeholder: 'IT ジェンダーギャップ問題を解決するアプリケーションを作る事業に、エンジニアとして携わる。'

--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -48,6 +48,7 @@
   = f.text_field :facebook_url, class: 'a-text-input', placeholder: 'https://www.facebook.com/komagata1111'
   .a-form-help
     p ID ではなく URL を入力。
+.a-anchor#form-blog-url
 .form-item
   = f.label :blog_url, class: 'a-form-label'
   = f.text_field :blog_url, class: 'a-text-input', placeholder: 'https://docs.komagata.org/'

--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -1,3 +1,4 @@
+.a-anchor#form-discord-account
 .form-item
   = f.label :discord_account, class: 'a-form-label'
   .form-item__mention-input
@@ -21,6 +22,7 @@
           | こちら
         span.a-help
           i.fas.fa-question
+.a-anchor#form-github-account
 .form-item
   = f.label :github_account, class: 'a-form-label'
   .form-item__mention-input

--- a/app/views/users/form/_tags.html.slim
+++ b/app/views/users/form/_tags.html.slim
@@ -1,3 +1,4 @@
+.a-anchor#form-tag-list
 .form-item
   = f.label :tag_list, class: 'a-form-label'
   = render partial: 'tags_input', locals: { taggable: @user }

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -14,32 +14,60 @@ class HomeTest < ApplicationSystemTestCase
     assert_equal 'ダッシュボード | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
-  test 'GET / without github account ' do
+  test 'verify message presence of github_account registration' do
     visit_with_auth '/', 'hajime'
-    within('.card-list__item-link.is-github_account') do
-      assert_text 'GitHubアカウントを登録してください。'
-    end
+    assert_text 'GitHubアカウントを登録してください。'
+    users(:hajime).update!(github_account: 'hajime')
+    page.refresh
+    assert_no_text 'GitHubアカウントを登録してください。'
   end
 
-  test 'GET / with github account' do
-    user = users(:hajime)
-    user.update!(github_account: 'hajime')
+  test 'verify message presence of discord_account registration' do
     visit_with_auth '/', 'hajime'
-    assert_no_selector '.card-list__item-link.is-github_account'
+    assert_text 'Discordアカウントを登録してください。'
+    users(:hajime).update!(discord_account: 'hajime#1111')
+    page.refresh
+    assert_no_text 'Discordアカウントを登録してください。'
   end
 
-  test 'GET / without discord_account' do
+  test 'verify message presence of avatar registration' do
     visit_with_auth '/', 'hajime'
-    within('.card-list__item-link.is-discord_account') do
-      assert_text 'Discordアカウントを登録してください。'
-    end
+    assert_text 'ユーザーアイコンを登録してください。'
+    path = Rails.root.join('test/fixtures/files/users/avatars/default.jpg')
+    users(:hajime).avatar.attach(io: File.open(path), filename: 'hajime.jpg')
+    page.refresh
+    assert_no_text 'ユーザーアイコンを登録してください。'
   end
 
-  test 'GET / with discord_account' do
-    user = users(:hajime)
-    user.update!(discord_account: 'hajime#1111')
-    visit_with_auth '/', 'hajime'
-    assert_no_selector '.card-list__item-link.is-discord_account'
+  test 'verify message presence of tags registration' do
+    visit_with_auth '/', 'hatsuno'
+    assert_text 'タグを登録してください。'
+    users(:hatsuno).update!(tag_list: ['猫'])
+    page.refresh
+    assert_no_text 'タグを登録してください。'
+  end
+
+  test 'verify message presence of after_graduation_hope registration' do
+    visit_with_auth '/', 'hatsuno'
+    assert_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。'
+    users(:hatsuno).update!(after_graduation_hope: 'IT ジェンダーギャップ問題を解決するアプリケーションを作る事業に、エンジニアとして携わる。')
+    page.refresh
+    assert_no_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。'
+  end
+
+  test 'not show messages of required field' do
+    user = users(:hatsuno)
+    # hatsuno の未入力項目を登録
+    user.update!(
+      tag_list: ['猫'],
+      after_graduation_hope: 'IT ジェンダーギャップ問題を解決するアプリケーションを作る事業に、エンジニアとして携わる。',
+      discord_account: 'hatsuno#1234'
+    )
+    path = Rails.root.join('test/fixtures/files/users/avatars/hatsuno.jpg')
+    user.avatar.attach(io: File.open(path), filename: 'hatsuno.jpg')
+
+    visit_with_auth '/', 'hatsuno'
+    assert_no_text '未入力の項目'
   end
 
   test 'show latest announcements on dashboard' do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -19,9 +19,8 @@ class HomeTest < ApplicationSystemTestCase
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'GitHubアカウントを登録してください。'
 
-    # GitHub との連携処理を update! で代用
     users(:hajime).update!(github_account: 'hajime')
-    visit '/'
+    refresh
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'GitHubアカウントを登録してください。'
   end
@@ -31,10 +30,8 @@ class HomeTest < ApplicationSystemTestCase
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'Discordアカウントを登録してください。'
 
-    visit '/current_user/edit'
-    fill_in 'user[discord_account]', with: 'hajime#1111'
-    click_button '更新する'
-    visit '/'
+    users(:hajime).update!(discord_account: 'hajime#1111')
+    refresh
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'Discordアカウントを登録してください。'
   end
@@ -44,11 +41,9 @@ class HomeTest < ApplicationSystemTestCase
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'ユーザーアイコンを登録してください。'
 
-    visit '/current_user/edit'
-    file_path = Rails.root.join('test/fixtures/files/users/avatars/default.jpg')
-    attach_file 'user[avatar]', file_path, make_visible: true
-    click_button '更新する'
-    visit '/'
+    path = Rails.root.join('test/fixtures/files/users/avatars/default.jpg')
+    users(:hajime).avatar.attach(io: File.open(path), filename: 'hajime.jpg')
+    refresh
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'ユーザーアイコンを登録してください。'
   end
@@ -58,12 +53,8 @@ class HomeTest < ApplicationSystemTestCase
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'タグを登録してください。'
 
-    visit '/current_user/edit'
-    tag_input = find('.ti-new-tag-input')
-    tag_input.set '猫'
-    tag_input.native.send_keys :return
-    click_button '更新する'
-    visit '/'
+    users(:hatsuno).update!(tag_list: ['猫'])
+    refresh
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'タグを登録してください。'
   end
@@ -73,10 +64,8 @@ class HomeTest < ApplicationSystemTestCase
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。'
 
-    visit '/current_user/edit'
-    fill_in 'user[after_graduation_hope]', with: 'IT ジェンダーギャップ問題を解決するアプリケーションを作る事業に、エンジニアとして携わる。'
-    click_button '更新する'
-    visit '/'
+    users(:hatsuno).update!(after_graduation_hope: 'IT ジェンダーギャップ問題を解決するアプリケーションを作る事業に、エンジニアとして携わる。')
+    refresh
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。'
   end
@@ -87,10 +76,8 @@ class HomeTest < ApplicationSystemTestCase
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'ブログURLを登録してください。'
 
-    visit '/current_user/edit'
-    fill_in 'user[blog_url]', with: 'http://hatsuno.org'
-    click_button '更新する'
-    visit '/'
+    users(:hatsuno).update!(blog_url: 'http://hatsuno.org')
+    refresh
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'ブログURLを登録してください。'
   end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -16,43 +16,83 @@ class HomeTest < ApplicationSystemTestCase
 
   test 'verify message presence of github_account registration' do
     visit_with_auth '/', 'hajime'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'GitHubアカウントを登録してください。'
+
+    # GitHub との連携処理を update! で代用
     users(:hajime).update!(github_account: 'hajime')
-    page.refresh
+    visit '/'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'GitHubアカウントを登録してください。'
   end
 
   test 'verify message presence of discord_account registration' do
     visit_with_auth '/', 'hajime'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'Discordアカウントを登録してください。'
-    users(:hajime).update!(discord_account: 'hajime#1111')
-    page.refresh
+
+    visit '/current_user/edit'
+    fill_in 'user[discord_account]', with: 'hajime#1111'
+    click_button '更新する'
+    visit '/'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'Discordアカウントを登録してください。'
   end
 
   test 'verify message presence of avatar registration' do
     visit_with_auth '/', 'hajime'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'ユーザーアイコンを登録してください。'
-    path = Rails.root.join('test/fixtures/files/users/avatars/default.jpg')
-    users(:hajime).avatar.attach(io: File.open(path), filename: 'hajime.jpg')
-    page.refresh
+
+    visit '/current_user/edit'
+    file_path = Rails.root.join('test/fixtures/files/users/avatars/default.jpg')
+    attach_file 'user[avatar]', file_path, make_visible: true
+    click_button '更新する'
+    visit '/'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'ユーザーアイコンを登録してください。'
   end
 
   test 'verify message presence of tags registration' do
     visit_with_auth '/', 'hatsuno'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'タグを登録してください。'
-    users(:hatsuno).update!(tag_list: ['猫'])
-    page.refresh
+
+    visit '/current_user/edit'
+    tag_input = find('.ti-new-tag-input')
+    tag_input.set '猫'
+    tag_input.native.send_keys :return
+    click_button '更新する'
+    visit '/'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'タグを登録してください。'
   end
 
   test 'verify message presence of after_graduation_hope registration' do
     visit_with_auth '/', 'hatsuno'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。'
-    users(:hatsuno).update!(after_graduation_hope: 'IT ジェンダーギャップ問題を解決するアプリケーションを作る事業に、エンジニアとして携わる。')
-    page.refresh
+
+    visit '/current_user/edit'
+    fill_in 'user[after_graduation_hope]', with: 'IT ジェンダーギャップ問題を解決するアプリケーションを作る事業に、エンジニアとして携わる。'
+    click_button '更新する'
+    visit '/'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。'
+  end
+
+  test 'verify message presence of blog_url registration' do
+    users(:hatsuno).update!(blog_url: '') # 確認のために削除
+    visit_with_auth '/', 'hatsuno'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
+    assert_text 'ブログURLを登録してください。'
+
+    visit '/current_user/edit'
+    fill_in 'user[blog_url]', with: 'http://hatsuno.org'
+    click_button '更新する'
+    visit '/'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
+    assert_no_text 'ブログURLを登録してください。'
   end
 
   test 'not show messages of required field' do
@@ -67,6 +107,7 @@ class HomeTest < ApplicationSystemTestCase
     user.avatar.attach(io: File.open(path), filename: 'hatsuno.jpg')
 
     visit_with_auth '/', 'hatsuno'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text '未入力の項目'
   end
 


### PR DESCRIPTION
## Issue
- #4135 

## 概要
バリデーション対象のプロフィール項目の内、タグ登録以外が完了している場合に、メッセージなしで未入力項目ブロックが表示されているバグを修正しました。また、以下の変更もしています。

- バリデーション対象のプロフィール項目を以下の6つに変更
⇒ [アバターアイコン、タグ登録、卒業した自分はどうなっていたいか、Discordアカウント、GitHubアカウント、ブログURL]
- メッセージから該当の登録フォームへ移動するように、アンカーリンクを追加・修正

（ ※ 未入力項目ブロック表示の際のバリデーションと、ユーザー情報登録フォームでのバリデーションは別です。）

## 修正前
### タグ以外が登録済みの状態
![image](https://user-images.githubusercontent.com/83743223/155887625-d25bb59b-9e66-4081-8a56-5376a157d034.png)

## 修正後
### タグ以外が登録済みの状態
![image](https://user-images.githubusercontent.com/83743223/155887598-e310b308-b5aa-47e5-919b-132b1db11e10.png)


## ローカル環境での確認方法
1. `bug/display-of-not-entered-user-profile` ブランチを起動
2. `student` か `trainee` のユーザー（`hatsuno` など）でログイン
3. バリデーション対象のプロフィール項目の内、タグ以外を登録済みにし、「タグを登録してください。」のメッセージが表示されることを確認
4. 全ての未入力項目を登録し、未入力項目ブロックが表示されないことを確認
