### PR TITLE
レイアウト application にブログへのリンクを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -7,6 +7,9 @@ footer.footer
             = link_to welcome_path, class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | ホームページ
           li.footer-nav__item
+            = link_to articles_path, class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | ブログ
+          li.footer-nav__item
             = link_to books_path, class: 'footer-nav__item-link' do
               | 参考書籍
           li.footer-nav__item


### PR DESCRIPTION
## Issue

- #5317

## 概要

- ブログを追加。URL は articles_path にする。
  - 変更前：なし
  - 変更後：footerに「ブログ」を追加する

## 確認方法

1. `add_blog_link_to_layout_application`をローカルに取り込む
2. `rails s`で起動する
3. 任意のユーザーでログインする
4. `http://localhost:3000`にアクセスする。
5. 一番下(footer)で「ブログ」が表示されて、「ブログ」をクリックすると`http://localhost:3000/articles`に移動される。

## 変更前
footerにブログがない
<img width="1290" alt="Screen Shot 0004-08-11 at 19 32 34" src="https://user-images.githubusercontent.com/94335407/184115106-9ef8348a-c613-44fd-95c7-1852370f6641.png">

## 変更後
footerにブログがある
<img width="1217" alt="Screen Shot 0004-08-11 at 19 33 01" src="https://user-images.githubusercontent.com/94335407/184115172-223f8642-0e0a-48b6-81d9-5022ef67cd3c.png">

