### PR TITLE
担当提出物のみ返信が0だった場合の文言を変更した

### DIFF
--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -9,7 +9,7 @@ header.page-header
 = render 'products/tabs'
 = render 'nav'
 
-- title 'レビューを担当する未返信の提出物' if @target == 'self_assigned_no_replied'
+- title '未返信の担当提出物' if @target == 'self_assigned_no_replied'
 
 .page-body
   .container.is-md


### PR DESCRIPTION
 ## Issue
  
  - #5008
  
  ## 概要
  
  担当提出物の未返信が0だった場合の文言を変更した。
  
  ## 変更確認方法
  
  1. ブランチ`feature/change-wording-when-there-are-zero-unreturned-submissions`をローカルに取り込む
  2. `bin/rails s`でローカル環境を立ち上げる
  3. 任意のメンターでログインする
  4. 右記へ接続する`http://localhost:3000/products/self_assigned?target=self_assigned_no_replied`
  5. `未返信の担当提出物はありません`に文言が変わっていることを確認する
  
  ## 変更前
  
[![Image from Gyazo](https://i.gyazo.com/b86da4a64adcd182f1d8ef9890e6053e.png)](https://gyazo.com/b86da4a64adcd182f1d8ef9890e6053e)
  
  ## 変更後

  ![image](https://user-images.githubusercontent.com/65638955/186894601-6efab0da-44a5-4590-b3f3-dc401c00e388.png)