### PR TITLE
休会復帰時のトライアル日時処理の変更

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -11,7 +11,7 @@ class AnnouncementsController < ApplicationController
   def new
     @announcement = Announcement.new(target: 'students')
 
-    if params[:page_id].present?
+    if params[:page_id]
       page = Page.find(params[:page_id])
       page_url = "https://bootcamp.fjord.jp/pages/#{params[:page_id]}"
       @announcement.title       = "ドキュメント「#{page.title}」を公開しました。"

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -11,6 +11,13 @@ class AnnouncementsController < ApplicationController
   def new
     @announcement = Announcement.new(target: 'students')
 
+    if params[:page_id].present?
+      page = Page.find(params[:page_id])
+      page_url = "https://bootcamp.fjord.jp/pages/#{params[:page_id]}"
+      @announcement.title       = "ドキュメント「#{page.title}」を公開しました。"
+      @announcement.description = "<!--  このテキストを編集してください-->\n\nドキュメント「#{page.title}」を公開しました。\n#{page_url}\n\n<!--  不要な場合以下は削除 -->\n---\n\n#{page.description}"
+    end
+
     return unless params[:id]
 
     announcement = Announcement.find(params[:id])

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,20 +29,16 @@ class PagesController < ApplicationController
 
   def create
     @page = Page.new(page_params)
-    @page.user ? @page.last_updated_user = current_user : @page.user = current_user
+    @page.last_updated_user = current_user
+    @page.user ||= current_user
     set_wip
     if @page.save
-      unless @page.wip?
+      url = page_url(@page)
+      if @page.not_wip?
         Newspaper.publish(:page_create, @page)
-        if @page.announcement_of_publication?
-          redirect_to new_announcement_path(page_id: @page.id), notice: notice_message(@page, :create)
-        else
-          redirect_to @page, notice: notice_message(@page, :create)
-        end
-        return
+        url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
-
-      redirect_to @page, notice: notice_message(@page, :create)
+      redirect_to url, notice: notice_message(@page, :create)
     else
       render :new
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -34,7 +34,9 @@ class PagesController < ApplicationController
     if @page.save
       unless @page.wip?
         Newspaper.publish(:page_create, @page)
-        redirect_to new_announcement_path, notice: notice_message(@page, :create) and return if announcement_checked?
+        if announcement_checked?
+          redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create) and return
+        end
       end
 
       redirect_to @page, notice: notice_message(@page, :create)
@@ -49,7 +51,9 @@ class PagesController < ApplicationController
     if @page.update(page_params)
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
-        redirect_to new_announcement_path, notice: notice_message(@page, :create) and return if announcement_checked?
+        if announcement_checked?
+          redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create) and return
+        end
       end
 
       redirect_to @page, notice: notice_message(@page, :update)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -35,8 +35,11 @@ class PagesController < ApplicationController
       unless @page.wip?
         Newspaper.publish(:page_create, @page)
         if @page.announcement_of_publication?
-          redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create) and return
+          redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create)
+        else
+          redirect_to @page, notice: notice_message(@page, :create)
         end
+        return
       end
 
       redirect_to @page, notice: notice_message(@page, :create)
@@ -52,8 +55,11 @@ class PagesController < ApplicationController
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
         if @page.announcement_of_publication?
-          redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create) and return
+          redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create)
+        else
+          redirect_to @page, notice: notice_message(@page, :update)
         end
+        return
       end
 
       redirect_to @page, notice: notice_message(@page, :update)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -34,7 +34,7 @@ class PagesController < ApplicationController
     set_wip
     if @page.save
       url = page_url(@page)
-      if @page.not_wip?
+      if !@page.wip?
         Newspaper.publish(:page_create, @page)
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
@@ -48,17 +48,12 @@ class PagesController < ApplicationController
     set_wip
     @page.last_updated_user = current_user
     if @page.update(page_params)
+      url = page_url(@page)
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
-        if @page.announcement_of_publication?
-          redirect_to new_announcement_path(page_id: @page.id), notice: notice_message(@page, :update)
-        else
-          redirect_to @page, notice: notice_message(@page, :update)
-        end
-        return
+        url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
       end
-
-      redirect_to @page, notice: notice_message(@page, :update)
+      redirect_to url, notice: notice_message(@page, :update)
     else
       render :edit
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -35,7 +35,7 @@ class PagesController < ApplicationController
       unless @page.wip?
         Newspaper.publish(:page_create, @page)
         if @page.announcement_of_publication?
-          redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create)
+          redirect_to new_announcement_path(page_id: @page.id), notice: notice_message(@page, :create)
         else
           redirect_to @page, notice: notice_message(@page, :create)
         end
@@ -55,7 +55,7 @@ class PagesController < ApplicationController
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
         if @page.announcement_of_publication?
-          redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create)
+          redirect_to new_announcement_path(page_id: @page.id), notice: notice_message(@page, :update)
         else
           redirect_to @page, notice: notice_message(@page, :update)
         end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -34,7 +34,7 @@ class PagesController < ApplicationController
     set_wip
     if @page.save
       url = page_url(@page)
-      if !@page.wip?
+      if @page.not_wip?
         Newspaper.publish(:page_create, @page)
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -34,7 +34,7 @@ class PagesController < ApplicationController
     if @page.save
       unless @page.wip?
         Newspaper.publish(:page_create, @page)
-        if announcement_checked?
+        if @page.announcement_of_publication?
           redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create) and return
         end
       end
@@ -51,7 +51,7 @@ class PagesController < ApplicationController
     if @page.update(page_params)
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
         Newspaper.publish(:page_update, @page)
-        if announcement_checked?
+        if @page.announcement_of_publication?
           redirect_to new_announcement_path(title: page_params[:title], description: page_params[:body]), notice: notice_message(@page, :create) and return
         end
       end
@@ -74,7 +74,7 @@ class PagesController < ApplicationController
   end
 
   def page_params
-    keys = %i[title body tag_list practice_id slug announcement]
+    keys = %i[title body tag_list practice_id slug announcement_of_publication]
     keys << :user_id if admin_or_mentor_login?
     params.require(:page).permit(*keys)
   end
@@ -106,9 +106,5 @@ class PagesController < ApplicationController
     return if @page.slug.nil?
 
     redirect_to request.original_url.sub(params[:slug_or_id], @page.slug) unless params[:slug_or_id].start_with?(/[a-z]/)
-  end
-
-  def announcement_checked?
-    page_params[:announcement] == '1' # ’1’は「ドキュメント公開のお知らせを書く」にチェックが入っている場合を指します
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -109,6 +109,6 @@ class PagesController < ApplicationController
   end
 
   def announcement_checked?
-    page_params[:announcement] == '1' # ’1’は「このドキュメント公開についてお知らせを書く」にチェックが入っている場合を指します
+    page_params[:announcement] == '1' # ’1’は「ドキュメント公開のお知らせを書く」にチェックが入っている場合を指します
   end
 end

--- a/app/javascript/stylesheets/application/blocks/form/_form-actions.sass
+++ b/app/javascript/stylesheets/application/blocks/form/_form-actions.sass
@@ -95,3 +95,8 @@
   +text-block(.875rem 1.4, $muted-text)
   &:hover
     color: $danger
+
+.form-action-before-option
+  margin-bottom: .5rem
+  &.has-help
+    display: flex

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -29,6 +29,10 @@ class Page < ApplicationRecord
     Page.find_by!(attr_name => params)
   end
 
+  def not_wip?
+    !wip?
+  end
+
   private
 
   def empty_slug_to_nil

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,6 +18,7 @@ class Page < ApplicationRecord
   validates :slug, length: { maximum: 200 }, format: { with: /\A[a-z][a-z0-9_-]*\z/ }, uniqueness: true, allow_nil: true
   paginates_per 20
   alias sender user
+  attribute :announcement, :string
 
   columns_for_keyword_search :title, :body
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,7 +18,7 @@ class Page < ApplicationRecord
   validates :slug, length: { maximum: 200 }, format: { with: /\A[a-z][a-z0-9_-]*\z/ }, uniqueness: true, allow_nil: true
   paginates_per 20
   alias sender user
-  attribute :announcement, :string
+  attribute :announcement_of_publication, :boolean
 
   columns_for_keyword_search :title, :body
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -29,10 +29,6 @@ class Page < ApplicationRecord
     Page.find_by!(attr_name => params)
   end
 
-  def not_wip?
-    !wip?
-  end
-
   private
 
   def empty_slug_to_nil

--- a/app/models/page_notifier.rb
+++ b/app/models/page_notifier.rb
@@ -13,7 +13,7 @@ class PageNotifier
   private
 
   def send_notification(page)
-    receivers = User.where(retired_on: nil, graduated_on: nil, adviser: false, trainee: false)
+    receivers = User.where(admin: true).or(User.where(mentor: true))
     receivers.each do |receiver|
       ActivityDelivery.with(receiver: receiver, page: page).notify(:create_page) if page.sender != receiver
     end

--- a/app/models/page_notifier.rb
+++ b/app/models/page_notifier.rb
@@ -13,7 +13,7 @@ class PageNotifier
   private
 
   def send_notification(page)
-    receivers = User.where(admin: true).or(User.where(mentor: true))
+    receivers = User.admins_and_mentors
     receivers.each do |receiver|
       ActivityDelivery.with(receiver: receiver, page: page).notify(:create_page) if page.sender != receiver
     end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -13,13 +13,13 @@ class Subscription
   end
 
   def create(customer_id, idempotency_key = SecureRandom.uuid, trial: 3)
-    Stripe::Subscription.create({
-                                  customer: customer_id,
-                                  trial_end: trial.days.since.to_i,
-                                  items: [{ plan: Plan.standard_plan.id }]
-                                }, {
-                                  idempotency_key: idempotency_key
-                                })
+    options = {
+      customer: customer_id,
+      items: [{ plan: Plan.standard_plan.id }]
+    }
+    options[:trial_end] = trial.days.since.to_i if trial.positive?
+
+    Stripe::Subscription.create(options, { idempotency_key: idempotency_key })
   end
 
   def destroy(subscription_id)

--- a/app/views/admin/companies/edit.html.slim
+++ b/app/views/admin/companies/edit.html.slim
@@ -9,7 +9,7 @@ header.page-header
           .page-header-actions__item
             = link_to new_admin_company_path, class: 'a-button is-md is-secondary is-block' do
               i.fa-regular.fa-plus
-              | 企業作成
+              | 企業追加
 
 = render 'admin/admin_page_tabs'
 

--- a/app/views/admin/companies/new.html.slim
+++ b/app/views/admin/companies/new.html.slim
@@ -18,8 +18,7 @@ main.page-main
           .page-main-header-actions
             ul.page-main-header-actions__items
               li.page-main-header-actions__item
-                = link_to admin_companies_path, class: 'a-button is-sm is-block is-secondary is-back' do
-                  | 企業一覧
+                = link_to '企業一覧', admin_companies_path, class: 'a-button is-sm is-block is-secondary is-back'
 .page-body
   .container.is-md
     = render 'form', company: @company

--- a/app/views/admin/companies/new.html.slim
+++ b/app/views/admin/companies/new.html.slim
@@ -1,4 +1,4 @@
-- title '企業作成'
+- title '管理ページ'
 
 header.page-header
   .container
@@ -7,6 +7,12 @@ header.page-header
 
 = render 'admin/admin_page_tabs'
 
+header.page-main-header
+  .container
+    .page-main-header__inner
+      .page-main-header__start
+        h1.page-main-header__title
+          | 企業追加
 .page-body
   .container.is-md
     = render 'form', company: @company

--- a/app/views/admin/companies/new.html.slim
+++ b/app/views/admin/companies/new.html.slim
@@ -7,12 +7,19 @@ header.page-header
 
 = render 'admin/admin_page_tabs'
 
-header.page-main-header
-  .container
-    .page-main-header__inner
-      .page-main-header__start
-        h1.page-main-header__title
-          | 企業追加
+main.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        .page-main-header__start
+          h1.page-main-header__title
+            | 企業追加
+        .page-main-header__end
+          .page-main-header-actions
+            ul.page-main-header-actions__items
+              li.page-main-header-actions__item
+                = link_to admin_companies_path, class: 'a-button is-sm is-block is-secondary is-back' do
+                  | 企業一覧
 .page-body
   .container.is-md
     = render 'form', company: @company

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -8,21 +8,12 @@
         .col-lg-9.col-xs-12
           .form-item
             = f.label :title, class: 'a-form-label'
-            - if params[:title].present?
-              = f.text_field :title, class: 'a-text-input js-warning-form', value: "ドキュメント「#{params[:title]}」を公開しました。"
-            - else
-              = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
+            = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
     .form-item
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          - if params[:description].present?
-            = f.text_area :description,
-              class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
-              data: { 'preview': '.js-preview' },
-              value: "<!--  このテキストを編集してください-->\n\nドキュメント「#{params[:title]}」を公開しました。\nhttps://bootcamp.fjord.jp/pages/#{current_user.pages.last.id}\n\n<!--  不要な場合以下は削除 -->\n---\n\n#{params[:description]}"
-          - else
-            = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -8,7 +8,7 @@
         .col-lg-9.col-xs-12
           .form-item
             = f.label :title, class: 'a-form-label'
-            - if request.referer.include?('/pages/')
+            - if params[:title].present?
               = f.text_field :title, class: 'a-text-input js-warning-form', value: "ドキュメント「#{current_user.pages.last.title}」を公開しました。"
             - else
               = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
@@ -16,7 +16,7 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          - if request.referer.include?('/pages/')
+          - if params[:description].present?
             = f.text_area :description,
               class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
               data: { 'preview': '.js-preview' },

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -8,12 +8,21 @@
         .col-lg-9.col-xs-12
           .form-item
             = f.label :title, class: 'a-form-label'
-            = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
+            - if request.referer.include?('/pages/')
+              = f.text_field :title, class: 'a-text-input js-warning-form', value: "ドキュメント「#{current_user.pages.last.title}」を公開しました。"
+            - else
+              = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
     .form-item
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+          - if request.referer.include?('/pages/')
+            = f.text_area :description,
+              class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+              data: { 'preview': '.js-preview' },
+              value: "<!--  このテキストを編集してください-->\n\nドキュメント「#{current_user.pages.last.title}」を公開しました。\nhttps://bootcamp.fjord.jp/pages/#{current_user.pages.last.id}\n\n<!--  不要な場合以下は削除 -->\n---\n\n#{current_user.pages.last.description}"
+          - else
+            = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -9,7 +9,7 @@
           .form-item
             = f.label :title, class: 'a-form-label'
             - if params[:title].present?
-              = f.text_field :title, class: 'a-text-input js-warning-form', value: "ドキュメント「#{current_user.pages.last.title}」を公開しました。"
+              = f.text_field :title, class: 'a-text-input js-warning-form', value: "ドキュメント「#{params[:title]}」を公開しました。"
             - else
               = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
     .form-item
@@ -20,7 +20,7 @@
             = f.text_area :description,
               class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
               data: { 'preview': '.js-preview' },
-              value: "<!--  このテキストを編集してください-->\n\nドキュメント「#{current_user.pages.last.title}」を公開しました。\nhttps://bootcamp.fjord.jp/pages/#{current_user.pages.last.id}\n\n<!--  不要な場合以下は削除 -->\n---\n\n#{current_user.pages.last.description}"
+              value: "<!--  このテキストを編集してください-->\n\nドキュメント「#{params[:title]}」を公開しました。\nhttps://bootcamp.fjord.jp/pages/#{current_user.pages.last.id}\n\n<!--  不要な場合以下は削除 -->\n---\n\n#{params[:description]}"
           - else
             = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
         .col-md-6.col-xs-12

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -52,8 +52,8 @@
             .checkboxes
               ul.checkboxes__items
                 li.checkboxes__item
-                  = f.check_box :announcement, class: 'a-toggle-checkbox'
-                  = f.label :announcement
+                  = f.check_box :announcement_of_publication, class: 'a-toggle-checkbox'
+                  = f.label :announcement_of_publication
                     | ドキュメント公開のお知らせを書く
             label.a-form-help-link.is-muted-text(for='modal-announcement')
               span.a-help

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -42,6 +42,14 @@
               | スラッグを設定すると`https://bootcamp.fjord.jp/pages/{スラッグ}`の様にスラッグで指定した文字列のURLでアクセスが出来るようになります。
               br
               | スラッグにはアルファベットから始まる半角英数字と、ハイフン （ - ）、アンダーバー （ _ ） が使えます。
+    .form-item
+      = f.label :announcement, class: 'a-form-label'
+      .checkboxes
+        ul.checkboxes__items
+          li.checkboxes__item
+            = f.check_box :announcement, class: 'a-toggle-checkbox'
+            = f.label :announcement
+              | このドキュメント公開についてお知らせを書く
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -42,28 +42,51 @@
               | スラッグを設定すると`https://bootcamp.fjord.jp/pages/{スラッグ}`の様にスラッグで指定した文字列のURLでアクセスが出来るようになります。
               br
               | スラッグにはアルファベットから始まる半角英数字と、ハイフン （ - ）、アンダーバー （ _ ） が使えます。
-    - unless @page.published_at?
-      .form-item
-        = f.label :announcement, class: 'a-form-label'
-        .checkboxes
-          ul.checkboxes__items
-            li.checkboxes__item
-              = f.check_box :announcement, class: 'a-toggle-checkbox'
-              = f.label :announcement
-                | このドキュメント公開についてお知らせを書く
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main
         = f.submit 'WIP', class: 'a-button is-lg is-secondary is-block', id: 'js-shortcut-wip'
       li.form-actions__item.is-main
+        - unless @page.published_at?
+          .form-action-before-option.has-help
+            .checkboxes
+              ul.checkboxes__items
+                li.checkboxes__item
+                  = f.check_box :announcement, class: 'a-toggle-checkbox'
+                  = f.label :announcement
+                    | ドキュメント公開のお知らせを書く
+            label.a-form-help-link.is-muted-text(for='modal-announcement')
+              span.a-help
+                i.fa-solid.fa-question
+
         = button_tag(class: 'a-button is-lg is-primary is-block') do
-          - if params[:action] == 'new' || params[:action] == 'create' || params[:action] == 'edit' || params[:action] == 'update'
-            | 内容を保存
-          - else
-            | 内容を投稿
+          - case params[:action]
+          - when 'new', 'create'
+            | Docを公開
+          - when 'edit', 'update'
+            | 内容を更新
       li.form-actions__item.is-sub
         - case params[:action]
         - when 'new', 'create'
           = link_to 'キャンセル', :pages, class: 'a-button is-sm is-text'
         - when 'edit', 'update'
           = link_to 'キャンセル', :pages, class: 'a-button is-sm is-text'
+
+= render '/shared/modal', id: 'modal-announcement', modal_title: 'ドキュメント公開のお知らせを書く'
+  .modal__description.is-md
+    .a-short-text
+      p
+        | こちらのチェックを入れてから Doc を公開すると、
+        | お知らせ作成ページに遷移します。
+      p
+        | 遷移したお知らせ作成ページには予め、
+        | この Doc を公開したことをみんなに伝えるための情報が
+        | 入力されています。
+      p
+        | この Doc を公開したことをみんなに知らせる場合は、
+        | このチェックを入れてから公開をしてください。
+      p
+        | もし、チェックを入れ忘れた場合は、自分でお知らせ作成ページに行き、
+        | お知らせを作成して、この Doc を公開したことをみんなに伝えてください。
+      p
+        | みんなに伝える必要のない Doc の場合は、お知らせは作成する必要はありません。

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -42,14 +42,15 @@
               | スラッグを設定すると`https://bootcamp.fjord.jp/pages/{スラッグ}`の様にスラッグで指定した文字列のURLでアクセスが出来るようになります。
               br
               | スラッグにはアルファベットから始まる半角英数字と、ハイフン （ - ）、アンダーバー （ _ ） が使えます。
-    .form-item
-      = f.label :announcement, class: 'a-form-label'
-      .checkboxes
-        ul.checkboxes__items
-          li.checkboxes__item
-            = f.check_box :announcement, class: 'a-toggle-checkbox'
-            = f.label :announcement
-              | このドキュメント公開についてお知らせを書く
+    - unless @page.published_at?
+      .form-item
+        = f.label :announcement, class: 'a-form-label'
+        .checkboxes
+          ul.checkboxes__items
+            li.checkboxes__item
+              = f.check_box :announcement, class: 'a-toggle-checkbox'
+              = f.label :announcement
+                | このドキュメント公開についてお知らせを書く
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -165,7 +165,6 @@ ja:
         body: 本文
         tag_list: タグ
         slug: スラッグ
-        announcement: お知らせ作成
       question:
         practice: プラクティス
         title: タイトル

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -165,6 +165,7 @@ ja:
         body: 本文
         tag_list: タグ
         slug: スラッグ
+        announcement: お知らせ作成
       question:
         practice: プラクティス
         title: タイトル

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -103,7 +103,7 @@ notification_moved_up_event_waiting_user:
 
 notification_create_page:
   kind: 12
-  user: hatsuno
+  user: mentormentaro
   sender: komagata
   message: "komagataさんがDocsにBootcampの作業のページを投稿しました。"
   link: "/pages/<%= ActiveRecord::FixtureSet.identify(:page4) %>"

--- a/test/cassettes/subscription/create.yml
+++ b/test/cassettes/subscription/create.yml
@@ -316,7 +316,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/subscriptions
     body:
       encoding: UTF-8
-      string: customer=cus_JhRfQ7G68L2k8R&trial_end=1672758000&items[0][plan]=price_1J0hhTBpeWcLFd8ffLjm4nKO
+      string: customer=cus_12345678&items[0][plan]=price_1J0hhTBpeWcLFd8ffLjm4nKO&trial_end=1672758000
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/4.5.0
@@ -385,7 +385,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "sub_JhRnTQ6cElxGDL",
+          "id": "sub_12345678",
           "object": "subscription",
           "application_fee_percent": null,
           "automatic_tax": {

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -154,7 +154,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
   test '.notify(:create_page)' do
     params = {
       page: pages(:page4),
-      receiver: users(:hatsuno)
+      receiver: users(:mentormentaro)
     }
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -136,7 +136,7 @@ notification_moved_up_event_waiting_user:
 
 notification_create_page:
   kind: 12
-  user: hatsuno
+  user: mentormentaro
   sender: komagata
   message: "komagataさんがDocsにBootcampの作業のページを投稿しました。"
   link: "/pages/<%= ActiveRecord::FixtureSet.identify(:page4) %>"

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -468,7 +468,7 @@ class ActivityMailerTest < ActionMailer::TestCase
 
   test 'create_page' do
     page = pages(:page4)
-    receiver = users(:hatsuno)
+    receiver = users(:mentormentaro)
 
     ActivityMailer.create_page(
       page: page,
@@ -479,14 +479,14 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     query = CGI.escapeHTML({ kind: 12, link: "/pages/#{page.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['hatsuno@fjord.jp'], email.to
+    assert_equal ['mentormentaro@fjord.jp'], email.to
     assert_equal '[FBC] komagataさんがDocsにBootcampの作業のページを投稿しました。', email.subject
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">このDocsへ</a>}, email.body.to_s)
   end
 
   test 'create_page with params' do
     page = pages(:page4)
-    receiver = users(:hatsuno)
+    receiver = users(:mentormentaro)
 
     mailer = ActivityMailer.with(
       page: page,
@@ -501,7 +501,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     query = CGI.escapeHTML({ kind: 12, link: "/pages/#{page.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['hatsuno@fjord.jp'], email.to
+    assert_equal ['mentormentaro@fjord.jp'], email.to
     assert_equal '[FBC] komagataさんがDocsにBootcampの作業のページを投稿しました。', email.subject
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">このDocsへ</a>}, email.body.to_s)
   end

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -63,7 +63,7 @@ class ActivityMailerPreview < ActionMailer::Preview
 
   def create_page
     page = Page.find(ActiveRecord::FixtureSet.identify(:page4))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:hatsuno))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))
 
     ActivityMailer.with(sender: page.user, receiver: receiver, page: page).create_page
   end

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -28,7 +28,7 @@ class ActivityNotifierTest < ActiveSupport::TestCase
     @create_page_params = {
       body: 'test Docs',
       kind: :create_pages,
-      sender: users(:hajime),
+      sender: users(:mentormentaro),
       receiver: users(:komagata),
       link: 'pages',
       read: false,

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -8,7 +8,7 @@ class MarkdownTest < ApplicationSystemTestCase
     fill_in 'page[title]', with: 'インタビュー'
     fill_in 'page[body]', with: ":::speak @mentormentaro\n## 質問\nあああ\nいいい\n:::"
 
-    click_button '内容を保存'
+    click_button 'Docを公開'
 
     assert_css '.a-long-text.is-md.js-markdown-view'
     assert_css '.speak'
@@ -21,7 +21,7 @@ class MarkdownTest < ApplicationSystemTestCase
     fill_in 'page[title]', with: 'レポート'
     fill_in 'page[body]', with: ":@mentormentaro: \n すみません、これも確認していただけませんか？"
 
-    click_button '内容を保存'
+    click_button 'Docを公開'
 
     assert_css '.a-long-text.is-md.js-markdown-view'
     assert_css "a[href='/users/mentormentaro']"

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -12,7 +12,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
     AbstractNotifier.delivery_mode = @delivery_mode
   end
 
-  test 'Only students and mentors are notified' do
+  test 'Only admins and mentors are notified' do
     visit_with_auth '/pages', 'komagata'
     click_link 'Doc作成'
 
@@ -23,7 +23,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
     click_button '内容を保存'
     assert_text 'ページを作成しました。'
 
-    visit_with_auth '/notifications', 'hatsuno'
+    visit_with_auth '/notifications', 'mentormentaro'
 
     within first('.card-list-item.is-unread') do
       assert_text 'komagataさんがDocsにDocsTestを投稿しました。'
@@ -34,6 +34,10 @@ class Notification::PagesTest < ApplicationSystemTestCase
     within first('.card-list-item.is-unread') do
       assert_text 'komagataさんがDocsにDocsTestを投稿しました。'
     end
+
+    logout
+    visit_with_auth '/notifications', 'hatsuno'
+    assert_no_text 'komagataさんがDocsにDocsTestを投稿しました。'
 
     logout
     visit_with_auth '/notifications', 'yameo'

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -20,7 +20,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
       fill_in('page[title]', with: 'DocsTest')
       fill_in('page[body]', with: 'DocsTestBody')
     end
-    click_button '内容を保存'
+    click_button 'Docを公開'
     assert_text 'ページを作成しました。'
 
     visit_with_auth '/notifications', 'mentormentaro'
@@ -65,7 +65,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
     visit_with_auth page_path(page), 'komagata'
 
     click_link '内容変更'
-    click_button '内容を保存'
+    click_button '内容を更新'
     assert_text 'ページを更新しました。'
 
     visit_with_auth '/notifications', 'machida'

--- a/test/system/page/tags_test.rb
+++ b/test/system/page/tags_test.rb
@@ -19,7 +19,7 @@ class Page::TagsTest < ApplicationSystemTestCase
         tag_input.set tag
         tag_input.native.send_keys :return
       end
-      click_on '内容を保存'
+      click_on 'Docを公開'
     end
     click_on 'Docs', match: :first
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -273,7 +273,7 @@ class PagesTest < ApplicationSystemTestCase
     check 'ドキュメント公開のお知らせを書く', allow_label_click: true
     click_button '内容を更新'
 
-    assert_text 'ページを作成しました'
+    assert_text 'ページを更新しました'
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -258,7 +258,7 @@ class PagesTest < ApplicationSystemTestCase
     click_button '内容を保存'
 
     assert_text 'ページを作成しました'
-    assert has_field?('announcement[title]', with:'ドキュメント「お知らせにチェックを入れて新規Docを作成」を公開しました。')
+    assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れて新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れて新規Docを作成」の本文です。'
   end
 
@@ -273,8 +273,7 @@ class PagesTest < ApplicationSystemTestCase
     click_button '内容を保存'
 
     assert_text 'ページを作成しました'
-    assert has_field?('announcement[title]', with:'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
+    assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end
 end
-

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -249,4 +249,15 @@ class PagesTest < ApplicationSystemTestCase
     assert_link 'プラクティスに紐付いたDocs'
     assert_link '全て見る'
   end
+
+  test 'Check the box on the notice to create a document' do
+    visit_with_auth new_page_path, 'komagata'
+    fill_in 'page[title]', with: 'お知らせにチェックを入れて新規Docを作成'
+    fill_in 'page[body]', with: '「お知らせにチェックを入れて新規Docを作成」の本文です'
+    check 'このドキュメント公開についてお知らせを書く', allow_label_click: true
+    click_button '内容を保存'
+    assert_text 'ページを作成しました'
+    assert_text 'ドキュメント「お知らせにチェックを入れて新規Docを作成」を公開しました。'
+    assert_text 'このテキストを編集してください'
+  end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -250,7 +250,7 @@ class PagesTest < ApplicationSystemTestCase
     assert_link '全て見る'
   end
 
-  test 'check the box on the notice to create a document' do
+  test 'check the box for notification to publish the document' do
     visit_with_auth new_page_path, 'komagata'
     fill_in 'page[title]', with: 'お知らせにチェックを入れて新規Docを作成'
     fill_in 'page[body]', with: '「お知らせにチェックを入れて新規Docを作成」の本文です。'
@@ -264,7 +264,6 @@ class PagesTest < ApplicationSystemTestCase
 
   test 'publish a new document from WIP after checking the create notification box.' do
     visit_with_auth new_page_path, 'komagata'
-    debugger
     fill_in 'page[title]', with: 'お知らせにチェックを入れてWIP状態から新規Docを作成'
     fill_in 'page[body]', with: '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
     click_button 'WIP'

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -40,7 +40,7 @@ class PagesTest < ApplicationSystemTestCase
     visit_with_auth edit_page_path(target_page), 'kimura'
     assert_equal edit_page_path(target_page), current_path
     fill_in 'page[title]', with: '半角スペースを 含んでも 正常なページに 遷移する'
-    click_button '内容を保存'
+    click_button '内容を更新'
     assert_equal page_path(target_page.reload), current_path
     assert_text 'ページを更新しました'
   end
@@ -50,7 +50,7 @@ class PagesTest < ApplicationSystemTestCase
     assert_equal new_page_path, current_path
     fill_in 'page[title]', with: '新規Docを作成する'
     fill_in 'page[body]', with: '新規Docを作成する本文です'
-    click_button '内容を保存'
+    click_button 'Docを公開'
     assert_text 'ページを作成しました'
     assert_text 'Watch中'
   end
@@ -114,7 +114,7 @@ class PagesTest < ApplicationSystemTestCase
     fill_in 'page[body]', with: 'Docに関連プラクティスを指定'
     first('.select2-container').click
     find('li.select2-results__option[role="option"]', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
-    click_button '内容を保存'
+    click_button '内容を更新'
     assert_text 'Linuxのファイル操作の基礎を覚える'
   end
 
@@ -149,7 +149,7 @@ class PagesTest < ApplicationSystemTestCase
     fill_in 'page[title]', with: 'ページタイトル'
     fill_in 'page[slug]', with: slug
     fill_in 'page[body]', with: 'slug付きテストページの本文'
-    click_button '内容を保存'
+    click_button 'Docを公開'
     visit "/pages/#{slug}"
     assert_text 'slug付きテストページの本文'
   end
@@ -220,7 +220,7 @@ class PagesTest < ApplicationSystemTestCase
     stub_info = proc { |i| mock_log << i }
 
     Rails.logger.stub(:info, stub_info) do
-      click_button '内容を保存'
+      click_button 'Docを公開'
     end
 
     assert_text 'ページを作成しました'
@@ -236,7 +236,7 @@ class PagesTest < ApplicationSystemTestCase
     stub_info = proc { |i| mock_log << i }
 
     Rails.logger.stub(:info, stub_info) do
-      click_button '内容を保存'
+      click_button '内容を更新'
     end
 
     assert_text 'ページを更新しました'
@@ -254,8 +254,8 @@ class PagesTest < ApplicationSystemTestCase
     visit_with_auth new_page_path, 'komagata'
     fill_in 'page[title]', with: 'お知らせにチェックを入れて新規Docを作成'
     fill_in 'page[body]', with: '「お知らせにチェックを入れて新規Docを作成」の本文です。'
-    check 'このドキュメント公開についてお知らせを書く', allow_label_click: true
-    click_button '内容を保存'
+    check 'ドキュメント公開のお知らせを書く', allow_label_click: true
+    click_button 'Docを公開'
 
     assert_text 'ページを作成しました'
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れて新規Docを作成」を公開しました。')
@@ -269,8 +269,8 @@ class PagesTest < ApplicationSystemTestCase
     click_button 'WIP'
 
     click_on '内容変更'
-    check 'このドキュメント公開についてお知らせを書く', allow_label_click: true
-    click_button '内容を保存'
+    check 'ドキュメント公開のお知らせを書く', allow_label_click: true
+    click_button 'Docを公開'
 
     assert_text 'ページを作成しました'
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -81,9 +81,10 @@ class PagesTest < ApplicationSystemTestCase
     within('.form') do
       find('#select2-page_user_id-container').click
       select('kimura', from: 'page[user_id]')
+      find(".select-users").click
     end
 
-    click_on '保存'
+    click_button '内容を更新'
     within '.a-meta.is-creator' do
       assert find('.thread-header__user-icon')[:title].start_with?('kimura')
     end
@@ -102,7 +103,7 @@ class PagesTest < ApplicationSystemTestCase
       fill_in('page[title]', with: 'Created by non-admin')
       fill_in('page[body]', with: "非管理者によって作られたDocです。It's created by non-admin.")
     end
-    click_on '保存'
+    click_on 'Docを公開'
 
     click_on '内容変更'
     assert_no_selector '.select-users'
@@ -114,7 +115,7 @@ class PagesTest < ApplicationSystemTestCase
     fill_in 'page[body]', with: 'Docに関連プラクティスを指定'
     first('.select2-container').click
     find('li.select2-results__option[role="option"]', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
-    click_button '内容を更新'
+    click_button 'Docを公開'
     assert_text 'Linuxのファイル操作の基礎を覚える'
   end
 
@@ -196,7 +197,7 @@ class PagesTest < ApplicationSystemTestCase
     fill_in 'page[body]', with: 'Docに関連プラクティスを指定'
     first('.select2-container').click
     find('li.select2-results__option[role="option"]', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
-    click_button '内容を保存'
+    click_button 'Docを公開'
     assert_text 'Linuxのファイル操作の基礎を覚える'
 
     visit pages_path
@@ -270,7 +271,7 @@ class PagesTest < ApplicationSystemTestCase
 
     click_on '内容変更'
     check 'ドキュメント公開のお知らせを書く', allow_label_click: true
-    click_button 'Docを公開'
+    click_button '内容を更新'
 
     assert_text 'ページを作成しました'
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -250,14 +250,15 @@ class PagesTest < ApplicationSystemTestCase
     assert_link '全て見る'
   end
 
-  test 'Check the box on the notice to create a document' do
+  test 'check the box on the notice to create a document' do
     visit_with_auth new_page_path, 'komagata'
     fill_in 'page[title]', with: 'お知らせにチェックを入れて新規Docを作成'
-    fill_in 'page[body]', with: '「お知らせにチェックを入れて新規Docを作成」の本文です'
+    fill_in 'page[body]', with: '「お知らせにチェックを入れて新規Docを作成」の本文です。'
     check 'このドキュメント公開についてお知らせを書く', allow_label_click: true
     click_button '内容を保存'
     assert_text 'ページを作成しました'
-    assert_text 'ドキュメント「お知らせにチェックを入れて新規Docを作成」を公開しました。'
-    assert_text 'このテキストを編集してください'
+    assert has_field?('announcement[title]', with:'ドキュメント「お知らせにチェックを入れて新規Docを作成」を公開しました。')
+    assert_text '「お知らせにチェックを入れて新規Docを作成」の本文です。'
   end
 end
+

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -256,9 +256,26 @@ class PagesTest < ApplicationSystemTestCase
     fill_in 'page[body]', with: '「お知らせにチェックを入れて新規Docを作成」の本文です。'
     check 'このドキュメント公開についてお知らせを書く', allow_label_click: true
     click_button '内容を保存'
+
     assert_text 'ページを作成しました'
     assert has_field?('announcement[title]', with:'ドキュメント「お知らせにチェックを入れて新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れて新規Docを作成」の本文です。'
+  end
+
+  test 'publish a new document from WIP after checking the create notification box.' do
+    visit_with_auth new_page_path, 'komagata'
+    debugger
+    fill_in 'page[title]', with: 'お知らせにチェックを入れてWIP状態から新規Docを作成'
+    fill_in 'page[body]', with: '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
+    click_button 'WIP'
+
+    click_on '内容変更'
+    check 'このドキュメント公開についてお知らせを書く', allow_label_click: true
+    click_button '内容を保存'
+
+    assert_text 'ページを作成しました'
+    assert has_field?('announcement[title]', with:'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
+    assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end
 end
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -81,7 +81,7 @@ class PagesTest < ApplicationSystemTestCase
     within('.form') do
       find('#select2-page_user_id-container').click
       select('kimura', from: 'page[user_id]')
-      find(".select-users").click
+      find('.select-users').click
     end
 
     click_button '内容を更新'


### PR DESCRIPTION
休会復帰時にサブスクリプションのトライアル終了日が過去だとエラーになるようになったため。