### PR TITLE
最初の日報投稿通知をactive_delivery化する

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -22,12 +22,13 @@ class ActivityMailer < ApplicationMailer
 
     return false unless @receiver.mail_notification? # cancel sending email
 
+    @user = @receiver
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:comebacked]
     )
     subject = "[FBC] #{@sender.login_name}さんが休会から復帰しました。"
-    mail to: @receiver.email, subject: subject
+    mail to: @user.email, subject: subject
   end
 
   # required params: sender, receiver
@@ -37,12 +38,13 @@ class ActivityMailer < ApplicationMailer
 
     return false unless @receiver.mail_notification? # cancel sending email
 
+     @user = @receiver
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:graduated]
     )
     subject = "[FBC] #{@sender.login_name}さんが卒業しました。"
-    mail to: @receiver.email, subject: subject
+    mail to: @user.email, subject: subject
   end
 
   # required params: answer
@@ -81,13 +83,14 @@ class ActivityMailer < ApplicationMailer
     @receiver ||= args[:receiver]
     @announcement ||= args[:announcement]
 
+    @user = @receiver
     @link_url = notification_redirector_url(
       link: "/announcements/#{@announcement.id}",
       kind: Notification.kinds[:announced]
     )
     subject = "[FBC] お知らせ「#{@announcement.title}」"
-    message = mail to: @receiver.email, subject: subject
-    message.perform_deliveries = @receiver.mail_notification? && !@receiver.retired?
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
 
     message
   end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -38,7 +38,7 @@ class ActivityMailer < ApplicationMailer
 
     return false unless @receiver.mail_notification? # cancel sending email
 
-     @user = @receiver
+    @user = @receiver
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:graduated]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -12,6 +12,7 @@ class ActivityMailer < ApplicationMailer
     @question = params[:question] if params&.key?(:question)
     @mentionable = params[:mentionable] if params&.key?(:mentionable)
     @page = params[:page] if params&.key?(:page)
+    @report = params[:report] if params&.key?(:report)
   end
 
   # required params: sender, receiver
@@ -21,13 +22,12 @@ class ActivityMailer < ApplicationMailer
 
     return false unless @receiver.mail_notification? # cancel sending email
 
-    @user = @receiver
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:comebacked]
     )
     subject = "[FBC] #{@sender.login_name}さんが休会から復帰しました。"
-    mail to: @user.email, subject: subject
+    mail to: @receiver.email, subject: subject
   end
 
   # required params: sender, receiver
@@ -37,13 +37,12 @@ class ActivityMailer < ApplicationMailer
 
     return false unless @receiver.mail_notification? # cancel sending email
 
-    @user = @receiver
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:graduated]
     )
     subject = "[FBC] #{@sender.login_name}さんが卒業しました。"
-    mail to: @user.email, subject: subject
+    mail to: @receiver.email, subject: subject
   end
 
   # required params: answer
@@ -82,14 +81,13 @@ class ActivityMailer < ApplicationMailer
     @receiver ||= args[:receiver]
     @announcement ||= args[:announcement]
 
-    @user = @receiver
     @link_url = notification_redirector_url(
       link: "/announcements/#{@announcement.id}",
       kind: Notification.kinds[:announced]
     )
     subject = "[FBC] お知らせ「#{@announcement.title}」"
-    message = mail to: @user.email, subject: subject
-    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+    message = mail to: @receiver.email, subject: subject
+    message.perform_deliveries = @receiver.mail_notification? && !@receiver.retired?
 
     message
   end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -217,7 +217,10 @@ class ActivityMailer < ApplicationMailer
     @report ||= args[:report]
 
     @user = @receiver
-    @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
+    @link_url = notification_redirector_path(
+      link: "/reports/#{@report.id}",
+      kind: Notification.kinds[:first_report]
+    )
     mail to: @user.email,
          subject: "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
   end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -212,4 +212,15 @@ class ActivityMailer < ApplicationMailer
 
     message
   end
+
+  # required params: report, receiver
+  def first_report(args = {})
+    @receiver ||= args[:receiver]
+    @report ||= args[:report]
+
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
+    mail to: @user.email,
+         subject: "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -54,6 +54,13 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
          subject: "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
   end
 
+  # required params: product, receiver, message
+  def submitted
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: "/products/#{@product.id}")
+    mail to: @user.email, subject: "[FBC] #{@message}"
+  end
+
   # required params: watchable, receiver
   def watching_notification
     @sender = @watchable.user

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -31,7 +31,7 @@ class ReportCallbacks
 
   def notify_first_report(report)
     User.admins_and_mentors.each do |receiver|
-      NotificationFacade.first_report(report, receiver) if report.sender != receiver
+      ActivityDelivery.with(report: report, receiver: receiver).notify(:first_report) if report.sender != receiver
     end
   end
 

--- a/app/views/activity_mailer/first_report.html.slim
+++ b/app/views/activity_mailer/first_report.html.slim
@@ -1,0 +1,4 @@
+= render 'notification_mailer_template', title: "#{@report.user.login_name}さんのはじめての日報です！", link_url: notification_url(@notification), link_text: 'この日報へ' do
+  p #{@report.user.login_name}さんのはじめての日報です。歓迎のコメントを投稿しよう！！
+  div(style='border-top: solid 1px #ccc; height: 0;')
+  = md2html(@report.description)

--- a/app/views/activity_mailer/first_report.html.slim
+++ b/app/views/activity_mailer/first_report.html.slim
@@ -1,4 +1,4 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@report.user.login_name}さんのはじめての日報です！", link_url: notification_url(@notification), link_text: 'この日報へ' do
+= render '/notification_mailer/notification_mailer_template', title: "#{@report.user.login_name}さんのはじめての日報です！", link_url: @link_url, link_text: 'この日報へ' do
   p #{@report.user.login_name}さんのはじめての日報です。歓迎のコメントを投稿しよう！！
   div(style='border-top: solid 1px #ccc; height: 0;')
   = md2html(@report.description)

--- a/app/views/activity_mailer/first_report.html.slim
+++ b/app/views/activity_mailer/first_report.html.slim
@@ -1,4 +1,4 @@
-= render 'notification_mailer_template', title: "#{@report.user.login_name}さんのはじめての日報です！", link_url: notification_url(@notification), link_text: 'この日報へ' do
+= render '/notification_mailer/notification_mailer_template', title: "#{@report.user.login_name}さんのはじめての日報です！", link_url: notification_url(@notification), link_text: 'この日報へ' do
   p #{@report.user.login_name}さんのはじめての日報です。歓迎のコメントを投稿しよう！！
   div(style='border-top: solid 1px #ccc; height: 0;')
   = md2html(@report.description)

--- a/app/views/notification_mailer/first_report.html.slim
+++ b/app/views/notification_mailer/first_report.html.slim
@@ -1,4 +1,0 @@
-= render 'notification_mailer_template', title: "#{@report.user.login_name}さんのはじめての日報です！", link_url: notification_url(@notification), link_text: 'この日報へ' do
-  p #{@report.user.login_name}さんのはじめての日報です。歓迎のコメントを投稿しよう！！
-  div(style='border-top: solid 1px #ccc; height: 0;')
-  = md2html(@report.description)

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class ActivityDeliveryTest < ActiveSupport::TestCase
   test '.notify(:graduated)' do
-    @params = {
+    params = {
       kind: :graduated,
       body: 'test message',
       sender: users(:kimura),

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class ActivityDeliveryTest < ActiveSupport::TestCase
   test '.notify(:graduated)' do
-    params = {
+    @params = {
       kind: :graduated,
       body: 'test message',
       sender: users(:kimura),
@@ -189,19 +189,19 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       read: false
     )
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.notify!(:first_report, **params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.notify(:first_report, **params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify!(:first_report)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify(:first_report)
     end
   end

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -173,4 +173,36 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:create_page)
     end
   end
+
+  test '.notify(:first_report)' do
+    params = {
+      report: reports(:report10),
+      receiver: users(:komagata)
+    }
+
+    Notification.create!(
+      kind: Notification.kinds['first_report'],
+      user: users(:komagata),
+      sender: users(:hajime),
+      link: "/reports/#{reports(:report10).id}",
+      message: "🎉#{users(:hajime).login_name}さんがはじめての日報を書きました！",
+      read: false
+    )
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+      ActivityDelivery.notify!(:first_report, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.notify(:first_report, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify!(:first_report)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify(:first_report)
+    end
+  end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -601,4 +601,40 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] kensyuさんが日報【 フォローされた日報 】を書きました！', email.subject
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">この日報へ</a>}, email.body.to_s)
   end
+
+  test 'first_report' do
+    report = reports(:report10)
+    first_report = notifications(:notification_first_report)
+    ActivityMailer.first_report(
+      report: report,
+      receiver: first_report.user
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] hajimeさんがはじめての日報を書きました！', email.subject
+    assert_match(/はじめて/, email.body.to_s)
+  end
+
+  test 'first_report with params' do
+    report = reports(:report10)
+    first_report = notifications(:notification_first_report)
+    mailer = ActivityMailer.with(
+      report: report,
+      receiver: first_report.user
+    ).first_report
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] hajimeさんがはじめての日報を書きました！', email.subject
+    assert_match(/はじめて/, email.body.to_s)
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -24,26 +24,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/コメント/, email.body.to_s)
   end
 
-  test 'first_report' do
-    report = reports(:report10)
-    first_report = notifications(:notification_first_report)
-    mailer = NotificationMailer.with(
-      report: report,
-      receiver: first_report.user
-    ).first_report
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] hajimeさんがはじめての日報を書きました！', email.subject
-    assert_match(/はじめて/, email.body.to_s)
-  end
-
   test 'watching_notification' do
     watch = watches(:report1_watch_kimura)
     watching = notifications(:notification_watching)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -86,4 +86,11 @@ class ActivityMailerPreview < ActionMailer::Preview
       receiver: receiver
     ).following_report
   end
+
+  def first_report
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
+    report = Report.find(ActiveRecord::FixtureSet.identify(:report10))
+
+    ActivityMailer.with(report: report, receiver: receiver).first_report
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -29,13 +29,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.with(check: check).checked
   end
 
-  def first_report
-    report = Report.find(ActiveRecord::FixtureSet.identify(:report10))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
-
-    NotificationMailer.with(report: report, receiver: receiver).first_report
-  end
-
   def watching_noitification
     watchable = Report.find(ActiveRecord::FixtureSet.identify(:report1))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:kimura))

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -214,7 +214,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     follower_user_login_name = User.find(following.follower_id).login_name
     title = '初めて提出した時だけ'
     description = 'フォローされているユーザーに通知を飛ばす'
-    notification_message = "#{followed_user_login_name}さんがはじめての日報を書きました！"
+    notification_message = make_write_report_notification_message(followed_user_login_name, title)
     assert_notify_only_at_first_published_of_report(
       notification_message,
       followed_user_login_name,

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -214,9 +214,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     follower_user_login_name = User.find(following.follower_id).login_name
     title = '初めて提出した時だけ'
     description = 'フォローされているユーザーに通知を飛ばす'
-    notification_message = make_write_report_notification_message(
-      followed_user_login_name, title
-    )
+    notification_message = "#{followed_user_login_name}さんがはじめての日報を書きました！"
     assert_notify_only_at_first_published_of_report(
       notification_message,
       followed_user_login_name,


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5881

## 概要
最初の日報投稿通知をactive_delivery化しました。
見た目の変更はありません。

## 変更確認方法

1. `feature/replace-notification-first-report-to-active-delivery`をローカルに取り込む
2. `muryou`でログインし、初日報を公開する
3. `komagata`でログインし、通知に`muryou`ユーザーが初日報書いたことが通知されていることを確認する
4. `http://localhost:3000/letter_opener/`にアクセスし、メールが届いていることを確認する

## Screenshot
見た目の変更はありません。
<img width="1300" alt="image" src="https://user-images.githubusercontent.com/43959158/209819822-22b0fe68-eb40-4461-91a5-605fcd92e152.png">
<img width="1431" alt="image" src="https://user-images.githubusercontent.com/43959158/209820585-eb68867d-82d6-4a9c-8e49-d9bebe731bb0.png">


### 変更前

### 変更後

