### PR TITLE
卒業生のダッシュボードに学習時間を非表示するボタンを作成

### DIFF
--- a/app/assets/stylesheets/atoms/_a-button.sass
+++ b/app/assets/stylesheets/atoms/_a-button.sass
@@ -21,8 +21,16 @@
   &.is-muted
     border: none
     color: $muted-text
-    font-weight: 400
+    font-weight: 400 !important
     background-color: $background
+  &.is-muted-borderd
+    border-color: $border
+    color: $muted-text
+    font-weight: 400 !important
+    background-color: $base
+    &:hover
+      background-color: $background-more-tint
+      color: $semi-muted-text
 
   &.is-sm-text
     span
@@ -39,6 +47,10 @@
     padding: 0 !important
 
   //size
+  &.is-xxs,
+  &.is-xxs input[type="submit"]
+    +button-size(.625rem, 1, 1.4rem)
+    font-weight: 300
   &.is-xs,
   &.is-xs input[type="submit"]
     +button-size(.75rem, 1, 1.7rem)

--- a/app/assets/stylesheets/blocks/card/_card-header.sass
+++ b/app/assets/stylesheets/blocks/card/_card-header.sass
@@ -8,6 +8,8 @@
     padding: .5rem .75rem
   &.is-sm
     +padding(vertical, .625rem)
+    .a-button.is-xs
+      +margin(vertical, -.25rem)
   &:first-child
     +border-radius(top, .25rem)
   & + .a-form-tabs

--- a/app/javascript/grass.js
+++ b/app/javascript/grass.js
@@ -5,12 +5,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const selector = '#js-grass'
   const grass = document.querySelector(selector)
   if (grass) {
+    const currentUser = window.currentUser
     const userId = grass.getAttribute('data-user-id')
 
     new Vue({
       render: (h) =>
         h(Grass, {
           props: {
+            currentUser: currentUser,
             userId: userId
           }
         })

--- a/app/javascript/grass.vue
+++ b/app/javascript/grass.vue
@@ -3,6 +3,8 @@
   header.card-header.is-sm
     h2.card-header__title
       | 学習時間
+    h2.card-header__title(v-if='currentUser.primary_role === "graduate"')
+      | <button @click='close'>非表示</button>
   .user-grass
     .user-grass-nav
       .user-grass-nav__previous(@click='onPrevYearMonth')
@@ -22,6 +24,7 @@ import dayjs from 'dayjs'
 
 export default {
   props: {
+    currentUser: { type: Object, required: true },
     userId: { type: String, required: true }
   },
   data() {
@@ -38,6 +41,9 @@ export default {
     this.canvas = document.getElementById('grass')
 
     this.load(dayjs().format(this.serverFormat))
+  },
+  beforeDestroy() {
+    document.cookie = `user_grass=${JSON.stringify(this.userId)}`
   },
   methods: {
     getPrevYearMonth(yearMonth) {
@@ -138,6 +144,10 @@ export default {
       }
       ctx.strokeText('0 h', sampleStartX - 23, sampleStartY + 8.5)
       ctx.strokeText('6 h', sampleStartX + 71, sampleStartY + 8.5)
+    },
+    close() {
+      this.$destroy()
+      this.$el.parentNode.removeChild(this.$el)
     }
   }
 }

--- a/app/javascript/grass.vue
+++ b/app/javascript/grass.vue
@@ -3,8 +3,8 @@
   header.card-header.is-sm
     h2.card-header__title
       | 学習時間
-    h2.card-header__title(v-if='currentUser.primary_role === "graduate"')
-      | <button @click='close'>非表示</button>
+    .card-header__action(v-if='currentUser.primary_role === "graduate"')
+      | <button @click='close' class='a-button is-xs is-muted-borderd'>非表示</button>
   .user-grass
     .user-grass-nav
       .user-grass-nav__previous(@click='onPrevYearMonth')

--- a/app/javascript/grass.vue
+++ b/app/javascript/grass.vue
@@ -3,8 +3,10 @@
   header.card-header.is-sm
     h2.card-header__title
       | 学習時間
-    .card-header__action(v-if='currentUser.primary_role === "graduate"')
-      | <button @click='close' class='a-button is-xs is-muted-borderd'>非表示</button>
+    .card-header__action(
+      v-if='currentUser.primary_role === "graduate" && isDashboard'
+    )
+      | <button @click='hideGrass' class='a-button is-xs is-muted-borderd'>非表示</button>
   .user-grass
     .user-grass-nav
       .user-grass-nav__previous(@click='onPrevYearMonth')
@@ -33,6 +35,11 @@ export default {
       serverFormat: 'YYYY-MM-DD',
       prevYearMonth: null,
       currentYearMonth: null
+    }
+  },
+  computed: {
+    isDashboard() {
+      return location.pathname === '/'
     }
   },
   mounted() {
@@ -145,9 +152,9 @@ export default {
       ctx.strokeText('0 h', sampleStartX - 23, sampleStartY + 8.5)
       ctx.strokeText('6 h', sampleStartX + 71, sampleStartY + 8.5)
     },
-    close() {
+    hideGrass() {
       this.$destroy()
-      this.$el.parentNode.removeChild(this.$el)
+      this.$el.remove()
     }
   }
 }

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -64,7 +64,7 @@ header.page-header
                     | 内容を更新
           - if (current_user.admin? || current_user.adviser?) && @job_seeking_users.present?
             = render 'job_seeking_users', users: @job_seeking_users
-          - if current_user.student_or_trainee?
+          - if current_user.student_or_trainee? && !cookies[:user_grass]
             #js-grass(data-user-id="#{current_user.id}")
           - if current_user.github_account.present?
             = render 'users/github_grass', user: current_user

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -199,4 +199,14 @@ class HomeTest < ApplicationSystemTestCase
       assert_no_text '就職関係かつ直近イベントの表示テスト用'
     end
   end
+
+  test 'hide user grass for graduate' do
+    visit_with_auth '/', 'kimura'
+    assert_no_text '非表示'
+
+    visit_with_auth '/', 'sotugyou'
+    assert_text '非表示'
+    click_button '非表示'
+    assert_no_text '学習時間'
+  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -200,12 +200,11 @@ class HomeTest < ApplicationSystemTestCase
     end
   end
 
-  test 'hide user grass for graduate' do
+  test 'show grass hide button for graduates' do
     visit_with_auth '/', 'kimura'
     assert_no_text '非表示'
 
     visit_with_auth '/', 'sotugyou'
-    assert_text '非表示'
     click_button '非表示'
     assert_no_text '学習時間'
   end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -202,10 +202,11 @@ class HomeTest < ApplicationSystemTestCase
 
   test 'show grass hide button for graduates' do
     visit_with_auth '/', 'kimura'
-    assert_no_text '非表示'
+    assert_not has_button? '非表示'
 
     visit_with_auth '/', 'sotugyou'
+    assert_selector 'h2.card-header__title', text: '学習時間'
     click_button '非表示'
-    assert_no_text '学習時間'
+    assert_no_selector 'h2.card-header__title', text: '学習時間'
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -317,6 +317,6 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'not show grass hide button for graduates' do
     visit_with_auth "/users/#{users(:sotugyou).id}", 'sotugyou'
-    assert_no_text '非表示'
+    assert_not has_button? '非表示'
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -314,4 +314,9 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth '/users?target=trainee', 'senpai'
     assert_text '自社研修生'
   end
+
+  test 'not show grass hide button for graduates' do
+    visit_with_auth "/users/#{users(:sotugyou).id}", 'sotugyou'
+    assert_no_text '非表示'
+  end
 end


### PR DESCRIPTION
## Issue
- #4347

## 概要
卒業生のダッシュボードに学習時間を非表示するボタンを作成しました。

卒業生本人が自分のダッシュボードの学習時間を非表示にできるような仕様となっています。
非表示にした情報はcookieにて保存しています。
個々のプロフィール画面では非表示ボタンは出現しないようになっています。

## 変更確認方法
1. ブランチ `feature/non-display-user-grass-for-graduate`をローカルに取り込む
1. `bin/setup`と`rails db:seed`を実行しDBの内容を開発環境に反映する
2. `rails s` でローカル環境を立ち上げる
3. 卒業生のアカウントでログインし、ダッシュボードの学習時間に非表示ボタンがあることを確認。クリックにて学習時間のコンポーネントが非表示になります(`sotugyou`確認しました)
4. 非表示にした情報は`user_grass`というcookieで保存しています。こちらを削除して更新していただくと、再度コンポーネントが表示されます。
5. 現役生のユーザーは非表示ボタンは出現せず、その他ロール(管理者、メンター等)では元々学習時間がダッシュボードで出現しない仕様となっています。

cookieの確認方法はこちらが参考になると思います(Google Chromeの場合)
[【Google Chrome】CookieのSameSite属性などをデベロッパーツールで確認する](https://atmarkit.itmedia.co.jp/ait/articles/2002/19/news021.html)

## 変更前
![localhost_3000_ (2)](https://user-images.githubusercontent.com/69446373/159240789-3c6b824f-2e93-4de0-bda5-5e28fa58cf73.png)

## 変更後
![localhost_3000_](https://user-images.githubusercontent.com/69446373/159802130-8844c02e-1121-4c1c-80ea-c090fadc4756.png)


## 参考PR
- #3163 (cookieの保存に関してこちらを参考にしました)