### PR TITLE
メンターは自分以外の日報も編集できるようにする

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -44,7 +44,6 @@ class ReportsController < ApplicationController
 
   def edit
     @report.no_learn = true if @report.learning_times.empty?
-    @report.user = current_user
   end
 
   def create

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,7 +5,8 @@ class ReportsController < ApplicationController
   include Rails.application.routes.url_helpers
   before_action :require_login
   before_action :set_report, only: %i[show]
-  before_action :set_my_report, only: %i[edit update destroy]
+  before_action :set_my_report, only: %i[destroy]
+  before_action :set_editable_report, only: %i[edit update]
   before_action :set_checks, only: %i[show]
   before_action :set_check, only: %i[show]
   before_action :set_user, only: %i[show]
@@ -98,6 +99,10 @@ class ReportsController < ApplicationController
 
   def set_my_report
     @report = current_user.reports.find(params[:id])
+  end
+
+  def set_editable_report
+    @report = current_user.mentor? ? Report.find(params[:id]) : current_user.reports.find(params[:id])
   end
 
   def set_user

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.card-footer.is-only-mentor.is-only-adviser
+.card-footer.is-only-mentor
   .card-main-actions
     ul.card-main-actions__items
       li.card-main-actions__item(v-if='checkableType === "Product"')

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -111,7 +111,7 @@ header.page-header
             = render 'reactions/reactions', reactionable: @report
 
             - if @report.user_id == current_user.id || mentor_login?
-              .card-footer
+              .card-footer(class="#{mentor_login? ? 'is-only-mentor':''}")
                 .card-main-actions
                   ul.card-main-actions__items
                     li.card-main-actions__item

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -110,7 +110,7 @@ header.page-header
                   = @report.description
             = render 'reactions/reactions', reactionable: @report
 
-            - if @report.user_id == current_user.id
+            - if @report.user_id == current_user.id || mentor_login?
               .card-footer
                 .card-main-actions
                   ul.card-main-actions__items
@@ -118,10 +118,11 @@ header.page-header
                       = link_to edit_report_path(@report), class: 'card-main-actions__action a-button is-sm is-secondary is-block', id: 'js-shortcut-edit' do
                         i.fa-solid.fa-pen#new
                         | 内容修正
-                    li.card-main-actions__item.is-sub
-                      = link_to report_path(@report), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
-                        span#delete
-                          | 削除する
+                    - if @report.user_id == current_user.id
+                      li.card-main-actions__item.is-sub
+                        = link_to report_path(@report), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
+                          span#delete
+                            | 削除する
 
             - if admin_or_mentor_login?
               #js-check(data-checkable-id="#{@report.id}" data-checkable-type='Report' data-checkable-label="#{Report.model_name.human}")

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -111,7 +111,7 @@ header.page-header
             = render 'reactions/reactions', reactionable: @report
 
             - if @report.user_id == current_user.id || mentor_login?
-              .card-footer(class="#{mentor_login? ? 'is-only-mentor':''}")
+              .card-footer(class="#{mentor_login? ? 'is-only-mentor' : ''}")
                 .card-main-actions
                   ul.card-main-actions__items
                     li.card-main-actions__item

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -661,7 +661,12 @@ class ReportsTest < ApplicationSystemTestCase
   test 'mentor can edit reports written by others' do
     visit_with_auth report_path(reports(:report1)), 'mentormentaro'
     click_link '内容修正'
+    assert_no_text('変更された日報のタイトル')
+    within('form[name=report]') do
+      fill_in('report[title]', with: '変更された日報のタイトル')
+    end
     click_button '内容変更'
     assert_text '日報を保存しました。'
+    assert_text '変更された日報のタイトル'
   end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -657,4 +657,11 @@ class ReportsTest < ApplicationSystemTestCase
     find(:css, '#checkbox-mentor-mode').set(false)
     assert_no_text '内容修正'
   end
+
+  test 'mentor can edit reports written by others' do
+    visit_with_auth report_path(reports(:report1)), 'mentormentaro'
+    click_link '内容修正'
+    click_button '内容変更'
+    assert_text '日報を保存しました。'
+  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -650,4 +650,11 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth reports_path, 'komagata'
     assert_selector('.card-list-item__user')
   end
+
+  test 'show edit button when mentor is logged in and menter mode is on in report detail page' do
+    visit_with_auth report_path(reports(:report1)), 'mentormentaro'
+    assert_text '内容修正'
+    find(:css, '#checkbox-mentor-mode').set(false)
+    assert_no_text '内容修正'
+  end
 end


### PR DESCRIPTION
## Issue

- #5644 

## 概要

ネタバレを書いている日報を編集できるように、メンターが自分以外の日報を編集できるようにしました。

## 変更確認方法

1. ブランチ`feature/mentor_can_edit_other_reports`をローカルに取り込む
2. `mentormentaro` でログイン（メンターになっているユーザであれば誰でも構いません）
3. [メンターのレポート画面](http://localhost:3000/reports/unchecked)から他の人（`mentormentaro` 以外のユーザ）が書いた日報に遷移
4. 「内容修正」ボタンが表示されていることを確認
5. 「内容修正」ボタンを押下し、編集画面に遷移
6. タイトルや内容を変更し、「内容変更」ボタンを押下し保存
7. 日報詳細画面に遷移するので日報が変更した内容に更新されているかを確認

変更確認方法の3~7の動画

https://user-images.githubusercontent.com/43805056/197789177-bacf8e81-2f03-4cd6-be26-98821b879c2e.mp4


## 変更前
![CleanShot 2022-10-25 at 22 23 16](https://user-images.githubusercontent.com/43805056/197789296-d6f1c54c-45e7-4cab-8c13-2597d1ec0fd2.png)


## 変更後
![CleanShot 2022-10-25 at 22 31 04](https://user-images.githubusercontent.com/43805056/197789320-26361efd-0e99-4f1c-968f-6086be974099.png)