### PR TITLE
ユーザーの最終ログインを最終活動日時に変更

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,7 +9,7 @@ class HomeController < ApplicationController
       else
         @announcements = Announcement.with_avatar.where(wip: false).order(published_at: :desc).limit(3)
         @completed_learnings = current_user.learnings.where(status: 3).includes(:practice).order(updated_at: :desc)
-        @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.includes(:company).order(updated_at: :desc)
+        @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.includes(:company).order(last_activity_at: :desc)
         @job_seeking_users = User.with_attached_avatar.job_seeking.includes(:reports, :products, :works, :course, :company)
         display_events_on_dashboard
         display_welcome_message_for_adviser

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -12,7 +12,6 @@ class UserSessionsController < ApplicationController
         logout
         redirect_to retire_path
       else
-        save_updated_at(@user)
         redirect_back_or_to root_url, notice: 'ログインしました。'
       end
     else
@@ -27,10 +26,7 @@ class UserSessionsController < ApplicationController
   end
 
   def destroy
-    if current_user
-      save_updated_at(current_user)
-      logout
-    end
+    logout if current_user
     redirect_to root_url, notice: 'ログアウトしました。'
   end
 
@@ -48,7 +44,6 @@ class UserSessionsController < ApplicationController
         redirect_to retire_path
       else
         session[:user_id] = user.id
-        save_updated_at(user)
         redirect_back_or_to root_url, notice: 'サインインしました。'
       end
     else
@@ -63,11 +58,4 @@ class UserSessionsController < ApplicationController
     redirect_to root_path
   end
   # rubocop:enable Metrics/MethodLength
-
-  private
-
-  def save_updated_at(user)
-    user.updated_at = Time.current
-    user.save(validate: false)
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   include Searchable
 
   authenticates_with_sorcery!
-  VALID_SORT_COLUMNS = %w[id login_name company_id updated_at created_at report comment asc desc].freeze
+  VALID_SORT_COLUMNS = %w[id login_name company_id last_activity_at created_at report comment asc desc].freeze
   AVATAR_SIZE = '88x88>'
   RESERVED_LOGIN_NAMES = %w[adviser all graduate inactive job_seeking mentor retired student student_and_trainee trainee year_end_party].freeze
   MAX_PERCENTAGE = 100

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -249,7 +249,7 @@ class User < ApplicationRecord
   }
   scope :inactive_students_and_trainees, lambda {
     where(
-      updated_at: Date.new..1.month.ago,
+      last_activity_at: Date.new..1.month.ago,
       admin: false,
       mentor: false,
       adviser: false,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -238,10 +238,10 @@ class User < ApplicationRecord
       graduated_on: nil
     )
   }
-  scope :active, -> { where(updated_at: 1.month.ago..Float::INFINITY) }
+  scope :active, -> { where(last_activity_at: 1.month.ago..Float::INFINITY) }
   scope :inactive, lambda {
     where(
-      updated_at: Date.new..1.month.ago,
+      last_activity_at: Date.new..1.month.ago,
       adviser: false,
       retired_on: nil,
       graduated_on: nil
@@ -264,7 +264,7 @@ class User < ApplicationRecord
       adviser: false,
       graduated_on: nil,
       retired_on: nil
-    ).order(updated_at: :desc)
+    ).order(last_activity_at: :desc)
   }
   scope :admins, -> { where(admin: true) }
   scope :trainees, -> { where(trainee: true) }
@@ -300,7 +300,7 @@ class User < ApplicationRecord
   scope :desc_tagged_with, lambda { |tag_name|
     with_attached_avatar
       .unretired
-      .order(updated_at: :desc)
+      .order(last_activity_at: :desc)
       .tagged_with(tag_name)
   }
   scope :search_by_keywords_scope, -> { unretired }
@@ -362,7 +362,7 @@ class User < ApplicationRecord
       when 'adviser'
         advisers
       when 'inactive'
-        inactive.order(:updated_at)
+        inactive.order(:last_activity_at)
       when 'trainee'
         trainees
       else
@@ -398,7 +398,7 @@ class User < ApplicationRecord
   end
 
   def away?
-    updated_at <= 10.minutes.ago
+    last_activity_at <= 10.minutes.ago
   end
 
   def completed_percentage
@@ -423,7 +423,7 @@ class User < ApplicationRecord
   end
 
   def active?
-    updated_at > 1.month.ago
+    last_activity_at > 1.month.ago
   end
 
   def checked_product_of?(*practices)

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -13,8 +13,9 @@
           = render 'sort_column', order_by: 'company_id', direction: direction, target: @target
         th.admin-table__label Discord
         th.admin-table__label
-          | 最終アクセス
-          = render 'sort_column', order_by: 'updated_at', direction: direction, target: @target
+          |
+          = User.human_attribute_name :last_activity_at
+          = render 'sort_column', order_by: 'last_activity_at', direction: direction, target: @target
         th.admin-table__label
           | 登録日時
           = render 'sort_column', order_by: 'created_at', direction: direction, target: @target
@@ -69,7 +70,7 @@
           td.admin-table__item-value.is-text-align-center
             = user.discord_account.presence || '-'
           td.admin-table__item-value.is-text-align-center
-            = l user.updated_at
+            = l user.last_activity_at
           td.admin-table__item-value.is-text-align-center
             = l user.created_at
           td.admin-table__item-value.is-text-align-center

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -20,6 +20,6 @@
                 .card-list-item-meta
                   time.a-meta
                     span.a-meta__label
-                      = User.human_attribute_name :updated_at
+                      = User.human_attribute_name :last_activity_at
                     span.a-meta__value
-                      = l user.updated_at
+                      = l user.last_activity_at

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -51,9 +51,10 @@
           | 回答なし
     .user-metas__item
       .user-metas__item-label
-        | 最終ログイン
+        |
+        = User.human_attribute_name :last_activity_at
       .user-metas__item-value
-        = l user.updated_at
+        = l user.last_activity_at
     .user-metas__item
       .user-metas__item-label
         | 卒業後のゴール

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -52,7 +52,7 @@ Rails.application.config.sorcery.configure do |config|
   # will register the time of last user login, every login.
   # Default: `true`
   #
-  # config.register_login_time =
+  config.register_login_time = false
 
   # will register the time of last user logout, every logout.
   # Default: `true`

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -64,6 +64,11 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.register_last_activity_time =
 
+  # Will register the source ip address of last user login, every login.
+  # Default: `true`
+  #
+  config.register_last_ip_address = false
+
   # -- external --
   # What providers are supported by this app, i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack] .
   # Default: `[]`

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # The default is nothing which will include only core features (password encryption, login/logout).
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging, :external
-Rails.application.config.sorcery.submodules = [:remember_me, :reset_password, :jwt]
+Rails.application.config.sorcery.submodules = [:remember_me, :reset_password, :jwt, :activity_logging]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -57,7 +57,7 @@ Rails.application.config.sorcery.configure do |config|
   # will register the time of last user logout, every logout.
   # Default: `true`
   #
-  # config.register_logout_time =
+  config.register_logout_time = false
 
   # will register the time of last user action, every action.
   # Default: `true`

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -87,6 +87,7 @@ ja:
         github_collaborator: GitHubチーム
         tag_list: タグ
         training_ends_on: 研修終了日
+        last_activity_at: 最終活動日時
       course:
         title: タイトル
         description: 詳細

--- a/db/migrate/20220629154015_sorcery_activity_logging.rb
+++ b/db/migrate/20220629154015_sorcery_activity_logging.rb
@@ -1,0 +1,12 @@
+class SorceryActivityLogging < ActiveRecord::Migration[6.1]
+  class User < ActiveRecord::Base; end
+
+  def change
+    add_column :users, :last_activity_at,  :datetime
+
+    User.reset_column_information
+    User.find_each do |user|
+      user.update_columns(last_activity_at: user.updated_at)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_25_064850) do
+ActiveRecord::Schema.define(version: 2022_06_29_154015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -521,6 +521,7 @@ ActiveRecord::Schema.define(version: 2022_06_25_064850) do
     t.date "training_ends_on"
     t.boolean "sad_streak", default: false, null: false
     t.integer "last_sad_report_id"
+    t.datetime "last_activity_at"
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -26,6 +26,7 @@ komagata:
   last_sad_report_id: <%= ActiveRecord::FixtureSet.identify(:report28) %>
   updated_at: "2014-01-01 00:00:01"
   created_at: "2014-01-01 00:00:01"
+  last_activity_at: "2014-01-01 00:00:01"
 
 machida:
   login_name: machida
@@ -50,6 +51,7 @@ machida:
   unsubscribe_email_token: MnC-Dv3HrNLs7WmfE975qA
   updated_at: "2014-01-01 00:00:02"
   created_at: "2014-01-01 00:00:02"
+  last_activity_at: "2014-01-01 00:00:02"
 
 adminonly: # adminのroleだけを持ったユーザー
   login_name: adminonly
@@ -73,6 +75,7 @@ adminonly: # adminのroleだけを持ったユーザー
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-02-01 00:00:30"
   created_at: "2021-02-01 00:00:30"
+  last_activity_at: "2021-02-01 00:00:30"
 
 sotugyou_with_job:
   login_name: sotugyou-with-job
@@ -95,6 +98,7 @@ sotugyou_with_job:
   unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwj
   updated_at: "2014-01-01 00:00:03"
   created_at: "2014-01-01 00:00:03"
+  last_activity_at: "2014-01-01 00:00:03"
 
 sotugyou:
   login_name: sotugyou
@@ -117,6 +121,7 @@ sotugyou:
   last_sad_report_id: <%= ActiveRecord::FixtureSet.identify(:report27) %>
   updated_at: "2014-01-01 00:00:03"
   created_at: "2014-01-01 00:00:03"
+  last_activity_at: "2014-01-01 00:00:03"
 
 advijirou:
   login_name: advijirou
@@ -134,6 +139,7 @@ advijirou:
   unsubscribe_email_token: 6ULb9vj1AJzTH_mOsfR46Q
   updated_at: "2014-01-01 00:00:04"
   created_at: "2014-01-01 00:00:04"
+  last_activity_at: "2014-01-01 00:00:04"
 
 yameo:
   login_name: yameo
@@ -158,6 +164,7 @@ yameo:
   retire_reason: "内容が難しかった"
   updated_at: "2014-01-01 00:00:05"
   created_at: "2014-01-01 00:00:05"
+  last_activity_at: "2014-01-01 00:00:05"
 
 mentormentaro:
   login_name: mentormentaro
@@ -179,6 +186,7 @@ mentormentaro:
   unsubscribe_email_token: -PmtH0Rmh36FIPhbxzkMGA
   updated_at: "2014-01-01 00:00:06"
   created_at: "2014-01-01 00:00:06"
+  last_activity_at: "2014-01-01 00:00:06"
 
 kimura:
   login_name: kimura
@@ -201,6 +209,7 @@ kimura:
   unsubscribe_email_token: k6Da-oL3cRi8ApNFO9-Gcg
   updated_at: "2014-01-01 00:00:07"
   created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"
   mentor_memo: "kimuraさんのメモ"
 
 hatsuno:
@@ -226,6 +235,7 @@ hatsuno:
   unsubscribe_email_token: k3a49_NwgTsiJS0oHGU2Fw
   updated_at: "2014-01-01 00:00:08"
   created_at: "2014-01-01 00:00:08"
+  last_activity_at: "2014-01-01 00:00:08"
 
 hajime:
   login_name: hajime
@@ -247,6 +257,7 @@ hajime:
   unsubscribe_email_token: iHzoJxKvrBeGGT6DjAJgJQ
   updated_at: "2014-01-01 00:00:09"
   created_at: "2014-01-01 00:00:09"
+  last_activity_at: "2014-01-01 00:00:09"
 
 muryou:
   login_name: muryou
@@ -270,6 +281,7 @@ muryou:
   unsubscribe_email_token: V8qOxq82MrYh6P_jwx9CQQ
   updated_at: "2014-01-01 00:00:10"
   created_at: "2014-01-01 00:00:10"
+  last_activity_at: "2014-01-01 00:00:10"
 
 kensyu:
   login_name: kensyu
@@ -297,6 +309,7 @@ kensyu:
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
+  last_activity_at: "2014-01-01 00:00:11"
 
 senpai:
   login_name: senpai
@@ -321,6 +334,7 @@ senpai:
   unsubscribe_email_token: E8ycg7ahXNYj5bPA9Ic7aw
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
+  last_activity_at: "2014-01-01 00:00:12"
 
 kananashi: #name_kanaを持たないユーザー
   login_name: kananashi
@@ -342,6 +356,7 @@ kananashi: #name_kanaを持たないユーザー
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
+  last_activity_at: "2014-01-01 00:00:12"
 
 osnashi: #osを持たないユーザー
   login_name: osnashi
@@ -363,6 +378,7 @@ osnashi: #osを持たないユーザー
   unsubscribe_email_token: JgunX7Zejd-r1Vhqev401w
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
+  last_activity_at: "2014-01-01 00:00:12"
 
 discordinvalid: #Discord IDが不正なユーザー
   login_name: discordinvalid
@@ -384,6 +400,7 @@ discordinvalid: #Discord IDが不正なユーザー
   unsubscribe_email_token: JgunX7Zejd-r1Vhqev401w
   updated_at: "2014-01-01 00:00:12"
   created_at: "2014-01-01 00:00:12"
+  last_activity_at: "2014-01-01 00:00:12"
 
 twitterinvalid: #Twitter IDが不正なユーザー
   login_name: twitterinvalid
@@ -405,6 +422,7 @@ twitterinvalid: #Twitter IDが不正なユーザー
   unsubscribe_email_token: JgunX7Zejd-r1Vhqev401w
   updated_at: "2020-01-01 00:00:12"
   created_at: "2020-01-01 00:00:12"
+  last_activity_at: "2020-01-01 00:00:12"
 
 jobseeker: #就活希望するユーザー
   login_name: jobseeker
@@ -427,6 +445,7 @@ jobseeker: #就活希望するユーザー
   unsubscribe_email_token: Z2tKHxSjj7FreyqQ95Yd9g
   updated_at: "2020-01-01 00:00:12"
   created_at: "2020-01-01 00:00:12"
+  last_activity_at: "2020-01-01 00:00:12"
 
 nippounashi: # 日報を投稿していないユーザー
   login_name: nippounashi
@@ -448,6 +467,7 @@ nippounashi: # 日報を投稿していないユーザー
   unsubscribe_email_token: QV8qOjwxrYxqh6P_Q9C82M
   updated_at: "2014-01-01 00:00:10"
   created_at: "2014-01-01 00:00:10"
+  last_activity_at: "2014-01-01 00:00:10"
 
 with_hyphen:
   login_name: &login_name with-hyphen
@@ -469,6 +489,7 @@ with_hyphen:
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-01-01 00:00:17"
   created_at: "2021-01-01 00:00:17"
+  last_activity_at: "2021-01-01 00:00:17"
 
 kensyuowata: # 研修が終わったユーザー
   login_name: kensyuowata
@@ -496,6 +517,7 @@ kensyuowata: # 研修が終わったユーザー
   unsubscribe_email_token: Vb3zzFj5oO4zcwOURn14qW
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
+  last_activity_at: "2014-01-01 00:00:11"
 
 taikai: # 退会直後のユーザー
   login_name: taikai
@@ -519,6 +541,7 @@ taikai: # 退会直後のユーザー
   unsubscribe_email_token: Vb3zzFj5oO4zcwOURn14qW
   updated_at: "2021-12-10 00:00:11"
   created_at: "2021-12-10 00:00:11"
+  last_activity_at: "2021-12-10 00:00:11"
 
 taikai3: # 退会3ヶ月後のユーザー
   login_name: taikai3
@@ -543,6 +566,7 @@ taikai3: # 退会3ヶ月後のユーザー
   unsubscribe_email_token: Vb3zzFj5oO4zcwOURn14qW
   updated_at: "2021-12-10 00:00:11"
   created_at: "2021-12-10 00:00:11"
+  last_activity_at: "2021-12-10 00:00:11"
 
 otameshi:
   login_name: otameshi
@@ -564,6 +588,7 @@ otameshi:
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: <%= Time.current %>
   created_at: <%= Time.current %>
+  last_activity_at: <%= Time.current %>
 
 enchomaemae:
   login_name: enchomaemae
@@ -585,6 +610,7 @@ enchomaemae:
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-03-25 00:00:00"
   created_at: "2021-03-25 00:00:00"
+  last_activity_at: "2021-03-25 00:00:00"
 
 enchomaeyo:
   login_name: enchomaeyo
@@ -606,6 +632,7 @@ enchomaeyo:
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-08-19 23:59:59"
   created_at: "2021-08-19 23:59:59"
+  last_activity_at: "2021-08-19 23:59:59"
 
 enchohayashi:
   login_name: enchohayashi
@@ -627,6 +654,7 @@ enchohayashi:
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-08-20 00:00:00"
   created_at: "2021-08-20 00:00:00"
+  last_activity_at: "2021-08-20 00:00:00"
 
 enchoososhi:
   login_name: enchoososhi
@@ -648,6 +676,7 @@ enchoososhi:
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-08-31 23:59:00"
   created_at: "2021-08-31 23:59:00"
+  last_activity_at: "2021-08-31 23:59:00"
 
 enchoowata:
   login_name: enchoowata
@@ -669,6 +698,7 @@ enchoowata:
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-09-01 00:00:00"
   created_at: "2021-09-01 00:00:00"
+  last_activity_at: "2021-09-01 00:00:00"
 
 kimuramitai:
   login_name: kimuramitai
@@ -692,6 +722,7 @@ kimuramitai:
   unsubscribe_email_token: k6Da-oL3cRi8ApNFO9-Gcg
   updated_at: "2022-03-28 00:00:01"
   created_at: "2022-03-28 00:00:01"
+  last_activity_at: "2022-03-28 00:00:01"
 
 long-id-mentor:
   login_name: long-id-mentor
@@ -713,6 +744,7 @@ long-id-mentor:
   mentor: true
   updated_at: "2022-04-15 00:00:01"
   created_at: "2022-04-15 00:00:01"
+  last_activity_at: "2022-04-15 00:00:01"
 
 nocompanykensyu: # 所属企業のない研修生
   login_name: nocompanykensyu
@@ -736,3 +768,4 @@ nocompanykensyu: # 所属企業のない研修生
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
+  last_activity_at: "2014-01-01 00:00:11"

--- a/test/system/notification/graduation_test.rb
+++ b/test/system/notification/graduation_test.rb
@@ -13,9 +13,9 @@ class Notification::GraduationTest < ApplicationSystemTestCase
   end
 
   test 'notify mentor when student graduate' do
-    users(:kimura).update!(updated_at: Time.current)
+    users(:kimura).update!(last_activity_at: Time.current)
     # kimura が一番上に表示されるようにソート
-    path = 'admin/users?direction=desc&order_by=updated_at&target=student_and_trainee'
+    path = 'admin/users?direction=desc&order_by=last_activity_at&target=student_and_trainee'
     visit_with_auth path, 'komagata'
 
     accept_confirm do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -77,16 +77,25 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_text 'Terminalの基礎を覚える'
   end
 
-  test 'show last active date only to mentors' do
+  test 'show last active date and time of access user only to mentors' do
     travel_to Time.zone.local(2014, 1, 1, 0, 0, 0) do
-      visit_with_auth '/', 'kimura'
+      visit_with_auth login_path, 'kimura'
+    end
+
+    travel_to Time.zone.local(2014, 1, 1, 1, 0, 0) do
+      visit login_path
+    end
+
+    travel_to Time.zone.local(2014, 1, 1, 2, 0, 0) do
+      visit logout_path
     end
 
     visit_with_auth "/users/#{users(:kimura).id}", 'komagata'
-    assert_text '最終ログイン'
+    assert_text '最終活動日時'
+    assert_text '2014年01月01日(水) 01:00'
 
     visit_with_auth "/users/#{users(:kimura).id}", 'hatsuno'
-    assert_no_text '最終ログイン'
+    assert_no_text '最終活動日時'
   end
 
   test 'show inactive message on users page' do
@@ -104,13 +113,15 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test 'show inactive users only to mentors' do
-    User.inactive_students_and_trainees.each(&:touch)
+    User.inactive_students_and_trainees.each do |user|
+      user.update_columns(last_activity_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    end
 
     visit_with_auth '/', 'komagata'
     assert_no_text '1ヶ月以上ログインのないユーザー'
 
     users(:kimura).update!(
-      updated_at: Time.zone.local(2020, 1, 1, 0, 0, 0)
+      last_activity_at: Time.zone.local(2020, 1, 1, 0, 0, 0)
     )
 
     visit_with_auth '/', 'komagata'


### PR DESCRIPTION
## 関連Issue

- #2231
 
## 概要

usersテーブルの`最終活動日時`のカラム(`last_activity_at`)を新規追加し、既存の`最終ログイン`のカラム(`updated_at`)が使用されている箇所と置き換える。(また`last_activity_at`カラムの初期値は、`updated_at`カラムの値をセットする)

`最終活動日時`の定義としては、ログインしてからログアウトするまでの間において最後にアクセス(HTTPリクエスト)した日時とする。
(ただし、ログインの日時は含むが、ログアウトの日時は含まないことする)

これを実現するために、SorceryのサブモジュールであるActivity Loggingを利用し、そのうちの1つである、最後の活動日時(ログインの日時は含むが、ログアウトの日時は含まない)を記録する機能のみを使用することにした。(それ以外の機能は今回の要件には必要無いため、configで無効化している)
Activity Loggingについては、以下が参考になると思う。
- [Activity logging · Sorcery/sorcery Wiki](https://github.com/Sorcery/sorcery/wiki/Activity-logging)
- [sorcery/activity\_logging\.rb at master · Sorcery/sorcery](https://github.com/Sorcery/sorcery/blob/master/lib/sorcery/controller/submodules/activity_logging.rb)
- [sorcery/activity\_logging\.rb at master · Sorcery/sorcery](https://github.com/Sorcery/sorcery/blob/master/lib/sorcery/model/submodules/activity_logging.rb)

### 補足情報
`最終ログイン`の日時についてのまとめ

項目 | 変更前 | 変更後 | 変更後
-- | -- | -- | -- 
usersテーブルのカラム名 | `updated_at` | `last_activity_at` | `updated_at`
カラムの更新タイミング | ログイン時 or ログアウト時 | ログイン時 or HTTPリクエスト時 | ログイン時やログアウト時に更新しない
画面での表示名 | `最終ログイン` or `最終アクセス` | `最終活動日時` | 表示項目でどこにも使用していない


## 環境準備
1. ブランチ`feature/change-last-login-to-last-activity`をローカルに取り込む。
2. `bin/rails db:migrate`でDBを更新する。
3. `bin/rails s`でローカル環境を立ち上げる。
4. 任意の受講生でログインし、適当なリソースにアクセスする度に、`最終活動日時`が更新される。

## 確認方法と確認内容

既存の`最終ログイン`のカラム(`updated_at`)が使用されている箇所は、以下の画面で表示されている。

1. ユーザー非公開情報の「最終ログイン」
    - ユーザー詳細ページ(`/users/:id`)　※管理者orメンターのみ
    - 日報詳細ページ(`/reports/:id`)のユーザーメモ　※管理者orメンターのみ
    - 提出物詳細ページ(`/products/:id`)のユーザーメモ　※管理者orメンターのみ
    - 相談部屋詳細ページ(`/talks/:id`)のユーザーメモ　※管理者のみ
2. 管理ページ(`/admin/users`)のユーザーの「最終アクセス」カラム　※管理者のみ
3. ダッシュボード(`/`)の1ヶ月以上ログインのないユーザーの「最終ログイン」　※メンターのみ

そのため、上記の画面を確認することになるが、1. ユーザー非公開情報については、同一のViewファイル(`_user_secret_attributes.html.slim`)であるため、どれか1つをピックアップして確認する方針とする。

ここで以下の通り、確認方法と確認内容を纏める。

項番 | ログインユーザー | アクセス先 | 行うこと | 変更前 | 変更後
-- | -- | -- | -- | -- | --
1 | メンター | ユーザー詳細ページ(`/users/:id`) | ユーザー非公開情報を確認 | 「最終ログイン」がユーザーのログインorログアウト日時 | 「最終活動日時」がユーザーが最後にアクセスした日時 |
2 | 管理者 | 管理ページ(`/admin/users`) | ユーザータブをクリックし、「最終アクセス」カラムを確認 | 「最終アクセス」がユーザーのログインorログアウト日時 | 「最終活動日時」がユーザーが最後にアクセスした日時 |
3 | メンター | ダッシュボード(`/`) | 1ヶ月以上ログインのないユーザーを確認 | 「最終ログイン」ががユーザーのログインorログアウト日時 | 「最終活動日時」がユーザーが最後にアクセスした日時 |

### 項番1【ユーザー詳細ページ(`/users/:id`)】
#### 変更前
<img width="640" alt="Cursor_and__development__marumarushain10___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/176851944-1241ec5d-808f-4393-b68a-29abe0d3a71d.png">

#### 変更後(marumarushain10さんでログインし、2022/7/1(金) 17:06に適当なリソースにアクセスした後)
<img width="638" alt="Cursor_and__development__marumarushain10___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/176852889-183594ab-4230-4762-a774-1b0baacaa644.png">

### 項番2【管理ページ(`/admin/users`)】
#### 変更前
<img width="842" alt="Cursor_and__development__管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/176852141-11ce1340-2821-4bfb-a16b-89a4b458de22.png">

#### 変更後(marumarushain10さんでログインし、2022/7/1(金) 17:06に適当なリソースにアクセスした後)
<img width="840" alt="Cursor_and__development__管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/176853232-022ecbce-a4f8-468c-af92-7a3d455102e6.png">

### 項番3【ダッシュボード(`/`)】
#### 変更前
<img width="641" alt="Cursor_and__development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/176852430-2fec1cb9-0d89-4605-874c-610dc0358cbe.png">

#### 変更後(marumarushain10さんでログインし、2022/7/1(金) 17:06に適当なリソースにアクセスした後)
<img width="645" alt="Cursor_and__development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/176855951-4c4d194c-cdf2-4c50-9885-c64756b91943.png">

