### PR TITLE
「最初にコメントしたメンターが提出物の担当者になる」処理が重複してるので、不要な方を削除した

### DIFF
--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -69,13 +69,6 @@ class Comment::AfterCreateCallback
     @watch.save!
   end
 
-  def create_checker_id(comment)
-    return nil unless comment.user.mentor?
-
-    product = comment.commentable
-    product.checker_id = comment.sender.id unless product.checker_id?
-  end
-
   def delete_product_cache(product_id)
     Rails.cache.delete "/model/product/#{product_id}/last_commented_user"
   end

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -17,7 +17,6 @@ class Comment::AfterCreateCallback
 
     return unless comment.commentable.instance_of?(Product)
 
-    comment.commentable.create_checker_id(comment)
     comment.commentable.update_last_commented_at(comment)
     comment.commentable.update_commented_at(comment)
     delete_product_cache(comment.commentable.id)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -173,12 +173,6 @@ class Product < ApplicationRecord
     is_replied_by_checker_previous != is_replied_by_checker_current
   end
 
-  def create_checker_id(comment)
-    return nil unless comment.user.mentor?
-
-    update_columns(checker_id: comment.user.id) unless checker_id? # rubocop:disable Rails/SkipsModelValidations
-  end
-
   def update_last_commented_at(comment)
     if comment
       if comment.user.mentor


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6696

## 概要

「最初にコメントしたメンターが提出物の担当者になる」処理が `API::CommentsController` と `API::Products::CheckerController` で重複しており、動作時に競合が発生しています。

現時点で問題は発生していませんが、今後仕様変更や機能追加した際に Flaky な動作を誘発する可能性があるため、１つのルートから処理を実行するように片方の処理を削除しました。


## 変更点

提出物の担当者を決定する処理は `API::Products::CheckerController` に任せるのが自然だと思うので、`API::CommentsController` 側で実行される処理 ( `Product#create_checker_id` ) を削除しました。

※アプリの動作に変化はありません。

### コメント後に提出物の担当者になるプロセス

#### 変更前

```
comments.vue#postComment
  ┣ API::CommentsController#create
  ┃  ┗ Comment#save
  ┃      ┗ Comment::AfterCreateCallback#after_commit
  ┃          ┗ Product#create_checker_id ━━┓
  ┃                                          ┣ この処理が競合する
  ┗ API::Products::CheckerController#update  ┃
      ┗ Product#save_checker  ━━━━━━━━━┛
```

#### 変更後

```
comments.vue#postComment
  ┗ API::Products::CheckerController#update
      ┗ Product#save_checker
```

