### PR TITLE
アバター画像が未設定の人へアイコンでのメンションをしようとすると画像がリンク切れにならないようにした

### DIFF
--- a/app/javascript/user-icon-renderer.js
+++ b/app/javascript/user-icon-renderer.js
@@ -21,7 +21,6 @@ export default class {
 
   _callbackFunc() {
     const DEFAULT_PROFILE_IMAGE_PATH = "/images/users/avatars/default.png"
-
     const elements = document.getElementsByClassName('js-user-icon')
     Array.from(elements).forEach((element) => {
       const loginName = element.dataset.user

--- a/app/javascript/user-icon-renderer.js
+++ b/app/javascript/user-icon-renderer.js
@@ -25,7 +25,8 @@ export default class {
     Array.from(elements).forEach((element) => {
       const loginName = element.dataset.user
       if (element.src === '') element.src = this.urls[loginName]
-      if (this.urls[loginName] === undefined) element.src = DEFAULT_PROFILE_IMAGE_PATH
+      if (this.urls[loginName] === undefined)
+        element.src = DEFAULT_PROFILE_IMAGE_PATH
     })
   }
 }

--- a/app/javascript/user-icon-renderer.js
+++ b/app/javascript/user-icon-renderer.js
@@ -20,10 +20,13 @@ export default class {
   }
 
   _callbackFunc() {
+    const DEFAULT_PROFILE_IMAGE_PATH = "/images/users/avatars/default.png"
+
     const elements = document.getElementsByClassName('js-user-icon')
     Array.from(elements).forEach((element) => {
       const loginName = element.dataset.user
       if (element.src === '') element.src = this.urls[loginName]
+      if (this.urls[loginName] === undefined) element.src = DEFAULT_PROFILE_IMAGE_PATH
     })
   }
 }

--- a/app/javascript/user-icon-renderer.js
+++ b/app/javascript/user-icon-renderer.js
@@ -20,7 +20,7 @@ export default class {
   }
 
   _callbackFunc() {
-    const DEFAULT_PROFILE_IMAGE_PATH = "/images/users/avatars/default.png"
+    const DEFAULT_PROFILE_IMAGE_PATH = '/images/users/avatars/default.png'
     const elements = document.getElementsByClassName('js-user-icon')
     Array.from(elements).forEach((element) => {
       const loginName = element.dataset.user


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/5469

## 概要
アイコンを設定していないユーザーにアイコンでのメンション（`:@hoge:`みたいなもの）をすると画像がリンク切れになるので、デフォルトのアイコンが表示されるようにしました。

## 変更前
<img width="344" alt="スクリーンショット 2022-10-30 23 24 43" src="https://user-images.githubusercontent.com/59280290/198883828-61fa59dd-f5af-40ff-b0ed-83eba7fcab43.png">


## 変更後
<img width="402" alt="スクリーンショット 2022-10-30 23 24 05" src="https://user-images.githubusercontent.com/59280290/198883797-b22761f5-5cda-47c4-8a71-bd7354b6d2c4.png">


##  確認方法
1. ブランチ`bug/fix-broken_link_when_mention_user_without_avator`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログイン
4. [コメントのできるページ](http://localhost:3000/reports/818206278)でアイコンのないユーザー（@ kimuraなど）に対しアイコンでのメンションをする（:@kimura:）
5. プレビューを押下する
6. グレーのピヨルドの画像が表示されているのを確認する

## 補足
~~- 半角スペース1つ分くらい他のユーザーのアイコンとずれているのが気になっているので @machida さんに相談します~~
順番を入れ替えても同様のことが起こりました。
<img width="367" alt="スクリーンショット 2022-10-31 6 54 52" src="https://user-images.githubusercontent.com/59280290/198903388-1c9de992-f1d2-47e2-9b53-524eb6b905d1.png">

```css
.a-long-text .a-user-emoji-link:not(:first-child) {
    margin-left: 0.5em;
}
```

CSS確認したところ、1つ目のアイコンにはmargin-leftが当たらないようになっていたので、一旦メンバーレビュー完了後に見ていただこうと思います。

- このパスの指定の仕方`const DEFAULT_PROFILE_IMAGE_PATH = '/images/users/avatars/default.png'`で開発環境に関係なく動作するか少し不安です