### PR TITLE
呼ばれなくなったメソッドを削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -382,15 +382,6 @@ class User < ApplicationRecord
       ).pluck(:last_sad_report_id)
       Report.joins(:user).where(id: ids).order(reported_on: :desc)
     end
-
-    private
-
-    def reports_by_user(ids)
-      Report.where(user_id: ids)
-            .preload([:comments, { user: [:company, { avatar_attachment: :blob }] }, { checks: { user: { avatar_attachment: :blob } } }])
-            .order(reported_on: :desc)
-            .group_by(&:user_id)
-    end
   end
 
   def retired_three_months_ago_and_notification_not_sent?


### PR DESCRIPTION
#5085 の対応時に呼ばれなくなったメソッドを削除しました。
元々は`User.depressed_reports`メソッドからのみ呼ばれるメソッドでしたが、中身が変更になったため。