### PR TITLE
日報一覧のtruncateを削除して全ての文字を表示する

### DIFF
--- a/app/views/api/reports/_report.json.jbuilder
+++ b/app/views/api/reports/_report.json.jbuilder
@@ -1,5 +1,5 @@
 json.id report.id
-json.title truncate(report.title, {length: 46, escape: false})
+json.title report.title
 json.reportedOn l(report.reported_on)
 json.url report_url(report)
 json.editURL edit_report_path(report)


### PR DESCRIPTION
## 概要
* 日報一覧のtruncate（テキストが長くなったら ... とかをつかって省略するもの）を削除し、全ての文字を表示するように修正しました。

## issue
https://github.com/fjordllc/bootcamp/issues/4835

## 変更箇所
赤枠で囲った箇所です。
<img width="1410" alt="スクリーンショット 2022-05-30 21 20 41" src="https://user-images.githubusercontent.com/20497053/170991285-8ea705c7-1edb-477e-9c82-130cfdeed338.png">

## UI
### 変更前
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/20497053/170991577-14bd4315-3ef2-429a-847f-3cb5a6bbb9e2.png">

### 変更後
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/20497053/170991137-fc8af157-cee4-4ddd-9d46-65a5ab5d0b9c.png">


## 確認方法
* feature/remove-trancate-for-report のブランチへ移動する
* 日報をかけるユーザーでログインする
* 日報の新規作成ページに遷移する
* 必要な情報と、タイトルに100文字くらい入力して日報を新規作成する
* 日報一覧画面に遷移して確認する

## テスト観点（受け入れテスト時の観点）
- [ ] 日報一覧ページに崩れがないこと
- [ ] 日報一覧ページで長いタイトルを入れても省略されずに全て表示されること
- [ ] 日報一覧から日報詳細に遷移できること