### PR TITLE
提出物一覧ページに出現するVue warn に対応した

### DIFF
--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -28,7 +28,7 @@ export default {
     checkerName: { type: String, required: false, default: null },
     currentUserId: { type: String, required: true },
     productId: { type: Number, required: true },
-    checkableType: { type: String, required: true },
+    checkableType: { type: String, required: false, default: null },
     checkerAvatar: { type: String, required: false, default: null }
   },
   data() {


### PR DESCRIPTION
# 関連issue
- #4392 

- この実装の背景にあたるPR
  - #2510


# 変更前
![スクリーンショット 2022-03-13 16 44 12](https://user-images.githubusercontent.com/45246171/159145208-1c129873-a8ac-4650-8e6c-5631898635c6.png)

# 変更後
![スクリーンショット 2022-03-20 11 23 51](https://user-images.githubusercontent.com/45246171/159145220-6bf3abfe-2807-4764-a0b3-a47a8d6d5545.png)

# 確認手順

1.  左サイドバーの提出物をクリックして/products にアクセス
2. タブは「全て」「未完了」「未アサイン」「自分の担当」どれでも良い
3. ブラウザのdev toolのコンソールを開く

# 調査した結果

## 仕様

#2483 より引用
> 提出物一覧のときのボタンは、is-sm というclassが付く
提出物個別のときのボタンは、is-md というclassが付く

## もともとの実装
  - `checkableType: { type: String, required: true }` これでエラーが出ていた理由(`product_checker.vue`)
  - この`product_checker.vue`を呼び出しているのは`product.vue(提出物一覧のそれぞれのコンポーネント)` `check.vue(提出物の個別ページの担当するボタンのコンポーネント)`
  - `required: true`なのに`product.vue`には`checkableType`が渡されておらず、スクリーンショットのようなWarnが出ていた。

## 変更後の実装
  - `checkableType: { type: String, required: false, default: null }`とすることで、`product.vue`のときには`null`渡り、`check.vue`のときは`Product`という値が入るようにした
