### PR TITLE
企業編集ページに削除リンクを設置

### DIFF
--- a/app/assets/stylesheets/atoms/_a-button.sass
+++ b/app/assets/stylesheets/atoms/_a-button.sass
@@ -41,8 +41,17 @@
   &.is-text
     background: none
     border: none
+    font-weight: 400
     +hover-link-reversal
     +default-link
+    height: auto !important
+    padding: 0 !important
+  &.is-muted-text
+    background: none
+    border: none
+    font-weight: 400
+    +hover-link-reversal
+    +muted-link
     height: auto !important
     padding: 0 !important
 
@@ -50,7 +59,7 @@
   &.is-xxs,
   &.is-xxs input[type="submit"]
     +button-size(.625rem, 1, 1.4rem)
-    font-weight: 300
+    font-weight: 400
   &.is-xs,
   &.is-xs input[type="submit"]
     +button-size(.75rem, 1, 1.7rem)
@@ -58,15 +67,12 @@
   &.is-sm,
   &.is-sm input[type="submit"]
     +button-size(.75rem, 1.25, 2rem)
-    font-weight: 600
   &.is-md,
   &.is-md input[type="submit"]
     +button-size(.8125rem, 1.5, 2.375rem)
-    font-weight: 600
   &.is-lg,
   &.is-lg input[type="submit"]
     +button-size(1rem, 1, 2.75rem)
-    font-weight: 600
   &.is-xl,
   &.is-xl input[type="submit"]
     +button-size(1.25rem, 1, 57px)

--- a/app/assets/stylesheets/blocks/form/_form-actions.sass
+++ b/app/assets/stylesheets/blocks/form/_form-actions.sass
@@ -19,6 +19,7 @@
     align-items: flex-end
     justify-content: center
     flex-wrap: wrap
+    position: relative
     &.is-ais-flex-start
       align-items: flex-start
   +media-breakpoint-down(sm)
@@ -30,6 +31,13 @@
   &.is-sub
     +media-breakpoint-up(md)
       flex: 0 0 auto
+    +media-breakpoint-down(sm)
+      text-align: center
+  &.is-muted
+    +media-breakpoint-up(md)
+      +position(absolute, right 0, bottom 0)
+    +media-breakpoint-down(sm)
+      text-align: right
   &.is-help
     +media-breakpoint-down(sm)
       margin-bottom: 1rem
@@ -52,6 +60,10 @@
       margin-top: .75rem
     > *
       width: 100%
+    .a-button.is-text,
+    .a-button.is-muted-text
+      width: auto
+
 
 .form-actions__item-help
   +text-block(.8125rem 1, center)

--- a/app/assets/stylesheets/mixins/_button.sass
+++ b/app/assets/stylesheets/mixins/_button.sass
@@ -1,5 +1,6 @@
 =button-base
   text-transform: none
+  font-weight: 600
   display: inline-flex
   border: solid 1px
   border-radius: .25rem

--- a/app/assets/stylesheets/variables/_colors.sass
+++ b/app/assets/stylesheets/variables/_colors.sass
@@ -84,6 +84,18 @@ $main-shade: tint($main, 90%)
   &:active
     color: #b3430b
 
+=muted-link
+  transition: color .2s ease-in
+  color: $muted-text
+  &:link
+    color: $muted-text
+  &:visited
+    color: $muted-text
+  &:hover
+    color: $danger
+  &:active
+    color: $danger
+
 $luma-contrast-bright-color: $default-text
 $luma-contrast-dark-color: $reversal-text
 $button-checked-color: $danger

--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -29,7 +29,15 @@ class Admin::CompaniesController < AdminController
     end
   end
 
-  def destroy; end
+  def destroy
+    @company = Company.find(params[:id])
+
+    if @company.destroy
+      redirect_to admin_companies_url, notice: '企業を削除しました。'
+    else
+      head :bad_request
+    end
+  end
 
   private
 

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -30,3 +30,5 @@
         = f.submit nil, class: 'a-button is-lg is-block is-primary'
       li.form-actions__item.is-sub
         = link_to 'キャンセル', :back, class: 'a-button is-sm is-text'
+      li.form-actions__item.is-sub
+        = link_to '削除', admin_company_path(company), data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。'}, method: :delete, class: 'a-button is-sm is-text'

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -22,7 +22,8 @@
           - else
             p 画像を選択
           = f.file_field :logo
-        .a-form-help
+      .a-form-help
+        p
           | 正方形に切り抜かれるので、正方形で加工したものをアップロードする必要があります。
   .form-actions
     ul.form-actions__items
@@ -31,5 +32,5 @@
       li.form-actions__item.is-sub
         = link_to 'キャンセル', :back, class: 'a-button is-sm is-text'
       - unless company.id.nil?
-        li.form-actions__item.is-sub
-          = link_to '削除', admin_company_path(company), data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }, method: :delete, class: 'a-button is-sm is-text'
+        li.form-actions__item.is-muted
+          = link_to '削除', admin_company_path(company), data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }, method: :delete, class: 'a-button is-sm is-muted-text'

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -31,6 +31,6 @@
         = f.submit nil, class: 'a-button is-lg is-block is-primary'
       li.form-actions__item.is-sub
         = link_to 'キャンセル', :back, class: 'a-button is-sm is-text'
-      - unless company.id.nil?
+      - if company.id.present?
         li.form-actions__item.is-muted
           = link_to '削除', admin_company_path(company), data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }, method: :delete, class: 'a-button is-sm is-muted-text'

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -31,4 +31,4 @@
       li.form-actions__item.is-sub
         = link_to 'キャンセル', :back, class: 'a-button is-sm is-text'
       li.form-actions__item.is-sub
-        = link_to '削除', admin_company_path(company), data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。'}, method: :delete, class: 'a-button is-sm is-text'
+        = link_to '削除', admin_company_path(company), data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }, method: :delete, class: 'a-button is-sm is-text'

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -30,5 +30,6 @@
         = f.submit nil, class: 'a-button is-lg is-block is-primary'
       li.form-actions__item.is-sub
         = link_to 'キャンセル', :back, class: 'a-button is-sm is-text'
-      li.form-actions__item.is-sub
-        = link_to '削除', admin_company_path(company), data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }, method: :delete, class: 'a-button is-sm is-text'
+      - unless company.id.nil?
+        li.form-actions__item.is-sub
+          = link_to '削除', admin_company_path(company), data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }, method: :delete, class: 'a-button is-sm is-text'

--- a/app/views/practices/_form.html.slim
+++ b/app/views/practices/_form.html.slim
@@ -87,7 +87,8 @@
               p 画像を選択
             = f.file_field :ogp_image
         .a-form-help
-          | 画像サイズ: 1200px × 630xp
+          p
+            | 画像サイズ: 1200px × 630xp
 
   .form-actions
     ul.form-actions__items

--- a/app/views/practices/_form.html.slim
+++ b/app/views/practices/_form.html.slim
@@ -87,8 +87,7 @@
               p 画像を選択
             = f.file_field :ogp_image
         .a-form-help
-          p
-            | 画像サイズ: 1200px × 630xp
+          p 画像サイズ: 1200px × 630xp
 
   .form-actions
     ul.form-actions__items

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -10,7 +10,8 @@
         = f.label :title, class: 'a-form-label'
         = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'display: inline-block の挙動の調査を進めた'
         .a-form-help
-          | 後で探しやすくなるタイトルがオススメ
+          p
+            | 後で探しやすくなるタイトルがオススメ
       .form-item
         = f.label :reported_on, class: 'a-form-label'
         = f.date_field :reported_on, class: 'a-text-input'

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -10,8 +10,7 @@
         = f.label :title, class: 'a-form-label'
         = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'display: inline-block の挙動の調査を進めた'
         .a-form-help
-          p
-            | 後で探しやすくなるタイトルがオススメ
+          p 後で探しやすくなるタイトルがオススメ
       .form-item
         = f.label :reported_on, class: 'a-form-label'
         = f.date_field :reported_on, class: 'a-text-input'

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -37,4 +37,11 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
     visit_with_auth '/admin/companies', 'komagata'
     assert_selector 'nav.pagination', count: 2
   end
+
+  test 'delete company' do
+    visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
+    click_on '削除'
+    page.driver.browser.switch_to.alert.accept
+    assert_text '企業を削除しました。'
+  end
 end


### PR DESCRIPTION
新しいブランチを作成したので、PRも作り直しました。

以前のPRはこちらのURLです。
https://github.com/fjordllc/bootcamp/pull/4567

## 関連issue
- #4535

## 概要・要件
管理者ページの企業一覧から削除ボタンを消すのと併せて、企業編集ページに削除ボタンを設置。ボタンを押すと企業のページが削除される。

管理者ページの企業編集ページなので、この削除ボタンは管理者にしか見えない。

このPRは以下のissueと関連していて、企業一覧ページから削除ボタンを削除し、企業編集ページに削除ボタンを設置した。
- #4534

## 変更前
<img width="1000" src="https://user-images.githubusercontent.com/49633473/161770047-965ad701-a21b-48a6-af74-cae39497b011.png">

## 変更後
<img width="1000" src="https://user-images.githubusercontent.com/49633473/161770305-f3253681-5d03-465c-a19f-1561650fad35.png">

## 削除ボタンの確認方法
1. `feature/display-delete-link-on-the-company-edit-page`をローカルに取り込む
1. `bin/rails s`でサーバーを立ち上げる
1. 管理者ロールのユーザー(`komagata`か`machida`)でログイン
1. 右上のユーザーアイコンをクリックし(Meと書いてあるアイコン)、管理ページを選択
1. 管理ページの「企業」のタブをクリックして企業一覧のページに遷移し、「操作」の項目にある編集ボタン（えんぴつマークのボタン）をクリックし、企業編集ページに遷移。画面をスクロールし、削除ボタンが表示されていることを確認
2. ボタンを押して企業が削除されるか確認

## 削除ボタンのテストの確認方法
1. HEADED=1 bin/rails test test/system/admin/companies_test.rbを実行
2. テストが正常に終了することを確認