### PR TITLE
メンター、アドバイザー、管理者でログインしたときに、提出物、日報が0だったらタブを非表示にする

### DIFF
--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -4,11 +4,11 @@
       li.page-tabs__item
         = link_to root_path, class: "page-tabs__item-link #{current_page_tab_or_not('')}" do
           | ダッシュボード
-      - if !current_user.mentor? && !current_user.adviser? && !current_user.admin? || !user.reports.empty?
+      - if !staff_login? || !user.reports.empty?
         li.page-tabs__item
           = link_to current_user_reports_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
             | 自分の日報 （#{user.reports.length}）
-      - if !current_user.mentor? && !current_user.adviser? && !current_user.admin? || !user.products.empty?
+      - if !staff_login? || !user.products.empty?
         li.page-tabs__item
           = link_to current_user_products_path, class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
             | 自分の提出物 （#{user.products.length}）

--- a/app/views/home/_page_tabs.html.slim
+++ b/app/views/home/_page_tabs.html.slim
@@ -4,12 +4,14 @@
       li.page-tabs__item
         = link_to root_path, class: "page-tabs__item-link #{current_page_tab_or_not('')}" do
           | ダッシュボード
-      li.page-tabs__item
-        = link_to current_user_reports_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
-          | 自分の日報 （#{user.reports.length}）
-      li.page-tabs__item
-        = link_to current_user_products_path, class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
-          | 自分の提出物 （#{user.products.length}）
+      - if !current_user.mentor? && !current_user.adviser? && !current_user.admin? || !user.reports.empty?
+        li.page-tabs__item
+          = link_to current_user_reports_path, class: "page-tabs__item-link #{current_page_tab_or_not('reports')}" do
+            | 自分の日報 （#{user.reports.length}）
+      - if !current_user.mentor? && !current_user.adviser? && !current_user.admin? || !user.products.empty?
+        li.page-tabs__item
+          = link_to current_user_products_path, class: "page-tabs__item-link #{current_page_tab_or_not('products')}" do
+            | 自分の提出物 （#{user.products.length}）
       li.page-tabs__item
         = link_to current_user_watches_path, class: "page-tabs__item-link #{current_page_tab_or_not('watches')}" do
           | Watch中


### PR DESCRIPTION
## Issue

- #5724 

## 概要

メンター、アドバイザー、管理者でログインしたときに、提出物、日報が0だったらタブを非表示にしました。

## 変更確認方法

1. ブランチ`feature/hide-the-tab-if-the-number-of-submissions-and-daily-reports-is-zero-when-logged-in-as-a-mentor-adviser-or-administrator`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `unadmentor`（メンター）,`advijirou`(アドバイザー),`adminonly`（管理者）でログインして、提出物と日報のタブが表示されていないことを確認してください。
4. 最後にそれぞれ日報と提出物を作成してみて、0でない場合はタブが表示されることを確認してください。（アドバイザーは日報作成のリンクがないので、`http://localhost:3000/reports/new`にアクセスして作成してください。）

## 変更前

### メンター

<img width="807" alt="スクリーンショット 2022-11-12 15 43 45" src="https://user-images.githubusercontent.com/88083085/201467589-6e084d65-7d1d-4e22-91de-3d5a31bb259b.png">

### アドバイザー

<img width="804" alt="スクリーンショット 2022-11-12 15 46 21" src="https://user-images.githubusercontent.com/88083085/201467595-429cf14a-f135-415c-a7b7-f9c8bcdc20a4.png">

### 管理者

<img width="806" alt="スクリーンショット 2022-11-12 15 48 07" src="https://user-images.githubusercontent.com/88083085/201467600-6dfe264a-0e75-4665-b8dc-6796ede96138.png">

## 変更後

### メンター

<img width="793" alt="スクリーンショット 2022-11-12 15 28 57" src="https://user-images.githubusercontent.com/88083085/201467609-57e0d78e-c736-4548-8744-24a40cb56cee.png">

### アドバイザー

<img width="794" alt="スクリーンショット 2022-11-12 16 08 39" src="https://user-images.githubusercontent.com/88083085/201467614-7c8ddc35-27b7-4da1-a898-4b07af5294f2.png">

### 管理者

<img width="786" alt="スクリーンショット 2022-11-12 15 38 49" src="https://user-images.githubusercontent.com/88083085/201467623-4ff90d58-44d1-46ac-85c7-cd0f829e17c7.png">

