### PR TITLE
【メンター向け】メンターが未アサインの提出物にコメントした際、担当者になったことをToastでわかりやすく通知する

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -235,10 +235,12 @@ export default {
           this.tab = 'comment'
           this.buttonDisabled = false
           this.resizeTextarea()
-          this.checkable.checkProduct()
-          if (this.productCheckerId) {
-            this.toast('コメントを投稿しました！')
-          }
+          if (this.currentUser.primary_role == 'mentor') {
+            console.log(this.productCheckerId)
+            if (this.productCheckerId) {
+              this.toast('コメントを投稿しました！')
+            }
+          } else this.toast('コメントを投稿しました！')
         })
         .catch((error) => {
           console.warn(error)

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -235,7 +235,10 @@ export default {
           this.tab = 'comment'
           this.buttonDisabled = false
           this.resizeTextarea()
-          if (this.currentUser.roles.includes('mentor')) {
+          if (
+            this.currentUser.roles.includes('mentor') &&
+            this.commentableType === 'Product'
+          ) {
             if (this.productCheckerId) {
               this.toast('コメントを投稿しました！')
             }

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -235,7 +235,7 @@ export default {
           this.tab = 'comment'
           this.buttonDisabled = false
           this.resizeTextarea()
-          if (this.currentUser.primary_role === 'mentor') {
+          if (this.currentUser.roles.includes('mentor')) {
             if (this.productCheckerId) {
               this.toast('コメントを投稿しました！')
             }

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -242,7 +242,9 @@ export default {
             if (this.productCheckerId) {
               this.toast('コメントを投稿しました！')
             }
-          } else this.toast('コメントを投稿しました！')
+          } else {
+            this.toast('コメントを投稿しました！')
+          }
         })
         .catch((error) => {
           console.warn(error)

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -235,8 +235,7 @@ export default {
           this.tab = 'comment'
           this.buttonDisabled = false
           this.resizeTextarea()
-          if (this.currentUser.primary_role == 'mentor') {
-            console.log(this.productCheckerId)
+          if (this.currentUser.primary_role === 'mentor') {
             if (this.productCheckerId) {
               this.toast('コメントを投稿しました！')
             }

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -235,7 +235,10 @@ export default {
           this.tab = 'comment'
           this.buttonDisabled = false
           this.resizeTextarea()
-          this.toast('コメントを投稿しました！')
+          this.checkable.checkProduct()
+          if (this.productCheckerId) {
+            this.toast('コメントを投稿しました！')
+          }
         })
         .catch((error) => {
           console.warn(error)

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -14,9 +14,11 @@ class Product::CheckerTest < ApplicationSystemTestCase
     visit "/products/#{products(:product1).id}"
 
     post_comment('担当者がいない提出物の場合、担当者になる')
+    assert_text '担当になりました。'
     assert_text '担当から外れる'
 
     post_comment('自分が担当者の場合、担当者のまま')
+    assert_text 'コメントを投稿しました！'
     assert_text '担当から外れる'
 
     visit '/products/unchecked?target=unchecked_no_replied'
@@ -42,6 +44,7 @@ class Product::CheckerTest < ApplicationSystemTestCase
 
     visit show_product_path
     post_comment('担当者がいる提出物の場合、担当者にならない')
+    assert_text 'コメントを投稿しました！'
 
     visit '/products/unchecked?target=unchecked_no_replied'
     assert_equal before_comment, assigned_product_count


### PR DESCRIPTION
## Issue

- #5355 

## 概要

未アサインの提出物にコメントすると、「コメントを投稿しました！」のToastしか表示されないので、担当者になったことがわかりづらいです。
（もしかすると「担当になりました。」が一瞬出ているのかもしれないが、ほとんど気づけないレベル）

Toast上でもわかりやすく表示してもらえると嬉しいです。
提出物に対して、もし担当者がいない場合、「コメントを投稿しました！」を表示しなくてもいいです。
「担当になりました。」を表示した方がいいです。
そのため、ちょっと変更しました。
  - 変更前：「担当になりました。」が表示できない（0.01秒だけ表示しただけです）、「コメントを投稿しました！」（3秒）が表示される。
  - 変更後：「担当になりました。」が表示できる（３秒になりました）、「コメントを投稿しました！」が表示されない。

## 確認方法

1. `feature/make_toast_notify_about_undertaking_easier_to_understand`をローカルに取り込む
2. `rails s`で起動する
3. 任意の管理者ユーザーでログインする
4. http://localhost:3000/products/1006890726 にアクセスする(どんな担当者がいない提出物もできるが、例を出しただけです。）
5. （もし、この提出物は既に担当者が存在したら、「担当から外れる」を押してください。）
6. 提出物詳細ページで、「コメント」部分でコメントする。
7. 「担当になりました。」が表示される。

## 変更前
「担当になりました。」が表示されない。
「コメントを投稿しました！」が表示される。
<img width="395" alt="Screen Shot 0004-08-25 at 17 16 14" src="https://user-images.githubusercontent.com/94335407/186612775-a11048ff-a9ff-4bbb-9baf-1eb94cb46156.png">

## 変更後
「担当になりました。」が表示される。
<img width="401" alt="Screen Shot 0004-08-25 at 17 13 08" src="https://user-images.githubusercontent.com/94335407/186612150-63b83ce4-4f7b-44b7-8151-9d2123da20a9.png">