### PR TITLE
tagsテーブルへのN+1を解消

### DIFF
--- a/app/controllers/api/mention_users_controller.rb
+++ b/app/controllers/api/mention_users_controller.rb
@@ -4,7 +4,7 @@ class API::MentionUsersController < API::BaseController
   def index
     users = User.select(:login_name, :name)
                 .order(updated_at: :desc)
-                .as_json(except: :id)
+                .as_json(only: %i[login_name name])
     render json: users
   end
 end


### PR DESCRIPTION
該当のコントローラアクション内で、as_json呼び出し時に意図せずtagsテーブルへのクエリが発行されていたため、
必要なカラムのみjsonに変換するようにオプションを変更しました。
このAPI呼び出し元を確認し、必要なカラムが`login_name`と`name`であることを確認しました。

https://github.com/fjordllc/bootcamp/blob/main/app/javascript/textarea-autocomplte-mention.js