### PR TITLE
Markdown 内のメンションの a タグに class を付与

### DIFF
--- a/app/javascript/markdown-it-mention.js
+++ b/app/javascript/markdown-it-mention.js
@@ -13,6 +13,6 @@ export default MarkdownItRegexp(mentionRegexp, (match) => {
   } else {
     return `<a href="${
       match[0] === '@mentor' ? `/users?target=mentor` : `/users/${match[1]}`
-    }">${match[0]}</a>`
+    }" class="mention-link">${match[0]}</a>`
   }
 })


### PR DESCRIPTION
## Issue

- #4720 

## 概要

bootcampアプリのMarkdownエディタでメンションを書くと、`class="mention-link"`が付与されるようにしました。

## 変更確認方法

1. ブランチ`feature/add-class-to-mention-a-tag-in-markdown`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインする
4. 日報作成画面`http://localhost:3000/reports/new`などの、Markdownエディタを使用できる画面にアクセスする
5. `@komagata`など、本文にメンションを書いて送信する
6. 日報詳細画面に遷移するので、ブラウザの検証ツールでメンション部分のHTMLを確認する

## 変更前

![_development__aaa___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMVdzQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--e62a3ee7502ca2f67d94c1b3243ffaf516d30b7d/_development__aaa___FJORD_BOOT_CAMP%EF%BC%88%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%EF%BC%89.png)

## 変更後

![_development__aaa___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMWFzQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--73c7c1ab8fdc9eeb3759d1930d2047b595bf8c22/_development__aaa___FJORD_BOOT_CAMP%EF%BC%88%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%88%E3%82%99%E3%83%95%E3%82%99%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%95%E3%82%9A%EF%BC%89.png)