### PR TITLE
休会から復帰時に管理者・メンターに通知が飛ぶようにした

### DIFF
--- a/app/controllers/comeback_controller.rb
+++ b/app/controllers/comeback_controller.rb
@@ -12,6 +12,7 @@ class ComebackController < ApplicationController
     if @user
       if @user&.hibernated?
         @user.comeback!
+        notify_to_mentors_and_admins(@user)
         redirect_to root_url, notice: '休会から復帰しました。'
       else
         @user = User.new
@@ -22,6 +23,14 @@ class ComebackController < ApplicationController
       @user = User.new
       flash.now[:alert] = 'メールアドレスかパスワードが違います。'
       render 'new'
+    end
+  end
+
+  private
+
+  def notify_to_mentors_and_admins(user)
+    User.admins_and_mentors.each do |admin_or_mentor|
+      ActivityDelivery.with(sender: user, receiver: admin_or_mentor).notify(:comebacked)
     end
   end
 end

--- a/app/controllers/comeback_controller.rb
+++ b/app/controllers/comeback_controller.rb
@@ -12,7 +12,7 @@ class ComebackController < ApplicationController
     if @user
       if @user&.hibernated?
         @user.comeback!
-        notify_to_mentors_and_admins(@user)
+        Newspaper.publish(:comeback_update, @user)
         redirect_to root_url, notice: '休会から復帰しました。'
       else
         @user = User.new
@@ -23,14 +23,6 @@ class ComebackController < ApplicationController
       @user = User.new
       flash.now[:alert] = 'メールアドレスかパスワードが違います。'
       render 'new'
-    end
-  end
-
-  private
-
-  def notify_to_mentors_and_admins(user)
-    User.admins_and_mentors.each do |admin_or_mentor|
-      ActivityDelivery.with(sender: user, receiver: admin_or_mentor).notify(:comebacked)
     end
   end
 end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -18,7 +18,7 @@ class ActivityMailer < ApplicationMailer
     return false unless @receiver.mail_notification? # cancel sending email
 
     @user = @receiver
-    @link_url = notification_redirector_path(
+    @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:comebacked]
     )

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -15,6 +15,8 @@ class ActivityMailer < ApplicationMailer
     @sender ||= args[:sender]
     @receiver ||= args[:receiver]
 
+    return false unless @receiver.mail_notification? # cancel sending email
+
     @user = @receiver
     @link_url = notification_redirector_path(
       link: "/users/#{@sender.id}",

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -11,6 +11,20 @@ class ActivityMailer < ApplicationMailer
   end
 
   # required params: sender, receiver
+  def comebacked(args = {})
+    @sender ||= args[:sender]
+    @receiver ||= args[:receiver]
+
+    @user = @receiver
+    @link_url = notification_redirector_path(
+      link: "/users/#{@sender.id}",
+      kind: Notification.kinds[:comebacked]
+    )
+    subject = "[FBC] #{@sender.login_name}さんが復帰しました。"
+    mail to: @user.email, subject: subject
+  end
+
+  # required params: sender, receiver
   def graduated(args = {})
     @sender ||= args[:sender]
     @receiver ||= args[:receiver]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -20,7 +20,7 @@ class ActivityMailer < ApplicationMailer
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:comebacked]
     )
-    subject = "[FBC] #{@sender.login_name}さんが復帰しました。"
+    subject = "[FBC] #{@sender.login_name}さんが休会から復帰しました。"
     mail to: @user.email, subject: subject
   end
 

--- a/app/models/comeback_notifier.rb
+++ b/app/models/comeback_notifier.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ComebacknNotifier
+  def call(user)
+    User.admins_and_mentors.each do |admin_or_mentor|
+      ActivityDelivery.with(sender: user, receiver: admin_or_mentor).notify(:comebacked)
+    end
+  end
+end

--- a/app/models/comeback_notifier.rb
+++ b/app/models/comeback_notifier.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ComebacknNotifier
+class ComebackNotifier
   def call(user)
     User.admins_and_mentors.each do |admin_or_mentor|
       ActivityDelivery.with(sender: user, receiver: admin_or_mentor).notify(:comebacked)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -38,7 +38,8 @@ class Notification < ApplicationRecord
     hibernated: 19,
     signed_up: 20,
     regular_event_updated: 21,
-    no_correct_answer: 22
+    no_correct_answer: 22,
+    comebacked: 23
   }
 
   scope :unreads, -> { where(read: false) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -721,10 +721,10 @@ class User < ApplicationRecord
   def comeback!
     update_last_returned_at!
 
-#    subscription = Subscription.new.create(customer_id, trial: 0)
+    subscription = Subscription.new.create(customer_id, trial: 0)
 
     self.hibernated_at = nil
-#    self.subscription_id = subscription['id']
+    self.subscription_id = subscription['id']
     save!(validate: false)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -721,10 +721,10 @@ class User < ApplicationRecord
   def comeback!
     update_last_returned_at!
 
-    subscription = Subscription.new.create(customer_id, trial: 0)
+#    subscription = Subscription.new.create(customer_id, trial: 0)
 
     self.hibernated_at = nil
-    self.subscription_id = subscription['id']
+#    self.subscription_id = subscription['id']
     save!(validate: false)
   end
 

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -172,6 +172,21 @@ class ActivityNotifier < ApplicationNotifier
     )
   end
 
+  def comebacked(params = {})
+    params.merge!(@params)
+    sender = params[:sender]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{sender.login_name}さんが休会から復帰しました！",
+      kind: :comebacked,
+      sender: sender,
+      receiver: receiver,
+      link: Rails.application.routes.url_helpers.polymorphic_path(sender),
+      read: false
+    )
+  end
+
   def signed_up(params = {})
     params.merge!(@params)
     sender = params[:sender]

--- a/app/views/activity_mailer/comebacked.html.slim
+++ b/app/views/activity_mailer/comebacked.html.slim
@@ -1,0 +1,4 @@
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@sender.login_name}さんが復帰しました。",
+  link_url: @link_url,
+  link_text: "#{@sender.login_name}さんのページへ"

--- a/app/views/activity_mailer/comebacked.html.slim
+++ b/app/views/activity_mailer/comebacked.html.slim
@@ -1,4 +1,4 @@
 = render '/notification_mailer/notification_mailer_template',
-  title: "#{@sender.login_name}さんが復帰しました。",
+  title: "#{@sender.login_name}さんが休会から復帰しました！",
   link_url: @link_url,
   link_text: "#{@sender.login_name}さんのページへ"

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -30,5 +30,7 @@ Rails.configuration.to_prepare do
 
   Newspaper.subscribe(:graduation_update, GraduationNotifier.new)
 
+  Newspaper.subscribe(:comeback_update, ComebackNotifier.new)
+
   Newspaper.subscribe(:check_create, ProductStatusUpdater.new)
 end

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -42,7 +42,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
   test '.notify(:comebacked)' do
     params = {
       sender: users(:kimura),
-      receiver: users(:komagata),
+      receiver: users(:komagata)
     }
 
     Notification.create!(

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -53,6 +53,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       message: "#{users(:kimura).login_name}さんが休会から復帰しました！",
       read: false
     )
+
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.notify!(:comebacked, **params)
     end

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -3,8 +3,8 @@
 require 'test_helper'
 
 class ActivityDeliveryTest < ActiveSupport::TestCase
-  setup do
-    @params = {
+  test '.notify(:graduated)' do
+    params = {
       kind: :graduated,
       body: 'test message',
       sender: users(:kimura),
@@ -12,9 +12,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       link: '/example',
       read: false
     }
-  end
 
-  test '.notify(:graduated)' do
     Notification.create!(
       kind: Notification.kinds['graduated'],
       user: users(:komagata),
@@ -25,11 +23,11 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     )
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
-      ActivityDelivery.notify!(:graduated, **@params)
+      ActivityDelivery.notify!(:graduated, **params)
     end
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-      ActivityDelivery.notify(:graduated, **@params)
+      ActivityDelivery.notify(:graduated, **params)
     end
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
@@ -38,6 +36,37 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**@params).notify(:graduated)
+    end
+  end
+
+  test '.notify(:comebacked)' do
+    params = {
+      sender: users(:kimura),
+      receiver: users(:komagata),
+    }
+
+    Notification.create!(
+      kind: Notification.kinds['comebacked'],
+      user: users(:komagata),
+      sender: users(:kimura),
+      link: "/users/#{users(:kimura).id}",
+      message: "#{users(:kimura).login_name}さんが復帰しました",
+      read: false
+    )
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+      ActivityDelivery.notify!(:comebacked, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.notify(:comebacked, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify!(:comebacked)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify(:comebacked)
     end
   end
 end

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -50,7 +50,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       user: users(:komagata),
       sender: users(:kimura),
       link: "/users/#{users(:kimura).id}",
-      message: "#{users(:kimura).login_name}さんが復帰しました",
+      message: "#{users(:kimura).login_name}さんが休会から復帰しました！",
       read: false
     )
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -31,11 +31,11 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     end
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
-      ActivityDelivery.with(**@params).notify!(:graduated)
+      ActivityDelivery.with(**params).notify!(:graduated)
     end
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-      ActivityDelivery.with(**@params).notify(:graduated)
+      ActivityDelivery.with(**params).notify(:graduated)
     end
   end
 

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -53,19 +53,19 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       message: "#{users(:kimura).login_name}さんが休会から復帰しました！",
       read: false
     )
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.notify!(:comebacked, **params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.notify(:comebacked, **params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify!(:comebacked)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify(:comebacked)
     end
   end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -50,6 +50,53 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert ActionMailer::Base.deliveries.empty?
   end
 
+  test 'comebacked' do
+    user = users(:kimura)
+    mentor = users(:mentormentaro)
+    ActivityMailer.comebacked(
+      sender: user,
+      receiver: mentor
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 23, link: "/users/#{user.id}" }.to_param)
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['mentormentaro@fjord.jp'], email.to
+    assert_equal '[FBC] kimuraさんが休会から復帰しました。', email.subject
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">kimuraさんのページへ</a>}, email.body.to_s)
+  end
+
+  test 'comebacked with params' do
+    user = users(:kimura)
+    mentor = users(:mentormentaro)
+    mailer = ActivityMailer.with(
+      sender: user,
+      receiver: mentor
+    ).comebacked
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 23, link: "/users/#{user.id}" }.to_param)
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['mentormentaro@fjord.jp'], email.to
+    assert_equal '[FBC] kimuraさんが休会から復帰しました。', email.subject
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">kimuraさんのページへ</a>}, email.body.to_s)
+  end
+
+  test 'comebacked with user who have been denied' do
+    ActivityMailer.comebacked(
+      sender: users(:kimura),
+      receiver: users(:hajime)
+    ).deliver_now
+
+    assert ActionMailer::Base.deliveries.empty?
+  end
+
   test 'came_answer' do
     answer = answers(:answer3)
     ActivityMailer.came_answer(answer: answer).deliver_now

--- a/test/system/notification/comeback_test.rb
+++ b/test/system/notification/comeback_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Notification::ComebackTest < ApplicationSystemTestCase
+  setup do
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
+  test 'notify mentor when student comeback' do
+    visit new_comeback_path
+    within('form[name=comeback]') do
+      fill_in 'user[email]', with: 'kyuukai@fjord.jp'
+      fill_in 'user[password]', with: 'testtest'
+    end
+
+    VCR.use_cassette 'subscription/create', vcr_options do
+      click_on '休会から復帰する'
+    end
+    logout
+
+    visit_with_auth '/notifications', 'mentormentaro'
+    within first('.card-list-item.is-unread') do
+      assert_text 'kyuukaiさんが休会から復帰しました！'
+    end
+  end
+end


### PR DESCRIPTION
## Issue

- #5952 

## 概要
休会復帰時に管理者・メンターに通知が飛ぶようにしました。
通知はサイト内通知とメール通知です。

## 変更確認方法
1. `feature/add-notification-of-comeback`をローカルに取り込む
1. Stripeの処理をコメントアウトする
開発環境で休会復帰操作を行うと回避できないStripeのエラーが発生するため、Stripe関連の処理はコメントアウトして動作確認をします。

https://github.com/fjordllc/bootcamp/blob/4efa1c09434f93c1d3ddbee024996c483988e9d5/app/models/user.rb#L721-L729
上記`comeback!`メソッドの一部をコメントアウトして、以下のようにしてください。
```ruby
  def comeback!
    update_last_returned_at!

#    subscription = Subscription.new.create(customer_id, trial: 0)

    self.hibernated_at = nil
#    self.subscription_id = subscription['id']
    save!(validate: false)
  end
```

3. `$ bin/rails s`でアプリを立ち上げる。
4. 休会復帰ページhttp://localhost:3000/comeback/new にアクセス。
5. メールアドレス`kyuukai@fjord.jp`で休会復帰する。
6. http://localhost:3000/letter_opener/ を開き、休会復帰のメール通知が飛んでいることを確認する。
    - DBに登録されているユーザーがfixture通りなら5件飛んでいるはずです。 
7. `kyuukai`からログアウト
8. `komagata`(管理者もしくはメンターアカウント)でログイン。
9. サイト内通知 http://localhost:3000/notifications で休会復帰のお知らせが飛んでいることを確認する。

## Screenshot
### 変更後
- メール通知
![mail](https://user-images.githubusercontent.com/66685066/213612702-f881d938-6a93-48a3-b281-eafc709dd185.png)
- サイト内通知
![notice](https://user-images.githubusercontent.com/66685066/213613900-55b6ee1f-a947-40a4-927d-93ff0ca50a0a.png)

## 参考にしたPR
- #5961 
- #6063 
- #6070 