### PR TITLE
プラクティス作成画面のタイトルにplaceholderを追加

### DIFF
--- a/app/views/practices/_form.html.slim
+++ b/app/views/practices/_form.html.slim
@@ -4,7 +4,7 @@
     .row
       .col-md-6.col-xs-12
         = f.label :title, class: 'a-form-label is-required'
-        = f.text_field :title, class: 'a-text-input js-warning-form'
+        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'HTMLの基本を理解する'
   .form-item
     = f.label :categories, class: 'a-form-label is-required'
     .checkboxes


### PR DESCRIPTION
## Issue
- #6094

## 概要
プラクティス作成画面のタイトルにplaceholderを追加しました。

## 変更確認方法
1. `feature/add-placeholder-practice`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `mentormentaro`でログインする
4. サイドバーの「プラクティス」をクリックする
<img width="465" alt="スクリーンショット 2023-01-29 21 30 36" src="https://user-images.githubusercontent.com/77523896/215326252-bb020d0b-0786-4399-9474-5e4168fa57a3.png">
5. 画面右上の「プラクティス作成」をクリックする
<img width="546" alt="スクリーンショット 2023-01-29 21 31 28" src="https://user-images.githubusercontent.com/77523896/215326314-e879b483-ebd6-4781-a5a0-2091ed440be6.png">

## Screenshot
### 変更前
![215242451-f4b1d7a2-edc8-4820-8c2a-3f520423811d](https://user-images.githubusercontent.com/77523896/215253120-a2db44dd-dfc9-4295-81c0-c5f5afcc6b37.png)

### 変更後
![215242459-fd73c689-866f-4825-8498-319708c9be97](https://user-images.githubusercontent.com/77523896/215253150-6e4b26d2-827d-4bff-9034-565b15d4d2df.png)

