### PR TITLE
メンターダッシュボードに「５日経過した提出物はありません」と表示する機能を追加

### DIFF
--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -6,6 +6,11 @@
     i.fa-regular.fa-smile
   p.o-empty-message__text
     | {{ title }}はありません
+.o-empty-message(v-else-if='isDashboard && isNotProduct5daysElapsed')
+  .o-empty-message__icon
+    i.fa-regular.fa-smile
+  p.o-empty-message__text
+    | 5日経過した提出物はありません
 div(:class='contentClassName')(v-else)
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')
@@ -154,6 +159,13 @@ export default {
     },
     isDashboard() {
       return location.pathname === '/'
+    },
+    isNotProduct5daysElapsed () {
+      const elapsedDays = []
+      this.productsGroupedByElapsedDays.forEach((h) => {
+        elapsedDays.push(h.elapsed_days)
+      })
+      return elapsedDays.every((day) => day < 5)
     }
   },
   created() {

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -160,7 +160,7 @@ export default {
     isDashboard() {
       return location.pathname === '/'
     },
-    isNotProduct5daysElapsed () {
+    isNotProduct5daysElapsed() {
       const elapsedDays = []
       this.productsGroupedByElapsedDays.forEach((h) => {
         elapsedDays.push(h.elapsed_days)

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -393,4 +393,13 @@ class HomeTest < ApplicationSystemTestCase
     visit_with_auth '/', 'kimura'
     assert_no_selector 'h2.card-header__title', text: '研修生の最新の日報'
   end
+
+  test 'display message if no Product after 5 days' do
+    visit_with_auth '/', 'komagata'
+    8.times do
+      click_button '担当する', match: :first
+      click_on 'ダッシュボード'
+    end
+    assert_text '5日経過した提出物はありません'
+  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -394,7 +394,7 @@ class HomeTest < ApplicationSystemTestCase
     assert_no_selector 'h2.card-header__title', text: '研修生の最新の日報'
   end
 
-  test 'display message if no Product after 5 days' do
+  test 'display message if no product after 5 days' do
     Product.delete_all
     user = users(:kimura)
     practice = practices(:practice1)

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -395,7 +395,6 @@ class HomeTest < ApplicationSystemTestCase
   end
 
   test 'display message if no Product after 5 days' do
-    products = Product.all
     user = users(:komagata)
     products.map do |product|
       product.update(checker_id: user.id) if product.elapsed_days >= 5

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -395,11 +395,12 @@ class HomeTest < ApplicationSystemTestCase
   end
 
   test 'display message if no Product after 5 days' do
-    visit_with_auth '/', 'komagata'
-    while has_button? '担当する'
-      click_button '担当する', match: :first
-      click_on 'ダッシュボード'
+    products = Product.all
+    user = users(:komagata)
+    products.map do |product|
+      product.update(checker_id: user.id) if product.elapsed_days >= 5
     end
+    visit_with_auth '/', 'komagata'
     assert_text '5日経過した提出物はありません'
   end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -395,11 +395,13 @@ class HomeTest < ApplicationSystemTestCase
   end
 
   test 'display message if no Product after 5 days' do
-    user = users(:komagata)
-    products.map do |product|
-      product.update(checker_id: user.id) if product.elapsed_days >= 5
+    Product.delete_all
+    user = users(:kimura)
+    practice = practices(:practice1)
+    Product.create(practice_id: practice.id, user_id: user.id, body: 'test body', published_at: Time.current.ago(1.day))
+    travel_to Time.current do
+      visit_with_auth '/', 'komagata'
+      assert_text '5日経過した提出物はありません'
     end
-    visit_with_auth '/', 'komagata'
-    assert_text '5日経過した提出物はありません'
   end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -396,7 +396,7 @@ class HomeTest < ApplicationSystemTestCase
 
   test 'display message if no Product after 5 days' do
     visit_with_auth '/', 'komagata'
-    8.times do
+    while has_button? '担当する'
       click_button '担当する', match: :first
       click_on 'ダッシュボード'
     end


### PR DESCRIPTION
 ## Issue
 
 - #5735
 
 ## 概要
5日経過した提出物が0件の場合かつ５日未満の提出物が存在する場合、メンターダッシュボードに「５日経過した提出物はありません」と表示する機能を追加しました。
 
 
 ## 変更確認方法

 1. ブランチ`feature/display-No-product-submissions-after-5days-on-the-mentor-dashboard`をローカルに取り込む
 2. `bin/rails s`でローカル環境を立ち上げる
 3. メンターダッシュボードに表示されている5日以上経過した全ての提出物の「担当する」ボタンをクリックし「担当から外れる」へ変更する
![image](https://user-images.githubusercontent.com/65638955/201622634-27777e52-1e19-43b2-9932-5dd7816ddb51.png)
4. ダッシュボードのタブをクリックしページを更新する
5. 「５日経過した提出物はありません」と表示されることを確認する

 ## 変更前
5日以上の提出物は0件だが、5日未満の提出物が存在する場合の表示結果 
 
![image](https://user-images.githubusercontent.com/65638955/200589087-5e02e26a-50ea-486d-8a05-21024b4c6ad9.png)

![image](https://user-images.githubusercontent.com/65638955/200589140-f1914856-2804-42fd-8d35-ad5c4219d918.png)
 
 ## 変更後
 ![image](https://user-images.githubusercontent.com/65638955/201621159-f4a083e0-c1a0-4ef3-bb08-c8e6b665548a.png)