### PR TITLE
フッターの「参考書籍一覧」リンクの文言と位置を変更

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -7,6 +7,9 @@ footer.footer
             = link_to welcome_path, class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | ホームページ
           li.footer-nav__item
+            = link_to books_path, class: 'footer-nav__item-link' do
+              | 参考書籍
+          li.footer-nav__item
             = link_to 'https://github.com/fjordllc/bootcamp/projects/1', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | GitHub Projects
           li.footer-nav__item
@@ -27,9 +30,6 @@ footer.footer
           li.footer-nav__item
             = link_to courses_path, class: 'footer-nav__item-link' do
               | コース一覧
-          li.footer-nav__item
-            = link_to books_path, class: 'footer-nav__item-link' do
-              | 参考書籍一覧
           li.footer-nav__item
             = link_to companies_path, class: 'footer-nav__item-link' do
               | 企業一覧


### PR DESCRIPTION
## Issue

- #4956

## 概要

フッターの「参考書籍一覧」リンクの文言と位置を以下のように変更しました。
- 文言
　変更前：参考書籍一覧
　変更後：参考書籍

- 位置
　変更前：「コース一覧」と「企業一覧」リンクの間
　変更後：「ホームページ」と「GitHub Projects」リンクの間

## 確認方法

1. ブランチ`feature/modify-link-of-referance-book-in-footer`をローカルに取り込む。
2. `bin/rails s`でローカル環境を立ち上げる。
3. 任意のユーザでログインし、ページ下のフッターまでスクロールする。

## 確認内容

1. フッターに「参考書籍一覧」リンクが存在しないことを確認する。
2. フッターの「参考書籍」リンクをクリックし、`/books`ページが表示されることを確認する。

## 変更前
<img width="1330" alt="Cursor_and__development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173007785-3a832be6-177b-48d1-88d7-6b2c1e7724ff.png">

## 変更後

<img width="1327" alt="Cursor_and__development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173009470-5df71904-d2e9-414b-a326-23d0e7f1438a.png">

