### PR TITLE
MetaTags.config.title_limit を nil に設定

### DIFF
--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -4,7 +4,7 @@
 MetaTags.configure do |config|
   # How many characters should the title meta tag have at most. Default is 70.
   # Set to nil or 0 to remove limits.
-  # config.title_limit = 70
+  config.title_limit = nil
 
   # When true, site title will be truncated instead of title. Default is false.
   # config.truncate_site_title_first = false


### PR DESCRIPTION
ページタイトルが長くてかつスペースが含まれていると変なところで truncate されてしまうので、truncate されないように meta-tags の設定を変更します。

| before | after |
| - | - |
| <img width="1333" alt="Screen Shot 2022-09-23 at 21 00 23" src="https://user-images.githubusercontent.com/7645585/191956123-27e1d61d-bbd3-482f-bbac-8f2391c60b41.png"> | <img width="1333" alt="Screen Shot 2022-09-23 at 21 01 48" src="https://user-images.githubusercontent.com/7645585/191956136-da19f6b4-19ae-4141-8e62-d153219723b0.png"> |