### PR TITLE
休会通知をactive_delivery化する

### DIFF
--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -44,7 +44,7 @@ class HibernationController < ApplicationController
 
   def notify_to_mentors_and_admins
     User.admins_and_mentors.each do |admin_or_mentor|
-      NotificationFacade.hibernated(current_user, admin_or_mentor)
+      ActivityDelivery.with(sender: current_user, receiver: admin_or_mentor).notify(:hibernated)
     end
   end
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -253,4 +253,22 @@ class ActivityMailer < ApplicationMailer
 
     message
   end
+
+  # required params: sender, receiver
+  def hibernated(args = {})
+    @sender ||= args[:sender]
+    @receiver ||= args[:receiver]
+
+    @user = @receiver
+    @link_url = notification_redirector_url(
+      link: "/users/#{@sender.id}",
+      kind: Notification.kinds[:hibernated]
+    )
+
+    subject = "[FBC] #{@sender.login_name}さんが休会しました。"
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -102,14 +102,6 @@ class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLeng
   end
 
   # required params: sender, receiver
-  def hibernated
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:hibernated])
-    subject = "[FBC] #{@sender.login_name}さんが休会しました。"
-    mail to: @user.email, subject: subject
-  end
-
-  # required params: sender, receiver
   def signed_up
     @user = @receiver
     roles = @sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NotificationMailer < ApplicationMailer # rubocop:disable Metrics/ClassLength
+class NotificationMailer < ApplicationMailer
   helper ApplicationHelper
 
   before_action do

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -70,16 +70,6 @@ class NotificationFacade
     ).consecutive_sad_report.deliver_later(wait: 5)
   end
 
-  def self.hibernated(sender, receiver)
-    ActivityNotifier.with(sender: sender, receiver: receiver).hibernated.notify_now
-    return unless receiver.mail_notification?
-
-    NotificationMailer.with(
-      sender: sender,
-      receiver: receiver
-    ).hibernated.deliver_later(wait: 5)
-  end
-
   def self.tomorrow_regular_event(event)
     DiscordNotifier.with(event: event).tomorrow_regular_event.notify_now
   end

--- a/app/views/activity_mailer/hibernated.html.slim
+++ b/app/views/activity_mailer/hibernated.html.slim
@@ -1,0 +1,1 @@
+= render '/notification_mailer/notification_mailer_template', title: "#{@sender.login_name}さんが休会しました。", link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ" do

--- a/app/views/notification_mailer/hibernated.html.slim
+++ b/app/views/notification_mailer/hibernated.html.slim
@@ -1,1 +1,0 @@
-= render 'notification_mailer_template', title: "#{@sender.login_name}さんが休会しました。", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ" do

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -224,4 +224,28 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:assigned_as_checker)
     end
   end
+
+  test '.notify(:hibernated)' do
+    user = hibernations(:hibernation1).user
+    params = {
+      sender: user,
+      receiver: users(:komagata)
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:hibernated, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:hibernated, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:hibernated)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:hibernated)
+    end
+  end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -697,7 +697,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
   end
 
-  test 'hibernated' do
+  test 'hibernated using synchronous mailer' do
     user = users(:kimura)
     mentor = users(:komagata)
     Notification.create!(
@@ -721,7 +721,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_match(/休会/, email.body.to_s)
   end
 
-  test 'hibernated with params' do
+  test 'hibernated with params using asynchronous mailer' do
     user = users(:kimura)
     mentor = users(:komagata)
     Notification.create!(

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -708,6 +708,30 @@ class ActivityMailerTest < ActionMailer::TestCase
       link: "/users/#{user.id}",
       read: false
     )
+    ActivityMailer.hibernated(
+      sender: user,
+      receiver: mentor
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] kimuraさんが休会しました。', email.subject
+    assert_match(/休会/, email.body.to_s)
+  end
+
+  test 'hibernated with params' do
+    user = users(:kimura)
+    mentor = users(:komagata)
+    Notification.create!(
+      kind: 19,
+      sender: user,
+      user: mentor,
+      message: 'kimuraさんが休会しました。',
+      link: "/users/#{user.id}",
+      read: false
+    )
     mailer = ActivityMailer.with(
       sender: user,
       receiver: mentor

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -152,34 +152,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/入会/, email.body.to_s)
   end
 
-  test 'hibernated' do
-    user = users(:kimura)
-    mentor = users(:komagata)
-    Notification.create!(
-      kind: 19,
-      sender: user,
-      user: mentor,
-      message: 'kimuraさんが休会しました。',
-      link: "/users/#{user.id}",
-      read: false
-    )
-    mailer = NotificationMailer.with(
-      sender: user,
-      receiver: mentor
-    ).hibernated
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] kimuraさんが休会しました。', email.subject
-    assert_match(/休会/, email.body.to_s)
-  end
-
   test 'update_regular_event' do
     regular_event = regular_events(:regular_event1)
     notification = notifications(:notification_regular_event_updated)

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -107,4 +107,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(product: product, receiver: receiver).assigned_as_checker
   end
+
+  def hibernated
+    sender = User.find(ActiveRecord::FixtureSet.identify(:hatsuno))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))
+
+    ActivityMailer.with(sender: sender, receiver: receiver).hibernated
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -81,13 +81,6 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.with(sender: sender, receiver: receiver).graduated
   end
 
-  def hibernated
-    sender = User.find(ActiveRecord::FixtureSet.identify(:hatsuno))
-    receiver = User.find(ActiveRecord::FixtureSet.identify(:mentormentaro))
-
-    NotificationMailer.with(sender: sender, receiver: receiver).hibernated
-  end
-
   def update_regular_event
     regular_event = RegularEvent.find(ActiveRecord::FixtureSet.identify(:regular_event1))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:hatsuno))


### PR DESCRIPTION
## Issue

- #5892

## 概要
休会した際の通知処理を既存の仕様からactive_deliveryに置き換えました。
対象となる通知処理はメール通知とアプリ内通知です。

## 変更確認方法
1. `feature/active_delivery_use_in_hibernate_notification`をローカルに取り込む
2. 任意のアカウントでログインし、休会する ※休会方法は[「休会の手続き」](https://bootcamp.fjord.jp/pages/suspension_of_membership)を参照
3. `machida`でログインし、http://localhost:3000/notifications から休会の通知が届いていることを確認します。
<img width="851" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/ceeb97f1-505c-4403-8c06-4f8c0e5076c7">

4. 通知から休会ユーザーにアクセスできるか確認します。
<img width="658" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/3a93f57d-38df-477c-a86c-bd8e96e4eb93">

5. http://localhost:3000/letter_opener/ にアクセスし、休会のメールが配信されていることを確認します。
<img width="1327" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/d949f78c-7e5b-4edc-a915-b4cd69a16277">

6. メールから休会ユーザーにアクセスできるか確認します。
<img width="658" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/3a93f57d-38df-477c-a86c-bd8e96e4eb93">

## Screenshot
外見上の変更はないため省略します。

## 参考
[gemを使った通知機能 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/gem%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%9F%E9%80%9A%E7%9F%A5%E6%A9%9F%E8%83%BD)
[abstract_notifier](https://github.com/palkan/abstract_notifier)
[abstract_notifierで通知を実装する - komagataのブログ](https://docs.komagata.org/5857)
[active_delivery](https://github.com/palkan/active_delivery)
[active_deliveryで通知をまとめる - komagataのブログ](https://docs.komagata.org/5858)
[Action Mailer の基礎 - Railsガイド](https://railsguides.jp/action_mailer_basics.html)

## クラス図
### 変更前
```mermaid
graph TD;

app/controllers/hibernation_controller.rb-->app/models/notification_facade.rb;
app/models/notification_facade.rb-->app/mailers/notification_mailer.rb;
app/models/notification_facade.rb-->app/notifier/activity_notifier.rb;
app/notifier/activity_notifier.rb-->app内通知;
app/mailers/notification_mailer.rb-->メール通知;
```
### 変更後
```mermaid
graph TD;

app/controllers/hibernation_controller.rb-->ActiveDelivery;
ActiveDelivery-->app/mailers/activity_mailer.rb;
ActiveDelivery-->app/notifier/activity_notifier.rb;
app/notifier/activity_notifier.rb-->app内通知;
app/mailers/activity_mailer.rb-->メール通知;
```