### PR TITLE
ダッシュボード画面のタイトル部分をpartialにして共通化する

### DIFF
--- a/app/views/current_user/bookmarks/index.html.slim
+++ b/app/views/current_user/bookmarks/index.html.slim
@@ -1,21 +1,5 @@
 - title 'ブックマーク一覧'
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        | ダッシュボード
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
-              i.fa-solid.fa-user
-              | マイプロフィール
-          - unless current_user.adviser?
-            .page-header-actions__item
-              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-                i.fa-regular.fa-plus
-                | 日報作成
-
+= render 'home/page_header'
 = render 'home/page_tabs', user: @user
 
 .page-body

--- a/app/views/current_user/products/index.html.slim
+++ b/app/views/current_user/products/index.html.slim
@@ -1,22 +1,5 @@
 - title '自分の提出物'
-
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        | ダッシュボード
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to current_user, class: 'a-button is-md is-secondary is-block' do
-              i.fa-solid.fa-user
-              | マイプロフィール
-          - unless current_user.adviser?
-            .page-header-actions__item
-              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-                i.fa-regular.fa-plus
-                | 日報作成
-
+= render 'home/page_header'
 = render 'home/page_tabs', user: @user
 
 .page-body

--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -1,22 +1,5 @@
 - title 'ダッシュボード 自分の日報'
-
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        | ダッシュボード
-      .page-header-actions
-        ul.page-header-actions__items
-          li.page-header-actions__item
-            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
-              i.fa-solid.fa-user
-              | マイプロフィール
-          - unless current_user.adviser?
-            li.page-header-actions__item
-              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-                i.fa-regular.fa-plus
-                | 日報作成
-
+= render 'home/page_header'
 = render 'home/page_tabs', user: @user
 
 .page-body

--- a/app/views/current_user/watches/index.html.slim
+++ b/app/views/current_user/watches/index.html.slim
@@ -1,22 +1,5 @@
 - title 'Watch中'
-
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        | ダッシュボード
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to current_user, class: 'a-button is-md is-secondary is-block' do
-              i.fa-solid.fa-user
-              | マイプロフィール
-          - unless current_user.adviser?
-            .page-header-actions__item
-              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-                i.fa-regular.fa-plus
-                | 日報作成
-
+= render 'home/page_header'
 = render 'home/page_tabs', user: @user
 
 div(data-vue="Watches")

--- a/app/views/home/_page_header.html.slim
+++ b/app/views/home/_page_header.html.slim
@@ -1,0 +1,16 @@
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        | ダッシュボード
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
+              i.fa-solid.fa-user
+              | マイプロフィール
+          - unless current_user.adviser?
+            li.page-header-actions__item
+              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+                i.fa-regular.fa-plus
+                | 日報作成

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,22 +1,5 @@
 - title 'ダッシュボード'
-
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        = title
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
-              i.fa-solid.fa-user
-              | マイプロフィール
-          - unless current_user.adviser?
-            .page-header-actions__item
-              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-                i.fa-regular.fa-plus
-                | 日報作成
-
+= render 'page_header'
 = render 'page_tabs', user: current_user
 
 .page-body.is-dash-board


### PR DESCRIPTION
## Issue
アサインされたissue
- https://github.com/fjordllc/bootcamp/issues/5783

関連してクローズするissue
- https://github.com/fjordllc/bootcamp/issues/5607
- https://github.com/fjordllc/bootcamp/issues/5800
- https://github.com/fjordllc/bootcamp/issues/5799

@machida さんと会話して、タグ付与ではなく共通化して対応する方針でOKとなったため、アサインされた以外にもクローズできるissueが発生しています。（→ https://github.com/fjordllc/bootcamp/issues/5783#issuecomment-1321295740 ）


## 概要
- ダッシュボード画面の、タイトル部分（※下記キャプチャの部分）のコードを共通化しました。
![スクリーンショット 2022-11-22 9 47 09](https://user-images.githubusercontent.com/40317050/203187273-45e9c809-019e-4be5-96e6-5f5bba2ef5a0.png)
- `Watch中`の画面にも、`マイプロフィール` `日報作成`ボタンが表示されるようになりました。


各タブのviewに、下記のようなタイトル部分のコードが重複して記載されていたので、partialに書き換えています。
`マイプロフィール` `日報作成`のボタンがなかった`Watch中`画面にも同じpartialを追加しています。

```
header.page-header
  .container
    .page-header__inner
      h2.page-header__title
        | ダッシュボード
      .page-header-actions
        .page-header-actions__items
          .page-header-actions__item
            = link_to user_path(id: current_user.id), class: 'a-button is-md is-secondary is-block' do
              i.fa-solid.fa-user
              | マイプロフィール
          - unless current_user.adviser?
            .page-header-actions__item
              = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
                i.fa-regular.fa-plus
                | 日報作成
```



...

## 変更確認方法

1. ブランチ`feature/dashboard-title-section-to-partial`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. アドバイザー以外のユーザーでログインし、ダッシュボード画面を開く
4.  `ダッシュボード` `自分の日報` `自分の提出物` `Watch中` `ブックマーク`の5つ全てのタブで、タイトル部分に「ダッシュボード」というタイトルと`マイプロフィール` `日報作成`ボタンが表示されており、ボタンが機能していることを確認する。
5. アドバイザーでログインし直し、ダッシュボード画面を開く
6. `ダッシュボード`  `Watch中` `ブックマーク`の3つ全てのタブで、タイトル部分に「ダッシュボード」というタイトルと`マイプロフィール` ボタンが表示されており、ボタンが機能していることを確認する。`日報作成`ボタンは表示されないことを確認する。



## 変更前
`ダッシュボード` 
![スクリーンショット 2022-11-22 10 06 13](https://user-images.githubusercontent.com/40317050/203189555-a9c8bdbd-30ff-43ae-9d31-eceb8d983254.png)

`自分の日報` 
![スクリーンショット 2022-11-22 10 06 19](https://user-images.githubusercontent.com/40317050/203189554-e3dc5bc4-ae1e-49ea-9cef-003162b1ca50.png)

`自分の提出物` 
![スクリーンショット 2022-11-22 10 06 24](https://user-images.githubusercontent.com/40317050/203189550-358db1ce-a02a-4379-a9e7-d8172bc4977b.png)

`Watch中`
![スクリーンショット 2022-11-22 10 05 54](https://user-images.githubusercontent.com/40317050/203189557-d8481bfa-c297-4997-9d01-79d730b2764d.png)

`ブックマーク`
![スクリーンショット 2022-11-22 10 06 32](https://user-images.githubusercontent.com/40317050/203189547-b1c57e77-10d2-48be-b4f1-c595f925c386.png)

## 変更後

- `Watch中`タブには、新たに`マイプロフィール` `日報作成`ボタンが表示されるようになります。
- それ以外のタブは、画面表示は変わりません。

`ダッシュボード`
![スクリーンショット 2022-11-22 10 00 07](https://user-images.githubusercontent.com/40317050/203188971-15cb015b-69de-4747-ae46-7c2c71dc71f8.png)

`自分の日報`
![スクリーンショット 2022-11-22 10 00 17](https://user-images.githubusercontent.com/40317050/203188970-c75e65ea-b76a-4862-bc4e-e9452c0a2aa5.png)

 `自分の提出物`
![スクリーンショット 2022-11-22 10 00 27](https://user-images.githubusercontent.com/40317050/203188969-3f108f10-82a8-4c06-8e01-c3dc8da986db.png)

`Watch中`
![スクリーンショット 2022-11-22 10 00 40](https://user-images.githubusercontent.com/40317050/203188966-f1023ecc-95e8-48c8-aa10-1f4381eb3dab.png)

`ブックマーク`
![スクリーンショット 2022-11-22 10 00 48](https://user-images.githubusercontent.com/40317050/203188963-e8f6053d-c32e-4682-addc-093e49cdff65.png)


