### PR TITLE
参考書籍一覧ページの本の表紙画像が表示されないバグを修正

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -17,7 +17,7 @@ class Book < ApplicationRecord
   def cover_url
     default_image_path = '/images/books/covers/default.svg'
     if cover.attached?
-      cover.variant(resize: COVER_SIZE)
+      cover.variant(resize: COVER_SIZE).processed.url
     else
       image_url default_image_path
     end


### PR DESCRIPTION
## 関連Issue

- #4949 

## 概要

関連Issueにおける以下のPRをマージした影響で、`https://bootcamp.fjord.jp/books`における本の表紙画像が表示されない問題が発生しましたので、その問題を修正しました。

- #5164 

<img width="1819" alt="参考書籍___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/181872403-d2bde30e-62dc-4f59-bb19-69cc9b630929.png">

## 修正確認方法

1. ブランチ`bug/fix-display-of-books-cover-images`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 管理者権限またはメンター権限を持つユーザーでログインする
4. `http://localhost:3000/books/new`にアクセスし、**適当な表紙画像を添付して**参考書籍を作成する。
5. `http://localhost:3000/books`において、各情報が問題なく表示されているかを確認する

## 修正前

<img width="1839" alt="_development__参考書籍___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/181875393-0571e23c-d7d8-446f-81ec-90c4efd3d863.png">

`http://localhost:3000/api/books.json`
![localhost_3000_api_books_json.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNWE3QWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--e773c458e8a51eac216d4fa08cc93f217a614e8c/localhost_3000_api_books_json.png)

## 修正後

<img width="1835" alt="_development__参考書籍___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/53898556/181875420-829dbb47-9da5-4419-b825-20a431ef667f.png">

`http://localhost:3000/api/books.json`
![localhost_3000_api_books_json.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNVc3QWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--30126dfe6688201ff8e22300d444faaf7fa26fcb/localhost_3000_api_books_json.png)

## 参考

- [Active Storage の概要 遅延読み込みとイミディエイト読み込み](https://railsguides.jp/active_storage_overview.html#%E9%81%85%E5%BB%B6%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%81%BF%E3%81%A8%E3%82%A4%E3%83%9F%E3%83%87%E3%82%A3%E3%82%A8%E3%82%A4%E3%83%88%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%81%BF)

- https://github.com/fjordllc/bootcamp/blob/24726304d8ade11971a7522f034b65189c521f58/app/models/user.rb#L540