### PR TITLE
Bootcamp::Setup.attachmentを開発環境だけで実行されるようにした

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,3 +45,4 @@ tables = %i[
 ]
 
 ActiveRecord::FixtureSet.create_fixtures 'db/fixtures', tables
+Bootcamp::Setup.attachment if Rails.env.development?


### PR DESCRIPTION
ステージング環境でのエラー対応用です。