### PR TITLE
vue に書かれているユーザーアイコンのマークアップを変更

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -8,7 +8,7 @@ module UserDecorator
   def roles
     roles = []
 
-    roles << :retired if retired?
+    roles << :retired if retired_on?
     roles << :admin if admin?
     roles << :mentor if mentor?
     roles << :adviser if adviser?

--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -2,10 +2,10 @@
 .thread-comment
   .thread-comment__author
     a.thread-comment__user-link(:href='answer.user.url', itemprop='url')
-      img.thread-comment__user-icon.a-user-icon(
-        :src='answer.user.avatar_url',
-        :title='answer.user.icon_title',
-        :class='[roleClass]')
+      span(:class='["a-user-role", roleClass]')
+        img.thread-comment__user-icon.a-user-icon(
+          :src='answer.user.avatar_url',
+          :title='answer.user.icon_title')
       a.thread-comment__company-link(
         v-if='answer.user.company && answer.user.adviser',
         :href='answer.user.company.url')

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -18,9 +18,10 @@
       @update='updateAnswer')
   .thread-comment-form
     .thread-comment__author
-      img.thread-comment__user-icon.a-user-icon(
-        :src='currentUser.avatar_url',
-        :title='currentUser.icon_title')
+      span(:class='["a-user-role", roleClass]')
+        img.thread-comment__user-icon.a-user-icon(
+          :src='currentUser.avatar_url',
+          :title='currentUser.icon_title')
     .thread-comment-form__form.a-card
       .a-form-tabs.js-tabs
         .a-form-tabs__tab.js-tabs__tab(
@@ -91,6 +92,9 @@ export default {
     },
     baseUrl: function () {
       return '/api/answers'
+    },
+    roleClass() {
+      return `is-${this.currentUser.primary_role}`
     }
   },
   created: function () {

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -2,10 +2,10 @@
 .thread-comment
   .thread-comment__author
     a.thread-comment__user-link(:href='comment.user.url')
-      img.thread-comment__user-icon.a-user-icon(
-        :src='comment.user.avatar_url',
-        :title='comment.user.icon_title',
-        :class='[roleClass]')
+      span(:class='["a-user-role", roleClass]')
+        img.thread-comment__user-icon.a-user-icon(
+          :src='comment.user.avatar_url',
+          :title='comment.user.icon_title')
     a.thread-comment__company-link(
       v-if='comment.user.company && comment.user.adviser',
       :href='comment.user.company.url')

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -29,10 +29,10 @@
   .thread-comment-form
     #latest-comment(v-if='comments.length === 0')
     .thread-comment__author
-      img.thread-comment__user-icon.a-user-icon(
-        :src='currentUser.avatar_url',
-        :class='[roleClass]',
-        :title='currentUser.icon_title')
+      span(:class='["a-user-role", roleClass]')
+        img.thread-comment__user-icon.a-user-icon(
+          :src='currentUser.avatar_url',
+          :title='currentUser.icon_title')
     .thread-comment-form__form.a-card
       .a-form-tabs.js-tabs
         .a-form-tabs__tab.js-tabs__tab(

--- a/app/javascript/company.vue
+++ b/app/javascript/company.vue
@@ -17,11 +17,12 @@
     .a-user-icons__items
       .a-user-icons__item(v-for='user in company.users', :key='user.id')
         a.a-user-icons__item-link(:href='user.url')
-          img(
-            :src='user.avatar_url',
-            :title='user.icon_title',
-            :data-login-name='user.login_name',
-            :class='`a-user-icons__item-icon a-user-icon is-${user.primary_role}`')
+          span(:class='["a-user-role", `is-${user.primary_role}`]')
+            img(
+              :src='user.avatar_url',
+              :title='user.icon_title',
+              :data-login-name='user.login_name',
+              :class='"a-user-icons__item-icon a-user-icon"')
 </template>
 <script>
 export default {

--- a/app/javascript/components/announcement.vue
+++ b/app/javascript/components/announcement.vue
@@ -3,11 +3,11 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='announcement.user.url')
-        img.card-list-item__user-icon.a-user-icon(
-          :title='announcement.user.icon_title',
-          :alt='announcement.user.icon_title',
-          :src='announcement.user.avatar_url',
-          :class='[roleClass]')
+        span.a-user-role(:class='roleClass')
+          img.card-list-item__user-icon.a-user-icon(
+            :title='announcement.user.icon_title',
+            :alt='announcement.user.icon_title',
+            :src='announcement.user.avatar_url')
     .card-list-item__rows
       .card-list-item__row
         .card-list-item-title

--- a/app/javascript/components/announcement.vue
+++ b/app/javascript/components/announcement.vue
@@ -3,7 +3,7 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='announcement.user.url')
-        span(:class='`a-user-role ${roleClass}`')
+        span(:class='["a-user-role", roleClass]')
           img.card-list-item__user-icon.a-user-icon(
             :title='announcement.user.icon_title',
             :alt='announcement.user.icon_title',

--- a/app/javascript/components/announcement.vue
+++ b/app/javascript/components/announcement.vue
@@ -3,7 +3,7 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='announcement.user.url')
-        span.a-user-role(:class='roleClass')
+        span(:class='`a-user-role ${roleClass}`')
           img.card-list-item__user-icon.a-user-icon(
             :title='announcement.user.icon_title',
             :alt='announcement.user.icon_title',

--- a/app/javascript/components/footprint.vue
+++ b/app/javascript/components/footprint.vue
@@ -1,11 +1,12 @@
 <template lang="pug">
 li.user-icons__item
   a.user-icons__item-link(:href='`${footprint.user.url}`')
-    img.a-user-icon.is-sm(
-      :title='footprint.user.icon_title',
-      :alt='footprint.user.icon_title',
-      :src='footprint.user.avatar_url',
-      :class='[loginNameClass, primaryRoleClass]')
+    span(:class='["a-user-role", primaryRoleClass]')
+      img.a-user-icon.is-sm(
+        :title='footprint.user.icon_title',
+        :alt='footprint.user.icon_title',
+        :src='footprint.user.avatar_url',
+        :class='loginNameClass')
 </template>
 <script>
 export default {

--- a/app/javascript/components/page.vue
+++ b/app/javascript/components/page.vue
@@ -3,11 +3,11 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='page.user.url')
-        img.card-list-item__user-icon.a-user-icon(
-          :title='page.user.icon_title',
-          :alt='page.user.icon_title',
-          :src='page.user.avatar_url',
-          :class='[roleClassPublishedUser]')
+        span(:class='["a-user-role", roleClassPublishedUser]')
+          img.card-list-item__user-icon.a-user-icon(
+            :title='page.user.icon_title',
+            :alt='page.user.icon_title',
+            :src='page.user.avatar_url')
 
     .card-list-item__rows
       .card-list-item__row

--- a/app/javascript/components/question.vue
+++ b/app/javascript/components/question.vue
@@ -3,11 +3,11 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='question.user.url')
-        img.card-list-item__user-icon.a-user-icon(
-          :title='question.user.icon_title',
-          :alt='question.user.icon_title',
-          :src='question.user.avatar_url',
-          :class='[roleClass]')
+        span(:class='`a-user-role ${roleClass}`')
+          img.card-list-item__user-icon.a-user-icon(
+            :title='question.user.icon_title',
+            :alt='question.user.icon_title',
+            :src='question.user.avatar_url')
     .card-list-item__rows
       .card-list-item__row
         .card-list-item-title

--- a/app/javascript/components/question.vue
+++ b/app/javascript/components/question.vue
@@ -3,7 +3,7 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='question.user.url')
-        span(:class='`a-user-role ${roleClass}`')
+        span(:class='["a-user-role", roleClass]')
           img.card-list-item__user-icon.a-user-icon(
             :title='question.user.icon_title',
             :alt='question.user.icon_title',

--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -3,7 +3,7 @@
   .card-list-item__inner
     .card-list-item__user(v-if='displayUserIcon')
       a.card-list-item__user-link(:href='report.user.url')
-        span(:class='`a-user-role ${roleClass}`')
+        span(:class='["a-user-role", roleClass]')
           img.card-list-item__user-icon.a-user-icon(
             :src='report.user.avatar_url',
             :title='report.user.login_name',

--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -3,11 +3,11 @@
   .card-list-item__inner
     .card-list-item__user(v-if='displayUserIcon')
       a.card-list-item__user-link(:href='report.user.url')
-        img.card-list-item__user-icon.a-user-icon(
-          :src='report.user.avatar_url',
-          :title='report.user.login_name',
-          :alt='report.user.login_name',
-          :class='[roleClass]')
+        span(:class='`a-user-role ${roleClass}`')
+          img.card-list-item__user-icon.a-user-icon(
+            :src='report.user.avatar_url',
+            :title='report.user.login_name',
+            :alt='report.user.login_name')
     .card-list-item__rows
       .card-list-item__row
         header.card-list-item-title

--- a/app/javascript/components/user.vue
+++ b/app/javascript/components/user.vue
@@ -10,11 +10,11 @@
           .users-item__header-start
             .users-item__icon
               a(:href='user.url')
-                img.users-item__user-icon-image.a-user-icon(
-                  :title='user.icon_title',
-                  :alt='user.icon_title',
-                  :src='user.avatar_url',
-                  :class='[roleClass]')
+                span(:class='["a-user-role", roleClass]')
+                  img.users-item__user-icon-image.a-user-icon(
+                    :title='user.icon_title',
+                    :alt='user.icon_title',
+                    :src='user.avatar_url')
           .users-item__header-end
             .card-list-item__rows
               .card-list-item__row

--- a/app/javascript/components/users-answer.vue
+++ b/app/javascript/components/users-answer.vue
@@ -3,11 +3,11 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='answer.question.user.url')
-        img.card-list-item__user-icon.a-user-icon(
-          :title='answer.question.user.icon_title',
-          :alt='answer.question.user.icon_title',
-          :src='answer.question.user.avatar_url',
-          :class='[roleClass]')
+        span(:class='["a-user-role", roleClass]')
+          img.card-list-item__user-icon.a-user-icon(
+            :title='answer.question.user.icon_title',
+            :alt='answer.question.user.icon_title',
+            :src='answer.question.user.avatar_url')
     .card-list-item__rows
       .card-list-item__row
         .card-list-item-title

--- a/app/javascript/generation.vue
+++ b/app/javascript/generation.vue
@@ -13,11 +13,12 @@
     .a-user-icons__items
       .a-user-icons__item(v-for='user in users', :key='user.id')
         a.a-user-icons__item-link(:href='user.url')
-          img(
-            :src='user.avatar_url',
-            :title='user.icon_title',
-            :data-login-name='user.login_name',
-            :class='`a-user-icons__item-icon a-user-icon is-${user.primary_role}`')
+          span(:class='["a-user-role", `is-${user.primary_role}`]')
+            img(
+              :src='user.avatar_url',
+              :title='user.icon_title',
+              :data-login-name='user.login_name',
+              :class='"a-user-icons__item-icon a-user-icon"')
 </template>
 <script>
 import loadingGenerationsPageGenerationPlaceholder from './loading-generations-page-generation-placeholder.vue'

--- a/app/javascript/practice-user-icon.vue
+++ b/app/javascript/practice-user-icon.vue
@@ -1,10 +1,11 @@
 <template lang="pug">
 .a-user-icons__item
   a.a-user-icons__item-link(:href='startedStudent.user_link')
-    img(
-      :class='`a-user-icons__item-icon a-user-icon ${activeOrInactive} is-${startedStudent.primary_role}`',
-      :src='startedStudent.avatar_url',
-      :title='`${startedStudent.icon_title}`')
+    span(:class='`a-user-role is-${startedStudent.primary_role}`')
+      img(
+        :class='`a-user-icons__item-icon a-user-icon ${activeOrInactive}`',
+        :src='startedStudent.avatar_url',
+        :title='`${startedStudent.icon_title}`')
 </template>
 
 <script>

--- a/app/javascript/practice-user-icon.vue
+++ b/app/javascript/practice-user-icon.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .a-user-icons__item
   a.a-user-icons__item-link(:href='startedStudent.user_link')
-    span(:class='`a-user-role is-${startedStudent.primary_role}`')
+    span(:class='["a-user-role", roleClass]')
       img(
         :class='`a-user-icons__item-icon a-user-icon ${activeOrInactive}`',
         :src='startedStudent.avatar_url',
@@ -17,6 +17,9 @@ export default {
     activeOrInactive() {
       const active = this.startedStudent.active
       return active ? 'active' : 'inactive'
+    },
+    roleClass() {
+      return `is-${this.startedStudent.primary_role}`
     }
   }
 }

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -3,11 +3,11 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='product.user.url')
-        img.card-list-item__user-icon.a-user-icon(
-          :title='product.user.icon_title',
-          :alt='product.user.icon_title',
-          :src='product.user.avatar_url',
-          :class='[roleClass]')
+        span(:class='["a-user-role", roleClass]')
+          img.card-list-item__user-icon.a-user-icon(
+            :title='product.user.icon_title',
+            :alt='product.user.icon_title',
+            :src='product.user.avatar_url')
     .card-list-item__rows
       .card-list-item__row
         .card-list-item-title

--- a/app/javascript/user-icon.vue
+++ b/app/javascript/user-icon.vue
@@ -1,10 +1,11 @@
 <template lang="pug">
 a(:href='user.url', :class='`${blockClass}user-link`')
-  img(
-    :src='user.avatar_url',
-    :alt='user.icon_title',
-    :title='user.icon_title',
-    :class='[`${blockClass}user-icon`, "a-user-icon", roleClass]')
+  span(:class='["a-user-role", roleClass]')
+    img(
+      :src='user.avatar_url',
+      :alt='user.icon_title',
+      :title='user.icon_title',
+      :class='[`${blockClass}user-icon`, "a-user-icon"]')
 </template>
 
 <script>

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -147,13 +147,9 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       within all('.a-user-icons__items').last do
-<<<<<<< HEAD
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-retired')['title'], 'yameo (辞目 辞目夫)'
-=======
         within first('.a-user-role.is-retired') do
           assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'yameo (辞目 辞目夫)'
         end
->>>>>>> 7915c33cf ( HTML構造を変更したのでテストを修正)
       end
     end
   end

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -20,7 +20,9 @@ class GenerationsTest < ApplicationSystemTestCase
     assert_text 'ユーザー一覧'
     assert_link "#{users(:otameshi).generation}期生"
     within all('.a-user-icons__items').first do
-      assert_equal first('img')['class'], 'a-user-icons__item-icon a-user-icon is-student'
+      within first('.a-user-role.is-student') do
+        assert_equal first('img')['class'], 'a-user-icons__item-icon a-user-icon'
+      end
     end
     assert_equal '期生別ユーザー一覧 | FBC', title
   end
@@ -41,19 +43,29 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '33期生'
       assert_text '2021年01月01日 ~ 2021年03月31日'
       within all('.a-user-icons__items').first do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-admin')['title'], 'adminonly (アドミン 能美代): 管理者'
+        within first('.a-user-role.is-admin') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'adminonly (アドミン 能美代): 管理者'
+        end
       end
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       within all('.a-user-icons__items').last do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-student')['title'], 'marumarushain1 (marumarushain1)'
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['title'], 'kensyu (Kensyu Seiko)'
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['title'], 'advijirou (アドバイ 次郎): アドバイザー'
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['title'], 'sotugyou (卒業 太郎)'
-        assert_equal all('.a-user-icons__item-icon.a-user-icon.is-mentor').last['title'], 'mentormentaro (メンタ 麺太郎): メンター'
-        all('.a-user-icons__item-icon.a-user-icon.is-student').each do |selector|
-          assert_not_equal selector['title'], 'yameo (辞目 辞目夫)'
+        within first('.a-user-role.is-student') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'marumarushain1 (marumarushain1)'
         end
+        within first('.a-user-role.is-trainee') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'kensyu (Kensyu Seiko)'
+        end
+        within first('.a-user-role.is-adviser') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'advijirou (アドバイ 次郎): アドバイザー'
+        end
+        within first('.a-user-role.is-graduate') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'sotugyou (卒業 太郎)'
+        end
+        within all('.a-user-role.is-mentor').last do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'mentormentaro (メンタ 麺太郎): メンター'
+        end
+        assert_empty all('.a-user-role.is-retired')
       end
     end
   end
@@ -67,10 +79,10 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       within all('.a-user-icons__items').last do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['title'], 'kensyu (Kensyu Seiko)'
-        all('.a-user-icons__item-icon.a-user-icon.is-student').each do |selector|
-          assert_not_equal selector['title'], 'yameo (辞目 辞目夫)'
+        within first('.a-user-role.is-trainee') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'kensyu (Kensyu Seiko)'
         end
+        assert_empty all('.a-user-role.is-retired')
       end
     end
   end
@@ -84,10 +96,10 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       within all('.a-user-icons__items').last do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['title'], 'advijirou (アドバイ 次郎): アドバイザー'
-        all('.a-user-icons__item-icon.a-user-icon.is-student').each do |selector|
-          assert_not_equal selector['title'], 'yameo (辞目 辞目夫)'
+        within first('.a-user-role.is-adviser') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'advijirou (アドバイ 次郎): アドバイザー'
         end
+        assert_empty all('.a-user-role.is-retired')
       end
     end
   end
@@ -101,10 +113,10 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       within all('.a-user-icons__items').last do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['title'], 'sotugyou (卒業 太郎)'
-        all('.a-user-icons__item-icon.a-user-icon.is-student').each do |selector|
-          assert_not_equal selector['title'], 'yameo (辞目 辞目夫)'
+        within first('.a-user-role.is-graduate') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'sotugyou (卒業 太郎)'
         end
+        assert_empty all('.a-user-role.is-retired')
       end
     end
   end
@@ -118,10 +130,10 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       within all('.a-user-icons__items').last do
-        assert_equal all('.a-user-icons__item-icon.a-user-icon.is-mentor').last['title'], 'mentormentaro (メンタ 麺太郎): メンター'
-        all('.a-user-icons__item-icon.a-user-icon.is-student').each do |selector|
-          assert_not_equal selector['title'], 'yameo (辞目 辞目夫)'
+        within all('.a-user-role.is-mentor').last do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'mentormentaro (メンタ 麺太郎): メンター'
         end
+        assert_empty all('.a-user-role.is-retired')
       end
     end
   end
@@ -135,7 +147,13 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       within all('.a-user-icons__items').last do
+<<<<<<< HEAD
         assert_equal first('.a-user-icons__item-icon.a-user-icon.is-retired')['title'], 'yameo (辞目 辞目夫)'
+=======
+        within first('.a-user-role.is-retired') do
+          assert_equal first('.a-user-icons__item-icon.a-user-icon')['title'], 'yameo (辞目 辞目夫)'
+        end
+>>>>>>> 7915c33cf ( HTML構造を変更したのでテストを修正)
       end
     end
   end

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -21,15 +21,27 @@ class User::CompaniesTest < ApplicationSystemTestCase
     end
     assert_selector('.group-company-name__label', text: 'Fjord Inc.')
     within all('.a-user-icons__items')[1] do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
-      assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'machida'
+      within first('.a-user-role.is-admin') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
+      end
+      within all('.a-user-role.is-admin')[1] do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'machida'
+      end
     end
     assert_selector('.group-company-name__label', text: 'root inc.')
     within all('.a-user-icons__items')[2] do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
-      assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'kensyuowata'
-      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'senpai'
-      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
+      within first('.a-user-role.is-trainee') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
+      end
+      within all('.a-user-role.is-trainee')[1] do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyuowata'
+      end
+      within first('.a-user-role.is-adviser') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'senpai'
+      end
+      within first('.a-user-role.is-graduate') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
+      end
     end
 
     click_link '全員'
@@ -37,19 +49,33 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_text '企業別（全員）'
     assert_selector('.group-company-name__label', text: 'ユーザの企業に登録しないで株式会社')
     within first('.a-user-icons__items') do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['data-login-name'], 'advisernocolleguetrainee'
-    end
+      within first('.a-user-role.is-adviser') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'advisernocolleguetrainee'
+      end
+    end 
     assert_selector('.group-company-name__label', text: 'Fjord Inc.')
     within all('.a-user-icons__items')[1] do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-admin')['data-login-name'], 'komagata'
-      assert_equal all('.a-user-icons__item-icon.a-user-icon.is-admin')[1]['data-login-name'], 'machida'
+      within first('.a-user-role.is-admin') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
+      end
+      within all('.a-user-role.is-admin')[1] do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'machida'
+      end
     end
     assert_selector('.group-company-name__label', text: 'root inc.')
     within all('.a-user-icons__items')[2] do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['data-login-name'], 'kensyu'
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-retired')['data-login-name'], 'kensyuowata'
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['data-login-name'], 'senpai'
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['data-login-name'], 'sotsugyoukigyoshozoku'
+      within first('.a-user-role.is-trainee') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
+      end
+      within all('.a-user-role.is-trainee')[1] do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyuowata'
+      end
+      within first('.a-user-role.is-adviser') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'senpai'
+      end
+      within first('.a-user-role.is-graduate') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
+      end
     end
   end
 
@@ -61,8 +87,12 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_selector('a.tab-nav__item-link.is-active', text: '研修生')
     assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
     assert_selector('.group-company-name__label', text: 'root inc.')
-    assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
-    assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'kensyuowata'
+    within first('.a-user-role.is-trainee') do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
+    end
+    within all('.a-user-role.is-trainee')[1] do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyuowata'
+    end
   end
 
   test 'show adviser belonging to each company' do
@@ -73,9 +103,13 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_selector('a.tab-nav__item-link.is-active', text: 'アドバイザー')
     assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
     assert_selector('.group-company-name__label', text: 'ユーザの企業に登録しないで株式会社')
-    assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'advisernocolleguetrainee'
+    within first('.a-user-role.is-adviser') do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'advisernocolleguetrainee'
+    end
     assert_selector('.group-company-name__label', text: 'root inc.')
-    assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'senpai'
+    within all('.a-user-role.is-adviser')[1] do
+      assert_equal all('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'senpai'
+    end
   end
 
   test 'show graduate belonging to each company' do
@@ -86,7 +120,9 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_selector('a.tab-nav__item-link.is-active', text: '卒業生')
     assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
     assert_selector('.group-company-name__label', text: 'root inc.')
-    assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
+    within first('.a-user-role.is-graduate') do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
+    end
   end
 
   test 'show mentor belonging to each company' do
@@ -96,8 +132,12 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_text '企業別（メンター）'
     assert_selector('a.tab-nav__item-link.is-active', text: 'メンター')
     assert_selector('.group-company-name__label', text: 'Fjord Inc.')
-    assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
-    assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'machida'
+    within first('.a-user-role.is-admin') do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
+    end
+    within all('.a-user-role.is-admin')[1] do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'machida'
+    end
     assert_no_selector('.group-company-name__label', text: 'root inc.')
   end
 end

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -33,7 +33,7 @@ class User::CompaniesTest < ApplicationSystemTestCase
       within first('.a-user-role.is-trainee') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
       end
-      within all('.a-user-role.is-trainee')[1] do
+      within first('.a-user-role.is-retired') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyuowata'
       end
       within first('.a-user-role.is-adviser') do
@@ -67,7 +67,7 @@ class User::CompaniesTest < ApplicationSystemTestCase
       within first('.a-user-role.is-trainee') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
       end
-      within all('.a-user-role.is-trainee')[1] do
+      within first('.a-user-role.is-retired') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyuowata'
       end
       within first('.a-user-role.is-adviser') do
@@ -90,7 +90,7 @@ class User::CompaniesTest < ApplicationSystemTestCase
     within first('.a-user-role.is-trainee') do
       assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
     end
-    within all('.a-user-role.is-trainee')[1] do
+    within first('.a-user-role.is-retired') do
       assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyuowata'
     end
   end

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -17,19 +17,19 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_text '企業別（全員）'
     assert_selector('.group-company-name__label', text: 'ユーザの企業に登録しないで株式会社')
     within first('.a-user-icons__items') do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['data-login-name'], 'advisernocolleguetrainee'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'advisernocolleguetrainee'
     end
     assert_selector('.group-company-name__label', text: 'Fjord Inc.')
     within all('.a-user-icons__items')[1] do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-admin')['data-login-name'], 'komagata'
-      assert_equal all('.a-user-icons__item-icon.a-user-icon.is-admin')[1]['data-login-name'], 'machida'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
+      assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'machida'
     end
     assert_selector('.group-company-name__label', text: 'root inc.')
     within all('.a-user-icons__items')[2] do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['data-login-name'], 'kensyu'
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-retired')['data-login-name'], 'kensyuowata'
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['data-login-name'], 'senpai'
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['data-login-name'], 'sotsugyoukigyoshozoku'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
+      assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'kensyuowata'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'senpai'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
     end
 
     click_link '全員'
@@ -61,8 +61,8 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_selector('a.tab-nav__item-link.is-active', text: '研修生')
     assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
     assert_selector('.group-company-name__label', text: 'root inc.')
-    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['data-login-name'], 'kensyu'
-    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-retired')['data-login-name'], 'kensyuowata'
+    assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
+    assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'kensyuowata'
   end
 
   test 'show adviser belonging to each company' do
@@ -73,9 +73,9 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_selector('a.tab-nav__item-link.is-active', text: 'アドバイザー')
     assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
     assert_selector('.group-company-name__label', text: 'ユーザの企業に登録しないで株式会社')
-    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['data-login-name'], 'advisernocolleguetrainee'
+    assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'advisernocolleguetrainee'
     assert_selector('.group-company-name__label', text: 'root inc.')
-    assert_equal all('.a-user-icons__item-icon.a-user-icon.is-adviser')[1]['data-login-name'], 'senpai'
+    assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'senpai'
   end
 
   test 'show graduate belonging to each company' do
@@ -86,7 +86,7 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_selector('a.tab-nav__item-link.is-active', text: '卒業生')
     assert_no_selector('.group-company-name__label', text: 'Fjord Inc.')
     assert_selector('.group-company-name__label', text: 'root inc.')
-    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['data-login-name'], 'sotsugyoukigyoshozoku'
+    assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
   end
 
   test 'show mentor belonging to each company' do
@@ -96,8 +96,8 @@ class User::CompaniesTest < ApplicationSystemTestCase
     assert_text '企業別（メンター）'
     assert_selector('a.tab-nav__item-link.is-active', text: 'メンター')
     assert_selector('.group-company-name__label', text: 'Fjord Inc.')
-    assert_equal first('.a-user-icons__item-icon.a-user-icon.is-admin')['data-login-name'], 'komagata'
-    assert_equal all('.a-user-icons__item-icon.a-user-icon.is-admin')[1]['data-login-name'], 'machida'
+    assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
+    assert_equal all('.a-user-icons__item-icon.a-user-icon')[1]['data-login-name'], 'machida'
     assert_no_selector('.group-company-name__label', text: 'root inc.')
   end
 end

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -52,7 +52,7 @@ class User::CompaniesTest < ApplicationSystemTestCase
       within first('.a-user-role.is-adviser') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'advisernocolleguetrainee'
       end
-    end 
+    end
     assert_selector('.group-company-name__label', text: 'Fjord Inc.')
     within all('.a-user-icons__items')[1] do
       within first('.a-user-role.is-admin') do

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -108,7 +108,7 @@ class User::CompaniesTest < ApplicationSystemTestCase
     end
     assert_selector('.group-company-name__label', text: 'root inc.')
     within all('.a-user-role.is-adviser')[1] do
-      assert_equal all('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'senpai'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'senpai'
     end
   end
 


### PR DESCRIPTION
## Issue
- #5848

## 概要
### 行ったこと1
#### 退会したユーザーアイコンに`is-retired`クラスを付与

ユーザーアイコンには`user class`が付与されています。

以下の例では管理者なので`is-admin`というクラスが付与されています。

<img width="108" alt="スクリーンショット 2022-11-30 16 53 11" src="https://user-images.githubusercontent.com/81839214/204738436-9a967802-c4db-477e-9f1e-0595574e9efc.png">

<img width="1065" alt="スクリーンショット 2022-11-30 16 51 38" src="https://user-images.githubusercontent.com/81839214/204738131-7fc5f91d-08aa-4855-96ca-be87b7d1681d.png">

他にも以下のような`user class`が状況に応じて付与される様になっています。
- 現役受講生... is-student
- 管理者... is-admin
- メンター... is-mentor
- アドバイザー... is-adviser
- 研修生... is-trainee
- 卒業生... is-graduate


しかし退会したユーザーのclassがないので、退会したユーザーアイコンに`is-retired`というクラスを付与しました。
### 行ったこと2
#### ユーザーアイコンのhtml構造を変更
ユーザーアイコンのhtml構造が以下の様になっていました。

```html
<img title="ユーザー名" alt="ユーザー名" src="アイコン画像パス" class="a-user-icon is-graduate">
```

これを以下の様な構造に変更しました。

```html
<span  class="a-user-role is-graduate">
  <img title="ユーザー名" alt="ユーザー名" src="アイコン画像パス" class="a-user-icon">
</span>
```

## Screenshot

### 変更前
<img width="1440" alt="スクリーンショット 2023-01-21 17 23 25" src="https://user-images.githubusercontent.com/81839214/213858741-fa7cbe29-61ef-4091-a26e-873a23dd22eb.png">

### 変更後
<img width="1440" alt="スクリーンショット 2023-01-21 17 21 35" src="https://user-images.githubusercontent.com/81839214/213858660-462e0132-c581-4d08-9d30-07f7c3098217.png">

## 変更確認方法

1. `ffeature/change-user-icon-markup-writen-in-vue`をローカルに取り込む。
2. bin/rails sでローカル環境を立ち上げてください。
3. komagataのアカウントでログインを行い、ユーザーページに移動してください。(この時のURLは`localhost:3000/users`です。)
4. ユーザーページの「全て」タブをクリックし、さらに「退会」タブをクリックしてください。
<img width="1440" alt="スクリーンショット 2023-01-20 20 45 01" src="https://user-images.githubusercontent.com/81839214/213688196-14d6f178-9b07-4d90-8dd7-87c36b5dc77e.png">
5. 開発者ツールを開き、「yameo」のユーザーアイコンのHTML構造が以下の様になっていることを確認してください。

```html
<span  class="a-user-role is-retired">
  <img title="yameo (辞目 辞目夫)" alt="yameo (辞目 辞目夫)" src="(画像パスは割愛します)" class="users-item__user-icon-image a-user-icon">
</span>
```
※ オプションでimgタグに`users-item__user-icon-image`クラスが付与されていますが元の仕様なので無視してもらって問題ありません。
以下の例では`card-list-item__user-icon`がオプションで付与されています。
<img width="1129" alt="スクリーンショット 2022-12-09 15 36 29" src="https://user-images.githubusercontent.com/81839214/206640488-8ddebd35-e066-4859-a7c7-ebb569e5cd7b.png">

以上の確認方法で他の変更を行った箇所を確認していただきたいです🤲
以下が変更を行った箇所とそのURL、ログインに使用していただきたいユーザーです。

※ 今回の変更ではslimに関わる箇所への変更は行わず、vueへの変更を行いました。
(例 [ヘッダー]Meアイコンはslimで書かれている箇所なので変更はしていません。)

|修正した箇所 | URL| ログインユーザー |
| --- | --- | --- |
| [お知らせ]一覧 お知らせ作成ユーザー | localhost:3000/announcements |kimura|
| [プラクティス]一覧 ユーザーアイコン | localhost:3000/courses/829913840/practices#category-917504053 | kimura |
| [日報]一覧 作成ユーザーアイコン | localhost:3000/reports | kimura |
| [Q&A]一覧 作成ユーザーアイコン| localhost:3000/questions | kimura |
| [Q&A]一覧未解決 作成ユーザーアイコン| localhost:3000/questions?target=not_solved | kimura |
| [Q&A]一覧未解決 作成ユーザーアイコン| localhost:3000/questions?target=solved | kimura |
| [Q&A]詳細 作成ユーザーアイコン |localhost:3000/questions/1037106414 | kimura |
| [Q&A]詳細 回答者ユーザーアイコン |localhost:3000/questions/782854533 | komagata |
| [Q&A]詳細 回答,コメントフォーム左 ユーザーアイコン | localhost:3000/questions/1011540508 | komagata |
| [提出物]一覧 作成者ユーザーアイコン | localhost:3000/products | komagata |
| [提出物]一覧自分の担当 作成者ユーザーアイコン | localhost:3000/products/self_assigned | komagata |
| [提出物]一覧未アサイン 作成者ユーザーアイコン |localhost:3000/products/unassigned | komagata|
| [ユーザー]一覧 現役生 アイコン | localhost:3000/users?target=student_and_trainee | komagata |
| [ユーザー]一覧 メンター アイコン |localhost:3000/users?target=mentor  | komagata |
| [ユーザー]一覧 卒業生 アイコン |localhost:3000/users?target=graduate  |komagata  |
| [ユーザー]一覧 アドバイザー アイコン | localhost:3000/users?target=adviser | komagata |
| [ユーザー]一覧 研修生 アイコン | localhost:3000/users?target=trainee | komagata |
| [ユーザー]一覧 就職活動 アイコン | localhost:3000/users?target=job_seeking | komagata |
| [ユーザー]一覧 全員 アイコン | localhost:3000/users?target=job_all | komagata |
| [ユーザー一覧]期生別ユーザーアイコン 期生一覧ページ | localhost:3000/generations | kimura |
| [ユーザー]一覧  期生別詳細ユーザーアイコン | localhost:3000/generations/40 | kimura |
| [ユーザー]一覧  タグ別詳細ユーザーアイコン  | localhost:3000/users/tags/猫 | kimura |
| [ユーザー]一覧  フォロー中ユーザーアイコン | localhost:3000/users?target=followings | kimura |
| [ユーザー]一覧  フォロー中ユーザーアイコン コメントあり |localhost:3000/users?target=followings&watch=true  | kimura |
| [ユーザー]一覧  フォロー中ユーザーアイコン コメントなし |localhost:3000/users?target=followings&watch=false  | kimura |
| [ユーザー]一覧 企業一覧 ユーザー一覧 全員|localhost:3000/users/companies?target=mentor  | kimura |
| [ユーザー]一覧 企業一覧 ユーザー一覧 研修生 | localhost:3000/users/companies?target=trainee | kimura |
| [ユーザー]一覧 企業一覧 ユーザー一覧 メンター | localhost:3000/users/companies?target=mentor | kimura |
| [ユーザー]一覧 企業一覧 ユーザー一覧 アドバイザー | localhost:3000/users/companies?target=advieser | kimura |
| [ユーザー]一覧 企業一覧 ユーザー一覧 卒業生 | localhost:3000/users/companies?target=graduate | kimura |
| [ユーザー]一覧 企業別 ユーザー一覧 全員|localhost:3000/companies/636488896/users?target=all  | kimura |
| [ユーザー]一覧 企業別 ユーザー一覧 研修生 |localhost:3000/companies/636488896?target=trainee | kimura |
| [ユーザー]一覧 企業別 ユーザー一覧 メンター | localhost:3000/companies/636488896?target=mentor | kimura |
| [ユーザー]一覧 企業別 ユーザー一覧 アドバイザー | localhost:3000/companies/636488896?target=advieser | kimura |
| [ユーザー]一覧 企業別 ユーザー一覧 卒業生 | localhost:3000/companies/636488896?target=graduate | kimura |
| [ユーザー]一覧 企業別 日報一覧 | localhost:3000/companies/636488896/reports | kimura |
| [ユーザー]一覧 企業別 提出物一覧 | localhost:3000/companies/636488896/products | kimura |
| [イベント]定期イベント主催者ユーザアイコン | localhost:3000/regular_events?target=not_finished | kimura |
| [マイプロフィール]質問一覧  | localhost:3000/users/459775584/questions | komagata |
| [マイプロフィール]回答一覧 |localhost:3000/users/459775584/answers  | komagata |
| コメント投稿者ユーザーアイコン | 適所 |  |
| コメントフォーム左ユーザーアイコン | 適所 |  |
| 見たよユーザーアイコン | 適所 |  |