### PR TITLE
RangeErrorを解消し、スマホからhash付きのコメントURLにアクセスできるようにする

### DIFF
--- a/app/javascript/components/footprints.vue
+++ b/app/javascript/components/footprints.vue
@@ -64,9 +64,6 @@ export default {
     }
   },
   created() {
-    window.onpopstate = function () {
-      location.replace(location.href)
-    }
     this.getFootprints()
   },
   methods: {


### PR DESCRIPTION
## Issue

## 概要

iPhoneのSafariからhash付きのコメントURLにアクセスすると

![257038731-d201d4d8-5d55-49b0-8fc2-2251ab2a7aef_PNG__1170×2532_](https://github.com/fjordllc/bootcamp/assets/50437473/c46c6017-f4f3-444e-9148-5a3ff9e69811)

のようなエラーが発生し、クラッシュしていました。

原因を探るためPCのChromeでアクセスすると、

![_70_【WebAP】「Webを支える技術」読了🎉___FBC](https://github.com/fjordllc/bootcamp/assets/50437473/23afe01f-5306-42ba-bd37-c3849bf29583)

クラッシュはしないのですが、上記のように

https://github.com/fjordllc/bootcamp/blob/c6187a325d16c534399f72cf96be9850c1e33d1f/app/javascript/components/footprints.vue#L66-L71

の`window.onpopstate`にて無限ループが発生していることが分かりました。

少し調査したところ、このような記述は

https://github.com/fjordllc/bootcamp/blob/c6187a325d16c534399f72cf96be9850c1e33d1f/app/javascript/notifications.vue#L77-L83

にて、ブラウザバック/フォワード時にページャーを読み込ませるために必要なもののようです。
しかしfootprints.vueではこのような挙動は不要のため、この3行を単純に削除してエラーを解消したいと考えています。

## 変更確認方法

1. `bug/range-error`をローカルに取り込む
2. (ユーザー1操作)日報上で、ユーザー2へのメンションを含むコメントをする。
3. (ユーザー2操作)通知タブを開き、メンションされた日報コメントにアクセスする。
4. (ユーザー2操作)アクセスした日報ページで検証ツールのConsoleを開き、`Uncaught RangeError`が発生していないことを確認する。

## Screenshot

### 変更前

![_70_【WebAP】「Webを支える技術」読了🎉___FBC](https://github.com/fjordllc/bootcamp/assets/50437473/12f9c59b-2513-464d-bbaf-2f72187f010f)

### 変更後

![_development__テストのお知らせ___FBC](https://github.com/fjordllc/bootcamp/assets/50437473/a33e80a9-dcc5-4b89-9067-7e4353744425)
