### PR TITLE
提出物ページの「直近の日報」に気分のアイコンが表示されるようにした

### DIFF
--- a/app/views/products/_report.html.slim
+++ b/app/views/products/_report.html.slim
@@ -12,6 +12,7 @@
                   | WIP
             h2.card-list-item-title__title(itemprop="name")
               = link_to report, itemprop: 'url', class: 'card-list-item-title__link a-text-link js-unconfirmed-link' do
+                = image_tag("emotion/#{report.emotion}.svg", alt: report.emotion, class: 'card-list-item-title__emotion-image')
                 = report.title
       .card-list-item__row
         .card-list-item-meta

--- a/test/system/practice/reports_test.rb
+++ b/test/system/practice/reports_test.rb
@@ -6,5 +6,9 @@ class Practice::ReportsTest < ApplicationSystemTestCase
   test 'show listing reports' do
     visit_with_auth "/practices/#{practices(:practice1).id}/reports", 'hatsuno'
     assert_equal 'OS X Mountain Lionをクリーンインストールする | FBC', title
+    within first('.card-list-item') do
+      assert_selector 'img[alt="happy"]'
+      assert_text '1時間だけ学習'
+    end
   end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -430,6 +430,14 @@ class ProductsTest < ApplicationSystemTestCase
     assert_no_text 'ユーザーメモ'
   end
 
+  test 'display recently reports' do
+    visit_with_auth "/products/#{products(:product1).id}", 'mentormentaro'
+    within first('.side-tabs .card-list-item') do
+      assert_selector 'img[alt="happy"]'
+      assert_text '1時間だけ学習'
+    end
+  end
+
   test 'display the user memos after click on user-memos tab' do
     visit_with_auth "/products/#{products(:product2).id}", 'komagata'
     find('#side-tabs-nav-3').click

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -451,6 +451,14 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '学習日は今日以前の日付にしてください'
   end
 
+  test 'display recently reports' do
+    visit_with_auth report_path(reports(:report10)), 'mentormentaro'
+    within first('.side-tabs .card-list-item') do
+      assert_selector 'img[alt="happy"]'
+      assert_text '今日は頑張りました'
+    end
+  end
+
   test 'display list of submission when mentor is access' do
     visit_with_auth report_path(reports(:report5)), 'komagata'
     assert_text '提出物'


### PR DESCRIPTION
## Issue

#5063 

## 概要

PR #5290 にて上記Issueの対応を行ったが、提出物ページに表示される「直近の日報」のパーシャルファイルの対応が漏れていた。
このPRで提出物ページ用のパーシャルを更新したことで、提出物ページに表示される「直近の日報」にも気分のアイコンが表示されるようになる。

## 動作確認方法

1. `bug/display-niconico-icon-on-pordudts-partial-report` をローカルに取り込む
2. `rails s` で起動する
3. `mentormentaro` でログインする
4. http://localhost:3000/products/178176131 にアクセスする

### 変更前
![image](https://user-images.githubusercontent.com/33394676/185520149-10548872-fc58-4646-8ca6-ebcdd8805a9c.png)

### 変更後
![image](https://user-images.githubusercontent.com/33394676/185520009-9e51af4c-e503-4301-ba30-5ab3f588a3ef.png)

## 補足

念のため全検索して、これ以外に日報のパーシャルが無いことを確認しました。