### PR TITLE
参考書籍一覧から参考書籍にタイトルを変更した

### DIFF
--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -1,4 +1,4 @@
-- title '参考書籍一覧'
+- title '参考書籍'
 
 header.page-header
   .container

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class BooksTest < ApplicationSystemTestCase
   test 'show listing books' do
     visit_with_auth '/books', 'komagata'
-    assert_equal '参考書籍一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal '参考書籍 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'create book' do


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/4971

## 概要

`books`ページにて、参考書籍一覧から参考書籍にタイトルを変更しました。

## 変更確認方法

1. ブランチ`feature/rename-books-page-title`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインし、`books`ページにアクセスする

## 変更前
![image](https://user-images.githubusercontent.com/97820517/172750590-8231907a-f9a5-41cc-88d1-687376a1f2ba.png)

## 変更後
![image](https://user-images.githubusercontent.com/97820517/172750344-562a66a1-5ff7-4134-bdb2-b96c324bdae5.png)



