### PR TITLE
イベントで補欠から参加に繰り上がった時の通知をabstract_notifierに置き換えた

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -80,17 +80,6 @@ class Notification < ApplicationRecord
       )
     end
 
-    def moved_up_event_waiting_user(event, receiver)
-      Notification.create!(
-        kind: kinds[:moved_up_event_waiting_user],
-        user: receiver,
-        sender: event.user,
-        link: Rails.application.routes.url_helpers.polymorphic_path(event),
-        message: "#{event.title}で、補欠から参加に繰り上がりました。",
-        read: false
-      )
-    end
-
     def chose_correct_answer(answer, receiver)
       Notification.create!(
         kind: kinds[:chose_correct_answer],

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -136,7 +136,10 @@ class NotificationFacade
   end
 
   def self.moved_up_event_waiting_user(event, receiver)
-    Notification.moved_up_event_waiting_user(event, receiver)
+    ActivityNotifier.with(
+      event: event,
+      receiver: receiver
+    ).moved_up_event_waiting_user.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -337,4 +337,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def moved_up_event_waiting_user(params = {})
+    params.merge!(@params)
+    event = params[:event]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{event.title}で、補欠から参加に繰り上がりました。",
+      kind: :moved_up_event_waiting_user,
+      receiver: receiver,
+      sender: event.user,
+      link: Rails.application.routes.url_helpers.polymorphic_path(event),
+      read: false
+    )
+  end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -80,9 +80,9 @@ class EventTest < ActiveSupport::TestCase
 
   test '#send_notification' do
     event = events(:event3)
-    user = users(:hatsuno)
+    user = users(:hajime)
     event.send_notification(user)
-    assert Notification.where(user: user, link: "/events/#{event.id}").exists?
+    assert Notification.where(user: user, sender: event.user, link: "/events/#{event.id}").exists?
   end
 
   test 'should be invalid when start_at >= end_at' do

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -132,4 +132,16 @@ class ActivityNotifierTest < ActiveSupport::TestCase
       notification.notify_later
     end
   end
+
+  test '#moved_up_event_waiting_user' do
+    notification = ActivityNotifier.with(event: events(:event3), receiver: users(:hatsuno)).moved_up_event_waiting_user
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      notification.notify_now
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      notification.notify_later
+    end
+  end
 end

--- a/test/system/notification/events_test.rb
+++ b/test/system/notification/events_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class Notification::EventsTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
   test 'waiting user receive notification when the event participant cancel' do
     event = events(:event3)
     visit_with_auth event_path(event), 'komagata'


### PR DESCRIPTION
 ## Issue
 
 - #4686 
 
 ## 概要
- イベントで補欠から参加に繰り上がった時の通知をabstract_notifierに置き換えました。
- 既に[導入済みのPR](https://github.com/fjordllc/bootcamp/pull/4673)を参考に実装しました。
- 見た目上の変更はないため、変更前/変更後のスクリーンショットは割愛させていただきました。
 
 ## 変更確認方法
 1. ブランチ`feature/replace-notification-to-moved-up-event-waiting-user-with-abstract_notifier`をローカルに取り込む
 2. `bin/rails s`でローカル環境を立ち上げる
 3. 以下2点確認する（補欠から参加へ繰り上がるタイミングが2つのケースで存在する）

### ① キャンセルが出た時
1.  `komagata@fjord.jp`でログインし、http://localhost:3000/events へアクセスする
2.  `募集期間中のイベント(補欠者あり)`イベントのページへ遷移し、参加を取り消す
3. `hatsuno@fjord.jp`でログインし、http://localhost:3000/notifications へアクセスする
4. サイト内通知が来ていることを確認する
![image](https://user-images.githubusercontent.com/65638955/202447755-1aab65b5-3bdf-4ac2-ab1b-34e28d72e44a.png)

5. http://localhost:3000/letter_opener/ へアクセスし、メールが届いていることを確認する
![image](https://user-images.githubusercontent.com/65638955/202448862-2100da44-3045-436a-a22f-d383f7e5669b.png)

### ② 定員が増えた時
1. `komagata@fjord.jp`でログインし、http://localhost:3000/events へアクセスする
2.  `募集期間中のイベント(補欠者あり)`イベントのページへ遷移し、内容修正から定員を3へ増やす
3.  `sotugyou@example.com` でログインし、http://localhost:3000/notifications へアクセスする
4. サイト内通知が来ていることを確認する
![image](https://user-images.githubusercontent.com/65638955/202451638-1fe6994e-cbc2-4a7d-82b0-d175334e949d.png)

5. http://localhost:3000/letter_opener/ へアクセスし、メールが届いていることを確認する
![image](https://user-images.githubusercontent.com/65638955/202451741-927bf672-0af4-4249-acb1-4b54b63274ff.png)