### PR TITLE
メール通知設定がOFFになっている場合は、相談部屋からのメール通知が飛ばないように修正

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -43,6 +43,8 @@ class ActivityMailer < ApplicationMailer
     @message ||= args[:message]
     @receiver ||= args[:receiver]
 
+    return unless @receiver.mail_notification
+
     @user = @receiver
     link = "/#{@comment.commentable_type.downcase.pluralize}/#{@comment.commentable.id}"
     @link_url = notification_redirector_path(

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -43,7 +43,7 @@ class ActivityMailer < ApplicationMailer
     @message ||= args[:message]
     @receiver ||= args[:receiver]
 
-    return unless @receiver.mail_notification
+    return unless @receiver.mail_notification?
 
     @user = @receiver
     link = "/#{@comment.commentable_type.downcase.pluralize}/#{@comment.commentable.id}"

--- a/app/models/comment_notifier_for_admin.rb
+++ b/app/models/comment_notifier_for_admin.rb
@@ -6,7 +6,6 @@ class CommentNotifierForAdmin
 
     User.admins.each do |admin_user|
       next if comment.sender == admin_user
-      next unless admin_user.mail_notification?
 
       commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
       ActivityDelivery.with(

--- a/app/models/comment_notifier_for_admin.rb
+++ b/app/models/comment_notifier_for_admin.rb
@@ -6,6 +6,7 @@ class CommentNotifierForAdmin
 
     User.admins.each do |admin_user|
       next if comment.sender == admin_user
+      next unless admin_user.mail_notification?
 
       commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
       ActivityDelivery.with(

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -1099,4 +1099,19 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] 相談部屋でkomagataさんからコメントがありました。', email.subject
     assert_match(/コメント/, email.body.to_s)
   end
+
+  test 'came_comment for admin with mail_notification off' do
+    admin = users(:komagata)
+    admin.update(mail_notification: false)
+
+    comment = comments(:commentOfTalk)
+
+    ActivityMailer.came_comment(
+      comment: comment,
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      receiver: comment.receiver
+    ).deliver_now
+
+    assert ActionMailer::Base.deliveries.empty?
+  end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -1102,7 +1102,7 @@ class ActivityMailerTest < ActionMailer::TestCase
 
   test 'came_comment for admin with mail_notification off' do
     ActionMailer::Base.deliveries.clear
-    
+
     admin = users(:komagata)
     admin.update(mail_notification: false)
 

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -1099,31 +1099,4 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal '[FBC] 相談部屋でkomagataさんからコメントがありました。', email.subject
     assert_match(/コメント/, email.body.to_s)
   end
-
-  test 'came_comment for admin with mail_notification off' do
-    ActionMailer::Base.deliveries.clear
-
-    admin = users(:komagata)
-    admin.update(mail_notification: false)
-
-    comment = comments(:commentOfTalk)
-    commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)
-
-    Notification.create!(
-      kind: Notification.kinds['came_comment'],
-      user: comment.receiver,
-      sender: comment.sender,
-      link: "#{commentable_path}#latest-comment",
-      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
-      read: false
-    )
-
-    ActivityMailer.came_comment(
-      comment: comment,
-      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
-      receiver: comment.receiver
-    ).deliver_now
-
-    assert ActionMailer::Base.deliveries.empty?
-  end
 end


### PR DESCRIPTION
## Issue

- #6948

## 概要

- 管理者のメール通知設定を`OFF`にした場合、相談部屋からのメール通知が飛ばないように修正。

## 変更確認方法

1. `bug/fix-admin-notification-ignoring-settings`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. `localhost:3000`にアクセス
4. `komagata`でログイン
5. 「登録情報変更」画面でメール通知設定を`OFF`にし、「更新する」ボタン押下
6. `kimura`でログインし直す
7. 相談部屋で任意のテキストを入力し「コメントする」ボタン押下
8. `http://localhost:3000/letter_opener/`にアクセス
9. `komagata`宛にメール通知が届いていないことを確認する

## Screenshot

### 変更前

<img width="1216" alt="_development__LetterOpenerWeb" src="https://github.com/fjordllc/bootcamp/assets/79001972/97a46061-97c1-4997-a9e1-8ec892c352cb">


### 変更後

<img width="1252" alt="_development__LetterOpenerWeb" src="https://github.com/fjordllc/bootcamp/assets/79001972/0691b70c-c95f-4d1b-a738-4dc3956a983a">

