### PR TITLE
リリースのために定期イベントのタブをコメントアウトした

### DIFF
--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -12,6 +12,6 @@ header.page-header
               i.fa-regular.fa-plus
               | イベント作成
 
-= render 'events/tabs'
+/ = render 'events/tabs'
 
 #js-events


### PR DESCRIPTION
-  #4925

## 概要
定期イベントの基本的な機能を以下のPRで作成しました。
- #4862

今回、以下の理由から一旦定期イベントのタブをコメントアウトしてリリースすることになりました。
- 定期イベントの基本的な機能はできたが、さらに肉付けしてリリースしたい
- しかし、長い間、mainにマージされずに開発を続けると、mainと開発環境がかけ離れてしまい、マージしにくい
- そのため、一旦上記のPRをマージしておき、リリースの段階ではコメントアウトしておく → 定期イベントの機能がある程度できた段階で、コメントアウトを外し、ユーザーが使えるようにしたい

## 修正箇所
左メニューのイベントをクリックすると、上部にイベントと定期イベントに遷移できるタブが出ていましたが、こちらをコメントアウトしています。

<img width="750" alt="image" src="https://user-images.githubusercontent.com/31835314/173973736-54cc7cc2-8cb8-4554-8c06-90e1c3157220.png">


## 確認手順
- `feature/comment-out-regular-events`を取り込む
- メニューのイベントをクリックして、定期イベントに遷移できるタブが出てこないことを確認
