### PR TITLE
sadアイコンの通知をabstract_notifierに置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -232,17 +232,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def consecutive_sad_report(report, receiver)
-      Notification.create!(
-        kind: kinds[:consecutive_sad_report],
-        user: receiver,
-        sender: report.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(report),
-        message: "#{report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。",
-        read: false
-      )
-    end
-
     def assigned_as_checker(product, receiver)
       Notification.create!(
         kind: 16,

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -166,7 +166,6 @@ class NotificationFacade
   end
 
   def self.consecutive_sad_report(report, receiver)
-    Notification.consecutive_sad_report(report, receiver)
     ActivityNotifier.with(report: report, receiver: receiver).consecutive_sad_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -167,6 +167,7 @@ class NotificationFacade
 
   def self.consecutive_sad_report(report, receiver)
     Notification.consecutive_sad_report(report, receiver)
+    ActivityNotifier.with(report: report, receiver: receiver).consecutive_sad_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -18,4 +18,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def consecutive_sad_report(params = {})
+    params.merge!(@params)
+    report = params[:report]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。",
+      kind: :consecutive_sad_report,
+      sender: report.sender,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(report),
+      read: false
+    )
+  end
 end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class Notification::ReportsTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test 'the first daily report notification is sent only to current students and mentors' do
     report = users(:muryou).reports.create!(
       title: '初日報です',


### PR DESCRIPTION
# 関連issue

- #4682 
  - #1894   
   (sadアイコンの日報が2日続いた場合、メンターに通知する機能を実装をした時のissueです)
 
# 概要
- sadアイコンの日報が2日続いた場合、メンターに通知する実装を、[abstract_notifier](https://github.com/palkan/abstract_notifier)に置き換えました。
- 実装方法については、komagataさんが作成された、[ユーザーが卒業した時の通知を、abstract_notifierに置き換えたPR](https://github.com/fjordllc/bootcamp/pull/4673)を参考にしています。
- 仕様は変更していないため、変更前/変更後のスクリーンショットは割愛させていただきました。
 
# 動作確認手順
仕様は #1894 で実装されて以来変わっていないため、以下3点をご確認いただきたいです。
## 概要

日報が2回以上連続でsadアイコンで提出された場合、以下のタスクが実行される。
1. ダッシュボードに該当ユーザーの日報を表示する
2. メンターに該当ユーザーの日報を通知する
3. メンターに該当ユーザーの日報をメール通知する


## 詳細

- `feature/replace-sad-icon-notification-with-abstract_notifier`ブランチをローカルに持ってきて、`rails s`で起動する。
- `kimura`でログインする。
- `http://localhost:3000/reports/new`にアクセスし、sadマークの日報を2日連続で作成する。

- `komagata`(`mentor`ロールであれば誰でも可)でログインする。
- 以下3点を確認する。

### 1. ダッシュボードに表示されているか確認する
- `komagata`でダッシュボードにアクセスする。
- 「2回連続sadのユーザー」欄に、上記で作ったsadアイコン2日目の日報が表示されているか確認する
![スクリーンショット 2022-05-25 13 34 00](https://user-images.githubusercontent.com/58052292/170180736-74adc24d-b106-47a7-bb13-9314ce148d07.png)

### 2. 該当ユーザーの日報のサイト内通知が来ているか、確認する
- 右上の通知マークをクリックして、該当の通知が来ているか確認する。
![スクリーンショット 2022-05-25 13 37 12](https://user-images.githubusercontent.com/58052292/170180926-2f44aae6-c6ca-4376-8353-28dab1e91779.png)
- 通知をクリックすると該当の日報にアクセスできることを確認する。

### 3. 該当ユーザーの日報がメール通知されているか、確認する
- `http://127.0.0.1:3000/letter_opener/` にアクセスする。
- 該当ユーザーの通知がきているか確認する。
- メンター権限を持つ全てのユーザーのアドレスに通知されているかを確認する。
  - `unadmentor@gmail.com`(管理者権限の無いメンター)
  - `daimyo-mentor@fjord.jp` (大名エンジニアカレッジのメンター)
  - `mentormentaro@fjord.jp`
  - `machidanohimitsu@gmail.com`
  - `komagata@fjord.jp`
![スクリーンショット 2022-05-25 13 43 33](https://user-images.githubusercontent.com/58052292/170182329-36c5c00f-4eb9-49b7-b617-14532f54e2e6.png)

