### PR TITLE
コメント・回答を投稿したら、画面をリロードしなくてもボタンをWatch中に変更する

### DIFF
--- a/app/javascript/VueMounter.js
+++ b/app/javascript/VueMounter.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import store from './check-store.js'
 
 export default class VueMounter {
   constructor() {
@@ -20,6 +21,7 @@ export default class VueMounter {
           const component = this.components[name]
 
           new Vue({
+            store,
             render: (h) => h(component, { props: props })
           }).$mount(`[data-vue="${name}"]`)
         })

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -171,6 +171,9 @@ export default {
           this.resizeTextarea()
           this.updateAnswerCount()
           this.toast('回答を投稿しました！')
+          this.$store.dispatch('setWatchable', {
+            watchableUserId: this.currentUser.id
+          })
         })
         .catch((error) => {
           console.warn(error)

--- a/app/javascript/check-store.js
+++ b/app/javascript/check-store.js
@@ -11,7 +11,8 @@ export default new Vuex.Store({
     checkableId: null,
     checkableType: null,
     productId: null,
-    productCheckerId: null
+    productCheckerId: null,
+    watchableUserId: null
   },
   getters: {
     checkId: (state) => state.checkId,
@@ -20,7 +21,8 @@ export default new Vuex.Store({
     checkableId: (state) => state.checkableId,
     checkableType: (state) => state.checkableType,
     productId: (state) => state.productId,
-    productCheckerId: (state) => state.productCheckerId
+    productCheckerId: (state) => state.productCheckerId,
+    watchableUserId: (state) => state.watchableUserId
   },
   mutations: {
     setCheckable(
@@ -36,6 +38,9 @@ export default new Vuex.Store({
     setProduct(state, { productId, productCheckerId }) {
       state.productId = productId
       state.productCheckerId = productCheckerId
+    },
+    setWatchable(state, { watchableUserId }) {
+      state.watchableUserId = watchableUserId
     }
   },
   actions: {
@@ -107,6 +112,17 @@ export default new Vuex.Store({
         .catch((error) => {
           console.warn(error)
         })
+    },
+    setWatchable({ commit }, { watchableUserId }) {
+      if (watchableUserId) {
+        commit('setWatchable', {
+          watchableUserId: watchableUserId
+        })
+      } else {
+        commit('setWatchable', {
+          watchableUserId: null
+        })
+      }
     }
   }
 })

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -283,6 +283,9 @@ export default {
     },
     postComment() {
       this.createComment()
+      this.$store.dispatch('setWatchable', {
+        watchableUserId: this.currentUserId
+      })
       if (this.isUnassignedAndUnchekedProduct) {
         this.checkProduct(
           this.commentableId,

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -31,6 +31,7 @@ class AnswersTest < ApplicationSystemTestCase
     assert_text 'test'
     click_button 'コメントする'
     assert_text 'test'
+    assert_text 'Watch中'
   end
 
   test 'edit answer form has comment tab and preview tab' do

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -44,6 +44,7 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'test'
     click_button 'コメントする'
     assert_text 'test'
+    assert_text 'Watch中'
   end
 
   test 'post new comment with mention for report' do
@@ -140,6 +141,7 @@ class CommentsTest < ApplicationSystemTestCase
     end
     click_button 'コメントする'
     assert_text 'test'
+    assert_text 'Watch中'
   end
 
   test 'check preview for product' do
@@ -160,6 +162,7 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'test'
     click_button 'コメントする'
     assert_text 'test'
+    assert_text 'Watch中'
   end
 
   test 'post new comment for page' do
@@ -171,6 +174,7 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'test'
     click_button 'コメントする'
     assert_text 'test'
+    assert_text 'Watch中'
   end
 
   test 'post new comment for event' do
@@ -182,6 +186,7 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'test'
     click_button 'コメントする'
     assert_text 'test'
+    assert_text 'Watch中'
   end
 
   test 'comment tab is active after a comment has been posted' do


### PR DESCRIPTION
## Issue

- #6227

## 概要
お知らせ、日報、提出物、Q&A、ドキュメント、イベントにコメント（Q&Aの場合は回答）を投稿した場合、リロードを行わなくてもWatchボタンが「Watch中」に変更されるようにしました。

## 変更確認方法

1. `feature/change-button-to-watching-without-reloading`をローカルに取り込む
2. `komagata`でログインする
3. お知らせ一覧（`/announcements`）にアクセスする
4. お知らせ一覧の先頭にあるお知らせ詳細ページにアクセスし、Watch状態になっていないことを確認する
もし先頭のページが「Watch中」になっていた場合は、Watch状態を解除してください。
5. コメントを投稿する
6. リロードを行わずに「Watch中」になっていることを確認する
7. 3−6の手順を「日報」「提出物」「Q&A」「ドキュメント」「イベント」「定期イベント」でそれぞれ行う
それぞれの一覧ページのURLは以下の通りです。
    * 日報一覧：`/reports`
    * 提出物一覧：`/products`
    * Q&A一覧：`/questions`
    * ドキュメント一覧：`/pages`
    * イベント一覧：`/events`
    * 定期イベント一覧：`/regular_events`

### 備考
こちらのIssue（#6227）に取り組んでいる際に、「Watchしていない状態でコメント・回答を投稿した後Watchボタンを押すと、Watchが重複した状態になる」バグを1点発見しました。
町田さんとの確認の結果、別Issueで対応が行われる形になりましたため、このIssueでは対応しておりません。バグの詳細につきましては、以下のIssueにて記載しています。
- #6369

## Screenshot

### 変更前
![23032502](https://user-images.githubusercontent.com/77523896/227696451-74c5c463-89e6-4f59-bc19-1f61a5fc9ad2.gif)

### 変更後
![23032501](https://user-images.githubusercontent.com/77523896/227696366-6d3fed86-9717-49f6-ab5f-05a7dc37c556.gif)

