### PR TITLE
定期イベント作成ページのタイトルのプレイスホルダーに「アジャイルサムライ輪読会」を追加

### DIFF
--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -4,7 +4,7 @@
     .form__items-inner
       .form-item
         = f.label :title, class: 'a-form-label'
-        = f.text_field :title, class: 'a-text-input js-warning-form'
+        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'アジャイルサムライ輪読会'
       .form-item
         = f.label :organizer, class: 'a-form-label'
         = f.select(:user_ids, users_name, { include_hidden: false }, { multiple: true, id: 'js-choices-multiple-select' })


### PR DESCRIPTION
## Issue

- #5519 

## 概要

定期イベント作成ページのタイトルのプレイスホルダーに「アジャイルサムライ輪読会」を追加しました。

## 変更確認方法

1. ブランチ`feature/add_placeholder_regular_events_title`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意のユーザでログインする（自分の環境では卒業太郎でログインしました）
5. http://127.0.0.1:3000/regular_events/new にアクセスする

## 変更前
![CleanShot 2022-10-09 at 09 19 05](https://user-images.githubusercontent.com/43805056/194731966-89b57f1b-4af7-416a-827f-504719603765.png)


## 変更後

![CleanShot 2022-10-09 at 09 13 52](https://user-images.githubusercontent.com/43805056/194731970-9d7c108b-4d75-4dd3-b1a4-1c90b4c753f4.png)