### PR TITLE
企業登録ページのタイトルを変更

### DIFF
--- a/app/views/admin/companies/edit.html.slim
+++ b/app/views/admin/companies/edit.html.slim
@@ -9,7 +9,7 @@ header.page-header
           .page-header-actions__item
             = link_to new_admin_company_path, class: 'a-button is-md is-secondary is-block' do
               i.fa-regular.fa-plus
-              | 企業作成
+              | 企業追加
 
 = render 'admin/admin_page_tabs'
 

--- a/app/views/admin/companies/new.html.slim
+++ b/app/views/admin/companies/new.html.slim
@@ -18,8 +18,7 @@ main.page-main
           .page-main-header-actions
             ul.page-main-header-actions__items
               li.page-main-header-actions__item
-                = link_to admin_companies_path, class: 'a-button is-sm is-block is-secondary is-back' do
-                  | 企業一覧
+                = link_to '企業一覧', admin_companies_path, class: 'a-button is-sm is-block is-secondary is-back'
 .page-body
   .container.is-md
     = render 'form', company: @company

--- a/app/views/admin/companies/new.html.slim
+++ b/app/views/admin/companies/new.html.slim
@@ -1,4 +1,4 @@
-- title '企業作成'
+- title '管理ページ'
 
 header.page-header
   .container
@@ -7,6 +7,12 @@ header.page-header
 
 = render 'admin/admin_page_tabs'
 
+header.page-main-header
+  .container
+    .page-main-header__inner
+      .page-main-header__start
+        h1.page-main-header__title
+          | 企業追加
 .page-body
   .container.is-md
     = render 'form', company: @company

--- a/app/views/admin/companies/new.html.slim
+++ b/app/views/admin/companies/new.html.slim
@@ -7,12 +7,19 @@ header.page-header
 
 = render 'admin/admin_page_tabs'
 
-header.page-main-header
-  .container
-    .page-main-header__inner
-      .page-main-header__start
-        h1.page-main-header__title
-          | 企業追加
+main.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        .page-main-header__start
+          h1.page-main-header__title
+            | 企業追加
+        .page-main-header__end
+          .page-main-header-actions
+            ul.page-main-header-actions__items
+              li.page-main-header-actions__item
+                = link_to admin_companies_path, class: 'a-button is-sm is-block is-secondary is-back' do
+                  | 企業一覧
 .page-body
   .container.is-md
     = render 'form', company: @company


### PR DESCRIPTION
## Issue

- #6281

## 概要
- 企業登録ページのタイトルを`管理ページ`に変更しました。
  - タブの左下に`企業追加`を追加しました。
  - タブの右下に`企業一覧`リンクボタンを追加しました。（[68a5555](https://github.com/fjordllc/bootcamp/pull/6288/commits/68a5555dc11e4c1b6327ca0b54d3d11b1dd3bb06)で対応）
- 企業編集ページの`企業作成`ボタンの文言を`企業追加`に変更しました。

## 変更確認方法

1. `feature/change-title-of-company-registration-page`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. 管理者`komagata`でログインし、`http://localhost:3000/admin/companies/new`（企業登録ページ）にアクセス
4. `http://localhost:3000/admin/companies/24043549/edit`（企業編集ページ）にアクセス

## Screenshot

### 変更前
#### 企業登録ページ
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/85052152/222722150-c102cdf1-c60d-44e9-a8dc-064d47b99efe.png">

#### 企業編集ページ
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/85052152/222722042-537bfc29-c954-45a0-bc10-176a49b36ad7.png">

### 変更後

#### 企業登録ページ
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/85052152/225797542-d51ccf0b-021b-4cf6-9d3e-fca2a9b48be9.png">

#### 企業編集ページ
![image](https://user-images.githubusercontent.com/85052152/222723207-0a2935cd-3ff9-4386-8498-89f8ca7ccb92.png)

