### PR TITLE
期生別ユーザー一覧で期生別タブにアクティブする

### DIFF
--- a/app/views/users/_lg_page_tabs.html.slim
+++ b/app/views/users/_lg_page_tabs.html.slim
@@ -5,7 +5,7 @@
         = link_to users_path, class: "page-tabs__item-link #{'is-active' if users_current_page_tab?('users') && @target != 'followings'}" do
           | 全て
       li.page-tabs__item
-        = link_to generations_path, class: "page-tabs__item-link #{users_current_page_tab_or_not('generations')}" do
+        = link_to generations_path, class: "page-tabs__item-link #{current_page_tab_or_not('generations')}" do
           | 期生別
       li.page-tabs__item
         = link_to users_tags_path, class: "page-tabs__item-link #{users_current_page_tab_or_not('tags')} #{current_page_tab_or_not('tags')}" do


### PR DESCRIPTION
## Issue

- #5899

## 概要

期生別ユーザー一覧で期生別タブにアクティブする

## 変更確認方法

1. `feature/improve-loading-speed-of-generation-list-page`をローカルに取り込む
2. `bin/setup`実行
3. `bin/rails s`でサーバーを立ち上げる
4. ログインする
5. `http://127.0.0.1:3000/generations/5`に行く
6. 期生別タブがアクティブしているかどうか確認する

## Screenshot

### 変更前

![before](https://user-images.githubusercontent.com/52590443/206133529-c96e3d61-1385-4e87-947d-52b9ac4a1c1d.png)


### 変更後

![after](https://user-images.githubusercontent.com/52590443/206133545-fb26180a-353f-4474-b6c2-89b4c46b7c44.png)
