### PR TITLE
未完了の提出物の最後のコメントが提出者の場合、5日経過したらdiscordのメンターチャンネルで通知されるように

### DIFF
--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -3,7 +3,7 @@
 class Scheduler::DailyController < SchedulerController
   def show
     User.notify_to_discord
-    notify_three_months_after_retirement
+    notify_certain_period_passed_after_retirement
     notify_tomorrow_regular_event
     notify_product_review_not_completed
     head :ok
@@ -11,7 +11,7 @@ class Scheduler::DailyController < SchedulerController
 
   private
 
-  def notify_three_months_after_retirement
+  def notify_certain_period_passed_after_retirement
     User.retired.find_each do |retired_user|
       if retired_user.retired_three_months_ago_and_notification_not_sent?
         User.admins.each do |admin_user|

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -23,10 +23,10 @@ class Scheduler::DailyController < SchedulerController
   end
 
   def notify_tomorrow_regular_event
-    if RegularEvent.tomorrow_events.present?
-      RegularEvent.tomorrow_events.each do |regular_event|
-        NotificationFacade.tomorrow_regular_event(regular_event)
-      end
+    return if RegularEvent.tomorrow_events.blank?
+
+    RegularEvent.tomorrow_events.each do |regular_event|
+      NotificationFacade.tomorrow_regular_event(regular_event)
     end
   end
 

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -33,8 +33,8 @@ class Scheduler::DailyController < SchedulerController
   def notify_product_review_not_completed
     Comment.where(commentable_type: 'Product').find_each do |product_comment|
       product = product_comment.commentable
-      if product_comment.five_days_since_the_last_comment_by_submitter? && !product.unassigned? && !product.checked?
-        NotificationFacade.product_review_not_completed(product_comment)
+      if product_comment.certain_period_passed_since_the_last_comment_by_submitter?(5.days) && !product.unassigned? && !product.checked?
+        DiscordNotifier.with(comment: product_comment).product_review_not_completed.notify_now
       end
     end
   end

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -3,6 +3,15 @@
 class Scheduler::DailyController < SchedulerController
   def show
     User.notify_to_discord
+    notify_three_months_after_retirement
+    notify_tomorrow_regular_event
+    notify_product_review_not_completed
+    head :ok
+  end
+
+  private
+
+  def notify_three_months_after_retirement
     User.retired.find_each do |retired_user|
       if retired_user.retired_three_months_ago_and_notification_not_sent?
         User.admins.each do |admin_user|
@@ -11,12 +20,22 @@ class Scheduler::DailyController < SchedulerController
         end
       end
     end
+  end
 
+  def notify_tomorrow_regular_event
     if RegularEvent.tomorrow_events.present?
       RegularEvent.tomorrow_events.each do |regular_event|
         NotificationFacade.tomorrow_regular_event(regular_event)
       end
     end
-    head :ok
+  end
+
+  def notify_product_review_not_completed
+    Comment.where(commentable_type: 'Product').find_each do |product_comment|
+      product = product_comment.commentable
+      if product_comment.five_days_since_the_last_comment_by_submitter? && !product.unassigned? && !product.checked?
+        NotificationFacade.product_review_not_completed(product_comment)
+      end
+    end
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -50,8 +50,8 @@ class Comment < ApplicationRecord
     !later_exists?
   end
 
-  def five_days_since_the_last_comment_by_submitter?
-    (created_at.since(5.days).to_date == Date.current) && latest? && (user == commentable.user)
+  def certain_period_passed_since_the_last_comment_by_submitter?(certain_period)
+    (created_at.since(certain_period).to_date == Date.current) && latest? && (user == commentable.user)
   end
 
   private

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -50,6 +50,10 @@ class Comment < ApplicationRecord
     !later_exists?
   end
 
+  def five_days_since_the_last_comment_by_submitter?
+    created_at.since(5.days).to_date == Date.current && latest? && user == commentable.user
+  end
+
   private
 
   def later_exists?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -51,7 +51,7 @@ class Comment < ApplicationRecord
   end
 
   def five_days_since_the_last_comment_by_submitter?
-    created_at.since(5.days).to_date == Date.current && latest? && user == commentable.user
+    (created_at.since(5.days).to_date == Date.current) && latest? && (user == commentable.user)
   end
 
   private

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -220,4 +220,8 @@ class NotificationFacade
       receiver: receiver
     ).signed_up.deliver_later(wait: 5)
   end
+
+  def self.product_review_not_completed(comment)
+    DiscordNotifier.with(comment: comment).product_review_not_completed.notify_now
+  end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -220,8 +220,4 @@ class NotificationFacade
       receiver: receiver
     ).signed_up.deliver_later(wait: 5)
   end
-
-  def self.product_review_not_completed(comment)
-    DiscordNotifier.with(comment: comment).product_review_not_completed.notify_now
-  end
 end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -83,4 +83,17 @@ class DiscordNotifier < ApplicationNotifier
       webhook_url: webhook_url
     )
   end
+
+  def product_review_not_completed(params = {})
+    params.merge!(@params)
+    webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:admin]
+    comment = params[:comment]
+    product_checker_name = User.find_by(id: comment.commentable.checker_id).login_name
+
+    notification(
+      body: " ⚠️ #{product_checker_name}さんが担当の#{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。",
+      name: 'ピヨルド',
+      webhook_url: webhook_url
+    )
+  end
 end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -86,7 +86,7 @@ class DiscordNotifier < ApplicationNotifier
 
   def product_review_not_completed(params = {})
     params.merge!(@params)
-    webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:admin]
+    webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:mentor]
     comment = params[:comment]
     product_checker_name = User.find_by(id: comment.commentable.checker_id).login_name
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,6 +19,7 @@
 shared:
   webhook:
     admin: <%= ENV['DISCORD_ADMIN_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/admin' %>
+    mentor: <%= ENV['DISCORD_MENTOR_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/mentor' %>
     all: <%= ENV['DISCORD_ALL_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/all' %>
   stripe:
     public_key: pk_test_Je8A9BUHRC8oqsqx8wtfbKwg

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -80,7 +80,7 @@ class CommentTest < ActiveSupport::TestCase
     end
   end
 
-  test '.five_days_since_the_last_comment_by_submitter?' do
+  test '.days_paassed_since_the_last_comment_by_submitter?' do
     Comment.create!(
       user: users(:komagata),
       commentable: products(:product8),
@@ -95,6 +95,6 @@ class CommentTest < ActiveSupport::TestCase
       created_at: Time.current.ago(5.days)
     )
 
-    assert last_comment.five_days_since_the_last_comment_by_submitter?
+    assert last_comment.certain_period_passed_since_the_last_comment_by_submitter?(5.days)
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -80,7 +80,7 @@ class CommentTest < ActiveSupport::TestCase
     end
   end
 
-  test '.days_paassed_since_the_last_comment_by_submitter?' do
+  test '#certain_period_passed_since_the_last_comment_by_submitter?' do
     Comment.create!(
       user: users(:komagata),
       commentable: products(:product8),

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -79,4 +79,22 @@ class CommentTest < ActiveSupport::TestCase
       comment.destroy!
     end
   end
+
+  test '.five_days_since_the_last_comment_by_submitter?' do
+    Comment.create!(
+      user: users(:komagata),
+      commentable: products(:product8),
+      description: '提出物への最初のコメント',
+      created_at: Time.current.ago(6.days)
+    )
+
+    last_comment = Comment.create!(
+      user: users(:kimura),
+      commentable: products(:product8),
+      description: '提出物への提出者による最後のコメントかつ、投稿から5日経過',
+      created_at: Time.current.ago(5.days)
+    )
+
+    assert last_comment.five_days_since_the_last_comment_by_submitter?
+  end
 end

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -121,7 +121,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       DiscordNotifier.with(params).payment_failed.notify_later
     end
   end
-  
+
   test '.product_review_not_completed' do
     product = products(:product8)
     product.update!(checker_id: users(:komagata).id)

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -121,4 +121,30 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       DiscordNotifier.with(params).payment_failed.notify_later
     end
   end
+  
+  test '.product_review_not_completed' do
+    product = products(:product8)
+    product.update!(checker_id: users(:komagata).id)
+    comment = Comment.create!(user: users(:kimura), commentable: product, description: '提出者による返信')
+
+    params = {
+      comment: comment,
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    expected = {
+      body: ' ⚠️ komagataさんが担当のkimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから5日経過しました。',
+      name: 'ピヨルド',
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+    assert_notifications_sent 2, **expected do
+      DiscordNotifier.product_review_not_completed(params).notify_now
+      DiscordNotifier.with(params).product_review_not_completed.notify_now
+    end
+
+    assert_notifications_enqueued 2, **expected do
+      DiscordNotifier.product_review_not_completed(params).notify_later
+      DiscordNotifier.with(params).product_review_not_completed.notify_later
+    end
+  end
 end

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -123,9 +123,8 @@ class DiscordNotifierTest < ActiveSupport::TestCase
   end
 
   test '.product_review_not_completed' do
-    product = products(:product8)
-    product.update!(checker_id: users(:komagata).id)
-    comment = Comment.create!(user: users(:kimura), commentable: product, description: '提出者による返信')
+    products(:product8).update!(checker_id: users(:komagata).id)
+    comment = Comment.create!(user: users(:kimura), commentable: products(:product8), description: '提出者による返信')
 
     params = {
       comment: comment,


### PR DESCRIPTION
## Issue

- #5324 

## 概要
未完了の提出物のページにおいて最後のコメントが提出者の場合、そのコメントから5日が経過したらメンターチャンネルでdiscord通知されるようにしました。（Discordのメンターチャンネルは非公開チャンネルです。）


## 変更確認方法
1. このPRにおいてはdiscordでの通知を確認するために、discordのサーバー、チャンネルの作成とそのwebhookの取得が必要となります。discordでテスト用のサーバーを作成しテスト用のチャンネルを作ってそのwebhookURLの取得をしてください。yumさんの #5480 の確認方法においてwebhookURLの取得までが丁寧に説明されています。
2. ブランチ`feature/notify-other-mentors-if-the-person-made-last-comment-is-submitter`をローカルに取り込む
3.  以下の`params[:webhook_url]`の部分を`'1で取得したdiscordのwebhookURL'`に置き換える（置き換えないと通知のテストができないため）
https://github.com/fjordllc/bootcamp/blob/5b5dff6519594ce4a9321121a463b9c81e61671d/app/notifiers/discord_notifier.rb#L78

4. `bin/rails s`でローカル環境を立ち上げる
5.  `mentormentaro`でログインし、`kensyu`の提出物である( http://localhost:3000/products/613458348 ) へアクセスする
6. `担当する`ボタンを押して、5.でアクセスした`kensyu`の「OS X Mountain Lionをクリーンインストールするの提出物」で`mentormentaro`が担当となるように設定する

7. `rails c`で担当者`mentormentaro`による7日前のコメントを作成する（以下をコピー＆ペーストしてください）
```ruby
# commentable_id → 手順5.でアクセスした提出物のid
# user_id → mentormentaroのid
Comment.create!(commentable_id:613458348, user_id: 534981761, description: "test", commentable_type: "Product", created_at:Time.current.ago(7.days), updated_at:Time.current.ago(7.days))
```
8. `rails c`で提出者`kensyu`による5日前のコメントを作成する（以下をコピー＆ペーストしてください）
```ruby
# commentable_id → 手順5.でアクセスした提出物のid
# user_id → kensyuのid
Comment.create!(commentable_id:613458348, user_id: 301971253, description: "test", commentable_type: "Product", created_at:Time.current.ago(5.days), updated_at:Time.current.ago(5.days))
```

👍このような状態になります
![image](https://user-images.githubusercontent.com/58751858/197460300-e092e4c2-51a6-434e-b2d1-261c2aec5ac1.png)

9. 上記が全て整ったら、http://localhost:3000/scheduler/daily にアクセスする（画面は何も表示されませんが、処理が走ります）
10. Discordの通知に以下のような内容で通知が来ることを確認する
![image](https://user-images.githubusercontent.com/58751858/197460843-30bfa882-3fb3-49b6-80fa-2052ed6642ae.png)
