### PR TITLE
イベント作成時に作成者をWatchにする機能のテストが失敗してしまう問題を修正

### DIFF
--- a/test/models/event_organizer_watcher_test.rb
+++ b/test/models/event_organizer_watcher_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class EventOrganizerWatcherTest < ActiveSupport::TestCase
   test '#call' do
-    event = events(:event1)
+    event = events(:event3)
     assert_difference 'Watch.where(user: event.user, watchable: event).count', 1 do
       EventOrganizerWatcher.new.call(event)
     end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6719

## 概要

イベント作成時に作成者をWatchにする機能のテストである`EventOrganizerWatcherTest#call`が失敗してしまいます。

https://github.com/fjordllc/bootcamp/pull/6462 にて同じイベントを２重にWatchしないよう修正されましたが、`EventOrganizerWatcherTest#call`にて使用されてるテストデータがmainブランチでは Watch中 だったため、マージ後にバリデーションエラーが発生してしまっていると思われます。

- EventOrganizerWatcherTest#call

https://github.com/fjordllc/bootcamp/blob/ca948794f9704c5fa5c609333af3bde40a21a67d/test/models/event_organizer_watcher_test.rb#L6-L11

- Watchモデルのバリデーション

https://github.com/fjordllc/bootcamp/blob/ca948794f9704c5fa5c609333af3bde40a21a67d/app/models/watch.rb#L8


- テストで使用しているデータ

https://github.com/fjordllc/bootcamp/blob/ca948794f9704c5fa5c609333af3bde40a21a67d/test/fixtures/events.yml#L3-L12

https://github.com/fjordllc/bootcamp/blob/ca948794f9704c5fa5c609333af3bde40a21a67d/test/fixtures/watches.yml#L19-L23

## 修正内容

`EventOrganizerWatcherTest#call` 内で使用するテストデータを作成者がWatch中ではないイベントに変更しました🙋‍♂️

