### PR TITLE
日報一覧の user-role の class の表示の修正

### DIFF
--- a/app/javascript/components/Report.jsx
+++ b/app/javascript/components/Report.jsx
@@ -66,10 +66,12 @@ export default function Report({ report, currentUserId, displayUserIcon }) {
 }
 
 const DisplayUserIcon = ({ report }) => {
+  const roleClass = `is-${report.user.primary_role}`
+
   return (
     <div className="card-list-item__user">
       <a href={report.user.url} className="card-list-item__user-link">
-        <span className='["a-user-role", roleClass]'>
+        <span className={`a-user-role ${roleClass}`}>
           <img
             className="card-list-item__user-icon a-user-icon"
             src={report.user.avatar_url}

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,6 +18,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include CommentHelper
   include TagHelper
 
+  Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+
   if ENV['HEADED']
     driven_by :selenium, using: :chrome
   else

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,8 +18,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include CommentHelper
   include TagHelper
 
-  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-
   if ENV['HEADED']
     driven_by :selenium, using: :chrome
   else

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,7 +18,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include CommentHelper
   include TagHelper
 
-  Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+  Webdrivers::Chromedriver.required_version = '114.0.5735.90'
 
   if ENV['HEADED']
     driven_by :selenium, using: :chrome

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,8 +18,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include CommentHelper
   include TagHelper
 
-  Webdrivers::Chromedriver.required_version = "114.0.5735.90"
-
   if ENV['HEADED']
     driven_by :selenium, using: :chrome
   else

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -661,7 +661,7 @@ class ReportsTest < ApplicationSystemTestCase
         span.a-user-role.is-adviser,
         span.a-user-role.is-graduate,
         span.a-user-role.is-trainee
-        ')
+      ')
     end
   end
 

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -648,7 +648,7 @@ class ReportsTest < ApplicationSystemTestCase
     assert_selector('.card-list-item__user')
   end
 
-  test 'check user role class in reports' do
+  test 'user role class is displayed correctly in reports' do
     visit_with_auth reports_path, 'kimura'
 
     within('.card-list-item__user', match: :first) do

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -650,8 +650,18 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'check user role class in reports' do
     visit_with_auth reports_path, 'kimura'
+
     within('.card-list-item__user', match: :first) do
-      assert_selector('span.a-user-role.is-student')
+      assert_selector('
+        span.a-user-role.is-student,
+        span.a-user-role.is-admin,
+        span.a-user-role.is-retired,
+        span.a-user-role.is-hibernationed,
+        span.a-user-role.is-mentor,
+        span.a-user-role.is-adviser,
+        span.a-user-role.is-graduate,
+        span.a-user-role.is-trainee
+        ')
     end
   end
 

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -664,9 +664,7 @@ class ReportsTest < ApplicationSystemTestCase
 
     visit_with_auth reports_path, 'kimura'
     within('.card-list-item__user', match: :first) do
-      assert_selector('
-        span.a-user-role.is-mentor
-      ')
+      assert_selector('span.a-user-role.is-mentor')
     end
   end
 

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -649,18 +649,23 @@ class ReportsTest < ApplicationSystemTestCase
   end
 
   test 'user role class is displayed correctly in reports' do
-    visit_with_auth reports_path, 'kimura'
+    visit_with_auth '/reports/new', 'mentormentaro'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'test title')
+      fill_in('report[description]', with: 'test')
+      fill_in('report[reported_on]', with: Time.current)
+    end
 
+    first('.learning-time').all('.learning-time__started-at select')[0].select('07')
+    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
+    first('.learning-time').all('.learning-time__finished-at select')[0].select('08')
+    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
+    click_button '提出'
+
+    visit_with_auth reports_path, 'kimura'
     within('.card-list-item__user', match: :first) do
       assert_selector('
-        span.a-user-role.is-student,
-        span.a-user-role.is-admin,
-        span.a-user-role.is-retired,
-        span.a-user-role.is-hibernationed,
-        span.a-user-role.is-mentor,
-        span.a-user-role.is-adviser,
-        span.a-user-role.is-graduate,
-        span.a-user-role.is-trainee
+        span.a-user-role.is-mentor
       ')
     end
   end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -648,6 +648,13 @@ class ReportsTest < ApplicationSystemTestCase
     assert_selector('.card-list-item__user')
   end
 
+  test 'check user role class in reports' do
+    visit_with_auth reports_path, 'kimura'
+    within('.card-list-item__user', match: :first) do
+      assert_selector('span.a-user-role.is-student')
+    end
+  end
+
   test 'show edit button when mentor is logged in and menter mode is on in report detail page' do
     visit_with_auth report_path(reports(:report1)), 'mentormentaro'
     assert_text '内容修正'


### PR DESCRIPTION
## Issue

- #6654

## 概要

http://localhost:3000/reports
日報一覧の各日報にあるユーザーアイコンを囲っている span タグの class が壊れている。
<img width="643" alt="貼り付けた画像_2023_06_20_0_03" src="https://github.com/fjordllc/bootcamp/assets/168265/6fd6484e-8c0a-4991-b1d8-119d128a8893">

正常ならば、画像のroleClassの箇所が、`is-mentor`や`is-student`の様にuserの役割を表示する処理になる。

## 変更確認方法

1. `bug/class-of-user-role-in-report-list-is-broken`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `localhost:3000`にアクセス
4. ユーザー名 : `komagata` でログイン
5. 日報一覧ページにアクセスする。
`http://localhost:3000/reports`

6. デベロッパーツールを開き、デベロッパーツール上で、1つ目（最新）の日報のユーザーアイコンに該当する箇所を開く。

<img width="381" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/066df299-5dce-4340-97c6-d24489b7ff1d">

<img width="694" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/a2d1b356-f9fd-4a3f-8a0b-eacb5579cc95">

7. spanタグ内で、日報作成者のroleClassが正常に表示されていることを確認する。

<img width="722" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/4e60ebec-d1c5-4e90-9cb4-f1827f0df3b5">

## Screenshot

### 変更前
<img width="383" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/6a8d0b38-4812-42bc-8f4b-f38904d81066">

<br>

<img width="415" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/1566191b-62e0-4222-8a23-fc1354a77688">


### 変更後
<img width="383" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/3e9f5628-dfb7-4abb-8eee-f489366aaaea">

<br>

<img width="388" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/c59ae08a-3f84-4541-a4f7-2519869f91ae">


