### PR TITLE
Questionモデルのスコープ内でサブクエリを使用するようにしてクエリの発行回数を減らした

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -25,8 +25,8 @@ class Question < ApplicationRecord
   validates :user, presence: true
   validates :published_at, presence: true, if: :will_be_published?
 
-  scope :solved, -> { where(id: CorrectAnswer.pluck(:question_id)) }
-  scope :not_solved, -> { where.not(id: CorrectAnswer.pluck(:question_id)) }
+  scope :solved, -> { where(id: CorrectAnswer.select(:question_id)) }
+  scope :not_solved, -> { where.not(id: CorrectAnswer.select(:question_id)) }
   scope :wip, -> { where(wip: true) }
   scope :not_wip, -> { where(wip: false) }
 


### PR DESCRIPTION
軽微ですが、スコープ内でサブクエリにすることで余計なクエリを発行しないようにしました。

- 参考
  - [サブクエリを利用する](https://tech.smarthr.jp/entry/2021/11/11/151444#:~:text=Jeremy%27%5D%2C%20%5B3%2C%20%27Jose%27%5D%5D-,%E3%82%B5%E3%83%96%E3%82%AF%E3%82%A8%E3%83%AA%E3%82%92%E5%88%A9%E7%94%A8%E3%81%99%E3%82%8B,-%E5%85%AC%E9%96%8B%E3%81%97%E3%81%A6)