### PR TITLE
カテゴリー並び替えで空のスラッグの行を削除した

### DIFF
--- a/app/javascript/courses-categories.vue
+++ b/app/javascript/courses-categories.vue
@@ -5,8 +5,6 @@
       tr.admin-table__labels
         th.admin-table__label
           | 名前
-        th.admin-table__label
-          | URLスラッグ
         th.admin-table__label.handle
           | 並び順
     draggable.admin-table__items(
@@ -22,8 +20,6 @@
       )
         td.admin-table__item-value
           | {{ coursesCategory.category.name }}
-        td.admin-table__item-value
-          | {{ coursesCategory.slug }}
         td.admin-table__item-value.is-text-align-center.is-grab
           span.js-grab.a-grab
             i.fa-solid.fa-align-justify


### PR DESCRIPTION
- #4563

## 概要
カテゴリーの並び替えでスラッグの行が空なので削除した。

## 修正前
![image](https://user-images.githubusercontent.com/31835314/163750857-a7da9692-7cd7-47e7-93cd-643c1c87991f.png)

## 修正後
![image](https://user-images.githubusercontent.com/31835314/163750790-c08b9e60-871b-43d0-b4ca-c83d26202ebd.png)

## 確認手順
- ブランチ `bug/delete-slug-from-category` をローカルに取り込む
- `bin/rails s`でサーバーを立ち上げる
- 管理者ロール（`komagata`） でログインし、管理ページ > コース の操作の行から並び替えボタンをクリック
- カテゴリ並び替えにてスラッグの行が出ていないいことを確認