### PR TITLE
提出物OK後に更新すると他の人の提出物が見れなくなってしまう

### DIFF
--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -75,8 +75,7 @@
             :tagsTypeId='String(question.id)',
             tagsParamName='question[tag_list]',
             tagsType='Question',
-            :tagsEditable='true'
-          )
+            :tagsEditable='true')
 
   .a-card(v-if='!editing')
     .card-body

--- a/app/javascript/question-edit.vue
+++ b/app/javascript/question-edit.vue
@@ -75,7 +75,8 @@
             :tagsTypeId='String(question.id)',
             tagsParamName='question[tag_list]',
             tagsType='Question',
-            :tagsEditable='true')
+            :tagsEditable='true'
+          )
 
   .a-card(v-if='!editing')
     .card-body

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -88,6 +88,6 @@ class ProductCallbacks
              else
                :submitted
              end
-    product.change_learning_status status
+    product.change_learning_status status unless product.user.learnings.map(&:status).include?('complete')
   end
 end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -83,12 +83,19 @@ class ProductCallbacks
 
   def update_learning_status(product)
     status_check = product.user.learnings.map(&:status)
+
+    learning = Learning.find_or_initialize_by(
+      user_id: product.user.id,
+      practice_id: product.practice.id
+    )
     status = if product.wip
                started_practice = status_check.include?('started')
                started_practice ? :unstarted : :started
+             elsif learning.status == 'complete'
+               :complete
              else
                :submitted
              end
-    product.change_learning_status status unless status_check.include?('complete')
+    product.change_learning_status status
   end
 end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -82,16 +82,14 @@ class ProductCallbacks
   end
 
   def update_learning_status(product)
-    status_check = product.user.learnings.map(&:status)
-
-    learning = Learning.find_or_initialize_by(
+    previous_learning = Learning.find_or_initialize_by(
       user_id: product.user.id,
       practice_id: product.practice.id
     )
-    status = if learning.status == 'complete'
+    status = if previous_learning.status == 'complete'
                :complete
              elsif product.wip
-               started_practice = status_check.include?('started')
+               started_practice = product.user.learnings.map(&:status).include?('started')
                started_practice ? :unstarted : :started
              else
                :submitted

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -82,12 +82,13 @@ class ProductCallbacks
   end
 
   def update_learning_status(product)
+    status_check = product.user.learnings.map(&:status)
     status = if product.wip
-               started_practice = product.user.learnings.map(&:status).include?('started')
+               started_practice = status_check.include?('started')
                started_practice ? :unstarted : :started
              else
                :submitted
              end
-    product.change_learning_status status unless product.user.learnings.map(&:status).include?('complete')
+    product.change_learning_status status unless status_check.include?('complete')
   end
 end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -88,11 +88,11 @@ class ProductCallbacks
       user_id: product.user.id,
       practice_id: product.practice.id
     )
-    status = if product.wip
+    status = if learning.status == 'complete'
+               :complete
+             elsif product.wip
                started_practice = status_check.include?('started')
                started_practice ? :unstarted : :started
-             elsif learning.status == 'complete'
-               :complete
              else
                :submitted
              end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -155,6 +155,19 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '提出物を更新しました。'
   end
 
+  test 'update product after checked' do
+    my_product = products(:product2)
+    others_product = products(:product15)
+    visit_with_auth "/products/#{my_product.id}/edit", 'kimura'
+    within('form[name=product]') do
+      fill_in('product[body]', with: 'test')
+    end
+    click_button '提出する'
+
+    visit "/products/#{others_product.id}"
+    assert_current_path("/products/#{others_product.id}")
+  end
+
   test 'delete product' do
     product = products(:product1)
     visit_with_auth "/products/#{product.id}", 'mentormentaro'


### PR DESCRIPTION
## Issue

- #5637 

## 概要

OKをもらった後に提出物を更新すると、他の人の提出物が見れなくなるバグを修正しました。

## 詳細
提出物のステータスを更新する処理('app/models/product_callbacks.rb'の`update_learning_status(product)`メソッド)に修了(:complete)のステータスを付与する箇所がなかったので追加しました。
今まではOK後に更新すると、ステータスが「修了」→「着手」に切り替わってしまい、他の人の提出物が見れなくなっていました。
(`previous_learning`は変更前の提出物のステータスを示しています。既存の`product.user.learnings`では今回変更する提出物のステータスではなく、ユーザーが持つ全ての提出物についての情報を示しているので、`:complete`の判定には用いていません。)

### 提出物更新の流れ
流れがややこしいのでまとめます。

1. Productモデルのインスタンス(product)が生成される
1. app/models/product.rbの`after_create ProductCallbacks.new` が呼ばれ、app/models/product_callbacks.rbの`after_create(product)`メソッドが動く
1. `after_update ProductCallbacks.new`が呼ばれ、`after_update(product)`メソッドが動く
1. `after_save ProductCallbacks.new`が呼ばれ、`after_save(product)`メソッドが動く
1. `update_learning_status product`が呼ばれる
1. `update_learning_status(product)`メソッドで、提出物のstatusを決定する
1. `product.change_learning_status status`が呼ばれ、`app/models/product.rb`の`change_learning_status(status)`メソッドで提出物の更新を行う

## 変更確認方法

1. ブランチ`bug/open-only-my-product-after-update-finihed-product`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 受講生のアカウントでログインする
4. OKをもらわないと他の人の提出物が見れないプラクティスで提出物を作る(例: http://localhost:3000/practices/315059988)
5. メンターのアカウントでログインする
6. `4.`の提出物を確認する
7. `3.` のアカウントで`4.`の提出物の「内容編集」を押し、内容を変更して「提出する」を押す
8. 同じプラクティスで他の人の提出物を見れることを確認する