### PR TITLE
確認通知をactive_delivery化

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -44,17 +44,6 @@ class ActivityMailer < ApplicationMailer
     mail to: @user.email, subject: subject
   end
 
-  # required params: check
-  def checked(args = {})
-    @check ||= args[:check]
-
-    @user = @check.receiver
-    link = "/#{@check.checkable_type.downcase.pluralize}/#{@check.checkable.id}"
-    @notification = @user.notifications.find_by(link: link)
-    subject = "[FBC] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
-    mail to: @user.email, subject: subject
-  end
-
   # required params: answer
   def came_answer(args = {})
     @answer = params&.key?(:answer) ? params[:answer] : args[:answer]
@@ -133,5 +122,21 @@ class ActivityMailer < ApplicationMailer
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 
     message
+  end
+
+  # required params: check, receiver
+  def checked(args = {})
+    @check ||= args[:check]
+    @receiver ||= args[:receiver]
+
+    return false unless @receiver.mail_notification?
+
+    @user = @receiver
+    @link_url = notification_redirector_url(
+      link: "/users/#{@user.id}",
+      kind: Notification.kinds[:checked]
+    )
+    subject = "[FBC] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
+    mail to: @user.email, subject: subject
   end
 end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -7,6 +7,7 @@ class ActivityMailer < ApplicationMailer
   before_action do
     @sender = params[:sender] if params&.key?(:sender)
     @receiver = params[:receiver] if params&.key?(:receiver)
+    @check = params[:check] if params&.key?(:check)
     @announcement = params[:announcement] if params&.key?(:announcement)
     @question = params[:question] if params&.key?(:question)
   end
@@ -40,6 +41,17 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:graduated]
     )
     subject = "[FBC] #{@sender.login_name}さんが卒業しました。"
+    mail to: @user.email, subject: subject
+  end
+
+  # required params: check
+  def checked(args = {})
+    @check ||= args[:check]
+
+    @user = @check.receiver
+    link = "/#{@check.checkable_type.downcase.pluralize}/#{@check.checkable.id}"
+    @notification = @user.notifications.find_by(link: link)
+    subject = "[FBC] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
     mail to: @user.email, subject: subject
   end
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActivityMailer < ApplicationMailer
+class ActivityMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
   helper ApplicationHelper
   include Rails.application.routes.url_helpers
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -129,14 +129,15 @@ class ActivityMailer < ApplicationMailer
     @check ||= args[:check]
     @receiver ||= args[:receiver]
 
-    return false unless @receiver.mail_notification?
-
     @user = @receiver
     @link_url = notification_redirector_url(
       link: "/users/#{@user.id}",
       kind: Notification.kinds[:checked]
     )
     subject = "[FBC] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
-    mail to: @user.email, subject: subject
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -29,15 +29,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: "[FBC] #{@message}"
   end
 
-  # required params: check
-  def checked
-    @user = @check.receiver
-    link = "/#{@check.checkable_type.downcase.pluralize}/#{@check.checkable.id}"
-    @notification = @user.notifications.find_by(link: link)
-    subject = "[FBC] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
-    mail to: @user.email, subject: subject
-  end
-
   # required params: mentionable, receiver
   def mentioned
     @user = @receiver

--- a/app/models/check_callbacks.rb
+++ b/app/models/check_callbacks.rb
@@ -2,7 +2,7 @@
 
 class CheckCallbacks
   def after_create(check)
-    NotificationFacade.checked(check) if check.sender != check.receiver && check.checkable_type != 'Report'
+    ActivityDelivery.with(check: check, receiver: check.receiver).notify(:checked) if check.sender != check.receiver && check.checkable_type != 'Report'
 
     delete_report_cache(check)
     delete_product_cache(check)

--- a/app/models/check_callbacks.rb
+++ b/app/models/check_callbacks.rb
@@ -2,7 +2,9 @@
 
 class CheckCallbacks
   def after_create(check)
-    ActivityDelivery.with(check: check, receiver: check.receiver).notify(:checked) if check.sender != check.receiver && check.checkable_type != 'Report'
+    if check.sender != check.receiver && check.checkable_type != 'Report'
+      ActivityDelivery.with(sender: check.sender, receiver: check.receiver, check: check).notify(:checked)
+    end
 
     delete_report_cache(check)
     delete_product_cache(check)

--- a/app/models/check_callbacks.rb
+++ b/app/models/check_callbacks.rb
@@ -3,7 +3,11 @@
 class CheckCallbacks
   def after_create(check)
     if check.sender != check.receiver && check.checkable_type != 'Report'
-      ActivityDelivery.with(sender: check.sender, receiver: check.receiver, check: check).notify(:checked)
+      ActivityDelivery.with(
+        sender: check.sender,
+        receiver: check.receiver,
+        check: check
+      ).notify(:checked)
     end
 
     delete_report_cache(check)

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -12,14 +12,6 @@ class NotificationFacade
     ).came_comment.deliver_later(wait: 5)
   end
 
-  def self.checked(check)
-    ActivityNotifier.with(check: check, receiver: check.receiver).checked.notify_now
-    receiver = check.receiver
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(check: check).checked.deliver_later(wait: 5)
-  end
-
   def self.product_update(product, receiver)
     ActivityNotifier.with(product: product, receiver: receiver).product_update.notify_now
     return if receiver.retired?

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -265,7 +265,6 @@ class ActivityNotifier < ApplicationNotifier
   def checked(params = {})
     params.merge!(@params)
     check = params[:check]
-    sender = params[:sender]
     receiver = params[:receiver]
 
     notification(

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -265,6 +265,7 @@ class ActivityNotifier < ApplicationNotifier
   def checked(params = {})
     params.merge!(@params)
     check = params[:check]
+    sender = params[:sender]
     receiver = params[:receiver]
 
     notification(

--- a/app/views/activity_mailer/checked.html.slim
+++ b/app/views/activity_mailer/checked.html.slim
@@ -1,2 +1,6 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@check.checkable.title}が確認されました", link_url: notification_url(@notification), link_text: "この#{@check.checkable.model_name.human}へ" do
-  p #{link_to @check.checkable.title, notification_url(@notification)} が#{@check.user.login_name}さんに確認されました。
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@check.checkable.title}が確認されました",
+  link_url: @link_url,
+  link_text: "この#{@check.checkable.model_name.human}へ"
+  do
+    p #{link_to @check.checkable.title, @link_url} が#{@check.user.login_name}さんに確認されました。

--- a/app/views/activity_mailer/checked.html.slim
+++ b/app/views/activity_mailer/checked.html.slim
@@ -1,0 +1,2 @@
+= render '/notification_mailer/notification_mailer_template', title: "#{@check.checkable.title}が確認されました", link_url: notification_url(@notification), link_text: "この#{@check.checkable.model_name.human}へ" do
+  p #{link_to @check.checkable.title, notification_url(@notification)} が#{@check.user.login_name}さんに確認されました。

--- a/app/views/notification_mailer/checked.html.slim
+++ b/app/views/notification_mailer/checked.html.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: "#{@check.checkable.title}が確認されました", link_url: notification_url(@notification), link_text: "この#{@check.checkable.model_name.human}へ" do
-  p #{link_to @check.checkable.title, notification_url(@notification)} が#{@check.user.login_name}さんに確認されました。

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -39,6 +39,39 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     end
   end
 
+  test '.notify(:checked)' do
+    check = checks(:procuct2_check_komagata)
+    params = {
+      check: check,
+      receiver: check.receiver
+    }
+
+    Notification.create!(
+      kind: Notification.kinds['checked'],
+      user: check.receiver,
+      sender: check.sender,
+      link: "/products/#{check.checkable.id}",
+      message: "#{check.sender.login_name}さんが#{check.checkable.title}を確認しました。",
+      read: false
+    )
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:checked, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:checked, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:checked)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:checked)
+    end
+  end
+
   test '.notify(:comebacked)' do
     params = {
       sender: users(:kimura),

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -345,4 +345,53 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert ActionMailer::Base.deliveries.empty?
   end
+
+  test 'checked' do
+    check = checks(:procuct2_check_komagata)
+
+    ActivityMailer.checked(
+      sender: check.sender,
+      receiver: check.receiver,
+      check: check
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['kimura@fjord.jp'], email.to
+    assert_equal '[FBC] kimuraさんの「OS X Mountain Lionをクリーンインストールする」の提出物を確認しました。', email.subject
+    assert_match(/確認/, email.body.to_s)
+  end
+
+  test 'checked with params' do
+    check = checks(:procuct2_check_komagata)
+
+    mailer = ActivityMailer.with(
+      sender: check.sender,
+      receiver: check.receiver,
+      check: check
+    ).checked
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['kimura@fjord.jp'], email.to
+    assert_equal '[FBC] kimuraさんの「OS X Mountain Lionをクリーンインストールする」の提出物を確認しました。', email.subject
+    assert_match(/確認/, email.body.to_s)
+  end
+
+  test 'checked with user who have been denied' do
+    check = checks(:procuct2_check_komagata)
+    ActivityMailer.checked(
+      sender: check.sender,
+      receiver: users(:hajime),
+      check: check
+    ).deliver_now
+
+    assert ActionMailer::Base.deliveries.empty?
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -24,22 +24,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/コメント/, email.body.to_s)
   end
 
-  test 'checked' do
-    check = checks(:report5_check_machida)
-    mailer = NotificationMailer.with(check: check).checked
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[FBC] sotugyouさんの学習週1日目を確認しました。', email.subject
-    assert_match(/確認/, email.body.to_s)
-  end
-
   test 'mentioned' do
     mentionable = comments(:comment9)
     mentioned = notifications(:notification_mentioned)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -11,9 +11,15 @@ class ActivityMailerPreview < ActionMailer::Preview
   end
 
   def checked
-    report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
-    check = report.checks.first
-
+    check = Check.find(ActiveRecord::FixtureSet.identify(:procuct2_check_komagata))
+    Notification.create!(
+      kind: Notification.kinds['checked'],
+      user: check.receiver,
+      sender: check.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(check.checkable),
+      message: "#{check.sender.login_name}さんが#{check.checkable.title}を確認しました。",
+      read: false
+    )
     ActivityMailer.with(check: check).checked
   end
 

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -12,15 +12,7 @@ class ActivityMailerPreview < ActionMailer::Preview
 
   def checked
     check = Check.find(ActiveRecord::FixtureSet.identify(:procuct2_check_komagata))
-    Notification.create!(
-      kind: Notification.kinds['checked'],
-      user: check.receiver,
-      sender: check.sender,
-      link: Rails.application.routes.url_helpers.polymorphic_path(check.checkable),
-      message: "#{check.sender.login_name}さんが#{check.checkable.title}を確認しました。",
-      read: false
-    )
-    ActivityMailer.with(check: check).checked
+    ActivityMailer.with(receiver: check.receiver, check: check).checked
   end
 
   def came_answer

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -10,6 +10,13 @@ class ActivityMailerPreview < ActionMailer::Preview
     ActivityMailer.with(sender: sender, receiver: receiver).graduated
   end
 
+  def checked
+    report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
+    check = report.checks.first
+
+    ActivityMailer.with(check: check).checked
+  end
+
   def came_answer
     question = Question.find(ActiveRecord::FixtureSet.identify(:question2))
     answer = question.answers.first

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -14,13 +14,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     ).came_comment
   end
 
-  def checked
-    report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
-    check = report.checks.first
-
-    NotificationMailer.with(check: check).checked
-  end
-
   def mentioned
     report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
     mentionable = Comment.find(ActiveRecord::FixtureSet.identify(:comment9))


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5874

## 概要

- 確認通知（＝受講生の提出物を、メンターが確認完了した時に飛ぶ通知）を、active_deliveryを使うように修正しました。
- 確認通知は、bootcamp上での通知と、メール通知の2種類が飛びます。

### 関連PR
- https://github.com/fjordllc/bootcamp/pull/4701
- https://github.com/fjordllc/bootcamp/pull/5898
- https://github.com/fjordllc/bootcamp/pull/5939
- https://github.com/fjordllc/bootcamp/pull/6001
- https://github.com/fjordllc/bootcamp/pull/6063
- https://github.com/fjordllc/bootcamp/pull/6070

## 変更確認方法

1. `feature/use-active-delivery-for-checked-notifications`をローカルに取り込む
2. メンターアカウントでログインし、未完了の提出物（作成者`kimura`）にアクセスして提出物を確認する（「提出物を確認」ボタンをクリック）
3. 確認した提出物を作成した生徒のアカウントでログインし、確認通知が来ていることを確認する
4. http://localhost:3000/letter_opener/ にアクセスし、確認通知メールが1通来ていることを確認する

## Screenshot

画面上の変更はないです。

メンターアカウントで提出物を確認：
![スクリーンショット 2022-12-11 10 00 30](https://user-images.githubusercontent.com/40317050/206881731-900a1934-d409-40da-821c-3f9943adc50b.png)

生徒アカウントに確認通知がくる：
![スクリーンショット 2022-12-11 10 01 30](https://user-images.githubusercontent.com/40317050/206881735-f9bcb3c9-63ea-478c-9d71-2654955f87e9.png)

メール：
![スクリーンショット 2022-12-25 12 23 50](https://user-images.githubusercontent.com/40317050/209466538-5beeef93-6640-4b58-bec6-5b16043b7360.png)
