### PR TITLE
[fixture] docsのseedデータに関連プラクティス、タグを持たせる

### DIFF
--- a/db/fixtures/acts_as_taggable_on/taggings.yml
+++ b/db/fixtures/acts_as_taggable_on/taggings.yml
@@ -2,42 +2,52 @@ komagata_tag_cat:
   taggable: komagata (User)
   context: tags
   tag: cat
+
 komagata_tag_game:
   taggable: komagata (User)
   context: tags
   tag: game
+
 komagata_tag_manga:
   taggable: komagata (User)
   context: tags
   tag: manga
+
 machida_tag_designer:
   taggable: machida (User)
   context: tags
   tag: designer
+
 machida_tag_guitar:
   taggable: machida (User)
   context: tags
   tag: guitar
+
 kimura_tag_cat:
   taggable: kimura (User)
   context: tags
   tag: cat
+
 hajime_tag_cat:
   taggable: hajime (User)
   context: tags
   tag: cat
+
 kimura_tag_shinjuku_rb:
   taggable: kimura (User)
   context: tags
   tag: shinjuku_rb
+
 kimura_tag_neovim_v_zero_five_zero:
   taggable: kimura (User)
   context: tags
   tag: neovim_v_zero_five_zero
+
 kimura_tag__net_framework:
   taggable: kimura (User)
   context: tags
   tag: _net_framework
+
 kimura_tag_may_j_:
   taggable: kimura (User)
   context: tags
@@ -46,11 +56,13 @@ kimura_tag_may_j_:
 question13_tag_cat:
   taggable: question13 (Question)
   context: tags
+
   tag: cat
 question13_tag_game:
   taggable: question13 (Question)
   context: tags
   tag: game
+
 question14_tag_manga:
   taggable: question14 (Question)
   context: tags
@@ -60,22 +72,27 @@ page3_tag_shinjuku_rb:
   taggable: page3 (Page)
   context: tags
   tag: shinjuku_rb
+
 page4_tag_designer:
   taggable: page4 (Page)
   context: tags
   tag: designer
+
 page6_tag_may_j_:
   taggable: page6 (Page)
   context: tags
   tag: may_j_
+
 page9_tag_cat:
   taggable: page9 (Page)
   context: tags
   tag: cat
+
 page12_neovim_v_zero_five_zero:
   taggable: page12 (Page)
   context: tags
   tag: neovim_v_zero_five_zero
+
 page13_tag_net_framework:
   taggable: page13 (Page)
   context: tags

--- a/db/fixtures/acts_as_taggable_on/taggings.yml
+++ b/db/fixtures/acts_as_taggable_on/taggings.yml
@@ -55,3 +55,28 @@ question14_tag_manga:
   taggable: question14 (Question)
   context: tags
   tag: manga
+
+page3_tag_shinjuku_rb:
+  taggable: page3 (Page)
+  context: tags
+  tag: shinjuku_rb
+page4_tag_designer:
+  taggable: page4 (Page)
+  context: tags
+  tag: designer
+page6_tag_may_j_:
+  taggable: page6 (Page)
+  context: tags
+  tag: may_j_
+page9_tag_cat:
+  taggable: page9 (Page)
+  context: tags
+  tag: cat
+page12_neovim_v_zero_five_zero:
+  taggable: page12 (Page)
+  context: tags
+  tag: neovim_v_zero_five_zero
+page13_tag_net_framework:
+  taggable: page13 (Page)
+  context: tags
+  tag: _net_framework

--- a/db/fixtures/acts_as_taggable_on/tags.yml
+++ b/db/fixtures/acts_as_taggable_on/tags.yml
@@ -1,18 +1,26 @@
 cat:
   name: 猫
+
 designer:
   name: デザイナー
+
 game:
   name: ゲーム
+
 guitar:
   name: ギター
+
 manga:
   name: マンガ
+
 shinjuku_rb:
   name: shinjuku.rb
+
 neovim_v_zero_five_zero:
   name: neovim_v0.5.0
+
 _net_framework:
   name: .NET_Framework
+
 may_j_:
   name: May_J.

--- a/db/fixtures/pages.yml
+++ b/db/fixtures/pages.yml
@@ -13,6 +13,7 @@ page2:
     テスト
     [example](http://example.com)
   user: komagata
+  practice: practice44
   published_at: "2019-01-01 00:00:00"
 
 page3:
@@ -29,6 +30,7 @@ page4:
     ## テスト
     テスト
   user: komagata
+  practice: practice51
   published_at: "2021-01-01 00:00:00"
 
 page5:
@@ -49,6 +51,7 @@ page7:
   body: 上手な質問の方法
   slug: how_to_ask_questions
   user: komagata
+  practice: practice11
   published_at: "2021-07-01 00:00:00"
 
 page8:
@@ -70,6 +73,7 @@ page10:
   body: フォロー機能
   slug: follow_the_report
   user: komagata
+  practice: practice33
   published_at: "2021-07-01 00:00:00"
 
 page11:
@@ -94,6 +98,7 @@ page12:
       - 完全一致: `$ apt-cache search ^vim$`
       - 前方一致: `$ apt-cache search ^vim`
   user: komagata
+  practice: practice6
   published_at: "2022-01-01 00:00:00"
 
 page13:

--- a/db/fixtures/reactions.yml
+++ b/db/fixtures/reactions.yml
@@ -32,4 +32,3 @@ reaction7:
   user: komagata
   reactionable: product12 (Product)
   kind: eyes
-

--- a/test/fixtures/acts_as_taggable_on/taggings.yml
+++ b/test/fixtures/acts_as_taggable_on/taggings.yml
@@ -2,50 +2,62 @@ komagata_tag_cat:
   taggable: komagata (User)
   context: tags
   tag: cat
+
 komagata_tag_game:
   taggable: komagata (User)
   context: tags
   tag: game
+
 komagata_tag_manga:
   taggable: komagata (User)
   context: tags
   tag: manga
+
 machida_tag_designer:
   taggable: machida (User)
   context: tags
   tag: designer
+
 machida_tag_guitar:
   taggable: machida (User)
   context: tags
   tag: guitar
+
 kimura_tag_cat:
   taggable: kimura (User)
   context: tags
   tag: cat
+
 hajime_tag_cat:
   taggable: hajime (User)
   context: tags
   tag: cat
+
 kimura_tag_shinjuku_rb:
   taggable: kimura (User)
   context: tags
   tag: shinjuku_rb
+
 kimura_tag_neovim_v_zero_five_zero:
   taggable: kimura (User)
   context: tags
   tag: neovim_v_zero_five_zero
+
 kimura_tag__net_framework:
   taggable: kimura (User)
   context: tags
   tag: _net_framework
+
 kimura_tag_may_j_:
   taggable: kimura (User)
   context: tags
   tag: may_j_
+
 kimura_tag_beginner:
   taggable: kimura (User)
   context: tags
   tag: beginner
+
 hajime_tag_intermediate:
   taggable: hajime (User)
   context: tags
@@ -55,10 +67,12 @@ question3_tag_beginner:
   taggable: question3 (Question)
   context: tags
   tag: beginner
+
 question3_tag_intermediate:
   taggable: question3 (Question)
   context: tags
   tag: intermediate
+
 question4_tag_intermediate:
   taggable: question4 (Question)
   context: tags
@@ -68,6 +82,7 @@ page1_tag_beginner:
   taggable: page1 (Page)
   context: tags
   tag: beginner
+
 page2_tag_intermediate:
   taggable: page2 (Page)
   context: tags

--- a/test/fixtures/acts_as_taggable_on/tags.yml
+++ b/test/fixtures/acts_as_taggable_on/tags.yml
@@ -1,22 +1,32 @@
 cat:
   name: 猫
+
 designer:
   name: デザイナー
+
 game:
   name: ゲーム
+
 guitar:
   name: ギター
+
 manga:
   name: マンガ
+
 shinjuku_rb:
   name: shinjuku.rb
+
 neovim_v_zero_five_zero:
   name: neovim_v0.5.0
+
 _net_framework:
   name: .NET_Framework
+
 may_j_:
   name: May_J.
+
 beginner:
   name: 初心者
+
 intermediate:
   name: 中級者

--- a/test/fixtures/reactions.yml
+++ b/test/fixtures/reactions.yml
@@ -32,4 +32,3 @@ reaction7:
   user: komagata
   reactionable: product12 (Product)
   kind: eyes
-

--- a/test/fixtures/works.yml
+++ b/test/fixtures/works.yml
@@ -11,4 +11,3 @@ work2:
   url: https://hatsunosapp.com
   repository: https://hatsunosapp.repository.com
   user: hatsuno
-


### PR DESCRIPTION
Issue: #4240 

## 概要
docsのseedデータに関連プラクティス、タグを持っているものがないので、今 fixtures に入っているデータに、関連プラクティスとタグを持たせました。

## 変更理由
Issue作成者の町田さんにヒアリングしたところ、タグ周りのデータがないのでデザインの確認ができないという問題が起きているとのことです。
また、余談ですが、「一例としてデザインが確認できないという問題がありますが、機能があるのにデータがないことでその機能の存在がコードを見るか本番環境を見ないと知ることができないことによる弊害は色々あります。フィヨルドブートキャンプは利用者が開発しているという特殊なアプリなのですが、例えば特定の会社でしか使わない業務アプリの開発を請け負った場合は本番環境が見れないという場合もあります。」とのことです。こういった面でも、デモデータを充実させておくことは重要のようです。

## 変更点
下記3点の観点で、関連プラクティス、タグを配置してみました。
- Docsの各タイトルに関連がありそうなプラクティスを選択。
- タグは漢字、カタカナ、英語・記号のミックスのパターンを網羅。
- 関連プラクティスのみ、タグのみ、両方あり、両方なしのパターンを網羅

## 動作確認
関連プラクティス、タグが追加されていることを確認した。

### 修正前
![image](https://user-images.githubusercontent.com/58363353/155843038-cff2e734-5306-4d3f-adae-55c34346cbff.png)

### 修正後
![image](https://user-images.githubusercontent.com/58363353/155843045-48ee726c-3262-40cc-b29d-a27bddf187bf.png)

### 確認手順
1. `feature/add-related-practices-and-tags-to-docs-seed-data`をローカルの任意のブランチに持ってくる。
2. `$ rails db:seed`を実行し、本ブランチのデータをDBに投入する。
3. Railsサーバーを起動し、任意のユーザーでログインする。
4. 最左列MenuのDocsを選択し、関連プラクティス、タグが追加されていることを目視確認する。
5. 確認終了後、`main`ブランチに戻ったら、`$ rails db:seed`を実行してDB内のデータを元のmainの状態に戻す。