### PR TITLE
サインアップ通知をactive_delivery化した

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -134,8 +134,8 @@ class UsersController < ApplicationController
   # rubocop:enable Metrics/MethodLength, Metrics/BlockLength
 
   def notify_to_mentors(user)
-    User.mentor.each do |mentor_user|
-      NotificationFacade.signed_up(user, mentor_user)
+    User.mentor.each do |mentor|
+      ActivityDelivery.with(sender: user, receiver: mentor, sender_roles: user.roles_to_s).notify(:signed_up)
     end
   end
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -325,4 +325,23 @@ class ActivityMailer < ApplicationMailer
 
     message
   end
+
+  # required params: sender, receiver
+  def signed_up(args = {})
+    @sender ||= args[:sender]
+    @receiver ||= args[:receiver]
+    @sender_roles ||= args[:sender_roles]
+
+    @user = @receiver
+    @link_url = notification_redirector_url(
+      link: "/users/#{@sender.id}",
+      kind: Notification.kinds[:signed_up]
+    )
+
+    subject = "[FBC] #{@sender.login_name}さん#{@sender_roles}が新しく入会しました！"
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -77,14 +77,6 @@ class NotificationMailer < ApplicationMailer
     mail to: @user.email, subject: subject
   end
 
-  # required params: report, receiver
-  def consecutive_sad_report
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
-    mail to: @user.email,
-         subject: "[FBC] #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。"
-  end
-
   # required params: question, receiver
   def no_correct_answer
     @user = @receiver

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -77,13 +77,12 @@ class NotificationMailer < ApplicationMailer
     mail to: @user.email, subject: subject
   end
 
-  # required params: sender, receiver
-  def signed_up
+  # required params: report, receiver
+  def consecutive_sad_report
     @user = @receiver
-    roles = @sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"
-    @notification = @user.notifications.find_by(link: "/users/#{@sender.id}", kind: Notification.kinds[:signed_up])
-    subject = "[FBC] #{@sender.login_name}さん#{roles}が新しく入会しました！"
-    mail to: @user.email, subject: subject
+    @notification = @user.notifications.find_by(link: "/reports/#{@report.id}")
+    mail to: @user.email,
+         subject: "[FBC] #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。"
   end
 
   # required params: question, receiver

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -41,16 +41,6 @@ class NotificationFacade
     DiscordNotifier.with(event: event).tomorrow_regular_event.notify_now
   end
 
-  def self.signed_up(sender, receiver)
-    ActivityNotifier.with(sender: sender, receiver: receiver, sender_roles: sender.roles_to_s).signed_up.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      sender: sender,
-      receiver: receiver
-    ).signed_up.deliver_later(wait: 5)
-  end
-
   def self.no_correct_answer(question, receiver)
     ActivityNotifier.with(question: question, receiver: receiver).no_correct_answer.notify_now
     return unless receiver.mail_notification? && !receiver.retired?

--- a/app/views/activity_mailer/signed_up.html.slim
+++ b/app/views/activity_mailer/signed_up.html.slim
@@ -1,0 +1,3 @@
+= render '/notification_mailer/notification_mailer_template',
+title: "#{@sender.login_name}さん#{@sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"}が新しく入会しました！",
+link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ"

--- a/app/views/notification_mailer/signed_up.html.slim
+++ b/app/views/notification_mailer/signed_up.html.slim
@@ -1,1 +1,0 @@
-= render 'notification_mailer_template', title: "#{@sender.login_name}さん#{@sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"}が新しく入会しました！", link_url: notification_url(@notification), link_text: "#{@sender.login_name}さんのページへ"

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -318,4 +318,30 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:update_regular_event)
     end
   end
+
+  test '.notify(:signed_up)' do
+    user = ActiveDecorator::Decorator.instance.decorate(User.find(users(:hajime).id))
+
+    params = {
+      sender: user,
+      receiver: users(:komagata),
+      sender_roles: user.roles_to_s
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:signed_up, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:signed_up, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:signed_up)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:signed_up)
+    end
+  end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -862,4 +862,57 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] 定期イベント【開発MTG】が更新されました。', email.subject
     assert_match(/定期イベント/, email.body.to_s)
   end
+
+  test 'signed_up using synchronous mailer' do
+    user = users(:hajime)
+    mentor = users(:komagata)
+    Notification.create!(
+      kind: 20,
+      sender: user,
+      user: mentor,
+      message: '🎉 hajimeさんが新しく入会しました！',
+      link: "/users/#{user.id}",
+      read: false
+    )
+
+    ActivityMailer.signed_up(
+      sender: user,
+      receiver: mentor
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] hajimeさんが新しく入会しました！', email.subject
+    assert_match(/入会/, email.body.to_s)
+  end
+
+  test 'signed_up with params using asynchronous mailer' do
+    user = users(:hajime)
+    mentor = users(:komagata)
+    Notification.create!(
+      kind: 20,
+      sender: user,
+      user: mentor,
+      message: '🎉 hajimeさんが新しく入会しました！',
+      link: "/users/#{user.id}",
+      read: false
+    )
+    mailer = ActivityMailer.with(
+      sender: user,
+      receiver: mentor
+    ).signed_up
+
+    perform_enqueued_jobs do
+      mailer.deliver_later
+    end
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] hajimeさんが新しく入会しました！', email.subject
+    assert_match(/入会/, email.body.to_s)
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -64,26 +64,6 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/回答/, email.body.to_s)
   end
 
-  test 'consecutive_sad_report' do
-    report = reports(:report16)
-    consecutive_sad_report = notifications(:notification_consecutive_sad_report)
-    mailer = NotificationMailer.with(
-      report: report,
-      receiver: consecutive_sad_report.user
-    ).consecutive_sad_report
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] hajimeさんが2回連続でsadアイコンの日報を提出しました。', email.subject
-    assert_match(/2回連続/, email.body.to_s)
-  end
-
   test 'no_correct_answer' do
     user = users(:kimura)
     question = questions(:question8)

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -64,21 +64,13 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_match(/回答/, email.body.to_s)
   end
 
-  test 'signed up' do
-    user = users(:hajime)
-    mentor = users(:mentormentaro)
-    Notification.create!(
-      kind: 20,
-      sender: user,
-      user: mentor,
-      message: '🎉 hajimeさんが新しく入会しました！',
-      link: "/users/#{user.id}",
-      read: false
-    )
+  test 'consecutive_sad_report' do
+    report = reports(:report16)
+    consecutive_sad_report = notifications(:notification_consecutive_sad_report)
     mailer = NotificationMailer.with(
-      sender: user,
-      receiver: mentor
-    ).signed_up
+      report: report,
+      receiver: consecutive_sad_report.user
+    ).consecutive_sad_report
 
     perform_enqueued_jobs do
       mailer.deliver_later
@@ -87,9 +79,9 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['mentormentaro@fjord.jp'], email.to
-    assert_equal '[FBC] hajimeさんが新しく入会しました！', email.subject
-    assert_match(/入会/, email.body.to_s)
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] hajimeさんが2回連続でsadアイコンの日報を提出しました。', email.subject
+    assert_match(/2回連続/, email.body.to_s)
   end
 
   test 'no_correct_answer' do

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -139,4 +139,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(regular_event: regular_event, receiver: receiver).update_regular_event
   end
+
+  def signed_up
+    sender = ActiveDecorator::Decorator.instance.decorate(User.find(ActiveRecord::FixtureSet.identify(:hajime)))
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
+
+    ActivityMailer.with(sender: sender, receiver: receiver, sender_roles: sender.roles_to_s).signed_up
+  end
 end


### PR DESCRIPTION
## Issue

- #5894 

## 概要
ユーザーが新規登録した際にメンターに届くメール通知とapp内通知をactive_delivery化しました。
これによって`app/controllers/users_controller.rb`で個別に呼び出していたメール処理とapp内通知処理のエントリーポイントを一元化できました。
Discord通知は途中処理が他通知とことなるため対象外です。

## 変更確認方法

1. `feature/active_delivery_use_in_sign_up_notification`をローカルに取り込む
2. http://localhost:3000/users/new にアクセス。
3. 必要な情報を入力して「参加する」をクリックし、新規ユーザー登録をしてください。※有効なカード番号は、[sign_up_test.rb](https://github.com/fjordllc/bootcamp/blob/552625fbb4b1b84e43f1f8d467ea5f1a89060ae5/test/system/sign_up_test.rb#L32) を参照してください
4. `machida`にログインし、新規ユーザー加入のapp内通知が届いていることを確認します。
<img width="1024" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/de3dcf75-f442-40c7-8b60-993262cf76df">
5. http://localhost:3000/letter_opener/ にアクセスし、新規ユーザー加入のメールが届いていることを確認します。
<img width="1327" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/e091105f-50fd-4d2e-86d0-09930318a8d8">


## Screenshot
画面上の変更がないため省略します。

## 参考
[gemを使った通知機能 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/gem%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%9F%E9%80%9A%E7%9F%A5%E6%A9%9F%E8%83%BD)
[abstract_notifier](https://github.com/palkan/abstract_notifier)
[abstract_notifierで通知を実装する - komagataのブログ](https://docs.komagata.org/5857)
[active_delivery](https://github.com/palkan/active_delivery)
[active_deliveryで通知をまとめる - komagataのブログ](https://docs.komagata.org/5858)
[Action Mailer の基礎 - Railsガイド](https://railsguides.jp/action_mailer_basics.html)
[active_decorator](https://github.com/amatsuda/active_decorator)
[decoratorをviewで使っているのにno method errorになる・・・ - Qiita](https://qiita.com/aiyu427/items/6360c39e696d8908e533)
[ActionMailer Preview のススメ - Qiita](https://qiita.com/port-development/items/ce30e580da064de07b4a)


