### PR TITLE
メールのプレビュー画面でエラーが出ないようにした

### DIFF
--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -124,6 +124,14 @@ notification_chose_correct_answer:
   link: "/questions/<%= ActiveRecord::FixtureSet.identify(:question12) %>"
   read: false
 
+notification_consecutive_sad_report:
+  kind: 15
+  user: komagata
+  sender: hajime
+  message: hajimeさんが2回連続でsadアイコンの日報を提出しました。
+  link: "/reports/<%= ActiveRecord::FixtureSet.identify(:report16) %>"
+  read: false
+
 notification_graduated:
   kind: 18
   user: mentormentaro

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -23,10 +23,10 @@ class NotificationMailerPreview < ActionMailer::Preview
 
   def mentioned
     report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
-    comment = report.comments.first
+    mentionable = Comment.find(ActiveRecord::FixtureSet.identify(:comment9))
     receiver = report.user
 
-    NotificationMailer.with(comment: comment, receiver: receiver).mentioned
+    NotificationMailer.with(mentionable: mentionable, receiver: receiver).mentioned
   end
 
   def submitted
@@ -110,7 +110,7 @@ class NotificationMailerPreview < ActionMailer::Preview
 
   def moved_up_event_waiting_user
     event = Event.find(ActiveRecord::FixtureSet.identify(:event3))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:hatsuno))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:hajime))
 
     NotificationMailer.with(
       event: event,


### PR DESCRIPTION
- #4441

## 概要
メールのプレビュー画面において、以下の3つのプレビューでエラーが出て、メールの外観を確認できない。

http://localhost:3000/rails/mailers/notification_mailer/consecutive_sad_report
http://localhost:3000/rails/mailers/notification_mailer/mentioned
http://localhost:3000/rails/mailers/notification_mailer/moved_up_event_waiting_user

なお、issueには`http://localhost:3000/rails/mailers/notification_mailer/came_answer`も対象と記載されておりますが、私が確認した際には問題なく、プレビュー画面を確認できましたので、今回は修正しておりません。

## 確認手順
- ブランチ `feature/display-mail-preview` をローカルに取り込む
- `bin/rails db:seed`を実行した後、`bin/rails s` でサーバーを立ち上げる
- 上記の3つのリンクにアクセスし、プレビュー画面が表示されるか確認する