### PR TITLE
管理者がユーザー情報変更から退会、卒業、特殊ユーザー属性の無料、Githubコラボレーターの情報を変更できるように修正

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -19,7 +19,7 @@ class CurrentUserController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(
+    user_attribute = [
       :adviser, :login_name, :name,
       :name_kana, :email, :course_id,
       :description, :job_seeking, :discord_account,
@@ -30,7 +30,9 @@ class CurrentUserController < ApplicationController
       :nda, :avatar, :trainee,
       :mail_notification, :job_seeker, :tag_list,
       :after_graduation_hope, :training_ends_on
-    )
+    ]
+    user_attribute.push(:retired_on, :graduated_on, :free, :github_collaborator) if current_user.admin?
+    params.require(:user).permit(user_attribute)
   end
 
   def set_user

--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -19,17 +19,17 @@ class CurrentUserController < ApplicationController
   private
 
   def user_params
-    user_attribute = [
-      :adviser, :login_name, :name,
-      :name_kana, :email, :course_id,
-      :description, :job_seeking, :discord_account,
-      :github_account, :twitter_account, :facebook_url,
-      :blog_url, :times_url, :password, :password_confirmation,
-      :job, :organization, :os,
-      :experience, :prefecture_code, :company_id,
-      :nda, :avatar, :trainee,
-      :mail_notification, :job_seeker, :tag_list,
-      :after_graduation_hope, :training_ends_on
+    user_attribute = %i[
+      adviser login_name name
+      name_kana email course_id
+      description job_seeking discord_account
+      github_account twitter_account facebook_url
+      blog_url times_url password password_confirmation
+      job organization os
+      experience prefecture_code company_id
+      nda avatar trainee
+      mail_notification job_seeker tag_list
+      after_graduation_hope training_ends_on
     ]
     user_attribute.push(:retired_on, :graduated_on, :free, :github_collaborator) if current_user.admin?
     params.require(:user).permit(user_attribute)

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -124,4 +124,51 @@ class CurrentUserTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{kimura.id}", 'komagata'
     assert_text 'Linux'
   end
+
+  test 'update admin user\'s retired_on' do
+    user = users(:komagata)
+
+    visit_with_auth '/current_user/edit', 'komagata'
+    check '退会', allow_label_click: true
+    fill_in 'user[retired_on]', with: '2022-05-01'.to_date
+
+    click_on '更新する'
+
+    visit_with_auth '/current_user/edit', 'komagata'
+
+    assert_match user.reload.retired_on.to_s, '2022-05-01'
+  end
+
+  test 'update admin user\'s graduated_on' do
+    user = users(:komagata)
+
+    visit_with_auth '/current_user/edit', 'komagata'
+    check '卒業', allow_label_click: true
+    fill_in 'user[graduated_on]', with: '2022-05-01'.to_date
+    click_on '更新する'
+
+    assert_match user.reload.graduated_on.to_s, '2022-05-01'
+  end
+
+  test 'update admin user\'s free' do
+    user = users(:komagata)
+
+    visit_with_auth '/current_user/edit', 'komagata'
+    check '無料', allow_label_click: true
+
+    click_on '更新する'
+
+    assert user.reload.free
+  end
+
+  test 'update admin user\'s github_collaborator' do
+    user = users(:komagata)
+
+    visit_with_auth '/current_user/edit', 'komagata'
+    check 'GitHubチーム', allow_label_click: true
+
+    click_on '更新する'
+
+    assert user.reload.github_collaborator
+  end
 end

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -165,10 +165,10 @@ class CurrentUserTest < ApplicationSystemTestCase
     user = users(:komagata)
 
     visit_with_auth '/current_user/edit', 'komagata'
-    check 'GitHubチーム', allow_label_click: true
+    uncheck 'GitHubチーム', allow_label_click: true
 
     click_on '更新する'
 
-    assert user.reload.github_collaborator
+    assert_not user.reload.github_collaborator
   end
 end


### PR DESCRIPTION
## issue
- #4789

## 変更したファイル
`app/controllers/current_user_controller.rb`
current_userでユーザー情報更新した場合、`:retired_on, :graduated_on, :free, :github_collaborator`はストロングパラメーターに許可されていなかったため、管理者の場合は許可するように変更しました。

### 変更前
```ruby
def user_params
    params.require(:user).permit(
      :adviser, :login_name, :name,
      :name_kana, :email, :course_id,
      :description, :job_seeking, :discord_account,
      :github_account, :twitter_account, :facebook_url,
      :blog_url, :times_url, :password, :password_confirmation,
      :job, :organization, :os,
      :experience, :prefecture_code, :company_id,
      :nda, :avatar, :trainee,
      :mail_notification, :job_seeker, :tag_list,
      :after_graduation_hope, :training_ends_on
    )
end
```
### 変更後
```ruby
def user_params
    user_attribute = %i[
      adviser login_name name
      name_kana email course_id
      description job_seeking discord_account
      github_account twitter_account facebook_url
      blog_url times_url password password_confirmation
      job organization os
      experience prefecture_code company_id
      nda avatar trainee
      mail_notification job_seeker tag_list
      after_graduation_hope training_ends_on
    ]
    user_attribute.push(:retired_on, :graduated_on, :free, :github_collaborator) if current_user.admin?
    params.require(:user).permit(user_attribute)
end
```

## 確認手順
1. ブランチ`bug/fix-admin-cant-change-user-retire-info`をローカルに取り込む。
2. 管理者（komagata）でログインする。
3. 右上の`Me`=>`登録情報変更`をクリックをする
![_development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/169729651-0a6e06f3-c429-4a4d-8b8c-b6ae0d8085e1.png)
4. `退会`をクリックして任意の日付を入力 `卒業`をクリックして任意の日付を入力 `無料`にチェック `Githubコラボレーター`にチェックなど行う。
5. 「更新する」ボタンをクリックする。
6. 右上の`Me`=>`登録情報変更`をクリックして`退会` `卒業` `無料` `Githubコラボレーター`の情報が更新されていることを確認する。
