### PR TITLE
ログイン画面の参加登録リンク名を修正

### DIFF
--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -16,6 +16,6 @@
           li.auth-form-nav__item
             = link_to 'トップページ', root_path, class: 'auth-form-nav__item-link'
           li.auth-form-nav__item
-            = link_to 'サインアップ', new_user_path, class: 'auth-form-nav__item-link'
+            = link_to '参加登録', new_user_path, class: 'auth-form-nav__item-link'
           li.auth-form-nav__item
             = link_to '休会からの復帰', new_comeback_path, class: 'auth-form-nav__item-link'


### PR DESCRIPTION
## Issue

- #6087 

## 概要

ログイン画面の「サインアップ」を「参加登録」に変更しました。

## 変更確認方法

1. `feature/change-signup-link-name`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `http://localhost:3000/login`に遷移する

## Screenshot

### 変更前

<img width="688" alt="スクリーンショット 2023-01-28 13 57 30" src="https://user-images.githubusercontent.com/94843475/215243288-51b08afa-4661-4ba6-b4fc-e857b60d82b9.png">

### 変更後

<img width="659" alt="スクリーンショット 2023-01-28 13 59 35" src="https://user-images.githubusercontent.com/94843475/215243310-5ecff136-6fea-428c-9c75-aee82e17fbbb.png">
