### PR TITLE
管理者権限でユーザー情報変更ページから一般受講生を「研修生」に変更できるようにする

### DIFF
--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -106,7 +106,7 @@
               = link_to 'https://github.com/orgs/fjordllc/people', target: '_blank', rel: 'noopener' do
                 | GitHub設定
 
-  - if admin_login? || user.trainee?
+  - if (admin_login? && user.current_student?) || user.trainee?
     .form__items.js-training-info-block
       h3.form__items-title 研修情報
       = render 'users/form/training_end', f: f

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -49,12 +49,6 @@
   - if from == :new && user.student?
     = render 'users/form/card'
 
-  - if (admin_login? && user.trainee?) || user.trainee?
-    .form__items.js-training-info-block
-      h3.form__items-title 研修情報
-      = render 'users/form/training_end', f: f
-      = render 'users/form/company', f: f, user: user
-
   - if user.mentor?
     .form__items
       h3.form__items-title メンター紹介用公開プロフィール
@@ -111,6 +105,12 @@
             li
               = link_to 'https://github.com/orgs/fjordllc/people', target: '_blank', rel: 'noopener' do
                 | GitHub設定
+
+  - if admin_login? || user.trainee?
+    .form__items.js-training-info-block
+      h3.form__items-title 研修情報
+      = render 'users/form/training_end', f: f
+      = render 'users/form/company', f: f, user: user
 
   - if from == :new
     .form__items


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/5731

## 概要
管理者権限で受講生を研修生に変更した際に研修情報が表示されるように修正しました。
また、Issueのコメントにある通り、研修情報ブロックの位置を一番下に持ってきました。
## 変更確認方法

1. `feature/enable-to-change-from-student-to-trainee`をローカルに取り込む
2.  `komagata`でログインする
3. `http://localhost:3000/admin/users/199512416/edit`にアクセス
4. 特殊ユーザー属性を研修生に変更し、その下に研修情報ブロックが表示されることを確認する

## Screenshot

### 変更前
研修生にチェック入れてもブロックが表示されない
<img width="273" alt="image" src="https://user-images.githubusercontent.com/43959158/216761322-e4e09bd8-1837-4b07-877a-f022b0766930.png">

### 変更後
<img width="575" alt="image" src="https://user-images.githubusercontent.com/43959158/216761212-a13792fa-91d2-4864-b602-60bd218b9b70.png">

