### PR TITLE
プラクティス作成のタイトルにプレイスホルダをつける

### DIFF
--- a/app/views/mentor/home/index.html.slim
+++ b/app/views/mentor/home/index.html.slim
@@ -9,3 +9,4 @@ header.page-header
 = render 'mentor/mentor_page_tabs'
 
 div(data-vue="WorriedUsers")
+ 

--- a/app/views/practices/_form.html.slim
+++ b/app/views/practices/_form.html.slim
@@ -4,7 +4,7 @@
     .row
       .col-md-6.col-xs-12
         = f.label :title, class: 'a-form-label is-required'
-        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'HTMLの基本を理解する'
+        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'JavaScript 入門'
   .form-item
     = f.label :categories, class: 'a-form-label is-required'
     .checkboxes


### PR DESCRIPTION
## Issue

- #6026

## 概要

 プラクティス作成のタイトルにプレースホルダが欲しい。

## 変更確認方法

1. ブランチ'feature/show-placeholder-practice-creation-title'をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる

## Screenshot

### 変更前
<img width="1384" alt="スクリーンショット 2023-02-15 6 04 22" src="https://user-images.githubusercontent.com/18245840/218869973-214ba840-5da0-4a39-884f-689234c61c98.png">

 
### 変更後
<img width="1387" alt="スクリーンショット 2023-02-15 6 06 17" src="https://user-images.githubusercontent.com/18245840/218870065-701b9482-b27e-47e4-bc1a-c05b20ae725f.png">


