### PR TITLE
管理者でログイン時に相談部屋個別ページにタブを表示

### DIFF
--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -6,6 +6,9 @@ header.page-header
       h2.page-header__title
         = title
 
+- if admin_login?
+  = render 'users/page_tabs', user: @user
+
 .page-body
   .container.is-xxxl
     .row.is-jc:c

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -354,4 +354,16 @@ class TalksTest < ApplicationSystemTestCase
     fill_in 'js-talk-search-input', with: 'hoge'
     assert_text '一致する相談部屋はありません'
   end
+
+  test 'admin can see tabs on user talk page' do
+    user = users(:kimura)
+    visit_with_auth "/talks/#{user.talk.id}", 'komagata'
+    has_css?('page-tabs')
+  end
+
+  test 'non-admin user cannot see tabs on user talk page' do
+    user = users(:kimura)
+    visit_with_auth "/talks/#{user.talk.id}", 'kimura'
+    has_no_css?('page-tabs')
+  end
 end


### PR DESCRIPTION
## Issue

- #4931

## 概要

管理者でログイン時に相談部屋の個別ページにタブを表示させました。

タブの内容は、各ユーザーのプロフィールに表示されているものです。

![_development__marumarushain19___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMjJyQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--4fad32c19b8d61a3795fc892ae58cb7172d9fb81/_development__marumarushain19___FJORD_BOOT_CAMP%EF%BC%88%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%EF%BC%89.png)

## 変更確認方法

1. ブランチ`feature/display-tabs-on-talk-page-when-logged-in-as-admin`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 管理者権限を持つユーザーでログインする
4. `http://localhost:3000/talks`にアクセスし、任意のユーザーの相談部屋個別ページにアクセスする
5. 相談部屋個別ページ上部にタブが表示されていることを確認する
6. 各タブの動作を確認する
7. 管理者権限を持たないユーザーでログインし、相談部屋個別ページ上部にタブが**表示されていない**ことを確認する

## 変更前

![Cursor_と__development__marumarushain19さんの相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMnVyQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--708272e8857011262e4dc2f68a514acc155f5c3d/Cursor_%E3%81%A8__development__marumarushain19%E3%81%95%E3%82%93%E3%81%AE%E7%9B%B8%E8%AB%87%E9%83%A8%E5%B1%8B___FJORD_BOOT_CAMP%EF%BC%88%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%EF%BC%89.png)

## 変更後

<img width="1919" alt="_development__marumarushain19さんの相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/172099733-d7bbe5f9-c135-44d1-9fb8-92f8f18f6802.png">

<img width="1919" alt="_development__kimuraさんの相談部屋___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/172099507-c014863d-dcb0-40bf-a94f-29786f93e5a9.png">