### PR TITLE
管理者orメンターとしてログインした際にブログ記事一覧画面に新規記事作成ボタンを追加した

### DIFF
--- a/app/assets/stylesheets/welcome/welcome-page/_welcome-page-header.sass
+++ b/app/assets/stylesheets/welcome/welcome-page/_welcome-page-header.sass
@@ -4,10 +4,16 @@
 .welcome-page-header__inner
   display: flex
   align-items: center
+  justify-content: space-between
   +media-breakpoint-up(md)
     height: 4.5rem
   +media-breakpoint-down(sm)
     height: 3.5rem
+
+.welcome-page-header__start
+  flex: 1
+  display: flex
+  align-items: center
 
 .welcome-page-header__title
   +text-block(1em 1.4, 600 $reversal-text)

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -5,11 +5,14 @@
 .welcome-page-header
   .container.is-xxl
     .welcome-page-header__inner
-      h1.welcome-page-header__title
-        = title
-        - if current_user.mentor?
+      .welcome-page-header__start
+        h1.welcome-page-header__title
+          = title
+      - if current_user.mentor?
+        .welcome-page-header__end
           = link_to new_article_path, class: 'a-button is-md is-secondary is-block' do
-            | +ブログ記事作成
+            i.fas.fa-plus
+            | ブログ記事作成
 
 .welcome-page-body
   .articles

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -8,7 +8,7 @@
       .welcome-page-header__start
         h1.welcome-page-header__title
           = title
-      - if !current_user.nil? && current_user.mentor?
+      - if current_user&.mentor?
         .welcome-page-header__end
           = link_to new_article_path, class: 'a-button is-md is-secondary is-block' do
             i.fas.fa-plus

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -8,7 +8,7 @@
       .welcome-page-header__start
         h1.welcome-page-header__title
           = title
-      - if current_user.mentor?
+      - if !current_user.nil? && current_user.mentor?
         .welcome-page-header__end
           = link_to new_article_path, class: 'a-button is-md is-secondary is-block' do
             i.fas.fa-plus

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -7,6 +7,9 @@
     .welcome-page-header__inner
       h1.welcome-page-header__title
         = title
+        - if current_user.mentor?
+          = link_to new_article_path, class: 'a-button is-md is-secondary is-block' do
+            | +ブログ記事作成
 
 .welcome-page-body
   .articles


### PR DESCRIPTION
## Issue

- #5449

## 概要

管理者またはメンターとしてログインしている場合、ブログ記事一覧画面に新規記事作成ボタンが表示されるようにしました。

## 変更確認方法

1. ブランチ`feature/show-new-blog-button-login-as-admin-or-mentor`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 管理者またはメンターのユーザーでログインする
4. ブログ記事一覧画面( http://127.0.0.1:3000/articles )にアクセスする
5. ヘッダーに`ブログ記事作成` ボタンが表示されていることと、ブログ作成画面に遷移することを確認する
3. 一般のユーザーでログインする
4. ブログ記事一覧画面( http://127.0.0.1:3000/articles )にアクセスする
5. ヘッダーに`ブログ記事作成` ボタンが表示されていないことを確認する
6. ログインしていない状態でブログ記事一覧画面( http://127.0.0.1:3000/articles )にアクセスしてもエラーが出ないことを確認する

## 変更前
![image](https://user-images.githubusercontent.com/62344131/187710748-e8ddd866-3a03-4930-8fbd-b792d9f892a3.png)

## 変更後
※管理者またはメンターのユーザーでログインしたときのみ
![image](https://user-images.githubusercontent.com/62344131/187710401-46473ea6-334d-443f-ad25-2e8943361cac.png)

