### PR TITLE
ユーザー個別ページの日報一覧のtitleタグの文言を変更

### DIFF
--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -1,9 +1,9 @@
-- title @user.login_name
+- title "#{@user.login_name} 日報"
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        = @user.login_name
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item

--- a/test/system/user/reports_test.rb
+++ b/test/system/user/reports_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class User::ReportsTest < ApplicationSystemTestCase
   test 'show listing reports' do
     visit_with_auth "/users/#{users(:hatsuno).id}/reports", 'hatsuno'
-    assert_equal 'hatsuno | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal 'hatsuno 日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'cannot access other users download reports' do


### PR DESCRIPTION
## Issue

- #4969

## 概要

ユーザー個別ページの日報一覧のtitleタグに「 日報」という文言を追加しました。

## 確認方法

1. ブランチ`feature/modify-title-of-individual-user's-report-lists`をローカルに取り込む。
2. `bin/rails s`でローカル環境を立ち上げる。
3. 任意のユーザでログインし、`/users/:user_id/reports`にアクセスする。

## 確認内容

1. titleタグが`{ユーザー名} 日報 | FJORD BOOT CAMP（フィヨルドブートキャンプ）`となっていることを確認する。

## 変更前
- ブラウザタブのタイトル
<img width="335" alt="Cursor_and__development__hajime___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173096103-05988b3f-83a5-460f-85e0-22294533ede2.png">

- HTML
<img width="543" alt="Cursor_and__development__hajime___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173096142-9d88d1b8-fe9f-4cc0-8c86-0496ae4df8e3.png">


## 変更後
- ブラウザタブのタイトル
<img width="333" alt="Cursor_and__development__hajime_日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173096896-36e3ed14-a137-4907-a418-da5ccd0cc474.png">

- HTML
<img width="563" alt="Cursor_and__development__hajime_日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173096999-c82b2bfe-0754-4a80-a246-439fb62e56b7.png">
