### PR TITLE
フォローしているユーザーの日報通知をactive_delivery化

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -188,6 +188,25 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:create_pages]
     )
     subject = "[FBC] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
+
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
+
+  def following_report(args = {})
+    @sender ||= args[:sender]
+    @report = params&.key?(:report) ? params[:report] : args[:report]
+    @receiver ||= args[:receiver]
+    @user = @receiver
+
+    @link_url = notification_redirector_url(
+      link: "/reports/#{@report.id}",
+      kind: Notification.kinds[:following_report]
+    )
+    subject = "[FBC] #{@sender.login_name}さんが日報【 #{@report.title} 】を書きました！"
+
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -205,7 +205,7 @@ class ActivityMailer < ApplicationMailer
       link: "/reports/#{@report.id}",
       kind: Notification.kinds[:following_report]
     )
-    subject = "[FBC] #{@sender.login_name}さんが日報【 #{@report.title} 】を書きました！"
+    subject = "[FBC] #{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！"
 
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -89,11 +89,11 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: subject
   end
 
-  # required params: report, receiver
-  def following_report
+  # required params: page, receiver
+  def create_page
     @user = @receiver
-    @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
-    subject = "[FBC] #{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！"
+    @notification = @user.notifications.find_by(link: "/pages/#{@page.id}")
+    subject = "[FBC] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
     mail to: @user.email, subject: subject
   end
 

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -48,16 +48,6 @@ class NotificationFacade
     ).trainee_report.deliver_later(wait: 5)
   end
 
-  def self.following_report(report, receiver)
-    ActivityNotifier.with(report: report, receiver: receiver).following_report.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      report: report,
-      receiver: receiver
-    ).following_report.deliver_later(wait: 5)
-  end
-
   def self.moved_up_event_waiting_user(event, receiver)
     ActivityNotifier.with(
       event: event,

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -34,7 +34,7 @@ class Report < ApplicationRecord
   validates :emotion, presence: true
   validate :reported_on_or_before_today
 
-  after_save   ReportCallbacks.new
+  after_save_commit ReportCallbacks.new
   after_create ReportCallbacks.new
   after_destroy ReportCallbacks.new
   after_initialize :set_default_emotion, if: :new_record?

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -52,7 +52,7 @@ class ReportCallbacks
 
   def notify_followers(report)
     report.user.followers.each do |follower|
-      NotificationFacade.following_report(report, follower)
+      ActivityDelivery.with(sender: report.user, receiver: follower, report: report).notify(:following_report)
       create_following_watch(report, follower) if follower.watching?(report.user)
     end
   end

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReportCallbacks
-  def after_save(report)
+  def after_commit(report)
     return unless report.saved_changes?
 
     Cache.delete_unchecked_report_count

--- a/app/views/activity_mailer/following_report.html.slim
+++ b/app/views/activity_mailer/following_report.html.slim
@@ -1,0 +1,5 @@
+= render '/notification_mailer/notification_mailer_template',
+title: "#{@user.login_name}さんが日報【 #{@report.title} 】を書きました！",
+link_url: @link_url,
+link_text: 'この日報へ' do
+  = md2html(@report.description)

--- a/app/views/activity_mailer/following_report.html.slim
+++ b/app/views/activity_mailer/following_report.html.slim
@@ -1,5 +1,5 @@
 = render '/notification_mailer/notification_mailer_template',
-title: "#{@user.login_name}さんが日報【 #{@report.title} 】を書きました！",
+title: "#{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！",
 link_url: @link_url,
 link_text: 'この日報へ' do
   = md2html(@report.description)

--- a/app/views/notification_mailer/following_report.html.slim
+++ b/app/views/notification_mailer/following_report.html.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: "#{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！", link_url: notification_url(@notification), link_text: 'この日報へ' do
-  = md2html(@report.description)

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -105,26 +105,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/イベント/, email.body.to_s)
   end
 
-  test 'following_report' do
-    report = reports(:report23)
-    notification = notifications(:notification_following_report)
-    mailer = NotificationMailer.with(
-      report: report,
-      receiver: notification.user
-    ).following_report
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['muryou@fjord.jp'], email.to
-    assert_equal '[FBC] kensyuさんが日報【 フォローされた日報 】を書きました！', email.subject
-    assert_match(/日報/, email.body.to_s)
-  end
-
   test 'chose_correct_answer' do
     answer = correct_answers(:correct_answer2)
     notification = notifications(:notification_chose_correct_answer)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -74,4 +74,16 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(product: product, receiver: receiver).submitted
   end
+
+  def following_report
+    report = Report.find(ActiveRecord::FixtureSet.identify(:report23))
+    sender = User.find(ActiveRecord::FixtureSet.identify(:kensyu))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:muryou))
+
+    ActivityMailer.with(
+      report: report,
+      sender: sender,
+      receiver: receiver
+    ).following_report
+  end
 end


### PR DESCRIPTION
## Issue

- #5885 

## 概要
フォローしているユーザーの日報通知をactive_delivery化しました。
- `NotificationFacade` が不要になり、通知送信は `ActivityDelivery` を経由して、サイト内通知が実行されるようになりました。
  - `NotificationFacade` によって実行されて板処理の部分に関わるコードを`ActiveDelivery` で実行されるように修正しました
  - 通知、メール送信、テストがそれぞれ影響を受け、修正しています。

## 変更確認方法

フォローしているユーザーの日報通知をactive_delivery経由で送信できることを確認する手順です。

1. `feature/change_following_report_notification` をローカルに取り込みます
2. `bin/setup` を実行します
3. `bin/rails s` でサーバーを立ち上げます
4. テストユーザー(kensyu)アカウントでログインし、日報を投稿する
5. テストユーザー(muryou)アカウントでログインし、手順4の通知が来ていることを確認する
6. http://localhost:3000/letter_opener/ を開いてメールが届いていることを確認する

## Screenshot
処理の置き換えのため変更前後で違いはありません。

<img width="344" alt="日報通知" src="https://user-images.githubusercontent.com/76797372/215376174-af33a620-aa83-4343-b8cc-cc095e6e8aec.png">
