### PR TITLE
dead_endの代わりにsyntax_suggestをGemfileで指定するように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
   # not default
-  gem 'dead_end'
+  gem 'syntax_suggest'
   gem 'pry-byebug'
   gem 'traceroute'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,6 @@ GEM
     data_migrate (8.0.0)
       activerecord (>= 5.0)
       railties (>= 5.0)
-    dead_end (3.1.1)
     declarative (0.0.20)
     diffy (3.4.1)
     digest (3.1.0)
@@ -486,6 +485,7 @@ GEM
     strings-ansi (0.2.0)
     stripe (5.43.0)
     strscan (3.0.1)
+    syntax_suggest (0.0.1)
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.10)
@@ -556,7 +556,6 @@ DEPENDENCIES
   cocoon
   commonmarker
   data_migrate
-  dead_end
   diffy
   discord-notifier
   google-cloud-storage (~> 1.25)
@@ -610,6 +609,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   stripe
   stripe-i18n!
+  syntax_suggest
   traceroute
   vcr!
   view_source_map


### PR DESCRIPTION
## 概要

dead_end gemがsyntax_suggestにリネームされたため、Gemfile内もそれに追従しました。

ref: https://github.com/ruby/syntax_suggest#syntaxsuggest

