### PR TITLE
トップページの資本金金額を500万に修正

### DIFF
--- a/app/views/welcome/_administrator.slim
+++ b/app/views/welcome/_administrator.slim
@@ -27,7 +27,7 @@ section.welcome-section.is-administrator#administrator
               td 2007年12月7日
             tr
               th 資本金
-              td 50万円
+              td 500万円
             tr
               th URL
               td


### PR DESCRIPTION
## Issue

- #4788

## 概要

トップページの資本金金額を500万に修正しました。


## 変更確認方法

1. ブランチ`feature/correct-top-page-capital`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. http://localhost:3000/welcome の一番下の方を見る
4. 資本金金額が５０万から５００万に変更されている

## 変更前
<img width="824" alt="スクリーンショット 2022-05-19 15 32 00" src="https://user-images.githubusercontent.com/76685187/169226369-409e7d23-6f53-4063-ae60-a5e5255462ac.png">



## 変更後


<img width="824" alt="スクリーンショット 2022-05-19 15 34 42" src="https://user-images.githubusercontent.com/76685187/169226328-6bd7666d-694f-4ae2-81c0-e7c9f13a8071.png">

