### PR TITLE
退会手続きページのタイトルから「休会」を外した

### DIFF
--- a/app/views/retirement/new.html.slim
+++ b/app/views/retirement/new.html.slim
@@ -1,4 +1,4 @@
-- title '退会・休会手続き'
+- title '退会手続き'
 
 header.page-header
   .container


### PR DESCRIPTION
## Issue

- #6147 

## 概要

退会手続きページのタイトルを「退会・休会手続き」から「退会手続き」に変更しました。
(休会手続きページが別にあるため)

## 変更確認方法

1. `feature/change-retirement-page-title`をローカルに取り込む
2. `rails s`でサーバーを起動
3. `localhost:3000`にアクセス
4. `kimura`でログイン
5. `/retirement/new`にアクセス

## Screenshot

### 変更前
![issue_6147_before-1](https://user-images.githubusercontent.com/65595901/219846437-53df3138-504c-476a-800c-5b98f3b72174.jpg)



### 変更後
![issue_6147_after-1](https://user-images.githubusercontent.com/65595901/219846445-ce070422-adbe-48f6-8745-15d199d854f9.jpg)
