### PR TITLE
未完了の提出物一覧を担当メンターで絞り込めるようにした

### DIFF
--- a/app/assets/stylesheets/blocks/form/_form-item.sass
+++ b/app/assets/stylesheets/blocks/form/_form-item.sass
@@ -9,6 +9,9 @@
   &.is-md
     width: 40rem
     max-width: 100%
+  .choices
+    width: 100%
+    z-index: 2
   .a-page-notice
     margin-bottom: 1rem
     border-radius: .25rem

--- a/app/assets/stylesheets/blocks/form/_talk-search.sass
+++ b/app/assets/stylesheets/blocks/form/_talk-search.sass
@@ -1,2 +1,0 @@
-.talk-search
-  margin-bottom: 1.75rem

--- a/app/assets/stylesheets/blocks/page-content/_page-content.sass
+++ b/app/assets/stylesheets/blocks/page-content/_page-content.sass
@@ -2,7 +2,13 @@
   width: $thread-max-width
   max-width: 100%
   +margin(horizontal, auto)
-  +media-breakpoint-up(md)
-    margin-bottom: 2rem
-  +media-breakpoint-down(sm)
-    margin-bottom: 1rem
+  &:not(:first-child)
+    +media-breakpoint-up(md)
+      margin-top: 1.25rem
+    +media-breakpoint-down(sm)
+      margin-top: 1rem
+  &:not(:last-child)
+    +media-breakpoint-up(md)
+      margin-bottom: 2rem
+    +media-breakpoint-down(sm)
+      margin-bottom: 1rem

--- a/app/assets/stylesheets/blocks/page/_o-empty-message.sass
+++ b/app/assets/stylesheets/blocks/page/_o-empty-message.sass
@@ -3,6 +3,8 @@
   +margin(horizontal, auto)
   text-align: center
   color: $semi-muted-text
+  &:not(:first-child)
+    margin-top: 1.5rem
 
 .o-empty-message__icon
   +text-block(5rem 1)

--- a/app/assets/stylesheets/blocks/page/_page-filter.sass
+++ b/app/assets/stylesheets/blocks/page/_page-filter.sass
@@ -1,0 +1,1 @@
+.page-filter

--- a/app/assets/stylesheets/blocks/shared/_pagination.sass
+++ b/app/assets/stylesheets/blocks/shared/_pagination.sass
@@ -3,12 +3,13 @@
   &:first-child
     +media-breakpoint-up(md)
       margin-bottom: 1rem
-      margin-top: -.75rem
     +media-breakpoint-down(sm)
       margin-bottom: .5rem
-      margin-top: -.25rem
-    .pill-nav + .page-body &
-      margin-top: 0
+    .page-content:first-child &
+      +media-breakpoint-up(md)
+        margin-top: -.5rem
+      +media-breakpoint-down(sm)
+        margin-top: -.25rem
   &:not(:first-child)
     +media-breakpoint-up(md)
       margin-top: 1rem

--- a/app/assets/stylesheets/blocks/shared/_pill-nav.sass
+++ b/app/assets/stylesheets/blocks/shared/_pill-nav.sass
@@ -1,11 +1,12 @@
+.pill-nav
+  &:not(:first-child)
+    padding-top: 1.25rem
+
 .pill-nav__items
   display: flex
-  +padding(vertical, .875rem)
   overflow-x: auto
   overflow-y: hidden
   justify-content: center
-  padding-top: 1.5rem
-  padding-bottom: 0
 
 .pill-nav__item
   &:first-child .pill-nav__item-link

--- a/app/assets/stylesheets/modules/_choices.sass
+++ b/app/assets/stylesheets/modules/_choices.sass
@@ -6,6 +6,7 @@ body
     border-color: $input-border
     padding: .25rem
     border-radius: 4px
+    min-height: 2.5rem
   .choices.is-focused .choices__inner
     background-color: $base
   .choices[data-type*=select-one] .choices__inner

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -6,7 +6,6 @@ class API::Products::UncheckedController < API::BaseController
     @target = params[:target]
     @target = 'unchecked_all' unless target_allowlist.include?(@target)
     @checker_id = params[:checker_id]
-    commenter_id = params[:checker_id].present? ? @checker_id : current_user.id
     @products = case @target
                 when 'unchecked_all'
                   Product.unchecked
@@ -15,13 +14,13 @@ class API::Products::UncheckedController < API::BaseController
                          .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 when 'unchecked_no_replied'
-                  Product.unchecked_no_replied_products(commenter_id)
+                  Product.unchecked_no_replied_products(current_user.id)
                          .unchecked
                          .not_wip
                          .list
                          .page(params[:page])
                 end
-    @products = @products.where(checker_id: commenter_id) if params[:checker_id].present?
+    @products = @products.where(checker_id: @checker_id) if @checker_id.present?
     @products_grouped_by_elapsed_days = @products.group_by { |product| product.elapsed_days >= 7 ? 7 : product.elapsed_days }
   end
 

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -5,7 +5,7 @@ class API::Products::UncheckedController < API::BaseController
   def index
     @target = params[:target]
     @target = 'unchecked_all' unless target_allowlist.include?(@target)
-    @checker_id = params[:checker_id]
+    checker_id = params[:checker_id]
     @products = case @target
                 when 'unchecked_all'
                   Product.unchecked
@@ -20,7 +20,7 @@ class API::Products::UncheckedController < API::BaseController
                          .list
                          .page(params[:page])
                 end
-    @products = @products.where(checker_id: @checker_id) if @checker_id.present?
+    @products = @products.where(checker_id: checker_id) if checker_id.present?
     @products_grouped_by_elapsed_days = @products.group_by { |product| product.elapsed_days >= 7 ? 7 : product.elapsed_days }
   end
 

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -5,6 +5,8 @@ class API::Products::UncheckedController < API::BaseController
   def index
     @target = params[:target]
     @target = 'unchecked_all' unless target_allowlist.include?(@target)
+    @checker_id = params[:checker_id]
+    params[:checker_id].present? ? commenter_id = @checker_id : commenter_id = current_user.id
     @products = case @target
                 when 'unchecked_all'
                   Product.unchecked
@@ -13,13 +15,13 @@ class API::Products::UncheckedController < API::BaseController
                          .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 when 'unchecked_no_replied'
-                  Product.unchecked_no_replied_products(current_user.id)
+                  Product.unchecked_no_replied_products(commenter_id)
                          .unchecked
                          .not_wip
                          .list
                          .page(params[:page])
                 end
-    @products = @products.where(checker_id: params[:checker_id]) if params[:checker_id].present?
+    @products = @products.where(checker_id: commenter_id) if params[:checker_id].present?
     @products_grouped_by_elapsed_days = @products.group_by { |product| product.elapsed_days >= 7 ? 7 : product.elapsed_days }
   end
 

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -6,7 +6,7 @@ class API::Products::UncheckedController < API::BaseController
     @target = params[:target]
     @target = 'unchecked_all' unless target_allowlist.include?(@target)
     @checker_id = params[:checker_id]
-    params[:checker_id].present? ? commenter_id = @checker_id : commenter_id = current_user.id
+    commenter_id = params[:checker_id].present? ? @checker_id : current_user.id
     @products = case @target
                 when 'unchecked_all'
                   Product.unchecked

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -19,6 +19,7 @@ class API::Products::UncheckedController < API::BaseController
                          .list
                          .page(params[:page])
                 end
+    @products = @products.where(checker_id: params[:checker_id]) if params[:checker_id].present?
     @products_grouped_by_elapsed_days = @products.group_by { |product| product.elapsed_days >= 7 ? 7 : product.elapsed_days }
   end
 

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -14,7 +14,7 @@ class API::Products::UncheckedController < API::BaseController
                          .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 when 'unchecked_no_replied'
-                  Product.unchecked_no_replied_products(current_user.id)
+                  Product.unchecked_no_replied_products
                          .unchecked
                          .not_wip
                          .list

--- a/app/controllers/products/unchecked_controller.rb
+++ b/app/controllers/products/unchecked_controller.rb
@@ -5,6 +5,7 @@ class Products::UncheckedController < ApplicationController
   def index
     @target = params[:target]
     @target = 'unchecked_all' unless target_allowlist.include?(@target)
+    @checker_id = params[:checker_id]
   end
 
   private

--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-#notifications.container.is-md.loaing(v-if='!loaded')
+#notifications.page-content.loaing(v-if='!loaded')
   loadingListPlaceholder
 .o-empty-message(v-else-if='notifications.length === 0')
   .o-empty-message__icon
@@ -8,7 +8,7 @@
     | 未読の通知はありません
   p.o-empty-message__text(v-else)
     | 通知はありません
-#notifications.container.is-md.loaded(v-else)
+#notifications.page-content.loaded(v-else)
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')
   .card-list.a-card

--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -1,14 +1,13 @@
 <template lang="pug">
 #notifications.container.is-md.loaing(v-if='!loaded')
   loadingListPlaceholder
-.container(v-else-if='notifications.length === 0')
-  .o-empty-message
-    .o-empty-message__icon
-      i.fa-regular.fa-smile
-    p.o-empty-message__text(v-if='isUnreadPage')
-      | 未読の通知はありません
-    p.o-empty-message__text(v-else)
-      | 通知はありません
+.o-empty-message(v-else-if='notifications.length === 0')
+  .o-empty-message__icon
+    i.fa-regular.fa-smile
+  p.o-empty-message__text(v-if='isUnreadPage')
+    | 未読の通知はありません
+  p.o-empty-message__text(v-else)
+    | 通知はありません
 #notifications.container.is-md.loaded(v-else)
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')

--- a/app/javascript/products.js
+++ b/app/javascript/products.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const selectedTab = products.getAttribute('data-selected-tab')
     const isMentor = products.getAttribute('data-mentor-login')
     const currentUserId = products.getAttribute('data-current-user-id')
+    const checkerId = products.getAttribute('data-checker-id')
     new Vue({
       store,
       render: (h) =>
@@ -18,7 +19,8 @@ document.addEventListener('DOMContentLoaded', () => {
             title: title,
             selectedTab: selectedTab,
             isMentor: isMentor === 'true',
-            currentUserId: currentUserId
+            currentUserId: currentUserId,
+            checkerId: checkerId
           }
         })
     }).$mount(selector)

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -91,7 +91,7 @@ export default {
     selectedTab: { type: String, required: true },
     isMentor: { type: Boolean, required: true },
     currentUserId: { type: String, required: true },
-    checkerId:  { type: String, required: false, default: null}
+    checkerId: { type: String, required: false, default: null }
   },
   data() {
     return {

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -91,7 +91,7 @@ export default {
     selectedTab: { type: String, required: true },
     isMentor: { type: Boolean, required: true },
     currentUserId: { type: String, required: true },
-    checkerId:  { type: String, required: false, default: 0}
+    checkerId:  { type: String, required: false, default: null}
   },
   data() {
     return {
@@ -217,7 +217,6 @@ export default {
           params[queryArr[0]] = queryArr[1]
         })
       return params
-      debugger;
     },
     countProductsGroupedBy({ elapsed_days: elapsedDays }) {
       const element = this.productsGroupedByElapsedDays.find(

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -196,9 +196,10 @@ export default {
     },
     newUrl(pageNumber) {
       const params = new URL(location.href).searchParams
-      if (pageNumber !== 1) params.set('page', pageNumber);
-      if (this.params.target) params.set('target', this.params.target);
-      if (this.params.checker_id) params.set('checker_id', this.params.checker_id);
+      if (pageNumber !== 1) params.set('page', pageNumber)
+      if (this.params.target) params.set('target', this.params.target)
+      if (this.params.checker_id)
+        params.set('checker_id', this.params.checker_id)
       return `${location.pathname}?${params}`
     },
     getParams() {

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -195,17 +195,11 @@ export default {
       window.scrollTo(0, 0)
     },
     newUrl(pageNumber) {
-      if (this.params.target) {
-        return (
-          location.pathname +
-          `?target=${this.params.target}` +
-          (pageNumber === 1 ? '' : `&page=${pageNumber}`)
-        )
-      } else {
-        return (
-          location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
-        )
-      }
+      const params = new URL(location.href).searchParams
+      if (pageNumber !== 1) params.set('page', pageNumber);
+      if (this.params.target) params.set('target', this.params.target);
+      if (this.params.checker_id) params.set('checker_id', this.params.checker_id);
+      return `${location.pathname}?${params}`
     },
     getParams() {
       const params = {}

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -90,7 +90,8 @@ export default {
     title: { type: String, required: true },
     selectedTab: { type: String, required: true },
     isMentor: { type: Boolean, required: true },
-    currentUserId: { type: String, required: true }
+    currentUserId: { type: String, required: true },
+    checkerId:  { type: String, required: false, default: 0}
   },
   data() {
     return {
@@ -110,6 +111,7 @@ export default {
           ? ''
           : '/' + this.selectedTab.replace('-', '_')) +
         `?page=${this.currentPage}` +
+        (this.checkerId ? `&checker_id=${this.checkerId}` : '') +
         (this.params.target ? `&target=${this.params.target}` : '')
       )
     },
@@ -215,6 +217,7 @@ export default {
           params[queryArr[0]] = queryArr[1]
         })
       return params
+      debugger;
     },
     countProductsGroupedBy({ elapsed_days: elapsedDays }) {
       const element = this.productsGroupedByElapsedDays.find(

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -1,12 +1,12 @@
 <template lang="pug">
-.products(v-if='!loaded')
+.page-content.products(v-if='!loaded')
   loadingListPlaceholder
 .o-empty-message(v-else-if='products.length === 0')
   .o-empty-message__icon
     i.fa-regular.fa-smile
   p.o-empty-message__text
     | {{ title }}はありません
-.products(v-else)
+.page-content.products(v-else)
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')
   .a-card(v-if='productsGroupedByElapsedDays === null')

--- a/app/javascript/reports.vue
+++ b/app/javascript/reports.vue
@@ -20,7 +20,9 @@ div(v-else)
         i.fa-regular.fa-sad-tear
       .o-empty-message__text
         | 日報はまだありません。
-  .page-content.reports(v-else-if='reports.length > 0 || !isUncheckedReportsPage')
+  .page-content.reports(
+    v-else-if='reports.length > 0 || !isUncheckedReportsPage'
+  )
     nav.pagination(v-if='totalPages > 1')
       pager(v-bind='pagerProps')
     .card-list.a-card

--- a/app/javascript/reports.vue
+++ b/app/javascript/reports.vue
@@ -14,13 +14,13 @@ div(v-if='limit')
 div(v-else)
   .reports.is-md(v-if='reports === null')
     loadingListPlaceholder
-  .reports(v-else-if='reports.length === 0')
+  .page-content.reports(v-else-if='reports.length === 0')
     .o-empty-message
       .o-empty-message__icon
         i.fa-regular.fa-sad-tear
       .o-empty-message__text
         | 日報はまだありません。
-  .reports(v-else-if='reports.length > 0 || !isUncheckedReportsPage')
+  .page-content.reports(v-else-if='reports.length > 0 || !isUncheckedReportsPage')
     nav.pagination(v-if='totalPages > 1')
       pager(v-bind='pagerProps')
     .card-list.a-card

--- a/app/javascript/talks.vue
+++ b/app/javascript/talks.vue
@@ -1,22 +1,22 @@
 <template lang="pug">
-.talks
-  .talk-search.form
+div
+  .page-filter.form
     .form__items
       .form-item.is-inline-md-up
         label.a-form-label
           | 絞り込み
-        input#js-talk-search-input.talk-search__text-input.a-text-input(
+        input#js-talk-search-input.a-text-input(
           v-model.trim='searchTalksWord',
           placeholder='ユーザーID、ユーザー名、読み方、Discord ID など'
         )
-  #talks.loading(v-if='!loaded')
+  #talks.page-content.loading(v-if='!loaded')
     loadingListPlaceholder
   .o-empty-message(v-else-if='talks.length === 0')
     .o-empty-message__icon
       i.fa-regular.fa-smile
     p.o-empty-message__text
       | 未返信の相談部屋はありません
-  #talks.loaded(v-else)
+  #talks.page-content.loaded(v-else)
     .talk-list(v-show='!showSearchedTalks')
       nav.pagination(v-if='totalPages > 1')
         pager(v-bind='pagerProps')

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -26,7 +26,7 @@ main.page-main
                     class: "a-button is-sm is-warning is-block #{current_user.notifications.by_target(@target.presence&.to_sym).unreads.empty? ? 'is-disabled' : ''}"
 
   .page-body
-    .container
+    .container.is-md
       nav.pill-nav
         .container
           ul.pill-nav__items

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -25,13 +25,13 @@ main.page-main
             = link_to "#{t("notification.#{@target}")}の通知を既読にする", read_by_category_path(target: @target), method: :post,
                     class: "a-button is-sm is-warning is-block #{current_user.notifications.by_target(@target.presence&.to_sym).unreads.empty? ? 'is-disabled' : ''}"
 
-  nav.pill-nav
-    .container
-      ul.pill-nav__items
-        li.pill-nav__item
-          = link_to '未読', notifications_path(status: 'unread', target: @target), class: "pill-nav__item-link #{params[:status] == 'unread' ? 'is-active' : ''}"
-        li.pill-nav__item
-          = link_to '全て', notifications_path(target: @target), class: "pill-nav__item-link #{params[:status] == 'unread' ? '' : 'is-active'}"
-
   .page-body
-    #js-notifications(data-is-mentor="#{mentor_login?}" data-target="#{@target}")
+    .container
+      nav.pill-nav
+        .container
+          ul.pill-nav__items
+            li.pill-nav__item
+              = link_to '未読', notifications_path(status: 'unread', target: @target), class: "pill-nav__item-link #{params[:status] == 'unread' ? 'is-active' : ''}"
+            li.pill-nav__item
+              = link_to '全て', notifications_path(target: @target), class: "pill-nav__item-link #{params[:status] == 'unread' ? '' : 'is-active'}"
+      #js-notifications(data-is-mentor="#{mentor_login?}" data-target="#{@target}")

--- a/app/views/products/unchecked/_nav.html.slim
+++ b/app/views/products/unchecked/_nav.html.slim
@@ -4,4 +4,4 @@ nav.pill-nav
       - targets = %w[unchecked_no_replied unchecked_all]
       - targets.each do |target|
         li.pill-nav__item
-          = link_to t("target.#{target}"), products_unchecked_index_path(target: target), class: (@target == target ? ['is-active'] : []) << 'pill-nav__item-link'
+          = link_to t("target.#{target}"), products_unchecked_index_path(target: target, checker_id: checker_id), class: (@target == target ? ['is-active'] : []) << 'pill-nav__item-link'

--- a/app/views/products/unchecked/_nav.html.slim
+++ b/app/views/products/unchecked/_nav.html.slim
@@ -1,7 +1,6 @@
 nav.pill-nav
-  .container.is-padding-horizontal-0-sm-dow
-    ul.pill-nav__items
-      - targets = %w[unchecked_no_replied unchecked_all]
-      - targets.each do |target|
-        li.pill-nav__item
-          = link_to t("target.#{target}"), products_unchecked_index_path(target: target, checker_id: checker_id), class: (@target == target ? ['is-active'] : []) << 'pill-nav__item-link'
+  ul.pill-nav__items
+    - targets = %w[unchecked_no_replied unchecked_all]
+    - targets.each do |target|
+      li.pill-nav__item
+        = link_to t("target.#{target}"), products_unchecked_index_path(target: target, checker_id: checker_id), class: (@target == target ? ['is-active'] : []) << 'pill-nav__item-link'

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -7,15 +7,17 @@ header.page-header
         = title
 
 = render 'products/tabs'
-nav.sort-nav
-  = form_with url: products_unchecked_index_path, local: true, method: 'get'
-    .container.is-md
-      .sort-nav__inner
-        = label_tag :checker_id, 'メンターで絞り込む', class: 'sort-nav__label'
-        .sort-nav__select
-          = select_tag :checker_id, options_from_collection_for_select(User.mentor.order(:login_name), :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
-= render 'nav', checker_id: @checker_id
 
 .page-body
   .container.is-md
+
+    .page-filter.form
+      = form_with url: products_unchecked_index_path, local: true, method: 'get'
+        .form__items
+          .form-item.is-inline-md-up
+            = label_tag :checker_id, 'メンターで絞り込む', class: 'a-form-label'
+            = select_tag :checker_id, options_from_collection_for_select(User.mentor.order(:login_name), :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select', class: 'a-text-input'
+
+    = render 'nav', checker_id: @checker_id
+
     #js-products(data-title="#{title}" data-selected-tab="unchecked" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}" data-checker-id="#{params[:checker_id]}")

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -13,7 +13,7 @@ nav.sort-nav
       .sort-nav__inner
         = label_tag :checker_id, 'メンターで絞り込む', class: 'sort-nav__label'
         .sort-nav__select
-          = select_tag :checker_id, options_from_collection_for_select(User.mentor, :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
+          = select_tag :checker_id, options_from_collection_for_select(User.mentor.order(:login_name), :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
 = render 'nav', checker_id: @checker_id
 
 .page-body

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -16,7 +16,7 @@ header.page-header
         .form__items
           .form-item.is-inline-md-up
             = label_tag :checker_id, 'メンターで絞り込む', class: 'a-form-label'
-            = select_tag :checker_id, options_from_collection_for_select(User.mentor.order(:login_name), :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select', class: 'a-text-input'
+            = select_tag :checker_id, options_from_collection_for_select(User.mentor.order(:login_name), :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
 
     = render 'nav', checker_id: @checker_id
 

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -7,6 +7,13 @@ header.page-header
         = title
 
 = render 'products/tabs'
+nav.sort-nav
+  = form_with url: products_unchecked_index_path, local: true, method: 'get'
+    .container.is-md
+      .sort-nav__inner
+        = label_tag :checker_id, 'メンターで絞り込む', class: 'sort-nav__label'
+        .sort-nav__select
+          = select_tag :checker_id, options_from_collection_for_select(User.mentor, :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
 = render 'nav'
 
 .page-body

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -14,7 +14,7 @@ nav.sort-nav
         = label_tag :checker_id, 'メンターで絞り込む', class: 'sort-nav__label'
         .sort-nav__select
           = select_tag :checker_id, options_from_collection_for_select(User.mentor, :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
-= render 'nav'
+= render 'nav', checker_id: @checker_id
 
 .page-body
   .container.is-md

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -15,7 +15,7 @@ header.page-header
       = form_with url: products_unchecked_index_path, local: true, method: 'get'
         .form__items
           .form-item.is-inline-md-up
-            = label_tag :checker_id, 'メンターで絞り込む', class: 'a-form-label'
+            = label_tag :checker_id, '担当メンターで絞り込む', class: 'a-form-label'
             = select_tag :checker_id, options_from_collection_for_select(User.mentor.order(:login_name), :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
 
     = render 'nav', checker_id: @checker_id

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -18,4 +18,4 @@ nav.sort-nav
 
 .page-body
   .container.is-md
-    #js-products(data-title="#{title}" data-selected-tab="unchecked" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
+    #js-products(data-title="#{title}" data-selected-tab="unchecked" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}" data-checker-id="#{params[:checker_id]}")

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -28,6 +28,17 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'GET /api/products/unchecked.json?checker_id=534981761' do
+    checker = users(:mentormentaro)
+    get api_products_unchecked_index_path(checker_id: checker.id, format: :json)
+    assert_response :unauthorized
+
+    token = create_token('mentormentaro', 'testtest')
+    get api_products_unchecked_index_path(checker_id: checker.id, format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
   test 'GET /api/products/self_assigned.json' do
     get api_products_self_assigned_index_path(format: :json)
     assert_response :unauthorized

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -151,6 +151,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     find('.pill-nav__item-link', text: '全て').click
     assert_current_path("/products/unchecked?checker_id=#{product.checker_id}&target=unchecked_all")
     assert_selector '.card-list-item__assignee-name', text: 'komagata'
+    assert_no_selector '.card-list-item__assignee-name', text: 'machida'
   end
 
   test "show only mentor's products if you select a mentor in products unchecked no replied" do
@@ -170,5 +171,6 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     find('.pill-nav__item-link', text: '未返信').click
     assert_current_path("/products/unchecked?checker_id=#{product.checker_id}&target=unchecked_no_replied")
     assert_selector '.card-list-item__assignee-name', text: 'komagata'
+    assert_no_selector '.card-list-item__assignee-name', text: 'machida'
   end
 end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -79,13 +79,32 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_text product.practice.title
   end
 
-  test 'display no-replied products if click on no-replied-button' do
+  test 'display no-comment products if click on no-replied-button' do
+    product = products(:product8)
+    visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
+    assert_text product.practice.title
+  end
+
+  test 'display products last commented by submitter if click on no-replied-button' do
     product = products(:product8)
     visit_with_auth "/products/#{product.id}", 'kimura'
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
+    assert_equal 'kimura', product.comments.last.user.login_name
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
     assert_text product.practice.title
+    assert_selector '.card-list-item-meta__item', text: '提出者'
+  end
+
+  test 'not display products last commented by mentor if click on no-replied-button' do
+    product = products(:product8)
+    visit_with_auth "/products/#{product.id}", 'mentormentaro'
+    fill_in('new_comment[description]', with: 'test')
+    click_button 'コメントする'
+    assert_equal 'mentormentaro', product.comments.last.user.login_name
+    visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
+    assert_no_text product.practice.title
+    assert_no_selector '.card-list-item-meta__item', text: 'メンター'
   end
 
   test 'display no-replied products if click on unchecked-all-button' do

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -134,22 +134,6 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_link '未完了一覧'
   end
 
-  test 'display products in listing unchecked if unchecked products all checked' do
-    checker = users(:komagata)
-    practice = practices(:practice47)
-    user = users(:mentormentaro)
-    product = Product.create!(
-      body: 'test',
-      user: user,
-      practice: practice,
-      checker_id: checker.id
-    )
-    visit_with_auth "/products/#{product.id}", 'komagata'
-    click_button '提出物を確認'
-    visit_with_auth '/products/unchecked?target=unchecked_all', 'komagata'
-    assert_no_text product.practice.title
-  end
-
   test "show only mentor's products if you select a mentor in products unchecked all" do
     user = users(:kimura)
     practice = practices(:practice47)

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -133,4 +133,58 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
     assert_link '未完了一覧'
   end
+
+  test 'display products in listing unchecked if unchecked products all checked' do
+    checker = users(:komagata)
+    practice = practices(:practice47)
+    user = users(:mentormentaro)
+    product = Product.create!(
+      body: 'test',
+      user: user,
+      practice: practice,
+      checker_id: checker.id
+    )
+    visit_with_auth "/products/#{product.id}", 'komagata'
+    click_button '提出物を確認'
+    visit_with_auth '/products/unchecked?target=unchecked_all', 'komagata'
+    assert_no_text product.practice.title
+  end
+
+  test "show only mentor's products if you select a mentor in products unchecked all" do
+    user = users(:kimura)
+    practice = practices(:practice47)
+    checker = users(:komagata)
+    product = Product.create!(
+      body: 'test',
+      user: user,
+      practice: practice,
+      checker_id: checker.id
+    )
+
+    visit_with_auth '/products/unchecked', 'mentormentaro'
+    find('.choices__list').click
+    find('#choices--js-choices-single-select-item-choice-2', text: 'komagata').click
+    find('.pill-nav__item-link', text: '全て').click
+    assert_current_path("/products/unchecked?checker_id=#{product.checker_id}&target=unchecked_all")
+    assert_selector '.card-list-item__assignee-name', text: 'komagata'
+  end
+
+  test "show only mentor's products if you select a mentor in products unchecked no replied" do
+    user = users(:kimura)
+    practice = practices(:practice47)
+    checker = users(:komagata)
+    product = Product.create!(
+      body: 'test',
+      user: user,
+      practice: practice,
+      checker_id: checker.id
+    )
+
+    visit_with_auth '/products/unchecked', 'mentormentaro'
+    find('.choices__list').click
+    find('#choices--js-choices-single-select-item-choice-2', text: 'komagata').click
+    find('.pill-nav__item-link', text: '未返信').click
+    assert_current_path("/products/unchecked?checker_id=#{product.checker_id}&target=unchecked_no_replied")
+    assert_selector '.card-list-item__assignee-name', text: 'komagata'
+  end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -305,7 +305,7 @@ class ProductsTest < ApplicationSystemTestCase
     all('.pagination .is-active').each do |active_button|
       assert active_button.has_text? '2'
     end
-    assert_current_path('/products?page=2')
+    assert_current_path('/products?_login_name=komagata&page=2')
   end
 
   test 'specify the page number in the URL' do


### PR DESCRIPTION
# Issue
- #4853 
- #5028 

- 関連issue
  - #3229
 
# 概要
- 未完了の提出物一覧(`http://localhost:3000/products/unchecked`)を、担当メンターで絞り込めるようにした。
- 未完了タブは、さらに【全て】タブと【未返信】タブに別れており、両方に絞り込み機能を実装した。
- プルダウンリストのメンターの並び順は、検索時に探しているメンターが大体どの辺にあるかを予想する助けになるため、アルファベット順(昇順)にソートした。

## ※仕様追加 (Issue #5028 )

元々、未返信タブには、 「ログインユーザーがコメントした提出物」以外全てが表示されていた。
これを、
- コメントが0件のもの
- (コメントが付いている場合、)最後のコメントが提出者であるもの

を表示するように変更した。

# 実装の背景
- これまで、提出物一覧ページでは、自分が担当の提出物一覧は【自分の担当】タブで見ることができたが、他のメンターが担当している提出物一覧は見ることができなかった。
- 体調不良等でメンターが突然担当の提出物を見ることができなくなった際、そのメンターが抱えている提出物を見る機能が無いため、実装することになった。

# データ受け渡しの流れ
```
リクエスト localhost:3000/products/unchecked?checker_id=1
↓
ルーティング：config/routes.rb (checker_idはクエリパラメーターで受取るので、今回は変更無し)
↓
コントローラ：app/controllers/products/unchecked_controller.rb
↓
ビューファイル：app/views/products/unchecked/index.html.slim 
         ("#{params[:checker_id]}"を変数data-checker-idに入れてproducts.js に渡す)
↓
JavaScriptをWebpacker経由で読み込む：app/javascript/packs/application.js
↓    　　　　　          ↓
↓　　　　　　　Vueファイルへ繋ぐ準備：app/javascript/products.js 
　　　　　　　　　　　(data-checker-idをcheckerIdに入れてproducts.vueに渡す)
↓　 　　　　　　　　　　　↓
↓  　　　Vue.jsで作成したページ：app/javascript/products.vue
↓　　　　　　　↓                 ↑
全体共通のレイアウト    Railsで作ったAPI：app/views/api/products/unchecked/index.json.jbuilder
↓　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　(`http://localhost:3000/products/unchecked.json?checker_id=メンターのid`でアクセスできる)
ブラウザでページ表示
```

# 変更点
## 全ての提出物を表示した時の【未返信】タブ (#5028 )
 |  変更前  |変更後  |
| ---- | ---- |
|  ![スクリーンショット 2022-06-19 14 31 30](https://user-images.githubusercontent.com/58052292/174467525-c6363a6c-e3c9-4684-8987-791f7128fc5a.png)|  ![スクリーンショット 2022-06-19 14 36 02](https://user-images.githubusercontent.com/58052292/174467476-2cbe57be-f907-40cf-bf35-694e9e0d678c.png)


## メンターを絞り込んだ時 (#4853 )の【全て】タブと【未返信】タブ

|  変更箇所  |  変更前  |変更後  |
| ---- | ---- | ---- |
|  【全て】 |![スクリーンショット 2022-06-08 22 59 26](https://user-images.githubusercontent.com/58052292/172636868-cb24679b-19f5-4338-aa8c-7fd60a978c89.png) |[![Image from Gyazo](https://i.gyazo.com/3451feb3f90517f28a62a7e4ded4cea7.gif)](https://gyazo.com/3451feb3f90517f28a62a7e4ded4cea7)
|  【未返信】 |![スクリーンショット 2022-06-08 23 00 03](https://user-images.githubusercontent.com/58052292/172637616-dcf8e930-75a5-461f-9a84-ca9e9aae881c.png)| ![スクリーンショット 2022-06-19 14 42 04](https://user-images.githubusercontent.com/58052292/174467627-564a1a7d-5d72-4429-8f7e-7ff8b133a3a0.png)


# 動作確認手順
1. `mentormentaro`でログイン
2. `/products/unchecked`(提出物一覧の未完了タブ)にアクセス
3. 「担当する」ボタンをクリックし、何件かの提出物を自分の担当にする
4. 担当になった提出物のうち1件に、コメントする (※「提出物を確認」をクリックしないように注意)
5. 担当になった提出物のうち1件に、提出者本人でコメントする
6. `komagata`(`mentormentaro`以外のメンター)でログインし直し、`/products/unchecked`にアクセス
7. 以下を確認する

## 全ての提出物を表示した時の【未返信】タブ (#5028 )

1. 【未返信】タブをクリック
2. **コメントが0件の提出物と、最後のコメントが提出者になっている提出物のみ**表示されているか確認

## メンターを絞り込んだ時 (#4853 )
### 【全て】タブ
1. 「メンターで絞り込む」と表示されているプルダウンリストで、`mentormentaro`を選択
2. 表示された提出物一覧の担当が、全て`mentormentaro`か確認

### 【未返信】タブ

1. 「メンターで絞り込む」と表示されているプルダウンリストで、`mentormentaro`を選択
2. 【未返信】タブをクリック
3. 表示された提出物一覧の担当が、全て`mentormentaro`か確認
4. ~`mentormentaro`が返信していない提出物のみが表示されているか確認~
**コメントが0件の提出物と、最後のコメントが提出者になっている提出物のみ**表示されているか確認


