### PR TITLE
確認通知を[abstract_notifier]に置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -89,7 +89,6 @@ class Notification < ApplicationRecord
       )
     end
 
->>>>>>> a90935a66 (確認通知を[abstract_notifier]に置き換えた)
     def watching_notification(watchable, receiver, comment)
       watchable_user = watchable.user
       sender = comment.user

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -78,17 +78,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def came_answer(answer)
-      Notification.create!(
-        kind: kinds[:answered],
-        user: answer.receiver,
-        sender: answer.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
-        message: "#{answer.user.login_name}さんから回答がありました。",
-        read: false
-      )
-    end
-
     def watching_notification(watchable, receiver, comment)
       watchable_user = watchable.user
       sender = comment.user

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -67,6 +67,29 @@ class Notification < ApplicationRecord
       )
     end
 
+    def came_answer(answer)
+      Notification.create!(
+        kind: kinds[:answered],
+        user: answer.receiver,
+        sender: answer.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
+        message: "#{answer.user.login_name}さんから回答がありました。",
+        read: false
+      )
+    end
+
+    def came_answer(answer)
+      Notification.create!(
+        kind: kinds[:answered],
+        user: answer.receiver,
+        sender: answer.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
+        message: "#{answer.user.login_name}さんから回答がありました。",
+        read: false
+      )
+    end
+
+>>>>>>> a90935a66 (確認通知を[abstract_notifier]に置き換えた)
     def watching_notification(watchable, receiver, comment)
       watchable_user = watchable.user
       sender = comment.user

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -13,7 +13,7 @@ class NotificationFacade
   end
 
   def self.checked(check)
-    Notification.checked(check)
+    ActivityNotifier.with(check: check, receiver: check.receiver).checked.notify_now
     receiver = check.receiver
     return unless receiver.mail_notification? && !receiver.retired?
 

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -230,4 +230,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def checked(params = {})
+    params.merge!(@params)
+    check = params[:check]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{check.sender.login_name}さんが#{check.checkable.title}を確認しました。",
+      kind: :checked,
+      receiver: receiver,
+      sender: check.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(check.checkable),
+      read: false
+    )
+  end
 end

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -28,7 +28,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'update product notificationmessage' do
+  test 'update product notification message' do
     product = products(:product2)
 
     visit_with_auth "/products/#{product.id}/edit", 'kimura'
@@ -45,7 +45,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'checked product notificationmessage' do
+  test 'checked product notification message' do
     checker = users(:komagata)
     practice = practices(:practice47)
     user = users(:kimura)

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -44,4 +44,25 @@ class Notification::ProductsTest < ApplicationSystemTestCase
       assert_text 'kimuraさんの提出物が更新されました'
     end
   end
+
+  test 'checked product notificationmessage' do
+    checker = users(:komagata)
+    practice = practices(:practice47)
+    user = users(:kimura)
+    product = Product.create!(
+      body: 'test',
+      user: user,
+      practice: practice,
+      checker_id: checker.id
+    )
+    visit_with_auth "/products/#{product.id}", 'komagata'
+    click_button '提出物を確認'
+    assert_text '提出物を確認済みにしました。'
+
+    visit_with_auth '/notifications', 'kimura'
+
+    within first('.card-list-item.is-unread') do
+      assert_text "komagataさんが「#{practices(:practice47).title}」の提出物を確認しました。"
+    end
+  end
 end

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -62,7 +62,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'kimura'
 
     within first('.card-list-item.is-unread') do
-      assert_text "komagataさんが「#{practices(:practice47).title}」の提出物を確認しました。"
+      assert_text "#{checker.login_name}さんが「#{practices(:practice47).title}」の提出物を確認しました。"
     end
   end
 end


### PR DESCRIPTION
## Issue
 
 - https://github.com/fjordllc/bootcamp/issues/4697
 
 ## 概要
 提出物を確認した際の通知機能を[abstract_notifier](https://github.com/palkan/abstract_notifier)に置き換えました。
 
 ## 変更確認方法
 
 1. ブランチ`feature/replace-checked-notice-with-abstract_notifier`をローカルに取り込む
 2. `bin/rails s`でローカル環境を立ち上げる
 3. 管理者権限のあるユーザーでログイン、未完了の提出物にアクセスした後「提出物を確認」ボタンをクリックする

      <img width="1429" alt="_development__capybaraを使ってrequest_specを書く___FBC" src="https://user-images.githubusercontent.com/99729409/189534345-45af1660-d5aa-4616-a8fe-5017d6a199f6.png">

 5. 3で提出物を確認されたユーザーでログインし、通知を確認する
      ※ 提出物を確認されたユーザー：`with-hyphen`

      <img width="1429" alt="_development__ダッシュボード___FBC" src="https://user-images.githubusercontent.com/99729409/189534518-4eb2dd15-8ea3-4307-ad51-aca19f2fbd5a.png">

 6. http://localhost:3000/letter_opener/ へアクセス

   * 件名：「Try Gitをやる」の提出物が確認されました
   * 宛先：with-hyphen@fjord.jp
   上記のメールが届いている事を確認する

      <img width="1534" alt="_development__LetterOpenerWeb" src="https://user-images.githubusercontent.com/99729409/189534667-3a2043d4-26c8-4480-8c32-aee642c3d201.png">
