### PR TITLE
退会3ヶ月後通知のコードの重複を削除した

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -78,8 +78,6 @@ class ActivityMailer < ApplicationMailer
     @sender ||= args[:sender]
     @receiver ||= args[:receiver]
 
-    return false unless @receiver.mail_notification? # cancel sending email
-
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:retired]


### PR DESCRIPTION
## 概要

#6110 のPull Requestのコメントでご指摘を受けた点を修正したものです。

https://github.com/fjordllc/bootcamp/pull/6110#discussion_r1096588746

```rb
return false unless @receiver.mail_notification? # cancel sending email
```

を削除致しました。
