### PR TITLE
提出物の時間経過に関する日本語の表現を修正

### DIFF
--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -154,7 +154,7 @@ div(v-else-if='isDashboard')
         class='hover\:bg-black',
         href='/products/unassigned#4days-elapsed',
         v-else)
-        | <strong>{{ countAlmostPassed5days() }}件</strong>の提出物が、<br>8時間後に5日経過に到達します。
+        | <strong>{{ countAlmostPassed5days() }}件</strong>の提出物が、<br>8時間以内に5日経過に到達します。
 
 //- 全て, 未完了
 .page-content.is-products(v-else)

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -415,7 +415,7 @@ product69:
 product70:
   practice: practice11
   user: kimura
-  body: 8時間後に5日経過に到達する提出物です。
+  body: 8時間以内に5日経過に到達する提出物です。
   created_at: <%= 5.day.ago + 8.hours %>
   updated_at: <%= 5.day.ago + 8.hours %>
   published_at: <%= 5.day.ago + 8.hours %>
@@ -423,7 +423,7 @@ product70:
 product71:
   practice: practice12
   user: kimura
-  body: 8時間後に5日経過に到達する提出物です。
+  body: 8時間以内に5日経過に到達する提出物です。
   created_at: <%= 5.day.ago + 8.hours %>
   updated_at: <%= 5.day.ago + 8.hours %>
   published_at: <%= 5.day.ago + 8.hours %>

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -300,11 +300,11 @@ class HomeTest < ApplicationSystemTestCase
 
   test 'display counts of passed almost 5days' do
     visit_with_auth '/', 'mentormentaro'
-    assert_text "2件の提出物が、\n8時間後に5日経過に到達します。"
+    assert_text "2件の提出物が、\n8時間以内に5日経過に到達します。"
 
     products(:product70).update!(checker: users(:mentormentaro))
     visit current_path
-    assert_text "1件の提出物が、\n8時間後に5日経過に到達します。"
+    assert_text "1件の提出物が、\n8時間以内に5日経過に到達します。"
 
     products(:product71).update!(checker: users(:mentormentaro))
     visit current_path


### PR DESCRIPTION
## Issue

- #6926

## 概要
「8時間**後**に5日経過」ではなく「8時間**以内**に5日経過」に表現を変更。

## 変更確認方法

1. `feature/fix-time-expression`をローカルに取り込む
2. `rails db:reset`を実行
3. `rails s`でローカル環境を立ち上げる
4. `localhost:3000` にアクセス
5. ユーザー名： `machida`でログイン
6. ダッシュボード画面にて最下部までスクロールし、該当の文言を確認

## Screenshot

### 変更前

![_development__ダッシュボード___FBC](https://github.com/fjordllc/bootcamp/assets/79001972/78478b42-99ba-4d1e-b13a-38de0f8b4547)


### 変更後


![_development__ダッシュボード___FBC](https://github.com/fjordllc/bootcamp/assets/79001972/6f5250cf-9e94-4739-8d33-7f16f5b8b383)


