### PR TITLE
capybaraエラー時のscreenshotの保存先を設定

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,8 +85,7 @@ jobs:
       - store_test_results:
           path: test/reports
       - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
+          path: tmp/screenshots
 workflows:
   build_and_test:
     jobs:


### PR DESCRIPTION
CircleCIでスクショが見れなくなっていたので。