### PR TITLE
Twitter IDが不正でも退会できるように修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -130,13 +130,6 @@ class User < ApplicationRecord
   validates :description, presence: true
   validates :nda, presence: true
   validates :password, length: { minimum: 4 }, confirmation: true, if: :password_required?
-  validates :twitter_account,
-            length: { maximum: 15 },
-            format: {
-              allow_blank: true,
-              with: /\A\w+\z/,
-              message: 'は英文字と_（アンダースコア）のみが使用できます'
-            }
   validates :mail_notification, inclusion: { in: [true, false] }
   validates :github_id, uniqueness: true, allow_nil: true
   validates :times_url,
@@ -186,6 +179,13 @@ class User < ApplicationRecord
                 allow_blank: true,
                 with: /\A[^\s\p{blank}].*[^\s\p{blank}]#\d{4}\z/,
                 message: 'は「ユーザー名#４桁の数字」で入力してください'
+              }
+    validates :twitter_account,
+              length: { maximum: 15 },
+              format: {
+                allow_blank: true,
+                with: /\A\w+\z/,
+                message: 'は英文字と_（アンダースコア）のみが使用できます'
               }
   end
 

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -175,3 +175,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
 talk_discordinvalid:
   user: discordinvalid
   unreplied: false
+
+talk_twitterinvalid:
+  user: twitterinvalid
+  unreplied: false

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -973,3 +973,24 @@ discordinvalid: #Discord IDが不正なユーザー
   unsubscribe_email_token: JgunX7Zejd-r1Vhqev401w
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
+
+twitterinvalid: #Twitter IDが不正なユーザー
+  login_name: twitterinvalid
+  email: twitterinvalid@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: ユーザーです Twitter IDが不正
+  name_kana: ツイッター フセイ
+  discord_account: twitterinvalid#8888
+  github_account: twitterinvalid
+  twitter_account: twit-ter
+  times_url: https://discord.com/channels/715806612824260640/123456789000000114
+  facebook_url: http://www.facebook.com/twitterinvalid
+  blog_url: http://twitterinvalid.org
+  description: "Twitter IDが不正なユーザーです"
+  course: course1
+  job: office_worker
+  experience: rails
+  unsubscribe_email_token: JgunX7Zejd-r1Vhqev401w
+  updated_at: "2020-01-01 00:00:12"
+  created_at: "2020-01-01 00:00:12"

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -88,3 +88,7 @@ talk22:
 talk23:
   user: discordinvalid
   unreplied: false
+
+talk24:
+    user: twitterinvalid
+    unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -380,6 +380,27 @@ discordinvalid: #Discord IDが不正なユーザー
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
 
+twitterinvalid: #Twitter IDが不正なユーザー
+  login_name: twitterinvalid
+  email: twitterinvalid@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: ユーザーです Twitter IDが不正
+  name_kana: ツイッター フセイ
+  discord_account: twitterinvalid#8888
+  github_account: twitterinvalid
+  twitter_account: twit-ter
+  times_url: https://discord.com/channels/715806612824260640/123456789000000114
+  facebook_url: http://www.facebook.com/twitterinvalid
+  blog_url: http://twitterinvalid.org
+  description: "Twitter IDが不正なユーザーです"
+  course: course1
+  job: office_worker
+  experience: rails
+  unsubscribe_email_token: JgunX7Zejd-r1Vhqev401w
+  updated_at: "2020-01-01 00:00:12"
+  created_at: "2020-01-01 00:00:12"
+
 jobseeker: #就活希望するユーザー
   login_name: jobseeker
   email: jobseeker@fjord.jp

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -46,6 +46,21 @@ class RetirementTest < ApplicationSystemTestCase
     assert_text 'ログインができません'
   end
 
+  test 'enables retirement regardless of validity of twitter id' do
+    user = users(:twitterinvalid)
+    visit_with_auth new_retirement_path, 'twitterinvalid'
+    choose 'とても悪い', visible: false
+    click_on '退会する'
+    page.accept_confirm
+    assert_text '退会処理が完了しました'
+    assert_equal Date.current, user.reload.retired_on
+    assert_equal 'twitterinvalidさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal 'twitterinvalidさんが退会しました。', users(:machida).notifications.last.message
+
+    login_user 'twitterinvalid', 'testtest'
+    assert_text 'ログインができません'
+  end
+
   test 'delete unchecked products when the user retired' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice5).id}", 'muryou'
     within('form[name=product]') do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -117,6 +117,7 @@ class UsersTest < ApplicationSystemTestCase
       nippounashi
       with_hyphen
       discordinvalid
+      twitterinvalid
     ].each do |name|
       users(name).touch # rubocop:disable Rails/SkipsModelValidations
     end


### PR DESCRIPTION
issue #4224 

 ## 概要
### 変更前
![_development__退会・休会手続き___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/155993359-2d90ea19-1641-4fb5-98cc-44b6cbc6edc6.png)
このように、twitterコードが不正の場合、エラーが出て退会できません。
### 変更後
![_development__FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/155993394-00508fbd-bcf3-4480-95a1-2cee4ea57619.png)
退会の際はこのエラーの元になるバリデーションを外すことで退会を可能にしています。

#4220 
こちらと同様のエラーを解消するissueであり、大変参考にしています。

## 確認方法
1. ブランチ`bug/enable-retirement-regardless-validity-of-twitter-id` をローカルに取り込みます。
1. `bin/rails db:seed`でユーザー情報をデータに取り込み、`bin/rails s`でサーバーを立ち上げます。
1. 不正なtwitter IDにしたユーザー`twitterinvalid`でログインします。
1. 必要項目をチェックし退会するボタンで無事退会できることを確認します。