### PR TITLE
提出物タブでもマイプロフィール確認と日報作成がしたい

### DIFF
--- a/app/views/current_user/products/index.html.slim
+++ b/app/views/current_user/products/index.html.slim
@@ -5,6 +5,17 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         | ダッシュボード
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
+              i.fa-solid.fa-user
+              | マイプロフィール
+          - unless current_user.adviser?
+            .page-header-actions__item
+              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+                i.fa-regular.fa-plus
+                | 日報作成
 
 = render 'home/page_tabs', user: @user
 

--- a/app/views/current_user/products/index.html.slim
+++ b/app/views/current_user/products/index.html.slim
@@ -8,7 +8,7 @@ header.page-header
       .page-header-actions
         .page-header-actions__items
           .page-header-actions__item
-            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
+            = link_to current_user, class: 'a-button is-md is-secondary is-block' do
               i.fa-solid.fa-user
               | マイプロフィール
           - unless current_user.adviser?


### PR DESCRIPTION
# Issue

- #5606

## 概要

ダッシュボードの提出物でも「マイプロフィール」と「日報作成」のリンクを、Watch中タブでも表示する

## 変更点確認方法

1. `feature/add_daily_note_button_on_products_view` ブランチをローカルに取り込む
2. `bin/rails s` でローカルサーバーを起動
3. ダッシュボード→提出物タブをクリック。「マイプロフィール」、「日報作成」ボタンが追加されていることを確認
4. kimuraからログアウト→ advijirouでログイン
5. ダッシュボード→提出物タブをクリック。「マイプロフィール」のみ表示されることを確認

## 変更前

![CleanShot 2022-11-11 at 10 33 16](https://user-images.githubusercontent.com/5976902/201248162-30a765be-8df9-4df0-8b78-0b71f7bd0941.png)

## 変更後

kimura

![CleanShot 2022-11-11 at 10 27 32](https://user-images.githubusercontent.com/5976902/201248066-85c45d45-1e19-4693-9c55-ec1990c88042.png)

アドバイザー

![CleanShot 2022-11-11 at 10 25 48](https://user-images.githubusercontent.com/5976902/201248044-5819cd96-4e25-4a1a-beea-238b49690c62.png)
