### PR TITLE
プラクティス個別ページのQ&Aページの、titleタグを変更した

### DIFF
--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -1,4 +1,4 @@
-- title @practice.title + 'に関するQ&A'
+- title "#{@practice.title}に関するQ&A"
 - category = @practice.category(current_user.course)
 
 = render '/practices/page_header', title: title, category: category

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -1,4 +1,4 @@
-- title @practice.title
+- title @practice.title + 'に関するQ&A'
 - category = @practice.category(current_user.course)
 
 = render '/practices/page_header', title: title, category: category

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -1,7 +1,7 @@
 - title "#{@practice.title}に関するQ&A"
 - category = @practice.category(current_user.course)
 
-= render '/practices/page_header', title: title, category: category
+= render '/practices/page_header', title: @practice.title, category: category
 = render 'page_tabs', resource: @practice
 
 nav.tab-nav

--- a/test/reports/TEST-Practice_QuestionsTest.xml
+++ b/test/reports/TEST-Practice_QuestionsTest.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuite time='125.352722' skipped='0' failures='0' errors='0' name="Practice::QuestionsTest" assertions='4' tests='3' timestamp="2022-08-30T20:13:26+09:00">
-  <testcase time='60.509259' file="test/system/practice/questions_test.rb" name="test_show_listing_questions" assertions='1'>
-  </testcase>
-  <testcase time='60.698054' file="test/system/practice/questions_test.rb" name="test_not_show_a_WIP_question_on_the_unsolved_questions_list_" assertions='2'>
-  </testcase>
-  <testcase time='4.145409' file="test/system/practice/questions_test.rb" name="test_show_a_WIP_question_on_the_all_questions_list_" assertions='1'>
-  </testcase>
-</testsuite>

--- a/test/reports/TEST-Practice_QuestionsTest.xml
+++ b/test/reports/TEST-Practice_QuestionsTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite time='125.352722' skipped='0' failures='0' errors='0' name="Practice::QuestionsTest" assertions='4' tests='3' timestamp="2022-08-30T20:13:26+09:00">
+  <testcase time='60.509259' file="test/system/practice/questions_test.rb" name="test_show_listing_questions" assertions='1'>
+  </testcase>
+  <testcase time='60.698054' file="test/system/practice/questions_test.rb" name="test_not_show_a_WIP_question_on_the_unsolved_questions_list_" assertions='2'>
+  </testcase>
+  <testcase time='4.145409' file="test/system/practice/questions_test.rb" name="test_show_a_WIP_question_on_the_all_questions_list_" assertions='1'>
+  </testcase>
+</testsuite>

--- a/test/system/practice/questions_test.rb
+++ b/test/system/practice/questions_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class Practice::QuestionsTest < ApplicationSystemTestCase
   test 'show listing questions' do
     visit_with_auth "/practices/#{practices(:practice1).id}/questions", 'hatsuno'
-    assert_equal 'OS X Mountain Lionをクリーンインストールする | FBC', title
+    assert_equal 'OS X Mountain Lionをクリーンインストールするに関するQ&A | FBC', title
   end
 
   test 'show a WIP question on the all questions list ' do


### PR DESCRIPTION
# issue
[プラクティス個別ページ > Q&A の title タグ変更 · Issue \#5410 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/5410)

## 概要
現在、各プラクティスページの中の、Q&Aページのtitleがプラクティス名になっている。
例えば、このページ（ http://localhost:3000/practices/315059988 ）のプラクティスの場合は、
このページ（ http://localhost:3000/practices/315059988/questions ）がQ&Aページに該当する。
このページの、下記画像で赤で示した部分がプラクティス名になっているので、「[プラクティス名]に関するQ&A」とした。
![image](https://user-images.githubusercontent.com/76944527/186676168-68e1165e-4173-4dc1-ab25-9daa910c8e37.png)

## 変更前
![image](https://user-images.githubusercontent.com/76944527/186676168-68e1165e-4173-4dc1-ab25-9daa910c8e37.png)

## 変更後
![image](https://user-images.githubusercontent.com/76944527/186676198-f1507c1e-7073-48a2-a4ec-f067773571f8.png)

## 変更点の確認方法
1. feature/change_title_tag_in_practice_pageブランチをローカルに取り込む
1. rails sで立ち上げる
1. komagataでログインする
1. http://localhost:3000/practices/315059988/questions にアクセスする


ご確認よろしくお願いいたします！