### PR TITLE
Docs作成の通知の実装をabstract_notifierに置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -177,17 +177,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def create_page(page, reciever)
-      Notification.create!(
-        kind: kinds[:create_pages],
-        user: reciever,
-        sender: page.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(page),
-        message: "#{page.user.login_name}さんがDocsに#{page.title}を投稿しました。",
-        read: false
-      )
-    end
-
     def following_report(report, receiver)
       Notification.create!(
         kind: kinds[:following_report],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -146,7 +146,7 @@ class NotificationFacade
   end
 
   def self.create_page(page, receiver)
-    Notification.create_page(page, receiver)
+    ActivityNotifier.with(page: page, receiver: receiver).create_page.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -80,4 +80,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def create_page(params = {})
+    params.merge!(@params)
+    page = params[:page]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{page.user.login_name}さんがDocsに#{page.title}を投稿しました。",
+      kind: :create_pages,
+      sender: page.sender,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(page),
+      read: false
+    )
+  end
 end

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -14,8 +14,40 @@ class ActivityNotifierTest < ActiveSupport::TestCase
     }
   end
 
-  test '.graduated' do
+  test '#graduated' do
     notification = ActivityNotifier.graduated(@params)
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      notification.notify_now
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      notification.notify_later
+    end
+  end
+
+  test '#create_page' do
+    @create_page_params = {
+      body: 'test Docs',
+      kind: :create_pages,
+      sender: users(:hajime),
+      receiver: users(:komagata),
+      link: 'pages',
+      read: false,
+      page: pages(:page1)
+    }
+
+    notification = ActivityNotifier.create_page(@create_page_params)
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      notification.notify_now
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      notification.notify_later
+    end
+
+    notification = ActivityNotifier.with(@create_page_params).create_page
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       notification.notify_now

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -65,8 +65,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
     assert_text 'ページを更新しました。'
 
     visit_with_auth '/notifications', 'machida'
-    sleep(10)
-    save_screenshot('/Users/home-folder/fjordllc/bootcamp/tmp/screenshots/screenshot.png')
+
     within first('.card-list-item.is-unread') do
       assert_text 'komagataさんがDocsにWIPのテストを投稿しました。'
     end

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class Notification::PagesTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test 'Only students and mentors are notified' do
     visit_with_auth '/pages', 'komagata'
     click_link 'Doc作成'
@@ -56,7 +65,8 @@ class Notification::PagesTest < ApplicationSystemTestCase
     assert_text 'ページを更新しました。'
 
     visit_with_auth '/notifications', 'machida'
-
+    sleep(10)
+    save_screenshot('/Users/home-folder/fjordllc/bootcamp/tmp/screenshots/screenshot.png')
     within first('.card-list-item.is-unread') do
       assert_text 'komagataさんがDocsにWIPのテストを投稿しました。'
     end


### PR DESCRIPTION
## issue
- #4685 

## 概要
- Docs作成を通知する実装を、[abstract_notifier](https://github.com/palkan/abstract_notifier)に置き換えました。
- 仕様は変更していないため、変更前/変更後のスクリーンショットは割愛します。

## 動作確認手順
1. `feature/change-notification-to-abstract-notifier`ブランチをローカルに持ってきます。
2. `bin/rails s`でアプリケーションを起動します。
3. `hajime`でログインし、`http://localhost:3000/pages/new`にアクセス後、Docsを作成します。
4. ログアウトします。
5. `kimura`でログインし、右上の通知をクリックし、3で作成したDocsの通知が来ていることを確認します。
![_development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/170243734-2fdfbab4-958c-4e74-b267-b47a48582ec2.png)
6. 通知にアクセスし、Docsを閲覧することができることを確認します。
7. `http://127.0.0.1:3000/letter_opener/`にアクセスし、メールが送信されていることを確認します。
![_development__LetterOpenerWeb](https://user-images.githubusercontent.com/64620506/170244231-a6d8b115-ae80-4a16-b323-5fb5f0db5f05.png)