### PR TITLE
Q&Aのページ見出し（h2）を修正した

### DIFF
--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -2,7 +2,8 @@
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title Q&A
+      h2.page-header__title
+        | Q&A
       .page-header-actions
         .page-header-actions__items
           .page-header-actions__item

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -2,7 +2,7 @@
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title = title
+      h2.page-header__title Q&A
       .page-header-actions
         .page-header-actions__items
           .page-header-actions__item

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -298,7 +298,7 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'not show a WIP question on the unsolved Q&A list page' do
     visit_with_auth questions_path(target: 'not_solved'), 'kimura'
     assert_no_text 'wipテスト用の質問(wip中)'
-    assert_text '未解決のQ&A'
+    assert_selector 'h2', text: 'Q&A'
   end
 
   test "visit user profile page when clicked on user's name on question" do


### PR DESCRIPTION
## Issue

- #5106 
- #5107

## 概要

- Q&Aのページ見出しを「Q&A」とする
  - Issueの要件について認識違いがあったため、マージ済みの変更を修正するためのプルリクエストになります
  - #5115
  - #5162 

## 確認方法

1. `feature/change-questions-h2-title`をローカルに取り込む
2. `rails s`で起動する
1. 任意のユーザーでログインする
2. http://localhost:3000/questions?target=not_solved にアクセスする
1. http://localhost:3000/questions?target=solved にアクセスする

## 変更前

ページの見出しが「未解決の質問一覧」になっている
![image](https://user-images.githubusercontent.com/33394676/177680869-0544db46-588d-4998-ba2e-8f660c91d9d4.png)

ページの見出しが「解決済みのQ&A」になっている
![image](https://user-images.githubusercontent.com/33394676/177680965-c9e0c039-8d52-4ce5-a858-6e409890d2b3.png)

## 変更後
![image](https://user-images.githubusercontent.com/33394676/177680539-8d6562fe-67f2-4beb-9949-7f74126f13f7.png)

![image](https://user-images.githubusercontent.com/33394676/177680373-bd444431-81c1-4e05-8eb1-25fe11924fa5.png)
