### PR TITLE
gemの並び順をアルファベット順にした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,8 +63,8 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
   # not default
-  gem 'syntax_suggest'
   gem 'pry-byebug'
+  gem 'syntax_suggest'
   gem 'traceroute'
 end
 


### PR DESCRIPTION
## 概要

- #5579 でgemを追加したが、rubocopで落ちるようになってしまっているため、gem名がアルファベット順になるように修正しました。

ref: https://app.circleci.com/pipelines/github/fjordllc/bootcamp/3683/workflows/b1ac2499-4d26-4139-8413-b6414f7b48fa/jobs/8987

```sh
Gemfile:67:3: C: [Correctable] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem pry-byebug should appear before syntax_suggest.
  gem 'pry-byebug'
  ^^^^^^^^^^^^^^^^
```