### PR TITLE
Flakyなテストを2個直す

### DIFF
--- a/app/controllers/api/footprints_controller.rb
+++ b/app/controllers/api/footprints_controller.rb
@@ -2,9 +2,10 @@
 
 class API::FootprintsController < API::BaseController
   def index
-    if params[:footprintable_type].present?
-      footprintable.footprints.create_or_find_by(user: current_user) if footprintable.user != current_user
-      @footprints = footprintable.footprints.with_avatar.order(created_at: :desc)
+    footprintable_data = footprintable
+    if params[:footprintable_type].present? && footprintable_data.present?
+      footprintable_data.footprints.create_or_find_by(user: current_user) if footprintable_data.user != current_user
+      @footprints = footprintable_data.footprints.with_avatar.order(created_at: :desc)
       @footprint_total_count = @footprints.size
     else
       head :bad_request
@@ -14,6 +15,6 @@ class API::FootprintsController < API::BaseController
   private
 
   def footprintable
-    params[:footprintable_type].constantize.find(params[:footprintable_id])
+    params[:footprintable_type].constantize.find_by(id: params[:footprintable_id])
   end
 end

--- a/app/controllers/api/footprints_controller.rb
+++ b/app/controllers/api/footprints_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class API::FootprintsController < API::BaseController
-  before_action :footprintable
+  before_action :footprintable, only: %i[index]
 
   def index
     if @footprintable.present?

--- a/app/controllers/api/footprints_controller.rb
+++ b/app/controllers/api/footprints_controller.rb
@@ -3,7 +3,7 @@
 class API::FootprintsController < API::BaseController
   def index
     footprintable_data = footprintable
-    if params[:footprintable_type].present? && footprintable_data.present?
+    if footprintable_data.present?
       footprintable_data.footprints.create_or_find_by(user: current_user) if footprintable_data.user != current_user
       @footprints = footprintable_data.footprints.with_avatar.order(created_at: :desc)
       @footprint_total_count = @footprints.size
@@ -15,6 +15,8 @@ class API::FootprintsController < API::BaseController
   private
 
   def footprintable
+    return if params[:footprintable_type].nil?
+
     params[:footprintable_type].constantize.find_by(id: params[:footprintable_id])
   end
 end

--- a/app/controllers/api/footprints_controller.rb
+++ b/app/controllers/api/footprints_controller.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class API::FootprintsController < API::BaseController
+  before_action :footprintable
+
   def index
-    footprintable_data = footprintable
-    if footprintable_data.present?
-      footprintable_data.footprints.create_or_find_by(user: current_user) if footprintable_data.user != current_user
-      @footprints = footprintable_data.footprints.with_avatar.order(created_at: :desc)
+    if @footprintable.present?
+      @footprintable.footprints.create_or_find_by(user: current_user) if @footprintable.user != current_user
+      @footprints = @footprintable.footprints.with_avatar.order(created_at: :desc)
       @footprint_total_count = @footprints.size
     else
       head :bad_request
@@ -15,8 +16,10 @@ class API::FootprintsController < API::BaseController
   private
 
   def footprintable
-    return if params[:footprintable_type].nil?
-
-    params[:footprintable_type].constantize.find_by(id: params[:footprintable_id])
+    @footprintable = if params[:footprintable_type].nil?
+                       nil
+                     else
+                       params[:footprintable_type].constantize.find_by(id: params[:footprintable_id])
+                     end
   end
 end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -125,17 +125,17 @@ class AnnouncementsTest < ApplicationSystemTestCase
 
     assert has_no_button? '公開'
     click_button '作成'
-    assert_text 'お知らせを作成しました'
+    assert page.has_css?('p.flash__message', text: 'お知らせを作成しました')
 
     visit_with_auth '/notifications', 'hatsuno'
-    assert_text 'お知らせ「タイトルtest」'
+    assert page.has_text? 'お知らせ「タイトルtest」'
 
     visit_with_auth '/announcements', 'komagata'
     page.find('h2', text: 'タイトルtest').click_on
     accept_confirm do
       click_link '削除'
     end
-    assert_text 'お知らせを削除しました'
+    assert page.has_css?('p.flash__message', text: 'お知らせを削除しました')
 
     visit_with_auth '/notifications', 'hatsuno'
     assert_no_text 'お知らせ「タイトルtest」'

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -125,7 +125,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
 
     assert has_no_button? '公開'
     click_button '作成'
-    assert page.has_css?('p.flash__message', text: 'お知らせを作成しました')
+    assert has_css?('p.flash__message', text: 'お知らせを作成しました')
 
     visit_with_auth '/notifications', 'hatsuno'
     assert_text 'お知らせ「タイトルtest」'
@@ -135,7 +135,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '削除'
     end
-    assert page.has_css?('p.flash__message', text: 'お知らせを削除しました')
+    assert has_css?('p.flash__message', text: 'お知らせを削除しました')
 
     visit_with_auth '/notifications', 'hatsuno'
     assert_no_text 'お知らせ「タイトルtest」'

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -131,7 +131,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせ「タイトルtest」'
 
     visit_with_auth '/announcements', 'komagata'
-    click_on 'タイトルtest'
+    page.find('h2', text: 'タイトルtest').click_on
     accept_confirm do
       click_link '削除'
     end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -132,7 +132,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
 
     visit_with_auth '/announcements', 'komagata'
     click_on 'タイトルtest'
-    page.accept_confirm do
+    accept_confirm do
       click_link '削除'
     end
     assert page.has_css?('p.flash__message', text: 'お知らせを削除しました')

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -128,11 +128,11 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert page.has_css?('p.flash__message', text: 'お知らせを作成しました')
 
     visit_with_auth '/notifications', 'hatsuno'
-    assert page.has_text? 'お知らせ「タイトルtest」'
+    assert_text 'お知らせ「タイトルtest」'
 
     visit_with_auth '/announcements', 'komagata'
-    page.find('h2', text: 'タイトルtest').click_on
-    accept_confirm do
+    click_on 'タイトルtest'
+    page.accept_confirm do
       click_link '削除'
     end
     assert page.has_css?('p.flash__message', text: 'お知らせを削除しました')

--- a/test/system/notification/graduation_test.rb
+++ b/test/system/notification/graduation_test.rb
@@ -19,6 +19,7 @@ class Notification::GraduationTest < ApplicationSystemTestCase
     accept_confirm do
       find('.a-button.is-sm.is-danger.is-block', text: '卒業にする').click
     end
+    page.has_css?('p.flash__message', text: 'ユーザー情報を更新しました。')
     logout
 
     visit_with_auth '/notifications', 'mentormentaro'

--- a/test/system/notification/graduation_test.rb
+++ b/test/system/notification/graduation_test.rb
@@ -19,7 +19,7 @@ class Notification::GraduationTest < ApplicationSystemTestCase
     accept_confirm do
       find('.a-button.is-sm.is-danger.is-block', text: '卒業にする').click
     end
-    page.has_css?('p.flash__message', text: 'ユーザー情報を更新しました。')
+    has_css?('p.flash__message', text: 'ユーザー情報を更新しました。')
     logout
 
     visit_with_auth '/notifications', 'mentormentaro'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5908

## 概要
### 1. test/system/announcements_test.rb
`delete announcement with notification`のテストで、以下のAPIエラーと`お知らせを削除しました`のメッセージが表示されないエラーが発生していた。

```bash
Error:
AnnouncementsTest#test_delete_announcement_with_notification:
ActiveRecord::RecordNotFound: Couldn't find Announcement with 'id'=966683407
    app/controllers/api/footprints_controller.rb:17:in `footprintable'
    app/controllers/api/footprints_controller.rb:6:in `index'
```
=>こちらのfootprint APIエラーは、お知らせ詳細ページで叩かれているが、お知らせレコードが作成されていないタイミングでAPIが叩かれてしまう場合があるため、footprint APIで`nil`の場合は処理を実行されないように修正（`find`メソッドだとレコードないとエラーになるため`find_by`を利用する）。

```bash
Failure:
AnnouncementsTest#test_delete_announcement_with_notification [/Users/moooo/repo/bootcamp/test/system/announcements_test.rb:144]:
expected to find text "お知らせを削除しました" in "お知らせ\nプラクティス\n65\n日報・ブログ\n57\n提出物\n13\nQ&A\nDocs\nユーザー\nイベント\nヘルプ\n1\n相談\nメンター\n管理者\nメンターモード\nすべて\nお知らせ\nプラクティス\n日報\n提出物\nQ&A\nDocs\nイベント\nユーザー\nMe\n6\n通知\nお知らせ\nお知らせ作成\nWIP\nwipのお知らせ\nkomagata (Komagata Masaki)\nお知らせ作成中\nコメント（0）\nお知らせの検索結果テスト用\nkomagata (Komagata Masaki)\n公開\n2018年05月20日(日) 09:00\nコメント（0）\n後から公開されたお知らせ\nkomagata (Komagata Masaki)\n公開\n2018年01月11日(木) 09:00\nコメント（0）\n現役生にのみ通知するお知らせ\nmachida (Machida Teppei)\n公開\n2018年01月04日(木) 09:00\nコメント（0）\n生徒からのお知らせ\nkimura (Kimura Tadasi)\n公開\n2018年01月03日(水) 09:00\nコメント（0）\nテストのお知らせ\nmachida (Machida Teppei)\n公開\n2018年01月03日(水) 09:00\nコメント（0）\nお知らせ2\nmachida (Machida Teppei)\n公開\n2018年01月02日(火) 09:00\nコメント（0）\nお知らせ1\nkomagata (Komagata Masaki)\n公開\n2018年01月01日(月) 09:00\nコメント（1）\nホームページ\nブログ\n参考書籍\nGitHub Projects\nグッズ購入\nアンチハラスメントポリシー\n利用規約\nプライバシーポリシー\n特定商取引法に基づく表記\nコース一覧\n企業一覧\n#fjordbootcamp\nFjord Choice\nFBC Contributors\nBuzzcord\nDiscordBotF\nFjord Inc.2012 - 2023"
```
=> こちらはページの読み込みが完了していなかったり、お知らせが削除されていなかったりしたため、flashメッセージが含まれる要素を待機するようにすることで、お知らせレコードの作成、削除を保証する。

（10/10成功）

### 2. test/system/notification/graduation_test.rb
```bash
Failure:
Notification::GraduationTest#test_notify_mentor_when_student_graduate [~/bootcamp/test/system/notification/graduation_test.rb:26]:
expected to find text "🎉️ kimuraさんが卒業しました！" in "未読\n🎉 sotugyouさんが卒業しました。\n2023年02月13日(月) 22:12"
```
=>卒業が反映されていないタイミングでお知らせ確認しにいっているため、flashメッセージが含まれる要素を待機することで卒業ステータスになることを保証した。（10/10成功）

## 変更確認方法

1. `feature/fix-flaky-tests`をローカルに取り込む
2.  `bin/rails test test/system/notification/graduation_test.rb`を実行する
3.  `bin/rails test test/system/announcements_test.rb:125`を実行する

## Screenshot
テスト修正のためなし
### 変更前

### 変更後

