### PR TITLE
system/questions_test.rbのテストを修正

### DIFF
--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -252,7 +252,7 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     assert_text '質問をWIPとして保存しました。'
 
-    visit_with_auth questions_path, 'komagata'
+    visit_with_auth questions_path(all: 'true'), 'komagata'
     click_link 'WIPタイトル'
     assert_text '削除する'
     assert_no_text 'Watch中'
@@ -267,7 +267,7 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     assert_text '質問をWIPとして保存しました。'
 
-    visit questions_path
+    visit questions_path(all: 'true')
     click_link 'WIPタイトル'
     assert_text '削除する'
     click_button '内容修正'


### PR DESCRIPTION
## Issue
- #4634 
 
## 概要
Q&Aページ内で、WIP中の質問の表示を「未解決」タブから「全ての質問」タブに変更したことによって既存のテストが通らなくなったため、修正を行いました。

## 関連
Refs: #4474 

## 修正の内容
- WIP中の質問の表示場所がQ&Aページ内の「未解決」タブから「全ての質問」タブに変更になったため、テスト内のWIP中の質問にアクセス(visit)する場所を`questions_path`から`questions_path(all: 'true')`に変更しました。


## 修正後
- system/questions_test.rbのテストが全て通るようになりました。