### PR TITLE
定期イベントが明日になった場合にDiscordで通知が飛ぶようにする

### DIFF
--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -12,6 +12,12 @@ class Scheduler::DailyController < SchedulerController
         end
       end
     end
+
+    if RegularEvent.tomorrow_events.present?
+      RegularEvent.tomorrow_events.each do |regular_event|
+        NotificationFacade.tomorrow_regular_event(regular_event)
+      end
+    end
     head :ok
   end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -206,4 +206,8 @@ class NotificationFacade
       receiver: receiver
     ).hibernated.deliver_later(wait: 5)
   end
+
+  def self.tomorrow_regular_event(event)
+    DiscordNotifier.with(event: event).tomorrow_regular_event.notify_now
+  end
 end

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -96,22 +96,8 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def next_specific_day_of_the_week(repeat_rule)
-    case repeat_rule.day_of_the_week
-    when 0
-      0.days.ago.next_occurring(:sunday).to_date
-    when 1
-      0.days.ago.next_occurring(:monday).to_date
-    when 2
-      0.days.ago.next_occurring(:tuesday).to_date
-    when 3
-      0.days.ago.next_occurring(:wednesday).to_date
-    when 4
-      0.days.ago.next_occurring(:thursday).to_date
-    when 5
-      0.days.ago.next_occurring(:friday).to_date
-    when 6
-      0.days.ago.next_occurring(:saturday).to_date
-    end
+    day_of_the_week_symbol = DateAndTime::Calculations::DAYS_INTO_WEEK.key(repeat_rule.day_of_the_week)
+    0.days.ago.next_occurring(day_of_the_week_symbol).to_date
   end
 
   def tomorrow_event?

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
+class RegularEvent < ApplicationRecord
   DAYS_OF_THE_WEEK_COUNT = 7
 
   FREQUENCY_LIST = [

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RegularEvent < ApplicationRecord
+class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   DAYS_OF_THE_WEEK_COUNT = 7
 
   FREQUENCY_LIST = [

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RegularEvent < ApplicationRecord
+class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   DAYS_OF_THE_WEEK_COUNT = 7
 
   FREQUENCY_LIST = [
@@ -39,6 +39,8 @@ class RegularEvent < ApplicationRecord
   with_options if: -> { start_at && end_at } do
     validate :end_at_be_greater_than_start_at
   end
+
+  scope :holding, -> { where.not(finished: true) }
 
   belongs_to :user
   has_many :organizers, dependent: :destroy
@@ -94,8 +96,40 @@ class RegularEvent < ApplicationRecord
   end
 
   def next_specific_day_of_the_week(repeat_rule)
-    day_of_the_week_symbol = DateAndTime::Calculations::DAYS_INTO_WEEK.key(repeat_rule.day_of_the_week)
-    0.days.ago.next_occurring(day_of_the_week_symbol).to_date
+    case repeat_rule.day_of_the_week
+    when 0
+      0.days.ago.next_occurring(:sunday).to_date
+    when 1
+      0.days.ago.next_occurring(:monday).to_date
+    when 2
+      0.days.ago.next_occurring(:tuesday).to_date
+    when 3
+      0.days.ago.next_occurring(:wednesday).to_date
+    when 4
+      0.days.ago.next_occurring(:thursday).to_date
+    when 5
+      0.days.ago.next_occurring(:friday).to_date
+    when 6
+      0.days.ago.next_occurring(:saturday).to_date
+    end
+  end
+
+  def tomorrow_event?
+    tomorrow = Time.current.next_day
+    regular_event_repeat_rules.map do |repeat_rule|
+      if repeat_rule.frequency.zero?
+        repeat_rule.day_of_the_week == tomorrow.wday
+      else
+        repeat_rule.day_of_the_week == tomorrow.wday && repeat_rule.frequency == convert_date_into_week(tomorrow.day)
+      end
+    end.include?(true)
+  end
+
+  class << self
+    def tomorrow_events
+      holding_events = RegularEvent.holding
+      holding_events.select(&:tomorrow_event?)
+    end
   end
 
   private

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -40,7 +40,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     validate :end_at_be_greater_than_start_at
   end
 
-  scope :holding, -> { where.not(finished: true) }
+  scope :holding, -> { where(finished: false) }
 
   belongs_to :user
   has_many :organizers, dependent: :destroy

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -25,4 +25,25 @@ class DiscordNotifier < ApplicationNotifier
       webhook_url: webhook_url
     )
   end
+
+  def tomorrow_regular_event(params = {})
+    params.merge!(@params)
+    event = params[:event]
+    webhook_url = params[:webhook_url] || ENV['DISCORD_ALL_WEBHOOK_URL']
+    day_of_the_week = %w[日 月 火 水 木 金 土]
+    event_date = event.next_event_date
+
+    notification(
+      body: "⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
+      【イベントのお知らせ】
+      明日 #{event_date.strftime("%m月%d日（#{day_of_the_week[event_date.wday]}）")}に開催されるイベントです！
+      --------------------------------------------
+      #{event.title}
+      時間: #{event.start_at.strftime('%H:%M')} 〜 #{event.end_at.strftime('%H:%M')}
+      詳細: #{Rails.application.routes.url_helpers.regular_event_url(event)}
+      --------------------------------------------\n⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️",
+      name: 'ピヨルド',
+      webhook_url: webhook_url
+    )
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -88,4 +88,6 @@ Rails.application.configure do
 
   config.rack_dev_mark.enable = true
   config.rack_dev_mark.theme = [:title, Rack::DevMark::Theme::GithubForkRibbon.new(position: 'right-bottom')]
+
+  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -133,4 +133,7 @@ Rails.application.configure do
    AnyLogin.setup do |config|
      config.enabled = false
    end
+   
+   Rails.application.routes.default_url_options[:host] = ENV["APP_HOST_NAME"]
+   Rails.application.routes.default_url_options[:protocol] = 'https'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,4 +59,5 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
 end

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -37,4 +37,31 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       DiscordNotifier.with(params).graduated.notify_later
     end
   end
+
+  test '.tomorrow_regular_event' do
+    params = {
+      event: regular_events(:regular_event1),
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    expected = {
+      body: "⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
+      【イベントのお知らせ】
+      明日 07月31日（日）に開催されるイベントです！
+      --------------------------------------------
+      開発MTG
+      時間: 15:00 〜 16:00
+      詳細: http://localhost:3000/regular_events/459650222
+      --------------------------------------------\n⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️",
+      name: 'ピヨルド',
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    travel_to Time.zone.local(2022, 7, 30, 0, 0, 0) do
+      assert_notifications_sent 2, **expected do
+        DiscordNotifier.tomorrow_regular_event(params).notify_now
+        DiscordNotifier.with(params).tomorrow_regular_event.notify_now
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
* 明日が定期イベントの開催日である場合、Discordに開催するイベントの情報を自動通知するようにする
* Discordの通知チャンネルは「お知らせ」チャンネルとする

## issue
https://github.com/fjordllc/bootcamp/issues/4572

## UI

## 確認方法
* mainブランチからfeature/add-discord-notify-for-tomorrow-regular-eventブランチへ移動する
* app/notifiers/discord_notifier.rb の 46行目にある webhook_urlの値を自分のDiscordのサーバーのwebhookのURLに置き換える（置き換えないと通知のテストができないため）
*  webhookのURLの取得方法は[こちら](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks)
* 終了していない定期イベントを編集し、テストしている日の次の日の開催になるようにする（2022年8月2日にテストする場合は、2022年8月3日に開催されるイベントがある状態にするということ）
* 上記が全て整ったら、http://localhost:3000/scheduler/daily にアクセスする（画面は何も表示されないが、処理が走ります）
* Discordの通知に以下のような内容で通知が来ることを確認する

<img width="603" alt="image" src="https://user-images.githubusercontent.com/20497053/182416132-ac2fb1ee-a67d-4d3e-99f0-7c2232e5aa87.png">

## テスト観点
- [ ] 定期イベントの編集がエラーなく行えること
- [ ] 定期イベントの作成がエラーなく行えること
- [ ] webhook_urlを個人のDiscordサーバーから取得し、アプリケーションに設定した状態で http://localhost:3000/scheduler/daily にアクセスしてエラーが起きないこと
- [ ] http://localhost:3000/scheduler/daily にアクセスするとDiscordに通知が飛ぶこと
- [ ] Discordへの通知が行われた際、タイトル、時刻、イベントのURLが通知に含まれること
- [ ] Discordの通知に含まれるイベントのURLをクリックすると正しくそのイベントの詳細ページに遷移すること
- [ ] 対象のイベントがない場合は通知が飛ばないこと