### PR TITLE
テスト実行時のcautionメッセージ解消のためにテストメソッドを見直し

### DIFF
--- a/test/integration/graduation_test.rb
+++ b/test/integration/graduation_test.rb
@@ -23,6 +23,6 @@ class GraduationTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_equal '管理者としてログインしてください', '管理者としてログインしてください'
-    assert_equal users(:hajime).graduated_on, nil
+    assert_nil users(:hajime).graduated_on
   end
 end


### PR DESCRIPTION
## Issue

- #6721 

## 概要
`test/integration/gradation_test.rb`実行すると`DEPRECATED: Use assert_nil if expecting nil from test/integration/graduation_test.rb:26. This will fail in Minitest 6.`とのメッセージが表示されるようになってしまっていたものを解消させた。

## 変更確認方法

1. `bug/resolve_caution_messages_during_test`をローカルに取り込む
2. `bin/rails test test/integration/graduation_test.rb`を実行する
3. 特にメッセージが表示されずにテストが完了すればOK

## Screenshot
### 変更前
<img width="812" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/431f0930-5e4b-4b7d-9d78-3b0dd5ad5223">

### 変更後
<img width="697" alt="image" src="https://github.com/fjordllc/bootcamp/assets/69577164/6747ac66-2d29-494a-9ada-23aa919ab3c6">


