### PR TITLE
Q&Aのパラメーターを変更

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -6,12 +6,13 @@ class API::QuestionsController < API::BaseController
 
   def index
     questions =
-      if params[:solved].present?
+      case params[:target]
+      when 'solved'
         Question.solved
-      elsif params[:all].present?
-        Question.all
-      else
+      when 'not_solved'
         Question.not_solved.not_wip
+      else
+        Question.all
       end
     questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
     questions = params[:user_id].present? ? Question.where(user_id: params[:user_id]) : questions

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -6,9 +6,10 @@ class Practices::QuestionsController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
     questions =
-      if params[:solved].present?
+      case params[:target]
+      when 'solved'
         @practice.questions.solved
-      elsif params[:not_solved].present?
+      when 'not_solved'
         @practice.questions.not_solved.not_wip
       else
         @practice.questions

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -11,12 +11,13 @@ class QuestionsController < ApplicationController
 
   def index
     questions =
-      if params[:solved].present?
+      case params[:target]
+      when 'solved'
         Question.solved
-      elsif params[:all].present?
-        Question.all
+      when 'not_solved'
+        Question.not_solved.not_wip
       else
-        Question.not_solved
+        Question.all
       end
     @tag = ActsAsTaggableOn::Tag.find_by(name: params[:tag])
     @tags = questions.all_tags
@@ -80,12 +81,13 @@ class QuestionsController < ApplicationController
   end
 
   def questions_property
-    if params[:all] == 'true'
-      QuestionsProperty.new('全ての質問', '質問はありません。')
-    elsif params[:solved] == 'true'
+    case params[:target]
+    when 'solved'
       QuestionsProperty.new('解決済みの質問一覧', '解決済みの質問はありません。')
-    else
+    when 'not_solved'
       QuestionsProperty.new('未解決の質問一覧', '未解決の質問はありません。')
+    else
+      QuestionsProperty.new('全ての質問', '質問はありません。')
     end
   end
 

--- a/app/javascript/practice-select.js
+++ b/app/javascript/practice-select.js
@@ -14,7 +14,6 @@ document.addEventListener('DOMContentLoaded', () => {
         h(PracticeSelect, {
           props: {
             title: title,
-            solved: practiceSelect.dataset.solved ?? '',
             currentUserId: practiceSelect.dataset.currentUserId
           }
         })

--- a/app/javascript/practice-select.vue
+++ b/app/javascript/practice-select.vue
@@ -21,7 +21,6 @@ export default {
   },
   props: {
     title: { type: String, required: true },
-    solved: { type: String, required: true },
     currentUserId: { type: String, required: true }
   },
   data() {

--- a/app/views/api/pages/_page.json.jbuilder
+++ b/app/views/api/pages/_page.json.jbuilder
@@ -25,5 +25,5 @@ json.commentsSize page.comments.size
 
 json.tags page.tags.each do |tag|
   json.name tag.name
-  json.url pages_url(tag: tag.name, all: true)
+  json.url pages_url(tag: tag.name)
 end

--- a/app/views/api/questions/_question.json.jbuilder
+++ b/app/views/api/questions/_question.json.jbuilder
@@ -24,6 +24,5 @@ end
 
 json.tags question.tags.each do |tag|
   json.name tag.name
-  json.url questions_url(tag: tag.name, all: true)
+  json.url questions_url(tag: tag.name)
 end
-

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -35,7 +35,7 @@ nav.global-nav
                   = Cache.unassigned_product_count
               .global-nav-links__link-label 提出物
         li.global-nav-links__item
-          = link_to questions_path, class: "global-nav-links__link #{current_link(/^questions/)}" do
+          = link_to questions_path(target: 'not_solved'), class: "global-nav-links__link #{current_link(/^questions/)}" do
             .global-nav-links__link-icon
               i.fa-solid.fa-comments-question-check
             - if Question.not_solved.not_wip.count.positive?

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -8,11 +8,11 @@ nav.tab-nav
   .container.is-xs-horizontal-padding-0
     ul.tab-nav__items
       li.tab-nav__item
-        = link_to '全ての質問', polymorphic_path([@practice, :questions], all: 'true'), class: "tab-nav__item-link #{params[:solved].present? || params[:not_solved].present? ? '' : 'is-active'}"
+        = link_to '全ての質問', practice_questions_path(@practice), class: "tab-nav__item-link #{params[:target].blank? ? 'is-active' : ''}"
       li.tab-nav__item
-        = link_to '解決済み', polymorphic_path([@practice, :questions], solved: 'true'), class: "tab-nav__item-link #{params[:all].blank? && params[:solved].present? && params[:not_solved].blank? ? 'is-active' : ''}"
+        = link_to '解決済み', practice_questions_path(@practice, target: 'solved'), class: "tab-nav__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
       li.tab-nav__item
-        = link_to '未解決', polymorphic_path([@practice, :questions], not_solved: 'true'), class: "tab-nav__item-link #{params[:all].blank? && params[:solved].blank? && params[:not_solved].present? ? 'is-active' : ''}"
+        = link_to '未解決', practice_questions_path(@practice, target: 'not_solved'), class: "tab-nav__item-link #{params[:target] == 'not_solved' ? 'is-active' : ''}"
 
 .page-body
   .container.is-md
@@ -21,12 +21,13 @@ nav.tab-nav
         = render partial: 'questions/question', collection: @questions, as: :question
     - else
       .o-empty-message
-        - if params[:solved]
+        - case params[:target]
+        - when 'solved'
           .o-empty-message__icon
             i.fa-regular.fa-sad-tear
           p.o-empty-message__text
             | 解決済みの質問はまだありません。
-        - else
+        - when 'not_solved'
           .o-empty-message__icon
             i.fa-regular.fa-smile
           p.o-empty-message__text

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -8,7 +8,7 @@ nav.tab-nav
   .container.is-xs-horizontal-padding-0
     ul.tab-nav__items
       li.tab-nav__item
-        = link_to '全ての質問', practice_questions_path(@practice), class: "tab-nav__item-link #{params[:target].blank? ? 'is-active' : ''}"
+        = link_to '全ての質問', practice_questions_path(@practice), class: "tab-nav__item-link #{params[:target] == 'not_solved' || params[:target] == 'solved' ? '' : 'is-active'}"
       li.tab-nav__item
         = link_to '解決済み', practice_questions_path(@practice, target: 'solved'), class: "tab-nav__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
       li.tab-nav__item

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -36,4 +36,4 @@
       li.form-actions__item.is-main
         = f.submit nil, class: 'a-button is-lg is-primary is-block'
       li.form-actions__item
-          = link_to 'キャンセル', questions_path, class: 'a-button is-sm is-secondary'
+        = link_to 'キャンセル', questions_path(target: 'not_solved'), class: 'a-button is-sm is-secondary'

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -2,13 +2,13 @@
   .container
     ul.page-tabs__items
       li.page-tabs__item
-        = link_to polymorphic_path(:questions, practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:all].present? || params[:solved].present? ? '' : 'is-active'}" do
+        = link_to questions_path(target: 'not_solved', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target] == 'not_solved' ? 'is-active' : ''}" do
           | 未解決
           - if Question.not_solved.not_wip.size.positive? && current_user.admin_or_mentor?
             .page-tabs__item-count.a-notification-count
               #not-solved-count
                 = params[:practice_id].present? ? Question.not_solved.not_wip.where(practice_id: params[:practice_id]).size : Question.not_solved.not_wip.size
       li.page-tabs__item
-        = link_to '解決済み', polymorphic_path(:questions, solved: 'true', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:solved].present? ? 'is-active' : ''}"
+        = link_to '解決済み', questions_path(target: 'solved', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
       li.page-tabs__item
-        = link_to '全ての質問', polymorphic_path(:questions, all: 'true', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:all].present? && params[:solved].blank? ? 'is-active' : ''}"
+        = link_to '全ての質問', questions_path(practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target].blank? ? 'is-active' : ''}"

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -11,4 +11,4 @@
       li.page-tabs__item
         = link_to '解決済み', questions_path(target: 'solved', practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
       li.page-tabs__item
-        = link_to '全ての質問', questions_path(practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target].blank? ? 'is-active' : ''}"
+        = link_to '全ての質問', questions_path(practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target] == 'not_solved' || params[:target] == 'solved' ? '' : 'is-active'}"

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -16,7 +16,7 @@ header.page-header
       .sort-nav__inner
         = label_tag :practice_id, 'プラクティスで絞り込む', class: 'sort-nav__label'
         .sort-nav__select
-          #js-practice-select data-solved=params[:solved] data-current-user-id=current_user.id
+          #js-practice-select data-current-user-id=current_user.id
   = render 'questions/tabs'
 
 - if @tag.present?
@@ -47,4 +47,4 @@ header.page-header
                 - Question.all.all_tags.each do |tag|
                   - if tag.present?
                     li.page-tags-nav__item
-                      = link_to tag.name, questions_tag_path(tag.name, all: 'true'), class: 'page-tags-nav__item-link'
+                      = link_to tag.name, questions_tag_path(tag.name), class: 'page-tags-nav__item-link'

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -8,7 +8,7 @@ header.page-header
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item
-            = link_to questions_path, class: 'a-button is-md is-secondary is-block is-back' do
+            = link_to questions_path(target: 'not_solved'), class: 'a-button is-md is-secondary is-block is-back' do
               | Q&A一覧
 
 .a-page-notice.page-notice

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -11,7 +11,7 @@ header.page-header
               i.fa-regular.fa-plus
               | 質問する
           li.page-header-actions__item
-            = link_to questions_path, class: 'a-button is-md is-secondary is-block is-back' do
+            = link_to questions_path(target: 'not_solved'), class: 'a-button is-md is-secondary is-block is-back' do
               | Q&A一覧
 
 #js-question(

--- a/test/system/practice/questions_test.rb
+++ b/test/system/practice/questions_test.rb
@@ -14,7 +14,7 @@ class Practice::QuestionsTest < ApplicationSystemTestCase
   end
 
   test 'not show a WIP question on the unsolved questions list ' do
-    visit_with_auth "/practices/#{practices(:practice1).id}/questions?not_solved=true", 'hatsuno'
+    visit_with_auth "/practices/#{practices(:practice1).id}/questions?target=not_solved", 'hatsuno'
     assert_no_text 'wipテスト用の質問(wip中)'
     assert_selector('a.tab-nav__item-link.is-active', text: '未解決')
   end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -7,17 +7,17 @@ class QuestionsTest < ApplicationSystemTestCase
   include TagHelper
 
   test 'show listing unsolved questions' do
-    visit_with_auth questions_path, 'kimura'
+    visit_with_auth questions_path(target: 'not_solved'), 'kimura'
     assert_equal '未解決の質問一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'show listing solved questions' do
-    visit_with_auth questions_path(solved: 'true'), 'kimura'
+    visit_with_auth questions_path(target: 'solved'), 'kimura'
     assert_equal '解決済みの質問一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'show listing all questions' do
-    visit_with_auth questions_path(all: 'true'), 'kimura'
+    visit_with_auth questions_path, 'kimura'
     assert_equal '全ての質問 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
@@ -160,14 +160,14 @@ class QuestionsTest < ApplicationSystemTestCase
   end
 
   test 'Question display 25 items correctly' do
-    visit_with_auth questions_path(solved: 'true'), 'kimura'
+    visit_with_auth questions_path(target: 'solved'), 'kimura'
     50.times do |n|
       q = Question.create(title: "順番ばらつきテスト#{n}", description: "答え#{n}", user_id: 253_826_460, practice_id: 315_059_988)
       Answer.create(description: '正しい答え', user_id: 253_826_460, question_id: q.id, type: 'CorrectAnswer')
       Answer.create(description: '正しい答え2', user_id: 253_826_460, question_id: q.id)
     end
 
-    visit questions_path(solved: 'true')
+    visit questions_path(target: 'solved')
 
     assert_selector '.card-list-item', count: 25
     first('.pagination__item-link', text: '2').click
@@ -198,7 +198,7 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     assert_text '質問をWIPとして保存しました。'
 
-    visit_with_auth questions_path(all: 'true'), 'komagata'
+    visit_with_auth questions_path, 'komagata'
     click_link 'WIPタイトル'
     assert_text '削除する'
     assert_no_text 'Watch中'
@@ -213,7 +213,7 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     assert_text '質問をWIPとして保存しました。'
 
-    visit questions_path(all: 'true')
+    visit questions_path
     click_link 'WIPタイトル'
     assert_text '削除する'
     click_button '内容修正'
@@ -286,7 +286,7 @@ class QuestionsTest < ApplicationSystemTestCase
   end
 
   test 'show a WIP question on the All Q&A list page' do
-    visit_with_auth questions_path(all: 'true'), 'kimura'
+    visit_with_auth questions_path, 'kimura'
     assert_text 'wipテスト用の質問(wip中)'
     element = all('.card-list-item').find { |component| component.has_text?('wipテスト用の質問(wip中)') }
     within element do
@@ -295,7 +295,7 @@ class QuestionsTest < ApplicationSystemTestCase
   end
 
   test 'not show a WIP question on the unsolved Q&A list page' do
-    visit_with_auth questions_path, 'kimura'
+    visit_with_auth questions_path(target: 'not_solved'), 'kimura'
     assert_no_text 'wipテスト用の質問(wip中)'
     assert_text '未解決の質問一覧'
   end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -129,7 +129,7 @@ class QuestionsTest < ApplicationSystemTestCase
       assert_text '削除する'
     end
 
-    visit_with_auth questions_path, 'komagata'
+    visit_with_auth questions_path(target: 'not_solved'), 'komagata'
     click_on 'テストの質問タイトル'
     within '.a-card.is-answer' do
       assert_text '内容修正'
@@ -137,7 +137,7 @@ class QuestionsTest < ApplicationSystemTestCase
       assert_text '削除する'
     end
 
-    visit_with_auth questions_path, 'hatsuno'
+    visit_with_auth questions_path(target: 'not_solved'), 'hatsuno'
     click_on 'テストの質問タイトル'
     within '.a-card.is-answer' do
       assert_no_text '内容修正'
@@ -147,7 +147,7 @@ class QuestionsTest < ApplicationSystemTestCase
   end
 
   test 'select box shows the practices that belong to a user course' do
-    visit_with_auth questions_path, 'kimura'
+    visit_with_auth questions_path(target: 'not_solved'), 'kimura'
     find('.multiselect').click
     selects_size = users(:kimura).course.practices.size + 1
     assert_selector '.multiselect__element', count: selects_size
@@ -183,7 +183,7 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     assert_text '質問を作成しました。'
 
-    visit_with_auth questions_path, 'komagata'
+    visit_with_auth questions_path(target: 'not_solved'), 'komagata'
     click_link 'メンターのみ投稿された質問が"Watch中"になるテスト'
     assert_text '削除する'
     assert_text 'Watch中'
@@ -224,14 +224,14 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     assert_text '質問を更新しました'
 
-    visit_with_auth questions_path, 'komagata'
+    visit_with_auth questions_path(target: 'not_solved'), 'komagata'
     click_link '更新されたタイトル'
     assert_text '削除する'
     assert_text 'Watch中'
   end
 
   test 'show number of comments' do
-    visit_with_auth questions_path, 'kimura'
+    visit_with_auth questions_path(target: 'not_solved'), 'kimura'
     assert_text 'コメント数表示テスト用の質問'
     element = all('.card-list-item').find { |component| component.has_text?('コメント数表示テスト用の質問') }
     within element do
@@ -301,7 +301,7 @@ class QuestionsTest < ApplicationSystemTestCase
   end
 
   test "visit user profile page when clicked on user's name on question" do
-    visit_with_auth questions_path, 'kimura'
+    visit_with_auth questions_path(target: 'not_solved'), 'kimura'
     assert_text '質問のタブの作り方'
     click_link 'hatsuno (Hatsuno Shinji)', match: :first
     assert_text 'プロフィール'
@@ -309,7 +309,7 @@ class QuestionsTest < ApplicationSystemTestCase
   end
 
   test 'show number of unanswered questions' do
-    visit_with_auth questions_path(practice_id: practices(:practice1).id), 'komagata'
+    visit_with_auth questions_path(practice_id: practices(:practice1).id, target: 'not_solved'), 'komagata'
     assert_selector '#not-solved-count', text: Question.not_solved.not_wip.where(practice_id: practices(:practice1).id).size
   end
 
@@ -356,7 +356,7 @@ class QuestionsTest < ApplicationSystemTestCase
     click_button '登録する'
     assert_text 'Questionに関連プラクティスを指定'
 
-    visit questions_path
+    visit questions_path(target: 'not_solved')
     within first('.card-list-item-title__title') do
       assert_text 'Questionに関連プラクティスを指定'
     end


### PR DESCRIPTION
# Issue
- #4515
- #5053

## 関連PR
- #5049
※上記PRの変更反映済みです。

## 概要
Q&Aのパラメーターを変更しました。

- 未解決：パラメーターなし → `target=not_solved`
- 解決済み：`solved=true` → `target=solved`
- 全ての質問：`all=true` → パラメーターなし

## 変更確認方法
1. ブランチ`feature/change-parameter`をローカルに取り込む
2. `bin/rails server`でローカル環境を立ち上げる
3. Q&Aページ( `/questions` )でタブ遷移を確認
4. プラクティス内の質問ページ( `/practices/:id/questions` )でタブ遷移を確認
5. タグ一覧から”猫”( `/questions/tags/猫` )を選択し、タグ「猫」の全ての質問が表示されることを確認