### PR TITLE
Markdownのエディタでdetailsを簡単に書けるようにした

### DIFF
--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -9,6 +9,7 @@ import UserIconRenderer from './user-icon-renderer'
 import MarkdownItTaskListsInitializer from './markdown-it-task-lists-initializer'
 import MarkdownItHeadings from './markdown-it-headings'
 import MarkDownItContainerMessage from './markdown-it-container-message'
+import MarkDownItContainerDetails from './markdown-it-container-details'
 
 export default class {
   replace(selector) {
@@ -35,6 +36,7 @@ export default class {
     md.use(MarkdownItTaskLists)
     md.use(MarkdownItHeadings)
     md.use(MarkDownItContainerMessage)
+    md.use(MarkDownItContainerDetails)
 
     return md.render(text)
   }

--- a/app/javascript/markdown-it-container-details.js
+++ b/app/javascript/markdown-it-container-details.js
@@ -1,19 +1,17 @@
 import MarkdownItContainer from 'markdown-it-container'
 
 export default (md) => {
-    md.use(MarkdownItContainer, 'details', {
-        render: (tokens, idx) => {
-            const detailsInfo = tokens[idx].info
-                .trim()
-                .match(/^details\s+(.*)$/)
-            // const  detailsTitle = detailsInfo ? `${detailsInfo[1]}` : ''
-            if (tokens[idx].nesting === 1) {
-                // opening tag
-                return '<details><summary>' + `${detailsInfo[1]}` + '</summary>\n'
-            } else {
-                // closing tag
-                return '</details>\n'
-            }
-        }
-    })
+  md.use(MarkdownItContainer, 'details', {
+    render: (tokens, idx) => {
+      const detailsInfo = tokens[idx].info.trim().match(/^details\s+(.*)$/)
+      // const  detailsTitle = detailsInfo ? `${detailsInfo[1]}` : ''
+      if (tokens[idx].nesting === 1) {
+        // opening tag
+        return '<details><summary>' + `${detailsInfo[1]}` + '</summary>\n'
+      } else {
+        // closing tag
+        return '</details>\n'
+      }
+    }
+  })
 }

--- a/app/javascript/markdown-it-container-details.js
+++ b/app/javascript/markdown-it-container-details.js
@@ -4,10 +4,10 @@ export default (md) => {
   md.use(MarkdownItContainer, 'details', {
     render: (tokens, idx) => {
       const detailsInfo = tokens[idx].info.trim().match(/^details\s+(.*)$/)
-      // const  detailsTitle = detailsInfo ? `${detailsInfo[1]}` : ''
+      const  detailsTitle = detailsInfo ? `${detailsInfo[1]}` : ''
       if (tokens[idx].nesting === 1) {
         // opening tag
-        return '<details><summary>' + `${detailsInfo[1]}` + '</summary>\n'
+        return '<details><summary>' + detailsTitle + '</summary>\n'
       } else {
         // closing tag
         return '</details>\n'

--- a/app/javascript/markdown-it-container-details.js
+++ b/app/javascript/markdown-it-container-details.js
@@ -4,7 +4,7 @@ export default (md) => {
   md.use(MarkdownItContainer, 'details', {
     render: (tokens, idx) => {
       const detailsInfo = tokens[idx].info.trim().match(/^details\s+(.*)$/)
-      const  detailsTitle = detailsInfo ? `${detailsInfo[1]}` : ''
+      const detailsTitle = detailsInfo ? `${detailsInfo[1]}` : ''
       if (tokens[idx].nesting === 1) {
         // opening tag
         return '<details><summary>' + escapeHTML(detailsTitle) + '</summary>\n'
@@ -16,10 +16,11 @@ export default (md) => {
   })
 }
 
-function escapeHTML(string){
-  return string.replace(/&/g, '&lt;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, "&#x27;");
+function escapeHTML(string) {
+  return string
+    .replace(/&/g, '&lt;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
 }

--- a/app/javascript/markdown-it-container-details.js
+++ b/app/javascript/markdown-it-container-details.js
@@ -1,0 +1,19 @@
+import MarkdownItContainer from 'markdown-it-container'
+
+export default (md) => {
+    md.use(MarkdownItContainer, 'details', {
+        render: (tokens, idx) => {
+            const detailsInfo = tokens[idx].info
+                .trim()
+                .match(/^details\s+(.*)$/)
+            // const  detailsTitle = detailsInfo ? `${detailsInfo[1]}` : ''
+            if (tokens[idx].nesting === 1) {
+                // opening tag
+                return '<details><summary>' + `${detailsInfo[1]}` + '</summary>\n'
+            } else {
+                // closing tag
+                return '</details>\n'
+            }
+        }
+    })
+}

--- a/app/javascript/markdown-it-container-details.js
+++ b/app/javascript/markdown-it-container-details.js
@@ -7,11 +7,19 @@ export default (md) => {
       const  detailsTitle = detailsInfo ? `${detailsInfo[1]}` : ''
       if (tokens[idx].nesting === 1) {
         // opening tag
-        return '<details><summary>' + detailsTitle + '</summary>\n'
+        return '<details><summary>' + escapeHTML(detailsTitle) + '</summary>\n'
       } else {
         // closing tag
         return '</details>\n'
       }
     }
   })
+}
+
+function escapeHTML(string){
+  return string.replace(/&/g, '&lt;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, "&#x27;");
 }

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -10,6 +10,7 @@ import MarkdownOption from './markdown-it-option'
 import UserIconRenderer from './user-icon-renderer'
 import autosize from 'autosize'
 import MarkDownItContainerMessage from './markdown-it-container-message'
+import MarkDownItContainerDetails from './markdown-it-container-details'
 
 export default class {
   static initialize(selector) {
@@ -70,7 +71,8 @@ export default class {
           MarkdownItMention,
           MarkdownItUserIcon,
           MarkdownItTaskLists,
-          MarkDownItContainerMessage
+          MarkDownItContainerMessage,
+          MarkDownItContainerDetails
         ],
         markdownOptions: MarkdownOption
       })


### PR DESCRIPTION
issue #4462 


https://user-images.githubusercontent.com/64455939/164006025-c7ef1f88-63e2-4e1b-8c3b-7a5f87d22be3.mp4


## 概要

```md
:::details ネタバレ注意！
## 私の書いたコード

今回はこんなコードを書きました。
:::
```
と記載すると、

```html
<details>
    <summary>ネタバレ注意！</summary>
    <h2>私の書いたコード</h2>
    <p>今回はこんなコードを書きました。</p>
</details>
```

と、`details`の右に半角スペースで記載した文字列が`<summary>`タグで囲われ、
下に書いた`:::`までの文字列が`</details>`タグに囲われるHTMLが出力されるようになります。

## ローカル環境での確認方法
1. ブランチ `feature/markdown-details-easier` をローカルに取り込みます。
1. 何らかのユーザーでログインし、日報、コメント等テキストを記載する際に上記`:::details`を利用して記載して、マークダウンが適用されるか確認していただけると幸いです。また、XSS対策も施したので、試していただけるとありがたいです。

### 参考にしたissue,PR
- [Markdownの中で独自記法でメッセージブロックを書けるようにした(クラス名message)](https://github.com/fjordllc/bootcamp/pull/4424)
- [[Markdown]メッセージブロック機能でXSSの危険性](https://github.com/fjordllc/bootcamp/issues/4491)
