### PR TITLE
commentのAPIでparams[:commentable_type]がnilの時にNoMethodErrorが出ないよう修正

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -5,10 +5,14 @@ class API::CommentsController < API::BaseController
   before_action :set_available_emojis, only: %i[index create]
 
   def index
-    @comments = commentable.comments.order(created_at: :desc)
-    @comment_total_count = @comments.size
-    @comments = @comments.limit(params[:comment_limit])
-                         .offset(params[:comment_offset])
+    if params[:commentable_type].present?
+      @comments = commentable.comments.order(created_at: :desc)
+      @comment_total_count = @comments.size
+      @comments = @comments.limit(params[:comment_limit])
+                           .offset(params[:comment_offset])
+    else
+      head :bad_request
+    end
   end
 
   def create

--- a/test/integration/api/comments_test.rb
+++ b/test/integration/api/comments_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::CommentsTest < ActionDispatch::IntegrationTest
+  fixtures :comments, :reports
+
+  test 'GET /api/comments.json?commentable_id=12168338' do
+    get api_comments_path(format: :json)
+    assert_response :unauthorized
+
+    token = create_token('machida', 'testtest')
+    get api_comments_path(format: :json, commentable_id: 12_168_338),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :bad_request
+  end
+end


### PR DESCRIPTION
## Issue
- [commentのAPIでエラー · Issue \#4407](https://github.com/fjordllc/bootcamp/issues/4407)

## 概要
- commentのAPIで`params[:commentable_type]`がnilの時にNoMethodErrorが出ないよう修正した。

## エラー再現方法
1. `main`ブランチで`bin/rails s`を実行し、ローカル環境を起動する。
1. 適当なuserでログインする。（例：kensyu）
1. 適当な日報にコメントを投稿する。
1. Chromeのデベロッパーツールを開いてネットワークタブをクリックし、一旦画面をリロード。
1. フィルターを削除し、`Fetch/XHR`を選択する。表示された`comments.json?~~~`で右クリックし、「コピー」→「fetchとしてコピー」を選択する。
<img width="1440" alt="1" src="https://user-images.githubusercontent.com/70277776/165553076-7ef11cbd-e378-4296-905b-bd01f41a74f2.png">

6. コンソールタブをクリックし、今コピーした物をペーストする。
1. 1行目の`http://127.0.0.1:3000/api/comments.json?commentable_type=Report&commentable_id=819157022&comment_limit=8&comment_offset=0`の部分をコピーし、ブラウザの新しいタブでアドレスバーに貼り付け、`commentable_type=Report&`を削除して実行する。
1. ブラウザに`NoMethodError`が表示され、ターミナルに`500 Internal Server Error`と`NoMethodError (undefined method `constantize' for nil:NilClass`が表示された。
![2](https://user-images.githubusercontent.com/70277776/165554909-1d68d6f7-3a50-4e18-ab58-005b9f4e2c5a.png)


## 修正確認方法
1. ブランチ `bug/error-in-comments-api` をローカルに取り込み、ローカル環境で起動する。
1. 上の「エラー再現方法」を実行する。
1. ターミナルに`Completed 400 Bad Request`が表示され、`NoMethodError`は出なくなった。
![3](https://user-images.githubusercontent.com/70277776/165556686-315639c9-eb1b-427f-bb7b-bdd95146d2f3.png)

