### PR TITLE
日報のURL生成方法を修正

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -45,7 +45,7 @@ class ActivityMailer < ApplicationMailer
 
     @user = @receiver
     link = "/#{@comment.commentable_type.downcase.pluralize}/#{@comment.commentable.id}"
-    @link_url = notification_redirector_path(
+    @link_url = notification_redirector_url(
       link: link,
       kind: Notification.kinds[:came_comment]
     )
@@ -298,7 +298,7 @@ class ActivityMailer < ApplicationMailer
     @user = @receiver
 
     @link_url = notification_redirector_url(
-      link: report_url(@report),
+      link: "/reports/#{@report.id}",
       kind: Notification.kinds[:first_report]
     )
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -298,7 +298,7 @@ class ActivityMailer < ApplicationMailer
     @user = @receiver
 
     @link_url = notification_redirector_url(
-      link: "/reports/#{@report.id}",
+      link: report_url(@report),
       kind: Notification.kinds[:first_report]
     )
 

--- a/app/views/activity_mailer/first_report.html.slim
+++ b/app/views/activity_mailer/first_report.html.slim
@@ -1,6 +1,6 @@
 = render '/notification_mailer/notification_mailer_template',
   title: "#{@report.user.login_name}さんのはじめての日報です！",
-  link_url: "/reports/#{@report.id}", link_text: 'この日報へ' do
+  link_url: @link_url, link_text: 'この日報へ' do
   p #{@report.user.login_name}さんのはじめての日報です。歓迎のコメントを投稿しよう！！
   div(style='border-top: solid 1px #ccc; height: 0;')
   = md2html(@report.description)


### PR DESCRIPTION
## Issue

- #6963

## 概要
- 「○○さんのはじめての日報です！」の通知メールにある「この日報へ」ボタンのURLが`http:///reports/82102`のようになっている。その為、URLを正しい形式に修正し、クリックした際に目的のページに遷移できるようにする。
- また、上記に関連して相談部屋のコメント通知メールにある「コメントへ」ボタンのURLも正しい形式に修正。

## 変更確認方法

1. `bug/fix-first-report-notification-link`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. `localhost:3000`にアクセス
4. `nippounashi`でログイン
5. `http://localhost:3000/reports/new`で初日報を作成
6. `komagata`でログインし直す
7. 初めての日報の通知が来ているかを確認
8. `http://localhost:3000/letter_opener/`に「nippounashiさんのはじめての日報です！」メールが来ていることを確認
9. Chromeのデベロッパーツールで「この日報へ」ボタンのURLを確認

## Screenshot

### 変更前
 - 本番環境：Issueより引用
![【メンター向け】「はじめての日報です！」の通知メールのリンクがおかしい_·_Issue__6963_·_fjordllc_bootcamp](https://github.com/fjordllc/bootcamp/assets/79001972/4c784612-ffad-4000-8646-109101576a5c)

- ローカル環境

<img width="1122" alt="_development__LetterOpenerWeb" src="https://github.com/fjordllc/bootcamp/assets/79001972/34eeed02-207a-458a-9093-a92efec35d0f">

### 変更後
- ※ステージング・本番環境についてはマージ後にURLが正しいかとページ遷移が正常に実施できるか確認する

- ローカル環境

<img width="1216" alt="_development__LetterOpenerWeb" src="https://github.com/fjordllc/bootcamp/assets/79001972/ab4a28ee-84ad-4d22-a232-0cbad5fa63ca">
