### PR TITLE
ログイン後のフッターにDiscordBotF へのリンクを追加する

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -48,6 +48,9 @@ footer.footer
           li.footer-nav__item
             = link_to 'https://buzzcord-fjord-jp.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | Buzzcord
+          li.footer-nav__item
+            = link_to 'https://discord-bot-fjord.herokuapp.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | DiscordBotF
 
       small.footer__copyright
         i.fa-regular.fa-copyright


### PR DESCRIPTION
## Issue

- #5906 

## 概要

ログイン後のフッター（ `app/views/application/footer/_footer.html.slim` ）に次のリンクを追加する。

- リンク名：DiscordBotF 
- リンク先：https://discord-bot-fjord.herokuapp.com/

なおログイン前のフッター（ `app/views/welcome/_welcome_footer.html.slim` ）にはリンクを追加しません。

## 変更確認方法

1. `feature/add-discord-bot-f-link-to-footer` をローカルに取り込みます
2. `bin/setup` を実行します
3. `bin/rails s` でサーバーを立ち上げます
4. ログインします
    - 例： `hajime`
5. ログイン後のページ最下部にリンクが表示されていること
    - リンク「Buzzcord」の右側に追加しています
    ※ 2022/12-29 更新 コンフリクトを解決しました（ [並べ替えは別 Issue となるお言葉に甘えました](https://github.com/fjordllc/bootcamp/issues/5907#issuecomment-1363690629) ）

## Screenshot

### 変更前

![before](https://user-images.githubusercontent.com/943541/209965449-670cc64e-0f29-4559-9851-a837e38e1a02.png)

### 変更後

![after](https://user-images.githubusercontent.com/943541/209965465-8567c0d1-7690-499e-9e47-73af197ccec1.png)

## その他

過去の類似したPRは [こちら](https://github.com/fjordllc/bootcamp/pulls?q=is%3Apr+%E3%83%95%E3%83%83%E3%82%BF%E3%83%BC+is%3Aclosed) から確認しました。
