### PR TITLE
初日報の投稿を自己紹介チャンネルに通知する

### DIFF
--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -76,6 +76,7 @@ class ReportCallbacks
   end
 
   def notify_to_chat(report)
+    DiscordNotifier.with(report: report).first_report.notify_now if report.first?
     ChatNotifier.message(<<~TEXT, webhook_url: ENV['DISCORD_REPORT_WEBHOOK_URL'])
       #{report.user.login_name}さんが#{I18n.l report.reported_on}の日報を公開しました。
       タイトル：「#{report.title}」

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -99,4 +99,16 @@ class DiscordNotifier < ApplicationNotifier
       webhook_url: webhook_url
     )
   end
+
+  def first_report(params = {})
+    params.merge!(@params)
+    webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:introduction]
+    report = params[:report]
+
+    notification(
+      body: "🎉 #{report.user.login_name}さんがはじめての日報を書きました！",
+      name: 'ピヨルド',
+      webhook_url: webhook_url
+    )
+  end
 end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -104,9 +104,10 @@ class DiscordNotifier < ApplicationNotifier
     params.merge!(@params)
     webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:introduction]
     report = params[:report]
+    url = Rails.application.routes.url_helpers.report_url(report)
 
     notification(
-      body: "🎉 #{report.user.login_name}さんがはじめての日報を書きました！",
+      body: "🎉 #{report.user.login_name}さんがはじめての日報を書きました！\r#{url}",
       name: 'ピヨルド',
       webhook_url: webhook_url
     )

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -104,10 +104,14 @@ class DiscordNotifier < ApplicationNotifier
     params.merge!(@params)
     webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:introduction]
     report = params[:report]
-    url = Rails.application.routes.url_helpers.report_url(report)
+    body = <<~TEXT.chomp
+      🎉 #{report.user.login_name}さんがはじめての日報を書きました！
+      タイトル：「#{report.title}」
+      URL： #{Rails.application.routes.url_helpers.report_url(report)}
+    TEXT
 
     notification(
-      body: "🎉 #{report.user.login_name}さんがはじめての日報を書きました！\r#{url}",
+      body: body,
       name: 'ピヨルド',
       webhook_url: webhook_url
     )

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -21,6 +21,7 @@ shared:
     admin: <%= ENV['DISCORD_ADMIN_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/admin' %>
     mentor: <%= ENV['DISCORD_MENTOR_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/mentor' %>
     all: <%= ENV['DISCORD_ALL_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/all' %>
+    introduction: <%= ENV['DISCORD_INTRODUCTION_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/introduction' %>
   stripe:
     public_key: pk_test_Je8A9BUHRC8oqsqx8wtfbKwg
     secret_key: sk_test_XLP1Ajz1JvT9jUt5uKGvL0Wd

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -175,4 +175,27 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       DiscordNotifier.with(params).hibernated.notify_later
     end
   end
+
+  test '.first_report' do
+    params = {
+      report: reports(:report10),
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    expected = {
+      body: '🎉 hajimeさんがはじめての日報を書きました！',
+      name: 'ピヨルド',
+      webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
+    }
+
+    assert_notifications_sent 2, **expected do
+      DiscordNotifier.first_report(params).notify_now
+      DiscordNotifier.with(params).first_report.notify_now
+    end
+
+    assert_notifications_enqueued 2, **expected do
+      DiscordNotifier.first_report(params).notify_later
+      DiscordNotifier.with(params).first_report.notify_later
+    end
+  end
 end

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -182,8 +182,13 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }
 
+    body = <<~TEXT.chomp
+      🎉 hajimeさんがはじめての日報を書きました！
+      タイトル：「初日報です」
+      URL： http://localhost:3000/reports/819157022
+    TEXT
     expected = {
-      body: "🎉 hajimeさんがはじめての日報を書きました！\rhttp://localhost:3000/reports/819157022",
+      body: body,
       name: 'ピヨルド',
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -183,7 +183,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     }
 
     expected = {
-      body: '🎉 hajimeさんがはじめての日報を書きました！',
+      body: "🎉 hajimeさんがはじめての日報を書きました！\rhttp://localhost:3000/reports/819157022",
       name: 'ピヨルド',
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }


### PR DESCRIPTION
## Issue

- #6120 

## 概要

初日報の投稿をDiscordの自己紹介🥁チャンネルに通知するようにしました。
現在メンターのみに通知されていますが、Discord参加者全員が知ることができます。

## 変更確認方法

ローカル環境で動作確認を行う場合は自己紹介🥁チャンネルに通知を行うことはできないので、通知先を用意します。
また通知先のウェブフックURLを環境変数`DISCORD_INTRODUCTION_WEBHOOK_URL`に設定しないと通知が行われません。

1. Discordの事前設定
   1. 通知先となるDiscordサーバーとテキストチャンネルを用意します(無料で作れます)
   2. サーバー設定 -> 連携サービス -> ウェブフックから通知先のウェブフックを作成します
   3. 「ウェブフックURLをコピー」をクリックしてコピーされるURLを控えます
2. `feature/post-first-report-submission-to-the-discord-introduction-channel`をローカルに取り込む
3. `DISCORD_INTRODUCTION_WEBHOOK_URL=<ウェブフックのURL> rails s`でローカル環境を立ち上げます
4. ユーザー`nippounashi `でログインします
5. 「日報作成」をクリックします
6. 日報を記入し「提出」します
7. Discordチャンネルに通知が投稿されます

## Screenshot

### 変更前

通知されません

### 変更後

<img width="532" alt="image" src="https://user-images.githubusercontent.com/69447745/216972443-90bf47b2-cd5c-4055-9b2a-a355bf428930.png">
