### PR TITLE
メンション通知をactive_delivery化する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'holiday_jp'
 gem 'jp_prefecture'
 gem 'jquery-rails'
 gem 'kaminari'
-gem 'mentionable', '~> 0.2.1'
+gem 'mentionable', '~> 0.3.0'
 gem 'meta-tags'
 gem 'mini_magick'
 gem 'net-imap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)
-    mentionable (0.2.1)
+    mentionable (0.3.0)
       activerecord
       railties
     meta-tags (2.18.0)
@@ -556,7 +556,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web (~> 2.0)
   listen
-  mentionable (~> 0.2.1)
+  mentionable (~> 0.3.0)
   meta-tags
   mini_magick
   minitest-ci

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -10,6 +10,7 @@ class ActivityMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
     @check = params[:check] if params&.key?(:check)
     @announcement = params[:announcement] if params&.key?(:announcement)
     @question = params[:question] if params&.key?(:question)
+    @mentionable = params[:mentionable] if params&.key?(:mentionable)
   end
 
   # required params: sender, receiver
@@ -136,6 +137,21 @@ class ActivityMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
     )
     subject = "[FBC] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
     message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
+
+  # required params: mentionable, receiver
+  def mentioned(args = {})
+    @mentionable ||= args[:mentionable]
+    @receiver ||= args[:receiver]
+
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: @mentionable.path)
+    subject = "[FBC] #{@mentionable.where_mention}で#{@mentionable.sender.login_name}さんからメンションがありました。"
+    message = mail to: @user.email, subject: subject
+
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 
     message

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -148,13 +148,12 @@ class ActivityMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
     @receiver ||= args[:receiver]
 
     @user = @receiver
-    @link_url = notification_redirector_path(
+    @link_url = notification_redirector_url(
       link: @mentionable.path,
       kind: Notification.kinds[:mentioned]
     )
     subject = "[FBC] #{@mentionable.where_mention}で#{@mentionable.sender.login_name}さんからメンションがありました。"
     message = mail to: @user.email, subject: subject
-
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 
     message

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -148,7 +148,10 @@ class ActivityMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
     @receiver ||= args[:receiver]
 
     @user = @receiver
-    @notification = @user.notifications.find_by(link: @mentionable.path)
+    @link_url = notification_redirector_path(
+      link: @mentionable.path,
+      kind: Notification.kinds[:mentioned]
+    )
     subject = "[FBC] #{@mentionable.where_mention}で#{@mentionable.sender.login_name}さんからメンションがありました。"
     message = mail to: @user.email, subject: subject
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -37,6 +37,15 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: subject
   end
 
+  # required params: check
+  def checked
+    @user = @check.receiver
+    link = "/#{@check.checkable_type.downcase.pluralize}/#{@check.checkable.id}"
+    @notification = @user.notifications.find_by(link: link)
+    subject = "[FBC] #{@user.login_name}さんの#{@check.checkable.title}を確認しました。"
+    mail to: @user.email, subject: subject
+  end
+
   # required params: product, receiver, message
   def submitted
     @user = @receiver

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -16,7 +16,7 @@ class Comment < ApplicationRecord
 
   columns_for_keyword_search :description
 
-  mentionable_as :description
+  mentionable_as :description, hook_name: :after_commit
 
   class << self
     def commented_users

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -44,7 +44,7 @@ module Mentioner
     return nil if instance_of?(Comment) && commentable.instance_of?(Talk) # protect mention in talk
 
     receivers.each do |receiver|
-      ActivityDelivery.with(mentionable: self, receiver: receiver).notify!(:mentioned) if sender != receiver
+      ActivityDelivery.with(mentionable: self, receiver: receiver).notify(:mentioned) if sender != receiver
     end
   end
 

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -44,7 +44,7 @@ module Mentioner
     return nil if instance_of?(Comment) && commentable.instance_of?(Talk) # protect mention in talk
 
     receivers.each do |receiver|
-      NotificationFacade.mentioned(self, receiver) if sender != receiver
+      ActivityDelivery.with(mentionable: self, receiver: receiver).notify(:mentioned) if sender != receiver
     end
   end
 

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -44,7 +44,7 @@ module Mentioner
     return nil if instance_of?(Comment) && commentable.instance_of?(Talk) # protect mention in talk
 
     receivers.each do |receiver|
-      ActivityDelivery.with(mentionable: self, receiver: receiver).notify(:mentioned) if sender != receiver
+      ActivityDelivery.with(mentionable: self, receiver: receiver).notify!(:mentioned) if sender != receiver
     end
   end
 

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -17,16 +17,6 @@ class NotificationFacade
     return if receiver.retired?
   end
 
-  def self.mentioned(mentionable, receiver)
-    ActivityNotifier.with(mentionable: mentionable, receiver: receiver).mentioned.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      mentionable: mentionable,
-      receiver: receiver
-    ).mentioned.deliver_later(wait: 5)
-  end
-
   def self.submitted(subject, receiver, message)
     ActivityNotifier.with(subject: subject, receiver: receiver, message: message).submitted.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/views/activity_mailer/mentioned.html.slim
+++ b/app/views/activity_mailer/mentioned.html.slim
@@ -1,0 +1,2 @@
+= render '/notification_mailer/notification_mailer_template', title: "#{@mentionable.user.login_name}さんからメンションがありました", link_url: notification_url(@notification), link_text: 'このメンションへ' do
+  = md2html @mentionable.body

--- a/app/views/activity_mailer/mentioned.html.slim
+++ b/app/views/activity_mailer/mentioned.html.slim
@@ -1,2 +1,2 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@mentionable.user.login_name}さんからメンションがありました", link_url: notification_url(@notification), link_text: 'このメンションへ' do
+= render '/notification_mailer/notification_mailer_template', title: "#{@mentionable.user.login_name}さんからメンションがありました", link_url: @link_url, link_text: 'このメンションへ' do
   = md2html @mentionable.body

--- a/app/views/notification_mailer/mentioned.html.slim
+++ b/app/views/notification_mailer/mentioned.html.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: "#{@mentionable.user.login_name}さんからメンションがありました", link_url: notification_url(@notification), link_text: 'このメンションへ' do
-  = md2html @mentionable.body

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -299,6 +299,42 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">質問へ</a>}, email.body.to_s)
   end
 
+  test 'mentioned' do
+    mentionable = comments(:comment9)
+    mentioned = notifications(:notification_mentioned)
+    ActivityMailer.mentioned(
+      mentionable: mentionable,
+      receiver: mentioned.user
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['sotugyou@example.com'], email.to
+    assert_equal '[FBC] sotugyouさんの日報「学習週1日目」へのコメントでkomagataさんからメンションがありました。', email.subject
+    assert_match(/メンション/, email.body.to_s)
+  end
+
+  test 'mentioned with params' do
+    mentionable = comments(:comment9)
+    mentioned = notifications(:notification_mentioned)
+    mailer = ActivityMailer.with(
+      mentionable: mentionable,
+      receiver: mentioned.user
+    ).mentioned
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['sotugyou@example.com'], email.to
+    assert_equal '[FBC] sotugyouさんの日報「学習週1日目」へのコメントでkomagataさんからメンションがありました。', email.subject
+    assert_match(/メンション/, email.body.to_s)
+  end
+
   test 'retired' do
     user = users(:yameo)
     mentor = users(:mentormentaro)

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -24,42 +24,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/コメント/, email.body.to_s)
   end
 
-  test 'mentioned' do
-    mentionable = comments(:comment9)
-    mentioned = notifications(:notification_mentioned)
-    mailer = NotificationMailer.with(
-      mentionable: mentionable,
-      receiver: mentioned.user
-    ).mentioned
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[FBC] sotugyouさんの日報「学習週1日目」へのコメントでkomagataさんからメンションがありました。', email.subject
-    assert_match(/メンション/, email.body.to_s)
-  end
-
-  test 'checked' do
-    check = checks(:report5_check_machida)
-    mailer = NotificationMailer.with(check: check).checked
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['sotugyou@example.com'], email.to
-    assert_equal '[FBC] sotugyouさんの学習週1日目を確認しました。', email.subject
-    assert_match(/確認/, email.body.to_s)
-  end
-
   test 'submitted' do
     product = products(:product3)
     submitted = notifications(:notification_submitted)

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -44,6 +44,22 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/メンション/, email.body.to_s)
   end
 
+  test 'checked' do
+    check = checks(:report5_check_machida)
+    mailer = NotificationMailer.with(check: check).checked
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['sotugyou@example.com'], email.to
+    assert_equal '[FBC] sotugyouさんの学習週1日目を確認しました。', email.subject
+    assert_match(/確認/, email.body.to_s)
+  end
+
   test 'submitted' do
     product = products(:product3)
     submitted = notifications(:notification_submitted)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -52,4 +52,12 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(sender: sender, receiver: receiver).retired
   end
+
+  def mentioned
+    mentionable = Comment.find(ActiveRecord::FixtureSet.identify(:comment9))
+    report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
+    receiver = report.user
+
+    ActivityMailer.with(mentionable: mentionable, receiver: receiver).mentioned
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -22,6 +22,13 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.with(mentionable: mentionable, receiver: receiver).mentioned
   end
 
+  def checked
+    report = Report.find(ActiveRecord::FixtureSet.identify(:report5))
+    check = report.checks.first
+
+    NotificationMailer.with(check: check).checked
+  end
+
   def submitted
     product = Product.find(ActiveRecord::FixtureSet.identify(:product3))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -40,10 +40,12 @@ class NotificationsTest < ApplicationSystemTestCase
     select '00', from: :report_learning_times_attributes_0_finished_at_5i
     click_button '提出'
 
-    find('#js-new-comment').set("login_nameの補完テスト: @komagata\n")
-    click_button 'コメントする'
-    assert_text 'login_nameの補完テスト: @komagata'
-    assert_selector :css, "a[href='/users/komagata']"
+    perform_enqueued_jobs do
+      find('#js-new-comment').set("login_nameの補完テスト: @komagata\n")
+      click_button 'コメントする'
+      assert_text 'login_nameの補完テスト: @komagata'
+      assert_selector :css, "a[href='/users/komagata']"
+    end
 
     visit_with_auth '/notifications', 'komagata'
     assert_no_text 'kensyuさんがはじめての日報を書きました！'


### PR DESCRIPTION
## Issue

- #5876

## 概要

メンション通知をactive_delivery化する

## 変更確認方法

1. `feature/use-active-delivery-for-mention-notifications`をローカルに取り込む。
2. `hajime`でログインする。
3. `http://127.0.0.1:3000/reports/469634013` にアクセス。
4. コメントのところに`@hatsuno テスト`を入力し、「コメントする」をクリック。
5. `http://127.0.0.1:3000/letter_opener/`でメール通知を確認する。
6. `hatsuno`でログインする。
7. サイト内通知確認する。

## 参考リソース
- #6067
- #5989