### PR TITLE
ページ作成をドキュメント作成に変更

### DIFF
--- a/app/views/pages/new.html.slim
+++ b/app/views/pages/new.html.slim
@@ -1,4 +1,4 @@
-- title 'ページ作成'
+- title 'ドキュメント作成'
 
 header.page-header
   .container


### PR DESCRIPTION
## Issue

- #6224 

## 概要

ページ作成画面(`/pages/new`)のタイトルを「ページ作成」から「ドキュメント作成」に変更しました。

## 変更確認方法

1. `feature/change-new-document-title`をローカルに取り込む
2. `rails s`でサーバーを起動
3. `localhost:3000`にアクセス
4. `kimura`でログイン
5. `/pages/new`にアクセス

## Screenshot

### 変更前
![issue_6224_before-1](https://user-images.githubusercontent.com/65595901/219843576-d7bf67ee-de81-46a8-ad5a-4e521fedab52.jpg)

![issue_6224_before-2](https://user-images.githubusercontent.com/65595901/219843586-516931da-f554-42bc-82d4-ff7f7d734b76.png)


### 変更後
![issue_6224_after-1](https://user-images.githubusercontent.com/65595901/219843591-f98e63c6-e6c6-4226-925e-3ec26e12a6f6.jpg)


![issue_6224_after-2](https://user-images.githubusercontent.com/65595901/219843599-2b40d9e0-431e-4752-a540-a0e6fac3b6a5.png)



