### PR TITLE
提出物の作者のWatch作成処理をnewspaperに置き換えた

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,6 +40,7 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.save
+      Newspaper.publish(:product_create, @product)
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new

--- a/app/models/product_author_watcher.rb
+++ b/app/models/product_author_watcher.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ProductAuthorWatcher
+  def call(product)
+    Watch.create!(user: product.user, watchable: product)
+  end
+end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -2,8 +2,6 @@
 
 class ProductCallbacks
   def after_create(product)
-    create_author_watch(product)
-
     Cache.delete_unchecked_product_count
     Cache.delete_unassigned_product_count
     Cache.delete_self_assigned_no_replied_product_count(product.checker_id)
@@ -40,10 +38,6 @@ class ProductCallbacks
   end
 
   private
-
-  def create_author_watch(product)
-    Watch.create!(user: product.user, watchable: product)
-  end
 
   def create_advisers_watch(product)
     product.user.company.advisers.each do |adviser|

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -33,6 +33,7 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:comeback_update, ComebackNotifier.new)
 
   Newspaper.subscribe(:check_create, ProductStatusUpdater.new)
+  Newspaper.subscribe(:product_create, ProductAuthorWatcher.new)
 
   page_notifier = PageNotifier.new
   Newspaper.subscribe(:page_create, page_notifier)


### PR DESCRIPTION
## Issue

- #6107

## 概要
プラクティスの提出物作成時に、提出物の作者が付与される「Watch中」のWatch処理をnewspaperに置き換えました。
（[newspaper](https://github.com/komagata/newspaper) に関する詳細は、上記ISSUEに参考リンクが貼付されています）


テストは、`test/system/products_test.rb `に作成されている状態のため、今回新たに追加はしていません。

## 変更確認方法
今回の修正では、bootcampアプリの挙動に変更はありません。
変更がないことを確認する手順になります。

1. `feature/replace-create-author-watch-with-newspaper`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3.  `kensyu`でログイン
4. http://localhost:3000/courses/829913840/practices へアクセスする
5.  適当な未提出のプラクティスを選択し、「提出する」ボタンをクリックする
6. 提出物作成画面で、プラクティスを提出する
7. 該当のプラクティス詳細画面にて、提出物のWatchが「Watch中」のステータスになっていることを確認する

## Screenshot
画面の変更がないため割愛します。
