### PR TITLE
コメントが付いたときの通知メールの文言を修正した

### DIFF
--- a/app/views/notification_mailer/watching_notification.html.slim
+++ b/app/views/notification_mailer/watching_notification.html.slim
@@ -1,6 +1,7 @@
-- is_question = @watchable.instance_of?(Question),
+ruby:
+  is_question = @watchable.instance_of?(Question)
   anchor_prefix = is_question ? 'answer_' : 'comment_'
-- action = is_question ? '回答' : 'コメント'
+  action = is_question ? '回答' : 'コメント'
 = render 'notification_mailer_template',
   title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんが#{action}しました。",
   link_url: notification_url(@notification, anchor: "#{anchor_prefix}#{@comment.id}"),

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -195,6 +195,7 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['kimura@fjord.jp'], email.to
     assert_equal '[FBC] komagataさんの【 「作業週1日目」の日報 】にmachidaさんがコメントしました。', email.subject
+    assert_match(/コメント/, email.body.to_s)
   end
 
   test 'retired' do


### PR DESCRIPTION
## Issue

- #5697 

## 概要

日報や提出物にコメントが付いた時に届く通知メールの本文は本来「○○さんがコメントしました」となるべきところ、「○○さんが回答しました」となっていた。
slimの記法に誤りがあり、`action = is_question ? '回答' : 'コメント'` の条件判定が常にtrueになるようになっていたため修正した。

## 確認方法

1. komagataでログイン
2. kimuraの日報にコメントする  
   - http://localhost:3000/products/313836099
4. Letter openerで `kimura@fjord.jp` 宛のメールを確認する
   - http://localhost:3000/letter_opener/

### 修正前

![image](https://user-images.githubusercontent.com/33394676/198524815-04d4930d-1ffc-4579-ac7a-70d416a3f5ea.png)

### 修正後

![image](https://user-images.githubusercontent.com/33394676/198524674-d67e5e3a-9e4c-4d02-9b29-244334de6274.png)
