### PR TITLE
Docsの編集者を自動でWatch中にした

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -59,8 +59,8 @@ class PagesController < ApplicationController
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
-      elsif @page.published_at && !@page.watched_by?(current_user)
-        Watch.create!(user: current_user, watchable: @page)
+      elsif @page.published_at
+        current_user.become_watcher(@page)
       end
       redirect_to url, notice: notice_message(@page, :update)
     else

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,7 +46,7 @@ class PagesController < ApplicationController
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      become_watcher
+      current_user.become_watcher!(@page)
 
       redirect_to url, notice: notice_message(@page, :create)
     else
@@ -64,7 +64,7 @@ class PagesController < ApplicationController
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      become_watcher
+      current_user.become_watcher!(@page)
 
       redirect_to url, notice: notice_message(@page, :update)
     else
@@ -116,9 +116,5 @@ class PagesController < ApplicationController
     return if @page.slug.nil?
 
     redirect_to request.original_url.sub(params[:slug_or_id], @page.slug) unless params[:slug_or_id].start_with?(/[a-z]/)
-  end
-
-  def become_watcher
-    current_user.watches.find_or_create_by!(watchable: @page)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,7 +46,7 @@ class PagesController < ApplicationController
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      current_user.watches.create!(watchable: @page) unless current_user.watches.exists?(watchable: @page)
+      current_user.watches.find_or_create_by!(watchable: @page)
 
       redirect_to url, notice: notice_message(@page, :create)
     else
@@ -64,7 +64,7 @@ class PagesController < ApplicationController
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      current_user.watches.create!(watchable: @page) unless current_user.watches.exists?(watchable: @page)
+      current_user.watches.find_or_create_by!(watchable: @page)
 
       redirect_to url, notice: notice_message(@page, :update)
     else

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,7 +46,7 @@ class PagesController < ApplicationController
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      current_user.watches.find_or_create_by!(watchable: @page)
+      become_watcher
 
       redirect_to url, notice: notice_message(@page, :create)
     else
@@ -64,7 +64,7 @@ class PagesController < ApplicationController
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      current_user.watches.find_or_create_by!(watchable: @page)
+      become_watcher
 
       redirect_to url, notice: notice_message(@page, :update)
     else
@@ -116,5 +116,9 @@ class PagesController < ApplicationController
     return if @page.slug.nil?
 
     redirect_to request.original_url.sub(params[:slug_or_id], @page.slug) unless params[:slug_or_id].start_with?(/[a-z]/)
+  end
+
+  def become_watcher
+    current_user.watches.find_or_create_by!(watchable: @page)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,7 +46,7 @@ class PagesController < ApplicationController
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      current_user.become_watcher(@page)
+      current_user.watches.create!(watchable: @page) unless current_user.watches.exists?(watchable: @page)
 
       redirect_to url, notice: notice_message(@page, :create)
     else
@@ -64,7 +64,7 @@ class PagesController < ApplicationController
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      current_user.become_watcher(@page)
+      current_user.watches.create!(watchable: @page) unless current_user.watches.exists?(watchable: @page)
 
       redirect_to url, notice: notice_message(@page, :update)
     else

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -45,6 +45,9 @@ class PagesController < ApplicationController
         Newspaper.publish(:page_create, @page)
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
+
+      current_user.become_watcher(@page)
+
       redirect_to url, notice: notice_message(@page, :create)
     else
       render :new
@@ -59,9 +62,10 @@ class PagesController < ApplicationController
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
-      elsif @page.published_at
-        current_user.become_watcher(@page)
       end
+
+      current_user.become_watcher(@page)
+
       redirect_to url, notice: notice_message(@page, :update)
     else
       render :edit

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -59,7 +59,7 @@ class PagesController < ApplicationController
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
-      elsif @page.published_at && !@page.already_on_watch?(current_user)
+      elsif @page.published_at && !@page.watched_by?(current_user)
         Watch.create!(user: current_user, watchable: @page)
       end
       redirect_to url, notice: notice_message(@page, :update)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -59,6 +59,8 @@ class PagesController < ApplicationController
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
+      elsif @page.published_at && !@page.already_on_watch?(current_user)
+        Watch.create!(user: current_user, watchable: @page)
       end
       redirect_to url, notice: notice_message(@page, :update)
     else

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -13,6 +13,10 @@ module Watchable
     watches.present?
   end
 
+  def already_on_watch?(user)
+    watches.find_by(user: user)
+  end
+
   def notification_title
     case self
     when Product

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -14,7 +14,7 @@ module Watchable
   end
 
   def already_on_watch?(user)
-    watches.find_by(user: user)
+    !!watches.find_by(user: user)
   end
 
   def notification_title

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -13,8 +13,8 @@ module Watchable
     watches.present?
   end
 
-  def already_on_watch?(user)
-    !!watches.find_by(user: user)
+  def watched_by?(user)
+    watches.exists?(user: user)
   end
 
   def notification_title

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -13,10 +13,6 @@ module Watchable
     watches.present?
   end
 
-  def watched_by?(user)
-    watches.exists?(user: user)
-  end
-
   def notification_title
     case self
     when Product

--- a/app/models/page_notifier.rb
+++ b/app/models/page_notifier.rb
@@ -4,7 +4,6 @@ class PageNotifier
   def call(page)
     send_notification(page)
     notify_to_chat(page)
-    create_author_watch(page)
 
     page.published_at = Time.current
     page.save
@@ -30,9 +29,5 @@ class PageNotifier
       Docs：「#{page.title}」が作成されました。
       #{page_url}
     TEXT
-  end
-
-  def create_author_watch(page)
-    Watch.create!(user: page.user, watchable: page)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -750,6 +750,12 @@ class User < ApplicationRecord
     )
   end
 
+  def become_watcher(watchable)
+    return nil if watchable.watched_by?(self)
+
+    Watch.create!(user: self, watchable: watchable)
+  end
+
   private
 
   def password_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -750,10 +750,8 @@ class User < ApplicationRecord
     )
   end
 
-  def become_watcher(watchable)
-    return nil if watchable.watched_by?(self)
-
-    Watch.create!(user: self, watchable: watchable)
+  def become_watcher!(watchable)
+    watches.find_or_create_by!(watchable:)
   end
 
   private

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -648,4 +648,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal users(:komagata).id, comment.user_id
     assert_equal description, comment.body
   end
+
+  test '#become_watcher!' do
+    watchable = pages(:page1)
+    user = users(:kimura)
+
+    assert_not user.watches.exists?(watchable:)
+
+    user.become_watcher!(watchable)
+    assert user.watches.exists?(watchable:)
+  end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -232,12 +232,19 @@ class PagesTest < ApplicationSystemTestCase
   end
 
   test 'put docs editor except for author on watch' do
-    visit_with_auth "/pages/#{pages(:page1).id}/edit", 'kimura'
+    # 編集前にWatch中になってないかチェック(作成者を除くDocs編集者)
+    docs_editor_except_for_author = 'machida'
+    visit_with_auth "/pages/#{pages(:page1).id}", docs_editor_except_for_author
+    assert_text 'Watch'
+    visit "/pages/#{pages(:page2).id}"
+    assert_text 'Watch'
+
+    visit "/pages/#{pages(:page1).id}/edit"
     click_button '内容を保存'
     assert_text 'ページを更新しました'
     assert_text 'Watch中'
 
-    visit "/pages/#{pages(:page1).id}/edit"
+    visit "/pages/#{pages(:page2).id}/edit"
     click_button 'WIP'
     assert_text 'ページをWIPとして保存しました。'
     assert_text 'Watch中'

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -231,6 +231,18 @@ class PagesTest < ApplicationSystemTestCase
     assert_match 'Message to Discord.', mock_log.to_s
   end
 
+  test 'put docs editor except for author on watch' do
+    visit_with_auth "/pages/#{pages(:page1).id}/edit", 'kimura'
+    click_button '内容を保存'
+    assert_text 'ページを更新しました'
+    assert_text 'Watch中'
+
+    visit "/pages/#{pages(:page1).id}/edit"
+    click_button 'WIP'
+    assert_text 'ページをWIPとして保存しました。'
+    assert_text 'Watch中'
+  end
+
   test 'Check the list of columns on the right of the document' do
     visit_with_auth "/pages/#{pages(:page7).id}", 'kimura'
     assert_link 'OS X Mountain Lionをクリーンインストールする'

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -241,12 +241,12 @@ class PagesTest < ApplicationSystemTestCase
 
     visit edit_page_path(pages(:page1))
     click_button '内容を更新'
-    assert_text 'ページを更新しました'
+    assert_text 'ドキュメントを更新しました'
     assert_text 'Watch中'
 
     visit edit_page_path(pages(:page2))
     click_button 'WIP'
-    assert_text 'ページをWIPとして保存しました。'
+    assert_text 'ドキュメントをWIPとして保存しました。'
     assert_text 'Watch中'
   end
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -246,7 +246,7 @@ class PagesTest < ApplicationSystemTestCase
 
     visit edit_page_path(pages(:page2))
     click_button 'WIP'
-    assert_text 'ドキュメントをWIPとして保存しました。'
+    visit page_path(pages(:page2))
     assert_text 'Watch中'
   end
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -240,7 +240,7 @@ class PagesTest < ApplicationSystemTestCase
     assert_text 'Watch'
 
     visit edit_page_path(pages(:page1))
-    click_button '内容を保存'
+    click_button '内容を更新'
     assert_text 'ページを更新しました'
     assert_text 'Watch中'
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -231,20 +231,20 @@ class PagesTest < ApplicationSystemTestCase
     assert_match 'Message to Discord.', mock_log.to_s
   end
 
-  test 'put docs editor except for author on watch' do
+  test 'non-author docs editor becomes Watcher when editing docs' do
     # 編集前にWatch中になってないかチェック(作成者を除くDocs編集者)
-    docs_editor_except_for_author = 'machida'
-    visit_with_auth "/pages/#{pages(:page1).id}", docs_editor_except_for_author
+    editor = 'machida'
+    visit_with_auth page_path(pages(:page1)), editor
     assert_text 'Watch'
-    visit "/pages/#{pages(:page2).id}"
+    visit page_path(pages(:page2))
     assert_text 'Watch'
 
-    visit "/pages/#{pages(:page1).id}/edit"
+    visit edit_page_path(pages(:page1))
     click_button '内容を保存'
     assert_text 'ページを更新しました'
     assert_text 'Watch中'
 
-    visit "/pages/#{pages(:page2).id}/edit"
+    visit edit_page_path(pages(:page2))
     click_button 'WIP'
     assert_text 'ページをWIPとして保存しました。'
     assert_text 'Watch中'


### PR DESCRIPTION
## Issue

- #6226 

## 概要
Docsの編集者を自動でWatch中にしました。（編集形式「WIP」、「公開」に関わらずWatch中となります。）
※ 変更前は作成者のみ自動でWatch中になります。

## 変更確認方法

1. `feature/put-docs-editor-on-watch`をローカルに取り込む
2. `rails s`でサーバー起動
3. `localhost:3000`にアクセス
4. `machida`でログイン
5. `/pages/new`にアクセス
6. 「タイトル」、「本文」を入力し「内容を保存」ボタンをクリックし、Docsを作成する
7. `kimura`でログイン
8. `/pages/{page_id}/edit`にアクセス（`page_id`は手順6.で作成したDocsのid）
9.  「WIP」ボタン、または「内容を保存」ボタンをクリックし、Docsを編集する

## Screenshot

### 変更前
<img width="974" alt="image" src="https://user-images.githubusercontent.com/85052152/224902319-4712f2d2-62f4-459c-9dff-4b689375323e.png">


### 変更後
<img width="968" alt="image" src="https://user-images.githubusercontent.com/85052152/224902920-7d0d243d-8908-4920-9d7d-c6d4bd6cec2c.png">


