### PR TITLE
自分の作成したWIPのお知らせとWIPのイベントの一覧をダッシュボードに表示できるようにした

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -19,4 +19,8 @@ module HomeHelper
       blog_url: 'form-blog-url'
     }[attribute]
   end
+
+  def wip_present?(user)
+    user.pages.wip.present? || user.reports.wip.present? || user.questions.wip.present? || user.products.wip.present? || user.announcements.wip.present? || user.events.wip.present?
+  end
 end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -19,8 +19,4 @@ module HomeHelper
       blog_url: 'form-blog-url'
     }[attribute]
   end
-
-  def wip_present?(user)
-    user.pages.wip.present? || user.reports.wip.present? || user.questions.wip.present? || user.products.wip.present? || user.announcements.wip.present? || user.events.wip.present?
-  end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -27,4 +27,6 @@ class Announcement < ApplicationRecord
   validates :target, presence: true
 
   columns_for_keyword_search :title, :description
+
+  scope :wip, -> { where(wip: true) }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -40,6 +40,8 @@ class Event < ApplicationRecord
 
   columns_for_keyword_search :title, :description
 
+  scope :wip, -> { where(wip: true) }
+
   def opening?
     Time.current.between?(open_start_at, open_end_at)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -635,7 +635,7 @@ class User < ApplicationRecord
     Cache.delete_mentioned_and_unread_notification_count(id)
   end
 
-  def has_wip_contents?
+  def wip_owned?
     wip_contents = pages.wip + reports.wip + questions.wip + products.wip + announcements.wip + events.wip
     wip_contents.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -635,7 +635,7 @@ class User < ApplicationRecord
     Cache.delete_mentioned_and_unread_notification_count(id)
   end
 
-  def wip_owned?
+  def own_wip?
     wip_contents = pages.wip + reports.wip + questions.wip + products.wip + announcements.wip + events.wip
     wip_contents.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -635,6 +635,11 @@ class User < ApplicationRecord
     Cache.delete_mentioned_and_unread_notification_count(id)
   end
 
+  def wip_present?
+    user_wip = pages.wip + reports.wip + questions.wip + products.wip + announcements.wip + events.wip
+    user_wip.present?
+  end
+
   private
 
   def password_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -635,9 +635,9 @@ class User < ApplicationRecord
     Cache.delete_mentioned_and_unread_notification_count(id)
   end
 
-  def wip_present?
-    user_wip = pages.wip + reports.wip + questions.wip + products.wip + announcements.wip + events.wip
-    user_wip.present?
+  def has_wip_contents?
+    wip_contents = pages.wip + reports.wip + questions.wip + products.wip + announcements.wip + events.wip
+    wip_contents.present?
   end
 
   private

--- a/app/views/home/_wip_items.html.slim
+++ b/app/views/home/_wip_items.html.slim
@@ -13,3 +13,5 @@
       = render 'users/products/wip_products', user: current_user
     - if current_user.announcements.wip.present?
       = render 'users/announcements/wip_announcements', user: current_user
+    - if current_user.events.wip.present?
+      = render 'users/events/wip_events', user: current_user

--- a/app/views/home/_wip_items.html.slim
+++ b/app/views/home/_wip_items.html.slim
@@ -11,3 +11,5 @@
       = render 'users/questions/wip_questions', user: current_user
     - if current_user.products.wip.present?
       = render 'users/products/wip_products', user: current_user
+    - if current_user.announcements.wip.present?
+      = render 'users/announcements/wip_announcements', user: current_user

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -40,7 +40,7 @@ header.page-header
           - if current_user.mentor?
             #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
-          - if current_user.pages.wip.present? || current_user.reports.wip.present? || current_user.questions.wip.present? || current_user.products.wip.present?
+          - if current_user.pages.wip.present? || current_user.reports.wip.present? || current_user.questions.wip.present? || current_user.products.wip.present? || current_user.announcements.wip.present?
             = render 'wip_items'
 
           - if current_user.active_practices.present?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -40,7 +40,7 @@ header.page-header
           - if current_user.mentor?
             #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
-          - if current_user.wip_present?
+          - if current_user.has_wip_contents?
             = render 'wip_items'
 
           - if current_user.active_practices.present?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -40,7 +40,7 @@ header.page-header
           - if current_user.mentor?
             #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
-          - if wip_present?(current_user)
+          - if current_user.wip_present?
             = render 'wip_items'
 
           - if current_user.active_practices.present?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -40,7 +40,7 @@ header.page-header
           - if current_user.mentor?
             #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
-          - if current_user.has_wip_contents?
+          - if current_user.wip_owned?
             = render 'wip_items'
 
           - if current_user.active_practices.present?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -40,7 +40,7 @@ header.page-header
           - if current_user.mentor?
             #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
-          - if current_user.pages.wip.present? || current_user.reports.wip.present? || current_user.questions.wip.present? || current_user.products.wip.present? || current_user.announcements.wip.present? || current_user.events.wip.present?
+          - if wip_present?(current_user)
             = render 'wip_items'
 
           - if current_user.active_practices.present?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -40,7 +40,7 @@ header.page-header
           - if current_user.mentor?
             #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
-          - if current_user.wip_owned?
+          - if current_user.own_wip?
             = render 'wip_items'
 
           - if current_user.active_practices.present?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -40,7 +40,7 @@ header.page-header
           - if current_user.mentor?
             #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
 
-          - if current_user.pages.wip.present? || current_user.reports.wip.present? || current_user.questions.wip.present? || current_user.products.wip.present? || current_user.announcements.wip.present?
+          - if current_user.pages.wip.present? || current_user.reports.wip.present? || current_user.questions.wip.present? || current_user.products.wip.present? || current_user.announcements.wip.present? || current_user.events.wip.present?
             = render 'wip_items'
 
           - if current_user.active_practices.present?

--- a/app/views/users/announcements/_wip_announcements.html.slim
+++ b/app/views/users/announcements/_wip_announcements.html.slim
@@ -1,0 +1,17 @@
+- user.announcements.wip.each do |announcement|
+  .card-list-item.is-announcement
+    .card-list-item__inner
+      .card-list-item__rows
+        .card-list-item__row
+          .card-list-item-title
+            .card-list-item-title__start
+              .card-list-item-title__icon.is-announcement
+                | お知らせ
+              .card-list-item-title__title
+                = link_to announcement.title, announcement, class: 'card-list-item-title__link a-text-link'
+        .card-list-item__row
+          .card-list-item-meta
+            .card-list-item-meta__items
+              .card-list-item-meta__item
+                time.a-meta datetime= announcement.updated_at
+                  = l announcement.updated_at

--- a/app/views/users/events/_wip_events.html.slim
+++ b/app/views/users/events/_wip_events.html.slim
@@ -1,0 +1,17 @@
+- user.events.wip.each do |event|
+  .card-list-item.is-event
+    .card-list-item__inner
+      .card-list-item__rows
+        .card-list-item__row
+          .card-list-item-title
+            .card-list-item-title__start
+              .card-list-item-title__icon.is-event
+                | イベント
+              .card-list-item-title__title
+                = link_to event.title, event, class: 'card-list-item-title__link a-text-link'
+        .card-list-item__row
+          .card-list-item-meta
+            .card-list-item-meta__items
+              .card-list-item-meta__item
+                time.a-meta datetime= event.updated_at
+                  = l event.updated_at

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -530,4 +530,12 @@ class UserTest < ActiveSupport::TestCase
     reports = User.depressed_reports(user_ids)
     assert_equal 0, reports.size
   end
+
+  test '#wip_owned?' do
+    user = users(:machida)
+    assert_not user.wip_owned?
+
+    Report.create!(user_id: user.id, title: 'WIP test', description: 'WIP test', wip: true, reported_on: Time.current)
+    assert user.wip_owned?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -531,11 +531,11 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 0, reports.size
   end
 
-  test '#wip_owned?' do
+  test '#own_wip?' do
     user = users(:machida)
-    assert_not user.wip_owned?
+    assert_not user.own_wip?
 
     Report.create!(user_id: user.id, title: 'WIP test', description: 'WIP test', wip: true, reported_on: Time.current)
-    assert user.wip_owned?
+    assert user.own_wip?
   end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -253,4 +253,38 @@ class HomeTest < ApplicationSystemTestCase
     assert_text '5日経過（1）'
     assert_no_text '今日提出（48）'
   end
+
+  test "show my wip's announcement on dashboard" do
+    visit_with_auth '/', 'komagata'
+    assert_text 'WIPで保存中'
+    within '.card-list-item.is-announcement' do
+      assert_text 'お知らせ'
+      find_link 'wipのお知らせ'
+      assert_text I18n.l announcements(:announcement_wip).updated_at
+    end
+  end
+
+  test "show my wip's event on dashboard" do
+    visit_with_auth '/', 'kimura'
+    click_link 'イベント'
+    click_link 'イベント作成'
+    fill_in 'event[title]', with: 'WIPのイベント'
+    fill_in 'event[location]', with: 'オンライン'
+    fill_in 'event[capacity]', with: 100
+    fill_in 'event[start_at]', with: Time.current.next_month
+    fill_in 'event[end_at]', with:  Time.current.next_month + 1.hour
+    fill_in 'event[open_start_at]', with: Time.current
+    fill_in 'event[open_end_at]', with: Time.current + 20.days
+    fill_in 'event[description]', with: 'WIPイベント本文'
+    click_button 'WIP'
+
+    visit '/'
+    assert_text 'WIPで保存中'
+    within '.card-list-item.is-event' do
+      assert_text 'イベント'
+      find_link 'WIPのイベント'
+      event = Event.find_by(title: 'WIPのイベント')
+      assert_text I18n.l event.updated_at
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #4727

## 概要
自分の作成したWIPのお知らせとWIPのイベントの一覧をダッシュボードに表示できるようにしました。

## 変更確認方法
1. ブランチ`feature/add-wips-announcement-and-event-to-dashboard`をローカルに取り込みます。
2. `bin/rails s`でローカル環境を立ち上げます。
3. kimuraでログインします。
4. お知らせ作成ページ(http://localhost:3000/announcements/new )からお知らせ作成のフォーマットを完成させWIPで保存します。
5. ダッシュボード(http://localhost )に移動し、4で作成したお知らせがWIPで保存中の一覧に表示されているか確認します。
6. 次にイベント作成ページ(http://localhost3000/events/new )からイベント作成のフォーマットを完成させWIPで保存します。
7.  再度ダッシュボード(http://localhost )を確認し、6で作成したイベントがWIPで保存中の一覧に表示されているか確認します。

## 変更前
<img width="965" alt="スクリーンショット 2022-06-07 14 34 09" src="https://user-images.githubusercontent.com/76685187/172304040-27dedcf2-7913-45c7-9fcd-8d2a3d23b776.png">
<img width="965" alt="スクリーンショット 2022-06-07 14 34 48" src="https://user-images.githubusercontent.com/76685187/172304123-daf25ae0-54ad-42c5-ae2c-c66fa1369c7a.png">
<img width="564" alt="スクリーンショット 2022-06-07 14 35 25" src="https://user-images.githubusercontent.com/76685187/172304371-75e5b24c-1187-46d6-b297-2c7da1e22c58.png">

## 変更後
<img width="710" alt="スクリーンショット 2022-06-08 13 47 24" src="https://user-images.githubusercontent.com/76685187/172533980-0779e793-ad36-42b0-a869-d810bcb3d17f.png">

