### PR TITLE
db/fixtures/answers.yml内のデータを作成できるようにした

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,6 +36,4 @@ tables = %i[
   talks
 ]
 
-tables.each do |table|
-  ActiveRecord::FixtureSet.create_fixtures 'db/fixtures', table
-end
+ActiveRecord::FixtureSet.create_fixtures 'db/fixtures', tables


### PR DESCRIPTION
## Issue
- #4438
`correct_answers.yml`内の回答データは作成できるが、`answers.yml`内の回答データが作成できなかった

## 修正内容
`app/models/correct_answer.rb`を見ると、`correct_answer`は`answer`モデルを単一継承しているため、DB上のテーブルは`correct_answers`ではなく`answers`テーブルであることが確認できます。

修正前の`db/seeds.rb`では、`tables`という配列に入ったymlファイルひとつずつについてeachメソッドで`ActiveRecord::FixtureSet.create_fixtures`を実行していました。
`create_fixtures`は実行時に毎回、ymlデータ投入先のテーブルに存在しているレコードを削除した後にymlデータの流し込みを行っています。
つまり、ひとつのテーブルに対し複数のymlデータを投入する場合は、先に`create_fixtures`を実行したレコードを上書きする形で新しいymlデータに対して`create_fixtures`が実行されることになります。
そのため、先に実行された`answers.yml`のfixtureは1度`answers`テーブルに作成されたあと、`correct_answers.yml`のfixtureを作る前に削除されてしまい、後から実行された`correct_answers.yml`のfixtureデータのみが`answers`テーブルに残る形になっていました。

`rails db:seed`実行後のログを見ると、`create_fixtures`によって、`answers`テーブルに対して`DELETE`→`INSERT`→`DELETE`→`INSERT`の順で実行されていることが確認できます。

```sql
DELETE FROM "answers";
-- answersテーブル内のレコード削除
INSERT INTO "answers" ("id", "description", "user_id", "question_id", "created_at", "updated_at", "type") VALUES (134407869, 'atom一択です！', 459775584, 302937193, '2022-03-21 10:51:30.189922', '2022-03-21 10:51:30.189922', DEFAULT), (285980417, 'vimしかないでしょう。常識的に考えて。', 609827778, 302937193, '2022-03-21 10:51:30.189922', '2022-03-21 10:51:30.189922', DEFAULT), (638355350, 'injectを使っては？', 459775584, 185017813, '2022-03-21 10:51:30.189922', '2022-03-21 10:51:30.189922', DEFAULT), (946344503, 'テストの回答4です。', 459775584, 1006638408, '2022-03-21 10:51:30.189922', '2022-03-21 10:51:30.189922', DEFAULT), (258941606, 'テストの回答5です。', 459775584, 208331212, '2022-03-21 10:51:30.189922', '2022-03-21 10:51:30.189922', DEFAULT), (375812890, 'Q&Aのコメントです。(ベストアンサーではない)', 679998234, 208331212, '2022-03-21 10:51:30.189922', '2022-03-21 10:51:30.189922', DEFAULT)
-- answers.yml内のレコードがanswersテーブルにINSERTされる
DELETE FROM "answers";
-- さっきINSERTしたanswersテーブル内のレコード削除をしてしまっている！
INSERT INTO "answers" ("id", "description", "user_id", "question_id", "created_at", "updated_at", "type") VALUES (594808440, 'テストの正解回答1です。', 459775584, 1006638408, '2022-03-21 10:51:30.293914', '2022-03-21 10:51:30.293914', 'CorrectAnswer'), (981295044, 'テストの正解回答です。', 421530892, 782854533, '2022-03-21 10:51:30.293914', '2022-03-21 10:51:30.293914', 'CorrectAnswer'), (226127703, 'Q&Aのコメントです。(ベストアンサー)', 679998234, 302937193, '2022-03-21 10:51:30.293914', '2022-03-21 10:51:30.293914', 'CorrectAnswer')
-- correct_answers.yml内のレコードがanswersテーブルにINSERTされる
```

今回の変更で、`create_fixtures`を、eachメソッドでymlファイル1つずつについて実行するのではなく、`tables配列`全体を引数にして実行する形に変更したところ、`DELETE`と`INSERT`が`answers`テーブルに対して1度ずつ呼び出され、`answers.yml`と`correct_answers.yml`のデータが同時に`answers`テーブルに投入されてどちらのデータも残るようになりました。
[rails/test\_fixtures\.rb at dc0f5db3c181e4ee3feafde8b18303faaa78a632 · rails/rails](https://github.com/rails/rails/blob/dc0f5db3c181e4ee3feafde8b18303faaa78a632/activerecord/lib/active_record/test_fixtures.rb#L249)

```sql
DELETE FROM "answers";
INSERT INTO "answers" ("id", "description", "user_id", "question_id", "created_at", "updated_at", "type") VALUES (594808440, 'テストの正解回答1です。', 459775584, 1006638408, '2022-03-21 11:29:20.438322', '2022-03-21 11:29:20.438322', 'CorrectAnswer'), (981295044, 'テストの正解回答です。', 421530892, 782854533, '2022-03-21 11:29:20.438322', '2022-03-21 11:29:20.438322', 'CorrectAnswer'), (226127703, 'Q&Aのコメントです。(ベストアンサー)', 679998234, 302937193, '2022-03-21 11:29:20.438322', '2022-03-21 11:29:20.438322', 'CorrectAnswer'), (134407869, 'atom一択です！', 459775584, 302937193, '2022-03-21 11:29:20.423763', '2022-03-21 11:29:20.423763', DEFAULT), (285980417, 'vimしかないでしょう。常識的に考えて。', 609827778, 302937193, '2022-03-21 11:29:20.423763', '2022-03-21 11:29:20.423763', DEFAULT), (638355350, 'injectを使っては？', 459775584, 185017813, '2022-03-21 11:29:20.423763', '2022-03-21 11:29:20.423763', DEFAULT), (946344503, 'テストの回答4です。', 459775584, 1006638408, '2022-03-21 11:29:20.423763', '2022-03-21 11:29:20.423763', DEFAULT), (258941606, 'テストの回答5です。', 459775584, 208331212, '2022-03-21 11:29:20.423763', '2022-03-21 11:29:20.423763', DEFAULT), (375812890, 'Q&Aのコメントです。(ベストアンサーではない)', 679998234, 208331212, '2022-03-21 11:29:20.423763', '2022-03-21 11:29:20.423763', DEFAULT)
```

## 確認方法
1. `main`ブランチで`bin/rails db:seed`を実行後、`bin/rails c`で`Answer.count`を実行し、`correct_answers.yml`内に記述された3件の回答データのみが作成されていることを確認する
1. `bug/enable-to-work-db-fixtures-answers-yml`ブランチをローカルに取り込みチェックアウトする
1. `bin/rails db:seed`を実行後、`bin/rails c`で`Answer.count`を実行し、`correct_answers.yml`と`answers.yml`に記述されたデータがどちらも作成されて9件の回答が作成されていることを確認する

分かりづらい記述になってしまったので、不明点があればご指摘ください！