### PR TITLE
プラクティス共通の説明のDocがWIPの場合は、詳細画面に表示しないように修正

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -11,6 +11,7 @@ class PracticesController < ApplicationController
     @categories = @practice.categories
     @tweet_url = @practice.tweet_url(practice_completion_url(@practice.id))
     @common_page = Page.find_by(slug: 'practice_common_description')
+    @common_page = nil if @common_page&.wip?
   end
 
   def new

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -265,4 +265,18 @@ class PracticesTest < ApplicationSystemTestCase
     visit "/practices/#{practices(:practice2).id}"
     assert_text '困った時は'
   end
+
+  test 'not show common description block when practice_common_description is wip' do
+    pages(:page10).update!(wip: true) # practice_common_description
+    visit_with_auth "/practices/#{practices(:practice1).id}", 'hajime'
+    assert_selector '.page-header__title', text: 'OS X Mountain Lionをクリーンインストールする'
+    assert_no_selector '.common-page-body', text: '困った時は'
+  end
+
+  test 'not show common description block when practice_common_description does not exist' do
+    pages(:page10).delete # practice_common_description
+    visit_with_auth "/practices/#{practices(:practice1).id}", 'hajime'
+    assert_selector '.page-header__title', text: 'OS X Mountain Lionをクリーンインストールする'
+    assert_no_selector '.common-page-body', text: '困った時は'
+  end
 end


### PR DESCRIPTION
## 概要
関連 Issue & Pull Request
- #3995 
- #4382 

`practice_common_description` の slug を持つ Doc が WIP の場合にも、Doc の内容がプラクティス詳細に表示されてしまっていたので、WIP の場合は表示しないように修正しました。 
