### PR TITLE
未解決の質問一覧のページ見出しとtitleタグを変更した

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -85,7 +85,7 @@ class QuestionsController < ApplicationController
     when 'solved'
       QuestionsProperty.new('解決済みの質問一覧', '解決済みの質問はありません。')
     when 'not_solved'
-      QuestionsProperty.new('未解決の質問一覧', '未解決の質問はありません。')
+      QuestionsProperty.new('未解決のQ&A', '未解決のQ&Aはありません。')
     else
       QuestionsProperty.new('全ての質問', '質問はありません。')
     end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -8,7 +8,7 @@ class QuestionsTest < ApplicationSystemTestCase
 
   test 'show listing unsolved questions' do
     visit_with_auth questions_path(target: 'not_solved'), 'kimura'
-    assert_equal '未解決の質問一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal '未解決のQ&A | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'show listing solved questions' do
@@ -298,7 +298,7 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'not show a WIP question on the unsolved Q&A list page' do
     visit_with_auth questions_path(target: 'not_solved'), 'kimura'
     assert_no_text 'wipテスト用の質問(wip中)'
-    assert_text '未解決の質問一覧'
+    assert_text '未解決のQ&A'
   end
 
   test "visit user profile page when clicked on user's name on question" do


### PR DESCRIPTION
## Issue

- #5106

## 概要

- Q&Aのページで「未解決」タブを表示している時のページ見出しとtitleに含まれる文言を以下のように変更した
  - 変更前：質問一覧
  - 変更後：Q&A

## 確認方法

1. `feature/change-questions-title-when-not-solved`をローカルに取り込む
2. `rails s`で起動する
1. 任意のユーザーでログインする
1. http://localhost:3000/questions?target=not_solved にアクセスする

## 変更前

![image](https://user-images.githubusercontent.com/33394676/176582924-fc805611-b1a9-4d59-81cb-eb047fd686d2.png)
タブに表示される`<title>`と、ページの見出しが「未解決の質問一覧」になっている

## 変更後

![image](https://user-images.githubusercontent.com/33394676/176582780-af14a601-304b-4153-bd9d-93296e17fa84.png)
タブに表示される`<title>`と、ページの見出しが「未解決のQ&A」になっている
