### PR TITLE
研修生の日報作成の通知の実装を[abstract_notifier]へ置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -103,17 +103,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def trainee_report(report, receiver)
-      Notification.create!(
-        kind: kinds[:trainee_report],
-        user: receiver,
-        sender: report.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(report),
-        message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
-        read: false
-      )
-    end
-
     def moved_up_event_waiting_user(event, receiver)
       Notification.create!(
         kind: kinds[:moved_up_event_waiting_user],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -116,7 +116,6 @@ class NotificationFacade
   end
 
   def self.trainee_report(report, receiver)
-    # Notification.trainee_report(report, receiver)
     ActivityNotifier.with(report: report, receiver: receiver).trainee_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -116,7 +116,8 @@ class NotificationFacade
   end
 
   def self.trainee_report(report, receiver)
-    Notification.trainee_report(report, receiver)
+    # Notification.trainee_report(report, receiver)
+    ActivityNotifier.with(report: report, receiver: receiver).trainee_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -254,7 +254,7 @@ class ActivityNotifier < ApplicationNotifier
     notification(
       body: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
       kind: :trainee_report,
-      user: receiver,
+      receiver: receiver,
       sender: report.sender,
       link: Rails.application.routes.url_helpers.polymorphic_path(report),
       read: false

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -245,4 +245,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def trainee_report(params = {})
+    params.merge!(@params)
+    report = params[:report]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
+      kind: :trainee_report,
+      user: receiver,
+      sender: report.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(report),
+      read: false
+    )
+  end
 end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -189,10 +189,10 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     end
   end
 
-  test '研修生が初めて提出した時だけ、企業のアドバイザーに通知する' do
+  test '研修生が日報を作成し提出した時、企業のアドバイザーに通知する' do
     kensyu_login_name = 'kensyu'
     advisor_login_name = 'senpai'
-    title = '研修生が初めて提出した時だけ、'
+    title = '研修生が日報を作成し提出した時'
     description = 'アドバイザーに通知を飛ばす'
     notification_message = make_write_report_notification_message(
       kensyu_login_name, title


### PR DESCRIPTION
 ## Issue
 
 - #4687
 
 ## 概要
研修生の日報作成の通知の実装を[abstract_notifier](https://github.com/palkan/abstract_notifier)へ置き換えました。見た目上の変更はありません。
 
 ## 変更確認方法
 1. ブランチ`feature/replace-notification-of-trainee-daily-report-creates-to-abstract_notifier`をローカルに取り込む
 2. `bin/rails s`でローカル環境を立ち上げる
 3. `kensyu@fjord.jp`でログインし日報を作成し提出する
 ![image](https://user-images.githubusercontent.com/65638955/191015945-e593f50d-a2bc-49da-bc31-000753d5eb98.png)
 
 4. `senpai@fjord.jp`でログインし通知を確認する http://localhost:3000/notifications
![image](https://user-images.githubusercontent.com/65638955/191018073-86bf46bc-844f-4369-ac94-394f9da6e41c.png)

5. http://localhost:3000/letter_opener/ へアクセスしメールが届いているか確認する
![image](https://user-images.githubusercontent.com/65638955/191017631-b1a17e53-8025-4bd8-9d60-c60a0fec87b8.png) 
