### PR TITLE
必須項目未入力でエラーが出た場合のヘッダの不要なボーダーを削除

### DIFF
--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -19,6 +19,7 @@ class RetirementController < ApplicationController
       logout
       redirect_to retirement_url
     else
+      current_user.retired_on = nil
       render :new
     end
   end


### PR DESCRIPTION
## Issue

#4662

## 概要

現役生で退会をしようとして必須項目未入力でエラーが出た場合にヘッダに不要なboderが出ていたので修正

## 変更確認方法

1. ブランチ `fix/remove_header_border_when_user_got_input_error`をローカルに取り込む
2. `hatsuno` でログイン（現役生なら誰でも構いません）
3. [退会手続き画面](http://localhost:3000/retirement/new)に移動
4. 何も入力せずに「退会する」ボタンを押す
6. アラートにも 「OK」を押す
7. ヘッダーのピヨルドの横に空白の丸が存在しないことを確認


## 変更前
![CleanShot 2022-11-01 at 21 04 10@2x](https://user-images.githubusercontent.com/43805056/199229339-4dda7440-02a4-4e16-ad0e-14e845a1ff88.png)

## 変更後
![CleanShot 2022-11-01 at 21 08 46@2x](https://user-images.githubusercontent.com/43805056/199229335-4b2a90c0-b2c9-47d6-b6e2-8feb5d70dd53.png)
