### PR TITLE
ログインしていない状態でプラクティスページにアクセスしたときの meta description を設定

### DIFF
--- a/app/views/layouts/not_logged_in.html.slim
+++ b/app/views/layouts/not_logged_in.html.slim
@@ -2,6 +2,7 @@ doctype html
 html lang='ja'
   head
     = render 'google_tag_manager_head'
+    meta name='description' content="オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「#{@practice.title}」のページです。"
     meta content='IE=edge' http-equiv='X-UA-Compatible'
     = display_meta_tags default_meta_tags
     = javascript_include_tag 'application'

--- a/app/views/layouts/not_logged_in.html.slim
+++ b/app/views/layouts/not_logged_in.html.slim
@@ -2,7 +2,6 @@ doctype html
 html lang='ja'
   head
     = render 'google_tag_manager_head'
-    meta name='description' content="オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「#{@practice.title}」のページです。"
     meta content='IE=edge' http-equiv='X-UA-Compatible'
     = display_meta_tags default_meta_tags
     = javascript_include_tag 'application'

--- a/app/views/practices/unauthorized_show.slim
+++ b/app/views/practices/unauthorized_show.slim
@@ -1,4 +1,5 @@
 - title @practice.title
+- description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「#{@practice.title}」のページです。"
 - content_for :extra_body_classes
 
 .page-body

--- a/test/system/practice/completion_test.rb
+++ b/test/system/practice/completion_test.rb
@@ -8,6 +8,14 @@ class Practice::CompletionTest < ApplicationSystemTestCase
     assert_text '「OS X Mountain Lionをクリーンインストールする」'
   end
 
+  test 'Appropriate meta description is displayed when accessed by non-logged-in user' do
+    visit "/practices/#{practices(:practice1).id}"
+
+    assert_selector 'head', visible: false do
+      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「#{practices(:practice1).title}」のページです。']", visible: false
+    end
+  end
+
   test 'ogp image is displayed' do
     practice = practices(:practice1)
     visit_with_auth "/practices/#{practice.id}/edit", 'komagata'

--- a/test/system/practice/completion_test.rb
+++ b/test/system/practice/completion_test.rb
@@ -8,7 +8,7 @@ class Practice::CompletionTest < ApplicationSystemTestCase
     assert_text '「OS X Mountain Lionをクリーンインストールする」'
   end
 
-  test 'Appropriate meta description is displayed when accessed by non-logged-in user' do
+  test 'appropriate meta description is displayed when accessed by non-logged-in user' do
     visit "/practices/#{practices(:practice1).id}"
 
     assert_selector 'head', visible: false do


### PR DESCRIPTION
## Issue

- #6389

## 概要
未ログイン状態でプラクティスページにアクセスした際の「meta description」を「オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「{プラクティス名}」のページです。」に設定しました。

## 変更確認方法

1. `feature/set-meta-description-without-login`をローカルに取り込む
2. `http://localhost:3000/practices/315059988`に未ログインの状態でアクセスする
3. 「検証(コンソール)」を開き、`<head>~</head>`を確認
4. `<meta>`内に「「オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「OS X Mountain Lionをクリーンインストールする」のページです。」と確認できます。プラクティス名はプラクティスページごとに変動します。

## Screenshot
### 変更前
<img width="1261" alt="スクリーンショット 2023-04-10 8 29 18" src="https://user-images.githubusercontent.com/69577164/230801579-b81d2e0c-db80-435b-ab55-9e6085827524.png">

### 変更後
<img width="1261" alt="スクリーンショット 2023-04-10 8 29 31" src="https://user-images.githubusercontent.com/69577164/230801582-d25e166e-e4c3-420e-aa43-3c6c9def4dea.png">