### PR TITLE
ブログ投稿・修正時に投稿者を選べるようにした

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -26,7 +26,7 @@ class ArticlesController < ApplicationController
 
   def create
     @article = Article.new(article_params)
-    @article.user = current_user
+    @article.user = current_user if @article.user.nil?
     set_wip_or_published_time
     if @article.save
       redirect_to redirect_url(@article), notice: notice_message(@article)
@@ -61,7 +61,7 @@ class ArticlesController < ApplicationController
   end
 
   def article_params
-    params.require(:article).permit(:title, :body, :tag_list)
+    params.require(:article).permit(:title, :body, :tag_list, :user_id)
   end
 
   def redirect_url(article)

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ArticlesHelper
+  def contributor
+    User.admins.or(User.mentor).pluck(:login_name, :id).sort
+  end
+end

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -9,7 +9,7 @@
         .col-md-3.col-xs-6
           = f.label :user, class: 'a-form-label'
           .select-users
-            = f.select(:user_id, User.admins.or(User.mentor).pluck(:login_name, :id).sort, { include_blank: (article.user || current_user).login_name }, { id: 'js-choices-single-select' })
+            = f.select(:user_id, contributor, { include_blank: (article.user || current_user).login_name }, { id: 'js-choices-single-select' })
 
     .form-item
       .row.js-markdown-parent

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -3,10 +3,13 @@
   .form__items
     .form-item
       .row
-        .col-lg-9.col-xs-12
-          .form-item
-            = f.label :title, class: 'a-form-label'
-            = f.text_field :title, class: 'a-text-input js-warning-form'
+        .col-md-6.col-xs-12
+          = f.label :title, class: 'a-form-label'
+          = f.text_field :title, class: 'a-text-input js-warning-form'
+        .col-md-3.col-xs-6
+          = f.label :user, class: 'a-form-label'
+          .select-users
+            = f.select(:user_id, User.admins.or(User.mentor).pluck(:login_name, :id).sort, { include_blank: (article.user || current_user).login_name }, { id: 'js-choices-single-select' })
 
     .form-item
       .row.js-markdown-parent

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -159,6 +159,7 @@ ja:
       article:
         title: タイトル
         body: 本文
+        user: ユーザー
       work:
         title: タイトル
         description: 説明

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -201,4 +201,29 @@ class ArticlesTest < ApplicationSystemTestCase
 
     assert_no_text @article.title
   end
+
+  test 'can select a contributor and create the article' do
+    visit_with_auth new_article_path, 'komagata'
+
+    fill_in 'article[title]', with: @article.title
+    fill_in 'article[body]', with: @article.body
+    find('.choices__inner').click
+    find('#choices--js-choices-single-select-item-choice-6', text: 'mentormentaro').click
+    click_on '登録する'
+
+    assert_text '記事を作成しました'
+    assert_text 'mentormentaro'
+  end
+
+  test 'can select a contributor and edit the article' do
+    visit_with_auth edit_article_path(@article), 'mentormentaro'
+    assert_text 'komagata'
+
+    find('.choices__inner').click
+    find('#choices--js-choices-single-select-item-choice-6', text: 'mentormentaro').click
+    click_on '更新する'
+
+    assert_text '記事を更新しました'
+    assert_text 'mentormentaro'
+  end
 end


### PR DESCRIPTION
## Issue
- #4513

## 概要
[Choices.js](https://choices-js.github.io/Choices/)を使用し、ブログの投稿・修正時に投稿者を選べるようにしました。

選択可能な投稿者は **管理者・メンターのみ** です。（[machidaさんへ確認済み](https://github.com/fjordllc/bootcamp/issues/4513#issuecomment-1115039719)）

## 変更確認方法
1. ブランチ`feature/select-contributor-when-posting-or-modifying-blogs`をローカルに取り込む
2. `rails server`でローカル環境を立ち上げる
3. 管理者orメンターでログインし、ブログ投稿・修正時に投稿者を選べることを確認

## ブログ記事作成
- ブログ記事の作成ページ( `/articles/new` )にアクセスし、ユーザーのセレクトボックスから投稿者を選ぶ
※投稿者を選ばない場合、元の仕様の通りカレントユーザーが投稿者になります。

## 変更前
<img width="1325" alt="2022-05-04-01" src="https://user-images.githubusercontent.com/60736158/166678973-3e5f221e-dc36-4981-8d68-23786554bdb0.png">

## 変更後
<img width="1325" alt="2022-05-04-02" src="https://user-images.githubusercontent.com/60736158/166678955-d99ed981-2834-489c-ba91-969b712df3c8.png">

## ブログ記事編集
- ブログ記事の編集ページ( `/articles/:id/edit` )にアクセスし、ユーザーのセレクトボックスから投稿者を選ぶ

### 変更前
<img width="1326" alt="2022-05-04-03" src="https://user-images.githubusercontent.com/60736158/166680216-52821379-2533-4ea7-824a-bba08e00c1d2.png">

### 変更後
<img width="1325" alt="2022-05-04-04" src="https://user-images.githubusercontent.com/60736158/166680189-c01a5905-8a3a-4676-8e42-b7f5b7fd58af.png">
