### PR TITLE
日報を確認した際にtoastで日報が確認済になった通知を表示する

### DIFF
--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -56,9 +56,6 @@ export default {
       return this.$store.getters.checkId
     },
     buttonLabel() {
-      if (this.checkId) {
-        this.toast('日報を確認済みにしました。')
-      }
       return (
         this.checkableLabel + (this.checkId ? 'の確認を取り消す' : 'を確認')
       )
@@ -106,6 +103,9 @@ export default {
           this.method,
           this.token()
         )
+      }
+      if (!this.checkId) {
+        this.toast('日報を確認済みにしました。')
       }
     }
   }

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -27,7 +27,7 @@
       li.card-main-actions__item(:class='checkId ? "is-sub" : ""')
         button#js-shortcut-check.is-block(
           :class='checkId ? "card-main-actions__muted-action" : "a-button is-sm is-danger"',
-          @click='checkSad'
+          @click='confirm'
         )
           | {{ buttonLabel }}
 </template>
@@ -80,7 +80,7 @@ export default {
       const meta = document.querySelector('meta[name="csrf-token"]')
       return meta ? meta.getAttribute('content') : ''
     },
-    checkSad() {
+    confirm() {
       if (this.checkHasSadEmotion && !this.checkHasComment && !this.checkId) {
         if (
           window.confirm(

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -27,7 +27,7 @@
       li.card-main-actions__item(:class='checkId ? "is-sub" : ""')
         button#js-shortcut-check.is-block(
           :class='checkId ? "card-main-actions__muted-action" : "a-button is-sm is-danger"',
-          @click='confirm'
+          @click='checkSad'
         )
           | {{ buttonLabel }}
 </template>
@@ -80,7 +80,7 @@ export default {
       const meta = document.querySelector('meta[name="csrf-token"]')
       return meta ? meta.getAttribute('content') : ''
     },
-    confirm() {
+    checkSad() {
       if (this.checkHasSadEmotion && !this.checkHasComment && !this.checkId) {
         if (
           window.confirm(

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -56,6 +56,9 @@ export default {
       return this.$store.getters.checkId
     },
     buttonLabel() {
+      if (this.checkId) {
+        this.toast('日報を確認済みにしました。')
+      }
       return (
         this.checkableLabel + (this.checkId ? 'の確認を取り消す' : 'を確認')
       )

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -104,9 +104,6 @@ export default {
           this.token()
         )
       }
-      if (!this.checkId) {
-        this.toast('日報を確認済みにしました。')
-      }
     }
   }
 }

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -31,6 +31,10 @@ export default {
         .then((json) => {
           if (json.message) {
             this.toast(json.message, 'error')
+          } else {
+            if (!this.checkId) {
+              this.toast('日報を確認済みにしました。')
+            }
           }
         })
         .catch((error) => {


### PR DESCRIPTION
## Issue概要
- #4894

メンターが日報を確認したらtoastで「日報を確認済みにしました。」という通知が右上に表示される。

## 変更前
![image](https://user-images.githubusercontent.com/49633473/173417194-12325a38-3d35-426d-bdf1-8a033fc7c6ea.png)「日報を確認」ボタンを押すと確認済のスタンプが表示される。

## 変更後
![image](https://user-images.githubusercontent.com/49633473/173417484-777f802f-4617-4109-bf08-e6d0c901f77e.png)「日報を確認」ボタンを押すと確認済のスタンプが表示されるだけでなく、「日報を確認済みにしました。」の通知も右上に表示される。

## 確認方法
1. `feature/add-notification-in-toast-when-mentor-reviewed-reports`をローカルに取り込む
1. `bin/setup`実行
1. `bin/rails s`でサーバーを立ち上げる
1. メンターロールのユーザーでログイン
1. 日報の画面に行き、未確認の日報を開く
1. 「日報を確認」ボタンを押し、右上に「日報を確認済みにしました。」の通知が表示されることを確認する