### PR TITLE
Discord IDの入力フォームを一旦隠した

### DIFF
--- a/app/models/required_field.rb
+++ b/app/models/required_field.rb
@@ -15,7 +15,8 @@ class RequiredField
   validates :avatar_attached, presence: { message: 'ユーザーアイコンを登録してください。' }
   validates :tag_list_count, numericality: { greater_than: 0, message: 'タグを登録してください。' }
   validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }, unless: :graduated
-  validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
+  # TODO Discord の ID のルールが変更になったので、それに対応できるまで隠す。
+  #validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
   validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
   validates :blog_url, presence: { message: 'ブログURLを登録してください。' }
 end

--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -1,15 +1,17 @@
-.form-item#form-discord-account
-  = f.label :discord_account, class: 'a-form-label'
-  .form-item__mention-input
-    = f.text_field :discord_account, class: 'a-text-input', placeholder: 'komagata#1111'
-  .a-form-help
-    p
-      | Discord のアカウントの調べ方は
-      label.a-form-help-link.is-danger(for='modal-discord-account')
-        span.a-form-help-link__label
-          | こちら
-        span.a-help
-          i.fa-solid.fa-question
+// Discord の ID のルールが変更になったので、それに対応できるまで隠す
+//
+  .form-item#form-discord-account
+    = f.label :discord_account, class: 'a-form-label'
+    .form-item__mention-input
+      = f.text_field :discord_account, class: 'a-text-input', placeholder: 'komagata#1111'
+    .a-form-help
+      p
+        | Discord のアカウントの調べ方は
+        label.a-form-help-link.is-danger(for='modal-discord-account')
+          span.a-form-help-link__label
+            | こちら
+          span.a-help
+            i.fa-solid.fa-question
 .form-item#times-url
   = f.label :times_url, class: 'a-form-label'
   = f.text_field :times_url, class: 'a-text-input', placeholder: 'https://discord.com/channels/715806612824260640/123456789012345678'


### PR DESCRIPTION
Discord の ID のルールが変更になったので、それに対応できるまで隠す。