### PR TITLE
ブックマーク一覧画面で発生していたN+1を解消

### DIFF
--- a/app/controllers/api/bookmarks_controller.rb
+++ b/app/controllers/api/bookmarks_controller.rb
@@ -4,7 +4,7 @@ class API::BookmarksController < API::BaseController
   PAGER_NUMBER = 25
 
   def index
-    bookmarks = Bookmark.where(user: current_user).order(created_at: :desc)
+    bookmarks = Bookmark.where(user: current_user).order(created_at: :desc).preload(bookmarkable: :user)
     @bookmarks = Kaminari.paginate_array(bookmarks).page(params[:page]).per(PAGER_NUMBER)
     return unless params[:bookmarkable_id] && params[:bookmarkable_type]
 


### PR DESCRIPTION
## 概要

Bookmarkモデルに紐づくbookmarkableの関連と、さらにそこに関連するuserをeager loadingするようにしました

### 該当コード

https://github.com/fjordllc/bootcamp/blob/18cae819dab9e95524b73676a48425a946435ff8/app/views/api/bookmarks/index.json.jbuilder#L2-L4

https://github.com/fjordllc/bootcamp/blob/18cae819dab9e95524b73676a48425a946435ff8/app/views/api/bookmarks/_bookmark.json.jbuilder