### PR TITLE
hotfix: reports are ordered in descending of reported_onのシステムテストを修正した

### DIFF
--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -380,7 +380,6 @@ class ReportsTest < ApplicationSystemTestCase
     assert_no_text 'この日報はすでに提出済みです。'
   end
 
-  # 日報が増えて前の状態だと１ページ目に該当する日報が表示されていなかったので、１ページ目に該当する日報でテストを書き換えた
   test 'reports are ordered in descending of reported_on' do
     visit_with_auth reports_path, 'kimura'
     precede = reports(:report15).title
@@ -400,7 +399,6 @@ class ReportsTest < ApplicationSystemTestCase
     within '.card-list__items' do
       assert page.text.index(precede) < page.text.index(succeed)
     end
-    debugger # HEADED=1 rails test test/system/reports_test.rb:395をすると、ここで画面が止まるのでHTML構造を確認できる！
   end
 
   test 'reports can be checked as plain markdown' do

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -380,12 +380,13 @@ class ReportsTest < ApplicationSystemTestCase
     assert_no_text 'この日報はすでに提出済みです。'
   end
 
+  # 日報が増えて前の状態だと１ページ目に該当する日報が表示されていなかったので、１ページ目に該当する日報でテストを書き換えた
   test 'reports are ordered in descending of reported_on' do
     visit_with_auth reports_path, 'kimura'
-    precede = reports(:report24).title
-    succeed = reports(:report23).title
-    assert_text '検索用の日報'
-    assert_text 'フォローされた日報'
+    precede = reports(:report15).title
+    succeed = reports(:report16).title
+    assert_text '頑張りました'
+    assert_text '頑張れませんでした'
     within '.card-list__items' do
       assert page.text.index(precede) < page.text.index(succeed)
     end
@@ -399,6 +400,7 @@ class ReportsTest < ApplicationSystemTestCase
     within '.card-list__items' do
       assert page.text.index(precede) < page.text.index(succeed)
     end
+    debugger # HEADED=1 rails test test/system/reports_test.rb:395をすると、ここで画面が止まるのでHTML構造を確認できる！
   end
 
   test 'reports can be checked as plain markdown' do


### PR DESCRIPTION
## Issue

- #6123 

## 概要
`main`ブランチにおいてシステムテストの`reports are ordered in descending of reported_on`が落ちてしまっていたので修正をしました。

日報の数の増加に伴い、システムテストでチェックすべき文面と該当する日報が、`/reports`の１ページ目に表示されていなかったことが原因だと考えられます。

## 変更確認方法

1. `hotfix/fix-systemtest-reports-are-ordered-in-descending-of-reported_on`をローカルに取り込む
2. `rails test test/system/reports_test.rb`でテストコードを動かす。
3. テストコードが通る。

## Screenshot

### 変更前
![image](https://user-images.githubusercontent.com/93074851/215241239-511a8eb8-4e97-4be5-a80e-1f02cc086e0b.png)

![image](https://user-images.githubusercontent.com/93074851/215241252-b053236e-b074-49e0-bf11-149b27bd4f96.png)


### 変更後
![image](https://user-images.githubusercontent.com/93074851/215241180-a6fea963-0f5b-4d49-a532-57ad572d116e.png)


