### PR TITLE
お知らせ投稿通知をactive_delivery化した

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -10,8 +10,6 @@ class ActivityMailer < ApplicationMailer
     @announcement = params[:announcement] if params&.key?(:announcement)
   end
 
-  after_action :prevent_delivery
-
   # required params: sender, receiver
   def graduated(args = {})
     @sender ||= args[:sender]
@@ -53,12 +51,9 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:announced]
     )
     subject = "[FBC] お知らせ「#{@announcement.title}」"
-    mail to: @user.email, subject: subject
-  end
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
 
-  private
-
-  def prevent_delivery
-    mail.perform_deliveries = @user.mail_notification? && !@user.retired?
+    message
   end
 end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -46,7 +46,7 @@ class ActivityMailer < ApplicationMailer
     @announcement ||= args[:announcement]
 
     @user = @receiver
-    @link_url = notification_redirector_path(
+    @link_url = notification_redirector_url(
       link: "/announcements/#{@announcement.id}",
       kind: Notification.kinds[:announced]
     )

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -53,13 +53,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: "[FBC] #{@message}"
   end
 
-  # required params: announcement, receiver
-  def post_announcement
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/announcements/#{@announcement.id}")
-    mail to: @user.email, subject: "[FBC] お知らせ「#{@announcement.title}」"
-  end
-
   # required params: question, receiver
   def came_question
     @user = @receiver

--- a/app/models/announcement_notifier.rb
+++ b/app/models/announcement_notifier.rb
@@ -12,7 +12,7 @@ class AnnouncementNotifier
     target_users.each do |target|
       next if announce.sender == target
 
-      NotificationFacade.post_announcement(announce, target)
+      ActivityDelivery.with(announcement: announce, receiver: target).notify(:post_announcement)
     end
   end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -46,16 +46,6 @@ class NotificationFacade
     ).submitted.deliver_later(wait: 5)
   end
 
-  def self.post_announcement(announce, receiver)
-    ActivityNotifier.with(announce: announce, receiver: receiver).post_announcement.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      announcement: announce,
-      receiver: receiver
-    ).post_announcement.deliver_later(wait: 5)
-  end
-
   def self.came_question(question, receiver)
     ActivityNotifier.with(question: question, receiver: receiver).came_question.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -129,7 +129,7 @@ class ActivityNotifier < ApplicationNotifier
 
   def post_announcement(params = {})
     params.merge!(@params)
-    announce = params[:announce]
+    announce = params[:announcement]
     receiver = params[:receiver]
 
     notification(

--- a/app/views/activity_mailer/post_announcement.html.slim
+++ b/app/views/activity_mailer/post_announcement.html.slim
@@ -1,0 +1,5 @@
+= render '/notification_mailer/notification_mailer_template',
+  title: @announcement.title,
+  link_url: @link_url,
+  link_text: 'このお知らせへ' do
+  = md2html(@announcement.description)

--- a/app/views/notification_mailer/post_announcement.html.slim
+++ b/app/views/notification_mailer/post_announcement.html.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: @announcement.title, link_url: notification_url(@notification), link_text: 'このお知らせへ' do
-  = md2html(@announcement.description)

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -109,10 +109,11 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 5, link: "/announcements/#{announce.id}"}.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
     assert_equal '[FBC] お知らせ「お知らせ1」', email.subject
-    assert_match(/お知らせ本文1/, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">このお知らせへ</a>}, email.body.to_s)
   end
 
   test 'post_announcement with params' do
@@ -129,10 +130,11 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 5, link: "/announcements/#{announce.id}"}.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
     assert_equal '[FBC] お知らせ「お知らせ1」', email.subject
-    assert_match(/お知らせ本文1/, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">このお知らせへ</a>}, email.body.to_s)
   end
 
   test 'post_announcement to mute email notification or retired user' do

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -98,4 +98,73 @@ class ActivityMailerTest < ActionMailer::TestCase
     ActivityMailer.came_answer(answer: answer.reload).deliver_now
     assert_not ActionMailer::Base.deliveries.empty?
   end
+
+  test 'post_announcement' do
+    announce = announcements(:announcement1)
+    receiver = users(:sotugyou)
+    ActivityMailer.post_announcement(
+      announcement: announce,
+      receiver: receiver
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['sotugyou@example.com'], email.to
+    assert_equal '[FBC] お知らせ「お知らせ1」', email.subject
+    assert_match(/お知らせ本文1/, email.body.to_s)
+  end
+
+  test 'post_announcement with params' do
+    announce = announcements(:announcement1)
+    receiver = users(:sotugyou)
+    mailer = ActivityMailer.with(
+      announcement: announce,
+      receiver: receiver
+    ).post_announcement
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['sotugyou@example.com'], email.to
+    assert_equal '[FBC] お知らせ「お知らせ1」', email.subject
+    assert_match(/お知らせ本文1/, email.body.to_s)
+  end
+
+  test 'post_announcement to mute email notification or retired user' do
+    announce = announcements(:announcement1)
+    receiver = users(:sotugyou)
+
+    receiver.update_columns(mail_notification: false, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
+    ActivityMailer.post_announcement(
+      announcement: announce,
+      receiver: receiver
+    ).deliver_now
+    assert ActionMailer::Base.deliveries.empty?
+
+    receiver.update_columns(mail_notification: false, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
+    ActivityMailer.post_announcement(
+      announcement: announce,
+      receiver: receiver
+    ).deliver_now
+    assert ActionMailer::Base.deliveries.empty?
+
+    receiver.update_columns(mail_notification: true, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
+    ActivityMailer.post_announcement(
+      announcement: announce,
+      receiver: receiver
+    ).deliver_now
+    assert ActionMailer::Base.deliveries.empty?
+
+    receiver.update_columns(mail_notification: true, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
+    ActivityMailer.post_announcement(
+      announcement: announce,
+      receiver: receiver
+    ).deliver_now
+    assert_not ActionMailer::Base.deliveries.empty?
+  end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -109,7 +109,7 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
-    query = CGI.escapeHTML({ kind: 5, link: "/announcements/#{announce.id}"}.to_param)
+    query = CGI.escapeHTML({ kind: 5, link: "/announcements/#{announce.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
     assert_equal '[FBC] お知らせ「お知らせ1」', email.subject
@@ -130,7 +130,7 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
-    query = CGI.escapeHTML({ kind: 5, link: "/announcements/#{announce.id}"}.to_param)
+    query = CGI.escapeHTML({ kind: 5, link: "/announcements/#{announce.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
     assert_equal '[FBC] お知らせ「お知らせ1」', email.subject

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -81,26 +81,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/提出/, email.body.to_s)
   end
 
-  test 'post_announcement' do
-    announce = announcements(:announcement1)
-    announced = notifications(:notification_announced)
-    mailer = NotificationMailer.with(
-      announcement: announce,
-      receiver: announced.user
-    ).post_announcement
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[FBC] お知らせ「お知らせ1」', email.subject
-    assert_match(/お知らせ/, email.body.to_s)
-  end
-
   test 'came_question' do
     question = questions(:question2)
     questioned = notifications(:notification_questioned)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -16,4 +16,14 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(answer: answer).came_answer
   end
+
+  def post_announcement
+    announce = Announcement.find(ActiveRecord::FixtureSet.identify(:announcement1))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:sotugyou))
+
+    ActivityMailer.with(
+      announcement: announce,
+      receiver: receiver
+    ).post_announcement
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -41,16 +41,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     ).submitted
   end
 
-  def post_announcement
-    announce = Announcement.find(ActiveRecord::FixtureSet.identify(:announcement1))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:sotugyou))
-
-    NotificationMailer.with(
-      announcement: announce,
-      receiver: receiver
-    ).post_announcement
-  end
-
   def came_question
     question = Question.find(ActiveRecord::FixtureSet.identify(:question2))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:sotugyou))

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -63,7 +63,7 @@ class ActivityNotifierTest < ActiveSupport::TestCase
   end
 
   test '#announcement' do
-    notification = ActivityNotifier.with(announce: announcements(:announcement1), receiver: users(:kimura)).post_announcement
+    notification = ActivityNotifier.with(announcement: announcements(:announcement1), receiver: users(:kimura)).post_announcement
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       notification.notify_now


### PR DESCRIPTION
## Issue

- #5879

## 概要
お知らせ投稿通知をactive_delivery化しました。
確認通知は、サイト内通知と、メール通知の2種類が飛びます。
## 変更確認方法

1. `feature/use-active-delivery-for-announcement-post-notification`をローカルに取り込む
2. `bin/rails s`でサーバーを立ち上げる
3. 別々のブラウザ（シークレットモードなどで）で2つのユーザーにログインする
    - `komagata`でログインする（お知らせを投稿するユーザー）
    - `kimura`でログインする（お知らせを受け取るユーザー）
4. `komagata`で`localhost:3000/announcements/new`にアクセスし、タイトルと内容に任意の文字を打ち込んで、投稿する
5. `kimura`で`localhost:3000/notifications`にアクセスし、`komagata`で投稿したお知らせ通知があることを確認する
6. `localhost:3000/letter_opener`にアクセスし、`komagata`で投稿したお知らせ通知があることを確認する
7. kimuraで`http://localhost:3000/current_user/edit`にアクセスし、メール通知をOFFにして更新する
8. 再び`komagata`で`localhost:3000/announcements/new`にアクセスし、タイトルと内容に任意の文字を打ち込んで、投稿する
9. `localhost:3000/letter_opener`にアクセスし、`komagata`で投稿したお知らせ通知がないことを確認する

## Screenshot

画面上の変更はありません。

