### PR TITLE
卒業させることができてしまうバグを修正

### DIFF
--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -4,9 +4,9 @@ class GraduationController < ApplicationController
   skip_before_action :require_active_user_login, raise: false
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]
-  before_action :check_admin_permission, only: %i[update]
 
   def update
+    return if require_admin_login
     if @user.update(graduated_on: Date.current)
       Subscription.new.destroy(@user.subscription_id) if @user.subscription_id
       Newspaper.publish(:graduation_update, @user)
@@ -20,14 +20,6 @@ class GraduationController < ApplicationController
 
   def set_user
     @user = User.find(params[:user_id])
-  end
-
-  def check_admin_permission
-    if logged_in?
-      redirect_to root_path, alert: '管理者としてログインしてください' unless current_user.admin?
-    else
-      redirect_to root_path, alert: 'ログインしてください'
-    end
   end
 
   def set_redirect_url

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -7,6 +7,7 @@ class GraduationController < ApplicationController
 
   def update
     return if require_admin_login
+
     if @user.update(graduated_on: Date.current)
       Subscription.new.destroy(@user.subscription_id) if @user.subscription_id
       Newspaper.publish(:graduation_update, @user)

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -4,6 +4,7 @@ class GraduationController < ApplicationController
   skip_before_action :require_active_user_login, raise: false
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]
+  before_action :check_admin_permission, only: %i[update]
 
   def update
     if @user.update(graduated_on: Date.current)
@@ -19,6 +20,10 @@ class GraduationController < ApplicationController
 
   def set_user
     @user = User.find(params[:user_id])
+  end
+
+  def check_admin_permission
+    redirect_to root_path, alert: '管理者としてログインしてください' unless current_user.admin?
   end
 
   def set_redirect_url

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -23,7 +23,11 @@ class GraduationController < ApplicationController
   end
 
   def check_admin_permission
-    redirect_to root_path, alert: '管理者としてログインしてください' unless current_user.admin?
+    if logged_in?
+      redirect_to root_path, alert: '管理者としてログインしてください' unless current_user.admin?
+    else
+      redirect_to root_path, alert: 'ログインしてください'
+    end
   end
 
   def set_redirect_url

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -4,10 +4,9 @@ class GraduationController < ApplicationController
   skip_before_action :require_active_user_login, raise: false
   before_action :set_user, only: %i[update]
   before_action :set_redirect_url, only: %i[update]
+  before_action :require_admin_login, only: %i[update]
 
   def update
-    return if require_admin_login
-
     if @user.update(graduated_on: Date.current)
       Subscription.new.destroy(@user.subscription_id) if @user.subscription_id
       Newspaper.publish(:graduation_update, @user)

--- a/test/integration/graduation_controller_test.rb
+++ b/test/integration/graduation_controller_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GraduationControllerTest < ActionDispatch::IntegrationTest
+  fixtures :users
+
+  test 'not admin permission requests for graduation' do
+    token = create_token('kensyu', 'testtest')
+    user = users(:kensyu)
+    target = users(:hajime)
+
+    post user_sessions_path, params: { authenticity_token: token, user: { login: user.login_name, password: 'testtest' } }
+    follow_redirect!
+    patch "/users/#{target.id}/graduation", params: { authenticity_token: token, user_id: target.id }
+    follow_redirect!
+
+    assert_equal '管理者としてログインしてください', '管理者としてログインしてください'
+    assert_equal users(:hajime).graduated_on, nil
+  end
+end

--- a/test/integration/graduation_controller_test.rb
+++ b/test/integration/graduation_controller_test.rb
@@ -10,9 +10,16 @@ class GraduationControllerTest < ActionDispatch::IntegrationTest
     user = users(:kensyu)
     target = users(:hajime)
 
-    post user_sessions_path, params: { authenticity_token: token, user: { login: user.login_name, password: 'testtest' } }
+    post user_sessions_path, params: {
+      authenticity_token: token, user: {
+        login: user.login_name, password: 'testtest'
+      }
+    }
     follow_redirect!
-    patch "/users/#{target.id}/graduation", params: { authenticity_token: token, user_id: target.id }
+
+    patch "/users/#{target.id}/graduation", params: {
+      authenticity_token: token, user_id: target.id
+    }
     follow_redirect!
 
     assert_equal '管理者としてログインしてください', '管理者としてログインしてください'

--- a/test/integration/graduation_test.rb
+++ b/test/integration/graduation_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class GraduationControllerTest < ActionDispatch::IntegrationTest
+class GraduationTest < ActionDispatch::IntegrationTest
   fixtures :users
 
   test 'not admin permission requests for graduation' do


### PR DESCRIPTION
## Issue
- #6497 

## 概要
権限を持たないユーザーや閲覧者であっても不正な方法で卒業のリクエストを送ることで任意のユーザーを卒業状態にすることが可能になっていました。
これに対してController層でリクエスト元のログインチェックと権限チェックを導入しバグに対応しています。

## 変更確認方法

1. `bug/graduation_user_by_not_admin`をローカルに取り込む
2. `kimura`でログインする
3. ユーザー一覧ページから、他の[任意の卒業させたい現役生ユーザー（ここではtake8）のページ](http://localhost:3000/users/1038099145)に入って、現役生であることをを確認。また、URLを見てユーザーIDを確認してメモする。（ここでは、ID: 1038099145）
![image](https://github.com/fjordllc/bootcamp/assets/69577164/43dd75ba-e08d-4fad-a29f-c129e4c31c28)
4. 自分の日報ページから、適当な日報を開いて、「内容修正」を押す。
5. ブラウザの開発者ツールを開いて、「内容変更」ボタン周辺のソースを開く。
![image](https://github.com/fjordllc/bootcamp/assets/69577164/ccd4c382-d85a-44e2-b118-b5bb80c492ef)
6. formタグの`action="/reports/{レポートID}"`を、`action="/users/{卒業させたいユーザーのID}/graduation`に変更。（ここでは、/users/1038099145/graduationに変更）
![image](https://github.com/fjordllc/bootcamp/assets/69577164/b15d1d67-5172-4ba9-b245-15dc7a209624)
7. 日報画面の「内容変更」ボタンを押す。
8. トップ画面にリダイレクトされ、「管理者としてログインしてください」の警告が出ることを確認
![image](https://github.com/fjordllc/bootcamp/assets/69577164/2f704330-85a8-4596-9dd8-4a696d7da833)
9. 再び`taka8`の[ユーザーページ](http://localhost:3000/users/1038099145)にアクセスし、「区分」が現役生のままであることを確認する

## Screenshot
画面上の変化はないため省略します