### PR TITLE
dailyからnotify_tomorrow_regular_eventを新規のcontrollerとして移動

### DIFF
--- a/app/controllers/scheduler/daily/notify_tomorrow_regular_event_controller.rb
+++ b/app/controllers/scheduler/daily/notify_tomorrow_regular_event_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Scheduler::Daily::NotifyTomorrowRegularEventController < ApplicationController
+  def show
+    notify_tomorrow_regular_event
+    head :ok
+  end
+
+  private
+
+  def notify_tomorrow_regular_event
+    return if RegularEvent.tomorrow_events.blank?
+
+    RegularEvent.tomorrow_events.each do |regular_event|
+      NotificationFacade.tomorrow_regular_event(regular_event)
+    end
+  end
+end

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -3,21 +3,12 @@
 class Scheduler::DailyController < SchedulerController
   def show
     User.notify_to_discord
-    notify_tomorrow_regular_event
     notify_product_review_not_completed
     Question.notify_certain_period_passed_after_last_answer
     head :ok
   end
 
   private
-
-  def notify_tomorrow_regular_event
-    return if RegularEvent.tomorrow_events.blank?
-
-    RegularEvent.tomorrow_events.each do |regular_event|
-      NotificationFacade.tomorrow_regular_event(regular_event)
-    end
-  end
 
   def notify_product_review_not_completed
     Comment.where(commentable_type: 'Product').find_each do |product_comment|

--- a/config/routes/scheduler.rb
+++ b/config/routes/scheduler.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     resource :daily, only: %i(show), controller: "daily"
     namespace :daily do
       resource :after_retirement, only: %i(show), controller: "after_retirement"
+      resource :notify_tomorrow_regular_event, only: %i(show), controller: "notify_tomorrow_regular_event"
     end
   end
 end

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -51,7 +51,7 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
                          headers: { 'Content-Type' => 'application/json' })
 
     travel_to Time.zone.local(2022, 7, 30, 0, 0, 0) do
-      visit_with_auth '/scheduler/daily', 'komagata'
+      visit_with_auth '/scheduler/daily/notify_tomorrow_regular_event', 'komagata'
     end
 
     assert_requested(stub_message)


### PR DESCRIPTION
## Issue

- #5932 

## 概要

`/scheduler/daily`にあった`notify_tomorrow_regular_event`を新規のコントローラとして、`scheduler/daily`配下に移動しました。

## 変更確認方法

1. `feature/move-notify_tomorrow_regular_event`をローカルに取り込む
2. （念の為）`bin/rails db:reset`しておく
3. #5480 にあるDiscordでの確認の下準備が必要です。すでに済んでいる方は次のステップに進んでください
4. `app/notifiers/discord_notifier.rb` の`tomorrow_regular_event`メソッドを以下のように変更
```diff
   def tomorrow_regular_event(params = {})
     params.merge!(@params)
     event = params[:event]
-    webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:admin]
+    webhook_url = 'ここにwebhookのurl' || Rails.application.secrets[:webhook][:admin]
```
5. `bin/rails s`でサーバーを起動
6. `localhost:3000/scheduler/daily/notify_tomorrow_regular_event`にアクセスする
7. Discordに以下の画像のような通知がきたらOKです
<img width="392" alt="image" src="https://user-images.githubusercontent.com/5976902/209457976-bc42733d-3e88-49b6-b24c-9f94db1274be.png">  
