### PR TITLE
ユーザーSeedデータが追加されても期生一覧のテストが通るように変更

### DIFF
--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -20,7 +20,7 @@ class GenerationsTest < ApplicationSystemTestCase
     assert_text 'ユーザー一覧'
     assert_link "#{users(:otameshi).generation}期生"
     within all('.a-user-icons__items').first do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon.is-student')['title'], 'otameshi (お試し 延長)'
+      assert_equal first('img')['class'], 'a-user-icons__item-icon a-user-icon is-student'
     end
     assert_equal '期生別ユーザー一覧 | FBC', title
   end


### PR DESCRIPTION
## Issue

- #5996 

## 概要

以下の条件下だとテストが落ちる可能性がありました。
-  [ユーザーotameshi](https://github.com/fjordllc/bootcamp/blob/main/test/fixtures/users.yml#L577)の`created_at`が`Time.current`で指定されている
- テスト用seedデータで上記以外のユーザーに`created_at`が`Time.current`で指定されている

当該のテストでは、otameshiのアバター画像の`img`要素の`title`属性の値をassertで指定していましたが、期生一覧の表示だけテストするのであれば、`img`要素の`calss`属性をテストするほうが適切だと思いました。（`title`属性の値はユーザーごとに変わりますし、必ずしも先頭に表示されるとは限らないため）

## 変更確認方法

1. `bug/faile-generations-test`をローカルに取り込む
2. 手元で当該のテストがクリアするか確認する
