### PR TITLE
休会中ユーザーのプロフィール画面での区分のI18nを追加し、翻訳ミッシングを解消

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -311,6 +311,7 @@ ja:
     student_and_trainee: 現役生
     student: 現役生
     job_seeking: 就職活動中
+    hibernationed: 休会中
     mentor: メンター
     graduate: 卒業生
     adviser: アドバイザー

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -79,6 +79,9 @@ class UsersTest < ApplicationSystemTestCase
 
     visit_with_auth "/users/#{users(:sotugyou).id}", 'sotugyou'
     assert_text '卒業生'
+
+    visit_with_auth "/users/#{users(:kyuukai).id}", 'kyuukai'
+    assert_text '休会中'
   end
 
   test 'show completed practices' do


### PR DESCRIPTION
## Issue

- [休会ユーザーのプロフィールでtranslation missing #6296](https://github.com/fjordllc/bootcamp/issues/6296)

## 概要
休会中ユーザーのプロフィール画面において、区分欄の表示にtranslation missingが生じていたところ、翻訳を追加し「休会中」と表示されるようにしました。

## 変更確認方法

1. feature/resolving_translation_missing_adjourned_userをローカルに取り込む
1. `$ foreman start -f Procfile.dev`で起動
1. 任意のアカウントにログインし、http://localhost:3000/users/kyuukai にアクセス

## Screenshot
### 変更前
<img width="1440" alt="スクリーンショット 2023-03-26 16 09 59" src="https://user-images.githubusercontent.com/69577164/227764148-37aba2bb-5506-4190-8a13-0ad928351cd7.png">

### 変更後
<img width="1440" alt="スクリーンショット 2023-03-26 17 25 26" src="https://user-images.githubusercontent.com/69577164/227764154-3267330d-eadd-4c86-901a-d7ee7903d77b.png">
