### PR TITLE
ページ(Docs)作成画面で発生していたN+1を解消

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -84,7 +84,7 @@ class PagesController < ApplicationController
   def set_categories
     @categories =
       Category
-      .eager_load(:practices)
+      .eager_load(:practices, :categories_practices)
       .where.not(practices: { id: nil })
       .order('categories_practices.position')
   end


### PR DESCRIPTION
## 概要

- ページ(Docs)作成画面で出ていたbulletのwarning対応です。
    - `categories_practices`テーブルへのN+1を解消しました

### 該当コード

https://github.com/fjordllc/bootcamp/blob/687dfffc4b3668a3113d62e7b150da9072104746/app/controllers/pages_controller.rb#L85-L89

https://github.com/fjordllc/bootcamp/blob/687dfffc4b3668a3113d62e7b150da9072104746/app/helpers/reports_helper.rb#L6
- categoriesテーブルのレコードに関連するpracticesテーブルのレコードを引いてくる際にjoinするが、中間テーブルとしてcategories_practicesテーブルもjoinしており、view内でカテゴリーに関連するプラクティスを参照しようとする際にcategories_practicesテーブルはeager loadingされていなかったためN+1となっていた。