### PR TITLE
ダッシュボードアクセス時のパフォーマンス劣化を防止

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -15,8 +15,6 @@ class HomeController < ApplicationController
         display_events_on_dashboard
         display_welcome_message_for_adviser
         set_required_fields
-        @depressed_reports = User.depressed_reports(User.students_and_trainees.select(:id))
-
         render aciton: :index
       end
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -378,7 +378,7 @@ class User < ApplicationRecord
 
     def reports_by_user(ids)
       Report.where(user_id: ids)
-            .preload([:comments, { checks: { user: { avatar_attachment: :blob } } }])
+            .preload([:comments, { user: [:company, { avatar_attachment: :blob }] }, { checks: { user: { avatar_attachment: :blob } } }])
             .order(reported_on: :desc)
             .group_by(&:user_id)
     end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -83,5 +83,5 @@ header.page-header
           - if current_user.student_or_trainee?
             #js-niconico_calendar(data-user-id="#{current_user.id}")
           - if current_user.mentor?
-            = render 'users/sad_emotion_report', reports: @depressed_reports
+            = render 'users/sad_emotion_report', reports: User.depressed_reports(User.students_and_trainees.select(:id))
             = render 'users/inactive_users', users: @inactive_students


### PR DESCRIPTION
#5013 対応後にパフォーマンス上考慮した方が良い点に気づいたので対応しましたmm

## 変更点

- Reportを引いてくる際にN+1になるレコードをeager loadingするようにした
- メンターログイン時のみ`User.depressed_reports`を呼ぶようにした
    - メンター以外は表示されない項目にも関わらず、必ずクエリが発行される状態だったため