### PR TITLE
企業一覧、企業個別の現役生の数字から卒業生分を除いた

### DIFF
--- a/app/views/companies/_user_counts.html.slim
+++ b/app/views/companies/_user_counts.html.slim
@@ -18,7 +18,7 @@
         dt.company-counts__item-label
           | 現役生
         dd.company-counts__item-value
-          = users.unretired.trainees.size
+          = users.students_and_trainees.size
     - unless users.admins.size.zero?
       .company-counts__item
         .company-counts__item-inner

--- a/app/views/companies/_user_counts.html.slim
+++ b/app/views/companies/_user_counts.html.slim
@@ -16,7 +16,7 @@
     .company-counts__item
       .company-counts__item-inner
         dt.company-counts__item-label
-          | 研修生
+          | 現役生
         dd.company-counts__item-value
           = users.unretired.trainees.size
     - unless users.admins.size.zero?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -542,6 +542,7 @@ class UserTest < ActiveSupport::TestCase
       users(:komagata).reports.order(reported_on: :desc).limit(1).pick(:id),
       users(:komagata).raw_last_sad_report_id
   end
+
   test 'students人数が整合する' do
     # User.count = 33
     # User.mentor.count = 4 ①
@@ -553,7 +554,7 @@ class UserTest < ActiveSupport::TestCase
     # User.trainees.count = 3　⑤
     # User.trainees.graduated.count = 0　③と⑤で2度カウントしている分
     # User.trainees.retired.count = 1　④と⑤で2度カウントしている分
-    assert_equal 33 - (4 + 3 - 2 + 2 + 2 + 4 + 3 + 0 - 1), User.students.count
+    assert_equal 33 - (4 + 3 - 2 + 2 + 2 + 4 + 3 + 0 - 1), User.students.size
   end
 
   test 'students_and_trainees人数が整合する' do
@@ -561,16 +562,16 @@ class UserTest < ActiveSupport::TestCase
     # User.trainees.count = 3
     # User.trainees.graduated.count = 0
     # User.trainees.retired.count = 1
-    assert_equal 18 + 3 - (0 + 1), User.students_and_trainees.count
+    assert_equal 18 + 3 - (0 + 1), User.students_and_trainees.size
   end
 
   test '企業の現役生数が整合する' do
-    assert_equal 1, User.students_and_trainees.where(company_id: 1022975240).count
+    assert_equal 1, User.students_and_trainees.where(company_id: 1_022_975_240).size
   end
 
   test '研修が終わるとstudents_and_traineesメソッドにカウントされない' do
-    users(:kensyu).update!(retired_on: "2022-07-01")
+    users(:kensyu).update!(retired_on: '2022-07-01')
 
-    assert_equal 0, User.students_and_trainees.where(company_id: 1022975240).count
+    assert_equal 0, User.students_and_trainees.where(company_id: 1_022_975_240).size
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -542,4 +542,35 @@ class UserTest < ActiveSupport::TestCase
       users(:komagata).reports.order(reported_on: :desc).limit(1).pick(:id),
       users(:komagata).raw_last_sad_report_id
   end
+  test 'students人数が整合する' do
+    # User.count = 33
+    # User.mentor.count = 4 ①
+    # User.admins.count = 3　②
+    # User.admins.mentor.count = 2　①と②で2度カウントしている分
+    # User.advisers.count = 2
+    # User.graduated.count = 2　③
+    # User.retired.count = 4　④
+    # User.trainees.count = 3　⑤
+    # User.trainees.graduated.count = 0　③と⑤で2度カウントしている分
+    # User.trainees.retired.count = 1　④と⑤で2度カウントしている分
+    assert_equal 33 - (4 + 3 - 2 + 2 + 2 + 4 + 3 + 0 - 1), User.students.count
+  end
+
+  test 'students_and_trainees人数が整合する' do
+    # User.students.count = 18
+    # User.trainees.count = 3
+    # User.trainees.graduated.count = 0
+    # User.trainees.retired.count = 1
+    assert_equal 18 + 3 - (0 + 1), User.students_and_trainees.count
+  end
+
+  test '企業の現役生数が整合する' do
+    assert_equal 1, User.students_and_trainees.where(company_id: 1022975240).count
+  end
+
+  test '研修が終わるとstudents_and_traineesメソッドにカウントされない' do
+    users(:kensyu).update!(retired_on: "2022-07-01")
+
+    assert_equal 0, User.students_and_trainees.where(company_id: 1022975240).count
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -543,7 +543,7 @@ class UserTest < ActiveSupport::TestCase
       users(:komagata).raw_last_sad_report_id
   end
 
-  test 'students人数が整合する' do
+  test 'number_of_students_matches' do
     # User.count = 33
     # User.mentor.count = 4 ①
     # User.admins.count = 3　②
@@ -557,7 +557,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 33 - (4 + 3 - 2 + 2 + 2 + 4 + 3 + 0 - 1), User.students.size
   end
 
-  test 'students_and_trainees人数が整合する' do
+  test 'number_of_students_and_trainees_matches' do
     # User.students.count = 18
     # User.trainees.count = 3
     # User.trainees.graduated.count = 0
@@ -565,11 +565,11 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 18 + 3 - (0 + 1), User.students_and_trainees.size
   end
 
-  test '企業の現役生数が整合する' do
+  test 'number_of_students_and_trainees_in_the_company_matches' do
     assert_equal 1, User.students_and_trainees.where(company_id: 1_022_975_240).size
   end
 
-  test '研修が終わるとstudents_and_traineesメソッドにカウントされない' do
+  test 'retired_trainees_are_not_counted' do
     users(:kensyu).update!(retired_on: '2022-07-01')
 
     assert_equal 0, User.students_and_trainees.where(company_id: 1_022_975_240).size

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -543,35 +543,15 @@ class UserTest < ActiveSupport::TestCase
       users(:komagata).raw_last_sad_report_id
   end
 
-  test 'number_of_students_matches' do
-    # User.count = 33
-    # User.mentor.count = 4 ①
-    # User.admins.count = 3　②
-    # User.admins.mentor.count = 2　①と②で2度カウントしている分
-    # User.advisers.count = 2
-    # User.graduated.count = 2　③
-    # User.retired.count = 4　④
-    # User.trainees.count = 3　⑤
-    # User.trainees.graduated.count = 0　③と⑤で2度カウントしている分
-    # User.trainees.retired.count = 1　④と⑤で2度カウントしている分
-    assert_equal 33 - (4 + 3 - 2 + 2 + 2 + 4 + 3 + 0 - 1), User.students.size
-  end
-
-  test 'number_of_students_and_trainees_matches' do
-    # User.students.count = 18
-    # User.trainees.count = 3
-    # User.trainees.graduated.count = 0
-    # User.trainees.retired.count = 1
-    assert_equal 18 + 3 - (0 + 1), User.students_and_trainees.size
-  end
-
-  test 'number_of_students_and_trainees_in_the_company_matches' do
-    assert_equal 1, User.students_and_trainees.where(company_id: 1_022_975_240).size
-  end
-
-  test 'retired_trainees_are_not_counted' do
+  test 'students_and_trainees_method_does_not_include_retired_trainee' do
+    target = User.students_and_trainees
+    assert_includes(target, users(:kensyu))
     users(:kensyu).update!(retired_on: '2022-07-01')
+    assert_not_includes(target, users(:kensyu))
+  end
 
-    assert_equal 0, User.students_and_trainees.where(company_id: 1_022_975_240).size
+  test 'students_and_trainees_method_does_not_include_graduates' do
+    target = User.students_and_trainees
+    assert_not_includes(target, users(:sotugyou_with_job))
   end
 end


### PR DESCRIPTION
## Issue

- #5163

### 前提
- 企業所属の受講生は研修生と呼ぶ
- 研修生には研修修了生が含まれる
- 現役の受講生を現役生と呼ぶ
- 研修生フラグのつけ忘れ（研修生なのに現役生表記）があり得る
- 研修終了生は退会の扱いである


### 実装
- 研修生フラグのつけ忘れがあり得るため、研修生の数から修了生を引くのではなく、
企業所属の現役生をカウントすることで、得るべき数字を出している

### その他、下記を確認している
- 管理者権限でログインして現役生の一人を退会にすると、MaruMaru Inc.の現役生数が一人減り21人になる
- 1人退会処理をしても、MaruMaru Inc.企業全員の人数は25で変わらない
- MaruMaru Inc.全員の人数の25は、メンターと研修修了生と管理者を合わせた数字より2少ないが、これは管理者兼メンターが2人いるためで、数字は整合している


## 実装確認方法

1. ブランチ`feature/exclude-graduates-from-trainees-number`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. ユーザー権限に制限無し
4. http://localhost:3000/companies
　http://127.0.0.1:3000/companies/636488896
　http://127.0.0.1:3000/companies/636488896/users
で、
- 研修生表記が現役生に統一されていること
- 現役生の数字が整合していることを確認
　

## 変更前
![現役生_before](https://user-images.githubusercontent.com/82737807/177956030-57f26dc1-aaca-4c65-8e2e-e93a5be65be7.jpg)
## 変更後
![現役生_after](https://user-images.githubusercontent.com/82737807/177956117-ff3f07d8-45ec-49cf-a83e-af8f92a07aca.jpg)

