### PR TITLE
プラクティスの完了メッセージのAPIでlearningがnilの時にNoMethodErrorが出ないよう修正

### DIFF
--- a/app/controllers/api/practices/learning/completion_message_controller.rb
+++ b/app/controllers/api/practices/learning/completion_message_controller.rb
@@ -2,7 +2,7 @@
 
 class API::Practices::Learning::CompletionMessageController < API::BaseController
   def update
-    learning = current_user.learnings.find_by(practice_id: params[:practice_id])
+    learning = current_user.learnings.find_by!(practice_id: params[:practice_id])
     if learning.update(completion_message_displayed: true)
       head :ok
     else


### PR DESCRIPTION
## issue
- [プラクティスの完了メッセージのAPIでlearningがない時にエラーが出る · Issue \#4292](https://github.com/fjordllc/bootcamp/issues/4292)

## 概要
- プラクティスの完了メッセージのAPIに存在しない`practice_id`を指定するとNoMethodErrorが出るので修正した。

## エラー再現方法
1. `main`ブランチで`bin/rails s`を実行し、ローカル環境を起動する。
1. 適当なuserでログインする。（例：kensyu）
1. 適当なプラクティスを開く。（例：OS X Mountain Lionをクリーンインストールする）
1. Chromeのデベロッパーツールを開き、ネットワークタブをクリックする。フィルターを削除し、`Fetch/XHR`を選択しておく。
<img width="1436" alt="手順4" src="https://user-images.githubusercontent.com/70277776/163717014-d9550930-645b-4eab-b661-d3fe6369e25b.png">

5. 完了を押し、出てきたモーダルの閉じるを押す。
<img width="1441" alt="手順5" src="https://user-images.githubusercontent.com/70277776/163717053-97268b91-854d-41ab-a142-050aaacd152f.png">

6. ネットワークに表示された`completion_message`で右クリックし、「コピー」→「fetchとしてコピー」を選択する。
<img width="1430" alt="手順6" src="https://user-images.githubusercontent.com/70277776/163717066-42fc0384-4eff-4105-b5b2-308aaf0ce54c.png">

7. コンソールタブをクリックし、今コピーした物をペーストする。
1. 1行目の`"http://127.0.0.1:3000/api/practices/315059988/learning/completion_message"`の`/practices/315059988/`の部分を`/practices/1/`に修正し、実行する。
1. コンソールに`PATCH http://127.0.0.1:3000/api/practices/1/learning/completion_message 500 (Internal Server Error)`が表示され、ターミナルに`NoMethodError (undefined method `update' for nil:NilClass`が表示された。
<img width="876" alt="手順9" src="https://user-images.githubusercontent.com/70277776/163717082-ab226338-5284-4543-bf26-2737b7aa979a.png">

## 修正確認方法
1. ブランチ `bug/api-for-practice-completion-messages-error-with-larning-is-nil` をローカルに取り込み、ローカル環境で起動する。
1. 上の「エラー再現方法」を実行する。
1. コンソールに`PATCH http://127.0.0.1:3000/api/practices/1/learning/completion_message 404 (Not Found)`が表示され、
ターミナルに`Completed 404 Not Found`と`ActiveRecord::RecordNotFound`が表示され、`NoMethodError`は出なくなった。
<img width="1399" alt="修正後" src="https://user-images.githubusercontent.com/70277776/163717103-743d5c0a-2651-4377-8e14-1c5f897ca37c.png">

