### PR TITLE
WIPの質問は未解決一覧には含めず、全ての質問一覧にだけ含める

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -11,7 +11,7 @@ class API::QuestionsController < API::BaseController
       elsif params[:all].present?
         Question.all
       else
-        Question.not_solved
+        Question.not_solved.not_wip
       end
     questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
     questions = params[:user_id].present? ? Question.where(user_id: params[:user_id]) : questions

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -9,7 +9,7 @@ class Practices::QuestionsController < ApplicationController
       if params[:solved].present?
         @practice.questions.solved
       elsif params[:not_solved].present?
-        @practice.questions.not_solved
+        @practice.questions.not_solved.not_wip
       else
         @practice.questions
       end

--- a/test/system/practice/questions_test.rb
+++ b/test/system/practice/questions_test.rb
@@ -16,5 +16,6 @@ class Practice::QuestionsTest < ApplicationSystemTestCase
   test 'not show a WIP question on the unsolved questions list ' do
     visit_with_auth "/practices/#{practices(:practice1).id}/questions?not_solved=true", 'hatsuno'
     assert_no_text 'wipテスト用の質問(wip中)'
+    assert_selector('a.tab-nav__item-link.is-active', text: '未解決')
   end
 end

--- a/test/system/practice/questions_test.rb
+++ b/test/system/practice/questions_test.rb
@@ -7,4 +7,14 @@ class Practice::QuestionsTest < ApplicationSystemTestCase
     visit_with_auth "/practices/#{practices(:practice1).id}/questions", 'hatsuno'
     assert_equal 'OS X Mountain Lionをクリーンインストールする | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
+
+  test 'show a WIP question on the all questions list ' do
+    visit_with_auth "/practices/#{practices(:practice1).id}/questions", 'hatsuno'
+    assert_text 'wipテスト用の質問(wip中)'
+  end
+
+  test 'not show a WIP question on the unsolved questions list ' do
+    visit_with_auth "/practices/#{practices(:practice1).id}/questions?not_solved=true", 'hatsuno'
+    assert_no_text 'wipテスト用の質問(wip中)'
+  end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -305,6 +305,7 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'not show a WIP question on the unsolved Q&A list page' do
     visit_with_auth questions_path, 'kimura'
     assert_no_text 'wipテスト用の質問(wip中)'
+    assert_text '未解決の質問一覧'
   end
 
   test "visit user profile page when clicked on user's name on question" do

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -293,13 +293,18 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_selector '.thread-header-title__label.is-wip', text: 'WIP'
   end
 
-  test 'show a WIP question on the Q&A list page' do
-    visit_with_auth questions_path, 'kimura'
+  test 'show a WIP question on the All Q&A list page' do
+    visit_with_auth questions_path(all: 'true'), 'kimura'
     assert_text 'wipテスト用の質問(wip中)'
     element = all('.thread-list-item').find { |component| component.has_text?('wipテスト用の質問(wip中)') }
     within element do
       assert_selector '.thread-list-item-title__icon.is-wip', text: 'WIP'
     end
+  end
+
+  test 'not show a WIP question on the unsolved Q&A list page' do
+    visit_with_auth questions_path, 'kimura'
+    assert_no_text 'wipテスト用の質問(wip中)'
   end
 
   test "visit user profile page when clicked on user's name on question" do


### PR DESCRIPTION
Issue: [WIPの質問は未解決一覧には含めず、全ての質問一覧にだけ含めるようにしたい。 #4474](https://github.com/fjordllc/bootcamp/issues/4474)

# 概要

以下の質問一覧表示時はWIP状態の質問を表示しないようにした。
- 「未解決の質問一覧」
- 「プラクティス」の個別ページの「質問」「未解決」タブ選択時

# 確認方法

1. 本ブランチをローカルに取り込む。
2. rails s を実行し開発環境を開く。
3. 適当なユーザーでログインし、「OS X Mountain Lionをクリーンインストールする」のプラクティスを選択してWIPの質問を作成する。
5. 左メニューの「Q&A」から未解決の質問一覧を開き、3で作成したWIPの質問が表示されていないことを確認する。
6. 左メニューの「プラクティス」から「OS X Mountain Lionをクリーンインストールする」のプラクティスを開き、「質問」→「未解決」タブを選択して、3で作成したWIPの質問が表示されていないことを確認する。

# 変更前

## 未解決の質問一覧
WIPの質問が表示されています。
<img width="802" alt="スクリーンショット 2022-04-12 13 59 39" src="https://user-images.githubusercontent.com/770527/162884441-df0c73fd-bea1-41d1-aa71-8c3a05d6ab3c.png">

## プラクティスの質問ページ
WIPの質問が表示されています。
<img width="803" alt="スクリーンショット 2022-04-12 13 59 17" src="https://user-images.githubusercontent.com/770527/162884452-4a5ace29-2993-4cf0-9697-dcc234d9e34f.png">

# 変更後

## 未解決の質問一覧
WIPの質問が表示されなくなりました。
<img width="802" alt="スクリーンショット 2022-04-12 14 00 17" src="https://user-images.githubusercontent.com/770527/162884458-a5189101-0026-4fdf-b42d-2b4ca719f538.png">

## プラクティスの質問ページ
WIPの質問が表示されなくなりました。
<img width="805" alt="スクリーンショット 2022-04-12 14 00 26" src="https://user-images.githubusercontent.com/770527/162884455-d3f3f517-872e-4293-b8ff-912c824394a2.png">
