### PR TITLE
質問の新規作成時にWIPを経由して公開するときフラッシュメッセージを書き換える

### DIFF
--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -337,6 +337,15 @@ export default {
       })
     },
     updateQuestion(wip) {
+      const flashElement = document.querySelector('.flash__message')
+      if (flashElement) {
+        if (wip) {
+          flashElement.innerHTML = '質問をWIPとして保存しました。'
+        } else {
+          flashElement.innerHTML = '質問を公開しました。'
+        }
+      }
+
       this.edited.wip = wip
       if (!this.changedQuestion(this.edited)) {
         // 何も変更していなくても、更新メッセージは表示する

--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -339,11 +339,9 @@ export default {
     updateQuestion(wip) {
       const flashElement = document.querySelector('.flash__message')
       if (flashElement) {
-        if (wip) {
-          flashElement.innerHTML = '質問をWIPとして保存しました。'
-        } else {
-          flashElement.innerHTML = '質問を公開しました。'
-        }
+        flashElement.innerHTML = wip
+          ? '質問をWIPとして保存しました。'
+          : '質問を公開しました。'
       }
 
       this.edited.wip = wip

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -43,6 +43,24 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_text '質問を作成しました。'
   end
 
+  test 'create a question through wip' do
+    visit_with_auth new_question_path, 'kimura'
+    within 'form[name=question]' do
+      fill_in 'question[title]', with: 'テストの質問'
+      fill_in 'question[description]', with: 'テストの質問です。'
+      click_button 'WIP'
+    end
+    assert_text '質問をWIPとして保存しました。'
+
+    click_button '内容修正'
+    click_button '質問を公開'
+    assert_text '質問を公開しました。'
+
+    click_button '内容修正'
+    click_button 'WIP'
+    assert_text '質問をWIPとして保存しました。'
+  end
+
   test 'update a question' do
     question = questions(:question8)
     visit_with_auth question_path(question), 'kimura'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6517

## 概要
質問の新規作成時にWIPを経由して公開すると「質問をWIPとして保存しました。」のメッセージが出たままになります。
それを防ぐため、質問の公開時にフラッシュメッセージが表示されていた場合は「質問を公開しました。」という内容に書き換えるようにしました。
さらに、質問を公開したのちにWIPに戻した場合は、フラッシュメッセージを「質問をWIPとして保存しました。」に再度書き換えるようにしました。

https://github.com/fjordllc/bootcamp/issues/6517#issuecomment-1561238968 にある通り、根本的には質問編集ページをSPAでなくするべきと考えられますが、今回はアドホックな対応にとどめています。

## 変更確認方法

1. `bug/delete-flash-message-when-question-create-through-wip2`をローカルに取り込む
2. 質問作成ページ（`questions/new`）で適当に質問を作成し、「WIP」をクリックして保存
3. 「質問をWIPとして保存しました。」というフラッシュメッセージが出て、質問ページに遷移することを確認
4. 「内容修正」をクリック→適当に内容を編集して「質問を公開」をクリック
5. 質問ページに自動で遷移し、「質問をWIPとして保存しました。」というフラッシュメッセージが「質問を公開しました。」に書き換わっていることを確認
6. 「内容修正」をクリック→適当に内容を編集して「WIP」をクリック
7. 質問ページに自動で遷移し、「質問を公開しました。」というフラッシュメッセージが「質問をWIPとして保存しました。」に書き換わっていることを確認

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/46841037/6d6372c0-7141-498a-b5f8-ca9072a30687)


### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/46841037/b33eea78-9412-42ed-a037-a7d83b8976d6)

