### PR TITLE
ユーザー情報変更画面にサブスクリプションID項目を追加

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -46,7 +46,7 @@ class Admin::UsersController < AdminController
   def user_params
     params.require(:user).permit(
       :adviser, :login_name, :name,
-      :name_kana, :email, :course_id,
+      :name_kana, :email, :course_id, :subscription_id,
       :description, :discord_account, :github_account,
       :twitter_account, :facebook_url, :blog_url, :times_url,
       :password, :password_confirmation, :job,

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -83,6 +83,10 @@
             .form-item-block__item
               = render 'users/form/graduate', f: f
 
+      .form-item
+        = f.label :subscription_id, class: 'a-form-label'
+        = f.text_field :subscription_id, class: 'a-text-input', placeholder: 'sub_123456789'
+
       .form-item-block
         .form-item-block__inner
           header.form-item-block__header

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -99,6 +99,7 @@ ja:
         profile_name: プロフィール名
         profile_job: 職業
         profile_text: プロフィール文
+        subscription_id: サブスクリプションID
       hibernation:
         reason: 休会の理由
         scheduled_return_on: 復帰予定日

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -185,6 +185,7 @@ kimura:
   experience: inexperienced
   prefecture_code: 13
   organization: 木村大学
+  subscription_id: sub-id-test-123
   unsubscribe_email_token: k6Da-oL3cRi8ApNFO9-Gcg
   updated_at: "2014-01-01 00:00:07"
   created_at: "2014-01-01 00:00:07"


### PR DESCRIPTION
## Issue

- #6140 

## 概要

ユーザー情報変更画面にサブスクリプションID項目を追加し、画面から編集できるようにする。

## 変更確認方法

1. `add-subscription-id-editor` をローカルに取り込む
1. `bin/rails s` でサーバーを起動
1. `komagata`(メンターならなんでも)でログイン
1. ユーザー情報変更画面へ遷移
    1. サイドバーから`ユーザー`をクリック
    1. `kimura`(テストデータに`subscription-id`を持つ)をクリック
    1. `ステータス変更`欄の`管理者として情報変更`をクリック
1. `以下管理者のみ操作ができます`セクションの`サブスクリプションID`の値を適当な文字列に変更
1. `更新する`をクリック
1. 再度ユーザー情報変更画面へ遷移し、`サブスクリプションID`の値が変更されていることを確認

## Screenshot

### 変更前
<img width="601" alt="スクリーンショット 2023-02-13 21 55 44" src="https://user-images.githubusercontent.com/94843475/218464167-4e1a88ae-17b3-4801-b106-94035eda1bd9.png">

### 変更後

#### データあり
<img width="599" alt="スクリーンショット 2023-02-13 21 54 37" src="https://user-images.githubusercontent.com/94843475/218464236-130bceac-04ed-431f-bea6-3aac2cf40c2d.png">


#### データなし
<img width="599" alt="スクリーンショット 2023-02-13 21 54 52" src="https://user-images.githubusercontent.com/94843475/218464272-34e3b607-3041-46cb-87bd-11aed5268edb.png">

