### PR TITLE
相談部屋に管理者にだけブックマーク機能を追加した

### DIFF
--- a/app/javascript/components/Bookmarks.jsx
+++ b/app/javascript/components/Bookmarks.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import useSWR, { useSWRConfig } from 'swr'
 import fetcher from '../fetcher'
 import Bootcamp from '../bootcamp'
+import UserIcon from './UserIcon';
 
 export default function Bookmarks() {
   const [editable, setEditable] = useState(false);
@@ -86,7 +87,17 @@ const Bookmark = ({ bookmark, editable, setEditable }) => {
   return (
     <div className={'card-list-item is-' + bookmark.bookmark_class_name}>
       <div className="card-list-item__inner">
-        <div className="card-list-item__label">{bookmark.modelNameI18n}</div>
+        {bookmark.modelName === 'Talk' ? (
+          <div className="card-list-item__user">
+            <UserIcon
+              user={bookmark.user}
+              blockClassSuffix='card-list-item'
+            />
+          </div>
+        ) : (
+          <div className="card-list-item__label">{bookmark.modelNameI18n}</div>
+        )
+        }
         <div className="card-list-item__rows">
           <div className="card-list-item__row">
             <div className="card-list-item-title">
@@ -97,23 +108,27 @@ const Bookmark = ({ bookmark, editable, setEditable }) => {
               </div>
             </div>
           </div>
-          <div className="card-list-item__row">
-            <div className="card-list-item__summary">
-              <p>{bookmark.summary}</p>
-            </div>
-          </div>
-          <div className="card-list-item__row">
-            <div className="card-list-item-meta">
-              <div className="card-list-item-meta__item">
-                <a href={bookmark.authorUrl} className="a-user-name">{bookmark.author}</a>
+          {bookmark.modelName !== 'Talk' &&
+            <div>
+              <div className="card-list-item__row">
+                <div className="card-list-item__summary">
+                  <p>{bookmark.summary}</p>
+                </div>
               </div>
-              <div className="card-list-item-meta__item">
-                <time className="a-meta" dateTime={bookmark.updated_at}>
-                  {createdAt}
-                </time>
+              <div className="card-list-item__row">
+                <div className="card-list-item-meta">
+                  <div className="card-list-item-meta__item">
+                    <a href={bookmark.authorUrl} className="a-user-name">{bookmark.author}</a>
+                  </div>
+                  <div className="card-list-item-meta__item">
+                    <time className="a-meta" dateTime={bookmark.updated_at}>
+                      {createdAt}
+                    </time>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
+          }
         </div>
         {editable && (
           <DeleteButton id={bookmark.id} afterDelete={afterDelete} />

--- a/app/javascript/components/Bookmarks.jsx
+++ b/app/javascript/components/Bookmarks.jsx
@@ -96,8 +96,7 @@ const Bookmark = ({ bookmark, editable, setEditable }) => {
           </div>
         ) : (
           <div className="card-list-item__label">{bookmark.modelNameI18n}</div>
-        )
-        }
+        )}
         <div className="card-list-item__rows">
           <div className="card-list-item__row">
             <div className="card-list-item-title">

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -2,6 +2,7 @@
 
 class Talk < ApplicationRecord
   include Commentable
+  include Bookmarkable
 
   belongs_to :user
 

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -6,6 +6,7 @@ json.modelName bookmark.bookmarkable_type
 json.modelNameI18n t("activerecord.models.#{bookmarkable.class.to_s.tableize.singularize}")
 json.author bookmarkable.user.name
 json.authorUrl bookmarkable.user.url
+json.user bookmarkable.user, partial: "api/users/user", as: :user
 json.url polymorphic_url(bookmarkable)
 json.title bookmarkable_title
 json.created_at matched_document(bookmark.bookmarkable).created_at

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -1,5 +1,5 @@
 bookmarkable = bookmark.bookmarkable
-bookmarkable_title = bookmark.bookmarkable_type == 'Talk' ? "#{bookmarkable.user.long_name}さんの相談部屋" : bookmarkable.title
+bookmarkable_title = bookmark.bookmarkable_type == 'Talk' ? "#{bookmarkable.user.long_name} さんの相談部屋" : bookmarkable.title
 json.id bookmark.id
 json.bookmarkable_id bookmark.bookmarkable_id
 json.modelName bookmark.bookmarkable_type

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -1,4 +1,5 @@
 bookmarkable = bookmark.bookmarkable
+bookmarkable_title = bookmark.bookmarkable_type == 'Talk' ? "#{bookmarkable.user.long_name}さんの相談部屋" : bookmarkable.title
 json.id bookmark.id
 json.bookmarkable_id bookmark.bookmarkable_id
 json.modelName bookmark.bookmarkable_type
@@ -6,9 +7,9 @@ json.modelNameI18n t("activerecord.models.#{bookmarkable.class.to_s.tableize.sin
 json.author bookmarkable.user.name
 json.authorUrl bookmarkable.user.url
 json.url polymorphic_url(bookmarkable)
-json.title bookmarkable.title
+json.title bookmarkable_title
 json.created_at matched_document(bookmark.bookmarkable).created_at
 json.updated_at matched_document(bookmark.bookmarkable).updated_at
 json.reported_on matched_document(bookmark.bookmarkable).reported_on if bookmark.bookmarkable_type == "Report"
 json.bookmark_class_name bookmark.bookmarkable_type.to_s.tableize.chop
-json.summary searchable_summary(filtered_message(bookmark.bookmarkable))
+json.summary searchable_summary(filtered_message(bookmark.bookmarkable)) unless bookmark.bookmarkable_type == 'Talk'

--- a/app/views/home/_bookmark.html.slim
+++ b/app/views/home/_bookmark.html.slim
@@ -8,7 +8,7 @@
           header.card-list-item-title
             h2.card-list-item-title__title
               = link_to bookmark.bookmarkable, class: 'card-list-item-title__link a-text-link' do
-                = "#{bookmark.bookmarkable.user.long_name}さんの相談部屋"
+                = "#{bookmark.bookmarkable.user.long_name} さんの相談部屋"
     - else
       .card-list-item__label
         = bookmark.bookmarkable.model_name.human

--- a/app/views/home/_bookmark.html.slim
+++ b/app/views/home/_bookmark.html.slim
@@ -1,22 +1,32 @@
 .card-list-item(class="is-#{bookmark.bookmarkable.model_name.to_s.downcase}")
   .card-list-item__inner
-    .card-list-item__label
-      = bookmark.bookmarkable.model_name.human
-    .card-list-item__rows
-      .card-list-item__row
-        header.card-list-item-title
-          h2.card-list-item-title__title
-            = link_to bookmark.bookmarkable, class: 'card-list-item-title__link a-text-link' do
-              = bookmark.bookmarkable.title
-      .card-list-item__row
-        .card-list-item-meta
-          .card-list-item-meta__items
-            .card-list-item-meta__item
-              = link_to bookmark.bookmarkable.user, class: 'a-user-name' do
-                = bookmark.bookmarkable.user.long_name
-            .card-list-item-meta__item
-              time.a-meta(datetime= bookmark.reported_on_or_created_at)
-                = l bookmark.reported_on_or_created_at, format: :long
+    - if bookmark.bookmarkable_type == 'Talk'
+      .card-list-item__user
+        = render 'users/icon', user: bookmark.bookmarkable.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'
+      .card-list-item__rows
+        .card-list-item__row
+          header.card-list-item-title
+            h2.card-list-item-title__title
+              = link_to bookmark.bookmarkable, class: 'card-list-item-title__link a-text-link' do
+                = "#{bookmark.bookmarkable.user.long_name}さんの相談部屋"
+    - else
+      .card-list-item__label
+        = bookmark.bookmarkable.model_name.human
+      .card-list-item__rows
+        .card-list-item__row
+          header.card-list-item-title
+            h2.card-list-item-title__title
+              = link_to bookmark.bookmarkable, class: 'card-list-item-title__link a-text-link' do
+                = bookmark.bookmarkable.title
+        .card-list-item__row
+          .card-list-item-meta
+            .card-list-item-meta__items
+              .card-list-item-meta__item
+                = link_to bookmark.bookmarkable.user, class: 'a-user-name' do
+                  = bookmark.bookmarkable.user.long_name
+              .card-list-item-meta__item
+                time.a-meta(datetime= bookmark.reported_on_or_created_at)
+                  = l bookmark.reported_on_or_created_at, format: :long
     .card-list-item__option.js-bookmark-delete-button
       = link_to current_user_bookmark_path(bookmark.id), method: :delete, class: 'a-button is-sm is-primary' do
         | 削除

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -18,12 +18,13 @@
               .page-content-header__row
                 h1.page-content-header__title
                   = title
-              .page-content-header__row
-                - if admin_login?
+              - if admin_login?
+                .page-content-header__row
                   .page-content-header-actions
                     .page-content-header-actions__start
                       .page-content-header-actions__action
                         #js-bookmark(data-bookmarkable-id="#{@talk.id}", data-bookmarkable-type='Talk')
+              .page-content-header__row
                 .page-content-header__description
                   .a-long-text.is-md
                     p

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -18,7 +18,12 @@
               .page-content-header__row
                 h1.page-content-header__title
                   = title
-              .page-content-header__row
+              .page-content-header__row  
+                - if admin_login?            
+                  .page-content-header-actions
+                    .page-content-header-actions__start
+                      .page-content-header-actions__action
+                        #js-bookmark(data-bookmarkable-id="#{@talk.id}", data-bookmarkable-type='Talk')
                 .page-content-header__description
                   .a-long-text.is-md
                     p

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -18,8 +18,8 @@
               .page-content-header__row
                 h1.page-content-header__title
                   = title
-              .page-content-header__row  
-                - if admin_login?            
+              .page-content-header__row
+                - if admin_login?
                   .page-content-header-actions
                     .page-content-header-actions__start
                       .page-content-header-actions__action

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -42,7 +42,6 @@ ja:
       campaign: お試し延長
       book: 参考書籍
       regular_event: 定期イベント
-      talk: 相談
     attributes:
       user:
         login_name: アカウント

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -42,6 +42,7 @@ ja:
       campaign: お試し延長
       book: 参考書籍
       regular_event: 定期イベント
+      talk: 相談
     attributes:
       user:
         login_name: アカウント

--- a/db/fixtures/bookmarks.yml
+++ b/db/fixtures/bookmarks.yml
@@ -1,3 +1,7 @@
+bookmark31:
+  user: komagata
+  bookmarkable: talk_komagata (Talk)
+
 bookmark30:
   user: kimura
   bookmarkable: page1 (Page)

--- a/test/decorators/bookmark_decorator_test.rb
+++ b/test/decorators/bookmark_decorator_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class BookmarkDecoratorTest < ActiveSupport::TestCase
   def setup
+    @bookmark31 = ActiveDecorator::Decorator.instance.decorate(bookmarks(:bookmark31))
     @bookmark30 = ActiveDecorator::Decorator.instance.decorate(bookmarks(:bookmark30))
     @bookmark29 = ActiveDecorator::Decorator.instance.decorate(bookmarks(:bookmark29))
     @bookmark28 = ActiveDecorator::Decorator.instance.decorate(bookmarks(:bookmark28))
@@ -11,6 +12,7 @@ class BookmarkDecoratorTest < ActiveSupport::TestCase
   end
 
   test '#reported_on_or_created_at' do
+    assert_equal I18n.l(bookmarks(:bookmark31).bookmarkable.created_at), I18n.l(@bookmark31.reported_on_or_created_at)
     assert_equal I18n.l(bookmarks(:bookmark30).bookmarkable.created_at), I18n.l(@bookmark30.reported_on_or_created_at)
     assert_equal I18n.l(bookmarks(:bookmark29).bookmarkable.created_at), I18n.l(@bookmark29.reported_on_or_created_at)
     assert_equal I18n.l(bookmarks(:bookmark28).bookmarkable.created_at), I18n.l(@bookmark28.reported_on_or_created_at)

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,3 +1,7 @@
+bookmark31:
+  user: komagata
+  bookmarkable: talk1 (Talk)
+
 bookmark30:
   user: kimura
   bookmarkable: page1 (Page)

--- a/test/integration/api/bookmarks_test.rb
+++ b/test/integration/api/bookmarks_test.rb
@@ -84,6 +84,19 @@ class API::BookmarksTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test 'POST talk' do
+    talk = talks(:talk2)
+    token = create_token('komagata', 'testtest')
+    post api_bookmarks_path(format: :json),
+         params: {
+           user: 'komagata',
+           bookmarkable_id: talk.id,
+           bookmarkable_type: 'Talk'
+         },
+         headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :created
+  end
+
   test 'duplicate POST page' do
     page = pages(:page1)
     token = create_token('komagata', 'testtest')
@@ -167,6 +180,28 @@ class API::BookmarksTest < ActionDispatch::IntegrationTest
            user: report.user_id,
            bookmarkable_id: report.id,
            bookmarkable_type: 'Report'
+         },
+         headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :no_content
+  end
+
+  test 'duplicate POST talk' do
+    talk = talks(:talk1)
+    token = create_token('machida', 'testtest')
+    post api_bookmarks_path(format: :json),
+         params: {
+           user: talk.user_id,
+           bookmarkable_id: talk.id,
+           bookmarkable_type: 'Talk'
+         },
+         headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :created
+
+    post api_bookmarks_path(format: :json),
+         params: {
+           user: talk.user_id,
+           bookmarkable_id: talk.id,
+           bookmarkable_type: 'Talk'
          },
          headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :no_content

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -34,4 +34,12 @@ class BookmarkTest < ActiveSupport::TestCase
     Bookmark.create(user: user, bookmarkable: page)
     assert_not Bookmark.new(user: user, bookmarkable: page).valid?
   end
+
+  test 'prohibit to duplicate talk registration' do
+    user = users(:komagata)
+    talk = talks(:talk1)
+
+    Bookmark.create(user: user, bookmarkable: talk)
+    assert_not Bookmark.new(user: user, bookmarkable: talk).valid?
+  end
 end

--- a/test/system/bookmark/talks_test.rb
+++ b/test/system/bookmark/talks_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Bookmark::TalkTest < ApplicationSystemTestCase
+  setup do
+    @talk = talks(:talk1)
+    @user = @talk.user
+  end
+
+  test 'show talk bookmark on lists' do
+    visit_with_auth '/current_user/bookmarks', 'komagata'
+    assert_text "#{@user.login_name} (#{@user.name}) さんの相談部屋"
+  end
+
+  test 'show active button when bookmarked talk' do
+    visit_with_auth "/talks/#{@talk.id}", 'komagata'
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+  end
+
+  test 'show inactive button when not bookmarked talk' do
+    visit_with_auth "/talks/#{@talk.id}", 'machida'
+    assert_selector '#bookmark-button.is-inactive'
+    assert_no_selector '#bookmark-button.is-active'
+  end
+
+  test 'bookmark talk' do
+    visit_with_auth "/talks/#{@talk.id}", 'machida'
+    find('#bookmark-button').click
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+
+    visit '/current_user/bookmarks'
+    assert_text "#{@user.login_name} (#{@user.name}) さんの相談部屋"
+  end
+
+  test 'unbookmark talk' do
+    visit_with_auth "/talks/#{@talk.id}", 'komagata'
+    assert_selector '#bookmark-button.is-active'
+    find('#bookmark-button').click
+    assert_selector '#bookmark-button.is-inactive'
+    assert_no_selector '#bookmark-button.is-active'
+
+    visit '/current_user/bookmarks'
+    assert_no_text "#{@user.login_name} (#{@user.name}) さんの相談部屋"
+  end
+
+  test 'hide bookmark button when mentor login' do
+    visit_with_auth "/talks/#{talks(:talk6).id}", 'mentormentaro'
+    assert_text 'mentormentaroさんの相談部屋'
+    assert_no_selector '#bookmark-button'
+  end
+
+  test 'hide bookmark button when adviser login' do
+    visit_with_auth "/talks/#{talks(:talk4).id}", 'advijirou'
+    assert_text 'advijirouさんの相談部屋'
+    assert_no_selector '#bookmark-button'
+  end
+
+  test 'hide bookmark button when graduate login' do
+    visit_with_auth "/talks/#{talks(:talk3).id}", 'sotugyou'
+    assert_text 'sotugyouさんの相談部屋'
+    assert_no_selector '#bookmark-button'
+  end
+
+  test 'hide bookmark button when trainee login' do
+    visit_with_auth "/talks/#{talks(:talk11).id}", 'kensyu'
+    assert_text 'kensyuさんの相談部屋'
+    assert_no_selector '#bookmark-button'
+  end
+
+  test 'hide bookmark button when student login' do
+    visit_with_auth "/talks/#{talks(:talk7).id}", 'kimura'
+    assert_text 'kimuraさんの相談部屋'
+    assert_no_selector '#bookmark-button'
+  end
+end

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -96,11 +96,11 @@ class BookmarksTest < ApplicationSystemTestCase
     visit_with_auth report_path(@report), 'komagata'
     assert_text 'Bookmark中'
     visit current_user_bookmarks_path
-    assert_text '作業週1日目'
+    assert_text 'komagata (Komagata Masaki) さんの相談部屋'
     find(:css, '#spec-edit-mode').set(true)
     assert_selector '.card-list-item__option'
     first('#bookmark-button').click
-    assert_no_text '作業週1日目'
+    assert_no_text 'komagata (Komagata Masaki) さんの相談部屋'
     visit report_path(@report)
     assert_text 'Bookmark'
   end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -293,7 +293,9 @@ class HomeTest < ApplicationSystemTestCase
     find('#bookmark-button').click
     visit "/pages/#{pages(:page1).id}"
     find('#bookmark-button').click
-    reports = %i[report68 report69 report70 report71]
+    visit "/talks/#{talks(:talk1).id}"
+    find('#bookmark-button').click
+    reports = %i[report68 report69 report70]
     reports.each do |report|
       visit "/reports/#{reports(report).id}"
       find('#bookmark-button').click
@@ -304,6 +306,8 @@ class HomeTest < ApplicationSystemTestCase
     assert_text '最新のブックマーク'
     find_link pages(:page1).title
     assert_text I18n.l pages(:page1).created_at, format: :long
+    user = talks(:talk1).user
+    find_link "#{user.login_name} (#{user.name}) さんの相談部屋"
     reports.each do |report|
       find_link reports(report).title
       assert_text I18n.l reports(report).reported_on, format: :long

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -146,7 +146,7 @@ class TalksTest < ApplicationSystemTestCase
 
   test 'talks unreplied page displays when admin logined ' do
     visit_with_auth '/', 'komagata'
-    click_link '相談'
+    click_link '相談', match: :first
     assert_equal '/talks/unreplied', current_path
   end
 


### PR DESCRIPTION
## Issue

- #5748

## 概要
相談部屋に管理者にだけブックマーク機能を追加しました。

## 変更確認方法

1. `feature/add-bookmark-function-to-the-consultation-room`をローカルに取り込む
2. `rails db:drop`を実行する
3. `bin/setup`を実行する
4. `bin/rails s`でサーバーを起動する
5. `localhost:3000`にアクセスして`komagata`でログインする
6. `localhost:3000/talks/28995025`にアクセスして`Bookmark`をクリックし`Bookmark中`に変わることを確認する
7. `localhost:3000/current_user/bookmarks`にアクセスして`marumarushain19 (marumarushain19) さんの相談部屋`がリストの一番上にあることを確認する
8. `marumarushain19 (marumarushain19) さんの相談部屋`をクリックして相談部屋に遷移することを確認する
9. `localhost:3000`にアクセスして、ダッシュボード最新のブックマーク一覧の一番上に`marumarushain19 (marumarushain19) さんの相談部屋`があることを確認する
10. `marumarushain19 (marumarushain19) さんの相談部屋`をクリックして相談部屋に遷移することを確認する
11. 最後に`Bookmark中`をクリックしてブックマークを解除し、`localhost:3000/current_user/bookmarks`とダッシュボード最新のブックマーク一覧から`marumarushain19 (marumarushain19) さんの相談部屋`が消えていることを確認する

## Screenshot

### 変更前

marumarushain19さんの相談部屋(localhost:3000/talks/28995025)

<img width="736" alt="スクリーンショット 2023-01-06 18 14 36" src="https://user-images.githubusercontent.com/88083085/210971257-9b484ba2-9fa8-4495-b065-f16ca512dee1.png">


### 変更後

marumarushain19さんの相談部屋(localhost:3000/talks/28995025)

<img width="735" alt="スクリーンショット 2023-01-06 18 11 26" src="https://user-images.githubusercontent.com/88083085/210971190-8ae5b39a-f5aa-4874-83b7-eab47faf1afa.png">

ブックマーク一覧(localhost:3000/current_user/bookmarks)

<img width="728" alt="スクリーンショット 2023-01-06 18 12 11" src="https://user-images.githubusercontent.com/88083085/210971221-55356807-514e-4876-bb12-24f8fd504454.png">

ダッシュボード最新のブックマーク一覧(localhost:3000)

<img width="752" alt="スクリーンショット 2023-01-06 18 12 31" src="https://user-images.githubusercontent.com/88083085/210971237-9934a16a-84c7-4f9d-b528-225828b7c7d8.png">
