### PR TITLE
プラクティス作成のタイトルにプレイスホルダをつける

### DIFF
--- a/app/views/mentor/home/index.html.slim
+++ b/app/views/mentor/home/index.html.slim
@@ -9,4 +9,3 @@ header.page-header
 = render 'mentor/mentor_page_tabs'
 
 div(data-vue="WorriedUsers")
- 

--- a/app/views/mentor/home/index.html.slim
+++ b/app/views/mentor/home/index.html.slim
@@ -9,3 +9,4 @@ header.page-header
 = render 'mentor/mentor_page_tabs'
 
 div(data-vue="WorriedUsers")
+ 

--- a/app/views/practices/_form.html.slim
+++ b/app/views/practices/_form.html.slim
@@ -4,7 +4,7 @@
     .row
       .col-md-6.col-xs-12
         = f.label :title, class: 'a-form-label is-required'
-        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'HTMLの基本を理解する'
+        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'JavaScript 入門'
   .form-item
     = f.label :categories, class: 'a-form-label is-required'
     .checkboxes


### PR DESCRIPTION
## Issue

-  #6026

## 概要

プラクティス作成のタイトルに’Javascript'のプレースホルダをつける

## 変更確認方法

1. ブランチ'feature/show-placeholder-practice-creation-title'をローカルに取り込む
2. bin/rails sでローカル環境を立ち上げる


## Screenshot

### 変更前
<img width="1384" alt="スクリーンショット 2023-02-15 6 04 22" src="https://user-images.githubusercontent.com/18245840/218872460-8d3cb8f5-c8ab-46d3-b82d-aafbd300a66a.png">

### 変更後
<img width="1387" alt="スクリーンショット 2023-02-15 6 06 17" src="https://user-images.githubusercontent.com/18245840/218872500-fe589b33-4c25-4e3d-b4dd-d30ae1d29e1e.png">
