### PR TITLE
DocsやQ&Aの一覧ページでプラクティスにリンクを付ける

### DIFF
--- a/app/javascript/page.vue
+++ b/app/javascript/page.vue
@@ -25,7 +25,7 @@
         .card-list-item-meta
           .card-list-item-meta__items
             .card-list-item-meta__item
-              a.card-list-item-sub-title(:href='practiceUrl()')
+              a.card-list-item-sub-title(:href='practiceUrl')
                 | {{ page.practice.title }}
 
       .card-list-item__row
@@ -84,9 +84,7 @@ export default {
     },
     daimyoClass() {
       return { 'is-daimyo': this.page.user.daimyo }
-    }
-  },
-  methods: {
+    },
     practiceUrl() {
       return `/practices/${this.page.practice.id}`
     }

--- a/app/javascript/page.vue
+++ b/app/javascript/page.vue
@@ -25,7 +25,7 @@
         .card-list-item-meta
           .card-list-item-meta__items
             .card-list-item-meta__item
-              .card-list-item-sub-title
+              a.card-list-item-sub-title(:href='practiceUrl()')
                 | {{ page.practice.title }}
 
       .card-list-item__row
@@ -84,6 +84,11 @@ export default {
     },
     daimyoClass() {
       return { 'is-daimyo': this.page.user.daimyo }
+    }
+  },
+  methods: {
+    practiceUrl() {
+      return `/practices/${this.page.practice.id}`
     }
   }
 }

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -24,7 +24,8 @@
         .card-list-item-meta
           .card-list-item-meta__items
             .card-list-item-meta__item
-              .card-list-item-sub-title {{ question.practice.title }}
+              a.card-list-item-sub-title(:href='practiceUrl()')
+                | {{ question.practice.title }}
 
       .card-list-item__row
         .card-list-item-meta
@@ -90,6 +91,11 @@ export default {
       } else {
         return ''
       }
+    }
+  },
+  methods: {
+    practiceUrl() {
+      return `/practices/${this.question.practice.id}`
     }
   }
 }

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -24,7 +24,7 @@
         .card-list-item-meta
           .card-list-item-meta__items
             .card-list-item-meta__item
-              a.card-list-item-sub-title(:href='practiceUrl()')
+              a.card-list-item-sub-title(:href='practiceUrl')
                 | {{ question.practice.title }}
 
       .card-list-item__row
@@ -91,9 +91,7 @@ export default {
       } else {
         return ''
       }
-    }
-  },
-  methods: {
+    },
     practiceUrl() {
       return `/practices/${this.question.practice.id}`
     }

--- a/app/views/api/questions/_question.json.jbuilder
+++ b/app/views/api/questions/_question.json.jbuilder
@@ -15,6 +15,7 @@ end
 
 json.practice do
   json.title question.practice.title
+  json.id question.practice.id
 end if question.practice
 
 json.answers do

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -189,4 +189,23 @@ class PagesTest < ApplicationSystemTestCase
     visit_with_auth "/pages/#{slug}", 'kimura'
     assert_text 'ActiveRecord::RecordNotFound'
   end
+
+  test 'link to the practice should appear and work correctly' do
+    visit_with_auth new_page_path, 'kimura'
+    fill_in 'page[title]', with: 'Docに関連プラクティスを指定'
+    fill_in 'page[body]', with: 'Docに関連プラクティスを指定'
+    first('.select2-container').click
+    find('li.select2-results__option[role="option"]', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
+    click_button '内容を保存'
+    assert_text 'Linuxのファイル操作の基礎を覚える'
+
+    visit pages_path
+    within first('.card-list-item-title__title') do
+      assert_text 'Docに関連プラクティスを指定'
+    end
+    within first('.card-list-item-sub-title') do
+      assert_text 'Linuxのファイル操作の基礎を覚える'
+    end
+    assert_link 'Linuxのファイル操作の基礎を覚える'
+  end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -380,7 +380,8 @@ class QuestionsTest < ApplicationSystemTestCase
     visit_with_auth new_question_path, 'kimura'
     fill_in 'question[title]', with: 'Questionに関連プラクティスを指定'
     fill_in 'question[description]', with: 'Questionに関連プラクティスを指定'
-
+    find('.choices__inner').click
+    find('#choices--js-choices-single-select-item-choice-6', text: 'Linuxのファイル操作の基礎を覚える').click
     click_button '登録する'
     assert_text 'Questionに関連プラクティスを指定'
 
@@ -389,8 +390,8 @@ class QuestionsTest < ApplicationSystemTestCase
       assert_text 'Questionに関連プラクティスを指定'
     end
     within first('.card-list-item-sub-title') do
-      assert_text 'OS X Mountain Lionをクリーンインストールする'
+      assert_text 'Linuxのファイル操作の基礎を覚える'
     end
-    assert_link 'OS X Mountain Lionをクリーンインストールする'
+    assert_link 'Linuxのファイル操作の基礎を覚える'
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -375,4 +375,22 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_text '質問をWIPとして保存しました。'
     assert_no_match 'Message to Discord.', mock_log.to_s
   end
+
+  test 'link to the question should appear and work correctly' do
+    visit_with_auth new_question_path, 'kimura'
+    fill_in 'question[title]', with: 'Questionに関連プラクティスを指定'
+    fill_in 'question[description]', with: 'Questionに関連プラクティスを指定'
+
+    click_button '登録する'
+    assert_text 'Questionに関連プラクティスを指定'
+
+    visit questions_path
+    within first('.card-list-item-title__title') do
+      assert_text 'Questionに関連プラクティスを指定'
+    end
+    within first('.card-list-item-sub-title') do
+      assert_text 'OS X Mountain Lionをクリーンインストールする'
+    end
+    assert_link 'OS X Mountain Lionをクリーンインストールする'
+  end
 end


### PR DESCRIPTION
## 概要

※ **見た目の細かい部分は町田さんと相談する必要あり**
* DocsやQ&Aの一覧ページに、プラクティスに紐づくものがあった場合に、プラクティスへのリンクを表示する
* 対象箇所は以下
<img width="613" alt="image" src="https://user-images.githubusercontent.com/20497053/169718450-b8ff37ef-aa0f-417d-b4c9-ece96eb8542b.png">


## issue
https://github.com/fjordllc/bootcamp/issues/4397

## UI
### Docs一覧
<img width="678" alt="image" src="https://user-images.githubusercontent.com/20497053/169719129-f1df9ccb-c670-4630-98ab-a40bbb32d273.png">

### Q&A一覧
<img width="678" alt="image" src="https://user-images.githubusercontent.com/20497053/169719120-e37990d5-2fbb-42e3-9c40-789005040e20.png">


## 確認方法
* 何らかのアカウントでログインする
* Docs、Q&Aともに、プラクティスに紐づいているものがあるので、そのタイトルの下にあるプラクティスの名前のリンクをクリックする
* プラクティスの名前と同じプラクティスの詳細ページが表示されることを確認する

## 受け入れテスト観点
受け入れテスト時の観点です。
- [ ] Docsのページに表示崩れがないこと
- [ ] Docsのページにあるプラクティスに紐づくDocのタイトルの下に、紐づいたプラクティスのタイトルが表示されていること
- [ ] 上記のタイトル部分をクリックすると、対象のプラクティスの詳細ページに遷移すること
- [ ] Docsを特定のプラクティスと紐付けて新規作成し、新しいDocにもプラクティスへのリンクが表示され、遷移できること
- [ ] Q&Aのページに表示崩れがないこと
- [ ] Q&Aのページにあるプラクティスに紐づく質問のタイトルの下に、紐づいたプラクティスのタイトルが表示されていること
- [ ] 上記のタイトル部分をクリックすると、対象のプラクティスの詳細ページに遷移すること
- [ ] 質問を特定のプラクティスと紐付けて新規作成し、新しい質問にもプラクティスへのリンクが表示され、遷移できること
