### PR TITLE
質問投稿時の通知に質問のタイトルが表示されるようにした

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -70,7 +70,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def came_question
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/questions/#{@question.id}")
-    mail to: @user.email, subject: "[bootcamp] #{@question.user.login_name}さんから質問がありました。"
+    mail to: @user.email, subject: "[bootcamp] #{@question.user.login_name}さんから質問「#{@question.title}」が投稿されました。"
   end
 
   # required params: report, receiver

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -125,7 +125,7 @@ class Notification < ApplicationRecord
         user: receiver,
         sender: question.sender,
         link: Rails.application.routes.url_helpers.polymorphic_path(question),
-        message: "#{question.user.login_name}さんから質問がありました。",
+        message: "#{question.user.login_name}さんから質問「#{question.title}」が投稿されました。",
         read: false
       )
     end

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -106,6 +106,9 @@ notification_create_page:
   user: hatsuno
   sender: komagata
   message: "komagataさんがDocsにBootcampの作業のページを投稿しました。"
+  link: "/pages/<%= ActiveRecord::FixtureSet.identify(:page4) %>"
+  read: false
+
 notification_following_report:
   user: muryou
   sender: kensyu

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -58,7 +58,10 @@ notification_questioned:
   kind: 6
   user: komagata
   sender: sotugyou
-  message: sotugyouさんから質問がありました。
+  message: sotugyouさんから質問「injectとreduce」が投稿されました。
+  link: "/questions/<%= ActiveRecord::FixtureSet.identify(:question2) %>"
+  read: false
+
 notification_first_report:
   user: komagata
   sender: hajime

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -82,7 +82,7 @@ notification_questioned:
   kind: 6
   user: komagata
   sender: sotugyou
-  message: sotugyouさんから質問がありました。
+  message: sotugyouさんから質問「injectとreduce」が投稿されました。
   link: "/questions/<%= ActiveRecord::FixtureSet.identify(:question2) %>"
   read: false
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -133,7 +133,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[bootcamp] sotugyouさんから質問がありました。', email.subject
+    assert_equal '[bootcamp] sotugyouさんから質問「injectとreduce」が投稿されました。', email.subject
     assert_match(/質問/, email.body.to_s)
   end
 

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -4,7 +4,6 @@ require 'application_system_test_case'
 
 class Notification::QuestionsTest < ApplicationSystemTestCase
   setup do
-    @notice_text = 'hatsunoさんから質問がありました。'
     @notice_kind = Notification.kinds['came_question']
     @notified_count = Notification.where(kind: @notice_kind).size
     @mentor_count = User.mentor.size
@@ -16,15 +15,12 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       fill_in('question[title]', with: 'メンターに質問！！')
       fill_in('question[description]', with: '通知行ってますか？')
     end
-    first('.select2-selection--single').click
-    find('li', text: '[Mac OS X] OS X Mountain Lionをクリーンインストールする').click
     click_button '登録する'
     assert_text '質問を作成しました。'
 
     visit_with_auth '/notifications', 'mentormentaro'
-
     within first('.thread-list-item.is-unread') do
-      assert_text @notice_text
+      assert_text 'hatsunoさんから質問「メンターに質問！！」が投稿されました。'
     end
 
     assert_equal @notified_count + @mentor_count, Notification.where(kind: @notice_kind).size
@@ -36,17 +32,11 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       fill_in('question[title]', with: '皆さんに質問！！')
       fill_in('question[description]', with: '通知行ってますか？')
     end
-    first('.select2-selection--single').click
-    find('li', text: '[Mac OS X] OS X Mountain Lionをクリーンインストールする').click
     click_button '登録する'
-    logout
+    assert_text '質問を作成しました。'
 
-    login_user users(:mentormentaro).login_name, 'testtest'
-    # 通知メッセージが非表示項目でassert_textでは取得できないため、findでvisible指定
-    # 存在時、findは複数取得してエラーになるためassert_raisesにて検証
-    assert_raises Capybara::ElementNotFound do
-      find('mentormentaroさんから質問がありました。', visible: false)
-    end
-    logout
+    visit '/notifications'
+    assert_selector '.page-header__title', text: '通知'
+    assert_no_text 'mentormentaroさんから質問「皆さんに質問！！」が投稿されました。'
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -109,7 +109,7 @@ class QuestionsTest < ApplicationSystemTestCase
 
     visit_with_auth '/notifications', 'komagata'
     assert_text 'yameoさんが退会しました。'
-    assert_text 'kimuraさんから質問がありました。'
+    assert_text 'kimuraさんから質問「タイトルtest」が投稿されました。'
 
     visit_with_auth '/questions', 'kimura'
     click_on 'タイトルtest'
@@ -122,7 +122,7 @@ class QuestionsTest < ApplicationSystemTestCase
 
     visit_with_auth '/notifications', 'komagata'
     assert_text 'yameoさんが退会しました。'
-    assert_no_text 'kimuraさんから質問がありました。'
+    assert_no_text 'kimuraさんから質問「タイトルtest」が投稿されました。'
   end
 
   test 'admin can update and delete any questions' do


### PR DESCRIPTION
## Issue
- #4285

## 概要
質問投稿時に送られる通知の件名に、質問のタイトルが表示されるようにしました。
=> 文言のフォーマット：`XXXさんから質問「質問のタイトル」が投稿されました。`

### 変更前
サイト内通知
![image](https://user-images.githubusercontent.com/83743223/156877878-bca64cc3-c209-4d3a-b74d-43333e6960da.png)

メール通知
![image](https://user-images.githubusercontent.com/83743223/156877898-2f679923-01fa-43ce-8083-a3b3a485d0a9.png)

### 変更後
サイト内通知
![image](https://user-images.githubusercontent.com/83743223/156877680-672cf3bf-f9f1-4e8c-96ab-16c825c5f7dc.png)

メール通知
![image](https://user-images.githubusercontent.com/83743223/156877786-9f7c6751-b618-47ad-8500-27babd1d9160.png)

## ローカル環境での確認方法
### サイト内通知
- `feature/show-question-title-in-notification` ブランチを起動
- ユーザーログイン後、Q&A > 質問をする から、質問を投稿する
- `mentor? == true` の他のユーザーでログインし直し、通知の中に `XXXさんから質問「質問のタイトル」が投稿されました。` の形式で通知が届いていることを確認する
  - メンターのユーザー例：`mentormentaro`、`komagata` など

### メール通知
- `feature/show-question-title-in-notification` ブランチを起動
- http://localhost:3000/rails/mailers/notification_mailer/came_question を開く
- メールのプレビューで件名が `[bootcamp] XXXさんから質問「質問のタイトル」が投稿されました。` の形式であることを確認する
