### PR TITLE
Q＆Aの回答がきた通知処理をnewspaperに置き換えた

### DIFF
--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -29,6 +29,7 @@ class API::AnswersController < API::BaseController
     @answer = question.answers.new(answer_params)
     @answer.user = current_user
     if @answer.save
+      Newspaper.publish(:answer_create, @answer)
       render :create, status: :created
     else
       head :bad_request

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -2,7 +2,6 @@
 
 class AnswerCallbacks
   def after_create(answer)
-    notify_answer(answer)
     create_watch(answer)
     notify_to_watching_user(answer)
   end
@@ -18,15 +17,6 @@ class AnswerCallbacks
   end
 
   private
-
-  def notify_answer(answer)
-    return if answer.sender == answer.receiver
-
-    question = answer.question
-    watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
-    mention_user_ids = answer.new_mention_users.ids
-    NotificationFacade.came_answer(answer) if watcher_ids.concat(mention_user_ids).exclude?(answer.receiver.id)
-  end
 
   def notify_to_watching_user(answer)
     question = Question.find(answer.question_id)

--- a/app/models/answer_notifier.rb
+++ b/app/models/answer_notifier.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AnswerNotifier
+  def call(answer)
+    return if answer.sender == answer.receiver
+
+    question = answer.question
+    watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
+    mention_user_ids = answer.new_mention_users.ids
+    NotificationFacade.came_answer(answer) if watcher_ids.concat(mention_user_ids).exclude?(answer.receiver.id)
+  end
+end

--- a/config/initializers/newspaer.rb
+++ b/config/initializers/newspaer.rb
@@ -1,5 +1,6 @@
 Rails.configuration.to_prepare do
   Newspaper.subscribe(:event_create, EventOrganizerWatcher.new)
+  Newspaper.subscribe(:answer_create, AnswerNotifier.new)
 
   sad_streak_updater = SadStreakUpdater.new
   Newspaper.subscribe(:report_create, sad_streak_updater)


### PR DESCRIPTION
## Issue

- #5495   

## 概要

Q＆Aのページで質問に対して回答が来た際の質問者への通知処理をnewspaperに置き換えました。
（Watch中の人への通知は別issueが立てられているため本issueでは対応しません）

## 変更点
見た目上の変更はありません。

## 変更確認方法

1. ブランチ`feature/replace-q-and-a-response-notification-with-newspaper`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3.  `kimura`（ほか任意のアカウントでもOK)でログインし、http://localhost:3000/questions/new へアクセスする
4. テスト用の質問を作成、投稿する
5. `kimura`をログアウトする
6. 別のアカウント`hajime`（ほか任意のアカウントでもOK)で再度ログインする
7.  4.で作成した質問へテスト用の回答を投稿する
8. `hajime`をログアウトする
9. `kimura`(4で質問を投稿したアカウント）で再ログインし、7.の回答が以下のように質問者へ正常に通知されることを確認する。
![image](https://user-images.githubusercontent.com/58751858/190119423-6d0da560-027e-4ec2-a52f-22032750eded.png)
10. http://localhost:3000/notifications でも9.と同様の通知が到着することを確認してください🙏✨
![image](https://user-images.githubusercontent.com/58751858/190120256-b3a3456c-9a01-4b12-8361-99bb89eeb85e.png)

