### PR TITLE
研修生の日報作成の通知の実装を[abstract_notifier]へ置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -92,17 +92,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def trainee_report(report, receiver)
-      Notification.create!(
-        kind: kinds[:trainee_report],
-        user: receiver,
-        sender: report.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(report),
-        message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
-        read: false
-      )
-    end
-
     def moved_up_event_waiting_user(event, receiver)
       Notification.create!(
         kind: kinds[:moved_up_event_waiting_user],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -116,7 +116,7 @@ class NotificationFacade
   end
 
   def self.trainee_report(report, receiver)
-    Notification.trainee_report(report, receiver)
+    ActivityNotifier.with(report: report, receiver: receiver).trainee_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -230,4 +230,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def trainee_report(params = {})
+    params.merge!(@params)
+    report = params[:report]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
+      kind: :trainee_report,
+      user: receiver,
+      sender: report.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(report),
+      read: false
+    )
+  end
 end

--- a/test/system/notification/trainee_report_test.rb
+++ b/test/system/notification/trainee_report_test.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+
+end


### PR DESCRIPTION
 ## Issue
 
 - #4687
 
 ## 概要
 研修生の日報作成の通知の実装を[abstract_notifier]へ置き換えた

 ...
 
 ## 変更確認方法
 
 1. ブランチ``をローカルに取り込む
 2. `bin/rails s`でローカル環境を立ち上げる
 3. ...
 
 ## 変更前
 
 <img ...>
 
 ## 変更後
 
 <img ...>