### PR TITLE
mac_m1をmac_appleに変更した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
 
   enum os: {
     mac: 0,
-    mac_m1: 2,
+    mac_apple: 2,
     linux: 1,
     windows_wsl2: 3
   }, _prefix: true

--- a/app/views/users/form/_os.html.slim
+++ b/app/views/users/form/_os.html.slim
@@ -15,12 +15,12 @@
                 .image-check__name
                   = t('activerecord.enums.user.os.mac')
           li.form-radio
-            = f.radio_button :os, 'mac_m1', id: 'mac_m1', class: 'a-toggle-checkbox'
-            label.form-radio__label(for='mac_m1')
+            = f.radio_button :os, 'mac_apple', id: 'mac_apple', class: 'a-toggle-checkbox'
+            label.form-radio__label(for='mac_apple')
              .image-check
                 = image_tag('signup/os/apple.svg', class: 'image-check__image')
                 .image-check__name
-                  = t('activerecord.enums.user.os.mac_m1')
+                  = t('activerecord.enums.user.os.mac_apple')
         .form-item-group__help
           label.a-form-help-link.is-danger(for='modal-mac')
             span.a-form-help-link__label

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -225,7 +225,7 @@ ja:
           windows_wsl2: Windows(WSL2)
           mac: Mac（Intel チップ）
           linux: Linux
-          mac_m1: Mac（Apple チップ）
+          mac_apple: Mac（Apple チップ）
         study_place:
           local: フィヨルドブートキャンプオフィス
           remote: 自宅

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -429,7 +429,7 @@ sumi:
   description: "testユーザーです。"
   course: course1
   job: office_worker
-  os: mac_m1
+  os: mac_apple
   experience: html_css
   job_seeker: true
   job_seeking: true
@@ -497,7 +497,7 @@ take:
   description: "testユーザーです。"
   course: course1
   job: vacation
-  os: mac_m1
+  os: mac_apple
   experience: rails
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-01-01 00:00:21"
@@ -653,7 +653,7 @@ fujiyasu:
   description: "testユーザーです。"
   course: course1
   job: unemployed
-  os: mac_m1
+  os: mac_apple
   experience: inexperienced
   unsubscribe_email_token: iIT7nlauOm7TOhQFoLs3UA
   updated_at: "2021-01-01 00:00:28"


### PR DESCRIPTION
## Issue

- #5205

## 概要

- M2チップ対応に合わせて、コード中でシンボルが`mac_m1`となっている個所を`mac_apple`に変更した
  - UI側の変更は #5216 （町田さん）にて対応済み

## 確認方法

画面表示上の変更はないため、以下のような観点でご確認いただくようになるかと思います。
- コードの変更箇所が妥当か
- 既存の画面表示に影響が出ていないか

1. `feature/change-m1-chip-to-apple-chip-in-users-os`をローカルに取り込む
2. `rails s`で起動する

## 画面上の表示個所

- メンターでログインした時のユーザー情報
  http://localhost:3000/users/784971462
  ![image](https://user-images.githubusercontent.com/33394676/178920787-882f7878-62c7-49fd-9857-ee846eaba97d.png)
- 会員登録画面
  http://localhost:3000/users/new
  ![image](https://user-images.githubusercontent.com/33394676/178921023-e1ed6976-6bf4-4853-bd99-12e45953a9fc.png)
- 登録情報変更画面
  http://localhost:3000/current_user/edit
  ![image](https://user-images.githubusercontent.com/33394676/178969304-4cce7c5a-03d0-40cb-81de-4eb11e9dd4f1.png)
