### PR TITLE
メールの件名を[bootcamp]から[FBC]に変更する

### DIFF
--- a/app/mailers/check_url_mailer.rb
+++ b/app/mailers/check_url_mailer.rb
@@ -5,6 +5,6 @@ class CheckUrlMailer < ApplicationMailer
     @page_error_url = page_error_url
     @practice_error_url = practice_error_url
     @number_of_error_url = page_error_url.size + practice_error_url.size
-    mail to: 'info@fjord.jp', subject: '[BootCamp Admin] リンク切れ報告'
+    mail to: 'info@fjord.jp', subject: '[FBC Admin] リンク切れ報告'
   end
 end

--- a/app/mailers/inquiry_mailer.rb
+++ b/app/mailers/inquiry_mailer.rb
@@ -3,6 +3,6 @@
 class InquiryMailer < ApplicationMailer
   def incoming(inquiry)
     @inquiry = inquiry
-    mail to: 'info@fjord.jp', reply_to: @inquiry.email, subject: '[Bootcamp] お問い合わせ'
+    mail to: 'info@fjord.jp', reply_to: @inquiry.email, subject: '[FBC] お問い合わせ'
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -25,7 +25,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @user = @receiver
     link = "/#{@comment.commentable_type.downcase.pluralize}/#{@comment.commentable.id}"
     @notification = @user.notifications.find_by(link: link) || @user.notifications.find_by(link: "#{link}#latest-comment")
-    mail to: @user.email, subject: "[bootcamp] #{@message}"
+    mail to: @user.email, subject: "[FBC] #{@message}"
   end
 
   # required params: check
@@ -33,7 +33,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @user = @check.receiver
     link = "/#{@check.checkable_type.downcase.pluralize}/#{@check.checkable.id}"
     @notification = @user.notifications.find_by(link: link)
-    subject = "[bootcamp] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
+    subject = "[FBC] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
     mail to: @user.email, subject: subject
   end
 
@@ -41,7 +41,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def mentioned
     @user = @receiver
     @notification = @user.notifications.find_by(link: @mentionable.path)
-    subject = "[bootcamp] #{@mentionable.where_mention}で#{@mentionable.sender.login_name}さんからメンションがありました。"
+    subject = "[FBC] #{@mentionable.where_mention}で#{@mentionable.sender.login_name}さんからメンションがありました。"
     mail to: @user.email, subject: subject
   end
 
@@ -49,28 +49,28 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def submitted
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/products/#{@product.id}")
-    mail to: @user.email, subject: "[bootcamp] #{@message}"
+    mail to: @user.email, subject: "[FBC] #{@message}"
   end
 
   # required params: answer
   def came_answer
     @user = @answer.receiver
     @notification = @user.notifications.find_by(link: "/questions/#{@answer.question.id}")
-    mail to: @user.email, subject: "[bootcamp] #{@answer.user.login_name}さんから回答がありました。"
+    mail to: @user.email, subject: "[FBC] #{@answer.user.login_name}さんから回答がありました。"
   end
 
   # required params: announcement, receiver
   def post_announcement
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/announcements/#{@announcement.id}")
-    mail to: @user.email, subject: "[bootcamp] お知らせ「#{@announcement.title}」"
+    mail to: @user.email, subject: "[FBC] お知らせ「#{@announcement.title}」"
   end
 
   # required params: question, receiver
   def came_question
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/questions/#{@question.id}")
-    mail to: @user.email, subject: "[bootcamp] #{@question.user.login_name}さんから質問「#{@question.title}」が投稿されました。"
+    mail to: @user.email, subject: "[FBC] #{@question.user.login_name}さんから質問「#{@question.title}」が投稿されました。"
   end
 
   # required params: report, receiver
@@ -78,7 +78,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
     mail to: @user.email,
-         subject: "[bootcamp] #{@report.user.login_name}さんがはじめての日報を書きました！"
+         subject: "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
   end
 
   # required params: watchable, receiver
@@ -88,7 +88,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     link = "/#{@watchable.class.name.downcase.pluralize}/#{@watchable.id}"
     @notification = @user.notifications.find_by(link: link)
     action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
-    subject = "[bootcamp] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんが#{action}しました。"
+    subject = "[FBC] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんが#{action}しました。"
     mail to: @user.email, subject: subject
   end
 
@@ -96,7 +96,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def retired
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/users/#{@sender.id}")
-    subject = "[bootcamp] #{@sender.login_name}さんが退会しました。"
+    subject = "[FBC] #{@sender.login_name}さんが退会しました。"
     mail to: @user.email, subject: subject
   end
 
@@ -110,7 +110,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def trainee_report
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
-    subject = "[bootcamp] #{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！"
+    subject = "[FBC] #{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！"
     mail to: @user.email, subject: subject
   end
 
@@ -118,7 +118,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def moved_up_event_waiting_user
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/events/#{@event.id}")
-    subject = "[bootcamp] #{@event.title}で、補欠から参加に繰り上がりました。"
+    subject = "[FBC] #{@event.title}で、補欠から参加に繰り上がりました。"
     mail to: @user.email, subject: subject
   end
 
@@ -126,7 +126,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def create_page
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/pages/#{@page.id}")
-    subject = "[bootcamp] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
+    subject = "[FBC] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
     mail to: @user.email, subject: subject
   end
 
@@ -134,7 +134,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def following_report
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
-    subject = "[bootcamp] #{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！"
+    subject = "[FBC] #{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！"
     mail to: @user.email, subject: subject
   end
 
@@ -142,7 +142,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def chose_correct_answer
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/questions/#{@answer.question.id}")
-    subject = "[bootcamp] #{@answer.receiver.login_name}さんの質問【 #{@answer.question.title} 】で#{@answer.sender.login_name}さんの回答がベストアンサーに選ばれました。"
+    subject = "[FBC] #{@answer.receiver.login_name}さんの質問【 #{@answer.question.title} 】で#{@answer.sender.login_name}さんの回答がベストアンサーに選ばれました。"
     mail to: @user.email, subject: subject
   end
 
@@ -151,13 +151,13 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
     mail to: @user.email,
-         subject: "[bootcamp] #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。"
+         subject: "[FBC] #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。"
   end
 
   def assigned_as_checker
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/products/#{@product.id}")
-    subject = "[bootcamp] #{@product.user.login_name}さんの提出物#{@product.title}の担当になりました。"
+    subject = "[FBC] #{@product.user.login_name}さんの提出物#{@product.title}の担当になりました。"
     mail to: @user.email, subject: subject
   end
 
@@ -165,7 +165,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def graduated
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:graduated])
-    subject = "[bootcamp] #{@sender.login_name}さんが卒業しました。"
+    subject = "[FBC] #{@sender.login_name}さんが卒業しました。"
     mail to: @user.email, subject: subject
   end
 
@@ -173,7 +173,7 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   def hibernated
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:hibernated])
-    subject = "[bootcamp] #{@sender.login_name}さんが休会しました。"
+    subject = "[FBC] #{@sender.login_name}さんが休会しました。"
     mail to: @user.email, subject: subject
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,16 +4,16 @@ class UserMailer < ApplicationMailer
   def reset_password_email(user)
     @user = User.find(user.id)
     @url = edit_password_reset_url(@user.reset_password_token)
-    mail to: user.email, subject: '[bootcamp] パスワードのリセット'
+    mail to: user.email, subject: '[FBC] パスワードのリセット'
   end
 
   def welcome(user)
     @user = user
-    mail to: user.email, subject: '[bootcamp] フィヨルドブートキャンプへようこそ'
+    mail to: user.email, subject: '[FBC] フィヨルドブートキャンプへようこそ'
   end
 
   def retire(user)
     @user = user
-    mail to: user.email, subject: '[bootcamp] 退会処理が完了しました'
+    mail to: user.email, subject: '[FBC] 退会処理が完了しました'
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -310,6 +310,6 @@ ja:
     following_report: フォロー中
   notification_mailer:
     three_months_after_retirement:
-      subject: '[bootcamp] %{user}さんが退会してから3カ月が経過しました。'
+      subject: '[FBC] %{user}さんが退会してから3カ月が経過しました。'
       retire_notice: '%{user}さんが退会してから3カ月が経過しました。'
   retire_notice: '%{user}さんが退会してから3カ月が経過しました。'

--- a/test/mailers/check_url_mailer_test.rb
+++ b/test/mailers/check_url_mailer_test.rb
@@ -13,7 +13,7 @@ class CheckUrlMailerTest < ActionMailer::TestCase
 
     mail = CheckUrlMailer.notify_error_url(page_error_url, practice_error_url).deliver_now
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal '[BootCamp Admin] リンク切れ報告', mail.subject
+    assert_equal '[FBC Admin] リンク切れ報告', mail.subject
     assert_equal ['info@fjord.jp'], mail.to
     assert_equal ['noreply@bootcamp.fjord.jp'], mail.from
     assert_match(/リンク切れがありました。/, mail.body.to_s)

--- a/test/mailers/inquiry_mailer_test.rb
+++ b/test/mailers/inquiry_mailer_test.rb
@@ -10,7 +10,7 @@ class InquiryMailerTest < ActionMailer::TestCase
       body: "お問い合わせ内容\nあああ\nいいい\nううう"
     )
     mail = InquiryMailer.incoming(inquiry)
-    assert_equal '[Bootcamp] お問い合わせ', mail.subject
+    assert_equal '[FBC] お問い合わせ', mail.subject
     assert_equal ['info@fjord.jp'], mail.to
     assert_equal ['noreply@bootcamp.fjord.jp'], mail.from
     assert_equal ['komagata@example.com'], mail.reply_to

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -20,7 +20,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[bootcamp] komagataさんからコメントが届きました。', email.subject
+    assert_equal '[FBC] komagataさんからコメントが届きました。', email.subject
     assert_match(/コメント/, email.body.to_s)
   end
 
@@ -36,7 +36,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[bootcamp] sotugyouさんの学習週1日目を確認しました。', email.subject
+    assert_equal '[FBC] sotugyouさんの学習週1日目を確認しました。', email.subject
     assert_match(/確認/, email.body.to_s)
   end
 
@@ -56,7 +56,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[bootcamp] sotugyouさんの日報「学習週1日目」へのコメントでkomagataさんからメンションがありました。', email.subject
+    assert_equal '[FBC] sotugyouさんの日報「学習週1日目」へのコメントでkomagataさんからメンションがありました。', email.subject
     assert_match(/メンション/, email.body.to_s)
   end
 
@@ -77,7 +77,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal "[bootcamp] sotugyouさんが「#{product.title}」を提出しました。", email.subject
+    assert_equal "[FBC] sotugyouさんが「#{product.title}」を提出しました。", email.subject
     assert_match(/提出/, email.body.to_s)
   end
 
@@ -93,7 +93,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[bootcamp] komagataさんから回答がありました。', email.subject
+    assert_equal '[FBC] komagataさんから回答がありました。', email.subject
     assert_match(/回答/, email.body.to_s)
   end
 
@@ -113,7 +113,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[bootcamp] お知らせ「お知らせ1」', email.subject
+    assert_equal '[FBC] お知らせ「お知らせ1」', email.subject
     assert_match(/お知らせ/, email.body.to_s)
   end
 
@@ -133,7 +133,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[bootcamp] sotugyouさんから質問「injectとreduce」が投稿されました。', email.subject
+    assert_equal '[FBC] sotugyouさんから質問「injectとreduce」が投稿されました。', email.subject
     assert_match(/質問/, email.body.to_s)
   end
 
@@ -153,7 +153,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[bootcamp] hajimeさんがはじめての日報を書きました！', email.subject
+    assert_equal '[FBC] hajimeさんがはじめての日報を書きました！', email.subject
     assert_match(/はじめて/, email.body.to_s)
   end
 
@@ -173,7 +173,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['hatsuno@fjord.jp'], email.to
-    assert_equal '[bootcamp] komagataさんがDocsにBootcampの作業のページを投稿しました。', email.subject
+    assert_equal '[FBC] komagataさんがDocsにBootcampの作業のページを投稿しました。', email.subject
     assert_match(/Bootcamp/, email.body.to_s)
   end
 
@@ -194,7 +194,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['kimura@fjord.jp'], email.to
-    assert_equal '[bootcamp] komagataさんの【 「作業週1日目」の日報 】にmachidaさんがコメントしました。', email.subject
+    assert_equal '[FBC] komagataさんの【 「作業週1日目」の日報 】にmachidaさんがコメントしました。', email.subject
   end
 
   test 'retired' do
@@ -213,7 +213,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[bootcamp] yameoさんが退会しました。', email.subject
+    assert_equal '[FBC] yameoさんが退会しました。', email.subject
     assert_match(/退会/, email.body.to_s)
   end
 
@@ -233,7 +233,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[bootcamp] kensyuowataさんが退会してから3カ月が経過しました。', email.subject
+    assert_equal '[FBC] kensyuowataさんが退会してから3カ月が経過しました。', email.subject
     assert_match(/退会/, email.body.to_s)
   end
 
@@ -253,7 +253,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['senpai@fjord.jp'], email.to
-    assert_equal '[bootcamp] kensyuさんが日報【 研修の日報 】を書きました！', email.subject
+    assert_equal '[FBC] kensyuさんが日報【 研修の日報 】を書きました！', email.subject
     assert_match(/日報/, email.body.to_s)
   end
 
@@ -273,7 +273,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['hajime@fjord.jp'], email.to
-    assert_equal '[bootcamp] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
+    assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
     assert_match(/イベント/, email.body.to_s)
   end
 
@@ -293,7 +293,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['muryou@fjord.jp'], email.to
-    assert_equal '[bootcamp] kensyuさんが日報【 フォローされた日報 】を書きました！', email.subject
+    assert_equal '[FBC] kensyuさんが日報【 フォローされた日報 】を書きました！', email.subject
     assert_match(/日報/, email.body.to_s)
   end
 
@@ -313,7 +313,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['advijirou@example.com'], email.to
-    assert_equal '[bootcamp] hajimeさんの質問【 解決済みの質問 】でadvijirouさんの回答がベストアンサーに選ばれました。', email.subject
+    assert_equal '[FBC] hajimeさんの質問【 解決済みの質問 】でadvijirouさんの回答がベストアンサーに選ばれました。', email.subject
     assert_match(/回答/, email.body.to_s)
   end
 
@@ -333,7 +333,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[bootcamp] hajimeさんが2回連続でsadアイコンの日報を提出しました。', email.subject
+    assert_equal '[FBC] hajimeさんが2回連続でsadアイコンの日報を提出しました。', email.subject
     assert_match(/2回連続/, email.body.to_s)
   end
 
@@ -353,7 +353,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['mentormentaro@fjord.jp'], email.to
-    assert_equal '[bootcamp] sotugyouさんが卒業しました。', email.subject
+    assert_equal '[FBC] sotugyouさんが卒業しました。', email.subject
     assert_match(/卒業/, email.body.to_s)
   end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -10,7 +10,7 @@ class UserMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[bootcamp] フィヨルドブートキャンプへようこそ', email.subject
+    assert_equal '[FBC] フィヨルドブートキャンプへようこそ', email.subject
     assert_match(/お申し込みありがとうございます/, email.body.to_s)
   end
 
@@ -21,7 +21,7 @@ class UserMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['kimura@fjord.jp'], email.to
-    assert_equal '[bootcamp] 退会処理が完了しました', email.subject
+    assert_equal '[FBC] 退会処理が完了しました', email.subject
     assert_match(/ご利用いただきありがとうございました/, email.body.to_s)
     assert_match("#{user.name}様の今後のご活躍を心からお祈り申し上げます。", email.body.to_s)
   end

--- a/test/system/notification/assigned_as_checker_test.rb
+++ b/test/system/notification/assigned_as_checker_test.rb
@@ -29,7 +29,7 @@ class Notification::AssignedAsCheckerTest < ApplicationSystemTestCase
 
     sleep 0.2 until deliveries.count.positive?
 
-    expected = "[bootcamp] mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
+    expected = "[FBC] mentormentaroさんの提出物#{products(:product1).title}の担当になりました。"
     assert_equal expected, deliveries.last.subject
   end
 

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -14,7 +14,7 @@ class NotificationsTest < ApplicationSystemTestCase
 
     if ActionMailer::Base.deliveries.present?
       last_mail = ActionMailer::Base.deliveries.last
-      assert_not_equal '[Bootcamp] kimuraさんからコメントが届きました。', last_mail.subject
+      assert_not_equal '[FBC] kimuraさんからコメントが届きました。', last_mail.subject
     end
   end
 


### PR DESCRIPTION
## Issue

- #5244

## 概要

現在、フィヨルドブートキャンプから届くメールのサブジェクトの頭に、[bootcamp] もしくは [Bootcamp] という文字が入っている。これを [FBC] に変更する。

## 変更確認方法

1. ブランチ`feature/change-subject-of-the-mail`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `http://localhost:3000/login` にアクセスし「パスワードを忘れた」をクリックする
4. 「kimura@fjord.jp」と入力し「パスワード再設定」をクリックする
5. `http://localhost:3000/letter_opener`にアクセスする


## 変更前

<img width="811" alt="スクリーンショット 2022-07-25 13 24 23" src="https://user-images.githubusercontent.com/98577773/180746071-074645d8-c1d3-4572-96b1-97cc0b395c0c.png">

## 変更後

<img width="798" alt="スクリーンショット 2022-07-25 13 27 59" src="https://user-images.githubusercontent.com/98577773/180746082-ac8244c7-f0de-4e27-aaf9-83c396ccf86f.png">
