### PR TITLE
研修生の日報個別ページのタイトル付近に企業アイコンを表示

### DIFF
--- a/app/assets/stylesheets/application/blocks/page-content/_page-content-header.sass
+++ b/app/assets/stylesheets/application/blocks/page-content/_page-content-header.sass
@@ -70,6 +70,17 @@
 .page-content-header__user-icon
   +size(3.5rem)
 
+.page-content-header__company-logo
+  +size(3.5rem)
+  background-color: $base
+  object-fit: contain
+  border-radius: .25rem
+  border: solid 1px $border
+  +media-breakpoint-up(md)
+    margin-top: .5rem
+  +media-breakpoint-down(sm)
+    +position(absolute, right 0, top 0)
+
 .page-content-header__before-title
   gap: .25rem
   +media-breakpoint-up(md)

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -43,6 +43,9 @@ header.page-header
                   - if @report.emotion.present?
                     span.page-content-header__emotion
                       = image_tag Report.faces[@report.emotion], id: @report.emotion, alt: @report.emotion, class: 'page-content-header__emotion-image'
+                  - if @report.user.trainee?
+                    = link_to company_path(@report.user.company) do
+                      = image_tag @report.user.company.logo_url, class: 'user-profile__company-logo'
                   - if @report.wip?
                     span.a-title-label.is-wip
                       | WIP

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -34,6 +34,9 @@ header.page-header
             .page-content-header__start
               .page-content-header__user
                 = render 'users/icon', user: @report.user, link_class: 'page-content-header__user-link', image_class: 'page-content-header__user-icon'
+              - if @report.user.trainee?
+                = link_to company_path(@report.user.company) do
+                  = image_tag @report.user.company.logo_url, class: 'page-content-header__company-logo'
             .page-content-header__end
               .page-content-header__row
                 .page-content-header__before-title
@@ -43,9 +46,6 @@ header.page-header
                   - if @report.emotion.present?
                     span.page-content-header__emotion
                       = image_tag Report.faces[@report.emotion], id: @report.emotion, alt: @report.emotion, class: 'page-content-header__emotion-image'
-                  - if @report.user.trainee?
-                    = link_to company_path(@report.user.company) do
-                      = image_tag @report.user.company.logo_url, class: 'user-profile__company-logo'
                   - if @report.wip?
                     span.a-title-label.is-wip
                       | WIP

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -8,4 +8,9 @@ class AttachmentsTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{users(:komagata).id}", 'komagata'
     assert find('img.user-profile__user-icon-image')['src'].include?('komagata.png')
   end
+
+  test 'attachment company icons in reports' do
+    visit_with_auth '/reports/49764969', 'kensyu'
+    assert find('img.user-profile__company-logo')['src'].include?('2.png')
+  end
 end

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -11,6 +11,6 @@ class AttachmentsTest < ApplicationSystemTestCase
 
   test 'attachment company icons in reports' do
     visit_with_auth '/reports/49764969', 'kensyu'
-    assert find('img.user-profile__company-logo')['src'].include?('2.png')
+    assert find('img.page-content-header__company-logo')['src'].include?('2.png')
   end
 end

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -10,7 +10,8 @@ class AttachmentsTest < ApplicationSystemTestCase
   end
 
   test 'attachment company icons in reports' do
-    visit_with_auth '/reports/49764969', 'kensyu'
+    report = reports(:report11)
+    visit_with_auth "/reports/#{report.id}", 'kensyu'
     assert find('img.page-content-header__company-logo')['src'].include?('2.png')
   end
 end


### PR DESCRIPTION
## Issue
- #5442

## 概要
研修生の日報個別ページのタイトル付近に企業アイコンを表示されるように変更。

## 変更確認方法
### 研修生の場合のみ企業アイコンが表示されます。
1. ブランチ`feature/display-company-icons-on-reports-for-trainee`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 研修生ユーザー（`kensyu`）でログインする
4. http://localhost:3000/reports/49764969 にアクセスする

### 卒業したあとに企業に所属した場合、日報個別ページに企業アイコンは表示されません。
1. ブランチ`feature/display-company-icons-on-reports-for-trainee`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 卒業ユーザー（`sotsugyoukigyoshozoku`）でログインする
4. http://localhost:3000/reports/1066585821 にアクセスする

## 変更前
<img width="1434" alt="_development__フォローされた日報___FBCaaaaaaaaa" src="https://user-images.githubusercontent.com/99729409/187418565-5b3f1c37-c0c5-464a-9ad2-203b95e83b07.png">


## 変更後
### ユーザー：`kensyu`
<img width="1432" alt="_development__フォローされた日報___FBC" src="https://user-images.githubusercontent.com/99729409/188293837-c2c4d63b-a1e9-4716-837d-41edfb1968f3.png">


### ユーザー：`sotsugyoukigyoshozoku`
<img width="1432" alt="_development__aaaaaaaaaaaaa___FBC" src="https://user-images.githubusercontent.com/99729409/187059821-0a6d365a-169f-4d08-b635-9b06da590f3d.png">

