### PR TITLE
登録したばかりのユーザーには「1ヶ月間活動がない」と表示しない

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -10,14 +10,6 @@ module UsersHelper
     end
   end
 
-  def user_tr_attrs(user)
-    if user.active?
-      { class: 'active' }
-    else
-      { class: 'inactive' }
-    end
-  end
-
   def user_github_url(user)
     "https://github.com/#{user.github_account}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -483,7 +483,7 @@ class User < ApplicationRecord
   end
 
   def active?
-    last_activity_at && (last_activity_at > 1.month.ago)
+    (last_activity_at && (last_activity_at > 1.month.ago)) || created_at > 1.month.ago
   end
 
   def checked_product_of?(*practices)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -33,6 +33,10 @@ class UserTest < ActiveSupport::TestCase
     end
 
     travel_to Time.zone.local(2022, 7, 11, 0, 0, 0) do
+      assert users(:neverlogin).active? # 未ログインでも登録したばかりならactive
+    end
+
+    travel_to Time.zone.local(2022, 8, 12, 0, 0, 0) do
       assert_not users(:neverlogin).active?
     end
   end


### PR DESCRIPTION
## Issue

- #6449 

## 概要
メンター／管理者から見たユーザー一覧ページで、登録したばかりのユーザーにも「1ヶ月間活動がない」と表示されてしまうのを修正しました。

## 変更確認方法
影響する画面は、以下の2箇所です。イシューの対象としては①ですが、②にも影響があるため、両方で確認します。

①管理者/メンターから見たユーザー一覧ページ
  - 全ユーザー一覧 `/users`
  - 期生別ユーザー一覧 `/generations/:id`
  - 企業別ユーザー一覧 `/users/companies/:company_id/users`

②管理ページのユーザー一覧ページ `/admin/users`

### テスト用ユーザーの作成
1. ログアウトした状態でトップページにアクセスし、上部メニューの「参加登録」
2. 登録フォームを適当に埋めて「参加する」
    - クレジットカード番号には、テスト用のカードを入れる
      - https://stripe.com/docs/testing?testing-method=card-numbers#cards
3. Railsコンソール上で操作し、ユーザーを適当な企業に所属させる（企業別ユーザー一覧ページでテストするため）
```ruby
> user = User.find_by(login_name: 'shinkitouroku')
> company = Company.find_by(name: 'MaruMaru Inc.')
> user.update(company: company)
```
### ①管理者/メンターから見たユーザー一覧ページでの確認
1. mainブランチの状態で、machida（管理者）でログイン
2. ユーザー一覧ページにアクセスし、先ほど登録したユーザーに「1ヶ月以上ログインがありません」の表示があることを確認
![image](https://user-images.githubusercontent.com/46841037/233784033-45fea073-f49b-40db-85ff-3bc63be25cbb.png)

3. `bug/remove-no-activity-for-a-month-display-from-just-registered-user`に切り替える
4. ページをリロードし、「1ヶ月以上ログインがありません」の表示が消えることを確認
![image](https://user-images.githubusercontent.com/46841037/233783994-a2e46094-733d-4560-ad7e-73938efb1088.png)
5. 上記2-4の挙動を、期生別ユーザー一覧ページと企業別ユーザー一覧ページでも確認する
    - それぞれ、ユーザー一覧ページ上部の「期生別」「企業別」タブから遷移できる

### ②管理ページのユーザー一覧ページでの確認
1. mainブランチの状態で、machida（管理者）でログイン
2. 右上のユーザーメニューから管理ページに移動
![image](https://user-images.githubusercontent.com/46841037/233784240-b382f66c-147c-487b-b56b-6b2340e9a426.png)
3. 「ユーザー」タブを開き、先ほど登録したユーザーに「非ア」と表示されているのを確認
![image](https://user-images.githubusercontent.com/46841037/233784401-0b0b830c-9b67-42a7-b4f1-09387fabc39a.png)

5. `bug/remove-no-activity-for-a-month-display-from-just-registered-user`に切り替える
6. ページをリロードし、「非ア」の表示が消えることを確認
![image](https://user-images.githubusercontent.com/46841037/233784430-f8a0a98b-8366-4a2b-a110-e84d50ded638.png)

## 具体的にやったこと
この表示は`User`モデルの`active?`メソッドで制御されています。このメソッドでは1ヵ月内にログインがあるかを見ていますが、ログインがない場合でも登録から1ヵ月以内であればactiveであると判定するように修正しました。

## このあとやりたいこと
`active?`メソッドは下記の場所でも使われています。
https://github.com/fjordllc/bootcamp/blob/8d2c8e0f21a2b51ace429a9eb8624f831e0492d5/app/views/api/courses/practices/index.json.jbuilder#L14
この値はプラクティス一覧ページのユーザーアイコンにクラスを付与するために使われているようですが、そもそも上記の箇所でtypoしているため機能していないようです。常に`inactive`クラスが付与されます。また、このクラスにはとくにスタイルが当たっていないようです。
![image](https://user-images.githubusercontent.com/46841037/233784875-11c5e898-b6db-4d85-97f2-fd600bf7dc55.png)

このクラスが必要ならば適切にクラスとスタイルを付与したいですし、不要なら関連コードを消したいです。これは別途起票して対応しようと思います。
→起票しました
https://github.com/fjordllc/bootcamp/issues/6469