### PR TITLE
 提出物で、最後のコメントから5日経過したときにメンターチャンネルに飛ぶメッセージにURLを入れる

### DIFF
--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DiscordNotifier < ApplicationNotifier
+class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLength
   self.driver = DiscordDriver.new
   self.async_adapter = DiscordAsyncAdapter.new
 
@@ -94,9 +94,9 @@ class DiscordNotifier < ApplicationNotifier
     product_checker_name = User.find_by(id: comment.commentable.checker_id).login_name
     product = comment.commentable
     body = <<~TEXT.chomp
-    ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
-    担当：#{product_checker_name}さん
-    URL： #{Rails.application.routes.url_helpers.product_url(product)}
+      ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
+      担当：#{product_checker_name}さん
+      URL： #{Rails.application.routes.url_helpers.product_url(product)}
     TEXT
 
     notification(

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -92,9 +92,15 @@ class DiscordNotifier < ApplicationNotifier
     webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:mentor]
     comment = params[:comment]
     product_checker_name = User.find_by(id: comment.commentable.checker_id).login_name
+    product = comment.commentable
+    body = <<~TEXT.chomp
+    ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
+    担当：#{product_checker_name}さん
+    URL： #{Rails.application.routes.url_helpers.product_url(product)}
+    TEXT
 
     notification(
-      body: " ⚠️ #{product_checker_name}さんが担当の#{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。",
+      body: body,
       name: 'ピヨルド',
       webhook_url: webhook_url
     )

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -129,14 +129,20 @@ class DiscordNotifierTest < ActiveSupport::TestCase
   test '.product_review_not_completed' do
     products(:product8).update!(checker_id: users(:komagata).id)
     comment = Comment.create!(user: users(:kimura), commentable: products(:product8), description: '提出者による返信')
+    body = <<~TEXT.chomp
+    ⚠️ kimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから5日経過しました。
+    担当：komagataさん
+    URL： http://localhost:3000/products/313836099
+    TEXT
 
     params = {
       comment: comment,
+      body: body,
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }
 
     expected = {
-      body: ' ⚠️ komagataさんが担当のkimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから5日経過しました。',
+      body: body,
       name: 'ピヨルド',
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -130,9 +130,9 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     products(:product8).update!(checker_id: users(:komagata).id)
     comment = Comment.create!(user: users(:kimura), commentable: products(:product8), description: '提出者による返信')
     body = <<~TEXT.chomp
-    ⚠️ kimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから5日経過しました。
-    担当：komagataさん
-    URL： http://localhost:3000/products/313836099
+      ⚠️ kimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから5日経過しました。
+      担当：komagataさん
+      URL： http://localhost:3000/products/313836099
     TEXT
 
     params = {


### PR DESCRIPTION
## Issue

- #6507

## 概要
提出物で、提出物に投稿された最後のコメントが、提出物作成者によるもので、かつ、5日経過していると、
Discrord のメンターチャンネルに状況を知らせる通知が飛びます。
このメッセージに、該当する提出物の URL も追加する修正を行いました。

## 変更確認方法
1. Wikiの「[Develop環境でのDiscord通知の確認方法](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95) 」を参考にテスト用サーバーを立ち上げて、ウェブフックURLを取得できるようにします。 ※記事内の`app/models/chat_notifier.rbの編集`はこのIssueには不要です。
1. `feature/include_URL_in_the_message_5_days_passed_submissions_last_comment`をローカルに取り込む
1. `DISCORD_MENTOR_WEBHOOK_URL=<1で取得したwebhookURL> foreman start -f Procfile.dev`でローカル環境を立ち上げる
1. `mentormentaro`でログインし、`kensyu`の[提出物](http://localhost:3000/products/613458348) にアクセスする
1. `担当する`ボタンを押して、4.でアクセスした`kensyu`の「OS X Mountain Lionをクリーンインストールするの提出物」で`mentormentaro`が担当となるように設定する
1. `rails c`で担当者`mentormentaro`による7日前のコメントを作成する（以下をコピー＆ペーストしてください）
```ruby
# commentable_id → 手順4.でアクセスした提出物のid
# user_id → mentormentaroのid
Comment.create!(commentable_id:613458348, user_id: 534981761, description: "test", commentable_type: "Product", created_at:Time.current.ago(7.days), updated_at:Time.current.ago(7.days))
```
7. `rails c`で提出者`kensyu`による5日前のコメントを作成する（以下をコピー＆ペーストしてください）
```ruby
# commentable_id → 手順4.でアクセスした提出物のid
# user_id → kensyuのid
Comment.create!(commentable_id:613458348, user_id: 301971253, description: "test", commentable_type: "Product", created_at:Time.current.ago(5.days), updated_at:Time.current.ago(5.days))
```
8.  ここまで完了すると[提出物](http://localhost:3000/products/613458348) にコメントが二件追加された状態になります。
9. http://localhost:3000/scheduler/daily/notify_product_review_not_completed にアクセスする（画面は何も表示されませんが、処理が走ります）
10. Discordの通知に以下のような内容で通知が来ることを確認する
<img width="580" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/172512ef-28fd-4b4b-adc0-6d93899a57c1">

## Screenshot

### 変更前
<img width="580" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/e75f3db6-8e13-4d49-b4e0-af32c2863253">

### 変更後
<img width="580" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/172512ef-28fd-4b4b-adc0-6d93899a57c1">

## 参考
-  #6180

- Develop環境でのDiscord通知の確認方法 · fjordllc/bootcamp Wiki
https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95
