### PR TITLE
ブログの編集ページに記事公開日時(published_at)の変更フォームを作成

### DIFF
--- a/app/assets/stylesheets/application/blocks/form/_form-item.sass
+++ b/app/assets/stylesheets/application/blocks/form/_form-item.sass
@@ -50,6 +50,8 @@
   &.is-unit
     align-self: flex-end
     padding-bottom: .25em
+  &.is-action
+    align-self: flex-end
 
 .form-item__button
   text-align: center

--- a/app/assets/stylesheets/application/blocks/form/_hidden-form-item.sass
+++ b/app/assets/stylesheets/application/blocks/form/_hidden-form-item.sass
@@ -1,0 +1,7 @@
+.hidden-form-item__target
+  display: none
+  input:checked + .hidden-form-item__trigger + &
+    display: block
+
+input:checked + .hidden-form-item__trigger
+  display: none

--- a/app/assets/stylesheets/atoms/_a-button.sass
+++ b/app/assets/stylesheets/atoms/_a-button.sass
@@ -69,7 +69,7 @@
     +button-size(.75rem, 1.25, 2rem)
   &.is-md,
   &.is-md input[type="submit"]
-    +button-size(.8125rem, 1.5, 2.375rem)
+    +button-size(.8125rem, 1.5, 2.5rem)
   &.is-lg,
   &.is-lg input[type="submit"]
     +button-size(1rem, 1, 2.75rem)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -67,11 +67,16 @@ class ArticlesController < ApplicationController
   end
 
   def article_params
-    if params[:commit] == 'WIP'
-      params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail, :summary)
-    else
-      params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail, :summary, :published_at)
-    end
+    article_attributes = %i[
+      title
+      body
+      tag_list
+      user_id
+      thumbnail
+      summary
+    ]
+    article_attributes.push(:published_at) unless params[:commit] == 'WIP'
+    params.require(:article).permit(*article_attributes)
   end
 
   def redirect_url(article)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -23,14 +23,12 @@ class ArticlesController < ApplicationController
     @article = Article.new
   end
 
-  def edit
-    @article.published_at = Time.current.beginning_of_minute if @article.published_at.nil?
-  end
+  def edit; end
 
   def create
     @article = Article.new(article_params)
     @article.user = current_user if @article.user.nil?
-    set_wip_or_published_time
+    set_wip
     if @article.save
       redirect_to redirect_url(@article), notice: notice_message(@article)
     else
@@ -39,7 +37,7 @@ class ArticlesController < ApplicationController
   end
 
   def update
-    set_wip_or_published_time
+    set_wip
     if @article.update(article_params)
       redirect_to redirect_url(@article), notice: notice_message(@article)
     else
@@ -80,13 +78,8 @@ class ArticlesController < ApplicationController
     article.wip? ? edit_article_url(article) : article
   end
 
-  def set_wip_or_published_time
-    if params[:commit] == 'WIP'
-      @article.wip = true
-    else
-      @article.wip = false
-      @article.published_at = Time.current.beginning_of_minute if @article.published_at.nil?
-    end
+  def set_wip
+    @article.wip = params[:commit] == 'WIP'
   end
 
   def notice_message(article)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -79,7 +79,7 @@ class ArticlesController < ApplicationController
       @article.wip = true
     else
       @article.wip = false
-      @article.published_at = Time.current
+      @article.published_at = Time.current.beginning_of_minute
     end
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -23,7 +23,9 @@ class ArticlesController < ApplicationController
     @article = Article.new
   end
 
-  def edit; end
+  def edit
+    @article.published_at = Time.current.beginning_of_minute if @article.published_at.nil?
+  end
 
   def create
     @article = Article.new(article_params)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -69,7 +69,11 @@ class ArticlesController < ApplicationController
   end
 
   def article_params
-    params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail, :summary, :published_at)
+    if params[:commit] == 'WIP'
+      params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail, :summary)
+    else
+      params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail, :summary, :published_at)
+    end
   end
 
   def redirect_url(article)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -67,7 +67,7 @@ class ArticlesController < ApplicationController
   end
 
   def article_params
-    params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail, :summary)
+    params.require(:article).permit(:title, :body, :tag_list, :user_id, :thumbnail, :summary, :published_at)
   end
 
   def redirect_url(article)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -79,7 +79,7 @@ class ArticlesController < ApplicationController
       @article.wip = true
     else
       @article.wip = false
-      @article.published_at = Time.current.beginning_of_minute
+      @article.published_at = Time.current.beginning_of_minute if @article.published_at.nil?
     end
   end
 

--- a/app/javascript/current-date-time-setter.js
+++ b/app/javascript/current-date-time-setter.js
@@ -4,12 +4,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const currentDateTimeButton = document.getElementById(
     'js-current-date-time-input-button'
   )
+  if (!currentDateTimeButton) return
   const dateTimeField = document.getElementById('date_time_input_field')
   function reflectDateTime() {
     const currentDateTime = dayjs().format('YYYY-MM-DD HH:mm:ss')
     dateTimeField.value = currentDateTime
   }
-  if (currentDateTimeButton) {
-    currentDateTimeButton.addEventListener('click', reflectDateTime)
-  }
+  currentDateTimeButton.addEventListener('click', reflectDateTime)
 })

--- a/app/javascript/current-date-time-setter.js
+++ b/app/javascript/current-date-time-setter.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   )
   const dateTimeField = document.getElementById('date_time_input_field')
   function reflectDateTime() {
-    const currentDateTime = dayjs().format('YYYY-MM-DD HH:mm')
+    const currentDateTime = dayjs().format('YYYY-MM-DD HH:mm:ss')
     dateTimeField.value = currentDateTime
   }
   if (currentDateTimeButton) {

--- a/app/javascript/current-date-time-setter.js
+++ b/app/javascript/current-date-time-setter.js
@@ -1,0 +1,15 @@
+import dayjs from 'dayjs'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const currentDateTimeButton = document.getElementById(
+    'js-current-date-time-input-button'
+  )
+  const dateTimeField = document.getElementById('date_time_input_field')
+  function reflectDateTime() {
+    const currentDateTime = dayjs().format('YYYY-MM-DD HH:mm')
+    dateTimeField.value = currentDateTime
+  }
+  if (currentDateTimeButton) {
+    currentDateTimeButton.addEventListener('click', reflectDateTime)
+  }
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -61,6 +61,7 @@ import '../welcome_message_for_adviser.js'
 import '../stylesheets/application.css'
 import '../bookmarks-edit-button.js'
 import '../hibernation_agreements.js'
+import '../current-date-time-setter.js'
 
 import VueMounter from '../VueMounter.js'
 import Announcements from '../components/announcements.vue'

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -7,6 +7,10 @@ class Article < ApplicationRecord
   THUMBNAIL_SIZE = '1200x630>'
   has_one_attached :thumbnail
 
+  before_validation do
+    self.published_at = Time.current.beginning_of_minute if published_at.nil? && wip == false
+  end
+
   validates :title, presence: true
   validates :body, presence: true
   validates :thumbnail,

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -7,12 +7,11 @@ class Article < ApplicationRecord
   THUMBNAIL_SIZE = '1200x630>'
   has_one_attached :thumbnail
 
-  before_save do
-    self.published_at = Time.zone.now if published_at.nil? && wip == false
-  end
+  before_validation :set_published_at, if: :will_be_published?
 
   validates :title, presence: true
   validates :body, presence: true
+  validates :published_at, presence: true, if: :will_be_published?
   validates :thumbnail,
             content_type: %w[image/png image/jpg image/jpeg],
             size: { less_than: 10.megabytes }
@@ -26,5 +25,15 @@ class Article < ApplicationRecord
     else
       image_url('/images/articles/thumbnails/default.png')
     end
+  end
+
+  private
+
+  def will_be_published?
+    !wip && published_at.nil?
+  end
+
+  def set_published_at
+    self.published_at = Time.zone.now
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -7,7 +7,7 @@ class Article < ApplicationRecord
   THUMBNAIL_SIZE = '1200x630>'
   has_one_attached :thumbnail
 
-  before_validation do
+  before_save do
     self.published_at = Time.current.beginning_of_minute if published_at.nil? && wip == false
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,7 +8,7 @@ class Article < ApplicationRecord
   has_one_attached :thumbnail
 
   before_save do
-    self.published_at = Time.current.beginning_of_minute if published_at.nil? && wip == false
+    self.published_at = Time.zone.now if published_at.nil? && wip == false
   end
 
   validates :title, presence: true

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -34,6 +34,6 @@ class Article < ApplicationRecord
   end
 
   def set_published_at
-    self.published_at = Time.zone.now
+    self.published_at = Time.current
   end
 end

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -58,6 +58,14 @@
             p
               | ここにアップロードした画像が、TwitterでTweet、Facebookで投稿した際に表示される画像として使われます。
               | 画像サイズは必ず 1200px × 630xpx でお願いします。
+              
+    - if params[:action] == 'edit'
+      .form-item
+        .row
+          .col-md-6.col-xs-12
+            = f.label :published_at, '記事公開日時', class: 'a-form-label'
+            = f.datetime_field :published_at, class: 'a-text-input js-warning-form'
+
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -61,15 +61,25 @@
 
     - if params[:action] == 'edit'
       .form-item
-        .row
-          .col-md-6.col-xs-12
-            = f.label :published_at, '記事公開日時', class: 'a-form-label'
-            = f.datetime_field :published_at, class: 'a-text-input js-warning-form', id: 'date_time_input_field'
-            .a-form-help
-              p
-                | WIPで保存した場合は、記事公開日時は保存されません。
-          #js-current-date-time-input-button
-            | 現在の日時
+        .hidden-form-item
+          input.a-toggle-checkbox#toggle-published-at(type='checkbox')
+          .hidden-form-item__trigger
+            label.a-button.is-sm.is-secondary(for='toggle-published-at')
+              | 記事公開日時を変更
+          .hidden-form-item__target
+            .form-item
+              .row
+                .col-md-6.col-xs-12
+                  = f.label :published_at, '記事公開日時', class: 'a-form-label'
+                  .form-item__row
+                    .form-item__column
+                      = f.datetime_field :published_at, class: 'a-text-input js-warning-form', id: 'date_time_input_field'
+                    .form-item__column.is-action
+                      .a-button.is-md.is-primary#js-current-date-time-input-button
+                        | 現在の日時
+                  .a-form-help
+                    p
+                      | WIPで保存した場合は、記事公開日時は保存されません。
 
   .form-actions
     ul.form-actions__items

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -73,7 +73,7 @@
                   = f.label :published_at, '記事公開日時', class: 'a-form-label'
                   .form-item__row
                     .form-item__column
-                      = f.datetime_field :published_at, class: 'a-text-input js-warning-form', id: 'date_time_input_field'
+                      = f.datetime_field :published_at, class: 'a-text-input js-warning-form', id: 'date_time_input_field', step: '1'
                     .form-item__column.is-action
                       .a-button.is-md.is-primary#js-current-date-time-input-button
                         | 現在の日時

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -58,13 +58,18 @@
             p
               | ここにアップロードした画像が、TwitterでTweet、Facebookで投稿した際に表示される画像として使われます。
               | 画像サイズは必ず 1200px × 630xpx でお願いします。
-              
+
     - if params[:action] == 'edit'
       .form-item
         .row
           .col-md-6.col-xs-12
             = f.label :published_at, '記事公開日時', class: 'a-form-label'
-            = f.datetime_field :published_at, class: 'a-text-input js-warning-form'
+            = f.datetime_field :published_at, class: 'a-text-input js-warning-form', id: 'date_time_input_field'
+            .a-form-help
+              p
+                | WIPで保存した場合は、記事公開日時は保存されません。
+          #js-current-date-time-input-button
+            | 現在の日時
 
   .form-actions
     ul.form-actions__items

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -7,4 +7,53 @@ class ArticleTest < ActiveSupport::TestCase
     article = articles(:article1)
     assert_equal '/images/articles/thumbnails/default.png', article.thumbnail_url
   end
+
+  test 'articles directly published without WIP have value of the published_at' do
+    article = Article.create(
+      title: '公開された記事',
+      body: 'WIPを経由せずに公開された記事本文',
+      user: users(:komagata),
+      wip: false
+    )
+    assert article.published_at
+  end
+
+  test 'once articles published, value of the published_at can be kept at WIP.' do
+    article = Article.create(
+      title: '一度公開された記事をWIPに',
+      body: '一度公開され、その後WIPになった記事本文',
+      user: users(:komagata),
+      wip: false
+    )
+    published_at_when_not_wip = article.published_at
+
+    article.update(
+      wip: true
+    )
+    assert_equal article.published_at, published_at_when_not_wip
+  end
+
+  test 'articles directly kept at WIP do not have value of the published_at' do
+    article = Article.create(
+      title: '未公開の記事',
+      body: '一度も公開したことがないWIP記事',
+      user: users(:komagata),
+      wip: true
+    )
+    assert_nil article.published_at
+  end
+
+  test 'once articles directly kept at WIP is published, value of the published_at is not nil' do
+    article = Article.create(
+      title: '未公開の記事',
+      body: '一度も公開したことがないWIP記事',
+      user: users(:komagata),
+      wip: true
+    )
+
+    article.update(
+      wip: false
+    )
+    assert article.published_at
+  end
 end

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -15,7 +15,7 @@ class ArticleTest < ActiveSupport::TestCase
       user: users(:komagata),
       wip: false
     )
-    assert article.published_at
+    assert article.published_at?
   end
 
   test 'once articles published, value of the published_at can be kept at WIP.' do
@@ -54,6 +54,6 @@ class ArticleTest < ActiveSupport::TestCase
     article.update(
       wip: false
     )
-    assert article.published_at
+    assert article.published_at?
   end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -357,4 +357,12 @@ class ArticlesTest < ApplicationSystemTestCase
     visit "/articles/#{@article.id}"
     assert_equal 'タイトル１ | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
+
+  test 'published_at can be changed' do
+    visit_with_auth edit_article_path(@article), 'komagata'
+    find('label.a-button.is-sm.is-secondary', text: '記事公開日時を変更').click
+    fill_in 'article[published_at]', with: Time.zone.parse('2021-12-24 23:59')
+    click_on '更新する'
+    assert_text '2021年12月24日(金) 23:59'
+  end
 end


### PR DESCRIPTION
## Issue

- #5561

## 概要
ブログの編集ページに記事公開日時（`published_at`）の変更フォームを作成し、日時を変更できるようにしました。
`現在の日時`をクリックすると、その時点の日時がフォームに 反映されます。

## 変更点
### 変更前
![image](https://user-images.githubusercontent.com/58751858/192964555-8511c493-dce5-4b38-9000-4d176253f9ad.png)

### 変更後
1. `記事公開日時を変更`のボタンを押す
![スクリーンショット 2022-10-22 15 27 48](https://user-images.githubusercontent.com/58751858/197324053-fe34ce4d-24ed-4a90-aff9-195a8df7f3c9.png)
2. 記事公開日時を変更するためのフォームが現れる
![スクリーンショット 2022-10-22 15 27 56](https://user-images.githubusercontent.com/58751858/197324065-49262f43-f820-4342-96cd-a8476179448f.png)


## 変更確認方法
1. ブランチ`feature/add-form-for-published-at-on-blog-edit-page`をローカルに取り込む
3. `bin/rails s`でローカル環境を立ち上げる
4.  `mentormentaro`でログインし、ブログ記事作成ページ( http://localhost:3000/articles/new ) へアクセスする
5.  テスト記事を作成する
![image](https://user-images.githubusercontent.com/58751858/192967538-29ca921d-f6d7-4e69-a612-85afcae8ccaa.png)

6.  4のリダイレクト先（もしくは http://localhost:3000/articles/ で4.で作成したブログ記事のページ）で`内容修正`ボタンを押し、`ブログ記事編集`ページへアクセスする
7. 一番下までスクロールし、`記事公開日時の編集`のボタンがあることを確認し、クリック。
![スクリーンショット 2022-10-22 15 33 08](https://user-images.githubusercontent.com/58751858/197324262-427e697b-0222-4e41-86fa-fa882828703e.png)

8. フォームへ適当な日時を入力し、`現在の日時`ボタンを押すと、きちんとその時点の時刻がフォームに反映されるか確認。
確認ができたら再度、フォームへ適当な日時を入力し`ページ下の`更新する`ボタンを押し、ブログの記事公開日時を変更する。
![スクリーンショット 2022-10-22 15 27 56](https://user-images.githubusercontent.com/58751858/197324432-07553399-a1fa-4086-94c8-a58adfb48657.png)


10. 記事公開日時が変更されていることを確認する。
![スクリーンショット 2022-10-22 15 40 38](https://user-images.githubusercontent.com/58751858/197324528-64ec1617-1bd6-44db-b13c-b1224707ad08.png)
