### PR TITLE
お支払い情報ページを追加

### DIFF
--- a/app/controllers/billing_portal_controller.rb
+++ b/app/controllers/billing_portal_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class BillingPortalController < ApplicationController
+  before_action :require_login
+
+  def create
+    session = Stripe::BillingPortal::Session.create(customer: current_user.customer_id)
+    redirect_to session.url
+  end
+end

--- a/app/views/application/_user_menu.html.slim
+++ b/app/views/application/_user_menu.html.slim
@@ -9,6 +9,8 @@
     - if !current_user.adviser? && !current_user.mentor? && !current_user.trainee?
       - if current_user.card?
         li.header-dropdown__item
+          = link_to 'お支払い情報', billing_portal_path, method: :post, class: 'header-dropdown__item-link'
+        li.header-dropdown__item
           = link_to 'クレジットカード情報', card_path, class: 'header-dropdown__item-link'
         li.header-dropdown__item
           = link_to 'クレジットカード変更', edit_card_path, class: 'header-dropdown__item-link'

--- a/app/views/card/edit.html.slim
+++ b/app/views/card/edit.html.slim
@@ -3,15 +3,14 @@
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title = title
+      h2.page-header__title
+        = title
 
 .page-body
-  .container
-    .auth-form.is-sign-up.a-card.is-in-app
-      .a-card
-        header.auth-form__header
-          h1.auth-form__title
-            | クレジットカード変更
-        .auth-form__body
-          = render 'form', action: :edit
-      = render 'notice'
+  .auth-form.is-sign-up.a-card.is-in-app
+    header.auth-form__header
+      h1.auth-form__title
+        | クレジットカード変更
+    .auth-form__body
+      = render 'form', action: :edit
+  = render 'notice'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
     resources :products, only: %i(index), controller: "companies/products"
   end
   resources :generations, only: %i(show index)
+  resource :billing_portal, only: :create, controller: "billing_portal"
   get "articles/tags/:tag", to: "articles#index", as: :tag, tag: /.+/
   get "pages/tags/:tag", to: "pages#index", as: :pages_tag, tag: /.+/, format: "html"
   get "questions/tags/:tag", to: "questions#index", as: :questions_tag, tag: /.+/, format: "html"


### PR DESCRIPTION
Stripeが用意しているユーザーごとの支払い履歴と請求書・領収書が見れるページ（Stripeのカスタマーポータルという機能）へアクセスできるようにしました。

メニューに「お支払い情報」というリンクを追加。

<img width="479" alt="スクリーンショット 2022-04-08 17 18 39" src="https://user-images.githubusercontent.com/16577/162396069-5659e420-2c21-43cf-91a3-7801e8e999d0.png">

↓こういうページにアクセスできる。（アクセスごとに一時的なURLを発行してるので安全）

<img width="1358" alt="スクリーンショット 2022-04-08 17 17 15" src="https://user-images.githubusercontent.com/16577/162395698-31763b19-56c1-430a-befe-72e3ad70bbbd.png">

↓それぞれの支払いについてこういうページができていて、請求書（インボイス）と領収書がPDFでダウンロードできる。

<img width="1358" alt="スクリーンショット 2022-04-08 17 17 26" src="https://user-images.githubusercontent.com/16577/162395875-3cb4e397-e2ab-4d3a-9169-5cb6b66ba692.png">

↓こういう領収書PDFがダウンロードできる。

<img width="1053" alt="スクリーンショット 2022-04-08 17 19 36" src="https://user-images.githubusercontent.com/16577/162395998-4584542c-7b88-46ef-bb20-df271edea6b2.png">

これがあればメールがどっかいってしまった人でも後で領収書をDLできるのと、次の請求日も表示されるので、カード情報のページが入らなくなるかもしれない。（今は機能をオフにしているが、このカスタマーポータルでカード番号の更新もユーザー自身でできる）

（ちなみに請求先の宛名の変更はStripeから発行される請求書を使う場合、できない）