### PR TITLE
フォローしている人の日報の更新の通知をabstract_notifierに置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -125,17 +125,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def following_report(report, receiver)
-      Notification.create!(
-        kind: kinds[:following_report],
-        user: receiver,
-        sender: report.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(report),
-        message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
-        read: false
-      )
-    end
-
     def chose_correct_answer(answer, receiver)
       Notification.create!(
         kind: kinds[:chose_correct_answer],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -126,7 +126,7 @@ class NotificationFacade
   end
 
   def self.following_report(report, receiver)
-    Notification.following_report(report, receiver)
+    ActivityNotifier.with(report: report, receiver: receiver).following_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -201,4 +201,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def following_report(params = {})
+    params.merge!(@params)
+    report = params[:report]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
+      kind: :following_report,
+      receiver: receiver,
+      sender: report.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(report),
+      read: false
+    )
+  end
 end

--- a/test/system/followings_test.rb
+++ b/test/system/followings_test.rb
@@ -79,37 +79,6 @@ class FollowingsTest < ApplicationSystemTestCase
     assert_text users(:mentormentaro).login_name
   end
 
-  test 'receive a notification when following user create a report' do
-    visit_with_auth user_path(users(:hatsuno)), 'kimura'
-    find('.following').click
-    click_button 'コメントあり'
-
-    visit_with_auth user_path(users(:hatsuno)), 'mentormentaro'
-    find('.following').click
-    click_button 'コメントなし'
-
-    visit_with_auth '/reports/new', 'hatsuno'
-    within('form[name=report]') do
-      fill_in('report[title]', with: 'test title')
-      fill_in('report[description]', with: 'test')
-      fill_in('report[reported_on]', with: Time.current)
-    end
-
-    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
-    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
-
-    click_button '提出'
-    assert_text '日報を保存しました。'
-
-    visit_with_auth '/notifications', 'kimura'
-    assert_text 'hatsunoさんが日報【 test title 】を書きました！'
-
-    visit_with_auth '/notifications', 'mentormentaro'
-    assert_text 'hatsunoさんが日報【 test title 】を書きました！'
-  end
-
   test "receive a notification when following user's report has comment" do
     visit_with_auth user_path(users(:hatsuno)), 'kimura'
     find('.following').click

--- a/test/system/notification/followings_test.rb
+++ b/test/system/notification/followings_test.rb
@@ -28,10 +28,10 @@ class Notification::FollowingsTest < ApplicationSystemTestCase
       fill_in('report[reported_on]', with: Time.current)
     end
 
-    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
-    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+    first('.learning-time').first('.learning-time__started-at select').select('07')
+    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
+    first('.learning-time').first('.learning-time__finished-at select').select('08')
+    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
 
     click_button '提出'
     assert_text '日報を保存しました。'

--- a/test/system/notification/followings_test.rb
+++ b/test/system/notification/followings_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Notification::FollowingsTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
+  test 'receive a notification when following user create a report' do
+    visit_with_auth user_path(users(:hatsuno)), 'kimura'
+    find('.following').click
+    click_button 'コメントあり'
+
+    visit_with_auth user_path(users(:hatsuno)), 'mentormentaro'
+    find('.following').click
+    click_button 'コメントなし'
+
+    visit_with_auth '/reports/new', 'hatsuno'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: 'test')
+      fill_in('report[reported_on]', with: Time.current)
+    end
+
+    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
+    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+
+    click_button '提出'
+    assert_text '日報を保存しました。'
+
+    visit_with_auth '/notifications', 'kimura'
+    assert_text 'hatsunoさんが日報【 test title 】を書きました！'
+
+    visit_with_auth '/notifications', 'mentormentaro'
+    assert_text 'hatsunoさんが日報【 test title 】を書きました！'
+  end
+end


### PR DESCRIPTION
## issue
- #4684
## 概要
フォローしている人の日報が更新された時のフォロワーへの通知をabstract_notifierに置き換えました。
見た目上の変更はありません。
### 備考
bootcampでは特定のユーザーをフォローできる機能があります。このフォローには、

- コメントあり
- コメントなし
<img width="349" alt="_development__akiyosi___FBC" src="https://user-images.githubusercontent.com/72614612/186287065-4c246817-eda7-4677-a863-22e8af127203.png">

の2種類があります。

#### コメントありを選んでフォローした場合
そのユーザーの日報を自動的にWatch状態にし、

- 日報の更新(投稿)
- 日報に対するコメント

があった場合フォロワーにサイト内通知とメールで通知が行きます。

#### コメントなしを選んでフォローした場合
そのユーザーの日報をWatch状態にせず、

- 日報の更新(投稿)

があった時のみフォロワーにサイト内通知とメールで通知が行きます。

#### 変更前の実装

- 日報にコメントがあったときの通知は
  - `app/models/notification.rb`の`watching_notification`を使って通知してます。
- 日報の更新があった時の通知は
  - `app/models/notification.rb`の`following_report`を使って通知しています。

#### 変更後の実装
`watching_notification`については別のPR(#4690 )として用意されているようなので今回は`following_report`のみabstract_notifierに置き換えてます。なのでテストに関しても、「日報が更新されたとき」は新たにテストを追加し、「日報にコメントが来た時」のテストは従来のままです。

## 変更確認方法

1. `feature/replace-report-updates-notification-with-abstract-notifier`をローカルに取り込む
2. `rails s`で立ち上げる
3. 任意のユーザーでログインする
4. `kimura`を`コメントあり`でフォローする
5. ログアウトし最初にログインしたユーザーとは別のユーザーでログインする
6. `kimura`を`コメントなし`でフォローする
7. ログアウトして`kimura`でログインする
8. 日報を投稿する
9. 再度フォロワー(3と5のユーザー)でログインし、http://localhost:3000/notifications にアクセスしてサイト内通知が来ているかそれぞれ確認する
10. http://localhost:3000/letter_opener にアクセスしそれぞれにメールが届いているか確認する
