### PR TITLE
Markdownの外部リンクを別タブで開くようにした

### DIFF
--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -10,6 +10,7 @@ import MarkdownItTaskListsInitializer from 'markdown-it-task-lists-initializer'
 import MarkdownItHeadings from 'markdown-it-headings'
 import MarkDownItContainerMessage from 'markdown-it-container-message'
 import MarkDownItContainerDetails from 'markdown-it-container-details'
+import MarkDownItLinkAttributes from 'markdown-it-link-attributes'
 
 export default class {
   replace(selector) {
@@ -37,6 +38,15 @@ export default class {
     md.use(MarkdownItHeadings)
     md.use(MarkDownItContainerMessage)
     md.use(MarkDownItContainerDetails)
+    md.use(MarkDownItLinkAttributes, {
+      matcher(href) {
+        return !href.startsWith("http://localhost:3000")      
+      },
+      attrs: {
+        target: "_blank",
+        rel: "noopener",
+      },
+    })
 
     return md.render(text)
   }

--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -40,12 +40,16 @@ export default class {
     md.use(MarkDownItContainerDetails)
     md.use(MarkDownItLinkAttributes, {
       matcher(href) {
-        return !href.startsWith("http://localhost:3000")      
+        return !(
+          href.startsWith(location.origin) ||
+          href.startsWith('/') ||
+          href.startsWith('#')
+        )
       },
       attrs: {
-        target: "_blank",
-        rel: "noopener",
-      },
+        target: '_blank',
+        rel: 'noopener'
+      }
     })
 
     return md.render(text)

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -11,6 +11,7 @@ import UserIconRenderer from 'user-icon-renderer'
 import autosize from 'autosize'
 import MarkDownItContainerMessage from 'markdown-it-container-message'
 import MarkDownItContainerDetails from 'markdown-it-container-details'
+import MarkDownItLinkAttributes from 'markdown-it-link-attributes'
 
 export default class {
   static initialize(selector) {
@@ -72,7 +73,8 @@ export default class {
           MarkdownItUserIcon,
           MarkdownItTaskLists,
           MarkDownItContainerMessage,
-          MarkDownItContainerDetails
+          MarkDownItContainerDetails,
+          MarkDownItLinkAttributes
         ],
         markdownOptions: MarkdownOption
       })

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "markdown-it-anchor": "^8.4.1",
     "markdown-it-container": "^3.0.0",
     "markdown-it-emoji": "^1.4.0",
+    "markdown-it-link-attributes": "^4.0.0",
     "markdown-it-regexp": "^0.4.0",
     "markdown-it-task-lists": "^2.1.1",
     "mem": "^4.0.0",

--- a/test/system/markdown_link_test.rb
+++ b/test/system/markdown_link_test.rb
@@ -14,22 +14,22 @@ class MarkdownLinkTest < ApplicationSystemTestCase
     first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
     first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
-    assert_equal find("a", text:"http://www.google.co.jp")[:href], "http://www.google.co.jp/"
-    assert_equal find("a", text:"http://www.google.co.jp")[:target], "_blank"
+    assert_equal find('a', text: 'http://www.google.co.jp')[:href], 'http://www.google.co.jp/'
+    assert_equal find('a', text: 'http://www.google.co.jp')[:target], '_blank'
   end
 
   test 'internal link on same tab' do
     visit_with_auth 'reports/new', 'kimura'
     within('form[name=report]') do
       fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: 'http://localhost:3000/reports')
+      fill_in('report[description]', with: (current_host + ":#{Capybara.current_session.server.port}"))
     end
     first('.learning-time').all('.learning-time__started-at select')[0].select('07')
     first('.learning-time').all('.learning-time__started-at select')[1].select('30')
     first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
     first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
-    assert_equal find("a", text:"http://localhost:3000/reports")[:href], "http://localhost:3000/reports"
-    assert_not_equal find("a", text:"http://localhost:3000/reports")[:target], "_blank"
+    assert_equal find('a', text: current_host)[:href], (current_host + ":#{Capybara.current_session.server.port}/")
+    assert_not_equal find('a', text: current_host)[:target], '_blank'
   end
 end

--- a/test/system/markdown_link_test.rb
+++ b/test/system/markdown_link_test.rb
@@ -19,21 +19,23 @@ class MarkdownLinkTest < ApplicationSystemTestCase
   end
 
   test 'internal link on same tab' do
+    current_origin = "http://#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}"
     visit_with_auth 'reports/new', 'kimura'
     within('form[name=report]') do
       fill_in('report[title]', with: 'internal link test')
-      fill_in('report[description]', with: (current_host + ":#{Capybara.current_session.server.port}"))
+      fill_in('report[description]', with: current_origin)
     end
     first('.learning-time').all('.learning-time__started-at select')[0].select('07')
     first('.learning-time').all('.learning-time__started-at select')[1].select('30')
     first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
     first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
-    assert_equal find('a', text: current_host)[:href], (current_host + ":#{Capybara.current_session.server.port}/")
-    assert_not_equal find('a', text: current_host)[:target], '_blank'
+    assert_equal find('a', text: current_origin)[:href], "#{current_origin}/"
+    assert_not_equal find('a', text: current_origin)[:target], '_blank'
   end
 
   test 'relative link on same tab' do
+    current_origin = "http://#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}"
     visit_with_auth 'reports/new', 'kimura'
     within('form[name=report]') do
       fill_in('report[title]', with: 'relative link test')
@@ -44,7 +46,7 @@ class MarkdownLinkTest < ApplicationSystemTestCase
     first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
     first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
-    assert_equal find('a', text: 'relative_link')[:href], (current_host + ":#{Capybara.current_session.server.port}/reports")
+    assert_equal find('a', text: 'relative_link')[:href], "#{current_origin}/reports"
     assert_not_equal find('a', text: 'relative_link')[:target], '_blank'
   end
 

--- a/test/system/markdown_link_test.rb
+++ b/test/system/markdown_link_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class MarkdownLinkTest < ApplicationSystemTestCase
+  test 'external link on another tab' do
+    visit_with_auth 'reports/new', 'kimura'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: 'http://www.google.co.jp')
+    end
+    first('.learning-time').all('.learning-time__started-at select')[0].select('07')
+    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
+    first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
+    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
+    click_button '提出'
+    assert_equal find("a", text:"http://www.google.co.jp")[:href], "http://www.google.co.jp/"
+    assert_equal find("a", text:"http://www.google.co.jp")[:target], "_blank"
+  end
+
+  test 'internal link on same tab' do
+    visit_with_auth 'reports/new', 'kimura'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: 'http://localhost:3000/reports')
+    end
+    first('.learning-time').all('.learning-time__started-at select')[0].select('07')
+    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
+    first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
+    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
+    click_button '提出'
+    assert_equal find("a", text:"http://localhost:3000/reports")[:href], "http://localhost:3000/reports"
+    assert_not_equal find("a", text:"http://localhost:3000/reports")[:target], "_blank"
+  end
+end

--- a/test/system/markdown_link_test.rb
+++ b/test/system/markdown_link_test.rb
@@ -6,7 +6,7 @@ class MarkdownLinkTest < ApplicationSystemTestCase
   test 'external link on another tab' do
     visit_with_auth 'reports/new', 'kimura'
     within('form[name=report]') do
-      fill_in('report[title]', with: 'test title')
+      fill_in('report[title]', with: 'external link test')
       fill_in('report[description]', with: 'http://www.google.co.jp')
     end
     first('.learning-time').all('.learning-time__started-at select')[0].select('07')
@@ -21,7 +21,7 @@ class MarkdownLinkTest < ApplicationSystemTestCase
   test 'internal link on same tab' do
     visit_with_auth 'reports/new', 'kimura'
     within('form[name=report]') do
-      fill_in('report[title]', with: 'test title')
+      fill_in('report[title]', with: 'internal link test')
       fill_in('report[description]', with: (current_host + ":#{Capybara.current_session.server.port}"))
     end
     first('.learning-time').all('.learning-time__started-at select')[0].select('07')
@@ -31,5 +31,35 @@ class MarkdownLinkTest < ApplicationSystemTestCase
     click_button '提出'
     assert_equal find('a', text: current_host)[:href], (current_host + ":#{Capybara.current_session.server.port}/")
     assert_not_equal find('a', text: current_host)[:target], '_blank'
+  end
+
+  test 'relative link on same tab' do
+    visit_with_auth 'reports/new', 'kimura'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'relative link test')
+      fill_in('report[description]', with: '[relative_link](/reports)')
+    end
+    first('.learning-time').all('.learning-time__started-at select')[0].select('07')
+    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
+    first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
+    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
+    click_button '提出'
+    assert_equal find('a', text: 'relative_link')[:href], (current_host + ":#{Capybara.current_session.server.port}/reports")
+    assert_not_equal find('a', text: 'relative_link')[:target], '_blank'
+  end
+
+  test 'anchor link on same tab' do
+    visit_with_auth 'reports/new', 'kimura'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'anchor link test')
+      fill_in('report[description]', with: "[anchor_link](#anchortext)\n## <a id='anchortext' />anchor")
+    end
+    first('.learning-time').all('.learning-time__started-at select')[0].select('07')
+    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
+    first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
+    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
+    click_button '提出'
+    assert_equal find('a', text: 'anchor_link')[:href], "#{current_url}#anchortext"
+    assert_not_equal find('a', text: 'anchor_link')[:target], '_blank'
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4909,6 +4909,11 @@ markdown-it-emoji@^1.4.0:
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
   integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
 
+markdown-it-link-attributes@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-link-attributes/-/markdown-it-link-attributes-4.0.0.tgz#188fdba1cae0d11dc80cc841ae9a7919ad8a9be3"
+  integrity sha512-ssjxSLlLfQBkX6BvAx1rCPrx7ZoK91llQQvS3P7KXvlbnVD34OUkfXwWecN7su/7mrI/HOW0RI5szdJOIqYC3w==
+
 markdown-it-regexp@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz#d64d713eecec55ce4cfdeb321750ecc099e2c2dc"


### PR DESCRIPTION
## Issue

- #4968

## 概要

ブートキャンプのアプリではnpmの`markdown-it`を使ってMarkdownの実装をしており、今回はその拡張プラグインである`markdown-it-link-attributes`を使い、Markdownで書かれた外部リンクが別タブで開くようにした。
### 参考
- markdown-it-link-attributesのREADME
https://github.com/crookedneighbor/markdown-it-link-attributes

## 変更確認方法

1. ブランチ`feature/open-external-link-of-markdown-in-another-tab`をローカルに取り込む
2. `markdown-it-link-attributes`をインストールするため、`yarn install`を実行する
3. `bin/rails s`でローカル環境を立ち上げる
4. 任意のユーザーでログインする
5. 日報 > +日報作成 から日報作成画面に入り、「内容」に下記のテキストをコピー&ペーストする。(タイトル等他の入力項目は適当でOK)
6. 各種リンクの挙動を確認する(外部リンクのみ別タブで開き、他は同じタブ内で開くかどうか)
```
内部リンク
http://localhost:3000/reports

外部リンク
http://www.google.co.jp

[スラスタリンク](/reports)

[アンカーリンク](#anchortext)
## <a id="anchortext" />アンカー
```
### 変更後の動作
![markdown-link](https://user-images.githubusercontent.com/96340764/178208148-720f183a-3fef-4c5e-a9c4-36e112869917.gif)

