### PR TITLE
categories.positionを削除した

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -4,7 +4,7 @@ class Admin::CategoriesController < AdminController
   before_action :set_category, only: %i[edit update destroy]
 
   def index
-    @categories = Category.order('position')
+    @categories = Category.all
   end
 
   def new

--- a/app/controllers/api/courses/practices_controller.rb
+++ b/app/controllers/api/courses/practices_controller.rb
@@ -9,7 +9,7 @@ class API::Courses::PracticesController < API::BaseController
                   .joins(:courses_categories)
                   .where(courses_categories: { course_id: @course_id })
                   .includes(practices: [{ started_students: { avatar_attachment: :blob } }, :learning_minute_statistic])
-                  .order('courses_categories.position ASC')
+                  .order('courses_categories.position')
     @learnings = current_user.learnings
     @completed_practices_size_by_category = current_user.completed_practices_size_by_category
   end

--- a/app/controllers/api/courses/practices_controller.rb
+++ b/app/controllers/api/courses/practices_controller.rb
@@ -9,7 +9,7 @@ class API::Courses::PracticesController < API::BaseController
                   .joins(:courses_categories)
                   .where(courses_categories: { course_id: @course_id })
                   .includes(practices: [{ started_students: { avatar_attachment: :blob } }, :learning_minute_statistic])
-                  .order('courses_categories.position ASC, categories.position ASC')
+                  .order('courses_categories.position ASC')
     @learnings = current_user.learnings
     @completed_practices_size_by_category = current_user.completed_practices_size_by_category
   end

--- a/app/controllers/api/practices_controller.rb
+++ b/app/controllers/api/practices_controller.rb
@@ -12,7 +12,7 @@ class API::PracticesController < API::BaseController
     @categories = @categories
                   .eager_load(:practices)
                   .where.not(practices: { id: nil })
-                  .order('categories.position ASC, categories_practices.position ASC')
+                  .order('categories_practices.position ASC')
   end
 
   def update

--- a/app/controllers/api/practices_controller.rb
+++ b/app/controllers/api/practices_controller.rb
@@ -12,7 +12,7 @@ class API::PracticesController < API::BaseController
     @categories = @categories
                   .eager_load(:practices)
                   .where.not(practices: { id: nil })
-                  .order('categories_practices.position ASC')
+                  .order('categories_practices.position')
   end
 
   def update

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -86,7 +86,7 @@ class PagesController < ApplicationController
       Category
       .eager_load(:practices)
       .where.not(practices: { id: nil })
-      .order('categories_practices.position ASC')
+      .order('categories_practices.position')
   end
 
   def redirect_to_slug

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -86,7 +86,7 @@ class PagesController < ApplicationController
       Category
       .eager_load(:practices)
       .where.not(practices: { id: nil })
-      .order('categories.position ASC, categories_practices.position ASC')
+      .order('categories_practices.position ASC')
   end
 
   def redirect_to_slug

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -68,7 +68,7 @@ class QuestionsController < ApplicationController
       Category
       .eager_load(:practices)
       .where.not(practices: { id: nil })
-      .order('categories.position ASC, categories_practices.position ASC')
+      .order('categories_practices.position ASC')
   end
 
   def question_params

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -68,7 +68,7 @@ class QuestionsController < ApplicationController
       Category
       .eager_load(:practices)
       .where.not(practices: { id: nil })
-      .order('categories_practices.position ASC')
+      .order('categories_practices.position')
   end
 
   def question_params

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -64,7 +64,8 @@ class QuestionsController < ApplicationController
   end
 
   def set_categories
-    @categories = Category
+    @categories =
+      Category
       .eager_load(:practices)
       .where.not(practices: { id: nil })
       .order('categories_practices.position ASC')

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -64,7 +64,10 @@ class QuestionsController < ApplicationController
   end
 
   def set_categories
-    @categories = current_user.course.categories
+    @categories = Category
+      .eager_load(:practices)
+      .where.not(practices: { id: nil })
+      .order('categories_practices.position ASC')
   end
 
   def question_params

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -64,11 +64,7 @@ class QuestionsController < ApplicationController
   end
 
   def set_categories
-    @categories =
-      Category
-      .eager_load(:practices)
-      .where.not(practices: { id: nil })
-      .order('categories_practices.position ASC')
+    @categories = current_user.course.categories
   end
 
   def question_params

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -129,7 +129,7 @@ class ReportsController < ApplicationController
   end
 
   def set_categories
-    @categories = Category.eager_load(:practices).where.not(practices: { id: nil }).order('categories_practices.position ASC')
+    @categories = Category.eager_load(:practices).where.not(practices: { id: nil }).order('categories_practices.position')
   end
 
   def set_wip

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -129,7 +129,7 @@ class ReportsController < ApplicationController
   end
 
   def set_categories
-    @categories = Category.eager_load(:practices).where.not(practices: { id: nil }).order('categories.position ASC, categories_practices.position ASC')
+    @categories = Category.eager_load(:practices).where.not(practices: { id: nil }).order('categories_practices.position ASC')
   end
 
   def set_wip

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -306,7 +306,8 @@ export default {
               searchResultLimit: 10,
               searchPlaceholderValue: '検索ワード',
               noResultsText: '一致する情報は見つかりません',
-              itemSelectText: '選択'
+              itemSelectText: '選択',
+              shouldSort: false
             })
           }
         })

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -281,7 +281,7 @@ export default {
       return meta ? meta.getAttribute('content') : ''
     },
     fetchPractices() {
-      fetch('/api/practices.json', {
+      fetch('/api/practices.json?scoped_by_user=true', {
         method: 'GET',
         headers: {
           'X-Requested-With': 'XMLHttpRequest',

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,7 +7,6 @@ class Category < ApplicationRecord
   has_many :practices, through: :categories_practices
   validates :name, presence: true
   validates :slug, presence: true
-  acts_as_list
 
   def self.category(practice:, course:)
     categories = practice.categories

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -571,7 +571,7 @@ class User < ApplicationRecord
   end
 
   def practices
-    course.practices.order('categories.position', 'practices.position')
+    course.practices.order('courses_categories.position', 'practices.position')
   end
 
   def update_mentor_memo(new_memo)

--- a/app/views/api/courses/practices/index.json.jbuilder
+++ b/app/views/api/courses/practices/index.json.jbuilder
@@ -2,7 +2,6 @@ json.categories @categories do |category|
   json.id category.id
   json.name category.name
   json.slug category.slug
-  json.position category.position
   json.description category.description
 
   json.practices do

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -8,7 +8,7 @@
             .form-item
               = f.label :practice, class: 'a-form-label'
               .select-practices
-                = f.select(:practice_ids, practice_options_within_course, { selected: params[:practice_id] }, { id: 'js-choices-single-select' })
+                = f.select(:practice_id, practice_options_within_course, { selected: params[:practice_id] }, { id: 'js-choices-single-select' })
 
       .form-item
         .row.js-markdown-parent

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -8,7 +8,7 @@
             .form-item
               = f.label :practice, class: 'a-form-label'
               .select-practices
-                = f.select(:practice_id, practice_options(categories), { selected: params[:practice_id] }, { id: 'js-choices-single-select' })
+                = f.select(:practice_ids, practice_options_within_course, { selected: params[:practice_id] }, { id: 'js-choices-single-select' })
 
       .form-item
         .row.js-markdown-parent

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -95,7 +95,7 @@ header.page-header
                   .page-content-header__tags
                     .tag-links
                       ul.tag-links__items
-                        - @report.practices.eager_load(:categories).order('categories_practices.position ASC').each do |practice|
+                        - @report.practices.eager_load(:categories).order('categories_practices.position').each do |practice|
                           li.tag-links__item
                             = link_to practice, class: 'tag-links__item-link' do
                               = practice.title

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -95,7 +95,7 @@ header.page-header
                   .page-content-header__tags
                     .tag-links
                       ul.tag-links__items
-                        - @report.practices.eager_load(:categories).order('categories.position ASC, categories_practices.position ASC').each do |practice|
+                        - @report.practices.eager_load(:categories).order('categories_practices.position ASC').each do |practice|
                           li.tag-links__item
                             = link_to practice, class: 'tag-links__item-link' do
                               = practice.title

--- a/db/fixtures/categories.yml
+++ b/db/fixtures/categories.yml
@@ -2,124 +2,103 @@ category1:
   name: "学習の準備"
   slug: "ready-for-learn"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 1
 
 category2:
   name: "Mac OS X"
   slug: "mac-os-x"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 2
 
 category3:
   name: "HTML & CSS"
   slug: "html-and-css"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 3
 
 category4:
   name: "UNIX"
   slug: "unix"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 4
 
 category5:
   name: "Ruby"
   slug: "ruby"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 5
 
 category6:
   name: "Ruby on Rails"
   slug: "ruby-on-rails"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 6
 
 category7:
   name: "SQL"
   slug: "sql"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 7
 
 category8:
   name: "Vim"
   slug: "vim"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 8
 
 category9:
   name: "自動テスト"
   slug: "testing"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 9
 
 category10:
   name: "JavaScript"
   slug: "javascript"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 10
 
 category11:
   name: "Git"
   slug: "git"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 11
 
 category12:
   name: "開発手法"
   slug: "development"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 12
 
 category13:
   name: "iOS"
   slug: "ios"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 13
 
 category14:
   name: "Android"
   slug: "android"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 14
 
 category15:
   name: "Nginx"
   slug: "nginx"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 15
 
 category16:
   name: "HTTP"
   slug: "http"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 16
 
 category17:
   name: "Unity"
   slug: "unity"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 17
 
 category18:
   name: "C#"
   slug: "csherp"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 18
 
 category19:
   name: "ゲームのビルド"
   slug: "game-build"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 19
 
 category20:
   name: "Unity発展編"
   slug: "unity-advance"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 20
 
 category21:
   name: "ゲームのテスト"
   slug: "game-test"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 21

--- a/db/migrate/20220418054838_remove_position_from_categories.rb
+++ b/db/migrate/20220418054838_remove_position_from_categories.rb
@@ -1,0 +1,6 @@
+class RemovePositionFromCategories < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :categories, :position
+    remove_column :categories, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_28_133239) do
+ActiveRecord::Schema.define(version: 2022_04_18_054838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -101,9 +101,7 @@ ActiveRecord::Schema.define(version: 2022_03_28_133239) do
     t.string "slug"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "position"
     t.text "description"
-    t.index ["position"], name: "index_categories_on_position"
   end
 
   create_table "categories_practices", force: :cascade do |t|

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -2,124 +2,103 @@ category1:
   name: "学習の準備"
   slug: "ready-for-learn"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 1
 
 category2:
   name: "Mac OS X"
   slug: "mac-os-x"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 2
 
 category3:
   name: "HTML & CSS"
   slug: "html-and-css"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 3
 
 category4:
   name: "UNIX"
   slug: "unix"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 4
 
 category5:
   name: "Ruby"
   slug: "ruby"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 5
 
 category6:
   name: "Ruby on Rails"
   slug: "ruby-on-rails"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 6
 
 category7:
   name: "SQL"
   slug: "sql"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 7
 
 category8:
   name: "Vim"
   slug: "vim"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 8
 
 category9:
   name: "自動テスト"
   slug: "testing"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 9
 
 category10:
   name: "JavaScript"
   slug: "javascript"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 10
 
 category11:
   name: "Git"
   slug: "git"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 11
 
 category12:
   name: "開発手法"
   slug: "development"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 12
 
 category13:
   name: "iOS"
   slug: "ios"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 13
 
 category14:
   name: "Android"
   slug: "android"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 14
 
 category15:
   name: "Nginx"
   slug: "nginx"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 15
 
 category16:
   name: "HTTP"
   slug: "http"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 16
 
 category17:
   name: "Unity"
   slug: "unity"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 17
 
 category18:
   name: "C#"
   slug: "csherp"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 18
 
 category19:
   name: "ゲームのビルド"
   slug: "game-build"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 19
 
 category20:
   name: "Unity発展編"
   slug: "unity-advance"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 20
 
 category21:
   name: "ゲームのテスト"
   slug: "game-test"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
-  position: 21

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -52,7 +52,7 @@ class QuestionsTest < ApplicationSystemTestCase
       fill_in 'question[title]', with: 'テストの質問（修正）'
       fill_in 'question[description]', with: 'テストの質問です。（修正）'
       find('.choices__inner').click
-      find('#choices--js-choices-single-select-item-choice-44', text: 'sshdでパスワード認証を禁止にする').click
+      find('#choices--js-choices-single-select-item-choice-11', text: 'sshdでパスワード認証を禁止にする').click
       click_button '更新する'
     end
     assert_text '質問を更新しました'

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -62,34 +62,6 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_text 'sshdでパスワード認証を禁止にする'
   end
 
-  test 'update question for practice without questioner\'s course' do
-    visit_with_auth edit_current_user_path, 'kimura'
-
-    visit new_question_path
-    within 'form[name=question]' do
-      fill_in 'question[title]', with: '質問者のコースにはないプラクティスの質問を編集できるかのテスト'
-      fill_in 'question[description]', with: '編集できれば期待通りの動作'
-      first('.choices__inner').click
-      find('#choices--js-choices-single-select-item-choice-55', text: 'iOSへのビルドと固有の問題').click
-      click_button '登録する'
-    end
-    assert_text '質問を作成しました。'
-
-    click_button '内容修正'
-    within 'form[name=question]' do
-      fill_in 'question[title]', with: '質問者のコースにはないプラクティスの質問でも'
-      fill_in 'question[description]', with: '編集できる'
-      find('.choices__inner').click
-      find('#choices--js-choices-single-select-item-choice-52', text: 'iOSへのビルドと固有の問題').click
-      click_button '更新する'
-    end
-    assert_text '質問を更新しました'
-
-    assert_text '質問者のコースにはないプラクティスの質問でも'
-    assert_text '編集できる'
-    assert_text 'iOSへのビルドと固有の問題'
-  end
-
   test 'delete a question' do
     question = questions(:question8)
     visit_with_auth question_path(question), 'kimura'


### PR DESCRIPTION
# issue
- #4245 

- 関連issue
  - #3182
  - #4746 

# 概要
- カテゴリーの並び順を決めるDBのカラムは、以前は `categories.position`を使っていた。
    - ※カテゴリーとは、プラクティス一覧(`courses/:id/practices`)でいうと、「Mac OS X」や「UNIX」のことを指す。プラクティスとは、「[OS X Mountain Lionをクリーンインストールする」「PC性能の見方を知る」のことを指す。
- しかしバグが発生するため、 [PR#3190](https://github.com/fjordllc/bootcamp/pull/3190) で、代わりに`courses_categories.poisition`を使うように変更された。
- 現在、カテゴリーの並び順は `courses_categories.position`を参照すべきなのだが、`cateogories.position`が使われてしまっている箇所がある。
- このため、このPRでは、`categories`テーブルの`position`カラムを削除し、`categories.position`が使われていた箇所の削除・修正を行った。

# カテゴリーの並び替えの仕組みの説明
## コースとカテゴリーの関係
- コースは「Railsプログラマーコース」の他にも複数存在している。
- コースごとに、カテゴリーの並び順は異なっている。

## `categories.position`を使用していた時のデータ構造はどうなっていたか
`categories`テーブルの`position`カラムに、カテゴリーの並び順を決める数字が入っていた。(例:カラムに1が入っているデータは、並び順が1番最初)

```
# `categories.position` が使われていた時のデータ構造

* Railsプログラマーコース
  * (categories.position: 1) 開発環境 
  * (categories.position: 2) 学習の準備 
  * (categories.position: 3) HTML & CSS 
  * (categories.position: 4) Vi 
  * (categories.position: 5) Linux 

* XXX コース
  * (categories.position: 1) 開発環境
  * (categories.position: 3) HTML & CSS

* YYY コース
  * (categories.position: 3) HTML & CSS
  * (categories.position: 2) 学習の準備
  * (categories.position: 1) 開発環境
```
## `categories.position`の問題点
これにより、Railsプログラマーコースのカテゴリーを並び替えると、他のコースの並びも変わってしまうというバグが発生した。
(例：Railsプログラマーコースの「開発環境」というカテゴリーをアプリで並び替えた時、それ以外のコース全部の「開発環境」の位置も一緒に移動してしまう。)

## どのように解決したか：中間テーブル`courses_categories`に`position`カラムを作り、こちらを使うように変更
本来は、コースごとにカテゴリーの並び替えをしたい = あるコースのカテゴリーの並び順を変更しても、他のコースの並びは変わらないようにしたい。
そのため、[PR#3190](https://github.com/fjordllc/bootcamp/pull/3190)  によって、元々存在していた `courses_categories` という中間テーブルに、`position` カラムを作って使うようにした。

## `courses_categories.position` が使われている現在のデータ構造
```
# `courses_categories.position` が使われている現在のデータ構造

* コース
  * (id : 1) Rails プログラマーコース
  * (id : 2) XXX コース
  * (id : 3) YYY コース

* カテゴリ
  * (id: 1, position: 2) 開発環境
  * (id: 2, position: 1) 学習の準備
  * (id: 3, position: 3) HTML & CSS

* コース <-> カテゴリ (中間テーブル)
  * (position: 1), (course_id: 1) Rails プログラマーコース, (category_id: 1) 開発環境
  * (position: 2), (course_id: 1) Rails プログラマーコース, (category_id: 2) 学習の準備
  * (position: 3), (course_id: 1) Rails プログラマーコース, (category_id: 3) HTML & CSS
  * (course_id: 2) XXX コース,             (category_id: 1) 開発環境
  * (course_id: 2) XXX コース,             (category_id: 2) 学習の準備
  * (course_id: 3) YYY コース,             (category_id: 1) 開発環境
```
- コースとカテゴリーは多対多の関係である
    - 1つのコースは複数のカテゴリーを持っている (例：Railsプログラマーコースは、「学習の準備」や「HTML&CSS」など複数のカテゴリーを持ってる)
    - 1つのカテゴリーは複数のコースに属している (例：「学習の準備」というカテゴリーは、Railsプログラマーコースだけでなく、他のコースにも属している)
- 中間テーブルを作ることによって、コースごとにどのカテゴリーを選択するかを紐付けている。
    - 上記の表でいうと、「Rails プログラマー」のコースかつ「開発環境」カテゴリーは、 position が1
		`* (position: 1), (course_id: 1) Rails プログラマーコース, (category_id: 1) 開発環境`
    - Rails プログラマー」のコースかつ「学習の準備」カテゴリーは、 position が2 
    `* (position: 2), (course_id: 1) Rails プログラマーコース, (category_id: 2) 学習の準備`
    - というようにカテゴリーとコースの紐付けを行っている。

## 変更点
- `categories`テーブルの`position`カラムを削除した。
- `cateogories.position`が、以下の7箇所で使用されていたので、削除した。

1. 管理ページのカテゴリー一覧の並び順
2. プラクティス一覧のカテゴリーの並び順
3. Docs作成時のプラクティス選択の並び順
4. 日報詳細画面のプラクティスの並び順
5. Q&A新規作成時・詳細画面のプラクティスの並び順
6. Q&A編集時のプラクティスの並び順
7. `models/user.rb`の`practices`メソッド

|  使用箇所  |  変更前  | 変更後  |
| ---- | ---- | ---- |
| 1.管理ページのカテゴリー一覧  |`@categories = Category.order('position')`![スクリーンショット 2022-05-04 17 01 57](https://user-images.githubusercontent.com/58052292/166643146-e28ab56c-f2ba-43c3-8381-9f3b86e23bd8.png)|`@categories = Category.all`![スクリーンショット 2022-05-04 17 01 57](https://user-images.githubusercontent.com/58052292/166643146-e28ab56c-f2ba-43c3-8381-9f3b86e23bd8.png)| 
|2.プラクティス一覧   | `.order('courses_categories.position ASC, categories.position ASC')`![image](https://user-images.githubusercontent.com/58052292/166643912-40e688a8-51b6-453d-aa8d-8df2357522fd.png)|`.order('courses_categories.position ASC')`(変更前と同じ並び順)![image](https://user-images.githubusercontent.com/58052292/166644380-0a311a7c-075c-463e-94fd-e4a576be29d4.png)|
|3.Docs作成時のプラクティス選択 |`.order('categories.position ASC, categories_practices.position ASC')`[![Image from Gyazo](https://i.gyazo.com/00578900d95f46666a7d427a5132e80e.gif)](https://gyazo.com/00578900d95f46666a7d427a5132e80e)|`.order('categories_practices.position ASC')`[![Image from Gyazo](https://i.gyazo.com/d9f3efab6a2ade2e617053eaa7928882.gif)](https://gyazo.com/d9f3efab6a2ade2e617053eaa7928882)|
|4.日報詳細画面のプラクティスの並び順|`.order('categories.position ASC, categories_practices.position ASC')`|`.order('categories_practices.position ASC')`|
|5.Q&A新規作成時・詳細画面のプラクティスの並び順|全カテゴリー表示[![Image from Gyazo](https://i.gyazo.com/0e6d0e8ab71b8f564f2b4768b5824737.gif)](https://gyazo.com/0e6d0e8ab71b8f564f2b4768b5824737)|ユーザーが属しているコースのカテゴリーのみ表示/並び順はログインユーザーのプラクティス一覧と同じ[![Image from Gyazo](https://i.gyazo.com/8911926be2262a6fcfa0dfa2dc2d2bcd.gif)](https://gyazo.com/8911926be2262a6fcfa0dfa2dc2d2bcd)|
|6.Q&A編集時のプラクティスの並び順  |全カテゴリー表示[![Image from Gyazo](https://i.gyazo.com/c19fe5d9fea31ca2679a99a7086e64c7.gif)](https://gyazo.com/c19fe5d9fea31ca2679a99a7086e64c7)   |ユーザーが属しているコースのカテゴリーのみ表示[![Image from Gyazo](https://i.gyazo.com/f9639cd9fb6cff2c9d57dc9662555af5.gif)](https://gyazo.com/f9639cd9fb6cff2c9d57dc9662555af5)
|`models/user.rb`の`practices`メソッド|`order`メソッドの第一引数に`categories.position`が渡されていた|`courses_categories.position`に変更した(並び順は変更前と同じ)

# 動作確認の手順
1. `bug/delete-categories.position`ブランチをローカルに持ってくる
2. `bin/setup`を実行
3. `rails s`で立ち上げる
4. `admin`でログイン
5. 以下7点の動作確認を行う。

### 1. 管理ページのカテゴリー一覧
1. `/admin/categories`にアクセス
2. 「カテゴリー」タブを開く
3. カテゴリーの名前と数が、ステージング環境を同じになっているか確認する
(komagataさんより、この箇所の並び順は`all`メソッドで良いと伺ったので、並び順は確認しなくて良いです)

#### 関連ファイル
- `app/controllers/admin/categories_controller.rb`

## 2. プラクティス一覧
1. 左メニューの「プラクティス」をクリックして`/courses/:course_id/practices`にアクセス
2. カテゴリーの並び順が、ステージング環境と同じになっているか確認する

#### 関連ファイル
- `app/controllers/api/courses/practices_controller.rb`
- `app/views/api/courses/practices/index.json.jbuilder`

## 3. Docs作成時のプラクティス選択の並び順
1. `/questions/new`にアクセス
2. プラクティスの並び順を見て、「カテゴリーの中のプラクティス」の並び順が、プラクティス一覧と同じになっているか確認する。(ここにはユーザーが属しているコースに関わらず全カテゴリーを表示しているため、カテゴリーの並び順は確認しなくてよい。komagataさんにも確認済。)



#### 関連ファイル
- `app/controllers/pages_controller.rb`

## 4.日報詳細画面のプラクティスの並び順
1. `/reports/new`にアクセス
2. すべてのプラクティスを選択する
3. タイトル、学習時間、内容を入力し、「提出」をクリック
4. 日報詳細画面のプラクティスの表示内容が、プラクティス一覧ページと同じか確認する。※並び順はプラクティス一覧と同じでなくて良いです。

#### 関連ファイル
- `app/controllers/reports_controller.rb`
- `app/views/reports/show.html.slim`

## 5. Q&A新規作成時・詳細画面のプラクティスの並び順
1. `/questions/new`にアクセス
2. プラクティス選択において、「**ユーザーが属しているコースのカテゴリーのみを表示しているか**」を確認する。
 ※こちら、元々は全カテゴリーが表示されていましたが、komagataさんより、
   - 表示内容：ユーザーが属しているコースのカテゴリーのみ表示
   - 並び順：プラクティス一覧(`courses/:course_id`/practices`)と同じ 
   に変更するようご指示がございました。**並び順**の実装のみ、 #4748 で対応しております。そのため、こちらのPRでは**表示内容のみ**ご確認をお願いします。
  - ※5/9(月)追記：#4748 がmainにマージされたため、並び順のご確認もお願いします🙏

#### 関連ファイル
- `app/controllers/questions_controller.rb`
- `app/views/questions/_form.html.slim`

## 6. Q&A編集時のプラクティスの並び順 
1. 左メニューの「Q&A」をクリック
2. 任意の質問をクリックし、「内容修正」をクリック
3. プラクティスの並び順を見て、「**表示内容が、ユーザーが属しているコースのカテゴリーのみか**」と「**並び順が、プラクティス一覧(`courses/:course_id/practices`)と同じか** 」を確認する。

#### 関連ファイル
- `app/javascript/question-edit.vue`

## 7. `models/user.rb`の`practices`メソッド
1. **ステージング環境でログインし**、左メニューの「プラクティス」をクリックして`/courses/:course_id/practices`にアクセス
2. ターミナルで`rails c`を実行し、`User.find(1でログインしているユーザーのid)`.practicesを実行
3. 1の並び順と2の並び順が同じか確認

#### 関連ファイル
- `app/models/user.rb`
