### PR TITLE
ファイル選択ダイアログから画像を添付する機能を追加

### DIFF
--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -85,16 +85,22 @@
         .a-markdown-input.js-markdown-parent
           .a-markdown-input__inner.js-tabs__content(
             v-bind:class='{ "is-active": isActive("answer") }')
-            textarea.a-text-input.a-markdown-input__textarea(
-              v-model='description',
-              :id='`js-comment-${this.answer.id}`',
-              :data-preview='`#js-comment-preview-${this.answer.id}`',
-            :data-input='`.js-comment-file-input-${this.answer.id}`',
-              name='answer[description]')
-          input(
-            :class='`js-comment-file-input-${this.answer.id}`',
-            type='file',
-            multiple)
+          .form-textarea
+            .form-textarea__body
+                textarea.a-text-input.a-markdown-input__textarea(
+                v-model='description',
+                :id='`js-comment-${this.answer.id}`',
+                :data-preview='`#js-comment-preview-${this.answer.id}`',
+              :data-input='`.js-comment-file-input-${this.answer.id}`',
+                name='answer[description]')
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input(
+                    :class='`js-comment-file-input-${this.answer.id}`',
+                    type='file',
+                    multiple)
           .a-markdown-input__inner.js-tabs__content(
             v-bind:class='{ "is-active": isActive("preview") }')
             .js-preview.a-long-text.is-md.a-markdown-input__preview(

--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -87,11 +87,11 @@
             v-bind:class='{ "is-active": isActive("answer") }')
           .form-textarea
             .form-textarea__body
-                textarea.a-text-input.a-markdown-input__textarea(
+              textarea.a-text-input.a-markdown-input__textarea(
                 v-model='description',
                 :id='`js-comment-${this.answer.id}`',
                 :data-preview='`#js-comment-preview-${this.answer.id}`',
-              :data-input='`.js-comment-file-input-${this.answer.id}`',
+                :data-input='`.js-comment-file-input-${this.answer.id}`',
                 name='answer[description]')
             .form-textarea__footer
               .form-textarea__insert

--- a/app/javascript/answer.vue
+++ b/app/javascript/answer.vue
@@ -89,7 +89,12 @@
               v-model='description',
               :id='`js-comment-${this.answer.id}`',
               :data-preview='`#js-comment-preview-${this.answer.id}`',
+            :data-input='`.js-comment-file-input-${this.answer.id}`',
               name='answer[description]')
+          input(
+            :class='`js-comment-file-input-${this.answer.id}`',
+            type='file',
+            multiple)
           .a-markdown-input__inner.js-tabs__content(
             v-bind:class='{ "is-active": isActive("preview") }')
             .js-preview.a-long-text.is-md.a-markdown-input__preview(

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -37,13 +37,19 @@
         .a-markdown-input.js-markdown-parent
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("answer") }')
-            textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
-              v-model='description',
-              name='answer[description]',
-              data-preview='#new-comment-preview',
-            data-input='.new-comment-file-input',
-              @input='editAnswer')
-          input.new-comment-file-input(type='file', multiple)
+          .form-textarea
+            .form-textarea__body
+                textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
+                v-model='description',
+                name='answer[description]',
+                data-preview='#new-comment-preview',
+              data-input='.new-comment-file-input',
+                @input='editAnswer')
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input.new-comment-file-input(type='file', multiple)
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("preview") }')
             #new-comment-preview.a-long-text.is-md.a-markdown-input__preview

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -41,7 +41,9 @@
               v-model='description',
               name='answer[description]',
               data-preview='#new-comment-preview',
+            data-input='.new-comment-file-input',
               @input='editAnswer')
+          input(type='file' class='new-comment-file-input' multiple)
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("preview") }')
             #new-comment-preview.a-long-text.is-md.a-markdown-input__preview

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -43,7 +43,7 @@
               data-preview='#new-comment-preview',
             data-input='.new-comment-file-input',
               @input='editAnswer')
-          input(type='file' class='new-comment-file-input' multiple)
+          input.new-comment-file-input(type='file', multiple)
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("preview") }')
             #new-comment-preview.a-long-text.is-md.a-markdown-input__preview

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -37,19 +37,19 @@
         .a-markdown-input.js-markdown-parent
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("answer") }')
-          .form-textarea
-            .form-textarea__body
-              textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
-                v-model='description',
-                name='answer[description]',
-                data-preview='#new-comment-preview',
-                data-input='.new-comment-file-input',
-                @input='editAnswer')
-            .form-textarea__footer
-              .form-textarea__insert
-                label.a-file-insert.a-button.is-sm.is-secondary.is-block
-                  | ファイルを挿入
-                  input.new-comment-file-input(type='file', multiple)
+            .form-textarea
+              .form-textarea__body
+                textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
+                  v-model='description',
+                  name='answer[description]',
+                  data-preview='#new-comment-preview',
+                  data-input='.new-comment-file-input',
+                  @input='editAnswer')
+              .form-textarea__footer
+                .form-textarea__insert
+                  label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                    | ファイルを挿入
+                    input.new-comment-file-input(type='file', multiple)
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("preview") }')
             #new-comment-preview.a-long-text.is-md.a-markdown-input__preview

--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -39,11 +39,11 @@
             :class='{ "is-active": isActive("answer") }')
           .form-textarea
             .form-textarea__body
-                textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
+              textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
                 v-model='description',
                 name='answer[description]',
                 data-preview='#new-comment-preview',
-              data-input='.new-comment-file-input',
+                data-input='.new-comment-file-input',
                 @input='editAnswer')
             .form-textarea__footer
               .form-textarea__insert

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -69,8 +69,13 @@
             textarea.a-text-input.a-markdown-input__textarea(
               :id='`js-comment-${this.comment.id}`',
               :data-preview='`#js-comment-preview-${this.comment.id}`',
+            :data-input='`.js-comment-file-input-${this.comment.id}`',
               v-model='description',
               name='comment[description]')
+          input(
+            :class='`js-comment-file-input-${this.comment.id}`',
+            type='file',
+            multiple)
           .a-markdown-input__inner.js-tabs__content(
             v-bind:class='{ "is-active": isActive("preview") }')
             .a-long-text.is-md.a-markdown-input__preview(

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -66,16 +66,22 @@
         .a-markdown-input.js-markdown-parent
           .a-markdown-input__inner.js-tabs__content(
             v-bind:class='{ "is-active": isActive("comment") }')
-            textarea.a-text-input.a-markdown-input__textarea(
-              :id='`js-comment-${this.comment.id}`',
-              :data-preview='`#js-comment-preview-${this.comment.id}`',
-            :data-input='`.js-comment-file-input-${this.comment.id}`',
-              v-model='description',
-              name='comment[description]')
-          input(
-            :class='`js-comment-file-input-${this.comment.id}`',
-            type='file',
-            multiple)
+          .form-textarea
+            .form-textarea__body
+                textarea.a-text-input.a-markdown-input__textarea(
+                  :id='`js-comment-${this.comment.id}`',
+                  :data-preview='`#js-comment-preview-${this.comment.id}`',
+                :data-input='`.js-comment-file-input-${this.comment.id}`',
+                  v-model='description',
+                  name='comment[description]')
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input(
+                    :class='`js-comment-file-input-${this.comment.id}`',
+                    type='file',
+                    multiple)
           .a-markdown-input__inner.js-tabs__content(
             v-bind:class='{ "is-active": isActive("preview") }')
             .a-long-text.is-md.a-markdown-input__preview(

--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -66,22 +66,22 @@
         .a-markdown-input.js-markdown-parent
           .a-markdown-input__inner.js-tabs__content(
             v-bind:class='{ "is-active": isActive("comment") }')
-          .form-textarea
-            .form-textarea__body
+            .form-textarea
+              .form-textarea__body
                 textarea.a-text-input.a-markdown-input__textarea(
                   :id='`js-comment-${this.comment.id}`',
                   :data-preview='`#js-comment-preview-${this.comment.id}`',
-                :data-input='`.js-comment-file-input-${this.comment.id}`',
+                  :data-input='`.js-comment-file-input-${this.comment.id}`',
                   v-model='description',
                   name='comment[description]')
-            .form-textarea__footer
-              .form-textarea__insert
-                label.a-file-insert.a-button.is-sm.is-secondary.is-block
-                  | ファイルを挿入
-                  input(
-                    :class='`js-comment-file-input-${this.comment.id}`',
-                    type='file',
-                    multiple)
+              .form-textarea__footer
+                .form-textarea__insert
+                  label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                    | ファイルを挿入
+                    input(
+                      :class='`js-comment-file-input-${this.comment.id}`',
+                      type='file',
+                      multiple)
           .a-markdown-input__inner.js-tabs__content(
             v-bind:class='{ "is-active": isActive("preview") }')
             .a-long-text.is-md.a-markdown-input__preview(

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -54,7 +54,7 @@
               data-preview='#new-comment-preview',
             data-input='.new-comment-file-input',
               @input='editComment')
-        input(type='file' class='new-comment-file-input' multiple)
+        input.new-comment-file-input(type='file', multiple)
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("preview") }')
             #new-comment-preview.a-long-text.is-md.a-markdown-input__preview

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -48,13 +48,19 @@
         .a-markdown-input.js-markdown-parent
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("comment") }')
-            textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
-              v-model='description',
-              name='new_comment[description]',
-              data-preview='#new-comment-preview',
-            data-input='.new-comment-file-input',
-              @input='editComment')
-        input.new-comment-file-input(type='file', multiple)
+          .form-textarea
+            .form-textarea__body
+                textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
+                v-model='description',
+                name='new_comment[description]',
+                data-preview='#new-comment-preview',
+              data-input='.new-comment-file-input',
+                @input='editComment')
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input.new-comment-file-input(type='file', multiple)
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("preview") }')
             #new-comment-preview.a-long-text.is-md.a-markdown-input__preview

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -48,19 +48,19 @@
         .a-markdown-input.js-markdown-parent
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("comment") }')
-          .form-textarea
-            .form-textarea__body
-              textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
-                v-model='description',
-                name='new_comment[description]',
-                data-preview='#new-comment-preview',
-                data-input='.new-comment-file-input',
-                @input='editComment')
-            .form-textarea__footer
-              .form-textarea__insert
-                label.a-file-insert.a-button.is-sm.is-secondary.is-block
-                  | ファイルを挿入
-                  input.new-comment-file-input(type='file', multiple)
+            .form-textarea
+              .form-textarea__body
+                textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
+                  v-model='description',
+                  name='new_comment[description]',
+                  data-preview='#new-comment-preview',
+                  data-input='.new-comment-file-input',
+                  @input='editComment')
+              .form-textarea__footer
+                .form-textarea__insert
+                  label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                    | ファイルを挿入
+                    input.new-comment-file-input(type='file', multiple)
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("preview") }')
             #new-comment-preview.a-long-text.is-md.a-markdown-input__preview

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -50,11 +50,11 @@
             :class='{ "is-active": isActive("comment") }')
           .form-textarea
             .form-textarea__body
-                textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
+              textarea#js-new-comment.a-text-input.js-warning-form.a-markdown-input__textarea(
                 v-model='description',
                 name='new_comment[description]',
                 data-preview='#new-comment-preview',
-              data-input='.new-comment-file-input',
+                data-input='.new-comment-file-input',
                 @input='editComment')
             .form-textarea__footer
               .form-textarea__insert

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -52,7 +52,9 @@
               v-model='description',
               name='new_comment[description]',
               data-preview='#new-comment-preview',
+            data-input='.new-comment-file-input',
               @input='editComment')
+        input(type='file' class='new-comment-file-input' multiple)
           .a-markdown-input__inner.js-tabs__content(
             :class='{ "is-active": isActive("preview") }')
             #new-comment-preview.a-long-text.is-md.a-markdown-input__preview

--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -150,7 +150,9 @@
                 textarea#js-question-content.a-text-input.form-tabs-item__textarea(
                   v-model='edited.description',
                   data-preview='#js-question-preview',
+                  data-input='.js-question-file-input',
                   name='question[description]')
+                input(type='file' class='js-question-file-input' multiple)
               .form-tabs-item__markdown.js-tabs__content(
                 :class='{ "is-active": isActive("preview") }')
                 #js-question-preview.js-preview.a-long-text.is-md.form-tabs-item__preview

--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -158,9 +158,7 @@
                     .form-textarea__insert
                       label.a-file-insert.a-button.is-sm.is-secondary.is-block
                         | ファイルを挿入
-                        input.js-question-file-input(
-                        type='file',
-                        multiple)
+                        input.js-question-file-input(type='file', multiple)
               .form-tabs-item__markdown.js-tabs__content(
                 :class='{ "is-active": isActive("preview") }')
                 #js-question-preview.js-preview.a-long-text.is-md.form-tabs-item__preview

--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -152,7 +152,7 @@
                   data-preview='#js-question-preview',
                   data-input='.js-question-file-input',
                   name='question[description]')
-                input(type='file' class='js-question-file-input' multiple)
+                input.js-question-file-input(type='file', multiple)
               .form-tabs-item__markdown.js-tabs__content(
                 :class='{ "is-active": isActive("preview") }')
                 #js-question-preview.js-preview.a-long-text.is-md.form-tabs-item__preview

--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -144,15 +144,23 @@
                 :class='{ "is-active": isActive("preview") }',
                 @click='changeActiveTab("preview")')
                 | プレビュー
-            .form-tabs-item__markdown-parent.js-markdown-parent
-              .form-tabs-item__markdown.js-tabs__content(
-                :class='{ "is-active": isActive("question") }')
-                textarea#js-question-content.a-text-input.form-tabs-item__textarea(
-                  v-model='edited.description',
-                  data-preview='#js-question-preview',
-                  data-input='.js-question-file-input',
-                  name='question[description]')
-                input.js-question-file-input(type='file', multiple)
+            .a-markdown-parent.js-markdown-parent
+              .a-markdown-input__inner.js-tabs__content(
+                v-bind:class='{ "is-active": isActive("question") }')
+                .form-textarea
+                  .form-textarea__body
+                    textarea#js-question-content.a-text-input.form-tabs-item__textarea(
+                      v-model='edited.description',
+                      data-preview='#js-question-preview',
+                      data-input='.js-question-file-input',
+                      name='question[description]')
+                  .form-textarea__footer
+                    .form-textarea__insert
+                      label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                        | ファイルを挿入
+                        input.js-question-file-input(
+                        type='file',
+                        multiple)
               .form-tabs-item__markdown.js-tabs__content(
                 :class='{ "is-active": isActive("preview") }')
                 #js-question-preview.js-preview.a-long-text.is-md.form-tabs-item__preview

--- a/app/javascript/stylesheets/_common-imports.sass
+++ b/app/javascript/stylesheets/_common-imports.sass
@@ -111,7 +111,6 @@
 @import "atoms/a-text-input"
 @import "atoms/a-text-link"
 @import "atoms/a-text"
-@import "atoms/a-textarea-bottom-note"
 @import "atoms/a-title-label"
 @import "atoms/a-user-icon"
 @import "atoms/a-user-icons"
@@ -121,6 +120,7 @@
 @import "atoms/a-watch-button"
 @import "atoms/a-welcome-button"
 @import "atoms/a-checker"
+@import "atoms/a-file-insert"
 
 ////////////
 // layouts

--- a/app/javascript/stylesheets/application.sass
+++ b/app/javascript/stylesheets/application.sass
@@ -53,6 +53,7 @@
 @import application/blocks/form/memo
 @import application/blocks/form/radios
 @import application/blocks/form/vue-tags-input
+@import application/blocks/form/form-textarea
 
 @import application/blocks/header/header-current-user
 @import application/blocks/header/header-dropdown

--- a/app/javascript/stylesheets/application/blocks/form/_form-textarea.sass
+++ b/app/javascript/stylesheets/application/blocks/form/_form-textarea.sass
@@ -1,0 +1,32 @@
+.form-textarea
+  +position(relative)
+  textarea.a-text-input
+    padding-bottom: 6.25rem
+
++media-breakpoint-down(md)
+  .form-textarea__bottom-note
+    display: none
+
++media-breakpoint-up(lg)
+  .form-textarea__bottom-note
+    +text-block(.75rem 1.4, center)
+
+.form-textarea__footer
+  height: 2.5rem
+  display: flex
+  gap: 1rem
+  align-items: center
+  background-color: $background-semi-shade
+  +position(absolute, left 1px, bottom 1px, right 1px)
+  +border-radius(bottom, 3px)
+  +padding(horizontal, .5rem)
+  border-top: solid 1px $border-shade
+
+.form-textarea__insert
+  width: 8rem
+
+.form-textarea__bottom-note
+  +media-breakpoint-down(md)
+    display: none
+  +media-breakpoint-up(lg)
+    +text-block(.75rem 1.4, center)

--- a/app/javascript/stylesheets/application/blocks/form/_form-textarea.sass
+++ b/app/javascript/stylesheets/application/blocks/form/_form-textarea.sass
@@ -16,7 +16,7 @@
   display: flex
   gap: 1rem
   align-items: center
-  background-color: $background-semi-shade
+  background-color: $background
   +position(absolute, left 1px, bottom 1px, right 1px)
   +border-radius(bottom, 3px)
   +padding(horizontal, .5rem)

--- a/app/javascript/stylesheets/atoms/_a-file-insert.sass
+++ b/app/javascript/stylesheets/atoms/_a-file-insert.sass
@@ -1,0 +1,5 @@
+.a-file-insert
+  cursor: pointer
+  input
+    +position(absolute, left 0, top 0)
+    +size(0)

--- a/app/javascript/stylesheets/atoms/_a-form-tabs.sass
+++ b/app/javascript/stylesheets/atoms/_a-form-tabs.sass
@@ -4,6 +4,7 @@
   border-bottom: solid 1px var(--border-shade)
   margin-bottom: 1rem
   padding: .5rem .75rem 0
+  border-radius: .1875rem .1875rem 0 0
 
 .a-form-tabs__tab
   +size(6.5rem 2.5rem)

--- a/app/javascript/stylesheets/atoms/_a-markdown-input.sass
+++ b/app/javascript/stylesheets/atoms/_a-markdown-input.sass
@@ -20,4 +20,4 @@
   background-color: var(--base)
   +text-block(.875rem 1.8)
   border-radius: .25rem
-  min-height: 6rem
+  min-height: 9.5rem

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -13,7 +13,9 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+          input(type='file' class='file-input' multiple)
+          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+          data: { 'preview': '.js-preview', 'input': '.file-input' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -13,9 +13,17 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          input(type='file' class='file-input' multiple)
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
-          data: { 'preview': '.js-preview', 'input': '.file-input' }
+          .form-textarea
+            .form-textarea__body
+              = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+              data: { 'preview': '.js-preview', 'input': '.file-input' }
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input(type='file' class='file-input' multiple)
+              .form-textarea__bottom-note
+                | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -37,7 +37,9 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+          input(type='file' class='file-input' multiple)
+          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+          data: { 'preview': '.js-preview', 'input': '.file-input' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -37,9 +37,17 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          input(type='file' class='file-input' multiple)
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
-          data: { 'preview': '.js-preview', 'input': '.file-input' }
+          .form-textarea
+            .form-textarea__body
+              = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+              data: { 'preview': '.js-preview', 'input': '.file-input' }
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input(type='file' class='file-input' multiple)
+              .form-textarea__bottom-note
+                | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -22,7 +22,9 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :body, class: 'a-form-label'
-          = f.text_area :body, class: 'a-text-input js-warning-form markdown-form__text-area js-markdown', data: { 'preview': '.js-preview' }
+          input(type='file' class='file-input' multiple)
+          = f.text_area :body, class: 'a-text-input js-warning-form markdown-form__text-area js-markdown',
+          data: { 'preview': '.js-preview', 'input': '.file-input' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -22,9 +22,17 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :body, class: 'a-form-label'
-          input(type='file' class='file-input' multiple)
-          = f.text_area :body, class: 'a-text-input js-warning-form markdown-form__text-area js-markdown',
-          data: { 'preview': '.js-preview', 'input': '.file-input' }
+          .form-textarea
+            .form-textarea__body
+              = f.text_area :body, class: 'a-text-input js-warning-form markdown-form__text-area js-markdown',
+              data: { 'preview': '.js-preview', 'input': '.file-input' }
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input(type='file' class='file-input' multiple)
+              .form-textarea__bottom-note
+                | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -7,7 +7,9 @@
         .col-md-6.col-xs-12
           label.a-form-label
             | 提出物
-          = f.text_area :body, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+          input(type='file' class='file-input' multiple)
+          = f.text_area :body, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+          data: { 'preview': '.js-preview', 'input': '.file-input' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -7,9 +7,17 @@
         .col-md-6.col-xs-12
           label.a-form-label
             | 提出物
-          input(type='file' class='file-input' multiple)
-          = f.text_area :body, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
-          data: { 'preview': '.js-preview', 'input': '.file-input' }
+          .form-textarea
+            .form-textarea__body
+              = f.text_area :body, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+              data: { 'preview': '.js-preview', 'input': '.file-input' }
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input(type='file' class='file-input' multiple)
+              .form-textarea__bottom-note
+                | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -19,7 +19,9 @@
         .row.js-markdown-parent
           .col-md-6.col-xs-12
             = f.label :description, class: 'a-form-label'
-            = f.text_area :description, class: 'a-text-input markdown-form__text-area js-markdown js-warning-form', data: { 'preview': '.js-preview' }
+            input(type='file' class='file-input' multiple)
+            = f.text_area :description, class: 'a-text-input markdown-form__text-area js-markdown js-warning-form',
+            data: { 'preview': '.js-preview', 'input': '.file-input' }
           .col-md-6.col-xs-12
             .a-form-label
               | プレビュー

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -19,9 +19,17 @@
         .row.js-markdown-parent
           .col-md-6.col-xs-12
             = f.label :description, class: 'a-form-label'
-            input(type='file' class='file-input' multiple)
-            = f.text_area :description, class: 'a-text-input markdown-form__text-area js-markdown js-warning-form',
-            data: { 'preview': '.js-preview', 'input': '.file-input' }
+            .form-textarea
+              .form-textarea__body
+                = f.text_area :description, class: 'a-text-input markdown-form__text-area js-markdown js-warning-form',
+                data: { 'preview': '.js-preview', 'input': '.file-input' }
+              .form-textarea__footer
+                .form-textarea__insert
+                  label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                    | ファイルを挿入
+                    input(type='file' class='file-input' multiple)
+                .form-textarea__bottom-note
+                  | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
           .col-md-6.col-xs-12
             .a-form-label
               | プレビュー

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -51,7 +51,9 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area', data: { 'preview': '.js-preview' }
+          input(type='file' class='file-input' multiple)
+          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+          data: { 'preview': '.js-preview', 'input': '.file-input' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -8,7 +8,6 @@
       .form-item
         = f.label :organizer, class: 'a-form-label'
         = f.select(:user_ids, users_name, { include_hidden: false }, { multiple: true, id: 'js-choices-multiple-select' })
-      / TODO 定期開催日のCSSは機能追加が完了してから対応する
       .form-item
         label.a-form-label
           | カテゴリー
@@ -51,9 +50,17 @@
       .row.js-markdown-parent
         .col-md-6.col-xs-12
           = f.label :description, class: 'a-form-label'
-          input(type='file' class='file-input' multiple)
-          = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
-          data: { 'preview': '.js-preview', 'input': '.file-input' }
+          .form-textarea
+            .form-textarea__body
+              = f.text_area :description, class: 'a-text-input js-warning-form js-markdown markdown-form__text-area',
+              data: { 'preview': '.js-preview', 'input': '.file-input' }
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input(type='file' class='file-input' multiple)
+              .form-textarea__bottom-note
+                | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -72,9 +72,10 @@
               template-id="#{current_user.report_template&.id}"
             )
           .a-textarea-bottom-note
+            input(type='file' class='file-input' multiple)
             = f.text_area :description,
               class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
-              data: { 'preview': '.js-preview' }
+              data: { 'preview': '.js-preview', 'input': '.file-input' }
             .a-textarea-bottom-note__banner
               | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
         .col-md-6.col-xs-12

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -71,13 +71,18 @@
               template-description="#{current_user.report_template&.description}"
               template-id="#{current_user.report_template&.id}"
             )
-          .a-textarea-bottom-note
-            input(type='file' class='file-input' multiple)
-            = f.text_area :description,
-              class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
-              data: { 'preview': '.js-preview', 'input': '.file-input' }
-            .a-textarea-bottom-note__banner
-              | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
+          .form-textarea
+            .form-textarea__body
+              = f.text_area :description,
+                class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
+                data: { 'preview': '.js-preview', 'input': '.file-input' }
+            .form-textarea__footer
+              .form-textarea__insert
+                label.a-file-insert.a-button.is-sm.is-secondary.is-block
+                  | ファイルを挿入
+                  input(type='file' class='file-input' multiple)
+              .form-textarea__bottom-note
+                | 途中保存は「#{request.os == 'Mac OSX' ? 'command + s' : 'Ctrl + s'}」 マメに保存しよう。
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "^1.3.12",
+    "textarea-markdown": "https://github.com/YukiWatanabe824/textarea-markdown.git#main",
     "tributejs": "^5.1.3",
     "vue": "^2.6.10",
     "vue-loader": "^15.9.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "^1.3.2",
+    "textarea-markdown": "^1.3.12",
     "tributejs": "^5.1.3",
     "vue": "^2.6.10",
     "vue-loader": "^15.9.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "https://github.com/YukiWatanabe824/textarea-markdown.git#main",
+    "textarea-markdown": "https://github.com/komagata/textarea-markdown.git#main",
     "tributejs": "^5.1.3",
     "vue": "^2.6.10",
     "vue-loader": "^15.9.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "https://github.com/komagata/textarea-markdown.git#main",
+    "textarea-markdown": "^1.4.0",
     "tributejs": "^5.1.3",
     "vue": "^2.6.10",
     "vue-loader": "^15.9.6",

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -265,6 +265,6 @@ class AnnouncementsTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.file-input', visible: false
     end
-    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -259,4 +259,12 @@ class AnnouncementsTest < ApplicationSystemTestCase
     click_button 'WIP'
     assert_text '別の人がお知らせを更新していたので更新できませんでした。'
   end
+
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth new_announcement_path, 'komagata'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.file-input', visible: false
+    end
+    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+  end
 end

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -126,7 +126,7 @@ class AnswersTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.new-comment-file-input', visible: false
     end
-    assert_equal '.new-comment-file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.new-comment-file-input', find('textarea.a-text-input')['data-input']
   end
 
   test 'using file uploading by file selection dialogue in answers textarea' do
@@ -143,7 +143,7 @@ class AnswersTest < ApplicationSystemTestCase
 
     test_target_textarea = page.all('.form-textarea__body')[0]
     within test_target_textarea do
-    assert_equal ".js-comment-file-input-#{answers(:answer1).id}", find("textarea.a-text-input")["data-input"]
+      assert_equal ".js-comment-file-input-#{answers(:answer1).id}", find('textarea.a-text-input')['data-input']
     end
   end
 end

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -120,4 +120,30 @@ class AnswersTest < ApplicationSystemTestCase
     assert_text 'test'
     assert_equal '2.png', File.basename(find('img.thread-comment__company-logo')['src'])
   end
+
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth "/questions/#{questions(:question2).id}", 'senpai'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.new-comment-file-input', visible: false
+    end
+    assert_equal '.new-comment-file-input', find("textarea.a-text-input")["data-input"]
+  end
+
+  test 'using file uploading by file selection dialogue in answers textarea' do
+    visit_with_auth "/questions/#{questions(:question1).id}", 'komagata'
+    assert_text 'atom一択です！'
+    answer_by_user = page.all('.thread-comment')[0]
+    within answer_by_user do
+      click_button '内容修正'
+    end
+    test_target_label = page.all('.a-file-insert')[0]
+    within test_target_label do
+      assert_selector "input.js-comment-file-input-#{answers(:answer1).id}", visible: false
+    end
+
+    test_target_textarea = page.all('.form-textarea__body')[0]
+    within test_target_textarea do
+    assert_equal ".js-comment-file-input-#{answers(:answer1).id}", find("textarea.a-text-input")["data-input"]
+    end
+  end
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -344,6 +344,6 @@ class CommentsTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.new-comment-file-input', visible: false
     end
-    assert_equal '.new-comment-file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.new-comment-file-input', find('textarea.a-text-input')['data-input']
   end
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -338,4 +338,12 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text 'test'
     assert_equal '2.png', File.basename(find('img.thread-comment__company-logo')['src'])
   end
+
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth "/reports/#{reports(:report1).id}", 'senpai'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.new-comment-file-input', visible: false
+    end
+    assert_equal '.new-comment-file-input', find("textarea.a-text-input")["data-input"]
+  end
 end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -393,7 +393,7 @@ class EventsTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.file-input', visible: false
     end
-    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 
   test 'When signing up for an event during Watch, Watch is not registered twice' do

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -388,6 +388,14 @@ class EventsTest < ApplicationSystemTestCase
     assert_equal find('#event_open_end_at').value, '2050-12-24T23:59'
   end
 
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth new_event_path, 'komagata'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.file-input', visible: false
+    end
+    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+  end
+
   test 'When signing up for an event during Watch, Watch is not registered twice' do
     visit_with_auth event_path(events(:event2)), 'komagata'
     find('#watch-button').click

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -262,4 +262,12 @@ class PagesTest < ApplicationSystemTestCase
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end
+
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth new_page_path, 'komagata'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.file-input', visible: false
+    end
+    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+  end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -268,6 +268,6 @@ class PagesTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.file-input', visible: false
     end
-    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -589,4 +589,12 @@ class ProductsTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{products(:product13).id}", 'mentormentaro'
     assert_selector 'img[class="page-content-header__company-logo"]'
   end
+
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth "/products/new?practice_id=#{practices(:practice6).id}", 'mentormentaro'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.file-input', visible: false
+    end
+    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+  end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -595,6 +595,6 @@ class ProductsTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.file-input', visible: false
     end
-    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -511,7 +511,7 @@ class QuestionsTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.file-input', visible: false
     end
-    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 
   test 'using file uploading by file selection dialogue in textarea at editing question' do
@@ -523,6 +523,6 @@ class QuestionsTest < ApplicationSystemTestCase
     within element do
       assert_selector 'input.js-question-file-input', visible: false
     end
-    assert_equal '.js-question-file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.js-question-file-input', find('textarea.a-text-input')['data-input']
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -505,4 +505,24 @@ class QuestionsTest < ApplicationSystemTestCase
       assert_no_text 'wipテスト用の質問(wip中)'
     end
   end
+
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth new_question_path, 'kimura'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.file-input', visible: false
+    end
+    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+  end
+
+  test 'using file uploading by file selection dialogue in textarea at editing question' do
+    question = questions(:question3)
+    visit_with_auth "/questions/#{question.id}", 'komagata'
+    click_button '内容修正'
+
+    element = first('.a-file-insert')
+    within element do
+      assert_selector 'input.js-question-file-input', visible: false
+    end
+    assert_equal '.js-question-file-input', find("textarea.a-text-input")["data-input"]
+  end
 end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -201,4 +201,12 @@ class RegularEventsTest < ApplicationSystemTestCase
     assert_text 'Watch中'
     assert_text 'この定期イベントは全員参加のため参加登録は不要です。'
   end
+
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth new_regular_event_path, 'komagata'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.file-input', visible: false
+    end
+    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+  end
 end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -207,6 +207,6 @@ class RegularEventsTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.file-input', visible: false
     end
-    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -696,6 +696,6 @@ class ReportsTest < ApplicationSystemTestCase
     within(:css, '.a-file-insert') do
       assert_selector 'input.file-input', visible: false
     end
-    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+    assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -690,4 +690,12 @@ class ReportsTest < ApplicationSystemTestCase
 
     assert_text '研修生の日報'
   end
+
+  test 'using file uploading by file selection dialogue in textarea' do
+    visit_with_auth '/reports/new', 'kensyu'
+    within(:css, '.a-file-insert') do
+      assert_selector 'input.file-input', visible: false
+    end
+    assert_equal '.file-input', find("textarea.a-text-input")["data-input"]
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -8693,9 +8693,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-"textarea-markdown@https://github.com/komagata/textarea-markdown.git#main":
-  version "1.3.12"
-  resolved "https://github.com/komagata/textarea-markdown.git#32ff245fe72b73271fad8a32501691e77a9b0fcf"
+textarea-markdown@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.4.0.tgz#711ad85b630667d4187825f32d89c03fe2f86f73"
+  integrity sha512-SyNC3iYA00VaZ5h+7RYHmWMqQJY6dgTpoPiW+J61wTQV+83306ASL8MFxIH1Hr+nxTgCF5XptEscl2Lx4kd9zw==
   dependencies:
     file-type "^16.5.4"
     filesize "^10.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8693,10 +8693,9 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-textarea-markdown@^1.3.12:
+"textarea-markdown@https://github.com/YukiWatanabe824/textarea-markdown.git#main":
   version "1.3.12"
-  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.3.12.tgz#c2d46638400675b5af6e883aa4732d04d21e20b4"
-  integrity sha512-4rIjkas/9Ypp5+Dc/qPGrIbE9SK8zuB6cZeyEEDrF23idE3tfmn1CBcvBe8AeM4Rm6g3KiQoknsqhpPNH3kFeA==
+  resolved "https://github.com/YukiWatanabe824/textarea-markdown.git#e96f2c8f0d224827015798212421efca4eb0d846"
   dependencies:
     file-type "^16.5.4"
     filesize "^10.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3859,9 +3859,9 @@ file-uri-to-path@1.0.0:
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filesize@^10.0.5:
-  version "10.0.5"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-10.0.5.tgz#d77553eb00a525f4cc7983047d2197cda6fff321"
-  integrity sha512-qrzyt8gLh86nsyYiC3ibI5KyIYRCWg2yqIklYrWF4a0qNfekik4OQfn7AoPJG2hRrPMSlH6fET4VEITweZAzjA==
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-10.0.7.tgz#2237a816ee60a83fd0c3382ae70800e54eced3ad"
+  integrity sha512-iMRG7Qo9nayLoU3PNCiLizYtsy4W1ClrapeCwEgtiQelOAOuRJiw4QaLI+sSr8xr901dgHv+EYP2bCusGZgoiA==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -8693,9 +8693,9 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-"textarea-markdown@https://github.com/YukiWatanabe824/textarea-markdown.git#main":
+"textarea-markdown@https://github.com/komagata/textarea-markdown.git#main":
   version "1.3.12"
-  resolved "https://github.com/YukiWatanabe824/textarea-markdown.git#e96f2c8f0d224827015798212421efca4eb0d846"
+  resolved "https://github.com/komagata/textarea-markdown.git#32ff245fe72b73271fad8a32501691e77a9b0fcf"
   dependencies:
     file-type "^16.5.4"
     filesize "^10.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1280,6 +1280,11 @@
     escape-string-regexp "^5.0.0"
     lodash.deburr "^4.1.0"
 
+"@tokenizer/token@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
+  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
+
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -3839,6 +3844,15 @@ file-loader@^6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+file-type@^16.5.4:
+  version "16.5.4"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.4.tgz#474fb4f704bee427681f98dd390058a172a6c2fd"
+  integrity sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "^6.2.4"
+    token-types "^4.1.1"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -4434,7 +4448,7 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
-ieee754@^1.1.4:
+ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -5226,11 +5240,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-magic-bytes.js@^1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/magic-bytes.js/-/magic-bytes.js-1.0.13.tgz#b8e72e7c78900bf7be8647bb71098d4371b3c818"
-  integrity sha512-DiI8gdaLxnO4+H0WglSlDSCIQRff1L42ZhOVTuAbb0uwCFIVLM3J28oQ4XMX6LJmFTiqMV/ejYV8bc/eewwdmQ==
 
 make-dir@^2.0.0:
   version "2.1.0"
@@ -6142,6 +6151,11 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+peek-readable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.1.0.tgz#4ece1111bf5c2ad8867c314c81356847e8a62e72"
+  integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
 
 picocolors@^0.2.1:
   version "0.2.1"
@@ -7598,6 +7612,13 @@ readable-stream@^3.0.6, readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-web-to-node-stream@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
+  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
+  dependencies:
+    readable-stream "^3.6.0"
+
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -8481,6 +8502,14 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strtok3@^6.2.4:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.3.0.tgz#358b80ffe6d5d5620e19a073aa78ce947a90f9a0"
+  integrity sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    peek-readable "^4.1.0"
+
 style-loader@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e"
@@ -8664,13 +8693,13 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-textarea-markdown@^1.3.2:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.3.3.tgz#ee4a77715948286e3b80d5d56e1fe4f11c9cc3ff"
-  integrity sha512-Ni3q6svvN0XwHFbNesPcCAUNuzV69lcdTJ3S4BYxoR2/P80KtLdYdFmNalpt8pEi2+s6L43rxEuPBgltqHJY6Q==
+textarea-markdown@^1.3.12:
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.3.12.tgz#c2d46638400675b5af6e883aa4732d04d21e20b4"
+  integrity sha512-4rIjkas/9Ypp5+Dc/qPGrIbE9SK8zuB6cZeyEEDrF23idE3tfmn1CBcvBe8AeM4Rm6g3KiQoknsqhpPNH3kFeA==
   dependencies:
+    file-type "^16.5.4"
     filesize "^10.0.5"
-    magic-bytes.js "^1.0.13"
     markdown-it "^12.3.2"
     whatwg-fetch "^2.0.3"
 
@@ -8750,6 +8779,14 @@ token-stream@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/token-stream/-/token-stream-1.0.0.tgz#cc200eab2613f4166d27ff9afc7ca56d49df6eb4"
   integrity sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==
+
+token-types@^4.1.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-4.2.1.tgz#0f897f03665846982806e138977dbe72d44df753"
+  integrity sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    ieee754 "^1.2.1"
 
 tributejs@^5.1.3:
   version "5.1.3"


### PR DESCRIPTION
## Issue

- #6259 

## 概要
bootcamp内のテキストエリアに対してファイル選択ダイアログを使用したファイル添付機能を追加しました。
機能追加の主な修正は以前より「テキストエリアでドラッグ&ドロップでのファイル添付機能」や「マークダウン記法機能」を提供しているnpmライブラリ[textarea-markdown](https://github.com/komagata/textarea-markdown)にて行っています。
bootcamp上では`textarea-markdown`から提供される「ファイル選択ダイアログによるファイル添付機能」が機能するようviewおよびパーシャル、Vueテンプレート上に修正を施しています。

## 変更確認方法

1. `feature/add_file_to_be_attached_using_the_file_selection_dialog`をローカルに取り込む
2. `bin/setup`を実行
3. `hatsuno`でログイン
4. 下記記載の「確認先」のテキストエリアにおいて、テキストエリア下部の「ファイルを挿入」をクリックしてファイル選択ダイアログを開き、ファイルを選択してファイルアップロードができることを確認する。
![画面収録_2023-06-21_2_14_12_AdobeExpress](https://github.com/fjordllc/bootcamp/assets/69577164/0f92d4aa-d90e-4b22-b902-9fcd85096764)

### 確認先
いずれのリンクもローカル開発環境を立ち上げてアクセスしてください。

- [日報の新規作成画面](http://localhost:3000/reports/new)
- [日報](http://localhost:3000/reports/469634013)のコメント新規作成および作成済みコメントの編集
- [Q&Aの新規作成画面](http://localhost:3000/questions/new)
- Q&Aの編集画面 ※前項から質問を作成して編集画面を確認してください。
- Q&Aのコメント新規作成および作成済みコメントの編集 ※前前項で作成した質問を使用して確認してください。
- [DOCSの新規作成画面](http://localhost:3000/pages/new)
- [お知らせの新規作成画面](http://localhost:3000/announcements/new)
- [特別イベントの新規作成画面](http://localhost:3000/events/new)
- [定期イベントの新規作成画面](http://localhost:3000/regular_events/new)
- [提出物の新規作成画面](http://localhost:3000/products/new?practice_id=315059988)

## Screenshot
変更箇所が多いのでテキストエリアを使用している箇所を一箇所例示します。

### 変更前
<img width="1343" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/6f5dd243-6f20-46ab-b14c-3a39e9f6f212">

### 変更後
![画面収録_2023-06-21_2_14_12_AdobeExpress](https://github.com/fjordllc/bootcamp/assets/69577164/0f92d4aa-d90e-4b22-b902-9fcd85096764)

## 関連、その他
- komagata/textarea-markdown: Make textarea a markdown editor.
https://github.com/komagata/textarea-markdown

