### PR TITLE
ブログ記事のタグ入力を、Reactを使ったUIに変更した

### DIFF
--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -39,7 +39,7 @@
         .col-md-6.col-xs-12
           = f.label :tag_list, 'タグを入力してください（カンマ区切り）',
             class: 'a-form-label'
-          = f.text_field :tag_list, class: 'a-text-input js-warning-form'
+          = render partial: 'tags_input', locals: { taggable: article }
 
     .form-item
       .row

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -39,7 +39,7 @@
         .col-md-6.col-xs-12
           = f.label :tag_list, 'タグを入力してください（カンマ区切り）',
             class: 'a-form-label'
-          = render partial: 'tags_input', locals: { taggable: article }
+          = render 'tags_input', taggable: article
 
     .form-item
       .row

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Article::TagsTest < ApplicationSystemTestCase
+  test 'cat add tag to article' do
+    visit_with_auth new_article_url, 'komagata'
+    fill_in 'タイトル', with: 'タグ追加のテスト記事'
+    fill_in '本文', with: '2つタグが付与された記事です'
+    tags = %w[FirstTag SecondTag]
+    tags.each do |tag|
+      fill_in_tag tag
+    end
+    assert page.has_text?(tags.first)
+    assert page.has_text?(tags.second)
+    click_on '登録する'
+
+    created_article = Article.find_by(title: 'タグ追加のテスト記事')
+    assert_equal tags, created_article.tag_list.sort
+  end
+end


### PR DESCRIPTION
## Issue

- #6663 

## 概要
ブログ記事を作成するページで、タグ入力のUIをReactを使ったUIに変更しました。


## 変更確認方法

1. `feature/change-tag-input-UI-on-article-create-page-to-use-React`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動
3. komagata でログイン
4. `http://localhost:3000/articles/new`を開く
5. タグを入力するUIに適当な値を入力し、UIが変更されていることを確認する
<img width="625" alt="_development__ブログ記事作成___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/757f1537-b613-423e-93fe-12cb92284dec">

## Screenshot

### 変更前

[![Image from Gyazo](https://i.gyazo.com/32c252336244164d39e838424032a291.gif)](https://gyazo.com/32c252336244164d39e838424032a291)

### 変更後

[![Image from Gyazo](https://i.gyazo.com/1cca10be5e7e37d0fed13fac0f3d9826.gif)](https://gyazo.com/1cca10be5e7e37d0fed13fac0f3d9826)

