### PR TITLE
プラクティスの日報タブに表示される日報一覧にVueComponentを適用させた

### DIFF
--- a/app/javascript/components/reports.vue
+++ b/app/javascript/components/reports.vue
@@ -69,6 +69,10 @@ export default {
       type: Number,
       default: null
     },
+    practiceId: {
+      type: Number,
+      default: null
+    },
     limit: {
       type: String,
       default: null
@@ -98,6 +102,9 @@ export default {
       }
       if (this.companyId) {
         params.set('company_id', this.companyId)
+      }
+      if (this.practiceId) {
+        params.set('practice_id', this.practiceId)
       }
       if (this.limit) {
         params.set('limit', this.limit)

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -6,14 +6,4 @@
 
 .page-body
   .container.is-md
-    = paginate @reports
-    - if @reports.present?
-      .card-list.a-card
-        = render partial: 'reports/report', collection: @reports, as: :report
-      = paginate @reports
-    - else
-      .o-empty-message
-        .o-empty-message__icon
-          i.fa-regular.fa-sad-tear
-        .o-empty-message__text
-          | 日報はまだありません。
+    div(data-vue="Reports" data-vue-practice-id:number="#{@practice.id}")

--- a/test/system/practice/reports_test.rb
+++ b/test/system/practice/reports_test.rb
@@ -6,9 +6,7 @@ class Practice::ReportsTest < ApplicationSystemTestCase
   test 'show listing reports' do
     visit_with_auth "/practices/#{practices(:practice1).id}/reports", 'hatsuno'
     assert_equal 'OS X Mountain Lionをクリーンインストールするに関する日報 | FBC', title
-    within first('.card-list-item') do
-      assert_selector 'img[alt="happy"]'
-      assert_text '1時間だけ学習'
-    end
+    assert_selector 'img[alt="happy"]', count: 2
+    assert_selector '.card-list-item-title__link', text: '1時間だけ学習'
   end
 end


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/5414

## Description
プラクティスの個別ページから遷移できる「プラクティスに関する日報」の一覧をReportsComponentに対応させた。

## 変更点
画面上の細かい変化があります。

- 元のviewファイル `app/views/reports/_report.html.slim`
- 切り替え後の単一コンポーネントファイル `app/javascript/components/reports.vue`
で仕様が異なるため、下記のような変化があります。

### 変更前
![image](https://user-images.githubusercontent.com/70259961/189468897-7e1a559b-b668-4f71-8fd8-764c1af63c1c.png)

### 変更後
![image](https://user-images.githubusercontent.com/70259961/189468904-55de961c-bef1-44fd-88cc-1ea7f8cfc0a1.png)

