### PR TITLE
メンターページのカテゴリーに関連するプラクティス並び替えページに、メンターでもアクセスできるようにした

### DIFF
--- a/app/controllers/categories/practices_controller.rb
+++ b/app/controllers/categories/practices_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Categories::PracticesController < ApplicationController
-  before_action :require_admin_login
+  before_action :require_admin_or_mentor_login
 
   def index
     @category = Category.find(params[:category_id])

--- a/test/system/categories/practices_test.rb
+++ b/test/system/categories/practices_test.rb
@@ -12,7 +12,7 @@ class Categories::PracticesTest < ApplicationSystemTestCase
 
   test 'non-admin user cannot access practices sort page' do
     visit_with_auth category_practices_path(categories(:category2)), 'kimura'
-    assert_text '管理者としてログインしてください'
+    assert_text '管理者・メンターとしてログインしてください'
   end
 
   test 'sorting practices of a category' do

--- a/test/system/mentor/categories_test.rb
+++ b/test/system/mentor/categories_test.rb
@@ -80,4 +80,18 @@ class Mentor::CategoriesTest < ApplicationSystemTestCase
     assert_text 'カテゴリーを削除しました。'
     assert_no_text '学習の準備'
   end
+
+  test 'admin and mentor can access category practice sorting page' do
+    category = Category.find_by(name: '学習の準備')
+
+    visit_with_auth mentor_categories_path, 'komagata'
+    assert_text '学習の準備'
+    find("a[href='/categories/#{category.id}/practices']").click
+    assert_text '学習の準備カテゴリーのプラクティス並び替え'
+
+    visit_with_auth mentor_categories_path, 'mentormentaro'
+    assert_text '学習の準備'
+    find("a[href='/categories/#{category.id}/practices']").click
+    assert_text '学習の準備カテゴリーのプラクティス並び替え'
+  end
 end


### PR DESCRIPTION
## Issue

- #6844

## 概要

メンターページ(`/mentor/categories`)のカテゴリー欄で、カテゴリーに関連するプラクティスを並び替えるページは管理者しかアクセスすることができませんでしたが、メンターもアクセスできるようにしました。

## 変更確認方法

1. `feature/enable-mentor-to-access-category-practice-sorting-page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動
3. mentormentaroでログインし、`http://localhost:3000/mentor/categories`を開く
4. プラクティス並び替えのリンクをクリック
<img width="976" alt="_development__メンターページ___FBC_🔊" src="https://github.com/fjordllc/bootcamp/assets/79003082/6a3fa240-6195-4ff7-b50d-30457fb2fd7a">
5. プラクティス並び替えページにアクセスできることを確認

## Screenshot

### 変更前

[![Image from Gyazo](https://i.gyazo.com/35dfae1370d29c183f0807ca3bd391f1.gif)](https://gyazo.com/35dfae1370d29c183f0807ca3bd391f1)


### 変更後


[![Image from Gyazo](https://i.gyazo.com/7d9864d8a35550a19da3b7309de7eaa8.gif)](https://gyazo.com/7d9864d8a35550a19da3b7309de7eaa8)

## 備考
Issueでは以下の点も修正してほしいとありますが、これらに関しては[こちらのIssue](https://github.com/fjordllc/bootcamp/issues/6852)で実装が行われています。

- コースページからカテゴリー並び替えページに行った時、コースのタブがアクティブになるようにする
- カテゴリーページからプラクティス並び替えページに行った時、カテゴリータブがアクティブになるようにする
