### PR TITLE
管理者でログインしたときに、ユーザー個別ページに相談部屋へのリンクを表示

### DIFF
--- a/app/views/users/_profile.html.slim
+++ b/app/views/users/_profile.html.slim
@@ -23,7 +23,7 @@
               = user.discord_account.presence || 'Discord未設定'
     = render 'users/sns', user: user
     - if admin_login?
-      .form-actions
+      .form-actions.is-only-mentor
         ul.form-actions__items
           li.form-actions__item.is-main
             = link_to user_reports_path(user, format: :md), class: 'a-button is-md is-primary is-block' do

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -7,8 +7,8 @@ header.page-header
       .page-header-actions
         ul.page-header-actions__items
           - if current_user.admin && !@user.admin
-            li.page-header-actions__item
-              = link_to talk_path(@user.talk), class: 'a-button is-md is-secondary is-block is-back' do
+            li.page-header-actions__item.is-only-mentor
+              = link_to talk_path(@user.talk), class: 'a-button is-md is-secondary is-block' do
                 | 相談部屋
           - if current_user == @user
             li.page-header-actions__item

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -6,7 +6,7 @@ header.page-header
         = title
       .page-header-actions
         ul.page-header-actions__items
-          - if (current_user.admin && !@user.admin) || current_user == @user # komagataさんが自分の表示されちゃう
+          - if current_user.admin && !@user.admin
             li.page-header-actions__item
               = link_to talk_path(@user.talk), class: 'a-button is-md is-secondary is-block is-back' do
                 | 相談部屋

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -6,6 +6,10 @@ header.page-header
         = title
       .page-header-actions
         ul.page-header-actions__items
+          - if (current_user.admin && !@user.admin) || current_user == @user # komagataさんが自分の表示されちゃう
+            li.page-header-actions__item
+              = link_to talk_path(@user.talk), class: 'a-button is-md is-secondary is-block is-back' do
+                | 相談部屋
           - if current_user == @user
             li.page-header-actions__item
               = link_to edit_current_user_path, class: 'a-button is-md is-secondary is-block' do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -116,7 +116,6 @@ class UsersTest < ApplicationSystemTestCase
       daimyo
       nippounashi
       with_hyphen
-      discordinvalid
     ].each do |name|
       users(name).touch # rubocop:disable Rails/SkipsModelValidations
     end
@@ -257,4 +256,24 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{users(:kimura).id}", 'hatsuno'
     assert_no_text '日報一括ダウンロード'
   end
+
+  test 'show link to talk room when logined as admin' do
+    kimura = users(:kimura)
+    visit_with_auth "/users/#{kimura.id}", 'komagata'
+    assert_link '相談部屋',href: "/talks/#{kimura.talk.id}"
+  end
+
+  test 'should not show link to talk room of admin when logined as admin' do
+    machida = users(:machida)
+    visit_with_auth "/users/#{machida.id}", 'komagata'
+    assert_no_link '相談部屋'
+  end
+
+  test 'should not show link to talk room when logined as no-admin' do
+    hatsuno = users(:hatsuno)
+    visit_with_auth "/users/#{hatsuno.id}", 'fujiyasu'
+    assert_no_link '相談部屋'
+  end
 end
+
+

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -260,20 +260,21 @@ class UsersTest < ApplicationSystemTestCase
   test 'show link to talk room when logined as admin' do
     kimura = users(:kimura)
     visit_with_auth "/users/#{kimura.id}", 'komagata'
-    assert_link '相談部屋',href: "/talks/#{kimura.talk.id}"
+    assert_text 'プロフィール'
+    assert_link '相談部屋', href: "/talks/#{kimura.talk.id}"
   end
 
-  test 'should not show link to talk room of admin when logined as admin' do
+  test 'should not show link to talk room of admin even if logined as admin' do
     machida = users(:machida)
     visit_with_auth "/users/#{machida.id}", 'komagata'
+    assert_text 'プロフィール'
     assert_no_link '相談部屋'
   end
 
   test 'should not show link to talk room when logined as no-admin' do
     hatsuno = users(:hatsuno)
     visit_with_auth "/users/#{hatsuno.id}", 'fujiyasu'
+    assert_text 'プロフィール'
     assert_no_link '相談部屋'
   end
 end
-
-

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -273,7 +273,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'should not show link to talk room when logined as no-admin' do
     hatsuno = users(:hatsuno)
-    visit_with_auth "/users/#{hatsuno.id}", 'fujiyasu'
+    visit_with_auth "/users/#{hatsuno.id}", 'kimura'
     assert_text 'プロフィール'
     assert_no_link '相談部屋'
   end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -116,6 +116,7 @@ class UsersTest < ApplicationSystemTestCase
       daimyo
       nippounashi
       with_hyphen
+      discordinvalid
     ].each do |name|
       users(name).touch # rubocop:disable Rails/SkipsModelValidations
     end


### PR DESCRIPTION
- #4094

# 変更前
管理者でログインして、管理者以外のユーザー詳細ページを見た時、各ユーザーの「相談部屋」のリンクが表示されていない。

![管理者ログイン：変更前](https://user-images.githubusercontent.com/58052292/155820360-6feecb9c-0d37-46f7-a382-ea848419a564.png)


# 変更後
- 管理者でログインして、管理者以外のユーザー詳細ページを見た時、各ユーザーの「相談部屋」のリンクが表示される。
![スクリーンショット 2022-02-26 9 32 27](https://user-images.githubusercontent.com/58052292/155820841-cb082283-38e0-457d-9795-6d1c65ba9750.png)


- 管理者でログインして、**管理者の**ユーザー詳細ページを見た時は、「相談部屋」のリンクを表示しない。
![スクリーンショット 2022-02-26 9 34 29](https://user-images.githubusercontent.com/58052292/155820910-18c2211f-835c-43e7-bd2e-fcc02baeceb9.png)

# 動作確認の手順
1. ブランチ`feature/display-link-to-user-talk-room-when-logined-as-admin`をローカルに取り込む
2. `bin/setup`を実行する
3. `bin/rails s`でサーバーを立ち上げる
4. `komagata`(管理者)でログインし、`fujiyasu`のユーザー詳細ページにアクセスする
5. 右上のユーザー一覧ページの隣に「相談部屋」リンクが表示されていること、クリックすると`fujiyasu`の相談部屋にアクセスできることを確認する
6. `komagata`(管理者)でログインし、`machida`(管理者)のユーザー詳細ページにアクセスする
7. 右上のユーザー一覧ページの隣に「相談部屋」リンクが表示されていないことを確認する
8. `mentormentaro`(管理者以外)でログインし、`fujiyasu`のユーザー詳細ページにアクセスする
9. 右上のユーザー一覧ページの隣に「相談部屋」リンクが表示されていないことを確認する

