### PR TITLE
カテゴリー作成時にバリデーションのエラーメッセージを表示する

### DIFF
--- a/app/views/admin/categories/_form.html.slim
+++ b/app/views/admin/categories/_form.html.slim
@@ -1,4 +1,5 @@
 = form_with model: [:admin, category], local: true, html: { name: 'category', class: 'form' } do |f|
+  = render 'errors', object: category
   = f.hidden_field :course_id, value: params[:course_id]
   .form__items
     .form-item

--- a/test/system/admin/categories_test.rb
+++ b/test/system/admin/categories_test.rb
@@ -25,6 +25,28 @@ class Admin::CategoriesTest < ApplicationSystemTestCase
     assert_text 'カテゴリーを作成しました。'
   end
 
+  test 'cannot create category without category name' do
+    visit_with_auth new_admin_category_path, 'komagata'
+    within 'form[name=category]' do
+      fill_in 'category[slug]', with: 'test-category'
+      fill_in 'category[description]', with: 'テストのカテゴリーです。'
+      click_button '登録する'
+    end
+    assert_text '入力内容にエラーがありました'
+    assert_text '名前を入力してください'
+  end
+
+  test 'cannot create category without category slug' do
+    visit_with_auth new_admin_category_path, 'komagata'
+    within 'form[name=category]' do
+      fill_in 'category[name]', with: 'テストカテゴリー'
+      fill_in 'category[description]', with: 'テストのカテゴリーです。'
+      click_button '登録する'
+    end
+    assert_text '入力内容にエラーがありました'
+    assert_text 'URLスラッグを入力してください'
+  end
+
   test 'update category from course page' do
     visit_with_auth course_practices_path(courses(:course1)), 'komagata'
     first('.categories-item__edit').click


### PR DESCRIPTION
## Issue

- #6402

## 概要
カテゴリー作成時に必須項目に未入力がある場合、バリデーションメッセージを表示するようにしました。

## 変更確認方法

1. `bug/display-validation-errors-on-category-new`をローカルに取り込む
2. machida（管理者）としてログイン
3. `admin/categories/new`にアクセスする
4. 「名前」または「URLスラッグ」を未入力にする
5. 「登録する」ボタンをクリックする
6. 「名前を入力してください」「URLスラッグを入力してください」というエラーメッセージが表示される

## Screenshot
![image](https://user-images.githubusercontent.com/46841037/233836618-ae70babc-7ce7-427a-af55-8edb1b3eaaf5.png)

## 具体的にやったこと
- 該当のviewで`app/views/application/_errors.slim`パーシャルをcategoryモデルを渡して呼び出す
- システムテストの追加（このレベルのテストをいちいちやるかな？と思いつつ…）
- モデルテストの追加（無かったので、ついでに）
