### PR TITLE
Q＆Aのページで回答を投稿したらWatchする処理をnewspaperに置き換えた

### DIFF
--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -30,7 +30,6 @@ class API::AnswersController < API::BaseController
     @answer.user = current_user
     if @answer.save
       Newspaper.publish(:answer_create, @answer)
-      Newspaper.publish(:answer_create_answerer_watcher, @answer)
       render :create, status: :created
     else
       head :bad_request

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -30,6 +30,7 @@ class API::AnswersController < API::BaseController
     @answer.user = current_user
     if @answer.save
       Newspaper.publish(:answer_create, @answer)
+      Newspaper.publish(:answer_create_answerer_watcher, @answer)
       render :create, status: :created
     else
       head :bad_request

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -9,7 +9,6 @@ class Answer < ApplicationRecord
   belongs_to :question, touch: false
   alias sender user
 
-  after_create AnswerCallbacks.new
   after_save AnswerCallbacks.new
   after_destroy AnswerCallbacks.new
 

--- a/app/models/answer_callbacks.rb
+++ b/app/models/answer_callbacks.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class AnswerCallbacks
-  def after_create(answer)
-    create_watch(answer)
-  end
-
   def after_save(answer)
     notify_correct_answer(answer) if answer.saved_change_to_attribute?('type', to: 'CorrectAnswer')
 
@@ -25,17 +21,5 @@ class AnswerCallbacks
       receiver = User.find(receiver_id)
       NotificationFacade.chose_correct_answer(answer, receiver)
     end
-  end
-
-  def create_watch(answer)
-    question = Question.find(answer.question_id)
-
-    return if question.watches.pluck(:user_id).include?(answer.sender.id)
-
-    @watch = Watch.new(
-      user: answer.sender,
-      watchable: question
-    )
-    @watch.save!
   end
 end

--- a/app/models/answerer_watcher.rb
+++ b/app/models/answerer_watcher.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AnswererWatcher
+  def call(answer)
+    question = Question.find(answer.question_id)
+
+    return if question.watches.pluck(:user_id).include?(answer.sender.id)
+
+    @watch = Watch.new(
+      user: answer.sender,
+      watchable: question
+    )
+    @watch.save!
+  end
+end

--- a/config/initializers/newspaer.rb
+++ b/config/initializers/newspaer.rb
@@ -2,6 +2,7 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:event_create, EventOrganizerWatcher.new)
   Newspaper.subscribe(:answer_create, AnswerNotifier.new)
   Newspaper.subscribe(:answer_create, NotifierToWatchingUser.new)
+  Newspaper.subscribe(:answer_create, AnswererWatcher.new)
 
   sad_streak_updater = SadStreakUpdater.new
   Newspaper.subscribe(:report_create, sad_streak_updater)


### PR DESCRIPTION
## Issue

- #5496 

## 概要

Q＆Aのページで質問へ回答するとその質問のスレッドをWatch中にする処理をnewspaperに置き換えました。

## 変更点
見た目上の変更はありません。

## 変更確認方法

1. ブランチ`feature/replace-adding-watch-process-upon-posting-answer-with-newspaper`をローカルに取り込む
2. `app/models/answerer_watcher.rb`のcallメソッドの1行目に`puts "AnswerWatcher#call"`を追加する
3. `bin/rails s`でローカル環境を立ち上げる
4.  `kimura`でログインし、http://localhost:3000/questions?target=not_solved へアクセスする
5.  `kimura`以外のユーザーが作成した適当な質問を選択し、テスト用の回答を投稿する
6.  実行ターミナル画面に `"AnswerWatcher#call"`が出力されていることを確認する
![image](https://user-images.githubusercontent.com/58751858/191526712-f53557c9-5a9f-48e9-b857-17d038490309.png)


7. `kimura`をログアウトする
8. 別のアカウント`machida`で再度ログインする
9.  4.でテスト用の回答を投稿した質問へまた新たにテスト用の回答を投稿する
10. `machida`をログアウトする
11. `kimura`で再ログインし、7.の回答が以下のように正常に通知されることを確認する
![image](https://user-images.githubusercontent.com/58751858/190913073-e6697a22-032c-4175-bd51-3f6ee76a3111.png)

12. 通知ページのWatch中のタブ http://localhost:3000/notifications?status=unread&target=watching でも11.と同様の通知が到着することを確認する
![image](https://user-images.githubusercontent.com/58751858/190913092-f7ed06b8-aad1-4e57-ae3f-72ccd330ff83.png)


