### PR TITLE
プラクティス一覧ページのクエリ発行回数を減らしました

### DIFF
--- a/app/controllers/api/courses/practices_controller.rb
+++ b/app/controllers/api/courses/practices_controller.rb
@@ -8,7 +8,7 @@ class API::Courses::PracticesController < API::BaseController
     @categories = Category
                   .joins(:courses_categories)
                   .where(courses_categories: { course_id: @course_id })
-                  .includes(practices: [{ started_students: { avatar_attachment: :blob } }, :learning_minute_statistic])
+                  .includes(practices: [{ started_students: { avatar_attachment: :blob } }, :learning_minute_statistic, :practices_books])
                   .order('courses_categories.position')
     @learnings = current_user.learnings
     @completed_practices_size_by_category = current_user.completed_practices_size_by_category

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -756,7 +756,7 @@ class User < ApplicationRecord
   end
 
   def unstarted_practices
-    practices -
+    @unstarted_practices ||= practices -
       practices.joins(:learnings).where(learnings: { user_id: id, status: :started })
                .or(practices.joins(:learnings).where(learnings: { user_id: id, status: :submitted }))
                .or(practices.joins(:learnings).where(learnings: { user_id: id, status: :complete }))


### PR DESCRIPTION

## 概要

`/courses/:id/practices`ページにアクセス時に発行されるクエリの数を減らす下記対応を行いました。

### [practices_booksをeager_loadingするようにした](https://github.com/fjordllc/bootcamp/commit/914a9c7e5303321048c417c3cf46c126cac20c18)

該当のコントローラから呼ばれるjbuilderの中でPractice#include_must_read_books?が呼ばれ、プラクティスの数分practices_booksの呼び出しがありN+1となっていたため。

### [unstarted_practicesメソッドの戻り値をキャッシュするようにした](https://github.com/fjordllc/bootcamp/commit/af564ec0cc78ea36d80274ef70e24c75b3f92a46)

category_active_or_unstarted_practiceメソッド内で上記のメソッドが複数回呼ばれ、かつcategory_active_or_unstarted_practiceメソッドも同じユーザーモデルから複数回呼ばれるため、キャッシュすることでクエリの発行回数を減らします。
