### PR TITLE
提出物更新通知をnewspaper化した

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -57,7 +57,6 @@ class ProductsController < ApplicationController
       Newspaper.publish(:product_update, @product)
       redirect_to @product, notice: notice_message(@product, :update)
       notice_another_mentor_assigned_as_checker
-      notice_product_update if @product.checker_id.present?
     else
       render :edit
     end
@@ -133,12 +132,5 @@ class ProductsController < ApplicationController
     return unless @checker_id && admin_or_mentor_login? && (@checker_id != current_user.id) && !@product.wip?
 
     ActivityDelivery.with(product: @product, receiver: User.find(@checker_id)).notify(:assigned_as_checker)
-  end
-
-  def notice_product_update
-    @checker_id = @product.checker_id
-    return if admin_or_mentor_login? || @product.wip?
-
-    NotificationFacade.product_update(@product, User.find(@checker_id))
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,7 +40,7 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.save
-      Newspaper.publish(:product_update, {product: @product, current_user: current_user})
+      Newspaper.publish(:product_update, { product: @product, current_user: current_user })
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new
@@ -54,7 +54,7 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.update(product_params)
-      Newspaper.publish(:product_update, {product: @product, current_user: current_user})
+      Newspaper.publish(:product_update, { product: @product, current_user: current_user })
       redirect_to @product, notice: notice_message(@product, :update)
       notice_another_mentor_assigned_as_checker
     else

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,7 +40,7 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.save
-      Newspaper.publish(:product_create, @product)
+      Newspaper.publish(:product_update, {product: @product, current_user: current_user})
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -54,7 +54,7 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.update(product_params)
-      Newspaper.publish(:product_update, @product)
+      Newspaper.publish(:product_update, {product: @product, current_user: current_user})
       redirect_to @product, notice: notice_message(@product, :update)
       notice_another_mentor_assigned_as_checker
     else

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,7 +40,7 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.save
-      Newspaper.publish(:product_update, { product: @product, current_user: current_user })
+      Newspaper.publish(:product_create, { product: @product, current_user: current_user })
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,7 +40,7 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.save
-      Newspaper.publish(:product_create, { product: @product, current_user: current_user })
+      Newspaper.publish(:product_create, @product)
       redirect_to @product, notice: notice_message(@product, :create)
     else
       render :new

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class LearningStatusUpdater
-  def call(product_or_associated_object)
+  def call(payload)
+    product_or_associated_object = payload[:product]
     case product_or_associated_object
     when Product
       update_after_submission(product_or_associated_object)

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -2,7 +2,13 @@
 
 class LearningStatusUpdater
   def call(payload)
-    product_or_associated_object = payload[:product]
+    product_or_associated_object =
+      case payload
+      when Hash
+        payload[:product]
+      else
+        payload
+      end
     case product_or_associated_object
     when Product
       update_after_submission(product_or_associated_object)

--- a/app/models/product_notifier.rb
+++ b/app/models/product_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ProductNotifier
-  def call(product)
+  def call(payload)
+    product = payload[:product]
     return if product.wip
 
     notify_advisers product if product.user.trainee? && product.user.company

--- a/app/models/product_notifier.rb
+++ b/app/models/product_notifier.rb
@@ -2,7 +2,13 @@
 
 class ProductNotifier
   def call(payload)
-    product = payload[:product]
+    product =
+      case payload
+      when Hash
+        payload[:product]
+      else
+        payload
+      end
     return if product.wip
 
     notify_advisers product if product.user.trainee? && product.user.company

--- a/app/models/product_update_notifier.rb
+++ b/app/models/product_update_notifier.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ProductUpdateNotifier
+  def call(product)
+    return if product.wip? || product.checker_id.blank?
+
+    NotificationFacade.product_update(product, User.find(product.checker_id))
+  end
+end

--- a/app/models/product_update_notifier.rb
+++ b/app/models/product_update_notifier.rb
@@ -6,6 +6,6 @@ class ProductUpdateNotifier
     current_user = payload[:current_user]
     return if product.wip? || product.checker_id.nil? || !current_user.nil? && current_user.admin_or_mentor?
 
-    NotificationFacade.product_update(product, User.find(product.checker_id))
+    NotificationFacade.product_update(product, product.checker)
   end
 end

--- a/app/models/product_update_notifier.rb
+++ b/app/models/product_update_notifier.rb
@@ -4,6 +4,11 @@ class ProductUpdateNotifier
   def call(product)
     return if product.wip? || product.checker_id.blank?
 
-    NotificationFacade.product_update(product, User.find(product.checker_id))
+    def call(payload)
+      product = payload[:product]
+      current_user = payload[:current_user]
+
+      NotificationFacade.product_update(product, current_user)
+    end
   end
 end

--- a/app/models/product_update_notifier.rb
+++ b/app/models/product_update_notifier.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 class ProductUpdateNotifier
-  def call(product)
-    return if product.wip? || product.checker_id.blank?
+  def call(payload)
+    product = payload[:product]
+    current_user = payload[:current_user]
+    return if product.wip? || product.checker_id.nil? || !current_user.nil? && current_user.admin_or_mentor?
 
-    def call(payload)
-      product = payload[:product]
-      current_user = payload[:current_user]
-
-      NotificationFacade.product_update(product, current_user)
-    end
+    NotificationFacade.product_update(product, User.find(product.checker_id))
   end
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -64,4 +64,6 @@ Rails.configuration.to_prepare do
   question_notifier = QuestionNotifier.new
   Newspaper.subscribe(:question_create, question_notifier)
   Newspaper.subscribe(:question_update, question_notifier)
+
+  Newspaper.subscribe(:product_update, ProductUpdateNotifier.new)
 end


### PR DESCRIPTION
## Issue

- #6515 

## 概要

## 変更確認方法

1. `feature/replace-product-update-notification-with-newspaper`をローカルに取り込む
2. ID`hajime`でログイン、http://localhost:3000/practices/315059988 にアクセスして提出物を作成する。
3. ID`komagata`でログイン、上記の提出物の担当になる。
4. ID`hajime`で再度ログイン、http://localhost:3000/practices/315059988 にアクセスして提出物を更新する。
5. ID`komagata`で再度ログイン、再度IDkomagataでログイン、http://localhost:3000/notifications にアクセスして通知を確認。

※受講生が提出物を作成、メンターが担当者になる、受講生が提出物を更新、メンターに通知が来ているか確認するという流れができればユーザーと提出物はどれでも問題ありません。

## Screenshot
画面の変更はありません。