### PR TITLE
rubocopの指摘箇所を修正した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -759,9 +759,9 @@ class User < ApplicationRecord
 
   def unstarted_practices
     @unstarted_practices ||= practices -
-      practices.joins(:learnings).where(learnings: { user_id: id, status: :started })
-               .or(practices.joins(:learnings).where(learnings: { user_id: id, status: :submitted }))
-               .or(practices.joins(:learnings).where(learnings: { user_id: id, status: :complete }))
+                             practices.joins(:learnings).where(learnings: { user_id: id, status: :started })
+                                      .or(practices.joins(:learnings).where(learnings: { user_id: id, status: :submitted }))
+                                      .or(practices.joins(:learnings).where(learnings: { user_id: id, status: :complete }))
   end
 
   def category_having_active_practice


### PR DESCRIPTION
## Issue

- #6869 

## 概要

以下のPRで追加されたコードにより、rubocopの違反が出るようになっています。

[プラクティス一覧ページのクエリ発行回数を減らしました by shibaaaa · Pull Request \#6862 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/pull/6862)

このままだとCIが通らないため、修正を行いました。

## 変更確認方法

1. main ブランチで`bundle exec rubocop`を実行し、違反が出ることを確認する

次のエラーが表示されると思います。
```ruby
% bundle exec rubocop                                                                                                                     [hotfix/correcting-rubocop-offense]
Inspecting 638 files
...................................................................................................................................................................................................................................................................................................................................................C..........................................................................................................................................................................................................................................................................................................

Offenses:

app/models/user.rb:762:7: C: [Correctable] Layout/MultilineOperationIndentation: Align the operands of an expression in an assignment spanning multiple lines.
      practices.joins(:learnings).where(learnings: { user_id: id, status: :started }) ...
```

3. `hotfix/correcting-rubocop-offense`をローカルに取り込む
4. `bundle exec rubocop`を実行し、違反が出ないことを確認する





