### PR TITLE
未アサインのDiscord通知の並び順を経過日数が大きいものほど先にする

### DIFF
--- a/app/views/api/products/unassigned/counts.text.erb
+++ b/app/views/api/products/unassigned/counts.text.erb
@@ -2,14 +2,14 @@
 提出されてから日数が経っている提出物の数をお知らせします。
 https://bootcamp.fjord.jp/products/unassigned
 
-<% if @passed5 > 0 %>
-- 5日経過：<%= @passed5 %>件
+<% if @over7 > 0 %>
+- 7日以上経過：<%= @over7 %>件
 <% end %>
 <% if @passed6 > 0 %>
 - 6日経過：<%= @passed6 %>件
 <% end %>
-<% if @over7 > 0 %>
-- 7日以上経過：<%= @over7 %>件
+<% if @passed5 > 0 %>
+- 5日経過：<%= @passed5 %>件
 <% end %>
 
 <% else %>

--- a/test/integration/api/products/unassigned_counts_test.rb
+++ b/test/integration/api/products/unassigned_counts_test.rb
@@ -6,6 +6,8 @@ class API::Products::UnassignedTextTest < ActionDispatch::IntegrationTest
   fixtures :products
 
   test 'GET /api/products/unassigned/counts.txt' do
+    products(:product15).update_column(:checker_id, nil)  # rubocop:disable Rails/SkipsModelValidations
+
     get counts_api_products_unassigned_index_path(format: :text)
     assert_response :unauthorized
 
@@ -13,8 +15,12 @@ class API::Products::UnassignedTextTest < ActionDispatch::IntegrationTest
     get counts_api_products_unassigned_index_path(format: :text),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    assert_match '5日経過：1件', response.body
-    assert_match '6日経過：1件', response.body
-    assert_match '7日以上経過：6件', response.body
+
+    expected = <<~BODY
+      - 7日以上経過：6件
+      - 6日経過：2件
+      - 5日経過：1件
+    BODY
+    assert response.body.include?(expected)
   end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -535,9 +535,12 @@ class ProductsTest < ApplicationSystemTestCase
 
     visit_with_auth '/api/products/unassigned/counts.txt', 'komagata'
 
-    assert_text '5日経過：1件'
-    assert_text '6日経過：1件'
-    assert_text '7日以上経過：5件'
+    expected = <<~BODY
+      - 7日以上経過：5件
+      - 6日経過：1件
+      - 5日経過：1件
+    BODY
+    assert page.body.include?(expected)
   end
 
   test 'no company trainee create product' do


### PR DESCRIPTION
## Issue

- #5910

## 概要

メンター向けのDiscord通知で使用されている Web API の出力内容に関するプルリクエストです。
現状は未アサインの提出物があれば経過日数が5日経過、6日経過、7日以上経過の順で出力されます。
今後は緊急度の高いものが先になるため、7日以上経過、6日経過、5日経過の順で出力されます。

なお類似する Web API で `/api/products/passed.txt` が存在しますが、こちらは議題の範囲外と認識しています。

## 変更確認方法

1. `feature/change-order-by-unassigned-products-for-discord-notification` をローカルに取り込みます
2. `bundle exec rails db:drop` を実行します
3. `bin/setup` を実行します
4. `bin/rails s` でサーバーを立ち上げます
5. mentormentaro でログインします
6. ブラウザで http://localhost:3000/api/products/unassigned/counts.txt にアクセスします
7. 次の内容が表示されていること
```
提出されてから日数が経っている提出物の数をお知らせします。
https://bootcamp.fjord.jp/products/unassigned

- 7日以上経過：7件
- 6日経過：1件
- 5日経過：2件
```

## Screenshot

### 変更前

![before](https://user-images.githubusercontent.com/943541/211148473-f0fb51e4-a758-4357-b83d-87a0966dea0f.png)

### 変更後

![after](https://user-images.githubusercontent.com/943541/211148479-97f7afcf-472c-481b-ba06-1268099f794c.png)

## その他

### 関連するプルリクエスト

- #4136
- #4559

### Discordへ通知する部分について

- https://github.com/fjordllc/bootcamp/issues/4716#issuecomment-1111043457
