### PR TITLE
不足しているdiscord関連のローカルデータを追加

### DIFF
--- a/db/fixtures/discord_profiles.yml
+++ b/db/fixtures/discord_profiles.yml
@@ -1,6 +1,51 @@
+discord_profile_komagata:
+  user: komagata
+  account_name: komagata#0000
+  times_url:
+
+discord_profile_machida:
+  user: machida
+  account_name:
+  times_url:
+
+discord_profile_sotugyou_with_job:
+  user: sotugyou_with_job
+  account_name:
+  times_url:
+
+discord_profile_sotugyou:
+  user: sotugyou
+  account_name:
+  times_url:
+
+discord_profile_advijirou:
+  user: advijirou
+  account_name:
+  times_url:
+
+discord_profile_yameo:
+  user: yameo
+  account_name:
+  times_url:
+
+discord_profile_mentormentaro:
+  user: mentormentaro
+  account_name:
+  times_url:
+
 discord_profile_kimura:
   user: kimura
   account_name: kimura#1234
+  times_url:
+
+discord_profile_hatsuno:
+  user: hatsuno
+  account_name:
+  times_url:
+
+discord_profile_hajime:
+  user: hajime
+  account_name:
   times_url:
 
 discord_profile_muryou:
@@ -98,10 +143,20 @@ discord_profile_fujiyasu:
   account_name: fujiyasu#1234
   times_url:
 
+discord_profile_adminonly:
+  user: adminonly
+  account_name:
+  times_url:
+
 discord_profile_kensyuowata:
   user: kensyuowata
   account_name: kensyuowata#5678
   times_url: https://discord.com/channels/715806612824260640/123456789000000011
+
+discord_profile_unadmentor:
+  user: unadmentor
+  account_name:
+  times_url:
 
 discord_profile_tatenoicon:
   user: tatenoicon
@@ -113,9 +168,36 @@ discord_profile_thuynga:
   account_name: nga#5675
   times_url:
 
+discord_profile_sotugyou-adviser:
+  user: sotugyou-adviser
+  account_name:
+  times_url:
+
+<% 1.upto(25) do |i| %>
+discord_profile_marumarushain<%= i %>: # ページネーション確認のためのユーザー
+  user: marumarushain<%= i %>
+  account_name:
+  times_url:
+<% end %>
+
 discord_profile_otameshi:
   user: otameshi
   account_name: otameshi#1234
+  times_url:
+
+discord_profile_registration30days:
+  user: registration30days
+  account_name: registration30days#1234
+  times_url:
+
+discord_profile_registration40days:
+  user: registration40days
+  account_name: registration40days#1234
+  times_url:
+
+discord_profile_unhibernated:
+  user: unhibernated
+  account_name: unhibernated#1234
   times_url:
 
 discord_profile_discordinvalid:
@@ -131,4 +213,24 @@ discord_profile_twitterinvalid:
 discord_profile_nocompanykensyu:
   user: nocompanykensyu
   account_name: nocompanykensyu#9999
+  times_url:
+
+discord_profile_neverlogin:
+  user: neverlogin
+  account_name:
+  times_url:
+
+discord_profile_kyuukai:
+  user: kyuukai
+  account_name:
+  times_url:
+
+discord_profile_sotsugyoukigyoshozoku:
+  user: sotsugyoukigyoshozoku
+  account_name:
+  times_url:
+
+discord_profile_advisernocolleguetrainee:
+  user: advisernocolleguetrainee
+  account_name:
   times_url:

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -884,7 +884,6 @@ registration30days:
   name: 入会 三十郎
   name_kana: ニュウカイ サンジュウロウ
   github_account: thirty
-  discord_account: thirty#1234
   twitter_account: thirty
   description: "入会30日経過したユーザーです"
   course: course1
@@ -905,7 +904,6 @@ registration40days:
   name: 入会 四十郎
   name_kana: ニュウカイ ヨソジロウ
   github_account: fourty
-  discord_account: fourty#1234
   twitter_account: fourty
   description: "入会30日経過したユーザーです"
   course: course1
@@ -926,7 +924,6 @@ unhibernated:
   name: 復帰 太郎
   name_kana: フッキ タロウ
   github_account: unhibernated
-  discord_account: unhibernated#1234
   twitter_account: unhibernated
   description: "入会30日目の休会中ユーザーです"
   course: course1

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1,3 +1,6 @@
+# userを増やした場合、以下のymlにも追記する
+# db/fixtures/discord_profiles.yml
+
 komagata:
   login_name: komagata
   email: komagata@fjord.jp


### PR DESCRIPTION
## Issue

- #6447 

## 概要

不足しているローカルのDiscord関連のデータを追加しました。

修正前の挙動としては、 `undefined method account_name' for nil:NilClass` というエラーが発生しておりました。
こちらの修正により上記エラーは解消されます。

[Discordログ](https://discord.com/channels/715806612824260640/809595476847493192/1135482097759440926)

## 変更確認方法

1. `feature/create-discord-local-data` をローカルに取り込む
2. `bin/rails db:reset` を実行する
3. `bin/setup` を実行する
4. `bin/rails s` でサーバーを立ち上げる
5. `kimura` でログインする
6. エラーが表示されず正常にホーム画面が閲覧できることを確認する

## Screenshot

画面上の変更はありません。
