### PR TITLE
メンターが提出物のコメントフォームから確認okにした時のトーストが正しく表示されるようにした

### DIFF
--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -1,4 +1,13 @@
 export default {
+  computed: {
+    isUnassignedAndUnchekedProduct() {
+      return (
+        this.commentableType === 'Product' &&
+        this.productCheckerId === null &&
+        this.checkId === null
+      )
+    }
+  },
   methods: {
     check(checkableType, checkableId, url, method, token) {
       const params = {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -294,12 +294,8 @@ export default {
       }
     },
     postComment() {
-      this.createComment({ toastMessage: null })
-      if (
-        this.commentableType === 'Product' &&
-        this.productCheckerId === null &&
-        this.checkId === null
-      ) {
+      this.createComment({})
+      if (this.isUnassignedAndUnchekedProduct) {
         this.checkProduct(
           this.commentableId,
           this.currentUserId,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -203,7 +203,7 @@ export default {
           }
         })
     },
-    createComment({ toastMessage = null }) {
+    createComment({ toastMessage } = {}) {
       if (this.description.length < 1) {
         return null
       }
@@ -294,7 +294,7 @@ export default {
       }
     },
     postComment() {
-      this.createComment({})
+      this.createComment()
       if (this.isUnassignedAndUnchekedProduct) {
         this.checkProduct(
           this.commentableId,

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -297,15 +297,17 @@ export default {
       this.createComment({ toastMessage: null })
       if (
         this.commentableType === 'Product' &&
-        this.productCheckerId === null && this.checkId === null) {
-          this.checkProduct(
-            this.commentableId,
-            this.currentUserId,
-            '/api/products/checker',
-            'PATCH',
-            this.token()
-            )
-          }
+        this.productCheckerId === null &&
+        this.checkId === null
+      ) {
+        this.checkProduct(
+          this.commentableId,
+          this.currentUserId,
+          '/api/products/checker',
+          'PATCH',
+          this.token()
+        )
+      }
     },
     async fetchUncheckedProducts(page) {
       return fetch(`/api/products/unchecked?page=${page}`, {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -68,7 +68,7 @@
           .card-main-actions__items
             .card-main-actions__item
               button#js-shortcut-post-comment.a-button.is-sm.is-primary.is-block(
-                @click='createComment',
+                @click='postComment',
                 :disabled='!validation || buttonDisabled'
               )
                 | コメントする
@@ -240,18 +240,6 @@ export default {
         .catch((error) => {
           console.warn(error)
         })
-      if (
-        this.commentableType === 'Product' &&
-        this.productCheckerId === null
-      ) {
-        this.checkProduct(
-          this.commentableId,
-          this.currentUserId,
-          '/api/products/checker',
-          'PATCH',
-          this.token()
-        )
-      }
     },
     deleteComment(id) {
       fetch(`/api/comments/${id}.json`, {
@@ -304,6 +292,20 @@ export default {
           this.token()
         )
       }
+    },
+    postComment() {
+      this.createComment({ toastMessage: null })
+      if (
+        this.commentableType === 'Product' &&
+        this.productCheckerId === null && this.checkId === null) {
+          this.checkProduct(
+            this.commentableId,
+            this.currentUserId,
+            '/api/products/checker',
+            'PATCH',
+            this.token()
+            )
+          }
     },
     async fetchUncheckedProducts(page) {
       return fetch(`/api/products/unchecked?page=${page}`, {

--- a/app/javascript/toast.js
+++ b/app/javascript/toast.js
@@ -23,7 +23,7 @@ export default {
     },
     displayToast(toastMessage) {
       if (this.isMentorsCommentToProducts) {
-        if (this.productCheckerId) {
+        if (this.productCheckerId || this.checkId) {
           this.toast(this.confirmOrCommentMessage(toastMessage))
         }
       } else {

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -301,6 +301,19 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'comment test'
   end
 
+  test 'when mentor confirm unassigned product with comment' do
+    unassigned_product = products(:product1)
+    visit_with_auth product_url(unassigned_product), 'machida'
+    assert_button '担当する'
+
+    accept_confirm do
+      fill_in 'new_comment[description]', with: 'comment test'
+      click_button '確認OKにする'
+    end
+    assert_text '提出物を確認済みにしました'
+    assert_text 'comment test'
+  end
+
   test 'when mentor confirm a report with comment' do
     visit_with_auth "/reports/#{reports(:report2).id}", 'machida'
     assert_text '確認OKにする'


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/5502
## 概要
担当者がついていない提出物個別ページのコメントフォームから、メンターがコメントをつけて「確認ok」を押した時に正しくトーストが表示されるようにしました。

bootcampでは担当者がついていない提出物に「最初にコメントしたメンター」が担当者になるという仕様があります。この時、表示されるトーストは「担当になりました」というトーストが表示されます。

修正前の状況としては、担当者がついていない提出物に対してメンターがコメントフォームからコメントを入力し、**「コメントする」ではなく**「確認okにする」を押した時に、提出物が確認済みにならず、かつ、「担当になりました」のトーストが表示されていました。

変更後は上記動作時に提出物を確認済みにし、かつ「提出物を確認済みにしました」というトーストが表示されるようにしました。

## 変更確認方法
1. `bug/display-correct-toast`をローカルに取り込む
2. `rails s`で立ち上げる
3. メンターでログインする
4. 未アサインの提出物にコメントをつけて「確認okにする」をクリックする
5. 「提出物を確認済みにしました」というトーストが表示され確認済みスタンプが押されたことを確認する

以下、念の為の確認

6. 4とは違う未アサインの提出物にコメントをつけて「コメントする」をクリックする
7. 「担当になりました」というトーストが表示される
8. その状態でコメントをつけて「確認okにする」をクリックする
9. 「提出物を確認済みにしました」というトーストが表示され確認済みスタンプが押されたことを確認する
10. その状態でコメントをつけて「コメントする」をクリックする
11. 「コメントを投稿しました」のトーストが表示されることを確認する
12. 一般ユーザーでログインし、他ユーザーの未アサインの提出物にコメントを投稿する
13. 「コメントを投稿しました」のトーストが表示されることを確認する
### 変更前
[![Image from Gyazo](https://i.gyazo.com/36f9ba5b53a8f7fd7da170ef7e5c9315.gif)](https://gyazo.com/36f9ba5b53a8f7fd7da170ef7e5c9315)

### 変更後
[![Image from Gyazo](https://i.gyazo.com/c2a275b662c9741d670413b21a0cddf8.gif)](https://gyazo.com/c2a275b662c9741d670413b21a0cddf8)