### PR TITLE
企業一覧に研修生の招待リンクを追加

### DIFF
--- a/app/decorators/company_decorator.rb
+++ b/app/decorators/company_decorator.rb
@@ -12,4 +12,12 @@ module CompanyDecorator
       token: ENV['TOKEN'] || 'token'
     )
   end
+
+  def trainee_sign_up_url
+    new_user_url(
+      role: 'trainee',
+      company_id: id,
+      token: ENV['TOKEN'] || 'token'
+    )
+  end
 end

--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -14,6 +14,8 @@
             | ウェブサイト
           th.admin-table__label.actions
             | アドバイザー招待
+          th
+            | 研修生招待リンク
           th.admin-table__label.actions
             | 編集
       tbody.admin-table__items
@@ -39,6 +41,11 @@
               :href='company.adviser_sign_up_url'
             )
               i.fa-solid.fa-user-plus
+          td
+            a(
+              :title='"研修生サインアップURL"',
+              :href='company.trainee_sign_up_url'
+            )
           td.admin-table__item-value.is-text-align-center
             ul.is-inline-buttons
               li

--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -14,7 +14,7 @@
             | ウェブサイト
           th.admin-table__label.actions
             | アドバイザー招待
-          th
+          th.admin-table__label.actions
             | 研修生招待リンク
           th.admin-table__label.actions
             | 編集
@@ -41,8 +41,12 @@
               :href='company.adviser_sign_up_url'
             )
               i.fa-solid.fa-user-plus
-          td
-            a(:title='"研修生サインアップURL"', :href='company.trainee_sign_up_url')
+          td.admin-table__item-value.is-text-align-center
+            a.a-button.is-sm.is-secondary.is-icon(
+              :title='"研修生サインアップURL"',
+              :href='company.trainee_sign_up_url'
+            )
+              i.fa-solid.fa-user-plus
           td.admin-table__item-value.is-text-align-center
             ul.is-inline-buttons
               li

--- a/app/javascript/admin_companies.vue
+++ b/app/javascript/admin_companies.vue
@@ -42,10 +42,7 @@
             )
               i.fa-solid.fa-user-plus
           td
-            a(
-              :title='"研修生サインアップURL"',
-              :href='company.trainee_sign_up_url'
-            )
+            a(:title='"研修生サインアップURL"', :href='company.trainee_sign_up_url')
           td.admin-table__item-value.is-text-align-center
             ul.is-inline-buttons
               li

--- a/app/views/api/admin/companies/_company.json.jbuilder
+++ b/app/views/api/admin/companies/_company.json.jbuilder
@@ -5,3 +5,4 @@ json.description company.description
 json.website company.website
 json.blog_url company.blog_url
 json.adviser_sign_up_url company.adviser_sign_up_url
+json.trainee_sign_up_url company.trainee_sign_up_url

--- a/test/decorators/company_decorator_test.rb
+++ b/test/decorators/company_decorator_test.rb
@@ -14,4 +14,9 @@ class CompanyDecoratorTest < ActiveSupport::TestCase
     expected = "http://test.host/users/new?company_id=#{@company1.id}&role=adviser&token=token"
     assert_equal expected, @company1.adviser_sign_up_url
   end
+
+  test '#trainee_sign_up_url' do
+    expected = "http://test.host/users/new?company_id=#{@company1.id}&role=trainee&token=token"
+    assert_equal expected, @company1.trainee_sign_up_url
+  end
 end


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/4611

## 概要・要件
管理ページの企業タブに研修生招待リンクを追加しました。

## 変更前
![image](https://user-images.githubusercontent.com/47073105/168828596-693fd079-949a-4aa2-976e-199ae4f936a3.png)
## 変更後
![image](https://user-images.githubusercontent.com/47073105/170054513-28782f94-8a7c-4ea3-9148-6322e9caa32b.png)
### 参加登録ページ（研修生招待リンクをクリック後）
- 「所属企業」で対象の企業名が選択済み
![貼り付けた画像_2022_06_05_18_59](https://user-images.githubusercontent.com/47073105/172045290-a0bee634-4a22-4853-b104-6e8e1f5b988d.png)

![貼り付けた画像_2022_06_05_19_05](https://user-images.githubusercontent.com/47073105/172045477-2ea740f5-d922-445d-9a4b-a232a3c40229.png)


- 「特殊ユーザー属性」の「研修生」にチェック済み
![貼り付けた画像_2022_06_05_19_02](https://user-images.githubusercontent.com/47073105/172045324-bc2b36f3-2e1f-42e3-b391-1dd97212f34a.png)

## 確認方法
1. feature/add-trainees-invitation-link-to-admin-companiesをローカルに取り込む
1. bin/rails sでサーバーを立ち上げる
1. 管理者ロールのユーザー(komagataかmachida)でログイン
1. `http://localhost:3000/admin/companies`にアクセスする
1. 「研修生招待リンク」のいずれかをクリックする

## 確認内容
- `/admin/companies`に「研修生招待リンク」列が表示されている
- 「研修生招待リンク」のいずれかをクリックすると「フィヨルドブートキャンプ参加登録」ページが表示される
- 「フィヨルドブートキャンプ参加登録」ページで以下のように設定されている
    - 「所属企業」で対象の企業名が選択済み
    - 「特殊ユーザー属性」の「研修生」にチェックが入っている