### PR TITLE
日報一覧の投稿者名のカッコ内を名前ではなく「名前（カナ）」に変更

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -83,7 +83,7 @@ module UserDecorator
   end
 
   def long_name
-    "#{login_name} (#{name})"
+    "#{name} (#{name_kana})"
   end
 
   def enrollment_period

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -28,7 +28,7 @@ class UserDecoratorTest < ActiveSupport::TestCase
   end
 
   test '#long_name' do
-    assert_equal 'hajime (Hajime Tayo)', @student_user.long_name
+    assert_equal 'Hajime Tayo (ハジメ タヨ)', @student_user.long_name
   end
 
   test '#enrollment_period' do

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -211,9 +211,12 @@ class AnnouncementsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'show user full_name next to user login_name' do
-    visit_with_auth "/announcements/#{announcements(:announcement1).id}", 'kimura'
-    assert_text 'komagata (Komagata Masaki)'
+  test 'show user name_kana next to user name' do
+    announcement = announcements(:announcement1)
+    user = announcement.user
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
+    visit_with_auth "/announcements/#{announcement.id}", 'kimura'
+    assert_text decorated_user.long_name
   end
 
   test 'show comment count' do

--- a/test/system/bookmark/talks_test.rb
+++ b/test/system/bookmark/talks_test.rb
@@ -6,11 +6,12 @@ class Bookmark::TalkTest < ApplicationSystemTestCase
   setup do
     @talk = talks(:talk1)
     @user = @talk.user
+    @decorated_user = ActiveDecorator::Decorator.instance.decorate(@user)
   end
 
   test 'show talk bookmark on lists' do
     visit_with_auth '/current_user/bookmarks', 'komagata'
-    assert_text "#{@user.login_name} (#{@user.name}) さんの相談部屋"
+    assert_text "#{@decorated_user.long_name} さんの相談部屋"
   end
 
   test 'show active button when bookmarked talk' do
@@ -32,7 +33,7 @@ class Bookmark::TalkTest < ApplicationSystemTestCase
     assert_no_selector '#bookmark-button.is-inactive'
 
     visit '/current_user/bookmarks'
-    assert_text "#{@user.login_name} (#{@user.name}) さんの相談部屋"
+    assert_text "#{@decorated_user.long_name} さんの相談部屋"
   end
 
   test 'unbookmark talk' do
@@ -43,7 +44,7 @@ class Bookmark::TalkTest < ApplicationSystemTestCase
     assert_no_selector '#bookmark-button.is-active'
 
     visit '/current_user/bookmarks'
-    assert_no_text "#{@user.login_name} (#{@user.name}) さんの相談部屋"
+    assert_no_text "#{@decorated_user.long_name} さんの相談部屋"
   end
 
   test 'hide bookmark button when mentor login' do

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -93,14 +93,16 @@ class BookmarksTest < ApplicationSystemTestCase
   end
 
   test 'delete bookmark from bookmarks' do
+    user = @report.user
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth report_path(@report), 'komagata'
     assert_text 'Bookmark中'
     visit current_user_bookmarks_path
-    assert_text 'komagata (Komagata Masaki) さんの相談部屋'
+    assert_text "#{decorated_user.long_name} さんの相談部屋"
     find(:css, '#spec-edit-mode').set(true)
     assert_selector '.card-list-item__option'
     first('#bookmark-button').click
-    assert_no_text 'komagata (Komagata Masaki) さんの相談部屋'
+    assert_no_text "#{decorated_user.long_name} さんの相談部屋"
     visit report_path(@report)
     assert_text 'Bookmark'
   end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -359,14 +359,17 @@ class EventsTest < ApplicationSystemTestCase
     assert_text 'Watch中'
   end
 
-  test 'show user full_name next to user login_name' do
-    visit_with_auth event_path(events(:event2)), 'kimura'
-    assert_text 'komagata (Komagata Masaki)'
+  test 'show user name_kana next to user name' do
+    event = events(:event2)
+    user = event.user
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
+    visit_with_auth event_path(event), 'kimura'
+    assert_text decorated_user.long_name
   end
 
   test 'show user full name on list page' do
     visit_with_auth '/events', 'kimura'
-    assert_text 'komagata (Komagata Masaki)'
+    assert_text 'Komagata Masaki (コマガタ マサキ)'
   end
 
   test 'show pagination' do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -307,7 +307,8 @@ class HomeTest < ApplicationSystemTestCase
     find_link pages(:page1).title
     assert_text I18n.l pages(:page1).created_at, format: :long
     user = talks(:talk1).user
-    find_link "#{user.login_name} (#{user.name}) さんの相談部屋"
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
+    find_link "#{decorated_user.long_name} さんの相談部屋"
     reports.each do |report|
       find_link reports(report).title
       assert_text I18n.l reports(report).reported_on, format: :long

--- a/test/system/mentor/home_test.rb
+++ b/test/system/mentor/home_test.rb
@@ -6,8 +6,8 @@ class Mentor::HomeTest < ApplicationSystemTestCase
   test 'GET /mentor' do
     visit_with_auth '/mentor', 'komagata'
     assert_equal 'メンターページ | FBC', title
-    assert_no_text 'jobseeker (就活 のぞむ)'
-    assert_text 'muryou (Muryou Nosuke)'
+    assert_no_text '就活 のぞむ (シュウカツ ノゾム)'
+    assert_text 'Muryou Nosuke (ムリョウ ノスケ)'
   end
 
   test 'accessed by non-mentor users' do

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -391,9 +391,12 @@ class ProductsTest < ApplicationSystemTestCase
     assert_not page.has_css?('.pagination')
   end
 
-  test 'show user full_name next to user login_name' do
-    visit_with_auth "/products/#{products(:product1).id}", 'kimura'
-    assert_text 'mentormentaro (メンタ 麺太郎)'
+  test 'show user name_kana next to name' do
+    product = products(:product1)
+    visit_with_auth "/products/#{product.id}", 'kimura'
+    user = product.user
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
+    assert_text decorated_user.long_name
   end
 
   test 'notice accessibility to open products on products index' do

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -56,8 +56,9 @@ class TalksTest < ApplicationSystemTestCase
   end
 
   test 'admin can access user talk page from talks page' do
-    talks(:talk7).update!(updated_at: Time.current) # user: kimura
-    user = users(:kimura)
+    talk = talks(:talk7)
+    talk.update!(updated_at: Time.current)
+    user = talk.user
     decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth '/talks', 'komagata'
     click_link "#{decorated_user.long_name} さんの相談部屋"

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -40,6 +40,7 @@ class TalksTest < ApplicationSystemTestCase
 
   test 'a talk room is shown up on unreplied tab when users except admin comments there' do
     user = users(:kimura)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')
@@ -51,18 +52,21 @@ class TalksTest < ApplicationSystemTestCase
     logout
     visit_with_auth '/talks', 'komagata'
     find('.page-tabs__item-link', text: '未返信').click
-    assert_text "#{user.login_name} (#{user.name}) さんの相談部屋"
+    assert_text "#{decorated_user.long_name} さんの相談部屋"
   end
 
   test 'admin can access user talk page from talks page' do
     talks(:talk7).update!(updated_at: Time.current) # user: kimura
+    user = users(:kimura)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth '/talks', 'komagata'
-    click_link 'kimura (Kimura Tadasi) さんの相談部屋'
+    click_link "#{decorated_user.long_name} さんの相談部屋"
     assert_selector '.page-header__title', text: 'kimura'
   end
 
   test 'a talk room is removed from unreplied tab when admin comments there' do
     user = users(:with_hyphen)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth "/talks/#{user.talk.id}", 'komagata'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'test')
@@ -72,43 +76,55 @@ class TalksTest < ApplicationSystemTestCase
     click_button 'コメントする'
     visit '/talks'
     find('.page-tabs__item-link', text: '未返信').click
-    assert_no_text "#{user.login_name} (#{user.name}) さんの相談部屋"
+    assert_no_text "#{decorated_user.long_name} さんの相談部屋"
   end
 
   test 'a list of current students is displayed' do
+    user = users(:hajime)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth '/talks?target=student_and_trainee', 'komagata'
     find('#talks.loaded', wait: 10)
-    assert_text 'hajime (Hajime Tayo) さんの相談部屋'
+    assert_text "#{decorated_user.long_name} さんの相談部屋"
   end
 
   test 'a list of graduates is displayed' do
+    user = users(:sotugyou)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth '/talks?target=graduate', 'komagata'
     find('#talks.loaded', wait: 10)
-    assert_text 'sotugyou (卒業 太郎) さんの相談部屋'
+    assert_text "#{decorated_user.long_name} さんの相談部屋"
   end
 
   test 'a list of advisers is displayed' do
+    user = users(:advijirou)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth '/talks?target=adviser', 'komagata'
     find('#talks.loaded', wait: 10)
-    assert_text 'advijirou (アドバイ 次郎) さんの相談部屋'
+    assert_text "#{decorated_user.long_name} さんの相談部屋"
   end
 
   test 'a list of mentors is displayed' do
+    user = users(:machida)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth '/talks?target=mentor', 'komagata'
     find('#talks.loaded', wait: 10)
-    assert_text 'machida (Machida Teppei) さんの相談部屋'
+    assert_text "#{decorated_user.long_name} さんの相談部屋"
   end
 
   test 'a list of trainees is displayed' do
+    user = users(:kensyu)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth '/talks?target=trainee', 'komagata'
     find('#talks.loaded', wait: 10)
-    assert_text 'kensyu (Kensyu Seiko) さんの相談部屋'
+    assert_text "#{decorated_user.long_name} さんの相談部屋"
   end
 
   test 'a list of retire users is displayed' do
+    user = users(:yameo)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     visit_with_auth '/talks?target=retired', 'komagata'
     find('#talks.loaded', wait: 10)
-    assert_text 'yameo (辞目 辞目夫) さんの相談部屋'
+    assert_text "#{decorated_user.long_name} さんの相談部屋"
   end
 
   test 'both public and private information is displayed' do


### PR DESCRIPTION
## Issue

- #6137

## 概要
日報一覧の投稿者名のカッコ内を名前ではなく「名前（カナ）」にしました。
今回修正した箇所が `user_decorator.rb` で共通化されている `long_name` メソッドに対してとなるため、このメソッドを用いて名前の表示を行なっていた画面全てが影響を受けます。

町田さんより

> もし、この部分が共通化されていて、他の部分も同様に変更されてしまう場合、それでOKです。

とコメントいただいているため、問題ないとに認識しています。

また、 `long_name` メソッドは使用箇所が多くメソッド名を見直すと修正が必要な影響範囲が広がるため、メソッドの処理のみ修正し、名前はそのままとしました。

テストについては元々のテストで使用されていたfixtureからuserを呼び出せる場合は、active_decoratorのメソッドを使用してテストをするように置き換え、fixtureが使用されていなかった箇所は名前をベタ書きのままで修正しました。
※ `test/system/talks_test.rb` に関してはテスト箇所が多く、変数に置き換えた方が今後のメンテもやりやすいのではと考えfixtureを使用する形で修正しました。

## 変更確認方法

1. `feature/display_user_name_with_kana`をローカルに取り込む
2. http://localhost:3000/ を開き、「日報・ブログ」一覧を開く
3. 投稿者名の表記が「名前（カナ）」になっていることを確認

## Screenshot

### 変更前
<img width="586" alt="ユーザー名_before" src="https://user-images.githubusercontent.com/76797372/218496830-02910313-068d-40f4-858a-64759eaae97e.png">

### 変更後
<img width="644" alt="フルネーム_after" src="https://user-images.githubusercontent.com/76797372/218496882-b8ca47b8-d4d7-4e68-8786-26fbcaf1a0bd.png">

