### PR TITLE
相談部屋のボタンを削除しタブを設置した

### DIFF
--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -23,3 +23,7 @@
       li.page-tabs__item
         = link_to user_answers_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('answers')}" do
           | 回答（#{user.answers.length}）
+      - if current_user.admin && !@user.admin
+        li.page-tabs__item
+          = link_to talk_path(@user.talk), class: "page-tabs__item-link #{current_page_tab_or_not('talks')} " do
+            | 相談部屋

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -6,10 +6,6 @@ header.page-header
         = title
       .page-header-actions
         ul.page-header-actions__items
-          - if current_user.admin && !@user.admin
-            li.page-header-actions__item.is-only-mentor
-              = link_to talk_path(@user.talk), class: 'a-button is-md is-secondary is-block' do
-                | 相談部屋
           - if current_user == @user
             li.page-header-actions__item
               = link_to edit_current_user_path, class: 'a-button is-md is-secondary is-block' do


### PR DESCRIPTION
## 関連issue
- #4155

## 概要・要件
各ユーザーのダッシュボードのページにて、管理者のみ表示されている相談部屋のボタンを削除し、タブを設置した。相談部屋のタブを押すと、ユーザーの相談部屋に遷移する。ボタンからタブに位置を変更しただけなので、遷移先の変更などはない。

相談部屋のボタンのテスト（`/test/system/users_test.rb`の`show link to talk room when logined as admin`）が使用できたため、テストは書いていない。

## 変更前
<img width="1000" src="https://user-images.githubusercontent.com/168265/160862135-5c9fbad1-31aa-4a57-90b0-9a8f1193b524.png">

## 変更後
<img width="1000" src="https://user-images.githubusercontent.com/49633473/168492258-923ca6e8-5443-4e68-86f7-4bf0ad060220.png">

## 相談部屋のタブの確認方法
1. `feature/change-the-position-of-the-link-for-the-user-talk-room-on-the-admin-page`をローカルに取り込む
1. `bin/rails s`でサーバーを立ち上げる
1. 管理者ロールのユーザー(`komagata`か`machida`)でログイン
1. ユーザーkimuraのページ（ユーザー個別ページ）に行く
1. 相談部屋のタブがあること、相談部屋のボタンが削除されていることを確認
2. ボタンを押してkimuraの相談部屋に遷移することを確認