### PR TITLE
お試し延長編集ページにあるボタンの位置を変更

### DIFF
--- a/app/javascript/stylesheets/application/blocks/page/_page-main-header.sass
+++ b/app/javascript/stylesheets/application/blocks/page/_page-main-header.sass
@@ -2,11 +2,11 @@
   border-bottom: solid 1px var(--border)
 
 .page-main-header__inner
-  padding-block: .5rem
-  display: flex
-  align-items: center
+  padding-block: .75rem
   +media-breakpoint-up(md)
-    min-height: 2.5rem
+    min-height: calc(3.75rem - 1px)
+    display: flex
+    align-items: center
   +media-breakpoint-down(sm)
     display: block
 
@@ -18,7 +18,7 @@
 
 .page-main-header__end
   +media-breakpoint-down(sm)
-    margin-top: .75rem
+    margin-top: .125rem
 
 .page-main-header__title
   color: var(--main)

--- a/app/views/admin/campaigns/edit.html.slim
+++ b/app/views/admin/campaigns/edit.html.slim
@@ -1,10 +1,10 @@
-- title '管理ページ'
+- title 'お試し延長編集'
 
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        | 管理ページ
 
 = render 'admin/admin_page_tabs'
 
@@ -12,13 +12,15 @@ header.page-header
   header.page-main-header
     .container
       .page-main-header__inner
-        h1.page-main-header__title
-          | お試し延長編集
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | お試し延長一覧
+        .page-main-header__start
+          h1.page-main-header__title
+            | お試し延長編集
+        .page-main-header__end
+          .page-header-actions
+            .page-header-actions__items
+              .page-header-actions__item
+                = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
+                  | お試し延長一覧
   .page-body
     .container.is-md
       = render 'form', campaign: @campaign

--- a/app/views/admin/campaigns/edit.html.slim
+++ b/app/views/admin/campaigns/edit.html.slim
@@ -5,11 +5,6 @@ header.page-header
     .page-header__inner
       h2.page-header__title
         = title
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
-              | お試し延長一覧
 
 = render 'admin/admin_page_tabs'
 
@@ -19,6 +14,11 @@ header.page-header
       .page-main-header__inner
         h1.page-main-header__title
           | お試し延長編集
+      .page-header-actions
+        .page-header-actions__items
+          .page-header-actions__item
+            = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
+              | お試し延長一覧
   .page-body
     .container.is-md
       = render 'form', campaign: @campaign

--- a/app/views/admin/campaigns/index.html.slim
+++ b/app/views/admin/campaigns/index.html.slim
@@ -1,10 +1,10 @@
-- title '管理ページ'
+- title 'お試し延長一覧'
 
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        | 管理ページ
       .page-header-actions
         .page-header-actions__items
           .page-header-actions__item

--- a/app/views/admin/campaigns/new.html.slim
+++ b/app/views/admin/campaigns/new.html.slim
@@ -1,10 +1,10 @@
-- title '管理ページ'
+- title 'お試し延長作成'
 
 header.page-header
   .container
     .page-header__inner
       h2.page-header__title
-        = title
+        | 管理ページ
 
 = render 'admin/admin_page_tabs'
 


### PR DESCRIPTION
## Issue

- #6285 

## 概要
お試し延長を編集するページにて、`お試し延長一覧`のボタンをタブの下に移動しました。

また、レイアウトの調整に伴い、以下のページの`title`タグの文言が変更されました。
+ お試し延長一覧ページの`title`タグ : `管理ページ` → `お試し延長一覧`
+ お試し延長作成ページの`title`タグ : `管理ページ` → `お試し延長作成`
+ お試し延長編集ページの`title`タグ :  `管理ページ` → `お試し延長編集`

## 変更確認方法

1. `move-campaign-list-button-on-campaign-edit-page`をローカルに取り込む
2. 対象のブランチに切り替え、`foreman start -f Procfile.dev`でアプリを起動
3. ブラウザで`http://localhost:3000`を開く
4. 管理者である`komagata`でログイン
5. `http://localhost:3000/admin/campaigns`を開く
6. 右上の`お試し延長作成`ボタンをクリック
<img width="1282" alt="_development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/9cbb874d-de52-49bf-a430-695b36d30fb3">
7. `タイトル`に適当な値を入力して、`内容を保存`をクリック
<img width="1042" alt="_development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/0205717f-ec2d-48ab-89a2-43efe50fa012">
8. お試し延長一覧ページに遷移するので、7で作成したお試し延長の編集ボタンをクリック
<img width="1276" alt="_development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/588f328e-1224-4f17-9c12-6ed5eb8e2250">
9. お試し延長編集ページが表示されるので、`お試し延長一覧`ボタンの位置を確認

## 変更箇所のScreenshot
### お試し延長編集ページにあるボタンの移動
#### 変更前
<img width="1279" alt="_development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/9a159836-a730-476a-b630-022c9a09ba0d">

#### 変更後
<img width="1276" alt="_development__お試し延長編集___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/046438b2-8278-4d18-96ea-a667e6f8b4ae">

### `title`タグの文言変更
#### お試し延長一覧ページ
##### 変更前

<img width="683" alt="_development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/b5144988-0a73-499b-946d-b06c9589f3ee">

##### 変更後

<img width="508" alt="_development__お試し延長一覧___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/478b3a48-975d-4165-a185-63398c70d17f">

#### お試し延長作成ページ
##### 変更前
<img width="683" alt="_development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/d2fe950d-d563-44dc-bef5-2c2b8b56531a">


##### 変更後
<img width="510" alt="_development__お試し延長作成___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/bfa6f8e5-ad0b-41d8-a697-c5d819287123">


#### お試し延長編集ページ
##### 変更前
<img width="685" alt="_development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/e6832f46-c42d-4b48-9b53-ba3474495df6">


##### 変更後
<img width="685" alt="_development__お試し延長編集___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/930824bb-a763-48e7-8183-1acd74e48983">

