### PR TITLE
commentable.comments が nil になり例外を出すことがあるため、 nil の時は処理をしないように修正

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -6,6 +6,8 @@ class API::CommentsController < API::BaseController
 
   def index
     if params[:commentable_type].present?
+      return if commentable.comments.nil?
+
       @comments = commentable.comments.order(created_at: :desc)
       @comment_total_count = @comments.size
       @comments = @comments.limit(params[:comment_limit])


### PR DESCRIPTION
## Issue

- #5570 

## 概要

`CommentsController.index` で `commentable.comments` が `nil` になり例外が発生していました。
[コメントが存在する画面に遷移](https://github.com/fjordllc/bootcamp/issues/5570#issuecomment-1312391118)して例外を再現させようとしましたが、再現ができませんでした。

>  📝 再現しないとしたら、その周辺にcommentsがない場合の処理を追加していただければと思います。

https://github.com/fjordllc/bootcamp/issues/5570#issuecomment-1264597021

上記のようにチケットにコメントがありましたので、`comments` が `nil` の時は例外を出さないように処理をしないように修正しました。

## 変更確認方法

念の為コメント周りの一連の動作を行っていただきたいです🙏
コメントを投稿し、コメントが表示されるまでの確認をお願いいたします。

1. ブランチ`fix/commentable_comments_nil`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. ログインする（誰でも構いません）
5. http://localhost:3000/reports/ にアクセスする
6. 一番上の日報詳細画面に遷移
7. コメントを投稿
8. 投稿したコメントが表示されることを確認

## コメントが表示されていることが分かる画像

![CleanShot 2022-11-12 at 17 16 02](https://user-images.githubusercontent.com/43805056/201465441-c348a0c3-c563-41c0-b6bc-8966b9453d56.png)

