### PR TITLE
カテゴリー編集画面の文言変更

### DIFF
--- a/app/views/admin/categories/_form.html.slim
+++ b/app/views/admin/categories/_form.html.slim
@@ -18,7 +18,7 @@
           = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area practices-edit__input', data: { 'preview': '.js-preview' }
           .a-form-help
             p
-              | これを学ぶことで身に付くのか？これを学ぶことの目標、これを学ぶにあたっての必要な前提条件、修了していないといけないプラクティスを記入してください。
+              | このカテゴリーを学ぶことでできるようになること、なぜこれを学ぶのかの理由、学ぶにあたっての必要な前提条件（修了していないといけないプラクティスなど）を記入してください。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー


### PR DESCRIPTION
# Issue
- https://github.com/fjordllc/bootcamp/issues/5517

# 変更内容
カテゴリーの編集画面のテキストボックスの下部のメッセージを変更しました。
```
これを学ぶことで身に付くのか？これを学ぶことの目標、これを学ぶにあたっての必要な前提条件、修了していないといけないプラクティスを記入してください。
```

![image](https://user-images.githubusercontent.com/43959158/190664328-94599f18-d2b2-4a43-bb9c-aa63a1849f92.png)

↓
```
このカテゴリーを学ぶことでできるようになること、なぜこれを学ぶのかの理由、学ぶにあたっての必要な前提条件（修了していないといけないプラクティスなど）を記入してください。
```

![image](https://user-images.githubusercontent.com/43959158/190663992-845e9cec-1577-46af-9cb1-709eb5f383fb.png)

# 確認方法
※`feature/change-category-edit-page-message`ブランチを取り込み、`bin/rails s`でサーバーを立ち上げる

1. 管理者でログイン
![Screenshot 2022-09-16 23 13 09](https://user-images.githubusercontent.com/43959158/190664747-44de5b90-2b91-4df2-bb12-6d0c7174ef2c.png)

2.  `/admin/categories/`からカテゴリの編集画面に移動する
![Screenshot 2022-09-16 23 13 44](https://user-images.githubusercontent.com/43959158/190665126-85e139f3-c27c-4de7-b62e-d8b48d589150.png)

3. メッセージの確認
![image](https://user-images.githubusercontent.com/43959158/190665453-7b4969e8-3abb-442b-83cb-b346408f3dae.png)
