### PR TITLE
user-practice-progress.vueをVueMounterに対応させる

### DIFF
--- a/app/javascript/company-users.vue
+++ b/app/javascript/company-users.vue
@@ -26,7 +26,7 @@
     pager(v-bind='pagerProps')
 </template>
 <script>
-import User from './components/user'
+import User from './components/user.vue'
 import Pager from 'pager.vue'
 
 export default {

--- a/app/javascript/components/user-practice-progress.vue
+++ b/app/javascript/components/user-practice-progress.vue
@@ -14,7 +14,6 @@
 </template>
 <script>
 export default {
-  name: 'UserPracticeProgress',
   props: {
     user: { type: Object, required: true }
   },

--- a/app/javascript/components/user-practice-progress.vue
+++ b/app/javascript/components/user-practice-progress.vue
@@ -14,6 +14,7 @@
 </template>
 <script>
 export default {
+  name: 'UserPracticeProgress',
   props: {
     user: { type: Object, required: true }
   },

--- a/app/javascript/components/user.vue
+++ b/app/javascript/components/user.vue
@@ -80,7 +80,7 @@
 import Following from '../following.vue'
 import UserSns from '../user-sns.vue'
 import UserTags from '../user-tags.vue'
-import UserPracticeProgress from '../user-practice-progress.vue'
+import UserPracticeProgress from './user-practice-progress.vue'
 
 export default {
   name: 'User',

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -78,7 +78,6 @@ import User from '../components/user.vue'
 import Watches from '../components/watches.vue'
 import WatchToggle from '../components/watch-toggle.vue'
 import UserMentorMemo from '../components/user_mentor_memo.vue'
-import UserPracticeProgress from '../components/user-practice-progress.vue'
 
 const mounter = new VueMounter()
 mounter.addComponent(Hello)
@@ -94,7 +93,6 @@ mounter.addComponent(User)
 mounter.addComponent(Watches)
 mounter.addComponent(WatchToggle)
 mounter.addComponent(UserMentorMemo)
-mounter.addComponent(UserPracticeProgress)
 mounter.mount()
 
 // Support component names relative to this directory:

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -76,9 +76,9 @@ import Reports from '../components/reports.vue'
 import Users from '../components/users.vue'
 import User from '../components/user.vue'
 import Watches from '../components/watches.vue'
-import UserPracticeProgress from '../components/user-practice-progress.vue'
 import WatchToggle from '../components/watch-toggle.vue'
 import UserMentorMemo from '../components/user_mentor_memo.vue'
+import UserPracticeProgress from '../components/user-practice-progress.vue'
 
 const mounter = new VueMounter()
 mounter.addComponent(Hello)
@@ -92,9 +92,9 @@ mounter.addComponent(Reports)
 mounter.addComponent(Users)
 mounter.addComponent(User)
 mounter.addComponent(Watches)
-mounter.addComponent(UserPracticeProgress)
 mounter.addComponent(WatchToggle)
 mounter.addComponent(UserMentorMemo)
+mounter.addComponent(UserPracticeProgress)
 mounter.mount()
 
 // Support component names relative to this directory:

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -76,6 +76,7 @@ import Reports from '../components/reports.vue'
 import Users from '../components/users.vue'
 import User from '../components/user.vue'
 import Watches from '../components/watches.vue'
+import UserPracticeProgress from '../components/user-practice-progress.vue'
 import WatchToggle from '../components/watch-toggle.vue'
 import UserMentorMemo from '../components/user_mentor_memo.vue'
 
@@ -91,6 +92,7 @@ mounter.addComponent(Reports)
 mounter.addComponent(Users)
 mounter.addComponent(User)
 mounter.addComponent(Watches)
+mounter.addComponent(UserPracticeProgress)
 mounter.addComponent(WatchToggle)
 mounter.addComponent(UserMentorMemo)
 mounter.mount()


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5145

## 概要
user-practice-progress.vueのマウント方法を新マウント方法に変更する。

## 動作確認方法
1. ブランチ`feature/adjust-user-practice-progress-to-vue-mounter`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインする
4. http://localhost:3000/users にアクセスし、表示されることを確認する

## 新マウント確認方法
1. 開発者ツールの`Source`>`top`>`webpack://` > `app/javascript` > `VueMounter.js`の22行目にブレイクポイントを設定する
2. http://localhost:3000/users にアクセスする
ブレークポイントで停止する場合は、VueMounter.jsを使っている
ブレークポイントで停止せずにページが表示される場合は、VueMounter.jsを使っていない

<img width="1419" alt="Notification_Center" src="https://user-images.githubusercontent.com/99729409/188262886-1a5ebd28-a5f0-46d0-9327-1a2972c77e3f.png">
