### PR TITLE
ベストアンサーの通知をabstract_notifierに置換した

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -89,13 +89,24 @@ class Notification < ApplicationRecord
       )
     end
 
-    def chose_correct_answer(answer, receiver)
+    def following_report(report, receiver)
       Notification.create!(
-        kind: kinds[:chose_correct_answer],
+        kind: kinds[:following_report],
         user: receiver,
-        sender: answer.receiver,
-        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
-        message: "#{answer.receiver.login_name}さんの質問【 #{answer.question.title} 】で#{answer.sender.login_name}さんの回答がベストアンサーに選ばれました。",
+        sender: report.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(report),
+        message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
+        read: false
+      )
+    end
+
+    def product_update(product, receiver)
+      Notification.create!(
+        kind: 17,
+        user: receiver,
+        sender: product.user,
+        link: Rails.application.routes.url_helpers.polymorphic_path(product),
+        message: "#{product.user.login_name}さんの提出物が更新されました",
         read: false
       )
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -89,6 +89,17 @@ class Notification < ApplicationRecord
       )
     end
 
+    def chose_correct_answer(answer, receiver)
+      Notification.create!(
+        kind: kinds[:chose_correct_answer],
+        user: receiver,
+        sender: answer.receiver,
+        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
+        message: "#{answer.receiver.login_name}さんの質問【 #{answer.question.title} 】で#{answer.sender.login_name}さんの回答がベストアンサーに選ばれました。",
+        read: false
+      )
+    end
+
     def product_update(product, receiver)
       Notification.create!(
         kind: 17,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -67,17 +67,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def came_answer(answer)
-      Notification.create!(
-        kind: kinds[:answered],
-        user: answer.receiver,
-        sender: answer.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
-        message: "#{answer.user.login_name}さんから回答がありました。",
-        read: false
-      )
-    end
-
     def moved_up_event_waiting_user(event, receiver)
       Notification.create!(
         kind: kinds[:moved_up_event_waiting_user],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -156,7 +156,7 @@ class NotificationFacade
   end
 
   def self.chose_correct_answer(answer, receiver)
-    Notification.chose_correct_answer(answer, receiver)
+    ActivityNotifier.with(answer: answer, receiver: receiver).came_question.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -156,7 +156,7 @@ class NotificationFacade
   end
 
   def self.chose_correct_answer(answer, receiver)
-    ActivityNotifier.with(answer: answer, receiver: receiver).came_question.notify_now
+    ActivityNotifier.with(answer: answer, receiver: receiver).chose_correct_answer.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -202,6 +202,21 @@ class ActivityNotifier < ApplicationNotifier
     )
   end
 
+  def chose_correct_answer(params = {})
+    params.merge!(@params)
+    answer = params[:answer]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{answer.receiver.login_name}さんの質問【 #{answer.question.title} 】で#{answer.sender.login_name}さんの回答がベストアンサーに選ばれました。",
+      kind: :chose_correct_answer,
+      sender: answer.receiver,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
+      read: false
+    )
+  end
+
   def following_report(params = {})
     params.merge!(@params)
     report = params[:report]

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -202,6 +202,7 @@ class ActivityNotifier < ApplicationNotifier
     )
   end
 
+<<<<<<< HEAD
   def following_report(params = {})
     params.merge!(@params)
     report = params[:report]
@@ -218,6 +219,9 @@ class ActivityNotifier < ApplicationNotifier
   end
 
   def came_answer(params = {})
+=======
+  def chose_correct_answer(params = {})
+>>>>>>> メソッド名を修正した
     params.merge!(@params)
     answer = params[:answer]
 
@@ -242,67 +246,6 @@ class ActivityNotifier < ApplicationNotifier
       sender: sender,
       receiver: receiver,
       link: Rails.application.routes.url_helpers.polymorphic_path(sender),
-      read: false
-    )
-  end
-
-  def checked(params = {})
-    params.merge!(@params)
-    check = params[:check]
-    receiver = params[:receiver]
-
-    notification(
-      body: "#{check.sender.login_name}さんが#{check.checkable.title}を確認しました。",
-      kind: :checked,
-      receiver: receiver,
-      sender: check.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(check.checkable),
-      read: false
-    )
-  end
-
-  def trainee_report(params = {})
-    params.merge!(@params)
-    report = params[:report]
-    receiver = params[:receiver]
-
-    notification(
-      body: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
-      kind: :trainee_report,
-      receiver: receiver,
-      sender: report.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(report),
-      read: false
-    )
-  end
-
-  def product_update(params = {})
-    params.merge!(@params)
-    product = params[:product]
-    receiver = params[:receiver]
-
-    notification(
-      body: "#{product.user.login_name}さんの提出物が更新されました",
-      kind: :product_update,
-      receiver: receiver,
-      sender: product.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(product),
-      read: false
-    )
-  end
-
-  def watching_notification(params = {})
-    params.merge!(@params)
-    watchable = params[:watchable]
-    receiver = params[:receiver]
-    sender = params[:comment].user
-    action = watchable.instance_of?(Question) ? '回答' : 'コメント'
-    notification(
-      body: "#{watchable.user.login_name}さんの【 #{watchable.notification_title} 】に#{sender.login_name}さんが#{action}しました。",
-      kind: :watching,
-      receiver: receiver,
-      sender: sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(watchable),
       read: false
     )
   end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -202,7 +202,6 @@ class ActivityNotifier < ApplicationNotifier
     )
   end
 
-<<<<<<< HEAD
   def following_report(params = {})
     params.merge!(@params)
     report = params[:report]
@@ -219,9 +218,6 @@ class ActivityNotifier < ApplicationNotifier
   end
 
   def came_answer(params = {})
-=======
-  def chose_correct_answer(params = {})
->>>>>>> メソッド名を修正した
     params.merge!(@params)
     answer = params[:answer]
 
@@ -245,7 +241,7 @@ class ActivityNotifier < ApplicationNotifier
       kind: :retired,
       sender: sender,
       receiver: receiver,
-      link: Rails.application.routes.url_helpers.polymorphic_path(sender),
+      link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
       read: false
     )
   end

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -43,52 +43,6 @@ class AnswersTest < ApplicationSystemTestCase
     end
   end
 
-  test "admin can resolve user's question" do
-    visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
-    assert_text 'ベストアンサーにする'
-    accept_alert do
-      click_button 'ベストアンサーにする'
-    end
-    assert_no_text 'ベストアンサーにする'
-  end
-
-  test 'delete best answer' do
-    visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
-    accept_alert do
-      click_button 'ベストアンサーにする'
-    end
-    accept_alert do
-      click_button 'ベストアンサーを取り消す'
-    end
-    assert_text 'ベストアンサーにする'
-  end
-
-  test 'notify watchers of best answer' do
-    visit_with_auth "/questions/#{questions(:question2).id}", 'sotugyou'
-
-    assert_difference 'ActionMailer::Base.deliveries.count', 1 do
-      perform_enqueued_jobs do
-        assert_no_text '解決済'
-        accept_alert do
-          click_button 'ベストアンサーにする'
-        end
-        assert_text '解決済'
-      end
-    end
-
-    # Watcherに通知される
-    visit_with_auth '/notifications?status=unread', 'kimura'
-    assert_text 'sotugyouさんの質問【 injectとreduce 】でkomagataさんの回答がベストアンサーに選ばれました。'
-
-    # Watchしていない回答者には通知されない
-    visit_with_auth '/notifications?status=unread', 'komagata'
-    assert_no_text 'sotugyouさんの質問【 injectとreduce 】でkomagataさんの回答がベストアンサーに選ばれました。'
-
-    # 質問者には通知されない
-    visit_with_auth '/notifications?status=unread', 'sotugyou'
-    assert_no_text 'sotugyouさんの質問【 injectとreduce 】でkomagataさんの回答がベストアンサーに選ばれました。'
-  end
-
   test 'clear preview after posting comment for question' do
     visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
     find('#js-new-comment').set('test')

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -43,6 +43,26 @@ class AnswersTest < ApplicationSystemTestCase
     end
   end
 
+  test "admin can resolve user's question" do
+    visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
+    assert_text 'ベストアンサーにする'
+    accept_alert do
+      click_button 'ベストアンサーにする'
+    end
+    assert_no_text 'ベストアンサーにする'
+  end
+
+  test 'delete best answer' do
+    visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
+    accept_alert do
+      click_button 'ベストアンサーにする'
+    end
+    accept_alert do
+      click_button 'ベストアンサーを取り消す'
+    end
+    assert_text 'ベストアンサーにする'
+  end
+
   test 'clear preview after posting comment for question' do
     visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
     find('#js-new-comment').set('test')

--- a/test/system/notification/answers_test.rb
+++ b/test/system/notification/answers_test.rb
@@ -7,27 +7,11 @@ class Notification::AnswersTest < ApplicationSystemTestCase
     @delivery_mode = AbstractNotifier.delivery_mode
     AbstractNotifier.delivery_mode = :normal
     @notice_text = 'komagataさんから回答がありました。'
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
   end
 
   teardown do
     AbstractNotifier.delivery_mode = @delivery_mode
-  end
-
-  test "receive a notification when I got my question's answer" do
-    visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
-    within('.thread-comment-form__form') do
-      fill_in('answer[description]', with: 'reduceも使ってみては？')
-    end
-    click_button 'コメントする'
-    assert_text '回答を投稿しました！'
-
-    visit_with_auth '/notifications', 'sotugyou'
-
-    within first('.card-list-item.is-unread') do
-      assert_text @notice_text
-    end
-
-    visit_with_auth '/', 'komagata'
-    refute_text @notice_text
   end
 end

--- a/test/system/notification/answers_test.rb
+++ b/test/system/notification/answers_test.rb
@@ -14,4 +14,49 @@ class Notification::AnswersTest < ApplicationSystemTestCase
   teardown do
     AbstractNotifier.delivery_mode = @delivery_mode
   end
+
+  test "admin can resolve user's question" do
+    visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
+    assert_text 'ベストアンサーにする'
+    accept_alert do
+      click_button 'ベストアンサーにする'
+    end
+    assert_no_text 'ベストアンサーにする'
+  end
+
+  test 'delete best answer' do
+    visit_with_auth "/questions/#{questions(:question2).id}", 'komagata'
+    accept_alert do
+      click_button 'ベストアンサーにする'
+    end
+    accept_alert do
+      click_button 'ベストアンサーを取り消す'
+    end
+    assert_text 'ベストアンサーにする'
+  end
+
+  test 'notify watchers of best answer' do
+    visit_with_auth "/questions/#{questions(:question2).id}", 'sotugyou'
+    accept_confirm do
+      click_button 'ベストアンサーにする'
+    end
+
+    # Watcherに通知される
+    visit_with_auth '/notifications?status=unread', 'kimura'
+    within first('.card-list-item.is-unread') do
+      assert_text 'sotugyouさんの質問【 injectとreduce 】でkomagataさんの回答がベストアンサーに選ばれました。'
+    end
+
+    # Watchしていない回答者には通知されない
+    visit_with_auth '/notifications?status=unread', 'komagata'
+    within first('.card-list-item.is-unread') do
+      assert_no_text 'sotugyouさんの質問【 injectとreduce 】でkomagataさんの回答がベストアンサーに選ばれました。'
+    end
+
+    # 質問者には通知されない
+    visit_with_auth '/notifications?status=unread', 'sotugyou'
+    within first('.card-list-item.is-unread') do
+      assert_no_text 'sotugyouさんの質問【 injectとreduce 】でkomagataさんの回答がベストアンサーに選ばれました。'
+    end
+  end
 end


### PR DESCRIPTION
新しいブランチを作成したので、PRも作り直しました。

以前のPRはこちらのURLです。
https://github.com/fjordllc/bootcamp/pull/5353

## Issue
- #4683

## 概要
ベストアンサーの通知を[abstract_notifier](https://github.com/palkan/abstract_notifier)に置き換えました。仕様は変更していないため、変更前/変更後のスクリーンショットはありません。

## 確認方法
1. `feature/replace-the-best-answer-notification-with-abstract_notifier`をローカルに取り込む
1. `bin/setup`実行
1. `bin/rails s`でサーバーを立ち上げる
1. `sotugyou`でログインし、質問ページにいき、質問を作成する
1. `kensyu`でログインし直し、`sotugyou`が作成した質問ページにいき、回答を投稿する
1. `sotugyou`でログインし直し、`kensyu`の回答をベストアンサーにする
1. `kensyu`でログインし直し、下記のように`kensyu`の回答がベストアンサーに選ばれた通知を確認する
![image](https://user-images.githubusercontent.com/49633473/186528815-5de31d6d-e80d-49af-bc83-a8947753314a.png)
1. 通知一覧のページにいき、下記のように`kensyu`の回答がベストアンサーに選ばれた通知を確認する
![image](https://user-images.githubusercontent.com/49633473/186529103-349a0e6e-f1b9-487c-95ad-e88b475bd6be.png)
1. `http://127.0.0.1:3000/letter_opener/`にアクセスし、メールが送信されていることを確認する
![image](https://user-images.githubusercontent.com/49633473/186529455-a5f72f4c-ef32-4858-99d7-d70c3415aac1.png)