### PR TITLE
選択プルダウンにおける検索結果の表示上限数を変更

### DIFF
--- a/app/javascript/choices-ui.js
+++ b/app/javascript/choices-ui.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return new Choices(elementMultipleSelect, {
       removeItemButton: true,
       allowHTML: true,
-      searchResultLimit: 6,
+      searchResultLimit: 20,
       searchPlaceholderValue: '検索ワード',
       noResultsText: '一致する情報は見つかりません',
       itemSelectText: '選択',

--- a/app/javascript/choices-ui.js
+++ b/app/javascript/choices-ui.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return new Choices(element, {
       removeItemButton: true,
       allowHTML: true,
-      searchResultLimit: 10,
+      searchResultLimit: 20,
       searchPlaceholderValue: '検索ワード',
       noResultsText: '一致する情報は見つかりません',
       itemSelectText: '選択',

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -300,7 +300,7 @@ export default {
           if (choices) {
             return new Choices(choices, {
               allowHTML: true,
-              searchResultLimit: 10,
+              searchResultLimit: 20,
               searchPlaceholderValue: '検索ワード',
               noResultsText: '一致する情報は見つかりません',
               itemSelectText: '選択',


### PR DESCRIPTION
## 関連Issue

- #4793

## 概要

選択プルダウン(単一選択 or 複数選択)にChoice.jsを適用している場合、検索結果の表示上限数が設定されている。
そのため、検索結果の数がその表示上限数より大きい場合は、表示上限数までしか表示されなくなり、検索機能を十分に活用できていないケースが発生している。
そこで、上限数を現状よりも大きな値(`20`)に一旦変更してみることで、解消を試みる。


## 確認方法

1. ブランチ`feature/change-maximum-amount-of-search-results-in-multiple-select`をローカルに取り込む。
2. `bin/rails s`でローカル環境を立ち上げる。

## 確認方法と確認内容

choices.jsをインポートし選択プルダウンに適用しているファイルは以下の2つである。

- [app/javascript/choices-ui.js](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/choices-ui.js)
- [app/javascript/question-edit.vue](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/question-edit.vue)

また、確認するアクセス先およびプルダウンは、以下のように3種類に分けることができる。

1. [app/javascript/choices-ui.js](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/choices-ui.js)で'js-choices-single-select'にchoices.jsを適用しているところの使用箇所
    1. 日報一覧ページ(`/reports`) の「プラクティスで絞り込む」のプルダウン
    2. ブログ作成ページ(`/articles/new`) の「ユーザー」のプルダウン　(※管理者 or メンターでログイン)
    3. ブログ編集ページ(`/articles/:id/edit`) の「ユーザー」のプルダウン　(※管理者 or メンターでログイン)
    4. 登録情報変更ページ(`/current_user/edit`) の「所属企業」のプルダウン　(※研修生でログイン)
    5. ユーザー登録情報変更(`/admin/users/:id/edit`) の「所属企業」のプルダウン　(※管理者でログイン)
2. [app/javascript/question-edit.vue](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/question-edit.vue)の'js-choices-single-select'の使用箇所
    1. 質問編集ページ(`/questions/:id`) のプラクティスのプルダウン
3. [app/javascript/choices-ui.js](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/choices-ui.js)で'js-choices-multiple-select'にchoices.jsを適用しているところの使用箇所
    1. 日報作成ページ(`/reports/new`) の「プラクティス」のプルダウン
    2. 日報編集ページ(`/reports/:id/edit`) の「プラクティス」のプルダウン
    3. 定期イベント作成ページ(`regular_events/new`) の「主催者」のプルダウン
    4. 定期イベント編集ページ(`/regular_events/:id/edit`) の「主催者」のプルダウン


そのため、上記のそれぞれの中から1つずつをピックアップして、以下のように3つを確認することにする。(全ての選択プルダウンは確認しない方針とする)

項番 | ログインユーザー | アクセス先 | 行うこと | 変更前 | 変更後
-- | -- | -- | -- | -- | --
1 | 任意 | 日報一覧ページ(/reports) | 「プラクティスで絞り込む」のプルダウンの検索窓に任意の検索ワードを入力する | 検索結果が最大10個まで表示される | 検索結果が最大20個まで表示される |   |   |  
2 | 任意 | 質問編集ページ(/questions/:id) | 「プラクティス」のプルダウンの検索窓に任意の検索ワードを入力する | 検索結果が最大10個まで表示される | 検索結果が最大20個まで表示される
3 | 任意 | 日報作成ページ(/reports/new) | 「プラクティス」のプルダウンの検索窓に任意の検索ワードを入力する | 検索結果が最大6個まで表示される | 検索結果が最大20個まで表示される


### 項番1【日報一覧ページ(/reports)】
#### 変更前
<img width="680" alt="Cursor_and__development__日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174081479-db6adc3e-b63c-4aaa-ade8-c01c27883348.png">

<img width="679" alt="Cursor_and__development__日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174081659-fb262922-4954-43ba-aff8-aac694c0efe2.png">

#### 変更後
<img width="682" alt="Cursor_and__development__日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174082079-106a0e67-ad06-42b1-8b56-e93617dd8512.png">

<img width="676" alt="Cursor_and__development__日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174082243-5383e8b0-d6f1-4f49-9917-0025829dcc94.png">

<img width="677" alt="Cursor_and__development__日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174082462-add25010-5063-4ac0-a338-70987537966c.png">



### 項番2【質問編集ページ(/questions/:id)】
#### 変更前
<img width="807" alt="Cursor_and__development__テストの質問40___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174080328-4817d814-d85a-40f4-9f1b-5aee37180912.png">

<img width="808" alt="Cursor_and__development__テストの質問40___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174080559-11460718-1689-43a9-ba06-bf7f0a2a89e1.png">


#### 変更後

<img width="811" alt="Cursor_and__development__テストの質問40___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174077398-cb5d18b8-792f-44e0-bc58-3cab7887c645.png">

<img width="807" alt="Cursor_and__development__テストの質問40___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174077435-a763bf91-fe1c-43b3-ad75-2d10fd0727d8.png">

<img width="812" alt="Cursor_and__development__テストの質問40___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174077476-6c2a59b3-d74a-4a14-a87f-ac123a37148c.png">

### 項番3【日報作成ページ(/reports/new)】
#### 変更前
<img width="690" alt="Cursor_and__development__日報作成___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174085179-41321c98-3744-43ec-8e29-cdcfa1829698.png">



#### 変更後
<img width="688" alt="Cursor_and__development__日報作成___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174083678-449429a8-8cc0-457c-9dd4-de9415ea9c81.png">

<img width="682" alt="Cursor_and__development__日報作成___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174083791-93e874cb-1a2b-4e76-a08d-819818d9e0eb.png">

<img width="683" alt="Cursor_and__development__日報作成___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174084011-582db571-ad14-4d9e-a9b8-7244099e6064.png">


