### PR TITLE
管理者ページのユーザー一覧のお試し延長適用ユーザー一覧にアドバイザーを削除

### DIFF
--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -26,6 +26,7 @@
         th.admin-table__label 削除
     tbody.admin-table__items
       - users.each do |user|
+        - next if params[:target] == 'campaign' && user.adviser
         tr.admin-table__item class="#{user.retired_on? ? 'is-inactive' : '' }"
           td.admin-table__item-value.is-text-align-center
             - if user.admin?

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -26,7 +26,7 @@
         th.admin-table__label 削除
     tbody.admin-table__items
       - users.each do |user|
-        - next if params[:target] == 'campaign' && user.adviser
+        - next if params[:target] == 'campaign' && user.adviser?
         tr.admin-table__item class="#{user.retired_on? ? 'is-inactive' : '' }"
           td.admin-table__item-value.is-text-align-center
             - if user.admin?

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -148,4 +148,38 @@ class Admin::UsersTest < ApplicationSystemTestCase
     visit "/admin/users/#{user.id}/edit"
     assert_text '追加タグ'
   end
+
+  test 'does not display advisor in the list of trial period users' do
+    start = Time.current - 20.years
+    seven_days_later = Time.current + 7.days
+    visit_with_auth new_admin_campaign_path, 'komagata'
+    within 'form[name=campaign]' do
+      fill_in 'campaign[start_at]', with: Time.zone.parse(start.to_s)
+      fill_in 'campaign[end_at]', with: Time.zone.parse(seven_days_later.to_s)
+      fill_in 'campaign[title]', with: 'テスト用キャンペーン'
+      click_button '内容を保存'
+    end
+    assert_text 'お試し延長を作成しました。'
+    visit_with_auth '/admin/users?target=campaign', 'komagata'
+    within('.page-body') do
+      assert_no_text 'アドバイザー'
+    end
+  end
+
+  test 'display advisor in lists other than the list of trial period users' do
+    start = Time.current - 20.years
+    seven_days_later = Time.current + 7.days
+    visit_with_auth new_admin_campaign_path, 'komagata'
+    within 'form[name=campaign]' do
+      fill_in 'campaign[start_at]', with: Time.zone.parse(start.to_s)
+      fill_in 'campaign[end_at]', with: Time.zone.parse(seven_days_later.to_s)
+      fill_in 'campaign[title]', with: 'テスト用キャンペーン'
+      click_button '内容を保存'
+    end
+    assert_text 'お試し延長を作成しました。'
+    visit_with_auth '/admin/users?target=adviser', 'komagata'
+    within('.page-body') do
+      assert_text 'アドバイザー'
+    end
+  end
 end


### PR DESCRIPTION
### Issue
- #4331

### 概要
- 管理者ページのユーザー一覧のお試し延長適用ユーザー一覧からアドバイザーを削除 しました。

### 変更確認方法
1. ブランチ `bug/remove-advisors-from-list-of-users-under-trial-period`をローカルに取り込む
1. `rails s` でローカル環境を立ち上げる
1. 管理者でログイン
1. 右上のMeから管理ページを選択
1. タブのお試し延長を選択(**※**)
1. 右上のお試し延長一覧ボタンをクリックし、開始日時と終了日時を入力して内容を保存する(**※**)
1. タブのユーザーを選択
1. タブ直下の一番左にあるお試し延長をクリック

**※5と6の手順ついては下記のお試し延長期間作成手順の画像をご参照ください。**
[[参考]お試し延長 開始・終了機能を作成 by napple29 · Pull Request \#4030 ](https://github.com/fjordllc/bootcamp/pull/4030)

### お試し延長期間作成手順

![スクリーンショット_2022-03-09_23_59_14](https://user-images.githubusercontent.com/64824195/157470687-ee3c6b4c-ee77-47e6-b67f-a14285321ccf.jpg)

### 変更前

![before](https://user-images.githubusercontent.com/64824195/156880084-91f467e2-a072-4e21-b7cf-4adace66a2b9.jpg)

### 変更後

タブのアドバイザー以外、検索しても表示されなくなりました。

![after](https://user-images.githubusercontent.com/64824195/156880165-cfbed606-0bbd-4ae6-b9b5-51eb1ca17c4e.jpg)

以下、２点について報告です。
- 管理者ページのユーザー一覧のお試し延長適用ユーザー一覧からアドバイザーは削除しましたが、メンターや卒業生、退会者等は表示されている状態となっております。
- ページ下部の全員のメアドの欄にアドバイザーのメールアドレスが表示された状態となっております。

上記、修正不要との回答を駒形さん、町田さんに確認済。