### PR TITLE
Doc個別ページの右カラムに、そのDocの紐づくプラクティスに紐づくDocs一覧を表示するようにした

### DIFF
--- a/app/assets/stylesheets/shared/_container.sass
+++ b/app/assets/stylesheets/shared/_container.sass
@@ -1,9 +1,9 @@
 .container
   max-width: 100%
   +margin(horizontal, auto)
-  +media-breakpoint-up(lg)
+  +media-breakpoint-up(md)
     +padding(horizontal, 1.5rem)
-  +media-breakpoint-down(md)
+  +media-breakpoint-down(sm)
     +padding(horizontal, 1rem)
   &.is-xxxl
     width: 93.75rem

--- a/app/assets/stylesheets/shared/blocks/_page-nav.sass
+++ b/app/assets/stylesheets/shared/blocks/_page-nav.sass
@@ -1,14 +1,13 @@
 .page-nav
-  +position(right 0, top 3.5rem)
-  position: sticky
-  transition: opacity .2s ease-in
-  overflow: hidden
+  +media-breakpoint-up(lg)
+    +position(right 0, top 3.5rem)
+    position: sticky
+    overflow: hidden
   +media-breakpoint-down(md)
-    display: none
+    position: static
 
 .page-nav__header
   border: solid 1px $border
-  border-bottom: none
   background-color: $base
   border-radius: .25rem .25rem 0 0
 
@@ -23,10 +22,34 @@
   white-space: nowrap
   overflow: hidden
   text-overflow: ellipsis
+  &:hover
+    text-decoration: underline
+
+.page-nav__footer
+  border: solid 1px $border
+  background-color: $base
+  border-radius: 0 0 .25rem .25rem
+  transform: translateY(-1px)
+
+.page-nav__footer-link
+  +block-link
+  +text-block(.8125rem 1.4)
+  text-align: right
+  padding: .5rem .75rem
+  color: $default-text
+  white-space: nowrap
+  overflow: hidden
+  text-overflow: ellipsis
+  &:hover
+    text-decoration: underline
 
 .page-nav__items
-  max-height: calc(100vh - 8.5rem)
   overflow-y: auto
+  transform: translateY(-1px)
+  +media-breakpoint-up(lg)
+    max-height: calc(100vh - 8.5rem)
+  +media-breakpoint-down(md)
+    max-height: 12rem
 
 =page-nav-current($background-color, $border-color, $text-color, $pointer-events-none)
   +position(relative, 1)
@@ -47,6 +70,8 @@
     border-radius: 0
   &:last-child
     border-radius: 0 0 .25rem .25rem
+  .page-nav.has-footer &:last-child
+    border-radius: 0
   &:not(:first-child)
     margin-top: -1px
   &.is-active

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,8 @@ class PagesController < ApplicationController
   before_action :set_categories, only: %i[new create edit update]
   before_action :redirect_to_slug, only: %i[show edit]
 
+  SIDE_LINK_LIMIT = 20
+
   def index
     @pages = Page.with_avatar
                  .includes(:comments, :practice, :tags,
@@ -16,7 +18,7 @@ class PagesController < ApplicationController
   end
 
   def show
-    @pages = @page.practice.pages.limit(20) if @page.practice
+    @pages = @page.practice.pages.limit(SIDE_LINK_LIMIT) if @page.practice
   end
 
   def new

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,9 @@ class PagesController < ApplicationController
     @tag = ActsAsTaggableOn::Tag.find_by(name: params[:tag])
   end
 
-  def show; end
+  def show
+    @pages = @page.practice.pages.limit(20) if @page.practice
+  end
 
   def new
     @page = Page.new

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -15,28 +15,52 @@ header.page-header
 
 .page-body
   .container.is-lg
-    .doc.page-content
-      = render 'doc_header', page: @page
-      .a-card
-        .card-body
-          .card__description
-            .a-long-text.is-md.js-markdown-view
-              = @page.body
-        = render 'reactions/reactions', reactionable: @page
-        footer.card-footer
-          .card-main-actions
-            ul.card-main-actions__items
-              li.card-main-actions__item
-                = link_to [:edit, @page], class: 'card-main-actions__action a-button is-sm is-secondary is-block' do
-                  i.fa-solid.fa-pen
-                  | 内容変更
-              - if admin_or_mentor_login? || current_user == @page.user
-                li.card-main-actions__item.is-sub
-                  = link_to @page, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
-                    | 削除する
-      .page-content-prev-next
-        .page-content-prev-next__item
-          = link_to :pages, class: 'page-content-prev-next__item-link is-index' do
-            | 一覧に戻る
+    .row.is-gutter-width-32
+      .col-lg-8.col-xs-12
+        .doc.page-content
+          = render 'doc_header', page: @page
+          .a-card
+            .card-body
+              .card__description
+                .a-long-text.is-md.js-markdown-view
+                  = @page.body
+            = render 'reactions/reactions', reactionable: @page
+            footer.card-footer
+              .card-main-actions
+                ul.card-main-actions__items
+                  li.card-main-actions__item
+                    = link_to [:edit, @page], class: 'card-main-actions__action a-button is-sm is-secondary is-block' do
+                      i.fa-solid.fa-pen
+                      | 内容変更
+                  - if admin_or_mentor_login? || current_user == @page.user
+                    li.card-main-actions__item.is-sub
+                      = link_to @page, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
+                        | 削除する
+          .page-content-prev-next
+            .page-content-prev-next__item
+              = link_to :pages, class: 'page-content-prev-next__item-link is-index' do
+                | 一覧に戻る
 
-    #js-comments(data-commentable-id="#{@page.id}" data-commentable-type='Page' data-current-user-id="#{current_user.id}")
+        #js-comments(data-commentable-id="#{@page.id}" data-commentable-type='Page' data-current-user-id="#{current_user.id}")
+
+      .col-lg-4.col-xs-12
+        nav.page-nav
+          header.page-nav__header
+            h2.page-nav__title
+              = link_to @page.practice,
+                class: 'page-nav__title-link' do
+                - if @page.practice.present?
+                  = @page.practice.title
+          ul.page-nav__items
+            - if @pages.present?
+              - @pages.each do |page|
+                li.page-nav__item(class="#{@page == page ? 'is-current' : ''}")
+                  = link_to page_path(page), class: 'page-nav__item-link' do
+                    span.page-nav__item-link-inner
+                      = page.title
+          header.page-nav__header
+            h2.page-nav__title
+              - if @page.practice.present?
+                = link_to practice_pages_path(@page.practice),
+                  class: 'page-nav__title-link' do
+                  = @page.practice.title + "の関連ドキュメント一覧"

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -45,22 +45,23 @@ header.page-header
 
       .col-lg-4.col-xs-12
         nav.page-nav
-          header.page-nav__header
-            h2.page-nav__title
-              = link_to @page.practice,
-                class: 'page-nav__title-link' do
-                - if @page.practice.present?
-                  = @page.practice.title
-          ul.page-nav__items
-            - if @pages.present?
-              - @pages.each do |page|
-                li.page-nav__item(class="#{@page == page ? 'is-current' : ''}")
-                  = link_to page_path(page), class: 'page-nav__item-link' do
-                    span.page-nav__item-link-inner
-                      = page.title
-          header.page-nav__header
-            h2.page-nav__title
-              - if @page.practice.present?
-                = link_to practice_pages_path(@page.practice),
+          - if @page.practice
+            header.page-nav__header
+              h2.page-nav__title
+                = link_to @page.practice,
                   class: 'page-nav__title-link' do
-                  = @page.practice.title + "の関連ドキュメント一覧"
+                  - if @page.practice.present?
+                    = @page.practice.title
+            ul.page-nav__items
+              - if @pages.present?
+                - @pages.each do |page|
+                  li.page-nav__item(class="#{@page == page ? 'is-current' : ''}")
+                    = link_to page_path(page), class: 'page-nav__item-link' do
+                      span.page-nav__item-link-inner
+                        = page.title
+            header.page-nav__header
+              h2.page-nav__title
+                - if @page.practice.present?
+                  = link_to practice_pages_path(@page.practice),
+                    class: 'page-nav__title-link' do
+                    = @page.practice.title + "の関連ドキュメント一覧"

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -14,7 +14,7 @@ header.page-header
               | Docs
 
 .page-body
-  .container.is-lg
+  .container.is-xxl
     .row.is-gutter-width-32
       .col-lg-8.col-xs-12
         .doc.page-content
@@ -44,7 +44,7 @@ header.page-header
         #js-comments(data-commentable-id="#{@page.id}" data-commentable-type='Page' data-current-user-id="#{current_user.id}")
 
       .col-lg-4.col-xs-12
-        nav.page-nav
+        nav.page-nav.has-footer
           - if @page.practice
             header.page-nav__header
               h2.page-nav__title
@@ -59,9 +59,8 @@ header.page-header
                     = link_to page_path(page), class: 'page-nav__item-link' do
                       span.page-nav__item-link-inner
                         = page.title
-            header.page-nav__header
-              h2.page-nav__title
-                - if @page.practice.present?
-                  = link_to practice_pages_path(@page.practice),
-                    class: 'page-nav__title-link' do
-                    = "#{@page.practice.title}の関連ドキュメント一覧"
+            footer.page-nav__footer
+              - if @page.practice.present?
+                = link_to practice_pages_path(@page.practice),
+                  class: 'page-nav__footer-link' do
+                  | 全て見る

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -64,4 +64,4 @@ header.page-header
                 - if @page.practice.present?
                   = link_to practice_pages_path(@page.practice),
                     class: 'page-nav__title-link' do
-                    = @page.practice.title + "の関連ドキュメント一覧"
+                    = "#{@page.practice.title}の関連ドキュメント一覧"

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -50,17 +50,14 @@ header.page-header
               h2.page-nav__title
                 = link_to @page.practice,
                   class: 'page-nav__title-link' do
-                  - if @page.practice.present?
-                    = @page.practice.title
+                  = @page.practice.title
             ul.page-nav__items
-              - if @pages.present?
-                - @pages.each do |page|
-                  li.page-nav__item(class="#{@page == page ? 'is-current' : ''}")
-                    = link_to page_path(page), class: 'page-nav__item-link' do
-                      span.page-nav__item-link-inner
-                        = page.title
+              - @pages.each do |page|
+                li.page-nav__item(class="#{@page == page ? 'is-current' : ''}")
+                  = link_to page_path(page), class: 'page-nav__item-link' do
+                    span.page-nav__item-link-inner
+                      = page.title
             footer.page-nav__footer
-              - if @page.practice.present?
-                = link_to practice_pages_path(@page.practice),
-                  class: 'page-nav__footer-link' do
-                  | 全て見る
+              = link_to practice_pages_path(@page.practice),
+                class: 'page-nav__footer-link' do
+                | 全て見る

--- a/db/fixtures/pages.yml
+++ b/db/fixtures/pages.yml
@@ -126,3 +126,163 @@ page14:
   slug: practice_common_description
   user: komagata
   published_at: "2022-03-10 00:00:00"
+
+page15:
+  title: プラクティスに紐付いたDocs2
+  body: プラクティスに紐付いている2
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-02 00:00:00"
+  last_updated_user: komagata
+
+page16:
+  title: プラクティスに紐付いたDocs3
+  body: プラクティスに紐付いている3
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-03 00:00:00"
+  last_updated_user: komagata
+
+page17:
+  title: プラクティスに紐付いたDocs4
+  body: プラクティスに紐付いている4
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-04 00:00:00"
+  last_updated_user: komagata
+
+page18:
+  title: プラクティスに紐付いたDocs5
+  body: プラクティスに紐付いている5
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-05 00:00:00"
+  last_updated_user: komagata
+
+page19:
+  title: プラクティスに紐付いたDocs6
+  body: プラクティスに紐付いている6
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-06 00:00:00"
+  last_updated_user: komagata
+
+page20:
+  title: プラクティスに紐付いたDocs7
+  body: プラクティスに紐付いている7
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-07 00:00:00"
+  last_updated_user: komagata
+
+page21:
+  title: プラクティスに紐付いたDocs8
+  body: プラクティスに紐付いている8
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-08 00:00:00"
+  last_updated_user: komagata
+
+page22:
+  title: プラクティスに紐付いたDocs9
+  body: プラクティスに紐付いている9
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-09 00:00:00"
+  last_updated_user: komagata
+
+page23:
+  title: プラクティスに紐付いたDocs10
+  body: プラクティスに紐付いている10
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-10 00:00:00"
+  last_updated_user: komagata
+
+page24:
+  title: プラクティスに紐付いたDocs11
+  body: プラクティスに紐付いている11
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-11 00:00:00"
+  last_updated_user: komagata
+
+page25:
+  title: プラクティスに紐付いたDocs12
+  body: プラクティスに紐付いている12
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-12 00:00:00"
+  last_updated_user: komagata
+
+page26:
+  title: プラクティスに紐付いたDocs13
+  body: プラクティスに紐付いている13
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-13 00:00:00"
+  last_updated_user: komagata
+
+page27:
+  title: プラクティスに紐付いたDocs14
+  body: プラクティスに紐付いている14
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-14 00:00:00"
+  last_updated_user: komagata
+
+page28:
+  title: プラクティスに紐付いたDocs15
+  body: プラクティスに紐付いている15
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-15 00:00:00"
+  last_updated_user: komagata
+
+page29:
+  title: プラクティスに紐付いたDocs16
+  body: プラクティスに紐付いている16
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-16 00:00:00"
+  last_updated_user: komagata
+
+page30:
+  title: プラクティスに紐付いたDocs17
+  body: プラクティスに紐付いている17
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-17 00:00:00"
+  last_updated_user: komagata
+
+page31:
+  title: プラクティスに紐付いたDocs18
+  body: プラクティスに紐付いている18
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-18 00:00:00"
+  last_updated_user: komagata
+
+page32:
+  title: プラクティスに紐付いたDocs19
+  body: プラクティスに紐付いている19
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-19 00:00:00"
+  last_updated_user: komagata
+
+page33:
+  title: プラクティスに紐付いたDocs20
+  body: プラクティスに紐付いている20
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-20 00:00:00"
+  last_updated_user: komagata
+
+page34:
+  title: プラクティスに紐付いたDocs21
+  body: プラクティスに紐付いている21
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-21 00:00:00"
+  last_updated_user: komagata

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -101,3 +101,11 @@ page11:
   body: test
   user: long-id-mentor
   published_at: "2022-04-15 00:00:00"
+
+page12:
+  title: プラクティスに紐付いたDocs2
+  body: プラクティスに紐付いている2
+  user: komagata
+  practice: practice1
+  published_at: "2022-12-02 00:00:00"
+  last_updated_user: komagata

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -101,11 +101,3 @@ page11:
   body: test
   user: long-id-mentor
   published_at: "2022-04-15 00:00:00"
-
-page12:
-  title: プラクティスに紐付いたDocs2
-  body: プラクティスに紐付いている2
-  user: komagata
-  practice: practice1
-  published_at: "2022-12-02 00:00:00"
-  last_updated_user: komagata

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -246,7 +246,7 @@ class PagesTest < ApplicationSystemTestCase
   test 'Check the list of columns on the right of the document' do
     visit_with_auth "/pages/#{pages(:page7).id}", 'kimura'
     assert_link 'OS X Mountain Lionをクリーンインストールする'
-    assert_link 'プラクティスに紐付いたDocs2'
+    assert_link 'プラクティスに紐付いたDocs'
     assert_link 'OS X Mountain Lionをクリーンインストールするの関連ドキュメント一覧'
   end
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -247,6 +247,6 @@ class PagesTest < ApplicationSystemTestCase
     visit_with_auth "/pages/#{pages(:page7).id}", 'kimura'
     assert_link 'OS X Mountain Lionをクリーンインストールする'
     assert_link 'プラクティスに紐付いたDocs'
-    assert_link 'OS X Mountain Lionをクリーンインストールするの関連ドキュメント一覧'
+    assert_link '全て見る'
   end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -242,4 +242,12 @@ class PagesTest < ApplicationSystemTestCase
     assert_text 'ページを更新しました'
     assert_match 'Message to Discord.', mock_log.to_s
   end
+
+  test 'Check the list of columns on the right of the document' do
+    visit_with_auth "/pages/#{pages(:page7).id}", 'kimura'
+    assert_link 'OS X Mountain Lionをクリーンインストールする'
+    assert_link 'プラクティスに紐付いたDocs2'
+    assert_link 'OS X Mountain Lionをクリーンインストールするの関連ドキュメント一覧'
+  end
+
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -249,5 +249,4 @@ class PagesTest < ApplicationSystemTestCase
     assert_link 'プラクティスに紐付いたDocs'
     assert_link 'OS X Mountain Lionをクリーンインストールするの関連ドキュメント一覧'
   end
-
 end


### PR DESCRIPTION
## Issue

- #6000 

## 概要

Doc個別ページの右カラムに、そのDocの紐づくプラクティスに紐づくDocs一覧を表示するように致しました。

Issueに従って、Docの表示数は20個に制限致しました。

また、Docs一覧の最初に「紐づくプラクティス名」を、最後に「紐づくプラクティスに関連するドキュメント一覧」へのリンクを表示するように致しました。

## 変更確認方法

1. `feature/display-related-docs-on-the-right-column-of-the-doc-page`をローカルに取り込む
2. `bin/rails db:seed`を実行して、seedファイルが反映されるようにする（プラクティスに紐づいたDoc21個が自動生成される）。
3. `http://localhost:3000/pages/568079207`へと進み、右カラムにDocs一覧が表示されていることを確認する。

## Screenshot

### 変更前

![image](https://user-images.githubusercontent.com/93074851/213662676-5f0e44dc-eeb7-4f32-8e79-6d751549ebfe.png)


### 変更後
ページ上部
![スクリーンショット_20230120_161412](https://user-images.githubusercontent.com/93074851/213661083-9689ebdc-82ed-40c4-a87e-afb2beb77271.png)

ページ下部
![スクリーンショット_20230120_161428](https://user-images.githubusercontent.com/93074851/213661124-376b8632-6556-416c-9758-28a3b27dc838.png)


## GIF画像

動作確認をGIF画像にしてみました。

![docs](https://user-images.githubusercontent.com/93074851/213662449-2972af94-25c1-4cd2-8027-181bb214f655.gif)



## デザインについて
デザイン調整が難しく、現段階ではDocページの横幅が狭くなってしまっているので、ご確認よろしくお願いします。🙏