### PR TITLE
fix: Stale botが動かない問題を修正

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,9 @@ name: "Close stale issues"
 on:
   schedule:
     - cron: "0 1 * * *"
+  push:
+    paths:
+      - '.github/workflows/stale.yml'
 
 jobs:
   stale:
@@ -21,3 +24,4 @@ jobs:
           days-before-close: 7
           exempt-issue-labels: "pinned,security,release,bug,バグ"
           stale-issue-label: stale
+          debug-only: ${{ github.event_name == 'push' }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   stale:
     name: stale
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ jobs:
   stale:
     name: stale
     runs-on: ubuntu:latest
+    timeout-minutes: 5
     steps:
       - uses: actions/stale@v3
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: "Close stale issues"
+on:
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+  stale:
+    name: stale
+    runs-on: ubuntu:latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'このissue|PRは60日間更新がないため7日後にcloseします。closeしたくない場合はstaleラベルを外してください。'
+          close-issue-message: 'このissue|PRはstaleラベルを付けた後7日間更新がないためcloseしました。'
+          days-before-stale: 60
+          days-before-close: 7
+          exempt-issue-labels: "pinned,security,release,bug,バグ"
+          stale-issue-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,9 @@ jobs:
     name: stale
     runs-on: ubuntu:latest
     timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v3
         with:


### PR DESCRIPTION
[actions/stale](https://github.com/actions/stale) の設定を色々と直しました。
これで動くようになると思います。

## 動かなかった理由

おそらくランナーの記述ミスだと思うが、確証がないので `timeout-minutes` も指定するようにしてます。
これでダメだったとしても、5分で止まるので。

## 動作確認

動作確認がしやすいように `push` イベントを追加しつつ `debug-only` を追加しました。

`fjordllc/bootcamp` のpush権限を持っている人なら、以下のような感じで私のブランチを別名でpushして頂ければ dry-run で動作確認できると思います。

```bash
$ git remote add sinsoku https://github.com/sinsoku/bootcamp.git
$ git fetch sinsoku update_stale_setting
$ git branch update_stale_setting_test FEATCH_HEAD
$ git push origin update_stale_setting_test
```