### PR TITLE
Watchしているものにコメントが来た通知をactive_deliveryに置き換えた

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -232,7 +232,6 @@ class ActivityMailer < ApplicationMailer
 
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
-
     message
   end
 end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -11,12 +11,9 @@ class ActivityMailer < ApplicationMailer
     @announcement = params[:announcement] if params&.key?(:announcement)
     @question = params[:question] if params&.key?(:question)
     @mentionable = params[:mentionable] if params&.key?(:mentionable)
-<<<<<<< HEAD
     @page = params[:page] if params&.key?(:page)
-=======
     @watchable = params[:watchable] if params&.key?(:watchable)
     @comment = params[:comment] if params&.key?(:comment)
->>>>>>> c705d3210 (active_delivery置き換えを行った)
   end
 
   # required params: sender, receiver

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -216,7 +216,7 @@ class ActivityMailer < ApplicationMailer
   end
 
   # required params: sender, comment, watchable
-  def watching_notification( args = {})
+  def watching_notification(args = {})
     # @sender ||= args[:sender]
     # @comment ||= args[:comment]
     # @watchable ||= args[:watchable]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -222,10 +222,12 @@ class ActivityMailer < ApplicationMailer
     @watchable ||= args[:watchable]
 
     @user = @receiver
-    link = "/#{@watchable.class.name.underscore.pluralize}/#{@watchable.id}"
-    @notification = @user.notifications.find_by(link: link)
-    action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
-    subject = "[FBC] #{@watchable.user.login_name}さんの【 #{@watchable.notification_title} 】に#{@sender.login_name}さんが#{action}しました。"
+    @link_url = notification_redirector_url(
+      link: @watchable.path,
+      kind: Notification.kinds[:watched]
+    )
+    @action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
+    subject = "[FBC] #{@watchable.user.login_name}さんの【 #{@watchable.notification_title} 】に#{@sender.login_name}さんが#{@action}しました。"
 
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -225,7 +225,7 @@ class ActivityMailer < ApplicationMailer
     link = "/#{@watchable.class.name.underscore.pluralize}/#{@watchable.id}"
     @notification = @user.notifications.find_by(link: link)
     action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
-    subject = "[FBC] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんが#{action}しました。"
+    subject = "[FBC] #{@watchable.user.login_name}さんの【 #{@watchable.notification_title} 】に#{@sender.login_name}さんが#{action}しました。"
 
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -216,7 +216,7 @@ class ActivityMailer < ApplicationMailer
   end
 
   # required params: sender, comment, watchable
-  def watching_notification(_args = {})
+  def watching_notification( args = {})
     # @sender ||= args[:sender]
     # @comment ||= args[:comment]
     # @watchable ||= args[:watchable]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -217,6 +217,7 @@ class ActivityMailer < ApplicationMailer
 
   # required params: sender, comment, watchable
   def watching_notification(args = {})
+    @receiver ||= args[:receiver]
     @sender ||= args[:sender]
     @comment ||= args[:comment]
     @watchable ||= args[:watchable]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -11,7 +11,12 @@ class ActivityMailer < ApplicationMailer
     @announcement = params[:announcement] if params&.key?(:announcement)
     @question = params[:question] if params&.key?(:question)
     @mentionable = params[:mentionable] if params&.key?(:mentionable)
+<<<<<<< HEAD
     @page = params[:page] if params&.key?(:page)
+=======
+    @watchable = params[:watchable] if params&.key?(:watchable)
+    @comment = params[:comment] if params&.key?(:comment)
+>>>>>>> c705d3210 (active_delivery置き換えを行った)
   end
 
   # required params: sender, receiver
@@ -206,6 +211,24 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:following_report]
     )
     subject = "[FBC] #{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！"
+
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
+
+  # required params: sender, comment, watchable
+  def watching_notification( args = {} )
+    # @sender ||= args[:sender]
+    # @comment ||= args[:comment]
+    # @watchable ||= args[:watchable]
+
+    @user = @receiver
+    link = "/#{@watchable.class.name.underscore.pluralize}/#{@watchable.id}"
+    @notification = @user.notifications.find_by(link: link)
+    action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
+    subject = "[FBC] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんが#{action}しました。"
 
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -217,9 +217,9 @@ class ActivityMailer < ApplicationMailer
 
   # required params: sender, comment, watchable
   def watching_notification(args = {})
-    # @sender ||= args[:sender]
-    # @comment ||= args[:comment]
-    # @watchable ||= args[:watchable]
+    @sender ||= args[:sender]
+    @comment ||= args[:comment]
+    @watchable ||= args[:watchable]
 
     @user = @receiver
     link = "/#{@watchable.class.name.underscore.pluralize}/#{@watchable.id}"

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -219,7 +219,7 @@ class ActivityMailer < ApplicationMailer
   end
 
   # required params: sender, comment, watchable
-  def watching_notification( args = {} )
+  def watching_notification(_args = {})
     # @sender ||= args[:sender]
     # @comment ||= args[:comment]
     # @watchable ||= args[:watchable]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -215,7 +215,7 @@ class ActivityMailer < ApplicationMailer
     message
   end
 
-  # required params: sender, comment, watchable
+  # required params: sender, comment, watchable, receiver
   def watching_notification(args = {})
     @receiver ||= args[:receiver]
     @sender ||= args[:sender]

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -14,7 +14,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     @announcement = params[:announcement]
     @question = params[:question]
     @report = params[:report]
-    @watchable = params[:watchable]
     @sender = params[:sender]
     @event = params[:event]
     @page = params[:page]

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -54,17 +54,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
          subject: "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
   end
 
-  # required params: watchable, receiver
-  def watching_notification
-    @sender = @watchable.user
-    @user = @receiver
-    link = "/#{@watchable.class.name.underscore.pluralize}/#{@watchable.id}"
-    @notification = @user.notifications.find_by(link: link)
-    action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
-    subject = "[FBC] #{@sender.login_name}さんの【 #{@watchable.notification_title} 】に#{@comment.user.login_name}さんが#{action}しました。"
-    mail to: @user.email, subject: subject
-  end
-
   # required params: sender, receiver
   def retired
     @user = @receiver

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,7 +7,7 @@ class Comment < ApplicationRecord
 
   belongs_to :user, touch: true
   belongs_to :commentable, polymorphic: true
-  after_create Comment::AfterCreateCallback.new
+  after_commit Comment::AfterCreateCallback.new
   after_update Comment::AfterUpdateCallback.new
   after_destroy Comment::AfterDestroyCallback.new
   alias sender user

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -46,7 +46,8 @@ class Comment::AfterCreateCallback
     watcher_ids.each do |watcher_id|
       if watcher_id != comment.sender.id && !mention_user_ids.include?(watcher_id)
         watcher = User.find_by(id: watcher_id)
-        NotificationFacade.watching_notification(watchable, watcher, comment)
+        sender = watchable.user
+        ActivityDelivery.with(watchable: watchable, receiver: watcher, comment: comment, sender: sender).notify(:watching_notification)
       end
     end
   end

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -48,7 +48,12 @@ class Comment::AfterCreateCallback
 
       watcher = User.find_by(id: watcher_id)
       sender = comment.user
-      ActivityDelivery.with(watchable: watchable, receiver: watcher, comment: comment, sender: sender).notify(:watching_notification)
+
+      ActivityDelivery.with(
+        watchable: watchable,
+        receiver: watcher,
+        comment: comment,
+        sender: sender).notify(:watching_notification)
     end
   end
 

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -47,7 +47,7 @@ class Comment::AfterCreateCallback
       next unless watcher_id != comment.sender.id && !mention_user_ids.include?(watcher_id)
 
       watcher = User.find_by(id: watcher_id)
-      sender = watchable.user
+      sender = comment.user
       ActivityDelivery.with(watchable: watchable, receiver: watcher, comment: comment, sender: sender).notify(:watching_notification)
     end
   end

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -44,11 +44,11 @@ class Comment::AfterCreateCallback
 
     watcher_ids = watchable.watches.pluck(:user_id)
     watcher_ids.each do |watcher_id|
-      if watcher_id != comment.sender.id && !mention_user_ids.include?(watcher_id)
-        watcher = User.find_by(id: watcher_id)
-        sender = watchable.user
-        ActivityDelivery.with(watchable: watchable, receiver: watcher, comment: comment, sender: sender).notify(:watching_notification)
-      end
+      next unless watcher_id != comment.sender.id && !mention_user_ids.include?(watcher_id)
+
+      watcher = User.find_by(id: watcher_id)
+      sender = watchable.user
+      ActivityDelivery.with(watchable: watchable, receiver: watcher, comment: comment, sender: sender).notify(:watching_notification)
     end
   end
 

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -53,7 +53,8 @@ class Comment::AfterCreateCallback
         watchable: watchable,
         receiver: watcher,
         comment: comment,
-        sender: sender).notify(:watching_notification)
+        sender: sender
+      ).notify(:watching_notification)
     end
   end
 

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -47,7 +47,7 @@ class Comment::AfterCreateCallback
       next unless watcher_id != comment.sender.id && !mention_user_ids.include?(watcher_id)
 
       watcher = User.find_by(id: watcher_id)
-      sender = comment.user
+      sender = comment.sender
 
       ActivityDelivery.with(
         watchable: watchable,

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Comment::AfterCreateCallback
-  def after_create(comment)
+  def after_commit(comment)
     if comment.commentable.class.include?(Watchable)
       create_watch(comment)
       notify_to_watching_user(comment)

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -27,17 +27,6 @@ class NotificationFacade
     ).first_report.deliver_later(wait: 5)
   end
 
-  def self.watching_notification(watchable, receiver, comment)
-    ActivityNotifier.with(watchable: watchable, receiver: receiver, comment: comment).watching_notification.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      watchable: watchable,
-      receiver: receiver,
-      comment: comment
-    ).watching_notification.deliver_later(wait: 5)
-  end
-
   def self.trainee_report(report, receiver)
     ActivityNotifier.with(report: report, receiver: receiver).trainee_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/models/notifier_to_watching_user.rb
+++ b/app/models/notifier_to_watching_user.rb
@@ -11,7 +11,13 @@ class NotifierToWatchingUser
     watcher_ids.each do |watcher_id|
       if watcher_id != answer.sender.id && !mention_user_ids.include?(watcher_id)
         watcher = User.find_by(id: watcher_id)
-        NotificationFacade.watching_notification(question, watcher, answer)
+        sender = answer.user
+
+        ActivityDelivery.with(
+          watchable: question, 
+          receiver: watcher, 
+          comment: answer, 
+          sender: sender).notify(:watching_notification)
       end
     end
   end

--- a/app/models/notifier_to_watching_user.rb
+++ b/app/models/notifier_to_watching_user.rb
@@ -9,16 +9,17 @@ class NotifierToWatchingUser
 
     watcher_ids = Watch.where(watchable_id: question.id).pluck(:user_id)
     watcher_ids.each do |watcher_id|
-      if watcher_id != answer.sender.id && !mention_user_ids.include?(watcher_id)
-        watcher = User.find_by(id: watcher_id)
-        sender = answer.user
+      next unless watcher_id != answer.sender.id && !mention_user_ids.include?(watcher_id)
 
-        ActivityDelivery.with(
-          watchable: question, 
-          receiver: watcher, 
-          comment: answer, 
-          sender: sender).notify(:watching_notification)
-      end
+      watcher = User.find_by(id: watcher_id)
+      sender = answer.user
+
+      ActivityDelivery.with(
+        watchable: question,
+        receiver: watcher,
+        comment: answer,
+        sender: sender
+      ).notify(:watching_notification)
     end
   end
 end

--- a/app/models/notifier_to_watching_user.rb
+++ b/app/models/notifier_to_watching_user.rb
@@ -12,7 +12,7 @@ class NotifierToWatchingUser
       next unless watcher_id != answer.sender.id && !mention_user_ids.include?(watcher_id)
 
       watcher = User.find_by(id: watcher_id)
-      sender = answer.user
+      sender = answer.sender
 
       ActivityDelivery.with(
         watchable: question,

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -312,6 +312,7 @@ class ActivityNotifier < ApplicationNotifier
     receiver = params[:receiver]
     sender = params[:sender]
     action = watchable.instance_of?(Question) ? '回答' : 'コメント'
+
     notification(
       body: "#{watchable.user.login_name}さんの【 #{watchable.notification_title} 】に#{sender.login_name}さんが#{action}しました。",
       kind: :watching,

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -310,7 +310,7 @@ class ActivityNotifier < ApplicationNotifier
     params.merge!(@params)
     watchable = params[:watchable]
     receiver = params[:receiver]
-    sender = params[:comment].user
+    sender = params[:sender]
     action = watchable.instance_of?(Question) ? '回答' : 'コメント'
     notification(
       body: "#{watchable.user.login_name}さんの【 #{watchable.notification_title} 】に#{sender.login_name}さんが#{action}しました。",

--- a/app/views/activity_mailer/watching_notification.html.slim
+++ b/app/views/activity_mailer/watching_notification.html.slim
@@ -1,9 +1,5 @@
-ruby:
-  is_question = @watchable.instance_of?(Question)
-  anchor_prefix = is_question ? 'answer_' : 'comment_'
-  action = is_question ? '回答' : 'コメント'
 = render '/notification_mailer/notification_mailer_template',
-  title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんが#{action}しました。",
-  link_url: notification_url(@notification, anchor: "#{anchor_prefix}#{@comment.id}"),
+  title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんが#{@action}しました。",
+  link_url: @link_url,
   link_text: "この#{@watchable.class.model_name.human}へ" do
   = md2html @comment.description

--- a/app/views/activity_mailer/watching_notification.html.slim
+++ b/app/views/activity_mailer/watching_notification.html.slim
@@ -1,0 +1,9 @@
+ruby:
+  is_question = @watchable.instance_of?(Question)
+  anchor_prefix = is_question ? 'answer_' : 'comment_'
+  action = is_question ? '回答' : 'コメント'
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんが#{action}しました。",
+  link_url: notification_url(@notification, anchor: "#{anchor_prefix}#{@comment.id}"),
+  link_text: "この#{@watchable.class.model_name.human}へ" do
+  = md2html @comment.description

--- a/app/views/notification_mailer/watching_notification.html.slim
+++ b/app/views/notification_mailer/watching_notification.html.slim
@@ -1,9 +1,0 @@
-ruby:
-  is_question = @watchable.instance_of?(Question)
-  anchor_prefix = is_question ? 'answer_' : 'comment_'
-  action = is_question ? '回答' : 'コメント'
-= render 'notification_mailer_template',
-  title: "#{@watchable.notification_title}に#{@comment.user.login_name}さんが#{action}しました。",
-  link_url: notification_url(@notification, anchor: "#{anchor_prefix}#{@comment.id}"),
-  link_text: "この#{@watchable.class.model_name.human}へ" do
-  = md2html @comment.description

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -173,4 +173,31 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:create_page)
     end
   end
+
+  test '.notify(:watching_notification)' do
+    watch = watches(:report1_watch_kimura)
+    watching = notifications(:notification_watching)
+    params = {
+      watchable: watch.watchable,
+      receiver: watching.user,
+      comment: comments(:comment1),
+      sender: comments(:comment1).user
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:watching_notification, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:watching_notification, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:watching_notification)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:watching_notification)
+    end
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -44,27 +44,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/はじめて/, email.body.to_s)
   end
 
-  test 'watching_notification' do
-    watch = watches(:report1_watch_kimura)
-    watching = notifications(:notification_watching)
-    mailer = NotificationMailer.with(
-      watchable: watch.watchable,
-      receiver: watching.user,
-      comment: comments(:comment1)
-    ).watching_notification
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['kimura@fjord.jp'], email.to
-    assert_equal '[FBC] komagataさんの【 「作業週1日目」の日報 】にmachidaさんがコメントしました。', email.subject
-    assert_match(/コメント/, email.body.to_s)
-  end
-
   test 'trainee_report' do
     report = reports(:report11)
     trainee_report = notifications(:notification_trainee_report)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -86,4 +86,18 @@ class ActivityMailerPreview < ActionMailer::Preview
       receiver: receiver
     ).following_report
   end
+
+  def watching_noitification
+    watchable = Report.find(ActiveRecord::FixtureSet.identify(:report1))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:kimura))
+    comment = Comment.find(ActiveRecord::FixtureSet.identify(:comment4))
+    sender = comment.user
+
+    ActivityMailer.with(
+      watchable: watchable,
+      receiver: receiver,
+      sender: sender,
+      comment: comment
+    ).watching_notification
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -36,18 +36,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.with(report: report, receiver: receiver).first_report
   end
 
-  def watching_noitification
-    watchable = Report.find(ActiveRecord::FixtureSet.identify(:report1))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:kimura))
-    comment = Comment.find(ActiveRecord::FixtureSet.identify(:comment4))
-
-    NotificationMailer.with(
-      watchable: watchable,
-      receiver: receiver,
-      comment: comment
-    ).watching_notification
-  end
-
   def retired
     sender = User.find(ActiveRecord::FixtureSet.identify(:yameo))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -102,17 +102,3 @@ class CommentTest < ActiveSupport::TestCase
     assert last_comment.certain_period_passed_since_the_last_comment_by_submitter?(5.days)
   end
 end
-
-# class ActiveJob::Base
-#   def queue_adapter
-#     @queue_adapter
-#   end
-
-#   def queue_adapter=(queue_adapter)
-#     @queue_adapter = queue_adapter = :inline
-#   end
-# end
-
-# ActiveJob::Base.queue_adapter = :inline
-# ActiveJob::Base.queue_adapter
-# => inline

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -49,7 +49,7 @@ class CommentTest < ActiveSupport::TestCase
   end
 
   test 'not notify mentor watching product of submitted when comment on product' do
-    perform_enqueued_jobs do 
+    perform_enqueued_jobs do
       Comment.create!(
         user: users(:mentormentaro),
         commentable: products(:product8),

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -47,11 +47,13 @@ class CommentTest < ActiveSupport::TestCase
   end
 
   test 'not notify mentor watching product of submitted when comment on product' do
+    default_notifications_count = users(:kimura).notifications.count
     Comment.create!(
       user: users(:mentormentaro),
       commentable: products(:product8),
       description: '提出物のコメントcreate'
     )
+    sleep 0.2 until users(:kimura).notifications.count == default_notifications_count + 1
     assert users(:kimura).notifications.exists?(
       kind: 'watching',
       sender: users(:mentormentaro),

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -165,14 +165,15 @@ class NotificationsTest < ApplicationSystemTestCase
     login_user 'hatsuno', 'testtest'
     report = create_report 'コメントと', '確認があった', false
 
-    visit_with_auth "/reports/#{report}", 'komagata'
-    visit "/reports/#{report}"
-    fill_in 'new_comment[description]', with: 'コメントと確認した'
-    click_button '確認OKにする'
-
-    visit_with_auth "/reports/#{report}", 'hatsuno'
-    find('.header-links__link.test-show-notifications').click
-    assert_text 'hatsunoさんの【 「コメントと」の日報 】にkomagataさんがコメントしました。'
+    perform_enqueued_jobs do
+      visit_with_auth "/reports/#{report}", 'komagata'
+      visit "/reports/#{report}"
+      fill_in 'new_comment[description]', with: 'コメントと確認した'
+      click_button '確認OKにする'
+      visit_with_auth "/reports/#{report}", 'hatsuno'
+      find('.header-links__link.test-show-notifications').click
+      assert_text 'hatsunoさんの【 「コメントと」の日報 】にkomagataさんがコメントしました。'
+    end
   end
 
   test 'show notification count' do


### PR DESCRIPTION
## Issue

- #5883

## 概要
watchしているものにコメントが来た通知をactivedelivery化しました。
見た目の変更はありません。

## 変更確認方法
1. `feature/use-active-delivery-notification-for-comments-on-watched-items` をローカルに取り込んでください。
2. ` $ foreman start -f Procfile.dev `でローカル環境を立ち上げてください。
3.  `kimura`でログインを行い、「後から公開されたお知らせ」(`http://localhost:3000/announcements/721644200`)をwatchしてください。

![スクリーンショット 2023-03-28 10 44 52](https://user-images.githubusercontent.com/81839214/228105457-350513e5-dee3-41ef-8837-acfea432b22f.png)

4. `mentormentaro`でログインを行い「後から公開されたお知らせ」(`http://localhost:3000/announcements/721644200`)にメンションをつけずにコメントをしてください。

![スクリーンショット 2023-03-28 10 47 35](https://user-images.githubusercontent.com/81839214/228105649-ab1df60f-fe65-439e-8c7c-9422aea3b14b.png)

5. 再度`kimura`でログインを行い、「後から公開されたお知らせ」に4で行ったコメントがついたという通知が来ていることを確認してください。

![スクリーンショット 2023-03-28 10 48 52](https://user-images.githubusercontent.com/81839214/228105901-4d80d92e-5538-4b84-8852-90fc88ee887c.png)

6. `http://localhost:3000/letter_opener/`にアクセスし、`kimura`に対して「後から公開されたお知らせ」に4で行ったコメントがついたというメール届いていることを確認してください。
![スクリーンショット 2023-03-28 10 50 04](https://user-images.githubusercontent.com/81839214/228106019-8b2767db-b488-49e4-a0e1-70882eb708a7.png)

## Screenshot
見た目の変更はありません。

