### PR TITLE
質問作成時のDiscord通知をActiveRecordコールバックからnewspaperに置き換えた

### DIFF
--- a/app/models/question_callbacks.rb
+++ b/app/models/question_callbacks.rb
@@ -5,7 +5,6 @@ class QuestionCallbacks
     return unless question.saved_change_to_attribute?(:published_at, from: nil)
 
     send_notification_to_mentors(question)
-    notify_to_chat(question)
     Cache.delete_not_solved_question_count
   end
 
@@ -15,13 +14,6 @@ class QuestionCallbacks
   end
 
   private
-
-  def notify_to_chat(question)
-    ChatNotifier.message(<<~TEXT)
-      質問：「#{question.title}」を#{question.user.login_name}さんが作成しました。
-      https://bootcamp.fjord.jp/questions/#{question.id}
-    TEXT
-  end
 
   def send_notification_to_mentors(question)
     User.mentor.each do |user|

--- a/app/models/question_notifier.rb
+++ b/app/models/question_notifier.rb
@@ -12,7 +12,7 @@ class QuestionNotifier
   def notify_to_chat(question)
     ChatNotifier.message(<<~TEXT)
       質問：「#{question.title}」を#{question.user.login_name}さんが作成しました。
-      #{Rails.application.routes.url_helpers.question_url(question, host: 'bootcamp.fjord.jp', protocol: 'https')}
+      #{Rails.application.routes.url_helpers.question_url(question)}
     TEXT
   end
 end

--- a/app/models/question_notifier.rb
+++ b/app/models/question_notifier.rb
@@ -4,12 +4,6 @@ class QuestionNotifier
   def call(question)
     return if question.wip?
 
-    notify_to_chat(question)
-  end
-
-  private
-
-  def notify_to_chat(question)
     ChatNotifier.message(<<~TEXT)
       質問：「#{question.title}」を#{question.user.login_name}さんが作成しました。
       #{Rails.application.routes.url_helpers.question_url(question)}

--- a/app/models/question_notifier.rb
+++ b/app/models/question_notifier.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class QuestionNotifier
+  def call(question)
+    return if question.wip?
+
+    notify_to_chat(question)
+  end
+
+  private
+
+  def notify_to_chat(question)
+    ChatNotifier.message(<<~TEXT)
+      質問：「#{question.title}」を#{question.user.login_name}さんが作成しました。
+      https://bootcamp.fjord.jp/questions/#{question.id}
+    TEXT
+  end
+end

--- a/app/models/question_notifier.rb
+++ b/app/models/question_notifier.rb
@@ -12,7 +12,7 @@ class QuestionNotifier
   def notify_to_chat(question)
     ChatNotifier.message(<<~TEXT)
       質問：「#{question.title}」を#{question.user.login_name}さんが作成しました。
-      https://bootcamp.fjord.jp/questions/#{question.id}
+      #{Rails.application.routes.url_helpers.question_url(question, host: 'bootcamp.fjord.jp', protocol: 'https')}
     TEXT
   end
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -59,4 +59,7 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:question_update, ai_answer_creator)
 
   Newspaper.subscribe(:retirement_create, UnfinishedDataDestroyer.new)
+
+  question_notifier = QuestionNotifier.new
+  Newspaper.subscribe(:question_create, question_notifier)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -62,4 +62,5 @@ Rails.configuration.to_prepare do
 
   question_notifier = QuestionNotifier.new
   Newspaper.subscribe(:question_create, question_notifier)
+  Newspaper.subscribe(:question_update, question_notifier)
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -387,6 +387,22 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_no_match 'Message to Discord.', mock_log.to_s
   end
 
+  test 'notify to chat after publish a question from WIP' do
+    question = questions(:question_for_wip)
+    visit_with_auth question_path(question), 'kimura'
+    click_button '内容修正'
+
+    mock_log = []
+    stub_info = proc { |i| mock_log << i }
+
+    Rails.logger.stub(:info, stub_info) do
+      click_button '質問を公開'
+      assert_text '質問を更新しました'
+    end
+
+    assert_match 'Message to Discord.', mock_log.to_s
+  end
+
   test 'link to the question should appear and work correctly' do
     visit_with_auth new_question_path, 'kimura'
     fill_in 'question[title]', with: 'Questionに関連プラクティスを指定'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6329

## 概要
- 新規作成時の処理
  - `QuestionCallbacks#after_save`から呼びだされていた`ChatNotifier.message`を`QuestionsController#create`内の`Newspaper`を経由して`QuestionNotifier#call`から呼びだすように変更しました。
- WIP→公開時の処理
  - `QuestionCallbacks#after_save`から呼びだされていた`ChatNotifier.message`を`API::QuestionsController#update`内の`Newspaper`を経由して`QuestionNotifier#call`から呼びだすように変更しました。

## 変更確認方法

1. `feature/replace-discord-notification-for-questions-with-newspaper`をローカルに取り込む
2. [Develop環境でのDiscord通知の確認方法](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95)の設定を行う
3. `bin/rails s`でサーバーを起動
4. `localhost:3000`にアクセスし、`kimura`でログイン
5. 質問を作成する(`/questions/new`→「登録する」)
6. 追加したDiscordサーバーのテキストチャンネル内に通知が来ていることを確認
7. 質問をWIPで保存する(`/questions/new`→「WIP」)
8. 追加したDiscordサーバーのテキストチャンネル内に通知が来ていないことを確認
9. WIPで保存した質問を公開する(「内容修正」→「質問を公開」)
10. 追加したDiscordサーバーのテキストチャンネル内に通知が来ていることを確認

## Screenshot

画面上の変更はありません。

## その他
### 参考資料
- [ActiveRecordのObserversやCallbacksの問題点 - komagataのブログ](https://docs.komagata.org/5859)
- [newspaperでActiveRecordのCallbacksを置き換える - komagataのブログ](https://docs.komagata.org/5860)
- [Active Record コールバック - Railsガイド](https://railsguides.jp/active_record_callbacks.html)
- [Rails アプリケーションのデバッグ - Railsガイド](https://railsguides.jp/debugging_rails_applications.html#%E3%83%AD%E3%82%AC%E3%83%BC)
- [Object#stub - minitest-5.18.0 Documentation](https://docs.seattlerb.org/minitest/Object.html#method-i-stub)
  - [minitest/mock.rb](https://github.com/minitest/minitest/blob/master/lib/minitest/mock.rb#L278)

### 関連PR
- https://github.com/fjordllc/bootcamp/pull/6165
- https://github.com/fjordllc/bootcamp/pull/4476
- https://github.com/fjordllc/bootcamp/pull/4325

