### PR TITLE
ブログ記事一覧にページャーを付ける

### DIFF
--- a/app/assets/stylesheets/article.sass
+++ b/app/assets/stylesheets/article.sass
@@ -2,6 +2,7 @@
 @import /blocks/base/body
 @import /blocks/footer/footer
 @import /blocks/shared/flash
+@import /blocks/shared/pagination
 
 .articles__header
   margin-bottom: 1rem

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -56,11 +56,8 @@ class ArticlesController < ApplicationController
   end
 
   def list_articles
-    if admin_or_mentor_login?
-      Article.includes(user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page])
-    else
-      Article.includes(user: { avatar_attachment: :blob }).where(wip: false).order(created_at: :desc).page(params[:page])
-    end
+    articles = Article.includes(user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page])
+    admin_or_mentor_login? ? articles : articles.where(wip: false)
   end
 
   def article_params

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -57,9 +57,9 @@ class ArticlesController < ApplicationController
 
   def list_articles
     if admin_or_mentor_login?
-      Article.all.order(created_at: :desc)
+      Article.order(created_at: :desc).page(params[:page])
     else
-      Article.all.where(wip: false).order(created_at: :desc)
+      Article.where(wip: false).order(created_at: :desc).page(params[:page])
     end
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -57,9 +57,9 @@ class ArticlesController < ApplicationController
 
   def list_articles
     if admin_or_mentor_login?
-      Article.order(created_at: :desc).page(params[:page])
+      Article.includes(user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page])
     else
-      Article.where(wip: false).order(created_at: :desc).page(params[:page])
+      Article.includes(user: { avatar_attachment: :blob }).where(wip: false).order(created_at: :desc).page(params[:page])
     end
   end
 

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -1,4 +1,5 @@
 - title 'ブログ記事一覧'
+= render '/head/fontawsome'
 
 .articles
   header.articles__header
@@ -31,3 +32,4 @@
                           = l(article.created_at)
                         - else
                           = l(article.published_at)
+      = paginate @articles

--- a/db/fixtures/articles.yml
+++ b/db/fixtures/articles.yml
@@ -55,3 +55,13 @@ article3:
     物理マシンでしたらインストールCD（やUSB）をマシンに入れてインストールしますが、仮想マシンの場合は、仮想のCDドライブにCDイメージをセットしてインストールします。
   user: komagata
   wip: true
+
+<% (4..20).each do |id| %>
+article<%= id %>:
+  title: test title<%= id %>
+  body: |-
+    test body<%= id %>
+  user: komagata
+  wip: false
+  published_at: "2022-03-14 00:00:00"
+<% end %>

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -24,3 +24,12 @@ article4:
   body: 本文４
   user: komagata
   wip: false
+
+<% (5..11).each do |id| %>
+article<%= id %>:
+  title: タイトル<%= id %>
+  body: 本文<%= id %>
+  user: komagata
+  wip: false
+  published_at: "2022-03-16 00:00:00"
+<% end %>

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -24,12 +24,3 @@ article4:
   body: 本文４
   user: komagata
   wip: false
-
-<% (5..11).each do |id| %>
-article<%= id %>:
-  title: タイトル<%= id %>
-  body: 本文<%= id %>
-  user: komagata
-  wip: false
-  published_at: "2022-03-16 00:00:00"
-<% end %>

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -126,13 +126,6 @@ class ArticlesTest < ApplicationSystemTestCase
   end
 
   test 'show pagination' do
-    Article.delete_all
-    user = users(:komagata)
-    number_of_pages = Article.page(1).limit_value + 1
-    number_of_pages.times do
-      Article.create(title: 'test title', body: 'test body', user_id: user.id, wip: false, published_at: Time.current)
-    end
-
     visit_with_auth articles_url, 'komagata'
     find 'nav.pagination'
   end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -93,6 +93,7 @@ class ArticlesTest < ApplicationSystemTestCase
     end
 
     visit_with_auth articles_url, 'kimura'
+    find('.pagination__item .is-last').click
     assert_text @article3.title
     assert_no_text 'WIP'
     assert_no_text '執筆中'

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -8,12 +8,11 @@ class ArticlesTest < ApplicationSystemTestCase
     @article3 = articles(:article3)
   end
 
-  # 仮デザインなので一時的に無効化
-  # test 'show listing articles' do
-  #   login_user 'komagata', 'testtest'
-  #   visit_with_auth articles_url
-  #   assert_text 'ブログ記事一覧'
-  # end
+  test 'show listing articles' do
+    login_user 'komagata', 'testtest'
+    visit_with_auth articles_url
+    assert_text 'ブログ記事一覧'
+  end
 
   test 'create article' do
     visit_with_auth new_article_url, 'komagata'
@@ -124,5 +123,17 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_selector 'head', visible: false do
       assert_selector "meta[name='robots'][content='none']", visible: false
     end
+  end
+
+  test 'show pagination' do
+    Article.delete_all
+    user = users(:komagata)
+    number_of_pages = Article.page(1).limit_value + 1
+    number_of_pages.times do
+      Article.create(title: 'test title', body: 'test body', user_id: user.id, wip: false, published_at: Time.current)
+    end
+
+    visit_with_auth articles_url, 'komagata'
+    find 'nav.pagination'
   end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -93,7 +93,6 @@ class ArticlesTest < ApplicationSystemTestCase
     end
 
     visit_with_auth articles_url, 'kimura'
-    find('.pagination__item .is-last').click
     assert_text @article3.title
     assert_no_text 'WIP'
     assert_no_text '執筆中'
@@ -127,6 +126,13 @@ class ArticlesTest < ApplicationSystemTestCase
   end
 
   test 'show pagination' do
+    Article.delete_all
+    user = users(:komagata)
+    number_of_pages = Article.page(1).limit_value + 1
+    number_of_pages.times do
+      Article.create(title: 'test title', body: 'test body', user_id: user.id, wip: false, published_at: Time.current)
+    end
+
     visit_with_auth articles_url, 'komagata'
     find 'nav.pagination'
   end


### PR DESCRIPTION
- #4277 
- good first issueからいただいたものになります！
 
## 概要

ブログ記事一覧(/articles)にページャーをつけました。

<img width="1148" alt="スクリーンショット 2022-03-15 20 11 45" src="https://user-images.githubusercontent.com/36134103/158365576-ae4c0376-1ef7-4c47-ada8-77c6fd1fd83f.png">

以前はありませんでした。ブログ全件が1ページに表示されるという状態でした。

<img width="789" alt="スクリーンショット 2022-03-15 20 25 50" src="https://user-images.githubusercontent.com/36134103/158367858-d9a5ef11-1c63-41f7-8069-2d90c759c900.png">

## やったこと
- viewでkaminariのヘルパーを使いました
- controllerでkaminariのメソッドを使いました
  - この時N+1問題が発生しないように`includes`を使用しました
- ページャーが表示されるかを確認するテストを書きました
- `db/fixtures/articles.yml`がブログ3件分しかデータがなかったので、ページャーが表示されるよう件数をかさ増ししました

## 気になったこと
- ページャーの件数
  - なぜか昔からArticleモデルに`paginates_per 10`の指定がされていましたので、現状そちらを使っています。ご希望ありましたら変更します。
- テスト
  - 他のページャー追加のPRを参考に「ページャーが表示されるか」というテストを書きましたが、テストが足りているかが少し不安になりました....😅 

## 確認方法
対象ページは http://localhost:3000/articles になります。
`db/fixtures/articles.yml`を更新していますので、`bin/setup`していただけるとブログ記事が増えた状態で確認いただけるかと思います！
