### PR TITLE
ブックマークにリンクを追加

### DIFF
--- a/app/views/current_user/bookmarks/index.html.slim
+++ b/app/views/current_user/bookmarks/index.html.slim
@@ -4,6 +4,16 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         | ダッシュボード
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
+              i.fa-solid.fa-user
+              | マイプロフィール
+          .page-header-actions__item
+            = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+              i.fa-regular.fa-plus
+              | 日報作成
 
 = render 'home/page_tabs', user: @user
 


### PR DESCRIPTION
## Issue

- #5608

## 概要

ブックマークページ右側に「マイプロフィール」と「日報作成」のリンクを追加しました。

## 変更確認方法

1. ブランチ`feature/add-link-to-bookmark`をローカルに取り込んでください。
2. `bin/rails s`でローカル環境を立ち上げてください。
3. http://localhost:3000 にアクセスし、`kimura`でログインしてください。
4. ダッシュボードのブックマークタブをクリックすると、ブックマークページが表示され、右側に「マイプロフィール」と「日報作成」のリンクが表示されます。
5. 「マイプロフィール」と「日報作成」をクリックして、それぞれのページが表示されることを確認してください。

## 変更前

<img width="1369" alt="スクリーンショット 2022-10-28 17 05 07" src="https://user-images.githubusercontent.com/88083085/198538004-9eee6af6-8cfc-4e68-8d9c-c0a7a1b3b46c.png">

## 変更後

<img width="1372" alt="スクリーンショット 2022-10-28 17 02 08" src="https://user-images.githubusercontent.com/88083085/198538052-fbe9b45f-96a5-42b1-816c-72181e1a8e4a.png">



