### PR TITLE
[コース]カテゴリー個別ページを作成した

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class Admin::CategoriesController < AdminController
-  before_action :set_category, only: %i[edit update destroy]
+  before_action :set_category, only: %i[show edit update destroy]
 
   def index
     @categories = Category.all
   end
+
+  def show; end
 
   def new
     @category = Category.new

--- a/app/javascript/categories.vue
+++ b/app/javascript/categories.vue
@@ -12,7 +12,8 @@
     tbody.admin-table__items
       tr.admin-table__item(v-for='category in categories', :key='category.id')
         td.admin-table__item-value
-          | {{ category.name }}
+          a(:href='`/admin/categories/${category.id}`')
+            | {{ category.name }}
         td.admin-table__item-value
           | {{ category.slug }}
         td.admin-table__item-value.is-text-align-center

--- a/app/views/admin/categories/_form.html.slim
+++ b/app/views/admin/categories/_form.html.slim
@@ -16,6 +16,9 @@
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
           = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area practices-edit__input', data: { 'preview': '.js-preview' }
+          .a-form-help
+            p
+              | これを学ぶことで身に付くのか？これを学ぶことの目標、これを学ぶにあたっての必要な前提条件、修了していないといけないプラクティスを記入してください。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/admin/categories/show.html.slim
+++ b/app/views/admin/categories/show.html.slim
@@ -1,0 +1,50 @@
+- title @category.name
+
+header.page-header
+  .container
+    .page-header__inner
+      h1.page-header__title
+        | 管理ページ
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+            = link_to new_admin_category_path, class: 'a-button is-md is-secondary is-block' do
+              i.fa-regular.fa-plus
+              | カテゴリー作成
+
+= render 'admin/admin_page_tabs'
+
+.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        h1.page-main-header__title
+          = title
+  .page-body
+    .container.is-md
+      div
+        | URLスラッグ
+      div
+        = @category.slug
+      div
+        | 詳細
+      div
+        = @category.description
+      .admin-table
+        table.admin-table__table
+          thead.admin-table__header
+            tr.admin-table__labels
+              th.admin-table__label
+                | プラクティス
+              / th.admin-table__label
+              /   | 操作
+          tbody.admin-table__items
+            - @category.practices.each do |practice|
+              tr.admin-table__item(id="practice_#{practice.id}")
+                td.admin-table__item-value
+                  = link_to practice.title, practice_path(practice)
+                / td.admin-table__item-value.is-text-align-center
+                /   ul.is-inline-buttons
+                /     li
+                /       = link_to edit_practice_path(practice), class: 'a-button is-sm is-secondary is-icon' do
+                /         i.fa-solid.fa-pen

--- a/app/views/admin/categories/show.html.slim
+++ b/app/views/admin/categories/show.html.slim
@@ -20,6 +20,9 @@ header.page-header
       .page-main-header__inner
         h1.page-main-header__title
           = title
+          .categories-item__edit
+            = link_to edit_admin_category_path(@category), class: 'categories-item__edit-link'
+              i.fa-solid.fa-pen
   .page-body
     .container.is-md
       div
@@ -36,15 +39,15 @@ header.page-header
             tr.admin-table__labels
               th.admin-table__label
                 | プラクティス
-              / th.admin-table__label
-              /   | 操作
+              th.admin-table__label
+                | 操作
           tbody.admin-table__items
             - @category.practices.each do |practice|
               tr.admin-table__item(id="practice_#{practice.id}")
                 td.admin-table__item-value
                   = link_to practice.title, practice_path(practice)
-                / td.admin-table__item-value.is-text-align-center
-                /   ul.is-inline-buttons
-                /     li
-                /       = link_to edit_practice_path(practice), class: 'a-button is-sm is-secondary is-icon' do
-                /         i.fa-solid.fa-pen
+                td.admin-table__item-value.is-text-align-center
+                  ul.is-inline-buttons
+                    li
+                      = link_to edit_practice_path(practice), class: 'a-button is-sm is-secondary is-icon' do
+                        i.fa-solid.fa-pen

--- a/app/views/admin/categories/show.html.slim
+++ b/app/views/admin/categories/show.html.slim
@@ -15,39 +15,70 @@ header.page-header
 = render 'admin/admin_page_tabs'
 
 .page-main
-  header.page-main-header
-    .container
-      .page-main-header__inner
-        h1.page-main-header__title
-          = title
-          .categories-item__edit
-            = link_to edit_admin_category_path(@category), class: 'categories-item__edit-link'
-              i.fa-solid.fa-pen
   .page-body
-    .container.is-md
-      div
-        | URLスラッグ
-      div
-        = @category.slug
-      div
-        | 詳細
-      div
-        = @category.description
-      .admin-table
-        table.admin-table__table
-          thead.admin-table__header
-            tr.admin-table__labels
-              th.admin-table__label
+    .container.is-xxxl
+      .row.is-jc:c
+        .col-xl-7.col-xs-12
+          .page-content.category
+            header.page-content-header
+              .page-content-header__end
+                .page-content-header__row
+                  h1.page-content-header__title
+                    = title
+                .page-content-header__row
+                  .page-content-header-metas
+                    .page-content-header-metas__start
+                      .page-content-header-metas__meta
+                        .a-meta
+                          .a-meta__label
+                            | URLスラッグ
+                          .a-meta__value
+                            = @category.slug
+            .a-card
+              .card-header.is-sm
+                h2.card-header__title
+                  | 説明
+              .card-body
+                .card__description
+                  .a-long-text.is-md.js-markdown-view
+                    = @category.description
+                .card-footer
+                  .card-main-actions
+                    ul.card-main-actions__items
+                      li.card-main-actions__item
+                        = link_to edit_admin_category_path(@category), class: 'card-main-actions__action a-button is-sm is-secondary is-block' do
+                          i.fa-solid.fa-pen
+                          | 編集
+            .page-content-prev-next
+              .page-content-prev-next__item
+              .page-content-prev-next__item
+                = link_to admin_categories_path, class: 'page-content-prev-next__item-link is-index' do
+                  | カテゴリー一覧
+              .page-content-prev-next__item
+        .col-xl-5.col-xs-12
+          .card-list.a-card
+            .card-header.is-sm
+              h2.card-header__title
                 | プラクティス
-              th.admin-table__label
-                | 操作
-          tbody.admin-table__items
-            - @category.practices.each do |practice|
-              tr.admin-table__item(id="practice_#{practice.id}")
-                td.admin-table__item-value
-                  = link_to practice.title, practice_path(practice)
-                td.admin-table__item-value.is-text-align-center
-                  ul.is-inline-buttons
-                    li
-                      = link_to edit_practice_path(practice), class: 'a-button is-sm is-secondary is-icon' do
-                        i.fa-solid.fa-pen
+                | （#{@category.practices.count}）
+            - if @category.practices.present?
+              .card-list__items
+                - @category.practices.each do |practice|
+                  .card-list-item(id="practice_#{practice.id}")
+                    .card-list-item__inner
+                      .card-list-item__rows
+                        .card-list-item__row
+                          header.card-list-item-title
+                            .card-list-item-title__start
+                              h3.card-list-item-title__title
+                                = link_to practice.title, practice_path(practice), class: 'card-list-item-title__link a-text-link'
+                            .card-list-item-title__end
+                              = link_to edit_practice_path(practice), class: 'a-button is-xs is-secondary is-icon' do
+                                i.fa-solid.fa-pen
+            - else
+              .card-list__message
+                .o-empty-message
+                  .o-empty-message__icon
+                    i.fa-regular.fa-sad-tear
+                  .o-empty-message__text
+                    | 紐づくプラクティスはありません。

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     resources :users, only: %i(index show edit update destroy) do
       resource :password, only: %i(edit update), controller: "users/password"
     end
-    resources :categories, except: %i(show)
+    resources :categories
     resources :courses, except: %i(show destroy)
     resources :campaigns, only: %i(new create index edit update)
   end

--- a/test/system/admin/categories_test.rb
+++ b/test/system/admin/categories_test.rb
@@ -8,6 +8,12 @@ class Admin::CategoriesTest < ApplicationSystemTestCase
     assert_equal '管理ページ | FBC', title
   end
 
+  test 'show category page' do
+    visit_with_auth admin_category_path(categories(:category2)), 'komagata'
+    assert_equal 'Mac OS X | FBC', title
+    first('.admin-table__item-value').assert_text 'OS X Mountain Lionをクリーンインストールする'
+  end
+
   test 'create category' do
     visit_with_auth '/admin/categories/new', 'komagata'
     within 'form[name=category]' do

--- a/test/system/admin/categories_test.rb
+++ b/test/system/admin/categories_test.rb
@@ -11,7 +11,7 @@ class Admin::CategoriesTest < ApplicationSystemTestCase
   test 'show category page' do
     visit_with_auth admin_category_path(categories(:category2)), 'komagata'
     assert_equal 'Mac OS X | FBC', title
-    first('.admin-table__item-value').assert_text 'OS X Mountain Lionをクリーンインストールする'
+    first('.card-list-item').assert_text 'OS X Mountain Lionをクリーンインストールする'
   end
 
   test 'create category' do


### PR DESCRIPTION
## Issue

- #5311

## 概要

管理画面にカテゴリーの個別ページを作成する。

※見た目については町田さんによるデザイン前の状態です
![image](https://user-images.githubusercontent.com/33394676/183395958-a544a47c-ac12-4561-b4b5-153ba300604f.png)

## 動作確認方法

1. `feature/create-admin-category-page` をローカルに取り込む
2. `rails s` で起動する
3. `komagata` でログインする
4. 管理ページ > カテゴリーにアクセスする
   - http://localhost:3000/admin/categories
5. `Ruby` のプラクティスをクリックする
   - プラクティスが1つ以上所属しているカテゴリーならどれでも良いです
   ![image](https://user-images.githubusercontent.com/33394676/183397271-2e519555-a8bd-4afa-a65d-c0d34e05ac22.png)

### 備考

Issueのコメントでのやり取りで、個別ページには編集画面へのリンクも表示することとなりました。