### PR TITLE
コース編集の「詳細」を「説明」に変更

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -99,7 +99,7 @@ ja:
         returned_at: 復帰日時
       course:
         title: タイトル
-        description: 詳細
+        description: 説明
         created_at: 作成日時
         updated_at: 更新日時
       practice:


### PR DESCRIPTION
## Issue

- #5312

## 概要

- コース編集ページで詳細を説明に変更する。
  - 変更前：詳細
  - 変更後：説明

## 確認方法

1. `change_course_description_title`をローカルに取り込む
2. `rails s`で起動する
3. 任意の管理者ユーザーでログインする
4. http://localhost:3000/admin/courses/829913840/edit にアクセスする

## 変更前
コース編集ページをアクセスすると、description部分のタイトルは「詳細」になっている
<img width="662" alt="Screen Shot 0004-08-11 at 17 11 44" src="https://user-images.githubusercontent.com/94335407/184091194-0329ca4c-aaf9-48e8-8a43-ea10b280a09b.png">


## 変更後
コース編集ページをアクセスすると、description部分のタイトルは「説明」になっている
<img width="661" alt="Screen Shot 0004-08-11 at 17 14 57" src="https://user-images.githubusercontent.com/94335407/184091721-94279c48-c28d-42df-88af-770db0619fa3.png">

