### PR TITLE
提出通知をabstract_notifierに置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -76,17 +76,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def submitted(subject, receiver, message)
-      Notification.create!(
-        kind: kinds[:submitted],
-        user: receiver,
-        sender: subject.user,
-        link: Rails.application.routes.url_helpers.polymorphic_path(subject),
-        message: message,
-        read: false
-      )
-    end
-
     def came_answer(answer)
       Notification.create!(
         kind: kinds[:answered],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -36,7 +36,7 @@ class NotificationFacade
   end
 
   def self.submitted(subject, receiver, message)
-    Notification.submitted(subject, receiver, message)
+    ActivityNotifier.with(subject: subject, receiver: receiver, message: message).submitted.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -56,11 +56,11 @@ class ActivityNotifier < ApplicationNotifier
     message = params[:message]
 
     notification(
+      body: message,
       kind: :came_comment,
-      user: receiver,
+      receiver: receiver,
       sender: comment.sender,
       link: Rails.application.routes.url_helpers.polymorphic_path(comment.commentable),
-      message: message,
       read: false
     )
   end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -56,11 +56,27 @@ class ActivityNotifier < ApplicationNotifier
     message = params[:message]
 
     notification(
-      body: message,
       kind: :came_comment,
-      receiver: receiver,
+      user: receiver,
       sender: comment.sender,
       link: Rails.application.routes.url_helpers.polymorphic_path(comment.commentable),
+      message: message,
+      read: false
+    )
+  end
+
+  def submitted(params = {})
+    params.merge!(@params)
+    subject = params[:subject]
+    receiver = params[:receiver]
+    message = params[:message]
+
+    notification(
+      body: message,
+      kind: :submitted,
+      sender: subject.user,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(subject),
       read: false
     )
   end

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class Notification::ProductsTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test 'send adviser a notification when trainee create product' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice5).id}", 'kensyu'
 


### PR DESCRIPTION
# 関連Issue
- https://github.com/fjordllc/bootcamp/issues/4695

# 概要

- プラクティスの提出通知の実装を、[abstract_notifier](https://github.com/palkan/abstract_notifier)に置き換えました。
- 実装方針については、[卒業の通知](https://github.com/fjordllc/bootcamp/pull/4673)を参考にしています。
- 仕様の変更は無いので、変更前/変更後のスクリーンショットは割愛しました。

# 動作確認の方法

## 確認内容

生徒がプラクティスに提出物を提出したら、以下の動作が正常にされること。
- そのプラクティスをwatchしているメンター宛に通知が飛ぶ
- そのプラクティスをwatchしているメンター宛にメールが飛ぶ

## 確認手順

1. `feature/replace-the-submitted-notice-with-abstract_notifier` のブランチをローカルに持ってきて、`bin/setup` と`rails s` で起動する。
2. `mentormentaro`  でログインし、プラクティス「OS X Mountain Lionをクリーンインストールする」をwatchする。
3. `hatsuno` でログインし、プラクティス`OS X Mountain Lionをクリーンインストールする`の提出物を提出する。
4. `mentormentaro`  でログインし、未読通知に「hatsunoさんが「OS X Mountain Lionをクリーンインストールする」の提出物を提出しました。」が通知されていることを確認する。
![image](https://user-images.githubusercontent.com/770527/171086679-08e16842-54ac-4f02-8b84-a4a3f32cbe80.png)

6. `/letter_opener` に
  - 件名:「[bootcamp] hatsunoさんが「OS X Mountain Lionをクリーンインストールする」の提出物を提出しました。」
  - 送信先: mentormentaro@fjord.jp
  のメールが届いていることを確認する。
![image](https://user-images.githubusercontent.com/770527/171086734-a10b05a6-0eea-4abc-8b99-da6819b74fd9.png)


