### PR TITLE
提出通知をactive delivery化する

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -60,9 +60,8 @@ class ActivityMailer < ApplicationMailer
     message
   end
 
-  # required params: product, receivers, message
+  # required params: product, receiver
   def submitted(args = {})
-    @message = params&.key?(:message) ? params[:message] : args[:message]
     @product = params&.key?(:product) ? params[:product] : args[:product]
     @sender ||= args[:sender]
     @receiver ||= args[:receiver]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -68,7 +68,7 @@ class ActivityMailer < ApplicationMailer
     @receiver ||= args[:receiver]
 
     @user = @receiver
-    @link_url = notification_redirector_path(
+    @link_url = notification_redirector_url(
       link: "/products/#{@product.id}",
       kind: Notification.kinds[:submitted]
     )

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -73,7 +73,7 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:submitted]
     )
     # @notification = @user.notifications.find_by(link: "/products/#{product.id}")
-    subject = "[FBC] #{message}"
+    subject = "[FBC] #{@message}"
     mail to: @user.email, subject: subject
   end
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -63,7 +63,6 @@ class ActivityMailer < ApplicationMailer
   # required params: product, receiver
   def submitted(args = {})
     @product = params&.key?(:product) ? params[:product] : args[:product]
-    @sender ||= args[:sender]
     @receiver ||= args[:receiver]
 
     @user = @receiver

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -71,8 +71,11 @@ class ActivityMailer < ApplicationMailer
       link: "/products/#{@product.id}",
       kind: Notification.kinds[:submitted]
     )
-    subject = "[FBC] #{@message}"
-    mail to: @user.email, subject: subject
+    subject = "[FBC] #{@product.user.login_name}さんが#{@product.title}を提出しました。"
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
   end
 
   # required params: announcement, receiver

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -72,7 +72,6 @@ class ActivityMailer < ApplicationMailer
       link: "/products/#{@product.id}",
       kind: Notification.kinds[:submitted]
     )
-    # @notification = @user.notifications.find_by(link: "/products/#{product.id}")
     subject = "[FBC] #{@message}"
     mail to: @user.email, subject: subject
   end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -60,6 +60,23 @@ class ActivityMailer < ApplicationMailer
     message
   end
 
+  # required params: product, receivers, message
+  def submitted(args = {})
+    @message = params&.key?(:message) ? params[:message] : args[:message]
+    @product = params&.key?(:product) ? params[:product] : args[:product]
+    @sender ||= args[:sender]
+    @receiver ||= args[:receiver]
+
+    @user = @receiver
+    @link_url = notification_redirector_path(
+      link: "/products/#{@product.id}",
+      kind: Notification.kinds[:submitted]
+    )
+    # @notification = @user.notifications.find_by(link: "/products/#{product.id}")
+    subject = "[FBC] #{message}"
+    mail to: @user.email, subject: subject
+  end
+
   # required params: announcement, receiver
   def post_announcement(args = {})
     @receiver ||= args[:receiver]

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -53,6 +53,20 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: "[FBC] #{@message}"
   end
 
+  # required params: announcement, receiver
+  def post_announcement
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: "/announcements/#{@announcement.id}")
+    mail to: @user.email, subject: "[FBC] お知らせ「#{@announcement.title}」"
+  end
+
+  # required params: question, receiver
+  def came_question
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: "/questions/#{@question.id}")
+    mail to: @user.email, subject: "[FBC] #{@question.user.login_name}さんから質問「#{@question.title}」が投稿されました。"
+  end
+
   # required params: report, receiver
   def first_report
     @user = @receiver

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -46,27 +46,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: subject
   end
 
-  # required params: product, receiver, message
-  def submitted
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/products/#{@product.id}")
-    mail to: @user.email, subject: "[FBC] #{@message}"
-  end
-
-  # required params: announcement, receiver
-  def post_announcement
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/announcements/#{@announcement.id}")
-    mail to: @user.email, subject: "[FBC] お知らせ「#{@announcement.title}」"
-  end
-
-  # required params: question, receiver
-  def came_question
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/questions/#{@question.id}")
-    mail to: @user.email, subject: "[FBC] #{@question.user.login_name}さんから質問「#{@question.title}」が投稿されました。"
-  end
-
   # required params: report, receiver
   def first_report
     @user = @receiver

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -17,17 +17,6 @@ class NotificationFacade
     return if receiver.retired?
   end
 
-  def self.submitted(subject, receiver, message)
-    ActivityNotifier.with(subject: subject, receiver: receiver, message: message).submitted.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      product: subject,
-      receiver: receiver,
-      message: message
-    ).submitted.deliver_later(wait: 5)
-  end
-
   def self.first_report(report, receiver)
     ActivityNotifier.with(report: report, receiver: receiver).first_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -19,7 +19,7 @@ class Product < ApplicationRecord
 
   after_create ProductCallbacks.new
   after_update ProductCallbacks.new
-  after_commit ProductCallbacks.new, on: %i[create update]
+  after_save_commit ProductCallbacks.new
   after_destroy ProductCallbacks.new
 
   columns_for_keyword_search :body

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -19,7 +19,7 @@ class Product < ApplicationRecord
 
   after_create ProductCallbacks.new
   after_update ProductCallbacks.new
-  after_save ProductCallbacks.new
+  after_commit ProductCallbacks.new, on: %i[create update]
   after_destroy ProductCallbacks.new
 
   columns_for_keyword_search :body

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -45,7 +45,7 @@ class ProductCallbacks
 
   def send_notification(product:, receivers:, message:)
     receivers.each do |receiver|
-      NotificationFacade.submitted(product, receiver, message)
+      ActivityDelivery.with(product: product, receiver: receiver, message: message).notify(:submitted)
     end
   end
 

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -43,9 +43,9 @@ class ProductCallbacks
     end
   end
 
-  def send_notification(product:, receivers:, message:)
+  def send_notification(product:, receivers:)
     receivers.each do |receiver|
-      ActivityDelivery.with(product: product, receiver: receiver, message: message).notify(:submitted)
+      ActivityDelivery.with(product: product, receiver: receiver).notify(:submitted)
     end
   end
 
@@ -59,8 +59,7 @@ class ProductCallbacks
     mentors = User.where(id: mentor_ids)
     send_notification(
       product: product,
-      receivers: mentors,
-      message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
+      receivers: mentors
     )
   end
 

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -15,7 +15,7 @@ class ProductCallbacks
     Cache.delete_unassigned_product_count
   end
 
-  def after_save(product)
+  def after_commit(product)
     update_learning_status product
 
     unless product.wip

--- a/app/models/product_notifier.rb
+++ b/app/models/product_notifier.rb
@@ -18,7 +18,7 @@ class ProductNotifier
 
   def send_notification(product:, receivers:)
     receivers.each do |receiver|
-      NotificationFacade.submitted(product, receiver)
+      ActivityDelivery.with(product: product, receiver: receiver).notify(:submitted)
     end
   end
 end

--- a/app/models/product_notifier.rb
+++ b/app/models/product_notifier.rb
@@ -12,14 +12,13 @@ class ProductNotifier
   def notify_advisers(product)
     send_notification(
       product: product,
-      receivers: product.user.company.advisers,
-      message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
+      receivers: product.user.company.advisers
     )
   end
 
-  def send_notification(product:, receivers:, message:)
+  def send_notification(product:, receivers:)
     receivers.each do |receiver|
-      NotificationFacade.submitted(product, receiver, message)
+      NotificationFacade.submitted(product, receiver)
     end
   end
 end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -83,16 +83,16 @@ class ActivityNotifier < ApplicationNotifier
 
   def submitted(params = {})
     params.merge!(@params)
-    subject = params[:subject]
+    product = params[:product]
     receiver = params[:receiver]
     message = params[:message]
 
     notification(
       body: message,
       kind: :watching,
-      sender: subject.user,
+      sender: product.user,
       receiver: receiver,
-      link: Rails.application.routes.url_helpers.polymorphic_path(subject),
+      link: Rails.application.routes.url_helpers.polymorphic_path(product),
       read: false
     )
   end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -85,10 +85,9 @@ class ActivityNotifier < ApplicationNotifier
     params.merge!(@params)
     product = params[:product]
     receiver = params[:receiver]
-    message = params[:message]
 
     notification(
-      body: message,
+      body: "#{product.user.login_name}さんが#{product.title}を提出しました。",
       kind: :watching,
       sender: product.user,
       receiver: receiver,

--- a/app/views/activity_mailer/submitted.html.slim
+++ b/app/views/activity_mailer/submitted.html.slim
@@ -1,0 +1,2 @@
+= render '/notification_mailer/notification_mailer_template', title: @message, link_url: @link_url, link_text: '提出物へ' do
+  = md2html(@product.body)

--- a/app/views/activity_mailer/submitted.html.slim
+++ b/app/views/activity_mailer/submitted.html.slim
@@ -1,2 +1,2 @@
-= render '/notification_mailer/notification_mailer_template', title: @message, link_url: @link_url, link_text: '提出物へ' do
+= render '/notification_mailer/notification_mailer_template', title: "#{@product.user.login_name}さんが#{@product.title}を提出しました。", link_url: @link_url, link_text: '提出物へ' do
   = md2html(@product.body)

--- a/app/views/notification_mailer/submitted.html.slim
+++ b/app/views/notification_mailer/submitted.html.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: @message, link_url: notification_url(@notification), link_text: '提出物へ' do
-  = md2html(@product.body)

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -111,7 +111,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
   test '.notify(:submitted)' do
     product = products(:product6)
     params = {
-      subject: product,
+      product: product,
       message: 'test message'
     }
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -104,6 +104,17 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     end
   end
 
+  test '.notify(:submitted)' do
+    product = products(:product6)
+    params = {
+      subject: product,
+      message: 'test message'
+    }
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify(:submitted)
+    end
+  end
+
   test '.notify(:retired)' do
     params = {
       sender: users(:yameo),

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -35,7 +35,6 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     end
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-<<<<<<< HEAD
       ActivityDelivery.with(**params).notify(:graduated)
     end
   end
@@ -102,9 +101,6 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify(:comebacked)
-=======
-      ActivityDelivery.with(**@params).notify(:graduated)
->>>>>>> 7a09e5869 (テストの通知作成数を修正)
     end
   end
 

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -35,6 +35,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     end
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+<<<<<<< HEAD
       ActivityDelivery.with(**params).notify(:graduated)
     end
   end
@@ -101,6 +102,9 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify(:comebacked)
+=======
+      ActivityDelivery.with(**@params).notify(:graduated)
+>>>>>>> 7a09e5869 (テストの通知作成数を修正)
     end
   end
 
@@ -110,7 +114,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       subject: product,
       message: 'test message'
     }
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify(:submitted)
     end
   end

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -108,8 +108,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     product = products(:product6)
     params = {
       product: product,
-      receiver: users(:mentormentaro),
-      message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
+      receiver: users(:mentormentaro)
     }
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -108,8 +108,22 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     product = products(:product6)
     params = {
       product: product,
-      message: 'test message'
+      receiver: users(:mentormentaro),
+      message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
     }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:submitted, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:submitted, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:submitted)
+    end
+
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify(:submitted)
     end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -24,27 +24,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/コメント/, email.body.to_s)
   end
 
-  test 'submitted' do
-    product = products(:product3)
-    submitted = notifications(:notification_submitted)
-    mailer = NotificationMailer.with(
-      product: product,
-      receiver: submitted.user,
-      message: "#{product.user.login_name}さんが「#{product.title}」を提出しました。"
-    ).submitted
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal "[FBC] sotugyouさんが「#{product.title}」を提出しました。", email.subject
-    assert_match(/提出/, email.body.to_s)
-  end
-
   test 'first_report' do
     report = reports(:report10)
     first_report = notifications(:notification_first_report)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -67,4 +67,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(sender: page.user, receiver: receiver, page: page).create_page
   end
+
+  def submitted
+    product = Product.find(ActiveRecord::FixtureSet.identify(:product15))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))
+
+    ActivityMailer.with(product: product, receiver: receiver).submitted
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -29,18 +29,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.with(check: check).checked
   end
 
-  def submitted
-    product = Product.find(ActiveRecord::FixtureSet.identify(:product3))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
-    message = "#{product.user.login_name}さんが提出しました。"
-
-    NotificationMailer.with(
-      product: product,
-      receiver: receiver,
-      message: message
-    ).submitted
-  end
-
   def first_report
     report = Report.find(ActiveRecord::FixtureSet.identify(:report10))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))


### PR DESCRIPTION
## Issue

- #5877 

## 概要
プラクティスの提出物が提出されたときの通知をActive Deliveryを使うようにしました。
- アプリ内通知とメール通知が発行されます。
- 提出物が提出されたプラクティスをWatchしているメンターに通知されます。
- 提出者が研修生の場合は、研修生が所属している企業の先輩（アドバイザー）にも通知されます。
- 見た目の変更はありません。

## 変更確認方法

1. `feature/use-active_delivery-for-submitted-notifications`をローカルに取り込む
2. `bin/setup`
3. `bin/rails s`
4. `localhost:3000`にアクセスして、`mentormentaro`でログイン
5. `http://localhost:3000/practices/198065840`にアクセスして、Watchするをクリック
6. `hajime`で再ログイン
7. `http://localhost:3000/practices/198065840`にアクセスして、提出物を作成、提出
8. `kensyu`で再ログイン
9. `http://localhost:3000/practices/198065840`にアクセスして、提出物を作成、提出
10. `mentormentaro`で再ログイン
11. `http://localhost:3000/notifications`にアクセスして、`hajime`、`kensyu`が提出物を提出した通知が届いていることを確認する
12. `senpai`で再ログイン
13. `http://localhost:3000/notifications`にアクセスして、`kensyu`が提出物を提出した通知が届いていることを確認する
14. `http://localhost:3000/letter_opener`にアクセス
15. `mentormentaro`宛に`hajime`、`kensyu`が提出物を提出したメール通知が届いていることを確認する
16. `senpai`宛に`kensyu`が提出物を提出したメール通知が届いていることを確認する


