### PR TITLE
提出物一覧の提出物投稿者名を名前（カナ）に変更

### DIFF
--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -26,7 +26,7 @@
           .card-list-item-meta__items
             .card-list-item-meta__item
               a.a-user-name(:href='product.user.url')
-                | {{ product.user.login_name }}
+                | {{ product.user.long_name }}
       .card-list-item__row
         .card-list-item-meta
           .card-list-item-meta__items

--- a/test/system/company/products_test.rb
+++ b/test/system/company/products_test.rb
@@ -15,8 +15,10 @@ class Company::ProductsTest < ApplicationSystemTestCase
     # id順で並べたときの最初と最後の提出物を、作成日順で見たときに最新と最古になるように入れ替える
     Product.where(user: user).update_all(created_at: 1.day.ago, published_at: 1.day.ago) # rubocop:disable Rails/SkipsModelValidations
     newest_product = Product.where(user: user).first
+    newest_product_decorated_author = ActiveDecorator::Decorator.instance.decorate(newest_product.user)
     newest_product.update(created_at: Time.current)
     oldest_product = Product.where(user: user).last
+    oldest_product_decorated_author = ActiveDecorator::Decorator.instance.decorate(oldest_product.user)
     oldest_product.update(created_at: 2.days.ago)
 
     visit_with_auth "/companies/#{companies(:company1).id}/products", 'kimura'
@@ -25,8 +27,8 @@ class Company::ProductsTest < ApplicationSystemTestCase
     titles = all('.card-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.card-list-item-meta .a-user-name').map(&:text)
     assert_equal "#{newest_product.practice.title}の提出物", titles.first
-    assert_equal newest_product.user.login_name, names.first
+    assert_equal newest_product_decorated_author.long_name, names.first
     assert_equal "#{oldest_product.practice.title}の提出物", titles.last
-    assert_equal oldest_product.user.login_name, names.last
+    assert_equal oldest_product_decorated_author.long_name, names.last
   end
 end

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -101,7 +101,7 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     checker = users(:mentormentaro)
     practice = practices(:practice5)
     user = users(:kimura)
-    decorated_user = ActiveDecorator::Decorator.instance.decorate(user) 
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     product = Product.create!(
       body: 'test',
       user: user,

--- a/test/system/product/self_assigned_test.rb
+++ b/test/system/product/self_assigned_test.rb
@@ -65,6 +65,7 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     checker = users(:mentormentaro)
     practice = practices(:practice5)
     user = users(:kimura)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     Product.create!(
       body: 'test',
       user: user,
@@ -75,13 +76,14 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     titles = all('.card-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.card-list-item-meta .a-user-name').map(&:text)
     assert_equal ["#{practice.title}の提出物"], titles
-    assert_equal [user.login_name], names
+    assert_equal [decorated_user.long_name], names
   end
 
   test 'display no replied products if click on no-replied-button' do
     checker = users(:mentormentaro)
     practice = practices(:practice5)
     user = users(:kimura)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
     Product.create!(
       body: 'test',
       user: user,
@@ -92,13 +94,14 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     titles = all('.card-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.card-list-item-meta .a-user-name').map(&:text)
     assert_equal ["#{practice.title}の提出物"], titles
-    assert_equal [user.login_name], names
+    assert_equal [decorated_user.long_name], names
   end
 
   test 'display replied products if click on self_assigned_all-button' do
     checker = users(:mentormentaro)
     practice = practices(:practice5)
     user = users(:kimura)
+    decorated_user = ActiveDecorator::Decorator.instance.decorate(user) 
     product = Product.create!(
       body: 'test',
       user: user,
@@ -114,7 +117,7 @@ class Product::SelfAssignedTest < ApplicationSystemTestCase
     titles = all('.card-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.card-list-item-meta .a-user-name').map(&:text)
     assert_equal ["#{practice.title}の提出物"], titles
-    assert_equal [user.login_name], names
+    assert_equal [decorated_user.long_name], names
     visit_with_auth '/products/self_assigned?target=self_assigned_no_replied', 'mentormentaro'
     assert_text '未返信の担当提出物はありません'
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -303,7 +303,9 @@ class ProductsTest < ApplicationSystemTestCase
     Product.limit(Product.count - Product.default_per_page).delete_all
     newest_product = Product.reorder(:id).first
     newest_product.update(published_at: Time.current)
+    newest_product_decorated_author = ActiveDecorator::Decorator.instance.decorate(newest_product.user)
     oldest_product = Product.reorder(:id).last
+    oldest_product_decorated_author = ActiveDecorator::Decorator.instance.decorate(oldest_product.user)
     oldest_product.update(published_at: 2.days.ago)
 
     visit_with_auth '/products', 'komagata'
@@ -312,9 +314,9 @@ class ProductsTest < ApplicationSystemTestCase
     titles = all('.card-list-item-title__title').map { |t| t.text.gsub('★', '') }
     names = all('.card-list-item-meta .a-user-name').map(&:text)
     assert_equal "#{newest_product.practice.title}の提出物", titles.first
-    assert_equal newest_product.user.login_name, names.first
+    assert_equal newest_product_decorated_author.long_name, names.first
     assert_equal "#{oldest_product.practice.title}の提出物", titles.last
-    assert_equal oldest_product.user.login_name, names.last
+    assert_equal oldest_product_decorated_author.long_name, names.last
   end
 
   test 'setting checker' do


### PR DESCRIPTION
## Issue

- #6321

## 概要
現在、提出物投稿者名が`アカウント名`のみの表示になっています。
今回の修正で提出物投稿者名を`アカウント名（カタカナの名前）`に変更しました。

## 変更確認方法

1. `feature/display_user_name_with_kana_on_products_page`をローカルに取り込んでください
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げてください。
3. `mentormentaro`でログインを行い、提出物ページへ移動してください。
4. 提出物投稿者名が`アカウント名（カタカナの名前）`になっていることを確認してください。

## Screenshot

### 変更前
![スクリーンショット 2023-03-30 13 09 20](https://user-images.githubusercontent.com/81839214/228727120-15804486-44cf-438e-9a57-c60e8d718512.png)
### 変更後
![スクリーンショット 2023-03-30 13 14 14](https://user-images.githubusercontent.com/81839214/228727616-f83b83d2-78ae-40aa-8124-2e71ee60f594.png)

### 参考PR
[日報一覧の投稿者名のカッコ内を名前ではなく「名前（カナ）」に変更 \#6216](https://github.com/fjordllc/bootcamp/pull/6216)
