### PR TITLE
プラクティス個別ページの提出物titleタグ変更

### DIFF
--- a/app/views/practices/products/index.html.slim
+++ b/app/views/practices/products/index.html.slim
@@ -1,7 +1,7 @@
-- title @practice.title
+- title "#{@practice.title}の提出物"
 - category = @practice.category(current_user.course)
 
-= render '/practices/page_header', title: title, category: category
+= render '/practices/page_header', title: @practice.title, category: category
 = render 'page_tabs', resource: @practice
 
 .page-body

--- a/test/system/practice/products_test.rb
+++ b/test/system/practice/products_test.rb
@@ -5,6 +5,6 @@ require 'application_system_test_case'
 class Practice::ProductsTest < ApplicationSystemTestCase
   test 'show listing products' do
     visit_with_auth "/practices/#{practices(:practice1).id}/products", 'komagata'
-    assert_equal 'OS X Mountain Lionをクリーンインストールする | FBC', title
+    assert_equal 'OS X Mountain Lionをクリーンインストールするの提出物 | FBC', title
   end
 end


### PR DESCRIPTION
## Issue

- #5412

## 概要

プラクティス個別ページの「提出物」遷移時のtitleタグを変更。

変更前：プラクティス名
変更後：プラクティス名の提出物

## 変更確認方法

1. ブランチ`feature/change-title-tag-of-product`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 一般ユーザーでログインする
4. http://localhost:3000/practices/315059988/products にアクセスする

## 変更前
<img width="1434" alt="_development__OS_X_Mountain_Lionをクリーンインストールする___FBC" src="https://user-images.githubusercontent.com/99729409/186705516-251b60cb-a9c5-4293-ac42-f84670418790.png">


## 変更後
<img width="1434" alt="_development__OS_X_Mountain_Lionをクリーンインストールするの提出物___FBC" src="https://user-images.githubusercontent.com/99729409/186704788-3868a992-073b-44ba-8707-f561e024f86a.png">

