### PR TITLE
個人の日報一覧をプラクティスで絞り込めるようにした

### DIFF
--- a/app/javascript/components/CommentUserIcon.jsx
+++ b/app/javascript/components/CommentUserIcon.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function CommentUserIcon({comment}) {
+  return (
+    <a className="card-list-item__user-icons-icon" href={`/users/${comment.user_id}`}>
+      <img className="a-user-icon" src={comment.user_icon} />
+    </a>
+  )
+}

--- a/app/javascript/components/ListComment.jsx
+++ b/app/javascript/components/ListComment.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import CommentUserIcon from './CommentUserIcon'
+
+export default function ListComment({ report }) {
+  return (
+    <>
+      <hr className="card-list-item__row-separator"></hr>
+      <div className="card-list-item__row">
+        <div className="card-list-item-meta">
+          <div className="card-list-item-meta__items">
+            <div className="card-list-item-meta__item">
+              <div className="a-meta">
+                コメント（{report.numberOfComments}）
+              </div>
+            </div>
+            <div className="card-list-item-meta__item">
+              <div className="card-list-item__user-icons">
+                {report.comments.map((comment) => {
+                  return (
+                    <CommentUserIcon comment={comment} key={comment.user_id} />
+                  )
+                })}
+              </div>
+            </div>
+            <div className="card-list-item-meta__item">
+              <time
+                className="a-meta"
+                dateTime={report.lastCommentDatetime}
+                pubdate="'pubdate'">{`〜 ${report.lastCommentDate}`}</time>
+            </div>
+            <div className="card-list-item-meta__item"></div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/javascript/components/PracticeFilterDropdown.jsx
+++ b/app/javascript/components/PracticeFilterDropdown.jsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect, useRef } from 'react'
+import Choices from 'choices.js'
+
+export default function PracticeFilterDropdown({
+  practices,
+  setPracticeId,
+  practiceId
+}) {
+  const [selectedId, setSelectedId] = useState(practiceId)
+
+  const onChange = (event) => {
+    const value = event.target.value
+    setSelectedId(value)
+    setPracticeId(value)
+  }
+
+  const selectRef = useRef(null)
+
+  useEffect(() => {
+    const selectElement = selectRef.current
+    const choicesInstance = new Choices(selectElement, {
+      searchEnabled: true,
+      allowHTML: true,
+      searchResultLimit: 20,
+      searchPlaceholderValue: '検索ワード',
+      noResultsText: '一致する情報は見つかりません',
+      itemSelectText: '選択',
+      shouldSort: false
+    })
+
+    return () => {
+      choicesInstance.destroy()
+    }
+  }, [])
+
+  return (
+    <>
+      <nav className="page-filter form">
+        <div className="container is-md">
+          <div className="form-item is-inline-md-up">
+            <label className="a-form-label" htmlFor="js-choices-single-select">
+              プラクティスで絞り込む
+            </label>
+            <select
+              className="a-form-select"
+              onChange={onChange}
+              ref={selectRef}
+              value={selectedId}
+              id="js-choices-single-select">
+              <option key="" value="">
+                全ての日報を表示
+              </option>
+              {practices.map((practice) => {
+                return (
+                  <option key={practice.id} value={practice.id}>
+                    {practice.title}
+                  </option>
+                )
+              })}
+            </select>
+          </div>
+        </div>
+      </nav>
+    </>
+  )
+}

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -68,7 +68,7 @@ export default function Report({report, currentUser}){
 const ReportListItemActions = ({ report }) => {
   return (
     <div className="card-list-item-title__end">
-      <label className="card-list-item-actions__trigger" for={report.id}></label>
+      <label className="card-list-item-actions__trigger" htmlFor={report.id}></label>
       <div className="card-list-item-actions">
         <input className="a-toggle-checkbox" type="checkbox" id={report.id} />
         <div className="card-list-item-actions__inner">
@@ -84,7 +84,7 @@ const ReportListItemActions = ({ report }) => {
               </a>
             </li>
           </ul>
-          <label className="a-overlay" for={report.id}></label>
+          <label className="a-overlay" htmlFor={report.id}></label>
         </div>
       </div>
     </div>

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -60,7 +60,7 @@ export default function Report({ report, currentUser }) {
             {report.hasAnyComments && <ListComment report={report} />}
           </div>
         </div>
-        {report.hascheck && (
+        {report.hasCheck && (
           <div className="stamp stamp-approve">
             <h2 className="stamp__content is-title">確認済</h2>
             <time className="stamp__content is-created-at">

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -80,11 +80,12 @@ const ReportListItemActions = ({ report }) => {
   return (
     <div className="card-list-item-title__end">
       <label className="card-list-item-actions__trigger" htmlFor={report.id}>
+        <i className="fa-solid fa-ellipsis-h"></i>
       </label>
       <div className="card-list-item-actions">
         <input className="a-toggle-checkbox" type="checkbox" id={report.id} />
         <div className="card-list-item-actions__inner">
-          <ul>
+          <ul className="card-list-item-actions__items">
             <li className="card-list-item-actions__item">
               <a
                 className="card-list-item-actions__action"

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -1,14 +1,19 @@
 import React from 'react'
 import ListComment from './ListComment'
 
-export default function Report({report, currentUser}){
+export default function Report({ report, currentUser }) {
   return (
-    <div className={`card-list-item ${report.wip ? "is-wip" : ""}`}>
+    <div className={`card-list-item ${report.wip ? 'is-wip' : ''}`}>
       <div className="card-list-item__inner">
         <div className="card-list-item__user">
           <a href={report.user.url} className="card-list-item__user-link">
-            <span className="[&quot;a-user-role&quot;, roleClass]">
-              <img className="card-list-item__user-icon a-user-icon" src={report.user.avatar_url} title={report.user.login_name} alt={report.user.login_name} />
+            <span className='["a-user-role", roleClass]'>
+              <img
+                className="card-list-item__user-icon a-user-icon"
+                src={report.user.avatar_url}
+                title={report.user.login_name}
+                alt={report.user.login_name}
+              />
             </span>
           </a>
         </div>
@@ -22,12 +27,18 @@ export default function Report({report, currentUser}){
                   </div>
                 )}
                 <h2 className="card-list-item-title__title">
-                  <a className="card-list-item-title__link a-text-link js-unconfirmed-link" href={report.url}>
-                    <img className="card-list-item-title__emotion-image" src={`/images/emotion/${report.emotion}.svg`} alt={report.emotion} />
+                  <a
+                    className="card-list-item-title__link a-text-link js-unconfirmed-link"
+                    href={report.url}>
+                    <img
+                      className="card-list-item-title__emotion-image"
+                      src={`/images/emotion/${report.emotion}.svg`}
+                      alt={report.emotion}
+                    />
                     {report.title}
                   </a>
                 </h2>
-                {(currentUser.id === report.user.id) && (
+                {currentUser.id === report.user.id && (
                   <ReportListItemActions report={report} />
                 )}
               </div>
@@ -38,11 +49,11 @@ export default function Report({report, currentUser}){
               <div className="card-list-item-meta__items">
                 <div className="card-list-item-meta__item">
                   <a className="a-user-name" href={report.user.url}>
-                    { report.user.long_name }
+                    {report.user.long_name}
                   </a>
                 </div>
                 <div className="card-list-item-meta__item">
-                  <time className="a-meta">{ `${report.reportedOn}の日報` }</time>
+                  <time className="a-meta">{`${report.reportedOn}の日報`}</time>
                 </div>
               </div>
             </div>
@@ -52,9 +63,11 @@ export default function Report({report, currentUser}){
         {report.hascheck && (
           <div className="stamp stamp-approve">
             <h2 className="stamp__content is-title">確認済</h2>
-            <time className="stamp__content is-created-at">{ report.checkDate }</time>
+            <time className="stamp__content is-created-at">
+              {report.checkDate}
+            </time>
             <div className="stamp__content is-user-name">
-              <div className="stamp__content-inner">{ report.checkUserName }</div>
+              <div className="stamp__content-inner">{report.checkUserName}</div>
             </div>
           </div>
         )}
@@ -66,18 +79,23 @@ export default function Report({report, currentUser}){
 const ReportListItemActions = ({ report }) => {
   return (
     <div className="card-list-item-title__end">
-      <label className="card-list-item-actions__trigger" htmlFor={report.id}></label>
+      <label className="card-list-item-actions__trigger" htmlFor={report.id}>
+      </label>
       <div className="card-list-item-actions">
         <input className="a-toggle-checkbox" type="checkbox" id={report.id} />
         <div className="card-list-item-actions__inner">
           <ul>
             <li className="card-list-item-actions__item">
-              <a className="card-list-item-actions__action" href={report.editURL}>
+              <a
+                className="card-list-item-actions__action"
+                href={report.editURL}>
                 <i className="fa-solid fa-pen">内容変更</i>
               </a>
             </li>
             <li className="card-list-item-actions__item">
-              <a className="card-list-item-actions__action" href={report.newURL}>
+              <a
+                className="card-list-item-actions__action"
+                href={report.newURL}>
                 <i className="fa-solid fa-copy">コピー</i>
               </a>
             </li>

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import CommentUserIcon from './CommentUserIcon'
+import ListComment from './ListComment'
 
 export default function Report({report, currentUser}){
   return (
@@ -46,9 +46,7 @@ export default function Report({report, currentUser}){
                 </div>
               </div>
             </div>
-          {(report.hasAnyComments) && (
-            <ReportListComment report={report} />
-          )}
+            {report.hasAnyComments && <ListComment report={report} />}
           </div>
         </div>
         {report.hascheck && (
@@ -88,35 +86,5 @@ const ReportListItemActions = ({ report }) => {
         </div>
       </div>
     </div>
-  )
-}
-
-const ReportListComment = ({ report }) => {
-  return (
-    <>
-      <hr className="card-list-item__row-separator"></hr>
-      <div className="card-list-item__row">
-        <div className="card-list-item-meta">
-          <div className="card-list-item-meta__items">
-            <div className="card-list-item-meta__item">
-              <div className="a-meta">コメント（{ report.numberOfComments }）</div>
-            </div>
-            <div className="card-list-item-meta__item">
-              <div className="card-list-item__user-icons">
-                {report.comments.map((comment) => {
-                  return (
-                    <CommentUserIcon comment={comment} key={comment.user_id}/>
-                  )
-                })}
-              </div>
-            </div>
-            <div className="card-list-item-meta__item">
-              <time className="a-meta" dateTime={report.lastCommentDatetime} pubdate="'pubdate'">{`〜 ${report.lastCommentDate}`}</time>
-            </div>
-            <div className="card-list-item-meta__item"></div>
-          </div>
-        </div>
-      </div>
-    </>
   )
 }

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import CommentUserIcon from './CommentUserIcon'
+
+export default function Report({report, currentUser}){
+  return (
+    <div className={`card-list-item ${report.wip ? "is-wip" : ""}`}>
+      <div className="card-list-item__inner">
+        <div className="card-list-item__user">
+          <a href={report.user.url} className="card-list-item__user-link">
+            <span className="[&quot;a-user-role&quot;, roleClass]">
+              <img className="card-list-item__user-icon a-user-icon" src={report.user.avatar_url} title={report.user.login_name} alt={report.user.login_name} />
+            </span>
+          </a>
+        </div>
+        <div className="card-list-item__rows">
+          <div className="card-list-item__row">
+            <header className="card-list-item-title">
+              <div className="card-list-item-title__start">
+                {report.wip && (
+                  <div className="a-list-item-badge is-wip">
+                    <span>WIP</span>
+                  </div>
+                )}
+                <h2 className="card-list-item-title__title">
+                  <a className="card-list-item-title__link a-text-link js-unconfirmed-link" href={report.url}>
+                    <img className="card-list-item-title__emotion-image" src={`/images/emotion/${report.emotion}.svg`} alt={report.emotion} />
+                    {report.title}
+                  </a>
+                </h2>
+                {(currentUser.id === report.user.id) && (
+                  <ReportListItemActions report={report} />
+                )}
+              </div>
+            </header>
+          </div>
+          <div className="card-list-item__row">
+            <div className="card-list-item-meta">
+              <div className="card-list-item-meta__items">
+                <div className="card-list-item-meta__item">
+                  <a className="a-user-name" href={report.user.url}>
+                    { report.user.long_name }
+                  </a>
+                </div>
+                <div className="card-list-item-meta__item">
+                  <time className="a-meta">{ `${report.reportedOn}の日報` }</time>
+                </div>
+              </div>
+            </div>
+          {(report.hasAnyComments) && (
+            <ReportListComment report={report} />
+          )}
+          </div>
+        </div>
+        {report.hascheck && (
+          <div className="stamp stamp-approve">
+            <h2 className="stamp__content is-title">確認済</h2>
+            <time className="stamp__content is-created-at">{ report.checkDate }</time>
+            <div className="stamp__content is-user-name">
+              <div className="stamp__content-inner">{ report.checkUserName }</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const ReportListItemActions = ({ report }) => {
+  return (
+    <div className="card-list-item-title__end">
+      <label className="card-list-item-actions__trigger" for={report.id}></label>
+      <div className="card-list-item-actions">
+        <input className="a-toggle-checkbox" type="checkbox" id={report.id} />
+        <div className="card-list-item-actions__inner">
+          <ul>
+            <li className="card-list-item-actions__item">
+              <a className="card-list-item-actions__action" href={report.editURL}>
+                <i className="fa-solid fa-pen">内容変更</i>
+              </a>
+            </li>
+            <li className="card-list-item-actions__item">
+              <a className="card-list-item-actions__action" href={report.newURL}>
+                <i className="fa-solid fa-copy">コピー</i>
+              </a>
+            </li>
+          </ul>
+          <label className="a-overlay" for={report.id}></label>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const ReportListComment = ({ report }) => {
+  return (
+    <>
+      <hr className="card-list-item__row-separator"></hr>
+      <div className="card-list-item__row">
+        <div className="card-list-item-meta">
+          <div className="card-list-item-meta__items">
+            <div className="card-list-item-meta__item">
+              <div className="a-meta">コメント（{ report.numberOfComments }）</div>
+            </div>
+            <div className="card-list-item-meta__item">
+              <div className="card-list-item__user-icons">
+                {report.comments.map((comment) => {
+                  return (
+                    <CommentUserIcon comment={comment} key={comment.user_id}/>
+                  )
+                })}
+              </div>
+            </div>
+            <div className="card-list-item-meta__item">
+              <time className="a-meta" dateTime={report.lastCommentDatetime} pubdate="'pubdate'">{`〜 ${report.lastCommentDate}`}</time>
+            </div>
+            <div className="card-list-item-meta__item"></div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -6,17 +6,22 @@ import LoadingListPlaceholder from './LoadingListPlaceholder'
 import Report from './Report'
 import Pagination from './Pagination'
 
-export default function Reports({user, currentUser}) {
+export default function Reports({user, currentUser, practices}) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
   const [page, setPage] = useState(defaultPage)
+  const [practiceId, setPracticeId] = useState('')
 
   useEffect(() => {
     setPage(page)
   }, [page])
+
+  useEffect(() => {
+    setPracticeId(practiceId)
+  }, [practiceId])
   
-  const { data, error } = useSWR(`/api/reports.json?user_id=${user.id}&page=${page}`, fetcher)
+  const { data, error } = useSWR(`/api/reports.json?user_id=${user.id}&page=${page}&practice_id=${practiceId}`, fetcher)
   
   const handlePaginate = (p) => {
     setPage(p)
@@ -32,45 +37,53 @@ export default function Reports({user, currentUser}) {
     )
   }
 
-  if (data.totalPages === 0){
-    return <NoReports />
-  } else {
-    return (
-      <div className="page-content reports">
-        {data.totalPages > 1 && (
-          <Pagination
-            sum={data.totalPages * per}
-            per={per}
-            neighbours={neighbours}
-            page={page}
-            onChange={e => handlePaginate(e.page)}
-          />
-        )}
-        <ul className="card-list a-card">
-          <div className="card-list__items">
-            {data.reports.map((report) => {
-              return (
-                <Report
-                  key={report.id}
-                  report={report}
-                  currentUser={currentUser}
-                />
-              )
-            })}
-          </div>
-        </ul>
-        {data.totalPages > 1 && (
-          <Pagination
-            sum={data.totalPages * per}
-            per={per}
-            neighbours={neighbours}
-            page={page}
-            onChange={e => handlePaginate(e.page)}
-          />
-        )}
+  return (
+    <>
+      <DropDown
+        practices={practices}
+        setPracticeId={setPracticeId}
+      />
+      {(data.totalPages === 0) && <NoReports />}
+      {(data.totalPages > 0) && (
+        <div className="container is-md">
+        <div className="page-content reports">
+          {data.totalPages > 1 && (
+            <Pagination
+              sum={data.totalPages * per}
+              per={per}
+              neighbours={neighbours}
+              page={page}
+              onChange={e => handlePaginate(e.page)}
+            />
+          )}
+          <ul className="card-list a-card">
+            <div className="card-list__items">
+              {data.reports.map((report) => {
+                return (
+                  <Report
+                    key={report.id}
+                    report={report}
+                    currentUser={currentUser}
+                  />
+                )
+              })}
+            </div>
+          </ul>
+          {data.totalPages > 1 && (
+            <Pagination
+              sum={data.totalPages * per}
+              per={per}
+              neighbours={neighbours}
+              page={page}
+              onChange={e => handlePaginate(e.page)}
+            />
+          )}
+        </div>
       </div>
-    )
-  }
+      )
+      }
+    </>
+  )
 }
 
 const NoReports = () => {
@@ -81,5 +94,37 @@ const NoReports = () => {
         <p className="o-empty-message__text">日報はまだありません。</p>
       </div>
     </div>
+  )
+}
+
+const DropDown = ({practices, setPracticeId}) => {
+  const [selectValue, setSelectValue] = useState('');
+  const onChange = (event) => {
+    const value = event.target.value
+    setSelectValue(value)
+    setPracticeId(value)
+  };
+  return (
+    <>
+      <nav className="page-filter form">
+        <div className="container is-md">
+          <div className="form-item is-inline-md-up">
+            <label className="a-form-label" htmlFor="js-choices-single-select">プラクティスで絞り込む</label>
+            <select
+              id="js-choices-single-select"
+              className="a-form-select choices__input"
+              onChange={onChange}
+            >
+              <option key="" value="">全ての日報を表示</option>
+              {practices.map((practice) => {
+                return (
+                  <option key={practice.id} value={practice.id}>{practice.title}</option>
+                )
+              })}
+            </select>
+          </div>
+        </div>
+      </nav>
+    </>
   )
 }

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect } from 'react'
 import useSWR from 'swr'
 import queryString from 'query-string'
 import fetcher from '../fetcher'
 import LoadingListPlaceholder from './LoadingListPlaceholder'
 import Report from './Report'
 import Pagination from './Pagination'
-import Choices from "choices.js";
+import PracticeFilterDropdown from './PracticeFilterDropdown'
 
 export default function Reports({user, currentUser, practices}) {
   const per = 20
@@ -37,7 +37,7 @@ export default function Reports({user, currentUser, practices}) {
     <>
       {(data.totalPages === 0) && (
         <div className="container is-md">
-          <DropDown
+          <PracticeFilterDropdown
             practices={practices}
             setPracticeId={setPracticeId}
             practiceId={practiceId}
@@ -47,47 +47,46 @@ export default function Reports({user, currentUser, practices}) {
       )}
       {(data.totalPages > 0) && (
         <div className="container is-md">
-        <DropDown
-          practices={practices}
-          setPracticeId={setPracticeId}
-          practiceId={practiceId}
-        />
-        <div className="page-content reports">
-          {data.totalPages > 1 && (
-            <Pagination
-              sum={data.totalPages * per}
-              per={per}
-              neighbours={neighbours}
-              page={page}
-              onChange={e => setPage(e.page)}
-            />
-          )}
-          <ul className="card-list a-card">
-            <div className="card-list__items">
-              {data.reports.map((report) => {
-                return (
-                  <Report
-                    key={report.id}
-                    report={report}
-                    currentUser={currentUser}
-                  />
-                )
-              })}
-            </div>
-          </ul>
-          {data.totalPages > 1 && (
-            <Pagination
-              sum={data.totalPages * per}
-              per={per}
-              neighbours={neighbours}
-              page={page}
-              onChange={e => setPage(e.page)}
-            />
-          )}
+          <PracticeFilterDropdown
+            practices={practices}
+            setPracticeId={setPracticeId}
+            practiceId={practiceId}
+          />
+          <div className="page-content reports">
+            {data.totalPages > 1 && (
+              <Pagination
+                sum={data.totalPages * per}
+                per={per}
+                neighbours={neighbours}
+                page={page}
+                onChange={(e) => setPage(e.page)}
+              />
+            )}
+            <ul className="card-list a-card">
+              <div className="card-list__items">
+                {data.reports.map((report) => {
+                  return (
+                    <Report
+                      key={report.id}
+                      report={report}
+                      currentUser={currentUser}
+                    />
+                  )
+                })}
+              </div>
+            </ul>
+            {data.totalPages > 1 && (
+              <Pagination
+                sum={data.totalPages * per}
+                per={per}
+                neighbours={neighbours}
+                page={page}
+                onChange={(e) => setPage(e.page)}
+              />
+            )}
+          </div>
         </div>
-      </div>
-      )
-      }
+      )}
     </>
   )
 }
@@ -100,62 +99,5 @@ const NoReports = () => {
         <p className="o-empty-message__text">日報はまだありません。</p>
       </div>
     </div>
-  )
-}
-
-const DropDown = ({practices, setPracticeId, practiceId}) => {
-  const [selectedId, setSelectedId] = useState(practiceId)
-
-  const onChange = (event) => {
-    const value = event.target.value
-    setSelectedId(value)
-    setPracticeId(value)
-  };
-
-  const selectRef = useRef(null);
-
-  useEffect(() => {
-    const selectElement = selectRef.current;
-    const choicesInstance = new Choices(selectElement, {
-      searchEnabled: true,
-      allowHTML: true,
-      searchResultLimit: 20,
-      searchPlaceholderValue: '検索ワード',
-      noResultsText: '一致する情報は見つかりません',
-      itemSelectText: '選択',
-      shouldSort: false
-    });
-
-    return () => {
-      choicesInstance.destroy();
-    };
-  }, []);
-
-  return (
-    <>
-      <nav className="page-filter form">
-        <div className="container is-md">
-          <div className="form-item is-inline-md-up">
-            <label className="a-form-label" htmlFor='js-choices-single-select'>プラクティスで絞り込む</label>
-            <select
-              className="a-form-select"
-              onChange={onChange}
-              ref={selectRef}
-              value={selectedId}
-              id='js-choices-single-select'
-            >
-              <option key="" value="">全ての日報を表示</option>
-              {practices.map((practice) => {
-                return (
-                  <option key={practice.id} value={practice.id}>
-                    {practice.title}
-                  </option>
-                )
-              })}
-            </select>
-          </div>
-        </div>
-      </nav>
-    </>
   )
 }

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -35,14 +35,23 @@ export default function Reports({user, currentUser, practices}) {
 
   return (
     <>
-      <DropDown
-        practices={practices}
-        setPracticeId={setPracticeId}
-        practiceId={practiceId}
-      />
-      {(data.totalPages === 0) && <NoReports />}
+      {(data.totalPages === 0) && (
+        <div className="container is-md">
+          <DropDown
+            practices={practices}
+            setPracticeId={setPracticeId}
+            practiceId={practiceId}
+          />
+          <NoReports />
+        </div>
+      )}
       {(data.totalPages > 0) && (
         <div className="container is-md">
+        <DropDown
+          practices={practices}
+          setPracticeId={setPracticeId}
+          practiceId={practiceId}
+        />
         <div className="page-content reports">
           {data.totalPages > 1 && (
             <Pagination
@@ -127,24 +136,23 @@ const DropDown = ({practices, setPracticeId, practiceId}) => {
       <nav className="page-filter form">
         <div className="container is-md">
           <div className="form-item is-inline-md-up">
-            <label className="a-form-label">プラクティスで絞り込む</label>
-            <div className="select-container">
-              <select
-                className="a-form-select"
-                onChange={onChange}
-                ref={selectRef}
-                value={selectedId}
-              >
-                <option key="" value="">全ての日報を表示</option>
-                {practices.map((practice) => {
-                  return (
-                    <option key={practice.id} value={practice.id}>
-                      {practice.title}
-                    </option>
-                  )
-                })}
-              </select>
-            </div>
+            <label className="a-form-label" htmlFor='js-choices-single-select'>プラクティスで絞り込む</label>
+            <select
+              className="a-form-select"
+              onChange={onChange}
+              ref={selectRef}
+              value={selectedId}
+              id='js-choices-single-select'
+            >
+              <option key="" value="">全ての日報を表示</option>
+              {practices.map((practice) => {
+                return (
+                  <option key={practice.id} value={practice.id}>
+                    {practice.title}
+                  </option>
+                )
+              })}
+            </select>
           </div>
         </div>
       </nav>

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react'
+import useSWR from 'swr'
+import queryString from 'query-string'
+import fetcher from '../fetcher'
+import LoadingListPlaceholder from './LoadingListPlaceholder'
+import Report from './Report'
+import Pagination from './Pagination'
+
+export default function Reports({user, currentUser}) {
+  const per = 20
+  const neighbours = 4
+  const defaultPage = parseInt(queryString.parse(location.search).page) || 1
+  const [page, setPage] = useState(defaultPage)
+
+  useEffect(() => {
+    setPage(page)
+  }, [page])
+  
+  const { data, error } = useSWR(`/api/reports.json?user_id=${user.id}&page=${page}`, fetcher)
+  
+  const handlePaginate = (p) => {
+    setPage(p)
+    window.history.pushState(null, null, `/events?page=${p}`)
+  }
+
+  if (error) return <>エラーが発生しました。</>
+  if (!data) {
+    return (
+      <div className="container is-md">
+        <LoadingListPlaceholder />
+      </div>
+    )
+  }
+
+  if (data.totalPages === 0){
+    return <NoReports />
+  } else {
+    return (
+      <div className="page-content reports">
+        {data.totalPages > 1 && (
+          <Pagination
+            sum={data.totalPages * per}
+            per={per}
+            neighbours={neighbours}
+            page={page}
+            onChange={e => handlePaginate(e.page)}
+          />
+        )}
+        <ul className="card-list a-card">
+          <div className="card-list__items">
+            {data.reports.map((report) => {
+              return (
+                <Report
+                  key={report.id}
+                  report={report}
+                  currentUser={currentUser}
+                />
+              )
+            })}
+          </div>
+        </ul>
+        {data.totalPages > 1 && (
+          <Pagination
+            sum={data.totalPages * per}
+            per={per}
+            neighbours={neighbours}
+            page={page}
+            onChange={e => handlePaginate(e.page)}
+          />
+        )}
+      </div>
+    )
+  }
+}
+
+const NoReports = () => {
+  return (
+    <div className="o-empty-message">
+      <div className="o-empty-message__icon">
+        <i className="fa-regular fa-face-sad-tear" />
+        <p className="o-empty-message__text">日報はまだありません。</p>
+      </div>
+    </div>
+  )
+}

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -7,7 +7,7 @@ import Report from './Report'
 import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 
-export default function Reports({user, currentUser, practices}) {
+export default function Reports({ user, currentUser, practices }) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -21,9 +21,12 @@ export default function Reports({user, currentUser, practices}) {
   useEffect(() => {
     setPracticeId(practiceId)
   }, [practiceId])
-  
-  const { data, error } = useSWR(`/api/reports.json?user_id=${user.id}&page=${page}&practice_id=${practiceId}`, fetcher)
-  
+
+  const { data, error } = useSWR(
+    `/api/reports.json?user_id=${user.id}&page=${page}&practice_id=${practiceId}`,
+    fetcher
+  )
+
   if (error) return <>エラーが発生しました。</>
   if (!data) {
     return (
@@ -35,7 +38,7 @@ export default function Reports({user, currentUser, practices}) {
 
   return (
     <>
-      {(data.totalPages === 0) && (
+      {data.totalPages === 0 && (
         <div className="container is-md">
           <PracticeFilterDropdown
             practices={practices}
@@ -45,7 +48,7 @@ export default function Reports({user, currentUser, practices}) {
           <NoReports />
         </div>
       )}
-      {(data.totalPages > 0) && (
+      {data.totalPages > 0 && (
         <div className="container is-md">
           <PracticeFilterDropdown
             practices={practices}

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import useSWR from 'swr'
 import queryString from 'query-string'
 import fetcher from '../fetcher'
 import LoadingListPlaceholder from './LoadingListPlaceholder'
 import Report from './Report'
 import Pagination from './Pagination'
+import Choices from "choices.js";
 
 export default function Reports({user, currentUser, practices}) {
   const per = 20
@@ -23,11 +24,6 @@ export default function Reports({user, currentUser, practices}) {
   
   const { data, error } = useSWR(`/api/reports.json?user_id=${user.id}&page=${page}&practice_id=${practiceId}`, fetcher)
   
-  const handlePaginate = (p) => {
-    setPage(p)
-    window.history.pushState(null, null, `/events?page=${p}`)
-  }
-
   if (error) return <>エラーが発生しました。</>
   if (!data) {
     return (
@@ -42,6 +38,7 @@ export default function Reports({user, currentUser, practices}) {
       <DropDown
         practices={practices}
         setPracticeId={setPracticeId}
+        practiceId={practiceId}
       />
       {(data.totalPages === 0) && <NoReports />}
       {(data.totalPages > 0) && (
@@ -53,7 +50,7 @@ export default function Reports({user, currentUser, practices}) {
               per={per}
               neighbours={neighbours}
               page={page}
-              onChange={e => handlePaginate(e.page)}
+              onChange={e => setPage(e.page)}
             />
           )}
           <ul className="card-list a-card">
@@ -75,7 +72,7 @@ export default function Reports({user, currentUser, practices}) {
               per={per}
               neighbours={neighbours}
               page={page}
-              onChange={e => handlePaginate(e.page)}
+              onChange={e => setPage(e.page)}
             />
           )}
         </div>
@@ -97,31 +94,57 @@ const NoReports = () => {
   )
 }
 
-const DropDown = ({practices, setPracticeId}) => {
-  const [selectValue, setSelectValue] = useState('');
+const DropDown = ({practices, setPracticeId, practiceId}) => {
+  const [selectedId, setSelectedId] = useState(practiceId)
+
   const onChange = (event) => {
     const value = event.target.value
-    setSelectValue(value)
+    setSelectedId(value)
     setPracticeId(value)
   };
+
+  const selectRef = useRef(null);
+
+  useEffect(() => {
+    const selectElement = selectRef.current;
+    const choicesInstance = new Choices(selectElement, {
+      searchEnabled: true,
+      allowHTML: true,
+      searchResultLimit: 20,
+      searchPlaceholderValue: '検索ワード',
+      noResultsText: '一致する情報は見つかりません',
+      itemSelectText: '選択',
+      shouldSort: false
+    });
+
+    return () => {
+      choicesInstance.destroy();
+    };
+  }, []);
+
   return (
     <>
       <nav className="page-filter form">
         <div className="container is-md">
           <div className="form-item is-inline-md-up">
-            <label className="a-form-label" htmlFor="js-choices-single-select">プラクティスで絞り込む</label>
-            <select
-              id="js-choices-single-select"
-              className="a-form-select choices__input"
-              onChange={onChange}
-            >
-              <option key="" value="">全ての日報を表示</option>
-              {practices.map((practice) => {
-                return (
-                  <option key={practice.id} value={practice.id}>{practice.title}</option>
-                )
-              })}
-            </select>
+            <label className="a-form-label">プラクティスで絞り込む</label>
+            <div className="select-container">
+              <select
+                className="a-form-select"
+                onChange={onChange}
+                ref={selectRef}
+                value={selectedId}
+              >
+                <option key="" value="">全ての日報を表示</option>
+                {practices.map((practice) => {
+                  return (
+                    <option key={practice.id} value={practice.id}>
+                      {practice.title}
+                    </option>
+                  )
+                })}
+              </select>
+            </div>
           </div>
         </div>
       </nav>

--- a/app/javascript/components/report.vue
+++ b/app/javascript/components/report.vue
@@ -30,11 +30,11 @@
                 .card-list-item-actions__inner
                   ul.card-list-item-actions__items
                     li.card-list-item-actions__item
-                      a.card-list-item-actions__action(:href='report.editURL')
+                      a.card-list-item-actions__action(:href='report.editPath')
                         i.fa-solid.fa-pen
                         | 内容変更
                     li.card-list-item-actions__item
-                      a.card-list-item-actions__action(:href='report.newURL')
+                      a.card-list-item-actions__action(:href='report.newPath')
                         i.fa-solid.fa-copy
                         | コピー
                   label.a-overlay(:for='report.id')

--- a/app/views/api/reports/_report.json.jbuilder
+++ b/app/views/api/reports/_report.json.jbuilder
@@ -2,7 +2,9 @@ json.id report.id
 json.title report.title
 json.reportedOn l(report.reported_on)
 json.url report_url(report)
-json.editURL edit_report_path(report)
-json.newURL new_report_path(id: report)
+json.editPath edit_report_path(report)
+json.newPath new_report_path(id: report)
+json.editURL edit_report_url(report)
+json.newURL new_report_url(id: report)
 json.wip report.wip?
 json.emotion report.emotion

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -5,5 +5,4 @@
 = render 'users/page_tabs', user: @user
 
 .page-body
-  .container.is-md
-    = react_component('Reports', user: @user, currentUser: current_user, practices: @user.practices)
+  = react_component('Reports', user: @user, currentUser: current_user, practices: @user.practices)

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -6,10 +6,4 @@
 
 .page-body
   .container.is-md
-    .page-filter.form
-      = form_with url: user_reports_path, local: true, method: 'get'
-        .form-item.is-inline-md-up
-          = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
-          = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
-
-    div(data-vue="Reports" data-vue-user-id:number="#{params[:user_id]}")
+    = react_component("Reports" , user: @user, currentUser: current_user)

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -6,4 +6,4 @@
 
 .page-body
   .container.is-md
-    = react_component("Reports" , user: @user, currentUser: current_user)
+    = react_component("Reports" , user: @user, currentUser: current_user, practices: @user.practices)

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -6,4 +6,4 @@
 
 .page-body
   .container.is-md
-    = react_component("Reports" , user: @user, currentUser: current_user, practices: @user.practices)
+    = react_component('Reports' , user: @user, currentUser: current_user, practices: @user.practices)

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -6,4 +6,10 @@
 
 .page-body
   .container.is-md
+    .page-filter.form
+      = form_with url: user_reports_path, local: true, method: 'get'
+        .form-item.is-inline-md-up
+          = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
+          = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
+
     div(data-vue="Reports" data-vue-user-id:number="#{params[:user_id]}")

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -6,4 +6,4 @@
 
 .page-body
   .container.is-md
-    = react_component('Reports' , user: @user, currentUser: current_user, practices: @user.practices)
+    = react_component('Reports', user: @user, currentUser: current_user, practices: @user.practices)

--- a/test/system/user/reports_test.rb
+++ b/test/system/user/reports_test.rb
@@ -8,6 +8,24 @@ class User::ReportsTest < ApplicationSystemTestCase
     assert_equal 'hatsuno 日報 | FBC', title
   end
 
+  test 'can use select box to filter user reports by practice' do
+    visit_with_auth "/users/#{users(:hajime).id}/reports", 'kimura'
+
+    expected_reports = users(:hajime).reports
+    displayed_reports_count = all('.card-list-item-title__link').count
+    assert_equal expected_reports.count, displayed_reports_count
+
+    find('.choices__inner').click
+    find('#choices--js-choices-single-select-item-choice-3', text: 'Terminalの基礎を覚える').click
+    assert_text 'Terminalの基礎を覚える'
+
+    expected_reports = Practice.find_by(title: 'Terminalの基礎を覚える').reports.where(user: users(:hajime))
+    displayed_reports_count = all('.card-list-item-title__link').count
+    assert_equal expected_reports.count, displayed_reports_count
+
+    assert_text expected_reports.first.title
+  end
+
   test 'cannot access other users download reports' do
     visit_with_auth "/users/#{users(:hatsuno).id}/reports.md", 'kimura'
     assert_text '自分以外の日報はダウンロードすることができません'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6037

## 概要

個人の日報一覧（https://bootcamp.fjord.jp/users/1463/reports など）を、プラクティスで絞り込めるようにしました。
（全ユーザーの日報一覧（ https://bootcamp.fjord.jp/reports ）には、既に同様の絞り込み機能が実装されています。）

## 変更確認方法

1. `feature/filter-user-reports-by-practice`をローカルに取り込む
2. 任意のユーザーでログイン
3. `komagata`さんの日報一覧（ http://localhost:3000/users/459775584/reports ）を表示
4. セレクトボックスが表示されていること、プラクティスで日報を絞り込めることを確認します。テストデータ上は、`OS X Mountain Lionをクリーンインストールする`のプラクティスに、紐づく日報が存在しています。

## Screenshot

### 変更前
<img width="1435" alt="スクリーンショット 2023-01-13 10 44 20" src="https://user-images.githubusercontent.com/40317050/212217910-11368e9a-84a7-4c45-9b1c-26f552bb2fc2.png">

### 変更後
<img width="1438" alt="スクリーンショット 2023-01-13 10 40 24" src="https://user-images.githubusercontent.com/40317050/212217778-f0c96574-3030-49d5-a944-0459e839a14a.png">

<img width="820" alt="スクリーンショット 2023-01-13 10 40 32" src="https://user-images.githubusercontent.com/40317050/212217511-b9570681-82a2-4831-8a3f-8a6b85dca4d8.png">
<img width="792" alt="スクリーンショット 2023-01-13 10 40 55" src="https://user-images.githubusercontent.com/40317050/212217504-e3175139-bf90-42ce-a27e-d0f56670c162.png">


