### PR TITLE
Docsの作成通知をactive_deliveryに置き換える

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ Metrics/ClassLength:
     - app/controllers/products_controller.rb
     - app/controllers/reports_controller.rb
     - app/controllers/users_controller.rb
+    - app/mailers/activity_mailer.rb
     - app/models/event.rb
     - app/models/notification.rb
     - app/models/notification_facade.rb

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -11,6 +11,7 @@ class ActivityMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
     @announcement = params[:announcement] if params&.key?(:announcement)
     @question = params[:question] if params&.key?(:question)
     @mentionable = params[:mentionable] if params&.key?(:mentionable)
+    @page = params[:page] if params&.key?(:page)
   end
 
   # required params: sender, receiver
@@ -153,6 +154,23 @@ class ActivityMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
       kind: Notification.kinds[:mentioned]
     )
     subject = "[FBC] #{@mentionable.where_mention}で#{@mentionable.sender.login_name}さんからメンションがありました。"
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
+
+  # required params: page, receiver
+  def create_page(args = {})
+    @receiver ||= args[:receiver]
+    @page ||= args[:page]
+
+    @user = @receiver
+    @link_url = notification_redirector_url(
+      link: "/pages/#{@page.id}",
+      kind: Notification.kinds[:create_pages]
+    )
+    subject = "[FBC] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActivityMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
+class ActivityMailer < ApplicationMailer
   helper ApplicationHelper
   include Rails.application.routes.url_helpers
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -96,14 +96,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: subject
   end
 
-  # required params: page, receiver
-  def create_page
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/pages/#{@page.id}")
-    subject = "[FBC] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
-    mail to: @user.email, subject: subject
-  end
-
   # required params: report, receiver
   def following_report
     @user = @receiver

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -82,16 +82,6 @@ class NotificationFacade
     ).moved_up_event_waiting_user.deliver_later(wait: 5)
   end
 
-  def self.create_page(page, receiver)
-    ActivityNotifier.with(page: page, receiver: receiver).create_page.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      page: page,
-      receiver: receiver
-    ).create_page.deliver_later(wait: 5)
-  end
-
   def self.chose_correct_answer(answer, receiver)
     Notification.chose_correct_answer(answer, receiver)
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/models/page_notifier.rb
+++ b/app/models/page_notifier.rb
@@ -15,7 +15,7 @@ class PageNotifier
   def send_notification(page)
     receivers = User.where(retired_on: nil, graduated_on: nil, adviser: false, trainee: false)
     receivers.each do |receiver|
-      NotificationFacade.create_page(page, receiver) if page.sender != receiver
+      ActivityDelivery.with(receiver: receiver, page: page).notify(:create_page) if page.sender != receiver
     end
   end
 

--- a/app/views/activity_mailer/create_page.html.slim
+++ b/app/views/activity_mailer/create_page.html.slim
@@ -1,0 +1,2 @@
+= render '/notification_mailer/notification_mailer_template', title: "#{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。", link_url: @link_url, link_text: 'このDocsへ' do
+  = md2html(@page.body)

--- a/app/views/notification_mailer/create_page.html.slim
+++ b/app/views/notification_mailer/create_page.html.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: "#{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。", link_url: notification_url(@notification), link_text: 'このDocsへ' do
-  = md2html(@page.body)

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -126,4 +126,27 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:retired)
     end
   end
+
+  test '.notify(:create_page)' do
+    params = {
+      page: pages(:page4),
+      receiver: users(:hatsuno)
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:create_page, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:create_page, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:create_page)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:create_page)
+    end
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -65,26 +65,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/はじめて/, email.body.to_s)
   end
 
-  test 'create_page' do
-    page = pages(:page4)
-    create_page = notifications(:notification_create_page)
-    mailer = NotificationMailer.with(
-      page: page,
-      receiver: create_page.user
-    ).create_page
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['hatsuno@fjord.jp'], email.to
-    assert_equal '[FBC] komagataさんがDocsにBootcampの作業のページを投稿しました。', email.subject
-    assert_match(/Bootcamp/, email.body.to_s)
-  end
-
   test 'watching_notification' do
     watch = watches(:report1_watch_kimura)
     watching = notifications(:notification_watching)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -60,4 +60,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(mentionable: mentionable, receiver: receiver).mentioned
   end
+
+  def create_page
+    page = Page.find(ActiveRecord::FixtureSet.identify(:page4))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:hatsuno))
+
+    ActivityMailer.with(sender: page.user, receiver: receiver, page: page).create_page
+  end
 end


### PR DESCRIPTION
## Issue

- #5888

## 概要
Docsの作成通知を`NotificationFacade`から`ActivityDelivery`に置き換えました。
active_delivery経由で送信されるDocsの作成通知は、サイト内通知とメール通知の2種類となります。

## 変更確認方法

1. `feature/replace_notification_on_docs_creation_with_active_delivery`をローカルに取り込む
2. `bin/setup` を実行する
3. `bin/rails s` でサーバーを立ち上げる
4. `mentormentaro`でログインし、Docsを作成する
5. `kimura`でログインし、投稿したDocsに関するサイト内通知が届いていることを確認する
6. http://localhost:3000/letter_opener/ にアクセスし、`Refresh`ボタンを押す
7. `kimura@fjord.jp`に、投稿したDocsに関するメール通知が届いているか確認する

## Screenshot
通知処理の置き換えとなるため、画面上の変更はありません。

### サイト内通知
（例）`kimura`でログインした場合
<img width="244" alt="スクリーンショット 2023-02-12 22 57 11" src="https://user-images.githubusercontent.com/77523896/218315397-7a38278a-3d7d-4229-81da-b42876aca797.png">

### メール通知
（例）`kimura`のメール通知
<img width="1083" alt="スクリーンショット 2023-02-12 22 57 53" src="https://user-images.githubusercontent.com/77523896/218315410-b428c070-3802-47c9-86bd-3e17568164f3.png">
