### PR TITLE
管理者でログインしている場合のユーザー相談部屋のページタイトルの変更

### DIFF
--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -5,7 +5,7 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         - if current_user.admin?
-          | #{@user.login_name}
+          = @user.login_name
         - else
           | 相談部屋
       - if current_user.admin?

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -4,7 +4,10 @@ header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        - if current_user.admin?
+          | #{@user.login_name}
+        - else
+          | 相談部屋
       - if current_user.admin?
         .page-header-actions
           ul.page-header-actions__items

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -38,12 +38,6 @@ class TalksTest < ApplicationSystemTestCase
     assert_text "#{visited_user.login_name}さんの相談部屋"
   end
 
-  test 'non-admin user can access their own talk page' do
-    user = users(:kimura)
-    visit_with_auth "/talks/#{user.talk.id}", 'kimura'
-    assert_selector '.page-header__title', text: '相談部屋'
-  end
-
   test 'a talk room is shown up on unreplied tab when users except admin comments there' do
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'
@@ -65,6 +59,12 @@ class TalksTest < ApplicationSystemTestCase
     visit_with_auth '/talks', 'komagata'
     click_link 'kimura (Kimura Tadasi) さんの相談部屋'
     assert_selector '.page-header__title', text: 'kimura'
+  end
+
+  test 'non-admin user can access their own talk page' do
+    user = users(:kimura)
+    visit_with_auth "/talks/#{user.talk.id}", 'kimura'
+    assert_selector '.page-header__title', text: '相談部屋'
   end
 
   test 'a talk room is removed from unreplied tab when admin comments there' do

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -58,7 +58,7 @@ class TalksTest < ApplicationSystemTestCase
     talks(:talk7).update!(updated_at: Time.current) # user: kimura
     visit_with_auth '/talks', 'komagata'
     click_link 'kimura (Kimura Tadasi) さんの相談部屋'
-    assert_selector '.page-header__title', text: 'kimuraさんの相談部屋'
+    assert_selector '.page-header__title', text: 'kimura'
   end
 
   test 'a talk room is removed from unreplied tab when admin comments there' do

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -38,6 +38,12 @@ class TalksTest < ApplicationSystemTestCase
     assert_text "#{visited_user.login_name}さんの相談部屋"
   end
 
+  test 'non-admin user can access their own talk page' do
+    user = users(:kimura)
+    visit_with_auth "/talks/#{user.talk.id}", 'kimura'
+    assert_selector '.page-header__title', text: '相談部屋'
+  end
+
   test 'a talk room is shown up on unreplied tab when users except admin comments there' do
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'


### PR DESCRIPTION
## Issue

- #5403 

## 概要
### 管理者でログインしている場合
ユーザーそれぞれの相談部屋にアクセスした際に表示される、
ページ左上のタイトルを`(ユーザーID)さんの相談部屋`から`ユーザーID`へ変更


### 管理者以外でログインしている場合
メニューから「相談部屋」をクリックした際に表示される、
ページ左上のタイトルを`(自分のユーザーID)さんの相談部屋`から`相談部屋`へ変更

🌟なお、metaタグは変更ないようにとのご指示を駒形さん＆町田さんからいただいているため、上記どちらのパターンにおいても変更はありません。


## 変更点
### 管理者でログインしている場合

#### 変更前
![image](https://user-images.githubusercontent.com/58751858/188828470-e15706f3-09a9-416b-b86d-7e25d3f4b9b6.png)


#### 変更後
![image](https://user-images.githubusercontent.com/58751858/188827969-71ce9a8d-b9cd-4c5c-91f6-14fe425e8b8b.png)


### 管理者以外でログインしている場合

#### 変更前
![image](https://user-images.githubusercontent.com/58751858/188828734-26a4b4cb-8b58-4c61-acb6-12e17859401a.png)


#### 変更後
![image](https://user-images.githubusercontent.com/58751858/188832191-94f9c8ad-5d84-433f-9450-760f8ca2ebec.png)


## 変更確認方法

1. ブランチ`feature/change-title-of-talk-room`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる

### 管理者でログインしている場合の確認
→ `komagata`または`machida`でログインし、http://localhost:3000/talks へアクセスする
→ 任意のユーザーの相談部屋へアクセスする

### 管理者以外でログインしている場合の確認
→ 管理者以外の任意のアカウントでログインし、メニューから`相談部屋`を選択し、相談部屋へアクセスする
