### PR TITLE
ユーザー一覧ページのtlteタグとページタイトル変更

### DIFF
--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,10 +1,10 @@
-- title 'ユーザー一覧'
+- title '全てのユーザー'
 
 header.page-header.is-border-bottom-none
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        | ユーザー
 
 = render 'lg_page_tabs'
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -418,9 +418,9 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.boolean "hold_national_holiday", null: false
     t.time "start_at", null: false
     t.time "end_at", null: false
-    t.boolean "wip", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "wip", default: false, null: false
     t.index ["user_id"], name: "index_regular_events_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -418,9 +418,9 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.boolean "hold_national_holiday", null: false
     t.time "start_at", null: false
     t.time "end_at", null: false
+    t.boolean "wip", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "wip", default: false, null: false
     t.index ["user_id"], name: "index_regular_events_on_user_id"
   end
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -3,6 +3,12 @@
 require 'application_system_test_case'
 
 class UsersTest < ApplicationSystemTestCase
+  test 'show listing all users' do
+    visit_with_auth users_path, 'kimura'
+    assert_equal '全てのユーザー | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector 'h2.page-header__title', text: 'ユーザー'
+  end
+
   test 'show profile' do
     visit_with_auth "/users/#{users(:hatsuno).id}", 'hatsuno'
     assert_equal 'hatsuno | FBC', title

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class UsersTest < ApplicationSystemTestCase
   test 'show listing all users' do
     visit_with_auth users_path, 'kimura'
-    assert_equal '全てのユーザー | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_equal '全てのユーザー | FBC', title
     assert_selector 'h2.page-header__title', text: 'ユーザー'
   end
 


### PR DESCRIPTION
## issue
- #5274 
## 概要
現在http://localhost:3000/users にアクセスした時、titleタグとページタイトルが

`ユーザー一覧`となっている。

これを

- titleタグ → `全てのユーザー`
- ページタイトル → `ユーザー`

に変更した。

## 変更確認方法
1. `feature/change-title-tag-and-page-title`ブランチをローカルに取り込む
2. `rails s`で立ち上げる
3. 一般ユーザーでログインする
4. http://localhost:3000/users にアクセスする

## 変更前
<img width="744" alt="_development__ユーザー一覧___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/72614612/182122305-6069a5fb-ef2f-4438-a24b-55a60257b352.png">

## 変更後
<img width="649" alt="_development__全てのユーザー___FJORD_BOOT_CAMP（フィヨルドブートキャンプ）" src="https://user-images.githubusercontent.com/72614612/182122679-9778e355-a879-4e1a-b5d8-8203dcadd40e.png">

