### PR TITLE
トライアルが０日の時にエラーになる問題を修正

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -13,13 +13,13 @@ class Subscription
   end
 
   def create(customer_id, idempotency_key = SecureRandom.uuid, trial: 3)
-    Stripe::Subscription.create({
-                                  customer: customer_id,
-                                  trial_end: trial.days.since.to_i,
-                                  items: [{ plan: Plan.standard_plan.id }]
-                                }, {
-                                  idempotency_key: idempotency_key
-                                })
+    options = {
+      customer: customer_id,
+      items: [{ plan: Plan.standard_plan.id }]
+    }
+    options[:trial_end] = trial.days.since.to_i if trial.positive?
+
+    Stripe::Subscription.create(options, { idempotency_key: idempotency_key })
   end
 
   def destroy(subscription_id)

--- a/test/cassettes/subscription/create.yml
+++ b/test/cassettes/subscription/create.yml
@@ -101,7 +101,7 @@ http_interactions:
     uri: https://api.stripe.com/v1/subscriptions
     body:
       encoding: UTF-8
-      string: customer=cus_12345678&trial_end=1672758000&items[0][plan]=price_1J0hhTBpeWcLFd8ffLjm4nKO
+      string: customer=cus_12345678&items[0][plan]=price_1J0hhTBpeWcLFd8ffLjm4nKO&trial_end=1672758000
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/4.5.0


### PR DESCRIPTION
trial_endが過去の日付だとエラーになる問題を修正。

おそらく、Stripe側のAPIが変わったか、休会復帰処理が遅いと起こるもよう。