### PR TITLE
イベント参加への繰り上がり通知を、active_delivery化する

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -12,6 +12,7 @@ class ActivityMailer < ApplicationMailer
     @question = params[:question] if params&.key?(:question)
     @mentionable = params[:mentionable] if params&.key?(:mentionable)
     @page = params[:page] if params&.key?(:page)
+    @event = params[:event] if params&.key?(:event)
     @watchable = params[:watchable] if params&.key?(:watchable)
     @comment = params[:comment] if params&.key?(:comment)
     @product = params[:product] if params&.key?(:product)
@@ -194,6 +195,22 @@ class ActivityMailer < ApplicationMailer
 
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
+
+  def moved_up_event_waiting_user(args = {})
+    @sender ||= args[:sender]
+    @receiver ||= args[:receiver]
+    @event ||= args[:event]
+
+    @user = @receiver
+    @link_url = notification_redirector_url(
+      link: "/events/#{@event.id}",
+      kind: Notification.kinds[:moved_up_event_waiting_user]
+    )
+    subject = "[FBC] #{@event.title}で、補欠から参加に繰り上がりました。"
+    message = mail to: @user.email, subject: subject
 
     message
   end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -210,9 +210,7 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:moved_up_event_waiting_user]
     )
     subject = "[FBC] #{@event.title}で、補欠から参加に繰り上がりました。"
-    message = mail to: @user.email, subject: subject
-
-    message
+    mail to: @user.email, subject: subject
   end
 
   def following_report(args = {})

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -209,7 +209,10 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:moved_up_event_waiting_user]
     )
     subject = "[FBC] #{@event.title}で、補欠から参加に繰り上がりました。"
-    mail to: @user.email, subject: subject
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
   end
 
   def following_report(args = {})

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -200,7 +200,6 @@ class ActivityMailer < ApplicationMailer
   end
 
   def moved_up_event_waiting_user(args = {})
-    @sender ||= args[:sender]
     @receiver ||= args[:receiver]
     @event ||= args[:event]
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -69,14 +69,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
     mail to: @user.email, subject: subject
   end
 
-  # required params: event, receiver
-  def moved_up_event_waiting_user
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/events/#{@event.id}")
-    subject = "[FBC] #{@event.title}で、補欠から参加に繰り上がりました。"
-    mail to: @user.email, subject: subject
-  end
-
   # required params: page, receiver
   def create_page
     @user = @receiver

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
+class NotificationMailer < ApplicationMailer
   helper ApplicationHelper
 
   before_action do

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -104,7 +104,7 @@ class Event < ApplicationRecord
   end
 
   def send_notification(receiver)
-    NotificationFacade.moved_up_event_waiting_user(self, receiver)
+    ActivityDelivery.with(receiver: receiver, event: self).notify(:moved_up_event_waiting_user)
   end
 
   def holding_today?

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -37,19 +37,6 @@ class NotificationFacade
     ).trainee_report.deliver_later(wait: 5)
   end
 
-  def self.moved_up_event_waiting_user(event, receiver)
-    ActivityNotifier.with(
-      event: event,
-      receiver: receiver
-    ).moved_up_event_waiting_user.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      event: event,
-      receiver: receiver
-    ).moved_up_event_waiting_user.deliver_later(wait: 5)
-  end
-
   def self.chose_correct_answer(answer, receiver)
     ActivityNotifier.with(answer: answer, receiver: receiver).chose_correct_answer.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/views/activity_mailer/moved_up_event_waiting_user.slim
+++ b/app/views/activity_mailer/moved_up_event_waiting_user.slim
@@ -1,0 +1,2 @@
+= render '/notification_mailer/notification_mailer_template', title: "#{@event.title}で、補欠から参加に繰り上がりました。", link_url: @link_url, link_text: '特別イベント詳細へ' do
+  = md2html(@event.description)

--- a/app/views/notification_mailer/moved_up_event_waiting_user.slim
+++ b/app/views/notification_mailer/moved_up_event_waiting_user.slim
@@ -1,2 +1,0 @@
-= render 'notification_mailer_template', title: "#{@event.title}で、補欠から参加に繰り上がりました。", link_url: notification_url(@notification), link_text: '特別イベント詳細へ' do
-  = md2html(@event.description)

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -128,7 +128,7 @@ notification_trainee_report:
 
 notification_moved_up_event_waiting_user:
   kind: 11
-  user: kimura
+  user: hatsuno
   sender: komagata
   message: 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。
   link: "/events/<%= ActiveRecord::FixtureSet.identify(:event3) %>"

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -128,7 +128,7 @@ notification_trainee_report:
 
 notification_moved_up_event_waiting_user:
   kind: 11
-  user: hajime
+  user: kimura
   sender: komagata
   message: 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。
   link: "/events/<%= ActiveRecord::FixtureSet.identify(:event3) %>"

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -517,7 +517,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['kimura@fjord.jp'], email.to
+    assert_equal ['hatsuno@fjord.jp'], email.to
     assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
     assert_match(/イベント/, email.body.to_s)
   end
@@ -537,7 +537,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['kimura@fjord.jp'], email.to
+    assert_equal ['hatsuno@fjord.jp'], email.to
     assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
     assert_match(/イベント/, email.body.to_s)
   end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -506,6 +506,26 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">このDocsへ</a>}, email.body.to_s)
   end
 
+  test 'moved_up_event_waiting_user' do
+    event = events(:event3)
+    notification = notifications(:notification_moved_up_event_waiting_user)
+    mailer = ActivityMailer.moved_up_event_waiting_user(
+      receiver: notification.user,
+      event: event
+    )
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['hajime@fjord.jp'], email.to
+    assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
+    assert_match(/イベント/, email.body.to_s)
+  end
+
   test 'submitted' do
     product = products(:product11)
     receiver = users(:mentormentaro)

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -521,7 +521,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['hajime@fjord.jp'], email.to
+    assert_equal ['kimura@fjord.jp'], email.to
     assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
     assert_match(/イベント/, email.body.to_s)
   end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -516,10 +516,11 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 11, link: "/events/#{event.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['hatsuno@fjord.jp'], email.to
     assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
-    assert_match(/イベント/, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">特別イベント詳細へ</a>}, email.body.to_s)
   end
 
   test 'moved_up_event_waiting_user with params' do
@@ -536,10 +537,11 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 11, link: "/events/#{event.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['hatsuno@fjord.jp'], email.to
     assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
-    assert_match(/イベント/, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">特別イベント詳細へ</a>}, email.body.to_s)
   end
 
   test 'submitted' do

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -509,6 +509,22 @@ class ActivityMailerTest < ActionMailer::TestCase
   test 'moved_up_event_waiting_user' do
     event = events(:event3)
     notification = notifications(:notification_moved_up_event_waiting_user)
+    ActivityMailer.moved_up_event_waiting_user(
+      receiver: notification.user,
+      event: event
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['kimura@fjord.jp'], email.to
+    assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
+    assert_match(/イベント/, email.body.to_s)
+  end
+
+  test 'moved_up_event_waiting_user with params' do
+    event = events(:event3)
+    notification = notifications(:notification_moved_up_event_waiting_user)
     mailer = ActivityMailer.moved_up_event_waiting_user(
       receiver: notification.user,
       event: event

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -64,26 +64,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/日報/, email.body.to_s)
   end
 
-  test 'moved_up_event_waiting_user' do
-    event = events(:event3)
-    notification = notifications(:notification_moved_up_event_waiting_user)
-    mailer = NotificationMailer.with(
-      event: event,
-      receiver: notification.user
-    ).moved_up_event_waiting_user
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['hajime@fjord.jp'], email.to
-    assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
-    assert_match(/イベント/, email.body.to_s)
-  end
-
   test 'chose_correct_answer' do
     answer = correct_answers(:correct_answer2)
     notification = notifications(:notification_chose_correct_answer)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -68,6 +68,16 @@ class ActivityMailerPreview < ActionMailer::Preview
     ActivityMailer.with(sender: page.user, receiver: receiver, page: page).create_page
   end
 
+  def moved_up_event_waiting_user
+    event = Event.find(ActiveRecord::FixtureSet.identify(:event3))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:hajime))
+
+    ActivityMailer.with(
+      event: event,
+      receiver: receiver
+    ).moved_up_event_waiting_user
+  end
+
   def submitted
     product = Product.find(ActiveRecord::FixtureSet.identify(:product15))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -70,7 +70,7 @@ class ActivityMailerPreview < ActionMailer::Preview
 
   def moved_up_event_waiting_user
     event = Event.find(ActiveRecord::FixtureSet.identify(:event3))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:hajime))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:hatsuno))
 
     ActivityMailer.with(
       event: event,

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -50,16 +50,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.with(report: report, receiver: receiver).trainee_report
   end
 
-  def moved_up_event_waiting_user
-    event = Event.find(ActiveRecord::FixtureSet.identify(:event3))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:hajime))
-
-    NotificationMailer.with(
-      event: event,
-      receiver: receiver
-    ).moved_up_event_waiting_user
-  end
-
   def chose_correct_answer
     answer = Answer.find(ActiveRecord::FixtureSet.identify(:correct_answer2))
     receiver = answer.sender

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -80,7 +80,7 @@ class EventTest < ActiveSupport::TestCase
 
   test '#send_notification' do
     event = events(:event3)
-    user = users(:kimura)
+    user = users(:hatsuno)
     event.send_notification(user)
     assert Notification.where(user: user, sender: event.user, link: "/events/#{event.id}").exists?
   end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -80,7 +80,7 @@ class EventTest < ActiveSupport::TestCase
 
   test '#send_notification' do
     event = events(:event3)
-    user = users(:hajime)
+    user = users(:kimura)
     event.send_notification(user)
     assert Notification.where(user: user, sender: event.user, link: "/events/#{event.id}").exists?
   end


### PR DESCRIPTION
## Issue

- #5887

## 概要

FBCの、イベント参加への繰り上がり通知を、active_delivery化する

## 変更確認方法

1. ブランチ  feature/change_event_entry_carrying_notification_to_active_deliveryをローカルに取り込む
1. bin/setupでセットアップする
1. bin/rails s でサーバーを立ち上げる
1. komagataさんのアカウントでログインする
1. 「募集期間中のイベント(補欠者あり)」にアクセスする => http://localhost:3000/events/626726618
<img width="1005" alt="スクリーンショット 2023-04-30 10 39 10" src="https://user-images.githubusercontent.com/54713809/235331458-6ed06b95-404a-46c2-a452-e943ecb2fc5c.png">

6. komagataさんが、イベントへの参加を申し込んでおり、補欠者がいる事を確認する(このように、補欠者で、最初に繰り上がりする方は「hatsuno」さんであることを確認する)
<img width="194" alt="スクリーンショット 2023-04-30 10 41 49" src="https://user-images.githubusercontent.com/54713809/235331512-112e78b3-b31d-4287-8feb-b9bb034bcaf3.png">

7. komagataさんが参加を取り消す。
<img width="496" alt="スクリーンショット 2023-04-30 10 45 10" src="https://user-images.githubusercontent.com/54713809/235331592-a41d504e-48be-4714-9163-2c19b2927c0a.png">

8. 参加者がkomagataさんから「hatsuno」さんに変わっていることを確認する
<img width="221" alt="スクリーンショット 2023-04-30 10 46 13" src="https://user-images.githubusercontent.com/54713809/235331627-378528b5-8f84-4b76-93df-a993cabebe57.png">

9. http://localhost:3000/letter_opener/ にアクセスすると、「hatsuno」さんに、メールで通知がきていることを確認する
<img width="1170" alt="スクリーンショット 2023-04-30 10 51 28" src="https://user-images.githubusercontent.com/54713809/235331767-6d6ab8c2-e7e0-40c4-ada5-52d8a49f59bc.png">