### PR TITLE
フッターにFBC Contributorsのリンクを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -42,6 +42,9 @@ footer.footer
           li.footer-nav__item
             = link_to 'https://fjord-choice.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | Fjord Choice
+          li.footer-nav__item
+            = link_to 'https://fjord-boot-camp-contributors-production.up.railway.app', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | FBC Contributors
 
       small.footer__copyright
         i.fa-regular.fa-copyright


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5817

## 概要

FBC Contributors のリンクをフッターに追加する

テキストは FBC Contributors
URL は https://fjord-boot-camp-contributors-production.up.railway.app

## 変更確認方法

1. feature/add-fjord-contributors-link-to-footerをローカルに取り込む
2. bin/setup実行
3. bin/rails sでサーバーを立ち上げる
4. ログインする
5. ページの下に表示されていることを確認する

## Screenshot

### 変更前

<img width="1234" alt="スクリーンショット 2022-12-07 16 40 08" src="https://user-images.githubusercontent.com/1616717/206117709-1f510604-06d9-4a57-9445-dd496308779b.png">

### 変更後

<img width="1226" alt="スクリーンショット 2022-12-07 16 39 39" src="https://user-images.githubusercontent.com/1616717/206117754-f2f581fe-bb6a-401d-a1fc-48be76eed17f.png">


