### PR TITLE
ReactでもTailwind CSSを使えるようにする

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   content: [
     './app/views/**/*.html.slim',
-    './app/javascript/**/*.{js,vue}',
+    './app/javascript/**/*.{js,jsx,vue}',
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6008

## 概要

今までTailwind CSSがReactで使えない状態だったので、使えるように`tailwind.config.js`を変更しました。

## 変更確認方法

1. [chore/tailwind-in-react](https://github.com/fjordllc/bootcamp/tree/chore/tailwind-in-react)をローカルに取り込む。
2. `bin/setup`を実行する。
3. `text-5xl`などのTailwind CSSのクラスをReactのコンポーネントに追加する。
4. `bundle exec rails s`を実行してブラウザで対象のReactのコンポーネントにTailwind CSSのクラスが適用されているか確認する。

