### PR TITLE
不要なdiscord_accountの記述を削除する

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -22,7 +22,7 @@ class CurrentUserController < ApplicationController
     user_attribute = [
       :adviser, :login_name, :name,
       :name_kana, :email, :course_id,
-      :description, :job_seeking, :discord_account,
+      :description, :job_seeking,
       :github_account, :twitter_account, :facebook_url,
       :blog_url, :password, :password_confirmation,
       :job, :organization, :os,

--- a/db/migrate/20231001031818_remove_discord_account_and_times_url_and_times_id_from_users.rb
+++ b/db/migrate/20231001031818_remove_discord_account_and_times_url_and_times_id_from_users.rb
@@ -1,0 +1,7 @@
+class RemoveDiscordAccountAndTimesUrlAndTimesIdFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :discord_account, :string
+    remove_column :users, :times_url, :string
+    remove_column :users, :times_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_25_075918) do
+ActiveRecord::Schema.define(version: 2023_10_01_031818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -719,8 +719,11 @@ ActiveRecord::Schema.define(version: 2023_09_25_075918) do
     t.bigint "retire_reasons", default: 0, null: false
     t.string "unsubscribe_email_token"
     t.text "mentor_memo"
+<<<<<<< HEAD
     t.string "discord_account"
     t.string "times_url"
+=======
+>>>>>>> b9e7e94dd (Usersからdiscord_account, times_url, times_idカラムを削除)
     t.text "after_graduation_hope"
     t.date "training_ends_on"
     t.boolean "sad_streak", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -719,8 +719,6 @@ ActiveRecord::Schema.define(version: 2023_10_01_031818) do
     t.bigint "retire_reasons", default: 0, null: false
     t.string "unsubscribe_email_token"
     t.text "mentor_memo"
-    t.string "discord_account"
-    t.string "times_url"
     t.text "after_graduation_hope"
     t.date "training_ends_on"
     t.boolean "sad_streak", default: false, null: false
@@ -732,7 +730,6 @@ ActiveRecord::Schema.define(version: 2023_10_01_031818) do
     t.text "profile_text"
     t.string "feed_url"
     t.boolean "sent_student_followup_message", default: false
-    t.string "times_id", comment: "Snowflake ID"
     t.string "country_code"
     t.string "subdivision_code"
     t.boolean "auto_retire", default: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -719,11 +719,8 @@ ActiveRecord::Schema.define(version: 2023_10_01_031818) do
     t.bigint "retire_reasons", default: 0, null: false
     t.string "unsubscribe_email_token"
     t.text "mentor_memo"
-<<<<<<< HEAD
     t.string "discord_account"
     t.string "times_url"
-=======
->>>>>>> b9e7e94dd (Usersからdiscord_account, times_url, times_idカラムを削除)
     t.text "after_graduation_hope"
     t.date "training_ends_on"
     t.boolean "sad_streak", default: false, null: false

--- a/test/models/times_channel_creator_test.rb
+++ b/test/models/times_channel_creator_test.rb
@@ -12,7 +12,7 @@ class TimesChannelCreatorTest < ActiveSupport::TestCase
       Discord::TimesChannel.stub(:new, ->(_) { InvalidTimesChannel.new }) do
         TimesChannelCreator.new.call(user)
       end
-      assert_nil user.times_id
+      assert_nil user.discord_profile.times_id
       assert_equal "[Discord API] #{user.login_name}の分報チャンネルが作成できませんでした。", logs.pop
 
       Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do


### PR DESCRIPTION
## Issue

- #6856 
- #6818 

## 概要
https://github.com/fjordllc/bootcamp/issues/6818 にて、Users テーブルにある Discord 関連のカラムを Discord 用のテーブルdiscord_profileに移行した。

- 移行前(説明に必要なカラムのみ記載。)
<img width="150" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/c1c8cec2-9c3a-47f1-8ac1-4a1044b655de">

- 移行後
<img width="156" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/f17a01d3-e135-4c18-8f07-aeb5d71a5133">

しかし、完全に移行できておらず、Users テーブル内の discord関連のカラムとそれに関連するコードはまだ残っている状態。Usersテーブル関連のコード と DiscordProfile関連のコード が混在しているので、今回のPRにて、Usersテーブルに残っている カラムとそれに関連するコードを削除する。

- 関連するコード
app/controllers/current_user_controller.rb
````ruby
(途中略)
  private

  def user_params
    user_attribute = [
      :adviser, :login_name, :name,
      :name_kana, :email, :course_id,
      :description, :job_seeking, :discord_account, # このdiscord_accountが使用されていないのに残されている状態
````

## 変更確認方法

1. `feature/remove-discord-account-attribute-and-leave-discord-profile-attribute`をローカルに取り込む
2. `schema.rb`を開く。
3. usersテーブルに、以下のカラムが無いことを確認する。
- discord_account
- times_url
- times_id
4. `app/controllers/current_user_controller.rb`を開き、下記の`:discord_account`が削除されていることを確認する。
````ruby
(途中略)
  private

  def user_params
    user_attribute = [
      :adviser, :login_name, :name,
      :name_kana, :email, :course_id,
      :description, :job_seeking, :discord_account, # このdiscord_accountが使用されていないのに残されている状態
````


## Screenshot

screenshotはありません。

