### PR TITLE
お知らせのDiscord通知をabstract_notifierに置き換えた

### DIFF
--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -33,10 +33,6 @@ class AnnouncementCallbacks
     end
   end
 
-  def delete_notification(announce)
-    Notification.where(link: "/announcements/#{announce.id}").destroy_all
-  end
-
   def create_author_watch(announce)
     Watch.create!(user: announce.user, watchable: announce)
   end

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -17,15 +17,19 @@ class AnnouncementCallbacks
   private
 
   def after_first_publish(announce)
+    notify_to_chat(announce)
     send_notification(announce)
     announce.update(published_at: Time.current)
   end
 
+  def notify_to_chat(announce)
+    DiscordNotifier.with(announce: announce).post_announcement.notify_now
+  end
+
   def send_notification(announce)
     target_users = User.announcement_receiver(announce.target)
-    target_users.each_with_index do |target, index|
-      first_call = true if index.zero?
-      NotificationFacade.post_announcement(announce, target, first_call) if announce.sender != target
+    target_users.each do |target|
+      NotificationFacade.post_announcement(announce, target) if announce.sender != target
     end
   end
 

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -17,19 +17,15 @@ class AnnouncementCallbacks
   private
 
   def after_first_publish(announce)
-    notify_to_chat(announce)
     send_notification(announce)
     announce.update(published_at: Time.current)
   end
 
-  def notify_to_chat(announce)
-    DiscordNotifier.with(announce: announce).post_announcement.notify_now
-  end
-
   def send_notification(announce)
     target_users = User.announcement_receiver(announce.target)
-    target_users.each do |target|
-      NotificationFacade.post_announcement(announce, target) if announce.sender != target
+    target_users.each_with_index do |target, index|
+      first_call = true if index.zero?
+      NotificationFacade.post_announcement(announce, target, first_call) if announce.sender != target
     end
   end
 

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -17,9 +17,13 @@ class AnnouncementCallbacks
   private
 
   def after_first_publish(announce)
-    DiscordNotifier.with(announce: announce).post_announcement.notify_now
+    notify_to_chat(announce)
     send_notification(announce)
     announce.update(published_at: Time.current)
+  end
+
+  def notify_to_chat(announce)
+    DiscordNotifier.with(announce: announce).post_announcement.notify_now
   end
 
   def send_notification(announce)

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -17,7 +17,7 @@ class AnnouncementCallbacks
   private
 
   def after_first_publish(announce)
-    notify_to_chat(announce)
+    DiscordNotifier.with(announce: announce).post_announcement.notify_now
     send_notification(announce)
     announce.update(published_at: Time.current)
   end
@@ -29,14 +29,8 @@ class AnnouncementCallbacks
     end
   end
 
-  def notify_to_chat(announce)
-    path = Rails.application.routes.url_helpers.polymorphic_path(announce)
-    url = "https://bootcamp.fjord.jp#{path}"
-
-    ChatNotifier.message(
-      "お知らせ：「#{announce.title}」\r#{url}",
-      webhook_url: ENV['DISCORD_ALL_WEBHOOK_URL']
-    )
+  def delete_notification(announce)
+    Notification.where(link: "/announcements/#{announce.id}").destroy_all
   end
 
   def create_author_watch(announce)

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -23,7 +23,7 @@ class AnnouncementCallbacks
   end
 
   def notify_to_chat(announce)
-    DiscordNotifier.with(announce: announce).post_announcement.notify_now
+    DiscordNotifier.with(announce: announce).announce.notify_now
   end
 
   def send_notification(announce)

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -23,7 +23,7 @@ class AnnouncementCallbacks
   end
 
   def notify_to_chat(announce)
-    DiscordNotifier.with(announce: announce).announce.notify_now
+    DiscordNotifier.with(announce: announce).announced.notify_now
   end
 
   def send_notification(announce)

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -54,9 +54,8 @@ class NotificationFacade
     NotificationMailer.with(answer: answer).came_answer.deliver_later(wait: 5)
   end
 
-  def self.post_announcement(announce, receiver, first_call)
+  def self.post_announcement(announce, receiver)
     ActivityNotifier.with(announce: announce, receiver: receiver).post_announcement.notify_now
-    DiscordNotifier.with(announce: announce).post_announcement.notify_now if first_call
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -54,8 +54,9 @@ class NotificationFacade
     NotificationMailer.with(answer: answer).came_answer.deliver_later(wait: 5)
   end
 
-  def self.post_announcement(announce, receiver)
+  def self.post_announcement(announce, receiver, first_call)
     ActivityNotifier.with(announce: announce, receiver: receiver).post_announcement.notify_now
+    DiscordNotifier.with(announce: announce).post_announcement.notify_now if first_call
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -28,7 +28,7 @@ class DiscordNotifier < ApplicationNotifier
 
   def post_announcement(params = {})
     params.merge!(@params)
-    webhook_url = ENV['DISCORD_ALL_WEBHOOK_URL'] || Rails.application.secrets[:webhook][:all]
+    webhook_url = Rails.application.secrets[:webhook][:all]
 
     path = Rails.application.routes.url_helpers.polymorphic_path(params[:announce])
     url = "https://bootcamp.fjord.jp#{path}"

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -26,6 +26,20 @@ class DiscordNotifier < ApplicationNotifier
     )
   end
 
+  def post_announcement(params = {})
+    params.merge!(@params)
+    webhook_url = params[:webhook_url] || ENV['DISCORD_ALL_WEBHOOK_URL']
+
+    path = Rails.application.routes.url_helpers.polymorphic_path(params[:announce])
+    url = "https://bootcamp.fjord.jp#{path}"
+
+    notification(
+      body: "お知らせ：「#{params[:announce].title}」\r#{url}",
+      name: 'ピヨルド',
+      webhook_url: webhook_url
+    )
+  end
+
   def tomorrow_regular_event(params = {})
     params.merge!(@params)
     event = params[:event]

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -28,7 +28,7 @@ class DiscordNotifier < ApplicationNotifier
 
   def post_announcement(params = {})
     params.merge!(@params)
-    webhook_url = params[:webhook_url] || ENV['DISCORD_ALL_WEBHOOK_URL']
+    webhook_url = ENV['DISCORD_ALL_WEBHOOK_URL'] || Rails.application.secrets[:webhook][:all]
 
     path = Rails.application.routes.url_helpers.polymorphic_path(params[:announce])
     url = "https://bootcamp.fjord.jp#{path}"

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -26,7 +26,7 @@ class DiscordNotifier < ApplicationNotifier
     )
   end
 
-  def announce(params = {})
+  def announced(params = {})
     params.merge!(@params)
     webhook_url = Rails.application.secrets[:webhook][:all]
 

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -26,7 +26,7 @@ class DiscordNotifier < ApplicationNotifier
     )
   end
 
-  def post_announcement(params = {})
+  def announce(params = {})
     params.merge!(@params)
     webhook_url = Rails.application.secrets[:webhook][:all]
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -32,7 +32,7 @@ test:
     secret_key: sk_test_XLP1Ajz1JvT9jUt5uKGvL0Wd
   webhook:
     admin: https://discord.com/api/webhooks/0123456789/admin
-    all: https://discord.com/api/webhooks/0123456789/xxxxxxxx
+    all: https://discord.com/api/webhooks/0123456789/all
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -31,6 +31,7 @@ test:
     secret_key: sk_test_XLP1Ajz1JvT9jUt5uKGvL0Wd
   webhook:
     admin: https://discord.com/api/webhooks/0123456789/admin
+    all: https://discord.com/api/webhooks/0123456789/xxxxxxxx
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,6 +19,7 @@
 shared:
   webhook:
     admin: <%= ENV['DISCORD_ADMIN_WEBHOOK_URL'] %>
+    all: <%= ENV['DISCORD_ALL_WEBHOOK_URL'] %>
 
 development:
   stripe:

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -63,6 +63,31 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     end
   end
 
+  test '.post_announcement' do
+    params = {
+      body: 'test message',
+      announce: announcements(:announcement1),
+      name: 'bob',
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    expected = {
+      body: "お知らせ：「お知らせ1」\rhttps://bootcamp.fjord.jp/announcements/395315747",
+      name: 'ピヨルド',
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    assert_notifications_sent 2, **expected do
+      DiscordNotifier.post_announcement(params).notify_now
+      DiscordNotifier.with(params).post_announcement.notify_now
+    end
+
+    assert_notifications_enqueued 2, **expected do
+      DiscordNotifier.post_announcement(params).notify_later
+      DiscordNotifier.with(params).post_announcement.notify_later
+    end
+  end
+
   test '.tomorrow_regular_event' do
     params = {
       event: regular_events(:regular_event1),

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -38,31 +38,6 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     end
   end
 
-  test '.hibernated' do
-    params = {
-      body: 'test message',
-      sender: users(:kimura),
-      name: 'bob',
-      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
-    }
-
-    expected = {
-      body: 'kimuraさんが休会しました。',
-      name: 'ピヨルド',
-      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
-    }
-
-    assert_notifications_sent 2, **expected do
-      DiscordNotifier.hibernated(params).notify_now
-      DiscordNotifier.with(params).hibernated.notify_now
-    end
-
-    assert_notifications_enqueued 2, **expected do
-      DiscordNotifier.hibernated(params).notify_later
-      DiscordNotifier.with(params).hibernated.notify_later
-    end
-  end
-
   test '.post_announcement' do
     params = {
       body: 'test message',

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -38,7 +38,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     end
   end
 
-  test '.post_announcement' do
+  test '.announce' do
     params = {
       body: 'test message',
       announce: announcements(:announcement1),
@@ -52,13 +52,13 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     }
 
     assert_notifications_sent 2, **expected do
-      DiscordNotifier.post_announcement(params).notify_now
-      DiscordNotifier.with(params).post_announcement.notify_now
+      DiscordNotifier.announce(params).notify_now
+      DiscordNotifier.with(params).announce.notify_now
     end
 
     assert_notifications_enqueued 2, **expected do
-      DiscordNotifier.post_announcement(params).notify_later
-      DiscordNotifier.with(params).post_announcement.notify_later
+      DiscordNotifier.announce(params).notify_later
+      DiscordNotifier.with(params).announce.notify_later
     end
   end
 

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -42,8 +42,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     params = {
       body: 'test message',
       announce: announcements(:announcement1),
-      name: 'bob',
-      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+      name: 'bob'
     }
 
     expected = {

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -38,6 +38,31 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     end
   end
 
+  test '.hibernated' do
+    params = {
+      body: 'test message',
+      sender: users(:kimura),
+      name: 'bob',
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    expected = {
+      body: 'kimuraさんが休会しました。',
+      name: 'ピヨルド',
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    assert_notifications_sent 2, **expected do
+      DiscordNotifier.hibernated(params).notify_now
+      DiscordNotifier.with(params).hibernated.notify_now
+    end
+
+    assert_notifications_enqueued 2, **expected do
+      DiscordNotifier.hibernated(params).notify_later
+      DiscordNotifier.with(params).hibernated.notify_later
+    end
+  end
+
   test '.tomorrow_regular_event' do
     params = {
       event: regular_events(:regular_event1),

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -38,7 +38,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     end
   end
 
-  test '.announce' do
+  test '.announced' do
     params = {
       body: 'test message',
       announce: announcements(:announcement1),
@@ -48,17 +48,17 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     expected = {
       body: "お知らせ：「お知らせ1」\rhttps://bootcamp.fjord.jp/announcements/395315747",
       name: 'ピヨルド',
-      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/all'
     }
 
     assert_notifications_sent 2, **expected do
-      DiscordNotifier.announce(params).notify_now
-      DiscordNotifier.with(params).announce.notify_now
+      DiscordNotifier.announced(params).notify_now
+      DiscordNotifier.with(params).announced.notify_now
     end
 
     assert_notifications_enqueued 2, **expected do
-      DiscordNotifier.announce(params).notify_later
-      DiscordNotifier.with(params).announce.notify_later
+      DiscordNotifier.announced(params).notify_later
+      DiscordNotifier.with(params).announced.notify_later
     end
   end
 


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/4699

## Description
お知らせを初めて公開・作成した際に行っている、Discordの「お知らせ📣」チャンネルへの通知処理をabstract_notifierを使用したものに変更した。
見た目上の変更点はありません。
## 確認方法
### 下準備
開発環境でDiscordへの通知を確認するためにご自身のDiscordアカウントで新しいサーバを作成してください。
1. サーバーを追加 をクリック
![image](https://user-images.githubusercontent.com/70259961/188273598-fd5cf70f-5083-4fe6-9406-427031227123.png)
1. オリジナルの作成を選択
![image](https://user-images.githubusercontent.com/70259961/188273976-ad40b168-7d76-4ed3-b644-f875a7094fe4.png)
1. 自分と友達のためを選択
![image](https://user-images.githubusercontent.com/70259961/188273991-0e05adb4-0df9-4632-ba1c-249c6a364e54.png)
1. サーバー名を入力して新規作成
![image](https://user-images.githubusercontent.com/70259961/188274004-67bdf7c5-ebde-417d-8087-2ae65af8996b.png)
1. サーバー内のテキストチャンネルを1つ決めて編集をクリック
![image](https://user-images.githubusercontent.com/70259961/188274633-a1bd6509-bfec-436e-8d7f-f7195a8c0227.png)
1. 連携サービス内のウェブフックを作成をクリック
![image](https://user-images.githubusercontent.com/70259961/188274437-f9d673c9-f8fe-4aea-a9cd-051bfb35e299.png)
1. 名前の入力、チャンネルを選択して変更を保存する
![image](https://user-images.githubusercontent.com/70259961/188274474-408eed43-fe35-4a22-b10f-e5bae4ec020e.png)
1. ウェブフックURLをコピーして環境変数に設定する
環境変数名は`DISCORD_ALL_WEBHOOK_URL`
（自分は`~/.zshrc`ファイルに`export DISCORD_ALL_WEBHOOK_URL='コピーしたURL'`を追加しました）
![image](https://user-images.githubusercontent.com/70259961/188274488-3a64f4d8-d610-47f2-b85d-02d1a6e6c6db.png)
以上でDiscordの準備は完了です。

### ローカルで動作検証
1. ローカルに`feature/apply-abstract-notifier-for-discord-notification`を取り込む。
2. `bin/rails s`して`localhost`にアクセス
3. `komagata`でログインする
4. `/announcements/new`に遷移してお知らせを作成する
5. 下準備で作成したチャンネルに通知が来ていることを確認する
6. 通知のリンクをクリックする
(URLが本番環境向けになっているため、`https://bootcamp.fjord.jp`の部分を`localhost:3000`に変更してアクセスする)
7. 該当のページが作成したお知らせであることを確認する
8. 再度`/announcements/new`に遷移して今度はお知らせを一度WIPで保存する
9. 保存したお知らせを編集、公開してDiscordチャンネルに通知が来ていることを確認する
10. 6同様にアクセスして該当のお知らせページに遷移できることを確認する

