### PR TITLE
他の人のWIP提出物ページの警告メッセージの変更

### DIFF
--- a/app/views/products/_message_for_wip.html.slim
+++ b/app/views/products/_message_for_wip.html.slim
@@ -2,4 +2,4 @@
   .container.is-md
     .a-page-notice__inner
       p
-        | 提出物はまだ提出されていません。<br class='is-hidden-md-up'>完成したら「提出する」をクリック！
+        | 提出物はまだ提出されていません。

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -717,8 +717,8 @@ ActiveRecord::Schema.define(version: 2023_03_12_200635) do
     t.string "profile_job"
     t.text "profile_text"
     t.string "feed_url"
-    t.string "times_id", comment: "Snowflake ID"
     t.boolean "sent_student_followup_message", default: false
+    t.string "times_id", comment: "Snowflake ID"
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github_id"], name: "index_users_on_github_id", unique: true


### PR DESCRIPTION
## Issue

- #6045

## 概要

提出物個別ページを表示すると警告メッセージがWIPにしたユーザー以外にも、『提出物はまだ提出されていません。完成したら「提出する」をクリック!』と表示ていたが、『完成したら「提出する」をクリック!』を削除

## 変更確認方法

1. {bug/modify-warning-message-wip-submissions-page }をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる

## Screenshot

### 変更前
<img width="1184" alt="スクリーンショット 2023-04-20 7 24 11" src="https://user-images.githubusercontent.com/18245840/233213941-5112651e-0b58-4a20-a56b-e23159b7d80c.png">

### 変更後
<img width="1179" alt="スクリーンショット 2023-04-20 7 24 46" src="https://user-images.githubusercontent.com/18245840/233214005-c9f8a9a4-53ae-468f-878f-30dfc820231a.png">


