### PR TITLE
企業の提出物ページに企業一覧リンクを貼った

### DIFF
--- a/app/views/companies/products/index.html.slim
+++ b/app/views/companies/products/index.html.slim
@@ -4,6 +4,11 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         = @company.name
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to companies_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | 企業一覧
 
 = render 'companies/tabs', company: @company
 


### PR DESCRIPTION
## Issue

- #4775 

## 概要

企業の提出物ページに「企業一覧」ページへのリンクを貼りました。

## 変更確認方法

1. ブランチ`feature/add-company-list-link-in-submission-page`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. [http://localhost:3000/companies](http://localhost:3000/companies)にアクセスし、任意の企業名をクリック。
4. 「提出物」タブをクリック。右上あたりにリンクが貼ってあります。

## 変更前

![issue2](https://user-images.githubusercontent.com/97820517/172849188-5e4d55da-74e5-4fe6-9c72-9cf80dcf2713.png)


## 変更後

![issu2-2](https://user-images.githubusercontent.com/97820517/172849275-b2dd0b7a-67ce-4112-b305-32ff05fd4432.png)
