### PR TITLE
管理画面の企業一覧の企業名をリンクに置換

### DIFF
--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -24,7 +24,8 @@
           v-if='companies'
         )
           td.admin-table__item-value
-            | {{ company.name }}
+            a(:href='`/companies/${company.id}`')
+              | {{ company.name }}
           td.admin-table__item-value.is-text-align-center
             img.admin-table__item-logo-image(
               v-if='company.logo_url',

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -6,6 +6,7 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
   test 'show listing companies' do
     visit_with_auth '/admin/companies', 'komagata'
     assert_equal '管理ページ | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert has_link?(companies(:company1).name, href: company_path(companies(:company1)))
   end
 
   test 'create company' do


### PR DESCRIPTION
## issue
 - #4665 

管理画面の企業一覧の企業名をリンクに置き換えました。
リンクに指定している URL は`/companies/XXXXX` で、 admin でなくても見れる会社個別ページ です。

## 変更前

<img width="777" alt="note_md_—_fjord_note" src="https://user-images.githubusercontent.com/53898556/166113857-9086ebe0-f495-40f5-9014-eb82795af3e2.png">

## 変更後

<img width="817" alt="ページ編集___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/166113902-86a164d5-c868-40fb-86e8-6d3d2a66927f.png">

