### PR TITLE
メンターのカテゴリー画面のカテゴリー作成ボタンの移動

### DIFF
--- a/app/javascript/stylesheets/application/blocks/page/_page-header.sass
+++ b/app/javascript/stylesheets/application/blocks/page/_page-header.sass
@@ -18,10 +18,13 @@
   align-items: center
 
 .page-header__title
-  +text-block(1.25rem 1, 700)
   color: var(--main)
+  line-height: 1
+  font-weight: 700
   font-feature-settings: "palt"
   letter-spacing: .02em
+  +media-breakpoint-up(md)
+    font-size: 1.25rem
   +media-breakpoint-down(sm)
     font-size: 1.125rem
     word-wrap: break-word

--- a/app/javascript/stylesheets/application/blocks/page/_page-main-header.sass
+++ b/app/javascript/stylesheets/application/blocks/page/_page-main-header.sass
@@ -2,9 +2,9 @@
   border-bottom: solid 1px var(--border)
 
 .page-main-header__inner
-  padding-block: .75rem
+  padding-block: .5rem
   +media-breakpoint-up(md)
-    min-height: calc(3.75rem - 1px)
+    min-height: calc(3.5rem - 1px)
     display: flex
     align-items: center
   +media-breakpoint-down(sm)
@@ -24,6 +24,6 @@
   color: var(--main)
   font-weight: 700
   +media-breakpoint-up(md)
-    +text-block(1.25rem 1.4)
+    +text-block(1.125rem 1.4)
   +media-breakpoint-down(sm)
     +text-block(1rem 1.4)

--- a/app/views/mentor/categories/index.html.slim
+++ b/app/views/mentor/categories/index.html.slim
@@ -17,10 +17,9 @@ main.page-main
           .page-header-actions
             .page-header-actions__items
               .page-header-actions__item
-              - if current_user.mentor?
                 = link_to new_mentor_category_path, class: 'a-button is-md is-secondary is-block' do
                   i.fa-regular.fa-plus
-                    | カテゴリー作成
+                  | カテゴリー作成
   .page-body
     .container.is-lg
       = react_component 'Categories'

--- a/app/views/mentor/categories/index.html.slim
+++ b/app/views/mentor/categories/index.html.slim
@@ -4,17 +4,9 @@ header.page-header
   .container
     .page-header__inner
       h1.page-header__title = title
-      .page-header-actions
-        - if current_user.mentor?
-          .page-header-actions__items
-            .page-header-actions__item
-              = link_to new_mentor_category_path, class: 'a-button is-md is-secondary is-block' do
-                i.fa-regular.fa-plus
-                | カテゴリー作成
-
 = render 'mentor/mentor_page_tabs'
 
-.page-main
+main.page-main
   header.page-main-header
     .container
       .page-main-header__inner
@@ -25,10 +17,10 @@ header.page-header
           .page-header-actions
             .page-header-actions__items
               .page-header-actions__item
+              - if current_user.mentor?
                 = link_to new_mentor_category_path, class: 'a-button is-md is-secondary is-block' do
                   i.fa-regular.fa-plus
-                  | カテゴリー作成
-
+                    | カテゴリー作成
   .page-body
     .container.is-lg
       = react_component 'Categories'


### PR DESCRIPTION
## Issue

- #6278

## 概要
カテゴリーページのカテゴリー作成ボタンの位置をタブの下に移動しました。

## 変更確認方法

1. ブランチ`feature/move-category-new-button`をローカルに取り込む
2. foreman start -f Procfile.devでローカル環境を立ち上げる
3. ブラウザで`http://localhost:3000`を開く
4. 管理者でログインする
5. `http://localhost:3000/mentor/categories`にアクセスする
6. `カテゴリー作成`ボタンの位置を確認する

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/99132547/73197200-7cc5-495c-8dd0-4c5ffef82f2f)

### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/99132547/5dd8ee23-dd53-47cf-9b33-00c028b41a52)

