### PR TITLE
ユーザー一覧、期生別ユーザー一覧で1ページに表示されるユーザー数を24件にした

### DIFF
--- a/app/controllers/api/generations_controller.rb
+++ b/app/controllers/api/generations_controller.rb
@@ -2,7 +2,7 @@
 
 class API::GenerationsController < API::BaseController
   before_action :require_login
-  PAGER_NUMBER = 20
+  PAGER_NUMBER = 24
 
   def show
     generation = params[:id].to_i

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,7 +3,7 @@
 class API::UsersController < API::BaseController
   before_action :set_user, only: %i[show update]
   before_action :require_login_for_api
-  PAGER_NUMBER = 20
+  PAGER_NUMBER = 24
 
   def index
     @tag = params[:tag]

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -136,9 +136,3 @@ talk34:
 talk_advisernocolleguetrainee:
   user: advisernocolleguetrainee
   unreplied: false
-
-<% 1.upto(4) do |i| %>
-marumarushain<%= i %>: # ページネーション確認のためのユーザー
-  user: marumarushain<%= i %>
-  unreplied: false
-<% end %>

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -136,3 +136,9 @@ talk34:
 talk_advisernocolleguetrainee:
   user: advisernocolleguetrainee
   unreplied: false
+
+<% 1.upto(4) do |i| %>
+marumarushain<%= i %>: # ページネーション確認のためのユーザー
+  user: marumarushain<%= i %>
+  unreplied: false
+<% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -895,3 +895,28 @@ advisernocolleguetrainee:
   updated_at: "2022-07-01 00:00:00"
   created_at: "2022-07-01 00:00:00"
   last_activity_at: "2022-07-01 00:00:00"
+
+<% 1.upto(4) do |i| %>
+marumarushain<%= i %>: # ページネーション確認のためのユーザー
+  login_name: marumarushain<%= i %>
+  email: marumarushain<%= i %>@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: marumarushain<%= i %>
+  name_kana: マルマル シャイン<%= i %>
+  twitter_account:
+  facebook_url:
+  blog_url:
+  company: company1
+  description: マルマル企業の社員<%= i %>
+  course: course1
+  job: office_worker
+  os: mac
+  experience: rails
+  organization: 株式会社フィヨルド
+  github_collaborator: true
+  unsubscribe_email_token: MnC-Dv3HrNLs7WmfE975qA
+  updated_at: "2014-01-01 00:00:02"
+  created_at: "2014-01-01 00:00:02"
+  last_activity_at: "2014-01-01 00:00:02"
+<% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -895,28 +895,3 @@ advisernocolleguetrainee:
   updated_at: "2022-07-01 00:00:00"
   created_at: "2022-07-01 00:00:00"
   last_activity_at: "2022-07-01 00:00:00"
-
-<% 1.upto(4) do |i| %>
-marumarushain<%= i %>: # ページネーション確認のためのユーザー
-  login_name: marumarushain<%= i %>
-  email: marumarushain<%= i %>@fjord.jp
-  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
-  salt: zW3kQ9ubsxQQtzzzs4ap
-  name: marumarushain<%= i %>
-  name_kana: マルマル シャイン<%= i %>
-  twitter_account:
-  facebook_url:
-  blog_url:
-  company: company1
-  description: マルマル企業の社員<%= i %>
-  course: course1
-  job: office_worker
-  os: mac
-  experience: rails
-  organization: 株式会社フィヨルド
-  github_collaborator: true
-  unsubscribe_email_token: MnC-Dv3HrNLs7WmfE975qA
-  updated_at: "2014-01-01 00:00:02"
-  created_at: "2014-01-01 00:00:02"
-  last_activity_at: "2014-01-01 00:00:02"
-<% end %>

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -84,7 +84,7 @@ class TalksTest < ApplicationSystemTestCase
   test 'a list of current students is displayed' do
     visit_with_auth '/talks?target=student_and_trainee', 'komagata'
     find('#talks.loaded', wait: 10)
-    assert_text 'kimura (Kimura Tadasi) さんの相談部屋'
+    assert_text 'hajime (Hajime Tayo) さんの相談部屋'
   end
 
   test 'a list of graduates is displayed' do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -402,63 +402,63 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'incremental search by login_name' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimura'
     assert_text 'Kimura Tadasi', count: 1
   end
 
   test 'incremental search by name' do
     visit_with_auth '/users', 'kimura'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'Shinji'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by name_kana' do
     visit_with_auth '/users', 'mentormentaro'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'キムラ ミタイ'
     assert_text 'Kimura Mitai', count: 1
   end
 
   test 'incremental search by twitter_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'hatsuno'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by blog_url' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'hatsuno.org'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by github_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kananashi'
     assert_text 'ユーザーです 読み方のカナが無い', count: 1
   end
 
   test 'incremental search by discord_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimura#1234'
     assert_text 'Kimura Tadasi', count: 1
   end
 
   test 'incremental search by facebook_url' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimurafacebook'
     assert_text 'Kimura Mitai', count: 1
   end
 
   test 'incremental search by description' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: '木村です'
     assert_text 'Kimura Tadasi', count: 1
   end
@@ -542,9 +542,9 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'incremental search needs more than two characters for Japanese and three for others' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'ki'
-    assert_equal 21, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kim'
     assert_text 'Kimura', count: 2
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -402,63 +402,63 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'incremental search by login_name' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimura'
     assert_text 'Kimura Tadasi', count: 1
   end
 
   test 'incremental search by name' do
     visit_with_auth '/users', 'kimura'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'Shinji'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by name_kana' do
     visit_with_auth '/users', 'mentormentaro'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'キムラ ミタイ'
     assert_text 'Kimura Mitai', count: 1
   end
 
   test 'incremental search by twitter_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'hatsuno'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by blog_url' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'hatsuno.org'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by github_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kananashi'
     assert_text 'ユーザーです 読み方のカナが無い', count: 1
   end
 
   test 'incremental search by discord_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimura#1234'
     assert_text 'Kimura Tadasi', count: 1
   end
 
   test 'incremental search by facebook_url' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimurafacebook'
     assert_text 'Kimura Mitai', count: 1
   end
 
   test 'incremental search by description' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: '木村です'
     assert_text 'Kimura Tadasi', count: 1
   end
@@ -542,9 +542,9 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'incremental search needs more than two characters for Japanese and three for others' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'ki'
-    assert_equal 24, all('.users-item').length
+    assert_equal 21, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kim'
     assert_text 'Kimura', count: 2
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -402,63 +402,63 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'incremental search by login_name' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimura'
     assert_text 'Kimura Tadasi', count: 1
   end
 
   test 'incremental search by name' do
     visit_with_auth '/users', 'kimura'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'Shinji'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by name_kana' do
     visit_with_auth '/users', 'mentormentaro'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'キムラ ミタイ'
     assert_text 'Kimura Mitai', count: 1
   end
 
   test 'incremental search by twitter_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'hatsuno'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by blog_url' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'hatsuno.org'
     assert_text 'Hatsuno Shinji', count: 1
   end
 
   test 'incremental search by github_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kananashi'
     assert_text 'ユーザーです 読み方のカナが無い', count: 1
   end
 
   test 'incremental search by discord_account' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimura#1234'
     assert_text 'Kimura Tadasi', count: 1
   end
 
   test 'incremental search by facebook_url' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kimurafacebook'
     assert_text 'Kimura Mitai', count: 1
   end
 
   test 'incremental search by description' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: '木村です'
     assert_text 'Kimura Tadasi', count: 1
   end
@@ -506,7 +506,7 @@ class UsersTest < ApplicationSystemTestCase
   test 'search users from all users when target is all' do
     visit_with_auth '/users?target=all', 'komagata'
     assert_text 'ロード中'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'hajime'
     assert_text 'Hajime Tayo', count: 1
 
@@ -542,9 +542,9 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'incremental search needs more than two characters for Japanese and three for others' do
     visit_with_auth '/users', 'komagata'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'ki'
-    assert_equal 20, all('.users-item').length
+    assert_equal 24, all('.users-item').length
     fill_in 'js-user-search-input', with: 'kim'
     assert_text 'Kimura', count: 2
 


### PR DESCRIPTION
## Issue
- #2185 

## 概要
ユーザー一覧、期生別ユーザー一覧で1ページに表示されるユーザー数を20件から24件に変更しました。
この変更によって、どの画面幅でも一覧の最後に空白が出なくなりました。

空白とは、下の画像のように要素が足りなくて出来てしまうスペースのことを指しています。
![blank](https://user-images.githubusercontent.com/66685066/205914810-1d0624cd-cb5a-463b-b096-2619f17f9ea5.png)

## 変更確認方法
1. `feature/change-the-number-of-users-displayed-on-one-page`をローカルに取り込む
1. `$ bin/rails s`でローカル環境を立ち上げる
1. 任意のアカウントでログイン
1. ユーザー一覧(`/users`)にアクセス
    1. フッター付近までスクロールしてください。
    1. ブラウザの幅を変更しながら、ユーザーの表示が2列、3列、4列どの場合も一覧の最後に空白がないことを確認してください。
    1. 念の為1ページあたりのユーザー表示件数が24件であることを確認してください。
1. 5期生のユーザー一覧 (`/generations/5`)にアクセス
    1. フッター付近までスクロールしてください。
    1. ブラウザの幅を変更しながら、ユーザーの表示が2列、3列、4列どの場合も一覧の最後に空白がないことを確認してください。
    1. 念の為1ページあたりのユーザー表示件数が24件であることを確認してください。

## Screenshot
### ユーザー一覧 `/users`
#### 変更前
空白がある。
![before_activeDuty](https://user-images.githubusercontent.com/66685066/205905603-43f6206c-bf3c-44b2-819d-458f38993f3b.png)
#### 変更後
空白がない。
![after_activeDuty](https://user-images.githubusercontent.com/66685066/205905864-0994b68b-d99a-468e-bba4-7883cfafeace.png)
### 期生別ユーザー一覧 `/generations/:id`
#### 変更前
空白がある。
![before_generations](https://user-images.githubusercontent.com/66685066/205905795-6ec412de-1897-493a-9a22-8388a4c2e2e8.png)
#### 変更後
空白がない。
![after_generations](https://user-images.githubusercontent.com/66685066/205905926-e34f7919-e227-4b8a-a288-d31be23cdf3d.png)
