### PR TITLE
テスト環境でユーザーとアイコン画像が紐付けされるようにした

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -14,5 +14,7 @@ class Company < ApplicationRecord
     else
       image_url('/images/companies/logos/default.png')
     end
+  rescue ActiveStorage::FileNotFoundError
+    image_url('/images/companies/logos/default.png')
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,3 +45,4 @@ tables = %i[
 ]
 
 ActiveRecord::FixtureSet.create_fixtures 'db/fixtures', tables
+Bootcamp::Setup.attachment

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -1,3 +1,6 @@
+# Pull Request #4182(https://github.com/fjordllc/bootcamp/pull/4182) で Rails 7 への移行完了後、
+# ActiveStorage::FixtureSet.blob を使うように変更する
+
 # companies
 company1_logo:
   name: logo

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -1,6 +1,3 @@
-# Pull Request #4182(https://github.com/fjordllc/bootcamp/pull/4182) で Rails 7 への移行完了後、
-# ActiveStorage::FixtureSet.blob を使うように変更する
-
 # companies
 company1_logo:
   name: logo

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -1,0 +1,56 @@
+# companies
+company1_logo:
+  name: logo
+  record: company1 (Company)
+  blob: company1_logo_blob
+
+company2_logo:
+  name: logo
+  record: company2 (Company)
+  blob: company2_logo_blob
+
+company3_logo:
+  name: logo
+  record: company3 (Company)
+  blob: company3_logo_blob
+
+company4_logo:
+  name: logo
+  record: company4 (Company)
+  blob: company4_logo_blob
+
+# users
+hatsuno_avatar:
+  name: avatar
+  record: hatsuno (User)
+  blob: hatsuno_avatar_blob
+
+komagata_avatar:
+  name: avatar
+  record: komagata (User)
+  blob: komagata_avatar_blob
+
+machida_avatar:
+  name: avatar
+  record: machida (User)
+  blob: machida_avatar_blob
+
+mentormentaro_avatar:
+  name: avatar
+  record: mentormentaro (User)
+  blob: mentormentaro_avatar_blob
+
+mineo_avatar:
+  name: avatar
+  record: mineo (User)
+  blob: mineo_avatar_blob
+
+tanaka_avatar:
+  name: avatar
+  record: tanaka (User)
+  blob: tanaka_avatar_blob
+
+yameo_avatar:
+  name: avatar
+  record: yameo (User)
+  blob: yameo_avatar_blob

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,4 +1,6 @@
-# Pull Request #4182 Update rails 7.0.2.2 の完了後、ActiveStorage::FixtureSet.blob を使うように変更する
+# Pull Request #4182(https://github.com/fjordllc/bootcamp/pull/4182) で Rails 7 への移行完了後、
+# ActiveStorage::FixtureSet.blob を使うように変更する
+
 # companies
 company1_logo_blob: <%= ActiveStorage::Blob.fixture filename: "companies/logos/1.jpg" %>
 

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,0 +1,24 @@
+# Pull Request #4182 Update rails 7.0.2.2 の完了後、ActiveStorage::FixtureSet.blob を使うように変更する
+# companies
+company1_logo_blob: <%= ActiveStorage::Blob.fixture filename: "companies/logos/1.jpg" %>
+
+company2_logo_blob: <%= ActiveStorage::Blob.fixture filename: "companies/logos/2.jpg" %>
+
+company3_logo_blob: <%= ActiveStorage::Blob.fixture filename: "companies/logos/3.jpg" %>
+
+company4_logo_blob: <%= ActiveStorage::Blob.fixture filename: "companies/logos/4.jpg" %>
+
+# users
+hatsuno_avatar_blob: <%= ActiveStorage::Blob.fixture filename: "users/avatars/hatsuno.jpg" %>
+
+komagata_avatar_blob: <%= ActiveStorage::Blob.fixture filename: "users/avatars/komagata.jpg" %>
+
+machida_avatar_blob: <%= ActiveStorage::Blob.fixture filename: "users/avatars/machida.jpg" %>
+
+mentormentaro_avatar_blob: <%= ActiveStorage::Blob.fixture filename: "users/avatars/mentormentaro.jpg" %>
+
+mineo_avatar_blob: <%= ActiveStorage::Blob.fixture filename: "users/avatars/mineo.jpg" %>
+
+tanaka_avatar_blob: <%= ActiveStorage::Blob.fixture filename: "users/avatars/tanaka.jpg" %>
+
+yameo_avatar_blob: <%= ActiveStorage::Blob.fixture filename: "users/avatars/yameo.jpg" %>

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Pull Request #4182(https://github.com/fjordllc/bootcamp/pull/4182) で Rails 7 への移行完了後、
-# ActiveStorage::FixtureSet.blob を使うように変更する
-
+# Pull Request #4182(https://github.com/fjordllc/bootcamp/pull/4182) で Rails 7 への移行完了後に削除する
 require 'application_system_test_case'
 
 class AttachmentsTest < ApplicationSystemTestCase

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class AttachmentsTest < ApplicationSystemTestCase
+  test 'attachment user avatar' do
+    visit_with_auth "/users/#{users(:komagata).id}", 'komagata'
+    assert find('img.user-profile__user-icon-image')['src'].include?('komagata.png')
+    assert find('img.user-profile__company-logo')['src'].include?('1.png')
+  end
+end

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Pull Request #4182(https://github.com/fjordllc/bootcamp/pull/4182) で Rails 7 への移行完了後、
+# ActiveStorage::FixtureSet.blob を使うように変更する
+
 require 'application_system_test_case'
 
 class AttachmentsTest < ApplicationSystemTestCase

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -7,11 +7,5 @@ class AttachmentsTest < ApplicationSystemTestCase
   test 'attachment user avatar' do
     visit_with_auth "/users/#{users(:komagata).id}", 'komagata'
     assert find('img.user-profile__user-icon-image')['src'].include?('komagata.png')
-    assert find('img.user-profile__company-logo')['src'].include?('1.png')
-  end
-
-  test 'attachment company logo' do
-    visit_with_auth "/companies/#{companies(:company2).id}", 'kimura'
-    assert find('img.company-profile__logo-image')['src'].include?('2.png')
   end
 end

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -8,4 +8,9 @@ class AttachmentsTest < ApplicationSystemTestCase
     assert find('img.user-profile__user-icon-image')['src'].include?('komagata.png')
     assert find('img.user-profile__company-logo')['src'].include?('1.png')
   end
+
+  test 'attachment company logo' do
+    visit_with_auth "/companies/#{companies(:company2).id}", 'kimura'
+    assert find('img.company-profile__logo-image')['src'].include?('2.png')
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,7 +36,7 @@ ActiveSupport.on_load(:action_dispatch_system_test_case) do
 end
 
 # Rails 7 の ActiveStorage::FixtureSet.blob と同様の機能を実装
-# Pull Request #4182 「Update rails 7.0.2.2」の完了後に削除する
+# Pull Request #4182(https://github.com/fjordllc/bootcamp/pull/4182) でRails 7 への移行完了後に削除する
 # => test/fixtures/active_storage/blobs.yml でActiveStorage::FixtureSet.blob を使うように変更する
 module BlobFixtureSet
   def fixture(filename:, **attributes)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,3 +34,22 @@ end
 ActiveSupport.on_load(:action_dispatch_system_test_case) do
   ActionDispatch::SystemTesting::Server.silence_puma = true
 end
+
+# Rails 7 の ActiveStorage::FixtureSet.blob と同様の機能を実装
+# Pull Request #4182 「Update rails 7.0.2.2」の完了後に削除する
+# => test/fixtures/active_storage/blobs.yml でActiveStorage::FixtureSet.blob を使うように変更する
+module BlobFixtureSet
+  def fixture(filename:, **attributes)
+    blob = new(
+      filename: filename,
+      key: generate_unique_secure_token
+    )
+    io = Rails.root.join("test/fixtures/files/#{filename}").open
+    blob.unfurl(io)
+    blob.assign_attributes(attributes)
+    blob.upload_without_unfurling(io)
+
+    blob.attributes.transform_values { |values| values.is_a?(Hash) ? values.to_json : values }.compact.to_json
+  end
+end
+ActiveStorage::Blob.extend BlobFixtureSet


### PR DESCRIPTION
## Issue

- #4249

## 概要

テスト環境と開発環境でユーザーとアイコン画像が紐付けされるようにした
参考issue:https://github.com/fjordllc/bootcamp/issues/4305

## 変更確認方法
### 準備
ブランチ`bug/link-userdata-and-images-in-test-environment`をローカルに取り込む
### 開発環境での確認
1. `rails db:reset`でDBの再生成をする。
1. `bin/setup`でDBに初期データを投入する。
1. `rails s`でサーバーを起動する。
1. 任意のユーザーでログインする。
1. ユーザー>ユーザー一覧でユーザーとアイコン画像が紐付けされているか確認する。
### 変更前
<img width="1096" alt="スクリーンショット 2022-07-04 21 15 47" src="https://user-images.githubusercontent.com/96340764/177153543-8f1a4014-e5dd-4ae8-aa04-161acea30513.png">

### 変更後
<img width="1097" alt="スクリーンショット 2022-07-04 21 17 15" src="https://user-images.githubusercontent.com/96340764/177153552-ed82cd56-40cf-4bb6-982f-7c44b35caee0.png">

### テスト環境での確認

1.  コマンドラインで`HEADED=1 rails test test/system/attachments_test.rb`を実行し、ブラウザでのシステムテストを起動する。
1. ユーザーアイコンが画像データと紐づいていることを確認する。
ウィンドウが閉じるのが早くて確認しにくい場合は、`test/system/attachments_test.rb`にあるテストメソッドの`visit_with_auth〜`の次の行に`sleep 10`などを挟む。
### 変更前

<img width="1393" alt="スクリーンショット 2022-06-28 23 48 36" src="https://user-images.githubusercontent.com/96340764/176213049-18c9f527-8a5a-4b04-96ac-7374a66c05c7.png">

### 変更後

<img width="1395" alt="スクリーンショット 2022-06-28 22 33 39" src="https://user-images.githubusercontent.com/96340764/176213110-aaf9aa49-69a6-4a8e-900e-6addeef55368.png">

