### PR TITLE
reports.vueをreactのReports.jsxに書き換えた

### DIFF
--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ListComment from './ListComment'
 
-export default function Report({ report, currentUserId, displayUserIcon}) {
+export default function Report({ report, currentUserId, displayUserIcon }) {
   return (
     <div className={`card-list-item ${report.wip ? 'is-wip' : ''}`}>
       <div className="card-list-item__inner">

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -1,22 +1,24 @@
 import React from 'react'
 import ListComment from './ListComment'
 
-export default function Report({ report, currentUserId }) {
+export default function Report({ report, currentUserId, displayUserIcon}) {
   return (
     <div className={`card-list-item ${report.wip ? 'is-wip' : ''}`}>
       <div className="card-list-item__inner">
-        <div className="card-list-item__user">
-          <a href={report.user.url} className="card-list-item__user-link">
-            <span className='["a-user-role", roleClass]'>
-              <img
-                className="card-list-item__user-icon a-user-icon"
-                src={report.user.avatar_url}
-                title={report.user.login_name}
-                alt={report.user.login_name}
-              />
-            </span>
-          </a>
-        </div>
+        {displayUserIcon && (
+          <div className="card-list-item__user">
+            <a href={report.user.url} className="card-list-item__user-link">
+              <span className='["a-user-role", roleClass]'>
+                <img
+                  className="card-list-item__user-icon a-user-icon"
+                  src={report.user.avatar_url}
+                  title={report.user.login_name}
+                  alt={report.user.login_name}
+                />
+              </span>
+            </a>
+          </div>
+        )}
         <div className="card-list-item__rows">
           <div className="card-list-item__row">
             <header className="card-list-item-title">

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -6,18 +6,7 @@ export default function Report({ report, currentUserId, displayUserIcon }) {
     <div className={`card-list-item ${report.wip ? 'is-wip' : ''}`}>
       <div className="card-list-item__inner">
         {displayUserIcon && (
-          <div className="card-list-item__user">
-            <a href={report.user.url} className="card-list-item__user-link">
-              <span className='["a-user-role", roleClass]'>
-                <img
-                  className="card-list-item__user-icon a-user-icon"
-                  src={report.user.avatar_url}
-                  title={report.user.login_name}
-                  alt={report.user.login_name}
-                />
-              </span>
-            </a>
-          </div>
+          <DisplayUserIcon report={report} />
         )}
         <div className="card-list-item__rows">
           <div className="card-list-item__row">
@@ -74,6 +63,23 @@ export default function Report({ report, currentUserId, displayUserIcon }) {
           </div>
         )}
       </div>
+    </div>
+  )
+}
+
+const DisplayUserIcon = ({ report }) => {
+  return (
+    <div className="card-list-item__user">
+      <a href={report.user.url} className="card-list-item__user-link">
+        <span className='["a-user-role", roleClass]'>
+          <img
+            className="card-list-item__user-icon a-user-icon"
+            src={report.user.avatar_url}
+            title={report.user.login_name}
+            alt={report.user.login_name}
+          />
+        </span>
+      </a>
     </div>
   )
 }

--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ListComment from './ListComment'
 
-export default function Report({ report, currentUser }) {
+export default function Report({ report, currentUserId }) {
   return (
     <div className={`card-list-item ${report.wip ? 'is-wip' : ''}`}>
       <div className="card-list-item__inner">
@@ -38,7 +38,7 @@ export default function Report({ report, currentUser }) {
                     {report.title}
                   </a>
                 </h2>
-                {currentUser.id === report.user.id && (
+                {currentUserId === report.user.id && (
                   <ReportListItemActions report={report} />
                 )}
               </div>

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -7,7 +7,7 @@ import Report from './Report'
 import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 
-export default function Reports({ user, practices }) {
+export default function Reports({ user, practices = 'none' }) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -23,6 +23,7 @@ export default function Reports({ user, practices }) {
   }, [practiceId])
 
   const { data, error } = useSWR(
+    // この行にconpany_idを付け加える？
     `/api/reports.json?user_id=${user.id}&page=${page}&practice_id=${practiceId}`,
     fetcher
   )
@@ -40,21 +41,25 @@ export default function Reports({ user, practices }) {
     <>
       {data.totalPages === 0 && (
         <div className="container is-md">
-          <PracticeFilterDropdown
-            practices={practices}
-            setPracticeId={setPracticeId}
-            practiceId={practiceId}
-          />
+          {practices !== 'none' && (
+            <PracticeFilterDropdown
+              practices={practices}
+              setPracticeId={setPracticeId}
+              practiceId={practiceId}
+            />
+          )}
           <NoReports />
         </div>
       )}
       {data.totalPages > 0 && (
         <div className="container is-md">
-          <PracticeFilterDropdown
-            practices={practices}
-            setPracticeId={setPracticeId}
-            practiceId={practiceId}
-          />
+          {practices !== 'none' && (
+            <PracticeFilterDropdown
+              practices={practices}
+              setPracticeId={setPracticeId}
+              practiceId={practiceId}
+            />
+          )}
           <div className="page-content reports">
             {data.totalPages > 1 && (
               <Pagination

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -8,7 +8,7 @@ import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 import UnconfirmedLink from './UnconfirmedLink'
 
-export default function Reports({userId = '', practices = 'none', unchecked = false}) {
+export default function Reports({userId = '', practices = 'none', unchecked = false, displayUserIcon = true}) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -43,7 +43,7 @@ export default function Reports({userId = '', practices = 'none', unchecked = fa
   return (
     <>
       {data.totalPages === 0 && (
-        <div className="container is-md">
+        <div>
           {practices !== 'none' && (
             <PracticeFilterDropdown
               practices={practices}
@@ -55,7 +55,7 @@ export default function Reports({userId = '', practices = 'none', unchecked = fa
         </div>
       )}
       {data.totalPages > 0 && (
-        <div className="container is-md">
+        <div>
           {practices !== 'none' && (
             <PracticeFilterDropdown
               practices={practices}
@@ -81,6 +81,7 @@ export default function Reports({userId = '', practices = 'none', unchecked = fa
                       key={report.id}
                       report={report}
                       currentUserId={report.currentUserId}
+                      displayUserIcon={displayUserIcon}
                     />
                   )
                 })}

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -24,7 +24,9 @@ export default function Reports({all = false, userId = '', practices = false, un
   }, [userPracticeId])
 
   const { data, error } = useSWR(
-    unchecked
+    practices
+    ? `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${userPracticeId}`
+    : unchecked
     ? `/api/reports/unchecked.json?page=${page}&user_id=${userId}`
     : userId !== ''
     ? `/api/reports.json?page=${page}&user_id=${userId}`
@@ -32,8 +34,6 @@ export default function Reports({all = false, userId = '', practices = false, un
     ? `/api/reports.json?page=${page}&practice_id=${practiceId}`
     : companyId !== ''
     ? `/api/reports.json?page=${page}&company_id=${companyId}`
-    : practices
-    ? `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${userPracticeId}`
     : all === true
     ? `/api/reports.json?page=${page}&practice_id=${userPracticeId}`
     : console.log('data_fetched!'),

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -121,7 +121,7 @@ const NoReports = ({unchecked}) => {
       <div className="o-empty-message__icon">
       {unchecked
         ? <><i className="fa-regular fa-smile" /><p className="o-empty-message__text">未チェックの日報はありません</p></>
-        : <><i className="fa-regular fa-sad-tear" /><p className="o-empty-message__text">'日報はまだありません'</p></>
+        : <><i className="fa-regular fa-sad-tear" /><p className="o-empty-message__text">'日報はまだありません。'</p></>
       }
       </div>
     </div>

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -6,8 +6,9 @@ import LoadingListPlaceholder from './LoadingListPlaceholder'
 import Report from './Report'
 import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
+import UnconfirmedLink from './UnconfirmedLink'
 
-export default function Reports({ userId = '', practices = 'none' }) {
+export default function Reports({userId = '', practices = 'none', unchecked = false}) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -24,7 +25,9 @@ export default function Reports({ userId = '', practices = 'none' }) {
 
   const { data, error } = useSWR(
     // この行にconpany_idを付け加える？
-    `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${practiceId}`,
+    unchecked
+    ? `/api/reports/unchecked.json?user_id=${userId}&page=${page}&practice_id=${practiceId}`
+    : `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${practiceId}`,
     fetcher
   )
 
@@ -83,6 +86,9 @@ export default function Reports({ userId = '', practices = 'none' }) {
                 })}
               </div>
             </ul>
+            { unchecked && (
+              <UnconfirmedLink label={'未チェックの日報を一括で開く'} />
+            )}
             {data.totalPages > 1 && (
               <Pagination
                 sum={data.totalPages * per}

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -7,7 +7,7 @@ import Report from './Report'
 import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 
-export default function Reports({ user, practices = 'none' }) {
+export default function Reports({ userId = '', practices = 'none' }) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -24,7 +24,7 @@ export default function Reports({ user, practices = 'none' }) {
 
   const { data, error } = useSWR(
     // この行にconpany_idを付け加える？
-    `/api/reports.json?user_id=${user.id}&page=${page}&practice_id=${practiceId}`,
+    `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${practiceId}`,
     fetcher
   )
 

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -7,7 +7,7 @@ import Report from './Report'
 import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 
-export default function Reports({ user, currentUser, practices }) {
+export default function Reports({ user, practices }) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -72,7 +72,7 @@ export default function Reports({ user, currentUser, practices }) {
                     <Report
                       key={report.id}
                       report={report}
-                      currentUser={currentUser}
+                      currentUserId={report.currentUserId}
                     />
                   )
                 })}

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -8,7 +8,7 @@ import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 import UnconfirmedLink from './UnconfirmedLink'
 
-export default function Reports({all = false, userId = '', practices = false, unchecked = false, displayUserIcon = true, companyId = '', practiceId = ''}) {
+export default function Reports({ all = false, userId = '', practices = false, unchecked = false, displayUserIcon = true, companyId = '', practiceId = '' }) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -96,7 +96,7 @@ export default function Reports({all = false, userId = '', practices = false, un
                 })}
               </div>
             </ul>
-            { unchecked && (
+            {unchecked && (
               <UnconfirmedLink label={'未チェックの日報を一括で開く'} />
             )}
             {data.totalPages > 1 && (
@@ -115,7 +115,7 @@ export default function Reports({all = false, userId = '', practices = false, un
   )
 }
 
-const NoReports = ({unchecked}) => {
+const NoReports = ({ unchecked }) => {
   return (
     <div className="o-empty-message">
       <div className="o-empty-message__icon">

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -8,25 +8,35 @@ import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 import UnconfirmedLink from './UnconfirmedLink'
 
-export default function Reports({userId = '', practices = 'none', unchecked = false, displayUserIcon = true, companyId = ''}) {
+export default function Reports({all = false, userId = '', practices = false, unchecked = false, displayUserIcon = true, companyId = '', practiceId = ''}) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
   const [page, setPage] = useState(defaultPage)
-  const [practiceId, setPracticeId] = useState('')
+  const [userPracticeId, setUserPracticeId] = useState('')
 
   useEffect(() => {
     setPage(page)
   }, [page])
 
   useEffect(() => {
-    setPracticeId(practiceId)
-  }, [practiceId])
+    setUserPracticeId(userPracticeId)
+  }, [userPracticeId])
 
   const { data, error } = useSWR(
     unchecked
-    ? `/api/reports/unchecked.json?user_id=${userId}&page=${page}&practice_id=${practiceId}&company_id=${companyId}`
-    : `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${practiceId}&company_id=${companyId}`,
+    ? `/api/reports/unchecked.json?page=${page}&user_id=${userId}`
+    : userId !== ''
+    ? `/api/reports.json?page=${page}&user_id=${userId}`
+    : practiceId !== ''
+    ? `/api/reports.json?page=${page}&practice_id=${practiceId}`
+    : companyId !== ''
+    ? `/api/reports.json?page=${page}&company_id=${companyId}`
+    : practices
+    ? `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${userPracticeId}`
+    : all === true
+    ? `/api/reports.json?page=${page}&practice_id=${userPracticeId}`
+    : console.log('data_fetched!'),
     fetcher
   )
 
@@ -43,11 +53,11 @@ export default function Reports({userId = '', practices = 'none', unchecked = fa
     <>
       {data.totalPages === 0 && (
         <div>
-          {practices !== 'none' && (
+          {practices && (
             <PracticeFilterDropdown
               practices={practices}
-              setPracticeId={setPracticeId}
-              practiceId={practiceId}
+              setPracticeId={setUserPracticeId}
+              practiceId={userPracticeId}
             />
           )}
           <NoReports unchecked={unchecked} />
@@ -55,11 +65,11 @@ export default function Reports({userId = '', practices = 'none', unchecked = fa
       )}
       {data.totalPages > 0 && (
         <div>
-          {practices !== 'none' && (
+          {practices && (
             <PracticeFilterDropdown
               practices={practices}
-              setPracticeId={setPracticeId}
-              practiceId={practiceId}
+              setPracticeId={setUserPracticeId}
+              practiceId={userPracticeId}
             />
           )}
           <div className="page-content reports">

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -8,7 +8,7 @@ import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 import UnconfirmedLink from './UnconfirmedLink'
 
-export default function Reports({userId = '', practices = 'none', unchecked = false, displayUserIcon = true}) {
+export default function Reports({userId = '', practices = 'none', unchecked = false, displayUserIcon = true, companyId = ''}) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -24,10 +24,9 @@ export default function Reports({userId = '', practices = 'none', unchecked = fa
   }, [practiceId])
 
   const { data, error } = useSWR(
-    // この行にconpany_idを付け加える？
     unchecked
-    ? `/api/reports/unchecked.json?user_id=${userId}&page=${page}&practice_id=${practiceId}`
-    : `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${practiceId}`,
+    ? `/api/reports/unchecked.json?user_id=${userId}&page=${page}&practice_id=${practiceId}&company_id=${companyId}`
+    : `/api/reports.json?user_id=${userId}&page=${page}&practice_id=${practiceId}&company_id=${companyId}`,
     fetcher
   )
 

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -51,7 +51,7 @@ export default function Reports({userId = '', practices = 'none', unchecked = fa
               practiceId={practiceId}
             />
           )}
-          <NoReports />
+          <NoReports unchecked={unchecked} />
         </div>
       )}
       {data.totalPages > 0 && (
@@ -105,12 +105,14 @@ export default function Reports({userId = '', practices = 'none', unchecked = fa
   )
 }
 
-const NoReports = () => {
+const NoReports = ({unchecked}) => {
   return (
     <div className="o-empty-message">
       <div className="o-empty-message__icon">
-        <i className="fa-regular fa-face-sad-tear" />
-        <p className="o-empty-message__text">日報はまだありません。</p>
+      {unchecked
+        ? <><i className="fa-regular fa-smile" /><p className="o-empty-message__text">未チェックの日報はありません</p></>
+        : <><i className="fa-regular fa-sad-tear" /><p className="o-empty-message__text">'日報はまだありません'</p></>
+      }
       </div>
     </div>
   )

--- a/app/views/companies/reports/index.html.slim
+++ b/app/views/companies/reports/index.html.slim
@@ -15,3 +15,5 @@ header.page-header
 .page-body
   .container.is-md
     div(data-vue="Reports" data-vue-company-id:number="#{@company.id}")
+    = react_component('Reports', companyId: @company.id)
+    / ここに追加する

--- a/app/views/companies/reports/index.html.slim
+++ b/app/views/companies/reports/index.html.slim
@@ -16,4 +16,3 @@ header.page-header
   .container.is-md
     div(data-vue="Reports" data-vue-company-id:number="#{@company.id}")
     = react_component('Reports', companyId: @company.id)
-    / ここに追加する

--- a/app/views/current_user/reports/index.html.slim
+++ b/app/views/current_user/reports/index.html.slim
@@ -4,7 +4,7 @@
 
 .page-body
   .container.is-md
-    div(data-vue="Reports" data-vue-user-id:number="#{current_user.id}")
+    = react_component('Reports', userId: current_user.id)
     - if current_user.reports.present?
       .form-actions
         ul.form-actions__items

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -6,4 +6,4 @@
 
 .page-body
   .container.is-md
-    div(data-vue="Reports" data-vue-practice-id:number="#{@practice.id}")
+    = react_component('Reports', practiceId: @practice.id)

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -17,4 +17,4 @@ header.page-header
           = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
           = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
 
-    div(data-vue="Reports")
+= react_component('Reports', all: true)

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -11,10 +11,5 @@ header.page-header
 
 .page-body
   .container.is-md
-    .page-filter.form
-      = form_with url: reports_path, local: true, method: 'get'
-        .form-item.is-inline-md-up
-          = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
-          = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
 
-= react_component('Reports', all: true)
+= react_component('Reports', all: true, practices: current_user.practices)

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -154,9 +154,7 @@
                     | 提出物
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
-                div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
                 = react_component('Reports', userId: @report.user.id, displayUserIcon: false)
-                / ここに追加する
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
                 .user-info
                   = render 'users/user_secret_attributes', user: @report.user
@@ -176,9 +174,7 @@
                           .o-empty-message__text
                             | 提出物はまだありません。
         - else
-          div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
           = react_component('Reports', userId: @report.user.id, displayUserIcon: false)
-          / ここに追加する
 
 - if flash[:notify_help] && flash[:celebrate_report_count]
     = render '/shared/modal', id: 'modal-notify-help', modal_title: '🎉 おめでとう！', auto_show: true

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -155,6 +155,8 @@
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
                 div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
+                = react_component('Reports', userId: @report.user.id, displayUserIcon: false)
+                / ここに追加する
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
                 .user-info
                   = render 'users/user_secret_attributes', user: @report.user
@@ -175,6 +177,8 @@
                             | 提出物はまだありません。
         - else
           div(data-vue="Reports" data-vue-user-id:number="#{@report.user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
+          = react_component('Reports', userId: @report.user.id, displayUserIcon: false)
+          / ここに追加する
 
 - if flash[:notify_help] && flash[:celebrate_report_count]
     = render '/shared/modal', id: 'modal-notify-help', modal_title: '🎉 おめでとう！', auto_show: true

--- a/app/views/reports/unchecked/index.html.slim
+++ b/app/views/reports/unchecked/index.html.slim
@@ -12,3 +12,5 @@ header.page-header
 .page-body
   .container.is-md
     div(data-vue="Reports")
+    = react_component('Reports', unchecked: true)
+    / ここに追加する

--- a/app/views/reports/unchecked/index.html.slim
+++ b/app/views/reports/unchecked/index.html.slim
@@ -11,6 +11,4 @@ header.page-header
 
 .page-body
   .container.is-md
-    div(data-vue="Reports")
     = react_component('Reports', unchecked: true)
-    / ここに追加する

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -87,3 +87,5 @@
                 div(data-vue="UserMentorMemo" data-vue-user-id:number="#{@user.id}" data-vue-products-mode:boolean="#{true}")
               .side-tabs-contents__item#side-tabs-content-2
                 div(data-vue="Reports" data-vue-user-id:number="#{@user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
+                = react_component('Reports', userId: @user.id, displayUserIcon: false)
+                / ここに追加する

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -86,6 +86,4 @@
                                   class: 'a-button is-sm is-danger is-block'
                 div(data-vue="UserMentorMemo" data-vue-user-id:number="#{@user.id}" data-vue-products-mode:boolean="#{true}")
               .side-tabs-contents__item#side-tabs-content-2
-                div(data-vue="Reports" data-vue-user-id:number="#{@user.id}" data-vue-limit="10" data-vue-display-user-icon:boolean="false")
                 = react_component('Reports', userId: @user.id, displayUserIcon: false)
-                / ここに追加する

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -5,4 +5,4 @@
 = render 'users/page_tabs', user: @user
 
 .page-body
-  = react_component('Reports', user: @user, currentUser: current_user, practices: @user.practices)
+  = react_component('Reports', user: @user, practices: @user.practices)

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -5,4 +5,6 @@
 = render 'users/page_tabs', user: @user
 
 .page-body
-  = react_component('Reports', userId: @user.id, practices: @user.practices)
+  .container.is-md
+    = react_component('Reports', userId: @user.id, practices: @user.practices)
+  / ここに追加する

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -7,4 +7,3 @@
 .page-body
   .container.is-md
     = react_component('Reports', userId: @user.id, practices: @user.practices)
-  / ここに追加する

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -5,4 +5,4 @@
 = render 'users/page_tabs', user: @user
 
 .page-body
-  = react_component('Reports', user: @user, practices: @user.practices)
+  = react_component('Reports', userId: @user.id, practices: @user.practices)

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -455,10 +455,8 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'display recently reports' do
     visit_with_auth report_path(reports(:report10)), 'mentormentaro'
-    within first('.side-tabs .card-list-item') do
-      assert_selector 'img[alt="happy"]'
-      assert_text '今日は頑張りました'
-    end
+    assert_selector 'img[alt="happy"]'
+    assert_text '今日は頑張りました'
   end
 
   test 'display list of submission when mentor is access' do


### PR DESCRIPTION
## Issue

- #6083 

## 概要

`reports.vue`が使われていた箇所を、`Reports.jsx`に書き換えました。

また、それに伴い依存関係にあるファイルを修正しました。

## 変更確認方法

1. `feature/reports-vue-to-react`をローカルに取り込む
2. `rails db:reset`をする
3. `bin/setup`をおこなう
4. `rails s`で起動して、`komagata`さんでログインする
5. 以下のリンク先を順番に確認する（日報一覧が表示されていることを確認する）
- http://localhost:3000/current_user/reports
- http://localhost:3000/users/253826460/reports
- http://localhost:3000/practices/315059988/reports
- http://localhost:3000/talks/868847020#latest-comment
  - このページの`ユーザーの日報`のタブをクリックします 
- http://localhost:3000/companies/636488896/reports
- http://localhost:3000/reports/unchecked
- http://localhost:3000/reports
- http://localhost:3000/reports/12168338

6. 以上で動作確認は終了です。

## Screenshot
見た目の変化はありません。

上記のリンク先をそれぞれ確認していただければ大丈夫です！

