### PR TITLE
active_deliveryを使用して退会通知を送るようにする

### DIFF
--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -41,13 +41,13 @@ class RetirementController < ApplicationController
 
   def notify_to_admins
     User.admins.each do |admin_user|
-      NotificationFacade.retired(current_user, admin_user)
+      ActivityDelivery.with(sender: current_user, receiver: admin_user).notify(:retired)
     end
   end
 
   def notify_to_mentors
     User.mentor.each do |mentor_user|
-      NotificationFacade.retired(current_user, mentor_user)
+      ActivityDelivery.with(sender: current_user, receiver: mentor_user).notify(:retired)
     end
   end
 end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -103,6 +103,23 @@ class ActivityMailer < ApplicationMailer
     message = mail to: @user.email, subject: subject
 
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
+    message
+  end
+
+  # required params: sender, receiver
+  def retired(args = {})
+    @sender ||= args[:sender]
+    @receiver ||= args[:receiver]
+
+    return false unless @receiver.mail_notification? # cancel sending email
+
+    @link_url = notification_redirector_url(
+      link: "/users/#{@sender.id}",
+      kind: Notification.kinds[:retired]
+    )
+    subject = "[FBC] #{@sender.login_name}さんが退会しました。"
+    message = mail to: @receiver.email, subject: subject
+    message.perform_deliveries = @receiver.mail_notification? && !@receiver.retired?
 
     message
   end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -111,8 +111,6 @@ class ActivityMailer < ApplicationMailer
     @sender ||= args[:sender]
     @receiver ||= args[:receiver]
 
-    return false unless @receiver.mail_notification? # cancel sending email
-
     @user = @receiver
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -113,13 +113,14 @@ class ActivityMailer < ApplicationMailer
 
     return false unless @receiver.mail_notification? # cancel sending email
 
+    @user = @receiver
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:retired]
     )
     subject = "[FBC] #{@sender.login_name}さんが退会しました。"
-    message = mail to: @receiver.email, subject: subject
-    message.perform_deliveries = @receiver.mail_notification? && !@receiver.retired?
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
 
     message
   end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -67,16 +67,6 @@ class NotificationFacade
     ).watching_notification.deliver_later(wait: 5)
   end
 
-  def self.retired(sender, receiver)
-    ActivityNotifier.with(sender: sender, receiver: receiver).retired.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      sender: sender,
-      receiver: receiver
-    ).retired.deliver_later(wait: 5)
-  end
-
   def self.trainee_report(report, receiver)
     ActivityNotifier.with(report: report, receiver: receiver).trainee_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/views/activity_mailer/retired.html.slim
+++ b/app/views/activity_mailer/retired.html.slim
@@ -1,4 +1,7 @@
-= render 'notification_mailer_template', title: "#{@sender.login_name}さんが退会しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@sender.login_name}さんが退会しました。",
+  link_url: @link_url,
+  link_text: "#{@sender.login_name}さんのページへ" do
   .a-long-text
     h2
       = User.human_attribute_name('retire_reasons')

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -70,4 +70,27 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:comebacked)
     end
   end
+
+  test '.notify(:retired)' do
+    params = {
+      sender: users(:yameo),
+      receiver: users(:mentormentaro)
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:retired, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:retired, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:retired)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:retired)
+    end
+  end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -298,4 +298,51 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] machidaさんから質問「どのエディターを使うのが良いでしょうか」が投稿されました。', email.subject
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">質問へ</a>}, email.body.to_s)
   end
+
+  test 'retired' do
+    user = users(:yameo)
+    mentor = users(:mentormentaro)
+    ActivityMailer.retired(
+      sender: user,
+      receiver: mentor
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 9, link: "/users/#{user.id}" }.to_param)
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['mentormentaro@fjord.jp'], email.to
+    assert_equal '[FBC] yameoさんが退会しました。', email.subject
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">yameoさんのページへ</a>}, email.body.to_s)
+  end
+
+  test 'retired with params' do
+    user = users(:yameo)
+    mentor = users(:mentormentaro)
+    mailer = ActivityMailer.with(
+      sender: user,
+      receiver: mentor
+    ).retired
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 9, link: "/users/#{user.id}" }.to_param)
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['mentormentaro@fjord.jp'], email.to
+    assert_equal '[FBC] yameoさんが退会しました。', email.subject
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">yameoさんのページへ</a>}, email.body.to_s)
+  end
+
+  test 'retired with user who have been denied' do
+    ActivityMailer.retired(
+      sender: users(:yameo),
+      receiver: users(:hajime)
+    ).deliver_now
+
+    assert ActionMailer::Base.deliveries.empty?
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -142,26 +142,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/コメント/, email.body.to_s)
   end
 
-  test 'retired' do
-    user = users(:yameo)
-    admin = users(:komagata)
-    mailer = NotificationMailer.with(
-      sender: user,
-      receiver: admin
-    ).retired
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] yameoさんが退会しました。', email.subject
-    assert_match(/退会/, email.body.to_s)
-  end
-
   test 'trainee_report' do
     report = reports(:report11)
     trainee_report = notifications(:notification_trainee_report)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -40,4 +40,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(sender: question.user, receiver: receiver, question: question).came_question
   end
+
+  def retired
+    sender = User.find(ActiveRecord::FixtureSet.identify(:yameo))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))
+
+    ActivityMailer.with(sender: sender, receiver: receiver).retired
+  end
 end


### PR DESCRIPTION
## Issue

- #5882 

## 概要

active_deliveryを使用して、退会通知(サイト内・メール)を送るようにしました。

## 変更確認方法

1. `feature/use-active_delivery-for-retired-notifications`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. 現役受講生ユーザー(kimura, marumarushain1など)でログインする
4. `/retirement/new`にアクセスする
5. 何かしらの退会理由を入力して、「退会する」をクリック
6. メンターユーザー(komagataなど)でログインする
7. `/notifications`にアクセスする
8. 退会通知が来ていることを確認する
9. `/letter_opener`にアクセスする
10. 退会通知メールが届いていることを確認する

## Screenshot

### 変更後

**変更前後に違いはありません**

![image](https://user-images.githubusercontent.com/69447745/216211025-5d258e32-63ee-40ae-9db4-a78db1e256fe.png)
