### PR TITLE
相談部屋一覧画面で発生していたN+1を解消

### DIFF
--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -7,7 +7,8 @@ class API::TalksController < API::BaseController
   def index
     @target = params[:target]
     @target = 'student_and_trainee' unless TARGETS.include?(@target)
-    @users_talks = Talk.joins(:user).merge(User.users_role(@target))
+    @users_talks = Talk.eager_load(user: [:company, { avatar_attachment: :blob }])
+                       .merge(User.users_role(@target))
                        .page(params[:page]).per(PAGER_NUMBER)
                        .order(updated_at: :desc)
   end


### PR DESCRIPTION
## Description

相談部屋一覧画面遷移時に下記テーブルに対してN+1が発生していたので`eager_load`してクエリが一回で済むようにしました。
- usersテーブル
- companiesテーブル
- active_storage_attachmentsテーブル
- active_storage_blobsテーブル