### PR TITLE
明日定期イベントが開催される場合に通知を行う機能のシステムテストを作成

### DIFF
--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -46,16 +46,20 @@ class DiscordNotifier < ApplicationNotifier
     webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:admin]
     day_of_the_week = %w[日 月 火 水 木 金 土]
     event_date = event.next_event_date
-
-    notification(
-      body: "⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
+    event_info = <<~TEXT.chomp
+      ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
       【イベントのお知らせ】
       明日 #{event_date.strftime("%m月%d日（#{day_of_the_week[event_date.wday]}）")}に開催されるイベントです！
       --------------------------------------------
       #{event.title}
       時間: #{event.start_at.strftime('%H:%M')} 〜 #{event.end_at.strftime('%H:%M')}
       詳細: #{Rails.application.routes.url_helpers.regular_event_url(event)}
-      --------------------------------------------\n⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️",
+      --------------------------------------------
+      ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
+    TEXT
+
+    notification(
+      body: event_info,
       name: 'ピヨルド',
       webhook_url: webhook_url
     )

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -67,16 +67,20 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       event: regular_events(:regular_event1),
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }
-
-    expected = {
-      body: "⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
+    event_info = <<~TEXT.chomp
+      ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
       【イベントのお知らせ】
       明日 07月31日（日）に開催されるイベントです！
       --------------------------------------------
       開発MTG
       時間: 15:00 〜 16:00
       詳細: http://localhost:3000/regular_events/459650222
-      --------------------------------------------\n⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️",
+      --------------------------------------------
+      ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
+    TEXT
+
+    expected = {
+      body: event_info,
       name: 'ピヨルド',
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -2,7 +2,7 @@
 
 require 'application_system_test_case'
 
-class Notification::ProductsTest < ApplicationSystemTestCase
+class Notification::RegularEventsTest < ApplicationSystemTestCase
   setup do
     @delivery_mode = AbstractNotifier.delivery_mode
     AbstractNotifier.delivery_mode = :normal

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -26,4 +26,34 @@ class Notification::ProductsTest < ApplicationSystemTestCase
       assert_text "定期イベント【#{regular_event.title}】が更新されました。"
     end
   end
+
+  test 'notify_tommorrow_regular_event' do
+    event_info = <<~TEXT.chomp
+      ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
+      【イベントのお知らせ】
+      明日 07月31日（日）に開催されるイベントです！
+      --------------------------------------------
+      開発MTG
+      時間: 15:00 〜 16:00
+      詳細: http://localhost:3000/regular_events/459650222
+      --------------------------------------------
+      ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
+    TEXT
+    params = {
+      url: 'https://discord.com/api/webhooks/0123456789/admin',
+      username: 'ピヨルド',
+      avatar_url: 'https://i.gyazo.com/7099977680d8d8c2d72a3f14ddf14cc6.png',
+      content: event_info
+    }
+
+    stub_message = stub_request(:post, 'https://discord.com/api/webhooks/0123456789/admin')
+                   .with(body: params,
+                         headers: { 'Content-Type' => 'application/json' })
+
+    travel_to Time.zone.local(2022, 7, 30, 0, 0, 0) do
+      visit_with_auth '/scheduler/daily', 'komagata'
+    end
+
+    assert_requested(stub_message)
+  end
 end

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -12,7 +12,7 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
     AbstractNotifier.delivery_mode = @delivery_mode
   end
 
-  test 'Notify when a regular event change' do
+  test 'notify when a regular event change' do
     regular_event = regular_events(:regular_event1)
     visit_with_auth "/regular_events/#{regular_event.id}/edit", 'komagata'
     within('form[name=regular_event]') do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require 'minitest/retry'
 require 'supports/api_helper'
 require 'supports/vcr_helper'
 require 'abstract_notifier/testing/minitest'
+require 'webmock/minitest'
 
 Capybara.default_max_wait_time = 5
 Capybara.disable_animation = true


### PR DESCRIPTION
## Issue

- #5566

## 概要
明日定期イベントが開催される場合、その旨をDiscordに通知する機能のシステムテストを作成しました。

テストでの確認ポイントを以下としました。
- `/scheduler/daily`にアクセスした場合に、Discord宛にHTTPリクエストが行われているか。（本当にリクエストを送るわけではなく、`webmock`を使い、スタブリクエストを作成して確認しています。）
- アクセス日は2022年7月30日に設定し、`fixtures`の`regular_event1`をテスト対象としている。（`regular_event1`は毎週開催のため、土曜日であればいつでもいいが、すでに作成済みのテストhttps://github.com/fjordllc/bootcamp/blob/main/test/notifiers/discord_notifier_test.rb#L84 に倣って統一しました。）

※今回のissueに関連する部分で気になった点があったので、そちらも修正しました。
- テスト対象となる機能のコードで、改行が含まれる文字列にヒアドキュメントが使われておらず、インデントが影響しそうだったので修正。
- 上記に関連するテスト`discord_notifier_test`の`.tomorrow_regular_event`の修正。
- `regular_events_test.rb`のクラス名がファイル名と統一されていなかったため修正。
- `regular_events_test.rb`の別のテスト名が大文字始まりだったため、小文字に修正。（他ファイルのテストは小文字始まりだったので、そちらに倣って統一しました。）

## 確認方法

1. `feature/add_test_to_notify_tomorrow_regular_event`をローカルに取り込む
2. 以下のテストを実行し、テストが通ることを確認
```
$ rails test test/system/notification/regular_events_test.rb:30
```

3. 概要に記述した通り、`discord_notifier_test`も修正したため、以下のテストを実行し、テストが通ることを確認
```
$ rails test test/notifiers/discord_notifier_test.rb:65
```

## Screenshot
<img width="387" alt="スクリーンショット 2022-12-05 22 18 23" src="https://user-images.githubusercontent.com/88083085/205647030-c277e54e-eb37-4fe7-a07d-8959e1ceff09.png">

<img width="369" alt="スクリーンショット 2022-12-05 22 18 43" src="https://user-images.githubusercontent.com/88083085/205647057-d2a79cc4-35aa-4ebd-a22d-76ab4b828832.png">
