### PR TITLE
イベント詳細ページで発生していたN+1を解消

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,12 +2,13 @@
 
 class EventsController < ApplicationController
   before_action :require_login
-  before_action :set_event, only: %i[show edit update destroy]
-  before_action :set_footprints, only: %i[show]
+  before_action :set_event, only: %i[edit update destroy]
 
   def index; end
 
   def show
+    @event = Event.with_avatar.find(params[:id])
+    @footprints = @event.footprints.with_avatar.order(created_at: :desc)
     footprint!
   end
 
@@ -66,10 +67,6 @@ class EventsController < ApplicationController
 
   def set_event
     @event = Event.find(params[:id])
-  end
-
-  def set_footprints
-    @footprints = @event.footprints.with_avatar.order(created_at: :desc)
   end
 
   def footprint!


### PR DESCRIPTION
## 概要

イベント詳細画面でuserとavatar_attachmentに対してN+1が発生していたので解消しました。

## 変更内容

- with_avatarを呼び出してuser,avatar_attachmentをpreloadするようにした
- showアクションのみが対象のため、eventオブジェクトのセットをアクション内で明示的に行うようにした
- 上記の影響でfootprintsもアクション内でセットした方が可読性が上がるため移譲