### PR TITLE
イベントリストの読み込み中にプレースホルダーが表示されるようにした

### DIFF
--- a/app/javascript/events.vue
+++ b/app/javascript/events.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .page-body
-  .container(v-if='!loaded')
-    | ロード中
+  .container.is-md(v-if='!loaded')
+    loadingListPlaceholder
   .container.is-md(v-else)
     nav.pagination(v-if='totalPages > 1')
       pager(v-bind='pagerProps')
@@ -14,11 +14,13 @@
 <script>
 import Event from 'event'
 import Pager from 'pager'
+import LoadingListPlaceholder from 'loading-list-placeholder'
 
 export default {
   components: {
     event: Event,
-    pager: Pager
+    pager: Pager,
+    loadingListPlaceholder: LoadingListPlaceholder,
   },
   data() {
     return {

--- a/app/javascript/events.vue
+++ b/app/javascript/events.vue
@@ -20,7 +20,7 @@ export default {
   components: {
     event: Event,
     pager: Pager,
-    loadingListPlaceholder: LoadingListPlaceholder,
+    loadingListPlaceholder: LoadingListPlaceholder
   },
   data() {
     return {


### PR DESCRIPTION
## Issue

- #4767 

## 概要

イベント一覧を読み込み中にプレースホルダーが表示されるようにしました。

## 変更確認方法

1. ブランチ`feature/show-placeholders-while-loading-event-list`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインし、左横メニューから「イベント」をクリック

## 変更前

https://user-images.githubusercontent.com/97820517/173174914-8e9a9253-ac5c-4112-b6f2-61b2fd25a9a2.mp4

## 変更後

https://user-images.githubusercontent.com/97820517/173174975-7bbdc276-8560-4ca2-84cc-278c891e5082.mp4
