### PR TITLE
通知一覧のメンションの合計数を削除

### DIFF
--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -10,13 +10,7 @@
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
           = link_to notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip do
-            - if target == :mention
-              | #{t('notification.mention')} （#{Cache.mentioned_notification_count(current_user)}）
-              - if Cache.mentioned_and_unread_notification_count(current_user).positive?
-                .page-tabs__item-count.a-notification-count
-                  = Cache.mentioned_and_unread_notification_count(current_user)
-            - else
-              = t("notification.#{target}")
-              - if ensure_notifications?(target)
-                .page-tabs__item-count.a-notification-count
-                  = current_user.notifications.by_target(target).unreads.latest_of_each_link.size
+            = t("notification.#{target}")
+            - if ensure_notifications?(target)
+              .page-tabs__item-count.a-notification-count
+                = current_user.notifications.by_target(target).unreads.latest_of_each_link.size

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -314,17 +314,6 @@ class NotificationsTest < ApplicationSystemTestCase
     assert_no_text "mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
   end
 
-  test 'show the total number of mentions on the mentioned tab' do
-    user = users(:kimura)
-    expected_total_number_of_mentions = user.notifications.by_target(:mention).latest_of_each_link.size
-
-    visit_with_auth '/notifications', user.login_name
-
-    within '.page-tabs__item', text: 'メンション' do
-      assert_text format('メンション （%d）', expected_total_number_of_mentions)
-    end
-  end
-
   test 'show the number of unread mentions on the badge of the mentioned tab' do
     user = users(:kimura)
     expected_number_of_unread_mentions = user.notifications.by_target(:mention).unreads.latest_of_each_link.size


### PR DESCRIPTION
### Issue
- #4355

### 概要
- 通知一覧のメンションタブの合計数を削除しました。

### 参考
下記のプルリクを参照の上、不要箇所を削除しました。
[#3925](https://github.com/fjordllc/bootcamp/pull/3925)
[#3642](https://github.com/fjordllc/bootcamp/pull/3642)
[#4027](https://github.com/fjordllc/bootcamp/pull/4027)

### 変更確認方法
1. ブランチ `feature/remove-total-number-of-mention-in-notification-list`をローカルに取り込む
1. `rails s` でローカル環境を立ち上げる
1. ログイン(ローカル上では`kimura`でログインしました。)
1. 右上の通知をクリックして、全ての通知をクリック

### 変更前

![before](https://user-images.githubusercontent.com/64824195/158021658-2c3f95ff-b16e-4b42-b2a5-b0a11a66ecb4.jpg)

### 変更後

![after](https://user-images.githubusercontent.com/64824195/158021756-781c879b-ec8f-4ab5-b073-d1cf9c269a16.jpg)
