### PR TITLE
アドバイザーがQ&Aに回答をしたら、所属企業のアイコンがコメントに表示される

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -6,6 +6,10 @@
         :src='answer.user.avatar_url',
         :title='answer.user.icon_title',
         :class='[roleClass]')
+      a.thread-comment__company-link(
+        v-if='answer.user.company && answer.user.adviser',
+        :href='answer.user.company.url')
+        img.thread-comment__company-logo(:src='answer.user.company.logo_url')
   .a-card.is-answer(v-if='!editing')
     .answer-badge(v-if='hasCorrectAnswer && answer.type == "CorrectAnswer"')
       .answer-badge__icon
@@ -24,6 +28,10 @@
         @click='copyAnswerURLToClipboard(answer.id)')
         | {{ updatedAt }}
     .thread-comment__description
+      a.thread-comment__company-link.is-hidden-md-up(
+        v-if='answer.user.company && answer.user.adviser',
+        :href='answer.user.company.url')
+        img.thread-comment__company-logo(:src='answer.user.company.logo_url')
       .a-long-text.is-md(v-html='markdownDescription')
     .thread-comment__reactions
       reaction(

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -99,4 +99,15 @@ class AnswersTest < ApplicationSystemTestCase
       assert_no_text :all, 'test'
     end
   end
+
+  test 'the company logo is shown when an adviser who belongs to a company posts an answer' do
+    visit_with_auth "/questions/#{questions(:question2).id}", 'senpai'
+    within('.thread-comment-form__form') do
+      fill_in('answer[description]', with: 'test')
+    end
+    page.all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    click_button 'コメントする'
+    assert_text 'test'
+    assert_equal '2.png', File.basename(find('img.thread-comment__company-logo')['src'])
+  end
 end


### PR DESCRIPTION
## Issue
https://github.com/fjordllc/bootcamp/issues/5553

## 概要
企業に所属するアドバイザーがQ&Aに回答したときに、ユーザーアイコンの下に所属する企業のアイコンを表示するようにしました。

## 変更確認方法
企業に所属しているアドバイザーと所属していないアドバイザーの二通りを確認していただきます。

1. ブランチ`feature/if_advisor_display_company-icons_in_the_answers`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `senpai`でログインする（こちらは企業に所属しているアカウント）
4. `http://localhost:3000/questions/1037106414`にアクセスしてコメントをする
5. アイコンの下に企業ロゴが表示されることを確認する
6. アイコンをクリックすると`http://localhost:3000/companies/1022975240`に遷移することを確認する
7. `advijirou`でログインする（こちらは企業に所属していないアカウント）
8. `http://localhost:3000/questions/1037106414`にアクセスしてコメントをする
9. 今度はアイコンの下に企業ロゴが表示されないことを確認する

## 変更前

<img width="702" alt="スクリーンショット 2022-11-01 12 36 09" src="https://user-images.githubusercontent.com/59002337/199153397-39670b6e-ce38-4248-b708-ea2904b0195d.png">


## 変更後
<img width="702" alt="スクリーンショット 2022-11-01 12 06 01" src="https://user-images.githubusercontent.com/59002337/199153384-f04ffdee-602e-432b-911a-8bcf2e389b4c.png">

