### PR TITLE
「最初にコメントしたメンターが提出物の担当者になる」機能を修正

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -146,7 +146,7 @@ class Product < ApplicationRecord
   end
 
   def other_checker_exists?(user_id)
-    checker_id.present? && checker_id.to_s != user_id
+    checker_id.present? && checker_id != user_id
   end
 
   def unassigned?

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -89,6 +89,17 @@ class ProductTest < ActiveSupport::TestCase
     assert_not product.other_checker_exists?(other_checker.id)
   end
 
+  test 'other_checker_not_exists_if_self' do
+    other_checker = users(:machida)
+    product = Product.create!(
+      body: 'test',
+      user: users(:kimura),
+      practice: practices(:practice5),
+      checker_id: other_checker.id
+    )
+    assert_not product.other_checker_exists?(other_checker.id)
+  end
+
   test '#checker_name' do
     product = products(:product1)
 


### PR DESCRIPTION
## Issue

- #6681 

## 概要
最初にコメントしたメンターが提出物の担当者になる」機能のシステムテストがよく落ちています。この機能のバグによるものなので修正をしました。

### 原因
原因としては、`Product#other_checker_exists?` の引数`user_id`の型がStringを想定した処理でしたが、実引数がStringからIntegerに変更され（※１）意図しない処理が実行されてしまうためです。
具体的には、`API::Products::CheckerController#update`の`@product.save_checker(params[:current_user_id])
`の判定がfalseになると、テスト実行中に意図しないダイアログが表示されるため失敗してしまいます。

falseになるケースとしては、内部で呼び出される`Product#other_checker_exists?`で`checker_id`の値が存在する場合です。`checker_id`がto_sで変換するためInteger型のuser_idと一致しなくなり、同一ユーザーのチェックを間違えてしまいます。
```rb
  def save_checker(user_id)
    return false if other_checker_exists?(user_id)

    self.checker_id = user_id
    Cache.delete_self_assigned_no_replied_product_count(user_id)
    save!
  end

  def other_checker_exists?(user_id)
    checker_id.present? && checker_id.to_s != user_id
  end
```

また、flakeyなテストになる理由としては、２つのAPIで呼び出される処理の実行順序が変化するためです。メンターが提出物に初コメントする際に、担当者データ`Product.checker_id`の読み込み処理と書き込み処理が異なるAPIによって実行されます。読み込み処理は、`API::Products::CheckerController#update`、書き込み処理は`API::CommentsController#create`の各内部で呼び出されます。※２

上で書きましたが、今回テストが落ちる原因は、`API::Products::CheckerController#update`内部で呼ばれる`Product#other_checker_exists?`の`checker_id`の値が存在する場合です。
読み込み処理と書き込み処理の実行順序ごとの`Product#other_checker_exists?`の`checker_id`は以下となります。
| 実行順序                     | `Product#other_checker_exists?`実行時の`Product.checker_id` |
|------------------------------|-------------------------------------------------------------|
| 読み込み処理 -> 書き込み処理 | nil                                                        |
| 書き込み処理 -> 読み込み処理 | コメントしたユーザーid                                      |

このことから、`API::CommentsController#create`側の書き込み処理が先に実行された場合にテストが失敗してしまいます。

※１`Product#other_checker_exists?` の実引数の型がStringからIntegerに変更した経緯は、以下のPRとなります。
- #6610 

※２ 実際には`API::Products::CheckerController#update`でも書き込み処理は行われています。

### 修正内容
`Product#other_checker_exists?`で`user_id`はInteger型になるので、適切な比較が出来るように`checker_id`のto_sを削除しました。
