### PR TITLE
定期イベントが二日連続開催の場合に今日と明日と表示するよう修正した

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -64,17 +64,10 @@ class HomeController < ApplicationController
 
   def display_regular_events_on_dashboard
     cookies_ids = JSON.parse(cookies[:confirmed_regular_event_ids]) if cookies[:confirmed_regular_event_ids]
-    @today_regular_events, @tomorrow_regular_events =
-      [RegularEvent.today_events, RegularEvent.tomorrow_events].map do |regular_events|
-        regular_events.select { |event| event.participated_by?(current_user) }
-      end
+    @today_regular_events, @tomorrow_regular_events = RegularEvent.comming_soon_events(current_user)
 
     cookies_ids&.each do |id|
-      [@today_regular_events, @tomorrow_regular_events].each do |regular_events|
-        regular_events.delete_if do |event|
-          event.id == id.to_i
-        end
-      end
+      RegularEvent.remove_events([@today_regular_events, @tomorrow_regular_events], id)
     end
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -64,12 +64,16 @@ class HomeController < ApplicationController
 
   def display_regular_events_on_dashboard
     cookies_ids = JSON.parse(cookies[:confirmed_regular_event_ids]) if cookies[:confirmed_regular_event_ids]
-    regular_events_comming_soon = RegularEvent.today_events + RegularEvent.tomorrow_events
-    @regular_events_comming_soon_for_current_user = regular_events_comming_soon.select { |event| event.participated_by?(current_user) }
+    @regular_events_holding_today_for_current_user, @regular_events_holding_tomorrow_for_current_user =
+      [RegularEvent.today_events, RegularEvent.tomorrow_events].map do |regular_events|
+        regular_events.select { |event| event.participated_by?(current_user) }
+      end
 
     cookies_ids&.each do |id|
-      @regular_events_comming_soon_for_current_user.delete_if do |event|
-        event.id == id.to_i
+      [@regular_events_holding_today_for_current_user, @regular_events_holding_tomorrow_for_current_user].each do |regular_events|
+        regular_events.delete_if do |event|
+          event.id == id.to_i
+        end
       end
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -64,13 +64,13 @@ class HomeController < ApplicationController
 
   def display_regular_events_on_dashboard
     cookies_ids = JSON.parse(cookies[:confirmed_regular_event_ids]) if cookies[:confirmed_regular_event_ids]
-    @regular_events_holding_today_for_current_user, @regular_events_holding_tomorrow_for_current_user =
+    @today_regular_events, @tomorrow_regular_events =
       [RegularEvent.today_events, RegularEvent.tomorrow_events].map do |regular_events|
         regular_events.select { |event| event.participated_by?(current_user) }
       end
 
     cookies_ids&.each do |id|
-      [@regular_events_holding_today_for_current_user, @regular_events_holding_tomorrow_for_current_user].each do |regular_events|
+      [@today_regular_events, @tomorrow_regular_events].each do |regular_events|
         regular_events.delete_if do |event|
           event.id == id.to_i
         end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -67,7 +67,7 @@ class HomeController < ApplicationController
     @today_regular_events, @tomorrow_regular_events = RegularEvent.comming_soon_events(current_user)
 
     cookies_ids&.each do |id|
-      RegularEvent.remove_events([@today_regular_events, @tomorrow_regular_events], id)
+      RegularEvent.remove_event([@today_regular_events, @tomorrow_regular_events], id)
     end
   end
 

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -9,14 +9,6 @@ module HomeHelper
     end
   end
 
-  def event_date(event)
-    if event.holding_today?
-      Date.current
-    elsif event.holding_tomorrow?
-      Date.tomorrow
-    end
-  end
-
   def anchor_to_required_field(attribute)
     {
       avatar_attached: 'form-user-avatar',

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -150,6 +150,20 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
       holding_events = RegularEvent.holding
       holding_events.select(&:holding_tomorrow?)
     end
+
+    def comming_soon_events(user)
+      [today_events, tomorrow_events].map do |regular_events|
+        regular_events.select { |event| event.participated_by?(user) }
+      end
+    end
+
+    def remove_events(events_arr, id)
+      events_arr.each do |events|
+        events.delete_if do |event|
+          event.id == id.to_i
+        end
+      end
+    end
   end
 
   private

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -157,7 +157,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
       end
     end
 
-    def remove_events(events_arr, id)
+    def remove_event(events_arr, id)
       events_arr.each do |events|
         events.delete_if do |event|
           event.id == id.to_i

--- a/app/views/home/_regular_event.html.slim
+++ b/app/views/home/_regular_event.html.slim
@@ -7,8 +7,8 @@
             = link_to regular_event, itemprop: 'url', class: 'has-badge' do
               span.a-badge.is-primary.is-xs
                 | 定期イベント
-              = today_or_tommorow(regular_event)
-              = l event_date(regular_event), format: :md
+              = date.today? ? '今日' : '明日'
+              = l date, format: :md
               | は 「
               span.a-page-notice__label
                 = regular_event.title

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -3,16 +3,16 @@
 = render 'page_tabs', user: current_user
 
 .page-body.is-dash-board
-  - if [@events_coming_soon, @regular_events_holding_today_for_current_user, @regular_events_holding_tomorrow_for_current_user].any?(&:present?)
+  - if [@events_coming_soon, @today_regular_events, @tomorrow_regular_events].any?(&:present?)
     #events_on_dashboard.confirmed_event
       .page-notices
         - if @events_coming_soon.present? && current_user.job_seeker
           = render partial: 'event', collection: @events_coming_soon, as: :event
         - if @events_coming_soon_except_job_hunting.present? && !current_user.job_seeker
           = render partial: 'event', collection: @events_coming_soon_except_job_hunting, as: :event
-        - @regular_events_holding_today_for_current_user.each do |regular_event|
+        - @today_regular_events.each do |regular_event|
             = render partial: 'regular_event', locals: { regular_event: regular_event, date: Date.current }
-        - @regular_events_holding_tomorrow_for_current_user.each do |regular_event|
+        - @tomorrow_regular_events.each do |regular_event|
             = render partial: 'regular_event', locals: { regular_event: regular_event, date: Date.tomorrow }
 
   - if current_user.adviser?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -3,15 +3,17 @@
 = render 'page_tabs', user: current_user
 
 .page-body.is-dash-board
-  - if @events_coming_soon.present? || @regular_events_comming_soon_for_current_user.present?
+  - if [@events_coming_soon, @regular_events_holding_today_for_current_user, @regular_events_holding_tomorrow_for_current_user].any?(&:present?)
     #events_on_dashboard.confirmed_event
       .page-notices
         - if @events_coming_soon.present? && current_user.job_seeker
           = render partial: 'event', collection: @events_coming_soon, as: :event
         - if @events_coming_soon_except_job_hunting.present? && !current_user.job_seeker
           = render partial: 'event', collection: @events_coming_soon_except_job_hunting, as: :event
-        - if @regular_events_comming_soon_for_current_user.present?
-          = render partial: 'regular_event', collection: @regular_events_comming_soon_for_current_user, as: :regular_event
+        - @regular_events_holding_today_for_current_user.each do |regular_event|
+            = render partial: 'regular_event', locals: { regular_event: regular_event, date: Date.current }
+        - @regular_events_holding_tomorrow_for_current_user.each do |regular_event|
+            = render partial: 'regular_event', locals: { regular_event: regular_event, date: Date.tomorrow }
 
   - if current_user.adviser?
     = render 'adviser_dashboard'

--- a/db/fixtures/regular_event_participations.yml
+++ b/db/fixtures/regular_event_participations.yml
@@ -9,3 +9,7 @@ regular_event_participation2:
 regular_event_participation3:
   user: kimura
   regular_event: regular_event9
+
+regular_event_participation4:
+  user: kimura
+  regular_event: regular_event27

--- a/db/fixtures/regular_event_participations.yml
+++ b/db/fixtures/regular_event_participations.yml
@@ -12,4 +12,4 @@ regular_event_participation3:
 
 regular_event_participation4:
   user: kimura
-  regular_event: regular_event27
+  regular_event: regular_event26

--- a/db/fixtures/regular_event_repeat_rules.yml
+++ b/db/fixtures/regular_event_repeat_rules.yml
@@ -62,10 +62,11 @@ regular_event_repeat_rule28:
   regular_event: regular_event1
 
 regular_event_repeat_rule29:
-  frequency: 3
-  day_of_the_week: 2
-  regular_event: regular_event2
+  frequency: 0
+  day_of_the_week: <%= Date.current.wday %>
+  regular_event: regular_event27
 
 regular_event_repeat_rule30:
-  frequency: 2
-  day_of_the_week: 3
+  frequency: 0
+  day_of_the_week: <%= Date.tomorrow.wday %>
+  regular_event: regular_event27

--- a/db/fixtures/regular_event_repeat_rules.yml
+++ b/db/fixtures/regular_event_repeat_rules.yml
@@ -33,17 +33,7 @@ regular_event_repeat_rule7:
   day_of_the_week: 3
   regular_event: regular_event7
 
-regular_event_repeat_rule8:
-  frequency: 0
-  day_of_the_week: <%= Date.current.wday %>
-  regular_event: regular_event8
-
-regular_event_repeat_rule9:
-  frequency: 0
-  day_of_the_week: <%= Date.tomorrow.wday %>
-  regular_event: regular_event9
-
-<% (10..26).each do |i| %>
+<% (8..25).each do |i| %>
 regular_event_repeat_rule<%= i %>:
   frequency: 0
   day_of_the_week: 0
@@ -51,22 +41,22 @@ regular_event_repeat_rule<%= i %>:
 <% end %>
 
 # NOTE: 定期イベントが複数存在する場合
-regular_event_repeat_rule27:
+regular_event_repeat_rule26:
   frequency: 1
   day_of_the_week: 1
   regular_event: regular_event1
 
-regular_event_repeat_rule28:
+regular_event_repeat_rule27:
   frequency: 2
   day_of_the_week: 1
   regular_event: regular_event1
 
-regular_event_repeat_rule29:
+regular_event_repeat_rule28:
   frequency: 0
   day_of_the_week: <%= Date.current.wday %>
-  regular_event: regular_event27
+  regular_event: regular_event26
 
-regular_event_repeat_rule30:
+regular_event_repeat_rule29:
   frequency: 0
   day_of_the_week: <%= Date.tomorrow.wday %>
-  regular_event: regular_event27
+  regular_event: regular_event26

--- a/db/fixtures/regular_events.yml
+++ b/db/fixtures/regular_events.yml
@@ -94,3 +94,12 @@ regular_event<%= i %>:
   user: komagata
   category: 1
 <% end %>
+
+regular_event27:
+  title: 二日連続開催の定期イベント
+  description: 二日連続開催用の定期イベント
+  finished: false
+  hold_national_holiday: true
+  start_at: <%= Time.zone.local(2020, 1, 1, 23, 58, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 23, 59, 0) %>
+  user: komagata

--- a/db/fixtures/regular_events.yml
+++ b/db/fixtures/regular_events.yml
@@ -65,25 +65,7 @@ regular_event7:
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
 
-regular_event8:
-  title: ダッシュボード表示確認用テスト定期イベント(当日用)
-  description: ダッシュボード表示確認用テスト定期イベント(当日用)
-  finished: false
-  hold_national_holiday: true
-  start_at: <%= Time.zone.local(2020, 1, 1, 23, 58, 0) %>
-  end_at: <%= Time.zone.local(2020, 1, 1, 23, 59, 0) %>
-  user: komagata
-
-regular_event9:
-  title: ダッシュボード表示確認用テスト定期イベント(翌日用)
-  description: ダッシュボード表示確認用テスト定期イベント(翌日用)
-  finished: false
-  hold_national_holiday: true
-  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
-  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
-  user: komagata
-
-<% (10..26).each do |i| %>
+<% (8..25).each do |i| %>
 regular_event<%= i %>:
   title: 定期イベント<%= i %>
   description: <%= i %>番目の定期イベントです。
@@ -95,9 +77,9 @@ regular_event<%= i %>:
   category: 1
 <% end %>
 
-regular_event27:
-  title: 二日連続開催の定期イベント
-  description: 二日連続開催用の定期イベント
+regular_event26:
+  title: ダッシュボード表示確認用テスト定期イベント
+  description: ダッシュボード表示確認用テスト定期イベント
   finished: false
   hold_national_holiday: true
   start_at: <%= Time.zone.local(2020, 1, 1, 23, 58, 0) %>

--- a/test/fixtures/regular_event_participations.yml
+++ b/test/fixtures/regular_event_participations.yml
@@ -9,3 +9,7 @@ regular_event_participation2:
 regular_event_participation3:
   user: kimura
   regular_event: regular_event9
+
+regular_event_participation4:
+  user: kimura
+  regular_event: regular_event27

--- a/test/fixtures/regular_event_participations.yml
+++ b/test/fixtures/regular_event_participations.yml
@@ -12,4 +12,4 @@ regular_event_participation3:
 
 regular_event_participation4:
   user: kimura
-  regular_event: regular_event27
+  regular_event: regular_event26

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -33,29 +33,19 @@ regular_event_repeat_rule7:
   day_of_the_week: 3
   regular_event: regular_event7
 
-regular_event_repeat_rule8:
-  frequency: 0
-  day_of_the_week: 1
-  regular_event: regular_event8
-
-regular_event_repeat_rule9:
-  frequency: 0
-  day_of_the_week: 2
-  regular_event: regular_event9
-
-<% (10..26).each do |i| %>
+<% (8..25).each do |i| %>
 regular_event_repeat_rule<%= i %>:
   frequency: 0
   day_of_the_week: 0
   regular_event: regular_event<%= i %>
 <% end %>
 
-regular_event_repeat_rule27:
+regular_event_repeat_rule26:
   frequency: 0
   day_of_the_week: 1
-  regular_event: regular_event27
+  regular_event: regular_event26
 
-regular_event_repeat_rule28:
+regular_event_repeat_rule27:
   frequency: 0
   day_of_the_week: 2
-  regular_event: regular_event27
+  regular_event: regular_event26

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -49,3 +49,13 @@ regular_event_repeat_rule<%= i %>:
   day_of_the_week: 0
   regular_event: regular_event<%= i %>
 <% end %>
+
+regular_event_repeat_rule27:
+  frequency: 0
+  day_of_the_week: 1
+  regular_event: regular_event27
+
+regular_event_repeat_rule28:
+  frequency: 0
+  day_of_the_week: 2
+  regular_event: regular_event27

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -94,3 +94,12 @@ regular_event<%= i %>:
   user: komagata
   category: 1
 <% end %>
+
+regular_event27:
+  title: 二日連続開催の定期イベント
+  description: 二日連続開催の定期イベント
+  finished: false
+  hold_national_holiday: true
+  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
+  user: komagata

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -65,25 +65,7 @@ regular_event7:
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
 
-regular_event8:
-  title: ダッシュボード表示確認用テスト定期イベント(当日用)
-  description: ダッシュボード表示確認用テスト定期イベント(当日用)
-  finished: false
-  hold_national_holiday: true
-  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
-  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
-  user: komagata
-
-regular_event9:
-  title: ダッシュボード表示確認用テスト定期イベント(翌日用)
-  description: ダッシュボード表示確認用テスト定期イベント(翌日用)
-  finished: false
-  hold_national_holiday: true
-  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
-  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
-  user: komagata
-
-<% (10..26).each do |i| %>
+<% (8..25).each do |i| %>
 regular_event<%= i %>:
   title: 定期イベント<%= i %>
   description: <%= i %>番目の定期イベントです。
@@ -95,9 +77,9 @@ regular_event<%= i %>:
   category: 1
 <% end %>
 
-regular_event27:
-  title: 二日連続開催の定期イベント
-  description: 二日連続開催の定期イベント
+regular_event26:
+  title: ダッシュボード表示確認用テスト定期イベント
+  description: ダッシュボード表示確認用テスト定期イベント
   finished: false
   hold_national_holiday: true
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -87,7 +87,7 @@ class RegularEventTest < ActiveSupport::TestCase
     assert regular_event.watched_by?(user)
   end
 
-  test 'participated_by?' do
+  test '#participated_by?' do
     regular_event = regular_events(:regular_event1)
     user = users(:hatsuno)
     assert regular_event.participated_by?(user)
@@ -96,7 +96,7 @@ class RegularEventTest < ActiveSupport::TestCase
     assert_not regular_event.participated_by?(user)
   end
 
-  test 'comming_soon_events' do
+  test '.comming_soon_events' do
     regular_event = regular_events(:regular_event26)
     user = users(:kimura)
 
@@ -107,7 +107,7 @@ class RegularEventTest < ActiveSupport::TestCase
     end
   end
 
-  test 'remove_event' do
+  test '.remove_event' do
     regular_event1 = regular_events(:regular_event1)
     regular_event2 = regular_events(:regular_event2)
     regular_event3 = regular_events(:regular_event3)

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -103,7 +103,7 @@ class RegularEventTest < ActiveSupport::TestCase
     travel_to Time.zone.local(2023, 4, 10, 0, 0, 0) do
       today_regular_events, tomorrow_regular_events = RegularEvent.comming_soon_events(user)
       assert today_regular_events.size == 1 && today_regular_events.include?(regular_event)
-      assert tomorrow_regular_events.size == 1  && tomorrow_regular_events.include?(regular_event)
+      assert tomorrow_regular_events.size == 1 && tomorrow_regular_events.include?(regular_event)
     end
   end
 

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -95,4 +95,28 @@ class RegularEventTest < ActiveSupport::TestCase
     user = users(:komagata)
     assert_not regular_event.participated_by?(user)
   end
+
+  test 'comming_soon_events' do
+    regular_event = regular_events(:regular_event26)
+    user = users(:kimura)
+
+    travel_to Time.zone.local(2023, 4, 10, 0, 0, 0) do
+      today_regular_events, tomorrow_regular_events = RegularEvent.comming_soon_events(user)
+      assert today_regular_events.size == 1 && today_regular_events.include?(regular_event)
+      assert tomorrow_regular_events.size == 1  && tomorrow_regular_events.include?(regular_event)
+    end
+  end
+
+  test 'remove_event' do
+    regular_event1 = regular_events(:regular_event1)
+    regular_event2 = regular_events(:regular_event2)
+    regular_event3 = regular_events(:regular_event3)
+    regular_events1 = [regular_event1, regular_event2]
+    regular_events2 = [regular_event3]
+
+    RegularEvent.remove_event([regular_events1, regular_events2], regular_event1.id)
+    assert_not regular_events1.include?(regular_event1)
+    assert regular_events1.include?(regular_event2)
+    assert regular_events2.include?(regular_event3)
+  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -226,23 +226,15 @@ class HomeTest < ApplicationSystemTestCase
   test 'show regular events on dashbord for only event participant' do
     travel_to Time.zone.local(2023, 1, 30, 10, 0, 0) do
       visit_with_auth '/', 'kimura'
-      assert_text 'ダッシュボード表示確認用テスト定期イベント(当日用)'
-      assert_text 'ダッシュボード表示確認用テスト定期イベント(翌日用)'
+      assert_text '今日01月30日は 「ダッシュボード表示確認用テスト定期イベント」'
+      assert_text '明日01月31日は 「ダッシュボード表示確認用テスト定期イベント」'
       first('.js-close-event').click
-      assert_no_text 'ダッシュボード表示確認用テスト定期イベント(当日用)'
+      assert_no_text '今日01月30日は 「ダッシュボード表示確認用テスト定期イベント」'
       logout
 
       visit_with_auth '/', 'komagata'
-      assert_no_text 'ダッシュボード表示確認用テスト定期イベント(当日用)'
-      assert_no_text 'ダッシュボード表示確認用テスト定期イベント(翌日用)'
-    end
-  end
-
-  test 'show regular event held for two consecutive days on dashbord' do
-    travel_to Time.zone.local(2023, 1, 30, 10, 0, 0) do
-      visit_with_auth '/', 'kimura'
-      assert_text '今日01月30日は 「二日連続開催の定期イベント」'
-      assert_text '明日01月31日は 「二日連続開催の定期イベント」'
+      assert_no_text '今日01月30日は 「ダッシュボード表示確認用テスト定期イベント」'
+      assert_no_text '明日01月31日は 「ダッシュボード表示確認用テスト定期イベント」'
     end
   end
 

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -238,6 +238,14 @@ class HomeTest < ApplicationSystemTestCase
     end
   end
 
+  test 'show regular event held for two consecutive days on dashbord' do
+    travel_to Time.zone.local(2023, 1, 30, 10, 0, 0) do
+      visit_with_auth '/', 'kimura'
+      assert_text '今日01月30日は 「二日連続開催の定期イベント」'
+      assert_text '明日01月31日は 「二日連続開催の定期イベント」'
+    end
+  end
+
   test 'show grass hide button for graduates' do
     visit_with_auth '/', 'kimura'
     assert_not has_button? '非表示'

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -171,7 +171,7 @@ class RegularEventsTest < ApplicationSystemTestCase
     visit_with_auth regular_events_path, 'kimura'
     assert_selector '.card-list-item', count: 25
     visit regular_events_path(page: 2)
-    assert_selector '.card-list-item', count: 1
+    assert_selector '.card-list-item', count: 2
   end
 
   test 'create a regular event for all students and trainees' do

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -164,14 +164,14 @@ class RegularEventsTest < ApplicationSystemTestCase
 
   test 'show listing not finished regular events' do
     visit_with_auth regular_events_path(target: 'not_finished'), 'kimura'
-    assert_selector '.card-list-item', count: 10
+    assert_selector '.card-list-item', count: 8
   end
 
   test 'show listing all regular events' do
     visit_with_auth regular_events_path, 'kimura'
     assert_selector '.card-list-item', count: 25
     visit regular_events_path(page: 2)
-    assert_selector '.card-list-item', count: 2
+    assert_selector '.card-list-item', count: 1
   end
 
   test 'create a regular event for all students and trainees' do

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -164,7 +164,7 @@ class RegularEventsTest < ApplicationSystemTestCase
 
   test 'show listing not finished regular events' do
     visit_with_auth regular_events_path(target: 'not_finished'), 'kimura'
-    assert_selector '.card-list-item', count: 9
+    assert_selector '.card-list-item', count: 10
   end
 
   test 'show listing all regular events' do


### PR DESCRIPTION
## Issue

- #6312

## 概要
定期イベントが二日連続開催の場合、今日開催と二重に表示されてしまっていたので、それぞれ今日と明日開催と表示されるように修正しました。
## 変更確認方法

1. `bug/regular-events-are-displayed-in-duplicate-on-the-dashboad`をローカルに取り込む
2. `rails db:seed`を実行する
3. `rails s`でサーバーを起動する
4. `kimura`でログインする
5. ダッシュボードに「ダッシュボード表示確認用テスト定期イベント」が今日と明日開催と表示される（日付も今日と明日の日付になっている）ことを確認する

## Screenshot

### 変更前
<img width="723" alt="スクリーンショット 2023-03-25 14 45 33" src="https://user-images.githubusercontent.com/88083085/227699182-c0781893-8928-4630-a440-184baddcd7d6.png">


### 変更後
<img width="708" alt="スクリーンショット 2023-03-25 14 45 01" src="https://user-images.githubusercontent.com/88083085/227699204-76ee8211-5502-43f0-991f-e8773f357fc6.png">


