### PR TITLE
ログインしてないユーザーがDocsにアクセスした時、meta descriptionが表示されるようにする

### DIFF
--- a/app/views/pages/unauthorized_show.slim
+++ b/app/views/pages/unauthorized_show.slim
@@ -1,5 +1,5 @@
 - title @page.title
-- set_meta_tags description: content= "オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{@page.title}」のページです。"
+- description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{@page.title}」のページです。"
 - content_for :extra_body_classes
 
 .page-body

--- a/app/views/pages/unauthorized_show.slim
+++ b/app/views/pages/unauthorized_show.slim
@@ -1,4 +1,5 @@
 - title @page.title
+= set_meta_tags description: content= "オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{@page.title}」のページです。"
 - content_for :extra_body_classes
 
 .page-body

--- a/app/views/pages/unauthorized_show.slim
+++ b/app/views/pages/unauthorized_show.slim
@@ -1,5 +1,5 @@
 - title @page.title
-= set_meta_tags description: content= "オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{@page.title}」のページです。"
+- set_meta_tags description: content= "オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{@page.title}」のページです。"
 - content_for :extra_body_classes
 
 .page-body

--- a/test/system/page/not_logged_in_test.rb
+++ b/test/system/page/not_logged_in_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Page::NotLoggedInTest < ApplicationSystemTestCase
+  test 'when not logged in user access docs, meta description is displayed' do
+    target_page = pages(:page1)
+    visit page_path(target_page)
+    assert_selector 'head', visible: false do
+      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{target_page.title}」のページです。']", visible: false
+    end
+  end
+end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -277,4 +277,11 @@ class PagesTest < ApplicationSystemTestCase
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end
+
+  test 'When Non-logged-in user access docs, meta description is displayed' do
+    visit "/pages/#{pages(:page1).id}"
+    assert_selector 'head', visible: false do
+      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{pages(:page1).title}」のページです。']", visible: false
+    end
+  end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -278,7 +278,7 @@ class PagesTest < ApplicationSystemTestCase
     assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end
 
-  test 'When Non-logged-in user access docs, meta description is displayed' do
+  test 'when Non-logged-in user access docs, meta description is displayed' do
     visit "/pages/#{pages(:page1).id}"
     assert_selector 'head', visible: false do
       assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{pages(:page1).title}」のページです。']", visible: false

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -277,11 +277,4 @@ class PagesTest < ApplicationSystemTestCase
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end
-
-  test 'when Non-logged-in user access docs, meta description is displayed' do
-    visit "/pages/#{pages(:page1).id}"
-    assert_selector 'head', visible: false do
-      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{pages(:page1).title}」のページです。']", visible: false
-    end
-  end
 end


### PR DESCRIPTION
## Issue

- #6391

## 概要

ログインしてないユーザーがDocsにアクセスした時、ドキュメント用のmeta descriptionが表示されるようにする

## 変更確認方法

1. ブランチ feature/set_document_meta_description_when_not_loginをローカルに取り込む
2. bin/rails sでローカル環境を立ち上げる
3. http://127.0.0.1:3000/pages/950453707 にアクセスする ※ログインしてない状態でご確認お願い致します🙇‍♂️
4. 検証ツールを開く
5. こちらの写真のように、headタグの中に、「オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「test1」のページです。」というmetaタグが表示されることを確認する
<img width="1464" alt="メタタグがある" src="https://user-images.githubusercontent.com/54713809/233068266-1c6b5437-8dd4-4c89-8fb8-499ae1ee9eb4.png">

## Screenshot

### 変更前
「オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「test1」のページです。」という文言のmetaタグがない
<img width="1373" alt="メタタグが無い" src="https://user-images.githubusercontent.com/54713809/233068304-08ebb5b0-8b0f-4e23-aecb-856b469e636d.png">

### 変更後
metaタグがある。
<img width="1464" alt="メタタグがある" src="https://user-images.githubusercontent.com/54713809/233068326-a4884759-85eb-49c7-b11e-bb8d32b0495e.png">
