### PR TITLE
show画面でページネーションが表示されないように修正しました

### DIFF
--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -8,7 +8,7 @@ import Pagination from './Pagination'
 import PracticeFilterDropdown from './PracticeFilterDropdown'
 import UnconfirmedLink from './UnconfirmedLink'
 
-export default function Reports({ all = false, userId = '', practices = false, unchecked = false, displayUserIcon = true, companyId = '', practiceId = '' }) {
+export default function Reports({ all = false, userId = '', practices = false, unchecked = false, displayUserIcon = true, companyId = '', practiceId = '', displayPagination = true }) {
   const per = 20
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
@@ -73,7 +73,7 @@ export default function Reports({ all = false, userId = '', practices = false, u
             />
           )}
           <div className="page-content reports">
-            {data.totalPages > 1 && (
+            {data.totalPages > 1 && displayPagination && (
               <Pagination
                 sum={data.totalPages * per}
                 per={per}
@@ -99,7 +99,7 @@ export default function Reports({ all = false, userId = '', practices = false, u
             {unchecked && (
               <UnconfirmedLink label={'未チェックの日報を一括で開く'} />
             )}
-            {data.totalPages > 1 && (
+            {data.totalPages > 1 && displayPagination && (
               <Pagination
                 sum={data.totalPages * per}
                 per={per}

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -154,7 +154,7 @@
                     | 提出物
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
-                = react_component('Reports', userId: @report.user.id, displayUserIcon: false)
+                = react_component('Reports', userId: @report.user.id, displayUserIcon: false, displayPagination: false)
               .side-tabs-contents__item#side-tabs-content-2.is-only-mentor
                 .user-info
                   = render 'users/user_secret_attributes', user: @report.user
@@ -174,7 +174,7 @@
                           .o-empty-message__text
                             | 提出物はまだありません。
         - else
-          = react_component('Reports', userId: @report.user.id, displayUserIcon: false)
+          = react_component('Reports', userId: @report.user.id, displayUserIcon: false, displayPagination: false)
 
 - if flash[:notify_help] && flash[:celebrate_report_count]
     = render '/shared/modal', id: 'modal-notify-help', modal_title: '🎉 おめでとう！', auto_show: true

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -86,4 +86,4 @@
                                   class: 'a-button is-sm is-danger is-block'
                 div(data-vue="UserMentorMemo" data-vue-user-id:number="#{@user.id}" data-vue-products-mode:boolean="#{true}")
               .side-tabs-contents__item#side-tabs-content-2
-                = react_component('Reports', userId: @user.id, displayUserIcon: false)
+                = react_component('Reports', userId: @user.id, displayUserIcon: false, displayPagination: false)


### PR DESCRIPTION
## Issue

- #6083 

## 概要
#6236 のPull Requestにおいて、日報個別ページと相談部屋のshow画面で、ページネーションが表示されてしまっている問題を修正しました。

## 変更確認方法
1. feature/reports-vue-to-react`をローカルに取り込む
2. `rails db:reset`をする
3. `bin/setup`をおこなう
4. `rails s`で起動して、`komagata`さんでログインする
5. こちらのページでページネーションが表示されていないことを確認する。

- http://localhost:3000/reports/646578073
- http://localhost:3000/talks/335391287#latest-comment

## Screenshot

### 変更前

![image](https://user-images.githubusercontent.com/93074851/221147645-a194fdbf-7ae1-44b8-a8e3-313db770e302.png)

![image](https://user-images.githubusercontent.com/93074851/221147757-66dfa6a3-8965-43d3-89d4-9d2da7a5a3df.png)


### 変更後

![image](https://user-images.githubusercontent.com/93074851/221147197-a8761cc0-d22b-4e82-a033-91b94f771a1e.png)

![image](https://user-images.githubusercontent.com/93074851/221147278-4850351e-db47-4dc1-a906-53cd2bda96f4.png)

