### PR TITLE
提出物ページで企業研修生は研修終了日を名前の横に表示する

### DIFF
--- a/app/javascript/stylesheets/application/blocks/page-content/_page-content-header.sass
+++ b/app/javascript/stylesheets/application/blocks/page-content/_page-content-header.sass
@@ -83,7 +83,8 @@
     +position(absolute, left 0, top 0)
 
 .page-content-header__before-title
-  gap: .25rem
+  gap: .25rem 1rem
+  flex-wrap: wrap
   +media-breakpoint-up(md)
     display: inline-flex
     margin-bottom: .125rem

--- a/app/javascript/stylesheets/atoms/_a-meta.sass
+++ b/app/javascript/stylesheets/atoms/_a-meta.sass
@@ -45,3 +45,6 @@ a.a-meta
   display: flex
   .a-user-icon + &
     margin-left: .25rem
+  &.is-danger
+    font-weight: 600
+    color: $danger

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -743,12 +743,8 @@ class User < ApplicationRecord
     save!(validate: false)
   end
 
-  def training_end_date
-    training_ends_on
-  end
-
   def training_remaining_days
-    (training_end_date - Time.zone.today).to_i
+    (training_ends_on - Time.zone.today).to_i
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -743,6 +743,14 @@ class User < ApplicationRecord
     save!(validate: false)
   end
 
+  def training_end_date
+    training_ends_on
+  end
+
+  def training_remaining_days
+    (training_end_date - Time.zone.today).to_i
+  end
+
   private
 
   def password_required?

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -8,6 +8,24 @@ header.page-content-header
       .page-content-header__before-title
         = link_to @product.user, class: 'a-user-name' do
           = @product.user.long_name
+          - if current_user&.mentor? && @product.user.trainee?
+            = User.human_attribute_name :training_ends_on
+            - end_date = @product.user.training_ends_on
+            - remaining_days = (end_date - Time.zone.today).to_i
+            = end_date.strftime('%Y年%m月%d日')
+            - if end_date
+              - if remaining_days.zero?
+                | （本日研修最終日）
+              - elsif remaining_days.negative?
+                | （研修終了済み）
+              - elsif remaining_days < 7
+                / 赤字にする
+                | （あと#{remaining_days}日）
+              - else
+                | （あと#{remaining_days}日）
+            - else
+              | （未入力）
+
       h1.page-content-header__title(class="#{@product.wip? ? 'is-wip' : ''}")
         - if @product.wip?
           span.a-title-label.is-wip

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -8,23 +8,30 @@ header.page-content-header
       .page-content-header__before-title
         = link_to @product.user, class: 'a-user-name' do
           = @product.user.long_name
-          - if current_user&.mentor? && @product.user.trainee?
-            = User.human_attribute_name :training_ends_on
+        - if current_user&.mentor? && @product.user.trainee?
+          .a-meta
+            span.a-meta__label
+              = User.human_attribute_name :training_ends_on
             - end_date = @product.user.training_ends_on
-            - remaining_days = (end_date - Time.zone.today).to_i
-            = end_date.strftime('%Y年%m月%d日')
             - if end_date
+              - remaining_days = (end_date - Time.zone.today).to_i
+              span.a-meta__value
+                = end_date.strftime('%Y年%m月%d日')
               - if remaining_days.zero?
-                | （本日研修最終日）
+                span.a-meta__value.is-danger
+                  | （本日研修最終日）
               - elsif remaining_days.negative?
-                | （研修終了済み）
+                span.a-meta__value
+                  | （研修終了済み）
               - elsif remaining_days < 7
-                / 赤字にする
-                | （あと#{remaining_days}日）
+                span.a-meta__value.is-danger
+                  | （あと#{remaining_days}日）
               - else
-                | （あと#{remaining_days}日）
+                span.a-meta__value
+                  | （あと#{remaining_days}日）
             - else
-              | （未入力）
+              span.a-meta__value
+                | 未入力
 
       h1.page-content-header__title(class="#{@product.wip? ? 'is-wip' : ''}")
         - if @product.wip?

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -12,9 +12,9 @@ header.page-content-header
           .a-meta
             span.a-meta__label
               = User.human_attribute_name :training_ends_on
-            - if @product.user.training_end_date
+            - if @product.user.training_ends_on
               span.a-meta__value
-                = l @product.user.training_end_date
+                = l @product.user.training_ends_on
               - if @product.user.training_remaining_days.zero?
                 span.a-meta__value.is-danger
                   | （本日研修最終日）

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -12,23 +12,21 @@ header.page-content-header
           .a-meta
             span.a-meta__label
               = User.human_attribute_name :training_ends_on
-            - end_date = @product.user.training_ends_on
-            - if end_date
-              - remaining_days = (end_date - Time.zone.today).to_i
+            - if @product.user.training_end_date
               span.a-meta__value
-                = end_date.strftime('%Y年%m月%d日')
-              - if remaining_days.zero?
+                = l @product.user.training_end_date
+              - if @product.user.training_remaining_days.zero?
                 span.a-meta__value.is-danger
                   | （本日研修最終日）
-              - elsif remaining_days.negative?
+              - elsif @product.user.training_remaining_days.negative?
                 span.a-meta__value
                   | （研修終了済み）
-              - elsif remaining_days < 7
+              - elsif @product.user.training_remaining_days < 7
                 span.a-meta__value.is-danger
-                  | （あと#{remaining_days}日）
+                  | （あと#{@product.user.training_remaining_days}日）
               - else
                 span.a-meta__value
-                  | （あと#{remaining_days}日）
+                  | （あと#{@product.user.training_remaining_days}日）
             - else
               span.a-meta__value
                 | 未入力

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -288,6 +288,7 @@ kensyu:
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
   last_activity_at: "2014-01-01 00:00:11"
+  training_ends_on: "2023-12-31"
 
 senpai:
   login_name: senpai

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -288,7 +288,7 @@ kensyu:
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
   last_activity_at: "2014-01-01 00:00:11"
-  training_ends_on: "2023-12-31"
+  training_ends_on: <%= Time.current.next_year %>
 
 senpai:
   login_name: senpai


### PR DESCRIPTION
## Issue

- #6298

## 概要
提出物ページで企業研修生は研修終了日を名前の横に表示するようにしました。

## 変更確認方法

1. ブランチ`feature/display-training-end-date-next-to-name`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. ID`komagata`でログインして http://localhost:3000/products/901096139 にアクセス。

## Screenshot

### 変更前
<img width="802" alt="貼り付けた画像_2023_03_10_20_26-2" src="https://user-images.githubusercontent.com/83024928/227195456-faaa30ba-7c56-49f9-bf16-5574d22a0d2f.png">

### 変更後
<img width="776" alt="image" src="https://user-images.githubusercontent.com/83024928/232187625-95d71640-04af-4c7a-954e-7190ee3f1177.png">