### PR TITLE
企業編集ページのタイトル修正

### DIFF
--- a/app/views/admin/companies/edit.html.slim
+++ b/app/views/admin/companies/edit.html.slim
@@ -15,9 +15,9 @@ main.page-main
           h1.page-main-header__title
             | 企業編集
         .page-main-header__end
-          .page-header-actions
-            .page-header-actions__items
-              .page-header-actions__item
+          .page-main-header-actions
+            .page-main-header-actions__items
+              .page-main-header-actions__item
                 = link_to admin_companies_path, class: 'a-button is-md is-secondary is-block' do
                   i.fa-solid.fa-angle-left
                   | 企業一覧

--- a/app/views/admin/companies/edit.html.slim
+++ b/app/views/admin/companies/edit.html.slim
@@ -1,18 +1,26 @@
-- title '企業編集'
+- title '管理ページ'
 
 header.page-header
   .container
     .page-header__inner
       h1.page-header__title = title
-      .page-header-actions
-        .page-header-actions__items
-          .page-header-actions__item
-            = link_to new_admin_company_path, class: 'a-button is-md is-secondary is-block' do
-              i.fa-regular.fa-plus
-              | 企業追加
 
 = render 'admin/admin_page_tabs'
 
-.page-body
-  .container.is-md
-    = render 'form', company: @company
+main.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        .page-main-header__start
+          h1.page-main-header__title
+            | 企業編集
+        .page-main-header__end
+          .page-header-actions
+            .page-header-actions__items
+              .page-header-actions__item
+                = link_to admin_companies_path, class: 'a-button is-md is-secondary is-block' do
+                  i.fa-solid.fa-angle-left
+                  | 企業一覧
+  .page-body
+    .container.is-md
+      = render 'form', company: @company


### PR DESCRIPTION
## Issue

- #6284

## 概要
企業編集ページのタイトルを編集しました。
企業作成ボタンを削除し、企業一覧へのリンクを追加しました。

## 変更確認方法

1. ブランチ`feature/change-companies-editing-page-title`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. ブラウザでhttp://localhost:3000 を開く
4. 管理者でログインする
5. http://localhost:3000/admin/companies にアクセスする
6. 任意の企業の編集ボタンをクリックする
7. 企業編集ページのタイトル、ボタン、リンクが変更されていることを確認する

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/99132547/14f93263-34cd-4093-9eda-8284580912f3)

### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/99132547/fa6d9cc1-9abd-4837-907d-b9409910a24d)
