### PR TITLE
登録情報変更時アドバイザーは卒業後の希望欄を非表示にする

### DIFF
--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -17,8 +17,8 @@
     = render 'users/form/avatar', f: f, user: user
     = render 'users/form/description', f: f, user: user
     = render 'users/form/tags', f: f, user: user
-    = render 'users/form/after_graduation_hope', f: f, user: user
     - unless user.adviser?
+      = render 'users/form/after_graduation_hope', f: f, user: user
       = render 'users/form/job', f: f
       = render 'users/form/os', f: f
       = render 'users/form/prefecture', f: f

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -55,4 +55,11 @@ class CurrentUserTest < ApplicationSystemTestCase
     click_button '更新する'
     assert_text '分報URLはDiscordのチャンネルURLを入力してください'
   end
+
+  test 'Do not show after graduation hope when advisor' do
+    visit_with_auth '/current_user/edit', 'hajime'
+    assert_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください'
+    visit_with_auth '/current_user/edit', 'senpai'
+    assert_no_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください'
+  end
 end


### PR DESCRIPTION
Issue https://github.com/fjordllc/bootcamp/issues/4449

通常の生徒の場合、卒業後の希望欄が表示される。
![image](https://user-images.githubusercontent.com/770527/160059189-68040f32-8578-4ba6-ab15-4fdc308253c0.png)


アドバイザーの場合、卒業後の希望欄は表示されない。

![image](https://user-images.githubusercontent.com/770527/160058968-b8a74ba5-7f4d-41bb-bdbb-1285dd1c186a.png)
