### PR TITLE
wait_for_vuejsを可能な限り排除する

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -16,7 +16,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ReportHelper
   include CommentHelper
 
-  VUEJS_WAIT_SECOND = (ENV['VUEJS_WAIT_SECOND'] || 2).to_i
+  VUEJS_WAIT_SECOND = 0
 
   if ENV['HEADED']
     driven_by :selenium, using: :chrome

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -16,6 +16,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ReportHelper
   include CommentHelper
 
+  # VUEJS_WAIT_SECOND = (ENV["VUEJS_WAIT_SECOND"] || 2).to_i
   VUEJS_WAIT_SECOND = 0
 
   if ENV['HEADED']

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -16,19 +16,11 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ReportHelper
   include CommentHelper
 
-  # VUEJS_WAIT_SECOND = (ENV["VUEJS_WAIT_SECOND"] || 2).to_i
-  VUEJS_WAIT_SECOND = 0
-
   if ENV['HEADED']
     driven_by :selenium, using: :chrome
   else
     driven_by(:selenium, using: :headless_chrome) do |driver_option|
       driver_option.add_argument('--no-sandbox')
     end
-  end
-
-  def wait_for_vuejs
-    # https://bootcamp.fjord.jp/questions/468 に書いた理由により、やむを得ずsleepする
-    sleep VUEJS_WAIT_SECOND
   end
 end

--- a/test/supports/comment_helper.rb
+++ b/test/supports/comment_helper.rb
@@ -4,6 +4,5 @@ module CommentHelper
   def post_comment(comment)
     fill_in('new_comment[description]', with: comment)
     click_button 'コメントする'
-    wait_for_vuejs
   end
 end

--- a/test/supports/notification_helper.rb
+++ b/test/supports/notification_helper.rb
@@ -9,13 +9,19 @@ module NotificationHelper
     all('.test-notification-message').map(&:text)
   end
 
+  # TODO: このモジュール以外では使用禁止。いつかなくしたい
+  # 本来であればsleepは使いたくないが、テストコードがロジカルすぎてすぐに修正できないため、やむを得ず残したままにする
+  def wait_for_vuejs_再利用禁止 # rubocop:disable Naming/MethodName, Naming/AsciiIdentifiers
+    sleep 2
+  end
+
   # notification_messages.include?(text)
   # でも可能だが、notification_messagesは
   # open_notificationを実行した(右上のベルボタンを押した)かで
   # 戻り値が変更されるため、これを作成
   def exists_unread_notification?(message)
     visit notifications_path(status: 'unread')
-    wait_for_vuejs # 通知一覧はVueでREST APIを利用して表示しているため
+    wait_for_vuejs_再利用禁止 # 通知一覧はVueでREST APIを利用して表示しているため # rubocop:disable Naming/AsciiIdentifiers
     exists = page.has_selector?('span.thread-list-item-title__link-label',
                                 text: message)
     go_back
@@ -24,7 +30,7 @@ module NotificationHelper
 
   def link_to_page_by_unread_notification(message)
     visit notifications_path(status: 'unread')
-    wait_for_vuejs # 通知一覧はVueでREST APIを利用して表示しているため
+    wait_for_vuejs_再利用禁止 # 通知一覧はVueでREST APIを利用して表示しているため # rubocop:disable Naming/AsciiIdentifiers
     click_link message, class: 'thread-list-item-title__link'
   end
 

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -39,7 +39,6 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
 
   test 'delete company' do
     visit_with_auth '/admin/companies', 'komagata'
-    wait_for_vuejs
     accept_confirm do
       find("#company_#{companies(:company1).id} a.a-button.is-sm.is-danger.is-icon.js-delete").click
     end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -145,7 +145,6 @@ class Admin::UsersTest < ApplicationSystemTestCase
     tag_input.set '追加タグ'
     tag_input.native.send_keys :enter
     click_on '更新する'
-    wait_for_vuejs
     visit "/admin/users/#{user.id}/edit"
     assert_text '追加タグ'
   end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -214,7 +214,6 @@ class AnnouncementsTest < ApplicationSystemTestCase
 
     fill_in 'new_comment[description]', with: 'コメント数表示のテストです。'
     click_button 'コメントする'
-    wait_for_vuejs
 
     visit current_path
     assert_text "コメント（\n2\n）"

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -38,6 +38,7 @@ class AnswersTest < ApplicationSystemTestCase
 
   test 'admin can edit and delete any questions' do
     visit_with_auth "/questions/#{questions(:question1).id}", 'komagata'
+    assert_text 'vimしかないでしょう。常識的に考えて。'
     wait_for_vuejs
     answer_by_user = page.all('.thread-comment')[1]
     within answer_by_user do
@@ -73,10 +74,11 @@ class AnswersTest < ApplicationSystemTestCase
 
     assert_difference 'ActionMailer::Base.deliveries.count', 1 do
       perform_enqueued_jobs do
+        assert_no_text '解決済'
         accept_alert do
           click_button 'ベストアンサーにする'
         end
-        wait_for_vuejs
+        assert_text '解決済'
       end
     end
 

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -7,7 +7,6 @@ class AnswersTest < ApplicationSystemTestCase
 
   test 'answer form in questions/:id has comment tab and preview tab' do
     visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
-    wait_for_vuejs
     within('.a-form-tabs') do
       assert_text 'コメント'
       assert_text 'プレビュー'
@@ -16,7 +15,6 @@ class AnswersTest < ApplicationSystemTestCase
 
   test 'post new comment for question' do
     visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
-    wait_for_vuejs
     within('.thread-comment-form__form') do
       fill_in('answer[description]', with: 'test')
     end
@@ -28,7 +26,6 @@ class AnswersTest < ApplicationSystemTestCase
 
   test 'edit answer form has comment tab and preview tab' do
     visit_with_auth "/questions/#{questions(:question3).id}", 'komagata'
-    wait_for_vuejs
     within('.thread-comment:first-child') do
       click_button '内容修正'
       assert_text 'コメント'
@@ -39,7 +36,6 @@ class AnswersTest < ApplicationSystemTestCase
   test 'admin can edit and delete any questions' do
     visit_with_auth "/questions/#{questions(:question1).id}", 'komagata'
     assert_text 'vimしかないでしょう。常識的に考えて。'
-    wait_for_vuejs
     answer_by_user = page.all('.thread-comment')[1]
     within answer_by_user do
       assert_text '内容修正'
@@ -49,7 +45,6 @@ class AnswersTest < ApplicationSystemTestCase
 
   test "admin can resolve user's question" do
     visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
-    wait_for_vuejs
     assert_text 'ベストアンサーにする'
     accept_alert do
       click_button 'ベストアンサーにする'
@@ -59,7 +54,6 @@ class AnswersTest < ApplicationSystemTestCase
 
   test 'delete best answer' do
     visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
-    wait_for_vuejs
     accept_alert do
       click_button 'ベストアンサーにする'
     end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -26,6 +26,7 @@ class Check::ReportsTest < ApplicationSystemTestCase
 
   test 'success report checking cancel' do
     visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
+    assert_text '昨日よりできませんでした'
     accept_alert do
       click_button '日報を確認'
     end
@@ -33,7 +34,7 @@ class Check::ReportsTest < ApplicationSystemTestCase
     within('.thread') do
       assert_no_text '確認済'
     end
-    assert has_button? '日報を確認'
+    assert_button '日報を確認'
   end
 
   test 'comment and check report' do

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -17,7 +17,6 @@ class Check::ReportsTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
     assert has_button? '日報を確認'
     accept_alert do
-      wait_for_vuejs
       click_button '日報を確認'
     end
     assert has_button? '日報の確認を取り消す'
@@ -28,7 +27,6 @@ class Check::ReportsTest < ApplicationSystemTestCase
   test 'success report checking cancel' do
     visit_with_auth "/reports/#{reports(:report20).id}", 'komagata'
     accept_alert do
-      wait_for_vuejs
       click_button '日報を確認'
     end
     click_button '日報の確認を取り消す'

--- a/test/system/bookmark/page_test.rb
+++ b/test/system/bookmark/page_test.rb
@@ -39,7 +39,7 @@ class Bookmark::PageTest < ApplicationSystemTestCase
 
   test 'unbookmark page' do
     visit_with_auth "/pages/#{@page.id}", 'kimura'
-    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
     wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'

--- a/test/system/bookmark/page_test.rb
+++ b/test/system/bookmark/page_test.rb
@@ -14,14 +14,12 @@ class Bookmark::PageTest < ApplicationSystemTestCase
 
   test 'show active button when bookmarked page' do
     visit_with_auth "/pages/#{@page.id}", 'kimura'
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
   end
 
   test 'show inactive button when not bookmarked page' do
     visit_with_auth "/pages/#{@page.id}", 'komagata'
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
   end
@@ -29,7 +27,6 @@ class Bookmark::PageTest < ApplicationSystemTestCase
   test 'bookmark page' do
     visit_with_auth "/pages/#{@page.id}", 'komagata'
     find('#bookmark-button').click
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
 
@@ -41,7 +38,6 @@ class Bookmark::PageTest < ApplicationSystemTestCase
     visit_with_auth "/pages/#{@page.id}", 'kimura'
     assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
 

--- a/test/system/bookmark/products_test.rb
+++ b/test/system/bookmark/products_test.rb
@@ -39,7 +39,7 @@ class Bookmark::ProductTest < ApplicationSystemTestCase
 
   test 'unbookmark product' do
     visit_with_auth "/products/#{@product.id}", 'kimura'
-    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
     wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'

--- a/test/system/bookmark/products_test.rb
+++ b/test/system/bookmark/products_test.rb
@@ -14,14 +14,12 @@ class Bookmark::ProductTest < ApplicationSystemTestCase
 
   test 'show active button when bookmarked product' do
     visit_with_auth "/products/#{@product.id}", 'kimura'
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
   end
 
   test 'show inactive button when not bookmarked product' do
     visit_with_auth "/products/#{@product.id}", 'komagata'
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
   end
@@ -29,7 +27,6 @@ class Bookmark::ProductTest < ApplicationSystemTestCase
   test 'bookmark product' do
     visit_with_auth "/products/#{@product.id}", 'komagata'
     find('#bookmark-button').click
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
 
@@ -41,7 +38,6 @@ class Bookmark::ProductTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{@product.id}", 'kimura'
     assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
 

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -16,14 +16,12 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'show my bookmark report' do
     visit_with_auth "/reports/#{@report.id}", 'komagata'
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
   end
 
   test 'show not bookmark report' do
     visit_with_auth "/reports/#{@report.id}", 'machida'
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
   end
@@ -31,7 +29,6 @@ class BookmarksTest < ApplicationSystemTestCase
   test 'bookmark' do
     visit_with_auth "/reports/#{@report.id}", 'machida'
     find('#bookmark-button').click
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
 
@@ -43,7 +40,6 @@ class BookmarksTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{@report.id}", 'komagata'
     assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
 
@@ -58,14 +54,12 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'show active button when bookmarked question' do
     visit_with_auth "/questions/#{@question.id}", 'kimura'
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
   end
 
   test 'show inactive button when not bookmarked question' do
     visit_with_auth "/questions/#{@question.id}", 'hajime'
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
   end
@@ -73,7 +67,6 @@ class BookmarksTest < ApplicationSystemTestCase
   test 'bookmark question' do
     visit_with_auth "/questions/#{@question.id}", 'hatsuno'
     find('#bookmark-button').click
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-active'
     assert_no_selector '#bookmark-button.is-inactive'
 
@@ -85,7 +78,6 @@ class BookmarksTest < ApplicationSystemTestCase
     visit_with_auth "/questions/#{@question.id}", 'kimura'
     assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
-    wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
     assert_no_selector '#bookmark-button.is-active'
 
@@ -97,20 +89,17 @@ class BookmarksTest < ApplicationSystemTestCase
     visit_with_auth current_user_bookmarks_path, 'kimura'
     assert_no_selector '.thread-list-item__option'
     find(:css, '#spec-edit-mode').set(true)
-    wait_for_vuejs
     assert_selector '.thread-list-item__option'
   end
 
   test 'delete bookmark from bookmarks' do
     visit_with_auth report_path(@report), 'komagata'
-    wait_for_vuejs
     assert_text 'Bookmark中'
     visit current_user_bookmarks_path
     assert_text '作業週1日目'
     find(:css, '#spec-edit-mode').set(true)
     assert_selector '.thread-list-item__option'
     first('#bookmark-button').click
-    wait_for_vuejs
     assert_no_text '作業週1日目'
     visit report_path(@report)
     assert_text 'Bookmark'

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -41,7 +41,7 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'unbookmark' do
     visit_with_auth "/reports/#{@report.id}", 'komagata'
-    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
     wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'
@@ -83,7 +83,7 @@ class BookmarksTest < ApplicationSystemTestCase
 
   test 'unbookmark question' do
     visit_with_auth "/questions/#{@question.id}", 'kimura'
-    wait_for_vuejs
+    assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
     wait_for_vuejs
     assert_selector '#bookmark-button.is-inactive'

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -98,7 +98,7 @@ class CommentsTest < ApplicationSystemTestCase
   test 'post new comment with image for report' do
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     find('#comments.loaded', wait: 10)
-    find('#js-new-comment').set("画像付きで説明します。 ![Image](https://example.com/test.png)")
+    find('#js-new-comment').set('画像付きで説明します。 ![Image](https://example.com/test.png)')
     click_button 'コメントする'
     assert_text '画像付きで説明します。'
     assert_match '<a href="https://example.com/test.png" target="_blank" rel="noopener noreferrer"><img src="https://example.com/test.png" alt="Image"></a>',

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -92,16 +92,15 @@ class CommentsTest < ApplicationSystemTestCase
     end
 
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text '絵文字の補完テスト: 😺'
   end
 
   test 'post new comment with image for report' do
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     find('#comments.loaded', wait: 10)
-    find('#js-new-comment').set("![Image](https://example.com/test.png)'")
+    find('#js-new-comment').set("画像付きで説明します。 ![Image](https://example.com/test.png)")
     click_button 'コメントする'
-    wait_for_vuejs
+    assert_text '画像付きで説明します。'
     assert_match '<a href="https://example.com/test.png" target="_blank" rel="noopener noreferrer"><img src="https://example.com/test.png" alt="Image"></a>',
                  page.body
   end
@@ -195,16 +194,14 @@ class CommentsTest < ApplicationSystemTestCase
 
   test 'comment tab is active after a comment has been posted' do
     visit_with_auth "/reports/#{reports(:report3).id}", 'komagata'
-    assert_equal 'コメント', find('.a-form-tabs__tab.is-active').text
+    assert_selector '.a-form-tabs__tab.is-active', text: 'コメント'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')
     end
     find('.a-form-tabs__tab', text: 'プレビュー').click
-    assert_equal 'プレビュー', find('.a-form-tabs__tab.is-active').text
+    assert_selector '.a-form-tabs__tab.is-active', text: 'プレビュー'
     click_button 'コメントする'
-    wait_for_vuejs
-    assert_text 'test'
-    assert_equal 'コメント', find('.a-form-tabs__tab.is-active').text
+    assert_selector '.a-form-tabs__tab.is-active', text: 'コメント'
   end
 
   test 'prevent double submit' do

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -43,7 +43,6 @@ class CommentsTest < ApplicationSystemTestCase
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
   end
 
@@ -75,7 +74,6 @@ class CommentsTest < ApplicationSystemTestCase
     end
 
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'login_nameの補完テスト: @mentor'
     assert_selector :css, "a[href='/users?target=mentor']"
   end
@@ -110,7 +108,6 @@ class CommentsTest < ApplicationSystemTestCase
     find('#comments.loaded', wait: 10)
     find('#js-new-comment').set('[![Image](https://example.com/test.png)](https://example.com)')
     click_button 'コメントする'
-    wait_for_vuejs
     assert_match '<a href="https://example.com"><img src="https://example.com/test.png" alt="Image"></a>', page.body
   end
 
@@ -142,13 +139,11 @@ class CommentsTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: 'test')
     end
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
   end
 
   test 'check preview for product' do
     visit_with_auth "/products/#{products(:product2).id}", 'komagata'
-    wait_for_vuejs
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: "1\n2\n3\n4\n5\n6\n7\n8\n9")
     end
@@ -164,7 +159,6 @@ class CommentsTest < ApplicationSystemTestCase
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
   end
 
@@ -176,7 +170,6 @@ class CommentsTest < ApplicationSystemTestCase
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
   end
 
@@ -188,7 +181,6 @@ class CommentsTest < ApplicationSystemTestCase
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
   end
 
@@ -220,13 +212,11 @@ class CommentsTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: 'test')
     end
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'testtest')
     end
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'testtest'
   end
 

--- a/test/system/course/practices_test.rb
+++ b/test/system/course/practices_test.rb
@@ -11,7 +11,6 @@ class Course::PracticesTest < ApplicationSystemTestCase
   test 'show/hide the progress of others' do
     visit_with_auth practice_path(practices(:practice1)), 'hatsuno'
     click_button '着手'
-    wait_for_vuejs
     visit course_practices_path(courses(:course1).id)
 
     assert page.find(:css, '#display-progress', visible: false).checked?

--- a/test/system/current_user/watches_test.rb
+++ b/test/system/current_user/watches_test.rb
@@ -8,6 +8,12 @@ class CurrentUser::WatchesTest < ApplicationSystemTestCase
     assert_equal 'Watch中 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
+  # 画面上では更新の完了がわからないため、やむを得ずsleepする
+  # 注意）安易に使用しないこと!! https://bootcamp.fjord.jp/pages/use-assert-text-instead-of-wait-for-vuejs
+  def wait_for_watch_change
+    sleep 1
+  end
+
   # 下記3つのtestは/watches削除に伴い、WatchingTestより転記し修正した
   test 'show my watch list' do
     visit_with_auth '/current_user/watches', 'hajime'
@@ -15,6 +21,7 @@ class CurrentUser::WatchesTest < ApplicationSystemTestCase
     question = questions(:question3)
     visit question_path(question)
     find('#watch-button').click
+    wait_for_watch_change
     visit '/current_user/watches'
     assert_text 'テストの質問1'
   end
@@ -37,6 +44,7 @@ class CurrentUser::WatchesTest < ApplicationSystemTestCase
     find(:css, '#spec-edit-mode').set(true)
     assert_selector '.thread-list-item__option'
     first('#watch-button').click
+    wait_for_watch_change
     assert_no_text '作業週1日目'
     visit report_path(report)
     assert_text 'Watch'

--- a/test/system/current_user/watches_test.rb
+++ b/test/system/current_user/watches_test.rb
@@ -14,7 +14,6 @@ class CurrentUser::WatchesTest < ApplicationSystemTestCase
     assert_no_text 'テストの質問1'
     question = questions(:question3)
     visit question_path(question)
-    wait_for_vuejs
     find('#watch-button').click
     visit '/current_user/watches'
     assert_text 'テストの質問1'
@@ -25,7 +24,6 @@ class CurrentUser::WatchesTest < ApplicationSystemTestCase
     visit '/current_user/watches'
     assert_no_selector '.thread-list-item__option'
     find(:css, '#spec-edit-mode').set(true)
-    wait_for_vuejs
     assert_selector '.thread-list-item__option'
   end
 
@@ -33,14 +31,12 @@ class CurrentUser::WatchesTest < ApplicationSystemTestCase
     login_user 'kimura', 'testtest'
     report = reports(:report1)
     visit report_path(report)
-    wait_for_vuejs
     assert_text 'Watch中'
     visit '/current_user/watches'
     assert_text '作業週1日目'
     find(:css, '#spec-edit-mode').set(true)
     assert_selector '.thread-list-item__option'
     first('#watch-button').click
-    wait_for_vuejs
     assert_no_text '作業週1日目'
     visit report_path(report)
     assert_text 'Watch'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -180,10 +180,10 @@ class EventsTest < ApplicationSystemTestCase
   test 'user can participate in an event' do
     event = events(:event2)
     visit_with_auth event_path(event), 'kimura'
-    accept_confirm do
-      click_link '参加申込'
-    end
     assert_difference 'event.users.count', 1 do
+      accept_confirm do
+        click_link '参加申込'
+      end
       assert_text '参加登録しました。'
     end
   end
@@ -191,10 +191,10 @@ class EventsTest < ApplicationSystemTestCase
   test 'user can cancel event' do
     event = events(:event2)
     visit_with_auth event_path(event), 'hatsuno'
-    accept_confirm do
-      click_link '参加を取り消す'
-    end
     assert_difference 'event.users.count', -1 do
+      accept_confirm do
+        click_link '参加を取り消す'
+      end
       assert_text '参加を取り消しました。'
     end
   end
@@ -202,10 +202,10 @@ class EventsTest < ApplicationSystemTestCase
   test 'user can cancel event even if deadline has passed' do
     event = events(:event5)
     visit_with_auth event_path(event), 'kimura'
-    accept_confirm do
-      click_link '参加を取り消す'
-    end
     assert_difference 'event.users.count', -1 do
+      accept_confirm do
+        click_link '参加を取り消す'
+      end
       assert_text '参加を取り消しました。'
     end
     assert_no_link '参加申込'
@@ -246,13 +246,14 @@ class EventsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '参加申込'
     end
-    sleep 1
+    assert_text '参加登録しました'
 
     visit_with_auth events_path, 'kimura'
     click_link '先着順のイベント'
     accept_confirm do
       click_link '参加申込'
     end
+    assert_text '参加登録しました'
     within '.participants' do
       participants = all('img').map { |img| img['alt'] }
       assert_equal %w[komagata kimura], participants
@@ -275,13 +276,14 @@ class EventsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '参加申込'
     end
-    sleep 1
+    assert_text '参加登録しました'
 
     visit_with_auth events_path, 'kimura'
     click_link '補欠者のいるイベント'
     accept_confirm do
       click_link '補欠登録'
     end
+    assert_text '参加登録しました'
     within '.waitlist' do
       wait_user = all('img').map { |img| img['alt'] }
       assert_equal ['kimura (Kimura Tadasi)'], wait_user
@@ -304,13 +306,14 @@ class EventsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '参加申込'
     end
-    sleep 1
+    assert_text '参加登録しました'
 
     visit_with_auth events_path, 'kimura'
     click_link '補欠者が繰り上がるイベント'
     accept_confirm do
       click_link '補欠登録'
     end
+    assert_text '参加登録しました'
     within '.participants' do
       participants = all('img').map { |img| img['alt'] }
       assert_equal %w[komagata], participants
@@ -321,6 +324,7 @@ class EventsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '参加を取り消す'
     end
+    assert_text '参加を取り消しました'
     within '.participants' do
       participants = all('img').map { |img| img['alt'] }
       assert_equal %w[kimura], participants
@@ -343,7 +347,7 @@ class EventsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '参加申込'
     end
-    sleep 1
+    assert_text '参加登録しました'
 
     assert_no_selector '.waitlist'
   end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -81,7 +81,6 @@ class HomeTest < ApplicationSystemTestCase
   test 'keep Nico Nico calendar page even when leave dashboard' do
     visit_with_auth '/', 'hajime'
     find('.niconico-calendar-nav__previous').click
-    wait_for_vuejs
     find('.niconico-calendar-nav').assert_text 1.month.ago.strftime('%Y年%-m月')
     find('.niconico-calendar').click_link href: /reports/, match: :first
     go_back

--- a/test/system/mention/comments_test.rb
+++ b/test/system/mention/comments_test.rb
@@ -14,7 +14,6 @@ module Mention
           fill_in('new_comment[description]', with: comment)
         end
         click_button 'コメントする'
-        wait_for_vuejs
       }
       assert_notify_mention(post_mention)
     end

--- a/test/system/notification/comments_test.rb
+++ b/test/system/notification/comments_test.rb
@@ -10,7 +10,6 @@ class Notification::CommentsTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: '@machida @machida test')
     end
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text '@machida @machida test'
 
     visit_with_auth '/notifications', 'machida'

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -12,7 +12,6 @@ class Notification::TalkTest < ApplicationSystemTestCase
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
 
     visit_with_auth '/notifications', 'machida'
@@ -31,7 +30,6 @@ class Notification::TalkTest < ApplicationSystemTestCase
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
 
     visit '/notifications'
@@ -56,7 +54,6 @@ class Notification::TalkTest < ApplicationSystemTestCase
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     assert_text 'test'
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'test'
 
     visit_with_auth '/notifications', 'kimura'

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -11,7 +11,6 @@ class Notification::WatchesTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: 'いい日報ですね。')
     end
     click_button 'コメントする'
-    wait_for_vuejs
     logout
 
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
@@ -42,7 +41,6 @@ class Notification::WatchesTest < ApplicationSystemTestCase
       fill_in('answer[description]', with: 'Vimチュートリアルがおすすめです。')
     end
     click_button 'コメントする'
-    wait_for_vuejs
     logout
 
     visit_with_auth "/questions/#{questions(:question1).id}", 'machida'

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -306,9 +306,11 @@ class NotificationsTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
     click_link '内容修正'
     select 'machida', from: 'product_checker_id'
-    click_button '提出する'
-    assert_text '提出物を更新しました'
-    assert_text 'machida'
+    assert_difference -> { Notification.count }, 1 do
+      click_button '提出する'
+      assert_text '提出物を更新しました'
+      assert_text 'machida'
+    end
 
     visit_with_auth '/notifications?status=unread', 'machida'
     wait_for_vuejs

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -3,6 +3,8 @@
 require 'application_system_test_case'
 
 class NotificationsTest < ApplicationSystemTestCase
+  include ActiveJob::TestHelper
+
   test 'do not send mail if user deny mail' do
     visit_with_auth "/reports/#{reports(:report8).id}", 'kimura'
     within('.thread-comment-form__form') do
@@ -286,19 +288,19 @@ class NotificationsTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
     click_link '内容修正'
     select 'machida', from: 'product_checker_id'
-    assert_difference -> { Notification.count }, 1 do
-      click_button '提出する'
-      assert_text '提出物を更新しました'
-      assert_text 'machida'
+    perform_enqueued_jobs do
+      assert_difference -> { Notification.count }, 1 do
+        click_button '提出する'
+        assert_text '提出物を更新しました'
+        assert_text 'machida'
+      end
     end
 
     visit_with_auth '/notifications?status=unread', 'machida'
     assert_text "mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
 
-    if ActionMailer::Base.deliveries.present?
-      last_mail = ActionMailer::Base.deliveries.last
-      assert_equal "[bootcamp] mentormentaroさんの提出物#{products(:product1).title}の担当になりました。", last_mail.subject
-    end
+    last_mail = ActionMailer::Base.deliveries.last
+    assert_equal "[bootcamp] mentormentaroさんの提出物#{products(:product1).title}の担当になりました。", last_mail.subject
   end
 
   test 'not notice self assigned as checker' do

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -307,6 +307,7 @@ class NotificationsTest < ApplicationSystemTestCase
     click_link '内容修正'
     select 'machida', from: 'product_checker_id'
     click_button '提出する'
+    assert_text '提出物を更新しました'
     assert_text 'machida'
 
     visit_with_auth '/notifications?status=unread', 'machida'

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -9,7 +9,6 @@ class NotificationsTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: 'test')
     end
     click_button 'コメントする'
-    wait_for_vuejs
 
     if ActionMailer::Base.deliveries.present?
       last_mail = ActionMailer::Base.deliveries.last
@@ -32,12 +31,10 @@ class NotificationsTest < ApplicationSystemTestCase
 
     find('#js-new-comment').set("login_nameの補完テスト: @komagata\n")
     click_button 'コメントする'
-    wait_for_vuejs
     assert_text 'login_nameの補完テスト: @komagata'
     assert_selector :css, "a[href='/users/komagata']"
 
     visit_with_auth '/notifications', 'komagata'
-    wait_for_vuejs
     assert_no_text 'kensyuさんがはじめての日報を書きました！'
     assert_text 'kensyuさんからメンションがきました。'
   end
@@ -51,7 +48,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         user: users(:mentormentaro),
                         sender: users(:machida))
     visit_with_auth '/notifications?status=unread', 'mentormentaro'
-    wait_for_vuejs
     assert_no_text '1番新しい既読の通知'
   end
 
@@ -77,7 +73,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         user: users(:mentormentaro),
                         sender: users(:machida))
     visit_with_auth '/notifications', 'mentormentaro'
-    wait_for_vuejs
     within first('nav.pagination') do
       find('a', text: '2').click
     end
@@ -113,7 +108,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         sender: users(:machida))
     login_user 'mentormentaro', 'testtest'
     visit '/notifications?page=2'
-    wait_for_vuejs
     assert_text '1番古い通知'
     assert_no_text '1番新しい通知'
     all('.pagination .is-active').each do |active_button|
@@ -143,12 +137,10 @@ class NotificationsTest < ApplicationSystemTestCase
                         sender: users(:machida))
     login_user 'mentormentaro', 'testtest'
     visit '/notifications?page=2'
-    wait_for_vuejs
     within first('nav.pagination') do
       find('a', text: '1').click
     end
     page.go_back
-    wait_for_vuejs
     assert_text '1番古い通知'
     assert_no_text '1番新しい通知'
     all('.pagination .is-active').each do |active_button|
@@ -167,7 +159,6 @@ class NotificationsTest < ApplicationSystemTestCase
 
     visit_with_auth "/reports/#{report}", 'hatsuno'
     find('.header-links__link.test-show-notifications').click
-    wait_for_vuejs
     assert_text 'hatsunoさんの【 「コメントと」の日報 】にkomagataさんがコメントしました。'
   end
 
@@ -180,7 +171,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         sender: users(:machida))
 
     visit_with_auth '/notifications', 'mentormentaro'
-    wait_for_vuejs
     assert_selector '.header-notification-count', text: '1'
 
     20.times do |n|
@@ -191,7 +181,6 @@ class NotificationsTest < ApplicationSystemTestCase
                           sender: users(:machida))
     end
     visit_with_auth '/notifications', 'mentormentaro'
-    wait_for_vuejs
     assert_selector '.header-notification-count', text: '21'
   end
 
@@ -207,7 +196,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         user: users(:hatsuno),
                         sender: users(:machida))
     visit_with_auth '/notifications?status=unread', 'hatsuno'
-    wait_for_vuejs
     assert_no_button '未読の通知を一括で開く'
   end
 
@@ -218,7 +206,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         user: users(:komagata),
                         sender: users(:machida))
     visit_with_auth '/notifications?status=unread', 'komagata'
-    wait_for_vuejs
     assert_button '未読の通知を一括で開く'
   end
 
@@ -234,7 +221,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         user: users(:komagata),
                         sender: users(:machida))
     visit_with_auth '/notifications', 'komagata'
-    wait_for_vuejs
     assert_text 'コメントの通知'
     assert_text 'お知らせの通知'
   end
@@ -251,7 +237,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         user: users(:komagata),
                         sender: users(:machida))
     visit_with_auth '/notifications?target=announcement', 'komagata'
-    wait_for_vuejs
     assert_text 'お知らせの通知'
     assert_no_text 'コメントの通知'
   end
@@ -269,7 +254,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         sender: users(:machida),
                         read: true)
     visit_with_auth '/notifications?status=unread&target=announcement', 'komagata'
-    wait_for_vuejs
     assert_text '未読のお知らせの通知'
     assert_no_text '既読のお知らせの通知'
   end
@@ -286,19 +270,15 @@ class NotificationsTest < ApplicationSystemTestCase
                         user: users(:komagata),
                         sender: users(:machida))
     visit_with_auth '/notifications?status=unread&target=announcement', 'komagata'
-    wait_for_vuejs
     click_link 'お知らせの通知を既読にする'
 
     visit_with_auth '/notifications?status=unread&target=announcement', 'komagata'
-    wait_for_vuejs
     assert_no_text 'お知らせのテスト通知'
 
     visit_with_auth '/notifications?status=unread&target=comment', 'komagata'
-    wait_for_vuejs
     assert_text 'コメントのテスト通知'
 
     visit_with_auth '/notifications?status=unread', 'komagata'
-    wait_for_vuejs
     assert_text 'コメントのテスト通知'
   end
 
@@ -313,7 +293,6 @@ class NotificationsTest < ApplicationSystemTestCase
     end
 
     visit_with_auth '/notifications?status=unread', 'machida'
-    wait_for_vuejs
     assert_text "mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
 
     if ActionMailer::Base.deliveries.present?
@@ -330,7 +309,6 @@ class NotificationsTest < ApplicationSystemTestCase
     assert_text '担当から外れる'
 
     visit_with_auth '/notifications?status=unread', 'komagata'
-    wait_for_vuejs
     assert_no_text "mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
   end
 

--- a/test/system/page/tags_test.rb
+++ b/test/system/page/tags_test.rb
@@ -62,7 +62,7 @@ class Page::TagsTest < ApplicationSystemTestCase
     click_button 'タグ名変更'
     fill_in('tag[name]', with: update_tag_text)
     click_button '変更'
-    wait_for_vuejs
+    assert_text 'タグ 「上級者」'
 
     visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'
     assert_text '質問はありません。'

--- a/test/system/page/tags_test.rb
+++ b/test/system/page/tags_test.rb
@@ -88,7 +88,7 @@ class Page::TagsTest < ApplicationSystemTestCase
     click_button 'タグ名変更'
     fill_in('tag[name]', with: update_tag.name)
     click_button '変更'
-    wait_for_vuejs
+    assert_text 'タグ 「中級者」'
 
     visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'
     assert_text '質問はありません。'

--- a/test/system/page/tags_test.rb
+++ b/test/system/page/tags_test.rb
@@ -38,7 +38,6 @@ class Page::TagsTest < ApplicationSystemTestCase
     tag_input.set '追加タグ'
     tag_input.native.send_keys :return
     click_on '保存'
-    wait_for_vuejs
     assert_text '追加タグ'
   end
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -148,7 +148,6 @@ class PagesTest < ApplicationSystemTestCase
 
     fill_in 'new_comment[description]', with: 'コメント数表示のテストです。'
     click_button 'コメントする'
-    wait_for_vuejs
 
     visit current_path
     assert_text "コメント（\n1\n）"

--- a/test/system/practice/memos_test.rb
+++ b/test/system/practice/memos_test.rb
@@ -10,7 +10,7 @@ class Practice::MemoTest < ApplicationSystemTestCase
     click_button '編集'
     fill_in('js-practice-memo', with: 'メンター向けメモをページ遷移せず編集')
     click_button '保存する'
-    wait_for_vuejs
+    assert_text '保存しました'
     assert_text 'メンター向けメモをページ遷移せず編集'
   end
 end

--- a/test/system/practice/memos_test.rb
+++ b/test/system/practice/memos_test.rb
@@ -10,6 +10,7 @@ class Practice::MemoTest < ApplicationSystemTestCase
     click_button '編集'
     practice = products(:product2).practice
     assert_changes -> { practice.reload.memo } do
+      fill_in('js-practice-memo', with: '') # テスト安定化のために実験的に追加してみた
       fill_in('js-practice-memo', with: 'メンター向けメモをページ遷移せず編集')
       click_button '保存する'
       assert_text '保存しました'

--- a/test/system/practice/memos_test.rb
+++ b/test/system/practice/memos_test.rb
@@ -5,7 +5,6 @@ require 'application_system_test_case'
 class Practice::MemoTest < ApplicationSystemTestCase
   test 'update mentor memo without page transitions' do
     visit_with_auth "/products/#{products(:product2).id}", 'komagata'
-    wait_for_vuejs
     find('#side-tabs-nav-2').click
     click_button '編集'
     fill_in('js-practice-memo', with: 'メンター向けメモをページ遷移せず編集')

--- a/test/system/practice/memos_test.rb
+++ b/test/system/practice/memos_test.rb
@@ -3,13 +3,17 @@
 require 'application_system_test_case'
 
 class Practice::MemoTest < ApplicationSystemTestCase
+  # TODO: リトライすると通るが、最後のアサーションでよくfailする。テキストエリアへの入力がうまくいってない？
   test 'update mentor memo without page transitions' do
     visit_with_auth "/products/#{products(:product2).id}", 'komagata'
     find('#side-tabs-nav-2').click
     click_button '編集'
-    fill_in('js-practice-memo', with: 'メンター向けメモをページ遷移せず編集')
-    click_button '保存する'
-    assert_text '保存しました'
+    practice = products(:product2).practice
+    assert_changes -> { practice.reload.memo } do
+      fill_in('js-practice-memo', with: 'メンター向けメモをページ遷移せず編集')
+      click_button '保存する'
+      assert_text '保存しました'
+    end
     assert_text 'メンター向けメモをページ遷移せず編集'
   end
 end

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -169,11 +169,17 @@ class PracticesTest < ApplicationSystemTestCase
     assert_text '進捗の計算'
   end
 
+  # 画面上では更新の完了がわからないため、やむを得ずsleepする
+  # 注意）安易に使用しないこと!! https://bootcamp.fjord.jp/pages/use-assert-text-instead-of-wait-for-vuejs
+  def wait_for_status_change
+    sleep 1
+  end
+
   test 'change status' do
     practice = practices(:practice1)
     visit_with_auth "/practices/#{practice.id}", 'hatsuno'
     first('.js-started').click
-    sleep 5
+    wait_for_status_change
     assert_equal 'started', practice.status(users(:hatsuno))
   end
 
@@ -181,15 +187,14 @@ class PracticesTest < ApplicationSystemTestCase
     practice = practices(:practice1)
     visit_with_auth "/practices/#{practice.id}", 'hatsuno'
     first('.js-started').click
-    sleep 5
+    wait_for_status_change
     assert_equal 'started', practice.status(users(:hatsuno))
 
     practice = practices(:practice2)
     visit "/practices/#{practice.id}"
-    first('.js-started').click
-    sleep 5
-    assert_equal page.driver.browser.switch_to.alert.text, "すでに着手しているプラクティスがあります。\n提出物を提出するか完了すると新しいプラクティスを開始できます。"
-    page.driver.browser.switch_to.alert.accept
+    accept_alert "すでに着手しているプラクティスがあります。\n提出物を提出するか完了すると新しいプラクティスを開始できます。" do
+      first('.js-started').click
+    end
   end
 
   test 'show other practices' do

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -109,7 +109,6 @@ class PracticesTest < ApplicationSystemTestCase
     end
     assert_text 'プラクティスを更新しました'
     visit "/products/#{product.id}"
-    wait_for_vuejs
     find('#side-tabs-nav-2').click
     assert_text 'メンター向けのメモの内容です'
   end
@@ -219,7 +218,6 @@ class PracticesTest < ApplicationSystemTestCase
     end
     assert_text 'プラクティスを更新しました'
     visit "/practices/#{practice.id}"
-    wait_for_vuejs
     assert_equal 'テストプラクティス | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -17,6 +17,7 @@ class Product::CheckerTest < ApplicationSystemTestCase
     ].each do |comment|
       visit "/products/#{products(:product1).id}"
       post_comment(comment)
+      assert_text 'コメントを投稿しました'
 
       visit '/products/unchecked?target=unchecked_no_replied'
       assert_equal before_comment + 1, assigned_product_count

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -84,7 +84,6 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
       checker_id: checker.id
     )
     visit_with_auth '/products/self_assigned', 'mentormentaro'
-    wait_for_vuejs
     titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.thread-list-item-meta .a-user-name').map(&:text)
     assert_equal ["#{practice.title}の提出物"], titles
@@ -102,7 +101,6 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
       checker_id: checker.id
     )
     visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', 'mentormentaro'
-    wait_for_vuejs
     titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.thread-list-item-meta .a-user-name').map(&:text)
     assert_equal ["#{practice.title}の提出物"], titles
@@ -125,13 +123,11 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     end
     click_button 'コメントする'
     visit_with_auth '/products/self_assigned?target=self_assigned_all', 'mentormentaro'
-    wait_for_vuejs
     titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.thread-list-item-meta .a-user-name').map(&:text)
     assert_equal ["#{practice.title}の提出物"], titles
     assert_equal [user.login_name], names
     visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', 'mentormentaro'
-    wait_for_vuejs
     assert_text 'レビューを担当する未返信の提出物はありません'
   end
 end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -67,7 +67,6 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{product.id}", 'komagata'
     click_button '提出物を確認'
     visit_with_auth '/products/unchecked?target=unchecked_all', 'komagata'
-    wait_for_vuejs
     assert_no_text product.practice.title
   end
 
@@ -85,7 +84,6 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
     visit_with_auth '/products/unchecked', 'komagata'
-    wait_for_vuejs
     click_link '自分の担当'
     assert_text product.practice.title
   end
@@ -104,7 +102,6 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
-    wait_for_vuejs
     assert_text product.practice.title
   end
 
@@ -122,7 +119,6 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
     visit_with_auth '/products/unchecked?target=unchecked_all', 'komagata'
-    wait_for_vuejs
     click_link '自分の担当'
     assert_text product.practice.title
   end
@@ -141,7 +137,6 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
-    wait_for_vuejs
     assert_no_text product.practice.title
   end
 

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -132,7 +132,6 @@ class ProductsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '削除'
     end
-    wait_for_vuejs
     assert_text '提出物を削除しました。'
   end
 
@@ -147,7 +146,6 @@ class ProductsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '削除'
     end
-    wait_for_vuejs
     assert_text '提出物を削除しました。'
   end
 
@@ -465,7 +463,6 @@ class ProductsTest < ApplicationSystemTestCase
     assignee_buttons.first.click
 
     unassigned_tab.click
-    wait_for_vuejs
     operated_counter = find('#test-unassigned-counter').text
     assert_not_equal initial_counter, operated_counter
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -284,6 +284,7 @@ class ProductsTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
     fill_in 'new_comment[description]', with: 'コメントしたら担当になるテスト'
     click_button 'コメントする'
+    assert_text 'コメントしたら担当になるテスト'
     visit current_path
     assert_text '担当から外れる'
     assert_no_text '担当する'

--- a/test/system/question/tags_test.rb
+++ b/test/system/question/tags_test.rb
@@ -38,7 +38,6 @@ class Question::TagsTest < ApplicationSystemTestCase
     tag_input.set '追加タグ'
     tag_input.native.send_keys :return
     click_on '保存'
-    wait_for_vuejs
     assert_text '追加タグ'
   end
 
@@ -62,7 +61,6 @@ class Question::TagsTest < ApplicationSystemTestCase
     click_button 'タグ名変更'
     fill_in('tag[name]', with: update_tag_text)
     click_button '変更'
-    wait_for_vuejs
 
     assert_text "タグ「#{update_tag_text}」のQ&A（1）"
     visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'
@@ -87,7 +85,6 @@ class Question::TagsTest < ApplicationSystemTestCase
     click_button 'タグ名変更'
     fill_in('tag[name]', with: update_tag.name)
     click_button '変更'
-    wait_for_vuejs
 
     assert_text "タグ「#{update_tag.name}」のQ&A（2）"
     visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -102,20 +102,26 @@ class QuestionsTest < ApplicationSystemTestCase
     fill_in 'question[title]', with: 'タイトルtest'
     fill_in 'question[description]', with: '内容test'
 
-    click_button '登録する'
-    assert_text '質問を作成しました。'
+    assert_difference -> { Question.count }, 1 do
+      click_button '登録する'
+      assert_text '質問を作成しました。'
+    end
 
     visit_with_auth '/notifications', 'komagata'
+    assert_text 'yameoさんが退会しました。'
     assert_text 'kimuraさんから質問がありました。'
 
     visit_with_auth '/questions', 'kimura'
     click_on 'タイトルtest'
-    accept_confirm do
-      click_link '削除する'
+    assert_difference -> { Question.count }, -1 do
+      accept_confirm do
+        click_link '削除する'
+      end
+      assert_text '質問を削除しました。'
     end
-    assert_text '質問を削除しました。'
 
     visit_with_auth '/notifications', 'komagata'
+    assert_text 'yameoさんが退会しました。'
     assert_no_text 'kimuraさんから質問がありました。'
   end
 

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -100,8 +100,8 @@ class QuestionsTest < ApplicationSystemTestCase
       select updated_question[:practice].title, from: 'question[practice]'
       click_button '更新する'
     end
+    assert_text '質問を更新しました'
 
-    wait_for_vuejs # Vueが実行したREST APIがDBに反映されるのを待つ
     question = Question.last
     updated_question.each do |key, val|
       is_practice_value = key == :practice

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -46,28 +46,19 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'update a question' do
     question = questions(:question8)
     visit_with_auth question_path(question), 'kimura'
-    updated_question = {
-      title: 'テストの質問（修正）',
-      description: 'テストの質問です。（修正）',
-      practice: Practice.where.not(id: question.practice.id).first
-    }
-    wait_for_vuejs
+
     click_button '内容修正'
     within 'form[name=question]' do
-      fill_in 'question[title]', with: updated_question[:title]
-      fill_in 'question[description]', with: updated_question[:description]
-      select updated_question[:practice].title, from: 'question[practice]'
+      fill_in 'question[title]', with: 'テストの質問（修正）'
+      fill_in 'question[description]', with: 'テストの質問です。（修正）'
+      select 'sshdでパスワード認証を禁止にする', from: 'question[practice]'
       click_button '更新する'
     end
-
-    wait_for_vuejs # Vueが実行したREST APIがDBに反映されるのを待つ
-    question.reload
-    updated_question.each do |key, val|
-      is_practice_value = key == :practice
-      assert_equal val, is_practice_value ? question.practice : question[key]
-      assert_text is_practice_value ? question.practice.title : val
-    end
     assert_text '質問を更新しました'
+
+    assert_text 'テストの質問（修正）'
+    assert_text 'テストの質問です。（修正）'
+    assert_text 'sshdでパスワード認証を禁止にする'
   end
 
   test 'update question for practice without questioner\'s course' do

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -73,42 +73,27 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'update question for practice without questioner\'s course' do
     visit_with_auth edit_current_user_path, 'kimura'
 
-    login_user = User.find_by(login_name: find_field(id: 'user_login_name').value)
-    practice = Practice.where.not(
-      id: login_user.course.practices.map(&:id)
-    ).first
-
     visit new_question_path
     within 'form[name=question]' do
       fill_in 'question[title]', with: '質問者のコースにはないプラクティスの質問を編集できるかのテスト'
       fill_in 'question[description]', with: '編集できれば期待通りの動作'
-      select practice.title, from: 'question[practice_id]'
+      select 'iOSへのビルドと固有の問題', from: 'question[practice_id]'
       click_button '登録する'
     end
     assert_text '質問を作成しました。'
 
-    updated_question = {
-      title: '質問者のコースにはないプラクティスの質問でも',
-      description: '編集できる',
-      practice: practice
-    }
-    wait_for_vuejs
     click_button '内容修正'
     within 'form[name=question]' do
-      fill_in 'question[title]', with: updated_question[:title]
-      fill_in 'question[description]', with: updated_question[:description]
-      select updated_question[:practice].title, from: 'question[practice]'
+      fill_in 'question[title]', with: '質問者のコースにはないプラクティスの質問でも'
+      fill_in 'question[description]', with: '編集できる'
+      select 'iOSへのビルドと固有の問題', from: 'question[practice]'
       click_button '更新する'
     end
     assert_text '質問を更新しました'
 
-    question = Question.last
-    updated_question.each do |key, val|
-      is_practice_value = key == :practice
-      assert_equal val, is_practice_value ? question.practice : question[key]
-      assert_text is_practice_value ? question.practice.title : val
-    end
-    assert_text '質問を更新しました'
+    assert_text '質問者のコースにはないプラクティスの質問でも'
+    assert_text '編集できる'
+    assert_text 'iOSへのビルドと固有の問題'
   end
 
   test 'delete a question' do

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -90,7 +90,6 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'delete a question' do
     question = questions(:question8)
     visit_with_auth question_path(question), 'kimura'
-    wait_for_vuejs
     accept_confirm do
       click_link '削除する'
     end
@@ -111,7 +110,6 @@ class QuestionsTest < ApplicationSystemTestCase
 
     visit_with_auth '/questions', 'kimura'
     click_on 'タイトルtest'
-    wait_for_vuejs
     accept_confirm do
       click_link '削除する'
     end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -339,9 +339,6 @@ class ReportsTest < ApplicationSystemTestCase
     all('.learning-time')[1].all('.learning-time__finished-at select')[1].select('30')
     click_button '内容変更'
 
-    # Watchの非同期処理ための待ち時間
-    sleep 0.5
-
     assert_selector('ul.learning-times__items li.learning-times__item:nth-child(1)', text: '07:30 〜 08:30')
     assert_selector('ul.learning-times__items li.learning-times__item:nth-child(2)', text: '19:30 〜 20:15')
   end
@@ -371,11 +368,17 @@ class ReportsTest < ApplicationSystemTestCase
     assert_selector '.thread-comment-form'
   end
 
+  # 画面上では更新の完了がわからないため、やむを得ずsleepする
+  # 注意）安易に使用しないこと!! https://bootcamp.fjord.jp/pages/use-assert-text-instead-of-wait-for-vuejs
+  def wait_for_watch_change
+    sleep 1
+  end
+
   test 'unwatch' do
     visit_with_auth report_path(reports(:report1)), 'kimura'
     assert_difference('Watch.count', -1) do
       find('div.a-watch-button', text: 'Watch中').click
-      sleep 0.5
+      wait_for_watch_change
     end
   end
 
@@ -383,7 +386,7 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth report_path(reports(:report1)), 'kimura'
     assert_difference('Watch.count', -1) do
       find('div.a-watch-button', text: 'Watch中').click
-      sleep 0.5
+      wait_for_watch_change
     end
   end
 

--- a/test/system/user/memos_test.rb
+++ b/test/system/user/memos_test.rb
@@ -9,7 +9,6 @@ class User::MemoTest < ApplicationSystemTestCase
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'ユーザーメンターメモ'
     click_button '保存する'
-    wait_for_vuejs
     assert_text 'ユーザーメンターメモ'
     assert_no_text 'ユーザーメモはまだありません。'
   end
@@ -21,7 +20,6 @@ class User::MemoTest < ApplicationSystemTestCase
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'ユーザーメンターメモ'
     click_button 'キャンセル'
-    wait_for_vuejs
     assert_no_text 'ユーザーメンターメモ'
     assert_text 'kimuraさんのメモ'
     assert_no_text 'ユーザーメモはまだありません。'

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -142,9 +142,14 @@ class User::TagsTest < ApplicationSystemTestCase
     tag_input.set '#ハッシュハッシュ'
     tag_input.native.send_keys :return
     click_button '保存する'
+    within '.tag-links__items' do
+      assert_text 'ハッシュハッシュ'
+    end
 
     visit_with_auth user_path(users(:hatsuno)), 'komagata'
-    assert_no_text '#ハッシュハッシュ'
-    assert_text 'ハッシュハッシュ'
+    within '.tag-links__items' do
+      assert_text 'ハッシュハッシュ'
+      assert_no_text '#ハッシュハッシュ'
+    end
   end
 end

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -92,7 +92,7 @@ class User::TagsTest < ApplicationSystemTestCase
     click_button 'タグ名変更'
     fill_in('tag[name]', with: update_tag_text)
     click_button '変更'
-    wait_for_vuejs
+    assert_text 'タグ「上級者」'
 
     visit_with_auth users_tag_path(tag.name), 'komagata'
     assert_text "#{tag.name}のユーザーはいません"
@@ -113,7 +113,7 @@ class User::TagsTest < ApplicationSystemTestCase
     click_button 'タグ名変更'
     fill_in('tag[name]', with: update_tag.name)
     click_button '変更'
-    wait_for_vuejs
+    assert_text 'タグ「中級者」'
 
     visit_with_auth users_tag_path(tag.name), 'komagata'
     assert_text "#{tag.name}のユーザーはいません"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -180,7 +180,6 @@ class UsersTest < ApplicationSystemTestCase
   test 'not show welcome message' do
     visit_with_auth practice_path(practices(:practice1).id), 'hatsuno'
     click_button '着手'
-    wait_for_vuejs
     visit '/'
     assert_no_text 'ようこそ'
   end
@@ -193,7 +192,6 @@ class UsersTest < ApplicationSystemTestCase
     within '.niconico-calendar-nav' do
       assert_text "#{today.year}年#{today.month}月"
       find('.niconico-calendar-nav__previous').click
-      wait_for_vuejs
       assert_text "#{last_month.year}年#{last_month.month}月"
     end
   end
@@ -211,7 +209,6 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth root_path, 'hatsuno'
     visit user_path(users(:hajime).id)
     find('.niconico-calendar-nav__previous').click
-    wait_for_vuejs
     assert_no_selector '.niconico-calendar__day.is-today'
   end
 


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/pull/1489 で「やむを得ず」導入した `wait_for_vuejs` がいつの間にか乱用されまくっているので、可能な限り排除しました。

まだ一部不安定な部分もあるかもしれませんが、fail / retryなしで全パスさせることもできました。
https://github.com/fjordllc/bootcamp/runs/5404074186?check_suite_focus=true
<img width="839" alt="Screen Shot 2022-03-03 at 17 44 22" src="https://user-images.githubusercontent.com/1148320/156529075-e7bebcb9-a78b-4d6e-aaa7-fedb6ee45c36.png">
