### PR TITLE
コメントのリアクションボタンが押せないのを修正した

### DIFF
--- a/app/assets/stylesheets/blocks/thread/_thread-comment.sass
+++ b/app/assets/stylesheets/blocks/thread/_thread-comment.sass
@@ -1,7 +1,6 @@
 .thread-comment
   +position(relative)
   border-radius: .25rem
-  overflow: hidden
   +media-breakpoint-up(md)
     margin-bottom: 2rem
     padding-left: $thread-header-author


### PR DESCRIPTION
@komagata 

すいません、修正しました 🙇‍♂️

Issue: https://github.com/fjordllc/bootcamp/issues/4902



<img width="345" alt="image" src="https://user-images.githubusercontent.com/168265/170445867-cb2c50a7-ef4a-4925-b452-3ac52580ffdb.png">

