### PR TITLE
参考書籍ページで各書籍に紐付くプラクティスへのリンクを追加

### DIFF
--- a/app/assets/stylesheets/blocks/card/_card-books.sass
+++ b/app/assets/stylesheets/blocks/card/_card-books.sass
@@ -8,11 +8,18 @@
   +media-breakpoint-up(md)
     border-top: solid 1px $border-tint
     flex: 0 0 50%
+    height: 100%
+    display: flex
+    flex-direction: column
     &:nth-child(odd)
       border-right: solid 1px $border-tint
   +media-breakpoint-down(sm)
     &:not(:first-child)
       border-top: solid 1px $border-tint
+
+.card-books-item__body
+  +media-breakpoint-up(md)
+    flex: 1
 
 .card-books-item__inner
   padding: .75rem 1rem
@@ -39,11 +46,23 @@
 .card-books-item__end
   flex: 1
 
+.card-books-item__row
+  &:not(:first-child)
+    margin-top: .25rem
+
 .card-books-item__cover-container
   height: 100%
   display: flex
   align-items: center
   justify-content: center
+
+.card-books-item__image
+  max-height: 100%
+  max-width: 100%
+  object-fit: contain
+  object-position: 50% 0
+  border: solid 1px $border-tint
+  border-radius: 2px
 
 .card-books-item__title
   +text-block(.875rem 1.4, $default-text 600)
@@ -64,17 +83,16 @@ a.card-books-item__inner:hover
     color: $main-text
 
 .card-books-item__price
-  +text-block(.75rem 1.4 .25rem, $default-text)
-
-.card-books-item__image
-  max-height: 100%
-  max-width: 100%
-  object-fit: contain
-  object-position: 50% 0
-  border: solid 1px $border-tint
-  border-radius: 2px
+  +text-block(.75rem 1.4, $default-text)
 
 .card-books-item__description
   font-size: .75rem
   color: $semi-muted-text
-  margin-top: .25rem
+
+.card-books-item__practices
+  padding: 0 1rem .75rem
+  .tag-links__item-link
+    max-width: 9rem
+    text-overflow: ellipsis
+    overflow: hidden
+    white-space: nowrap

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,8 +4,8 @@ class Book < ApplicationRecord
   include ActionView::Helpers::AssetUrlHelper
 
   COVER_SIZE = '100x150>'
-  has_many :practices, through: :practices_books
   has_many :practices_books, dependent: :destroy
+  has_many :practices, through: :practices_books
   has_one_attached :cover
   validates :title, presence: true
   validates :price, presence: true, numericality: { only_integer: true }

--- a/app/views/books/_book.html.slim
+++ b/app/views/books/_book.html.slim
@@ -27,15 +27,6 @@
             - book.practices.each do |practice|
               li.tag-links__item
                 = link_to practice.title, practice_path(practice), class: 'tag-links__item-link'
-            - book.practices.each do |practice|
-              li.tag-links__item
-                = link_to practice.title, practice_path(practice), class: 'tag-links__item-link'
-            - book.practices.each do |practice|
-              li.tag-links__item
-                = link_to practice.title, practice_path(practice), class: 'tag-links__item-link'
-            - book.practices.each do |practice|
-              li.tag-links__item
-                = link_to practice.title, practice_path(practice), class: 'tag-links__item-link'
     - if current_user.admin_or_mentor?
       footer.card-footer.is-only-mentor
         .card-main-actions

--- a/app/views/books/_book.html.slim
+++ b/app/views/books/_book.html.slim
@@ -16,6 +16,12 @@
             .card-books-item__description
               .a-short-text
                 = simple_format(book.description)
+          ul
+            - if book.practices_books.exists?
+              - book.practices_books.each do |practice_book|
+                - practice = practice_book.practice
+                li
+                  = link_to practice.title, practice_path(practice)
       - if current_user.admin_or_mentor?
         footer.card-footer.is-only-mentor
           .card-main-actions

--- a/app/views/books/_book.html.slim
+++ b/app/views/books/_book.html.slim
@@ -17,9 +17,8 @@
               .a-short-text
                 = simple_format(book.description)
           ul
-            - if book.practices_books.exists?
-              - book.practices_books.each do |practice_book|
-                - practice = practice_book.practice
+            - if book.practices.exists?
+              - book.practices.each do |practice|
                 li
                   = link_to practice.title, practice_path(practice)
       - if current_user.admin_or_mentor?

--- a/app/views/books/_book.html.slim
+++ b/app/views/books/_book.html.slim
@@ -1,30 +1,45 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .card-books-item
-    .a-card
+  .card-books-item.a-card
+    .card-books-item__body
       .card-books-item__inner
         .card-books-item__start
           = link_to book.page_url, target: '_blank', rel: 'noopener', class: 'card-books-item__cover-container' do
             = image_tag book.cover_url, title: book.title, alt: book.title, class: 'card-books-item__image'
         .card-books-item__end
-          h2.card-books-item__title
-            = link_to book.page_url, target: '_blank', rel: 'noopener', class: 'card-books-item__title-link' do
-              span.card-books-item__title-label
-                = book.title
-          p.card-books-item__price
-            = number_to_currency(book.price, unit: '円（税込）')
-          - if book.description
-            .card-books-item__description
-              .a-short-text
-                = simple_format(book.description)
-          ul
-            - if book.practices.exists?
-              - book.practices.each do |practice|
-                li
-                  = link_to practice.title, practice_path(practice)
-      - if current_user.admin_or_mentor?
-        footer.card-footer.is-only-mentor
-          .card-main-actions
-            ul.card-main-actions__items
-              li.card-main-actions__item
-                = link_to edit_book_path(book), class: 'card-main-actions__action a-button is-sm is-secondary is-block' do
-                  | 編集
+          .card-books-item__rows
+            .card-books-item__row
+              h2.card-books-item__title
+                = link_to book.page_url, target: '_blank', rel: 'noopener', class: 'card-books-item__title-link' do
+                  span.card-books-item__title-label
+                    = book.title
+            .card-books-item__row
+              p.card-books-item__price
+                = number_to_currency(book.price, unit: '円（税込）')
+            - if book.description
+              .card-books-item__row
+                .card-books-item__description
+                  .a-short-text
+                    = simple_format(book.description)
+    .card-books-item__practices
+      .tag-links
+        ul.tag-links__items
+          - if book.practices.exists?
+            - book.practices.each do |practice|
+              li.tag-links__item
+                = link_to practice.title, practice_path(practice), class: 'tag-links__item-link'
+            - book.practices.each do |practice|
+              li.tag-links__item
+                = link_to practice.title, practice_path(practice), class: 'tag-links__item-link'
+            - book.practices.each do |practice|
+              li.tag-links__item
+                = link_to practice.title, practice_path(practice), class: 'tag-links__item-link'
+            - book.practices.each do |practice|
+              li.tag-links__item
+                = link_to practice.title, practice_path(practice), class: 'tag-links__item-link'
+    - if current_user.admin_or_mentor?
+      footer.card-footer.is-only-mentor
+        .card-main-actions
+          ul.card-main-actions__items
+            li.card-main-actions__item
+              = link_to edit_book_path(book), class: 'card-main-actions__action a-button is-sm is-secondary is-block' do
+                | 編集

--- a/app/views/practices/_practice_books.html.slim
+++ b/app/views/practices/_practice_books.html.slim
@@ -7,20 +7,21 @@
       - practice.practices_books.each do |practices_book|
         - book = practices_book.book
         .card-books-item
-          = link_to book.page_url, target: '_blank', rel: 'noopener', class: 'card-books-item__inner' do
-            .card-books-item__start
-              .card-books-item__cover-container
-                = image_tag book.cover_url, class: 'card-books-item__image', alt: book.title
-            .card-books-item__end
-              h3.card-books-item__title
-                - if practices_book.must_read
-                  span.a-badge.is-danger.is-sm
-                    | 必読
-                span.card-books-item__title-label
-                  = book.title
-              p.card-books-item__price
-                = number_to_currency(book.price, unit: '円（税込）')
-              - if book.description
-                .card-books-item__description
-                  .a-short-text
-                    = simple_format(book.description)
+          .card-books-item__body
+            = link_to book.page_url, target: '_blank', rel: 'noopener', class: 'card-books-item__inner' do
+              .card-books-item__start
+                .card-books-item__cover-container
+                  = image_tag book.cover_url, class: 'card-books-item__image', alt: book.title
+              .card-books-item__end
+                h3.card-books-item__title
+                  - if practices_book.must_read
+                    span.a-badge.is-danger.is-sm
+                      | 必読
+                  span.card-books-item__title-label
+                    = book.title
+                p.card-books-item__price
+                  = number_to_currency(book.price, unit: '円（税込）')
+                - if book.description
+                  .card-books-item__description
+                    .a-short-text
+                      = simple_format(book.description)

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -6,6 +6,7 @@ class BooksTest < ApplicationSystemTestCase
   test 'show listing books' do
     visit_with_auth '/books', 'komagata'
     assert_equal '参考書籍 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert has_link?(practices(:practice1).title, href: practice_path(practices(:practice1)))
   end
 
   test 'create book' do


### PR DESCRIPTION
## Issue

- #4959

## 概要

参考書籍ページにおいて、各書籍に紐付くプラクティスへのリンクを追加しました。

## 確認方法

1. ブランチ`feature/add-link-to-practice-lassociated-with-book-in-reference-books`をローカルに取り込む。
2. `bin/rails s`でローカル環境を立ち上げる。
3. 任意のユーザでログインし、`/books`にアクセスする。

## 確認内容
1. 書籍にプラクティスが紐付く場合
    1-1. プラクティス個別ページへのリンクが表示されていることを確認する。
    1-2. プラクティス個別ページへのリンクをクリックし、`/practices/:id`へアクセスできることを確認する。
2. 書籍にプラクティスが紐付かない場合
    2-1 何も表示されないことを確認する。


## 変更前
<img width="961" alt="Cursor_and__development__参考書籍___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173373336-c8c188df-b64b-4c5c-894f-d6149ecbb25c.png">

## 変更後
`/books`にアクセスしたときの、参考書籍ページ
<img width="965" alt="Cursor_and__development__参考書籍___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173374781-31b9d5e3-d3a3-4d97-bfd4-09b5124645be.png">
　↓
プラクティス個別ページへのリンクをクリック後の、プラクティス個別ページ
<img width="1424" alt="Cursor_and__development__OS_X_Mountain_Lionをクリーンインストールする___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/173381326-57400565-810e-4b6e-a42d-4ebb12e4ab14.png">


