### PR TITLE
会員登録、ユーザー編集の「学習に使うマシン・OS」のプルダウンメニューをラジオボタンに置換

### DIFF
--- a/app/views/users/form/_os.html.slim
+++ b/app/views/users/form/_os.html.slim
@@ -4,19 +4,19 @@
     li.form-radio
       = f.radio_button :os, 'mac', id: 'mac', class: 'a-toggle-checkbox'
       label.form-radio__label(for='mac')
-        = t("activerecord.enums.user.os.mac")
+        = t('activerecord.enums.user.os.mac')
     li.form-radio
       = f.radio_button :os, 'mac_m1', id: 'mac_m1', class: 'a-toggle-checkbox'
       label.form-radio__label(for='mac_m1')
-        = t("activerecord.enums.user.os.mac_m1")
+        = t('activerecord.enums.user.os.mac_m1')
     li.form-radio
       = f.radio_button :os, 'linux', id: 'linux', class: 'a-toggle-checkbox'
       label.form-radio__label(for='linux')
-        = t("activerecord.enums.user.os.linux")
+        = t('activerecord.enums.user.os.linux')
     li.form-radio
       = f.radio_button :os, 'windows_wsl2', id: 'windows_wsl2', class: 'a-toggle-checkbox'
       label.form-radio__label(for='windows_wsl2')
-        = t("activerecord.enums.user.os.windows_wsl2")
+        = t('activerecord.enums.user.os.windows_wsl2')
 
   .a-form-help.is-important
     h2

--- a/app/views/users/form/_os.html.slim
+++ b/app/views/users/form/_os.html.slim
@@ -4,19 +4,19 @@
     li.form-radio
       = f.radio_button :os, 'mac', id: 'mac', class: 'a-toggle-checkbox'
       label.form-radio__label(for='mac')
-        | Mac(Intel)
+        = t("activerecord.enums.user.os.mac")
     li.form-radio
       = f.radio_button :os, 'mac_m1', id: 'mac_m1', class: 'a-toggle-checkbox'
       label.form-radio__label(for='mac_m1')
-        | Mac(M1 chip)
+        = t("activerecord.enums.user.os.mac_m1")
     li.form-radio
       = f.radio_button :os, 'linux', id: 'linux', class: 'a-toggle-checkbox'
       label.form-radio__label(for='linux')
-        | Linux
+        = t("activerecord.enums.user.os.linux")
     li.form-radio
       = f.radio_button :os, 'windows_wsl2', id: 'windows_wsl2', class: 'a-toggle-checkbox'
       label.form-radio__label(for='windows_wsl2')
-        | Windows(WSL2)
+        = t("activerecord.enums.user.os.windows_wsl2")
 
   .a-form-help.is-important
     h2

--- a/app/views/users/form/_os.html.slim
+++ b/app/views/users/form/_os.html.slim
@@ -1,8 +1,23 @@
 .form-item
   = f.label :os, '学習に使うマシン・OS', class: 'a-form-label is-required'
-  .a-button.is-md.is-secondary.is-select.is-block
-    - options = options_for_select(User.os.map { |k, _| [t("activerecord.enums.user.os.#{k}"), k] }, selected: f.object.os)
-    = f.select :os, options, include_blank: '- 選択してください -'
+  ul.form-item__radios
+    li.form-radio
+      = f.radio_button :os, 'mac', id: 'mac', class: 'a-toggle-checkbox'
+      label.form-radio__label(for='mac')
+        | Mac(Intel)
+    li.form-radio
+      = f.radio_button :os, 'mac_m1', id: 'mac_m1', class: 'a-toggle-checkbox'
+      label.form-radio__label(for='mac_m1')
+        | Mac(M1 chip)
+    li.form-radio
+      = f.radio_button :os, 'linux', id: 'linux', class: 'a-toggle-checkbox'
+      label.form-radio__label(for='linux')
+        | Linux
+    li.form-radio
+      = f.radio_button :os, 'windows_wsl2', id: 'windows_wsl2', class: 'a-toggle-checkbox'
+      label.form-radio__label(for='windows_wsl2')
+        | Windows(WSL2)
+
   .a-form-help.is-important
     h2
       | M1 Mac or Intel Mac

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -112,4 +112,16 @@ class CurrentUserTest < ApplicationSystemTestCase
     visit_with_auth '/current_user/edit', 'kimura'
     assert_no_text '所属なし'
   end
+
+  test 'update os' do
+    kimura = users(:kimura)
+    visit_with_auth '/current_user/edit', 'kimura'
+    find('label', text: 'Linux').click
+
+    click_on '更新する'
+    assert_text 'ユーザー情報を更新しました。'
+
+    visit_with_auth "/users/#{kimura.id}", 'komagata'
+    assert_text 'Linux'
+  end
 end

--- a/test/system/sign_up_test.rb
+++ b/test/system/sign_up_test.rb
@@ -23,7 +23,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password_confirmation]', with: 'testtest'
       fill_in 'user[after_graduation_hope]', with: '起業したいです'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       find('label', text: 'アンチハラスメントポリシーに同意').click
       find('label', text: '利用規約に同意').click
@@ -48,7 +48,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       find('label', text: 'アンチハラスメントポリシーに同意').click
       find('label', text: '利用規約に同意').click
@@ -73,7 +73,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       find('label', text: 'アンチハラスメントポリシーに同意').click
       find('label', text: '利用規約に同意').click
@@ -98,7 +98,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       find('label', text: 'アンチハラスメントポリシーに同意').click
       find('label', text: '利用規約に同意').click
@@ -148,7 +148,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       first('.choices__inner').click
       find('.choices__list--dropdown').click
@@ -183,7 +183,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       find('label', text: 'アンチハラスメントポリシーに同意').click
       find('label', text: '利用規約に同意').click
@@ -234,7 +234,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       first('.choices__inner').click
       find('.choices__list--dropdown').click
@@ -258,7 +258,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       find('label', text: 'アンチハラスメントポリシーに同意').click
       find('label', text: '利用規約に同意').click
@@ -286,7 +286,7 @@ class SignUpTest < ApplicationSystemTestCase
       fill_in 'user[password]', with: 'testtest'
       fill_in 'user[password_confirmation]', with: 'testtest'
       select '学生', from: 'user[job]'
-      select 'Mac(Intel)', from: 'user[os]'
+      find('label', text: 'Mac(Intel)').click
       select '未経験', from: 'user[experience]'
       find('label', text: 'アンチハラスメントポリシーに同意').click
       find('label', text: '利用規約に同意').click


### PR DESCRIPTION
## Issue

- #4771 

## 概要

会員登録画面、ユーザー編集画面にある「学習に使うマシン・OS」を選択するプルダウンメニューをラジオボタンに置き換えました。

## 変更確認方法

1. ブランチ`feature/replace-os-for-learning-pull-down-menu-to-radio-button`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `http://localhost:3000/users/new`にアクセスし、ラジオボタンを確認
4. `hajime`などの現役生ユーザーでログインする
6. `http://localhost:3000/current_user/edit`にアクセスし、ラジオボタンを確認
7. 任意のマシン・OSを選択して「更新する」を押す
8. 再び`http://localhost:3000/current_user/edit`にアクセスし、選択中のラジオボタンの位置で更新されていることを確認
9. 管理者ユーザーでログインする
10. 4でログインした現役生ユーザーのプロフィールページにアクセスし、「マシンのOS」が更新されていることを確認

## 変更前

![スクリーンショット 2022-05-13 14.01.48.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOVdrQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--4ffb8878697db8c122eecf8504bd6fe3282da790/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202022-05-13%2014.01.48.png)

## 変更後

![_development__フィヨルドブートキャンプ参加登録___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOUdsQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--a96447d63f7c58d87cc5b0909d64619860520ebe/_development__%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%E5%8F%82%E5%8A%A0%E7%99%BB%E9%8C%B2___FJORD_BOOT_CAMP%EF%BC%88%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%EF%BC%89.png)

## その他

実装やCSSの指定は、以下のお知らせ作成画面のフォームのラジオボタンを参考にしています。
https://github.com/fjordllc/bootcamp/blob/main/app/views/announcements/_form.html.slim

最終的にmachidaさんによるデザインが必要なPRとなります。