### PR TITLE
イベント一覧に定期イベント作成リンクを追加

### DIFF
--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -11,6 +11,10 @@ header.page-header
             = link_to new_event_path, class: 'a-button is-md is-secondary is-block' do
               i.fa-regular.fa-plus
               | イベント作成
+          .page-header-actions__item
+            = link_to new_regular_event_path, class: 'a-button is-md is-secondary is-block' do
+              i.fa-regular.fa-plus
+              | 定期イベント作成
 
 = render 'events/tabs'
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -8,6 +8,11 @@ class EventsTest < ApplicationSystemTestCase
     assert_link 'イベント作成'
   end
 
+  test 'show link to create new regular event' do
+    visit_with_auth events_path, 'komagata'
+    assert_link '定期イベント作成'
+  end
+
   test 'users except admin cannot publish a event' do
     visit_with_auth new_event_path, 'kimura'
     page.assert_no_selector("input[value='作成']")

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -3,16 +3,6 @@
 require 'application_system_test_case'
 
 class EventsTest < ApplicationSystemTestCase
-  test 'show link to create new event' do
-    visit_with_auth events_path, 'komagata'
-    assert_link 'イベント作成'
-  end
-
-  test 'show link to create new regular event' do
-    visit_with_auth events_path, 'komagata'
-    assert_link '定期イベント作成'
-  end
-
   test 'users except admin cannot publish a event' do
     visit_with_auth new_event_path, 'kimura'
     page.assert_no_selector("input[value='作成']")


### PR DESCRIPTION
## Issue
- #5693 

## 概要

イベント一覧に定期イベント作成リンクを追加しました。

## 変更確認方法

1. ブランチ`feature/add-creating-regular-event-link-to-events`をローカルに取り込んでください。
2. `bin/rails s`でローカル環境を立ち上げてください。
3. http://localhost:3000 にアクセスし、任意のユーザーでログインしてください。
4. 左側メニューの「イベント」リンクをクリックしイベント一覧を表示してください。
5. 右上に「+定期イベント作成」のリンクがあることを確認し、クリックすると定期イベント作成画面に遷移することを確認してください。

## 変更前
![before](https://user-images.githubusercontent.com/66685066/200739998-2814b7d6-deb6-4da0-9ce3-1c4686853b6d.png)

## 変更後
![after](https://user-images.githubusercontent.com/66685066/200740221-0059910d-21ec-49ac-9613-c05e901e1ddd.png)

