### PR TITLE
ダッシュボード画面で発生していたN+1を解消

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,7 @@ class HomeController < ApplicationController
         redirect_to retire_path
       else
         @announcements = Announcement.with_avatar.where(wip: false).order(published_at: :desc).limit(3)
-        @bookmarks = current_user.bookmarks.order(created_at: :desc).limit(5)
+        @bookmarks = current_user.bookmarks.order(created_at: :desc).limit(5).preload(bookmarkable: :user)
         @completed_learnings = current_user.learnings.where(status: 3).includes(:practice).order(updated_at: :desc)
         @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.order(last_activity_at: :desc)
         @job_seeking_users = User.with_attached_avatar.job_seeking.includes(:reports, :products, :works, :course, :company)


### PR DESCRIPTION
## 概要

* bulletの警告が出ていたので対応しました
* bookmarkableの関連と、さらにそこに関連するuserをeager loadingするようにしました
    * 現状ではBookmarkableで関連づけられているモデルはUserモデルにも関連づいているため