### PR TITLE
Docs作成時のdiscordの通知をタイトルとURLだけにする

### DIFF
--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -39,13 +39,10 @@ class PageCallbacks
       protocol: 'https'
     )
 
-    ChatNotifier.notify(
-      title: page.title,
-      title_url: page_url,
-      description: page.body,
-      user: page.user,
-      webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
-    )
+    ChatNotifier.message(<<~TEXT)
+      Docs：「#{page.title}」が作成されました。
+      #{page_url}
+    TEXT
   end
 
   def create_author_watch(page)

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -208,4 +208,38 @@ class PagesTest < ApplicationSystemTestCase
     end
     assert_link 'Linuxのファイル操作の基礎を覚える'
   end
+
+  test 'notify to chat after create a page' do
+    visit_with_auth new_page_path, 'kimura'
+    within('.form') do
+      fill_in('page[title]', with: 'test')
+      fill_in('page[body]', with: 'test')
+    end
+
+    mock_log = []
+    stub_info = proc { |i| mock_log << i }
+
+    Rails.logger.stub(:info, stub_info) do
+      click_button '内容を保存'
+    end
+
+    assert_text 'ページを作成しました'
+    assert_text 'Watch中'
+    assert_match 'Message to Discord.', mock_log.to_s
+  end
+
+  test 'notify to chat after update a page' do
+    target_page = pages(:page5)
+    visit_with_auth edit_page_path(target_page), 'kimura'
+
+    mock_log = []
+    stub_info = proc { |i| mock_log << i }
+
+    Rails.logger.stub(:info, stub_info) do
+      click_button '内容を保存'
+    end
+
+    assert_text 'ページを更新しました'
+    assert_match 'Message to Discord.', mock_log.to_s
+  end
 end


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/4547
## 概要
現状、Docsを作成時に本文が全てDiscordに通知されています。
この通知をQA投稿時と同じように「タイトル + URL」のみに変更しました。

## 確認手順
ローカル環境で通知内容を確認できないため、「Files changed」から確認いただければと思います。