### PR TITLE
Choices.jsのマルチセレクトボックスにresetScrollPositionのオプションを追加

### DIFF
--- a/app/javascript/choices-ui.js
+++ b/app/javascript/choices-ui.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
       noResultsText: '一致する情報は見つかりません',
       itemSelectText: '選択',
       shouldSort: false,
+      resetScrollPosition: false,
       renderSelectedChoices: 'always'
     })
   }


### PR DESCRIPTION
## 概要
日報を書く際にプラクティスのマルチセレクトがリセットされ、入力に時間がかかってしまっていたのでオプションを追加しました
（現在、Choices.jsのマルチセレクトが使われているのは日報でのプラクティス選択のみです）

## 変更前
https://user-images.githubusercontent.com/69446373/164973468-7939993d-1fde-4ba6-94e9-d0c1ffdf805a.mov

## 変更後
https://user-images.githubusercontent.com/69446373/164973469-0f6e1a3f-3e3d-4bb3-ad43-ad170b23b4bc.mov


