### PR TITLE
退会時のサイト内通知をAbstract Notifierに置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -100,17 +100,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def retired(sender, receiver)
-      Notification.create!(
-        kind: kinds[:retired],
-        user: receiver,
-        sender: sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(sender),
-        message: "😢 #{sender.login_name}さんが退会しました。",
-        read: false
-      )
-    end
-
     def three_months_after_retirement(sender, receiver)
       Notification.create!(
         kind: kinds[:retired],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -96,7 +96,7 @@ class NotificationFacade
   end
 
   def self.retired(sender, receiver)
-    Notification.retired(sender, receiver)
+    ActivityNotifier.with(sender: sender, receiver: receiver).retired.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -140,4 +140,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def retired(params = {})
+    params.merge!(@params)
+    sender = params[:sender]
+    receiver = params[:receiver]
+
+    notification(
+      body: "😢 #{sender.login_name}さんが退会しました。",
+      kind: :retired,
+      sender: sender,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(sender),
+      read: false
+    )
+  end
 end

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -73,4 +73,12 @@ class ActivityNotifierTest < ActiveSupport::TestCase
       notification.notify_later
     end
   end
+
+  test '#retired' do
+    notification = ActivityNotifier.with(sender: users(:kimura), receiver: users(:komagata)).retired
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      notification.notify_now
+    end
+  end
 end

--- a/test/system/notification/retirement_test.rb
+++ b/test/system/notification/retirement_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Notification::RetirementTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
+  test 'notify admins and mentors when a user retire' do
+    visit_with_auth notifications_path, 'komagata'
+    within first('.card-list-item') do
+      assert_no_selector '.card-list-item-title__link-label', text: '😢 kimuraさんが退会しました。'
+    end
+
+    visit_with_auth notifications_path, 'machida'
+    within first('.card-list-item') do
+      assert_no_selector '.card-list-item-title__link-label', text: '😢 kimuraさんが退会しました。'
+    end
+
+    visit_with_auth new_retirement_path, 'kimura'
+    find('label', text: 'とても良い').click
+    click_on '退会する'
+    page.driver.browser.switch_to.alert.accept
+    assert_text '退会処理が完了しました'
+
+    visit_with_auth notifications_path, 'komagata'
+    within first('.card-list-item.is-unread') do
+      assert_selector '.card-list-item-title__link-label', text: '😢 kimuraさんが退会しました。'
+    end
+
+    visit_with_auth notifications_path, 'machida'
+    within first('.card-list-item.is-unread') do
+      assert_selector '.card-list-item-title__link-label', text: '😢 kimuraさんが退会しました。'
+    end
+  end
+end

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class RetirementTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test 'retire user' do
     user = users(:kananashi)
     visit_with_auth new_retirement_path, 'kananashi'


### PR DESCRIPTION
## 関連Issue

- #4689
 
## 概要

退会時のサイト内通知の処理をAbstract Notifierに置き換えた。
内部処理のみの変更のため、データやUIに変更は無い。

## 環境準備
1. ブランチ`feature/replace-unsubscribe-notification-with-abstract-notifier`をローカルに取り込む。
2. `bin/rails s`でローカル環境を立ち上げる。

## 確認方法と確認内容
データやUIに変更は無いため、これまで通り、退会時にサイト内通知が行われていることを確認する。

1. `任意のユーザー`でログインする。
2. 退会・休会手続きページ(`/retirement/new`)にアクセスし、退会するボタンをクリックし、退会する。
3. `管理者` or `メンター`でログインする。
4. 通知ページ(`/notifications`)にアクセスし、全てタブをクリックし、1.でログインしたユーザーが退会した旨の通知があることを確認する。

<img width="683" alt="_development__通知___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/177004368-145c2b55-9435-4f8e-8f09-1c7f7cd7f990.png">
