### PR TITLE
コメント通知をactive_delivery化したい

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -19,7 +19,10 @@ class ActivityMailer < ApplicationMailer
 
     @user = @receiver
     link = "/#{@comment.commentable_type.downcase.pluralize}/#{@comment.commentable.id}"
-    @notification = @user.notifications.find_by(link: link) || @user.notifications.find_by(link: "#{link}#latest-comment")
+    @link_url = notification_redirector_path(
+      link: link,
+      kind: Notification.kinds[:came_comment]
+    )
     mail to: @user.email, subject: "[FBC] #{@message}"
   end
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -5,8 +5,22 @@ class ActivityMailer < ApplicationMailer
   include Rails.application.routes.url_helpers
 
   before_action do
+    @comment = params[:comment] if params&.key?(:comment)
+    @message = params[:message] if params&.key?(:message)
     @sender = params[:sender] if params&.key?(:sender)
     @receiver = params[:receiver] if params&.key?(:receiver)
+  end
+
+  # required params: comment, message, receiver
+  def came_comment(args = {})
+    @comment ||= args[:comment]
+    @message ||= args[:message]
+    @receiver ||= args[:receiver]
+
+    @user = @receiver
+    link = "/#{@comment.commentable_type.downcase.pluralize}/#{@comment.commentable.id}"
+    @notification = @user.notifications.find_by(link: link) || @user.notifications.find_by(link: "#{link}#latest-comment")
+    mail to: @user.email, subject: "[FBC] #{@message}"
   end
 
   # required params: sender, receiver

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -21,14 +21,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @regular_event = params[:regular_event]
   end
 
-  # required params: comment, receiver, message
-  def came_comment
-    @user = @receiver
-    link = "/#{@comment.commentable_type.downcase.pluralize}/#{@comment.commentable.id}"
-    @notification = @user.notifications.find_by(link: link) || @user.notifications.find_by(link: "#{link}#latest-comment")
-    mail to: @user.email, subject: "[FBC] #{@message}"
-  end
-
   # required params: check
   def checked
     @user = @check.receiver

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -28,12 +28,12 @@ class Comment::AfterCreateCallback
 
   def notify_comment(comment)
     commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
-    NotificationFacade.came_comment(
-      comment,
-      comment.receiver,
-      "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
-      "#{commentable_path}#latest-comment"
-    )
+    ActivityDelivery.with(
+      comment: comment,
+      receiver: comment.receiver,
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      link: "#{commentable_path}#latest-comment"
+    ).notify(:came_comment)
   end
 
   def notify_to_watching_user(comment)

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -87,12 +87,12 @@ class Comment::AfterCreateCallback
       next if comment.sender == admin_user
 
       commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
-      NotificationFacade.came_comment(
-        comment,
-        admin_user,
-        "#{comment.commentable.user.login_name}さんの相談部屋で#{comment.sender.login_name}さんからコメントが届きました。",
-        "#{commentable_path}#latest-comment"
-      )
+      ActivityDelivery.with(
+        comment: comment,
+        receiver: admin_user,
+        message: "#{comment.commentable.user.login_name}さんの相談部屋で#{comment.sender.login_name}さんからコメントが届きました。",
+        link: "#{commentable_path}#latest-comment"
+      ).notify(:came_comment)
     end
   end
 

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 class NotificationFacade
-  def self.came_comment(comment, receiver, message, link)
-    ActivityNotifier.with(comment: comment, receiver: receiver, message: message, link: link).came_comment.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      comment: comment,
-      receiver: receiver,
-      message: message
-    ).came_comment.deliver_later(wait: 5)
-  end
-
   def self.checked(check)
     ActivityNotifier.with(check: check, receiver: check.receiver).checked.notify_now
     receiver = check.receiver

--- a/app/views/activity_mailer/came_comment.html.slim
+++ b/app/views/activity_mailer/came_comment.html.slim
@@ -1,2 +1,2 @@
-= render '/notification_mailer/notification_mailer_template', title: @message, link_url: notifications_url(@notification, anchor: 'latest-comment'), link_text: 'コメントへ' do
+= render '/notification_mailer/notification_mailer_template', title: @message, link_url: notification_url(@notification, anchor: 'latest-comment'), link_text: 'コメントへ' do
   = md2html(@comment.description)

--- a/app/views/activity_mailer/came_comment.html.slim
+++ b/app/views/activity_mailer/came_comment.html.slim
@@ -1,2 +1,5 @@
-= render '/notification_mailer/notification_mailer_template', title: @message, link_url: notification_url(@notification, anchor: 'latest-comment'), link_text: 'コメントへ' do
+= render '/notification_mailer/notification_mailer_template',
+  title: @message,
+  link_url: @link_url,
+  link_text: 'コメントへ'
   = md2html(@comment.description)

--- a/app/views/activity_mailer/came_comment.html.slim
+++ b/app/views/activity_mailer/came_comment.html.slim
@@ -1,0 +1,2 @@
+= render '/notification_mailer/notification_mailer_template', title: @message, link_url: notifications_url(@notification, anchor: 'latest-comment'), link_text: 'コメントへ' do
+  = md2html(@comment.description)

--- a/app/views/notification_mailer/came_comment.html.slim
+++ b/app/views/notification_mailer/came_comment.html.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: @message, link_url: notification_url(@notification, anchor: 'latest-comment'), link_text: 'コメントへ' do
-  = md2html(@comment.description)

--- a/db/fixtures/comments.yml
+++ b/db/fixtures/comments.yml
@@ -126,3 +126,9 @@ comment41:
   user: machida
   commentable: announcement1 (Announcement)
   description: "お知らせのコメントです。"
+
+commentOfTalk:
+  user: komagata
+  commentable: talk_komagata (Talk)
+  description: "これは相談部屋の会話です。"
+  updated_at: "2019-01-02 00:00:00 JST"

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -52,6 +52,15 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       link: "#{commentable_path}#latest-comment"
     }
 
+    Notification.create!(
+      kind: Notification.kinds['came_comment'],
+      user: comment.receiver,
+      sender: comment.sender,
+      link: "#{commentable_path}#latest-comment",
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      read: false
+    )
+
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
       ActivityDelivery.notify!(:came_comment, **params)
     end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -38,4 +38,62 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] sotugyouさんが卒業しました。', email.subject
     assert_match(/卒業/, email.body.to_s)
   end
+
+  test 'came_comment' do
+    comment = comments(:commentOfTalk)
+    commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
+
+    Notification.create!(
+      kind: Notification.kinds['came_comment'],
+      user: comment.receiver,
+      sender: comment.sender,
+      link: "#{commentable_path}#latest-comment",
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      read: false
+    )
+
+    ActivityMailer.came_comment(
+      comment: comment,
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      receiver: comment.receiver
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] 相談部屋でkomagataさんからコメントがありました。', email.subject
+    assert_match(/コメント/, email.body.to_s)
+  end
+
+  test 'came_comment with params' do
+    comment = comments(:commentOfTalk)
+    commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
+
+    Notification.create!(
+      kind: Notification.kinds['came_comment'],
+      user: comment.receiver,
+      sender: comment.sender,
+      link: "#{commentable_path}#latest-comment",
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      read: false
+    )
+
+    mailer = ActivityMailer.with(
+      comment: comment,
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      receiver: comment.receiver
+    ).came_comment
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] 相談部屋でkomagataさんからコメントがありました。', email.subject
+    assert_match(/コメント/, email.body.to_s)
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -3,27 +3,6 @@
 require 'test_helper'
 
 class NotificationMailerTest < ActionMailer::TestCase
-  test 'came_comment' do
-    comment = comments(:comment9)
-    came_comment = notifications(:notification_commented)
-    mailer = NotificationMailer.with(
-      comment: comment,
-      receiver: came_comment.user,
-      message: "#{comment.user.login_name}さんからコメントが届きました。"
-    ).came_comment
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[FBC] komagataさんからコメントが届きました。', email.subject
-    assert_match(/コメント/, email.body.to_s)
-  end
-
   test 'checked' do
     check = checks(:report5_check_machida)
     mailer = NotificationMailer.with(check: check).checked

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -3,6 +3,16 @@
 require 'active_record/fixtures'
 
 class ActivityMailerPreview < ActionMailer::Preview
+  def came_comment
+    comment = Comment.find(ActiveRecord::FixtureSet.identify(:commentOfTalk))
+
+    ActivityMailer.with(
+      comment: comment,
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      receiver: comment.receiver
+    ).came_comment
+  end
+
   def graduated
     sender = User.find(ActiveRecord::FixtureSet.identify(:sotugyou))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -3,17 +3,6 @@
 require 'active_record/fixtures'
 
 class NotificationMailerPreview < ActionMailer::Preview
-  def came_comment
-    report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
-    comment = report.comments.first
-
-    NotificationMailer.with(
-      comment: comment,
-      receiver: comment.receiver,
-      message: "#{comment.sender.login_name}さんからコメントが届きました。"
-    ).came_comment
-  end
-
   def checked
     report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
     check = report.checks.first


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5873

## 概要

NotificationFacadeを使った相談部屋でのコメントの通知をactive_deliveryを使うように書き換えました。
コメントの通知は、bootcamp上での通知とメール通知の2種類があります。


## 変更確認方法

1. `chore/use-active_delivery-to-notify-comment`をローカルに取り込む
2. 生徒アカウントでログインして自分の相談部屋にコメントをする。
3. adminアカウントでログインしてコメントの通知が来ていることを確認する。
4. adminアカウントで相談部屋にコメントをする。
5. 生徒アカウントでログインしてコメントの通知が来ていることを確認する。
6. http://localhost:3000/letter_opener/ にアクセスし、生徒とadminアカウントのコメント通知メールが送られていることを確認する。



## Screenshot

機能の変更はないので見た目の変化はありません。
