### PR TITLE
フォロー中ユーザー一覧のtitleタグを変更

### DIFF
--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,4 +1,7 @@
-- title '全てのユーザー'
+- if @target == 'followings'
+  - title 'フォロー中のユーザー一覧'
+- else
+  - title '全てのユーザー'
 
 header.page-header.is-border-bottom-none
   .container


### PR DESCRIPTION
## Issue
- #5407 

## 概要
- http://localhost:3000/users?target=followings
- http://localhost:3000/users?target=followings&watch=true
- http://localhost:3000/users?target=followings&watch=false
これらのページ(フォロー中ユーザー一覧)の`title`タグが`全てのユーザー`になっているので`フォロー中のユーザー一覧`に変更しました。

## 変更前
<img width="411" alt="スクリーンショット 2022-10-29 13 04 32" src="https://user-images.githubusercontent.com/81839214/198813028-94bbff2b-7a6b-446b-8aed-a2fc03b4fa0b.png">
<img width="499" alt="スクリーンショット 2022-10-29 13 09 47" src="https://user-images.githubusercontent.com/81839214/198813197-dfa78185-c1aa-4e3b-b61d-d0af8fce9015.png">
<img width="505" alt="スクリーンショット 2022-10-29 13 10 07" src="https://user-images.githubusercontent.com/81839214/198813208-54e7dd6e-e598-4f29-8eb9-9ec7215bc982.png">
<img width="617" alt="スクリーンショット 2022-10-29 13 08 33" src="https://user-images.githubusercontent.com/81839214/198813164-43b6dc83-de52-4d64-a6c9-99718f1e87dc.png">

## 変更後
<img width="413" alt="スクリーンショット 2022-10-29 13 11 41" src="https://user-images.githubusercontent.com/81839214/198813263-002bddf6-9a27-444f-87cb-a5e759ce10b2.png">
<img width="495" alt="スクリーンショット 2022-10-29 13 11 52" src="https://user-images.githubusercontent.com/81839214/198813269-d596e0f1-265c-4037-86fc-2e63f3a8e8c6.png">
<img width="499" alt="スクリーンショット 2022-10-29 13 12 03" src="https://user-images.githubusercontent.com/81839214/198813273-566aaf55-00f5-4c67-b854-fdd368204f25.png">
<img width="594" alt="スクリーンショット 2022-10-29 13 12 53" src="https://user-images.githubusercontent.com/81839214/198813300-dfe90782-6b22-408f-9416-a08bc4fca74a.png">

## 変更確認方法
1. ブランチ`feature/change-title-tag-of-following-user-list`をローカルに取り込んでください。
2. `bin/rails s`でローカル環境を立ち上げてください。
3. `http://localhost:3000`にアクセスを行い、任意のユーザーでログインしてください。
4. ` http://localhost:3000/users?target=followings`
`http://localhost:3000/users?target=followings&watch=true`
`http://localhost:3000/users?target=followings&watch=false`
にアクセスをしてください。
5. ブラウザのタブのタイトルが`フォロー中のユーザー一覧`になっていることを確認してください。