### PR TITLE
ベストアンサーなし通知をactive_delivery化する

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -326,6 +326,24 @@ class ActivityMailer < ApplicationMailer
     message
   end
 
+  # required params: question, receiver
+  def no_correct_answer(args = {})
+    @question ||= args[:question]
+    @receiver ||= args[:receiver]
+    @user = @receiver
+
+    @link_url = notification_redirector_url(
+      link: "/questions/#{@question.id}",
+      kind: Notification.kinds[:no_correct_answer]
+    )
+
+    subject = "[FBC] #{@user.login_name}さんの質問【 #{@question.title} 】のベストアンサーがまだ選ばれていません。"
+    message = mail to: @user.email, subject: subject
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
+
+    message
+  end
+
   # required params: sender, receiver
   def signed_up(args = {})
     @sender ||= args[:sender]

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -68,12 +68,4 @@ class NotificationMailer < ApplicationMailer
     subject = "[FBC] #{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。"
     mail to: @user.email, subject: subject
   end
-
-  # required params: question, receiver
-  def no_correct_answer
-    @user = @receiver
-    @notification = @user.notifications.find_by(link: "/questions/#{@question.id}", kind: Notification.kinds[:no_correct_answer])
-    subject = "[FBC] #{@user.login_name}さんの質問【 #{@question.title} 】のベストアンサーがまだ選ばれていません。"
-    mail to: @user.email, subject: subject
-  end
 end

--- a/app/models/notification_facade.rb
+++ b/app/models/notification_facade.rb
@@ -30,14 +30,4 @@ class NotificationFacade
   def self.coming_soon_regular_events(today_events, tomorrow_events)
     DiscordNotifier.with(today_events: today_events, tomorrow_events: tomorrow_events).coming_soon_regular_events.notify_now
   end
-
-  def self.no_correct_answer(question, receiver)
-    ActivityNotifier.with(question: question, receiver: receiver).no_correct_answer.notify_now
-    return unless receiver.mail_notification? && !receiver.retired?
-
-    NotificationMailer.with(
-      question: question,
-      receiver: receiver
-    ).no_correct_answer.deliver_later(wait: 5)
-  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -39,7 +39,7 @@ class Question < ApplicationRecord
       return if Question.not_solved_and_certain_period_has_passed.blank?
 
       Question.not_solved_and_certain_period_has_passed.each do |not_solved_question|
-        NotificationFacade.no_correct_answer(not_solved_question, not_solved_question.user)
+        ActivityDelivery.with(question: not_solved_question, receiver: not_solved_question.user).notify(:no_correct_answer)
       end
     end
 

--- a/app/views/activity_mailer/no_correct_answer.html.slim
+++ b/app/views/activity_mailer/no_correct_answer.html.slim
@@ -1,0 +1,1 @@
+= render '/notification_mailer/notification_mailer_template', title: "#{@user.login_name}さんの質問【 #{@question.title} 】のベストアンサーがまだ選ばれていません。", link_url: @link_url, link_text: "#{@user.login_name}さんの質問へ"

--- a/app/views/notification_mailer/no_correct_answer.html.slim
+++ b/app/views/notification_mailer/no_correct_answer.html.slim
@@ -1,1 +1,0 @@
-= render 'notification_mailer_template', title: "#{@user.login_name}さんの質問【 #{@question.title} 】のベストアンサーがまだ選ばれていません。", link_url: notification_url(@notification), link_text: "#{@user.login_name}さんの質問へ"

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -368,4 +368,28 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:chose_correct_answer)
     end
   end
+
+  test '.notify(:no_correct_answer)' do
+    question = questions(:question1)
+    params = {
+      question: question,
+      receiver: question.user
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:no_correct_answer, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:no_correct_answer, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:no_correct_answer)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:no_correct_answer)
+    end
+  end
 end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -43,32 +43,4 @@ class NotificationMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] kensyuさんが日報【 研修の日報 】を書きました！', email.subject
     assert_match(/日報/, email.body.to_s)
   end
-
-  test 'no_correct_answer' do
-    user = users(:kimura)
-    question = questions(:question8)
-    Notification.create!(
-      kind: 22,
-      sender: user,
-      user: user,
-      message: 'Q&A「テストの質問」のベストアンサーがまだ選ばれていません。',
-      link: "/questions/#{question.id}",
-      read: false
-    )
-    mailer = NotificationMailer.with(
-      question: question,
-      receiver: user
-    ).no_correct_answer
-
-    perform_enqueued_jobs do
-      mailer.deliver_later
-    end
-
-    assert_not ActionMailer::Base.deliveries.empty?
-    email = ActionMailer::Base.deliveries.last
-    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
-    assert_equal ['kimura@fjord.jp'], email.to
-    assert_equal '[FBC] kimuraさんの質問【 テストの質問 】のベストアンサーがまだ選ばれていません。', email.subject
-    assert_match(/まだ選ばれていません/, email.body.to_s)
-  end
 end

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -153,4 +153,11 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(answer: answer, receiver: receiver).chose_correct_answer
   end
+
+  def no_correct_answer
+    question = Question.find(ActiveRecord::FixtureSet.identify(:question1))
+    receiver = User.find(question.user_id)
+
+    ActivityMailer.with(question: question, receiver: receiver).no_correct_answer
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5896

## 概要
質問に対する最後の回答から1週間が経過し、ベストアンサーが決まっていない場合、質問を投稿した人にサイト内通知とメール通知が飛びます。
その通知をactive_delivery化しました。

## 変更確認方法

1. `feature/replace-notification-on-no-correct-answer-with-active-delivery`をローカルに取り込む
2. Railsコンソールで、適当なユーザー（ここではhatsuno）で2週間前の質問を2つ作成する
```ruby
> user = User.find_by(login_name: 'hatsuno')
> time = 2.week.ago
> question1 = Question.create!(title: 'test1', description: 'test1', user: user, practice: Practice.first, created_at: time, updated_at: time, published_at: time)
> question2 = Question.create!(title: 'test2', description: 'test2', user: user, practice: Practice.first, created_at: time, updated_at: time, published_at: time)
```
3. さらに、上記の1つ目の質問に6日前の回答を、2つ目の質問に7日前の回答をつける
```ruby
> day6 = 6.day.ago
> question1.answers.create!(description: '6日前の回答', user: user, created_at: day6, updated_at: day6)
> day7 = 7.day.ago
> question2.answers.create!(description: '7日前の回答', user: user, created_at: day7, updated_at: day7)
```
5. Q&Aページにアクセスし、上記の質問・回答が正しく作られていることを確認する
![image](https://github.com/fjordllc/bootcamp/assets/46841037/c86abe57-ff70-4edb-85cb-956b9c4c693d)
![image](https://github.com/fjordllc/bootcamp/assets/46841037/0d25ce3a-e64a-4ca8-a384-72c82db0694b)

6. http://localhost:3000/scheduler/daily/notify_certain_period_passed_after_last_answer にアクセス
7. 質問を作成したユーザーでアクセスし、2つ目の質問についてのみ通知が来ていることを確認
![image](https://github.com/fjordllc/bootcamp/assets/46841037/f77f9226-0502-4ec6-8ea1-183eb530e4aa)

8. http://localhost:3000/letter_opener/ にアクセスし、2つ目の質問についてのみメール通知が飛んでいることを確認
![image](https://github.com/fjordllc/bootcamp/assets/46841037/cd42c963-d481-464a-9d3c-c13866f58360)

## やったこと
- NotificationFacadeをActivityNotifierに置き換え
- NotificationMailerをActivityMailerに置き換え
- Mailerのプレビュー画面を追加

変更前

```mermaid
flowchart TD
  NotifyCertainPeriodPassedAfterLastAnswerController -- notify_certain_period_passed_after_last_answer --> Question
  Question -- no_correct_answer --> NotificationFacade
  NotificationFacade -- no_correct_answer --> NotificationMailer:::orange
  NotificationFacade:::orange -- no_correct_answer --> ActivityNotifier

  classDef orange fill:#f96
```

変更後

```mermaid
flowchart TD
  NotifyCertainPeriodPassedAfterLastAnswerController -- notify_certain_period_passed_after_last_answer --> Question
  Question -- "notify(:no_correct_answer)" --> ActivityDelivery
  ActivityDelivery -. no_correct_answer .-> ActivityMailer:::orange
  ActivityDelivery:::orange -. no_correct_answer .-> ActivityNotifier

  classDef orange fill:#f96
```

## 参考情報
### ベストアンサーなし通知を導入したPR
- https://github.com/fjordllc/bootcamp/pull/5587

### 通知関連の参考リンク
- [gemを使った通知機能 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/gem%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%9F%E9%80%9A%E7%9F%A5%E6%A9%9F%E8%83%BD)
- [abstract_notifier](https://github.com/palkan/abstract_notifier)
  - [abstract_notifierで通知を実装する - komagataのブログ](https://docs.komagata.org/5857)
- [active_delivery](https://github.com/palkan/active_delivery)
  - [active_deliveryで通知をまとめる - komagataのブログ](https://docs.komagata.org/5858)
- [Action Mailer の基礎 - Railsガイド](https://railsguides.jp/action_mailer_basics.html)
- [Active Job の基礎 - Railsガイド](https://railsguides.jp/active_job_basics.html)

### active_delivery化の参考PR
- https://github.com/fjordllc/bootcamp/pull/6342
- https://github.com/fjordllc/bootcamp/pull/6479
- https://github.com/fjordllc/bootcamp/pull/6506

（他にもactive_delivery化のPRは多数あり）
