### PR TITLE
相談部屋個別ページに、管理者のみに表示される一覧に戻るリンクを貼った

### DIFF
--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -5,6 +5,12 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         = title
+      - if current_user.admin?
+        .page-header-actions
+          ul.page-header-actions__items
+            li.page-header-actions__item
+              = link_to talks_path, class: 'a-button is-md is-secondary is-block is-back' do
+                | 相談部屋一覧
 
 .page-body
   .container.is-xxxl


### PR DESCRIPTION
## Issue

- [#4187](https://github.com/fjordllc/bootcamp/issues/4187)

## 概要

相談部屋個別ページに、管理者にだけ表示される一覧に戻るリンクを貼りました。 

## 変更確認方法

1. ブランチ`feature/link-to-talks-index-only-admin`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 管理者でログインする
4. 相談タブから相談部屋>相談部屋個別ページに移動する
5. 相談部屋一覧リンクを確認する

## 変更前

<img width="1433" alt="スクリーンショット 2022-06-05 21 24 16" src="https://user-images.githubusercontent.com/96340764/172053666-3eefe2c4-fafa-40e0-bf87-4c1e7eab198e.png">

## 変更後

<img width="1435" alt="スクリーンショット 2022-06-05 22 01 38" src="https://user-images.githubusercontent.com/96340764/172053636-b92cf5d9-5cc3-41e3-a063-7b18e33770ce.png">
