### PR TITLE
通知のユーザーアイコンにroleを付けた

### DIFF
--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -22,11 +22,12 @@ li.header-links__item(v-bind:class='hasCountClass')
           a.header-dropdown__item-link.unconfirmed_link(
             :href='notification.path')
             .header-notifications-item__body
-              img.header-notifications-item__user-icon.a-user-icon(
-                :src='notification.sender.avatar_url')
-              .header-notifications-item__message
-                p.test-notification-message {{ notification.message }}
-              time.header-notifications-item__created-at {{ createdAtFromNow(notification.created_at) }}
+              span.a-user-role(:class="'is-' + notification.sender.primary_role")
+                img.header-notifications-item__user-icon.a-user-icon(
+                  :src='notification.sender.avatar_url')
+                .header-notifications-item__message
+                  p.test-notification-message {{ notification.message }}
+                time.header-notifications-item__created-at {{ createdAtFromNow(notification.created_at) }}
       footer.header-dropdown__footer
         a.header-dropdown__footer-link(href='/notifications?status=unread') 全ての未読通知
         a.header-dropdown__footer-link(href='/notifications') 全ての通知
@@ -76,6 +77,7 @@ export default {
       .then((json) => {
         json.notifications.forEach((n) => {
           this.notifications.push(n)
+          console.log(n)
         })
       })
       .catch((error) => {

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -22,7 +22,8 @@ li.header-links__item(v-bind:class='hasCountClass')
           a.header-dropdown__item-link.unconfirmed_link(
             :href='notification.path')
             .header-notifications-item__body
-              span.a-user-role(:class="'is-' + notification.sender.primary_role")
+              span.a-user-role(
+                :class='"is-" + notification.sender.primary_role')
                 img.header-notifications-item__user-icon.a-user-icon(
                   :src='notification.sender.avatar_url')
                 .header-notifications-item__message

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -22,13 +22,13 @@ li.header-links__item(v-bind:class='hasCountClass')
           a.header-dropdown__item-link.unconfirmed_link(
             :href='notification.path')
             .header-notifications-item__body
-              span.a-user-role(
+              span.a-user-role.header-notifications-item__user-icon(
                 :class='"is-" + notification.sender.primary_role')
-                img.header-notifications-item__user-icon.a-user-icon(
+                img.a-user-icon(
                   :src='notification.sender.avatar_url')
-                .header-notifications-item__message
-                  p.test-notification-message {{ notification.message }}
-                time.header-notifications-item__created-at {{ createdAtFromNow(notification.created_at) }}
+              .header-notifications-item__message
+                p.test-notification-message {{ notification.message }}
+              time.header-notifications-item__created-at {{ createdAtFromNow(notification.created_at) }}
       footer.header-dropdown__footer
         a.header-dropdown__footer-link(href='/notifications?status=unread') 全ての未読通知
         a.header-dropdown__footer-link(href='/notifications') 全ての通知

--- a/app/javascript/notifications_bell.vue
+++ b/app/javascript/notifications_bell.vue
@@ -24,8 +24,7 @@ li.header-links__item(v-bind:class='hasCountClass')
             .header-notifications-item__body
               span.a-user-role.header-notifications-item__user-icon(
                 :class='"is-" + notification.sender.primary_role')
-                img.a-user-icon(
-                  :src='notification.sender.avatar_url')
+                img.a-user-icon(:src='notification.sender.avatar_url')
               .header-notifications-item__message
                 p.test-notification-message {{ notification.message }}
               time.header-notifications-item__created-at {{ createdAtFromNow(notification.created_at) }}
@@ -78,7 +77,6 @@ export default {
       .then((json) => {
         json.notifications.forEach((n) => {
           this.notifications.push(n)
-          console.log(n)
         })
       })
       .catch((error) => {

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -177,8 +177,7 @@ class NotificationsTest < ApplicationSystemTestCase
   end
 
   test 'notify user class name role contains' do
-    login_user 'komagata', 'testtest'
-    visit '/'
+    visit_with_auth '/', 'komagata'
     find('.header-links__link.test-show-notifications').click
     assert_selector 'span.a-user-role.is-admin'
     assert_selector 'span.a-user-role.is-student'

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -176,6 +176,15 @@ class NotificationsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'notify user class name role contains' do
+    login_user 'komagata', 'testtest'
+    visit '/'
+    find('.header-links__link.test-show-notifications').click
+    assert_selector 'span.a-user-role.is-admin'
+    assert_selector 'span.a-user-role.is-student'
+    assert_selector 'span.a-user-role.is-mentor'
+  end
+
   test 'show notification count' do
     Notification.create(message: 'machidaさんからメンションが届きました',
                         created_at: '2040-01-18 06:06:42',


### PR DESCRIPTION
## Issue

- #6523

## 概要

通知のユーザーアイコンに、今まで`role`が付いていなかったが、
`img`タグを`span`タグで囲んで、クラス名で`role`を付与した。
また、それに伴い、ユーザーアイコン写真にデザインが加わりました。

## 変更確認方法

1. ブランチ`feature/add_role_user_icon_notification`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. http://localhost:3000/ にアクセスする
4. ユーザー名 : komagata、パスワード : testtestでログインする
5. 「通知」ボタンをクリックする
<img width="1440" alt="最初" src="https://github.com/fjordllc/bootcamp/assets/54713809/bcd9fc4b-3e4c-44a1-8bc3-ad04343c9a54">
6. 通知一覧の、真ん中ににあるhajimeさんの所で右クリックして、「検証」を押す

![クリック](https://github.com/fjordllc/bootcamp/assets/54713809/717ed2bf-b8eb-4d20-9071-fbcee35c91bf)


7. こちらの写真のように、ユーザーの役割に応じて、「a-user-role is-OOOO(ここには役割が入る)」と表示されるのを確認する
[例：ユーザーが現在受講中の生徒だと、` is-student `が付く]
![一般ユーザー](https://github.com/fjordllc/bootcamp/assets/54713809/95affa2b-3d82-47b7-9282-f099d6face4e)


8. 卒業したユーザなら、このように` is-graduate `と付く
![変更後2](https://github.com/fjordllc/bootcamp/assets/54713809/1e37068a-9032-48f5-9db4-bdf8c12b2884)


## Screenshot

### 変更前
[ユーザーの役割に応じたクラスが付与されていない]
<img width="1481" alt="変更前" src="https://github.com/fjordllc/bootcamp/assets/54713809/ca4b9c16-1f6a-4959-a364-1fc45ecf648e">


### 変更後
[spanタグで付与されてる]
![変更後2](https://github.com/fjordllc/bootcamp/assets/54713809/1e37068a-9032-48f5-9db4-bdf8c12b2884)

また、アイコン画像のスタイルが、役割事に少し違うことが分かる
[卒業生は、写真の外側のborderが緑色になっていて、退会者は写真が黒くなっている事が分かる]
![スクリーンショット 2023-05-24 14 52 39](https://github.com/fjordllc/bootcamp/assets/54713809/0154c27e-1f16-403f-8d0c-678faefcbb06)
