### PR TITLE
dailyからnotify_certain_period_passed_after_last_answerルートを作る

### DIFF
--- a/app/controllers/scheduler/daily/notify_certain_period_passed_after_last_answer_controller.rb
+++ b/app/controllers/scheduler/daily/notify_certain_period_passed_after_last_answer_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Scheduler::Daily::NotifyCertainPeriodPassedAfterLastAnswerController < ApplicationController
+  def show
+    Question.notify_certain_period_passed_after_last_answer
+    head :ok
+  end
+end

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -4,7 +4,6 @@ class Scheduler::DailyController < SchedulerController
   def show
     User.notify_to_discord
     notify_product_review_not_completed
-    Question.notify_certain_period_passed_after_last_answer
     head :ok
   end
 

--- a/config/routes/scheduler.rb
+++ b/config/routes/scheduler.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     namespace :daily do
       resource :after_retirement, only: %i(show), controller: "after_retirement"
       resource :notify_tomorrow_regular_event, only: %i(show), controller: "notify_tomorrow_regular_event"
+      resource :notify_certain_period_passed_after_last_answer, only: %i(show), controller: "notify_certain_period_passed_after_last_answer"
     end
   end
 end

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -303,14 +303,14 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     )
 
     travel_to Time.zone.local(2022, 11, 6, 0, 0, 0) do
-      visit_with_auth '/scheduler/daily', 'kimura'
+      visit_with_auth '/scheduler/daily/notify_certain_period_passed_after_last_answer', 'kimura'
       visit '/notifications'
 
       assert_no_text 'Q&A「テストの質問」のベストアンサーがまだ選ばれていません。'
     end
 
     travel_to Time.zone.local(2022, 11, 7, 0, 0, 0) do
-      visit_with_auth '/scheduler/daily', 'kimura'
+      visit_with_auth '/scheduler/daily/notify_certain_period_passed_after_last_answer', 'kimura'
       visit '/notifications'
 
       assert_text 'Q&A「テストの質問」のベストアンサーがまだ選ばれていません。'


### PR DESCRIPTION
## Issue

- #5934

## 概要

新しいルートを作成して、`question.notify_certain_period_passed_after_last_answer`を`daily`から分離します。

## 変更確認方法

1. `feature/move-question-notify_certain_period_passed_after_last_answer`をローカルに取り込む
2. `bin/rails db:reset`と`bin/rails s`でサーバーを起動
3. `kimura`でログイン
4. `http://127.0.0.1:3000/scheduler/daily/notify_certain_period_passed_after_last_answer`にアクセスする
5. 通知確認する。
    - サイト内通知はこのURLに`http://127.0.0.1:3000/notifications?status=unread`にアクセスし、「Q&A「1週間前の質問」のベストアンサーがまだ選ばれていません。」表示されることを確認する。
    - メール通知は`http://127.0.0.1:3000/letter_opener/`にアクセスし、メール内容`kimuraさんの質問【 1週間前の質問 】のベストアンサーがまだ選ばれていません。`が表示されることを確認する。