### PR TITLE
日報のafter_saveの循環リスクを排除する

### DIFF
--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -8,8 +8,7 @@ class ReportCallbacks
 
     return unless report.first_public?
 
-    report.published_at = report.updated_at
-    report.save!(validate: false)
+    report.update_column(:published_at, report.updated_at) # rubocop:disable Rails/SkipsModelValidations
 
     notify_users(report)
   end


### PR DESCRIPTION
Issue: #4241 

## 概要
日報のコールバック`after_save`内で`save!`が使用されており循環のリスクがあったのですが、保存後のコールバックをスキップする`update_column`メソッドに置き換えることで循環のリスクを排除しました。

## 変更点
日報のコールバックafter_save内の`save!`メソッドを`update_column`メソッドに変更。
変更にあたって、以下のマニュアル、記事を参照しました。

- Rails ガイド：`update_column`メソッドがコールバックのスキップ対象であることを確認。
[Active Record Callbacks — Ruby on Rails Guides](https://guides.rubyonrails.org/active_record_callbacks.html#skipping-callbacks)

- Rails API 公式リファレンス：`update_column`メソッドの使用方法
[ActiveRecord::Persistence](https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-update_column)

- Rubocopで`update_column`に対してバリデーションスキップに対する警告が表示されましたが、`published_at`に対するバリデーションはないため、問題なしと判断しており、RuboCopの警告をコメントで無効化する方法で、警告対象の`Rails/SkipsModelValidations`のみをスキップしています。
[RuboCopの警告をコメントで無効化する方法 \- Qiita](https://qiita.com/tbpgr/items/a9000c5c6fa92a46c206#%E5%8D%98%E4%B8%80%E8%A1%8C%E3%81%AE%E7%89%B9%E5%AE%9A%E3%81%AE%E8%AD%A6%E5%91%8A%E3%82%92%E7%84%A1%E5%8A%B9%E5%8C%96%E3%81%97%E3%81%9F%E3%81%84%E5%A0%B4%E5%90%88)
```
Offenses:

app/models/report_callbacks.rb:11:12: C: Rails/SkipsModelValidations: Avoid using update_column because it skips validations.
    report.update_column(:published_at, report.updated_at)
           ^^^^^^^^^^^^^
```

## 変更理由
現状、次項の確認結果の上から6つのケースで循環が発生していないことをbyebugのステップ実行で確認しましたが、Issue: #4241 記載の通り、日報のafter_save内の5行目と9行目のガード節が何らかの変更で欠落した最下行のケースでは、循環が発生して戻ってこなくなるため、今回のバグ修正に至りました。

## 確認結果
問題なし。

-  変更前：saveが1回余計に実行されるケースがあった → 変更後：余計に実行されない。
- 変更前：日報のafter_save内のガード節を削除すると循環が発生 → 変更後：循環は発生しない。

|   日報の状態遷移              |   created_at         |   updated_at                     |   published_at       |   wip           |   【変更前】after_save内の循環  |   【変更後】after_save内の循環  |
|-------------------------------|----------------------|----------------------------------|----------------------|-----------------|---------------------------------|---------------------------------|
|   なし→WIP                    |   なし→Time.current  |   なし→Time.current              |   変更されない       |   なし→True     |   なし                          |   なし                          |
|   なし→提出                   |   なし→Time.current  |   なし→Time.current              |   なし→Time.current  |   なし→False    |   なし（**1回余計にsave実行**）         |   なし                          |
|   WIP→WIP                     |   変更されない       |   前のTime.current→Time.current  |   変更されない       |   変更されない  |   なし                          |   なし                          |
|   WIP→提出                    |   変更されない       |   前のTime.current→Time.current  |   なし→Time.current  |   True→False    |   なし（**1回余計にsave実行**）         |   なし                          |
|   提出→WIP                    |   変更されない       |   前のTime.current→Time.current  |   変更されない       |   False→True    |   なし                          |   なし                          |
|   提出→提出                   |   変更されない       |   前のTime.current→Time.current  |   変更されない       |   変更されない  |   なし                          |   なし                          |
|   after_save内のガード節削除  |   -                  |   -                              |   -                  |   -             |   **あり**                          |   なし                          |

## 確認手順
1. `bug/fix-eliminating-cyclical-risk-when-saving-reports`をローカルの任意のブランチに持ってくる。
2. 日報のafter_save内の5行目と9行目のガード節をコメントアウトする。
3. Railsサーバーを起動し、任意のユーザーでログインする。
4. 日報を作成し、提出する。
5. コマンドラインのRails のログが流れて止まることを確認する（循環するとログが流れっぱなしで戻ってこなくなる）。
