### PR TITLE
WIPで保存されているブログ記事がeditでもWIPであることがわかるようにした

### DIFF
--- a/app/views/articles/edit.html.slim
+++ b/app/views/articles/edit.html.slim
@@ -5,7 +5,11 @@ header.page-header
     .page-header__inner
       h2.page-header__title = title
 - if @article.wip?
-  | この記事はまだ公開されていません
+  .a-page-notice
+    .container
+      .a-page-notice__inner
+        p
+          | この記事はまだ公開されていません。
 .page-body
   .container.is-xxl
     = render 'form', article: @article

--- a/app/views/articles/edit.html.slim
+++ b/app/views/articles/edit.html.slim
@@ -4,7 +4,8 @@ header.page-header
   .container
     .page-header__inner
       h2.page-header__title = title
-
+- if @article.wip?
+  | この記事はまだ公開されていません
 .page-body
   .container.is-xxl
     = render 'form', article: @article


### PR DESCRIPTION
# Issue概要
- #4261

WIPで保存されているブログ記事を編集中の場合、WIPであることが編集画面からは分からなかった

# 変更前
![image](https://user-images.githubusercontent.com/63531341/157360242-6332d7f8-6d08-47f8-a42e-165a19171f78.png)


# 変更後
![_development__ブログ記事編集___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/63531341/157360081-a31cc614-c494-401e-a519-ddef6af8be52.png)


# 動作確認手順
1. ブランチ`feature/clarify-wip-of-blog-post-when-editing`をローカルに取り込む
1. `bin/setup`を実行する
1. `bin/rails s`でサーバーを立ち上げる
1. `komagata`(管理者)でログインし、右上の自分のアイコンからメンターメニューのブログ投稿ページに移動し、ブログ記事一覧画面(`/articles`)に移動する
1. 一覧からWIPで作成されている「仮想マシンにDebianをインストールしよう」という記事にアクセスし、内容修正ボタンから編集画面に移動する
1. ブログ記事の編集画面「ブログ記事編集」の下に「この記事はまだ公開されていません」が表示されていることを確認