### PR TITLE
未解決のコメント数0の質問を目立たせる

### DIFF
--- a/app/javascript/components/question.vue
+++ b/app/javascript/components/question.vue
@@ -56,8 +56,10 @@
                   | 更新
                 span.a-meta__value
                   | {{ updatedAt }}
-            .card-list-item-meta__item(v-if='question.answers.size > 0')
-              .a-meta
+            .card-list-item-meta__item
+              .a-meta(
+                :class='[zeroComment]'
+              )
                 | 回答・コメント（{{ question.answers.size }}）
     .stamp.is-circle.is-solved(v-if='question.has_correct_answer')
       .stamp__content.is-icon 解
@@ -83,6 +85,11 @@ export default {
     },
     roleClass() {
       return `is-${this.question.user.primary_role}`
+    },
+    zeroComment() {
+      return {
+        'is-danger': this.question.answers.size === 0
+      }
     },
     questionClass() {
       if (this.question.has_correct_answer) {

--- a/app/javascript/components/question.vue
+++ b/app/javascript/components/question.vue
@@ -57,9 +57,7 @@
                 span.a-meta__value
                   | {{ updatedAt }}
             .card-list-item-meta__item
-              .a-meta(
-                :class='[zeroComment]'
-              )
+              .a-meta(:class='[urgentClass]')
                 | 回答・コメント（{{ question.answers.size }}）
     .stamp.is-circle.is-solved(v-if='question.has_correct_answer')
       .stamp__content.is-icon 解
@@ -83,12 +81,15 @@ export default {
         'YYYY年MM月DD日(dd) HH:mm'
       )
     },
+    hasAnswers() {
+      return this.question.answers.size > 0
+    },
     roleClass() {
       return `is-${this.question.user.primary_role}`
     },
-    zeroComment() {
+    urgentClass() {
       return {
-        'is-danger': this.question.answers.size === 0
+        'is-danger': !this.hasAnswers
       }
     },
     questionClass() {

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -240,6 +240,16 @@ class QuestionsTest < ApplicationSystemTestCase
     end
   end
 
+  test "show number of comments when comments don't exist" do
+    visit_with_auth questions_path(target: 'not_solved'), 'kimura'
+    assert_text 'テストの質問'
+
+    element = all('.card-list-item').find { |component| component.has_text?('テストの質問') }
+    within element do
+      assert_selector '.a-meta.is-danger', text: '（0）'
+    end
+  end
+
   test 'create a WIP question' do
     visit_with_auth new_question_path, 'kimura'
     within 'form[name=question]' do


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/4805

## Description
コメントがついていない質問（早急な対応が求められる）を目立って表示させるためにCSSクラスを追加しました。

##  変更点

### 変更前
![image](https://user-images.githubusercontent.com/70259961/187145092-b68dab64-4d7c-4b67-a95f-6f6a6add2321.png)


### 変更後
![image](https://user-images.githubusercontent.com/70259961/187143893-6320bf50-7c76-462c-87d4-2afdf766713d.png)


## 確認方法
1. ローカルに`feature/add-is-danger-class-for-zero-comment-question`ブランチを取り込む
2. ローカル環境でbootcampを立ち上げてkimuraでログイン
3. Q&A一覧(`/questions`)ページに遷移
4.  Q&A一覧ページでDevツールを立ち上げて、コメントが0の質問に`is-danger`クラスが**ついている**ことを確認する
5.  4と同様にしてコメントがついている質問に`is-danger`クラスが**ついていない**ことを確認する

##  補足
デザイン（赤太字にする）はレビュー後にmachidaさんが追加予定です。