### PR TITLE
webpackの問題でテストが時々落ちる問題を修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,9 @@ jobs:
           name: Database setup
           command: 'bundle exec rails db:setup'
       - run:
+          name: Assets compile
+          command: 'bundle exec rails assets:precompile'
+      - run:
           name: Test
           command: |
             TESTFILES=$(circleci tests glob "test/**/*_test.rb" | circleci tests split --split-by=timings)


### PR DESCRIPTION
[ruby on rails \- CircleCiでのRailsテスト実行時ランダムにエラーが発生してしまいます: ActionView::Template::Error: 783: unexpected token at '' \- スタック・オーバーフロー](https://ja.stackoverflow.com/questions/80784/circleci%e3%81%a7%e3%81%aerails%e3%83%86%e3%82%b9%e3%83%88%e5%ae%9f%e8%a1%8c%e6%99%82%e3%83%a9%e3%83%b3%e3%83%80%e3%83%a0%e3%81%ab%e3%82%a8%e3%83%a9%e3%83%bc%e3%81%8c%e7%99%ba%e7%94%9f%e3%81%97%e3%81%a6%e3%81%97%e3%81%be%e3%81%84%e3%81%be%e3%81%99-actionviewtemplateerror-783-unexp)