### PR TITLE
[abstract_notifier] Watchしてるものへのコメント通知を置き換えたい

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -78,20 +78,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def watching_notification(watchable, receiver, comment)
-      watchable_user = watchable.user
-      sender = comment.user
-      action = watchable.instance_of?(Question) ? '回答' : 'コメント'
-      Notification.create!(
-        kind: kinds[:watching],
-        user: receiver,
-        sender: sender,
-        link: Rails.application.routes.url_helpers.polymorphic_path(watchable),
-        message: "#{watchable_user.login_name}さんの【 #{watchable.notification_title} 】に#{comment.user.login_name}さんが#{action}しました。",
-        read: false
-      )
-    end
-
     def three_months_after_retirement(sender, receiver)
       Notification.create!(
         kind: kinds[:retired],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -85,7 +85,7 @@ class NotificationFacade
   end
 
   def self.watching_notification(watchable, receiver, comment)
-    Notification.watching_notification(watchable, receiver, comment)
+    ActivityNotifier.with(watchable: watchable, receiver: receiver, comment: comment).watching_notification.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -275,7 +275,7 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
-  
+
   def watching_notification(params = {})
     params.merge!(@params)
     watchable = params[:watchable]

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -275,4 +275,20 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+  
+  def watching_notification(params = {})
+    params.merge!(@params)
+    watchable = params[:watchable]
+    receiver = params[:receiver]
+    sender = params[:comment].user
+    action = watchable.instance_of?(Question) ? '回答' : 'コメント'
+    notification(
+      kind: :watching,
+      user: receiver,
+      sender: sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(watchable),
+      body: "#{watchable.user.login_name}さんの【 #{watchable.notification_title} 】に#{sender.login_name}さんが#{action}しました。",
+      read: false
+    )
+  end
 end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -283,11 +283,11 @@ class ActivityNotifier < ApplicationNotifier
     sender = params[:comment].user
     action = watchable.instance_of?(Question) ? '回答' : 'コメント'
     notification(
+      body: "#{watchable.user.login_name}さんの【 #{watchable.notification_title} 】に#{sender.login_name}さんが#{action}しました。",
       kind: :watching,
-      user: receiver,
+      receiver: receiver,
       sender: sender,
       link: Rails.application.routes.url_helpers.polymorphic_path(watchable),
-      body: "#{watchable.user.login_name}さんの【 #{watchable.notification_title} 】に#{sender.login_name}さんが#{action}しました。",
       read: false
     )
   end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -3,6 +3,15 @@
 require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test '.commented_users' do
     report = reports(:report4)
     users = report.comments.commented_users

--- a/test/system/followings_test.rb
+++ b/test/system/followings_test.rb
@@ -11,7 +11,7 @@ class FollowingsTest < ApplicationSystemTestCase
   teardown do
     AbstractNotifier.delivery_mode = @delivery_mode
   end
-  
+
   setup do
     @hatsuno = users(:hatsuno)
     @kimura = users(:kimura)

--- a/test/system/followings_test.rb
+++ b/test/system/followings_test.rb
@@ -4,6 +4,15 @@ require 'application_system_test_case'
 
 class FollowingsTest < ApplicationSystemTestCase
   setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+  
+  setup do
     @hatsuno = users(:hatsuno)
     @kimura = users(:kimura)
   end

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class Notification::WatchesTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test '日報作成者がコメントをした際、ウォッチ通知が飛ばないバグの再現' do
     watches(:report1_watch_kimura)
     # コメントを投稿しても自動的にウォッチがONになる


### PR DESCRIPTION
## issue
- #4690
## 概要
通知部分を整理するのに[active_delivery](https://github.com/palkan/active_delivery)を使ったものに変えたいと思っているが、前準備として[abstract_notifier](https://github.com/palkan/abstract_notifier)に対応させる必要がある。

#### 変更前の実装
置き換えるので変更前と変更あとが同じです。

![Screen Shot 0004-09-28 at 13 40](https://user-images.githubusercontent.com/94335407/192689210-4c191a98-e2fe-4f6e-8bb9-ea875b05bb20.png)
#### 変更後の実装

![Screen Shot 0004-09-28 at 13 40](https://user-images.githubusercontent.com/94335407/192689210-4c191a98-e2fe-4f6e-8bb9-ea875b05bb20.png)
## 変更確認方法

1. `feature/replace-watching-people-notifications-with-abstract-notifier`をローカルに取り込む
2. `rails s`で立ち上げる
3. 任意の管理者アカウントでログインする（私の方はmachidaさんアカウントでログインする）
4. `http://localhost:3000/products/938030279`　（何の提出物ページでもいいです）をアクセスしてください。
5. コメント部分でコメントしてください。
6. ブラウザの別のウィンドウで別のアカウントをログインしてください。（任意のユーザ、私の方はwith-hyphenさん）
7.  `http://localhost:3000/products/938030279`　にアクセスしてください。
8. そこで、コメントしてください。
9. machidaさんのウィンドウで新た通知が来てくるはずので`http://localhost:3000/notifications`　にアクセスしてください。
10. 通知があるかどうかを確認する。
![Screen Shot 0004-09-28 at 13 40](https://user-images.githubusercontent.com/94335407/192689210-4c191a98-e2fe-4f6e-8bb9-ea875b05bb20.png)
