### PR TITLE
ページ作成のタイトルに placeholder を追加

### DIFF
--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -12,7 +12,7 @@
       .row
         .col-md-6.col-xs-12
           = f.label :title, class: 'a-form-label'
-          = f.text_field :title, class: 'a-text-input js-warning-form'
+          = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'つらくなったときに見るドキュメント'
         - if admin_or_mentor_login?
           .col-md-3.col-xs-6
             = f.label :user, class: 'a-form-label'


### PR DESCRIPTION
## Issue

- #6092

## 概要
ページ作成のタイトルに placeholder を設定しました

## 変更確認方法
1. `feature/add-pages-placeholder`をローカルに取り込む
2. `bin/rails s `でサーバーを起動
3. `mentormentaro` でログイン
4. `/pages/new ` にアクセス

## Screenshot

### 変更前
<img width="674" alt="スクリーンショット 2023-01-28 15 05 36" src="https://user-images.githubusercontent.com/75718420/215250197-b2445c74-e367-4c3d-bb89-c3667adba5f9.png">

### 変更後
<img width="662" alt="スクリーンショット 2023-01-28 15 17 23" src="https://user-images.githubusercontent.com/75718420/215250231-feac9e97-07e3-468f-a65c-3d4f72f6174c.png">

