### PR TITLE
回答通知をactive_delivery経由で送信する

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -29,7 +29,10 @@ class ActivityMailer < ApplicationMailer
   def came_answer(args = {})
     @answer = params&.key?(:answer) ? params[:answer] : args[:answer]
     @user = @answer.receiver
-    @notification = @user.notifications.find_by(link: "/questions/#{@answer.question.id}")
+    @link_url = notification_redirector_url(
+      link: "/questions/#{@answer.question.id}",
+      kind: Notification.kinds[:answered]
+    )
     message = mail to: @user.email, subject: "[FBC] #{@answer.user.login_name}さんから回答がありました。"
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -24,4 +24,15 @@ class ActivityMailer < ApplicationMailer
     subject = "[FBC] #{@sender.login_name}さんが卒業しました。"
     mail to: @user.email, subject: subject
   end
+
+  # required params: answer
+  def came_answer(args = {})
+    @answer = params&.key?(:answer) ? params[:answer] : args[:answer]
+    @user = @answer.receiver
+    @notification = @user.notifications.find_by(link: "/questions/#{@answer.question.id}")
+    message = mail to: @user.email, subject: "[FBC] #{@answer.user.login_name}さんから回答がありました。"
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -53,13 +53,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: "[FBC] #{@message}"
   end
 
-  # required params: answer
-  def came_answer
-    @user = @answer.receiver
-    @notification = @user.notifications.find_by(link: "/questions/#{@answer.question.id}")
-    mail to: @user.email, subject: "[FBC] #{@answer.user.login_name}さんから回答がありました。"
-  end
-
   # required params: announcement, receiver
   def post_announcement
     @user = @receiver

--- a/app/models/answer_notifier.rb
+++ b/app/models/answer_notifier.rb
@@ -7,6 +7,6 @@ class AnswerNotifier
     question = answer.question
     watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
     mention_user_ids = answer.new_mention_users.ids
-    NotificationFacade.came_answer(answer) if watcher_ids.concat(mention_user_ids).exclude?(answer.receiver.id)
+    ActivityDelivery.with(answer: answer).notify(:came_answer) if watcher_ids.concat(mention_user_ids).exclude?(answer.receiver.id)
   end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -46,14 +46,6 @@ class NotificationFacade
     ).submitted.deliver_later(wait: 5)
   end
 
-  def self.came_answer(answer)
-    receiver = answer.receiver
-    ActivityNotifier.with(answer: answer).came_answer.notify_now
-    return unless answer.receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(answer: answer).came_answer.deliver_later(wait: 5)
-  end
-
   def self.post_announcement(announce, receiver)
     ActivityNotifier.with(announce: announce, receiver: receiver).post_announcement.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/views/activity_mailer/came_answer.html.slim
+++ b/app/views/activity_mailer/came_answer.html.slim
@@ -1,0 +1,2 @@
+= render '/notification_mailer/notification_mailer_template', title: "質問「#{@answer.question.title}」に#{@answer.user.login_name}さんが回答しました。", link_url: notification_url(@notification, anchor: "answer_#{@answer.id}"), link_text: '回答へ' do
+  = md2html(@answer.description)

--- a/app/views/activity_mailer/came_answer.html.slim
+++ b/app/views/activity_mailer/came_answer.html.slim
@@ -1,2 +1,2 @@
-= render '/notification_mailer/notification_mailer_template', title: "質問「#{@answer.question.title}」に#{@answer.user.login_name}さんが回答しました。", link_url: notification_url(@notification, anchor: "answer_#{@answer.id}"), link_text: '回答へ' do
+= render '/notification_mailer/notification_mailer_template', title: "質問「#{@answer.question.title}」に#{@answer.user.login_name}さんが回答しました。", link_url: @link_url, link_text: '回答へ' do
   = md2html(@answer.description)

--- a/app/views/notification_mailer/came_answer.html.slim
+++ b/app/views/notification_mailer/came_answer.html.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: "質問「#{@answer.question.title}」に#{@answer.user.login_name}さんが回答しました。", link_url: notification_url(@notification, anchor: "answer_#{@answer.id}"), link_text: '回答へ' do
-  = md2html(@answer.description)

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -54,10 +54,11 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 4, link: "/questions/#{answer.question.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
     assert_equal '[FBC] komagataさんから回答がありました。', email.subject
-    assert_match(/回答/, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">回答へ</a>}, email.body.to_s)
   end
 
   test 'came_answer with params' do
@@ -70,10 +71,11 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 4, link: "/questions/#{answer.question.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
     assert_equal '[FBC] komagataさんから回答がありました。', email.subject
-    assert_match(/回答/, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">回答へ</a>}, email.body.to_s)
   end
 
   test 'came_answer to mute email notification or retired user' do

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -47,4 +47,53 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert ActionMailer::Base.deliveries.empty?
   end
+
+  test 'came_answer' do
+    answer = answers(:answer3)
+    ActivityMailer.came_answer(answer: answer).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['sotugyou@example.com'], email.to
+    assert_equal '[FBC] komagataさんから回答がありました。', email.subject
+    assert_match(/回答/, email.body.to_s)
+  end
+
+  test 'came_answer with params' do
+    answer = answers(:answer3)
+    mailer = ActivityMailer.with(answer: answer).came_answer
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['sotugyou@example.com'], email.to
+    assert_equal '[FBC] komagataさんから回答がありました。', email.subject
+    assert_match(/回答/, email.body.to_s)
+  end
+
+  test 'came_answer to mute email notification or retired user' do
+    answer = answers(:answer3)
+    receiver = users(:sotugyou)
+
+    receiver.update_columns(mail_notification: false, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
+    ActivityMailer.came_answer(answer: answer.reload).deliver_now
+    assert ActionMailer::Base.deliveries.empty?
+
+    receiver.update_columns(mail_notification: false, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
+    ActivityMailer.came_answer(answer: answer.reload).deliver_now
+    assert ActionMailer::Base.deliveries.empty?
+
+    receiver.update_columns(mail_notification: true, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
+    ActivityMailer.came_answer(answer: answer.reload).deliver_now
+    assert ActionMailer::Base.deliveries.empty?
+
+    receiver.update_columns(mail_notification: true, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
+    ActivityMailer.came_answer(answer: answer.reload).deliver_now
+    assert_not ActionMailer::Base.deliveries.empty?
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -81,22 +81,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/提出/, email.body.to_s)
   end
 
-  test 'came_answer' do
-    answer = answers(:answer3)
-    mailer = NotificationMailer.with(answer: answer).came_answer
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[FBC] komagataさんから回答がありました。', email.subject
-    assert_match(/回答/, email.body.to_s)
-  end
-
   test 'post_announcement' do
     announce = announcements(:announcement1)
     announced = notifications(:notification_announced)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -9,4 +9,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(sender: sender, receiver: receiver).graduated
   end
+
+  def came_answer
+    question = Question.find(ActiveRecord::FixtureSet.identify(:question2))
+    answer = question.answers.first
+
+    ActivityMailer.with(answer: answer).came_answer
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -41,13 +41,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     ).submitted
   end
 
-  def came_answer
-    question = Question.find(ActiveRecord::FixtureSet.identify(:question2))
-    answer = question.answers.first
-
-    NotificationMailer.with(answer: answer).came_answer
-  end
-
   def post_announcement
     announce = Announcement.find(ActiveRecord::FixtureSet.identify(:announcement1))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:sotugyou))


### PR DESCRIPTION
## Issue

- #5878

## 概要

Q&A への回答コメントを通知する機能を `NotificationFacade` から `ActivityDelivery` に変更しました。そのため次の変更があります。

- `NotificationFacade` が不要になり、通知送信は `ActivityDelivery` を経由して、サイト内通知「 `ActivityNotifier.came_answer` 」とメール通知「 `ActivityMailer.came_answer` 」が 実行されるようになりました。
- 送信メール生成メソッドの「`came_answer`」は `ActivityDelivery` を使用することにより `NotificationMailer` から接頭辞が一致する `ActivityMailer` への移動が必要となりました。
- `NotificationFacade` でメール送信判断をしていた箇所は `ActivityMailer.came_answer` の `perform_deliveries` で代替するようにしています。

## 変更確認方法

### 初回レビュー依頼分（2022-12-29）

回答通知をactive_delivery経由で送信できることを確認する手順です。

1. `feature/use-active_delivery-for-came_answer` をローカルに取り込みます
2. `bin/setup` を実行します
3. `bin/rails s` でサーバーを立ち上げます
4. 別々のブラウザ（シークレットモードなどで）で2つのユーザーにログインします
    - `hajime` でログインします（回答通知を受け取るユーザー）
    - `muryou` でログインします（回答をコメントするユーザー）
5. ログインユーザー「hajime」の登録情報（ http://localhost:3000/current_user/edit ）のメール通知がOFFであることを確認します
6. ログインユーザー「muryou」でテストの質問40（ http://localhost:3000/questions/1037106414 ）にコメントします
7. ログインユーザー「hajime」の通知（ http://localhost:3000/notifications ）にサイト内通知「muryouさんから回答がありました。」があること
8. 受信メール一覧（ http://localhost:3000/letter_opener ）にメールがないこと
9. ログインユーザー「hajime」の登録情報（ http://localhost:3000/current_user/edit ）のメール通知をONに更新します
10. ログインユーザー「muryou」でテストの質問40（ http://localhost:3000/questions/1037106414 ）に再びコメントします
11. 受信メール一覧（ http://localhost:3000/letter_opener ）に件名「質問「テストの質問40」にmuryouさんが回答しました。」のメールがあること

### 再レビュー依頼分（2023-01-14）

サイト内通知より先にメール通知が送られると、通知URL生成でエラーになる不具合がありました。
上記の不具合を修正したことで、メール内のリンクが意図しているものかを確認する手順です。

1. `feature/use-active_delivery-for-came_answer` をローカルに取り込みます
2. `bin/setup` を実行します
3. `bin/rails s` でサーバーを立ち上げます
4. `sotugyou` でログインします
5. http://localhost:3000/rails/mailers から [came_answer](http://localhost:3000/rails/mailers/activity_mailer/came_answer) にアクセスし、表示されたメールプレビューにあるリンク「回答へ」をクリックします
6. Q&A「injectとreduce」が表示されること
    - 従来はアンカーリンクで回答へのページ内リンク（画面を開いた時に自動でスクロールされている挙動）を実現していましたが、今回の通知URL方式の変更でアンカーリンクはなくなりました

## Screenshot

画面上の変更はありません。

## その他

### 参考リソース

- メール送信をキャンセルする方法（perform_deliveries）
  - https://github.com/rails/rails/blob/6-1-stable/actionmailer/lib/action_mailer/log_subscriber.rb#L12
  - https://railsguides.jp/action_mailer_basics.html
- [gemを使った通知機能](https://github.com/fjordllc/bootcamp/wiki/gem%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%9F%E9%80%9A%E7%9F%A5%E6%A9%9F%E8%83%BD)

### 類似するプルリクエスト

- [最初の日報投稿通知をactive_delivery化する by akingo55](https://github.com/fjordllc/bootcamp/pull/5931)
- [確認通知をactive_delivery化 by peno022](https://github.com/fjordllc/bootcamp/pull/5924)
- [コメント通知をactive_delivery化したい by dowdiness](https://github.com/fjordllc/bootcamp/pull/5919)
- 卒業通知のメール
  - [卒業通知のメールが送られていなかった問題を修正 by komagata](https://github.com/fjordllc/bootcamp/pull/5939)
  - [NotificationFacade.graduatedを削除 by komagata](https://github.com/fjordllc/bootcamp/pull/5898)