### PR TITLE
受講生の卒業時にメンターに通知する

### DIFF
--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -8,6 +8,7 @@ class GraduationController < ApplicationController
       Subscription.new.destroy(@user.subscription_id) if @user.subscription_id
 
       notify_to_chat(@user)
+      notify_to_mentors(@user)
       redirect_to admin_users_url, notice: 'ユーザー情報を更新しました。'
     else
       redirect_to admin_users_url, alert: 'ユーザー情報の更新に失敗しました'
@@ -25,5 +26,9 @@ class GraduationController < ApplicationController
       "#{user.login_name}さんが卒業しました。",
       webhook_url: ENV['DISCORD_ADMIN_WEBHOOK_URL']
     )
+  end
+
+  def notify_to_mentors(user)
+    User.mentor.each { |mentor| NotificationFacade.graduated(user, mentor) }
   end
 end

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -22,7 +22,7 @@ class GraduationController < ApplicationController
 
   def notify_to_chat(user)
     ChatNotifier.message(
-      "「#{user.login_name}さんが卒業になりました」",
+      "#{user.login_name}さんが卒業しました。",
       webhook_url: ENV['DISCORD_ADMIN_WEBHOOK_URL']
     )
   end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -159,4 +159,12 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     subject = "[bootcamp] #{@product.user.login_name}さんの提出物#{@product.title}の担当になりました。"
     mail to: @user.email, subject: subject
   end
+
+  # required params: sender, receiver
+  def graduated
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:graduated])
+    subject = "[bootcamp] #{@sender.login_name}さんが卒業しました。"
+    mail to: @user.email, subject: subject
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -33,7 +33,8 @@ class Notification < ApplicationRecord
     chose_correct_answer: 14,
     consecutive_sad_report: 15,
     assigned_as_checker: 16,
-    product_update: 17
+    product_update: 17,
+    graduated: 18
   }
 
   scope :unreads, -> { where(read: false) }
@@ -260,6 +261,17 @@ class Notification < ApplicationRecord
         sender: product.user,
         link: Rails.application.routes.url_helpers.polymorphic_path(product),
         message: "#{product.user.login_name}さんの提出物が更新されました",
+        read: false
+      )
+    end
+
+    def graduated(sender, receiver)
+      Notification.create!(
+        kind: kinds[:graduated],
+        user: receiver,
+        sender: sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(sender),
+        message: "#{sender.login_name}さんが卒業しました。",
         read: false
       )
     end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -177,11 +177,21 @@ class NotificationFacade
 
   def self.assigned_as_checker(product, receiver)
     Notification.assigned_as_checker(product, receiver)
-    return unless receiver.mail_notification? && !receiver.retired_on?
+    return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(
       product: product,
       receiver: receiver
     ).assigned_as_checker.deliver_later(wait: 5)
+  end
+
+  def self.graduated(sender, receiver)
+    Notification.graduated(sender, receiver)
+    return unless receiver.mail_notification? && !receiver.retired?
+
+    NotificationMailer.with(
+      sender: sender,
+      receiver: receiver
+    ).graduated.deliver_later(wait: 5)
   end
 end

--- a/app/views/notification_mailer/graduated.html.slim
+++ b/app/views/notification_mailer/graduated.html.slim
@@ -1,0 +1,1 @@
+= render 'notification_mailer_template', title: "#{@sender.login_name}さんが卒業しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -123,3 +123,11 @@ notification_chose_correct_answer:
   message: hajimeさんの質問【 解決済みの質問 】でadvijirouさんの回答がベストアンサーに選ばれました。
   link: "/questions/<%= ActiveRecord::FixtureSet.identify(:question12) %>"
   read: false
+
+notification_graduated:
+  kind: 18
+  user: mentormentaro
+  sender: sotugyou
+  message: sotugyouさんが卒業しました。
+  link: "/users/<%= ActiveRecord::FixtureSet.identify(:sotugyou) %>"
+  read: false

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -165,3 +165,11 @@ notification_consecutive_sad_report:
   message: hajimeさんが2回連続でsadアイコンの日報を提出しました。
   link: "/reports/<%= ActiveRecord::FixtureSet.identify(:report16) %>"
   read: false
+
+notification_graduated:
+  kind: 18
+  user: mentormentaro
+  sender: sotugyou
+  message: sotugyouさんが卒業しました。
+  link: "/users/<%= ActiveRecord::FixtureSet.identify(:sotugyou) %>"
+  read: false

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -336,4 +336,24 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal '[bootcamp] hajimeさんが2回連続でsadアイコンの日報を提出しました。', email.subject
     assert_match(/2回連続/, email.body.to_s)
   end
+
+  test 'graduated' do
+    user = users(:sotugyou)
+    mentor = users(:mentormentaro)
+    mailer = NotificationMailer.with(
+      sender: user,
+      receiver: mentor
+    ).graduated
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['mentormentaro@fjord.jp'], email.to
+    assert_equal '[bootcamp] sotugyouさんが卒業しました。', email.subject
+    assert_match(/卒業/, email.body.to_s)
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -131,4 +131,11 @@ class NotificationMailerPreview < ActionMailer::Preview
 
     NotificationMailer.with(report: report, receiver: receiver).consecutive_sad_report
   end
+
+  def graduated
+    sender = User.find(ActiveRecord::FixtureSet.identify(:sotugyou))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))
+
+    NotificationMailer.with(sender: sender, receiver: receiver).graduated
+  end
 end

--- a/test/system/notification/graduation_test.rb
+++ b/test/system/notification/graduation_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Notification::GraduationTest < ApplicationSystemTestCase
+  test 'notify mentor when student graduate' do
+    users(:kimura).update!(updated_at: Time.current)
+    # kimura が一番上に表示されるようにソート
+    path = 'admin/users?direction=desc&order_by=updated_at&target=student_and_trainee'
+    visit_with_auth path, 'komagata'
+    accept_confirm do
+      first('.a-button.is-sm.is-primary', text: '卒業').click
+    end
+    logout
+
+    visit_with_auth '/notifications', 'mentormentaro'
+    within first('.thread-list-item.is-unread') do
+      assert_text 'kimuraさんが卒業しました。'
+    end
+  end
+end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -169,20 +169,20 @@ class NotificationsTest < ApplicationSystemTestCase
                         created_at: '2040-01-18 06:06:42',
                         kind: 'mentioned',
                         link: '/reports/20400118',
-                        user: users(:mentormentaro),
+                        user: users(:kananashi),
                         sender: users(:machida))
 
-    visit_with_auth '/notifications', 'mentormentaro'
+    visit_with_auth '/notifications', 'kananashi'
     assert_selector '.header-notification-count', text: '1'
 
     20.times do |n|
       Notification.create(message: "machidaさんからメンションが届きました#{n}",
                           kind: 'mentioned',
                           link: "/reports/#{n}",
-                          user: users(:mentormentaro),
+                          user: users(:kananashi),
                           sender: users(:machida))
     end
-    visit_with_auth '/notifications', 'mentormentaro'
+    visit_with_auth '/notifications', 'kananashi'
     assert_selector '.header-notification-count', text: '21'
   end
 


### PR DESCRIPTION
## Issue
- #4361 

## 概要
受講生が卒業した際、メンターに通知するようにしました。

https://user-images.githubusercontent.com/83743223/158973328-d49366b4-bec3-4404-a83e-7f8e6a43d29b.mov

## ローカル環境での確認方法
- `feature/notify-mentor-when-student-graduate` ブランチを起動
- 管理者（admin）でログイン後、概要内の動画を参考に通知を確認する
  - adminユーザー例：komagata
  - mentorユーザー例：mentormentaro
