### PR TITLE
ダッシュボードのGithubの草にローディング中の表示がされるようにした

### DIFF
--- a/app/assets/stylesheets/atoms/_a-placeholder.sass
+++ b/app/assets/stylesheets/atoms/_a-placeholder.sass
@@ -1,6 +1,6 @@
 @keyframes loadingNow
   0%
-    opacity: .5
+    opacity: .4
   100%
     opacity: 1
 

--- a/app/assets/stylesheets/blocks/user/_user-grass.sass
+++ b/app/assets/stylesheets/blocks/user/_user-grass.sass
@@ -2,7 +2,8 @@
   padding: 1rem
   +media-breakpoint-down(sm)
     padding: .75rem
-  svg
+  svg,
+  .user-grass__image
     font-size: .625rem
     max-width: 100%
     +margin(vertical, -1.75rem)
@@ -12,6 +13,8 @@
       +margin(vertical, 0)
     +media-breakpoint-up(lg)
       +margin(vertical, -.75rem)
+    &.is-loading
+      animation: loadingNow .5s ease infinite alternate
 
 .user-grass-nav
   font-size: .875rem

--- a/app/javascript/github_grass.js
+++ b/app/javascript/github_grass.js
@@ -22,6 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
         .catch((error) => {
           console.warn(error)
         })
+        .then(() => {
+          document.querySelector('.js-user-grass__loading').remove()
+        })
     })
   }
 })

--- a/app/javascript/github_grass.js
+++ b/app/javascript/github_grass.js
@@ -19,11 +19,13 @@ document.addEventListener('DOMContentLoaded', () => {
         .then((text) => {
           grass.innerHTML = text
         })
+        .then(() => {
+          document
+            .querySelector('.js-github-grass + .js-user-grass__loading')
+            .remove()
+        })
         .catch((error) => {
           console.warn(error)
-        })
-        .then(() => {
-          document.querySelector('.js-user-grass__loading').remove()
         })
     })
   }

--- a/app/views/users/_github_grass.html.slim
+++ b/app/views/users/_github_grass.html.slim
@@ -1,7 +1,8 @@
 .a-card
   .card-header.is-sm
     h2.card-header__title GitHub
-  .user-grass__loading
+
   .user-grass
     = link_to user_github_url(user), target: '_blank', rel: 'noopener', class: 'user-grass__link' do
       .js-github-grass(data-name="#{user.github_account}")
+      = image_tag('loading/github-grass-loading.svg', class: 'user-grass__image is-loading js-user-grass__loading')

--- a/app/views/users/_github_grass.html.slim
+++ b/app/views/users/_github_grass.html.slim
@@ -1,6 +1,7 @@
 .a-card
   .card-header.is-sm
     h2.card-header__title GitHub
+  .user-grass__loading
   .user-grass
     = link_to user_github_url(user), target: '_blank', rel: 'noopener', class: 'user-grass__link' do
       .js-github-grass(data-name="#{user.github_account}")


### PR DESCRIPTION
## Issue

- #4541 

## 概要

ダッシュボードにあるGithubの草のローディングが完了するまでに、ローディング中のアニメーション表示がされるようにした

## 変更確認方法

1. ブランチ`feature/display_loading_github_grass_on_dashboard`をローカルに取り込む
2. `rails s`でサーバーを起動する
3. ユーザー`komagata`でログインする
4. ダッシュボードのGithubの草のところに、ローディング中の表示がされているか確認する(ローディングが終わっていたらリロードしてみる)

## 変更前
<img width="676" alt="スクリーンショット 2022-06-14 17 59 30" src="https://user-images.githubusercontent.com/96340764/178494360-3205d9f9-2dda-4654-a981-d4c6e8be6ef8.png">

## 変更後
<img width="663" alt="スクリーンショット 2022-07-15 15 19 19" src="https://user-images.githubusercontent.com/96340764/179222570-038e61ff-eb61-4ae3-9dd9-7a1bed73bd8e.png">

