### PR TITLE
ベストアンサー決定通知をactive_delivery化する

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -344,4 +344,20 @@ class ActivityMailer < ApplicationMailer
 
     message
   end
+
+  # required params: answer, receiver
+  def chose_correct_answer
+    @user = @receiver
+    @answer = params[:answer]
+
+    @link_url = notification_redirector_url(
+      link: question_path(@answer.question),
+      kind: Notification.kinds[:chose_correct_answer]
+    )
+
+    subject = "[FBC] #{@answer.receiver.login_name}さんの質問【 #{@answer.question.title} 】で#{@answer.sender.login_name}さんの回答がベストアンサーに選ばれました。"
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+    message
+  end
 end

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -351,7 +351,7 @@ class ActivityMailer < ApplicationMailer
     @answer = params[:answer]
 
     @link_url = notification_redirector_url(
-      link: question_path(@answer.question),
+      link: question_path(@answer.question, anchor: "answer_#{@answer.id}"),
       kind: Notification.kinds[:chose_correct_answer]
     )
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -346,9 +346,10 @@ class ActivityMailer < ApplicationMailer
   end
 
   # required params: answer, receiver
-  def chose_correct_answer
+  def chose_correct_answer(args = {})
+    @receiver ||= args[:receiver]
     @user = @receiver
-    @answer = params[:answer]
+    @answer = params&.key?(:answer) ? params[:answer] : args[:answer]
 
     @link_url = notification_redirector_url(
       link: question_path(@answer.question, anchor: "answer_#{@answer.id}"),

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -69,12 +69,12 @@ class NotificationMailer < ApplicationMailer
     mail to: @user.email, subject: subject
   end
 
-  # required params: answer, receiver
-  def chose_correct_answer
+  # required params: report, receiver
+  def consecutive_sad_report
     @user = @receiver
-    @notification = @user.notifications.find_by(link: "/questions/#{@answer.question.id}")
-    subject = "[FBC] #{@answer.receiver.login_name}さんの質問【 #{@answer.question.title} 】で#{@answer.sender.login_name}さんの回答がベストアンサーに選ばれました。"
-    mail to: @user.email, subject: subject
+    @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
+    mail to: @user.email,
+         subject: "[FBC] #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。"
   end
 
   # required params: question, receiver

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -69,14 +69,6 @@ class NotificationMailer < ApplicationMailer
     mail to: @user.email, subject: subject
   end
 
-  # required params: report, receiver
-  def consecutive_sad_report
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
-    mail to: @user.email,
-         subject: "[FBC] #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。"
-  end
-
   # required params: question, receiver
   def no_correct_answer
     @user = @receiver

--- a/app/models/correct_answer_notifier.rb
+++ b/app/models/correct_answer_notifier.rb
@@ -13,7 +13,7 @@ class CorrectAnswerNotifier
     receiver_ids = watcher_ids - [question.user_id]
     receiver_ids.each do |receiver_id|
       receiver = User.find(receiver_id)
-      NotificationFacade.chose_correct_answer(answer, receiver)
+      ActivityDelivery.with(answer: answer, receiver: receiver).notify(:chose_correct_answer)
     end
   end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -27,16 +27,6 @@ class NotificationFacade
     ).trainee_report.deliver_later(wait: 5)
   end
 
-  def self.chose_correct_answer(answer, receiver)
-    ActivityNotifier.with(answer: answer, receiver: receiver).chose_correct_answer.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      answer: answer,
-      receiver: receiver
-    ).chose_correct_answer.deliver_later(wait: 5)
-  end
-
   def self.coming_soon_regular_events(today_events, tomorrow_events)
     DiscordNotifier.with(today_events: today_events, tomorrow_events: tomorrow_events).coming_soon_regular_events.notify_now
   end

--- a/app/views/activity_mailer/chose_correct_answer.html.slim
+++ b/app/views/activity_mailer/chose_correct_answer.html.slim
@@ -1,5 +1,5 @@
 = render '/notification_mailer/notification_mailer_template',
-  title: "#{@answer.receiver.login_name}さんの質問【 #{@answer.question.title} 】で#{@answer.sender.login_name}さんの回答がベストアンサーが選ばれました。",
+  title: "#{@answer.receiver.login_name}さんの質問【 #{@answer.question.title} 】で#{@answer.sender.login_name}さんの回答がベストアンサーに選ばれました。",
   link_url: @link_url,
   link_text: '回答へ' do
   = md2html(@answer.description)

--- a/app/views/activity_mailer/chose_correct_answer.html.slim
+++ b/app/views/activity_mailer/chose_correct_answer.html.slim
@@ -1,5 +1,5 @@
-= render 'notification_mailer_template',
+= render '/notification_mailer/notification_mailer_template',
   title: "#{@answer.receiver.login_name}さんの質問【 #{@answer.question.title} 】で#{@answer.sender.login_name}さんの回答がベストアンサーが選ばれました。",
-  link_url: notification_url(@notification, anchor: "answer_#{@answer.id}"),
+  link_url: @link_url,
   link_text: '回答へ' do
   = md2html(@answer.description)

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -353,6 +353,14 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     }
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:chose_correct_answer, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:chose_correct_answer, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify!(:chose_correct_answer)
     end
 

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -344,4 +344,20 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:signed_up)
     end
   end
+
+  test '.notify(:chose_correct_answer)' do
+    answer = answers(:answer1)
+    params = {
+      answer: answer,
+      receiver: answer.user
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:chose_correct_answer)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:chose_correct_answer)
+    end
+  end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -823,7 +823,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal ['komagata@fjord.jp'], email.to
     assert_equal '[FBC] hajimeさんが2回連続でsadアイコンの日報を提出しました。', email.subject
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">この日報へ</a>}, email.body.to_s)
-  end
+  end 
 
   test 'update_regular_event using synchronous mailer' do
     regular_event = regular_events(:regular_event1)
@@ -914,5 +914,61 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal ['komagata@fjord.jp'], email.to
     assert_equal '[FBC] hajimeさんが新しく入会しました！', email.subject
     assert_match(/入会/, email.body.to_s)
+  end
+
+  test 'chose_correct_answer' do
+    answer = correct_answers(:correct_answer1)
+    receiver = answer.user
+
+    mailer = ActivityMailer.with(
+      answer: answer,
+      receiver: receiver
+    ).chose_correct_answer
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last   
+    query = CGI.escapeHTML({ kind: Notification.kinds[:chose_correct_answer], link: "/questions/#{answer.question.id}#answer_#{answer.id}" }.to_param)
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal [receiver.email], email.to
+    assert_equal "[FBC] #{answer.receiver.login_name}さんの質問【 #{answer.question.title} 】で#{answer.sender.login_name}さんの回答がベストアンサーに選ばれました。", email.subject
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">回答へ</a>}, email.body.to_s)
+  end
+
+  test 'not send chose_correct_answer email to user with mail_notification off' do
+    answer = correct_answers(:correct_answer1)
+    receiver = answer.user
+    receiver.update(mail_notification: false)
+
+    mailer = ActivityMailer.with(
+      answer: answer,
+      receiver: receiver
+    ).chose_correct_answer
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert ActionMailer::Base.deliveries.empty?
+  end
+
+  test 'not send chose_correct_answer email to retired user' do
+    answer = correct_answers(:correct_answer1)
+    receiver = answer.user
+    receiver.update(retired_on: Date.current)
+
+    mailer = ActivityMailer.with(
+      answer: answer,
+      receiver: receiver
+    ).chose_correct_answer
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert ActionMailer::Base.deliveries.empty?
   end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -823,7 +823,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal ['komagata@fjord.jp'], email.to
     assert_equal '[FBC] hajimeさんが2回連続でsadアイコンの日報を提出しました。', email.subject
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">この日報へ</a>}, email.body.to_s)
-  end 
+  end
 
   test 'update_regular_event using synchronous mailer' do
     regular_event = regular_events(:regular_event1)
@@ -948,7 +948,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     end
 
     assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last   
+    email = ActionMailer::Base.deliveries.last
     query = CGI.escapeHTML({ kind: Notification.kinds[:chose_correct_answer], link: "/questions/#{answer.question.id}#answer_#{answer.id}" }.to_param)
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal [receiver.email], email.to

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -44,26 +44,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/日報/, email.body.to_s)
   end
 
-  test 'moved_up_event_waiting_user' do
-    event = events(:event3)
-    notification = notifications(:notification_moved_up_event_waiting_user)
-    mailer = NotificationMailer.with(
-      event: event,
-      receiver: notification.user
-    ).moved_up_event_waiting_user
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['hajime@fjord.jp'], email.to
-    assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
-    assert_match(/イベント/, email.body.to_s)
-  end
-
   test 'no_correct_answer' do
     user = users(:kimura)
     question = questions(:question8)

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -44,13 +44,13 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/日報/, email.body.to_s)
   end
 
-  test 'chose_correct_answer' do
-    answer = correct_answers(:correct_answer2)
-    notification = notifications(:notification_chose_correct_answer)
+  test 'moved_up_event_waiting_user' do
+    event = events(:event3)
+    notification = notifications(:notification_moved_up_event_waiting_user)
     mailer = NotificationMailer.with(
-      answer: answer,
+      event: event,
       receiver: notification.user
-    ).chose_correct_answer
+    ).moved_up_event_waiting_user
 
     perform_enqueued_jobs do
       mailer.deliver_later
@@ -59,9 +59,9 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['advijirou@example.com'], email.to
-    assert_equal '[FBC] hajimeさんの質問【 解決済みの質問 】でadvijirouさんの回答がベストアンサーに選ばれました。', email.subject
-    assert_match(/回答/, email.body.to_s)
+    assert_equal ['hajime@fjord.jp'], email.to
+    assert_equal '[FBC] 募集期間中のイベント(補欠者あり)で、補欠から参加に繰り上がりました。', email.subject
+    assert_match(/イベント/, email.body.to_s)
   end
 
   test 'no_correct_answer' do

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -146,4 +146,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(sender: sender, receiver: receiver, sender_roles: sender.roles_to_s).signed_up
   end
+
+  def chose_correct_answer
+    answer = Answer.find(ActiveRecord::FixtureSet.identify(:correct_answer1))
+    receiver = User.find(answer.user_id)
+
+    ActivityMailer.with(answer: answer, receiver: receiver).chose_correct_answer
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5889

## 概要
ベストアンサー決定通知をactive_delivery化しました。
対象は、メール通知とサイト内通知の2種類です。
チャットの通知は変更していません。

## 変更確認方法

1. `feature/replace-notification-on-correct-answer-save-with-active-delivery`をローカルに取り込む
2. kimuraでログイン（メール通知がONのユーザーならOK）
4. Q&Aページから適当な質問にアクセスして回答する
5. ログアウトし、3で回答した質問の質問者でログイン
6. 3で回答した質問にアクセスし、回答の「ベストアンサーにする」をクリック
7. http://localhost:3000/letter_opener/ にアクセスし、kimuraに「…kimuraさんの回答がベストアンサーに選ばれました。」というメールが飛んでいることを確認
8. メールの「回答へ」をクリックすると、回答に遷移することを確認
9.  ログアウトし、もう一度kimuraでログイン
10. ページ右上の通知で、「…kimuraさんの回答がベストアンサーに選ばれました。」と表示されることを確認
11. 通知をクリックすると質問に遷移することを確認

## Screenshot
とくに画面に変更はないので略

## やったこと
- NotificationFacadeをActivityNotifierに置き換え
- NotificationMailerをActivityMailerに置き換え
- Mailerのプレビュー画面を追加

### ベストアンサー決定通知処理の全体像と今回変更した箇所
#### before
```mermaid
flowchart TD
  CorrectAnswersController -- message --> ChatNotifier
  ChatNotifier -- message --> Discord::Notifier
  CorrectAnswersController -- publish --> Newspaper
  Newspaper -. "call" .-> CorrectAnswerNotifier
  CorrectAnswerNotifier -- chose_correct_answer --> NotificationFacade
  NotificationFacade:::orange -- chose_correct_answer --> NotificationMailer
  NotificationMailer:::orange -- mail --> ApplicationMailer
  NotificationFacade -- chose_correct_answer --> ActivityNotifier
  ActivityNotifier -. "call" .-> ActivityDriver
  ActivityDriver -- create! --> Notification
  classDef orange fill:#f96
```
#### After
```mermaid
flowchart TD
  CorrectAnswersController -- message --> ChatNotifier
  ChatNotifier -- message --> Discord::Notifier
  CorrectAnswersController -- publish --> Newspaper
  Newspaper -. "call" .-> CorrectAnswerNotifier
  CorrectAnswerNotifier -- "notify(:chose_correct_answer)" --> ActivityDelivery
  ActivityDelivery:::orange -. chose_correct_answer .-> ActivityMailer
  ActivityMailer:::orange -- mail --> ApplicationMailer
  ActivityDelivery -. chose_correct_answer .-> ActivityNotifier
  ActivityNotifier -. "call" .-> ActivityDriver
  ActivityDriver -- create! --> Notification
  classDef orange fill:#f96
```

## 参考情報
### 参考リンク
- [gemを使った通知機能 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/gem%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%9F%E9%80%9A%E7%9F%A5%E6%A9%9F%E8%83%BD)
- [abstract_notifier](https://github.com/palkan/abstract_notifier)
  - [abstract_notifierで通知を実装する - komagataのブログ](https://docs.komagata.org/5857)
- [active_delivery](https://github.com/palkan/active_delivery)
  - [active_deliveryで通知をまとめる - komagataのブログ](https://docs.komagata.org/5858)
- [Action Mailer の基礎 - Railsガイド](https://railsguides.jp/action_mailer_basics.html)
- [Active Job の基礎 - Railsガイド](https://railsguides.jp/active_job_basics.html)

### 参考PR
- https://github.com/fjordllc/bootcamp/pull/6342

（他にもactive_delivery化のPRは多数あるが略）