### PR TITLE
メンターの提出物一覧の未返信タブにWIPの提出物は含めないようにする

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -78,6 +78,7 @@ class Product < ApplicationRecord
         SELECT products.*
         FROM products
         WHERE checker_id = ?
+        AND wip = false
       )
       SELECT self_assigned_products.id
       FROM self_assigned_products

--- a/db/fixtures/comments.yml
+++ b/db/fixtures/comments.yml
@@ -127,20 +127,12 @@ comment41:
   commentable: announcement1 (Announcement)
   description: "お知らせのコメントです。"
 
-<% (1..3).each do |i| %>
-comment<%= i + 41 %>:
-  user: <%= i.odd? ? 'kimura' : 'mentormentaro' %>
+comment42:
+  user: kimura
   commentable: product73 (Product)
-  description: <%= "#{i.odd? ? '提出者' : 'メンター'}のコメントです。" %>
-  created_at: <%= Time.current + i.minutes %>
-  updated_at: <%= Time.current + i.minutes %>
-<% end %>
+  description: "提出者のコメントです。"
 
-<% (1..3).each do |i| %>
-comment<%= i + 45 %>:
-  user: <%= i.even? ? 'kimura' : 'mentormentaro' %>
+comment43:
+  user: mentormentaro
   commentable: product74 (Product)
-  description: <%= "#{i.even? ? '提出者' : 'メンター'}のコメントです。" %>
-  created_at: <%= Time.current + i.minutes %>
-  updated_at: <%= Time.current + i.minutes %>
-<% end %>
+  description: "メンターのコメントです。"

--- a/db/fixtures/comments.yml
+++ b/db/fixtures/comments.yml
@@ -126,3 +126,21 @@ comment41:
   user: machida
   commentable: announcement1 (Announcement)
   description: "お知らせのコメントです。"
+
+<% (1..3).each do |i| %>
+comment<%= i + 41 %>:
+  user: <%= i.odd? ? 'kimura' : 'mentormentaro' %>
+  commentable: product73 (Product)
+  description: <%= "#{i.odd? ? '提出者' : 'メンター'}のコメントです。" %>
+  created_at: <%= Time.current + i.minutes %>
+  updated_at: <%= Time.current + i.minutes %>
+<% end %>
+
+<% (1..3).each do |i| %>
+comment<%= i + 45 %>:
+  user: <%= i.even? ? 'kimura' : 'mentormentaro' %>
+  commentable: product74 (Product)
+  description: <%= "#{i.even? ? '提出者' : 'メンター'}のコメントです。" %>
+  created_at: <%= Time.current + i.minutes %>
+  updated_at: <%= Time.current + i.minutes %>
+<% end %>

--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -140,3 +140,35 @@ product70:
   created_at: <%= 23.hour.ago %>
   updated_at: <%= 23.hour.ago %>
   published_at: <%= 23.hour.ago %>
+
+product71:
+  practice: practice7
+  user: kimura
+  body: 『mentormentaroが担当/提出済み/コメントがゼロ』の提出物です。
+  checker: mentormentaro
+  published_at: <%= now.to_formatted_s(:db) %>
+  created_at: <%= now.to_formatted_s(:db) %>
+
+product72:
+  practice: practice8
+  user: kimura
+  body: 『mentormentaroが担当/WIP/コメントがゼロ』の提出物です。
+  checker: mentormentaro
+  created_at: <%= now.to_formatted_s(:db) %>
+  wip: true
+
+product73:
+  practice: practice9
+  user: kimura
+  body: 『mentormentaroが担当/提出済み/最新のコメントがkimura』の提出物です。
+  checker: mentormentaro
+  published_at: <%= now.to_formatted_s(:db) %>
+  created_at: <%= now.to_formatted_s(:db) %>
+
+product74:
+  practice: practice10
+  user: kimura
+  body: 『mentormentaroが担当/提出済み/最新のコメントがmentormentaro』の提出物です。
+  checker: mentormentaro
+  published_at: <%= now.to_formatted_s(:db) %>
+  created_at: <%= now.to_formatted_s(:db) %>

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -114,13 +114,25 @@ class ProductTest < ActiveSupport::TestCase
 
   test '.self_assigned_no_replied_products' do
     current_user = users(:mentormentaro)
-    product = Product.create!(
+    published_product = Product.create!(
       body: 'test',
       user: users(:kimura),
       practice: practices(:practice5),
-      checker_id: nil
+      checker_id: nil,
+      published_at: Time.current.to_formatted_s(:db)
     )
-    product.save_checker(current_user.id)
-    assert_equal [product.id], Product.self_assigned_no_replied_products(current_user.id).pluck(:id)
+    wip_product = Product.create!(
+      body: 'test',
+      user: users(:kimura),
+      practice: practices(:practice7),
+      checker_id: nil,
+      wip: true
+    )
+    published_product.save_checker(current_user.id)
+    wip_product.save_checker(current_user.id)
+
+    self_assigned_no_replied_products = Product.self_assigned_no_replied_products(current_user.id).pluck(:id)
+    assert_not_equal  [wip_product.id], self_assigned_no_replied_products
+    assert_equal [published_product.id], self_assigned_no_replied_products
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -113,25 +113,26 @@ class ProductTest < ActiveSupport::TestCase
   end
 
   test '.self_assigned_no_replied_products' do
-    current_user = users(:mentormentaro)
+    mentor = users(:mentormentaro)
+    student = users(:kimura)
     published_product = Product.create!(
       body: 'test',
-      user: users(:kimura),
+      user: student,
       practice: practices(:practice5),
       checker_id: nil,
       published_at: Time.current.to_formatted_s(:db)
     )
     wip_product = Product.create!(
       body: 'test',
-      user: users(:kimura),
+      user: student,
       practice: practices(:practice7),
       checker_id: nil,
       wip: true
     )
-    published_product.save_checker(current_user.id)
-    wip_product.save_checker(current_user.id)
+    published_product.save_checker(mentor.id)
+    wip_product.save_checker(mentor.id)
 
-    self_assigned_no_replied_products = Product.self_assigned_no_replied_products(current_user.id).pluck(:id)
+    self_assigned_no_replied_products = Product.self_assigned_no_replied_products(mentor.id).pluck(:id)
     assert_not_equal [wip_product.id], self_assigned_no_replied_products
     assert_equal [published_product.id], self_assigned_no_replied_products
   end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -114,26 +114,30 @@ class ProductTest < ActiveSupport::TestCase
 
   test '.self_assigned_no_replied_products' do
     mentor = users(:mentormentaro)
-    student = users(:kimura)
-    published_product = Product.create!(
+    no_replied_product = Product.create!(
       body: 'test',
-      user: student,
+      user: users(:kimura),
       practice: practices(:practice5),
-      checker_id: nil,
+      checker_id: mentor.id,
       published_at: Time.current.to_formatted_s(:db)
     )
-    wip_product = Product.create!(
+
+    product_id_list = Product.self_assigned_no_replied_products(mentor.id).pluck(:id)
+    assert_includes product_id_list, no_replied_product.id
+  end
+
+  test '.self_assigned_no_replied_products not include wip products' do
+    mentor = users(:mentormentaro)
+    no_replied_wip_product = Product.create!(
       body: 'test',
-      user: student,
-      practice: practices(:practice7),
-      checker_id: nil,
+      user: users(:kimura),
+      practice: practices(:practice5),
+      checker_id: mentor.id,
+      published_at: Time.current.to_formatted_s(:db),
       wip: true
     )
-    published_product.save_checker(mentor.id)
-    wip_product.save_checker(mentor.id)
 
-    self_assigned_no_replied_products = Product.self_assigned_no_replied_products(mentor.id).pluck(:id)
-    assert_not_equal [wip_product.id], self_assigned_no_replied_products
-    assert_equal [published_product.id], self_assigned_no_replied_products
+    product_id_list = Product.self_assigned_no_replied_products(mentor.id).pluck(:id)
+    assert_not_includes product_id_list, no_replied_wip_product.id
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -132,7 +132,7 @@ class ProductTest < ActiveSupport::TestCase
     wip_product.save_checker(current_user.id)
 
     self_assigned_no_replied_products = Product.self_assigned_no_replied_products(current_user.id).pluck(:id)
-    assert_not_equal  [wip_product.id], self_assigned_no_replied_products
+    assert_not_equal [wip_product.id], self_assigned_no_replied_products
     assert_equal [published_product.id], self_assigned_no_replied_products
   end
 end

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -95,51 +95,23 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     assert_equal [user.login_name], names
   end
 
-  test 'not include no replied wip products' do
-    product62 = products(:product62)
-    product_title = "#{product62.practice.title}の提出物"
+  test 'not display no replied wip products if click on no-replied-button' do
+    mentor = users(:mentormentaro)
+    product = products(:product5)
 
-    assert_not product62.checked?
-
-    visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', 'machida'
+    visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', mentor.login_name
     product_list_titles = all('.card-list-item-title__title').map(&:text)
-    assert_includes product_list_titles, product_title
-
-    product62.update!(wip: true)
-
-    visit '/products/self_assigned?target=self_assigned_no_replied'
-    product_list_titles = all('.card-list-item-title__title').map(&:text)
-    assert_not_includes product_list_titles, product_title
+    assert_not_includes product_list_titles, product.title
   end
 
-  test 'not include wip product last replied by owner' do
-    checker = users(:machida)
-    product62 = products(:product62)
-    product_title = "#{product62.practice.title}の提出物"
+  test 'not display last replied by student replied wip products if click on no-replied-button' do
+    mentor = users(:machida)
+    product = products(:product63)
+    product.update(wip: true)
 
-    Comment.create!(
-      user: checker,
-      commentable: product62,
-      description: 'メンターのコメント'
-    )
-
-    Comment.create!(
-      user: product62.user,
-      commentable: product62,
-      description: '提出者のコメント'
-    )
-
-    assert_not product62.checked?
-
-    visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', checker.login_name
+    visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', mentor.login_name
     product_list_titles = all('.card-list-item-title__title').map(&:text)
-    assert_includes product_list_titles, product_title
-
-    product62.update!(wip: true)
-
-    visit '/products/self_assigned?target=self_assigned_no_replied'
-    product_list_titles = all('.card-list-item-title__title').map(&:text)
-    assert_not_includes product_list_titles, product_title
+    assert_not_includes product_list_titles, product.title
   end
 
   test 'display replied products if click on self_assigned_all-button' do

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -96,22 +96,29 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
   end
 
   test 'not display no replied wip products if click on no-replied-button' do
-    mentor = users(:mentormentaro)
-    product = products(:product5)
+    mentor = users(:machida)
+    product = products(:product62)
+    product.update!(wip: true)
 
     visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', mentor.login_name
-    product_list_titles = all('.card-list-item-title__title').map(&:text)
-    assert_not_includes product_list_titles, product.title
+    product_title_list = all('.card-list-item-title__title').map(&:text)
+    assert_not_includes product_title_list, "#{product.practice.title}の提出物"
   end
 
-  test 'not display last replied by student replied wip products if click on no-replied-button' do
+  test 'not display last replied wip products by student if click on no-replied-button' do
     mentor = users(:machida)
     product = products(:product63)
     product.update(wip: true)
 
+    Comment.create!(
+      user: product.user,
+      commentable: product,
+      description: '提出者のコメント'
+    )
+
     visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', mentor.login_name
-    product_list_titles = all('.card-list-item-title__title').map(&:text)
-    assert_not_includes product_list_titles, product.title
+    product_title_list = all('.card-list-item-title__title').map(&:text)
+    assert_not_includes product_title_list, "#{product.practice.title}の提出物"
   end
 
   test 'display replied products if click on self_assigned_all-button' do


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6252

## 概要

メンターの提出物一覧の未返信タブに表示されていたWIPの提出物を表示しないように変更しました

## 変更確認方法

1. `feature/not-include-wip-product-in-the-mentors-assigned-no-replay-products`をローカルに取り込む
2. `bin/rails db:seed` を実行
3. `bin/rails s`で起動後、[自分の担当する提出物一覧(全て)](http://localhost:3000/products/self_assigned?target=self_assigned_all) に `mentormentaro` でログイン
4. 『viのチュートリアルをやるの提出物』が WIP である事を確認
5. [未返信タブ](http://localhost:3000/products/self_assigned?target=self_assigned_no_replied)をクリックする
6. 『 viのチュートリアルをやるの提出物』が一覧に表示されない事を確認 
**※『 sshdをインストールするの提出物』も表示されなくなりますが正常です。(これは最新のコメントがメンターであるため "未返信である" という条件を満たさないためです)**

## Screenshot

### 変更前

![未返信タブ_自分の担当する提出物一覧_before](https://user-images.githubusercontent.com/95903475/229335170-979d21e7-b234-48e7-82c2-67af1ec6ae79.png)

### 変更後

![未返信タブ_自分の担当する提出物一覧_after](https://user-images.githubusercontent.com/95903475/229335188-61145611-e6bf-4ddb-b661-6f8cb6a78478.png)
