### PR TITLE
user decoratorのテストがCIで落ちているため修正する

### DIFF
--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -27,7 +27,7 @@ class UserDecoratorTest < ActiveSupport::TestCase
   end
 
   test 'enrollment_period' do
-    assert_equal '<span> 3070日目 </span><a href="/generations/5">5期生</a>', @user2.enrollment_period
-    assert_equal '<span> (2015年01月01日卒業 365日) </span><a href="/generations/5">5期生</a>', @user3.enrollment_period
+    assert_equal "<span> #{@user2.elapsed_days}日目 </span><a href=\"/generations/#{@user2.generation}\">#{@user2.generation}期生</a>", @user2.enrollment_period
+    assert_equal "<span> (#{l @user3.graduated_on}卒業 #{@user3.elapsed_days}日) </span><a href=\"/generations/#{@user3.generation}\">#{@user2.generation}期生</a>", @user3.enrollment_period
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -28,6 +28,7 @@ class UserDecoratorTest < ActiveSupport::TestCase
 
   test 'enrollment_period' do
     assert_equal "<span> #{@user2.elapsed_days}日目 </span><a href=\"/generations/#{@user2.generation}\">#{@user2.generation}期生</a>", @user2.enrollment_period
-    assert_equal "<span> (#{l @user3.graduated_on}卒業 #{@user3.elapsed_days}日) </span><a href=\"/generations/#{@user3.generation}\">#{@user2.generation}期生</a>", @user3.enrollment_period
+    assert_equal "<span> (#{l @user3.graduated_on}卒業 #{@user3.elapsed_days}日) </span><a href=\"/generations/#{@user3.generation}\">#{@user2.generation}期生</a>",
+                 @user3.enrollment_period
   end
 end


### PR DESCRIPTION
## 概要
* https://github.com/fjordllc/bootcamp/pull/4786 のPRで書いたテストコードが文字列をベタ書きしていたため、日数の部分が合わなくなりテストが落ちてしまっていた。
* 上記の内容を修正し、ついでに卒業生に対してのテストも修正した。

## 該当箇所
https://github.com/fjordllc/bootcamp/pull/4786/files#diff-6cedd495484ea6401dd3037c3c252d1e56550fec9cb48d13eef341af69a1f30aR30

## UI
* 特に変更なし

## 確認方法
* hotfix/modify-user-decorator-test のブランチに移動し、テストを実行する
* テストの実行は `rails test test/decorators/user_decorator_test.rb` で実行できる