### PR TITLE
管理者の場合、ユーザー情報変更ページでコース変更できるようにした

### DIFF
--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -52,6 +52,7 @@
   - if admin_login?
     .form__items
       h3.form__items-title 以下管理者のみ操作ができます
+      = render 'users/form/course', f: f
       = render 'users/form/job_seeking', f: f
       = render 'users/form/company', f: f
       = render 'users/form/retire', f: f

--- a/app/views/users/form/_course.html.slim
+++ b/app/views/users/form/_course.html.slim
@@ -1,6 +1,6 @@
 .form-item
   = f.label :course_id, class: 'a-form-label is-required'
   .a-button.is-md.is-secondary.is-select.is-block
-    = f.collection_select :course_id, Course.order(:created_at), :id, :title
+    = f.collection_select :course_id, Course.order(:created_at), :id, :title, {}
   .a-form-help
     p コースの一覧は#{link_to 'こちら', courses_path, trget: '_blank'}

--- a/app/views/users/form/_course.html.slim
+++ b/app/views/users/form/_course.html.slim
@@ -1,6 +1,6 @@
 .form-item
   = f.label :course_id, class: 'a-form-label is-required'
   .a-button.is-md.is-secondary.is-select.is-block
-    = f.collection_select :course_id, Course.order(:created_at), :id, :title, {}
+    = f.collection_select :course_id, Course.order(:created_at), :id, :title
   .a-form-help
     p コースの一覧は#{link_to 'こちら', courses_path, trget: '_blank'}

--- a/app/views/users/form/_course.html.slim
+++ b/app/views/users/form/_course.html.slim
@@ -1,4 +1,4 @@
-.form-item.is-hidden
+.form-item
   = f.label :course_id, class: 'a-form-label is-required'
   .a-button.is-md.is-secondary.is-select.is-block
     = f.collection_select :course_id, Course.order(:created_at), :id, :title, {}

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -224,6 +224,6 @@ class Admin::UsersTest < ApplicationSystemTestCase
       select 'iOSプログラマー', from: 'user[course_id]'
     end
     click_on '更新する'
-    assert_equal 'iOSプログラマー', User.find(user.id).course.title
+    assert_equal 'iOSプログラマー', user.reload.course.title
   end
 end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -226,4 +226,11 @@ class Admin::UsersTest < ApplicationSystemTestCase
     click_on '更新する'
     assert_equal 'iOSプログラマー', user.reload.course.title
   end
+
+  test 'general user cannot change user course' do
+    user = users(:kensyu)
+    visit_with_auth "/admin/users/#{user.id}/edit", 'kimura'
+    assert_current_path('/')
+    assert_text '管理者としてログインしてください'
+  end
 end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -216,4 +216,14 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert has_checked_field?('user_trainee', visible: false)
     assert has_field?('user_training_ends_on', with: '')
   end
+
+  test 'admin can change user course' do
+    user = users(:kensyu)
+    visit_with_auth "/admin/users/#{user.id}/edit", 'machida'
+    within 'form[name=user]' do
+      select 'iOSプログラマー', from: 'user[course_id]'
+    end
+    click_on '更新する'
+    assert_equal 'iOSプログラマー', User.find(user.id).course.title
+  end
 end


### PR DESCRIPTION
- #4138 

## 概要
現在、DBを直接変更しないとユーザーのコース変更ができないため、管理者でログインした時、ユーザー情報変更ページでコースを変更できるようにしました。

## 変更前
- 管理者でログイン時、ユーザー情報変更ページに、コース変更の項目が無い。
![スクリーンショット 2022-04-09 18 58 31](https://user-images.githubusercontent.com/58052292/162567051-0002217d-2802-4c36-8876-b28cf02bac12.png)


## 変更後
- 管理者でログイン時、ユーザー情報変更ページの「以下管理者のみ操作ができます」の下の一番目に、コースの項目が有る。
[![Image from Gyazo](https://i.gyazo.com/f4e83237f55a5449066322e856421a0e.gif)](https://gyazo.com/f4e83237f55a5449066322e856421a0e)

## 動作確認の手順
1. `feature/enable-change-courses-at-user-info-edit-page-when-logined-as-admin`ブランチをローカルに持ってきて、立ち上げる
2. 管理者 (`machida`)でログインする。
3. `kensyu` のユーザー個別ページにアクセスする。(http://localhost:3000/users/301971253)
4. プロフィールのコースが「Rails Webプログラマー」になっていることを確認する。
5. プロフィールの「管理者として情報変更」をクリックする。
6. 「以下管理者のみ操作ができます」の下の**一番目に、「コース」の項目がある**ことを確認する。
7. コースを「iOSプログラマー」に変更し、「更新する」をクリックする。
8. `kensyu`のプロフィールのコースが、「iOSプログラマー」に変更されていることを確認する。
