### PR TITLE
Docを削除したときの notification のメッセージを変更

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -68,7 +68,7 @@ class PagesController < ApplicationController
 
   def destroy
     @page.destroy
-    redirect_to '/pages', notice: 'ページを削除しました。'
+    redirect_to '/pages', notice: 'ドキュメントを削除しました。'
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -68,7 +68,7 @@ class PagesController < ApplicationController
 
   def destroy
     @page.destroy
-    redirect_to '/pages', notice: notice_message(@page, :destroy)
+    redirect_to '/pages', notice: 'ページを削除しました。'
   end
 
   private
@@ -95,8 +95,6 @@ class PagesController < ApplicationController
       'ドキュメントを作成しました。'
     when :update
       'ページを更新しました。'
-    when :destroy
-      'ドキュメントを削除しました。'
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -68,7 +68,7 @@ class PagesController < ApplicationController
 
   def destroy
     @page.destroy
-    redirect_to '/pages', notice: 'ページを削除しました。'
+    redirect_to '/pages', notice: notice_message(@page, :destroy)
   end
 
   private
@@ -95,6 +95,8 @@ class PagesController < ApplicationController
       'ドキュメントを作成しました。'
     when :update
       'ページを更新しました。'
+    when :destroy
+      'ドキュメントを削除しました。'
     end
   end
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -75,7 +75,7 @@ class PagesTest < ApplicationSystemTestCase
     assert_text 'ページをWIPとして保存しました。'
   end
 
-  test 'destroy document' do
+  test 'destroy page' do
     visit_with_auth new_page_path, 'kimura'
     within('.form') do
       fill_in 'page[title]', with: 'test'

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -75,6 +75,21 @@ class PagesTest < ApplicationSystemTestCase
     assert_text 'ページをWIPとして保存しました。'
   end
 
+  test 'destroy document' do
+    visit_with_auth new_page_path, 'kimura'
+    within('.form') do
+      fill_in 'page[title]', with: 'test'
+      fill_in 'page[body]', with: 'test'
+      click_button 'Docを公開'
+    end
+    assert_text 'ドキュメントを作成しました。'
+    accept_confirm do
+      click_link '削除する'
+    end
+
+    assert_text 'ドキュメントを削除しました。'
+  end
+
   test 'administrator can change doc user' do
     visit_with_auth "/pages/#{pages(:page1).id}/edit", 'komagata'
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -76,13 +76,8 @@ class PagesTest < ApplicationSystemTestCase
   end
 
   test 'destroy page' do
-    visit_with_auth new_page_path, 'kimura'
-    within('.form') do
-      fill_in 'page[title]', with: 'test'
-      fill_in 'page[body]', with: 'test'
-      click_button 'Docを公開'
-    end
-    assert_text 'ドキュメントを作成しました。'
+    visit_with_auth "/pages/#{pages(:page1).id}", 'komagata'
+
     accept_confirm do
       click_link '削除する'
     end


### PR DESCRIPTION
## Issue

- #6303

## 概要

Docを削除したときの notification のメッセージを「ページを削除しました。」から「ドキュメントを削除しました。」に変更。

## 変更確認方法

1. feature/change-message-when-document-is-deletedをローカルに取り込む
2. bin/rails sでローカル環境を立ち上げる
3. localhost:3000にアクセス
4. ユーザー名 : komagata でログイン
5. Docsを選択
<img width="984" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/f4043f69-7f03-4849-bd43-2adbec3bf116">


6. 「+ Doc作成」ボタンを選択
<img width="913" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/eda0cfbd-f546-4f2b-8838-4eb6dcb3d35a">


7. タイトルと本文を入力して、「Docを公開」を選択

8. 削除するを選択
<img width="1010" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/7ccc7fb5-6f00-4c0b-8075-9cd74278aa05">

9. メッセージが、「ドキュメントを削除しました。」であることを確認する。

<img width="1012" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/f99620ef-ba41-4260-b35a-e1e32ee43f09">



## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/92995093/67d7c7c5-a3a8-4d38-b339-0b5b1fd97c67)



### 変更後
<img width="1875" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/33905809-f26a-4ca1-b558-b6805dddfc0f">


