### PR TITLE
イベント作成ページの定員にプレースホルダを設定

### DIFF
--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -10,7 +10,7 @@
         = f.text_field :location, class: 'a-text-input js-warning-form'
       .form-item
         = f.label :capacity, class: 'a-form-label'
-        = f.text_field :capacity, class: 'a-text-input js-warning-form'
+        = f.text_field :capacity, class: 'a-text-input js-warning-form', placeholder: '100'
       .form-item
         = f.label :start_at, class: 'a-form-label'
         = f.datetime_field :start_at, class: 'a-text-input js-warning-form'


### PR DESCRIPTION
## Issue

- #6021

## 概要
イベント作成ページの定員にプレースホルダを設定しました。
## 変更確認方法

1. ブランチ `feature/add_placeholder` をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. [http://localhost:3000/events/new](http://localhost:3000/events/new) にアクセスする
## Screenshot

### 変更前
<img width="1208" alt="add_placeholder_before" src="https://user-images.githubusercontent.com/76797372/212110067-0ef29d31-0adc-4e3e-98ae-7b6497b13779.png">

### 変更後
<img width="1258" alt="add_placeholder_after" src="https://user-images.githubusercontent.com/76797372/212110112-822b19e0-c9af-4745-be89-b4205c249d38.png">

