### PR TITLE
ダッシュボードページで提出物の「次の経過日数まで」を表示

### DIFF
--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -45,7 +45,7 @@
                 span.a-meta__label 更新
                 | {{ product.updated_at }}
             .card-list-item-meta__item(
-              v-if='(product.selectedTab = unassigned)')
+              v-if='isUnassignedProductsPage || isDashboardPage')
               time.a-meta(v-if='untilNextElapsedDays(product) < 1')
                 span.a-meta__label 次の経過日数まで
                 | 1時間未満
@@ -131,11 +131,11 @@ export default {
     practiceTitle() {
       return `${this.product.practice.title}の提出物`
     },
-    unassigned() {
-      return location.pathname === '/products/unassigned'
+    isDashboardPage() {
+      return location.pathname === '/'
     },
-    unchecked() {
-      return location.pathname === '/products/unchecked'
+    isUnassignedProductsPage() {
+      return location.pathname === '/products/unassigned'
     },
     notRespondedSign() {
       return (


### PR DESCRIPTION
## 概要

ダッシュボードページの「提出物状況」で、提出物の「次の経過日数まで」を表示するようにしました。提出物ページの未アサインタブでは表示されていたのですが、ダッシュボードページでは表示されていなくて不便だったので直しました。

## 変更確認方法

1. komagata でログインして、ダッシュボードページにアクセスする
3. ダッシュボードページの提出物状況で、未アサインの提出物に「次の経過日数まで」が表示されていることを確認する

## Screenshot

| 変更前 | 変更後 |
| - | - |
| ![localhost_3000_](https://user-images.githubusercontent.com/7645585/233838114-105f0975-7539-450f-a0f5-ef1772e8fce0.png) | ![localhost_3000_ (1)](https://user-images.githubusercontent.com/7645585/233838135-7a809a7c-bf54-4c62-ae58-b9dbf1fb7218.png) |