### PR TITLE
初回公開時に通知が発行されるように修正

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -32,6 +32,7 @@ class AnnouncementsController < ApplicationController
     set_wip
 
     if @announcement.update(announcement_params)
+      Newspaper.publish(:announcement_create, @announcement) if @announcement.saved_change_to_published_at?(from: nil)
       redirect_to @announcement, notice: notice_message(@announcement)
     else
       render :edit

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -74,6 +74,54 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせをWIPとして保存しました。'
   end
 
+  test 'create announcement with notification' do
+    visit_with_auth new_announcement_path, 'komagata'
+    fill_in 'announcement[title]', with: '公開お知らせ'
+    fill_in 'announcement[description]', with: '公開されるお知らせです。'
+    assert_difference 'Announcement.count', 1 do
+      click_button '作成'
+    end
+
+    visit_with_auth '/notifications', 'hatsuno'
+    assert_text 'お知らせ「公開お知らせ」'
+  end
+
+  test 'publish wip announcement with notification' do
+    announcement = announcements(:announcement_wip)
+    visit_with_auth announcement_path(announcement), 'komagata'
+    within '.announcement' do
+      click_link '内容修正'
+    end
+    click_button '公開'
+
+    visit_with_auth '/notifications', 'hatsuno'
+    assert_text 'お知らせ「wipのお知らせ」'
+  end
+
+  test 'update published announcement without notification' do
+    announcement = announcements(:announcement1)
+    visit_with_auth announcement_path(announcement), 'komagata'
+    within '.announcement' do
+      click_link '内容修正'
+    end
+    click_button '公開'
+
+    visit_with_auth '/notifications', 'hatsuno'
+    assert_no_text 'お知らせ「お知らせ1」'
+  end
+
+  test 'create wip announcement without notification' do
+    visit_with_auth new_announcement_path, 'komagata'
+    fill_in 'announcement[title]', with: '仮のお知らせ'
+    fill_in 'announcement[description]', with: 'まだWIPです。'
+    assert_difference 'Announcement.count', 1 do
+      click_button 'WIP'
+    end
+
+    visit_with_auth '/notifications', 'hatsuno'
+    assert_no_text 'お知らせ「仮のお知らせ」'
+  end
+
   test 'delete announcement with notification' do
     visit_with_auth '/announcements', 'komagata'
     click_link 'お知らせ作成'


### PR DESCRIPTION
## 概要
https://github.com/fjordllc/bootcamp/pull/5591 
こちらのPRの修正です。確認方法などはこちらのPRをご確認ください。

### 事象
お知らせをWIPで保存→公開というフローで操作するとお知らせの通知が発行されないという事象をステージング環境で確認しました。

### 修正内容
updateアクション実行時に`published_at`が`nil`から変更された時（＝初回公開時）に通知を発行する処理を追加しました。

