### PR TITLE
8時間後に5日経過に到達する提出物の件数を表示

### DIFF
--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -78,17 +78,6 @@
                 :isMentor='isMentor',
                 :display-user-icon='displayUserIcon')
       .under-cards(v-if='isDashboard')
-        .under-cards__links.mt-4.text-center.leading-normal.text-sm
-          a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
-            class='hover\:bg-black',
-            href='/products/unassigned#4days-elapsed',
-            v-if='countAlmostPassed5days() === 0')
-            | しばらく5日経過に到達する<br>提出物はありません。
-          a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
-            class='hover\:bg-black',
-            href='/products/unassigned#4days-elapsed',
-            v-else)
-            | <strong>{{ countAlmostPassed5days() }}件</strong>の提出物が、<br>8時間後に5日経過に到達します。
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all" && !isDashboard',
         :label='`${unconfirmedLinksName}の提出物を一括で開く`')
@@ -153,6 +142,19 @@ div(v-else-if='isDashboard')
             :currentUserId='currentUserId',
             :isMentor='isMentor',
             :display-user-icon='displayUserIcon')
+
+  .under-cards
+    .under-cards__links.mt-4.text-center.leading-normal.text-sm
+      a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
+        class='hover\:bg-black',
+        href='/products/unassigned#4days-elapsed',
+        v-if='countAlmostPassed5days() === 0')
+        | しばらく5日経過に到達する<br>提出物はありません。
+      a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
+        class='hover\:bg-black',
+        href='/products/unassigned#4days-elapsed',
+        v-else)
+        | <strong>{{ countAlmostPassed5days() }}件</strong>の提出物が、<br>8時間後に5日経過に到達します。
 
 //- 全て, 未完了
 .page-content.is-products(v-else)

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -77,9 +77,11 @@
                 :currentUserId='currentUserId',
                 :isMentor='isMentor',
                 :display-user-icon='displayUserIcon')
-      a.almost-5days-passed(href='/products/unassigned#4days-elapsed')(
+      .under-cards(
         v-if='isDashboard && productsGroupedByElapsedDays != null')
-        | 8時間後に5日経過に到達する提出物は{{ countAlmostPassed5days() }}件です。
+          .under-cards__links.mt-4.text-center.leading-normal.text-sm
+            a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(class='hover\:bg-black' href='/products/unassigned#4days-elapsed')
+              | <strong>{{ countAlmostPassed5days() }}件</strong>の提出物が、<br>8時間後に5日経過に到達します。
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all" && !isDashboard',
         :label='`${unconfirmedLinksName}の提出物を一括で開く`')

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -336,9 +336,9 @@ export default {
         })
       return params
     },
-    getElementNdaysPassed(n) {
+    getElementNdaysPassed(elapsedDays) {
       const element = this.productsGroupedByElapsedDays.find(
-        (el) => el.elapsed_days === n
+        (el) => el.elapsed_days === elapsedDays
       )
       return element
     },

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -77,6 +77,8 @@
                 :currentUserId='currentUserId',
                 :isMentor='isMentor',
                 :display-user-icon='displayUserIcon')
+      a.almost-5days-passed(href='/products/unassigned#4days-elapsed')
+        | 8時間後に5日経過に到達する提出物は {{ countAlmostPassed5days }}件です。
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all" && !isDashboard',
         :label='`${unconfirmedLinksName}の提出物を一括で開く`')
@@ -229,6 +231,22 @@ export default {
     },
     isUnassigned() {
       return location.pathname === '/products/unassigned'
+    },
+    countAlmostPassed5days() {
+      const elements = this.productsGroupedByElapsedDays.find(
+        (el) => el.elapsed_days === 4
+      )
+      const productsPassedAlmost5days = []
+
+      elements.products.forEach((product) => {
+        const time = product.published_at_date_time || product.created_at_date_time
+        const elapsedTimes = (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
+
+        if(Math.floor((5 - elapsedTimes) * 24) <= 8 ) { 
+          productsPassedAlmost5days.push(product)}
+      })
+
+      return productsPassedAlmost5days.length
     },
     isNotProduct5daysElapsed() {
       const elapsedDays = []

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -353,7 +353,8 @@ export default {
       const productsPassedAlmost5days = products.filter((product) => {
         const lastSubmittedTime =
           product.published_at_date_time || product.created_at_date_time
-        const elapsedTimes = (new Date() - new Date(lastSubmittedTime)) / 1000 / 60 / 60 / 24
+        const elapsedTimes =
+          (new Date() - new Date(lastSubmittedTime)) / 1000 / 60 / 60 / 24
         const thresholdDay = 5
         const thresholdHour = 8
         return Math.floor((thresholdDay - elapsedTimes) * 24) <= thresholdHour

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -351,9 +351,9 @@ export default {
     },
     PassedAlmost5daysProducts(products) {
       const productsPassedAlmost5days = products.filter((product) => {
-        const time =
+        const lastSubmittedTime =
           product.published_at_date_time || product.created_at_date_time
-        const elapsedTimes = (new Date() - new Date(time)) / 1000 / 60 / 60 / 24
+        const elapsedTimes = (new Date() - new Date(lastSubmittedTime)) / 1000 / 60 / 60 / 24
         const thresholdDay = 5
         const thresholdHour = 8
         return Math.floor((thresholdDay - elapsedTimes) * 24) <= thresholdHour

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -353,15 +353,21 @@ export default {
     },
     PassedAlmost5daysProducts(products) {
       const productsPassedAlmost5days = products.filter((product) => {
-        const lastSubmittedTime =
-          product.published_at_date_time || product.created_at_date_time
-        const elapsedTimes =
-          (new Date() - new Date(lastSubmittedTime)) / 1000 / 60 / 60 / 24
         const thresholdDay = 5
         const thresholdHour = 8
-        return Math.floor((thresholdDay - elapsedTimes) * 24) <= thresholdHour
+        return (
+          Math.floor((thresholdDay - this.elapsedTimes(product)) * 24) <=
+          thresholdHour
+        )
       })
       return productsPassedAlmost5days
+    },
+    elapsedTimes(product) {
+      const lastSubmittedTime =
+        product.published_at_date_time || product.created_at_date_time
+      const elapsedTimes =
+        (new Date() - new Date(lastSubmittedTime)) / 1000 / 60 / 60 / 24
+      return elapsedTimes
     },
     countAlmostPassed5days() {
       const elementPassed4days =

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -79,7 +79,7 @@
                 :display-user-icon='displayUserIcon')
       a.almost-5days-passed(href='/products/unassigned#4days-elapsed')(
         v-if='isDashboard && productsGroupedByElapsedDays != null')
-        | 8時間後に5日経過に到達する提出物は {{ countAlmostPassed5days() }}件です。
+        | 8時間後に5日経過に到達する提出物は{{ countAlmostPassed5days() }}件です。
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all" && !isDashboard',
         :label='`${unconfirmedLinksName}の提出物を一括で開く`')

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -327,20 +327,18 @@ export default {
         })
       return params
     },
-    countProductsGroupedBy({ elapsed_days: elapsedDays }) {
+    getElementNdaysPassed(n) {
       const element = this.productsGroupedByElapsedDays.find(
-        (el) => el.elapsed_days === elapsedDays
+        (el) => el.elapsed_days === n
       )
+      return element
+    },
+    countProductsGroupedBy({ elapsed_days: elapsedDays }) {
+      const element = this.getElementNdaysPassed(elapsedDays)
       return element === undefined ? 0 : element.products.length
     },
     elapsedDaysId(elapsedDays) {
       return `${elapsedDays}days-elapsed`
-    },
-    getElementAlmost4daysPassed() {
-      const elements = this.productsGroupedByElapsedDays.find(
-        (el) => el.elapsed_days === 4
-      )
-      return elements
     },
     PassedAlmost5daysProducts(products) {
       const productsPassedAlmost5days = products.filter((product) => {
@@ -352,10 +350,10 @@ export default {
       return productsPassedAlmost5days
     },
     countAlmostPassed5days() {
-      const productsPassed4days = this.getElementAlmost4daysPassed()
-      return productsPassed4days === undefined
+      const elementPassed4days = this.getElementNdaysPassed(4)
+      return elementPassed4days === undefined
         ? 0
-        : this.PassedAlmost5daysProducts(productsPassed4days.products).length
+        : this.PassedAlmost5daysProducts(elementPassed4days.products).length
     }
   }
 }

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -343,16 +343,11 @@ export default {
       return elements
     },
     calculateCount(products) {
-      const productsPassedAlmost5days = []
-
-      products.forEach((product) => {
+      const productsPassedAlmost5days = products.filter((product) => {
         const time =
           product.published_at_date_time || product.created_at_date_time
-        const elapsedTimes =
-          (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
-        if (Math.floor((5 - elapsedTimes) * 24) <= 8) {
-          productsPassedAlmost5days.push(product)
-        }
+        const elapsedTimes = (new Date() - new Date(time)) / 1000 / 60 / 60 / 24
+        return Math.floor((5 - elapsedTimes) * 24) <= 8
       })
       return productsPassedAlmost5days.length
     },

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -239,11 +239,14 @@ export default {
       const productsPassedAlmost5days = []
 
       elements.products.forEach((product) => {
-        const time = product.published_at_date_time || product.created_at_date_time
-        const elapsedTimes = (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
+        const time =
+          product.published_at_date_time || product.created_at_date_time
+        const elapsedTimes =
+          (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
 
-        if(Math.floor((5 - elapsedTimes) * 24) <= 8 ) { 
-          productsPassedAlmost5days.push(product)}
+        if (Math.floor((5 - elapsedTimes) * 24) <= 8) {
+          productsPassedAlmost5days.push(product)
+        }
       })
 
       return productsPassedAlmost5days.length

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -354,7 +354,9 @@ export default {
         const time =
           product.published_at_date_time || product.created_at_date_time
         const elapsedTimes = (new Date() - new Date(time)) / 1000 / 60 / 60 / 24
-        return Math.floor((5 - elapsedTimes) * 24) <= 8
+        const thresholdDay = 5
+        const thresholdHour = 8
+        return Math.floor((thresholdDay - elapsedTimes) * 24) <= thresholdHour
       })
       return productsPassedAlmost5days
     },

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -77,7 +77,9 @@
                 :currentUserId='currentUserId',
                 :isMentor='isMentor',
                 :display-user-icon='displayUserIcon')
-      a.almost-5days-passed(href='/products/unassigned#4days-elapsed')
+      a.almost-5days-passed(href='/products/unassigned#4days-elapsed')(
+        v-if='isDashboard && productsGroupedByElapsedDays != null'
+      )
         | 8時間後に5日経過に到達する提出物は {{ countAlmostPassed5days }}件です。
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all" && !isDashboard',
@@ -249,7 +251,7 @@ export default {
         }
       })
 
-      return productsPassedAlmost5days.length
+      return productsPassedAlmost5days === undefined ? 0 :productsPassedAlmost5days.length
     },
     isNotProduct5daysElapsed() {
       const elapsedDays = []

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -77,11 +77,18 @@
                 :currentUserId='currentUserId',
                 :isMentor='isMentor',
                 :display-user-icon='displayUserIcon')
-      .under-cards(
-        v-if='isDashboard && productsGroupedByElapsedDays != null')
-          .under-cards__links.mt-4.text-center.leading-normal.text-sm
-            a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(class='hover\:bg-black' href='/products/unassigned#4days-elapsed')
-              | <strong>{{ countAlmostPassed5days() }}件</strong>の提出物が、<br>8時間後に5日経過に到達します。
+      .under-cards(v-if='isDashboard')
+        .under-cards__links.mt-4.text-center.leading-normal.text-sm
+          a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
+            class='hover\:bg-black',
+            href='/products/unassigned#4days-elapsed',
+            v-if='countAlmostPassed5days() === 0')
+            | しばらく5日経過に到達する<br>提出物はありません。
+          a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
+            class='hover\:bg-black',
+            href='/products/unassigned#4days-elapsed',
+            v-else)
+            | <strong>{{ countAlmostPassed5days() }}件</strong>の提出物が、<br>8時間後に5日経過に到達します。
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all" && !isDashboard',
         :label='`${unconfirmedLinksName}の提出物を一括で開く`')
@@ -352,7 +359,10 @@ export default {
       return productsPassedAlmost5days
     },
     countAlmostPassed5days() {
-      const elementPassed4days = this.getElementNdaysPassed(4)
+      const elementPassed4days =
+        this.productsGroupedByElapsedDays === null
+          ? undefined
+          : this.getElementNdaysPassed(4)
       return elementPassed4days === undefined
         ? 0
         : this.PassedAlmost5daysProducts(elementPassed4days.products).length

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -79,7 +79,7 @@
                 :display-user-icon='displayUserIcon')
       a.almost-5days-passed(href='/products/unassigned#4days-elapsed')(
         v-if='isDashboard && productsGroupedByElapsedDays != null')
-        | 8時間後に5日経過に到達する提出物は {{ countAlmostPassed5days }}件です。
+        | 8時間後に5日経過に到達する提出物は {{ countAlmostPassed5days() }}件です。
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all" && !isDashboard',
         :label='`${unconfirmedLinksName}の提出物を一括で開く`')
@@ -233,27 +233,6 @@ export default {
     isUnassigned() {
       return location.pathname === '/products/unassigned'
     },
-    countAlmostPassed5days() {
-      const elements = this.productsGroupedByElapsedDays.find(
-        (el) => el.elapsed_days === 4
-      )
-      const productsPassedAlmost5days = []
-
-      elements.products.forEach((product) => {
-        const time =
-          product.published_at_date_time || product.created_at_date_time
-        const elapsedTimes =
-          (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
-
-        if (Math.floor((5 - elapsedTimes) * 24) <= 8) {
-          productsPassedAlmost5days.push(product)
-        }
-      })
-
-      return productsPassedAlmost5days === undefined
-        ? 0
-        : productsPassedAlmost5days.length
-    },
     isNotProduct5daysElapsed() {
       const elapsedDays = []
       this.productsGroupedByElapsedDays.forEach((h) => {
@@ -356,6 +335,32 @@ export default {
     },
     elapsedDaysId(elapsedDays) {
       return `${elapsedDays}days-elapsed`
+    },
+    getProductsAlmost4daysPassed() {
+      const elements = this.productsGroupedByElapsedDays.find(
+        (el) => el.elapsed_days === 4
+      )
+      return elements
+    },
+    calculateCount(products) {
+      const productsPassedAlmost5days = []
+
+      products.forEach((product) => {
+        const time =
+          product.published_at_date_time || product.created_at_date_time
+        const elapsedTimes =
+          (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
+        if (Math.floor((5 - elapsedTimes) * 24) <= 8) {
+          productsPassedAlmost5days.push(product)
+        }
+      })
+      return productsPassedAlmost5days.length
+    },
+    countAlmostPassed5days() {
+      const productsPassed4days = this.getProductsAlmost4daysPassed()
+      return productsPassed4days === undefined
+        ? 0
+        : this.calculateCount(productsPassed4days.products)
     }
   }
 }

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -336,26 +336,26 @@ export default {
     elapsedDaysId(elapsedDays) {
       return `${elapsedDays}days-elapsed`
     },
-    getProductsAlmost4daysPassed() {
+    getElementAlmost4daysPassed() {
       const elements = this.productsGroupedByElapsedDays.find(
         (el) => el.elapsed_days === 4
       )
       return elements
     },
-    calculateCount(products) {
+    PassedAlmost5daysProducts(products) {
       const productsPassedAlmost5days = products.filter((product) => {
         const time =
           product.published_at_date_time || product.created_at_date_time
         const elapsedTimes = (new Date() - new Date(time)) / 1000 / 60 / 60 / 24
         return Math.floor((5 - elapsedTimes) * 24) <= 8
       })
-      return productsPassedAlmost5days.length
+      return productsPassedAlmost5days
     },
     countAlmostPassed5days() {
-      const productsPassed4days = this.getProductsAlmost4daysPassed()
+      const productsPassed4days = this.getElementAlmost4daysPassed()
       return productsPassed4days === undefined
         ? 0
-        : this.calculateCount(productsPassed4days.products)
+        : this.PassedAlmost5daysProducts(productsPassed4days.products).length
     }
   }
 }

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -78,8 +78,7 @@
                 :isMentor='isMentor',
                 :display-user-icon='displayUserIcon')
       a.almost-5days-passed(href='/products/unassigned#4days-elapsed')(
-        v-if='isDashboard && productsGroupedByElapsedDays != null'
-      )
+        v-if='isDashboard && productsGroupedByElapsedDays != null')
         | 8時間後に5日経過に到達する提出物は {{ countAlmostPassed5days }}件です。
       unconfirmed-links-open-button(
         v-if='isMentor && selectedTab != "all" && !isDashboard',
@@ -251,7 +250,9 @@ export default {
         }
       })
 
-      return productsPassedAlmost5days === undefined ? 0 :productsPassedAlmost5days.length
+      return productsPassedAlmost5days === undefined
+        ? 0
+        : productsPassedAlmost5days.length
     },
     isNotProduct5daysElapsed() {
       const elapsedDays = []

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -365,9 +365,7 @@ export default {
     elapsedTimes(product) {
       const lastSubmittedTime =
         product.published_at_date_time || product.created_at_date_time
-      const elapsedTimes =
-        (new Date() - new Date(lastSubmittedTime)) / 1000 / 60 / 60 / 24
-      return elapsedTimes
+      return (new Date() - new Date(lastSubmittedTime)) / 1000 / 60 / 60 / 24
     },
     countAlmostPassed5days() {
       const elementPassed4days =

--- a/app/javascript/stylesheets/atoms/_a-text-link.sass
+++ b/app/javascript/stylesheets/atoms/_a-text-link.sass
@@ -2,6 +2,12 @@
   +hover-link-reversal
   +default-link
 
+.a-hover-link
+  +hover-link
+
+.a-hover-link-reversal
+  +hover-link-reversal
+
 .a-reversal-text-link
   +hover-link-reversal
   +reversal-link

--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -172,3 +172,10 @@ product74:
   checker: mentormentaro
   published_at: <%= now.to_formatted_s(:db) %>
   created_at: <%= now.to_formatted_s(:db) %>
+
+product5:
+  practice: practice14
+  user: kimura
+  body: 4時間後に5日経過に到達する提出物です。
+  published_at: <%= (now - 60 * 60 * 23 * 5).to_formatted_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 23 * 5).to_formatted_s(:db) %>

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -411,3 +411,11 @@ product69:
   created_at: <%= 2.day.ago %>
   updated_at: <%= 2.day.ago %>
   published_at: <%= 2.day.ago %>
+
+product70:
+  practice: practice11
+  user: kimura
+  body: 8時間後に5日経過に到達する提出物です。
+  created_at: <%= 5.day.ago + 8.hours %>
+  updated_at: <%= 5.day.ago + 8.hours %>
+  published_at: <%= 5.day.ago + 8.hours %>

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -419,3 +419,11 @@ product70:
   created_at: <%= 5.day.ago + 8.hours %>
   updated_at: <%= 5.day.ago + 8.hours %>
   published_at: <%= 5.day.ago + 8.hours %>
+
+product71:
+  practice: practice12
+  user: kimura
+  body: 8時間後に5日経過に到達する提出物です。
+  created_at: <%= 5.day.ago + 8.hours %>
+  updated_at: <%= 5.day.ago + 8.hours %>
+  published_at: <%= 5.day.ago + 8.hours %>

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -274,6 +274,10 @@ class HomeTest < ApplicationSystemTestCase
   test 'display counts of passed almost 5days' do
     visit_with_auth '/', 'mentormentaro'
     assert_text '8時間後に5日経過に到達する提出物は1件です。'
+    visit "/products/#{products(:product70).id}"
+    click_button '担当する'
+    visit '/'
+    assert_text '8時間後に5日経過に到達する提出物は0件です。'
   end
 
   test 'work link of passed almost 5days' do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -275,14 +275,12 @@ class HomeTest < ApplicationSystemTestCase
     visit_with_auth '/', 'mentormentaro'
     assert_text "2件の提出物が、\n8時間後に5日経過に到達します。"
 
-    visit "/products/#{products(:product70).id}"
-    click_button '担当する'
-    visit '/'
+    products(:product70).update!(checker: users(:mentormentaro))
+    visit current_path
     assert_text "1件の提出物が、\n8時間後に5日経過に到達します。"
 
-    visit "/products/#{products(:product71).id}"
-    click_button '担当する'
-    visit '/'
+    products(:product71).update!(checker: users(:mentormentaro))
+    visit current_path
     assert_text "しばらく5日経過に到達する\n提出物はありません。"
   end
 

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -273,8 +273,14 @@ class HomeTest < ApplicationSystemTestCase
 
   test 'display counts of passed almost 5days' do
     visit_with_auth '/', 'mentormentaro'
-    assert_text "1件の提出物が、\n8時間後に5日経過に到達します。"
+    assert_text "2件の提出物が、\n8時間後に5日経過に到達します。"
+
     visit "/products/#{products(:product70).id}"
+    click_button '担当する'
+    visit '/'
+    assert_text "1件の提出物が、\n8時間後に5日経過に到達します。"
+
+    visit "/products/#{products(:product71).id}"
     click_button '担当する'
     visit '/'
     assert_text "しばらく5日経過に到達する\n提出物はありません。"

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -271,6 +271,17 @@ class HomeTest < ApplicationSystemTestCase
     assert_no_text '今日提出（48）'
   end
 
+  test 'display counts of passed almost 5days' do
+    visit_with_auth '/', 'mentormentaro'
+    assert_text '8時間後に5日経過に到達する提出物は0件です。'
+  end
+
+  test 'click on link of passed almost 5days' do
+    visit_with_auth '/', 'mentormentaro'
+    click_link '8時間後に5日経過に到達する提出物は0件です。'
+    assert_current_path('/products/unassigned')
+  end
+
   test "show my wip's announcement on dashboard" do
     visit_with_auth '/', 'komagata'
     assert_text 'WIPで保存中'

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -273,16 +273,16 @@ class HomeTest < ApplicationSystemTestCase
 
   test 'display counts of passed almost 5days' do
     visit_with_auth '/', 'mentormentaro'
-    assert_text '8時間後に5日経過に到達する提出物は1件です。'
+    assert_text "1件の提出物が、\n8時間後に5日経過に到達します。"
     visit "/products/#{products(:product70).id}"
     click_button '担当する'
     visit '/'
-    assert_text '8時間後に5日経過に到達する提出物は0件です。'
+    assert_text "しばらく5日経過に到達する\n提出物はありません。"
   end
 
   test 'work link of passed almost 5days' do
     visit_with_auth '/', 'mentormentaro'
-    click_link '8時間後に5日経過に到達する提出物は1件です。'
+    find('.under-cards').click
     assert_current_path('/products/unassigned')
   end
 

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -273,12 +273,12 @@ class HomeTest < ApplicationSystemTestCase
 
   test 'display counts of passed almost 5days' do
     visit_with_auth '/', 'mentormentaro'
-    assert_text '8時間後に5日経過に到達する提出物は0件です。'
+    assert_text '8時間後に5日経過に到達する提出物は1件です。'
   end
 
-  test 'click on link of passed almost 5days' do
+  test 'work link of passed almost 5days' do
     visit_with_auth '/', 'mentormentaro'
-    click_link '8時間後に5日経過に到達する提出物は0件です。'
+    click_link '8時間後に5日経過に到達する提出物は1件です。'
     assert_current_path('/products/unassigned')
   end
 


### PR DESCRIPTION
## Issue

- #6270 

## 概要
８時間後に5日経過に到達する件数をメンター向けのダッシュボードに表示するようにしました。

## 変更確認方法

1. `feature/display-numbers-of-products-almost-passed-5days`をローカルに取り込んでください。
2. `rails db:reset`を実行してください。
3. `foreman start -f Procfile.dev`を実行してローカル環境を立ち上げてください。
4. `mentormentaro`でログインを行い、ダッシュボードにアクセスしてください。
5. ~日経過というカードの下に` 1件の提出物が、8時間後に5日経過に到達します。`と表示されていることを確認してください。
6. `1件の提出物が、8時間後に5日経過に到達します。`というリンクをクリックして、`localhost:3000/products/unassigned#4days-elapsed`にアクセスされることを確認してください。
7. `kimura`が提出した`telnetを使ってget, postを試し、HTTPの基礎を理解するの提出物`を`担当する`を押してください。
 
<img src=https://github.com/fjordllc/bootcamp/assets/81839214/d787234a-fb70-4405-8c0e-a3660037331b  width=60%>

8. ダッシュボードにアクセスして、`しばらく5日経過に到達する提出物はありません。`と表示が変わっていることを確認してください。

## Screenshot

### 変更前
<img src=https://github.com/fjordllc/bootcamp/assets/81839214/cc33ae0b-68ae-4f3c-b71b-cf47a1b8bfd5  width=100%>

### 変更後(8時間後に5日経過に到達する提出物が存在する場合)

<img src=https://github.com/fjordllc/bootcamp/assets/81839214/f9c9ffec-603d-403b-ae2c-bbcbb517c97a  width=100%>

<img src=https://github.com/fjordllc/bootcamp/assets/81839214/78bb367a-f880-4592-a473-af5d624017f1  width=70%>


### 変更後(8時間後に5日経過に到達する提出物が存在しない場合)
<img src=https://github.com/fjordllc/bootcamp/assets/81839214/569eec8a-091d-484a-bc86-3e05861a3b3b  width=100%>

<img src=https://github.com/fjordllc/bootcamp/assets/81839214/a70166cc-c1a1-40e8-947b-382da9a12fa5  width=70%>


