### PR TITLE
[abstract_notifier] 回答通知を置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -67,17 +67,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def came_answer(answer)
-      Notification.create!(
-        kind: kinds[:answered],
-        user: answer.receiver,
-        sender: answer.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
-        message: "#{answer.user.login_name}さんから回答がありました。",
-        read: false
-      )
-    end
-
     def watching_notification(watchable, receiver, comment)
       watchable_user = watchable.user
       sender = comment.user

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -47,8 +47,8 @@ class NotificationFacade
   end
 
   def self.came_answer(answer)
-    Notification.came_answer(answer)
     receiver = answer.receiver
+    ActivityNotifier.with(answer: answer).came_answer.notify_now
     return unless answer.receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(answer: answer).came_answer.deliver_later(wait: 5)

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -216,4 +216,18 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def came_answer(params = {})
+    params.merge!(@params)
+    answer = params[:answer]
+
+    notification(
+      body: "#{answer.user.login_name}さんから回答がありました。",
+      kind: :answered,
+      receiver: answer.receiver,
+      sender: answer.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
+      read: false
+    )
+  end
 end

--- a/test/system/notification/answers_test.rb
+++ b/test/system/notification/answers_test.rb
@@ -4,7 +4,13 @@ require 'application_system_test_case'
 
 class Notification::AnswersTest < ApplicationSystemTestCase
   setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
     @notice_text = 'komagataさんから回答がありました。'
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
   end
 
   test "receive a notification when I got my question's answer" do


### PR DESCRIPTION
## Issue

- #4694
- #4673 (関連)

## 概要

通知部分を整理するのに[active_delivery](https://github.com/palkan/active_delivery)を使ったものに変えたいと思っているが、前準備として[abstract_notifier](https://github.com/palkan/abstract_notifier)に対応させる必要がある。今回は回答の通知機能を対応させた。

## 変更確認方法

1. ブランチ`feature/move-narrow-down-parts`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `senpai`でログイン
4. Q&Aから「tagが付与された質問2」（komagataさんが質問者であればなんでもOK）にアクセス
5. コメントをフォームに入力し「コメントする」を押下
6. ログアウト
7. komagataさんでログイン（Id: komagata, Pass: testtest）
8. 通知タブを押下
9. senpaiから回答通知があることを確認

変更前後の見た目上の変化はないです。