### PR TITLE
開発環境・ステージング環境のユーザー期生別ページにページャーを表示

### DIFF
--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -820,7 +820,7 @@ sotugyou-adviser: # 区分が卒業生ではない卒業したユーザー
   created_at: "2014-01-01 00:00:03"
   last_activity_at: "2014-01-01 00:00:03"
 
-<% 1.upto(25) do |i| %> # 期生別のページネーションが表示される回数繰り返す
+<% 1.upto(25) do |i| %> # 期生別ページのページネーションを表示させるため25人分登録
 marumarushain<%= i %>: # ページネーション確認のためのユーザー
   login_name: marumarushain<%= i %>
   email: marumarushain<%= i %>@fjord.jp
@@ -841,7 +841,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   github_collaborator: true
   unsubscribe_email_token: MnC-Dv3HrNLs7WmfE975qA
   updated_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
-  created_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %> # 3ヶ月間隔で期が変更されるため3で設定
+  created_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %> # 3ヶ月間隔で期が変更されるため、入会日を3ヶ月毎に設定
   last_activity_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
 <% end %>
 

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -820,7 +820,7 @@ sotugyou-adviser: # 区分が卒業生ではない卒業したユーザー
   created_at: "2014-01-01 00:00:03"
   last_activity_at: "2014-01-01 00:00:03"
 
-<% 1.upto(22) do |i| %>
+<% 1.upto(25) do |i| %> # 期生別のページネーションが表示される回数繰り返す
 marumarushain<%= i %>: # ページネーション確認のためのユーザー
   login_name: marumarushain<%= i %>
   email: marumarushain<%= i %>@fjord.jp
@@ -840,9 +840,9 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   organization: 株式会社フィヨルド
   github_collaborator: true
   unsubscribe_email_token: MnC-Dv3HrNLs7WmfE975qA
-  updated_at: "2014-01-01 00:00:02"
-  created_at: "2014-01-01 00:00:02"
-  last_activity_at: "2014-01-01 00:00:02"
+  updated_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
+  created_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %> # 3ヶ月間隔で期が変更されるため3で設定
+  last_activity_at: <%= Date.new(2014, 1, 1).next_month(i * 3) %>
 <% end %>
 
 otameshi:


### PR DESCRIPTION
## Issue

- #6134

## 概要
Seedデータ内のユーザーの入会日をずらし、ユーザーが存在する期を増やすことで、開発環境・ステージング環境のユーザー期生別ページにページャーが表示されるようにしました。

## 変更確認方法
ステージング環境につきましては、PRがマージされた後でないと確認を行えないため、開発環境での変更確認方法のみ記載します。
1. `feature/display-pager-on-users-generation-page-in-staging`をローカルに取り込む
2. `rails db:seed`を実行する
3. `bin/rails s`でローカル環境を立ち上げる
4. 任意のアカウントで`/generations`にアクセスし、ページャーが表示されていることを確認する

## Screenshot

### 変更前
<img width="1361" alt="スクリーンショット 2023-01-31 22 06 04" src="https://user-images.githubusercontent.com/77523896/216610342-2d06407e-ed3d-4c96-a56c-ad725ce8316c.png">

### 変更後
<img width="1362" alt="スクリーンショット 2023-02-03 22 03 28" src="https://user-images.githubusercontent.com/77523896/216610369-857acf64-19d0-401b-9ee4-99e3962a9c87.png">



