### PR TITLE
ページ作成ビュー内のスラッグにプレースホルダーを追加

### DIFF
--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -36,7 +36,7 @@
       .row
         .col-md-6.col-xs-12
           = f.label :slug, class: 'a-form-label'
-          = f.text_field :slug, class: 'a-text-input js-warning-form'
+          = f.text_field :slug, class: 'a-text-input js-warning-form', placeholder: 'help'
           .a-form-help
             p アルファベットから始まる半角英数字と、ハイフン （ - ）、アンダーバー （ _ ） が使えます。
   .form-actions


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6091

## 概要

ページ作成画面(`/pages/new`)のスラッグにプレースホルダーを設定して help と表示させました

## 変更確認方法

1. feature/add-placeholder-to-slug-of-the-new-page をローカルに取り込む
2. `bin/rails s` で起動し、`/pages/new` へアクセス
3. 下の画像のように、ページ内のスラッグ入力欄に help と表示される

![placeholder実装後](https://user-images.githubusercontent.com/95903475/216751201-96bdfc6a-cb9d-401b-898e-24e85cdbc3be.png)

## Screenshot

### 変更前

![placeholder追加前](https://user-images.githubusercontent.com/95903475/216750991-a4f90e05-66a4-4a61-9e0e-095ba9924dda.png)

### 変更後

![placeholder追加後](https://user-images.githubusercontent.com/95903475/216751026-b5bb07ae-5366-4f8c-9abd-1d67ab8674fc.png)


