### PR TITLE
研修生は企業の選択を必須にした

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -173,6 +173,10 @@ class User < ApplicationRecord
     validates :satisfaction, presence: true
   end
 
+  with_options if: -> { trainee? } do
+    validates :company_id, presence: true
+  end
+
   with_options if: -> { validation_context != :retirement } do
     validates :discord_account,
               format: {

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -25,6 +25,8 @@
       = render 'users/form/experience', f: f
     - if user.student?
       = render 'users/form/job_seeker', f: f
+    - if user.trainee?
+      =render 'users/form/company', f: f
   - if from == :edit
     .form__items
       h3.form__items-title パスワードの変更

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -26,7 +26,7 @@
     - if user.student?
       = render 'users/form/job_seeker', f: f
     - if user.trainee?
-      =render 'users/form/company', f: f
+      = render 'users/form/company', f: f
   - if from == :edit
     .form__items
       h3.form__items-title パスワードの変更

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -66,6 +66,7 @@ ja:
         prefecture_code: お住まいの都道府県
         organization: 現在の所属組織
         company: 企業
+        company_id: 所属企業
         created_at: 開始日
         updated_at: 最終ログイン
         nda: 秘密保持契約

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -509,4 +509,10 @@ class UserTest < ActiveSupport::TestCase
     )
     assert_equal 685_020_562, machida.category_active_or_unstarted_practice.id
   end
+
+  test 'trainee must select company ' do
+    user = users(:kensyu)
+    user.company_id = nil
+    assert user.invalid?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -510,7 +510,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 685_020_562, machida.category_active_or_unstarted_practice.id
   end
 
-  test 'trainee must select company ' do
+  test 'trainee must select company' do
     user = users(:kensyu)
     user.company_id = nil
     assert user.invalid?

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -79,8 +79,7 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test 'create a report without company as trainee' do
-    user = users(:kensyu)
-    user.update!(company: nil)
+    user = users(:nocompanykensyu)
 
     visit_with_auth '/reports/new', 'kensyu'
     within('form[name=report]') do

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -79,9 +79,7 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test 'create a report without company as trainee' do
-    user = users(:nocompanykensyu)
-
-    visit_with_auth '/reports/new', 'kensyu'
+    visit_with_auth '/reports/new', 'nocompanykensyu'
     within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -79,7 +79,7 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test 'create a report without company as trainee' do
-    visit_with_auth '/reports/new', 'nocompanykensyu'
+    visit_with_auth '/reports/new', 'kensyu'
     within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
       fill_in('report[description]', with: 'test')

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -78,23 +78,6 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '日報を保存しました。'
   end
 
-  test 'create a report without company as trainee' do
-    visit_with_auth '/reports/new', 'kensyu'
-    within('form[name=report]') do
-      fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: 'test')
-      fill_in('report[reported_on]', with: Time.current)
-    end
-
-    first('.learning-time').all('.learning-time__started-at select')[0].select('07')
-    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
-    first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
-    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
-
-    click_button '提出'
-    assert_text '日報を保存しました。'
-  end
-
   test 'create and update learning times in a report' do
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -150,6 +150,7 @@ class SignUpTest < ApplicationSystemTestCase
       select '学生', from: 'user[job]'
       select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
+      select 'テスト企業', from: 'user[company_id]', visible: :all
       check 'アンチハラスメントポリシーに同意', allow_label_click: true
       check '利用規約に同意', allow_label_click: true
     end

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -150,7 +150,10 @@ class SignUpTest < ApplicationSystemTestCase
       select '学生', from: 'user[job]'
       select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
-      select 'テスト企業', from: 'user[company_id]', visible: :all
+      first('.choices__inner').click
+      find('.choices__list--dropdown').click
+      find('.choices__list').click
+      find('#choices--js-company-select-item-choice-2').click
       check 'アンチハラスメントポリシーに同意', allow_label_click: true
       check '利用規約に同意', allow_label_click: true
     end
@@ -233,6 +236,10 @@ class SignUpTest < ApplicationSystemTestCase
       select '学生', from: 'user[job]'
       select 'Mac(Intel)', from: 'user[os]'
       select '未経験', from: 'user[experience]'
+      first('.choices__inner').click
+      find('.choices__list--dropdown').click
+      find('.choices__list').click
+      find('#choices--js-company-select-item-choice-2').click
       check 'アンチハラスメントポリシーに同意', allow_label_click: true
       check '利用規約に同意', allow_label_click: true
     end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -123,6 +123,7 @@ class UsersTest < ApplicationSystemTestCase
       enchohayashi
       enchoososhi
       enchoowata
+      nocompanykensyu
     ].each do |name|
       users(name).touch # rubocop:disable Rails/SkipsModelValidations
     end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -123,7 +123,6 @@ class UsersTest < ApplicationSystemTestCase
       enchohayashi
       enchoososhi
       enchoowata
-      nocompanykensyu
     ].each do |name|
       users(name).touch # rubocop:disable Rails/SkipsModelValidations
     end


### PR DESCRIPTION
- issue #4573   

## 概要
ユーザー編集画面で研修生にチェックが入っているのに、企業名が未設定の状態で`登録する` `更新する`をクリックした場合、下記エラーメッセージが出て登録完了できないように変更しました。
![_development__ユーザー登録情報変更___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64455939/163132650-7e57e4a0-b1a5-42c4-a198-a544106e8e4e.png)

また、研修生の登録欄に「所属企業」選択欄がなかったので、`app/views/users/_form.html.slim`を研修生の場合これを表示させるように修正し、`test/system/sign_up_test.rb`の2つのテストが通るように修正しています。

さらに、当バリデーション設定のため`app/views/users/_form.html.slim`の中の不要な1テストを削除しています。

## ローカル環境での確認方法
1. ブランチ `feature/company-of-trainee-requirement` をローカルに取り込みます。
1. `http://localhost:3000/users/new?role=trainee`にアクセスします。
1. 企業名を未設定で登録すると、エラーメッセージが出ることを確認します。