### PR TITLE
未読の通知一覧で発生していたN+1を解消

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -11,7 +11,6 @@ class API::NotificationsController < API::BaseController
 
     @notifications = Notification.with_avatar
                                  .from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
-                                 .includes(:sender)
                                  .order(created_at: :desc)
     @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications
   end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -9,7 +9,8 @@ class API::NotificationsController < API::BaseController
                                        .by_read_status(status)
                                        .latest_of_each_link
 
-    @notifications = Notification.from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
+    @notifications = Notification.with_avatar
+                                 .from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
                                  .order(created_at: :desc)
                                  .includes(:sender)
     @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -9,8 +9,10 @@ class API::NotificationsController < API::BaseController
                                        .by_read_status(status)
                                        .latest_of_each_link
 
+    # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、
+    # from を使ってサブクエリとした
     @notifications = Notification.with_avatar
-                                 .from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
+                                 .from(latest_notifications, :notifications)
                                  .order(created_at: :desc)
     @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications
   end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -11,8 +11,8 @@ class API::NotificationsController < API::BaseController
 
     @notifications = Notification.with_avatar
                                  .from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
-                                 .order(created_at: :desc)
                                  .includes(:sender)
+                                 .order(created_at: :desc)
     @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications
   end
 end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -11,6 +11,7 @@ class API::NotificationsController < API::BaseController
 
     @notifications = Notification.from(latest_notifications, :notifications) # latest_notifications のクエリで指定している ORDER BY の順序を他と混ぜないようにするため、from を使ってサブクエリとした
                                  .order(created_at: :desc)
+                                 .includes(:sender)
     @notifications = params[:page] ? @notifications.page(params[:page]) : @notifications
   end
 end


### PR DESCRIPTION
新しいブランチを作成したので、PRも作り直しました。

以前のPRはこちらのURLです。
https://github.com/fjordllc/bootcamp/pull/5185

## Issue概要
- #4977

未読の通知一覧でN+1が発生していたので、それを解消した。

発生箇所: http://localhost:3000/notifications?status=unread

## 変更内容
- includes(:sender)することでUserとNotificationテーブルを結合してN+1を解決した
- with_avatarを呼び出してuserとavatar_attachmentをpreloadするようにした

## 確認方法
1. `bug/fix-n+1-in-list-of-unread-notifications`をローカルに取り込む
1. `bin/setup`実行
1. `bin/rails s`でサーバーを立ち上げる
1. ブラウザから`/api/notifications.json?status=unread`と`/api/notifications.json?page=1&status=unread&target=`にそれぞれアクセスする
1. `tail -f log/bullet.log` のコマンドでbulletのログをリアルタイムで確認し、N+1がログとして表示されていないことを確認する