### PR TITLE
[アンケート]アンケートの質問を並び替えられるようにした

### DIFF
--- a/app/controllers/api/survey_question_listings/position_controller.rb
+++ b/app/controllers/api/survey_question_listings/position_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class API::SurveyQuestionListings::PositionController < API::BaseController
+  def update
+    @survey_question_listing = SurveyQuestionListing.find(params[:survey_question_listing_id])
+    if @survey_question_listing.insert_at(params[:insert_at])
+      head :no_content
+    else
+      render json: @survey_question_listing.errors, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/surveys/survey_question_listings_controller.rb
+++ b/app/controllers/surveys/survey_question_listings_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Surveys::SurveyQuestionListingsController < ApplicationController
+  before_action :require_admin_or_mentor_login
+
+  def index
+    @survey = Survey.find(params[:survey_id])
+    @survey_question_listings = @survey.survey_question_listings
+  end
+end

--- a/app/controllers/surveys/survey_question_listings_controller.rb
+++ b/app/controllers/surveys/survey_question_listings_controller.rb
@@ -5,6 +5,6 @@ class Surveys::SurveyQuestionListingsController < ApplicationController
 
   def index
     @survey = Survey.find(params[:survey_id])
-    @survey_question_listings = @survey.survey_question_listings
+    @survey_question_listings = @survey.survey_question_listings.order(:position)
   end
 end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -67,9 +67,9 @@ class SurveysController < ApplicationController
   def notice_message(survey)
     case params[:action]
     when 'create'
-      survey.before_start?(survey.id) ? 'アンケートを受付前として保存しました。' : 'アンケートを作成しました。'
+      survey.before_start? ? 'アンケートを受付前として保存しました。' : 'アンケートを作成しました。'
     when 'update'
-      survey.before_start?(survey.id) ? 'アンケートを受付前として保存しました。' : 'アンケートを更新しました。'
+      survey.before_start? ? 'アンケートを受付前として保存しました。' : 'アンケートを更新しました。'
     end
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -63,6 +63,7 @@ import '../bookmarks-edit-button.js'
 import '../hibernation_agreements.js'
 import '../current-date-time-setter.js'
 import '../modal-switcher.js'
+import '../survey-question-listings.js'
 
 import VueMounter from '../VueMounter.js'
 import Announcements from '../components/announcements.vue'

--- a/app/javascript/survey-question-listings.js
+++ b/app/javascript/survey-question-listings.js
@@ -2,9 +2,7 @@ import Sortable from 'sortablejs'
 import Bootcamp from 'bootcamp'
 
 document.addEventListener('DOMContentLoaded', () => {
-  const element = document.querySelector(
-    '#js-survey-question-listings-sortable'
-  )
+  const element = document.querySelector('#js-survey-question-listing-sortable')
   if (!element) {
     return null
   }

--- a/app/javascript/survey-question-listings.js
+++ b/app/javascript/survey-question-listings.js
@@ -1,0 +1,24 @@
+import Sortable from 'sortablejs'
+import Bootcamp from 'bootcamp'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const element = document.querySelector(
+    '#js-survey-question-listings-sortable'
+  )
+  if (!element) {
+    return null
+  }
+
+  Sortable.create(element, {
+    handle: '.js-grab',
+    onEnd(event) {
+      const id = event.item.dataset.survey_question_listings_id
+      const params = { insert_at: event.newIndex + 1 }
+      // const url = `/api/survey_question_listings/${id}/position.json`
+
+      Bootcamp.patch(url, params).catch((error) => {
+        console.warn(error)
+      })
+    }
+  })
+})

--- a/app/javascript/survey-question-listings.js
+++ b/app/javascript/survey-question-listings.js
@@ -12,9 +12,10 @@ document.addEventListener('DOMContentLoaded', () => {
   Sortable.create(element, {
     handle: '.js-grab',
     onEnd(event) {
-      const id = event.item.dataset.survey_question_listings_id
+      const id = event.item.dataset.survey_question_listing_id
+      // sortablejsのindexは0からはじまるため+1する
       const params = { insert_at: event.newIndex + 1 }
-      // const url = `/api/survey_question_listings/${id}/position.json`
+      const url = `/api/survey_question_listings/${id}/position.json`
 
       Bootcamp.patch(url, params).catch((error) => {
         console.warn(error)

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -12,19 +12,15 @@ class Survey < ApplicationRecord
   validates :end_at, presence: true
   validates :survey_question_listings, presence: true
 
-  def before_start?(survey_id)
-    Survey.where('start_at >= ?', Date.current)
-          .exists?(survey_id)
+  def before_start?
+    Time.current <= start_at
   end
 
-  def answer_accepting?(survey_id)
-    Survey.where('start_at <= ?', Date.current)
-          .where('end_at >= ?', Date.current)
-          .exists?(survey_id)
+  def answer_accepting?
+    Time.current.between?(start_at, end_at)
   end
 
-  def answer_ended?(survey_id)
-    Survey.where('end_at <= ?', Date.current)
-          .exists?(survey_id)
+  def answer_ended?
+    Time.current >= end_at
   end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -21,6 +21,6 @@ class Survey < ApplicationRecord
   end
 
   def answer_ended?
-    Time.current >= end_at
+    Time.current > end_at
   end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -22,4 +22,9 @@ class Survey < ApplicationRecord
           .where('end_at >= ?', Date.current)
           .exists?(survey_id)
   end
+
+  def answer_ended?(survey_id)
+    Survey.where('end_at <= ?', Date.current)
+          .exists?(survey_id)
+  end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -13,7 +13,7 @@ class Survey < ApplicationRecord
   validates :survey_question_listings, presence: true
 
   def before_start?
-    Time.current <= start_at
+    Time.current < start_at
   end
 
   def answer_accepting?

--- a/app/models/survey_question_listing.rb
+++ b/app/models/survey_question_listing.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SurveyQuestionListing < ApplicationRecord
+  default_scope -> { order(:position) }
   belongs_to :survey
   belongs_to :survey_question
+  acts_as_list scope: :survey
 end

--- a/app/views/surveys/_survey.html.slim
+++ b/app/views/surveys/_survey.html.slim
@@ -27,5 +27,5 @@ tbody.admin-table__items
           = link_to edit_survey_path(survey), class: 'a-button is-sm is-secondary is-icon is-block' do
             i.fa.fa-solid.fa-pen
         li
-          = link_to survey_survey_question_listings_path(survey), class: 'a-button is-sm is-secondary is-icon is-block' do
+          = link_to survey_survey_questions_path(survey), class: 'a-button is-sm is-secondary is-icon is-block' do
             i.fa-solid.fa-align-justify

--- a/app/views/surveys/_survey.html.slim
+++ b/app/views/surveys/_survey.html.slim
@@ -14,10 +14,9 @@ tbody.admin-table__items
           span
             | 受付終了
     td.admin-table__item-value
-      span
-        = l survey.start_at
-        |〜
-        = l survey.end_at
+      = l survey.start_at
+      |〜
+      = l survey.end_at
     td.admin-table__item-value
       = link_to survey do
           = survey.title

--- a/app/views/surveys/_survey.html.slim
+++ b/app/views/surveys/_survey.html.slim
@@ -1,24 +1,31 @@
-.card-list-item(class="#{survey.before_start?(survey.id) ? 'is-wip' : ''}")
-  .card-list-item__inner
-    .card-list-item__rows
-      .card-list-item__row
-        .card-list-item-title
-          .card-list-item-title__start
-            - if survey.before_start?(survey.id)
-              .a-list-item-badge.is-wip
-                span
-                  | 受付前
-            - elsif survey.answer_accepting?(survey.id)
-              .a-list-item-badge.is-active
-                span
-                  | 受付中
-            h2.card-list-item-title__title(itemprop='name')
-              = link_to survey, itemprop: 'url', class: 'card-list-item-title__link a-text-link js-unconfirmed-link' do
-                = l survey.start_at
-                |〜
-                = l survey.end_at
-      .card-list-item__row
-        .card-list-item-meta
-          .card-list-item-meta__items
-            .card-list-item-meta__item
-              = survey.title
+tbody.admin-table__items
+  tr.admin-table__item(class="#{survey.before_start?(survey.id) ? 'is-wip' : ''}")
+    td.admin-table__item-value.is-text-align-center
+      - if survey.before_start?(survey.id)
+        .a-list-item-badge.is-wip
+          span
+            | 受付前
+      - elsif survey.answer_accepting?(survey.id)
+        .a-list-item-badge.is-active
+          span
+            | 受付中
+      - elsif survey.answer_ended?(survey.id)
+        .a-list-item-badge.is-ended
+          span
+            | 受付終了
+    td.admin-table__item-value
+      span
+        = l survey.start_at
+        |〜
+        = l survey.end_at
+    td.admin-table__item-value
+      = link_to survey do
+          = survey.title
+    td.admin-table__item-value.is-text-align-center
+      ul.is-inline-buttons
+        li
+          = link_to edit_survey_path(survey), class: 'a-button is-sm is-secondary is-icon is-block' do
+            i.fa.fa-solid.fa-pen
+        li
+          = link_to survey_survey_question_listings_path(survey), class: 'a-button is-sm is-secondary is-icon is-block' do
+            i.fa-solid.fa-align-justify

--- a/app/views/surveys/_survey.html.slim
+++ b/app/views/surveys/_survey.html.slim
@@ -1,15 +1,15 @@
 tbody.admin-table__items
-  tr.admin-table__item(class="#{survey.before_start?(survey.id) ? 'is-wip' : ''}")
+  tr.admin-table__item(class="#{survey.before_start? ? 'is-wip' : ''}")
     td.admin-table__item-value.is-text-align-center
-      - if survey.before_start?(survey.id)
+      - if survey.before_start?
         .a-list-item-badge.is-wip
           span
             | 受付前
-      - elsif survey.answer_accepting?(survey.id)
+      - elsif survey.answer_accepting?
         .a-list-item-badge.is-active
           span
             | 受付中
-      - elsif survey.answer_ended?(survey.id)
+      - elsif survey.answer_ended?
         .a-list-item-badge.is-ended
           span
             | 受付終了

--- a/app/views/surveys/index.html.slim
+++ b/app/views/surveys/index.html.slim
@@ -22,12 +22,22 @@ header.page-header
                 = link_to new_survey_path, class: 'a-button is-md is-secondary is-block' do
                   i.fa-regular.fa-plus
                   | 新規作成
-
 .page-body
-  .container.is-md
+  .container.is-xxl
     - if @surveys.present?
-      .card-list.a-card
-        = render partial: 'surveys/survey', collection: @surveys, as: :survey
+      .admin-table
+        table.admin-table__table
+          thead.admin-table__header
+            tr.admin-table__labels
+              td.admin-table__label
+                | ステータス
+              td.admin-table__label
+                | 回答期間
+              td.admin-table__label
+                | アンケート名
+              td.admin-table__label
+                | 操作
+          = render partial: 'surveys/survey', collection: @surveys, as: :survey
     - else
       .o-empty-message
         .o-empty-message__icon

--- a/app/views/surveys/survey_question_listings/index.html.slim
+++ b/app/views/surveys/survey_question_listings/index.html.slim
@@ -30,7 +30,7 @@ header.page-header
           tr.admin-table__labels
             th.admin-table__label 名前
             th.admin-table__label.handle 並び順
-        tbody.admin-table__items#js-survey-question-listings-sortable
+        tbody.admin-table__items#js-survey-question-listing-sortable
           - @survey_question_listings.each do |survey_question_listing|
             tr.admin-table__item(data-survey_question_listing_id="#{survey_question_listing.id}")
               td.admin-table__item-value

--- a/app/views/surveys/survey_question_listings/index.html.slim
+++ b/app/views/surveys/survey_question_listings/index.html.slim
@@ -1,0 +1,41 @@
+- title "アンケート質問並び替え"
+
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+
+= render 'surveys/tabs'
+
+.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        .page-main-header__start
+          h1.page-main-header__title
+            | #{@survey.title}
+        .page-main-header__end
+          .page-main-header-actions
+            ul.page-main-header-actions__items
+              li.page-main-header-actions__item
+                = link_to surveys_path, class: 'a-button is-md is-secondary is-block is-back' do
+                  i.fa-regular
+                  | アンケート一覧
+
+.page-body
+  .container.is-lg
+    .admin-table.is-grab
+      table.admin-table__table
+        thead.admin-table__header
+          tr.admin-table__labels
+            th.admin-table__label 名前
+            th.admin-table__label.handle 並び順
+        tbody.admin-table__items#js-survey-question-listings-sortable
+          - @survey_question_listings.each do |survey_question_listing|
+            tr.admin-table__item(data-survey_question_listing_id="#{survey_question_listing.id}")
+              td.admin-table__item-value
+                = survey_question_listing.survey_question.title
+              td.admin-table__item-value.is-text-align-center.is-grab
+                span.js-grab.a-grab
+                  i.fa-solid.fa-align-justify

--- a/app/views/surveys/survey_question_listings/index.html.slim
+++ b/app/views/surveys/survey_question_listings/index.html.slim
@@ -1,4 +1,4 @@
-- title "アンケート質問並び替え"
+- title 'アンケート質問並び替え'
 
 header.page-header
   .container
@@ -22,7 +22,6 @@ header.page-header
                 = link_to surveys_path, class: 'a-button is-md is-secondary is-block is-back' do
                   i.fa-regular
                   | アンケート一覧
-
 .page-body
   .container.is-lg
     .admin-table.is-grab

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   resources :surveys do
-    resources :survey_question_listings, only: %i(index), controller: "surveys/survey_question_listings"
+    resources :survey_questions, only: %i(index), controller: "surveys/survey_question_listings"
   end
   root to: "home#index"
   get "test", to: "home#test", as: "test"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  resources :surveys
+  resources :surveys do
+    resources :survey_question_listings, only: %i(index), controller: "surveys/survey_question_listings"
+  end
   root to: "home#index"
   get "test", to: "home#test", as: "test"
   get "welcome", to: "welcome#index", as: "welcome"
@@ -49,7 +51,7 @@ Rails.application.routes.draw do
     resource :completion, only: %i(show), controller: "practices/completion"
   end
   resources :pages, param: :slug_or_id
-  namespace :notification do 
+  namespace :notification do
     resource :redirector, only: %i(show), controller: "redirector"
   end
   resources :notifications, only: %i(index show) do

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -89,5 +89,8 @@ Rails.application.routes.draw do
     resources :courses, only: %i(index)
     resources :footprints, only: %i(index)
     resources :external_entries, only: %i(index)
+    resources :survey_question_listings, only: %i() do
+      resource :position, only: %i(update), controller: "survey_question_listings/position"
+    end
   end
 end

--- a/db/fixtures/survey_question_listings.yml
+++ b/db/fixtures/survey_question_listings.yml
@@ -1,71 +1,89 @@
 survey_question_listing1:
   survey: survey1
   survey_question: survey_question1
+  position: 1
 
 survey_question_listing2:
   survey: survey1
   survey_question: survey_question2
+  position: 2
 
 survey_question_listing3:
   survey: survey1
   survey_question: survey_question3
+  position: 3
 
 survey_question_listing4:
   survey: survey1
   survey_question: survey_question4
+  position: 4
 
 survey_question_listing5:
   survey: survey1
   survey_question: survey_question5
+  position: 5
 
 survey_question_listing6:
   survey: survey1
   survey_question: survey_question6
+  position: 6
 
 survey_question_listing7:
   survey: survey2
   survey_question: survey_question1
+  position: 1
 
 survey_question_listing8:
   survey: survey2
   survey_question: survey_question2
+  position: 2
 
 survey_question_listing9:
   survey: survey2
   survey_question: survey_question3
+  position: 3
 
 survey_question_listing10:
   survey: survey2
   survey_question: survey_question4
+  position: 4
 
 survey_question_listing11:
   survey: survey2
   survey_question: survey_question5
+  position: 5
 
 survey_question_listing12:
   survey: survey2
   survey_question: survey_question6
+  position: 6
 
 survey_question_listing13:
   survey: survey3
   survey_question: survey_question1
+  position: 1
 
 survey_question_listing14:
   survey: survey3
   survey_question: survey_question2
+  position: 2
 
 survey_question_listing15:
   survey: survey3
   survey_question: survey_question3
+  position: 3
 
 survey_question_listing16:
   survey: survey3
   survey_question: survey_question4
+  position: 4
 
 survey_question_listing17:
   survey: survey3
   survey_question: survey_question5
+  position: 5
 
 survey_question_listing18:
   survey: survey3
   survey_question: survey_question6
+  position: 6

--- a/db/migrate/20230304124009_add_position_to_survey_question_listing.rb
+++ b/db/migrate/20230304124009_add_position_to_survey_question_listing.rb
@@ -1,0 +1,5 @@
+class AddPositionToSurveyQuestionListing < ActiveRecord::Migration[6.1]
+  def change
+    add_column :survey_question_listings, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -595,6 +595,7 @@ ActiveRecord::Schema.define(version: 2023_03_12_200635) do
     t.bigint "survey_question_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "position"
     t.index ["survey_id"], name: "index_survey_question_listings_on_survey_id"
     t.index ["survey_question_id"], name: "index_survey_question_listings_on_survey_question_id"
   end

--- a/test/fixtures/survey_question_listings.yml
+++ b/test/fixtures/survey_question_listings.yml
@@ -1,19 +1,24 @@
 survey_question_listing1:
   survey: survey1
   survey_question: survey_question1
+  position: 1
 
 survey_question_listing2:
   survey: survey1
   survey_question: survey_question2
+  position: 2
 
 survey_question_listing3:
   survey: survey1
   survey_question: survey_question3
+  position: 3
 
 survey_question_listing4:
   survey: survey1
   survey_question: survey_question4
+  position: 4
 
 survey_question_listing5:
   survey: survey1
   survey_question: survey_question5
+  position: 5

--- a/test/fixtures/survey_question_listings.yml
+++ b/test/fixtures/survey_question_listings.yml
@@ -23,27 +23,27 @@ survey_question_listing5:
   survey_question: survey_question5
   position: 5
 
-survey_question_listing7:
+survey_question_listing6:
   survey: survey2
   survey_question: survey_question1
   position: 1
 
-survey_question_listing8:
+survey_question_listing7:
   survey: survey2
   survey_question: survey_question2
   position: 2
 
-survey_question_listing9:
+survey_question_listing8:
   survey: survey2
   survey_question: survey_question3
   position: 3
 
-survey_question_listing10:
+survey_question_listing9:
   survey: survey2
   survey_question: survey_question4
   position: 4
 
-survey_question_listing11:
+survey_question_listing10:
   survey: survey2
   survey_question: survey_question5
   position: 5

--- a/test/fixtures/survey_question_listings.yml
+++ b/test/fixtures/survey_question_listings.yml
@@ -22,3 +22,28 @@ survey_question_listing5:
   survey: survey1
   survey_question: survey_question5
   position: 5
+
+survey_question_listing7:
+  survey: survey2
+  survey_question: survey_question1
+  position: 1
+
+survey_question_listing8:
+  survey: survey2
+  survey_question: survey_question2
+  position: 2
+
+survey_question_listing9:
+  survey: survey2
+  survey_question: survey_question3
+  position: 3
+
+survey_question_listing10:
+  survey: survey2
+  survey_question: survey_question4
+  position: 4
+
+survey_question_listing11:
+  survey: survey2
+  survey_question: survey_question5
+  position: 5

--- a/test/fixtures/surveys.yml
+++ b/test/fixtures/surveys.yml
@@ -8,10 +8,10 @@ survey1:
   updated_at: <%= Time.zone.local(2020, 1, 1, 0, 0) %>
 
 survey2:
-  title: "【第2回】FBCモチベーションに関するアンケート"
-  description: "フィヨルドブートキャンプでは満足度向上と質の高いサービスの提供に活かすためアンケートを実施しております。5分程度の簡単なアンケートです。ご協力いただけますと幸いです。個人情報は第三者に提供することはありません。ただし、個人が特定できないことに注意しながら、フィヨルドブートキャンプのブログ等で一部紹介させてもらうことがあります。"
+  title: "【第0回】テストに関するアンケート"
+  description: "テストに関するアンケート"
   user: komagata
-  start_at: <%= Time.current.beginning_of_day %>
-  end_at: <%= Time.zone.local(2040, 1, 1, 23, 59) %>
-  created_at: <%= Time.current %>
-  updated_at: <%= Time.current %>
+  start_at: <%= Time.zone.local(2020, 1, 1, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 23, 59) %>
+  created_at: <%= Time.zone.local(2020, 1, 1, 0, 0) %>
+  updated_at: <%= Time.zone.local(2020, 1, 1, 0, 0) %>

--- a/test/fixtures/surveys.yml
+++ b/test/fixtures/surveys.yml
@@ -6,3 +6,12 @@ survey1:
   end_at: <%= Time.zone.local(2020, 1, 1, 23, 59) %>
   created_at: <%= Time.zone.local(2020, 1, 1, 0, 0) %>
   updated_at: <%= Time.zone.local(2020, 1, 1, 0, 0) %>
+
+survey2:
+  title: "【第2回】FBCモチベーションに関するアンケート"
+  description: "フィヨルドブートキャンプでは満足度向上と質の高いサービスの提供に活かすためアンケートを実施しております。5分程度の簡単なアンケートです。ご協力いただけますと幸いです。個人情報は第三者に提供することはありません。ただし、個人が特定できないことに注意しながら、フィヨルドブートキャンプのブログ等で一部紹介させてもらうことがあります。"
+  user: komagata
+  start_at: <%= Time.current.beginning_of_day %>
+  end_at: <%= Time.zone.local(2040, 1, 1, 23, 59) %>
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>

--- a/test/system/survey/survey_question_listings_test.rb
+++ b/test/system/survey/survey_question_listings_test.rb
@@ -3,20 +3,40 @@
 require 'application_system_test_case'
 
 class Survey::SurveyQuestionListingsTest < ApplicationSystemTestCase
-  test 'sorting questions of a survey_question_listings' do
+  test 'sorting survey_questions of a survey ' do
     visit_with_auth "/surveys/#{surveys(:survey1).id}/", 'komagata'
-    assert_equal all('label.a-form-label.is-lg')[0].text, survey_questions(:survey_question1).title
-    assert_equal all('label.a-form-label.is-lg')[1].text, survey_questions(:survey_question2).title
+    assert_equal survey_questions(:survey_question1).title, all('label.a-form-label.is-lg')[0].text
+    assert_equal survey_questions(:survey_question2).title, all('label.a-form-label.is-lg')[1].text
 
-    visit_with_auth "/surveys/#{surveys(:survey1).id}/survey_question_listings", 'komagata'
-    source = all('.js-grab')[0] # surveyQuestion1
-    target = all('.js-grab')[1] # surveyQuestion2
+    visit_with_auth "/surveys/#{surveys(:survey1).id}/survey_questions", 'komagata'
+    source = all('.js-grab')[0]
+    target = all('.js-grab')[2]
     source.drag_to(target)
-    assert_equal all('.js-grab')[0].text, survey_questions(:survey_question2).title
-    assert_equal all('.js-grab')[1].text, survey_questions(:survey_question1).title
+    assert_equal survey_questions(:survey_question2).title, all('td.admin-table__item-value')[0].text
+    assert_equal survey_questions(:survey_question1).title, all('td.admin-table__item-value')[2].text
 
     visit_with_auth "/surveys/#{surveys(:survey1).id}/", 'komagata'
-    assert_equal all('label.a-form-label.is-lg')[0].text, survey_questions(:survey_question2).title
-    assert_equal all('label.a-form-label.is-lg')[1].text, survey_questions(:survey_question1).title
+    assert_equal survey_questions(:survey_question2).title, all('label.a-form-label.is-lg')[0].text
+    assert_equal survey_questions(:survey_question1).title, all('label.a-form-label.is-lg')[1].text
+  end
+
+  test 'sorting survey_questions of a survey not affecting the survey_questions order of another survey' do
+    visit_with_auth "/surveys/#{surveys(:survey2).id}/", 'komagata'
+    assert_equal survey_questions(:survey_question1).title, all('label.a-form-label.is-lg')[0].text
+    assert_equal survey_questions(:survey_question2).title, all('label.a-form-label.is-lg')[1].text
+
+    visit_with_auth "/surveys/#{surveys(:survey1).id}/survey_questions", 'komagata'
+    assert_equal survey_questions(:survey_question1).title, all('td.admin-table__item-value')[0].text
+    assert_equal survey_questions(:survey_question2).title, all('td.admin-table__item-value')[2].text
+    source = all('.js-grab')[0]
+    target = all('.js-grab')[2]
+    source.drag_to(target)
+    assert_equal survey_questions(:survey_question2).title, all('td.admin-table__item-value')[0].text
+    assert_equal survey_questions(:survey_question1).title, all('td.admin-table__item-value')[2].text
+
+    # survey1の質問並び替え後もsurvey2の質問の並び順には変化がないことを確認
+    visit_with_auth "/surveys/#{surveys(:survey2).id}/", 'komagata'
+    assert_equal survey_questions(:survey_question1).title, all('label.a-form-label.is-lg')[0].text
+    assert_equal survey_questions(:survey_question2).title, all('label.a-form-label.is-lg')[1].text
   end
 end

--- a/test/system/survey/survey_question_listings_test.rb
+++ b/test/system/survey/survey_question_listings_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Survey::SurveyQuestionListingsTest < ApplicationSystemTestCase
+  test 'sorting questions of a survey_question_listings' do
+    visit_with_auth "/surveys/#{surveys(:survey1).id}/", 'komagata'
+    assert_equal all('label.a-form-label.is-lg')[0].text, survey_questions(:survey_question1).title
+    assert_equal all('label.a-form-label.is-lg')[1].text, survey_questions(:survey_question2).title
+
+    visit_with_auth "/surveys/#{surveys(:survey1).id}/survey_question_listings", 'komagata'
+    source = all('.js-grab')[0] # surveyQuestion1
+    target = all('.js-grab')[1] # surveyQuestion2
+    source.drag_to(target)
+    assert_equal all('.js-grab')[0].text, survey_questions(:survey_question2).title
+    assert_equal all('.js-grab')[1].text, survey_questions(:survey_question1).title
+
+    visit_with_auth "/surveys/#{surveys(:survey1).id}/", 'komagata'
+    assert_equal all('label.a-form-label.is-lg')[0].text, survey_questions(:survey_question2).title
+    assert_equal all('label.a-form-label.is-lg')[1].text, survey_questions(:survey_question1).title
+  end
+end

--- a/test/system/surveys_test.rb
+++ b/test/system/surveys_test.rb
@@ -35,7 +35,7 @@ class SurveysTest < ApplicationSystemTestCase
     assert_text 'そのように回答された理由を教えてください。'
   end
 
-  test 'not displaying any badge if a survey which deadline is over' do
+  test 'displaying ended badge if a survey which deadline is over' do
     visit_with_auth '/surveys', 'komagata'
     assert_selector 'h1', text: 'アンケート一覧'
 
@@ -44,6 +44,7 @@ class SurveysTest < ApplicationSystemTestCase
 
     assert_no_text '受付前'
     assert_no_text '受付中'
+    assert_text '受付終了'
   end
 
   test 'creating a survey which beginning of accepting and deadline is current' do


### PR DESCRIPTION
## Issue
- #5568

## 概要
アンケートの質問の並べ替えができるようにしました。
### アンケート機能について
- アンケート機能は管理者またはメンターがアンケートを作成、公開しブートキャンプの受講生にアンケートの回答をしてもらうための開発中機能です。[^anchor1]
- アンケート機能、アンケートの質問機能については以下PRで実装されています。
    - #5690
    - #5370 

#5690 に記載のあるER図を以下に引用します。
![ERimgae](https://user-images.githubusercontent.com/76944527/203032529-c56384c6-e794-4a26-8db1-3412e5058058.png)

アンケートのテーブル`survey`とアンケートの質問`survey_question`テーブルがあり、中間テーブルの`survey_question_listing`がアンケートとアンケートの質問の関連付けをしています。

###  このPRで行ったこと
- `survey_question_listing`テーブルにpositionカラムを追加し、[acts\_as\_list](https://github.com/brendon/acts_as_list)Gemによって質問の並び順を管理できるようにしました。
- ドラッグ&ドロップは[SortableJS](https://github.com/SortableJS/Sortable)で実装しています。
- アンケート一覧画面(`/surveys`)のレイアウトをテーブルに変更しました。
- アンケートの質問並び替え画面(`/surveys/:id/survey_questions`)を作りました。
- 参考にしたPR
    - #4890
    - #3190 
    - #2208

## 変更確認方法
1. [feature/survey_questions-can-be-sorted](https://github.com/fjordllc/bootcamp/tree/feature/survey_questions-can-be-sorted)をローカルに取り込む
1. bin/rails sでローカル環境を立ち上げる
1. `komagata`でログイン
1. アンケートの質問並び替え画面(http://localhost:3000/surveys/427061050/survey_questions など)でドラッグ&ドロップで質問が並び替えられることを確認
1. アンケート画面(http://localhost:3000/surveys/427061050/ など)に並び替えた質問の順番が反映されていることを確認する

## Screenshot
### アンケート一覧
#### 変更前
![before_survey_index](https://user-images.githubusercontent.com/66685066/223102509-8053dba9-27b5-4841-ae44-a12f59ae78c8.png)
#### 変更後
![after_survey_index](https://user-images.githubusercontent.com/66685066/223102549-ab0731ff-3655-4bb9-a2cb-82dcf1faf9a6.png)
### アンケートの質問並び替え画面
#### 変更前
今回追加した画面なのでなし
#### 変更後
![survey_question_listings](https://user-images.githubusercontent.com/66685066/223102636-a6197633-0c4f-4fd6-998b-ab9e51ab00e9.png)

[^anchor1]: アンケート回答画面など、開発中でまだ存在しない機能もあります。