### PR TITLE
落ちやすいテストを２つ直す(質問を作成するとき通知がテストできない) #2

### DIFF
--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -106,6 +106,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       fill_in 'question[description]', with: '公開本文'
     end
     click_button '登録する'
+    assert_text '公開タイトル'
     assert_text '質問を作成しました。'
 
     visit_with_auth '/notifications?status=unread', 'komagata'

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -105,12 +105,11 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       fill_in 'question[title]', with: '公開タイトル'
       fill_in 'question[description]', with: '公開本文'
     end
-    click_button '登録する'
-    assert_text '質問を作成しました。'
-    assert_text '公開タイトル'
-
+    find('input[value="登録する"]').click
+    find('.flash__message', text: '質問を作成しました。')
+    find('.page-content-header__title', text: '公開タイトル')
     visit_with_auth '/notifications?status=unread', 'komagata'
-    assert_text 'kimuraさんから質問「公開タイトル」が投稿されました。'
+    find('.card-list-item-title__link-label', text: 'kimuraさんから質問「公開タイトル」が投稿されました。')
   end
 
   test 'should not notify when a WIP question was updated' do

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -108,6 +108,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     find('input[value="登録する"]').click
     find('.flash__message', text: '質問を作成しました。')
     find('.page-content-header__title', text: '公開タイトル')
+
     visit_with_auth '/notifications?status=unread', 'komagata'
     find('.card-list-item-title__link-label', text: 'kimuraさんから質問「公開タイトル」が投稿されました。')
   end

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -106,8 +106,8 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       fill_in 'question[description]', with: '公開本文'
     end
     click_button '登録する'
-    assert_text '公開タイトル'
     assert_text '質問を作成しました。'
+    assert_text '公開タイトル'
 
     visit_with_auth '/notifications?status=unread', 'komagata'
     assert_text 'kimuraさんから質問「公開タイトル」が投稿されました。'


### PR DESCRIPTION
## issue
- #5320 
## 概要
落ちやすいテストを二つ直す。
<img width="1076" alt="Screen Shot 0004-10-05 at 18 23 23" src="https://user-images.githubusercontent.com/94335407/194027169-9ab7f10c-55b0-4ccd-a96f-9107448a8100.png">
こちらのテストが落ちやすいので修正しました。

#### 変更前の実装
テストが通らないです。
<img width="1076" alt="Screen Shot 0004-10-05 at 18 23 23" src="https://user-images.githubusercontent.com/94335407/194027169-9ab7f10c-55b0-4ccd-a96f-9107448a8100.png">

#### 変更後の実装
テストが通りました。
## 変更確認方法

1. `bug/fix-cannot-find-notification-after-create-a-new-question`をローカルに取り込む
2. zsh shellで`repeat 100 {  rails test test/system/notification/questions_test.rb:99 }`を実行してください。これは100回実行するので30分ぐらいお待ちください。落ちやすい原因はページがまだフールロードできないので100回実行したらそのテストがいつも通るかどうかを確認できる。
3. 全てのテストが通ることを確認する。
