### PR TITLE
提出物ページの「直近の日報」をVue化した

### DIFF
--- a/app/javascript/components/user-recent-reports.vue
+++ b/app/javascript/components/user-recent-reports.vue
@@ -1,0 +1,167 @@
+<template lang="pug">
+.card-list.a-card(v-if='limit')
+  .card-header.is-sm
+    h2.card-header__title
+      | 直近の日報
+  .card-list__items(v-if='reports && reports.length > 0')
+    report(
+      v-for='report in reports',
+      :key='report.id',
+      :report='report',
+      :current-user-id='currentUserId',
+      :display-user-icon='displayUserIcon'
+    )
+  .card-body(v-else)
+    .card__description
+      .o-empty-message
+        .o-empty-message__icon
+          i.fa-regular.fa-sad-tear
+        .o-empty-message__text
+          | 日報はまだありません。
+.page-content.reports(v-else)
+  nav.pagination(v-if='totalPages > 1')
+    pager(v-bind='pagerProps')
+  .reports.is-md(v-if='reports === null')
+    loadingListPlaceholder
+  .card-list.a-card(v-else-if='reports.length > 0')
+    .card-list__items
+      report(
+        v-for='report in reports',
+        :key='report.id',
+        :report='report',
+        :current-user-id='currentUserId',
+        :display-user-icon='displayUserIcon'
+      )
+    unconfirmed-link(v-if='isUncheckedReportsPage', label='未チェックの日報を一括で開く')
+  .o-empty-message(v-else-if='reports.length === 0 && isUncheckedReportsPage')
+    .o-empty-message__icon
+      i.fa-regular.fa-smile
+    p.o-empty-message__text
+      | 未チェックの日報はありません
+  .o-empty-message(v-else)
+    .o-empty-message__icon
+      i.fa-regular.fa-sad-tear
+    .o-empty-message__text
+      | 日報はまだありません。
+  nav.pagination(v-if='totalPages > 1')
+    pager(v-bind='pagerProps')
+</template>
+<script>
+import Report from 'components/report.vue'
+import UnconfirmedLink from 'unconfirmed_link.vue'
+import LoadingListPlaceholder from 'loading-list-placeholder.vue'
+import Pager from 'pager.vue'
+
+export default {
+  name: 'UserRecentReports',
+  components: {
+    report: Report,
+    'unconfirmed-link': UnconfirmedLink,
+    loadingListPlaceholder: LoadingListPlaceholder,
+    pager: Pager
+  },
+  props: {
+    userId: {
+      type: Number,
+      default: null
+    },
+    companyId: {
+      type: Number,
+      default: null
+    },
+    practiceId: {
+      type: Number,
+      default: null
+    },
+    limit: {
+      type: String,
+      default: null
+    },
+    displayUserIcon: {
+      type: Boolean,
+      default: true
+    }
+  },
+  data() {
+    return {
+      reports: null,
+      currentPage: this.pageParam(),
+      totalPages: null,
+      currentUserId: null
+    }
+  },
+  computed: {
+    isUncheckedReportsPage() {
+      return location.pathname.includes('unchecked')
+    },
+    newParams() {
+      const params = new URL(location.href).searchParams
+      params.set('page', this.currentPage)
+      if (this.userId) {
+        params.set('user_id', this.userId)
+      }
+      if (this.companyId) {
+        params.set('company_id', this.companyId)
+      }
+      if (this.practiceId) {
+        params.set('practice_id', this.practiceId)
+      }
+      if (this.limit) {
+        params.set('limit', this.limit)
+      }
+      return params
+    },
+    newURL() {
+      return `${location.pathname}?${this.newParams}`
+    },
+    reportsAPI() {
+      const params = this.newParams
+      if (this.isUncheckedReportsPage) {
+        return `/api/reports/unchecked.json?${params}`
+      } else {
+        return `/api/reports.json?${params}`
+      }
+    },
+    pagerProps() {
+      return {
+        initialPageNumber: this.currentPage,
+        pageCount: this.totalPages,
+        pageRange: 9,
+        clickHandle: this.clickCallback
+      }
+    }
+  },
+  created() {
+    window.onpopstate = () => {
+      this.currentPage = this.pageParam()
+      this.getReports()
+    }
+    this.getReports()
+  },
+  methods: {
+    pageParam() {
+      const url = new URL(location.href)
+      const page = url.searchParams.get('page')
+      return parseInt(page || 1)
+    },
+    clickCallback(pageNum) {
+      this.currentPage = pageNum
+      history.pushState(null, null, this.newURL)
+      this.getReports()
+      window.scrollTo(0, 0)
+    },
+    async getReports() {
+      const response = await fetch(this.reportsAPI, {
+        method: 'GET',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      }).catch((error) => console.warn(error))
+      const json = await response.json().catch((error) => console.warn(error))
+      this.reports = json.reports
+      this.currentUserId = json.currentUserId
+      this.totalPages = parseInt(json.totalPages)
+    }
+  }
+}
+</script>

--- a/app/javascript/components/user-recent-reports.vue
+++ b/app/javascript/components/user-recent-reports.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.card-list.a-card(v-if='limit')
+.card-list.a-card
   .card-header.is-sm
     h2.card-header__title
       | 直近の日報
@@ -17,57 +17,23 @@
           i.fa-regular.fa-sad-tear
         .o-empty-message__text
           | 日報はまだありません。
-.page-content.reports(v-else)
-  .reports.is-md(v-if='reports === null')
-    loadingListPlaceholder
-  .card-list.a-card(v-else-if='reports.length > 0')
-    .card-list__items
-      report(
-        v-for='report in reports',
-        :key='report.id',
-        :report='report',
-        :current-user-id='currentUserId'
-      )
-    unconfirmed-link(v-if='isUncheckedReportsPage', label='未チェックの日報を一括で開く')
-  .o-empty-message(v-else-if='reports.length === 0 && isUncheckedReportsPage')
-    .o-empty-message__icon
-      i.fa-regular.fa-smile
-    p.o-empty-message__text
-      | 未チェックの日報はありません
-  .o-empty-message(v-else)
-    .o-empty-message__icon
-      i.fa-regular.fa-sad-tear
-    .o-empty-message__text
-      | 日報はまだありません。
 </template>
 <script>
 import Report from 'components/report.vue'
-import UnconfirmedLink from 'unconfirmed_link.vue'
-import LoadingListPlaceholder from 'loading-list-placeholder.vue'
 
 export default {
   name: 'UserRecentReports',
   components: {
-    report: Report,
-    'unconfirmed-link': UnconfirmedLink,
-    loadingListPlaceholder: LoadingListPlaceholder
+    report: Report
   },
   props: {
     userId: {
       type: Number,
       default: null
     },
-    companyId: {
-      type: Number,
-      default: null
-    },
-    practiceId: {
-      type: Number,
-      default: null
-    },
     limit: {
-      type: String,
-      default: null
+      type: Number,
+      default: 10
     }
   },
   data() {
@@ -77,19 +43,10 @@ export default {
     }
   },
   computed: {
-    isUncheckedReportsPage() {
-      return location.pathname.includes('unchecked')
-    },
     newParams() {
       const params = new URL(location.href).searchParams
       if (this.userId) {
         params.set('user_id', this.userId)
-      }
-      if (this.companyId) {
-        params.set('company_id', this.companyId)
-      }
-      if (this.practiceId) {
-        params.set('practice_id', this.practiceId)
       }
       if (this.limit) {
         params.set('limit', this.limit)
@@ -101,11 +58,7 @@ export default {
     },
     reportsAPI() {
       const params = this.newParams
-      if (this.isUncheckedReportsPage) {
-        return `/api/reports/unchecked.json?${params}`
-      } else {
-        return `/api/reports.json?${params}`
-      }
+      return `/api/reports.json?${params}`
     }
   },
   created() {

--- a/app/javascript/components/user-recent-reports.vue
+++ b/app/javascript/components/user-recent-reports.vue
@@ -18,8 +18,6 @@
         .o-empty-message__text
           | 日報はまだありません。
 .page-content.reports(v-else)
-  nav.pagination(v-if='totalPages > 1')
-    pager(v-bind='pagerProps')
   .reports.is-md(v-if='reports === null')
     loadingListPlaceholder
   .card-list.a-card(v-else-if='reports.length > 0')
@@ -41,22 +39,18 @@
       i.fa-regular.fa-sad-tear
     .o-empty-message__text
       | 日報はまだありません。
-  nav.pagination(v-if='totalPages > 1')
-    pager(v-bind='pagerProps')
 </template>
 <script>
 import Report from 'components/report.vue'
 import UnconfirmedLink from 'unconfirmed_link.vue'
 import LoadingListPlaceholder from 'loading-list-placeholder.vue'
-import Pager from 'pager.vue'
 
 export default {
   name: 'UserRecentReports',
   components: {
     report: Report,
     'unconfirmed-link': UnconfirmedLink,
-    loadingListPlaceholder: LoadingListPlaceholder,
-    pager: Pager
+    loadingListPlaceholder: LoadingListPlaceholder
   },
   props: {
     userId: {
@@ -79,8 +73,6 @@ export default {
   data() {
     return {
       reports: null,
-      currentPage: this.pageParam(),
-      totalPages: null,
       currentUserId: null
     }
   },
@@ -90,7 +82,6 @@ export default {
     },
     newParams() {
       const params = new URL(location.href).searchParams
-      params.set('page', this.currentPage)
       if (this.userId) {
         params.set('user_id', this.userId)
       }
@@ -115,35 +106,12 @@ export default {
       } else {
         return `/api/reports.json?${params}`
       }
-    },
-    pagerProps() {
-      return {
-        initialPageNumber: this.currentPage,
-        pageCount: this.totalPages,
-        pageRange: 9,
-        clickHandle: this.clickCallback
-      }
     }
   },
   created() {
-    window.onpopstate = () => {
-      this.currentPage = this.pageParam()
-      this.getReports()
-    }
     this.getReports()
   },
   methods: {
-    pageParam() {
-      const url = new URL(location.href)
-      const page = url.searchParams.get('page')
-      return parseInt(page || 1)
-    },
-    clickCallback(pageNum) {
-      this.currentPage = pageNum
-      history.pushState(null, null, this.newURL)
-      this.getReports()
-      window.scrollTo(0, 0)
-    },
     async getReports() {
       const response = await fetch(this.reportsAPI, {
         method: 'GET',
@@ -154,7 +122,6 @@ export default {
       const json = await response.json().catch((error) => console.warn(error))
       this.reports = json.reports
       this.currentUserId = json.currentUserId
-      this.totalPages = parseInt(json.totalPages)
     }
   }
 }

--- a/app/javascript/components/user-recent-reports.vue
+++ b/app/javascript/components/user-recent-reports.vue
@@ -19,7 +19,7 @@
           | 日報はまだありません。
 </template>
 <script>
-import Report from 'components/report.vue'
+import Report from './report.vue'
 
 export default {
   name: 'UserRecentReports',

--- a/app/javascript/components/user-recent-reports.vue
+++ b/app/javascript/components/user-recent-reports.vue
@@ -8,8 +8,7 @@
       v-for='report in reports',
       :key='report.id',
       :report='report',
-      :current-user-id='currentUserId',
-      :display-user-icon='displayUserIcon'
+      :current-user-id='currentUserId'
     )
   .card-body(v-else)
     .card__description
@@ -29,8 +28,7 @@
         v-for='report in reports',
         :key='report.id',
         :report='report',
-        :current-user-id='currentUserId',
-        :display-user-icon='displayUserIcon'
+        :current-user-id='currentUserId'
       )
     unconfirmed-link(v-if='isUncheckedReportsPage', label='未チェックの日報を一括で開く')
   .o-empty-message(v-else-if='reports.length === 0 && isUncheckedReportsPage')
@@ -76,10 +74,6 @@ export default {
     limit: {
       type: String,
       default: null
-    },
-    displayUserIcon: {
-      type: Boolean,
-      default: true
     }
   },
   data() {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -77,6 +77,7 @@ import User from '../components/user.vue'
 import Watches from '../components/watches.vue'
 import WatchToggle from '../components/watch-toggle.vue'
 import UserMentorMemo from '../components/user_mentor_memo.vue'
+import UserRecentReports from '../components/user-recent-reports.vue'
 import Talks from '../components/talks.vue'
 
 const mounter = new VueMounter()
@@ -94,6 +95,7 @@ mounter.addComponent(User)
 mounter.addComponent(Watches)
 mounter.addComponent(WatchToggle)
 mounter.addComponent(UserMentorMemo)
+mounter.addComponent(UserRecentReports)
 mounter.addComponent(Talks)
 mounter.mount()
 

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -70,7 +70,7 @@ header.page-header
                     | 提出物
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
-                div(data-vue="Reports" data-vue-user-id:number="#{@product.user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
+                div(data-vue="UserRecentReports" data-vue-user-id:number="#{@product.user.id}")
               .side-tabs-contents__item#side-tabs-content-2
                 #js-practice-memo(data-practice-id="#{@product.practice_id}")
               .side-tabs-contents__item#side-tabs-content-3


### PR DESCRIPTION
## Issue

- #5416 

## 概要
メンター/管理者ユーザーで受講生の提出物ページにアクセスした時に表示される`直近の日報`をVue化しました。

## 確認方法

1. ブランチ`feature/convert-user-recent-reports-on-product-page-to-vuejs`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3.  `mentormentaro`でログインし、左サイドバーから`提出物`をクリックして提出物の一覧ページに移動する
4. どのタブでもいいので`with-hyphen`の提出物のどれかをクリックして、提出物の詳細ページへアクセスする
5. 直近の日報が最大10件表示されていることを確認する
![image](https://user-images.githubusercontent.com/58751858/193611187-7574294e-c772-4857-8758-c9b40ad1c971.png)
6.【お手元のブラウザの拡張機能に依るとは思いますが、こちらも出来れば確認をお願いしたいです】
 [Vue.js devtools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)が既にブラウザの拡張機能にインストールされている場合、デベロッパーツールを開き、`>>`から`Vue`を選択し`直近の日報`全体が`UserRecentReports`としてVue化されていることを確認する
![image](https://user-images.githubusercontent.com/58751858/193612647-f371cbb7-2035-4d65-be43-9e364d9646db.png)

