### PR TITLE
企業/ユーザー一覧から企業一覧にリンクを貼った

### DIFF
--- a/app/views/companies/users/_users_tabs.html.slim
+++ b/app/views/companies/users/_users_tabs.html.slim
@@ -4,3 +4,4 @@ nav.tab-nav
         - Companies::UsersController::TARGETS.each do |target|
           li.tab-nav__item
             = link_to t("target.#{target}"), company_users_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'
+            

--- a/app/views/companies/users/_users_tabs.html.slim
+++ b/app/views/companies/users/_users_tabs.html.slim
@@ -4,4 +4,3 @@ nav.tab-nav
         - Companies::UsersController::TARGETS.each do |target|
           li.tab-nav__item
             = link_to t("target.#{target}"), company_users_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'
-            

--- a/app/views/companies/users/index.html.slim
+++ b/app/views/companies/users/index.html.slim
@@ -8,8 +8,7 @@ header.page-header.is-border-bottom-none
         ul.page-header-actions__items
           li.page-header-actions__item
             = link_to companies_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | 企業一覧
-
+              |企業一覧
 
 = render 'companies/tabs', company: @company
 = render 'users_tabs', company: @company

--- a/app/views/companies/users/index.html.slim
+++ b/app/views/companies/users/index.html.slim
@@ -6,6 +6,10 @@ header.page-header.is-border-bottom-none
         = @company.name
       .page-header-actions
         ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to companies_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | 企業一覧
+
 
 = render 'companies/tabs', company: @company
 = render 'users_tabs', company: @company

--- a/app/views/companies/users/index.html.slim
+++ b/app/views/companies/users/index.html.slim
@@ -8,7 +8,7 @@ header.page-header.is-border-bottom-none
         ul.page-header-actions__items
           li.page-header-actions__item
             = link_to companies_path, class: 'a-button is-md is-secondary is-block is-back' do
-              |企業一覧
+              | 企業一覧
 
 = render 'companies/tabs', company: @company
 = render 'users_tabs', company: @company


### PR DESCRIPTION
## Issue

- #4773

## 概要

企業 > ユーザー一覧 に 企業一覧へのリンクを貼りました。

## 変更確認方法

1. ブランチ`feature/link-to-company-index`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. http://localhost:3000/companies の企業一覧から企業個別ページに入り、ユーザータブでユーザー一覧を表示
1. 企業一覧リンクが貼られているか確認する。 

## 変更前
<img width="1415" alt="スクリーンショット 2022-06-01 16 11 41" src="https://user-images.githubusercontent.com/96340764/171982673-9c704ff6-e579-4799-8e3a-7bc1f24ac7bd.png">


## 変更後
<img width="1046" alt="スクリーンショット 2022-06-03 17 05 15" src="https://user-images.githubusercontent.com/96340764/171982688-7798696d-5493-4df0-9cfc-f93a9e090539.png">

