### PR TITLE
コメントが多い場合の表示方法を変更

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -118,7 +118,7 @@ export default {
       commentTotalCount: null,
       loadedComment: false,
       nextCommentAmount: null,
-      defaultCommentAdd: 8
+      incrementCommentSize: 8
     }
   },
   computed: {
@@ -152,20 +152,20 @@ export default {
     changeActiveTab(tab) {
       this.tab = tab
     },
-    showRemainingComments: function () {
-      const commentRemaining = this.commentTotalCount - this.commentOffset
-
-      if (commentRemaining > this.defaultCommentAdd) {
-        this.nextCommentAmount = `${this.defaultCommentAdd} / ${commentRemaining}`
-      } else {
-        this.nextCommentAmount = commentRemaining
-      }
-    },
     calcCommentIncrement: function () {
       this.loadedComment =
         this.commentLimit + this.commentOffset >= this.commentTotalCount
-      if (this.loadedComment === false) {
+      if (!this.loadedComment) {
         this.commentOffset += this.commentLimit
+      }
+    },
+    showNextCommentsAmount: function () {
+      const commentRemaining = this.commentTotalCount - this.commentOffset
+
+      if (commentRemaining > this.incrementCommentSize) {
+        this.nextCommentAmount = `${this.incrementCommentSize} / ${commentRemaining}`
+      } else {
+        this.nextCommentAmount = commentRemaining
       }
     },
     showComments() {
@@ -203,7 +203,7 @@ export default {
             })
           }
           this.calcCommentIncrement()
-          this.showRemainingComments()
+          this.showNextCommentsAmount()
         })
     },
     createComment() {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -152,44 +152,44 @@ export default {
     },
     showComments() {
       fetch(
-        `/api/comments.json?commentable_type=${this.commentableType}&` +
+          `/api/comments.json?commentable_type=${this.commentableType}&` +
           `commentable_id=${this.commentableId}&comment_limit=${this.commentLimit}&` +
           `comment_offset=${this.commentOffset}`,
-        {
-          method: 'GET',
-          headers: {
-            'X-Requested-With': 'XMLHttpRequest'
-          },
-          credentials: 'same-origin',
-          redirect: 'manual'
-        }
+          {
+            method: 'GET',
+            headers: {
+              'X-Requested-With': 'XMLHttpRequest'
+            },
+            credentials: 'same-origin',
+            redirect: 'manual'
+          }
       )
-        .then((response) => {
-          return response.json()
-        })
-        .then((json) => {
-          json.comments.forEach((c) => {
-            this.comments.unshift(c)
+          .then((response) => {
+            return response.json()
           })
-          this.commentTotalCount = json.comment_total_count
-        })
-        .catch((error) => {
-          console.warn(error)
-        })
-        .finally(() => {
-          if (this.loaded === false) {
-            this.loaded = true
-            this.$nextTick(() => {
-              TextareaInitializer.initialize('#js-new-comment')
-              this.setDefaultTextareaSize()
+          .then((json) => {
+            json.comments.forEach((c) => {
+              this.comments.unshift(c)
             })
-          }
-          this.loadedComment =
-            this.commentLimit + this.commentOffset >= this.commentTotalCount
-          if (this.loadedComment === false) {
-            this.commentOffset = this.commentLimit
-          }
-        })
+            this.commentTotalCount = json.comment_total_count
+          })
+          .catch((error) => {
+            console.warn(error)
+          })
+          .finally(() => {
+            if (this.loaded === false) {
+              this.loaded = true
+              this.$nextTick(() => {
+                TextareaInitializer.initialize('#js-new-comment')
+                this.setDefaultTextareaSize()
+              })
+            }
+            this.loadedComment =
+                this.commentLimit + this.commentOffset >= this.commentTotalCount
+            if (this.loadedComment === false) {
+              this.commentOffset += this.commentLimit
+            }
+          })
     },
     createComment() {
       if (this.description.length < 1) {
@@ -213,31 +213,31 @@ export default {
         redirect: 'manual',
         body: JSON.stringify(params)
       })
-        .then((response) => {
-          return response.json()
-        })
-        .then(async (comment) => {
-          this.comments.push(comment)
-          this.description = ''
-          this.clearPreview('new-comment-preview')
-          this.tab = 'comment'
-          this.buttonDisabled = false
-          this.resizeTextarea()
-          this.toast('コメントを投稿しました！')
-        })
-        .catch((error) => {
-          console.warn(error)
-        })
+          .then((response) => {
+            return response.json()
+          })
+          .then(async (comment) => {
+            this.comments.push(comment)
+            this.description = ''
+            this.clearPreview('new-comment-preview')
+            this.tab = 'comment'
+            this.buttonDisabled = false
+            this.resizeTextarea()
+            this.toast('コメントを投稿しました！')
+          })
+          .catch((error) => {
+            console.warn(error)
+          })
       if (
-        this.commentableType === 'Product' &&
-        this.productCheckerId === null
+          this.commentableType === 'Product' &&
+          this.productCheckerId === null
       ) {
         this.checkProduct(
-          this.commentableId,
-          this.currentUserId,
-          '/api/products/checker',
-          'PATCH',
-          this.token()
+            this.commentableId,
+            this.currentUserId,
+            '/api/products/checker',
+            'PATCH',
+            this.token()
         )
       }
     },
@@ -251,16 +251,16 @@ export default {
         credentials: 'same-origin',
         redirect: 'manual'
       })
-        .then(() => {
-          this.comments.forEach((comment, i) => {
-            if (comment.id === id) {
-              this.comments.splice(i, 1)
-            }
+          .then(() => {
+            this.comments.forEach((comment, i) => {
+              if (comment.id === id) {
+                this.comments.splice(i, 1)
+              }
+            })
           })
-        })
-        .catch((error) => {
-          console.warn(error)
-        })
+          .catch((error) => {
+            console.warn(error)
+          })
     },
     updateComment(description, id) {
       const updatedComment = this.comments.find((comment) => {
@@ -278,18 +278,18 @@ export default {
     },
     commentAndCheck() {
       if (
-        this.commentableType === 'Product' &&
-        !window.confirm('提出物を確認済にしてよろしいですか？')
+          this.commentableType === 'Product' &&
+          !window.confirm('提出物を確認済にしてよろしいですか？')
       ) {
         return null
       } else {
         this.createComment()
         this.check(
-          this.commentableType,
-          this.commentableId,
-          '/api/checks',
-          'POST',
-          this.token()
+            this.commentableType,
+            this.commentableId,
+            '/api/checks',
+            'POST',
+            this.token()
         )
       }
     },
@@ -304,13 +304,13 @@ export default {
         credentials: 'same-origin',
         redirect: 'manual'
       })
-        .then((response) => {
-          return response.json()
-        })
-        .catch((error) => {
-          console.warn(error)
-          return null
-        })
+          .then((response) => {
+            return response.json()
+          })
+          .catch((error) => {
+            console.warn(error)
+            return null
+          })
     },
     editComment() {
       if (this.description.length > 0) {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -152,14 +152,12 @@ export default {
     changeActiveTab(tab) {
       this.tab = tab
     },
-    calcCommentIncrement: function () {
+    displayMoreComments() {
       this.loadedComment =
         this.commentLimit + this.commentOffset >= this.commentTotalCount
       if (!this.loadedComment) {
         this.commentOffset += this.commentLimit
       }
-    },
-    showNextCommentsAmount: function () {
       const commentRemaining = this.commentTotalCount - this.commentOffset
 
       if (commentRemaining > this.incrementCommentSize) {
@@ -190,6 +188,7 @@ export default {
             this.comments.unshift(c)
           })
           this.commentTotalCount = json.comment_total_count
+          this.displayMoreComments()
         })
         .catch((error) => {
           console.warn(error)
@@ -202,8 +201,6 @@ export default {
               this.setDefaultTextareaSize()
             })
           }
-          this.calcCommentIncrement()
-          this.showNextCommentsAmount()
         })
     },
     createComment() {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -187,10 +187,7 @@ export default {
           this.loadedComment =
             this.commentLimit + this.commentOffset >= this.commentTotalCount
           if (this.loadedComment === false) {
-            const commentLimit = this.commentLimit
-            this.commentLimit =
-              this.commentTotalCount - (this.commentLimit + this.commentOffset)
-            this.commentOffset = commentLimit
+            this.commentOffset = this.commentLimit
           }
         })
     },

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -6,7 +6,7 @@
     .thread-comments-more__inner
       .thread-comments-more__action
         button.a-button.is-lg.is-text.is-block(@click='showComments')
-          | 次のコメント（ {{nextCommentAmount}} ）
+          | 次のコメント（ {{ nextCommentAmount }} ）
   h2.thread-comments__title(
     v-if='commentableType === "RegularEvent" || commentableType === "Event"'
   )
@@ -163,48 +163,48 @@ export default {
     },
     calcCommentIncrement: function () {
       this.loadedComment =
-          this.commentLimit + this.commentOffset >= this.commentTotalCount
+        this.commentLimit + this.commentOffset >= this.commentTotalCount
       if (this.loadedComment === false) {
         this.commentOffset += this.commentLimit
       }
     },
     showComments() {
       fetch(
-          `/api/comments.json?commentable_type=${this.commentableType}&` +
+        `/api/comments.json?commentable_type=${this.commentableType}&` +
           `commentable_id=${this.commentableId}&comment_limit=${this.commentLimit}&` +
           `comment_offset=${this.commentOffset}`,
-          {
-            method: 'GET',
-            headers: {
-              'X-Requested-With': 'XMLHttpRequest'
-            },
-            credentials: 'same-origin',
-            redirect: 'manual'
-          }
+        {
+          method: 'GET',
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          },
+          credentials: 'same-origin',
+          redirect: 'manual'
+        }
       )
-          .then((response) => {
-            return response.json()
+        .then((response) => {
+          return response.json()
+        })
+        .then((json) => {
+          json.comments.forEach((c) => {
+            this.comments.unshift(c)
           })
-          .then((json) => {
-            json.comments.forEach((c) => {
-              this.comments.unshift(c)
+          this.commentTotalCount = json.comment_total_count
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
+        .finally(() => {
+          if (this.loaded === false) {
+            this.loaded = true
+            this.$nextTick(() => {
+              TextareaInitializer.initialize('#js-new-comment')
+              this.setDefaultTextareaSize()
             })
-            this.commentTotalCount = json.comment_total_count
-          })
-          .catch((error) => {
-            console.warn(error)
-          })
-          .finally(() => {
-            if (this.loaded === false) {
-              this.loaded = true
-              this.$nextTick(() => {
-                TextareaInitializer.initialize('#js-new-comment')
-                this.setDefaultTextareaSize()
-              })
-            }
-            this.calcCommentIncrement()
-            this.showRemainingComments()
-          })
+          }
+          this.calcCommentIncrement()
+          this.showRemainingComments()
+        })
     },
     createComment() {
       if (this.description.length < 1) {
@@ -228,31 +228,31 @@ export default {
         redirect: 'manual',
         body: JSON.stringify(params)
       })
-          .then((response) => {
-            return response.json()
-          })
-          .then(async (comment) => {
-            this.comments.push(comment)
-            this.description = ''
-            this.clearPreview('new-comment-preview')
-            this.tab = 'comment'
-            this.buttonDisabled = false
-            this.resizeTextarea()
-            this.toast('コメントを投稿しました！')
-          })
-          .catch((error) => {
-            console.warn(error)
-          })
+        .then((response) => {
+          return response.json()
+        })
+        .then(async (comment) => {
+          this.comments.push(comment)
+          this.description = ''
+          this.clearPreview('new-comment-preview')
+          this.tab = 'comment'
+          this.buttonDisabled = false
+          this.resizeTextarea()
+          this.toast('コメントを投稿しました！')
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
       if (
-          this.commentableType === 'Product' &&
-          this.productCheckerId === null
+        this.commentableType === 'Product' &&
+        this.productCheckerId === null
       ) {
         this.checkProduct(
-            this.commentableId,
-            this.currentUserId,
-            '/api/products/checker',
-            'PATCH',
-            this.token()
+          this.commentableId,
+          this.currentUserId,
+          '/api/products/checker',
+          'PATCH',
+          this.token()
         )
       }
     },
@@ -266,16 +266,16 @@ export default {
         credentials: 'same-origin',
         redirect: 'manual'
       })
-          .then(() => {
-            this.comments.forEach((comment, i) => {
-              if (comment.id === id) {
-                this.comments.splice(i, 1)
-              }
-            })
+        .then(() => {
+          this.comments.forEach((comment, i) => {
+            if (comment.id === id) {
+              this.comments.splice(i, 1)
+            }
           })
-          .catch((error) => {
-            console.warn(error)
-          })
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
     },
     updateComment(description, id) {
       const updatedComment = this.comments.find((comment) => {
@@ -293,18 +293,18 @@ export default {
     },
     commentAndCheck() {
       if (
-          this.commentableType === 'Product' &&
-          !window.confirm('提出物を確認済にしてよろしいですか？')
+        this.commentableType === 'Product' &&
+        !window.confirm('提出物を確認済にしてよろしいですか？')
       ) {
         return null
       } else {
         this.createComment()
         this.check(
-            this.commentableType,
-            this.commentableId,
-            '/api/checks',
-            'POST',
-            this.token()
+          this.commentableType,
+          this.commentableId,
+          '/api/checks',
+          'POST',
+          this.token()
         )
       }
     },
@@ -319,13 +319,13 @@ export default {
         credentials: 'same-origin',
         redirect: 'manual'
       })
-          .then((response) => {
-            return response.json()
-          })
-          .catch((error) => {
-            console.warn(error)
-            return null
-          })
+        .then((response) => {
+          return response.json()
+        })
+        .catch((error) => {
+          console.warn(error)
+          return null
+        })
     },
     editComment() {
       if (this.description.length > 0) {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -6,7 +6,7 @@
     .thread-comments-more__inner
       .thread-comments-more__action
         button.a-button.is-lg.is-text.is-block(@click='showComments')
-          | コメント（{{ commentLimit }}）をもっと見る
+          | 次のコメント（ {{nextCommentAmount}} ）
   h2.thread-comments__title(
     v-if='commentableType === "RegularEvent" || commentableType === "Event"'
   )
@@ -116,7 +116,9 @@ export default {
       commentLimit: 8,
       commentOffset: 0,
       commentTotalCount: null,
-      loadedComment: false
+      loadedComment: false,
+      nextCommentAmount: null,
+      defaultCommentAdd: 8
     }
   },
   computed: {
@@ -189,6 +191,13 @@ export default {
             if (this.loadedComment === false) {
               this.commentOffset += this.commentLimit
             }
+              const commentRemaining = this.commentTotalCount - this.commentOffset
+
+              if (commentRemaining > this.defaultCommentAdd) {
+                this.nextCommentAmount = `${this.defaultCommentAdd} / ${commentRemaining}`
+              } else {
+                this.nextCommentAmount = commentRemaining
+              }
           })
     },
     createComment() {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -152,6 +152,22 @@ export default {
     changeActiveTab(tab) {
       this.tab = tab
     },
+    showRemainingComments: function () {
+      const commentRemaining = this.commentTotalCount - this.commentOffset
+
+      if (commentRemaining > this.defaultCommentAdd) {
+        this.nextCommentAmount = `${this.defaultCommentAdd} / ${commentRemaining}`
+      } else {
+        this.nextCommentAmount = commentRemaining
+      }
+    },
+    calcCommentIncrement: function () {
+      this.loadedComment =
+          this.commentLimit + this.commentOffset >= this.commentTotalCount
+      if (this.loadedComment === false) {
+        this.commentOffset += this.commentLimit
+      }
+    },
     showComments() {
       fetch(
           `/api/comments.json?commentable_type=${this.commentableType}&` +
@@ -186,18 +202,8 @@ export default {
                 this.setDefaultTextareaSize()
               })
             }
-            this.loadedComment =
-                this.commentLimit + this.commentOffset >= this.commentTotalCount
-            if (this.loadedComment === false) {
-              this.commentOffset += this.commentLimit
-            }
-              const commentRemaining = this.commentTotalCount - this.commentOffset
-
-              if (commentRemaining > this.defaultCommentAdd) {
-                this.nextCommentAmount = `${this.defaultCommentAdd} / ${commentRemaining}`
-              } else {
-                this.nextCommentAmount = commentRemaining
-              }
+            this.calcCommentIncrement()
+            this.showRemainingComments()
           })
     },
     createComment() {

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -244,19 +244,35 @@ class CommentsTest < ApplicationSystemTestCase
     assert_selector 'span.mention', text: 'mentor'
   end
 
-  test 'clicking "see more comments" will display old comments' do
+  test 'text change "see more comments" button by remaining comment amount' do
     visit_with_auth product_path(users(:hatsuno).products.first.id), 'komagata'
 
-    assert_no_text '提出物のコメント1です。'
-    old_comments = find('.a-button.is-lg.is-text.is-block').text
-    assert_text old_comments
+    assert_selector '.a-button.is-lg.is-text.is-block', text: '次のコメント（ 8 / 12 ）'
+
+    find('.a-button.is-lg.is-text.is-block').click
+    assert_selector '.a-button.is-lg.is-text.is-block', text: '次のコメント（ 4 ）'
+
+    find('.a-button.is-lg.is-text.is-block').click
+    assert_no_selector '.a-button.is-lg.is-text.is-block'
+  end
+
+  test 'comments added 8 or within the last 8' do
+    visit_with_auth product_path(users(:hatsuno).products.first.id), 'komagata'
+
+    assert_text '提出物のコメント20です'
     assert_text '提出物のコメント13です。'
+    assert_no_text '提出物のコメント12です。'
 
-    click_button old_comments
+    find('.a-button.is-lg.is-text.is-block').click
+    assert_text '提出物のコメント20です'
+    assert_text '提出物のコメント12です。'
+    assert_text '提出物のコメント5です。'
+    assert_no_text '提出物のコメント4です。'
 
+    find('.a-button.is-lg.is-text.is-block').click
+    assert_text '提出物のコメント20です'
+    assert_text '提出物のコメント4です。'
     assert_text '提出物のコメント1です。'
-    assert_no_text old_comments
-    assert_text '提出物のコメント13です。'
   end
 
   test 'clear preview after posting new comment for report' do


### PR DESCRIPTION
## Issue

- #5276

## 概要

コメントが多い場合、表示を8件ずつ追加する

## 変更確認方法

1. ブランチ`feature/change_way_of_comments_loading`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. http://localhost:3000/products/1033498648 に管理者でアクセスする
4. 以下を確認する
  - コメントが8件ずつ（又は最後の8件以内）追加される
  - `次のコメント()`ボタンについて、コメントの残数が8超が、8以下かによって表示が変わる

