### PR TITLE
定期イベントの主催者全員が定期イベントページを編集できるようにした

### DIFF
--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -54,7 +54,7 @@
     - unless regular_event.wip?
       = render 'regular_events/participation', regular_event: regular_event
     = render 'reactions/reactions', reactionable: regular_event
-    - if admin_or_mentor_login? || regular_event.user_id == current_user.id
+    - if admin_or_mentor_login? || regular_event.organizers.ids.include?(current_user.id)
       .card-footer
         .card-main-actions
           ul.card-main-actions__items

--- a/db/fixtures/organizers.yml
+++ b/db/fixtures/organizers.yml
@@ -41,3 +41,7 @@ organizer10:
 organizer11:
   user: kimura
   regular_event: regular_event8
+
+organizer12:
+  user: hajime
+  regular_event: regular_event4

--- a/test/fixtures/organizers.yml
+++ b/test/fixtures/organizers.yml
@@ -41,3 +41,7 @@ organizer10:
 organizer11:
   user: kimura
   regular_event: regular_event8
+
+organizer12:
+  user: hajime
+  regular_event: regular_event4

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -86,6 +86,47 @@ class RegularEventsTest < ApplicationSystemTestCase
     assert_text '定期イベントを削除しました。'
   end
 
+  test 'edit by co-organizers' do
+    visit_with_auth new_regular_event_path, 'hajime'
+    within 'form[name=regular_event]' do
+      fill_in 'regular_event[title]', with: 'チェリー本輪読会'
+      first('.choices__inner').click
+      find('#choices--js-choices-multiple-select-item-choice-10').click
+      find('#choices--js-choices-multiple-select-item-choice-11').click
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('月曜日')
+      fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
+      fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
+      fill_in 'regular_event[description]', with: '予習不要です'
+      assert_difference 'RegularEvent.count', 1 do
+        click_button '作成'
+      end
+    end
+    assert_text '定期イベントを作成しました。'
+    assert_text '毎週月曜日'
+    assert_text 'Watch中'
+
+    visit_with_auth regular_events_path, 'hatsuno'
+    click_on 'チェリー本輪読会', match: :first
+    # debugger
+    click_on '内容修正', match: :first
+    within 'form[name=regular_event]' do
+      fill_in 'regular_event[title]', with: 'チェリー本輪読会（修正）'
+      first('.choices__inner').click
+      find('#choices--js-choices-multiple-select-item-choice-2').click
+      find('label', text: '主催者').click
+      find('label', text: '輪読会').click
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('第2')
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('水曜日')
+      fill_in 'regular_event[start_at]', with: Time.zone.parse('20:00')
+      fill_in 'regular_event[end_at]', with: Time.zone.parse('21:00')
+      fill_in 'regular_event[description]', with: '予習不要です（修正）'
+      click_button '内容変更'
+    end
+    assert_text '定期イベントを更新しました。'
+    assert_text '第2水曜日'
+  end
+
   test 'show the category of the regular event on regular events list' do
     visit_with_auth '/regular_events/new', 'komagata'
     fill_in 'regular_event[title]', with: '定期イベント・カテゴリーのテスト'

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -87,33 +87,9 @@ class RegularEventsTest < ApplicationSystemTestCase
   end
 
   test 'edit by co-organizers' do
-    visit_with_auth new_regular_event_path, 'hajime'
+    visit_with_auth edit_regular_event_path(regular_events(:regular_event4)), 'hajime'
     within 'form[name=regular_event]' do
-      fill_in 'regular_event[title]', with: 'ブルーベリー本輪読会'
-      first('.choices__inner').click
-      find('#choices--js-choices-multiple-select-item-choice-10').click
-      find('#choices--js-choices-multiple-select-item-choice-11').click
-      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
-      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('月曜日')
-      fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
-      fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
-      fill_in 'regular_event[description]', with: '予習不要です'
-      assert_difference 'RegularEvent.count', 1 do
-        click_button '作成'
-      end
-    end
-    assert_text '定期イベントを作成しました。'
-    assert_text '毎週月曜日'
-    assert_text 'Watch中'
-
-    visit_with_auth regular_events_path, 'hatsuno'
-    click_on 'ブルーベリー本輪読会', match: :first
-    click_on '内容修正', match: :first
-    within 'form[name=regular_event]' do
-      fill_in 'regular_event[title]', with: 'ブルーベリー本輪読会（修正）'
-      first('.choices__inner').click
-      find('#choices--js-choices-multiple-select-item-choice-2').click
-      find('label', text: '主催者').click
+      fill_in 'regular_event[title]', with: 'チェリー本輪読会（修正）'
       find('label', text: '輪読会').click
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('第2')
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('水曜日')

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -108,7 +108,6 @@ class RegularEventsTest < ApplicationSystemTestCase
 
     visit_with_auth regular_events_path, 'hatsuno'
     click_on 'チェリー本輪読会', match: :first
-    # debugger
     click_on '内容修正', match: :first
     within 'form[name=regular_event]' do
       fill_in 'regular_event[title]', with: 'チェリー本輪読会（修正）'

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -89,7 +89,7 @@ class RegularEventsTest < ApplicationSystemTestCase
   test 'edit by co-organizers' do
     visit_with_auth new_regular_event_path, 'hajime'
     within 'form[name=regular_event]' do
-      fill_in 'regular_event[title]', with: 'チェリー本輪読会'
+      fill_in 'regular_event[title]', with: 'ブルーベリー本輪読会'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-10').click
       find('#choices--js-choices-multiple-select-item-choice-11').click
@@ -107,10 +107,10 @@ class RegularEventsTest < ApplicationSystemTestCase
     assert_text 'Watch中'
 
     visit_with_auth regular_events_path, 'hatsuno'
-    click_on 'チェリー本輪読会', match: :first
+    click_on 'ブルーベリー本輪読会', match: :first
     click_on '内容修正', match: :first
     within 'form[name=regular_event]' do
-      fill_in 'regular_event[title]', with: 'チェリー本輪読会（修正）'
+      fill_in 'regular_event[title]', with: 'ブルーベリー本輪読会（修正）'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-2').click
       find('label', text: '主催者').click


### PR DESCRIPTION
## Issue

- #6014 

## 概要
定期イベントの主催者全員が定期イベントページを編集できるようにした
（以前は作成者と管理者しか編集できなかった）

## 変更確認方法

1. `feature/co-editing-of-regular-events`をローカルに取り込む
2. 任意のユーザーで定期イベントを作成する。主催者を複数人追加する
3. 別のユーザーでログインする。このとき、主催者に追加されたユーザーを選ぶ
4. （定期イベント作成者ではない）そのユーザーでも定期イベントが編集できることを確認する

## Screenshot

### 変更前
hajimeとkimuraが主催する定期イベントを、hajimeのアカウントで作成する。

hajimeが作成した定期イベントは、hajimeは編集することができる（「内容修正」がある）。↓

![スクリーンショット_20230113_213427](https://user-images.githubusercontent.com/93074851/212412864-215c0ced-43fc-439d-a4ae-84536c9080ff.png)


しかし、kimuraはこの定期イベントを編集することができない（内容修正がない）。↓

![スクリーンショット_20230113_213511](https://user-images.githubusercontent.com/93074851/212412888-9be27696-b8b6-408b-809c-f1d086931676.png)


### 変更後

kimuraの画面から定期イベントページに行くと、内容修正ができるようになっている。

![image](https://user-images.githubusercontent.com/93074851/212413153-18fead1f-9847-4976-95fd-681023aabd50.png)

