### PR TITLE
Twitterに投稿しても画像が出ない

### DIFF
--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -30,30 +30,11 @@ module MetaTagsHelper
 
   # rubocop:disable Metrics/MethodLength
   def welcome_meta_tags
-    {
-      title: title || nil,
-      site: 'FBC',
-      reverse: true,
-      charset: 'utf-8',
-      description: '現場の即戦力になれるプログラミングスクール。',
-      viewport: 'width=device-width, initial-scale=1.0',
-      og: {
-        title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）',
-        type: 'website',
-        site_name: 'fjord bootcamp',
-        description: :description,
-        image: 'https://bootcamp.fjord.jp/ogp/ogp.png',
-        url: 'https://bootcamp.fjord.jp'
-      },
-      twitter: {
-        title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）',
-        card: 'summary',
-        site: '@fjordbootcamp',
-        description: :description,
-        image: 'https://bootcamp.fjord.jp/ogp/ogp.png',
-        domain: 'https://bootcamp.fjord.jp'
-      }
-    }
+    welcome_meta_tags = default_meta_tags.dup
+    welcome_meta_tags[:title] = title || nil
+    welcome_meta_tags[:og][:title] = title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
+    welcome_meta_tags[:twitter][:title] = title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
+    welcome_meta_tags
   end
   # rubocop:enable Metrics/MethodLength
 end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -28,7 +28,6 @@ module MetaTagsHelper
   end
   # rubocop:enable Metrics/MethodLength
 
-  # rubocop:disable Metrics/MethodLength
   def welcome_meta_tags
     welcome_meta_tags = default_meta_tags.dup
     welcome_meta_tags[:title] = title || nil
@@ -36,5 +35,4 @@ module MetaTagsHelper
     welcome_meta_tags[:twitter][:title] = title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
     welcome_meta_tags
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -30,13 +30,13 @@ module MetaTagsHelper
 
   def welcome_meta_tags
     default_meta_tags.deep_merge({
-      title: title,
-      og: {
-        title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
-      },
-      twitter: {
-        title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
-      }
-    })
+                                   title: title,
+                                   og: {
+                                     title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
+                                   },
+                                   twitter: {
+                                     title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
+                                   }
+                                 })
   end
 end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -27,4 +27,33 @@ module MetaTagsHelper
     }
   end
   # rubocop:enable Metrics/MethodLength
+
+  # rubocop:disable Metrics/MethodLength
+  def welcome_meta_tags
+    {
+      title: title || nil,
+      site: 'FBC',
+      reverse: true,
+      charset: 'utf-8',
+      description: '現場の即戦力になれるプログラミングスクール。',
+      viewport: 'width=device-width, initial-scale=1.0',
+      og: {
+        title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）',
+        type: 'website',
+        site_name: 'fjord bootcamp',
+        description: :description,
+        image: 'https://bootcamp.fjord.jp/ogp/ogp.png',
+        url: 'https://bootcamp.fjord.jp'
+      },
+      twitter: {
+        title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）',
+        card: 'summary',
+        site: '@fjordbootcamp',
+        description: :description,
+        image: 'https://bootcamp.fjord.jp/ogp/ogp.png',
+        domain: 'https://bootcamp.fjord.jp'
+      }
+    }
+  end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -29,10 +29,14 @@ module MetaTagsHelper
   # rubocop:enable Metrics/MethodLength
 
   def welcome_meta_tags
-    welcome_meta_tags = default_meta_tags.dup
-    welcome_meta_tags[:title] = title || nil
-    welcome_meta_tags[:og][:title] = title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
-    welcome_meta_tags[:twitter][:title] = title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
-    welcome_meta_tags
+    default_meta_tags.deep_merge({
+      title: title,
+      og: {
+        title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
+      },
+      twitter: {
+        title: title || 'FJORD BOOT CAMP（フィヨルドブートキャンプ）'
+      }
+    })
   end
 end

--- a/app/views/layouts/welcome.html.slim
+++ b/app/views/layouts/welcome.html.slim
@@ -4,7 +4,7 @@ html.is-application lang='ja'
   head
     = render 'google_tag_manager_head'
     meta content='IE=edge' http-equiv='X-UA-Compatible'
-    = display_meta_tags default_meta_tags
+    = display_meta_tags welcome_meta_tags
     = javascript_include_tag 'application'
     = javascript_pack_tag 'application'
     = csrf_meta_tags

--- a/test/system/welcome_test.rb
+++ b/test/system/welcome_test.rb
@@ -6,50 +6,70 @@ class WelcomeTest < ApplicationSystemTestCase
   test 'GET /welcome' do
     visit '/welcome'
     assert_equal 'FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='FJORD BOOT CAMP（フィヨルドブートキャンプ）']", visible: false
+    assert_selector "meta[name='twitter:title'][content='FJORD BOOT CAMP（フィヨルドブートキャンプ）']", visible: false
   end
 
   test 'GET /practices' do
     visit '/practices'
     assert_equal '学習内容 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='学習内容']", visible: false
+    assert_selector "meta[name='twitter:title'][content='学習内容']", visible: false
   end
 
   test 'GET /pricing' do
     visit '/pricing'
     assert_equal '料金 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='料金']", visible: false
+    assert_selector "meta[name='twitter:title'][content='料金']", visible: false
   end
 
   test 'GET /training' do
     visit '/training'
     assert_equal '法人利用 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='法人利用']", visible: false
+    assert_selector "meta[name='twitter:title'][content='法人利用']", visible: false
   end
 
   test 'GET /articles' do
     visit '/articles'
     assert_equal 'ブログ | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='ブログ']", visible: false
+    assert_selector "meta[name='twitter:title'][content='ブログ']", visible: false
   end
 
   test 'GET /faq' do
     visit '/faq'
     assert_equal 'FAQ | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='FAQ']", visible: false
+    assert_selector "meta[name='twitter:title'][content='FAQ']", visible: false
   end
 
   test 'GET /tos' do
     visit '/tos'
     assert_equal '利用規約 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='利用規約']", visible: false
+    assert_selector "meta[name='twitter:title'][content='利用規約']", visible: false
   end
 
   test 'GET /pp' do
     visit '/pp'
     assert_equal 'プライバシーポリシー | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='プライバシーポリシー']", visible: false
+    assert_selector "meta[name='twitter:title'][content='プライバシーポリシー']", visible: false
   end
 
   test 'GET /law' do
     visit '/law'
     assert_equal '特定商取引法に基づく表記 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='特定商取引法に基づく表記']", visible: false
+    assert_selector "meta[name='twitter:title'][content='特定商取引法に基づく表記']", visible: false
   end
 
   test 'GET /coc' do
     visit '/coc'
     assert_equal 'アンチハラスメントポリシー | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='アンチハラスメントポリシー']", visible: false
+    assert_selector "meta[name='twitter:title'][content='アンチハラスメントポリシー']", visible: false
   end
 end


### PR DESCRIPTION
## Issue

- #5354

## 概要

Twitterでブートキャンプのプレビューがないので修正する。
  - 変更前：プレビューが表示されない。
  - 変更後：プレビューが表示される。

## 確認方法
1. `https://ngrok.com/download`にアクセスして、ngrokをダウンロードしてインストールしてください。
2. インストールできたら、`ngrok http 3000`を実行してきださい。
3.  表示されたURLをコピーしてください。
![ngrok 0004-10-04 16-42-40](https://user-images.githubusercontent.com/94335407/193763022-3ad50a79-775c-4fa7-a5f8-7cf8433d81bf.png)
4. `bug/twitter_card_bug`をローカルに取り込む
5. `config/environments/development.rb`で「３」のURLを設定してください。
例: `config.hosts << "c57f-240b-10-26c3-9f00-7df6-fa78-8da2-c41e.jp.ngrok.io"` (httpsがない)
<img width="719" alt="Screen Shot 0004-10-07 at 21 01 23" src="https://user-images.githubusercontent.com/94335407/194548539-28fe04bc-41b8-4f00-a673-76be21bdfad3.png">
6. `rails s`で起動する

7.  `https://cards-dev.twitter.com/validator`にアクセスして、「３」のURLを入れて、試してください。
エラーが出たないならいいです。
<img width="1440" alt="Screen Shot 0004-10-04 at 16 44 49" src="https://user-images.githubusercontent.com/94335407/193763213-3220a04b-7687-4e97-800d-002867a0d47b.png">
注意: https://cards-dev.twitter.com/validatorのプレビューはないはずです。なぜなら、Twitterはそのプレビューを削除したからです。
参考: https://twittercommunity.com/t/card-validator-preview-removal/175006

8.  twitterの本番で「３」のURLはプレビューがあるかどうかを試しても大事です。
<img width="1440" alt="Screen Shot 0004-10-04 at 16 45 56" src="https://user-images.githubusercontent.com/94335407/193763446-f7f55002-8b7f-4ad8-9b2b-e64626f6d826.png">
確認するURL:

-  /
-  /faq
-  /law
-  /pp
-  /practices
-  /pricing
-  /tos
-  /training
-  /coc
例: `/pricing`を確認したいなら、twitter本番で「3」の表示されたURLに`/pricing`を入れてください。
<img width="637" alt="Screen Shot 0004-10-07 at 20 30 02" src="https://user-images.githubusercontent.com/94335407/194543263-d8e73ebe-c013-495c-b7ee-d5da42977cc4.png">

## 変更前
Twitter本番でURLを入れてもプレビューがないです。

## 変更後
<img width="628" alt="Screen Shot 0004-10-07 at 20 33 15" src="https://user-images.githubusercontent.com/94335407/194543770-18d64818-f83c-4f51-9680-0e645868d315.png">
<img width="637" alt="Screen Shot 0004-10-07 at 20 33 51" src="https://user-images.githubusercontent.com/94335407/194543867-e33cfe7c-41a2-4c34-9e7a-b22b6a18cc19.png">
<img width="607" alt="Screen Shot 0004-10-07 at 20 34 11" src="https://user-images.githubusercontent.com/94335407/194543919-bbaf628c-3300-4f0f-8859-0c93534c62af.png">
<img width="601" alt="Screen Shot 0004-10-07 at 20 34 31" src="https://user-images.githubusercontent.com/94335407/194543965-dad5c45c-f397-4783-ae04-e7808aa1601a.png">
<img width="568" alt="Screen Shot 0004-10-07 at 20 34 45" src="https://user-images.githubusercontent.com/94335407/194544003-cbf846ad-756d-49fc-b698-1573b9090a4f.png">
<img width="636" alt="Screen Shot 0004-10-07 at 20 34 58" src="https://user-images.githubusercontent.com/94335407/194544044-d77967b8-846f-464d-a530-5a927355a52d.png">
<img width="611" alt="Screen Shot 0004-10-07 at 20 35 14" src="https://user-images.githubusercontent.com/94335407/194544092-c98de460-fee2-4e8c-90f7-1719016715ef.png">
<img width="597" alt="Screen Shot 0004-10-07 at 20 35 29" src="https://user-images.githubusercontent.com/94335407/194544126-1221dbf1-5ba3-4265-ab49-19e893803d17.png">
<img width="616" alt="Screen Shot 0004-10-07 at 20 59 23" src="https://user-images.githubusercontent.com/94335407/194548043-e42e0aee-05b8-425b-88fb-795e6ef12990.png">
