### PR TITLE
watchesのカラムにnullが入らないように修正

### DIFF
--- a/app/models/watch.rb
+++ b/app/models/watch.rb
@@ -6,4 +6,5 @@ class Watch < ApplicationRecord
   belongs_to :watchable, polymorphic: true
 
   validates :user_id, uniqueness: { scope: %i[watchable_id watchable_type] }
+  validates :watchable_type, :watchable_id, :user_id, presence: true
 end

--- a/db/migrate/20230925075918_change_column_null_watches.rb
+++ b/db/migrate/20230925075918_change_column_null_watches.rb
@@ -1,0 +1,7 @@
+class ChangeColumnNullWatches < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null(:watches, :watchable_type, false)
+    change_column_null(:watches, :watchable_id, false)
+    change_column_null(:watches, :user_id, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_24_095814) do
+ActiveRecord::Schema.define(version: 2023_09_25_075918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -123,8 +123,8 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
   end
 
   create_table "categories", id: :serial, force: :cascade do |t|
-    t.string "name", limit: 255
-    t.string "slug", limit: 255
+    t.string "name"
+    t.string "slug"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "description"
@@ -178,14 +178,13 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
     t.datetime "updated_at"
     t.string "commentable_type", default: "Report"
     t.index ["commentable_id"], name: "index_comments_on_commentable_id"
-    t.index ["user_id"], name: "comment_user_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "companies", id: :serial, force: :cascade do |t|
-    t.string "name", limit: 255
+    t.string "name"
     t.text "description"
-    t.string "website", limit: 255
+    t.string "website"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "tos"
@@ -207,9 +206,6 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id", "category_id"], name: "index_courses_categories_on_course_id_and_category_id", unique: true
-  end
-
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "discord_profiles", force: :cascade do |t|
@@ -547,8 +543,8 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
     t.integer "kind", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["reactionable_type", "reactionable_id"], name: "index_reactions_on_reactionable_type_and_reactionable_id"
-    t.index ["user_id", "reactionable_id", "reactionable_type", "kind"], name: "index_reactions_on_reactionable", unique: true
+    t.index ["reactionable_type", "reactionable_id"], name: "index_reactions_on_reactionable"
+    t.index ["user_id", "reactionable_id", "reactionable_type", "kind"], name: "index_reactions_on_reactionable_u_k", unique: true
     t.index ["user_id"], name: "index_reactions_on_user_id"
   end
 
@@ -579,9 +575,9 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
     t.boolean "hold_national_holiday", null: false
     t.time "start_at", null: false
     t.time "end_at", null: false
+    t.boolean "wip", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "wip", default: false, null: false
     t.integer "category", default: 0, null: false
     t.boolean "all", default: false, null: false
     t.datetime "published_at"
@@ -608,7 +604,6 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
     t.datetime "published_at"
     t.index ["user_id", "reported_on"], name: "index_reports_on_user_id_and_reported_on", unique: true
     t.index ["user_id", "title"], name: "index_reports_on_user_id_and_title", unique: true
-    t.index ["user_id"], name: "reports_user_id"
   end
 
   create_table "survey_question_listings", force: :cascade do |t|
@@ -678,21 +673,21 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
-    t.string "login_name", limit: 255, null: false
-    t.string "email", limit: 255
-    t.string "crypted_password", limit: 255
-    t.string "salt", limit: 255
+    t.string "login_name", null: false
+    t.string "email"
+    t.string "crypted_password"
+    t.string "salt"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "remember_me_token", limit: 255
+    t.string "remember_me_token"
     t.datetime "remember_me_token_expires_at"
-    t.string "twitter_account", limit: 255
-    t.string "facebook_url", limit: 255
-    t.string "blog_url", limit: 255
+    t.string "twitter_account"
+    t.string "facebook_url"
+    t.string "blog_url"
     t.integer "company_id"
     t.text "description"
     t.datetime "accessed_at"
-    t.string "github_account", limit: 255
+    t.string "github_account"
     t.boolean "adviser", default: false, null: false
     t.boolean "nda", default: true, null: false
     t.string "reset_password_token"
@@ -707,24 +702,24 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
     t.string "organization"
     t.integer "os"
     t.integer "experience"
-    t.boolean "free", default: false, null: false
-    t.boolean "trainee", default: false, null: false
     t.text "retire_reason"
-    t.boolean "job_seeking", default: false, null: false
+    t.boolean "trainee", default: false, null: false
+    t.boolean "free", default: false, null: false
     t.string "customer_id"
+    t.boolean "job_seeking", default: false, null: false
     t.string "subscription_id"
     t.boolean "mail_notification", default: true, null: false
     t.boolean "job_seeker", default: false, null: false
-    t.boolean "github_collaborator", default: false, null: false
     t.string "github_id"
+    t.boolean "github_collaborator", default: false, null: false
+    t.string "name", default: "", null: false
+    t.string "name_kana", default: "", null: false
     t.integer "satisfaction"
     t.text "opinion"
     t.bigint "retire_reasons", default: 0, null: false
-    t.string "name", default: "", null: false
-    t.string "name_kana", default: "", null: false
     t.string "unsubscribe_email_token"
-    t.string "discord_account"
     t.text "mentor_memo"
+    t.string "discord_account"
     t.string "times_url"
     t.text "after_graduation_hope"
     t.date "training_ends_on"
@@ -736,8 +731,8 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
     t.string "profile_job"
     t.text "profile_text"
     t.string "feed_url"
-    t.string "times_id", comment: "Snowflake ID"
     t.boolean "sent_student_followup_message", default: false
+    t.string "times_id", comment: "Snowflake ID"
     t.string "country_code"
     t.string "subdivision_code"
     t.boolean "auto_retire", default: true
@@ -750,13 +745,13 @@ ActiveRecord::Schema.define(version: 2023_07_24_095814) do
   end
 
   create_table "watches", force: :cascade do |t|
-    t.string "watchable_type"
-    t.bigint "watchable_id"
+    t.string "watchable_type", null: false
+    t.bigint "watchable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.integer "user_id", null: false
     t.index ["watchable_type", "watchable_id", "user_id"], name: "index_watches_on_watchable_type_and_watchable_id_and_user_id", unique: true
-    t.index ["watchable_type", "watchable_id"], name: "index_watches_on_watchable_type_and_watchable_id"
+    t.index ["watchable_type", "watchable_id"], name: "index_watches_on_watchable"
   end
 
   create_table "works", force: :cascade do |t|


### PR DESCRIPTION
## Issue

-  #6738

## 概要
- watchesテーブルのカラムにNOT NULL制約を追加した
- watchモデルに`presence: true`のバリデーションを追加
## 変更確認方法
1. `feature/no_null_watches_column`をローカルに取り込む
2. `20230925075918_change_column_null_watches.rb`のmigrationファイルを確認し、`rails db:migrate`を実行する
3. `schema.rb`を確認し、`watchable_type` `watchable_id` `user_id`のカラムに`null: false`が追加されたことを確認する

## Screenshot
`schema.rb`
### 変更前

<img width="450" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/e2794e53-b07b-4f37-8c35-570131213487">

### 変更後
<img width="408" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/b7e31a41-b8d8-4113-9e17-80e1aa8b5495">


