### PR TITLE
担当通知のabstract_notifier対応

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -232,17 +232,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def assigned_as_checker(product, receiver)
-      Notification.create!(
-        kind: 16,
-        user: receiver,
-        sender: product.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(product),
-        message: "#{product.user.login_name}さんの提出物#{product.title}の担当になりました。",
-        read: false
-      )
-    end
-
     def product_update(product, receiver)
       Notification.create!(
         kind: 17,

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -176,7 +176,7 @@ class NotificationFacade
   end
 
   def self.assigned_as_checker(product, receiver)
-    Notification.assigned_as_checker(product, receiver)
+    ActivityNotifier.with(product: product, receiver: receiver).assigned_as_checker.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -40,7 +40,7 @@ class ActivityNotifier < ApplicationNotifier
     receiver = params[:receiver]
 
     notification(
-      body: "#{product.user.login_name}さんの提出物#{product.title}の担当になりました。!",
+      body: "#{product.user.login_name}さんの提出物#{product.title}の担当になりました。",
       kind: :assigned_as_checker,
       sender: product.sender,
       receiver: receiver,

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -33,4 +33,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def assigned_as_checker(params = {})
+    params.merge!(@params)
+    product = params[:product]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{product.user.login_name}さんの提出物#{product.title}の担当になりました。!",
+      kind: :assigned_as_checker,
+      sender: product.sender,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(product),
+      read: false
+    )
+  end
 end

--- a/test/system/notification/assigned_as_checker_test.rb
+++ b/test/system/notification/assigned_as_checker_test.rb
@@ -13,14 +13,28 @@ class Notification::AssignedAsCheckerTest < ApplicationSystemTestCase
   end
 
   test 'notify mentor when assigned as checker' do
-    visit_with_auth "/products/#{products(:product11).id}/edit", 'komagata'
-    select 'mentormentaro', from: 'product_checker_id'
+    visit_with_auth "/products/#{products(:product1).id}/edit", 'komagata'
+    select 'machida', from: 'product_checker_id'
     click_button '提出する'
     logout
 
-    visit_with_auth '/notifications', 'mentormentaro'
+    visit_with_auth '/notifications', 'machida'
     within first('.card-list-item.is-unread') do
-      assert_text "hatsunoさんの提出物「#{products(:product11).practice.title}」の提出物の担当になりました。"
+      assert_text "mentormentaroさんの提出物「#{products(:product1).practice.title}」の提出物の担当になりました。"
     end
+
+    last_mail = ActionMailer::Base.deliveries.last
+    assert_equal "[bootcamp] mentormentaroさんの提出物#{products(:product1).title}の担当になりました。", last_mail.subject
+  end
+
+  test 'not notice self assigned as checker' do
+    visit_with_auth "/products/#{products(:product1).id}", 'komagata'
+    click_link '内容修正'
+    select 'komagata', from: 'product_checker_id'
+    click_button '提出する'
+    assert_text '担当から外れる'
+
+    visit_with_auth '/notifications?status=unread', 'komagata'
+    assert_no_text "mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
   end
 end

--- a/test/system/notification/assigned_as_checker_test.rb
+++ b/test/system/notification/assigned_as_checker_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Notification::AssignedAsCheckerTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
+  test 'notify mentor when assigned as checker' do
+    visit_with_auth "/products/#{products(:product11).id}/edit", 'komagata'
+    select 'mentormentaro', from: 'product_checker_id'
+    click_button '提出する'
+    logout
+
+    visit_with_auth '/notifications', 'mentormentaro'
+    within first('.card-list-item.is-unread') do
+      assert_text "hatsunoさんの提出物「#{products(:product11).practice.title}」の提出物の担当になりました。"
+    end
+  end
+end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -284,36 +284,6 @@ class NotificationsTest < ApplicationSystemTestCase
     assert_text 'コメントのテスト通知'
   end
 
-  test 'notice another mentor assigned as checker' do
-    visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    click_link '内容修正'
-    select 'machida', from: 'product_checker_id'
-    perform_enqueued_jobs do
-      assert_difference -> { Notification.count }, 1 do
-        click_button '提出する'
-        assert_text '提出物を更新しました'
-        assert_text 'machida'
-      end
-    end
-
-    visit_with_auth '/notifications?status=unread', 'machida'
-    assert_text "mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
-
-    last_mail = ActionMailer::Base.deliveries.last
-    assert_equal "[bootcamp] mentormentaroさんの提出物#{products(:product1).title}の担当になりました。", last_mail.subject
-  end
-
-  test 'not notice self assigned as checker' do
-    visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    click_link '内容修正'
-    select 'komagata', from: 'product_checker_id'
-    click_button '提出する'
-    assert_text '担当から外れる'
-
-    visit_with_auth '/notifications?status=unread', 'komagata'
-    assert_no_text "mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
-  end
-
   test 'show the number of unread mentions on the badge of the mentioned tab' do
     user = users(:kimura)
     expected_number_of_unread_mentions = user.notifications.by_target(:mention).unreads.latest_of_each_link.size


### PR DESCRIPTION
# Issue
- https://github.com/fjordllc/bootcamp/issues/4681

# 概要

- 提出物の担当通知の実装を、[abstract_notifier](https://github.com/palkan/abstract_notifier)に置き換えました。
- 実装方針については、[卒業の通知](https://github.com/fjordllc/bootcamp/pull/4673)を参考にしています。
- テストについては、abstract_notifierによる動作に対応（`AbstractNotifier.delivery_mode = :normal`）させるため、既存の`test/system/notifications_test.rb` に書かれていたものを、今回追加した`test/system/notification/assigned_as_checker_test.rb` に移設しました。

# 確認手順

提出物の担当通知は、以下の流れで動作しています。
但し、本実装（abstract_notifier対応）による画面上の変更点はありません。

管理者でログインし、担当者がアサインされていない提出物を選択する。
![image](https://user-images.githubusercontent.com/770527/169959889-eae6e0bd-7c22-44e2-96d8-45517ff6597c.png)

選択した提出物の編集画面で、担当者（machida）を指定し「提出する」で保存する。
![image](https://user-images.githubusercontent.com/770527/169960311-3ae90286-6928-481b-8704-80d75ca28859.png)

提出物の担当者（machida）が決定する。
![image](https://user-images.githubusercontent.com/770527/169960379-fdec98a2-8c6b-4c8e-b299-6198bae3fbd6.png)

担当者（machida）でログイン。通知に担当者としてアサインされたことが表示される。
![image](https://user-images.githubusercontent.com/770527/169960585-a009582b-9131-40d6-be5f-602c3d876ab2.png)

 担当者（machida）宛に通知がメール送信される。
![image](https://user-images.githubusercontent.com/770527/169960795-2741be29-caa3-4ed7-b461-f66e2d86e9ae.png)
