### PR TITLE
提出個別ページのページタイトルを変更

### DIFF
--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -1,4 +1,4 @@
-- title "#{@product.practice.title}の提出物"
+- title "#{@product.practice.title}"
 - category = @product.category(current_user.course)
 
 = render '/shared/modal_learning_completion',

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -1,4 +1,4 @@
-- title "#{@product.practice.title}"
+- title @product.practice.title
 - category = @product.category(current_user.course)
 
 = render '/shared/modal_learning_completion',

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -5,32 +5,32 @@ require 'application_system_test_case'
 class ProductsTest < ApplicationSystemTestCase
   test 'see my product' do
     visit_with_auth "/products/#{products(:product1).id}", 'mentormentaro'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product1).practice.title} | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test 'admin can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product1).practice.title} | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test 'adviser can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'advijirou'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product1).practice.title} | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test 'graduate can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'sotugyou'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product1).practice.title} | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test "user who completed the practice can see the other user's product" do
     visit_with_auth "/products/#{products(:product1).id}", 'kimura'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product1).practice.title} | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test "can see other user's product if it is permitted" do
     visit_with_auth "/products/#{products(:product3).id}", 'hatsuno'
-    assert_equal "#{products(:product3).practice.title}の提出物 | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
+    assert_equal "#{products(:product3).practice.title} | FJORD BOOT CAMP（フィヨルドブートキャンプ）", title
   end
 
   test "can not see other user's product if it isn't permitted" do


### PR DESCRIPTION
- issue [#4274](https://github.com/fjordllc/bootcamp/issues/4274) #4274
- 提出個別ページのページタイトルを変更しました。

### 変更前

![before](https://user-images.githubusercontent.com/64824195/156578359-2bd7ab99-a24a-4638-ad95-8c16ebe3dc5b.png)

### 変更後

![after](https://user-images.githubusercontent.com/64824195/156580760-9cf0378f-dd0c-4556-ae3a-b9040cc8093e.png)
