### PR TITLE
フッターにブログへのリンクを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -7,6 +7,9 @@ footer.footer
             = link_to welcome_path, class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | ホームページ
           li.footer-nav__item
+            = link_to articles_path, class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | ブログ
+          li.footer-nav__item
             = link_to books_path, class: 'footer-nav__item-link' do
               | 参考書籍
           li.footer-nav__item


### PR DESCRIPTION
## Issue

- #5317

## 概要

フッターにブログへのリンクを追加しました。

## 変更確認方法

1. ブランチ`feature/add-link-to-blog-in-layout-application`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインする
4. ダッシュボード(http://localhost:3000/) に接続する
5. フッターの`ホームページ`と`関連書籍`の間に`ブログ`が表示されていることと、クリックするとブログにリンクされることを確認する

## 変更前
<img width="1338" alt="image" src="https://user-images.githubusercontent.com/62344131/186901651-6fcce61a-da5c-4fde-a53f-9911d4002982.png">

## 変更後
◯フッター
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/62344131/186901831-3571f18c-28c9-4760-a302-ac7b3b5c2e5e.png">

◯ブログ画面
![image](https://user-images.githubusercontent.com/62344131/186902043-6e437666-9d02-4fbf-b4a7-871b3363eb93.png)
