### PR TITLE
イベント個別ページにもタブを表示するように変更した

### DIFF
--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -16,6 +16,8 @@ header.page-header
             = link_to events_path, class: 'a-button is-md is-secondary is-block is-back' do
               | イベント一覧
 
+= render 'events/tabs'
+
 - if @event.wip?
   .a-page-notice.is-danger
     .container.is-lg


### PR DESCRIPTION
## Issue

- #6022 

## 概要
イベント一覧ページと同様に、イベント個別ページにもタブを表示するように変更しました。

## 変更確認方法

1. `feature/change-top-of-individual-event-page`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. イベント一覧画面（`/events`）に行き、それぞれのイベントをクリックしてイベント個別ページを表示する

## Screenshot

### 変更前


![スクリーンショット_20230112_085442](https://user-images.githubusercontent.com/93074851/211948009-7be17831-4205-490d-b01b-20b2426951c8.png)

### 変更後



![スクリーンショット_20230112_091818](https://user-images.githubusercontent.com/93074851/211948015-134f3c0a-f264-42c9-bdd2-626939eb355e.png)
