### PR TITLE
メンターが未アサインの提出物にコメントしたら、担当者になったことを画面上に反映するようにした

### DIFF
--- a/app/controllers/api/products/checker_controller.rb
+++ b/app/controllers/api/products/checker_controller.rb
@@ -2,10 +2,21 @@
 
 class API::Products::CheckerController < API::BaseController
   before_action :require_mentor_login_for_api
-  before_action :set_product, only: %i[update]
+  before_action :set_product, only: %i[update destroy]
 
   def update
     if @product.save_checker(params[:current_user_id])
+      render json: {
+        checker_id: @product.checker_id,
+        checker_name: @product.checker_name
+      }
+    else
+      render status: :bad_request, json: { message: 'すでに他のメンターが担当者になっています。' }
+    end
+  end
+
+  def destroy
+    if @product.update(checker_id: nil)
       render json: {
         checker_id: @product.checker_id,
         checker_name: @product.checker_name

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class API::ProductsController < API::BaseController
-  before_action :require_staff_login_for_api, only: %i[index show]
+  before_action :require_login_for_api, only: %i[index show]
 
   def index
     @company = Company.find(params[:company_id]) if params[:company_id]

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class API::ProductsController < API::BaseController
-  before_action :require_login_for_api, only: :index
+  before_action :require_staff_login_for_api, only: %i[index show]
 
   def index
     @company = Company.find(params[:company_id]) if params[:company_id]
@@ -11,5 +11,9 @@ class API::ProductsController < API::BaseController
                 .page(params[:page])
     @products_grouped_by_elapsed_days = @products.group_by { |product| product.elapsed_days >= 7 ? 7 : product.elapsed_days }
     @products = @products.joins(:user).where(users: { company_id: params[:company_id] }) if params[:company_id]
+  end
+
+  def show
+    @product = Product.find(params[:id])
   end
 end

--- a/app/javascript/check-store.js
+++ b/app/javascript/check-store.js
@@ -80,7 +80,7 @@ export default new Vuex.Store({
     },
     setProduct({ commit }, { productId }) {
       const meta = document.querySelector('meta[name="csrf-token"]')
-      fetch(`/api/products.json/?id=${productId}`, {
+      fetch(`/api/products/${productId}.json`, {
         method: 'GET',
         headers: {
           'X-Requested-With': 'XMLHttpRequest',
@@ -92,10 +92,10 @@ export default new Vuex.Store({
           return response.json()
         })
         .then((json) => {
-          if (json.products[0].checker_id !== null) {
+          if (json.products.checker_id !== null) {
             commit('setProduct', {
-              productId: json.products[0].id,
-              productCheckerId: json.products[0].checker_id
+              productId: json.products.id,
+              productCheckerId: json.products.checker_id
             })
           } else {
             commit('setProduct', {

--- a/app/javascript/check-store.js
+++ b/app/javascript/check-store.js
@@ -91,11 +91,11 @@ export default new Vuex.Store({
         .then((response) => {
           return response.json()
         })
-        .then((json) => {
-          if (json.checker_id !== null) {
+        .then((product) => {
+          if (product.checker_id !== null) {
             commit('setProduct', {
-              productId: json.id,
-              productCheckerId: json.checker_id
+              productId: product.id,
+              productCheckerId: product.checker_id
             })
           } else {
             commit('setProduct', {

--- a/app/javascript/check-store.js
+++ b/app/javascript/check-store.js
@@ -9,14 +9,18 @@ export default new Vuex.Store({
     userName: null,
     createdAt: null,
     checkableId: null,
-    checkableType: null
+    checkableType: null,
+    productId: null,
+    productCheckerId: null
   },
   getters: {
     checkId: (state) => state.checkId,
     userName: (state) => state.userName,
     createdAt: (state) => state.createdAt,
     checkableId: (state) => state.checkableId,
-    checkableType: (state) => state.checkableType
+    checkableType: (state) => state.checkableType,
+    productId: (state) => state.productId,
+    productCheckerId: (state) => state.productCheckerId
   },
   mutations: {
     setCheckable(
@@ -28,6 +32,10 @@ export default new Vuex.Store({
       state.createdAt = createdAt
       state.checkableId = checkableId
       state.checkableType = checkableType
+    },
+    setProduct(state, { productId, productCheckerId }) {
+      state.productId = productId
+      state.productCheckerId = productCheckerId
     }
   },
   actions: {
@@ -63,6 +71,36 @@ export default new Vuex.Store({
               userName: null,
               checkableId: checkableId,
               checkableType: checkableType
+            })
+          }
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
+    },
+    setProduct({ commit }, { productId }) {
+      const meta = document.querySelector('meta[name="csrf-token"]')
+      fetch(`/api/products.json/?id=${productId}`, {
+        method: 'GET',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': meta ? meta.getAttribute('content') : ''
+        },
+        credentials: 'same-origin'
+      })
+        .then((response) => {
+          return response.json()
+        })
+        .then((json) => {
+          if (json.products[0].checker_id !== null) {
+            commit('setProduct', {
+              productId: json.products[0].id,
+              productCheckerId: json.products[0].checker_id
+            })
+          } else {
+            commit('setProduct', {
+              productId: productId,
+              productCheckerId: null
             })
           }
         })

--- a/app/javascript/check-store.js
+++ b/app/javascript/check-store.js
@@ -92,10 +92,10 @@ export default new Vuex.Store({
           return response.json()
         })
         .then((json) => {
-          if (json.products.checker_id !== null) {
+          if (json.checker_id !== null) {
             commit('setProduct', {
-              productId: json.products.id,
-              productCheckerId: json.products.checker_id
+              productId: json.id,
+              productCheckerId: json.checker_id
             })
           } else {
             commit('setProduct', {

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -21,7 +21,8 @@
           :checkerAvatar='checkerAvatar',
           :currentUserId='currentUserId',
           :productId='checkableId',
-          :checkableType='checkableType'
+          :checkableType='checkableType',
+          :parentComponent='"check"'
         )
       li.card-main-actions__item(:class='checkId ? "is-sub" : ""')
         button#js-shortcut-check.is-block(

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -66,14 +66,6 @@ export default {
         .catch((error) => {
           console.warn(error)
         })
-      // .then(() => {
-      //   this.$store.dispatch('setProduct', {
-      //     productId: productId
-      //   })
-      // })
-      // .catch((error) => {
-      //   console.warn(error)
-      // })
     }
   }
 }

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -27,7 +27,7 @@ export default {
           console.warn(error)
         })
     },
-    checker(productId, currentUserId, url, method, token) {
+    checkProduct(productId, currentUserId, url, method, token) {
       const params = {
         product_id: productId,
         current_user_id: currentUserId
@@ -44,14 +44,36 @@ export default {
         redirect: 'manual',
         body: JSON.stringify(params)
       })
-        .then(() => {
-          this.$store.dispatch('setProduct', {
-            productId: productId
-          })
+        .then((response) => {
+          return response.json()
+        })
+        .then((json) => {
+          if (json.message) {
+            alert(json.message)
+          } else {
+            this.id = json.checker_id
+            this.name = json.checker_name
+            if (this.id !== null) {
+              this.toast('担当になりました。')
+            } else {
+              this.toast('担当から外れました。')
+            }
+            this.$store.dispatch('setProduct', {
+              productId: productId
+            })
+          }
         })
         .catch((error) => {
           console.warn(error)
         })
+      // .then(() => {
+      //   this.$store.dispatch('setProduct', {
+      //     productId: productId
+      //   })
+      // })
+      // .catch((error) => {
+      //   console.warn(error)
+      // })
     }
   }
 }

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -26,6 +26,32 @@ export default {
         .catch((error) => {
           console.warn(error)
         })
+    },
+    checker(productId, currentUserId, url, method, token) {
+      const params = {
+        product_id: productId,
+        current_user_id: currentUserId
+      }
+
+      fetch(url, {
+        method: method,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': token
+        },
+        credentials: 'same-origin',
+        redirect: 'manual',
+        body: JSON.stringify(params)
+      })
+        .then(() => {
+          this.$store.dispatch('setProduct', {
+            productId: productId
+          })
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
     }
   }
 }

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -221,7 +221,10 @@ export default {
         .catch((error) => {
           console.warn(error)
         })
-      if (this.productCheckerId === null) {
+      if (
+        this.commentableType === 'Product' &&
+        this.productCheckerId === null
+      ) {
         this.checkProduct(
           this.commentableId,
           this.currentUserId,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -213,7 +213,15 @@ export default {
           this.tab = 'comment'
           this.buttonDisabled = false
           this.resizeTextarea()
-          this.toast('コメントを投稿しました！')
+          const assignmentButton = document.getElementById('js-assignment')
+          if (
+            assignmentButton !== null &&
+            assignmentButton.textContent === '担当する'
+          ) {
+            assignmentButton.click()
+          } else {
+            this.toast('コメントを投稿しました！')
+          }
         })
         .catch((error) => {
           console.warn(error)

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -122,6 +122,9 @@ export default {
     },
     daimyoClass() {
       return { 'is-daimyo': this.currentUser.daimyo }
+    },
+    productCheckerId() {
+      return this.$store.getters.productCheckerId
     }
   },
   created() {
@@ -218,13 +221,15 @@ export default {
         .catch((error) => {
           console.warn(error)
         })
-      this.checker(
-        this.commentableId,
-        this.currentUserId,
-        '/api/products/checker',
-        'PATCH',
-        this.token()
-      )
+      if (this.productCheckerId === null) {
+        this.checkProduct(
+          this.commentableId,
+          this.currentUserId,
+          '/api/products/checker',
+          'PATCH',
+          this.token()
+        )
+      }
     },
     deleteComment(id) {
       fetch(`/api/comments/${id}.json`, {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -218,6 +218,13 @@ export default {
         .catch((error) => {
           console.warn(error)
         })
+      this.checker(
+        this.commentableId,
+        this.currentUserId,
+        '/api/products/checker',
+        'PATCH',
+        this.token()
+      )
     },
     deleteComment(id) {
       fetch(`/api/comments/${id}.json`, {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -213,15 +213,7 @@ export default {
           this.tab = 'comment'
           this.buttonDisabled = false
           this.resizeTextarea()
-          const assignmentButton = document.getElementById('js-assignment')
-          if (
-            assignmentButton !== null &&
-            assignmentButton.textContent === '担当する'
-          ) {
-            assignmentButton.click()
-          } else {
-            this.toast('コメントを投稿しました！')
-          }
+          this.toast('コメントを投稿しました！')
         })
         .catch((error) => {
           console.warn(error)

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -116,7 +116,8 @@
         :checkerName='product.checker_name',
         :checkerAvatar='product.checker_avatar',
         :currentUserId='currentUserId',
-        :productId='product.id'
+        :productId='product.id',
+        :parentComponent='"product"'
       )
 </template>
 <script>

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-button#js-assignment.is-block(
+button(
   v-if='!checkerId || checkerId == currentUserId',
   :class='["a-button", "is-block", id ? "is-warning" : "is-secondary", checkableType ? "is-sm" : "is-sm"]',
   @click='check'

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -2,12 +2,12 @@
 button(
   v-if='!checkerId || checkerId == currentUserId',
   :class='["a-button", "is-block", id ? "is-warning" : "is-secondary", checkableType ? "is-sm" : "is-sm"]',
-  @click='check'
+  @click='checkInCharge'
 )
   i(
     v-if='!checkerId || checkerId == currentUserId',
-    :class='["fas", id ? "fa-times" : "fa-hand-paper"]',
-    @click='check'
+    :class='["fas", productCheckerId ? "fa-times" : "fa-hand-paper"]',
+    @click='checkInCharge'
   )
   | {{ buttonLabel }}
 .a-button.is-sm.is-block.thread-list-item__assignee-button.is-only-mentor(
@@ -19,10 +19,15 @@ button(
     | {{ this.name }}
 </template>
 <script>
+<<<<<<< HEAD
 import toast from 'toast'
+=======
+import toast from './toast'
+import checkable from './checkable.js'
+>>>>>>> a9d264089 (Vuexを使って実装)
 
 export default {
-  mixins: [toast],
+  mixins: [toast, checkable],
   props: {
     checkerId: { type: Number, required: false, default: null },
     checkerName: { type: String, required: false, default: null },
@@ -33,40 +38,38 @@ export default {
   },
   data() {
     return {
-      id: this.checkerId,
       name: this.checkerName
     }
   },
   computed: {
+    productCheckerId() {
+      return this.$store.getters.productCheckerId
+    },
     buttonLabel() {
-      return this.id ? '担当から外れる' : '担当する'
+      return this.productCheckerId ? '担当から外れる' : '担当する'
     },
     url() {
       return `/api/products/checker`
     }
+  },
+  mounted() {
+    this.$store.dispatch('setProduct', {
+      productId: this.productId
+    })
   },
   methods: {
     token() {
       const meta = document.querySelector('meta[name="csrf-token"]')
       return meta ? meta.getAttribute('content') : ''
     },
-    check() {
-      const params = {
-        product_id: this.productId,
-        current_user_id: this.currentUserId,
-        checker_id: this.checkerId
-      }
-      fetch(this.url, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRF-Token': this.token()
-        },
-        credentials: 'same-origin',
-        redirect: 'manual',
-        body: JSON.stringify(params)
-      })
+    checkInCharge() {
+      this.checker(
+        this.productId,
+        this.currentUserId,
+        '/api/products/checker',
+        'PATCH',
+        this.token()
+      )
         .then((response) => {
           return response.json()
         })

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -63,29 +63,13 @@ export default {
       return meta ? meta.getAttribute('content') : ''
     },
     checkInCharge() {
-      this.checker(
+      this.checkProduct(
         this.productId,
         this.currentUserId,
         '/api/products/checker',
         this.productCheckerId ? 'DELETE' : 'PATCH',
         this.token()
       )
-        .then((response) => {
-          return response.json()
-        })
-        .then((json) => {
-          if (json.message) {
-            alert(json.message)
-          } else {
-            this.id = json.checker_id
-            this.name = json.checker_name
-            if (this.buttonLabel === '担当する') {
-              this.toast('担当から外れました。')
-            } else {
-              this.toast('担当になりました。')
-            }
-          }
-        })
     }
   }
 }

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -67,7 +67,7 @@ export default {
         this.productId,
         this.currentUserId,
         '/api/products/checker',
-        'PATCH',
+        this.productCheckerId ? 'DELETE' : 'PATCH',
         this.token()
       )
         .then((response) => {

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -34,16 +34,23 @@ export default {
     currentUserId: { type: String, required: true },
     productId: { type: Number, required: true },
     checkableType: { type: String, required: false, default: null },
-    checkerAvatar: { type: String, required: false, default: null }
+    checkerAvatar: { type: String, required: false, default: null },
+    parentComponent: { type: String, required: true }
   },
   data() {
     return {
-      name: this.checkerName
+      id: this.checkerId,
+      name: this.checkerName,
+      parent: this.parentComponent
     }
   },
   computed: {
     productCheckerId() {
-      return this.$store.getters.productCheckerId
+      if (this.parent === 'product') {
+        return this.id
+      } else {
+        return this.$store.getters.productCheckerId
+      }
     },
     buttonLabel() {
       return this.productCheckerId ? '担当から外れる' : '担当する'

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -19,7 +19,6 @@ button(
     | {{ this.name }}
 </template>
 <script>
-
 import toast from 'toast'
 import checkable from './checkable.js'
 

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -19,12 +19,9 @@ button(
     | {{ this.name }}
 </template>
 <script>
-<<<<<<< HEAD
+
 import toast from 'toast'
-=======
-import toast from './toast'
 import checkable from './checkable.js'
->>>>>>> a9d264089 (Vuexを使って実装)
 
 export default {
   mixins: [toast, checkable],

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-button(
+button#js-assignment.is-block(
   v-if='!checkerId || checkerId == currentUserId',
   :class='["a-button", "is-block", id ? "is-warning" : "is-secondary", checkableType ? "is-sm" : "is-sm"]',
   @click='check'

--- a/app/javascript/products.js
+++ b/app/javascript/products.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import Products from 'products.vue'
+import store from './check-store.js'
 
 document.addEventListener('DOMContentLoaded', () => {
   const selector = '#js-products'
@@ -10,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const isMentor = products.getAttribute('data-mentor-login')
     const currentUserId = products.getAttribute('data-current-user-id')
     new Vue({
+      store,
       render: (h) =>
         h(Products, {
           props: {

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -61,6 +61,13 @@ class Comment::AfterCreateCallback
     @watch.save!
   end
 
+  def create_checker_id(comment)
+    return nil unless comment.user.mentor?
+
+    product = comment.commentable
+    product.checker_id = comment.sender.id unless product.checker_id?
+  end
+
   def delete_product_cache(product_id)
     Rails.cache.delete "/model/product/#{product_id}/last_commented_user"
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -164,7 +164,7 @@ class Product < ApplicationRecord
   def save_checker(current_user_id)
     return false if other_checker_exists?(current_user_id)
 
-    self.checker_id = checker_id ? nil : current_user_id
+    self.checker_id = current_user_id
     Cache.delete_self_assigned_no_replied_product_count(current_user_id)
     save!
   end

--- a/app/views/api/products/show.json.jbuilder
+++ b/app/views/api/products/show.json.jbuilder
@@ -1,3 +1,1 @@
-json.products do
-    json.partial! "api/products/product", product: @product
-end
+json.partial! "api/products/product", product: @product

--- a/app/views/api/products/show.json.jbuilder
+++ b/app/views/api/products/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.products do
+    json.partial! "api/products/product", product: @product
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
         get 'counts', on: :collection
       end
       resources :self_assigned, only: %i(index)
-      resource :checker, only: %i(update), controller: 'checker'
+      resource :checker, only: %i(update destroy), controller: 'checker'
       resource :passed, only: %i(show), controller: 'passed'
     end
     resources :products, only: %i(index)

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
       resource :checker, only: %i(update destroy), controller: 'checker'
       resource :passed, only: %i(show), controller: 'passed'
     end
-    resources :products, only: %i(index)
+    resources :products, only: %i(index show)
     namespace :categories_practices do
       resources :position, only: %i(update)
     end

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -5,7 +5,6 @@ require 'application_system_test_case'
 class Product::CheckerTest < ApplicationSystemTestCase
   test 'be person on charge at comment on product of there are not person on charge' do
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'machida'
-
     def assigned_product_count
       text[/自分の担当 （(\d+)）/, 1].to_i
     end
@@ -15,16 +14,10 @@ class Product::CheckerTest < ApplicationSystemTestCase
     [
       '担当者がいない提出物の場合、担当者になる',
       '自分が担当者の場合、担当者のまま'
-    ].each_with_index do |comment, index|
+    ].each do |comment|
       visit "/products/#{products(:product1).id}"
       post_comment(comment)
-      if index.zero?
-        assert_text '担当になりました。'
-      else
-        assert_text 'コメントを投稿しました'
-      end
-
-      assert_text '担当から外れる'
+      assert_text 'コメントを投稿しました'
 
       visit '/products/unchecked?target=unchecked_no_replied'
       assert_equal before_comment + 1, assigned_product_count

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -5,6 +5,7 @@ require 'application_system_test_case'
 class Product::CheckerTest < ApplicationSystemTestCase
   test 'be person on charge at comment on product of there are not person on charge' do
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'machida'
+
     def assigned_product_count
       text[/自分の担当 （(\d+)）/, 1].to_i
     end
@@ -14,10 +15,16 @@ class Product::CheckerTest < ApplicationSystemTestCase
     [
       '担当者がいない提出物の場合、担当者になる',
       '自分が担当者の場合、担当者のまま'
-    ].each do |comment|
+    ].each_with_index do |comment, index|
       visit "/products/#{products(:product1).id}"
       post_comment(comment)
-      assert_text 'コメントを投稿しました'
+      if index.zero?
+        assert_text '担当になりました。'
+      else
+        assert_text 'コメントを投稿しました'
+      end
+
+      assert_text '担当から外れる'
 
       visit '/products/unchecked?target=unchecked_no_replied'
       assert_equal before_comment + 1, assigned_product_count

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -11,23 +11,27 @@ class Product::CheckerTest < ApplicationSystemTestCase
 
     before_comment = assigned_product_count
 
-    [
-      '担当者がいない提出物の場合、担当者になる',
-      '自分が担当者の場合、担当者のまま'
-    ].each do |comment|
-      visit "/products/#{products(:product1).id}"
-      post_comment(comment)
-      assert_text 'コメントを投稿しました'
+    visit "/products/#{products(:product1).id}"
 
-      visit '/products/unchecked?target=unchecked_no_replied'
-      assert_equal before_comment + 1, assigned_product_count
-    end
+    post_comment('担当者がいない提出物の場合、担当者になる')
+    assert_text '担当になりました。'
+    assert_text 'コメントを投稿しました'
+    assert_text '担当から外れる'
+
+    post_comment('自分が担当者の場合、担当者のまま')
+    assert_text 'コメントを投稿しました'
+    assert_text '担当から外れる'
+
+    visit '/products/unchecked?target=unchecked_no_replied'
+    assert_equal before_comment + 1, assigned_product_count
   end
 
   test 'be not person on charge at comment on product of there are person on charge' do
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
     product = find('.thread-list-item', match: :first)
     product.click_button '担当する'
+    assert_text '担当から外れる'
+
     show_product_path = product.find_link(href: /products/)[:href]
     logout
 

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -14,12 +14,9 @@ class Product::CheckerTest < ApplicationSystemTestCase
     visit "/products/#{products(:product1).id}"
 
     post_comment('担当者がいない提出物の場合、担当者になる')
-    assert_text '担当になりました。'
-    assert_text 'コメントを投稿しました'
     assert_text '担当から外れる'
 
     post_comment('自分が担当者の場合、担当者のまま')
-    assert_text 'コメントを投稿しました'
     assert_text '担当から外れる'
 
     visit '/products/unchecked?target=unchecked_no_replied'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -461,6 +461,7 @@ class ProductsTest < ApplicationSystemTestCase
 
     assignee_buttons = all('.a-button.is-block.is-secondary.is-sm', text: '担当する')
     assignee_buttons.first.click
+    assert_text '担当から外れる'
 
     unassigned_tab.click
     operated_counter = find('#test-unassigned-counter').text


### PR DESCRIPTION
## Issue概要
- #4469

担当者のいない提出物にメンターがコメントすると担当者になるという機能がありますが、画面上では担当になったことがわからなかったので、画面上でもアサインが分かるように変更しました。

## 変更前
[![Image from Gyazo](https://i.gyazo.com/75383a95feda4f869a4cf420900eb2f6.gif)](https://gyazo.com/75383a95feda4f869a4cf420900eb2f6)
コメントを行うだけで提出物の担当者にはなっているが、画面上からは通常のコメントと違いがなく、リロードしないと「担当する」ボタンが「担当から外れる」ボタンに切り替わらない

## 変更後
[![Image from Gyazo](https://i.gyazo.com/2bf7c753fb3cae2f4d3c380d364dc02b.gif)](https://gyazo.com/2bf7c753fb3cae2f4d3c380d364dc02b)

## 確認方法
1. `feature/visualize-assignment-when-mentor-commented-on-unassigned-product`をローカルに取り込む
1. `bin/setup`実行
1. `bin/rails s`でサーバーを立ち上げる
1. メンターロールのユーザーでログイン
1. 提出物一覧から未アサインの提出物を1つ選択し詳細画面を開く
1. 提出物にコメントし、「担当する」ボタンが黄色の「担当から外れる」ボタンに変わり、「担当になりました」「コメントを投稿しました！」というToastが右上に表示されることを確認