### PR TITLE
titleタグを[プラクティス名に関する日報]に変更

### DIFF
--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -1,7 +1,7 @@
-- title @practice.title
+- title "#{@practice.title}に関する日報"
 - category = @practice.category(current_user.course)
 
-= render '/practices/page_header', title: title, category: category
+= render '/practices/page_header', title: @practice.title, category: category
 = render 'page_tabs', resource: @practice
 
 .page-body

--- a/test/system/practice/reports_test.rb
+++ b/test/system/practice/reports_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class Practice::ReportsTest < ApplicationSystemTestCase
   test 'show listing reports' do
     visit_with_auth "/practices/#{practices(:practice1).id}/reports", 'hatsuno'
-    assert_equal 'OS X Mountain Lionをクリーンインストールする | FBC', title
+    assert_equal 'OS X Mountain Lionをクリーンインストールするに関する日報 | FBC', title
     within first('.card-list-item') do
       assert_selector 'img[alt="happy"]'
       assert_text '1時間だけ学習'


### PR DESCRIPTION
## Issue

- #5409

## 概要

プラクティス個別ページの「日報」遷移時のtitleタグを変更。

変更前：プラクティス名
変更後：プラクティス名に関する日報

## 変更確認方法

1. ブランチ`feature/change-title-tag-of-practices-reports`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 一般ユーザーでログインする
4. http://localhost:3000/practices/315059988/reports にアクセスする

## 変更前
<img width="1431" alt="_development__OS_X_Mountain_Lionをクリーンインストールする___FBC" src="https://user-images.githubusercontent.com/99729409/187035335-0ea6493e-367f-4803-b600-4b5918cf5597.png">



## 変更後
<img width="1431" alt="_development__OS_X_Mountain_Lionをクリーンインストールするに関する日報___FBC" src="https://user-images.githubusercontent.com/99729409/187035264-a34d5c6b-2442-4658-8fd3-aabece9380d5.png">

