### PR TITLE
落ちやすいテスト（プラクティスのメンターメモ機能のテスト）を改善した

### DIFF
--- a/test/system/practice/memos_test.rb
+++ b/test/system/practice/memos_test.rb
@@ -3,14 +3,13 @@
 require 'application_system_test_case'
 
 class Practice::MemoTest < ApplicationSystemTestCase
-  # TODO: リトライすると通るが、最後のアサーションでよくfailする。テキストエリアへの入力がうまくいってない？
   test 'update mentor memo without page transitions' do
     visit_with_auth "/products/#{products(:product2).id}", 'komagata'
     find('#side-tabs-nav-2').click
     click_button '編集'
+    assert_field('practice[memo]', with: '「OS X Mountain Lionをクリーンインストールする」のメンターメモ')
     practice = products(:product2).practice
     assert_changes -> { practice.reload.memo } do
-      fill_in('js-practice-memo', with: '') # テスト安定化のために実験的に追加してみた
       fill_in('js-practice-memo', with: 'メンター向けメモをページ遷移せず編集')
       click_button '保存する'
       assert_text '保存しました'


### PR DESCRIPTION
## Issue

- #5222
  - １つ目のテスト

## 概要

落ちやすいテストの改善。
テキストエリアの描画がテストの処理に追い付いていないために失敗していると考えられたため、対策としてテキストエリアが表示されたことを `assert_selector` で検証してから次の処理に移るようにした。

## GitHub Actionsのログ

- メモ編集・保存後の `assert_changes` で失敗している
- リトライで成功しているが、一旦失敗してリトライで成功する事が少なくとも３月頃から続いている様子

```
[MinitestRetry] retry 'test_update_mentor_memo_without_page_transitions' count: 1,  msg: #<Proc:0x00007f7655b86870 /home/runner/work/bootcamp/bootcamp/test/system/practice/memos_test.rb:12 (lambda)> didn't change.
Expected "「OS X Mountain Lionをクリーンインストールする」のメンターメモ" to not be equal to "「OS X Mountain Lionをクリーンインストールする」のメンターメモ".
```

## 開発環境での再現

CPUの使用率を100%近くにし続けると同様の失敗が再現した。
失敗する個所は２パターンあったが、いずれもテキストエリアに所定の文言を入力できていないために生じていると考えられる。入力できていない理由として、当該テキストエリアはJavaScript＋CSSによる表示の切り替えが起こるため、リソースが十分でない状況で「編集」ボタンをクリックした後、描画完了を待たずに次の処理に入っている可能性があると考えた。

### パターン１

- `assert_changes` で失敗する
  - GitHub Actionsで確認できたログと同じ

```
Minitest::Assertion: #<Proc:0x00007f0f698e2860 /home/yocajii/work/bootcamp/test/system/practice/memos_test.rb:12 (lambda)> didn't change.
Expected "「OS X Mountain Lionをクリーンインストールする」のメンターメモ" to not be equal to "「OS X Mountain Lionをクリーンインストールする」のメンターメモ".
test/system/practice/memos_test.rb:12:in `block in <class:MemoTest>'
```
![image](https://user-images.githubusercontent.com/33394676/182026445-4d6df1ff-c5f1-4558-b43b-9e4ea32449a7.png)

### パターン２

- `assert_text 'メンター向けメモをページ遷移せず編集'` で失敗する

```
Minitest::Assertion: expected to find text "メンター向けメモをページ遷移せず編集" in "お知らせ\nプラクティス\n65\n日報\n56\n提出物\n13\nQ&A\nDocs\nユーザー\nイベント\nヘルプ\n1\n相談\nメンター\n管理者\nメンターモード\nすべて\nお知らせ\nプラクティス\n日報\n提出物\nQ&A\nDocs\nイベント\nユーザー\nMe\n6\n通知\nOS X Mountain Lionをクリーンインストールする\nプラクティス一覧\n未完了一覧\nプラクティス\n日報 （3）\n質問 （11）\nDocs （1）\n提出物\n確認済\n2022/07/31\nkomagata\nkimura (Kimura Tadasi)\nOS X Mountain Lionをクリーンインストールするの提出物\n提出日\n2022年07月30日(土) 19:46\n更新\n2022年07月30日(土) 19:46\nコメント（\n0\n）\nWatch\nBookmark\nRaw\n終了条件を確認\n提出物\nテストの提出物2です。\n内容修正\n削除する\n提出物の確認を取り消す\nプラクティスに戻る\n提出物・自分の担当\n提出物・未アサイン\nコメント\nコメント\nプレビュー\nコメントする\n見たよ\n直近の日報\nプラクティスメモ\nユーザーメモ\n「OS X Mountain Lionをクリーンインストールする」のメンターメモ\n編集\nホームページ\n参考書籍\nGitHub Projects\nグッズ購入\nアンチハラスメントポリシー\n利用規約\nプライバシーポリシー\n特定商取引法に基づく表記\nコース一覧\n企業一覧\n#fjordbootcamp\nFjord Inc.2012 - 2022"
test/system/practice/memos_test.rb:19:in `block in <class:MemoTest>'
```
![image](https://user-images.githubusercontent.com/33394676/182026420-97e49be5-210d-490c-87fa-48a764cea8e2.png)

## 変更前後の比較

CPUの使用率を100%近くにした状態で当該のテストケースを複数回実行して失敗の頻度を確認した。

### 変更前

- 成功1回
- 失敗9回

### 変更後

- 成功10回
- 失敗0回