### PR TITLE
Fix test_show_inactive_users_only_to_mentors

### DIFF
--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -104,28 +104,7 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test 'show inactive users only to mentors' do
-    %i[
-      kimura
-      hatsuno
-      hajime
-      muryou
-      kensyu
-      kananashi
-      osnashi
-      jobseeker
-      daimyo
-      nippounashi
-      with_hyphen
-      discordinvalid
-      twitterinvalid
-      enchomaemae
-      enchomaeyo
-      enchohayashi
-      enchoososhi
-      enchoowata
-    ].each do |name|
-      users(name).touch # rubocop:disable Rails/SkipsModelValidations
-    end
+    User.inactive_students_and_trainees.each(&:touch)
 
     visit_with_auth '/', 'komagata'
     assert_no_text '1ヶ月以上ログインのないユーザー'


### PR DESCRIPTION
test/fixtures/users.yml に inactive なユーザーがいる場合に、テスト内の配列にそのユーザー名を追加しなくともテストが落ちないように修正しました