### PR TITLE
js-choices-single-selectを使っている箇所において、Railsで渡したデータの並び順がJavaScriptに渡っても保持されるようにした。

### DIFF
--- a/app/javascript/choices-ui.js
+++ b/app/javascript/choices-ui.js
@@ -9,7 +9,8 @@ document.addEventListener('DOMContentLoaded', () => {
       searchResultLimit: 10,
       searchPlaceholderValue: '検索ワード',
       noResultsText: '一致する情報は見つかりません',
-      itemSelectText: '選択'
+      itemSelectText: '選択',
+      shouldSort: false
     })
   }
 

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -69,7 +69,7 @@ class QuestionsTest < ApplicationSystemTestCase
       fill_in 'question[title]', with: '質問者のコースにはないプラクティスの質問を編集できるかのテスト'
       fill_in 'question[description]', with: '編集できれば期待通りの動作'
       first('.choices__inner').click
-      find('#choices--js-choices-single-select-item-choice-52', text: 'iOSへのビルドと固有の問題').click
+      find('#choices--js-choices-single-select-item-choice-55', text: 'iOSへのビルドと固有の問題').click
       click_button '登録する'
     end
     assert_text '質問を作成しました。'


### PR DESCRIPTION
## 関連issue
- #4746 
  - #4385 
  - #4637 

## 概要
- `js-choices-single-select`を使っている箇所において、Railsで渡したデータの並び順が、JavaScriptに渡された際に破壊されていた。
- Railsで渡したデータの並び順を維持するため、`js-choices-single-select`の設定に、`shouldSort: false`を追加した。

## 変更点
現在、`js-choices-single-select`は、以下の3点で使用されている。
`js-choices-single-select`側で並び順が変更されないようにしたため、変更後はRails側で設定したデータの並び順になっている。

|  変更箇所  |  変更前の並び順  | 変更後の並び順  |
| ---- | ---- | ---- |
|  管理者でログイン時の、ユーザー情報変更ページの企業のセレクトボックス | ![image](https://user-images.githubusercontent.com/58052292/166201314-a8c86339-1351-4105-ae07-82c4b9e4ffda.png)     |`app/helpers/companies_helper.rb`の`all_companies_with_empty`メソッドの並び順![image](https://user-images.githubusercontent.com/58052292/166211529-8ecadfd9-2601-43d0-b3fc-3d474d8b204e.png)|
|  日報一覧の「プラクティスで絞り込む」のセレクトボックス  |[![Image from Gyazo](https://i.gyazo.com/ab4f1722351257a82b92ca666c772940.gif)](https://gyazo.com/ab4f1722351257aall_companies_with_empty82b92ca666c772940)    |並び順が`current_user.practices`[![Image from Gyazo](https://i.gyazo.com/98a640da8eee3678efb798a15f98020b.gif)](https://gyazo.com/98a640da8eee3678efb798a15f98020b)  |
| Q&A作成のプラクティス選択のセレクトボックス |[![Image from Gyazo](https://i.gyazo.com/2b9888875252828acc3b0f2267db8bb3.gif)](https://gyazo.com/2b9888875252828acc3b0f2267db8bb3)  | `app/helpers/reports_helper.rb`の`practice_options`メソッドの並び順[![Image from Gyazo](https://i.gyazo.com/ddf9e0298eeb0d650ad95ee76c3a481e.gif)](https://gyazo.com/ddf9e0298eeb0d650ad95ee76c3a481e)|



## 動作確認の手順
1. `bug/add-shouldSort`ブランチをローカルに持ってくる
2. `bin/setup`して`rails s`
3. `admin`でログイン
4. 以下3つの動作確認を行う

### 1. 管理者でログイン時の、ユーザー情報変更ページの企業のセレクトボックス
1. 任意のユーザーのプロフィールページにアクセス
2. 「管理者として情報変更」をクリック
4. 企業のセレクトボックスの項目を確認
5. ターミナルで`rails console`を立ち上げて、`Company.all.to_a.unshift(Company.new(name: '所属なし'))`を実行する。
6. 「所属企業なし」〜「DAIMYO Engineer College」までの並び順が、アプリとターミナルの出力とで同じか確認する

### 2. 日報一覧の「プラクティスで絞り込む」のセレクトボックス
1. 日報一覧ページ(`http://localhost:3000/reports`)にアクセス
2. タブ「全て」をクリック
3. ターミナルで`rails console`を立ち上げて、`User.find(ログインしたユーザーのid).practices`を実行
4. アプリのプラクティスで絞り込む」のセレクトボックスの並びと、ターミナルで出力されたプラクティスの並びが同じか確認する

### 3. Q&A作成のプラクティス選択のセレクトボックス
1. 左のサイドメニューの「Q&A」をクリック
2. 「＋質問する」をクリック
3. ターミナルで`rails console`を立ち上げて、以下を実行する
```ruby
categories =
      Category
      .eager_load(:practices)
      .where.not(practices: { id: nil })
      .order('categories.position ASC, categories_practices.position ASC')

categories.flat_map do |category|
  category.practices.map do |practice|
    ["[#{category.name}] #{practice.title}", practice.id]
  end
end
```
4. アプリのプラクティス選択の並び順と、ターミナルで出力されたプラクティスの並び順が同じか確認する。