### PR TITLE
検索結果にアイコンを表示する

### DIFF
--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -37,6 +37,13 @@
             .card-list-item-meta__item(
               v-if='!["practice", "page", "user"].includes(searchable.model_name)'
             )
+              a.a-img-user-icon(:href='userUrl')
+                img.user-icon.a-user-icon(
+                  :src='searchable.avatar_url',
+                  :title='searchable.icon_title',
+                  :alt='searchable.icon_title',
+                  :class='roleClass'
+                )
               a.a-user-name(:href='userUrl')
                 | {{ searchable.login_name }}
             .card-list-item-meta__item

--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -37,15 +37,16 @@
             .card-list-item-meta__item(
               v-if='!["practice", "page", "user"].includes(searchable.model_name)'
             )
-              a.a-img-user-icon(:href='userUrl')
-                img.user-icon.a-user-icon(
-                  :src='searchable.avatar_url',
-                  :title='searchable.icon_title',
-                  :alt='searchable.icon_title',
-                  :class='roleClass'
-                )
-              a.a-user-name(:href='userUrl')
-                | {{ searchable.login_name }}
+              .card-list-item-meta__user
+                a.card-list-item-meta__icon-link(:href='userUrl')
+                  img.card-list-item-meta__icon.a-user-icon(
+                    :src='searchable.avatar_url',
+                    :title='searchable.icon_title',
+                    :alt='searchable.icon_title',
+                    :class='roleClass'
+                  )
+                a.a-user-name(:href='userUrl')
+                  | {{ searchable.login_name }}
             .card-list-item-meta__item
               time.a-meta(:datetime='searchable.updated_at', pubdate='pubdate')
                 | {{ updatedAt }}

--- a/app/views/api/searchables/_searchable.json.jbuilder
+++ b/app/views/api/searchables/_searchable.json.jbuilder
@@ -9,6 +9,9 @@ json.wip searchable.respond_to?(:wip?) ? searchable.wip? : false
 if searchable.respond_to?(:user)
   json.login_name searchable.user.login_name
   json.user_id searchable.user.id
+  json.avatar_url searchable.user.avatar_url
+  json.icon_title searchable.user.icon_title
+  json.primary_role searchable.user.primary_role
 end
 json.is_comment_or_answer comment_or_answer?(searchable)
 if comment_or_answer?(searchable)

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -79,7 +79,7 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_text 'テストの日報'
   end
 
-  test 'show user icon , name and updated time in report' do
+  test 'show user icon, name and updated time in report' do
     visit_with_auth '/', 'hatsuno'
     within('form[name=search]') do
       select '日報'
@@ -88,7 +88,7 @@ class SearchablesTest < ApplicationSystemTestCase
     find('#test-search').click
     assert_text 'mentormentaro'
     assert_css '.a-meta'
-    assert_css 'img.user-icon.a-user-icon'
+    assert_css 'img.card-list-item-meta__icon.a-user-icon'
     assert_no_text 'テストの回答'
   end
 
@@ -164,9 +164,9 @@ class SearchablesTest < ApplicationSystemTestCase
       fill_in 'word', with: '提出物のコメントです。'
     end
     find('#test-search').click
-    assert find('img.user-icon.a-user-icon')['src'].include?('komagata.png')
+    assert find('img.card-list-item-meta__icon.a-user-icon')['src'].include?('komagata.png')
 
-    find('img.user-icon.a-user-icon').click
+    find('img.card-list-item-meta__icon.a-user-icon').click
     assert_selector 'h1.user-profile__login-name', text: 'komagata'
   end
 
@@ -177,6 +177,6 @@ class SearchablesTest < ApplicationSystemTestCase
       fill_in 'word', with: 'hajime'
     end
     find('#test-search').click
-    assert_no_css 'img.user-icon.a-user-icon'
+    assert_no_css 'img.card-list-item-meta__icon.a-user-icon'
   end
 end

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -79,7 +79,7 @@ class SearchablesTest < ApplicationSystemTestCase
     assert_text 'テストの日報'
   end
 
-  test 'show user name and updated time' do
+  test 'show user icon , name and updated time in report' do
     visit_with_auth '/', 'hatsuno'
     within('form[name=search]') do
       select '日報'
@@ -88,6 +88,7 @@ class SearchablesTest < ApplicationSystemTestCase
     find('#test-search').click
     assert_text 'mentormentaro'
     assert_css '.a-meta'
+    assert_css 'img.user-icon.a-user-icon'
     assert_no_text 'テストの回答'
   end
 
@@ -154,5 +155,28 @@ class SearchablesTest < ApplicationSystemTestCase
     end
     find('#test-search').click
     assert_text '相談部屋'
+  end
+
+  test 'show icon and go profile page when click icon' do
+    visit_with_auth '/', 'hatsuno'
+    within('form[name=search]') do
+      select 'すべて'
+      fill_in 'word', with: '提出物のコメントです。'
+    end
+    find('#test-search').click
+    assert find('img.user-icon.a-user-icon')['src'].include?('komagata.png')
+
+    find('img.user-icon.a-user-icon').click
+    assert_selector 'h1.user-profile__login-name', text: 'komagata'
+  end
+
+  test 'disappear icon when search user' do
+    visit_with_auth '/', 'hatsuno'
+    within('form[name=search]') do
+      select 'ユーザー'
+      fill_in 'word', with: 'hajime'
+    end
+    find('#test-search').click
+    assert_no_css 'img.user-icon.a-user-icon'
   end
 end


### PR DESCRIPTION
## Issue
- #5184

## 概要

![2022-08-05 (1)](https://user-images.githubusercontent.com/82737807/183291501-0dd9a1de-7771-42a7-8eca-e8bab501b2a7.png)
検索結果にアイコンを表示する
## 実装確認方法
- feature/display_icon_in_search_result ブランチを取り込む
- ログインし（権限に制限なし）、検索窓で検索する
- 検索結果がユーザー、プラクティス、Docsの場合、アイコンは表示されない
- 上記以外の時にコンテンツ作成者のアイコンが表示される
（コメントの時は元コンテンツの作成者ではなく、コメントした人のアイコン）
- Q&Aページ(/questions) 等の他のアイコン表示箇所と同じように、
   - アイコンにホバーするとユーザー名とroleがポップアップ表示される
   - アイコンをクリックするとユーザーのプロフィール画面に遷移する
## テストについて
テストはアイコンが付くパターン、付かないパターンの2種類と、コメントした人のアイコンがついていること＋アイコンクリック時のリンクを確認するテストを実装している。
本来なら、プラクティス、Q&A、ユーザー、日報等すべてのパターンで確認すべきかもしれないが、検索結果にアイコンがつくことの重要性は高くはないだろうと思うので、最低限でいいのではないかと考えた。



