### PR TITLE
Q&Aで質問する際のタイトル欄にplaceholderを追加

### DIFF
--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -14,7 +14,7 @@
         .row.js-markdown-parent
           .col-md-6.col-xs-12
             = f.label :title, class: 'a-form-label'
-            = f.text_field :title, class: 'a-text-input js-warning-form'
+            = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: "メソッドを定義するときの考え方がわからない"
       .form-item
         .row.js-markdown-parent
           .col-md-6.col-xs-12

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -14,7 +14,7 @@
         .row.js-markdown-parent
           .col-md-6.col-xs-12
             = f.label :title, class: 'a-form-label'
-            = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: "メソッドを定義するときの考え方がわからない"
+            = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'メソッドを定義するときの考え方がわからない'
       .form-item
         .row.js-markdown-parent
           .col-md-6.col-xs-12


### PR DESCRIPTION
## Issue

- #6093 

## 概要

Q&Aで質問する際のタイトル欄にplaceholderを追加する

## 変更確認方法

1. `feature/add-placeholder-qa-title`をローカルに取り込む
2. `bin/rails s` でサーバーを起動
3. `komagata` でログイン
4. `/questions/new` にアクセス

## Screenshot

### 変更前

<img width="878" alt="スクリーンショット 2023-01-27 23 18 31" src="https://user-images.githubusercontent.com/94843475/215108638-61669cd7-3bde-4949-a3b7-413e38d380cb.png">


### 変更後

<img width="986" alt="スクリーンショット 2023-01-27 23 17 07" src="https://user-images.githubusercontent.com/94843475/215108369-fcde4835-0e79-4eae-a28d-bfdb97ee064c.png">

