### PR TITLE
参考書籍一覧のセレクトボックスの文言を修正

### DIFF
--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -21,7 +21,7 @@ header.page-header
           = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
           = select_tag :practice_id,
                   options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]),
-                  include_blank: '全ての質問を表示',
+                  include_blank: '全ての書籍を表示',
                   onchange: 'this.form.submit()',
                   id: 'js-choices-single-select'
   .page-content.is-books


### PR DESCRIPTION
## Issue
- #6047

## 概要
参考書籍一覧のセレクトボックスの文言を「全ての質問を表示」から「全ての書籍を表示」に修正しました。

## 変更確認方法
1. `bug/fix-wording-in-reference-book-list`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `/books`（参考書籍一覧）にアクセスし、「プラクティスで絞り込む」のセレクトボックスを確認する

## Screenshot

### 変更前
<img width="1361" alt="スクリーンショット 2023-01-29 20 43 37" src="https://user-images.githubusercontent.com/77523896/215325941-2c454e42-b13b-4b8b-a338-3f52e9d78102.png">

### 変更後
<img width="1361" alt="スクリーンショット 2023-01-29 20 44 50" src="https://user-images.githubusercontent.com/77523896/215325924-a27b68fb-9cfd-483d-9c6c-8e65027679a7.png">
