### PR TITLE
存在しないメールアドレスだと退会できないエラーを解消する

### DIFF
--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -12,7 +12,12 @@ class RetirementController < ApplicationController
     current_user.retired_on = Date.current
     if current_user.save(context: :retirement)
       user = current_user
-      UserMailer.retire(user).deliver_now
+      begin
+        UserMailer.retire(user).deliver_now
+      rescue Postmark::InactiveRecipientError => e
+        logger.warn "[Postmark] 受信者由来のエラーのためメールを送信できませんでした。：#{e.message}"
+      end
+
       destroy_subscription
       notify_to_admins
       notify_to_mentors


### PR DESCRIPTION
## Issue

- #3213

## 概要

このプルリクエストは本番環境で使用しているメール配信サービス「Postmark」で発生するエラーを解決します。
現状は、退会時のお礼メールを送信しようとした際、受信者のメールアドレスが存在しないなどの理由からエラー（ `Postmark::InactiveRecipientError` ）が発生し、退会できません。

このプルリクエストは上記のエラーが発生した場合でも退会できるようにする修正とテストが含まれます。

## 変更確認方法

1. `bug/error-if-email-not-exist-when-retire` をローカルに取り込みます
2. `bin/setup` を実行します
3. 次のコマンドでテスト環境をセットアップします
    - `bundle exec rails db:setup RAILS_ENV=test`
4. 次のコマンドで今回の影響範囲をテストします
    - `bundle exec rails test test/system/retirement_test.rb`
5. 上記のテストがすべてパスすることを確認します（次のように `0 failures, 0 errors, 0 skips` と出力されます）
    - `10 runs, 54 assertions, 0 failures, 0 errors, 0 skips`

## Screenshot

開発環境では `letter_opener` で通知メールを管理しているため再現できません（詳細： [Develop環境でのメールの確認方法 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AE%E3%83%A1%E3%83%BC%E3%83%AB%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95) ）。
本番環境では 退会するとき、存在しないメールアドレス（議題の例では `senpai@fjord.jp` ）では500エラーが発生していたのが、発生しなくなり、退会できるようになります。

## 参考情報

- [Railsアプリケーションにおけるエラー処理（例外設計）の考え方 - Qiita](https://qiita.com/jnchito/items/3ef95ea144ed15df3637#%E9%80%94%E4%B8%AD%E3%81%A7%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%8C%E7%99%BA%E7%94%9F%E3%81%97%E3%81%A6%E3%82%82%E7%B6%9A%E8%A1%8C%E3%81%97%E3%81%9F%E3%81%84%E3%82%B1%E3%83%BC%E3%82%B9)
- [Error Handling · ActiveCampaign/postmark-gem Wiki](https://github.com/ActiveCampaign/postmark-gem/wiki/Error-Handling)