### PR TITLE
Seedデータの特定のユーザーについて、名前（カナ）の末尾を数字からカタカナに変更

### DIFF
--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -828,7 +828,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
   name: marumarushain<%= i %>
-  name_kana: マルマル シャイン<%= trailing_katakana %>
+  name_kana: マルマル シャイン<%= trailing_katakana.next! %>
   twitter_account:
   facebook_url:
   blog_url:
@@ -844,7 +844,6 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   updated_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
   created_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %> # 3ヶ月間隔で期が変更されるため、入会日を3ヶ月毎に設定
   last_activity_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
-  <% trailing_katakana.next! %>
 <% end %>
 
 otameshi:

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -820,6 +820,7 @@ sotugyou-adviser: # 区分が卒業生ではない卒業したユーザー
   created_at: "2014-01-01 00:00:03"
   last_activity_at: "2014-01-01 00:00:03"
 
+<% trailing_katakana = "ァ" %> 
 <% 1.upto(25) do |i| %> # 期生別ページのページネーションを表示させるため25人分登録
 marumarushain<%= i %>: # ページネーション確認のためのユーザー
   login_name: marumarushain<%= i %>
@@ -827,7 +828,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
   name: marumarushain<%= i %>
-  name_kana: マルマル シャイン<%= i %>
+  name_kana: マルマル シャイン<%= trailing_katakana %>
   twitter_account:
   facebook_url:
   blog_url:
@@ -843,6 +844,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   updated_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
   created_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %> # 3ヶ月間隔で期が変更されるため、入会日を3ヶ月毎に設定
   last_activity_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
+  <% trailing_katakana! %>
 <% end %>
 
 otameshi:

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -844,7 +844,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   updated_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
   created_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %> # 3ヶ月間隔で期が変更されるため、入会日を3ヶ月毎に設定
   last_activity_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
-  <% trailing_katakana! %>
+  <% trailing_katakana.next! %>
 <% end %>
 
 otameshi:

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -898,6 +898,7 @@ advisernocolleguetrainee:
   created_at: "2022-07-01 00:00:00"
   last_activity_at: "2022-07-01 00:00:00"
 
+<% trailing_katakana = "ァ" %>
 <% 1.upto(4) do |i| %>
 marumarushain<%= i %>: # ページネーション確認のためのユーザー
   login_name: marumarushain<%= i %>
@@ -905,7 +906,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
   name: marumarushain<%= i %>
-  name_kana: マルマル シャイン<%= i %>
+  name_kana: マルマル シャイン<%= trailing_katakana %>
   twitter_account:
   facebook_url:
   blog_url:
@@ -921,4 +922,5 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   updated_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
   created_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
   last_activity_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
+  <% trailing_katakana = trailing_katakana.next %>
 <% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -922,5 +922,5 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   updated_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
   created_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
   last_activity_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
-  <% trailing_katakana = trailing_katakana.next %>
+  <% trailing_katakana.next! %>
 <% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -906,7 +906,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
   salt: zW3kQ9ubsxQQtzzzs4ap
   name: marumarushain<%= i %>
-  name_kana: マルマル シャイン<%= trailing_katakana %>
+  name_kana: マルマル シャイン<%= trailing_katakana.next! %>
   twitter_account:
   facebook_url:
   blog_url:
@@ -922,5 +922,4 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   updated_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
   created_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
   last_activity_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
-  <% trailing_katakana.next! %>
 <% end %>


### PR DESCRIPTION
## Issue

- #6082

## 概要
Seedデータのユーザーである`marumarushain(末尾に数字)`について、以下のような形で修正しました。
* カナ（`name_kana`）の末尾に使われていた数字をカタカナ1文字に変更
カナ（`name_kana`）に数字が入っていたことによるバリデーションエラーを解消しました。
* 末尾のカタカナは重複しない形で付与。順不同
末尾につけるカタカナの仕様はふりかえり・計画ミーティングおよび質問タイムにて確認をとっています。

また、今回のissueではエラーが発生していませんが、`test/fixtures/users.yml`内の`marumarushain(末尾に数字)`でもカナに数字が含まれていたため、Seedデータと同じ形で修正を行っています（ふりかえり・計画ミーティングにて確認をとっています）。

## 変更確認方法
1. `bug/fix-kana-in-seed-data`をローカルに取り込む
2. `rails db:seed`を実行する
3. `bin/rails s`でローカル環境を立ち上げる
4. `marumarushain8`でログインする
5. 「マイプロフィール」をクリックする
<img width="1360" alt="スクリーンショット 2023-02-03 16 04 42" src="https://user-images.githubusercontent.com/77523896/216534269-0dbbb39a-bf7e-467a-94e1-c3eda6459491.png">

6.  プロフィールの名前（カナ）が「marumarushain8（マルマル シャインォ）」になっていることを確認する
7. `/current_user/edit`にアクセスし、「名前（カナ）」の欄が「マルマルシャインォ」となっていることを確認する
8. ページ下部の「更新する」をクリックする
9. `marumarushain8`のプロフィールページに遷移され、ページ上部に「ユーザー情報を更新しました。」が表示されていることを確認する

## Screenshot

### 変更前
プロフィール画面（名前（カナ）欄の末尾が数字になっている）
<img width="629" alt="スクリーンショット 2023-02-03 15 49 22" src="https://user-images.githubusercontent.com/77523896/216531963-18cb1b92-b88a-489b-8a20-052fe25bb144.png">

ユーザーの登録情報変更画面（名前（カナ）欄の末尾が数字になっている）
<img width="1368" alt="スクリーンショット 2023-02-03 15 50 14" src="https://user-images.githubusercontent.com/77523896/216531975-b5c7a2ea-cb55-4e07-848e-c3b6c0ba1a54.png">

「更新する」ボタンを押した後（バリデーションエラーが発生）
<img width="1368" alt="スクリーンショット 2023-02-03 15 51 02" src="https://user-images.githubusercontent.com/77523896/216531993-4e53dfec-64d0-41b3-93bb-046909d4a112.png">

### 変更後
プロフィール画面（名前（カナ）欄の末尾がカタカナになっている）
<img width="631" alt="スクリーンショット 2023-02-10 20 36 13" src="https://user-images.githubusercontent.com/77523896/218083220-14dcb764-5c3f-4407-9603-83d58cfe0d0d.png">

ユーザーの登録情報変更画面（名前（カナ）欄の末尾がカタカナになっている）
<img width="759" alt="スクリーンショット 2023-02-10 20 38 02" src="https://user-images.githubusercontent.com/77523896/218083526-778208cf-ba1f-4847-b2e6-ed391054857e.png">

「更新する」ボタンを押した後（「ユーザー情報を更新しました。」と表示される）
<img width="1359" alt="スクリーンショット 2023-02-10 20 39 00" src="https://user-images.githubusercontent.com/77523896/218083664-01152b23-eeab-400d-b8f5-06c379af2f56.png">

