### PR TITLE
最終コメントdivの`id`にコメントidを付与し、hash付きURLをページを開いた時に画面をスクロールさせる

### DIFF
--- a/app/javascript/comment.vue
+++ b/app/javascript/comment.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
 .thread-comment
+  #latest-comment(v-if='isLatest')
   .thread-comment__start
     a.thread-comment__user-link(:href='comment.user.url')
       span(:class='["a-user-role", roleClass]')
@@ -107,7 +108,8 @@ export default {
   mixins: [confirmUnload, role],
   props: {
     comment: { type: Object, required: true },
-    currentUser: { type: Object, required: true }
+    currentUser: { type: Object, required: true },
+    isLatest: { type: Boolean, required: true }
   },
   data() {
     return {

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -24,7 +24,8 @@
       :key='comment.id',
       :comment='comment',
       :currentUser='currentUser',
-      :id='index === comments.length - 1 ? "latest-comment" : "comment_" + comment.id',
+      :id='"comment_" + comment.id',
+      :isLatest='index === comments.length - 1'
       @delete='deleteComment',
       @update='updateComment')
   .thread-comment-form


### PR DESCRIPTION
## Issue

## 概要

最終コメントdivの`id`が`"latest-comment"`になっているため、最終コメントidのhash付きURLをページを開いた時に画面がスクロールしないのでこれを修正する。

## 変更確認方法

1. `bug/latest-comment`をローカルに取り込む
2. 日報ページで検証ツールを開き、
- 最終コメントdivの`id`が`'comment_コメントid'`となっていること
- 直下に`<div id="latest-comment"></div>`があること

を確認する

## Screenshot

### 変更前

![_development__OS_X_Mountain_Lionをクリーンインストールする___FBC](https://github.com/fjordllc/bootcamp/assets/50437473/b8b0ae79-b7e1-4edc-bf14-4cc0b1d8a521)

### 変更後

![_development__OS_X_Mountain_Lionをクリーンインストールする___FBC](https://github.com/fjordllc/bootcamp/assets/50437473/97faaa08-4810-4a62-ac53-1dd7b74de530)
