### PR TITLE
不要なeager loadingを削除

### DIFF
--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -14,7 +14,7 @@ class API::AnswersController < API::BaseController
         {
           question: [
             :correct_answer,
-            { user: [:company, { avatar_attachment: :blob }] },
+            { user: { avatar_attachment: :blob } },
             :practice,
             :tag_taggings,
             :tags

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -19,7 +19,7 @@ class API::QuestionsController < API::BaseController
     questions = questions.tagged_with(params[:tag]) if params[:tag]
     @questions = questions
                  .with_avatar
-                 .includes(:practice, :answers, :tags, :correct_answer, user: :company)
+                 .includes(:practice, :answers, :tags, :correct_answer)
                  .order(updated_at: :desc, id: :desc)
                  .page(params[:page])
   end

--- a/app/controllers/api/reports/recents_controller.rb
+++ b/app/controllers/api/reports/recents_controller.rb
@@ -3,7 +3,7 @@
 class API::Reports::RecentsController < API::BaseController
   def index
     @reports = Report
-               .includes([{ user: [{ avatar_attachment: :blob }, :company] }, :checks])
+               .includes({ user: { avatar_attachment: :blob } }, :checks)
                .not_wip
                .order(reported_on: :desc, id: :desc)
                .limit(20)

--- a/app/controllers/api/talks/unreplied_controller.rb
+++ b/app/controllers/api/talks/unreplied_controller.rb
@@ -4,7 +4,7 @@ class API::Talks::UnrepliedController < API::BaseController
   PAGER_NUMBER = 20
 
   def index
-    @talks = Talk.eager_load(user: [:company, { avatar_attachment: :blob }])
+    @talks = Talk.eager_load(user: { avatar_attachment: :blob })
                  .unreplied
                  .order(updated_at: :desc, id: :asc)
     @talks =

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -7,7 +7,7 @@ class API::TalksController < API::BaseController
   def index
     @target = params[:target]
     @target = 'all' unless TARGETS.include?(@target)
-    @talks = Talk.eager_load(user: [:company, { avatar_attachment: :blob }])
+    @talks = Talk.eager_load(user: { avatar_attachment: :blob })
                  .order(updated_at: :desc, id: :asc)
     @talks =
       if params[:search_word]

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,7 +9,7 @@ class HomeController < ApplicationController
       else
         @announcements = Announcement.with_avatar.where(wip: false).order(published_at: :desc).limit(3)
         @completed_learnings = current_user.learnings.where(status: 3).includes(:practice).order(updated_at: :desc)
-        @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.includes(:company).order(last_activity_at: :desc)
+        @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.order(last_activity_at: :desc)
         @job_seeking_users = User.with_attached_avatar.job_seeking.includes(:reports, :products, :works, :course, :company)
         display_events_on_dashboard
         display_welcome_message_for_adviser

--- a/app/controllers/practices/products_controller.rb
+++ b/app/controllers/practices/products_controller.rb
@@ -10,7 +10,7 @@ class Practices::ProductsController < ApplicationController
                   :practice,
                   :comments,
                   :checks,
-                  user: [:company, { avatar_attachment: :blob }]
+                  user: { avatar_attachment: :blob }
                 )
                 .where(practice: @practice)
                 .order(created_at: :desc)

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -16,7 +16,7 @@ class Practices::QuestionsController < ApplicationController
       end
     @questions = questions
                  .with_avatar
-                 .includes(:answers, :tags, :correct_answer, user: :company)
+                 .includes(:answers, :tags, :correct_answer)
                  .order(updated_at: :desc, id: :desc)
   end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -25,7 +25,7 @@ class QuestionsController < ApplicationController
     questions = questions.tagged_with(params[:tag]) if params[:tag]
     @questions = questions
                  .with_avatar
-                 .includes(:practice, :answers, :tags, :correct_answer, user: :company)
+                 .includes(:practice, :answers, :tags, :correct_answer)
                  .order(updated_at: :desc, id: :desc)
                  .page(params[:page])
     @questions_property = questions_property

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -32,8 +32,8 @@ class TalksController < ApplicationController
   end
 
   def set_members
-    @members = User.where(id: User.admins.ids.push(@talk.user_id))
-                   .eager_load([:company, { avatar_attachment: :blob }])
+    @members = User.with_attached_avatar
+                   .where(id: User.admins.ids.push(@talk.user_id))
                    .order(:id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
 
     @users = target_users
              .page(params[:page]).per(PAGER_NUMBER)
-             .preload(:company, :avatar_attachment, :course, :taggings)
+             .preload(:avatar_attachment, :course, :taggings)
              .unretired
              .order(updated_at: :desc)
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -45,7 +45,6 @@ class Product < ApplicationRecord
     with_avatar
       .preload(:practice,
                :comments,
-               { user: :company },
                { checks: { user: { avatar_attachment: :blob } } })
   }
   scope :order_for_list, -> { order(created_at: :desc, id: :desc) }


### PR DESCRIPTION
## 概要

修正箇所は`daimyo?`メソッドのN+1回避のためにcompaniesテーブルのeager loadingをしていましたが、#5012 で`daimyo?`メソッドは使われなくなり、不要なクエリを削減するため。
それ以外でcompaniesテーブルをeager loadingしてN+1を回避している箇所はそのままにしてあります。