### PR TITLE
letter_openerでclearできないバグの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ group :development do
   # not default
   gem 'bullet'
   gem 'bundle_outdated_formatter'
-  gem 'letter_opener_web', '~> 1.0'
+  gem 'letter_opener_web', '~> 2.0'
   gem 'rack-dev-mark'
   gem 'rack-mini-profiler', '~> 2.0', require: false
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,12 +236,13 @@ GEM
     kaminari-core (1.2.2)
     launchy (2.5.0)
       addressable (~> 2.7)
-    letter_opener (1.7.0)
-      launchy (~> 2.2)
-    letter_opener_web (1.4.1)
-      actionmailer (>= 3.2)
-      letter_opener (~> 1.0)
-      railties (>= 3.2)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -565,7 +566,7 @@ DEPENDENCIES
   jp_prefecture
   jquery-rails
   kaminari
-  letter_opener_web (~> 1.0)
+  letter_opener_web (~> 2.0)
   listen
   mentionable (~> 0.2.1)
   meta-tags


### PR DESCRIPTION
## Issue

- #5577 

## 概要

letter_opener画面で`clear` ボタンを押すと404エラーとなり、clearできないバグを修正しました。
`letter_opener_web`gem( https://github.com/fgrehm/letter_opener_web )のバージョンを上げて対応しました。


## 変更確認方法

1. ブランチ`bug/cannot_clear_with_letter_opener`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `http://localhost:3000/letter_opener` にアクセスする
4. `clear` ボタンを押し、`Are you sure?` に`OK` (もしメールリストが空っぽの場合は任意のアカウントでログインし、適当に質問を投稿してください。メンターにメールが送信されます)
![image](https://user-images.githubusercontent.com/62344131/193575042-823cf3af-99f3-4f2d-9746-0c5b66c95343.png)
5. メールリストが空っぽになることを確認する
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/62344131/193575546-90bf7215-9430-43ca-98f1-42f3106bdf82.png">