### PR TITLE
js-target-blank という class を削除

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -24,7 +24,7 @@
           @click='copyAnswerURLToClipboard(answer.id)'
         )
           | {{ updatedAt }}
-      .thread-comment__description.js-target-blank.a-long-text.is-md(
+      .thread-comment__description.a-long-text.is-md(
         v-html='markdownDescription'
       )
     .thread-comment__reactions

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -19,7 +19,7 @@
           @click='copyCommentURLToClipboard(comment.id)'
         )
           | {{ updatedAt }}
-      .thread-comment__description.js-target-blank.a-long-text.is-md(
+      .thread-comment__description.a-long-text.is-md(
         v-html='markdownDescription'
       )
     .thread-comment__reactions

--- a/app/javascript/practice_memo.vue
+++ b/app/javascript/practice_memo.vue
@@ -2,7 +2,7 @@
 .a-card
   div(v-if='!editing')
     .card-body(v-if='memo')
-      .js-target-blank.a-long-text.is-md(v-html='markdownMemo')
+      .a-long-text.is-md(v-html='markdownMemo')
     .thread-list(v-else)
       .thread-list__inner
         .container

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -72,7 +72,8 @@
       )
 
     .thread__body(v-if='!editing')
-      .thread__description.a-long-text.is-md(v-html='markdownDescription')
+      .thread-question__body
+        .thread__description.a-long-text.is-md(v-html='markdownDescription')
       .thread-question__reactions
         reaction(
           :reactionable='question',

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -72,10 +72,7 @@
       )
 
     .thread__body(v-if='!editing')
-      .thread-question__body
-        .thread__description.a-long-text.is-md(
-          v-html='markdownDescription'
-        )
+      .thread__description.a-long-text.is-md(v-html='markdownDescription')
       .thread-question__reactions
         reaction(
           :reactionable='question',

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -73,7 +73,7 @@
 
     .thread__body(v-if='!editing')
       .thread-question__body
-        .thread__description.js-target-blank.a-long-text.is-md(
+        .thread__description.a-long-text.is-md(
           v-html='markdownDescription'
         )
       .thread-question__reactions

--- a/app/javascript/user_mentor_memo.vue
+++ b/app/javascript/user_mentor_memo.vue
@@ -4,7 +4,7 @@ section.a-card.is-memo.is-only-mentor
     h2.card-header__title
       | メンター向けユーザーメモ
   .card-body(v-if='!editing')
-    .js-target-blank.a-long-text.is-md(v-html='markdownMemo')
+    .a-long-text.is-md(v-html='markdownMemo')
     .o-empty-message(v-if='memo.length === 0')
       .o-empty-message__icon
         i.far.fa-sad-tear

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -38,7 +38,7 @@
                 | コピー
 
     .thread__body
-      .thread__description.js-target-blank.a-long-text.is-md.js-markdown-view
+      .thread__description.a-long-text.is-md.js-markdown-view
         = announcement.description
       = render 'reactions/reactions', reactionable: @announcement
       .card-footer

--- a/app/views/courses/practices/sort/index.html.slim
+++ b/app/views/courses/practices/sort/index.html.slim
@@ -32,7 +32,7 @@ header.page-header
                   h2.categories-item__title
                     = category.name
                 .categories-item__description
-                  .js-markdown-view.js-target-blank.a-long-text.is-md
+                  .js-markdown-view.a-long-text.is-md
                     = category.description
                 .categories-item__body
                   .category-practices.js-category-practices

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -57,7 +57,7 @@
 
     .thread__body
       = render('event_meta', event: event)
-      .thread__description.js-target-blank.a-long-text.is-md.js-markdown-view
+      .thread__description.a-long-text.is-md.js-markdown-view
         = event.description
       - unless event.wip?
         = render 'events/participation', event: event

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -94,7 +94,7 @@ header.page-header
             data-page-id="#{@page.id}"
           )
         .thread__body
-          .thread__description.js-markdown-view.js-target-blank.a-long-text.is-md
+          .thread__description.js-markdown-view.a-long-text.is-md
             = @page.body
           = render 'reactions/reactions', reactionable: @page
         footer.card-footer

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -68,7 +68,7 @@
             h2.card-header__title
               = Practice.human_attribute_name :description
           .practice-content__body.is-practice
-            .js-markdown-view.js-target-blank.a-long-text.is-md
+            .js-markdown-view.a-long-text.is-md
               = @practice.description
           footer.card-footer
             .card-main-actions
@@ -110,7 +110,7 @@
             h2.card-header__title
               = Practice.human_attribute_name :goal
           .practice-content__body.is-goal
-            .js-markdown-view.js-target-blank.a-long-text.is-md
+            .js-markdown-view.a-long-text.is-md
               = @practice.goal
             - if !current_user.adviser? && @practice.open_product?
               = render '/practices/practice_content_notice'
@@ -138,7 +138,7 @@
               h2.card-header__title
                 = Practice.human_attribute_name :memo
             .practice-content__body.is-memo
-              .js-markdown-view.js-target-blank.a-long-text.is-md
+              .js-markdown-view.a-long-text.is-md
                 = @practice.memo
           section.a-card.is-only-mentor
             header.card-header

--- a/app/views/products/new.html.slim
+++ b/app/views/products/new.html.slim
@@ -13,7 +13,7 @@ header.page-header
           .card-header
             h2.card-header__title
               = Practice.human_attribute_name :goal
-          .practice-content__body.is-goal.js-markdown-view.js-target-blank.a-long-text
+          .practice-content__body.is-goal.js-markdown-view.a-long-text
             = @product.practice.goal
     .page-body__row
       .container.is-xxl

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -109,9 +109,9 @@ header.page-header
             - if @product.wip?
               .thread__warning-message
                 | まだ提出されていません。<br class='is-hidden-md-up'>完成したら「提出する」をクリック！
-            .thread__description.js-target-blank.a-long-text.is-md.js-markdown-view
+            .thread__description.a-long-text.is-md.js-markdown-view
               =  @product.practice.goal
-            .thread__description.js-target-blank.a-long-text.is-md.js-markdown-view(data-taskable-id="#{@product.id}" data-taskable-type='Product' data-taskable="#{@product.taskable?(current_user).to_s}")
+            .thread__description.a-long-text.is-md.js-markdown-view(data-taskable-id="#{@product.id}" data-taskable-type='Product' data-taskable="#{@product.taskable?(current_user).to_s}")
               =  @product.body
             = render 'reactions/reactions', reactionable: @product
 

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -98,7 +98,7 @@ header.page-header
             = render 'reports/learning_times', report: @report
 
             .thread__body
-              .thread__description.js-target-blank.a-long-text.is-md.js-markdown-view(data-taskable-id="#{@report.id}" data-taskable-type='Report' data-taskable="#{@report.taskable?(current_user).to_s}")
+              .thread__description.a-long-text.is-md.js-markdown-view(data-taskable-id="#{@report.id}" data-taskable-type='Report' data-taskable="#{@report.taskable?(current_user).to_s}")
                 = @report.description
               = render 'reactions/reactions', reactionable: @report
 

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -34,7 +34,7 @@ header.page-header
             h1.thread-header-title
               span.thread-header-title__title
                 = @work.title
-        .thread__description.js-target-blank
+        .thread__description
           - if @work.thumbnail.attached?
             p
               = image_tag @work.thumbnail_url, alt: @work.title


### PR DESCRIPTION
Issue https://github.com/fjordllc/bootcamp/issues/4125

HTMLから`js-target-blank`というclassを削除しました。
リポジトリのコードを対象に`js-target-blank`を検索し、該当する部分をすべて削除しました。

修正前
![image](https://user-images.githubusercontent.com/770527/159834265-abfe2710-b468-415b-a570-b16625c8ee6e.png)

修正後
![image](https://user-images.githubusercontent.com/770527/159834298-6c798c18-ed7f-46ab-80a4-17561886b5bc.png)
