### PR TITLE
通知一覧のページャーを使ったページ遷移に問題がないように変更

### DIFF
--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -117,11 +117,7 @@ export default {
       } else {
         url.searchParams.append('page', pageNumber)
       }
-      history.pushState(
-        null,
-        null,
-        url
-      )
+      history.pushState(null, null, url)
       window.scrollTo(0, 0)
     },
     getPageValueFromParameter: function () {

--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -76,17 +76,17 @@ export default {
   },
   created() {
     // ブラウザバック・フォワードした時にページネーションの更新をする
-    window.addEventListener("popstate", this.handlePopstate)
+    window.addEventListener('popstate', this.handlePopstate)
     this.getNotificationsPerPage()
   },
   beforeDestroy() {
-    window.removeEventListener("popstate", this.handlePopstate)
+    window.removeEventListener('popstate', this.handlePopstate)
   },
   methods: {
     handlePopstate() {
       this.currentPage = this.getPageValueFromParameter()
       this.getNotificationsPerPage()
-  },
+    },
     getNotificationsPerPage: function () {
       fetch(this.url, {
         method: 'GET',

--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -49,7 +49,7 @@ export default {
     return {
       notifications: [],
       totalPages: 0,
-      currentPage: Number(this.getPageValueFromParameter()) || 1,
+      currentPage: this.getPageValueFromParameter(),
       loaded: false
     }
   },
@@ -75,13 +75,18 @@ export default {
     }
   },
   created() {
-    // ブラウザバック・フォワードした時に画面を読み込ませる
-    window.onpopstate = function () {
-      location.replace(location.href)
-    }
+    // ブラウザバック・フォワードした時にページネーションの更新をする
+    window.addEventListener("popstate", this.handlePopstate)
     this.getNotificationsPerPage()
   },
+  beforeDestroy() {
+    window.removeEventListener("popstate", this.handlePopstate)
+  },
   methods: {
+    handlePopstate() {
+      this.currentPage = this.getPageValueFromParameter()
+      this.getNotificationsPerPage()
+  },
     getNotificationsPerPage: function () {
       fetch(this.url, {
         method: 'GET',
@@ -108,23 +113,17 @@ export default {
       this.currentPage = pageNumber
       this.getNotificationsPerPage()
       const url = new URL(location)
-      if (url.searchParams.has('page')) {
-        if (pageNumber > 1) {
-          url.searchParams.set('page', pageNumber)
-        } else {
-          url.searchParams.delete('page')
-        }
+      if (pageNumber > 1) {
+        url.searchParams.set('page', pageNumber)
       } else {
-        url.searchParams.append('page', pageNumber)
+        url.searchParams.delete('page')
       }
       history.pushState(null, null, url)
       window.scrollTo(0, 0)
     },
     getPageValueFromParameter: function () {
-      const url = location.href
-      const results = url.match(/\?page=(\d+)/)
-      if (!results) return null
-      return results[1]
+      const url = new URL(location)
+      return Number(url.searchParams.get('page')) || 1
     }
   }
 }

--- a/app/javascript/notifications.vue
+++ b/app/javascript/notifications.vue
@@ -107,10 +107,20 @@ export default {
     paginateClickCallback: function (pageNumber) {
       this.currentPage = pageNumber
       this.getNotificationsPerPage()
+      const url = new URL(location)
+      if (url.searchParams.has('page')) {
+        if (pageNumber > 1) {
+          url.searchParams.set('page', pageNumber)
+        } else {
+          url.searchParams.delete('page')
+        }
+      } else {
+        url.searchParams.append('page', pageNumber)
+      }
       history.pushState(
         null,
         null,
-        location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
+        url
       )
       window.scrollTo(0, 0)
     },

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -155,3 +155,13 @@ notification_regular_event_updated:
   message: "[FBC] 定期イベント【開発MTG】が更新されました。"
   link: "/regular_events/<%= ActiveRecord::FixtureSet.identify(:regular_event1) %>"
   read: false
+
+<% 1.upto(25) do |i| %>
+notification_for_pagination<%= i %>: # 通知ページのページネーション動作確認のための通知
+  kind: 5
+  user: hatsuno
+  sender: komagata
+  message: "practice<%= i %>が更新されました。"
+  link: "/practices/<%= ActiveRecord::FixtureSet.identify("practice#{i}".to_sym) %>"
+  read: false
+<% end %>

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -86,7 +86,7 @@ class NotificationsTest < ApplicationSystemTestCase
                         user: users(:mentormentaro),
                         sender: users(:machida))
     login_user 'mentormentaro', 'testtest'
-    visit '/notifications', 'mentormentaro'
+    visit '/notifications'
     within first('nav.pagination') do
       find('a', text: '2').click
     end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -100,6 +100,72 @@ class NotificationsTest < ApplicationSystemTestCase
     assert_current_path('/notifications?page=2')
   end
 
+  test 'click on the pager button with query string' do
+    19.times do |n|
+      Notification.create(message: "machidaさんからメンションが届きました#{n}",
+                          kind: 'mentioned',
+                          link: "/reports/#{n}",
+                          user: users(:mentormentaro),
+                          sender: users(:machida))
+    end
+    Notification.create(message: '1番新しい通知',
+                        created_at: '2040-01-18 06:06:42',
+                        kind: 'mentioned',
+                        link: '/reports/20400118',
+                        user: users(:mentormentaro),
+                        sender: users(:machida))
+    Notification.create(message: '1番古い通知',
+                        created_at: '2000-01-18 06:06:42',
+                        kind: 'mentioned',
+                        link: '/reports/20000118',
+                        user: users(:mentormentaro),
+                        sender: users(:machida))
+    login_user 'mentormentaro', 'testtest'
+    visit '/notifications?status=unread'
+    within first('nav.pagination') do
+      find('a', text: '2').click
+    end
+    assert_text '1番古い通知'
+    assert_no_text '1番新しい通知'
+    all('.pagination .is-active').each do |active_button|
+      assert active_button.has_text? '2'
+    end
+    assert_current_path('/notifications?status=unread&page=2')
+  end
+
+  test 'click on the pager button with multiple query string' do
+    19.times do |n|
+      Notification.create(message: "machidaさんからメンションが届きました#{n}",
+                          kind: 'mentioned',
+                          link: "/reports/#{n}",
+                          user: users(:mentormentaro),
+                          sender: users(:machida))
+    end
+    Notification.create(message: '1番新しい通知',
+                        created_at: '2040-01-18 06:06:42',
+                        kind: 'mentioned',
+                        link: '/reports/20400118',
+                        user: users(:mentormentaro),
+                        sender: users(:machida))
+    Notification.create(message: '1番古い通知',
+                        created_at: '2000-01-18 06:06:42',
+                        kind: 'mentioned',
+                        link: '/reports/20000118',
+                        user: users(:mentormentaro),
+                        sender: users(:machida))
+    login_user 'mentormentaro', 'testtest'
+    visit '/notifications?status=unread&target=mention'
+    within first('nav.pagination') do
+      find('a', text: '2').click
+    end
+    assert_text '1番古い通知'
+    assert_no_text '1番新しい通知'
+    all('.pagination .is-active').each do |active_button|
+      assert active_button.has_text? '2'
+    end
+    assert_current_path('/notifications?status=unread&target=mention&page=2')
+  end
+
   test 'specify the page number in the URL' do
     19.times do |n|
       Notification.create(message: "machidaさんからメンションが届きました#{n}",

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -85,7 +85,8 @@ class NotificationsTest < ApplicationSystemTestCase
                         link: '/reports/20000118',
                         user: users(:mentormentaro),
                         sender: users(:machida))
-    visit_with_auth '/notifications', 'mentormentaro'
+    login_user 'mentormentaro', 'testtest'
+    visit '/notifications', 'mentormentaro'
     within first('nav.pagination') do
       find('a', text: '2').click
     end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6455

## 概要

通知ページ内のページャーのリンクをクリックすると、query stringの情報がpageフィールドのみになりそれ以外のフィールドが全て消えてしまった通知ページへと移動してしまう。

問題なく動くようにページャーのリンクをクリックした際にquery string内のpageフィールドのみが変更した先へとページ遷移するように修正しました。

issueでは未返信の通知一覧のページでの問題のみ挙げられていますが、お知らせやメンションなど通知ページ内の他のタグ上でもページの移動自体は問題無いですがURLだけおかしくなる状態になっていました。このPRによってこれらの問題も解決しています。

## 変更確認方法

1. [bug/fix-notifications-pagination](https://github.com/fjordllc/bootcamp/tree/bug/fix-notifications-pagination)をローカルに取り込む
2. `bin/setup`、`foreman start -f Procfile.dev`でアプリを起動
3. `bin/rails db:seed`を実行する
4. hatsunoでログインする
5. 通知一覧ページへと移動する
6. 下記のスクショ通りにページャーのリンクをクリックしても望んだ通りにページ遷移してquery stringも問題なく変化するかどうか確認する。

## Screenshot

### 変更前

https://github.com/fjordllc/bootcamp/assets/1616717/9c4d7df6-e1b5-4864-abc4-1f6d5cfd42b2

### 変更後

https://github.com/fjordllc/bootcamp/assets/1616717/f7ac4e66-5834-4f96-907c-4b7058948bcd
