### PR TITLE
メッセージブロック機能でのXSSの危険性がある正規表現を修正

### DIFF
--- a/app/javascript/markdown-it-container-message.js
+++ b/app/javascript/markdown-it-container-message.js
@@ -3,7 +3,9 @@ import MarkdownItContainer from 'markdown-it-container'
 export default (md) => {
   md.use(MarkdownItContainer, 'message', {
     render: (tokens, idx) => {
-      const messageInfo = tokens[idx].info.trim().match(/^message\s+(alert|danger|warning|info|primary|success)$/)
+      const messageInfo = tokens[idx].info
+        .trim()
+        .match(/^message\s+(alert|danger|warning|info|primary|success)$/)
       const messageName = messageInfo ? ` ${messageInfo[1]}` : ''
       if (tokens[idx].nesting === 1) {
         return `<div class="message${messageName}">\n`

--- a/app/javascript/markdown-it-container-message.js
+++ b/app/javascript/markdown-it-container-message.js
@@ -3,7 +3,7 @@ import MarkdownItContainer from 'markdown-it-container'
 export default (md) => {
   md.use(MarkdownItContainer, 'message', {
     render: (tokens, idx) => {
-      const messageInfo = tokens[idx].info.trim().match(/^message\s+(.*)$/)
+      const messageInfo = tokens[idx].info.trim().match(/^message\s+(alert|danger|warning|info|primary|success)$/)
       const messageName = messageInfo ? ` ${messageInfo[1]}` : ''
       if (tokens[idx].nesting === 1) {
         return `<div class="message${messageName}">\n`

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -688,4 +688,17 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text 'おめでとう！'
     assert_text '100日目の日報を提出しました。'
   end
+
+  test 'should ignore unexpected class name to prevent XSS attack' do
+    visit_with_auth '/reports/new', 'komagata'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: ":::message \"></div><a href=\"javascript:alert('XSS');\">クリックしてね</a><div class=\"\nメッセージ\n:::")
+      fill_in('report[reported_on]', with: Time.current)
+
+      check '学習時間は無し', allow_label_click: true
+    end
+    click_button '提出'
+    assert_no_text 'クリックしてね'
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -693,12 +693,26 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: ":::message \"></div><a href=\"javascript:alert('XSS');\">クリックしてね</a><div class=\"\nメッセージ\n:::")
+      fill_in('report[description]', with: ":::message \"></div><a href=\"javascript:alert('XSS');\">クリックしてね</a><div class=\"\nここにメッセージが入ります。\n:::")
       fill_in('report[reported_on]', with: Time.current)
-
       check '学習時間は無し', allow_label_click: true
     end
     click_button '提出'
+    assert_text 'ここにメッセージが入ります。'
     assert_no_text 'クリックしてね'
+  end
+
+  test 'should accept genuine class name' do
+    visit_with_auth '/reports/new', 'komagata'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: ":::message success\nここにメッセージが入ります。\n:::")
+      fill_in('report[reported_on]', with: Time.current)
+      check '学習時間は無し', allow_label_click: true
+    end
+    click_button '提出'
+    within(:css, '.success') do
+      assert_text 'ここにメッセージが入ります。'
+    end
   end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -711,7 +711,7 @@ class ReportsTest < ApplicationSystemTestCase
       check '学習時間は無し', allow_label_click: true
     end
     click_button '提出'
-    within(:css, '.success') do
+    within('.success') do
       assert_text 'ここにメッセージが入ります。'
     end
   end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -689,7 +689,7 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '100日目の日報を提出しました。'
   end
 
-  test 'should ignore unexpected class name to prevent XSS attack' do
+  test 'should ignore invalid class name to prevent XSS attack' do
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
@@ -706,7 +706,7 @@ class ReportsTest < ApplicationSystemTestCase
     assert_no_text 'クリックしてね'
   end
 
-  test 'should accept genuine class name' do
+  test 'should accept valid class name' do
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: 'test title')

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -693,7 +693,11 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: ":::message \"></div><a href=\"javascript:alert('XSS');\">クリックしてね</a><div class=\"\nここにメッセージが入ります。\n:::")
+      fill_in('report[description]', with: <<~TEXT)
+        :::message "></div><a href="javascript:alert('XSS');">クリックしてね</a><div class="
+        ここにメッセージが入ります。
+        :::
+      TEXT
       fill_in('report[reported_on]', with: Time.current)
       check '学習時間は無し', allow_label_click: true
     end
@@ -706,7 +710,11 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: ":::message success\nここにメッセージが入ります。\n:::")
+      fill_in('report[description]', with: <<~TEXT)
+        :::message success
+        ここにメッセージが入ります。
+        :::
+      TEXT
       fill_in('report[reported_on]', with: Time.current)
       check '学習時間は無し', allow_label_click: true
     end


### PR DESCRIPTION
## 概要
- #4491
#4424 での変更で、XSSの危険性がある正規表現があったため、有効なクラス名だけが捕捉できる正規表現に書き換え、テストを追加しました。

## 変更前
[![Image from Gyazo](https://i.gyazo.com/e3fe114c24146e55390bde916d6ca07f.gif)](https://gyazo.com/e3fe114c24146e55390bde916d6ca07f)

クラス名にJSが埋め込めてしまうのでXSSが行えてしまう

## 変更後

[![Image from Gyazo](https://i.gyazo.com/145d8d4987c49ae7a6590296f3f06573.gif)](https://gyazo.com/145d8d4987c49ae7a6590296f3f06573)

指定したクラス名以外は無視されるので、XSSが行えない

## 確認手順
1. `bug/prevent-XSS-attack-from-markdown-original-message-block`を手元に取り込む
2. 任意のユーザーでログイン後、日報新規作成画面で下記を入力して保存
```
:::message "></div><a href="javascript:alert('XSS');">クリックしてね</a><div class="
メッセージ
:::
```
3. `クリックしてね`というリンクが表示されておらず、`メッセージ`のみがメッセージブロック内に表示されていることを確認