### PR TITLE
Q&Aの削除確認メッセージを、受講生向けからメンター/管理者向けに修正

### DIFF
--- a/app/javascript/components/question-edit.vue
+++ b/app/javascript/components/question-edit.vue
@@ -104,7 +104,7 @@
             // - 確認ダイアログとDELETE methodのリンクを実装する
             a.js-delete.card-main-actions__muted-action(
               :href='`/questions/${question.id}`',
-              data-confirm='自己解決した場合は削除せずに回答を書き込んでください。本当に削除しますか？',
+              data-confirm='本当に削除しますか？質問はなるべく消さず、もし質問者が自己解決した場合も、質問者自身で解決した手段や手順を回答に記入し、それをベストアンサーにしてこの質問を解決することを即すようにしてください。',
               data-method='delete')
               | 削除する
           li.card-main-actions__item.is-sub(v-else)


### PR DESCRIPTION
## Issue

- #6918

## 概要

- Q＆Aの削除確認メッセージが受講生向けの内容のままになっていたため、メンター/管理者向けに修正。

## 変更確認方法

1. `bug/fix-qa-deletion-message-for-students`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. `localhost:3000`にアクセス
4. ユーザー名：`machida`でログイン
5. Q&Aページの任意の質問を選択
6. 「削除する」ボタンを押下
7. 削除確認メッセージの文言を確認

## Screenshot

### 変更前

<img width="1425" alt="localhost_3000_の内容_と__development__テストの質問40___FBC" src="https://github.com/fjordllc/bootcamp/assets/79001972/16083673-3008-470e-9b39-4c168d6679fd">

### 変更後

<img width="1421" alt="localhost_3000_の内容_と__development__テストの質問40___FBC" src="https://github.com/fjordllc/bootcamp/assets/79001972/00cee919-5036-4708-951b-42d16b5f5c36">

