### PR TITLE
新規ユーザー登録時にメンターにメール通知およびサイト内通知するようにした

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,6 +76,7 @@ class UsersController < ApplicationController
   def create_free_user!
     if @user.save
       UserMailer.welcome(@user).deliver_now
+      notify_to_mentors(@user)
       notify_to_chat(@user)
       redirect_to root_url, notice: 'サインアップメールをお送りしました。メールからサインアップを完了させてください。'
     else
@@ -115,6 +116,7 @@ class UsersController < ApplicationController
 
       if @user.save
         UserMailer.welcome(@user).deliver_now
+        notify_to_mentors(@user)
         notify_to_chat(@user)
         redirect_to root_url, notice: 'サインアップメールをお送りしました。メールからサインアップを完了させてください。'
       else
@@ -123,6 +125,12 @@ class UsersController < ApplicationController
     end
   end
   # rubocop:enable Metrics/MethodLength, Metrics/BlockLength
+
+  def notify_to_mentors(user)
+    User.mentor.each do |mentor_user|
+      NotificationFacade.signed_up(user, mentor_user)
+    end
+  end
 
   def notify_to_chat(user)
     ChatNotifier.message "#{user.name}さんが新たなメンバーとしてJOINしました🎉\r#{url_for(user)}"

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -176,4 +176,12 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     subject = "[FBC] #{@sender.login_name}さんが休会しました。"
     mail to: @user.email, subject: subject
   end
+
+  # required params: sender, receiver
+  def signed_up
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:signed_up])
+    subject = "[FBC] #{@sender.login_name}さんが新しく入会しました！"
+    mail to: @user.email, subject: subject
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -35,7 +35,8 @@ class Notification < ApplicationRecord
     assigned_as_checker: 16,
     product_update: 17,
     graduated: 18,
-    hibernated: 19
+    hibernated: 19,
+    signed_up: 20
   }
 
   scope :unreads, -> { where(read: false) }

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -210,4 +210,14 @@ class NotificationFacade
   def self.tomorrow_regular_event(event)
     DiscordNotifier.with(event: event).tomorrow_regular_event.notify_now
   end
+
+  def self.signed_up(sender, receiver)
+    ActivityNotifier.with(sender: sender, receiver: receiver).signed_up.notify_now
+    return unless receiver.mail_notification? && !receiver.retired?
+
+    NotificationMailer.with(
+      sender: sender,
+      receiver: receiver
+    ).signed_up.deliver_later(wait: 5)
+  end
 end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -171,4 +171,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def signed_up(params = {})
+    params.merge!(@params)
+    sender = params[:sender]
+    receiver = params[:receiver]
+
+    notification(
+      body: "🎉 #{sender.login_name}さんが新しく入会しました！",
+      kind: :signed_up,
+      sender: sender,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(sender),
+      read: false
+    )
+  end
 end

--- a/app/views/notification_mailer/signed_up.html.slim
+++ b/app/views/notification_mailer/signed_up.html.slim
@@ -1,0 +1,1 @@
+= render 'notification_mailer_template', title: "#{@sender.login_name}さんが新しく入会しました！", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -27,4 +27,14 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   teardown do
     ActionMailer::Base.deliveries.clear
   end
+
+  def vcr_options
+    {
+      record: :once,
+      match_requests_on: [
+        :method,
+        VCR.request_matchers.uri_without_param(:source)
+      ]
+    }
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -356,4 +356,32 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] sotugyouさんが卒業しました。', email.subject
     assert_match(/卒業/, email.body.to_s)
   end
+
+  test 'signed up' do
+    user = users(:hajime)
+    mentor = users(:mentormentaro)
+    Notification.create!(
+      kind: 20,
+      sender: user,
+      user: mentor,
+      message: '🎉 hajimeさんが新しく入会しました！',
+      link: "/users/#{user.id}",
+      read: false
+    )
+    mailer = NotificationMailer.with(
+      sender: user,
+      receiver: mentor
+    ).signed_up
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['mentormentaro@fjord.jp'], email.to
+    assert_equal '[FBC] hajimeさんが新しく入会しました！', email.subject
+    assert_match(/入会/, email.body.to_s)
+  end
 end

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -81,4 +81,16 @@ class ActivityNotifierTest < ActiveSupport::TestCase
       notification.notify_now
     end
   end
+
+  test '#signed_up' do
+    notification = ActivityNotifier.with(sender: users(:hajime), receiver: users(:mentormentaro)).signed_up
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      notification.notify_now
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      notification.notify_later
+    end
+  end
 end

--- a/test/system/notification/signed_up_test.rb
+++ b/test/system/notification/signed_up_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Notification::SignedUpTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
+  test 'notify mentors when signed up as adviser' do
+    visit '/users/new?role=adviser'
+
+    email = 'haruko@example.com'
+
+    within 'form[name=user]' do
+      fill_in 'user[login_name]', with: 'haruko'
+      fill_in 'user[email]', with: email
+      fill_in 'user[name]', with: 'テスト 春子'
+      fill_in 'user[name_kana]', with: 'テスト ハルコ'
+      fill_in 'user[description]', with: 'テスト春子です。'
+      fill_in 'user[password]', with: 'testtest'
+      fill_in 'user[password_confirmation]', with: 'testtest'
+      find('label', text: 'アンチハラスメントポリシーに同意').click
+      find('label', text: '利用規約に同意').click
+    end
+
+    click_button 'アドバイザー登録'
+    assert_text 'サインアップメールをお送りしました。メールからサインアップを完了させてください。'
+    assert User.find_by(email: email).adviser?
+
+    visit_with_auth notifications_path, 'komagata'
+    within first('.card-list-item.is-unread') do
+      assert_selector '.card-list-item-title__link-label', text: '🎉 harukoさんが新しく入会しました！'
+    end
+  end
+
+  test 'notify mentors when signed up as trainee' do
+    visit '/users/new?role=trainee'
+
+    email = 'natsumi@example.com'
+
+    within 'form[name=user]' do
+      fill_in 'user[login_name]', with: 'natsumi'
+      fill_in 'user[email]', with: email
+      fill_in 'user[name]', with: 'テスト 夏美'
+      fill_in 'user[name_kana]', with: 'テスト ナツミ'
+      fill_in 'user[description]', with: 'テスト夏美です。'
+      fill_in 'user[password]', with: 'testtest'
+      fill_in 'user[password_confirmation]', with: 'testtest'
+      select '学生', from: 'user[job]'
+      find('label', text: 'Mac（Apple チップ）').click
+      select '未経験', from: 'user[experience]'
+      first('.choices__inner').click
+      find('.choices__list--dropdown').click
+      find('.choices__list').click
+      find('#choices--js-choices-single-select-item-choice-2').click
+      find('label', text: 'アンチハラスメントポリシーに同意').click
+      find('label', text: '利用規約に同意').click
+    end
+
+    click_button '参加する'
+    assert_text 'サインアップメールをお送りしました。メールからサインアップを完了させてください。'
+    assert User.find_by(email: email).trainee?
+
+    visit_with_auth notifications_path, 'komagata'
+    within first('.card-list-item.is-unread') do
+      assert_selector '.card-list-item-title__link-label', text: '🎉 natsumiさんが新しく入会しました！'
+    end
+  end
+
+  test 'notify mentors when signed up as normal user' do
+    visit '/users/new'
+    within 'form[name=user]' do
+      fill_in 'user[login_name]', with: 'taro'
+      fill_in 'user[email]', with: 'test@example.com'
+      fill_in 'user[name]', with: 'テスト 太郎'
+      fill_in 'user[name_kana]', with: 'テスト タロウ'
+      fill_in 'user[description]', with: 'テスト太郎です。'
+      fill_in 'user[password]', with: 'testtest'
+      fill_in 'user[password_confirmation]', with: 'testtest'
+      fill_in 'user[after_graduation_hope]', with: '起業したいです'
+      select '学生', from: 'user[job]'
+      find('label', text: 'Mac（Apple チップ）').click
+      select '未経験', from: 'user[experience]'
+      find('label', text: 'アンチハラスメントポリシーに同意').click
+      find('label', text: '利用規約に同意').click
+    end
+
+    fill_stripe_element('4242 4242 4242 4242', '12 / 50', '111')
+
+    VCR.use_cassette 'sign_up/valid-card', vcr_options do
+      click_button '参加する'
+      assert_text 'サインアップメールをお送りしました。メールからサインアップを完了させてください。'
+    end
+
+    visit_with_auth notifications_path, 'komagata'
+    within first('.card-list-item.is-unread') do
+      assert_selector '.card-list-item-title__link-label', text: '🎉 taroさんが新しく入会しました！'
+    end
+  end
+end


### PR DESCRIPTION
## 関連Issue
- #5198

## 概要

新規ユーザー登録時、メンター宛てに、`メール通知`および`サイト内通知`を行うようにする。(Discordへの通知は既に実装済みのため対象外)
対象の新規ユーザーは、全てのユーザーとする。

また、メール通知やサイト内通知の文言などの仕様確認は、以下のDiscordにてmachidaさんにOK頂いております。
https://ptb.discord.com/channels/715806612824260640/809595476847493192/999824618942640129

## 環境準備
1. ブランチ`feature/notify-mentor-when-new-user-registers`をローカルに取り込む。
2. `bin/rails s`でローカル環境を立ち上げる。

## 確認方法と確認内容
### 方針
ユーザーの種類は以下の通り5種類あるが、`1. 非課金ユーザー` については、いずれか1種類をピックアップし、確認する方針とする。
1. 非課金ユーザー
    - 管理者
    - メンター
    - アドバイザー
    - 研修生
2. 課金ユーザー
    - 上記以外

### 1. メール通知の場合
1. フィヨルドブートキャンプ参加登録ページ(/users/new)にアクセスし、必要な情報を入力し「参加する」をクリックし、新規ユーザーを登録する。(有効なカード番号は、[sign\_up\_test\.rb](https://github.com/fjordllc/bootcamp/blob/552625fbb4b1b84e43f1f8d467ea5f1a89060ae5/test/system/sign_up_test.rb#L32) を参照)
2. LetterOpenerWeb(`/letter_opener/`)にアクセスし、メンター宛て(4人)に送信される以下のようなメールの内容を確認する。

| From | Subject | Date | To |
| --- | --- | --- | --- |
| "フィヨルドブートキャンプ" <noreply@bootcamp.fjord.jp> | [FBC] xxxxさんが新しく入会しました！ | 「フィヨルドブートキャンプへようこそ」というタイトルのwelcomメールが送信された5秒後の日時 | machidanohimitsu@gmail.com |
| "フィヨルドブートキャンプ" <noreply@bootcamp.fjord.jp> | [FBC] xxxxさんが新しく入会しました！ | 「フィヨルドブートキャンプへようこそ」というタイトルのwelcomメールが送信された5秒後の日時 | komagata@fjord.jp |
| "フィヨルドブートキャンプ" <noreply@bootcamp.fjord.jp> | [FBC] xxxxさんが新しく入会しました！ | 「フィヨルドブートキャンプへようこそ」というタイトルのwelcomメールが送信された5秒後の日時 | mentormentaro@fjord.jp |
| "フィヨルドブートキャンプ" <noreply@bootcamp.fjord.jp> | [FBC] xxxxさんが新しく入会しました！ | 「フィヨルドブートキャンプへようこそ」というタイトルのwelcomメールが送信された5秒後の日時 | unadmentor@gmail.com |

本文は以下の通り。
```
xxxxさんが新しく入会しました！
xxxxさんのページへ
```

![Cursor_and__development__LetterOpenerWeb](https://user-images.githubusercontent.com/11376040/179086352-1d9182d2-fea9-4d33-9488-dae721981697.png)


3. メール本文の「xxxxさんのページへ」のリンクをクリックし、`メンター`でログインすると、新規登録ユーザーの詳細ページ(`/users/:id`)が表示されることを確認する。

![Cursor_and__development__new-user___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/11376040/179087769-abf8998d-e10c-497d-8f00-d84d21065ab2.png)

4. 管理ページの企業ページ(`/admin/companies`)にアクセスし、「アドバイザー招待」または「研修生招待リンク」のリンクをクリックし、必要な情報を入力し新規ユーザー(アドバイザー or 研修生)を登録する。

5. 項番2 ~ 3 を同様に行う。

### 2. サイト内通知の場合
1. フィヨルドブートキャンプ参加登録ページ(/users/new)にアクセスし、必要な情報を入力し「参加する」をクリックし、新規ユーザーを登録する。(有効なカード番号は、[sign\_up\_test\.rb](https://github.com/fjordllc/bootcamp/blob/552625fbb4b1b84e43f1f8d467ea5f1a89060ae5/test/system/sign_up_test.rb#L32) を参照)

2. メンターでログインし、画面右上の「通知」ナビゲーションをクリックし、以下のように通知モーダルが追加されていることを確認する。
通知の文言は以下の通り。
```
🎉 xxxxさんが新しく入会しました！
```

![Cursor_and__development__ダッシュボード___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/11376040/179088701-88a7039c-30c9-4934-aa49-26e9de8df33a.png)

3. `🎉 xxxxさんが新しく入会しました！`という通知をクリックし、通知一覧ページ(`/notifications`)が表示され、以下のような通知が追加されていることを確認する。
```
🎉 xxxxさんが新しく入会しました！
```
![Cursor_and__development__通知___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/11376040/179089420-473d3ec6-cb3d-404d-a406-d4d3bfaed904.png)

4. `🎉 xxxxさんが新しく入会しました！`というリンクをクリックし、新規登録ユーザーのユーザー詳細ページ(`/users/:id`)が表示されることを確認する。

![Cursor_and__development__new-user___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）](https://user-images.githubusercontent.com/11376040/179087769-abf8998d-e10c-497d-8f00-d84d21065ab2.png)

5. 管理ページの企業ページ(`/admin/companies`)にアクセスし、「アドバイザー招待」または「研修生招待リンク」のリンクをクリックし、必要な情報を入力し新規ユーザー(アドバイザー or 研修生)を登録する。

6. 項番2 〜4 を同様に行う。

## テストについての補足
[システムテスト](https://github.com/fjordllc/bootcamp/pull/5227/commits/3d6e1ac66165addfc725d2601f5425520d964e33)で、新規登録するユーザーは、アドバイザー、研修生、それ以外の3パターンでよいとkomagataさんにご教授頂きましたので、その3パターンでテストしております。