### PR TITLE
fixturesのタイムゾーンの処理をto_fsからto_sに戻した

### DIFF
--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -4,114 +4,114 @@ product1:
   practice: practice1
   user: mentormentaro
   body: テストの提出物1です。
-  published_at: <%= (now - 60 * 60 * 24 * 1).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 1).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 1).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 1).to_s(:db) %>
 
 product2:
   practice: practice1
   user: kimura
   body: テストの提出物2です。
-  published_at: <%= (now - 60 * 60 * 24 * 2).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 2).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 2).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 2).to_s(:db) %>
 
 product3:
   practice: practice2
   user: sotugyou
   body: 確認済みの提出物
-  published_at: <%= (now - 60 * 60 * 24 * 3).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 3).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 3).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 3).to_s(:db) %>
 
 product4:
   practice: practice2
   user: mentormentaro
   body: テストの提出物4です。
-  published_at: <%= (now - 60 * 60 * 24 * 4).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 4).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 4).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 4).to_s(:db) %>
 
 product5:
   practice: practice2
   user: kimura
   body: テストの提出物5です。
-  published_at: <%= (now - 60 * 60 * 24 * 5).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 5).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 5).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 5).to_s(:db) %>
 
 product6:
   practice: practice3
   user: sotugyou
   body: 確認待ちの提出物
-  published_at: <%= (now - 60 * 60 * 24 * 6).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 6).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 6).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 6).to_s(:db) %>
 
 product7:
   practice: practice3
   user: mentormentaro
   body: テストの提出物7です。
-  published_at: <%= (now - 60 * 60 * 24 * 7).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 7).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 7).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 7).to_s(:db) %>
 
 product8:
   practice: practice3
   user: kimura
   body: テストの提出物8です。
-  published_at: <%= (now - 60 * 60 * 24 * 8).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 8).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 8).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 8).to_s(:db) %>
 
 product9:
   practice: practice4
   user: mentormentaro
   body: テストの提出物9です。
-  published_at: <%= (now - 60 * 60 * 24 * 9).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 9).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 9).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 9).to_s(:db) %>
 
 product10:
   practice: practice4
   user: kimura
   body: テストの提出物10です。
-  published_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
 
 product11:
   practice: practice2
   user: hatsuno
   body: テストの提出物11です。
-  published_at: <%= (now - 60 * 60 * 24 * 11).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 11).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 11).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 11).to_s(:db) %>
 
 product12:
   practice: practice5
   user: mentormentaro
   body: リアクションテスト
-  published_at: <%= (now - 60 * 60 * 24 * 12).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 12).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 12).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 12).to_s(:db) %>
 
 product13:
   practice: practice1
   user: kensyu
   body: 研修の提出物です。
-  published_at: <%= (now - 60 * 60 * 24 * 13).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 13).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 13).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 13).to_s(:db) %>
 
 <% (14..60).each do |i| %>
 product<%= i %>:
   practice: practice<%= i - 12 %>
   user: with_hyphen
   body: テストの提出物<%= i %>です。
-  published_at: <%= (now - i).to_fs(:db) %>
-  created_at: <%= (now - i).to_fs(:db) %>
+  published_at: <%= (now - i).to_s(:db) %>
+  created_at: <%= (now - i).to_s(:db) %>
 <% end %>
 
 product61:
   practice: practice1
   user: sumi
   body: テストの提出物61です。
-  published_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
-  created_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
 
 product62:
   practice: practice1
   user: take8
   body: テストの提出物62です。
-  published_at: <%= (now - 60 * 60 * 24 * 10).to_fs(:db) %>
+  published_at: <%= (now - 60 * 60 * 24 * 10).to_s(:db) %>
 
 product63:
   practice: practice6
@@ -129,8 +129,8 @@ product<%= 64 + i %>:
   practice: practice<%= 3 + i %>
   user: hatsuno
   body: <%= i+1 %>日前の提出物です。
-  published_at: <%= (i+1).day.ago.to_fs(:db) %>
-  created_at: <%= (i+1).day.ago.to_fs(:db) %>
+  published_at: <%= (i+1).day.ago.to_s(:db) %>
+  created_at: <%= (i+1).day.ago.to_s(:db) %>
 <% end %>
 
 product70:


### PR DESCRIPTION
## Issue

- Issue番号

## 概要
`db/fixtures/products.yml` のタイムゾーンに使用されているメソッドが `to_s` から `to_fs`に変更されているが、現在のRrailsのバージョンが `6.1.4.4` であり、rails7で推奨されている `to_fs` が `to_formated_s` のエイリアスに指定されていないためCIが落ちている。
一旦該当箇所を `to_s` に戻すPRを作成した。

以下は参考にしたコードです。
https://github.com/sampatbadhe/rails/blob/0055b72a3b83dddd2a5477719f479b3071509524/activesupport/lib/active_support/core_ext/time/conversions.rb#L61
