### PR TITLE
Chrome115以上を使用している場合にWebdrivers::VersionErrorが発生しない様にする。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,5 @@ group :test do
   gem 'minitest-retry'
   gem 'selenium-webdriver'
   gem 'vcr'
-  gem 'webdrivers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       activerecord (>= 6.0, < 7.1)
     acts_as_list (1.0.4)
       activerecord (>= 4.2)
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     any_login (1.5.2)
       rails (>= 6.0)
@@ -133,7 +133,7 @@ GEM
       thor (>= 0.20)
       tty-table (~> 0.10)
     byebug (11.1.3)
-    capybara (3.39.1)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -282,8 +282,8 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
-    mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_mime (1.1.5)
+    mini_portile2 (2.8.4)
     minitest (5.17.0)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
@@ -304,10 +304,10 @@ GEM
     netrc (0.11.0)
     newspaper (0.2.0)
     nio4r (2.5.9)
-    nokogiri (1.15.1)
+    nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.15.1-x86_64-darwin)
+    nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     oauth (0.6.2)
       snaky_hash (~> 2.0)
@@ -354,12 +354,12 @@ GEM
       pry (>= 0.13, < 0.15)
     psych (4.0.6)
       stringio
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.3.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
-    racc (1.6.2)
-    rack (2.2.7)
+    racc (1.7.1)
+    rack (2.2.8)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-dev-mark (0.7.9)
@@ -423,7 +423,7 @@ GEM
       tilt
     recaptcha (5.12.3)
       json
-    regexp_parser (2.8.0)
+    regexp_parser (2.8.2)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -434,7 +434,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rollbar (3.3.2)
     rss (0.2.9)
       rexml
@@ -470,7 +470,7 @@ GEM
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.9.1)
+    selenium-webdriver (4.14.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -551,10 +551,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -565,7 +561,7 @@ GEM
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
     webrick (1.7.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-client-simple (0.6.0)
       event_emitter
       websocket
@@ -666,7 +662,6 @@ DEPENDENCIES
   vcr
   view_source_map
   web-console (>= 4.1.0)
-  webdrivers
   webmock
   webpacker (~> 5.0)
 

--- a/test/supports/vcr_helper.rb
+++ b/test/supports/vcr_helper.rb
@@ -25,9 +25,6 @@ VCR.configure do |c|
     name = 'UTF-8' || !http_message.body.valid_encoding?
     http_message.body.encoding.name == name
   end
-
-  driver_hosts = Webdrivers::Common.subclasses.map { |driver| URI(driver.base_url).host }
-  c.ignore_hosts(*driver_hosts)
 end
 
 module VCRHelper

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,6 @@ require 'webmock/minitest'
 
 Capybara.default_max_wait_time = 10
 Capybara.disable_animation = true
-Webdrivers.cache_time = 86_400
 Minitest::Retry.use! if ENV['CI']
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6881

## 概要
ローカルでインストールされているChromeが115以上の場合システムテストを実行すると、`Webdrivers::VersionError`が発生する。

<details><summary>Webdrivers::VersionErrorエラー全文</summary>

````
😄 ~/fjord/fjord_page/bootcamp bundle exec rails test test/system/announcements_test.rb:15
/Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:83:in `rescue in latest_point_release': Unable to find latest point release version for 118.0.5993. You appear to be using a non-production version of Chrome. Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` to a known chromedriver version: https://chromedriver.storage.googleapis.com/index.html (Webdrivers::VersionError)
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:65:in `latest_point_release'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:39:in `block in latest_version'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:166:in `with_cache'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:37:in `latest_version'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:122:in `download_version'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:126:in `download_url'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:98:in `update'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:156:in `block in <main>'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/actionpack-6.1.4.7/lib/action_dispatch/system_testing/browser.rb:37:in `preload'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/actionpack-6.1.4.7/lib/action_dispatch/system_testing/driver.rb:15:in `initialize'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/actionpack-6.1.4.7/lib/action_dispatch/system_test_case.rb:157:in `new'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/actionpack-6.1.4.7/lib/action_dispatch/system_test_case.rb:157:in `driven_by'
        from /Users/ochiaisoushi/fjord/fjord_page/bootcamp/test/application_system_test_case.rb:24:in `<class:ApplicationSystemTestCase>'
        from /Users/ochiaisoushi/fjord/fjord_page/bootcamp/test/application_system_test_case.rb:12:in `<main>'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/fjord/fjord_page/bootcamp/test/system/announcements_test.rb:3:in `<main>'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/test_unit/runner.rb:50:in `block in load_tests'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/test_unit/runner.rb:50:in `each'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/test_unit/runner.rb:50:in `load_tests'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/test_unit/runner.rb:39:in `run'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/commands/test/test_command.rb:33:in `perform'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/command/base.rb:69:in `perform'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/command.rb:48:in `invoke'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/commands.rb:18:in `<main>'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from bin/rails:4:in `<main>'
/Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/network.rb:19:in `get': Net::HTTPServerException: 404 "Not Found" with https://chromedriver.storage.googleapis.com/LATEST_RELEASE_118.0.5993 (Webdrivers::NetworkError)
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:66:in `latest_point_release'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:39:in `block in latest_version'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:166:in `with_cache'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:37:in `latest_version'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:122:in `download_version'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:126:in `download_url'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/common.rb:98:in `update'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/webdrivers-5.2.0/lib/webdrivers/chromedriver.rb:156:in `block in <main>'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/actionpack-6.1.4.7/lib/action_dispatch/system_testing/browser.rb:37:in `preload'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/actionpack-6.1.4.7/lib/action_dispatch/system_testing/driver.rb:15:in `initialize'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/actionpack-6.1.4.7/lib/action_dispatch/system_test_case.rb:157:in `new'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/actionpack-6.1.4.7/lib/action_dispatch/system_test_case.rb:157:in `driven_by'
        from /Users/ochiaisoushi/fjord/fjord_page/bootcamp/test/application_system_test_case.rb:24:in `<class:ApplicationSystemTestCase>'
        from /Users/ochiaisoushi/fjord/fjord_page/bootcamp/test/application_system_test_case.rb:12:in `<main>'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/fjord/fjord_page/bootcamp/test/system/announcements_test.rb:3:in `<main>'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/test_unit/runner.rb:50:in `block in load_tests'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/test_unit/runner.rb:50:in `each'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/test_unit/runner.rb:50:in `load_tests'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/test_unit/runner.rb:39:in `run'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/commands/test/test_command.rb:33:in `perform'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/command/base.rb:69:in `perform'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/command.rb:48:in `invoke'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/railties-6.1.4.7/lib/rails/commands.rb:18:in `<main>'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /Users/ochiaisoushi/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from bin/rails:4:in `<main>'
````
</details>

### 原因
- chromedriverの管理方針がバージョン115から変わった
- webdrivers gemがこれに対応していない
- ローカルマシンにインストールされているChromeが115以上になるとこの問題が発生する

### 対処方法
最新版のselenium-webdriverにはドライバの管理機能が組み込まれており、これに切り替えることで問題が解決する。

### 参考記事
https://github.com/rails/rails/pull/48847
https://qiita.com/jnchito/items/f994dd3ac2cdc39bff8c

## 変更確認方法
(前提) chrome driverのversionが115以上であること

1. ローカル環境のmainブランチで任意のシステムテストを実行して、`Webdrivers::VersionError`が発生することを確認する。
2. `bug/webdrivers_version_error_occurs_when_using_above_chrome_115`をローカルに取り込んで、ブランチを切り替える。
3. ローカル環境で任意のシステムテストを実行して、`Webdrivers::VersionError`が発生しないことを確認する。

## Screenshot

- 変更前
![image](https://github.com/fjordllc/bootcamp/assets/92995093/2116edd0-70e0-42a1-aba1-86ca16effdfc)

- 変更後
![image](https://github.com/fjordllc/bootcamp/assets/92995093/da4650f4-5ae2-41ae-a377-192a9d7f65a0)



