### PR TITLE
先に卒業通知メールが送られた場合にエラーがになる問題を修正

### DIFF
--- a/app/controllers/notification/redirector_controller.rb
+++ b/app/controllers/notification/redirector_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Notification::RedirectorController < ApplicationController
+  before_action :set_my_notification, only: %i[show]
+
+  def show
+    notifications = current_user.notifications.where(
+      link: params[:link]
+    )
+    current_user.mark_all_as_read_and_delete_cache_of_unreads(
+      target_notifications: notifications
+    )
+    redirect_to params[:link]
+  end
+
+  private
+
+  def set_my_notification
+    @notification = current_user.notifications.find_by(
+      link: params[:link],
+      kind: params[:kind]
+    )
+  end
+end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -2,6 +2,7 @@
 
 class ActivityMailer < ApplicationMailer
   helper ApplicationHelper
+  include Rails.application.routes.url_helpers
 
   before_action do
     @sender = params[:sender] if params&.key?(:sender)
@@ -14,7 +15,10 @@ class ActivityMailer < ApplicationMailer
     @receiver ||= args[:receiver]
 
     @user = @receiver
-    @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:graduated])
+    @link_url = notification_redirector_path(
+      link: "/users/#{@sender.id}",
+      kind: Notification.kinds[:graduated]
+    )
     subject = "[FBC] #{@sender.login_name}さんが卒業しました。"
     mail to: @user.email, subject: subject
   end

--- a/app/views/activity_mailer/graduated.html.slim
+++ b/app/views/activity_mailer/graduated.html.slim
@@ -1,1 +1,4 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@sender.login_name}さんが卒業しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@sender.login_name}さんが卒業しました。",
+  link_url: @link_url,
+  link_text: "#{@sender.login_name}さんのページへ"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,9 @@ Rails.application.routes.draw do
     resource :completion, only: %i(show), controller: "practices/completion"
   end
   resources :pages, param: :slug_or_id
+  namespace :notification do 
+    resource :redirector, only: %i(show), controller: "redirector"
+  end
   resources :notifications, only: %i(index show) do
     collection do
       resources :allmarks, only: %i(create), controller: "notifications/allmarks"


### PR DESCRIPTION
サイト内通知より先にメール通知が送られるとnotification_pathが決まらない
のでメール文がエラーになる問題を修正。