### PR TITLE
管理画面のお試し延長一覧のステータスに「開催前」「開催中」を追加

### DIFF
--- a/app/views/admin/campaigns/index.html.slim
+++ b/app/views/admin/campaigns/index.html.slim
@@ -42,6 +42,10 @@ header.page-header
             - @campaigns.each do |campaign|
               tr.admin-table__item(id="campaign_#{campaign.id}")
                 td.admin-table__item-value
+                  - if (nil...campaign.start_at).cover? Time.current
+                    | 開催前
+                  - if (campaign.start_at..campaign.end_at).cover? Time.current
+                    | 開催中
                   - if (campaign.end_at..nil).cover? Time.current
                     | 終了
                 td.admin-table__item-value


### PR DESCRIPTION
## Issue

- #5916

## 概要
管理画面のお試し延長一覧に、
開催前の場合は「開催前」、開催中の場合は「開催中」のステータスの表示を追加しました。

## 変更確認方法

1. `feature/add-before-starting-to-admin-campaign`をローカルに取り込む
2. `bin/rails s `でサーバーを起動
3. `machida` でログイン
4. `/admin/campaigns ` にアクセス
5. campaignsのデータがない場合は`admin/campaigns/new`画面で作成する
    1.  「開催前」：開始日時が、現在日時以降になるように作成する
    2. 「開催中」：現在日時が、開始日時〜終了日時の範囲内になるように作成する
    3. 「終了」：終了日時が、現在日時以降になるように作成する
6. ステータスが条件通りに表示されていることを確認

## Screenshot
※画像は、現在日時が2023/02/04 15:00の場合です

### 変更前
<img width="1229" alt="スクリーンショット 2023-02-04 15 07 05" src="https://user-images.githubusercontent.com/75718420/216752013-f3b094b8-c426-43f1-bec2-31a108069a26.png">

### 変更後
<img width="1231" alt="スクリーンショット 2023-02-04 15 06 38" src="https://user-images.githubusercontent.com/75718420/216752009-b672e37e-fda0-4900-9c9e-b9ecc7db026f.png">

