### PR TITLE
企業編集ページに削除リンクを表示させた

### DIFF
--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -30,3 +30,5 @@
         = f.submit nil, class: 'a-button is-lg is-block is-warning'
       li.form-actions__item.is-sub
         = link_to 'キャンセル', :back, class: 'a-button is-md is-block is-secondary'
+      li.form-actions__item.is-sub
+        = link_to '削除', :back, class: 'a-button is-md is-block is-secondary'


### PR DESCRIPTION
## 関連issue
- #4535

## 概要・要件
管理者ページの企業一覧から削除ボタンを消すのと併せて、企業編集ページに削除リンクを表示させた。削除リンクなので、ボタンを押すと企業編集ページから企業一覧に戻るようになっている。現状は削除は出来ない。

管理者ページの企業編集ページなので、この削除ボタンは管理者にしか見えない。

リンクの設置なので、削除ボタンを押すと企業一覧のページに戻る。削除ボタンを押した企業は削除されない。

## スクリーンショット

|Before|After|
|---|---|
|<img width="1054" src="https://user-images.githubusercontent.com/49633473/161770047-965ad701-a21b-48a6-af74-cae39497b011.png">|<img width="1054" src="https://user-images.githubusercontent.com/49633473/161770305-f3253681-5d03-465c-a19f-1561650fad35.png">|

## 確認方法
1. `feature/display-delete-link-on-the-company-edit-page`をローカルに取り込む
1. `bin/rails s`でサーバーを立ち上げる
1. 管理者ロールのユーザー(`komagata`か`machida`)でログイン
1. 右上のユーザーアイコンをクリックし(Meと書いてあるアイコン)、管理ページを選択
1. 管理ページの「企業」のタブをクリックして企業一覧のページに遷移し、「操作」の項目にある編集ボタン（えんぴつマークのボタン）をクリックし、企業編集ページに遷移。画面をスクロールし、削除ボタンが表示されていることを確認。削除ボタンを押すと企業一覧ページに戻ることを確認