### PR TITLE
unconfirmed_link.vue, user-icon.vueをreactに対応させる

### DIFF
--- a/app/javascript/components/UnconfirmedLink.jsx
+++ b/app/javascript/components/UnconfirmedLink.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+export default class UnconfirmedLink extends React.Component {
+  openUnconfirmedItems() {
+    const links = document.querySelectorAll(
+      '.card-list-item .js-unconfirmed-link'
+    )
+    links.forEach((link) => {
+      window.open(link.href, '_target', 'noopener')
+    })
+  }
+
+  render() {
+    return (
+      <div className="card-footer">
+        <div className="card-main-actions">
+         <ul className="card-main-actions__items">
+           <li className="card-main-actions__item">
+             <button className="thread-unconfirmed-links-form__action a-button is-block is-sm is-secondary"
+              onClick={() => this.openUnconfirmedItems()}
+            >{this.props.label}</button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/javascript/unconfirmed_link.vue
+++ b/app/javascript/unconfirmed_link.vue
@@ -1,25 +1,17 @@
 <template lang="pug">
-.card-footer
-  .card-main-actions
-    ul.card-main-actions__items
-      li.card-main-actions__item
-        button.thread-unconfirmed-links-form__action.a-button.is-sm.is-block.is-secondary(
-          @click='openUnconfirmedItems()') {{ label }}
+.react-root
 </template>
 <script>
+import React from 'react'
+import { render } from 'react-dom'
+import UnconfirmedLink from 'components/UnconfirmedLink'
+
 export default {
   props: {
     label: { type: String, required: true }
   },
-  methods: {
-    openUnconfirmedItems() {
-      const links = document.querySelectorAll(
-        '.card-list-item .js-unconfirmed-link'
-      )
-      links.forEach((link) => {
-        window.open(link.href, '_target', 'noopener')
-      })
-    }
+  mounted() {
+    render(<UnconfirmedLink label={this.label} />, this.$el)
   }
 }
 </script>

--- a/app/javascript/user-icon.vue
+++ b/app/javascript/user-icon.vue
@@ -1,25 +1,18 @@
 <template lang="pug">
-a(:href='user.url', :class='`${blockClass}user-link`')
-  img(
-    :src='user.avatar_url',
-    :alt='user.icon_title',
-    :title='user.icon_title',
-    :class='[`${blockClass}user-icon`, "a-user-icon", roleClass]')
+.react-root
 </template>
-
 <script>
+import React from 'react'
+import { render } from 'react-dom'
+import UserIcon from 'components/UserIcon'
+
 export default {
   props: {
     user: { type: Object, required: true },
     blockClassSuffix: { type: String, required: true }
   },
-  computed: {
-    blockClass: function () {
-      return `${this.blockClassSuffix}__`
-    },
-    roleClass: function () {
-      return `is-${this.user.primary_role}`
-    }
+  mounted() {
+    render(<UserIcon user={this.user} blockClassSuffix={this.blockClassSuffix} />, this.$el)
   }
 }
 </script>


### PR DESCRIPTION
## Issue

- #5144

## 概要

次の vue コンポーネントを react に変えるプルリクエストです。

- `app/javascript/unconfirmed_link.vue`
- `app/javascript/user-icon.vue`

なお問題点としては `unconfirmed_link.vue` を使用している `app/javascript/components/reports.vue` では [v-if='isUncheckedReportsPage'](https://github.com/fjordllc/bootcamp/blob/main/app/javascript/components/reports.vue#L33) で描画有無を判断しており、動的は要素の書き替えが発生します。
そのため、react コンポーネントを単純に描画すればよいわけではない。

上記の問題点からこのプルリクエストで達成する課題点を次のようにしました。

1. `app/javascript/components` に react に変えたコンポーネントを作成する
    - `UnconfirmedLink.jsx` （今回新規作成）
    - `UserIcon.jsx` （ #5912 で作成いただいていました ）
2. 既存の vue コンポーネントは 1.で作成した react コンポーネントに props を委譲し、描画するだけにする
    - ただし、react コンポーネント描画用の意味のない `div.react-root` が追加される

## 変更確認方法

1. `feature/change-from-vue-to-react-for-unconfirmed_link-and-user-icon` をローカルに取り込みます
4. `bundle exec rails db:drop` を実行します
5. `bin/setup` を実行します
6. `bin/rails s` でサーバーを立ち上げます
7. `TODO` でログインします
8. TODO

## Screenshot

### 変更前

### 変更後

## その他

### 参考情報

- TODO

### 類似するプルリクエスト

- TODO

