### PR TITLE
ダッシュボードの最新のお知らせ一覧に投稿者名を表示したい。

### DIFF
--- a/app/views/home/_announcement.html.slim
+++ b/app/views/home/_announcement.html.slim
@@ -12,5 +12,8 @@
         .card-list-item-meta
           .card-list-item-meta__items
             .card-list-item-meta__item
+              = link_to announcement.user, class: 'a-user-name' do
+                = announcement.user.long_name
+            .card-list-item-meta__item
               time.a-meta(datetime="#{announcement.published_at.to_datetime}" pubdate='pubdate')
                 = l announcement.published_at


### PR DESCRIPTION
## Issue

- #6322

## 概要

ダッシュボードの最新のお知らせに、投稿者名が表示されるようにしました。

## 変更確認方法

1. feature/display-username-in-latest-announcementsをローカルに取り込む
2. bin/rails sでローカル環境を立ち上げる
3. localhost:3000にアクセス
4. ユーザー名 : komagata でログイン
5. 最新のお知らせで投稿者名が表示されていることを確認する。
<img width="993" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/b52e4bed-5529-4cbf-8c64-ecc4311380d9">

<img width="399" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/f02493bc-6de4-4763-b69c-1cb33f6c7c0c">


## Screenshot

### 変更前
<img width="445" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/c0c120ce-525e-4195-83da-51693b63d142">

### 変更後
<img width="399" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/7d244917-cf13-4356-a82d-99292a2bb1a0">
