### PR TITLE
日報個別ページに名前を表示

### DIFF
--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -37,8 +37,8 @@ header.page-header
             .page-content-header__end
               .page-content-header__row
                 .page-content-header__before-title
-                  = link_to @report.user, class: 'a-user-name', title: @report.user.name do
-                    = @report.user.login_name
+                  = link_to @report.user, class: 'a-user-name' do
+                    = @report.user.long_name
                 h1.page-content-header__title(class="#{@report.wip? ? 'is-wip' : ''}")
                   - if @report.emotion.present?
                     span.page-content-header__emotion


### PR DESCRIPTION
## Issue

- #4718

## 概要

日報個別ページに、日報作成者のIDだけでなく、名前も表示しました。
また、もとのコードでは、日報作成者のIDにマウスオーバーすると名前が**ポップアップする**実装になっていました。提出物やQ&A、Docsなどの個別ページに合わせ、**ポップアップなし**の実装に変更しました。

## 変更確認方法

1. ブランチ`feature/display-name-on-daily-report-page`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意の日報個別ページで作成者の名前を確認

## 変更前

![Cursor_と__development__今日は頑張りました___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOEdqQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--0b24d0f306dbe08814fd762b5358a5049610344e/Cursor_%E3%81%A8__development__%E4%BB%8A%E6%97%A5%E3%81%AF%E9%A0%91%E5%BC%B5%E3%82%8A%E3%81%BE%E3%81%97%E3%81%9F___FJORD_BOOT_CAMP%EF%BC%88%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%EF%BC%89.png)

<img width="1051" alt="スクリーンショット 2022-05-10 21 42 37" src="https://user-images.githubusercontent.com/53898556/167630936-2471df9d-12a1-4bf6-8190-dec1cb2bc2eb.png">

## 変更後

<img width="1285" alt="Cursor_と__development__今日は頑張りました___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/167625971-7f211fef-cd40-4a5c-886c-68c86f7331e7.png">

<img width="1060" alt="Cursor_と__development__今日は頑張りました___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/167628681-4d623ccd-bd6c-4bca-a9f1-4ed31152fc12.png">