### PR TITLE
[Choices.js] 質問編集フォームのプラクティス選択を Choice.js に置き換える。

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -125,9 +125,8 @@
                 .fa-solid.fa-spinner.fa-pulse
                 | ロード中
             .select-practices(v-show='practices !== null')
-              select.js-select2(
+              select#js-choices-single-select(
                 v-model='edited.practiceId',
-                v-select2,
                 name='question[practice]'
               )
                 option(
@@ -210,6 +209,7 @@ import confirmUnload from 'confirm-unload'
 import dayjs from 'dayjs'
 import ja from 'dayjs/locale/ja'
 import role from 'role'
+import Choices from 'choices.js'
 dayjs.locale(ja)
 
 export default {
@@ -219,15 +219,6 @@ export default {
     tags: Tags,
     reaction: Reaction,
     userIcon: UserIcon
-  },
-  directives: {
-    select2: {
-      inserted(el) {
-        $(el).on('select2:select', () => {
-          el.dispatchEvent(new Event('change'))
-        })
-      }
-    }
   },
   mixins: [confirmUnload, role],
   props: {
@@ -266,7 +257,7 @@ export default {
 
       return practices === null
         ? question.practice.title
-        : practices.find((practice) => practice.id === practiceId).title
+        : practices.find((practice) => practice.id === Number(practiceId)).title
     },
     markdownDescription() {
       const markdownInitializer = new MarkdownInitializer()
@@ -306,6 +297,18 @@ export default {
             return practice
           })
         })
+        .then(() => {
+          const choices = document.getElementById('js-choices-single-select')
+          if (choices) {
+            return new Choices(choices, {
+              allowHTML: true,
+              searchResultLimit: 10,
+              searchPlaceholderValue: '検索ワード',
+              noResultsText: '一致する情報は見つかりません',
+              itemSelectText: '選択'
+            })
+          }
+        })
         .catch((error) => {
           console.warn(error)
         })
@@ -314,9 +317,6 @@ export default {
       this.editing = true
       this.$nextTick(() => {
         $(`.question-id-${this.question.id}`).trigger('input')
-      })
-      $('.js-select2').select2({
-        closeOnSelect: true
       })
     },
     finishEditing(hasUpdatedQuestion) {

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -51,7 +51,8 @@ class QuestionsTest < ApplicationSystemTestCase
     within 'form[name=question]' do
       fill_in 'question[title]', with: 'テストの質問（修正）'
       fill_in 'question[description]', with: 'テストの質問です。（修正）'
-      select 'sshdでパスワード認証を禁止にする', from: 'question[practice]'
+      find('.choices__inner').click
+      find('#choices--js-choices-single-select-item-choice-44', text: 'sshdでパスワード認証を禁止にする').click
       click_button '更新する'
     end
     assert_text '質問を更新しました'
@@ -78,7 +79,8 @@ class QuestionsTest < ApplicationSystemTestCase
     within 'form[name=question]' do
       fill_in 'question[title]', with: '質問者のコースにはないプラクティスの質問でも'
       fill_in 'question[description]', with: '編集できる'
-      select 'iOSへのビルドと固有の問題', from: 'question[practice]'
+      find('.choices__inner').click
+      find('#choices--js-choices-single-select-item-choice-52', text: 'iOSへのビルドと固有の問題').click
       click_button '更新する'
     end
     assert_text '質問を更新しました'


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/4581

## 概要

- 「質問編集フォーム」の「プラクティス選択」機能で使用しているライブラリをselect2からChoices.jsに変更しました。
- https://github.com/Choices-js/Choices
- Choices.jsへ変更後、テストに記述されていたプルダウンに対する`select`が効かなくなったので、`find('#choices--js-choices-single-select-item-choice-52', text: 'iOSへのビルドと固有の問題').click`のような検証方法に変更しました。

## 変更前
![image](https://user-images.githubusercontent.com/770527/165204237-45a271da-9be5-4f7e-ac2a-e4254143c669.png)

## 変更後

![image](https://user-images.githubusercontent.com/770527/165204226-2af8afd7-ab38-4430-b25e-211ca573964f.png)

# 確認方法

1. ブランチ `feature/replace-practice-selection-on-question-editing-forms-with-choices-js` をローカルに取り込む
2. `bin/rails s`でサーバーを立ち上げる
3.`hajime` でログインし、「全ての質問」画面を開く
4. `hajime` の作成した質問を開き、「内容修正」で修正フォームを開く
5. 「プラクティス」選択プルダウンが`select2`から`choices.js` に切り替わっていることを確認する

