### PR TITLE
相談部屋詳細画面で発生していたN+1を解消

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -32,6 +32,8 @@ class TalksController < ApplicationController
   end
 
   def set_members
-    @members = User.where(id: [@talk.user_id] + User.admins.pluck(:id)).order(:id)
+    @members = User.where(id: User.admins.ids.push(@talk.user_id))
+                   .eager_load([:company, { avatar_attachment: :blob }])
+                   .order(:id)
   end
 end


### PR DESCRIPTION
関連先のレコードが多くないのでeager_loadで対応し、SQL発行回数が少なく済むようにしました。