### PR TITLE
落ちやすいテストを２つ直す（日報を確認するのとキャンセルする時、アラートが表示されないテスト）

### DIFF
--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -71,8 +71,10 @@ export default {
       return sadEmotion !== null
     },
     checkHasComment() {
-      const comment = document.querySelector('.thread-comment')
-      return comment !== null
+      const numberOfComments = parseInt(
+        document.querySelector('a[href="#comments"] > span').innerHTML
+      )
+      return numberOfComments > 0
     }
   },
   methods: {


### PR DESCRIPTION
## issue
- #5320 
## 概要
落ちやすいテストを二つ直す。
https://app.circleci.com/pipelines/github/fjordllc/bootcamp/3701/workflows/02248f00-866a-4360-bbc1-4b004678f33a/jobs/9056
https://app.circleci.com/pipelines/github/fjordllc/bootcamp/3776/workflows/687bc484-0bb4-44b9-bc08-3ec88e4f6f2b/jobs/9303
```
Error:
Check::ReportsTest#test_success_report_checking:
Capybara::ModalNotFound: Unable to find modal dialog
    test/system/api/check/reports_test.rb:19:in `block in <class:ReportsTest>'
```
```
Error:
Check::ReportsTest#test_success_report_checking_cancel:
Capybara::ModalNotFound: Unable to find modal dialog
    test/system/api/check/reports_test.rb:30:in `block in <class:ReportsTest>'
```
こちらのテストが落ちやすいので修正しました。

#### 変更前の実装
テストが通らないです。
<img width="597" alt="Screen Shot 0004-10-13 at 9 45 27" src="https://user-images.githubusercontent.com/94335407/195473400-838f7880-287c-4cf4-81ed-d8a5e400a9a6.png">
<img width="616" alt="Screen Shot 0004-10-13 at 9 43 28" src="https://user-images.githubusercontent.com/94335407/195473204-5176aae7-47ce-4e4d-829f-e21ddf7e461a.png">
#### 変更後の実装
テストが通りました。
<img width="561" alt="Screen Shot 0004-10-13 at 9 46 06" src="https://user-images.githubusercontent.com/94335407/195473457-f075f7fc-bc41-482e-a86d-1438fb83ed5c.png">
## 変更確認方法
1. `bug/fix-report-confirm-alert-not-display-test`をローカルに取り込む
2. bashで
```
for i in `seq 100`; do rails test test/system/api/check/reports_test.rb:16; rails test test/system/api/check/reports_test.rb:27; done
```
を実行してください。
これは100回実行するので30分ぐらいお待ちください。
落ちやすい原因は`.thread-comment`というクラスのelementがまだロードしてないのにseleniumは早すぎたので落ちました。
100回実行したらそのテストがいつも通るかどうかを確認できる。
3. 全てのテストが通ることを確認する。
