### PR TITLE
FirefoxでD&Dによる画像添付ができるようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sortablejs": "^1.15.0",
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
-    "textarea-markdown": "^1.2.9",
+    "textarea-markdown": "^1.3.2",
     "tributejs": "^5.1.3",
     "vue": "^2.6.10",
     "vue-loader": "^15.9.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,11 +3094,6 @@ entities@^2.0.0:
   resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@~1.1.1:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz"
-  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
-
 entities@~2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz"
@@ -4898,13 +4893,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-linkify-it@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz"
-  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
-  dependencies:
-    uc.micro "^1.0.1"
-
 linkify-it@^3.0.1:
   version "3.0.3"
   resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz"
@@ -5139,17 +5127,6 @@ markdown-it@^12.3.2:
     argparse "^2.0.1"
     entities "~2.1.0"
     linkify-it "^3.0.1"
-    mdurl "^1.0.1"
-    uc.micro "^1.0.5"
-
-markdown-it@^8.4.0:
-  version "8.4.2"
-  resolved "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz"
-  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
-  dependencies:
-    argparse "^1.0.7"
-    entities "~1.1.1"
-    linkify-it "^2.0.0"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
@@ -8223,12 +8200,12 @@ text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-textarea-markdown@^1.2.9:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/textarea-markdown/-/textarea-markdown-1.3.1.tgz"
-  integrity sha512-1rCSrFwnRE++oM5NT+t7GEbT647geFVPcnhD4y0gSwpIKIpWwy7UbBCTowt7pum+CZB2Hv5niNmO54bP+wyjMA==
+textarea-markdown@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.3.2.tgz#974cfd32081a1e929c208bb756c48296967366a4"
+  integrity sha512-FKRzD04qeE32h/mRoYMZR5j8o3jHjyoACNSIbM5pvvWZI2WTxXWLbLZVKT3R6iQ27p45WxowNxpDc4grIDzmVw==
   dependencies:
-    markdown-it "^8.4.0"
+    markdown-it "^12.3.2"
     whatwg-fetch "^2.0.3"
 
 through2@^2.0.0:


### PR DESCRIPTION
- #5332

## 概要
Firefoxを使って、日報投稿画面にドラッグ&ドロップで画像を添付しようとしても添付されない状態でした。

↓変更前の状況です
![Aug-06-2022 11-03-09](https://user-images.githubusercontent.com/5976902/183229384-2b3fee5b-28d6-4b9d-976f-07bd0c1199af.gif)

## 今回の対応
日報投稿画面などで使用しているnpm（[textarea\-markdown](https://www.npmjs.com/package/textarea-markdown/v/1.3.2)）側でFirefoxでのドラッグ&ドロップができない状況でしたので、そちらにPRを送り、マージしていただきました。
[fix file uploader when use firefox by siroemk · Pull Request \#25](https://github.com/komagata/textarea-markdown/pull/25)
## 確認手順
1. `bug/attach-images-by-drag-and-drop-when-use-firefox`を取り入れる
1. `bin/setup`を実行する
2. `bin/rails s`でサーバーを立ち上げ、Firefoxで`http://localhost:3000/reports/:id/edit`にアクセスする
3. 「日報」の「内容」テキストエリアにドラッグ&ドロップで画像を添付する
画像が添付できればOKです
