### PR TITLE
新規入会者の通知にロールを追加

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -33,6 +33,21 @@ module UserDecorator
                .join('、')
   end
 
+  def roles_to_s
+    return '' if roles.empty?
+
+    roles = [
+      { role: '管理者', value: admin },
+      { role: 'メンター', value: mentor },
+      { role: 'アドバイザー', value: adviser },
+      { role: '卒業生', value: graduated_on? },
+      { role: '研修生', value: trainee }
+    ]
+    roles.find_all { |v| v[:value] }
+         .map { |v| v[:role] }
+         .join('、')
+  end
+
   def icon_title
     ["#{login_name} (#{name})", staff_roles].reject(&:blank?)
                                             .join(': ')

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -180,8 +180,9 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   # required params: sender, receiver
   def signed_up
     @user = @receiver
+    roles = @sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"
     @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:signed_up])
-    subject = "[FBC] #{@sender.login_name}さんが新しく入会しました！"
+    subject = "[FBC] #{@sender.login_name}さん#{roles}が新しく入会しました！"
     mail to: @user.email, subject: subject
   end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -212,7 +212,7 @@ class NotificationFacade
   end
 
   def self.signed_up(sender, receiver)
-    ActivityNotifier.with(sender: sender, receiver: receiver).signed_up.notify_now
+    ActivityNotifier.with(sender: sender, receiver: receiver, sender_roles: sender.roles_to_s).signed_up.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -176,9 +176,10 @@ class ActivityNotifier < ApplicationNotifier
     params.merge!(@params)
     sender = params[:sender]
     receiver = params[:receiver]
+    roles = sender.roles_to_s.empty? ? '' : "（#{sender.roles_to_s}）"
 
     notification(
-      body: "🎉 #{sender.login_name}さんが新しく入会しました！",
+      body: "🎉 #{sender.login_name}さん#{roles}が新しく入会しました！",
       kind: :signed_up,
       sender: sender,
       receiver: receiver,

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -175,11 +175,11 @@ class ActivityNotifier < ApplicationNotifier
   def signed_up(params = {})
     params.merge!(@params)
     sender = params[:sender]
+    sender_roles = params[:sender_roles].empty? ? '' : "(#{params[:sender_roles]})"
     receiver = params[:receiver]
-    roles = sender.roles_to_s.empty? ? '' : "（#{sender.roles_to_s}）"
 
     notification(
-      body: "🎉 #{sender.login_name}さん#{roles}が新しく入会しました！",
+      body: "🎉 #{sender.login_name}さん#{sender_roles}が新しく入会しました！",
       kind: :signed_up,
       sender: sender,
       receiver: receiver,

--- a/app/views/notification_mailer/signed_up.html.slim
+++ b/app/views/notification_mailer/signed_up.html.slim
@@ -1,1 +1,1 @@
-= render 'notification_mailer_template', title: "#{@sender.login_name}さんが新しく入会しました！", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ"
+= render 'notification_mailer_template', title: "#{@sender.login_name}さん#{@sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"}が新しく入会しました！", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ"

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -7,42 +7,43 @@ class UserDecoratorTest < ActiveSupport::TestCase
 
   def setup
     ActiveDecorator::ViewContext.push(controller.view_context)
-    @user1 = ActiveDecorator::Decorator.instance.decorate(users(:komagata))
-    @user2 = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
-    @user3 = ActiveDecorator::Decorator.instance.decorate(users(:sotugyou))
-    @user4 = ActiveDecorator::Decorator.instance.decorate(users(:adminonly))
-    @user5 = ActiveDecorator::Decorator.instance.decorate(users(:advijirou))
-    @user6 = ActiveDecorator::Decorator.instance.decorate(users(:mentormentaro))
-    @user7 = ActiveDecorator::Decorator.instance.decorate(users(:kensyu))
+    @admin_mentor_user = ActiveDecorator::Decorator.instance.decorate(users(:komagata))
+    @student_user = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
+    @graduated_user = ActiveDecorator::Decorator.instance.decorate(users(:sotugyou))
+    @admin_user = ActiveDecorator::Decorator.instance.decorate(users(:adminonly))
+    @adviser_user = ActiveDecorator::Decorator.instance.decorate(users(:advijirou))
+    @mentor_user = ActiveDecorator::Decorator.instance.decorate(users(:mentormentaro))
+    @trainee_user = ActiveDecorator::Decorator.instance.decorate(users(:kensyu))
   end
 
   test '#staff_roles' do
-    assert_equal '管理者、メンター', @user1.staff_roles
-    assert_equal '', @user2.staff_roles
+    assert_equal '管理者、メンター', @admin_mentor_user.staff_roles
+    assert_equal '', @student_user.staff_roles
   end
 
   test '#icon_title' do
-    assert_equal 'komagata (Komagata Masaki): 管理者、メンター', @user1.icon_title
-    assert_equal 'hajime (Hajime Tayo)', @user2.icon_title
+    assert_equal 'komagata (Komagata Masaki): 管理者、メンター', @admin_mentor_user.icon_title
+    assert_equal 'hajime (Hajime Tayo)', @student_user.icon_title
   end
 
   test '#long_name' do
-    assert_equal 'hajime (Hajime Tayo)', @user2.long_name
+    assert_equal 'hajime (Hajime Tayo)', @student_user.long_name
   end
 
   test '#enrollment_period' do
-    assert_equal "<span> #{@user2.elapsed_days}日目 </span><a href=\"/generations/#{@user2.generation}\">#{@user2.generation}期生</a>", @user2.enrollment_period
-    assert_equal "<span> (#{l @user3.graduated_on}卒業 #{@user3.elapsed_days}日) </span><a href=\"/generations/#{@user3.generation}\">#{@user2.generation}期生</a>",
-                 @user3.enrollment_period
+    assert_equal "<span> #{@student_user.elapsed_days}日目 </span><a href=\"/generations/#{@student_user.generation}\">#{@student_user.generation}期生</a>",
+                 @student_user.enrollment_period
+    assert_equal "<span> (#{l @graduated_user.graduated_on}卒業 #{@graduated_user.elapsed_days}日) </span><a href=\"/generations/#{@graduated_user.generation}\">#{@student_user.generation}期生</a>",
+                 @graduated_user.enrollment_period
   end
 
   test '#roles_to_s' do
-    assert_equal '管理者、メンター', @user1.roles_to_s
-    assert_equal '', @user2.roles_to_s
-    assert_equal '卒業生', @user3.roles_to_s
-    assert_equal '管理者', @user4.roles_to_s
-    assert_equal 'アドバイザー', @user5.roles_to_s
-    assert_equal 'メンター', @user6.roles_to_s
-    assert_equal '研修生', @user7.roles_to_s
+    assert_equal '管理者、メンター', @admin_mentor_user.roles_to_s
+    assert_equal '', @student_user.roles_to_s
+    assert_equal '卒業生', @graduated_user.roles_to_s
+    assert_equal '管理者', @admin_user.roles_to_s
+    assert_equal 'アドバイザー', @adviser_user.roles_to_s
+    assert_equal 'メンター', @mentor_user.roles_to_s
+    assert_equal '研修生', @trainee_user.roles_to_s
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -10,6 +10,10 @@ class UserDecoratorTest < ActiveSupport::TestCase
     @user1 = ActiveDecorator::Decorator.instance.decorate(users(:komagata))
     @user2 = ActiveDecorator::Decorator.instance.decorate(users(:hajime))
     @user3 = ActiveDecorator::Decorator.instance.decorate(users(:sotugyou))
+    @user4 = ActiveDecorator::Decorator.instance.decorate(users(:adminonly))
+    @user5 = ActiveDecorator::Decorator.instance.decorate(users(:advijirou))
+    @user6 = ActiveDecorator::Decorator.instance.decorate(users(:mentormentaro))
+    @user7 = ActiveDecorator::Decorator.instance.decorate(users(:kensyu))
   end
 
   test '#staff_roles' do
@@ -30,5 +34,15 @@ class UserDecoratorTest < ActiveSupport::TestCase
     assert_equal "<span> #{@user2.elapsed_days}日目 </span><a href=\"/generations/#{@user2.generation}\">#{@user2.generation}期生</a>", @user2.enrollment_period
     assert_equal "<span> (#{l @user3.graduated_on}卒業 #{@user3.elapsed_days}日) </span><a href=\"/generations/#{@user3.generation}\">#{@user2.generation}期生</a>",
                  @user3.enrollment_period
+  end
+
+  test '#roles_to_s' do
+    assert_equal '管理者、メンター', @user1.roles_to_s
+    assert_equal '', @user2.roles_to_s
+    assert_equal '卒業生', @user3.roles_to_s
+    assert_equal '管理者', @user4.roles_to_s
+    assert_equal 'アドバイザー', @user5.roles_to_s
+    assert_equal 'メンター', @user6.roles_to_s
+    assert_equal '研修生', @user7.roles_to_s
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -33,7 +33,9 @@ class UserDecoratorTest < ActiveSupport::TestCase
   test '#enrollment_period' do
     assert_equal "<span> #{@student_user.elapsed_days}日目 </span><a href=\"/generations/#{@student_user.generation}\">#{@student_user.generation}期生</a>",
                  @student_user.enrollment_period
-    assert_equal "<span> (#{l @graduated_user.graduated_on}卒業 #{@graduated_user.elapsed_days}日) </span><a href=\"/generations/#{@graduated_user.generation}\">#{@student_user.generation}期生</a>",
+
+    assert_equal "<span> (#{l @graduated_user.graduated_on}卒業 #{@graduated_user.elapsed_days}日)" \
+                  " </span><a href=\"/generations/#{@graduated_user.generation}\">#{@graduated_user.generation}期生</a>",
                  @graduated_user.enrollment_period
   end
 

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -83,7 +83,10 @@ class ActivityNotifierTest < ActiveSupport::TestCase
   end
 
   test '#signed_up' do
-    notification = ActivityNotifier.with(sender: users(:hajime), receiver: users(:mentormentaro)).signed_up
+    notification = ActivityNotifier.with(sender: users(:hajime),
+                                         receiver: users(:mentormentaro),
+                                         # テストでは Decorator(user_decorator) のメソッドを参照できないため、user(:hajime).roles_to_s メソッドは使用せずに手動でロールを記述。
+                                         sender_roles: '').signed_up
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       notification.notify_now

--- a/test/system/notification/signed_up_test.rb
+++ b/test/system/notification/signed_up_test.rb
@@ -35,7 +35,7 @@ class Notification::SignedUpTest < ApplicationSystemTestCase
 
     visit_with_auth notifications_path, 'komagata'
     within first('.card-list-item.is-unread') do
-      assert_selector '.card-list-item-title__link-label', text: '🎉 harukoさんが新しく入会しました！'
+      assert_selector '.card-list-item-title__link-label', text: '🎉 harukoさん(アドバイザー)が新しく入会しました！'
     end
   end
 
@@ -69,7 +69,7 @@ class Notification::SignedUpTest < ApplicationSystemTestCase
 
     visit_with_auth notifications_path, 'komagata'
     within first('.card-list-item.is-unread') do
-      assert_selector '.card-list-item-title__link-label', text: '🎉 natsumiさんが新しく入会しました！'
+      assert_selector '.card-list-item-title__link-label', text: '🎉 natsumiさん(研修生)が新しく入会しました！'
     end
   end
 


### PR DESCRIPTION
## Issue

- #5620 

## 概要

新規入会者の通知の時にユーザ名の横に役割を表示

## 変更確認方法

1. ブランチ`feature/show_role_in_signed_up_notification`をローカルに取り込む
2. ロールを持つユーザを追加するために、管理者権限を持つユーザでログイン(machida, komagata)
3. [ダッシュボード ＞ Me ＞ 管理メニュー＞ 管理ページ ＞ 企業](http://localhost:3000/admin/companies) を開く→ どの企業でも良いので「アドバイザー招待リンク」を押下
4. 特殊ユーザ特性の「アドバイザー」にチェックを入れる。他は適当な値を全ての欄に入力。最後に「アドバイザーの登録」を押して登録を完了する。
6. 管理者権限を持つユーザの[ダッシュボード](http://localhost:3000/) に遷移して、通知にロールが追加されているかを確認
7. [メール一覧](http://localhost:3000/letter_opener)を表示して、件名と内容の名前の横にロールが追加されているかを確認

アドバイザーのチェック欄
![CleanShot 2022-10-23 at 17 37 23](https://user-images.githubusercontent.com/43805056/197382790-f7184d3a-3123-4695-90c1-46f362241490.png)


## 変更前

### 通知欄
![CleanShot 2022-10-23 at 17 47 48](https://user-images.githubusercontent.com/43805056/197383019-e0f200ab-2eaf-469c-811e-894d6fbd28bb.png)
![CleanShot 2022-10-23 at 17 47 34](https://user-images.githubusercontent.com/43805056/197383020-1dd233d2-3da9-46ac-aa2a-094448fc96b5.png)
### メール
![CleanShot 2022-10-24 at 22 30 31](https://user-images.githubusercontent.com/43805056/197539513-e32a96db-c8dd-4c6b-99f7-f390277c5584.png)


## 変更後
### 通知欄
![CleanShot 2022-10-23 at 17 41 30](https://user-images.githubusercontent.com/43805056/197382824-ec117734-2757-48fb-a3b0-f6fd94cf4753.png)

![CleanShot 2022-10-23 at 17 41 39](https://user-images.githubusercontent.com/43805056/197382826-77d4dcd7-bc5d-4317-ac77-9fc62ed94639.png)

### メール
![CleanShot 2022-10-24 at 22 35 26](https://user-images.githubusercontent.com/43805056/197539500-086abc2e-8596-4cc7-a923-189eea86afa9.png)
