### PR TITLE
定期イベントのseedする時の順番を入れ替えた

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,6 @@ tables = %i[
   courses
   courses_categories
   events
-  organizers
   followings
   reports
   learning_times
@@ -33,10 +32,11 @@ tables = %i[
   products
   questions
   reactions
-  regular_events
   watches
   works
   talks
+  regular_events
+  organizers
 ]
 
 ActiveRecord::FixtureSet.create_fixtures 'db/fixtures', tables


### PR DESCRIPTION
- #4537
## 概要
こちらのPRの影響で、db migrate時にエラーが出て、デプロイ失敗エラーが出ていたため、修正しました。
- #4862
```
Already have image (with digest): asia.gcr.io/bootcamp-224405/bootcamp:c24692771218036aa7b1ef36e8d051c7e12c59c4
Dropped database 'bootcamp_staging'
Created database 'bootcamp_staging'
WARNING: Rails was not able to disable referential integrity.

This is most likely caused due to missing permissions.
Rails needs superuser privileges to disable referential integrity.

    cause: PG::InsufficientPrivilege: ERROR:  permission denied: "RI_ConstraintTrigger_c_281770" is a system trigger


rails aborted!
ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation: ERROR:  insert or update on table "organizers" violates foreign key constraint "fk_rails_cd7e0bf080"
DETAIL:  Key (regular_event_id)=(459650222) is not present in table "regular_events".
/workspace/db/seeds.rb:42:in `<main>'

Caused by:
PG::ForeignKeyViolation: ERROR:  insert or update on table "organizers" violates foreign key constraint "fk_rails_cd7e0bf080"
DETAIL:  Key (regular_event_id)=(459650222) is not present in table "regular_events".
/workspace/db/seeds.rb:42:in `<main>'
Tasks: TOP => db:reset => db:setup => db:seed
(See full trace by running task with --trace)
```


organizersはregular_eventsに依存しているけど、seedの時にorganizersを先に作ろうとしてエラーが出ていたので、順番を入れ替えました。
