### PR TITLE
解決済みの質問一覧のページ見出しとtitleタグを変更した

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -83,7 +83,7 @@ class QuestionsController < ApplicationController
   def questions_property
     case params[:target]
     when 'solved'
-      QuestionsProperty.new('解決済みの質問一覧', '解決済みの質問はありません。')
+      QuestionsProperty.new('解決済みのQ&A', '解決済みのQ&Aはありません。')
     when 'not_solved'
       QuestionsProperty.new('未解決のQ&A', '未解決のQ&Aはありません。')
     else

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -13,7 +13,7 @@ class QuestionsTest < ApplicationSystemTestCase
 
   test 'show listing solved questions' do
     visit_with_auth questions_path(target: 'solved'), 'kimura'
-    assert_equal '解決済みの質問一覧 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal '解決済みのQ&A | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'show listing all questions' do


### PR DESCRIPTION
## Issue

- #5107

## 概要

- Q&Aのページで「解決済み」タブを表示している時のページ見出しとtitleに含まれる文言を以下のように変更した
  - 変更前：質問一覧
  - 変更後：Q&A

## 確認方法

1. `feature/change-questions-title-when-solved`をローカルに取り込む
2. `rails s`で起動する
1. 任意のユーザーでログインする
1. http://localhost:3000/questions?target=solved にアクセスする

## 変更前

![image](https://user-images.githubusercontent.com/33394676/177020122-896fbf61-fbcc-4599-b6d5-f0940b1c45dc.png)
タブに表示される`<title>`と、ページの見出しが「解決済みの質問一覧」になっている

## 変更後

![image](https://user-images.githubusercontent.com/33394676/177020103-cade1269-3bb3-4130-aff4-45f6d71cebb0.png)
タブに表示される`<title>`と、ページの見出しが「解決済みのQ&A」になっている
