### PR TITLE
Discordの管理者向け卒業通知が何個も飛んでしまうのを解消

### DIFF
--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -9,6 +9,7 @@ class GraduationController < ApplicationController
       Subscription.new.destroy(@user.subscription_id) if @user.subscription_id
 
       notify_to_mentors(@user)
+      notify_to_chat(@user)
       redirect_to @redirect_url, notice: 'ユーザー情報を更新しました。'
     else
       redirect_to @redirect_url, alert: 'ユーザー情報の更新に失敗しました'
@@ -29,5 +30,9 @@ class GraduationController < ApplicationController
     User.mentor.each do |mentor|
       ActivityDelivery.with(sender: user, receiver: mentor).notify(:graduated)
     end
+  end
+
+  def notify_to_chat(user)
+    DiscordNotifier.with(sender: user).graduated.notify_now
   end
 end

--- a/app/deliveries/activity_delivery.rb
+++ b/app/deliveries/activity_delivery.rb
@@ -6,7 +6,4 @@ class ActivityDelivery < ActiveDelivery::Base
   register_line :activity,
                 ActiveDelivery::Lines::Notifier,
                 resolver: ->(_) { ActivityNotifier }
-  register_line :discord,
-                ActiveDelivery::Lines::Notifier,
-                resolver: ->(_) { DiscordNotifier }
 end

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -24,19 +24,19 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       read: false
     )
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 3 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
       ActivityDelivery.notify!(:graduated, **@params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 3 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
       ActivityDelivery.notify(:graduated, **@params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 3 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
       ActivityDelivery.with(**@params).notify!(:graduated)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 3 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
       ActivityDelivery.with(**@params).notify(:graduated)
     end
   end


### PR DESCRIPTION
## Issue
- #5868

## 概要
ユーザーの卒業時、管理者向けにDiscordで通知する機能が本来一度のみ投稿されるべきところ、複数投稿される問題を解消しました。

## 変更確認方法
このPRの動作確認には事前準備として確認用のDiscordサーバーとDiscord APIのURL取得が必要です。
### 事前準備

### 動作確認手順
1. `bug/fix-graduation-notice-posted-multiple-times-on-discord`をローカルに取り込む
1. `komagata`など管理者権限を持つアカウントでログイン
1. ユーザー一覧`http://localhost:3000/users`にアクセス
1. 任意のアカウントをクリック

### 変更前

### 変更後

