### PR TITLE
カテゴリー編集の「詳細」を「説明」に変更

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -134,7 +134,7 @@ ja:
       category:
         name: 名前
         slug: URLスラッグ
-        description: 詳細
+        description: 説明
       report:
         title: タイトル
         practice: プラクティス


### PR DESCRIPTION
## Issue

- #5313

## 概要

- カテゴリー編集で「詳細」を「説明」に変更 する。
  - 変更前：詳細
  - 変更後：説明

## 確認方法

1. `change_category_description_title`をローカルに取り込む
2. `rails s`で起動する
3. 任意のユーザーでログインする
4. http://localhost:3000/admin/categories/800674185/edit にアクセスする

## 変更前
カテゴリー編集ページをアクセスすると、description部分のタイトルは「詳細」になっている
<img width="649" alt="Screen Shot 0004-08-11 at 17 40 35" src="https://user-images.githubusercontent.com/94335407/184095963-f4406d88-f9e6-4e29-80d1-a2fc481d6c99.png">


## 変更後
カテゴリー編集ページをアクセスすると、description部分のタイトルは「説明」になっている
<img width="657" alt="Screen Shot 0004-08-11 at 17 40 58" src="https://user-images.githubusercontent.com/94335407/184096028-b06b2c06-41d0-40b6-8d99-3c4906cfd84b.png">

