### PR TITLE
管理者で相談部屋から相談主の卒業フラグをオンにできるようにした。

### DIFF
--- a/app/assets/stylesheets/blocks/side/_side-tabs-contents.sass
+++ b/app/assets/stylesheets/blocks/side/_side-tabs-contents.sass
@@ -28,7 +28,7 @@
     background-color: $base
     border: solid 1px $border-more-shade
     border-bottom: none
-    height: 11rem
+    max-height: 13rem
     overflow: auto
   .user-metas
     margin-top: 0
@@ -39,20 +39,14 @@
     font-size: .625rem
     background-color: $background
   .user-metas__items
-    display: flex
-    flex-wrap: wrap
     padding: .25rem .5rem
-    +media-breakpoint-down(sm)
-      display: block
   .user-metas__item
-    flex: 0 0 auto
+    display: inline
     +text-block(.75rem 1.6)
     padding: 0
     border: none
     &:not(:last-child)::after
       content: '、'
-    +media-breakpoint-down(sm)
-      display: inline
   .user-metas__item:not(:last-child)
     border: none
   .user-metas__item:nth-child(even)
@@ -60,9 +54,15 @@
   .user-metas__item-label,
   .user-metas__item-value
     padding: 0
+    display: inline
     +media-breakpoint-down(sm)
       border: none
+    ul,
+    li
+      margin-left: 0
       display: inline
+    li:not(:last-child)::after
+      content: '・'
   .user-metas__item-label
     border-right: none
     flex: 0 0 auto

--- a/app/assets/stylesheets/blocks/side/_user-statuses.sass
+++ b/app/assets/stylesheets/blocks/side/_user-statuses.sass
@@ -1,0 +1,26 @@
+.user-statuses
+  border: solid 1px $border-shade
+  padding: .75rem 1rem
+  background-color: $base
+  border-bottom: none
+  & + .a-card
+    border-radius: 0 0 4px 4px
+
+.user-statuses__actions
+  display: flex
+  align-items: center
+  gap: .75rem
+
+.user-statuses__title
+  +text-block(.8125rem 1.4, 600)
+
+.user-statuses__items
+  flex: 1
+  display: flex
+  align-items: center
+  flex-wrap: wrap
+  gap: .75rem
+
+.user-statuses__item
+  flex: 1
+  max-width: 15rem

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -8,9 +8,9 @@ class GraduationController < ApplicationController
       Subscription.new.destroy(@user.subscription_id) if @user.subscription_id
 
       notify_to_mentors(@user)
-      redirect_to admin_users_url, notice: 'ユーザー情報を更新しました。'
+      redirect_to @redirect_url, notice: 'ユーザー情報を更新しました。'
     else
-      redirect_to admin_users_url, alert: 'ユーザー情報の更新に失敗しました'
+      redirect_to @redirect_url, alert: 'ユーザー情報の更新に失敗しました'
     end
   end
 
@@ -18,6 +18,7 @@ class GraduationController < ApplicationController
 
   def set_user
     @user = User.find(params[:user_id])
+    @redirect_url = params[:redirect_url].presence || admin_users_url
   end
 
   def notify_to_mentors(user)

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -2,6 +2,7 @@
 
 class GraduationController < ApplicationController
   before_action :set_user, only: %i[update]
+  before_action :set_redirect_url, only: %i[update]
 
   def update
     if @user.update(graduated_on: Date.current)
@@ -18,6 +19,9 @@ class GraduationController < ApplicationController
 
   def set_user
     @user = User.find(params[:user_id])
+  end
+
+  def set_redirect_url
     @redirect_url = params[:redirect_url].presence || admin_users_url
   end
 

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -74,3 +74,12 @@ header.page-header
                 #js-user-mentor-memo(data-user-id="#{@user.id}" data-products-mode="#{true}")
               .side-tabs-contents__item#side-tabs-content-2
                 #js-reports(data-user-id="#{@user.id}" data-limit="10")
+            .graduation_button
+              - if @user.graduated_on?
+                .a-button.is-sm.is-disabled
+                  | 卒業済
+              - else
+                = link_to '卒業', user_graduation_path(@user, redirect_url: "/talks/#{@talk.id}"),
+                        method: :patch,
+                        data: { confirm: '本当によろしいですか？' },
+                        class: 'a-button is-sm is-primary'

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -71,15 +71,21 @@ header.page-header
                 .user-info
                   = render 'users/user_secret_attributes', user: @user
                   = render 'users/metas', user: @user
+                .user-statuses
+                  .user-statuses__items
+                    .user-statuses__item
+                      = link_to 'ユーザー情報変更', edit_admin_user_path(@talk.user), class: 'card-main-actions__action a-button is-sm is-secondary is-block'
+                    .user-statuses__item
+                    .user-statuses__item
+                      .graduation_button
+                        - if @user.graduated_on?
+                          .a-button.is-sm.is-disabled.is-block
+                            | 卒業済
+                        - else
+                          = link_to '卒業にする', user_graduation_path(@user, redirect_url: "/talks/#{@talk.id}"),
+                                  method: :patch,
+                                  data: { confirm: '本当によろしいですか？' },
+                                  class: 'a-button is-sm is-danger is-block'
                 #js-user-mentor-memo(data-user-id="#{@user.id}" data-products-mode="#{true}")
               .side-tabs-contents__item#side-tabs-content-2
                 #js-reports(data-user-id="#{@user.id}" data-limit="10")
-            .graduation_button
-              - if @user.graduated_on?
-                .a-button.is-sm.is-disabled
-                  | 卒業済
-              - else
-                = link_to '卒業', user_graduation_path(@user, redirect_url: "/talks/#{@talk.id}"),
-                        method: :patch,
-                        data: { confirm: '本当によろしいですか？' },
-                        class: 'a-button is-sm is-primary'

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -355,6 +355,15 @@ class TalksTest < ApplicationSystemTestCase
     assert_text '一致する相談部屋はありません'
   end
 
+  test 'push guraduation button in talk room when admin logined' do
+    user = users(:kimura)
+    visit_with_auth "/talks/#{user.talk.id}", 'komagata'
+    accept_confirm do
+      click_link '卒業'
+    end
+    assert_text '卒業済'
+  end
+
   test 'admin can see tabs on user talk page' do
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'komagata'

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -359,7 +359,7 @@ class TalksTest < ApplicationSystemTestCase
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'komagata'
     accept_confirm do
-      click_link '卒業'
+      click_link '卒業にする'
     end
     assert_text '卒業済'
   end


### PR DESCRIPTION
## Issue
- [相談部屋から相談部屋の主の卒業フラグをオンできるようにしたい。 · Issue \#4708](https://github.com/fjordllc/bootcamp/issues/4708)

## 概要
- 管理者で相談部屋に入った際に卒業ボタンを表示するようにし、相談主の卒業フラグをオンにできるようにした。

## 変更前
<img width="1424" alt="作業前" src="https://user-images.githubusercontent.com/70277776/169902752-a1e82e23-27b1-44be-9988-85abb6b6dc08.png">

## 変更後
<img width="1422" alt="デザイン完了後" src="https://user-images.githubusercontent.com/70277776/171778868-727a2c98-aa50-4f4b-aaec-c4b6af557606.png">

## 変更確認方法
1. ブランチ `feature/add_graduation_button_in_talks_for_admin` をローカルに取り込み、ローカル環境で起動する。
1. 管理者でログインし、相談部屋の個別ページを表示する。（例：rieさんの相談部屋）
1. 「卒業」ボタンが表示されているのが確認できる。
1. 「卒業」ボタンを押すと「卒業済」の表示に変わる。