### PR TITLE
ユーザーのコメント一覧ページのタイトルを変更した

### DIFF
--- a/app/views/users/comments/index.html.slim
+++ b/app/views/users/comments/index.html.slim
@@ -1,10 +1,10 @@
-- title "#{@user.login_name}のコメント一覧"
+- title "#{@user.login_name} コメント"
 
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        = @user.login_name
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item

--- a/test/system/user/comments_test.rb
+++ b/test/system/user/comments_test.rb
@@ -5,6 +5,6 @@ require 'application_system_test_case'
 class User::CommentsTest < ApplicationSystemTestCase
   test 'show listing comments' do
     visit_with_auth "/users/#{users(:hatsuno).id}/comments", 'hatsuno'
-    assert_equal 'hatsunoのコメント一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal 'hatsuno コメント | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 end


### PR DESCRIPTION
## Issue
#4970 
## 概要

ユーザーのコメント一覧ページのタイトルを変更しました。

* ページ上部のタイトル
「{ユーザー名}のコメント一覧」→「{ユーザー名}」

* `<head>`タグ内の`<title>`部分
「{ユーザー名}のコメント一覧」→「{ユーザー名} コメント」

## 変更確認方法

1. ブランチ`feature/rename-title-in-user-comment-page`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインし、http://localhost:3000/users/459775584/comments にアクセス

## ✨変更前

### ✅ページ上部
![issue0613](https://user-images.githubusercontent.com/97820517/173285417-98d8fd65-7628-4fbd-929b-c5d569374a5f.png)

### ✅タイトル
![issue0613-2](https://user-images.githubusercontent.com/97820517/173285429-77c875ce-d9c4-4fea-a3f4-0aba4706581a.png)


## ✨変更後
### ✅ページ上部
![issue0613-3](https://user-images.githubusercontent.com/97820517/173285460-4bdfb517-e328-4e2b-ac8f-cccca7b6aaea.png)
### ✅タイトル
![issue0613-4](https://user-images.githubusercontent.com/97820517/173285472-38ef2c98-0478-4258-90f4-b5feeaefa56d.png)
