### PR TITLE
新規登録ユーザーが初回ログインするまでの間、表示されない一部のページを表示されるようにした

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -389,7 +389,7 @@ class User < ApplicationRecord
   end
 
   def away?
-    last_activity_at <= 10.minutes.ago
+    last_activity_at && (last_activity_at <= 10.minutes.ago)
   end
 
   def completed_percentage
@@ -414,7 +414,7 @@ class User < ApplicationRecord
   end
 
   def active?
-    last_activity_at > 1.month.ago
+    last_activity_at && (last_activity_at > 1.month.ago)
   end
 
   def checked_product_of?(*practices)

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -70,7 +70,8 @@
           td.admin-table__item-value.is-text-align-center
             = user.discord_account.presence || '-'
           td.admin-table__item-value.is-text-align-center
-            = l user.last_activity_at
+            - if user.last_activity_at?
+              = l user.last_activity_at
           td.admin-table__item-value.is-text-align-center
             = l user.created_at
           td.admin-table__item-value.is-text-align-center

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -22,4 +22,5 @@
                     span.a-meta__label
                       = User.human_attribute_name :last_activity_at
                     span.a-meta__value
-                      = l user.last_activity_at
+                      - if user.last_activity_at?
+                        = l user.last_activity_at

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -54,7 +54,8 @@
         |
         = User.human_attribute_name :last_activity_at
       .user-metas__item-value
-        = l user.last_activity_at
+        - if user.last_activity_at?
+          = l user.last_activity_at
     .user-metas__item
       .user-metas__item-label
         | 卒業後のゴール

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -159,3 +159,7 @@ talk_twitterinvalid:
 talk_nocompanykensyu:
   user: nocompanykensyu
   unreplied: false
+
+talk_neverlogin:
+  user: neverlogin
+  unreplied: false

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -920,3 +920,18 @@ nocompanykensyu: # 所属企業のない研修生
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
   last_activity_at: "2014-01-01 00:00:11"
+
+neverlogin: # 1度もログインしたことがないユーザー
+  login_name: neverlogin
+  email: neverlogin@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 根場亜　呂具印
+  name_kana:  ネバー　ログイン
+  description: "ユーザー登録後、1度もログインしていないユーザーです。"
+  course: course1
+  os: mac
+  experience: rails
+  free: true
+  updated_at: "2022-07-11 00:00:00"
+  created_at: "2022-07-11 00:00:00"

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -120,3 +120,7 @@ talk30:
 talk31:
   user: nocompanykensyu
   unreplied: false
+
+talk32:
+  user: neverlogin
+  unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -769,3 +769,18 @@ nocompanykensyu: # 所属企業のない研修生
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
   last_activity_at: "2014-01-01 00:00:11"
+
+neverlogin: # 1度もログインしたことがないユーザー
+  login_name: neverlogin
+  email: neverlogin@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 根場亜　呂具印
+  name_kana:  ネバー　ログイン
+  description: "ユーザー登録後、1度もログインしていないユーザーです。"
+  course: course1
+  os: mac
+  experience: rails
+  free: true
+  updated_at: "2022-07-11 00:00:00"
+  created_at: "2022-07-11 00:00:00"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -26,6 +26,10 @@ class UserTest < ActiveSupport::TestCase
     travel_to Time.zone.local(2014, 2, 2, 0, 0, 0) do
       assert_not users(:machida).active?
     end
+
+    travel_to Time.zone.local(2022, 7, 11, 0, 0, 0) do
+      assert_not users(:neverlogin).active?
+    end
   end
 
   test '#prefecture_name' do

--- a/test/system/notification/graduation_test.rb
+++ b/test/system/notification/graduation_test.rb
@@ -14,12 +14,10 @@ class Notification::GraduationTest < ApplicationSystemTestCase
 
   test 'notify mentor when student graduate' do
     users(:kimura).update!(last_activity_at: Time.current)
-    # kimura が一番上に表示されるようにソート
-    path = 'admin/users?direction=desc&order_by=last_activity_at&target=student_and_trainee'
-    visit_with_auth path, 'komagata'
 
+    visit_with_auth user_path(users(:kimura)), 'komagata'
     accept_confirm do
-      first('.a-button.is-sm.is-primary', text: '卒業').click
+      find('.a-button.is-sm.is-danger.is-block', text: '卒業にする').click
     end
     logout
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -96,6 +96,13 @@ class UsersTest < ApplicationSystemTestCase
 
     visit_with_auth "/users/#{users(:kimura).id}", 'hatsuno'
     assert_no_text '最終活動日時'
+
+    visit_with_auth "/users/#{users(:neverlogin).id}", 'komagata'
+    assert_text '最終活動日時'
+    assert_no_text '2022年07月11日(月) 09:00'
+
+    visit_with_auth "/users/#{users(:neverlogin).id}", 'hatsuno'
+    assert_no_text '最終活動日時'
   end
 
   test 'show inactive message on users page' do


### PR DESCRIPTION
## 関連Issue
- #2231
    - #5207

## 関連PR
- #5081
- #5176

## 概要

### 現状
新規ユーザーが登録されて初回ログインするまでの間、一部のページが正しく表示されない不具合が発生しうるため、対処する。

正しく表示されないページは以下の通り。
1. ユーザー一覧ページ(/users)　※全ユーザー
2. 新規登録されたユーザーのユーザー詳細ページ(/users/:id)　※管理者orメンターでログイン時
3. 管理ページのユーザー一覧(/admin/users)　※管理者でログイン時

【追記(7/14 )】
　初回ログインするまでの間は、`最終活動日時`の欄は何も表示しない仕様とする。

### 原因
新規ユーザーが登録されて初回ログインするまでの間は、usersテーブルのlast_activity_atカラムの値がnullの状態であり、現状のプログラムではnullに対応できておらず、エラーが発生してしまう。
(初回ログイン以降は、last_activity_atカラムにアクセス日時が登録されるため、問題は発生しない)

## 環境準備
1. ブランチ`bug/can't-refer-to-user-info-that-never-logged-in`をローカルに取り込む。
2. `bin/rails db:reset`でDBを作り直しする。
3. `bin/rails s`でローカル環境を立ち上げる。
4. フィヨルドブートキャンプ参加登録(/users/new)にアクセスし、必要な情報を入力し「参加する」をクリックし、新規ユーザーを登録する。(有効なカード番号は、[sign\_up\_test\.rb](https://github.com/fjordllc/bootcamp/blob/552625fbb4b1b84e43f1f8d467ea5f1a89060ae5/test/system/sign_up_test.rb#L32) を参照)

## 確認方法と確認内容

#### 1. ユーザー一覧ページの場合
1. ログインページ(/login)にアクセスし、任意のユーザーでログインする。
2. ユーザー一覧ページ(/users)にアクセス。
3. 「ロード中」と表示されず、正しく表示されることを確認する。

![Cursor_and__development__ユーザー一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/11376040/178867844-4521c26d-8a14-4b3a-b73c-af5928c24825.png)


#### 2. 新規登録されたユーザーのユーザー詳細ページの場合
1. ログインページ(/login)にアクセスし、管理者orメンターでログインする。
2. 新規登録されたユーザーのユーザー詳細ページ(/users/:id)にアクセス。
3. 正しく表示されることを確認する。
4. 1度もログインしていないユーザーの場合、`最終活動日時`が何も表示されていないことを確認する。

![Cursor_and__development__neverlogin___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/11376040/178872716-6717bca2-a816-4590-9747-fb4f83f2d171.png)

#### 3. 管理ページのユーザー一覧の場合
1. ログインページ(/login)にアクセスし、管理者でログインする。
2. 管理ページのユーザー一覧(/admin/users)にアクセス。
3. 正しく表示されることを確認する。
4. 1度もログインしていないユーザーの場合、`最終活動日時`が何も表示されていないことを確認する。

![Cursor_and__development__管理ページ___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/11376040/178874236-8e1e6f34-1bb8-457e-b942-c8bd9f353a15.png)