### PR TITLE
管理者・メンターはブログを修正・削除できるようにした

### DIFF
--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -26,7 +26,7 @@
         .article__body
           .js-markdown-view.a-long-text.is-md
             = @article.body
-          - if admin_login?
+          - if admin_or_mentor_login?
             .article__actions
               ul
                 li

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -136,7 +136,7 @@ class ArticlesTest < ApplicationSystemTestCase
     find 'nav.pagination'
   end
 
-  test "can't see edit and delete buttons" do
+  test "general user can't see edit and delete buttons" do
     visit_with_auth article_path(@article), 'kimura'
     assert_no_text '内容修正'
     assert_no_text '削除'

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -135,4 +135,22 @@ class ArticlesTest < ApplicationSystemTestCase
     visit_with_auth articles_url, 'komagata'
     find 'nav.pagination'
   end
+
+  test "can't see edit and delete buttons" do
+    visit_with_auth article_path(@article), 'kimura'
+    assert_no_text '内容修正'
+    assert_no_text '削除'
+  end
+
+  test 'admin can see edit and delete buttons' do
+    visit_with_auth article_path(@article), 'komagata'
+    assert_text '内容修正'
+    assert_text '削除'
+  end
+
+  test 'mentor can see edit and delete buttons' do
+    visit_with_auth article_path(@article), 'mentormentaro'
+    assert_text '内容修正'
+    assert_text '削除'
+  end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -153,4 +153,52 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_text '内容修正'
     assert_text '削除'
   end
+
+  test 'admin can edit an article' do
+    visit_with_auth article_path(@article), 'komagata'
+    assert_text @article.title
+    click_on '内容修正'
+
+    fill_in 'article[title]', with: 'edited by mentor'
+    click_on '更新する'
+
+    visit article_path(@article)
+    assert_text 'edited by mentor'
+  end
+
+  test 'mentor can edit an article' do
+    visit_with_auth article_path(@article), 'mentormentaro'
+    assert_text @article.title
+    click_on '内容修正'
+
+    fill_in 'article[title]', with: 'edited by mentor'
+    click_on '更新する'
+
+    visit article_path(@article)
+    assert_text 'edited by mentor'
+  end
+
+  test 'admin can delete an article' do
+    visit_with_auth articles_path, 'komagata'
+    assert_text @article.title
+
+    visit article_path(@article)
+    accept_confirm do
+      click_on '削除'
+    end
+
+    assert_no_text @article.title
+  end
+
+  test 'mentor can delete an article' do
+    visit_with_auth articles_path, 'mentormentaro'
+    assert_text @article.title
+
+    visit article_path(@article)
+    accept_confirm do
+      click_on '削除'
+    end
+
+    assert_no_text @article.title
+  end
 end


### PR DESCRIPTION
## Issue
- #4514

## 概要
管理者・メンターはブログを修正・削除できるようにしました。

管理者のみブログ記事の個別ページに修正・削除ボタンが表示されていましたが、メンターにも表示されるようにしました。

## 変更確認方法
1. ブランチ`feature/allow-administrators-and-mentors-to-modify-and-delete-blogs`をローカルに取り込む
2. `rails server`でローカル環境を立ち上げる
3. メンターでログインし、ブログ記事の個別ページ( `/articles/:id` )にアクセスする
4. 修正・削除ボタンが表示されていることを確認

## 変更前
<img width="1000" alt="2022-04-13-02" src="https://user-images.githubusercontent.com/60736158/162995171-9b9e2d09-c133-4908-b7fc-88b1f9001faf.png">

## 変更後
<img width="1000" alt="2022-04-13-01" src="https://user-images.githubusercontent.com/60736158/162995209-ddde09a1-991f-489b-860a-0bf1411e8a39.png">
