### PR TITLE
現在FBCに登録されている企業の合計数を、企業一覧に表示するようにする

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -3,6 +3,7 @@
 class CompaniesController < ApplicationController
   def index
     @companies = Company.with_attached_logo
+    @total_count_registered_company = Company.count
   end
 
   def show

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -3,7 +3,6 @@
 class CompaniesController < ApplicationController
   def index
     @companies = Company.with_attached_logo
-    @total_count_registered_company = Company.count
   end
 
   def show

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -1,10 +1,10 @@
-- title '企業一覧'
+- title '企業一覧　'
 
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        = "#{title}(#{@total_count_registered_company})"
 
 .page-body
   .container

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -4,7 +4,7 @@ header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = "#{title}（#{@companies.count}）"
+        | #{title}（#{@companies.count}）
 
 .page-body
   .container

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -4,7 +4,7 @@ header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = "#{title}(#{@total_count_registered_company})"
+        = "#{title}(#{@companies.count})"
 
 .page-body
   .container

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -1,10 +1,10 @@
-- title '企業一覧　'
+- title '企業一覧'
 
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = "#{title}(#{@companies.count})"
+        = "#{title}（#{@companies.count}）"
 
 .page-body
   .container

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -10,7 +10,7 @@ class CompaniesTest < ApplicationSystemTestCase
 
   test 'display company total count with company list' do
     visit_with_auth '/companies', 'komagata'
-    total_count_registered_company = Company.count
+    total_count_registered_company = companies.count
     assert_selector 'h2.page-header__title', text: "企業一覧　(#{total_count_registered_company})"
   end
 

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -5,7 +5,13 @@ require 'application_system_test_case'
 class CompaniesTest < ApplicationSystemTestCase
   test 'GET /companies' do
     visit_with_auth '/companies', 'komagata'
-    assert_equal '企業一覧 | FBC', title
+    assert_equal '企業一覧　 | FBC', title
+  end
+
+  test 'display company total count with company list' do
+    visit_with_auth '/companies', 'komagata'
+    total_count_registered_company = Company.count
+    assert_selector 'h2.page-header__title', text: "企業一覧　(#{total_count_registered_company})"
   end
 
   test 'show company information' do

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -5,12 +5,12 @@ require 'application_system_test_case'
 class CompaniesTest < ApplicationSystemTestCase
   test 'GET /companies' do
     visit_with_auth '/companies', 'komagata'
-    assert_equal '企業一覧　 | FBC', title
+    assert_equal '企業一覧 | FBC', title
   end
 
   test 'display company total count with company list' do
     visit_with_auth '/companies', 'komagata'
-    assert_selector 'h2.page-header__title', text: '企業一覧　(27)'
+    assert_selector 'h2.page-header__title', text: '企業一覧（27）'
   end
 
   test 'show company information' do

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -10,7 +10,7 @@ class CompaniesTest < ApplicationSystemTestCase
 
   test 'display company total count with company list' do
     visit_with_auth '/companies', 'komagata'
-    assert_selector 'h2.page-header__title', text: '企業一覧（27）'
+    assert_selector 'h2.page-header__title', text: "企業一覧（#{companies.count}）"
   end
 
   test 'show company information' do

--- a/test/system/companies_test.rb
+++ b/test/system/companies_test.rb
@@ -10,8 +10,7 @@ class CompaniesTest < ApplicationSystemTestCase
 
   test 'display company total count with company list' do
     visit_with_auth '/companies', 'komagata'
-    total_count_registered_company = companies.count
-    assert_selector 'h2.page-header__title', text: "企業一覧　(#{total_count_registered_company})"
+    assert_selector 'h2.page-header__title', text: '企業一覧　(27)'
   end
 
   test 'show company information' do


### PR DESCRIPTION
## Issue

- #6405

## 概要

現在、FBCに登録されている企業の合計数を、企業一覧に表示するように変更した。

## 変更確認方法

1. ブランチ` feature/display_company_total_count_with_company_list`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. ユーザー名 : komagata、パスワード : testtestでログインする ※どのユーザーでログインしても確認出来ます。
4. http://localhost:3000/companies にアクセスする
5. こちらの写真のように、企業一覧の後に「(27)」という、現在「FJORD BOOT CAMP」に登録されている企業の合計数が表示されることを確認する
<img width="543" alt="スクリーンショット 2023-04-14 22 01 11" src="https://user-images.githubusercontent.com/54713809/232050884-cb379331-9c89-499f-8e71-b5d528194375.png">

## Screenshot

### 変更前

<img width="654" alt="スクリーンショット 2023-04-14 18 13 09" src="https://user-images.githubusercontent.com/54713809/232050384-ca95f244-080e-4dda-8583-a28e5e029c14.png">


### 変更後

<img width="543" alt="スクリーンショット 2023-04-14 22 01 11" src="https://user-images.githubusercontent.com/54713809/232050884-cb379331-9c89-499f-8e71-b5d528194375.png">

