### PR TITLE
プラクティスカテゴリーの削除ボタンを移動

### DIFF
--- a/app/assets/stylesheets/application/blocks/form/_form-actions.sass
+++ b/app/assets/stylesheets/application/blocks/form/_form-actions.sass
@@ -20,6 +20,8 @@
     justify-content: center
     flex-wrap: wrap
     position: relative
+    max-width: 45em
+    +margin(horizontal,  auto)
     &.is-ais-flex-start
       align-items: flex-start
   +media-breakpoint-down(sm)
@@ -43,7 +45,7 @@
       margin-bottom: 1rem
   &.is-main
     +media-breakpoint-up(md)
-      min-width: 20rem
+      min-width: 18rem
       .auth-form__body &
         min-width: 50%
     +media-breakpoint-down(sm)

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::CategoriesController < AdminController
-  before_action :set_category, only: %i[show edit update]
+  before_action :set_category, only: %i[show edit update destroy]
 
   def index; end
 
@@ -29,6 +29,11 @@ class Admin::CategoriesController < AdminController
     else
       render action: 'edit'
     end
+  end
+
+  def destroy
+    @category.destroy
+    redirect_to admin_categories_url, notice: 'カテゴリーを削除しました。'
   end
 
   private

--- a/app/javascript/components/Categories.jsx
+++ b/app/javascript/components/Categories.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import useSWR, { useSWRConfig } from 'swr'
+import useSWR from 'swr'
 import fetcher from '../fetcher'
-import Bootcamp from '../bootcamp'
 
 const Categories = () => {
   const { data, error } = useSWR(`/api/categories.json`, fetcher)
@@ -29,20 +28,6 @@ const Categories = () => {
 }
 
 const Category = ({ category }) => {
-  const { mutate } = useSWRConfig()
-
-  const destroy = (id) => {
-    if (window.confirm('本当によろしいですか？')) {
-      Bootcamp.delete(`/api/categories/${id}`)
-        .then((_response) => {
-          mutate('/api/categories.json')
-        })
-        .catch((error) => {
-          console.warn(error)
-        })
-    }
-  }
-
   return (
     <tr className="admin-table__item">
       <td className="admin-table__item-value">
@@ -57,13 +42,6 @@ const Category = ({ category }) => {
               className="a-button is-sm is-secondary is-icon spec-edit">
               <i className="fa-solid fa-pen" />
             </a>
-          </li>
-          <li>
-            <button
-              onClick={() => destroy(category.id)}
-              className="a-button is-sm is-danger is-icon js-delete">
-              <i className="fa-solid fa-trash-alt" />
-            </button>
           </li>
         </ul>
       </td>

--- a/app/views/admin/categories/_form.html.slim
+++ b/app/views/admin/categories/_form.html.slim
@@ -29,3 +29,6 @@
         = f.submit nil, class: 'a-button is-lg is-primary is-block'
       li.form-actions__item.is-sub
         = link_to 'キャンセル', admin_categories_path, class: 'a-button is-sm is-text'
+      - if category.id.present?
+        li.form-actions__item.is-muted
+          = link_to '削除', admin_category_path(category), method: :delete, data: { confirm: '本当によろしいですか？' }, class: 'a-button is-sm is-muted-text'

--- a/app/views/admin/categories/show.html.slim
+++ b/app/views/admin/categories/show.html.slim
@@ -49,6 +49,9 @@ header.page-header
                         = link_to edit_admin_category_path(@category), class: 'card-main-actions__action a-button is-sm is-secondary is-block' do
                           i.fa-solid.fa-pen
                           | 編集
+                      li.card-main-actions__item.is-sub
+                        = link_to '削除', admin_category_path(@category), method: :delete, data: { confirm: '本当によろしいですか？' }, class: 'card-main-actions__muted-action'
+
             .page-content-prev-next
               .page-content-prev-next__item
               .page-content-prev-next__item

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     resources :users, only: %i(index show edit update destroy) do
       resource :password, only: %i(edit update), controller: "users/password"
     end
-    resources :categories, except: %i(destroy)
+    resources :categories
     resources :practices, only: %i(index)
     resources :courses, except: %i(show destroy)
     resources :campaigns, only: %i(new create index edit update)

--- a/test/system/admin/categories_test.rb
+++ b/test/system/admin/categories_test.rb
@@ -52,12 +52,10 @@ class Admin::CategoriesTest < ApplicationSystemTestCase
   end
 
   test 'delete category' do
-    visit_with_auth '/admin/categories', 'komagata'
-    within('.admin-table__item:first-child') do
-      accept_confirm do
-        find('.js-delete').click
-      end
-    end
+    visit_with_auth "/admin/categories/#{categories(:category1).id}/edit", 'komagata'
+    click_on '削除'
+    page.driver.browser.switch_to.alert.accept
+    assert_text 'カテゴリーを削除しました。'
     assert_no_text '学習の準備'
   end
 end


### PR DESCRIPTION
## Issue

- #6208 

## 概要
プラクティスカテゴリーの削除ボタンを`admin/categories`から`/admin/categories/{ID}`と`/admin/categories/{ID}/edit`に移動しました。

## 変更確認方法

1. `feature/move-practice-category-delete-button`をローカルに取り込む
2. `rails s`でサーバーを起動
3. `localhost:3000`にアクセス
4. `komagata`でログイン
5. `/admin/categories/800674185`(「学習の準備」)にアクセス
6. `/admin/categories/800674185/edit`(「学習の準備」の編集画面)にアクセス

## Screenshot

### 変更前
`admin/categories`
![issue_6208_before-1](https://user-images.githubusercontent.com/65595901/221462768-9e436985-dce3-4ab7-8c10-03ee1e4213cc.jpg)

`/admin/categories/{ID}`
![issue_6208_before-2](https://user-images.githubusercontent.com/65595901/222317547-732c95e2-3760-4d75-9f22-e98bfbfef650.jpg)


`/admin/categories/{ID}/edit`
![issue_6208_before-2](https://user-images.githubusercontent.com/65595901/221462787-ee12736a-c8b2-4cfa-967b-92e7b1b937de.jpg)

### 変更後
`admin/categories`
![issue_6208_after-1](https://user-images.githubusercontent.com/65595901/221462806-3d30990c-0ff3-42c3-8b9a-266176e771f4.jpg)

`/admin/categories/{ID}`
![issue_6208_after-2](https://user-images.githubusercontent.com/65595901/222317574-7be2b140-6a12-45ab-95b1-0faef04a2c37.jpg)


`/admin/categories/{ID}/edit`

![issue_6208_after-3](https://user-images.githubusercontent.com/65595901/222317601-74400405-957e-4de5-9591-1c8ba0893f05.jpg)


