### PR TITLE
ログイン失敗時に続けてログイン可能にする

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -24,6 +24,7 @@ class UserSessionsController < ApplicationController
       end
     else
       logout
+      @user = User.new
       flash.now[:alert] = 'ユーザー名かパスワードが違います。'
       render 'new'
     end

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -25,7 +25,7 @@ class SignInTest < ApplicationSystemTestCase
     assert_text 'ログインしました。'
   end
 
-  test 'sign in with wrong password' do
+  test 'sign in with wrong password, then sign in successfully' do
     visit '/login'
     within('#sign-in-form') do
       fill_in('user[login]', with: 'komagata')
@@ -33,6 +33,13 @@ class SignInTest < ApplicationSystemTestCase
     end
     click_button 'ログイン'
     assert_text 'ユーザー名かパスワードが違います。'
+
+    within('#sign-in-form') do
+      fill_in('user[login]', with: 'komagata')
+      fill_in('user[password]', with: 'testtest')
+    end
+    click_button 'ログイン'
+    assert_text 'ログインしました。'
   end
 
   test 'sign in with retire account' do


### PR DESCRIPTION
## Issue

- #6055 

## 概要

ログイン画面でログインに失敗した場合、その後正しいユーザー名とパスワードを
入力してもログインできませんでしたが、ログインできるようにしました。

## 変更確認方法

1. `bug/enable-login-after-login-failure`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. `http://localhost:3000/login`にアクセス
4. 間違いのあるユーザー名 or パスワードを入力してログインをクリック
5. ログイン可能なユーザー名とパスワードを入力してログインをクリック
6. 「ログインしました。」が表示され、ログインできる

## Screenshot

### 変更前

![login-before](https://user-images.githubusercontent.com/69447745/213686143-eb17549f-3be9-42ed-932c-57b91afd0566.gif)

### 変更後

![login-after](https://user-images.githubusercontent.com/69447745/213686150-76ff033d-0126-428d-ba1f-dc8f7f90c587.gif)

