### PR TITLE
記事ごとの登録日時を持たない場合も例外が発生しないよう修正

### DIFF
--- a/app/models/external_entry.rb
+++ b/app/models/external_entry.rb
@@ -78,7 +78,7 @@ class ExternalEntry < ApplicationRecord
         title: atom_item.title&.content,
         url: atom_item.link&.href,
         summary: atom_item.content&.content,
-        thumbnail_image_url: atom_item.links&.find { |link| !link.type.nil? && link.type.include?('image') }&.href,
+        thumbnail_image_url: atom_image_url(atom_item),
         published_at: atom_publish_date(atom_item, feed_updated),
         user:
       )
@@ -98,6 +98,10 @@ class ExternalEntry < ApplicationRecord
       return feed_updated if feed_updated
 
       Time.zone.today
+    end
+
+    def atom_image_url(atom_item)
+      atom_item.links&.find { |link| !link.type.nil? && link.type.include?('image') }&.href
     end
 
     def atom_publish_date(atom_item, feed_updated)

--- a/app/models/external_entry.rb
+++ b/app/models/external_entry.rb
@@ -17,15 +17,15 @@ class ExternalEntry < ApplicationRecord
     def fetch_and_save_rss_feeds(users)
       threads = Concurrent::Promises.future do
         users.each do |user|
-          rss_items = ExternalEntry.parse_rss_feed(user.feed_url)
+          feed = ExternalEntry.parse_rss_feed(user.feed_url)
 
-          next unless rss_items
+          next unless feed
 
-          rss_items.each do |item|
+          feed.items.each do |item|
             case item.class.name
-            when 'RSS::Atom::Feed::Entry' then ExternalEntry.save_atom_feed(user, item)
-            when 'RSS::Rss::Channel::Item' then ExternalEntry.save_rss_feed(user, item)
-            when 'RSS::RDF::Item' then ExternalEntry.save_rdf_feed(user, item)
+            when 'RSS::Atom::Feed::Entry' then ExternalEntry.save_atom_feed(user, item, feed.channel&.dc_date)
+            when 'RSS::Rss::Channel::Item' then ExternalEntry.save_rss_feed(user, item, feed.channel&.lastBuildDate)
+            when 'RSS::RDF::Item' then ExternalEntry.save_rdf_feed(user, item, feed.updated&.content)
             end
           end
         end
@@ -38,14 +38,14 @@ class ExternalEntry < ApplicationRecord
       return nil if feed_url.blank?
 
       begin
-        RSS::Parser.parse(feed_url).items
+        RSS::Parser.parse(feed_url)
       rescue StandardError => e
         logger.warn("[RSS Feed] #{feed_url}: #{e.message}")
         nil
       end
     end
 
-    def save_rdf_feed(user, rdf_item)
+    def save_rdf_feed(user, rdf_item, feed_updated)
       return if ExternalEntry.find_by(url: rdf_item.link)
 
       ExternalEntry.create(
@@ -53,12 +53,12 @@ class ExternalEntry < ApplicationRecord
         url: rdf_item.link,
         summary: rdf_item.description,
         thumbnail_image_url: nil,
-        published_at: rdf_item.dc_date,
+        published_at: rdf_publish_date(rdf_item, feed_updated),
         user:
       )
     end
 
-    def save_rss_feed(user, rss_item)
+    def save_rss_feed(user, rss_item, feed_updated)
       return if ExternalEntry.find_by(url: rss_item.link)
 
       ExternalEntry.create(
@@ -66,22 +66,46 @@ class ExternalEntry < ApplicationRecord
         url: rss_item.link,
         summary: rss_item.description,
         thumbnail_image_url: rss_item.enclosure&.url,
-        published_at: rss_item.pubDate,
+        published_at: rss_publish_date(rss_item, feed_updated),
         user:
       )
     end
 
-    def save_atom_feed(user, atom_item)
-      return if ExternalEntry.find_by(url: atom_item.link.href)
+    def save_atom_feed(user, atom_item, feed_updated)
+      return if ExternalEntry.find_by(url: atom_item.link&.href)
 
       ExternalEntry.create(
-        title: atom_item.title.content,
-        url: atom_item.link.href,
-        summary: atom_item.content.content,
-        thumbnail_image_url: atom_item.links.find { |link| !link.type.nil? && link.type.include?('image') }&.href,
-        published_at: atom_item.published.content,
+        title: atom_item.title&.content,
+        url: atom_item.link&.href,
+        summary: atom_item.content&.content,
+        thumbnail_image_url: atom_item.links&.find { |link| !link.type.nil? && link.type.include?('image') }&.href,
+        published_at: atom_publish_date(atom_item, feed_updated),
         user:
       )
+    end
+
+    private
+
+    def rdf_publish_date(rdf_item, feed_updated)
+      return rdf_item.dc_date if rdf_item.dc_date
+      return feed_updated if feed_updated
+
+      Time.zone.today
+    end
+
+    def rss_publish_date(rss_item, feed_updated)
+      return rss_item.pubDate if rss_item.pubDate
+      return feed_updated if feed_updated
+
+      Time.zone.today
+    end
+
+    def atom_publish_date(atom_item, feed_updated)
+      return atom_item.published.content if atom_item.published
+      return atom_item.updated.content if atom_item.updated
+      return feed_updated if feed_updated
+
+      Time.zone.today
     end
   end
 end

--- a/app/models/external_entry.rb
+++ b/app/models/external_entry.rb
@@ -48,12 +48,13 @@ class ExternalEntry < ApplicationRecord
     def save_rdf_feed(user, rdf_item, feed_updated)
       return if ExternalEntry.find_by(url: rdf_item.link)
 
+      published_at = rdf_publish_date(rdf_item, feed_updated)
       ExternalEntry.create(
         title: rdf_item.title,
         url: rdf_item.link,
         summary: rdf_item.description,
         thumbnail_image_url: nil,
-        published_at: rdf_publish_date(rdf_item, feed_updated),
+        published_at: published_at.utc? ? Time.zone.parse(published_at.to_s) : published_at,
         user:
       )
     end
@@ -61,12 +62,13 @@ class ExternalEntry < ApplicationRecord
     def save_rss_feed(user, rss_item, feed_updated)
       return if ExternalEntry.find_by(url: rss_item.link)
 
+      published_at = rss_publish_date(rss_item, feed_updated)
       ExternalEntry.create(
         title: rss_item.title,
         url: rss_item.link,
         summary: rss_item.description,
         thumbnail_image_url: rss_item.enclosure&.url,
-        published_at: rss_publish_date(rss_item, feed_updated),
+        published_at: published_at.utc? ? Time.zone.parse(published_at.to_s) : published_at,
         user:
       )
     end
@@ -74,12 +76,13 @@ class ExternalEntry < ApplicationRecord
     def save_atom_feed(user, atom_item, feed_updated)
       return if ExternalEntry.find_by(url: atom_item.link&.href)
 
+      published_at = atom_publish_date(atom_item, feed_updated)
       ExternalEntry.create(
         title: atom_item.title&.content,
         url: atom_item.link&.href,
         summary: atom_item.content&.content,
         thumbnail_image_url: atom_image_url(atom_item),
-        published_at: atom_publish_date(atom_item, feed_updated),
+        published_at: published_at.utc? ? Time.zone.parse(published_at.to_s) : published_at,
         user:
       )
     end
@@ -90,14 +93,14 @@ class ExternalEntry < ApplicationRecord
       return rdf_item.dc_date if rdf_item.dc_date
       return feed_updated if feed_updated
 
-      Time.zone.today
+      Time.zone.now
     end
 
     def rss_publish_date(rss_item, feed_updated)
       return rss_item.pubDate if rss_item.pubDate
       return feed_updated if feed_updated
 
-      Time.zone.today
+      Time.zone.now
     end
 
     def atom_image_url(atom_item)
@@ -109,7 +112,7 @@ class ExternalEntry < ApplicationRecord
       return atom_item.updated.content if atom_item.updated
       return feed_updated if feed_updated
 
-      Time.zone.today
+      Time.zone.now
     end
   end
 end

--- a/app/models/external_entry.rb
+++ b/app/models/external_entry.rb
@@ -23,9 +23,9 @@ class ExternalEntry < ApplicationRecord
 
           feed.items.each do |item|
             case item.class.name
-            when 'RSS::Atom::Feed::Entry' then ExternalEntry.save_atom_feed(user, item, feed.channel&.dc_date)
+            when 'RSS::Atom::Feed::Entry' then ExternalEntry.save_atom_feed(user, item, feed.updated&.content)
             when 'RSS::Rss::Channel::Item' then ExternalEntry.save_rss_feed(user, item, feed.channel&.lastBuildDate)
-            when 'RSS::RDF::Item' then ExternalEntry.save_rdf_feed(user, item, feed.updated&.content)
+            when 'RSS::RDF::Item' then ExternalEntry.save_rdf_feed(user, item, feed.channel&.dc_date)
             end
           end
         end

--- a/test/models/external_entry_test.rb
+++ b/test/models/external_entry_test.rb
@@ -58,20 +58,20 @@ class ExternalEntryTest < ActiveSupport::TestCase
     rdf_item.expect(:description, nil)
     rdf_item.expect(:dc_date, nil)
 
-    assert ExternalEntry.save_rdf_feed(user, rdf_item, nil)
+    assert ExternalEntry.save_rdf_feed(user, rdf_item, Time.zone.local(2023, 1, 1, 0, 0, 0).utc)
   end
 
   test '.save_rss_feed' do
     user = users(:hatsuno)
     rss_item = Minitest::Mock.new
     rss_item.expect(:link, 'https://test.com/rss')
+    rss_item.expect(:pubDate, Time.zone.local(2022, 1, 1, 0, 0, 0))
+    rss_item.expect(:pubDate, Time.zone.local(2022, 1, 1, 0, 0, 0))
     rss_item.expect(:title, 'test title')
     rss_item.expect(:link, 'https://test.com/rss')
     rss_item.expect(:description, 'article description')
     rss_item.expect(:enclosure, rss_item)
     rss_item.expect(:url, 'https://test.com/image.png')
-    rss_item.expect(:pubDate, Time.zone.local(2022, 1, 1, 0, 0, 0))
-    rss_item.expect(:pubDate, Time.zone.local(2022, 1, 1, 0, 0, 0))
 
     assert ExternalEntry.save_rss_feed(user, rss_item, nil)
   end
@@ -80,24 +80,24 @@ class ExternalEntryTest < ActiveSupport::TestCase
     user = users(:hatsuno)
     rss_item = Minitest::Mock.new
     rss_item.expect(:link, 'https://test.com/rss')
+    rss_item.expect(:pubDate, nil)
     rss_item.expect(:title, 'test title')
     rss_item.expect(:link, 'https://test.com/rss')
     rss_item.expect(:description, 'article description')
     rss_item.expect(:enclosure, nil)
-    rss_item.expect(:pubDate, nil)
 
-    assert ExternalEntry.save_rss_feed(user, rss_item, Time.zone.local(2023, 1, 1, 0, 0, 0))
+    assert ExternalEntry.save_rss_feed(user, rss_item, Time.zone.local(2023, 1, 1, 0, 0, 0).utc)
   end
 
   test 'no exception even if all rss elements are nil' do
     user = users(:hatsuno)
     rss_item = Minitest::Mock.new
     rss_item.expect(:link, nil)
+    rss_item.expect(:pubDate, nil)
     rss_item.expect(:title, nil)
     rss_item.expect(:link, nil)
     rss_item.expect(:description, nil)
     rss_item.expect(:enclosure, nil)
-    rss_item.expect(:pubDate, nil)
 
     assert ExternalEntry.save_rss_feed(user, rss_item, nil)
   end
@@ -107,6 +107,9 @@ class ExternalEntryTest < ActiveSupport::TestCase
     atom_item = Minitest::Mock.new
     atom_item.expect(:link, atom_item)
     atom_item.expect(:href, 'https://test.com/feed')
+    atom_item.expect(:published, atom_item)
+    atom_item.expect(:published, atom_item)
+    atom_item.expect(:content, Time.zone.local(2022, 1, 1, 0, 0, 0))
     atom_item.expect(:title, atom_item)
     atom_item.expect(:content, 'test title')
     atom_item.expect(:link, atom_item)
@@ -117,9 +120,6 @@ class ExternalEntryTest < ActiveSupport::TestCase
     atom_item.expect(:find, atom_item)
     atom_item.expect(:nil?, atom_item)
     atom_item.expect(:href, 'https://test.com/image.png')
-    atom_item.expect(:published, atom_item)
-    atom_item.expect(:published, atom_item)
-    atom_item.expect(:content, Time.zone.local(2022, 1, 1, 0, 0, 0))
 
     assert ExternalEntry.save_atom_feed(user, atom_item, nil)
   end
@@ -129,6 +129,8 @@ class ExternalEntryTest < ActiveSupport::TestCase
     atom_item = Minitest::Mock.new
     atom_item.expect(:link, atom_item)
     atom_item.expect(:href, 'https://test.com/feed')
+    atom_item.expect(:published, nil)
+    atom_item.expect(:updated, nil)
     atom_item.expect(:title, atom_item)
     atom_item.expect(:content, 'test title')
     atom_item.expect(:link, atom_item)
@@ -139,23 +141,21 @@ class ExternalEntryTest < ActiveSupport::TestCase
     atom_item.expect(:find, atom_item)
     atom_item.expect(:nil?, atom_item)
     atom_item.expect(:href, 'https://test.com/image.png')
-    atom_item.expect(:published, nil)
-    atom_item.expect(:updated, nil)
 
-    assert ExternalEntry.save_atom_feed(user, atom_item, Time.zone.local(2023, 1, 1, 0, 0, 0))
+    assert ExternalEntry.save_atom_feed(user, atom_item, Time.zone.local(2023, 1, 1, 0, 0, 0).utc)
   end
 
   test 'no exception even if all atom elements are nil' do
     user = users(:hatsuno)
     atom_item = Minitest::Mock.new
     atom_item.expect(:link, nil)
+    atom_item.expect(:published, nil)
+    atom_item.expect(:updated, nil)
     atom_item.expect(:title, nil)
     atom_item.expect(:content, nil)
     atom_item.expect(:link, nil)
     atom_item.expect(:content, nil)
     atom_item.expect(:links, nil)
-    atom_item.expect(:published, nil)
-    atom_item.expect(:updated, nil)
 
     assert ExternalEntry.save_atom_feed(user, atom_item, nil)
   end

--- a/test/models/external_entry_test.rb
+++ b/test/models/external_entry_test.rb
@@ -160,28 +160,28 @@ class ExternalEntryTest < ActiveSupport::TestCase
     assert ExternalEntry.save_atom_feed(user, atom_item, nil)
   end
 
-  # test '.fetch_and_save_rss_feeds' do
-  #   users = [users(:kimura), users(:hatsuno), users(:komagata)]
-  #
-  #   assert_difference 'ExternalEntry.count', 56 do
-  #     VCR.use_cassette 'external_entry/fetch3', vcr_options do
-  #       VCR.use_cassette 'external_entry/fetch2', vcr_options do
-  #         VCR.use_cassette 'external_entry/fetch' do
-  #           ExternalEntry.fetch_and_save_rss_feeds(users)
-  #         end
-  #       end
-  #     end
-  #   end
-  #
-  #   assert_no_difference 'ExternalEntry.count' do
-  #     # 同じ記事は重複して保存しない
-  #     VCR.use_cassette 'external_entry/fetch3', vcr_options do
-  #       VCR.use_cassette 'external_entry/fetch2', vcr_options do
-  #         VCR.use_cassette 'external_entry/fetch' do
-  #           ExternalEntry.fetch_and_save_rss_feeds(users)
-  #         end
-  #       end
-  #     end
-  #   end
-  # end
+  test '.fetch_and_save_rss_feeds' do
+    users = [users(:kimura), users(:hatsuno), users(:komagata)]
+
+    assert_difference 'ExternalEntry.count', 56 do
+      VCR.use_cassette 'external_entry/fetch3', vcr_options do
+        VCR.use_cassette 'external_entry/fetch2', vcr_options do
+          VCR.use_cassette 'external_entry/fetch' do
+            ExternalEntry.fetch_and_save_rss_feeds(users)
+          end
+        end
+      end
+    end
+
+    assert_no_difference 'ExternalEntry.count' do
+      # 同じ記事は重複して保存しない
+      VCR.use_cassette 'external_entry/fetch3', vcr_options do
+        VCR.use_cassette 'external_entry/fetch2', vcr_options do
+          VCR.use_cassette 'external_entry/fetch' do
+            ExternalEntry.fetch_and_save_rss_feeds(users)
+          end
+        end
+      end
+    end
+  end
 end

--- a/test/models/external_entry_test.rb
+++ b/test/models/external_entry_test.rb
@@ -32,8 +32,33 @@ class ExternalEntryTest < ActiveSupport::TestCase
     rdf_item.expect(:link, 'https://test.com/index.rdf')
     rdf_item.expect(:description, 'article description')
     rdf_item.expect(:dc_date, Time.zone.local(2022, 1, 1, 0, 0, 0))
+    rdf_item.expect(:dc_date, Time.zone.local(2022, 1, 1, 0, 0, 0))
 
-    assert ExternalEntry.save_rdf_feed(user, rdf_item)
+    assert ExternalEntry.save_rdf_feed(user, rdf_item, nil)
+  end
+
+  test 'save rdf feed with no article publish date' do
+    user = users(:hatsuno)
+    rdf_item = Minitest::Mock.new
+    rdf_item.expect(:link, 'https://test.com/index.rdf')
+    rdf_item.expect(:title, 'test title')
+    rdf_item.expect(:link, 'https://test.com/index.rdf')
+    rdf_item.expect(:description, 'article description')
+    rdf_item.expect(:dc_date, nil)
+
+    assert ExternalEntry.save_rdf_feed(user, rdf_item, nil)
+  end
+
+  test 'no exception even if all rdf elements are nil' do
+    user = users(:hatsuno)
+    rdf_item = Minitest::Mock.new
+    rdf_item.expect(:link, nil)
+    rdf_item.expect(:title, nil)
+    rdf_item.expect(:link, nil)
+    rdf_item.expect(:description, nil)
+    rdf_item.expect(:dc_date, nil)
+
+    assert ExternalEntry.save_rdf_feed(user, rdf_item, nil)
   end
 
   test '.save_rss_feed' do
@@ -46,8 +71,35 @@ class ExternalEntryTest < ActiveSupport::TestCase
     rss_item.expect(:enclosure, rss_item)
     rss_item.expect(:url, 'https://test.com/image.png')
     rss_item.expect(:pubDate, Time.zone.local(2022, 1, 1, 0, 0, 0))
+    rss_item.expect(:pubDate, Time.zone.local(2022, 1, 1, 0, 0, 0))
 
-    assert ExternalEntry.save_rss_feed(user, rss_item)
+    assert ExternalEntry.save_rss_feed(user, rss_item, nil)
+  end
+
+  test 'save rss feed with no article publish date' do
+    user = users(:hatsuno)
+    rss_item = Minitest::Mock.new
+    rss_item.expect(:link, 'https://test.com/rss')
+    rss_item.expect(:title, 'test title')
+    rss_item.expect(:link, 'https://test.com/rss')
+    rss_item.expect(:description, 'article description')
+    rss_item.expect(:enclosure, nil)
+    rss_item.expect(:pubDate, nil)
+
+    assert ExternalEntry.save_rss_feed(user, rss_item, Time.zone.local(2023, 1, 1, 0, 0, 0))
+  end
+
+  test 'no exception even if all rss elements are nil' do
+    user = users(:hatsuno)
+    rss_item = Minitest::Mock.new
+    rss_item.expect(:link, nil)
+    rss_item.expect(:title, nil)
+    rss_item.expect(:link, nil)
+    rss_item.expect(:description, nil)
+    rss_item.expect(:enclosure, nil)
+    rss_item.expect(:pubDate, nil)
+
+    assert ExternalEntry.save_rss_feed(user, rss_item, nil)
   end
 
   test '.save_atom_feed' do
@@ -66,33 +118,70 @@ class ExternalEntryTest < ActiveSupport::TestCase
     atom_item.expect(:nil?, atom_item)
     atom_item.expect(:href, 'https://test.com/image.png')
     atom_item.expect(:published, atom_item)
+    atom_item.expect(:published, atom_item)
     atom_item.expect(:content, Time.zone.local(2022, 1, 1, 0, 0, 0))
 
-    assert ExternalEntry.save_atom_feed(user, atom_item)
+    assert ExternalEntry.save_atom_feed(user, atom_item, nil)
   end
 
-  test '.fetch_and_save_rss_feeds' do
-    users = [users(:kimura), users(:hatsuno), users(:komagata)]
+  test 'save atom feed with no article publish date' do
+    user = users(:hatsuno)
+    atom_item = Minitest::Mock.new
+    atom_item.expect(:link, atom_item)
+    atom_item.expect(:href, 'https://test.com/feed')
+    atom_item.expect(:title, atom_item)
+    atom_item.expect(:content, 'test title')
+    atom_item.expect(:link, atom_item)
+    atom_item.expect(:href, 'https://test.com/feed')
+    atom_item.expect(:content, atom_item)
+    atom_item.expect(:content, 'article description')
+    atom_item.expect(:links, atom_item)
+    atom_item.expect(:find, atom_item)
+    atom_item.expect(:nil?, atom_item)
+    atom_item.expect(:href, 'https://test.com/image.png')
+    atom_item.expect(:published, nil)
+    atom_item.expect(:updated, nil)
 
-    assert_difference 'ExternalEntry.count', 56 do
-      VCR.use_cassette 'external_entry/fetch3', vcr_options do
-        VCR.use_cassette 'external_entry/fetch2', vcr_options do
-          VCR.use_cassette 'external_entry/fetch' do
-            ExternalEntry.fetch_and_save_rss_feeds(users)
-          end
-        end
-      end
-    end
-
-    assert_no_difference 'ExternalEntry.count' do
-      # 同じ記事は重複して保存しない
-      VCR.use_cassette 'external_entry/fetch3', vcr_options do
-        VCR.use_cassette 'external_entry/fetch2', vcr_options do
-          VCR.use_cassette 'external_entry/fetch' do
-            ExternalEntry.fetch_and_save_rss_feeds(users)
-          end
-        end
-      end
-    end
+    assert ExternalEntry.save_atom_feed(user, atom_item, Time.zone.local(2023, 1, 1, 0, 0, 0))
   end
+
+  test 'no exception even if all atom elements are nil' do
+    user = users(:hatsuno)
+    atom_item = Minitest::Mock.new
+    atom_item.expect(:link, nil)
+    atom_item.expect(:title, nil)
+    atom_item.expect(:content, nil)
+    atom_item.expect(:link, nil)
+    atom_item.expect(:content, nil)
+    atom_item.expect(:links, nil)
+    atom_item.expect(:published, nil)
+    atom_item.expect(:updated, nil)
+
+    assert ExternalEntry.save_atom_feed(user, atom_item, nil)
+  end
+
+  # test '.fetch_and_save_rss_feeds' do
+  #   users = [users(:kimura), users(:hatsuno), users(:komagata)]
+  #
+  #   assert_difference 'ExternalEntry.count', 56 do
+  #     VCR.use_cassette 'external_entry/fetch3', vcr_options do
+  #       VCR.use_cassette 'external_entry/fetch2', vcr_options do
+  #         VCR.use_cassette 'external_entry/fetch' do
+  #           ExternalEntry.fetch_and_save_rss_feeds(users)
+  #         end
+  #       end
+  #     end
+  #   end
+  #
+  #   assert_no_difference 'ExternalEntry.count' do
+  #     # 同じ記事は重複して保存しない
+  #     VCR.use_cassette 'external_entry/fetch3', vcr_options do
+  #       VCR.use_cassette 'external_entry/fetch2', vcr_options do
+  #         VCR.use_cassette 'external_entry/fetch' do
+  #           ExternalEntry.fetch_and_save_rss_feeds(users)
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
 end

--- a/test/models/external_entry_test.rb
+++ b/test/models/external_entry_test.rb
@@ -37,7 +37,7 @@ class ExternalEntryTest < ActiveSupport::TestCase
     assert ExternalEntry.save_rdf_feed(user, rdf_item, nil)
   end
 
-  test 'save rdf feed with no article publish date' do
+  test '.save_rdf_feed with no article publish date' do
     user = users(:hatsuno)
     rdf_item = Minitest::Mock.new
     rdf_item.expect(:link, 'https://test.com/index.rdf')
@@ -49,7 +49,7 @@ class ExternalEntryTest < ActiveSupport::TestCase
     assert ExternalEntry.save_rdf_feed(user, rdf_item, nil)
   end
 
-  test 'no exception even if all rdf elements are nil' do
+  test '.save_rdf_feed no exception even if all rdf elements are nil' do
     user = users(:hatsuno)
     rdf_item = Minitest::Mock.new
     rdf_item.expect(:link, nil)
@@ -76,7 +76,7 @@ class ExternalEntryTest < ActiveSupport::TestCase
     assert ExternalEntry.save_rss_feed(user, rss_item, nil)
   end
 
-  test 'save rss feed with no article publish date' do
+  test '.save_rss_feed with no article publish date' do
     user = users(:hatsuno)
     rss_item = Minitest::Mock.new
     rss_item.expect(:link, 'https://test.com/rss')
@@ -89,7 +89,7 @@ class ExternalEntryTest < ActiveSupport::TestCase
     assert ExternalEntry.save_rss_feed(user, rss_item, Time.zone.local(2023, 1, 1, 0, 0, 0).utc)
   end
 
-  test 'no exception even if all rss elements are nil' do
+  test '.save_rss_feed no exception even if all rss elements are nil' do
     user = users(:hatsuno)
     rss_item = Minitest::Mock.new
     rss_item.expect(:link, nil)
@@ -124,7 +124,7 @@ class ExternalEntryTest < ActiveSupport::TestCase
     assert ExternalEntry.save_atom_feed(user, atom_item, nil)
   end
 
-  test 'save atom feed with no article publish date' do
+  test '.save_atom_feed with no article publish date' do
     user = users(:hatsuno)
     atom_item = Minitest::Mock.new
     atom_item.expect(:link, atom_item)
@@ -145,7 +145,7 @@ class ExternalEntryTest < ActiveSupport::TestCase
     assert ExternalEntry.save_atom_feed(user, atom_item, Time.zone.local(2023, 1, 1, 0, 0, 0).utc)
   end
 
-  test 'no exception even if all atom elements are nil' do
+  test '.save_atom_feed no exception even if all atom elements are nil' do
     user = users(:hatsuno)
     atom_item = Minitest::Mock.new
     atom_item.expect(:link, nil)


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/6901

## 概要
Atom形式のフィード内に作成日が存在しないときに登録エラーとなっていたバグを修正しました。
Atom形式のフィードに記事の作成日時が存在しない場合は、更新日時を使用するようにしています。
気象庁のAtomフィードは記事ごとの日付を持っていないため、こちらを使用して動作確認していただけばと思います。

- 気象庁のフィードURL
  - https://www.data.jma.go.jp/developer/xml/feed/regular.xml

## 変更確認方法
1. mainブランチを最新にする
2. `komagata`でログインする
3. `http://localhost:3000/current_user/edit`にアクセスし、ブログのフィードURLに`https://www.data.jma.go.jp/developer/xml/feed/regular.xml`を設定、「更新する」ボタンをクリックする
4. `http://localhost:3000/scheduler/daily/fetch_external_entry`にアクセスして、エラーが発生することを確認する
6. bug/save-rss-with-no-publish-dateをローカルに取り込む
7. `komagata`でログインする
8. `http://localhost:3000/current_user/edit`にアクセスし、ブログのフィードURLに`https://www.data.jma.go.jp/developer/xml/feed/regular.xml`を設定、「更新する」ボタンをクリックする
9. `http://localhost:3000/scheduler/daily/fetch_external_entry`にアクセスする
10. `http://localhost:3000/external_entries`にアクセスし、RSSフィードが登録されていることを確認する（実行日付または実行した前日の日付のフィードが登録されていればOK）