### PR TITLE
ブログのページにメンタープロフィールを追加

### DIFF
--- a/app/assets/stylesheets/welcome/welcome-member/_welcome-member.sass
+++ b/app/assets/stylesheets/welcome/welcome-member/_welcome-member.sass
@@ -1,16 +1,24 @@
 .welcome-member
+  &.is-welcome-index
+    +media-breakpoint-up(md)
+      height: 100%
+    +media-breakpoint-down(sm)
+      height: auto
+
+.welcome-member__inner
   padding: 1.25rem 1.5rem 1.5rem
-  +media-breakpoint-up(md)
-    height: 100%
-  +media-breakpoint-down(sm)
-    height: auto
+  .welcome-member.is-articles-show &
+    padding: .75rem 1rem
 
 .welcome-member__header
   display: flex
   align-items: flex-start
 
 .welcome-member__start
-  flex: 0 0 4.5rem
+  +media-breakpoint-up(md)
+    flex: 0 0 4.5rem
+  +media-breakpoint-down(sm)
+    flex: 0 0 3.5rem
 
 .welcome-member__end
   flex: 1
@@ -22,10 +30,16 @@
   margin-right: 1rem
 
 .welcome-member__name
-  +text-block(1.25rem 1.45, 600)
+  +media-breakpoint-up(md)
+    +text-block(1.25rem 1.45, 600)
+  +media-breakpoint-down(sm)
+    +text-block(1rem 1.45, 600)
 
 .welcome-member__job
-  +text-block(.75rem 1.45, 400)
+  +media-breakpoint-up(md)
+    +text-block(.75rem 1.45, 400)
+  +media-breakpoint-down(sm)
+    +text-block(.625rem 1.45, 400)
 
 .welcome-member__sns
   display: flex

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -12,6 +12,7 @@ class ArticlesController < ApplicationController
   end
 
   def show
+    @mentor = @article.user
     @recent_articles = list_recent_articles
     if !@article.wip? || admin_or_mentor_login?
       render layout: 'welcome'

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -57,7 +57,6 @@ ruby:
                       = link_to article_path(@article), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'a-button is-secondary is-md is-block' do
                         | 削除
         .col-xl-4.col-lg-4.col-xs-12
-          .a-card
-            = render partial: 'welcome/mentor', locals: { mentor: @mentor }
+          = render 'welcome/mentor', mentor: @mentor, page: 'articles-show'
           = render 'recent_articles'
           = render 'ad'

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -57,5 +57,7 @@ ruby:
                       = link_to article_path(@article), data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'a-button is-secondary is-md is-block' do
                         | 削除
         .col-xl-4.col-lg-4.col-xs-12
+          .a-card
+            = render partial: 'welcome/mentor', locals: { mentor: @mentor }
           = render 'recent_articles'
           = render 'ad'

--- a/app/views/welcome/_mentor.html.slim
+++ b/app/views/welcome/_mentor.html.slim
@@ -1,40 +1,45 @@
-section.welcome-member.a-card
-  .welcome-member__header
-    - if mentor.profile_image.attached?
-      .welcome-member__start
-        = image_tag(mentor.profile_image, class: 'welcome-member__image', alt: "#{mentor.profile_name}のアイコン画像")
-    .welcome-member__end
-      - if mentor.profile_name.present?
-        h3.welcome-member__name
-          = mentor.profile_name
-      - if mentor.profile_job.present?
-        p.welcome-member__job
-          = mentor.profile_job
-      ul.welcome-member__sns
-        - if mentor.github_account.present?
-          li.welcome-member__sns-item
-            = link_to "https://github.com/#{mentor.github_account}", class: 'welcome-member__sns-item-link' do
-              i.fa-brands.fa-github-alt
-        - if mentor.blog_url.present?
-          li.welcome-member__sns-item
-            = link_to mentor.blog_url, class: 'welcome-member__sns-item-link' do
-              i.fa-solid.fa-home
-        - if mentor.twitter_account.present?
-          li.welcome-member__sns-item
-            = link_to "https://twitter.com/#{mentor.twitter_account}", class: 'welcome-member__sns-item-link' do
-              i.fa-brands.fa-twitter
-        - if mentor.facebook_url.present?
-          li.welcome-member__sns-item
-            = link_to mentor.facebook_url, class: 'welcome-member__sns-item-link' do
-              i.fa-brands.fa-facebook-square
-  .welcome-member__body
-    .a-long-text.is-md.js-markdown-view
-      = mentor.profile_text
-  - if mentor.authored_books.present?
-    .welcome-member-books
-      ul.welcome-member-books__items
-        - mentor.authored_books.sorted.each do |authored_book|
-          - if authored_book.cover.attached?
-            li.welcome-member-books__item
-              = link_to authored_book.url, target: :_blank, rel: 'noopener noreferrer', class: 'welcome-member-books__item-link' do
-                = image_tag(authored_book.cover, alt: authored_book.title, class: 'welcome-member-books__item-image')
+section.welcome-member.a-card(class="is-#{page}")
+  - if page == 'articles-show'
+    header.card-header.is-sm
+      h2.card-header__title
+        | 著者
+  .welcome-member__inner
+    .welcome-member__header
+      - if mentor.profile_image.attached?
+        .welcome-member__start
+          = image_tag(mentor.profile_image, class: 'welcome-member__image', alt: "#{mentor.profile_name}のアイコン画像")
+      .welcome-member__end
+        - if mentor.profile_name.present?
+          h3.welcome-member__name
+            = mentor.profile_name
+        - if mentor.profile_job.present?
+          p.welcome-member__job
+            = mentor.profile_job
+        ul.welcome-member__sns
+          - if mentor.github_account.present?
+            li.welcome-member__sns-item
+              = link_to "https://github.com/#{mentor.github_account}", class: 'welcome-member__sns-item-link' do
+                i.fa-brands.fa-github-alt
+          - if mentor.blog_url.present?
+            li.welcome-member__sns-item
+              = link_to mentor.blog_url, class: 'welcome-member__sns-item-link' do
+                i.fa-solid.fa-home
+          - if mentor.twitter_account.present?
+            li.welcome-member__sns-item
+              = link_to "https://twitter.com/#{mentor.twitter_account}", class: 'welcome-member__sns-item-link' do
+                i.fa-brands.fa-twitter
+          - if mentor.facebook_url.present?
+            li.welcome-member__sns-item
+              = link_to mentor.facebook_url, class: 'welcome-member__sns-item-link' do
+                i.fa-brands.fa-facebook-square
+    .welcome-member__body
+      .a-long-text.js-markdown-view(class="#{page == 'articles-show' ? 'is-sm' : 'is-md'}")
+        = mentor.profile_text
+    - if mentor.authored_books.present?
+      .welcome-member-books
+        ul.welcome-member-books__items
+          - mentor.authored_books.sorted.each do |authored_book|
+            - if authored_book.cover.attached?
+              li.welcome-member-books__item
+                = link_to authored_book.url, target: :_blank, rel: 'noopener noreferrer', class: 'welcome-member-books__item-link' do
+                  = image_tag(authored_book.cover, alt: authored_book.title, class: 'welcome-member-books__item-image')

--- a/app/views/welcome/_mentors.html.slim
+++ b/app/views/welcome/_mentors.html.slim
@@ -6,4 +6,4 @@ section.welcome-child-section
       - mentors.each do |mentor|
         - if mentor.profile_image && mentor.profile_name && mentor.profile_job && mentor.profile_text
           .col-xs-12.col-md-6.col-lg-4
-            = render 'welcome/mentor', mentor: mentor
+            = render 'welcome/mentor', mentor: mentor, page: 'welcome-index'


### PR DESCRIPTION
## Issue

- #6040 

## 概要
`/welcome` ページのヘッダーから「ブログ」ページへ遷移し、個別のブログ詳細を開くと著者（メンター）のプロフィールが表示されるように修正
## 変更確認方法

1. `feature/add_mentor_profile_to_blog` をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. http://localhost:3000/articles から任意のブログにアクセスする
4. 右サイドエリアにプロフィールが表示されているかを確認

## Screenshot

### 変更前

<img width="1796" alt="プロフィールbefore" src="https://user-images.githubusercontent.com/76797372/212913896-142fcc16-f18f-4686-a9ff-f8fa2a775e44.png">

### 変更後
<img width="1679" alt="プロフィールafter_1" src="https://user-images.githubusercontent.com/76797372/212913947-8cd95fef-e0ac-4a28-b7b0-368159817e92.png">
<img width="1688" alt="プロフィールafter_2" src="https://user-images.githubusercontent.com/76797372/212913985-c7f4d39c-5fba-40d3-8160-cafa029c278e.png">
<img width="728" alt="プロフィールafter_3" src="https://user-images.githubusercontent.com/76797372/212914072-25f53fa9-df69-4b45-acbe-eae77fed4aec.png">

### ローカルテスト実行結果
<img width="954" alt="ローカルテスト1" src="https://user-images.githubusercontent.com/76797372/212914199-a82ad3dc-c239-4db3-8b74-cb9c734902db.png">

<img width="976" alt="ローカルテスト2" src="https://user-images.githubusercontent.com/76797372/212914237-836c7dc0-299c-4276-aad4-8e094a2a7e43.png">

