### PR TITLE
管理者・メンター・アドバイザー・卒業生でログインしているときは休会リンクを非表示にした

### DIFF
--- a/app/views/application/_user_menu.html.slim
+++ b/app/views/application/_user_menu.html.slim
@@ -17,9 +17,10 @@
     li.header-dropdown__item
       = link_to logout_path, class: 'header-dropdown__item-link' do
         | ログアウト
-    li.header-dropdown__item
-      = link_to new_hibernation_path, class: 'header-dropdown__item-link' do
-        | 休会手続き
+    - if current_user.student_or_trainee_or_retired?
+        li.header-dropdown__item
+          = link_to new_hibernation_path, class: 'header-dropdown__item-link' do
+            | 休会手続き
     li.header-dropdown__item
       = link_to new_retirement_path, class: 'header-dropdown__item-link' do
         | 退会手続き


### PR DESCRIPTION
## Issue
- #5769 

## 概要
管理者・メンター・アドバイザー・卒業生でログインしているときは休会リンクが表示されないようにしました。

## 変更確認方法
1. ブランチ`feature/hide-a-hibernating-link-when-login-as-admin-mentor-adviser-graduated`をローカルに取り込む
1. `bin/rails s`でローカル環境を立ち上げる
1. まず休会リンクが表示されるケースを確認
    - `hatsuno`でログイン[^1]し、右上の「Me」からドロップダウンメニューを表示。休会リンクが**ある**ことを確認する
1. 次に休会リンクが表示されないケースを確認
    1. 管理者(`adminonly`)でログインし、右上の「Me」からドロップダウンメニューを表示。休会リンクが**ない**ことを確認する
    1. メンター(`mentormentaro`)でログインし、右上の「Me」からドロップダウンメニューを表示。休会リンクが**ない**ことを確認する
    1. アドバイザー(`advijirou`)でログインし、右上の「Me」からドロップダウンメニューを表示。休会リンクが**ない**ことを確認する
    1. 卒業生(`sotugyou`)でログインし、右上の「Me」からドロップダウンメニューを表示。休会リンクが**ない**ことを確認する

## 変更前
- 管理者(`adminonly`)
![before_adminonly](https://user-images.githubusercontent.com/66685066/202348507-44a17783-268f-4d35-a369-23ac6ce7ff69.png)
- メンター(`mentormentaro`)
![before_mentormentaro](https://user-images.githubusercontent.com/66685066/202348521-e5432e88-1771-4f2e-bdaf-e4903d1240d2.png)
- アドバイザー(`advijirou`)
![before_advijirou](https://user-images.githubusercontent.com/66685066/202348530-4d11233b-0329-48af-8780-bdfaecbe46de.png)
- 卒業生(`sotugyou`)
![before_sotugyou](https://user-images.githubusercontent.com/66685066/202348559-02d3b345-14a7-418d-b73c-a13aa69a7eee.png)
## 変更後
- 管理者(`adminonly`)
![after_adminonly](https://user-images.githubusercontent.com/66685066/202353489-e786dfa7-c081-43c9-bfe3-d33f3de5101f.png)
- メンター(`mentormentaro`)
![after_mentormentaro](https://user-images.githubusercontent.com/66685066/202353502-d7c3d47b-1ebb-427a-9fdd-f87c6e046568.png)
- アドバイザー(`advijirou`)
![after_advijirou](https://user-images.githubusercontent.com/66685066/202353528-f4ff4261-436c-4284-b75c-b5b7a3d72204.png)
- 卒業生(`sotugyou`)
![after_sotugyou](https://user-images.githubusercontent.com/66685066/202353546-535ae4cf-ae0f-4477-8115-95e6dce660b6.png)

[^1]: 管理者・メンター・アドバイザー・卒業生以外のユーザーであればなんでも構いません。