### PR TITLE
提出物の更新の通知をabstract_notiferに置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -124,17 +124,6 @@ class Notification < ApplicationRecord
         read: false
       )
     end
-
-    def product_update(product, receiver)
-      Notification.create!(
-        kind: 17,
-        user: receiver,
-        sender: product.user,
-        link: Rails.application.routes.url_helpers.polymorphic_path(product),
-        message: "#{product.user.login_name}さんの提出物が更新されました",
-        read: false
-      )
-    end
   end
 
   def unread?

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -21,7 +21,7 @@ class NotificationFacade
   end
 
   def self.product_update(product, receiver)
-    Notification.product_update(product, receiver)
+    ActivityNotifier.with(product: product, receiver: receiver).product_update.notify_now
     return if receiver.retired?
   end
 

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -260,4 +260,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def product_update(params = {})
+    params.merge!(@params)
+    product = params[:product]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{product.user.login_name}さんの提出物が更新されました",
+      kind: :product_update,
+      receiver: receiver,
+      sender: product.sender,
+      link:  Rails.application.routes.url_helpers.polymorphic_path(product),
+      read: false
+    )
+  end
 end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -271,7 +271,7 @@ class ActivityNotifier < ApplicationNotifier
       kind: :product_update,
       receiver: receiver,
       sender: product.sender,
-      link:  Rails.application.routes.url_helpers.polymorphic_path(product),
+      link: Rails.application.routes.url_helpers.polymorphic_path(product),
       read: false
     )
   end


### PR DESCRIPTION
## Issue

- #4680 

## 概要

提出物更新の通知をabstract_notifierに置き換えました。
見た目の変更はありません。

## 変更確認方法

1. ブランチ`feature/replace-notification-product-with-abstract-notifier`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 受講生のユーザー(`kananashi` など)のアカウントでログインする
4. サイドバーから`プラクティス`をクリックし、任意のプラクティス(例: http://localhost:3000/practices/198065840#learning-Status )を選択する
![image](https://user-images.githubusercontent.com/62344131/191969702-4abf8930-36e0-4936-9ef7-1bfa4ad0b085.png)
5. `提出物を作る` をクリックする
6. `提出物` に任意の文字を入力し、`提出する` をクリックする
7. メンターのアカウントでログインする
8. サイドバーから`提出物` をクリックし、`6.` で作成した提出物について`担当する` をクリックする
![image](https://user-images.githubusercontent.com/62344131/191970038-eb000be2-d7d4-43ed-a3d6-1e57667abdb8.png)
9. `3.` の受講生のユーザーアカウントで6. の提出物画面にアクセスし、`内容修正` をクリックする
10. `提出物` を以前の内容から変更して`提出する` をクリックする
11. `7.` のメンターのアカウントで右上の`通知` をクリックし、`全ての通知` をクリックする
![image](https://user-images.githubusercontent.com/62344131/191970553-27890af7-d30d-4b9a-97c8-91dd23c92021.png)
12. `6.` で作成した提出物の通知が届いていることと、クリックして提出物確認画面に遷移することを確認する
![image](https://user-images.githubusercontent.com/62344131/191970819-64cb58b0-e507-42b9-97ad-2005829fc05b.png)

※難しく書いてしまいましたが、受講生が提出物を作る→メンターがそれの担当になる→提出物を更新する→メンターに通知が送られるかチェック　ということです！
