### PR TITLE
テストの出力にDiscordのエラーメッセージが混ざっていたのを修正

### DIFF
--- a/test/models/discord/server_test.rb
+++ b/test/models/discord/server_test.rb
@@ -105,6 +105,8 @@ module Discord
     test '.delete_text_channel with error' do
       logs = []
       Rails.logger.stub(:error, ->(message) { logs << message }) do
+        Discordrb::LOGGER.mode = :silent
+
         VCR.use_cassette 'discord/server/delete_text_channel_with_unknown_channel_id' do
           assert_nil Discord::Server.delete_text_channel('12345')
           assert_equal '[Discord API] Unknown Channel', logs.pop
@@ -115,6 +117,8 @@ module Discord
           assert_nil Discord::Server.delete_text_channel('987654321987654321')
           assert_equal '[Discord API] 401: Unauthorized', logs.pop
         end
+
+        Discordrb::LOGGER.mode = :info
       end
     end
 


### PR DESCRIPTION
```sh
❯ rails test test/models/discord/server_test.rb:105
Run options: --seed 12730

# Running:

[ERROR : main @ 2023-10-22 16:12:51.308] Unknown Channel
.
```

↑こういうやつ。