### PR TITLE
提出物を提出したらステータスが自動で提出に変わるようにした

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -42,6 +42,7 @@ class ProductsController < ApplicationController
     @product.practice = @practice
     @product.user = current_user
     set_wip
+    add_watchers
     update_published_at
     if @product.save
       redirect_to @product, notice: notice_message(@product, :create)
@@ -55,6 +56,7 @@ class ProductsController < ApplicationController
     @practice = @product.practice
     @product.published_at = nil if @product.published_at? && @product.wip
     set_wip
+    add_watchers
     update_published_at
     if @product.update(product_params)
       redirect_to @product, notice: notice_message(@product, :update)
@@ -77,6 +79,14 @@ class ProductsController < ApplicationController
     return if @product.wip || @product.published_at?
 
     @product.published_at = Time.current
+  end
+
+  def add_watchers
+    return if @product.wip || @product.published_at?
+
+    @product.user.company.advisers.each do |adviser|
+      Watch.create!(user: adviser, watchable: @product)
+    end
   end
 
   def find_product

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -42,7 +42,6 @@ class ProductsController < ApplicationController
     @product.practice = @practice
     @product.user = current_user
     set_wip
-    add_watchers
     update_published_at
     if @product.save
       redirect_to @product, notice: notice_message(@product, :create)
@@ -56,7 +55,6 @@ class ProductsController < ApplicationController
     @practice = @product.practice
     @product.published_at = nil if @product.published_at? && @product.wip
     set_wip
-    add_watchers
     update_published_at
     if @product.update(product_params)
       redirect_to @product, notice: notice_message(@product, :update)
@@ -79,15 +77,6 @@ class ProductsController < ApplicationController
     return if @product.wip || @product.published_at?
 
     @product.published_at = Time.current
-  end
-
-  def add_watchers
-    return unless @product.user.trainee? && @product.user.company
-    return if @product.wip || @product.published_at?
-
-    @product.user.company.advisers.each do |adviser|
-      Watch.create!(user: adviser, watchable: @product)
-    end
   end
 
   def find_product

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -82,6 +82,7 @@ class ProductsController < ApplicationController
   end
 
   def add_watchers
+    return unless @product.user.trainee? && @product.user.company
     return if @product.wip || @product.published_at?
 
     @product.user.company.advisers.each do |adviser|

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -18,8 +18,9 @@ class ProductCallbacks
   end
 
   def after_save(product)
+    update_learning_status(product)
+
     unless product.wip
-      product.change_learning_status(:submitted)
       notify_to_watching_mentor(product)
       if product.user.trainee? && product.user.company
         send_notification(
@@ -78,5 +79,15 @@ class ProductCallbacks
       receivers: mentors,
       message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
     )
+  end
+
+  def update_learning_status(product)
+    if product.wip
+      started_practice = product.user.learnings.map(&:status).include?('started')
+      status = started_practice ? :unstarted : :started
+    else
+      status = :submitted
+    end
+    product.change_learning_status status
   end
 end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -23,8 +23,8 @@ class ProductCallbacks
     unless product.wip
       notify_watching_mentors product
       if product.user.trainee? && product.user.company
+        notify_advisers product
         create_advisers_watch product
-        notify_watching_advisers product
       end
     end
 
@@ -73,7 +73,7 @@ class ProductCallbacks
     )
   end
 
-  def notify_watching_advisers(product)
+  def notify_advisers(product)
     send_notification(
       product: product,
       receivers: product.user.company.advisers,

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -74,12 +74,12 @@ class ProductCallbacks
   end
 
   def update_learning_status(product)
-    if product.wip
-      started_practice = product.user.learnings.map(&:status).include?('started')
-      status = started_practice ? :unstarted : :started
-    else
-      status = :submitted
-    end
+    status = if product.wip
+               started_practice = product.user.learnings.map(&:status).include?('started')
+               started_practice ? :unstarted : :started
+             else
+               :submitted
+             end
     product.change_learning_status status
   end
 end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -18,13 +18,13 @@ class ProductCallbacks
   end
 
   def after_save(product)
-    update_learning_status(product)
+    update_learning_status product
 
     unless product.wip
-      notify_watching_mentors(product)
+      notify_watching_mentors product
       if product.user.trainee? && product.user.company
-        create_advisers_watch(product)
-        notify_watching_advisers(product)
+        create_advisers_watch product
+        notify_watching_advisers product
       end
     end
 

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -19,6 +19,7 @@ class ProductCallbacks
 
   def after_save(product)
     unless product.wip
+      product.change_learning_status(:submitted)
       notify_to_watching_mentor(product)
       if product.user.trainee? && product.user.company
         send_notification(
@@ -26,15 +27,12 @@ class ProductCallbacks
           receivers: product.user.company.advisers,
           message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
         )
-      end
-      if product.published_at.nil?
-        if product.user.trainee? && product.user.company
+        if product.published_at.nil?
           create_watch(
             watchers: product.user.company.advisers,
             watchable: product
           )
         end
-        product.change_learning_status(:submitted)
       end
     end
 

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -60,12 +60,6 @@ class ProductCallbacks
     end
   end
 
-  def create_watch(watchers:, watchable:)
-    watchers.each do |watcher|
-      Watch.create!(user: watcher, watchable: watchable)
-    end
-  end
-
   def delete_notification(product)
     Notification.where(link: "/products/#{product.id}").destroy_all
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -90,7 +90,7 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text 'Watch中'
   end
 
-  test 'should change status and messages after initial submission' do
+  test 'should change messages when submit product' do
     visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'hatsuno'
     within('form[name=product]') do
       fill_in('product[body]', with: 'test')
@@ -100,7 +100,34 @@ class ProductsTest < ApplicationSystemTestCase
 
     visit "/practices/#{practices(:practice6).id}"
     assert_equal first('.test-product').text, '提出物へ'
-    find_button(class: 'is-submitted', disabled: true).has_css?('.is-active')
+  end
+
+  test 'should change learning status when change wip status' do
+    product = products(:product5)
+    product_path = "/products/#{product.id}"
+    practice_path = "/practices/#{product.practice.id}"
+
+    visit_with_auth "#{product_path}/edit", 'kimura'
+    click_button '提出する'
+    visit practice_path
+
+    assert find_button(class: 'is-submitted', disabled: true).matches_css?('.is-active')
+
+    products(:product8).change_learning_status(:started)
+    visit "#{product_path}/edit"
+    click_button 'WIP'
+    visit practice_path
+
+    assert find_button(class: 'is-unstarted', disabled: true).matches_css?('.is-active')
+
+    products(:product8).change_learning_status(:submitted)
+    visit product_path
+    click_button '提出する'
+    visit "#{product_path}/edit"
+    click_button 'WIP'
+    visit practice_path
+
+    assert find_button(class: 'is-started', disabled: true).matches_css?('.is-active')
   end
 
   test 'update product' do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -90,8 +90,8 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text 'Watch中'
   end
 
-  test 'create product change status submitted' do
-    visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'mentormentaro'
+  test 'should change status and messages after initial submission' do
+    visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'hatsuno'
     within('form[name=product]') do
       fill_in('product[body]', with: 'test')
     end
@@ -100,6 +100,7 @@ class ProductsTest < ApplicationSystemTestCase
 
     visit "/practices/#{practices(:practice6).id}"
     assert_equal first('.test-product').text, '提出物へ'
+    find_button(class: 'is-submitted', disabled: true).has_css?('.is-active')
   end
 
   test 'update product' do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -271,6 +271,20 @@ class ProductsTest < ApplicationSystemTestCase
     assert_no_text "kensyuさんが「#{practices(:practice3).title}」の提出物を提出しました。"
   end
 
+  test "should add to trainer's watching list when trainee submits product" do
+    users(:senpai).watches.delete_all
+
+    visit_with_auth "/products/new?practice_id=#{practices(:practice3).id}", 'kensyu'
+    within('form[name=product]') do
+      fill_in('product[body]', with: '研修生が提出物を提出すると、その企業のアドバイザーのWatch中に登録される')
+    end
+    click_button '提出する'
+    assert_text "7日以内にメンターがレビューしますので、次のプラクティスにお進みください。\nもし、7日以上経ってもレビューされない場合は、メンターにお問い合わせください。"
+
+    visit_with_auth '/current_user/watches', 'senpai'
+    assert_text '研修生が提出物を提出すると、その企業のアドバイザーのWatch中に登録される'
+  end
+
   test 'products order on all tab' do
     Product.update_all(created_at: 1.day.ago, published_at: 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
     # 最新と最古の提出物を画面上で判定するため、提出物を1ページ内に収める


### PR DESCRIPTION
## Issue

- #5214
  - #4428
  - #5202 

## 概要

このPRで行った変更は以下の3点

- バグ修正
  - 従来は初回の提出時にステータスが自動で提出に変わっていたが、3月の頭頃から機能しなくなった事象の修正
  - **（追加）** 研修生が作成した提出物は、従来は初回提出時に所属企業のアドバイザーのWatchリストに入っていたが、3月の頭頃から機能しなくなった事象の修正
- 仕様変更
  - 提出済みの提出物をWIPに戻した時に、ステータスを「着手」もしくは「未着手（「着手」のプラクティスがすでに他にあった場合）」に変更する

### バグの詳細

- #4238

上記のプルリクにて、`product.published_at = Time.current`の処理がコールバックからコントローラーに移った。
このため、`after_save`のコールバック処理内では`product.published_at.nil?`の結果は常にfalseとなるようになったが、初回提出時にはtrueになるはずと意図して初回提出時の処理はコールバックに残された。
その結果、当該処理が実行されなくなった。

### 仕様変更の詳細

- https://github.com/fjordllc/bootcamp/issues/5214#issuecomment-1193255807

> 提出物が「WIP」ではない状態から「WIP」に変更された場合、もし他のプラクティスで「着手」のものがあった場合は「未着手」に変更、「着手」のものがなかったら「着手」に変更するようにしたい。

上記の要望に対応するため。
「着手」のプラクティスは1つまでとされているため、WIPに戻したときに他のプラクティスが「着手」になっていたら、WIPに戻した提出物のプラクティスは「未着手」に変更する。

## 確認方法

手順を明確にするためにプラクティス名を明示していますが、同等の操作であれば別のプラクティスを使っていただいても問題ありません。

### 準備

1. `bug/correct-unmodified-learning-status-when-submit-product`をローカルに取り込む
2. `rails s`で起動する

### バグが解消済みであることの確認１

1. 任意のユーザーでログインし、「aptの基礎を覚える」のプラクティスページにアクセスする
    http://localhost:3000/practices/212073145
2. プラクティスのステータスが「未着手」であることを確認する
   ![image](https://user-images.githubusercontent.com/33394676/180920765-5e3fc1a5-90f0-450f-a426-580da1a755e3.png)
3. 「aptの基礎を覚える」の提出物を作成・提出する
4. 「aptの基礎を覚える」のプラクティスページにアクセスする
5. プラクティスのステータスが「提出」であることを確認する
   ![image](https://user-images.githubusercontent.com/33394676/180920895-d8475b7f-40de-4b5a-b672-6c29df9b3bf6.png)

### WIPに戻すとステータスが変わることの確認１

1. プラクティス一覧ページで、「着手」のプラクティスが一つもない事を確認する
   http://localhost:3000/courses/829913840/practices
   - 「着手」のプラクティスがあったら、「未着手」「提出」「完了」のどれかに変更する
2. バグ解消の確認手順で提出した「aptの基礎を覚える」の提出物をWIPに戻す
3. 「aptの基礎を覚える」のプラクティスページにアクセスする
4. プラクティスのステータスが「着手」であることを確認する
   ![image](https://user-images.githubusercontent.com/33394676/180921610-baaf083e-ffcb-40ff-be81-f0d2a43288cb.png)

### WIPに戻すとステータスが変わることの確認２

1. 「PC性能の見方を知る」のステータスを「着手」にする
   http://localhost:3000/practices/1019809339
   ![image](https://user-images.githubusercontent.com/33394676/180922653-471cddef-59c7-4a70-9035-25769153d87a.png)
2. 「Linuxのファイル操作の基礎を覚える」の提出物を提出する
   http://localhost:3000/practices/363506445
3. 「Linuxのファイル操作の基礎を覚える」の提出物をWIPに戻す
4. 「Linuxのファイル操作の基礎を覚える」のプラクティスページにアクセスする
5. プラクティスのステータスが「未着手」であることを確認する
   ![image](https://user-images.githubusercontent.com/33394676/180920765-5e3fc1a5-90f0-450f-a426-580da1a755e3.png)

### （追加）バグが解消済みであることの確認２

1. `kensyu` ユーザーでログインし、「Terminalの基礎を覚える」のプラクティスページにアクセスする
   http://localhost:3000/practices/198065840
2. 「Terminalの基礎を覚える」の提出物を作成・提出する
3. `senpai` ユーザーでログインし、ダッシュボードの「Watch中」にアクセスする
   http://localhost:3000/current_user/watches
4. kensyuの「Terminalの基礎を覚える」の提出物が表示されていることを確認する
![image](https://user-images.githubusercontent.com/33394676/181388118-a9fa3674-a1a3-43ee-8658-eb5616b02d2d.png)
