### PR TITLE
ユーザー一覧に退会者一覧追加する

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -8,16 +8,15 @@ class API::UsersController < API::BaseController
   def index
     @tag = params[:tag]
     @company = params[:company_id]
-    @target = params[:target]
     @watch = params[:watch]
 
-    @target = 'student_and_trainee' unless target_allowlist.include?(@target)
+    @target = target_allowlist.include?(params[:target]) ? params[:target] : 'student_and_trainee'
 
     target_users =
       if @target == 'followings'
         current_user.followees_list(watch: @watch)
-      elsif params[:tag]
-        User.tagged_with(params[:tag])
+      elsif @tag
+        User.tagged_with(@tag)
       elsif @company
         User.where(company_id: @company).users_role(@target)
       elsif @target == 'retired'
@@ -29,16 +28,8 @@ class API::UsersController < API::BaseController
     @users = target_users.page(params[:page]).per(PAGER_NUMBER)
                          .preload(:company, :avatar_attachment, :course, :tags)
                          .order(updated_at: :desc)
-    if params[:search_word]
-      @users = 
-        if @target == 'retired'
-          User.search_by_keywords({ word: params[:search_word] })
-              .unscope(where: :retired_on)
-              .users_role(@target)
-        else
-          target_users.search_by_keywords({ word: params[:search_word] })
-        end
-    end
+
+    @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
   end
 
   def show; end
@@ -52,6 +43,12 @@ class API::UsersController < API::BaseController
   end
 
   private
+
+  def search_for_users(target, target_users, search_word)
+    users = target_users.search_by_keywords({ word: search_word })
+    users = User.search_by_keywords({ word: search_word }).unscope(where: :retired_on).users_role(target) if target == 'retired'
+    users
+  end
 
   def target_allowlist
     target_allowlist = %w[student_and_trainee followings mentor graduate adviser trainee year_end_party]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,14 +17,15 @@ class UsersController < ApplicationController
         current_user.followees_list(watch: @watch)
       elsif params[:tag]
         User.tagged_with(params[:tag])
-      else
+      elsif @target == 'retired'
         User.users_role(@target)
+      else
+        User.users_role(@target).unretired
       end
 
     @users = target_users
              .page(params[:page]).per(PAGER_NUMBER)
              .preload(:avatar_attachment, :course, :taggings)
-             .unretired
              .order(updated_at: :desc)
 
     @random_tags = User.tags.sample(20)

--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -9,10 +9,12 @@ nav.tab-nav
             = link_to t("watch.#{watch}"), users_path(target: @target, watch: watch), class: (@watch == watch ? ['is-active'] : []) << 'tab-nav__item-link'
       - else
         - targets = %w[student_and_trainee mentor graduate adviser trainee]
+        - if current_user.admin?
+          - targets += %w[retired]
         - if current_user.mentor?
           - targets += %w[job_seeking all]
         - elsif current_user.adviser?
           - targets += %w[job_seeking]
         - targets.each do |target|
-          li.tab-nav__item(class="#{%w[job_seeking all].include?(target) ? 'is-only-mentor is-only-adviser' : ''}")
+          li.tab-nav__item(class="#{%w[job_seeking retired all].include?(target) ? 'is-only-mentor is-only-adviser' : ''}")
             = link_to t("target.#{target}"), users_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -183,6 +183,7 @@ class UsersTest < ApplicationSystemTestCase
   test 'admin access control' do
     visit_with_auth '/users', 'komagata'
     assert find_link('就職活動中')
+    assert find_link('退会')
     assert find_link('全員')
   end
 
@@ -488,6 +489,16 @@ class UsersTest < ApplicationSystemTestCase
     assert_equal 3, all('.users-item').length
     fill_in 'js-user-search-input', with: 'advijirou'
     assert_text 'アドバイ 次郎', count: 1
+
+    fill_in 'js-user-search-input', with: 'kimura'
+    assert_text '一致するユーザーはいません'
+  end
+
+  test 'search only retired when target is retired' do
+    visit_with_auth '/users?target=retired', 'komagata'
+    assert_equal 4, all('.users-item').length
+    fill_in 'js-user-search-input', with: 'yameo'
+    assert_text '辞目 辞目夫', count: 1
 
     fill_in 'js-user-search-input', with: 'kimura'
     assert_text '一致するユーザーはいません'


### PR DESCRIPTION
## Issue

- #5610

## 概要

ユーザー一覧に管理者だけ見れる退会者一覧を追加する。

## 変更確認方法

1. `feature/add-retired-target-to-users-list-page-for-admin`をローカルに取り込む。
2. `komagata`でログインする。
3. `http://127.0.0.1:3000/users`に行って、退会タブが表示しているか確認、絞り込み機能も確認する。
4. `hajime`でログイン、退会タブが表示しないのことを確認する。

## Screenshot

### 変更前

![before](https://user-images.githubusercontent.com/52590443/209784444-afc52cce-0714-4667-9b9d-ec5ba38a3fb1.png)

### 変更後

![after](https://user-images.githubusercontent.com/52590443/209784434-ac052873-9b20-4e00-9bc6-029f3d0f7d2c.png)