### PR TITLE
Q&Aを削除する際に表示する確認ダイアログの文言を変更

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -105,7 +105,7 @@
             // - 確認ダイアログとDELETE methodのリンクを実装する
             a.js-delete.card-main-actions__muted-action(
               :href='`/questions/${question.id}`',
-              data-confirm='本当によろしいですか？',
+              data-confirm='自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？',
               data-method='delete'
             )
               | 削除する

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -394,4 +394,11 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     assert_link 'Linuxのファイル操作の基礎を覚える'
   end
+
+  test 'show confirm dialog before delete' do
+    visit_with_auth question_path(questions(:question8)), 'kimura'
+    dismiss_confirm('自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？') do
+      click_link '削除する'
+    end
+  end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -397,8 +397,7 @@ class QuestionsTest < ApplicationSystemTestCase
 
   test 'show confirm dialog before delete' do
     visit_with_auth question_path(questions(:question8)), 'kimura'
-    dismiss_confirm('自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？') do
-      click_link '削除する'
-    end
+    confirm_dialog = dismiss_confirm { click_link '削除する' }
+    assert_equal '自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？', confirm_dialog
   end
 end


### PR DESCRIPTION
## Issue
- #1531

## 概要
Q&Aを削除する際に表示する確認ダイアログの文言を変更しました。

## 変更確認方法
1. ブランチ`feature/change-confirm-prompt-to-delete-question`をローカルに取り込みます
2. `bin/rails s`でローカル環境を立ち上げます
3. kimuraでログインします
4. http://localhost:3000/questions/new から質問を作成します
5. 作成した質問の詳細画面に遷移し「削除する」をクリックします
6. 確認ダイアログが「自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？」と表示される事を確認してください

## 変更前
<img width="1072" alt="スクリーンショット 2022-06-09 12 21 52" src="https://user-images.githubusercontent.com/76685187/172757361-396854a7-fb68-41cc-9f99-bbb4c39a99d4.png">


## 変更後
<img width="1075" alt="スクリーンショット 2022-06-09 12 16 29" src="https://user-images.githubusercontent.com/76685187/172757519-f8d1b28f-c954-4bc7-a06e-86b5e88defb2.png">

