### PR TITLE
落ちやすいテストを2つ直した

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -47,7 +47,7 @@ class API::CommentsController < API::BaseController
   end
 
   def commentable
-    params[:commentable_type].constantize.find_by(id: params[:commentable_id])
+    params[:commentable_type].constantize.find(params[:commentable_id])
   end
 
   def set_my_comment

--- a/app/controllers/api/footprints_controller.rb
+++ b/app/controllers/api/footprints_controller.rb
@@ -14,6 +14,6 @@ class API::FootprintsController < API::BaseController
   private
 
   def footprintable
-    params[:footprintable_type].constantize.find_by(id: params[:footprintable_id])
+    params[:footprintable_type].constantize.find(params[:footprintable_id])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -330,7 +330,7 @@ class User < ApplicationRecord
     end
   }
   scope :same_generations, lambda { |start_date, end_date|
-    where(created_at: start_date..end_date).order(:created_at)
+    where(created_at: start_date..end_date).order(:created_at, :id)
   }
   scope :desc_tagged_with, lambda { |tag_name|
     with_attached_avatar

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -916,7 +916,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   organization: 株式会社フィヨルド
   github_collaborator: true
   unsubscribe_email_token: MnC-Dv3HrNLs7WmfE975qA
-  updated_at: "2014-01-01 00:00:02"
-  created_at: "2014-01-01 00:00:02"
-  last_activity_at: "2014-01-01 00:00:02"
+  updated_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
+  created_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
+  last_activity_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
 <% end %>

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -83,6 +83,8 @@ class EventsTest < ApplicationSystemTestCase
 
   test 'destroy event' do
     visit_with_auth event_path(events(:event1)), 'komagata'
+    find 'h2', text: 'コメント'
+    find 'div.container > div.user-icons > ul.user-icons__items', visible: :all
     accept_confirm do
       click_link '削除'
     end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -123,6 +123,8 @@ class Notification::ReportsTest < ApplicationSystemTestCase
 
     visit_with_auth "/reports/#{report.id}", 'kimura'
 
+    find 'h2', text: 'コメント'
+    find 'div.container div.user-icons > ul.user-icons__items', visible: :all
     accept_confirm do
       click_link '削除'
     end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -80,6 +80,8 @@ class RegularEventsTest < ApplicationSystemTestCase
 
   test 'destroy regular event' do
     visit_with_auth regular_event_path(regular_events(:regular_event1)), 'komagata'
+    find 'h2', text: 'コメント'
+    find 'div.container > div.user-icons > ul.user-icons__items', visible: :all
     accept_confirm do
       click_link '削除'
     end


### PR DESCRIPTION
## Issue

- #5319

## 概要

以下の落ちやすいテスト(+関連するテスト)を直しました。

1. `GenerationsTest#test_all_users_filter_for_generation`
1. `RegularEventsTest#test_destroy_regular_event`

個別の説明は別コメントに記載します

## 変更確認方法

1. ` feature/fix-two-unstable-test`をローカルに取り込む
2. `rails test:all`を実行する(必要に応じて環境変数(`CI=1 PARALLEL_WORKERS=1`)を指定します)
3. 全てのテストが通過する
