### PR TITLE
ブログのサムネイル画像アップロードUIを変更

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -29,7 +29,6 @@ class ArticlesController < ApplicationController
     @article.user = current_user if @article.user.nil?
     set_wip_or_published_time
     if @article.save
-      @article.resize_thumbnail!
       redirect_to redirect_url(@article), notice: notice_message(@article)
     else
       render :new
@@ -39,7 +38,6 @@ class ArticlesController < ApplicationController
   def update
     set_wip_or_published_time
     if @article.update(article_params)
-      @article.resize_thumbnail!
       redirect_to redirect_url(@article), notice: notice_message(@article)
     else
       render :edit

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -16,10 +16,6 @@ class Article < ApplicationRecord
   paginates_per 10
   acts_as_taggable
 
-  def resize_thumbnail!
-    thumbnail.variant(resize: THUMBNAIL_SIZE).processed if thumbnail.attached?
-  end
-
   def thumbnail_url
     if thumbnail.attached?
       thumbnail.variant(resize: THUMBNAIL_SIZE).processed.url

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,7 +22,7 @@ class Article < ApplicationRecord
 
   def thumbnail_url
     if thumbnail.attached?
-      thumbnail.variant(resize: THUMBNAIL_SIZE).service_url
+      thumbnail.variant(resize: THUMBNAIL_SIZE).processed.url
     else
       image_url('/images/articles/thumbnails/default.png')
     end

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -42,8 +42,15 @@
           = f.text_field :tag_list, class: 'a-text-input js-warning-form'
 
     .form-item
-      = f.label :thumbnail, 'サムネイル画像を登録してください', class: 'a-label'
-      = f.file_field :thumbnail
+      = f.label :thumbnail, 'サムネイル画像を登録してください', class: 'a-form-label'
+      .form-item-file-input.js-file-input.a-file-input
+        label.js-file-input__preview
+          - if article.thumbnail.attached?
+            = image_tag article.thumbnail
+            p 画像を変更
+          - else
+            p 画像を選択
+          = f.file_field :thumbnail
 
   .form-actions
     ul.form-actions__items


### PR DESCRIPTION
## Issue
- #4926

## 概要
ブログのサムネイル画像アップロードUIを変更しました。

## 変更確認方法
1. ブランチ`feature/change-thumbnail-image-upload-ui-for-blog`をローカルに取り込む
2. `bin/rails server`でローカル環境を立ち上げる
3. 管理者orメンターでログインしてブログ記事の作成ページ( `/articles/new` )を開く
4. サムネイル画像アップロードUIの変更を確認

## 変更前

<img width="1665" alt="2022-06-24-01" src="https://user-images.githubusercontent.com/60736158/175337279-2fbe5cc1-16a7-491c-8375-fe8f2a6ce28a.png">

## 変更後

<img width="1665" alt="2022-06-24-02" src="https://user-images.githubusercontent.com/60736158/175337309-f03ce1e9-21b9-4197-b498-8a0c9f5a6678.png">
