### PR TITLE
FBC Contributorsへのリンクを削除

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -44,9 +44,6 @@ footer.footer
             = link_to 'https://fjord-choice.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | Fjord Choice
           li.footer-nav__item
-            = link_to 'https://fjord-boot-camp-contributors-production.up.railway.app', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
-              | FBC Contributors
-          li.footer-nav__item
             = link_to 'https://buzzcord-fjord-jp.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | Buzzcord
           li.footer-nav__item


### PR DESCRIPTION
## Issue

- Issue番号
#6896
## 概要
フッターの「FBC Contributors」のリンクを外しました。
## 変更確認方法
1. `feature/footer_fbc_contributors_link_delete`ブランチをローカルに取り込む
2. 任意のユーザーでログイン
3. ページを最下までスクロールし、フッターに「FBC Contributors」のリンクが表示されていないことを確認

## Screenshot

### 変更前
<img width="1358" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/d64efe66-b32f-4d53-a444-01bbd67567a8">

### 変更後
<img width="1356" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/869ab8eb-e6da-4edd-b4b7-92189606ee32">


