### PR TITLE
【メンター向け】ダッシュボードに5日以上経過した提出物を表示する

### DIFF
--- a/app/assets/stylesheets/atoms/_a-elapsed-days.sass
+++ b/app/assets/stylesheets/atoms/_a-elapsed-days.sass
@@ -1,7 +1,7 @@
 .card-header.a-elapsed-days
   letter-spacing: .125em
   text-indent: .125em
-  margin: -1px
+  margin: -1px -1px 0
   background-color: $base
   border: solid 1px $border-shade
   >*

--- a/app/assets/stylesheets/blocks/card-list/_products.sass
+++ b/app/assets/stylesheets/blocks/card-list/_products.sass
@@ -1,0 +1,6 @@
+.page-body.is-dash-board
+  .products
+    +media-breakpoint-up(xl)
+      +margin(vertical, 1.25rem)
+    +media-breakpoint-down(lg)
+      +margin(vertical, 1rem)

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -8,7 +8,7 @@
         i.fa-regular.fa-smile
       p.o-empty-message__text
         | {{ title }}はありません
-  div(:class="contentClassName")(v-else)
+  div(:class='contentClassName')(v-else)
     nav.pagination(v-if='totalPages > 1')
       pager(v-bind='pagerProps')
     .card-list.a-card(v-if='productsGroupedByElapsedDays === null')
@@ -21,7 +21,9 @@
           :isMentor='isMentor'
         )
     template(v-for='product_n_days_passed in productsGroupedByElapsedDays') <!-- product_n_days_passedはn日経過の提出物 -->
-      .card-list.a-card(v-if='(!isDashboard || isDashboard && product_n_days_passed.elapsed_days >= 5)')
+      .card-list.a-card(
+        v-if='!isDashboard || (isDashboard && product_n_days_passed.elapsed_days >= 5)'
+      )
         header.card-header.a-elapsed-days(
           v-if='product_n_days_passed.elapsed_days === 0'
         )

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -155,7 +155,8 @@ export default {
         .then((json) => {
           if (
             location.pathname === '/products/unassigned' ||
-            location.pathname === '/products/unchecked'
+            location.pathname === '/products/unchecked' ||
+            location.pathname === '/'
           ) {
             this.productsGroupedByElapsedDays =
               json.products_grouped_by_elapsed_days

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -8,7 +8,7 @@
         i.fa-regular.fa-smile
       p.o-empty-message__text
         | {{ title }}はありません
-  .container.is-md(v-else)
+  div(:class="contentClassName")(v-else)
     nav.pagination(v-if='totalPages > 1')
       pager(v-bind='pagerProps')
     .card-list.a-card(v-if='productsGroupedByElapsedDays === null')
@@ -125,6 +125,9 @@ export default {
         pageRange: 5,
         clickHandle: this.paginateClickCallback
       }
+    },
+    contentClassName() {
+      return location.pathname === '/' ? 'is-md' : 'container is-md'
     }
   },
   created() {

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -21,7 +21,7 @@
           :isMentor='isMentor'
         )
     template(v-for='product_n_days_passed in productsGroupedByElapsedDays') <!-- product_n_days_passedはn日経過の提出物 -->
-      .card-list.a-card
+      .card-list.a-card(v-if='(!isDashboard || isDashboard && product_n_days_passed.elapsed_days >= 5)')
         header.card-header.a-elapsed-days(
           v-if='product_n_days_passed.elapsed_days === 0'
         )
@@ -127,7 +127,10 @@ export default {
       }
     },
     contentClassName() {
-      return location.pathname === '/' ? 'is-md' : 'container is-md'
+      return this.isDashboard ? 'is-md' : 'container is-md'
+    },
+    isDashboard() {
+      return location.pathname === '/'
     }
   },
   created() {

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -1,17 +1,16 @@
 <template lang="pug">
-.page-body
-  .container.is-md(v-if='!loaded')
-    loadingListPlaceholder
-  .container(v-else-if='products.length === 0')
-    .o-empty-message
-      .o-empty-message__icon
-        i.fa-regular.fa-smile
-      p.o-empty-message__text
-        | {{ title }}はありません
-  div(:class='contentClassName')(v-else)
-    nav.pagination(v-if='totalPages > 1')
-      pager(v-bind='pagerProps')
-    .card-list.a-card(v-if='productsGroupedByElapsedDays === null')
+.products(v-if='!loaded')
+  loadingListPlaceholder
+.o-empty-message(v-else-if='products.length === 0')
+  .o-empty-message__icon
+    i.fa-regular.fa-smile
+  p.o-empty-message__text
+    | {{ title }}はありません
+.products(v-else)
+  nav.pagination(v-if='totalPages > 1')
+    pager(v-bind='pagerProps')
+  .a-card(v-if='productsGroupedByElapsedDays === null')
+    .card-list
       .card-list__items
         product(
           v-for='product in products',
@@ -20,43 +19,44 @@
           :currentUserId='currentUserId',
           :isMentor='isMentor'
         )
-    template(v-for='product_n_days_passed in productsGroupedByElapsedDays') <!-- product_n_days_passedはn日経過の提出物 -->
-      .card-list.a-card(
-        v-if='!isDashboard || (isDashboard && product_n_days_passed.elapsed_days >= 5)'
+  template(v-for='product_n_days_passed in productsGroupedByElapsedDays') <!-- product_n_days_passedはn日経過の提出物 -->
+    .a-card(
+      v-if='!isDashboard || (isDashboard && product_n_days_passed.elapsed_days >= 5)'
+    )
+      header.card-header.a-elapsed-days(
+        v-if='product_n_days_passed.elapsed_days === 0'
       )
-        header.card-header.a-elapsed-days(
-          v-if='product_n_days_passed.elapsed_days === 0'
-        )
-          h2.card-header__title
-            | 今日提出
-            span.card-header__count(v-if='selectedTab === "unassigned"')
-              | （{{ countProductsGroupedBy(product_n_days_passed) }}）
-        header.card-header.a-elapsed-days.is-reply-warning(
-          v-else-if='product_n_days_passed.elapsed_days === 5'
-        )
-          h2.card-header__title
-            | {{ product_n_days_passed.elapsed_days }}日経過
-            span.card-header__count(v-if='selectedTab === "unassigned"')
-              | （{{ countProductsGroupedBy(product_n_days_passed) }}）
-        header.card-header.a-elapsed-days.is-reply-alert(
-          v-else-if='product_n_days_passed.elapsed_days === 6'
-        )
-          h2.card-header__title
-            | {{ product_n_days_passed.elapsed_days }}日経過
-            span.card-header__count(v-if='selectedTab === "unassigned"')
-              | （{{ countProductsGroupedBy(product_n_days_passed) }}）
-        header.card-header.a-elapsed-days.is-reply-deadline(
-          v-else-if='product_n_days_passed.elapsed_days === 7'
-        )
-          h2.card-header__title
-            | {{ product_n_days_passed.elapsed_days }}日以上経過
-            span.card-header__count(v-if='selectedTab === "unassigned"')
-              | （{{ countProductsGroupedBy(product_n_days_passed) }}）
-        header.card-header.a-elapsed-days(v-else)
-          h2.card-header__title
-            | {{ product_n_days_passed.elapsed_days }}日経過
-            span.card-header__count(v-if='selectedTab === "unassigned"')
-              | （{{ countProductsGroupedBy(product_n_days_passed) }}）
+        h2.card-header__title
+          | 今日提出
+          span.card-header__count(v-if='selectedTab === "unassigned"')
+            | （{{ countProductsGroupedBy(product_n_days_passed) }}）
+      header.card-header.a-elapsed-days.is-reply-warning(
+        v-else-if='product_n_days_passed.elapsed_days === 5'
+      )
+        h2.card-header__title
+          | {{ product_n_days_passed.elapsed_days }}日経過
+          span.card-header__count(v-if='selectedTab === "unassigned"')
+            | （{{ countProductsGroupedBy(product_n_days_passed) }}）
+      header.card-header.a-elapsed-days.is-reply-alert(
+        v-else-if='product_n_days_passed.elapsed_days === 6'
+      )
+        h2.card-header__title
+          | {{ product_n_days_passed.elapsed_days }}日経過
+          span.card-header__count(v-if='selectedTab === "unassigned"')
+            | （{{ countProductsGroupedBy(product_n_days_passed) }}）
+      header.card-header.a-elapsed-days.is-reply-deadline(
+        v-else-if='product_n_days_passed.elapsed_days === 7'
+      )
+        h2.card-header__title
+          | {{ product_n_days_passed.elapsed_days }}日以上経過
+          span.card-header__count(v-if='selectedTab === "unassigned"')
+            | （{{ countProductsGroupedBy(product_n_days_passed) }}）
+      header.card-header.a-elapsed-days(v-else)
+        h2.card-header__title
+          | {{ product_n_days_passed.elapsed_days }}日経過
+          span.card-header__count(v-if='selectedTab === "unassigned"')
+            | （{{ countProductsGroupedBy(product_n_days_passed) }}）
+      .card-list(:class='listClassName')
         .card-list__items
           product(
             v-for='product in product_n_days_passed.products',
@@ -65,12 +65,12 @@
             :currentUserId='currentUserId',
             :isMentor='isMentor'
           )
-    unconfirmed-links-open-button(
-      v-if='isMentor && selectedTab != "all"',
-      :label='`${unconfirmedLinksName}の提出物を一括で開く`'
-    )
-    nav.pagination(v-if='totalPages > 1')
-      pager(v-bind='pagerProps')
+  unconfirmed-links-open-button(
+    v-if='isMentor && selectedTab != "all" && !isDashboard',
+    :label='`${unconfirmedLinksName}の提出物を一括で開く`'
+  )
+  nav.pagination(v-if='totalPages > 1')
+    pager(v-bind='pagerProps')
 </template>
 
 <script>
@@ -128,8 +128,8 @@ export default {
         clickHandle: this.paginateClickCallback
       }
     },
-    contentClassName() {
-      return this.isDashboard ? 'is-md' : 'container is-md'
+    listClassName() {
+      return this.isDashboard ? 'has-scroll' : ''
     },
     isDashboard() {
       return location.pathname === '/'

--- a/app/views/home/_after_graduation_hope.html.slim
+++ b/app/views/home/_after_graduation_hope.html.slim
@@ -1,0 +1,12 @@
+.a-card
+  header.card-header.is-sm
+    h2.card-header__title
+      | 卒業後のゴール
+  .card-body
+    .card__description
+      .a-long-text.is-md
+        = simple_format(user.after_graduation_hope)
+  .card-footer
+    .card-footer__footer-link
+      = link_to edit_current_user_path(anchor: 'form-after-graduation-hope'), class: 'card-footer__footer-text-link' do
+        | 内容を更新

--- a/app/views/home/_wip_items.html.slim
+++ b/app/views/home/_wip_items.html.slim
@@ -1,0 +1,13 @@
+.a-card
+  header.card-header.is-sm
+    h2.card-header__title
+      | WIPで保存中
+  .card-list
+    - if current_user.pages.wip.present?
+      = render 'users/pages/wip_pages', user: current_user
+    - if current_user.reports.wip.present?
+      = render 'users/reports/wip_reports', user: current_user
+    - if current_user.questions.wip.present?
+      = render 'users/questions/wip_questions', user: current_user
+    - if current_user.products.wip.present?
+      = render 'users/products/wip_products', user: current_user

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -3,7 +3,8 @@
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title = title
+      h2.page-header__title
+        = title
       .page-header-actions
         .page-header-actions__items
           .page-header-actions__item
@@ -17,7 +18,7 @@ header.page-header
 
 = render 'page_tabs', user: current_user
 
-.page-body
+.page-body.is-dash-board
   - if @events_coming_soon.present? && current_user.job_seeker
     #events_on_dashboard.confirmed_event
       .page-notices
@@ -40,19 +41,7 @@ header.page-header
             #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
           - if current_user.pages.wip.present? || current_user.reports.wip.present? || current_user.questions.wip.present? || current_user.products.wip.present?
-            .a-card
-              header.card-header.is-sm
-                h2.card-header__title
-                  | WIPで保存中
-              .card-list
-                - if current_user.pages.wip.present?
-                  = render 'users/pages/wip_pages', user: current_user
-                - if current_user.reports.wip.present?
-                  = render 'users/reports/wip_reports', user: current_user
-                - if current_user.questions.wip.present?
-                  = render 'users/questions/wip_questions', user: current_user
-                - if current_user.products.wip.present?
-                  = render 'users/products/wip_products', user: current_user
+            = render 'wip_items'
 
           - if current_user.active_practices.present?
             = render '/users/practices/active_practices', user: current_user
@@ -64,18 +53,7 @@ header.page-header
           - if current_user.student_or_trainee?
             = render 'required_field', user: current_user
           - if current_user.after_graduation_hope?
-            .a-card
-              header.card-header.is-sm
-                h2.card-header__title
-                  | 卒業後のゴール
-              .card-body
-                .card__description
-                  .a-long-text.is-md
-                    = simple_format(current_user.after_graduation_hope)
-              .card-footer
-                .card-footer__footer-link
-                  = link_to edit_current_user_path(anchor: 'form-after-graduation-hope'), class: 'card-footer__footer-text-link' do
-                    | 内容を更新
+            = render 'after_graduation_hope', user: current_user
           - if (current_user.admin? || current_user.adviser?) && @job_seeking_users.present?
             = render 'job_seeking_users', users: @job_seeking_users
           - if current_user.student_or_trainee? && !cookies[:user_grass]

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -36,6 +36,8 @@ header.page-header
       .row
         .col-xs-12.col-xl-6.col-xxl-6
           = render partial: 'announcements'
+          - if current_user.mentor?
+            #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
           - if current_user.pages.wip.present? || current_user.reports.wip.present? || current_user.questions.wip.present? || current_user.products.wip.present?
             .a-card

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -9,4 +9,6 @@ header.page-header
 - if current_user.admin? || current_user.mentor?
   = render 'products/tabs'
 
-  #js-products(data-title="#{title}" data-selected-tab="all" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
+  .page-body
+    .container.is-md
+      #js-products(data-title="#{title}" data-selected-tab="all" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -11,4 +11,6 @@ header.page-header
 
 - title 'レビューを担当する未返信の提出物' if @target == 'self_assigned_no_replied'
 
-#js-products(data-title="#{title}" data-selected-tab="self-assigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
+.page-body
+  .container.is-md
+    #js-products(data-title="#{title}" data-selected-tab="self-assigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")

--- a/app/views/products/unassigned/index.html.slim
+++ b/app/views/products/unassigned/index.html.slim
@@ -8,4 +8,6 @@ header.page-header
 
 = render 'products/tabs'
 
-#js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
+.page-body
+  .container.is-md
+    #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -9,4 +9,6 @@ header.page-header
 = render 'products/tabs'
 = render 'nav'
 
-#js-products(data-title="#{title}" data-selected-tab="unchecked" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
+.page-body
+  .container.is-md
+    #js-products(data-title="#{title}" data-selected-tab="unchecked" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -245,4 +245,33 @@ class HomeTest < ApplicationSystemTestCase
     visit_with_auth '/', 'komagata'
     assert_no_text 'ようこそ'
   end
+
+  test 'mentor can check the number of days elapsed for products.' do
+    visit_with_auth '/', 'mentormentaro'
+    assert_text '7日以上経過（6）'
+    assert_text '6日経過（1）'
+    assert_text '5日経過（1）'
+    assert_text '今日提出（48）'
+  end
+
+  test 'mentor can see a button to open to open all unassigned products' do
+    visit_with_auth '/', 'mentormentaro'
+    assert_button '未アサインの提出物を一括で開く'
+  end
+
+  test 'click on open all unassigned submissions button' do
+    visit_with_auth '/', 'mentormentaro'
+
+    click_button '未アサインの提出物を一括で開く'
+
+    within_window(windows.last) do
+      newest_product = Product
+                       .unassigned
+                       .unchecked
+                       .not_wip
+                       .ascending_by_date_of_publishing_and_id
+                       .first
+      assert_text newest_product.body
+    end
+  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -253,25 +253,4 @@ class HomeTest < ApplicationSystemTestCase
     assert_text '5日経過（1）'
     assert_no_text '今日提出（48）'
   end
-
-  test 'mentor can see a button to open to open all unassigned products' do
-    visit_with_auth '/', 'mentormentaro'
-    assert_button '未アサインの提出物を一括で開く'
-  end
-
-  test 'click on open all unassigned submissions button' do
-    visit_with_auth '/', 'mentormentaro'
-
-    click_button '未アサインの提出物を一括で開く'
-
-    within_window(windows.last) do
-      newest_product = Product
-                       .unassigned
-                       .unchecked
-                       .not_wip
-                       .ascending_by_date_of_publishing_and_id
-                       .first
-      assert_text newest_product.body
-    end
-  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -246,12 +246,12 @@ class HomeTest < ApplicationSystemTestCase
     assert_no_text 'ようこそ'
   end
 
-  test 'mentor can check the number of days elapsed for products.' do
+  test 'mentor can products that are more than 5 days.' do
     visit_with_auth '/', 'mentormentaro'
     assert_text '7日以上経過（6）'
     assert_text '6日経過（1）'
     assert_text '5日経過（1）'
-    assert_text '今日提出（48）'
+    assert_no_text '今日提出（48）'
   end
 
   test 'mentor can see a button to open to open all unassigned products' do


### PR DESCRIPTION
## 概要
* メンターがダッシュボードの画面で5日以上経過した提出物を確認できるようにしました。
* 「担当する」ボタンも提出物一覧ページと同じく動作するようにしています。

## issue
https://github.com/fjordllc/bootcamp/issues/4677

## 変更箇所
赤枠で囲った箇所です。
<img width="1419" alt="スクリーンショット 2022-05-30 20 29 03" src="https://user-images.githubusercontent.com/20497053/170983232-b3d79f41-e0bf-4f54-b7f1-7bf253ff93b3.png">


## UI
### 変更前
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/20497053/170982931-4ef4eecb-b539-4e49-b5fd-377ff61c0a5d.png">


### 変更後
<img width="1406" alt="image" src="https://user-images.githubusercontent.com/20497053/170982818-bd1ab1d1-50c8-4836-becf-57d21cd2a368.png">

<img width="1414" alt="image" src="https://user-images.githubusercontent.com/20497053/170982848-63895f9a-636d-4e93-8296-b4497f65de16.png">



## 確認方法
* feature/show-submissions-older-than-5days-on-the-dashboard のブランチへ移動する
* mentormentaro でログインする
* トップページ（ダッシュボードのページ）に移動する
* ダッシュボードの左側に、5日以上経過した提出物が並んでいることを確認する
* 経過時間が5日よりも前の場合を確認する場合は、新規で提出物を作るか既存の提出物のデータを利用して、提出日、更新日をX日前に変更すると動作確認ができるようになります。
* ↑のデータの変更はローカル環境であれば `bin/rails c` でocnsoleを立ち上げて、対象のデータの書き換えを行えばOKです。

## テスト観点
- [x] メンターでログインするとダッシュボードの画面（パスは `/` ）に、未アサイン提出物が表示される
- [x] 対象のページ（パスは `/` ）に表示崩れがない
- [x] 対象のページ（パスは `/` ）にコンソールエラーが出ない
- [x] 未アサインの提出物は、5日以上経過しているものだけが表示される
- [x] 「担当する」ボタンを押すと、メンターが未アサインのものを自分の担当する提出物にできる
- [x] 「担当する」ボタンを押すと、自分の担当のところにその提出物が表示される
- [x]  `/products` 配下のページで不具合が起こらない（`/products/unassigned` と同じコンポーネントを使っているため）