### PR TITLE
複数カテゴリーに所属するプラクティスを紐づけた日報の重複表示を修正

### DIFF
--- a/app/controllers/api/practices_controller.rb
+++ b/app/controllers/api/practices_controller.rb
@@ -13,6 +13,7 @@ class API::PracticesController < API::BaseController
                   .eager_load(:practices)
                   .where.not(practices: { id: nil })
                   .order('categories_practices.position')
+    @unique_practices = @categories.flat_map(&:practices).uniq
   end
 
   def update

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -11,12 +11,7 @@ module ReportsHelper
 
   def practice_options_within_course
     user_course_categories = current_user.course.categories.includes(:practices)
-    user_practices = user_course_categories.flat_map do |category|
-      category.practices.map do |practice|
-        [practice.title, practice.id]
-      end
-    end
-    user_practices.uniq
+    user_course_categories.flat_map(&:practices).map { |practice| [practice.title, practice.id] }.uniq
   end
 
   def convert_to_hour_minute(time)

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -11,11 +11,12 @@ module ReportsHelper
 
   def practice_options_within_course
     user_course_categories = current_user.course.categories.includes(:practices)
-    user_course_categories.flat_map do |category|
+    user_practices = user_course_categories.flat_map do |category|
       category.practices.map do |practice|
-        ["[#{category.name}] #{practice.title}", practice.id]
+        [practice.title, practice.id]
       end
     end
+    user_practices.uniq
   end
 
   def convert_to_hour_minute(time)

--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -134,7 +134,7 @@
                 option(
                   v-for='practice in practices',
                   :key='practice.id',
-                  :value='practice.id') {{ practice.categoryAndPracticeName }}
+                  :value='practice.id') {{ practice.title }}
           .form-item
             .a-form-label
               | タイトル
@@ -302,10 +302,7 @@ export default {
           return response.json()
         })
         .then((practices) => {
-          this.practices = practices.map((practice) => {
-            practice.categoryAndPracticeName = `[${practice.category}] ${practice.title}`
-            return practice
-          })
+          this.practices = practices
         })
         .then(() => {
           const choices = document.getElementById('js-choices-single-select')

--- a/app/views/api/practices/index.json.jbuilder
+++ b/app/views/api/practices/index.json.jbuilder
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-unique_practices = @categories.flat_map(&:practices).uniq
-
-json.array! unique_practices do |practice|
+json.array! @unique_practices do |practice|
   json.(practice, :id, :title)
 end

--- a/app/views/api/practices/index.json.jbuilder
+++ b/app/views/api/practices/index.json.jbuilder
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
-@categories.flat_map do |category|
-  json.array! category.practices do |practice|
-    json.(practice, :id, :title)
-    json.category category.name
-  end
+
+user_practices = @categories.flat_map do |category|
+  category.practices
+end
+
+unique_practices = user_practices.uniq
+
+json.array! unique_practices do |practice|
+  json.(practice, :id, :title)
 end

--- a/app/views/api/practices/index.json.jbuilder
+++ b/app/views/api/practices/index.json.jbuilder
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-user_practices = @categories.flat_map do |category|
-  category.practices
-end
-
-unique_practices = user_practices.uniq
+unique_practices = @categories.flat_map(&:practices).uniq
 
 json.array! unique_practices do |practice|
   json.(practice, :id, :title)

--- a/db/data/20230701031415_delete_duplicate_rows_in_practices_reports.rb
+++ b/db/data/20230701031415_delete_duplicate_rows_in_practices_reports.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DeleteDuplicateRowsInPracticesReports < ActiveRecord::Migration[6.1]
+  def up
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      DELETE FROM practices_reports
+      WHERE ctid NOT IN (
+        SELECT min(ctid)
+        FROM practices_reports
+        GROUP BY practice_id, report_id
+      );
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20230702035134_add_unique_constraint_to_practices_reports.rb
+++ b/db/migrate/20230702035134_add_unique_constraint_to_practices_reports.rb
@@ -1,0 +1,6 @@
+class AddUniqueConstraintToPracticesReports < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :practices_reports, [:practice_id, :report_id]
+    add_index :practices_reports, [:practice_id, :report_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -486,7 +486,7 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
   create_table "practices_reports", id: false, force: :cascade do |t|
     t.integer "practice_id", null: false
     t.integer "report_id", null: false
-    t.index ["practice_id", "report_id"], name: "index_practices_reports_on_practice_id_and_report_id"
+    t.index ["practice_id", "report_id"], name: "index_practices_reports_on_practice_id_and_report_id", unique: true
     t.index ["report_id", "practice_id"], name: "index_practices_reports_on_report_id_and_practice_id"
   end
 

--- a/test/helpers/reports_helper.rb
+++ b/test/helpers/reports_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ReportsHelperTest < ActionView::TestCase
+  include Sorcery::Controller::InstanceMethods
+  include Sorcery::TestHelpers::Rails::Controller
+
+  test 'practice_options_within_course' do
+    login_user(users(:kimura))
+    assert_equal 'OS X Mountain Lionをクリーンインストールする', practice_options_within_course.first[0]
+    assert_equal 'sslの基礎を理解する', practice_options_within_course.last[0]
+    assert_no_difference 'practice_options_within_course.count' do
+      CategoriesPractice.create!(category_id: categories(:category2).id, practice_id: practices(:practice2).id, position: 7)
+    end
+  end
+end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -201,7 +201,7 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'select practice title when push question button on practice page' do
     visit_with_auth "/practices/#{practices(:practice23).id}", 'hatsuno'
     click_on '質問する'
-    assert_text '[Ruby] rubyをインストールする'
+    assert_text 'rubyをインストールする'
   end
 
   test 'Question display 25 items correctly' do


### PR DESCRIPTION
## Issue

- #6477 

## 概要
### バグの詳細
https://github.com/fjordllc/bootcamp/issues/6477#issuecomment-1543040567
### 変更点
- 日報のプラクティス選択欄の表示形式を`[カテゴリー名]プラクティス名`から`プラクティス名`に変更した
  - これにより日報のプラクティス選択欄に同一プラクティスが重複して表示されなくなった
    - `[Mac OS X]Terminalの基礎を覚える`、`[UNIX]Terminalの基礎を覚える`→`Terminalの基礎を覚える`
  - 質問のプラクティス選択欄の表示形式も上記に統一した
- 本番環境の`practices_reports`テーブルに存在する重複レコードを削除するdata-migrateファイルを作成した
- `practices_reports`テーブルの`[practice_id, report_id]`にユニーク制約を追加した
  - これによりプラクティスの日報一覧(`/practices/{ID}/reports`)での日報の重複表示がなくなった

## 変更確認方法
### 1. バグの再現
以下の手順をmainブランチ上で行う
1. `db/fixtures/categories_practices.yml`に以下を追加
```diff
+ categories_practice61:
+   practice: practice2
+   category: category2
+   position: 7
```
2. `rails db:reset`を実行(dbの初期化とseedデータの読み込み)
3. `rails s`でサーバーを起動
4. `localhost:3000`にアクセスし、`kimura`でログイン
5. 日報`テスト日報5です`の編集画面(`/reports/730242988/edit`)を開く
6. 日報のプラクティス選択欄の表示形式が`[カテゴリー名]プラクティス名`になっていることを確認する
7. 日報のプラクティス選択欄で`[Mac OS X]Terminalの基礎を覚える`と`[UNIX]Terminalの基礎を覚える`を選択し、`内容変更`をクリックして保存する
8. プラクティス`Terminalの基礎を覚える`の日報一覧(`/practices/198065840/reports`)にアクセスし、編集した日報が重複表示されていることを確認する

※この時点で`db/fixtures/categories_practices.yml`の変更は破棄してok

### 2. 変更確認
日報
1. `bug/fix-duplicate-practice-reports`をローカルに取り込む
1. `rails dbconsole`でdbに接続し、`SELECT * FROM practices_reports;`を実行して重複レコードを確認する
1. `rails data:migrate:up VERSION=20230701031415`を実行(data-migrate)
1. `rails dbconsole`でdbに接続し、`SELECT * FROM practices_reports;`を実行して重複レコードが削除されていることを確認する
1. `rails db:migrate`を実行
1. `rails s`でサーバーを起動
1. `localhost:3000`にアクセスし、`kimura`でログイン
1. 日報`テスト日報5です`の編集画面(`/reports/730242988/edit`)を開く
1. 日報のプラクティス選択欄の表示形式が`プラクティス名`になっており、選択肢の重複がないことを確認する
1. プラクティス`Terminalの基礎を覚える`の日報一覧(`/practices/198065840/reports`)にアクセスし、日報の重複表示がないことを確認する

※手順3のdata-migrate実行時に`db/data_schema.rb`に生じる差分は無視していい(rubocop実行後に元に戻るため)

質問
1. 質問作成画面(`/questions/new`)を開き、プラクティス選択欄の表示形式が`プラクティス名`になっており、選択肢の重複がないことを確認する
1. 質問の表示画面(`/questions/{ID}`)で`内容修正`を選択して編集ブロックを表示させ、プラクティス選択欄の表示形式が`プラクティス名`になっており、選択肢の重複がないことを確認する

## Screenshot
開発環境のデータを表示しています。

### 変更前
`/reports/730242988/edit`
![issue_6477_before-1](https://github.com/fjordllc/bootcamp/assets/65595901/4dddd071-7c56-4acb-bd16-fb700874a764)

`/practices/198065840/reports`
![issue_6477_before-2](https://github.com/fjordllc/bootcamp/assets/65595901/9b1de102-e7d6-40b5-a0e2-c04dbeba8f39)

`/questions/new`
![issue_6477_before-3](https://github.com/fjordllc/bootcamp/assets/65595901/8b3e7b17-fcc0-4cd7-b7b3-ce90ce6336bb)

`/questions/{ID}`(編集時)
![issue_6477_before-4](https://github.com/fjordllc/bootcamp/assets/65595901/2a227cb1-1cfc-47d0-8a22-3e3f502a9949)


### 変更後
`/reports/730242988/edit`
![issue_6477_after-1](https://github.com/fjordllc/bootcamp/assets/65595901/bacd5471-fc24-4cdc-9a4c-11fb57a9d3d9)

`/practices/198065840/reports`
![issue_6477_after-2](https://github.com/fjordllc/bootcamp/assets/65595901/fbb6ee75-b63c-4c4e-89c5-d30954fa8e50)

`/questions/new`
![issue_6477_after-3](https://github.com/fjordllc/bootcamp/assets/65595901/0a32a83e-de34-43a1-b22c-8c60cc84c332)

`/questions/{ID}`(編集時)
![issue_6477_after-4](https://github.com/fjordllc/bootcamp/assets/65595901/c8c4b16d-f9fe-47c9-9089-1ccfeb186823)


## 参考
- データマイグレーション
  - [DBのデータをmigrateする方法 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/DB%E3%81%AE%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92migrate%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
  - [ilyakatz/data-migrate](https://github.com/ilyakatz/data-migrate)
  - https://github.com/fjordllc/bootcamp/pull/5959
  - https://github.com/fjordllc/bootcamp/pull/6443
- Active Record マイグレーション
  - [ActiveRecord::Migration](https://api.rubyonrails.org/classes/ActiveRecord/Migration.html)
  - [ActiveRecord::ConnectionAdapters::SchemaStatements#add_index](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_index)
  - [ActiveRecord::ConnectionAdapters::SchemaStatements#remove_index](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_index)
- SQL
  - [CoursesCategory モデルを追加](https://github.com/fjordllc/bootcamp/commit/6c347f289242d824fa3c5baf358ae22d02a1e88c#diff-1d676278f7bdc7849b18013c936cd19a341022c7abe11a9e185abc5fd46bc5c5)
  - [ActiveRecord::ConnectionAdapters::DatabaseStatements#execute](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-execute)
  - [sql - Delete duplicate rows from small table - Stack Overflow](https://stackoverflow.com/questions/6583916/delete-duplicate-rows-from-small-table)
  - [sql server - How can I remove duplicate rows? - Stack Overflow](https://stackoverflow.com/questions/18932/how-can-i-remove-duplicate-rows)
  - [How to delete duplicate rows in SQL Server? - Stack Overflow](https://stackoverflow.com/questions/18390574/how-to-delete-duplicate-rows-in-sql-server)
  - [Deleting duplicates - PostgreSQL wiki](https://wiki.postgresql.org/wiki/Deleting_duplicates)
- index基礎
  - [図解 DB インデックス](https://zenn.dev/suzuki_hoge/books/2022-12-database-index-9520da88d02c4f)
  - [SQLのインデックスとそのチューニングについてのオンラインブック](https://use-the-index-luke.com/ja)
- `app/views/reports/_form.html.slim`
  - [ActionView::Helpers::FormOptionsHelper#select](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select)
  - [Choices-js/Choices](https://github.com/Choices-js/Choices)
  - https://github.com/fjordllc/bootcamp/pull/4626
  - https://github.com/fjordllc/bootcamp/pull/3321
