### PR TITLE
参考書籍の絞り込みUIをVue.jsに置き換え

### DIFF
--- a/app/javascript/components/books.vue
+++ b/app/javascript/components/books.vue
@@ -1,62 +1,74 @@
 <template lang="pug">
-.books
-  .empty(v-if='books === null')
-    .fa-solid.fa-spinner.fa-pulse
-    |
-    | ロード中
-  .books__items(v-else-if='books.length !== 0')
-    .row
-      book(
-        v-for='book in books',
-        :key='book.id',
-        :book='book',
-        :isAdmin='isAdmin',
-        :isMentor='isMentor')
-  .o-empty-message(v-else)
-    .o-empty-message__icon
-      i.fa-regular.fa-sad-tear
-    p.o-empty-message__text
-      | 登録されている本はありません
+.page-body
+  nav.page-filter.form
+    .container.is-md
+      filterDropdown(
+        label='プラクティスで絞り込む',
+        :options='practices',
+        v-model='practiceId')
+  .page-content.is-books
+    .container
+      .books
+        .empty(v-if='books === null')
+          .fa-solid.fa-spinner.fa-pulse
+          |
+          | ロード中
+        .books__items(v-else-if='books.length !== 0')
+          .row
+            book(
+              v-for='book in filteredBooks',
+              :key='book.id',
+              :book='book',
+              :isAdmin='isAdmin',
+              :isMentor='isMentor')
+        .o-empty-message(v-else)
+          .o-empty-message__icon
+            i.fa-regular.fa-sad-tear
+          p.o-empty-message__text
+            | 登録されている本はありません
 </template>
 <script>
 import CSRF from 'csrf'
+import Choices from 'choices.js'
 import Book from './book'
+import FilterDropdown from './filterDropdown'
 
 export default {
   name: 'Books',
   components: {
-    book: Book
+    book: Book,
+    filterDropdown: FilterDropdown
   },
   props: {
     isAdmin: { type: Boolean, required: true },
-    isMentor: { type: Boolean, required: true },
-    practiceId: { type: Number, default: null, required: false }
+    isMentor: { type: Boolean, required: true }
   },
   data() {
     return {
-      books: null
+      books: null,
+      practices: [],
+      practiceId: null
     }
   },
   computed: {
-    newParams() {
-      const params = new URL(location.href).searchParams
-      if (this.practiceId) params.set('practice_id', this.practiceId)
-      return params
-    },
-    booksAPI() {
-      const params = this.newParams
-      return `/api/books.json?${params}`
+    filteredBooks() {
+      return this.practiceId
+        ? this.books.filter((book) =>
+            book.practices.some(
+              (practice) => practice.id === Number(this.practiceId)
+            )
+          )
+        : this.books
     }
   },
   created() {
-    window.onpopstate = function () {
-      location.replace(location.href)
-    }
     this.getBooks()
+    this.getPractices()
   },
   methods: {
     getBooks() {
-      fetch(this.booksAPI, {
+      const uri = '/api/books.json'
+      fetch(uri, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
@@ -66,18 +78,53 @@ export default {
         credentials: 'same-origin',
         redirect: 'manual'
       })
-        .then((response) => {
-          return response.json()
-        })
+        .then((res) => res.json())
         .then((json) => {
           this.books = []
-          json.books.forEach((r) => {
-            this.books.push(r)
-          })
+          json.books.forEach((book) => this.books.push(book))
         })
-        .catch((error) => {
-          console.warn(error)
+        .catch((err) => console.warn(err))
+    },
+    getPractices() {
+      const uri = '/api/users.json'
+      fetch(uri, {
+        method: 'GET',
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': this.token()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      })
+        .then((res) => res.json())
+        .then((json) => {
+          this.practices = [
+            {
+              id: null,
+              title: 'すべての参考書籍を表示'
+            }
+          ]
+          json.currentUser.practices.forEach((practice) =>
+            this.practices.push(practice)
+          )
         })
+        .then(() => this.choicesUi())
+        .catch((err) => console.warn(err))
+    },
+    choicesUi() {
+      const element = document.querySelector('#js-choices-single-select')
+      if (element) {
+        return new Choices(element, {
+          searchEnabled: true,
+          allowHTML: true,
+          searchResultLimit: 20,
+          searchPlaceholderValue: '検索ワード',
+          noResultsText: '一致する情報は見つかりません',
+          itemSelectText: '選択',
+          shouldSort: false
+        })
+      }
     }
   }
 }

--- a/app/javascript/components/books.vue
+++ b/app/javascript/components/books.vue
@@ -92,7 +92,7 @@ export default {
         headers: {
           'content-type': 'application/json; charset=utf-8',
           'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRF-Token': this.token()
+          'X-CSRF-Token': CSRF.getToken()
         },
         credentials: 'same-origin',
         redirect: 'manual'

--- a/app/javascript/components/filterDropdown.vue
+++ b/app/javascript/components/filterDropdown.vue
@@ -1,0 +1,31 @@
+<template lang="pug">
+.filterDropdown
+  .form-item.is-inline-md-up
+    label.a-form-label(for='js-choices-single-select') {{ label }}
+    select#js-choices-single-select(@change='updateValue')
+      option(
+        v-for='(option, index) in options',
+        :value='option.id',
+        :key='index') {{ option.title }}
+</template>
+
+<script>
+export default {
+  name: 'FilterDropdown',
+  props: {
+    label: {
+      type: String,
+      required: true
+    },
+    options: {
+      type: Array,
+      required: true
+    }
+  },
+  methods: {
+    updateValue(element) {
+      this.$emit('input', element.target.value)
+    }
+  }
+}
+</script>

--- a/app/views/api/users/index.json.jbuilder
+++ b/app/views/api/users/index.json.jbuilder
@@ -8,6 +8,7 @@ json.currentUser do
   json.adviser current_user.adviser
   json.company_id current_user.company_id
   json.admin current_user.admin
+  json.practices current_user.practices
 end
 
 json.target t("target.#{@target}")

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -13,17 +13,4 @@ header.page-header
                 i.fas.fa-plus
                 | 参考書籍登録
 
-.page-body
-  nav.page-filter.form
-    .container.is-md
-      = form_with url: books_path, method: 'get', local: true
-        .form-item.is-inline-md-up
-          = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
-          = select_tag :practice_id,
-                  options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]),
-                  include_blank: '全ての書籍を表示',
-                  onchange: 'this.form.submit()',
-                  id: 'js-choices-single-select'
-  .page-content.is-books
-    .container
-      div(data-vue="Books" data-vue-is-admin:boolean="#{current_user.admin?}" data-vue-is-mentor:boolean="#{current_user.mentor?}" data-vue-practice-id:number="#{params[:practice_id]}")
+div(data-vue="Books" data-vue-is-admin:boolean="#{current_user.admin?}" data-vue-is-mentor:boolean="#{current_user.mentor?}")


### PR DESCRIPTION
## Issue

- #5787 

## 概要

- 参考書籍一覧の絞り込みUIをVue.jsに置き換えました
- 「すべての質問を表示」→「すべての書籍を表示」に変更
- ローカル確認用にSeedデータを書き換えています

## 変更確認方法

1. `replace_filtered_books_with_vuejs`をローカルに取り込む
2. `bin/rails db:reset` を実行
3. http://localhost:3000/books を確認（リロードなし、非同期で一覧が変更されればOK）

## Screenshot


https://github.com/fjordllc/bootcamp/assets/5976902/8b4b3776-7eaf-4a2f-9004-028901057115

