### PR TITLE
titleタグの文言変更#ユーザー一覧ページ期生別タブ遷移時

### DIFF
--- a/app/views/generations/index.html.slim
+++ b/app/views/generations/index.html.slim
@@ -1,4 +1,4 @@
-- title '期一覧'
+- title '期生別ユーザー一覧'
 
 header.page-header.is-border-bottom-none
   .container
@@ -14,7 +14,7 @@ main.page-main
     .container
       .page-main-header__inner
         h1.page-main-header__title
-          = title
+          = '期一覧'
   .page-body
     .container.is-lg
       - if @generations.present?

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -20,5 +20,7 @@ class GenerationsTest < ApplicationSystemTestCase
     assert_text 'ユーザー一覧'
     assert_link "#{users(:kimura).generation}期生"
     assert_text '2014年01月01日 ~ 2014年03月31日'
+    assert_equal '期生別ユーザー一覧 | FBC', title
+    assert_selector 'h1', text: '期一覧'
   end
 end


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/5405

## Description
ユーザー一覧ページ内、期生別タブ遷移時のtitleタグの文言を変更

## 変更前
![image](https://user-images.githubusercontent.com/70259961/186656409-a726e53f-6424-4f97-97c8-c090ef40c598.png)

## 変更後
![image](https://user-images.githubusercontent.com/70259961/186656482-0d2c36a4-51a1-4557-8118-48fd10902c79.png)
