### PR TITLE
退会後3ヶ月通知をabstract_notifierに置き換えた

### DIFF
--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -6,7 +6,6 @@ class Scheduler::DailyController < SchedulerController
     User.retired.find_each do |retired_user|
       if retired_user.retired_three_months_ago_and_notification_not_sent?
         User.admins.each do |admin_user|
-          ActivityNotifier.three_months_after_retirement(sender: retired_user, receiver: admin_user)
           NotificationFacade.three_months_after_retirement(retired_user, admin_user)
           retired_user.update!(notified_retirement: true)
         end

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -6,7 +6,7 @@ class Scheduler::DailyController < SchedulerController
     User.retired.find_each do |retired_user|
       if retired_user.retired_three_months_ago_and_notification_not_sent?
         User.admins.each do |admin_user|
-          ActivityNotifier.three_months_after_retirement(receiver: admin_user, sender: retired_user)
+          ActivityNotifier.three_months_after_retirement(sender: retired_user, receiver: admin_user)
           NotificationFacade.three_months_after_retirement(retired_user, admin_user)
           retired_user.update!(notified_retirement: true)
         end

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -6,7 +6,7 @@ class Scheduler::DailyController < SchedulerController
     User.retired.find_each do |retired_user|
       if retired_user.retired_three_months_ago_and_notification_not_sent?
         User.admins.each do |admin_user|
-          Notification.three_months_after_retirement(retired_user, admin_user)
+          ActivityNotifier.three_months_after_retirement(receiver: admin_user, sender: retired_user)
           NotificationFacade.three_months_after_retirement(retired_user, admin_user)
           retired_user.update!(notified_retirement: true)
         end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -78,27 +78,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def three_months_after_retirement(sender, receiver)
-      Notification.create!(
-        kind: kinds[:retired],
-        user: receiver,
-        sender: sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(sender),
-        message: "#{I18n.t('.retire_notice', user: sender.login_name)}Discord ID: #{sender.discord_account}, ユーザーページ: https://bootcamp.fjord.jp/users/#{sender.id}",
-        read: false
-      )
-
-    def trainee_report(report, receiver)
-      Notification.create!(
-        kind: kinds[:trainee_report],
-        user: receiver,
-        sender: report.sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(report),
-        message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
-        read: false
-      )
-    end
-
     def moved_up_event_waiting_user(event, receiver)
       Notification.create!(
         kind: kinds[:moved_up_event_waiting_user],

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -87,6 +87,16 @@ class Notification < ApplicationRecord
         message: "#{I18n.t('.retire_notice', user: sender.login_name)}Discord ID: #{sender.discord_account}, ユーザーページ: https://bootcamp.fjord.jp/users/#{sender.id}",
         read: false
       )
+
+    def trainee_report(report, receiver)
+      Notification.create!(
+        kind: kinds[:trainee_report],
+        user: receiver,
+        sender: report.sender,
+        link: Rails.application.routes.url_helpers.polymorphic_path(report),
+        message: "#{report.user.login_name}さんが日報【 #{report.title} 】を書きました！",
+        read: false
+      )
     end
 
     def moved_up_event_waiting_user(event, receiver)

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -106,7 +106,7 @@ class NotificationFacade
   end
 
   def self.three_months_after_retirement(sender, receiver)
-    Notification.three_months_after_retirement(sender, receiver)
+    ActivityNotifier.with(sender: sender, receiver: receiver).three_months_after_retirement.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -236,7 +236,7 @@ class ActivityNotifier < ApplicationNotifier
     receiver = params[:receiver]
 
     notification(
-      body: "#{I18n.t('.retire_notice', user: sender.login_name)}Discord ID: #{sender.discord_account}, ユーザーページ: https://bootcamp.fjord.jp/users/#%7Bsender.id%7D",
+      body: "#{I18n.t('.retire_notice', user: sender.login_name)}Discord ID: #{sender.discord_account}, ユーザーページ: https://bootcamp.fjord.jp/users/#{sender.id}",
       kind: :retired,
       sender: sender,
       receiver: receiver,

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -229,7 +229,8 @@ class ActivityNotifier < ApplicationNotifier
       link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
       read: false
     )
-    
+  end
+  
   def three_months_after_retirement(params = {})
     params.merge!(@params)
     sender = params[:sender]

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -230,7 +230,7 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
-  
+
   def three_months_after_retirement(params = {})
     params.merge!(@params)
     sender = params[:sender]

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -229,6 +229,20 @@ class ActivityNotifier < ApplicationNotifier
       link: Rails.application.routes.url_helpers.polymorphic_path(answer.question),
       read: false
     )
+    
+  def three_months_after_retirement(params = {})
+    params.merge!(@params)
+    sender = params[:sender]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{I18n.t('.retire_notice', user: sender.login_name)}Discord ID: #{sender.discord_account}, ユーザーページ: https://bootcamp.fjord.jp/users/#%7Bsender.id%7D",
+      kind: :retired,
+      sender: sender,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(sender),
+      read: false
+    )
   end
 
   def checked(params = {})

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -43,7 +43,7 @@ class DiscordNotifier < ApplicationNotifier
   def tomorrow_regular_event(params = {})
     params.merge!(@params)
     event = params[:event]
-    webhook_url = params[:webhook_url] || ENV['DISCORD_ALL_WEBHOOK_URL']
+    webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:admin]
     day_of_the_week = %w[日 月 火 水 木 金 土]
     event_date = event.next_event_date
 

--- a/test/system/notification/after_retirement_test.rb
+++ b/test/system/notification/after_retirement_test.rb
@@ -17,6 +17,8 @@ class Notification::AfterRetirementTest < ApplicationSystemTestCase
     visit_with_auth '/scheduler/daily', 'komagata'
     visit '/notifications'
 
-    assert_selector 'h2', text: 'taikai3さんが退会してから3カ月が経過しました。Discord ID:taikai#3333, ユーザーページ:https://bootcamp.fjord.jp/users/1008501353'
+    within first('.card-list-item.is-unread') do
+      assert_text 'taikai3さんが退会してから3カ月が経過しました。Discord ID: taikai#3333, ユーザーページ: https://bootcamp.fjord.jp/users/1008501353'
+    end
   end
 end

--- a/test/system/notification/after_retirement_test.rb
+++ b/test/system/notification/after_retirement_test.rb
@@ -17,8 +17,6 @@ class Notification::AfterRetirementTest < ApplicationSystemTestCase
     visit_with_auth '/scheduler/daily', 'komagata'
     visit '/notifications'
 
-    within first('.card-list-item.is-unread') do
-      assert_text 'taikai3さんが退会してから3カ月が経過しました。Discord ID: taikai#3333, ユーザーページ: https://bootcamp.fjord.jp/users/1008501353'
-    end
+    assert_selector 'h2', text: 'taikai3さんが退会してから3カ月が経過しました。Discord ID:taikai#3333, ユーザーページ:https://bootcamp.fjord.jp/users/1008501353'
   end
 end

--- a/test/system/notification/after_retirement_test.rb
+++ b/test/system/notification/after_retirement_test.rb
@@ -3,6 +3,16 @@
 require 'application_system_test_case'
 
 class Notification::AfterRetirementTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+    @notice_text = 'komagataさんから回答がありました。'
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test 'three months have passed since user retired' do
     visit_with_auth '/scheduler/daily', 'komagata'
     visit '/notifications'

--- a/test/system/notification/after_retirement_test.rb
+++ b/test/system/notification/after_retirement_test.rb
@@ -7,6 +7,8 @@ class Notification::AfterRetirementTest < ApplicationSystemTestCase
     visit_with_auth '/scheduler/daily', 'komagata'
     visit '/notifications'
 
-    assert_selector 'h2', text: 'taikai3さんが退会してから3カ月が経過しました。Discord ID:taikai#3333, ユーザーページ:https://bootcamp.fjord.jp/users/1008501353'
+    within first('.card-list-item.is-unread') do
+      assert_text 'taikai3さんが退会してから3カ月が経過しました。Discord ID: taikai#3333, ユーザーページ: https://bootcamp.fjord.jp/users/1008501353'
+    end
   end
 end

--- a/test/system/notification/after_retirement_test.rb
+++ b/test/system/notification/after_retirement_test.rb
@@ -7,12 +7,10 @@ class Notification::AfterRetirementTest < ApplicationSystemTestCase
     @delivery_mode = AbstractNotifier.delivery_mode
     AbstractNotifier.delivery_mode = :normal
     @notice_text = 'komagataさんから回答がありました。'
-    ENV['DISCORD_ALL_WEBHOOK_URL'] = 'https://example.com/'
   end
 
   teardown do
     AbstractNotifier.delivery_mode = @delivery_mode
-    ENV['DISCORD_ALL_WEBHOOK_URL'] = nil
   end
 
   test 'three months have passed since user retired' do

--- a/test/system/notification/after_retirement_test.rb
+++ b/test/system/notification/after_retirement_test.rb
@@ -7,8 +7,6 @@ class Notification::AfterRetirementTest < ApplicationSystemTestCase
     visit_with_auth '/scheduler/daily', 'komagata'
     visit '/notifications'
 
-    within first('.card-list-item.is-unread') do
-      assert_text 'taikai3さんが退会してから3カ月が経過しました。Discord ID: taikai#3333, ユーザーページ: https://bootcamp.fjord.jp/users/1008501353'
-    end
+    assert_selector 'h2', text: 'taikai3さんが退会してから3カ月が経過しました。Discord ID:taikai#3333, ユーザーページ:https://bootcamp.fjord.jp/users/1008501353'
   end
 end

--- a/test/system/notification/after_retirement_test.rb
+++ b/test/system/notification/after_retirement_test.rb
@@ -7,10 +7,12 @@ class Notification::AfterRetirementTest < ApplicationSystemTestCase
     @delivery_mode = AbstractNotifier.delivery_mode
     AbstractNotifier.delivery_mode = :normal
     @notice_text = 'komagataさんから回答がありました。'
+    ENV['DISCORD_ALL_WEBHOOK_URL'] = 'https://example.com/'
   end
 
   teardown do
     AbstractNotifier.delivery_mode = @delivery_mode
+    ENV['DISCORD_ALL_WEBHOOK_URL'] = nil
   end
 
   test 'three months have passed since user retired' do


### PR DESCRIPTION
## Issue

- #4688 

## 概要

退会後3ヶ月通知をabstract_notifierに置き換えました。
見た目の変更はありません。

## 変更確認方法

1. ブランチ`feature/replace-notification-three-after-retirement-with-abstract-notifier-2`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 管理者またはメンターのユーザーでログインする
4. ヘッダー右上の`通知`をクリック→`全ての通知`から、通知一覧画面( http://localhost:3000/notifications )にアクセスする
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/62344131/190912218-17b59a63-4087-4ecb-a22b-449c542975c4.png">
5. 退会後3ヶ月通知をクリックして、退会したユーザーのユーザーページに遷移することを確認する
<img width="752" alt="image" src="https://user-images.githubusercontent.com/62344131/190911085-7f47d695-496e-42da-9d19-b083f37301cc.png">