### PR TITLE
相談部屋のコメント通知をNewspaper化した

### DIFF
--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -6,7 +6,7 @@ class Comment::AfterCreateCallback
       create_watch(comment)
       notify_to_watching_user(comment)
     elsif comment.sender != comment.receiver
-      notify_comment(comment)
+      Newspaper.publish(:came_comment, comment)
     end
 
     if comment.commentable.instance_of?(Talk)
@@ -26,16 +26,6 @@ class Comment::AfterCreateCallback
   end
 
   private
-
-  def notify_comment(comment)
-    commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
-    ActivityDelivery.with(
-      comment: comment,
-      receiver: comment.receiver,
-      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
-      link: "#{commentable_path}#latest-comment"
-    ).notify(:came_comment)
-  end
 
   def notify_to_watching_user(comment)
     watchable = comment.commentable

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -74,17 +74,7 @@ class Comment::AfterCreateCallback
   end
 
   def notify_to_admins(comment)
-    User.admins.each do |admin_user|
-      next if comment.sender == admin_user
-
-      commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
-      ActivityDelivery.with(
-        comment: comment,
-        receiver: admin_user,
-        message: "#{comment.commentable.user.login_name}さんの相談部屋で#{comment.sender.login_name}さんからコメントが届きました。",
-        link: "#{commentable_path}#latest-comment"
-      ).notify(:came_comment)
-    end
+    Newspaper.publish(:came_comment_in_talk, comment)
   end
 
   def update_action_completed(comment)

--- a/app/models/comment_notifier.rb
+++ b/app/models/comment_notifier.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class CommentNotifier
-  def call(payload)
-    comment = payload[:comment]
-    current_user = payload[:current_user]
-    return if current_user.nil?
+  def call(comment)
+    return if comment.nil?
 
     commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
     ActivityDelivery.with(

--- a/app/models/comment_notifier.rb
+++ b/app/models/comment_notifier.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CommentNotifier
+  def call(payload)
+    comment = payload[:comment]
+    current_user = payload[:current_user]
+    return if current_user.nil?
+
+    commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
+    ActivityDelivery.with(
+      comment:,
+      receiver: comment.receiver,
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      link: "#{commentable_path}#latest-comment"
+    ).notify(:came_comment)
+  end
+end

--- a/app/models/comment_notifier_for_admin.rb
+++ b/app/models/comment_notifier_for_admin.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CommentNotifierForAdmin
+  def call(comment)
+    return if comment.nil?
+
+    User.admins.each do |admin_user|
+      next if comment.sender == admin_user
+
+      commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
+      ActivityDelivery.with(
+        comment:,
+        receiver: admin_user,
+        message: "#{comment.commentable.user.login_name}さんの相談部屋で#{comment.sender.login_name}さんからコメントが届きました。",
+        link: "#{commentable_path}#latest-comment"
+      ).notify(:came_comment)
+    end
+  end
+end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -68,4 +68,5 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForWatcher.new)
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForChecker.new)
   Newspaper.subscribe(:came_comment, CommentNotifier.new)
+  Newspaper.subscribe(:came_comment_in_talk, CommentNotifierForAdmin.new)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -67,4 +67,5 @@ Rails.configuration.to_prepare do
 
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForWatcher.new)
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForChecker.new)
+  Newspaper.subscribe(:came_comment, CommentNotifier.new)
 end


### PR DESCRIPTION
## Issue

- #6824 

## 概要
相談部屋のコメント通知処理でNewspaperを使うように修正した。

## 変更確認方法

1. `feature/use-Newspaper-in-comment-notifications-in-talks`をローカルに取り込む
2. http://localhost:3000 にアクセスする
3. ID:`komagata`でログインする
4. http://localhost:3000/talks/868847020 にアクセスし、コメントする
5. http://localhost:3000/letter_opener にアクセスし、メールでの通知が飛んでいることを確認する
6. ID:`kimura`でログインする
7. サイト内通知が来ていることを確認する

## Screenshot
画面の変更はありません