### PR TITLE
メンターページのプラクティスタグにある所属カテゴリーのモーダルが正しく表示される様に修正

### DIFF
--- a/app/javascript/components/Tags/TagEditModal.jsx
+++ b/app/javascript/components/Tags/TagEditModal.jsx
@@ -41,7 +41,7 @@ export default function TagEditModal({ tagId, initialTagName, setShowModal }) {
   }
 
   return (
-    <div className="a-overlay is-vue">
+    <div className="a-overlay is-js">
       <div className="a-card is-modal">
         <header className="card-header is-sm">
           <h2 className="card-header__title">タグ名変更</h2>

--- a/app/javascript/components/mentor-practice-modal.vue
+++ b/app/javascript/components/mentor-practice-modal.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.a-overlay.is-vue(@click.self='closeModal')
+.a-overlay.is-js(@click.self='closeModal')
   .a-card.is-modal
     header.card-header.is-sm
       h2.card-header__title

--- a/app/javascript/components/mentor-practice-modal.vue
+++ b/app/javascript/components/mentor-practice-modal.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.a-overlay.is-js(@click.self='closeModal')
+.a-overlay.is-vue(@click.self='closeModal')
   .a-card.is-modal
     header.card-header.is-sm
       h2.card-header__title

--- a/app/javascript/report_template_modal.vue
+++ b/app/javascript/report_template_modal.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.a-overlay.is-vue(@click.self='closeModal')
+.a-overlay.is-js(@click.self='closeModal')
   .a-card.is-modal
     header.card-header.is-sm
       h1.card-header__title

--- a/app/javascript/stylesheets/atoms/_a-overlay.sass
+++ b/app/javascript/stylesheets/atoms/_a-overlay.sass
@@ -3,7 +3,7 @@
   background-color: rgba(black, .6)
   +size(100%)
   opacity: 0
-  &.is-vue
+  &.is-js
     opacity: 1
     z-index: 3
     background-color: rgba(black, .6)


### PR DESCRIPTION
## Issue

- #6737 

## 概要

メンターページのプラクティスタグ(`mentor/practices`)で表示される所属カテゴリー欄に関して、所属カテゴリーをクリックしてもモーダルが表示されない問題を修正しました。

問題の修正に伴い、以下のコンポーネントとsassファイルにおいて、モーダル表示に関するCSSクラスの変更を行っています。

+ `app/javascript/components/Tags/TagEditModal.jsx`
+ `app/javascript/report_template_modal.vue`
+ `app/javascript/stylesheets/atoms/_a-overlay.sass`

## 変更確認方法
### モーダルが表示されない問題の修正に関して

1. `bug/not-display-modal`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動
3. komagataでログイン
4. `http://localhost:3000/mentor/practices`を表示
5. 所属カテゴリーをクリック
<img width="977" alt="_development__メンターページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/48ea9860-6ec8-4f88-982e-32a90ef545dd">
6. モーダルが表示されることを確認

### モーダル表示に関するCSSクラスの変更に関して
以下の4箇所でモーダルが表示されることの確認をお願いします。

#### ユーザータグ
1. ユーザ一覧ページ(`/users`)を表示
2. 表示されているタグの中から、適当なタグをクリック
<img width="1282" alt="_development__全てのユーザー___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/044c416d-14fc-408d-a1be-040303150767">

3. `タグ名変更`をクリック
<img width="1279" alt="_development__全てのユーザー___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/9abc4bbe-a8f8-433d-9360-686d8f636faf">

4. タグ名を編集するモーダルが表示されることを確認
<img width="840" alt="_development__全てのユーザー___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/23f057f8-9cec-442e-bbb6-4968a6fd3426">


#### Q&Aタグ
1. Q&Aページ(`/questions?target=not_solved`)を表示
2. ユーザタグ確認の手順2 - 4の操作を行い、正しくモーダルが表示されることを確認

#### Docsタグ
1. ドキュメント一覧ページ(`/pages`)を表示
2. ユーザタグ確認の手順2 - 4の操作を行い、正しくモーダルが表示されることを確認

#### 日報のテンプレート変更
1. 日報新規作成ページ(`reports/new`)を開く
2. `テンプレート変更`ボタンをクリック
<img width="657" alt="_development__日報作成___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/b39972cd-b26b-4a44-9fc4-011c40ffb155">

3. テンプレート編集モーダルが表示されることを確認
<img width="792" alt="_development__日報作成___FBC" src="https://github.com/fjordllc/bootcamp/assets/79003082/95202a30-1cf5-4e6a-ab18-126e4d45d62c">

## Screenshot

### 変更前

[![Image from Gyazo](https://i.gyazo.com/81009e6d69cc4c9090ec7fc5334349db.gif)](https://gyazo.com/81009e6d69cc4c9090ec7fc5334349db)

### 変更後

[![Image from Gyazo](https://i.gyazo.com/07d261d7a8cc1841a5b52c29ea9e4b9f.gif)](https://gyazo.com/07d261d7a8cc1841a5b52c29ea9e4b9f)

