### PR TITLE
お知らせを作成者が公開できるようにする

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -20,9 +20,7 @@ class AnnouncementsController < ApplicationController
     flash.now[:notice] = 'お知らせをコピーしました。'
   end
 
-  def edit
-    @announcement.user_id = current_user.id
-  end
+  def edit; end
 
   def update
     set_wip

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -46,10 +46,7 @@
       - if announcement.new_record?
         li.form-actions__item.is-main.is-help
           = f.submit '作成', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
-      - elsif (announcement.user == current_user || admin_or_mentor_login?) && announcement.published_at && !announcement.wip?
-        li.form-actions__item.is-main.is-help
-          = f.submit "更新", class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
-      - elsif (announcement.user == current_user || admin_or_mentor_login?) && (!announcement.published_at || announcement.wip?)
+      - elsif announcement.user == current_user || admin_or_mentor_login?
         li.form-actions__item.is-main.is-help
           = f.submit "公開", class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
       li.form-actions__item.is-sub

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -46,7 +46,7 @@
       - if announcement.new_record?
         li.form-actions__item.is-main.is-help
           = f.submit '作成', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
-      - elsif announcement.user == current_user || admin_or_mentor_login?
+      - elsif announcement.user == current_user || admin_or_mentor_login? || announcement.published_at
         li.form-actions__item.is-main.is-help
           = f.submit "公開", class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
       li.form-actions__item.is-sub

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -58,7 +58,4 @@
           = link_to 'キャンセル', announcements_path, class: 'a-button is-sm is-text'
         - when 'edit', 'update'
           = link_to 'キャンセル', announcement_path, class: 'a-button is-sm is-text'
-    - unless admin_or_mentor_login? || announcement.published_at
-      .form-actions__description.a-short-text
-        p
-          | お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。
+

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -43,12 +43,15 @@
     ul.form-actions__items
       li.form-actions__item.is-main
         = f.submit 'WIP', class: 'a-button is-lg is-secondary is-block', id: 'js-shortcut-wip'
-      - if admin_or_mentor_login? && announcement.new_record?
+      - if announcement.new_record?
         li.form-actions__item.is-main.is-help
           = f.submit '作成', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
-      - elsif admin_or_mentor_login? || announcement.published_at
+      - elsif (announcement.user == current_user || admin_or_mentor_login?) && announcement.published_at && !announcement.wip?
         li.form-actions__item.is-main.is-help
-          = f.submit '公開', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
+          = f.submit "更新", class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
+      - elsif (announcement.user == current_user || admin_or_mentor_login?) && (!announcement.published_at || announcement.wip?)
+        li.form-actions__item.is-main.is-help
+          = f.submit "公開", class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
       li.form-actions__item.is-sub
         - case params[:action]
         - when 'new', 'create'

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -48,11 +48,10 @@
           = f.submit '作成', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
       - elsif announcement.user == current_user || admin_or_mentor_login? || announcement.published_at
         li.form-actions__item.is-main.is-help
-          = f.submit "公開", class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
+          = f.submit '公開', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
       li.form-actions__item.is-sub
         - case params[:action]
         - when 'new', 'create'
           = link_to 'キャンセル', announcements_path, class: 'a-button is-sm is-text'
         - when 'edit', 'update'
           = link_to 'キャンセル', announcement_path, class: 'a-button is-sm is-text'
-

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -54,10 +54,10 @@ announcement_wip:
   target: 0
   wip: true
 
-announcement_wip_kimura:
+announcement_wip_not_mentor_or_admin:
   user: kimura
-  title: kimuraのwipお知らせ
-  description: kimuraのwipお知らせ本文
+  title: アドミン・メンター以外のユーザーのwipお知らせ
+  description: アドミン・メンター以外のユーザーのwipお知らせ本文
   created_at: "2018-01-05"
   target: 0
   wip: true

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -54,6 +54,14 @@ announcement_wip:
   target: 0
   wip: true
 
+announcement_wip_kimura:
+  user: kimura
+  title: kimuraのwipお知らせ
+  description: kimuraのwipお知らせ本文
+  created_at: "2018-01-05"
+  target: 0
+  wip: true
+
 announcement_published_later:
   user: komagata
   title: 後から公開されたお知らせ

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -148,7 +148,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
   end
 
   test 'announcement creator can publish wip announcement' do
-    announcement = announcements(:announcement_wip_kimura)
+    announcement = announcements(:announcement_wip_not_mentor_or_admin)
     visit_with_auth announcement_path(announcement), 'kimura'
     within '.announcement' do
       click_link '内容修正'
@@ -157,7 +157,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
   end
 
   test "general user can't publish other user's wip announcement" do
-    announcement = announcements(:announcement_wip_kimura)
+    announcement = announcements(:announcement_wip_not_mentor_or_admin)
     visit_with_auth announcement_path(announcement), 'hajime'
     within '.announcement' do
       click_link '内容修正'

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -175,7 +175,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert has_button? '公開'
   end
 
-  test 'adimin user can publish submitted announcement' do
+  test 'admin user can publish submitted announcement' do
     announcement = announcements(:announcement1)
     visit_with_auth announcement_path(announcement), 'komagata'
     within '.announcement' do

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -59,11 +59,6 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせをコピーしました。'
   end
 
-  test 'users except admin cannot publish an announcement' do
-    visit_with_auth new_announcement_path, 'kimura'
-    page.assert_no_selector('input[value="作成"]')
-  end
-
   test 'create a new announcement as wip' do
     visit_with_auth new_announcement_path, 'kimura'
     fill_in 'announcement[title]', with: '仮のお知らせ'
@@ -146,12 +141,28 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_no_text 'お知らせ「タイトルtest」'
   end
 
-  test "general user can't create announcement" do
+  test 'general user can create announcement' do
     visit_with_auth '/announcements', 'kimura'
     click_link 'お知らせ作成'
-    assert has_no_button? '作成'
+    assert has_button? '作成'
+  end
+
+  test 'announcement creator can publish wip announcement' do
+    announcement = announcements(:announcement_wip_kimura)
+    visit_with_auth announcement_path(announcement), 'kimura'
+    within '.announcement' do
+      click_link '内容修正'
+    end
+    assert has_button? '公開'
+  end
+
+  test "general user can't publish other user's wip announcement" do
+    announcement = announcements(:announcement_wip_kimura)
+    visit_with_auth announcement_path(announcement), 'hajime'
+    within '.announcement' do
+      click_link '内容修正'
+    end
     assert has_no_button? '公開'
-    assert_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
 
   test 'admin user can publish wip announcement' do
@@ -162,18 +173,6 @@ class AnnouncementsTest < ApplicationSystemTestCase
     end
     assert has_no_button? '作成'
     assert has_button? '公開'
-    assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
-  end
-
-  test "general user can't publish wip announcement" do
-    announcement = announcements(:announcement_wip)
-    visit_with_auth announcement_path(announcement), 'kimura'
-    within '.announcement' do
-      click_link '内容修正'
-    end
-    assert has_no_button? '作成'
-    assert has_no_button? '公開'
-    assert_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
 
   test 'adimin user can publish submitted announcement' do
@@ -184,7 +183,6 @@ class AnnouncementsTest < ApplicationSystemTestCase
     end
     assert has_no_button? '作成'
     assert has_button? '公開'
-    assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
 
   test 'general user can publish submitted announcement' do
@@ -195,7 +193,6 @@ class AnnouncementsTest < ApplicationSystemTestCase
     end
     assert has_no_button? '作成'
     assert has_button? '公開'
-    assert_no_text 'お知らせを作成しましたら、WIPで保存し、作成したお知らせのコメントから @mentor へ確認・公開の連絡をお願いします。'
   end
 
   test 'general user can copy submitted announcement' do


### PR DESCRIPTION
## Issue

- #6089

## 概要

元々お知らせを作成しましたら、WIPで保存し、メンターへ確認・公開の連絡をお願いする。

以下のユーザーにお知らせを公開できるようになりました。
- そのお知らせの作成者
- アドミン
- メンター

## 変更確認方法

1. `feature/give-announcement-creator-ability-to-publish`をローカルに取り込む
2. `rails server`に実行する
3. `hajime`でログイン
4. `http://127.0.0.1:3000/announcements/new`にアクセスし、お知らせを公開できることを確認する。

## Screenshot
`hajime`のお知らせ作成ページ

### 変更前
![before](https://user-images.githubusercontent.com/52590443/216281798-4d5ed02b-ade7-45ac-8a4d-fec232530658.png)

### 変更後
![after](https://user-images.githubusercontent.com/52590443/216281779-19b7274d-8035-4334-9c80-ba6bbf774d03.png)