### PR TITLE
定期イベントタブ選択時のページタイトルを定期イベントからイベントに変更

### DIFF
--- a/app/views/regular_events/index.html.slim
+++ b/app/views/regular_events/index.html.slim
@@ -1,10 +1,10 @@
-- title 'イベント'
+- title '定期イベント'
 
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        = 'イベント'
       .page-header-actions
         .page-header-actions__items
           .page-header-actions__item

--- a/app/views/regular_events/index.html.slim
+++ b/app/views/regular_events/index.html.slim
@@ -1,4 +1,4 @@
-- title '定期イベント'
+- title 'イベント'
 
 header.page-header
   .container


### PR DESCRIPTION
## Issue

- #5402

## 概要

定期イベントタブ選択時のページタイトルを`定期イベント`→`イベント`に変更しました。

## 変更確認方法

1. ブランチ`feature/change-the-page-title-from-recurring-events-to-events`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインする
4. サイドバーの`イベント`をクリックし、`定期イベント`タブに切り替える (あるいは http://127.0.0.1:3000/regular_events に接続する) 
5. ページタイトルが`イベント`になっていることを確認する

## 変更前
<img width="453" alt="image" src="https://user-images.githubusercontent.com/62344131/187075029-2a6cc1f3-43cf-4ed8-9029-1122750e9faf.png">

## 変更後
<img width="547" alt="image" src="https://user-images.githubusercontent.com/62344131/187074860-07c3a48c-f611-4283-b4ef-37892afc8d39.png">
