### PR TITLE
ブートキャンプを退会した時にDiscordからも退出させる

### DIFF
--- a/app/models/discord_member.rb
+++ b/app/models/discord_member.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class DiscordMember
+  # NOTE: https://discord.com/developers/docs/resources/guild#search-guild-members の limit の初期値は 1 だが、
+  #       ユーザー名またはニックネームの前方一致となるため、limit を 10 にしてニックネームで一致した場合を考慮した
+  RECORD_LIMIT_OF_FORWARD_MATCH = 10
+
+  attr_reader :account_name
+
+  class << self
+    def find_by(account_name:)
+      return nil if account_name.blank?
+      return nil unless ready?
+
+      username = account_name.split('#').first
+      query = {
+        query: username,
+        limit: RECORD_LIMIT_OF_FORWARD_MATCH
+      }.to_query
+      response = Discord::Resource.get("#{site_base}/search?#{query}")
+      return nil unless response.is_a?(Net::HTTPSuccess)
+
+      result = JSON.parse(response.body, symbolize_names: true)
+      discord_members = result.map { |attrs| DiscordMember.new(attrs) }
+      discord_members.find { |member| account_name == member.account_name }
+    rescue Timeout::Error
+      Rails.logger.error '[Discord API] APIへの接続がタイムアウトしました。'
+      nil
+    rescue StandardError => e
+      Rails.logger.error "[Discord API] 予期せぬエラーが発生しました。：#{e.message}"
+      nil
+    end
+
+    def site_base
+      "guilds/#{guild_id}/members"
+    end
+
+    private
+
+    def ready?
+      !!guild_id
+    end
+
+    def guild_id
+      ENV['DISCORD_GUILD_ID'].presence
+    end
+  end
+
+  def initialize(attributes = {})
+    user = attributes[:user]
+
+    @account_id = user[:id]
+    @account_name = [
+      user[:username],
+      user[:discriminator]
+    ].join('#')
+
+    @bot = user[:bot]
+    @role_ids = attributes[:roles]
+  end
+
+  def destroy
+    return false if @bot
+    return false unless @role_ids.empty?
+
+    response = Discord::Resource.delete("#{self.class.site_base}/#{@account_id}")
+    return false unless response.is_a?(Net::HTTPSuccess)
+
+    true
+  rescue Timeout::Error
+    Rails.logger.error '[Discord API] APIへの接続がタイムアウトしました。'
+    false
+  rescue StandardError => e
+    Rails.logger.error "[Discord API] 予期せぬエラーが発生しました。：#{e.message}"
+    false
+  end
+end

--- a/lib/discord/resource.rb
+++ b/lib/discord/resource.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Discord
+  class Resource
+    # NOTE: 2023年1月時点で最新のAPIバージョン
+    API_SITE_BASE = 'https://discord.com/api/v10/'
+    # NOTE: タイムアウトの初期値が60秒のため利用者の待ち時間を短縮するため変更した
+    TIMEOUT_SECONDS = 5
+
+    class << self
+      def get(path)
+        resource = new(Net::HTTP::Get, site_uri(path))
+        resource.request_with_auth
+      end
+
+      def delete(path)
+        resource = new(Net::HTTP::Delete, site_uri(path))
+        resource.request_with_auth
+      end
+
+      private
+
+      def site_uri(path)
+        URI.join(API_SITE_BASE, path)
+      end
+    end
+
+    def initialize(method_klass, uri)
+      @uri = uri
+      @request = method_klass.new(uri.request_uri)
+    end
+
+    def request_with_auth
+      return nil unless bot_token
+
+      @request.add_field('Authorization', "Bot #{bot_token}")
+      http_client.request(@request)
+    end
+
+    private
+
+    def bot_token
+      ENV['DISCORD_BOT_TOKEN'].presence
+    end
+
+    def http_client
+      http = Net::HTTP.new(@uri.host, @uri.port)
+      http.use_ssl = true
+      http.open_timeout = TIMEOUT_SECONDS
+      http.read_timeout = TIMEOUT_SECONDS
+
+      http
+    end
+  end
+end

--- a/test/cassettes/discord/guild_members/found_bot.yml
+++ b/test/cassettes/discord/guild_members/found_bot.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://discord.com/api/v10/guilds/0123456789/members/search?limit=10&query=TestBot%20%E2%9C%A8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 06:02:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=412867e268745b23f3d8d0817595c1c90cdd3b91-1674540175; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=be8039329bac11ed85a55287e9097545; Expires=Sun, 23-Jan-2028 06:02:55
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=be8039329bac11ed85a55287e9097545fe67b3c3c6a0f398692739d120d3397e85e86c7857ced215a93d2928e652b646;
+        Expires=Sun, 23-Jan-2028 06:02:55 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - d721eda6a63e6522373d361f98e4b58b
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1674540184.446'
+      X-Ratelimit-Reset-After:
+      - '9.351'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=7LJh04MkvYFFnmFzOuEKEl8ojnaAHqHWn3QSGQURId%2BNJC8JpmWRZYJ0gnwC%2BFBp0zpouT4a%2FVf9o4MpmvSTcT4FoRnrcdP%2F%2F9n0ZMQ30jAz5DyIJOnAElALRB%2Bo"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e6901d7e6d19ce-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        WwogIHsKICAgICJhdmF0YXIiOiBudWxsLAogICAgImNvbW11bmljYXRpb25f
+        ZGlzYWJsZWRfdW50aWwiOiBudWxsLAogICAgImRlYWYiOiBmYWxzZSwKICAg
+        ICJmbGFncyI6IDAsCiAgICAiam9pbmVkX2F0IjogIjIwMjMtMDEtMjNUMDk6
+        NDE6NDEuMDE3Mzg0KzAwOjAwIiwKICAgICJtdXRlIjogZmFsc2UsCiAgICAi
+        bmljayI6IG51bGwsCiAgICAicGVuZGluZyI6IGZhbHNlLAogICAgInByZW1p
+        dW1fc2luY2UiOiBudWxsLAogICAgInJvbGVzIjogWwoKICAgIF0sCiAgICAi
+        dXNlciI6IHsKICAgICAgImF2YXRhciI6ICIiLAogICAgICAiYXZhdGFyX2Rl
+        Y29yYXRpb24iOiBudWxsLAogICAgICAiYm90IjogdHJ1ZSwKICAgICAgImRp
+        c2NyaW1pbmF0b3IiOiAiNTgwMyIsCiAgICAgICJpZCI6ICIzMjgzOTQ1OTA4
+        NzY1MzcwNCIsCiAgICAgICJwdWJsaWNfZmxhZ3MiOiA2NTUzNiwKICAgICAg
+        InVzZXJuYW1lIjogIlRlc3RCb3Qg4pyoIgogICAgfQogIH0KXQ==
+  recorded_at: Tue, 24 Jan 2023 06:02:57 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/found_human.yml
+++ b/test/cassettes/discord/guild_members/found_human.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://discord.com/api/v10/guilds/0123456789/members/search?limit=10&query=Human
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:41:35 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=f31235248fa10f0adb086ea397f9c098ab8539e5-1674546095; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=8726f2889bba11ed85abfa5ae4ea42e0; Expires=Sun, 23-Jan-2028 07:41:35
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=8726f2889bba11ed85abfa5ae4ea42e0cfa366d86e3a7218081fdb02e5259df3a0e854a28610b871d9cd9559a7565b32;
+        Expires=Sun, 23-Jan-2028 07:41:35 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - d721eda6a63e6522373d361f98e4b58b
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1674546105.189'
+      X-Ratelimit-Reset-After:
+      - '10.000'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=3%2Bom5aFOtEvIW5%2F0uJGNnlwyQGqCQSSpxIBBXBZhRUZHC8P7Vn3%2BWjhnymPLtXoPeioRcW0UT4nsMuUHYct1krxebNNC%2BtImr9WOxsn1axIl5A4t7QIIt5OEnWa8"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e720a6180e836d-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        WwogIHsKICAgICJhdmF0YXIiOiBudWxsLAogICAgImNvbW11bmljYXRpb25f
+        ZGlzYWJsZWRfdW50aWwiOiBudWxsLAogICAgImRlYWYiOiBmYWxzZSwKICAg
+        ICJmbGFncyI6IDEsCiAgICAiam9pbmVkX2F0IjogIjIwMjMtMDEtMjRUMDc6
+        NDE6MDAuMzA3NzY5KzAwOjAwIiwKICAgICJtdXRlIjogZmFsc2UsCiAgICAi
+        bmljayI6IG51bGwsCiAgICAicGVuZGluZyI6IGZhbHNlLAogICAgInByZW1p
+        dW1fc2luY2UiOiBudWxsLAogICAgInJvbGVzIjogWwoKICAgIF0sCiAgICAi
+        dXNlciI6IHsKICAgICAgImF2YXRhciI6ICIyMTM4NmMyNWVlNDYyYmI0Yzc4
+        YzFmZDJkNjMxMDUwZSIsCiAgICAgICJhdmF0YXJfZGVjb3JhdGlvbiI6IG51
+        bGwsCiAgICAgICJib3QiOiBmYWxzZSwKICAgICAgImRpc2NyaW1pbmF0b3Ii
+        OiAiNDU0NSIsCiAgICAgICJpZCI6ICIyNDA3Mzk1Mjc5NTAyMDgxNjgiLAog
+        ICAgICAicHVibGljX2ZsYWdzIjogMCwKICAgICAgInVzZXJuYW1lIjogIkh1
+        bWFuIgogICAgfQogIH0KXQ==
+  recorded_at: Tue, 24 Jan 2023 07:41:37 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/found_human_with_kanji.yml
+++ b/test/cassettes/discord/guild_members/found_human_with_kanji.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://discord.com/api/v10/guilds/0123456789/members/search?limit=10&query=%E3%81%B2%E3%82%89%E3%81%8C%E3%81%AA%E3%81%A8%E6%BC%A2%E5%AD%97
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:41:35 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=f31235248fa10f0adb086ea397f9c098ab8539e5-1674546095; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=875102809bba11edb1479a8c6482ced8; Expires=Sun, 23-Jan-2028 07:41:35
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=875102809bba11edb1479a8c6482ced801b2b7cffb08aeeda081c986c08062b5d9e6d1b46c720416060f18dec58198fd;
+        Expires=Sun, 23-Jan-2028 07:41:35 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - d721eda6a63e6522373d361f98e4b58b
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1674546105.186'
+      X-Ratelimit-Reset-After:
+      - '9.715'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=woT7bszJiZwQByGee2JKcT%2FLaKdOqH3TZZoWJU67taMZq1vcM%2FXtT0Zsv2VmEZX5IqiypPn8NHPXwFVX2s8s9gmxxWQwlwsVh1XzG7t4A15bP0ZhVZNKFNXPd%2B3l"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e720a7f820831d-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        WwogIHsKICAgICJhdmF0YXIiOiBudWxsLAogICAgImNvbW11bmljYXRpb25f
+        ZGlzYWJsZWRfdW50aWwiOiBudWxsLAogICAgImRlYWYiOiBmYWxzZSwKICAg
+        ICJmbGFncyI6IDAsCiAgICAiam9pbmVkX2F0IjogIjIwMjMtMDEtMjJUMDE6
+        NTk6MzcuNzA1MDAwKzAwOjAwIiwKICAgICJtdXRlIjogZmFsc2UsCiAgICAi
+        bmljayI6ICIiLAogICAgInBlbmRpbmciOiBmYWxzZSwKICAgICJwcmVtaXVt
+        X3NpbmNlIjogbnVsbCwKICAgICJyb2xlcyI6IFsKCiAgICBdLAogICAgInVz
+        ZXIiOiB7CiAgICAgICJhdmF0YXIiOiBudWxsLAogICAgICAiYXZhdGFyX2Rl
+        Y29yYXRpb24iOiBudWxsLAogICAgICAiYm90IjogZmFsc2UsCiAgICAgICJk
+        aXNjcmltaW5hdG9yIjogIjAwMTkiLAogICAgICAiaWQiOiAiMTkxODE5NTY5
+        MDIxMzMwMzc3IiwKICAgICAgInB1YmxpY19mbGFncyI6IDAsCiAgICAgICJ1
+        c2VybmFtZSI6ICLjgbLjgonjgYzjgarjgajmvKLlrZciCiAgICB9CiAgfQpd
+  recorded_at: Tue, 24 Jan 2023 07:41:37 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/found_human_with_owner.yml
+++ b/test/cassettes/discord/guild_members/found_human_with_owner.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://discord.com/api/v10/guilds/0123456789/members/search?limit=10&query=%E3%82%AA%E3%83%BC%E3%83%8A%E3%83%BC%E3%81%A0%E3%81%8C%E3%83%AD%E3%83%BC%E3%83%AB%E3%81%AA%E3%81%97
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:28:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=2acd11eaacd3c1f2b0694f5089393a7d8965237a-1674545283; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=a31427249bb811edb17b56c5b1f21f77; Expires=Sun, 23-Jan-2028 07:28:03
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=a31427249bb811edb17b56c5b1f21f77e5e25da22283a425c682044384bb37e939a178c78e89a521ceae06d947ca6557;
+        Expires=Sun, 23-Jan-2028 07:28:03 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - d721eda6a63e6522373d361f98e4b58b
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1674545290.047'
+      X-Ratelimit-Reset-After:
+      - '7.017'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=RP9sOuSwf4%2BNQt2tr514Kqd93nEqF%2BH81cx8%2FwX7uMggV6c95vBRHaa4%2FauYGw%2FHfm85udWtIozC2nmounHiRsb2gIcRMXztxeFCzJAynFhk1YPkTnmXYw2L970s"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e70cd208558317-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        WwogIHsKICAgICJhdmF0YXIiOiBudWxsLAogICAgImNvbW11bmljYXRpb25f
+        ZGlzYWJsZWRfdW50aWwiOiBudWxsLAogICAgImRlYWYiOiBmYWxzZSwKICAg
+        ICJmbGFncyI6IDAsCiAgICAiam9pbmVkX2F0IjogIjIwMjMtMDEtMjJUMDE6
+        NTk6MzcuNzA1MDAwKzAwOjAwIiwKICAgICJtdXRlIjogZmFsc2UsCiAgICAi
+        bmljayI6ICIiLAogICAgInBlbmRpbmciOiBmYWxzZSwKICAgICJwcmVtaXVt
+        X3NpbmNlIjogbnVsbCwKICAgICJyb2xlcyI6IFsKCiAgICBdLAogICAgInVz
+        ZXIiOiB7CiAgICAgICJhdmF0YXIiOiBudWxsLAogICAgICAiYXZhdGFyX2Rl
+        Y29yYXRpb24iOiBudWxsLAogICAgICAiYm90IjogZmFsc2UsCiAgICAgICJk
+        aXNjcmltaW5hdG9yIjogIjgxODEiLAogICAgICAiaWQiOiAiOTg3NjUiLAog
+        ICAgICAicHVibGljX2ZsYWdzIjogMCwKICAgICAgInVzZXJuYW1lIjogIuOC
+        quODvOODiuODvOOBoOOBjOODreODvOODq+OBquOBlyIKICAgIH0KICB9Cl0=
+  recorded_at: Tue, 24 Jan 2023 07:28:05 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/kick_human.yml
+++ b/test/cassettes/discord/guild_members/kick_human.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://discord.com/api/v10/guilds/0123456789/members/240739527950208168
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:28:00 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=b70e2eec57478ed5348e84f31e3c4b2d95c068b2-1674545280; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=a18366e09bb811edb4b6167ef6d1499f; Expires=Sun, 23-Jan-2028 07:28:00
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=a18366e09bb811edb4b6167ef6d1499f152e04848bb6eeb577ac0158fc8ada1428eb31ec66829c027ee32073d038b102;
+        Expires=Sun, 23-Jan-2028 07:28:00 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - e06f83c33559dfd4dc34f5666fdfa1d3
+      X-Ratelimit-Limit:
+      - '5'
+      X-Ratelimit-Remaining:
+      - '4'
+      X-Ratelimit-Reset:
+      - '1674545281.313'
+      X-Ratelimit-Reset-After:
+      - '1.000'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=88aa3EfgLmMPnu2gCltpBWSbAvUdvGStpHfizPFapwwkfJ0HwZ0erTKXexkjkotypWMz86fu%2BaX%2F6%2Ft6O49Ejgn2jhLn%2F1rwx0xCvtGvCmfsecrvz6P57Jt%2F0mwl"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e70cc14bbb19f4-KIX
+    body:
+      encoding: UTF-8
+      base64_string: ''
+  recorded_at: Tue, 24 Jan 2023 07:28:02 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/kick_unknown_user.yml
+++ b/test/cassettes/discord/guild_members/kick_unknown_user.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://discord.com/api/v10/guilds/0123456789/members/654321
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 23:33:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=35cc9b4b1e7a3af332412a6a71a0d3d4504b524b-1674603202; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=7dd72f929c3f11edbb78a63bcfe821af; Expires=Sun, 23-Jan-2028 23:33:22
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=7dd72f929c3f11edbb78a63bcfe821af88807ee10ca9824bc2556e75517af36bb19d0fbfd775c530d25915dd4f5c1a82;
+        Expires=Sun, 23-Jan-2028 23:33:22 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - e06f83c33559dfd4dc34f5666fdfa1d3
+      X-Ratelimit-Limit:
+      - '5'
+      X-Ratelimit-Remaining:
+      - '4'
+      X-Ratelimit-Reset:
+      - '1674603203.640'
+      X-Ratelimit-Reset-After:
+      - '1.000'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=3D%2BRKK04vBfsUmh1DqqkY0McS1g78%2B3eiUQ5zeNerA5%2FhUpmCqFOlg03wIZVj6VfzKhvI%2BUun6iQW%2BOxZ1mKqLq0Sgs8nx3jUXTNF52oP27G5ME6R5sWkiaqbE6%2F"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78ec92dfbaab8d07-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        ewogICJtZXNzYWdlIjogIlVua25vd24gVXNlciIsCiAgImNvZGUiOiAxMDAx
+        Mwp9
+  recorded_at: Tue, 24 Jan 2023 23:33:22 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/kick_with_lack_permission.yml
+++ b/test/cassettes/discord/guild_members/kick_with_lack_permission.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://discord.com/api/v10/guilds/0123456789/members/123456
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot NOT PRIVILEGED GATEWAY FOR GUILD MEMBERS INTENT
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 23:38:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=b4073ba16219b9e00e31a27a06903172cead606b-1674603534; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=43c216c29c4011edb384baba65353a66; Expires=Sun, 23-Jan-2028 23:38:54
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=43c216c29c4011edb384baba65353a66205c0764de7bdfb8361ec08a6a7b63775c68388a6fb4cd096c92b455695ff233;
+        Expires=Sun, 23-Jan-2028 23:38:54 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - e06f83c33559dfd4dc34f5666fdfa1d3
+      X-Ratelimit-Limit:
+      - '5'
+      X-Ratelimit-Remaining:
+      - '4'
+      X-Ratelimit-Reset:
+      - '1674603535.683'
+      X-Ratelimit-Reset-After:
+      - '1.000'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=YLurDOGZ84m3teZn6FeGU%2BOSOM7t1sZUnAizuoTy%2Fjw8frOueuFromNwexvnvrYKYraNkYkiLt0gXxoj0Ks1T%2Bq7lcemqpTRIoJGUDGp6evVX2Llue0WQmCxjwKs"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78ec9afaec05836a-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        ewogICJtZXNzYWdlIjogIk1pc3NpbmcgUGVybWlzc2lvbnMiLAogICJjb2Rl
+        IjogNTAwMTMKfQ==
+  recorded_at: Tue, 24 Jan 2023 23:38:54 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/kick_with_missing_access.yml
+++ b/test/cassettes/discord/guild_members/kick_with_missing_access.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://discord.com/api/v10/guilds/0123456789/members/98765
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:28:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=2acd11eaacd3c1f2b0694f5089393a7d8965237a-1674545283; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=a340bb0e9bb811edbabdbe3d4ce3efb4; Expires=Sun, 23-Jan-2028 07:28:03
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=a340bb0e9bb811edbabdbe3d4ce3efb4a7f9ed0e5488eeff72e3194668ba90444173fb631a7e4cde5cafe4e87aa3b058;
+        Expires=Sun, 23-Jan-2028 07:28:03 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - e06f83c33559dfd4dc34f5666fdfa1d3
+      X-Ratelimit-Limit:
+      - '5'
+      X-Ratelimit-Remaining:
+      - '4'
+      X-Ratelimit-Reset:
+      - '1674545284.347'
+      X-Ratelimit-Reset-After:
+      - '1.000'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=p7LsX%2FNuIN3l1aO%2BEIU9BkVp2NIAjvQUkWW6F7W8fxn%2Fwdp%2BSe%2FyffgHNwAZdxCH52JsBWy8ZwZN6dJOoxPy4po6eTgaVTuuU3w8sm8dO2uhOrj6uoUWx2trC2Fx"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e70cd42be58d13-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        ewogICJtZXNzYWdlIjogIk1pc3NpbmcgUGVybWlzc2lvbnMiLAogICJjb2Rl
+        IjogNTAwMTMKfQ==
+  recorded_at: Tue, 24 Jan 2023 07:28:05 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/not_found.yml
+++ b/test/cassettes/discord/guild_members/not_found.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://discord.com/api/v10/guilds/0123456789/members/search?limit=10&query=Unknown
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:28:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=2acd11eaacd3c1f2b0694f5089393a7d8965237a-1674545283; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=a3197bfc9bb811ed9aaa6a9a9a1939fc; Expires=Sun, 23-Jan-2028 07:28:03
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=a3197bfc9bb811ed9aaa6a9a9a1939fcd8d5ab0a5cc8d192d760f8b9062c19a5b6353ce386001b5a83121ad94acf3848;
+        Expires=Sun, 23-Jan-2028 07:28:03 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - d721eda6a63e6522373d361f98e4b58b
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1674545290.051'
+      X-Ratelimit-Reset-After:
+      - '6.973'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Akt8lSqSah1l3V0ivlcJmKc%2BfBmOWAA9DbvnY8BGWeZpbMQiHLfaPGajVk1fzXOJufOOlZGRad6tx9W8Uq8Nn9azr5CMZjRmv0kijjqxZlIfEc6vg6NuemqoDQ%2B9"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e70cd2686c8d00-KIX
+    body:
+      encoding: UTF-8
+      base64_string: 'WwoKXQ==
+
+        '
+  recorded_at: Tue, 24 Jan 2023 07:28:05 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/not_found_with_unsafe_name.yml
+++ b/test/cassettes/discord/guild_members/not_found_with_unsafe_name.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://discord.com/api/v10/guilds/0123456789/members/search?limit=10&query=%5E
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot example
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:28:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=2acd11eaacd3c1f2b0694f5089393a7d8965237a-1674545283; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=a30c94b49bb811edb403b6d689d377ca; Expires=Sun, 23-Jan-2028 07:28:03
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=a30c94b49bb811edb403b6d689d377cadad67733b147bc782617fd1e7bcf3b15d75a523040c1065b77bc4ea6d78f1dcb;
+        Expires=Sun, 23-Jan-2028 07:28:03 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - d721eda6a63e6522373d361f98e4b58b
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1674545290.045'
+      X-Ratelimit-Reset-After:
+      - '7.041'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=PT04x5YwhjXiCKyNptt5zU4kjAY0fWKlhkazp6EOXHOGOREgRxoACVGSGGwW5mPoaZcf4fIoz0MKKN3kl3WX%2BPhmW7%2B7%2FedqQyXn%2ByMASl2mRyH1feWl7aXAm6SW"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e70cd20d0b19d1-KIX
+    body:
+      encoding: UTF-8
+      base64_string: 'WwoKXQ==
+
+        '
+  recorded_at: Tue, 24 Jan 2023 07:28:05 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/unauthorized_delete.yml
+++ b/test/cassettes/discord/guild_members/unauthorized_delete.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://discord.com/api/v10/guilds/0123456789/members/123456
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot unauthorized
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:28:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=b70e2eec57478ed5348e84f31e3c4b2d95c068b2-1674545280; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=a14a82309bb811eda4d6d61d084cbf6e; Expires=Sun, 23-Jan-2028 07:28:00
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=a14a82309bb811eda4d6d61d084cbf6e73aabb2f74bff06ea5e884ad19e4227634f5d092d138358a7192156a424e09a5;
+        Expires=Sun, 23-Jan-2028 07:28:00 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=dfz6ZbrLYMmERzB66YIp9xD%2B2TEnFEhSS7cF1sApH2KSrLHHT8074sXu3u142VKdW5tbtcdaptojbRfyF5DSyQ33cx0%2BXKCXwu7R9gPBDu%2FUitnnATXbrcyXKrFs"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e70cbf995417be-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        ewogICJtZXNzYWdlIjogIjQwMTogVW5hdXRob3JpemVkIiwKICAiY29kZSI6
+        IDAKfQ==
+  recorded_at: Tue, 24 Jan 2023 07:28:02 GMT
+recorded_with: VCR 6.1.0

--- a/test/cassettes/discord/guild_members/unauthorized_get.yml
+++ b/test/cassettes/discord/guild_members/unauthorized_get.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://discord.com/api/v10/guilds/0123456789/members/search?limit=10&query=Human
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bot unauthorized
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Tue, 24 Jan 2023 07:28:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=b70e2eec57478ed5348e84f31e3c4b2d95c068b2-1674545280; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=a13df7cc9bb811ed9da7de7671220bb3; Expires=Sun, 23-Jan-2028 07:27:59
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/
+      - __sdcfduid=a13df7cc9bb811ed9da7de7671220bb3ee9824cc4de244bf67efaf8d25876597313e0051096788e667cd861d2b375aff;
+        Expires=Sun, 23-Jan-2028 07:27:59 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=mP7I6TlYuy%2BUF1Z5kHNawpSkPCG76ePvRYl4%2F40XTArWI8QwPJRiXv82FvFS2V3z1cehYzzQZUizOIBPrg5IUehtyhsUc100Q5cZv99k%2F90v1AbHFafOvLkjoKN6"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 78e70cbf3ec48378-KIX
+    body:
+      encoding: UTF-8
+      base64_string: |
+        ewogICJtZXNzYWdlIjogIjQwMTogVW5hdXRob3JpemVkIiwKICAiY29kZSI6
+        IDAKfQ==
+  recorded_at: Tue, 24 Jan 2023 07:28:02 GMT
+recorded_with: VCR 6.1.0

--- a/test/models/discord_member_test.rb
+++ b/test/models/discord_member_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DiscordMemberTest < ActiveSupport::TestCase
+  setup do
+    @guild_id = ENV['DISCORD_GUILD_ID']
+    @bot_token = ENV['DISCORD_BOT_TOKEN']
+
+    ENV['DISCORD_GUILD_ID'] = '0123456789'
+    ENV['DISCORD_BOT_TOKEN'] = 'example'
+  end
+
+  teardown do
+    ENV['DISCORD_GUILD_ID'] = @guild_id
+    ENV['DISCORD_BOT_TOKEN'] = @bot_token
+  end
+
+  test '.find_by return found' do
+    VCR.use_cassette 'discord/guild_members/found_human' do
+      found = DiscordMember.find_by(account_name: 'Human#4545')
+      assert_equal found.account_name, 'Human#4545'
+    end
+
+    VCR.use_cassette 'discord/guild_members/found_human_with_kanji' do
+      found = DiscordMember.find_by(account_name: 'ひらがなと漢字#0019')
+      assert_equal found.account_name, 'ひらがなと漢字#0019'
+    end
+
+    VCR.use_cassette 'discord/guild_members/found_bot' do
+      found = DiscordMember.find_by(account_name: 'TestBot ✨#5803')
+      assert_equal found.account_name, 'TestBot ✨#5803'
+    end
+  end
+
+  test '.find_by return nil by unauthorized' do
+    ENV['DISCORD_BOT_TOKEN'] = 'unauthorized'
+    VCR.use_cassette 'discord/guild_members/unauthorized_get' do
+      found = DiscordMember.find_by(account_name: 'Human#4545')
+      assert_nil found
+    end
+  end
+
+  test '.find_by return nil by not found with blank name' do
+    found = DiscordMember.find_by(account_name: '')
+    assert_nil found
+  end
+
+  test '.find_by return nil by not found' do
+    VCR.use_cassette 'discord/guild_members/not_found' do
+      found = DiscordMember.find_by(account_name: 'Unknown')
+      assert_nil found
+    end
+  end
+
+  test '.find_by return nil by not found with unsafe name' do
+    VCR.use_cassette 'discord/guild_members/not_found_with_unsafe_name' do
+      found = DiscordMember.find_by(account_name: '^#\#0019')
+      assert_nil found
+    end
+  end
+
+  test '.find_by return nil by server error' do
+    logs = []
+    stub_error_logger = ->(message) { logs << message }
+    Rails.logger.stub(:error, stub_error_logger) do
+      stub_timeout_error = ->(_path) { raise Net::OpenTimeout }
+      Discord::Resource.stub(:get, stub_timeout_error) do
+        found = DiscordMember.find_by(account_name: 'Human#4545')
+        assert_nil found
+      end
+    end
+    assert_match '[Discord API] APIへの接続がタイムアウトしました。', logs.to_s
+  end
+
+  test '#destroy return true by destroyed' do
+    VCR.use_cassette 'discord/guild_members/found_human' do
+      @discord_member = DiscordMember.find_by(account_name: 'Human#4545')
+    end
+
+    VCR.use_cassette 'discord/guild_members/kick_human' do
+      assert @discord_member.destroy
+    end
+  end
+
+  test '#destroy return false by unknown user' do
+    # NOTE: https://discord.com/developers/docs/topics/opcodes-and-status-codes#:~:text=lack%20permissions
+    VCR.use_cassette 'discord/guild_members/kick_unknown_user' do
+      discord_member = DiscordMember.new(user: { bot: false, id: 654_321, username: 'Unknown' }, roles: [])
+      assert_not discord_member.destroy
+    end
+  end
+
+  test '#destroy return false by bot' do
+    discord_member = DiscordMember.new(user: { bot: true, id: 123_456 }, roles: [])
+    assert_not discord_member.destroy
+  end
+
+  test '#destroy return false by has role' do
+    discord_member = DiscordMember.new(user: { bot: false, id: 123_456 }, roles: ['87654321'])
+    assert_not discord_member.destroy
+  end
+
+  test '#destroy return false by unauthorized' do
+    ENV['DISCORD_BOT_TOKEN'] = 'unauthorized'
+    VCR.use_cassette 'discord/guild_members/unauthorized_delete' do
+      discord_member = DiscordMember.new(user: { bot: false, id: 123_456 }, roles: [])
+      assert_not discord_member.destroy
+    end
+  end
+
+  test '#destroy return false by lack permission' do
+    ENV['DISCORD_BOT_TOKEN'] = 'NOT PRIVILEGED GATEWAY FOR GUILD MEMBERS INTENT'
+    # NOTE: https://discord.com/developers/docs/topics/opcodes-and-status-codes#:~:text=lack%20permissions
+    VCR.use_cassette 'discord/guild_members/kick_with_lack_permission' do
+      discord_member = DiscordMember.new(user: { bot: false, id: 123_456 }, roles: [])
+      assert_not discord_member.destroy
+    end
+  end
+
+  test '#destroy return false by try to kick owner' do
+    VCR.use_cassette 'discord/guild_members/found_human_with_owner' do
+      @discord_member = DiscordMember.find_by(account_name: 'オーナーだがロールなし#8181')
+    end
+    # NOTE: https://discord.com/developers/docs/topics/opcodes-and-status-codes#:~:text=Missing%20access
+    VCR.use_cassette 'discord/guild_members/kick_with_missing_access' do
+      assert_not @discord_member.destroy
+    end
+  end
+
+  test '#destroy return false by server error' do
+    logs = []
+    stub_error_logger = ->(message) { logs << message }
+    Rails.logger.stub(:error, stub_error_logger) do
+      stub_timeout_error = ->(_path) { raise Net::OpenTimeout }
+      Discord::Resource.stub(:delete, stub_timeout_error) do
+        discord_member = DiscordMember.new(user: { bot: false, id: 123_456 }, roles: [])
+        assert_not discord_member.destroy
+      end
+    end
+    assert_match '[Discord API] APIへの接続がタイムアウトしました。', logs.to_s
+  end
+end

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -60,13 +60,18 @@ class RetirementTest < ApplicationSystemTestCase
   end
 
   test 'enables retirement regardless of validity of discord id' do
+    logs = []
+    stub_warn_logger = ->(message) { logs << message }
     user = users(:discordinvalid)
-    visit_with_auth new_retirement_path, 'discordinvalid'
-    find('label', text: 'とても悪い').click
-    click_on '退会する'
-    page.accept_confirm
-    assert_text '退会処理が完了しました'
+    Rails.logger.stub(:warn, stub_warn_logger) do
+      visit_with_auth new_retirement_path, 'discordinvalid'
+      find('label', text: 'とても悪い').click
+      click_on '退会する'
+      page.accept_confirm
+      assert_text '退会処理が完了しました'
+    end
     assert_equal Date.current, user.reload.retired_on
+    assert_match '[Discord API] discordinvalid#1234567890 はアカウントが見つかりませんでした。', logs.to_s
     assert_equal '😢 discordinvalidさんが退会しました。', users(:komagata).notifications.last.message
     assert_equal '😢 discordinvalidさんが退会しました。', users(:mentormentaro).notifications.last.message
 


### PR DESCRIPTION
## Issue

- #1996

## 概要

ブートキャンプ退会時に Discord アカウント情報があれば Web API を利用して自動で Discord サーバーから退出させる機能を実装しました。

ただし、次の懸念点があります。

1. ブートキャンプの登録情報にある Discord アカウント情報は非認証の自己申告されたものであること
2. ブートキャンプの登録情報は `/current_user/edit` から変更できるが Discord アカウント情報の入力は必須ではないこと
3. 休会時にも同様に Discord サーバーから退出させる必要があるのでは？

上記の懸念点への対応としては次の通りとしました。

- 懸念点1への対応
  - 自動で退出させる Discord アカウントのロールを現役生のみに限定することで、
  管理者・メンター・顧問・研修生などのロールが付与されている Discord アカウントの退出を回避します
  - Discord アカウント情報が存在しないものであったり、上記のロールが付与されているものの場合は、
  Discord サーバーから退出させずに、試みたことをエラーログとして記録します
- 懸念点2への対応
  - Discord アカウント情報があった場合のみ Discord サーバーからさせます
- 懸念点3への対応
  - この議題の範囲外として判断しました（次回ミーティングで共有します）

## 変更確認方法

1. `feature/kick-from-discord-when-bootcamp-retired` をローカルに取り込みます
2. `bundle exec rails db:drop` を実行します
3. `bin/setup` を実行します
4. `bin/rails log:clear` を実行します
5. 後述の「注意・伝達事項」にある追加する2の環境変数を設定します
6. `bin/rails s` でサーバーを立ち上げます
7. `kimura` でログインします
8. Discord Bot を参加させた Discord サーバーに確認用のアカウント（Bot 以外）を参加させます
    - Discord にて @maeda-m に招待リンクを共有いただければ参加します👍
9. 登録情報変更（ http://localhost:3000/current_user/edit ）から項目「Discord アカウント」に 8 で参加させた確認用のアカウント（＃付き）を入力し、ボタン「更新する」をクリックします
10. 退会手続き（ http://localhost:3000/retirement/new ）にアクセスし、項目「全体の満足度を教えてください」に任意の値を選択し、ボタン「退会する」をクリックします
11. 確認ダイアログのOKをクリックすると、「退会処理が完了しました」と表示されます
12. 8 で参加させた確認用のアカウントが Discord サーバーから退出されたことを確認します
    - Discord の画面右に表示されるメンバーリストや
    管理者であれば `サーバー設定 > ユーザー管理` のメンバーから確認できます
13. `log/development.log` に `[Discord API] <Discord アカウント（＃付き）が入ります> を退出させました。` と出力されていることを確認します

## Screenshot

画面上の変更はありません。

## 注意・伝達事項

### Discord Bot を参加させる Discord サーバーのIDを取得する

> **Note**
> 
> 確認用の Discord サーバーを作成する場合は #5454 ようにサーバーを新規作成してください（webhookURLの取得は不要です）。

アイコンを右クリックして、コンテキストメニュー「IDをコピー」をクリックして控えます。

![discord_005](https://user-images.githubusercontent.com/943541/214308064-b644a23a-18d7-4871-8fef-d7b20206acf8.png)

### Discord Bot のトークン情報を取得する

https://discord.com/developers/applications にアクセスして右上のボタン「New Application」からアプリケーションを登録し、ボットを使えるように設定します。

1. 次の項目を入力・チェックしてアプリケーションを作成します
    - NAME: Bootcamp
    - By clicking Create, you agree to the Discord Developer Terms of Service and Developer Policy（利用規約や開発者ポリシーへの同意）: チェックを入れる
2. 左のメニューからBotをクリックし、ボタン「Add Bot」からボットを追加します
3. Bot のトークン情報の更新と各種設定をします
    - ボタン「Reset Token」をクリックし、コピーして控えます
    - `Authorization Flow > PUBLIC BOT` のトグルボタンを OFF にします
    - `Privileged Gateway Intents > SERVER MEMBERS INTENT` のトグルボタンを ON にします
    - ボタン「Save Changes」をクリックします

![discord_003](https://user-images.githubusercontent.com/943541/214451554-eba42402-4b97-46fd-8f88-237147865a87.png)

4. OAuth2 > URL Generator をクリックし、Discord サーバーへ参加させるためのリンクを発行します
    - SCOPES
      - bot: チェックを入れる
    - BOT PERMISSIONS
      - Kick Members: チェックを入れる
    - GENERATED URL
      - ボタン「Copy」をクリックし、コピーして控えます

![discord_004](https://user-images.githubusercontent.com/943541/214309349-fc308262-48fd-464c-8aae-09956a67c692.png)

5. 4でコピーしたリンクを開いて Bot を Discord サーバーへ参加させます

> **Warning**
> 
> 前述の `Privileged Gateway Intents > SERVER MEMBERS INTENT` を OFF のまま参加した場合は、前項の URL Generator からやり直してください。

ボタン「認証」をクリックして画面の指示に従えばOKです。

|Bot を 参加させる Discord サーバーを選びます|メンバーをキックにチェックが入っていることを確認します|
|:---:|:---:|
|![discord_006](https://user-images.githubusercontent.com/943541/214311330-dc0d30af-5f6b-4965-a16f-cbcb568678a5.png)|![discord_007](https://user-images.githubusercontent.com/943541/214453561-4dc78018-36fe-41f4-af5f-2bd9c64ef76d.png)|

### 追加する2の環境変数を設定する

前述の手順で発行された各キーを環境変数を設定する必要があります。

1. `DISCORD_GUILD_ID`
    - 前述の「Discord Bot を参加させる Discord サーバーのIDを取得する」で控えた値です
2. `DISCORD_BOT_TOKEN`
    - 前述の「Discord Bot のトークン情報を取得する」の3.で控えた値です

開発環境での例として次のコマンドをターミナルで実行します:
```console
export DISCORD_GUILD_ID=nnnnnnnnnnnnnnnnnnn
export DISCORD_BOT_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

## 参考情報

- Discord では `kick` を追放と呼んでいます
  - このプルリクエストでは議題の表現と統一するために退出と呼んでいます
- Discord の開発者向けドキュメントでは `guild` をサーバーと呼んでいます
  - [Discord Developer Portal — Documentation — Gateway](https://discord.com/developers/docs/topics/gateway#gateway-intents)
- [メンター、アドバイザー、卒業生の見分け方 | FBC](https://bootcamp.fjord.jp/pages/360)
- [チャットを使えるようになる | FBC](https://bootcamp.fjord.jp/practices/129)
- [shardlab/discordrb: Discord API for Ruby](https://github.com/shardlab/discordrb)
  - 今回使用する Web API（ [Search Guild Members](https://discord.com/developers/docs/resources/guild#search-guild-members)） に非対応だったようなので未採用です
- [rails/activeresource: Connects business objects and REST web services](https://github.com/rails/activeresource)
  - 今回使用する Web API（ [Search Guild Members](https://discord.com/developers/docs/resources/guild#search-guild-members)） では適用しにくかったので未採用です
- [Railsアプリケーションにおけるエラー処理（例外設計）の考え方 - Qiita](https://qiita.com/jnchito/items/3ef95ea144ed15df3637)
- [DiscordのAPIをちょっと触ってみる - Qiita](https://qiita.com/tan/items/d876fca53615e5dba85b)
- [「DiscordのIDでログイン」を実装する(Oauth2) - Qiita](https://qiita.com/masayoshi4649/items/46fdb744cb8255f5eb98)

