### PR TITLE
未チェックの日報一覧ページで自分の日報の「内容変更/コピー」トグルが表示されるように修正

### DIFF
--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -82,8 +82,7 @@ export default {
   },
   props: {
     report: { type: Object, required: true },
-    // issue #2625 を修正すれば、required: true にし、defaultはいらなくなる
-    currentUserId: { type: Number, required: false, default: null }
+    currentUserId: { type: Number, required: true }
   },
   computed: {
     roleClass() {

--- a/app/views/api/reports/unchecked/index.json.jbuilder
+++ b/app/views/api/reports/unchecked/index.json.jbuilder
@@ -6,5 +6,5 @@ json.reports @reports do |report|
   end
 end
 
-json.current_user_id current_user.id
+json.currentUserId current_user.id
 json.totalPages @reports.total_pages


### PR DESCRIPTION
## Issue

- #2625

## 概要

### 現状
未チェックの日報一覧ページ(`/reports/unchecked`)で、自分が作成した日報のタイトル右端に、日報の「内容変更/コピー」トグルが表示されていない状況。
　※未チェックの日報一覧ページにアクセスできるユーザーは、管理者 or メンター or アドバイザーのいずれかである。
### 原因
「内容変更/コピー」トグルの表示条件は、ログインユーザのidと日報作成者のidが同じであること。
しかし、jbuilderで取得したログインユーザのidのキー名とvueでログインユーザのidをセットするためのキー名が異なるため、ログインユーザのidは常にnullとなり、表示条件が常にfalseとなってしまっている。

## 確認方法

1. ブランチ`bug/modify-key-name-for-login-user-id`をローカルに取り込む。
2. `bin/rails s`でローカル環境を立ち上げる。
3. 管理者 or メンター or アドバイザーのいずれかでログインする。
4. 日報作成ページ(`/reports/new`)にアクセスし、適当に日報を新規作成しておく。
5. 未チェックの日報一覧ページ(`/reports/unchecked`)にアクセスし、作成した日報に「内容変更/コピー」トグルが表示されることを確認する。

## 変更前
<img width="1003" alt="Cursor_and__development__未チェックの日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174489467-6b214efc-f79a-4434-8b96-79143f4befd4.png">


## 変更後
<img width="1002" alt="Cursor_and__development__未チェックの日報___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/174489442-241219cb-9d35-4500-9a26-a73ddcd7dbc3.png">


