### PR TITLE
メンターが提出物をコメント付きで確認を行なった際のトースト内容変更

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -304,7 +304,7 @@ export default {
       ) {
         return null
       } else {
-        this.createComment({ toast: '提出物を確認済みにしました。'})
+        this.createComment({ toast: '提出物を確認済みにしました。' })
         this.check(
           this.commentableType,
           this.commentableId,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -203,7 +203,7 @@ export default {
           }
         })
     },
-    createComment() {
+    createComment({ toast = null }) {
       if (this.description.length < 1) {
         return null
       }
@@ -243,7 +243,7 @@ export default {
               this.toast('コメントを投稿しました！')
             }
           } else {
-            this.toast('コメントを投稿しました！')
+            this.toast(toast ?? 'コメントを投稿しました！')
           }
         })
         .catch((error) => {
@@ -304,7 +304,7 @@ export default {
       ) {
         return null
       } else {
-        this.createComment()
+        this.createComment({ toast: '提出物を確認済みにしました。'})
         this.check(
           this.commentableType,
           this.commentableId,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -203,7 +203,7 @@ export default {
           }
         })
     },
-    createComment({ toast = null }) {
+    createComment({ toast }) {
       if (this.description.length < 1) {
         return null
       }
@@ -304,7 +304,7 @@ export default {
       ) {
         return null
       } else {
-        this.createComment({ toast: '提出物を確認済みにしました。' })
+        this.createComment({ toast: this.toastMessage() })
         this.check(
           this.commentableType,
           this.commentableId,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -203,7 +203,7 @@ export default {
           }
         })
     },
-    createComment({ toast }) {
+    createComment({ toastMessage = null }) {
       if (this.description.length < 1) {
         return null
       }
@@ -235,16 +235,7 @@ export default {
           this.tab = 'comment'
           this.buttonDisabled = false
           this.resizeTextarea()
-          if (
-            this.currentUser.roles.includes('mentor') &&
-            this.commentableType === 'Product'
-          ) {
-            if (this.productCheckerId) {
-              this.toast('コメントを投稿しました！')
-            }
-          } else {
-            this.toast(toast ?? 'コメントを投稿しました！')
-          }
+          this.displayToast(toastMessage)
         })
         .catch((error) => {
           console.warn(error)
@@ -304,7 +295,7 @@ export default {
       ) {
         return null
       } else {
-        this.createComment({ toast: this.toastMessage() })
+        this.createComment({ toastMessage: this.toastMessage() })
         this.check(
           this.commentableType,
           this.commentableId,

--- a/app/javascript/toast.js
+++ b/app/javascript/toast.js
@@ -1,6 +1,14 @@
 import Swal from 'sweetalert2'
 
 export default {
+  computed: {
+    isMentorsCommentToProducts() {
+      return (
+        this.currentUser.roles.includes('mentor') &&
+        this.commentableType === 'Product'
+      )
+    }
+  },
   methods: {
     toast(title, status = 'success') {
       Swal.fire({
@@ -12,6 +20,18 @@ export default {
         timerProgressBar: true,
         customClass: { popup: `is-${status}` }
       })
+    },
+    displayToast(toastMessage) {
+      if (this.isMentorsCommentToProducts) {
+        if (this.productCheckerId) {
+          this.toast(this.confirmOrCommentMessage(toastMessage))
+        }
+      } else {
+        this.toast(this.confirmOrCommentMessage(toastMessage))
+      }
+    },
+    confirmOrCommentMessage(toastMessage) {
+      return toastMessage ?? 'コメントを投稿しました！'
     },
     toastMessage() {
       if (this.commentableType === 'Product') {

--- a/app/javascript/toast.js
+++ b/app/javascript/toast.js
@@ -12,6 +12,16 @@ export default {
         timerProgressBar: true,
         customClass: { popup: `is-${status}` }
       })
+    },
+
+    toastMessage() {
+      if (this.commentableType === 'Product') return this.getToastMessage('提出物')
+      if (this.commentableType === 'Report') return this.getToastMessage('日報')
+      return null
+    },
+
+    getToastMessage(type) {
+      return `${type}を確認済みにしました。`
     }
   }
 }

--- a/app/javascript/toast.js
+++ b/app/javascript/toast.js
@@ -13,13 +13,15 @@ export default {
         customClass: { popup: `is-${status}` }
       })
     },
-
     toastMessage() {
-      if (this.commentableType === 'Product') return this.getToastMessage('提出物')
-      if (this.commentableType === 'Report') return this.getToastMessage('日報')
-      return null
+      if (this.commentableType === 'Product') {
+        return this.getToastMessage('提出物')
+      } else if (this.commentableType === 'Report') {
+        return this.getToastMessage('日報')
+      } else {
+        return null
+      }
     },
-
     getToastMessage(type) {
       return `${type}を確認済みにしました。`
     }

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -290,6 +290,8 @@ class CommentsTest < ApplicationSystemTestCase
   test 'when mentor confirm a product with comment' do
     unconfirmed_product = products(:product1)
     visit_with_auth product_url(unconfirmed_product), 'machida'
+    click_button '担当する'
+    assert_button '担当から外れる'
 
     accept_confirm do
       fill_in 'new_comment[description]', with: 'comment test'

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -286,4 +286,28 @@ class CommentsTest < ApplicationSystemTestCase
       assert_no_text :all, 'test'
     end
   end
+
+  test 'when mentor confirm a product with comment' do
+    unconfirmed_product = products(:product1)
+    visit_with_auth product_url(unconfirmed_product), 'machida'
+
+    accept_confirm do
+      fill_in 'new_comment[description]', with: 'comment test'
+      click_button '確認OKにする'
+    end
+    assert_text '提出物を確認済みにしました'
+    assert_text 'comment test'
+  end
+
+  test 'when mentor confirm a report with comment' do
+    visit_with_auth "/reports/#{reports(:report2).id}", 'machida'
+    assert_text '確認OKにする'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'comment test')
+    end
+    click_button '確認OKにする'
+
+    assert_text '日報を確認済みにしました'
+    assert_text 'comment test'
+  end
 end

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -63,19 +63,4 @@ class Product::CheckerTest < ApplicationSystemTestCase
     assert_text 'コメントを投稿しました'
     assert_nil Product.find(old_product.id).checker_id
   end
-
-  test "when mentor comment and confirm a product, there're different toasts" do
-    unchecked_product = products(:product1)
-
-    visit_with_auth product_url(unchecked_product), 'machida'
-
-    post_comment 'toast check'
-    assert_text 'コメントを投稿しました'
-
-    accept_confirm do
-      fill_in 'new_comment[description]', with: 'taost check'
-      click_button '確認OKにする'
-    end
-    assert_text '提出物を確認済みにしました'
-  end
 end

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -63,4 +63,18 @@ class Product::CheckerTest < ApplicationSystemTestCase
     assert_text 'コメントを投稿しました'
     assert_nil Product.find(old_product.id).checker_id
   end
+
+  test "when mentor comment and confirm a product, there're different toasts" do
+    unchecked_product = products(:product1)
+
+    visit_with_auth product_url(unchecked_product), 'machida'
+
+    post_comment 'toast check'
+    assert_text 'コメントを投稿しました'
+
+    fill_in 'new_comment[description]', with: 'taost check'
+    click_button '確認OKにする'
+    page.driver.browser.switch_to.alert.accept
+    assert_text '提出物を確認済みにしました'
+  end
 end

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -72,9 +72,10 @@ class Product::CheckerTest < ApplicationSystemTestCase
     post_comment 'toast check'
     assert_text 'コメントを投稿しました'
 
-    fill_in 'new_comment[description]', with: 'taost check'
-    click_button '確認OKにする'
-    page.driver.browser.switch_to.alert.accept
+    accept_confirm do
+      fill_in 'new_comment[description]', with: 'taost check'
+      click_button '確認OKにする'
+    end
     assert_text '提出物を確認済みにしました'
   end
 end


### PR DESCRIPTION
## issue

- https://github.com/fjordllc/bootcamp/issues/5364

## Description
メンターが提出物をコメント付きで確認OKにした場合のトーストコメントを変更しました。

## 変更点

### 変更前
https://i.gyazo.com/e19d94044bf02febe1f37d7d8f20fe87.mp4

### 変更後
https://i.gyazo.com/c6bf55e003b79902e87e914001c78e39.mp4

## 確認方法
1. ローカルに`feature/change-commented-toast-to-confirm-done`ブランチを取り込む
2. machidaでログイン
3. `/products/self_assigned`から個別の提出物ページに遷移する
4. コメントフォームにコメントを入れて`確認OKにする`ボタンを押す