### PR TITLE
定期イベントの開催日時の区切りを全角に変更

### DIFF
--- a/app/decorators/regular_event_decorator.rb
+++ b/app/decorators/regular_event_decorator.rb
@@ -6,7 +6,7 @@ module RegularEventDecorator
       holding_frequency = RegularEvent::FREQUENCY_LIST.find { |frequency| frequency[1] == repeat_rule.frequency }[0]
       holding_day_of_the_week = RegularEvent::DAY_OF_THE_WEEK_LIST.find { |day_of_the_week| day_of_the_week[1] == repeat_rule.day_of_the_week }[0]
       holding_frequency + holding_day_of_the_week
-    end.join(',')
+    end.join('、')
   end
 
   def next_holding_date

--- a/db/fixtures/regular_event_repeat_rules.yml
+++ b/db/fixtures/regular_event_repeat_rules.yml
@@ -6,29 +6,44 @@ regular_event_repeat_rule1:
 regular_event_repeat_rule2:
   frequency: 1
   day_of_the_week: 1
-  regular_event: regular_event2
+  regular_event: regular_event1
 
 regular_event_repeat_rule3:
   frequency: 2
   day_of_the_week: 1
-  regular_event: regular_event3
+  regular_event: regular_event1
 
 regular_event_repeat_rule4:
   frequency: 3
   day_of_the_week: 2
-  regular_event: regular_event4
+  regular_event: regular_event2
 
 regular_event_repeat_rule5:
   frequency: 2
   day_of_the_week: 3
-  regular_event: regular_event5
+  regular_event: regular_event2
 
 regular_event_repeat_rule6:
   frequency: 4
   day_of_the_week: 1
-  regular_event: regular_event6
+  regular_event: regular_event3
 
 regular_event_repeat_rule7:
+  frequency: 0
+  day_of_the_week: 3
+  regular_event: regular_event4
+
+regular_event_repeat_rule8:
+  frequency: 0
+  day_of_the_week: 3
+  regular_event: regular_event5
+
+regular_event_repeat_rule9:
+  frequency: 0
+  day_of_the_week: 3
+  regular_event: regular_event6
+
+regular_event_repeat_rule10:
   frequency: 0
   day_of_the_week: 3
   regular_event: regular_event7

--- a/db/fixtures/regular_event_repeat_rules.yml
+++ b/db/fixtures/regular_event_repeat_rules.yml
@@ -47,10 +47,10 @@ regular_event_repeat_rule9:
 regular_event_repeat_rule<%= i %>:
   frequency: 0
   day_of_the_week: 0
-  regular_event: regular_event<%= i - 3 %>
+  regular_event: regular_event<%= i %>
 <% end %>
 
-# NOTE: 定期イベントが複数の場合
+# NOTE: 定期イベントが複数存在する場合
 regular_event_repeat_rule27:
   frequency: 1
   day_of_the_week: 1
@@ -69,4 +69,3 @@ regular_event_repeat_rule29:
 regular_event_repeat_rule30:
   frequency: 2
   day_of_the_week: 3
-  regular_event: regular_event2

--- a/db/fixtures/regular_event_repeat_rules.yml
+++ b/db/fixtures/regular_event_repeat_rules.yml
@@ -47,7 +47,7 @@ regular_event_repeat_rule9:
 regular_event_repeat_rule<%= i %>:
   frequency: 0
   day_of_the_week: 0
-  regular_event: regular_event<%= i %>
+  regular_event: regular_event<%= i - 3 %>
 <% end %>
 
 # NOTE: 定期イベントが複数の場合

--- a/db/fixtures/regular_event_repeat_rules.yml
+++ b/db/fixtures/regular_event_repeat_rules.yml
@@ -6,44 +6,29 @@ regular_event_repeat_rule1:
 regular_event_repeat_rule2:
   frequency: 1
   day_of_the_week: 1
-  regular_event: regular_event1
+  regular_event: regular_event2
 
 regular_event_repeat_rule3:
   frequency: 2
   day_of_the_week: 1
-  regular_event: regular_event1
+  regular_event: regular_event3
 
 regular_event_repeat_rule4:
   frequency: 3
   day_of_the_week: 2
-  regular_event: regular_event2
+  regular_event: regular_event4
 
 regular_event_repeat_rule5:
   frequency: 2
   day_of_the_week: 3
-  regular_event: regular_event2
+  regular_event: regular_event5
 
 regular_event_repeat_rule6:
   frequency: 4
   day_of_the_week: 1
-  regular_event: regular_event3
-
-regular_event_repeat_rule7:
-  frequency: 0
-  day_of_the_week: 3
-  regular_event: regular_event4
-
-regular_event_repeat_rule8:
-  frequency: 0
-  day_of_the_week: 3
-  regular_event: regular_event5
-
-regular_event_repeat_rule9:
-  frequency: 0
-  day_of_the_week: 3
   regular_event: regular_event6
 
-regular_event_repeat_rule10:
+regular_event_repeat_rule7:
   frequency: 0
   day_of_the_week: 3
   regular_event: regular_event7
@@ -64,3 +49,24 @@ regular_event_repeat_rule<%= i %>:
   day_of_the_week: 0
   regular_event: regular_event<%= i %>
 <% end %>
+
+# NOTE: 定期イベントが複数の場合
+regular_event_repeat_rule27:
+  frequency: 1
+  day_of_the_week: 1
+  regular_event: regular_event1
+
+regular_event_repeat_rule28:
+  frequency: 2
+  day_of_the_week: 1
+  regular_event: regular_event1
+
+regular_event_repeat_rule29:
+  frequency: 3
+  day_of_the_week: 2
+  regular_event: regular_event2
+
+regular_event_repeat_rule30:
+  frequency: 2
+  day_of_the_week: 3
+  regular_event: regular_event2

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -1,34 +1,49 @@
 regular_event_repeat_rule1:
-  regular_event: regular_event1
   frequency: 0
   day_of_the_week: 0
+  regular_event: regular_event1
 
 regular_event_repeat_rule2:
   frequency: 1
   day_of_the_week: 1
-  regular_event: regular_event2
+  regular_event: regular_event1
 
 regular_event_repeat_rule3:
   frequency: 2
   day_of_the_week: 1
-  regular_event: regular_event3
+  regular_event: regular_event1
 
 regular_event_repeat_rule4:
   frequency: 3
   day_of_the_week: 2
-  regular_event: regular_event4
+  regular_event: regular_event2
 
 regular_event_repeat_rule5:
   frequency: 2
   day_of_the_week: 3
-  regular_event: regular_event5
+  regular_event: regular_event2
 
 regular_event_repeat_rule6:
   frequency: 4
   day_of_the_week: 1
-  regular_event: regular_event6
+  regular_event: regular_event3
 
 regular_event_repeat_rule7:
+  frequency: 0
+  day_of_the_week: 3
+  regular_event: regular_event4
+
+regular_event_repeat_rule8:
+  frequency: 0
+  day_of_the_week: 3
+  regular_event: regular_event5
+
+regular_event_repeat_rule9:
+  frequency: 0
+  day_of_the_week: 3
+  regular_event: regular_event6
+
+regular_event_repeat_rule10:
   frequency: 0
   day_of_the_week: 3
   regular_event: regular_event7

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -1,49 +1,34 @@
 regular_event_repeat_rule1:
+  regular_event: regular_event1
   frequency: 0
   day_of_the_week: 0
-  regular_event: regular_event1
 
 regular_event_repeat_rule2:
   frequency: 1
   day_of_the_week: 1
-  regular_event: regular_event1
+  regular_event: regular_event2
 
 regular_event_repeat_rule3:
   frequency: 2
   day_of_the_week: 1
-  regular_event: regular_event1
+  regular_event: regular_event3
 
 regular_event_repeat_rule4:
   frequency: 3
   day_of_the_week: 2
-  regular_event: regular_event2
+  regular_event: regular_event4
 
 regular_event_repeat_rule5:
   frequency: 2
   day_of_the_week: 3
-  regular_event: regular_event2
+  regular_event: regular_event5
 
 regular_event_repeat_rule6:
   frequency: 4
   day_of_the_week: 1
-  regular_event: regular_event3
-
-regular_event_repeat_rule7:
-  frequency: 0
-  day_of_the_week: 3
-  regular_event: regular_event4
-
-regular_event_repeat_rule8:
-  frequency: 0
-  day_of_the_week: 3
-  regular_event: regular_event5
-
-regular_event_repeat_rule9:
-  frequency: 0
-  day_of_the_week: 3
   regular_event: regular_event6
 
-regular_event_repeat_rule10:
+regular_event_repeat_rule7:
   frequency: 0
   day_of_the_week: 3
   regular_event: regular_event7


### PR DESCRIPTION
## Issue

- #6027

## 概要
- 定期イベントの開催日時の区切りを全角に変更
    - ` , `を` 、`に修正
- 定期イベントに複数日程が作成されるよう、fixtureにデータを追加

## 変更確認方法

1.`feature/change-regular-event-comma-to-panctuation-mark`をローカルに取り込む
2. `bin/rails db:seed` でfixtureに記載のデータを取り込む
3. `bin/rails s`でサーバーを起動
4. `mentormentaro` でログイン
5. `/regular_events?target=not_finished ` にアクセス
- 定期イベント一覧画面を確認
- 定期イベント個別ページを確認 

## Screenshot

### 変更前
定期イベント一覧。
<img width="683" alt="image_一覧" src="https://user-images.githubusercontent.com/75718420/222056070-60397240-0746-4a18-ba4a-c0fff423826a.png">

定期イベント個別ページ。
<img width="809" alt="image_個別" src="https://user-images.githubusercontent.com/75718420/222056083-78f13ac4-3ceb-4abe-ac7f-f2b5e11ec356.png">

### 変更後
定期イベント一覧。
<img width="682" alt="image_a_一覧" src="https://user-images.githubusercontent.com/75718420/222055370-219d1fae-da93-4ec1-8c45-6fe54496b3e6.png">

定期イベント個別ページ。
<img width="815" alt="image_a_個別" src="https://user-images.githubusercontent.com/75718420/222055392-3da064f0-00ee-43c1-9990-62b8950d0473.png">
