### PR TITLE
ポートフォリオ削除関係のテストコードを修正

### DIFF
--- a/test/system/works_test.rb
+++ b/test/system/works_test.rb
@@ -50,7 +50,7 @@ class WorksTest < ApplicationSystemTestCase
   test 'destroy my work' do
     visit_with_auth work_path(works(:work1)), 'kimura'
     accept_confirm do
-      click_link '削除'
+      click_link '削除する'
     end
     assert_text 'ポートフォリオから作品を削除しました'
   end
@@ -66,7 +66,7 @@ class WorksTest < ApplicationSystemTestCase
   test 'admin can destroy a work' do
     visit_with_auth work_path(works(:work1)), 'komagata'
     accept_confirm do
-      click_link '削除'
+      click_link '削除する'
     end
     assert_text 'ポートフォリオから作品を削除しました'
   end
@@ -78,6 +78,6 @@ class WorksTest < ApplicationSystemTestCase
 
   test "user can't destroy other user's work" do
     visit_with_auth work_path(works(:work2)), 'kimura'
-    assert_no_text '削除'
+    assert_no_text '削除する'
   end
 end


### PR DESCRIPTION
## Issue
無し
## 概要
ポートフォリオ削除関連のテストが落ちやすいので修正したい
## 修正内容
実際の画面（下記スクショ）では、"削除する"というリンク表記になっているが、テストコードは"削除"と書かれているので、テストコードを実際の画面の表記に合わせた

## 確認方法
- http://localhost:3000/works/775365376 ページにアクセスして表記を確認する
- `test/system/works_test.rb` を実行する
## テストが落ちたときのlog
```ruby
Failure:
WorksTest#test_destroy_my_work [/home/kei-kmj/dev/projects/rails/bootcamp/test/system/works_test.rb:55]:
expected to find text "ポートフォリオから作品を削除しました" in "お知らせ\nプラクティス\n日報\n13\nQ&A\nDocs\nユーザー\nイベント\nヘルプ\n相談\nすべて\n
お知らせ\nプラクティス\n日報\n提出物\nQ&A\nDocs\nイベント\nユーザー\nMe\n3\n通知\nkimura\n作品を追加\nユーザー一覧\nプロフィール\nポートフォリオ\n日報
（1）\nコメント （0）\n提出物 （8）\n質問 （3）\n回答（0）\nこのページは、就職希望先のエンジニアや人事担当者が、kimuraさんのスキルを手っ取り早く確認する
ための作品集ページ（ポートフォリオ）です。\n自分の作ったGemや登壇した際の発表資料、自分で作ったWebサービス、自分が書いた書籍など、作品を登録していきまし
ょう。\n作品を追加\nホームページ\n参考書籍\nGitHub Projects\nグッズ購入\nアンチハラスメントポリシー\n利用規約\nプライバシーポリシー\n特定商取引法に基づ
く表記\nコース一覧\n企業一覧\n#fjordbootcamp\nFjord Inc.2012 - 2022"


rails test test/system/works_test.rb:50
```

## 実際の画面のスクショ
![2022-07-27 (4)](https://user-images.githubusercontent.com/82737807/181232278-97e02d08-653d-4e64-95d3-171e43ca7d37.png)
