### PR TITLE
メンターの場合、卒業後の自分について記入するフォームを非表示しました

### DIFF
--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -18,7 +18,8 @@
     = render 'users/form/description', f: f, user: user
     = render 'users/form/tags', f: f, user: user
     - unless user.adviser?
-      = render 'users/form/after_graduation_hope', f: f, user: user
+      - unless user.mentor?
+        = render 'users/form/after_graduation_hope', f: f, user: user
       = render 'users/form/job', f: f
       = render 'users/form/os', f: f
       = render 'users/form/prefecture', f: f

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -56,10 +56,12 @@ class CurrentUserTest < ApplicationSystemTestCase
     assert_text '分報URLはDiscordのチャンネルURLを入力してください'
   end
 
-  test 'Do not show after graduation hope when advisor' do
+  test 'Do not show after graduation hope when advisor or mentor' do
     visit_with_auth '/current_user/edit', 'hajime'
     assert_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください'
     visit_with_auth '/current_user/edit', 'senpai'
+    assert_no_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください'
+    visit_with_auth '/current_user/edit', 'mentormentaro'
     assert_no_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください'
   end
 

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -56,7 +56,7 @@ class CurrentUserTest < ApplicationSystemTestCase
     assert_text '分報URLはDiscordのチャンネルURLを入力してください'
   end
 
-  test 'Do not show after graduation hope when advisor or mentor' do
+  test 'do not show after graduation hope when advisor or mentor' do
     visit_with_auth '/current_user/edit', 'hajime'
     assert_text 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください'
     visit_with_auth '/current_user/edit', 'senpai'


### PR DESCRIPTION
# Issue

-  #5780 

# 概要

メンターの場合は卒業後の自分について記入する必要がないので、入力フォームを非表示にするようにしました。

## 変更点確認方法

- `feature/hide_from_after_graduation_hope` ブランチをローカルに取り込む
- `bin/rails s` でローカルサーバーを起動
- hatsunoでログイン→登録情報変更へ移動
- 「フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください」が表示されていることを確認
- ログアウト→mentormentaroでログイン→登録情報変更へ移動
- 「フィヨルドブートキャンプを卒業した自分はどうなっていたいかを教えてください」表示されていないことを確認

### Screenshot

| 受講生 | メンター |
| :---: | :---: |
| ![Screenshot 2022-11-17 at 10-47-57 登録情報変更](https://user-images.githubusercontent.com/5976902/202334716-ad1378fb-ec82-4e0c-bac6-f6e261a9b1bd.png) | ![Screenshot 2022-11-17 at 10-48-22 登録情報変更](https://user-images.githubusercontent.com/5976902/202334803-ce1511ca-70b8-4046-adb2-08a331ccbde2.png) |
