### PR TITLE
footerにFjord Choiceのリンクを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -39,6 +39,9 @@ footer.footer
           li.footer-nav__item
             = link_to 'https://twitter.com/hashtag/fjordbootcamp?src=hashtag_click&f=live', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | #fjordbootcamp
+          li.footer-nav__item
+            = link_to 'https://fjord-choice.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | Fjord Choice
 
       small.footer__copyright
         i.fa-regular.fa-copyright


### PR DESCRIPTION
## Issue

- #5797

## 概要

footerにFjord Choiceのリンクを追加する

テキスト：Fjord Choice
リンク：https://fjord-choice.herokuapp.com

## 変更確認方法

1. `feature/add-fjord-choice-link-to-footer`をローカルに取り込む
2. `bin/setup`実行
3. `bin/rails s`でサーバーを立ち上げる
4. ログインする
5. ページの下に表示されていることを確認する

### 変更前

![footer-before-change](https://user-images.githubusercontent.com/52590443/204752141-7eb5ca2a-c4b2-4d28-928c-eb950b2f2cc5.png)

### 変更後

![footer-after-change](https://user-images.githubusercontent.com/52590443/204752061-4fcde63a-322d-432d-89e8-1f2a3537649a.png)
