### PR TITLE
提出物を更新した時の通知の文面を変更した

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -196,4 +196,10 @@ class Product < ApplicationRecord
   def delete_commented_at
     update_commented_at(comments.last)
   end
+
+  def updated_after_submission?
+    return false if saved_change_to_attribute?('published_at', from: nil)
+
+    created_at != updated_at
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -197,6 +197,10 @@ class Product < ApplicationRecord
     update_commented_at(comments.last)
   end
 
+  def notification_type
+    updated_after_submission? ? :product_update : :submitted
+  end
+
   def updated_after_submission?
     return false if saved_change_to_attribute?('published_at', from: nil)
 

--- a/app/models/product_notifier_for_colleague.rb
+++ b/app/models/product_notifier_for_colleague.rb
@@ -24,9 +24,8 @@ class ProductNotifierForColleague
   end
 
   def send_notification(product:, receivers:)
-    notification = product.updated_after_submission? ? :product_update : :submitted
     receivers.each do |receiver|
-      ActivityDelivery.with(product: product, receiver: receiver).notify(notification)
+      ActivityDelivery.with(product: product, receiver: receiver).notify(product.notification_type)
     end
   end
 end

--- a/app/models/product_notifier_for_colleague.rb
+++ b/app/models/product_notifier_for_colleague.rb
@@ -24,8 +24,9 @@ class ProductNotifierForColleague
   end
 
   def send_notification(product:, receivers:)
+    notification = product.updated_after_submission? ? :product_update : :submitted
     receivers.each do |receiver|
-      ActivityDelivery.with(product: product, receiver: receiver).notify(:submitted)
+      ActivityDelivery.with(product: product, receiver: receiver).notify(notification)
     end
   end
 end

--- a/app/models/product_notifier_for_practice_watcher.rb
+++ b/app/models/product_notifier_for_practice_watcher.rb
@@ -16,9 +16,8 @@ class ProductNotifierForPracticeWatcher
   private
 
   def send_notification(product:, receivers:)
-    notification = product.updated_after_submission? ? :product_update : :submitted
     receivers.each do |receiver|
-      ActivityDelivery.with(product: product, receiver: receiver).notify(notification)
+      ActivityDelivery.with(product: product, receiver: receiver).notify(product.notification_type)
     end
   end
 end

--- a/app/models/product_notifier_for_practice_watcher.rb
+++ b/app/models/product_notifier_for_practice_watcher.rb
@@ -16,8 +16,9 @@ class ProductNotifierForPracticeWatcher
   private
 
   def send_notification(product:, receivers:)
+    notification = product.updated_after_submission? ? :product_update : :submitted
     receivers.each do |receiver|
-      ActivityDelivery.with(product: product, receiver: receiver).notify(:submitted)
+      ActivityDelivery.with(product: product, receiver: receiver).notify(notification)
     end
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -160,7 +160,7 @@ class ProductTest < ActiveSupport::TestCase
     assert_not_includes product_id_list, no_replied_wip_product.id
   end
 
-  test '#updated_after_submission? return true when product is updated after submission' do
+  test '#notification_type return :product_update when product is updated after submission' do
     product = Product.create!(
       body: 'test',
       user: users(:kimura),
@@ -170,15 +170,15 @@ class ProductTest < ActiveSupport::TestCase
     )
 
     product.update!(body: 'product is updated.')
-    assert product.updated_after_submission?
+    assert_equal :product_update, product.notification_type
 
     product.update!(body: 'product is saved as WIP.', wip: true)
 
     product.update!(body: 'product is reupdated.', wip: false, published_at: Time.current)
-    assert product.updated_after_submission?
+    assert_equal :product_update, product.notification_type
   end
 
-  test '#updated_after_submission? return false when product is first saved as WIP then updated' do
+  test '#notification_type return :submitted when product is first saved as WIP then updated' do
     product = Product.create!(
       body: 'first saved as WIP',
       user: users(:kimura),
@@ -188,6 +188,6 @@ class ProductTest < ActiveSupport::TestCase
     )
 
     product.update!(body: 'product is updated.', wip: false, published_at: Time.current)
-    assert_not product.updated_after_submission?
+    assert_equal :submitted, product.notification_type
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -160,25 +160,7 @@ class ProductTest < ActiveSupport::TestCase
     assert_not_includes product_id_list, no_replied_wip_product.id
   end
 
-  test '#notification_type return :product_update when product is updated after submission' do
-    product = Product.create!(
-      body: 'test',
-      user: users(:kimura),
-      practice: practices(:practice5),
-      checker_id: nil,
-      published_at: Time.current
-    )
-
-    product.update!(body: 'product is updated.')
-    assert_equal :product_update, product.notification_type
-
-    product.update!(body: 'product is saved as WIP.', wip: true)
-
-    product.update!(body: 'product is reupdated.', wip: false, published_at: Time.current)
-    assert_equal :product_update, product.notification_type
-  end
-
-  test '#notification_type return :submitted when product is first saved as WIP then updated' do
+  test '#notification_type' do
     product = Product.create!(
       body: 'first saved as WIP',
       user: users(:kimura),
@@ -187,7 +169,12 @@ class ProductTest < ActiveSupport::TestCase
       wip: true
     )
 
-    product.update!(body: 'product is updated.', wip: false, published_at: Time.current)
+    product.update!(body: 'product is submitted.', wip: false, published_at: Time.current)
     assert_equal :submitted, product.notification_type
+
+    product.update!(body: 'product is saved as WIP after submission.', wip: true)
+
+    product.update!(body: 'product is updated.', wip: false, published_at: Time.current)
+    assert_equal :product_update, product.notification_type
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -159,4 +159,35 @@ class ProductTest < ActiveSupport::TestCase
     product_id_list = Product.self_assigned_no_replied_products(mentor.id).pluck(:id)
     assert_not_includes product_id_list, no_replied_wip_product.id
   end
+
+  test '#updated_after_submission? return true when product is updated after submission' do
+    product = Product.create!(
+      body: 'test',
+      user: users(:kimura),
+      practice: practices(:practice5),
+      checker_id: nil,
+      published_at: Time.current
+    )
+
+    product.update!(body: 'product is updated.')
+    assert product.updated_after_submission?
+
+    product.update!(body: 'product is saved as WIP.', wip: true)
+
+    product.update!(body: 'product is reupdated.', wip: false, published_at: Time.current)
+    assert product.updated_after_submission?
+  end
+
+  test '#updated_after_submission? return false when product is first saved as WIP then updated' do
+    product = Product.create!(
+      body: 'first saved as WIP',
+      user: users(:kimura),
+      practice: practices(:practice5),
+      checker_id: nil,
+      wip: true
+    )
+
+    product.update!(body: 'product is updated.', wip: false, published_at: Time.current)
+    assert_not product.updated_after_submission?
+  end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -177,4 +177,26 @@ class ProductTest < ActiveSupport::TestCase
     product.update!(body: 'product is updated.', wip: false, published_at: Time.current)
     assert_equal :product_update, product.notification_type
   end
+
+  test '#updated_after_submission?' do
+    product = Product.create!(
+      body: 'product is submitted.',
+      user: users(:kimura),
+      practice: practices(:practice5),
+      checker_id: nil
+    )
+    assert_not product.updated_after_submission?
+    product.update!(body: 'product is updated.')
+    assert product.updated_after_submission?
+
+    wip_product = Product.create!(
+      body: 'first saved as wip.',
+      user: users(:kimura),
+      practice: practices(:practice7),
+      checker_id: nil,
+      wip: true
+    )
+    wip_product.update!(body: 'product is updated.', wip: false, published_at: Time.current)
+    assert_not wip_product.updated_after_submission?
+  end
 end


### PR DESCRIPTION
## Issue

- #6647 

## 概要

以下の2つの通知に関して、提出物が更新された場合に飛ぶ通知の文面が`〇〇さんが「×××」の提出物を提出しました。`となっていたのを、`〇〇さんの提出物が更新されました`となるよう変更しました。

+ 提出物が作成or更新された際に、そのプラクティスをwatchしているメンターに飛ぶ通知
+ 企業の研修生が提出物を作成or更新した際に、同じ企業に属しているアドバイザーに飛ぶ通知

## 変更確認方法
最初に、次の下準備をお願いします。

1. `feature/change-notification-message-when-product-is-updated`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバを起動
3. komagataでログイン
4. プラクティス一覧ページを開き、「Terminalの基礎を覚える」プラクティスを選択。
<img width="912" alt="_development__Railsプログラマーコース___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/8500d59f-9d13-4d7e-9932-c61fbe206181">

5. プラクティスをWatchする。
<img width="849" alt="_development__Terminalの基礎を覚える___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/d288ebdf-e56c-44db-befa-24dc4e342642">

### 提出物を提出し、更新した場合
1. kensyuでログイン
2. 「Terminalの基礎を覚える」プラクティスの提出物を提出する
3. senpaiでログインし、`kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました`という通知が来ていることを確認する
4. komagataでログインし、`kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました`という通知が来ていることを確認する
6. kensyuでログインし、2で提出した提出物を再提出する
7. senpaiでログインし、`kensyuさんの提出物が更新されました`という通知が来ていることを確認する
8. komagataでログインし、`kensyuさんの提出物が更新されました`という通知が来ていることを確認する

7まで確認が終わったら、次の確認に備えて2で作成した提出物を削除します。

### 最初に提出物をWIPで保存し、提出した場合
1. kensyuでログイン
2. 「Terminalの基礎を覚える」プラクティスの提出物を、WIPで保存する
3. 2で保存した提出物を、提出する
4. senpaiでログインし、`kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました`という通知が来ていることを確認する
5. komagataでログインし、`kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました`という通知が来ていることを確認する

5まで確認が終わったら、次の確認に備えて2で保存した提出物を削除します。

### 提出物を提出し、WIPで保存し、更新した場合
1. kensyuでログイン
2. 「Terminalの基礎を覚える」プラクティスの提出物を提出する
3. senpaiでログインし、`kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました`という通知が来ていることを確認する
4. komagataでログインし、`kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました`という通知が来ていることを確認する
5. kensyuでログインし、2で提出した提出物を、WIPで保存する。
6. 5で保存した提出物を、提出する。
7. senpaiでログインし、`kensyuさんの提出物が更新されました`という通知が来ていることを確認する
9. komagataでログインし、`kensyuさんの提出物が更新されました`という通知が来ていることを確認する


## Screenshot

### 変更前
+ プラクティスをWatchしているメンターに飛ぶ通知

<img width="241" alt="_development__ダッシュボード___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/ad1fb185-3266-4632-9c69-97c239334503">

+ 同じ企業に所属しているアドバイザーに飛ぶ通知

<img width="249" alt="_development__ダッシュボード___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/edb1abb2-f429-4246-8a8f-a563fcd39496">

### 変更後
+ プラクティスをWatchしているメンターに飛ぶ通知

<img width="245" alt="_development__ダッシュボード___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/4de54df2-9e90-4e75-b643-1c5baec06380">

+ 同じ企業に所属しているアドバイザーに飛ぶ通知

<img width="241" alt="_development__ダッシュボード___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/55d0f0c9-7c8d-4b04-b9f2-816d14e047a0">