### PR TITLE
ダッシュボードに表示されるWIP（Docs、日報、Q＆A、提出物）の日付をデータと紐づいた表示に変更

### DIFF
--- a/app/views/users/pages/_wip_pages.html.slim
+++ b/app/views/users/pages/_wip_pages.html.slim
@@ -14,5 +14,5 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                time.a-meta datetime= page.updated_at
+                time.a-meta(datetime="#{page.updated_at}")
                   = l page.updated_at

--- a/app/views/users/pages/_wip_pages.html.slim
+++ b/app/views/users/pages/_wip_pages.html.slim
@@ -14,5 +14,5 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                time.a-meta datetime="2022-04-21T12:11:15.096+09:00" pubdate="pubdate"
-                  | 2022年04月21日(木) 12:11
+                time.a-meta datetime= page.updated_at
+                  = l page.updated_at

--- a/app/views/users/products/_wip_products.html.slim
+++ b/app/views/users/products/_wip_products.html.slim
@@ -14,4 +14,5 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                time.a-meta datetime="2022-04-14T16:56:00.492+09:00" pubdate="pubdate"  2022年04月14日(木) 16:56
+                time.a-meta datetime= product.updated_at
+                  = l product.updated_at

--- a/app/views/users/products/_wip_products.html.slim
+++ b/app/views/users/products/_wip_products.html.slim
@@ -14,5 +14,5 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                time.a-meta datetime= product.updated_at
+                time.a-meta(datetime="#{product.updated_at}")
                   = l product.updated_at

--- a/app/views/users/questions/_wip_questions.html.slim
+++ b/app/views/users/questions/_wip_questions.html.slim
@@ -14,5 +14,5 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                time.a-meta datetime= question.updated_at
+                time.a-meta(datetime="#{question.updated_at}")
                   = l question.updated_at

--- a/app/views/users/questions/_wip_questions.html.slim
+++ b/app/views/users/questions/_wip_questions.html.slim
@@ -14,4 +14,5 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                time.a-meta datetime="2022-04-26T14:28:24.481+09:00" pubdate="pubdate"  2022年04月26日(火) 14:28
+                time.a-meta datetime= question.updated_at
+                  = l question.updated_at

--- a/app/views/users/reports/_wip_reports.html.slim
+++ b/app/views/users/reports/_wip_reports.html.slim
@@ -14,4 +14,5 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                time.a-meta datetime="2022-04-26T15:52:56.864+09:00" pubdate="pubdate"  2022年04月26日(火) 15:52
+                time.a-meta datetime= report.updated_at
+                  = l report.updated_at

--- a/app/views/users/reports/_wip_reports.html.slim
+++ b/app/views/users/reports/_wip_reports.html.slim
@@ -14,5 +14,5 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                time.a-meta datetime= report.updated_at
+                time.a-meta(datetime="#{report.updated_at}")
                   = l report.updated_at

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -315,4 +315,36 @@ class HomeTest < ApplicationSystemTestCase
     assert_current_path '/?_login_name=machida'
     assert_no_text '最新のブックマーク'
   end
+
+  test "show my wip's page's date on dashboard" do
+    visit_with_auth '/', 'komagata'
+    assert_text 'WIPで保存中'
+    within '.card-list-item.is-page' do
+      assert_text I18n.l pages(:page5).updated_at
+    end
+  end
+
+  test "show my wip's report's date on dashboard" do
+    visit_with_auth '/', 'sotugyou'
+    assert_text 'WIPで保存中'
+    within '.card-list-item.is-report' do
+      assert_text I18n.l reports(:report9).updated_at
+    end
+  end
+
+  test "show my wip's question's date on dashboard" do
+    visit_with_auth '/', 'kimura'
+    assert_text 'WIPで保存中'
+    within '.card-list-item.is-question' do
+      assert_text I18n.l questions(:question_for_wip).updated_at
+    end
+  end
+
+  test "show my wip's product's date on dashboard" do
+    visit_with_auth '/', 'kimura'
+    assert_text 'WIPで保存中'
+    within '.card-list-item.is-product' do
+      assert_text I18n.l products(:product5).updated_at
+    end
+  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -333,6 +333,8 @@ class HomeTest < ApplicationSystemTestCase
   end
 
   test "show my wip's question's date on dashboard" do
+    Bookmark.destroy_all
+
     visit_with_auth '/', 'kimura'
     assert_text 'WIPで保存中'
     within '.card-list-item.is-question' do
@@ -341,6 +343,8 @@ class HomeTest < ApplicationSystemTestCase
   end
 
   test "show my wip's product's date on dashboard" do
+    Bookmark.destroy_all
+
     visit_with_auth '/', 'kimura'
     assert_text 'WIPで保存中'
     within '.card-list-item.is-product' do


### PR DESCRIPTION
## Issue

- #5060 

## 概要

ダッシュボードに表示されるWIP（Docs、日報、Q＆A、提出物）の日付が固定された日付の表示となっていたため、データと紐づいた表示に変更しました。

## 変更確認方法

1. ブランチ`bug/fix-date-of-wip-data-on-dashbord`をローカルに取り込みます。
2. `bin/rails s`でローカル環境を立ち上げます。
3. kimuraでログインします。
4. Q&AのWIPは初期データ投入で作成されていると思うので、残りのDocs( http://localhost:3000/pages/new )、日報( http://localhost:3000/reports/new )、提出物( http://localhost:3000/products/new?practice_id=363506445 )をWIPで作成します。
5. http://localhost:3000/ で「WIPで保存中」の一覧に表示されている、Docs、日報、Q＆A、提出物の日付が更新（作成）した日付になっている事を確認してください。

## 変更前

変更後の画像と同じデータを使用しているが日付がデータと紐づいていない。
<img width="654" alt="スクリーンショット 2022-06-27 23 26 41" src="https://user-images.githubusercontent.com/76685187/175965373-39525f31-6ac8-4a32-a22d-6ff41cf29bf8.png">


## 変更後

<img width="654" alt="スクリーンショット 2022-06-27 23 23 54" src="https://user-images.githubusercontent.com/76685187/175964646-6c20511e-4d61-44b5-8a5d-0838e75d8c9c.png">

