### PR TITLE
removing "FBC Contributors" link on footer

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -44,9 +44,6 @@ footer.footer
             = link_to 'https://fjord-choice.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | Fjord Choice
           li.footer-nav__item
-            = link_to 'https://fjord-boot-camp-contributors-production.up.railway.app', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
-              | FBC Contributors
-          li.footer-nav__item
             = link_to 'https://buzzcord-fjord-jp.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | Buzzcord
           li.footer-nav__item


### PR DESCRIPTION
## Issue

- This PR solves issue #6896

## 概要

Simply removing link definition on `.slim` file do it good

## Screenshot

![image](https://github.com/fjordllc/bootcamp/assets/6942685/d9c244a0-f5f0-44ad-b35e-a69c961ebe78)

As shown in above image, the link is gone
