### PR TITLE
Question投稿通知をactive_delivery化

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -8,6 +8,7 @@ class ActivityMailer < ApplicationMailer
     @sender = params[:sender] if params&.key?(:sender)
     @receiver = params[:receiver] if params&.key?(:receiver)
     @announcement = params[:announcement] if params&.key?(:announcement)
+    @question = params[:question] if params&.key?(:question)
   end
 
   # required params: sender, receiver
@@ -60,11 +61,11 @@ class ActivityMailer < ApplicationMailer
   def came_question(args = {})
     @sender ||= args[:sender]
     @receiver ||= args[:receiver]
-    @question = params[:question]
+    @question ||= args[:question]
 
     @user = @receiver
     @link_url = notification_redirector_path(
-      link: "/users/#{@sender.id}",
+      link: "/questions/#{@question.id}",
       kind: Notification.kinds[:came_question]
     )
     subject = "[FBC] #{@sender.login_name}さんから質問「#{@question.title}」が投稿されました。"

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -56,4 +56,18 @@ class ActivityMailer < ApplicationMailer
 
     message
   end
+
+  def came_question(args = {})
+    @sender ||= args[:sender]
+    @receiver ||= args[:receiver]
+    @question = params[:question]
+
+    @user = @receiver
+    @link_url = notification_redirector_path(
+      link: "/users/#{@sender.id}",
+      kind: Notification.kinds[:came_question]
+    )
+    subject = "[FBC] #{@sender.login_name}さんから質問「#{@question.title}」が投稿されました。"
+    mail to: @user.email, subject: subject
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -60,6 +60,13 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: "[FBC] #{@question.user.login_name}さんから質問「#{@question.title}」が投稿されました。"
   end
 
+  # required params: announcement, receiver
+  def post_announcement
+    @user = @receiver
+    @notification = @user.notifications.find_by(link: "/announcements/#{@announcement.id}")
+    mail to: @user.email, subject: "[FBC] お知らせ「#{@announcement.title}」"
+  end
+
   # required params: report, receiver
   def first_report
     @user = @receiver

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -11,8 +11,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @check = params[:check]
     @product = params[:product]
     @answer = params[:answer]
-    @announcement = params[:announcement]
-    @question = params[:question]
     @report = params[:report]
     @watchable = params[:watchable]
     @sender = params[:sender]
@@ -51,20 +49,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @user = @receiver
     @notification = @user.notifications.find_by(link: "/products/#{@product.id}")
     mail to: @user.email, subject: "[FBC] #{@message}"
-  end
-
-  # required params: question, receiver
-  def came_question
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/questions/#{@question.id}")
-    mail to: @user.email, subject: "[FBC] #{@question.user.login_name}さんから質問「#{@question.title}」が投稿されました。"
-  end
-
-  # required params: announcement, receiver
-  def post_announcement
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/announcements/#{@announcement.id}")
-    mail to: @user.email, subject: "[FBC] お知らせ「#{@announcement.title}」"
   end
 
   # required params: report, receiver

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -46,16 +46,6 @@ class NotificationFacade
     ).submitted.deliver_later(wait: 5)
   end
 
-  def self.post_announcement(announce, receiver)
-    ActivityNotifier.with(announce: announce, receiver: receiver).post_announcement.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      announcement: announce,
-      receiver: receiver
-    ).post_announcement.deliver_later(wait: 5)
-  end
-
   def self.first_report(report, receiver)
     ActivityNotifier.with(report: report, receiver: receiver).first_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -46,14 +46,14 @@ class NotificationFacade
     ).submitted.deliver_later(wait: 5)
   end
 
-  def self.came_question(question, receiver)
-    ActivityNotifier.with(question: question, receiver: receiver).came_question.notify_now
+  def self.post_announcement(announce, receiver)
+    ActivityNotifier.with(announce: announce, receiver: receiver).post_announcement.notify_now
     return unless receiver.mail_notification? && !receiver.retired?
 
     NotificationMailer.with(
-      question: question,
+      announcement: announce,
       receiver: receiver
-    ).came_question.deliver_later(wait: 5)
+    ).post_announcement.deliver_later(wait: 5)
   end
 
   def self.first_report(report, receiver)

--- a/app/models/question_callbacks.rb
+++ b/app/models/question_callbacks.rb
@@ -26,7 +26,7 @@ class QuestionCallbacks
 
   def send_notification_to_mentors(question)
     User.mentor.each do |user|
-      NotificationFacade.came_question(question, user) if question.sender != user
+      ActivityDelivery.with(sender: question.user, receiver: user, question: question).notify(:came_question) if question.sender != user
     end
   end
 

--- a/app/views/activity_mailer/came_question.html.slim
+++ b/app/views/activity_mailer/came_question.html.slim
@@ -1,0 +1,4 @@
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@sender.login_name}さんから質問「#{@question.title}」が投稿されました。",
+  link_url: @link_url,
+  link_text: "#{@question.title}のページへ"

--- a/app/views/notification_mailer/came_question.html.slim
+++ b/app/views/notification_mailer/came_question.html.slim
@@ -1,6 +1,0 @@
-= render 'notification_mailer_template', title: "「#{@question.practice.title}」についての質問がありました。", link_url: notification_url(@notification), link_text: '質問へ' do
-  p #{@question.user.login_name}さんから質問がありました。アドバイスや回答を投稿しよう！！
-  div(style='border-top: solid 1px #ccc; height: 0;')
-  h1(style='margin-top: 1em; border-left: solid 6px #4638a0; padding: 0 0 0 1rem; font-size: 1.5em; border-bottom: none; color: #444444;')
-    = @question.title
-  = md2html(@question.description)

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -3,41 +3,41 @@
 require 'test_helper'
 
 class ActivityDeliveryTest < ActiveSupport::TestCase
-  test '.notify(:graduated)' do
-    params = {
-      kind: :graduated,
-      body: 'test message',
-      sender: users(:kimura),
-      receiver: users(:komagata),
-      link: '/example',
-      read: false
-    }
+  # test '.notify(:graduated)' do
+  #   params = {
+  #     kind: :graduated,
+  #     body: 'test message',
+  #     sender: users(:kimura),
+  #     receiver: users(:komagata),
+  #     link: '/example',
+  #     read: false
+  #   }
 
-    Notification.create!(
-      kind: Notification.kinds['graduated'],
-      user: users(:komagata),
-      sender: users(:kimura),
-      link: "/users/#{users(:kimura).id}",
-      message: "#{users(:kimura).login_name}さんがxxxxを確認しました。",
-      read: false
-    )
+  #   Notification.create!(
+  #     kind: Notification.kinds['graduated'],
+  #     user: users(:komagata),
+  #     sender: users(:kimura),
+  #     link: "/users/#{users(:kimura).id}",
+  #     message: "#{users(:kimura).login_name}さんがxxxxを確認しました。",
+  #     read: false
+  #   )
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
-      ActivityDelivery.notify!(:graduated, **params)
-    end
+  #   assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+  #     ActivityDelivery.notify!(:graduated, **params)
+  #   end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
-      ActivityDelivery.notify(:graduated, **params)
-    end
+  #   assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+  #     ActivityDelivery.notify(:graduated, **params)
+  #   end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
-      ActivityDelivery.with(**params).notify!(:graduated)
-    end
+  #   assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+  #     ActivityDelivery.with(**params).notify!(:graduated)
+  #   end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
-      ActivityDelivery.with(**params).notify(:graduated)
-    end
-  end
+  #   assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+  #     ActivityDelivery.with(**params).notify(:graduated)
+  #   end
+  # end
 
   test '.notify(:came_question)' do
     question = questions(:question1)
@@ -60,19 +60,19 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       read: false
     )
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.notify!(:came_question, **params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.notify(:came_question, **params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify!(:came_question)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify(:came_question)
     end
   end

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -3,41 +3,41 @@
 require 'test_helper'
 
 class ActivityDeliveryTest < ActiveSupport::TestCase
-  # test '.notify(:graduated)' do
-  #   params = {
-  #     kind: :graduated,
-  #     body: 'test message',
-  #     sender: users(:kimura),
-  #     receiver: users(:komagata),
-  #     link: '/example',
-  #     read: false
-  #   }
+  test '.notify(:graduated)' do
+    params = {
+      kind: :graduated,
+      body: 'test message',
+      sender: users(:kimura),
+      receiver: users(:komagata),
+      link: '/example',
+      read: false
+    }
 
-  #   Notification.create!(
-  #     kind: Notification.kinds['graduated'],
-  #     user: users(:komagata),
-  #     sender: users(:kimura),
-  #     link: "/users/#{users(:kimura).id}",
-  #     message: "#{users(:kimura).login_name}さんがxxxxを確認しました。",
-  #     read: false
-  #   )
+    Notification.create!(
+      kind: Notification.kinds['graduated'],
+      user: users(:komagata),
+      sender: users(:kimura),
+      link: "/users/#{users(:kimura).id}",
+      message: "#{users(:kimura).login_name}さんがxxxxを確認しました。",
+      read: false
+    )
 
-  #   assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
-  #     ActivityDelivery.notify!(:graduated, **params)
-  #   end
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:graduated, **params)
+    end
 
-  #   assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-  #     ActivityDelivery.notify(:graduated, **params)
-  #   end
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:graduated, **params)
+    end
 
-  #   assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
-  #     ActivityDelivery.with(**params).notify!(:graduated)
-  #   end
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:graduated)
+    end
 
-  #   assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-  #     ActivityDelivery.with(**params).notify(:graduated)
-  #   end
-  # end
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:graduated)
+    end
+  end
 
   test '.notify(:came_question)' do
     question = questions(:question1)

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -3,8 +3,8 @@
 require 'test_helper'
 
 class ActivityDeliveryTest < ActiveSupport::TestCase
-  setup do
-    @params = {
+  test '.notify(:graduated)' do
+    params = {
       kind: :graduated,
       body: 'test message',
       sender: users(:kimura),
@@ -12,9 +12,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       link: '/example',
       read: false
     }
-  end
 
-  test '.notify(:graduated)' do
     Notification.create!(
       kind: Notification.kinds['graduated'],
       user: users(:komagata),
@@ -24,20 +22,58 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       read: false
     )
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
-      ActivityDelivery.notify!(:graduated, **@params)
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+      ActivityDelivery.notify!(:graduated, **params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-      ActivityDelivery.notify(:graduated, **@params)
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.notify(:graduated, **params)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
-      ActivityDelivery.with(**@params).notify!(:graduated)
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify!(:graduated)
     end
 
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-      ActivityDelivery.with(**@params).notify(:graduated)
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify(:graduated)
+    end
+  end
+
+  test '.notify(:came_question)' do
+    question = questions(:question1)
+    params = {
+      kind: :came_question,
+      body: 'test message',
+      sender: question.user,
+      receiver: users(:komagata),
+      question: question,
+      link: '/example',
+      read: false
+    }
+
+    Notification.create!(
+      kind: Notification.kinds['came_question'],
+      user: users(:komagata),
+      sender: question.user,
+      link: "/questions/#{question.id}",
+      message: "#{question.user.login_name}さんから質問「#{question.title}」が投稿されました。",
+      read: false
+    )
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+      ActivityDelivery.notify!(:came_question, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.notify(:came_question, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify!(:came_question)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 2 do
+      ActivityDelivery.with(**params).notify(:came_question)
     end
   end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -73,6 +73,7 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+
     query = CGI.escapeHTML({ kind: 4, link: "/questions/#{answer.question.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['sotugyou@example.com'], email.to
@@ -170,5 +171,42 @@ class ActivityMailerTest < ActionMailer::TestCase
       receiver: receiver
     ).deliver_now
     assert_not ActionMailer::Base.deliveries.empty?
+  end
+
+
+  test 'came_question' do
+    question = questions(:question1)
+    user = question.user
+    mentor = users(:komagata)
+
+    ActivityMailer.came_question(
+      sender: user,
+      receiver: mentor,
+      question: question
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] machidaさんから質問「どのエディターを使うのが良いでしょうか」が投稿されました。', email.subject
+    assert_match(/エディター/, email.body.to_s)
+  end
+
+  test 'came_question with params' do
+    question = questions(:question1)
+    user = question.user
+    mentor = users(:komagata)
+
+    mailer = ActivityMailer.with(
+      sender: user,
+      receiver: mentor,
+      question: question
+    ).came_question
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] machidaさんから質問「どのエディターを使うのが良いでしょうか」が投稿されました。', email.subject
+    assert_match(/エディター/, email.body.to_s)
   end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -204,6 +204,13 @@ class ActivityMailerTest < ActionMailer::TestCase
       receiver: mentor,
       question: question
     ).came_question
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
     assert_equal '[FBC] machidaさんから質問「どのエディターを使うのが良いでしょうか」が投稿されました。', email.subject

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -173,7 +173,6 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
   end
 
-
   test 'came_question' do
     question = questions(:question1)
     user = question.user

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -81,26 +81,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/提出/, email.body.to_s)
   end
 
-  test 'came_question' do
-    question = questions(:question2)
-    questioned = notifications(:notification_questioned)
-    mailer = NotificationMailer.with(
-      question: question,
-      receiver: questioned.user
-    ).came_question
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] sotugyouさんから質問「injectとreduce」が投稿されました。', email.subject
-    assert_match(/質問/, email.body.to_s)
-  end
-
   test 'first_report' do
     report = reports(:report10)
     first_report = notifications(:notification_first_report)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -26,4 +26,11 @@ class ActivityMailerPreview < ActionMailer::Preview
       receiver: receiver
     ).post_announcement
   end
+
+  def came_question
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
+    question = Question.find(ActiveRecord::FixtureSet.identify(:question1))
+
+    ActivityMailer.with(sender: question.user, receiver: receiver, question: question).came_question
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -41,16 +41,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     ).submitted
   end
 
-  def came_question
-    question = Question.find(ActiveRecord::FixtureSet.identify(:question2))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:sotugyou))
-
-    NotificationMailer.with(
-      question: question,
-      receiver: receiver
-    ).came_question
-  end
-
   def first_report
     report = Report.find(ActiveRecord::FixtureSet.identify(:report10))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))


### PR DESCRIPTION
## Issue

- #5880 

## 概要

Q&A へ投稿を通知する機能を `NotificationFacade` から `ActivityDelivery` に変更しました。そのため次の変更があります。

- `NotificationFacade` が不要になり、通知送信は `ActivityDelivery` を経由して、サイト内通知が実行されるようになりました。
  - `NotificationFacade` によって実行されて板処理の部分に関わるコードを`ActiveDelivery` で実行されるように修正しました
  - 通知、メール送信、テストがそれぞれ影響を受け、修正しています。

## 変更確認方法

Q&A へ投稿通知をactive_delivery経由で送信できることを確認する手順です。

1. `feature/change_question_notification` をローカルに取り込みます
2. `bin/setup` を実行します
3. `bin/rails s` でサーバーを立ち上げます
4. テストユーザーアカウントでログインし、質問を投稿する(http://localhost:3000/questions/new)
5. メンターのテストアカウントでログインし、手順4の通知が来ていることを確認する
6. http://localhost:3000/letter_opener/ を開いてメールが届いていることを確認する

## Screenshot
処理の置き換えのため変更前後で違いはありません。
<img width="356" alt="通知" src="https://user-images.githubusercontent.com/76797372/214287876-52f5707d-3043-4c95-af3e-bca099a81947.png">
<img width="1296" alt="メール" src="https://user-images.githubusercontent.com/76797372/214287940-a4f0e7d3-7aad-420f-badb-91f4655ebd41.png">
## 関連PR
- https://github.com/fjordllc/bootcamp/pull/6063
- https://github.com/fjordllc/bootcamp/pull/5989
