### PR TITLE
メンターでログインしたときの未チェックの日報一覧のページタイトルを変更

### DIFF
--- a/app/views/reports/unchecked/index.html.slim
+++ b/app/views/reports/unchecked/index.html.slim
@@ -3,8 +3,7 @@
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title
-        = title
+      h2.page-header__title 日報
       = render 'reports/new_report'
 
 = render 'reports/tabs'


### PR DESCRIPTION
## Issue

- #5430  

## 概要

メンターでログインしたときの未チェックの日報一覧のページタイトルを`未チェックの日報`から`日報`へ変更しました。
なお、metaタグは変更ないようにとのご指示を駒形さん＆町田さんからいただいているため、そちらは変更ありません。

## 変更前
ページ左上のページタイトルは`未チェックの日報`となっています。

![image](https://user-images.githubusercontent.com/58751858/188631900-221da08d-a63f-430c-8ee3-2bf096b42d59.png)


- metaタグ

![image](https://user-images.githubusercontent.com/58751858/188631334-aee9a1bd-00bb-42b9-81da-5914d1369bc1.png)


## 変更後
`未チェックの日報`から`日報`へ変更しました。

![image](https://user-images.githubusercontent.com/58751858/188632164-e78805ed-0958-411f-b204-f775b899d25a.png)

- metaタグ
こちらは変更ありません。

![image](https://user-images.githubusercontent.com/58751858/188632276-3a4def09-9ec9-4c41-8e57-96bcde96bd1c.png)

## 変更確認方法

1. ブランチ`feature/change-title-of-unchecked-report-on-mentor-page`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3.  `komagata`でログインし、http://localhost:3000/reports/unchecked へアクセスする
