### PR TITLE
Q&Aでプラクティス項目を指定していない質問のタイトルや内容等が表示されるようにした

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -263,7 +263,11 @@ export default {
       ) {
         return ''
       } else {
-        return this.question.practice.title
+        const { practices, question, practiceId } = this
+
+        return practices === null
+            ? question.practice.title
+            : practices.find((practice) => practice.id === Number(practiceId)).title
       }
     },
     markdownDescription() {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -256,15 +256,15 @@ export default {
       )
     },
     practiceTitle() {
-      if (this.practiceId !== '' || undefined) {
+      if (this.practiceId === '' || this.practiceId === undefined || this.practiceId === null) {
+        return ''
+      } else {
         const { practices, question, practiceId } = this
 
         return practices === null
-          ? question.practice.title
-          : practices.find((practice) => practice.id === Number(practiceId))
-              .title
-      } else {
-        return ''
+            ? question.practice.title
+            : practices.find((practice) => practice.id === Number(practiceId))
+                .title
       }
     },
     markdownDescription() {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -256,15 +256,19 @@ export default {
       )
     },
     practiceTitle() {
-      if (this.practiceId === '' || this.practiceId === undefined || this.practiceId === null) {
+      if (
+        this.practiceId === '' ||
+        this.practiceId === undefined ||
+        this.practiceId === null
+      ) {
         return ''
       } else {
         const { practices, question, practiceId } = this
 
         return practices === null
-            ? question.practice.title
-            : practices.find((practice) => practice.id === Number(practiceId))
-                .title
+          ? question.practice.title
+          : practices.find((practice) => practice.id === Number(practiceId))
+              .title
       }
     },
     markdownDescription() {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -15,7 +15,7 @@
 
       .page-content-header__row
         .page-content-header__before-title
-          a.a-category-link(:href='`/practices/${practiceId}`')
+          a.a-category-link(:href='`/practices/${practiceId}`', v-if='practiceId !== null')
             | {{ practiceTitle }}
         h1.page-content-header__title(:class='question.wip ? "is-wip" : ""')
           span.a-title-label.is-solved.is-success(
@@ -229,11 +229,11 @@ export default {
     return {
       title: this.question.title,
       description: this.question.description,
-      practiceId: this.question.practice.id,
+      practiceId: this.getPracticeId(),
       edited: {
         title: this.question.title,
         description: this.question.description,
-        practiceId: this.question.practice.id
+        practiceId: this.getPracticeId()
       },
       editing: false,
       displayedUpdateMessage: false,
@@ -251,11 +251,15 @@ export default {
       )
     },
     practiceTitle() {
-      const { practices, question, practiceId } = this
+      if (this.practiceId !== null) {
+        const { practices, question, practiceId } = this
 
-      return practices === null
-        ? question.practice.title
-        : practices.find((practice) => practice.id === Number(practiceId)).title
+        return practices === null
+            ? question.practice.title
+            : practices.find((practice) => practice.id === Number(practiceId)).title
+      } else {
+        return ''
+      }
     },
     markdownDescription() {
       const markdownInitializer = new MarkdownInitializer()
@@ -268,6 +272,7 @@ export default {
   },
   created() {
     this.fetchPractices()
+    this.practiceId = this.getPracticeId()
   },
   mounted() {
     TextareaInitializer.initialize(`#js-question-content`)
@@ -276,6 +281,9 @@ export default {
     token() {
       const meta = document.querySelector('meta[name="csrf-token"]')
       return meta ? meta.getAttribute('content') : ''
+    },
+    getPracticeId() {
+      return this.question.practice === undefined ? null : this.question.practice.id
     },
     fetchPractices() {
       fetch('/api/practices.json?scoped_by_user=true', {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -263,12 +263,7 @@ export default {
       ) {
         return ''
       } else {
-        const { practices, question, practiceId } = this
-
-        return practices === null
-          ? question.practice.title
-          : practices.find((practice) => practice.id === Number(practiceId))
-              .title
+        return this.question.practice.title
       }
     },
     markdownDescription() {
@@ -282,7 +277,6 @@ export default {
   },
   created() {
     this.fetchPractices()
-    this.practiceId = this.getPracticeId()
   },
   mounted() {
     TextareaInitializer.initialize(`#js-question-content`)
@@ -363,8 +357,7 @@ export default {
         return
       }
 
-      const { title, description } = this.edited
-      const practiceId = this.edited.practiceId || null
+      const { title, description, practiceId } = this.edited
       const params = {
         question: {
           title,

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -266,8 +266,9 @@ export default {
         const { practices, question, practiceId } = this
 
         return practices === null
-            ? question.practice.title
-            : practices.find((practice) => practice.id === Number(practiceId)).title
+          ? question.practice.title
+          : practices.find((practice) => practice.id === Number(practiceId))
+              .title
       }
     },
     markdownDescription() {

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -129,6 +129,8 @@
                 v-model='edited.practiceId',
                 name='question[practice]'
               )
+                option(value='')
+                  | プラクティス選択なし
                 option(
                   v-for='practice in practices',
                   :key='practice.id',
@@ -251,7 +253,7 @@ export default {
       )
     },
     practiceTitle() {
-      if (this.practiceId !== null) {
+      if (this.practiceId !== '' || undefined) {
         const { practices, question, practiceId } = this
 
         return practices === null
@@ -307,6 +309,7 @@ export default {
           const choices = document.getElementById('js-choices-single-select')
           if (choices) {
             return new Choices(choices, {
+              removeItemButton: true,
               allowHTML: true,
               searchResultLimit: 20,
               searchPlaceholderValue: '検索ワード',
@@ -350,7 +353,8 @@ export default {
         return
       }
 
-      const { title, description, practiceId } = this.edited
+      const { title, description } = this.edited
+      const practiceId = this.edited.practiceId || null
       const params = {
         question: {
           title,

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -15,7 +15,10 @@
 
       .page-content-header__row
         .page-content-header__before-title
-          a.a-category-link(:href='`/practices/${practiceId}`', v-if='practiceId !== null')
+          a.a-category-link(
+            :href='`/practices/${practiceId}`',
+            v-if='practiceId !== null'
+          )
             | {{ practiceTitle }}
         h1.page-content-header__title(:class='question.wip ? "is-wip" : ""')
           span.a-title-label.is-solved.is-success(
@@ -257,8 +260,9 @@ export default {
         const { practices, question, practiceId } = this
 
         return practices === null
-            ? question.practice.title
-            : practices.find((practice) => practice.id === Number(practiceId)).title
+          ? question.practice.title
+          : practices.find((practice) => practice.id === Number(practiceId))
+              .title
       } else {
         return ''
       }
@@ -285,7 +289,9 @@ export default {
       return meta ? meta.getAttribute('content') : ''
     },
     getPracticeId() {
-      return this.question.practice === undefined ? null : this.question.practice.id
+      return this.question.practice === undefined
+        ? null
+        : this.question.practice.id
     },
     fetchPractices() {
       fetch('/api/practices.json?scoped_by_user=true', {

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -25,7 +25,10 @@
         .card-list-item-meta
           .card-list-item-meta__items
             .card-list-item-meta__item
-              a.a-meta.is-practice(:href='practiceUrl')
+              a.a-meta.is-practice(
+                :href='practiceUrl',
+                v-if='practiceUrl !== null'
+              )
                 | {{ question.practice.title }}
 
       .card-list-item__row
@@ -91,7 +94,9 @@ export default {
       }
     },
     practiceUrl() {
-      return `/practices/${this.question.practice.id}`
+      return this.question.practice === undefined
+          ? null
+          : `/practices/${this.question.practice.id}`
     }
   }
 }

--- a/app/javascript/question.vue
+++ b/app/javascript/question.vue
@@ -95,8 +95,8 @@ export default {
     },
     practiceUrl() {
       return this.question.practice === undefined
-          ? null
-          : `/practices/${this.question.practice.id}`
+        ? null
+        : `/practices/${this.question.practice.id}`
     }
   }
 }

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -120,3 +120,10 @@ question_for_wip:
   practice: practice1
   created_at: "2022-01-15"
   wip: true
+
+question14:
+  title: プラクティスを選択せずに登録したテストの質問
+  description: プラクティスを選択せずに登録したテストの質問。
+  user: kimura
+  created_at: "2022-01-16"
+  published_at: "2022-01-16"

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -372,4 +372,16 @@ class QuestionsTest < ApplicationSystemTestCase
     confirm_dialog = dismiss_confirm { click_link '削除する' }
     assert_equal '自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？', confirm_dialog
   end
+
+  test 'create a question with not choice practice' do
+    visit_with_auth new_question_path, 'kimura'
+    click_button 'Remove item'
+    within 'form[name=question]' do
+      fill_in 'question[title]', with: 'プラクティス指定のないテストの質問'
+      fill_in 'question[description]', with: 'プラクティス指定のないテストの質問です。'
+      click_button '登録する'
+    end
+    assert_text '質問を作成しました。'
+    assert_text 'プラクティス指定のないテストの質問'
+  end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -52,7 +52,7 @@ class QuestionsTest < ApplicationSystemTestCase
       fill_in 'question[title]', with: 'テストの質問（修正）'
       fill_in 'question[description]', with: 'テストの質問です。（修正）'
       find('.choices__inner').click
-      find('#choices--js-choices-single-select-item-choice-11', text: 'sshdでパスワード認証を禁止にする').click
+      find('#choices--js-choices-single-select-item-choice-12', text: 'sshdでパスワード認証を禁止にする').click
       click_button '更新する'
     end
     assert_text '質問を更新しました'
@@ -373,15 +373,41 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_equal '自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？', confirm_dialog
   end
 
+  test 'show a question with not choice practice' do
+    question = questions(:question14)
+    visit_with_auth question_path(question), 'kimura'
+    assert_no_selector('.a-category-link')
+    assert_text 'プラクティスを選択せずに登録したテストの質問'
+  end
+
   test 'create a question with not choice practice' do
     visit_with_auth new_question_path, 'kimura'
-    click_button 'Remove item'
+
     within 'form[name=question]' do
+      click_button 'Remove item'
       fill_in 'question[title]', with: 'プラクティス指定のないテストの質問'
       fill_in 'question[description]', with: 'プラクティス指定のないテストの質問です。'
       click_button '登録する'
     end
     assert_text '質問を作成しました。'
+    assert_no_selector('.a-category-link')
     assert_text 'プラクティス指定のないテストの質問'
+  end
+
+  test 'update a question with not choice practice' do
+    question = questions(:question8)
+    visit_with_auth question_path(question), 'kimura'
+
+    click_button '内容修正'
+    within 'form[name=question]' do
+      click_button 'Remove item'
+      fill_in 'question[title]', with: 'テストの質問（修正）'
+      fill_in 'question[description]', with: 'テストの質問です。（修正）'
+      click_button '更新する'
+    end
+    assert_text '質問を更新しました'
+    assert_selector '.a-category-link', text: ''
+    assert_text 'テストの質問（修正）'
+    assert_text 'テストの質問です。（修正）'
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -373,14 +373,14 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_equal '自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？', confirm_dialog
   end
 
-  test 'show a question with not choice practice' do
+  test 'show a question without choosing practice' do
     question = questions(:question14)
     visit_with_auth question_path(question), 'kimura'
     assert_no_selector('.a-category-link')
     assert_text 'プラクティスを選択せずに登録したテストの質問'
   end
 
-  test 'create a question with not choice practice' do
+  test 'create a question without choosing practice' do
     visit_with_auth new_question_path, 'kimura'
 
     within 'form[name=question]' do
@@ -394,7 +394,7 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_text 'プラクティス指定のないテストの質問'
   end
 
-  test 'update a question with not choice practice' do
+  test 'update a question without choosing practice' do
     question = questions(:question8)
     visit_with_auth question_path(question), 'kimura'
 


### PR DESCRIPTION
## Issue
- [Q&Aでプラクティス項目を指定していない質問のタイトルや内容等が表示されない · Issue \#5062](https://github.com/fjordllc/bootcamp/issues/5062)

関連Issue
- [Q&A作成時、プラクティスの指定を空にして保存すると表示や編集ができなくなる · Issue \#4896 ](https://github.com/fjordllc/bootcamp/issues/4896)

## 概要
- Issue#4896の対応をする中で、既存のQ&Aでもプラクティス項目を指定していない場合に質問タイトルや内容等が表示されなくなっていた。
- 開発ミーティングで確認したところ、新たにIssueを作成(Issue#5062)し、そちらの対応をしてからIssue#4896の対応をすることとなった。
- Issue#5062の対応として、Q&Aでプラクティス項目を指定していない質問のタイトルや内容等が表示されるよう修正した。
- プラクティス項目を指定していない質問を編集することができるようになったが、編集画面でプラクティス項目が削除できるようになっていなかったため、choices.jsのオプションを追加し、削除できるよう修正した。
- Issue#5062の対応をする中で、Issue#4896も同時に解決した。

## 変更前

<img width="1419" alt="#5062変更前" src="https://user-images.githubusercontent.com/70277776/177186958-10053b6a-1dc6-422a-bcce-2e54ce2fa210.png">

## 変更後
- 質問作成画面
<img width="1425" alt="#5062変更後" src="https://user-images.githubusercontent.com/70277776/177186990-c9a6b47e-affa-43e4-a84a-8b8d0c1d1969.png">

- 質問編集画面
![#5062変更後2](https://user-images.githubusercontent.com/70277776/177189450-eb46afda-d149-4e5b-a414-b9cbf434727c.png)


## 変更確認方法
1. 開発環境を立ち上げ、ログインする。（今回はkimuraでログイン）
2. `http://localhost:3000/questions/new` に接続し、質問の新規作成画面に遷移する。
3. プラクティス項目欄の右端の✖️をクリックし、プラクティスを空欄にする。
4. タイトル、質問文に適当な文字を入れて「登録する」をクリック。
5. 質問タイトル・内容等は表示されるがプラクティス内容が空欄の質問が作成される。