### PR TITLE
管理者の相談部屋一覧に相談部屋検索機能を追加

### DIFF
--- a/app/assets/stylesheets/blocks/form/_form-item.sass
+++ b/app/assets/stylesheets/blocks/form/_form-item.sass
@@ -23,6 +23,15 @@
     .a-form-label
       margin-bottom: 0
       margin-right: .75em
+      white-space: nowrap
+  &.is-inline-md-up
+    +media-breakpoint-up(md)
+      display: flex
+      align-items: center
+      .a-form-label
+        margin-bottom: 0
+        margin-right: .75em
+        white-space: nowrap
 
 .form-item__row
   display: flex

--- a/app/assets/stylesheets/blocks/form/_talk-search.sass
+++ b/app/assets/stylesheets/blocks/form/_talk-search.sass
@@ -1,0 +1,2 @@
+.talk-search
+  margin-bottom: 1.75rem

--- a/app/assets/stylesheets/blocks/shared/_tab-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_tab-nav.sass
@@ -3,6 +3,7 @@
 
 .tab-nav__items
   display: flex
+  gap: .5rem
   +padding(vertical, .875rem)
   gap: .5rem
   overflow-x: auto

--- a/app/controllers/api/talks/unreplied_controller.rb
+++ b/app/controllers/api/talks/unreplied_controller.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 class API::Talks::UnrepliedController < API::BaseController
+  PAGER_NUMBER = 20
+
   def index
-    @talks = Talk.unreplied.page(params[:page])
+    @talks = Talk.eager_load(user: [:company, { avatar_attachment: :blob }])
+                 .unreplied
+                 .order(updated_at: :desc)
+    @talks =
+      if params[:search_word]
+        @talks.search_by_user_keywords(params[:search_word])
+      else
+        @talks.page(params[:page]).per(PAGER_NUMBER)
+      end
   end
 end

--- a/app/controllers/api/talks/unreplied_controller.rb
+++ b/app/controllers/api/talks/unreplied_controller.rb
@@ -6,7 +6,7 @@ class API::Talks::UnrepliedController < API::BaseController
   def index
     @talks = Talk.eager_load(user: [:company, { avatar_attachment: :blob }])
                  .unreplied
-                 .order(updated_at: :desc)
+                 .order(updated_at: :desc, id: :asc)
     @talks =
       if params[:search_word]
         @talks.merge(

--- a/app/controllers/api/talks/unreplied_controller.rb
+++ b/app/controllers/api/talks/unreplied_controller.rb
@@ -9,7 +9,10 @@ class API::Talks::UnrepliedController < API::BaseController
                  .order(updated_at: :desc)
     @talks =
       if params[:search_word]
-        @talks.search_by_user_keywords(params[:search_word])
+        @talks.merge(
+          User.search_by_keywords({ word: params[:search_word] })
+              .unscope(where: :retired_on)
+        )
       else
         @talks.page(params[:page]).per(PAGER_NUMBER)
       end

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -8,7 +8,7 @@ class API::TalksController < API::BaseController
     @target = params[:target]
     @target = 'all' unless TARGETS.include?(@target)
     @talks = Talk.eager_load(user: [:company, { avatar_attachment: :blob }])
-                 .order(updated_at: :desc)
+                 .order(updated_at: :desc, id: :asc)
     @talks =
       if params[:search_word]
         @talks.merge(

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -7,12 +7,14 @@ class API::TalksController < API::BaseController
   def index
     @target = params[:target]
     @target = 'all' unless TARGETS.include?(@target)
-    @users_talks = Talk.required_list_data(@target).order(updated_at: :desc)
-    @users_talks =
+    @talks = Talk.eager_load(user: [:company, { avatar_attachment: :blob }])
+                 .merge(User.users_role(@target))
+                 .order(updated_at: :desc)
+    @talks =
       if params[:search_word]
-        @users_talks.search_by_user_keywords(params[:search_word])
+        @talks.search_by_user_keywords(params[:search_word])
       else
-        @users_talks.page(params[:page]).per(PAGER_NUMBER)
+        @talks.page(params[:page]).per(PAGER_NUMBER)
       end
   end
 end

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
 class API::TalksController < API::BaseController
-  TARGETS = %w[student_and_trainee mentor graduate adviser trainee retired all].freeze
+  TARGETS = %w[all student_and_trainee mentor graduate adviser trainee retired].freeze
   PAGER_NUMBER = 20
 
   def index
     @target = params[:target]
-    @target = 'student_and_trainee' unless TARGETS.include?(@target)
-    @users_talks = Talk.eager_load(user: [:company, { avatar_attachment: :blob }])
-                       .merge(User.users_role(@target))
-                       .page(params[:page]).per(PAGER_NUMBER)
-                       .order(updated_at: :desc)
+    @target = 'all' unless TARGETS.include?(@target)
+    @users_talks = Talk.required_list_data(@target).order(updated_at: :desc)
+    @users_talks =
+      if params[:search_word]
+        @users_talks.search_by_user_keywords(params[:search_word])
+      else
+        @users_talks.page(params[:page]).per(PAGER_NUMBER)
+      end
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -9,7 +9,7 @@ class TalksController < ApplicationController
 
   def index
     @target = params[:target]
-    @target = 'student_and_trainee' unless API::TalksController::TARGETS.include?(@target)
+    @target = 'all' unless API::TalksController::TARGETS.include?(@target)
   end
 
   def show; end

--- a/app/javascript/talks.vue
+++ b/app/javascript/talks.vue
@@ -1,18 +1,22 @@
 <template lang="pug">
 .talks
-  #talks.container.is-md
-    input#search-talks-form.search-talks-form.a-text-input(
-      v-model.trim='searchTalksWord',
-      placeholder='検索ワード'
-    )
-  #talks.container.is-md.loading(v-if='!loaded')
+  .talk-search.form
+    .form__items
+      .form-item.is-inline-md-up
+        label.a-form-label
+          | 絞り込み
+        input#js-talk-search-input.talk-search__text-input.a-text-input(
+          v-model.trim='searchTalksWord',
+          placeholder='ユーザーID、ユーザー名、読み方、Discord ID'
+        )
+  #talks.loading(v-if='!loaded')
     loadingListPlaceholder
   .o-empty-message(v-else-if='talks.length === 0')
     .o-empty-message__icon
       i.far.fa-smile
     p.o-empty-message__text
       | 未返信の相談部屋はありません
-  #talks.container.is-md.loaded(v-else)
+  #talks.loaded(v-else)
     .talk-list(v-show='!showSearchedTalks')
       nav.pagination(v-if='totalPages > 1')
         pager(v-bind='pagerProps')

--- a/app/javascript/talks.vue
+++ b/app/javascript/talks.vue
@@ -7,7 +7,7 @@
           | 絞り込み
         input#js-talk-search-input.talk-search__text-input.a-text-input(
           v-model.trim='searchTalksWord',
-          placeholder='ユーザーID、ユーザー名、読み方、Discord ID'
+          placeholder='ユーザーID、ユーザー名、読み方、Discord ID など'
         )
   #talks.loading(v-if='!loaded')
     loadingListPlaceholder

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -6,12 +6,4 @@ class Talk < ApplicationRecord
   belongs_to :user
 
   scope :unreplied, -> { where(unreplied: true) }
-  scope :search_by_user_keywords, lambda { |search_word|
-    where(<<~SQL, search_word: "%#{search_word}%")
-      "users"."login_name" ILIKE :search_word
-      OR "users"."name" ILIKE :search_word
-      OR "users"."name_kana" ILIKE :search_word
-      OR "users"."discord_account" ILIKE :search_word
-    SQL
-  }
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -6,4 +6,16 @@ class Talk < ApplicationRecord
   belongs_to :user
 
   scope :unreplied, -> { where(unreplied: true) }
+  scope :required_list_data, lambda { |target|
+    eager_load(user: [:company, { avatar_attachment: :blob }])
+      .merge(User.users_role(target))
+  }
+  scope :search_by_user_keywords, lambda { |search_word|
+    where(<<~SQL, search_word: "%#{search_word}%")
+      "users"."login_name" ILIKE :search_word
+      OR "users"."name" ILIKE :search_word
+      OR "users"."name_kana" ILIKE :search_word
+      OR "users"."discord_account" ILIKE :search_word
+    SQL
+  }
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -6,10 +6,6 @@ class Talk < ApplicationRecord
   belongs_to :user
 
   scope :unreplied, -> { where(unreplied: true) }
-  scope :required_list_data, lambda { |target|
-    eager_load(user: [:company, { avatar_attachment: :blob }])
-      .merge(User.users_role(target))
-  }
   scope :search_by_user_keywords, lambda { |search_word|
     where(<<~SQL, search_word: "%#{search_word}%")
       "users"."login_name" ILIKE :search_word

--- a/app/views/api/talks/_talks.jbuilder
+++ b/app/views/api/talks/_talks.jbuilder
@@ -1,0 +1,12 @@
+json.talks do
+  json.array! talks do |talk|
+    json.partial! 'api/talks/talk', talk: talk
+    json.has_any_comments talk.comments.present?
+    if talk.comments.present?
+      json.number_of_comments talk.comments.size
+      json.last_comment_user talk.comments.last.user
+      json.last_comment_user_icon talk.comments.last.user.avatar_url
+      json.last_commented_at l talk.comments.last.updated_at
+    end
+  end
+end

--- a/app/views/api/talks/index.json.jbuilder
+++ b/app/views/api/talks/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.talks do
   json.array! @users_talks do |talk|
-    json.partial! "api/talks/talk", talk: talk
+    json.partial! 'api/talks/talk', talk: talk
     json.has_any_comments talk.comments.present?
     if talk.comments.present?
       json.number_of_comments talk.comments.size
@@ -12,4 +12,4 @@ json.talks do
 end
 
 json.target t("target.#{@target}")
-json.totalPages @users_talks.total_pages
+json.totalPages @users_talks.total_pages if @users_talks.respond_to? :total_pages

--- a/app/views/api/talks/index.json.jbuilder
+++ b/app/views/api/talks/index.json.jbuilder
@@ -1,15 +1,3 @@
-json.talks do
-  json.array! @users_talks do |talk|
-    json.partial! 'api/talks/talk', talk: talk
-    json.has_any_comments talk.comments.present?
-    if talk.comments.present?
-      json.number_of_comments talk.comments.size
-      json.last_comment_user talk.comments.last.user
-      json.last_comment_user_icon talk.comments.last.user.avatar_url
-      json.last_commented_at l talk.comments.last.updated_at
-    end
-  end
-end
-
+json.partial! 'api/talks/talks', talks: @talks
 json.target t("target.#{@target}")
-json.totalPages @users_talks.total_pages if @users_talks.respond_to? :total_pages
+json.totalPages @talks.total_pages if @talks.respond_to? :total_pages

--- a/app/views/api/talks/unreplied/index.json.jbuilder
+++ b/app/views/api/talks/unreplied/index.json.jbuilder
@@ -1,7 +1,2 @@
-json.talks do
-  json.array! @talks do |talk|
-    json.partial! "api/talks/talk", talk: talk
-  end
-end
-
-json.totalPages @talks.total_pages
+json.partial! 'api/talks/talks', talks: @talks
+json.totalPages @talks.total_pages if @talks.respond_to? :total_pages

--- a/app/views/talks/index.html.slim
+++ b/app/views/talks/index.html.slim
@@ -10,4 +10,5 @@ header.page-header
 = render 'talks/nav'
 
 .page-body
-  #js-talks
+  .container.is-md
+    #js-talks

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -112,3 +112,7 @@ talk28:
 talk29:
   user: enchoowata
   unreplied: false
+
+talk30:
+  user: kimuramitai
+  unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -685,3 +685,25 @@ enchoowata:
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-09-01 00:00:00"
   created_at: "2021-09-01 00:00:00"
+
+kimuramitai:
+  login_name: kimuramitai
+  email: kimuramitai@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: Kimura Mitai
+  name_kana: キムラ ミタイ
+  discord_account: kimuradiscord#1234
+  twitter_account: kimuratwitter
+  facebook_url: http://www.facebook.com/kimurafacebook
+  blog_url: http://kimurablog.org
+  description: "木村さんに似ているとよく言われます。"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: inexperienced
+  prefecture_code: 13
+  organization: 木村そっくり大学
+  unsubscribe_email_token: k6Da-oL3cRi8ApNFO9-Gcg
+  updated_at: "2022-03-28 00:00:01"
+  created_at: "2022-03-28 00:00:01"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -693,6 +693,7 @@ kimuramitai:
   salt: zW3kQ9ubsxQQtzzzs4ap
   name: Kimura Mitai
   name_kana: キムラ ミタイ
+  github_account: kimuragithub
   discord_account: kimuradiscord#1234
   twitter_account: kimuratwitter
   facebook_url: http://www.facebook.com/kimurafacebook

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -185,12 +185,57 @@ class TalksTest < ApplicationSystemTestCase
     assert_text 'さんの相談部屋', count: 1
   end
 
+  test 'incremental search by twitter_account' do
+    visit_with_auth '/talks', 'komagata'
+    assert_text 'さんの相談部屋', count: 20
+    fill_in 'js-talk-search-input', with: 'kimura'
+    assert_text 'さんの相談部屋', count: 2
+    fill_in 'js-talk-search-input', with: 'kimuratwitter'
+    assert_text 'さんの相談部屋', count: 1
+  end
+
+  test 'incremental search by facebook_url' do
+    visit_with_auth '/talks', 'komagata'
+    assert_text 'さんの相談部屋', count: 20
+    fill_in 'js-talk-search-input', with: 'kimura'
+    assert_text 'さんの相談部屋', count: 2
+    fill_in 'js-talk-search-input', with: 'kimurafacebook'
+    assert_text 'さんの相談部屋', count: 1
+  end
+
+  test 'incremental search by blog_url' do
+    visit_with_auth '/talks', 'komagata'
+    assert_text 'さんの相談部屋', count: 20
+    fill_in 'js-talk-search-input', with: 'kimura'
+    assert_text 'さんの相談部屋', count: 2
+    fill_in 'js-talk-search-input', with: 'kimurablog.org'
+    assert_text 'さんの相談部屋', count: 1
+  end
+
+  test 'incremental search by github_account' do
+    visit_with_auth '/talks', 'komagata'
+    assert_text 'さんの相談部屋', count: 20
+    fill_in 'js-talk-search-input', with: 'kimura'
+    assert_text 'さんの相談部屋', count: 2
+    fill_in 'js-talk-search-input', with: 'kimuragithub'
+    assert_text 'さんの相談部屋', count: 1
+  end
+
   test 'incremental search by discord_account' do
     visit_with_auth '/talks', 'komagata'
     assert_text 'さんの相談部屋', count: 20
     fill_in 'js-talk-search-input', with: 'kimura'
     assert_text 'さんの相談部屋', count: 2
     fill_in 'js-talk-search-input', with: 'kimuradiscord'
+    assert_text 'さんの相談部屋', count: 1
+  end
+
+  test 'incremental search by description' do
+    visit_with_auth '/talks', 'komagata'
+    assert_text 'さんの相談部屋', count: 20
+    fill_in 'js-talk-search-input', with: 'kimura'
+    assert_text 'さんの相談部屋', count: 2
+    fill_in 'js-talk-search-input', with: '木村さんに似ているとよく言われます。'
     assert_text 'さんの相談部屋', count: 1
   end
 

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -48,10 +48,16 @@ class TalksTest < ApplicationSystemTestCase
     assert_text "#{user.login_name} (#{user.name}) さんの相談部屋"
   end
 
+  test 'admin can access user talk page from talks page' do
+    talks(:talk7).update!(updated_at: Time.current) # user: kimura
+    visit_with_auth '/talks', 'komagata'
+    click_link 'kimura (Kimura Tadasi) さんの相談部屋'
+    assert_selector '.page-header__title', text: 'kimuraさんの相談部屋'
+  end
+
   test 'a talk room is removed from unreplied tab when admin comments there' do
     user = users(:with_hyphen)
-    visit_with_auth '/talks', 'komagata'
-    click_link "#{user.login_name} (#{user.name}) さんの相談部屋"
+    visit_with_auth "/talks/#{user.talk.id}", 'komagata'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')
     end
@@ -106,16 +112,14 @@ class TalksTest < ApplicationSystemTestCase
     assert_no_text 'ユーザー公開情報'
 
     logout
-    visit_with_auth '/talks', 'komagata'
-    click_link "#{user.login_name} (#{user.name}) さんの相談部屋"
+    visit_with_auth "/talks/#{user.talk.id}", 'komagata'
     assert_text 'ユーザー非公開情報'
     assert_text 'ユーザー公開情報'
   end
 
   test 'update memo' do
     user = users(:kimura)
-    visit_with_auth '/talks', 'komagata'
-    click_link "#{user.login_name} (#{user.name}) さんの相談部屋"
+    visit_with_auth "/talks/#{user.talk.id}", 'komagata'
     assert_text 'kimuraさんのメモ'
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: '相談部屋テストメモ'
@@ -126,8 +130,7 @@ class TalksTest < ApplicationSystemTestCase
 
   test 'Displays a list of the 10 most recent reports' do
     user = users(:hajime)
-    visit_with_auth '/talks', 'komagata'
-    click_link "#{user.login_name} (#{user.name}) さんの相談部屋"
+    visit_with_auth "/talks/#{user.talk.id}", 'komagata'
     assert_text 'ユーザーの日報'
     page.find('#reports_list').click
     user.reports.first(10).each do |report|

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -161,102 +161,102 @@ class TalksTest < ApplicationSystemTestCase
   test 'incremental search by login_name' do
     visit_with_auth '/talks', 'komagata'
     assert_text 'さんの相談部屋', count: 20
-    fill_in 'search-talks-form', with: 'kimura'
+    fill_in 'js-talk-search-input', with: 'kimura'
     assert_text 'さんの相談部屋', count: 2
-    fill_in 'search-talks-form', with: 'kimuramitai'
+    fill_in 'js-talk-search-input', with: 'kimuramitai'
     assert_text 'さんの相談部屋', count: 1
   end
 
   test 'incremental search by name' do
     visit_with_auth '/talks', 'komagata'
     assert_text 'さんの相談部屋', count: 20
-    fill_in 'search-talks-form', with: 'Kimura'
+    fill_in 'js-talk-search-input', with: 'Kimura'
     assert_text 'さんの相談部屋', count: 2
-    fill_in 'search-talks-form', with: 'Kimura Mitai'
+    fill_in 'js-talk-search-input', with: 'Kimura Mitai'
     assert_text 'さんの相談部屋', count: 1
   end
 
   test 'incremental search by name_kana' do
     visit_with_auth '/talks', 'komagata'
     assert_text 'さんの相談部屋', count: 20
-    fill_in 'search-talks-form', with: 'キムラ'
+    fill_in 'js-talk-search-input', with: 'キムラ'
     assert_text 'さんの相談部屋', count: 2
-    fill_in 'search-talks-form', with: 'キムラ ミタイ'
+    fill_in 'js-talk-search-input', with: 'キムラ ミタイ'
     assert_text 'さんの相談部屋', count: 1
   end
 
   test 'incremental search by discord_account' do
     visit_with_auth '/talks', 'komagata'
     assert_text 'さんの相談部屋', count: 20
-    fill_in 'search-talks-form', with: 'kimura'
+    fill_in 'js-talk-search-input', with: 'kimura'
     assert_text 'さんの相談部屋', count: 2
-    fill_in 'search-talks-form', with: 'kimuradiscord'
+    fill_in 'js-talk-search-input', with: 'kimuradiscord'
     assert_text 'さんの相談部屋', count: 1
   end
 
   test 'incremental search for student_or_trainee' do
     users(:kimuramitai).update!(mentor: true)
     visit_with_auth '/talks', 'komagata'
-    fill_in 'search-talks-form', with: 'kimura'
+    fill_in 'js-talk-search-input', with: 'kimura'
     assert_text 'さんの相談部屋', count: 2
 
     visit '/talks?target=student_and_trainee'
-    fill_in 'search-talks-form', with: 'kimura'
+    fill_in 'js-talk-search-input', with: 'kimura'
     assert_text 'さんの相談部屋', count: 1 # users(:kimura)
   end
 
   test 'incremental search for mentor' do
     users(:kimuramitai).update!(login_name: 'mentorkimura')
     visit_with_auth '/talks', 'komagata'
-    fill_in 'search-talks-form', with: 'mentor'
+    fill_in 'js-talk-search-input', with: 'mentor'
     assert_text 'さんの相談部屋', count: 2
 
     visit '/talks?target=mentor'
-    fill_in 'search-talks-form', with: 'mentor'
+    fill_in 'js-talk-search-input', with: 'mentor'
     assert_text 'さんの相談部屋', count: 1 # users(:mentormentaro)
   end
 
   test 'incremental search for graduated' do
     users(:kimuramitai).update!(login_name: 'sotugyoukimura')
     visit_with_auth '/talks', 'komagata'
-    fill_in 'search-talks-form', with: 'sotugyou'
+    fill_in 'js-talk-search-input', with: 'sotugyou'
     assert_text 'さんの相談部屋', count: 3
 
     visit '/talks?target=graduate'
-    fill_in 'search-talks-form', with: 'sotugyou'
+    fill_in 'js-talk-search-input', with: 'sotugyou'
     assert_text 'さんの相談部屋', count: 2 # users(:sotugyou, :sotugyou_with_job)
   end
 
   test 'incremental search for adviser' do
     users(:kimuramitai).update!(login_name: 'advikimura')
     visit_with_auth '/talks', 'komagata'
-    fill_in 'search-talks-form', with: 'advi'
+    fill_in 'js-talk-search-input', with: 'advi'
     assert_text 'さんの相談部屋', count: 2
 
     visit '/talks?target=adviser'
-    fill_in 'search-talks-form', with: 'advi'
+    fill_in 'js-talk-search-input', with: 'advi'
     assert_text 'さんの相談部屋', count: 1 # users(:advijirou)
   end
 
   test 'incremental search for trainee' do
     users(:kimuramitai).update!(login_name: 'kensyukimura')
     visit_with_auth '/talks', 'komagata'
-    fill_in 'search-talks-form', with: 'kensyu'
+    fill_in 'js-talk-search-input', with: 'kensyu'
     assert_text 'さんの相談部屋', count: 3
 
     visit '/talks?target=trainee'
-    fill_in 'search-talks-form', with: 'kensyu'
+    fill_in 'js-talk-search-input', with: 'kensyu'
     assert_text 'さんの相談部屋', count: 2 # users(:kensyu, :kensyuowata)
   end
 
   test 'incremental search for retired' do
     users(:kimuramitai).update!(login_name: 'yameokimura')
     visit_with_auth '/talks', 'komagata'
-    fill_in 'search-talks-form', with: 'yameo'
+    fill_in 'js-talk-search-input', with: 'yameo'
     assert_text 'さんの相談部屋', count: 2
 
     visit '/talks?target=retired'
-    fill_in 'search-talks-form', with: 'yameo'
+    fill_in 'js-talk-search-input', with: 'yameo'
     assert_text 'さんの相談部屋', count: 1 # users(:yameo)
   end
 
@@ -266,19 +266,19 @@ class TalksTest < ApplicationSystemTestCase
     assert_no_selector '.searched-talk-list'
 
     # /^[\w-]+$/ の場合は3文字以上、それ以外は2文字以上で検索結果を表示
-    fill_in 'search-talks-form', with: 'kim'
+    fill_in 'js-talk-search-input', with: 'kim'
     assert_no_selector '.talk-list'
     assert_selector '.searched-talk-list'
 
-    fill_in 'search-talks-form', with: 'ki'
+    fill_in 'js-talk-search-input', with: 'ki'
     assert_selector '.talk-list'
     assert_no_selector '.searched-talk-list'
 
-    fill_in 'search-talks-form', with: 'キム'
+    fill_in 'js-talk-search-input', with: 'キム'
     assert_no_selector '.talk-list'
     assert_selector '.searched-talk-list'
 
-    fill_in 'search-talks-form', with: 'キ'
+    fill_in 'js-talk-search-input', with: 'キ'
     assert_selector '.talk-list'
     assert_no_selector '.searched-talk-list'
   end
@@ -286,7 +286,7 @@ class TalksTest < ApplicationSystemTestCase
   test 'show no talks message when no talks found' do
     visit_with_auth '/talks', 'komagata'
 
-    fill_in 'search-talks-form', with: 'hoge'
+    fill_in 'js-talk-search-input', with: 'hoge'
     assert_text '一致する相談部屋はありません'
   end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -260,6 +260,17 @@ class TalksTest < ApplicationSystemTestCase
     assert_text 'さんの相談部屋', count: 1 # users(:yameo)
   end
 
+  test 'incremental search for unreplied' do
+    users(:kimura).talk.update!(unreplied: true)
+    visit_with_auth '/talks', 'komagata'
+    fill_in 'js-talk-search-input', with: 'kimura'
+    assert_text 'さんの相談部屋', count: 2
+
+    visit '/talks/unreplied'
+    fill_in 'js-talk-search-input', with: 'kimura'
+    assert_text 'さんの相談部屋', count: 1 # users(:kimura)
+  end
+
   test 'switch between normal list and searched list' do
     visit_with_auth '/talks', 'komagata'
     assert_selector '.talk-list'


### PR DESCRIPTION
## Issue
- #4290 
## 概要
検索文字列を入力後、以下の条件でインクリメンタルサーチができるようにしました。
- 検索対象
  - ユーザーID
  - ユーザー名
  - ユーザー名読み方
  - Discord ID
  - GitHub ID
  - Twitter ID
  - facebook URL
  - ブログURL
  - 自己紹介文
- /^[\w-]+$/ にマッチする場合は3文字以上、それ以外は2文字以上必要
- 現在表示しているユーザーのロールを対象にする
- 未返信一覧でも絞り込み可能

### デモ
https://user-images.githubusercontent.com/83743223/161518321-1658f03d-6c02-4f9c-a6f0-a68fbd022761.mov

