### PR TITLE
定期イベント作成ページにお知らせ作成チェックボックスを追加

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -12,35 +12,23 @@ class AnnouncementsController < ApplicationController
     @announcement = Announcement.new(target: 'students')
 
     if params[:id]
-      announcement = Announcement.find(params[:id])
-      @announcement.title       = announcement.title
-      @announcement.description = announcement.description
-      @announcement.target = announcement.target
-      flash.now[:notice] = 'お知らせをコピーしました。'
+      copy_announcement(params[:id])
     elsif params[:page_id]
       page = Page.find(params[:page_id])
-      template = MessageTemplate.load('page_announcements.yml', params: { page: page })
-      @announcement.title       = template['title']
-      @announcement.description = template['description']
+      copy_template_by_resource('page_announcements.yml', page: page)
     elsif params[:event_id]
       event = Event.find(params[:event_id])
-      template = MessageTemplate.load('event_announcements.yml', params: { event: event })
-      @announcement.title       = template['title']
-      @announcement.description = template['description']
+      copy_template_by_resource('event_announcements.yml', event: event)
     elsif params[:regular_event_id]
       regular_event = RegularEvent.find(params[:regular_event_id])
       organizers = regular_event.organizers.map { |organizer| "@#{organizer.login_name}" }.join("\n    - ")
       holding_cycles = ActiveDecorator::Decorator.instance.decorate(regular_event).holding_cycles
       hold_national_holiday = "(祝日#{regular_event.hold_national_holiday ? 'も開催' : 'は休み'})"
-      template = MessageTemplate.load('regular_event_announcements.yml',
-                                      params: {
-                                        regular_event: regular_event,
-                                        organizers: organizers,
-                                        holding_cycles: holding_cycles,
-                                        hold_national_holiday: hold_national_holiday
-                                      })
-      @announcement.title       = template['title']
-      @announcement.description = template['description']
+      copy_template_by_resource('regular_event_announcements.yml',
+                                regular_event: regular_event,
+                                organizers: organizers,
+                                holding_cycles: holding_cycles,
+                                hold_national_holiday: hold_national_holiday)
     end
   end
 
@@ -116,5 +104,19 @@ class AnnouncementsController < ApplicationController
                                     title: params['announcement']['title'], \
                                     description: params['announcement']['description'], \
                                     target: params['announcement']['target'])
+  end
+
+  def copy_announcement(announcement_id)
+    announcement = Announcement.find(announcement_id)
+    @announcement.title       = announcement.title
+    @announcement.description = announcement.description
+    @announcement.target = announcement.target
+    flash.now[:notice] = 'お知らせをコピーしました。'
+  end
+
+  def copy_template_by_resource(template_file, params = {})
+    template = MessageTemplate.load(template_file, params: params)
+    @announcement.title       = template['title']
+    @announcement.description = template['description']
   end
 end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -28,7 +28,19 @@ class AnnouncementsController < ApplicationController
       @announcement.title       = template['title']
       @announcement.description = template['description']
     elsif params[:regular_event_id]
-      set_template_for_regular_event
+      regular_event = RegularEvent.find(params[:regular_event_id])
+      organizers = regular_event.organizers.map { |organizer| "@#{organizer.login_name}" }.join("\n    - ")
+      holding_cycles = ActiveDecorator::Decorator.instance.decorate(regular_event).holding_cycles
+      hold_national_holiday = "(祝日#{regular_event.hold_national_holiday ? 'も開催' : 'は休み'})"
+      template = MessageTemplate.load('regular_event_announcements.yml',
+                                      params: {
+                                        regular_event: regular_event,
+                                        organizers: organizers,
+                                        holding_cycles: holding_cycles,
+                                        hold_national_holiday: hold_national_holiday
+                                      })
+      @announcement.title       = template['title']
+      @announcement.description = template['description']
     end
   end
 
@@ -104,36 +116,5 @@ class AnnouncementsController < ApplicationController
                                     title: params['announcement']['title'], \
                                     description: params['announcement']['description'], \
                                     target: params['announcement']['target'])
-  end
-
-  def set_template_for_regular_event
-    regular_event = RegularEvent.find(params[:regular_event_id])
-    organizers = regular_event.organizers.map do |organizer|
-      "  - @#{organizer.login_name}"
-    end.join("\n")
-    holding_cycles = ActiveDecorator::Decorator.instance.decorate(regular_event).holding_cycles
-    hold_national_holiday = "(祝日#{regular_event.hold_national_holiday ? 'も開催' : 'は休み'})"
-    @announcement.title       = "#{regular_event.title}を開催します🎉"
-    @announcement.description = <<~DESCRIPTION_TEMPLATE
-      <!-- このテキストを編集してください -->
-
-      #{regular_event.title}を開催します🎉
-
-      - 開催日
-        - #{holding_cycles} #{hold_national_holiday}
-      - 開催時間
-        - #{l regular_event.start_at, format: :time_only} 〜 #{l regular_event.end_at, format: :time_only}
-      - 主催者
-      #{organizers}
-
-      ---
-
-      #{regular_event.description}
-
-      ## 参加登録はこちら
-      #{regular_event_url(regular_event)}
-
-      ---
-    DESCRIPTION_TEMPLATE
   end
 end

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -20,6 +20,7 @@ class RegularEventsController < ApplicationController
     @regular_event = RegularEvent.new(regular_event_params)
     @regular_event.user = current_user
     set_wip
+    set_publised_at
     if @regular_event.save
       Newspaper.publish(:event_create, @regular_event)
       set_all_user_participants_and_watchers
@@ -75,6 +76,12 @@ class RegularEventsController < ApplicationController
 
   def set_wip
     @regular_event.wip = (params[:commit] == 'WIP')
+  end
+
+  def set_publised_at
+    return if @regular_event.wip || @regular_event.published_at?
+
+    @regular_event.published_at = Time.current
   end
 
   def notice_message(regular_event)

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -35,10 +35,12 @@ class RegularEventsController < ApplicationController
 
   def update
     set_wip
+    set_publised_at
     if @regular_event.update(regular_event_params)
       Newspaper.publish(:regular_event_update, @regular_event)
       set_all_user_participants_and_watchers
-      redirect_to @regular_event, notice: notice_message(@regular_event)
+      path = @regular_event.announced? && !@regular_event.wip? ? new_announcement_path(regular_event_id: @regular_event.id) : @regular_event
+      redirect_to path, notice: notice_message(@regular_event)
     else
       render :edit
     end

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -24,7 +24,7 @@ class RegularEventsController < ApplicationController
     if @regular_event.save
       Newspaper.publish(:event_create, @regular_event)
       set_all_user_participants_and_watchers
-      path = @regular_event.announced? && !@regular_event.wip? ? new_announcement_path(regular_event_id: @regular_event.id) : @regular_event
+      path = @regular_event.wants_announcement? && !@regular_event.wip? ? new_announcement_path(regular_event_id: @regular_event.id) : @regular_event
       redirect_to path, notice: notice_message(@regular_event)
     else
       render :new
@@ -39,7 +39,7 @@ class RegularEventsController < ApplicationController
     if @regular_event.update(regular_event_params)
       Newspaper.publish(:regular_event_update, @regular_event)
       set_all_user_participants_and_watchers
-      path = @regular_event.announced? && !@regular_event.wip? ? new_announcement_path(regular_event_id: @regular_event.id) : @regular_event
+      path = @regular_event.wants_announcement? && !@regular_event.wip? ? new_announcement_path(regular_event_id: @regular_event.id) : @regular_event
       redirect_to path, notice: notice_message(@regular_event)
     else
       render :edit
@@ -63,7 +63,7 @@ class RegularEventsController < ApplicationController
       :end_at,
       :category,
       :all,
-      :announced,
+      :wants_announcement,
       user_ids: [],
       regular_event_repeat_rules_attributes: %i[id regular_event_id frequency day_of_the_week _destroy]
     )

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -20,8 +20,8 @@ class RegularEventsController < ApplicationController
     @regular_event = RegularEvent.new(regular_event_params)
     @regular_event.user = current_user
     set_wip
-    set_publised_at
     if @regular_event.save
+      update_publised_at
       Newspaper.publish(:event_create, @regular_event)
       set_all_user_participants_and_watchers
       path = @regular_event.wants_announcement? && !@regular_event.wip? ? new_announcement_path(regular_event_id: @regular_event.id) : @regular_event
@@ -35,8 +35,8 @@ class RegularEventsController < ApplicationController
 
   def update
     set_wip
-    set_publised_at
     if @regular_event.update(regular_event_params)
+      update_publised_at
       Newspaper.publish(:regular_event_update, @regular_event)
       set_all_user_participants_and_watchers
       path = @regular_event.wants_announcement? && !@regular_event.wip? ? new_announcement_path(regular_event_id: @regular_event.id) : @regular_event
@@ -77,10 +77,10 @@ class RegularEventsController < ApplicationController
     @regular_event.wip = (params[:commit] == 'WIP')
   end
 
-  def set_publised_at
+  def update_publised_at
     return if @regular_event.wip || @regular_event.published_at?
 
-    @regular_event.published_at = Time.current
+    @regular_event.update(published_at: Time.current)
   end
 
   def notice_message(regular_event)

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -23,7 +23,7 @@ class RegularEventsController < ApplicationController
     if @regular_event.save
       Newspaper.publish(:event_create, @regular_event)
       set_all_user_participants_and_watchers
-      if @regular_event.announced?
+      if @regular_event.announced? && !@regular_event.wip?
         redirect_to new_announcement_path(regular_event_id: @regular_event.id), notice: notice_message(@regular_event)
       else
         redirect_to @regular_event, notice: notice_message(@regular_event)

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -24,7 +24,7 @@ class RegularEventsController < ApplicationController
       Newspaper.publish(:event_create, @regular_event)
       set_all_user_participants_and_watchers
       if @regular_event.announced?
-        redirect_to new_announcement_path, notice: notice_message(@regular_event)
+        redirect_to new_announcement_path(regular_event_id: @regular_event.id), notice: notice_message(@regular_event)
       else
         redirect_to @regular_event, notice: notice_message(@regular_event)
       end

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -23,7 +23,11 @@ class RegularEventsController < ApplicationController
     if @regular_event.save
       Newspaper.publish(:event_create, @regular_event)
       set_all_user_participants_and_watchers
-      redirect_to @regular_event, notice: notice_message(@regular_event)
+      if @regular_event.announced?
+        redirect_to new_announcement_path, notice: notice_message(@regular_event)
+      else
+        redirect_to @regular_event, notice: notice_message(@regular_event)
+      end
     else
       render :new
     end
@@ -59,6 +63,7 @@ class RegularEventsController < ApplicationController
       :end_at,
       :category,
       :all,
+      :announced,
       user_ids: [],
       regular_event_repeat_rules_attributes: %i[id regular_event_id frequency day_of_the_week _destroy]
     )

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -24,11 +24,8 @@ class RegularEventsController < ApplicationController
     if @regular_event.save
       Newspaper.publish(:event_create, @regular_event)
       set_all_user_participants_and_watchers
-      if @regular_event.announced? && !@regular_event.wip?
-        redirect_to new_announcement_path(regular_event_id: @regular_event.id), notice: notice_message(@regular_event)
-      else
-        redirect_to @regular_event, notice: notice_message(@regular_event)
-      end
+      path = @regular_event.announced? && !@regular_event.wip? ? new_announcement_path(regular_event_id: @regular_event.id) : @regular_event
+      redirect_to path, notice: notice_message(@regular_event)
     else
       render :new
     end

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -68,7 +68,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
            through: :regular_event_participations,
            source: :user
   has_many :watches, as: :watchable, dependent: :destroy
-  attribute :announced, :boolean
+  attribute :wants_announcement, :boolean
 
   columns_for_keyword_search :title, :description
 

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -68,6 +68,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
            through: :regular_event_participations,
            source: :user
   has_many :watches, as: :watchable, dependent: :destroy
+  attribute :announced, :boolean
 
   columns_for_keyword_search :title, :description
 

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -91,29 +91,51 @@
                 = f.label :all do
                   | 全員参加イベントの場合はチェック
 
-  - if regular_event.published_at.nil?
-    .form__items
-      .form__items-inner
-        .form-item
-          .checkboxes
-            ul.checkboxes__items
-              li.checkboxes__item
-                = f.check_box :announced, class: 'a-toggle-checkbox js-warning-form'
-                = f.label :announced do
-                  | 定期イベント公開のお知らせを書く
-
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main
-        = f.submit 'WIP', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-wip'
+        = f.submit 'WIP', class: 'a-button is-lg is-secondary is-block', id: 'js-shortcut-wip'
       li.form-actions__item.is-main
-        - if regular_event.new_record?
-          = f.submit '作成', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
-        - else
-          = f.submit '内容変更', class: 'a-button is-lg is-warning is-block', id: 'js-shortcut-submit'
+        - if regular_event.published_at.nil?
+          .form-action-before-option.has-help
+            .checkboxes
+              ul.checkboxes__items
+                li.checkboxes__item
+                  = f.check_box :announced, class: 'a-toggle-checkbox'
+                  = f.label :announced do
+                    | 定期イベント公開のお知らせを書く
+            label.a-form-help-link.is-muted-text(for='modal-announcement')
+              span.a-help
+                i.fa-solid.fa-question
+
+        = button_tag(class: 'a-button is-lg is-primary is-block') do
+          - case params[:action]
+          - when 'new', 'create'
+            | 作成
+          - when 'edit', 'update'
+            | 内容変更
       li.form-actions__item.is-sub
         - case params[:action]
         - when 'new', 'create'
-          = link_to 'キャンセル', regular_events_path, class: 'a-button is-md is-secondary is-block'
+          = link_to 'キャンセル', regular_events_path, class: 'a-button is-sm is-text'
         - when 'edit', 'update'
-          = link_to 'キャンセル', regular_event_path, class: 'a-button is-md is-secondary is-block'
+          = link_to 'キャンセル', regular_event_path, class: 'a-button is-sm is-text'
+
+= render '/shared/modal', id: 'modal-announcement', modal_title: '定期イベント公開のお知らせを書く'
+  .modal__description.is-md
+    .a-short-text
+      p
+        | こちらのチェックを入れてから 定期イベント を公開すると、
+        | お知らせ作成ページに遷移します。
+      p
+        | 遷移したお知らせ作成ページには予め、
+        | この 定期イベント を公開したことをみんなに伝えるための情報が
+        | 入力されています。
+      p
+        | この 定期イベント を公開したことをみんなに知らせる場合は、
+        | このチェックを入れてから公開をしてください。
+      p
+        | もし、チェックを入れ忘れた場合は、自分でお知らせ作成ページに行き、
+        | お知らせを作成して、この 定期イベント を公開したことをみんなに伝えてください。
+      p
+        | みんなに伝える必要のない 定期イベント の場合は、お知らせは作成する必要はありません。

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -91,6 +91,16 @@
                 = f.label :all do
                   | 全員参加イベントの場合はチェック
 
+  .form__items
+    .form__items-inner
+      .form-item
+        .checkboxes
+          ul.checkboxes__items
+            li.checkboxes__item
+              = f.check_box :announced, class: 'a-toggle-checkbox js-warning-form'
+              = f.label :announced do
+                | 定期イベント公開のお知らせを書く
+
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -91,15 +91,16 @@
                 = f.label :all do
                   | 全員参加イベントの場合はチェック
 
-  .form__items
-    .form__items-inner
-      .form-item
-        .checkboxes
-          ul.checkboxes__items
-            li.checkboxes__item
-              = f.check_box :announced, class: 'a-toggle-checkbox js-warning-form'
-              = f.label :announced do
-                | 定期イベント公開のお知らせを書く
+  - if regular_event.published_at.nil?
+    .form__items
+      .form__items-inner
+        .form-item
+          .checkboxes
+            ul.checkboxes__items
+              li.checkboxes__item
+                = f.check_box :announced, class: 'a-toggle-checkbox js-warning-form'
+                = f.label :announced do
+                  | 定期イベント公開のお知らせを書く
 
   .form-actions
     ul.form-actions__items

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -101,8 +101,8 @@
             .checkboxes
               ul.checkboxes__items
                 li.checkboxes__item
-                  = f.check_box :announced, class: 'a-toggle-checkbox'
-                  = f.label :announced do
+                  = f.check_box :wants_announcement, class: 'a-toggle-checkbox'
+                  = f.label :wants_announcement do
                     | 定期イベント公開のお知らせを書く
             label.a-form-help-link.is-muted-text(for='modal-announcement')
               span.a-help

--- a/config/message_templates/regular_event_announcements.yml
+++ b/config/message_templates/regular_event_announcements.yml
@@ -1,0 +1,21 @@
+title: <%= "#{regular_event.title}を開催します🎉" %>
+description: |
+  <!-- このテキストを編集してください -->
+
+  <%= "#{regular_event.title}を開催します🎉" %>
+
+  - 開催日
+    - <%= "#{holding_cycles} #{hold_national_holiday}" %>
+  - 開催時間
+    - <%= "#{I18n.l regular_event.start_at, format: :time_only} 〜 #{I18n.l regular_event.end_at, format: :time_only}" %>
+  - 主催者
+    - <%= organizers %>
+
+  ---
+
+  <%= regular_event.description %>
+
+  ## 参加登録はこちら
+  <%= Rails.application.routes.url_helpers.regular_event_url(regular_event) %>
+
+  ---

--- a/db/data/20230809233700_add_current_time_to_published_at_for_published_regular_event.rb
+++ b/db/data/20230809233700_add_current_time_to_published_at_for_published_regular_event.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddCurrentTimeToPublishedAtForPublishedRegularEvent < ActiveRecord::Migration[6.1]
+  def up
+    RegularEvent.find_each do |regular_event|
+      unless regular_event.wip
+        regular_event.published_at = Time.current
+        regular_event.save!(validate: false)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-DataMigrate::Data.define(version: 20_230_510_134_712)
+DataMigrate::Data.define(version: 20_230_809_233_700)

--- a/db/fixtures/regular_events.yml
+++ b/db/fixtures/regular_events.yml
@@ -7,6 +7,7 @@ regular_event1:
   end_at: <%= Time.zone.local(2020, 1, 1, 16, 0, 0) %>
   user: komagata
   category: 3
+  published_at: "2023-08-01 00:00:00"
 
 regular_event2:
   title: 質問・雑談タイム
@@ -17,6 +18,7 @@ regular_event2:
   end_at: <%= Time.zone.local(2020, 1, 1, 17, 0, 0) %>
   user: machida
   category: 2
+  published_at: "2023-08-01 00:00:00"
 
 regular_event3:
   title: 自作サービス進捗報告会
@@ -28,6 +30,7 @@ regular_event3:
   user: komagata
   category: 3
   all: true
+  published_at: "2023-08-01 00:00:00"
 
 regular_event4:
   title: チェリー本輪読会
@@ -37,6 +40,7 @@ regular_event4:
   start_at: <%= Time.zone.local(2020, 1, 1, 18, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 19, 0, 0) %>
   user: kimura
+  published_at: "2023-08-01 00:00:00"
 
 regular_event5:
   title: Everyday Rails輪読会
@@ -46,6 +50,7 @@ regular_event5:
   start_at: <%= Time.zone.local(2020, 1, 1, 17, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 18, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event6:
   title: Ruby超入門輪読会
@@ -55,6 +60,7 @@ regular_event6:
   start_at: <%= Time.zone.local(2020, 1, 1, 10, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 11, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event7:
   title: 独習Git輪読会
@@ -64,6 +70,7 @@ regular_event7:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 <% (8..25).each do |i| %>
 regular_event<%= i %>:
@@ -75,6 +82,7 @@ regular_event<%= i %>:
   hold_national_holiday: true
   user: komagata
   category: 1
+  published_at: "2023-08-01 00:00:00"
 <% end %>
 
 regular_event26:
@@ -85,6 +93,7 @@ regular_event26:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event27:
   title: Discord通知確認用イベント(土曜日開催)
@@ -94,6 +103,7 @@ regular_event27:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event28:
   title: Discord通知確認用イベント(土曜日 + 日曜日開催)
@@ -103,6 +113,7 @@ regular_event28:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event29:
   title: Discord通知確認用、祝日非開催イベント(金曜日開催)
@@ -112,6 +123,7 @@ regular_event29:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event30:
   title: Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
@@ -121,3 +133,4 @@ regular_event30:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"

--- a/db/migrate/20230403001427_add_published_at_to_regular_events.rb
+++ b/db/migrate/20230403001427_add_published_at_to_regular_events.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToRegularEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :regular_events, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -584,6 +584,7 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
     t.boolean "wip", default: false, null: false
     t.integer "category", default: 0, null: false
     t.boolean "all", default: false, null: false
+    t.datetime "published_at"
     t.index ["user_id"], name: "index_regular_events_on_user_id"
   end
 

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -7,6 +7,7 @@ regular_event1:
   end_at: <%= Time.zone.local(2020, 1, 1, 16, 0, 0) %>
   user: komagata
   category: 3
+  published_at: "2023-08-01 00:00:00"
 
 regular_event2:
   title: 質問・雑談タイム
@@ -17,6 +18,7 @@ regular_event2:
   end_at: <%= Time.zone.local(2020, 1, 1, 17, 0, 0) %>
   user: machida
   category: 2
+  published_at: "2023-08-01 00:00:00"
 
 regular_event3:
   title: 自作サービス進捗報告会
@@ -28,6 +30,7 @@ regular_event3:
   user: komagata
   category: 3
   all: true
+  published_at: "2023-08-01 00:00:00"
 
 regular_event4:
   title: チェリー本輪読会
@@ -37,6 +40,7 @@ regular_event4:
   start_at: <%= Time.zone.local(2020, 1, 1, 18, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 19, 0, 0) %>
   user: kimura
+  published_at: "2023-08-01 00:00:00"
 
 regular_event5:
   title: Everyday Rails輪読会
@@ -46,6 +50,7 @@ regular_event5:
   start_at: <%= Time.zone.local(2020, 1, 1, 17, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 18, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event6:
   title: Ruby超入門輪読会
@@ -55,6 +60,7 @@ regular_event6:
   start_at: <%= Time.zone.local(2020, 1, 1, 10, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 11, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event7:
   title: 独習Git輪読会
@@ -64,6 +70,7 @@ regular_event7:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 <% (8..25).each do |i| %>
 regular_event<%= i %>:
@@ -75,6 +82,7 @@ regular_event<%= i %>:
   hold_national_holiday: true
   user: komagata
   category: 1
+  published_at: "2023-08-01 00:00:00"
 <% end %>
 
 regular_event26:
@@ -85,6 +93,7 @@ regular_event26:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event27:
   title: 定期イベントの検索結果テスト用
@@ -94,6 +103,7 @@ regular_event27:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event28:
   title: Discord通知確認用イベント(土曜日開催)
@@ -103,6 +113,7 @@ regular_event28:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event29:
   title: Discord通知確認用イベント(土曜日 + 日曜日開催)
@@ -112,6 +123,7 @@ regular_event29:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event30:
   title: Discord通知確認用、祝日非開催イベント(金曜日開催)
@@ -121,6 +133,7 @@ regular_event30:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"
 
 regular_event31:
   title: Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
@@ -130,3 +143,4 @@ regular_event31:
   start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
   end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
   user: komagata
+  published_at: "2023-08-01 00:00:00"

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -61,6 +61,7 @@ class RegularEventsTest < ApplicationSystemTestCase
 
   test 'update regular event' do
     visit_with_auth edit_regular_event_path(regular_events(:regular_event1)), 'komagata'
+    assert_no_selector 'label', text: '定期イベント公開のお知らせを書く'
     within 'form[name=regular_event]' do
       fill_in 'regular_event[title]', with: 'チェリー本輪読会（修正）'
       first('.choices__inner').click

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -214,7 +214,7 @@ class RegularEventsTest < ApplicationSystemTestCase
   test 'redirect to /announcements/new when create a regular event with announcement checkbox checked' do
     visit_with_auth new_regular_event_path, 'komagata'
     within 'form[name=regular_event]' do
-      fill_in 'regular_event[title]', with: 'チェリー本輪読会'
+      fill_in 'regular_event[title]', with: 'お知らせ作成チェックボックス確認用イベント'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-1').click
       within('.regular-event-repeat-rule') do
@@ -223,20 +223,21 @@ class RegularEventsTest < ApplicationSystemTestCase
       end
       fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
-      fill_in 'regular_event[description]', with: '予習不要です'
+      fill_in 'regular_event[description]', with: 'お知らせ作成画面に遷移します'
       check '定期イベント公開のお知らせを書く', allow_label_click: true
       assert_difference 'RegularEvent.count', 1 do
         click_button '作成'
       end
     end
     assert_text '定期イベントを作成しました。'
-    assert has_field?('announcement[title]', with: 'チェリー本輪読会を開催します🎉')
+    assert has_field?('announcement[title]', with: 'お知らせ作成チェックボックス確認用イベントを開催します🎉')
+    created_event = RegularEvent.find_by(title: 'お知らせ作成チェックボックス確認用イベント', description: 'お知らせ作成画面に遷移します')
     within('.markdown-form__preview') do
       assert_text '毎週月曜日 (祝日は休み)'
       assert_text '19:00 〜 20:00'
       assert_text '@adminonly'
-      assert_text '予習不要です'
-      assert_selector 'a[href*="regular_events"]'
+      assert_text 'お知らせ作成画面に遷移します'
+      assert_selector "a[href*='regular_events/#{created_event.id}']"
     end
   end
 

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -209,4 +209,26 @@ class RegularEventsTest < ApplicationSystemTestCase
     end
     assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
+
+  test 'redirect to /announcements/new when create a regular event with announcement checkbox checked' do
+    visit_with_auth new_regular_event_path, 'komagata'
+    within 'form[name=regular_event]' do
+      fill_in 'regular_event[title]', with: 'チェリー本輪読会'
+      first('.choices__inner').click
+      find('#choices--js-choices-multiple-select-item-choice-1').click
+      within('.regular-event-repeat-rule') do
+        first('.regular-event-repeat-rule__frequency select').select('毎週')
+        first('.regular-event-repeat-rule__day-of-the-week select').select('月曜日')
+      end
+      fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
+      fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
+      fill_in 'regular_event[description]', with: '予習不要です'
+      check '定期イベント公開のお知らせを書く', allow_label_click: true
+      assert_difference 'RegularEvent.count', 1 do
+        click_button '作成'
+      end
+    end
+    assert_text '定期イベントを作成しました。'
+    assert has_field?('announcement[title]')
+  end
 end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -238,4 +238,29 @@ class RegularEventsTest < ApplicationSystemTestCase
       assert_selector 'a[href*="regular_events"]'
     end
   end
+
+  test 'redirect to /announcements/new when publishing a regular event from WIP with announcement checkbox checked' do
+    visit_with_auth new_regular_event_path, 'komagata'
+    within 'form[name=regular_event]' do
+      fill_in 'regular_event[title]', with: 'WIPの定期イベント'
+      first('.choices__inner').click
+      find('#choices--js-choices-multiple-select-item-choice-1').click
+      within('.regular-event-repeat-rule') do
+        first('.regular-event-repeat-rule__frequency select').select('毎週')
+        first('.regular-event-repeat-rule__day-of-the-week select').select('月曜日')
+      end
+      fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
+      fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
+      fill_in 'regular_event[description]', with: 'WIPです'
+      assert_difference 'RegularEvent.count', 1 do
+        click_button 'WIP'
+      end
+    end
+    assert_text '定期イベントをWIPとして保存しました。'
+    click_link '内容修正'
+    check '定期イベント公開のお知らせを書く', allow_label_click: true
+    click_button '内容変更'
+    assert_text '定期イベントを更新しました。'
+    assert has_field?('announcement[title]', with: 'WIPの定期イベントを開催します🎉')
+  end
 end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -229,6 +229,13 @@ class RegularEventsTest < ApplicationSystemTestCase
       end
     end
     assert_text '定期イベントを作成しました。'
-    assert has_field?('announcement[title]')
+    assert has_field?('announcement[title]', with: 'チェリー本輪読会を開催します🎉')
+    within('.markdown-form__preview') do
+      assert_text '毎週月曜日 (祝日は休み)'
+      assert_text '19:00 〜 20:00'
+      assert_text '@adminonly'
+      assert_text '予習不要です'
+      assert_selector 'a[href*="regular_events"]'
+    end
   end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6325

## 概要
- 定期イベント作成画面(`/regular_events/new`)にお知らせ作成チェックボックスを追加した
  - このチェックボックスにチェックを入れた状態で定期イベントを作成すると、作成した定期イベントの内容が反映されたお知らせ作成画面(`/announcements/new`)に遷移する
  - 公開済みの定期イベントの編集画面にはこのチェックボックスは表示されない
- 定期イベントが公開済みかどうかを判定するために、`regular_events`テーブルに`published_at`カラムを追加した
- `regular_events`テーブルへの`published_at`カラムの追加に伴い、以下の変更を行なった
  - `db/fixtures/regular_events.yml`と`test/fixtures/regular_events.yml`の各データに`published_at`を追加した
  - 本番環境の公開済みの定期イベントの`published_at`に現在時刻を追加するdata-migrateファイルを作成した

## 変更確認方法

1. `feature/add-announcement-checkbox-to-regular-event-creation-page`をローカルに取り込む
1. `rails db:seed`を実行
1. `rails s`でサーバーを起動
1. `localhost:3000`にアクセスし、`kimura`でログイン
1. 定期イベント作成画面(`/regular_events/new`)を開く
1. フォームに任意の内容を入力し、`定期イベント公開のお知らせを書く`にチェックを入れて、`作成`を選択
1. お知らせ作成画面(`/announcements/new`)に自動で遷移し、`タイトル`と`内容`に作成した定期イベントの情報が反映されていることを確認する
1. 作成した定期イベントの編集画面(`/regular_events/{ID}/edit`)を開き、`定期イベント公開のお知らせを書く`チェックボックスが表示されていないことを確認する

## Screenshot

### 変更前
![issue_6325_before-1](https://github.com/fjordllc/bootcamp/assets/65595901/37eb9998-3936-4a2b-bc1a-c19ef3260984)


### 変更後
![issue_6325_after-1](https://github.com/fjordllc/bootcamp/assets/65595901/af89ced8-ba53-47db-9cee-f65e4f1547bc)

## 参考
- `MessageTemplate`
  - [フォームにメッセージテンプレートをセットする方法 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%E3%81%AB%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88%E3%82%92%E3%82%BB%E3%83%83%E3%83%88%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
  - https://github.com/fjordllc/bootcamp/pull/6370
- データマイグレーション
  - [DBのデータをmigrateする方法 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/DB%E3%81%AE%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92migrate%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
  - [ilyakatz/data-migrate](https://github.com/ilyakatz/data-migrate)