### PR TITLE
検索ページ内のユーザーアイコンの HTML構造を変更

### DIFF
--- a/app/javascript/searchable.vue
+++ b/app/javascript/searchable.vue
@@ -3,11 +3,11 @@
   .card-list-item__inner
     .card-list-item__user(v-if='searchable.is_user')
       a.card-list-item__user-link(:href='searchable.url')
-        img.card-list-item__user-icon.a-user-icon(
-          :src='searchable.avatar_url',
-          :title='searchable.title',
-          :alt='searchable.title',
-          :class='[roleClass]')
+        span(:class='["a-user-role", roleClass]')
+          img.card-list-item__user-icon.a-user-icon(
+            :src='searchable.avatar_url',
+            :title='searchable.title',
+            :alt='searchable.title')
     .card-list-item__label(v-else)
       | {{ searchable.model_name_with_i18n }}
     .card-list-item__rows
@@ -36,11 +36,11 @@
               v-if='!["practice", "page", "user"].includes(searchable.model_name)')
               .card-list-item-meta__user
                 a.card-list-item-meta__icon-link(:href='userUrl')
-                  img.card-list-item-meta__icon.a-user-icon(
-                    :src='searchable.avatar_url',
-                    :title='searchable.icon_title',
-                    :alt='searchable.icon_title',
-                    :class='roleClass')
+                  span(:class='["a-user-role", roleClass]')
+                    img.card-list-item-meta__icon.a-user-icon(
+                      :src='searchable.avatar_url',
+                      :title='searchable.icon_title',
+                      :alt='searchable.icon_title')
                 a.a-user-name(:href='userUrl')
                   | {{ searchable.login_name }}
             .card-list-item-meta__item


### PR DESCRIPTION
## Issue

- #6153

## 概要
`localhost:3000/searchables`内のユーザアイコンのHTML構造を変更

ユーザアイコンのHTML構造が以下のようになっていましたが、

```html
<img title="ユーザー名" alt="ユーザー名" src="アイコン画像パス" class="a-user-icon is-graduate">
```

以下のように変更しました。

```html
<span  class="a-user-role is-graduate">
  <img title="ユーザー名" alt="ユーザー名" src="アイコン画像パス" class="a-user-icon">
</span>
```
## 変更確認方法
確認していただきたい点が以下の2つです。

- ユーザーを検索した際のユーザーアイコンのHTML構造
- 日報などを検索した際の作成者ユーザーアイコンのHTML構造

### ユーザーを検索した際のユーザーアイコンのHTML構造
1. `feature/change-markup-of-usericon-in-search-page`をローカルに取り込んでください。
2. 任意のユーザーでログインを行い、ヘッダーの検索窓から任意のユーザーを検索してください。
3. 検索でヒットしたユーザーのユーザーアイコンのHTML構造を開発者ツールで確認し、以下のようになっていることを確認してください。

```html
<span  class="a-user-role is-graduate">
  <img title="ユーザー名" alt="ユーザー名" src="アイコン画像パス" class="a-user-icon">
</span>
```

※ オプションでimgタグに上記以外のクラスが付与されている箇所がありますが元の仕様なので無視してもらって問題ありません。

<img width="1440" alt="スクリーンショット 2023-02-03 14 05 34" src="https://user-images.githubusercontent.com/81839214/216517168-0dff0adb-d901-4ec9-895b-89aca1317ee5.png">


### 日報などを検索した際の作成者ユーザーアイコンのHTML構造
1. `feature/change-markup-of-usericon-in-search-page`をローカルに取り込んでください。
2. 任意のユーザーでログインを行い、ヘッダーの検索窓から「日報」と検索してください。
3. 検索でヒットした日報の作成ユーザーのユーザーアイコンのHTML構造を開発者ツールで確認し、以下のようになっていることを確認してください。

```html
<span  class="a-user-role is-graduate">
  <img title="ユーザー名" alt="ユーザー名" src="アイコン画像パス" class="a-user-icon">
</span>
```

※ こちらもオプションでimgタグに上記以外のクラスが付与されている箇所がありますが元の仕様なので無視してもらって問題ありません。

<img width="1440" alt="スクリーンショット 2023-02-03 14 08 04" src="https://user-images.githubusercontent.com/81839214/216517422-a3b22c39-66cd-4310-bba4-d63f12581409.png">

## Screenshot

### 変更前
<img width="1440" alt="スクリーンショット 2023-02-03 14 11 34" src="https://user-images.githubusercontent.com/81839214/216517931-5b4dc78d-947c-4aa9-a27a-cd729c78a0aa.png">

### 変更後
<img width="1440" alt="スクリーンショット 2023-02-03 14 08 04" src="https://user-images.githubusercontent.com/81839214/216517422-a3b22c39-66cd-4310-bba4-d63f12581409.png">
