### PR TITLE
定期イベントにWatch機能、参加機能を追加

### DIFF
--- a/app/assets/stylesheets/application/blocks/page-content/_page-content-header.sass
+++ b/app/assets/stylesheets/application/blocks/page-content/_page-content-header.sass
@@ -35,6 +35,35 @@
     display: flex
     justify-content: center
 
+.page-content-header__category
+  +media-breakpoint-down(sm)
+    display: flex
+    justify-content: center
+
+.page-content-header__category-icon
+  +size(3.5rem)
+  border-radius: 50%
+  display: flex
+  align-items: center
+  justify-content: center
+  +text-block(.875rem 1, 600)
+  // regular_events
+  &.is-meeting
+    background-color: #7f6fb7
+    color: $reversal-text
+  &.is-reading-circle
+    background-color: #79bcc3
+    color: $reversal-text
+  &.is-question
+    background-color: #de9172
+    color: $reversal-text
+  &.is-chat
+    background-color: #9fc593
+    color: $reversal-text
+  &.is-others
+    background-color: #f7cd5b
+    color: $default-text
+
 .page-content-header__user-link
   +block-link
 

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class RegularEvents::ParticipationsController < ApplicationController
+  before_action :set_regular_event
+
+  def create
+    @regular_event.regular_event_participations.create(user: current_user)
+    create_watch
+    redirect_to regular_event_path(@regular_event), notice: '参加登録しました。'
+  end
+
+  def destroy
+    @regular_event.cancel_participation(current_user)
+    redirect_to regular_event_path(@regular_event), notice: '参加を取り消しました。'
+  end
+
+  private
+
+  def set_regular_event
+    @regular_event = RegularEvent.find(params[:regular_event_id])
+  end
+
+  def create_watch
+    watch = Watch.new(
+      user: current_user,
+      watchable: @regular_event
+    )
+    watch.save!
+  end
+end

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -21,6 +21,8 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def create_watch
+    return if @regular_event.watched?(current_user)
+
     watch = Watch.new(
       user: current_user,
       watchable: @regular_event

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -25,6 +25,7 @@ class RegularEventsController < ApplicationController
     @regular_event.user = current_user
     set_wip
     if @regular_event.save
+      Newspaper.publish(:event_create, @regular_event)
       redirect_to @regular_event, notice: notice_message(@regular_event)
     else
       render :new

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -85,7 +85,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def watching_notification
     @sender = @watchable.user
     @user = @receiver
-    link = "/#{@watchable.class.name.downcase.pluralize}/#{@watchable.id}"
+    link = "/#{@watchable.class.name.underscore.pluralize}/#{@watchable.id}"
     @notification = @user.notifications.find_by(link: link)
     action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
     subject = "[FBC] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんが#{action}しました。"

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -23,6 +23,8 @@ module Watchable
       "「#{self[:title]}」のQ&A"
     when Event
       "「#{self[:title]}」のイベント"
+    when RegularEvent
+      "「#{self[:title]}」の定期イベント"
     when Page
       "「#{self[:title]}」のDocs"
     when Announcement
@@ -32,7 +34,7 @@ module Watchable
 
   def body
     case self
-    when Question, Event, Report, Announcement
+    when Question, Event, RegularEvent, Report, Announcement
       self[:description]
     else
       self[:body]

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -25,6 +25,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include Commentable
   include Footprintable
   include Reactionable
+  include Watchable
 
   enum category: {
     reading_circle: 0,
@@ -55,6 +56,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :users, through: :organizers
   has_many :regular_event_repeat_rules, dependent: :destroy
   accepts_nested_attributes_for :regular_event_repeat_rules, allow_destroy: true
+  has_many :watches, as: :watchable, dependent: :destroy
 
   def organizers
     users.with_attached_avatar.order('organizers.created_at')

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -56,6 +56,10 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :users, through: :organizers
   has_many :regular_event_repeat_rules, dependent: :destroy
   accepts_nested_attributes_for :regular_event_repeat_rules, allow_destroy: true
+  has_many :regular_event_participations, dependent: :destroy
+  has_many :participations,
+           through: :regular_event_participations,
+           source: :user
   has_many :watches, as: :watchable, dependent: :destroy
 
   def organizers
@@ -119,6 +123,11 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
         repeat_rule.day_of_the_week == tomorrow.wday && repeat_rule.frequency == convert_date_into_week(tomorrow.day)
       end
     end.include?(true)
+  end
+
+  def cancel_participation(user)
+    regular_event_participation = regular_event_participations.find_by(user_id: user.id)
+    regular_event_participation.destroy
   end
 
   class << self

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -57,7 +57,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :regular_event_repeat_rules, dependent: :destroy
   accepts_nested_attributes_for :regular_event_repeat_rules, allow_destroy: true
   has_many :regular_event_participations, dependent: :destroy
-  has_many :participations,
+  has_many :participants,
            through: :regular_event_participations,
            source: :user
   has_many :watches, as: :watchable, dependent: :destroy
@@ -128,6 +128,10 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def cancel_participation(user)
     regular_event_participation = regular_event_participations.find_by(user_id: user.id)
     regular_event_participation.destroy
+  end
+
+  def watched?(user)
+    watches.exists?(user_id: user.id)
   end
 
   class << self

--- a/app/models/regular_event_participation.rb
+++ b/app/models/regular_event_participation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RegularEventParticipation < ApplicationRecord
   belongs_to :user
   belongs_to :regular_event

--- a/app/models/regular_event_participation.rb
+++ b/app/models/regular_event_participation.rb
@@ -1,0 +1,6 @@
+class RegularEventParticipation < ApplicationRecord
+  belongs_to :user
+  belongs_to :regular_event
+
+  validates :user_id, uniqueness: { scope: :regular_event_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,7 @@ class User < ApplicationRecord
   has_many :notifications, dependent: :destroy
   has_many :events, dependent: :destroy
   has_many :participations, dependent: :destroy
+  has_many :regular_event_participations, dependent: :destroy
   has_many :answers, dependent: :destroy
   has_many :watches, dependent: :destroy
   has_many :articles, dependent: :destroy
@@ -124,6 +125,10 @@ class User < ApplicationRecord
 
   has_many :organize_regular_events,
            through: :organizers,
+           source: :regular_event
+
+  has_many :participate_regular_events,
+           through: :regular_event_participations,
            source: :regular_event
 
   has_one_attached :avatar
@@ -554,7 +559,8 @@ class User < ApplicationRecord
   end
 
   def participating?(event)
-    participate_events.include?(event)
+    method_name = "participate_#{event.class.name.underscore.pluralize}"
+    send(method_name).include?(event)
   end
 
   def register_github_account(id, account_name)

--- a/app/views/regular_events/_participation.html.slim
+++ b/app/views/regular_events/_participation.html.slim
@@ -1,0 +1,15 @@
+- if current_user.participating?(regular_event)
+  .event-main-actions.is-participationed
+    .event-main-actions__description
+      p
+        | 参加登録しています。
+    ul.event-main-actions__items
+      li.event-main-actions__item
+        = link_to regular_event_participation_path(regular_event_id: regular_event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+          | 参加を取り消す
+- else
+  .event-main-actions.is-unparticipationed.is-available
+    ul.event-main-actions__items
+      li.event-main-actions__item
+        = link_to regular_event_participations_path(regular_event_id: regular_event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-md is-block' do
+          | 参加申込

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -2,7 +2,7 @@
   header.page-content-header
     .page-content-header__start
       .page-content-header__category
-        .page-content-header__category-icon(class="is-#{regular_event.category.gsub('_', '-')}")
+        .page-content-header__category-icon(class="is-#{regular_event.category.tr('_', '-')}")
           = t("activerecord.enums.regular_event.category.#{regular_event.category}")
     .page-content-header__end
       .page-content-header__row

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -61,3 +61,23 @@
             li.card-main-actions__item.is-sub
               = link_to regular_event_path(regular_event), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                 | 削除する
+
+  - unless regular_event.wip?
+    .a-card.participants
+      header.card-header.is-sm
+        h2.card-header__title
+          | 参加者（#{regular_event.participants.count}名）
+      .card-body
+        .card__description
+          - if regular_event.participants.present?
+            ul.user-icons__items
+              - regular_event.participants.each do |participant|
+                li.user-icons-item
+                  = link_to participant do
+                    = image_tag participant.avatar_url, title: participant.icon_title, class: "a-user-icon is-sm is-#{participant.login_name} is-#{participant.primary_role}", alt: participant.login_name
+          - else
+            .o-empty-message
+              .o-empty-message__icon
+                i.fa-regular.fa-sad-tear
+              p.o-empty-message__text
+                | 参加者はまだいません。

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -1,5 +1,9 @@
 .page-content
   header.page-content-header
+    .page-content-header__start
+      .page-content-header__category
+        .page-content-header__category-icon(class="is-#{regular_event.category.gsub('_', '-')}")
+          = t("activerecord.enums.regular_event.category.#{regular_event.category}")
     .page-content-header__end
       .page-content-header__row
         h1.page-content-header__title(class="#{regular_event.wip? ? 'is-wip' : ''}")

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -30,6 +30,8 @@
       .page-content-header__row
         .page-content-header-actions
           .page-content-header-actions__start
+            .page-content-header-actions__action
+              #js-watch-toggle(data-watchable-id="#{@regular_event.id}", data-watchable-type='RegularEvent')
           .page-content-header-actions__end
             .page-content-header-actions__action
               = link_to new_regular_event_path(id: regular_event), class: 'a-button is-sm is-secondary is-block', id: 'copy' do

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -47,6 +47,8 @@
     .card__description
       .a-long-text.is-md.js-markdown-view
         = regular_event.description
+    - unless regular_event.wip?
+      = render 'regular_events/participation', regular_event: regular_event
     = render 'reactions/reactions', reactionable: regular_event
     - if admin_or_mentor_login? || regular_event.user_id == current_user.id
       .card-footer

--- a/app/views/regular_events/_regular_event_meta.html.slim
+++ b/app/views/regular_events/_regular_event_meta.html.slim
@@ -12,19 +12,11 @@
                   = image_tag organizer.avatar_url, title: organizer.icon_title, class: "a-user-icon is-sm is-#{organizer.login_name} is-#{organizer.primary_role}", alt: organizer.login_name
       .event-meta__item
         dt.event-meta__item-label
-          | 定期開催日
+          | 開催日時
         dd.event-meta__item-value
           = regular_event.holding_cycles
-      .event-meta__item
-        dt.event-meta__item-label
-          | 開催時間
-        dd.event-meta__item-value
           | #{l regular_event.start_at, format: :time_only} 〜 #{l regular_event.end_at, format: :time_only}
-      .event-meta__item
-        dt.event-meta__item-label
-          | 祝日
-        dd.event-meta__item-value
-          | #{regular_event.hold_national_holiday ? '開催します' : '開催しません'}
+          | （祝日#{regular_event.hold_national_holiday ? 'も開催' : 'は休み'}）
       .event-meta__item
         dt.event-meta__item-label
           | 次回開催日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,9 @@ Rails.application.routes.draw do
   resources :events do
     resources :participations, only: %i(create destroy), controller: "events/participations"
   end
-  resources :regular_events
+  resources :regular_events do
+    resources :participations, only: %i(create destroy), controller: "regular_events/participations"
+  end
   resources :companies, only: %i(index show) do
     resources :users, only: %i(index), controller: "companies/users"
     resources :reports, only: %i(index), controller: "companies/reports"

--- a/db/migrate/20220620132907_create_regular_event_participations.rb
+++ b/db/migrate/20220620132907_create_regular_event_participations.rb
@@ -6,5 +6,6 @@ class CreateRegularEventParticipations < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
+    add_index :regular_event_participations, %i[user_id regular_event_id], unique: true, name: 'index_user_id_and_regular_event_id'
   end
 end

--- a/db/migrate/20220620132907_create_regular_event_participations.rb
+++ b/db/migrate/20220620132907_create_regular_event_participations.rb
@@ -1,0 +1,10 @@
+class CreateRegularEventParticipations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :regular_event_participations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :regular_event, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -416,6 +416,7 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["regular_event_id"], name: "index_regular_event_participations_on_regular_event_id"
+    t.index ["user_id", "regular_event_id"], name: "index_user_id_and_regular_event_id", unique: true
     t.index ["user_id"], name: "index_regular_event_participations_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -410,6 +410,15 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.index ["regular_event_id"], name: "index_regular_event_repeat_rules_on_regular_event_id"
   end
 
+  create_table "regular_event_participations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "regular_event_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["regular_event_id"], name: "index_regular_event_participations_on_regular_event_id"
+    t.index ["user_id"], name: "index_regular_event_participations_on_user_id"
+  end
+
   create_table "regular_events", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "title", null: false
@@ -591,6 +600,8 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
   add_foreign_key "questions", "practices"
   add_foreign_key "reactions", "users"
   add_foreign_key "regular_event_repeat_rules", "regular_events"
+  add_foreign_key "regular_event_participations", "regular_events"
+  add_foreign_key "regular_event_participations", "users"
   add_foreign_key "regular_events", "users"
   add_foreign_key "report_templates", "users"
   add_foreign_key "talks", "users"

--- a/test/fixtures/regular_event_participations.yml
+++ b/test/fixtures/regular_event_participations.yml
@@ -1,0 +1,3 @@
+regular_event_participation1:
+  user: hatsuno
+  regular_event: regular_event1

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -65,4 +65,14 @@ class RegularEventTest < ActiveSupport::TestCase
     regular_event.cancel_participation(participant)
     assert_not regular_event.regular_event_participations.find_by(user_id: participant.id)
   end
+
+  test '#watched' do
+    regular_event = regular_events(:regular_event1)
+    user = users(:kimura)
+    assert_not regular_event.watched?(user)
+
+    watch = Watch.new(user: user, watchable: regular_event)
+    watch.save
+    assert regular_event.watched?(user)
+  end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -63,6 +63,6 @@ class RegularEventTest < ActiveSupport::TestCase
     participant = regular_event_participations(:regular_event_participation1).user
 
     regular_event.cancel_participation(participant)
-    refute regular_event.regular_event_participations.find_by(user_id: participant.id)
+    assert_not regular_event.regular_event_participations.find_by(user_id: participant.id)
   end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -57,4 +57,12 @@ class RegularEventTest < ActiveSupport::TestCase
       assert_equal Date.new(2022, 6, 5), regular_event.next_specific_day_of_the_week(regular_event_repeat_rule)
     end
   end
+
+  test '#cancel_participation' do
+    regular_event = regular_events(:regular_event1)
+    participant = regular_event_participations(:regular_event_participation1).user
+
+    regular_event.cancel_participation(participant)
+    refute regular_event.regular_event_participations.find_by(user_id: participant.id)
+  end
 end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -116,7 +116,7 @@ class RegularEventsTest < ApplicationSystemTestCase
   test 'user can participate in an regular event' do
     regular_event = regular_events(:regular_event1)
     visit_with_auth regular_event_path(regular_event), 'kimura'
-    assert_difference 'regular_event.participations.count', 1 do
+    assert_difference 'regular_event.participants.count', 1 do
       accept_confirm do
         click_link '参加申込'
       end
@@ -127,7 +127,7 @@ class RegularEventsTest < ApplicationSystemTestCase
   test 'user can cancel regular event' do
     regular_event = regular_events(:regular_event1)
     visit_with_auth regular_event_path(regular_event), 'hatsuno'
-    assert_difference 'regular_event.participations.count', -1 do
+    assert_difference 'regular_event.participants.count', -1 do
       accept_confirm do
         click_link '参加を取り消す'
       end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -19,6 +19,7 @@ class RegularEventsTest < ApplicationSystemTestCase
       end
     end
     assert_text '定期イベントをWIPとして保存しました。'
+    assert_text 'Watch中'
   end
 
   test 'create regular event' do
@@ -38,6 +39,7 @@ class RegularEventsTest < ApplicationSystemTestCase
     end
     assert_text '定期イベントを作成しました。'
     assert_text '毎週月曜日'
+    assert_text 'Watch中'
   end
 
   test 'create copy regular event' do

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -106,4 +106,41 @@ class RegularEventsTest < ApplicationSystemTestCase
       assert_text 'その他'
     end
   end
+
+  test 'show participation link during opening' do
+    regular_event = regular_events(:regular_event1)
+    visit_with_auth regular_event_path(regular_event), 'kimura'
+    assert_link '参加申込'
+  end
+
+  test 'user can participate in an regular event' do
+    regular_event = regular_events(:regular_event1)
+    visit_with_auth regular_event_path(regular_event), 'kimura'
+    assert_difference 'regular_event.participations.count', 1 do
+      accept_confirm do
+        click_link '参加申込'
+      end
+      assert_text '参加登録しました。'
+    end
+  end
+
+  test 'user can cancel regular event' do
+    regular_event = regular_events(:regular_event1)
+    visit_with_auth regular_event_path(regular_event), 'hatsuno'
+    assert_difference 'regular_event.participations.count', -1 do
+      accept_confirm do
+        click_link '参加を取り消す'
+      end
+      assert_text '参加を取り消しました。'
+    end
+  end
+
+  test 'turn on the watch when attend an regular event' do
+    regular_event = regular_events(:regular_event1)
+    visit_with_auth regular_event_path(regular_event), 'kimura'
+    accept_confirm do
+      click_link '参加申込'
+    end
+    assert_text 'Watch中'
+  end
 end


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/4912
- https://github.com/fjordllc/bootcamp/issues/4913

## 概要・要件
定期イベントにWatch機能と参加機能を追加しました。
各定期イベントの詳細画面に「Watch」ボタンと「参加申込」ボタンを追加しました。

## 画面
### 参加前
<img width="843" alt="貼り付けた画像_2022_07_09_14_25" src="https://user-images.githubusercontent.com/47073105/178092933-8467eb0b-0bc3-4eee-be79-2ed9430c6ddd.png">

### 参加後
<img width="835" alt="貼り付けた画像_2022_07_09_14_27" src="https://user-images.githubusercontent.com/47073105/178092959-41db4892-2d2c-46f0-9ea3-9cef157356a1.png">


## 確認方法
1. ブランチ`feature/add-participation-and-watch-to-regular-events`をローカルに取り込む
1. bin/rails sでローカル環境を立ち上げる
1. ログインする
1. `http://localhost:3000/regular_events/`にアクセスし、新規の定期イベントを作成する
1. ログアウトする
1. 「3.」と別のユーザーでログインする
1. `http://localhost:3000/regular_events/`にアクセスし、「4.」で作成した定期イベントの詳細ページを開く
1. 「参加申込」ボタンをクリックし、確認メッセージで「OK」ボタンをクリックする
1. ログアウトする
1. 「3.」のユーザー（定期イベントを作成したユーザー）でログインする
1. `http://localhost:3000/regular_events/`にアクセスし、「4.」で作成した定期イベントの詳細ページを開く
1. [質問・連絡・コメント]に任意の文字を入力し、「コメントする」ボタンをクリックする
1. `http://localhost:3000/letter_opener/`を開き、「6.」のユーザー（参加申込したユーザー）にメール通知が送信されているか確認する

## 確認内容
- 定期イベント作成時、自動的に「Watch中」になる（上記手順4.で確認）
- 参加申込を行った際に、自動的に「Watch中」になる（上記手順8.で確認）
- 定期イベントにコメントした際、Watch中のユーザーにメール通知が送信される（上記手順11.〜13.で確認）