### PR TITLE
Productモデルのテスト名を、メソッド名と一致するように変更した

### DIFF
--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -66,7 +66,7 @@ class ProductTest < ActiveSupport::TestCase
     assert_equal category, product.category(course)
   end
 
-  test 'other_checker_exists' do
+  test '#other_checker_exists' do
     checker = users(:komagata)
     other_checker = users(:machida)
     product = Product.create!(
@@ -78,7 +78,7 @@ class ProductTest < ActiveSupport::TestCase
     assert product.other_checker_exists?(other_checker.id)
   end
 
-  test 'other_checker_not_exists' do
+  test '#other_checker_exists return false when other checker not exists' do
     other_checker = users(:machida)
     product = Product.create!(
       body: 'test',
@@ -89,7 +89,7 @@ class ProductTest < ActiveSupport::TestCase
     assert_not product.other_checker_exists?(other_checker.id)
   end
 
-  test 'other_checker_not_exists_if_self' do
+  test '#other_checker_exists return false when checker is oneself' do
     other_checker = users(:machida)
     product = Product.create!(
       body: 'test',


### PR DESCRIPTION
## Issue

- #6835 

## 概要
`Product`モデルのテスト(`test/models/product_test.rb`)にて、一部のテスト名が対応するメソッドを推察しづらいものとなっていたため、テスト名を変更しました。

## 変更対象
今回変更対象となったのは、次のテスト名です。

+ `'other_checker_exists'` : 先頭に`#`を付けてメソッドであることを明記する
+ `other_checker_not_exists'` : メソッドなのか文章なのか分かりづらいので、メソッド名 + 説明 に変更する
+ `'other_checker_not_exists_if_self' ` : 同上

## 変更確認方法

修正内容はテスト名の変更のみであるため、このPRのFiles changedをご確認ください。
