### PR TITLE
最初の日報投稿通知をactive_deliveryに置き換える

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -283,6 +283,11 @@ class ActivityMailer < ApplicationMailer
     )
 
     subject = "[FBC] #{@sender.login_name}さんが休会しました。"
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+    message
+  end
+
   # required params: report, receiver
   def first_report(args = {})
     @report = params&.key?(:report) ? params[:report] : args[:report]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -283,6 +283,17 @@ class ActivityMailer < ApplicationMailer
     )
 
     subject = "[FBC] #{@sender.login_name}さんが休会しました。"
+  # required params: report, receiver
+  def first_report(args = {})
+    @report = params&.key?(:report) ? params[:report] : args[:report]
+    @user = @receiver
+
+    @link_url = notification_redirector_url(
+      link: "/reports/#{@report.id}",
+      kind: Notification.kinds[:first_report]
+    )
+    subject = "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
+
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -286,17 +286,17 @@ class ActivityMailer < ApplicationMailer
   # required params: report, receiver
   def first_report(args = {})
     @report = params&.key?(:report) ? params[:report] : args[:report]
+    @receiver ||= args[:receiver]
     @user = @receiver
 
     @link_url = notification_redirector_url(
       link: "/reports/#{@report.id}",
       kind: Notification.kinds[:first_report]
     )
-    subject = "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
 
+    subject = "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
-
     message
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -45,14 +45,6 @@ class NotificationMailer < ApplicationMailer
     mail to: @user.email, subject: subject
   end
 
-  # required params: report, receiver
-  def first_report
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
-    mail to: @user.email,
-         subject: "[FBC] #{@report.user.login_name}さんがはじめての日報を書きました！"
-  end
-
   # required params: sender, receiver
   def retired
     @user = @receiver

--- a/app/models/first_report_notifier.rb
+++ b/app/models/first_report_notifier.rb
@@ -5,7 +5,7 @@ class FirstReportNotifier
     return if report.wip || !report.first? || Notification.find_by(kind: :first_report, sender_id: report.user.id).present?
 
     User.admins_and_mentors.each do |receiver|
-      NotificationFacade.first_report(report, receiver) if report.sender != receiver
+      ActivityDelivery.with(report: report, receiver: receiver).notify(:first_report)
     end
   end
 end

--- a/app/models/first_report_notifier.rb
+++ b/app/models/first_report_notifier.rb
@@ -5,7 +5,7 @@ class FirstReportNotifier
     return if report.wip || !report.first? || Notification.find_by(kind: :first_report, sender_id: report.user.id).present?
 
     User.admins_and_mentors.each do |receiver|
-      ActivityDelivery.with(report: report, receiver: receiver).notify(:first_report)
+      ActivityDelivery.with(report: report, receiver: receiver).notify(:first_report) if report.sender != receiver
     end
   end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -17,16 +17,6 @@ class NotificationFacade
     return if receiver.retired?
   end
 
-  def self.first_report(report, receiver)
-    ActivityNotifier.with(report: report, receiver: receiver).first_report.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      report: report,
-      receiver: receiver
-    ).first_report.deliver_later(wait: 5)
-  end
-
   def self.trainee_report(report, receiver)
     ActivityNotifier.with(report: report, receiver: receiver).trainee_report.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/views/activity_mailer/first_report.html.slim
+++ b/app/views/activity_mailer/first_report.html.slim
@@ -1,0 +1,6 @@
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@report.user.login_name}さんのはじめての日報です！",
+  link_url: "/reports/#{@report.id}", link_text: 'この日報へ' do
+  p #{@report.user.login_name}さんのはじめての日報です。歓迎のコメントを投稿しよう！！
+  div(style='border-top: solid 1px #ccc; height: 0;')
+  = md2html(@report.description)

--- a/app/views/notification_mailer/first_report.html.slim
+++ b/app/views/notification_mailer/first_report.html.slim
@@ -1,4 +1,0 @@
-= render 'notification_mailer_template', title: "#{@report.user.login_name}さんのはじめての日報です！", link_url: notification_url(@notification), link_text: 'この日報へ' do
-  p #{@report.user.login_name}さんのはじめての日報です。歓迎のコメントを投稿しよう！！
-  div(style='border-top: solid 1px #ccc; height: 0;')
-  = md2html(@report.description)

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -229,6 +229,8 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     user = hibernations(:hibernation1).user
     params = {
       sender: user,
+      receiver: users(:komagata)
+    }
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.notify!(:hibernated, **params)
@@ -247,13 +249,14 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     end
   end
 
-    test '.notify(:first_report)' do
-      report = reports(:report10)
-      params = {
-        report: report,
-        receiver: users(:komagata)
-      }
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+  test '.notify(:first_report)' do
+    report = reports(:report10)
+    params = {
+      report: report,
+      receiver: users(:komagata)
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.notify!(:first_report, **params)
     end
 

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -229,8 +229,6 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     user = hibernations(:hibernation1).user
     params = {
       sender: user,
-      receiver: users(:komagata)
-    }
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
       ActivityDelivery.notify!(:hibernated, **params)
@@ -246,6 +244,29 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
       ActivityDelivery.with(**params).notify(:hibernated)
+    end
+  end
+
+    test '.notify(:first_report)' do
+      report = reports(:report10)
+      params = {
+        report: report,
+        receiver: users(:komagata)
+      }
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify!(:first_report, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:first_report, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:first_report)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:first_report)
     end
   end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -790,7 +790,7 @@ class ActivityMailerTest < ActionMailer::TestCase
   test 'first_report using synchronous mailer' do
     report = reports(:report10)
     first_report = notifications(:notification_first_report)
-    mailer = ActivityMailer.first_report(
+    ActivityMailer.first_report(
       report: report,
       receiver: first_report.user
     ).deliver_now

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -787,7 +787,23 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_match(/休会/, email.body.to_s)
   end
 
-  test 'first_report' do
+  test 'first_report using synchronous mailer' do
+    report = reports(:report10)
+    first_report = notifications(:notification_first_report)
+    mailer = ActivityMailer.first_report(
+      report: report,
+      receiver: first_report.user
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] hajimeさんがはじめての日報を書きました！', email.subject
+    assert_match(/はじめて/, email.body.to_s)
+  end
+
+  test 'first_report with params using asynchronous mailer' do
     report = reports(:report10)
     first_report = notifications(:notification_first_report)
     mailer = ActivityMailer.with(

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -786,4 +786,24 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] kimuraさんが休会しました。', email.subject
     assert_match(/休会/, email.body.to_s)
   end
+
+  test 'first_report' do
+    report = reports(:report10)
+    first_report = notifications(:notification_first_report)
+    mailer = ActivityMailer.with(
+      report: report,
+      receiver: first_report.user
+    ).first_report
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] hajimeさんがはじめての日報を書きました！', email.subject
+    assert_match(/はじめて/, email.body.to_s)
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -24,26 +24,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/コメント/, email.body.to_s)
   end
 
-  test 'first_report' do
-    report = reports(:report10)
-    first_report = notifications(:notification_first_report)
-    mailer = NotificationMailer.with(
-      report: report,
-      receiver: first_report.user
-    ).first_report
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] hajimeさんがはじめての日報を書きました！', email.subject
-    assert_match(/はじめて/, email.body.to_s)
-  end
-
   test 'trainee_report' do
     report = reports(:report11)
     trainee_report = notifications(:notification_trainee_report)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -124,4 +124,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(sender: sender, receiver: receiver).hibernated
   end
+
+  def first_report
+    report = Report.find(ActiveRecord::FixtureSet.identify(:report10))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
+
+    ActivityMailer.with(report: report, receiver: receiver).first_report
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -29,13 +29,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.with(check: check).checked
   end
 
-  def first_report
-    report = Report.find(ActiveRecord::FixtureSet.identify(:report10))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
-
-    NotificationMailer.with(report: report, receiver: receiver).first_report
-  end
-
   def retired
     sender = User.find(ActiveRecord::FixtureSet.identify(:yameo))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))


### PR DESCRIPTION
## Issue

- #5881

## 概要
最初の日報を投稿した際の通知処理を既存の仕様からactive_deliveryに置き換えました。
対象となる通知処理はメール通知とアプリ内通知です。

## 変更確認方法
1. `feature/active_delivery_use_in_first_report`をローカルに取り込む
2. `ogaoga`でログインし、日報を投稿する ※初日報であれば任意のアカウントで問題ありません
3. `machida`でログインし、「通知」から初日報のアプリ内通知が届いていることを確認します。
4. 通知から正しく日報にアクセスできるか確認します。
5. `http://localhost:3000/letter_opener/`にアクセスし、初日報のメールが配信されていることを確認します。
6. メールから日報にアクセスできるか確認します。

## Screenshot
外見上の変更はないため省略します。

## 参考
[gemを使った通知機能 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/gem%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%9F%E9%80%9A%E7%9F%A5%E6%A9%9F%E8%83%BD)
[abstract_notifier](https://github.com/palkan/abstract_notifier)
[abstract_notifierで通知を実装する - komagataのブログ](https://docs.komagata.org/5857)
[active_delivery](https://github.com/palkan/active_delivery)
[active_deliveryで通知をまとめる - komagataのブログ](https://docs.komagata.org/5858)
[Action Mailer の基礎 - Railsガイド](https://railsguides.jp/action_mailer_basics.html)