### PR TITLE
ユーザー個別 > 日報タブ の日報一覧を Vue.js 化した

### DIFF
--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -18,14 +18,4 @@ header.page-header
 
 .page-body
   .container.is-md
-    = paginate @reports
-    - if @reports.present?
-      .thread-list.a-card
-        = render partial: 'reports/report', collection: @reports, as: :report
-    - else
-      .o-empty-message
-        .o-empty-message__icon
-          i.far.fa-sad-tear
-        p.o-empty-message__text
-          | 日報はまだありません。
-    = paginate @reports
+    #js-reports data-user-id="#{params[:user_id]}"

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -302,3 +302,13 @@ report<%= i + 31 %>:
     - テスト
   reported_on: <%= Time.now - 1.month + i.day %>
 <% end %>
+
+<% 37.upto(70) do |i| %>
+report<%= i %>:
+  user: with_hyphen
+  title: 日報<%= i %>
+  emotion: 2
+  description: |-
+    頑張れませんでした
+  reported_on: <%= Time.now - 1.year + i.day %>
+<% end %>

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -142,16 +142,16 @@ report17:
     mentormentaroです、メンターです。
     今日は1時間学習しました。
   practices: practice1
-  reported_on: "2020-06-01"
-  created_at: "2020-06-01 17:00:00"
+  reported_on: "2022-04-01"
+  created_at: "2022-04-01 17:00:00"
 
 report18:
   user: daimyo
   title: テストのnippou
   description: |-
     今日は1時間学習しました。
-  reported_on: "2020-06-01"
-  created_at: "2020-06-01 18:00:00"
+  reported_on: "2022-04-01"
+  created_at: "2022-04-01 18:00:00"
 
 report19:
   user: hatsuno
@@ -191,14 +191,14 @@ report23:
   title: フォローされた日報
   description:
     フォローされました。
-  reported_on: "2020-11-10"
+  reported_on: "2022-03-31"
 
 report24:
   user: daimyo
   title: 検索用の日報
   description:
     ユーザーネームで検索できるよ
-  reported_on: "2020-11-20"
+  reported_on: "2022-03-31"
 
 report25:
   user: hatsuno

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -282,3 +282,13 @@ report34:
     最新から10日前の日報です
   reported_on: <%= Time.current - 11.day %>
   created_at: <%= Time.current - 11.day %>
+
+<% 35.upto(70) do |i| %>
+report<%= i %>:
+  user: with_hyphen
+  title: 日報<%= i %>
+  emotion: 2
+  description: |-
+    頑張れませんでした
+  reported_on: <%= Time.now - 1.year + i.day %>
+<% end %>

--- a/test/integration/api/reports_test.rb
+++ b/test/integration/api/reports_test.rb
@@ -24,4 +24,15 @@ class API::ReportsTest < ActionDispatch::IntegrationTest
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
   end
+
+  test 'GET /api/reports.json?user_id=984742968' do
+    user = users(:with_hyphen)
+    get api_reports_path(user_id: user.id, format: :json)
+    assert_response :unauthorized
+
+    token = create_token('kimura', 'testtest')
+    get api_reports_path(user_id: user.id, format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -727,7 +727,7 @@ class ReportsTest < ApplicationSystemTestCase
   test 'mentors can see reports page if products published_at is nil' do
     visit_with_auth '/reports/unchecked', 'mentormentaro'
     click_link 'テストのnippou'
-    assert_text '2020年06月01日 の日報'
+    assert_text '2022年04月01日 の日報'
     assert_text '今日は1時間学習しました。'
   end
 end


### PR DESCRIPTION
Issue #3640

## 概要
ユーザー個別ページの日報一覧(ページャー含む)をVue.js化させました。
#4343 のPRを参考に実装しています。

※ [ReportのAPIにユーザーIDでの絞り込み機能](https://github.com/fjordllc/bootcamp/blob/main/app/controllers/api/reports_controller.rb#:~:text=%40reports%20%3D%20%40reports.where(user_id%3A%20params%5B%3Auser_id%5D)%20if%20params%5B%3Auser_id%5D.present%3F)が既に実装されていた為、新たなJSファイル・APIは作成していません。

## 確認手順
1. 本ブランチをローカルに取り込む
2. `rails db:seed`を実行しDBの内容を開発環境に反映する
3. ユーザー個別ページの日報へ飛び、Vue化の確認をお願いします。
http://127.0.0.1:3000/users/632197024/reports ではページャーも確認できます

## 画面スクリーンショット
<img width="1440" alt="スクリーンショット 2022-04-04 13 16 21" src="https://user-images.githubusercontent.com/80372144/161473006-fd920fb5-af3b-445f-a5ab-017353b9ac54.png">


