### PR TITLE
[相談部屋] 管理者が見る相談部屋一覧の各相談部屋に、最新コメントの投稿日時と投稿者を出す

### DIFF
--- a/app/javascript/talk.vue
+++ b/app/javascript/talk.vue
@@ -16,6 +16,27 @@
               itemprop='url'
             )
               | {{ user.long_name }} さんの相談部屋
+      hr.thread-list-item__row-separator(v-if='talk.hasAnyComments')
+      .thread-list-item__row(v-if='talk.hasAnyComments')
+        .thread-list-item-meta__items
+          .thread-list-item-meta__item
+            .thread-list-item-comment
+              .thread-list-item-comment__label
+                | コメント ({{ talk.numberOfComments }})
+              .thread-list-item-comment__user-icons
+                img.a-user-icon(:src='talk.lastCommentUserIcon')
+              .thread-list-item-comment__label
+                | 〜 {{ talk.lastCommentTime }}
+              .thread-list-item-comment__label(
+                v-if='talk.lastCommentUser.mentor'
+              )
+                | (メンター)
+              .thread-list-item-comment__label(
+                v-else-if='talk.lastCommentUser.admin'
+              )
+                | (アドミン)
+              .thread-list-item-comment__label(v-else)
+                | ({{ user.login_name }})
 </template>
 <script>
 import UserIcon from './user-icon'

--- a/app/javascript/talk.vue
+++ b/app/javascript/talk.vue
@@ -16,19 +16,19 @@
               itemprop='url'
             )
               | {{ user.long_name }} さんの相談部屋
-      hr.thread-list-item__row-separator(v-if='talk.hasAnyComments')
-      .thread-list-item__row(v-if='talk.hasAnyComments')
+      hr.thread-list-item__row-separator(v-if='talk.has_any_comments')
+      .thread-list-item__row(v-if='talk.has_any_comments')
         .thread-list-item-meta__items
           .thread-list-item-meta__item
             .thread-list-item-comment
               .thread-list-item-comment__label
-                | コメント ({{ talk.numberOfComments }})
+                | コメント ({{ talk.number_of_comments }})
               .thread-list-item-comment__user-icons
-                img.a-user-icon(:src='talk.lastCommentUserIcon')
+                img.a-user-icon(:src='talk.last_comment_user_icon')
               .thread-list-item-comment__label
-                | 〜 {{ talk.lastCommentTime }}
+                | 〜 {{ talk.last_commented_at }}
               .thread-list-item-comment__label(
-                v-if='talk.lastCommentUser.admin'
+                v-if='talk.last_comment_user.admin'
               )
                 | (管理者)
               .thread-list-item-comment__label(v-else)

--- a/app/javascript/talk.vue
+++ b/app/javascript/talk.vue
@@ -28,13 +28,9 @@
               .thread-list-item-comment__label
                 | 〜 {{ talk.lastCommentTime }}
               .thread-list-item-comment__label(
-                v-if='talk.lastCommentUser.mentor'
+                v-if='talk.lastCommentUser.admin'
               )
-                | (メンター)
-              .thread-list-item-comment__label(
-                v-else-if='talk.lastCommentUser.admin'
-              )
-                | (アドミン)
+                | (管理者)
               .thread-list-item-comment__label(v-else)
                 | ({{ user.login_name }})
 </template>

--- a/app/views/api/talks/index.json.jbuilder
+++ b/app/views/api/talks/index.json.jbuilder
@@ -1,6 +1,13 @@
 json.talks do
   json.array! @users_talks do |talk|
     json.partial! "api/talks/talk", talk: talk
+    json.hasAnyComments talk.comments.present?
+    if talk.comments.present?
+      json.numberOfComments talk.comments.size
+      json.lastCommentUser talk.comments.last.user
+      json.lastCommentUserIcon talk.comments.last.user.avatar_url
+      json.lastCommentTime l talk.comments.last.updated_at
+    end
   end
 end
 

--- a/app/views/api/talks/index.json.jbuilder
+++ b/app/views/api/talks/index.json.jbuilder
@@ -1,12 +1,12 @@
 json.talks do
   json.array! @users_talks do |talk|
     json.partial! "api/talks/talk", talk: talk
-    json.hasAnyComments talk.comments.present?
+    json.has_any_comments talk.comments.present?
     if talk.comments.present?
-      json.numberOfComments talk.comments.size
-      json.lastCommentUser talk.comments.last.user
-      json.lastCommentUserIcon talk.comments.last.user.avatar_url
-      json.lastCommentTime l talk.comments.last.updated_at
+      json.number_of_comments talk.comments.size
+      json.last_comment_user talk.comments.last.user
+      json.last_comment_user_icon talk.comments.last.user.avatar_url
+      json.last_commented_at l talk.comments.last.updated_at
     end
   end
 end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -125,5 +125,5 @@ comment<%= i + 19 %>:
 commentOfTalk:
   user: komagata
   commentable: talk1 (Talk)
-  description: |-
-    これは相談部屋の会話です。
+  description: "これは相談部屋の会話です。"
+  updated_at: "2019-01-02 00:00:00 JST"

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -127,3 +127,9 @@ commentOfTalk:
   commentable: talk1 (Talk)
   description: "これは相談部屋の会話です。"
   updated_at: "2019-01-02 00:00:00 JST"
+
+commentOfTalk2:
+  user: hajime
+  commentable: talk9 (Talk)
+  description: "これは相談部屋の会話です。"
+  updated_at: "2019-01-02 00:00:00 JST"

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -142,12 +142,10 @@ class TalksTest < ApplicationSystemTestCase
   end
 
   test 'Display number of comments, detail of lastest comment user' do
-    visit_with_auth '/talks?target=mentor', 'komagata'
-    find('#talks.loaded', wait: 10)
+    visit_with_auth '/talks', 'komagata'
     assert_text 'コメント'
     assert_text '(1)'
-    assert_selector 'img[class="a-user-icon"]'
     assert_text '2019年01月02日(水) 00:00'
-    assert_text 'メンター'
+    assert_selector '.thread-list-item-comment', text: '(hajime)'
   end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -143,7 +143,7 @@ class TalksTest < ApplicationSystemTestCase
 
   test 'Display number of comments, detail of lastest comment user' do
     visit_with_auth '/talks', 'komagata'
-    within ('.thread-list-item-comment') do
+    within('.thread-list-item-comment') do
       assert_text 'コメント'
       assert_selector 'img[class="a-user-icon"]'
       assert_text '(1)'

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -140,4 +140,14 @@ class TalksTest < ApplicationSystemTestCase
     click_link '相談'
     assert_equal '/talks/unreplied', current_path
   end
+
+  test 'Display number of comments, detail of lastest comment user' do
+    visit_with_auth '/talks?target=mentor', 'komagata'
+    find('#talks.loaded', wait: 10)
+    assert_text 'コメント'
+    assert_text '(1)'
+    assert_selector 'img[class="a-user-icon"]'
+    assert_text '2019年01月02日(水) 00:00'
+    assert_text 'メンター'
+  end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -124,14 +124,6 @@ class TalksTest < ApplicationSystemTestCase
     assert_no_text 'kimuraさんのメモ'
   end
 
-  test 'Display number of comments, detail of lastest comment user' do
-    visit_with_auth '/talks', 'komagata'
-    assert_text 'コメント'
-    assert_text '(1)'
-    assert_text '2019年01月02日(水) 00:00'
-    assert_selector '.thread-list-item-comment', text: '(hajime)'
-  end
-
   test 'Displays a list of the 10 most recent reports' do
     user = users(:hajime)
     visit_with_auth '/talks', 'komagata'

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -124,6 +124,14 @@ class TalksTest < ApplicationSystemTestCase
     assert_no_text 'kimuraさんのメモ'
   end
 
+  test 'Display number of comments, detail of lastest comment user' do
+    visit_with_auth '/talks', 'komagata'
+    assert_text 'コメント'
+    assert_text '(1)'
+    assert_text '2019年01月02日(水) 00:00'
+    assert_selector '.thread-list-item-comment', text: '(hajime)'
+  end
+
   test 'Displays a list of the 10 most recent reports' do
     user = users(:hajime)
     visit_with_auth '/talks', 'komagata'
@@ -143,9 +151,12 @@ class TalksTest < ApplicationSystemTestCase
 
   test 'Display number of comments, detail of lastest comment user' do
     visit_with_auth '/talks', 'komagata'
-    assert_text 'コメント'
-    assert_text '(1)'
-    assert_text '2019年01月02日(水) 00:00'
-    assert_selector '.thread-list-item-comment', text: '(hajime)'
+    within ('.thread-list-item-comment') do
+      assert_text 'コメント'
+      assert_selector 'img[class="a-user-icon"]'
+      assert_text '(1)'
+      assert_text '2019年01月02日(水) 00:00'
+      assert_text '(hajime)'
+    end
   end
 end


### PR DESCRIPTION
[#4386](https://github.com/fjordllc/bootcamp/issues/4386)

## 要件
管理者でログインしたとき、相談部屋一覧の各相談部屋に、
- コメント合計数
- 最新コメントをした人のアイコン
- 最新コメント日時
- 最新コメントをした人のロール
表示する。

## 変更前
<img width="566" alt="Screen Shot 2022-03-15 at 16 52 52" src="https://user-images.githubusercontent.com/34033366/158352207-293f41a2-a794-44b6-a7ff-dcf22038ea1c.png">

## 変更後
<img width="562" alt="Screen Shot 2022-03-19 at 12 29 39" src="https://user-images.githubusercontent.com/34033366/159108465-3102393f-51b3-4f8f-a516-04b77c49b88d.png">

## 確認手順
- `feature/display-time-of-comment-in-talks-list`ブランチを手元に持ってくる。
- 管理者でログインして、相談部屋一覧ページを確認する。