### PR TITLE
notify_product_review_not_completedをDailyControllerから別のコントローラーに移動する

### DIFF
--- a/app/controllers/scheduler/daily/notify_product_review_not_completed_controller.rb
+++ b/app/controllers/scheduler/daily/notify_product_review_not_completed_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Scheduler::Daily::NotifyProductReviewNotCompletedController < SchedulerController
+  def show
+    notify_product_review_not_completed
+    head :ok
+  end
+
+  private
+
+  def notify_product_review_not_completed
+    Comment.where(commentable_type: 'Product').find_each do |product_comment|
+      product = product_comment.commentable
+      if product_comment.certain_period_passed_since_the_last_comment_by_submitter?(5.days) && !product.unassigned? && !product.checked?
+        DiscordNotifier.with(comment: product_comment).product_review_not_completed.notify_now
+      end
+    end
+  end
+end

--- a/app/controllers/scheduler/daily_controller.rb
+++ b/app/controllers/scheduler/daily_controller.rb
@@ -3,18 +3,6 @@
 class Scheduler::DailyController < SchedulerController
   def show
     User.notify_to_discord
-    notify_product_review_not_completed
     head :ok
-  end
-
-  private
-
-  def notify_product_review_not_completed
-    Comment.where(commentable_type: 'Product').find_each do |product_comment|
-      product = product_comment.commentable
-      if product_comment.certain_period_passed_since_the_last_comment_by_submitter?(5.days) && !product.unassigned? && !product.checked?
-        DiscordNotifier.with(comment: product_comment).product_review_not_completed.notify_now
-      end
-    end
   end
 end

--- a/config/routes/scheduler.rb
+++ b/config/routes/scheduler.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       resource :after_retirement, only: %i(show), controller: "after_retirement"
       resource :notify_tomorrow_regular_event, only: %i(show), controller: "notify_tomorrow_regular_event"
       resource :notify_certain_period_passed_after_last_answer, only: %i(show), controller: "notify_certain_period_passed_after_last_answer"
+      resource :notify_product_review_not_completed, only: %i(show), controller: "notify_product_review_not_completed"
     end
   end
 end


### PR DESCRIPTION
## Issue

- #5933

## 概要

現在`Scheduler::DailyController`で定期実行している`notify_product_review_not_completed`を別のコントローラー`Scheduler::Daily::NotifyProductReviewNotCompletedController`に移しました。

上記に伴い定期実行用のパス(`/scheduler/daily/notify_product_review_not_completed`)を新設しました。

## 変更確認方法

**関連PR #5667 を基に一部改変しています**

1. このPRにおいてはdiscordでの通知を確認するために、discordのサーバー、チャンネルの作成とそのwebhookの取得が必要となります。discordでテスト用のサーバーを作成しテスト用のチャンネルを作ってそのwebhookURLの取得をしてください。yumさんの #5480 の確認方法においてwebhookURLの取得までが丁寧に説明されています。
2. `feature/move-notify_product_review_not_completed-to-a-new-controller`をローカルに取り込む
3. `DISCORD_MENTOR_WEBHOOK_URL=<1で取得したwebhookURL> rails s`でローカル環境を立ち上げる
4.  `mentormentaro`でログインし、`kensyu`の提出物である( http://localhost:3000/products/613458348 ) へアクセスする
5. `担当する`ボタンを押して、4.でアクセスした`kensyu`の「OS X Mountain Lionをクリーンインストールするの提出物」で`mentormentaro`が担当となるように設定する

6. `rails c`で担当者`mentormentaro`による7日前のコメントを作成する（以下をコピー＆ペーストしてください）
```ruby
# commentable_id → 手順4.でアクセスした提出物のid
# user_id → mentormentaroのid
Comment.create!(commentable_id:613458348, user_id: 534981761, description: "test", commentable_type: "Product", created_at:Time.current.ago(7.days), updated_at:Time.current.ago(7.days))
```
7. `rails c`で提出者`kensyu`による5日前のコメントを作成する（以下をコピー＆ペーストしてください）
```ruby
# commentable_id → 手順4.でアクセスした提出物のid
# user_id → kensyuのid
Comment.create!(commentable_id:613458348, user_id: 301971253, description: "test", commentable_type: "Product", created_at:Time.current.ago(5.days), updated_at:Time.current.ago(5.days))
```

👍このような状態になります
![image](https://user-images.githubusercontent.com/58751858/197460300-e092e4c2-51a6-434e-b2d1-261c2aec5ac1.png)

8. 上記が全て整ったら、http://localhost:3000/scheduler/daily/notify_product_review_not_completed にアクセスする（画面は何も表示されませんが、処理が走ります）
9. Discordの通知に以下のような内容で通知が来ることを確認する
![image](https://user-images.githubusercontent.com/58751858/197460843-30bfa882-3fb3-49b6-80fa-2052ed6642ae.png)

## 関連PR

#5667
