### PR TITLE
担当者が決まった提出物にはレビュー中と表示するようにした

### DIFF
--- a/app/javascript/stylesheets/_common-imports.sass
+++ b/app/javascript/stylesheets/_common-imports.sass
@@ -120,6 +120,7 @@
 @import "atoms/a-user-role-badge"
 @import "atoms/a-watch-button"
 @import "atoms/a-welcome-button"
+@import "atoms/a-checker"
 
 ////////////
 // layouts

--- a/app/javascript/stylesheets/application.sass
+++ b/app/javascript/stylesheets/application.sass
@@ -78,12 +78,14 @@
 @import application/blocks/page/page-tabs
 @import application/blocks/page/page
 
+@import application/blocks/page-content/page-content
 @import application/blocks/page-content/page-content-header-actions
 @import application/blocks/page-content/page-content-header-metas
 @import application/blocks/page-content/page-content-header
 @import application/blocks/page-content/page-content-members
 @import application/blocks/page-content/page-content-prev-next
-@import application/blocks/page-content/page-content
+@import application/blocks/page-content/page-content-checker
+
 
 @import application/blocks/practice/categories
 @import application/blocks/practice/category-practices-item

--- a/app/javascript/stylesheets/application.sass
+++ b/app/javascript/stylesheets/application.sass
@@ -84,8 +84,6 @@
 @import application/blocks/page-content/page-content-header
 @import application/blocks/page-content/page-content-members
 @import application/blocks/page-content/page-content-prev-next
-@import application/blocks/page-content/page-content-checker
-
 
 @import application/blocks/practice/categories
 @import application/blocks/practice/category-practices-item

--- a/app/javascript/stylesheets/application/blocks/page-content/_page-content-checker.sass
+++ b/app/javascript/stylesheets/application/blocks/page-content/_page-content-checker.sass
@@ -1,0 +1,13 @@
+.page-content-checker
+  +position(absolute, right 0, bottom 0)
+  display: flex
+  align-items: center
+  justify-content: center
+  border: solid 1px $danger
+  border-radius: 1rem
+  padding: .25rem .75rem .25rem .5rem
+  background-color: $danger-tint
+
+.page-content-checker__status
+  +text-block(.625rem 1, $danger-text)
+  margin-left: .25rem

--- a/app/javascript/stylesheets/application/blocks/page-content/_page-content-header.sass
+++ b/app/javascript/stylesheets/application/blocks/page-content/_page-content-header.sass
@@ -162,3 +162,6 @@
 
 .page-content-header__emotion-image
   +size(100%)
+
+.page-content-header__checker
+  +position(absolute, right 0, top -.5rem)

--- a/app/javascript/stylesheets/atoms/_a-checker.sass
+++ b/app/javascript/stylesheets/atoms/_a-checker.sass
@@ -1,13 +1,12 @@
-.page-content-checker
-  +position(absolute, right 0, bottom 0)
+.a-checker
   display: flex
   align-items: center
   justify-content: center
   border: solid 1px $danger
   border-radius: 1rem
-  padding: .25rem .75rem .25rem .5rem
   background-color: $danger-tint
+  padding: .125rem .5rem .125rem .25rem
 
-.page-content-checker__status
+.a-checker__status
   +text-block(.625rem 1, $danger-text)
   margin-left: .25rem

--- a/app/javascript/stylesheets/atoms/_a-user-icon.sass
+++ b/app/javascript/stylesheets/atoms/_a-user-icon.sass
@@ -5,7 +5,9 @@
   +size(100%)
   +icon-role-style
   &.is-sm
-    +size(2em)
+    +size(2rem)
+  &.is-xs
+    +size(1.5rem)
 
 .a-long-text
   .a-user-emoji-link

--- a/app/javascript/stylesheets/atoms/_a-user-icon.sass
+++ b/app/javascript/stylesheets/atoms/_a-user-icon.sass
@@ -7,7 +7,10 @@
   &.is-sm
     +size(2rem)
   &.is-xs
-    +size(1.5rem)
+    +media-breakpoint-up(md)
+      +size(1.5rem)
+    +media-breakpoint-down(sm)
+      +size(1.125rem)
 
 .a-long-text
   .a-user-emoji-link

--- a/app/javascript/stylesheets/shared/blocks/card-list/_card-list-item.sass
+++ b/app/javascript/stylesheets/shared/blocks/card-list/_card-list-item.sass
@@ -213,3 +213,9 @@ a.card-list-item__inner
   +position(absolute, left 0, top 0, right 0, bottom 0)
   object-fit: cover
   border-radius: 4px
+
+.card-list-item__checker
+  +media-breakpoint-up(md)
+    +position(absolute, right .5rem, top .5rem)
+  +media-breakpoint-down(sm)
+    margin-top: .5rem

--- a/app/views/application/header/_header_links.html.slim
+++ b/app/views/application/header/_header_links.html.slim
@@ -17,7 +17,7 @@
             span class="a-user-role is-#{current_user.primary_role}"
               = image_tag current_user.avatar_url,
                 title: current_user.icon_title,
-                class: 'header-current-user__icon a-user-icon'
+                class: 'header-current-user__icon a-user-icon is-xs'
           .header-links__link-label Me
         input.a-toggle-checkbox#header-menu(type='checkbox')
         .header-dropdown

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -80,7 +80,7 @@
       .stamp__content.is-user-name
         .stamp__content-inner
           = product.checks.last.user.login_name
-  - elsif product.checker_id?
+  - elsif product.checker_id? && product.learning&.status == 'submitted'
     .card-list-item__checker
       .a-checker
         .a-checker__user
@@ -88,6 +88,5 @@
                   user: product.checker,
                   link_class: 'a-checker__user-link',
                   image_class: 'is-xs'
-        //- if product.learning&.status == 'submitted'
         .a-checker__status
           | レビュー中

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -11,6 +11,12 @@
                 span
                   | WIP
             h2.card-list-item-title__title(itemprop='name')
+              - if product.checker_id?
+                = render 'users/icon',
+                        user: product.checker,
+                        image_class: 'a-user-icon'
+                - if product.learning&.status == "submitted"
+                | レビュー中
               = link_to product, itemprop: 'url', class: 'card-list-item-title__link a-text-link js-unconfirmed-link' do
                 | #{product.practice.title}の提出物
       .card-list-item__row

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -15,8 +15,8 @@
                 = render 'users/icon',
                         user: product.checker,
                         image_class: 'a-user-icon'
-                - if product.learning&.status == "submitted"
-                | レビュー中
+                - if product.learning&.status == 'submitted'
+                  | レビュー中
               = link_to product, itemprop: 'url', class: 'card-list-item-title__link a-text-link js-unconfirmed-link' do
                 | #{product.practice.title}の提出物
       .card-list-item__row

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -11,12 +11,6 @@
                 span
                   | WIP
             h2.card-list-item-title__title(itemprop='name')
-              - if product.checker_id?
-                = render 'users/icon',
-                        user: product.checker,
-                        image_class: 'a-user-icon'
-                - if product.learning&.status == 'submitted'
-                  | レビュー中
               = link_to product, itemprop: 'url', class: 'card-list-item-title__link a-text-link js-unconfirmed-link' do
                 | #{product.practice.title}の提出物
       .card-list-item__row
@@ -74,13 +68,26 @@
               .card-list-item-meta__item
                 .card-list-item-meta__item-note
                   | このプラクティスは、OKをもらっていなくても他の人の提出物を閲覧できます。
-    - if product.checks.any?
-      .stamp.stamp-approve
-        h2.stamp__content.is-title 確認済
-        time.stamp__content.is-created-at
-          = l product.checks.last.created_at.to_date, format: :short
-        .stamp__content.is-user-name
-          .stamp__content-inner
-            = product.checks.last.user.login_name
+
     - if current_user.mentor? && product.checks.empty?
       .js-checker(data-checker-id="#{product.checker_id}" data-checker-name="#{product.checker_name}" data-current-user-id="#{current_user.id}" data-product-id="#{product.id}")
+
+  - if product.checks.any?
+    .stamp.stamp-approve
+      h2.stamp__content.is-title 確認済
+      time.stamp__content.is-created-at
+        = l product.checks.last.created_at.to_date, format: :short
+      .stamp__content.is-user-name
+        .stamp__content-inner
+          = product.checks.last.user.login_name
+  - elsif product.checker_id?
+    .card-list-item__checker
+      .a-checker
+        .a-checker__user
+          = render 'users/icon',
+                  user: product.checker,
+                  link_class: 'a-checker__user-link',
+                  image_class: 'is-xs'
+        //- if product.learning&.status == 'submitted'
+        .a-checker__status
+          | レビュー中

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -34,7 +34,7 @@ header.page-content-header
         = render 'users/icon',
                 user: product.checker,
                 image_class: 'a-user-icon'
-        - if product.learning&.status == "submitted"
+        - if product.learning&.status == 'submitted'
           | レビュー中
 
       h1.page-content-header__title(class="#{product.wip? ? 'is-wip' : ''}")

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -1,5 +1,16 @@
 header.page-content-header
   #js-check-stamp(data-checkable-id="#{product.id}" data-checkable-type='Product')
+  - if product.checker_id?
+    .page-content-header__checker
+      .a-checker
+        .a-checker__user
+          = render 'users/icon',
+                  user: product.checker,
+                  link_class: 'a-checker__user-link',
+                  image_class: 'is-xs'
+        //- if product.learning&.status == 'submitted'
+        .a-checker__status
+          | レビュー中
   .page-content-header__start
     .page-content-header__user
       = render 'users/icon', user: product.user, link_class: 'page-content-header__user-link', image_class: 'page-content-header__user-icon'
@@ -33,22 +44,11 @@ header.page-content-header
                 - else
                   span.a-meta__value
                     | 未入力
-      - if product.checker_id?
-        .page-content-checker
-          .page-content-checker__user
-            = render 'users/icon',
-                    user: product.checker,
-                    link_class: 'page-content-checker__user-link',
-                    image_class: 'is-xs'
-          - if product.learning&.status == 'submitted'
-            .page-content-checker__status
-              | レビュー中
     .page-content-header__row
       h1.page-content-header__title.has-checker(class="#{product.wip? ? 'is-wip' : ''}")
         - if product.wip?
           span.a-title-label.is-wip
             | WIP
-
         | #{link_to product.practice.title, product.practice, class: 'page-content-header__title-link'}の提出物
 
     .page-content-header__row

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -1,6 +1,6 @@
 header.page-content-header
   #js-check-stamp(data-checkable-id="#{product.id}" data-checkable-type='Product')
-  - if product.checker_id?
+  - if product.checker_id? && product.learning&.status == 'submitted'
     .page-content-header__checker
       .a-checker
         .a-checker__user
@@ -8,7 +8,6 @@ header.page-content-header
                   user: product.checker,
                   link_class: 'a-checker__user-link',
                   image_class: 'is-xs'
-        //- if product.learning&.status == 'submitted'
         .a-checker__status
           | レビュー中
   .page-content-header__start

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -1,72 +1,79 @@
 header.page-content-header
-  #js-check-stamp(data-checkable-id="#{@product.id}" data-checkable-type='Product')
+  #js-check-stamp(data-checkable-id="#{product.id}" data-checkable-type='Product')
   .page-content-header__start
     .page-content-header__user
-      = render 'users/icon', user: @product.user, link_class: 'page-content-header__user-link', image_class: 'page-content-header__user-icon'
+      = render 'users/icon', user: product.user, link_class: 'page-content-header__user-link', image_class: 'page-content-header__user-icon'
   .page-content-header__end
     .page-content-header__row
       .page-content-header__before-title
-        = link_to @product.user, class: 'a-user-name' do
-          = @product.user.long_name
-        - if current_user&.mentor? && @product.user.trainee?
+        = link_to product.user, class: 'a-user-name' do
+          = product.user.long_name
+        - if current_user&.mentor? && product.user.trainee?
           .a-meta
             span.a-meta__label
               = User.human_attribute_name :training_ends_on
-            - if @product.user.training_ends_on
+            - if product.user.training_ends_on
               span.a-meta__value
-                = l @product.user.training_ends_on
-              - if @product.user.training_remaining_days.zero?
+                = l product.user.training_ends_on
+              - if product.user.training_remaining_days.zero?
                 span.a-meta__value.is-danger
                   | （本日研修最終日）
-              - elsif @product.user.training_remaining_days.negative?
+              - elsif product.user.training_remaining_days.negative?
                 span.a-meta__value
                   | （研修終了済み）
-              - elsif @product.user.training_remaining_days < 7
+              - elsif product.user.training_remaining_days < 7
                 span.a-meta__value.is-danger
-                  | （あと#{@product.user.training_remaining_days}日）
+                  | （あと#{product.user.training_remaining_days}日）
               - else
                 span.a-meta__value
-                  | （あと#{@product.user.training_remaining_days}日）
+                  | （あと#{product.user.training_remaining_days}日）
             - else
               span.a-meta__value
                 | 未入力
+      - if product.checker_id?
+        = render 'users/icon',
+                user: product.checker,
+                image_class: 'a-user-icon'
+        - if product.learning&.status == "submitted"
+          | レビュー中
 
-      h1.page-content-header__title(class="#{@product.wip? ? 'is-wip' : ''}")
-        - if @product.wip?
+      h1.page-content-header__title(class="#{product.wip? ? 'is-wip' : ''}")
+        - if product.wip?
           span.a-title-label.is-wip
             | WIP
-        | #{link_to @product.practice.title, @product.practice, class: 'page-content-header__title-link'}の提出物
+
+        | #{link_to product.practice.title, product.practice, class: 'page-content-header__title-link'}の提出物
 
     .page-content-header__row
       .page-content-header-metas
         .page-content-header-metas__start
           .page-content-header-metas__meta
             .a-meta
-              - if @product.wip?
+              - if product.wip?
                 .a-meta__value
                   | 提出物作成中
-              - elsif @product.published_at.present?
+              - elsif product.published_at.present?
                 span.a-meta__label
                   | 提出
-                time.a-meta__value(datetime="#{@product.published_at.to_datetime}")
-                  = l @product.published_at
+                time.a-meta__value(datetime="#{product.published_at.to_datetime}")
+                  = l product.published_at
               - else
                 span.a-meta__label
                   | 提出
-                time.a-meta__value(datetime="#{@product.created_at.to_datetime}")
-                  = l @product.created_at
+                time.a-meta__value(datetime="#{product.created_at.to_datetime}")
+                  = l product.created_at
 
-          - if @product.updated_at.present?
+          - if product.updated_at.present?
             .page-content-header-metas__meta
               .a-meta
                 span.a-meta__label
                   | 更新
-                time.a-meta__value(datetime="#{@product.updated_at.to_datetime}")
-                  = l @product.updated_at
+                time.a-meta__value(datetime="#{product.updated_at.to_datetime}")
+                  = l product.updated_at
 
         .page-content-header-metas__end
           .page-content-header-metas__meta
-            - length = @product.comments.length
+            - length = product.comments.length
             a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
               | コメント（
               span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
@@ -77,9 +84,9 @@ header.page-content-header
       .page-content-header-actions
         .page-content-header-actions__start
           .page-content-header-actions__action
-            div(data-vue="WatchToggle" data-vue-watchable-id:number="#{@product.id}" data-vue-watchable-type='Product')
+            div(data-vue="WatchToggle" data-vue-watchable-id:number="#{product.id}" data-vue-watchable-type='Product')
           .page-content-header-actions__action
-            #js-bookmark(data-bookmarkable-id="#{@product.id}", data-bookmarkable-type='Product')
+            #js-bookmark(data-bookmarkable-id="#{product.id}", data-bookmarkable-type='Product')
         .page-content-header-actions__end
           .page-content-header-actions__action
             = link_to 'Raw', product_path(format: :md), class: 'a-button is-sm is-secondary is-block', target: '_blank', rel: 'noopener'

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -4,40 +4,47 @@ header.page-content-header
     .page-content-header__user
       = render 'users/icon', user: product.user, link_class: 'page-content-header__user-link', image_class: 'page-content-header__user-icon'
   .page-content-header__end
-    .page-content-header__row
-      .page-content-header__before-title
-        = link_to product.user, class: 'a-user-name' do
-          = product.user.long_name
-        - if current_user&.mentor? && product.user.trainee?
-          .a-meta
-            span.a-meta__label
-              = User.human_attribute_name :training_ends_on
-            - if product.user.training_ends_on
-              span.a-meta__value
-                = l product.user.training_ends_on
-              - if product.user.training_remaining_days.zero?
-                span.a-meta__value.is-danger
-                  | （本日研修最終日）
-              - elsif product.user.training_remaining_days.negative?
-                span.a-meta__value
-                  | （研修終了済み）
-              - elsif product.user.training_remaining_days < 7
-                span.a-meta__value.is-danger
-                  | （あと#{product.user.training_remaining_days}日）
-              - else
-                span.a-meta__value
-                  | （あと#{product.user.training_remaining_days}日）
-            - else
-              span.a-meta__value
-                | 未入力
+    .page-content-header__row.relative
+      .page-content-header-metas
+        .page-content-header-metas__start
+          .page-content-header-metas__meta
+            = link_to product.user, class: 'a-user-name' do
+              = product.user.long_name
+          - if current_user&.mentor? && product.user.trainee?
+            .page-content-header-metas__meta
+              .a-meta
+                span.a-meta__label
+                  = User.human_attribute_name :training_ends_on
+                - if product.user.training_ends_on
+                  span.a-meta__value
+                    = l product.user.training_ends_on
+                  - if product.user.training_remaining_days.zero?
+                    span.a-meta__value.is-danger
+                      | （本日研修最終日）
+                  - elsif product.user.training_remaining_days.negative?
+                    span.a-meta__value
+                      | （研修終了済み）
+                  - elsif product.user.training_remaining_days < 7
+                    span.a-meta__value.is-danger
+                      | （あと#{product.user.training_remaining_days}日）
+                  - else
+                    span.a-meta__value
+                      | （あと#{product.user.training_remaining_days}日）
+                - else
+                  span.a-meta__value
+                    | 未入力
       - if product.checker_id?
-        = render 'users/icon',
-                user: product.checker,
-                image_class: 'a-user-icon'
-        - if product.learning&.status == 'submitted'
-          | レビュー中
-
-      h1.page-content-header__title(class="#{product.wip? ? 'is-wip' : ''}")
+        .page-content-checker
+          .page-content-checker__user
+            = render 'users/icon',
+                    user: product.checker,
+                    link_class: 'page-content-checker__user-link',
+                    image_class: 'is-xs'
+          - if product.learning&.status == 'submitted'
+            .page-content-checker__status
+              | レビュー中
+    .page-content-header__row
+      h1.page-content-header__title.has-checker(class="#{product.wip? ? 'is-wip' : ''}")
         - if product.wip?
           span.a-title-label.is-wip
             | WIP


### PR DESCRIPTION
## Issue

- #6508

## 概要
担当者が決まった提出物にはレビュー中と表示し、横に担当者のアイコンも表示するようにしました。

## 変更確認方法

1. `feature/display-under-review-by-whom`をローカルに取り込む
2. bin/rails sでローカル環境を立ち上げる
3. ID`hajime`でログインして http://localhost:3000/practices/198065840 から提出物を作成
4. ID`machida`でログインして上記で作成した提出物の担当になる
5. 再度 ID`hajime`でログイン。以下の三つのページでレビュー中と担当者アイコンが表示されているか確認する。
自分の提出物一覧（ http://localhost:3000/current_user/products ）
プラクティスの提出物一覧（ http://localhost:3000/practices/198065840/products ）
提出物詳細（ http://localhost:3000/products/1071056613 ）
 
## Screenshot

### 変更前
<img width="1352" alt="image" src="https://github.com/fjordllc/bootcamp/assets/83024928/85a7b6b1-166b-4c37-8aee-ba71a4ac47b9">
<img width="1354" alt="image" src="https://github.com/fjordllc/bootcamp/assets/83024928/8f6b0f91-ffcf-4df3-88ab-4dfa76895a8c">
<img width="1357" alt="image" src="https://github.com/fjordllc/bootcamp/assets/83024928/c3b799a5-f790-4793-b66b-9d6c001885dc">

### 変更後
<img width="1350" alt="image" src="https://github.com/fjordllc/bootcamp/assets/83024928/349d8e57-dd1b-41dc-abca-6f5df4331b32">
<img width="1353" alt="image" src="https://github.com/fjordllc/bootcamp/assets/83024928/4f69e66c-42fd-482d-a1e7-0ccf8da1e997">
<img width="1346" alt="image" src="https://github.com/fjordllc/bootcamp/assets/83024928/a0164490-a4f3-4e2e-88f4-907f317a4917">