### PR TITLE
ニコニコカレンダーアイコンの位置がおかしかったのを修正

### DIFF
--- a/app/assets/stylesheets/blocks/page-content/_page-content-header.sass
+++ b/app/assets/stylesheets/blocks/page-content/_page-content-header.sass
@@ -108,13 +108,15 @@
       font-size: .8125rem
 
 .page-content-header__emotion
-  +size(1.75rem)
-  min-width: 1.75rem
-  display: flex
+  display: inline-flex
+  vertical-align: middle
+  +position(relative, top -.125em)
+  +size(1em)
   +media-breakpoint-up(md)
+    font-size: 1.75rem
     margin-right: .375em
-    +position(relative, top .25em)
   +media-breakpoint-down(sm)
+    font-size: 1.25rem
     margin-right: .25em
 
 .page-content-header__emotion-image


### PR DESCRIPTION
@komagata すいません！バグを出してました🙇‍♂️ 修正したのでデプロイをお願いします🙏

修正前

<img width="826" alt="貼り付けた画像_2022_05_19_16_17" src="https://user-images.githubusercontent.com/168265/169233734-19ca0f76-fa2c-485e-821c-e383aad451c6.png">

修正後

<img width="942" alt="image" src="https://user-images.githubusercontent.com/168265/169232692-2839d179-5015-40c8-9bea-6adc747359fa.png">

<img width="942" alt="image" src="https://user-images.githubusercontent.com/168265/169232692-2839d179-5015-40c8-9bea-6adc747359fa.png">
