### PR TITLE
管理者・メンター以外も特別イベントを公開できるようにする

### DIFF
--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -57,7 +57,7 @@
     - unless event.wip?
       = render 'events/participation', event: event
     = render 'reactions/reactions', reactionable: event
-    - if admin_or_mentor_login? || event.user_id == current_user.id
+    - if event.user_id == current_user.id || admin_or_mentor_login?
       .card-footer
         .card-main-actions
           ul.card-main-actions__items

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -47,11 +47,10 @@
     ul.form-actions__items
       li.form-actions__item.is-main
         = f.submit 'WIP', class: 'a-button is-lg is-secondary is-block', id: 'js-shortcut-wip'
-      - if admin_or_mentor_login?
         li.form-actions__item.is-main
           - if event.new_record?
             = f.submit '作成', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
-          - else
+          - elsif event.user_id == current_user.id || admin_or_mentor_login?
             = f.submit '内容変更', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
       li.form-actions__item.is-sub
         - case params[:action]

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -58,9 +58,3 @@
           = link_to 'キャンセル', events_path, class: 'a-button is-sm is-text'
         - when 'edit', 'update'
           = link_to 'キャンセル', event_path, class: 'a-button is-sm is-text'
-    - unless mentor_login?
-      .form-actions__description.a-short-text
-        p
-          | イベントを作成しましたら WIP で保存し、作成したイベントのコメントから
-          br
-          |  @mentor へ確認・公開依頼の連絡をお願いします。

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -50,7 +50,7 @@
         li.form-actions__item.is-main
           - if event.new_record?
             = f.submit '作成', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
-          - elsif event.user_id == current_user.id || admin_or_mentor_login?
+          - else
             = f.submit '内容変更', class: 'a-button is-lg is-primary is-block', id: 'js-shortcut-submit'
       li.form-actions__item.is-sub
         - case params[:action]

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -9,7 +9,7 @@ event1:
   end_at: 2019-12-20 12:30
   open_start_at: 2019-12-10 09:00
   open_end_at: 2019-12-19 9:00
-  user: komagata
+  user: kimura
 
 event2:
   title: "募集期間中のイベント(補欠者なし)"
@@ -20,7 +20,7 @@ event2:
   end_at: <%= Time.current.next_year %>
   open_start_at: <%= Time.current %>
   open_end_at: <%= Time.current.next_year %>
-  user: komagata
+  user: kimura
 
 event3:
   title: "募集期間中のイベント(補欠者あり)"
@@ -42,7 +42,7 @@ event4:
   end_at: <%= Time.current.next_year %>
   open_start_at: <%= Time.current.next_year - 1.day %>
   open_end_at: <%= Time.current.next_year %>
-  user: komagata
+  user: kimura
 
 event5:
   title: "募集期間後のイベント"
@@ -53,7 +53,7 @@ event5:
   end_at: <%= Time.current.next_year %>
   open_start_at: <%= Time.current.yesterday %>
   open_end_at: <%= Time.current.yesterday + 1.hour %>
-  user: komagata
+  user: kimura
 
 event6:
   title: "終了したイベント"
@@ -64,7 +64,7 @@ event6:
   end_at: 2019-12-17 12:00:00
   open_start_at: 2019-12-10 9:00
   open_end_at: 2019-12-16 9:00
-  user: komagata
+  user: kimura
 
 event7:
   title: "テストのイベント"
@@ -75,7 +75,7 @@ event7:
   end_at: 2019-12-17 12:00:00
   open_start_at: 2019-12-10 9:00
   open_end_at: 2019-12-16 9:00
-  user: komagata
+  user: kimura
 
 event8:
   title: "イベントの検索結果テスト用"
@@ -86,7 +86,7 @@ event8:
   end_at: 2018-5-20 12:00:00
   open_start_at: 2018-5-14 9:00
   open_end_at: 2018-5-20 9:00
-  user: komagata
+  user: kimura
 
 <% (9..26).each do |i| %>
 event<%= i %>:
@@ -100,7 +100,7 @@ event<%= i %>:
   open_end_at: <%= Time.zone.local(2018, 5, 20, 9).ago(i.days) %>
   created_at: <%= Time.zone.local(2018, 5, 14, 9).ago(i.days) %>
   updated_at: <%= Time.zone.local(2018, 5, 14, 9).ago(i.days) %>
-  user: komagata
+  user: kimura
 <% end %>
 
 event27:
@@ -112,7 +112,7 @@ event27:
   end_at: 2017-4-1 12:00:00
   open_start_at: 2017-3-25 9:00
   open_end_at: 2017-4-01 9:00
-  user: komagata
+  user: kimura
 
 event28:
   title: "直近イベントの表示テスト用(翌日)"
@@ -123,7 +123,7 @@ event28:
   end_at: 2017-4-2 12:00:00
   open_start_at: 2017-3-26 9:00
   open_end_at: 2017-4-02 9:00
-  user: komagata
+  user: kimura
 
 event29:
   title: "就職関係かつ直近イベントの表示テスト用"
@@ -135,7 +135,7 @@ event29:
   open_start_at: 2017-3-26 9:00
   open_end_at: 2017-4-02 9:00
   job_hunting: true
-  user: komagata
+  user: kimura
 
 event30:
   title: "未来のイベント境界値用"
@@ -146,7 +146,7 @@ event30:
   end_at: 2023-05-20 12:00
   open_start_at: 2023-04-20 10:00
   open_end_at: 2023-05-20 09:00
-  user: komagata
+  user: kimura
 
 event31:
   title: "過去のイベント境界値用"
@@ -157,4 +157,4 @@ event31:
   end_at: 2023-05-18 12:00
   open_start_at: 2023-04-18 10:00
   open_end_at: 2023-05-18 09:00
-  user: komagata
+  user: kimura

--- a/test/fixtures/participations.yml
+++ b/test/fixtures/participations.yml
@@ -27,6 +27,6 @@ participation5:
   enable: true
 
 participation6:
-  user: kimura
+  user: hatsuno
   event: event5
   enable: true

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -3,11 +3,6 @@
 require 'application_system_test_case'
 
 class EventsTest < ApplicationSystemTestCase
-  test 'users except admin cannot publish a event' do
-    visit_with_auth new_event_path, 'kimura'
-    page.assert_no_selector("input[value='作成']")
-  end
-
   test 'create a new event as wip' do
     visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -24,7 +24,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'create a new event' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '新しいイベント'
       fill_in 'event[description]', with: 'イベントの説明文'
@@ -44,7 +44,7 @@ class EventsTest < ApplicationSystemTestCase
 
   test 'create copy event' do
     event = events(:event1)
-    visit_with_auth event_path(event), 'komagata'
+    visit_with_auth event_path(event), 'kimura'
     click_link 'コピー'
     assert_text '特別イベントをコピーしました'
     within 'form[name=event]' do
@@ -61,7 +61,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'update event' do
-    visit_with_auth edit_event_path(events(:event1)), 'komagata'
+    visit_with_auth edit_event_path(events(:event1)), 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: 'ミートアップ(修正)'
       fill_in 'event[description]', with: 'ミートアップを開催します(修正)'
@@ -77,7 +77,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'destroy event' do
-    visit_with_auth event_path(events(:event1)), 'komagata'
+    visit_with_auth event_path(events(:event1)), 'kimura'
     find 'h2', text: 'コメント'
     find 'div.container > div.user-icons > ul.user-icons__items', visible: :all
     accept_confirm do
@@ -87,7 +87,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'cannot create a new event when start_at > end_at' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: 'イベント開始日時 > イベント終了日時のイベント'
       fill_in 'event[description]', with: 'エラーになる'
@@ -103,7 +103,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'cannot create a new event when open_start_at > open_end_at' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '募集開始日時 > 募集終了日時のイベント'
       fill_in 'event[description]', with: 'エラーになる'
@@ -119,7 +119,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'cannot create a new event when open_start_at > start_at' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '募集開始日時 > イベント開始日時のイベント'
       fill_in 'event[description]', with: 'エラーになる'
@@ -135,7 +135,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'cannot create a new event when open_end_at > end_at' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '募集終了日時 > イベント終了日時のイベント'
       fill_in 'event[description]', with: 'エラーになる'
@@ -194,7 +194,7 @@ class EventsTest < ApplicationSystemTestCase
 
   test 'user can cancel event even if deadline has passed' do
     event = events(:event5)
-    visit_with_auth event_path(event), 'kimura'
+    visit_with_auth event_path(event), 'hatsuno'
     assert_difference 'event.users.count', -1 do
       accept_confirm do
         click_link '参加を取り消す'
@@ -206,7 +206,7 @@ class EventsTest < ApplicationSystemTestCase
 
   test 'autolink location when url is included' do
     url = 'https://bootcamp.fjord.jp/'
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '会場にURLを含むイベント'
       fill_in 'event[description]', with: 'イベントの説明文'
@@ -224,7 +224,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'participating is first-come-first-served' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '先着順のイベント'
       fill_in 'event[description]', with: 'イベントの説明文'
@@ -241,7 +241,7 @@ class EventsTest < ApplicationSystemTestCase
     end
     assert_text '参加登録しました'
 
-    visit_with_auth events_path, 'kimura'
+    visit_with_auth events_path, 'hatsuno'
     click_link '先着順のイベント'
     accept_confirm do
       click_link '参加申込'
@@ -249,12 +249,12 @@ class EventsTest < ApplicationSystemTestCase
     assert_text '参加登録しました'
     within '.participants' do
       participants = all('img').map { |img| img['alt'] }
-      assert_equal %w[komagata kimura], participants
+      assert_equal %w[kimura hatsuno], participants
     end
   end
 
   test 'display user to waitlist when event participants are fulled' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '補欠者のいるイベント'
       fill_in 'event[description]', with: 'イベントの説明文'
@@ -271,7 +271,7 @@ class EventsTest < ApplicationSystemTestCase
     end
     assert_text '参加登録しました'
 
-    visit_with_auth events_path, 'kimura'
+    visit_with_auth events_path, 'hatsuno'
     click_link '補欠者のいるイベント'
     accept_confirm do
       click_link '補欠登録'
@@ -279,12 +279,12 @@ class EventsTest < ApplicationSystemTestCase
     assert_text '参加登録しました'
     within '.waitlist' do
       wait_user = all('img').map { |img| img['alt'] }
-      assert_equal ['kimura (Kimura Tadasi)'], wait_user
+      assert_equal ['hatsuno (Hatsuno Shinji)'], wait_user
     end
   end
 
   test 'waiting user moves up when participant cancels event' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '補欠者が繰り上がるイベント'
       fill_in 'event[description]', with: 'イベントの説明文'
@@ -301,7 +301,7 @@ class EventsTest < ApplicationSystemTestCase
     end
     assert_text '参加登録しました'
 
-    visit_with_auth events_path, 'kimura'
+    visit_with_auth events_path, 'hatsuno'
     click_link '補欠者が繰り上がるイベント'
     accept_confirm do
       click_link '補欠登録'
@@ -309,10 +309,10 @@ class EventsTest < ApplicationSystemTestCase
     assert_text '参加登録しました'
     within '.participants' do
       participants = all('img').map { |img| img['alt'] }
-      assert_equal %w[komagata], participants
+      assert_equal %w[kimura], participants
     end
 
-    visit_with_auth events_path, 'komagata'
+    visit_with_auth events_path, 'kimura'
     click_link '補欠者が繰り上がるイベント'
     accept_confirm do
       click_link '参加を取り消す'
@@ -320,12 +320,12 @@ class EventsTest < ApplicationSystemTestCase
     assert_text '参加を取り消しました'
     within '.participants' do
       participants = all('img').map { |img| img['alt'] }
-      assert_equal %w[kimura], participants
+      assert_equal %w[hatsuno], participants
     end
   end
 
   test 'does not display waitlist card when no users waiting' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[title]', with: '補欠者リストが表示されないイベント'
       fill_in 'event[description]', with: 'イベントの説明文'
@@ -364,7 +364,7 @@ class EventsTest < ApplicationSystemTestCase
 
   test 'show user full name on list page' do
     visit_with_auth '/events', 'kimura'
-    assert_text 'komagata (コマガタ マサキ)'
+    assert_text 'kimura (キムラ タダシ)'
   end
 
   test 'show pagination' do
@@ -373,7 +373,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'dates of target events get filled automatically only when they are empty' do
-    visit_with_auth new_event_path, 'komagata'
+    visit_with_auth new_event_path, 'kimura'
     within 'form[name=event]' do
       fill_in 'event[start_at]', with: Time.zone.local(2050, 12, 24, 23, 59)
     end


### PR DESCRIPTION
## Issue
- #6608 

## 概要
これまで受講生が特別イベントを作成or更新する場合、イベントをWIPで保存した後メンターに連絡して公開してもらう必要があり、受講生自身で公開することはできませんでした。
このPRでは管理者・メンター権限がないアカウントでも、自分が作成したイベントに関してはイベント作成フォームに「作成(内容更新)」ボタンが表示されるようにし、受講生がイベントの公開をできるようにしました。

## 変更確認方法
1. `feature/Non-admins-or-mentors-can-publish-events`をローカルに取り込む
2. `$ bin/rails s`でアプリを立ち上げる
3. 任意の受講生アカウント(`hatsuno`など)でログイン
4. 特別イベントの新規作成、公開ができるか確認
    1. 特別イベント作成画面`/events/new`にアクセス
    1. フォームの項目を入力後、画面下部の`作成`ボタンをクリック
    1. 特別イベント一覧`/events`にアクセスして、作成したイベントが公開されているか確認する
5. 特別イベントの更新、公開ができるか確認
    1. 手順4で作ったイベントページにアクセス
    1. `内容修正`をクリック
    1. 任意の項目を変更後、`内容変更`をクリック
    1. イベントが更新されていることを確認する

## Screenshot
### 変更前
- 特別イベント作成 `/event/new`
<img width="1174" alt="before_student_new" src="https://github.com/fjordllc/bootcamp/assets/66685066/3f6cbb70-4da3-46d3-98eb-498ede49678b">

- 特別イベント編集 `/event/:id/edit`
<img width="1158" alt="before_student_edit" src="https://github.com/fjordllc/bootcamp/assets/66685066/7bfc3152-5fed-4189-8a53-5784a123c063">

### 変更後
- 特別イベント作成 `/event/new`
<img width="1177" alt="after_student_new" src="https://github.com/fjordllc/bootcamp/assets/66685066/72313a74-604f-4ea0-b31d-a7f682253668">

- 特別イベント編集 `/event/:id/edit`
<img width="1166" alt="after_student_edit" src="https://github.com/fjordllc/bootcamp/assets/66685066/8f67d8d8-c61d-4d97-be8f-1056b5b58b9f">

## 補足
このPRによる権限の変化は以下の通りです。
公開権限だけ変わりました。

変更前
|  | 管理者・メンター以外 | 管理者・メンター | 
|--------|--------|--------| 
| 作成 | ○ | ○ | 
| 編集 | ○[^1] | ○ | 
| 公開 | X | ○ | 
| 削除 | ○[^1] | ○ | 

変更後
|  | 管理者・メンター以外 | 管理者・メンター |
|--------|--------|--------|
| 作成 | ○ | ○ |
| 編集 | ○[^1] | ○ |
| 公開 | ○[^1] | ○ |
| 削除 | ○[^1] | ○ | 

[^1]:自分が作成者のイベントのみ操作可