### PR TITLE
卒業通知、退会通知、初日報通知の文言を変更

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -137,7 +137,7 @@ class Notification < ApplicationRecord
         user: receiver,
         sender: report.sender,
         link: Rails.application.routes.url_helpers.polymorphic_path(report),
-        message: "🎉#{report.user.login_name}さんがはじめての日報を書きました！",
+        message: "🎉 #{report.user.login_name}さんがはじめての日報を書きました！",
         read: false
       )
     end
@@ -161,7 +161,7 @@ class Notification < ApplicationRecord
         user: receiver,
         sender: sender,
         link: Rails.application.routes.url_helpers.polymorphic_path(sender),
-        message: "😢#{sender.login_name}さんが退会しました。",
+        message: "😢 #{sender.login_name}さんが退会しました。",
         read: false
       )
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -137,7 +137,7 @@ class Notification < ApplicationRecord
         user: receiver,
         sender: report.sender,
         link: Rails.application.routes.url_helpers.polymorphic_path(report),
-        message: "#{report.user.login_name}さんがはじめての日報を書きました！",
+        message: "🎉#{report.user.login_name}さんがはじめての日報を書きました！",
         read: false
       )
     end
@@ -161,7 +161,7 @@ class Notification < ApplicationRecord
         user: receiver,
         sender: sender,
         link: Rails.application.routes.url_helpers.polymorphic_path(sender),
-        message: "#{sender.login_name}さんが退会しました。",
+        message: "😢#{sender.login_name}さんが退会しました。",
         read: false
       )
     end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -10,7 +10,7 @@ class ActivityNotifier < ApplicationNotifier
     receiver = params[:receiver]
 
     notification(
-      body: "#{sender.login_name}さんが卒業しました。",
+      body: "🎉️️️#{sender.login_name}さんが卒業しました！",
       kind: :graduated,
       sender: sender,
       receiver: receiver,

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -10,7 +10,7 @@ class ActivityNotifier < ApplicationNotifier
     receiver = params[:receiver]
 
     notification(
-      body: "🎉️️️#{sender.login_name}さんが卒業しました！",
+      body: "🎉️ ️️#{sender.login_name}さんが卒業しました！",
       kind: :graduated,
       sender: sender,
       receiver: receiver,

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -65,7 +65,7 @@ notification_questioned:
 notification_first_report:
   user: komagata
   sender: hajime
-  message: hajimeさんがはじめての日報を書きました！
+  message: 🎉 hajimeさんがはじめての日報を書きました！
   link: "/reports/<%= ActiveRecord::FixtureSet.identify(:report10) %>"
   read: false
 
@@ -81,7 +81,7 @@ notification_retired:
   kind: 9
   user: komagata
   sender: yameo
-  message: yameoさんが退会しました。
+  message: 😢 yameoさんが退会しました。
   link: "/users/<%= ActiveRecord::FixtureSet.identify(:yameo) %>"
   read: false
 
@@ -136,6 +136,6 @@ notification_graduated:
   kind: 18
   user: mentormentaro
   sender: sotugyou
-  message: sotugyouさんが卒業しました。
+  message: 🎉 sotugyouさんが卒業しました。
   link: "/users/<%= ActiveRecord::FixtureSet.identify(:sotugyou) %>"
   read: false

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -90,7 +90,7 @@ notification_first_report:
   kind: 7
   user: komagata
   sender: hajime
-  message: hajimeさんがはじめての日報を書きました！
+  message: 🎉 hajimeさんがはじめての日報を書きました！
   link: "/reports/<%= ActiveRecord::FixtureSet.identify(:report10) %>"
   read: false
 
@@ -106,7 +106,7 @@ notification_retired:
   kind: 9
   user: komagata
   sender: yameo
-  message: yameoさんが退会しました。
+  message: 😢 yameoさんが退会しました。
   link: "/users/<%= ActiveRecord::FixtureSet.identify(:yameo) %>"
   read: false
 
@@ -170,6 +170,6 @@ notification_graduated:
   kind: 18
   user: mentormentaro
   sender: sotugyou
-  message: sotugyouさんが卒業しました。
+  message: 🎉 sotugyouさんが卒業しました。
   link: "/users/<%= ActiveRecord::FixtureSet.identify(:sotugyou) %>"
   read: false

--- a/test/system/notification/graduation_test.rb
+++ b/test/system/notification/graduation_test.rb
@@ -25,7 +25,7 @@ class Notification::GraduationTest < ApplicationSystemTestCase
 
     visit_with_auth '/notifications', 'mentormentaro'
     within first('.card-list-item.is-unread') do
-      assert_text '🎉️️️kimuraさんが卒業しました！'
+      assert_text '🎉️ ️️kimuraさんが卒業しました！'
     end
   end
 end

--- a/test/system/notification/graduation_test.rb
+++ b/test/system/notification/graduation_test.rb
@@ -25,7 +25,7 @@ class Notification::GraduationTest < ApplicationSystemTestCase
 
     visit_with_auth '/notifications', 'mentormentaro'
     within first('.card-list-item.is-unread') do
-      assert_text 'kimuraさんが卒業しました。'
+      assert_text '🎉️️️kimuraさんが卒業しました！'
     end
   end
 end

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -11,9 +11,9 @@ class RetirementTest < ApplicationSystemTestCase
     page.driver.browser.switch_to.alert.accept
     assert_text '退会処理が完了しました'
     assert_equal Date.current, user.reload.retired_on
-    assert_equal 'kananashiさんが退会しました。', users(:komagata).notifications.last.message
-    assert_equal 'kananashiさんが退会しました。', users(:machida).notifications.last.message
-    assert_equal 'kananashiさんが退会しました。', users(:mentormentaro).notifications.last.message
+    assert_equal '😢kananashiさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal '😢kananashiさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal '😢kananashiさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'kananashi', 'testtest'
     assert_text 'ログインができません'
@@ -25,9 +25,9 @@ class RetirementTest < ApplicationSystemTestCase
     page.driver.browser.switch_to.alert.accept
     assert_text '退会処理が完了しました'
     assert_equal Date.current, user.reload.retired_on
-    assert_equal 'osnashiさんが退会しました。', users(:komagata).notifications.last.message
-    assert_equal 'osnashiさんが退会しました。', users(:machida).notifications.last.message
-    assert_equal 'osnashiさんが退会しました。', users(:mentormentaro).notifications.last.message
+    assert_equal '😢osnashiさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal '😢osnashiさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal '😢osnashiさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'osnashi', 'testtest'
     assert_text 'ログインができません'
@@ -41,9 +41,9 @@ class RetirementTest < ApplicationSystemTestCase
     page.accept_confirm
     assert_text '退会処理が完了しました'
     assert_equal Date.current, user.reload.retired_on
-    assert_equal 'discordinvalidさんが退会しました。', users(:komagata).notifications.last.message
-    assert_equal 'discordinvalidさんが退会しました。', users(:machida).notifications.last.message
-    assert_equal 'discordinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
+    assert_equal '😢discordinvalidさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal '😢discordinvalidさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal '😢discordinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'discordinvalid', 'testtest'
     assert_text 'ログインができません'
@@ -57,9 +57,9 @@ class RetirementTest < ApplicationSystemTestCase
     page.accept_confirm
     assert_text '退会処理が完了しました'
     assert_equal Date.current, user.reload.retired_on
-    assert_equal 'twitterinvalidさんが退会しました。', users(:komagata).notifications.last.message
-    assert_equal 'twitterinvalidさんが退会しました。', users(:machida).notifications.last.message
-    assert_equal 'twitterinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
+    assert_equal '😢twitterinvalidさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal '😢twitterinvalidさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal '😢twitterinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'twitterinvalid', 'testtest'
     assert_text 'ログインができません'

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -11,9 +11,9 @@ class RetirementTest < ApplicationSystemTestCase
     page.driver.browser.switch_to.alert.accept
     assert_text '退会処理が完了しました'
     assert_equal Date.current, user.reload.retired_on
-    assert_equal '😢kananashiさんが退会しました。', users(:komagata).notifications.last.message
-    assert_equal '😢kananashiさんが退会しました。', users(:machida).notifications.last.message
-    assert_equal '😢kananashiさんが退会しました。', users(:mentormentaro).notifications.last.message
+    assert_equal '😢 kananashiさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal '😢 kananashiさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal '😢 kananashiさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'kananashi', 'testtest'
     assert_text 'ログインができません'
@@ -25,9 +25,9 @@ class RetirementTest < ApplicationSystemTestCase
     page.driver.browser.switch_to.alert.accept
     assert_text '退会処理が完了しました'
     assert_equal Date.current, user.reload.retired_on
-    assert_equal '😢osnashiさんが退会しました。', users(:komagata).notifications.last.message
-    assert_equal '😢osnashiさんが退会しました。', users(:machida).notifications.last.message
-    assert_equal '😢osnashiさんが退会しました。', users(:mentormentaro).notifications.last.message
+    assert_equal '😢 osnashiさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal '😢 osnashiさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal '😢 osnashiさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'osnashi', 'testtest'
     assert_text 'ログインができません'
@@ -41,9 +41,9 @@ class RetirementTest < ApplicationSystemTestCase
     page.accept_confirm
     assert_text '退会処理が完了しました'
     assert_equal Date.current, user.reload.retired_on
-    assert_equal '😢discordinvalidさんが退会しました。', users(:komagata).notifications.last.message
-    assert_equal '😢discordinvalidさんが退会しました。', users(:machida).notifications.last.message
-    assert_equal '😢discordinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
+    assert_equal '😢 discordinvalidさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal '😢 discordinvalidさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal '😢 discordinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'discordinvalid', 'testtest'
     assert_text 'ログインができません'
@@ -57,9 +57,9 @@ class RetirementTest < ApplicationSystemTestCase
     page.accept_confirm
     assert_text '退会処理が完了しました'
     assert_equal Date.current, user.reload.retired_on
-    assert_equal '😢twitterinvalidさんが退会しました。', users(:komagata).notifications.last.message
-    assert_equal '😢twitterinvalidさんが退会しました。', users(:machida).notifications.last.message
-    assert_equal '😢twitterinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
+    assert_equal '😢 twitterinvalidさんが退会しました。', users(:komagata).notifications.last.message
+    assert_equal '😢 twitterinvalidさんが退会しました。', users(:machida).notifications.last.message
+    assert_equal '😢 twitterinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
 
     login_user 'twitterinvalid', 'testtest'
     assert_text 'ログインができません'


### PR DESCRIPTION
## Issue

- #4840 

## 概要

卒業通知、退会通知、初日報通知の文言を変更しました。
また、開発環境用のデータとテストで使用するデータについても変更しております。

## 変更確認方法

1. ブランチ`feature/replace-the-wording-of-the-notice-with-a-clearer-one`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `advijirou`など、日報を書いていないユーザーでログインして日報を書く
4. 任意のユーザーでログインして退会する
5. 管理者権限を持つユーザーでログインし、`http://localhost:3000/admin/users`にアクセスして任意のユーザー（アクティブ状態）を卒業させる
6. `http://localhost:3000/notifications`で通知を確認する

動作確認後は、以下を実行して開発環境のデータをリセットしてください。

```sh
$ rails db:migrate:reset
$ rails db:seed
```

## 変更前

卒業通知と退会通知の区別がつきにくい。

![_development__通知___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBN3lyQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--6e7c1e2ed940420c9a3055588321e71d9cd254ef/_development__%E9%80%9A%E7%9F%A5___FJORD_BOOT_CAMP%EF%BC%88%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%EF%BC%89.png)

## 変更後

![_development__通知___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBN3FyQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--b790ae8f8121b19f40b993a632c08701da47cefa/_development__%E9%80%9A%E7%9F%A5___FJORD_BOOT_CAMP%EF%BC%88%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%EF%BC%89.png)