### PR TITLE
卒業通知のメールが送られていなかった問題を修正

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ActivityMailer < ApplicationMailer
+  helper ApplicationHelper
+
+  before_action do
+    @sender = params[:sender] if params&.key?(:sender)
+    @receiver = params[:receiver] if params&.key?(:receiver)
+  end
+
+  # required params: sender, receiver
+  def graduated(args = {})
+    @sender ||= args[:sender]
+    @receiver ||= args[:receiver]
+
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:graduated])
+    subject = "[FBC] #{@sender.login_name}さんが卒業しました。"
+    mail to: @user.email, subject: subject
+  end
+end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -163,14 +163,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   end
 
   # required params: sender, receiver
-  def graduated
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:graduated])
-    subject = "[FBC] #{@sender.login_name}さんが卒業しました。"
-    mail to: @user.email, subject: subject
-  end
-
-  # required params: sender, receiver
   def hibernated
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:hibernated])

--- a/app/views/activity_mailer/graduated.html.slim
+++ b/app/views/activity_mailer/graduated.html.slim
@@ -1,0 +1,1 @@
+= render '/notification_mailer/notification_mailer_template', title: "#{@sender.login_name}さんが卒業しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do

--- a/app/views/notification_mailer/graduated.html.slim
+++ b/app/views/notification_mailer/graduated.html.slim
@@ -1,1 +1,0 @@
-= render 'notification_mailer_template', title: "#{@sender.login_name}さんが卒業しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -15,6 +15,15 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
   end
 
   test '.notify(:graduated)' do
+    Notification.create!(
+      kind: Notification.kinds['graduated'],
+      user: users(:komagata),
+      sender: users(:kimura),
+      link: "/users/#{users(:kimura).id}",
+      message: "#{users(:kimura).login_name}さんがxxxxを確認しました。",
+      read: false
+    )
+
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 3 do
       ActivityDelivery.notify!(:graduated, **@params)
     end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActivityMailerTest < ActionMailer::TestCase
+  test 'graduated' do
+    user = users(:sotugyou)
+    mentor = users(:mentormentaro)
+    ActivityMailer.graduated(
+      sender: user,
+      receiver: mentor
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['mentormentaro@fjord.jp'], email.to
+    assert_equal '[FBC] sotugyouさんが卒業しました。', email.subject
+    assert_match(/卒業/, email.body.to_s)
+  end
+
+  test 'graduated with params' do
+    user = users(:sotugyou)
+    mentor = users(:mentormentaro)
+    mailer = ActivityMailer.with(
+      sender: user,
+      receiver: mentor
+    ).graduated
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['mentormentaro@fjord.jp'], email.to
+    assert_equal '[FBC] sotugyouさんが卒業しました。', email.subject
+    assert_match(/卒業/, email.body.to_s)
+  end
+end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -338,26 +338,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/2回連続/, email.body.to_s)
   end
 
-  test 'graduated' do
-    user = users(:sotugyou)
-    mentor = users(:mentormentaro)
-    mailer = NotificationMailer.with(
-      sender: user,
-      receiver: mentor
-    ).graduated
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['mentormentaro@fjord.jp'], email.to
-    assert_equal '[FBC] sotugyouさんが卒業しました。', email.subject
-    assert_match(/卒業/, email.body.to_s)
-  end
-
   test 'signed up' do
     user = users(:hajime)
     mentor = users(:mentormentaro)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'active_record/fixtures'
+
+class ActivityMailerPreview < ActionMailer::Preview
+  def graduated
+    sender = User.find(ActiveRecord::FixtureSet.identify(:sotugyou))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))
+
+    ActivityMailer.with(sender: sender, receiver: receiver).graduated
+  end
+end


### PR DESCRIPTION
サイト内通知とDiscord通知は動いていたが、メール通知は動いていなかった。