### PR TITLE
Watch一覧ページにWatch中のプラクティスを表示するように修正

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -47,4 +47,8 @@ module SearchHelper
   def user?(searchable)
     searchable.instance_of?(User)
   end
+
+  def created_user(searchable)
+    searchable.respond_to?(:user) ? searchable.user : nil
+  end
 end

--- a/app/javascript/watch.vue
+++ b/app/javascript/watch.vue
@@ -15,7 +15,7 @@
       .card-list-item__row
         .card-list-item-meta
           .card-list-item-meta__items
-            .card-list-item-meta__item
+            .card-list-item-meta__item(v-if='watch.edit_user')
               a.a-user-name(:href='userUrl')
                 | {{ watch.edit_user.login_name }}
             .card-list-item-meta__item
@@ -48,7 +48,11 @@ export default {
       return `is-${this.watch.watch_class_name}`
     },
     userUrl() {
-      return `/users/${this.watch.edit_user.id}`
+      if (this.watch.edit_user) {
+        return `/users/${this.watch.edit_user.id}`
+      } else {
+        return null
+      }
     },
     createdAt() {
       return dayjs(this.watch.created_at).format('YYYY年MM月DD日(dd) HH:mm')

--- a/app/javascript/watch.vue
+++ b/app/javascript/watch.vue
@@ -15,9 +15,9 @@
       .card-list-item__row
         .card-list-item-meta
           .card-list-item-meta__items
-            .card-list-item-meta__item(v-if='watch.edit_user')
+            .card-list-item-meta__item(v-if='watch.created_user')
               a.a-user-name(:href='userUrl')
-                | {{ watch.edit_user.login_name }}
+                | {{ watch.created_user.login_name }}
             .card-list-item-meta__item
               time.a-meta(:datetime='watch.updated_at')
                 | {{ createdAt }}
@@ -48,8 +48,8 @@ export default {
       return `is-${this.watch.watch_class_name}`
     },
     userUrl() {
-      if (this.watch.edit_user) {
-        return `/users/${this.watch.edit_user.id}`
+      if (this.watch.created_user) {
+        return `/users/${this.watch.created_user.id}`
       } else {
         return null
       }

--- a/app/views/api/watches/_watch.json.jbuilder
+++ b/app/views/api/watches/_watch.json.jbuilder
@@ -2,7 +2,7 @@ json.id watch.id
 json.watchable_id watch.watchable_id
 json.watchable_type watch.watchable_type
 json.user watch.user
-json.edit_user created_user(matched_document(watch.watchable))
+json.created_user created_user(matched_document(watch.watchable))
 json.created_at matched_document(watch.watchable).created_at
 json.updated_at matched_document(watch.watchable).updated_at
 json.url searchable_url(watch.watchable)

--- a/app/views/api/watches/_watch.json.jbuilder
+++ b/app/views/api/watches/_watch.json.jbuilder
@@ -2,7 +2,7 @@ json.id watch.id
 json.watchable_id watch.watchable_id
 json.watchable_type watch.watchable_type
 json.user watch.user
-json.edit_user matched_document(watch.watchable).user
+json.edit_user created_user(matched_document(watch.watchable))
 json.created_at matched_document(watch.watchable).created_at
 json.updated_at matched_document(watch.watchable).updated_at
 json.url searchable_url(watch.watchable)

--- a/test/fixtures/watches.yml
+++ b/test/fixtures/watches.yml
@@ -21,3 +21,11 @@ event<%= i %>_watch_kimura:
    user: kimura
    watchable: event<%= i %> (Event)
 <% end %>
+   
+practice1_watch_mentormentaro:
+   user: mentormentaro
+   watchable: practice1 (Practice)
+
+page1_page_mentormentaro:
+   user: mentormentaro
+   watchable: page1 (Page)

--- a/test/system/current_user/watches_test.rb
+++ b/test/system/current_user/watches_test.rb
@@ -49,4 +49,16 @@ class CurrentUser::WatchesTest < ApplicationSystemTestCase
     visit report_path(report)
     assert_text 'Watch'
   end
+
+  test 'list watching practice and another' do
+    visit_with_auth '/current_user/watches', 'mentormentaro'
+
+    assert_text 'OS X Mountain Lionをクリーンインストールする'
+    assert_text 'description...'
+    assert_no_text 'mentormentaro'
+
+    assert_text 'test1'
+    assert_text 'testtest'
+    assert_text 'komagata'
+  end
 end


### PR DESCRIPTION
## 関連Issue

- #4538
- #5000
 
## 概要

### 課題
現状、メンターのみプラクティスをwatchすることができるが、watch対象にプラクティスが1個でも含まれている場合、watch一覧ページに何も(プラクティス以外も)表示されない状況。

また、watch対象は以下の通り。
　お知らせ
　プラクティス
　日報
　提出物
　Q&A
　Docs
　イベント 

### 原因
watch対象の作成者の情報を取得する処理において、watch対象に対して`user`メソッドを一律で呼んでいる。しかし、watch対象がプラクティスの場合は、プラクティスには`user`メソッドが定義されておらず、エラーが発生していることが原因。

### watch一覧ページのプラクティスの表示項目について
プラクティスの作成者の情報(ログイン名)はDB上に保存していないため、表示しなくてよい。

### 補足情報
対象(プラクティスを含む)をwatchする/watch解除の機能は、既に`watches.js`で実装済みであるため、本PRの対象外とする。

## 確認方法と確認内容
1. ブランチ`feature/show-watching-practice-in-watch-lists`をローカルに取り込む。
2. `bin/rails s`でローカル環境を立ち上げる。
3. メンターでログインする。
4. プラクティス詳細ページ(`/practices/:id`)にアクセスし、Watchボタンをクリックする。
5. プラクティス以外(何でもよい)のwatch詳細ページ(`/pages/:id`)にアクセスし、Watchボタンをクリックする。
6. Watch一覧ページ(`/current_user/watches`)にアクセスし、watchした対象(プラクティスとDocs)が表示されることを確認する。
7. watch対象がプラクティスの場合、プラクティスの作成者のログイン名は(存在しないため)表示されないことを確認する。

## 変更前
<img width="1021" alt="Cursor_and__development__Watch中___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/175429320-543a1061-0ce6-4107-b17d-662499a94712.png">

## 変更後
<img width="1012" alt="Cursor_and__development__Watch中___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/175446488-d5047aaf-fa6d-4f49-9a89-b46ae554e503.png">
