### PR TITLE
articlesのpagenationを10→24に変更

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -16,7 +16,7 @@ class Article < ApplicationRecord
             content_type: %w[image/png image/jpg image/jpeg],
             size: { less_than: 10.megabytes }
 
-  paginates_per 10
+  paginates_per 24
   acts_as_taggable
 
   def thumbnail_url


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5900

## 概要

ブログ一覧で、1ページあたりの記事表示数を3の倍数である24記事に修正しました。
1行3記事のレイアウトなのに対して1ページあたり10記事の表示になっていたため、画面の収まりがよくなかったという背景です。

## 変更確認方法

1. `feature/display-24-articles-per-page`をローカルに取り込む
2. `http://localhost:3000/articles`にアクセスする（ログイン有無は問わず）
3. 1ページあたりの記事表示数が24個になっていることを確認する

## Screenshot

### 変更前

![screencapture-localhost-3000-articles-2022-12-10-14_33_11](https://user-images.githubusercontent.com/40317050/206831103-8c18aa53-8daa-4dab-8c46-42848eae5d36.png)

### 変更後

![screencapture-localhost-3000-articles-2022-12-10-14_32_49](https://user-images.githubusercontent.com/40317050/206831106-74e3d830-1cf0-4886-9090-ec9803499ed8.png)

