### PR TITLE
研修生の日報の更新の通知の実装をabstract_notifierに置き換える

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -401,15 +401,6 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.index ["user_id"], name: "index_reactions_on_user_id"
   end
 
-  create_table "regular_event_repeat_rules", force: :cascade do |t|
-    t.bigint "regular_event_id"
-    t.integer "frequency", null: false
-    t.integer "day_of_the_week", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["regular_event_id"], name: "index_regular_event_repeat_rules_on_regular_event_id"
-  end
-
   create_table "regular_event_participations", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "regular_event_id", null: false
@@ -418,6 +409,15 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.index ["regular_event_id"], name: "index_regular_event_participations_on_regular_event_id"
     t.index ["user_id", "regular_event_id"], name: "index_user_id_and_regular_event_id", unique: true
     t.index ["user_id"], name: "index_regular_event_participations_on_user_id"
+  end
+
+  create_table "regular_event_repeat_rules", force: :cascade do |t|
+    t.bigint "regular_event_id"
+    t.integer "frequency", null: false
+    t.integer "day_of_the_week", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["regular_event_id"], name: "index_regular_event_repeat_rules_on_regular_event_id"
   end
 
   create_table "regular_events", force: :cascade do |t|
@@ -600,9 +600,9 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
   add_foreign_key "products", "users"
   add_foreign_key "questions", "practices"
   add_foreign_key "reactions", "users"
-  add_foreign_key "regular_event_repeat_rules", "regular_events"
   add_foreign_key "regular_event_participations", "regular_events"
   add_foreign_key "regular_event_participations", "users"
+  add_foreign_key "regular_event_repeat_rules", "regular_events"
   add_foreign_key "regular_events", "users"
   add_foreign_key "report_templates", "users"
   add_foreign_key "talks", "users"


### PR DESCRIPTION
## Issue
 
 - #4687
 
 ## 概要
 
 管理画面の企業一覧の企業名をリンクに置き換えました。
 ...
 
 ## 変更確認方法
 
 1. ブランチ`feature/replace-company-name-to-link`をローカルに取り込む
 2. `bin/rails s`でローカル環境を立ち上げる
 3. ...
 
 ## 変更前
 
 <img ...>
 
 ## 変更後
 
 <img ...>