### PR TITLE
お試し延長一覧のボタンをタブ下に移動

### DIFF
--- a/app/views/admin/campaigns/new.html.slim
+++ b/app/views/admin/campaigns/new.html.slim
@@ -8,17 +8,19 @@ header.page-header
 
 = render 'admin/admin_page_tabs'
 
-.page-main
+main.page-main
   header.page-main-header
     .container
       .page-main-header__inner
-        h1.page-main-header__title
-          | お試し延長作成
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | お試し延長一覧
+        .page-main-header__start
+          h1.page-main-header__title
+            | お試し延長作成
+        .page-main-header__end
+          .page-header-actions
+            .page-header-actions__items
+              .page-header-actions__item
+                = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
+                  | お試し延長一覧
   .page-body
     .container.is-md
       = render 'form', campaign: @campaign

--- a/app/views/admin/campaigns/new.html.slim
+++ b/app/views/admin/campaigns/new.html.slim
@@ -5,11 +5,6 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         = title
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | お試し延長一覧
 
 = render 'admin/admin_page_tabs'
 
@@ -19,6 +14,11 @@ header.page-header
       .page-main-header__inner
         h1.page-main-header__title
           | お試し延長作成
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+            = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | お試し延長一覧
   .page-body
     .container.is-md
       = render 'form', campaign: @campaign


### PR DESCRIPTION
## Issue

- #6283

## 概要
お試し延長一覧のボタンをタブ下に移動しました。

## 変更確認方法

1. ブランチ`feature/relocate-extension-of-trial-period-list-button`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. ID`komagata`でログインして http://localhost:3000/admin/campaigns/new にアクセス。

## Screenshot

### 変更前
<img width="1362" alt="image" src="https://user-images.githubusercontent.com/83024928/223997226-14a4d62c-c5c0-4d56-b773-536d4f59babc.png">

### 変更後
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/83024928/223996866-c74aee53-89d5-4bb4-99d0-5be7278df25b.png">

