### PR TITLE
落ちやすいテスト（Q&Aのコメントプレビュー機能のテスト）を改善した

### DIFF
--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -94,7 +94,7 @@ class AnswersTest < ApplicationSystemTestCase
     find('#js-new-comment').set('test')
     click_button 'コメントする'
     find('.thread-comment__description > div > p', text: 'test')
-    all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    find('.a-form-tabs__tab.js-tabs__tab', text: 'プレビュー').click
     within('#new-comment-preview') do
       assert_no_text :all, 'test'
     end

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -93,6 +93,7 @@ class AnswersTest < ApplicationSystemTestCase
     visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
     find('#js-new-comment').set('test')
     click_button 'コメントする'
+    find('.thread-comment__description > div > p', text: 'test')
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     within('#new-comment-preview') do
       assert_no_text :all, 'test'


### PR DESCRIPTION
## Issue

- #5222
  - ２つ目のテスト

## 概要

落ちやすいテストの改善。
対象は `test/system/answers_test.rb` の `test 'clear preview after posting comment for question'`。

コメントの投稿完了を待たずにプレビュータブをクリックした時にテストが落ちていると考えられたため、対策として投稿した最新のコメントが表示されたことを確認してから次の処理に移るようにした。

### 補足

`test/system/comments_test.rb` の `test 'clear preview after posting new comment for report'` も同様の処理になっていますが、すでにdaiki0381さんが対応中でしたので、このPRでは `test 'clear preview after posting comment for question'` のみを対象としています。

## GitHub Actionsのログ

```
[Screenshot Image]: /home/runner/work/bootcamp/bootcamp/tmp/screenshots/failures_test_clear_preview_after_posting_comment_for_question.png
[MinitestRetry] retry 'test_clear_preview_after_posting_comment_for_question' count: 1,  msg: Capybara::ElementNotFound: Unable to find css "#new-comment-preview"
    test/system/answers_test.rb:97:in `block in <class:AnswersTest>'
....[Screenshot Image]: /home/runner/work/bootcamp/bootcamp/tmp/screenshots/failures_test_clear_preview_after_posting_comment_for_question.png
[MinitestRetry] retry 'test_clear_preview_after_posting_comment_for_question' count: 2,  msg: Capybara::ElementNotFound: Unable to find visible css "#new-comment-preview"
    test/system/answers_test.rb:97:in `block in <class:AnswersTest>'
...[Screenshot Image]: /home/runner/work/bootcamp/bootcamp/tmp/screenshots/failures_test_clear_preview_after_posting_comment_for_question.png
[MinitestRetry] retry 'test_clear_preview_after_posting_comment_for_question' count: 3,  msg: Capybara::ElementNotFound: Unable to find visible css "#new-comment-preview"
    test/system/answers_test.rb:97:in `block in <class:AnswersTest>'
```

## 開発環境での再現

CPUの使用率を100%近くにし続けた上でテストファイル単位で実行すると同様の失敗が再現した。
```
Minitest::UnexpectedError: Capybara::ElementNotFound: Unable to find visible css "#new-comment-preview"
    test/system/answers_test.rb:97:in `block in <class:AnswersTest>'
test/system/answers_test.rb:97:in `block in <class:AnswersTest>'
```

クリック済のはずのプレビュータブがアクティブになっていない。
![image](https://user-images.githubusercontent.com/33394676/183250936-4241ef69-0bc4-4e71-9f2f-c45a94791982.png)

## 変更前後の比較

CPUの使用率を100%近くにした状態でテストファイル単位で複数回実行して当該テストケースの失敗の頻度を確認した。

### 変更前

- 成功7回
- 失敗3回

### 変更後

- 成功10回
- 失敗0回

## GitHub Actions

テストを5回実行してログを確認し、`test 'clear preview after posting comment for question'` の失敗（リトライを含む）は発生していないことを確認した。