### PR TITLE
メンター紹介にあるtadaakiの所属を変更

### DIFF
--- a/app/views/welcome/_mentors.html.slim
+++ b/app/views/welcome/_mentors.html.slim
@@ -128,7 +128,7 @@ section.welcome-child-section
                                    twitter_id: 'tdakak',
                                    facebook_id: 'aki.tada' do
           p
-            | #{link_to 'hey, Inc.', 'https://hey.jp/'}所属。
+            | 文鳥とビールとRubyが好きなフリーランス。
             | たくさんの人達が楽しく過ごせることを目指して、毎日ふわふわ過ごしています。
             | また、業務やイベントでプログラミング未経験の方、学生インターン、新卒入社社員や実務経験の浅い社員に対してプログラミング研修を行なってきました。
             | #{link_to 'Tokyu Ruby Kaigi', 'https://tokyurubykaigi.github.io/tokyu13/'}実行委員。


### PR DESCRIPTION
# やりたいこと

tadaaki の所属が変更になったので、メンター紹介に載せている内容を変更したい。

# やったこと

該当箇所の文言変更。

# 変更後の表示

<img width="370" alt="image" src="https://user-images.githubusercontent.com/3615622/158744048-709d661f-1b6f-4fcc-848c-07bc38d37fe9.png">
