### PR TITLE
 未ログインで相談部屋にアクセスすると「ログインしてください」と表示するようにした

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TalksController < ApplicationController
-  before_action :require_login
+  before_action :require_login, only: %i[show]
   before_action :set_talk, only: %i[show]
   before_action :set_user, only: %i[show]
   before_action :set_members, only: %i[show]

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TalksController < ApplicationController
+  before_action :require_login
   before_action :set_talk, only: %i[show]
   before_action :set_user, only: %i[show]
   before_action :set_members, only: %i[show]

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -2,10 +2,10 @@
 
 class TalksController < ApplicationController
   before_action :require_login, only: %i[show]
+  before_action :require_admin_login, only: %i[index]
   before_action :set_talk, only: %i[show]
   before_action :set_user, only: %i[show]
   before_action :set_members, only: %i[show]
-  before_action :require_admin_login, only: %i[index]
   before_action :allow_show_talk_page_only_admin, only: %i[show]
 
   def index

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -18,6 +18,12 @@ class TalksTest < ApplicationSystemTestCase
     assert_text '管理者としてログインしてください'
   end
 
+  test 'user who is not logged in cannot access talks page' do
+    user = users(:kimura)
+    visit "/talks/#{user.talk.id}"
+    assert_text 'ログインしてください'
+  end
+
   test 'cannot access other users talk page' do
     visited_user = users(:hatsuno)
     visit_user = users(:mentormentaro)


### PR DESCRIPTION
- #4487

## 概要
ログインしていない状態で相談部屋にアクセスすると500エラーが出る。
他のページと同じように、ログインしていない状態でアクセスするとトップページにリダイレクトし、「ログインしてください」と表示させたい。

## 変更前
![image](https://user-images.githubusercontent.com/31835314/162698454-39dc8193-7288-4f2c-9cea-2567eb284db8.png)

## 変更後
![image](https://user-images.githubusercontent.com/31835314/162698958-74ad1f1f-b98a-47f0-8750-88de6c101a2d.png)

## 確認方法
- ブランチ `bug/500error-occured-when-access-to-talks-page` をローカルに取り込む
- `bin/rails s`でサーバーを立ち上げる
- `kimura` でログインし、相談部屋を開き、URLをひかえておく
- ログアウトして、ひかえておいたURLにアクセスしてみる
トップページにリダイレクトされ、「ログインしてください」とアラートが出てくるか確認する