### PR TITLE
提出済みの提出物をwipにした後提出した場合に、提出日を更新するように修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -53,6 +53,7 @@ class ProductsController < ApplicationController
   def update
     @product = find_my_product
     @practice = @product.practice
+    @product.published_at = nil if @product.published_at? && @product.wip
     set_wip
     update_published_at
     if @product.update(product_params)
@@ -73,7 +74,7 @@ class ProductsController < ApplicationController
   private
 
   def update_published_at
-    return if @product.wip
+    return if @product.wip || @product.published_at?
 
     @product.published_at = Time.current
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -498,4 +498,24 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text "7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\nもし、7日以上経ってもレビューされない場合は、メンターにお問い合わせください。"
     assert_text 'Watch中'
   end
+
+  test 'update published_at when update product content after wips submitted product' do
+    product = products(:product5)
+    product_published_at = product.published_at
+ 
+    visit_with_auth "/products/#{product.id}", 'kimura'
+    click_button '提出する'
+
+    assert product.reload.published_at > product_published_at
+  end
+
+  test 'not update published_at when update product content after submitted product' do
+    product = products(:product12)
+    product_published_at = product.published_at
+
+    visit_with_auth "/products/#{product.id}/edit", 'mentormentaro'
+    click_button '提出する'
+
+    assert product.reload.published_at = product_published_at
+  end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -502,7 +502,7 @@ class ProductsTest < ApplicationSystemTestCase
   test 'update published_at when update product content after wips submitted product' do
     product = products(:product5)
     product_published_at = product.published_at
- 
+
     visit_with_auth "/products/#{product.id}", 'kimura'
     click_button '提出する'
 


### PR DESCRIPTION
## issue
- #4852 

提出済みの提出物をwip後に提出した場合だけ、提出日を更新するように修正しました。
提出済みの提出物をwipせずに再提出した場合は、提出日は更新されません。

![_development__Terminalの基礎を覚える___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/64620506/173237680-f4fd5f15-0823-4c02-affd-3bdb67b8e7c3.png)


## 変更前
- 提出済みの提出物の内容を更新して提出した場合(提出日は更新される)

![submit](https://user-images.githubusercontent.com/64620506/173237648-d8e1f46c-eef5-4348-b4a1-ba931740ac3c.gif)

## 変更後
- 提出済みの提出物をwipにした後、提出した場合(提出日は更新される)

![wip](https://user-images.githubusercontent.com/64620506/173236917-707c82bc-e95d-45a8-a0cd-958efd2179f4.gif)

- 提出済みの提出物の内容を更新して提出した場合(提出日は更新されない)

![submit](https://user-images.githubusercontent.com/64620506/173237078-2ffbdee0-a248-48bb-9375-783cf758dee0.gif)



## 確認手順
1. ブランチ`bug/fix-to-update-submit-day-after-wip`をローカルに取り込む。
(例)
```
git fetch
git checkout bug/fix-to-update-submit-day-after-wip
```
2. 任意のユーザーでログインする。
3. 提出物を提出できるプラクティスを提出済みにする。
4. 3で提出済みのしたプラクティスの`内容修正`をクリックし、`WIP`に変更する。
5. WIPに変更した提出物を`内容修正`をクリックし、`提出する`。
6. 提出日が更新されていることを確認する。
7. 提出済みの提出物をWIPにせずに提出した場合も確認したいため、再度`内容修正`をクリックし、`提出する`。（提出日の時間の変更を確認したいため、この時1分以上待つ）
8. 提出日が更新されていないことを確認する。
