### PR TITLE
ユーザーの解決済みの質問だけではなく、全ての質問を取得するよう修正

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -14,7 +14,7 @@ class API::QuestionsController < API::BaseController
         Question.not_solved
       end
     questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
-    questions = params[:user_id].present? ? questions.where(user_id: params[:user_id]) : questions
+    questions = params[:user_id].present? ? Question.where(user_id: params[:user_id]) : questions
     questions = questions.tagged_with(params[:tag]) if params[:tag]
     @questions = questions
                  .with_avatar

--- a/test/system/user/questions_test.rb
+++ b/test/system/user/questions_test.rb
@@ -7,4 +7,11 @@ class User::QuestionsTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{users(:hatsuno).id}/questions", 'hatsuno'
     assert_equal 'hatsuno | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
+
+  test 'show solved and unsolved questions' do
+    visit_with_auth "/users/#{users(:hajime).id}/questions", 'hajime'
+    assert_text '解決済みの質問'
+    assert_text '検索ワードが太字で表示されるかのテスト用の質問'
+    assert_no_text '質問はありません'
+  end
 end


### PR DESCRIPTION
- #4484
## 概要
ユーザー＞質問一覧にて、解決済みの質問が表示されていませんでした(未解決の質問は表示されています。)
質問のAPI取得方法が間違っておりましたので修正しています。

### 変更前
解決済みの質問からユーザーの質問を取得
<img width="855" alt="image" src="https://user-images.githubusercontent.com/69446373/159884816-250ae3eb-3a8d-4870-9b9b-6975e6ecfb2c.png">

### 変更後
全ての質問からユーザーの質問を取得
<img width="868" alt="image" src="https://user-images.githubusercontent.com/69446373/159884677-731c62aa-7045-415f-b427-10019a692c9a.png">
