### PR TITLE
休会中 or 退会済みのユーザーでログインに失敗した際に、Routing Errorが出ないよう修正

### DIFF
--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -1,4 +1,4 @@
-= form_with model: user, local: true, url: user_sessions_path, html: { id: 'sign-in-form', class: 'form', name: 'user_session' } do |f|
+= form_with model: user, local: true, url: user_sessions_path, method: :post, html: { id: 'sign-in-form', class: 'form', name: 'user_session' } do |f|
   .form__items
     .form-item
       = label_tag 'user_login', 'ユーザー名 or メールアドレス', class: 'a-form-label'

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -62,7 +62,7 @@ class SignInTest < ApplicationSystemTestCase
     assert_text '休会中です。休会復帰ページから手続きをお願いします。'
   end
 
-  test 'active account succeed if continue sign in after sign in failure' do
+  test 'active account succeed if continue sign in after sign in failed' do
     visit '/login'
     within('#sign-in-form') do
       fill_in('user[login]', with: 'yameo')

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -62,7 +62,7 @@ class SignInTest < ApplicationSystemTestCase
     assert_text '休会中です。休会復帰ページから手続きをお願いします。'
   end
 
-  test 'inactive account fail but active account success if continue login operation after login failure' do
+  test 'active account successed if continue sign in after sign in failure' do
     visit '/login'
     within('#sign-in-form') do
       fill_in('user[login]', with: 'yameo')

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -62,7 +62,7 @@ class SignInTest < ApplicationSystemTestCase
     assert_text '休会中です。休会復帰ページから手続きをお願いします。'
   end
 
-  test 'if continue operation, login fails with inactive account but success with active account' do
+  test 'inactive account fail but active account success if continue login operation after login failure ' do
     visit '/login'
     within('#sign-in-form') do
       fill_in('user[login]', with: 'yameo')

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -62,7 +62,7 @@ class SignInTest < ApplicationSystemTestCase
     assert_text '休会中です。休会復帰ページから手続きをお願いします。'
   end
 
-  test 'inactive account fail but active account success if continue login operation after login failure ' do
+  test 'inactive account fail but active account success if continue login operation after login failure' do
     visit '/login'
     within('#sign-in-form') do
       fill_in('user[login]', with: 'yameo')

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -61,4 +61,28 @@ class SignInTest < ApplicationSystemTestCase
     click_button 'ログイン'
     assert_text '休会中です。休会復帰ページから手続きをお願いします。'
   end
+
+  test 'if continue operation, login fails with inactive account but success with active account' do
+    visit '/login'
+    within('#sign-in-form') do
+      fill_in('user[login]', with: 'yameo')
+      fill_in('user[password]', with: 'testtest')
+    end
+    click_button 'ログイン'
+    assert_text '退会したユーザーです。'
+
+    within('#sign-in-form') do
+      fill_in('user[login]', with: 'kyuukai')
+      fill_in('user[password]', with: 'testtest')
+    end
+    click_button 'ログイン'
+    assert_text '休会中です。休会復帰ページから手続きをお願いします。'
+
+    within('#sign-in-form') do
+      fill_in('user[login]', with: 'komagata')
+      fill_in('user[password]', with: 'testtest')
+    end
+    click_button 'ログイン'
+    assert_text 'ログインしました。'
+  end
 end

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -62,7 +62,7 @@ class SignInTest < ApplicationSystemTestCase
     assert_text '休会中です。休会復帰ページから手続きをお願いします。'
   end
 
-  test 'active account successed if continue sign in after sign in failure' do
+  test 'active account succeed if continue sign in after sign in failure' do
     visit '/login'
     within('#sign-in-form') do
       fill_in('user[login]', with: 'yameo')


### PR DESCRIPTION
## Issue

- #6079

## 概要

上記のissueで問題になっていた、休会中または退会済みのユーザーでログインした際に、再びログインを試すとエラーになっていた問題を解決した。

<img width="461" alt="スクリーンショット 2023-05-09 20 02 03" src="https://github.com/fjordllc/bootcamp/assets/54713809/af64abcd-d7bf-44f3-ab92-b9607607224f">


## 解決策

ログインフォームの`form_with`ヘルパーメソッドに、`method: :post`の指定がなかったので、ログイン失敗時に、`method: :patch`で送信されていたのが原因(`form_with`は`method`オプションを付けないと、自動でhttpのメソッドを作成する)。
なので、`method: :post`を追加した。

リソース`user_sessions`には`patch`は用意されてないので、「Routing Error(ルーティングがありません、というエラー)」が出ていた。
<img width="1292" alt="rails routes" src="https://github.com/fjordllc/bootcamp/assets/54713809/4d2cd31e-ca22-44d8-9615-981399517dd6">


```rb
= form_with model: user, local: true, url: user_sessions_path, method: :post
```

## 変更確認方法

1. 以下のコマンドで、リモートブランチをローカルに取り込む` git checkout -b bug/login_error_for_inactive_users origin/bug/login_error_for_inactive_users`
1. http://127.0.0.1:3000/login にアクセス
1. ユーザー名にkyuukai、パスワードにtesttestを入力して、「ログイン」をクリック。
1. 休会中のユーザーが、ログインに失敗したメッセージが表示される(その画面のHTMLのログインフォームのhttpのメソッドがpostになっている事に注目する)
<img width="1433" alt="ログイン失敗" src="https://github.com/fjordllc/bootcamp/assets/54713809/9d0bc8a8-1c5e-4dbf-9eb2-c7badf2fe976">
5. 再びユーザー名kyuukaiでログインを押しても、「Routing Error」が発生しない事を確認する
<img width="1433" alt="ログイン失敗" src="https://github.com/fjordllc/bootcamp/assets/54713809/9d0bc8a8-1c5e-4dbf-9eb2-c7badf2fe976">
6. 駒形さん(休会中や退会済みでない有効なユーザー)ならログインに成功する事を確認する
<img width="1315" alt="ログイン成功" src="https://github.com/fjordllc/bootcamp/assets/54713809/18b4f255-5624-4a77-85f5-bf7094e11358">




## 動作確認動画

### 変更前

![fail](https://github.com/fjordllc/bootcamp/assets/54713809/8cba1913-6a57-45d7-b746-e730b402d644)


### 変更後

![success](https://github.com/fjordllc/bootcamp/assets/54713809/a5b85073-2ce5-4cb6-aed6-58116fa88f57)

