### PR TITLE
落ちやすいテストを２つ直す

### DIFF
--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -209,7 +209,7 @@ report23:
   emotion: 2
   description:
     フォローされました。
-  reported_on: "2022-03-31"
+  reported_on: "2022-03-30"
 
 report24:
   user: kimura

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -264,6 +264,7 @@ class CommentsTest < ApplicationSystemTestCase
     find('#js-new-comment').set('test')
     click_button 'コメントする'
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    assert_selector '.a-markdown-input__inner.js-tabs__content.is-active'
     within('#new-comment-preview') do
       assert_no_text :all, 'test'
     end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -263,8 +263,9 @@ class CommentsTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     find('#js-new-comment').set('test')
     click_button 'コメントする'
-    all('.a-form-tabs__tab.js-tabs__tab')[1].click
-    assert_selector '.a-markdown-input__inner.js-tabs__content.is-active'
+    assert_text 'test'
+    find('.a-form-tabs__tab.js-tabs__tab', text: 'プレビュー').click
+    assert_selector '.a-form-tabs__tab.is-active', text: 'プレビュー'
     within('#new-comment-preview') do
       assert_no_text :all, 'test'
     end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -384,6 +384,8 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth reports_path, 'kimura'
     precede = reports(:report24).title
     succeed = reports(:report23).title
+    assert_text '検索用の日報'
+    assert_text 'フォローされた日報'
     within '.card-list__items' do
       assert page.text.index(precede) < page.text.index(succeed)
     end


### PR DESCRIPTION
## Issue

- #5330

## 概要

下記の落ちやすいテストの改善。

- test/system/reports_test.rb:383
- test/system/comments_test.rb:262

## 落ちた時のログ

### test/system/reports_test.rb:383

<img width="850" alt="スクリーンショット 2022-08-06 16 06 30" src="https://user-images.githubusercontent.com/98577773/183246983-1135d30d-df84-4ee5-b756-8e7e98d5696f.png">

<img width="1300" alt="スクリーンショット 2022-08-06 16 01 09" src="https://user-images.githubusercontent.com/98577773/183246986-1803b6bc-7a70-4476-a086-6d53f3b26211.png">

### test/system/comments_test.rb:262

<img width="851" alt="スクリーンショット 2022-08-06 1 38 49" src="https://user-images.githubusercontent.com/98577773/183246994-ac82c9c4-11e3-4a9e-a296-60776d35daf6.png">

<img width="1309" alt="スクリーンショット 2022-08-06 16 13 48" src="https://user-images.githubusercontent.com/98577773/183246998-5e355501-decd-476d-aeb4-97282be733b7.png">

## 落ちた原因

### test/system/reports_test.rb:383

①日報の読み込み中にテストが走っていたので、`.card-list__items`が見つからなかったというエラーが表示されて落ちていた。(asset_textをつけることで表示されていること確認しつつ、asset_textで内部的に表示されるまで待つようにした)

### test/system/comments_test.rb:262
①プレビューの読み込み中にテストが走っていたので、`#new-comment-preview`が見つからなかったというエラーが表示されて落ちていた。(asset_selectorをつけることで表示されていること確認しつつ、asset_selectorで内部的に表示されるまで待つようにした)

## 確認方法
- `rails test test/system/reports_test.rb:383`を複数回実行して落ちていないか確認する。
- `rails test test/system/comments_test.rb:262`を複数回実行して落ちていないか確認する。
- ciを複数回実行して`test/system/reports_test.rb:383`が落ちていないか確認する。
- ciを複数回実行して`test/system/comments_test.rb:262`が落ちていないか確認する。
