### PR TITLE
プラクティス編集画面の参考書籍選択にて、複数使われていたidをclassに修正

### DIFF
--- a/app/javascript/book-select.js
+++ b/app/javascript/book-select.js
@@ -1,8 +1,8 @@
 import Choices from 'choices.js'
 
 document.addEventListener('DOMContentLoaded', () => {
-  const bookSelectCount = document.querySelectorAll('#js-book-select').length
-  const elements = document.querySelectorAll('#js-book-select')
+  const bookSelectCount = document.querySelectorAll('.js-book-select').length
+  const elements = document.querySelectorAll('.js-book-select')
   for (let i = 0; i < bookSelectCount; i++) {
     // eslint-disable-next-line no-new
     new Choices(elements[i], {
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
   $('.books-form__add').on('cocoon:after-insert', () => {
-    const elements = document.querySelectorAll('#js-book-select')
+    const elements = document.querySelectorAll('.js-book-select')
     const element = elements[elements.length - 1]
     if (element) {
       return new Choices(element, {

--- a/app/views/practices/_practices_book_fields.html.slim
+++ b/app/views/practices/_practices_book_fields.html.slim
@@ -7,7 +7,7 @@
     .books-form__items
       .books-form-item
         = f.label '参考書籍', class: 'a-form-label'
-        = f.collection_select :book_id, all_books, :first, :last, {}, { id: 'js-book-select' }
+        = f.collection_select :book_id, all_books, :first, :last, {}, { class: 'js-book-select' }
       .books-form-item.is-inline
         = f.label '必読', class: 'a-form-label'
         label.a-on-off-checkbox.is-sm.books-form-item__must-read

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -137,7 +137,7 @@ class PracticesTest < ApplicationSystemTestCase
     visit_with_auth "/practices/#{practice.id}/edit", 'komagata'
     within '#reference_books' do
       find('.choices__list').click
-      find('#choices--js-book-select-item-choice-2', text: 'はじめて学ぶソフトウェアのテスト技法').click
+      find('#choices--practice_practices_books_attributes_0_book_id-item-choice-2', text: 'はじめて学ぶソフトウェアのテスト技法').click
     end
     click_button '更新する'
     assert_text 'はじめて学ぶソフトウェアのテスト技法'


### PR DESCRIPTION
## Issue
- #5897

## 概要
プラクティス編集画面の参考書籍選択にて、`id="js-book-select"`が複数箇所に存在していたため`class`に変更しました。
また、`id`を`class`に変更した影響で、参考書籍選択に関するテストでエラーが発生するようになったため併せて修正を行いました。

## 変更確認方法

1. `bug/fix-id-on-reference-book-selection-to-class`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `mentormentaro`でログインし、`/practices/315059988/edit`にアクセスする
4. 「参考書籍」にて参考書籍を2つにし、それぞれ「ゼロからわかるRuby超入門」「はじめて学ぶソフトウェアのテスト技法」を選択する
5. デベロッパーツールを開く
6. 要素タブを開き、要素内をクリックしたあとに「command + F」を押す（検索欄が表示される）
7. `js-book-select`を検索する
8. 参考書籍選択に関するタグ（`select`タグ）内の`class`に`js-book-select`があることを確認する（2箇所）

4番目の手順に関する参考画像（以下の画像のような形で参考書籍を2つにし、書籍をそれぞれ選んでください）
<img width="925" alt="スクリーンショット 2023-02-07 17 02 31" src="https://user-images.githubusercontent.com/77523896/217186584-ad76bdf9-828a-4966-b334-06a8cd9c3f83.png">

5~8番目の手順に関する動画（以下のような形で確認をお願いします）

https://user-images.githubusercontent.com/77523896/217188444-c4eda1a5-5aa5-495f-8890-39dda516639f.mov

## Screenshot
### 変更前
複数箇所で`id`が使用されている

<img width="1036" alt="スクリーンショット 2023-02-07 13 30 05" src="https://user-images.githubusercontent.com/77523896/217158569-c23937d0-e3f7-4610-a8bb-b43917b570e7.png">

<img width="1038" alt="スクリーンショット 2023-02-07 13 30 36" src="https://user-images.githubusercontent.com/77523896/217158580-f19212b9-fb5a-4bdc-9504-cd9db0a00d3f.png">

### 変更後
`id`から`class`に変更

<img width="1036" alt="スクリーンショット 2023-02-07 13 26 29" src="https://user-images.githubusercontent.com/77523896/217158681-13bb5580-e5c3-48ca-b4dc-0a52d3434a1c.png">

<img width="1032" alt="スクリーンショット 2023-02-07 13 27 28" src="https://user-images.githubusercontent.com/77523896/217158716-4b433b98-a967-4df7-8fcf-e18b35ad37bd.png">
