### PR TITLE
QAの回答投稿時にプレビューがクリアされるように修正

### DIFF
--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -169,6 +169,7 @@ export default {
         .then((json) => {
           this.answers.push(json)
           this.description = ''
+          this.clearPreview('new-comment-preview')
           this.tab = 'answer'
           this.buttonDisabled = false
           this.resizeTextarea()
@@ -275,6 +276,12 @@ export default {
     editAnswer() {
       if (this.description.length > 0) {
         this.editing = true
+      }
+    },
+    clearPreview(elementId) {
+      const parent = document.getElementById(elementId)
+      while (parent.lastChild) {
+        parent.removeChild(parent.lastChild)
       }
     }
   }

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -88,4 +88,14 @@ class AnswersTest < ApplicationSystemTestCase
     visit_with_auth '/notifications?status=unread', 'sotugyou'
     assert_no_text 'sotugyouさんの質問【 injectとreduce 】でkomagataさんの回答がベストアンサーに選ばれました。'
   end
+
+  test 'clear preview after posting comment for question' do
+    visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
+    find('#js-new-comment').set('test')
+    click_button 'コメントする'
+    all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    within('#new-comment-preview') do
+      assert_no_text :all, 'test'
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/4960

## 概要・要件
Q&Aに回答を投稿した際に、プレビューがクリアされるように修正しました。

### 変更前
回答の投稿後もプレビューがクリアされない
[![Image from Gyazo](https://i.gyazo.com/2ee045f75bf7c705e08ae7442d8a6cbc.gif)](https://gyazo.com/2ee045f75bf7c705e08ae7442d8a6cbc)
### 変更後
回答を投稿したらプレビューがクリアされる
[![Image from Gyazo](https://i.gyazo.com/7b5b6c1dfe507ede95be0d1ea9001eea.gif)](https://gyazo.com/7b5b6c1dfe507ede95be0d1ea9001eea)
## 確認方法
1. ブランチ`bug/preview-does-not-clear-after-answer`をローカルに取り込む
1. bin/rails sでローカル環境を立ち上げる
1. ログインする
1. `http://localhost:3000/questions`にアクセスし、任意のQ&Aの詳細ページを開く
1. コメント欄にコメントを入力し、「コメントする」ボタンをクリックする
1. コメント欄のプレビュータブをクリックする

## 確認内容
- Q&A詳細画面で回答投稿後、プレビューに入力した文字が残っていないか（クリアされているか）