### PR TITLE
休会中・退会後でもログインが必要なページにアクセスできてしまう問題を修正

### DIFF
--- a/.traceroute.yml
+++ b/.traceroute.yml
@@ -13,15 +13,15 @@ ignore_unreachable_actions:
   - .*#student_login\?
   - .*#paid_login\?
   - .*#staff_or_paid_login\?
-  - .*#retired_login\?
   - .*#hibernated_login\?
+  - .*#retired_login\?
+  - .*#invalid_login\?
   - .*#policy
+  - .*#require_active_user_login
   - .*#require_staff_login
   - .*#require_admin_login
   - .*#require_mentor_login
   - .*#require_admin_or_mentor_login
-  - .*#refuse_retired_login
-  - .*#refuse_hibernated_login
   - mails#welcome
   - reports#convert_to_hour_minute
   - reports#convert_to_ceiled_hour

--- a/.traceroute.yml
+++ b/.traceroute.yml
@@ -6,9 +6,9 @@ ignore_unused_routes:
 ignore_unreachable_actions:
   - rails\/.*
   - .*#admin_login\?
+  - .*#mentor_login\?
   - .*#admin_or_mentor_login\?
   - .*#adviser_login\?
-  - .*#mentor_login\?
   - .*#staff_login\?
   - .*#student_login\?
   - .*#paid_login\?

--- a/.traceroute.yml
+++ b/.traceroute.yml
@@ -18,10 +18,10 @@ ignore_unreachable_actions:
   - .*#hibernated_or_retired_login\?
   - .*#policy
   - .*#require_active_user_login
-  - .*#require_staff_login
   - .*#require_admin_login
   - .*#require_mentor_login
   - .*#require_admin_or_mentor_login
+  - .*#require_staff_login
   - mails#welcome
   - reports#convert_to_hour_minute
   - reports#convert_to_ceiled_hour

--- a/.traceroute.yml
+++ b/.traceroute.yml
@@ -15,7 +15,7 @@ ignore_unreachable_actions:
   - .*#staff_or_paid_login\?
   - .*#hibernated_login\?
   - .*#retired_login\?
-  - .*#invalid_login\?
+  - .*#hibernated_or_retired_login\?
   - .*#policy
   - .*#require_active_user_login
   - .*#require_staff_login

--- a/.traceroute.yml
+++ b/.traceroute.yml
@@ -10,14 +10,18 @@ ignore_unreachable_actions:
   - .*#adviser_login\?
   - .*#mentor_login\?
   - .*#staff_login\?
+  - .*#student_login\?
   - .*#paid_login\?
   - .*#staff_or_paid_login\?
-  - .*#student_login\?
+  - .*#retired_login\?
+  - .*#hibernated_login\?
   - .*#policy
   - .*#require_staff_login
   - .*#require_admin_login
   - .*#require_mentor_login
   - .*#require_admin_or_mentor_login
+  - .*#refuse_retired_login
+  - .*#refuse_hibernated_login
   - mails#welcome
   - reports#convert_to_hour_minute
   - reports#convert_to_ceiled_hour

--- a/app/controllers/api/admin/base_controller.rb
+++ b/app/controllers/api/admin/base_controller.rb
@@ -2,5 +2,6 @@
 
 class API::Admin::BaseController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
   before_action :require_admin_login_for_api
 end

--- a/app/controllers/api/admin/base_controller.rb
+++ b/app/controllers/api/admin/base_controller.rb
@@ -2,6 +2,7 @@
 
 class API::Admin::BaseController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
   before_action :require_admin_login_for_api
 end

--- a/app/controllers/api/admin/base_controller.rb
+++ b/app/controllers/api/admin/base_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class API::Admin::BaseController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
   before_action :require_admin_login_for_api
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,5 +2,6 @@
 
 class API::BaseController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
   before_action :require_login_for_api
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class API::BaseController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
   before_action :require_login_for_api
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,6 +2,7 @@
 
 class API::BaseController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
   before_action :require_login_for_api
 end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -2,6 +2,7 @@
 
 class API::EventsController < API::BaseController
   before_action :require_login
+  before_action :require_current_student
 
   def index
     @events = Event.with_avatar

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -2,7 +2,8 @@
 
 class API::EventsController < API::BaseController
   before_action :require_login
-  before_action :require_current_student
+  before_action :refuse_retired_login
+  before_action :refuse_hibernated_login
 
   def index
     @events = Event.with_avatar

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class API::EventsController < API::BaseController
-  before_action :require_login
-  before_action :refuse_retired_login
-  before_action :refuse_hibernated_login
+  before_action :require_active_user_login
 
   def index
     @events = Event.with_avatar

--- a/app/controllers/api/generations_controller.rb
+++ b/app/controllers/api/generations_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class API::GenerationsController < API::BaseController
-  before_action :require_login
-  before_action :refuse_retired_login
-  before_action :refuse_hibernated_login
+  before_action :require_active_user_login
   PAGER_NUMBER = 24
 
   def show

--- a/app/controllers/api/generations_controller.rb
+++ b/app/controllers/api/generations_controller.rb
@@ -2,6 +2,7 @@
 
 class API::GenerationsController < API::BaseController
   before_action :require_login
+  before_action :require_current_student
   PAGER_NUMBER = 24
 
   def show

--- a/app/controllers/api/generations_controller.rb
+++ b/app/controllers/api/generations_controller.rb
@@ -2,7 +2,8 @@
 
 class API::GenerationsController < API::BaseController
   before_action :require_login
-  before_action :require_current_student
+  before_action :refuse_retired_login
+  before_action :refuse_hibernated_login
   PAGER_NUMBER = 24
 
   def show

--- a/app/controllers/api/regular_events_controller.rb
+++ b/app/controllers/api/regular_events_controller.rb
@@ -2,7 +2,8 @@
 
 class API::RegularEventsController < API::BaseController
   before_action :require_login
-  before_action :require_current_student
+  before_action :refuse_retired_login
+  before_action :refuse_hibernated_login
 
   def index
     regular_events =

--- a/app/controllers/api/regular_events_controller.rb
+++ b/app/controllers/api/regular_events_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class API::RegularEventsController < API::BaseController
-  before_action :require_login
-  before_action :refuse_retired_login
-  before_action :refuse_hibernated_login
+  before_action :require_active_user_login
 
   def index
     regular_events =

--- a/app/controllers/api/regular_events_controller.rb
+++ b/app/controllers/api/regular_events_controller.rb
@@ -2,6 +2,7 @@
 
 class API::RegularEventsController < API::BaseController
   before_action :require_login
+  before_action :require_current_student
 
   def index
     regular_events =

--- a/app/controllers/api/users/worried_controller.rb
+++ b/app/controllers/api/users/worried_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class API::Users::WorriedController < API::BaseController
-  before_action :require_login
-  before_action :refuse_retired_login
-  before_action :refuse_hibernated_login
+  before_action :require_active_user_login
 
   def index
     @worried_users = User.delayed.order(completed_at: :asc)

--- a/app/controllers/api/users/worried_controller.rb
+++ b/app/controllers/api/users/worried_controller.rb
@@ -2,6 +2,7 @@
 
 class API::Users::WorriedController < API::BaseController
   before_action :require_login
+  before_action :require_current_student
 
   def index
     @worried_users = User.delayed.order(completed_at: :asc)

--- a/app/controllers/api/users/worried_controller.rb
+++ b/app/controllers/api/users/worried_controller.rb
@@ -2,7 +2,8 @@
 
 class API::Users::WorriedController < API::BaseController
   before_action :require_login
-  before_action :require_current_student
+  before_action :refuse_retired_login
+  before_action :refuse_hibernated_login
 
   def index
     @worried_users = User.delayed.order(completed_at: :asc)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,9 +10,7 @@ class ApplicationController < ActionController::Base
   before_action :init_user
   before_action :allow_cross_domain_access
   before_action :set_host_for_disk_storage
-  before_action :require_login
-  before_action :refuse_retired_login
-  before_action :refuse_hibernated_login
+  before_action :require_active_user_login
 
   protected
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,8 @@ class ApplicationController < ActionController::Base
   before_action :allow_cross_domain_access
   before_action :set_host_for_disk_storage
   before_action :require_login
-  before_action :require_current_student
+  before_action :refuse_retired_login
+  before_action :refuse_hibernated_login
 
   protected
 
@@ -48,17 +49,6 @@ class ApplicationController < ActionController::Base
 
   def require_subscription
     redirect_to root_path, notice: 'サブスクリプション登録が必要です。' unless current_user&.subscription?
-  end
-
-  def require_current_student
-    if current_user&.retired_on?
-      logout
-      redirect_to root_path, alert: '退会したユーザーです。'
-    elsif current_user&.hibernated?
-      logout
-      link = view_context.link_to '休会復帰ページ', new_comeback_path, target: '_blank', rel: 'noopener'
-      redirect_to root_path, alert: "休会中です。#{link}から手続きをお願いします。"
-    end
   end
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   before_action :allow_cross_domain_access
   before_action :set_host_for_disk_storage
   before_action :require_login
+  before_action :require_current_student
 
   protected
 
@@ -47,6 +48,17 @@ class ApplicationController < ActionController::Base
 
   def require_subscription
     redirect_to root_path, notice: 'サブスクリプション登録が必要です。' unless current_user&.subscription?
+  end
+
+  def require_current_student
+    if current_user&.retired_on?
+      logout
+      redirect_to root_path, alert: '退会したユーザーです。'
+    elsif current_user&.hibernated?
+      logout
+      link = view_context.link_to '休会復帰ページ', new_comeback_path, target: '_blank', rel: 'noopener'
+      redirect_to root_path, alert: "休会中です。#{link}から手続きをお願いします。"
+    end
   end
 
   protected

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,6 +3,7 @@
 class ArticlesController < ApplicationController
   before_action :set_article, only: %i[show edit update destroy]
   skip_before_action :require_login, raise: false, only: %i[index show]
+  skip_before_action :require_current_student, raise: false, only: %i[index show]
   before_action :require_admin_or_mentor_login, except: %i[index show]
 
   def index

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,9 +2,7 @@
 
 class ArticlesController < ApplicationController
   before_action :set_article, only: %i[show edit update destroy]
-  skip_before_action :require_login, raise: false, only: %i[index show]
-  skip_before_action :refuse_retired_login, raise: false, only: %i[index show]
-  skip_before_action :refuse_hibernated_login, raise: false, only: %i[index show]
+  skip_before_action :require_active_user_login, raise: false, only: %i[index show]
   before_action :require_admin_or_mentor_login, except: %i[index show]
 
   def index

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,7 +3,8 @@
 class ArticlesController < ApplicationController
   before_action :set_article, only: %i[show edit update destroy]
   skip_before_action :require_login, raise: false, only: %i[index show]
-  skip_before_action :require_current_student, raise: false, only: %i[index show]
+  skip_before_action :refuse_retired_login, raise: false, only: %i[index show]
+  skip_before_action :refuse_hibernated_login, raise: false, only: %i[index show]
   before_action :require_admin_or_mentor_login, except: %i[index show]
 
   def index

--- a/app/controllers/comeback_controller.rb
+++ b/app/controllers/comeback_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class ComebackController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def new
     @user = User.new

--- a/app/controllers/comeback_controller.rb
+++ b/app/controllers/comeback_controller.rb
@@ -2,7 +2,8 @@
 
 class ComebackController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def new
     @user = User.new

--- a/app/controllers/comeback_controller.rb
+++ b/app/controllers/comeback_controller.rb
@@ -2,6 +2,7 @@
 
 class ComebackController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def new
     @user = User.new

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -61,16 +61,24 @@ module Authentication
     logged_in? && current_user.hibernated_or_retired?
   end
 
-  def require_mentor_login
-    return if mentor_login?
-
-    redirect_to root_path, alert: 'メンターとしてログインしてください'
+  def require_active_user_login
+    if hibernated_or_retired_login?
+      deny_hibernated_or_retired_login
+    else
+      require_login
+    end
   end
 
   def require_admin_login
     return if admin_login?
 
     redirect_to root_path, alert: '管理者としてログインしてください'
+  end
+
+  def require_mentor_login
+    return if mentor_login?
+
+    redirect_to root_path, alert: 'メンターとしてログインしてください'
   end
 
   def require_admin_or_mentor_login
@@ -83,14 +91,6 @@ module Authentication
     return if staff_login?
 
     redirect_to root_path, alert: '管理者・アドバイザー・メンターとしてログインしてください'
-  end
-
-  def require_active_user_login
-    if hibernated_or_retired_login?
-      deny_hibernated_or_retired_login
-    else
-      require_login
-    end
   end
 
   protected

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -11,7 +11,9 @@ module Authentication
                   :staff_login?,
                   :paid_login?,
                   :staff_or_paid_login?,
-                  :student_login?
+                  :student_login?,
+                  :hibernated_login?,
+                  :retired_login?
   end
 
   def admin_login?
@@ -46,6 +48,14 @@ module Authentication
     logged_in? && current_user.staff_or_paid?
   end
 
+  def hibernated_login?
+    logged_in? && current_user.hibernated?
+  end
+
+  def retired_login?
+    logged_in? && current_user.retired?
+  end
+
   def require_mentor_login
     return if mentor_login?
 
@@ -68,6 +78,21 @@ module Authentication
     return if staff_login?
 
     redirect_to root_path, alert: '管理者・アドバイザー・メンターとしてログインしてください'
+  end
+
+  def refuse_retired_login
+    return unless retired_login?
+
+    logout
+    redirect_to root_path, alert: '退会したユーザーです。'
+  end
+
+  def refuse_hibernated_login
+    return unless hibernated_login?
+
+    logout
+    link = view_context.link_to '休会復帰ページ', new_comeback_path, target: '_blank', rel: 'noopener'
+    redirect_to root_path, alert: "休会中です。#{link}から手続きをお願いします。"
   end
 
   protected

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -12,8 +12,8 @@ module Authentication
                   :student_login?,
                   :paid_login?,
                   :staff_or_paid_login?,
-                  :hibernated_login?,
-                  :retired_login?
+                  :retired_login?,
+                  :hibernated_login?
   end
 
   def admin_login?
@@ -48,12 +48,12 @@ module Authentication
     logged_in? && current_user.staff_or_paid?
   end
 
-  def hibernated_login?
-    logged_in? && current_user.hibernated?
-  end
-
   def retired_login?
     logged_in? && current_user.retired?
+  end
+
+  def hibernated_login?
+    logged_in? && current_user.hibernated?
   end
 
   def require_mentor_login

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -14,7 +14,7 @@ module Authentication
                   :staff_or_paid_login?,
                   :hibernated_login?,
                   :retired_login?,
-                  :invalid_login?
+                  :hibernated_or_retired_login?
   end
 
   def admin_login?
@@ -57,8 +57,8 @@ module Authentication
     logged_in? && current_user.retired?
   end
 
-  def invalid_login?
-    logged_in? && current_user.invalid?
+  def hibernated_or_retired_login?
+    logged_in? && current_user.hibernated_or_retired?
   end
 
   def require_mentor_login
@@ -86,8 +86,8 @@ module Authentication
   end
 
   def require_active_user_login
-    if invalid_login?
-      deny_invalid_login
+    if hibernated_or_retired_login?
+      deny_hibernated_or_retired_login
     else
       require_login
     end
@@ -99,7 +99,7 @@ module Authentication
     redirect_to root_path, alert: 'ログインしてください'
   end
 
-  def deny_invalid_login
+  def deny_hibernated_or_retired_login
     if hibernated_login?
       logout
       link = view_context.link_to '休会復帰ページ', new_comeback_path, target: '_blank', rel: 'noopener'

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -9,9 +9,9 @@ module Authentication
                   :admin_or_mentor_login?,
                   :adviser_login?,
                   :staff_login?,
+                  :student_login?,
                   :paid_login?,
                   :staff_or_paid_login?,
-                  :student_login?,
                   :hibernated_login?,
                   :retired_login?
   end

--- a/app/controllers/connection/git_hub_controller.rb
+++ b/app/controllers/connection/git_hub_controller.rb
@@ -2,6 +2,7 @@
 
 class Connection::GitHubController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def destroy
     current_user.update(github_id: nil)

--- a/app/controllers/connection/git_hub_controller.rb
+++ b/app/controllers/connection/git_hub_controller.rb
@@ -2,7 +2,8 @@
 
 class Connection::GitHubController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def destroy
     current_user.update(github_id: nil)

--- a/app/controllers/connection/git_hub_controller.rb
+++ b/app/controllers/connection/git_hub_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class Connection::GitHubController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def destroy
     current_user.update(github_id: nil)

--- a/app/controllers/events/participations_controller.rb
+++ b/app/controllers/events/participations_controller.rb
@@ -3,7 +3,8 @@
 class Events::ParticipationsController < ApplicationController
   before_action :set_event
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def create
     return if current_user.trainee && @event.job_hunting

--- a/app/controllers/events/participations_controller.rb
+++ b/app/controllers/events/participations_controller.rb
@@ -3,6 +3,7 @@
 class Events::ParticipationsController < ApplicationController
   before_action :set_event
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def create
     return if current_user.trainee && @event.job_hunting

--- a/app/controllers/events/participations_controller.rb
+++ b/app/controllers/events/participations_controller.rb
@@ -2,9 +2,7 @@
 
 class Events::ParticipationsController < ApplicationController
   before_action :set_event
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def create
     return if current_user.trainee && @event.job_hunting

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class GraduationController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]
 

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -2,7 +2,8 @@
 
 class GraduationController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]
 

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -2,6 +2,7 @@
 
 class GraduationController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]
 

--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -2,6 +2,7 @@
 
 class HibernationController < ApplicationController
   skip_before_action :require_login, raise: false, only: %i[show]
+  skip_before_action :require_current_student, raise: false, only: %i[show]
 
   def show; end
 

--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class HibernationController < ApplicationController
-  skip_before_action :require_login, raise: false, only: %i[show]
-  skip_before_action :refuse_retired_login, raise: false, only: %i[show]
-  skip_before_action :refuse_hibernated_login, raise: false, only: %i[show]
+  skip_before_action :require_active_user_login, raise: false, only: %i[show]
 
   def show; end
 

--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -5,7 +5,6 @@ class HibernationController < ApplicationController
   skip_before_action :refuse_retired_login, raise: false
   skip_before_action :refuse_hibernated_login, raise: false
 
-
   def show; end
 
   def new

--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -2,8 +2,8 @@
 
 class HibernationController < ApplicationController
   skip_before_action :require_login, raise: false, only: %i[show]
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :refuse_retired_login, raise: false, only: %i[show]
+  skip_before_action :refuse_hibernated_login, raise: false, only: %i[show]
 
   def show; end
 

--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -2,7 +2,9 @@
 
 class HibernationController < ApplicationController
   skip_before_action :require_login, raise: false, only: %i[show]
-  skip_before_action :require_current_student, raise: false, only: %i[show]
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
+
 
   def show; end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,7 @@
 
 class HomeController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def index
     if current_user

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def index
     if current_user

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,8 @@
 
 class HomeController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def index
     if current_user

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -2,7 +2,8 @@
 
 class InquiriesController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def new
     @inquiry = Inquiry.new

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class InquiriesController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def new
     @inquiry = Inquiry.new

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -2,6 +2,7 @@
 
 class InquiriesController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def new
     @inquiry = Inquiry.new

--- a/app/controllers/job_seek_controller.rb
+++ b/app/controllers/job_seek_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class JobSeekController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]

--- a/app/controllers/job_seek_controller.rb
+++ b/app/controllers/job_seek_controller.rb
@@ -2,6 +2,8 @@
 
 class JobSeekController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
+
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]
 

--- a/app/controllers/job_seek_controller.rb
+++ b/app/controllers/job_seek_controller.rb
@@ -2,7 +2,8 @@
 
 class JobSeekController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]

--- a/app/controllers/mail_notification_controller.rb
+++ b/app/controllers/mail_notification_controller.rb
@@ -2,6 +2,7 @@
 
 class MailNotificationController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def update
     user = User.find_by(unsubscribe_email_token: params[:token])

--- a/app/controllers/mail_notification_controller.rb
+++ b/app/controllers/mail_notification_controller.rb
@@ -2,7 +2,8 @@
 
 class MailNotificationController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def update
     user = User.find_by(unsubscribe_email_token: params[:token])

--- a/app/controllers/mail_notification_controller.rb
+++ b/app/controllers/mail_notification_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class MailNotificationController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def update
     user = User.find_by(unsubscribe_email_token: params[:token])

--- a/app/controllers/mails_controller.rb
+++ b/app/controllers/mails_controller.rb
@@ -2,6 +2,7 @@
 
 class MailsController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
   layout false
 
   def welcome; end

--- a/app/controllers/mails_controller.rb
+++ b/app/controllers/mails_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class MailsController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
   layout false
 
   def welcome; end

--- a/app/controllers/mails_controller.rb
+++ b/app/controllers/mails_controller.rb
@@ -2,7 +2,8 @@
 
 class MailsController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
   layout false
 
   def welcome; end

--- a/app/controllers/notifications/allmarks_controller.rb
+++ b/app/controllers/notifications/allmarks_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class Notifications::AllmarksController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def create
     current_user.mark_all_as_read_and_delete_cache_of_unreads

--- a/app/controllers/notifications/allmarks_controller.rb
+++ b/app/controllers/notifications/allmarks_controller.rb
@@ -2,7 +2,8 @@
 
 class Notifications::AllmarksController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def create
     current_user.mark_all_as_read_and_delete_cache_of_unreads

--- a/app/controllers/notifications/allmarks_controller.rb
+++ b/app/controllers/notifications/allmarks_controller.rb
@@ -2,6 +2,7 @@
 
 class Notifications::AllmarksController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def create
     current_user.mark_all_as_read_and_delete_cache_of_unreads

--- a/app/controllers/notifications/read_by_category_controller.rb
+++ b/app/controllers/notifications/read_by_category_controller.rb
@@ -2,7 +2,8 @@
 
 class Notifications::ReadByCategoryController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def create
     target = params[:target].presence&.to_sym

--- a/app/controllers/notifications/read_by_category_controller.rb
+++ b/app/controllers/notifications/read_by_category_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class Notifications::ReadByCategoryController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def create
     target = params[:target].presence&.to_sym

--- a/app/controllers/notifications/read_by_category_controller.rb
+++ b/app/controllers/notifications/read_by_category_controller.rb
@@ -2,6 +2,7 @@
 
 class Notifications::ReadByCategoryController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def create
     target = params[:target].presence&.to_sym

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,7 +2,8 @@
 
 class PasswordResetsController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def create
     @user = User.find_by(email: params[:email])

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -2,6 +2,7 @@
 
 class PasswordResetsController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def create
     @user = User.find_by(email: params[:email])

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class PasswordResetsController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def create
     @user = User.find_by(email: params[:email])

--- a/app/controllers/practices/completion_controller.rb
+++ b/app/controllers/practices/completion_controller.rb
@@ -2,7 +2,8 @@
 
 class Practices::CompletionController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
   layout 'completion'
 
   def show

--- a/app/controllers/practices/completion_controller.rb
+++ b/app/controllers/practices/completion_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class Practices::CompletionController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
   layout 'completion'
 
   def show

--- a/app/controllers/practices/completion_controller.rb
+++ b/app/controllers/practices/completion_controller.rb
@@ -2,6 +2,7 @@
 
 class Practices::CompletionController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
   layout 'completion'
 
   def show

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -2,6 +2,7 @@
 
 class RegularEvents::ParticipationsController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
   before_action :set_regular_event
 
   def create

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class RegularEvents::ParticipationsController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
   before_action :set_regular_event
 
   def create

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -2,7 +2,8 @@
 
 class RegularEvents::ParticipationsController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
   before_action :set_regular_event
 
   def create

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -5,7 +5,6 @@ class RetirementController < ApplicationController
   skip_before_action :refuse_retired_login, raise: false, only: %i[show]
   skip_before_action :refuse_hibernated_login, raise: false, only: %i[show]
 
-
   def show; end
 
   def new; end

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class RetirementController < ApplicationController
-  skip_before_action :require_login, raise: false, only: %i[show]
-  skip_before_action :refuse_retired_login, raise: false, only: %i[show]
-  skip_before_action :refuse_hibernated_login, raise: false, only: %i[show]
+  skip_before_action :require_active_user_login, raise: false, only: %i[show]
 
   def show; end
 

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -2,6 +2,7 @@
 
 class RetirementController < ApplicationController
   skip_before_action :require_login, raise: false, only: %i[show]
+  skip_before_action :require_current_student, raise: false, only: %i[show]
 
   def show; end
 

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -2,7 +2,9 @@
 
 class RetirementController < ApplicationController
   skip_before_action :require_login, raise: false, only: %i[show]
-  skip_before_action :require_current_student, raise: false, only: %i[show]
+  skip_before_action :refuse_retired_login, raise: false, only: %i[show]
+  skip_before_action :refuse_hibernated_login, raise: false, only: %i[show]
+
 
   def show; end
 

--- a/app/controllers/scheduler_controller.rb
+++ b/app/controllers/scheduler_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class SchedulerController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
   skip_before_action :verify_authenticity_token
   before_action :require_token
 

--- a/app/controllers/scheduler_controller.rb
+++ b/app/controllers/scheduler_controller.rb
@@ -2,6 +2,7 @@
 
 class SchedulerController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
   skip_before_action :verify_authenticity_token
   before_action :require_token
 

--- a/app/controllers/scheduler_controller.rb
+++ b/app/controllers/scheduler_controller.rb
@@ -2,7 +2,8 @@
 
 class SchedulerController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
   skip_before_action :verify_authenticity_token
   before_action :require_token
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,5 +2,6 @@
 
 class StaticPagesController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,4 +2,5 @@
 
 class StaticPagesController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 class StaticPagesController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 end

--- a/app/controllers/stripe/webhooks_controller.rb
+++ b/app/controllers/stripe/webhooks_controller.rb
@@ -3,7 +3,8 @@
 class Stripe::WebhooksController < ApplicationController
   protect_from_forgery
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def create
     event = Webhook.construct_event(

--- a/app/controllers/stripe/webhooks_controller.rb
+++ b/app/controllers/stripe/webhooks_controller.rb
@@ -3,6 +3,7 @@
 class Stripe::WebhooksController < ApplicationController
   protect_from_forgery
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def create
     event = Webhook.construct_event(

--- a/app/controllers/stripe/webhooks_controller.rb
+++ b/app/controllers/stripe/webhooks_controller.rb
@@ -2,9 +2,7 @@
 
 class Stripe::WebhooksController < ApplicationController
   protect_from_forgery
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def create
     event = Webhook.construct_event(

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   def new
     @user = User.new

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class UserSessionsController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   def new
     @user = User.new

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -2,7 +2,8 @@
 
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   def new
     @user = User.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@
 
 class UsersController < ApplicationController
   skip_before_action :require_login, raise: false, only: %i[new create]
+  skip_before_action :require_current_student, raise: false, only: %i[new create]
   before_action :require_token, only: %i[new] if Rails.env.production?
   before_action :set_user, only: %w[show]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,8 @@
 
 class UsersController < ApplicationController
   skip_before_action :require_login, raise: false, only: %i[new create]
-  skip_before_action :require_current_student, raise: false, only: %i[new create]
+  skip_before_action :refuse_retired_login, raise: false, only: %i[new create]
+  skip_before_action :refuse_hibernated_login, raise: false, only: %i[new create]
   before_action :require_token, only: %i[new] if Rails.env.production?
   before_action :set_user, only: %w[show]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  skip_before_action :require_login, raise: false, only: %i[new create]
-  skip_before_action :refuse_retired_login, raise: false, only: %i[new create]
-  skip_before_action :refuse_hibernated_login, raise: false, only: %i[new create]
+  skip_before_action :require_active_user_login, raise: false, only: %i[new create]
   before_action :require_token, only: %i[new] if Rails.env.production?
   before_action :set_user, only: %w[show]
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,6 +2,7 @@
 
 class WelcomeController < ApplicationController
   skip_before_action :require_login, raise: false
+  skip_before_action :require_current_student, raise: false
 
   layout 'welcome'
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,7 +2,8 @@
 
 class WelcomeController < ApplicationController
   skip_before_action :require_login, raise: false
-  skip_before_action :require_current_student, raise: false
+  skip_before_action :refuse_retired_login, raise: false
+  skip_before_action :refuse_hibernated_login, raise: false
 
   layout 'welcome'
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class WelcomeController < ApplicationController
-  skip_before_action :require_login, raise: false
-  skip_before_action :refuse_retired_login, raise: false
-  skip_before_action :refuse_hibernated_login, raise: false
+  skip_before_action :require_active_user_login, raise: false
 
   layout 'welcome'
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -550,7 +550,7 @@ class User < ApplicationRecord
     retired_on?
   end
 
-  def invalid?
+  def hibernated_or_retired?
     hibernated_at? || retired_on?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -550,6 +550,10 @@ class User < ApplicationRecord
     retired_on?
   end
 
+  def invalid?
+    hibernated_at? || retired_on?
+  end
+
   def graduated?
     graduated_on?
   end


### PR DESCRIPTION
## Issue
- #5928 

## 概要
休会中・退会済みユーザーがログインが必要なページを閲覧できてしまうバグを解消しました。

- 休会・退会操作をした場合、操作を行ったブラウザではログインが必要なページが閲覧できなくなりますが、休会・退会以前にログインしていた別ブラウザからは引き続きログインが必要なページを閲覧できてしまう問題がありました。
- ログインが必要などのページにアクセスしてもユーザーが現在休会・退会しているかチェックして、休会・退会していたら強制ログアウトをしてトップページにリダイレクトするようにしました。

## 変更確認方法
- この動作確認では複数ブラウザを使用します。
@sadanora はchromeとFirefoxで確認したので便宜的にchrome側とFirefox側操作に分けて手順を記載しますが、chrome&safariなどで動作確認いただいても大丈夫です。

### 手順
1. `bug/hibernated-or-retired-users-can-access-pages-for-required-login`をローカルに取り込む
2. `bin/rails s`でブートキャンプアプリを立ち上げる
3. 休会ユーザーの動作確認
      ##### chromeで操作
      1. 任意の現役生アカウントでログイン
      ##### Firefoxで操作
      2. 手順3と同じユーザーでログイン
      3. 右上の`Me`から**休会**手続きを行う
      ##### chromeで操作
      4. ログインが必要なページを開こうとするとトップにリダイレクトされ、「休会中です。休会復帰ページから手続きをお願いします。」というアラート文が表示されることを確認する
    
4. 退会ユーザーの動作確認
      ##### chromeで操作
      1. 任意の現役生アカウントでログイン
      ##### Firefoxで操作
      2. 手順7と同じユーザーでログイン
      3. 右上の`Me`から**退会**手続きを行う
      ##### chromeで操作
      4. ログインが必要なページを開こうとするとトップにリダイレクトされ、「退会したユーザーです。」というアラート文が表示されることを確認する
    
## Screenshot
### 変更前
https://user-images.githubusercontent.com/66685066/211139563-ab4fd554-42fc-4a24-b6b2-467ea590e49a.mov

### 変更後
https://user-images.githubusercontent.com/66685066/211139633-c6e8e544-38d0-42be-bcb1-b89808de3550.mov


