### PR TITLE
[fixture] 開発用データの日報にニコニコカレンダーの情報を追加した

### DIFF
--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -1,6 +1,7 @@
 report1:
   user: komagata
   title: "作業週1日目"
+  emotion: 2
   description: |-
     今日はローカルで怖話を動かしてみました。
     rbenv で ruby を動かすのは初めてだったので、色々手間取りました。
@@ -11,6 +12,7 @@ report1:
 report2:
   user: komagata
   title: "作業週2日目"
+  emotion: 2
   description: |-
     今日はローカルで Fjord Bootcamp を動かしてみました。
     ruby の指定バージョンが 2.2.3 だったので、 rbenv で ruby のバージョンを上げました。
@@ -20,6 +22,7 @@ report2:
 report3:
   user: komagata
   title: "学習週3日目"
+  emotion: 1
   description: |-
     今日は CSS の勉強をしました。デザイン難しい。。。
   reported_on: "2017-01-03"
@@ -28,6 +31,7 @@ report3:
 report4:
   user: machida
   title: "Fjord Bootcamp で Bootstrap のバージョン更新"
+  emotion: 2
   description: |-
     Fjord Bootcamp で Bootstrap のバージョン更新を行った他、デザインの微調整を行いました。
   reported_on: "2017-01-01"
@@ -35,6 +39,7 @@ report4:
 report5:
   user: sotugyou
   title: "学習週1日目"
+  emotion: 2
   description: |-
     今日は　Rubyの基礎 を学習しました。
   reported_on: "2017-01-01"
@@ -42,6 +47,7 @@ report5:
 report6:
   user: sotugyou
   title: "学習週2日目"
+  emotion: 2
   description: |-
     今日は　Railsの基礎 を学習しました。
   reported_on: "2017-01-02"
@@ -49,6 +55,7 @@ report6:
 report7:
   user: sotugyou
   title: "学習週3日目"
+  emotion: 2
   description: |-
     今日は　RSpecの基礎 を学習しました。
   reported_on: "2017-01-03"
@@ -56,6 +63,7 @@ report7:
 report8:
   user: mentormentaro
   title: テストの日報
+  emotion: 2
   description: |-
     いろいろやりました。
   reported_on: "2017-01-01"
@@ -63,6 +71,7 @@ report8:
 report9:
   user: sotugyou
   title: WIPの日報
+  emotion: 2
   description: |-
     WIP
   reported_on: "2019-01-01"
@@ -71,6 +80,7 @@ report9:
 report10:
   user: hajime
   title: 初日報です
+  emotion: 2
   description:
     学習の準備をしました。
   reported_on: "2019-01-01"
@@ -78,6 +88,7 @@ report10:
 report11:
   user: kensyu
   title: 研修の日報
+  emotion: 2
   description:
     研修を行いました。
   reported_on: "2019-01-01"
@@ -85,12 +96,14 @@ report11:
 sotugyou:
   user: sotugyou
   title: テストの日報
+  emotion: 2
   description: いろいろやりました
   reported_on: "2018-02-01"
 
 report12:
   user: mentormentaro
   title: 検索結果確認用-C
+  emotion: 1
   description:
     今年で150歳でーす
   reported_on: "2020-01-01"
@@ -99,6 +112,7 @@ report12:
 report13:
   user: mentormentaro
   title: 検索結果確認用-A
+  emotion: 2
   description:
     きたるべき20世紀
   reported_on: "1900-01-01"
@@ -107,6 +121,7 @@ report13:
 report14:
   user: mentormentaro
   title: 検索結果確認用-B
+  emotion: 2
   description:
     あれから100年か
   reported_on: "2000-01-01"
@@ -131,6 +146,7 @@ report16:
 report17:
   user: mentormentaro
   title: 1時間だけ学習
+  emotion: 2
   description: |-
     mentormentaroです、メンターです。
     今日は1時間学習しました。
@@ -141,6 +157,7 @@ report17:
 report18:
   user: daimyo
   title: テストのnippou
+  emotion: 2
   description: |-
     今日は1時間学習しました。
   reported_on: "2020-06-01"
@@ -165,6 +182,7 @@ report20:
 report21:
   user: sotugyou
   title: "学習週4日目"
+  emotion: 2
   description: |-
     今日は　Vueの基礎 を学習しました。
   practices: practice1
@@ -173,6 +191,7 @@ report21:
 report22:
   user: sotugyou
   title: 卒業生による日報
+  emotion: 2
   description:
     卒業しました。
   practices: practice2
@@ -182,6 +201,7 @@ report22:
 report23:
   user: kensyu
   title: フォローされた日報
+  emotion: 2
   description:
     フォローされました。
   reported_on: "2020-11-10"
@@ -189,6 +209,7 @@ report23:
 report24:
   user: daimyo
   title: 検索用の日報
+  emotion: 2
   description:
     ユーザーネームで検索できるよ
   reported_on: "2020-11-20"
@@ -196,6 +217,7 @@ report24:
 report25:
   user: hatsuno
   title: 検索用の日報
+  emotion: 2
   description:
     ユーザーネームで検索できるよ
   reported_on: "2020-11-20"
@@ -203,6 +225,7 @@ report25:
 report26:
   user: sotugyou
   title: 卒業の翌日の日報
+  emotion: 2
   description:
     「前の日報」をクリックすれば、前日の日報にちゃんと行ける
   reported_on: "2020-09-11"
@@ -211,6 +234,7 @@ report26:
 report27:
   user: sotugyou
   title: 卒業の前日(遡って日報を作成)
+  emotion: 2
   description:
     遡って作成しましたが、卒業の前日の分の日報です。
   reported_on: "2020-09-09"
@@ -252,6 +276,7 @@ report31:
 report<%= i + 31 %>:
   user: kimura
   title: <%= "テスト日報#{i}です" %>
+  emotion: 2
   description: |-
     # はじめに
     これはエクスポート機能のテストデータです


### PR DESCRIPTION
## issue
- #4248 

## 概要
日報のseedデータにニコニコカレンダーの情報を追加しました。

## 変更確認方法
1. ブランチ`feature/add-info-of-niconico-calendar-to-db-fixtures`をローカルに取り込む
2. `$ rails db:seed`を実行
3. `$ rails server`でローカル環境を立ち上げる
4. テスト用ユーザーでログイン
5. 日報個別ページに今日の気分（sad・soso・happyのどれか）が追加されていることを確認

## 変更前
<img width="1453" alt="screen-shot 2022-03-05 9 49 55" src="https://user-images.githubusercontent.com/60736158/156870349-e0285de2-e235-472d-8490-3aafe861b8da.png">

## 変更後
<img width="1455" alt="screen-shot 2022-03-05 9 51 22" src="https://user-images.githubusercontent.com/60736158/156870344-00a3f655-3143-415c-9a6e-3c0b662b0bf8.png">
