### PR TITLE
ユーザー一覧にインクリメンタルサーチを追加

### DIFF
--- a/app/assets/stylesheets/application/blocks/page-content/_page-content.sass
+++ b/app/assets/stylesheets/application/blocks/page-content/_page-content.sass
@@ -4,7 +4,8 @@
   +margin(horizontal, auto)
   &.is-products,
   &.is-questions,
-  &.is-books
+  &.is-books,
+  &.is-users
     width: 100%
   &:not(:first-child)
     +media-breakpoint-up(md)

--- a/app/assets/stylesheets/application/blocks/page/_page-main-header.sass
+++ b/app/assets/stylesheets/application/blocks/page/_page-main-header.sass
@@ -5,7 +5,7 @@
     font-size: 1rem
 
 .page-main-header__inner
-  padding-top: 1rem
+  padding-top: .75rem
   display: flex
   align-items: center
   +media-breakpoint-down(sm)

--- a/app/assets/stylesheets/shared/_container.sass
+++ b/app/assets/stylesheets/shared/_container.sass
@@ -19,3 +19,5 @@
     width: 33.75rem
   body &.has-no-right-padding
     padding-right: 0
+  body &.has-no-x-padding
+    +padding(horizontal, 0)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -23,10 +23,16 @@ class API::UsersController < API::BaseController
         User.users_role(@target)
       end
 
-    @users = target_users
-             .page(params[:page]).per(PAGER_NUMBER)
-             .preload(:company, :avatar_attachment, :course, :tags)
-             .order(updated_at: :desc)
+    @users =
+      if params[:search_word]
+        target_users.search_by_keywords( {word: params[:search_word]})
+      else
+        target_users
+          .page(params[:page]).per(PAGER_NUMBER)
+          .preload(:company, :avatar_attachment, :course, :tags)
+          .order(updated_at: :desc)
+      end
+
 
     @users = @users.unhibernated.unretired unless @company
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,16 +2,11 @@
 
 class API::UsersController < API::BaseController
   before_action :set_user, only: %i[show update]
+  before_action :set_targets, only: %i[index]
   before_action :require_login_for_api
   PAGER_NUMBER = 20
 
   def index
-    @tag = params[:tag]
-    @target = params[:target]
-    @company = params[:company_id]
-    @target = 'student_and_trainee' unless target_allowlist.include?(@target)
-    @watch = params[:watch]
-
     target_users =
       if @target == 'followings'
         current_user.followees_list(watch: @watch)
@@ -25,14 +20,12 @@ class API::UsersController < API::BaseController
 
     @users =
       if params[:search_word]
-        target_users.search_by_keywords( {word: params[:search_word]})
+        target_users.search_by_keywords({ word: params[:search_word] })
       else
-        target_users
-          .page(params[:page]).per(PAGER_NUMBER)
-          .preload(:company, :avatar_attachment, :course, :tags)
-          .order(updated_at: :desc)
+        target_users.page(params[:page]).per(PAGER_NUMBER)
+                    .preload(:company, :avatar_attachment, :course, :tags)
+                    .order(updated_at: :desc)
       end
-
 
     @users = @users.unhibernated.unretired unless @company
   end
@@ -59,6 +52,14 @@ class API::UsersController < API::BaseController
 
   def set_user
     @user = User.find(params[:id])
+  end
+
+  def set_targets
+    @tag = params[:tag]
+    @company = params[:company_id]
+    @target = params[:target]
+    @target = 'student_and_trainee' unless target_allowlist.include?(@target)
+    @watch = params[:watch]
   end
 
   def user_params

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -2,11 +2,15 @@
 
 class API::UsersController < API::BaseController
   before_action :set_user, only: %i[show update]
-  before_action :set_targets, only: %i[index]
   before_action :require_login_for_api
   PAGER_NUMBER = 20
 
   def index
+    @tag = params[:tag]
+    @company = params[:company_id]
+    @target = params[:target]
+    @watch = params[:watch]
+
     @target = 'student_and_trainee' unless target_allowlist.include?(@target)
 
     target_users =
@@ -51,13 +55,6 @@ class API::UsersController < API::BaseController
 
   def set_user
     @user = User.find(params[:id])
-  end
-
-  def set_targets
-    @tag = params[:tag]
-    @company = params[:company_id]
-    @target = params[:target]
-    @watch = params[:watch]
   end
 
   def user_params

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -1,31 +1,56 @@
 <template lang="pug">
 .users
-  nav.pagination(v-if='totalPages > 1')
-    pager(v-bind='pagerProps')
+  .page-filter.form(v-if='users.length !== 0 && isAll')
+    .form__items
+      .form-item.is-inline-md-up
+        label.a-form-label
+          | 絞り込み
+        input#js-user-search-input.a-text-input(
+          v-model.trim='searchUsersWord',
+          placeholder='ユーザー名、読み方、Discord ID、GitHub ID など'
+        )
   .users__items
-    .row(v-if='users === null')
+    .row(v-if='!loaded')
       .empty
         .fa-solid.fa-spinner.fa-pulse
         |
         | ロード中
     .row(v-else-if='users.length !== 0')
-      user(
-        v-for='user in users',
-        :key='user.id',
-        :user='user',
-        :currentUser='currentUser')
+      .user-list(v-show='!showSearchedUsers')
+        nav.pagination(v-if='totalPages > 1')
+          pager(v-bind='pagerProps')
+        user(
+          v-for='user in users',
+          :key='user.id',
+          :user='user',
+          :currentUser='currentUser'
+        )
+        nav.pagination(v-if='totalPages > 1')
+          pager(v-bind='pagerProps')
+      .searched-user-list(v-show='showSearchedUsers')
+        .o-empty-message(v-if='searchedUsers.length === 0')
+          .o-empty-message__icon
+            i.far.fa-sad-tear
+          p.o-empty-message__text
+            | 一致するユーザーはいません
+        .card-list.a-card(v-else)
+          user(
+            v-for=' user in searchedUsers',
+            :key='user.id',
+            :user='user',
+            :currentUser='currentUser'
+          )
     .row(v-else)
       .o-empty-message
         .o-empty-message__icon
           i.fa-regular.fa-sad-tear
         p.o-empty-message__text
           | {{ targetName }}のユーザーはいません
-  nav.pagination(v-if='totalPages > 1')
-    pager(v-bind='pagerProps')
 </template>
 <script>
 import User from './user.vue'
 import Pager from '../pager.vue'
+import { debounce } from 'lodash'
 
 export default {
   name: 'Users',
@@ -35,13 +60,17 @@ export default {
   },
   data() {
     return {
-      users: null,
+      users: [],
       currentUser: null,
       currentTarget: null,
       currentTag: null,
       currentPage: Number(this.getParams().page) || 1,
       totalPages: 0,
-      params: this.getParams()
+      params: this.getParams(),
+      searchUsersWord: '',
+      showSearchedUsers: false,
+      searchedUsers: [],
+      loaded: false
     }
   },
   computed: {
@@ -49,12 +78,14 @@ export default {
       return this.currentTag || this.currentTarget
     },
     url() {
+      const params = this.addParams()
       return (
         '/api/users/' +
         (this.params.tag ? `tags/${this.params.tag}` : '') +
         `?page=${this.currentPage}` +
         (this.params.target ? `&target=${this.params.target}` : '') +
-        (this.params.watch ? `&watch=${this.params.watch}` : '')
+        (this.params.watch ? `&watch=${this.params.watch}` : '') +
+        (params ? `&${params}` : '')
       )
     },
     pagerProps() {
@@ -64,21 +95,29 @@ export default {
         pageRange: 5,
         clickHandle: this.paginateClickCallback
       }
+    },
+    isAll() {
+      return location.search !== '?target=followings'
+    }
+  },
+  watch: {
+    searchUsersWord() {
+      this.searchUsers()
     }
   },
   created() {
     window.onpopstate = function () {
       location.replace(location.href)
     }
-    this.getUsers()
+    this.setupUsers()
   },
   methods: {
     token() {
       const meta = document.querySelector('meta[name="csrf-token"]')
       return meta ? meta.getAttribute('content') : ''
     },
-    getUsers() {
-      fetch(this.url, {
+    async fetchUsersResource() {
+      const usersResource = await fetch(this.url, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
@@ -88,18 +127,17 @@ export default {
         credentials: 'same-origin',
         redirect: 'manual'
       })
+      return usersResource.json()
+    },
+    setupUsers() {
+      this.fetchUsersResource()
         .then((response) => {
-          return response.json()
-        })
-        .then((json) => {
-          this.users = []
-          json.users.forEach((user) => {
-            this.users.push(user)
-          })
-          this.currentUser = json.currentUser
-          this.currentTarget = json.target
-          this.currentTag = json.tag
-          this.totalPages = json.totalPages
+          this.users.splice(0, this.users.length, ...response.users)
+          this.currentUser = response.currentUser
+          this.currentTarget = response.target
+          this.currentTag = response.tag
+          this.totalPages = response.totalPages
+          this.loaded = true
         })
         .catch((error) => {
           console.warn(error)
@@ -122,7 +160,7 @@ export default {
     },
     paginateClickCallback(pageNumber) {
       this.currentPage = pageNumber
-      this.getUsers()
+      this.setupUsers()
       history.pushState(null, null, this.newUrl(pageNumber))
       window.scrollTo(0, 0)
     },
@@ -138,6 +176,32 @@ export default {
           location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
         )
       }
+    },
+    validateSearchUsersWord() {
+      if (this.searchUsersWord.match(/^[\w-]+$/))
+        return this.searchUsersWord.length >= 3
+      return this.searchUsersWord.length >= 2
+    },
+    searchUsers: debounce( function () {
+      this.showSearchedUsers = false
+      if (!this.validateSearchUsersWord()) return
+      this.setupSearchedUsers()
+      this.showSearchedUsers = true
+    }, 500),
+    setupSearchedUsers() {
+      this.loaded = false
+      this.fetchUsersResource()
+        .then((response) => {
+          this.searchedUsers.splice(0, this.searchedUsers.length, ...response.users)
+          this.loaded = true
+        })
+        .catch((error) => console.warn(error))
+    },
+    addParams() {
+      if (!this.validateSearchUsersWord()) return
+      const params = new URL(location.origin).searchParams
+      params.set('search_word', this.searchUsersWord)
+      return params
     }
   }
 }

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -99,7 +99,10 @@ export default {
       }
     },
     isAll() {
-      return location.search !== '?target=followings'
+      return (
+        location.pathname === '/users' &&
+        location.search !== '?target=followings'
+      )
     }
   },
   watch: {

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -1,51 +1,53 @@
 <template lang="pug">
 .users
   .page-filter.form(v-if='users.length !== 0 && isAll')
-    .form__items
-      .form-item.is-inline-md-up
-        label.a-form-label
-          | 絞り込み
-        input#js-user-search-input.a-text-input(
-          v-model.trim='searchUsersWord',
-          placeholder='ユーザー名、読み方、Discord ID、GitHub ID など'
-        )
-  .users__items
-    .row(v-if='!loaded')
-      .empty
-        .fa-solid.fa-spinner.fa-pulse
-        |
-        | ロード中
-    .row(v-else-if='users.length !== 0')
-      .user-list(v-show='!showSearchedUsers')
-        nav.pagination(v-if='totalPages > 1')
-          pager(v-bind='pagerProps')
-        user(
-          v-for='user in users',
-          :key='user.id',
-          :user='user',
-          :currentUser='currentUser'
-        )
-        nav.pagination(v-if='totalPages > 1')
-          pager(v-bind='pagerProps')
-      .searched-user-list(v-show='showSearchedUsers')
-        .o-empty-message(v-if='searchedUsers.length === 0')
-          .o-empty-message__icon
-            i.far.fa-sad-tear
-          p.o-empty-message__text
-            | 一致するユーザーはいません
-        .card-list.a-card(v-else)
-          user(
-            v-for='user in searchedUsers',
-            :key='user.id',
-            :user='user',
-            :currentUser='currentUser'
+    .container.is-md.has-no-x-padding
+      .form__items
+        .form-item.is-inline-md-up
+          label.a-form-label
+            | 絞り込み
+          input#js-user-search-input.a-text-input(
+            v-model.trim='searchUsersWord',
+            placeholder='ユーザー名、読み方、Discord ID、GitHub ID など'
           )
-    .row(v-else)
-      .o-empty-message
-        .o-empty-message__icon
-          i.fa-regular.fa-sad-tear
-        p.o-empty-message__text
-          | {{ targetName }}のユーザーはいません
+  .page-content.is-users
+    .users__items
+      .row(v-if='!loaded')
+        .loading
+          .fa-solid.fa-spinner.fa-pulse
+          | ロード中
+      div(v-else-if='users.length !== 0')
+        .user-list(v-show='!showSearchedUsers')
+          nav.pagination(v-if='totalPages > 1')
+            pager(v-bind='pagerProps')
+          .row
+            user(
+              v-for='user in users',
+              :key='user.id',
+              :user='user',
+              :currentUser='currentUser'
+            )
+          nav.pagination(v-if='totalPages > 1')
+            pager(v-bind='pagerProps')
+        .searched-user-list(v-show='showSearchedUsers')
+          .o-empty-message(v-if='searchedUsers.length === 0')
+            .o-empty-message__icon
+              i.far.fa-sad-tear
+            p.o-empty-message__text
+              | 一致するユーザーはいません
+          div(v-else)
+            user(
+              v-for='user in searchedUsers',
+              :key='user.id',
+              :user='user',
+              :currentUser='currentUser'
+            )
+      .row(v-else)
+        .o-empty-message
+          .o-empty-message__icon
+            i.fa-regular.fa-sad-tear
+          p.o-empty-message__text
+            | {{ targetName }}のユーザーはいません
 </template>
 <script>
 import User from './user.vue'

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -52,18 +52,7 @@
 <script>
 import User from './user.vue'
 import Pager from '../pager.vue'
-
-const debounce = (func, wait) => {
-  let timerId
-  return function (...args) {
-    if (timerId) {
-      clearTimeout(timerId)
-    }
-    timerId = setTimeout(() => {
-      func.apply(this, args)
-    }, wait)
-  }
-}
+import Debounce from '../debounce.js'
 
 export default {
   name: 'Users',
@@ -198,7 +187,7 @@ export default {
         return this.searchUsersWord.length >= 3
       return this.searchUsersWord.length >= 2
     },
-    searchUsers: debounce(function () {
+    searchUsers: Debounce.debounce(function () {
       this.showSearchedUsers = false
       if (!this.validateSearchUsersWord()) return
       this.setupSearchedUsers()

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -35,7 +35,7 @@
               i.far.fa-sad-tear
             p.o-empty-message__text
               | 一致するユーザーはいません
-          div(v-else)
+          .row(v-else)
             user(
               v-for='user in searchedUsers',
               :key='user.id',

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -8,8 +8,7 @@
             | 絞り込み
           input#js-user-search-input.a-text-input(
             v-model.trim='searchUsersWord',
-            placeholder='ユーザー名、読み方、Discord ID、GitHub ID など'
-          )
+            placeholder='ユーザー名、読み方、Discord ID、GitHub ID など')
   .page-content.is-users
     .users__items
       .row(v-if='!loaded')
@@ -25,8 +24,7 @@
               v-for='user in users',
               :key='user.id',
               :user='user',
-              :currentUser='currentUser'
-            )
+              :currentUser='currentUser')
           nav.pagination(v-if='totalPages > 1')
             pager(v-bind='pagerProps')
         .searched-user-list(v-show='showSearchedUsers')
@@ -40,8 +38,7 @@
               v-for='user in searchedUsers',
               :key='user.id',
               :user='user',
-              :currentUser='currentUser'
-            )
+              :currentUser='currentUser')
       .row(v-else)
         .o-empty-message
           .o-empty-message__icon

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -35,7 +35,7 @@
             | 一致するユーザーはいません
         .card-list.a-card(v-else)
           user(
-            v-for=' user in searchedUsers',
+            v-for='user in searchedUsers',
             :key='user.id',
             :user='user',
             :currentUser='currentUser'
@@ -182,7 +182,7 @@ export default {
         return this.searchUsersWord.length >= 3
       return this.searchUsersWord.length >= 2
     },
-    searchUsers: debounce( function () {
+    searchUsers: debounce(function () {
       this.showSearchedUsers = false
       if (!this.validateSearchUsersWord()) return
       this.setupSearchedUsers()
@@ -192,7 +192,11 @@ export default {
       this.loaded = false
       this.fetchUsersResource()
         .then((response) => {
-          this.searchedUsers.splice(0, this.searchedUsers.length, ...response.users)
+          this.searchedUsers.splice(
+            0,
+            this.searchedUsers.length,
+            ...response.users
+          )
           this.loaded = true
         })
         .catch((error) => console.warn(error))

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -187,7 +187,7 @@ export default {
         return this.searchUsersWord.length >= 3
       return this.searchUsersWord.length >= 2
     },
-    searchUsers: Debounce.debounce(function () {
+    searchUsers: Debounce(function () {
       this.showSearchedUsers = false
       if (!this.validateSearchUsersWord()) return
       this.setupSearchedUsers()

--- a/app/javascript/components/users.vue
+++ b/app/javascript/components/users.vue
@@ -52,7 +52,18 @@
 <script>
 import User from './user.vue'
 import Pager from '../pager.vue'
-import { debounce } from 'lodash'
+
+const debounce = (func, wait) => {
+  let timerId
+  return function (...args) {
+    if (timerId) {
+      clearTimeout(timerId)
+    }
+    timerId = setTimeout(() => {
+      func.apply(this, args)
+    }, wait)
+  }
+}
 
 export default {
   name: 'Users',

--- a/app/javascript/debounce.js
+++ b/app/javascript/debounce.js
@@ -1,0 +1,15 @@
+const debounce = (func, wait) => {
+  let timerId
+  return function (...args) {
+    if (timerId) {
+      clearTimeout(timerId)
+    }
+    timerId = setTimeout(() => {
+      func.apply(this, args)
+    }, wait)
+  }
+}
+
+export default {
+  debounce
+}

--- a/app/javascript/debounce.js
+++ b/app/javascript/debounce.js
@@ -10,6 +10,4 @@ const debounce = (func, wait) => {
   }
 }
 
-export default {
-  debounce
-}
+export default debounce

--- a/app/views/api/users/index.json.jbuilder
+++ b/app/views/api/users/index.json.jbuilder
@@ -12,4 +12,4 @@ end
 
 json.target t("target.#{@target}")
 json.tag @tag
-json.totalPages @users.total_pages
+json.totalPages @users.total_pages if @users.respond_to? :total_pages

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -41,7 +41,8 @@ main.page-main
               - if admin_or_mentor_login?
                 span.is-only-mentor
                   |（#{@users.total_count}）
-  .page-body
+  .page-body.is-users
+    // TODO 暫定的な対応
     .container
       .page-body__columns
         .page-body__column.is-main

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -6,7 +6,7 @@ komagata:
   name: Komagata Masaki
   name_kana: コマガタ マサキ
   twitter_account: komagata
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/komagata1111
   github_account: komagata
   blog_url: http://komagata.org
   company: company1
@@ -63,7 +63,7 @@ sotugyou_with_job:
   name: 卒業 就職済美
   name_kana: ソツギョウ シュウショクズミ
   twitter_account: sotugyou_with_job
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/sotugyou_with_job
   blog_url: http://sotugyou_with_job.example.com/
   description: "卒業です。卒業しちゃいました。就職は希望していません。"
   course: course1
@@ -86,7 +86,7 @@ sotugyou:
   name: 卒業 太郎
   name_kana: ソツギョウ タロウ
   twitter_account: sotugyou
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/sotugyou
   blog_url: http://sotugyou.example.com/
   description: "卒業です。卒業しちゃいました。"
   course: course1
@@ -107,7 +107,7 @@ advijirou:
   name: アドバイ 次郎
   name_kana: アドバイ ジロウ
   twitter_account: advijirou
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/advijirou
   blog_url: http://advijirou.example.com
   description: "アドバイ次郎です。アドバイザーです。"
   adviser: true
@@ -125,7 +125,7 @@ yameo:
   name: 辞目 辞目夫
   name_kana: ヤメ ヤメオ
   twitter_account: yameo
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/yameo
   blog_url: http://yameo.org
   description: "退会しました。就職希望はしてました"
   course: course1
@@ -149,7 +149,7 @@ mentormentaro:
   name: メンタ 麺太郎
   name_kana: メンタ メンタロウ
   twitter_account: mentormentaro
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/mentormentaro
   blog_url: http://mentor.com
   description: "メンタ麺太郎です。メンターです。"
   course: course1
@@ -175,7 +175,7 @@ kimura:
   name_kana: キムラ タダシ
   discord_account: kimura#1234
   twitter_account: kimura
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kimura
   blog_url: http://kimura.org
   description: "木村です。"
   course: course1
@@ -197,7 +197,7 @@ hatsuno:
   name: Hatsuno Shinji
   name_kana: ハツノ シンジ
   twitter_account: hatsuno
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/hatsuno
   blog_url: http://hatsuno.org
   description: "初野です。課金しています。"
   customer_id: "cus_12345678"
@@ -222,7 +222,7 @@ hajime:
   name: Hajime Tayo
   name_kana: ハジメ タヨ
   twitter_account: hajime
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/hajime
   blog_url: http://hajime.org
   description: "始です。"
   course: course1
@@ -246,7 +246,7 @@ muryou:
   discord_account: muryou#2222
   twitter_account: muryou
   times_url: https://discord.com/channels/715806612824260640/123456789000000010
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/muryou
   blog_url: http://muryou.org
   description: "無料の助です。趣味は野良犬剣法です。"
   course: course1
@@ -271,7 +271,7 @@ kensyu:
   github_account: kensyu
   twitter_account: kensyu
   times_url: https://discord.com/channels/715806612824260640/123456789000000011
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kensyu
   blog_url: http://kensyu.org
   company: company2
   description: "研修聖子です。"
@@ -298,7 +298,7 @@ senpai:
   github_account: senpai
   twitter_account: senpai
   times_url: https://discord.com/channels/715806612824260640/123456789000000012
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/senpai
   blog_url: http://senpai.org
   company: company2
   description: "研修聖子の会社の先輩エンジニアです。アドバイザーです。"
@@ -322,7 +322,7 @@ kananashi: #name_kanaを持たないユーザー
   github_account: kananashi
   twitter_account: kananashi
   times_url: https://discord.com/channels/715806612824260640/123456789000000013
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kananashi
   blog_url: http://kananashi.org
   description: "読み方のカナが無いユーザーです"
   course: course1
@@ -345,7 +345,7 @@ osnashi: #osを持たないユーザー
   github_account: osnashi
   twitter_account: osnashi
   times_url: https://discord.com/channels/715806612824260640/123456789000000014
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/osnashi
   blog_url: http://osnashi.org
   description: "OSが無いユーザーです"
   course: course1
@@ -367,7 +367,7 @@ jobseeker: #就活希望するユーザー
   github_account: jobseeker
   twitter_account: jobseeker
   times_url: https://discord.com/channels/715806612824260640/123456789000000015
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/exmaple
   blog_url: http://example.org
   description: "フィヨルドからの就職希望してます！"
   course: course1
@@ -388,7 +388,7 @@ nippounashi: # 日報を投稿していないユーザー
   name_kana: ニッポウ　ナシ
   discord_account: nippounashi#0001
   twitter_account: nippounashi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/nippounashi
   blog_url: http://nippounashiorg
   description: "日報がないユーザーです。"
   course: course1
@@ -411,7 +411,7 @@ with_hyphen:
   github_account: *login_name
   discord_account: with_hyphen#1234
   twitter_account: with_hyphen
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/with-hyphen
   blog_url: http://with-hyphen.org
   description: "ログインネームにハイフン(-)を利用しているユーザーです。"
   course: course1
@@ -433,7 +433,7 @@ sumi:
   github_account: sumi
   discord_account: sumi#1234
   twitter_account: sumi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/sumi
   blog_url: http://sumi.org
   description: "testユーザーです。"
   course: course1
@@ -457,7 +457,7 @@ nobu:
   github_account: nobu
   discord_account: nobu#1234
   twitter_account: nobu
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/nobu
   blog_url: http://nobu.org
   description: "testユーザーです。"
   course: course1
@@ -479,7 +479,7 @@ rie:
   github_account: rie
   discord_account: rie#1234
   twitter_account: rie
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/rie
   blog_url: http://rie.org
   description: "testユーザーです。"
   course: course1
@@ -501,7 +501,7 @@ take:
   github_account: take
   discord_account: take#1234
   twitter_account: take
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/take
   blog_url: http://take.org
   description: "testユーザーです。"
   course: course1
@@ -523,7 +523,7 @@ kunimi:
   github_account: kunimi
   discord_account: kunimi#1234
   twitter_account: kunimi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kunimi
   blog_url: http://kunimi.org
   description: "testユーザーです。"
   course: course1
@@ -545,7 +545,7 @@ tomo:
   github_account: tomo
   discord_account: tomo#1234
   twitter_account: tomo
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/tomo
   blog_url: http://tomo.org
   description: "testユーザーです。"
   course: course1
@@ -567,7 +567,7 @@ akiyosi:
   github_account: akiyosi
   discord_account: akiyosi#1234
   twitter_account: akiyosi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/akiyosi
   blog_url: http://akiyosi.org
   description: "testユーザーです。"
   course: course1
@@ -589,7 +589,7 @@ tomomi:
   github_account: tomomi
   discord_account: tomomi#1234
   twitter_account: tomomi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/tomomi
   blog_url: http://tomomi.org
   description: "testユーザーです。"
   course: course1
@@ -611,7 +611,7 @@ ogaoga:
   github_account: ogaoga
   discord_account: ogaoga#1234
   twitter_account: ogaoga
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/ogaoga
   blog_url: http://ogaoga.org
   description: "testユーザーです。"
   course: course1
@@ -633,7 +633,7 @@ take8:
   github_account: take8
   discord_account: take8#1234
   twitter_account: take8
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/take8
   blog_url: http://take8.org
   description: "testユーザーです。"
   course: course1
@@ -657,7 +657,7 @@ fujiyasu:
   github_account: fujiyasu
   discord_account: fujiyasu#1234
   twitter_account: fujiyasu
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/fujiyasu
   blog_url: http://fujiyasu.org
   description: "testユーザーです。"
   course: course1
@@ -677,7 +677,7 @@ adminonly: # adminのroleだけを持ったユーザー
   name: アドミン 能美代
   name_kana: アドミン ノミヨ
   twitter_account: adminonly
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/adminonly
   github_account: adminonly
   blog_url: http://adminonly.org
   description: "管理者権限のみを持つユーザーです(メンターではない)"
@@ -704,7 +704,7 @@ kensyuowata:
   github_account: kensyuowata
   twitter_account: kensyuowata
   times_url: https://discord.com/channels/715806612824260640/123456789000000011
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kensyuowata
   blog_url: http://kensyuowata.org
   company: company2
   description: "研修終太です。"
@@ -758,7 +758,7 @@ tatenoicon: # アイコンが長方形のユーザー
   discord_account: tatenoicon#0001
   github_account: tatenoicon
   twitter_account: tatenoicon
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/tatenoicon
   blog_url: http://tatenoicon.org
   description: "アイコンが長方形のユーザーです。"
   course: course1
@@ -781,7 +781,7 @@ thuynga: # アイコンが小さい画像のユーザー
   discord_account: nga#5675
   github_account: nga20167304
   twitter_account: NgaValin
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/thuynga
   company: アクトインディ
   description: "ガーです。"
   course: course1
@@ -802,7 +802,7 @@ sotugyou-adviser: # 区分が卒業生ではない卒業したユーザー
   name: 卒業 アドバイザー
   name_kana: ソツギョウ アドバイザー
   twitter_account: sotugyou-adviser
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/sotugyou-adviser
   blog_url: http://sotugyou-adviser.example.com/
   description: "区分が卒業生ではない卒業したユーザーです"
   course: course1
@@ -853,7 +853,7 @@ otameshi:
   github_account: otameshi
   discord_account: otameshi#1234
   twitter_account: otameshi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/otameshi
   blog_url: http://otameshi.org
   description: "testユーザーです。お試し延長期間テスト用。"
   course: course1
@@ -876,7 +876,7 @@ discordinvalid: #Discord IDが不正なユーザー
   github_account: discordinvalid
   twitter_account: discordinvalid
   times_url: https://discord.com/channels/715806612824260640/123456789000000014
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/discordinvalid
   blog_url: http://discordinvalid.org
   description: "Discord IDが不正なユーザーです"
   course: course1
@@ -898,7 +898,7 @@ twitterinvalid: #Twitter IDが不正なユーザー
   github_account: twitterinvalid
   twitter_account: twit-ter
   times_url: https://discord.com/channels/715806612824260640/123456789000000114
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/twitterinvalid
   blog_url: http://twitterinvalid.org
   description: "Twitter IDが不正なユーザーです"
   course: course1
@@ -919,7 +919,7 @@ nocompanykensyu: # 所属企業のない研修生
   discord_account: nocompanykensyu#9999
   github_account: nocompanykensyu
   twitter_account: nocompanykensyu
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/nocompanykensyu
   blog_url: http://nocompanykensyu.org
   description: "所属企業がない研修生です。"
   course: course1
@@ -958,7 +958,7 @@ kyuukai:
   customer_id: cus_12345678
   subscription_id: sub_12345678
   twitter_account: kyuukai
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kyuukai
   blog_url: https://example.com/kyuukai
   description: "キュウカイです。休会しています。"
   customer_id: cus_LZ2wCJqYybuDlJ

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -8,7 +8,7 @@ komagata:
   name: Komagata Masaki
   name_kana: コマガタ マサキ
   twitter_account: komagata
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/komagata1111
   github_account: komagata
   blog_url: http://komagata.org
   company: company1
@@ -67,7 +67,7 @@ adminonly: # adminのroleだけを持ったユーザー
   name: アドミン 能美代
   name_kana: アドミン ノミヨ
   twitter_account: adminonly
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/adminonly
   github_account: adminonly
   blog_url: http://adminonly.org
   description: "管理者権限のみを持つユーザーです(メンターではない)"
@@ -91,7 +91,7 @@ sotugyou_with_job:
   name: 卒業 就職済美
   name_kana: ソツギョウ シュウショクズミ
   twitter_account: sotugyou_with_job
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/sotugyou_with_job
   blog_url: http://sotugyou_with_job.example.com/
   description: "卒業です。卒業しちゃいました。就職は希望していません。"
   course: course1
@@ -114,7 +114,7 @@ sotugyou:
   name: 卒業 太郎
   name_kana: ソツギョウ タロウ
   twitter_account: sotugyou
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/sotugyou
   blog_url: http://sotugyou.example.com/
   description: "卒業です。卒業しちゃいました。"
   course: course1
@@ -137,7 +137,7 @@ advijirou:
   name: アドバイ 次郎
   name_kana: アドバイ ジロウ
   twitter_account: advijirou
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/advijirou
   blog_url: http://advijirou.example.com
   description: "アドバイ次郎です。アドバイザーです。"
   adviser: true
@@ -155,7 +155,7 @@ yameo:
   name: 辞目 辞目夫
   name_kana: ヤメ ヤメオ
   twitter_account: yameo
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/yameo
   blog_url: http://yameo.org
   description: "退会しました。就職希望はしてました"
   course: course1
@@ -180,7 +180,7 @@ mentormentaro:
   name: メンタ 麺太郎
   name_kana: メンタ メンタロウ
   twitter_account: mentormentaro
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/mentormentaro
   blog_url: http://mentormentaro.com
   description: "メンタ麺太郎です。メンターです。"
   course: course1
@@ -203,7 +203,7 @@ kimura:
   name_kana: キムラ タダシ
   discord_account: kimura#1234
   twitter_account: kimura
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kimura
   blog_url: http://kimura.org
   description: "木村です。"
   course: course1
@@ -226,7 +226,7 @@ hatsuno:
   name: Hatsuno Shinji
   name_kana: ハツノ シンジ
   twitter_account: hatsuno
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/hatsuno
   blog_url: http://hatsuno.org
   description: "初野です。課金しています。"
   customer_id: "cus_12345678"
@@ -251,7 +251,7 @@ hajime:
   name: Hajime Tayo
   name_kana: ハジメ タヨ
   twitter_account: hajime
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/hajime
   blog_url: http://hajime.org
   description: "始です。テストです。"
   course: course1
@@ -275,7 +275,7 @@ muryou:
   discord_account: muryou#2222
   twitter_account: muryou
   times_url: https://discord.com/channels/715806612824260640/123456789000000010
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/muryou
   blog_url: http://muryou.org
   description: "無料の助です。趣味は野良犬剣法です。"
   course: course1
@@ -300,7 +300,7 @@ kensyu:
   github_account: kensyu
   twitter_account: kensyu
   times_url: https://discord.com/channels/715806612824260640/123456789000000011
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kensyu
   blog_url: http://kensyu.org
   company: company2
   description: "研修聖子です。"
@@ -328,7 +328,7 @@ senpai:
   github_account: senpai
   twitter_account: senpai
   times_url: https://discord.com/channels/715806612824260640/123456789000000012
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/senpai
   blog_url: http://senpai.org
   company: company2
   description: "研修聖子の会社の先輩エンジニアです。アドバイザーです。"
@@ -352,7 +352,7 @@ kananashi: #name_kanaを持たないユーザー
   github_account: kananashi
   twitter_account: kananashi
   times_url: https://discord.com/channels/715806612824260640/123456789000000013
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kananashi
   blog_url: http://kananashi.org
   description: "読み方のカナが無いユーザーです"
   course: course1
@@ -375,7 +375,7 @@ osnashi: #osを持たないユーザー
   github_account: osnashi
   twitter_account: osnashi
   times_url: https://discord.com/channels/715806612824260640/123456789000000014
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/osnashi
   blog_url: http://osnashi.org
   description: "OSが無いユーザーです"
   course: course1
@@ -397,7 +397,7 @@ discordinvalid: #Discord IDが不正なユーザー
   github_account: discordinvalid
   twitter_account: discordinvalid
   times_url: https://discord.com/channels/715806612824260640/123456789000000014
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/discordinvalid
   blog_url: http://discordinvalid.org
   description: "Discord IDが不正なユーザーです"
   course: course1
@@ -419,7 +419,7 @@ twitterinvalid: #Twitter IDが不正なユーザー
   github_account: twitterinvalid
   twitter_account: twit-ter
   times_url: https://discord.com/channels/715806612824260640/123456789000000114
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/twitterinvalid
   blog_url: http://twitterinvalid.org
   description: "Twitter IDが不正なユーザーです"
   course: course1
@@ -441,7 +441,7 @@ jobseeker: #就活希望するユーザー
   github_account: jobseeker
   twitter_account: jobseeker
   times_url: https://discord.com/channels/715806612824260640/123456789000000015
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/exmaple
   blog_url: http://example.org
   description: "フィヨルドからの就職希望してます！"
   course: course1
@@ -462,7 +462,7 @@ nippounashi: # 日報を投稿していないユーザー
   name_kana: ニッポウ　ナシ
   discord_account: nippounashi#0001
   twitter_account: nippounashi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/nippounashi
   blog_url: http://nippounashiorg
   description: "日報がないユーザーです。"
   course: course1
@@ -485,7 +485,7 @@ with_hyphen:
   github_account: *login_name
   discord_account: with_hyphen#1234
   twitter_account: with_hyphen
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/with-hyphen
   blog_url: http://with-hyphen.org
   description: "ログインネームにハイフン(-)を利用しているユーザーです。"
   course: course1
@@ -508,7 +508,7 @@ kensyuowata: # 研修が終わったユーザー
   github_account: kensyuowata
   twitter_account: kensyuowata
   times_url: https://discord.com/channels/715806612824260640/123456789000000011
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kensyuowata
   blog_url: http://kensyuowata.org
   company: company2
   description: "研修終太です。"
@@ -535,7 +535,7 @@ taikai: # 退会直後のユーザー
   discord_account: taikai#5678
   github_account: taikai
   twitter_account: taikai
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/taikai
   blog_url: http://taikai.org
   description: "退会直後後です。"
   course: course1
@@ -559,7 +559,7 @@ taikai3: # 退会3ヶ月後のユーザー
   discord_account: taikai#3333
   github_account: taikai3
   twitter_account: taikai3
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/taikai3
   blog_url: http://taikai3.org
   description: "退会3ヶ月後です。"
   course: course1
@@ -584,7 +584,7 @@ otameshi:
   github_account: otameshi
   discord_account: otameshi#1234
   twitter_account: otameshi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/otameshi
   blog_url: http://otameshi.org
   description: "testユーザーです。お試し延長期間テスト用。"
   course: course1
@@ -606,7 +606,7 @@ enchomaemae:
   github_account: enchomaemae
   discord_account: enchomaemae#1234
   twitter_account: enchomaemae
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/enchomaemae
   blog_url: http://enchomaemae.org
   description: "早始・遅始さんよりも前のキャンペーンで入会しました。お試し期間は5日間です。"
   course: course1
@@ -628,7 +628,7 @@ enchomaeyo:
   github_account: enchomaeyo
   discord_account: enchomaeyo#1234
   twitter_account: enchomaeyo
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/enchomaeyo
   blog_url: http://enchomaeyo.org
   description: "お試し延長キャンペーン直前に入会してしまいました。お試し期間は3日間です。"
   course: course1
@@ -650,7 +650,7 @@ enchohayashi:
   github_account: enchohayashi
   discord_account: enchohayashi#1234
   twitter_account: enchohayashi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/enchohayashi
   blog_url: http://otameshi.org
   description: "お試し延長キャンペーンの開始と同時に入会しました。お試し期間は7日間です。"
   course: course1
@@ -672,7 +672,7 @@ enchoososhi:
   github_account: enchoososhi
   discord_account: enchoososhi#1234
   twitter_account: enchoososhi
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/enchoososhi
   blog_url: http://enchoososhi.org
   description: "お試し延長キャンペーンの終了間際に入会しました。お試し期間は7日間です。"
   course: course1
@@ -694,7 +694,7 @@ enchoowata:
   github_account: enchoowata
   discord_account: enchoowata#1234
   twitter_account: enchoowata
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/enchoowata
   blog_url: http://enchoowata.org
   description: "お試し延長キャンペーン終了直後に入会しました。お試し期間は3日間です。"
   course: course1
@@ -716,7 +716,7 @@ kimuramitai:
   github_account: kimuragithub
   discord_account: kimuradiscord#1234
   twitter_account: kimuratwitter
-  facebook_url: http://www.facebook.com/kimurafacebook
+  facebook_url: https://www.facebook.com/fjordllc/kimurafacebook
   blog_url: http://kimurablog.org
   description: "木村さんに似ているとよく言われます。"
   course: course1
@@ -741,7 +741,7 @@ long-id-mentor:
   name: 戸手藻長巣義留 名前之面多
   name_kana: トテモナガスギル ナマエノメンタ
   twitter_account: long-id-mentor
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/long-id-mentor
   blog_url: http://long-id-mentor.com
   description: "名前がとても長いので頑張って覚えてください。"
   course: course1
@@ -765,7 +765,7 @@ nocompanykensyu: # 所属企業のない研修生
   discord_account: nocompanykensyu#9999
   github_account: nocompanykensyu
   twitter_account: nocompanykensyu
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/nocompanykensyu
   blog_url: http://nocompanykensyu.org
   description: "所属企業がない研修生です。"
   course: course1
@@ -802,7 +802,7 @@ kyuukai:
   name: Kyu Kai
   name_kana: キュウ カイ
   twitter_account: kyuukai
-  facebook_url: https://www.facebook.com/fjordllc
+  facebook_url: https://www.facebook.com/fjordllc/kyuukai
   blog_url: https://example.com/kyuukai
   description: "キュウカイです。休会しています。"
   customer_id: "cus_12345678"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -530,6 +530,9 @@ class UsersTest < ApplicationSystemTestCase
     visit '/users/tags'
     assert has_no_field? 'js-user-search-input'
 
+    visit '/users/tags/猫'
+    assert has_no_field? 'js-user-search-input'
+
     visit '/users?target=followings'
     assert has_no_field? 'js-user-search-input'
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -399,4 +399,149 @@ class UsersTest < ApplicationSystemTestCase
     visit '/users/new'
     assert_equal 'フィヨルドブートキャンプ参加登録 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
+
+  test 'incremental search by login_name' do
+    visit_with_auth '/users', 'komagata'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'kimura'
+    assert_text 'Kimura Tadasi', count: 1
+  end
+
+  test 'incremental search by name' do
+    visit_with_auth '/users', 'kimura'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'Shinji'
+    assert_text 'Hatsuno Shinji', count: 1
+  end
+
+  test 'incremental search by name_kana' do
+    visit_with_auth '/users', 'mentormentaro'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'キムラ ミタイ'
+    assert_text 'Kimura Mitai', count: 1
+  end
+
+  test 'incremental search by twitter_account' do
+    visit_with_auth '/users', 'komagata'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'hatsuno'
+    assert_text 'Hatsuno Shinji', count: 1
+  end
+
+  test 'incremental search by blog_url' do
+    visit_with_auth '/users', 'komagata'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'hatsuno.org'
+    assert_text 'Hatsuno Shinji', count: 1
+  end
+
+  test 'incremental search by github_account' do
+    visit_with_auth '/users', 'komagata'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'kananashi'
+    assert_text 'ユーザーです 読み方のカナが無い', count: 1
+  end
+
+  test 'incremental search by discord_account' do
+    visit_with_auth '/users', 'komagata'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'kimura#1234'
+    assert_text 'Kimura Tadasi', count: 1
+  end
+
+  test 'incremental search by description' do
+    visit_with_auth '/users', 'komagata'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: '木村です'
+    assert_text 'Kimura Tadasi', count: 1
+  end
+
+  test 'search only mentor when target is mentor' do
+    visit_with_auth '/users?target=mentor', 'komagata'
+    assert_equal 4, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'machida'
+    assert_text 'Machida Teppei', count: 1
+
+    fill_in 'js-user-search-input', with: 'kimura'
+    assert_text '一致するユーザーはいません'
+  end
+
+  test 'search only graduated students when target is graduate' do
+    visit_with_auth '/users?target=graduate', 'komagata'
+    assert_equal 3, all('.users-item').length
+    fill_in 'js-user-search-input', with: '卒業 就職済美'
+    assert_text '卒業 就職済美', count: 1
+
+    fill_in 'js-user-search-input', with: 'kimura'
+    assert_text '一致するユーザーはいません'
+  end
+
+  test 'search only adviser when target is adviser' do
+    visit_with_auth '/users?target=adviser', 'komagata'
+    assert_equal 2, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'advijirou'
+    assert_text 'アドバイ 次郎', count: 1
+
+    fill_in 'js-user-search-input', with: 'kimura'
+    assert_text '一致するユーザーはいません'
+  end
+
+  test 'search only trainee when target is trainee' do
+    visit_with_auth '/users?target=trainee', 'komagata'
+    assert_equal 2, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'Kensyu Seiko'
+    assert_text 'Kensyu Seiko', count: 1
+
+    fill_in 'js-user-search-input', with: 'kimura'
+    assert_text '一致するユーザーはいません'
+  end
+
+  test 'search users from all users when target is all' do
+    visit_with_auth '/users?target=all', 'komagata'
+    assert_text 'ロード中'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'hajime'
+    assert_text 'Hajime Tayo', count: 1
+
+    fill_in 'js-user-search-input', with: 'machida'
+    assert_text 'Machida Teppei', count: 1
+  end
+
+  test "don't show incremental search when target's users aren't exist" do
+    visit_with_auth '/users?target=job_seeking', 'komagata'
+    assert_equal 0, all('.users-item').length
+    assert has_no_field? 'js-user-search-input'
+  end
+
+  test 'only show incremental search in all tab' do
+    visit_with_auth '/users', 'komagata'
+    assert has_field? 'js-user-search-input'
+
+    visit '/generations'
+    assert has_no_field? 'js-user-search-input'
+
+    visit '/users/tags'
+    assert has_no_field? 'js-user-search-input'
+
+    visit '/users?target=followings'
+    assert has_no_field? 'js-user-search-input'
+
+    visit '/users/companies'
+    assert has_no_field? 'js-user-search-input'
+  end
+
+  test 'incremental search needs more than two characters for Japanese and three for others' do
+    visit_with_auth '/users', 'komagata'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'ki'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'kim'
+    assert_text 'Kimura', count: 2
+
+    fill_in 'js-user-search-input', with: 'キ'
+    assert_selector '.user-list'
+    assert_no_selector '.searched-user-list'
+    fill_in 'js-user-search-input', with: 'キム'
+    assert_text 'Kimura', count: 2
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -485,7 +485,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'search only adviser when target is adviser' do
     visit_with_auth '/users?target=adviser', 'komagata'
-    assert_equal 2, all('.users-item').length
+    assert_equal 3, all('.users-item').length
     fill_in 'js-user-search-input', with: 'advijirou'
     assert_text 'アドバイ 次郎', count: 1
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -449,6 +449,13 @@ class UsersTest < ApplicationSystemTestCase
     assert_text 'Kimura Tadasi', count: 1
   end
 
+  test 'incremental search by facebook_url' do
+    visit_with_auth '/users', 'komagata'
+    assert_equal 20, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'kimurafacebook'
+    assert_text 'Kimura Mitai', count: 1
+  end
+
   test 'incremental search by description' do
     visit_with_auth '/users', 'komagata'
     assert_equal 20, all('.users-item').length


### PR DESCRIPTION
## Issue
- #5349

## 概要
ユーザー一覧の全てタブのみにインクリメンタルサーチを設置しました。
検索文字列を入力後、以下の条件でインクリメンタルサーチができるようにしました。

- 現在表示しているユーザーのロールを検索対象にする
- 現在表示しているユーザーのロールでユーザーが存在しない場合はインクリメンタルサーチを非表示とする
- /^[\w-]+$/ にマッチする場合は3文字以上、それ以外は2文字以上の入力が必要
- 検索対象
  - ユーザーID（ログイン名）
  - ユーザー名
  - ユーザー名読み方
  - Discord ID
  - GitHub ID
  - Twitter ID
  - facebook URL
  - ブログURL
  - 自己紹介文


## 変更確認方法
1. ブランチ`feature/add-incremental-search-in-users-list`をローカルに取り込んでください。
2. `bin/rails s`でローカル環境を立ち上げてください。 
3. `komagata`でhttp://localhost:3000/users にアクセスし`絞り込み`と表示されているラベルと共にインクリメンタルサーチが存在することを確認してください。その際のユーザーロールは現役生になっています。
4.  任意の検索文字列を上記検索対象(現役生)で大文字/小文字の英字、数字、アンダースコア、ハイフンで３文字以上入力し、そのユーザーが現役生の中から検索されることを確認してください。その際検索文字列が２文字以内であれば検索機能が動作しない事も同時に確認してください。また検索中の際は画面にロード中と表示されます。
5. また任意の現役生を日本語２文字以上入力し、検索結果が表示されることを確認してください。その際に１文字のみだと検索機能が動作しない事も確認してください。
6. インクリメンタルサーチで任意のメンターを検索してください。検索結果にユーザーが表示されず一致するユーザーはいませんと表示されることを確認してください。
7. http://localhost:3000/users?target=followings にアクセスし、インクリメンタルサーチが表示されないことを確認してください。

### facebookURLを用いたテストについて
`fixtures/users.yml`で登録されているユーザーのfacebookURLがFBCに関係のない実在するものが使用されていたため、以前のIssueで全てのユーザーfacebookURLをフィヨルドのURLを使用したものに変更されています。今回のfacebookURLを用いたテストを作成するにあたり個人を特定したかったため、駒形さんに確認し現状使用されていないURLで一意のものに変更致しました。

## 変更箇所

<img width="1339" alt="スクリーンショット 2022-09-21 21 50 21" src="https://user-images.githubusercontent.com/76685187/191509631-cbbfd8f4-4126-486e-9502-ba3582d80629.png">
