### PR TITLE
events_testの「'waiting user moves up when participant cancels event」がリトライされる

### DIFF
--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -324,6 +324,7 @@ class EventsTest < ApplicationSystemTestCase
     within '.participants' do
       participants = all('img').map { |img| img['alt'] }
       assert_equal %w[kimura], participants
+      
     end
   end
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -298,7 +298,7 @@ class EventsTest < ApplicationSystemTestCase
         fill_in 'event[location]', with: 'FJORDオフィス'
         fill_in 'event[start_at]', with: Time.current.next_day
         fill_in 'event[end_at]', with: Time.current.next_day + 2.hours
-        fill_in 'event[open_start_at]', with: Time.current - 1.hours
+        fill_in 'event[open_start_at]', with: Time.current - 1.hour
         fill_in 'event[open_end_at]', with: Time.current + 2.hours
         click_button '作成'
       end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -324,7 +324,6 @@ class EventsTest < ApplicationSystemTestCase
     within '.participants' do
       participants = all('img').map { |img| img['alt'] }
       assert_equal %w[kimura], participants
-      
     end
   end
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -257,32 +257,34 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'display user to waitlist when event participants are fulled' do
-    visit_with_auth new_event_path, 'komagata'
-    within 'form[name=event]' do
-      fill_in 'event[title]', with: '補欠者のいるイベント'
-      fill_in 'event[description]', with: 'イベントの説明文'
-      fill_in 'event[capacity]', with: 1
-      fill_in 'event[location]', with: 'FJORDオフィス'
-      fill_in 'event[start_at]', with: Time.current.next_day
-      fill_in 'event[end_at]', with: Time.current.next_day + 2.hours
-      fill_in 'event[open_start_at]', with: Time.current
-      fill_in 'event[open_end_at]', with: Time.current + 2.hours
-      click_button '作成'
-    end
-    accept_confirm do
-      click_link '参加申込'
-    end
-    assert_text '参加登録しました'
+    travel_to Time.zone.local(2022, 12, 14, 16, 0, 0) do
+      visit_with_auth new_event_path, 'komagata'
+      within 'form[name=event]' do
+        fill_in 'event[title]', with: '補欠者のいるイベント'
+        fill_in 'event[description]', with: 'イベントの説明文'
+        fill_in 'event[capacity]', with: 1
+        fill_in 'event[location]', with: 'FJORDオフィス'
+        fill_in 'event[start_at]', with: Time.current.next_day
+        fill_in 'event[end_at]', with: Time.current.next_day + 2.hours
+        fill_in 'event[open_start_at]', with: Time.current
+        fill_in 'event[open_end_at]', with: Time.current + 2.hours
+        click_button '作成'
+      end
+      accept_confirm do
+        click_link '参加申込'
+      end
+      assert_text '参加登録しました'
 
-    visit_with_auth events_path, 'kimura'
-    click_link '補欠者のいるイベント'
-    accept_confirm do
-      click_link '補欠登録'
-    end
-    assert_text '参加登録しました'
-    within '.waitlist' do
-      wait_user = all('img').map { |img| img['alt'] }
-      assert_equal ['kimura (Kimura Tadasi)'], wait_user
+      visit_with_auth events_path, 'kimura'
+      click_link '補欠者のいるイベント'
+      accept_confirm do
+        click_link '補欠登録'
+      end
+      assert_text '参加登録しました'
+      within '.waitlist' do
+        wait_user = all('img').map { |img| img['alt'] }
+        assert_equal ['kimura (Kimura Tadasi)'], wait_user
+      end
     end
   end
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -289,15 +289,17 @@ class EventsTest < ApplicationSystemTestCase
   test 'waiting user moves up when participant cancels event' do
     visit_with_auth new_event_path, 'komagata'
     within 'form[name=event]' do
-      fill_in 'event[title]', with: '補欠者が繰り上がるイベント'
-      fill_in 'event[description]', with: 'イベントの説明文'
-      fill_in 'event[capacity]', with: 1
-      fill_in 'event[location]', with: 'FJORDオフィス'
-      fill_in 'event[start_at]', with: Time.current.next_day
-      fill_in 'event[end_at]', with: Time.current.next_day + 2.hours
-      fill_in 'event[open_start_at]', with: Time.current
-      fill_in 'event[open_end_at]', with: Time.current + 2.hours
-      click_button '作成'
+      travel_to Time.zone.local(2022, 12, 14, 16, 0, 0) do
+        fill_in 'event[title]', with: '補欠者が繰り上がるイベント'
+        fill_in 'event[description]', with: 'イベントの説明文'
+        fill_in 'event[capacity]', with: 1
+        fill_in 'event[location]', with: 'FJORDオフィス'
+        fill_in 'event[start_at]', with: Time.current.next_day
+        fill_in 'event[end_at]', with: Time.current.next_day + 2.hours
+        fill_in 'event[open_start_at]', with: Time.current
+        fill_in 'event[open_end_at]', with: Time.current + 2.hours
+        click_button '作成'
+      end
     end
     accept_confirm(wait: 10) do
       click_link '参加申込'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -299,14 +299,14 @@ class EventsTest < ApplicationSystemTestCase
       fill_in 'event[open_end_at]', with: Time.current + 2.hours
       click_button '作成'
     end
-    accept_confirm do
+    accept_confirm(wait: 10) do
       click_link '参加申込'
     end
     assert_text '参加登録しました'
 
     visit_with_auth events_path, 'kimura'
     click_link '補欠者が繰り上がるイベント'
-    accept_confirm do
+    accept_confirm(wait: 10) do
       click_link '補欠登録'
     end
     assert_text '参加登録しました'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -287,45 +287,46 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'waiting user moves up when participant cancels event' do
-    visit_with_auth new_event_path, 'komagata'
-    within 'form[name=event]' do
-      travel_to Time.zone.local(2022, 12, 14, 16, 0, 0) do
+    travel_to Time.zone.local(2022, 12, 14, 16, 0, 0) do
+      visit_with_auth new_event_path, 'komagata'
+      within 'form[name=event]' do
         fill_in 'event[title]', with: '補欠者が繰り上がるイベント'
         fill_in 'event[description]', with: 'イベントの説明文'
         fill_in 'event[capacity]', with: 1
         fill_in 'event[location]', with: 'FJORDオフィス'
         fill_in 'event[start_at]', with: Time.current.next_day
         fill_in 'event[end_at]', with: Time.current.next_day + 2.hours
-        fill_in 'event[open_start_at]', with: Time.current
+        fill_in 'event[open_start_at]', with: Time.current - 1.hours
         fill_in 'event[open_end_at]', with: Time.current + 2.hours
         click_button '作成'
       end
-    end
-    accept_confirm(wait: 10) do
-      click_link '参加申込'
-    end
-    assert_text '参加登録しました'
 
-    visit_with_auth events_path, 'kimura'
-    click_link '補欠者が繰り上がるイベント'
-    accept_confirm(wait: 10) do
-      click_link '補欠登録'
-    end
-    assert_text '参加登録しました'
-    within '.participants' do
-      participants = all('img').map { |img| img['alt'] }
-      assert_equal %w[komagata], participants
-    end
+      accept_confirm(wait: 10) do
+        click_link '参加申込'
+      end
+      assert_text '参加登録しました'
 
-    visit_with_auth events_path, 'komagata'
-    click_link '補欠者が繰り上がるイベント'
-    accept_confirm(wait: 10) do
-      click_link '参加を取り消す'
-    end
-    assert_text '参加を取り消しました'
-    within '.participants' do
-      participants = all('img').map { |img| img['alt'] }
-      assert_equal %w[kimura], participants
+      visit_with_auth events_path, 'kimura'
+      click_link '補欠者が繰り上がるイベント'
+      accept_confirm(wait: 10) do
+        click_link '補欠登録'
+      end
+      assert_text '参加登録しました'
+      within '.participants' do
+        participants = all('img').map { |img| img['alt'] }
+        assert_equal %w[komagata], participants
+      end
+
+      visit_with_auth events_path, 'komagata'
+      click_link '補欠者が繰り上がるイベント'
+      accept_confirm(wait: 10) do
+        click_link '参加を取り消す'
+      end
+      assert_text '参加を取り消しました'
+      within '.participants' do
+        participants = all('img').map { |img| img['alt'] }
+        assert_equal %w[kimura], participants
+      end
     end
   end
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -317,7 +317,7 @@ class EventsTest < ApplicationSystemTestCase
 
     visit_with_auth events_path, 'komagata'
     click_link '補欠者が繰り上がるイベント'
-    accept_confirm do
+    accept_confirm(wait: 10) do
       click_link '参加を取り消す'
     end
     assert_text '参加を取り消しました'


### PR DESCRIPTION
## Issue

- #5779

## 概要

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

