### PR TITLE
未ログイン時にユーザーアイコンメンションをブログに表示できるようにした

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
 class API::BaseController < ApplicationController
-  before_action :require_login_for_api, if: :not_before_user_icon_urls_controller?
-
-  def not_before_user_icon_urls_controller?
-    true
-  end
+  before_action :require_login_for_api
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class API::BaseController < ApplicationController
-  before_action :require_login_for_api, unless: :article_before_action?
+  before_action :require_login_for_api, unless: proc {request.headers[:referer].include?('articles')}
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 class API::BaseController < ApplicationController
-  before_action :require_login_for_api, unless: proc {request.headers[:referer].include?('articles')}
+  before_action :require_login_for_api, unless: :is_before_articles_contoroller?
+
+  def is_before_articles_contoroller?
+    Rails.application.routes.recognize_path(request.referer)[:controller] == 'articles'
+  end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class API::BaseController < ApplicationController
-  before_action :require_login_for_api
+  before_action :require_login_for_api, if: :article_before_action?
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class API::BaseController < ApplicationController
-  before_action :require_login_for_api, unless: :is_before_articles_contoroller?
+  before_action :require_login_for_api, if: :not_before_user_icon_urls_controller?
 
-  def is_before_articles_contoroller?
-    Rails.application.routes.recognize_path(request.referer)[:controller] == 'articles'
+  def not_before_user_icon_urls_controller?
+    true
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class API::BaseController < ApplicationController
-  before_action :require_login_for_api, if: :article_before_action?
+  before_action :require_login_for_api, unless: :article_before_action?
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -13,6 +13,6 @@ class API::UserIconUrlsController < API::BaseController
 
   def set_user_icon
     users = User.with_attached_avatar
-    logged_in? ? users : users.select {|test| !(test.avatar.blank?) }
+    logged_in? ? users : users.select {|user| !(user.avatar.blank?) }
   end
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -4,6 +4,6 @@ class API::UserIconUrlsController < API::BaseController
   skip_before_action :require_login_for_api
 
   def index
-    @users = User.with_attached_avatar.select { |user| user.avatar.present? }
+    @users = User.with_attached_avatar.where(id: ActiveStorage::Attachment.select(:record_id).where(record_type: 'User'))
   end
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -4,13 +4,6 @@ class API::UserIconUrlsController < API::BaseController
   skip_before_action :require_login_for_api
 
   def index
-    @users = set_user_icon
-  end
-
-  private
-
-  def set_user_icon
-    users = User.with_attached_avatar
-    logged_in? ? users : users.select { |user| user.avatar.present? }
+    @users = User.with_attached_avatar.select { |user| user.avatar.present? }
   end
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -4,6 +4,7 @@ class API::UserIconUrlsController < API::BaseController
   skip_before_action :require_login_for_api
 
   def index
-    @users = User.with_attached_avatar.where(id: ActiveStorage::Attachment.select(:record_id).where(record_type: 'User'))
+    #binding.pry
+    @users = User.with_attached_avatar.select(:id, :login_name).where(id: ActiveStorage::Attachment.select(:record_id).where(record_type: 'User'))
   end
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class API::UserIconUrlsController < API::BaseController
+  skip_before_action :require_login_for_api
+
   def index
     @users = set_user_icon
   end
@@ -10,9 +12,5 @@ class API::UserIconUrlsController < API::BaseController
   def set_user_icon
     users = User.with_attached_avatar
     logged_in? ? users : users.select { |user| user.avatar.present? }
-  end
-
-  def not_before_user_icon_urls_controller?
-    false
   end
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -2,6 +2,17 @@
 
 class API::UserIconUrlsController < API::BaseController
   def index
-    @users = User.with_attached_avatar
+    @users = set_user_icon
+  end
+
+  private
+
+  def article_before_action?
+    false
+  end
+
+  def set_user_icon
+    users = User.with_attached_avatar
+    logged_in? ? users : users.select {|test| !(test.avatar.blank?) }
   end
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -4,7 +4,6 @@ class API::UserIconUrlsController < API::BaseController
   skip_before_action :require_login_for_api
 
   def index
-    #binding.pry
     @users = User.with_attached_avatar.select(:id, :login_name).where(id: ActiveStorage::Attachment.select(:record_id).where(record_type: 'User'))
   end
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -8,7 +8,7 @@ class API::UserIconUrlsController < API::BaseController
   private
 
   def article_before_action?
-    false
+    true
   end
 
   def set_user_icon

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -9,6 +9,10 @@ class API::UserIconUrlsController < API::BaseController
 
   def set_user_icon
     users = User.with_attached_avatar
-    logged_in? ? users : users.select {|user| !(user.avatar.blank?) }
+    logged_in? ? users : users.select { |user| user.avatar.present? }
+  end
+
+  def not_before_user_icon_urls_controller?
+    false
   end
 end

--- a/app/controllers/api/user_icon_urls_controller.rb
+++ b/app/controllers/api/user_icon_urls_controller.rb
@@ -7,10 +7,6 @@ class API::UserIconUrlsController < API::BaseController
 
   private
 
-  def article_before_action?
-    true
-  end
-
   def set_user_icon
     users = User.with_attached_avatar
     logged_in? ? users : users.select {|user| !(user.avatar.blank?) }

--- a/app/javascript/user-icon-renderer.js
+++ b/app/javascript/user-icon-renderer.js
@@ -4,9 +4,7 @@ export default class {
     if (textareas.length === 0) {
       return null
     }
-    if (!window.signedIn) {
-      return null
-    }
+
     const response = await fetch('/api/user_icon_urls', {
       method: 'GET',
       credentials: 'same-origin',

--- a/test/integration/api/user_icon_urls_test.rb
+++ b/test/integration/api/user_icon_urls_test.rb
@@ -6,15 +6,13 @@ class API::UserIconUrlsTest < ActionDispatch::IntegrationTest
   fixtures :users
 
   test 'GET /api/user_icon_urls.json' do
+    # require_login_for_apiをskipしているため、tokenなしでもokを確認
     get api_user_icon_urls_path(format: :json)
-    user_icons = @controller.index
-    assert user_icons.empty?
+    assert_response :ok
 
     token = create_token('kimura', 'testtest')
     get api_user_icon_urls_path(format: :json),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    user_icons = @controller.index
-    assert_not user_icons.empty?
   end
 end

--- a/test/integration/api/user_icon_urls_test.rb
+++ b/test/integration/api/user_icon_urls_test.rb
@@ -7,11 +7,14 @@ class API::UserIconUrlsTest < ActionDispatch::IntegrationTest
 
   test 'GET /api/user_icon_urls.json' do
     get api_user_icon_urls_path(format: :json)
-    assert_response :unauthorized
+    user_icons = @controller.index
+    assert user_icons.empty?
 
     token = create_token('kimura', 'testtest')
     get api_user_icon_urls_path(format: :json),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
+    user_icons = @controller.index
+    assert_not user_icons.empty?
   end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -228,7 +228,11 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_text 'mentormentaro'
   end
 
+<<<<<<< HEAD
   test 'Summary text is used for meta description' do
+=======
+  test 'display user icon when not logged in' do
+>>>>>>> 24fba0fd3 (ESLintを通した)
     visit_with_auth new_article_url, 'komagata'
 
     fill_in 'article[title]', with: @article.title

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -281,4 +281,30 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_match(/ogp\.png$/, ogp_twitter_content)
     assert_match(/ogp\.png$/, ogp_othter_content)
   end
+
+  test 'display user icon when not logged in' do
+    visit_with_auth '/current_user/edit', 'komagata'
+
+    attach_file 'user[avatar]', Rails.root.join('test/fixtures/files/users/avatars/komagata.jpg'), make_visible: true
+    click_on '更新する'
+
+    find('.test-show-menu').click
+    click_link 'ログアウト'
+
+    visit_with_auth new_article_url, 'machida'
+    fill_in 'article[title]', with: 'test'
+    fill_in 'article[body]', with: ':@komagata:'
+
+    click_on '登録する'
+
+    click_link 'プラクティス'
+
+    find('.test-show-menu').click
+    click_link 'ログアウト'
+
+    visit articles_path
+    click_on 'test'
+
+    assert_selector "img[src$='komagata.jpg']"
+  end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -228,11 +228,7 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_text 'mentormentaro'
   end
 
-<<<<<<< HEAD
   test 'Summary text is used for meta description' do
-=======
-  test 'display user icon when not logged in' do
->>>>>>> 24fba0fd3 (ESLintを通した)
     visit_with_auth new_article_url, 'komagata'
 
     fill_in 'article[title]', with: @article.title


### PR DESCRIPTION
## issue
- #4895 

## 変更前
![_development__ブログタイトル___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/171452783-74fe61d5-0b26-4504-b00f-653cc882c2d0.png)


## 変更後
![_development__ブログタイトル___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/171453391-cb84ab15-4359-4071-a4f4-422c2bd1d0d1.png)


## 確認手順
1. ブランチ `feature/display-icon-on-the-blog-after-logout` をローカルに取り込む。
(例)
```
git fetch
git checkout feature/display-icon-on-the-blog-after-logout
```
2. 管理者（komagata）でログインする。
3. `Me`をクリックし、`ブログ投稿`をクリックする。
![_development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）_と_Comparing_main___feature_display-icon-on-the-blog-after-logout_·_fjordllc_bootcamp](https://user-images.githubusercontent.com/64620506/171453601-60e3bef5-ca05-4a27-b06f-9ac544752a53.png)
4. タイトルは任意に入力、本文に`:@machida:`を入力し、`登録する`をクリックする。
5. 右上の`プラクティス`->`Me`->`ログアウト`をクリックする。
6. `ブログ`をクリックする。
7. 作成したブログをクリックし、`:@machida:`のアイコンが表示されていることを確認する。

※`:@machida:`のアイコンが登録されていない場合は、machidaでログイン後、`Me`->`登録情報変更`にて、任意の画像をアップロードして更新してください。
