### PR TITLE
ログインせずにuser_portfolioにアクセスした際のエラーを解消

### DIFF
--- a/app/controllers/users/works_controller.rb
+++ b/app/controllers/users/works_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::WorksController < ApplicationController
+  before_action :require_login
+
   def index
     @user = User.find(params[:user_id])
     @works = @user.works.with_attached_thumbnail.eager_load(:user).order(updated_at: :desc)


### PR DESCRIPTION
## Issue

- #5861 

## 概要
非ログイン時にユーザーのポートフォリオページにアクセスすると発生していたエラーを解消しました。
`Users::WorksController`に`before_action :require_login`を追記し、非ログイン時のアクセスはトップページにリダイレクトするようにしました。

## 変更確認方法
1. `bug/nomethoderror-on-user_portfolio-without-login`をローカルに取り込む
1. `$ bin/rails s`でローカル環境を立ち上げる
1. 任意のアカウントでログイン
1. ユーザー一覧から`hatsuno`をクリックし、プロフィール画面に遷移する
1. ポートフォリオタブをクリックし、ポートフォリオページのURLをコピーしておく
1. bootcampアプリをログアウト
1. 手順5でコピーしたURLをブラウザのアドレスバーに貼り付けてアクセス
1. トップページにリダイレクトされることを確認する

## Screenshot
### 変更前
ログインせずにポートフォリオページにアクセスするとエラーが発生する
![グループ 11](https://user-images.githubusercontent.com/66685066/209492710-3be21625-de28-4c79-a739-8f1cedb40cf0.png)

### 変更後
ログインせずにポートフォリオページにアクセスするとトップページにリダイレクトされる
![スクリーンショット 2022-12-26 11 27 26（2）](https://user-images.githubusercontent.com/66685066/209492716-e7e769a6-4c0b-4be6-889d-06693bfe088f.png)

