### PR TITLE
Rails 7.0 以降で非推奨の TimeWithZone#to_s(:db), Date#to_s(:db) を to_fs(:db) に置き換えます

### DIFF
--- a/db/fixtures/learnings.yml
+++ b/db/fixtures/learnings.yml
@@ -114,6 +114,6 @@ learning<%= i + 18 %>:
   user: <%= [:akiyosi, :fujiyasu, :jobseeker, :muryou, :nippounashi][i] %>
   practice: practice1
   status: "complete"
-  created_at: <%= (today - 2.weeks + 2.day + 12.hours - i.day).to_s(:db) %>
-  updated_at: <%= (today - 2.weeks + 2.day + 12.hours - i.day).to_s(:db) %>
+  created_at: <%= (today - 2.weeks + 2.day + 12.hours - i.day).to_fs(:db) %>
+  updated_at: <%= (today - 2.weeks + 2.day + 12.hours - i.day).to_fs(:db) %>
 <% end %>

--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -4,121 +4,121 @@ product1:
   practice: practice1
   user: mentormentaro
   body: テストの提出物1です。
-  published_at: <%= (now - 60 * 60 * 24 * 1).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 1).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 1).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 1).to_fs(:db) %>
 
 product2:
   practice: practice1
   user: kimura
   body: テストの提出物2です。
-  published_at: <%= (now - 60 * 60 * 24 * 2).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 2).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 2).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 2).to_fs(:db) %>
 
 product3:
   practice: practice2
   user: sotugyou
   body: 確認済みの提出物
-  published_at: <%= (now - 60 * 60 * 24 * 3).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 3).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 3).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 3).to_fs(:db) %>
 
 product4:
   practice: practice2
   user: mentormentaro
   body: テストの提出物4です。
-  published_at: <%= (now - 60 * 60 * 24 * 4).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 4).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 4).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 4).to_fs(:db) %>
 
 product5:
   practice: practice2
   user: kimura
   body: テストの提出物5です。
-  published_at: <%= (now - 60 * 60 * 24 * 5).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 5).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 5).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 5).to_fs(:db) %>
 
 product6:
   practice: practice3
   user: sotugyou
   body: 確認待ちの提出物
-  published_at: <%= (now - 60 * 60 * 24 * 6).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 6).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 6).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 6).to_fs(:db) %>
 
 product7:
   practice: practice3
   user: mentormentaro
   body: テストの提出物7です。
-  published_at: <%= (now - 60 * 60 * 24 * 7).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 7).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 7).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 7).to_fs(:db) %>
 
 product8:
   practice: practice3
   user: kimura
   body: テストの提出物8です。
-  published_at: <%= (now - 60 * 60 * 24 * 8).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 8).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 8).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 8).to_fs(:db) %>
 
 product9:
   practice: practice4
   user: mentormentaro
   body: テストの提出物9です。
-  published_at: <%= (now - 60 * 60 * 24 * 9).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 9).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 9).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 9).to_fs(:db) %>
 
 product10:
   practice: practice4
   user: kimura
   body: テストの提出物10です。
-  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
 
 product11:
   practice: practice2
   user: hatsuno
   body: テストの提出物11です。
-  published_at: <%= (now - 60 * 60 * 24 * 11).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 11).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 11).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 11).to_fs(:db) %>
 
 product12:
   practice: practice5
   user: mentormentaro
   body: リアクションテスト
-  published_at: <%= (now - 60 * 60 * 24 * 12).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 12).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 12).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 12).to_fs(:db) %>
 
 product13:
   practice: practice1
   user: kensyu
   body: 研修の提出物です。
-  published_at: <%= (now - 60 * 60 * 24 * 13).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 13).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 13).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 13).to_fs(:db) %>
 
 product14:
   practice: practice1
   user: daimyo
   body: 研修の提出物です。
-  published_at: <%= (now - 60 * 60 * 24 * 14).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 14).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 14).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 14).to_fs(:db) %>
 
 <% (15..60).each do |i| %>
 product<%= i %>:
   practice: practice<%= i - 14 %>
   user: with_hyphen
   body: テストの提出物<%= i %>です。
-  published_at: <%= (now - i).to_s(:db) %>
-  created_at: <%= (now - i).to_s(:db) %>
+  published_at: <%= (now - i).to_fs(:db) %>
+  created_at: <%= (now - i).to_fs(:db) %>
 <% end %>
 
 product61:
   practice: practice1
   user: sumi
   body: テストの提出物61です。
-  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
 
 product62:
   practice: practice1
   user: take8
   body: テストの提出物62です。
-  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
 
 product63:
   practice: practice6

--- a/test/fixtures/learnings.yml
+++ b/test/fixtures/learnings.yml
@@ -114,6 +114,6 @@ learning<%= i + 18 %>:
   user: <%= [:jobseeker, :muryou][i] %>
   practice: practice1
   status: "complete"
-  created_at: <%= (today - (2.weeks - 1.day) - i.day).to_s(:db) %>
-  updated_at: <%= (today - (2.weeks - 1.day) - i.day).to_s(:db) %>
+  created_at: <%= (today - (2.weeks - 1.day) - i.day).to_fs(:db) %>
+  updated_at: <%= (today - (2.weeks - 1.day) - i.day).to_fs(:db) %>
 <% end %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -437,16 +437,16 @@ class UserTest < ActiveSupport::TestCase
       user: user,
       practice: practice1,
       status: :complete,
-      created_at: (today - 2.weeks).to_s(:db),
-      updated_at: (today - 2.weeks).to_s(:db)
+      created_at: (today - 2.weeks).to_fs(:db),
+      updated_at: (today - 2.weeks).to_fs(:db)
     )
 
     Learning.create!(
       user: user,
       practice: practice2,
       status: :complete,
-      created_at: (today - (2.weeks + 1.day)).to_s(:db),
-      updated_at: (today - (2.weeks + 1.day)).to_s(:db)
+      created_at: (today - (2.weeks + 1.day)).to_fs(:db),
+      updated_at: (today - (2.weeks + 1.day)).to_fs(:db)
     )
 
     worried_users = User.delayed.order(completed_at: :asc)
@@ -463,8 +463,8 @@ class UserTest < ActiveSupport::TestCase
       user: user,
       practice: Practice.first,
       status: :complete,
-      created_at: (today - (2.weeks - 1.day)).to_s(:db),
-      updated_at: (today - (2.weeks - 1.day)).to_s(:db)
+      created_at: (today - (2.weeks - 1.day)).to_fs(:db),
+      updated_at: (today - (2.weeks - 1.day)).to_fs(:db)
     )
 
     worried_users = User.delayed.order(completed_at: :asc)
@@ -481,8 +481,8 @@ class UserTest < ActiveSupport::TestCase
       user: user,
       practice: practice1,
       status: :complete,
-      created_at: (today - 2.weeks).to_s(:db),
-      updated_at: (today - 2.weeks).to_s(:db)
+      created_at: (today - 2.weeks).to_fs(:db),
+      updated_at: (today - 2.weeks).to_fs(:db)
     )
 
     worried_users = User.delayed.order(completed_at: :asc)


### PR DESCRIPTION
Rails 7.0 でテストを実行すると

```
DEPRECATION WARNING: TimeWithZone#to_s(:db) is deprecated. Please use TimeWithZone#to_fs(:db) instead.
DEPRECATION WARNING: Date#to_s(:db) is deprecated. Please use Date#to_fs(:db) instead.
```

と出るため、to_fs に置き換えます