### PR TITLE
ブックマーク削除ボタンの重複するidを削除してclassを付与した

### DIFF
--- a/app/javascript/components/Bookmarks.jsx
+++ b/app/javascript/components/Bookmarks.jsx
@@ -142,8 +142,7 @@ const DeleteButton = ({ id, afterDelete }) => {
   return (
     <div className="card-list-item__option">
       <div
-        id="bookmark-button"
-        className="a-bookmark-button a-button is-sm is-block is-main"
+        className="bookmark-delete-button a-bookmark-button a-button is-sm is-block is-main"
         onClick={() => afterDelete(id)}>
         削除
       </div>

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -91,19 +91,4 @@ class BookmarksTest < ApplicationSystemTestCase
     find(:css, '#spec-edit-mode').set(true)
     assert_selector '.card-list-item__option'
   end
-
-  test 'delete bookmark from bookmarks' do
-    user = @report.user
-    decorated_user = ActiveDecorator::Decorator.instance.decorate(user)
-    visit_with_auth report_path(@report), 'komagata'
-    assert_text 'Bookmark中'
-    visit current_user_bookmarks_path
-    assert_text "#{decorated_user.long_name} さんの相談部屋"
-    find(:css, '#spec-edit-mode').set(true)
-    assert_selector '.card-list-item__option'
-    first('.bookmark-delete-button').click
-    assert_no_text "#{decorated_user.long_name} さんの相談部屋"
-    visit report_path(@report)
-    assert_text 'Bookmark'
-  end
 end

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -101,7 +101,7 @@ class BookmarksTest < ApplicationSystemTestCase
     assert_text "#{decorated_user.long_name} さんの相談部屋"
     find(:css, '#spec-edit-mode').set(true)
     assert_selector '.card-list-item__option'
-    first('#bookmark-button').click
+    first('.bookmark-delete-button').click
     assert_no_text "#{decorated_user.long_name} さんの相談部屋"
     visit report_path(@report)
     assert_text 'Bookmark'

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -84,11 +84,4 @@ class BookmarksTest < ApplicationSystemTestCase
     visit '/current_user/bookmarks'
     assert_no_text @question.title
   end
-
-  test 'edit bookmarks' do
-    visit_with_auth current_user_bookmarks_path, 'kimura'
-    assert_no_selector '.card-list-item__option'
-    find(:css, '#spec-edit-mode').set(true)
-    assert_selector '.card-list-item__option'
-  end
 end

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -8,12 +8,6 @@ class BookmarksTest < ApplicationSystemTestCase
     @question = questions(:question1)
   end
 
-  test 'show my bookmark lists' do
-    visit_with_auth '/current_user/bookmarks', 'komagata'
-    assert_equal 'ブックマーク一覧 | FBC', title
-    assert_text @report.title
-  end
-
   test 'show my bookmark report' do
     visit_with_auth "/reports/#{@report.id}", 'komagata'
     assert_selector '#bookmark-button.is-active'

--- a/test/system/current_user/bookmarks_test.rb
+++ b/test/system/current_user/bookmarks_test.rb
@@ -36,8 +36,10 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
   end
 
   test 'can delete bookmarks when edit mode is active' do
-    visit_with_auth '/current_user/bookmarks', 'kimura'
+    visit_with_auth page_path(pages(:page1)), 'kimura'
+    assert_text 'Bookmark中'
 
+    visit_with_auth '/current_user/bookmarks', 'kimura'
     assert_selector '.card-list-item', count: 4
     assert_text 'test1'
     assert_no_selector '.bookmark-delete-button'
@@ -48,6 +50,9 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
 
     assert_selector '.card-list-item', count: 3
     assert_no_text 'test1'
+
+    visit_with_auth page_path(pages(:page1)), 'kimura'
+    assert_text 'Bookmark'
   end
 
   test 'show empty state when all bookmarks are deleted' do

--- a/test/system/current_user/bookmarks_test.rb
+++ b/test/system/current_user/bookmarks_test.rb
@@ -40,11 +40,11 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
 
     assert_selector '.card-list-item', count: 4
     assert_text 'test1'
-    assert_no_selector '#bookmark-button'
+    assert_no_selector '.bookmark-delete-button'
 
     find('#spec-edit-mode').click
-    assert_selector '#bookmark-button'
-    first('#bookmark-button').click
+    assert_selector '.bookmark-delete-button'
+    first('.bookmark-delete-button').click
 
     assert_selector '.card-list-item', count: 3
     assert_no_text 'test1'
@@ -68,7 +68,7 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
 
     assert_selector '.card-list-item', count: 1
     find('#spec-edit-mode').click
-    first('#bookmark-button').click
+    first('.bookmark-delete-button').click
 
     assert_text 'ブックマークはまだありません。'
     assert_selector 'i.fa-regular.fa-face-sad-tear', visible: false


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6273
- https://github.com/fjordllc/bootcamp/issues/6275

## 概要
- ブックマーク一覧ページ(`/current_user/bookmarks`)のブックマーク削除ボタンの重複する`id="bookmark-button"`を削除して、新たに`class="bookmark-delete-button"`を追加しました。
- idの削除とclassの追加に伴い、関連するテスト(`test/system/current_user/bookmarks_test.rb`)を修正しました。
- ブックマークに関するテスト(`test/system/bookmarks_test.rb`と`test/system/current_user/bookmarks_test.rb`)のリファクタリングを行いました。[9e864b7](https://github.com/fjordllc/bootcamp/pull/6501/commits/9e864b768c49965006c2a85b3fb2cadc7f06a6e3)で[#6275](https://github.com/fjordllc/bootcamp/issues/6275)に対応しています。

## 変更確認方法

1. `bug/fix-bookmark-delete-button-id-duplication`をローカルに取り込む
2. `rails s`でサーバーを起動
3. `localhost:3000`にアクセス
4. `kimura`でログイン
5. `/current_user/bookmarks`にアクセス
6. 「編集」を「ON」にして、削除ボタンを表示させる
7. Chromeデベロッパーツールで削除ボタンの要素から、`id="bookmark-button"`がないこと、`class="bookmark-delete-button"`が追加されていることを確認

## Screenshot

### 変更前
`/current_user/bookmarks`

<img width="614" alt="issue_6273_before-2" src="https://user-images.githubusercontent.com/65595901/236656847-4895fa01-8ae1-4f18-8643-8299ec45473b.png">


### 変更後
`/current_user/bookmarks`

![issue_6273_after-1](https://user-images.githubusercontent.com/65595901/236656992-7a570b82-b12b-4198-bab0-73dda42f4714.jpg)
