### PR TITLE
管理者・メンターにユーザー一覧に退会、休会のタブを表示するようにした

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -31,7 +31,7 @@ class API::UsersController < API::BaseController
 
     @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
 
-    @users = @users.unhibernated.unretired unless @company || check_target_if_hibernated_or_retired
+    @users = @users.unhibernated.unretired unless @company || hibernated_or_retired_target?
   end
 
   def show; end
@@ -62,6 +62,10 @@ class API::UsersController < API::BaseController
 
   def check_target_if_hibernated_or_retired
     true if @target == 'hibernated' || @target == 'retired'
+  end
+
+  def hibernated_or_retired_target?
+    @target == 'hibernated' || @target == 'retired'
   end
 
   def target_allowlist

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -31,7 +31,7 @@ class API::UsersController < API::BaseController
 
     @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
 
-    check_users_to_display
+    @users = @users.unhibernated.unretired unless @company || check_target_if_hibernated_or_retired
   end
 
   def show; end
@@ -58,6 +58,10 @@ class API::UsersController < API::BaseController
     else
       @users = @users.unhibernated.unretired
     end
+  end
+
+  def check_target_if_hibernated_or_retired
+    true if @target == 'hibernated' || @target == 'retired'
   end
 
   def target_allowlist

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -30,6 +30,8 @@ class API::UsersController < API::BaseController
                          .order(updated_at: :desc)
 
     @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
+
+    check_users_to_display
   end
 
   def show; end
@@ -50,11 +52,19 @@ class API::UsersController < API::BaseController
     users
   end
 
+  def check_users_to_display
+    if @target == 'hibernated' || @target == 'retired' || @company
+      @users
+    else
+      @users = @users.unhibernated.unretired
+    end
+  end
+
   def target_allowlist
     target_allowlist = %w[student_and_trainee followings mentor graduate adviser trainee year_end_party]
     target_allowlist.push('job_seeking') if current_user.adviser?
     target_allowlist.push('all') if @company
-    target_allowlist.concat(%w[job_seeking retired inactive all]) if current_user.mentor? || current_user.admin?
+    target_allowlist.concat(%w[job_seeking hibernated retired inactive all]) if current_user.mentor? || current_user.admin?
     target_allowlist
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -19,6 +19,8 @@ class API::UsersController < API::BaseController
         User.tagged_with(@tag)
       elsif @company
         User.where(company_id: @company).users_role(@target)
+      elsif @target == 'hibernated'
+        User.users_role(@target)
       elsif @target == 'retired'
         User.users_role(@target)
       else
@@ -31,7 +33,7 @@ class API::UsersController < API::BaseController
 
     @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
 
-    @users = @users.unhibernated.unretired unless @company || @target.in?(%w[hibernated retired])
+    # @users = @users.unhibernated.unretired unless @company || @target.in?(%w[hibernated retired])
   end
 
   def show; end
@@ -50,22 +52,6 @@ class API::UsersController < API::BaseController
     users = target_users.search_by_keywords({ word: search_word })
     users = User.search_by_keywords({ word: search_word }).unscope(where: :retired_on).users_role(target) if target == 'retired'
     users
-  end
-
-  def check_users_to_display
-    if @target == 'hibernated' || @target == 'retired' || @company
-      @users
-    else
-      @users = @users.unhibernated.unretired
-    end
-  end
-
-  def check_target_if_hibernated_or_retired
-    true if @target == 'hibernated' || @target == 'retired'
-  end
-
-  def hibernated_or_retired_target?
-    @target == 'hibernated' || @target == 'retired'
   end
 
   def target_allowlist

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -19,9 +19,7 @@ class API::UsersController < API::BaseController
         User.tagged_with(@tag)
       elsif @company
         User.where(company_id: @company).users_role(@target)
-      elsif @target == 'hibernated'
-        User.users_role(@target)
-      elsif @target == 'retired'
+      elsif @target.in? %w[hibernated retired]
         User.users_role(@target)
       else
         User.users_role(@target).unhibernated.unretired
@@ -32,8 +30,6 @@ class API::UsersController < API::BaseController
                          .order(updated_at: :desc)
 
     @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
-
-    # @users = @users.unhibernated.unretired unless @company || @target.in?(%w[hibernated retired])
   end
 
   def show; end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -31,7 +31,7 @@ class API::UsersController < API::BaseController
 
     @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
 
-    @users = @users.unhibernated.unretired unless @company || hibernated_or_retired_target?
+    @users = @users.unhibernated.unretired unless @company || @target.in?(%w[hibernated retired])
   end
 
   def show; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,8 @@ class UsersController < ApplicationController
              .preload(:avatar_attachment, :course, :taggings)
              .order(updated_at: :desc)
 
+    check_users_to_display
+
     @random_tags = User.tags.sample(20)
     @top3_tags_counts = User.tags.limit(3).map(&:count).uniq
     @tag = ActsAsTaggableOn::Tag.find_by(name: params[:tag])
@@ -71,10 +73,18 @@ class UsersController < ApplicationController
 
   private
 
+  def check_users_to_display
+    if @target == 'hibernated' || @target == 'retired'
+      @users
+    else
+      @users = @users.unhibernated.unretired
+    end
+  end
+
   def target_allowlist
     target_allowlist = %w[student_and_trainee followings mentor graduate adviser trainee year_end_party]
     target_allowlist.push('job_seeking') if current_user.adviser?
-    target_allowlist.concat(%w[job_seeking retired inactive all]) if current_user.mentor? || current_user.admin?
+    target_allowlist.concat(%w[job_seeking hibernated retired inactive all]) if current_user.mentor? || current_user.admin?
     target_allowlist
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
              .preload(:avatar_attachment, :course, :taggings)
              .order(updated_at: :desc)
 
-    check_users_to_display
+    @users = @users.unhibernated.unretired unless check_target_if_hibernated_or_retired
 
     @random_tags = User.tags.sample(20)
     @top3_tags_counts = User.tags.limit(3).map(&:count).uniq
@@ -73,12 +73,8 @@ class UsersController < ApplicationController
 
   private
 
-  def check_users_to_display
-    if @target == 'hibernated' || @target == 'retired'
-      @users
-    else
-      @users = @users.unhibernated.unretired
-    end
+  def check_target_if_hibernated_or_retired
+    true if @target == 'hibernated' || @target == 'retired'
   end
 
   def target_allowlist

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,10 +17,8 @@ class UsersController < ApplicationController
         current_user.followees_list(watch: @watch)
       elsif params[:tag]
         User.tagged_with(params[:tag])
-      elsif @target == 'retired'
-        User.users_role(@target)
       else
-        User.users_role(@target).unretired
+        User.users_role(@target)
       end
 
     @users = target_users
@@ -28,7 +26,7 @@ class UsersController < ApplicationController
              .preload(:avatar_attachment, :course, :taggings)
              .order(updated_at: :desc)
 
-    @users = @users.unhibernated.unretired unless hibernated_or_retired_target?
+    @users = @users.unhibernated.unretired unless @target.in? %w[hibernated retired]
 
     @random_tags = User.tags.sample(20)
     @top3_tags_counts = User.tags.limit(3).map(&:count).uniq
@@ -72,10 +70,6 @@ class UsersController < ApplicationController
   end
 
   private
-
-  def hibernated_or_retired_target?
-    @target == 'hibernated' || @target == 'retired'
-  end
 
   def target_allowlist
     target_allowlist = %w[student_and_trainee followings mentor graduate adviser trainee year_end_party]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
              .preload(:avatar_attachment, :course, :taggings)
              .order(updated_at: :desc)
 
-    @users = @users.unhibernated.unretired unless check_target_if_hibernated_or_retired
+    @users = @users.unhibernated.unretired unless hibernated_or_retired_target?
 
     @random_tags = User.tags.sample(20)
     @top3_tags_counts = User.tags.limit(3).map(&:count).uniq
@@ -73,8 +73,8 @@ class UsersController < ApplicationController
 
   private
 
-  def check_target_if_hibernated_or_retired
-    true if @target == 'hibernated' || @target == 'retired'
+  def hibernated_or_retired_target?
+    @target == 'hibernated' || @target == 'retired'
   end
 
   def target_allowlist

--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -12,9 +12,9 @@ nav.tab-nav
         - if current_user.admin?
           - targets += %w[retired]
         - if current_user.mentor?
-          - targets += %w[job_seeking all]
+          - targets += %w[job_seeking hibernated retired all]
         - elsif current_user.adviser?
           - targets += %w[job_seeking]
         - targets.each do |target|
-          li.tab-nav__item(class="#{%w[job_seeking retired all].include?(target) ? 'is-only-mentor is-only-adviser' : ''}")
+          li.tab-nav__item(class="#{%w[job_seeking hibernated retired all].include?(target) ? 'is-only-mentor is-only-adviser' : ''}")
             = link_to t("target.#{target}"), users_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -9,8 +9,6 @@ nav.tab-nav
             = link_to t("watch.#{watch}"), users_path(target: @target, watch: watch), class: (@watch == watch ? ['is-active'] : []) << 'tab-nav__item-link'
       - else
         - targets = %w[student_and_trainee mentor graduate adviser trainee]
-        - if current_user.admin?
-          - targets += %w[retired]
         - if current_user.mentor?
           - targets += %w[job_seeking hibernated retired all]
         - elsif current_user.adviser?

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -578,4 +578,22 @@ class UsersTest < ApplicationSystemTestCase
     user = users(:hajime)
     assert_match(/#{user.id}\.png$/, img.native['src'])
   end
+
+  test 'mentor can see retired and hibernated tabs' do
+    visit_with_auth '/users', 'mentormentaro'
+    has_link?('休会')
+    has_link?('退会')
+  end
+
+  test 'admin can see retired and hibernated tabs' do
+    visit_with_auth '/users', 'komagata'
+    has_link?('休会')
+    has_link?('退会')
+  end
+
+  test 'if the user is not admin or mentor, the user cannot see retired and hibernated tabs' do
+    visit_with_auth '/users', 'sotugyou'
+    has_no_link?('休会')
+    has_no_link?('退会')
+  end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -3,11 +3,6 @@
 require 'application_system_test_case'
 
 class UsersTest < ApplicationSystemTestCase
-  setup do
-    @hibernated_url = '/users?target=hibernated'
-    @retired_url = '/users?target=retired'
-  end
-
   test 'show listing all users' do
     visit_with_auth users_path, 'kimura'
     assert_equal '全てのユーザー | FBC', title
@@ -586,19 +581,19 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'mentor can see retired and hibernated tabs' do
     visit_with_auth '/users', 'mentormentaro'
-    assert_link '休会', href: @hibernated_url
-    assert_link '退会', href: @retired_url
+    assert_link '休会', href: '/users?target=hibernated'
+    assert_link '退会', href: '/users?target=retired'
   end
 
   test 'admin can see retired and hibernated tabs' do
     visit_with_auth '/users', 'komagata'
-    assert_link '休会', href: @hibernated_url
-    assert_link '退会', href: @retired_url
+    assert_link '休会', href: '/users?target=hibernated'
+    assert_link '退会', href: '/users?target=retired'
   end
 
   test 'if the user is not admin or mentor, the user cannot see retired and hibernated tabs' do
     visit_with_auth '/users', 'sotugyou'
-    assert_no_link '休会', href: @hibernated_url
-    assert_no_link '退会', href: @retired_url
+    assert_no_link '休会', href: '/users?target=hibernated'
+    assert_no_link '退会', href: '/users?target=retired'
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -3,6 +3,11 @@
 require 'application_system_test_case'
 
 class UsersTest < ApplicationSystemTestCase
+  setup do
+    @hibernated_url = '/users?target=hibernated'
+    @retired_url = '/users?target=retired'
+  end
+
   test 'show listing all users' do
     visit_with_auth users_path, 'kimura'
     assert_equal '全てのユーザー | FBC', title
@@ -581,19 +586,19 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'mentor can see retired and hibernated tabs' do
     visit_with_auth '/users', 'mentormentaro'
-    has_link?('休会')
-    has_link?('退会')
+    assert_link '休会', href: @hibernated_url
+    assert_link '退会', href: @retired_url
   end
 
   test 'admin can see retired and hibernated tabs' do
     visit_with_auth '/users', 'komagata'
-    has_link?('休会')
-    has_link?('退会')
+    assert_link '休会', href: @hibernated_url
+    assert_link '退会', href: @retired_url
   end
 
   test 'if the user is not admin or mentor, the user cannot see retired and hibernated tabs' do
     visit_with_auth '/users', 'sotugyou'
-    has_no_link?('休会')
-    has_no_link?('退会')
+    assert_no_link '休会', href: @hibernated_url
+    assert_no_link '退会', href: @retired_url
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -591,7 +591,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_link '退会', href: '/users?target=retired'
   end
 
-  test 'if the user is not admin or mentor, the user cannot see retired and hibernated tabs' do
+  test 'user can not see retired and hibernated tabs if the user is not admin or mentor' do
     visit_with_auth '/users', 'sotugyou'
     assert_no_link '休会', href: '/users?target=hibernated'
     assert_no_link '退会', href: '/users?target=retired'


### PR DESCRIPTION
## Issue
- #5404

## 概要
ユーザー一覧に管理者とメンターだけが見れる退会、休会のタブを表示するようにしました。

## 変更前
全員のタブのみ。
![image](https://user-images.githubusercontent.com/49633473/190722875-31ce4c94-94a7-43e9-b73b-7c1b41791bf2.png)
## 変更後
管理者とメンターには休会、退会のタブが表示されている。
![image](https://user-images.githubusercontent.com/49633473/190722349-434d1b46-18dd-46ec-8221-38b8283f5f15.png)


## 確認方法
1. `feature/display-tabs-for-retired-and-hibernation-to-administrators-and-mentors`をローカルに取り込む
1. `bin/setup`実行
1. `bin/rails s`でサーバーを立ち上げる
2. `mentormentaro`でログインする
1. ユーザーのページにいき、休会と退会のタブが表示されていることを確認する