### PR TITLE
使われないpropsを削除

### DIFF
--- a/app/javascript/courses-practice.vue
+++ b/app/javascript/courses-practice.vue
@@ -33,7 +33,6 @@ export default {
   },
   props: {
     practices: { type: Object, required: true },
-    category: { type: Object, required: true },
     learnings: { type: Array, required: true },
     currentUser: { type: Object, required: true, default: null }
   },

--- a/app/javascript/courses-practices.vue
+++ b/app/javascript/courses-practices.vue
@@ -30,7 +30,6 @@
               v-for='practices in category.practices',
               :key='practices.id',
               :practices='practices',
-              :category='category',
               :learnings='learnings',
               :currentUser='currentUser'
             )


### PR DESCRIPTION
## 概要

`courses-practice`コンポーネントにcategoryオブジェクトを渡しているが使われていないため削除しました。
ローカルで動作確認してコンソールエラーがないことを確認済みです。