### PR TITLE
ENVがない時のwebhhok_urlを設定

### DIFF
--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -28,7 +28,7 @@ class DiscordNotifier < ApplicationNotifier
 
   def announced(params = {})
     params.merge!(@params)
-    webhook_url = Rails.application.secrets[:webhook][:all]
+    webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:all]
 
     path = Rails.application.routes.url_helpers.polymorphic_path(params[:announce])
     url = "https://bootcamp.fjord.jp#{path}"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,8 +18,8 @@
 # Environmental secrets are only available for that specific environment.
 shared:
   webhook:
-    admin: <%= ENV['DISCORD_ADMIN_WEBHOOK_URL'] %>
-    all: <%= ENV['DISCORD_ALL_WEBHOOK_URL'] %>
+    admin: <%= ENV['DISCORD_ADMIN_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/admin' %>
+    all: <%= ENV['DISCORD_ALL_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/all' %>
 
 development:
   stripe:


### PR DESCRIPTION
Ref: https://discord.com/channels/715806612824260640/809595476847493192/1030130682866974810

> akingo55 — 2022/10/13
> komagata 
> Issueの動作確認しようとしたところ、以下のようなエラーに遭遇しました。
> お知らせをWIPで作成>公開ボタンをクリックしたタイミングで↑エラーが発生します。
> 自分のブランチだけかと思い、mainブランチでも同じく動作確認しましたが同上のエラーが発生します。
> 原因がわからずでして、解決方法をご教示いただきたいです 🙇