### PR TITLE
[newspaper] Q＆Aの解決質問数のキャッシュ削除処理をnewspaperに置き換えたい

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,8 +63,8 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
   # not default
-  gem 'syntax_suggest'
   gem 'pry-byebug'
+  gem 'syntax_suggest'
   gem 'traceroute'
 end
 

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -30,7 +30,7 @@ class API::AnswersController < API::BaseController
     @answer.user = current_user
     if @answer.save
       Newspaper.publish(:answer_create, @answer)
-      Newspaper.publish(:answer_create, @answer)
+      Newspaper.publish(:answer_save, @answer)
       render :create, status: :created
     else
       head :bad_request

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -30,7 +30,7 @@ class API::AnswersController < API::BaseController
     @answer.user = current_user
     if @answer.save
       Newspaper.publish(:answer_create, @answer)
-      Newspaper.publish(:answer_destroy, @answer)
+      Newspaper.publish(:answer_create, @answer)
       render :create, status: :created
     else
       head :bad_request
@@ -39,7 +39,7 @@ class API::AnswersController < API::BaseController
 
   def update
     if @answer.update(answer_params)
-      Newspaper.publish(:answer_destroy, @answer)
+      Newspaper.publish(:answer_update, @answer)
       head :ok
     else
       head :bad_request

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -39,7 +39,7 @@ class API::AnswersController < API::BaseController
 
   def update
     if @answer.update(answer_params)
-      Newspaper.publish(:answer_update, @answer)
+      Newspaper.publish(:answer_save, @answer)
       head :ok
     else
       head :bad_request

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -29,6 +29,7 @@ class API::AnswersController < API::BaseController
     @answer = question.answers.new(answer_params)
     @answer.user = current_user
     if @answer.save
+      Newspaper.publish(:answer_create, @answer)
       Newspaper.publish(:answer_destroy, @answer)
       render :create, status: :created
     else

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -29,7 +29,7 @@ class API::AnswersController < API::BaseController
     @answer = question.answers.new(answer_params)
     @answer.user = current_user
     if @answer.save
-      Newspaper.publish(:answer_create, @answer)
+      Newspaper.publish(:answer_destroy, @answer)
       render :create, status: :created
     else
       head :bad_request
@@ -38,6 +38,7 @@ class API::AnswersController < API::BaseController
 
   def update
     if @answer.update(answer_params)
+      Newspaper.publish(:answer_destroy, @answer)
       head :ok
     else
       head :bad_request
@@ -46,6 +47,7 @@ class API::AnswersController < API::BaseController
 
   def destroy
     @answer.destroy
+    Newspaper.publish(:answer_destroy, @answer)
   end
 
   private

--- a/app/controllers/api/correct_answers_controller.rb
+++ b/app/controllers/api/correct_answers_controller.rb
@@ -8,7 +8,7 @@ class API::CorrectAnswersController < API::BaseController
     @answer = @question.answers.find(params[:answer_id])
     @answer.type = 'CorrectAnswer'
     if @answer.save
-      Newspaper.publish(:answer_create, @answer)
+      Newspaper.publish(:answer_save, @answer)
       ChatNotifier.message("質問：「#{@answer.question.title}」のベストアンサーが選ばれました。\r#{url_for(@answer.question)}")
       render json: @answer
     else

--- a/app/controllers/api/correct_answers_controller.rb
+++ b/app/controllers/api/correct_answers_controller.rb
@@ -8,6 +8,7 @@ class API::CorrectAnswersController < API::BaseController
     @answer = @question.answers.find(params[:answer_id])
     @answer.type = 'CorrectAnswer'
     if @answer.save
+      Newspaper.publish(:answer_destroy, @answer)
       ChatNotifier.message("質問：「#{@answer.question.title}」のベストアンサーが選ばれました。\r#{url_for(@answer.question)}")
       render json: @answer
     else
@@ -18,6 +19,7 @@ class API::CorrectAnswersController < API::BaseController
   def update
     answer = @question.answers.find(params[:answer_id])
     answer.update!(type: '')
+    Newspaper.publish(:answer_destroy, answer)
   end
 
   private

--- a/app/controllers/api/correct_answers_controller.rb
+++ b/app/controllers/api/correct_answers_controller.rb
@@ -19,7 +19,7 @@ class API::CorrectAnswersController < API::BaseController
   def update
     answer = @question.answers.find(params[:answer_id])
     answer.update!(type: '')
-    Newspaper.publish(:answer_update, answer)
+    Newspaper.publish(:answer_save, @answer)
   end
 
   private

--- a/app/controllers/api/correct_answers_controller.rb
+++ b/app/controllers/api/correct_answers_controller.rb
@@ -8,7 +8,7 @@ class API::CorrectAnswersController < API::BaseController
     @answer = @question.answers.find(params[:answer_id])
     @answer.type = 'CorrectAnswer'
     if @answer.save
-      Newspaper.publish(:answer_destroy, @answer)
+      Newspaper.publish(:answer_create, @answer)
       ChatNotifier.message("質問：「#{@answer.question.title}」のベストアンサーが選ばれました。\r#{url_for(@answer.question)}")
       render json: @answer
     else
@@ -19,7 +19,7 @@ class API::CorrectAnswersController < API::BaseController
   def update
     answer = @question.answers.find(params[:answer_id])
     answer.update!(type: '')
-    Newspaper.publish(:answer_destroy, answer)
+    Newspaper.publish(:answer_update, answer)
   end
 
   private

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -10,8 +10,6 @@ class Answer < ApplicationRecord
   alias sender user
 
   after_create AnswerCallbacks.new
-  after_save AnswerCallbacks.new
-  after_destroy AnswerCallbacks.new
 
   validates :description, presence: true
   validates :user, presence: true

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -10,6 +10,7 @@ class Answer < ApplicationRecord
   alias sender user
 
   after_create AnswerCallbacks.new
+  after_save AnswerCallbacks.new
 
   validates :description, presence: true
   validates :user, presence: true

--- a/app/models/answer_cache_destroyer.rb
+++ b/app/models/answer_cache_destroyer.rb
@@ -5,4 +5,14 @@ class AnswerCacheDestroyer
     notify_correct_answer(answer) if answer.saved_change_to_attribute?('type', to: 'CorrectAnswer')
     Cache.delete_not_solved_question_count
   end
+
+  def notify_correct_answer(answer)
+    question = answer.question
+    watcher_ids = question.watches.pluck(:user_id)
+    receiver_ids = watcher_ids - [question.user_id]
+    receiver_ids.each do |receiver_id|
+      receiver = User.find(receiver_id)
+      NotificationFacade.chose_correct_answer(answer, receiver)
+    end
+  end
 end

--- a/app/models/answer_cache_destroyer.rb
+++ b/app/models/answer_cache_destroyer.rb
@@ -2,17 +2,6 @@
 
 class AnswerCacheDestroyer
   def call(answer)
-    notify_correct_answer(answer) if answer.saved_change_to_attribute?('type', to: 'CorrectAnswer')
     Cache.delete_not_solved_question_count
-  end
-
-  def notify_correct_answer(answer)
-    question = answer.question
-    watcher_ids = question.watches.pluck(:user_id)
-    receiver_ids = watcher_ids - [question.user_id]
-    receiver_ids.each do |receiver_id|
-      receiver = User.find(receiver_id)
-      NotificationFacade.chose_correct_answer(answer, receiver)
-    end
   end
 end

--- a/app/models/answer_cache_destroyer.rb
+++ b/app/models/answer_cache_destroyer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AnswerCacheDestroyer
-  def call(answer)
+  def call(_answer)
     Cache.delete_not_solved_question_count
   end
 end

--- a/app/models/answer_cache_destroyer.rb
+++ b/app/models/answer_cache_destroyer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AnswerCacheDestroyer
+  def call(answer)
+    notify_correct_answer(answer) if answer.saved_change_to_attribute?('type', to: 'CorrectAnswer')
+    Cache.delete_not_solved_question_count
+  end
+end

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -5,7 +5,21 @@ class AnswerCallbacks
     create_watch(answer)
   end
 
+  def after_save(answer)
+    notify_correct_answer(answer) if answer.saved_change_to_attribute?('type', to: 'CorrectAnswer')
+  end
+
   private
+
+  def notify_correct_answer(answer)
+    question = answer.question
+    watcher_ids = question.watches.pluck(:user_id)
+    receiver_ids = watcher_ids - [question.user_id]
+    receiver_ids.each do |receiver_id|
+      receiver = User.find(receiver_id)
+      NotificationFacade.chose_correct_answer(answer, receiver)
+    end
+  end
 
   def notify_correct_answer(answer)
     question = answer.question

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -5,16 +5,6 @@ class AnswerCallbacks
     create_watch(answer)
   end
 
-  def after_save(answer)
-    notify_correct_answer(answer) if answer.saved_change_to_attribute?('type', to: 'CorrectAnswer')
-
-    Cache.delete_not_solved_question_count
-  end
-
-  def after_destroy(_answer)
-    Cache.delete_not_solved_question_count
-  end
-
   private
 
   def notify_correct_answer(answer)

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -21,16 +21,6 @@ class AnswerCallbacks
     end
   end
 
-  def notify_correct_answer(answer)
-    question = answer.question
-    watcher_ids = question.watches.pluck(:user_id)
-    receiver_ids = watcher_ids - [question.user_id]
-    receiver_ids.each do |receiver_id|
-      receiver = User.find(receiver_id)
-      NotificationFacade.chose_correct_answer(answer, receiver)
-    end
-  end
-
   def create_watch(answer)
     question = Question.find(answer.question_id)
 

--- a/config/initializers/newspaer.rb
+++ b/config/initializers/newspaer.rb
@@ -12,5 +12,8 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:learning_create, learning_cache_destroyer)
   Newspaper.subscribe(:learning_destroy, learning_cache_destroyer)
 
-  Newspaper.subscribe(:answer_destroy, AnswerCacheDestroyer.new)
+  answer_cache_destroyer = AnswerCacheDestroyer.new
+  Newspaper.subscribe(:answer_create, answer_cache_destroyer)
+  Newspaper.subscribe(:answer_update, answer_cache_destroyer)
+  Newspaper.subscribe(:answer_destroy, answer_cache_destroyer)
 end

--- a/config/initializers/newspaer.rb
+++ b/config/initializers/newspaer.rb
@@ -12,6 +12,5 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:learning_create, learning_cache_destroyer)
   Newspaper.subscribe(:learning_destroy, learning_cache_destroyer)
 
-  answer_cache_destroyer = AnswerCacheDestroyer.new
-  Newspaper.subscribe(:answer_destroy, answer_cache_destroyer)
+  Newspaper.subscribe(:answer_destroy, AnswerCacheDestroyer.new)
 end

--- a/config/initializers/newspaer.rb
+++ b/config/initializers/newspaer.rb
@@ -11,4 +11,7 @@ Rails.configuration.to_prepare do
   learning_cache_destroyer = LearningCacheDestroyer.new
   Newspaper.subscribe(:learning_create, learning_cache_destroyer)
   Newspaper.subscribe(:learning_destroy, learning_cache_destroyer)
+
+  answer_cache_destroyer = AnswerCacheDestroyer.new
+  Newspaper.subscribe(:answer_destroy, answer_cache_destroyer)
 end

--- a/config/initializers/newspaer.rb
+++ b/config/initializers/newspaer.rb
@@ -13,7 +13,7 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:learning_destroy, learning_cache_destroyer)
 
   answer_cache_destroyer = AnswerCacheDestroyer.new
-  Newspaper.subscribe(:answer_create, answer_cache_destroyer)
+  Newspaper.subscribe(:answer_save, answer_cache_destroyer)
   Newspaper.subscribe(:answer_update, answer_cache_destroyer)
   Newspaper.subscribe(:answer_destroy, answer_cache_destroyer)
 end

--- a/config/initializers/newspaer.rb
+++ b/config/initializers/newspaer.rb
@@ -14,6 +14,5 @@ Rails.configuration.to_prepare do
 
   answer_cache_destroyer = AnswerCacheDestroyer.new
   Newspaper.subscribe(:answer_save, answer_cache_destroyer)
-  Newspaper.subscribe(:answer_update, answer_cache_destroyer)
   Newspaper.subscribe(:answer_destroy, answer_cache_destroyer)
 end


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/5499

## 概要
Q＆Aの解決質問数のキャッシュ削除処理をコールバックによる呼び出しから、[newspaper](https://github.com/komagata/newspaper)を使用した呼び出し方法に変更した。
※見た目上の変更はありません。

##  確認方法
### 1. Q&Aに回答した際のキャッシュ削除を確認
1. ブランチ`feature/delete_not_solved_question_count-newspaper-gem-for-cache`をローカルに取り込む
2. `app/models/answer_cache_destroyer.rb`の`call`メソッドの1行目に`puts "AnswerCacheDestroyer#call"`を追加する
3. `bin/rails s`でローカル環境を立ち上げる
4. komagataでログインし、適当なQ&Aページに移動(http://localhost:3000/questions/754319241)
5. 適当な回答を記入し、コメントをする
6. 実行ターミナル画面に`AnswerCacheDestroyer#call` が出力されていることを確認する

### 2. Q&Aの回答を更新した際のキャッシュ削除を確認
1. 1,2,3,4は上記と同様のため省略
2. 既にある回答を`内容修正`する
3. 実行ターミナル画面に`AnswerCacheDestroyer#call` が出力されていることを確認する

### 3. Q&Aの回答を削除した際のキャッシュ削除を確認
1. 1,2,3,4は上記と同様のため省略
2. 既にある回答を`削除`する
3. 実行ターミナル画面に`AnswerCacheDestroyer#call` が出力されていることを確認する

### 4. Q&Aの回答をベストアンサーにした際のキャッシュ削除を確認
1. 1,2,3,4は上記と同様のため省略
2. 既にある回答を`ベストアンサーにする`
3. 実行ターミナル画面に`AnswerCacheDestroyer#call` が出力されていることを確認する

### 5. Q&Aの回答をベストアンサーを取り消した際のキャッシュ削除を確認
1. 1,2,3,4は上記と同様のため省略
2. 既にあるベストアンサーを`取り消す`
3. 実行ターミナル画面に`AnswerCacheDestroyer#call` が出力されていることを確認する