### PR TITLE
ブログ投稿の文言を変更

### DIFF
--- a/app/views/application/_mentor_menu.html.slim
+++ b/app/views/application/_mentor_menu.html.slim
@@ -9,4 +9,4 @@
     li.header-dropdown__item
       = link_to new_article_path,
         class: 'header-dropdown__item-link' do
-        | ブログ投稿
+        | ブログ記事作成


### PR DESCRIPTION
## Issue

- #5450 

## 概要

管理者かメンターでログインした際のメニューの「ブログ投稿」を「ブログ記事作成」に変更。
Good First Issueとして担当させていただきました。

## 変更確認方法

1. ブランチ`feature/change-word-of-blog-postings`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 管理者かメンターでログイン
4. 右側のアイコンをクリックしてメニューの表示を確認してください

## 変更前
<img width="360" alt="スクリーンショット 2022-08-31 18 04 37" src="https://user-images.githubusercontent.com/59280290/187641903-a66346de-c995-4a4b-836b-ba1966fb20d6.png">


## 変更後
<img width="253" alt="スクリーンショット 2022-08-31 18 06 21" src="https://user-images.githubusercontent.com/59280290/187642123-56d0de59-b7ed-44bf-915b-8d8181aba05f.png">
