### PR TITLE
登録日 - 卒業日の計算がマイナスの値の場合は卒業してからの日数を出さないようにする

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -70,4 +70,16 @@ module UserDecorator
   def long_name
     "#{login_name} (#{name})"
   end
+
+  def enrollment_period
+    if graduated?
+      if elapsed_days.positive?
+        tag.span(" (#{l graduated_on}卒業 #{elapsed_days}日) ") + tag.a("#{generation}期生", href: generation_path(generation))
+      else
+        tag.span(" (#{l graduated_on}卒業 ") + tag.a("#{generation}期生", href: generation_path(generation))
+      end
+    else
+      tag.span(" #{elapsed_days}日目 ") + tag.a("#{generation}期生", href: generation_path(generation))
+    end
+  end
 end

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -8,9 +8,13 @@
       .user-metas__item-value
         = l user.created_at.to_date
         - if user.graduated?
-          | &nbsp;(#{l user.graduated_on}卒業&nbsp;#{user.elapsed_days}日)&nbsp;
+          span
+            | &nbsp;#{l user.graduated_on}卒業
+          - if user.elapsed_days.positive?
+            span
+              | &nbsp;#{user.elapsed_days}日&nbsp;
           = link_to generation_path(user.generation)
-            | #{user.generation}期生
+            | &nbsp;#{user.generation}期生
         - else
           | &nbsp;#{user.elapsed_days}日目&nbsp;
           = link_to generation_path(user.generation)

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -7,19 +7,7 @@
         = User.human_attribute_name :created_at
       .user-metas__item-value
         = l user.created_at.to_date
-        - if user.graduated?
-          span
-            | &nbsp;(#{l user.graduated_on}卒業
-          - if user.elapsed_days.positive?
-            span
-              | &nbsp;#{user.elapsed_days}日
-          | )&nbsp;
-          = link_to generation_path(user.generation)
-            | #{user.generation}期生
-        - else
-          | &nbsp;#{user.elapsed_days}日目&nbsp;
-          = link_to generation_path(user.generation)
-            | #{user.generation}期生
+        = user.enrollment_period
     .user-metas__item
       .user-metas__item-label
         | 都道府県

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -9,12 +9,13 @@
         = l user.created_at.to_date
         - if user.graduated?
           span
-            | &nbsp;#{l user.graduated_on}卒業
+            | &nbsp;(#{l user.graduated_on}卒業
           - if user.elapsed_days.positive?
             span
-              | &nbsp;#{user.elapsed_days}日&nbsp;
+              | &nbsp;#{user.elapsed_days}日
+          | )&nbsp;
           = link_to generation_path(user.generation)
-            | &nbsp;#{user.generation}期生
+            | #{user.generation}期生
         - else
           | &nbsp;#{user.elapsed_days}日目&nbsp;
           = link_to generation_path(user.generation)

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -4,8 +4,10 @@ require 'test_helper'
 
 class UserDecoratorTest < ActiveSupport::TestCase
   def setup
+    ActiveDecorator::ViewContext.push(controller.view_context)
     @user1 = ActiveDecorator::Decorator.instance.decorate(users(:komagata))
     @user2 = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
+    @user3 =  ActiveDecorator::Decorator.instance.decorate(users(:sotugyou))
   end
 
   test 'staff_roles' do
@@ -20,5 +22,10 @@ class UserDecoratorTest < ActiveSupport::TestCase
 
   test 'long_name' do
     assert_equal 'hajime (Hajime Tayo)', @user2.long_name
+  end
+
+  test 'enrollment_period' do
+    assert_equal '<span> 3070日目 </span><a href="/generations/5">5期生</a>', @user2.enrollment_period
+    assert_equal '<span> (2015年01月01日卒業 365日) </span><a href="/generations/5">5期生</a>', @user3.enrollment_period
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class UserDecoratorTest < ActiveSupport::TestCase
+  include ActionView::TestCase::Behavior
+
   def setup
     ActiveDecorator::ViewContext.push(controller.view_context)
     @user1 = ActiveDecorator::Decorator.instance.decorate(users(:komagata))

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -7,7 +7,7 @@ class UserDecoratorTest < ActiveSupport::TestCase
     ActiveDecorator::ViewContext.push(controller.view_context)
     @user1 = ActiveDecorator::Decorator.instance.decorate(users(:komagata))
     @user2 = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
-    @user3 =  ActiveDecorator::Decorator.instance.decorate(users(:sotugyou))
+    @user3 = ActiveDecorator::Decorator.instance.decorate(users(:sotugyou))
   end
 
   test 'staff_roles' do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -323,7 +323,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_text '卒業 1日'
   end
 
-  test 'if the number of days it took to graduate is negative, the value is not be displayed.' do
+  test 'if the number of days it took to graduate is negative, the value is not displayed.' do
     user = users(:sotugyou)
     user.update!(created_at: Time.zone.today, graduated_on: Time.zone.today - 1, job: 'office_worker')
     visit_with_auth "/users/#{user.id}", 'sotugyou'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -318,14 +318,14 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'if the number of days it took to graduate is positive, the value is displayed.' do
     user = users(:sotugyou)
-    user.update!(created_at: Date.today - 1, graduated_on: Date.today, job: 'office_worker')
+    user.update!(created_at: Time.zone.today - 1, graduated_on: Time.zone.today, job: 'office_worker')
     visit_with_auth "/users/#{user.id}", 'sotugyou'
     assert_text '卒業 1日'
   end
 
   test 'if the number of days it took to graduate is negative, the value is not be displayed.' do
     user = users(:sotugyou)
-    user.update!(created_at: Date.today, graduated_on: Date.today - 1 , job: 'office_worker')
+    user.update!(created_at: Time.zone.today, graduated_on: Time.zone.today - 1, job: 'office_worker')
     visit_with_auth "/users/#{user.id}", 'sotugyou'
     assert_no_text '卒業 1日'
   end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -315,4 +315,18 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth user_path(user.id), 'kensyu'
     assert has_no_field?('user_training_ends_on')
   end
+
+  test 'if the number of days it took to graduate is positive, the value is displayed.' do
+    user = users(:sotugyou)
+    user.update!(created_at: Date.today - 1, graduated_on: Date.today, job: 'office_worker')
+    visit_with_auth "/users/#{user.id}", 'sotugyou'
+    assert_text '卒業 1日'
+  end
+
+  test 'if the number of days it took to graduate is negative, the value is not be displayed.' do
+    user = users(:sotugyou)
+    user.update!(created_at: Date.today, graduated_on: Date.today - 1 , job: 'office_worker')
+    visit_with_auth "/users/#{user.id}", 'sotugyou'
+    assert_no_text '卒業 1日'
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,6 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
-  include ActionView::TestCase::Behavior
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  include ActionView::TestCase::Behavior
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
## 概要
* 卒業日のデータが登録日よりも前の場合は、ユーザーの情報の表示で出している、X日という表示を出さないようにしました。
* https://github.com/fjordllc/bootcamp/issues/2832 のissueの対応です。
* 添付の赤枠の箇所の表示が変わります。
<img width="636" alt="スクリーンショット 2022-05-10 14 53 23" src="https://user-images.githubusercontent.com/20497053/167557881-8a4f6ef0-2de8-4acb-bb77-09c6d1b3db5e.png">

## UI（変更前）

### 卒業日付が登録日よりも前（PC）
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/20497053/167559513-fc71a03c-6130-4dd2-a4bb-c6bfea5f5da9.png">

### 卒業日付が登録日よりも前（SP）
<img width="432" alt="image" src="https://user-images.githubusercontent.com/20497053/167559452-71d1aaa7-a743-47fb-b723-32a21b6c0c55.png">

### 卒業日付が登録日よりも後（PC）
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/20497053/167560064-70dcb9bf-652a-490c-aa95-f5cd0a29c542.png">

### 卒業日付が登録日よりも後（SP）
<img width="442" alt="image" src="https://user-images.githubusercontent.com/20497053/167560157-42266500-d2de-4439-b38e-28d33ba3102e.png">

## UI（変更後）
### 卒業日付が登録日よりも前（PC）
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/20497053/167558881-41f34a84-dff5-4c8b-b456-d06a1a793642.png">

### 卒業日付が登録日よりも前（SP）
<img width="438" alt="image" src="https://user-images.githubusercontent.com/20497053/167558975-ba4464d4-a02b-4ed2-9fd6-8d6422843399.png">

### 卒業日付が登録日よりも後（PC）
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/20497053/167560770-c6ec8184-d9e2-4e9c-8c6a-9eb164007dc5.png">

### 卒業日付が登録日よりも後（SP）
<img width="435" alt="image" src="https://user-images.githubusercontent.com/20497053/167560545-2a27d604-ab2d-4ca9-bb07-77a0478b53e1.png">

## 確認方法
- ブランチ bug/fix-negative-value-display をローカルに取り込む
- サーバーを立ち上げる
- ログインする（管理者である必要はない画面なのでユーザーは問わない）
- Railsコンソールを立ち上げ、卒業ユーザーの情報を以下の手順で書き換える
    - 後で戻すために、元のデータは復旧できるようにメモしておいた方がいいかも（created_at, updated_at, graduated_onあたり）
    - データ変更の過程で[http://localhost:3000/current_user/edit](http://localhost:3000/current_user/edit) にもアクセスする必要がある
- `user = User.find(609827778)`
↑
この間で、以下に添付する画面で職業を選択して更新しておく（そうしないとバリデーションに引っかかる）
↓
-  `user.update!(graduated_on: Date.today - 3650)`  # この操作によって卒業日をだいたい10年前に設定する
<img width="1348" alt="image" src="https://user-images.githubusercontent.com/20497053/167561826-a05248ff-d50c-4737-9184-f12ecbd3fd60.png">


## テスト観点
- [x] 対象のページにコンソールエラーなどの不具合がないこと
- [x] 対象のページに表示崩れがないこと
- [x] 卒業したユーザーの卒業日が登録日と比べてマイナスになる時には、登録してからの日数が表示されない
- [x] 卒業したユーザーの卒業日が登録日と比べてマイナスではない時には、登録してからの日数が表示される
- [x] 登録してからの日数が表示されない場合 2021年07月06日 (2022年03月20日卒業) [35期生](https://bootcamp.fjord.jp/generations/35) のように表示される
- [x] 登録してからの日数が表示される場合 2021年07月06日 (2022年03月20日卒業 257日) [35期生](https://bootcamp.fjord.jp/generations/35) のように表示される