### PR TITLE
すべてのissueをstalebotの処理対象とする

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,5 @@ jobs:
           close-issue-message: 'このissue|PRはstaleラベルを付けた後7日間更新がないためcloseしました。'
           days-before-stale: 60
           days-before-close: 7
-          exempt-issue-labels: "pinned,security,release,bug,バグ"
           stale-issue-label: stale
           debug-only: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
古い「バグ」も特に支障なく運用できているなら自動的にcloseしても問題なさそう。
releaseタグはさすがに60日も放置されなさそう。
それ以外のタグはほとんど使われてなさそう。
万一、対応が必要なissueがあれば、それは他のissueと同様に手作業でstaleラベルを外せば良さそう。
ということで、issueの件数を減らすためにすべてのissueをstalebotの処理対象にするのはどうでしょう？

関連PR: https://github.com/fjordllc/bootcamp/pull/4362