### PR TITLE
退会後3ヶ月経過した旨を管理者にメール通知する機能を別コントローラーに分割する

### DIFF
--- a/app/controllers/scheduler/daily/after_retirement_controller.rb
+++ b/app/controllers/scheduler/daily/after_retirement_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Scheduler::Daily::AfterRetirementController < SchedulerController
+  def show
+    notify_certain_period_passed
+    head :ok
+  end
+
+  private
+
+  def notify_certain_period_passed
+    admin_users = User.admins
+    User.retired_with_3_months_ago_and_notification_not_sent.find_each do |retired_user|
+      admin_users.each do |admin_user|
+        NotificationFacade.three_months_after_retirement(retired_user, admin_user)
+        retired_user.update!(notified_retirement: true)
+      end
+    end
+  end
+end

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -3,7 +3,6 @@
 class Scheduler::DailyController < SchedulerController
   def show
     User.notify_to_discord
-    notify_certain_period_passed_after_retirement
     notify_tomorrow_regular_event
     notify_product_review_not_completed
     Question.notify_certain_period_passed_after_last_answer
@@ -11,17 +10,6 @@ class Scheduler::DailyController < SchedulerController
   end
 
   private
-
-  def notify_certain_period_passed_after_retirement
-    User.retired.find_each do |retired_user|
-      if retired_user.retired_three_months_ago_and_notification_not_sent?
-        User.admins.each do |admin_user|
-          NotificationFacade.three_months_after_retirement(retired_user, admin_user)
-          retired_user.update!(notified_retirement: true)
-        end
-      end
-    end
-  end
 
   def notify_tomorrow_regular_event
     return if RegularEvent.tomorrow_events.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -233,6 +233,11 @@ class User < ApplicationRecord
   scope :hibernated, -> { where.not(hibernated_at: nil) }
   scope :unhibernated, -> { where(hibernated_at: nil) }
   scope :retired, -> { where.not(retired_on: nil) }
+  scope :retired_with_3_months_ago_and_notification_not_sent, lambda {
+    retired
+      .where('retired_on <= ?', Date.current.ago(3.months).to_date)
+      .where(notified_retirement: false)
+  }
   scope :unretired, -> { where(retired_on: nil) }
   scope :advisers, -> { where(adviser: true) }
   scope :not_advisers, -> { where(adviser: false) }

--- a/config/routes/scheduler.rb
+++ b/config/routes/scheduler.rb
@@ -6,5 +6,8 @@ Rails.application.routes.draw do
     resource :link_checker, only: %i(show), controller: "link_checker"
     resource :validator, only: %i(show), controller: "validator"
     resource :daily, only: %i(show), controller: "daily"
+    namespace :daily do
+      resource :after_retirement, only: %i(show), controller: "after_retirement"
+    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -586,4 +586,27 @@ class UserTest < ActiveSupport::TestCase
 
     user.avatar.purge
   end
+
+  test '.retired_with_3_months_ago_and_notification_not_sent' do
+    target_ids = [
+      users(:taikai).id,
+      users(:taikai3).id
+    ]
+    targets = User.where(id: target_ids)
+    three_months_ago = Date.new(2022, 9, 1)
+    users(:taikai3).update_column(:retired_on, three_months_ago) # rubocop:disable Rails/SkipsModelValidations
+
+    travel_to Time.zone.local(2022, 12, 1, 7, 0, 0) do
+      expected_count = 2
+      users(:taikai).update_column(:retired_on, three_months_ago - 1.day) # rubocop:disable Rails/SkipsModelValidations
+      records = targets.retired_with_3_months_ago_and_notification_not_sent
+      assert_equal records.count, expected_count
+
+      expected_count = 1
+      users(:taikai).update_column(:retired_on, three_months_ago + 1.day) # rubocop:disable Rails/SkipsModelValidations
+      records = targets.retired_with_3_months_ago_and_notification_not_sent
+      assert_equal records.count, expected_count
+      assert_equal records.first.login_name, 'taikai3'
+    end
+  end
 end

--- a/test/system/notification/after_retirement_test.rb
+++ b/test/system/notification/after_retirement_test.rb
@@ -14,7 +14,7 @@ class Notification::AfterRetirementTest < ApplicationSystemTestCase
   end
 
   test 'three months have passed since user retired' do
-    visit_with_auth '/scheduler/daily', 'komagata'
+    visit_with_auth '/scheduler/daily/after_retirement', 'komagata'
     visit '/notifications'
 
     within first('.card-list-item.is-unread') do


### PR DESCRIPTION
## Issue

- #5929

## 概要

このプルリクエストは `/scheduler/daily` で定期実行している処理時間がかかりすぎる問題を
実行していた処理の一部を別コントローラーに分割することで解決するものです。
あわせて次の2点を改善しています。

1. メール通知対象者の判断をSQLに置き換えて、繰り返し処理内で逐次判断しないように改善しました
2. メール通知先の管理者を、繰り返し処理内で逐次取得しないように改善しました

なお既存の通知処理をactive_delivery化する修正はこのプルリクエストに含みません（ 議題 #5884 で対応する内容です ）。

## 変更確認方法

### 正常系

1. `feature/move-notify_certain_period_passed_after_retirement-action` をローカルに取り込みます
4. `bundle exec rails db:drop` を実行します
5. `bin/setup` を実行します
6. `bin/rails s` でサーバーを立ち上げます
7. http://localhost:3000/letter_opener にアクセスし、開発環境用の受信メール一覧画面を表示します
8. http://localhost:3000/scheduler/daily/after_retirement にアクセスします
    - URLアクセス用のアクションのため、ブラウザ上の描画はありません
9. 5秒程度待ってから 4. で表示した開発環境用の受信メール一覧画面を更新します
10. 6件のメールを受信していること（次の件名のメールがそれぞれ3通です）
    - `[FBC] yameoさんが退会してから3カ月が経過しました。`
    - `[FBC] kensyuowataさんが退会してから3カ月が経過しました。`

### 異常系

1. `feature/move-notify_certain_period_passed_after_retirement-action` をローカルに取り込みます
2. `bundle exec rails db:drop` を実行します
3. `bin/setup` を実行します
4. `bin/rails s` でサーバーを立ち上げます
6. http://localhost:3000/scheduler/daily/after_retirement?token=fake にアクセスします
    - 異常系のため `HTTP ERROR 401` になります
7. 5秒程度待ってから http://localhost:3000/letter_opener にアクセスし、開発環境用の受信メール一覧画面を表示します
8. メールを受信していないこと

## Screenshot

画面はありません。

## 参考情報

- URLの考え方は次の記事を参考にしました
  - [DHHはどのようにRailsのコントローラを書くのか | POSTD](https://postd.cc/how-dhh-organizes-his-rails-controllers/)
- 過去の類似する議題は次のものがありました
  - [[abstract_notifier] 退会後３ヶ月通知の実装を置き換えたい · Issue #4688 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/4688)
  - [退会後3ヶ月経ったらその旨を管理者に通知、Discordの運営チャンネルに通知したい · Issue #3654 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/3654)
