### PR TITLE
Docを公開したときの notification のメッセージを変更

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -85,7 +85,7 @@ class PagesController < ApplicationController
 
     case action_name
     when :create
-      'ページを作成しました。'
+      'ドキュメントを作成しました。'
     when :update
       'ページを更新しました。'
     end

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -20,7 +20,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
       fill_in('page[title]', with: 'DocsTest')
       fill_in('page[body]', with: 'DocsTestBody')
     end
-    click_button '内容を保存'
+    click_button 'Docを公開'
     assert_text 'ドキュメントを作成しました。'
 
     visit_with_auth '/notifications', 'mentormentaro'

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -20,8 +20,8 @@ class Notification::PagesTest < ApplicationSystemTestCase
       fill_in('page[title]', with: 'DocsTest')
       fill_in('page[body]', with: 'DocsTestBody')
     end
-    click_button 'Docを公開'
-    assert_text 'ページを作成しました。'
+    click_button '内容を保存'
+    assert_text 'ドキュメントを作成しました。'
 
     visit_with_auth '/notifications', 'mentormentaro'
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -51,7 +51,7 @@ class PagesTest < ApplicationSystemTestCase
     fill_in 'page[title]', with: '新規Docを作成する'
     fill_in 'page[body]', with: '新規Docを作成する本文です'
     click_button '内容を保存'
-    assert_text 'ドキュメントを作成しました'
+    assert_text 'ドキュメントを作成しました。'
     assert_text 'Watch中'
   end
 
@@ -224,7 +224,7 @@ class PagesTest < ApplicationSystemTestCase
       click_button 'Docを公開'
     end
 
-    assert_text 'ドキュメントを作成しました'
+    assert_text 'ドキュメントを作成しました。'
     assert_text 'Watch中'
     assert_match 'Message to Discord.', mock_log.to_s
   end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -50,7 +50,7 @@ class PagesTest < ApplicationSystemTestCase
     assert_equal new_page_path, current_path
     fill_in 'page[title]', with: '新規Docを作成する'
     fill_in 'page[body]', with: '新規Docを作成する本文です'
-    click_button '内容を保存'
+    click_button 'Docを公開'
     assert_text 'ドキュメントを作成しました。'
     assert_text 'Watch中'
   end
@@ -258,7 +258,7 @@ class PagesTest < ApplicationSystemTestCase
     check 'ドキュメント公開のお知らせを書く', allow_label_click: true
     click_button 'Docを公開'
 
-    assert_text 'ページを作成しました'
+    assert_text 'ドキュメントを作成しました。'
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れて新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れて新規Docを作成」の本文です。'
   end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -50,8 +50,8 @@ class PagesTest < ApplicationSystemTestCase
     assert_equal new_page_path, current_path
     fill_in 'page[title]', with: '新規Docを作成する'
     fill_in 'page[body]', with: '新規Docを作成する本文です'
-    click_button 'Docを公開'
-    assert_text 'ページを作成しました'
+    click_button '内容を保存'
+    assert_text 'ドキュメントを作成しました'
     assert_text 'Watch中'
   end
 
@@ -224,7 +224,7 @@ class PagesTest < ApplicationSystemTestCase
       click_button 'Docを公開'
     end
 
-    assert_text 'ページを作成しました'
+    assert_text 'ドキュメントを作成しました'
     assert_text 'Watch中'
     assert_match 'Message to Discord.', mock_log.to_s
   end


### PR DESCRIPTION
## Issue

- [Docを公開したときの notification のメッセージを変更したい。 #6302](https://github.com/fjordllc/bootcamp/issues/6302)

## 概要
Docを公開してページ遷移後に表示されるフラッシュメッセージを「ドキュメントを作成しました。」に変更しました。

## 変更確認方法

1. `feature/change-Doc-published-notification-message`をローカルに取り込む
2. `$ foreman start -f Procfile.dev`で起動
3. 任意のアカウントにログインし、http://localhost:3000/pages/new にアクセス
4. 「タイトル」と「本文」に任意のテキストを入力し、「内容を保存」を実行
5. ページ遷移後に画面上部に該当箇所のフラッシュメッセージが表示される

## Screenshot
### 変更前
<img width="1440" alt="スクリーンショット 2023-03-25 17 11 43" src="https://user-images.githubusercontent.com/69577164/227757264-b3e4adc1-c529-4545-95e4-9532872d4dae.png">

### 変更後
<img width="1440" alt="スクリーンショット 2023-03-26 14 33 56" src="https://user-images.githubusercontent.com/69577164/227757395-a1fc19d0-cd82-4068-a8c1-537d6e405c02.png">

