### PR TITLE
企業作成ボタンの文言と位置を変更

### DIFF
--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -7,12 +7,20 @@ header.page-header
 
 = render 'admin/admin_page_tabs'
 
-.page-body
-  .page-header-actions
-    .page-header-actions__items
-      .page-header-actions__item
-        = link_to new_admin_company_path, class: 'a-button is-md is-secondary is-block' do
-          i.fa-regular.fa-plus
-          | 企業追加
-  .container.is-lg
-    = react_component 'AdminCompanies'
+main.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        .page-main-header__start
+          h1.page-main-header__title
+            | 企業一覧
+        .page-main-header__end
+          .page-header-actions
+            .page-header-actions__items
+              .page-header-actions__item
+                = link_to new_admin_company_path, class: 'a-button is-md is-secondary is-block' do
+                  i.fa-regular.fa-plus
+                  | 企業追加
+  .page-body
+    .container.is-lg
+      = react_component 'AdminCompanies'

--- a/app/views/admin/companies/index.html.slim
+++ b/app/views/admin/companies/index.html.slim
@@ -4,15 +4,15 @@ header.page-header
   .container
     .page-header__inner
       h1.page-header__title = title
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to new_admin_company_path, class: 'a-button is-md is-secondary is-block' do
-              i.fa-regular.fa-plus
-              | 企業作成
 
 = render 'admin/admin_page_tabs'
 
 .page-body
+  .page-header-actions
+    .page-header-actions__items
+      .page-header-actions__item
+        = link_to new_admin_company_path, class: 'a-button is-md is-secondary is-block' do
+          i.fa-regular.fa-plus
+          | 企業追加
   .container.is-lg
     = react_component 'AdminCompanies'


### PR DESCRIPTION
## Issue

- #6280

## 概要
- `企業作成` ボタンの位置をタブの下に移動しました。
  - `企業作成` ボタンの文言を `企業追加` に変更しました。
- タブの左下に`企業一覧`を追加しました。（[8ae4fdc](https://github.com/fjordllc/bootcamp/pull/6300/commits/8ae4fdcc589752001561973d88cfb38d4add19b5)にて対応)

## 変更確認方法
1. `feature/change-wording-of-create-company-button-and-move-button` をローカルで立ち上げる
2. `bin/rails s` でローカル環境を立ち上げる
3. 管理者 `komagata`  でログインし、 http://localhost:3000/admin/companies にアクセスする

## Screenshot

### 変更前
![image](https://user-images.githubusercontent.com/85052152/222870700-6e6ac5a6-87e6-4d8b-a121-20d7063164c4.png)

### 変更後
<img width="982" alt="image" src="https://user-images.githubusercontent.com/85052152/223902335-2e92dee6-7f45-4228-bead-f2548442ce52.png">



