### PR TITLE
「イベント」を「特別イベント」にリネーム

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -43,7 +43,7 @@ class EventsController < ApplicationController
 
   def destroy
     @event.destroy
-    redirect_to events_path, notice: 'イベントを削除しました。'
+    redirect_to events_path, notice: '特別イベントを削除しました。'
   end
 
   private
@@ -73,7 +73,7 @@ class EventsController < ApplicationController
   def notice_message(event)
     case params[:action]
     when 'create'
-      event.wip? ? 'イベントをWIPとして保存しました。' : '特別イベントを作成しました。'
+      event.wip? ? '特別イベントをWIPとして保存しました。' : '特別イベントを作成しました。'
     when 'update'
       event.wip? ? '特別イベントをWIPとして保存しました。' : '特別イベントを更新しました。'
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -75,7 +75,7 @@ class EventsController < ApplicationController
     when 'create'
       event.wip? ? 'イベントをWIPとして保存しました。' : '特別イベントを作成しました。'
     when 'update'
-      event.wip? ? '特別イベントをWIPとして保存しました。' : 'イベントを更新しました。'
+      event.wip? ? '特別イベントをWIPとして保存しました。' : '特別イベントを更新しました。'
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -75,7 +75,7 @@ class EventsController < ApplicationController
     when 'create'
       event.wip? ? 'イベントをWIPとして保存しました。' : '特別イベントを作成しました。'
     when 'update'
-      event.wip? ? 'イベントをWIPとして保存しました。' : 'イベントを更新しました。'
+      event.wip? ? '特別イベントをWIPとして保存しました。' : 'イベントを更新しました。'
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -88,6 +88,6 @@ class EventsController < ApplicationController
     new_event.description = event.description
     new_event.job_hunting = event.job_hunting
 
-    flash.now[:notice] = 'イベントをコピーしました。'
+    flash.now[:notice] = '特別イベントをコピーしました。'
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -73,7 +73,7 @@ class EventsController < ApplicationController
   def notice_message(event)
     case params[:action]
     when 'create'
-      event.wip? ? 'イベントをWIPとして保存しました。' : 'イベントを作成しました。'
+      event.wip? ? 'イベントをWIPとして保存しました。' : '特別イベントを作成しました。'
     when 'update'
       event.wip? ? 'イベントをWIPとして保存しました。' : 'イベントを更新しました。'
     end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -67,7 +67,7 @@ module Mentioner
     {
       Report: "#{commentable.user.login_name}さんの日報「#{commentable.title}」",
       Product: "#{commentable.user.login_name}さんの#{commentable.title}",
-      Event: "イベント「#{commentable.title}」",
+      Event: "特別イベント「#{commentable.title}」",
       Page: "Docs「#{commentable.title}」",
       Announcement: "お知らせ「#{commentable.title}」"
     }[:"#{commentable_class}"]

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -22,7 +22,7 @@ module Watchable
     when Question
       "「#{self[:title]}」のQ&A"
     when Event
-      "「#{self[:title]}」のイベント"
+      "「#{self[:title]}」の特別イベント"
     when RegularEvent
       "「#{self[:title]}」の定期イベント"
     when Page

--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -14,7 +14,7 @@
         | 参加登録しています。
     ul.event-main-actions__items
       li.event-main-actions__item
-        = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+        = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: '特別イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
           | 参加を取り消す
 - elsif event.opening?
   .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
@@ -30,8 +30,8 @@
       li.event-main-actions__item
         - if event.capacity > event.participants.count
           // TODO helprtにしてわかりやすくしたい↑
-          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-md is-block' do
+          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '特別イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-md is-block' do
             | 参加申込
         - else
-          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠としてイベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-md is-block' do
+          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠として特別イベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-md is-block' do
             | 補欠登録

--- a/app/views/events/_tabs.html.slim
+++ b/app/views/events/_tabs.html.slim
@@ -3,7 +3,7 @@
     ul.page-tabs__items
       li.page-tabs__item
         = link_to events_path, class: "page-tabs__item-link #{current_link(/^events/)}" do
-          | イベント
+          | 特別イベント
       li.page-tabs__item
         = link_to regular_events_path(target: 'not_finished'), class: "page-tabs__item-link #{current_link(/^regular_events/)}" do
           | 定期イベント

--- a/app/views/events/edit.html.slim
+++ b/app/views/events/edit.html.slim
@@ -1,4 +1,4 @@
-- title 'イベント編集'
+- title '特別イベント編集'
 
 header.page-header
   .container

--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -10,7 +10,7 @@ header.page-header
           .page-header-actions__item
             = link_to new_event_path, class: 'a-button is-md is-secondary is-block' do
               i.fa-regular.fa-plus
-              | イベント作成
+              | 特別イベント作成
           .page-header-actions__item
             = link_to new_regular_event_path, class: 'a-button is-md is-secondary is-block' do
               i.fa-regular.fa-plus

--- a/app/views/events/new.html.slim
+++ b/app/views/events/new.html.slim
@@ -1,4 +1,4 @@
-- title 'イベント作成'
+- title '特別イベント作成'
 
 header.page-header
   .container
@@ -8,7 +8,7 @@ header.page-header
         .page-header-actions__items
           .page-header-actions__item
             = link_to events_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | イベント一覧
+              | 特別イベント一覧
 
 .page-body
   .container.is-xxxl

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -11,10 +11,10 @@ header.page-header
             li.page-header-actions__item.is-only-mentor
               = link_to new_event_path, class: 'a-button is-md is-secondary is-block' do
                 i.fa-regular.fa-plus
-                | イベント作成
+                | 特別イベント作成
           li.page-header-actions__item
             = link_to events_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | イベント一覧
+              | 特別イベント一覧
 
 = render 'events/tabs'
 
@@ -48,7 +48,7 @@ header.page-header
       .container.is-lg
         .a-page-notice__inner
           p
-            | イベントは終了しました。
+            | 特別イベントは終了しました。
 
 .page-body
   .container.is-lg

--- a/app/views/home/_event.html.slim
+++ b/app/views/home/_event.html.slim
@@ -6,7 +6,7 @@
           p
             = link_to event, itemprop: 'url', class: 'has-badge' do
               span.a-badge.is-primary.is-xs
-                | イベント
+                | 特別イベント
               = today_or_tommorow(event)
               = l event.start_at.to_date, format: :md
               | は 「

--- a/app/views/notification_mailer/moved_up_event_waiting_user.slim
+++ b/app/views/notification_mailer/moved_up_event_waiting_user.slim
@@ -1,2 +1,2 @@
-= render 'notification_mailer_template', title: "#{@event.title}で、補欠から参加に繰り上がりました。", link_url: notification_url(@notification), link_text: 'イベント詳細へ' do
+= render 'notification_mailer_template', title: "#{@event.title}で、補欠から参加に繰り上がりました。", link_url: notification_url(@notification), link_text: '特別イベント詳細へ' do
   = md2html(@event.description)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -36,7 +36,7 @@ ja:
       announcement: お知らせ
       article: ブログ記事
       work: 作品
-      event: イベント
+      event: 特別イベント
       memo: メモ
       reference_book: 参考書籍
       campaign: お試し延長

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -23,7 +23,7 @@ class EventsTest < ApplicationSystemTestCase
         click_button 'WIP'
       end
     end
-    assert_text 'イベントをWIPとして保存しました。'
+    assert_text '特別イベントをWIPとして保存しました。'
     assert_text '公開されるまでお待ちください。'
     assert_text 'Watch中'
   end
@@ -43,7 +43,7 @@ class EventsTest < ApplicationSystemTestCase
         click_button '作成'
       end
     end
-    assert_text 'イベントを作成しました。'
+    assert_text '特別イベントを作成しました。'
     assert_text 'Watch中'
   end
 
@@ -51,14 +51,14 @@ class EventsTest < ApplicationSystemTestCase
     event = events(:event1)
     visit_with_auth event_path(event), 'komagata'
     click_link 'コピー'
-    assert_text 'イベントをコピーしました'
+    assert_text '特別イベントをコピーしました'
     within 'form[name=event]' do
       fill_in 'event[start_at]', with: Time.current.next_day
       fill_in 'event[end_at]', with: Time.current.next_day + 2.hours
       fill_in 'event[open_end_at]', with: Time.current + 2.hours
       click_button '作成'
     end
-    assert_text 'イベントを作成しました。'
+    assert_text '特別イベントを作成しました。'
     assert_text event.title
     assert_text event.location
     assert_text event.capacity
@@ -78,7 +78,7 @@ class EventsTest < ApplicationSystemTestCase
       fill_in 'event[open_end_at]', with: Time.zone.parse('2019-12-20 23:59')
       click_button '内容変更'
     end
-    assert_text 'イベントを更新しました。'
+    assert_text '特別イベントを更新しました。'
   end
 
   test 'destroy event' do
@@ -88,7 +88,7 @@ class EventsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '削除'
     end
-    assert_text 'イベントを削除しました。'
+    assert_text '特別イベントを削除しました。'
   end
 
   test 'cannot create a new event when start_at > end_at' do
@@ -172,7 +172,7 @@ class EventsTest < ApplicationSystemTestCase
 
   test 'show message about ending event after event end' do
     visit_with_auth event_path(events(:event6)), 'kimura'
-    assert_text 'イベントは終了しました。'
+    assert_text '特別イベントは終了しました。'
   end
 
   test 'user can participate in an event' do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -282,7 +282,7 @@ class HomeTest < ApplicationSystemTestCase
   test "show my wip's event on dashboard" do
     visit_with_auth '/', 'kimura'
     click_link 'イベント'
-    click_link 'イベント作成'
+    click_link '特別イベント作成'
     fill_in 'event[title]', with: 'WIPのイベント'
     fill_in 'event[location]', with: 'オンライン'
     fill_in 'event[capacity]', with: 100


### PR DESCRIPTION
## Issue

- #6352 

## 概要
下記の構造の最下層にある「イベント」が使わている文言を「特別イベント」にリネームしました。
- イベント
  - イベント... events
  - 定期イベント... regular-events
 
## 変更確認方法

1. `feature/rename-event-to-special-event`をローカルに取り込む

### イベント一覧
1. `komagata` でログインする
2.  イベント一覧ページ`/events` にアクセスする
3. 以下の文言が 「特別イベント」に変更されてあることを確認する
   - イベントタブ
   - イベント作成ボタン
  変更前
![image](https://user-images.githubusercontent.com/85052152/230314206-491cba0c-2fba-44f9-9a42-32db0b8dddc3.png)
  変更後
![image](https://user-images.githubusercontent.com/85052152/230314521-d750a921-bcc4-4e10-bfa8-eafe0711750c.png)

### イベント作成
1. `komagata`でログインする
1. イベント作成ページ `/events/new`にアクセスする
1. 以下項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - タイトル
    - イベント一覧ボタン
    変更前 
    ![image](https://user-images.githubusercontent.com/85052152/230318719-439dc231-9f66-4423-99c7-9672d9117a43.png)
    変更後
   ![image](https://user-images.githubusercontent.com/85052152/230318753-c4cecef1-eda0-49d9-a214-fa215aba58c1.png)

1. 以下の項目を入力し、「WIP」ボタンをクリックし、イベントをWIPとして保存する。
    1. タイトル、会場、定員
    2. イベント開始日時、イベント修了日時、募集開始日時、募集修了日時
    3. 詳細
1. 以下項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - WIPで保存後のメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230322159-47e9d484-04e1-4187-abd8-5b39821916b1.png)
   変更後
    ![image](https://user-images.githubusercontent.com/85052152/230320660-50b32428-399f-461d-8f51-6a3450b75c42.png)
1. イベント作成ページ `/events/new`にアクセスする
1. 手順4.と同様の項目を入力し、「作成」ボタンをクリックする。
1. 以下項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 作成後のメッセージ
    変更前
     ![image](https://user-images.githubusercontent.com/85052152/230321493-3cf43133-0d33-43ef-ba05-6f8c016e006c.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230321528-1d739e6e-56b4-40e1-81c8-edf66b4993cd.png)

### イベント編集

1. `komagata`でログインする
1. イベント編集ページ `/events/{event_id}/edit`にアクセスする
    1. event_id：編集可能なイベントページのid
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - WIPで保存後のメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230324870-c32029fd-897d-4959-8742-60f1674e5a34.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230324900-dbc41e17-c1f9-489d-acca-08d7e6200587.png)
1. 「WIP」ボタンをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - WIPで保存後のメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230353779-ea2ab558-12e7-449c-a296-4f9b0ab92def.png)
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230353802-39a879c4-234d-469d-be3b-3fb43c4c1272.png)
1. イベント編集ページ `/events/{event_id}/edit`にアクセスする
    1. event_id：編集可能なイベントページのid
1. 「内容変更」ボタンをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 保存後のメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230353824-3e3588a1-cea7-4c77-87e9-8bc07751646d.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230804704-516bbb8a-e020-49fb-9abb-a862f136b2c6.png)


#### コピー時のメッセージ

1. イベント編集ページ `/events/{event_id}/edit`にアクセスする
1. 「コピー」ボタンをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - コピー時のメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230804549-440c5ced-40eb-4a58-90f5-bb9954eea590.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230804555-e11c1306-3541-422e-99da-a5dd75a4015d.png)

### イベント詳細
1. `komagata`でログインする
1. 終了したイベントの詳細ページ `/events/{event_id}`にアクセスする
    1. event_id：終了したイベントのid
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - イベント終了のメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230805048-ccf0d294-669f-4d4a-a6f6-d7ed80fa6098.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230808641-95b39d4f-a5ca-4b10-9678-bf11322b799d.png)


#### イベント参加（補欠者なし）とキャンセルの確認ダイアログ

1. `kimura` でログインする
1. 補欠者なしのイベント詳細ページ `/events/{event_id}` にアクセスする
    1. `event_id` の例： `308029005`
1. 「参加申込」ボタンをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 確認ダイアログ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230807593-70f382d9-1057-4cff-9a5b-b66c35a1f25f.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230807603-858d6213-40e6-4c72-a740-95cf0504b21e.png)
1. 確認ダイアログの「OK」ボタンをクリックする
1. 「参加を取り消す」リンクをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 確認ダイアログ
    変更前
   ![image](https://user-images.githubusercontent.com/85052152/230807688-cd2fe0f0-56ed-41d6-b4b2-64bd5fbffe39.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230807701-6ba8da4a-04ad-4ea6-b688-e32587973c52.png)



#### 補欠者あり

1. `komagata` でログインする
1. イベント作成ページにてイベントを作成する（以下の操作を行うこと）
    - 入力項目「定員」を `1` に設定する
1. 作成したイベントページにアクセスし、「参加申込」ボタンをクリックして参加登録をする
1. `kimura` でログインする
1. 手順2.で作成したイベントページにアクセスする
1. 「補欠登録」ボタンをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 確認ダイアログ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230808045-0aeb376d-2eb1-4fda-9877-3aa4848f9752.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230808050-40ab9d61-c0d7-4db4-a901-6692dd91bd7b.png)

1. 確認ダイアログで「OK」ボタンをクリックする
1. `komagata` でログインする
1. 手順2.で作成したイベントページにアクセスする
1. 「参加を取り消す」リンクをクリックする
1. 確認ダイアログの「OK」ボタンをクリックする
1. `/letter_opener`にアクセスする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 「補欠から参加に繰り上がり」のメール内の詳細リンク
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230806927-7e1ff623-8208-4275-bbb1-34a7fcecc5f4.png)
     変更後
     ![image](https://user-images.githubusercontent.com/85052152/230808718-e0de5900-3a06-4b2f-8f75-da8474aa427f.png)

#### イベント削除メッセージ

1. `komagata`でログインする
2. `komagata` が作成した イベントの詳細ページ `/events/{event_id}`にアクセスする
3. 「削除する」リンクをクリックする。表示された確認ダイアログの「OK」ボタンをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - イベント削除時のメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230809125-5e1881ff-e344-4359-83d8-e55169f0df2e.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230809145-d2885a39-0367-431e-8961-0dc21c757165.png)

### イベント通知ダッシュボード

事前準備
1. 当日、または翌日開催のイベントがない場合、イベント作成ページにてイベントを作成する（以下の操作を行うこと）
    - 入力項目「イベント開始日時」を当日または翌日に設定する

確認
1. ダッシュボード `/`にアクセスする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 通知メッセージの区分
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230809705-cca9acc9-f7de-4009-8df1-08b754566a5d.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230809743-fe305728-8cd9-4850-bf41-a3b4e7c9d771.png)


### Watch中のイベント通知
1. `kimura` でログインする
1. 任意のイベント詳細ページ `/events/{event_id}` にアクセスする
1. 「Watch」ボタンをクリックし、Watch中にする
    1. 既にWatch中である場合、操作を省略する
1. `komagata` でログインする
1. 手順2.のイベント詳細ページにアクセスする
1. メンションなしのコメントをする
1. `kimura` でログイン
1. `/notifications?status=unread&target=watching` にアクセスする
1. 通知アイコンをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 通知メッセージ
    - Watch中のメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230812511-bb05a34b-a110-45f0-a858-7c4d7370a1b8.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230812521-13709398-7fc7-4219-8cc3-d9823184f607.png)
1. `/letter_opener` にアクセスする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - メールのSubject
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230812538-09a7daad-7ede-4932-84bc-916b880a9256.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230812550-7f435e79-d331-4763-bd05-f5b42bc83d00.png)

### メンション付きコメントのイベント通知
1. `komagata` でログインする
1. 任意のイベント詳細ページ `/events/{event_id}` にアクセスする
1. `kimura` へのメンションを付けてコメントをする
1. `kimura` でログイン
1. `/notifications?status=unread&target=mention` にアクセスする
1. 通知アイコンをクリックする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - 通知メッセージ
    - メンションのメッセージ
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230813155-208e7b89-ca94-4b11-9123-17321825e8e3.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230813182-37c91179-41bf-4fa1-8798-4f61b41be3f8.png)
1. `/letter_opener` にアクセスする
1. 以下の項目で「イベント」の文言が「特別イベント」に変更されてあることを確認する
    - メールのSubject
    変更前
    ![image](https://user-images.githubusercontent.com/85052152/230813204-bec801a8-0596-48c7-bd3b-635d41858460.png)
    変更後
    ![image](https://user-images.githubusercontent.com/85052152/230813222-5d7fe0bb-0bcb-47b8-ae2f-8f77cb92ed5c.png)

### Screenshot
スクリーンショットは`変更確認方法`で添付しているため、ここでは省略します。


