### PR TITLE
ダッシュボードの最新のブックマークの作成者名の表示を変更

### DIFF
--- a/app/views/home/_bookmark.html.slim
+++ b/app/views/home/_bookmark.html.slim
@@ -13,7 +13,7 @@
           .card-list-item-meta__items
             .card-list-item-meta__item
               = link_to bookmark.bookmarkable.user, class: 'a-user-name' do
-                = bookmark.bookmarkable.user.name
+                | #{bookmark.bookmarkable.user.login_name}（#{bookmark.bookmarkable.user.name}）
             .card-list-item-meta__item
               time.a-meta(datetime= bookmark.reported_on_or_created_at)
                 = l bookmark.reported_on_or_created_at, format: :long

--- a/app/views/home/_bookmark.html.slim
+++ b/app/views/home/_bookmark.html.slim
@@ -13,7 +13,7 @@
           .card-list-item-meta__items
             .card-list-item-meta__item
               = link_to bookmark.bookmarkable.user, class: 'a-user-name' do
-                | #{bookmark.bookmarkable.user.login_name}（#{bookmark.bookmarkable.user.name}）
+                = bookmark.bookmarkable.user.long_name
             .card-list-item-meta__item
               time.a-meta(datetime= bookmark.reported_on_or_created_at)
                 = l bookmark.reported_on_or_created_at, format: :long


### PR DESCRIPTION
## Issue

- #5509   

## 概要

ダッシュボードに表示される`最新のブックマーク`において、作成者が`名前`のみで表示されていたのを、`id名 (名前)`と表示されるよう変更しました。

## 変更前
`名前`と表示されていました。
![image](https://user-images.githubusercontent.com/58751858/191711412-a489bbcc-7c39-47da-ae23-8bca2fa29e1f.png)


## 変更後
`id名 (名前)`と表示されるよう変更しました。
![image](https://user-images.githubusercontent.com/58751858/191711132-dc06319d-4b58-4273-b27b-b458bbef576c.png)


## 変更確認方法

1. ブランチ`feature/change-display-of-author-name-of-bookmarks-on-dashboard`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3.  `komagata`でログインし、http://localhost:3000/ へアクセスする
