### PR TITLE
[Q&A]質問の本公開時にメンター側のWatchを自動的にonにするように修正

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -46,7 +46,6 @@ class QuestionsController < ApplicationController
     @question.user = current_user
     @question.wip = params[:commit] == 'WIP'
     if @question.save
-      create_mentors_watch
       redirect_to @question, notice: notice_message(@question)
     else
       render :new
@@ -87,22 +86,6 @@ class QuestionsController < ApplicationController
       QuestionsProperty.new('解決済みの質問一覧', '解決済みの質問はありません。')
     else
       QuestionsProperty.new('未解決の質問一覧', '未解決の質問はありません。')
-    end
-  end
-
-  def create_mentors_watch
-    Watch.insert_all(watch_records) # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  def watch_records
-    User.mentor.map do |mentor|
-      {
-        watchable_type: 'Question',
-        watchable_id: @question.id,
-        created_at: Time.current,
-        updated_at: Time.current,
-        user_id: mentor.id
-      }
     end
   end
 

--- a/app/models/question_callbacks.rb
+++ b/app/models/question_callbacks.rb
@@ -5,6 +5,7 @@ class QuestionCallbacks
     return unless question.saved_change_to_attribute?(:published_at, from: nil)
 
     send_notification_to_mentors(question)
+    create_mentors_watch(question)
     notify_to_chat(question)
     Cache.delete_not_solved_question_count
   end
@@ -31,5 +32,22 @@ class QuestionCallbacks
 
   def delete_notification(question)
     Notification.where(link: "/questions/#{question.id}").destroy_all
+  end
+
+  def create_mentors_watch(question)
+    watch_question_records = watch_records(question)
+    Watch.insert_all(watch_question_records) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def watch_records(question)
+    User.mentor.map do |mentor|
+      {
+        watchable_type: 'Question',
+        watchable_id: question.id,
+        created_at: Time.current,
+        updated_at: Time.current,
+        user_id: mentor.id
+      }
+    end
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -235,9 +235,11 @@ class QuestionsTest < ApplicationSystemTestCase
       fill_in 'question[description]', with: 'メンターのみ投稿された質問が"Watch中"になるテスト'
       click_button '登録する'
     end
+    assert_text '質問を作成しました。'
+
     visit_with_auth questions_path, 'komagata'
     click_link 'メンターのみ投稿された質問が"Watch中"になるテスト'
-    assert_text 'kimura (Kimura Tadasi)'
+    assert_text '削除する'
     assert_text 'Watch中'
   end
 
@@ -246,12 +248,13 @@ class QuestionsTest < ApplicationSystemTestCase
     within 'form[name=question]' do
       fill_in 'question[title]', with: 'WIPタイトル'
       fill_in 'question[description]', with: 'WIP本文'
+      click_button 'WIP'
     end
-    click_button 'WIP'
     assert_text '質問をWIPとして保存しました。'
+
     visit_with_auth questions_path, 'komagata'
     click_link 'WIPタイトル'
-    assert_text 'kimura (Kimura Tadasi)'
+    assert_text '削除する'
     assert_no_text 'Watch中'
   end
 
@@ -260,22 +263,24 @@ class QuestionsTest < ApplicationSystemTestCase
     within 'form[name=question]' do
       fill_in 'question[title]', with: 'WIPタイトル'
       fill_in 'question[description]', with: 'WIP本文'
+      click_button 'WIP'
     end
-    click_button 'WIP'
     assert_text '質問をWIPとして保存しました。'
+
     visit questions_path
     click_link 'WIPタイトル'
-    assert_text 'kimura (Kimura Tadasi)'
+    assert_text '削除する'
     click_button '内容修正'
     within 'form[name=question]' do
       fill_in 'question[title]', with: '更新されたタイトル'
       fill_in 'question[description]', with: '更新された本文'
+      click_button '質問を公開'
     end
-    click_button '質問を公開'
     assert_text '質問を更新しました'
+
     visit_with_auth questions_path, 'komagata'
     click_link '更新されたタイトル'
-    assert_text 'kimura (Kimura Tadasi)'
+    assert_text '削除する'
     assert_text 'Watch中'
   end
 

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -228,13 +228,54 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_selector '.thread-list-item', count: 25
   end
 
-  test 'mentor create a question' do
-    visit_with_auth new_question_path, 'komagata'
+  test "mentor's watch-button is automatically on when new question is published" do
+    visit_with_auth new_question_path, 'kimura'
     within 'form[name=question]' do
       fill_in 'question[title]', with: 'メンターのみ投稿された質問が"Watch中"になるテスト'
       fill_in 'question[description]', with: 'メンターのみ投稿された質問が"Watch中"になるテスト'
       click_button '登録する'
     end
+    visit_with_auth questions_path, 'komagata'
+    click_link 'メンターのみ投稿された質問が"Watch中"になるテスト'
+    assert_text 'kimura (Kimura Tadasi)'
+    assert_text 'Watch中'
+  end
+
+  test "mentor's watch-button is not automatically on when new question is created as WIP" do
+    visit_with_auth new_question_path, 'kimura'
+    within 'form[name=question]' do
+      fill_in 'question[title]', with: 'WIPタイトル'
+      fill_in 'question[description]', with: 'WIP本文'
+    end
+    click_button 'WIP'
+    assert_text '質問をWIPとして保存しました。'
+    visit_with_auth questions_path, 'komagata'
+    click_link 'WIPタイトル'
+    assert_text 'kimura (Kimura Tadasi)'
+    assert_no_text 'Watch中'
+  end
+
+  test "mentor's watch-button is automatically on when WIP question is updated as published" do
+    visit_with_auth new_question_path, 'kimura'
+    within 'form[name=question]' do
+      fill_in 'question[title]', with: 'WIPタイトル'
+      fill_in 'question[description]', with: 'WIP本文'
+    end
+    click_button 'WIP'
+    assert_text '質問をWIPとして保存しました。'
+    visit questions_path
+    click_link 'WIPタイトル'
+    assert_text 'kimura (Kimura Tadasi)'
+    click_button '内容修正'
+    within 'form[name=question]' do
+      fill_in 'question[title]', with: '更新されたタイトル'
+      fill_in 'question[description]', with: '更新された本文'
+    end
+    click_button '質問を公開'
+    assert_text '質問を更新しました'
+    visit_with_auth questions_path, 'komagata'
+    click_link '更新されたタイトル'
+    assert_text 'kimura (Kimura Tadasi)'
     assert_text 'Watch中'
   end
 


### PR DESCRIPTION
## Issue
- #4525 
 
## 概要
Q&AのWIP機能の付加(#4157)により、質問が作成された際に自動的にメンターさんのみ「Watch中」になるタイミングがWIP保存時にも働いてしまうため、タイミングを「本公開時」にWatch中になるよう修正しました。

## 参考PR
Refs: #3120

## 修正の内容
- 質問作成後にメンター側へ自動的にWatchをonにしていた処理はWIP導入以前は`app/controllers/questions_controller.rb`にて実装していましたが、`app/models/question_callbacks.rb`の`after_save`内へ移動させ、質問の初回の本公開時に行うように変更しました。
- N+1への対策として`insert_all`を使うことと、ここにrubocopの指摘が入るのを無効化することは、以前の実装時の受講生とアドバイザーさん、駒形さんとのやり取り・指示をそのまま受け継ぎました。
詳細は下記のコメントをご覧ください。
https://github.com/fjordllc/bootcamp/pull/3120/files#r700293736


## 修正前
- WIPで保存時にすでに「Watch中」ボタンがonになってしまっている
![スクリーンショット 2022-03-24 8 55 41](https://user-images.githubusercontent.com/82434093/159823041-23ab9979-6a02-4b38-8126-f238093b98e5.png)

## 修正後
- WIPで保存時には「Watch中」ボタンがonにならない
![image](https://user-images.githubusercontent.com/82434093/160615462-29dffa8f-fa88-4625-b810-01ea2d1e98eb.png)

- 質問の本公開時には「Watch中」ボタンがonになる
![image](https://user-images.githubusercontent.com/82434093/160615872-439d44fe-bec1-404c-b30c-c28246fe6a10.png)

## 動作確認手順
1. 手元に本ブランチを取り込む。
1. `bin/setup` `rails db:reset`を行い初期化した後、`rails s`にて開発環境を立ち上げる
1. 下記の手順で動作確認を行う。
    1. 受講生ユーザーでログインして質問を新規作成し、「登録する」で本公開する。
    1. メンターでログインして該当の本公開済みの質問が「Watch中」になっているのを確認する。
    1. 受講生ユーザーでログインして質問を新規作成し、「WIP」をクリックしてwip保存する。
    1. メンターでログインして該当のwIP中の質問が「Watch中」ではないのを確認する。
    1. 上で質問を作成した受講生ユーザーでログインしてwip保存した質問を「内容修正」から「質問を公開」をクリックして本公開する。
    1. メンターでログインして該当の本公開済みの質問が「Watch中」になっているのを確認する。
