### PR TITLE
スタンプ内のメンターIDのjが切れてしまうのを修正

### DIFF
--- a/app/assets/stylesheets/blocks/report/_stamp.sass
+++ b/app/assets/stylesheets/blocks/report/_stamp.sass
@@ -43,3 +43,5 @@
   overflow: hidden
   text-overflow: ellipsis
   +padding(horizontal, .25rem)
+  height: 100%
+  line-height: 1.55


### PR DESCRIPTION
Issue: #4452 