### PR TITLE
【メンター向け】非公開のコースをメンターも見れるようにする

### DIFF
--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -1,5 +1,5 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .courses-item(id="course_#{course.id}" class="#{course.published ? 'is-published' : 'is-closed'}")
+  .courses-item(id="course_#{course.id}" class="#{(current_user.mentor? && !current_user.admin?) || course.published ? 'is-published' : 'is-closed'}")
     .courses-item__inner.a-card
       header.courses-item__header
         h3.courses-item__title

--- a/app/views/courses/index.html.slim
+++ b/app/views/courses/index.html.slim
@@ -15,7 +15,7 @@ header.page-header
   .container
     .courses-items
       .row
-        - if current_user&.admin? && @courses.present?
+        - if (current_user&.admin? && @courses.present?) || (current_user&.mentor? && @courses.present?)
           = render @courses.order(:created_at)
         - elsif !current_user&.admin? && @courses.where(published: true).present?
           = render @courses.where(published: true).order(:created_at)

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -30,30 +30,23 @@ class CoursesTest < ApplicationSystemTestCase
   end
 
   test 'show published courses' do
+    visit_with_auth '/courses', 'hajime'
+    assert_no_text courses(:course1).title
     visit_with_auth "/admin/courses/#{courses(:course1).id}/edit", 'komagata'
     within 'form[name=course]' do
       find(:css, '#checkbox-published-course').set(true)
       click_button '内容を保存'
     end
-    visit_with_auth '/courses', 'mentormentaro'
+    visit_with_auth '/courses', 'hajime'
     assert_text courses(:course1).title
   end
 
   test 'mentors can see closed courses' do
     visit_with_auth "/admin/courses/#{courses(:course1).id}/edit", 'komagata'
     within 'form[name=course]' do
-      assert_equal false, find(:css, '#checkbox-published-course').checked?
+      assert_not find(:css, '#checkbox-published-course').checked?
     end
     visit_with_auth '/courses', 'mentormentaro'
     assert_text courses(:course1).title
-  end
-
-  test 'general users cannot see closed courses' do
-    visit_with_auth "/admin/courses/#{courses(:course1).id}/edit", 'komagata'
-    within 'form[name=course]' do
-      assert_equal false, find(:css, '#checkbox-published-course').checked?
-    end
-    visit_with_auth '/courses', 'hajime'
-    assert_no_text courses(:course1).title
   end
 end

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -40,4 +40,22 @@ class CoursesTest < ApplicationSystemTestCase
     visit_with_auth '/courses', 'mentormentaro'
     assert_text courses(:course1).title
   end
+
+  test 'mentors can see closed courses' do
+    visit_with_auth "/admin/courses/#{courses(:course1).id}/edit", 'komagata'
+    within 'form[name=course]' do
+      assert_equal false, find(:css, '#checkbox-published-course').checked?
+    end
+    visit_with_auth '/courses', 'mentormentaro'
+    assert_text courses(:course1).title
+  end
+
+  test 'general users cannot see closed courses' do
+    visit_with_auth "/admin/courses/#{courses(:course1).id}/edit", 'komagata'
+    within 'form[name=course]' do
+      assert_equal false, find(:css, '#checkbox-published-course').checked?
+    end
+    visit_with_auth '/courses', 'hajime'
+    assert_no_text courses(:course1).title
+  end
 end

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -30,8 +30,6 @@ class CoursesTest < ApplicationSystemTestCase
   end
 
   test 'show published courses' do
-    visit_with_auth '/courses', 'mentormentaro'
-    assert_no_text courses(:course1).title
     visit_with_auth "/admin/courses/#{courses(:course1).id}/edit", 'komagata'
     within 'form[name=course]' do
       find(:css, '#checkbox-published-course').set(true)


### PR DESCRIPTION
## Issue

- #5302

## 概要

【現在】

非公開のコースは管理者しか見れない。

【変更点】

非公開のコースをメンターも見れるようにした。

※ 一般ユーザーは公開されたコースしか見れません。
※ 管理者は非公開・公開を設定できるため、非公開のコースに関しては`is-closed`のクラスが当たっていますが、管理者権限のないメンターは非公開・公開に関わらず全てのコースが表示されるため、非公開のコースでも`is-published`を当てています。

【管理者】

<img width="1344" alt="スクリーンショット 2022-08-03 23 02 07" src="https://user-images.githubusercontent.com/98577773/182627845-f01954e5-016d-49ac-982f-a1c973306912.png">

【管理者権限のないメンター】

<img width="1338" alt="スクリーンショット 2022-08-03 23 02 25" src="https://user-images.githubusercontent.com/98577773/182627877-8cf9b527-a378-46ea-bbcf-9ba5c26fdc3c.png">

## 変更確認方法

1. ブランチ`feature/show-private-courses-to-mentors`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. mentormentaroでログインし、http://localhost:3000/courses にアクセスする。
4. コース一覧を確認する。

## 変更前

<img width="1341" alt="スクリーンショット 2022-08-03 22 48 59" src="https://user-images.githubusercontent.com/98577773/182624796-644d6fb6-9010-4b99-8ff7-5be6904a3062.png">

## 変更後

<img width="1337" alt="スクリーンショット 2022-08-03 22 50 39" src="https://user-images.githubusercontent.com/98577773/182625011-d8d74ff9-080f-4a7d-bb71-2b2f523da2a2.png">