### PR TITLE
定期イベントにコメントができないバグを修正

### DIFF
--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -22,7 +22,7 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def create_watch
-    return if @regular_event.watched?(current_user)
+    return if @regular_event.watched_by?(current_user)
 
     watch = Watch.new(
       user: current_user,

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -132,7 +132,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     regular_event_participation.destroy
   end
 
-  def watched?(user)
+  def watched_by?(user)
     watches.exists?(user_id: user.id)
   end
 

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -66,7 +66,7 @@ class RegularEventTest < ActiveSupport::TestCase
     assert_not regular_event.regular_event_participations.find_by(user_id: participant.id)
   end
 
-  test '#watched' do
+  test '#watched_by?' do
     regular_event = regular_events(:regular_event1)
     user = users(:kimura)
     assert_not regular_event.watched_by?(user)

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -69,10 +69,10 @@ class RegularEventTest < ActiveSupport::TestCase
   test '#watched' do
     regular_event = regular_events(:regular_event1)
     user = users(:kimura)
-    assert_not regular_event.watched?(user)
+    assert_not regular_event.watched_by?(user)
 
     watch = Watch.new(user: user, watchable: regular_event)
     watch.save
-    assert regular_event.watched?(user)
+    assert regular_event.watched_by?(user)
   end
 end


### PR DESCRIPTION
## Issue

- #5777

## 概要

定期イベントにコメントができないバグを修正

## 変更確認方法

1. `bug/fix-comment-issue-on-regular-events`をローカルに取り込む
2. ログインする。
3. `http://127.0.0.1:3000/regular_events` にアクセス。
4. 適当な定期イベントをクリック。
5. コメントを入力し、「コメントする」をクリック。

## Screenshot

### 変更前
![chrome_ZVGuC76M2A](https://user-images.githubusercontent.com/52590443/211962583-4f83c4bc-93eb-47aa-a8eb-f8369c0326b5.gif)

### 変更後
![chrome_N6tXfueWyJ](https://user-images.githubusercontent.com/52590443/211962591-9e15ee56-a46d-4196-938c-214caf6f3640.gif)
