### PR TITLE
「読みました」のチェックボックスを埋めたら「休会する」ボタンを押せるようにした

### DIFF
--- a/app/assets/stylesheets/application/blocks/form/_block-checks.sass
+++ b/app/assets/stylesheets/application/blocks/form/_block-checks.sass
@@ -8,6 +8,8 @@
   max-width: 20rem
   .block-checks.is-1-item &
     max-width: 100%
+  .block-checks.is-1-item.is-centered &
+    width: 20rem
   .block-checks.is-2-items &
     flex: 0 0 calc((100% - .5rem) / 2)
     max-width: calc((100% - .5rem) / 2)

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -294,7 +294,7 @@ export default {
       }
     },
     postComment() {
-      this.createComment({})
+      this.createComment()
       if (this.isUnassignedAndUnchekedProduct) {
         this.checkProduct(
           this.commentableId,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -294,12 +294,8 @@ export default {
       }
     },
     postComment() {
-      this.createComment({ toastMessage: null })
-      if (
-        this.commentableType === 'Product' &&
-        this.productCheckerId === null &&
-        this.checkId === null
-      ) {
+      this.createComment({})
+      if (this.isUnassignedAndUnchekedProduct) {
         this.checkProduct(
           this.commentableId,
           this.currentUserId,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -297,15 +297,17 @@ export default {
       this.createComment({ toastMessage: null })
       if (
         this.commentableType === 'Product' &&
-        this.productCheckerId === null && this.checkId === null) {
-          this.checkProduct(
-            this.commentableId,
-            this.currentUserId,
-            '/api/products/checker',
-            'PATCH',
-            this.token()
-            )
-          }
+        this.productCheckerId === null &&
+        this.checkId === null
+      ) {
+        this.checkProduct(
+          this.commentableId,
+          this.currentUserId,
+          '/api/products/checker',
+          'PATCH',
+          this.token()
+        )
+      }
     },
     async fetchUncheckedProducts(page) {
       return fetch(`/api/products/unchecked?page=${page}`, {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -294,16 +294,18 @@ export default {
       }
     },
     postComment() {
-      this.createComment()
-      if (this.isUnassignedAndUnchekedProduct) {
-        this.checkProduct(
-          this.commentableId,
-          this.currentUserId,
-          '/api/products/checker',
-          'PATCH',
-          this.token()
-        )
-      }
+      this.createComment({ toastMessage: null })
+      if (
+        this.commentableType === 'Product' &&
+        this.productCheckerId === null && this.checkId === null) {
+          this.checkProduct(
+            this.commentableId,
+            this.currentUserId,
+            '/api/products/checker',
+            'PATCH',
+            this.token()
+            )
+          }
     },
     async fetchUncheckedProducts(page) {
       return fetch(`/api/products/unchecked?page=${page}`, {

--- a/app/javascript/hibernation_agreements.js
+++ b/app/javascript/hibernation_agreements.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const checkbox = document.querySelector('.js-hibernation-agreements-checkbox')
+  const submit = document.querySelector('.js-hibernation-agreements-submit')
+
+  checkbox.addEventListener('change', () => {
+    if (checkbox.checked) {
+      submit.classList.remove('is-disabled')
+      submit.classList.add('is-danger')
+    } else {
+      submit.classList.add('is-disabled')
+      submit.classList.remove('is-danger')
+    }
+  })
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -61,6 +61,7 @@ import '../training-info-toggler.js'
 import '../company-products.js'
 import '../welcome_message_for_adviser.js'
 import '../regular-events.js'
+import '../hibernation_agreements.js'
 
 import VueMounter from '../VueMounter.js'
 import Hello from '../components/hello.vue'

--- a/app/views/hibernation/new.html.slim
+++ b/app/views/hibernation/new.html.slim
@@ -74,7 +74,7 @@ header.page-header
             .block-checks.is-1-item.is-centered
               .block-checks__item
                 .a-block-check.is-checkbox
-                  input.a-toggle-checkbox#aaa(type='checkbox')
+                  input.a-toggle-checkbox.js-hibernation-agreements-checkbox#aaa(type='checkbox')
                   label.a-block-check__label(for='aaa')
                     | 読みました
 
@@ -85,5 +85,5 @@ header.page-header
                 class: 'a-button is-md is-secondary is-block'
             li.form-actions__item.is-main
               = f.submit '休会する',
-                class: 'a-button is-md is-danger is-block',
+                class: 'a-button is-md is-block js-hibernation-agreements-submit is-disabled',
                 data: { confirm: '本当によろしいですか？' }

--- a/app/views/hibernation/new.html.slim
+++ b/app/views/hibernation/new.html.slim
@@ -74,8 +74,8 @@ header.page-header
             .block-checks.is-1-item.is-centered
               .block-checks__item
                 .a-block-check.is-checkbox
-                  input.a-toggle-checkbox.js-hibernation-agreements-checkbox#aaa(type='checkbox')
-                  label.a-block-check__label(for='aaa')
+                  input.a-toggle-checkbox.js-hibernation-agreements-checkbox#check-to-read(type='checkbox')
+                  label.a-block-check__label(for='check-to-read')
                     | 読みました
 
         .form-actions

--- a/app/views/hibernation/new.html.slim
+++ b/app/views/hibernation/new.html.slim
@@ -73,7 +73,7 @@ header.page-header
               | 休会についての注意を読みましたか？
             .block-checks.is-1-item.is-centered
               .block-checks__item
-                .a-block-check.is-checkbox
+                .a-block-check.is-checkbox.check-box-to-read
                   input.a-toggle-checkbox.js-hibernation-agreements-checkbox#check-to-read(type='checkbox')
                   label.a-block-check__label(for='check-to-read')
                     | 読みました

--- a/app/views/hibernation/new.html.slim
+++ b/app/views/hibernation/new.html.slim
@@ -21,17 +21,6 @@ header.page-header
         html: { name: 'hibernation' },
         class: 'form' do |f|
         .form__items
-          //
-            休会についての注意を実装したら表示する
-            .form-item
-              label.a-form-label.is-required
-                | 休会についての注意を読みましたか？
-              .block-checks.is-2-items
-                .block-checks__item
-                  .a-block-check.is-checkbox
-                    input.a-toggle-checkbox#aaa(type='checkbox')
-                    label.a-block-check__label(for='aaa')
-                      | 読みました
           .form-item
             = f.label :scheduled_return_on,
               class: 'a-form-label is-required'
@@ -78,6 +67,17 @@ header.page-header
                       = link_to edit_current_user_path(anchor: 'times-url') do
                         | こちら
                       | のページの「分報 URL」欄に分報チャンネルの URL を登録してください。
+
+
+          .form-item
+            label.a-form-label.is-required
+              | 休会についての注意を読みましたか？
+            .block-checks.is-1-item.is-centered
+              .block-checks__item
+                .a-block-check.is-checkbox
+                  input.a-toggle-checkbox#aaa(type='checkbox')
+                  label.a-block-check__label(for='aaa')
+                    | 読みました
 
         .form-actions
           ul.form-actions__items

--- a/app/views/hibernation/new.html.slim
+++ b/app/views/hibernation/new.html.slim
@@ -68,7 +68,6 @@ header.page-header
                         | こちら
                       | のページの「分報 URL」欄に分報チャンネルの URL を登録してください。
 
-
           .form-item
             label.a-form-label.is-required
               | 休会についての注意を読みましたか？

--- a/test/system/hibernation_test.rb
+++ b/test/system/hibernation_test.rb
@@ -19,6 +19,7 @@ class HibernationTest < ApplicationSystemTestCase
     end
 
     VCR.use_cassette 'subscription/update', vcr_options do
+      find('.is-checkbox').click
       click_on '休会する'
       page.driver.browser.switch_to.alert.accept
       assert_text '休会処理が完了しました'
@@ -31,6 +32,7 @@ class HibernationTest < ApplicationSystemTestCase
       fill_in('hibernation[reason]', with: 'test')
     end
 
+    find('.is-checkbox').click
     click_on '休会する'
     page.driver.browser.switch_to.alert.accept
     assert_text '復帰予定日を入力してください'

--- a/test/system/hibernation_test.rb
+++ b/test/system/hibernation_test.rb
@@ -19,7 +19,7 @@ class HibernationTest < ApplicationSystemTestCase
     end
 
     VCR.use_cassette 'subscription/update', vcr_options do
-      find('.is-checkbox').click
+      check 'is-checkbox'
       click_on '休会する'
       page.driver.browser.switch_to.alert.accept
       assert_text '休会処理が完了しました'

--- a/test/system/hibernation_test.rb
+++ b/test/system/hibernation_test.rb
@@ -19,7 +19,7 @@ class HibernationTest < ApplicationSystemTestCase
     end
 
     VCR.use_cassette 'subscription/update', vcr_options do
-      find('.is-checkbox').click
+      find('.check-box-to-read').click
       click_on '休会する'
       page.driver.browser.switch_to.alert.accept
       assert_text '休会処理が完了しました'
@@ -32,7 +32,7 @@ class HibernationTest < ApplicationSystemTestCase
       fill_in('hibernation[reason]', with: 'test')
     end
 
-    find('.is-checkbox').click
+    find('.check-box-to-read').click
     click_on '休会する'
     page.driver.browser.switch_to.alert.accept
     assert_text '復帰予定日を入力してください'

--- a/test/system/hibernation_test.rb
+++ b/test/system/hibernation_test.rb
@@ -32,7 +32,7 @@ class HibernationTest < ApplicationSystemTestCase
       fill_in('hibernation[reason]', with: 'test')
     end
 
-    find('.is-checkbox').click
+    check 'is-checkbox'
     click_on '休会する'
     page.driver.browser.switch_to.alert.accept
     assert_text '復帰予定日を入力してください'

--- a/test/system/hibernation_test.rb
+++ b/test/system/hibernation_test.rb
@@ -19,7 +19,7 @@ class HibernationTest < ApplicationSystemTestCase
     end
 
     VCR.use_cassette 'subscription/update', vcr_options do
-      check 'is-checkbox'
+      find('.is-checkbox').click
       click_on '休会する'
       page.driver.browser.switch_to.alert.accept
       assert_text '休会処理が完了しました'
@@ -32,7 +32,7 @@ class HibernationTest < ApplicationSystemTestCase
       fill_in('hibernation[reason]', with: 'test')
     end
 
-    check 'is-checkbox'
+    find('.is-checkbox').click
     click_on '休会する'
     page.driver.browser.switch_to.alert.accept
     assert_text '復帰予定日を入力してください'

--- a/test/system/notification/hibernation_test.rb
+++ b/test/system/notification/hibernation_test.rb
@@ -22,6 +22,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'kimura'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
+    find('.is-checkbox').click
     accept_confirm do
       click_button '休会する'
     end
@@ -44,6 +45,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'kensyu'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
+    find('.is-checkbox').click
     accept_confirm do
       click_button '休会する'
     end
@@ -66,6 +68,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'senpai'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
+    find('.is-checkbox').click
     accept_confirm do
       click_button '休会する'
     end

--- a/test/system/notification/hibernation_test.rb
+++ b/test/system/notification/hibernation_test.rb
@@ -22,7 +22,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'kimura'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    check 'is-checkbox'
+    find('.is-checkbox').click
     accept_confirm do
       click_button '休会する'
     end
@@ -45,7 +45,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'kensyu'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    check 'is-checkbox'
+    find('.is-checkbox').click
     accept_confirm do
       click_button '休会する'
     end
@@ -68,7 +68,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'senpai'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    check 'is-checkbox'
+    find('.is-checkbox').click
     accept_confirm do
       click_button '休会する'
     end

--- a/test/system/notification/hibernation_test.rb
+++ b/test/system/notification/hibernation_test.rb
@@ -22,7 +22,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'kimura'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    find('.is-checkbox').click
+    find('.check-box-to-read').click
     accept_confirm do
       click_button '休会する'
     end
@@ -45,7 +45,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'kensyu'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    find('.is-checkbox').click
+    find('.check-box-to-read').click
     accept_confirm do
       click_button '休会する'
     end
@@ -68,7 +68,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'senpai'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    find('.is-checkbox').click
+    find('.check-box-to-read').click
     accept_confirm do
       click_button '休会する'
     end

--- a/test/system/notification/hibernation_test.rb
+++ b/test/system/notification/hibernation_test.rb
@@ -22,7 +22,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'kimura'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    find('.is-checkbox').click
+    check 'is-checkbox'
     accept_confirm do
       click_button '休会する'
     end
@@ -45,7 +45,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'kensyu'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    find('.is-checkbox').click
+    check 'is-checkbox'
     accept_confirm do
       click_button '休会する'
     end
@@ -68,7 +68,7 @@ class Notification::HibernationTest < ApplicationSystemTestCase
     visit_with_auth new_hibernation_path, 'senpai'
     fill_in 'hibernation[scheduled_return_on]', with: Time.current.next_month
     fill_in 'hibernation[reason]', with: 'テストのため'
-    find('.is-checkbox').click
+    check 'is-checkbox'
     accept_confirm do
       click_button '休会する'
     end


### PR DESCRIPTION
## Issue

- #5378 

## 概要

休会フォームに休会についての注意を「読みました」のチェックボックスを追加しました。


## 変更確認方法

1. ブランチ`feature/comeback_check`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. でログイン
4. `http://localhost:3000/hibernation/new`にアクセス
5. devツールの「要素」タブを開く
6. devツールの一番左上にある、要素が選択できるようになるマーク（下記のアイコン）をクリックする
![image](https://user-images.githubusercontent.com/76944527/191978538-0f854317-a532-4e6b-a700-04f2a4ad9787.png)
7. 「休会する」ボタンの上にカーソルを持っていき、要素を特定する
（マシンによるかもしれませんが、私のmacの場合はescキー押下で要素選択モードが解除できるようになりました）
8. チェックが入っていない状態のときは`a-button is-md is-block js-hibernation-agreements-submit  is-disabled`となっていることを確認する。
![image](https://user-images.githubusercontent.com/76944527/191986345-b6117875-53dc-45af-b2e5-aa2c7a55da98.png)
9. チェックが入っている状態のときは`a-button is-md is-block js-hibernation-agreements-submit  is-danger `となっていることを確認する。
![image](https://user-images.githubusercontent.com/76944527/191985311-cfb0435d-8c61-4b1d-8603-0d349c0827ad.png)

## 変更前

![image](https://user-images.githubusercontent.com/76944527/191975786-df78341c-9137-4628-a601-27b896f76c4c.png)

## 変更後
チェックボックス「読みました」のチェックボックスを追加。
### チェックが入っていない時
![image](https://user-images.githubusercontent.com/76944527/191986384-441b7a38-045b-48a4-959b-23a5d69d8b7a.png)

### チェックが入っている時
![image](https://user-images.githubusercontent.com/76944527/191985358-32232a16-b935-4a9a-87ac-2a543983d52d.png)

## 注意点
本PRでmachidaさんと話しているのですが、「読みました」のチェックボックスを押し、「休会する」を押すと下記画像のようにエラーが発生してしまいます。
こちらは把握済みでして、別issueで対応することとなりましたのでご放念いただければと思います。
![image](https://user-images.githubusercontent.com/76944527/192505741-6b178f21-ae78-4276-8287-2654cd8ad03a.png)

