### PR TITLE
Q＆Aのページで回答を投稿したらWatchする処理をnewspaperに置き換えた

### DIFF
--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -2,7 +2,6 @@
 
 class AnswerCallbacks
   def after_create(answer)
-    create_watch(answer)
     notify_to_watching_user(answer)
   end
 
@@ -41,17 +40,5 @@ class AnswerCallbacks
       receiver = User.find(receiver_id)
       NotificationFacade.chose_correct_answer(answer, receiver)
     end
-  end
-
-  def create_watch(answer)
-    question = Question.find(answer.question_id)
-
-    return if question.watches.pluck(:user_id).include?(answer.sender.id)
-
-    @watch = Watch.new(
-      user: answer.sender,
-      watchable: question
-    )
-    @watch.save!
   end
 end

--- a/app/models/answer_notifier.rb
+++ b/app/models/answer_notifier.rb
@@ -2,11 +2,30 @@
 
 class AnswerNotifier
   def call(answer)
+    notify_answer(answer)
+    create_watch(answer)
+  end
+
+  private
+
+  def notify_answer(answer)
     return if answer.sender == answer.receiver
 
     question = answer.question
     watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
     mention_user_ids = answer.new_mention_users.ids
     NotificationFacade.came_answer(answer) if watcher_ids.concat(mention_user_ids).exclude?(answer.receiver.id)
+  end
+
+  def create_watch(answer)
+    question = Question.find(answer.question_id)
+
+    return if question.watches.pluck(:user_id).include?(answer.sender.id)
+
+    @watch = Watch.new(
+      user: answer.sender,
+      watchable: question
+    )
+    @watch.save!
   end
 end


### PR DESCRIPTION
## Issue

- #5496 

## 概要

Q＆Aのページで質問へ回答するとその質問のスレッドをWatch中にする処理をnewspaperに置き換えました。

## 変更点
見た目上の変更はありません。

## 変更確認方法

1. ブランチ`feature/replace-adding-watch-process-upon-posting-answer-with-newspaper`をローカルに取り込む
2. `app/models/answerer_watcher.rb`のcallメソッドの1行目に`puts "AnswerNotifier#call"`を追加する
3. `bin/rails s`でローカル環境を立ち上げる
4.  `kimura`（ほか任意のアカウントでもOK)でログインし、http://localhost:3000/questions?target=not_solved へアクセスする
5.  3.のログインアカウントのユーザー以外が作成した適当な質問を選択し、テスト用の回答を投稿する
6.  実行ターミナル画面に `"AnswerNotifier#call"`が出力されていることを確認する
![image](https://user-images.githubusercontent.com/58751858/190990115-5bd0fad2-af4f-452d-9365-32011f932c18.png)


7. `kimura`をログアウトする
8. 別のアカウント`machida`（ほか任意のアカウントでもOK)で再度ログインする
9.  4.でテスト用の回答を投稿した質問へまた新たにテスト用の回答を投稿する
10. `machida`をログアウトする
11. `kimura`(4.で回答を投稿したアカウント）で再ログインし、7.の回答が以下のように正常に通知されることを確認する
![image](https://user-images.githubusercontent.com/58751858/190913073-e6697a22-032c-4175-bd51-3f6ee76a3111.png)

12. http://localhost:3000/notifications でも11.と同様の通知が到着することを確認する
![image](https://user-images.githubusercontent.com/58751858/190913092-f7ed06b8-aad1-4e57-ae3f-72ccd330ff83.png)


