### PR TITLE
ダッシュボード上の自分の日報にリンクを追加

### DIFF
--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -8,6 +8,10 @@ header.page-header
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item
+            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
+              i.fa-solid.fa-user
+              | マイプロフィール
+          li.page-header-actions__item
             = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
               i.fa-regular.fa-plus
               | 日報作成


### PR DESCRIPTION
## Issue
- #5605 

## 概要
ダッシュボードの`自分の日報`ページ右側に`マイプロフィール`のリンクを追加しました。

## 変更前
<img width="1358" alt="スクリーンショット 2022-10-30 13 29 20" src="https://user-images.githubusercontent.com/81839214/198862681-af215012-a577-4323-bf4c-7f0f981551ee.png">

## 変更後
<img width="1360" alt="スクリーンショット 2022-10-30 13 33 01" src="https://user-images.githubusercontent.com/81839214/198862717-ba48992f-de99-4561-8767-4ace15d8a84b.png">

## 変更確認方法
1. ブランチ`feature/add-link-to-my-report-on-dashboard`をローカルに取り込んでください。
2. `bin/rails s`でローカル環境を立ち上げてください。
3. `http://localhost:3000`にアクセスを行い、任意のユーザーでログインしてください。
4. ダッシュボード上で(この時のURLは`http://localhost:3000/`)、自分の日報タブをクリックすると自分の日報ページが表示されますので（この時のURLは`http://localhost:3000/current_user/reports`）、ページ右側の`+ 日報作成`ボタンの左隣に`マイプロフィール`のリンクが表示されていることを確認してください
5. `マイプロフィール`をクリックしプロフィールページが表示されることを確認してください。
