### PR TITLE
Q&AのAをスマホで表示したときにアイコンを表示させた

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -17,6 +17,13 @@
       .answer-badge__label ベストアンサー
     header.card-header
       h2.thread-comment__title
+        a.thread-comment__title-user-link.is-hidden-md-up(
+          :href='answer.user.url')
+          img.thread-comment__title-user-icon.a-user-icon(
+            :src='answer.user.avatar_url',
+            :title='answer.user.icon_title',
+            :class='[roleClass]')
+
         a.thread-comment__title-link.a-text-link(
           :href='answer.user.url',
           itemprop='url')


### PR DESCRIPTION
## Issue

- #5863

## 概要
Q&AのAをスマホで表示した時にアイコンを表示させるようにしました。
## 変更確認方法

1. `feature/show-icon-when-viewed-on-mobile`をローカルに取り込む
2. `rails s`でアプリを起動する
3. `localhost:3000`にアクセスする
4. `komagata`でログインする
5. `localhost:3000/questions/208331212`にアクセスする
6. 開発者ツールを起動し画面をスマホ表示にする
7. 回答しているユーザーのアイコンが表示されていることを確認する
8. アイコンをクリックしてユーザーページに遷移することを確認する

## Screenshot

### 変更前
<img width="384" alt="スクリーンショット 2022-12-12 22 55 38" src="https://user-images.githubusercontent.com/88083085/207075657-ceb0f5e0-582f-447a-86f6-1ed4a8434a70.png">

### 変更後
<img width="385" alt="スクリーンショット 2022-12-12 23 05 07" src="https://user-images.githubusercontent.com/88083085/207076264-c66c69dd-ffc9-4f2f-a9b1-db0815c009d4.png">


