### PR TITLE
ブログ記事にサマリーを登録できるようにした

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -58,12 +58,12 @@ class ArticlesController < ApplicationController
   end
 
   def list_articles
-    articles = Article.includes(user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page])
+    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page])
     admin_or_mentor_login? ? articles : articles.where(wip: false)
   end
 
   def article_params
-    params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail)
+    params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail, :summary)
   end
 
   def redirect_url(article)

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -26,6 +26,12 @@
     .form-item
       .row
         .col-md-6.col-xs-12
+          = f.label :summary, class: 'a-form-label'
+          = f.text_field :summary, class: 'a-text-input'
+
+    .form-item
+      .row
+        .col-md-6.col-xs-12
           = f.label :tag_list, 'タグを入力してください（カンマ区切り）',
             class: 'a-form-label'
           = f.text_field :tag_list, class: 'a-text-input js-warning-form'

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -26,8 +26,13 @@
     .form-item
       .row
         .col-md-6.col-xs-12
-          = f.label :summary, class: 'a-form-label'
-          = f.text_field :summary, class: 'a-text-input'
+          = f.label '記事の概要・説明', class: 'a-form-label'
+          = f.text_area :summary, class: 'a-text-input'
+          .a-form-help
+            p
+              | ここに入力した文章が meta description に使われます。
+              | 検索結果に表示されるので、読んでみたいと思われるような
+              | 記事の説明・概要を100文字前後で入力してください。
 
     .form-item
       .row

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -42,6 +42,9 @@
                               = l(article.created_at)
                             - else
                               = l(article.published_at)
+                    .articles-item__row
+                      - if article.summary?
+                        = article.summary
         = paginate @articles
 
     = render 'ad'

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -1,4 +1,5 @@
 - title @article.title
+- set_meta_tags description: @article.summary if @article.summary.present?
 
 .welcome-page-header
   .container.is-xxl

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -166,6 +166,7 @@ ja:
         title: タイトル
         body: 本文
         user: ユーザー
+        summary: サマリー
       work:
         title: タイトル
         description: 説明

--- a/db/migrate/20220531063021_add_summary_to_articles.rb
+++ b/db/migrate/20220531063021_add_summary_to_articles.rb
@@ -1,0 +1,5 @@
+class AddSummaryToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :summary, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_18_054838) do
+ActiveRecord::Schema.define(version: 2022_05_31_063021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2022_04_18_054838) do
     t.bigint "user_id"
     t.boolean "wip", default: false, null: false
     t.datetime "published_at"
+    t.text "summary"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -227,4 +227,37 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_text '記事を更新しました'
     assert_text 'mentormentaro'
   end
+
+  test 'Summary text is used for meta description' do
+    visit_with_auth new_article_url, 'komagata'
+
+    fill_in 'article[title]', with: @article.title
+    fill_in 'article[summary]', with: 'サマリー１'
+    fill_in 'article[body]', with: @article.body
+    click_on '登録する'
+
+    assert_text '記事を作成しました'
+    assert_selector "meta[name='description'][content='サマリー１']", visible: false
+    assert_selector "meta[property='og:description'][content='サマリー１']", visible: false
+    assert_selector "meta[name='twitter:description'][content='サマリー１']", visible: false
+
+    visit articles_path
+    assert_text 'サマリー１'
+  end
+
+  test 'If there is no summary text, the fixed text is used for meta description' do
+    visit_with_auth new_article_url, 'komagata'
+
+    fill_in 'article[title]', with: @article.title
+    fill_in 'article[body]', with: @article.body
+    click_on '登録する'
+
+    assert_text '記事を作成しました'
+    assert_selector "meta[name='description'][content='現場の即戦力になれるプログラミングスクール。']", visible: false
+    assert_selector "meta[property='og:description'][content='現場の即戦力になれるプログラミングスクール。']", visible: false
+    assert_selector "meta[name='twitter:description'][content='現場の即戦力になれるプログラミングスクール。']", visible: false
+
+    visit articles_path
+    assert_no_text '現場の即戦力になれるプログラミングスクール。'
+  end
 end


### PR DESCRIPTION
# Issue
- https://github.com/fjordllc/bootcamp/issues/4839

# 概要

- ブログ記事に「サマリー」の項目をもたせる。
- ブログ投稿・編集フォームの本文の下に「サマリー」入力欄を追加する（プレビューは不要）。
- サマリーが入力されていたら、meta description にその文字列を指定する。
- サマリーは、ブログ一覧画面で表示する。
- サマリーは、ブログ個別画面で表示しない。

# 変更前

ブログ投稿画面
![image](https://user-images.githubusercontent.com/770527/171405590-a56fc66d-9d75-4694-a2c3-32ddd5ceee36.png)

# 変更後

サマリー入力前のブログ記事
![image](https://user-images.githubusercontent.com/770527/171405256-df815cdd-c5a9-47f4-bdfd-c1ad121c3f6b.png)

ブログ記事の編集画面、サマリー入力欄あり
![image](https://user-images.githubusercontent.com/770527/171404896-7f8fa074-5c58-41fa-b8b7-6a5d0f5d753c.png)

サマリー入力、保存後
![image](https://user-images.githubusercontent.com/770527/171405035-574da5bd-6485-468a-a740-018431a49fee.png)

# 動作確認の方法

## 確認内容

- 管理者がブログ記事にサマリーを登録した際、以下の動作が正常にされること。
  - ブログ一覧画面で、サマリーが表示されること
  - ブログ個別画面のmeta descriptionにサマリーの内容が指定されていること
- サマリーを空にした場合は、ブログ個別画面のmeta description に固定の文字列が表示されること。

## 確認手順

1. `feature/add-the-summary-field-to-the-blog-post` のブランチをローカルに持ってきて、`bin/setup` と`rails s` で起動する。
2. `komagata`  でログインし、`/articles/new`を開く。
3. タイトルと本文、サマリーに任意の文字列を入力し、登録する。
4. 表示されているブログの画面でソースを確認し、`meta description`、`og:description`、 `twitter:description`にサマリーで指定した文字列がセットされていることを確認する。
5. ヘッダーメニューの「ブログ」をクリックして、ブログ一覧を開く。
6. 3で登録したブログの記事にサマリーで指定した文字列が表示されていることを確認する。
7. 3で登録したブログの編集画面を開き、サマリーを空にして更新する。
8. 表示されているブログの画面でソースを確認し、`meta description`、`og:description`、 `twitter:description`に`現場の即戦力になれるプログラミングスクール。`がセットされていることを確認する。
9. ヘッダーメニューの「ブログ」をクリックして、ブログ一覧を開く。
10. 7で更新したブログの記事にサマリーの文字列が表示されていないことを確認する。