### PR TITLE
質問作成中にWIPしてもDiscordに通知が行かないように修正

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -47,7 +47,6 @@ class QuestionsController < ApplicationController
     @question.wip = params[:commit] == 'WIP'
     if @question.save
       create_mentors_watch
-      notify_to_chat(@question)
       redirect_to @question, notice: notice_message(@question)
     else
       render :new
@@ -75,10 +74,6 @@ class QuestionsController < ApplicationController
 
   def question_params
     params.require(:question).permit(:title, :description, :user_id, :resolve, :practice_id, :tag_list)
-  end
-
-  def notify_to_chat(question)
-    ChatNotifier.message("質問：#{question.title}が作成されました。\r#{question_url(question)}")
   end
 
   def set_watch

--- a/app/models/question_callbacks.rb
+++ b/app/models/question_callbacks.rb
@@ -5,6 +5,7 @@ class QuestionCallbacks
     return unless question.saved_change_to_attribute?(:published_at, from: nil)
 
     send_notification_to_mentors(question)
+    notify_to_chat(question)
     Cache.delete_not_solved_question_count
   end
 
@@ -14,6 +15,13 @@ class QuestionCallbacks
   end
 
   private
+
+  def notify_to_chat(question)
+    ChatNotifier.message(<<~TEXT)
+      質問：#{question.title}が作成されました。
+      https://bootcamp.fjord.jp/questions/#{question.id}
+    TEXT
+  end
 
   def send_notification_to_mentors(question)
     User.mentor.each do |user|


### PR DESCRIPTION
## Issue
- #4470 
 
## 概要
質問作成中にWIPするとDiscordに通知が行き、それを見たユーザーが質問ページに飛んで、まだ作成中の質問であることに気付いて無駄足となってしまう不具合を修正しました。

なお、Discord通知において開発環境で動作確認する際は、ソースコードを変更しての確認が必要です。
詳細は、動作確認手順をご覧ください。

## 参考PR
Refs: #4325 

## 動作確認手順
1. 手元に本ブランチを取り込む。
2. `dotenv-rails`というgemをインストールする
参考：[Railsで使える環境変数を管理できるgem(dotenv-rails)や.envの導入方法 - Qiita](https://qiita.com/ryosuketter/items/ceb592dc6b23a20e51b5)

```ruby
# Gemfile
   # not default
   gem 'bullet'
   gem 'bundle_outdated_formatter'
+  gem 'dotenv-rails'
   gem 'letter_opener_web', '~> 1.0'
   gem 'rack-dev-mark'
   gem 'rack-mini-profiler', '~> 2.0'
```

```
$ bundle install
```

3. .envファイルをbootcampディレクトリ配下に作成する

```
$ touch .env
```

4. 自分用のDiscordサーバーを作成する
参考：[Discord – サーバーの作り方と削除する方法 - 設定Lab](https://setup-lab.net/discord-server-creation-delete/#:~:text=Discord%E3%81%AE%E3%83%9B%E3%83%BC%E3%83%A0%E3%81%A7%E3%80%8C%2B%E3%80%8D,%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%81%8C%E4%BD%9C%E6%88%90%E3%81%95%E3%82%8C%E3%81%BE%E3%81%99%E3%80%82)
5. 4.で作成したサーバーのウェブフックURLをコピーしておく
参考：[DiscordのWebhookについて](https://popush.hatenablog.com/entry/2019/10/07/222047)

6. コピーしたウェブフックURLを環境変数として使いたいので、作成した.envファイルには下の内容を追記する

```env
DISCORD_TEST_WEBHOOK_URL = コピーしたウェブフックURL
```

7. app/models/chat_notifier.rbのmessageメソッドの記述を変更する

```ruby
# app/models/chat_notifier.rb
class ChatNotifier
  def self.message(
    message,
    username: 'ピヨルド',
-   webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
+   webhook_url: ENV['DISCORD_TEST_WEBHOOK_URL']
  )

-   if Rails.env.production?
+   if Rails.env.development?
      Discord::Notifier.message(message, username: username, url: webhook_url)
    else
      Rails.logger.info 'Message to Discord.'
    end
  end
..
```

Rails.env.development?にすることでtrueの分岐を実行することができる。
参考：[【Rails】 envメソッドで環境を確認する方法と各コマンドの指定方法 - Pikawaka](https://pikawaka.com/rails/env)

8. 動作確認をする

    1. 質問を新規作成し、「WIP」をクリックしてwip保存する。
    1. 自分で作成したDiscordチャンネルに通知が**来ない**のを確認する。
    1. wip保存した質問を「内容修正」から「質問を公開」をクリックして本公開する。
    1. 自分で作成したDiscordチャンネルに通知が**来る**のを確認する。
    1. 質問を新規作成し、「登録する」で本公開する。
    1. 自分で作成したDiscordチャンネルに通知が**来る**のを確認する。
