### PR TITLE
mentorかadminが定期イベントを主催した場合も、参加できるようにした。

### DIFF
--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -116,8 +116,8 @@ class RegularEventsController < ApplicationController
   def set_all_user_participants_and_watchers
     return if @regular_event.wip?
 
-    students_and_trainees = User.students_and_trainees.ids
-    RegularEvent::ParticipantsCreator.call(regular_event: @regular_event, target: students_and_trainees)
-    RegularEvent::ParticipantsWatcher.call(regular_event: @regular_event, target: students_and_trainees)
+    students_trainees_mentors_and_admins = User.students_trainees_mentors_and_admins.ids
+    RegularEvent::ParticipantsCreator.call(regular_event: @regular_event, target: students_trainees_mentors_and_admins)
+    RegularEvent::ParticipantsWatcher.call(regular_event: @regular_event, target: students_trainees_mentors_and_admins)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,6 +241,14 @@ class User < ApplicationRecord
       retired_on: nil
     )
   }
+  scope :students_trainees_mentors_and_admins, lambda {
+    where(
+      adviser: false,
+      graduated_on: nil,
+      hibernated_at: nil,
+      retired_on: nil
+    )
+  }
   scope :students, lambda {
     where(
       admin: false,

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -72,4 +72,19 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
 
     assert_requested(stub_message)
   end
+
+  test 'notify mentor or admin when comment on regular event page' do
+    regular_event = regular_events(:regular_event3)
+    visit_with_auth "/regular_events/#{regular_event.id}", 'kimura'
+    within('.thread-comment-form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    click_button 'コメントする'
+    assert_text "test"
+
+    visit_with_auth '/notifications', 'komagata'
+    within first('.card-list-item.is-unread') do
+      assert_text "komagataさんの【「#{regular_event.title}」の定期イベント】にkimuraさんがコメントしました。"
+    end
+  end
 end

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -72,19 +72,4 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
 
     assert_requested(stub_message)
   end
-
-  test 'notify mentor or admin when comment on regular event page' do
-    regular_event = regular_events(:regular_event3)
-    visit_with_auth "/regular_events/#{regular_event.id}", 'kimura'
-    within('.thread-comment-form') do
-      fill_in('new_comment[description]', with: 'test')
-    end
-    click_button 'コメントする'
-    assert_text "test"
-
-    visit_with_auth '/notifications', 'komagata'
-    within first('.card-list-item.is-unread') do
-      assert_text "komagataさんの【「#{regular_event.title}」の定期イベント】にkimuraさんがコメントしました。"
-    end
-  end
 end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -211,6 +211,35 @@ class RegularEventsTest < ApplicationSystemTestCase
     assert_text 'この定期イベントは全員参加のため参加登録は不要です。'
   end
 
+    test 'mentor or admin can join regular event when they are organizer' do
+    visit_with_auth new_regular_event_path, 'komagata'
+    within 'form[name=regular_event]' do
+      fill_in 'regular_event[title]', with: '全員参加イベント'
+      first('.choices__inner').click
+      find('#choices--js-choices-multiple-select-item-choice-1').click
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select("#{%w(日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日)[DateTime.now.wday]}")
+      fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
+      fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
+      fill_in 'regular_event[description]', with: '全員が参加するイベントです。'
+      check('regular_event_all', allow_label_click: true)
+      assert_difference 'RegularEvent.count', 1 do
+        click_button '作成'
+      end
+    end
+    assert_text '定期イベントを作成しました。'
+    assert_text "毎週#{%w(日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日)[DateTime.now.wday]}"
+    assert_text 'Watch中'
+    assert_no_text '参加申込'
+    assert_no_text '参加者'
+    assert_text 'この定期イベントは全員参加のため参加登録は不要です。'
+
+    visit_with_auth '/', 'komagata'
+    within first('.card-list.has-scroll') do
+      assert_text "全員参加イベント"
+    end
+  end
+
   test 'using file uploading by file selection dialogue in textarea' do
     visit_with_auth new_regular_event_path, 'komagata'
     within(:css, '.a-file-insert') do

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -211,14 +211,15 @@ class RegularEventsTest < ApplicationSystemTestCase
     assert_text 'この定期イベントは全員参加のため参加登録は不要です。'
   end
 
-    test 'mentor or admin can join regular event when they are organizer' do
+  test 'mentor or admin can join regular event when they are organizer' do
     visit_with_auth new_regular_event_path, 'komagata'
     within 'form[name=regular_event]' do
       fill_in 'regular_event[title]', with: '全員参加イベント'
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-1').click
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
-      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select("#{%w(日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日)[DateTime.now.wday]}")
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select("#{%w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日
+                                                                                                                   土曜日][DateTime.now.wday]}")
       fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
       fill_in 'regular_event[description]', with: '全員が参加するイベントです。'
@@ -228,7 +229,7 @@ class RegularEventsTest < ApplicationSystemTestCase
       end
     end
     assert_text '定期イベントを作成しました。'
-    assert_text "毎週#{%w(日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日)[DateTime.now.wday]}"
+    assert_text "毎週#{%w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日][DateTime.now.wday]}"
     assert_text 'Watch中'
     assert_no_text '参加申込'
     assert_no_text '参加者'
@@ -236,7 +237,7 @@ class RegularEventsTest < ApplicationSystemTestCase
 
     visit_with_auth '/', 'komagata'
     within first('.card-list.has-scroll') do
-      assert_text "全員参加イベント"
+      assert_text '全員参加イベント'
     end
   end
 

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -218,8 +218,8 @@ class RegularEventsTest < ApplicationSystemTestCase
       first('.choices__inner').click
       find('#choices--js-choices-multiple-select-item-choice-1').click
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
-      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select("#{%w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日
-                                                                                                                   土曜日][DateTime.now.wday]}")
+      first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select(%w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日
+                                                                                                                土曜日][DateTime.now.wday].to_s)
       fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
       fill_in 'regular_event[description]', with: '全員が参加するイベントです。'


### PR DESCRIPTION
## Issue

- #6794

## 概要

自動で全員参加するイベントでは、自動で受講生・研修生が参加になるようになっている。
しかし、主催者が管理者やメンターなど受講生・研修生ではない場合は主催者であっても参加になっていない。
これを、主催者が管理者やメンターなど受講生・研修生ではない場合でも、主催者であれば参加になるようにしたい。
そうすることで、そのイベントページにコメントがあった場合に、主催者もイベントの通知を受け取ることができるようになる。

## 変更確認方法

1. `feature/include-organizers-in-the-event-for-all-participants`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. `localhost:3000`にアクセス
4. ユーザー名 : `komagata` でログイン
5. `http://localhost:3000/regular_events/new`にアクセス
6. 任意の情報を入力する。(主催者を`komagata`に設定)
7. 「全員参加イベント」にチェックを入れて「作成」を選択。
![image](https://github.com/fjordllc/bootcamp/assets/92995093/82cd04dc-052c-44c0-8f2a-3f505474ce30)
8. ダッシュボード(`http://localhost:3000/`)の近日開催のイベント欄に、先ほど作成したイベントが表示されていることを確認
![image](https://github.com/fjordllc/bootcamp/assets/92995093/8f9f4acc-8ebe-4b87-b6e6-94ef3f3cdcea)
9. ログアウトして、ユーザー名 : `kimura` でログイン
10. 先ほど作成したイベントが、ダッシュボードの近日開催のイベント欄に表示されていることを確認する。
![image](https://github.com/fjordllc/bootcamp/assets/92995093/c70dc366-122e-4f53-9367-620b2eb3687d)
11. 先ほど作成したイベントを選択して、イベント詳細ページ(`http://localhost:3000/regular_events/XXXXXX`)に移動する。その後、任意のコメントを入力して、「コメントする」を選択
![image](https://github.com/fjordllc/bootcamp/assets/92995093/8e7a9b4a-5725-49b2-81f2-7a05204c5072)
12. 再度ユーザー名 : `komagata` でログインして、イベントページにコメントがあったことを知らせる通知が来ていることを確認する。
![image](https://github.com/fjordllc/bootcamp/assets/92995093/8892d16c-0330-4f0c-888d-bef8a9b485ff)




## Screenshot

screenshotはありません。
