### PR TITLE
Markdownの中で独自記法でインタビューブロックを書けるようにした(クラス名speak)

### DIFF
--- a/app/assets/stylesheets/config/mixins/_long-text-style.sass
+++ b/app/assets/stylesheets/config/mixins/_long-text-style.sass
@@ -21,6 +21,26 @@
         >ul
           list-style-type: square
 
+=speak
+  .speak
+    +margin(vertical, 1.5em 2em)
+  .speak__speaker
+    >a
+      display: flex
+      align-items: center
+      gap: .5rem
+      text-decoration: none
+      color: $default-text
+    >a:hover
+      .speak__speaker-name
+        text-decoration: underline
+  .speak__speaker-name
+    flex: 1
+    +text-block(1.125em 1.6, 700)
+    text-decoration: none
+  .speak__body
+    margin-top: .5rem
+
 =long-text-style($pc-font-size: 1rem, $mobile-font-size: .8125rem, $background: $base, $font: $default-text)
   font-size: $pc-font-size
   word-wrap: break-word
@@ -276,6 +296,8 @@
     padding-left: 1.375em
     .task-list-item-checkbox
       +position(absolute, top .5em, left 0)
+
+  +speak
 
   *:first-child
     margin-top: 0

--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -11,6 +11,7 @@ import MarkdownItHeadings from 'markdown-it-headings'
 import MarkDownItContainerMessage from 'markdown-it-container-message'
 import MarkDownItContainerDetails from 'markdown-it-container-details'
 import MarkDownItLinkAttributes from 'markdown-it-link-attributes'
+import MarkDownItContainerSpeak from 'markdown-it-container-speak'
 
 export default class {
   replace(selector) {
@@ -51,7 +52,7 @@ export default class {
         rel: 'noopener'
       }
     })
-
+    md.use(MarkDownItContainerSpeak)
     return md.render(text)
   }
 }

--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -1,0 +1,14 @@
+import MarkdownItContainer from 'markdown-it-container'
+
+export default (md) => {
+  md.use(MarkdownItContainer, 'speak', {
+    render: (tokens, idx) => {
+      const speakerName = tokens[idx].info.trim().match(/@([a-zA-Z0-9-]*)$/)
+      if (tokens[idx].nesting === 1) {
+        return `<div class="speak"><div class="speak__speaker"><a href="/users/${speakerName[1]}" class="a-user-emoji-link"><img class="js-user-icon a-user-emoji" data-user="${speakerName[1]}" width="40" height="40"></a><div class="speak__body"></div>`
+      } else {
+        return '</div>\n'
+      }
+    }
+  })
+}

--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -11,7 +11,8 @@ export default (md) => {
         return `<div class="speak">
                   <div class="speak__speaker">
                     <a href="/users/${speakerName}" class="a-user-emoji-link">
-                      <img class="js-user-icon a-user-emoji" data-user="${speakerName}" width="40" height="40">
+                      <img class="js-user-icon a-user-emoji" data-user="${speakerName}">
+                      <spanv class="speak__speaker-name">${speakerName}</span>
                     </a>
                   </div>
                   <div class="speak__body">`

--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -3,12 +3,30 @@ import MarkdownItContainer from 'markdown-it-container'
 export default (md) => {
   md.use(MarkdownItContainer, 'speak', {
     render: (tokens, idx) => {
-      const speakerName = tokens[idx].info.replace('speak @', '').trim()
+      const speakerName = escapeHTML(tokens[idx].info)
+        .replace('speak @', '')
+        .trim()
+
       if (tokens[idx].nesting === 1) {
-        return `<div class="speak"><div class="speak__speaker"><a href="/users/${speakerName}" class="a-user-emoji-link"><img class="js-user-icon a-user-emoji" data-user="${speakerName}" width="40" height="40"></a><div class="speak__body"></div>`
+        return `<div class="speak">
+                  <div class="speak__speaker">
+                    <a href="/users/${speakerName}" class="a-user-emoji-link">
+                      <img class="js-user-icon a-user-emoji" data-user="${speakerName}" width="40" height="40">
+                    </a>
+                  </div>
+                  <div class="speak__body">`
       } else {
-        return '</div>\n'
+        return '</div></div>\n'
       }
     }
   })
+}
+
+function escapeHTML(string) {
+  return string
+    .replace(/&/g, '&lt;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
 }

--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -3,9 +3,9 @@ import MarkdownItContainer from 'markdown-it-container'
 export default (md) => {
   md.use(MarkdownItContainer, 'speak', {
     render: (tokens, idx) => {
-      const speakerName = tokens[idx].info.trim().match(/@([a-zA-Z0-9-]*)$/)
+      const speakerName = tokens[idx].info.replace('speak @', '').trim()
       if (tokens[idx].nesting === 1) {
-        return `<div class="speak"><div class="speak__speaker"><a href="/users/${speakerName[1]}" class="a-user-emoji-link"><img class="js-user-icon a-user-emoji" data-user="${speakerName[1]}" width="40" height="40"></a><div class="speak__body"></div>`
+        return `<div class="speak"><div class="speak__speaker"><a href="/users/${speakerName}" class="a-user-emoji-link"><img class="js-user-icon a-user-emoji" data-user="${speakerName}" width="40" height="40"></a><div class="speak__body"></div>`
       } else {
         return '</div>\n'
       }

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -12,6 +12,7 @@ import autosize from 'autosize'
 import MarkDownItContainerMessage from 'markdown-it-container-message'
 import MarkDownItContainerDetails from 'markdown-it-container-details'
 import MarkDownItLinkAttributes from 'markdown-it-link-attributes'
+import MarkDownItContainerSpeak from 'markdown-it-container-speak'
 
 export default class {
   static initialize(selector) {
@@ -74,7 +75,8 @@ export default class {
           MarkdownItTaskLists,
           MarkDownItContainerMessage,
           MarkDownItContainerDetails,
-          MarkDownItLinkAttributes
+          MarkDownItLinkAttributes,
+          MarkDownItContainerSpeak
         ],
         markdownOptions: MarkdownOption
       })

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -3,7 +3,7 @@
 require 'application_system_test_case'
 
 class MarkdownTest < ApplicationSystemTestCase
-  test 'speak brock test' do
+  test 'speak block test' do
     visit_with_auth new_page_path, 'komagata'
     fill_in 'page[title]', with: 'インタビュー'
     fill_in 'page[body]', with: ":::speak @mentormentaro\n## 質問\nあああ\nいいい\n:::"

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class MarkdownTest < ApplicationSystemTestCase
+  test 'speak brock test' do
+    visit_with_auth new_page_path, 'komagata'
+    fill_in 'page[title]', with: 'インタビュー'
+    fill_in 'page[body]', with: ":::speak @mentormentaro\n## 質問\nあああ\nいいい\n:::"
+
+    click_button '内容を保存'
+
+    assert_css '.a-long-text.is-md.js-markdown-view'
+    assert_css '.speak'
+    assert_css "a[href='/users/mentormentaro']"
+    assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
+  end
+end


### PR DESCRIPTION
## Issue
- #4721

## 概要
独自記法で
```
:::speak @user

## あああああ

いいいい
うううう

:::
```
と書くと、
```
<div class="speak">
    <div class="speak__speaker">
        <a href="@userの個別ページ"><img src="@userのアイコン画像"></a>
    </div>
    <div class="speak__body">
        <h2>あああああ</h2>
        <p>いいいい<br>うううう</p>
    </div>
</speak>
```
というHTMLに変換される


## 実装確認方法
1. `feature/write_interview_blocks_in_markdown`ブランチをローカルに取り込む
2. rails/s で起動する
3. 日報やドキュメントなどの入力画面を開く（権限に制限なし）
4. `textarea`に下記をコピペする
```
:::speak @komagata
## 質問
foge
fuga?
:::

:::speak @machida
## 答え
foo
piyo
:::
```
をコピペして、
 -  インタビューブロックになっていること
 -  アイコンが表示されていること（cssは仮）
 -  アイコンをクリックするとユーザープロフィールページに遷移すること
 を確認する
 
