### PR TITLE
未アサインの提出物のDiscordの通知にリンクを付けた

### DIFF
--- a/app/views/api/products/unassigned/counts.text.erb
+++ b/app/views/api/products/unassigned/counts.text.erb
@@ -1,5 +1,6 @@
 <% if @passed5 + @passed6 + @over7 > 0 %>
 提出されてから日数が経っている提出物の数をお知らせします。
+https://bootcamp.fjord.jp/products/unassigned
 
 <% if @passed5 > 0 %>
 - 5日経過：<%= @passed5 %>件


### PR DESCRIPTION
- #4313

## 概要
Discordのメンターチャンネルで「提出されてから日数が経っている提出物の数をお知らせします」と通知されている。
この通知に未アサインの提出物ページへのリンクが付いていない。

## 修正内容
このファイルにある文字がDiscordのメンターチャンネルに毎日投稿されているので、
`app/views/api/products/unassigned/counts.text.erb`

文面に以下のリンクを追加した。
https://bootcamp.fjord.jp/products/unassigned

## 確認方法
1. ブランチ `feature/add-link-to-notifications-for-unassigned-products`をローカルに取り込む
1. `bin/rails s`でサーバーを立ち上げる
1. `komagata`でログインする
1. `http://localhost:3000/api/products/unassigned/counts.txt`にアクセスして、以下のリンクが文面に追加されているか確認する
https://bootcamp.fjord.jp/products/unassigned