### PR TITLE
現在のパラメーターを引き継ぐようにした

### DIFF
--- a/app/javascript/practice-select.vue
+++ b/app/javascript/practice-select.vue
@@ -62,7 +62,10 @@ export default {
     },
     submit() {
       this.$nextTick(() => {
-        location.href = `${location.pathname}?all=true&solved=${this.solved}&practice_id=${this.selected.id}&title=${this.selected.title}`
+        const newUrl = new URL(location.href)
+        newUrl.searchParams.set('practice_id', this.selected.id)
+        newUrl.searchParams.set('title', this.selected.title)
+        location.href = newUrl
       })
     }
   }

--- a/app/javascript/practice-select.vue
+++ b/app/javascript/practice-select.vue
@@ -63,6 +63,7 @@ export default {
     submit() {
       this.$nextTick(() => {
         const newUrl = new URL(location.href)
+        newUrl.searchParams.delete('page')
         newUrl.searchParams.set('practice_id', this.selected.id)
         newUrl.searchParams.set('title', this.selected.title)
         location.href = newUrl


### PR DESCRIPTION
## Issue
- #5053

## 概要
未解決の質問一覧からプラクティスを選択した場合、選択したプラクティスの未解決の質問を表示するよう修正しました。

## 変更確認方法
1. ブランチ`bug/fix-qa-url`をローカルに取り込む
2. `bin/rails server`でローカル環境を立ち上げる
3. Q&Aページ( `/questions` )を開く
4. ”プラクティスで絞り込む”からプラクティスを選択
5. 選択したプラクティスの未解決の質問が表示されることを確認

## 変更前

![2022-06-20-01](https://user-images.githubusercontent.com/60736158/174601265-c20009df-03a0-45eb-8617-102c974242bc.gif)

## 変更後

![2022-06-20-02](https://user-images.githubusercontent.com/60736158/174601253-787263f2-92a1-4a34-b869-6dbe8fcd5c10.gif)
