### PR TITLE
管理ページのユーザー編集ページから卒業or退会させるときにクレジットカードの定期支払いを停止する

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -21,6 +21,7 @@ class Admin::UsersController < AdminController
 
   def update
     if @user.update(user_params)
+      destroy_subscription(@user)
       Newspaper.publish(:retirement_create, @user)
       redirect_to admin_users_url, notice: 'ユーザー情報を更新しました。'
     else
@@ -60,5 +61,12 @@ class Admin::UsersController < AdminController
       :profile_image, :profile_name, :profile_job, :mentor,
       :profile_text, authored_books_attributes: %i[id title url cover _destroy]
     )
+  end
+
+  def destroy_subscription(user)
+    return if user.subscription_id.blank?
+    return unless user.saved_change_to_retired_on? || user.saved_change_to_graduated_on?
+
+    Subscription.new.destroy(user.subscription_id)
   end
 end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -130,7 +130,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert has_field?('user_retired_on', with: '')
   end
 
-  test 'update user with retired_on' do
+  test 'make user retired' do
     user = users(:hatsuno)
     date = Date.current
     VCR.use_cassette 'subscription/update' do
@@ -177,7 +177,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert has_field?('user_graduated_on', with: '')
   end
 
-  test 'update user with graduated_on' do
+  test 'make user graduated' do
     user = users(:hatsuno)
     date = Date.current
     VCR.use_cassette 'subscription/update' do

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -130,6 +130,23 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert has_field?('user_retired_on', with: '')
   end
 
+  test 'update user with retired_on' do
+    user = users(:hatsuno)
+    date = Date.current
+    VCR.use_cassette 'subscription/update' do
+      visit_with_auth edit_admin_user_path(user.id), 'komagata'
+      check '退会済', allow_label_click: true
+      fill_in 'user_retired_on', with: date
+      click_on '更新する'
+    end
+    assert_text 'ユーザー情報を更新しました。'
+    assert_equal date, user.reload.retired_on
+
+    assert_requested(:post, "https://api.stripe.com/v1/subscriptions/#{user.subscription_id}") do |req|
+      req.body.include?('cancel_at_period_end=true')
+    end
+  end
+
   test 'hide input for graduation date when unchecked' do
     user = users(:hatsuno)
     visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'
@@ -158,6 +175,23 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert has_unchecked_field?('graduation_checkbox', visible: false)
     check 'graduation_checkbox', allow_label_click: true, visible: false
     assert has_field?('user_graduated_on', with: '')
+  end
+
+  test 'update user with graduated_on' do
+    user = users(:hatsuno)
+    date = Date.current
+    VCR.use_cassette 'subscription/update' do
+      visit_with_auth edit_admin_user_path(user.id), 'komagata'
+      check '卒業済', allow_label_click: true
+      fill_in 'user_graduated_on', with: date
+      click_on '更新する'
+    end
+    assert_text 'ユーザー情報を更新しました。'
+    assert_equal date, user.reload.graduated_on
+
+    assert_requested(:post, "https://api.stripe.com/v1/subscriptions/#{user.subscription_id}") do |req|
+      req.body.include?('cancel_at_period_end=true')
+    end
   end
 
   test 'edit user tag' do


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6498
- https://github.com/fjordllc/bootcamp/issues/6499

## 概要
管理ページのユーザー編集ページからユーザーを卒業or退会させるとき、クレジットカードの定期支払いを停止するようにしました。
Issueとしては2つに分かれていますが、同じ画面での対応となるため1つのPRで対応しています。

## 変更確認方法

### 卒業させるときに定期支払いが停止されることの確認

1. `bug/stop-subscription-when-let-user-graduate-or-retire-from-admin-user-edit-page`をローカルに取り込む
2. ログインなしでユーザーの新規登録ページにアクセスし、適当にフォームを入れてユーザー登録をする
    - クレジットカードにはテスト用のカードを入れる
      - https://stripe.com/docs/testing?testing-method=card-numbers#cards 
3. Railsコンソール上で操作し、ユーザーのクレジットカード支払情報が存在しかつ定期支払いが停止されていないことを確認
```ruby
> user = User.find_by(login_name: 'sotugyousaseru')
> Stripe::Subscription.retrieve(user.subscription_id).cancel_at_period_end
=> false
```
4. 管理者ユーザーでログインし、新規登録したユーザー情報の編集ページ`/admin/users/:id/edit`にアクセスし、ユーザーステータスの「卒業済」にチェックを入れて更新
![image](https://user-images.githubusercontent.com/46841037/236363107-a8798869-bf5f-43a9-8bd8-52b91ec5fe41.png)
5. 再びRailsコンソール上で3と同じ操作をし、定期支払いが停止されていることを確認
```ruby
> Stripe::Subscription.retrieve(user.subscription_id).cancel_at_period_end
=> true
```

### 退会させるときに定期支払が停止されることの確認
1. `bug/stop-subscription-when-let-user-graduate-or-retire-from-admin-user-edit-page`をローカルに取り込む
2. ログインなしでユーザーの新規登録ページにアクセスし、適当にフォームを入れてユーザー登録をする
    - クレジットカードにはテスト用のカードを入れる
      - https://stripe.com/docs/testing?testing-method=card-numbers#cards 
3. Railsコンソール上で操作し、ユーザーのクレジットカード支払情報が存在しかつ定期支払いが停止されていないことを確認
```ruby
> user = User.find_by(login_name: 'taikaisaseru')
> Stripe::Subscription.retrieve(user.subscription_id).cancel_at_period_end
=> false
```
4. 管理者ユーザーでログインし、新規登録したユーザー情報の編集ページ`/admin/users/:id/edit`にアクセスし、ユーザーステータスの「退会済」にチェックを入れて更新
![image](https://user-images.githubusercontent.com/46841037/236355548-52acf493-9cd7-4da4-9d04-8ad19432e4ff.png)
5. 再びRailsコンソール上で3と同じ操作をし、定期支払いが停止されていることを確認
```ruby
> Stripe::Subscription.retrieve(user.subscription_id).cancel_at_period_end
=> true
```

## やったこと・検討したこと
管理ページのユーザー編集画面から卒業or退会させたとき、下記のコードを呼んでいます。

https://github.com/fjordllc/bootcamp/blob/e892fda0c5da128a9e27e94e9a3b03bce7044355/app/models/subscription.rb#L26

これはStripeの下記APIを叩いており、これによって定期支払を停止しています。
https://stripe.com/docs/api/subscriptions/update#update_subscription-cancel_at_period_end

Admin::UsersControllerが担う責務が大きくなりますが、今回に関してはそれほど複雑な処理でもなく、処理をコントローラに直接書き足しても問題ないと判断しました。
とくに退会に関しては付随する処理が複数ありかつ複数の導線があるため、下記のイシューで処理の共通化を検討しています。
- https://github.com/fjordllc/bootcamp/issues/6519