### PR TITLE
ユーザー一覧の企業別ページでユーザーをフィルターできるようにした

### DIFF
--- a/app/assets/stylesheets/application/blocks/page/_page-main-header.sass
+++ b/app/assets/stylesheets/application/blocks/page/_page-main-header.sass
@@ -1,12 +1,11 @@
 .page-main-header
-  border-bottom: solid 1px $border-shade
   +media-breakpoint-up(md)
     font-size: 1.125rem
   +media-breakpoint-down(sm)
     font-size: 1rem
 
 .page-main-header__inner
-  +padding(vertical, 1rem .5rem)
+  padding-top: 1rem
   display: flex
   align-items: center
   +media-breakpoint-down(sm)

--- a/app/assets/stylesheets/application/blocks/page/_page-tabs.sass
+++ b/app/assets/stylesheets/application/blocks/page/_page-tabs.sass
@@ -28,7 +28,7 @@
   align-items: center
   justify-content: center
   height: 2.75rem
-  background-color: #dfdfe5
+  background-color: $background-semi-shade
   +padding(horizontal, 1em)
   +border-radius(top, .25rem)
   border: solid 1px $border-more-shade

--- a/app/assets/stylesheets/shared/blocks/_tab-nav.sass
+++ b/app/assets/stylesheets/shared/blocks/_tab-nav.sass
@@ -11,8 +11,8 @@
   gap: .5rem
   overflow-x: auto
   overflow-y: hidden
-  +padding(vertical, .875rem)
   +margin(horizontal,  -1rem)
+  +padding(horizontal, 1rem)
 
 .tab-nav__item
   flex: 0 0 7rem

--- a/app/assets/stylesheets/shared/blocks/_tab-nav.sass
+++ b/app/assets/stylesheets/shared/blocks/_tab-nav.sass
@@ -13,7 +13,6 @@
   overflow-y: hidden
   +padding(vertical, .875rem)
   +margin(horizontal,  -1rem)
-  +padding(horizontal, 1rem)
 
 .tab-nav__item
   flex: 0 0 7rem

--- a/app/assets/stylesheets/shared/blocks/_tab-nav.sass
+++ b/app/assets/stylesheets/shared/blocks/_tab-nav.sass
@@ -1,12 +1,17 @@
 .tab-nav
+  +padding(vertical, .875rem)
   border-bottom: solid 1px $background-shade
+  .page-main-header + &
+    border-bottom: none
+    padding-bottom: 0
+
 
 .tab-nav__items
   display: flex
   gap: .5rem
-  +padding(vertical, .875rem)
   overflow-x: auto
   overflow-y: hidden
+  +padding(vertical, .875rem)
   +margin(horizontal,  -1rem)
   +padding(horizontal, 1rem)
 

--- a/app/controllers/api/users/companies_controller.rb
+++ b/app/controllers/api/users/companies_controller.rb
@@ -3,5 +3,6 @@
 class API::Users::CompaniesController < API::BaseController
   def index
     @companies = Company.with_attached_logo.order(:id)
+    @target = params[:target]
   end
 end

--- a/app/controllers/users/companies_controller.rb
+++ b/app/controllers/users/companies_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Users::CompaniesController < ApplicationController
+  TARGETS = %w[all trainee adviser graduate mentor].freeze
   before_action :require_login
 
-  def index; end
+  def index
+    @target = TARGETS.include?(params[:target]) ? params[:target] : TARGETS.first
+  end
 end

--- a/app/javascript/companies.js
+++ b/app/javascript/companies.js
@@ -5,8 +5,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const selector = '#js-companies'
   const companies = document.querySelector(selector)
   if (companies) {
+    const target = companies.getAttribute('data-target')
     new Vue({
-      render: (h) => h(Companies)
+      render: (h) =>
+        h(Companies, {
+          props: {
+            target: target
+          }
+        })
     }).$mount(selector)
   }
 })

--- a/app/javascript/companies.vue
+++ b/app/javascript/companies.vue
@@ -17,9 +17,21 @@ export default {
     company: Company,
     'user-icon': UserIcon
   },
+  props: {
+    target: {
+      type: String,
+      required: false,
+      default: 'all'
+    }
+  },
   data() {
     return {
       companies: []
+    }
+  },
+  computed: {
+    url() {
+      return `/api/users/companies?target=${this.target}`
     }
   },
   created() {
@@ -31,7 +43,7 @@ export default {
       return meta ? meta.getAttribute('content') : ''
     },
     getCompaniesPage() {
-      fetch('/api/users/companies', {
+      fetch(this.url, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json; charset=utf-8',

--- a/app/javascript/company.vue
+++ b/app/javascript/company.vue
@@ -21,6 +21,7 @@
           img(
             :src='user.avatar_url',
             :title='user.icon_title',
+            :data-login-name='user.login_name',
             :class='`a-user-icons__item-icon a-user-icon is-${user.primary_role}`'
           )
 </template>

--- a/app/views/api/users/companies/_company.json.jbuilder
+++ b/app/views/api/users/companies/_company.json.jbuilder
@@ -6,4 +6,4 @@ json.description company.description
 json.logo_url company.logo_url
 json.users_url company_users_url(company)
 
-json.users company.users.order(:id), partial: "api/users/user", as: :user
+json.users company.users.users_role(@target).order(:id), partial: "api/users/user", as: :user

--- a/app/views/users/companies/_users_tabs.html.slim
+++ b/app/views/users/companies/_users_tabs.html.slim
@@ -1,0 +1,6 @@
+nav.tab-nav
+  .container
+    ul.tab-nav__items
+      - Users::CompaniesController::TARGETS.each do |target|
+        li.tab-nav__item
+          = link_to t("target.#{target}"), users_companies_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/users/companies/index.html.slim
+++ b/app/views/users/companies/index.html.slim
@@ -16,4 +16,5 @@ main.page-main
       .page-main-header__inner
         h1.page-main-header__title
           = title
+          | （#{t("target.#{@target}")}）
   #js-companies(data-target="#{@target}")

--- a/app/views/users/companies/index.html.slim
+++ b/app/views/users/companies/index.html.slim
@@ -8,6 +8,7 @@ header.page-header.is-border-bottom-none
         ul.page-header-actions__items
 
 = render '/users/lg_page_tabs'
+= render 'users_tabs'
 
 main.page-main
   header.page-main-header
@@ -15,4 +16,4 @@ main.page-main
       .page-main-header__inner
         h1.page-main-header__title
           = title
-  #js-companies
+  #js-companies(data-target="#{@target}")

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -11,14 +11,6 @@ header.page-header.is-border-bottom-none
 - unless params[:tag]
   = render 'nav'
 
-- unless params[:tag]
-  .a-page-notice.page-notice
-    .container
-      .a-page-notice__inner
-        p
-          | 気になるユーザーをフォローしてみよう！自分が誰をフォローしているかを知られることはありません。
-          = link_to 'くわしくはこちら', '/pages/follow_the_report'
-
 main.page-main
   header.page-main-header
     .container
@@ -53,3 +45,9 @@ main.page-main
           #js-users
         .page-body__column.is-sub.is-hidden-lg-down
           = render '/users/random_tags'
+  - unless params[:tag]
+    .sticky-message
+      .container
+        p
+          | 気になるユーザーをフォローしてみよう！自分が誰をフォローしているかを知られることはありません。
+          = link_to 'くわしくはこちら', '/pages/follow_the_report'

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -167,3 +167,7 @@ talk_kyuukai:
 talk_neverlogin:
   user: neverlogin
   unreplied: false
+
+talk_sotsugyoukigyoshozoku:
+  user: sotsugyoukigyoshozoku
+  unreplied: false

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -998,3 +998,24 @@ kyuukai:
   hibernated_at: "2020-01-01 00:00:00"
   updated_at: "2014-01-01 00:00:13"
   created_at: "2014-01-01 00:00:13"
+
+sotsugyoukigyoshozoku:
+  login_name: sotsugyoukigyoshozoku
+  email: sotsugyoukigyoshozoku@example.com
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 卒業 企業所属
+  name_kana: ソツギョウ キギョウショゾク
+  twitter_account: sotsugyoukigyoshozoku
+  blog_url: https://sotsugyoukigyoshozoku.example.com/
+  company: company2
+  description: "卒業した後に、企業に所属しました。"
+  course: course1
+  os: mac
+  experience: rails
+  graduated_on: "2022-07-04"
+  unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwg
+  sad_streak: true
+  updated_at: "2022-07-01 00:00:00"
+  created_at: "2022-07-01 00:00:00"
+  last_activity_at: "2022-07-01 00:00:00"

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -124,3 +124,7 @@ talk31:
 talk32:
   user: neverlogin
   unreplied: false
+
+talk33:
+  user: sotsugyoukigyoshozoku
+  unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -847,3 +847,24 @@ kyuukai:
   hibernated_at: "2020-01-01 00:00:00"
   updated_at: "2014-01-01 00:00:13"
   created_at: "2014-01-01 00:00:13"
+
+sotsugyoukigyoshozoku:
+  login_name: sotsugyoukigyoshozoku
+  email: sotsugyoukigyoshozoku@example.com
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 卒業 企業所属
+  name_kana: ソツギョウ キギョウショゾク
+  twitter_account: sotsugyoukigyoshozoku
+  blog_url: https://sotsugyoukigyoshozoku.example.com/
+  company: company2
+  description: "卒業した後に、企業に所属しました。"
+  course: course1
+  os: mac
+  experience: rails
+  graduated_on: "2022-07-04"
+  unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwg
+  sad_streak: true
+  updated_at: "2022-07-01 00:00:00"
+  created_at: "2022-07-01 00:00:00"
+  last_activity_at: "2022-07-01 00:00:00"

--- a/test/integration/api/users/companies_test.rb
+++ b/test/integration/api/users/companies_test.rb
@@ -3,9 +3,33 @@
 require 'test_helper'
 
 class API::Users::CompaniesTest < ActionDispatch::IntegrationTest
-  test 'should get companies' do
+  test 'should fetch all users belonging to each company' do
     token = create_token('kimura', 'testtest')
-    get api_users_companies_path(format: :json), headers: { 'Authorization' => "Bearer #{token}" }
+    get api_users_companies_path(format: :json, target: 'all'), headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
+  test 'should fetch trainee belonging to each company' do
+    token = create_token('kimura', 'testtest')
+    get api_users_companies_path(format: :json, target: 'trainee'), headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
+  test 'should fetch adviser belonging to each company' do
+    token = create_token('kimura', 'testtest')
+    get api_users_companies_path(format: :json, target: 'adviser'), headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
+  test 'should fetch graduate belonging to each company' do
+    token = create_token('kimura', 'testtest')
+    get api_users_companies_path(format: :json, target: 'graduate'), headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
+  test 'should fetch mentor belonging to each company' do
+    token = create_token('kimura', 'testtest')
+    get api_users_companies_path(format: :json, target: 'mentor'), headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
   end
 

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -9,4 +9,85 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_text companies(:company1).name
     assert_no_text companies(:company3).name
   end
+
+  test 'show all users belonging to each company' do
+    visit_with_auth '/users/companies', 'kimura'
+
+    assert_selector('a.tab-nav__item-link.is-active', text: '全員')
+    assert_text '企業別（全員）'
+    assert_selector('.group-company-name__label', text: 'Fjord Inc.')
+    within first('.a-user-icons__items') do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-admin')['data-login-name'], 'komagata'
+      assert_equal all('.a-user-icons__item-icon.a-user-icon.is-admin')[1]['data-login-name'], 'machida'
+    end
+    assert_selector('.group-company-name__label', text: 'root inc.')
+    within all('.a-user-icons__items')[1] do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['data-login-name'], 'kensyu'
+      assert_equal all('.a-user-icons__item-icon.a-user-icon.is-trainee')[1]['data-login-name'], 'kensyuowata'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['data-login-name'], 'senpai'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['data-login-name'], 'sotsugyoukigyoshozoku'
+    end
+
+    click_link '全員'
+
+    assert_text '企業別（全員）'
+    assert_selector('.group-company-name__label', text: 'Fjord Inc.')
+    within first('.a-user-icons__items') do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-admin')['data-login-name'], 'komagata'
+      assert_equal all('.a-user-icons__item-icon.a-user-icon.is-admin')[1]['data-login-name'], 'machida'
+    end
+    assert_selector('.group-company-name__label', text: 'root inc.')
+    within all('.a-user-icons__items')[1] do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['data-login-name'], 'kensyu'
+      assert_equal all('.a-user-icons__item-icon.a-user-icon.is-trainee')[1]['data-login-name'], 'kensyuowata'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['data-login-name'], 'senpai'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['data-login-name'], 'sotsugyoukigyoshozoku'
+    end
+  end
+
+  test 'show trainee belonging to each company' do
+    visit_with_auth '/users/companies', 'kimura'
+    click_link '研修生'
+
+    assert_text '企業別（研修生）'
+    assert_selector('a.tab-nav__item-link.is-active', text: '研修生')
+    assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
+    assert_selector('.group-company-name__label', text: 'root inc.')
+    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['data-login-name'], 'kensyu'
+    assert_equal all('.a-user-icons__item-icon.a-user-icon.is-trainee')[1]['data-login-name'], 'kensyuowata'
+  end
+
+  test 'show adviser belonging to each company' do
+    visit_with_auth '/users/companies', 'kimura'
+    click_link 'アドバイザー'
+
+    assert_text '企業別（アドバイザー）'
+    assert_selector('a.tab-nav__item-link.is-active', text: 'アドバイザー')
+    assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
+    assert_selector('.group-company-name__label', text: 'root inc.')
+    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['data-login-name'], 'senpai'
+  end
+
+  test 'show graduate belonging to each company' do
+    visit_with_auth '/users/companies', 'kimura'
+    click_link '卒業生'
+
+    assert_text '企業別（卒業生）'
+    assert_selector('a.tab-nav__item-link.is-active', text: '卒業生')
+    assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
+    assert_selector('.group-company-name__label', text: 'root inc.')
+    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['data-login-name'], 'sotsugyoukigyoshozoku'
+  end
+
+  test 'show mentor belonging to each company' do
+    visit_with_auth '/users/companies', 'kimura'
+    click_link 'メンター'
+
+    assert_text '企業別（メンター）'
+    assert_selector('a.tab-nav__item-link.is-active', text: 'メンター')
+    assert_selector('.group-company-name__label', text: 'Fjord Inc.')
+    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-admin')['data-login-name'], 'komagata'
+    assert_equal all('.a-user-icons__item-icon.a-user-icon.is-admin')[1]['data-login-name'], 'machida'
+    assert_no_selector('.group-company-name__label', text: 'root inc.')
+  end
 end


### PR DESCRIPTION
## 関連Issue

- #5109

 ## 概要

ユーザー一覧の企業別ページで、表示するユーザーをフィルターできるようにした。

フィルターの種類は以下の5種類である。
- 全員
- 研修生
- アドバイザー
- 卒業生
- メンター

## 環境準備
1. ブランチ`feature/add-buttons-to-filter-users`をローカルに取り込む。
2. `bin/rails db:reset`でDBを作り直しする。
3. `bin/rails s`でローカル環境を立ち上げる。

## 確認方法と確認内容

1. 任意のユーザーでログインする。
2. ユーザー一覧の企業別ページ(`/users/companies`)にアクセスし、`全員`タブが適用され、全てのユーザーが表示されることを確認する。
3. 以下の各タブをクリックし、各企業に所属するユーザーがフィルターされて表示されることを確認する。

項番 | タブ名 | 表示される各企業に所属するユーザー
-- | -- | --
1 | 全員 | 全てのユーザー |
2 | 研修生 | 研修生 |
3 | アドバイザー | アドバイザー |
4 | 卒業生 | 卒業生 |
5 | メンター | メンター |

### 変更前
<img width="1246" alt="_development__企業別___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/178277644-2645f571-be8c-4073-bbaf-0535a578880c.png">

### 変更後

#### 項番1
<img width="1255" alt="Cursor_and__development__企業別___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/11376040/178277447-b30300b9-24de-46a4-af5e-06b188971c1a.png">

#### 項番2
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/11376040/177954594-3c742156-161e-435e-8041-12e66faa9b42.png">

#### 項番3

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/11376040/177954871-846c8453-258e-44fd-85ff-ae5bf69573b7.png">


#### 項番4

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/11376040/177955264-49ee17db-297f-46ba-a526-7a2e17db7c25.png">


#### 項番5

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/11376040/177955541-749c0188-8066-433d-9c69-c01c9f802976.png">


