### PR TITLE
Timeout.timeout で発生する例外を明示的に指定

### DIFF
--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -166,7 +166,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
     tag_input = find('.tagify__input')
     tag_input.set '追加タグ'
     tag_input.native.send_keys :enter
-    Timeout.timeout(Capybara.default_max_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time, StandardError) do
       loop until page.has_text?('追加タグ')
     end
     find_all('.tagify__tag').map(&:text)

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -51,7 +51,7 @@ class CommentsTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     find('#comments.loaded', wait: 10)
 
-    Timeout.timeout(Capybara.default_max_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time, StandardError) do
       until find('#js-new-comment').value == 'login_nameの補完テスト: @komagata '
         find('#js-new-comment').set('')
         find('#js-new-comment').set("login_nameの補完テスト: @koma\n")
@@ -67,7 +67,7 @@ class CommentsTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     find('#comments.loaded', wait: 10)
 
-    Timeout.timeout(Capybara.default_max_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time, StandardError) do
       until find('#js-new-comment').value == 'login_nameの補完テスト: @mentor '
         find('#js-new-comment').set('')
         find('#js-new-comment').set("login_nameの補完テスト: @men\n")
@@ -83,7 +83,7 @@ class CommentsTest < ApplicationSystemTestCase
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     find('#comments.loaded', wait: 10)
 
-    Timeout.timeout(Capybara.default_max_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time, StandardError) do
       until find('#js-new-comment').value == '絵文字の補完テスト: 😺 '
         find('#js-new-comment').set('')
         find('#js-new-comment').set("絵文字の補完テスト: :cat\n")
@@ -243,7 +243,7 @@ class CommentsTest < ApplicationSystemTestCase
   test 'suggest mention to mentor' do
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     find('#comments.loaded', wait: 10)
-    Timeout.timeout(Capybara.default_max_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time, StandardError) do
       find('#js-new-comment').set('@') until has_selector?('span.mention', wait: false)
     end
     assert_selector 'span.mention', text: 'mentor'

--- a/test/system/current_user/tags_test.rb
+++ b/test/system/current_user/tags_test.rb
@@ -8,7 +8,7 @@ class CurrentUser::TagsTest < ApplicationSystemTestCase
     tag_input = find '.tagify__input'
     tag_input.set 'タグ1'
     tag_input.native.send_keys :enter
-    Timeout.timeout(Capybara.default_max_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time, StandardError) do
       loop until page.has_text?('タグ1')
     end
     find_all('.tagify__tag').map(&:text)

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -53,7 +53,7 @@ class User::TagsTest < ApplicationSystemTestCase
     tag_input = find('.tagify__input')
     tag_input.set 'タグタグ'
     tag_input.native.send_keys :return
-    Timeout.timeout(Capybara.default_max_wait_time) do
+    Timeout.timeout(Capybara.default_max_wait_time, StandardError) do
       loop until page.has_text?('タグタグ')
     end
     find_all('.tagify__tag').map(&:text)


### PR DESCRIPTION
`Timeout.timeout` でデフォルトの `Timeout::Error` が発生すると Selenium WebDriver がおかしくなる気がするので、代わりに `StandardError` が発生するようにしてみました。もっとよさそうな例外があればそちらを指定したいですが...。