### PR TITLE
ページ作成のスラッグの説明文の修正

### DIFF
--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -38,7 +38,7 @@
           = f.label :slug, class: 'a-form-label'
           = f.text_field :slug, class: 'a-text-input js-warning-form'
           .a-form-help
-            p 
+            p
               | スラッグを設定すると`https://bootcamp.fjord.jp/pages/{スラッグ}`の様にスラッグで指定した文字列のURLでアクセスが出来るようになります。
               br
               | スラッグにはアルファベットから始まる半角英数字と、ハイフン （ - ）、アンダーバー （ _ ） が使えます。

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -38,7 +38,10 @@
           = f.label :slug, class: 'a-form-label'
           = f.text_field :slug, class: 'a-text-input js-warning-form'
           .a-form-help
-            p アルファベットから始まる半角英数字と、ハイフン （ - ）、アンダーバー （ _ ） が使えます。
+            p 
+              | スラッグを設定すると`https://bootcamp.fjord.jp/pages/{スラッグ}`の様にスラッグで指定した文字列のURLでアクセスが出来るようになります。
+              br
+              | スラッグにはアルファベットから始まる半角英数字と、ハイフン （ - ）、アンダーバー （ _ ） が使えます。
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main


### PR DESCRIPTION
## Issue
- #6090

## 概要
ページ作成のスラッグの説明文を修正しました

## 変更確認方法

1. `feature/change-pages-slug-description`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `mentormentaro`でログインする
4. `/pages/new` へアクセスする

## Screenshot

### 変更前
<img width="683" alt="スクリーンショット 2023-01-28 14 35 32" src="https://user-images.githubusercontent.com/75718420/215248680-a32fd2eb-ca76-4690-994f-0de5e6667642.png">

### 変更後
<img width="679" alt="スクリーンショット 2023-01-28 14 35 11" src="https://user-images.githubusercontent.com/75718420/215248691-53a2ca82-7dad-46a7-96ff-544a17d70311.png">
