### PR TITLE
【メンター向け】未確認の日報の件数をDiscordに通知する

### DIFF
--- a/app/controllers/api/reports/unchecked_controller.rb
+++ b/app/controllers/api/reports/unchecked_controller.rb
@@ -5,4 +5,10 @@ class API::Reports::UncheckedController < API::BaseController
   def index
     @reports = Report.unchecked.not_wip.list.page(params[:page])
   end
+
+  def counts
+    @reports = Report
+               .unchecked
+               .not_wip
+  end
 end

--- a/app/views/api/reports/unchecked/counts.text.erb
+++ b/app/views/api/reports/unchecked/counts.text.erb
@@ -1,0 +1,4 @@
+未確認の日報の数をお知らせします。
+https://bootcamp.fjord.jp/reports/unchecked
+
+- <%= @reports.count %>件

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -40,7 +40,9 @@ Rails.application.routes.draw do
     end
     resources :reports, only: %i(index)
     namespace "reports" do
-      resources :unchecked, only: %i(index)
+      resources :unchecked, only: %i(index) do
+        get 'counts', on: :collection
+      end
       resources :recents, only: %i(index)
     end
     resources :watches, only: %i(index)

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
-  fixtures :products
+  fixtures :reports
 
   test 'GET /api/reports/unchecked/counts.txt' do
     get counts_api_reports_unchecked_index_path(format: :text)

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
+  fixtures :products
+
+  test 'GET /api/reports/unchecked/counts.txt' do
+    get counts_api_reports_unchecked_index_path(format: :text)
+    assert_response :unauthorized
+
+    token = create_token('komagata', 'testtest')
+    get counts_api_reports_unchecked_index_path(format: :text),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+    assert_match '63件', response.body
+  end
+end

--- a/test/integration/api/reports_test.rb
+++ b/test/integration/api/reports_test.rb
@@ -35,15 +35,4 @@ class API::ReportsTest < ActionDispatch::IntegrationTest
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
   end
-
-  test 'GET /api/reports/unchecked/counts.txt' do
-    get counts_api_reports_unchecked_index_path(format: :text)
-    assert_response :unauthorized
-
-    token = create_token('komagata', 'testtest')
-    get counts_api_reports_unchecked_index_path(format: :text),
-        headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :ok
-    assert_match '63件', response.body
-  end
 end

--- a/test/integration/api/reports_test.rb
+++ b/test/integration/api/reports_test.rb
@@ -35,4 +35,15 @@ class API::ReportsTest < ActionDispatch::IntegrationTest
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
   end
+
+  test 'GET /api/reports/unchecked/counts.txt' do
+    get counts_api_reports_unchecked_index_path(format: :text)
+    assert_response :unauthorized
+
+    token = create_token('komagata', 'testtest')
+    get counts_api_reports_unchecked_index_path(format: :text),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+    assert_match '63件', response.body
+  end
 end


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/4716
  - 参考) [担当者が決まってない提出物（未アサイン）の数をテキストで表示する #4136](https://github.com/fjordllc/bootcamp/pull/4136/files)

## 概要

- 「未確認の日報の件数」をDiscordのメンターチャンネル（非公開）に通知するための、テキスト取得apiです。
- 「未チェックの日報」画面（メンター/管理者用）は http://127.0.0.1:3000/reports/unchecked です。

## 追加内容

### 管理者、メンター、アドバイザー権限で「未チェックの日報」画面にアクセスした場合
![image](https://user-images.githubusercontent.com/770527/166685868-7fca7647-5cc1-47a2-82b1-1d80629af790.png)

### 管理者、メンター、アドバイザー権限でAPIにアクセスした場合
![image](https://user-images.githubusercontent.com/770527/166674927-f1d708e6-6661-4420-85eb-21d92908d720.png)

### 管理者、メンター、アドバイザー権限以外でAPIにアクセスした場合
![image](https://user-images.githubusercontent.com/770527/166675429-af1123c2-82c6-48fa-a358-65ad9414a49c.png)

## 確認手順

1. ブランチ `feature/notify-discord-of-the-number-of-unconfirmed-daily-reports` をローカルに取り込む
2. `bin/rails s`でサーバーを立ち上げる
3. `komagata` でログインし、「日報」→「未チェックの日報」画面を開いて未チェックの件数を確認する。
4. ブラウザで http://127.0.0.1:3000/api/reports/unchecked/counts.txt にアクセスし、テキストに表示された「未確認の日報の数」が確認手順3の件数と同じであることを確認する。
