### PR TITLE
研修生が提出物を提出した時のアドバイザーへの通知をnewspaper化する

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -54,6 +54,7 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.update(product_params)
+      Newspaper.publish(:product_update, @product)
       redirect_to @product, notice: notice_message(@product, :update)
       notice_another_mentor_assined_as_checker
       notice_product_update if @product.checker_id.present?

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -20,10 +20,7 @@ class ProductCallbacks
 
     unless product.wip
       notify_watching_mentors product
-      if product.user.trainee? && product.user.company
-        notify_advisers product
-        create_advisers_watch product
-      end
+      create_advisers_watch product if product.user.trainee? && product.user.company
     end
 
     Cache.delete_unchecked_product_count
@@ -63,14 +60,6 @@ class ProductCallbacks
     send_notification(
       product: product,
       receivers: mentors,
-      message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
-    )
-  end
-
-  def notify_advisers(product)
-    send_notification(
-      product: product,
-      receivers: product.user.company.advisers,
       message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
     )
   end

--- a/app/models/product_notifier.rb
+++ b/app/models/product_notifier.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ProductNotifier
+  def call(product)
+    return if product.wip
+
+    notify_advisers product if product.user.trainee? && product.user.company
+  end
+
+  private
+
+  def notify_advisers(product)
+    send_notification(
+      product: product,
+      receivers: product.user.company.advisers,
+      message: "#{product.user.login_name}さんが#{product.title}を提出しました。"
+    )
+  end
+
+  def send_notification(product:, receivers:, message:)
+    receivers.each do |receiver|
+      NotificationFacade.submitted(product, receiver, message)
+    end
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -38,4 +38,8 @@ Rails.configuration.to_prepare do
   page_notifier = PageNotifier.new
   Newspaper.subscribe(:page_create, page_notifier)
   Newspaper.subscribe(:page_update, page_notifier)
+
+  product_notifier = ProductNotifier.new
+  Newspaper.subscribe(:product_create, product_notifier)
+  Newspaper.subscribe(:product_update, product_notifier)
 end


### PR DESCRIPTION
## Issue

- #6108 

## 概要

研修生が提出物を提出したときにアドバイザーへの通知が行われますが、その処理をnewspaperを使用する処理に置き換えました。以前はcallbackを使用していました。

## 変更確認方法

1. ` feature/use-newspaper-to-notify-advisors-when-creating-products`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. `kensyu`でログインする
3. 任意のプラクティス(Terminalの基礎を覚えるなど)で提出物を提出する
3. `senpai`でログインする
4. `/notifications`で`kensyu`の提出通知を確認する
5. `/letter_opener`で`kensyu`の提出通知を確認する

## Screenshot

通知内容は変更前後で変わりません

![image](https://user-images.githubusercontent.com/69447745/218373656-427899e6-c645-4f74-99be-751e49ee7e5a.png)
