### PR TITLE
重複している div 要素を削除

### DIFF
--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -61,8 +61,7 @@
         | 卒業後のゴール
       .user-metas__item-value
         - if user.after_graduation_hope?
-          .user-metas__item-value
-            .a-short-text
-              = simple_format(user.after_graduation_hope)
+          .a-short-text
+            = simple_format(user.after_graduation_hope)
         - else
           | 未入力


### PR DESCRIPTION
「卒業後のゴール」のところに余計な padding が含まれているように見えました。div 要素が重複しているせいに見えたので削除してみました。この変更に誤りがあれば遠慮なく close してください。

| before | after |
| - | - |
| ![localhost_3000_users_991528156 (1)](https://user-images.githubusercontent.com/7645585/201357801-3c9c0f52-1a1d-4b94-93a1-46d76f5a4741.png) | ![localhost_3000_users_991528156](https://user-images.githubusercontent.com/7645585/201357812-d7abf90b-c2d0-4bfa-85ff-709508ae3e2b.png) |
