### PR TITLE
タイトルタグの文言変更#プラクティス個別ページのDocsタブ遷移時

### DIFF
--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -1,4 +1,4 @@
-- title @practice.title
+- title "#{@practice.title}に関するDocs"
 - category = @practice.category(current_user.course)
 
 = render '/practices/page_header', title: title, category: category

--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -1,7 +1,7 @@
 - title "#{@practice.title}に関するDocs"
 - category = @practice.category(current_user.course)
 
-= render '/practices/page_header', title: title, category: category
+= render '/practices/page_header', title: @practice.title, category: category
 = render 'page_tabs', resource: @practice
 
 .page-body

--- a/test/system/practice/pages_test.rb
+++ b/test/system/practice/pages_test.rb
@@ -6,6 +6,7 @@ class Practice::PagesTest < ApplicationSystemTestCase
   test 'show listing pages' do
     visit_with_auth "/practices/#{practices(:practice1).id}/pages", 'hatsuno'
     assert_equal 'OS X Mountain Lionをクリーンインストールするに関するDocs | FBC', title
+    assert_selector 'h2.page-header__title', text: 'OS X Mountain Lionをクリーンインストールする'
   end
 
   test 'show last updated user icon and role' do

--- a/test/system/practice/pages_test.rb
+++ b/test/system/practice/pages_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class Practice::PagesTest < ApplicationSystemTestCase
   test 'show listing pages' do
     visit_with_auth "/practices/#{practices(:practice1).id}/pages", 'hatsuno'
-    assert_equal 'OS X Mountain Lionをクリーンインストールする | FBC', title
+    assert_equal 'OS X Mountain Lionをクリーンインストールするに関するDocs | FBC', title
   end
 
   test 'show last updated user icon and role' do


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/5411

## Description
プラクティス個別ページのDocsタブ遷移時のtitleタグの文言を変更しました。

## 変更前
![image](https://user-images.githubusercontent.com/70259961/186645353-055425b9-a168-464e-be19-b7fe4a93e53c.png)

## 変更後
![image](https://user-images.githubusercontent.com/70259961/186645495-63bf46bf-a450-414b-bafc-70aa1085cd93.png)

