### PR TITLE
adminのみ相談クリック時に未返信タブに遷移するように設定

### DIFF
--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -1,4 +1,4 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 
 module TalksHelper
   def unreplied_index_path(resource)

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -1,0 +1,7 @@
+#frozen_string_literal: true
+
+module TalksHelper
+  def unreplied_index_path(resource)
+    admin_login? ? talks_unreplied_index_path : talk_path(resource)
+  end
+end

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module TalksHelper
-  def unreplied_index_path(resource)
-    admin_login? ? talks_unreplied_index_path : talk_path(resource)
+  def unreplied_index_path(talk)
+    admin_login? ? talks_unreplied_index_path : talk_path(talk)
   end
 end

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -64,7 +64,7 @@ nav.global-nav
             .global-nav-links__link-label ヘルプ
         - if admin_login? || student_login?
           li.global-nav-links__item
-            - talks_link = admin_login? ? talks_unreplied_index_path : talk_path(current_user.talk)
+            - talks_link = unreplied_index_path(current_user.talk)
             = link_to talks_link, class: "global-nav-links__link #{current_link(/talk/)}" do
               .global-nav-links__link-icon
                 i.fas.fa-comment-alt-smile

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -64,7 +64,7 @@ nav.global-nav
             .global-nav-links__link-label ヘルプ
         - if admin_login? || student_login?
           li.global-nav-links__item
-            - talks_link = admin_login? ? talks_path : talk_path(current_user.talk)
+            - talks_link = admin_login? ? talks_unreplied_index_path : talk_path(current_user.talk)
             = link_to talks_link, class: "global-nav-links__link #{current_link(/talk/)}" do
               .global-nav-links__link-icon
                 i.fas.fa-comment-alt-smile

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -64,8 +64,7 @@ nav.global-nav
             .global-nav-links__link-label ヘルプ
         - if admin_login? || student_login?
           li.global-nav-links__item
-            - talks_link = unreplied_index_path(current_user.talk)
-            = link_to talks_link, class: "global-nav-links__link #{current_link(/talk/)}" do
+            = link_to unreplied_index_path(current_user_path), class: "global-nav-links__link #{current_link(/talk/)}" do
               .global-nav-links__link-icon
                 i.fas.fa-comment-alt-smile
               - if admin_or_mentor_login? && Talk.unreplied.count.positive?

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -66,7 +66,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
   test 'The number of unreplied comments is displayed in the global navigation and unreplied tab of the talks room' do
     visit_with_auth '/talks/unreplied', 'komagata'
     within(:css, '.global-nav') do
-      within(:css, "a[href='/talks']") do
+      within(:css, "a[href='/talks/unreplied']") do
         assert_selector '.global-nav__item-count.a-notification-count.is-only-mentor', count: 1
       end
     end
@@ -81,7 +81,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
 
     visit '/talks/unreplied'
     within(:css, '.global-nav') do
-      within(:css, "a[href='/talks'") do
+      within(:css, "a[href='/talks/unreplied'") do
         assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'
       end
     end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -138,7 +138,7 @@ class TalksTest < ApplicationSystemTestCase
   test 'talks unreplied page displays when admin logined ' do
     url = '/talks/unreplied'
     visit_with_auth '/', 'komagata'
-    click_link "相談"
+    click_link '相談'
     assert_equal url, current_path
   end
 

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -136,9 +136,8 @@ class TalksTest < ApplicationSystemTestCase
   end
 
   test 'talks unreplied page displays when admin logined ' do
-    url = '/talks/unreplied'
     visit_with_auth '/', 'komagata'
     click_link '相談'
-    assert_equal url, current_path
+    assert_equal '/talks/unreplied', current_path
   end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -134,4 +134,12 @@ class TalksTest < ApplicationSystemTestCase
       assert_text report.title
     end
   end
+
+  test 'talks unreplied page displays when admin logined ' do
+    url = '/talks/unreplied'
+    visit_with_auth '/', 'komagata'
+    click_link "相談"
+    assert_equal url, current_path
+  end
+
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -141,5 +141,4 @@ class TalksTest < ApplicationSystemTestCase
     click_link '相談'
     assert_equal url, current_path
   end
-
 end


### PR DESCRIPTION
issue #4265 

## 概要
admin権限を持つユーザーが相談ボタンをクリックした場合、未返信タブに遷移するように変更しました。

### 変更前
![_development__相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/156257504-6e78566f-07ff-43f0-83db-652f7bc6ac4a.png)


admin権限を持つユーザーが「相談」をクリックすると、`/talks`に遷移します。
### 変更後
![_development__未返信のコメント___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/156167021-7b005c3b-fe87-4316-b106-db6aea282142.png)
admin権限を持つユーザーが「相談」をクリックすると、`/talks/unreplied`に遷移します。
## ローカル環境での確認方法
1. admin権限を持つユーザーでログインし、「相談」をクリックして`/talks`に遷移することを確認します。
1. ブランチ `feature/display-talks-unreplied-page-when-logined-as-admin` をローカルに取り込みます。
1. admin権限を持つユーザーでログインし、「相談」をクリックして`/talks/unreplied`に遷移することを確認します。