### PR TITLE
ログインしていない状態でQ&Aページにアクセスしたときの meta description を設定

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -49,7 +49,6 @@ class QuestionsController < ApplicationController
     if logged_in?
       render :show
     else
-      @page_description = "オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{@question.title}」のページです。"
       render :unauthorized_show, layout: 'not_logged_in'
     end
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -49,6 +49,7 @@ class QuestionsController < ApplicationController
     if logged_in?
       render :show
     else
+      @page_description = "オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{@question.title}」のページです。"
       render :unauthorized_show, layout: 'not_logged_in'
     end
   end

--- a/app/views/questions/unauthorized_show.slim
+++ b/app/views/questions/unauthorized_show.slim
@@ -1,4 +1,5 @@
 - title @question.title
+- description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{@question.title}」のページです。"
 - content_for :extra_body_classes
 
 .page-body

--- a/test/system/question/not_logged_in_test.rb
+++ b/test/system/question/not_logged_in_test.rb
@@ -3,7 +3,7 @@
 require 'application_system_test_case'
 
 class Question::NotLoggedInTest < ApplicationSystemTestCase
-  test 'meta discription is set when not logged-in user access show' do
+  test 'not logged-in user can access show and meta description is set' do
     question = questions(:question1)
     visit question_path(question)
     assert_text "「#{question.title}」"

--- a/test/system/question/not_logged_in_test.rb
+++ b/test/system/question/not_logged_in_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Question::NotLoggedInTest < ApplicationSystemTestCase
+  test 'meta discription is set when not logged-in user access show' do
+    question = questions(:question1)
+    visit "/questions/#{question.id}"
+    assert_text "「#{question.title}」"
+    assert_text 'このページの閲覧にはフィヨルドブートキャンプの入会が必要です'
+    assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{question.title}」のページです。']", visible: false
+  end
+end

--- a/test/system/question/not_logged_in_test.rb
+++ b/test/system/question/not_logged_in_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class Question::NotLoggedInTest < ApplicationSystemTestCase
   test 'meta discription is set when not logged-in user access show' do
     question = questions(:question1)
-    visit "/questions/#{question.id}"
+    visit question_path(question)
     assert_text "「#{question.title}」"
     assert_text 'このページの閲覧にはフィヨルドブートキャンプの入会が必要です'
     assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{question.title}」のページです。']", visible: false


### PR DESCRIPTION
## Issue
- #6390 

## 概要
ログインをしてない状態でQ&A( questions/show ) にアクセスしたときのmeta description を設定しました。

meta description の文章は、
```
オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「{タイトル}」のページです。
```
としています。

## 変更確認方法

1. `feature/set-meta-description-on-qa-page-without-login`をローカルに取り込む
2. ログイン状態で適当なQ&Aページにアクセスし、URLをメモしておく
  
![image](https://user-images.githubusercontent.com/46841037/232280670-45f3dff5-620b-45bf-9a39-ac4ad42a50bc.png)

3. ログアウトし、メモしていたQ&Aページに再度アクセス
    
![image](https://user-images.githubusercontent.com/46841037/232280705-7a24e6e0-84f7-4e3e-87f8-150e0493ae96.png)
4. ブラウザのデベロッパーツールのElementsタブを開いて`<head>`タグ内にmeta desciptionが正しく設定されているのを確認する
![image](https://user-images.githubusercontent.com/46841037/232280726-1ed6ad72-af04-47ab-a8ca-46d5557e3f13.png)

※変更前のスクリーンショット
![image](https://user-images.githubusercontent.com/46841037/232280819-9bc6c4f8-15d1-49bb-8963-b26486a7e5b5.png)

## 具体的にやったこと
### meta descriptionの設定
meta descriptionの設定には、[meta-tags](https://github.com/kpumuk/meta-tags)というgemが提供するメソッドを用いています。コントローラ側でもビュー側でも設定できるようですが、メタタグを付与する責務はビュー側が持つほうがわかりやすいと思い、今回はビュー側で設定しています。
https://github.com/kpumuk/meta-tags#using-metatags-in-view
具体的には、ログインしていない状態でQuestionsコントローラのshowアクションが呼ばれたときに呼び出されるビューの中で設定しています。
（Questionsコントローラからビューを呼んでいる部分↓）
https://github.com/fjordllc/bootcamp/blob/ae5beffeeaec8df0c1099959a5cf494c590c2ecf/app/controllers/questions_controller.rb#L49-L53

### テスト
system testでmeta descriptionが設定されているのを確認しました。既存のテストファイルにちょうどよいものがなかったため、`test/system/question/not_logged_in_test.rb`というファイルを新たに作成し、そこにテストを書いています。

## レビューで見てほしいこと
- meta descriptionの設定の仕方が適切か（方法はいくつかあるので）
- 他の画面に影響を与えていないか
- テストが適切か（名前や場所なども含めて）
