### PR TITLE
Watchタブでも日報作成とマイプロフィールの確認をしたい

### DIFF
--- a/app/views/current_user/watches/index.html.slim
+++ b/app/views/current_user/watches/index.html.slim
@@ -5,6 +5,17 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         | ダッシュボード
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+            = link_to current_user, class: 'a-button is-md is-secondary is-block' do
+              i.fa-solid.fa-user
+              | マイプロフィール
+          - unless current_user.adviser?
+            .page-header-actions__item
+              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+                i.fa-regular.fa-plus
+                | 日報作成
 
 = render 'home/page_tabs', user: @user
 


### PR DESCRIPTION
# Issue

- #5607

## 概要

ダッシュボードのトップで表示している「マイプロフィール」と「日報作成」のリンクを、Watch中タブでも表示する

## 変更点確認方法

1. `feature/add_create_daily_note_button_on_watch_view`ブランチをローカルに取り込む
2. `bin/rails s`でローカルサーバーを起動
3. kimuraでログイン
4. ダッシュボード→Watchタブをクリック。「マイプロフィール」、「日報作成」ボタンが追加されていることを確認。
5. kimuraからログアウト→ advijirouでログイン
6. ダッシュボード→Watchタブをクリック。「マイプロフィール」のみ表示されることを確認。

## 変更前

![image](https://user-images.githubusercontent.com/5976902/201024700-28bf6fea-8998-4117-8a75-59c10627d864.png)


## 変更後


kimura アカウント
![image](https://user-images.githubusercontent.com/5976902/201025030-2d2bac29-bfbc-462a-ac87-ac66b5e23594.png)

advijirou アカウント
![image](https://user-images.githubusercontent.com/5976902/201028646-c0f83179-95eb-4c29-a11d-d08eeb19311f.png)
