### PR TITLE
Watch中のQ&Aに回答が投稿された際の通知文言を変更した

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -86,8 +86,9 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @sender = @watchable.user
     @user = @receiver
     link = "/#{@watchable.class.name.downcase.pluralize}/#{@watchable.id}"
+    action = link.start_with?('/questions') ? '回答' : 'コメント'
     @notification = @user.notifications.find_by(link: link)
-    subject = "[bootcamp] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんがコメントしました。"
+    subject = "[bootcamp] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんが#{action}しました。"
     mail to: @user.email, subject: subject
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -86,8 +86,8 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @sender = @watchable.user
     @user = @receiver
     link = "/#{@watchable.class.name.downcase.pluralize}/#{@watchable.id}"
-    action = link.start_with?('/questions') ? '回答' : 'コメント'
     @notification = @user.notifications.find_by(link: link)
+    action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
     subject = "[bootcamp] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんが#{action}しました。"
     mail to: @user.email, subject: subject
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -90,13 +90,12 @@ class Notification < ApplicationRecord
     def watching_notification(watchable, receiver, comment)
       watchable_user = watchable.user
       sender = comment.user
-      link = Rails.application.routes.url_helpers.polymorphic_path(watchable)
-      action = link.start_with?('/questions') ? '回答' : 'コメント'
+      action = watchable.instance_of?(Question) ? '回答' : 'コメント'
       Notification.create!(
         kind: kinds[:watching],
         user: receiver,
         sender: sender,
-        link: link,
+        link: Rails.application.routes.url_helpers.polymorphic_path(watchable),
         message: "#{watchable_user.login_name}さんの【 #{watchable.notification_title} 】に#{comment.user.login_name}さんが#{action}しました。",
         read: false
       )

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -90,12 +90,14 @@ class Notification < ApplicationRecord
     def watching_notification(watchable, receiver, comment)
       watchable_user = watchable.user
       sender = comment.user
+      link = Rails.application.routes.url_helpers.polymorphic_path(watchable)
+      action = link.start_with?('/questions') ? '回答' : 'コメント'
       Notification.create!(
         kind: kinds[:watching],
         user: receiver,
         sender: sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(watchable),
-        message: "#{watchable_user.login_name}さんの【 #{watchable.notification_title} 】に#{comment.user.login_name}さんがコメントしました。",
+        link: link,
+        message: "#{watchable_user.login_name}さんの【 #{watchable.notification_title} 】に#{comment.user.login_name}さんが#{action}しました。",
         read: false
       )
     end

--- a/app/views/notification_mailer/watching_notification.html.slim
+++ b/app/views/notification_mailer/watching_notification.html.slim
@@ -1,6 +1,6 @@
-- is_question = (@watchable.class.model_name.name == 'Question')
-- anchor_prefix = is_question ? 'answer_' : 'comment_'
-- action = is_question ? '回答' : 'コメント'
+- is_question = (@watchable.class.model_name.name == 'Question'),
+  anchor_prefix = is_question ? 'answer_' : 'comment_',
+  action = is_question ? '回答' : 'コメント'
 = render 'notification_mailer_template',
   title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんが#{action}しました。",
   link_url: notification_url(@notification, anchor: "#{anchor_prefix}#{@comment.id}"),

--- a/app/views/notification_mailer/watching_notification.html.slim
+++ b/app/views/notification_mailer/watching_notification.html.slim
@@ -1,6 +1,8 @@
-- anchor_prefix = @watchable.class.model_name.name == 'Question' ? 'answer_' : 'comment_'
+- is_question = (@watchable.class.model_name.name == 'Question')
+- anchor_prefix = is_question ? 'answer_' : 'comment_'
+- action = is_question ? '回答' : 'コメント'
 = render 'notification_mailer_template',
-  title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんがコメントしました。",
+  title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんが#{action}しました。",
   link_url: notification_url(@notification, anchor: "#{anchor_prefix}#{@comment.id}"),
   link_text: "この#{@watchable.class.model_name.human}へ" do
   = md2html @comment.description

--- a/app/views/notification_mailer/watching_notification.html.slim
+++ b/app/views/notification_mailer/watching_notification.html.slim
@@ -1,6 +1,6 @@
 - is_question = (@watchable.class.model_name.name == 'Question'),
-  anchor_prefix = is_question ? 'answer_' : 'comment_',
-  action = is_question ? '回答' : 'コメント'
+  anchor_prefix = is_question ? 'answer_' : 'comment_'
+- action = is_question ? '回答' : 'コメント'
 = render 'notification_mailer_template',
   title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんが#{action}しました。",
   link_url: notification_url(@notification, anchor: "#{anchor_prefix}#{@comment.id}"),

--- a/app/views/notification_mailer/watching_notification.html.slim
+++ b/app/views/notification_mailer/watching_notification.html.slim
@@ -1,4 +1,4 @@
-- is_question = (@watchable.class.model_name.name == 'Question'),
+- is_question = @watchable.instance_of?(Question),
   anchor_prefix = is_question ? 'answer_' : 'comment_'
 - action = is_question ? '回答' : 'コメント'
 = render 'notification_mailer_template',

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -53,13 +53,13 @@ class Notification::WatchesTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'kimura'
 
     within first('.card-list-item.is-unread') do
-      assert_text "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんがコメントしました。"
+      assert_text "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんが回答しました。"
     end
 
     visit_with_auth '/notifications', 'komagata'
 
     within first('.card-list-item.is-unread') do
-      assert_text "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんがコメントしました。"
+      assert_text "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんが回答しました。"
     end
   end
 end


### PR DESCRIPTION
## Issue

- #4450

## 概要

- Watch中のQ&Aに回答が投稿された際の通知（Web通知、メール）に含まれる文言を以下のように変更した
  - 変更前：コメント
  - 変更後：回答

### 補足

- Q&Aに新しい回答が付いた時の通知メッセージは二種類あるが、このIssueでは上記の通知が対象となることをIssueのコメント欄でmachidaさんに確認済
  - [Q&AのAが投稿された際の通知タイトル、通知文の変更 · Issue #4450 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/4450#issuecomment-1173023374)

## 確認方法

### 事前準備

1. `feature/change-notification-message-when-new-answer-added`をローカルに取り込む
2. `rails s`で起動する
3. 任意のユーザーAでログインする
4. Q&Aに新しい質問を作成する
5. 任意のユーザーBでログインする
6. 4 で作成した質問に回答を投稿する
7. 任意のユーザーCでログインする
8. 4 で作成した質問に回答を投稿する

### Web通知の確認

1. 任意のユーザーBでログインする
2. http://localhost:3000/notifications?status=unread にアクセスする

### メール通知の確認

1. http://localhost:3000/letter_opener/ にアクセスする
2. 直近で任意のユーザーB宛に送信されたメールを表示する

## 変更前

### Web通知

![image](https://user-images.githubusercontent.com/33394676/177072432-0cec4e56-14a0-4fa8-af4f-947a9af98918.png)

### メール通知

![image](https://user-images.githubusercontent.com/33394676/177072600-87088d5c-ce5f-4249-9fb0-063122fbeee7.png)

## 変更後

### Web通知

![image](https://user-images.githubusercontent.com/33394676/177071664-5ac38f4b-cfdc-44c5-b25b-cf8bdd738ba6.png)

### メール通知

![image](https://user-images.githubusercontent.com/33394676/177071844-4e1c9d66-9180-46cd-8411-04a7e6c42823.png)
