### PR TITLE
「新規質問作成フォームのプラクティス選択」と「日報一覧のプラクティスで絞り込む」をChoices.jsに置き換える。

### DIFF
--- a/app/javascript/choices-ui.js
+++ b/app/javascript/choices-ui.js
@@ -1,7 +1,7 @@
 import Choices from 'choices.js'
 
 document.addEventListener('DOMContentLoaded', () => {
-  const element = document.getElementById('js-company-select')
+  const element = document.getElementById('js-choices-single-select')
   if (element) {
     return new Choices(element, {
       removeItemButton: true,

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -8,7 +8,7 @@
             .form-item
               = f.label :practice, class: 'a-form-label'
               .select-practices
-                = f.select(:practice_id, practice_options(categories), { selected: params[:practice_id] }, { class: 'js-select2' })
+                = f.select(:practice_id, practice_options(categories), { selected: params[:practice_id] }, { id: 'js-company-select' })
 
       .form-item
         .row.js-markdown-parent

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -8,7 +8,7 @@
             .form-item
               = f.label :practice, class: 'a-form-label'
               .select-practices
-                = f.select(:practice_id, practice_options(categories), { selected: params[:practice_id] }, { id: 'js-company-select' })
+                = f.select(:practice_id, practice_options(categories), { selected: params[:practice_id] }, { id: 'js-choices-single-select' })
 
       .form-item
         .row.js-markdown-parent

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -13,7 +13,7 @@ nav.sort-nav
       .sort-nav__inner
         = label_tag :practice_id, 'プラクティスで絞り込む', class: 'sort-nav__label'
         .sort-nav__select
-          = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', class: 'js-select2'
+          = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-company-select'
 
 - if current_user.admin?
   = render 'reports/tabs'

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -13,7 +13,7 @@ nav.sort-nav
       .sort-nav__inner
         = label_tag :practice_id, 'プラクティスで絞り込む', class: 'sort-nav__label'
         .sort-nav__select
-          = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-company-select'
+          = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
 
 - if current_user.admin?
   = render 'reports/tabs'

--- a/app/views/users/form/_company.html.slim
+++ b/app/views/users/form/_company.html.slim
@@ -1,7 +1,7 @@
 .form-item
   = f.label :company, class: 'a-form-label'
   .is-md.is-secondary.is-select.is-block
-    = f.collection_select :company_id, all_companies_with_empty, :id, :name, {}, { id: 'js-company-select' }
+    = f.collection_select :company_id, all_companies_with_empty, :id, :name, {}, { id: 'js-choices-single-select' }
   .a-form-help
     p
       | 企業で利用しているアドバイザー、研修生は登録。

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -69,8 +69,6 @@ class QuestionsTest < ApplicationSystemTestCase
       fill_in 'question[title]', with: '質問者のコースにはないプラクティスの質問を編集できるかのテスト'
       fill_in 'question[description]', with: '編集できれば期待通りの動作'
       first('.choices__inner').click
-      find('.choices__list--dropdown').click
-      find('.choices__list').click
       find('#choices--js-choices-single-select-item-choice-52', text: 'iOSへのビルドと固有の問題').click
       click_button '登録する'
     end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -68,7 +68,10 @@ class QuestionsTest < ApplicationSystemTestCase
     within 'form[name=question]' do
       fill_in 'question[title]', with: '質問者のコースにはないプラクティスの質問を編集できるかのテスト'
       fill_in 'question[description]', with: '編集できれば期待通りの動作'
-      select 'iOSへのビルドと固有の問題', from: 'question[practice_id]'
+      first('.choices__inner').click
+      find('.choices__list--dropdown').click
+      find('.choices__list').click
+      find('#choices--js-choices-single-select-item-choice-52', text: 'iOSへのビルドと固有の問題').click
       click_button '登録する'
     end
     assert_text '質問を作成しました。'

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -533,9 +533,10 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'select box shows the practices that belong to a user course' do
     visit_with_auth reports_path, 'kimura'
-    find('#select2-practice_id-container').click
-    selects_size = users(:kimura).course.practices.size + 1
-    assert_selector '.select2-results__option', count: selects_size
+    find('.choices__inner').click
+    page_practices = page.all('.choices__item--choice').map(&:text).size
+    course_practices = users(:kimura).course.practices.size + 1
+    assert_equal page_practices, course_practices
   end
 
   test 'show number of comments' do


### PR DESCRIPTION
### Issue
- #4582
- #4584

### 概要
- 「新規質問作成フォームのプラクティス選択」と「日報一覧のプラクティスで絞り込む」の機能で使用しているライブラリを`select2`から`choices.js`に変更しました。
- 元々、「ユーザー編集の企業選択」の機能のみに`choices.js`を利用していたので、ファイルは`company-select.js`、select タグのid を`js-company-select`としていたが、今回新たに「新規質問作成フォームのプラクティス選択」と「日報一覧のプラクティスで絞り込む」の機能にも`choices.js`を使用するので、各機能で利用できるように、ファイル名は`choices-ui.js`、id名は`js-choices-single-select`に変更しました。
https://github.com/fjordllc/bootcamp/issues/4582#issuecomment-1099329700

### 変更確認方法
1. ブランチ `feature/replace-practice-selection-in-create-new-question-form-and-narrow-by-practice-in-daily-report-list-with-choice-js`をローカルに取り込み、ローカル環境を立ち上げる
1. ログイン(日報一覧はメンター/管理者だと表示が異なるので、**kimura** でログインしました)
1. コンソールを開いて以下の手順で「新規質問作成フォームのプラクティス選択」と「日報一覧のプラクティスで絞り込む」がchoices.jsに変更されたことを確認。

### 「新規質問作成フォームのプラクティス選択」
1. 左サイドバーの **Q&A** を選択
1. 右上の **質問する** を選択
1.  **プラクティス** を選択及び検索

### 変更前
![image](https://user-images.githubusercontent.com/64824195/164451599-92f35729-1d09-4190-9169-8200e78fb637.png)

### 変更後
![image](https://user-images.githubusercontent.com/64824195/164452475-d15343d3-711c-4504-b88b-9160f0758d7f.png)

### 「日報一覧のプラクティスで絞り込む」
1. 左サイドバーの **日報** を選択
1. **プラクティス** で絞り込むから選択及び検索

### 変更前
![image](https://user-images.githubusercontent.com/64824195/164451494-95835186-5594-43d6-8365-384cc42c9217.png)

### 変更後
![image](https://user-images.githubusercontent.com/64824195/164453251-18f3b2a3-bdf6-4a28-849a-4333865f45e8.png)
