### PR TITLE
viewsで使われているform_tagやform_forをform_withに変更

### DIFF
--- a/app/views/admin/categories/_form.html.slim
+++ b/app/views/admin/categories/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for([:admin, category], html: { name: 'category', class: 'form' }) do |f|
+= form_with model: [:admin, category], local: true, html: { name: 'category', class: 'form' } do |f|
   = f.hidden_field :course_id, value: params[:course_id]
   .form__items
     .form-item

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for [:admin, company], html: { name: 'company' } do |f|
+= form_with model: [:admin, company], local: true, html: { name: 'company' } do |f|
   .form__items
     .form-item
       = f.label :name, class: 'a-form-label'

--- a/app/views/application/_header_search.html.slim
+++ b/app/views/application/_header_search.html.slim
@@ -1,4 +1,4 @@
-= form_with url: searchables_path, local: true, method: 'get', html: { name: 'search', class: 'header-search' } do |f|
+= form_with url: searchables_path, local: true, method: 'get', html: { name: 'search', class: 'header-search' }
   .header-search__select.a-button.is-sm.is-secondary.is-select.is-block
     = select_tag 'document_type', options_for_select(Searcher::DOCUMENT_TYPES, params[:document_type]), id: select_id
   = text_field_tag 'word', params[:word], class: 'a-xs-text-input header-search__text-input', id: text_field_id, placeholder: '検索ワード'

--- a/app/views/application/_header_search.html.slim
+++ b/app/views/application/_header_search.html.slim
@@ -1,4 +1,4 @@
-= form_with url: searchables_path, local: true, method: 'get', html: { name: 'search', class: 'header-search'} do |f|
+= form_with url: searchables_path, local: true, method: 'get', html: { name: 'search', class: 'header-search' } do |f|
   .header-search__select.a-button.is-sm.is-secondary.is-select.is-block
     = select_tag 'document_type', options_for_select(Searcher::DOCUMENT_TYPES, params[:document_type]), id: select_id
   = text_field_tag 'word', params[:word], class: 'a-xs-text-input header-search__text-input', id: text_field_id, placeholder: '検索ワード'

--- a/app/views/application/_header_search.html.slim
+++ b/app/views/application/_header_search.html.slim
@@ -1,4 +1,4 @@
-= form_with url: searchables_path, local: true, method: 'get', class: 'header-search', name: 'search' do |f|
+= form_with url: searchables_path, local: true, method: 'get', html: { name: 'search', class: 'header-search'} do |f|
   .header-search__select.a-button.is-sm.is-secondary.is-select.is-block
     = select_tag 'document_type', options_for_select(Searcher::DOCUMENT_TYPES, params[:document_type]), id: select_id
   = text_field_tag 'word', params[:word], class: 'a-xs-text-input header-search__text-input', id: text_field_id, placeholder: '検索ワード'

--- a/app/views/application/_header_search.html.slim
+++ b/app/views/application/_header_search.html.slim
@@ -1,4 +1,4 @@
-= form_tag searchables_url, method: 'get', class: 'header-search', name: 'search' do
+= form_with url: searchables_path, local: true, method: 'get', class: 'header-search', name: 'search' do |f|
   .header-search__select.a-button.is-sm.is-secondary.is-select.is-block
     = select_tag 'document_type', options_for_select(Searcher::DOCUMENT_TYPES, params[:document_type]), id: select_id
   = text_field_tag 'word', params[:word], class: 'a-xs-text-input header-search__text-input', id: text_field_id, placeholder: '検索ワード'

--- a/app/views/password_resets/edit.html.slim
+++ b/app/views/password_resets/edit.html.slim
@@ -5,7 +5,7 @@
     h1.auth-form__title = title
   .auth-form__body
     = render 'errors', object: @user
-    = form_for @user, url: password_reset_path(@token), html: { method: :put, class: 'form', name: 'password_reset', autocomplete: :nope } do |f|
+    = form_with model: @user, local: true, url: password_reset_path(@token), html: { method: :put, class: 'form', name: 'password_reset', autocomplete: :nope } do |f|
       .form__items
         .form-item
           = f.label :password, class: 'a-form-label is-required'

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -1,5 +1,5 @@
 = render 'errors', object: product
-= form_for product, html: { name: 'product', class: 'form' } do |f|
+= form_with model: product, local: true, html: { name: 'product', class: 'form' } do |f|
   = hidden_field_tag :practice_id, practice.id
   .form__items
     .form-item

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -121,7 +121,7 @@ header.page-header
                   ul.card-main-actions__items
                     - if @product.wip?
                       li.card-main-actions__item
-                        = form_for @product do |f|
+                        = form_with model: @product, local: true do |f|
                           = f.hidden_field :body
                           = f.submit '提出する', class: 'a-button is-md is-warning is-block'
                     li.card-main-actions__item

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -10,7 +10,7 @@ header.page-header
               i.fas.fa-plus
               | 質問する
 
-= form_with url: questions_path, method: 'get' do |f|
+= form_with url: questions_path, method: 'get',local: true
   nav.sort-nav
     .container.is-md
       .sort-nav__inner

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -10,7 +10,7 @@ header.page-header
               i.fas.fa-plus
               | 質問する
 
-= form_with url: questions_path, method: 'get',local: true
+= form_with url: questions_path, method: 'get', local: true
   nav.sort-nav
     .container.is-md
       .sort-nav__inner

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -10,7 +10,7 @@ header.page-header
               i.fas.fa-plus
               | 質問する
 
-= form_tag :questions, method: 'get' do
+= form_with url: questions_path, method: 'get' do |f|
   nav.sort-nav
     .container.is-md
       .sort-nav__inner

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -1,5 +1,5 @@
 = render 'errors', object: report
-= form_for report do |f|
+= form_with model: report, local: true do |f|
   .form__items
     .form__items-inner
       .form-item

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -1,5 +1,5 @@
 = render 'errors', object: report
-= form_with model: report, local: true do |f|
+= form_with model: report, local: true, html: { name: 'report' } do |f|
   .form__items
     .form__items-inner
       .form-item

--- a/app/views/reports/_report_footprint_form.html.slim
+++ b/app/views/reports/_report_footprint_form.html.slim
@@ -1,3 +1,3 @@
-= form_for ([@report, @footprint]), html: { class: 'report-footprint-form' } do |f|
+= form_with model: [@report, @footprint], local: true, html: { class: 'report-footprint-form' } do |f|
   = hidden_field_tag :user_id, current_user.id
   = f.submit t('footprint_report'), class: 'report-footprint-form__action a-button is-sm is-danger'

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -9,7 +9,7 @@ header.page-header
 
 .page-tools
   nav.sort-nav
-    = form_with url: reports_path, local: true, method: 'get' do |f|
+    = form_with url: reports_path, local: true, method: 'get'
       .container.is-md
         .sort-nav__inner
           = label_tag :practice_id, 'プラクティスで絞り込む', class: 'sort-nav__label'

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -9,7 +9,7 @@ header.page-header
 
 .page-tools
   nav.sort-nav
-    = form_tag reports_url, method: 'get' do
+    = form_with url: reports_path, local: true, method: 'get' do |f|
       .container.is-md
         .sort-nav__inner
           = label_tag :practice_id, 'プラクティスで絞り込む', class: 'sort-nav__label'

--- a/app/views/user_sessions/_forget_password_form.html.slim
+++ b/app/views/user_sessions/_forget_password_form.html.slim
@@ -1,4 +1,4 @@
-= form_with url: password_resets_path, local: true, method: :post, id: 'password_resets_form', class: 'form' do |f|
+= form_with url: password_resets_path, local: true, method: :post, id: 'password_resets_form', class: 'form'
   .form__items
     .form-item
       = label_tag :email, t('email'), class: 'a-form-label is-required'

--- a/app/views/user_sessions/_forget_password_form.html.slim
+++ b/app/views/user_sessions/_forget_password_form.html.slim
@@ -1,4 +1,4 @@
-= form_tag password_resets_path, method: :post, id: 'password_resets_form', class: 'form' do
+= form_with url: password_resets_path, local: true, method: :post, id: 'password_resets_form', class: 'form' do |f|
   .form__items
     .form-item
       = label_tag :email, t('email'), class: 'a-form-label is-required'

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for user, url: user_sessions_path, html: { id: 'sign-in-form', class: 'form', name: 'user_session' } do |f|
+= form_with model: user, local: true, url: user_sessions_path, html: { id: 'sign-in-form', class: 'form', name: 'user_session' } do |f|
   .form__items
     .form-item
       = label_tag 'user_login', 'ユーザー名 or メールアドレス', class: 'a-form-label'

--- a/app/views/works/_form.html.slim
+++ b/app/views/works/_form.html.slim
@@ -1,5 +1,5 @@
 = render 'errors', object: work
-= form_for work, class: 'form' do |f|
+= form_with model: work, local: true, class: 'form' do |f|
   .form__items
     .form__items-inner
       .form-item

--- a/test/system/emotions_test.rb
+++ b/test/system/emotions_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class EmotionsTest < ApplicationSystemTestCase
   test 'create a report with an emotion' do
     visit_with_auth '/reports/new', 'komagata'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
     end
@@ -24,7 +24,7 @@ class EmotionsTest < ApplicationSystemTestCase
 
   test 'create a report with the sad emotion' do
     visit_with_auth '/reports/new', 'komagata'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
     end

--- a/test/system/followings_test.rb
+++ b/test/system/followings_test.rb
@@ -89,7 +89,7 @@ class FollowingsTest < ApplicationSystemTestCase
     click_button 'コメントなし'
 
     visit_with_auth '/reports/new', 'hatsuno'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
       fill_in('report[reported_on]', with: Time.current)
@@ -120,7 +120,7 @@ class FollowingsTest < ApplicationSystemTestCase
     click_button 'コメントなし'
 
     visit_with_auth '/reports/new', 'hatsuno'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
       fill_in('report[reported_on]', with: Time.current)

--- a/test/system/mention/products_test.rb
+++ b/test/system/mention/products_test.rb
@@ -10,7 +10,7 @@ module Mention
     test 'mention from a production' do
       post_mention = lambda { |body|
         visit "#{new_product_path}?practice_id=#{practices(:practice5).id}"
-        within('form[name=product]) do
+        within('form[name=product]') do
           fill_in('product[body]', with: body)
         end
         click_button '提出する'

--- a/test/system/mention/products_test.rb
+++ b/test/system/mention/products_test.rb
@@ -10,7 +10,7 @@ module Mention
     test 'mention from a production' do
       post_mention = lambda { |body|
         visit "#{new_product_path}?practice_id=#{practices(:practice5).id}"
-        within('#new_product') do
+        within('form[name=product]) do
           fill_in('product[body]', with: body)
         end
         click_button '提出する'

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -6,7 +6,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
   test 'send adviser a notification when trainee create product' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice5).id}", 'kensyu'
 
-    within('#new_product') do
+    within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end
     click_button '提出する'

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -45,7 +45,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/reports', 'komagata'
     click_link '日報作成'
 
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
     end
@@ -164,7 +164,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/reports', student
 
     click_link '日報作成'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title 1')
       fill_in('report[description]', with: 'test 1')
       fill_in('report[reported_on]', with: Date.current.prev_day)
@@ -178,7 +178,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     find('.modal-header__close').click
 
     click_link '日報作成'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title 2')
       fill_in('report[description]', with: 'test 2')
       fill_in('report[reported_on]', with: Date.current)

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -81,7 +81,7 @@ class ProductsTest < ApplicationSystemTestCase
 
   test 'create product' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'mentormentaro'
-    within('#new_product') do
+    within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end
     click_button '提出する'
@@ -91,7 +91,7 @@ class ProductsTest < ApplicationSystemTestCase
 
   test 'create product change status submitted' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'mentormentaro'
-    within('#new_product') do
+    within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end
     click_button '提出する'
@@ -177,7 +177,7 @@ class ProductsTest < ApplicationSystemTestCase
 
   test 'create product as WIP' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'mentormentaro'
-    within('#new_product') do
+    within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end
     click_button 'WIP'
@@ -209,7 +209,7 @@ class ProductsTest < ApplicationSystemTestCase
     click_link '全て既読にする'
 
     visit_with_auth "/products/new?practice_id=#{practices(:practice3).id}", 'kensyu'
-    within('#new_product') do
+    within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end
     click_button 'WIP'
@@ -224,7 +224,7 @@ class ProductsTest < ApplicationSystemTestCase
     click_link '全て既読にする'
 
     visit_with_auth "/products/new?practice_id=#{practices(:practice3).id}", 'kensyu'
-    within('#new_product') do
+    within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end
     click_button 'WIP'

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -10,7 +10,7 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'create report as WIP' do
     visit_with_auth '/reports/new', 'komagata'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
     end
@@ -20,7 +20,7 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'create a report' do
     visit_with_auth '/reports/new', 'komagata'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
       fill_in('report[reported_on]', with: Time.current)
@@ -39,7 +39,7 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'create a report without learning time' do
     visit_with_auth '/reports/new', 'komagata'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
       fill_in('report[reported_on]', with: Time.current)
@@ -83,7 +83,7 @@ class ReportsTest < ApplicationSystemTestCase
     user.update!(company: nil)
 
     visit_with_auth '/reports/new', 'kensyu'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
       fill_in('report[reported_on]', with: Time.current)
@@ -100,7 +100,7 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'create and update learning times in a report' do
     visit_with_auth '/reports/new', 'komagata'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
       fill_in('report[reported_on]', with: Time.current)
@@ -391,7 +391,7 @@ class ReportsTest < ApplicationSystemTestCase
     Report.destroy_all
 
     visit_with_auth '/reports/new', 'kensyu'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
       fill_in('report[reported_on]', with: Time.current)
@@ -416,7 +416,7 @@ class ReportsTest < ApplicationSystemTestCase
     Report.all.each(&:destroy)
 
     visit_with_auth '/reports/new', 'kensyu'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
       fill_in('report[reported_on]', with: Time.current)
@@ -504,7 +504,7 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'reports can be checked as plain markdown' do
     visit_with_auth '/reports/new', 'kimura'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'check plain markdown')
       fill_in('report[description]', with: '## this is heading2')
       fill_in('report[reported_on]', with: Time.current)
@@ -544,7 +544,7 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'cannot post a new report with future date' do
     visit_with_auth '/reports/new', 'komagata'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: '学習日が未来日では日報を作成できない')
       fill_in('report[description]', with: 'エラーになる')
       fill_in('report[reported_on]', with: Date.current.next_day)
@@ -568,7 +568,7 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'description of the daily report is previewed' do
     visit_with_auth '/reports/new', 'komagata'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
     end
     assert_selector '.js-preview.is-long-text.markdown-form__preview', text: 'Markdown入力するとプレビューにHTMLで表示されている。' do
@@ -579,7 +579,7 @@ class ReportsTest < ApplicationSystemTestCase
   test 'description of the daily report is previewed when editing' do
     visit_with_auth report_path(reports(:report1)), 'komagata'
     click_link '内容修正'
-    within("#edit_report_#{reports(:report1).id}") do
+    within('form[name=report]') do
       fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
     end
     assert_selector '.js-preview.is-long-text.markdown-form__preview', text: 'Markdown入力するとプレビューにHTMLで表示されている。' do
@@ -590,7 +590,7 @@ class ReportsTest < ApplicationSystemTestCase
   test 'description of the daily report is previewed when copied' do
     visit_with_auth report_path(reports(:report1)), 'komagata'
     click_link 'コピー'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
     end
     assert_selector '.js-preview.is-long-text.markdown-form__preview', text: 'Markdown入力するとプレビューにHTMLで表示されている。' do

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -33,7 +33,7 @@ class RetirementTest < ApplicationSystemTestCase
 
   test 'delete unchecked products when the user retired' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice5).id}", 'muryou'
-    within('#new_product') do
+    within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end
     click_button '提出する'

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -54,7 +54,7 @@ class RetirementTest < ApplicationSystemTestCase
 
   test 'delete WIP reports when the user retired' do
     visit_with_auth '/reports/new', 'muryou'
-    within('#new_report') do
+    within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')
     end


### PR DESCRIPTION
- issue #4231 

## 変更前と変更後
- 外観は変化なし
- `form_for` `form_tag`を`form_with`の形式に合わせる変更を行う
- `form_for` ではidが自動生成されるが、`form_with`ではされないため、関係するモデル（`report` `product`)のテストの下記を変更
　- `within(‘#new_product')’ → ’form[name=product]’
　- `within(‘#new_report')’ → ’form[name=report]’ （reportにname属性がなかったため、付与）
## 動作確認の手順
1. ブランチfeature/change-to-form-with-from-form-tag-and-form-forをローカルに取り込む
1. bin/setupを実行する
1. テストを実行し、エラーがでないことを確認する
