### PR TITLE
選択したテキストにURLをペーストしてMarkdownのリンクを自動生成する機能を実装

### DIFF
--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -14,6 +14,7 @@ import MarkDownItContainerDetails from 'markdown-it-container-details'
 import MarkDownItLinkAttributes from 'markdown-it-link-attributes'
 import MarkDownItContainerSpeak from 'markdown-it-container-speak'
 import CSRF from 'csrf'
+import TeaxtareaMarkdownLinkify from 'textarea-markdown-linkify'
 
 export default class {
   static initialize(selector) {
@@ -84,6 +85,9 @@ export default class {
 
     // user-icon
     new UserIconRenderer().render(selector)
+
+    // Convert selected text to markdown link on URL paste
+    new TeaxtareaMarkdownLinkify().linkify(selector)
   }
 
   static uninitialize(selector) {

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -14,7 +14,7 @@ import MarkDownItContainerDetails from 'markdown-it-container-details'
 import MarkDownItLinkAttributes from 'markdown-it-link-attributes'
 import MarkDownItContainerSpeak from 'markdown-it-container-speak'
 import CSRF from 'csrf'
-import TeaxtareaMarkdownLinkify from 'textarea-markdown-linkify'
+import TextareaMarkdownLinkify from 'textarea-markdown-linkify'
 
 export default class {
   static initialize(selector) {
@@ -87,7 +87,7 @@ export default class {
     new UserIconRenderer().render(selector)
 
     // Convert selected text to markdown link on URL paste
-    new TeaxtareaMarkdownLinkify().linkify(selector)
+    new TextareaMarkdownLinkify().linkify(selector)
   }
 
   static uninitialize(selector) {

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -19,9 +19,7 @@ import TextareaMarkdownLinkify from 'textarea-markdown-linkify'
 export default class {
   static initialize(selector) {
     const textareas = document.querySelectorAll(selector)
-    if (textareas.length === 0) {
-      return null
-    }
+    if (!textareas.length) return
 
     // autosize
     autosize(textareas)

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -1,0 +1,37 @@
+import MarkdownIt from 'markdown-it'
+
+export default class {
+  linkify(selector) {
+    const textareas = document.querySelectorAll(selector)
+    if (textareas.length === 0) {
+      return null
+    }
+
+    Array.from(textareas).forEach((textarea) => {
+      textarea.addEventListener('paste', (event) => {
+        const pasteText = event.clipboardData.getData('text')
+        const selectedText = window.getSelection().toString()
+        if (selectedText && this._isURL(pasteText)) {
+          event.preventDefault()
+          const markdownLink = `[${selectedText}](${pasteText})`
+          const selectionStart = textarea.selectionStart
+          const selectionEnd = textarea.selectionEnd
+          const newText =
+            textarea.value.slice(0, selectionStart) +
+            markdownLink +
+            textarea.value.slice(selectionEnd)
+          textarea.value = newText
+          textarea.setSelectionRange(
+            selectionStart + markdownLink.length,
+            selectionStart + markdownLink.length
+          )
+        }
+      })
+    })
+  }
+
+  _isURL(str) {
+    const md = new MarkdownIt()
+    return md.linkify.match(str)?.[0].url === str
+  }
+}

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -10,12 +10,12 @@ export default class {
     Array.from(textareas).forEach((textarea) => {
       textarea.addEventListener('paste', (event) => {
         const pasteText = event.clipboardData.getData('text')
-        const selectedText = window.getSelection().toString()
+        const selectionStart = textarea.selectionStart
+        const selectionEnd = textarea.selectionEnd
+        const selectedText = textarea.value.slice(selectionStart, selectionEnd)
         if (selectedText && this._isURL(pasteText)) {
           event.preventDefault()
           const markdownLink = `[${selectedText}](${pasteText})`
-          const selectionStart = textarea.selectionStart
-          const selectionEnd = textarea.selectionEnd
           textarea.setRangeText(
             markdownLink,
             selectionStart,

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -8,15 +8,19 @@ export default class {
     }
 
     Array.from(textareas).forEach((textarea) => {
-      textarea.addEventListener('paste', (event) => {
-        const pasteText = event.clipboardData.getData('text')
+      textarea.addEventListener('paste', async (event) => {
+        event.preventDefault()
         const selectionStart = textarea.selectionStart
         const selectionEnd = textarea.selectionEnd
         const selectedText = textarea.value.slice(selectionStart, selectionEnd)
+        const pasteText =
+          event.clipboardData.getData('text') ||
+          (await navigator.clipboard.readText())
         if (selectedText && this._isURL(pasteText)) {
-          event.preventDefault()
           const markdownLink = `[${selectedText}](${pasteText})`
           document.execCommand('insertText', false, markdownLink)
+        } else {
+          document.execCommand('insertText', false, pasteText)
         }
       })
     })

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -16,12 +16,7 @@ export default class {
         if (selectedText && this._isURL(pasteText)) {
           event.preventDefault()
           const markdownLink = `[${selectedText}](${pasteText})`
-          textarea.setRangeText(
-            markdownLink,
-            selectionStart,
-            selectionEnd,
-            'end'
-          )
+          document.execCommand('insertText', false, markdownLink)
         }
       })
     })

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -10,8 +10,7 @@ export default class {
     Array.from(textareas).forEach((textarea) => {
       textarea.addEventListener('paste', async (event) => {
         event.preventDefault()
-        const selectionStart = textarea.selectionStart
-        const selectionEnd = textarea.selectionEnd
+        const { selectionStart, selectionEnd } = textarea
         const selectedText = textarea.value.slice(selectionStart, selectionEnd)
         const pasteText =
           event.clipboardData.getData('text') ||

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -16,14 +16,11 @@ export default class {
           const markdownLink = `[${selectedText}](${pasteText})`
           const selectionStart = textarea.selectionStart
           const selectionEnd = textarea.selectionEnd
-          const newText =
-            textarea.value.slice(0, selectionStart) +
-            markdownLink +
-            textarea.value.slice(selectionEnd)
-          textarea.value = newText
-          textarea.setSelectionRange(
-            selectionStart + markdownLink.length,
-            selectionStart + markdownLink.length
+          textarea.setRangeText(
+            markdownLink,
+            selectionStart,
+            selectionEnd,
+            'end'
           )
         }
       })

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -12,6 +12,8 @@ export default class {
         event.preventDefault()
         const { selectionStart, selectionEnd } = textarea
         const selectedText = textarea.value.slice(selectionStart, selectionEnd)
+        // headless chromeではevent.clipboardData.getData('text')は空文字を返すため、代わりにnavigator.clipboard.readText()を使用
+        // https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325362833
         const pasteText =
           event.clipboardData.getData('text') ||
           (await navigator.clipboard.readText())
@@ -25,6 +27,8 @@ export default class {
     })
   }
 
+  // URLの判定にlinkify-itを使用している理由
+  // https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325332666
   _isURL(str) {
     const md = new MarkdownIt()
     return md.linkify.match(str)?.[0].url === str

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -3,9 +3,7 @@ import MarkdownIt from 'markdown-it'
 export default class {
   linkify(selector) {
     const textareas = document.querySelectorAll(selector)
-    if (textareas.length === 0) {
-      return null
-    }
+    if (!textareas.length) return
 
     Array.from(textareas).forEach((textarea) => {
       textarea.addEventListener('paste', async (event) => {

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -15,14 +15,14 @@ export default class {
         const escapedSelectedText = selectedText.replace(/[[\]]/g, '\\$&')
         // headless chromeではevent.clipboardData.getData('text')は空文字を返すため、代わりにnavigator.clipboard.readText()を使用
         // https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325362833
-        const pasteText =
+        const clipboardText =
           event.clipboardData.getData('text') ||
           (await navigator.clipboard.readText())
-        if (selectedText && this._isURL(pasteText)) {
-          const markdownLink = `[${escapedSelectedText}](${pasteText})`
+        if (selectedText && this._isURL(clipboardText)) {
+          const markdownLink = `[${escapedSelectedText}](${clipboardText})`
           document.execCommand('insertText', false, markdownLink)
         } else {
-          document.execCommand('insertText', false, pasteText)
+          document.execCommand('insertText', false, clipboardText)
         }
       })
     })

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -15,8 +15,7 @@ export default class {
         // headless chromeではevent.clipboardData.getData('text')は空文字を返すため、代わりにnavigator.clipboard.readText()を使用
         // https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325362833
         const pasteText =
-          event.clipboardData.getData('text') ||
-          (await navigator.clipboard.readText())
+          event.clipboardData.getData('text') || (await navigator.clipboard.readText())
         if (selectedText && this._isURL(pasteText)) {
           const markdownLink = `[${selectedText}](${pasteText})`
           document.execCommand('insertText', false, markdownLink)

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -18,12 +18,11 @@ export default class {
         const clipboardText =
           event.clipboardData.getData('text') ||
           (await navigator.clipboard.readText())
-        if (selectedText && this._isURL(clipboardText)) {
-          const markdownLink = `[${escapedSelectedText}](${clipboardText})`
-          document.execCommand('insertText', false, markdownLink)
-        } else {
-          document.execCommand('insertText', false, clipboardText)
-        }
+        const textToInsert =
+          selectedText && this._isURL(clipboardText)
+            ? `[${escapedSelectedText}](${clipboardText})`
+            : clipboardText
+        document.execCommand('insertText', false, textToInsert)
       })
     })
   }

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -16,7 +16,8 @@ export default class {
         // headless chromeではevent.clipboardData.getData('text')は空文字を返すため、代わりにnavigator.clipboard.readText()を使用
         // https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325362833
         const pasteText =
-          event.clipboardData.getData('text') || (await navigator.clipboard.readText())
+          event.clipboardData.getData('text') ||
+          (await navigator.clipboard.readText())
         if (selectedText && this._isURL(pasteText)) {
           const markdownLink = `[${escapedSelectedText}](${pasteText})`
           document.execCommand('insertText', false, markdownLink)

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -3,7 +3,6 @@ import MarkdownIt from 'markdown-it'
 export default class {
   linkify(selector) {
     const textareas = document.querySelectorAll(selector)
-    if (!textareas.length) return
 
     Array.from(textareas).forEach((textarea) => {
       textarea.addEventListener('paste', async (event) => {

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -12,12 +12,13 @@ export default class {
         event.preventDefault()
         const { selectionStart, selectionEnd } = textarea
         const selectedText = textarea.value.slice(selectionStart, selectionEnd)
+        const escapedSelectedText = selectedText.replace(/[[\]]/g, '\\$&')
         // headless chromeではevent.clipboardData.getData('text')は空文字を返すため、代わりにnavigator.clipboard.readText()を使用
         // https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325362833
         const pasteText =
           event.clipboardData.getData('text') || (await navigator.clipboard.readText())
         if (selectedText && this._isURL(pasteText)) {
-          const markdownLink = `[${selectedText}](${pasteText})`
+          const markdownLink = `[${escapedSelectedText}](${pasteText})`
           document.execCommand('insertText', false, markdownLink)
         } else {
           document.execCommand('insertText', false, pasteText)

--- a/app/javascript/textarea-markdown-linkify.js
+++ b/app/javascript/textarea-markdown-linkify.js
@@ -17,7 +17,7 @@ export default class {
           event.clipboardData.getData('text') ||
           (await navigator.clipboard.readText())
         const textToInsert =
-          selectedText && this._isURL(clipboardText)
+          escapedSelectedText && this._isURL(clipboardText)
             ? `[${escapedSelectedText}](${clipboardText})`
             : clipboardText
         document.execCommand('insertText', false, textToInsert)

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -44,16 +44,16 @@ class MarkdownTest < ApplicationSystemTestCase
     fill_in('report[description]', with: 'https://bootcamp.fjord.jp/')
     assert_field('report[description]', with: 'https://bootcamp.fjord.jp/')
     cmd_ctrl = page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
-    find('.js-report-content').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'x'])
+    find('#report_description').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'x'])
     fill_in('report[description]', with: 'FBC')
     assert_field('report[description]', with: 'FBC')
     grant_clipboard_read_permission
     clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
     assert_equal 'https://bootcamp.fjord.jp/', clip_text
     page.execute_script("document.querySelector('#report_description').select();")
-    find('.js-report-content').native.send_keys([cmd_ctrl, 'v'])
+    find('#report_description').native.send_keys([cmd_ctrl, 'v'])
     assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
-    find('.js-report-content').native.send_keys([cmd_ctrl, 'z'])
+    find('#report_description').native.send_keys([cmd_ctrl, 'z'])
     assert_field('report[description]', with: 'FBC')
   end
 

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -68,6 +68,10 @@ class MarkdownTest < ApplicationSystemTestCase
     find(selector).native.send_keys([cmd_ctrl, 'v'])
   end
 
+  def read_clipboard_text
+    page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+  end
+
   test 'should automatically create Markdown link when pasting a URL text into selected text' do
     visit_with_auth new_report_path, 'komagata'
     fill_in('report[description]', with: 'https://bootcamp.fjord.jp/')
@@ -76,7 +80,7 @@ class MarkdownTest < ApplicationSystemTestCase
     fill_in('report[description]', with: 'FBC')
     assert_field('report[description]', with: 'FBC')
     grant_clipboard_read_permission
-    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    clip_text = read_clipboard_text
     assert_equal 'https://bootcamp.fjord.jp/', clip_text
     select_text_and_paste('#report_description')
     assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
@@ -92,7 +96,7 @@ class MarkdownTest < ApplicationSystemTestCase
     fill_in('report[description]', with: 'test')
     assert_field('report[description]', with: 'test')
     grant_clipboard_read_permission
-    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    clip_text = read_clipboard_text
     assert_equal 'FBC', clip_text
     select_text_and_paste('#report_description')
     assert_field('report[description]', with: 'FBC')
@@ -104,7 +108,7 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_field('report[title]', with: 'https://bootcamp.fjord.jp/')
     all_copy('#report_title')
     grant_clipboard_read_permission
-    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    clip_text = read_clipboard_text
     assert_equal 'https://bootcamp.fjord.jp/', clip_text
     paste('#report_description')
     assert_field('report[description]', with: 'https://bootcamp.fjord.jp/')

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -28,7 +28,7 @@ class MarkdownTest < ApplicationSystemTestCase
     assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
   end
 
-  test 'should automatically create Markdown link by pasting URL into selected text' do
+  test 'should automatically create Markdown link when pasting a URL text into selected text' do
     visit_with_auth new_report_path, 'komagata'
     fill_in('report[description]', with: 'https://bootcamp.fjord.jp/')
     assert_field('report[description]', with: 'https://bootcamp.fjord.jp/')
@@ -52,5 +52,50 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
     find('.js-report-content').native.send_keys([cmd_ctrl, 'z'])
     assert_field('report[description]', with: 'FBC')
+  end
+
+  test 'should not create Markdown link when pasting non-URL text into selected text' do
+    visit_with_auth new_report_path, 'komagata'
+    fill_in('report[title]', with: 'FBC')
+    assert_field('report[title]', with: 'FBC')
+    cmd_ctrl = page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
+    find('#report_title').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
+    fill_in('report[description]', with: 'test')
+    assert_field('report[description]', with: 'test')
+    if !ENV['CI']
+      # クリップボードを読み取る権限を付与
+      cdp_permission = {
+        origin: page.server_url,
+        permission: { name: 'clipboard-read' },
+        setting: 'granted'
+      }
+      page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
+      clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+      assert_equal 'FBC', clip_text
+    end
+    page.execute_script("document.querySelector('#report_description').select();")
+    find('#report_description').native.send_keys([cmd_ctrl, 'v'])
+    assert_field('report[description]', with: 'FBC')
+  end
+
+  test 'should not create Markdown link when pasting a URL text without text selection' do
+    visit_with_auth new_report_path, 'komagata'
+    fill_in('report[title]', with: 'https://bootcamp.fjord.jp/')
+    assert_field('report[title]', with: 'https://bootcamp.fjord.jp/')
+    cmd_ctrl = page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
+    find('#report_title').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
+    if !ENV['CI']
+      # クリップボードを読み取る権限を付与
+      cdp_permission = {
+        origin: page.server_url,
+        permission: { name: 'clipboard-read' },
+        setting: 'granted'
+      }
+      page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
+      clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+      assert_equal 'https://bootcamp.fjord.jp/', clip_text
+    end
+    find('#report_description').native.send_keys([cmd_ctrl, 'v'])
+    assert_field('report[description]', with: 'https://bootcamp.fjord.jp/')
   end
 end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -28,6 +28,9 @@ class MarkdownTest < ApplicationSystemTestCase
     assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
   end
 
+  # ローカル環境のheadless chromeでのテスト実行時にのみ必要
+  # https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325417231
+  # https://bootcamp.fjord.jp/reports/80292
   def grant_clipboard_read_permission
     unless ENV['CI']
       cdp_permission = {
@@ -51,6 +54,9 @@ class MarkdownTest < ApplicationSystemTestCase
     find(selector).native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
   end
 
+  # CIでのみペースト前のctrl + Aが効かないため文字列の選択をselect()メソッドで実行
+  # https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325419865
+  # https://bootcamp.fjord.jp/questions/1720
   def select_text_and_paste(selector)
     page.execute_script("document.querySelector('#{selector}').select();")
     find(selector).native.send_keys([cmd_ctrl, 'v'])

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -27,4 +27,24 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_css "a[href='/users/mentormentaro']"
     assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
   end
+
+  test 'should automatically create Markdown link by pasting URL into selected text' do
+    visit_with_auth new_report_path, 'komagata'
+    fill_in('report[description]', with: 'https://bootcamp.fjord.jp/')
+    find('.js-report-content').native.send_keys([:command, 'a'], [:command, 'c'], :delete)
+    fill_in('report[description]', with: 'FBC')
+    find('.js-report-content').native.send_keys([:command, 'a'], [:command, 'v'])
+    assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
+  end
+
+  test 'should support undo after automatically create Markdown link by pasting URL into selected text' do
+    visit_with_auth new_report_path, 'komagata'
+    fill_in('report[description]', with: 'https://bootcamp.fjord.jp/')
+    find('.js-report-content').native.send_keys([:command, 'a'], [:command, 'c'], :delete)
+    fill_in('report[description]', with: 'FBC')
+    find('.js-report-content').native.send_keys([:command, 'a'], [:command, 'v'])
+    assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
+    find('.js-report-content').native.send_keys([:command, 'z'])
+    assert_field('report[description]', with: 'FBC')
+  end
 end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -45,7 +45,8 @@ class MarkdownTest < ApplicationSystemTestCase
     page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
     clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
     assert_equal 'https://bootcamp.fjord.jp/', clip_text
-    find('.js-report-content').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'v'])
+    page.execute_script("document.querySelector('#report_description').select();")
+    find('.js-report-content').native.send_keys([cmd_ctrl, 'v'])
     assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
     find('.js-report-content').native.send_keys([cmd_ctrl, 'z'])
     assert_field('report[description]', with: 'FBC')

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -36,7 +36,7 @@ class MarkdownTest < ApplicationSystemTestCase
     find('.js-report-content').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'x'])
     fill_in('report[description]', with: 'FBC')
     assert_field('report[description]', with: 'FBC')
-    if !ENV['CI']
+    unless ENV['CI']
       # クリップボードを読み取る権限を付与
       cdp_permission = {
         origin: page.server_url,
@@ -62,7 +62,7 @@ class MarkdownTest < ApplicationSystemTestCase
     find('#report_title').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
     fill_in('report[description]', with: 'test')
     assert_field('report[description]', with: 'test')
-    if !ENV['CI']
+    unless ENV['CI']
       # クリップボードを読み取る権限を付与
       cdp_permission = {
         origin: page.server_url,
@@ -84,7 +84,7 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_field('report[title]', with: 'https://bootcamp.fjord.jp/')
     cmd_ctrl = page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
     find('#report_title').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
-    if !ENV['CI']
+    unless ENV['CI']
       # クリップボードを読み取る権限を付与
       cdp_permission = {
         origin: page.server_url,

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -28,18 +28,16 @@ class MarkdownTest < ApplicationSystemTestCase
     assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
   end
 
-  # ローカル環境のheadless chromeでのテスト実行時にのみ必要
+  # headless chromeでnavigator.clipboard.readText()を実行する時に必要
   # https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325417231
   # https://bootcamp.fjord.jp/reports/80292
   def grant_clipboard_read_permission
-    unless ENV['CI']
-      cdp_permission = {
-        origin: page.server_url,
-        permission: { name: 'clipboard-read' },
-        setting: 'granted'
-      }
-      page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
-    end
+    cdp_permission = {
+      origin: page.server_url,
+      permission: { name: 'clipboard-read' },
+      setting: 'granted'
+    }
+    page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
   end
 
   def cmd_ctrl

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -32,7 +32,8 @@ class MarkdownTest < ApplicationSystemTestCase
     visit_with_auth new_report_path, 'komagata'
     fill_in('report[description]', with: 'https://bootcamp.fjord.jp/')
     assert_field('report[description]', with: 'https://bootcamp.fjord.jp/')
-    find('.js-report-content').native.send_keys([:command, 'a'], [:command, 'x'])
+    cmd_ctrl = page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
+    find('.js-report-content').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'x'])
     fill_in('report[description]', with: 'FBC')
     assert_field('report[description]', with: 'FBC')
     # クリップボードを読み取る権限を付与
@@ -44,9 +45,9 @@ class MarkdownTest < ApplicationSystemTestCase
     page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
     clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
     assert_equal 'https://bootcamp.fjord.jp/', clip_text
-    find('.js-report-content').native.send_keys([:command, 'a'], [:command, 'v'])
+    find('.js-report-content').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'v'])
     assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
-    find('.js-report-content').native.send_keys([:command, 'z'])
+    find('.js-report-content').native.send_keys([cmd_ctrl, 'z'])
     assert_field('report[description]', with: 'FBC')
   end
 end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -28,6 +28,17 @@ class MarkdownTest < ApplicationSystemTestCase
     assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
   end
 
+  def grant_clipboard_read_permission
+    unless ENV['CI']
+      cdp_permission = {
+        origin: page.server_url,
+        permission: { name: 'clipboard-read' },
+        setting: 'granted'
+      }
+      page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
+    end
+  end
+
   test 'should automatically create Markdown link when pasting a URL text into selected text' do
     visit_with_auth new_report_path, 'komagata'
     fill_in('report[description]', with: 'https://bootcamp.fjord.jp/')
@@ -36,17 +47,9 @@ class MarkdownTest < ApplicationSystemTestCase
     find('.js-report-content').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'x'])
     fill_in('report[description]', with: 'FBC')
     assert_field('report[description]', with: 'FBC')
-    unless ENV['CI']
-      # クリップボードを読み取る権限を付与
-      cdp_permission = {
-        origin: page.server_url,
-        permission: { name: 'clipboard-read' },
-        setting: 'granted'
-      }
-      page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
-      clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
-      assert_equal 'https://bootcamp.fjord.jp/', clip_text
-    end
+    grant_clipboard_read_permission
+    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    assert_equal 'https://bootcamp.fjord.jp/', clip_text
     page.execute_script("document.querySelector('#report_description').select();")
     find('.js-report-content').native.send_keys([cmd_ctrl, 'v'])
     assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
@@ -62,17 +65,9 @@ class MarkdownTest < ApplicationSystemTestCase
     find('#report_title').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
     fill_in('report[description]', with: 'test')
     assert_field('report[description]', with: 'test')
-    unless ENV['CI']
-      # クリップボードを読み取る権限を付与
-      cdp_permission = {
-        origin: page.server_url,
-        permission: { name: 'clipboard-read' },
-        setting: 'granted'
-      }
-      page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
-      clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
-      assert_equal 'FBC', clip_text
-    end
+    grant_clipboard_read_permission
+    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    assert_equal 'FBC', clip_text
     page.execute_script("document.querySelector('#report_description').select();")
     find('#report_description').native.send_keys([cmd_ctrl, 'v'])
     assert_field('report[description]', with: 'FBC')
@@ -84,17 +79,9 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_field('report[title]', with: 'https://bootcamp.fjord.jp/')
     cmd_ctrl = page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
     find('#report_title').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
-    unless ENV['CI']
-      # クリップボードを読み取る権限を付与
-      cdp_permission = {
-        origin: page.server_url,
-        permission: { name: 'clipboard-read' },
-        setting: 'granted'
-      }
-      page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
-      clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
-      assert_equal 'https://bootcamp.fjord.jp/', clip_text
-    end
+    grant_clipboard_read_permission
+    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    assert_equal 'https://bootcamp.fjord.jp/', clip_text
     find('#report_description').native.send_keys([cmd_ctrl, 'v'])
     assert_field('report[description]', with: 'https://bootcamp.fjord.jp/')
   end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -36,15 +36,17 @@ class MarkdownTest < ApplicationSystemTestCase
     find('.js-report-content').native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'x'])
     fill_in('report[description]', with: 'FBC')
     assert_field('report[description]', with: 'FBC')
-    # クリップボードを読み取る権限を付与
-    cdp_permission = {
-      origin: page.server_url,
-      permission: { name: 'clipboard-read' },
-      setting: 'granted'
-    }
-    page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
-    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
-    assert_equal 'https://bootcamp.fjord.jp/', clip_text
+    if !ENV['CI']
+      # クリップボードを読み取る権限を付与
+      cdp_permission = {
+        origin: page.server_url,
+        permission: { name: 'clipboard-read' },
+        setting: 'granted'
+      }
+      page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
+      clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+      assert_equal 'https://bootcamp.fjord.jp/', clip_text
+    end
     page.execute_script("document.querySelector('#report_description').select();")
     find('.js-report-content').native.send_keys([cmd_ctrl, 'v'])
     assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -61,7 +61,7 @@ class MarkdownTest < ApplicationSystemTestCase
   # https://bootcamp.fjord.jp/questions/1720
   def select_text_and_paste(selector)
     page.execute_script("document.querySelector('#{selector}').select();")
-    find(selector).native.send_keys([cmd_ctrl, 'v'])
+    paste(selector)
   end
 
   def undo(selector)

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -73,11 +73,11 @@ class MarkdownTest < ApplicationSystemTestCase
     fill_in('report[title]', with: 'https://bootcamp.fjord.jp/')
     assert_field('report[title]', with: 'https://bootcamp.fjord.jp/')
     all_copy('#report_title')
-    fill_in('report[description]', with: 'FBC')
-    assert_field('report[description]', with: 'FBC')
     grant_clipboard_read_permission
     clip_text = read_clipboard_text
     assert_equal 'https://bootcamp.fjord.jp/', clip_text
+    fill_in('report[description]', with: 'FBC')
+    assert_field('report[description]', with: 'FBC')
     select_text_and_paste('#report_description')
     assert_field('report[description]', with: '[FBC](https://bootcamp.fjord.jp/)')
     undo('#report_description')
@@ -89,11 +89,11 @@ class MarkdownTest < ApplicationSystemTestCase
     fill_in('report[title]', with: 'FBC')
     assert_field('report[title]', with: 'FBC')
     all_copy('#report_title')
-    fill_in('report[description]', with: 'test')
-    assert_field('report[description]', with: 'test')
     grant_clipboard_read_permission
     clip_text = read_clipboard_text
     assert_equal 'FBC', clip_text
+    fill_in('report[description]', with: 'test')
+    assert_field('report[description]', with: 'test')
     select_text_and_paste('#report_description')
     assert_field('report[description]', with: 'FBC')
   end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -28,6 +28,14 @@ class MarkdownTest < ApplicationSystemTestCase
     assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
   end
 
+  def cmd_ctrl
+    page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
+  end
+
+  def all_copy(selector)
+    find(selector).native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
+  end
+
   # headless chromeでnavigator.clipboard.readText()を実行する時に必要
   # https://github.com/fjordllc/bootcamp/pull/6747#discussion_r1325417231
   # https://bootcamp.fjord.jp/reports/80292
@@ -40,12 +48,12 @@ class MarkdownTest < ApplicationSystemTestCase
     page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
   end
 
-  def cmd_ctrl
-    page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
+  def read_clipboard_text
+    page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
   end
 
-  def all_copy(selector)
-    find(selector).native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
+  def paste(selector)
+    find(selector).native.send_keys([cmd_ctrl, 'v'])
   end
 
   # CIでのみペースト前のctrl + Aが効かないため文字列の選択をselect()メソッドで実行
@@ -58,14 +66,6 @@ class MarkdownTest < ApplicationSystemTestCase
 
   def undo(selector)
     find(selector).native.send_keys([cmd_ctrl, 'z'])
-  end
-
-  def paste(selector)
-    find(selector).native.send_keys([cmd_ctrl, 'v'])
-  end
-
-  def read_clipboard_text
-    page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
   end
 
   test 'should automatically create Markdown link when pasting a URL text into selected text' do

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -113,4 +113,18 @@ class MarkdownTest < ApplicationSystemTestCase
     paste('#report_description')
     assert_field('report[description]', with: 'https://bootcamp.fjord.jp/')
   end
+
+  test 'should escape square brackets in the selected text when pasting a URL text' do
+    visit_with_auth new_report_path, 'komagata'
+    fill_in('report[title]', with: 'https://bootcamp.fjord.jp/')
+    assert_field('report[title]', with: 'https://bootcamp.fjord.jp/')
+    all_copy('#report_title')
+    grant_clipboard_read_permission
+    clip_text = read_clipboard_text
+    assert_equal 'https://bootcamp.fjord.jp/', clip_text
+    fill_in('report[description]', with: '[]')
+    assert_field('report[description]', with: '[]')
+    select_text_and_paste('#report_description')
+    assert_field('report[description]', with: '[\[\]](https://bootcamp.fjord.jp/)')
+  end
 end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -44,10 +44,6 @@ class MarkdownTest < ApplicationSystemTestCase
     page.driver.browser.capabilities.platform_name.include?('mac') ? :command : :control
   end
 
-  def all_cut(selector)
-    find(selector).native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'x'])
-  end
-
   def all_copy(selector)
     find(selector).native.send_keys([cmd_ctrl, 'a'], [cmd_ctrl, 'c'])
   end
@@ -74,9 +70,9 @@ class MarkdownTest < ApplicationSystemTestCase
 
   test 'should automatically create Markdown link when pasting a URL text into selected text' do
     visit_with_auth new_report_path, 'komagata'
-    fill_in('report[description]', with: 'https://bootcamp.fjord.jp/')
-    assert_field('report[description]', with: 'https://bootcamp.fjord.jp/')
-    all_cut('#report_description')
+    fill_in('report[title]', with: 'https://bootcamp.fjord.jp/')
+    assert_field('report[title]', with: 'https://bootcamp.fjord.jp/')
+    all_copy('#report_title')
     fill_in('report[description]', with: 'FBC')
     assert_field('report[description]', with: 'FBC')
     grant_clipboard_read_permission


### PR DESCRIPTION
## Issue

- #6385 

## 概要
- bootcampアプリのMarkdownエディタで、選択したテキストにURLをペーストすると自動でMarkdownのリンクに変換する機能を実装しました。
  - `FBC`の文字列を選択した状態で`https://bootcamp.fjord.jp/`をペーストすると`[FBC](https://bootcamp.fjord.jp/)`になる
- `TextareaInitializer.initialize`が実行されているviewファイルのtextarea内で機能します。

## 変更確認方法

1. `feature/linkify-selected-text-on-url-paste`をローカルに取り込む
1. `bin/rails s`でサーバーを起動
1. `localhost:3000`にアクセスし、`komagata`でログイン
1. 日報作成画面(`/reports/new`)にアクセス
1. 日報の「内容」のtextarea内に`FBC`を入力する
1. `FBC`の文字列を選択した状態で`https://bootcamp.fjord.jp/`をペーストする
1. `[FBC](https://bootcamp.fjord.jp/)`に変換されることを確認する

## Screenshot

### 変更前
https://github.com/fjordllc/bootcamp/assets/65595901/06aeb7e5-6d9a-43a5-b986-787ce33629cf

### 変更後
https://github.com/fjordllc/bootcamp/assets/65595901/230e7fdd-6a04-409a-ad80-f3b0e26481e6

## 参考
- [Q&A：ヘッドレスブラザで実行するとコピペするシステムテストが落ちる | FBC](https://bootcamp.fjord.jp/questions/1720)
- [Q&A：Railsのシステムテストをヘッドレスブラウザで実行し、その際に実行されるJSのコードをデバッグしたい | FBC](https://bootcamp.fjord.jp/questions/1728)
