### PR TITLE
Stagingで発生したフォローアップメッセージ送信のエラーを修正

### DIFF
--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -154,7 +154,7 @@ talk_sotugyou-with-job:
   user: sotugyou_with_job
   unreplied: false
 
-<% 1.upto(22) do |i| %>
+<% 1.upto(25) do |i| %>
 marumarushain<%= i %>: # ページネーション確認のためのユーザー
   user: marumarushain<%= i %>
   unreplied: false


### PR DESCRIPTION
## 概要

- #6441 で発生したエラーを修正しました

### エラーの要因

- Seedデータにユーザーに紐づく相談部屋（Talk）の関連付けデータが足りないことで発生しているようでした

```ruby
NoMethodError: undefined method `id' for nil:NilClass

        commentable_id: Talk.find_by(user_id: student.id).id,
                                                         ^^^ 
```

## 変更確認方法

1. `bug/fix_daily_send_followup_message`をローカルに取り込む
2. `bin/rails db:reset`を実行
3. `bin/rake data:migrate:up VERSION=20230114032018`を実行（多分やらなくてもいいと思うけど、念の為）
4. `bin/rails console`を起動して以下を調べる
    -  `User.where.missing(:talk).count`
    -  `User.where.missing(:talk).each {|u| p u.login_name }`
    -  上記が０件であることを確認する（修正前は3件ほど存在する）
