### PR TITLE
Q&A一覧でプラクティスで絞り込んで未解決の件数表示が変化する

### DIFF
--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -6,7 +6,8 @@
           | 未解決
           - if Question.not_solved.not_wip.count.positive? && current_user.admin?
             .page-tabs__item-count.a-notification-count
-              = Question.not_solved.not_wip.count
+              #not-solved-count
+                = params[:practice_id].present? ? Question.not_solved.where(practice_id: params[:practice_id]).size : Question.not_solved.size
       li.page-tabs__item
         = link_to '解決済み', polymorphic_path(:questions, solved: 'true', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:solved].present? ? 'is-active' : ''}"
       li.page-tabs__item

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -4,7 +4,7 @@
       li.page-tabs__item
         = link_to polymorphic_path(:questions, practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:all].present? || params[:solved].present? ? '' : 'is-active'}" do
           | 未解決
-          - if Question.not_solved.not_wip.count.positive? && current_user.admin?
+          - if Question.not_solved.not_wip.size.positive? && current_user.admin?
             .page-tabs__item-count.a-notification-count
               #not-solved-count
                 = params[:practice_id].present? ? Question.not_solved.where(practice_id: params[:practice_id]).size : Question.not_solved.size

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -7,7 +7,7 @@
           - if Question.not_solved.not_wip.size.positive? && current_user.admin?
             .page-tabs__item-count.a-notification-count
               #not-solved-count
-                = params[:practice_id].present? ? Question.not_solved.where(practice_id: params[:practice_id]).size : Question.not_solved.size
+                = params[:practice_id].present? ? Question.not_solved.not_wip.where(practice_id: params[:practice_id]).size : Question.not_solved.not_wip.size
       li.page-tabs__item
         = link_to '解決済み', polymorphic_path(:questions, solved: 'true', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:solved].present? ? 'is-active' : ''}"
       li.page-tabs__item

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -4,7 +4,7 @@
       li.page-tabs__item
         = link_to polymorphic_path(:questions, practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:all].present? || params[:solved].present? ? '' : 'is-active'}" do
           | 未解決
-          - if Question.not_solved.not_wip.size.positive? && current_user.admin?
+          - if Question.not_solved.not_wip.size.positive? && current_user.admin_or_mentor?
             .page-tabs__item-count.a-notification-count
               #not-solved-count
                 = params[:practice_id].present? ? Question.not_solved.not_wip.where(practice_id: params[:practice_id]).size : Question.not_solved.not_wip.size

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -312,6 +312,6 @@ class QuestionsTest < ApplicationSystemTestCase
 
   test 'show number of unanswered questions' do
     visit_with_auth questions_path(practice_id: practices(:practice1).id), 'komagata'
-    assert_selector '#not-solved-count', text: Question.not_solved.where(practice_id: practices(:practice1).id).size
+    assert_selector '#not-solved-count', text: Question.not_solved.not_wip.where(practice_id: practices(:practice1).id).size
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -309,4 +309,9 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_text 'プロフィール'
     assert_text 'Hatsuno Shinji（ハツノ シンジ）'
   end
+
+  test 'show number of unanswered questions' do
+    visit_with_auth questions_path(practice_id: practices(:practice1).id), 'komagata'
+    assert_selector '#not-solved-count', text: Question.not_solved.where(practice_id: practices(:practice1).id).size
+  end
 end


### PR DESCRIPTION
[#4102](https://github.com/fjordllc/bootcamp/issues/4102)

## バグ
メンターでログインしているとQ&A一覧画面で未解決のタブに件数が表示されますが、プラクティスで絞り込んでも実際の件数に変わらないです。

## 変更前

全ての未解決の質問数
![image](https://user-images.githubusercontent.com/34033366/158387362-3b3fec85-2eab-42ff-acc8-57b4a1582d80.png)

Q&A一覧画面でプラクティスの絞り込みをした後、未解決の質問数のままになっている。
![image](https://user-images.githubusercontent.com/34033366/158387394-0f394127-7fbe-48e5-b39e-5f55c5c8cc3a.png)

## 変更後
![Screen Recording 2022-03-15 at 20 29 24](https://user-images.githubusercontent.com/34033366/158388462-895d4109-8ea4-45e7-9cf0-dfbb3ed5c330.gif)

## 確認手順
- `bug/show-correct-number-of-unanswered-questions`ブランチを手元に持ってくる。
- mentorとしてログインして、`/questions`にアクセスする。
- 「プラクティスで絞り込む」から任意のプラクティスを選択する。