### PR TITLE
管理者ページの企業一覧から削除ボタンを消した

### DIFF
--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -15,7 +15,7 @@
           th.admin-table__label.actions
             | リンク
           th.admin-table__label.actions
-            | 操作
+            | 編集
       tbody.admin-table__items
         tr.admin-table__item(
           v-for='company in companies',

--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -45,11 +45,6 @@
                   :href='`/admin/companies/${company.id}/edit`'
                 )
                   i.fa-solid.fa-pen
-              li
-                a.a-button.is-sm.is-danger.is-icon.js-delete(
-                  @click='destroy(company)'
-                )
-                  i.fa-solid.fa-trash-alt
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')
 </template>

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -36,12 +36,4 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
     visit_with_auth '/admin/companies', 'komagata'
     assert_selector 'nav.pagination', count: 2
   end
-
-  test 'delete company' do
-    visit_with_auth '/admin/companies', 'komagata'
-    accept_confirm do
-      find("#company_#{companies(:company1).id} a.a-button.is-sm.is-danger.is-icon.js-delete").click
-    end
-    assert_text '企業を削除しました。'
-  end
 end


### PR DESCRIPTION
## 関連issue
- #4534

## 概要・要件
企業編集ページに削除リンクを表示させるのと併せて、管理者ページの企業一覧から削除ボタンを消した。

また、項目名を「操作」から「編集」に変更した。

このPRは以下のissueと関連していて、企業一覧ページから削除ボタンを削除し、企業編集ページに削除ボタンを設置した。
- #4535

## スクリーンショット

|Before|After|
|---|---|
|<img width="1054" src="https://user-images.githubusercontent.com/168265/160847512-91d5ff1f-98f6-4528-80bc-1ca565f2573d.png">|<img width="1054" src="https://user-images.githubusercontent.com/49633473/161724977-d2653a11-de93-4d3b-bc94-2d6132af700c.png">|

## 確認方法
1. `feature/remove-delete-button-from-company-list-of-admin-page`をローカルに取り込む
1. `bin/rails setup`実行
1. `bin/rails s`でサーバーを立ち上げる
1. 管理者ロールのユーザー(`komagata`か`machida`)でログイン
1. 右上のユーザーアイコンをクリックし(Meと書いてあるアイコン)、管理ページを選択
1. 管理ページの「企業」のタブをクリックして企業一覧のページに遷移し、削除ボタンが表示されていないことを確認。また、項目名が「編集」になっていることも確認