### PR TITLE
ユーザーが退会した時にメンターにも通知が飛ぶようにした

### DIFF
--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -15,6 +15,7 @@ class RetirementController < ApplicationController
       UserMailer.retire(user).deliver_now
       destroy_subscription
       notify_to_admins
+      notify_to_mentors
       logout
       redirect_to retirement_url
     else
@@ -35,6 +36,12 @@ class RetirementController < ApplicationController
   def notify_to_admins
     User.admins.each do |admin_user|
       NotificationFacade.retired(current_user, admin_user)
+    end
+  end
+
+  def notify_to_mentors
+    User.mentor.each do |mentor_user|
+      NotificationFacade.retired(current_user, mentor_user)
     end
   end
 end

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -13,6 +13,7 @@ class RetirementTest < ApplicationSystemTestCase
     assert_equal Date.current, user.reload.retired_on
     assert_equal 'kananashiさんが退会しました。', users(:komagata).notifications.last.message
     assert_equal 'kananashiさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal 'kananashiさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'kananashi', 'testtest'
     assert_text 'ログインができません'
@@ -26,6 +27,7 @@ class RetirementTest < ApplicationSystemTestCase
     assert_equal Date.current, user.reload.retired_on
     assert_equal 'osnashiさんが退会しました。', users(:komagata).notifications.last.message
     assert_equal 'osnashiさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal 'osnashiさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'osnashi', 'testtest'
     assert_text 'ログインができません'
@@ -41,6 +43,7 @@ class RetirementTest < ApplicationSystemTestCase
     assert_equal Date.current, user.reload.retired_on
     assert_equal 'discordinvalidさんが退会しました。', users(:komagata).notifications.last.message
     assert_equal 'discordinvalidさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal 'discordinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'discordinvalid', 'testtest'
     assert_text 'ログインができません'
@@ -56,6 +59,7 @@ class RetirementTest < ApplicationSystemTestCase
     assert_equal Date.current, user.reload.retired_on
     assert_equal 'twitterinvalidさんが退会しました。', users(:komagata).notifications.last.message
     assert_equal 'twitterinvalidさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal 'twitterinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'twitterinvalid', 'testtest'
     assert_text 'ログインができません'


### PR DESCRIPTION
- #4387

## 概要
現在、ユーザーが退会したら、管理者に通知が飛んでいるが、管理者だけでなく、メンターにも通知が飛ぶようにしたい。
ユーザーの退会時に、メンターにも サイト内の通知 と メール通知 が飛ぶように変更した。

## 変更後
- サイト内の通知
<img width="895" alt="image" src="https://user-images.githubusercontent.com/31835314/162974877-cbf2e3de-ccfc-428b-b33a-d4983dc2ac70.png">

- 通知メール
<img width="561" alt="image" src="https://user-images.githubusercontent.com/31835314/162974985-b7511c21-df29-4cb1-b853-22b26fea6037.png">

## 確認方法
- ブランチ `feature/notify-mentor-when-user-retire` をローカルに取り込む
- bin/rails sでサーバーを立ち上げる
- `hajime` でログインし、退会手続きから退会する
- メンター（`mentormentaro` ）でログインして、退会の通知が来ているか確認する
- `http://localhost:3000/letter_opener`を開き、`mentormentaro@fjord.jp`宛に退会のメールが届いているか確認する