### PR TITLE
fixtureの変更により通らなくなったテストを通るようにした

### DIFF
--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -37,7 +37,7 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_equal first('.a-user-icons__item-icon.a-user-icon.is-admin')['title'], 'adminonly (アドミン 能美代): 管理者'
     end
     within all('.a-user-icons__items').last do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-student')['title'], 'kimura (Kimura Tadasi)'
+      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-student')['title'], 'marumarushain1 (marumarushain1)'
       assert_equal first('.a-user-icons__item-icon.a-user-icon.is-trainee')['title'], 'kensyu (Kensyu Seiko)'
       assert_equal first('.a-user-icons__item-icon.a-user-icon.is-adviser')['title'], 'advijirou (アドバイ 次郎): アドバイザー'
       assert_equal first('.a-user-icons__item-icon.a-user-icon.is-graduate')['title'], 'sotugyou-with-job (卒業 就職済美)'


### PR DESCRIPTION
## 概要
`test/fixtures/users.yml`にユーザーを追加したことにより、期待していた値が出現しなくなり通らなくなっていた以下のテストを通るようにしました。

https://app.circleci.com/pipelines/github/fjordllc/bootcamp/4484/workflows/ff89f40e-292a-4c5a-a25b-dac33307e719/jobs/11795

```bash
Failure:
GenerationsTest#test_all_users_filter_for_generation [/home/circleci/project/test/system/generations_test.rb:40]:
--- expected
+++ actual
@@ -1 +1 @@
-"marumarushain1 (marumarushain1)"
+"kimura (Kimura Tadasi)"

rails test test/system/generations_test.rb:31
```

## 変更確認方法

1. `feature/adapt-the-test-to-the-modified-fixture`ブランチをローカルに取り込む
2. `$ bin/rails test test/system/generations_test.rb`を実行、テストがすべてパスすることを確認する

## ローカルでの実行結果
### 変更前
```bash
$ bin/rails test test/system/generations_test.rb
Run options: --seed 62871

# Running:

Failure:
GenerationsTest#test_all_users_filter_for_generation [/bootcamp/test/system/generations_test.rb:40]:
--- expected
+++ actual
@@ -1 +1 @@
-"marumarushain1 (marumarushain1)"
+"kimura (Kimura Tadasi)"

rails test test/system/generations_test.rb:31

..
[Minitest::CI] Generating test report in JUnit XML format...


Finished in 68.384654s, 0.1462 runs/s, 0.4094 assertions/s.
10 runs, 28 assertions, 1 failures, 0 errors, 0 skips
```
### 変更後
```bash
$ bin/rails test test/system/generations_test.rb 
Run options: --seed 33758

# Running:

..........
[Minitest::CI] Generating test report in JUnit XML format...


Finished in 58.067672s, 0.1722 runs/s, 0.7750 assertions/s.
10 runs, 45 assertions, 0 failures, 0 errors, 0 skips
```
