### PR TITLE
日報の個別ページでpublished_atがnilでもエラーが出ないように修正

### DIFF
--- a/app/views/reports/_product.html.slim
+++ b/app/views/reports/_product.html.slim
@@ -17,7 +17,10 @@
         .thread-list-item-meta
           .thread-list-item-meta__items
             .thread-list-item-meta__item
-              time.a-meta(datetime="#{product.published_at.to_datetime}")
+              - if product.published_at.nil?
+                time.a-meta(datetime="#{product.created_at.to_datetime}")
+              - else
+                time.a-meta(datetime="#{product.published_at.to_datetime}")
                 = l product.published_at
                 = 'の提出物'
       - if product.comments.any?

--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -124,3 +124,9 @@ product63:
   practice: practice6
   user: kimura
   body: プラクティス完了メッセージ未表示の提出物です。
+
+product64:
+  practice: practice6
+  user: daimyo
+  body: publish_atがnilの提出物です。
+  published_at: nil

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -376,3 +376,9 @@ product65:
   practice: practice6
   user: kimura
   body: プラクティス完了メッセージ未表示の提出物です。
+
+product66:
+  practice: practice6
+  user: daimyo
+  body: publish_atがnilの提出物です。
+  published_at: nil

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -485,9 +485,4 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '6日経過：1件'
     assert_text '7日以上経過：5件'
   end
-
-  test 'mentors can see reports　page if prodacts published_at is nil' do
-    visit_with_auth "/reports/#{reports(:report18).id}", 'mentormentaro'
-    assert_text '2020年06月01日 の日報'
-  end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -485,4 +485,9 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '6日経過：1件'
     assert_text '7日以上経過：5件'
   end
+
+  test 'mentors can see reports　page if prodacts published_at is nil' do
+    visit_with_auth "/reports/#{reports(:report18).id}", 'mentormentaro'
+    assert_text '2020年06月01日 の日報'
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -722,5 +722,5 @@ class ReportsTest < ApplicationSystemTestCase
     within('.success') do
       assert_text 'ここにメッセージが入ります。'
     end
-
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -723,4 +723,11 @@ class ReportsTest < ApplicationSystemTestCase
       assert_text 'ここにメッセージが入ります。'
     end
   end
+
+  test 'mentors can see reports page if products published_at is nil' do
+    visit_with_auth '/reports/unchecked', 'mentormentaro'
+    click_link 'テストのnippou'
+    assert_text '2020年06月01日 の日報'
+    assert_text '今日は1時間学習しました。'
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -689,6 +689,7 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '100日目の日報を提出しました。'
   end
 
+<<<<<<< HEAD
   test 'should ignore invalid class name to prevent XSS attack' do
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
@@ -722,5 +723,9 @@ class ReportsTest < ApplicationSystemTestCase
     within('.success') do
       assert_text 'ここにメッセージが入ります。'
     end
+
+  test 'mentors can see reports　page if products published_at is nil' do
+    visit_with_auth "/reports/#{reports(:report18).id}", 'mentormentaro'
+    assert_text '2020年06月01日 の日報'
   end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -689,7 +689,6 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '100日目の日報を提出しました。'
   end
 
-<<<<<<< HEAD
   test 'should ignore invalid class name to prevent XSS attack' do
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
@@ -724,8 +723,4 @@ class ReportsTest < ApplicationSystemTestCase
       assert_text 'ここにメッセージが入ります。'
     end
 
-  test 'mentors can see reports　page if products published_at is nil' do
-    visit_with_auth "/reports/#{reports(:report18).id}", 'mentormentaro'
-    assert_text '2020年06月01日 の日報'
-  end
 end


### PR DESCRIPTION
issue #4326 

## 概要
メンター権限を持つユーザーが個別ユーザーの日報を開くとき、その個別ユーザーの提出物の`published_at`が`nil`の時、
error`NoMethodError in Reports#show`が発生するため、`published_at`が`nill`の場合でもエラーが出ないように修正しました。
### 変更前
https://user-images.githubusercontent.com/64455939/159407732-66eda55f-ae48-42ab-8ba6-6a97213ef66e.mp4
### 変更後
https://user-images.githubusercontent.com/64455939/159407997-9e731b4f-76cd-40a7-a4c5-5ce90f202483.mp4

## 確認方法
1. `main`ブランチで、メンター権限を持つユーザーでログインし、日報一覧から`publish_at`が`nil`の提出物を持つ`kimura`氏の日報をクリックし、エラーを確認します。
1. ブランチ`bug/report_product_error_with_published_at_nil` をローカルに取り込み、1と同様の作業を行なって、エラーが出ないこと、提出物が見れることを確認します。