### PR TITLE
Question作成時のmentorへのWatch作成処理をnewspaperに置き換え

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -31,6 +31,7 @@ class API::QuestionsController < API::BaseController
   def update
     question = Question.find(params[:id])
     if question.update(question_params)
+      Newspaper.publish(:question_create, question) unless question.watched?
       head :ok
     else
       head :bad_request

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -31,7 +31,7 @@ class API::QuestionsController < API::BaseController
   def update
     question = Question.find(params[:id])
     if question.update(question_params)
-      Newspaper.publish(:question_create, question) unless question.watched?
+      Newspaper.publish(:question_create, question)
       head :ok
     else
       head :bad_request

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -31,7 +31,7 @@ class API::QuestionsController < API::BaseController
   def update
     question = Question.find(params[:id])
     if question.update(question_params)
-      Newspaper.publish(:question_create, question)
+      Newspaper.publish(:question_update, question)
       head :ok
     else
       head :bad_request

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,7 @@ class QuestionsController < ApplicationController
   include Rails.application.routes.url_helpers
   before_action :set_question, only: %i[show destroy]
   before_action :set_categories, only: %i[new show create]
-  before_action :set_watch, only: %i[show]
+  before_action :set_watch, only: %i[show create]
 
   QuestionsProperty = Struct.new(:title, :empty_message)
 
@@ -55,6 +55,7 @@ class QuestionsController < ApplicationController
     @question.user = current_user
     @question.wip = params[:commit] == 'WIP'
     if @question.save
+      Newspaper.publish(:question_create, @question) unless @question.wip
       redirect_to @question, notice: notice_message(@question)
     else
       render :new

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,7 @@ class QuestionsController < ApplicationController
   include Rails.application.routes.url_helpers
   before_action :set_question, only: %i[show destroy]
   before_action :set_categories, only: %i[new show create]
-  before_action :set_watch, only: %i[show create]
+  before_action :set_watch, only: %i[show]
 
   QuestionsProperty = Struct.new(:title, :empty_message)
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -55,7 +55,7 @@ class QuestionsController < ApplicationController
     @question.user = current_user
     @question.wip = params[:commit] == 'WIP'
     if @question.save
-      Newspaper.publish(:question_create, @question) unless @question.wip
+      Newspaper.publish(:question_create, @question)
       redirect_to @question, notice: notice_message(@question)
     else
       render :new

--- a/app/models/creating_mentors_watch_for_question.rb
+++ b/app/models/creating_mentors_watch_for_question.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreatingMentorsWatchForQuestion
+  def call(question)
+    watch_question_records = watch_records(question)
+    Watch.insert_all(watch_question_records) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def watch_records(question)
+    User.mentor.map do |mentor|
+      {
+        watchable_type: 'Question',
+        watchable_id: question.id,
+        created_at: Time.current,
+        updated_at: Time.current,
+        user_id: mentor.id
+      }
+    end
+  end
+end

--- a/app/models/creating_mentors_watch_for_question.rb
+++ b/app/models/creating_mentors_watch_for_question.rb
@@ -2,6 +2,7 @@
 
 class CreatingMentorsWatchForQuestion
   def call(question)
+    return if question.wip? || question.watched?
     watch_question_records = watch_records(question)
     Watch.insert_all(watch_question_records) # rubocop:disable Rails/SkipsModelValidations
   end

--- a/app/models/creating_mentors_watch_for_question.rb
+++ b/app/models/creating_mentors_watch_for_question.rb
@@ -3,6 +3,7 @@
 class CreatingMentorsWatchForQuestion
   def call(question)
     return if question.wip? || question.watched?
+
     watch_question_records = watch_records(question)
     Watch.insert_all(watch_question_records) # rubocop:disable Rails/SkipsModelValidations
   end

--- a/app/models/mentors_watch_for_question_creator.rb
+++ b/app/models/mentors_watch_for_question_creator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreatingMentorsWatchForQuestion
+class MentorsWatchForQuestionCreator
   def call(question)
     return if question.wip? || question.watched?
 

--- a/app/models/question_callbacks.rb
+++ b/app/models/question_callbacks.rb
@@ -5,7 +5,6 @@ class QuestionCallbacks
     return unless question.saved_change_to_attribute?(:published_at, from: nil)
 
     send_notification_to_mentors(question)
-    create_mentors_watch(question)
     notify_to_chat(question)
     Cache.delete_not_solved_question_count
   end
@@ -32,22 +31,5 @@ class QuestionCallbacks
 
   def delete_notification(question)
     Notification.where(link: "/questions/#{question.id}").destroy_all
-  end
-
-  def create_mentors_watch(question)
-    watch_question_records = watch_records(question)
-    Watch.insert_all(watch_question_records) # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  def watch_records(question)
-    User.mentor.map do |mentor|
-      {
-        watchable_type: 'Question',
-        watchable_id: question.id,
-        created_at: Time.current,
-        updated_at: Time.current,
-        user_id: mentor.id
-      }
-    end
   end
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -39,21 +39,11 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:page_create, page_notifier)
   Newspaper.subscribe(:page_update, page_notifier)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   product_notifier = ProductNotifier.new
   Newspaper.subscribe(:product_create, product_notifier)
   Newspaper.subscribe(:product_update, product_notifier)
 
-  Newspaper.subscribe(:question_create, CreatingMentorsWatchForQuestion.new)
-=======
-  creating_mentors_watch_for_question = CreatingMentorsWatchForQuestion.new
-  Newspaper.subscribe(:question_create, creating_mentors_watch_for_question)
-  Newspaper.subscribe(:question_update, creating_mentors_watch_for_question)
->>>>>>> 7792e7778 (createとupdateでnewspaperの呼び出しを分けた)
-=======
   mentors_watch_for_question_creator = MentorsWatchForQuestionCreator.new
   Newspaper.subscribe(:question_create, mentors_watch_for_question_creator)
   Newspaper.subscribe(:question_update, mentors_watch_for_question_creator)
->>>>>>> dd2eaab4c (ファイルとクラス名をCreatingMentorsWatchForQueestionからMentorsWatchForQuestionCreatorに修正した)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -42,4 +42,6 @@ Rails.configuration.to_prepare do
   product_notifier = ProductNotifier.new
   Newspaper.subscribe(:product_create, product_notifier)
   Newspaper.subscribe(:product_update, product_notifier)
+
+  Newspaper.subscribe(:question_create, CreatingMentorsWatchForQuestion.new)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -39,9 +39,15 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:page_create, page_notifier)
   Newspaper.subscribe(:page_update, page_notifier)
 
+<<<<<<< HEAD
   product_notifier = ProductNotifier.new
   Newspaper.subscribe(:product_create, product_notifier)
   Newspaper.subscribe(:product_update, product_notifier)
 
   Newspaper.subscribe(:question_create, CreatingMentorsWatchForQuestion.new)
+=======
+  creating_mentors_watch_for_question = CreatingMentorsWatchForQuestion.new
+  Newspaper.subscribe(:question_create, creating_mentors_watch_for_question)
+  Newspaper.subscribe(:question_update, creating_mentors_watch_for_question)
+>>>>>>> 7792e7778 (createとupdateでnewspaperの呼び出しを分けた)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -40,6 +40,7 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:page_update, page_notifier)
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   product_notifier = ProductNotifier.new
   Newspaper.subscribe(:product_create, product_notifier)
   Newspaper.subscribe(:product_update, product_notifier)
@@ -50,4 +51,9 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:question_create, creating_mentors_watch_for_question)
   Newspaper.subscribe(:question_update, creating_mentors_watch_for_question)
 >>>>>>> 7792e7778 (createとupdateでnewspaperの呼び出しを分けた)
+=======
+  mentors_watch_for_question_creator = MentorsWatchForQuestionCreator.new
+  Newspaper.subscribe(:question_create, mentors_watch_for_question_creator)
+  Newspaper.subscribe(:question_update, mentors_watch_for_question_creator)
+>>>>>>> dd2eaab4c (ファイルとクラス名をCreatingMentorsWatchForQueestionからMentorsWatchForQuestionCreatorに修正した)
 end


### PR DESCRIPTION
## Issue

- #6109 

## 概要
Question作成時のmentorへのWatch作成処理をnewspaperに置き換えました。

`models/question.rb` の `after_save` で処理されていた `QuestionCallbacks` から、`controllers/questions_controller.rb` で質問が `create` される際に `Newspaper` で処理が実行されるように修正しました。
その際、`WIP` を除外しないと質問がWIP状態でもメンターさんのWatchがついてしまうため、`contorollers/api/questions_controller.rb` で質問が `update` される際、Watchが `true` でなければ `Newspaper` で同様に処理されるように対応しました。

今回は処理の置き換えになるため、画面の変更やテストの変更はありません。
## 変更確認方法

1. `bug/replaced_process_of_creating_question_watch_to_mentor` をローカルに取り込む
2. `bin/setup` を実行します
3. `bin/rails s` でサーバーを立ち上げます
4. `kimura` のアカウントでログインし、質問を投稿します。
5. `komagata` のアカウントでログインし直し、手順4の質問がWatch状態であることを確認します。
6. `kimura` のアカウントでログインし、質問をWIP状態で保存します。
7. `komagata` のアカウントでログインし、手順6の質問がWatch状態になっていないことを確認します。
8. `kimura` のアカウントで手順6の質問を公開します。
9. `komagata` のアカウントで手順6の質問がWatch状態に変わったことを確認します。

<img width="1552" alt="Watch" src="https://user-images.githubusercontent.com/76797372/216810628-8b9bac9f-cc83-4990-b687-c2b70dafca08.png">
