### PR TITLE
Markdownで表示している部分で、リンクのアンカーテキストに 「@」が含まれると userへのリンクになってしまう

### DIFF
--- a/app/javascript/markdown-it-mention.js
+++ b/app/javascript/markdown-it-mention.js
@@ -1,13 +1,16 @@
 import MarkdownItRegexp from 'markdown-it-regexp'
 
-export default MarkdownItRegexp(
-  /@([a-zA-Z0-9_-]+)/,
-  (match) => {
-    if(match.input.includes("(http")) {
-      const output = ("["+match.input).match(/^\[([\w\s\d+&@]+)\]\((https?:\/\/[\w\d./?=#]+)\)$/)
-      return output ? output[1].match(/@([a-zA-Z0-9_-]+)/)[0] : ("["+match.input).match(/@([a-zA-Z0-9_-]+)/)[0]
-    } else {
-      return `<a href="${match[0] === '@mentor' ? `/users?target=mentor` : `/users/${match[1]}`}">${match[0]}</a>`
-    }
+export default MarkdownItRegexp(/@([a-zA-Z0-9_-]+)/, (match) => {
+  if (match.input.includes('(http')) {
+    const output = ('[' + match.input).match(
+      /^\[([\w\s\d+&@]+)\]\((https?:\/\/[\w\d./?=#]+)\)$/
+    )
+    return output
+      ? output[1].match(/@([a-zA-Z0-9_-]+)/)[0]
+      : ('[' + match.input).match(/@([a-zA-Z0-9_-]+)/)[0]
+  } else {
+    return `<a href="${
+      match[0] === '@mentor' ? `/users?target=mentor` : `/users/${match[1]}`
+    }">${match[0]}</a>`
   }
-)
+})

--- a/app/javascript/markdown-it-mention.js
+++ b/app/javascript/markdown-it-mention.js
@@ -2,8 +2,12 @@ import MarkdownItRegexp from 'markdown-it-regexp'
 
 export default MarkdownItRegexp(
   /@([a-zA-Z0-9_-]+)/,
-  (match) =>
-    `<a href="${
-      match[0] === '@mentor' ? `/users?target=mentor` : `/users/${match[1]}`
-    }">${match[0]}</a>`
+  (match) => {
+    if(match.input.includes("(http")) {
+      const output = ("["+match.input).match(/^\[([\w\s\d+&@]+)\]\((https?:\/\/[\w\d./?=#]+)\)$/)
+      return output ? output[1].match(/@([a-zA-Z0-9_-]+)/)[0] : ("["+match.input).match(/@([a-zA-Z0-9_-]+)/)[0]
+    } else {
+      return `<a href="${match[0] === '@mentor' ? `/users?target=mentor` : `/users/${match[1]}`}">${match[0]}</a>`
+    }
+  }
 )

--- a/app/javascript/markdown-it-mention.js
+++ b/app/javascript/markdown-it-mention.js
@@ -1,13 +1,15 @@
 import MarkdownItRegexp from 'markdown-it-regexp'
 
-export default MarkdownItRegexp(/@([a-zA-Z0-9_-]+)/, (match) => {
+const mentionRegexp = /@([a-zA-Z0-9_-]+)/
+
+export default MarkdownItRegexp(mentionRegexp, (match) => {
   if (match.input.includes('(http')) {
     const output = ('[' + match.input).match(
       /^\[([\w\s\d+&@]+)\]\((https?:\/\/[\w\d./?=#]+)\)$/
     )
     return output
-      ? output[1].match(/@([a-zA-Z0-9_-]+)/)[0]
-      : ('[' + match.input).match(/@([a-zA-Z0-9_-]+)/)[0]
+      ? output[1].match(mentionRegexp)[0]
+      : ('[' + match.input).match(mentionRegexp)[0]
   } else {
     return `<a href="${
       match[0] === '@mentor' ? `/users?target=mentor` : `/users/${match[1]}`


### PR DESCRIPTION
#2037 

## バグ
Markdownで表示している部分で、リンクのアンカーテキストに 「@」が含まれると userへのリンクになってしまう。

## 要件
Markdownエディタで`[@machida](http://fjord.jp)`と書くと、

- 変更前
プレビューの結果をクリックすると、`/users/machida`というリンクにアクセスする。

- 変更後
プレビューの結果をクリックすると、`http://fjord.jp`にアクセスする。

## 確認手順
- `bug/error-markdown-mention-to-link`ブランチを手元に持ってくる。
- Markdownエディタで`[@machida](http://fjord.jp)`と書いて、確認する。