### PR TITLE
企業個別ページ > 提出物一覧のローディング中に、提出物はまだありませんと表示されていたものをプレースホルダに変更

### DIFF
--- a/app/javascript/company-products.vue
+++ b/app/javascript/company-products.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
 .page-body
+  .container(v-if='!loaded')
+      loadingListPlaceholder
   .container(v-if='products.length === 0')
     .o-empty-message
       .o-empty-message__icon
@@ -25,10 +27,12 @@
 <script>
 import Pager from 'pager.vue'
 import Product from 'product.vue'
+import LoadingListPlaceholder from './loading-list-placeholder.vue'
 
 export default {
   components: {
     product: Product,
+    loadingListPlaceholder: LoadingListPlaceholder,
     pager: Pager
   },
   props: {
@@ -39,6 +43,7 @@ export default {
   },
   data() {
     return {
+      loaded: false,
       products: [],
       currentPage: Number(this.getParams().page) || 1,
       totalPages: 0,
@@ -93,6 +98,7 @@ export default {
             this.products.push(product)
           })
           this.totalPages = json.total_pages
+          this.loaded = true
         })
         .catch((error) => {
           console.warn(error)

--- a/app/javascript/company-products.vue
+++ b/app/javascript/company-products.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .page-body
   .container(v-if='!loaded')
-      loadingListPlaceholder
+    loadingListPlaceholder
   .container(v-if='products.length === 0')
     .o-empty-message
       .o-empty-message__icon

--- a/app/javascript/company-products.vue
+++ b/app/javascript/company-products.vue
@@ -2,7 +2,7 @@
 .page-body
   .container(v-if='!loaded')
     loadingListPlaceholder
-  .container(v-if='products.length === 0')
+  .container(v-else-if='products.length === 0')
     .o-empty-message
       .o-empty-message__icon
         i.far.fa-smile


### PR DESCRIPTION
### Issue
- #4669

### 概要
- 企業個別ページ > 提出物一覧のローディング中に、提出物はありませんと表示されていたものをプレースホルダに変更しました。

### プレースホルダを実装している参考箇所
メンター(mentormentaro)でログインして下記にアクセスするとローディング中にプレースホルダが表示されることを確認できます。
http://localhost:3000/products/unassigned

### 参考にしたファイル
https://github.com/fjordllc/bootcamp/blob/main/app/javascript/watches.vue
([Pull Request \#3776](https://github.com/fjordllc/bootcamp/pull/3776))

https://github.com/fjordllc/bootcamp/blob/main/app/javascript/announcements.vue
([Pull Request #3412](https://github.com/fjordllc/bootcamp/pull/3412))

### 変更確認方法
1. ブランチ `feature/show-placeholders-while-loading-list-of-products-for-company-individual-pages`をローカルに取り込み、ローカル環境を立ち上げる
1. ログイン(誰でも良い)
1. 左サイドバーの**ユーザー**を選択
1. **企業別**タブを選択
1. 企業を選択(どの企業でも良い)
1. **提出物**タブを選択すると確認できます

### 変更前

![image](https://user-images.githubusercontent.com/64824195/166245358-4d46f1c4-9e49-41e8-b61a-4c4c7700ab89.png)

https://user-images.githubusercontent.com/64824195/165055470-25593cd8-72a8-4740-b651-cf7566d3db5a.mov

### 変更後

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/64824195/165079013-bba75153-a83c-496e-a008-a566e60dde47.png">

https://user-images.githubusercontent.com/64824195/165055112-8b4a9367-0573-4535-b944-b2a1d4cf2a44.mov