### PR TITLE
定期イベントにカテゴリーを設定できるようにした

### DIFF
--- a/app/assets/stylesheets/application/blocks/form/_block-checks.sass
+++ b/app/assets/stylesheets/application/blocks/form/_block-checks.sass
@@ -16,3 +16,8 @@
       max-width: 100%
   .block-checks.is-3-items &
     width: calc((100% - 1rem) / 3)
+    flex: 0 0 calc((100% - 1rem) / 3)
+  .block-checks.sm-down\:is-3-items &
+    +media-breakpoint-down(sm)
+      width: calc((100% - 1rem) / 3)
+      flex: 0 0 calc((100% - 1rem) / 3)

--- a/app/assets/stylesheets/application/blocks/form/_vue-tags-input.sass
+++ b/app/assets/stylesheets/application/blocks/form/_vue-tags-input.sass
@@ -1,5 +1,12 @@
 .vue-tags-input
   max-width: 100% !important
 
-.ti-input
-  border-radius: 4px
+body .vue-tags-input
+  .ti-input
+    border-radius: 4px
+    background-color: $input-background
+    border-color: $input-border
+    transition: all .2s ease-out
+    &:hover
+      background-color: $input-hover-background
+      border-color: $input-hover-border

--- a/app/assets/stylesheets/application/blocks/user/_following.sass
+++ b/app/assets/stylesheets/application/blocks/user/_following.sass
@@ -18,7 +18,7 @@
   text-align: left
   transition: all .2s ease-out
   &:hover
-    background-color: $hover-background
+    background-color: $background-more-tint
 
 .following-option__inner
   position: relative

--- a/app/assets/stylesheets/atoms/_a-block-check.sass
+++ b/app/assets/stylesheets/atoms/_a-block-check.sass
@@ -10,11 +10,7 @@
   cursor: pointer
   border-radius: .25rem
   transition: all .2s ease-in
-  +position(relative)
-  &:hover
-    background-color: $base
-  &.has-image
-    flex-direction: column
+  position: relative
   &.is-ta-left
     justify-content: flex-start
     text-align: left
@@ -23,11 +19,13 @@
     label
       flex: 0 0 100%
       cursor: pointer
+  &:hover
+    background-color: $input-hover-background
+    border-color: $input-hover-border
   input:checked + &
-    background-color: $warning-shade
-    border-color: $warning
-    color: $warning-text
-    font-weight: 600
+    background-color: $input-selected-background
+    border-color: $input-selected-border
+    color: $input-selected-text
   .a-block-check &::before
     display: block
     +position(absolute, left .75rem, top 50%)
@@ -63,14 +61,13 @@
     color: $reversal-text
 
 .a-block-check__name
-  +text-block(.875rem 1, block center)
+  +text-block(.875rem 1.4, block center)
 
 .a-block-check__image
   +size(2rem)
-  &.is-lg
-    +size(2.5rem)
-  & + .a-block-check__name
-    margin-top: .5rem
+  .a-block-check__label.has-icon &
+    +size(1.75rem)
+    margin-right: .5rem
 
 .a-block-check__account
   margin-left: .25em

--- a/app/assets/stylesheets/atoms/_a-text-input.sass
+++ b/app/assets/stylesheets/atoms/_a-text-input.sass
@@ -13,14 +13,13 @@
   .field_with_errors &
     border-color: #e1a7b6
     background-color: #fefafb
+  &:hover
+    background-color: $input-hover-background
+    border-color: $input-hover-border
   &:focus
-    background-color: $base
-    border-color: tint($primary, 20%)
-    box-shadow: rgba(black, .07) 0 .0625rem .0625rem inset, rgba($primary, .4) 0 0 1px 2px
-  &.is-inputed
-    border-style: dashed
-  &.is-align-center
-    text-align: center
+    background-color: $input-focus-background
+    border-color: $input-focus-border
+    box-shadow: $input-focus-shadow
   &:disabled
     color: #999
     background-color: #dedede

--- a/app/assets/stylesheets/config/variables/_colors.sass
+++ b/app/assets/stylesheets/config/variables/_colors.sass
@@ -9,7 +9,7 @@ $background-shade: #d6d6de
 $background-semi-shade: #e0e0e4
 $background-tint: #eceeef
 $background-more-tint: #f9f9fa
-$hover-background: $background-more-tint
+$background-more-more-tint: #fbfbfb
 
 // text
 $default-text: #42404e
@@ -32,8 +32,6 @@ $border-tint: $background
 $border-shade: #d2d2d8
 $border-more-shade: #c6c7cd
 $border-more-more-shade: #b8b8c0
-$input-border: #c1c5b9
-$input-background: #fafafa
 
 // Welcome Colors
 $welcome-blue: #178bff
@@ -64,14 +62,31 @@ $success-shade: tint($success, 90%)
 $info-text: shade($info, 60%)
 $info-shade: tint($info, 90%)
 
-$primary-text: shade($primary, 60%)
+$primary-text: shade($primary, 40%)
 $primary-shade: tint($primary, 90%)
+$primary-more-shade: tint($primary, 60%)
 
 $warning-text: shade($warning, 60%)
 $warning-shade: tint($warning, 90%)
 
 $main-text: shade($main, 10%)
 $main-shade: tint($main, 90%)
+
+// input
+$input-border: $border-shade
+$input-background: $background-more-more-tint
+
+$input-hover-border: $border-more-more-shade
+$input-hover-background: $base
+
+$input-selected-background: $primary-shade
+$input-selected-border: $primary
+$input-selected-text: $primary-text
+
+$input-focus-background: $base
+$input-focus-border: $primary
+$input-focus-shadow: rgba($primary, .4) 0 0 1px 2px
+
 
 =default-link
   transition: color .2s ease-in

--- a/app/assets/stylesheets/modules/_choices.sass
+++ b/app/assets/stylesheets/modules/_choices.sass
@@ -32,23 +32,23 @@ body
       text-overflow: ellipsis
       white-space: nowrap
       align-items: center
-      border-color: $main
-      color: $main-text
-      background-color: $main-shade
+      border-color: $input-selected-border
+      color: $input-selected-text
+      background-color: $input-selected-background
       border-radius: 4px
       line-height: calc(1.75rem - .125rem)
       height: 1.75rem
-      padding: 0 2rem 0 .25rem
+      padding: 0 2.25rem 0 .5rem
       margin: .125rem
       &.is-highlighted
-        border-color: $main
-        color: $main-text
-        background-color: $main-shade
+        border-color: $input-selected-border
+        color: $input-selected-text
+        background-color: $input-selected-background
 
   .choices[data-type*=select-multiple] .choices__button,
   .choices[data-type*=text] .choices__button
-    border-left-color: $main
-    color: $main-text
+    border-left-color: $input-selected-border
+    color: $input-selected-text
     height: 100%
     background-image: $choices-icon-cross
     margin: 0 0 0 .5rem
@@ -56,7 +56,7 @@ body
     +position(absolute, right 0, top 0)
     transition: all .2s ease-out
     &:hover
-      background-color: $main
+      background-color: $primary-more-shade
       background-image: $choices-icon-cross-inverse
 
 .choices__list--dropdown .choices__item, .choices__list[aria-expanded] .choices__item

--- a/app/assets/stylesheets/shared/blocks/card-list/_card-list-item.sass
+++ b/app/assets/stylesheets/shared/blocks/card-list/_card-list-item.sass
@@ -125,7 +125,7 @@ a.card-list-item__inner
   &.is-question
     background-color: #de9172
     color: $reversal-text
-  &.is-chatting
+  &.is-chat
     background-color: #9fc593
     color: $reversal-text
   &.is-others

--- a/app/assets/stylesheets/shared/blocks/card-list/_card-list-item.sass
+++ b/app/assets/stylesheets/shared/blocks/card-list/_card-list-item.sass
@@ -115,6 +115,22 @@ a.card-list-item__inner
   .card-list-item.is-user &
     background-color: #7cbd9c
     color: $reversal-text
+  // regular_events
+  &.is-meeting
+    background-color: #7f6fb7
+    color: $reversal-text
+  &.is-reading-circle
+    background-color: #79bcc3
+    color: $reversal-text
+  &.is-question
+    background-color: #de9172
+    color: $reversal-text
+  &.is-chatting
+    background-color: #9fc593
+    color: $reversal-text
+  &.is-others
+    background-color: #f7cd5b
+    color: $default-text
 
 .card-list-item__label-option
   +position(absolute)

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -96,8 +96,8 @@ class RegularEventsController < ApplicationController
     new_event.hold_national_holiday = regular_event.hold_national_holiday
     new_event.start_at = regular_event.start_at
     new_event.end_at = regular_event.end_at
-    new_event.user_ids = regular_event.organizers.map(&:id)
     new_event.category = regular_event.category
+    new_event.user_ids = regular_event.organizers.map(&:id)
 
     flash.now[:notice] = '定期イベントをコピーしました。'
   end

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -57,8 +57,9 @@ class RegularEventsController < ApplicationController
       :hold_national_holiday,
       :start_at,
       :end_at,
+      :category,
       user_ids: [],
-      regular_event_repeat_rules_attributes: %i[id regular_event_id frequency day_of_the_week _destroy]
+      regular_event_repeat_rules_attributes: %i[id regular_event_id frequency day_of_the_week _destroy],
     )
   end
 
@@ -96,6 +97,7 @@ class RegularEventsController < ApplicationController
     new_event.start_at = regular_event.start_at
     new_event.end_at = regular_event.end_at
     new_event.user_ids = regular_event.organizers.map(&:id)
+    new_event.category = regular_event.category
 
     flash.now[:notice] = '定期イベントをコピーしました。'
   end

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -59,7 +59,7 @@ class RegularEventsController < ApplicationController
       :end_at,
       :category,
       user_ids: [],
-      regular_event_repeat_rules_attributes: %i[id regular_event_id frequency day_of_the_week _destroy],
+      regular_event_repeat_rules_attributes: %i[id regular_event_id frequency day_of_the_week _destroy]
     )
   end
 

--- a/app/javascript/regular-event.vue
+++ b/app/javascript/regular-event.vue
@@ -59,8 +59,10 @@ export default {
   },
   computed: {
     categoryClass() {
-      return this.regularEvent.category_class === 'reading_circle' ? 'is-reading-circle' : `is-${this.regularEvent.category_class}`
+      return this.regularEvent.category_class === 'reading_circle'
+        ? 'is-reading-circle'
+        : `is-${this.regularEvent.category_class}`
     }
-  },
+  }
 }
 </script>

--- a/app/javascript/regular-event.vue
+++ b/app/javascript/regular-event.vue
@@ -9,7 +9,7 @@
     // 上記のclassを以下の `.card-list-item__label` に付ける（注: アンスコは使わずハイフンを使う）
     // 例 `.card-list-item__label.is-chat`
     .card-list-item__label
-      | {{ readableCategory }}
+      | {{ regularEvent.category }}
     .card-list-item__rows
       .card-list-item__row
         .card-list-item-title
@@ -63,21 +63,6 @@ export default {
   },
   props: {
     regularEvent: { type: Object, required: true }
-  },
-  computed: {
-    readableCategory() {
-      if (this.regularEvent.category === 0) {
-        return '輪読会'
-      } else if (this.regularEvent.category === 1) {
-        return '雑談'
-      } else if (this.regularEvent.category === 2) {
-        return '質問'
-      } else if (this.regularEvent.category === 3) {
-        return 'MTG'
-      } else {
-        return 'その他'
-      }
-    }
   }
 }
 </script>

--- a/app/javascript/regular-event.vue
+++ b/app/javascript/regular-event.vue
@@ -2,11 +2,7 @@
 .card-list-item(:class='{ "is-wip": regularEvent.wip }')
   .card-list-item__inner
     .card-list-item__user
-      user-icon(
-        :user='regularEvent.user',
-        link_class='card-list-item__user-link',
-        blockClassSuffix='card-list-item'
-      )
+      | {{ readableCategory }}
     .card-list-item__rows
       .card-list-item__row
         .card-list-item-title
@@ -60,6 +56,21 @@ export default {
   },
   props: {
     regularEvent: { type: Object, required: true }
+  },
+  computed: {
+    readableCategory() {
+      if (this.regularEvent.category === 0) {
+        return '輪読会'
+      } else if (this.regularEvent.category === 1) {
+        return '雑談'
+      } else if (this.regularEvent.category === 2) {
+        return '質問'
+      } else if (this.regularEvent.category === 3) {
+        return 'MTG'
+      } else {
+        return 'その他'
+      }
+    }
   }
 }
 </script>

--- a/app/javascript/regular-event.vue
+++ b/app/javascript/regular-event.vue
@@ -1,6 +1,13 @@
 <template lang="pug">
 .card-list-item(:class='{ "is-wip": regularEvent.wip }')
   .card-list-item__inner
+    // is-reading-circle
+    // is-chat
+    // is-question
+    // is-meeting
+    // is-others
+    // 上記のclassを以下の `.card-list-item__label` に付ける（注: アンスコは使わずハイフンを使う）
+    // 例 `.card-list-item__label.is-chat`
     .card-list-item__label
       | {{ readableCategory }}
     .card-list-item__rows

--- a/app/javascript/regular-event.vue
+++ b/app/javascript/regular-event.vue
@@ -1,14 +1,7 @@
 <template lang="pug">
 .card-list-item(:class='{ "is-wip": regularEvent.wip }')
   .card-list-item__inner
-    // is-reading-circle
-    // is-chat
-    // is-question
-    // is-meeting
-    // is-others
-    // 上記のclassを以下の `.card-list-item__label` に付ける（注: アンスコは使わずハイフンを使う）
-    // 例 `.card-list-item__label.is-chat`
-    .card-list-item__label
+    .card-list-item__label(:class='[categoryClass]')
       | {{ regularEvent.category }}
     .card-list-item__rows
       .card-list-item__row
@@ -63,6 +56,11 @@ export default {
   },
   props: {
     regularEvent: { type: Object, required: true }
-  }
+  },
+  computed: {
+    categoryClass() {
+      return `is-${this.regularEvent.category_class}`
+    }
+  },
 }
 </script>

--- a/app/javascript/regular-event.vue
+++ b/app/javascript/regular-event.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .card-list-item(:class='{ "is-wip": regularEvent.wip }')
   .card-list-item__inner
-    .card-list-item__user
+    .card-list-item__label
       | {{ readableCategory }}
     .card-list-item__rows
       .card-list-item__row

--- a/app/javascript/regular-event.vue
+++ b/app/javascript/regular-event.vue
@@ -59,7 +59,7 @@ export default {
   },
   computed: {
     categoryClass() {
-      return `is-${this.regularEvent.category_class}`
+      return this.regularEvent.category_class === 'reading_circle' ? 'is-reading-circle' : `is-${this.regularEvent.category_class}`
     }
   },
 }

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -32,7 +32,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     question: 2,
     meeting: 3,
     others: 4
-  }
+  }, _prefix: true
 
   validates :title, presence: true
   validates :user_ids, presence: true

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -26,6 +26,14 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include Footprintable
   include Reactionable
 
+  enum category: {
+    book_club: 0,
+    chat: 1,
+    question: 2,
+    meeting: 3,
+    others: 4
+  }
+
   validates :title, presence: true
   validates :user_ids, presence: true
   validates :start_at, presence: true

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -27,7 +27,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   include Reactionable
 
   enum category: {
-    book_club: 0,
+    reading_circle: 0,
     chat: 1,
     question: 2,
     meeting: 3,

--- a/app/views/api/regular_events/_regular_event.json.jbuilder
+++ b/app/views/api/regular_events/_regular_event.json.jbuilder
@@ -7,6 +7,5 @@ json.category t("activerecord.enums.regular_event.category.#{regular_event.categ
 json.category_class regular_event.category
 json.comments_count regular_event.comments.size
 json.url regular_event_url(regular_event)
-json.user regular_event.user, partial: "api/users/user", as: :user
 json.organizers regular_event.organizers, partial: "api/users/user", as: :user
 json.holding_cycles regular_event.holding_cycles

--- a/app/views/api/regular_events/_regular_event.json.jbuilder
+++ b/app/views/api/regular_events/_regular_event.json.jbuilder
@@ -8,3 +8,4 @@ json.url regular_event_url(regular_event)
 json.user regular_event.user, partial: "api/users/user", as: :user
 json.organizers regular_event.organizers, partial: "api/users/user", as: :user
 json.holding_cycles regular_event.holding_cycles
+json.category regular_event.category

--- a/app/views/api/regular_events/_regular_event.json.jbuilder
+++ b/app/views/api/regular_events/_regular_event.json.jbuilder
@@ -3,9 +3,10 @@ json.title regular_event.title
 json.start_at_localized l regular_event.start_at, format: :time_only
 json.end_at_localized l regular_event.end_at, format: :time_only
 json.finished regular_event.finished
+json.category t("activerecord.enums.regular_event.category.#{regular_event.category}")
+json.category_class regular_event.category
 json.comments_count regular_event.comments.size
 json.url regular_event_url(regular_event)
 json.user regular_event.user, partial: "api/users/user", as: :user
 json.organizers regular_event.organizers, partial: "api/users/user", as: :user
 json.holding_cycles regular_event.holding_cycles
-json.category t("activerecord.enums.regular_event.category.#{regular_event.category}")

--- a/app/views/api/regular_events/_regular_event.json.jbuilder
+++ b/app/views/api/regular_events/_regular_event.json.jbuilder
@@ -8,4 +8,4 @@ json.url regular_event_url(regular_event)
 json.user regular_event.user, partial: "api/users/user", as: :user
 json.organizers regular_event.organizers, partial: "api/users/user", as: :user
 json.holding_cycles regular_event.holding_cycles
-json.category regular_event.category
+json.category t("activerecord.enums.regular_event.category.#{regular_event.category}")

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -13,13 +13,14 @@
         label.a-form-label
           | カテゴリー
         ul.block-checks.sm-down:is-3-items
-          - %w[輪読会 雑談 質問 MTG その他].each_with_index do |category, i|
+          - RegularEvent.categories.keys.each_with_index do |category, i|
             li.block-checks__item
               .a-block-check.is-radio
                 = f.radio_button :category, i, class: 'a-toggle-checkbox'
                 = f.label :category, category, value: i, class: 'a-block-check__label' do
                   span.a-block-check__name
-                    = category
+                    = t "activerecord.enums.regular_event.category.#{category}"
+
       .form-item
         label.a-form-label
           | 定期開催日

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -13,11 +13,11 @@
         label.a-form-label
           | カテゴリー
         ul.block-checks.sm-down:is-3-items
-          - RegularEvent.categories.keys.each_with_index do |category, i|
+          - RegularEvent.categories.keys.each do |category|
             li.block-checks__item
               .a-block-check.is-radio
-                = f.radio_button :category, i, class: 'a-toggle-checkbox'
-                = f.label :category, category, value: i, class: 'a-block-check__label' do
+                = f.radio_button :category, category, class: 'a-toggle-checkbox'
+                = f.label :category, value: category, class: 'a-block-check__label' do
                   span.a-block-check__name
                     = t "activerecord.enums.regular_event.category.#{category}"
 

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -10,6 +10,10 @@
         = f.select(:user_ids, users_name, { include_hidden: false }, { multiple: true, id: 'js-choices-multiple-select' })
       / TODO 定期開催日のCSSは機能追加が完了してから対応する
       .form-item
+        - %w[輪読会 雑談 質問 MTG その他].each_with_index do |category, i|
+          = f.radio_button :category, i
+          = f.label :category, category, value: i
+      .form-item
         label.a-form-label
           | 定期開催日
         = f.fields_for :regular_event_repeat_rules do |regular_event_repeat_rule|

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -13,7 +13,7 @@
         label.a-form-label
           | カテゴリー
         ul.block-checks.sm-down:is-3-items
-          - RegularEvent.categories.keys.each do |category|
+          - RegularEvent.categories.each_key do |category|
             li.block-checks__item
               .a-block-check.is-radio
                 = f.radio_button :category, category, class: 'a-toggle-checkbox'

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -10,9 +10,16 @@
         = f.select(:user_ids, users_name, { include_hidden: false }, { multiple: true, id: 'js-choices-multiple-select' })
       / TODO 定期開催日のCSSは機能追加が完了してから対応する
       .form-item
-        - %w[輪読会 雑談 質問 MTG その他].each_with_index do |category, i|
-          = f.radio_button :category, i
-          = f.label :category, category, value: i
+        label.a-form-label
+          | カテゴリー
+        ul.block-checks.sm-down:is-3-items
+          - %w[輪読会 雑談 質問 MTG その他].each_with_index do |category, i|
+            li.block-checks__item
+              .a-block-check.is-radio
+                = f.radio_button :category, i, class: 'a-toggle-checkbox'
+                = f.label :category, category, value: i, class: 'a-block-check__label' do
+                  span.a-block-check__name
+                    = category
       .form-item
         label.a-form-label
           | 定期開催日

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -21,7 +21,7 @@
             li.block-checks__item.test-select-emotions
               .a-block-check.is-radio
                 = b.radio_button(class: 'a-toggle-checkbox')
-                label.a-block-check__label.has-image for="report_emotion_#{b.value}"
+                label.a-block-check__label.has-icon for="report_emotion_#{b.value}"
                   = image_tag b.text, id: b.value, alt: b.value, class: 'a-block-check__image'
                   span.a-block-check__name
                     = b.value

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -15,14 +15,8 @@
         = f.label :reported_on, class: 'a-form-label'
         = f.date_field :reported_on, class: 'a-text-input'
       .form-item.is-sm
-<<<<<<< HEAD
-        label.a-form-label
-          = f.label :emotion
-        ul.block-checks.is-3-items.is-inline
-=======
         = f.label :emotion, class: 'a-form-label'
-        ul.form-item__radios.is-inline.is-3-items
->>>>>>> 6f4840748 (定期イベントのカテゴリーのデザイン)
+        ul.block-checks.is-3-items.is-inline
           = f.collection_radio_buttons :emotion, Report.faces, :first, :second do |b|
             li.block-checks__item.test-select-emotions
               .a-block-check.is-radio

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -15,9 +15,14 @@
         = f.label :reported_on, class: 'a-form-label'
         = f.date_field :reported_on, class: 'a-text-input'
       .form-item.is-sm
+<<<<<<< HEAD
         label.a-form-label
           = f.label :emotion
         ul.block-checks.is-3-items.is-inline
+=======
+        = f.label :emotion, class: 'a-form-label'
+        ul.form-item__radios.is-inline.is-3-items
+>>>>>>> 6f4840748 (定期イベントのカテゴリーのデザイン)
           = f.collection_radio_buttons :emotion, Report.faces, :first, :second do |b|
             li.block-checks__item.test-select-emotions
               .a-block-check.is-radio

--- a/app/views/users/form/_os.html.slim
+++ b/app/views/users/form/_os.html.slim
@@ -10,23 +10,24 @@
           li.block-checks__item
             .a-block-check.is-radio
               = f.radio_button :os, 'mac', id: 'mac', class: 'a-toggle-checkbox'
-              label.a-block-check__label.has-image(for='mac')
-                = image_tag('signup/os/intel.svg', class: 'a-block-check__image is-lg')
+              label.a-block-check__label.has-icon.is-ta-left(for='mac')
+                = image_tag('signup/os/intel.svg', class: 'a-block-check__image')
                 span.a-block-check__name
                   = t('activerecord.enums.user.os.mac')
           li.block-checks__item
             .a-block-check.is-radio
               = f.radio_button :os, 'mac_apple', id: 'mac_apple', class: 'a-toggle-checkbox'
-              label.a-block-check__label.has-image(for='mac_apple')
-                = image_tag('signup/os/apple.svg', class: 'a-block-check__image is-lg')
+              label.a-block-check__label.has-icon.is-ta-left(for='mac_apple')
+                = image_tag('signup/os/apple.svg', class: 'a-block-check__image')
                 span.a-block-check__name
                   = t('activerecord.enums.user.os.mac_apple')
         .form-item-group__help
-          label.a-form-help-link.is-danger(for='modal-mac')
-            span.a-form-help-link__label
-              | Intel チップ or Apple チップ の調べ方
-            span.a-help
-              i.fa-solid.fa-question
+          .a-form-help
+            label.a-form-help-link.is-danger(for='modal-mac')
+              span.a-form-help-link__label
+                | Intel チップ or Apple チップ の調べ方
+              span.a-help
+                i.fa-solid.fa-question
 
     .form-item-group
       .form-item-group__header
@@ -37,16 +38,17 @@
           li.block-checks__item
             .a-block-check.is-radio
               = f.radio_button :os, 'windows_wsl2', id: 'windows_wsl2', class: 'a-toggle-checkbox'
-              label.a-block-check__label.has-image(for='windows_wsl2')
-                = image_tag('signup/os/windows.svg', class: 'a-block-check__image is-lg')
+              label.a-block-check__label.has-icon.is-ta-left(for='windows_wsl2')
+                = image_tag('signup/os/windows.svg', class: 'a-block-check__image')
                 span.a-block-check__name
                   = t('activerecord.enums.user.os.windows_wsl2')
         .form-item-group__help
-          label.a-form-help-link.is-danger(for='modal-win')
-            span.a-form-help-link__label
-              | WSL2とは？
-            span.a-help
-              i.fa-solid.fa-question
+          .a-form-help
+            label.a-form-help-link.is-danger(for='modal-win')
+              span.a-form-help-link__label
+                | WSL2とは？
+              span.a-help
+                i.fa-solid.fa-question
 
     .form-item-group
       .form-item-group__header
@@ -57,16 +59,17 @@
           li.block-checks__item
             .a-block-check.is-radio
               = f.radio_button :os, 'linux', id: 'linux', class: 'a-toggle-checkbox'
-              label.a-block-check__label.has-image(for='linux')
-                = image_tag('signup/os/linux.svg', class: 'a-block-check__image is-lg')
+              label.a-block-check__label.has-icon.is-ta-left(for='linux')
+                = image_tag('signup/os/linux.svg', class: 'a-block-check__image')
                 span.a-block-check__name
                   = t('activerecord.enums.user.os.linux')
         .form-item-group__help
-          label.a-form-help-link.is-danger(for='modal-linux')
-            span.a-form-help-link__label
-              | 注意
-            span.a-help
-              i.fa-solid.fa-question
+          .a-form-help
+            label.a-form-help-link.is-danger(for='modal-linux')
+              span.a-form-help-link__label
+                | Linuxで学習をする際の注意
+              span.a-help
+                i.fa-solid.fa-question
 
 = render '/shared/modal',
   id: 'modal-mac',

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -41,6 +41,7 @@ ja:
       reference_book: 参考書籍
       campaign: お試し延長
       book: 参考書籍
+      regular_event: 定期イベント
     attributes:
       user:
         login_name: アカウント

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -253,7 +253,7 @@ ja:
           complete: 完了
       regular_event:
         category:
-          book_club: 輪読会
+          reading_circle: 輪読会
           chat: 雑談
           question: 質問
           meeting: MTG

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -251,6 +251,13 @@ ja:
           started: 着手
           submitted: 提出
           complete: 完了
+      regular_event:
+        category:
+          book_club: 輪読会
+          chat: 雑談
+          question: 質問
+          meeting: MTG
+          others: その他
     errors:
       models:
         campaign:

--- a/db/fixtures/regular_events.yml
+++ b/db/fixtures/regular_events.yml
@@ -6,6 +6,7 @@ regular_event1:
   start_at: <%= Time.zone.local(2020, 1, 1, 15, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 16, 0, 0) %>
   user: komagata
+  category: 3
 
 regular_event2:
   title: 質問・雑談タイム
@@ -15,6 +16,7 @@ regular_event2:
   start_at: <%= Time.zone.local(2020, 1, 1, 16, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 17, 0, 0) %>
   user: machida
+  category: 2
 
 regular_event3:
   title: 自作サービス進捗報告会
@@ -24,6 +26,7 @@ regular_event3:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  category: 3
 
 regular_event4:
   title: チェリー本輪読会
@@ -70,4 +73,5 @@ regular_event<%= i %>:
   finished: true
   hold_national_holiday: true
   user: komagata
+  category: 1
 <% end %>

--- a/db/migrate/20220629033255_add_category_to_regular_events.rb
+++ b/db/migrate/20220629033255_add_category_to_regular_events.rb
@@ -1,0 +1,5 @@
+class AddCategoryToRegularEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :regular_events, :category, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -421,6 +421,7 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "wip", default: false, null: false
+    t.integer "category", default: 0, null: false
     t.index ["user_id"], name: "index_regular_events_on_user_id"
   end
 

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -6,6 +6,7 @@ regular_event1:
   start_at: <%= Time.zone.local(2020, 1, 1, 15, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 16, 0, 0) %>
   user: komagata
+  category: 3
 
 regular_event2:
   title: 質問・雑談タイム
@@ -15,6 +16,7 @@ regular_event2:
   start_at: <%= Time.zone.local(2020, 1, 1, 16, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 17, 0, 0) %>
   user: machida
+  category: 2
 
 regular_event3:
   title: 自作サービス進捗報告会
@@ -24,6 +26,7 @@ regular_event3:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  category: 3
 
 regular_event4:
   title: チェリー本輪読会
@@ -70,4 +73,5 @@ regular_event<%= i %>:
   finished: true
   hold_national_holiday: true
   user: komagata
+  category: 1
 <% end %>

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -116,7 +116,7 @@ class CurrentUserTest < ApplicationSystemTestCase
   test 'update os' do
     kimura = users(:kimura)
     visit_with_auth '/current_user/edit', 'kimura'
-    find('label', text: 'Linux').click
+    first('label', text: 'Linux').click
 
     click_on '更新する'
     assert_text 'ユーザー情報を更新しました。'

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -9,6 +9,7 @@ class RegularEventsTest < ApplicationSystemTestCase
       fill_in 'regular_event[title]', with: '質問相談タイム'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-1').click
+      choose 'regular_event_category_2'
       fill_in 'regular_event[start_at]', with: Time.zone.parse('16:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('17:00')
       fill_in 'regular_event[description]', with: '質問相談タイムです'
@@ -78,5 +79,31 @@ class RegularEventsTest < ApplicationSystemTestCase
       click_link '削除'
     end
     assert_text '定期イベントを削除しました。'
+  end
+
+  test 'show the category of the regular event on regular events list' do
+    RegularEvent.destroy_all
+
+    visit_with_auth '/regular_events/new', 'komagata'
+    5.times do |value|
+      fill_in 'regular_event[title]', with: '定期イベント・カテゴリーのテスト'
+      first('.choices__inner').click
+      find('#choices--js-choices-multiple-select-item-choice-1').click
+      choose "regular_event_category_#{value}"
+      fill_in 'regular_event[wday]', with: '木曜日'
+      fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
+      fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
+      fill_in 'regular_event[description]', with: '定期イベント・カテゴリーのテストです'
+      click_button '作成'
+    end
+
+    visit '/regular_events'
+    within '.card-list.a-card' do
+      assert_text '輪読会'
+      assert_text '雑談'
+      assert_text '質問'
+      assert_text 'MTG'
+      assert_text 'その他'
+    end
   end
 end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -94,7 +94,8 @@ class RegularEventsTest < ApplicationSystemTestCase
       find('#choices--js-choices-multiple-select-item-choice-1').click
       find('label', text: '主催者').click
       find('label', text: I18n.t("activerecord.enums.regular_event.category.#{category}")).click
-      fill_in 'regular_event[wday]', with: '木曜日'
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('木曜日')
       fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
       fill_in 'regular_event[description]', with: '定期イベント・カテゴリーのテストです'

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -63,6 +63,8 @@ class RegularEventsTest < ApplicationSystemTestCase
       fill_in 'regular_event[title]', with: 'チェリー本輪読会（修正）'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-2').click
+      find('label', text: '主催者').click
+      choose 'regular_event_category_0'
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('第2')
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('水曜日')
       fill_in 'regular_event[start_at]', with: Time.zone.parse('20:00')

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -9,6 +9,7 @@ class RegularEventsTest < ApplicationSystemTestCase
       fill_in 'regular_event[title]', with: '質問相談タイム'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-1').click
+      find('label', text: '主催者').click
       choose 'regular_event_category_2'
       fill_in 'regular_event[start_at]', with: Time.zone.parse('16:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('17:00')
@@ -84,17 +85,19 @@ class RegularEventsTest < ApplicationSystemTestCase
   test 'show the category of the regular event on regular events list' do
     RegularEvent.destroy_all
 
-    visit_with_auth '/regular_events/new', 'komagata'
     5.times do |value|
+      visit_with_auth '/regular_events/new', 'komagata'
       fill_in 'regular_event[title]', with: '定期イベント・カテゴリーのテスト'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-1').click
+      find('label', text: '主催者').click
       choose "regular_event_category_#{value}"
       fill_in 'regular_event[wday]', with: '木曜日'
       fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
       fill_in 'regular_event[description]', with: '定期イベント・カテゴリーのテストです'
       click_button '作成'
+      assert_text '定期イベントを作成しました。'
     end
 
     visit '/regular_events'

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -10,7 +10,7 @@ class RegularEventsTest < ApplicationSystemTestCase
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-1').click
       find('label', text: '主催者').click
-      choose 'regular_event_category_2'
+      find('label', text: '質問').click
       fill_in 'regular_event[start_at]', with: Time.zone.parse('16:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('17:00')
       fill_in 'regular_event[description]', with: '質問相談タイムです'
@@ -64,7 +64,7 @@ class RegularEventsTest < ApplicationSystemTestCase
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-2').click
       find('label', text: '主催者').click
-      choose 'regular_event_category_0'
+      find('label', text: '輪読会').click
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('第2')
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('水曜日')
       fill_in 'regular_event[start_at]', with: Time.zone.parse('20:00')
@@ -87,13 +87,13 @@ class RegularEventsTest < ApplicationSystemTestCase
   test 'show the category of the regular event on regular events list' do
     RegularEvent.destroy_all
 
-    5.times do |value|
+    RegularEvent.categories.each_key do |category|
       visit_with_auth '/regular_events/new', 'komagata'
       fill_in 'regular_event[title]', with: '定期イベント・カテゴリーのテスト'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-1').click
       find('label', text: '主催者').click
-      choose "regular_event_category_#{value}"
+      find('label', text: I18n.t("activerecord.enums.regular_event.category.#{category}")).click
       fill_in 'regular_event[wday]', with: '木曜日'
       fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -85,30 +85,22 @@ class RegularEventsTest < ApplicationSystemTestCase
   end
 
   test 'show the category of the regular event on regular events list' do
-    RegularEvent.destroy_all
-
-    RegularEvent.categories.each_key do |category|
-      visit_with_auth '/regular_events/new', 'komagata'
-      fill_in 'regular_event[title]', with: '定期イベント・カテゴリーのテスト'
-      first('.choices__inner').click
-      find('#choices--js-choices-multiple-select-item-choice-1').click
-      find('label', text: '主催者').click
-      find('label', text: I18n.t("activerecord.enums.regular_event.category.#{category}")).click
-      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
-      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('木曜日')
-      fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
-      fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
-      fill_in 'regular_event[description]', with: '定期イベント・カテゴリーのテストです'
-      click_button '作成'
-      assert_text '定期イベントを作成しました。'
-    end
+    visit_with_auth '/regular_events/new', 'komagata'
+    fill_in 'regular_event[title]', with: '定期イベント・カテゴリーのテスト'
+    first('.choices__inner').click
+    find('#choices--js-choices-multiple-select-item-choice-1').click
+    find('label', text: '主催者').click
+    find('label', text: 'その他').click
+    first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
+    first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('木曜日')
+    fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
+    fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
+    fill_in 'regular_event[description]', with: '定期イベント・カテゴリーのテストです'
+    click_button '作成'
+    assert_text '定期イベントを作成しました。'
 
     visit '/regular_events'
     within '.card-list.a-card' do
-      assert_text '輪読会'
-      assert_text '雑談'
-      assert_text '質問'
-      assert_text 'MTG'
       assert_text 'その他'
     end
   end


### PR DESCRIPTION
## Issue

- #4924 

## 概要
定期イベント作成ページで定期イベントのカテゴリーを選択し登録できるようにしました。また、その定期イベントのカテゴリーを、定期イベント一覧に表示できるようにしました。
#### <カテゴリー>
- 輪読会
- 雑談
- 質問
- MTG
- その他

## 変更確認方法
1. ブランチ`feature/add-categories-of-regular-event`をローカルに取り込んでください。
2. `bin/rails s`でローカル環境を立ち上げてください。
3. 任意のユーザーでログインしhttp://localhost:3000/regular_events/new  にアクセスし、定期イベントをそれぞれのカテゴリー（上記記載）から選択して作成してください。
4. http://localhost:3000/regular_events にアクセスし、５つのカテゴリーが`3`で作成した定期イベントのデータに紐づいてそれぞれ表示されていることを確認してください。
5. 作成したものの中からカテゴリーが輪読会以外のものを選びクリックし、その定期イベントの詳細画面に進んでください。
6. その画面の右上に表示されているコピーボタンをクリックしてください。

<img width="1072" alt="スクリーンショット 2022-07-27 23 09 10" src="https://user-images.githubusercontent.com/76685187/181268689-0467abea-db45-4aec-b268-7088a60680f9.png">

7. コピーされた定期イベントのフォームでカテゴリー（ラジオボタン）が元のデータのものと同じものにチェックが入っているか確認してください。


## 変更前
### 定期イベント作成
<img width="831" alt="スクリーンショット 2022-07-28 12 29 23" src="https://user-images.githubusercontent.com/76685187/181414281-d866f107-9a79-4c8e-b7ec-8464dacc0dd6.png">

### 定期イベント一覧
<img width="1011" alt="スクリーンショット 2022-07-28 12 31 20" src="https://user-images.githubusercontent.com/76685187/181414471-4e9f232b-47c5-4a48-98c2-c6664b113a63.png">

### 定期イベントコピー
<img width="807" alt="スクリーンショット 2022-07-28 12 32 41" src="https://user-images.githubusercontent.com/76685187/181414587-5a53a3d6-7035-400b-8ed9-5d47d01adf3a.png">


## 変更後
### 定期イベント作成
<img width="747" alt="スクリーンショット 2022-07-28 12 19 40" src="https://user-images.githubusercontent.com/76685187/181413319-4e8238dc-11bc-475e-abc8-49109e190928.png">

### 定期イベント一覧
<img width="1014" alt="スクリーンショット 2022-07-28 12 22 05" src="https://user-images.githubusercontent.com/76685187/181413587-6626326a-459a-47fd-a5f8-bdb82d59488d.png">

### 定期イベントコピー
<img width="831" alt="スクリーンショット 2022-07-28 12 25 39" src="https://user-images.githubusercontent.com/76685187/181413894-b8d60a44-cc8a-4938-be56-623baa7ebfeb.png">

