### PR TITLE
企業個別ページの日報一覧に企業一覧のリンクを追加した

### DIFF
--- a/app/views/companies/reports/index.html.slim
+++ b/app/views/companies/reports/index.html.slim
@@ -10,7 +10,6 @@ header.page-header
             = link_to companies_path, class: 'a-button is-md is-secondary is-block is-back' do
               | 企業一覧
 
-
 = render 'companies/tabs', company: @company
 
 .page-body

--- a/app/views/companies/reports/index.html.slim
+++ b/app/views/companies/reports/index.html.slim
@@ -4,6 +4,12 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         = @company.name
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to companies_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | 企業一覧
+
 
 = render 'companies/tabs', company: @company
 


### PR DESCRIPTION
## Issue
- #4774 

## 概要
企業個別ページの日報一覧から企業一覧にとべるようにリンクを追加しました。

## 変更確認方法
1. ブランチ`feature/add-companies-list-link-to-companys-report-list`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. http://localhost:3000/companies の企業一覧から企業個別ページに入り、日報をクリックする（日報一覧ページに入る）。
4. 日報一覧ページの右上に`企業一覧`のリンクが追加されている

## 変更前
<img width="1440" alt="スクリーンショット 2022-05-20 20 30 54" src="https://user-images.githubusercontent.com/76685187/169940337-402d2acb-706f-4710-88be-b30fdeb50517.png">

## 変更後
<img width="1440" alt="スクリーンショット 2022-05-24 14 10 51" src="https://user-images.githubusercontent.com/76685187/169953850-a7e0d3d9-af93-4f89-87f7-4c588da8e0c6.png">

