### PR TITLE
イベント作成ページの会場の入力欄にプレースホルダを設置した

### DIFF
--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -7,7 +7,7 @@
         = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'ミートアップ2022年12月'
       .form-item
         = f.label :location, class: 'a-form-label'
-        = f.text_field :location, class: 'a-text-input js-warning-form'
+        = f.text_field :location, class: 'a-text-input js-warning-form', placeholder: 'オンライン（Remo: https://live.remo.co/e/XXXXX）'
       .form-item
         = f.label :capacity, class: 'a-form-label'
         = f.text_field :capacity, class: 'a-text-input js-warning-form'


### PR DESCRIPTION
## Issue

- #6020 

## 概要
イベント作成ページの会場の入力欄にプレースホルダを設置しました。

## 変更確認方法

1. `feature/placeholder-of-venue-on-event-creation-page`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. イベント作成ページ（`/events/new`）を表示する

## Screenshot

### 変更前

![スクリーンショット_20230112_061142](https://user-images.githubusercontent.com/93074851/211932975-a9a9f701-4d86-48ab-a624-edc6a1bbbcd8.png)


### 変更後
![スクリーンショット_20230112_072408](https://user-images.githubusercontent.com/93074851/211933073-63a94634-b326-4cb6-94ba-ff6e558f4e65.png)

