### PR TITLE
卒業通知メール本文にあるリンクをフルパスのURLに修正する

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -15,7 +15,7 @@ class ActivityMailer < ApplicationMailer
     @receiver ||= args[:receiver]
 
     @user = @receiver
-    @link_url = notification_redirector_path(
+    @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:graduated]
     )

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -13,10 +13,11 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 18, link: "/users/#{user.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['mentormentaro@fjord.jp'], email.to
     assert_equal '[FBC] sotugyouさんが卒業しました。', email.subject
-    assert_match(/卒業/, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">sotugyouさんのページへ</a>}, email.body.to_s)
   end
 
   test 'graduated with params' do
@@ -33,9 +34,10 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 18, link: "/users/#{user.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['mentormentaro@fjord.jp'], email.to
     assert_equal '[FBC] sotugyouさんが卒業しました。', email.subject
-    assert_match(/卒業/, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">sotugyouさんのページへ</a>}, email.body.to_s)
   end
 end


### PR DESCRIPTION
## Issue

- #6065

## 概要

卒業通知メール本文にあるリンクが相対的なURLになっていたため、ホスト名を含めたフルパスのURLに変更する必要がある。

開発環境では http://localhost:3000/letter_opener/ でメールを閲覧しているため、リンククリック時にホスト名が補完される。
メーラーの場合はホスト名が補完されない。

## 変更確認方法

1. `bug/fix-mailer-body-link-from-path-to-url` をローカルに取り込みます
2. `bin/setup` を実行します
3. `bin/rails s` でサーバーを立ち上げます
4. http://localhost:3000/rails/mailers/activity_mailer/graduated にアクセスします
5. 卒業アカウントへのリンク要素を検証ツールから確認し `href` 属性の値が `http://localhost:3000/notification/redirector?` から始まること

## Screenshot

### 変更前

![path_to_url](https://user-images.githubusercontent.com/943541/213100220-de9f4f8a-f330-45f6-92f8-b818b2e767e1.png)

### 変更後

![path_to_url after](https://user-images.githubusercontent.com/943541/213111742-b2c0f849-5ff2-4de8-adbb-d940ea752050.png)
