### PR TITLE
Choices.jsのエラーを解消した

### DIFF
--- a/app/javascript/company-select.js
+++ b/app/javascript/company-select.js
@@ -1,11 +1,15 @@
 import Choices from 'choices.js'
 
 document.addEventListener('DOMContentLoaded', () => {
-  return new Choices('#js-company-select', {
-    removeItemButton: true,
-    searchResultLimit: 10,
-    searchPlaceholderValue: '検索ワード',
-    noResultsText: '一致する情報は見つかりません',
-    itemSelectText: '選択'
-  })
+  const element = document.getElementById('js-company-select')
+  if (element) {
+    return new Choices(element, {
+      removeItemButton: true,
+      allowHTML: true,
+      searchResultLimit: 10,
+      searchPlaceholderValue: '検索ワード',
+      noResultsText: '一致する情報は見つかりません',
+      itemSelectText: '選択'
+    })
+  }
 })


### PR DESCRIPTION
## issue
- #4483

## 概要
Choices.jsを導入した際(#4385)に出現してしまったコンソールのエラーを解消しました。

- Choices.jsを使うページではエラーは非表示、それ以外のページだと表示されていたので、
セレクトボックスのidの有無で`new Choices`をする形にいたしました。
- `allowHTML`オプションを設定するよう警告も出ていたため追加しています。

## 変更確認方法
1. ブランチ `bug/resolve-choices.js-errors`をローカルに取り込む
1. `bin/setup`と`rails db:seed`を実行しDBの内容を開発環境に反映する
2. `rails s` でローカル環境を立ち上げ、デベロッパーツールを開いていただくと変更点が確認できます

## 変更前
<img width="837" alt="スクリーンショット 2022-03-25 0 16 03" src="https://user-images.githubusercontent.com/69446373/159951865-e155960c-6f27-4f04-8c64-2b858e61b15a.png">

## 変更後
<img width="839" alt="スクリーンショット 2022-03-25 0 14 05" src="https://user-images.githubusercontent.com/69446373/159951892-2111e18d-2ace-45b5-ba6f-8a95195e409e.png">

