### PR TITLE
相談部屋にアクセスすると表示される404エラーを解消

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -64,7 +64,7 @@ nav.global-nav
             .global-nav-links__link-label ヘルプ
         - if admin_login? || student_login?
           li.global-nav-links__item
-            = link_to unreplied_index_path(current_user_path), class: "global-nav-links__link #{current_link(/talk/)}" do
+            = link_to unreplied_index_path(current_user.talk), class: "global-nav-links__link #{current_link(/talk/)}" do
               .global-nav-links__link-icon
                 i.fas.fa-comment-alt-smile
               - if admin_or_mentor_login? && Talk.unreplied.count.positive?

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -141,6 +141,12 @@ class TalksTest < ApplicationSystemTestCase
     assert_equal '/talks/unreplied', current_path
   end
 
+  test 'Displays users talks page when user loged in ' do
+    visit_with_auth '/', 'kimura'
+    click_link '相談'
+    assert_text "kimuraさんの相談部屋"
+  end
+
   test 'Display number of comments, detail of lastest comment user' do
     visit_with_auth '/talks', 'komagata'
     within('.thread-list-item-comment') do

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -144,7 +144,7 @@ class TalksTest < ApplicationSystemTestCase
   test 'Displays users talks page when user loged in ' do
     visit_with_auth '/', 'kimura'
     click_link '相談'
-    assert_text "kimuraさんの相談部屋"
+    assert_text 'kimuraさんの相談部屋'
   end
 
   test 'Display number of comments, detail of lastest comment user' do


### PR DESCRIPTION
- issue #4485 
## 概要
相談部屋のグローバルナビから相談部屋に偏移すると、URLに/current_userが文字列で渡って404エラーが表示される問題が起こるのを、変数`current_user_path`を`current_user.talk`に変更することで修正しました。
### 変更前
URL `https://bootcamp.fjord.jp/talks/%2Fcurrent_user`
![ご指定のページが見つかりません](https://user-images.githubusercontent.com/64455939/159899504-e8a87055-0504-476e-8e09-f0d3c0272060.png)
### 変更後
![_development__kimuraさんの相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/159899684-9491773f-5fba-41d4-b30a-1019faa4de5b.png)


