### PR TITLE
ダッシュボードの最新のお知らせを5件表示にしたい

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -43,7 +43,7 @@ class HomeController < ApplicationController
   end
 
   def display_dashboard
-    @announcements = Announcement.with_avatar.where(wip: false).order(published_at: :desc).limit(3)
+    @announcements = Announcement.with_avatar.where(wip: false).order(published_at: :desc).limit(5)
     @bookmarks = current_user.bookmarks.order(created_at: :desc).limit(5)
     @completed_learnings = current_user.learnings.where(status: 3).includes(:practice).order(updated_at: :desc)
     @inactive_students = User.with_attached_avatar.inactive_students_and_trainees.order(last_activity_at: :desc)


### PR DESCRIPTION
## Issue

- #5816

## 概要

- ダッシュボードに表示している最新のお知らせを3件→5件表示に変更しました。

## 変更確認方法

1. `feature/change-display-recently-announcements` をローカルに取り込む
2. メンターアカウント `mentormentaro` でログイン
3. ダッシュボードのお知らせが5件表示になっていることを確認する

## Screenshot

| 変更前 | 変更後 |
| :---: | :---: |
| ![Screenshot 2022-11-29 at 21-14-54 ダッシュボード](https://user-images.githubusercontent.com/5976902/204527876-64e84103-90ab-43b1-8bd8-6fd28ee64f29.png) | ![Screenshot 2022-11-29 at 21-15-23 ダッシュボード](https://user-images.githubusercontent.com/5976902/204527950-cf5cc82c-5006-4b5c-9eaf-75f6bf5fc468.png) |

