### PR TITLE
Docsに存在しないスラッグでアクセスした時404エラーを表示

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -57,7 +57,7 @@ class PagesController < ApplicationController
   private
 
   def set_page
-    @page = Page.search_by_slug_or_id(params[:slug_or_id])
+    @page = Page.search_by_slug_or_id!(params[:slug_or_id])
   end
 
   def page_params

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -25,9 +25,9 @@ class Page < ApplicationRecord
 
   before_validation :empty_slug_to_nil
 
-  def self.search_by_slug_or_id(params)
+  def self.search_by_slug_or_id!(params)
     attr_name = params.start_with?(/[a-z]/) ? :slug : :id
-    Page.find_by(attr_name => params)
+    Page.find_by!(attr_name => params)
   end
 
   private

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -6,6 +6,14 @@ require 'supports/tag_helper'
 class PagesTest < ApplicationSystemTestCase
   include TagHelper
 
+  setup do
+    @raise_server_errors = Capybara.raise_server_errors
+  end
+
+  teardown do
+    Capybara.raise_server_errors = @raise_server_errors
+  end
+
   test 'GET /pages' do
     visit_with_auth '/pages', 'kimura'
     assert_equal 'Docs | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
@@ -168,5 +176,13 @@ class PagesTest < ApplicationSystemTestCase
       assert_selector '.thread-list-item-title__icon.is-wip', text: 'WIP'
       assert_selector '.a-meta', text: 'Doc作成中'
     end
+  end
+
+  test 'show 404 page when accessed with slug does not exist in Docs' do
+    Capybara.raise_server_errors = false
+
+    slug = 'help12345'
+    visit_with_auth "/pages/#{slug}", 'kimura'
+    assert_text 'ActiveRecord::RecordNotFound'
   end
 end


### PR DESCRIPTION
## Issue
- #4338 

## 概要
Docsに存在しないスラッグでアクセスした時500エラーではなく404 Not foundへ変更しました。

## 変更確認方法
1. ブランチ`bug/show-404-page-when-accessed-with-slug-does-not-exist-in-Docs`をローカルに取り込む
2. `$ rails server`でローカル環境を立ち上げる
3. テスト用ユーザーでログイン
4. Docsに存在しないスラッグのページにアクセスしたら"Couldn't find Page"が表示されていることを確認

## 変更前
<img width="1020" alt="2022-03-16-01" src="https://user-images.githubusercontent.com/60736158/158588827-cb9a56a2-1856-48a2-82ca-8a75f0a8d65f.png">
<img width="654" alt="image" src="https://user-images.githubusercontent.com/60736158/158609491-d51ecf46-259e-4c7c-af4c-cc0489575ce5.png">

## 変更後
<img width="1020" alt="2022-03-16-02" src="https://user-images.githubusercontent.com/60736158/158588793-a55cdcce-7758-457a-885b-dcdea539798a.png">
<img width="653" alt="スクリーンショット 2022-03-16 23 11 12" src="https://user-images.githubusercontent.com/60736158/158609281-86105c6c-ebcc-415a-acf3-ac3e66b7d4a8.png">

## 補足
Capybaraのエラーでテストが失敗してしまうため、該当のテストのみ`Capybara.raise_server_errors = false`を設定してエラーが出ないようにしています。
下記は`Capybara.raise_server_errors = false`を使用するために設定しています。
```rb
  setup do
    @raise_server_errors = Capybara.raise_server_errors
  end

  teardown do
    Capybara.raise_server_errors = @raise_server_errors
  end
```

### 参考
[Railsのシステムテスト（Minitest）で「期待どおりに404エラーが発生したこと」を検証する方法 - Qiita](https://qiita.com/jnchito/items/37fcaf4486c4bdf78802)
