### PR TITLE
日報個別ページにユーザー用のタブナビを表示するようにした

### DIFF
--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -1,19 +1,8 @@
 - title @report.title
 
-header.page-header
-  .container
-    .page-header__inner
-      .page-header__title
-        | #{l @report.reported_on} の日報
-      .page-header-actions
-        ul.page-header-actions__items
-          li.page-header-actions__item
-            = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-              i.fa-regular.fa-plus
-              | 日報作成
-          li.page-header-actions__item
-            = link_to reports_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | 日報一覧
+= render 'users/page_title', user: @report.user
+
+= render 'users/page_tabs', user: @report.user
 
 - if mentor_login? && !@report.first? && @report.latest_of_user?
   .a-page-notice.is-only-mentor(class="#{@report.interval >= 10 ? 'is-danger' : ''}")

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -1,19 +1,6 @@
 - title "#{@user.login_name}さんの相談部屋"
 
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        - if current_user.admin?
-          = @user.login_name
-        - else
-          | 相談部屋
-      - if current_user.admin?
-        .page-header-actions
-          ul.page-header-actions__items
-            li.page-header-actions__item
-              = link_to talks_path, class: 'a-button is-md is-secondary is-block is-back' do
-                | 相談部屋一覧
+= render 'users/page_title', user: @user
 
 - if admin_login?
   = render 'users/page_tabs', user: @user

--- a/app/views/users/_page_tabs.html.slim
+++ b/app/views/users/_page_tabs.html.slim
@@ -23,7 +23,7 @@
       li.page-tabs__item
         = link_to user_answers_path(user), class: "page-tabs__item-link #{current_page_tab_or_not('answers')}" do
           | 回答（#{user.answers.length}）
-      - if current_user.admin && !@user.admin
+      - if current_user.admin && !user.admin
         li.page-tabs__item
-          = link_to talk_path(@user.talk), class: "page-tabs__item-link #{current_page_tab_or_not('talks')} " do
+          = link_to talk_path(user.talk), class: "page-tabs__item-link #{current_page_tab_or_not('talks')} " do
             | 相談部屋

--- a/app/views/users/_page_title.html.slim
+++ b/app/views/users/_page_title.html.slim
@@ -1,0 +1,15 @@
+- title user.login_name
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          li.page-header-actions__item
+            = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+              i.fa-regular.fa-plus
+              | 日報作成
+          li.page-header-actions__item
+            = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | ユーザー一覧

--- a/app/views/users/_page_title.html.slim
+++ b/app/views/users/_page_title.html.slim
@@ -1,9 +1,8 @@
-- title user.login_name
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        = user.login_name
       .page-header-actions
         ul.page-header-actions__items
           li.page-header-actions__item

--- a/app/views/users/answers/index.html.slim
+++ b/app/views/users/answers/index.html.slim
@@ -1,3 +1,5 @@
+- title "#{@user.login_name}の回答一覧"
+
 = render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user

--- a/app/views/users/answers/index.html.slim
+++ b/app/views/users/answers/index.html.slim
@@ -1,14 +1,4 @@
-- title "#{@user.login_name}の回答一覧"
-
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        = @user.login_name
-      .page-header-actions
-        ul.page-header-actions__items
-          li.page-header-actions__item
-            = link_to 'ユーザー一覧', users_path, class: 'a-button is-md is-secondary is-block is-back'
+= render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user
 

--- a/app/views/users/comments/index.html.slim
+++ b/app/views/users/comments/index.html.slim
@@ -1,3 +1,5 @@
+- title "#{@user.login_name} コメント"
+
 = render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user

--- a/app/views/users/comments/index.html.slim
+++ b/app/views/users/comments/index.html.slim
@@ -1,15 +1,4 @@
-- title "#{@user.login_name} コメント"
-
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        = @user.login_name
-      .page-header-actions
-        ul.page-header-actions__items
-          li.page-header-actions__item
-            = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | ユーザー一覧
+= render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user
 

--- a/app/views/users/products/index.html.slim
+++ b/app/views/users/products/index.html.slim
@@ -1,15 +1,4 @@
-- title "#{@user.login_name}の提出物一覧"
-
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        = @user.login_name
-      .page-header-actions
-        ul.page-header-actions__items
-          li.page-header-actions__item
-            = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | ユーザー一覧
+= render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user
 

--- a/app/views/users/products/index.html.slim
+++ b/app/views/users/products/index.html.slim
@@ -1,3 +1,5 @@
+- title "#{@user.login_name}の提出物一覧"
+
 = render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user

--- a/app/views/users/questions/index.html.slim
+++ b/app/views/users/questions/index.html.slim
@@ -1,14 +1,4 @@
-- title "#{@user.login_name}の質問一覧"
-
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        = @user.login_name
-      .page-header-actions
-        ul.page-header-actions__items
-          li.page-header-actions__item
-            = link_to 'ユーザー一覧', users_path, class: 'a-button is-md is-secondary is-block is-back'
+= render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user
 

--- a/app/views/users/questions/index.html.slim
+++ b/app/views/users/questions/index.html.slim
@@ -1,3 +1,5 @@
+- title "#{@user.login_name}の質問一覧"
+
 = render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -1,3 +1,5 @@
+- title "#{@user.login_name} 日報"
+
 = render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -1,18 +1,4 @@
-- title "#{@user.login_name} 日報"
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        = @user.login_name
-      .page-header-actions
-        ul.page-header-actions__items
-          li.page-header-actions__item
-            = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-              i.fa-regular.fa-plus
-              | 日報作成
-          li.page-header-actions__item
-            = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | ユーザー一覧
+= render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,19 +1,4 @@
-- title @user.login_name
-header.page-header
-  .container
-    .page-header__inner
-      h2.page-header__title
-        = title
-      .page-header-actions
-        ul.page-header-actions__items
-          - if current_user == @user
-            li.page-header-actions__item
-              = link_to edit_current_user_path, class: 'a-button is-md is-secondary is-block' do
-                i.fa-solid.fa-pen
-                | 登録情報変更
-          li.page-header-actions__item
-            = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | ユーザー一覧
+= render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,3 +1,5 @@
+- title @user.login_name
+
 = render 'users/page_title', user: @user
 
 = render 'users/page_tabs', user: @user

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -632,7 +632,6 @@ class ReportsTest < ApplicationSystemTestCase
   test 'mentors can see reports page if products published_at is nil' do
     visit_with_auth '/reports/unchecked', 'mentormentaro'
     click_link 'テストのnippou'
-    assert_text '2022年04月01日'
     assert_text '今日は1時間学習しました。'
   end
 

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -632,7 +632,7 @@ class ReportsTest < ApplicationSystemTestCase
   test 'mentors can see reports page if products published_at is nil' do
     visit_with_auth '/reports/unchecked', 'mentormentaro'
     click_link 'テストのnippou'
-    assert_text '2022年04月01日 の日報'
+    assert_text '2022年04月01日'
     assert_text '今日は1時間学習しました。'
   end
 

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -64,7 +64,7 @@ class TalksTest < ApplicationSystemTestCase
   test 'non-admin user can access their own talk page' do
     user = users(:kimura)
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'
-    assert_selector '.page-header__title', text: '相談部屋'
+    assert_selector '.page-header__title', text: 'kimura'
   end
 
   test 'a talk room is removed from unreplied tab when admin comments there' do

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -61,12 +61,6 @@ class TalksTest < ApplicationSystemTestCase
     assert_selector '.page-header__title', text: 'kimura'
   end
 
-  test 'non-admin user can access their own talk page' do
-    user = users(:kimura)
-    visit_with_auth "/talks/#{user.talk.id}", 'kimura'
-    assert_selector '.page-header__title', text: 'kimura'
-  end
-
   test 'a talk room is removed from unreplied tab when admin comments there' do
     user = users(:with_hyphen)
     visit_with_auth "/talks/#{user.talk.id}", 'komagata'


### PR DESCRIPTION
## Issue

- #5938 

## 概要
- ユーザー用のページタイトル部分を partial 化しました
- 日報個別ページにユーザー用のタブナビを表示するようにしました

## 変更確認方法

1. `feature/display-tabnav-on-individual-daily-report`をローカルに取り込む
2. `rails s`で起動する
3. 任意のユーザーでログインし、任意のユーザーページ(`http://localhost:3000/users/253826460`)のタブをクリックして、ページタイトル部分が表示されていることを確認する。
4. 任意の日報（`http://localhost:3000/reports/12168338`）を選択して、ページタイトルとタブナビが表示されていることを確認する。

## Screenshot

### 変更前

Partial化されていないため、「日報作成」がない。

![スクリーンショット_20230113_195153](https://user-images.githubusercontent.com/93074851/212315820-b9bdd11d-0107-413c-ad08-94f231251b6c.png)

### 変更後

Partial化されているため、「日報作成」がある。

![スクリーンショット_20230113_195240](https://user-images.githubusercontent.com/93074851/212315834-99e28748-c6cd-4c9f-9f26-7a5ae1f43fb5.png)

### 変更前

Partial化されていない。

![スクリーンショット_20230112_160150](https://user-images.githubusercontent.com/93074851/212315622-141a744a-0aed-4608-a785-364f87f23ff8.png)

### 変更後

Partial化されたページタイトルとタブナビが表示されている。

![スクリーンショット_20230113_195113](https://user-images.githubusercontent.com/93074851/212315690-d17426c2-ee89-465d-a3c4-47007492ca52.png)


