### PR TITLE
アドバイザーでログインしたときのダッシュボードに研修生がいなくても研修生を表示するブロックが表示される問題を修正

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -47,7 +47,7 @@ header.page-header
             = render '/users/practices/active_practices', user: current_user
           - if current_user.completed_practices.present?
             = render '/users/practices/completed_practices', user: current_user, completed_learnings: @completed_learnings
-          - if current_user.belongs_company_and_adviser?
+          - if current_user.belongs_company_and_adviser? && @collegue_trainees.present?
             = render 'collegue_trainees', collegue_trainees: @collegue_trainees
 
         .col-xs-12.col-xl-6.col-xxl-6

--- a/db/fixtures/companies.yml
+++ b/db/fixtures/companies.yml
@@ -69,3 +69,9 @@ company<%= i %>:
   website: "http://example.com/test"
   created_at: 2000-01-01 00:00:05
 <% end %>
+
+company27:
+  name: "ユーザの企業に登録しないで株式会社"
+  description: "この企業は user　login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
+  website: "http://example.com/test"
+  created_at: 2000-01-01 00:00:05

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -171,3 +171,7 @@ talk_neverlogin:
 talk_sotsugyoukigyoshozoku:
   user: sotsugyoukigyoshozoku
   unreplied: false
+
+talk_advisernocolleguetrainee:
+  user: advisernocolleguetrainee
+  unreplied: false

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -960,45 +960,6 @@ kyuukai:
   updated_at: "2014-01-01 00:00:13"
   created_at: "2014-01-01 00:00:13"
 
-neverlogin: # 1度もログインしたことがないユーザー
-  login_name: neverlogin
-  email: neverlogin@fjord.jp
-  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
-  salt: zW3kQ9ubsxQQtzzzs4ap
-  name: 根場亜　呂具印
-  name_kana:  ネバー　ログイン
-  description: "ユーザー登録後、1度もログインしていないユーザーです。"
-  course: course1
-  os: mac
-  experience: rails
-  free: true
-  updated_at: "2022-07-11 00:00:00"
-  created_at: "2022-07-11 00:00:00"
-
-kyuukai:
-  login_name: kyuukai
-  email: kyuukai@fjord.jp
-  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
-  salt: zW3kQ9ubsxQQtzzzs4ap
-  name: Kyu Kai
-  name_kana: キュウ カイ
-  twitter_account: kyuukai
-  facebook_url: https://www.facebook.com/fjordllc
-  blog_url: https://example.com/kyuukai
-  description: "キュウカイです。休会しています。"
-  customer_id: "cus_12345678"
-  subscription_id: "sub_12345678"
-  course: course1
-  job: office_worker
-  os: mac
-  experience: inexperienced
-  prefecture_code: 4
-  github_account: kyuukai
-  unsubscribe_email_token: k3a49_NwgTsiJS0oHGU2Fw
-  hibernated_at: "2020-01-01 00:00:00"
-  updated_at: "2014-01-01 00:00:13"
-  created_at: "2014-01-01 00:00:13"
-
 sotsugyoukigyoshozoku:
   login_name: sotsugyoukigyoshozoku
   email: sotsugyoukigyoshozoku@example.com

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -980,3 +980,20 @@ sotsugyoukigyoshozoku:
   updated_at: "2022-07-01 00:00:00"
   created_at: "2022-07-01 00:00:00"
   last_activity_at: "2022-07-01 00:00:00"
+
+advisernocolleguetrainee:
+  login_name: advisernocolleguetrainee
+  email: advisernocolleguetrainee@example.com
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: あどばいざ 同僚いない子
+  name_kana: アドバイザ ドウリョウイナイコ
+  twitter_account: advisernocolleguetrainee
+  facebook_url: https://www.facebook.com/fjordllc
+  blog_url: http://advisernocolleguetrainee.example.com
+  adviser: true
+  course: course1
+  unsubscribe_email_token: 6ULb9vj1AJzTH_mOsfR46Q
+  updated_at: "2014-01-01 00:00:04"
+  created_at: "2014-01-01 00:00:04"
+  last_activity_at: "2014-01-01 00:00:04"

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -75,3 +75,9 @@ company<%= i %>:
   website: "http://example.com/test"
   created_at: 2000-01-01 00:00:05
 <% end %>
+
+company27:
+  name: "ユーザの企業に登録しないで株式会社"
+  description: "この企業は user　login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
+  website: "http://example.com/test"
+  created_at: 2000-01-01 00:00:05

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -128,3 +128,7 @@ talk32:
 talk33:
   user: sotsugyoukigyoshozoku
   unreplied: false
+
+talk_advisernocolleguetrainee:
+  user: advisernocolleguetrainee
+  unreplied: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -809,45 +809,6 @@ kyuukai:
   updated_at: "2014-01-01 00:00:13"
   created_at: "2014-01-01 00:00:13"
 
-neverlogin: # 1度もログインしたことがないユーザー
-  login_name: neverlogin
-  email: neverlogin@fjord.jp
-  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
-  salt: zW3kQ9ubsxQQtzzzs4ap
-  name: 根場亜　呂具印
-  name_kana:  ネバー　ログイン
-  description: "ユーザー登録後、1度もログインしていないユーザーです。"
-  course: course1
-  os: mac
-  experience: rails
-  free: true
-  updated_at: "2022-07-11 00:00:00"
-  created_at: "2022-07-11 00:00:00"
-
-kyuukai:
-  login_name: kyuukai
-  email: kyuukai@fjord.jp
-  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
-  salt: zW3kQ9ubsxQQtzzzs4ap
-  name: Kyu Kai
-  name_kana: キュウ カイ
-  twitter_account: kyuukai
-  facebook_url: https://www.facebook.com/fjordllc
-  blog_url: https://example.com/kyuukai
-  description: "キュウカイです。休会しています。"
-  customer_id: "cus_12345678"
-  subscription_id: "sub_12345678"
-  course: course1
-  job: office_worker
-  os: mac
-  experience: inexperienced
-  prefecture_code: 4
-  github_account: kyuukai
-  unsubscribe_email_token: k3a49_NwgTsiJS0oHGU2Fw
-  hibernated_at: "2020-01-01 00:00:00"
-  updated_at: "2014-01-01 00:00:13"
-  created_at: "2014-01-01 00:00:13"
-
 sotsugyoukigyoshozoku:
   login_name: sotsugyoukigyoshozoku
   email: sotsugyoukigyoshozoku@example.com

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -829,3 +829,21 @@ sotsugyoukigyoshozoku:
   updated_at: "2022-07-01 00:00:00"
   created_at: "2022-07-01 00:00:00"
   last_activity_at: "2022-07-01 00:00:00"
+
+advisernocolleguetrainee:
+  login_name: advisernocolleguetrainee
+  email: nocollegueadvisernocollegueadviser@example.com
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: あどばいざ 同僚いない子
+  name_kana: アドバイザ ドウリョウイナイコ
+  course: course1
+  job: office_worker
+  os: mac
+  company: company27
+  description: "同じ企業に研修生がいないけど、アドバイザーです。"
+  unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwg
+  adviser: true
+  updated_at: "2022-07-01 00:00:00"
+  created_at: "2022-07-01 00:00:00"
+  last_activity_at: "2022-07-01 00:00:00"

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -361,4 +361,9 @@ class HomeTest < ApplicationSystemTestCase
     visit_with_auth '/', 'kimura'
     assert_no_selector 'h2.card-header__title', text: '研修生'
   end
+
+  test 'not show trainee lists for adviser when adviser does not have same company trainees' do
+    visit_with_auth '/', 'advisernocolleguetrainee'
+    assert_no_selector 'h2.card-header__title', text: '研修生'
+  end
 end


### PR DESCRIPTION
## Issue

- #5560 

## 概要

アドバイザーでログインしたときのダッシュボードに研修生がいなくても研修生を表示するブロックが表示されていたので、研修生がいない場合は表示しないようにしました。

## 変更確認方法

1 の方法が簡単なのでそちらで再現した方が良さそうです！

### 1. 既存のアドバイザーでログインして確認

1. ブランチ`fix/remove_colleague_block_trainees_if_colleque_trainees_are_not_exist`をローカルに取り込む
2. senpai もしくは advijiro でログイン
4. 登録者情報変更で「所属企業」を「テスト企業」に変更（テスト企業はどのユーザも所属していないため）
5. ダッシュボードに研修生のブロックがないか確認

### 2. 今回のPRで作成した新しいアドバイザーでログインして確認

1. ブランチ`fix/remove_colleague_block_trainees_if_colleque_trainees_are_not_exist`をローカルに取り込む
6. fixtures にデータを追加したので、 `bin/rails seed` で DB にデータを追加する
7. `bin/rails s`でローカル環境を立ち上げる
8. ユーザ（User: advisernocolleguetrainee — ID: 449244843） でログイン
9. ダッシュボードに研修生のブロックがないか確認

## 変更前

<img width="1505" alt="CleanShot 2022-10-12 at 09 55 13@2x" src="https://user-images.githubusercontent.com/43805056/195224604-a564bdbe-758d-452e-8046-10e2c348630d.png">

## 変更後

<img width="1512" alt="CleanShot 2022-10-12 at 09 56 02@2x" src="https://user-images.githubusercontent.com/43805056/195224675-e1554991-5f2c-46dd-ae33-3b189124b8ac.png">
