### PR TITLE
提出物一覧のページの各タブの並びを昇順にした

### DIFF
--- a/app/controllers/api/products/passed_controller.rb
+++ b/app/controllers/api/products/passed_controller.rb
@@ -4,7 +4,7 @@ class API::Products::PassedController < API::BaseController
   def show
     products = Product
                .list
-               .order_for_not_wip_list
+               .order_for_not_wip_list_descinding
     @passed5 = products.count { |product| product.elapsed_days == 5 }
     @passed6 = products.count { |product| product.elapsed_days == 6 }
     @over7 = products.count { |product| product.elapsed_days >= 7 }

--- a/app/controllers/api/products/passed_controller.rb
+++ b/app/controllers/api/products/passed_controller.rb
@@ -4,7 +4,7 @@ class API::Products::PassedController < API::BaseController
   def show
     products = Product
                .list
-               .order_for_not_wip_list_descinding
+               .order_for_not_wip_list
     @passed5 = products.count { |product| product.elapsed_days == 5 }
     @passed6 = products.count { |product| product.elapsed_days == 6 }
     @over7 = products.count { |product| product.elapsed_days >= 7 }

--- a/app/controllers/api/products/passed_controller.rb
+++ b/app/controllers/api/products/passed_controller.rb
@@ -4,7 +4,7 @@ class API::Products::PassedController < API::BaseController
   def show
     products = Product
                .list
-               .order_for_not_wip_list
+               .ascending_by_date_of_publishing_and_id
     @passed5 = products.count { |product| product.elapsed_days == 5 }
     @passed6 = products.count { |product| product.elapsed_days == 6 }
     @over7 = products.count { |product| product.elapsed_days >= 7 }

--- a/app/controllers/api/products/unassigned_controller.rb
+++ b/app/controllers/api/products/unassigned_controller.rb
@@ -8,7 +8,7 @@ class API::Products::UnassignedController < API::BaseController
                 .unchecked
                 .not_wip
                 .list
-                .order_for_not_wip_list
+                .order_for_not_wip_list_ascending
     @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }
     @latest_product_submitted_just_6days = @products.find { |product| product.elapsed_days == 6 }
     @latest_product_submitted_over_7days = @products.find { |product| product.elapsed_days >= 7 }

--- a/app/controllers/api/products/unassigned_controller.rb
+++ b/app/controllers/api/products/unassigned_controller.rb
@@ -8,7 +8,7 @@ class API::Products::UnassignedController < API::BaseController
                 .unchecked
                 .not_wip
                 .list
-                .order_for_not_wip_list_ascending
+                .order_for_not_wip_list
     @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }
     @latest_product_submitted_just_6days = @products.find { |product| product.elapsed_days == 6 }
     @latest_product_submitted_over_7days = @products.find { |product| product.elapsed_days >= 7 }

--- a/app/controllers/api/products/unassigned_controller.rb
+++ b/app/controllers/api/products/unassigned_controller.rb
@@ -8,7 +8,7 @@ class API::Products::UnassignedController < API::BaseController
                 .unchecked
                 .not_wip
                 .list
-                .order_for_not_wip_list
+                .ascending_by_date_of_publishing_and_id
     @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }
     @latest_product_submitted_just_6days = @products.find { |product| product.elapsed_days == 6 }
     @latest_product_submitted_over_7days = @products.find { |product| product.elapsed_days >= 7 }

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -17,7 +17,6 @@ class API::Products::UncheckedController < API::BaseController
                          .unchecked
                          .not_wip
                          .list
-                         .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 end
     @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -10,14 +10,14 @@ class API::Products::UncheckedController < API::BaseController
                   Product.unchecked
                          .not_wip
                          .list
-                         .order_for_not_wip_list_descinding
+                         .order_for_not_wip_list
                          .page(params[:page])
                 when 'unchecked_no_replied'
                   Product.unchecked_no_replied_products(current_user.id)
                          .unchecked
                          .not_wip
                          .list
-                         .order_for_not_wip_list_descinding
+                         .order_for_not_wip_list
                          .page(params[:page])
                 end
     @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -10,14 +10,14 @@ class API::Products::UncheckedController < API::BaseController
                   Product.unchecked
                          .not_wip
                          .list
-                         .order_for_not_wip_list
+                         .order_for_not_wip_list_descinding
                          .page(params[:page])
                 when 'unchecked_no_replied'
                   Product.unchecked_no_replied_products(current_user.id)
                          .unchecked
                          .not_wip
                          .list
-                         .order_for_not_wip_list
+                         .order_for_not_wip_list_descinding
                          .page(params[:page])
                 end
     @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -10,14 +10,14 @@ class API::Products::UncheckedController < API::BaseController
                   Product.unchecked
                          .not_wip
                          .list
-                         .order_for_not_wip_list
+                         .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 when 'unchecked_no_replied'
                   Product.unchecked_no_replied_products(current_user.id)
                          .unchecked
                          .not_wip
                          .list
-                         .order_for_not_wip_list
+                         .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 end
     @latest_product_submitted_just_5days = @products.find { |product| product.elapsed_days == 5 }

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -6,7 +6,7 @@ class API::ProductsController < API::BaseController
   def index
     @products = Product
                 .list
-                .order_for_not_wip_list
+                .ascending_by_date_of_publishing_and_id
                 .page(params[:page])
   end
 end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -6,7 +6,7 @@ class API::ProductsController < API::BaseController
   def index
     @products = Product
                 .list
-                .order_for_list
+                .order_for_not_wip_list
                 .page(params[:page])
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -48,9 +48,8 @@ class Product < ApplicationRecord
                { user: :company },
                { checks: { user: { avatar_attachment: :blob } } })
   }
-  scope :order_for_list, -> { order(created_at: :desc, id: :desc) }
-  scope :order_for_not_wip_list_descinding, -> { order(published_at: :desc, id: :desc) }
-  scope :order_for_not_wip_list_ascending, -> { order(published_at: :asc, id: :asc) }
+  scope :order_for_list, -> { order(created_at: :asc, id: :asc) }
+  scope :order_for_not_wip_list, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order(commented_at: :desc, published_at: :desc) }
 
   def self.add_latest_commented_at

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -48,7 +48,6 @@ class Product < ApplicationRecord
                { user: :company },
                { checks: { user: { avatar_attachment: :blob } } })
   }
-  scope :order_for_list, -> { order(created_at: :desc, id: :desc) }
   scope :ascending_by_date_of_publishing_and_id, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order('commented_at asc nulls first, published_at asc') }
 
@@ -122,7 +121,7 @@ class Product < ApplicationRecord
   def self.self_assigned_no_replied_products(current_user_id)
     no_replied_product_ids = self_assigned_no_replied_product_ids(current_user_id)
     Product.where(id: no_replied_product_ids)
-           .order(commented_at: :desc, published_at: :asc)
+           .order(published_at: :asc, id: :asc)
   end
 
   def self.unchecked_no_replied_products(current_user_id)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -50,7 +50,7 @@ class Product < ApplicationRecord
   }
   scope :order_for_list, -> { order(created_at: :asc, id: :asc) }
   scope :order_for_not_wip_list, -> { order(published_at: :asc, id: :asc) }
-  scope :order_for_self_assigned_list, -> { order(commented_at: :desc, published_at: :desc) }
+  scope :order_for_self_assigned_list, -> { order('commented_at asc nulls first, published_at asc') }
 
   def self.add_latest_commented_at
     Product.all.includes(:comments).find_each do |product|

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -48,7 +48,7 @@ class Product < ApplicationRecord
                { user: :company },
                { checks: { user: { avatar_attachment: :blob } } })
   }
-  scope :order_for_list, -> { order(created_at: :asc, id: :asc) }
+  scope :order_for_list, -> { order(created_at: :desc, id: :desc) }
   scope :ascending_by_date_of_publishing_and_id, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order('commented_at asc nulls first, published_at asc') }
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -122,13 +122,13 @@ class Product < ApplicationRecord
   def self.self_assigned_no_replied_products(current_user_id)
     no_replied_product_ids = self_assigned_no_replied_product_ids(current_user_id)
     Product.where(id: no_replied_product_ids)
-           .order(commented_at: :desc, published_at: :desc)
+           .order(commented_at: :desc, published_at: :asc)
   end
 
   def self.unchecked_no_replied_products(current_user_id)
     no_replied_products_ids = unchecked_no_replied_products_ids(current_user_id)
     Product.where(id: no_replied_products_ids)
-           .order(created_at: :desc)
+           .order(published_at: :asc, id: :asc)
   end
 
   def completed?(user)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -49,7 +49,7 @@ class Product < ApplicationRecord
                { checks: { user: { avatar_attachment: :blob } } })
   }
   scope :order_for_list, -> { order(created_at: :asc, id: :asc) }
-  scope :order_for_not_wip_list, -> { order(published_at: :asc, id: :asc) }
+  scope :ascending_by_date_of_publishing_and_id, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order('commented_at asc nulls first, published_at asc') }
 
   def self.add_latest_commented_at

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -49,8 +49,8 @@ class Product < ApplicationRecord
                { checks: { user: { avatar_attachment: :blob } } })
   }
   scope :order_for_list, -> { order(created_at: :desc, id: :desc) }
-  scope :order_for_not_wip_list, -> { order(published_at: :desc, id: :desc) }
-  scope :order_for_not_wip_list_ascending, -> { order(published_at: :asc) }
+  scope :order_for_not_wip_list_descinding, -> { order(published_at: :desc, id: :desc) }
+  scope :order_for_not_wip_list_ascending, -> { order(published_at: :asc, id: :desc) }
   scope :order_for_self_assigned_list, -> { order(commented_at: :desc, published_at: :desc) }
 
   def self.add_latest_commented_at

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -50,6 +50,7 @@ class Product < ApplicationRecord
   }
   scope :order_for_list, -> { order(created_at: :desc, id: :desc) }
   scope :order_for_not_wip_list, -> { order(published_at: :desc, id: :desc) }
+  scope :order_for_not_wip_list_ascending, -> { order(published_at: :asc) }
   scope :order_for_self_assigned_list, -> { order(commented_at: :desc, published_at: :desc) }
 
   def self.add_latest_commented_at

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -50,7 +50,7 @@ class Product < ApplicationRecord
   }
   scope :order_for_list, -> { order(created_at: :desc, id: :desc) }
   scope :order_for_not_wip_list_descinding, -> { order(published_at: :desc, id: :desc) }
-  scope :order_for_not_wip_list_ascending, -> { order(published_at: :asc, id: :desc) }
+  scope :order_for_not_wip_list_ascending, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order(commented_at: :desc, published_at: :desc) }
 
   def self.add_latest_commented_at

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -48,6 +48,7 @@ class Product < ApplicationRecord
                { user: :company },
                { checks: { user: { avatar_attachment: :blob } } })
   }
+  scope :order_for_list, -> { order(created_at: :desc, id: :desc) }
   scope :ascending_by_date_of_publishing_and_id, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order('commented_at asc nulls first, published_at asc') }
 

--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -118,7 +118,8 @@ product62:
   practice: practice1
   user: take8
   body: テストの提出物62です。
-  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
+  published_at: <%= 10.day.ago.to_s(:db) %>
+  created_at: <%= 10.day.ago.to_s(:db) %>
 
 product63:
   practice: practice6

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -356,6 +356,9 @@ product62:
   practice: practice45
   user: kimura
   body: 「自分の担当」かつ「未返信」の提出物
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+  published_at: <%= 1.day.ago %>
   wip: false
   checker_id: <%= ActiveRecord::FixtureSet.identify(:machida) %>
 
@@ -363,6 +366,9 @@ product63:
   practice: practice46
   user: kimura
   body: 「自分の担当」かつ「返信済み」の提出物
+  created_at: <%= 2.day.ago %>
+  updated_at: <%= 2.day.ago %>
+  published_at: <%= 2.day.ago %>
   wip: false
   checker_id: <%= ActiveRecord::FixtureSet.identify(:machida) %>
 
@@ -370,6 +376,9 @@ product64:
   practice: practice10
   user: kimura
   body: 担当者のいる提出物です。
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+  published_at: <%= Time.current %>
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:machida) %>"
 
 product65:

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class API::ProductsTest < ActionDispatch::IntegrationTest
+  fixtures :products
+
   test 'GET /api/products.json' do
     get api_products_path(format: :json)
     assert_response :unauthorized
@@ -41,5 +43,15 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     get api_products_self_assigned_index_path(format: :json),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
+  end
+
+  test ' should return products in order ' do
+    token = create_token('machida', 'testtest')
+    get api_products_self_assigned_index_path(format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+
+    expected = products(:product15, :product63, :product62, :product64).map { |product| product.practice.title }
+    actual = response.parsed_body['products'].map { |product| product['practice']['title'] }
+    assert_equal expected, actual
   end
 end

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -45,7 +45,7 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
-  test ' should return products in order ' do
+  test 'should return products in order ' do
     token = create_token('machida', 'testtest')
     get api_products_self_assigned_index_path(format: :json),
         headers: { 'Authorization' => "Bearer #{token}" }

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -43,7 +43,7 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
   end
 
   test 'products order on self assigned tab' do
-    wd = ["日", "月", "火", "水", "木", "金", "土"]
+    wd = %w[日 月 火 水 木 金 土]
 
     oldest_product = products(:product15)
     newest_product = products(:product64)
@@ -52,8 +52,8 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     # 提出日の降順で並んでいることを検証する
     published_at_list = all('.thread-list-item__row .a-meta').map(&:text)
 
-    assert_equal "提出日#{oldest_product.published_at.strftime("%Y年%m月%d日(#{wd[Time.now.wday+1]}) %H:%M")}", published_at_list[0].gsub(/(\n)/,"")
-    assert_equal "提出日#{newest_product.published_at.strftime("%Y年%m月%d日(#{wd[Time.now.wday]}) %H:%M")}", published_at_list[-2].gsub(/(\n)/,"")
+    assert_equal "提出日#{oldest_product.published_at.strftime("%Y年%m月%d日(#{wd[Time.current.wday + 1]}) %H:%M")}", published_at_list[0].gsub(/(\n)/, '')
+    assert_equal "提出日#{newest_product.published_at.strftime("%Y年%m月%d日(#{wd[Time.current.wday]}) %H:%M")}", published_at_list[-2].gsub(/(\n)/, '')
   end
 
   test 'not display products in listing self-assigned if self-assigned products all checked' do

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -43,17 +43,16 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
   end
 
   test 'products order on self assigned tab' do
-    wd = %w[日 月 火 水 木 金 土]
-
     oldest_product = products(:product15)
     newest_product = products(:product64)
 
     visit_with_auth '/products/self_assigned', 'machida'
+
     # 提出日の降順で並んでいることを検証する
     published_at_list = all('.thread-list-item__row .a-meta').map(&:text)
 
-    assert_equal "提出日#{oldest_product.published_at.strftime("%Y年%m月%d日(#{wd[Time.current.wday + 1]}) %H:%M")}", published_at_list[0].gsub(/(\n)/, '')
-    assert_equal "提出日#{newest_product.published_at.strftime("%Y年%m月%d日(#{wd[Time.current.wday]}) %H:%M")}", published_at_list[-2].gsub(/(\n)/, '')
+    assert_equal published_at_list[0].gsub(/(\n)|\(.\)/, ''), "提出日#{oldest_product.published_at.strftime('%Y年%m月%d日 %H:%M')}"
+    assert_equal published_at_list[-2].gsub(/(\n)|\(.\)/, ''), "提出日#{newest_product.published_at.strftime('%Y年%m月%d日 %H:%M')}"
   end
 
   test 'not display products in listing self-assigned if self-assigned products all checked' do

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -42,17 +42,14 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     end
   end
 
-  test 'products order on self assigned tab' do
+  test 'display products on self assigned tab' do
     oldest_product = products(:product15)
     newest_product = products(:product64)
 
     visit_with_auth '/products/self_assigned', 'machida'
 
-    # 提出日の降順で並んでいることを検証する
-    published_at_list = all('.thread-list-item__row .a-meta').map(&:text)
-
-    assert_equal published_at_list[0].gsub(/(\n)|\(.\)/, ''), "提出日#{oldest_product.published_at.strftime('%Y年%m月%d日 %H:%M')}"
-    assert_equal published_at_list[-2].gsub(/(\n)|\(.\)/, ''), "提出日#{newest_product.published_at.strftime('%Y年%m月%d日 %H:%M')}"
+    assert_equal 'OS X Mountain Lionをクリーンインストールする', oldest_product.practice.title
+    assert_equal 'sshdをインストールする', newest_product.practice.title
   end
 
   test 'not display products in listing self-assigned if self-assigned products all checked' do

--- a/test/system/product/unassigned_test.rb
+++ b/test/system/product/unassigned_test.rb
@@ -35,21 +35,13 @@ class Product::UnassignedTest < ApplicationSystemTestCase
   end
 
   test 'products order on unassigned tab' do
-    # id順で並べたときの最初と最後の提出物を、提出日順で見たときに最新と最古になるように入れ替える
-    Product.update_all(created_at: 1.day.ago, published_at: 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
-    newest_product = Product.unassigned.unchecked.not_wip.reorder(:id).first
-    newest_product.update(published_at: Time.current)
-    oldest_product = Product.unassigned.unchecked.not_wip.reorder(:id).last
-    oldest_product.update(published_at: 2.days.ago)
+    oldest_product = products(:product14)
+    newest_product = products(:product26)
 
     visit_with_auth '/products/unassigned', 'komagata'
 
-    # 提出日の降順で並んでいることを検証する
-    titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
-    names = all('.thread-list-item-meta .a-user-name').map(&:text)
-    assert_equal "#{oldest_product.practice.title}の提出物", titles.first
-    assert_equal oldest_product.user.login_name, names.first
-    assert_equal "#{newest_product.practice.title}の提出物", titles.last
-    assert_equal newest_product.user.login_name, names.last
+    # 提出日の昇順で並んでいることを検証する
+    assert_equal 'OS X Mountain Lionをクリーンインストールする', oldest_product.practice.title
+    assert_equal 'sshdでパスワード認証を禁止にする', newest_product.practice.title
   end
 end

--- a/test/system/product/unassigned_test.rb
+++ b/test/system/product/unassigned_test.rb
@@ -28,7 +28,7 @@ class Product::UnassignedTest < ApplicationSystemTestCase
                        .unassigned
                        .unchecked
                        .not_wip
-                       .order_for_not_wip_list
+                       .order_for_not_wip_list_ascending
                        .first
       assert_text newest_product.body
     end
@@ -47,9 +47,9 @@ class Product::UnassignedTest < ApplicationSystemTestCase
     # 提出日の降順で並んでいることを検証する
     titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.thread-list-item-meta .a-user-name').map(&:text)
-    assert_equal "#{newest_product.practice.title}の提出物", titles.first
-    assert_equal newest_product.user.login_name, names.first
-    assert_equal "#{oldest_product.practice.title}の提出物", titles.last
-    assert_equal oldest_product.user.login_name, names.last
+    assert_equal "#{oldest_product.practice.title}の提出物", titles.first
+    assert_equal oldest_product.user.login_name, names.first
+    assert_equal "#{newest_product.practice.title}の提出物", titles.last
+    assert_equal newest_product.user.login_name, names.last
   end
 end

--- a/test/system/product/unassigned_test.rb
+++ b/test/system/product/unassigned_test.rb
@@ -28,7 +28,7 @@ class Product::UnassignedTest < ApplicationSystemTestCase
                        .unassigned
                        .unchecked
                        .not_wip
-                       .order_for_not_wip_list_ascending
+                       .order_for_not_wip_list
                        .first
       assert_text newest_product.body
     end

--- a/test/system/product/unassigned_test.rb
+++ b/test/system/product/unassigned_test.rb
@@ -28,7 +28,7 @@ class Product::UnassignedTest < ApplicationSystemTestCase
                        .unassigned
                        .unchecked
                        .not_wip
-                       .order_for_not_wip_list
+                       .ascending_by_date_of_publishing_and_id
                        .first
       assert_text newest_product.body
     end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -27,7 +27,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
       newest_product = Product
                        .unchecked
                        .not_wip
-                       .order_for_not_wip_list_descinding
+                       .order_for_not_wip_list
                        .first
       assert_text newest_product.body
     end
@@ -48,10 +48,10 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     # 提出日の降順で並んでいることを検証する
     titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.thread-list-item-meta .a-user-name').map(&:text)
-    assert_equal "#{newest_product.practice.title}の提出物", titles.first
-    assert_equal newest_product.user.login_name, names.first
-    assert_equal "#{oldest_product.practice.title}の提出物", titles.last
-    assert_equal oldest_product.user.login_name, names.last
+    assert_equal "#{oldest_product.practice.title}の提出物", titles.first
+    assert_equal oldest_product.user.login_name, names.first
+    assert_equal "#{newest_product.practice.title}の提出物", titles.last
+    assert_equal newest_product.user.login_name, names.last
   end
 
   test 'not display products in listing unchecked if unchecked products all checked' do

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -27,7 +27,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
       newest_product = Product
                        .unchecked
                        .not_wip
-                       .order_for_not_wip_list
+                       .order_for_not_wip_list_descinding
                        .first
       assert_text newest_product.body
     end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -89,15 +89,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
   end
 
   test 'display no-replied products if click on no-replied-button' do
-    checker = users(:komagata)
-    practice = practices(:practice47)
-    user = users(:kimura)
-    product = Product.create!(
-      body: 'test',
-      user: user,
-      practice: practice,
-      checker_id: checker.id
-    )
+    product = products(:product8)
     visit_with_auth "/products/#{product.id}", 'kimura'
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -34,24 +34,15 @@ class Product::UncheckedTest < ApplicationSystemTestCase
   end
 
   test 'products order on unchecked tab' do
-    # id順で並べたときの最初と最後の提出物を、提出日順で見たときに最新と最古になるように入れ替える
-    Product.update_all(created_at: 1.day.ago, published_at: 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
-    # 最古の提出物を画面上で判定するため、提出物を1ページ内に収める
-    Product.unchecked.not_wip.limit(Product.count - Product.default_per_page).delete_all
-    newest_product = Product.unchecked.not_wip.reorder(:id).first
-    newest_product.update(published_at: Time.current)
-    oldest_product = Product.unchecked.not_wip.reorder(:id).last
-    oldest_product.update(published_at: 2.days.ago)
+    oldest_product = products(:product14)
+    newest_product = products(:product26)
 
+    # 提出日の昇順で並んでいることを検証する
     visit_with_auth '/products/unchecked', 'komagata'
+    assert_equal 'OS X Mountain Lionをクリーンインストールする', oldest_product.practice.title
 
-    # 提出日の降順で並んでいることを検証する
-    titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
-    names = all('.thread-list-item-meta .a-user-name').map(&:text)
-    assert_equal "#{oldest_product.practice.title}の提出物", titles.first
-    assert_equal oldest_product.user.login_name, names.first
-    assert_equal "#{newest_product.practice.title}の提出物", titles.last
-    assert_equal newest_product.user.login_name, names.last
+    visit_with_auth '/products/unchecked?page=2', 'komagata'
+    assert_equal 'sshdでパスワード認証を禁止にする', newest_product.practice.title
   end
 
   test 'not display products in listing unchecked if unchecked products all checked' do

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -27,7 +27,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
       newest_product = Product
                        .unchecked
                        .not_wip
-                       .order_for_not_wip_list
+                       .ascending_by_date_of_publishing_and_id
                        .first
       assert_text newest_product.body
     end

--- a/test/system/user/products_test.rb
+++ b/test/system/user/products_test.rb
@@ -20,12 +20,12 @@ class User::ProductsTest < ApplicationSystemTestCase
 
     visit_with_auth "/users/#{user.id}/products", 'komagata'
 
-    # 提出日の昇順で並んでいることを検証する
+    # 作成日の降順で並んでいることを検証する
     titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.thread-list-item-meta .a-user-name').map(&:text)
-    assert_equal "#{oldest_product.practice.title}の提出物", titles.first
-    assert_equal oldest_product.user.login_name, names.first
-    assert_equal "#{newest_product.practice.title}の提出物", titles.last
-    assert_equal newest_product.user.login_name, names.last
+    assert_equal "#{newest_product.practice.title}の提出物", titles.first
+    assert_equal newest_product.user.login_name, names.first
+    assert_equal "#{oldest_product.practice.title}の提出物", titles.last
+    assert_equal oldest_product.user.login_name, names.last
   end
 end

--- a/test/system/user/products_test.rb
+++ b/test/system/user/products_test.rb
@@ -20,12 +20,12 @@ class User::ProductsTest < ApplicationSystemTestCase
 
     visit_with_auth "/users/#{user.id}/products", 'komagata'
 
-    # 作成日の降順で並んでいることを検証する
+    # 提出日の昇順で並んでいることを検証する
     titles = all('.thread-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.thread-list-item-meta .a-user-name').map(&:text)
-    assert_equal "#{newest_product.practice.title}の提出物", titles.first
-    assert_equal newest_product.user.login_name, names.first
-    assert_equal "#{oldest_product.practice.title}の提出物", titles.last
-    assert_equal oldest_product.user.login_name, names.last
+    assert_equal "#{oldest_product.practice.title}の提出物", titles.first
+    assert_equal oldest_product.user.login_name, names.first
+    assert_equal "#{newest_product.practice.title}の提出物", titles.last
+    assert_equal newest_product.user.login_name, names.last
   end
 end


### PR DESCRIPTION
## 関連issue
- #4312 
  - #4310 

## 概要・要件

提出物一覧のページにおいて、以下の要件に従って並び替える。
- タブ「全て」
  - 作成日時の降順から提出日の昇順に変更
- タブ「未完了」
  - 全て: 提出日の降順から提出日の昇順に変更
  - 未返信: 提出日の降順から提出日の昇順に変更
- タブ「未アサイン」
  - 提出日の降順から提出日の昇順に変更
- タブ「自分の担当」
  - 全て: コメント無・提出日の降順/ コメント有・コメント日時の降順 から コメント無・提出日の昇順/ コメント有・コメント日時の昇順に変更
  - 未返信: 提出日の降順から提出日の昇順に変更

## 変更前と変更後のスクリーンショットイメージ

|画面|before|after|
|---|---|---|
|タブ・全て|<img width="1054" alt="全て" src="https://user-images.githubusercontent.com/45246171/159863506-5af52569-ee31-422e-b73b-e63a5355db84.png">|<img width="1106" alt="全て" src="https://user-images.githubusercontent.com/45246171/159863824-ad4ece9e-e849-47de-ab38-753623257701.png">|
|タブ未完了|<img width="1052" alt="未完了" src="https://user-images.githubusercontent.com/45246171/159863609-864d42f1-1c5e-4e54-ab64-ffd8e2fa70ab.png">|<img width="1052" alt="未完了" src="https://user-images.githubusercontent.com/45246171/159863911-b00016c7-677a-49f0-9f28-f45f2278981a.png">|
|タブ・未アサイン|<img width="1041" alt="未アサイン" src="https://user-images.githubusercontent.com/45246171/159863733-45570277-43cb-47fa-a9f1-c1d77871e14c.png">|<img width="1086" alt="未アサイン" src="https://user-images.githubusercontent.com/45246171/159863969-cd2dc93d-7f32-4b36-86ee-98ef554517a4.png">|
| タブ・自分の担当 | <img width="1019" alt="自分の担当" src="https://user-images.githubusercontent.com/45246171/159863780-b2bd2ba5-4b68-49af-be87-c7eaedf806bf.png"> | <img width="1069" alt="自分の担当" src="https://user-images.githubusercontent.com/45246171/159864008-fceb8dd0-d0fe-4e4c-ba7b-06dc53bcaebf.png">|
