### PR TITLE
Q&A一覧の質問タイトルのtruncateを削除した

### DIFF
--- a/app/views/api/questions/_question.json.jbuilder
+++ b/app/views/api/questions/_question.json.jbuilder
@@ -1,5 +1,5 @@
 json.id question.id
-json.title truncate(question.title, {length: 46, escape: false})
+json.title question.title
 json.url question_url(question)
 json.has_correct_answer question.correct_answer.present?
 json.wip question.wip


### PR DESCRIPTION
## Issue

- [Q&A一覧の質問タイトルのtrancateを削除し、CSSで対応したい。](https://github.com/fjordllc/bootcamp/issues/4836)

## 概要

Q&A一覧の質問タイトルの字数を制限していた処理を削除した
その後、CSSによる字数制限が追加された

## 変更確認方法

1. ブランチ`feature/delete_processing_ruby_for_truncate_of_question_title`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインし、「Q&A」>「+質問する」から長いタイトルをつけて質問を投稿する<details><summary>長いタイトル例</summary>`長ーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーい５０☆長ーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーい１００☆タイトル`</details>
4. Q＆Aの質問一覧から、先程投稿した質問のタイトルの字数が制限されていることを確認する
## 変更前

<img width="1440" alt="スクリーンショット 2022-06-13 0 15 51" src="https://user-images.githubusercontent.com/96340764/173292379-5857990f-210e-4796-82b7-7b8b551c50e1.png">

## Rubyでの字数制限を削除

<img width="1437" alt="スクリーンショット 2022-06-13 14 54 54" src="https://user-images.githubusercontent.com/96340764/173292406-414077e2-1161-4ccc-a2ec-66e08f68578b.png">
 
## CSSでの字数制限追加

<img width="1429" alt="スクリーンショット 2022-06-16 21 36 52" src="https://user-images.githubusercontent.com/96340764/174072831-152ef6ae-c5a2-497a-a580-c9a2f8dfa898.png">
