### PR TITLE
イベント一覧を開催日順へ変更 

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -6,7 +6,7 @@ class API::EventsController < API::BaseController
   def index
     @events = Event.with_avatar
                    .includes(:comments, :users)
-                   .order(created_at: :desc)
+                   .order(start_at: :desc)
                    .page(params[:page])
   end
 end


### PR DESCRIPTION
## issue
- #4336 

## 概要
イベント一覧を開催日順へ変更しました。

## 変更確認方法
1. ブランチ`feature/change-order-of-event-list`をローカルに取り込む
2. `$ rails server`でローカル環境を立ち上げる
3. テスト用ユーザーでログイン
4. イベント一覧ページでイベント一覧が開催日順に変更されていることを確認

## 変更前
<img width="1305" alt="スクリーンショット 2022-03-07 21 19 20" src="https://user-images.githubusercontent.com/60736158/157036758-2bad7b35-63fd-4f57-9da8-715f8d21773d.png">

## 変更後
<img width="1300" alt="screen-shot-2022-03-07 21 19 34" src="https://user-images.githubusercontent.com/60736158/157036630-c69c67f5-6bb3-421b-b4d5-6806bbcdcf1c.png">
