### PR TITLE
お試し期間の開始・終了日付とお試し期間が連動してしまっている

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -56,7 +56,7 @@ class Campaign < ApplicationRecord
       end
     end
   end
-  
+
   private
 
   def start_at_cannot_be_greater_than_end_at

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -6,10 +6,6 @@ class Campaign < ApplicationRecord
 
   # TODO: Rails 7に更新後、 `ComparisonValidator` を使うように直す。
   # refs: https://github.com/rails/rails/pull/40095
-  # validates :end_at, greater_than: :start_at
-  with_options if: -> { start_at && end_at && trial_period } do
-    validate :end_at_be_greater_than_trial_period
-  end
 
   validates :title, presence: true
   validates :trial_period, presence: true, numericality: { greater_than_or_equal_to: 4 }
@@ -55,16 +51,5 @@ class Campaign < ApplicationRecord
         return camp.trial_period if (camp.start_at..camp.end_at).cover?(join_date)
       end
     end
-  end
-
-  private
-
-  def end_at_be_greater_than_trial_period
-    diff = end_at - start_at
-    period = trial_period.days - 1.minute
-    return if diff >= period
-
-    shortest_end_at = start_at + period
-    errors.add(:end_at, :format, shortest_end_at: I18n.l(shortest_end_at, format: :short))
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -8,7 +8,7 @@ class Campaign < ApplicationRecord
   # refs: https://github.com/rails/rails/pull/40095
   # validates :end_at, greater_than: :start_at
   with_options if: -> { start_at && end_at && trial_period } do
-    validate :end_at_cannot_be_greater_than_start_at
+    validate :start_at_cannot_be_greater_than_end_at
   end
   validates :title, presence: true
   validates :trial_period, presence: true, numericality: { greater_than_or_equal_to: 4 }
@@ -56,7 +56,7 @@ class Campaign < ApplicationRecord
     end
   end
 
-  def end_at_cannot_be_greater_than_start_at
+  def start_at_cannot_be_greater_than_end_at
     return if end_at > start_at
 
     errors.add(:end_at, :format, shortest_end_at: I18n.l(start_at, format: :short))

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -6,7 +6,10 @@ class Campaign < ApplicationRecord
 
   # TODO: Rails 7に更新後、 `ComparisonValidator` を使うように直す。
   # refs: https://github.com/rails/rails/pull/40095
-
+  # validates :end_at, greater_than: :start_at
+  with_options if: -> { start_at && end_at && trial_period } do
+    validate :end_at_cannot_be_greater_than_start_at
+  end
   validates :title, presence: true
   validates :trial_period, presence: true, numericality: { greater_than_or_equal_to: 4 }
 
@@ -50,6 +53,12 @@ class Campaign < ApplicationRecord
       Campaign.find_each do |camp|
         return camp.trial_period if (camp.start_at..camp.end_at).cover?(join_date)
       end
+    end
+  end
+
+  def end_at_cannot_be_greater_than_start_at
+    if start_at > end_at
+      errors.add(:end_at, :format, shortest_end_at: I18n.l(start_at, format: :short))
     end
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -10,6 +10,7 @@ class Campaign < ApplicationRecord
   with_options if: -> { start_at && end_at && trial_period } do
     validate :start_at_cannot_be_greater_than_end_at
   end
+
   validates :title, presence: true
   validates :trial_period, presence: true, numericality: { greater_than_or_equal_to: 4 }
 
@@ -55,7 +56,7 @@ class Campaign < ApplicationRecord
       end
     end
   end
-
+  
   private
 
   def start_at_cannot_be_greater_than_end_at

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -56,6 +56,8 @@ class Campaign < ApplicationRecord
     end
   end
 
+  private
+
   def start_at_cannot_be_greater_than_end_at
     return if end_at > start_at
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -57,8 +57,8 @@ class Campaign < ApplicationRecord
   end
 
   def end_at_cannot_be_greater_than_start_at
-    if start_at > end_at
-      errors.add(:end_at, :format, shortest_end_at: I18n.l(start_at, format: :short))
-    end
+    return if end_at > start_at
+
+    errors.add(:end_at, :format, shortest_end_at: I18n.l(start_at, format: :short))
   end
 end

--- a/test/system/admin/campaigns_test.rb
+++ b/test/system/admin/campaigns_test.rb
@@ -17,6 +17,18 @@ class CampaignsTest < ApplicationSystemTestCase
     assert_link 'お試し延長作成'
   end
 
+  test 'new campaign cannot be created if start_at is greater than end_at' do
+    visit_with_auth new_admin_campaign_path, 'komagata'
+    within 'form[name=campaign]' do
+      fill_in 'campaign[start_at]', with: Time.zone.parse('2021-12-10 00:00')
+      fill_in 'campaign[end_at]', with: Time.zone.parse('2021-12-09 23:59')
+      fill_in 'campaign[trial_period]', with: 6
+      click_button '内容を保存'
+    end
+    assert_text '入力内容にエラーがありました'
+    assert_text '終了日時は2021/12/10 00:00以降を入力してください。'
+  end
+
   test 'new campaign can be created even if end_at is before start_at + trial_period ' do
     visit_with_auth new_admin_campaign_path, 'komagata'
     within 'form[name=campaign]' do

--- a/test/system/admin/campaigns_test.rb
+++ b/test/system/admin/campaigns_test.rb
@@ -17,7 +17,7 @@ class CampaignsTest < ApplicationSystemTestCase
     assert_link 'お試し延長作成'
   end
 
-  test 'new campaign cannot be created' do
+  test 'new campaign can be created even if end_at is before start_at + trial_period ' do
     visit_with_auth new_admin_campaign_path, 'komagata'
     within 'form[name=campaign]' do
       fill_in 'campaign[start_at]', with: Time.zone.parse('2021-12-10 00:00')
@@ -26,8 +26,11 @@ class CampaignsTest < ApplicationSystemTestCase
       fill_in 'campaign[trial_period]', with: 6
       click_button '内容を保存'
     end
-    assert_text '入力内容にエラーがありました'
-    assert_text '終了日時は2021/12/15 23:59以降を入力してください。'
+    assert_text 'お試し延長を作成しました。'
+    assert_text '終了日時の入力値がお試し日数を満たすケース'
+    assert_text '6日'
+    assert_text '2021年12月10日(金) 00:00'
+    assert_text '2021年12月15日(水) 23:58'
   end
 
   test 'new campaign can be created' do

--- a/test/system/admin/campaigns_test.rb
+++ b/test/system/admin/campaigns_test.rb
@@ -27,7 +27,6 @@ class CampaignsTest < ApplicationSystemTestCase
       click_button '内容を保存'
     end
     assert_text 'お試し延長を作成しました。'
-    assert_text '終了日時の入力値がお試し日数を満たすケース'
     assert_text '6日'
     assert_text '2021年12月10日(金) 00:00'
     assert_text '2021年12月15日(水) 23:58'


### PR DESCRIPTION
## Issue

- #5359

## 概要

"お試し期間"が"キャンペーン期間"の意味になってしまっているので終了日時は現在、"開始日時 + お試し期間"より前の日時は設定できないようになっているvalidationを削除する。

  - 変更前：終了日時は"開始日時 + お試し期間"より前の日時は設定できない。
  - 変更後：終了日時は"開始日時 + お試し期間"より前の日時は設定できる。

## 確認方法

1. `bug/start_and_end_date_of_trial_period_validation_error`をローカルに取り込む
2. `rails s`で起動する
3. 任意の管理者ユーザーでログインする
4. http://localhost:3000/admin/campaigns/new にアクセスする
5. 入力について、終了日時は"開始日時 + お試し期間"より前の日時に設定する。
例: 
<img width="837" alt="Screen Shot 0004-08-22 at 11 43 11" src="https://user-images.githubusercontent.com/94335407/185828311-cff2ef65-3b01-4daa-8c2c-621d4a6b2091.png">

7. 作成が成功されたら、「お試し延長を作成しました。」が表示されるはずです。


## 変更前
エラーが表示されるので終了日時は"開始日時 + お試し期間"より前の日時は設定できない。
<img width="806" alt="Screen Shot 0004-08-22 at 11 44 43" src="https://user-images.githubusercontent.com/94335407/185828479-10f543fd-ea56-4f47-80ee-54cb093a01a1.png">



## 変更後
終了日時は"開始日時 + お試し期間"より前の日時は設定できるので「お試し延長を作成しました。」が表示されます。
<img width="1440" alt="Screen Shot 0004-08-22 at 11 47 03" src="https://user-images.githubusercontent.com/94335407/185828715-8050a13e-8026-4762-8fc9-24f8aa55fb14.png">

