### PR TITLE
アイコン付きメンション時のアイコンをリサイズしました

### DIFF
--- a/app/views/api/user_icon_urls/index.json.jbuilder
+++ b/app/views/api/user_icon_urls/index.json.jbuilder
@@ -1,3 +1,3 @@
 @users.each do |user|
-  json.set! user.login_name, user.avatar.attached? ? rails_storage_proxy_url(user.avatar) : ''
+  json.set! user.login_name, user.avatar.attached? ? rails_storage_proxy_url(user.avatar.variant(resize_to_limit: [56, 56])) : ''
 end


### PR DESCRIPTION
## Issue

- #5200

## 概要
アイコン付きメンション時のアイコン画像がオリジナルサイズのままになっているので、リサイズして表示させるようにしました。
- issueより、56px * 56pxにリサイズ
- 実装結果はブラウザのdevツールから確認できるので、テストは未実装
- 参考にしたドキュメント：https://api.rubyonrails.org/v6.1.4/classes/ActiveStorage/Variant.html
## 変更確認方法

1. ブランチ`feature/resize_icon_when_mensioning_with_icon`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 重い画像を用意する（私はここから1.8MBの画像を選びました。https://jp.freepik.com/popular-photos ）
4. mentormentaro以外でログインし登録情報変更画面からユーザーアイコンとして2で選んだ画像を登録する
5. 4とは別人でログインし、4の人にお知らせ、日報、コメント等からアイコン付きメンションを送り、そのときの画像サイズをdevツールで確認する

## 変更前

![2022-07-20 (22)](https://user-images.githubusercontent.com/82737807/179971992-5dc62210-6d3f-48fc-9db0-df8f086331e5.png)


## 変更後
![2022-07-20 (20)](https://user-images.githubusercontent.com/82737807/179952671-adbd132d-8051-4a05-af4e-e3e79c76cb2a.png)
## mentormentaroさんについて
- #5241 で対応予定です
