### PR TITLE
メンターが見れるカテゴリー画面に、各カテゴリーに所属するプラクティス数を表示

### DIFF
--- a/app/javascript/components/Categories.jsx
+++ b/app/javascript/components/Categories.jsx
@@ -31,7 +31,8 @@ const Category = ({ category }) => {
   return (
     <tr className="admin-table__item">
       <td className="admin-table__item-value">
-        <a href={`/mentor/categories/${category.id}`}>{category.name}</a>
+        <a href={`/mentor/categories/${category.id}`}>{category.name}</a>(
+        {category.practices.length})
       </td>
       <td className="admin-table__item-value">{category.slug}</td>
       <td className="admin-table__item-value is-text-align-center">

--- a/app/views/api/categories/_category.json.jbuilder
+++ b/app/views/api/categories/_category.json.jbuilder
@@ -1,1 +1,1 @@
-json.(category, :id, :name, :slug)
+json.(category, :id, :name, :slug, :practices)

--- a/test/system/mentor/categories_test.rb
+++ b/test/system/mentor/categories_test.rb
@@ -94,4 +94,13 @@ class Mentor::CategoriesTest < ApplicationSystemTestCase
     find("a[href='/mentor/categories/#{category.id}/practices']").click
     assert_text '学習の準備カテゴリーのプラクティス並び替え'
   end
+
+  test 'should_display_practice_count_correctly' do
+    category_name = '学習の準備'
+    category = Category.find_by(name: category_name)
+    practice_count = category.practices.length
+
+    visit_with_auth '/mentor/categories', 'komagata'
+    assert_text "#{category_name}(#{practice_count})"
+  end
 end

--- a/test/system/mentor/categories_test.rb
+++ b/test/system/mentor/categories_test.rb
@@ -95,7 +95,7 @@ class Mentor::CategoriesTest < ApplicationSystemTestCase
     assert_text '学習の準備カテゴリーのプラクティス並び替え'
   end
 
-  test 'should_display_practice_count_correctly' do
+  test 'should display practice count correctly' do
     category_name = '学習の準備'
     category = Category.find_by(name: category_name)
     practice_count = category.practices.length


### PR DESCRIPTION
## Issue

- #6782

## 概要
メンターが見れるカテゴリー画面に、各カテゴリーに所属するプラクティス数を表示するようにしました。
## 変更確認方法

1. `feature/mentor_category_list_number_of_practices`をローカルに取り込む
2. メンターのアカウントでログイン
3. http://localhost:3000/mentor/categories にアクセス
4. 各カテゴリーの名前の横に、所属するプラクティスの数が表示されていることを確認

## Screenshot

### 変更前
<img width="1335" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/9d2d2adb-1c6b-4815-9db4-56c070ecc33f">

### 変更後
<img width="1342" alt="image 2" src="https://github.com/fjordllc/bootcamp/assets/88243294/bb99e188-5f56-4664-a548-50fa201a167f">
