### PR TITLE
確認済みの日報をチェックした場合エラーメッセージを表示する

### DIFF
--- a/app/assets/stylesheets/modules/_toasts.sass
+++ b/app/assets/stylesheets/modules/_toasts.sass
@@ -248,3 +248,8 @@ $swal2-toast-footer-font-size: 0.8em !default
 
     &.swal2-hide
       animation: $swal2-toast-hide-animation
+
+    &.is-success
+      background: rgba($success, 0.9)
+    &.is-error
+      background: rgba($danger, 0.9)

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -11,12 +11,10 @@ class API::ChecksController < API::BaseController
 
   def create
     if checkable.checks.empty?
-      @check = Check.new(
+      @check = Check.create!(
         user: current_user,
         checkable: checkable
       )
-
-      @check.save!
       head :created
     else
       render json: { message: "この#{checkable.class.model_name.human}は確認済です。" }, status: :unprocessable_entity

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -19,7 +19,7 @@ class API::ChecksController < API::BaseController
       @check.save!
       render json: {}, status: :created
     else
-      render json: { message: "この日報は確認済です。" }, status: :unprocessable_entity
+      render json: { message: "この#{checkable.class.model_name.human}は確認済です。" }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -17,7 +17,7 @@ class API::ChecksController < API::BaseController
       )
 
       @check.save!
-      render json: {}, status: :created
+      head :created
     else
       render json: { message: "この#{checkable.class.model_name.human}は確認済です。" }, status: :unprocessable_entity
     end
@@ -25,7 +25,7 @@ class API::ChecksController < API::BaseController
 
   def destroy
     @check = Check.find(params[:id]).destroy
-    render json: {}, status: :ok
+    head :no_content
   end
 
   private

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -10,18 +10,22 @@ class API::ChecksController < API::BaseController
   end
 
   def create
-    @check = Check.new(
-      user: current_user,
-      checkable: checkable
-    )
+    if checkable.checks.empty?
+      @check = Check.new(
+        user: current_user,
+        checkable: checkable
+      )
 
-    @check.save!
-    head :created
+      @check.save!
+      render json: {}, status: :created
+    else
+      render json: { message: "この日報は確認済です。" }, status: :unprocessable_entity
+    end
   end
 
   def destroy
     @check = Check.find(params[:id]).destroy
-    head :no_content
+    render json: {}, status: :ok
   end
 
   private

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -35,12 +35,13 @@
 import 'whatwg-fetch'
 import ProductChecker from 'product_checker'
 import checkable from 'checkable.js'
+import toast from './toast'
 
 export default {
   components: {
     'product-checker': ProductChecker
   },
-  mixins: [checkable],
+  mixins: [checkable, toast],
   props: {
     checkableId: { type: Number, required: true },
     checkableType: { type: String, required: true },

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -26,7 +26,7 @@ export default {
             checkableType: checkableType
           })
           if (json.message) {
-            this.toast(json.message)
+            this.toast(json.message, 'error')
           }
         })
         .catch((error) => {

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -18,13 +18,17 @@ export default {
         body: JSON.stringify(params)
       })
         .then((response) => {
-          return response.json()
-        })
-        .then((json) => {
           this.$store.dispatch('setCheckable', {
             checkableId: checkableId,
             checkableType: checkableType
           })
+          if (!response.ok) {
+            return response.json()
+          } else {
+            return response
+          }
+        })
+        .then((json) => {
           if (json.message) {
             this.toast(json.message, 'error')
           }

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -17,11 +17,17 @@ export default {
         redirect: 'manual',
         body: JSON.stringify(params)
       })
-        .then(() => {
+        .then((response) => {
+          return response.json()
+        })
+        .then((json) => {
           this.$store.dispatch('setCheckable', {
             checkableId: checkableId,
             checkableType: checkableType
           })
+          if (json.message) {
+            this.toast(json.message)
+          }
         })
         .catch((error) => {
           console.warn(error)

--- a/app/javascript/toast.js
+++ b/app/javascript/toast.js
@@ -2,14 +2,15 @@ import Swal from 'sweetalert2'
 
 export default {
   methods: {
-    toast(title) {
+    toast(title, status = 'success') {
       Swal.fire({
         title: title,
         toast: true,
         position: 'top-end',
         showConfirmButton: false,
         timer: 3000,
-        timerProgressBar: true
+        timerProgressBar: true,
+        customClass: { popup: `is-${status}` }
       })
     }
   }

--- a/test/integration/api/checks_test.rb
+++ b/test/integration/api/checks_test.rb
@@ -73,18 +73,18 @@ class API::ChecksTest < ActionDispatch::IntegrationTest
     token = create_token('komagata', 'testtest')
     delete api_check_path(@check2.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :ok
+    assert_response :no_content
 
     # adviser login
     token = create_token('advijirou', 'testtest')
     delete api_check_path(@check3.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :ok
+    assert_response :no_content
 
     # mentor login
     token = create_token('mentormentaro', 'testtest')
     delete api_check_path(@check4.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :ok
+    assert_response :no_content
   end
 end

--- a/test/integration/api/checks_test.rb
+++ b/test/integration/api/checks_test.rb
@@ -42,21 +42,21 @@ class API::ChecksTest < ActionDispatch::IntegrationTest
     post api_checks_path(format: :json),
          params: { checkable_type: @check2.checkable_type, checkable_id: @check2.checkable_id },
          headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :created
+    assert_response :unprocessable_entity
 
     # adviser login
     token = create_token('advijirou', 'testtest')
     post api_checks_path(format: :json),
          params: { checkable_type: @check3.checkable_type, checkable_id: @check3.checkable_id },
          headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :created
+    assert_response :unprocessable_entity
 
     # mentor login
     token = create_token('mentormentaro', 'testtest')
     post api_checks_path(format: :json),
          params: { checkable_type: @check4.checkable_type, checkable_id: @check4.checkable_id },
          headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :created
+    assert_response :unprocessable_entity
   end
 
   test 'DELETE /api/checks/1234.json' do
@@ -73,18 +73,18 @@ class API::ChecksTest < ActionDispatch::IntegrationTest
     token = create_token('komagata', 'testtest')
     delete api_check_path(@check2.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :no_content
+    assert_response :ok
 
     # adviser login
     token = create_token('advijirou', 'testtest')
     delete api_check_path(@check3.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :no_content
+    assert_response :ok
 
     # mentor login
     token = create_token('mentormentaro', 'testtest')
     delete api_check_path(@check4.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :no_content
+    assert_response :ok
   end
 end

--- a/test/system/api/check/products_test.rb
+++ b/test/system/api/check/products_test.rb
@@ -52,4 +52,24 @@ class Check::ProductsTest < ApplicationSystemTestCase
     assert_text '確認済'
     assert_text '提出物でcomment+確認OKにするtest'
   end
+
+  test 'display error message when checking confirmed product' do
+    using_session :mentormentaro do
+      visit_with_auth "/products/#{products(:product1).id}", 'mentormentaro'
+    end
+
+    using_session :komagata do
+      visit_with_auth "/products/#{products(:product1).id}", 'komagata'
+    end
+
+    using_session :mentormentaro do
+      click_button '提出物を確認'
+      assert_text '確認済'
+    end
+
+    using_session :komagata do
+      click_button '提出物を確認'
+      assert_text 'この提出物は確認済です'
+    end
+  end
 end

--- a/test/system/api/check/reports_test.rb
+++ b/test/system/api/check/reports_test.rb
@@ -52,4 +52,24 @@ class Check::ReportsTest < ApplicationSystemTestCase
     assert_text '確認済'
     assert_text '日報でcomment+確認OKにするtest'
   end
+
+  test 'display error message when checking confirmed report' do
+    using_session :mentormentaro do
+      visit_with_auth "/reports/#{reports(:report15).id}", 'mentormentaro'
+    end
+
+    using_session :komagata do
+      visit_with_auth "/reports/#{reports(:report15).id}", 'komagata'
+    end
+
+    using_session :mentormentaro do
+      click_button '日報を確認'
+      assert_text '確認済'
+    end
+
+    using_session :komagata do
+      click_button '日報を確認'
+      assert_text 'この日報は確認済です'
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #3242
- #4566

## 概要
確認済みの日報をチェックした場合のバグを修正しました。
- "この日報は確認済です。"というエラーのtoastを表示
- 日報一覧の確認済みスタンプの名前が置き換わらないよう修正

### 補足事項
- 確認ボタンは日報と提出物で共通の処理となっているため、提出物のテストも追加しました。

## 変更確認方法
1. ブランチ`bug/display-error-message-when-checking-confirmed-report`をローカルに取り込む
2. `bin/rails server`でローカル環境を立ち上げる
3. `メンターA`でログインし、日報個別ページ( `/reports/:id` )を開く
4. プライベートブラウザでローカル環境を立ち上げる
5. `メンターB`でログインし、上記3と同じ日報個別ページ( `/reports/:id` )を開く
6. 上記3で開いたページで"日報を確認"ボタンを押すと、`メンターA`の確認済みスタンプが付くことを確認
7. 上記5で開いたページで"日報を確認"ボタンを押すと、"この日報は確認済です。"というtoastが表示され、`メンターA`の確認済みスタンプが付くことを確認

## 変更前
![2022-05-24-01](https://user-images.githubusercontent.com/60736158/170087187-c1625a4d-1c07-4855-8439-8497dd580cf0.gif)

## 変更後
![2022-05-24-02](https://user-images.githubusercontent.com/60736158/170087232-da4b4c91-c82e-4d1f-85e8-37caf150100e.gif)
