### PR TITLE
ブックマーク一覧の表示を変更

### DIFF
--- a/app/javascript/components/Bookmarks.jsx
+++ b/app/javascript/components/Bookmarks.jsx
@@ -116,9 +116,7 @@ const Bookmark = ({ bookmark, editable, _setEditable }) => {
               <div className="card-list-item__row">
                 <div className="card-list-item-meta">
                   <div className="card-list-item-meta__item">
-                    <a href={bookmark.authorUrl} className="a-user-name">
-                      {bookmark.author}
-                    </a>
+                    <a href={bookmark.authorUrl} className="a-user-name">{bookmark.authorLoginName}({bookmark.authorNameKana})</a>
                   </div>
                   <div className="card-list-item-meta__item">
                     <time className="a-meta" dateTime={bookmark.updated_at}>

--- a/app/javascript/components/Bookmarks.jsx
+++ b/app/javascript/components/Bookmarks.jsx
@@ -116,7 +116,9 @@ const Bookmark = ({ bookmark, editable, _setEditable }) => {
               <div className="card-list-item__row">
                 <div className="card-list-item-meta">
                   <div className="card-list-item-meta__item">
-                    <a href={bookmark.authorUrl} className="a-user-name">{bookmark.authorLoginName}({bookmark.authorNameKana})</a>
+                    <a href={bookmark.authorUrl} className="a-user-name">
+                      {bookmark.authorLoginName}({bookmark.authorNameKana})
+                    </a>
                   </div>
                   <div className="card-list-item-meta__item">
                     <time className="a-meta" dateTime={bookmark.updated_at}>

--- a/app/views/api/bookmarks/_bookmark.json.jbuilder
+++ b/app/views/api/bookmarks/_bookmark.json.jbuilder
@@ -4,7 +4,8 @@ json.id bookmark.id
 json.bookmarkable_id bookmark.bookmarkable_id
 json.modelName bookmark.bookmarkable_type
 json.modelNameI18n t("activerecord.models.#{bookmarkable.class.to_s.tableize.singularize}")
-json.author bookmarkable.user.name
+json.authorLoginName bookmarkable.user.login_name
+json.authorNameKana bookmarkable.user.name_kana
 json.authorUrl bookmarkable.user.url
 json.user bookmarkable.user, partial: "api/users/user", as: :user
 json.url polymorphic_url(bookmarkable)

--- a/test/system/current_user/bookmarks_test.rb
+++ b/test/system/current_user/bookmarks_test.rb
@@ -31,7 +31,7 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
     assert_text '作業週1日目'
     assert_selector '.card-list-item__label', text: '日報'
     assert_text '今日はローカルで怖話を動かしてみました。rbenv で ruby を動かすのは初めてだったので、色々手間取りました。'
-    assert_text 'Komagata Masaki'
+    assert_text 'komagata(コマガタ マサキ)'
     assert_text '2017年01月01日(日) 00:00'
   end
 


### PR DESCRIPTION
## Issue

- #6175 

## 概要
ブックマーク一覧(`/current_user/bookmarks`)の投稿者名の表示を`名前`から`ログイン名(カナ名)`に変更しました。

## 変更確認方法

1. `feature/change-bookmarks-display-name`をローカルに取り込む
2. `rails s`でサーバーを起動
3. `localhost:3000`にアクセス
4. `kimura`でログイン
5. `/current_user/bookmarks`にアクセス

## Screenshot

### 変更前
![issue_6175_before-1](https://user-images.githubusercontent.com/65595901/220828316-b3cf7167-5dfc-47e6-ae73-f3dc9c400cbc.jpg)


### 変更後
![issue_6175_after-1](https://user-images.githubusercontent.com/65595901/220828333-de69ffd4-5cbc-47e3-a190-b66f28cb4946.jpg)


