### PR TITLE
メンターもブログが投稿できるようにする

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,7 +2,7 @@
 
 class ArticlesController < ApplicationController
   before_action :set_article, only: %i[show edit update destroy]
-  before_action :require_admin_login, except: %i[index show]
+  before_action :require_admin_or_mentor_login, except: %i[index show]
 
   def index
     @articles = list_articles

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -42,14 +42,14 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_no_text 'ブログ記事作成'
 
     visit new_article_path
-    assert_text '管理者としてログインしてください'
+    assert_text '管理者・メンターとしてログインしてください'
   end
 
   test "can't update article" do
     visit_with_auth articles_url, 'kimura'
 
     visit edit_article_path(@article)
-    assert_text '管理者としてログインしてください'
+    assert_text '管理者・メンターとしてログインしてください'
   end
 
   test 'save article with WIP' do
@@ -101,5 +101,28 @@ class ArticlesTest < ApplicationSystemTestCase
     click_on @article3.title
     assert_text @article3.title
     assert_text @article3.body
+  end
+
+  test 'mentor can create article' do
+    visit_with_auth new_article_url, 'mentormentaro'
+
+    fill_in 'article[title]', with: @article.title
+    fill_in 'article[body]', with: @article.body
+    click_on '登録する'
+
+    assert_text '記事を作成しました'
+  end
+
+  test 'mentor can see WIP label on index and show' do
+    visit_with_auth articles_path, 'mentormentaro'
+    assert_text 'WIP'
+    assert_text '執筆中'
+
+    click_on @article3.title
+    assert_text 'WIP'
+    assert_text '執筆中'
+    assert_selector 'head', visible: false do
+      assert_selector "meta[name='robots'][content='none']", visible: false
+    end
   end
 end


### PR DESCRIPTION
[#4403](https://github.com/fjordllc/bootcamp/issues/4403)
## 要件
adminしかブログが投稿できないのですが、mentorも投稿できるようにする。
WIPのブログ記事もadminしか見れないのですが、mentorも見れるようにする。

## 変更前
`http://localhost:3000/articles/new`をアクセスすると
<img width="1369" alt="Screen Shot 2022-03-15 at 18 52 27" src="https://user-images.githubusercontent.com/34033366/158372284-be2852b6-3f49-44c0-a33a-e6546fe57336.png">

## 変更後
`http://localhost:3000/articles/new`をアクセスすると

<img width="1365" alt="Screen Shot 2022-03-15 at 18 45 35" src="https://user-images.githubusercontent.com/34033366/158371204-76ca47ce-907b-46bb-9e8e-0e6f549178dd.png">

## 確認手順
- `feature/allow-mentors-to-create-and-view-wip-articles`ブランチを手元に持ってくる。
- mentorとしてログインして
   - `http://localhost:3000/articles/new`をアクセスして、ブログが投稿の機能を確認する。
   - `http://localhost:3000/articles/`をアクセスして、WIPのブログ記事が表示されることを確認する。