### PR TITLE
WIPで保存中の提出物ページの「提出する」ボタンと「内容修正」ボタンの位置を逆にした

### DIFF
--- a/app/views/products/_product_body.html.slim
+++ b/app/views/products/_product_body.html.slim
@@ -12,15 +12,15 @@
     .card-footer
       .card-main-actions
         ul.card-main-actions__items
+          li.card-main-actions__item
+            = link_to edit_product_path(product), class: 'card-main-actions_action a-button is-sm is-secondary is-block' do
+              i.fa-solid.fa-pen
+              | 内容修正
           - if product.wip?
             li.card-main-actions__item
               = form_with model: product, local: true do |f|
                 = f.hidden_field :body
                 = f.submit '提出する', class: 'a-button is-sm is-primary is-block'
-          li.card-main-actions__item
-            = link_to edit_product_path(product), class: 'card-main-actions_action a-button is-sm is-secondary is-block' do
-              i.fa-solid.fa-pen
-              | 内容修正
           li.card-main-actions__item.is-sub.is-only-mentor
             = link_to product, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
               | 削除する


### PR DESCRIPTION
## Issue

- #6471

## 概要

WIPで保存中の提出物ページ画面で、「提出する」ボタンを右に、「内容修正」ボタンが左になる様に修正をしました。

## 変更確認方法

1. feature/reverse-position-submit-and-correct-buttons-while-wipをローカルに取り込む
2. bin/rails sでローカル環境を立ち上げる
3. localhost:3000にアクセス
4. ユーザー名 : komagata でログイン
5. プラクティス 「OS X Mountain Lionをクリーンインストールする」(/practices/315059988)を選択
<img width="964" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/b7bd9798-bd12-4ea1-8761-d0c838eade52">

6. 提出物へボタンを選択
<img width="802" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/14a5446e-1c18-4ece-ba13-2715e9d8ad61">

7. 本文を入力して、「WIP」を選択

8. 内容修正ボタンが左に、と提出するボタンが右になっていることを確認する

## Screenshot

### 変更前
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBN2dMQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--2b473fdf00869002cc90b3c18f18ee12f28e38ee/image.png)


### 変更後
![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOVFMQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--39a40091d0b5ea45ae3fb8b0b000e69e1c017e86/image.png)

