### PR TITLE
アドバイザーは日報作成ボタンを非表示にする

### DIFF
--- a/app/views/current_user/bookmarks/index.html.slim
+++ b/app/views/current_user/bookmarks/index.html.slim
@@ -10,10 +10,11 @@ header.page-header
             = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
               i.fa-solid.fa-user
               | マイプロフィール
-          .page-header-actions__item
-            = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-              i.fa-regular.fa-plus
-              | 日報作成
+          - unless current_user.adviser?
+            .page-header-actions__item
+              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+                i.fa-regular.fa-plus
+                | 日報作成
 
 = render 'home/page_tabs', user: @user
 

--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -11,10 +11,11 @@ header.page-header
             = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
               i.fa-solid.fa-user
               | マイプロフィール
-          li.page-header-actions__item
-            = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-              i.fa-regular.fa-plus
-              | 日報作成
+          - unless current_user.adviser?
+            li.page-header-actions__item
+              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+                i.fa-regular.fa-plus
+                | 日報作成
 
 = render 'home/page_tabs', user: @user
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -11,10 +11,11 @@ header.page-header
             = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
               i.fa-solid.fa-user
               | マイプロフィール
-          .page-header-actions__item
-            = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-              i.fa-regular.fa-plus
-              | 日報作成
+          - unless current_user.adviser?
+            .page-header-actions__item
+              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+                i.fa-regular.fa-plus
+                | 日報作成
 
 = render 'page_tabs', user: current_user
 

--- a/app/views/reports/_new_report.html.slim
+++ b/app/views/reports/_new_report.html.slim
@@ -1,6 +1,7 @@
-.page-header-actions
-  .page-header-actions__items
-    .page-header-actions__item
-      = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-        i.fa-regular.fa-plus
-        | 日報作成
+- unless current_user.adviser?
+  .page-header-actions
+    .page-header-actions__items
+      .page-header-actions__item
+        = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+          i.fa-regular.fa-plus
+          | 日報作成


### PR DESCRIPTION
## Issue

- #5604 

## 概要

アドバイザーは日報作成ボタンを非表示にしました。

## 変更確認方法

1. ブランチ`feature/adviser-hides-daily-report-creation-button`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `advijirou`でログイン（アドバイザーになっているユーザーであれば誰でも構いません）
4. ダッシュボード、自分の日報、ブックマーク、日報ページにアクセスして、日報作成ボタンが表示されていないことを確認してください。
5. `kimura`でログイン（アドバイザー以外のユーザーであれば誰でも構いません）
6. ダッシュボード、自分の日報、ブックマーク、日報ページにアクセスして、日報作成ボタンが表示されていることを確認してください。

## 変更前

### ダッシュボード
<img width="1368" alt="スクリーンショット 2022-11-01 14 01 23" src="https://user-images.githubusercontent.com/88083085/199173726-bc11ea90-0e3f-4530-980b-b37f066eb3b2.png">

### 自分の日報
<img width="1368" alt="スクリーンショット 2022-11-01 14 02 14" src="https://user-images.githubusercontent.com/88083085/199174066-e917a199-109e-4b33-bfa1-ad43ad3cdcfb.png">

### ブックマーク
<img width="1370" alt="スクリーンショット 2022-11-01 14 02 34" src="https://user-images.githubusercontent.com/88083085/199174281-2471af25-7d51-4feb-bc69-8cf949a6afc5.png">

### 日報
<img width="1366" alt="スクリーンショット 2022-11-01 14 04 26" src="https://user-images.githubusercontent.com/88083085/199174452-4271b885-7b80-40de-8ee3-0616947d3875.png">

## 変更後

### ダッシュボード
<img width="1369" alt="スクリーンショット 2022-11-01 14 41 28" src="https://user-images.githubusercontent.com/88083085/199177119-c45fa756-a32d-41ff-905c-1a57f546b3e5.png">

### 自分の日報
<img width="1369" alt="スクリーンショット 2022-11-01 14 41 44" src="https://user-images.githubusercontent.com/88083085/199177516-28bd2a62-4a0b-43e6-9a8b-6111c6b35a00.png">

### ブックマーク
<img width="1369" alt="スクリーンショット 2022-11-01 14 42 00" src="https://user-images.githubusercontent.com/88083085/199177677-81c12fe2-256b-437d-9d01-7e63aafa381b.png">

### 日報
<img width="1368" alt="スクリーンショット 2022-11-01 14 42 46" src="https://user-images.githubusercontent.com/88083085/199178034-d25903f4-7a1c-4a30-bd20-da572b93f4cc.png">
