### PR TITLE
お知らせ作成ページに不要な公開ボタンを表示しない

### DIFF
--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -42,7 +42,7 @@
       - if admin_or_mentor_login? && announcement.new_record?
         li.form-actions__item.is-main.is-help
           = f.submit '作成', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
-      - if admin_or_mentor_login? || announcement.published_at
+      - elsif admin_or_mentor_login? || announcement.published_at
         li.form-actions__item.is-main.is-help
           = f.submit '公開', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
       li.form-actions__item.is-sub

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -71,6 +71,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     fill_in 'announcement[title]', with: 'タイトルtest'
     fill_in 'announcement[description]', with: '内容test'
 
+    assert has_no_button? '公開'
     click_button '作成'
     assert_text 'お知らせを作成しました'
 
@@ -144,6 +145,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     visit_with_auth '/announcements', 'kimura'
     click_link 'お知らせ作成'
     assert has_no_button? '作成'
+    assert has_no_button? '公開'
     assert_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
 
@@ -153,6 +155,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     within '.thread__inner' do
       click_link '内容修正'
     end
+    assert has_no_button? '作成'
     assert has_button? '公開'
     assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
@@ -163,6 +166,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     within '.thread__inner' do
       click_link '内容修正'
     end
+    assert has_no_button? '作成'
     assert has_no_button? '公開'
     assert_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
@@ -173,6 +177,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     within '.thread__inner' do
       click_link '内容修正'
     end
+    assert has_no_button? '作成'
     assert has_button? '公開'
     assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
@@ -183,6 +188,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     within '.thread__inner' do
       click_link '内容修正'
     end
+    assert has_no_button? '作成'
     assert has_button? '公開'
     assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end


### PR DESCRIPTION
Issue: #4327 

## 概要
#4215 がマージされた後に表示されるようになった、お知らせ作成ページの不要な公開ボタンを表示しないように修正しました。また、自動テストのボタン非表示のテストケースを追加しました。

## 変更前
#4215 のパターン1のケース：作成ボタンに加えて、公開ボタンまで表示されるのでNG。

![image](https://user-images.githubusercontent.com/58363353/156298285-af5e7983-8b5c-47ee-b01a-1cc4d44eedd3.png)

## 変更後
#4215 のパターン1のケース：作成ボタンが表示、公開ボタンが非表示でOK。

![image](https://user-images.githubusercontent.com/58363353/156298454-98508066-d7f2-4105-b673-ec36c199252a.png)
