### PR TITLE
コメント通知のabstract_notifier対応

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -54,17 +54,6 @@ class Notification < ApplicationRecord
   after_destroy NotificationCallbacks.new
 
   class << self
-    def came_comment(comment, receiver, message)
-      Notification.create!(
-        kind: kinds[:came_comment],
-        user: receiver,
-        sender: comment.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(comment.commentable),
-        message: message,
-        read: false
-      )
-    end
-
     def checked(check)
       Notification.create!(
         kind: kinds[:checked],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -2,7 +2,7 @@
 
 class NotificationFacade
   def self.came_comment(comment, receiver, message)
-    Notification.came_comment(comment, receiver, message)
+    ActivityNotifier.with(comment: comment, receiver: receiver, message: message).came_comment.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -56,11 +56,11 @@ class ActivityNotifier < ApplicationNotifier
     message = params[:message]
 
     notification(
+      body: message,
       kind: :came_comment,
-      user: receiver,
+      receiver: receiver,
       sender: comment.sender,
       link: Rails.application.routes.url_helpers.polymorphic_path(comment.commentable),
-      message: message,
       read: false
     )
   end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -48,4 +48,20 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def came_comment(params = {})
+    params.merge!(@params)
+    comment = params[:comment]
+    receiver = params[:receiver]
+    message = params[:message]
+
+    notification(
+      kind: :came_comment,
+      user: receiver,
+      sender: comment.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(comment.commentable),
+      message: message,
+      read: false
+    )
+  end
 end

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class Notification::TalkTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test 'Admin receive a notification when someone comments on a talk room' do
     talk_id = users(:kimura).talk.id
     visit_with_auth "/talks/#{talk_id}", 'kimura'


### PR DESCRIPTION
## Issue

- #4698

## 概要

- コメント通知に関する実装を[abstract_notifier](https://github.com/palkan/abstract_notifier)に置き換えました。
- [abstract\_notifierを導入](https://github.com/fjordllc/bootcamp/pull/4673?w=1)のPRを参考に実装しました。
- ビューにおける変更はないためスクリーンショットは割愛しています。

## 変更確認方法

1. ブランチ`feature/replace-comment-notice-with-abstract_notifier`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 管理者権限のあるユーザーでログインし、`kimura`など**メール通知をオンにしている**ユーザーの相談部屋でコメントする

<img width="1919" alt="_development__kimuraさんの相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/171588350-608a4a42-b837-4cb4-a73b-c599fbcaca85.png">

4. 3のユーザーでログインし、通知を確認する。

<img width="1918" alt="_development__kimuraさんの相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/171588863-d2b86593-d85f-4ab4-b302-575e3e06a83c.png">

5. `http://localhost:3000/letter_opener/`にアクセスして、3のユーザー宛と管理者権限を持つ他の2名へのメール通知を確認

<img width="1919" alt="Cursor_と__development__LetterOpenerWeb" src="https://user-images.githubusercontent.com/53898556/171589312-42fb2573-107e-4f2c-a1f3-7a47e1d4fd39.png">

6. 念の為、3のユーザーでも相談部屋でコメントする

<img width="1917" alt="_development__kimuraさんの相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/171590402-9ab5dbc7-7c1f-49c2-aec3-44d544b59c4b.png">

7. 管理者権限のあるユーザーで再度ログインして通知を確認する

<img width="1916" alt="_development__kimuraさんの相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/171590992-86856a1c-9174-4e87-90f7-2fa01f38afec.png">

8. `http://localhost:3000/letter_opener/`にアクセスして管理者権限を持つ3名宛のメール通知を確認

<img width="1916" alt="Cursor_と__development__LetterOpenerWeb" src="https://user-images.githubusercontent.com/53898556/171591222-d7a5b8a5-e6dc-4a84-a563-5918822b7896.png">