### PR TITLE
メンター向けユーザーメモにローディング中の表示を追加

### DIFF
--- a/app/javascript/components/user_mentor_memo.vue
+++ b/app/javascript/components/user_mentor_memo.vue
@@ -5,7 +5,9 @@ section.a-card.is-memo.is-only-mentor
       | メンター向けユーザーメモ
   .card-body(v-if='!editing')
     .card__description
-      .o-empty-message(v-if='memo.length === 0')
+      .loading(v-if='loading')
+        | ローディング中
+      .o-empty-message(v-else-if='memo.length === 0')
         .o-empty-message__icon
           i.fa-regular.fa-sad-tear
         .o-empty-message__text
@@ -68,7 +70,8 @@ export default {
     return {
       memo: '',
       tab: 'memo',
-      editing: false
+      editing: false,
+      loading: true
     }
   },
   computed: {
@@ -93,6 +96,7 @@ export default {
         if (json.mentor_memo) {
           this.memo = json.mentor_memo
         }
+        this.loading = false
       })
       .catch((error) => {
         console.warn(error)

--- a/app/javascript/components/user_mentor_memo.vue
+++ b/app/javascript/components/user_mentor_memo.vue
@@ -5,8 +5,13 @@ section.a-card.is-memo.is-only-mentor
       | メンター向けユーザーメモ
   .card-body(v-if='!editing')
     .card__description
-      .loading(v-if='loading')
-        | ローディング中
+      .a-long-text.is-md.a-placeholder(v-if='loading')
+        p
+        p
+        p
+        p
+        p
+        p
       .o-empty-message(v-else-if='memo.length === 0')
         .o-empty-message__icon
           i.fa-regular.fa-sad-tear


### PR DESCRIPTION
## Issue

- #5712

## 概要
メンター向けユーザーメモ欄のローディング中にはローディング中の表示がされるようにしました。以前は（メモの有無に関わらず）ローディング中は「ユーザーメモはまだありません。」と表示されてしまっていました。

## 変更確認方法

1. `feature/add-loading-to-user-memo-for-mentors`をローカルに取り込む
2. `bin/setup`を実行する
3. `bin/rails s`でサーバーを起動する
4. `mentormentaro`でログイン
5. `http://localhost:3000/users/655153192`にアクセス。メンター向けユーザーメモにローディング中の表示がされることを確認する

## Screenshot

### 変更前
![スクリーンショット 2022-12-16 20 52 37](https://user-images.githubusercontent.com/59002337/208092763-f4e16ac0-da87-405e-9a6d-6fac6551bc68.png)

### 変更後
![スクリーンショット 2022-12-16 20 36 21](https://user-images.githubusercontent.com/59002337/208092788-9b587be4-0322-4ddf-8f39-f4ef0e145be6.png)


