### PR TITLE
ユーザー個別ページの質問回答一覧にて各質問にプラクティスのリンクを追加した

### DIFF
--- a/app/javascript/users-answer.vue
+++ b/app/javascript/users-answer.vue
@@ -21,7 +21,9 @@
         .card-list-item-meta
           .card-list-item-meta__items
             .card-list-item-meta__item
-              .a-meta.is-practice {{ answer.question.practice.title }}
+              a.a-meta.is-practice(
+                :href='`/practices/${answer.question.practice.id}`'
+              ) {{ answer.question.practice.title }}
       .card-list-item__row
         .card-list-item__summary
           p {{ summary }}


### PR DESCRIPTION
## Issue
* #4967 

## 概要
ユーザー個別ページの回答一覧にて、各質問にプラクティスのリンクを貼りました。

## 変更確認方法
1. ブランチ`feature/add-practice-link-in-user-answers-page`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインし、ユーザー個別ページの回答一覧（http://localhost:3000/users/459775584/answers ）にアクセス。
4. 各質問のプラクティス名部分にそのプラクティスのリンクが貼られていることを確認する。

## ✨変更前
変更前は、プラクティス名部分はただのテキスト。
![image](https://user-images.githubusercontent.com/97820517/173488208-29a9b149-2e65-4c77-bf71-281b8352cf66.png)

## ✨変更後
変更後はプラクティス名部分にリンクが貼られている。
![image](https://user-images.githubusercontent.com/97820517/173488863-567f41ba-17ca-44ac-905f-19cbd4da19fb.png)
