### PR TITLE
Watchを外したらtoastを表示するようにした

### DIFF
--- a/app/javascript/watch-toggle.vue
+++ b/app/javascript/watch-toggle.vue
@@ -109,7 +109,7 @@ export default {
         .then(() => {
           this.watchId = null
           this.watchLabel = 'Watch'
-          this.toast('Bookmarkを削除しました')
+          this.toast('Watchを外しました')
         })
         .then(() => {
           this.$emit('update-index')

--- a/app/javascript/watch-toggle.vue
+++ b/app/javascript/watch-toggle.vue
@@ -109,6 +109,7 @@ export default {
         .then(() => {
           this.watchId = null
           this.watchLabel = 'Watch'
+          this.toast('Bookmarkを削除しました')
         })
         .then(() => {
           this.$emit('update-index')


### PR DESCRIPTION
issue #3281 

## 概要
watch一覧からwatchを外すと、watchした時と同様に、外したことをtoastで表示（右上に表示されるアラート）されるようにしました。
[PR3360](https://github.com/fjordllc/bootcamp/pull/3360)　を参考にしています。

## ローカル環境での確認方法
1. ブランチ `feature/show-deleting-watch-by-toast` をローカルに取り込みます。
1. 何らかのユーザーでログインし、日報をwatch、その後watchを外したときに右上にアラートが出ることを確認します。