### PR TITLE
検索結果のリストそれぞれに表示している本文のtrancateを削除し、cssで対応した

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,18 +19,17 @@ module ApplicationHelper
     simple_format(truncate(summary, length: word_count))
   end
 
-  def searchable_summary(comment, word_count, word = '')
+  def searchable_summary(comment, word = '')
     summary = strip_tags(md2html(comment)).gsub(/[\r\n]/, '')
     words = word.split(/[[:space:]]+/).compact.reject(&:empty?) unless word.nil?
-    return truncate(summary, length: word_count) if words.blank?
+    return summary if words.blank?
 
     words_pattern = words.map { |keyword| Regexp.escape(keyword) }.join('|')
     words_regexp = Regexp.new(words_pattern, Regexp::IGNORECASE)
     match = words_regexp.match(summary)
-    return truncate(summary, length: word_count) if match.nil?
+    return summary if match.nil?
 
     begin_offset = (match.begin(0) - EXTRACTING_CHARACTERS).clamp(0, Float::INFINITY)
-    end_offset = match.end(0) + EXTRACTING_CHARACTERS
-    summary[begin_offset...end_offset]
+    summary[begin_offset...]
   end
 end

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -11,4 +11,4 @@ json.created_at matched_document(bookmark.bookmarkable).created_at
 json.updated_at matched_document(bookmark.bookmarkable).updated_at
 json.reported_on matched_document(bookmark.bookmarkable).reported_on if bookmark.bookmarkable_type == "Report"
 json.bookmark_class_name bookmark.bookmarkable_type.to_s.tableize.chop
-json.summary searchable_summary(filtered_message(bookmark.bookmarkable), 90)
+json.summary searchable_summary(filtered_message(bookmark.bookmarkable))

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -3,7 +3,7 @@ json.title document.title
 json.url searchable_url(searchable)
 json.model_name document.class.to_s.tableize.singularize
 json.model_name_with_i18n t("activerecord.models.#{document.class.to_s.tableize.singularize}")
-json.summary searchable_summary(filtered_message(searchable), 90, params[:word])
+json.summary searchable_summary(filtered_message(searchable), params[:word])
 json.updated_at searchable.updated_at
 json.wip searchable.respond_to?(:wip?) ? searchable.wip? : false
 if searchable.respond_to?(:user)

--- a/app/views/api/watches/_watch.json.jbuilder
+++ b/app/views/api/watches/_watch.json.jbuilder
@@ -9,4 +9,4 @@ json.url searchable_url(watch.watchable)
 json.title matched_document(watch.watchable).title
 json.watch_class_name watch.watchable_type.to_s.tableize.chop
 json.model_name_with_i18n t("activerecord.models.#{matched_document(watch.watchable_type).to_s.tableize.singularize}")
-json.summary searchable_summary(filtered_message(watch.watchable), 90)
+json.summary searchable_summary(filtered_message(watch.watchable))

--- a/test/helpers/application_helper.rb
+++ b/test/helpers/application_helper.rb
@@ -3,68 +3,38 @@
 require 'test_helper'
 
 class  ApplicationHelperTest < ActionView::TestCase
-  test 'searchable_summary, characters before and after word is 50 over' do
-    comment = '098765432109876543210987654321098765432109876543210987654321検索ワード123456789012345678901234567890123456789012345678901234567890'
-    word_count = 90
-    word = '検索ワード'
-
-    assert_equal '09876543210987654321098765432109876543210987654321検索ワード12345678901234567890123456789012345678901234567890',
-                 searchable_summary(comment, word_count, word)
-  end
-
-  test 'searchable_summary, characters before and after word is 50 under' do
-    comment = '0987654321検索ワード1234567890'
-    word_count = 90
-    word = '検索ワード'
-
-    assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word_count, word)
-  end
-
   test 'searchable_summary, comment = word' do
     comment = '検索ワード'
-    word_count = 90
     word = '検索ワード'
 
-    assert_equal '検索ワード', searchable_summary(comment, word_count, word)
+    assert_equal '検索ワード', searchable_summary(comment, word)
   end
 
   test 'searchable_summary, word is ""' do
     comment = '0987654321検索ワード1234567890'
-    word_count = 90
     word = ''
 
-    assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word_count, word)
+    assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word)
   end
 
   test 'searchable_summary, word is space' do
     comment = '0987654321検索ワード1234567890'
-    word_count = 90
     word = ' '
 
-    assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word_count, word)
-  end
-
-  test 'searchable_summary, comment is 100 characters over and word is empty' do
-    comment = '09876543210987654321098765432109876543210987654321検索ワード12345678901234567890123456789012345678901234567890'
-    word_count = 90
-    word = ''
-
-    assert_equal '09876543210987654321098765432109876543210987654321検索ワード12345678901234567890123456789012...', searchable_summary(comment, word_count, word)
+    assert_equal '0987654321検索ワード1234567890', searchable_summary(comment, word)
   end
 
   test 'searchable_summary, word is multiple' do
     comment = '09876543210987654321098765432109876543210987654321検索ワード検索単語キーワード12345678901234567890'
-    word_count = 90
     word = 'キーワード　検索ワード　単語　'
 
-    assert_equal '09876543210987654321098765432109876543210987654321検索ワード検索単語キーワード12345678901234567890', searchable_summary(comment, word_count, word)
+    assert_equal '09876543210987654321098765432109876543210987654321検索ワード検索単語キーワード12345678901234567890', searchable_summary(comment, word)
   end
 
   test 'regexp in searchable_summary' do
     comment = 'テスト! " # $ \' % & ( ) = ~ | - ^ ¥ ` { @ [ + * } ; : ] < > ? _ , . / 　テスト'
-    word_count = 90
     word = '% テスト'
 
-    assert_equal 'テスト! " # $ \' % &amp; ( ) = ~ | - ^ ¥ ` { @ [ + * } ; ', searchable_summary(comment, word_count, word)
+    assert_equal 'テスト! " # $ \' % &amp; ( ) = ~ | - ^ ¥ ` { @ [ + * } ; : ] &lt; &gt; ? _ , . / 　テスト', searchable_summary(comment, word)
   end
 end


### PR DESCRIPTION
## Issue

- [検索結果のリストそれぞれに表示している本文のtrancateを削除し、cssで対応したい。](https://github.com/fjordllc/bootcamp/issues/4962)

## 概要

検索結果の本文の表示に使われていたrubyによる`truncate`処理を削除した。

## 変更確認方法

1. ブランチ`feature/delete_processing_ruby_for_truncate_of_text`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. いずれかのユーザーでログインし、ヘッダーにある検索フォームで`PC性能の見方を知る`(本文が長いため)の文字を入力し、検索結果が字数制限されていることを確認する

## 変更前

<img width="1356" alt="スクリーンショット 2022-06-15 22 15 42" src="https://user-images.githubusercontent.com/96340764/173839977-8a88f742-2bab-4304-a2fa-5ae143c7ee67.png">

## 変更後

<img width="1357" alt="スクリーンショット 2022-06-15 22 15 05" src="https://user-images.githubusercontent.com/96340764/173840043-638e3a39-e387-4f6b-80c0-3b8229a3eed3.png">
