### PR TITLE
お知らせ作成画面のタイトルにプレースホルダーを追加

### DIFF
--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -8,7 +8,7 @@
         .col-lg-9.col-xs-12
           .form-item
             = f.label :title, class: 'a-form-label'
-            = f.text_field :title, class: 'a-text-input js-warning-form'
+            = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
     .form-item
       .row.js-markdown-parent
         .col-md-6.col-xs-12


### PR DESCRIPTION
## Issue

- #5957

## 概要

お知らせ作成画面のタイトルにプレースホルダーを追加しました。

## 変更確認方法

1. `feature/add-placeholder-to-announcement-title`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. お知らせ作成画面(`/announcements/new`)を表示する

## Screenshot

### 変更前
![2022-12-24 11 07 15 localhost 1b5de9aa3ae4](https://user-images.githubusercontent.com/69447745/209418602-3a2370c8-0037-409a-85fc-303bc2ea440f.png)

### 変更後

![image](https://user-images.githubusercontent.com/69447745/209418625-f3fc0624-7d51-4ab8-82ee-da9f0e9c247f.png)
