### PR TITLE
アドバイザーでログインしたときに提出物にアクセスした際、全ての提出物一覧を表示

### DIFF
--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -3,7 +3,7 @@
     ul.page-tabs__items
       li.page-tabs__item
         = link_to '全て', products_path, class: "page-tabs__item-link #{current_link(/^products-index/)}"
-      - if current_user.admin? || current_user.mentor?
+      - if admin_or_mentor_login?
         li.page-tabs__item
           = link_to products_unchecked_index_path, class: "page-tabs__item-link #{current_link(/^products-unchecked-index/)}" do
             | 未完了 （#{Cache.unchecked_product_count}）

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -3,18 +3,19 @@
     ul.page-tabs__items
       li.page-tabs__item
         = link_to '全て', products_path, class: "page-tabs__item-link #{current_link(/^products-index/)}"
-      li.page-tabs__item.is-only-mentor
-        = link_to products_unchecked_index_path, class: "page-tabs__item-link #{current_link(/^products-unchecked-index/)}" do
-          | 未完了 （#{Cache.unchecked_product_count}）
-      li.page-tabs__item.is-only-mentor
-        = link_to products_unassigned_index_path, class: "page-tabs__item-link #{current_link(/^products-unassigned-index/)}", id: 'test-unassigned-tab' do
-          | 未アサイン
-          - if Cache.unassigned_product_count.positive?
-            .page-tabs__item-count.a-notification-count#test-unassigned-counter
-              = Cache.unassigned_product_count
-      li.page-tabs__item.is-only-mentor
-        = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
-          | 自分の担当 （#{Product.self_assigned_product(current_user.id).unchecked.size}）
-          - if Cache.self_assigned_no_replied_product_count(current_user.id).positive?
-            .page-tabs__item-count.a-notification-count.is-only-mentor
-              = Cache.self_assigned_no_replied_product_count(current_user.id)
+      - if current_user.admin? || current_user.mentor?
+        li.page-tabs__item
+          = link_to products_unchecked_index_path, class: "page-tabs__item-link #{current_link(/^products-unchecked-index/)}" do
+            | 未完了 （#{Cache.unchecked_product_count}）
+        li.page-tabs__item
+          = link_to products_unassigned_index_path, class: "page-tabs__item-link #{current_link(/^products-unassigned-index/)}", id: 'test-unassigned-tab' do
+            | 未アサイン
+            - if Cache.unassigned_product_count.positive?
+              .page-tabs__item-count.a-notification-count#test-unassigned-counter
+                = Cache.unassigned_product_count
+        li.page-tabs__item
+          = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
+            | 自分の担当 （#{Product.self_assigned_product(current_user.id).unchecked.size}）
+            - if Cache.self_assigned_no_replied_product_count(current_user.id).positive?
+              .page-tabs__item-count.a-notification-count.is-only-mentor
+                = Cache.self_assigned_no_replied_product_count(current_user.id)

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -3,10 +3,10 @@
     ul.page-tabs__items
       li.page-tabs__item
         = link_to '全て', products_path, class: "page-tabs__item-link #{current_link(/^products-index/)}"
-      li.page-tabs__item
+      li.page-tabs__item.is-only-mentor
         = link_to products_unchecked_index_path, class: "page-tabs__item-link #{current_link(/^products-unchecked-index/)}" do
           | 未完了 （#{Cache.unchecked_product_count}）
-      li.page-tabs__item
+      li.page-tabs__item.is-only-mentor
         = link_to products_unassigned_index_path, class: "page-tabs__item-link #{current_link(/^products-unassigned-index/)}", id: 'test-unassigned-tab' do
           | 未アサイン
           - if Cache.unassigned_product_count.positive?

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -6,7 +6,7 @@ header.page-header
       h2.page-header__title
         = title
 
-- if current_user.admin? || current_user.mentor?
+- if current_user.admin? || current_user.mentor? || current_user.adviser?
   = render 'products/tabs'
 
   .page-body

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -6,7 +6,7 @@ header.page-header
       h2.page-header__title
         = title
 
-- if admin_or_mentor_login? || adviser_login?
+- if staff_login?
   = render 'products/tabs'
 
   .page-body

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -6,7 +6,7 @@ header.page-header
       h2.page-header__title
         = title
 
-- if current_user.admin? || current_user.mentor? || current_user.adviser?
+- if admin_or_mentor_login? || adviser_login?
   = render 'products/tabs'
 
   .page-body


### PR DESCRIPTION
 ## Issue
 
 - #4651
 
 ## 概要
 
アドバイザーでログインしたときに提出物にアクセスをしたら、全ての提出物一覧が表示されてほしい。
 
 ## 変更確認方法
 
 1. ブランチ`feature/add-all-submissions-listed-on-the-adviser-page`をローカルに取り込む
 2. `bin/rails s`でローカル環境を立ち上げる
 3. アドバイザーでログインする
 4. 右記へ接続する `http://localhost:3000/products`
 5. 「全て」の提出物が表示されていることが確認できる

 
 ## 変更前
[![Image from Gyazo](https://i.gyazo.com/95aaa279c08341ded77eae7f2416dc1a.png)](https://gyazo.com/95aaa279c08341ded77eae7f2416dc1a)

 ## 変更後
 ![image](https://user-images.githubusercontent.com/65638955/187582284-9e0f8332-fe7d-47f7-8fb5-d279391d284f.png)