### PR TITLE
ユーザー一覧targetアドバイザーのエラー修正

### DIFF
--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1005,6 +1005,7 @@ advisernocolleguetrainee:
   twitter_account: advisernocolleguetrainee
   facebook_url: https://www.facebook.com/fjordllc
   blog_url: http://advisernocolleguetrainee.example.com
+  description: '同僚がいないアドバイザーです。'
   adviser: true
   course: course1
   unsubscribe_email_token: 6ULb9vj1AJzTH_mOsfR46Q


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6024

## 概要
chromeのデベロッパーツールのconsole上に以下のエラーが発生する。
adviserユーザーの「あどばいざ 同僚いない子」の自己紹介が空欄だったことが原因。
![image](https://user-images.githubusercontent.com/43959158/212693516-99b47492-8878-4bfe-86c3-2a674d9bbe90.png)

「あどばいざ 同僚いない子」の自己紹介を追加することでエラーが解消する。

## 変更確認方法
※DEV環境でエラーが再現しない場合は、`bin/rails db:seed`を実行してみてください。

1. `feature/fix-advisernocolleguetrainee-description`をローカルに取り込む
2. `http://localhost:3000/users?target=adviser`にアクセスし、chromeのデベロッパーツールに上記のエラーが発生しないこと＆「あどばいざ 同僚いない子」が表示されることを確認

## Screenshot

### 変更前
![image](https://user-images.githubusercontent.com/43959158/212693516-99b47492-8878-4bfe-86c3-2a674d9bbe90.png)

### 変更後
![image](https://user-images.githubusercontent.com/43959158/212694155-e9c18374-ff56-46e2-851b-dee8e771b102.png)

