### PR TITLE
入会時のDiscordへのお知らせで使用する属性をアカウント名に修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -140,7 +140,7 @@ class UsersController < ApplicationController
   end
 
   def notify_to_chat(user)
-    ChatNotifier.message "#{user.name}さんが新たなメンバーとしてJOINしました🎉\r#{url_for(user)}"
+    ChatNotifier.message "#{user.login_name}さんが新たなメンバーとしてJOINしました🎉\r#{url_for(user)}"
   end
 
   def user_params


### PR DESCRIPTION
## Issue

- [チャットのお知らせグループの通知で流している新メンバー参加のお知らせの表示を変更したい。 #6425](https://github.com/fjordllc/bootcamp/issues/6425)

## 概要
新規入会時にDiscordに流れる通知の中で、ユーザー名を表示している部分をアカウント名に差し替えたい

## 変更確認方法
ローカル環境でチェックする際にはDiscordの「お知らせ#通知」に飛ばすことはできないので、通知先を用意します。
通知先のウェブフックURLを環境変数`DISCORD_NOTICE_WEBHOOK_URL`に設定しないと通知が行われません。
また、ローカル環境では決済情報の認証にエラーが発生します。スキップするために新規アカウント作成の準備をいくつか行います。

1. Discordの事前設定
    1. 通知先となるDiscordサーバーとテキストチャンネルを用意します(無料で作れます)
    2. サーバー設定 -> 連携サービス -> ウェブフックから通知先のウェブフックを作成します
    3. 「ウェブフックURLをコピー」をクリックしてコピーされるURLを控えます
2. `feature/change_new_member_joining_announcement`を取り込む
3. 新規アカウント作成の事前準備(決済情報入力の省略)
    1. `app/controllers/users_controller.rb:61`を `if true` に変更する
    1. `app/views/users/_form.html.slim:49~50`を消す
4. ローカル環境でDiscordに通知が飛ぶように修正する
    1. `app/models/chat_notifier.rb:11` の `Discord::Notifier.message(message, username: username, url: webhook_url)` が本番でないと実行されないようになっているので条件分岐の外(`app/models/chat_notifier.rb:9`)にコピペします。
5. `DISCORD_NOTICE_WEBHOOK_URL=<ウェブフックのURL> foreman start -f Procfile.dev` でローカル環境を立ち上げます
6. [`http://localhost:3000/users/new`](http://localhost:3000/users/new)にアクセスしてアカウントを作成するとDiscordへの通知が確認できます

## Screenshot

### 変更前
赤枠内にユーザー名が表示されていました
<img width="609" alt="スクリーンショット 2023-04-16 10 49 14" src="https://user-images.githubusercontent.com/69577164/232261969-a690c359-2494-4c76-99f7-4bf8cfc40569.png">

### 変更後
アカウント名(`User.login_name`)が使用されるようになりました
<img width="1440" alt="スクリーンショット 2023-04-16 10 48 46" src="https://user-images.githubusercontent.com/69577164/232261970-072bbd95-fd61-459c-bd53-a34493a23aa7.png">
<img width="1440" alt="スクリーンショット 2023-04-16 10 48 36" src="https://user-images.githubusercontent.com/69577164/232261972-1b74c895-0c40-4e5e-9d38-d4282d9365c0.png">

## テスト
2023年4月19日 チーム開発MTGでテスト不要との確認が取れたため、テストの実装はありません。
