### PR TITLE
flakyなテストの解消

### DIFF
--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -91,8 +91,10 @@ class Notification::TalkTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: 'test')
     end
     click_button 'コメントする'
+    assert_text 'コメントを投稿しました'
 
     visit '/talks/unreplied'
+    assert_text '未返信の相談部屋はありません'
     within(:css, '.global-nav') do
       within(:css, "a[href='/talks/unreplied'") do
         assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -44,6 +44,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
     assert_text 'test'
 
     visit '/notifications'
+    assert_text '通知'
 
     within first('.card-list-item.is-unread') do
       assert_no_text 'kimuraさんの相談部屋でkomagataさんからコメントが届きました。'
@@ -106,6 +107,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
   test 'The number of unreplied comments is not displayed in the global navigation when mentor visit page' do
     user = users(:mentormentaro)
     visit_with_auth root_path, 'mentormentaro'
+    assert_text 'ダッシュボード'
     within(:css, '.global-nav') do
       within(:css, "a[href='/talks/#{user.talk.id}#latest-comment'") do
         assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'
@@ -116,6 +118,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
   test 'The number of unreplied comments is not displayed in the global navigation when advisor visit page' do
     user = users(:advijirou)
     visit_with_auth root_path, 'advijirou'
+    assert_text 'ダッシュボード'
     within(:css, '.global-nav') do
       within(:css, "a[href='/talks/#{user.talk.id}#latest-comment'") do
         assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'
@@ -126,6 +129,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
   test 'The number of unreplied comments is not displayed in the global navigation when student visit page' do
     user = users(:kimura)
     visit_with_auth root_path, 'kimura'
+    assert_text 'ダッシュボード'
     within(:css, '.global-nav') do
       within(:css, "a[href='/talks/#{user.talk.id}#latest-comment'") do
         assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'

--- a/test/system/notification/talk_test.rb
+++ b/test/system/notification/talk_test.rb
@@ -44,7 +44,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
     assert_text 'test'
 
     visit '/notifications'
-    assert_text '通知'
+    assert_selector '.page-header__title', text: '通知'
 
     within first('.card-list-item.is-unread') do
       assert_no_text 'kimuraさんの相談部屋でkomagataさんからコメントが届きました。'
@@ -107,7 +107,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
   test 'The number of unreplied comments is not displayed in the global navigation when mentor visit page' do
     user = users(:mentormentaro)
     visit_with_auth root_path, 'mentormentaro'
-    assert_text 'ダッシュボード'
+    assert_selector '.page-header__title', text: 'ダッシュボード'
     within(:css, '.global-nav') do
       within(:css, "a[href='/talks/#{user.talk.id}#latest-comment'") do
         assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'
@@ -118,7 +118,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
   test 'The number of unreplied comments is not displayed in the global navigation when advisor visit page' do
     user = users(:advijirou)
     visit_with_auth root_path, 'advijirou'
-    assert_text 'ダッシュボード'
+    assert_selector '.page-header__title', text: 'ダッシュボード'
     within(:css, '.global-nav') do
       within(:css, "a[href='/talks/#{user.talk.id}#latest-comment'") do
         assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'
@@ -129,7 +129,7 @@ class Notification::TalkTest < ApplicationSystemTestCase
   test 'The number of unreplied comments is not displayed in the global navigation when student visit page' do
     user = users(:kimura)
     visit_with_auth root_path, 'kimura'
-    assert_text 'ダッシュボード'
+    assert_selector '.page-header__title', text: 'ダッシュボード'
     within(:css, '.global-nav') do
       within(:css, "a[href='/talks/#{user.talk.id}#latest-comment'") do
         assert_no_selector '.global-nav__item-count.a-notification-count.is-only-mentor'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -459,13 +459,14 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'can preview editing of user-memos' do
-    visit_with_auth "/products/#{products(:product2).id}", 'komagata'
+    visit_with_auth "/products/#{products(:product6).id}", 'komagata'
     find('#side-tabs-nav-3').click
+    assert_text 'ユーザーメモはまだありません。'
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'プレビューができます。'
-    assert_selector '.is-editor.is-active'
     find('.form-tabs__tab', text: 'プレビュー').click
-    assert_selector '.is-preview.is-active'
+    assert_no_text 'ユーザーメモはまだありません'
+    assert_text 'プレビューができます'
   end
 
   test 'can update user-memos' do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -459,13 +459,13 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'can preview editing of user-memos' do
-    visit_with_auth "/products/#{products(:product6).id}", 'komagata'
+    visit_with_auth "/products/#{products(:product2).id}", 'komagata'
     find('#side-tabs-nav-3').click
-    assert_text 'ユーザーメモはまだありません。'
+    assert_text 'kimuraさんのメモ'
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'プレビューができます。'
+    assert_no_text 'kimuraさんのメモ'
     find('.form-tabs__tab', text: 'プレビュー').click
-    assert_no_text 'ユーザーメモはまだありません'
     assert_text 'プレビューができます'
   end
 

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -461,9 +461,9 @@ class ProductsTest < ApplicationSystemTestCase
   test 'can preview editing of user-memos' do
     visit_with_auth "/products/#{products(:product2).id}", 'komagata'
     find('#side-tabs-nav-3').click
+    assert_text 'kimuraさんのメモ'
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'プレビューができます。'
-    assert page.has_field? with: 'プレビューができます。'
     find('.form-tabs__tab', text: 'プレビュー').click
     assert_text 'プレビューができます。'
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -52,7 +52,9 @@ class ProductsTest < ApplicationSystemTestCase
   test 'not display learning completion message when a user of the completed product visits after the second time' do
     visit_with_auth "/products/#{products(:product65).id}", 'kimura'
     find('label.card-main-actions__muted-action').click
+    assert_no_text '喜びを Tweet する！'
     visit current_path
+    assert_text '修了 Tweet する'
     assert_no_text '喜びを Tweet する！'
   end
 
@@ -461,8 +463,9 @@ class ProductsTest < ApplicationSystemTestCase
     find('#side-tabs-nav-3').click
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'プレビューができます。'
+    assert_selector '.is-editor.is-active'
     find('.form-tabs__tab', text: 'プレビュー').click
-    assert_text 'プレビューができます。'
+    assert_selector '.is-preview.is-active'
   end
 
   test 'can update user-memos' do
@@ -501,6 +504,8 @@ class ProductsTest < ApplicationSystemTestCase
 
     assignee_buttons = all('.a-button.is-block.is-secondary.is-sm', text: '担当する')
     assignee_buttons.first.click
+    assert_selector '.a-button.is-warning'
+    assert_text '担当になりました'
     assert_text '担当から外れる'
 
     unassigned_tab.click

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -461,12 +461,11 @@ class ProductsTest < ApplicationSystemTestCase
   test 'can preview editing of user-memos' do
     visit_with_auth "/products/#{products(:product2).id}", 'komagata'
     find('#side-tabs-nav-3').click
-    assert_text 'kimuraさんのメモ'
     click_button '編集'
     fill_in 'js-user-mentor-memo', with: 'プレビューができます。'
-    assert_no_text 'kimuraさんのメモ'
+    assert page.has_field? with: 'プレビューができます。'
     find('.form-tabs__tab', text: 'プレビュー').click
-    assert_text 'プレビューができます'
+    assert_text 'プレビューができます。'
   end
 
   test 'can update user-memos' do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -504,8 +504,6 @@ class ProductsTest < ApplicationSystemTestCase
 
     assignee_buttons = all('.a-button.is-block.is-secondary.is-sm', text: '担当する')
     assignee_buttons.first.click
-    assert_selector '.a-button.is-warning'
-    assert_text '担当になりました'
     assert_text '担当から外れる'
 
     unassigned_tab.click

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -127,7 +127,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_text '1ヶ月以上ログインがありません'
 
     visit_with_auth '/users', 'hatsuno'
-    assert_text 'ユーザー'
+    assert_selector '.page-header__title', text: 'ユーザー'
     assert_no_selector 'div.users-item.inactive'
     assert_no_text '1ヶ月以上ログインがありません'
   end
@@ -138,7 +138,7 @@ class UsersTest < ApplicationSystemTestCase
     end
 
     visit_with_auth '/', 'komagata'
-    assert_text 'ダッシュボード'
+    assert_selector '.page-header__title', text: 'ダッシュボード'
     assert_no_text '1ヶ月以上ログインのないユーザー'
 
     users(:kimura).update!(
@@ -149,18 +149,18 @@ class UsersTest < ApplicationSystemTestCase
     assert_text '1ヶ月以上ログインのないユーザー'
 
     visit_with_auth '/', 'hatsuno'
-    assert_text 'ダッシュボード'
+    assert_selector '.page-header__title', text: 'ダッシュボード'
     assert_no_text '1ヶ月以上ログインのないユーザー'
   end
 
   test 'student access control' do
     visit_with_auth '/users', 'kimura'
-    assert_text 'ユーザー'
+    assert_selector '.page-header__title', text: 'ユーザー'
     assert_no_text '全員'
     assert_no_text '就職活動中'
 
     visit 'users?target=retired'
-    assert_text 'ユーザー'
+    assert_selector '.page-header__title', text: 'ユーザー'
     assert_no_text '退会'
   end
 
@@ -170,7 +170,7 @@ class UsersTest < ApplicationSystemTestCase
     assert find_link('就職活動中')
 
     visit 'users?target=retired'
-    assert_text 'ユーザー'
+    assert_selector '.page-header__title', text: 'ユーザー'
     assert_no_text '退会'
   end
 
@@ -207,7 +207,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_selector '.is-started.is-active'
 
     visit '/'
-    assert_text 'ダッシュボード'
+    assert_selector '.page-header__title', text: 'ダッシュボード'
     assert_no_text 'ようこそ'
   end
 
@@ -255,7 +255,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'show times link on user list page' do
     visit_with_auth '/users', 'hatsuno'
-    assert_text 'ユーザー'
+    assert_selector '.page-header__title', text: 'ユーザー'
     assert_no_link(href: 'https://discord.com/channels/715806612824260640/123456789000000007')
 
     kimura = users(:kimura)
@@ -272,7 +272,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'not admin cannot see link to talk on user list page' do
     visit_with_auth '/users', 'kimura'
-    assert_text 'ユーザー'
+    assert_selector '.page-header__title', text: 'ユーザー'
     assert_no_link '相談部屋'
   end
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -30,6 +30,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'graduation date is displayed' do
     visit_with_auth "/users/#{users(:mentormentaro).id}", 'komagata'
+    assert_text 'mentormentaro'
     assert_no_text '卒業日'
 
     visit "/users/#{users(:sotugyou).id}"
@@ -40,6 +41,7 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{users(:yameo).id}", 'komagata'
     assert_text '退会日'
     visit "/users/#{users(:sotugyou).id}"
+    assert_text 'sotugyou'
     assert_no_text '退会日'
   end
 
@@ -47,11 +49,13 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{users(:yameo).id}", 'komagata'
     assert_text '退会理由'
     visit "/users/#{users(:sotugyou).id}"
+    assert_text 'sotugyou'
     assert_no_text '退会理由'
   end
 
   test "retire reason isn't displayed when login user isn't admin" do
     visit_with_auth "/users/#{users(:yameo).id}", 'kimura'
+    assert_text 'yameo'
     assert_no_text '退会理由'
   end
 
@@ -101,6 +105,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_text '2014年01月01日(水) 01:00'
 
     visit_with_auth "/users/#{users(:kimura).id}", 'hatsuno'
+    assert_text 'kimura'
     assert_no_text '最終活動日時'
 
     visit_with_auth "/users/#{users(:neverlogin).id}", 'komagata'
@@ -108,6 +113,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_text '2022年07月11日(月) 09:00'
 
     visit_with_auth "/users/#{users(:neverlogin).id}", 'hatsuno'
+    assert_text 'neverlogin'
     assert_no_text '最終活動日時'
   end
 
@@ -121,6 +127,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_text '1ヶ月以上ログインがありません'
 
     visit_with_auth '/users', 'hatsuno'
+    assert_text 'ユーザー'
     assert_no_selector 'div.users-item.inactive'
     assert_no_text '1ヶ月以上ログインがありません'
   end
@@ -131,6 +138,7 @@ class UsersTest < ApplicationSystemTestCase
     end
 
     visit_with_auth '/', 'komagata'
+    assert_text 'ダッシュボード'
     assert_no_text '1ヶ月以上ログインのないユーザー'
 
     users(:kimura).update!(
@@ -141,15 +149,18 @@ class UsersTest < ApplicationSystemTestCase
     assert_text '1ヶ月以上ログインのないユーザー'
 
     visit_with_auth '/', 'hatsuno'
+    assert_text 'ダッシュボード'
     assert_no_text '1ヶ月以上ログインのないユーザー'
   end
 
   test 'student access control' do
     visit_with_auth '/users', 'kimura'
+    assert_text 'ユーザー'
     assert_no_text '全員'
     assert_no_text '就職活動中'
 
     visit 'users?target=retired'
+    assert_text 'ユーザー'
     assert_no_text '退会'
   end
 
@@ -159,6 +170,7 @@ class UsersTest < ApplicationSystemTestCase
     assert find_link('就職活動中')
 
     visit 'users?target=retired'
+    assert_text 'ユーザー'
     assert_no_text '退会'
   end
 
@@ -187,10 +199,15 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test 'not show welcome message' do
-    visit_with_auth practice_path(practices(:practice1).id), 'hatsuno'
+    visit_with_auth '/', 'hatsuno'
+    assert_text 'ようこそ'
+
+    visit practice_path(practices(:practice1).id)
     click_button '着手'
     assert_selector '.is-started.is-active'
+
     visit '/'
+    assert_text 'ダッシュボード'
     assert_no_text 'ようこそ'
   end
 
@@ -219,6 +236,7 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth root_path, 'hatsuno'
     visit user_path(users(:hajime).id)
     find('.niconico-calendar-nav__previous').click
+    assert_text 'hajime'
     assert_no_selector '.niconico-calendar__day.is-today'
   end
 
@@ -226,6 +244,7 @@ class UsersTest < ApplicationSystemTestCase
     kimura = users(:kimura)
 
     visit_with_auth "/users/#{kimura.id}", 'hatsuno'
+    assert_text 'kimura'
     assert_no_link(href: 'https://discord.com/channels/715806612824260640/123456789000000007')
 
     kimura.update!(times_url: 'https://discord.com/channels/715806612824260640/123456789000000007')
@@ -236,6 +255,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'show times link on user list page' do
     visit_with_auth '/users', 'hatsuno'
+    assert_text 'ユーザー'
     assert_no_link(href: 'https://discord.com/channels/715806612824260640/123456789000000007')
 
     kimura = users(:kimura)
@@ -252,6 +272,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'not admin cannot see link to talk on user list page' do
     visit_with_auth '/users', 'kimura'
+    assert_text 'ユーザー'
     assert_no_link '相談部屋'
   end
 
@@ -321,6 +342,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'not show grass hide button for graduates' do
     visit_with_auth "/users/#{users(:sotugyou).id}", 'sotugyou'
+    assert_text 'sotugyou'
     assert_not has_button? '非表示'
   end
 
@@ -338,6 +360,7 @@ class UsersTest < ApplicationSystemTestCase
     fill_in 'user_training_ends_on', with: training_ends_on
     click_on '更新する'
     visit_with_auth user_path(user.id), 'kensyu'
+    assert_text 'kensyu'
     assert has_no_field?('user_training_ends_on')
   end
 
@@ -352,6 +375,7 @@ class UsersTest < ApplicationSystemTestCase
     user = users(:sotugyou)
     user.update!(created_at: Time.zone.today, graduated_on: Time.zone.today - 1, job: 'office_worker')
     visit_with_auth "/users/#{user.id}", 'sotugyou'
+    assert_text 'sotugyou'
     assert_no_text '卒業 1日'
   end
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -189,6 +189,7 @@ class UsersTest < ApplicationSystemTestCase
   test 'not show welcome message' do
     visit_with_auth practice_path(practices(:practice1).id), 'hatsuno'
     click_button '着手'
+    assert_selector '.is-started.is-active'
     visit '/'
     assert_no_text 'ようこそ'
   end


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/5321

## Description
自分のローカル環境で`bin/rails test`を実行した際に落ちやすいテストをピックアップして修正しました。
対象のテストは下記です。

- `test/system/notification/talk_test.rb`
  - `The number of unreplied comments is displayed in the global navigation and unreplied tab of the talks room`
- `test/system/users_test.rb`
  - `not show welcome message`
- `test/system/products_test.rb`
  - `not display learning completion message when a user of the completed product visits after the second time`
  - `can preview editing of user-memos`


## 変更前後の比較

### `test/system/notification/talk_test.rb`

#### 変更前
- 成功9回
- 失敗1回

#### 変更後
- 成功10回
- 失敗0回

### `test/system/users_test.rb`

#### 変更前
- 成功7回
- 失敗3回

#### 変更後
- 成功10回
- 失敗0回

### `test/system/products_test.rb:52 not display learning completion...`

#### 変更前
- 成功6回
- 失敗4回

#### 変更後
- 成功9回
- 失敗1回

### `test/system/products_test.rb:461 can preview editing...`

#### 変更前
- 成功3回
- 失敗7回

#### 変更後
- 成功10回
- 失敗0回
