### PR TITLE
休会中のユーザーに、is-hibernationed というclassを付与

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -9,11 +9,11 @@ module UserDecorator
     role_list = [
       { role: 'retired', value: retired? },
       { role: 'hibernationed', value: hibernated? },
-      { role: 'admin', value: admin },
-      { role: 'mentor', value: mentor },
-      { role: 'adviser', value: adviser },
+      { role: 'admin', value: admin? },
+      { role: 'mentor', value: mentor? },
+      { role: 'adviser', value: adviser? },
       { role: 'graduate', value: graduated? },
-      { role: 'trainee', value: trainee }
+      { role: 'trainee', value: trainee? }
     ]
     roles = role_list.find_all { |v| v[:value] }
                      .map { |v| v[:role] }
@@ -28,9 +28,9 @@ module UserDecorator
 
   def staff_roles
     staff_roles = [
-      { role: '管理者', value: admin },
-      { role: 'メンター', value: mentor },
-      { role: 'アドバイザー', value: adviser }
+      { role: '管理者', value: admin? },
+      { role: 'メンター', value: mentor? },
+      { role: 'アドバイザー', value: adviser? }
     ]
     staff_roles.find_all { |v| v[:value] }
                .map { |v| v[:role] }
@@ -43,11 +43,11 @@ module UserDecorator
     roles = [
       { role: '退会ユーザー', value: retired? },
       { role: '休会ユーザー', value: hibernated? },
-      { role: '管理者', value: admin },
-      { role: 'メンター', value: mentor },
-      { role: 'アドバイザー', value: adviser },
+      { role: '管理者', value: admin? },
+      { role: 'メンター', value: mentor? },
+      { role: 'アドバイザー', value: adviser? },
       { role: '卒業生', value: graduated? },
-      { role: '研修生', value: trainee }
+      { role: '研修生', value: trainee? }
     ]
     roles.find_all { |v| v[:value] }
          .map { |v| v[:role] }

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -6,15 +6,17 @@ module UserDecorator
   end
 
   def roles
-    roles = []
-
-    roles << :retired if retired_on?
-    roles << :hibernationed if hibernated_at?
-    roles << :admin if admin?
-    roles << :mentor if mentor?
-    roles << :adviser if adviser?
-    roles << :graduate if graduated_on?
-    roles << :trainee if trainee?
+    role_list = [
+      { role: 'retired', value: retired? },
+      { role: 'hibernated', value: hibernated? },
+      { role: 'admin', value: admin },
+      { role: 'mentor', value: mentor },
+      { role: 'adviser', value: adviser },
+      { role: 'graduate', value: graduated? },
+      { role: 'trainee', value: trainee }
+    ]
+    roles = role_list.find_all { |v| v[:value] }
+                     .map { |v| v[:role] }
     roles << :student if roles.empty?
 
     roles

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -8,7 +8,7 @@ module UserDecorator
   def roles
     role_list = [
       { role: 'retired', value: retired? },
-      { role: 'hibernated', value: hibernated? },
+      { role: 'hibernationed', value: hibernated? },
       { role: 'admin', value: admin },
       { role: 'mentor', value: mentor },
       { role: 'adviser', value: adviser },
@@ -41,12 +41,12 @@ module UserDecorator
     return '' if roles.empty?
 
     roles = [
-      { role: '退会ユーザー', value: retired_on? },
-      { role: '休会ユーザー', value: hibernated_at? },
+      { role: '退会ユーザー', value: retired? },
+      { role: '休会ユーザー', value: hibernated? },
       { role: '管理者', value: admin },
       { role: 'メンター', value: mentor },
       { role: 'アドバイザー', value: adviser },
-      { role: '卒業生', value: graduated_on? },
+      { role: '卒業生', value: graduated? },
       { role: '研修生', value: trainee }
     ]
     roles.find_all { |v| v[:value] }

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -9,6 +9,7 @@ module UserDecorator
     roles = []
 
     roles << :retired if retired_on?
+    roles << :hibernationed if hibernated_at?
     roles << :admin if admin?
     roles << :mentor if mentor?
     roles << :adviser if adviser?
@@ -39,6 +40,7 @@ module UserDecorator
 
     roles = [
       { role: '退会ユーザー', value: retired_on? },
+      { role: '休会ユーザー', value: hibernated_at? },
       { role: '管理者', value: admin },
       { role: 'メンター', value: mentor },
       { role: 'アドバイザー', value: adviser },

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -15,6 +15,7 @@ class UserDecoratorTest < ActiveSupport::TestCase
     @mentor_user = ActiveDecorator::Decorator.instance.decorate(users(:mentormentaro))
     @trainee_user = ActiveDecorator::Decorator.instance.decorate(users(:kensyu))
     @retired_user = ActiveDecorator::Decorator.instance.decorate(users(:taikai))
+    @hibernationed_user = ActiveDecorator::Decorator.instance.decorate(users(:kyuukai))
   end
 
   test '#staff_roles' do
@@ -49,5 +50,6 @@ class UserDecoratorTest < ActiveSupport::TestCase
     assert_equal 'メンター', @mentor_user.roles_to_s
     assert_equal '研修生', @trainee_user.roles_to_s
     assert_equal '退会ユーザー', @retired_user.roles_to_s
+    assert_equal '休会ユーザー', @hibernationed_user.roles_to_s
   end
 end


### PR DESCRIPTION
## Issue
- #5937 

## 概要
### 行ったこと
#### 休会ユーザーに`is-hibernationed `クラスを付与
以下の例では管理者なので`is-admin`というクラスが付与されています。

<img width="108" alt="スクリーンショット 2022-11-30 16 53 11" src="https://user-images.githubusercontent.com/81839214/204738436-9a967802-c4db-477e-9f1e-0595574e9efc.png">

<img width="1065" alt="スクリーンショット 2022-11-30 16 51 38" src="https://user-images.githubusercontent.com/81839214/204738131-7fc5f91d-08aa-4855-96ca-be87b7d1681d.png">

他にも以下のような`user class`が状況に応じて付与される様になっています。
- 現役受講生... is-student
- 管理者... is-admin
- メンター... is-mentor
- アドバイザー... is-adviser
- 研修生... is-trainee
- 卒業生... is-graduate
- 退会ユーザー...is-retired

しかし休会したユーザーのclassがないので、退会したユーザーアイコンに`is-hibernationed`というクラスを付与しました。

## 変更確認方法

1.`feature/give-class-to-hibernationed-user`をローカルに取り込んでください。
2. bin/rails sでローカル環境を立ち上げてください。
3. 任意のアカウントでログインを行い、ページ右上の検索窓から`kyuukai`を検索してください。
<img width="1440" alt="スクリーンショット 2023-01-21 17 30 56" src="https://user-images.githubusercontent.com/81839214/213858928-27245d57-c626-4e6e-abe7-b5629b41f16d.png">
4. `kyuukai`ユーザーが表示されるので開発者ツールでユーザーアイコンを確認し、`img`タグのクラスに`is-hibernationed`クラスが付与されていることを確認してください。
<img width="1440" alt="スクリーンショット 2023-01-21 17 32 03" src="https://user-images.githubusercontent.com/81839214/213858988-c042cdcd-3da6-4a4a-8c55-4b5abe5ca941.png">


## Screenshot

### 変更前
<img width="1440" alt="スクリーンショット 2023-01-21 16 47 54" src="https://user-images.githubusercontent.com/81839214/213854164-0f7d0899-8c02-4f9b-a26f-efb590ba61ca.png">


### 変更後
<img width="1440" alt="スクリーンショット 2023-01-21 16 55 15" src="https://user-images.githubusercontent.com/81839214/213854069-d3e4277e-dc2f-45fc-acec-bf19d003b7cb.png">