### PR TITLE
お知らせの通知処理をNewspaperに置き換えた

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -43,6 +43,7 @@ class AnnouncementsController < ApplicationController
     @announcement.user_id = current_user.id
     set_wip
     if @announcement.save
+      Newspaper.publish(:announcement_create, @announcement) unless @announcement.wip?
       redirect_to @announcement, notice: notice_message(@announcement)
     else
       render :new

--- a/app/models/announcement_callbacks.rb
+++ b/app/models/announcement_callbacks.rb
@@ -17,20 +17,7 @@ class AnnouncementCallbacks
   private
 
   def after_first_publish(announce)
-    notify_to_chat(announce)
-    send_notification(announce)
     announce.update(published_at: Time.current)
-  end
-
-  def notify_to_chat(announce)
-    DiscordNotifier.with(announce: announce).announced.notify_now
-  end
-
-  def send_notification(announce)
-    target_users = User.announcement_receiver(announce.target)
-    target_users.each do |target|
-      NotificationFacade.post_announcement(announce, target) if announce.sender != target
-    end
   end
 
   def create_author_watch(announce)

--- a/app/models/announcement_chat_notifier.rb
+++ b/app/models/announcement_chat_notifier.rb
@@ -2,12 +2,6 @@
 
 class AnnouncementChatNotifier
   def call(announce)
-    path = Rails.application.routes.url_helpers.polymorphic_path(announce)
-    url = "https://bootcamp.fjord.jp#{path}"
-
-    ChatNotifier.message(
-      "お知らせ：「#{announce.title}」\r#{url}",
-      webhook_url: ENV['DISCORD_ALL_WEBHOOK_URL']
-    )
+    DiscordNotifier.with(announce: announce).announced.notify_now
   end
 end

--- a/app/models/announcement_chat_notifier.rb
+++ b/app/models/announcement_chat_notifier.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AnnouncementChatNotifier
+  def call(announce)
+    path = Rails.application.routes.url_helpers.polymorphic_path(announce)
+    url = "https://bootcamp.fjord.jp#{path}"
+
+    ChatNotifier.message(
+      "お知らせ：「#{announce.title}」\r#{url}",
+      webhook_url: ENV['DISCORD_ALL_WEBHOOK_URL']
+    )
+  end
+end

--- a/app/models/announcement_notifier.rb
+++ b/app/models/announcement_notifier.rb
@@ -2,14 +2,6 @@
 
 class AnnouncementNotifier
   def call(announce)
-    path = Rails.application.routes.url_helpers.polymorphic_path(announce)
-    url = "https://bootcamp.fjord.jp#{path}"
-
-    ChatNotifier.message(
-      "お知らせ：「#{announce.title}」\r#{url}",
-      webhook_url: ENV['DISCORD_ALL_WEBHOOK_URL']
-    )
-
     target_users = User.announcement_receiver(announce.target)
     target_users.each do |target|
       NotificationFacade.post_announcement(announce, target) if announce.sender != target

--- a/app/models/announcement_notifier.rb
+++ b/app/models/announcement_notifier.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AnnouncementNotifier
+  def call(announce)
+    path = Rails.application.routes.url_helpers.polymorphic_path(announce)
+    url = "https://bootcamp.fjord.jp#{path}"
+
+    ChatNotifier.message(
+      "お知らせ：「#{announce.title}」\r#{url}",
+      webhook_url: ENV['DISCORD_ALL_WEBHOOK_URL']
+    )
+
+    target_users = User.announcement_receiver(announce.target)
+    target_users.each do |target|
+      NotificationFacade.post_announcement(announce, target) if announce.sender != target
+    end
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -6,6 +6,7 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:answer_create, NotifierToWatchingUser.new)
   Newspaper.subscribe(:announcement_destroy, AnnouncementNotificationDestroyer.new)
   Newspaper.subscribe(:answer_create, AnswererWatcher.new)
+  Newspaper.subscribe(:announcement_create, AnnouncementNotifier.new)
 
   sad_streak_updater = SadStreakUpdater.new
   Newspaper.subscribe(:report_create, sad_streak_updater)

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -7,6 +7,7 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:announcement_destroy, AnnouncementNotificationDestroyer.new)
   Newspaper.subscribe(:answer_create, AnswererWatcher.new)
   Newspaper.subscribe(:announcement_create, AnnouncementNotifier.new)
+  Newspaper.subscribe(:announcement_create, AnnouncementChatNotifier.new)
 
   sad_streak_updater = SadStreakUpdater.new
   Newspaper.subscribe(:report_create, sad_streak_updater)


### PR DESCRIPTION
## Issue

- #5491

## 概要

お知らせの通知処理をNewspaperを使った処理に変更しました。

## 変更確認方法
アプリ画面の通知、メール通知、Discord通知の3つを確認します。

### 事前準備
1. [こちらの日報](https://bootcamp.fjord.jp/reports/41272)を参考に、通知を表示するためのDiscordサーバーを作成して`ウェブフックURL`をコピーする
2. ターミナルで`export DISCORD_ALL_WEBHOOK_URL="コピーしたURL"`を実行する（`env | grep DISCORD_ALL_WEBHOOK_URL`で値が設定されていればOK）


### 確認手順
1. ブランチ`feature/replace-announce-notification-with-newspaper`をローカルに取り込む
1. `bin/rails s`でローカル環境を立ち上げる
4. `komagata`でログインする
5. 通知ターゲットを`全員`にしてお知らせを作成する
6. `mentormentaro`でログインして`http://localhost:3000/notifications?target=announcement`にアクセスして、お知らせの通知が届いていることを確認する
7. `http://localhost:3000/letter_opener`にアクセスして、お知らせの通知が届いていることを確認する
8. Discordサーバーにお知らせの通知が届いていることを確認する
9. 通知のリンクをクリックする(URLが本番環境向けになっているため、`https://bootcamp.fjord.jp`の部分を`localhost:3000`に変更してアクセスする)
10. 該当のページが作成したお知らせであることを確認する
11. 再度`/announcements/new`に遷移して今度はお知らせを一度WIPで保存する
12. 保存したお知らせを編集、公開してDiscordチャンネルに通知が来ていることを確認する
13. 8同様にアクセスして該当のお知らせページに遷移できることを確認する


## 変更前
見た目の変更はありません