### PR TITLE
落ちやすいregular_events_testを修正

### DIFF
--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -212,6 +212,7 @@ class RegularEventsTest < ApplicationSystemTestCase
   end
 
   test 'mentor or admin can join regular event when they are organizer' do
+    now = Time.current
     visit_with_auth new_regular_event_path, 'komagata'
     within 'form[name=regular_event]' do
       fill_in 'regular_event[title]', with: '全員参加イベント'
@@ -219,7 +220,7 @@ class RegularEventsTest < ApplicationSystemTestCase
       find('#choices--js-choices-multiple-select-item-choice-1').click
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
       first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select(%w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日
-                                                                                                                土曜日][DateTime.now.wday].to_s)
+                                                                                                                土曜日][now.to_date.wday].to_s)
       fill_in 'regular_event[start_at]', with: Time.zone.parse('19:00')
       fill_in 'regular_event[end_at]', with: Time.zone.parse('20:00')
       fill_in 'regular_event[description]', with: '全員が参加するイベントです。'
@@ -229,15 +230,17 @@ class RegularEventsTest < ApplicationSystemTestCase
       end
     end
     assert_text '定期イベントを作成しました。'
-    assert_text "毎週#{%w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日][DateTime.now.wday]}"
+    assert_text "毎週#{%w[日曜日 月曜日 火曜日 水曜日 木曜日 金曜日 土曜日][now.to_date.wday]}"
     assert_text 'Watch中'
     assert_no_text '参加申込'
     assert_no_text '参加者'
     assert_text 'この定期イベントは全員参加のため参加登録は不要です。'
 
-    visit_with_auth '/', 'komagata'
-    within first('.card-list.has-scroll') do
-      assert_text '全員参加イベント'
+    travel_to Time.zone.local(now.year, now.month, now.day, 18, 0, 0) do
+      visit_with_auth '/', 'komagata'
+      within first('.card-list.has-scroll') do
+        assert_text '全員参加イベント'
+      end
     end
   end
 


### PR DESCRIPTION
## 概要
下記の箇所のテストが19時以降に実行すると必ず落ちるようになっていたので修正しました。
https://github.com/fjordllc/bootcamp/blob/84b62f5e71475d1e0c83072cb1627549d23e4d14/test/system/regular_events_test.rb#L240

## 原因と修正内容
このテストの意図は、本日開催予定の定期イベントがトップページに表示されているのを確認することです。
しかしながら、トップページに表示される本日開催予定の定期イベントは、現在時刻より後に開始されるものに限ります。
https://github.com/fjordllc/bootcamp/blob/84b62f5e71475d1e0c83072cb1627549d23e4d14/app/models/regular_event.rb#L91
そして、テスト中で作成するイベントの開始時刻が19時となっているため、19時以降にこのテストを実行すると作成したイベントがトップページに表示されず、テストが必ず落ちます。
https://github.com/fjordllc/bootcamp/blob/84b62f5e71475d1e0c83072cb1627549d23e4d14/test/system/regular_events_test.rb#L223

travel_toを用いてテスト中でトップページを確認する時刻をイベント開始前にすることにより、テストが常に通るようにしました。


## 変更確認方法
19時以降に以下のテストを実行し、成功すること
```ruby
❯ bin/rails test test/system/regular_events_test.rb:214   
```
