### PR TITLE
相談部屋にコメントがあった際の通知のURLに`#latest-comment`を指定した

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -24,7 +24,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def came_comment
     @user = @receiver
     link = "/#{@comment.commentable_type.downcase.pluralize}/#{@comment.commentable.id}"
-    @notification = @user.notifications.find_by(link: link)
+    @notification = @user.notifications.find_by(link: link) || @user.notifications.find_by(link: "#{link}#latest-comment")
     mail to: @user.email, subject: "[bootcamp] #{@message}"
   end
 

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -105,7 +105,7 @@ class Comment::AfterCreateCallback
     ChatNotifier.message(<<~TEXT, webhook_url: ENV['DISCORD_ADMIN_WEBHOOK_URL'])
       相談部屋にて#{comment.user.login_name}さんからコメントがありました。
       本文： #{comment.description}
-      URL： https://bootcamp.fjord.jp/talks/#{comment.commentable_id}
+      URL： https://bootcamp.fjord.jp/talks/#{comment.commentable_id}#latest-comment
     TEXT
   end
 end

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -27,10 +27,12 @@ class Comment::AfterCreateCallback
   private
 
   def notify_comment(comment)
+    commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
     NotificationFacade.came_comment(
       comment,
       comment.receiver,
-      "相談部屋で#{comment.sender.login_name}さんからコメントがありました。"
+      "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      "#{commentable_path}#latest-comment"
     )
   end
 
@@ -84,10 +86,12 @@ class Comment::AfterCreateCallback
     User.admins.each do |admin_user|
       next if comment.sender == admin_user
 
+      commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
       NotificationFacade.came_comment(
         comment,
         admin_user,
-        "#{comment.commentable.user.login_name}さんの相談部屋で#{comment.sender.login_name}さんからコメントが届きました。"
+        "#{comment.commentable.user.login_name}さんの相談部屋で#{comment.sender.login_name}さんからコメントが届きました。",
+        "#{commentable_path}#latest-comment"
       )
     end
   end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class NotificationFacade
-  def self.came_comment(comment, receiver, message)
-    ActivityNotifier.with(comment: comment, receiver: receiver, message: message).came_comment.notify_now
+  def self.came_comment(comment, receiver, message, link)
+    ActivityNotifier.with(comment: comment, receiver: receiver, message: message, link: link).came_comment.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -54,13 +54,14 @@ class ActivityNotifier < ApplicationNotifier
     comment = params[:comment]
     receiver = params[:receiver]
     message = params[:message]
+    link = params[:link]
 
     notification(
       body: message,
       kind: :came_comment,
       receiver: receiver,
       sender: comment.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(comment.commentable),
+      link: link,
       read: false
     )
   end

--- a/app/views/notification_mailer/came_comment.html.slim
+++ b/app/views/notification_mailer/came_comment.html.slim
@@ -1,2 +1,2 @@
-= render 'notification_mailer_template', title: @message, link_url: notification_url(@notification, anchor: "comment_#{@comment.id}"), link_text: 'コメントへ' do
+= render 'notification_mailer_template', title: @message, link_url: notification_url(@notification, anchor: 'latest-comment'), link_text: 'コメントへ' do
   = md2html(@comment.description)

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -26,8 +26,10 @@ class Notification::TalkTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'machida'
 
     within first('.card-list-item.is-unread') do
-      assert_text 'kimuraさんの相談部屋でkimuraさんからコメントが届きました。'
+      click_link 'kimuraさんの相談部屋でkimuraさんからコメントが届きました。'
     end
+
+    assert_current_path(/#latest-comment$/, url: true)
   end
 
   test 'Admin except myself receive a notification when other admin comments on a talk room' do
@@ -68,8 +70,10 @@ class Notification::TalkTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'kimura'
 
     within first('.card-list-item.is-unread') do
-      assert_text '相談部屋でkomagataさんからコメントがありました。'
+      click_link '相談部屋でkomagataさんからコメントがありました。'
     end
+
+    assert_current_path(/#latest-comment$/, url: true)
   end
 
   test 'The number of unreplied comments is displayed in the global navigation and unreplied tab of the talks room' do


### PR DESCRIPTION
## Issue

- #4770 

## 概要

- 相談部屋にコメントがあった際の通知（Web通知、メール通知、Discord通知）のリンク先に`#latest-comment`を指定して、相談部屋の最下部に遷移するようにした

## 確認方法

### 事前準備

1. `change-notification-link-when-talk-comment-added`をローカルに取り込む
2. `rails s`で起動する

### 管理者への通知

1. `kimura`でログインする
2. 相談部屋に新しいコメントを投稿する
3. `machida`でログインする
4. Web通知
   1. `http://localhost:3000/notifications?status=unread`にアクセスする
   2. 「kimuraさんの相談部屋でkimuraさんからコメントが届きました。」をクリックする
   3. 相談部屋の最下部に遷移することを確認する
5. メール通知
   1. `http://localhost:3000/letter_opener/`にアクセスする
   2. 件名が`[bootcamp] kimuraさんの相談部屋でkimuraさんからコメントが届きました。`、あて先が`machidanohimitsu@gmail.com`のメールを開く
   3. 「コメント」をクリックする
   4. 相談部屋の最下部に遷移することを確認する
6. Discord通知
   1. 本番環境のみで動作するため、Files changedにてご確認をお願いします

### 受講生への通知

1. `machida`でログインする
2. 相談部屋に新しいコメントを投稿する
3. `kimura`でログインする
4. Web通知
   1. `http://localhost:3000/notifications?status=unread`にアクセスする
   2. 「相談部屋でmachidaさんからコメントがありました。」をクリックする
   3. 相談部屋の最下部に遷移することを確認する
5. メール通知
   1. `http://localhost:3000/letter_opener/`にアクセスする
   2. 件名が`[bootcamp] 相談部屋でmachidaさんからコメントがありました。`、あて先が`kimura@fjord.jp`のメールを開く
   3. 「コメント」をクリックする
   4. 相談部屋の最下部に遷移することを確認する

## 変更前

- 当該の通知をクリックすると相談部屋の最上部に遷移する
![image](https://user-images.githubusercontent.com/33394676/178199273-f86004f0-86e6-4312-a916-ca0174184251.png)

## 変更後

- 当該の通知をクリックすると相談部屋の最下部に遷移する
![image](https://user-images.githubusercontent.com/33394676/178199157-41dc1cd6-5d68-41ec-9899-5e21392dc12c.png)
