### PR TITLE
検索結果一覧でWIPの日報やDocsを識別できるようにした

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -43,9 +43,4 @@ module SearchHelper
   def talk?(searchable)
     searchable.instance_of?(User) && searchable.talk.present?
   end
-
-  def can_be_wip?(searchable)
-    class_names = [Announcement, Event, Page, Product, Question, Report]
-    class_names.any? { |class_name| searchable.is_a?(class_name) }
-  end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -44,7 +44,8 @@ module SearchHelper
     searchable.instance_of?(User) && searchable.talk.present?
   end
 
-  def no_wip?(searchable)
-    searchable.is_a?(Practice) || searchable.is_a?(Answer) || searchable.is_a?(User) || searchable.is_a?(Comment)
+  def can_be_wip?(searchable)
+    class_names = [Announcement, Event, Page, Product, Question, Report]
+    class_names.any? { |class_name| searchable.is_a?(class_name) }
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -44,7 +44,7 @@ module SearchHelper
     searchable.instance_of?(User) && searchable.talk.present?
   end
 
-  def have_no_wip?(searchable)
+  def no_wip?(searchable)
     searchable.is_a?(Practice) || searchable.is_a?(Answer) || searchable.is_a?(User) || searchable.is_a?(Comment)
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -43,4 +43,8 @@ module SearchHelper
   def talk?(searchable)
     searchable.instance_of?(User) && searchable.talk.present?
   end
+
+  def have_no_wip?(searchable)
+    searchable.is_a?(Practice) || searchable.is_a?(Answer) || searchable.is_a?(User) || searchable.is_a?(Comment)
+  end
 end

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -58,9 +58,6 @@ export default {
     }
   },
   computed: {
-    modelName() {
-      return `is-${this.searchable.model_name}`
-    },
     userUrl() {
       return `/users/${this.searchable.user_id}`
     },

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -95,7 +95,7 @@ export default {
       }
     },
     searchableClass() {
-      if (this.searchable.have_no_wip) {
+      if (this.searchable.no_wip) {
         return `is-${this.searchable.model_name}`
       } else if (this.searchable.wip) {
         return `is-wip is-${this.searchable.model_name}`

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.thread-list-item(:class='modelName')
+.thread-list-item(:class='searchableClass')
   .thread-list-item__inner
     .thread-list-item__label(v-if='searchable.is_comment_or_answer')
       | {{ searchable.model_name_with_i18n }}
@@ -10,6 +10,8 @@
     .thread-list-item__rows
       .thread-list-item__row
         .thread-list-item-title
+          .thread-list-item-title__icon.is-wip(v-if='searchable.wip')
+            | WIP
           .thread-list-item-title__title
             a.thread-list-item-title__link(:href='searchable.url')
               | {{ searchable.title }}
@@ -90,6 +92,15 @@ export default {
         )
       } else {
         return this.searchable.summary
+      }
+    },
+    searchableClass() {
+      if (this.searchable.have_no_wip) {
+        return `is-${this.searchable.model_name}`
+      } else if (this.searchable.wip) {
+        return `is-wip is-${this.searchable.model_name}`
+      } else {
+        return `is-${this.searchable.model_name}`
       }
     }
   }

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -95,9 +95,7 @@ export default {
       }
     },
     searchableClass() {
-      if (this.searchable.no_wip) {
-        return `is-${this.searchable.model_name}`
-      } else if (this.searchable.wip) {
+      if (this.searchable.wip) {
         return `is-wip is-${this.searchable.model_name}`
       } else {
         return `is-${this.searchable.model_name}`

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -5,7 +5,7 @@ json.model_name document.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
-if searchable.has_attribute?(:wip)
+if searchable.respond_to?(:wip)
   json.wip searchable.wip
 end
 if searchable.respond_to?(:user)

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -5,12 +5,9 @@ json.model_name document.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
-if !no_wip?(searchable)
-  if searchable.wip.present?
-    json.wip searchable.wip
-  end
+if can_be_wip?(searchable)
+  json.wip searchable.wip
 end
-json.no_wip no_wip?(searchable)
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -5,12 +5,12 @@ json.model_name document.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
-if !have_no_wip?(searchable)
+if !no_wip?(searchable)
   if searchable.wip.present?
     json.wip searchable.wip
   end
 end
-json.have_no_wip have_no_wip?(searchable)
+json.no_wip no_wip?(searchable)
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -5,6 +5,12 @@ json.model_name document.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
+if !have_no_wip?(searchable)
+  if searchable.wip.present?
+    json.wip searchable.wip
+  end
+end
+json.have_no_wip have_no_wip?(searchable)
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -5,7 +5,7 @@ json.model_name document.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
-if can_be_wip?(searchable)
+if searchable.has_attribute?(:wip)
   json.wip searchable.wip
 end
 if searchable.respond_to?(:user)

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -5,9 +5,7 @@ json.model_name document.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
-if searchable.respond_to?(:wip?)
-  json.wip searchable.wip?
-end
+json.wip searchable.respond_to?(:wip?) ? searchable.wip? : false
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -5,8 +5,8 @@ json.model_name document.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
 json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
 json.updated_at searchable.updated_at
-if searchable.respond_to?(:wip)
-  json.wip searchable.wip
+if searchable.respond_to?(:wip?)
+  json.wip searchable.wip?
 end
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name


### PR DESCRIPTION
## Issue概要
- #4420

検索結果一覧では、見た目上WIPとそうでないものとの区別がつかないため、WIPであることを見て分かるように修正しました。

## 変更前
![image](https://user-images.githubusercontent.com/63531341/160328744-be5d85e6-05fd-4cbb-9357-a77951d7804d.png)
WIPとWIPでないものが混在しているが、どれがWIPか分からない

## 変更後
![image](https://user-images.githubusercontent.com/63531341/160328970-b238ec82-2243-45e4-b6c3-68587e3a69b1.png)
WIPのものがひと目でわかるようになった

## 確認手順
1. `feature/identify-wip-from-search-results`を手元に取り込む
1. `bin/rails setup`実行
1. `bin/rails s`でサーバーを立ち上げる
1. 好きなユーザーでログインし、好きな文字列でWIPとWIPでない日報を作成する
1. 検索フォームから先ほど作成した日報に記載の文字列で検索を行い、検索画面一覧からWIPとWIPでない日報の区別がつくことを確認する