### PR TITLE
不安定に落ちるテストを修正

### DIFF
--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -90,7 +90,10 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{product.id}", 'kimura'
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
-    assert_equal 'kimura', product.comments.last.user.login_name
+    within('#latest-comment') do
+      assert_text 'kimura'
+      assert_text 'test'
+    end
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
     assert_text product.practice.title
     assert_selector '.card-list-item-meta__item', text: '提出者'
@@ -101,7 +104,10 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{product.id}", 'mentormentaro'
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
-    assert_equal 'mentormentaro', product.comments.last.user.login_name
+    within('#latest-comment') do
+      assert_text 'mentormentaro'
+      assert_text 'test'
+    end
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
     assert_no_text product.practice.title
     assert_no_selector '.card-list-item-meta__item', text: 'メンター'


### PR DESCRIPTION
## 概要

現時点での最新のmainブランチ(843dff1d277d1bb4eb856de7825d7e2888626cd6)で常に下記のテストが落ちるようになっています。

https://github.com/fjordllc/bootcamp/runs/7146417094?check_suite_focus=true

```sh
[MinitestRetry] retry 'test_display_products_last_commented_by_submitter_if_click_on_no-replied-button' count: 1,  msg: NoMethodError: undefined method `user' for nil:NilClass
    assert_equal 'kimura', product.comments.last.user.login_name
                                                ^^^^^
    test/system/product/unchecked_test.rb:93:in `block in <class:UncheckedTest>'
```

## 原因と対応

ブラウザ操作でコメントを追加直後にレコードを確認しているが、insertが完了する前に確認しているのでレコードがなくnilとなり落ちていた。
systemテストなのでレコードを確認する代わりに画面の要素を確認するテストに書き換えた。