### PR TITLE
回答の本文が90文字以上の場合省略表記されるようにした

### DIFF
--- a/app/javascript/users-answer.vue
+++ b/app/javascript/users-answer.vue
@@ -24,7 +24,7 @@
               .thread-list-item-sub-title {{ answer.question.practice.title }}
       .thread-list-item__row
         .thread-list-item__summary
-          p {{ answer.description }}
+          p {{ summary }}
       .thread-list-item__row
         .thread-list-item-meta
           .thread-list-item-meta__items
@@ -61,6 +61,14 @@ export default {
       } else {
         return ''
       }
+    },
+    summary() {
+      let description = this.answer.description
+      description =
+          description.length <= 90
+              ? description
+              : description.substring(0, 90) + '...'
+      return description
     }
   }
 }

--- a/app/javascript/users-answer.vue
+++ b/app/javascript/users-answer.vue
@@ -65,9 +65,9 @@ export default {
     summary() {
       let description = this.answer.description
       description =
-          description.length <= 90
-              ? description
-              : description.substring(0, 90) + '...'
+        description.length <= 90
+          ? description
+          : description.substring(0, 90) + '...'
       return description
     }
   }


### PR DESCRIPTION
#4575 のバグに関し、回答本文が90文字以上の場合は「(90文字)+...」で表現されるように修正しました。
Ref: #4319