### PR TITLE
リンクという文言をアドバイザー招待に変更

### DIFF
--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -13,7 +13,7 @@
           th.admin-table__label
             | ウェブサイト
           th.admin-table__label.actions
-            | リンク
+            | アドバイザー招待
           th.admin-table__label.actions
             | 操作
       tbody.admin-table__items


### PR DESCRIPTION
issue #4533 
アドバイザー招待リンクのth`リンク`という文言を`アドバイザー招待`という文言に変更しました。
- 変更前

![image](https://user-images.githubusercontent.com/64620506/163291976-0dd114dd-1eab-4f71-b965-d4792f966a02.png)

- 変更後

![_development__管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/163293375-53137a12-70f4-47b4-bd43-92557df6666e.png)

