### PR TITLE
必読書籍があるプラクティスに要書籍のマークを表示する

### DIFF
--- a/app/assets/stylesheets/application/blocks/practice/_category-practices-item.sass
+++ b/app/assets/stylesheets/application/blocks/practice/_category-practices-item.sass
@@ -44,11 +44,17 @@
 
 .category-practices-item__title-link
   +text-block(.875rem 1.5, $default-text flex)
-  +hover-link
   align-items: center
   min-height: 1.875rem
+  text-decoration: none
   +media-breakpoint-down(sm)
     font-size: .8125rem
+  .a-badge
+    margin-right: .25rem
+
+.category-practices-item__title-link-label
+  a.category-practices-item__title-link:hover &
+    text-decoration: underline
 
 .category-practices-item__learning-time
   +text-block(.75rem 1.4, $muted-text)

--- a/app/assets/stylesheets/atoms/_a-badge.sass
+++ b/app/assets/stylesheets/atoms/_a-badge.sass
@@ -31,8 +31,8 @@
 
   //size
   &.is-xs
-    +button-size(.625rem, 1, .25)
-    font-weight: 600
+    +button-size(.625rem, 1, .5)
+    font-weight: 500
   &.is-sm
     +button-size(.6875rem, 1, .5)
     font-weight: 600

--- a/app/assets/stylesheets/atoms/_a-title-label.sass
+++ b/app/assets/stylesheets/atoms/_a-title-label.sass
@@ -1,5 +1,5 @@
 .a-title-label
-  +text-block(.5em 1, inline-flex nowrap 600)
+  +text-block(.5em 1, inline-flex nowrap 500)
   vertical-align: top
   background-color: #e9ebef
   +padding(horizontal, 1em)
@@ -16,10 +16,12 @@
     +position(top .375em)
   &.is-solved
     color: $reversal-text
-    &.is-success
-      background-color: $success
-    &.is-danger
-      background-color: $danger
   &.is-wip
     color: $semi-muted-text
     background-color: $background-semi-shade
+  &.is-success
+    color: $reversal-text
+    background-color: $success
+  &.is-danger
+    color: $reversal-text
+    background-color: $danger

--- a/app/javascript/courses-practice.vue
+++ b/app/javascript/courses-practice.vue
@@ -4,7 +4,7 @@
   header.category-practices-item__header
     .category-practices-item__title
       a.category-practices-item__title-link(:href='practices.url')
-        | {{ practices.practice.title }}
+        | {{ displayPracticeTitle(practices) }}
     a(
       :class='`practice-status category-practices-item__status is-${statusByLearnings(practices.practice.id)}`',
       :href='`${practices.url}#learning-Status`',
@@ -70,6 +70,10 @@ export default {
         submitted: '提出',
         complete: '修了'
       }[learningStatus]
+    },
+    displayPracticeTitle(practices) {
+      const title = practices.practice.title
+      return practices.include_must_read_books ? `要書籍 ${title}` : title
     }
   }
 }

--- a/app/javascript/courses-practice.vue
+++ b/app/javascript/courses-practice.vue
@@ -73,7 +73,7 @@ export default {
         submitted: '提出',
         complete: '修了'
       }[learningStatus]
-    },
+    }
   }
 }
 </script>

--- a/app/javascript/courses-practice.vue
+++ b/app/javascript/courses-practice.vue
@@ -4,7 +4,10 @@
   header.category-practices-item__header
     .category-practices-item__title
       a.category-practices-item__title-link(:href='practices.url')
-        | {{ displayPracticeTitle(practices) }}
+        span.a-badge.is-danger.is-xs(v-if='practices.include_must_read_books')
+          | 要書籍
+        span.category-practices-item__title-link-label
+          | {{ practices.practice.title }}
     a(
       :class='`practice-status category-practices-item__status is-${statusByLearnings(practices.practice.id)}`',
       :href='`${practices.url}#learning-Status`',
@@ -71,10 +74,6 @@ export default {
         complete: '修了'
       }[learningStatus]
     },
-    displayPracticeTitle(practices) {
-      const title = practices.practice.title
-      return practices.include_must_read_books ? `要書籍 ${title}` : title
-    }
   }
 }
 </script>

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -160,7 +160,7 @@ class Practice < ApplicationRecord
   end
 
   def include_must_read_books?
-    return false if practices_books.nil?
+    return false if practices_books.empty?
 
     practices_books.any?(&:must_read)
   end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -159,6 +159,12 @@ class Practice < ApplicationRecord
     "https://twitter.com/intent/tweet?#{tweet_param}"
   end
 
+  def include_must_read_books?
+    return false if practices_books.nil?
+
+    practices_books.any?(&:must_read)
+  end
+
   private
 
   def total_learning_minute(report)

--- a/app/views/api/courses/practices/index.json.jbuilder
+++ b/app/views/api/courses/practices/index.json.jbuilder
@@ -7,6 +7,7 @@ json.categories @categories do |category|
   json.practices do
     json.array! category.practices do |practice|
       json.practice practice
+      json.include_must_read_books practice.include_must_read_books?
       json.url practice_path(practice)
       json.learning_minute_statistic practice.learning_minute_statistic
       json.started_students practice.started_students.each do |user|

--- a/app/views/courses/practices/sort/index.html.slim
+++ b/app/views/courses/practices/sort/index.html.slim
@@ -56,11 +56,12 @@ header.page-header
                               span.a-grab.js-grab
                                 i.fa-solid.fa-align-justify
 
-        nav.page-nav
-          ul.page-nav__items
-            - @categories.each do |category|
-              - if category.practices.present?
-                li.page-nav__item
-                  a.page-nav__item-link(href="#category-#{category.id}")
-                    span.page-nav__item-link-inner
-                      = category.name
+        .page-body__column.is-sub
+          nav.page-nav.a-card
+            ul.page-nav__items
+              - @categories.each do |category|
+                - if category.practices.present?
+                  li.page-nav__item
+                    a.page-nav__item-link(href="#category-#{category.id}")
+                      span.page-nav__item-link-inner
+                        = category.name

--- a/app/views/courses/practices/sort/index.html.slim
+++ b/app/views/courses/practices/sort/index.html.slim
@@ -45,8 +45,13 @@ header.page-header
                           header.category-practices-item__header
                             .category-practices-item__title
                               .category-practices-item__title-link
-                                | #{categories_practice.position}
-                                = categories_practice.practice.title
+                                span.a-badge.is-dark-muted.is-xs
+                                  | #{categories_practice.position}
+                                - if categories_practice.practice.include_must_read_books?
+                                  span.a-badge.is-danger.is-xs
+                                    | 要書籍
+                                span.category-practices-item__title-link-label
+                                  = categories_practice.practice.title
                             .category-practices-item__grab
                               span.a-grab.js-grab
                                 i.fa-solid.fa-align-justify

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -42,7 +42,7 @@
               .page-content-header__row
                 h1.page-content-header__title
                   - if @practice.include_must_read_books?
-                    = '要書籍' + ' ' + @practice.title
+                    = "要書籍 #{@practice.title}"
                   - else
                     = @practice.title
 

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -1,8 +1,9 @@
 - title @practice.title
 - category = @practice.category(current_user.course)
+- include_must_read_books = @practice.include_must_read_books?
 
 = render '/shared/modal_learning_completion', practice: @practice, tweet_url: @tweet_url, should_display_message_automatically: false
-= render '/practices/page_header', title: title, category: category
+= render '/practices/page_header', title: title, category: category, include_must_read_books: include_must_read_books
 = render 'page_tabs', resource: @practice
 
 .page-body
@@ -40,7 +41,10 @@
             .page-content-header__end
               .page-content-header__row
                 h1.page-content-header__title
-                  = @practice.title
+                  - if @practice.include_must_read_books?
+                    = '要書籍' + ' ' + @practice.title
+                  - else
+                    = @practice.title
 
               - if @practice.last_updated_user.present?
                 .page-content-header__row

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -1,9 +1,8 @@
 - title @practice.title
 - category = @practice.category(current_user.course)
-- include_must_read_books = @practice.include_must_read_books?
 
 = render '/shared/modal_learning_completion', practice: @practice, tweet_url: @tweet_url, should_display_message_automatically: false
-= render '/practices/page_header', title: title, category: category, include_must_read_books: include_must_read_books
+= render '/practices/page_header', title: title, category: category
 = render 'page_tabs', resource: @practice
 
 .page-body

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -42,9 +42,9 @@
               .page-content-header__row
                 h1.page-content-header__title
                   - if @practice.include_must_read_books?
-                    = "要書籍 #{@practice.title}"
-                  - else
-                    = @practice.title
+                    span.a-title-label.is-danger
+                      | 要書籍
+                  = @practice.title
 
               - if @practice.last_updated_user.present?
                 .page-content-header__row


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/5733

## 概要
必読書籍があるプラクティスに要書籍のマークを表示させました（プラクティス一覧、プラクティス個別ページ）

## 変更確認方法

1. `feature/display-must-read-book-on-practice`をローカルに取り込む
2.  `komagata`でログイン
3.  `http://localhost:3000/courses/829913840/practices`にアクセスし要書籍と表示されていることを確認
4.  `http://localhost:3000/practices/315059988`にアクセスし要書籍と表示されていることを確認

## Screenshot
### 変更前
プラクティス一覧
![image](https://user-images.githubusercontent.com/43959158/205958147-7d92f54c-39af-4735-a040-4821cf1eaf2c.png)

プラクティス個別ページ
![image](https://user-images.githubusercontent.com/43959158/205958039-b90c07a3-7f68-4021-9605-cfd4339f8f47.png)

### 変更後
プラクティス一覧
![image](https://user-images.githubusercontent.com/43959158/207598104-b50ec514-cde3-4db6-8c56-c9d7afee6379.png)

プラクティス個別ページ
![image](https://user-images.githubusercontent.com/43959158/207598140-c7139cc3-d9cf-40b4-afaf-92304c59bf3c.png)


