### PR TITLE
新しい形式のDiscordユーザー名を設定できるようにした

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -22,7 +22,7 @@ class CurrentUserController < ApplicationController
     user_attribute = [
       :adviser, :login_name, :name,
       :name_kana, :email, :course_id,
-      :description, :job_seeking,
+      :description, :job_seeking, :discord_account,
       :github_account, :twitter_account, :facebook_url,
       :blog_url, :password, :password_confirmation,
       :job, :organization, :os,

--- a/app/models/required_field.rb
+++ b/app/models/required_field.rb
@@ -15,8 +15,7 @@ class RequiredField
   validates :avatar_attached, presence: { message: 'ユーザーアイコンを登録してください。' }
   validates :tag_list_count, numericality: { greater_than: 0, message: 'タグを登録してください。' }
   validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }, unless: :graduated
-  # Todo Discord の ID のルールが変更になったので、それに対応できるまで隠す。
-  # validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
+  validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
   validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
   validates :blog_url, presence: { message: 'ブログURLを登録してください。' }
 end

--- a/app/models/required_field.rb
+++ b/app/models/required_field.rb
@@ -15,7 +15,7 @@ class RequiredField
   validates :avatar_attached, presence: { message: 'ユーザーアイコンを登録してください。' }
   validates :tag_list_count, numericality: { greater_than: 0, message: 'タグを登録してください。' }
   validates :after_graduation_hope, presence: { message: 'フィヨルドブートキャンプを卒業した自分はどうなっていたいかを登録してください。' }, unless: :graduated
-  validates :discord_account, presence: { message: 'Discordアカウントを登録してください。' }
+  validates :discord_account_name, presence: { message: 'Discordアカウントを登録してください。' }
   validates :github_account, presence: { message: 'GitHubアカウントを登録してください。' }
   validates :blog_url, presence: { message: 'ブログURLを登録してください。' }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -204,7 +204,7 @@ class User < ApplicationRecord
               allow_blank: true,
               format: {
                 with: /\A(?!.*\.\.)[a-z0-9_.]+\z/,
-                message: 'は2文字以上32文字以内で入力してください アンダースコア（_）とピリオド（.）以外の特殊文字を使用できません ユーザー名にピリオド( . )を2つ連続して使用することはできません'
+                message: 'はアンダースコア（_）とピリオド（.）以外の特殊文字を使用できません ユーザー名にピリオド( . )を2つ連続して使用することはできません'
               }
     validates :twitter_account,
               length: { maximum: 15 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -199,10 +199,17 @@ class User < ApplicationRecord
   end
 
   with_options if: -> { validation_context != :retirement } do
+    validates :discord_account,
+              length: { maximum: 32, minimum: 2 },
+              allow_blank: true,
+              format: {
+                with: /\A(?!.*\.\.)[a-z0-9_.]+\z/,
+                message: 'は2文字以上32文字以内で入力してください アンダースコア（_）とピリオド（.）以外の特殊文字を使用できません ユーザー名にピリオド( . )を2つ連続して使用することはできません'
+              }
     validates :twitter_account,
               length: { maximum: 15 },
+              allow_blank: true,
               format: {
-                allow_blank: true,
                 with: /\A\w+\z/,
                 message: 'は英文字と_（アンダースコア）のみが使用できます'
               }

--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -1,30 +1,29 @@
-// Todo Discord の ID のルールが変更になったので、それに対応できるまで隠す
-//
-  .form-item#form-discord-account
-    = f.label :discord_account, class: 'a-form-label'
-    .form-item__mention-input
-      = f.text_field :discord_account, class: 'a-text-input', placeholder: 'komagata#1111'
-    .a-form-help
-      p
-        | Discord のアカウントの調べ方は
-        label.a-form-help-link.is-danger(for='modal-discord-account')
-          span.a-form-help-link__label
-            | こちら
-          span.a-help
-            i.fa-solid.fa-question
+.form-item#form-discord-account
+  = f.label :discord_account, class: 'a-form-label'
 
-= f.fields_for :discord_profile do |discord_profile_fields|
-  .form-item#times-url
-    = discord_profile_fields.label :times_url, class: 'a-form-label'
-    = discord_profile_fields.text_field :times_url, class: 'a-text-input', placeholder: 'https://discord.com/channels/715806612824260640/123456789012345678'
-    .a-form-help
-      p
-        | Discord の分報チャンネルの URL を入力。調べ方は
-        label.a-form-help-link.is-danger(for='modal-times-url')
-          span.a-form-help-link__label
-            | こちら
-          span.a-help
-            i.fa-solid.fa-question
+  .form-item__mention-input
+    = f.text_field :discord_account, class: 'a-text-input', placeholder: 'komagata'
+  .a-form-help
+    p
+      | 大文字は使えません。2文字以上32文字以内で入力してください。アンダースコア（_）とピリオド（.）以外の特殊文字を使用できません。 ユーザー名にピリオド( . )を2つ連続して使用することはできません。
+    p
+      | Discord のアカウントの調べ方は
+      label.a-form-help-link.is-danger(for='modal-discord-account')
+        span.a-form-help-link__label
+          | こちら
+        span.a-help
+          i.fa-solid.fa-question
+.form-item#times-url
+  = f.label :times_url, class: 'a-form-label'
+  = f.text_field :times_url, class: 'a-text-input', placeholder: 'https://discord.com/channels/715806612824260640/123456789012345678'
+  .a-form-help
+    p
+      | Discord の分報チャンネルの URL を入力。調べ方は
+      label.a-form-help-link.is-danger(for='modal-times-url')
+        span.a-form-help-link__label
+          | こちら
+        span.a-help
+          i.fa-solid.fa-question
 
 .form-item#form-github-account
   = f.label :github_account, class: 'a-form-label'

--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -1,6 +1,4 @@
-.form-item#form-discord-account
-  = f.label :discord_account, class: 'a-form-label'
-
+= f.fields_for :discord_profile do |discord_profile_fields|
   .form-item__mention-input
     = f.text_field :discord_account, class: 'a-text-input', placeholder: 'komagata'
   .a-form-help
@@ -13,17 +11,17 @@
           | こちら
         span.a-help
           i.fa-solid.fa-question
-.form-item#times-url
-  = f.label :times_url, class: 'a-form-label'
-  = f.text_field :times_url, class: 'a-text-input', placeholder: 'https://discord.com/channels/715806612824260640/123456789012345678'
-  .a-form-help
-    p
-      | Discord の分報チャンネルの URL を入力。調べ方は
-      label.a-form-help-link.is-danger(for='modal-times-url')
-        span.a-form-help-link__label
-          | こちら
-        span.a-help
-          i.fa-solid.fa-question
+  .form-item#times-url
+    = discord_profile_fields.label :times_url, class: 'a-form-label'
+    = discord_profile_fields.text_field :times_url, class: 'a-text-input', placeholder: 'https://discord.com/channels/715806612824260640/123456789012345678'
+    .a-form-help
+      p
+        | Discord の分報チャンネルの URL を入力。調べ方は
+        label.a-form-help-link.is-danger(for='modal-times-url')
+          span.a-form-help-link__label
+            | こちら
+          span.a-help
+            i.fa-solid.fa-question
 
 .form-item#form-github-account
   = f.label :github_account, class: 'a-form-label'

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,8 +18,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include CommentHelper
   include TagHelper
 
-  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-
   if ENV['HEADED']
     driven_by :selenium, using: :chrome
   else

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,6 +18,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include CommentHelper
   include TagHelper
 
+  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+
   if ENV['HEADED']
     driven_by :selenium, using: :chrome
   else


### PR DESCRIPTION
## Issue

- #6646

## 概要

discordアカウント登録時に、アカウント末尾に`#4桁の数字`を入れずにアカウント登録ができるようにした。
また、discord公式(https://support.discord.com/hc/ja/articles/12620128861463) に記載されている
ユーザー名に対する新仕様に合わせた`validate`を設定した。

## 変更確認方法

1. `feature/display-username-in-latest-announcements`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `localhost:3000`にアクセス
4. ユーザー名 : `komagata` でログイン
5. 登録情報変更ページにアクセスする。
`http://localhost:3000/current_user/edit`

<img width="1101" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/9f46934f-93c9-42df-b026-b58ba9a8eae9">

6. discordアカウント登録フォームに、`komagata`で登録
<img width="783" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/f5d2cfd5-bb12-4d5d-a46b-073eb9b1a1f1">

7. `更新する`を選択する。
<img width="797" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/2469decc-c182-426c-9442-ef21e65739bf">

8. エラーが出ず、ユーザ個別ページに遷移することを確認する。
<img width="1425" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/fd4082fc-b5a7-475c-8ae2-c07490372b96">

## Screenshot

### 変更前

- ユーザ名「kimura」で登録後の遷移画面(#○○○○の形ではないので、エラーが出る)
<img width="1422" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/eefbcbf8-28bf-4476-bfff-ecb3fbc75234">


### 変更後

- ユーザ名「kimura」で登録後の遷移画面（エラーが出ず、ユーザ個別ページに遷移する）
<img width="1440" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/a832503d-394a-4ce8-bb2b-246941f3dc83">

- discordユーザ名の新仕様のvalidatesに違反した場合のエラーメッセージ(例. discordユーザ名が「A」)
<img width="1437" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/b1ec0a75-3b9b-44d2-9bb8-aa78bb7f2d8a">


