### PR TITLE
お知らせ通知の実装をabstract_notifierに置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -87,17 +87,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def post_announcement(announce, receiver)
-      Notification.create!(
-        kind: kinds[:announced],
-        user: receiver,
-        sender: announce.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(announce),
-        message: "お知らせ「#{announce.title}」",
-        read: false
-      )
-    end
-
     def watching_notification(watchable, receiver, comment)
       watchable_user = watchable.user
       sender = comment.user

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -55,7 +55,7 @@ class NotificationFacade
   end
 
   def self.post_announcement(announce, receiver)
-    Notification.post_announcement(announce, receiver)
+    ActivityNotifier.with(announce: announce, receiver: receiver).post_announcement.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -125,4 +125,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def post_announcement(params = {})
+    params.merge!(@params)
+    announce = params[:announce]
+    receiver = params[:receiver]
+
+    notification(
+      body: "お知らせ「#{announce.title}」",
+      kind: :announced,
+      sender: announce.user,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(announce),
+      read: false
+    )
+  end
 end

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -61,4 +61,16 @@ class ActivityNotifierTest < ActiveSupport::TestCase
       ActivityNotifier.with(report: reports(:report10), receiver: users(:kimura)).first_report.notify_now
     end
   end
+
+  test '#announcement' do
+    notification = ActivityNotifier.with(announce: announcements(:announcement1), receiver: users(:kimura)).post_announcement
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      notification.notify_now
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      notification.notify_later
+    end
+  end
 end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class AnnouncementsTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test 'show link to create new announcement when user is admin' do
     visit_with_auth '/announcements', 'komagata'
     assert_text 'お知らせ作成'
@@ -87,58 +96,6 @@ class AnnouncementsTest < ApplicationSystemTestCase
 
     visit_with_auth '/notifications', 'hatsuno'
     assert_no_text 'お知らせ「タイトルtest」'
-  end
-
-  test 'announcement notification receive only active users' do
-    visit_with_auth '/announcements', 'machida'
-    click_link 'お知らせ作成'
-    fill_in 'announcement[title]', with: '現役生にのみお知らせtest'
-    fill_in 'announcement[description]', with: '内容test'
-    find('label', text: '現役生のみ').click
-
-    click_button '作成'
-    assert_text 'お知らせを作成しました'
-
-    visit_with_auth '/notifications', 'komagata'
-    assert_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'kimura'
-    assert_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'sotugyou'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'advijirou'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'yameo'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'mentormentaro'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'kensyu'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-  end
-
-  test 'announcement notifications are only recived by job seekers' do
-    visit_with_auth '/announcements', 'machida'
-    click_link 'お知らせ作成'
-    fill_in 'announcement[title]', with: '就活希望者のみお知らせします'
-    fill_in 'announcement[description]', with: '合同説明会をやるのでぜひいらしてください！'
-    find('label', text: '就職希望者のみ').click
-
-    click_button '作成'
-    assert_text 'お知らせを作成しました'
-
-    visit_with_auth '/notifications', 'komagata'
-    assert_text 'お知らせ「就活希望者のみお知らせします」'
-
-    visit_with_auth '/notifications', 'jobseeker'
-    assert_text 'お知らせ「就活希望者のみお知らせします」'
-
-    visit_with_auth '/notifications', 'kimura'
-    assert_no_text 'お知らせ「就活希望者のみお知らせします」'
   end
 
   test "general user can't create announcement" do

--- a/test/system/notification/announcements_test.rb
+++ b/test/system/notification/announcements_test.rb
@@ -4,10 +4,16 @@ require 'application_system_test_case'
 
 class Notification::AnnouncementsTest < ApplicationSystemTestCase
   setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
     @notice_text = 'お知らせ「タイトル通知用の確認です」'
     @notice_kind = Notification.kinds['announced']
     @notified_count = Notification.where(kind: @notice_kind).size
     @receiver_count = User.where(retired_on: nil).size - 1 # 送信者は除くため-1
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
   end
 
   test 'all member recieve a notification when announcement posted' do
@@ -33,5 +39,57 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
     expected = @notified_count + @receiver_count
     actual = Notification.where(kind: @notice_kind).size
     assert_equal expected, actual
+  end
+
+  test 'announcement notification receive only active users' do
+    visit_with_auth '/announcements', 'machida'
+    click_link 'お知らせ作成'
+    fill_in 'announcement[title]', with: '現役生にのみお知らせtest'
+    fill_in 'announcement[description]', with: '内容test'
+    find('label', text: '現役生のみ').click
+
+    click_button '作成'
+    assert_text 'お知らせを作成しました'
+
+    visit_with_auth '/notifications', 'komagata'
+    assert_text 'お知らせ「現役生にのみお知らせtest」'
+
+    visit_with_auth '/notifications', 'kimura'
+    assert_text 'お知らせ「現役生にのみお知らせtest」'
+
+    visit_with_auth '/notifications', 'sotugyou'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+
+    visit_with_auth '/notifications', 'advijirou'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+
+    visit_with_auth '/notifications', 'yameo'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+
+    visit_with_auth '/notifications', 'mentormentaro'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+
+    visit_with_auth '/notifications', 'kensyu'
+    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+  end
+
+  test 'announcement notifications are only recived by job seekers' do
+    visit_with_auth '/announcements', 'machida'
+    click_link 'お知らせ作成'
+    fill_in 'announcement[title]', with: '就活希望者のみお知らせします'
+    fill_in 'announcement[description]', with: '合同説明会をやるのでぜひいらしてください！'
+    find('label', text: '就職希望者のみ').click
+
+    click_button '作成'
+    assert_text 'お知らせを作成しました'
+
+    visit_with_auth '/notifications', 'komagata'
+    assert_text 'お知らせ「就活希望者のみお知らせします」'
+
+    visit_with_auth '/notifications', 'jobseeker'
+    assert_text 'お知らせ「就活希望者のみお知らせします」'
+
+    visit_with_auth '/notifications', 'kimura'
+    assert_no_text 'お知らせ「就活希望者のみお知らせします」'
   end
 end


### PR DESCRIPTION
## Issue

- #4693 

## 概要

お知らせ通知の実装をabstract_notifierに置き換えました
仕様は変更していないため、変更前/変更後のスクリーンショットは割愛します

## 変更確認方法

1. ブランチ`feature/replace-post-announcement-notification-with-abstract_notifier`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. メンター権限を持っているユーザーでログインする
4. 「お知らせ」タブを選び、「お知らせ作成」から新しいお知らせを投稿する
5. ログアウトし、別のユーザーでログインする
6. 右上の「通知」に、先ほど作成したお知らせの通知が来ているか確認する
<img width="241" alt="スクリーンショット 2022-06-23 15 12 10" src="https://user-images.githubusercontent.com/96340764/175956120-1e35913f-316e-4826-aeb2-c0dfc7f672c9.png">

7. 通知にアクセスし、作成したお知らせにリンクができているか確認する

8. `http://127.0.0.1:3000/letter_opener/`にアクセスし、お知らせのメール通知が来ているか確認する
<img width="1238" alt="スクリーンショット 2022-06-23 14 57 51" src="https://user-images.githubusercontent.com/96340764/175956181-679bd45a-162b-435d-904c-eac8a102f7e8.png">

