### PR TITLE
「全ての質問」のタブ名とタイトルを変更する

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -87,7 +87,7 @@ class QuestionsController < ApplicationController
     when 'not_solved'
       QuestionsProperty.new('未解決のQ&A', '未解決のQ&Aはありません。')
     else
-      QuestionsProperty.new('全てのQ&A', '質問はありません。')
+      QuestionsProperty.new('全てのQ&A', 'Q&Aはありません。')
     end
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -87,7 +87,7 @@ class QuestionsController < ApplicationController
     when 'not_solved'
       QuestionsProperty.new('未解決のQ&A', '未解決のQ&Aはありません。')
     else
-      QuestionsProperty.new('全ての質問', '質問はありません。')
+      QuestionsProperty.new('全てのQ&A', '質問はありません。')
     end
   end
 

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -11,4 +11,4 @@
       li.page-tabs__item
         = link_to '解決済み', questions_path(target: 'solved', practice_id: params[:practice_id]), class: "page-tabs__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
       li.page-tabs__item
-        = link_to '全ての質問', questions_path(practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target] == 'not_solved' || params[:target] == 'solved' ? '' : 'is-active'}"
+        = link_to '全て', questions_path(practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target] == 'not_solved' || params[:target] == 'solved' ? '' : 'is-active'}"

--- a/test/system/page/tags_test.rb
+++ b/test/system/page/tags_test.rb
@@ -64,7 +64,7 @@ class Page::TagsTest < ApplicationSystemTestCase
     assert_text 'タグ 「上級者」'
 
     visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'
-    assert_text '質問はありません。'
+    assert_text 'Q&Aはありません。'
     visit_with_auth questions_tag_path(update_tag_text, all: 'true'), 'komagata'
     assert_text "タグ「#{update_tag_text}」のQ&A（1）"
 
@@ -90,7 +90,7 @@ class Page::TagsTest < ApplicationSystemTestCase
     assert_text 'タグ 「中級者」'
 
     visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'
-    assert_text '質問はありません。'
+    assert_text 'Q&Aはありません。'
     visit_with_auth questions_tag_path(update_tag.name, all: 'true'), 'komagata'
     assert_text "タグ「#{update_tag.name}」のQ&A（2）"
 

--- a/test/system/question/tags_test.rb
+++ b/test/system/question/tags_test.rb
@@ -64,7 +64,7 @@ class Question::TagsTest < ApplicationSystemTestCase
 
     assert_text "タグ「#{update_tag_text}」のQ&A（1）"
     visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'
-    assert_text '質問はありません。'
+    assert_text 'Q&Aはありません。'
 
     visit_with_auth users_tag_path(tag.name), 'komagata'
     assert_text "#{tag.name}のユーザーはいません"
@@ -88,7 +88,7 @@ class Question::TagsTest < ApplicationSystemTestCase
 
     assert_text "タグ「#{update_tag.name}」のQ&A（2）"
     visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'
-    assert_text '質問はありません。'
+    assert_text 'Q&Aはありません。'
 
     visit_with_auth users_tag_path(tag.name), 'komagata'
     assert_text "#{tag.name}のユーザーはいません"

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -18,7 +18,7 @@ class QuestionsTest < ApplicationSystemTestCase
 
   test 'show listing all questions' do
     visit_with_auth questions_path, 'kimura'
-    assert_equal '全ての質問 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal '全てのQ&A | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
   test 'show a resolved qestion' do


### PR DESCRIPTION
## Issue

- #5108

## 概要

「全ての質問」のタブ名とタイトルを変更しました。(※見出しは既に対応済み)

- タブ名は「全ての質問」から「全て」に変更。
- タイトルは「全ての質問 | FJORD BOOT CAMP（フィヨルドブートキャンプ）」から「全てのQ&A | FJORD BOOT CAMP（フィヨルドブートキャンプ）」に変更。

## 変更確認方法

1. ブランチ`feature/change-title-and-tab-name-of-all-question-page`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. http://localhost:3000/questions にアクセスする。

## 変更前

<img width="1430" alt="スクリーンショット 2022-07-23 19 09 21" src="https://user-images.githubusercontent.com/98577773/180600805-8fc7efc9-50ae-4b5a-8605-b88dc53944b4.png">

## 変更後

<img width="1426" alt="スクリーンショット 2022-07-23 19 06 21" src="https://user-images.githubusercontent.com/98577773/180600799-f6e6eeed-fe80-4904-8d1b-1f25659bf8b2.png">