### PR TITLE
提出物の学習ステータス変更処理をCallbackからNewspaperへ置き換えた

### DIFF
--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
-class LearningStatusUpdaterWithProductSubmission
-  def call(product)
+class LearningStatusUpdater
+  def call(product_or_associated_object)
+    case product_or_associated_object
+    when Product
+      update_with_submission(product_or_associated_object)
+    when Check
+      update_with_check(product_or_associated_object)
+    end
+  end
+
+  def update_with_check(check)
+    return unless check.checkable_type == 'Product'
+
+    check.checkable.change_learning_status(:complete)
+  end
+
+  def update_with_submission(product)
     previous_learning = Learning.find_or_initialize_by(
       user_id: product.user.id,
       practice_id: product.practice.id

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -4,19 +4,19 @@ class LearningStatusUpdater
   def call(product_or_associated_object)
     case product_or_associated_object
     when Product
-      update_with_submission(product_or_associated_object)
+      update_after_submission(product_or_associated_object)
     when Check
-      update_with_check(product_or_associated_object)
+      update_after_check(product_or_associated_object)
     end
   end
 
-  def update_with_check(check)
+  def update_after_check(check)
     return unless check.checkable_type == 'Product'
 
     check.checkable.change_learning_status(:complete)
   end
 
-  def update_with_submission(product)
+  def update_after_submission(product)
     previous_learning = Learning.find_or_initialize_by(
       user_id: product.user.id,
       practice_id: product.practice.id

--- a/app/models/learning_status_updater_with_product_check.rb
+++ b/app/models/learning_status_updater_with_product_check.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class LearningStatusUpdaterWithProductCheck
-  def call(check)
-    return unless check.checkable_type == 'Product'
-
-    check.checkable.change_learning_status(:complete)
-  end
-end

--- a/app/models/learning_status_updater_with_product_check.rb
+++ b/app/models/learning_status_updater_with_product_check.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProductStatusUpdater
+class LearningStatusUpdaterWithProductCheck
   def call(check)
     return unless check.checkable_type == 'Product'
 

--- a/app/models/learning_status_updater_with_product_submission.rb
+++ b/app/models/learning_status_updater_with_product_submission.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class LearningStatusUpdaterWithProductSubmission
+  def call(product)
+    previous_learning = Learning.find_or_initialize_by(
+      user_id: product.user.id,
+      practice_id: product.practice.id
+    )
+    status = if previous_learning.status == 'complete'
+               :complete
+             elsif product.wip
+               started_practice = product.user.learnings.map(&:status).include?('started')
+               started_practice ? :unstarted : :started
+             else
+               :submitted
+             end
+    product.change_learning_status status
+  end
+end

--- a/app/models/product_callbacks.rb
+++ b/app/models/product_callbacks.rb
@@ -16,8 +16,6 @@ class ProductCallbacks
   end
 
   def after_commit(product)
-    update_learning_status product
-
     unless product.wip
       notify_watching_mentors product
       create_advisers_watch product if product.user.trainee? && product.user.company
@@ -61,21 +59,5 @@ class ProductCallbacks
       product: product,
       receivers: mentors
     )
-  end
-
-  def update_learning_status(product)
-    previous_learning = Learning.find_or_initialize_by(
-      user_id: product.user.id,
-      practice_id: product.practice.id
-    )
-    status = if previous_learning.status == 'complete'
-               :complete
-             elsif product.wip
-               started_practice = product.user.learnings.map(&:status).include?('started')
-               started_practice ? :unstarted : :started
-             else
-               :submitted
-             end
-    product.change_learning_status status
   end
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -35,7 +35,7 @@ Rails.configuration.to_prepare do
 
   Newspaper.subscribe(:comeback_update, ComebackNotifier.new)
 
-  Newspaper.subscribe(:check_create, ProductStatusUpdater.new)
+  Newspaper.subscribe(:check_create, LearningStatusUpdaterWithProductCheck.new)
   Newspaper.subscribe(:product_create, ProductAuthorWatcher.new)
   Newspaper.subscribe(:product_create, LearningStatusUpdaterWithProductSubmission.new)
   Newspaper.subscribe(:product_update, LearningStatusUpdaterWithProductSubmission.new)

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -37,6 +37,8 @@ Rails.configuration.to_prepare do
 
   Newspaper.subscribe(:check_create, ProductStatusUpdater.new)
   Newspaper.subscribe(:product_create, ProductAuthorWatcher.new)
+  Newspaper.subscribe(:product_create, LearningStatusUpdaterWithProductSubmission.new)
+  Newspaper.subscribe(:product_update, LearningStatusUpdaterWithProductSubmission.new)
 
   page_notifier = PageNotifier.new
   Newspaper.subscribe(:page_create, page_notifier)

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -35,10 +35,12 @@ Rails.configuration.to_prepare do
 
   Newspaper.subscribe(:comeback_update, ComebackNotifier.new)
 
-  Newspaper.subscribe(:check_create, LearningStatusUpdater.new)
   Newspaper.subscribe(:product_create, ProductAuthorWatcher.new)
-  Newspaper.subscribe(:product_create, LearningStatusUpdater.new)
-  Newspaper.subscribe(:product_update, LearningStatusUpdater.new)
+
+  learning_status_updater = LearningStatusUpdater.new
+  Newspaper.subscribe(:check_create, learning_status_updater)
+  Newspaper.subscribe(:product_create, learning_status_updater)
+  Newspaper.subscribe(:product_update, learning_status_updater)
 
   page_notifier = PageNotifier.new
   Newspaper.subscribe(:page_create, page_notifier)

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -35,10 +35,10 @@ Rails.configuration.to_prepare do
 
   Newspaper.subscribe(:comeback_update, ComebackNotifier.new)
 
-  Newspaper.subscribe(:check_create, LearningStatusUpdaterWithProductCheck.new)
+  Newspaper.subscribe(:check_create, LearningStatusUpdater.new)
   Newspaper.subscribe(:product_create, ProductAuthorWatcher.new)
-  Newspaper.subscribe(:product_create, LearningStatusUpdaterWithProductSubmission.new)
-  Newspaper.subscribe(:product_update, LearningStatusUpdaterWithProductSubmission.new)
+  Newspaper.subscribe(:product_create, LearningStatusUpdater.new)
+  Newspaper.subscribe(:product_update, LearningStatusUpdater.new)
 
   page_notifier = PageNotifier.new
   Newspaper.subscribe(:page_create, page_notifier)

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -52,7 +52,6 @@ class ProductTest < ActiveSupport::TestCase
       user: user,
       practice: practice
     )
-    assert Learning.find_by(user: user, practice: practice, status: :submitted)
 
     status = :complete
     product.change_learning_status(status)


### PR DESCRIPTION
## Issue

- #6328 

## 概要
- 課題を提出する際の学習ステータスの変更処理をProductCallbacks.rbからNewspaperに委譲しました。
  - Newspaperのsubscriberを新規追加するに伴い、既存のsubscriberである`ProductStatusUpdater`の名前の意味が広すぎるので、リネームをしました。

Newspaperに関する詳細は、Issueにて駒形さんが参考記事を共有してますのでそちらをご覧下さい。

## 変更確認方法

1. `feature/repalce-update-learning-status-function-with-newspaper`をローカルに取り込む
2. `bin/setup`を実行する
3.  `bin/rails db:reset`を実行する
4. `bin/rails s`でローカル環境を立ち上げる
5. `osnashi`でログインする

### 課題を提出すると学習ステータスが変化することの確認
1. 「OS X Mountain Lionをクリーンインストールする」のプラクティスページ`/practices/315059988`にアクセスする
1. 学習ステータスが`未着手`であることを確認する
   <img width="397" alt="image" src="https://user-images.githubusercontent.com/85052152/226766868-584f3053-9d1a-4370-b63e-64ec1e25e5a7.png">
1. 提出物作成ページ`/products/new?practice_id=315059988`にアクセスする
1. 本文に任意の文字を入力し、「提出する」ボタンを押下する
1. 「OS X Mountain Lionをクリーンインストールする」のプラクティスページ`/practices/315059988`にアクセスする
1. 学習ステータスが`提出`であることを確認する
    <img width="391" alt="image" src="https://user-images.githubusercontent.com/85052152/226767010-8dc7c5dc-536f-4c89-97de-7c2d7af87819.png">


### WIPに戻すと学習ステータスが`着手`に変化することの確認（学習ステータス`着手`のプラクティスがない場合）
事前手順として「課題を提出すると学習ステータスが変化することの確認」を行うこと
1. プラクティス一覧ページ`/courses/829913840/practices`にアクセスする
1. 全プラクティスの学習ステータスが`着手`以外であることを確認する
    1. `着手`がある場合、そのプラクティスページにアクセスする
    1. `未着手`、`提出`、`完了`のいずれかを押下し、ステータスを変更させる
1. 「OS X Mountain Lionをクリーンインストールする」プラクティスの提出物ページ`/products/1071056610`にアクセスする
1. 「内容修正」ボタンを押下し、提出物編集ページに遷移する
1. 提出物編集ページで「WIP」ボタンを押下する
1. 「OS X Mountain Lionをクリーンインストールする」のプラクティスページ`/practices/315059988`にアクセスする
1. 学習ステータスが`着手`であることを確認する
   <img width="391" alt="image" src="https://user-images.githubusercontent.com/85052152/226767752-b2a57f16-e615-4e3c-8b89-65667a87067d.png">

### WIPに戻すと学習ステータスが`未着手`に変化することの確認（学習ステータス`着手`のプラクティスがある場合）
1. 「OS X Mountain Lionをクリーンインストールする」のプラクティスページ`/practices/315059988`にアクセスする
1. 学習ステータスの`着手`を押下し、学習ステータスを`着手`に変更する
1. 「Terminalの基礎を覚える」プラクティスの提出物作成ページ`/products/new?practice_id=198065840`にアクセスする
1. 本文に任意の文字を入力後、「提出する」ボタンを押下し、提出物ページに遷移する
1. 提出物ページで「内容修正」ボタンを押下し、提出物編集ページに遷移する
1. 提出物編集ページで「WIP」ボタンを押下する
1. 「Terminalの基礎を覚える」のプラクティスページ`/practices/198065840`にアクセスする
1. 学習ステータスが`未着手`であることを確認する

## Screenshot
画面上の変更がないため割愛します。

