### PR TITLE
アドバイザーがコメントした時、企業に所属していたら企業アイコンを一緒に表示させる機能を実装

### DIFF
--- a/app/assets/stylesheets/application/blocks/thread/_thread-comment.sass
+++ b/app/assets/stylesheets/application/blocks/thread/_thread-comment.sass
@@ -22,10 +22,26 @@
   +media-breakpoint-down(sm)
     margin-bottom: .25ren
 
+.thread-comment__title-user-icon
+  +media-breakpoint-up(md)
+    display: none
+  +media-breakpoint-down(sm)
+    width: 1.5rem
+    display: inline-block
+    vertical-align: middle
+    margin-right: .25rem
+
 .thread-comment__title-link
-  height: 100%
-  display: flex
-  align-items: center
+  +media-breakpoint-up(md)
+    height: 100%
+    display: flex
+    align-items: center
+  +media-breakpoint-down(sm)
+    display: inline-block
+    max-width: 6rem
+    overflow: hidden
+    text-overflow: ellipsis
+    vertical-align: middle
   &.a-placeholder
     width: 15%
     height: 1.4em
@@ -53,9 +69,22 @@
   +size(3.5rem)
   object-fit: cover
   border-radius: 50%
-  +position(absolute, left 0, top 0)
   +media-breakpoint-down(sm)
     display: none
+
+.thread-comment__company-logo
+  +size(3.5rem)
+  object-fit: cover
+  border-radius: .25rem
+  border: solid 1px $border
+  background-color: white
+  +media-breakpoint-up(md)
+    margin-top: .5rem
+  +media-breakpoint-down(sm)
+    +size(2.25rem)
+    float: right
+    margin-left: .75rem
+    margin-bottom: .5rem
 
 .thread-comment__created-at
   display: block

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -7,6 +7,11 @@
         :title='comment.user.icon_title',
         :class='[roleClass]'
       )
+    a(
+    v-if='comment.user.company && comment.user.company.logo_url && comment.user.adviser',
+    :href='comment.user.company.url'
+    )
+      img.user-item__company-logo(:src='comment.user.company.logo_url')
   .a-card(v-if='!editing')
     header.card-header
       h2.thread-comment__title

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -8,8 +8,8 @@
         :class='[roleClass]'
       )
     a(
-    v-if='comment.user.company && comment.user.company.logo_url && comment.user.adviser',
-    :href='comment.user.company.url'
+      v-if='comment.user.company && comment.user.company.logo_url && comment.user.adviser',
+      :href='comment.user.company.url'
     )
       img.user-item__company-logo(:src='comment.user.company.logo_url')
   .a-card(v-if='!editing')

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -7,14 +7,21 @@
         :title='comment.user.icon_title',
         :class='[roleClass]'
       )
-    a(
+    a.thread-comment__company-link(
       v-if='comment.user.company && comment.user.company.logo_url && comment.user.adviser',
       :href='comment.user.company.url'
     )
-      img.user-item__company-logo(:src='comment.user.company.logo_url')
+      img.thread-comment__company-logo(:src='comment.user.company.logo_url')
   .a-card(v-if='!editing')
     header.card-header
       h2.thread-comment__title
+        a.thread-comment__title-user-link.is-hidden-md-up(:href='comment.user.url')
+          img.thread-comment__title-user-icon.a-user-icon(
+            :src='comment.user.avatar_url',
+            :title='comment.user.icon_title',
+            :class='[roleClass]'
+          )
+
         a.thread-comment__title-link.a-text-link(:href='comment.user.url')
           | {{ comment.user.login_name }}
       time.thread-comment__created-at(
@@ -24,6 +31,11 @@
       )
         | {{ updatedAt }}
     .thread-comment__description
+      a.thread-comment__company-link.is-hidden-md-up(
+        v-if='comment.user.company && comment.user.company.logo_url && comment.user.adviser',
+        :href='comment.user.company.url'
+      )
+        img.thread-comment__company-logo(:src='comment.user.company.logo_url')
       .a-long-text.is-md(v-html='markdownDescription')
     .thread-comment__reactions
       reaction(

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -8,7 +8,7 @@
         :class='[roleClass]'
       )
     a.thread-comment__company-link(
-      v-if='comment.user.company && comment.user.company.logo_url && comment.user.adviser',
+      v-if='comment.user.company && comment.user.adviser',
       :href='comment.user.company.url'
     )
       img.thread-comment__company-logo(:src='comment.user.company.logo_url')
@@ -34,7 +34,7 @@
         | {{ updatedAt }}
     .thread-comment__description
       a.thread-comment__company-link.is-hidden-md-up(
-        v-if='comment.user.company && comment.user.company.logo_url && comment.user.adviser',
+        v-if='comment.user.company && comment.user.adviser',
         :href='comment.user.company.url'
       )
         img.thread-comment__company-logo(:src='comment.user.company.logo_url')

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -15,7 +15,9 @@
   .a-card(v-if='!editing')
     header.card-header
       h2.thread-comment__title
-        a.thread-comment__title-user-link.is-hidden-md-up(:href='comment.user.url')
+        a.thread-comment__title-user-link.is-hidden-md-up(
+          :href='comment.user.url'
+        )
           img.thread-comment__title-user-icon.a-user-icon(
             :src='comment.user.avatar_url',
             :title='comment.user.icon_title',

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -3,3 +3,11 @@ columns << :mentor_memo if admin_or_mentor_login?
 json.(user, *columns)
 json.avatar_url user.avatar_url
 json.delayed user.completed_at >= 2.weeks.ago.end_of_day if user.respond_to?(:completed_at)
+json.adviser user.adviser
+
+json.company do
+  if user.company.present?
+    json.logo_url user.company.logo_url
+    json.url company_url(user.company)
+  end
+end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -325,4 +325,16 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text '日報を確認済みにしました'
     assert_text 'comment test'
   end
+
+  test ' company logo appear when adviser post comment ' do
+    visit_with_auth "/reports/#{reports(:report1).id}", 'senpai'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    assert_text 'test'
+    click_button 'コメントする'
+    assert_text 'test'
+    assert find('img.user-item__company-logo')['src'].include?('2.png')
+  end
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -335,6 +335,6 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'test'
     click_button 'コメントする'
     assert_text 'test'
-    assert find('img.user-item__company-logo')['src'].include?('2.png')
+    assert find('img.thread-comment__company-logo')['src'].include?('2.png')
   end
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -328,7 +328,7 @@ class CommentsTest < ApplicationSystemTestCase
 
   test 'company logo appear when adviser belongs to the company post comment' do
     visit_with_auth "/reports/#{reports(:report1).id}", 'senpai'
-    find('#js-new-comment').set('test')
+    fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
     assert_text 'test'
     assert find('img.thread-comment__company-logo')['src'].include?('2.png')

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -326,7 +326,7 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'comment test'
   end
 
-  test ' company logo appear when adviser post comment ' do
+  test ' company logo appear when adviser belongs to the company post comment ' do
     visit_with_auth "/reports/#{reports(:report1).id}", 'senpai'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -328,11 +328,7 @@ class CommentsTest < ApplicationSystemTestCase
 
   test ' company logo appear when adviser belongs to the company post comment ' do
     visit_with_auth "/reports/#{reports(:report1).id}", 'senpai'
-    within('.thread-comment-form__form') do
-      fill_in('new_comment[description]', with: 'test')
-    end
-    all('.a-form-tabs__tab.js-tabs__tab')[1].click
-    assert_text 'test'
+    find('#js-new-comment').set('test')
     click_button 'コメントする'
     assert_text 'test'
     assert find('img.thread-comment__company-logo')['src'].include?('2.png')

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -326,7 +326,7 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'comment test'
   end
 
-  test ' company logo appear when adviser belongs to the company post comment ' do
+  test 'company logo appear when adviser belongs to the company post comment' do
     visit_with_auth "/reports/#{reports(:report1).id}", 'senpai'
     find('#js-new-comment').set('test')
     click_button 'コメントする'

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -331,6 +331,6 @@ class CommentsTest < ApplicationSystemTestCase
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
     assert_text 'test'
-    assert find('img.thread-comment__company-logo')['src'].include?('2.png')
+    assert_equal '2.png', File.basename(find('img.thread-comment__company-logo')['src'])
   end
 end


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/5105

## 概要
アドバイザーがコメントした時、企業に所属している場合は企業アイコンが表示されるように変更。

## 変更確認方法

### 変更箇所
今回のissueで変更される箇所は、`日報`、`提出物`、`Docs`、`イベント`、`ヘルプ`、`相談`ページに対して、アドバイザー（企業に所属している場合）がコメントした際、企業アイコンが一緒に表示されます。
※ 今回の確認方法では、`日報`ページにコメントした場合を想定しています。

### アドバイザー（企業に所属している場合）でコメントした場合
1. ブランチ`feature/if_advisor_display_company-icons_in_the_comments`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. アドバイザー（senpai）でログインする
4. 特定の日報にアクセスし、コメントを作成する
6. ユーザーアイコン付近に企業アイコンが表示されていることを確認する

### アドバイザー（企業に所属している場合）以外でコメントした場合
1. ブランチ`feature/if_advisor_display_company-icons_in_the_comments`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. アドバイザー（kimura）でログインする
4. 特定の日報にアクセスし、コメントを作成する
6. ユーザーアイコン付近に企業アイコンが表示されないことを確認する

## 変更前
<img width="1434" alt="_development__1日目_できなかった___FBC_と_bootcamp_–_answers_controller_rb" src="https://user-images.githubusercontent.com/99729409/190940305-2683218d-8d02-451d-a9e5-1d2160edf036.png">

## 変更後
<img width="1434" alt="_development__今日は頑張りました___FBC" src="https://user-images.githubusercontent.com/99729409/191272696-130a4543-4317-4336-a9a1-1475fd53ea92.png">

