### PR TITLE
Docsの作成者へのWatch処理をnewspaperに置き換え

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -36,6 +36,7 @@ class PagesController < ApplicationController
     end
     set_wip
     if @page.save
+      Newspaper.publish(:page_create, @page)
       redirect_to @page, notice: notice_message(@page, :create)
     else
       render :new

--- a/app/models/page_callbacks.rb
+++ b/app/models/page_callbacks.rb
@@ -6,7 +6,6 @@ class PageCallbacks
 
     send_notification(page)
     notify_to_chat(page)
-    create_author_watch(page)
 
     page.published_at = Time.current
     page.save

--- a/app/models/page_notifier.rb
+++ b/app/models/page_notifier.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PageNotifier
+  def call(page)
+    return if page.wip?
+
+    create_author_watch(page)
+  end
+
+  private
+
+  def create_author_watch(page)
+    Watch.create!(user: page.user, watchable: page)
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Rails.configuration.to_prepare do
+Rails.configuration.to_prepare do # rubocop:disable Metrics/BlockLength
   Newspaper.subscribe(:event_create, EventOrganizerWatcher.new)
   Newspaper.subscribe(:answer_create, AnswerNotifier.new)
   Newspaper.subscribe(:answer_create, NotifierToWatchingUser.new)
@@ -33,4 +33,7 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:comeback_update, ComebackNotifier.new)
 
   Newspaper.subscribe(:check_create, ProductStatusUpdater.new)
+
+  page_notifier = PageNotifier.new
+  Newspaper.subscribe(:page_create, page_notifier)
 end


### PR DESCRIPTION
## Issue

- #6106 

## 概要

Docsの作成者へのWatch処理をnewspaperに置き換える

## 変更確認方法

### 内容を保存する場合

1. `feature/replace-newspaper-for-watch-to-doc-creater` をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. `komagata`でログインする
4. Docsを`内容を保存する`で作成する
5. `kimura`でログインする
6. 上記で作成したDocsにコメントする
7. `komagata`の通知欄に、`kimura`がコメントしたことに対する通知が来ていることを確認する

### WIPの場合

1 ~ 3までは上記と共通。

4. Docsを`WIP`で作成する
5. `kimura`でログインする
6. 上記で作成したDocsにコメントする
7. `komagata`の通知欄に、`kimura`がコメントしたことに対する通知が来て**いない**ことを確認する

## Screenshot

画面への変更はありません。

