### PR TITLE
定期イベント一覧にイベント作成リンクを追加

### DIFF
--- a/app/views/regular_events/index.html.slim
+++ b/app/views/regular_events/index.html.slim
@@ -8,6 +8,10 @@ header.page-header
       .page-header-actions
         .page-header-actions__items
           .page-header-actions__item
+            = link_to new_event_path, class: 'a-button is-md is-secondary is-block' do
+              i.fa-regular.fa-plus
+              | イベント作成
+          .page-header-actions__item
             = link_to new_regular_event_path, class: 'a-button is-md is-secondary is-block' do
               i.fa-regular.fa-plus
               | 定期イベント作成

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -3,7 +3,17 @@
 require 'application_system_test_case'
 
 class RegularEventsTest < ApplicationSystemTestCase
-  test 'create regular event as WIP' do
+  test 'show link to create new event' do
+    visit_with_auth regular_events_path, 'komagata'
+    assert_link 'イベント作成'
+  end
+
+  test 'show link to create new regular event' do
+    visit_with_auth regular_events_path, 'komagata'
+    assert_link '定期イベント作成'
+  end
+
+  test 'show regular event as WIP' do
     visit_with_auth new_regular_event_path, 'komagata'
     within 'form[name=regular_event]' do
       fill_in 'regular_event[title]', with: '質問相談タイム'

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -3,16 +3,6 @@
 require 'application_system_test_case'
 
 class RegularEventsTest < ApplicationSystemTestCase
-  test 'show link to create new event' do
-    visit_with_auth regular_events_path, 'komagata'
-    assert_link 'イベント作成'
-  end
-
-  test 'show link to create new regular event' do
-    visit_with_auth regular_events_path, 'komagata'
-    assert_link '定期イベント作成'
-  end
-
   test 'show regular event as WIP' do
     visit_with_auth new_regular_event_path, 'komagata'
     within 'form[name=regular_event]' do

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -3,7 +3,7 @@
 require 'application_system_test_case'
 
 class RegularEventsTest < ApplicationSystemTestCase
-  test 'show regular event as WIP' do
+  test 'create regular event as WIP' do
     visit_with_auth new_regular_event_path, 'komagata'
     within 'form[name=regular_event]' do
       fill_in 'regular_event[title]', with: '質問相談タイム'


### PR DESCRIPTION
## Issue
- #5695 

## 概要

定期イベント一覧にイベント作成リンクを追加しました。

## 変更確認方法

1. ブランチ`feature/add-creating-event-link-to-regular_events`をローカルに取り込んでください。
2. `bin/rails s`でローカル環境を立ち上げてください。
3. http://localhost:3000 にアクセスし、任意のユーザーでログインしてください。
4. 左側メニューの「イベント」リンクをクリックしイベント一覧を表示してください。
5. 「定期イベント」タブをクリックして定期イベント一覧を表示してください。
5. 右上に「+イベント作成」「+定期イベント作成」のリンクがあることを確認し、クリックするとそれぞれイベント作成画面、定期イベント作成画面に遷移することを確認してください。

## 変更前
![before](https://user-images.githubusercontent.com/66685066/200771456-8d2052e7-4344-466d-b57c-5822e88d7457.png)

## 変更後
![after](https://user-images.githubusercontent.com/66685066/200771482-db8e2afe-43a8-488c-91c4-81e3a320debd.png)
