### PR TITLE
reports.ymlファイルにおける2023年問題の解決

### DIFF
--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -310,7 +310,7 @@ report<%= i %>:
   emotion: 2
   description: |-
     頑張れませんでした
-  reported_on: <%= Time.now - 1.year + i.day %>
+  reported_on: <%= Time.local(2022) - 1.year + i.day %>
 <% end %>
 
 <% (1..15).each do |i| %>

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -325,7 +325,7 @@ report<%= i %>:
   emotion: 2
   description: |-
     頑張れませんでした
-  reported_on: <%= Time.now - 1.year + i.day %>
+  reported_on: <%= Time.local(2022) - 1.year + i.day %>
 <% end %>
 
 report72:


### PR DESCRIPTION
## Issue

- #6123 

このIssueと関連するもう一つのエラーを解決しました

## 概要

先日、`reports are ordered in descending of reported_on`のエラーを解決しました。

[hotfix: reports are ordered in descending of reported_onのシステムテストを修正した by lef237 · Pull Request #6124 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/pull/6124)

しかし数日経過して、今度は別のテスト、`reports are ordered in descending of created_at if reported_on is same`でエラーが発生するようになりました。

![image](https://user-images.githubusercontent.com/93074851/215650899-283d975e-8b7d-4975-85f6-9854755b018c.png)

この前のエラーと同様、`visit_with_auth reports_path, 'kimura'`で訪問したページの1ページ目に日報が存在しないことが原因でした。

そもそもの根本的な原因を調べるため、更に調査を致しました。

結論としては、`test/fixtures`の`reports.yml`に原因がありました。

[bootcamp/reports.yml at main · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/blob/main/test/fixtures/reports.yml#L328)

```yml
<% 35.upto(70) do |i| %>
report<%= i %>:
  user: with_hyphen
  title: 日報<%= i %>
  emotion: 2
  description: |-
    頑張れませんでした
  reported_on: <%= Time.now - 1.year + i.day %>
<% end %>
```

このコードは2022年に作成されたものであり、2022年の段階では`Time.now - 1.year`の部分が2021年に変換されていたため、問題が生じていませんでした。

しかし、2023年になったことで、`Time.now - 1.year`が2022年へと変換され、2023年の日報と2021年の日報の間に34個の日報が挿入される結果になりました。それにより、日報一覧の順番が変化して、1ページ目に該当する日報が表示されなくなったことがエラーの原因です。

（2022年のうちは以前のコードでも問題ありませんでしたが、2023年になったことで問題が生じました）

そのため、この`reports.yml`ファイルが再びエラーを生じさせないように、根本的な修正を加えました。

ご確認頂けると幸いです。

## Screenshot

### 変更前
![image](https://user-images.githubusercontent.com/93074851/215653504-283c6282-d530-490b-b182-dfc85124f137.png)


### 変更後
![image](https://user-images.githubusercontent.com/93074851/215653637-77ad44b3-db50-4a07-8a77-9eec6f052e3d.png)

