### PR TITLE
Error: undefined method `advisers' for nil:NilClass receivers: product.user.company.advisersの解消

### DIFF
--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -20,7 +20,7 @@ class ProductCallbacks
   def after_save(product)
     unless product.wip
       notify_to_watching_mentor(product)
-      if product.user.trainee?
+      if product.user.trainee? && product.user.company
         send_notification(
           product: product,
           receivers: product.user.company.advisers,
@@ -28,7 +28,7 @@ class ProductCallbacks
         )
       end
       if product.published_at.nil?
-        if product.user.trainee?
+        if product.user.trainee? && product.user.company
           create_watch(
             watchers: product.user.company.advisers,
             watchable: product

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -179,3 +179,7 @@ talk_discordinvalid:
 talk_twitterinvalid:
   user: twitterinvalid
   unreplied: false
+
+talk_nocompanykensyu:
+  user: nocompanykensyu
+  unreplied: false

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1017,4 +1017,3 @@ nocompanykensyu: # 所属企業のない研修生
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
-  training_ends_on: "2022-01-01"

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -994,3 +994,26 @@ twitterinvalid: #Twitter IDが不正なユーザー
   unsubscribe_email_token: JgunX7Zejd-r1Vhqev401w
   updated_at: "2020-01-01 00:00:12"
   created_at: "2020-01-01 00:00:12"
+
+nocompanykensyu: # 所属企業のない研修生
+  login_name: nocompanykensyu
+  email: no-company-kensyu@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 研修　会社無男
+  name_kana: ケンシュウ カイシャナシオ
+  discord_account: no-company-kensyu#9999
+  github_account: no-company-kensyu
+  twitter_account: no-company-kensyu
+  facebook_url: https://www.facebook.com/fjordllc
+  blog_url: http://no-company-kensyu.org
+  description: "所属企業がない研修生です。"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  trainee: true
+  free: true
+  unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
+  updated_at: "2014-01-01 00:00:11"
+  created_at: "2014-01-01 00:00:11"

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -997,16 +997,16 @@ twitterinvalid: #Twitter IDが不正なユーザー
 
 nocompanykensyu: # 所属企業のない研修生
   login_name: nocompanykensyu
-  email: no-company-kensyu@fjord.jp
+  email: nocompanykensyu@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
   name: 研修　会社無男
   name_kana: ケンシュウ カイシャナシオ
-  discord_account: no-company-kensyu#9999
-  github_account: no-company-kensyu
-  twitter_account: no-company-kensyu
+  discord_account: nocompanykensyu#9999
+  github_account: nocompanykensyu
+  twitter_account: nocompanykensyu
   facebook_url: https://www.facebook.com/fjordllc
-  blog_url: http://no-company-kensyu.org
+  blog_url: http://nocompanykensyu.org
   description: "所属企業がない研修生です。"
   course: course1
   job: office_worker
@@ -1017,3 +1017,4 @@ nocompanykensyu: # 所属企業のない研修生
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
+  training_ends_on: "2022-01-01"

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -120,3 +120,7 @@ talk30:
 talk31:
   user: long-id-mentor
   unreplied: false
+
+talk32:
+  user: nocompanykensyu
+  unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -730,3 +730,27 @@ long-id-mentor:
   mentor: true
   updated_at: "2022-04-15 00:00:01"
   created_at: "2022-04-15 00:00:01"
+
+nocompanykensyu: # 所属企業のない研修生
+  login_name: nocompanykensyu
+  email: nocompanykensyu@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 研修　会社無男
+  name_kana: ケンシュウ カイシャナシオ
+  discord_account: nocompanykensyu#9999
+  github_account: nocompanykensyu
+  twitter_account: nocompanykensyu
+  facebook_url: https://www.facebook.com/fjordllc
+  blog_url: http://nocompanykensyu.org
+  description: "所属企業がない研修生です。"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  trainee: true
+  free: true
+  unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
+  updated_at: "2014-01-01 00:00:11"
+  created_at: "2014-01-01 00:00:11"
+  training_ends_on: "2022-01-01"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -753,4 +753,3 @@ nocompanykensyu: # 所属企業のない研修生
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
-  training_ends_on: "2022-01-01"

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -487,8 +487,8 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '7日以上経過：5件'
   end
 
-  test 'no campany trainee create product' do
-    visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'no-company-kensyu'
+  test 'no company trainee create product' do
+    visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'nocompanykensyu'
     within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -486,4 +486,16 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '6日経過：1件'
     assert_text '7日以上経過：5件'
   end
+
+  test 'no campany trainee create product' do
+    visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'no-company-kensyu'
+    within('form[name=product]') do
+      fill_in('product[body]', with: 'test')
+    end
+    click_button '提出する'
+    assert_text '提出日'
+    assert_text Time.zone.now.strftime('%Y年%m月%d日')
+    assert_text "7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\nもし、7日以上経ってもレビューされない場合は、メンターにお問い合わせください。"
+    assert_text 'Watch中'
+  end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -296,11 +296,11 @@ class TalksTest < ApplicationSystemTestCase
     users(:kimuramitai).update!(login_name: 'kensyukimura')
     visit_with_auth '/talks', 'komagata'
     fill_in 'js-talk-search-input', with: 'kensyu'
-    assert_text 'さんの相談部屋', count: 3
+    assert_text 'さんの相談部屋', count: 4
 
     visit '/talks?target=trainee'
     fill_in 'js-talk-search-input', with: 'kensyu'
-    assert_text 'さんの相談部屋', count: 2 # users(:kensyu, :kensyuowata)
+    assert_text 'さんの相談部屋', count: 3 # users(:nocompanykensyu, :kensyu, :kensyuowata)
   end
 
   test 'incremental search for retired' do


### PR DESCRIPTION
- issue #4570  

## 概要
`company`が`nil`になることで発生する
```
NoMethodError: undefined method `advisers' for nil:NilClass receivers: product.user.company.advisers
```
に対し、`trainee`に`company`がある場合のみnotificationを行うよう変更することでerrorを解消しました。

## ローカル環境での確認方法
1. ブランチ `bug/error-with-no-compnany-trainee` をローカルに取り込みます。
1. `nocompanykensyu`ユーザーでログインし、提出物が提出できることを確認します。