### PR TITLE
メンターもプラクティスを作成できるようにした

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -2,8 +2,7 @@
 
 class PracticesController < ApplicationController
   before_action :require_login
-  before_action :require_admin_or_mentor_login, only: %i[new create]
-  before_action :require_admin_or_mentor_login, only: %i[edit update]
+  before_action :require_admin_or_mentor_login, only: %i[new create edit update]
   before_action :set_course, only: %i[new]
   before_action :set_practice, only: %i[show edit update]
 

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -2,7 +2,7 @@
 
 class PracticesController < ApplicationController
   before_action :require_login
-  before_action :require_admin_login, only: %i[new create]
+  before_action :require_admin_or_mentor_login, only: %i[new create]
   before_action :require_admin_or_mentor_login, only: %i[edit update]
   before_action :set_course, only: %i[new]
   before_action :set_practice, only: %i[show edit update]

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -90,6 +90,34 @@ class PracticesTest < ApplicationSystemTestCase
     assert_text 'プラクティスを作成しました'
   end
 
+  test 'create practice as a mentor' do
+    visit_with_auth '/practices/new', 'mentormentaro'
+    within 'form[name=practice]' do
+      fill_in 'practice[title]', with: 'メンター: テストプラクティス'
+      check categories(:category1).name, allow_label_click: true
+      fill_in 'practice[description]', with: 'テストの内容です'
+      within '#reference_books' do
+        click_link '書籍を追加'
+        fill_in 'タイトル', with: 'テストの参考書籍タイトル'
+        fill_in '価格', with: '1234'
+        fill_in 'URL', with: 'テストの参考書籍ASIN'
+        find('.reference-books-form-item__must-read').click
+        fill_in '説明', with: 'テストの参考書籍説明'
+        find('.reference-books-form__delete-link').click # delete
+        click_link '書籍を追加'
+        fill_in 'タイトル', with: 'テストの参考書籍タイトル2'
+        fill_in '価格', with: '1234'
+        fill_in 'URL', with: 'http://example.com'
+        find('.reference-books-form-item__must-read').click
+        fill_in '説明', with: 'テストの参考書籍説明'
+      end
+      fill_in 'practice[goal]', with: 'テストのゴールの内容です'
+      fill_in 'practice[memo]', with: 'テストのメンター向けメモの内容です'
+      click_button '登録する'
+    end
+    assert_text 'プラクティスを作成しました'
+  end
+
   test 'update practice' do
     practice = practices(:practice2)
     product = products(:product3)


### PR DESCRIPTION
## 関連issue
- #4561

## 概要・要件
プラクティスを作成出来るのが管理者のみだったので、メンターでも作成できるようにした。

## 変更前
<img width="1000" src="https://user-images.githubusercontent.com/49633473/169860079-c270c54a-fee5-4fd1-a834-adb944ed3e19.png">
<img width="1000" src="https://user-images.githubusercontent.com/49633473/169860270-c991617e-3223-4a4c-a944-9d1fb89e3eff.png">

## 変更後
<img width="1000" src="https://user-images.githubusercontent.com/49633473/169859096-5e6cbafa-e0ce-4196-99f3-3feed8c09828.png">
<img width="1000" src="https://user-images.githubusercontent.com/49633473/169859393-f217d174-bebb-490f-a6ca-ce54ad4b286b.png">
<img width="1000" src="https://user-images.githubusercontent.com/49633473/169859659-5e2fca63-78e4-40e6-916c-62d33c3715db.png">

## メンターのプラクティス作成の確認方法
1. `feature/mentors-can-also-create-practices`をローカルに取り込む
1. `bin/rails s`でサーバーを立ち上げる
1. メンターのロール(`mentormentaro`)でログイン
1. プラクティスのページにいき、プラクティスを作成のボタンをクリックする
1. プラクティス作成画面が開くので、タイトル、カテゴリー、内容、終了条件を入力し登録するをクリック
2. プラクティスが作成したカテゴリーに作成されていることを確認