### PR TITLE
研修生の相談部屋個別ページに企業ロゴを表示

### DIFF
--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -15,6 +15,9 @@
             .page-content-header__start
               .page-content-header__user
                 = render 'users/icon', user: @talk.user, link_class: 'page-content-header__user-link', image_class: 'page-content-header__user-icon'
+              - if @talk.user.trainee?
+                = link_to company_path(@talk.user.company) do
+                  = image_tag @talk.user.company.logo_url, class: 'page-content-header__company-logo'
             .page-content-header__end
               .page-content-header__row
                 .page-content-header__before-title

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -441,4 +441,9 @@ class TalksTest < ApplicationSystemTestCase
     visit '/talks/action_uncompleted'
     assert_text "#{decorated_user.long_name} さんの相談部屋"
   end
+
+  test 'display company-logo in consultation room when user is trainee' do
+    visit_with_auth "/talks/#{talks(:talk11).id}", 'kensyu'
+    assert_selector 'img[class="page-content-header__company-logo"]'
+  end
 end


### PR DESCRIPTION
## Issue

- #6475

## 概要
- すでに企業ロゴが表示されている日報個別ページ、提出物個別ページを参考に研修生の相談部屋個別ページに企業ロゴを表示。

## 変更確認方法

1. `feature/add-company-logo-to-trainee-consultation-page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. `localhost:3000`にアクセス
4. ユーザー名：`kensyu`でログイン
5. 相談タブをクリック
6. 相談部屋個別ページに企業ロゴが表示されていることを確認

## Screenshot

### 変更前

![_development__kensyuさんの相談部屋___FBC](https://github.com/fjordllc/bootcamp/assets/79001972/9e8b3596-1aec-4d2e-9faa-19c83261593c)


### 変更後

![_development__kensyuさんの相談部屋___FBC](https://github.com/fjordllc/bootcamp/assets/79001972/f7a79b6d-ab7c-4b0c-bc60-dba6f16346b1)