### PR TITLE
管理者は管理画面から特殊ユーザー属性でメンター権限を付けられる

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -56,7 +56,7 @@ class Admin::UsersController < AdminController
       :graduated_on, :retired_on, :free,
       :job_seeker, :github_collaborator,
       :officekey_permission, :tag_list, :training_ends_on,
-      :profile_image, :profile_name, :profile_job,
+      :profile_image, :profile_name, :profile_job, :mentor,
       :profile_text, authored_books_attributes: %i[id title url cover _destroy]
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,18 +169,6 @@ class User < ApplicationRecord
                        message: 'はPNG, JPG, GIF形式にしてください'
                      }
 
-  validates :profile_image, attached: true,
-                            content_type: {
-                              in: %w[image/png image/jpg image/jpeg image/gif],
-                              message: 'はPNG, JPG, GIF形式にしてください'
-                            }, if: :mentor?
-
-  with_options if: -> { mentor? }, presence: true do
-    validates :profile_name
-    validates :profile_job
-    validates :profile_text
-  end
-
   with_options if: -> { %i[create update].include? validation_context } do
     validates :login_name, presence: true, uniqueness: true,
                            format: {

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -95,6 +95,8 @@
               = render 'users/form/trainee', f: f
             .form-item-block__item
               = render 'users/form/free', f: f
+            .form-item-block__item
+              = render 'users/form/mentor', f: f
 
       .form-item-block#external-services
         .form-item-block__inner

--- a/app/views/users/form/_mentor.html.slim
+++ b/app/views/users/form/_mentor.html.slim
@@ -1,0 +1,6 @@
+.block-checks.is-1-item
+  .block-checks__item
+    .a-block-check.is-checkbox
+      = f.check_box :mentor, class: 'a-toggle-checkbox'
+      = f.label :mentor, class: 'a-block-check__label is-ta-left' do
+        = User.human_attribute_name :mentor

--- a/app/views/users/form/_profile_image.html.slim
+++ b/app/views/users/form/_profile_image.html.slim
@@ -1,5 +1,5 @@
 .form-item
-  = f.label :profile_image, class: 'a-form-label is-required'
+  = f.label :profile_image, class: 'a-form-label'
   .form-item-file-input.js-file-input.a-file-input.is-square
     label.js-file-input__preview
       - if f.object.profile_image.attached?

--- a/app/views/users/form/_profile_job.html.slim
+++ b/app/views/users/form/_profile_job.html.slim
@@ -1,3 +1,3 @@
 .form-item
-  = f.label :profile_job, class: 'a-form-label is-required'
+  = f.label :profile_job, class: 'a-form-label'
   = f.text_field :profile_job, class: 'a-text-input', placeholder: 'プログラマー'

--- a/app/views/users/form/_profile_name.html.slim
+++ b/app/views/users/form/_profile_name.html.slim
@@ -1,3 +1,3 @@
 .form-item
-  = f.label :profile_name, class: 'a-form-label is-required'
+  = f.label :profile_name, class: 'a-form-label'
   = f.text_field :profile_name, class: 'a-text-input', placeholder: '駒形 真幸'

--- a/app/views/users/form/_profile_text.html.slim
+++ b/app/views/users/form/_profile_text.html.slim
@@ -1,3 +1,3 @@
 .form-item
-  = f.label :profile_text, class: 'a-form-label is-required'
+  = f.label :profile_text, class: 'a-form-label'
   = f.text_area :profile_text, class: 'a-text-input is-sm', placeholder: '[株式会社フィヨルド](https://fjord.jp)の代表兼プログラマー。Rubyが大好きで[怖話](https://kowabana.jp)、[フィヨルドブートキャンプ](https://bootcamp.fjord.jp)などを開発している。'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -79,6 +79,7 @@ ja:
         graduated_on: 卒業日
         adviser: アドバイザー
         trainee: 研修生
+        mentor: メンター
         job_seeking: 就職活動中
         hibernated_at: 休会日時
         retired_on: 退会日

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -281,4 +281,14 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_text 'プロフィール名'
     assert_text 'プロフィール文'
   end
+
+  test 'display special user attributes when administrator logined' do
+    user = users(:machida)
+    visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'
+    assert_text '特殊ユーザー属性'
+    assert_text 'アドバイザー'
+    assert_text '研修生'
+    assert_text '無料'
+    assert_text 'メンター'
+  end
 end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -282,16 +282,6 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_text 'プロフィール文'
   end
 
-  test 'display special user attributes when administrator logined' do
-    user = users(:machida)
-    visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'
-    assert_text '特殊ユーザー属性'
-    assert_text 'アドバイザー'
-    assert_text '研修生'
-    assert_text '無料'
-    assert_text 'メンター'
-  end
-
   test 'administrator can set user’s special user attribute to mentor' do
     user = users(:advijirou)
     visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -291,4 +291,16 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_text '無料'
     assert_text 'メンター'
   end
+
+  test 'administrator can set user’s special user attribute to mentor' do
+    user = users(:advijirou)
+    visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'
+    assert_no_text 'メンター紹介用公開プロフィール'
+    check 'user_mentor', allow_label_click: true, visible: false
+    assert has_checked_field?('user_mentor', visible: false)
+    click_on '更新する'
+    assert_text 'ユーザー情報を更新しました'
+    visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'
+    assert_text 'メンター紹介用公開プロフィール'
+  end
 end


### PR DESCRIPTION
## Issue

- #5784 

## 概要

- 管理者はメンターフラグをつけることができる
- メンター紹介用入力フォームのバリデーションは外す（必須→非必須に変更）
- メンターフラグのon, offによるフォームの表示切り替えについては、このIssueではやらない 

## 変更確認方法

1. `feature/admin-provide-mentor-authority` をローカルに取り込む
2. `bin/rails s`でアプリを起動
3. `komagata`でログイン、管理ページへ移動
4. ユーザータブを開き、アドバイザータグを選択
5. `advijirou`を選び、「管理者として情報変更」をクリック
6. 「特殊ユーザー属性」にメンターが追加されていることを確認する
7. `advijirou`にメンター権限を付与して更新ボタン押下
8. メンター紹介用フォームが表示されていることを確認（必須項目でないことも確認する）

## Screenshot

### 変更前
<img width="599" alt="CleanShot 2022-12-08 at 20 15 39@2x" src="https://user-images.githubusercontent.com/5976902/206433288-5d1a4043-f715-4d1a-aa21-4609c5b67bd3.png">

### 変更後
![Screenshot 2022-12-08 at 20-09-45 ユーザー登録情報変更](https://user-images.githubusercontent.com/5976902/206433315-f5a82d03-b584-499e-8218-29a0d08ce9f1.png)


