### PR TITLE
Practicesテーブルのpositionカラムを削除した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -618,7 +618,7 @@ class User < ApplicationRecord
   end
 
   def practices
-    course.practices.order('courses_categories.position', 'practices.position')
+    course.practices.order('courses_categories.position', 'categories_practices.position')
   end
 
   def update_mentor_memo(new_memo)

--- a/app/views/courses/practices/sort/index.html.slim
+++ b/app/views/courses/practices/sort/index.html.slim
@@ -45,7 +45,7 @@ header.page-header
                           header.category-practices-item__header
                             .category-practices-item__title
                               .category-practices-item__title-link
-                                | #{categories_practice.practice.position}　
+                                | #{categories_practice.position}　
                                 = categories_practice.practice.title
                             .category-practices-item__grab
                               span.a-grab.js-grab

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -1,0 +1,279 @@
+categories_practice1:
+  practice: practice1
+  category: category2
+  position: 1
+
+categories_practice2:
+  practice: practice2
+  category: category4
+  position: 1
+
+categories_practice3:
+  practice: practice3
+  category: category2
+  position: 2
+
+categories_practice4:
+  practice: practice4
+  category: category4
+  position: 2
+
+categories_practice5:
+  practice: practice5
+  category: category4
+  position: 3
+
+categories_practice6:
+  practice: practice6
+  category: category4
+  position: 4
+
+categories_practice7:
+  practice: practice7
+  category: category8
+  position: 1
+
+categories_practice8:
+  practice: practice8
+  category: category8
+  position: 2
+
+categories_practice9:
+  practice: practice9
+  category: category4
+  position: 5
+
+categories_practice10:
+  practice: practice10
+  category: category4
+  position: 6
+
+categories_practice11:
+  practice: practice11
+  category: category4
+  position: 7
+
+categories_practice12:
+  practice: practice12
+  category: category4
+  position: 8
+
+categories_practice13:
+  practice: practice13
+  category: category4
+  position: 9
+
+categories_practice14:
+  practice: practice14
+  category: category16
+  position: 1
+
+categories_practice15:
+  practice: practice15
+  category: category16
+  position: 2
+
+categories_practice16:
+  practice: practice16
+  category: category15
+  position: 1
+
+categories_practice17:
+  practice: practice17
+  category: category15
+  position: 2
+
+categories_practice18:
+  practice: practice18
+  category: category16
+  position: 3
+
+categories_practice19:
+  practice: practice19
+  category: category15
+  position: 3
+
+categories_practice20:
+  practice: practice20
+  category: category7
+  position: 1
+
+categories_practice21:
+  practice: practice21
+  category: category7
+  position: 2
+
+categories_practice22:
+  practice: practice22
+  category: category7
+  position: 3
+
+categories_practice23:
+  practice: practice23
+  category: category5
+  position: 1
+
+categories_practice24:
+  practice: practice24
+  category: category5
+  position: 2
+
+categories_practice25:
+  practice: practice25
+  category: category5
+  position: 3
+
+categories_practice26:
+  practice: practice26
+  category: category5
+  position: 4
+
+categories_practice27:
+  practice: practice27
+  category: category11
+  position: 1
+
+categories_practice28:
+  practice: practice28
+  category: category9
+  position: 1
+
+categories_practice29:
+  practice: practice29
+  category: category5
+  position: 5
+
+categories_practice30:
+  practice: practice30
+  category: category5
+  position: 6
+
+categories_practice31:
+  practice: practice31
+  category: category5
+  position: 7
+
+categories_practice32:
+  practice: practice32
+  category: category5
+  position: 8
+
+categories_practice33:
+  practice: practice33
+  category: category6
+  position: 1
+
+categories_practice34:
+  practice: practice34
+  category: category6
+  position: 2
+
+categories_practice35:
+  practice: practice35
+  category: category6
+  position: 3
+
+categories_practice36:
+  practice: practice36
+  category: category6
+  position: 4
+
+categories_practice37:
+  practice: practice37
+  category: category6
+  position: 5
+
+categories_practice38:
+  practice: practice38
+  category: category6
+  position: 6
+
+categories_practice39:
+  practice: practice39
+  category: category6
+  position: 7
+
+categories_practice40:
+  practice: practice40
+  category: category6
+  position: 8
+
+categories_practice41:
+  practice: practice41
+  category: category6
+  position: 9
+
+categories_practice42:
+  practice: practice42
+  category: category6
+  position: 10
+
+categories_practice43:
+  practice: practice43
+  category: category6
+  position: 11
+
+categories_practice44:
+  practice: practice44
+  category: category9
+  position: 2
+
+categories_practice45:
+  practice: practice45
+  category: category9
+  position: 3
+
+categories_practice46:
+  practice: practice46
+  category: category9
+  position: 4
+
+categories_practice47:
+  practice: practice47
+  category: category9
+  position: 5
+
+categories_practice48:
+  practice: practice48
+  category: category11
+  position: 2
+
+categories_practice49:
+  practice: practice49
+  category: category6
+  position: 12
+
+categories_practice50:
+  practice: practice50
+  category: category6
+  position: 13
+
+categories_practice51:
+  practice: practice51
+  category: category13
+  position: 1
+
+categories_practice52:
+  practice: practice52
+  category: category17
+  position: 1
+
+categories_practice53:
+  practice: practice53
+  category: category18
+  position: 1
+
+categories_practice54:
+  practice: practice54
+  category: category19
+  position: 1
+
+categories_practice55:
+  practice: practice55
+  category: category20
+  position: 1
+
+categories_practice56:
+  practice: practice56
+  category: category21
+  position: 1

--- a/db/fixtures/practices.yml
+++ b/db/fixtures/practices.yml
@@ -4,7 +4,6 @@ practice1:
   goal: "OS X Mountain Lionをクリーンインストールする"
   memo: "「OS X Mountain Lionをクリーンインストールする」のメンターメモ"
   categories: category2
-  position: 1
   submission: true
   open_product: false
 
@@ -13,7 +12,6 @@ practice2:
   description: "description..."
   goal: "goal..."
   categories: category4
-  position: 2
   submission: true
   open_product: true
 
@@ -40,7 +38,6 @@ practice3:
     - 理解が浅いと感じたら突っ込みを入れてもいい。
 
   categories: category2
-  position: 3
 
 practice4:
   title: "Debianをインストールする"
@@ -48,7 +45,6 @@ practice4:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category4
-  position: 4
 
 practice5:
   title: "Linuxのファイル操作の基礎を覚える"
@@ -56,7 +52,6 @@ practice5:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category4
-  position: 5
   submission: true
 
 practice6:
@@ -65,7 +60,6 @@ practice6:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category4
-  position: 6
   submission: true
 
 practice7:
@@ -74,7 +68,6 @@ practice7:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category8
-  position: 7
 
 practice8:
   title: "viのチュートリアルをやる"
@@ -82,7 +75,6 @@ practice8:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category8
-  position: 8
 
 practice9:
   title: "sudoをインストールする"
@@ -90,7 +82,6 @@ practice9:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category4
-  position: 9
 
 practice10:
   title: "sshdをインストールする"
@@ -98,7 +89,6 @@ practice10:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category4
-  position: 10
 
 practice11:
   title: "リモートのサーバーにsshで鍵を使ってログインする"
@@ -106,7 +96,6 @@ practice11:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category4
-  position: 11
 
 practice12:
   title: "sshdでパスワード認証を禁止にする"
@@ -114,7 +103,6 @@ practice12:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category4
-  position: 12
 
 practice13:
   title: "sshdでrootでのログインを禁止にする"
@@ -122,7 +110,6 @@ practice13:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category4
-  position: 13
 
 practice14:
   title: "telnetを使ってget, postを試し、HTTPの基礎を理解する"
@@ -130,7 +117,6 @@ practice14:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category16
-  position: 14
 
 practice15:
   title: "HTTPのrequestとresponse、headerとbodyを理解する"
@@ -138,7 +124,6 @@ practice15:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category16
-  position: 15
 
 practice16:
   title: "nginxをインストールする"
@@ -146,7 +131,6 @@ practice16:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category15
-  position: 16
 
 practice17:
   title: "nginxにネームベースのVirtualHostを使ってサイトを作る"
@@ -154,7 +138,6 @@ practice17:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category15
-  position: 17
 
 practice18:
   title: "sslの基礎を理解する"
@@ -162,7 +145,6 @@ practice18:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category16
-  position: 18
 
 practice19:
   title: "nginxで自己認証した証明書を使ったssl対応サイトを作る"
@@ -170,7 +152,6 @@ practice19:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category15
-  position: 19
 
 practice20:
   title: "sqlの基礎を理解する"
@@ -178,7 +159,6 @@ practice20:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category7
-  position: 20
 
 practice21:
   title: "mysqlをインストールする"
@@ -186,7 +166,6 @@ practice21:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category7
-  position: 21
 
 practice22:
   title: "mysql, mysqladminコマンドでユーザー、データベース、テーブルを作成する"
@@ -194,7 +173,6 @@ practice22:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category7
-  position: 22
 
 practice23:
   title: "rubyをインストールする"
@@ -202,7 +180,6 @@ practice23:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category5
-  position: 23
 
 practice24:
   title: "rbenvをインストールする"
@@ -210,7 +187,6 @@ practice24:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category5
-  position: 24
 
 practice25:
   title: "rbenvで複数バージョンのrubyを切り替えれるようにする"
@@ -218,7 +194,6 @@ practice25:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category5
-  position: 25
 
 practice26:
   title: "「プログラミング入門 - Rubyを使って」をやる"
@@ -226,7 +201,6 @@ practice26:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category5
-  position: 26
 
 practice27:
   title: "「プログラミング入門 - Rubyを使って」をgithubにpushする"
@@ -234,7 +208,6 @@ practice27:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category11
-  position: 27
 
 practice28:
   title: "「プログラミング入門 - Rubyを使って」のテストをtestunitで書く"
@@ -242,7 +215,6 @@ practice28:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category9
-  position: 28
 
 practice29:
   title: "rubygemsの基礎を理解する"
@@ -250,7 +222,6 @@ practice29:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category5
-  position: 29
 
 practice30:
   title: "gemコマンドを使ってgemのインストール、更新、削除をする"
@@ -258,7 +229,6 @@ practice30:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category5
-  position: 30
 
 practice31:
   title: "rakeの基礎を理解する"
@@ -266,7 +236,6 @@ practice31:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category5
-  position: 31
 
 practice32:
   title: "rakeでCプログラムをコンパイルするRakefileを書く"
@@ -274,7 +243,6 @@ practice32:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category5
-  position: 32
 
 practice33:
   title: "Getting Started with RailsにしたがってRailsアプリを作る"
@@ -282,7 +250,6 @@ practice33:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 33
 
 practice34:
   title: "ActionControllerを理解する"
@@ -290,7 +257,6 @@ practice34:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 34
 
 practice35:
   title: "ActionViewを理解する"
@@ -298,7 +264,6 @@ practice35:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 35
 
 practice36:
   title: "ActiveRecordを理解する"
@@ -306,7 +271,6 @@ practice36:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 36
 
 practice37:
   title: "ActiveSupportを理解する"
@@ -314,7 +278,6 @@ practice37:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 37
 
 practice38:
   title: "Railsのroutesを理解する"
@@ -322,7 +285,6 @@ practice38:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 38
 
 practice39:
   title: "Railsのi18nの基礎を理解する"
@@ -330,7 +292,6 @@ practice39:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 39
 
 practice40:
   title: "deviseを使ってユーザー認証を作る"
@@ -338,7 +299,6 @@ practice40:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 40
 
 practice41:
   title: "deviseを使ってTwitter認証を作る"
@@ -346,7 +306,6 @@ practice41:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 41
 
 practice42:
   title: "exception_notificationを使ってエラーのメール通知機能を作る"
@@ -354,7 +313,6 @@ practice42:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 42
 
 practice43:
   title: "paperclipを使って画像アップロード機能を作る"
@@ -362,7 +320,6 @@ practice43:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 43
 
 practice44:
   title: "TDDの基礎を理解する"
@@ -370,7 +327,6 @@ practice44:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category9
-  position: 44
 
 practice45:
   title: "unittestの基礎を理解する"
@@ -378,7 +334,6 @@ practice45:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category9
-  position: 45
 
 practice46:
   title: "rspecを使ってRailsアプリのテストを書く"
@@ -386,7 +341,6 @@ practice46:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category9
-  position: 46
 
 practice47:
   title: "capybaraを使ってrequest specを書く"
@@ -394,7 +348,6 @@ practice47:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category9
-  position: 47
 
 practice48:
   title: "Try Gitをやる"
@@ -402,7 +355,6 @@ practice48:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category11
-  position: 48
 
 practice49:
   title: "unicornを使ってrailsアプリを動かす"
@@ -410,7 +362,6 @@ practice49:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 49
 
 practice50:
   title: "capistranoを使ってrailsアプリをデプロイする"
@@ -418,7 +369,6 @@ practice50:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category6
-  position: 50
 
 practice51:
   title: "iOSプログラミング入門"
@@ -426,7 +376,6 @@ practice51:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category13
-  position: 51
 
 practice52:
   title: "Unityのインストール"
@@ -434,7 +383,6 @@ practice52:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category17
-  position: 52
   include_progress: false
 
 practice53:
@@ -443,7 +391,6 @@ practice53:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category18
-  position: 53
   include_progress: false
 
 practice54:
@@ -452,7 +399,6 @@ practice54:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category19
-  position: 54
   include_progress: false
 
 practice55:
@@ -461,7 +407,6 @@ practice55:
   goal: "goal..."
   memo: "memo for mentors..."
   categories: category20
-  position: 55
   last_updated_user: komagata
 
 practice56:
@@ -469,6 +414,5 @@ practice56:
   description: "ユーザーネーム（最終更新者）で検索できるよ"
   goal: "goal..."
   categories: category21
-  position: 56
   include_progress: false
   last_updated_user: machida

--- a/db/fixtures/practices.yml
+++ b/db/fixtures/practices.yml
@@ -3,7 +3,6 @@ practice1:
   description: "description..."
   goal: "OS X Mountain Lionをクリーンインストールする"
   memo: "「OS X Mountain Lionをクリーンインストールする」のメンターメモ"
-  categories: category2
   submission: true
   open_product: false
 
@@ -11,7 +10,6 @@ practice2:
   title: "Terminalの基礎を覚える"
   description: "description..."
   goal: "goal..."
-  categories: category4
   submission: true
   open_product: true
 
@@ -37,21 +35,18 @@ practice3:
     - CPUとメモリの違いを把握しているかチェックする。
     - 理解が浅いと感じたら突っ込みを入れてもいい。
 
-  categories: category2
 
 practice4:
   title: "Debianをインストールする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category4
 
 practice5:
   title: "Linuxのファイル操作の基礎を覚える"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category4
   submission: true
 
 practice6:
@@ -59,7 +54,6 @@ practice6:
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category4
   submission: true
 
 practice7:
@@ -67,322 +61,276 @@ practice7:
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category8
 
 practice8:
   title: "viのチュートリアルをやる"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category8
 
 practice9:
   title: "sudoをインストールする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category4
 
 practice10:
   title: "sshdをインストールする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category4
 
 practice11:
   title: "リモートのサーバーにsshで鍵を使ってログインする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category4
 
 practice12:
   title: "sshdでパスワード認証を禁止にする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category4
 
 practice13:
   title: "sshdでrootでのログインを禁止にする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category4
 
 practice14:
   title: "telnetを使ってget, postを試し、HTTPの基礎を理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category16
 
 practice15:
   title: "HTTPのrequestとresponse、headerとbodyを理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category16
 
 practice16:
   title: "nginxをインストールする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category15
 
 practice17:
   title: "nginxにネームベースのVirtualHostを使ってサイトを作る"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category15
 
 practice18:
   title: "sslの基礎を理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category16
 
 practice19:
   title: "nginxで自己認証した証明書を使ったssl対応サイトを作る"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category15
 
 practice20:
   title: "sqlの基礎を理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category7
 
 practice21:
   title: "mysqlをインストールする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category7
 
 practice22:
   title: "mysql, mysqladminコマンドでユーザー、データベース、テーブルを作成する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category7
 
 practice23:
   title: "rubyをインストールする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category5
 
 practice24:
   title: "rbenvをインストールする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category5
 
 practice25:
   title: "rbenvで複数バージョンのrubyを切り替えれるようにする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category5
 
 practice26:
   title: "「プログラミング入門 - Rubyを使って」をやる"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category5
 
 practice27:
   title: "「プログラミング入門 - Rubyを使って」をgithubにpushする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category11
 
 practice28:
   title: "「プログラミング入門 - Rubyを使って」のテストをtestunitで書く"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category9
 
 practice29:
   title: "rubygemsの基礎を理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category5
 
 practice30:
   title: "gemコマンドを使ってgemのインストール、更新、削除をする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category5
 
 practice31:
   title: "rakeの基礎を理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category5
 
 practice32:
   title: "rakeでCプログラムをコンパイルするRakefileを書く"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category5
 
 practice33:
   title: "Getting Started with RailsにしたがってRailsアプリを作る"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice34:
   title: "ActionControllerを理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice35:
   title: "ActionViewを理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice36:
   title: "ActiveRecordを理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice37:
   title: "ActiveSupportを理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice38:
   title: "Railsのroutesを理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice39:
   title: "Railsのi18nの基礎を理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice40:
   title: "deviseを使ってユーザー認証を作る"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice41:
   title: "deviseを使ってTwitter認証を作る"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice42:
   title: "exception_notificationを使ってエラーのメール通知機能を作る"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice43:
   title: "paperclipを使って画像アップロード機能を作る"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice44:
   title: "TDDの基礎を理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category9
 
 practice45:
   title: "unittestの基礎を理解する"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category9
 
 practice46:
   title: "rspecを使ってRailsアプリのテストを書く"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category9
 
 practice47:
   title: "capybaraを使ってrequest specを書く"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category9
 
 practice48:
   title: "Try Gitをやる"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category11
 
 practice49:
   title: "unicornを使ってrailsアプリを動かす"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice50:
   title: "capistranoを使ってrailsアプリをデプロイする"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category6
 
 practice51:
   title: "iOSプログラミング入門"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category13
 
 practice52:
   title: "Unityのインストール"
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category17
   include_progress: false
 
 practice53:
@@ -390,7 +338,6 @@ practice53:
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category18
   include_progress: false
 
 practice54:
@@ -398,7 +345,6 @@ practice54:
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category19
   include_progress: false
 
 practice55:
@@ -406,13 +352,11 @@ practice55:
   description: "ユーザーネーム（最終更新者）で検索できるよ"
   goal: "goal..."
   memo: "memo for mentors..."
-  categories: category20
   last_updated_user: komagata
 
 practice56:
   title: "Unityでのテスト"
   description: "ユーザーネーム（最終更新者）で検索できるよ"
   goal: "goal..."
-  categories: category21
   include_progress: false
   last_updated_user: machida

--- a/db/migrate/20220911042216_remove_position_from_practice.rb
+++ b/db/migrate/20220911042216_remove_position_from_practice.rb
@@ -1,0 +1,5 @@
+class RemovePositionFromPractice < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :practices, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -332,12 +332,12 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.datetime "updated_at"
     t.text "goal"
     t.integer "category_id"
-    t.integer "position"
     t.boolean "submission", default: false, null: false
     t.boolean "open_product", default: false, null: false
     t.boolean "include_progress", default: true, null: false
     t.text "memo"
     t.integer "last_updated_user_id"
+    t.integer "position"
     t.index ["category_id"], name: "index_practices_on_category_id"
   end
 
@@ -401,15 +401,6 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.index ["user_id"], name: "index_reactions_on_user_id"
   end
 
-  create_table "regular_event_repeat_rules", force: :cascade do |t|
-    t.bigint "regular_event_id"
-    t.integer "frequency", null: false
-    t.integer "day_of_the_week", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["regular_event_id"], name: "index_regular_event_repeat_rules_on_regular_event_id"
-  end
-
   create_table "regular_event_participations", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "regular_event_id", null: false
@@ -418,6 +409,15 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.index ["regular_event_id"], name: "index_regular_event_participations_on_regular_event_id"
     t.index ["user_id", "regular_event_id"], name: "index_user_id_and_regular_event_id", unique: true
     t.index ["user_id"], name: "index_regular_event_participations_on_user_id"
+  end
+
+  create_table "regular_event_repeat_rules", force: :cascade do |t|
+    t.bigint "regular_event_id"
+    t.integer "frequency", null: false
+    t.integer "day_of_the_week", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["regular_event_id"], name: "index_regular_event_repeat_rules_on_regular_event_id"
   end
 
   create_table "regular_events", force: :cascade do |t|
@@ -600,9 +600,9 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
   add_foreign_key "products", "users"
   add_foreign_key "questions", "practices"
   add_foreign_key "reactions", "users"
-  add_foreign_key "regular_event_repeat_rules", "regular_events"
   add_foreign_key "regular_event_participations", "regular_events"
   add_foreign_key "regular_event_participations", "users"
+  add_foreign_key "regular_event_repeat_rules", "regular_events"
   add_foreign_key "regular_events", "users"
   add_foreign_key "report_templates", "users"
   add_foreign_key "talks", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -400,6 +400,15 @@ ActiveRecord::Schema.define(version: 2022_09_11_042216) do
     t.index ["user_id"], name: "index_reactions_on_user_id"
   end
 
+  create_table "regular_event_repeat_rules", force: :cascade do |t|
+    t.bigint "regular_event_id"
+    t.integer "frequency", null: false
+    t.integer "day_of_the_week", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["regular_event_id"], name: "index_regular_event_repeat_rules_on_regular_event_id"
+  end
+
   create_table "regular_event_participations", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "regular_event_id", null: false
@@ -408,15 +417,6 @@ ActiveRecord::Schema.define(version: 2022_09_11_042216) do
     t.index ["regular_event_id"], name: "index_regular_event_participations_on_regular_event_id"
     t.index ["user_id", "regular_event_id"], name: "index_user_id_and_regular_event_id", unique: true
     t.index ["user_id"], name: "index_regular_event_participations_on_user_id"
-  end
-
-  create_table "regular_event_repeat_rules", force: :cascade do |t|
-    t.bigint "regular_event_id"
-    t.integer "frequency", null: false
-    t.integer "day_of_the_week", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["regular_event_id"], name: "index_regular_event_repeat_rules_on_regular_event_id"
   end
 
   create_table "regular_events", force: :cascade do |t|
@@ -599,9 +599,9 @@ ActiveRecord::Schema.define(version: 2022_09_11_042216) do
   add_foreign_key "products", "users"
   add_foreign_key "questions", "practices"
   add_foreign_key "reactions", "users"
+  add_foreign_key "regular_event_repeat_rules", "regular_events"
   add_foreign_key "regular_event_participations", "regular_events"
   add_foreign_key "regular_event_participations", "users"
-  add_foreign_key "regular_event_repeat_rules", "regular_events"
   add_foreign_key "regular_events", "users"
   add_foreign_key "report_templates", "users"
   add_foreign_key "talks", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_05_085844) do
+ActiveRecord::Schema.define(version: 2022_09_11_042216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -337,7 +337,6 @@ ActiveRecord::Schema.define(version: 2022_07_05_085844) do
     t.boolean "include_progress", default: true, null: false
     t.text "memo"
     t.integer "last_updated_user_id"
-    t.integer "position"
     t.index ["category_id"], name: "index_practices_on_category_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,7 @@ tables = %i[
   articles
   bookmarks
   categories
+  categories_practices
   checks
   comments
   companies


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/4246

## Description
> [カテゴリー・プラクティスの並び順 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/%E3%82%AB%E3%83%86%E3%82%B4%E3%83%AA%E3%83%BC%E3%83%BB%E3%83%97%E3%83%A9%E3%82%AF%E3%83%86%E3%82%A3%E3%82%B9%E3%81%AE%E4%B8%A6%E3%81%B3%E9%A0%86)

上記ルールに沿ってプラクティスの並び順が正しく適用されるようにした。
行ったことは下記。

- Practicesテーブルのpositionカラムを削除する
- practice.positionを参照している箇所を`categories_practices.position`を参照するように変更
※ practice.positionが参照されているのは２箇所のみで画面に影響のあるファイルは`app/views/courses/practices/sort/index.html.slim`のみでした

## 変更点

### 変更前
![image](https://user-images.githubusercontent.com/70259961/189527657-5d908c5f-17d9-4f8d-9a18-36a3e1533984.png)

#### 変更前の全てのプラクティスの並び順
https://i.gyazo.com/3516acad8d6f07ad7884d9fa9a096482.mp4


### 変更後
![image](https://user-images.githubusercontent.com/70259961/189527957-42a66c2b-c8b5-47f7-b39b-ebd2b10b59a9.png)

#### 変更後の全てのプラクティスの並び順
https://i.gyazo.com/c8ee7fa85036ab223f376cab8d6b601c.mp4

## 確認方法
1. ローカルに`bug/delete-position-column-from-practices`を取り込む
2. `bin/setup`
3. `bin/rails s`
4. komagataでログイン
5. `/courses/:id/practices/sort`へ遷移
6. 並び順が上記写真の通りになっているか確認する