### PR TITLE
Buzzcordへのリンクをフッタに追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -45,6 +45,9 @@ footer.footer
           li.footer-nav__item
             = link_to 'https://fjord-boot-camp-contributors-production.up.railway.app', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | FBC Contributors
+          li.footer-nav__item
+            = link_to 'https://buzzcord-fjord-jp.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | Buzzcord
 
       small.footer__copyright
         i.fa-regular.fa-copyright


### PR DESCRIPTION
## Issue

- #5907 

## 概要

Buzzcord(https://buzzcord-fjord-jp.herokuapp.com/)へのリンクをフッタに追加しました。

## 変更確認方法

1. `feature/add-buzzcord-link-to-footer`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 任意のユーザーでログインする
4. ログイン後のフッタに、Buzzcordへのリンクが追加されていることを確認する

## Screenshot

### 変更前
![2022-12-25 20 06 08 localhost de63aed33fba](https://user-images.githubusercontent.com/69447745/209466929-ebbaed31-2ee7-4085-b577-e5d752510565.png)

### 変更後
![image](https://user-images.githubusercontent.com/69447745/209466946-c08ff070-b554-4adc-b6f3-301cafc9c6a8.png)

