### PR TITLE
開発環境で就職を希望するユーザーにのみ「就職関係かつ直近イベントの表示テスト用」のお知らせを表示させるようseedデータを修正した

### DIFF
--- a/db/fixtures/events.yml
+++ b/db/fixtures/events.yml
@@ -134,4 +134,5 @@ event29:
   end_at: 2019-12-17 12:00:00
   open_start_at: 2019-12-10 9:00
   open_end_at: 2019-12-16 9:00
+  job_hunting: true
   user: komagata


### PR DESCRIPTION
## Issue

- #6174

## 概要

明日or明後日開催のイベントがある場合、ダッシュボードにそのお知らせが表示される。
就職関係のイベントは就職を希望するユーザーにのみ表示されるが、その機能の確認のために開発環境のfixturesで用意されている「就職関係かつ直近イベントの表示テスト用」のseedデータの記述が誤っていて、就職を希望しないユーザーにもお知らせが表示されてしまっているので、就職を希望するユーザーにのみ表示されるよう修正しました。

## 変更確認方法

1. `bug/fix-event-in-seed-data`をローカルに取り込む
2. `rails db:seed`を実行する
3. `rails s`でサーバーを起動する
4. `kimura`（就職を希望しないユーザー）でログインする
5. 「就職関係かつ直近イベントの表示テスト用」のお知らせがダッシュボードに表示されていないことを確認する
6. `jobseeker`（就職を希望するユーザー）でログインする
7. 「就職関係かつ直近イベントの表示テスト用」のお知らせがダッシュボードに表示されていることを確認する

## Screenshot

### 変更前

kimura（就職を希望しないユーザー）のダッシュボード

<img width="1298" alt="216883075-911e5694-c20e-4e41-827d-9825601ffc8b" src="https://user-images.githubusercontent.com/88083085/216887349-3023832d-d4ba-420d-ae2a-9d6fd2fbf768.png">


### 変更後

kimura（就職を希望しないユーザー）のダッシュボード

<img width="1298" alt="スクリーンショット 2023-02-06 13 40 34" src="https://user-images.githubusercontent.com/88083085/216888079-9072f5bc-74b2-4344-8223-51ad0806500c.png">

jobseeker（就職を希望するユーザー）のダッシュボード

<img width="1300" alt="スクリーンショット 2023-02-06 13 40 53" src="https://user-images.githubusercontent.com/88083085/216888046-7e4958b9-375e-4477-9f5b-9716cb3e02d7.png">

