### PR TITLE
日報作成ページにMac以外の環境用ショートカットキーを表示する

### DIFF
--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -76,7 +76,7 @@
               class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
               data: { 'preview': '.js-preview' }
             .a-textarea-bottom-note__banner
-              | 途中保存は「command + s」 マメに保存しよう。
+              | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー


### PR DESCRIPTION
## Issue

- #6121

## 概要

日報作成ページにWindowsやLinuxからアクセスした時に、途中保存のショートカットキーとして[Ctrl + s]を表示します。

## 変更確認方法

1. `bug/show-shortcut-key-to-wip-for-non-mac`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. Mac以外(Windows等)で日報作成ページ(`/reports/new`)にアクセス
Windows等の環境を所持していない場合は開発者ツールからUserAgentを切り替えて確認して下さい(変更後のスクリーンショットで切り替えています)
4. 途中保存のショートカットキーを確認する


## Screenshot

### 変更前

![スクリーンショット_2023-01-27_142042](https://user-images.githubusercontent.com/69447745/218227840-cdfebd80-8876-4c48-a1e3-f4a68bf930f4.png)

### 変更後

<img width="600" alt="image" src="https://user-images.githubusercontent.com/69447745/218228134-33aeb9cf-5286-4ead-824b-414d0115d573.png">
