### PR TITLE
イベント作成のタイトル入力のinputにプレースホルダー追加

### DIFF
--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -4,7 +4,7 @@
     .form__items-inner
       .form-item
         = f.label :title, class: 'a-form-label'
-        = f.text_field :title, class: 'a-text-input js-warning-form'
+        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'ミートアップ2022年12月'
       .form-item
         = f.label :location, class: 'a-form-label'
         = f.text_field :location, class: 'a-text-input js-warning-form'


### PR DESCRIPTION
## Issue

- #5749

## 概要

イベント作成のタイトル入力のinputにプレースホルダー追加する

プレースホルダー：`ミートアップ2022年12月`

## 変更確認方法

1. `feature/add-placeholder-to-title-input-in-event-creation`をローカルに取り込む
2. `bin/setup`実行
3. `bin/rails s`でサーバーを立ち上げる
4. `komagata`でログインする
5. 左サイドバーの「イベント」をクリックする
6. 上部にある「イベントの作成」ボタンをクリックする。
7. 入力タイトルに表示されていることを確認する

## Screenshot

### 変更前

![before-change](https://user-images.githubusercontent.com/52590443/204969900-8ebda04e-7447-47cc-8ef5-36b02ba8f983.png)

### 変更後

![after-change](https://user-images.githubusercontent.com/52590443/204969892-e6eefc76-013e-41e1-9e08-4b1bd5d5c8d3.png)

