### PR TITLE
ユーザー登録・編集画面のタグをvue-tags-inputからchocies.jsに置き換える

### DIFF
--- a/app/javascript/tags-input.vue
+++ b/app/javascript/tags-input.vue
@@ -1,6 +1,8 @@
 <template lang="pug">
 div
-  input.tags-input(type='text', :name='tagsParamName')
+  input.tags-input(type='text', :name='tagsParamName', v-model='inputTag')
+  div(v-if='headIsSharpOrOctothorpe(inputTag)')
+    | 先頭の記号は無視されます
   //-
     vue-tags-input(
       v-model='inputTag',
@@ -19,11 +21,12 @@ div
 // import VueTagsInput from '@johmun/vue-tags-input'
 import Choices from 'choices.js'
 // import validateTagName from 'validate-tag-name'
-// import headIsSharpOrOctothorpe from 'head-is-sharp-or-octothorpe'
+import headIsSharpOrOctothorpe from 'head-is-sharp-or-octothorpe'
 
 export default {
 //   components: { VueTagsInput },
 //   mixins: [validateTagName, headIsSharpOrOctothorpe],
+  mixins: [headIsSharpOrOctothorpe],
   props: {
     tagsInitialValue: { type: String, required: true },
     tagsParamName: { type: String, required: true },
@@ -31,7 +34,7 @@ export default {
   },
   data() {
     return {
-      //     inputTag: '',
+      inputTag: '',
       tags: [],
       tagsValue: '',
       autocompleteTags: []


### PR DESCRIPTION
## Issue
- [ユーザー登録・編集画面のタグをvue\-tags\-inputからchocies\.jsに置き換える · Issue \#4850](https://github.com/fjordllc/bootcamp/issues/4850)