### PR TITLE
企業一覧のリンクを企業詳細ページに追加

### DIFF
--- a/app/views/companies/show.html.slim
+++ b/app/views/companies/show.html.slim
@@ -5,6 +5,11 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         = @company.name
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to companies_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | 企業一覧
 
 = render 'companies/tabs', company: @company
 

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -26,11 +26,4 @@ class CompaniesTest < ApplicationSystemTestCase
       assert_link 'Techブログ', href: 'https://tech.sample.com'
     end
   end
-
-  test 'show link to companies list page' do
-    visit_with_auth "/companies/#{companies(:company1).id}", 'komagata'
-    within '.page-header-actions__item' do
-      assert_link '企業一覧', href: companies_path
-    end
-  end
 end

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -26,4 +26,11 @@ class CompaniesTest < ApplicationSystemTestCase
       assert_link 'Techブログ', href: 'https://tech.sample.com'
     end
   end
+
+  test 'show link to companies list page' do
+    visit_with_auth "/companies/#{companies(:company1).id}", 'komagata'
+    within '.page-header-actions__item' do
+      assert_link '企業一覧', href: companies_path
+    end
+  end
 end


### PR DESCRIPTION
## 概要
* 企業詳細のページから企業一覧ページに遷移するためのリンクを設置しました。
* デザインはプラクティス一覧ページの「コース一覧」と合わせています。
* https://github.com/fjordllc/bootcamp/issues/4768  こちらのissueの対応です。
## UI

### 変更前（PC）
<img width="1431" alt="image" src="https://user-images.githubusercontent.com/20497053/167348040-766641ae-e6c1-4d8d-84a8-7ae2a6988f07.png">

### 変更前（SP）
<img width="421" alt="image" src="https://user-images.githubusercontent.com/20497053/167348318-9409c0f0-e10e-42cd-a5d0-5ec031c04f6a.png">

### 変更後（PC）
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/20497053/167347979-7e7f406a-06c4-4f82-ab85-147bdb8a58b4.png">


### 変更後（SP）
<img width="422" alt="image" src="https://user-images.githubusercontent.com/20497053/167347940-900b2770-50e0-40d1-a304-b5e307f15e93.png">


## 確認方法
1. ブランチ feature/add-link-to-company-index-page をローカルに取り込む
2. サーバーを立ち上げる
3. ログインする（管理者である必要はない画面なのでユーザーは問わない）
4. http://localhost:3000/companies にアクセスし、いくつかの企業詳細のページに遷移する

## テスト観点（PC,SP共に）
- [ ] 企業一覧ページにコンソールエラーなどの不具合がないこと
- [ ] 企業一覧ページに表示崩れがないこと
- [ ] 企業詳細ページにコンソールエラーなどの不具合がないこと
- [ ] 企業詳細ページに表示崩れがないこと
- [ ] 企業詳細ページから企業一覧ページに正しく遷移できること