### PR TITLE
最初の日報作成通知を newspaper に置き換える

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -51,8 +51,7 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
     if @report.save
-      Newspaper.publish(:report_create, @report.user)
-      Newspaper.publish(:first_report_create, @report)
+      Newspaper.publish(:report_save, @report)
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :new
@@ -65,8 +64,7 @@ class ReportsController < ApplicationController
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
     if @report.save
-      Newspaper.publish(:report_update, @report.user)
-      Newspaper.publish(:first_report_update, @report)
+      Newspaper.publish(:report_save, @report)
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :edit
@@ -75,7 +73,7 @@ class ReportsController < ApplicationController
 
   def destroy
     @report.destroy
-    Newspaper.publish(:report_destroy, @report.user)
+    Newspaper.publish(:report_destroy, @report)
     redirect_to reports_url, notice: '日報を削除しました。'
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -52,6 +52,7 @@ class ReportsController < ApplicationController
     canonicalize_learning_times(@report)
     if @report.save
       Newspaper.publish(:report_create, @report.user)
+      Newspaper.publish(:first_report_create, @report)
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :new
@@ -65,6 +66,7 @@ class ReportsController < ApplicationController
     canonicalize_learning_times(@report)
     if @report.save
       Newspaper.publish(:report_update, @report.user)
+      Newspaper.publish(:first_report_update, @report)
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :edit

--- a/app/models/first_report_notifier.rb
+++ b/app/models/first_report_notifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FirstReportNotifier
   def call(report)
     return if report.wip || !report.first? || Notification.find_by(kind: :first_report, sender_id: report.user.id).present?

--- a/app/models/first_report_notifier.rb
+++ b/app/models/first_report_notifier.rb
@@ -1,0 +1,9 @@
+class FirstReportNotifier
+  def call(report)
+    return if report.wip || !report.first? || Notification.find_by(kind: :first_report, sender_id: report.user.id).present?
+
+    User.admins_and_mentors.each do |receiver|
+      NotificationFacade.first_report(report, receiver) if report.sender != receiver
+    end
+  end
+end

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -29,14 +29,7 @@ class ReportCallbacks
     Watch.create!(user: report.user, watchable: report)
   end
 
-  def notify_first_report(report)
-    User.admins_and_mentors.each do |receiver|
-      NotificationFacade.first_report(report, receiver) if report.sender != receiver
-    end
-  end
-
   def notify_users(report)
-    notify_first_report(report) if report.first?
     notify_advisers(report) if report.user.trainee? && report.user.company_id?
     notify_consecutive_sad_report(report) if report.user.depressed?
     notify_followers(report)

--- a/app/models/sad_streak_updater.rb
+++ b/app/models/sad_streak_updater.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SadStreakUpdater
-  def call(user)
-    user.update_sad_streak
+  def call(report)
+    report.user.update_sad_streak
   end
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -16,6 +16,10 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:report_update, sad_streak_updater)
   Newspaper.subscribe(:report_destroy, sad_streak_updater)
 
+  first_report_notifier = FirstReportNotifier.new
+  Newspaper.subscribe(:first_report_create, first_report_notifier)
+  Newspaper.subscribe(:first_report_update, first_report_notifier)
+
   learning_cache_destroyer = LearningCacheDestroyer.new
   Newspaper.subscribe(:learning_create, learning_cache_destroyer)
   Newspaper.subscribe(:learning_destroy, learning_cache_destroyer)

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -12,13 +12,10 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:announcement_update, announcement_notifier)
 
   sad_streak_updater = SadStreakUpdater.new
-  Newspaper.subscribe(:report_create, sad_streak_updater)
-  Newspaper.subscribe(:report_update, sad_streak_updater)
+  Newspaper.subscribe(:report_save, sad_streak_updater)
   Newspaper.subscribe(:report_destroy, sad_streak_updater)
 
-  first_report_notifier = FirstReportNotifier.new
-  Newspaper.subscribe(:first_report_create, first_report_notifier)
-  Newspaper.subscribe(:first_report_update, first_report_notifier)
+  Newspaper.subscribe(:report_save, FirstReportNotifier.new)
 
   learning_cache_destroyer = LearningCacheDestroyer.new
   Newspaper.subscribe(:learning_create, learning_cache_destroyer)

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -13,20 +13,9 @@ class Notification::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'the first daily report notification is sent only to mentors' do
-    report = users(:muryou).reports.create!(
-      title: '初日報です',
-      description: '初日報の内容です',
-      reported_on: Date.current
-    )
-
-    Notification.create!(
-      kind: 7,
-      user: users(:komagata),
-      sender: users(:muryou),
-      message: "#{users(:muryou).login_name}さんがはじめての日報を書きました！",
-      link: "/reports/#{report.id}",
-      read: false
-    )
+    login_user 'muryou', 'testtest'
+    create_report('初日報です', '初日報の内容です', false)
+    logout
 
     notification_message = 'muryouさんがはじめての日報を書きました！'
     visit_with_auth '/notifications', 'machida'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6204

## 概要

ReportCallbacks.rbに定義されていた『最初の日報作成通知』を newspaper に置き換えました

## 変更確認方法

1. `feature/replace-first-report-notification-with-newspaper`をローカルに取り込む
2. `bin/rails s` 実行を実行後、[http://localhost:3000/](http://localhost:3000/)にアクセスし`osnashi`でログイン( 日報を未作成のユーザーなら誰でもOK )
3. [/reports/new (日報作成ページ)](http://localhost:3000/reports/new) にアクセス
4. 適当な内容で日報を作成する
5. `komagata`で再ログイン
6. [/notifications (通知ページ)](http://localhost:3000/notifications) にアクセスし、『🎉 osnashiさんがはじめての日報を書きました！』という通知が存在することを確認 ( osnashi には日報を作成した時のユーザー名が入ります )
7. [/letter_opner](http://localhost:3000/letter_opener) にアクセスし、`adminonly`, `komagata`, `machida`, `mentormentaro`, `unadmentor` の５人にメールが送信されているのを確認する

## Screenshot

### 変更前

**※アプリデザインの変更は無いため省略**

### 変更後

変更確認方法の手順を実行した結果です

#### 通知ページ

![download](https://user-images.githubusercontent.com/95903475/226629011-f7e7343f-5d53-41d6-b631-fec72092499e.png)

#### メール送信確認

![download](https://user-images.githubusercontent.com/95903475/226638575-34b45b55-4c23-4a68-aece-89edcf69b63c.png)


