### PR TITLE
開発用テストデータの作成：長いIDのユーザーのメンターID

### DIFF
--- a/test/fixtures/checks.yml
+++ b/test/fixtures/checks.yml
@@ -45,3 +45,7 @@ procuct7_check_komagata:
 procuct9_check_komagata:
   user: komagata
   checkable: product9 (Product)
+
+procuct67_check_long-id-mentor:
+  user: long-id-mentor
+  checkable: product67 (Product)

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -122,6 +122,16 @@ comment<%= i + 19 %>:
   updated_at: <%= Time.current + i.minute %>
 <% end %>
 
+comment21:
+  user: long-id-mentor
+  commentable: product67 (Product)
+  description: "長い名前のメンターのコメント"
+
+comment22:
+  user: long-id-mentor
+  commentable: report1 (Report)
+  description: "長い名前のメンターのコメント"
+
 commentOfTalk:
   user: komagata
   commentable: talk1 (Talk)

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -123,8 +123,8 @@ comment41:
   commentable: report71 (Report)
   description: "長い名前のメンター"
 
-<% 20.upto(39) do |i| %>
-comment<%= i %>:
+<% (1..20).each do |i| %>
+comment<%= i + 19 %>:
   user: komagata
   commentable: product11 (Product)
   description: <%= "提出物のコメント#{i}です。" %>

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -129,7 +129,7 @@ comment21:
 
 comment22:
   user: long-id-mentor
-  commentable: report1 (Report)
+  commentable: report71 (Report)
   description: "長い名前のメンターのコメント"
 
 commentOfTalk:

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -123,7 +123,7 @@ comment<%= i + 19 %>:
 <% end %>
 
 comment21:
-  user: long-id-mentor
+  user: longidmentor
   commentable: product67 (Product)
   description: "長い名前のメンターのコメント"
 

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -116,15 +116,15 @@ comment19:
 comment40:
   user: long-id-mentor
   commentable: product67 (Product)
-  description: "長い名前のメンターのコメント"
+  description: "長い名前のメンター"
 
 comment41:
   user: long-id-mentor
   commentable: report71 (Report)
-  description: "長い名前のメンターのコメント"
+  description: "長い名前のメンター"
 
-<% (1..20).each do |i| %>
-comment<%= i + 19 %>:
+<% 20.upto(39) do |i| %>
+comment<%= i %>:
   user: komagata
   commentable: product11 (Product)
   description: <%= "提出物のコメント#{i}です。" %>

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -113,12 +113,12 @@ comment19:
   commentable: report7 (Report)
   description: "@kimura 2つ目のメンションありの未読通知を発生させる"
 
-comment21:
+comment40:
   user: long-id-mentor
   commentable: product67 (Product)
   description: "長い名前のメンターのコメント"
 
-comment22:
+comment41:
   user: long-id-mentor
   commentable: report71 (Report)
   description: "長い名前のメンターのコメント"

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -113,6 +113,16 @@ comment19:
   commentable: report7 (Report)
   description: "@kimura 2つ目のメンションありの未読通知を発生させる"
 
+comment21:
+  user: long-id-mentor
+  commentable: product67 (Product)
+  description: "長い名前のメンターのコメント"
+
+comment22:
+  user: long-id-mentor
+  commentable: report71 (Report)
+  description: "長い名前のメンターのコメント"
+
 <% (1..20).each do |i| %>
 comment<%= i + 19 %>:
   user: komagata
@@ -121,16 +131,6 @@ comment<%= i + 19 %>:
   created_at: <%= Time.current + i.minute %>
   updated_at: <%= Time.current + i.minute %>
 <% end %>
-
-comment21:
-  user: longidmentor
-  commentable: product67 (Product)
-  description: "長い名前のメンターのコメント"
-
-comment22:
-  user: long-id-mentor
-  commentable: report71 (Report)
-  description: "長い名前のメンターのコメント"
 
 commentOfTalk:
   user: komagata

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -95,3 +95,9 @@ page10:
   slug: practice_common_description
   user: komagata
   published_at: "2022-03-10 00:00:00"
+
+page11:
+  title: 長いメンターIDのDOC
+  body: test
+  user: long-id-mentor
+  published_at: "2022-04-15 00:00:00"

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -393,7 +393,13 @@ product66:
   published_at: nil
 
 product67:
-  practice: practice54
+  practice: practice1
   user: kimuramitai
-  body: テストの提出物67です。
+  body: テストの確認済みの提出物67です。
+  checker_id: "<%= ActiveRecord::FixtureSet.identify(:'long-id-mentor') %>"
+
+product68:
+  practice: practice1
+  user: kimuramitai
+  body: テストの未確認だけど、担当になっている提出物68です。
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:'long-id-mentor') %>"

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -393,7 +393,7 @@ product66:
   published_at: nil
 
 product67:
-  practice: practice45
+  practice: practice2
   user: with_hyphen
   body: テストの提出物67です。
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:long-id-mentor) %>"

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -393,10 +393,7 @@ product66:
   published_at: nil
 
 product67:
-  practice: practice11
-  user: kimura
-  body: 長い名前のメンターIDのテスト用です。
-  created_at: <%= 1.day.ago %>
-  updated_at: <%= 1.day.ago %>
-  published_at: <%= 1.day.ago %>
-  checker_id: "<%= ActiveRecord::FixtureSet.identify(:komagata) %>"
+  practice: practice45
+  user: with_hyphen
+  body: テストの提出物67です。
+  checker_id: "<%= ActiveRecord::FixtureSet.identify(:long-id-mentor) %>"

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -391,3 +391,12 @@ product66:
   user: daimyo
   body: publish_atがnilの提出物です。
   published_at: nil
+
+product67:
+  practice: practice11
+  user: kimura
+  body: 長い名前のメンターIDのテスト用です。
+  created_at: <%= 1.day.ago %>
+  updated_at: <%= 1.day.ago %>
+  published_at: <%= 1.day.ago %>
+  checker_id: "<%= ActiveRecord::FixtureSet.identify(:komagata) %>"

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -393,7 +393,7 @@ product66:
   published_at: nil
 
 product67:
-  practice: practice2
-  user: with_hyphen
+  practice: practice54
+  user: kimuramitai
   body: テストの提出物67です。
-  checker_id: "<%= ActiveRecord::FixtureSet.identify(:long-id-mentor) %>"
+  checker_id: "<%= ActiveRecord::FixtureSet.identify(:'long-id-mentor') %>"

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -393,13 +393,13 @@ product66:
   published_at: nil
 
 product67:
-  practice: practice1
+  practice: practice16
   user: kimuramitai
   body: テストの確認済みの提出物67です。
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:'long-id-mentor') %>"
 
 product68:
-  practice: practice1
+  practice: practice17
   user: kimuramitai
-  body: テストの未確認だけど、担当になっている提出物68です。
+  body: 未確認だけど、担当になっている提出物68です。
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:'long-id-mentor') %>"

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -393,13 +393,13 @@ product66:
   published_at: nil
 
 product67:
-  practice: practice16
+  practice: practice3
   user: kimuramitai
-  body: テストの確認済みの提出物67です。
+  body: 確認済みの提出物67です。
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:'long-id-mentor') %>"
 
 product68:
-  practice: practice17
+  practice: practice5
   user: kimuramitai
   body: 未確認だけど、担当になっている提出物68です。
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:'long-id-mentor') %>"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -292,3 +292,11 @@ report<%= i %>:
     頑張れませんでした
   reported_on: <%= Time.now - 1.year + i.day %>
 <% end %>
+
+report71:
+  user: hajime
+  title: "名前の長いメンター用"
+  description:
+    "名前の長いメンター用"
+  reported_on: "2022-04-16"
+  created_at: "2017-04-16 00:00:00"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -283,6 +283,14 @@ report34:
   reported_on: <%= Time.current - 11.day %>
   created_at: <%= Time.current - 11.day %>
 
+report71:
+  user: kimuramitai
+  title: "名前の長いメンター用"
+  description:
+    "名前の長いメンター用"
+  reported_on: "2022-04-16"
+  created_at: "2017-04-16 00:00:00"
+
 <% 35.upto(70) do |i| %>
 report<%= i %>:
   user: with_hyphen
@@ -292,11 +300,3 @@ report<%= i %>:
     頑張れませんでした
   reported_on: <%= Time.now - 1.year + i.day %>
 <% end %>
-
-report71:
-  user: kimuramitai
-  title: "名前の長いメンター用"
-  description:
-    "名前の長いメンター用"
-  reported_on: "2022-04-16"
-  created_at: "2017-04-16 00:00:00"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -294,7 +294,7 @@ report<%= i %>:
 <% end %>
 
 report71:
-  user: hajime
+  user: kimuramitai
   title: "名前の長いメンター用"
   description:
     "名前の長いメンター用"

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -116,3 +116,7 @@ talk29:
 talk30:
   user: kimuramitai
   unreplied: false
+
+talk31:
+  user: long-id-mentor
+  unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -728,6 +728,5 @@ long-id-mentor:
   prefecture_code: 13
   organization: メンター大学
   mentor: true
-  unsubscribe_email_token: k6Da-oL3cRi8ApNFO9-Gcg
   updated_at: "2022-04-15 00:00:01"
   created_at: "2022-04-15 00:00:01"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -709,3 +709,25 @@ kimuramitai:
   unsubscribe_email_token: k6Da-oL3cRi8ApNFO9-Gcg
   updated_at: "2022-03-28 00:00:01"
   created_at: "2022-03-28 00:00:01"
+
+long-id-mentor:
+  login_name: long-id-mentor
+  email: long-id-mentor@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 戸手毛長巣義留 名前之助左衛門
+  name_kana: トテモナガスギル メイゼンノスケザエモン
+  twitter_account: long-id-mentor
+  facebook_url: https://www.facebook.com/fjordllc
+  blog_url: http://long-id-mentor.com
+  description: "名前がとても長いので頑張って覚えてください。"
+  course: course1
+  job: office_worker
+  os: mac
+  experience: inexperienced
+  prefecture_code: 13
+  organization: メンター大学
+  mentor: true
+  unsubscribe_email_token: k6Da-oL3cRi8ApNFO9-Gcg
+  updated_at: "2022-04-15 00:00:01"
+  created_at: "2022-04-15 00:00:01"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -715,8 +715,8 @@ long-id-mentor:
   email: long-id-mentor@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
-  name: 戸手毛長巣義留 名前之助左衛門
-  name_kana: トテモナガスギル メイゼンノスケザエモン
+  name: 戸手藻長巣義留 名前之面多
+  name_kana: トテモナガスギル ナマエノメンタ
   twitter_account: long-id-mentor
   facebook_url: https://www.facebook.com/fjordllc
   blog_url: http://long-id-mentor.com

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -257,11 +257,11 @@ class TalksTest < ApplicationSystemTestCase
     users(:kimuramitai).update!(login_name: 'mentorkimura')
     visit_with_auth '/talks', 'komagata'
     fill_in 'js-talk-search-input', with: 'mentor'
-    assert_text 'さんの相談部屋', count: 2
+    assert_text 'さんの相談部屋', count: 3
 
     visit '/talks?target=mentor'
     fill_in 'js-talk-search-input', with: 'mentor'
-    assert_text 'さんの相談部屋', count: 1 # users(:mentormentaro)
+    assert_text 'さんの相談部屋', count: 2 # users(:mentormentaro) users(:'long-id-mentor')
   end
 
   test 'incremental search for graduated' do


### PR DESCRIPTION
issue #4370 
開発用用テストデータとして、長いID・名前のメンターを作成しました。

issueのコメントにある通り、以下のテストデータを作成しました。
ファイルの構成がわかっていない部分があり、テストデータのファイルが間違っていたらご指摘ください🙇‍♂️

- 長いID・名前のメンター
    - test/fixtures/users.yml
    - test/fixtures/talks.yml

- 担当アサインしている提出物
    - test/fixtures/products.yml

- 確認した提出物(OKにした提出物)
    - test/fixtures/checks.yml

- 日報と提出物にコメント投稿したデータ
    - test/fixtures/comments.yml

- このメンターが作ったDoc
    - test/fixtures/pages.yml