### PR TITLE
質問の新規作成時にメッセージをヘッダでなく更新ボタンの下に表示する

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -63,7 +63,8 @@ class QuestionsController < ApplicationController
     @question.wip = params[:commit] == 'WIP'
     if @question.save
       Newspaper.publish(:question_create, @question)
-      redirect_to @question, notice: notice_message(@question)
+      flash[:created_message] = @question.wip ? '質問をWIPとして保存しました。' : '質問を作成しました。'
+      redirect_to @question
     else
       render :new
     end
@@ -105,11 +106,5 @@ class QuestionsController < ApplicationController
     else
       QuestionsProperty.new('全てのQ&A', 'Q&Aはありません。')
     end
-  end
-
-  def notice_message(question)
-    return '質問をWIPとして保存しました。' if question.wip?
-
-    '質問を作成しました。'
   end
 end

--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -105,9 +105,9 @@
               data-confirm='自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？',
               data-method='delete')
               | 削除する
-        .card-footer__notice(v-show='displayedUpdateMessage')
+        .card-footer__notice(v-show='savedMessage')
           p
-            | 質問を更新しました
+            | {{ savedMessage }}
 
   .a-card(v-show='editing')
     .thread-form
@@ -211,7 +211,8 @@ export default {
     question: { type: Object, required: true },
     answerCount: { type: Number, required: true },
     isAnswerCountUpdated: { type: Boolean, required: true },
-    currentUser: { type: Object, required: true }
+    currentUser: { type: Object, required: true },
+    createdMessage: { type: String, required: true }
   },
   data() {
     return {
@@ -224,7 +225,7 @@ export default {
         practiceId: this.getPracticeId()
       },
       editing: false,
-      displayedUpdateMessage: false,
+      savedMessage: this.createdMessage,
       tab: 'question',
       practices: null
     }
@@ -321,9 +322,9 @@ export default {
         $(`.question-id-${this.question.id}`).trigger('input')
       })
     },
-    finishEditing(hasUpdatedQuestion) {
+    finishEditing(savedMessage) {
       this.editing = false
-      this.displayedUpdateMessage = hasUpdatedQuestion
+      this.savedMessage = savedMessage
     },
     isActive(tab) {
       return this.tab === tab
@@ -338,10 +339,13 @@ export default {
     },
     updateQuestion(wip) {
       this.edited.wip = wip
+      const savedMessage = this.edited.wip
+        ? '質問をWIPとして保存しました。'
+        : '質問を更新しました。'
       if (!this.changedQuestion(this.edited)) {
         // 何も変更していなくても、更新メッセージは表示する
         // 表示しないとユーザーが更新されていないと不安に感じる
-        this.finishEditing(true)
+        this.finishEditing(savedMessage)
         return
       }
 
@@ -369,7 +373,7 @@ export default {
           Object.entries(this.edited).forEach(([key, val]) => {
             this[key] = val
           })
-          this.finishEditing(true)
+          this.finishEditing(savedMessage)
           this.$emit('afterUpdateQuestion')
         })
         .catch((error) => {
@@ -380,7 +384,7 @@ export default {
       Object.keys(this.edited).forEach((key) => {
         this.edited[key] = this[key]
       })
-      this.finishEditing(false)
+      this.finishEditing('')
     }
   }
 }

--- a/app/javascript/components/question-page.vue
+++ b/app/javascript/components/question-page.vue
@@ -8,6 +8,7 @@ div
       :answerCount='answerCount',
       :isAnswerCountUpdated='isAnswerCountUpdated',
       :currentUser='currentUser',
+      :createdMessage='createdMessage',
       @afterUpdateQuestion='fetchQuestion(questionId)')
     answers(
       :questionId='questionId',
@@ -32,7 +33,8 @@ export default {
   },
   props: {
     currentUserId: { type: String, required: true },
-    questionId: { type: String, required: true }
+    questionId: { type: String, required: true },
+    createdMessage: { type: String, required: true }
   },
   data() {
     return {

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -18,7 +18,7 @@ header.page-header
   .container.is-xxl
     .row.is-gutter-width-32
       .col-lg-8.col-xs-12
-        div(data-vue="QuestionPage" data-vue-current-user-id="#{current_user.id}" data-vue-question-id="#{@question.id}")
+        div(data-vue="QuestionPage" data-vue-current-user-id="#{current_user.id}" data-vue-question-id="#{@question.id}" data-vue-created-message="#{flash[:created_message] || ''}")
 
       .col-lg-4.col-xs-12
         nav.page-nav.has-footer.page-nav.has-footer


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6517

## 概要
・質問の作成フローにおいては画面上部のフラッシュメッセージは使用せず、「内容変更」ボタン下部（Vueコンポーネント内）にメッセージを表示するよう統一
・変数名のリファクタ

## 変更確認方法

1. `bug/delete-flash-message-when-question-create-through-wip`をローカルに取り込む

### 質問を新規作成してWIPとして保存しそのまま公開するとき

**1. 質問作成ページ`/questions/new`で質問を適当に作成し、「WIP」をクリック**

修正前: 「質問をWIPとして保存しました。」のメッセージが画面上部に表示される
 ![image](https://github.com/fjordllc/bootcamp/assets/46841037/fd9c8727-b4cf-4f77-83e2-197c01eb9d02)

修正後: 「質問をWIPとして保存しました。」のメッセージが「内容修正」ボタンの下部に表示される
![image](https://github.com/fjordllc/bootcamp/assets/46841037/a6767dc1-8161-48c0-9f06-38c7e817bf15)

**2. そのまま「内容修正」→「質問を公開」をクリック**

修正前: 「質問を更新しました。」のメッセージが「内容修正」ボタンの下部に表示されるが、「質問をWIPとして保存しました。」のメッセージが画面上部に表示されたままとなっている
![image](https://github.com/fjordllc/bootcamp/assets/46841037/3f87596f-8454-4478-8141-3b3ee6a15fd2)

修正後: 「質問を更新しました。」のメッセージが「内容修正」ボタンの下部に表示される
 ![image](https://github.com/fjordllc/bootcamp/assets/46841037/eaee407f-7a93-497a-acc6-8b30fe131a23)

### 質問を新規作成してそのまま公開するとき
**質問作成ページ`/questions/new`で質問を適当に作成し、「登録する」をクリック**

修正前: 「質問を作成しました。」のメッセージが画面上部に表示される
![image](https://github.com/fjordllc/bootcamp/assets/46841037/936fb49b-5e9a-4160-ba96-de10111442ec)
修正後: 「質問を作成しました。」のメッセージが「内容修正」ボタンの下部に表示される
![image](https://github.com/fjordllc/bootcamp/assets/46841037/d6f8d1f1-5842-4b84-8055-40713585869f)

## Screenshot

### 変更前

### 変更後

