### PR TITLE
研修生の場合、研修終了日をプロフィールページに表示するよう実装

### DIFF
--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -73,7 +73,7 @@
         .user-metas__item-label
           = User.human_attribute_name :training_ends_on
         .user-metas__item-value
-          = user.training_ends_on
+          = l user.training_ends_on.to_date
     - if user.graduated_on.present?
       .user-metas__item
         .user-metas__item-label

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -68,6 +68,12 @@
           - user.roles.each do |role|
             li
               = t "target.#{role}"
+    - if user.trainee?
+      .user-metas__item
+        .user-metas__item-label
+          = User.human_attribute_name :training_ends_on
+        .user-metas__item-value
+          = user.training_ends_on
     - if user.graduated_on.present?
       .user-metas__item
         .user-metas__item-label


### PR DESCRIPTION
issue #4532 

研修生のプロフィールページに研修終了日を表示させました。
- 変更前

![_development__kensyu___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/163508661-563c1ac6-723c-4fba-a863-7140c7ae3eb5.png)

- 変更後
    【研修生のプロフィールページ】
<details><summary>1回目のPR時のスクリーンショット(ミーティング時に町田さんよりご指摘を受けまして、表示形式が修正前のものです)</summary><div>

![_development__kensyu___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）_と_Comparing_main___feature_display-training-end-date-for-trainee_·_fjordllc_bootcamp](https://user-images.githubusercontent.com/64620506/163507534-df19aae1-fbd5-4c00-8c44-037841579467.png)

</div></details>


- 確認手順
1. ブランチ`feature/display-training-end-date-for-trainee`をローカルに取り込みます。

2. ユーザー`kensyu`でログイン
![_development__FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/164361323-4a34e699-b043-451f-aaf4-3112da56bcb3.png)

3. `マイプロフィール`をクリック
![_development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/164361421-a15f1d1b-63b7-4e10-bfa3-5c3d77c78de7.png)

4. 研修終了日が追加されていることを確認
![_development__kensyu___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/164361515-93269ef7-dec0-4204-a092-a0b0cb9835df.png)

- そのほかのロールのユーザープロフィールページ
    【現役生のプロフィールページ】

![_development__hatsuno___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/163508195-61ab2fc4-0578-48ac-b98c-f06a4e3bfceb.png)

    【卒業生のプロフィールページ】

![_development__sotugyou-with-job___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/163508261-18fa0e4f-fa1f-4df5-8143-981e63f26ab9.png)

    【管理者・メンターのプロフィールページ】

![_development__komagata___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/163508372-cf97c767-9e3b-4ffa-85f9-263ffb682668.png)
