### PR TITLE
ニコニコカレンダーのテストが落ちるので修正

### DIFF
--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -220,11 +220,9 @@ class UsersTest < ApplicationSystemTestCase
     today = Time.current
     last_month = today.prev_month
     visit user_path(users(:hajime).id)
-    within '.niconico-calendar-nav' do
-      assert_text "#{today.year}年#{today.month}月"
-      find('.niconico-calendar-nav__previous').click
-      assert_text "#{last_month.year}年#{last_month.month}月"
-    end
+    assert_text "#{today.year}年#{today.month}月"
+    find('.niconico-calendar-nav__previous').click
+    assert_text "#{last_month.year}年#{last_month.month}月"
   end
 
   test 'show mark to today on niconico_calendar' do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -217,7 +217,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'paging niconico_calendar' do
     visit_with_auth root_path, 'hatsuno'
-    today = Time.current
+    today = Date.current
     last_month = today.prev_month
     visit user_path(users(:hajime).id)
     assert_text "#{today.year}年#{today.month}月"
@@ -226,7 +226,7 @@ class UsersTest < ApplicationSystemTestCase
   end
 
   test 'show mark to today on niconico_calendar' do
-    today = Time.current
+    today = Date.current
     visit_with_auth root_path, 'hatsuno'
     visit user_path(users(:hajime).id)
     assert_selector '.niconico-calendar__day.is-today'


### PR DESCRIPTION
ニコニコカレンダーの前へボタンを押すと、`within` に指定している `.niconico-calendar-nav__previous` という要素が再描画され、chromedriver でときどきエラーが起きてしまうので、`within` そのものを削除しました。学習時間のほうにも年月が表示されているのですが、このテストでは学習時間は表示されていなさそうなので、`within` は不要であると判断しました。