### PR TITLE
Commentモデルがcreateされたcommit時のみ対象のコールバックが呼ばれるように変更

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,7 +7,7 @@ class Comment < ApplicationRecord
 
   belongs_to :user, touch: true
   belongs_to :commentable, polymorphic: true
-  after_commit Comment::AfterCreateCallback.new
+  after_create_commit Comment::AfterCreateCallback.new
   after_update Comment::AfterUpdateCallback.new
   after_destroy Comment::AfterDestroyCallback.new
   alias sender user


### PR DESCRIPTION

## Issue

- #6819

## 概要

対象のコールバックは元々create時のみ呼ばれる処理だったが、コミット時に呼び出す変更を加えた際にafter_commitを指定していたため、createのみではなくupdateやdestroy時のコミットでも呼ばれるようになっていた。 
( https://github.com/fjordllc/bootcamp/pull/6253/files#diff-3baef9453c5d8b6c8962ce9ff9ec6b570b2e9cbad934e9f95b6d217ff1029b07 で変更が加わった)
その結果、意図せずコールバックが呼ばれることにより、Commentモデルをdestroyする際に関連するProductモデルのcommented_atカラムをnullにしたいところを新たに値をセットしてupdateしてしまっていた。 
意図しないカラムのupdateを防ぐため、本来の挙動であるCommentモデルのcreate_commit時にのみコールバックが呼ばれるようにした。

詳細は https://github.com/fjordllc/bootcamp/issues/6819#issuecomment-1700295632 にも記載。

## 補足

issueとして起きているエラーは上記のコールバックの結果、レコードの持ち方が意図しないものとなっているのが原因で起きているので、本PRの変更によってエラーが消えるわけではありませんが、再発防止となる変更になっています。


