### PR TITLE
日報個別ページの直近の日報一覧のユーザーアイコンを非表示にした

### DIFF
--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -81,7 +81,7 @@
 </template>
 
 <script>
-import CommentUserIcon from '../comment-user-icon'
+import CommentUserIcon from 'comment-user-icon'
 
 export default {
   components: {

--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -81,7 +81,7 @@
 </template>
 
 <script>
-import CommentUserIcon from 'comment-user-icon.vue'
+import CommentUserIcon from '../comment-user-icon'
 
 export default {
   components: {

--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .card-list-item(:class='wipClass')
   .card-list-item__inner
-    .card-list-item__user(v-if='userIcon')
+    .card-list-item__user(v-if='displayUserIcon')
       a.card-list-item__user-link(:href='report.user.url')
         img.card-list-item__user-icon.a-user-icon(
           :src='report.user.avatar_url',
@@ -90,7 +90,7 @@ export default {
   props: {
     report: { type: Object, required: true },
     currentUserId: { type: Number, required: true },
-    userIcon: { type: Boolean }
+    displayUserIcon: { type: Boolean }
   },
   computed: {
     roleClass() {

--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -89,12 +89,8 @@ export default {
   },
   props: {
     report: { type: Object, required: true },
-    currentUserId: { type: Number, required: true }
-  },
-  data() {
-    return {
-      userIcon: true
-    }
+    currentUserId: { type: Number, required: true },
+    userIcon: { type: Boolean }
   },
   computed: {
     roleClass() {
@@ -105,18 +101,6 @@ export default {
     },
     emotionImg() {
       return `/images/emotion/${this.report.emotion}.svg`
-    }
-  },
-  created() {
-    const currentPath = location.pathname
-    const regex = /\/reports\/\d+/
-    if (regex.test(currentPath)) {
-      this.showUserIcon()
-    }
-  },
-  methods: {
-    showUserIcon() {
-      this.userIcon = false
     }
   }
 }

--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .card-list-item(:class='wipClass')
   .card-list-item__inner
-    .card-list-item__user
+    .card-list-item__user(v-if='userIcon')
       a.card-list-item__user-link(:href='report.user.url')
         img.card-list-item__user-icon.a-user-icon(
           :src='report.user.avatar_url',
@@ -91,6 +91,11 @@ export default {
     report: { type: Object, required: true },
     currentUserId: { type: Number, required: true }
   },
+  data() {
+    return {
+      userIcon: true
+    }
+  },
   computed: {
     roleClass() {
       return `is-${this.report.user.primary_role}`
@@ -100,6 +105,18 @@ export default {
     },
     emotionImg() {
       return `/images/emotion/${this.report.emotion}.svg`
+    }
+  },
+  created () {
+    const currentPath = location.pathname
+    const regex = /\/reports\/\d+/
+    if (regex.test(currentPath)){
+      this.showUserIcon()
+    }
+  },
+  methods: {
+    showUserIcon() {
+      this.userIcon = false
     }
   }
 }

--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -107,10 +107,10 @@ export default {
       return `/images/emotion/${this.report.emotion}.svg`
     }
   },
-  created () {
+  created() {
     const currentPath = location.pathname
     const regex = /\/reports\/\d+/
-    if (regex.test(currentPath)){
+    if (regex.test(currentPath)) {
       this.showUserIcon()
     }
   },

--- a/app/javascript/components/reports.vue
+++ b/app/javascript/components/reports.vue
@@ -9,7 +9,7 @@
       :key='report.id',
       :report='report',
       :current-user-id='currentUserId',
-      :user-icon='displayUserIcon'
+      :display-user-icon='displayUserIcon'
     )
 .page-content.reports(v-else)
   nav.pagination(v-if='totalPages > 1')
@@ -23,7 +23,7 @@
         :key='report.id',
         :report='report',
         :current-user-id='currentUserId',
-        :user-icon='displayUserIcon'
+        :display-user-icon='displayUserIcon'
       )
     unconfirmed-link(v-if='isUncheckedReportsPage', label='未チェックの日報を一括で開く')
   .o-empty-message(v-else-if='reports.length === 0 || isUncheckedReportsPage')

--- a/app/javascript/components/reports.vue
+++ b/app/javascript/components/reports.vue
@@ -8,7 +8,8 @@
       v-for='report in reports',
       :key='report.id',
       :report='report',
-      :current-user-id='currentUserId'
+      :current-user-id='currentUserId',
+      :user-icon='displayUserIcon'
     )
 .page-content.reports(v-else)
   nav.pagination(v-if='totalPages > 1')
@@ -21,7 +22,8 @@
         v-for='report in reports',
         :key='report.id',
         :report='report',
-        :current-user-id='currentUserId'
+        :current-user-id='currentUserId',
+        :user-icon='displayUserIcon'
       )
     unconfirmed-link(v-if='isUncheckedReportsPage', label='未チェックの日報を一括で開く')
   .o-empty-message(v-else-if='reports.length === 0 || isUncheckedReportsPage')
@@ -63,6 +65,9 @@ export default {
     limit: {
       type: String,
       default: null
+    },
+    displayUserIcon: {
+      type: Boolean
     }
   },
   data() {

--- a/app/javascript/components/reports.vue
+++ b/app/javascript/components/reports.vue
@@ -67,7 +67,8 @@ export default {
       default: null
     },
     displayUserIcon: {
-      type: Boolean
+      type: Boolean,
+      default: true
     }
   },
   data() {

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -161,7 +161,7 @@ header.page-header
                     | 提出物
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
-                div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-display-user-icon="")
+                div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
                 .user-info
                   = render 'users/user_secret_attributes', user: @report.user
@@ -181,7 +181,7 @@ header.page-header
                           .o-empty-message__text
                             | 提出物はまだありません。
         - else
-          div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-display-user-icon="")
+          div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
 
 - if flash[:notify_help] && flash[:celebrate_report_count]
     = render '/shared/modal', id: 'modal-notify-help', modal_title: '🎉 おめでとう！', auto_show: true

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -161,7 +161,7 @@ header.page-header
                     | 提出物
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
-                div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10")
+                div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-display-user-icon="")
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
                 .user-info
                   = render 'users/user_secret_attributes', user: @report.user
@@ -181,7 +181,7 @@ header.page-header
                           .o-empty-message__text
                             | 提出物はまだありません。
         - else
-          div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10")
+          div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-display-user-icon="")
 
 - if flash[:notify_help] && flash[:celebrate_report_count]
     = render '/shared/modal', id: 'modal-notify-help', modal_title: '🎉 おめでとう！', auto_show: true

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -630,4 +630,9 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/reports/new?reported_on=2022-1-1', 'komagata'
     assert_equal '2022-01-01', find('#report_reported_on').value
   end
+
+  test 'hide user icon from recent reports in report show' do
+    visit_with_auth report_path(reports(:report1)), 'komagata'
+    assert_no_selector('.card-list-item__user')
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -635,4 +635,9 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth report_path(reports(:report1)), 'komagata'
     assert_no_selector('.card-list-item__user')
   end
+
+  test 'display user icon in reports' do
+    visit_with_auth reports_path, 'komagata'
+    assert_selector('.card-list-item__user')
+  end
 end


### PR DESCRIPTION
## Issue
- [日報個別ページの右にある直近の日報一覧のユーザーアイコンは非表示にしたい。 · Issue \#4628 ](https://github.com/fjordllc/bootcamp/issues/4628)

## 概要
- 日報の個別ページの右側に表示される、直近の日報一覧のユーザーアイコンを非表示にした。

## 変更前
<img width="1422" alt="作業前" src="https://user-images.githubusercontent.com/70277776/178653059-d8fee9ef-744b-4f57-8056-1c17a2afddaa.png">

## 変更後
<img width="1418" alt="作業後" src="https://user-images.githubusercontent.com/70277776/178653092-a6e51f0c-708e-426a-a8e5-6ca2c0f35a6a.png">

## 変更確認方法
1. ブランチ`feature/hide-user-icon-from-recent-reports-list-in-report-show`をローカルに取り込み、ローカル環境で起動する。
1. 適当なユーザーでログインする。（今回はkimuraでログイン）
1. 日報個別ページ（今回は`http://localhost:3000/reports/730242988`）に移動し、右側の「直近の日報」のユーザーアイコンが非表示になっているのを確認する。

## コードの共通化
- 今回はURLから非表示の判定をしているが、次の関連Issueにてコードを共通化する予定。
関連Issue: https://github.com/fjordllc/bootcamp/issues/5224