### PR TITLE
管理者がアドバイザーの所属企業を変更できない

### DIFF
--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -48,7 +48,7 @@
   - if from == :new && user.student?
     = render 'users/form/card'
 
-  - if admin_login? || user.trainee?
+  - if ( admin_login? && user.trainee? ) || user.trainee?
     .form__items.js-training-info-block
       h3.form__items-title 研修情報
       = render 'users/form/training_end', f: f

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -48,7 +48,7 @@
   - if from == :new && user.student?
     = render 'users/form/card'
 
-  - if ( admin_login? && user.trainee? ) || user.trainee?
+  - if (admin_login? && user.trainee?) || user.trainee?
     .form__items.js-training-info-block
       h3.form__items-title 研修情報
       = render 'users/form/training_end', f: f

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -71,6 +71,19 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_text 'ユーザー情報を更新しました。'
   end
 
+  test 'update user with company' do
+    user = users(:kensyu)
+    visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'
+    within 'form[name=user]' do
+      assert_text '所属企業'
+      find('.choices').click
+      first('.choices__item', text: 'Fjord Inc.').click
+      click_on '更新する'
+    end
+    assert_text 'ユーザー情報を更新しました。'
+    assert_equal('Fjord Inc.', first('span', text: 'kensyu（Kensyu Seiko）').ancestor('tr').find(:xpath, 'td[4]').text)
+  end
+
   test 'delete user' do
     user = users(:kimura)
     visit_with_auth admin_users_path(target: 'student_and_trainee'), 'komagata'

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -84,6 +84,20 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_equal('Fjord Inc.', first('span', text: 'kensyu（Kensyu Seiko）').ancestor('tr').find(:xpath, 'td[4]').text)
   end
 
+  test 'update advisor with company' do
+    user = users(:senpai)
+    visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'
+    within 'form[name=user]' do
+      assert_text '所属企業'
+      find('.choices').click
+      first('.choices__item', text: 'Fjord Inc.').click
+      click_on '更新する'
+    end
+    assert_text 'ユーザー情報を更新しました。'
+    find('a', text: '全員').click
+    assert_equal('Fjord Inc.', first('span', text: 'senpai（Senpai Ichiro）').ancestor('tr').find(:xpath, 'td[4]').text)
+  end
+
   test 'delete user' do
     user = users(:kimura)
     visit_with_auth admin_users_path(target: 'student_and_trainee'), 'komagata'

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -81,7 +81,8 @@ class Admin::UsersTest < ApplicationSystemTestCase
       click_on '更新する'
     end
     assert_text 'ユーザー情報を更新しました。'
-    assert_equal('Fjord Inc.', first('span', text: 'kensyu（Kensyu Seiko）').ancestor('tr').find(:xpath, 'td[4]').text)
+    visit "/users/#{user.id}"
+    assert_equal('Fjord Inc.', find('.user-metas__item-label', text: '所属企業').sibling('.user-metas__item-value').text)
   end
 
   test 'update advisor with company' do
@@ -94,8 +95,8 @@ class Admin::UsersTest < ApplicationSystemTestCase
       click_on '更新する'
     end
     assert_text 'ユーザー情報を更新しました。'
-    find('a', text: '全員').click
-    assert_equal('Fjord Inc.', first('span', text: 'senpai（Senpai Ichiro）').ancestor('tr').find(:xpath, 'td[4]').text)
+    visit "/users/#{user.id}"
+    assert_equal('Fjord Inc.', find('.user-metas__item-label', text: '所属企業').sibling('.user-metas__item-value').text)
   end
 
   test 'delete user' do


### PR DESCRIPTION
## Issue

- #5589 

## 概要

管理者でログインし、アドバイザーユーザーの個別ページに行き、登録情報を管理者権限で変更できませんでした。

## 確認方法

1. `bug/fix-bug-cannot-update-company`をローカルに取り込む
2. `rails s`で起動する
3. 管理者としてログインして、`http://localhost:3000/admin/users/707153293/edit` にアクセスする
4. 「所属企業」で別の会社を選んでください。
5. 「変更する」ボタンをクリックしてください。
6. 「ユーザー情報を更新しました。」が表示された後で`http://localhost:3000/admin/users/707153293/edit`にもう一度アクセスしてください。
7. 「所属企業」がアップデートしたかどうかを確認してください。

## 変更前
「所属企業」は変更できなかったです。
## 変更後
「所属企業」は変更できるようになりました。