### PR TITLE
メンターログイン時にダッシュボードで発生していたreportsテーブルへのN+1を解消

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -15,6 +15,8 @@ class HomeController < ApplicationController
         display_events_on_dashboard
         display_welcome_message_for_adviser
         set_required_fields
+        @depressed_reports = User.depressed_reports(User.students_and_trainees.select(:id))
+
         render aciton: :index
       end
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -369,12 +369,9 @@ class User < ApplicationRecord
     end
 
     def depressed_reports(ids)
-      consecutive_depressed_reports =
-        reports_by_user(ids).values.select do |reports|
-          reports.size >= DEPRESSED_SIZE && reports.first(DEPRESSED_SIZE).all?(&:sad?)
-        end
-
-      consecutive_depressed_reports.flat_map(&:first)
+      reports_by_user(ids).values.filter_map do |reports|
+        reports.first if reports.size >= DEPRESSED_SIZE && reports.first(DEPRESSED_SIZE).all?(&:sad?)
+      end
     end
 
     private

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -83,5 +83,5 @@ header.page-header
           - if current_user.student_or_trainee?
             #js-niconico_calendar(data-user-id="#{current_user.id}")
           - if current_user.mentor?
-            = render 'users/sad_emotion_report', users: @students_and_trainees
+            = render 'users/sad_emotion_report', reports: @depressed_reports
             = render 'users/inactive_users', users: @inactive_students

--- a/app/views/users/_sad_emotion_report.html.slim
+++ b/app/views/users/_sad_emotion_report.html.slim
@@ -1,4 +1,4 @@
-- if users.any?(&:depressed?)
+- if reports.present?
   .a-card.is-only-mentor
     header.card-header
       h2.card-header__title
@@ -6,6 +6,4 @@
         = image_tag Report.faces['sad'], id: 'sad', alt: 'sad', class: 'card-header__title-emotion-image'
         | のユーザー
     .card-list
-      - users.each do |user|
-        - if user.depressed?
-          = render partial: 'reports/report', collection: user.reports.order(reported_on: :desc).limit(1), as: :report
+      = render partial: 'reports/report', collection: reports, as: :report

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -300,3 +300,19 @@ report<%= i %>:
     頑張れませんでした
   reported_on: <%= Time.now - 1.year + i.day %>
 <% end %>
+
+report72:
+  user: kensyu
+  title: "悲しい顔アイコンの日報1"
+  emotion: 1
+  description: |-
+    難しかったです
+  reported_on: "2022-06-01"
+
+report73:
+  user: kensyu
+  title: "悲しい顔アイコンの日報2"
+  emotion: 1
+  description: |-
+    やっぱり難しいです。
+  reported_on: "2022-06-03"

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -13,6 +13,6 @@ class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
     get counts_api_reports_unchecked_index_path(format: :text),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    assert_match '63件', response.body
+    assert_match '65件', response.body
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -515,4 +515,19 @@ class UserTest < ActiveSupport::TestCase
     user.company_id = nil
     assert user.invalid?
   end
+
+  test '.depressed_reports' do
+    no_depressed_user_id = users(:kimura).id
+    depressed_user_id = users(:kensyu).id
+    user_ids = [no_depressed_user_id, depressed_user_id]
+
+    reports = User.depressed_reports(user_ids)
+    assert_equal 1, reports.size
+
+    depressed_user_reports = Report.where(user_id: depressed_user_id)
+                                   .order(reported_on: :desc)
+    depressed_user_reports.first.update(emotion: 'happy')
+    reports = User.depressed_reports(user_ids)
+    assert_equal 0, reports.size
+  end
 end


### PR DESCRIPTION
## 概要

#3276 がクローズされてしまいましたが、まだ解消していないこと、issueの対応PR( #3314 )が停滞していたので別の案で実装してみました。

## 変更点

2回連続悲しい顔の日報を投稿したuserの最新の日報の絞り込みを下記に変更
- reportsテーブルを任意のuser_idで絞り込み
- 投稿の新しい順に並び替え、userごとにグルーピング
- グルーピングされた日報の新しい2件が悲しい顔の日報を抽出
- 抽出されたユーザーごとの日報からそれぞれ最新のもののみ抽出してviewに渡す