### PR TITLE
初日報の通知先をメンターのみにする

### DIFF
--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -75,7 +75,7 @@ class NotificationFacade
   end
 
   def self.first_report(report, receiver)
-    ActivityNotifier.with(report: report, receiver: receiver).first_report.notify_now if receiver.current_student? || receiver.admin_or_mentor?
+    ActivityNotifier.with(report: report, receiver: receiver).first_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -30,8 +30,7 @@ class ReportCallbacks
   end
 
   def notify_first_report(report)
-    receiver_list = User.where(retired_on: nil)
-    receiver_list.each do |receiver|
+    User.admins_and_mentors.each do |receiver|
       NotificationFacade.first_report(report, receiver) if report.sender != receiver
     end
   end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -12,7 +12,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     AbstractNotifier.delivery_mode = @delivery_mode
   end
 
-  test 'the first daily report notification is sent only to current students and mentors' do
+  test 'the first daily report notification is sent only to mentors' do
     report = users(:muryou).reports.create!(
       title: '初日報です',
       description: '初日報の内容です',
@@ -35,7 +35,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
 
     visit_with_auth '/notifications', 'kimura'
     find('#notifications.loaded', wait: 10)
-    assert_text notification_message
+    assert_no_text notification_message
 
     visit_with_auth '/notifications', 'advijirou'
     find('#notifications.loaded', wait: 10)
@@ -239,7 +239,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
   end
 
   test '初日報は初めて公開した時だけ通知する' do
-    check_notification_login_name = 'kimura'
+    check_notification_login_name = 'machida'
     author_login_name = 'nippounashi'
     title = '初めての日報を提出したら'
     description = 'ユーザーに通知をする'


### PR DESCRIPTION
## Issue

- #6006 

## 概要

初日報の通知先を現役受講生とメンターから、メンターのみに変更しました。

## 変更確認方法

1. `feature/notification-of-first-report-to-mentors-only`をローカルに取り込む
1. `bin/rails s`でローカル環境を立ち上げる
1. `nippounasi`(初日報を提出する現役受講生)でログインする
    1. `/reports/new`にアクセスして日報を提出する 
    入力内容はなんでもOK
1. `kimura`(現役受講生)でログインする
    1. `/notifications`にアクセスし、[🎉 nippounashiさんがはじめての日報を書きました！]が表示されない
1. `komagata`(メンター)でログインする
    1. `/notifications`にアクセスし、[🎉 nippounashiさんがはじめての日報を書きました！]が表示される
1. `/letter_opener`にアクセスし、`komagata`(メンター)に[[FBC] nippounashiさんがはじめての日報を書きました！]が届いていることを確認する
## Screenshot

### 変更後

#### `kimura`(現役受講生)への通知

![image](https://user-images.githubusercontent.com/69447745/212446138-aaea98aa-bf4b-44e3-93ae-7c3e037bcef4.png)

#### `komagata`(メンター)への通知

![image](https://user-images.githubusercontent.com/69447745/212446114-fe7f2190-7856-4e00-ab38-19b2a3efd430.png)
