### PR TITLE
参考書籍一覧ページに必読マークを表示する

### DIFF
--- a/app/decorators/book_decorator.rb
+++ b/app/decorators/book_decorator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module BookDecorator
+  def must_read_for_any_practices?
+    practices_books.any?(&:must_read)
+  end
+end

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module BooksHelper
+  def must_read_for_any_practice?(book)
+    book.practices_books.any?(&:must_read)
+  end
+end

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BooksHelper
-  def must_read_for_any_practice?(book)
+  def must_read_for_any_practices?(book)
     book.practices_books.any?(&:must_read)
   end
 end

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module BooksHelper
-  def must_read_for_any_practices?(book)
-    book.practices_books.any?(&:must_read)
-  end
-end

--- a/app/javascript/components/book.vue
+++ b/app/javascript/components/book.vue
@@ -16,6 +16,8 @@
           .card-books-item__rows
             .card-books-item__row
               h2.card-books-item__title
+                span.a-badge.is-danger.is-sm(v-if='book.mustRead')
+                  | 必読
                 a.card-books-item__title-link(
                   :href='book.pageUrl',
                   target='_blank',

--- a/app/views/api/books/_book.json.jbuilder
+++ b/app/views/api/books/_book.json.jbuilder
@@ -5,6 +5,6 @@ json.description book.description
 json.pageUrl book.page_url
 json.coverUrl book.cover_url
 json.editBookPath edit_book_path(book)
-json.mustRead must_read_for_any_practice?(book)
+json.mustRead must_read_for_any_practices?(book)
 
 json.practices book.practices, partial: "api/books/practice", as: :practice

--- a/app/views/api/books/_book.json.jbuilder
+++ b/app/views/api/books/_book.json.jbuilder
@@ -5,5 +5,6 @@ json.description book.description
 json.pageUrl book.page_url
 json.coverUrl book.cover_url
 json.editBookPath edit_book_path(book)
+json.mustRead must_read_for_any_practice?(book)
 
 json.practices book.practices, partial: "api/books/practice", as: :practice

--- a/app/views/api/books/_book.json.jbuilder
+++ b/app/views/api/books/_book.json.jbuilder
@@ -5,6 +5,6 @@ json.description book.description
 json.pageUrl book.page_url
 json.coverUrl book.cover_url
 json.editBookPath edit_book_path(book)
-json.mustRead must_read_for_any_practices?(book)
+json.mustRead book.must_read_for_any_practices?
 
 json.practices book.practices, partial: "api/books/practice", as: :practice

--- a/test/decorators/book_decorator_test.rb
+++ b/test/decorators/book_decorator_test.rb
@@ -9,7 +9,7 @@ class BookDecoratorTest < ActiveSupport::TestCase
   end
 
   test '#must_read_for_any_practices?' do
-    assert_equal true, @book1.must_read_for_any_practices?
-    assert_equal false, @book2.must_read_for_any_practices?
+    assert @book1.must_read_for_any_practices?
+    assert_not @book2.must_read_for_any_practices?
   end
 end

--- a/test/decorators/book_decorator_test.rb
+++ b/test/decorators/book_decorator_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BookDecoratorTest < ActiveSupport::TestCase
+  setup do
+    @book1 = ActiveDecorator::Decorator.instance.decorate(books(:book1))
+    @book2 = ActiveDecorator::Decorator.instance.decorate(books(:book2))
+  end
+
+  test '#must_read_for_any_practices?' do
+    assert_equal true, @book1.must_read_for_any_practices?
+    assert_equal false, @book2.must_read_for_any_practices?
+  end
+end


### PR DESCRIPTION
## Issue

- #5571

## 概要
`/books`書籍一覧ページで書籍が何かしらのプラクティスで必読に指定されている場合は必読マークを表示するように変更しました。

## 変更確認方法

1. ブランチ`feature/display-must-read-mark-in-books`をローカルに取り込む
2. サーバーを起動する
3. `mentormentaro`でログインする
4. `http://localhost:3000/books`にアクセスする
5. 『ゼロからわかるRuby超入門』に必読マークが付いていることを確認する
6. `http://localhost:3000/practices/199563205/edit`にアクセスする
7. 書籍を選択ボタンを押す
8. 『はじめて学ぶソフトウェアのテスト技法』を選択、必読をONにして、更新するボタンを押す
9. `http://localhost:3000/books`に再びアクセスする
10. 『はじめて学ぶソフトウェアのテスト技法』に必読マークが付いていることを確認する


## 変更前
![スクリーンショット 2022-10-27 15 54 44](https://user-images.githubusercontent.com/59002337/198212500-7f84ef69-68d5-424b-9ff8-400e29b0ed02.png)


## 変更後
![スクリーンショット 2022-10-27 15 57 21](https://user-images.githubusercontent.com/59002337/198213271-163865c0-2447-4947-b117-dbc904324be4.png)

