### PR TITLE
提出物個別ページのメンター用サイドカラムに提出物一覧を追加した

### DIFF
--- a/app/assets/stylesheets/application/blocks/side/_side-tabs-contents.sass
+++ b/app/assets/stylesheets/application/blocks/side/_side-tabs-contents.sass
@@ -10,6 +10,9 @@
 #side-tabs-3:checked ~ .side-tabs-contents #side-tabs-content-3
   display: block
 
+#side-tabs-4:checked ~ .side-tabs-contents #side-tabs-content-4
+  display: block
+
 .side-tabs-contents__item
   display: none
   .a-card

--- a/app/assets/stylesheets/application/blocks/side/_side-tabs-nav.sass
+++ b/app/assets/stylesheets/application/blocks/side/_side-tabs-nav.sass
@@ -7,7 +7,8 @@
 
 #side-tabs-1:checked ~ .side-tabs-nav #side-tabs-nav-1,
 #side-tabs-2:checked ~ .side-tabs-nav #side-tabs-nav-2,
-#side-tabs-3:checked ~ .side-tabs-nav #side-tabs-nav-3
+#side-tabs-3:checked ~ .side-tabs-nav #side-tabs-nav-3,
+#side-tabs-4:checked ~ .side-tabs-nav #side-tabs-nav-4
   background-color: $base
   color: $default-text
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -17,7 +17,6 @@ class ProductsController < ApplicationController
                        .order(reported_on: :DESC)
     @products = @product.user
                         .products
-                        .limit(10)
                         .not_wip
                         .order(published_at: :DESC)
     @practice = find_practice

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -15,6 +15,11 @@ class ProductsController < ApplicationController
                        .limit(10)
                        .includes(:comments, :checks)
                        .order(reported_on: :DESC)
+    @products = @product.user
+                        .products
+                        .limit(10)
+                        .not_wip
+                        .order(published_at: :DESC)
     @practice = find_practice
     @learning = @product.learning # decoratorメソッド用にcontrollerでインスタンス変数化
     @footprints = find_footprints

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -91,17 +91,8 @@ header.page-header
                 #js-user-mentor-memo(data-user-id="#{@product.user.id}" data-products-mode="#{true}")
               .side-tabs-contents__item#side-tabs-content-4
                 .card-list.a-card
-                  - if @products.present?
-                    - @products.each do |product|
-                      = render partial: 'product', locals: { product: product }
-                  - else
-                    .card-list__message
-                      .container
-                        .o-empty-message
-                          .o-empty-message__icon
-                            i.fa-regular.fa-sad-tear
-                          .o-empty-message__text
-                            | 提出物はまだありません。
+                  - @products.each do |product|
+                    = render partial: 'product', locals: { product: product }
 
 - if !current_user.adviser? && @product.practice.open_product?
   .sticky-message

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -53,6 +53,7 @@ header.page-header
             input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
             input.a-toggle-checkbox#side-tabs-2 type='radio' name='side-tabs-contents'
             input.a-toggle-checkbox#side-tabs-3 type='radio' name='side-tabs-contents'
+            input.a-toggle-checkbox#side-tabs-4 type='radio' name='side-tabs-contents'
             .side-tabs-nav
               .side-tabs-nav__items
                 .side-tabs-nav__item
@@ -64,6 +65,9 @@ header.page-header
                 .side-tabs-nav__item
                   label.side-tabs-nav__item-link#side-tabs-nav-3 for='side-tabs-3'
                     | ユーザーメモ
+                .side-tabs-nav__item
+                  label.side-tabs-nav__item-link#side-tabs-nav-4 for='side-tabs-4'
+                    | 提出物
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
                 .card-list.a-card
@@ -85,6 +89,19 @@ header.page-header
                   = render 'users/user_secret_attributes', user: @product.user
                   = render 'users/metas', user: @product.user
                 #js-user-mentor-memo(data-user-id="#{@product.user.id}" data-products-mode="#{true}")
+              .side-tabs-contents__item#side-tabs-content-4
+                .card-list.a-card
+                  - if @products.present?
+                    - @products.each do |product|
+                      = render partial: 'product', locals: { product: product }
+                  - else
+                    .card-list__message
+                      .container
+                        .o-empty-message
+                          .o-empty-message__icon
+                            i.fa-regular.fa-sad-tear
+                          .o-empty-message__text
+                            | 提出物はまだありません。
 
 - if !current_user.adviser? && @product.practice.open_product?
   .sticky-message

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -421,6 +421,7 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '直近の日報'
     assert_text 'プラクティスメモ'
     assert_text 'ユーザーメモ'
+    assert_selector '.side-tabs-nav__item-link', text: '提出物'
   end
 
   test 'students can not see block for mentors' do
@@ -428,6 +429,7 @@ class ProductsTest < ApplicationSystemTestCase
     assert_no_text '直近の日報'
     assert_no_text 'プラクティスメモ'
     assert_no_text 'ユーザーメモ'
+    assert_no_selector '.side-tabs-nav__item-link', text: '提出物'
   end
 
   test 'display the user memos after click on user-memos tab' do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -465,11 +465,11 @@ class ProductsTest < ApplicationSystemTestCase
     click_button '保存する'
   end
 
-  test 'display a list of the 10 most recent products' do
+  test 'display a list of products in side-column' do
     user = users(:kimura)
     visit_with_auth "/products/#{products(:product2).id}", 'mentormentaro'
     page.find('#side-tabs-nav-4').click
-    products = user.products.not_wip.first(10)
+    products = user.products.not_wip
     products.each do |product|
       assert_text "#{product.practice.title}の提出物"
     end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -421,7 +421,7 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '直近の日報'
     assert_text 'プラクティスメモ'
     assert_text 'ユーザーメモ'
-    assert_selector '.side-tabs-nav__item-link', text: '提出物'
+    assert_selector '#side-tabs-nav-4', text: '提出物'
   end
 
   test 'students can not see block for mentors' do
@@ -429,7 +429,7 @@ class ProductsTest < ApplicationSystemTestCase
     assert_no_text '直近の日報'
     assert_no_text 'プラクティスメモ'
     assert_no_text 'ユーザーメモ'
-    assert_no_selector '.side-tabs-nav__item-link', text: '提出物'
+    assert_no_selector '#side-tabs-nav-4', text: '提出物'
   end
 
   test 'display the user memos after click on user-memos tab' do
@@ -463,6 +463,16 @@ class ProductsTest < ApplicationSystemTestCase
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: '編集後のユーザーメモです。'
     click_button '保存する'
+  end
+
+  test 'display a list of the 10 most recent products' do
+    user = users(:kimura)
+    visit_with_auth "/products/#{products(:product2).id}", 'mentormentaro'
+    page.find('#side-tabs-nav-4').click
+    products = user.products.not_wip.first(10)
+    products.each do |product|
+      assert_text "#{product.practice.title}の提出物"
+    end
   end
 
   test 'can see unassigned-tab' do


### PR DESCRIPTION
## issue
- #5309 
## 概要
メンターでログインして提出物個別ページにアクセスした時に表示されるサイドカラムに`提出物`タブを追加した。
<img width="1332" alt="_development__OS_X_Mountain_Lionをクリーンインストールする___FBC" src="https://user-images.githubusercontent.com/72614612/183586729-b3929da1-1b94-4bb0-b69b-e9222b9ece95.png">

### 備考
- メンターが日報個別ページにアクセスした際のサイドカラムには`提出物`タブが有り、こちらを参考にした。
- ブラウザ幅を狭めるとデザインが一部崩れるがこちらは町田さんに確認済み。
- 提出物が0の場合はありえないのでその場合は考慮していない。
## 変更確認方法
1. `feature/add-products-tab-for-mentor`をローカルに取り込む
2. `rails s`で立ち上げる
3. `mentormentaro`でログインする
4. 提出物一覧から任意の提出物を選び確認する
## 変更前
<img width="1332" alt="_development__OS_X_Mountain_Lionをクリーンインストールする___FBC" src="https://user-images.githubusercontent.com/72614612/183588147-4b223377-8eef-4462-a974-8a1e7b331267.png">


## 変更後
<img width="1326" alt="_development__OS_X_Mountain_Lionをクリーンインストールする___FBC" src="https://user-images.githubusercontent.com/72614612/183588452-07e8a4ac-13a4-4b56-9b9a-96ba3a2bef3d.png">

### 提出物タブをクリックした後

<img width="1331" alt="_development__OS_X_Mountain_Lionをクリーンインストールする___FBC" src="https://user-images.githubusercontent.com/72614612/183588813-72e24d3b-f499-4c49-9dae-d62b9d60ff6e.png">


