### PR TITLE
近日開催の定期イベントをダッシュボードに表示させた

### DIFF
--- a/app/assets/stylesheets/application/blocks/page/_page-notices.sass
+++ b/app/assets/stylesheets/application/blocks/page/_page-notices.sass
@@ -3,5 +3,7 @@
   background-color: $success
 
 .page-notices__item
+  .a-badge
+    min-width: 5rem
   &:not(:first-child)
     border-top: dashed 1px rgba(white, .2)

--- a/app/assets/stylesheets/atoms/_a-page-notice.sass
+++ b/app/assets/stylesheets/atoms/_a-page-notice.sass
@@ -22,6 +22,7 @@
   &.has-close
     position: relative
     display: flex
+    text-align: left
   p
     +text-block(1em 1.5, $reversal-text)
     +media-breakpoint-up(md)
@@ -35,16 +36,20 @@
       text-decoration: none
       +media-breakpoint-down(sm)
         display: block
-        position: relative
-        padding-left: 4rem
       .a-badge
         margin-right: .75rem
         background-color: rgba(black, .4)
         border: none
         +media-breakpoint-down(sm)
-          +position(absolute, left 0, top 0)
       .a-page-notice__label
         +hover-link-reversal
+        +media-breakpoint-up(md)
+          max-width: 17.5rem
+          overflow: hidden
+          text-overflow: ellipsis
+          display: inline-block
+          white-space: nowrap
+          vertical-align: bottom
 
 .a-page-notice__inner-start
   flex: 1
@@ -58,7 +63,6 @@
   font-size: 1.5rem
   opacity: .6
   transition: all .2s ease-out
-  margin-left: .5rem
   transform: translateX(1rem)
   +margin(vertical,  -.75rem)
   &:hover

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -64,8 +64,9 @@ class HomeController < ApplicationController
 
   def display_regular_events_on_dashboard
     cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
-    @regular_events_comming_soon = RegularEvent.today_events + RegularEvent.tomorrow_events
-    
+    regular_events_comming_soon = RegularEvent.today_events + RegularEvent.tomorrow_events
+    @regular_events_comming_soon = regular_events_comming_soon.select { |event| event.participated_by?(current_user) }
+
     if cookies_ids
       cookies_ids.each do |id|
         @regular_events_comming_soon.delete_if do |event|

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -67,11 +67,9 @@ class HomeController < ApplicationController
     regular_events_comming_soon = RegularEvent.today_events + RegularEvent.tomorrow_events
     @regular_events_comming_soon = regular_events_comming_soon.select { |event| event.participated_by?(current_user) }
 
-    if cookies_ids
-      cookies_ids.each do |id|
-        @regular_events_comming_soon.delete_if do |event|
-          event.id == id.to_i
-        end
+    cookies_ids&.each do |id|
+      @regular_events_comming_soon.delete_if do |event|
+        event.id == id.to_i
       end
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -65,10 +65,10 @@ class HomeController < ApplicationController
   def display_regular_events_on_dashboard
     cookies_ids = JSON.parse(cookies[:confirmed_regular_event_ids]) if cookies[:confirmed_regular_event_ids]
     regular_events_comming_soon = RegularEvent.today_events + RegularEvent.tomorrow_events
-    @regular_events_comming_soon = regular_events_comming_soon.select { |event| event.participated_by?(current_user) }
+    @regular_events_comming_soon_for_current_user = regular_events_comming_soon.select { |event| event.participated_by?(current_user) }
 
     cookies_ids&.each do |id|
-      @regular_events_comming_soon.delete_if do |event|
+      @regular_events_comming_soon_for_current_user.delete_if do |event|
         event.id == id.to_i
       end
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,7 @@ class HomeController < ApplicationController
     if current_user
       display_dashboard
       display_events_on_dashboard
+      display_regular_events_on_dashboard
       display_welcome_message_for_adviser
       set_required_fields
       render aciton: :index
@@ -59,6 +60,19 @@ class HomeController < ApplicationController
     cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
     @events_coming_soon = Event.where(start_at: today_to_tomorrow).or(Event.where(start_at: tomorrow_to_day_after_tomorrow)).where.not(id: cookies_ids)
     @events_coming_soon_except_job_hunting = @events_coming_soon.where.not(job_hunting: true)
+  end
+
+  def display_regular_events_on_dashboard
+    cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
+    @regular_events_comming_soon = RegularEvent.today_events + RegularEvent.tomorrow_events
+    
+    if cookies_ids
+      cookies_ids.each do |id|
+        @regular_events_comming_soon.delete_if do |event|
+          event.id == id.to_i
+        end
+      end
+    end
   end
 
   def display_welcome_message_for_adviser

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -63,7 +63,7 @@ class HomeController < ApplicationController
   end
 
   def display_regular_events_on_dashboard
-    cookies_ids = JSON.parse(cookies[:confirmed_event_ids]) if cookies[:confirmed_event_ids]
+    cookies_ids = JSON.parse(cookies[:confirmed_regular_event_ids]) if cookies[:confirmed_regular_event_ids]
     regular_events_comming_soon = RegularEvent.today_events + RegularEvent.tomorrow_events
     @regular_events_comming_soon = regular_events_comming_soon.select { |event| event.participated_by?(current_user) }
 

--- a/app/decorators/regular_event_decorator.rb
+++ b/app/decorators/regular_event_decorator.rb
@@ -12,7 +12,7 @@ module RegularEventDecorator
   def next_holding_date
     if finished
       '開催終了'
-    elsif event_day?
+    elsif holding_today?
       '本日開催'
     else
       "次回の開催日は #{l next_event_date} です"

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -11,7 +11,7 @@ module HomeHelper
 
   def event_date(event)
     if event.event_day?
-      Date.today
+      Date.current
     elsif event.tomorrow_event?
       Date.tomorrow
     end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -2,17 +2,17 @@
 
 module HomeHelper
   def today_or_tommorow(event)
-    if event.event_day?
+    if event.holding_today?
       '今日'
-    elsif event.tomorrow_event?
+    elsif event.holding_tomorrow?
       '明日'
     end
   end
 
   def event_date(event)
-    if event.event_day?
+    if event.holding_today?
       Date.current
-    elsif event.tomorrow_event?
+    elsif event.holding_tomorrow?
       Date.tomorrow
     end
   end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -2,10 +2,18 @@
 
 module HomeHelper
   def today_or_tommorow(event)
-    if event.start_at.to_date.today?
+    if event.event_day?
       '今日'
-    elsif event.start_at.to_date == Date.tomorrow
+    elsif event.tomorrow_event?
       '明日'
+    end
+  end
+
+  def event_date(event)
+    if event.event_day?
+      Date.today
+    elsif event.tomorrow_event?
+      Date.tomorrow
     end
   end
 

--- a/app/javascript/incoming-events.js
+++ b/app/javascript/incoming-events.js
@@ -8,19 +8,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const eventType = event.getAttribute('data-event-type')
     const button = event.querySelector('.js-close-event')
     const key = {
-                  Event: 'confirmed_event_ids=', 
-                  RegularEvent: 'confirmed_regular_event_ids='
-                }[eventType]
+      Event: 'confirmed_event_ids=',
+      RegularEvent: 'confirmed_regular_event_ids='
+    }[eventType]
 
     button.addEventListener('click', () => {
       document
-        .querySelector(`.page-notices__item[data-event-id="${eventId}"][data-event-type="${eventType}"]`)
+        .querySelector(
+          `.page-notices__item[data-event-id="${eventId}"][data-event-type="${eventType}"]`
+        )
         .remove()
 
       if (
-        document.cookie
-          .split('; ')
-          .find((row) => row.startsWith(key)) === undefined
+        document.cookie.split('; ').find((row) => row.startsWith(key)) ===
+        undefined
       ) {
         saveCookie(key, [eventId])
       } else {
@@ -43,10 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function saveCookie(key, eventIds) {
     const secondsFor30days = 2592000
     document.cookie =
-      key +
-      JSON.stringify(eventIds) +
-      ';max-age=' +
-      secondsFor30days
+      key + JSON.stringify(eventIds) + ';max-age=' + secondsFor30days
   }
 
   function updateEventIds(key, latestCookie, eventId) {

--- a/app/javascript/incoming-events.js
+++ b/app/javascript/incoming-events.js
@@ -5,24 +5,30 @@ document.addEventListener('DOMContentLoaded', () => {
 
   events.forEach((event) => {
     const eventId = event.getAttribute('data-event-id')
+    const eventType = event.getAttribute('data-event-type')
     const button = event.querySelector('.js-close-event')
+    const key = {
+                  Event: 'confirmed_event_ids=', 
+                  RegularEvent: 'confirmed_regular_event_ids='
+                }[eventType]
 
     button.addEventListener('click', () => {
       document
-        .querySelector(`.page-notices__item[data-event-id="${eventId}"]`)
+        .querySelector(`.page-notices__item[data-event-id="${eventId}"][data-event-type="${eventType}"]`)
         .remove()
 
       if (
         document.cookie
           .split('; ')
-          .find((row) => row.startsWith('confirmed_event_ids')) === undefined
+          .find((row) => row.startsWith(key)) === undefined
       ) {
-        saveCookie([eventId])
+        saveCookie(key, [eventId])
       } else {
         const latestCookie = document.cookie
           .split('; ')
-          .find((row) => row.startsWith('confirmed_event_ids'))
-        saveCookie(updateEventIds(latestCookie, eventId))
+          .find((row) => row.startsWith(key))
+        const eventIds = updateEventIds(key, latestCookie, eventId)
+        saveCookie(key, eventIds)
       }
 
       const eventCount = document.querySelectorAll(
@@ -34,17 +40,17 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   })
 
-  function saveCookie(eventIds) {
+  function saveCookie(key, eventIds) {
     const secondsFor30days = 2592000
     document.cookie =
-      'confirmed_event_ids=' +
+      key +
       JSON.stringify(eventIds) +
       ';max-age=' +
       secondsFor30days
   }
 
-  function updateEventIds(latestCookie, eventId) {
-    const unnecessaryCharacters = 20
+  function updateEventIds(key, latestCookie, eventId) {
+    const unnecessaryCharacters = key.length
     const latestEventIds = latestCookie.substr(unnecessaryCharacters)
     const updatedEventIds = JSON.parse(latestEventIds)
     updatedEventIds.push(eventId)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -107,11 +107,11 @@ class Event < ApplicationRecord
     NotificationFacade.moved_up_event_waiting_user(self, receiver)
   end
 
-  def event_day?
+  def holding_today?
     start_at.to_date.today?
   end
 
-  def tomorrow_event?
+  def holding_tomorrow?
     start_at.to_date == Date.tomorrow
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -107,6 +107,14 @@ class Event < ApplicationRecord
     NotificationFacade.moved_up_event_waiting_user(self, receiver)
   end
 
+  def event_day?
+    start_at.to_date.today?
+  end
+
+  def tomorrow_event?
+    start_at.to_date == Date.tomorrow
+  end
+
   private
 
   def end_at_be_greater_than_start_at

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -136,6 +136,10 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     watches.exists?(user_id: user.id)
   end
 
+  def participated_by?(user)
+    regular_event_participations.find_by(user_id: user.id).present?
+  end
+
   class << self
     def today_events
       holding_events = RegularEvent.holding

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -137,6 +137,11 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   class << self
+    def today_events
+      holding_events = RegularEvent.holding
+      holding_events.select(&:event_day?)
+    end
+
     def tomorrow_events
       holding_events = RegularEvent.holding
       holding_events.select(&:tomorrow_event?)

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -68,7 +68,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     users.with_attached_avatar.order('organizers.created_at')
   end
 
-  def event_day?
+  def holding_today?
     now = Time.current
     event_day = regular_event_repeat_rules.map do |repeat_rule|
       if repeat_rule.frequency.zero?
@@ -116,7 +116,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     0.days.ago.next_occurring(day_of_the_week_symbol).to_date
   end
 
-  def tomorrow_event?
+  def holding_tomorrow?
     tomorrow = Time.current.next_day
     regular_event_repeat_rules.map do |repeat_rule|
       if repeat_rule.frequency.zero?
@@ -143,12 +143,12 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   class << self
     def today_events
       holding_events = RegularEvent.holding
-      holding_events.select(&:event_day?)
+      holding_events.select(&:holding_today?)
     end
 
     def tomorrow_events
       holding_events = RegularEvent.holding
-      holding_events.select(&:tomorrow_event?)
+      holding_events.select(&:holding_tomorrow?)
     end
   end
 

--- a/app/views/home/_event.html.slim
+++ b/app/views/home/_event.html.slim
@@ -1,4 +1,4 @@
-.page-notices__item(data-event-id="#{event.id}")
+.page-notices__item(data-event-id="#{event.id}" data-event-type="#{event.class}")
   .a-page-notice.page-notice
     .container.is-lg
       .a-page-notice__inner.has-close

--- a/app/views/home/_event.html.slim
+++ b/app/views/home/_event.html.slim
@@ -1,11 +1,11 @@
 .page-notices__item(data-event-id="#{event.id}" data-event-type="#{event.class}")
   .a-page-notice.page-notice
-    .container.is-lg
+    .container.is-md
       .a-page-notice__inner.has-close
         .a-page-notice__inner-start
           p
             = link_to event, itemprop: 'url', class: 'has-badge' do
-              span.a-badge.is-primary.is-sm
+              span.a-badge.is-primary.is-xs
                 | イベント
               = today_or_tommorow(event)
               = l event.start_at.to_date, format: :md

--- a/app/views/home/_event.html.slim
+++ b/app/views/home/_event.html.slim
@@ -8,7 +8,7 @@
               span.a-badge.is-primary.is-sm
                 | イベント
               = today_or_tommorow(event)
-                = l event.start_at.to_date, format: :md
+              = l event.start_at.to_date, format: :md
               | は 「
               span.a-page-notice__label
                 = event.title

--- a/app/views/home/_regular_event.html.slim
+++ b/app/views/home/_regular_event.html.slim
@@ -1,4 +1,4 @@
-.page-notices__item(data-event-id="#{regular_event.id}")
+.page-notices__item(data-event-id="#{regular_event.id}" data-event-type="#{regular_event.class}")
   .a-page-notice.page-notice
     .container.is-lg
       .a-page-notice__inner.has-close

--- a/app/views/home/_regular_event.html.slim
+++ b/app/views/home/_regular_event.html.slim
@@ -1,0 +1,18 @@
+.page-notices__item(data-event-id="#{regular_event.id}")
+  .a-page-notice.page-notice
+    .container.is-lg
+      .a-page-notice__inner.has-close
+        .a-page-notice__inner-start
+          p
+            = link_to regular_event, itemprop: 'url', class: 'has-badge' do
+              span.a-badge.is-primary.is-sm
+                | 定期イベント
+              = today_or_tommorow(regular_event)
+              = l event_date(regular_event), format: :md
+              | は 「
+              span.a-page-notice__label
+                = regular_event.title
+              | 」 が開催されます
+        .a-page-notice__inner-end
+          .a-page-notice__close.js-close-event
+            i.fal.fa-times

--- a/app/views/home/_regular_event.html.slim
+++ b/app/views/home/_regular_event.html.slim
@@ -1,11 +1,11 @@
 .page-notices__item(data-event-id="#{regular_event.id}" data-event-type="#{regular_event.class}")
   .a-page-notice.page-notice
-    .container.is-lg
+    .container.is-md
       .a-page-notice__inner.has-close
         .a-page-notice__inner-start
           p
             = link_to regular_event, itemprop: 'url', class: 'has-badge' do
-              span.a-badge.is-primary.is-sm
+              span.a-badge.is-primary.is-xs
                 | 定期イベント
               = today_or_tommorow(regular_event)
               = l event_date(regular_event), format: :md

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -11,10 +11,10 @@
     #events_on_dashboard.confirmed_event
       .page-notices
         = render partial: 'event', collection: @events_coming_soon_except_job_hunting, as: :event
-  - if @regular_events_comming_soon.present?
+  - if @regular_events_comming_soon_for_current_user.present?
     #events_on_dashboard.confirmed_event
       .page-notices
-        = render partial: 'regular_event', collection: @regular_events_comming_soon, as: :regular_event
+        = render partial: 'regular_event', collection: @regular_events_comming_soon_for_current_user, as: :regular_event
 
   - if current_user.adviser?
     = render 'adviser_dashboard'

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -11,6 +11,10 @@
     #events_on_dashboard.confirmed_event
       .page-notices
         = render partial: 'event', collection: @events_coming_soon_except_job_hunting, as: :event
+  - if @regular_events_comming_soon.present?
+    #events_on_dashboard.confirmed_event
+      .page-notices
+        = render partial: 'regular_event', collection: @regular_events_comming_soon, as: :regular_event
 
   - if current_user.adviser?
     = render 'adviser_dashboard'

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -3,18 +3,15 @@
 = render 'page_tabs', user: current_user
 
 .page-body.is-dash-board
-  - if @events_coming_soon.present? && current_user.job_seeker
+  - if @events_coming_soon.present? || @regular_events_comming_soon_for_current_user.present?
     #events_on_dashboard.confirmed_event
       .page-notices
-        = render partial: 'event', collection: @events_coming_soon, as: :event
-  - if @events_coming_soon_except_job_hunting.present? && !current_user.job_seeker
-    #events_on_dashboard.confirmed_event
-      .page-notices
-        = render partial: 'event', collection: @events_coming_soon_except_job_hunting, as: :event
-  - if @regular_events_comming_soon_for_current_user.present?
-    #events_on_dashboard.confirmed_event
-      .page-notices
-        = render partial: 'regular_event', collection: @regular_events_comming_soon_for_current_user, as: :regular_event
+        - if @events_coming_soon.present? && current_user.job_seeker
+          = render partial: 'event', collection: @events_coming_soon, as: :event
+        - if @events_coming_soon_except_job_hunting.present? && !current_user.job_seeker
+          = render partial: 'event', collection: @events_coming_soon_except_job_hunting, as: :event
+        - if @regular_events_comming_soon_for_current_user.present?
+          = render partial: 'regular_event', collection: @regular_events_comming_soon_for_current_user, as: :regular_event
 
   - if current_user.adviser?
     = render 'adviser_dashboard'

--- a/db/fixtures/regular_event_participations.yml
+++ b/db/fixtures/regular_event_participations.yml
@@ -1,3 +1,11 @@
 regular_event_participation1:
   user: hatsuno
   regular_event: regular_event1
+
+regular_event_participation2:
+  user: kimura
+  regular_event: regular_event8
+
+regular_event_participation3:
+  user: kimura
+  regular_event: regular_event9

--- a/db/fixtures/regular_event_repeat_rules.yml
+++ b/db/fixtures/regular_event_repeat_rules.yml
@@ -35,7 +35,7 @@ regular_event_repeat_rule7:
 
 regular_event_repeat_rule8:
   frequency: 0
-  day_of_the_week: <%= Date.today.wday %>
+  day_of_the_week: <%= Date.current.wday %>
   regular_event: regular_event8
 
 regular_event_repeat_rule9:

--- a/db/fixtures/regular_event_repeat_rules.yml
+++ b/db/fixtures/regular_event_repeat_rules.yml
@@ -33,7 +33,17 @@ regular_event_repeat_rule7:
   day_of_the_week: 3
   regular_event: regular_event7
 
-<% (8..26).each do |i| %>
+regular_event_repeat_rule8:
+  frequency: 0
+  day_of_the_week: <%= Date.today.wday %>
+  regular_event: regular_event8
+
+regular_event_repeat_rule9:
+  frequency: 0
+  day_of_the_week: <%= Date.tomorrow.wday %>
+  regular_event: regular_event9
+
+<% (10..26).each do |i| %>
 regular_event_repeat_rule<%= i %>:
   frequency: 0
   day_of_the_week: 0

--- a/db/fixtures/regular_events.yml
+++ b/db/fixtures/regular_events.yml
@@ -64,7 +64,25 @@ regular_event7:
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
 
-<% (8..26).each do |i| %>
+regular_event8:
+  title: ダッシュボード表示確認用テスト定期イベント(当日用)
+  description: ダッシュボード表示確認用テスト定期イベント(当日用)
+  finished: false
+  hold_national_holiday: true
+  start_at: <%= Time.zone.local(2020, 1, 1, 21, 58, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 23, 59, 0) %>
+  user: komagata
+
+regular_event9:
+  title: ダッシュボード表示確認用テスト定期イベント(翌日用)
+  description: ダッシュボード表示確認用テスト定期イベント(翌日用)
+  finished: false
+  hold_national_holiday: true
+  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
+  user: komagata
+
+<% (10..26).each do |i| %>
 regular_event<%= i %>:
   title: 定期イベント<%= i %>
   description: <%= i %>番目の定期イベントです。

--- a/db/fixtures/regular_events.yml
+++ b/db/fixtures/regular_events.yml
@@ -69,7 +69,7 @@ regular_event8:
   description: ダッシュボード表示確認用テスト定期イベント(当日用)
   finished: false
   hold_national_holiday: true
-  start_at: <%= Time.zone.local(2020, 1, 1, 21, 58, 0) %>
+  start_at: <%= Time.zone.local(2020, 1, 1, 23, 58, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 23, 59, 0) %>
   user: komagata
 

--- a/test/decorators/regular_event_decorator_test.rb
+++ b/test/decorators/regular_event_decorator_test.rb
@@ -8,7 +8,7 @@ class RegularEventDecoratorTest < ActiveSupport::TestCase
   def setup
     ActiveDecorator::ViewContext.push(controller.view_context)
     @regular_event = ActiveDecorator::Decorator.instance.decorate(regular_events(:regular_event1))
-    @finished_regular_event = ActiveDecorator::Decorator.instance.decorate(regular_events(:regular_event8))
+    @finished_regular_event = ActiveDecorator::Decorator.instance.decorate(regular_events(:regular_event10))
   end
 
   test '#holding_cycles' do

--- a/test/fixtures/regular_event_participations.yml
+++ b/test/fixtures/regular_event_participations.yml
@@ -1,3 +1,11 @@
 regular_event_participation1:
   user: hatsuno
   regular_event: regular_event1
+
+regular_event_participation2:
+  user: kimura
+  regular_event: regular_event8
+
+regular_event_participation3:
+  user: kimura
+  regular_event: regular_event9

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -33,7 +33,17 @@ regular_event_repeat_rule7:
   day_of_the_week: 3
   regular_event: regular_event7
 
-<% (8..26).each do |i| %>
+regular_event_repeat_rule8:
+  frequency: 0
+  day_of_the_week: 1
+  regular_event: regular_event8
+
+regular_event_repeat_rule9:
+  frequency: 0
+  day_of_the_week: 2
+  regular_event: regular_event9
+
+<% (10..26).each do |i| %>
 regular_event_repeat_rule<%= i %>:
   frequency: 0
   day_of_the_week: 0

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -64,7 +64,25 @@ regular_event7:
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
 
-<% (8..26).each do |i| %>
+regular_event8:
+  title: ダッシュボード表示確認用テスト定期イベント(当日用)
+  description: ダッシュボード表示確認用テスト定期イベント(当日用)
+  finished: false
+  hold_national_holiday: true
+  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
+  user: komagata
+
+regular_event9:
+  title: ダッシュボード表示確認用テスト定期イベント(翌日用)
+  description: ダッシュボード表示確認用テスト定期イベント(翌日用)
+  finished: false
+  hold_national_holiday: true
+  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
+  user: komagata
+
+<% (10..26).each do |i| %>
 regular_event<%= i %>:
   title: 定期イベント<%= i %>
   description: <%= i %>番目の定期イベントです。

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -85,25 +85,25 @@ class EventTest < ActiveSupport::TestCase
     assert Notification.where(user: user, sender: event.user, link: "/events/#{event.id}").exists?
   end
 
-  test '#event_day?' do
+  test '#holding_today?' do
     event = events(:event1)
     travel_to Time.zone.local(2019, 12, 20, 0, 0, 0) do
-      assert event.event_day?
+      assert event.holding_today?
     end
 
     travel_to Time.zone.local(2019, 12, 21, 0, 0, 0) do
-      assert_not event.event_day?
+      assert_not event.holding_today?
     end
   end
 
-  test '#tomorrow_event?' do
+  test '#holding_tomorrow?' do
     event = events(:event1)
     travel_to Time.zone.local(2019, 12, 19, 0, 0, 0) do
-      assert event.tomorrow_event?
+      assert event.holding_tomorrow?
     end
 
     travel_to Time.zone.local(2019, 12, 20, 0, 0, 0) do
-      assert_not event.tomorrow_event?
+      assert_not event.holding_tomorrow?
     end
   end
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -85,6 +85,28 @@ class EventTest < ActiveSupport::TestCase
     assert Notification.where(user: user, sender: event.user, link: "/events/#{event.id}").exists?
   end
 
+  test '#event_day?' do
+    event = events(:event1)
+    travel_to Time.zone.local(2019, 12, 20, 0, 0, 0) do
+      assert event.event_day?
+    end
+
+    travel_to Time.zone.local(2019, 12, 21, 0, 0, 0) do
+      assert_not event.event_day?
+    end
+  end
+
+  test '#tomorrow_event?' do
+    event = events(:event1)
+    travel_to Time.zone.local(2019, 12, 19, 0, 0, 0) do
+      assert event.tomorrow_event?
+    end
+
+    travel_to Time.zone.local(2019, 12, 20, 0, 0, 0) do
+      assert_not event.tomorrow_event?
+    end
+  end
+
   test 'should be invalid when start_at >= end_at' do
     event = events(:event1)
     event.end_at = event.start_at - 1.hour

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -15,14 +15,14 @@ class RegularEventTest < ActiveSupport::TestCase
     assert regular_event.invalid?
   end
 
-  test '#event_day?' do
+  test '#holding_today?' do
     regular_event = regular_events(:regular_event1)
     travel_to Time.zone.local(2022, 6, 5, 0, 0, 0) do
-      assert_equal true, regular_event.event_day?
+      assert regular_event.holding_today?
     end
 
     travel_to Time.zone.local(2022, 6, 1, 0, 0, 0) do
-      assert_equal false, regular_event.event_day?
+      assert_not regular_event.holding_today?
     end
   end
 

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -75,4 +75,13 @@ class RegularEventTest < ActiveSupport::TestCase
     watch.save
     assert regular_event.watched_by?(user)
   end
+
+  test 'participated_by?' do
+    regular_event = regular_events(:regular_event1)
+    user = users(:hatsuno)
+    assert regular_event.participated_by?(user)
+
+    user = users(:komagata)
+    assert_not regular_event.participated_by?(user)
+  end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -58,6 +58,17 @@ class RegularEventTest < ActiveSupport::TestCase
     end
   end
 
+  test '#holding_tomorrow?' do
+    regular_event = regular_events(:regular_event1)
+    travel_to Time.zone.local(2023, 2, 25, 0, 0, 0) do
+      assert regular_event.holding_tomorrow?
+    end
+
+    travel_to Time.zone.local(2023, 2, 26, 0, 0, 0) do
+      assert_not regular_event.holding_tomorrow?
+    end
+  end
+
   test '#cancel_participation' do
     regular_event = regular_events(:regular_event1)
     participant = regular_event_participations(:regular_event_participation1).user

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -223,6 +223,21 @@ class HomeTest < ApplicationSystemTestCase
     end
   end
 
+  test 'show regular events on dashbord for only event participant' do
+    travel_to Time.zone.local(2023, 1, 30, 10, 0, 0) do
+      visit_with_auth '/', 'kimura'
+      assert_text 'ダッシュボード表示確認用テスト定期イベント(当日用)'
+      assert_text 'ダッシュボード表示確認用テスト定期イベント(翌日用)'
+      first('.js-close-event').click
+      assert_no_text 'ダッシュボード表示確認用テスト定期イベント(当日用)'
+      logout
+
+      visit_with_auth '/', 'komagata'
+      assert_no_text 'ダッシュボード表示確認用テスト定期イベント(当日用)'
+      assert_no_text 'ダッシュボード表示確認用テスト定期イベント(翌日用)'
+    end
+  end
+
   test 'show grass hide button for graduates' do
     visit_with_auth '/', 'kimura'
     assert_not has_button? '非表示'

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -164,7 +164,7 @@ class RegularEventsTest < ApplicationSystemTestCase
 
   test 'show listing not finished regular events' do
     visit_with_auth regular_events_path(target: 'not_finished'), 'kimura'
-    assert_selector '.card-list-item', count: 7
+    assert_selector '.card-list-item', count: 9
   end
 
   test 'show listing all regular events' do


### PR DESCRIPTION
## Issue

- #6002 

## 概要

自分が参加している定期イベントが今日or明日開催の場合にお知らせがダッシュボードに表示させるようにしました。

要素の削除、cookieへのid保存等のイベントは、すでに実装されていた`app/javascript/incoming-events.js`で行っています。
cookieにidを保存する際、イベント、定期イベントでそれぞれキーを別にするために`app/views/home/_event.html.slim`、`app/views/home/_regular_event.html.slim`で`data-event-id`と一緒に`data-event-type`も渡すようにしております。

## 類似するPR

[イベントの日にダッシュボードに出したい(再作成) #3163](https://github.com/fjordllc/bootcamp/pull/3163)

## 変更確認方法

1. `feature/show-the-regular-event-on-the-dashboard`をローカルに取り込む
2. `rails db:seed`を実行する
3. `rails s`でサーバーを起動する
4. `kimura`でログインする
5. ダッシュボードに「ダッシュボード表示確認用テスト定期イベント(当日用)」と「ダッシュボード表示確認用テスト定期イベント(翌日用)」のお知らせがあることを確認する
6. リンクをクリックして定期イベントページに遷移することを確認する
7. ダッシュボードに戻り、右にある「×」ボタンをクリックしお知らせが削除されることを確認する
8. ページを更新して、先ほど削除したお知らせが表示されないことを確認する
9. ログアウトして`komagata`でログインする
10. ダッシュボードに「ダッシュボード表示確認用テスト定期イベント(当日用)」と「ダッシュボード表示確認用テスト定期イベント(翌日用)」のお知らせがないことを確認する

## Screenshot

### 変更前

<img width="1377" alt="スクリーンショット 2023-02-04 13 20 27" src="https://user-images.githubusercontent.com/88083085/216748340-4825f186-5d34-41f5-bd1b-47380d802cf1.png">

### 変更後

<img width="1378" alt="スクリーンショット 2023-02-17 20 10 45" src="https://user-images.githubusercontent.com/88083085/219634162-c42c6127-bdb3-4332-95fa-dca8f53fbb67.png">


