### PR TITLE
【メンター向け】退会の通知メールに選択入力の退会理由も載せる

### DIFF
--- a/app/views/notification_mailer/retired.html.slim
+++ b/app/views/notification_mailer/retired.html.slim
@@ -1,9 +1,11 @@
 = render 'notification_mailer_template', title: "#{@sender.login_name}さんが退会しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do
-  h1(style='margin-top: 1em; border-left: solid 6px #4638a0; padding: 0 0 0 1rem; font-size: 1.5em; border-bottom: none; color: #444444;') 退会理由
-  ul
-    - @sender.retire_reasons.each do |reason|
-      li
-        = md2html(t("active_flag.user.retire_reasons.#{reason}"))
-  h1(style='margin-top: 1em; border-left: solid 6px #4638a0; padding: 0 0 0 1rem; font-size: 1.5em; border-bottom: none; color: #444444;')
-    = User.human_attribute_name('retire_reason')
-  = md2html(@sender.retire_reason)
+  .a-long-text
+    h2
+      | 退会理由
+    ul
+      - @sender.retire_reasons.each do |reason|
+        li
+          = md2html(t("active_flag.user.retire_reasons.#{reason}"))
+    h2
+      = User.human_attribute_name('retire_reason')
+    = md2html(@sender.retire_reason)

--- a/app/views/notification_mailer/retired.html.slim
+++ b/app/views/notification_mailer/retired.html.slim
@@ -1,6 +1,6 @@
 = render 'notification_mailer_template', title: "#{@sender.login_name}さんが退会しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do
   .a-long-text
-    h2 
+    h2
       = User.human_attribute_name('retire_reasons')
     ul
       - @sender.retire_reasons.each do |reason|

--- a/app/views/notification_mailer/retired.html.slim
+++ b/app/views/notification_mailer/retired.html.slim
@@ -1,8 +1,9 @@
 = render 'notification_mailer_template', title: "#{@sender.login_name}さんが退会しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do
-  h3 style="font-family: sans-serif; font-size: 20px; color:#4638a0; line-height: 1.5; margin-bottom: 0; font-weight: bold"
-    = "#{User.human_attribute_name('retire_reasons')}:"
+  h1(style='margin-top: 1em; border-left: solid 6px #4638a0; padding: 0 0 0 1rem; font-size: 1.5em; border-bottom: none; color: #444444;') 退会理由
   ul
     - @sender.retire_reasons.each do |reason|
       li
         = md2html(t("active_flag.user.retire_reasons.#{reason}"))
+  h1(style='margin-top: 1em; border-left: solid 6px #4638a0; padding: 0 0 0 1rem; font-size: 1.5em; border-bottom: none; color: #444444;')
+    = User.human_attribute_name('retire_reason')
   = md2html(@sender.retire_reason)

--- a/app/views/notification_mailer/retired.html.slim
+++ b/app/views/notification_mailer/retired.html.slim
@@ -1,2 +1,8 @@
 = render 'notification_mailer_template', title: "#{@sender.login_name}さんが退会しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do
+  h3 style="font-family: sans-serif; font-size: 20px; color:#4638a0; line-height: 1.5; margin-bottom: 0; font-weight: bold"
+    = "#{User.human_attribute_name("retire_reasons")}:"    
+  ul
+    - @sender.retire_reasons.each do |reason|
+      li
+        = md2html(t("active_flag.user.retire_reasons.#{reason}"))
   = md2html(@sender.retire_reason)

--- a/app/views/notification_mailer/retired.html.slim
+++ b/app/views/notification_mailer/retired.html.slim
@@ -1,6 +1,6 @@
 = render 'notification_mailer_template', title: "#{@sender.login_name}さんが退会しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do
   h3 style="font-family: sans-serif; font-size: 20px; color:#4638a0; line-height: 1.5; margin-bottom: 0; font-weight: bold"
-    = "#{User.human_attribute_name("retire_reasons")}:"    
+    = "#{User.human_attribute_name('retire_reasons')}:"
   ul
     - @sender.retire_reasons.each do |reason|
       li

--- a/app/views/notification_mailer/retired.html.slim
+++ b/app/views/notification_mailer/retired.html.slim
@@ -1,7 +1,7 @@
 = render 'notification_mailer_template', title: "#{@sender.login_name}さんが退会しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do
   .a-long-text
-    h2
-      | 退会理由
+    h2 
+      = User.human_attribute_name('retire_reasons')
     ul
       - @sender.retire_reasons.each do |reason|
         li

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -214,6 +214,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
     assert_equal '[FBC] yameoさんが退会しました。', email.subject
+    assert_match(/選択入力の退会理由/, email.body.to_s)
     assert_match(/退会/, email.body.to_s)
   end
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -214,7 +214,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
     assert_equal '[FBC] yameoさんが退会しました。', email.subject
-    assert_match(/退会理由/, email.body.to_s)
     assert_match(/退会/, email.body.to_s)
   end
 

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -214,7 +214,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
     assert_equal '[FBC] yameoさんが退会しました。', email.subject
-    assert_match(/選択入力の退会理由/, email.body.to_s)
+    assert_match(/退会理由/, email.body.to_s)
     assert_match(/退会/, email.body.to_s)
   end
 


### PR DESCRIPTION
## Issue

- #5365

## 概要

- メンター向けの退会メール通知の内容を変更する。
  - 変更前：Aさんのメンターが退会するとき、他のメンター向けのメール内容はAさんの選択した理由がないです。
  - 変更後：Aさんのメンターが退会するとき、他のメンター向けのメール内容はAさんの選択した理由があります。

## 確認方法

1. `feature/add_chosen_reason_to_notification_mail_for_mentor_retirement`をローカルに取り込む
2. `rails s`で起動する
3. 任意の管理者ユーザーでログインする
4. http://localhost:3000/retirement/new にアクセスする
5. 選択入力の退会理由を選択して、以下のコメントも入力する。
6. http://localhost:3000/letter_opener で届くメールの内容は選択理由があるかどうかを確認する。


## 変更前
駒形さんのメンターが退会するとき、他のメンター向けのメール内容は駒形さんの選択した理由がないです。
![Screen Shot 0004-08-18 at 16 33 06](https://user-images.githubusercontent.com/94335407/185336686-00834b25-0610-47dd-9bee-327f28738d87.png)



## 変更後
駒形さんのメンターが退会するとき、他のメンター向けのメール内容は駒形さんの選択した理由があります。
<img width="437" alt="Screen Shot 0004-08-25 at 21 50 48" src="https://user-images.githubusercontent.com/94335407/186669494-98cfdf95-aa93-4b16-88b9-9b04e27647d4.png">

