### PR TITLE
アイコン付きメンションで、アイコンが付かないユーザーがいる

### DIFF
--- a/app/javascript/markdown-it-user-icon.js
+++ b/app/javascript/markdown-it-user-icon.js
@@ -1,7 +1,7 @@
 import MarkdownItRegexp from 'markdown-it-regexp'
 
 export default MarkdownItRegexp(
-  /:@(?!mentor)([a-zA-Z0-9_-]+):/,
+  /:@(?!mentor:)([a-zA-Z0-9_-]+):/,
 
   (match) => {
     return `<a href="/users/${match[1]}" class="a-user-emoji-link"><img class="js-user-icon a-user-emoji" data-user="${match[1]}" width="40" height="40"></a>`

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -15,4 +15,17 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_css "a[href='/users/mentormentaro']"
     assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
   end
+
+  test 'user profile image markdown test' do
+    visit_with_auth new_page_path, 'komagata'
+    fill_in 'page[title]', with: 'レポート'
+    fill_in 'page[body]', with: ":@mentormentaro: \n すみません、これも確認していただけませんか？"
+
+    click_button '内容を保存'
+
+    assert_css '.a-long-text.is-md.js-markdown-view'
+    assert_css '.speak'
+    assert_css "a[href='/users/mentormentaro']"
+    assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
+  end
 end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -24,7 +24,6 @@ class MarkdownTest < ApplicationSystemTestCase
     click_button '内容を保存'
 
     assert_css '.a-long-text.is-md.js-markdown-view'
-    assert_css '.speak'
     assert_css "a[href='/users/mentormentaro']"
     assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
   end


### PR DESCRIPTION
## Issue

- #5241 

## 概要

アイコン付きメンションをしようとしても、アイコンが付かないユーザーがいます。
原因はユーザー名が「mentor」で始まる場合、正規表現は最初にすべてのメンターにメンションしてしまうので、エラーが出ます。

  - 変更前：mentormentaroさんがメンションできない。
  - 変更後：mentormentaroさんがメンションできる。

## 確認方法

1. `bug/mention_some_mentor_not_display_profile_picture`をローカルに取り込む
2. `rails s`で起動する
3. 任意のユーザーでログインする
4. http://localhost:3000/reports/new にアクセスする
5. 説明部分で「:@mentormentaro:」に書きます。
6. プレビューでmentormentaroさんがプロファイル画像があるかどうかを確認する。
7. 念の為、他のメンターも画像があるかどうかを確認する。

## 変更前

mentormentaroさんがメンションできないの状況になっています。
<img width="941" alt="Screen Shot 0004-08-24 at 16 23 35" src="https://user-images.githubusercontent.com/94335407/186356675-25909891-f9fc-4723-ac4a-80b592763281.png">

## 変更後
mentormentaroさんがメンションできるようになりました。

<img width="850" alt="Screen Shot 0004-08-24 at 16 25 06" src="https://user-images.githubusercontent.com/94335407/186356916-e07e2cc0-f56e-4163-9679-b4b93776d2de.png">

