### PR TITLE
全てのタグを全てのタブで表示するため、コントローラーから全てのタグを渡すように変更

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -20,7 +20,7 @@ class QuestionsController < ApplicationController
         Question.all
       end
     @tag = ActsAsTaggableOn::Tag.find_by(name: params[:tag])
-    @tags = questions.all_tags
+    @tags = Question.all.all_tags
     questions = params[:practice_id].present? ? questions.where(practice_id: params[:practice_id]) : questions
     questions = questions.tagged_with(params[:tag]) if params[:tag]
     @questions = questions

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -46,7 +46,7 @@ header.page-header
                 | タグ一覧
             .page-tags-nav__body
               ul.page-tags-nav__items
-                - Question.all.all_tags.each do |tag|
+                - @tags.each do |tag|
                   - if tag.present?
                     li.page-tags-nav__item
                       = link_to tag.name, questions_tag_path(tag.name), class: 'page-tags-nav__item-link'


### PR DESCRIPTION
## Issue

- #5456 

## 概要
Q&Aのページには3つのタブが存在している。「未解決」「解決済み」「全て」である。
例えば、未解決の質問についているタグの一覧は解決済みの方には表示されない。

一方で、タグ一覧は質問の種類に関係なく全てのタグの一覧として表示されているのが望ましい。
本プルリクエストでは、それを解決した。

### 詳細
view側は変更せずに、コントローラーから渡す`@tags`の値をタブごとではなくQuestion全てに紐づくものにしました。

これによって、タグが存在していない場合はli要素の作成がされず、質問に関連するタグが存在している場合のみHTML要素が描画されると考えました。

## 変更確認方法

1. ブランチ`show-all-tags-in-q-and-a`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. http://localhost:3000/questions?target=not_solved にアクセス（未解決のページ）
4. 未解決の質問を任意で1つ開く
5. タグ編集を押下
6. 1つタグを追加して保存する（タグの文字を入力した後、一度EnterかReturnを押下してテキストではなく、タグとして認識されていることを確認してください）
7. http://localhost:3000/questions?target=solved にアクセス（解決済みのページ）
8. 6で追加したタグがページ右に表示されていることを確認
9. 6で追加したタグをクリックして全てタブ（解決したもの、未解決がミックスされた一覧）にアクセスできることを確認

※タグの保存を押下する直前の画面
<img width="455" alt="スクリーンショット 2022-09-06 17 17 01" src="https://user-images.githubusercontent.com/59280290/188583584-a049e2a1-9e3b-45ec-a7e9-e3e732765f1a.png">

こちらだとダメです。一度EnterかReturnキーを押下してください。
<img width="360" alt="スクリーンショット 2022-09-06 17 17 08" src="https://user-images.githubusercontent.com/59280290/188583648-cbe47594-763a-436f-90eb-de1bec469fad.png">

変更前後で見た目上の変化はありません（見た目は変わらず、出力されるものが変わります）

### その他
ブランチ名を間違えたのでcloseして作り直しました。