### PR TITLE
卒業生のダッシュボードに「卒業後の目標」の入力を促すブロックは表示しないようにした

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -39,7 +39,8 @@ class HomeController < ApplicationController
       after_graduation_hope: current_user.after_graduation_hope,
       discord_account: current_user.discord_account,
       github_account: current_user.github_account,
-      blog_url: current_user.blog_url
+      blog_url: current_user.blog_url,
+      graduated_on: current_user.graduated_on
     )
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -40,7 +40,7 @@ class HomeController < ApplicationController
       discord_account: current_user.discord_account,
       github_account: current_user.github_account,
       blog_url: current_user.blog_url,
-      graduated?: current_user.graduated?
+      graduated: current_user.graduated?
     )
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -40,7 +40,7 @@ class HomeController < ApplicationController
       discord_account: current_user.discord_account,
       github_account: current_user.github_account,
       blog_url: current_user.blog_url,
-      graduated_on: current_user.graduated_on
+      graduated?: current_user.graduated?
     )
   end
 

--- a/app/models/required_field.rb
+++ b/app/models/required_field.rb
@@ -10,11 +10,11 @@ class RequiredField
   attribute :discord_account, :string
   attribute :github_account, :string
   attribute :blog_url, :string
-  attribute :graduated?, :boolean
+  attribute :graduated, :boolean
 
   validates :avatar_attached, presence: { message: 'ユーザーアイコンを登録してください。' }
   validates :tag_list_count, numericality: { greater_than: 0, message: 'タグを登録してください。' }
-  validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }, unless: :graduated?
+  validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }, unless: :graduated
   validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
   validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
   validates :blog_url, presence: { message: 'ブログURLを登録してください。' }

--- a/app/models/required_field.rb
+++ b/app/models/required_field.rb
@@ -10,10 +10,11 @@ class RequiredField
   attribute :discord_account, :string
   attribute :github_account, :string
   attribute :blog_url, :string
+  attribute :graduated_on, :date
 
   validates :avatar_attached, presence: { message: 'ユーザーアイコンを登録してください。' }
   validates :tag_list_count, numericality: { greater_than: 0, message: 'タグを登録してください。' }
-  validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }
+  validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }, unless: :graduated_on
   validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
   validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
   validates :blog_url, presence: { message: 'ブログURLを登録してください。' }

--- a/app/models/required_field.rb
+++ b/app/models/required_field.rb
@@ -10,11 +10,11 @@ class RequiredField
   attribute :discord_account, :string
   attribute :github_account, :string
   attribute :blog_url, :string
-  attribute :graduated_on, :date
+  attribute :graduated?, :boolean
 
   validates :avatar_attached, presence: { message: 'ユーザーアイコンを登録してください。' }
   validates :tag_list_count, numericality: { greater_than: 0, message: 'タグを登録してください。' }
-  validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }, unless: :graduated_on
+  validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }, unless: :graduated?
   validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
   validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
   validates :blog_url, presence: { message: 'ブログURLを登録してください。' }

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -82,6 +82,12 @@ class HomeTest < ApplicationSystemTestCase
     assert_no_text 'ブログURLを登録してください。'
   end
 
+  test 'not show messages of after_graduation_hope for gradueted user' do
+    visit_with_auth '/', 'sotugyou'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
+    assert_no_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。'
+  end
+
   test 'not show messages of required field' do
     user = users(:hatsuno)
     # hatsuno の未入力項目を登録

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -82,7 +82,7 @@ class HomeTest < ApplicationSystemTestCase
     assert_no_text 'ブログURLを登録してください。'
   end
 
-  test 'not show messages of after_graduation_hope for gradueted user' do
+  test 'not show message of after_graduation_hope for graduated user' do
     visit_with_auth '/', 'sotugyou'
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     assert_no_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。'


### PR DESCRIPTION
- #4505

## 概要
卒業後の目標が未入力の場合、卒業生のダッシュボードにて「フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。」というアナウンスが表示される。

こちらは性質上受講生向けのものであるため、卒業生のダッシュボードには出てこないようにしたい。

卒業生以外のロールを確認したところ、管理者とメンター、アドバイザーは「未入力の項目」自体が表示されないため、今回は卒業生以外のロールは考慮しない。

## 修正前
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/31835314/162579321-6c182bdd-6ed8-4186-93e8-eb281acf3db6.png">

## 修正後
卒業後の目標が未入力の場合でも「フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。」というアナウンスは出てこない。
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/31835314/162579365-eda2f05a-1692-4913-98dd-fe2cba552358.png">

## 確認方法
- ブランチ `feature/fix-graduate-dashbord` をローカルに取り込む
- `bin/rails s`でサーバーを立ち上げる
- 卒業生のroleでログインする（`sotugyou`など）
- ダッシュボードにアクセスして「未入力の項目」の中に「[フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください」という項目が出てこないことを確認
- 現役生のroleでログインする（`kimura` など）
- ダッシュボードにアクセスして「未入力の項目」の中に「[フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください」という項目が出てくることを確認