### PR TITLE
Markdownの中で独自記法でメッセージブロックを書けるようにした(クラス名message)

### DIFF
--- a/app/assets/stylesheets/atoms/_a-completion-message.sass
+++ b/app/assets/stylesheets/atoms/_a-completion-message.sass
@@ -1,5 +1,5 @@
 .a-completion-message
-  background-color: $info
+  background-color: $success
   +padding(vertical, .75rem)
   &:not(:last-child)
     margin-bottom: 1.25rem

--- a/app/assets/stylesheets/blocks/card/_card-footer.sass
+++ b/app/assets/stylesheets/blocks/card/_card-footer.sass
@@ -20,7 +20,7 @@
       display: none
 
 .card-footer__notice
-  +text-block(.8125rem 1.4 .5rem, center $info)
+  +text-block(.8125rem 1.4 .5rem, center $success)
 
 .card-footer__footer-link
   display: flex

--- a/app/assets/stylesheets/blocks/form/_form-radio-button.sass
+++ b/app/assets/stylesheets/blocks/form/_form-radio-button.sass
@@ -55,8 +55,8 @@
     background-color: $base
   &.is-checked,
   input:checked + &
-    background-color: #fffadd
-    border-color: #d9c02a
+    background-color: $warning-shade
+    border-color: $warning
     font-weight: 600
     &::after
       content: ''

--- a/app/assets/stylesheets/blocks/page/_page-notices.sass
+++ b/app/assets/stylesheets/blocks/page/_page-notices.sass
@@ -1,6 +1,6 @@
 .page-notices
   +margin(vertical, -.5rem 1rem)
-  background-color: $info
+  background-color: $success
 
 .page-notices__item
   &:not(:first-child)

--- a/app/assets/stylesheets/blocks/practice/_practice-content.sass
+++ b/app/assets/stylesheets/blocks/practice/_practice-content.sass
@@ -19,14 +19,14 @@
     padding: .5rem .75rem
 
 .practice-content__body-notice
-  border: solid 1px $info
+  border: solid 1px $success
   margin-top: 1rem
-  background-color: rgba($info, .1)
+  background-color: rgba($success, .1)
   padding: .75rem .875rem
   +media-breakpoint-down(sm)
     padding: .375rem .625rem
   p
-    +text-block(.875rem 1.5, $info-text)
+    +text-block(.875rem 1.5, $success-text)
     +media-breakpoint-down(sm)
       font-size: .75rem
 

--- a/app/assets/stylesheets/blocks/practice/_sticky-message.sass
+++ b/app/assets/stylesheets/blocks/practice/_sticky-message.sass
@@ -1,6 +1,6 @@
 .sticky-message
   +media-breakpoint-up(md)
-    background-color: $info
+    background-color: $success
     width: 100%
     +position(sticky, left 0, bottom 0, 1)
     +padding(vertical, .5rem)

--- a/app/assets/stylesheets/blocks/shared/_errors.sass
+++ b/app/assets/stylesheets/blocks/shared/_errors.sass
@@ -10,12 +10,12 @@
     padding: .875rem 1rem
 
 .errors__title
-  +text-block(.875rem 1.45 0 .8em, center 600 $danger)
+  +text-block(.875rem 1.45 0 .8em, center 600 $danger-text)
   +media-breakpoint-down(sm)
     font-size: .8125rem
 
 .errors__item
-  +text-block(.8125rem 1.6 0 .2em, $danger)
+  +text-block(.8125rem 1.6 0 .2em, $danger-text)
   +media-breakpoint-down(sm)
     font-size: .75rem
 

--- a/app/assets/stylesheets/blocks/shared/_flash.sass
+++ b/app/assets/stylesheets/blocks/shared/_flash.sass
@@ -4,7 +4,7 @@
   &.is-alert
     background-color: $danger
   &.is-notice
-    background-color: $info
+    background-color: $success
   input:checked + &
     display: none
 

--- a/app/assets/stylesheets/blocks/user/_niconico-calendar.sass
+++ b/app/assets/stylesheets/blocks/user/_niconico-calendar.sass
@@ -54,10 +54,10 @@
     background-color: #fff9e8
   &.is-today
     .niconico-calendar__day-inner
-      border: dashed 2px $info
+      border: dashed 2px $success
     .niconico-calendar__day-label
       font-weight: 600
-      color: $info
+      color: $success
 
 .niconico-calendar__day-inner
   +block-link

--- a/app/assets/stylesheets/mixins/_long-text-style.sass
+++ b/app/assets/stylesheets/mixins/_long-text-style.sass
@@ -227,14 +227,19 @@
 
   .message
     padding: 1em 1.25em 1em 2.75em
-    background-color: $warning-shade
     border-radius: .25rem
     +margin(vertical, 1.5em 2em)
+    background-color: $warning-shade
     color: $warning-text
     &::before
       +fa(fas '\f06a')
       +position(absolute, left .25em, top .25em)
       +text-block(1.5em, $warning)
+    &.alert
+      background-color: $danger-shade
+      color: $danger-text
+      &::before
+        color: $danger
 
   *:first-child
     margin-top: 0

--- a/app/assets/stylesheets/mixins/_long-text-style.sass
+++ b/app/assets/stylesheets/mixins/_long-text-style.sass
@@ -26,10 +26,6 @@
   word-break: break-all
   +media-breakpoint-down(sm)
     font-size: $mobile-font-size
-  >*:first-child
-    margin-top: 0
-  >*:last-child
-    margin-bottom: 0
   h1
     +text-block(1.875em 1.466 0 .75em, 600 $main-text)
     padding-bottom: .25em
@@ -213,7 +209,7 @@
   iframe
     display: block
     max-width: 100%
-    +margin(vertical, 1.5em 2em)
+    +margin(vertical, 1.5em)
     +margin(horizontal, auto)
   code
     word-break: break-all
@@ -225,3 +221,22 @@
       margin-top: 1em
     *:last-child
       margin-bottom: 0
+
+  div
+    position: relative
+
+  .message
+    padding: 1em 1.25em 1em 2.75em
+    background-color: $warning-shade
+    border-radius: .25rem
+    +margin(vertical, 1.5em 2em)
+    color: $warning-text
+    &::before
+      +fa(fas '\f06a')
+      +position(absolute, left .25em, top .25em)
+      +text-block(1.5em, $warning)
+
+  *:first-child
+    margin-top: 0
+  *:last-child
+    margin-bottom: 0

--- a/app/assets/stylesheets/mixins/_long-text-style.sass
+++ b/app/assets/stylesheets/mixins/_long-text-style.sass
@@ -235,11 +235,32 @@
       +fa(fas '\f06a')
       +position(absolute, left .25em, top .25em)
       +text-block(1.5em, $warning)
-    &.alert
+    &.alert,
+    &.danger
       background-color: $danger-shade
       color: $danger-text
       &::before
         color: $danger
+    &.warning
+      background-color: $warning-shade
+      color: $warning-text
+      &::before
+        color: $warning
+    &.info
+      background-color: $info-shade
+      color: $info-text
+      &::before
+        color: $info
+    &.primary
+      background-color: $primary-shade
+      color: $primary-text
+      &::before
+        color: $primary
+    &.success
+      background-color: $success-shade
+      color: $success-text
+      &::before
+        color: $success
 
   *:first-child
     margin-top: 0

--- a/app/assets/stylesheets/mixins/_user-role.sass
+++ b/app/assets/stylesheets/mixins/_user-role.sass
@@ -3,7 +3,7 @@
   &.is-mentor
     border: solid 2px rgba($danger, .7)
   &.is-graduate
-    border: solid 2px rgba($info, .7)
+    border: solid 2px rgba($success, .7)
   &.is-adviser
     border: solid 2px rgba($warning, .7)
   &.is-trainee

--- a/app/assets/stylesheets/modules/_toasts.sass
+++ b/app/assets/stylesheets/modules/_toasts.sass
@@ -87,7 +87,7 @@ $swal2-toast-footer-font-size: 0.8em !default
     grid-template-columns: 1fr 99fr 1fr
     padding: $swal2-toast-padding
     overflow-y: hidden
-    background: rgba($info, 0.9)
+    background: rgba($success, 0.9)
     box-shadow: $swal2-toast-box-shadow
     //pointer-events: all;
     pointer-events: none

--- a/app/assets/stylesheets/variables/_colors.sass
+++ b/app/assets/stylesheets/variables/_colors.sass
@@ -50,7 +50,7 @@ $badge-color: #e54724
 $primary: #3383d6
 $secondary: $base
 $success: #54a739
-$info: #4cad7c
+$info: #21b5d3
 $warning: #fabd17
 $danger: #f54667
 $disabled: #c7c6c6
@@ -60,6 +60,12 @@ $danger-shade: tint($danger, 90%)
 
 $success-text: shade($success, 60%)
 $success-shade: tint($success, 90%)
+
+$info-text: shade($info, 60%)
+$info-shade: tint($info, 90%)
+
+$primary-text: shade($primary, 60%)
+$primary-shade: tint($primary, 90%)
 
 $warning-text: shade($warning, 60%)
 $warning-shade: tint($warning, 90%)

--- a/app/assets/stylesheets/variables/_colors.sass
+++ b/app/assets/stylesheets/variables/_colors.sass
@@ -2,11 +2,14 @@ $main: #4638a0
 $accent: #ffbe0a
 $base: white
 $background: #ececec
+
+// background
 $background-shade: #d6d6d6
 $background-tint: #eceeef
 $background-more-tint: #f7f7f9
 $hover-background: $background-more-tint
 
+// text
 $default-text: #403f47
 $reversal-text: white
 $muted-text: #9da4a7
@@ -22,11 +25,13 @@ $side-tint: #4e6165
 $side-shade: #3a228a
 $side-active: $accent
 
+// border
 $border: #e6e6e6
 $border-shade: #d7d7d7
 $border-more-shade: #cacaca
 $border-more-more-shade: #c1c1c1
 $welcome-card-border: #5a5f60
+$input-border: #c1c5b9
 
 // Welcome Colors
 $welcome-default-text: #333738
@@ -40,6 +45,8 @@ $welcome-pink: #ef6085
 $stamp-color: #ed5151
 $badge-color: #e54724
 
+// UI colors
+
 $primary: #3383d6
 $secondary: $base
 $success: #54a739
@@ -48,12 +55,15 @@ $warning: #fabd17
 $danger: #f54667
 $disabled: #c7c6c6
 
-$danger-shade: #fff1f4
+//$danger-shade: #fff1f4
+$danger-shade: tint($danger, 90%)
+
 
 $success-text: shade($success, 60%)
 $success-shade: tint($success, 90%)
 
-$input-border: #c1c5b9
+$warning-text: shade($warning, 60%)
+$warning-shade: tint($warning, 90%)
 
 =default-link
   transition: color .2s ease-in

--- a/app/assets/stylesheets/variables/_colors.sass
+++ b/app/assets/stylesheets/variables/_colors.sass
@@ -55,9 +55,8 @@ $warning: #fabd17
 $danger: #f54667
 $disabled: #c7c6c6
 
-//$danger-shade: #fff1f4
+$danger-text: shade($danger, 60%)
 $danger-shade: tint($danger, 90%)
-
 
 $success-text: shade($success, 60%)
 $success-shade: tint($success, 90%)

--- a/app/assets/stylesheets/variables/_colors.sass
+++ b/app/assets/stylesheets/variables/_colors.sass
@@ -16,7 +16,6 @@ $muted-text: #9da4a7
 $semi-muted-text: #898998
 $placeholder-text: #bbbbbb
 $main-text: #3c3282
-$info-text: #246946
 $link-text: #2e2088
 
 $side: $main
@@ -49,7 +48,7 @@ $badge-color: #e54724
 
 $primary: #3383d6
 $secondary: $base
-$success: #54a739
+$success: #4cad7c
 $info: #21b5d3
 $warning: #fabd17
 $danger: #f54667

--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -8,6 +8,7 @@ import MarkdownOption from './markdown-it-option'
 import UserIconRenderer from './user-icon-renderer'
 import MarkdownItTaskListsInitializer from './markdown-it-task-lists-initializer'
 import MarkdownItHeadings from './markdown-it-headings'
+import MarkDownItContainerMessage from './markdown-it-container-message'
 
 export default class {
   replace(selector) {
@@ -33,6 +34,7 @@ export default class {
     md.use(MarkdownItLinkingImage)
     md.use(MarkdownItTaskLists)
     md.use(MarkdownItHeadings)
+    md.use(MarkDownItContainerMessage)
 
     return md.render(text)
   }

--- a/app/javascript/markdown-it-container-message.js
+++ b/app/javascript/markdown-it-container-message.js
@@ -1,0 +1,5 @@
+import MarkdownItContainer from 'markdown-it-container'
+
+export default function (md) {
+  return MarkdownItContainer(md, 'message')
+}

--- a/app/javascript/markdown-it-container-message.js
+++ b/app/javascript/markdown-it-container-message.js
@@ -1,5 +1,15 @@
 import MarkdownItContainer from 'markdown-it-container'
 
-export default function (md) {
-  return MarkdownItContainer(md, 'message')
+export default (md) => {
+  md.use(MarkdownItContainer, 'message', {
+    render: (tokens, idx) => {
+      const messageInfo = tokens[idx].info.trim().match(/^message\s+(.*)$/)
+      const messageName = messageInfo ? ` ${messageInfo[1]}` : ''
+      if (tokens[idx].nesting === 1) {
+        return `<div class="message${messageName}">\n`
+      } else {
+        return '</div>\n'
+      }
+    }
+  })
 }

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -9,6 +9,7 @@ import MarkdownItUserIcon from './markdown-it-user-icon'
 import MarkdownOption from './markdown-it-option'
 import UserIconRenderer from './user-icon-renderer'
 import autosize from 'autosize'
+import MarkDownItContainerMessage from './markdown-it-container-message'
 
 export default class {
   static initialize(selector) {
@@ -68,7 +69,8 @@ export default class {
           MarkdownItEmoji,
           MarkdownItMention,
           MarkdownItUserIcon,
-          MarkdownItTaskLists
+          MarkdownItTaskLists,
+          MarkDownItContainerMessage
         ],
         markdownOptions: MarkdownOption
       })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lodash.template": "^4.5.0",
     "markdown-it": "^12.3.2",
     "markdown-it-anchor": "^8.4.1",
+    "markdown-it-container": "^3.0.0",
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-regexp": "^0.4.0",
     "markdown-it-task-lists": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4904,6 +4904,11 @@ markdown-it-anchor@^8.4.1:
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz#29e560593f5edb80b25fdab8b23f93ef8a91b31e"
   integrity sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==
 
+markdown-it-container@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-container/-/markdown-it-container-3.0.0.tgz#1d19b06040a020f9a827577bb7dbf67aa5de9a5b"
+  integrity sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw==
+
 markdown-it-emoji@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"


### PR DESCRIPTION
## Issue概要
- #4225

```
:::message
メッセージ
:::
```

Markdownのエディタの中で↑のように記述すると↓のようなHTMLに変換されるようにしました。
メッセージブロックの中ではMarkdown記法が使えるようにしています。

```
<div class="message">
<p>メッセージ</p>
</div>
```

~~※町田さんと相談した結果、クラス名は本Issueでは`message`に固定しています。
`message alert`や`message info`などのバリエーションには対応していません。~~

レビュワーのガラムマサラさんのご尽力により、`message`以下の文字列が自由にクラス名に指定できるようになりました。
`message alert`、`message info`などのバリエーションもクラス名になります。

## 変更前
[![Image from Gyazo](https://i.gyazo.com/70c3ed4d661784217caaf92bf69f2116.gif)](https://gyazo.com/70c3ed4d661784217caaf92bf69f2116)

`:::message`と`:::`がただの文字列として認識されている。
コンソールで要素を確認すると、`:::message`がdivタグの中のクラス名ではなく、pタグ内に入っている。

![_development__markdown_test___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/63531341/158542571-0607e762-57bd-4aa9-9f7d-53c1f185d124.png)

## 変更後
[![Image from Gyazo](https://i.gyazo.com/1997c3925f5029d661176490ac246671.gif)](https://gyazo.com/1997c3925f5029d661176490ac246671)

`:::message`と`:::`がdivタグとして認識されていて、`message`がクラス名になっていることが確認できる。

![_development__markdown_test___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/63531341/158544010-ef0f2848-d503-48aa-bc5b-489d5ac0dd80.png)

## 確認手順
JS、Rails、Vueで実装されている箇所それぞれできちんと実装されているかの確認が必要なので、下記3箇所のご確認をお願いします:pray:
- 日報新規作成時のプレビュー画面(JS)
- 日報詳細画面(Rails)
- 日報のコメント(Vue)

1. ブランチ`feature/enable-to-write-original-message-block-inside-of-markdown`をローカルに取り込む
2. `bin/setup`を実行する
3. `bin/rails s`でサーバーを立ち上げる
4. 好きなユーザーでログインし、日報を新規作成し、下記をコピペして内容欄に貼る
```
:::message
### 見出し

ああああああああああああああ

- あああああ
- あああああ
:::
```
5. 内容欄の右側のプレビュー画面で、入力した文字列がマークダウン表示されていることを確認する
6. 日報を提出ボタンをクリックし、そのまま遷移した日報詳細画面で日報の本文がマークダウン表示されていることを確認する
7. 日報詳細画面のコメント欄に下記をコピペして貼る
```
:::message
### 見出し

ああああああああああああああ

- あああああ
- あああああ
:::
```
8. コメントタブの右のプレビュータブで、入力した文字列がマークダウン表示されていることを確認する
9. 適宜Devツールのコンソールでクラス名が付与されているかを確認する

不明点等ありましたらお気軽にお声かけください！

## 参考にしたPR
- #2958
- #3882