### PR TITLE
1ページの場合はページネーションが表示されないように変更

### DIFF
--- a/app/controllers/api/users/companies_controller.rb
+++ b/app/controllers/api/users/companies_controller.rb
@@ -2,7 +2,7 @@
 
 class API::Users::CompaniesController < API::BaseController
   def index
-    @companies = Company.with_attached_logo.order(:id)
+    @companies = Company.with_attached_logo.order(:updated_at).reverse_order
     @target = params[:target]
   end
 end

--- a/app/controllers/api/users/companies_controller.rb
+++ b/app/controllers/api/users/companies_controller.rb
@@ -2,7 +2,7 @@
 
 class API::Users::CompaniesController < API::BaseController
   def index
-    @companies = Company.with_attached_logo.order(:updated_at).reverse_order
+    @companies = Company.with_attached_logo.order(:created_at).reverse_order
     @target = params[:target]
   end
 end

--- a/app/javascript/components/AdminCompanies.jsx
+++ b/app/javascript/components/AdminCompanies.jsx
@@ -28,13 +28,15 @@ export default function AdminCompanies() {
 
   return (
     <>
-      <Pagination
-        sum={data.total_pages * per}
-        per={per}
-        neighbours={neighbours}
-        page={page}
-        onChange={(e) => handlePaginate(e.page)}
-      />
+      {data.total_pages > 1 && (
+        <Pagination
+          sum={data.total_pages * per}
+          per={per}
+          neighbours={neighbours}
+          page={page}
+          onChange={(e) => handlePaginate(e.page)}
+        />
+      )}
       <div className="admin-table">
         <table className="admin-table__table">
           <thead className="admin-table__header">
@@ -54,13 +56,15 @@ export default function AdminCompanies() {
           </tbody>
         </table>
       </div>
-      <Pagination
-        sum={data.total_pages * per}
-        per={per}
-        neighbours={neighbours}
-        page={page}
-        onChange={(e) => handlePaginate(e.page)}
-      />
+      {data.total_pages > 1 && (
+        <Pagination
+          sum={data.total_pages * per}
+          per={per}
+          neighbours={neighbours}
+          page={page}
+          onChange={(e) => handlePaginate(e.page)}
+        />
+      )}
     </>
   )
 }

--- a/app/javascript/components/AdminCompanies.jsx
+++ b/app/javascript/components/AdminCompanies.jsx
@@ -27,7 +27,7 @@ export default function AdminCompanies() {
   }
 
   return (
-    <>
+    <div data-testid="admin-companies">
       {data.total_pages > 1 && (
         <Pagination
           sum={data.total_pages * per}
@@ -65,7 +65,7 @@ export default function AdminCompanies() {
           onChange={(e) => handlePaginate(e.page)}
         />
       )}
-    </>
+    </div>
   )
 }
 

--- a/app/javascript/components/Bookmarks.jsx
+++ b/app/javascript/components/Bookmarks.jsx
@@ -60,15 +60,15 @@ export default function Bookmarks() {
           <hr className="a-border"></hr>
           <div className="page-body">
             <div className="container is-md">
-            {data.totalPages > 1 && (
-              <Pagination
-                sum={data.totalPages * per}
-                per={per}
-                neighbours={neighbours}
-                page={page}
-                onChange={(e) => handlePaginate(e.page)}
-              />
-            )}
+              {data.totalPages > 1 && (
+                <Pagination
+                  sum={data.totalPages * per}
+                  per={per}
+                  neighbours={neighbours}
+                  page={page}
+                  onChange={(e) => handlePaginate(e.page)}
+                />
+              )}
               <div className="card-list a-card">
                 <div className="card-list__items">
                   {data.bookmarks.map((bookmark) => {

--- a/app/javascript/components/Bookmarks.jsx
+++ b/app/javascript/components/Bookmarks.jsx
@@ -60,6 +60,7 @@ export default function Bookmarks() {
           <hr className="a-border"></hr>
           <div className="page-body">
             <div className="container is-md">
+            {data.totalPages > 1 && (
               <Pagination
                 sum={data.totalPages * per}
                 per={per}
@@ -67,6 +68,7 @@ export default function Bookmarks() {
                 page={page}
                 onChange={(e) => handlePaginate(e.page)}
               />
+            )}
               <div className="card-list a-card">
                 <div className="card-list__items">
                   {data.bookmarks.map((bookmark) => {
@@ -82,13 +84,15 @@ export default function Bookmarks() {
                   })}
                 </div>
               </div>
-              <Pagination
-                sum={data.totalPages * per}
-                per={per}
-                neighbours={neighbours}
-                page={page}
-                onChange={(e) => handlePaginate(e.page)}
-              />
+              {data.totalPages > 1 && (
+                <Pagination
+                  sum={data.totalPages * per}
+                  per={per}
+                  neighbours={neighbours}
+                  page={page}
+                  onChange={(e) => handlePaginate(e.page)}
+                />
+              )}
             </div>
             {/* .container */}
           </div>

--- a/app/javascript/components/Bookmarks.jsx
+++ b/app/javascript/components/Bookmarks.jsx
@@ -31,7 +31,7 @@ export default function Bookmarks() {
     return <NoBookmarks />
   } else {
     return (
-      <>
+      <div data-testid="bookmarks">
         <div className="page-main">
           <div className="page-main-header">
             <div className="container">
@@ -99,7 +99,7 @@ export default function Bookmarks() {
           {/* .page-body */}
         </div>
         {/* .page-main */}
-      </>
+      </div>
     )
   }
 }

--- a/db/fixtures/companies.yml
+++ b/db/fixtures/companies.yml
@@ -62,7 +62,7 @@ company3:
   website: "http://example.com/zada.schumm"
   created_at: 2000-01-01 00:00:03
 
-<% (4..26).each do |i| %>
+<% (4..25).each do |i| %>
 company<%= i %>:
   name: "テスト企業"
   description: "このデータはページャーの確認用"
@@ -70,7 +70,7 @@ company<%= i %>:
   created_at: 2000-01-01 00:00:05
 <% end %>
 
-company27:
+company26:
   name: "ユーザの企業に登録しないで株式会社"
   description: "この企業は user login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
   website: "http://example.com/test"

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1105,7 +1105,7 @@ advisernocolleguetrainee:
   twitter_account: advisernocolleguetrainee
   facebook_url: https://www.facebook.com/fjordllc
   blog_url: http://advisernocolleguetrainee.example.com
-  company: company27
+  company: company26
   description: '同僚がいないアドバイザーです。'
   adviser: true
   course: course1

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -68,7 +68,7 @@ company4:
   website: "https://example.com/ignacio"
   created_at: 2000-01-01 00:00:04
 
-<% (5..26).each do |i| %>
+<% (5..25).each do |i| %>
 company<%= i %>:
   name: "テスト企業"
   description: "このデータはページャーの確認用"
@@ -76,7 +76,7 @@ company<%= i %>:
   created_at: 2000-01-01 00:00:05
 <% end %>
 
-company27:
+company26:
   name: "ユーザの企業に登録しないで株式会社"
   description: "この企業は user login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
   website: "http://example.com/test"

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -68,7 +68,7 @@ company4:
   website: "https://example.com/ignacio"
   created_at: 2000-01-01 00:00:04
 
-<% (5..25).each do |i| %>
+<% (5..24).each do |i| %>
 company<%= i %>:
   name: "テスト企業"
   description: "このデータはページャーの確認用"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -877,7 +877,7 @@ advisernocolleguetrainee:
   course: course1
   job: office_worker
   os: mac
-  company: company27
+  company: company26
   description: "同じ企業に研修生がいないけど、アドバイザーです。"
   unsubscribe_email_token: YnhyqxqalslEkTCM2jyVwg
   adviser: true

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -46,17 +46,7 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
   end
 
   test 'no pagination when 20 companies or less exist' do
-    (21..27).each do |n|
-      Company.find(companies("company#{n}".to_sym).id).destroy
-    end
-    visit_with_auth '/admin/companies', 'komagata'
-    assert_no_selector 'nav.pagination'
-  end
-
-  test 'no pagination when 1 company exists' do
-    (2..27).each do |n|
-      Company.find(companies("company#{n}".to_sym).id).destroy
-    end
+    Company.where.not(description: 'このデータはページャーの確認用').destroy_all
     visit_with_auth '/admin/companies', 'komagata'
     assert_no_selector 'nav.pagination'
   end

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -47,15 +47,15 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
 
   test 'no pagination when 20 companies or less exist' do
     (21..27).each do |n|
-      Company.find(id: companies("company#{n}".to_sym).id).destroy
+      Company.find(companies("company#{n}".to_sym).id).destroy
     end
     visit_with_auth '/admin/companies', 'komagata'
     assert_no_selector 'nav.pagination'
   end
 
   test 'no pagination when 1 company exists' do
-    (2..20).each do |n|
-      Company.find(id: companies("company#{n}".to_sym).id).destroy
+    (2..27).each do |n|
+      Company.find(companies("company#{n}".to_sym).id).destroy
     end
     visit_with_auth '/admin/companies', 'komagata'
     assert_no_selector 'nav.pagination'

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -33,15 +33,31 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
     assert_text '企業を更新しました。'
   end
 
-  test 'show pagination' do
-    visit_with_auth '/admin/companies', 'komagata'
-    assert_selector 'nav.pagination', count: 2
-  end
-
   test 'delete company' do
     visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
     click_on '削除'
     page.driver.browser.switch_to.alert.accept
     assert_text '企業を削除しました。'
+  end
+
+  test 'show pagination' do
+    visit_with_auth '/admin/companies', 'komagata'
+    assert_selector 'nav.pagination', count: 2
+  end
+
+  test 'no pagination when 20 companies or less exist' do
+    (21..27).each do |n|
+      Company.find(id: companies("company#{n}".to_sym).id).destroy
+    end
+    visit_with_auth '/admin/companies', 'komagata'
+    assert_no_selector 'nav.pagination'
+  end
+
+  test 'no pagination when 1 company exists' do
+    (2..20).each do |n|
+      Company.find(id: companies("company#{n}".to_sym).id).destroy
+    end
+    visit_with_auth '/admin/companies', 'komagata'
+    assert_no_selector 'nav.pagination'
   end
 end

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -42,12 +42,18 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
 
   test 'show pagination' do
     visit_with_auth '/admin/companies', 'komagata'
-    assert_selector 'nav.pagination', count: 2
+    # ページ遷移直後なのでreactコンポーネントが表示されるまで待つ
+    within "[data-testid='admin-companies']" do
+      assert_selector 'nav.pagination', count: 2
+    end
   end
 
   test 'no pagination when 20 companies or less exist' do
     Company.where.not(description: 'このデータはページャーの確認用').destroy_all
     visit_with_auth '/admin/companies', 'komagata'
-    assert_no_selector 'nav.pagination'
+    # ページ遷移直後なのでreactコンポーネントが表示されるまで待つ
+    within "[data-testid='admin-companies']" do
+      assert_no_selector 'nav.pagination'
+    end
   end
 end

--- a/test/system/current_user/bookmarks_test.rb
+++ b/test/system/current_user/bookmarks_test.rb
@@ -79,4 +79,44 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
     assert_selector 'i.fa-regular.fa-face-sad-tear', visible: false
     assert_no_selector 'input#card-list-tools__action', visible: false
   end
+
+  test 'no pager when 1 bookmark exists' do
+    user_with_one_bookmark = User.create!(
+      login_name: 'have-one-bookmark',
+      email: 'have-one-bookmark@fjord.jp',
+      password: 'testtest',
+      name: 'have-one-bookmark',
+      name_kana: 'ブックマーク イッケン',
+      description: 'test',
+      course: courses(:course1),
+      job: 'office_worker',
+      os: 'mac',
+      experience: 'inexperienced'
+    )
+    user_with_one_bookmark.bookmarks.create!(bookmarkable_id: reports(:report1).id, bookmarkable_type: 'Report')
+    visit_with_auth '/current_user/bookmarks', user_with_one_bookmark.login_name
+
+    assert_no_selector 'nav.pagination'
+  end
+
+  test 'no pager when 20 bookmarks or less exist' do
+    user_with_some_bookmarks = User.create!(
+      login_name: 'have-one-bookmark',
+      email: 'have-one-bookmark@fjord.jp',
+      password: 'testtest',
+      name: 'have-one-bookmark',
+      name_kana: 'ブックマーク タクサン',
+      description: 'test',
+      course: courses(:course1),
+      job: 'office_worker',
+      os: 'mac',
+      experience: 'inexperienced'
+    )
+    20.times do |n|
+      user_with_some_bookmarks.bookmarks.create!(bookmarkable_id: reports("report#{n}".to_sym).id, bookmarkable_type: 'Report')
+    end
+    visit_with_auth '/current_user/bookmarks', user_with_some_bookmarks.login_name
+
+    assert_no_selector 'nav.pagination'
+  end
 end

--- a/test/system/current_user/bookmarks_test.rb
+++ b/test/system/current_user/bookmarks_test.rb
@@ -80,24 +80,6 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
     assert_no_selector 'input#card-list-tools__action', visible: false
   end
 
-  test 'no pagination when 1 bookmark exists' do
-    user_with_one_bookmark = User.create!(
-      login_name: 'have-one-bookmark',
-      email: 'have-one-bookmark@fjord.jp',
-      password: 'testtest',
-      name: 'have-one-bookmark',
-      name_kana: 'ブックマーク イッケン',
-      description: 'test',
-      course: courses(:course1),
-      job: 'office_worker',
-      os: 'mac',
-      experience: 'inexperienced'
-    )
-    user_with_one_bookmark.bookmarks.create!(bookmarkable_id: reports(:report1).id, bookmarkable_type: 'Report')
-    visit_with_auth '/current_user/bookmarks', user_with_one_bookmark.login_name
-    assert_no_selector 'nav.pagination'
-  end
-
   test 'no pagination when 20 bookmarks or less exist' do
     user_with_some_bookmarks = User.create!(
       login_name: 'have-some-bookmarks',

--- a/test/system/current_user/bookmarks_test.rb
+++ b/test/system/current_user/bookmarks_test.rb
@@ -80,7 +80,7 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
     assert_no_selector 'input#card-list-tools__action', visible: false
   end
 
-  test 'no pager when 1 bookmark exists' do
+  test 'no pagination when 1 bookmark exists' do
     user_with_one_bookmark = User.create!(
       login_name: 'have-one-bookmark',
       email: 'have-one-bookmark@fjord.jp',
@@ -95,16 +95,15 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
     )
     user_with_one_bookmark.bookmarks.create!(bookmarkable_id: reports(:report1).id, bookmarkable_type: 'Report')
     visit_with_auth '/current_user/bookmarks', user_with_one_bookmark.login_name
-
     assert_no_selector 'nav.pagination'
   end
 
-  test 'no pager when 20 bookmarks or less exist' do
+  test 'no pagination when 20 bookmarks or less exist' do
     user_with_some_bookmarks = User.create!(
-      login_name: 'have-one-bookmark',
-      email: 'have-one-bookmark@fjord.jp',
+      login_name: 'have-some-bookmarks',
+      email: 'have-some-bookmarks@fjord.jp',
       password: 'testtest',
-      name: 'have-one-bookmark',
+      name: 'have-some-bookmarks',
       name_kana: 'ブックマーク タクサン',
       description: 'test',
       course: courses(:course1),
@@ -112,11 +111,30 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
       os: 'mac',
       experience: 'inexperienced'
     )
-    20.times do |n|
+    (1..20).each do |n|
       user_with_some_bookmarks.bookmarks.create!(bookmarkable_id: reports("report#{n}".to_sym).id, bookmarkable_type: 'Report')
     end
     visit_with_auth '/current_user/bookmarks', user_with_some_bookmarks.login_name
-
     assert_no_selector 'nav.pagination'
+  end
+
+  test 'show pagination when 21 bookmark or more exist' do
+    user_with_many_bookmarks = User.create!(
+      login_name: 'have-many-bookmarks',
+      email: 'have-many-bookmarks@fjord.jp',
+      password: 'testtest',
+      name: 'have-many-bookmarks',
+      name_kana: 'ブックマーク タクサン',
+      description: 'test',
+      course: courses(:course1),
+      job: 'office_worker',
+      os: 'mac',
+      experience: 'inexperienced'
+    )
+    (1..21).each do |n|
+      user_with_many_bookmarks.bookmarks.create!(bookmarkable_id: reports("report#{n}".to_sym).id, bookmarkable_type: 'Report')
+    end
+    visit_with_auth '/current_user/bookmarks', user_with_many_bookmarks.login_name
+    assert_selector 'nav.pagination', count: 2
   end
 end

--- a/test/system/current_user/bookmarks_test.rb
+++ b/test/system/current_user/bookmarks_test.rb
@@ -97,7 +97,10 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
       user_with_some_bookmarks.bookmarks.create!(bookmarkable_id: reports("report#{n}".to_sym).id, bookmarkable_type: 'Report')
     end
     visit_with_auth '/current_user/bookmarks', user_with_some_bookmarks.login_name
-    assert_no_selector 'nav.pagination'
+    # ページ遷移直後なのでreactコンポーネントが表示されるまで待つ
+    within "[data-testid='bookmarks']" do
+      assert_no_selector 'nav.pagination'
+    end
   end
 
   test 'show pagination when 21 bookmark or more exist' do
@@ -117,6 +120,9 @@ class CurrentUser::BookmarksTest < ApplicationSystemTestCase
       user_with_many_bookmarks.bookmarks.create!(bookmarkable_id: reports("report#{n}".to_sym).id, bookmarkable_type: 'Report')
     end
     visit_with_auth '/current_user/bookmarks', user_with_many_bookmarks.login_name
-    assert_selector 'nav.pagination', count: 2
+    # ページ遷移直後なのでreactコンポーネントが表示されるまで待つ
+    within "[data-testid='bookmarks']" do
+      assert_selector 'nav.pagination', count: 2
+    end
   end
 end

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -19,17 +19,8 @@ class User::CompaniesTest < ApplicationSystemTestCase
     within first('.a-user-icons__items') do
       assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'advisernocolleguetrainee'
     end
-    assert_selector('.group-company-name__label', text: 'Lokka Inc.')
-    within all('.a-user-icons__items')[1] do
-      within first('.a-user-role.is-admin') do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
-      end
-      within all('.a-user-role.is-admin')[1] do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'machida'
-      end
-    end
     assert_selector('.group-company-name__label', text: 'Fjord inc.')
-    within all('.a-user-icons__items')[2] do
+    within all('.a-user-icons__items')[1] do
       within first('.a-user-role.is-trainee') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
       end
@@ -41,6 +32,15 @@ class User::CompaniesTest < ApplicationSystemTestCase
       end
       within first('.a-user-role.is-graduate') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
+      end
+    end
+    assert_selector('.group-company-name__label', text: 'Lokka Inc.')
+    within all('.a-user-icons__items')[2] do
+      within first('.a-user-role.is-admin') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
+      end
+      within all('.a-user-role.is-admin')[1] do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'machida'
       end
     end
 
@@ -53,17 +53,8 @@ class User::CompaniesTest < ApplicationSystemTestCase
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'advisernocolleguetrainee'
       end
     end
-    assert_selector('.group-company-name__label', text: 'Lokka Inc.')
-    within all('.a-user-icons__items')[1] do
-      within first('.a-user-role.is-admin') do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
-      end
-      within all('.a-user-role.is-admin')[1] do
-        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'machida'
-      end
-    end
     assert_selector('.group-company-name__label', text: 'Fjord inc.')
-    within all('.a-user-icons__items')[2] do
+    within all('.a-user-icons__items')[1] do
       within first('.a-user-role.is-trainee') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
       end
@@ -75,6 +66,15 @@ class User::CompaniesTest < ApplicationSystemTestCase
       end
       within first('.a-user-role.is-graduate') do
         assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'sotsugyoukigyoshozoku'
+      end
+    end
+    assert_selector('.group-company-name__label', text: 'Lokka Inc.')
+    within all('.a-user-icons__items')[2] do
+      within first('.a-user-role.is-admin') do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'komagata'
+      end
+      within all('.a-user-role.is-admin')[1] do
+        assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'machida'
       end
     end
   end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6597

## 概要

下記のページでページネーションが必要で無い1ページのみの場合もページネーションが表示されてしまう。
必要のない場合には表示されないように修正しました。

- ブックマーク一覧(/current_user/bookmarks)
- 企業一覧(/admin/companies)

## 変更確認方法

1. [bug/fix-pagination](https://github.com/fjordllc/bootcamp/tree/bug/fix-pagination)をローカルに取り込む
2. `bin/setup`の後に`foreman start -f Procfile.dev`でアプリを起動
3. 管理者権限でログインする
4. ブックマーク一覧(/current_user/bookmarks)へと移動
5. ブックマークの件数を1～19件以下にする
6. 下記のスクショ通りにページネーションが表示されないことを確認する
7. 企業一覧(/admin/companies)へと移動
8. 企業数を1～19件以下にする
9. 下記のスクショ通りにページネーションが表示されないことを確認する

`db:seed`が実行されると25の企業が登録されている状態になるので、企業ページの確認には`bin/rails console` で `Company.destroy_all` をするとやりやすいかもしれません。

## Screenshot

### 変更前

ブックマーク一覧(/current_user/bookmarks)
<img width="1067" alt="スクリーンショット 2023-09-07 15 50 33" src="https://github.com/fjordllc/bootcamp/assets/1616717/ecb83148-2463-44e6-95b9-55933f48666d">

企業一覧(/admin/companies)
<img width="1063" alt="スクリーンショット 2023-09-07 16 19 12" src="https://github.com/fjordllc/bootcamp/assets/1616717/00882f55-2ff0-4b9c-9097-07516e35fb0b">


### 変更後

ブックマーク一覧(/current_user/bookmarks)
<img width="1058" alt="スクリーンショット 2023-09-07 15 49 37" src="https://github.com/fjordllc/bootcamp/assets/1616717/a321e43d-9c77-4d51-9106-ce49eb5613bb">

企業一覧(/admin/companies)
<img width="1064" alt="スクリーンショット 2023-09-07 16 19 53" src="https://github.com/fjordllc/bootcamp/assets/1616717/ef47125a-9ce7-4c57-9883-58ebf35c2ea1">

