### PR TITLE
ブックマーク一覧をロード中の表示をプレースホルダに置き換えた

### DIFF
--- a/app/javascript/bookmarks.vue
+++ b/app/javascript/bookmarks.vue
@@ -1,8 +1,7 @@
 <template lang="pug">
 .page-body
   .container.is-md(v-if='!loaded')
-    .fa-solid.fa-spinner.fa-pulse
-    | ロード中
+    loadingListPlaceholder
   .container.is-md(v-else)
     .o-empty-message(v-if='bookmarks.length === 0')
       .o-empty-message__icon
@@ -38,11 +37,13 @@
 <script>
 import Bookmark from 'bookmark.vue'
 import Pager from 'pager.vue'
+import LoadingListPlaceholder from 'loading-list-placeholder'
 
 export default {
   components: {
     bookmark: Bookmark,
-    pager: Pager
+    pager: Pager,
+    loadingListPlaceholder: LoadingListPlaceholder
   },
   data() {
     return {


### PR DESCRIPTION
## Issue

- #5191

## 概要

- ダッシュボードのブックマーク一覧ページにおいて、ロード中にプレースホルダが表示されるようにした

## 確認方法

1. `feature/show-placeholders-while-loading-bookmark-list`をローカルに取り込む
2. `rails s`で起動する
3. 任意のユーザーでログインし、ダッシュボードのブックマーク一覧ページにアクセスする
   - http://localhost:3000/current_user/bookmarks

### 変更前

![image](https://user-images.githubusercontent.com/33394676/179663502-4b10aa0c-7b92-4428-b1e8-237c6079b7ab.png)

### 変更後

![image](https://user-images.githubusercontent.com/33394676/179663708-907f83d8-57ec-4982-8e56-133a3f2ce0bc.png)
