### PR TITLE
管理ページ > ユーザー一覧 の「削除ボタン」を削除し、ユーザー個別ページに配置。 

### DIFF
--- a/app/javascript/stylesheets/application/blocks/side/_user-statuses.sass
+++ b/app/javascript/stylesheets/application/blocks/side/_user-statuses.sass
@@ -25,3 +25,9 @@
 .user-statuses__item
   flex: 1
   max-width: calc(50% - .75rem)
+
+.user-statuses__delete
+  display: flex
+  justify-content: flex-end
+  margin-top: .75rem
+  +text-block(.8125rem 1.4)

--- a/app/javascript/stylesheets/atoms/_a-text-link.sass
+++ b/app/javascript/stylesheets/atoms/_a-text-link.sass
@@ -5,3 +5,7 @@
 .a-reversal-text-link
   +hover-link-reversal
   +reversal-link
+
+.a-muted-text-link
+  +hover-link-reversal
+  +muted-link

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -24,7 +24,6 @@
         th.admin-table__label 卒業
         th.admin-table__label 外部サービス
         th.admin-table__label 操作
-        th.admin-table__label 削除
     tbody.admin-table__items
       - users.each do |user|
         - next if params[:target] == 'campaign' && user.adviser?
@@ -125,10 +124,6 @@
           td.admin-table__item-value.is-text-align-center
             = link_to edit_admin_user_path(user), id: "edit-#{user.id}", class: 'a-button is-sm is-secondary is-icon' do
               i.fa-solid.fa-pen
-          td.admin-table__item-value.is-text-align-center
-            - if user.id != current_user.id
-              = link_to admin_user_path(user), method: :delete, id: "delete-#{user.id}", class: 'a-button is-sm is-danger is-icon', data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }
-                i.fa-solid.fa-trash-alt
 
 .a-card
   header.card-header

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -93,6 +93,6 @@
                         method: :patch,
                         data: { confirm: '本当によろしいですか？' },
                         class: 'a-button is-sm is-danger is-block'
-            / ユーザー削除の表示
-            - if @user.id != current_user.id && current_user.admin?
-              = link_to '削除', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: '', data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }
+                - if @user.id != current_user.id
+                  .user-statuses__delete
+                    = link_to 'このユーザーを削除する', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: 'a-muted-text-link', data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -95,4 +95,4 @@
                         class: 'a-button is-sm is-danger is-block'
             / ユーザー削除の表示
             - if @user.id != current_user.id && current_user.admin?
-              = link_to '削除', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: 'a-button is-sm is-danger is-icon', data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }
+              = link_to '削除', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: '', data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -93,6 +93,6 @@
                         method: :patch,
                         data: { confirm: '本当によろしいですか？' },
                         class: 'a-button is-sm is-danger is-block'
-                - if @user.id != current_user.id
+                - if @user != current_user
                   .user-statuses__delete
                     = link_to 'このユーザーを削除する', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: 'a-muted-text-link', data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -93,3 +93,6 @@
                         method: :patch,
                         data: { confirm: '本当によろしいですか？' },
                         class: 'a-button is-sm is-danger is-block'
+            / ユーザー削除の表示
+            - if @user.id != current_user.id && current_user.admin?
+              = link_to '削除', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: 'a-button is-sm is-danger is-icon', data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -99,14 +99,6 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_equal('Fjord Inc.', find('.user-metas__item-label', text: '所属企業').sibling('.user-metas__item-value').text)
   end
 
-  test 'delete user' do
-    user = users(:kimura)
-    visit_with_auth admin_users_path(target: 'student_and_trainee'), 'komagata'
-    click_on "delete-#{user.id}"
-    page.driver.browser.switch_to.alert.accept
-    assert_text "#{user.name} さんを削除しました。"
-  end
-
   test 'hide input for retire date when unchecked' do
     user = users(:hatsuno)
     visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -599,4 +599,12 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_link '休会', href: '/users?target=hibernated'
     assert_no_link '退会', href: '/users?target=retired'
   end
+
+  test 'delete user' do
+    user = users(:kimura)
+    visit_with_auth "users/#{user.id}", 'komagata'
+    click_link "delete-#{user.id}"
+    page.driver.browser.switch_to.alert.accept
+    assert_text "#{user.name} さんを削除しました。"
+  end
 end


### PR DESCRIPTION
## Issue

- [管理ページ > ユーザー一覧 の「削除ボタン」を削除し、ユーザー個別ページに配置。 #6357](https://github.com/fjordllc/bootcamp/issues/6357)

## 概要
http://localhost:3000/admin/users に実装されている削除ボタンをユーザー個別ページに移動しました

## 変更確認方法

1. `feature/delete-button-delete-from-userlist-and-plase-userpage `をローカルに取り込む
2. http://localhost:3000/admin/users にアクセスし、削除ボタンが消えていることを確認
3. 任意のユーザー個別ページ`http://localhost:3000/users/:id`にアクセスし、削除ボタンがあること、ボタンをクリックして機能することを確認してください。

## Screenshot

### 変更前
<img width="1440" alt="スクリーンショット 2023-04-04 18 06 00" src="https://user-images.githubusercontent.com/69577164/229745040-8cad7216-0fe7-4051-b391-79fba95374ff.png">
<img width="1440" alt="スクリーンショット 2023-04-04 18 06 47" src="https://user-images.githubusercontent.com/69577164/229745058-b239a181-89e9-484e-8db6-235ff8ed0a05.png">

### 変更後
<img width="1440" alt="スクリーンショット 2023-04-04 18 07 58" src="https://user-images.githubusercontent.com/69577164/229745305-48e7cf87-da57-4ca2-b5e4-8dd2ebc85a79.png">

<img width="1440" alt="スクリーンショット 2023-04-07 6 35 30" src="https://user-images.githubusercontent.com/69577164/230498438-ab6c8a2b-1314-479a-aebb-50c8eb61dc24.png">

