### PR TITLE
「今日の気分」のアイコンを日報の一覧に表示した

### DIFF
--- a/app/assets/stylesheets/shared/blocks/card-list/_card-list-item-title.sass
+++ b/app/assets/stylesheets/shared/blocks/card-list/_card-list-item-title.sass
@@ -35,6 +35,11 @@
     font-size: .8125rem
     font-weight: 400
 
+.card-list-item-title__emotion-image
+  +size(1.125em)
+  margin-right: .375rem
+  transform: translate(0, -.0625em)
+
 .card-list-item-title__link
   word-break: break-all
   +line-clamp(2)

--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -16,14 +16,15 @@
             .a-list-item-badge.is-wip(v-if='report.wip')
               span
                 | WIP
-            img.niconico-calendar__emotion-image(
-              :src='`/images/emotion/${report.emotion}.svg`',
-              :alt='report.emotion'
-            )
             h2.card-list-item-title__title
               a.card-list-item-title__link.a-text-link.js-unconfirmed-link(
                 :href='report.url'
-              ) {{ report.title }}
+              )
+                img.card-list-item-title__emotion-image(
+                  :src='`/images/emotion/${report.emotion}.svg`',
+                  :alt='report.emotion'
+                )
+                | {{ report.title }}
             .card-list-item-title__end(v-if='currentUserId == report.user.id')
               label.card-list-item-actions__trigger(:for='report.id')
                 i.fa-solid.fa-ellipsis-h

--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -16,6 +16,10 @@
             .a-list-item-badge.is-wip(v-if='report.wip')
               span
                 | WIP
+            img.niconico-calendar__emotion-image(
+              :src='`/images/emotion/${report.emotion}.svg`',
+              :alt='report.emotion'
+            )
             h2.card-list-item-title__title
               a.card-list-item-title__link.a-text-link.js-unconfirmed-link(
                 :href='report.url'

--- a/app/javascript/report.vue
+++ b/app/javascript/report.vue
@@ -21,7 +21,7 @@
                 :href='report.url'
               )
                 img.card-list-item-title__emotion-image(
-                  :src='`/images/emotion/${report.emotion}.svg`',
+                  :src='emotionImg',
                   :alt='report.emotion'
                 )
                 | {{ report.title }}
@@ -97,6 +97,9 @@ export default {
     },
     wipClass() {
       return { 'is-wip': this.report.wip }
+    },
+    emotionImg() {
+      return `/images/emotion/${this.report.emotion}.svg`
     }
   }
 }

--- a/app/views/api/reports/_report.json.jbuilder
+++ b/app/views/api/reports/_report.json.jbuilder
@@ -5,3 +5,4 @@ json.url report_url(report)
 json.editURL edit_report_path(report)
 json.newURL new_report_path(id: report)
 json.wip report.wip?
+json.emotion report.emotion

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -10,9 +10,9 @@
               .a-list-item-badge.is-wip
                 span
                   | WIP
-            img.niconico-calendar__emotion-image src="/images/emotion/#{report.emotion}.svg" alt=report.emotion
             h2.card-list-item-title__title(itemprop='name')
               = link_to report, itemprop: 'url', class: 'card-list-item-title__link a-text-link js-unconfirmed-link' do
+                = image_tag("emotion/#{report.emotion}.svg", alt: report.emotion, class: 'card-list-item-title__emotion-image')
                 = report.title
           - if current_user == report.user
             .card-list-item-title__end

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -10,6 +10,7 @@
               .a-list-item-badge.is-wip
                 span
                   | WIP
+            img.niconico-calendar__emotion-image src="/images/emotion/#{report.emotion}.svg" alt=report.emotion
             h2.card-list-item-title__title(itemprop='name')
               = link_to report, itemprop: 'url', class: 'card-list-item-title__link a-text-link js-unconfirmed-link' do
                 = report.title

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -31,6 +31,7 @@ report3:
 report4:
   user: machida
   title: "Fjord Bootcamp で Bootstrap のバージョン更新"
+  emotion: 2
   description: |-
     Fjord Bootcamp で Bootstrap のバージョン更新を行った他、デザインの微調整を行いました。
   reported_on: "2017-01-01"
@@ -38,6 +39,7 @@ report4:
 report5:
   user: sotugyou
   title: "学習週1日目"
+  emotion: 2
   description: |-
     今日は　Rubyの基礎 を学習しました。
   reported_on: "2017-01-01"
@@ -45,6 +47,7 @@ report5:
 report6:
   user: sotugyou
   title: "学習週2日目"
+  emotion: 2
   description: |-
     今日は　Railsの基礎 を学習しました。
   reported_on: "2017-01-02"
@@ -52,6 +55,7 @@ report6:
 report7:
   user: sotugyou
   title: "学習週3日目"
+  emotion: 2
   description: |-
     今日は　RSpecの基礎 を学習しました。
   reported_on: "2017-01-03"
@@ -59,6 +63,7 @@ report7:
 report8:
   user: mentormentaro
   title: テストの日報
+  emotion: 2
   description: |-
     いろいろやりました。
   reported_on: "2017-01-01"
@@ -66,6 +71,7 @@ report8:
 report9:
   user: sotugyou
   title: WIPの日報
+  emotion: 2
   description: |-
     WIP
   reported_on: "2019-01-01"
@@ -84,6 +90,7 @@ report10:
 report11:
   user: kensyu
   title: 研修の日報
+  emotion: 2
   description:
     研修を行いました。
   reported_on: "2019-01-01"
@@ -91,12 +98,14 @@ report11:
 sotugyou:
   user: sotugyou
   title: テストの日報
+  emotion: 2
   description: いろいろやりました
   reported_on: "2018-02-01"
 
 report12:
   user: mentormentaro
   title: 検索結果確認用-C
+  emotion: 2
   description:
     今年で150歳でーす
   reported_on: "2020-01-01"
@@ -106,6 +115,7 @@ report12:
 report13:
   user: mentormentaro
   title: 検索結果確認用-A
+  emotion: 2
   description:
     きたるべき20世紀
   reported_on: "1900-01-01"
@@ -115,6 +125,7 @@ report13:
 report14:
   user: mentormentaro
   title: 検索結果確認用-B
+  emotion: 2
   description:
     あれから100年か
   reported_on: "2000-01-01"
@@ -140,6 +151,7 @@ report16:
 report17:
   user: mentormentaro
   title: 1時間だけ学習
+  emotion: 2
   description: |-
     mentormentaroです、メンターです。
     今日は1時間学習しました。
@@ -150,6 +162,7 @@ report17:
 report18:
   user: kensyu
   title: テストのnippou
+  emotion: 2
   description: |-
     今日は1時間学習しました。
   reported_on: "2022-04-01"
@@ -174,6 +187,7 @@ report20:
 report21:
   user: sotugyou
   title: "学習週4日目"
+  emotion: 2
   description: |-
     今日は　Vueの基礎 を学習しました。
   practices: practice1
@@ -192,6 +206,7 @@ report22:
 report23:
   user: kensyu
   title: フォローされた日報
+  emotion: 2
   description:
     フォローされました。
   reported_on: "2022-03-31"
@@ -199,6 +214,7 @@ report23:
 report24:
   user: kimura
   title: 検索用の日報
+  emotion: 2
   description:
     ユーザーネームで検索できるよ
   reported_on: "2022-03-31"
@@ -206,6 +222,7 @@ report24:
 report25:
   user: hatsuno
   title: 検索用の日報
+  emotion: 2
   description:
     ユーザーネームで検索できるよ
   reported_on: "2020-11-20"
@@ -256,6 +273,7 @@ report30:
 report31:
   user: kananashi
   title: 最新のwipの日報
+  emotion: 2
   description: |-
     最新のwipの日報です
   reported_on: <%= Time.current %>
@@ -265,6 +283,7 @@ report31:
 report32:
   user: kananashi
   title: wipを除いた最新の日報
+  emotion: 2
   description: |-
     wipを除いた最新の日報です
   reported_on: <%= Time.current - 1.day %>
@@ -284,6 +303,7 @@ report33:
 report34:
   user: kananashi
   title: 最新から10日前の日報
+  emotion: 2
   description: |-
     最新から10日前の日報です
   reported_on: <%= Time.current - 11.day %>
@@ -292,6 +312,7 @@ report34:
 report71:
   user: kimuramitai
   title: "名前の長いメンター用"
+  emotion: 2
   description:
     "名前の長いメンター用"
   reported_on: "2022-04-16"


### PR DESCRIPTION
## Issue

- #5063

## 概要

日報一覧パーツに「今日の気分」のアイコンを表示する。
※表示位置・表示サイズは町田さんによるデザイン前の状態です
![image](https://user-images.githubusercontent.com/33394676/181863327-519057c6-4a3a-46bd-a54f-031774ee2e9a.png)

日報一覧パーツはvue版とslim版2種類があり、それぞれの利用箇所は以下の通り。

1. `app/javascript/report.vue`
   - 日報詳細（直近の日報）
     - http://localhost:3000/reports/12168338 
   - 日報一覧
     - http://localhost:3000/reports
     - http://localhost:3000/reports/unchecked
   - 自分の日報一覧
     - http://localhost:3000/current_user/reports
   - ユーザーの日報一覧
     - http://localhost:3000/users/253826460/reports
   - 企業の日報一覧
     - http://localhost:3000/companies/636488896/reports
   - 相談部屋（ユーザーの日報・管理者のみ）
     - http://localhost:3000/talks/842643596
1. `app/views/reports/_report.html.slim`
    - プラクティスの日報一覧
      - http://localhost:3000/practices/315059988/reports
    - ダッシュボード（「2回連続sadのユーザー」のカード）
      - http://localhost:3000

## 動作確認方法

1. `feature/display-niconico-icons-on-report-list` をローカルに取り込む
2. `rails s` で起動する
3. `mentormentaro` でログインする

### `app/javascript/report.vue` による表示箇所の確認

1. 日報詳細画面にアクセスする
   - http://localhost:3000/reports/12168338
2. 「直近の日報」に気分のアイコンが表示されていることを確認する
   ![image](https://user-images.githubusercontent.com/33394676/181864031-c0f9631d-148b-45c1-aa9d-a580a38b2b5c.png)

### `app/views/reports/_report.html.slim` による表示箇所の確認

1. プラクティスの日報一覧画面にアクセスする
   - http://localhost:3000/practices/315059988/reports
2. 気分のアイコンが表示されていることを確認する
   ![image](https://user-images.githubusercontent.com/33394676/181864092-8561259a-5383-4b02-a516-8d2e9b306822.png)
