### PR TITLE
提出物一覧のページャーがページ１の時、URLが正しく表示されないバグを修正した

### DIFF
--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -195,12 +195,15 @@ export default {
       window.scrollTo(0, 0)
     },
     newUrl(pageNumber) {
-      const params = new URL(location.href).searchParams
+      const params = new URL(location.origin).searchParams
       if (pageNumber !== 1) params.set('page', pageNumber)
       if (this.params.target) params.set('target', this.params.target)
       if (this.params.checker_id)
         params.set('checker_id', this.params.checker_id)
-      return `${location.pathname}?${params}`
+      if (params.get('page') || params.get('target') || params.get('checker_id'))
+        return `${location.pathname}?${params}`
+      else
+        return location.pathname
     },
     getParams() {
       const params = {}

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -200,10 +200,13 @@ export default {
       if (this.params.target) params.set('target', this.params.target)
       if (this.params.checker_id)
         params.set('checker_id', this.params.checker_id)
-      if (params.get('page') || params.get('target') || params.get('checker_id'))
+      if (
+        params.get('page') ||
+        params.get('target') ||
+        params.get('checker_id')
+      )
         return `${location.pathname}?${params}`
-      else
-        return location.pathname
+      else return location.pathname
     },
     getParams() {
       const params = {}

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -206,7 +206,7 @@ export default {
         params.get('checker_id')
       )
         return `${location.pathname}?${params}`
-      else return location.pathname
+      return location.pathname
     },
     getParams() {
       const params = {}

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -287,14 +287,6 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'click on the pager button' do
-    (Product.default_per_page - Product.count + 1).times do |n|
-      Product.create!(
-        body: 'test',
-        user: users(:hajime),
-        practice: practices("practice#{n + 1}".to_sym)
-      )
-    end
-
     visit_with_auth '/products', 'komagata'
     within first('.pagination') do
       find('a', text: '2').click
@@ -307,13 +299,6 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'specify the page number in the URL' do
-    (Product.default_per_page - Product.count + 1).times do |n|
-      Product.create!(
-        body: 'test',
-        user: users(:hajime),
-        practice: practices("practice#{n + 1}".to_sym)
-      )
-    end
     login_user 'komagata', 'testtest'
     visit '/products?page=2'
     all('.pagination .is-active').each do |active_button|
@@ -323,18 +308,13 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'clicking the browser back button will show the previous page' do
-    (Product.default_per_page - Product.count + 1).times do |n|
-      Product.create!(
-        body: 'test',
-        user: users(:hajime),
-        practice: practices("practice#{n + 1}".to_sym)
-      )
-    end
     login_user 'komagata', 'testtest'
     visit '/products?page=2'
     within first('.pagination') do
       find('a', text: '1').click
     end
+    assert_current_path('/products')
+
     page.go_back
     assert_current_path('/products?page=2')
     all('.pagination .is-active').each do |active_button|

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -295,7 +295,7 @@ class ProductsTest < ApplicationSystemTestCase
     all('.pagination .is-active').each do |active_button|
       assert active_button.has_text? '2'
     end
-    assert_current_path('/products?_login_name=komagata&page=2')
+    assert_current_path('/products?page=2')
   end
 
   test 'specify the page number in the URL' do


### PR DESCRIPTION
## Issue

- #5229

## 概要

提出物一覧のページャーがページャー１から２など他に遷移した後に、１に戻るとURLが変わらない問題を解決しました。

## 変更確認方法

1. ブランチ`bug/fix-pager-in-products-list`をローカルに取り込んでください。
2. bin/rails sでローカル環境を立ち上げてください。
3. 任意の管理者、メンターでログインし、http://localhost:3000/products
 にアクセスしてください。
4. 現在ページャーが１になっていることを確認し、２をクリックしてください。
5. その際URLに`?page=2`のクエリが付くことを確認してください。
6. 再度ページャー１をクリックし、URLにクエリがつかないことを確認してください。

### その他
今回の修正に伴い、提出物一覧のURLのクエリの取得方法を全体的に変更しています（提出物そのもののURL取得方法には変更ありません）。そのため大変お手数お掛け致しますが、提出物一覧の`未完了`、`未アサイン`、`自分の担当`タブを表示させ、一通りの機能が正しく動作しているかと、`checker_id`、`target`クエリがURLとして表示（取得）されているかの動作確認もよろしくお願いいたします。

### テストについて
クエリの取得方法を変更いたしましたので、ページャー以外のクエリのテストも追加を検討したのですが、`checker_id`と`target`クエリのテストが`test/system/product/unchecked_test.rb`177行目に存在していました。よって今回はページャーでバグが発生していた部分のテストのみ追加しております。

## 変更前

[![Image from Gyazo](https://i.gyazo.com/81ed770fd7155678f986c2a61e23a7d0.gif)](https://gyazo.com/81ed770fd7155678f986c2a61e23a7d0)

## 変更後

[![Image from Gyazo](https://i.gyazo.com/cd4348741db0318d28019a61c6ffb3bf.gif)](https://gyazo.com/cd4348741db0318d28019a61c6ffb3bf)