### PR TITLE
コメントが多いときに表示されるリンクの文言変更

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -6,7 +6,7 @@
     .thread-comments-more__inner
       .thread-comments-more__action
         button.a-button.is-lg.is-text.is-block(@click='showComments')
-          | 次のコメント（ {{ nextCommentAmount }} ）
+          | 前のコメント（ {{ nextCommentAmount }} ）
   h2.thread-comments__title(
     v-if='commentableType === "RegularEvent" || commentableType === "Event"'
   )

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -247,10 +247,10 @@ class CommentsTest < ApplicationSystemTestCase
   test 'text change "see more comments" button by remaining comment amount' do
     visit_with_auth product_path(users(:hatsuno).products.first.id), 'komagata'
 
-    assert_selector '.a-button.is-lg.is-text.is-block', text: '次のコメント（ 8 / 12 ）'
+    assert_selector '.a-button.is-lg.is-text.is-block', text: '前のコメント（ 8 / 12 ）'
 
     find('.a-button.is-lg.is-text.is-block').click
-    assert_selector '.a-button.is-lg.is-text.is-block', text: '次のコメント（ 4 ）'
+    assert_selector '.a-button.is-lg.is-text.is-block', text: '前のコメント（ 4 ）'
 
     find('.a-button.is-lg.is-text.is-block').click
     assert_no_selector '.a-button.is-lg.is-text.is-block'


### PR DESCRIPTION
# Issue
- https://github.com/fjordllc/bootcamp/issues/5526

# 変更内容
コメントが多いときに表示されるリンクの文言を「次のコメント」から「前のコメント」に修正しました。

変更前
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/43959158/191465898-9e7cf5dc-3628-4c63-bb0d-d981f0fcca30.png">

変更後
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/43959158/191466173-de8d6b43-bff9-4b6a-9e62-627d33d076d7.png">

# 確認方法
※`feature/change-comments-link-message`ブランチをローカルに落として、railsを起動

1. `mentormentaro`でログイン
2. `http://localhost:3000/products/1033498648`にアクセス
3. コメントの文言が「前のコメント」になっていることを確認
<img width="669" alt="image" src="https://user-images.githubusercontent.com/43959158/191469072-35000454-afdb-4c34-ae57-4ffbb5b7f9c6.png">
