### PR TITLE
Doc更新時とWIPで保存時の通知メッセージを変更

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -94,7 +94,7 @@ class PagesController < ApplicationController
     when :create
       'ドキュメントを作成しました。'
     when :update
-      'ページを更新しました。'
+      'ドキュメントを更新しました。'
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -88,7 +88,7 @@ class PagesController < ApplicationController
   end
 
   def notice_message(page, action_name)
-    return 'ページをWIPとして保存しました。' if page.wip?
+    return 'ドキュメントをWIPとして保存しました。' if page.wip?
 
     case action_name
     when :create

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -66,7 +66,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
 
     click_link '内容変更'
     click_button '内容を更新'
-    assert_text 'ページを更新しました。'
+    assert_text 'ドキュメントを更新しました。'
 
     visit_with_auth '/notifications', 'machida'
 

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -53,7 +53,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
       fill_in('page[body]', with: 'DocsTestBody')
     end
     click_button 'WIP'
-    assert_text 'ページをWIPとして保存しました。'
+    assert_text 'ドキュメントをWIPとして保存しました。'
 
     logout
     visit_with_auth '/notifications', 'hatsuno'

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -42,7 +42,7 @@ class PagesTest < ApplicationSystemTestCase
     fill_in 'page[title]', with: '半角スペースを 含んでも 正常なページに 遷移する'
     click_button '内容を更新'
     assert_equal page_path(target_page.reload), current_path
-    assert_text 'ページを更新しました'
+    assert_text 'ドキュメントを更新しました。'
   end
 
   test 'add new page' do
@@ -225,7 +225,7 @@ class PagesTest < ApplicationSystemTestCase
       click_button '内容を更新'
     end
 
-    assert_text 'ページを更新しました'
+    assert_text 'ドキュメントを更新しました。'
     assert_match 'Message to Discord.', mock_log.to_s
   end
 
@@ -258,7 +258,7 @@ class PagesTest < ApplicationSystemTestCase
     check 'ドキュメント公開のお知らせを書く', allow_label_click: true
     click_button '内容を更新'
 
-    assert_text 'ページを更新しました'
+    assert_text 'ドキュメントを更新しました。'
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -62,7 +62,7 @@ class PagesTest < ApplicationSystemTestCase
       fill_in('page[body]', with: 'test')
     end
     click_button 'WIP'
-    assert_text 'ページをWIPとして保存しました。'
+    assert_text 'ドキュメントをWIPとして保存しました。'
   end
 
   test 'update page as WIP' do
@@ -72,7 +72,7 @@ class PagesTest < ApplicationSystemTestCase
       fill_in('page[body]', with: 'test')
     end
     click_button 'WIP'
-    assert_text 'ページをWIPとして保存しました。'
+    assert_text 'ドキュメントをWIPとして保存しました。'
   end
 
   test 'destroy page' do


### PR DESCRIPTION
## Issue

- #6304 

## 概要
Docを更新した時またはWIPで保存した時に表示されるメッセージが`ページをXXしました。`だったのを、`ドキュメントをXXしました。`に変更しました。


## 変更確認方法

1. `git fetch https://github.com/fjordllc/bootcamp pull/6705/head:feature/change-Doc-notification-message`でブランチをローカルに取り込む
2. `git switch feature/change-Doc-notification-message`で対象のブランチに切り替える
3. `foreman start -f Procfile.dev`でアプリを起動する
4. komagataでログイン
5. 左端のメニューバーから`Docs`をクリック

<img width="1231" alt="_development__ダッシュボード___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/549f82eb-6b1f-4946-921a-268b9bb6a4b2">

6. `+ Doc作成`をクリック

<img width="1156" alt="_development__Docs___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/b4016681-2367-4fed-81b8-fa66118508fe">


7. 「タイトル」と「本文」に適当な値を入力し、`WIP`ボタンをクリックすると、`ドキュメントをWIPとして保存しました。`のメッセージが表示される(変更点1)。

![screencapture-localhost-3000-pages-new-2023-07-07-07_17_02-edit](https://github.com/fjordllc/bootcamp/assets/79003082/3924f4e3-be6b-4b77-8979-4f6e0f833ec8)


8. `内容変更`ボタンを押して、Docの項目を更新し`内容を更新`をクリックすると、`ドキュメントを更新しました。`のメッセージが表示される(変更点2)

<img width="1227" alt="_development__テストドキュメント___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/4e8d1a1c-d24d-411e-8d35-762d7e61e557">

<img width="613" alt="Screen_Capture_Result" src="https://github.com/fjordllc/bootcamp/assets/79003082/b201e5f8-de2b-40e3-8681-8c5ca29d1999">


## 変更点のScreenshot
### DocをWIPで保存時のメッセージ
( 変更前 )
<img width="1134" alt="_development__サンプルドキュメント___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/8e9fc479-e254-4d97-b8a4-6d8187fbdd95">


( 変更後 )
<img width="1260" alt="_development__サンプルドキュメント___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/65cc8778-2cc1-4848-aec5-df27e17e9b98">

### Doc更新時のメッセージ
( 変更前 )
<img width="1012" alt="_development__サンプルドキュメント___FBC_png" src="https://github.com/fjordllc/bootcamp/assets/79003082/253116d4-58e5-4bd1-80b4-9c641db217e5">


( 変更後 )
<img width="1255" alt="_development__サンプルドキュメント___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/b5ffd29f-05d8-403b-9bf5-c958fb7f8c31">
