### PR TITLE
提出物一覧ページでコメントしたユーザーのアイコンの色が適切に表示されないバグを修正

### DIFF
--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -71,7 +71,7 @@
                     :title='user.icon_title',
                     :alt='user.icon_title',
                     :src='user.avatar_url',
-                    :class='[roleClass]'
+                    :class='[`is-${user.primary_role}`]'
                   )
 
             .card-list-item-meta__item(

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -44,6 +44,7 @@ json.comments do
       json.avatar_url user.avatar_url
       json.url user.url
       json.icon_title user.icon_title
+      json.primary_role user.primary_role
     end
   end
 end


### PR DESCRIPTION
提出物一覧ページで、提出物にコメントしたユーザーのアイコンの色が正しく表示されなくなっていました。コメントしたユーザーのロールの色ではなく、提出物の作成者のロールの色でアイコンが表示されていたようです。コメントしたユーザーのロールに合わせた色でアイコンを表示するようにしました。(ちなみに余白が余分に空いているのは、この PR とは関係なさそう...？)

| before | after |
| - | - |
| ![localhost_3000_products_self_assigned](https://user-images.githubusercontent.com/7645585/178025023-484f9d0f-d17c-441b-9c34-89f97b33979e.png) | ![localhost_3000_products_self_assigned (1)](https://user-images.githubusercontent.com/7645585/178025033-6afa6362-598a-49b4-999c-22b74ec4c448.png) |