### PR TITLE
CC へのリンクに leading whitespace を追加

### DIFF
--- a/app/views/welcome/_coc_text.html.slim
+++ b/app/views/welcome/_coc_text.html.slim
@@ -98,7 +98,7 @@ p
   | のライセンス下で提供されます。
   br
   | This work is licensed under
-  = link_to 'https://creativecommons.org/licenses/by/4.0/deed.en', target: '_blank', rel: 'noopener' do
+  =< link_to 'https://creativecommons.org/licenses/by/4.0/deed.en', target: '_blank', rel: 'noopener' do
     | CC BY 4.0
 
 = image_tag 'cc.png', alt: 'CC BY 4.0', width: 120


### PR DESCRIPTION
文字がくっついちゃっていたのでスペースを入れるようにしました。

before 

![localhost_3000_coc](https://user-images.githubusercontent.com/7645585/169020296-1944b508-4fa5-4281-875f-2670908afa2c.png)

after

![localhost_3000_coc (1)](https://user-images.githubusercontent.com/7645585/169020315-70aa17e5-4565-411e-be28-caa3ff367613.png)
 