### PR TITLE
質問の投稿の通知をabstract_notifierに置き換えた

### DIFF
--- a/app/models/chat_notifier.rb
+++ b/app/models/chat_notifier.rb
@@ -4,10 +4,10 @@ class ChatNotifier
   def self.message(
     message,
     username: 'ピヨルド',
-    webhook_url: 'https://discordapp.com/api/webhooks/987204651801792584/oKZkNcevfH_94Vbs6-aZZ9XZD9IlCGvrqGgsjV6W1p9zynHLIQDYQSfiobDnKnVYguNx'
+    webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
   )
 
-    if Rails.env.development?
+    if Rails.env.production?
       Discord::Notifier.message(message, username: username, url: webhook_url)
     else
       Rails.logger.info 'Message to Discord.'

--- a/app/models/chat_notifier.rb
+++ b/app/models/chat_notifier.rb
@@ -4,10 +4,10 @@ class ChatNotifier
   def self.message(
     message,
     username: 'ピヨルド',
-    webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
+    webhook_url: 'https://discordapp.com/api/webhooks/987204651801792584/oKZkNcevfH_94Vbs6-aZZ9XZD9IlCGvrqGgsjV6W1p9zynHLIQDYQSfiobDnKnVYguNx'
   )
 
-    if Rails.env.production?
+    if Rails.env.development?
       Discord::Notifier.message(message, username: username, url: webhook_url)
     else
       Rails.logger.info 'Message to Discord.'

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -98,17 +98,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    # def came_question(question, receiver)
-    #   Notification.create!(
-    #     kind: kinds[:came_question],
-    #     user: receiver,
-    #     sender: question.sender,
-    #     link: Rails.application.routes.url_helpers.polymorphic_path(question),
-    #     message: "#{question.user.login_name}さんから質問「#{question.title}」が投稿されました。",
-    #     read: false
-    #   )
-    # end
-
     def first_report(report, receiver)
       Notification.create!(
         kind: kinds[:first_report],

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -98,16 +98,16 @@ class Notification < ApplicationRecord
       )
     end
 
-    def came_question(question, receiver)
-      Notification.create!(
-        kind: kinds[:came_question],
-        user: receiver,
-        sender: question.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(question),
-        message: "#{question.user.login_name}さんから質問「#{question.title}」が投稿されました。",
-        read: false
-      )
-    end
+    # def came_question(question, receiver)
+    #   Notification.create!(
+    #     kind: kinds[:came_question],
+    #     user: receiver,
+    #     sender: question.sender,
+    #     link: Rails.application.routes.url_helpers.polymorphic_path(question),
+    #     message: "#{question.user.login_name}さんから質問「#{question.title}」が投稿されました。",
+    #     read: false
+    #   )
+    # end
 
     def first_report(report, receiver)
       Notification.create!(

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -65,7 +65,7 @@ class NotificationFacade
   end
 
   def self.came_question(question, receiver)
-    Notification.came_question(question, receiver)
+    ActivityNotifier.with(question: question, receiver: receiver).came_question.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -68,12 +68,12 @@ class ActivityNotifier < ApplicationNotifier
   def came_question(params = {})
     params.merge!(@params)
     question = params[:question]
-    receiver = params[:reciever]
+    receiver = params[:receiver]
 
     notification(
       body: "#{question.user.login_name}さんから質問「#{question.title}」が投稿されました。",
       kind: :came_question,
-      reciever: reciever,
+      receiver: receiver,
       sender: question.sender,
       link: Rails.application.routes.url_helpers.polymorphic_path(question),
       read: false

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -65,6 +65,21 @@ class ActivityNotifier < ApplicationNotifier
     )
   end
 
+  def came_question(params = {})
+    params.merge!(@params)
+    question = params[:question]
+    receiver = params[:reciever]
+
+    notification(
+      body: "#{question.user.login_name}さんから質問「#{question.title}」が投稿されました。",
+      kind: :came_question,
+      reciever: reciever,
+      sender: question.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(question),
+      read: false
+    )
+  end
+
   def submitted(params = {})
     params.merge!(@params)
     subject = params[:subject]

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -4,9 +4,15 @@ require 'application_system_test_case'
 
 class Notification::QuestionsTest < ApplicationSystemTestCase
   setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
     @notice_kind = Notification.kinds['came_question']
     @notified_count = Notification.where(kind: @notice_kind).size
     @mentor_count = User.mentor.size
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
   end
 
   test 'mentor receive notification when question is posted' do

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -253,4 +253,33 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     visit_with_auth '/notifications?status=unread', 'komagata'
     assert_no_text 'kimuraさんから質問「更新されたタイトル」が投稿されました。'
   end
+
+  test 'delete question with notification' do
+    visit_with_auth '/questions', 'kimura'
+    click_link '質問する'
+    fill_in 'question[title]', with: 'タイトルtest'
+    fill_in 'question[description]', with: '内容test'
+
+    assert_difference -> { Question.count }, 1 do
+      click_button '登録する'
+      assert_text '質問を作成しました。'
+    end
+
+    visit_with_auth '/notifications', 'komagata'
+    assert_text 'yameoさんが退会しました。'
+    assert_text 'kimuraさんから質問「タイトルtest」が投稿されました。'
+
+    visit_with_auth '/questions', 'kimura'
+    click_on 'タイトルtest'
+    assert_difference -> { Question.count }, -1 do
+      accept_confirm do
+        click_link '削除する'
+      end
+      assert_text '質問を削除しました。'
+    end
+
+    visit_with_auth '/notifications', 'komagata'
+    assert_text 'yameoさんが退会しました。'
+    assert_no_text 'kimuraさんから質問「タイトルtest」が投稿されました。'
+  end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -71,35 +71,6 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_text '質問を削除しました。'
   end
 
-  test 'delete question with notification' do
-    visit_with_auth '/questions', 'kimura'
-    click_link '質問する'
-    fill_in 'question[title]', with: 'タイトルtest'
-    fill_in 'question[description]', with: '内容test'
-
-    assert_difference -> { Question.count }, 1 do
-      click_button '登録する'
-      assert_text '質問を作成しました。'
-    end
-
-    visit_with_auth '/notifications', 'komagata'
-    assert_text 'yameoさんが退会しました。'
-    assert_text 'kimuraさんから質問「タイトルtest」が投稿されました。'
-
-    visit_with_auth '/questions', 'kimura'
-    click_on 'タイトルtest'
-    assert_difference -> { Question.count }, -1 do
-      accept_confirm do
-        click_link '削除する'
-      end
-      assert_text '質問を削除しました。'
-    end
-
-    visit_with_auth '/notifications', 'komagata'
-    assert_text 'yameoさんが退会しました。'
-    assert_no_text 'kimuraさんから質問「タイトルtest」が投稿されました。'
-  end
-
   test 'admin can update and delete any questions' do
     question = questions(:question8)
     visit_with_auth question_path(question), 'komagata'


### PR DESCRIPTION
## 関連issue
* #4692
## 概要
質問投稿をした時の通知機能を既存のものから[abstract_notifier](https://github.com/palkan/abstract_notifier)を使ったものに置き換えました。
通知はbootcampアプリとdiscordとメールの3か所に送られます。
画面上の変更はございません。

### テストについて
* `system/notification/questions_test.rb`にabstruct_notifierのテストの設定用コードを追記しました。
* `system/questions_test.rb`の中にあった質問の通知関連のテスト（`test 'delete question with notification'`の部分です）を`system/notification/questions_test.rb`にそっくりそのまま移動させております。
理由は`system/questions_test.br`の中にはabstruct_notifierのテストの設定が書かれておらず、そのままだとテストが落ちてしまうからです。テストの内容的にも`system/notification`ディレクトリ下に置いて問題ないと判断しました。

### 実装時に参考にしたもの
既にmerge済みの[こちらのPR](https://github.com/fjordllc/bootcamp/pull/4673)を参考にしました。

## 動作確認方法
1. `feature/replace-new-question-post-notification-with-abstract-notifier`ブランチを取り込む。
2. discordに通知が行くかを確認するために`app/models/chat_notifier.rb`ファイルを修正する。

```diff
  def self.message(
    message,
    username: 'ピヨルド',
-    webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
+    webhook_url: 'ここにテスト用チャンネルのWebhook URLを入れる'
  )

-    if Rails.env.production?
+    if Rails.env.development?
      Discord::Notifier.message(message, username: username, url: webhook_url)
    else
      Rails.logger.info 'Message to Discord.'
```

webhook urlについては私は以下を参考にしました。
参考：https://bootcamp.fjord.jp/reports/41272
参考：https://popush.hatenablog.com/entry/2019/10/07/222047

### Discord動作確認に関する余談
レビュワーさんにはあまり関係ない話なので読み飛ばしていただいて差支えありません。
もしこちらのPRを参考にDiscord関連の実装をされる方は、`app/models/chat_notifier.rb`に自分のwebhook_urlを含めたままコミットしないようにお気をつけください。（私はコミットしてしまって、GitguardianというGithubアプリから機密情報じゃありませんか？とメール通知がきました🙇‍♂️テスト用に作成した自分のDiscordチャンネルを削除して対応しました。）

3. `rails s`でサーバーを立ち上げる。
4. 任意のユーザーでログインしQ&Aに質問を投稿する。投稿後にdiscordのテスト用チャンネルに通知が来ることを確認する。
5. 先ほどとは別のユーザー（メンターを選ぶ）でログインし、アプリ内（画面右上のベルマーク部分）に通知が来ていることを確認する。
![image](https://user-images.githubusercontent.com/97820517/174291885-a0de0c6d-413a-4f79-bb3d-45fe952ec202.png)

6. `http://localhost:3000/letter_opener/`にアクセスし、管理者にメール通知が来ているかを確認する。
![image](https://user-images.githubusercontent.com/97820517/174292108-53e1e274-6d91-4f2d-a309-7d49af6b43e8.png)

7. `app/models/chat_notifier.rb`内の修正を元に戻す。

