### PR TITLE
ユーザー個別ページのコースにコース詳細へのリンクを貼る

### DIFF
--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -17,7 +17,7 @@
       .user-metas__item-label
         | コース
       .user-metas__item-value
-        = link_to user.course.title, course_practices_path(user.course_id), target: '_blank', rel: 'noopener'
+        = link_to user.course.title, course_practices_path(user.course), target: '_blank', rel: 'noopener'
     .user-metas__item
       .user-metas__item-label
         | 日報

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -17,7 +17,7 @@
       .user-metas__item-label
         | コース
       .user-metas__item-value
-        = user.course.title
+        = link_to user.course.title, course_practices_path(user.course_id), target: '_blank'
     .user-metas__item
       .user-metas__item-label
         | 日報

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -17,7 +17,7 @@
       .user-metas__item-label
         | コース
       .user-metas__item-value
-        = link_to user.course.title, course_practices_path(user.course_id), target: '_blank'
+        = link_to user.course.title, course_practices_path(user.course_id), target: '_blank', rel: 'noopener'
     .user-metas__item
       .user-metas__item-label
         | 日報

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -83,12 +83,6 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_text 'Terminalの基礎を覚える'
   end
 
-  test 'show course link' do
-    course = courses(:course1)
-    visit_with_auth "/users/#{users(:kimura).id}", 'kimura'
-    assert_link course.title, href: course_practices_path(course)
-  end
-
   test 'show last active date and time of access user only to mentors' do
     travel_to Time.zone.local(2014, 1, 1, 0, 0, 0) do
       visit_with_auth login_path, 'kimura'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -83,6 +83,12 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_text 'Terminalの基礎を覚える'
   end
 
+  test 'show course link' do
+    course = courses(:course1)
+    visit_with_auth "/users/#{users(:kimura).id}", 'kimura'
+    assert_link course.title, href: course_practices_path(course)
+  end
+
   test 'show last active date and time of access user only to mentors' do
     travel_to Time.zone.local(2014, 1, 1, 0, 0, 0) do
       visit_with_auth login_path, 'kimura'


### PR DESCRIPTION
## Issue

- #5310

## 概要

【現在】

ユーザー個別ページのコースにコース詳細へのリンクがない。

【変更点】

ユーザー個別ページのコースにコース詳細へのリンクを貼った。

- リンク先は、/courses/{course_id}/practicesというそのコースのプラクティス一覧。
- target blankを付けて別タグで開くようにした。

## 変更確認方法

1. ブランチ`feature/show-course-link`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. kimuraでログインし、http://localhost:3000/users/991528156 にアクセスする。
4. コースの箇所を確認する。

## 変更前

<img width="626" alt="スクリーンショット 2022-08-03 22 25 08" src="https://user-images.githubusercontent.com/98577773/182619349-4bcaf558-f52f-4a2d-9970-df60e92e5d43.png">

## 変更後

<img width="629" alt="スクリーンショット 2022-08-03 22 26 02" src="https://user-images.githubusercontent.com/98577773/182619378-3a6158e4-fdca-448a-8e1e-0aa912bc16ad.png">