### PR TITLE
提出物ページのReact化

### DIFF
--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -5,10 +5,12 @@ class API::ProductsController < API::BaseController
 
   def index
     @company = Company.find(params[:company_id]) if params[:company_id]
+    per = params[:per] || 50
     @products = Product
                 .list
                 .order_for_all_list
                 .page(params[:page])
+                .per(per)
     @products_grouped_by_elapsed_days = @products.group_by { |product| product.elapsed_days >= 7 ? 7 : product.elapsed_days }
     @products = @products.joins(:user).where(users: { company_id: params[:company_id] }) if params[:company_id]
     @products = @products.where(user_id: params[:user_id]) if params[:user_id].present?

--- a/app/javascript/checkable_react.js
+++ b/app/javascript/checkable_react.js
@@ -1,4 +1,4 @@
-import { toast } from '../toast_react'
+import { toast } from './toast_react'
 
 export const check = ({
   checkableType,
@@ -75,7 +75,7 @@ export const checkProduct = (productId, currentUserId, url, method, token) => {
     })
     .then((json) => {
       if (json.message) {
-        alert(json.message)
+        toast(json.message, 'error')
       } else {
         if (json.checker_id !== null) {
           toast('担当になりました。')

--- a/app/javascript/checkable_react.js
+++ b/app/javascript/checkable_react.js
@@ -1,59 +1,5 @@
 import { toast } from './toast_react'
 
-export const check = ({
-  checkableType,
-  checkableId,
-  url,
-  method,
-  token,
-  checkId,
-  updateState
-}) => {
-  const params = {
-    checkable_type: checkableType,
-    checkable_id: checkableId
-  }
-
-  fetch(url, {
-    method: method,
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'X-Requested-With': 'XMLHttpRequest',
-      'X-CSRF-Token': token
-    },
-    credentials: 'same-origin',
-    redirect: 'manual',
-    body: JSON.stringify(params)
-  })
-    .then((response) => {
-      if (!response.ok) {
-        return response.json()
-      } else {
-        return response
-      }
-    })
-    .then((json) => {
-      if (json.message) {
-        toast(json.message, 'error')
-      } else {
-        if (!checkId) {
-          if (checkableType === 'Product') {
-            toast('提出物を確認済みにしました。')
-          } else if (checkableType === 'Report') {
-            toast('日報を確認済みにしました。')
-          }
-        }
-        updateState({
-          checkableType: checkableType,
-          checkableId: checkableId
-        })
-      }
-    })
-    .catch((error) => {
-      console.warn(error)
-    })
-}
-
 export const checkProduct = (productId, currentUserId, url, method, token) => {
   const params = {
     product_id: productId,

--- a/app/javascript/components/Checkable.jsx
+++ b/app/javascript/components/Checkable.jsx
@@ -1,0 +1,90 @@
+import { toast } from '../toast_react'
+
+export const check = ({
+  checkableType,
+  checkableId,
+  url,
+  method,
+  token,
+  checkId,
+  updateState
+}) => {
+  const params = {
+    checkable_type: checkableType,
+    checkable_id: checkableId
+  }
+
+  fetch(url, {
+    method: method,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-Requested-With': 'XMLHttpRequest',
+      'X-CSRF-Token': token
+    },
+    credentials: 'same-origin',
+    redirect: 'manual',
+    body: JSON.stringify(params)
+  })
+    .then((response) => {
+      if (!response.ok) {
+        return response.json()
+      } else {
+        return response
+      }
+    })
+    .then((json) => {
+      if (json.message) {
+        toast(json.message, 'error')
+      } else {
+        if (!checkId) {
+          if (checkableType === 'Product') {
+            toast('提出物を確認済みにしました。')
+          } else if (checkableType === 'Report') {
+            toast('日報を確認済みにしました。')
+          }
+        }
+        updateState({
+          checkableType: checkableType,
+          checkableId: checkableId
+        })
+      }
+    })
+    .catch((error) => {
+      console.warn(error)
+    })
+}
+
+export const checkProduct = (productId, currentUserId, url, method, token) => {
+  const params = {
+    product_id: productId,
+    current_user_id: currentUserId
+  }
+  fetch(url, {
+    method: method,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-Requested-With': 'XMLHttpRequest',
+      'X-CSRF-Token': token
+    },
+    credentials: 'same-origin',
+    redirect: 'manual',
+    body: JSON.stringify(params)
+  })
+    .then((response) => {
+      return response.json()
+    })
+    .then((json) => {
+      if (json.message) {
+        alert(json.message)
+      } else {
+        if (json.checker_id !== null) {
+          toast('担当になりました。')
+        } else {
+          toast('担当から外れました。')
+        }
+      }
+    })
+    .catch((error) => {
+      console.warn(error)
+    })
+}

--- a/app/javascript/components/ElapsedDays.jsx
+++ b/app/javascript/components/ElapsedDays.jsx
@@ -1,24 +1,8 @@
 import React from 'react'
 
-export default function ElapsedDays({
-  productsGroupedByElapsedDays,
-  countProductsGroupedBy
-}) {
-  const countProductsByElapsedDays = (elapsedDays) => {
-    const productsGroup = productsGroupedByElapsedDays.find((product) => {
-      return product.elapsed_days === elapsedDays
-    })
-    if (productsGroup)
-      return countProductsGroupedBy(
-        productsGroup.elapsed_days,
-        productsGroup.products
-      )
-    return 0
-  }
-
+export default function ElapsedDays({ countProductsGroupedBy }) {
   const activeClass = (quantity) => {
-    if (quantity) return `is-active`
-    return `is-inactive`
+    return quantity ? 'is-active' : 'is-inactive'
   }
 
   return (
@@ -27,31 +11,31 @@ export default function ElapsedDays({
         <ol className="page-nav__items elapsed-days">
           <li
             className={`page-nav__item is-reply-deadline ${activeClass(
-              countProductsByElapsedDays(7)
+              countProductsGroupedBy(7)
             )}`}>
             <a className="page-nav__item-link" href="#7days-elapsed">
               <span className="page-nav__item-link-inner">
-                7日以上経過{` (${countProductsByElapsedDays(7)})`}
+                7日以上経過{` (${countProductsGroupedBy(7)})`}
               </span>
             </a>
           </li>
           <li
             className={`page-nav__item is-reply-alert ${activeClass(
-              countProductsByElapsedDays(6)
+              countProductsGroupedBy(6)
             )}`}>
             <a className="page-nav__item-link" href="#6days-elapsed">
               <span className="page-nav__item-link-inner">
-                6日経過{` (${countProductsByElapsedDays(6)})`}
+                6日経過{` (${countProductsGroupedBy(6)})`}
               </span>
             </a>
           </li>
           <li
             className={`page-nav__item is-reply-warning ${activeClass(
-              countProductsByElapsedDays(5)
+              countProductsGroupedBy(5)
             )}`}>
             <a className="page-nav__item-link" href="#5days-elapsed">
               <span className="page-nav__item-link-inner">
-                5日経過{` (${countProductsByElapsedDays(5)})`}
+                5日経過{` (${countProductsGroupedBy(5)})`}
               </span>
             </a>
           </li>
@@ -60,14 +44,14 @@ export default function ElapsedDays({
               <li
                 key={passedDay}
                 className={`page-nav__item ${activeClass(
-                  countProductsByElapsedDays(passedDay)
+                  countProductsGroupedBy(passedDay)
                 )}`}>
                 <a
                   href={`#${passedDay}days-elapsed`}
                   className="page-nav__item-link">
                   <span className="page-nav__item-link-inner">
                     {passedDay}日経過
-                    {` (${countProductsByElapsedDays(passedDay)})`}
+                    {` (${countProductsGroupedBy(passedDay)})`}
                   </span>
                 </a>
               </li>
@@ -75,11 +59,11 @@ export default function ElapsedDays({
           })}
           <li
             className={`page-nav__item ${activeClass(
-              countProductsByElapsedDays(0)
+              countProductsGroupedBy(0)
             )}`}>
             <a href="#0days-elapsed" className="page-nav__item-link">
               <span className="page-nav__item-link-inner">
-                今日提出{` (${countProductsByElapsedDays(0)})`}
+                今日提出{` (${countProductsGroupedBy(0)})`}
               </span>
             </a>
           </li>

--- a/app/javascript/components/ElapsedDays.jsx
+++ b/app/javascript/components/ElapsedDays.jsx
@@ -1,0 +1,89 @@
+import React from 'react'
+
+export default function ElapsedDays({
+  productsGroupedByElapsedDays,
+  countProductsGroupedBy
+}) {
+  const countProductsByElapsedDays = (elapsedDays) => {
+    const productsGroup = productsGroupedByElapsedDays.find((product) => {
+      return product.elapsed_days === elapsedDays
+    })
+    if (productsGroup)
+      return countProductsGroupedBy(
+        productsGroup.elapsed_days,
+        productsGroup.products
+      )
+    return countProductsGroupedBy(0, [])
+  }
+  const activeClass = (quantity) => {
+    if (quantity) return `is-active`
+    return `is-inactive`
+  }
+
+  return (
+    <nav className="page-body__column is-sub">
+      <div className="page-nav">
+        <ol className="page-nav__items elapsed-days">
+          <li
+            className={`page-nav__item is-reply-deadline ${activeClass(
+              countProductsByElapsedDays(7)
+            )}`}>
+            <a className="page-nav__item-link" href="#7days-elapsed">
+              <span className="page-nav__item-link-inner">
+                7日以上経過{` (${countProductsByElapsedDays(7)})`}
+              </span>
+            </a>
+          </li>
+          <li
+            className={`page-nav__item is-reply-alert ${activeClass(
+              countProductsByElapsedDays(6)
+            )}`}>
+            <a className="page-nav__item-link" href="#6days-elapsed">
+              <span className="page-nav__item-link-inner">
+                6日経過{` (${countProductsByElapsedDays(6)})`}
+              </span>
+            </a>
+          </li>
+          <li
+            className={`page-nav__item is-reply-warning ${activeClass(
+              countProductsByElapsedDays(5)
+            )}`}>
+            <a className="page-nav__item-link" href="#6days-elapsed">
+              <span className="page-nav__item-link-inner">
+                5日経過{` (${countProductsByElapsedDays(5)})`}
+              </span>
+            </a>
+          </li>
+          {[4, 3, 2, 1].map((passedDay) => {
+            return (
+              <li
+                key={passedDay}
+                className={`page-nav__item ${activeClass(
+                  countProductsByElapsedDays(passedDay)
+                )}`}>
+                <a
+                  href={`#${passedDay}days-elapsed`}
+                  className="page-nav__item-link">
+                  <span className="page-nav__item-link-inner">
+                    {passedDay}日経過
+                    {` (${countProductsByElapsedDays(passedDay)})`}
+                  </span>
+                </a>
+              </li>
+            )
+          })}
+          <li
+            className={`page-nav__item ${activeClass(
+              countProductsByElapsedDays(0)
+            )}`}>
+            <a href="#0days-elapsed" className="page-nav__item-link">
+              <span className="page-nav__item-link-inner">
+                今日提出{` (${countProductsByElapsedDays(0)})`}
+              </span>
+            </a>
+          </li>
+        </ol>
+      </div>
+    </nav>
+  )
+}

--- a/app/javascript/components/ElapsedDays.jsx
+++ b/app/javascript/components/ElapsedDays.jsx
@@ -13,8 +13,9 @@ export default function ElapsedDays({
         productsGroup.elapsed_days,
         productsGroup.products
       )
-    return countProductsGroupedBy(0, [])
+    return 0
   }
+
   const activeClass = (quantity) => {
     if (quantity) return `is-active`
     return `is-inactive`

--- a/app/javascript/components/ElapsedDays.jsx
+++ b/app/javascript/components/ElapsedDays.jsx
@@ -49,7 +49,7 @@ export default function ElapsedDays({
             className={`page-nav__item is-reply-warning ${activeClass(
               countProductsByElapsedDays(5)
             )}`}>
-            <a className="page-nav__item-link" href="#6days-elapsed">
+            <a className="page-nav__item-link" href="#5days-elapsed">
               <span className="page-nav__item-link-inner">
                 5日経過{` (${countProductsByElapsedDays(5)})`}
               </span>

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -99,14 +99,8 @@ export default function Product({ product, isMentor, currentUserId }) {
         product.self_last_commented_at_date_time
       const mentorLastCommentedAtDateTime =
         product.mentor_last_commented_at_date_time
-      console.log('FFF')
-      console.log('selfLastCommentedAtDateTime=' + selfLastCommentedAtDateTime)
-      console.log(
-        'mentorLastCommentedAtDateTime=' + mentorLastCommentedAtDateTime
-      )
       if (selfLastCommentedAtDateTime && mentorLastCommentedAtDateTime) {
         if (selfLastCommentedAtDateTime > mentorLastCommentedAtDateTime) {
-          console.log('AAA')
           return (
             <div className="a-meta">
               〜 {selfLastCommentedAt}（<strong>提出者</strong>）
@@ -115,26 +109,22 @@ export default function Product({ product, isMentor, currentUserId }) {
         } else if (
           selfLastCommentedAtDateTime < mentorLastCommentedAtDateTime
         ) {
-          console.log('BBB')
           return (
             <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
           )
         }
       } else if (selfLastCommentedAtDateTime) {
-        console.log('CCC')
         return (
           <div className="a-meta">
             〜 {selfLastCommentedAt}（<strong>提出者</strong>）
           </div>
         )
       } else if (mentorLastCommentedAtDateTime) {
-        console.log('DDD')
         return (
           <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
         )
       }
     }
-    console.log('null')
     return null
   }
 

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -173,36 +173,32 @@ const UserIcons = ({ users }) => {
 }
 
 const LastCommentedTime = ({ product }) => {
-  if (product.comments.size > 0) {
-    const selfLastCommentedAt = product.self_last_commented_at
-    const mentorLastCommentedAt = product.mentor_last_commented_at
-    const selfLastCommentedAtDateTime = product.self_last_commented_at_date_time
-    const mentorLastCommentedAtDateTime =
-      product.mentor_last_commented_at_date_time
+  const selfLastCommentedAt = product.self_last_commented_at
+  const mentorLastCommentedAt = product.mentor_last_commented_at
+  const selfLastCommentedAtDateTime = product.self_last_commented_at_date_time
+  const mentorLastCommentedAtDateTime =
+    product.mentor_last_commented_at_date_time
 
-    if (selfLastCommentedAtDateTime && mentorLastCommentedAtDateTime) {
-      if (selfLastCommentedAtDateTime > mentorLastCommentedAtDateTime) {
-        return (
-          <div className="a-meta">
-            〜 {selfLastCommentedAt}（<strong>提出者</strong>）
-          </div>
-        )
-      } else if (selfLastCommentedAtDateTime < mentorLastCommentedAtDateTime) {
-        return (
-          <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
-        )
-      }
-    } else if (selfLastCommentedAtDateTime) {
+  if (selfLastCommentedAtDateTime && mentorLastCommentedAtDateTime) {
+    if (selfLastCommentedAtDateTime > mentorLastCommentedAtDateTime) {
       return (
         <div className="a-meta">
           〜 {selfLastCommentedAt}（<strong>提出者</strong>）
         </div>
       )
-    } else if (mentorLastCommentedAtDateTime) {
+    } else if (selfLastCommentedAtDateTime < mentorLastCommentedAtDateTime) {
       return (
         <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
       )
     }
+  } else if (selfLastCommentedAtDateTime) {
+    return (
+      <div className="a-meta">
+        〜 {selfLastCommentedAt}（<strong>提出者</strong>）
+      </div>
+    )
+  } else if (mentorLastCommentedAtDateTime) {
+    return <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
   }
   return null
 }

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -8,151 +8,11 @@ export default function Product({
   currentUserId,
   elapsedDays
 }) {
-  const isDashboardPage = () => {
-    return location.pathname === '/'
-  }
-  const isUnassignedPage = () => {
-    return location.pathname === '/products/unassigned'
-  }
   const notRespondedSign = () => {
     return (
       product.self_last_commented_at_date_time >
         product.mentor_last_commented_at_date_time ||
       product.comments.size === 0
-    )
-  }
-  const untilNextElapsedDays = () => {
-    const elapsedTimes = calcElapsedTimes(product)
-    return Math.floor((Math.ceil(elapsedTimes) - elapsedTimes) * 24)
-  }
-
-  const calcElapsedTimes = () => {
-    const time = product.published_at_date_time || product.created_at_date_time
-    return (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
-  }
-  const TimeInfo = () => {
-    if (product.wip) {
-      return (
-        <div className="card-list-item-meta">
-          <div className="a-meta">提出物作成中</div>
-        </div>
-      )
-    } else {
-      return (
-        <div className="card-list-item-meta">
-          <div className="card-list-item__row">
-            <div className="card-list-item-meta">
-              <div className="card-list-item-meta__items">
-                <div className="card-list-item-meta__item">
-                  <time className="a-meta" dateTime={product.created_at}>
-                    <span className="a-meta__label">提出</span>
-                    <span className="a-meta__value">{product.created_at}</span>
-                  </time>
-                </div>
-                <div className="card-list-item-meta__item">
-                  <time className="a-meta" dateTime={product.updated_at}>
-                    <span className="a-meta__label">更新</span>
-                    <span className="a-meta__value">{product.updated_at}</span>
-                  </time>
-                </div>
-                {(elapsedDays !== 7 && isUnassignedPage()) ||
-                isDashboardPage() ? (
-                  <div className="card-list-item-meta__item">
-                    <div className="a-meta">
-                      {untilNextElapsedDays(product) < 1
-                        ? `次の経過日数まで 1時間未満`
-                        : `次の経過日数まで 約 ${untilNextElapsedDays(
-                            product
-                          )} 時間`}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          </div>
-        </div>
-      )
-    }
-  }
-
-  const UserIcons = ({ users }) => {
-    return (
-      <div className="card-list-item__user-icons">
-        {users.map((user) => (
-          <a
-            key={user.url}
-            href={user.url}
-            className="card-list-item__user-icons-icon">
-            <img
-              title={user.icon_title}
-              alt={user.icon_title}
-              src={user.avatar_url}
-              className={`a-user-icon is-${user.primary_role}`}
-            />
-          </a>
-        ))}
-      </div>
-    )
-  }
-
-  const LastCommentedTime = () => {
-    if (product.comments.size > 0) {
-      const selfLastCommentedAt = product.self_last_commented_at
-      const mentorLastCommentedAt = product.mentor_last_commented_at
-      const selfLastCommentedAtDateTime =
-        product.self_last_commented_at_date_time
-      const mentorLastCommentedAtDateTime =
-        product.mentor_last_commented_at_date_time
-
-      if (selfLastCommentedAtDateTime && mentorLastCommentedAtDateTime) {
-        if (selfLastCommentedAtDateTime > mentorLastCommentedAtDateTime) {
-          return (
-            <div className="a-meta">
-              〜 {selfLastCommentedAt}（<strong>提出者</strong>）
-            </div>
-          )
-        } else if (
-          selfLastCommentedAtDateTime < mentorLastCommentedAtDateTime
-        ) {
-          return (
-            <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
-          )
-        }
-      } else if (selfLastCommentedAtDateTime) {
-        return (
-          <div className="a-meta">
-            〜 {selfLastCommentedAt}（<strong>提出者</strong>）
-          </div>
-        )
-      } else if (mentorLastCommentedAtDateTime) {
-        return (
-          <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
-        )
-      }
-    }
-    return null
-  }
-
-  const CommentInfo = () => {
-    return (
-      <>
-        {product.comments.size > 0 && (
-          <hr className="card-list-item__row-separator" />
-        )}
-        {product.comments.size > 0 && (
-          <div className="card-list-item-meta__items">
-            <div className="card-list-item-meta__item">
-              <div className="a-meta">コメント（{product.comments.size}）</div>
-            </div>
-            <div className="card-list-item-meta__item">
-              <UserIcons users={product.comments.users} />
-            </div>
-            <div className="card-list-item-meta__item">
-              <LastCommentedTime />
-            </div>
-          </div>
-        )}
-      </>
     )
   }
 
@@ -197,8 +57,8 @@ export default function Product({
             </div>
           </div>
           <div className="card-list-item__row">
-            <TimeInfo />
-            <CommentInfo />
+            <TimeInfo product={product} elapsedDays={elapsedDays} />
+            <CommentInfo product={product} />
           </div>
         </div>
         {product.checks.size > 0 && (
@@ -228,5 +88,144 @@ export default function Product({
         </div>
       )}
     </div>
+  )
+}
+
+const TimeInfo = ({ product, elapsedDays }) => {
+  const isDashboardPage = () => {
+    return location.pathname === '/'
+  }
+  const isUnassignedPage = () => {
+    return location.pathname === '/products/unassigned'
+  }
+  const untilNextElapsedDays = () => {
+    const elapsedTimes = calcElapsedTimes(product)
+    return Math.floor((Math.ceil(elapsedTimes) - elapsedTimes) * 24)
+  }
+
+  const calcElapsedTimes = () => {
+    const time = product.published_at_date_time || product.created_at_date_time
+    return (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
+  }
+
+  if (product.wip) {
+    return (
+      <div className="card-list-item-meta">
+        <div className="a-meta">提出物作成中</div>
+      </div>
+    )
+  } else {
+    return (
+      <div className="card-list-item-meta">
+        <div className="card-list-item__row">
+          <div className="card-list-item-meta">
+            <div className="card-list-item-meta__items">
+              <div className="card-list-item-meta__item">
+                <time className="a-meta" dateTime={product.created_at}>
+                  <span className="a-meta__label">提出</span>
+                  <span className="a-meta__value">{product.created_at}</span>
+                </time>
+              </div>
+              <div className="card-list-item-meta__item">
+                <time className="a-meta" dateTime={product.updated_at}>
+                  <span className="a-meta__label">更新</span>
+                  <span className="a-meta__value">{product.updated_at}</span>
+                </time>
+              </div>
+              {(elapsedDays !== 7 && isUnassignedPage()) ||
+              isDashboardPage() ? (
+                <div className="card-list-item-meta__item">
+                  <div className="a-meta">
+                    {untilNextElapsedDays(product) < 1
+                      ? `次の経過日数まで 1時間未満`
+                      : `次の経過日数まで 約 ${untilNextElapsedDays(
+                          product
+                        )} 時間`}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+const UserIcons = ({ users }) => {
+  return (
+    <div className="card-list-item__user-icons">
+      {users.map((user) => (
+        <a
+          key={user.url}
+          href={user.url}
+          className="card-list-item__user-icons-icon">
+          <img
+            title={user.icon_title}
+            alt={user.icon_title}
+            src={user.avatar_url}
+            className={`a-user-icon is-${user.primary_role}`}
+          />
+        </a>
+      ))}
+    </div>
+  )
+}
+
+const LastCommentedTime = ({ product }) => {
+  if (product.comments.size > 0) {
+    const selfLastCommentedAt = product.self_last_commented_at
+    const mentorLastCommentedAt = product.mentor_last_commented_at
+    const selfLastCommentedAtDateTime = product.self_last_commented_at_date_time
+    const mentorLastCommentedAtDateTime =
+      product.mentor_last_commented_at_date_time
+
+    if (selfLastCommentedAtDateTime && mentorLastCommentedAtDateTime) {
+      if (selfLastCommentedAtDateTime > mentorLastCommentedAtDateTime) {
+        return (
+          <div className="a-meta">
+            〜 {selfLastCommentedAt}（<strong>提出者</strong>）
+          </div>
+        )
+      } else if (selfLastCommentedAtDateTime < mentorLastCommentedAtDateTime) {
+        return (
+          <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
+        )
+      }
+    } else if (selfLastCommentedAtDateTime) {
+      return (
+        <div className="a-meta">
+          〜 {selfLastCommentedAt}（<strong>提出者</strong>）
+        </div>
+      )
+    } else if (mentorLastCommentedAtDateTime) {
+      return (
+        <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
+      )
+    }
+  }
+  return null
+}
+
+const CommentInfo = ({ product }) => {
+  return (
+    <>
+      {product.comments.size > 0 && (
+        <hr className="card-list-item__row-separator" />
+      )}
+      {product.comments.size > 0 && (
+        <div className="card-list-item-meta__items">
+          <div className="card-list-item-meta__item">
+            <div className="a-meta">コメント（{product.comments.size}）</div>
+          </div>
+          <div className="card-list-item-meta__item">
+            <UserIcons users={product.comments.users} />
+          </div>
+          <div className="card-list-item-meta__item">
+            <LastCommentedTime product={product} />
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -83,7 +83,6 @@ export default function Product({
             checkerAvatar={product.checker_avatar}
             currentUserId={currentUserId}
             productId={product.id}
-            parentComponent="product"
           />
         </div>
       )}

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -50,6 +50,19 @@ export default function Product({ product }) {
             </div>
           </div>
         </div>
+        {product.checks.size > 0 && (
+          <div className=" stamp stamp-approve">
+            <h2 className="stamp__content is-title">確認済</h2>
+            <time className="stamp__content is-created-at">
+              {product.checks.last_created_at}
+            </time>
+            <div className="stamp__content is-user-name">
+              <div className="stamp__content-inner">
+                {product.checks.last_user_login_name}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </li>
   )

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -3,6 +3,12 @@ import UserIcon from './UserIcon'
 import ProductChecker from './ProductChecker'
 
 export default function Product({ product, isMentor, currentUserId }) {
+  const isDashboardPage = () => {
+    return location.pathname === '/'
+  }
+  const isUnassignedPage = () => {
+    return location.pathname === '/products/unassigned'
+  }
   const notRespondedSign = () => {
     return (
       product.self_last_commented_at_date_time >
@@ -10,6 +16,151 @@ export default function Product({ product, isMentor, currentUserId }) {
       product.comments.size === 0
     )
   }
+  const untilNextElapsedDays = () => {
+    const elapsedTimes = calcElapsedTimes(product)
+    return Math.floor((Math.ceil(elapsedTimes) - elapsedTimes) * 24)
+  }
+
+  const calcElapsedTimes = () => {
+    const time = product.published_at_date_time || product.created_at_date_time
+    return (new Date() - Date.parse(time)) / 1000 / 60 / 60 / 24
+  }
+  const TimeInfo = () => {
+    if (product.wip) {
+      return (
+        <div className="card-list-item-meta">
+          <div className="a-meta">提出物作成中</div>
+        </div>
+      )
+    } else {
+      return (
+        <div className="card-list-item-meta">
+          <div className="card-list-item-meta__items">
+            {isUnassignedPage() || isDashboardPage() ? (
+              <div className="a-meta">
+                {untilNextElapsedDays(product) < 1
+                  ? `次の経過日数まで 1時間未満`
+                  : `次の経過日数まで 約 ${untilNextElapsedDays(product)} 時間`}
+              </div>
+            ) : null}
+            <div className="card-list-item__row">
+              <div className="card-list-item-meta">
+                <div className="card-list-item-meta__items">
+                  <div className="card-list-item-meta__item">
+                    <time className="a-meta" dateTime={product.created_at}>
+                      <span className="a-meta__label">提出</span>
+                      <span className="a-meta__value">
+                        {product.created_at}
+                      </span>
+                    </time>
+                  </div>
+                  <div className="card-list-item-meta__item">
+                    <time className="a-meta" dateTime={product.updated_at}>
+                      <span className="a-meta__label">更新</span>
+                      <span className="a-meta__value">
+                        {product.updated_at}
+                      </span>
+                    </time>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )
+    }
+  }
+
+  const UserIcons = ({ users }) => {
+    return (
+      <div className="card-list-item__user-icons">
+        {users.map((user) => (
+          <a
+            key={user.url}
+            href={user.url}
+            className="card-list-item__user-icons-icon">
+            <img
+              title={user.icon_title}
+              alt={user.icon_title}
+              src={user.avatar_url}
+              className={`a-user-icon is-${user.primary_role}`}
+            />
+          </a>
+        ))}
+      </div>
+    )
+  }
+
+  const LastCommentedTime = () => {
+    if (product.comments.size > 0) {
+      const selfLastCommentedAt = product.self_last_commented_at
+      const mentorLastCommentedAt = product.mentor_last_commented_at
+      const selfLastCommentedAtDateTime =
+        product.self_last_commented_at_date_time
+      const mentorLastCommentedAtDateTime =
+        product.mentor_last_commented_at_date_time
+      console.log('FFF')
+      console.log('selfLastCommentedAtDateTime=' + selfLastCommentedAtDateTime)
+      console.log(
+        'mentorLastCommentedAtDateTime=' + mentorLastCommentedAtDateTime
+      )
+      if (selfLastCommentedAtDateTime && mentorLastCommentedAtDateTime) {
+        if (selfLastCommentedAtDateTime > mentorLastCommentedAtDateTime) {
+          console.log('AAA')
+          return (
+            <div className="a-meta">
+              〜 {selfLastCommentedAt}（<strong>提出者</strong>）
+            </div>
+          )
+        } else if (
+          selfLastCommentedAtDateTime < mentorLastCommentedAtDateTime
+        ) {
+          console.log('BBB')
+          return (
+            <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
+          )
+        }
+      } else if (selfLastCommentedAtDateTime) {
+        console.log('CCC')
+        return (
+          <div className="a-meta">
+            〜 {selfLastCommentedAt}（<strong>提出者</strong>）
+          </div>
+        )
+      } else if (mentorLastCommentedAtDateTime) {
+        console.log('DDD')
+        return (
+          <div className="a-meta">〜 {mentorLastCommentedAt}（メンター）</div>
+        )
+      }
+    }
+    console.log('null')
+    return null
+  }
+
+  const CommentInfo = () => {
+    return (
+      <>
+        {product.comments.size > 0 && (
+          <hr className="card-list-item__row-separator" />
+        )}
+        {product.comments.size > 0 && (
+          <div className="card-list-item-meta__items">
+            <div className="card-list-item-meta__item">
+              <div className="a-meta">コメント（{product.comments.size}）</div>
+            </div>
+            <div className="card-list-item-meta__item">
+              <UserIcons users={product.comments.users} />
+            </div>
+            <div className="card-list-item-meta__item">
+              <LastCommentedTime />
+            </div>
+          </div>
+        )}
+      </>
+    )
+  }
+
   return (
     <div className="card-list-item has-assigned">
       <div className="card-list-item__inner">
@@ -39,32 +190,20 @@ export default function Product({ product, isMentor, currentUserId }) {
               </h2>
             </div>
           </div>
-          <div className="card-list-item-meta">
-            <div className="card-list-item-meta__items">
-              <div className="card-list-item-meta__item">
-                <a className="a-user-name" href={product.user.url}>
-                  {product.user.long_name}
-                </a>
-              </div>
-            </div>
-          </div>
           <div className="card-list-item__row">
             <div className="card-list-item-meta">
               <div className="card-list-item-meta__items">
                 <div className="card-list-item-meta__item">
-                  <time className="a-meta" dateTime={product.created_at}>
-                    <span className="a-meta__label">提出</span>
-                    <span className="a-meta__value">{product.created_at}</span>
-                  </time>
-                </div>
-                <div className="card-list-item-meta__item">
-                  <time className="a-meta" dateTime={product.updated_at}>
-                    <span className="a-meta__label">更新</span>
-                    <span className="a-meta__value">{product.updated_at}</span>
-                  </time>
+                  <a className="a-user-name" href={product.user.url}>
+                    {product.user.long_name}
+                  </a>
                 </div>
               </div>
             </div>
+          </div>
+          <div className="card-list-item__row">
+            <TimeInfo />
+            <CommentInfo />
           </div>
         </div>
         {product.checks.size > 0 && (

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -2,7 +2,12 @@ import React from 'react'
 import UserIcon from './UserIcon'
 import ProductChecker from './ProductChecker'
 
-export default function Product({ product, isMentor, currentUserId }) {
+export default function Product({
+  product,
+  isMentor,
+  currentUserId,
+  elapsedDays
+}) {
   const isDashboardPage = () => {
     return location.pathname === '/'
   }
@@ -35,34 +40,33 @@ export default function Product({ product, isMentor, currentUserId }) {
     } else {
       return (
         <div className="card-list-item-meta">
-          <div className="card-list-item-meta__items">
-            {isUnassignedPage() || isDashboardPage() ? (
-              <div className="a-meta">
-                {untilNextElapsedDays(product) < 1
-                  ? `次の経過日数まで 1時間未満`
-                  : `次の経過日数まで 約 ${untilNextElapsedDays(product)} 時間`}
-              </div>
-            ) : null}
-            <div className="card-list-item__row">
-              <div className="card-list-item-meta">
-                <div className="card-list-item-meta__items">
-                  <div className="card-list-item-meta__item">
-                    <time className="a-meta" dateTime={product.created_at}>
-                      <span className="a-meta__label">提出</span>
-                      <span className="a-meta__value">
-                        {product.created_at}
-                      </span>
-                    </time>
-                  </div>
-                  <div className="card-list-item-meta__item">
-                    <time className="a-meta" dateTime={product.updated_at}>
-                      <span className="a-meta__label">更新</span>
-                      <span className="a-meta__value">
-                        {product.updated_at}
-                      </span>
-                    </time>
-                  </div>
+          <div className="card-list-item__row">
+            <div className="card-list-item-meta">
+              <div className="card-list-item-meta__items">
+                <div className="card-list-item-meta__item">
+                  <time className="a-meta" dateTime={product.created_at}>
+                    <span className="a-meta__label">提出</span>
+                    <span className="a-meta__value">{product.created_at}</span>
+                  </time>
                 </div>
+                <div className="card-list-item-meta__item">
+                  <time className="a-meta" dateTime={product.updated_at}>
+                    <span className="a-meta__label">更新</span>
+                    <span className="a-meta__value">{product.updated_at}</span>
+                  </time>
+                </div>
+                {(elapsedDays !== 7 && isUnassignedPage()) ||
+                isDashboardPage() ? (
+                  <div className="card-list-item-meta__item">
+                    <div className="a-meta">
+                      {untilNextElapsedDays(product) < 1
+                        ? `次の経過日数まで 1時間未満`
+                        : `次の経過日数まで 約 ${untilNextElapsedDays(
+                            product
+                          )} 時間`}
+                    </div>
+                  </div>
+                ) : null}
               </div>
             </div>
           </div>

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -1,7 +1,20 @@
 import React from 'react'
 import UserIcon from './UserIcon'
+import ProductChecker from './ProductChecker'
 
-export default function Product({ product }) {
+export default function Product({
+  product,
+  isMentor,
+  currentUserId,
+  displayUserIcon
+}) {
+  const notRespondedSign = () => {
+    return (
+      product.self_last_commented_at_date_time >
+        product.mentor_last_commented_at_date_time ||
+      product.comments.size === 0
+    )
+  }
   return (
     <li className="card-list-item">
       <div className="card-list-item__inner">
@@ -11,11 +24,16 @@ export default function Product({ product }) {
         <div className="card-list-item__rows">
           <div className="card-list-item__row">
             <div className="card-list-item-title">
-              {product.wip && (
-                <div className="a-list-item-badge is-wip">
-                  <span>WIP</span>
-                </div>
+              {notRespondedSign() && (
+                <div className="card-list-item__notresponded" />
               )}
+              <div card-list-item-title__start>
+                {product.wip && (
+                  <div className="a-list-item-badge is-wip">
+                    <span>WIP</span>
+                  </div>
+                )}
+              </div>
               <h2 className="card-list-item-title__title" itemProp="name">
                 <a
                   className="card-list-item-title__link a-text-link"
@@ -64,6 +82,18 @@ export default function Product({ product }) {
           </div>
         )}
       </div>
+      {isMentor && product.checks.size === 0 && (
+        <div className="card-list-item__assignee is-only-mentor">
+          <ProductChecker
+            checkerId={product.checker_id}
+            checkerName={product.checker_name}
+            checkerAvatar={product.checker_avatar}
+            currentUserId={currentUserId}
+            productId={product.id}
+            parentComponent="product"
+          />
+        </div>
+      )}
     </li>
   )
 }

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -39,10 +39,14 @@ export default function Product({ product, isMentor, currentUserId }) {
               </h2>
             </div>
           </div>
-          <div className="card-list-item__row">
-            <a className="a-user-name" href={product.user.url}>
-              {product.user.login_name}
-            </a>
+          <div className="card-list-item-meta">
+            <div className="card-list-item-meta__items">
+              <div className="card-list-item-meta__item">
+                <a className="a-user-name" href={product.user.url}>
+                  {product.user.long_name}
+                </a>
+              </div>
+            </div>
           </div>
           <div className="card-list-item__row">
             <div className="card-list-item-meta">

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -2,12 +2,7 @@ import React from 'react'
 import UserIcon from './UserIcon'
 import ProductChecker from './ProductChecker'
 
-export default function Product({
-  product,
-  isMentor,
-  currentUserId,
-  displayUserIcon
-}) {
+export default function Product({ product, isMentor, currentUserId }) {
   const notRespondedSign = () => {
     return (
       product.self_last_commented_at_date_time >
@@ -16,7 +11,7 @@ export default function Product({
     )
   }
   return (
-    <li className="card-list-item">
+    <div className="card-list-item has-assigned">
       <div className="card-list-item__inner">
         <div className="card-list-item__user">
           <UserIcon user={product.user} blockClassSuffix="card-list-item" />
@@ -27,7 +22,7 @@ export default function Product({
               {notRespondedSign() && (
                 <div className="card-list-item__notresponded" />
               )}
-              <div card-list-item-title__start>
+              <div className="card-list-item-title__start">
                 {product.wip && (
                   <div className="a-list-item-badge is-wip">
                     <span>WIP</span>
@@ -94,6 +89,6 @@ export default function Product({
           />
         </div>
       )}
-    </li>
+    </div>
   )
 }

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -99,6 +99,7 @@ export default function Product({ product, isMentor, currentUserId }) {
         product.self_last_commented_at_date_time
       const mentorLastCommentedAtDateTime =
         product.mentor_last_commented_at_date_time
+
       if (selfLastCommentedAtDateTime && mentorLastCommentedAtDateTime) {
         if (selfLastCommentedAtDateTime > mentorLastCommentedAtDateTime) {
           return (

--- a/app/javascript/components/ProductChecker.jsx
+++ b/app/javascript/components/ProductChecker.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import CSRF from 'csrf'
-import { checkProduct } from './Checkable.jsx'
+import { checkProduct } from '../checkable_react'
 
 export default function ProductChecker({
   checkerId,

--- a/app/javascript/components/ProductChecker.jsx
+++ b/app/javascript/components/ProductChecker.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react'
+import CSRF from 'csrf'
+import { checkProduct } from './Checkable.jsx'
+
+export default function ProductChecker({
+  checkerId,
+  checkerName,
+  currentUserId,
+  productId,
+  checkableType,
+  checkerAvatar
+}) {
+  const [isCheckerExist, setisCheckerExist] = useState(checkerId)
+
+  const buttonLabel = () => (isCheckerExist ? '担当から外れる' : '担当する')
+
+  const checkInCharge = () => {
+    checkProduct(
+      productId,
+      currentUserId,
+      '/api/products/checker',
+      isCheckerExist ? 'DELETE' : 'PATCH',
+      CSRF.getToken()
+    )
+  }
+  return (
+    <>
+      {(!checkerId || checkerId === currentUserId) && (
+        <button
+          className={`a-button is-block ${
+            isCheckerExist ? 'is-warning' : 'is-secondary'
+          } ${checkableType ? 'is-sm' : 'is-sm'} `}
+          onClick={() => {
+            setisCheckerExist(!isCheckerExist)
+            checkInCharge()
+          }}>
+          <i
+            className={`fas ${isCheckerExist ? 'fa-times' : 'fa-hand-paper'}`}
+          />
+          {buttonLabel()}
+        </button>
+      )}
+      {checkerId && checkerId !== currentUserId && (
+        <div className="a-button is-sm is-block card-list-item__assignee-button is-only-mentor">
+          <span className="card-list-item__assignee-image">
+            <img
+              className="a-user-icon"
+              src={checkerAvatar}
+              width="20"
+              height="20"
+              alt="Checker Avatar"
+            />
+          </span>
+          <span className="card-list-item__assignee-name">{checkerName}</span>
+        </div>
+      )}
+    </>
+  )
+}

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -67,6 +67,12 @@ export default function Products({
     return `${elapsedDays}days-elapsed`
   }
 
+  const checkerId = () => {
+    const params = new URLSearchParams(location.search)
+    const id = params.get('checker_id')
+    return id ? `&checker_id=${id}` : ''
+  }
+
   const isActive = (target) => {
     const params = new URLSearchParams(location.search)
     const urlTarget = params.get('target')
@@ -114,7 +120,7 @@ export default function Products({
                 return (
                   <li className="pill-nav__item" key={target}>
                     <a
-                      href={`/products/unchecked?target=${target}`}
+                      href={`/products/unchecked?target=${target}${checkerId()}`}
                       className={`pill-nav__item-link ${isActive(target)}`}>
                       {target === 'unchecked_no_replied' ? '未返信' : '全て'}
                     </a>

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -11,7 +11,6 @@ import usePage from './hooks/usePage'
 export default function Products({
   title,
   selectedTab,
-  checkerId,
   isMentor,
   currentUserId
 }) {
@@ -40,7 +39,6 @@ export default function Products({
       '.json' +
       '?' +
       params +
-      (checkerId ? `&checker_id=${checkerId}` : '') +
       (params.target ? `&target=${params.target}` : '') +
       `&per=${per}`
     return buildedUrl

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -66,8 +66,6 @@ export default function Products({
   }
 
   const countProductsGroupedBy = (elapsedDays) => {
-    console.log('elapsedDays =' + elapsedDays)
-
     const element = getElementNdaysPassed(
       elapsedDays,
       data.products_grouped_by_elapsed_days
@@ -194,7 +192,9 @@ export default function Products({
             {data.products_grouped_by_elapsed_days.map(
               (productsNDaysPassed) => {
                 return (
-                  <div className="a-card">
+                  <div
+                    className="a-card"
+                    key={productsNDaysPassed.elapsed_days}>
                     <ProductHeader productsNDaysPassed={productsNDaysPassed} />
                     <div className="card-list">
                       <div className="card-list__items">

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -67,42 +67,6 @@ export default function Products({
     return `${elapsedDays}days-elapsed`
   }
 
-  function ProductHeader({ productsNDaysPassed }) {
-    let headerClass = 'card-header a-elapsed-days'
-    if (productsNDaysPassed.elapsed_days === 5) {
-      headerClass += ' is-reply-warning'
-    } else if (productsNDaysPassed.elapsed_days === 6) {
-      headerClass += ' is-reply-alert'
-    } else if (productsNDaysPassed.elapsed_days >= 7) {
-      headerClass += ' is-reply-deadline'
-    }
-
-    const headerLabel = () => {
-      if (productsNDaysPassed.elapsed_days === 0) {
-        return '今日提出'
-      } else if (productsNDaysPassed.elapsed_days === 7) {
-        return `${productsNDaysPassed.elapsed_days}日以上経過`
-      } else {
-        return `${productsNDaysPassed.elapsed_days}日経過`
-      }
-    }
-
-    return (
-      <header
-        className={headerClass}
-        id={elapsedDaysId(productsNDaysPassed.elapsed_days)}>
-        <h2 className="card-header__title">
-          {headerLabel()}
-          {
-            <span className="card-header__count">
-              （{countProductsGroupedBy(productsNDaysPassed.elapsed_days)}）
-            </span>
-          }
-        </h2>
-      </header>
-    )
-  }
-
   if (error) return <>エラーが発生しました。</>
 
   if (!data) {
@@ -185,7 +149,11 @@ export default function Products({
                   <div
                     className="a-card"
                     key={productsNDaysPassed.elapsed_days}>
-                    <ProductHeader productsNDaysPassed={productsNDaysPassed} />
+                    <ProductHeader
+                      productsNDaysPassed={productsNDaysPassed}
+                      elapsedDaysId={elapsedDaysId}
+                      countProductsGroupedBy={countProductsGroupedBy}
+                    />
                     <div className="card-list">
                       <div className="card-list__items">
                         {productsNDaysPassed.products.map((product) => {
@@ -216,4 +184,44 @@ export default function Products({
       </div>
     )
   }
+}
+
+function ProductHeader({
+  productsNDaysPassed,
+  elapsedDaysId,
+  countProductsGroupedBy
+}) {
+  let headerClass = 'card-header a-elapsed-days'
+  if (productsNDaysPassed.elapsed_days === 5) {
+    headerClass += ' is-reply-warning'
+  } else if (productsNDaysPassed.elapsed_days === 6) {
+    headerClass += ' is-reply-alert'
+  } else if (productsNDaysPassed.elapsed_days >= 7) {
+    headerClass += ' is-reply-deadline'
+  }
+
+  const headerLabel = () => {
+    if (productsNDaysPassed.elapsed_days === 0) {
+      return '今日提出'
+    } else if (productsNDaysPassed.elapsed_days === 7) {
+      return `${productsNDaysPassed.elapsed_days}日以上経過`
+    } else {
+      return `${productsNDaysPassed.elapsed_days}日経過`
+    }
+  }
+
+  return (
+    <header
+      className={headerClass}
+      id={elapsedDaysId(productsNDaysPassed.elapsed_days)}>
+      <h2 className="card-header__title">
+        {headerLabel()}
+        {
+          <span className="card-header__count">
+            （{countProductsGroupedBy(productsNDaysPassed.elapsed_days)}）
+          </span>
+        }
+      </h2>
+    </header>
+  )
 }

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -205,6 +205,7 @@ export default function Products({
                               key={product.id}
                               isMentor={isMentor}
                               currentUserId={currentUserId}
+                              elapsedDays={productsNDaysPassed.elapsed_days}
                             />
                           )
                         })}

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -46,7 +46,6 @@ export default function Products({
       (checkerId ? `&checker_id=${checkerId}` : '') +
       (params.target ? `&target=${params.target}` : '') +
       `&per=${per}`
-    console.log(buildedUrl)
     return buildedUrl
   }
 

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -92,17 +92,25 @@ export default function Products({
       headerClass += ' is-reply-deadline'
     }
 
+    const headerLabel = () => {
+      if (productsNDaysPassed.elapsed_days === 0) {
+        return '今日提出'
+      } else if (productsNDaysPassed.elapsed_days === 7) {
+        return `${productsNDaysPassed.elapsed_days}日以上経過`
+      } else {
+        return `${productsNDaysPassed.elapsed_days}日経過`
+      }
+    }
+
     return (
       <header
         className={headerClass}
         id={elapsedDaysId(productsNDaysPassed.elapsed_days)}>
         <h2 className="card-header__title">
-          {productsNDaysPassed.elapsed_days === 0
-            ? '今日提出'
-            : `${productsNDaysPassed.elapsed_days}日経過`}
+          {headerLabel()}
           {
             <span className="card-header__count">
-              ({countProductsGroupedBy(productsNDaysPassed.elapsed_days)})
+              （{countProductsGroupedBy(productsNDaysPassed.elapsed_days)}）
             </span>
           }
         </h2>

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -70,7 +70,7 @@ export default function Products({
   const checkerId = () => {
     const params = new URLSearchParams(location.search)
     const id = params.get('checker_id')
-    return id ? `&checker_id=${id}` : ''
+    return id ? `checker_id=${id}` : ''
   }
 
   const isActive = (target) => {
@@ -120,7 +120,7 @@ export default function Products({
                 return (
                   <li className="pill-nav__item" key={target}>
                     <a
-                      href={`/products/unchecked?target=${target}${checkerId()}`}
+                      href={`/products/unchecked?${checkerId()}&target=${target}`}
                       className={`pill-nav__item-link ${isActive(target)}`}>
                       {target === 'unchecked_no_replied' ? '未返信' : '全て'}
                     </a>

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -67,6 +67,14 @@ export default function Products({
     return `${elapsedDays}days-elapsed`
   }
 
+  const isActive = (target) => {
+    const params = new URLSearchParams(location.search)
+    const urlTarget = params.get('target')
+    if ((!urlTarget && target === 'unchecked_all') || target === urlTarget) {
+      return 'is-active'
+    }
+  }
+
   if (error) return <>エラーが発生しました。</>
 
   if (!data) {
@@ -99,6 +107,22 @@ export default function Products({
     const per = 50
     return (
       <>
+        <nav className="pill-nav">
+          <ul className="pill-nav__items">
+            {['unchecked_no_replied', 'unchecked_all'].map((target) => {
+              return (
+                <li className="pill-nav__item" key={target}>
+                  <a
+                    href={`/products/unchecked?target=${target}`}
+                    className={`pill-nav__item-link ${isActive(target)}`}>
+                    {target === 'unchecked_no_replied' ? '未返信' : '全て'}
+                  </a>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+
         <div className="page-content is-products">
           <div className="page-body__columns">
             <div className="page-body__column is-main">

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -58,8 +58,8 @@ export default function Products({
 
   const isNotProduct5daysElapsed = () => {
     const elapsedDays = []
-    data.productsGroupedByElapsedDays.forEach((h) => {
-      elapsedDays.push(h.elapsed_days)
+    data.productsGroupedByElapsedDays.forEach((group) => {
+      elapsedDays.push(group.elapsed_days)
     })
     return elapsedDays.every((day) => day < 5)
   }

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -216,11 +216,9 @@ function ProductHeader({
       id={elapsedDaysId(productsNDaysPassed.elapsed_days)}>
       <h2 className="card-header__title">
         {headerLabel()}
-        {
-          <span className="card-header__count">
-            （{countProductsGroupedBy(productsNDaysPassed.elapsed_days)}）
-          </span>
-        }
+        <span className="card-header__count">
+          （{countProductsGroupedBy(productsNDaysPassed.elapsed_days)}）
+        </span>
       </h2>
     </header>
   )

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -107,21 +107,23 @@ export default function Products({
     const per = 50
     return (
       <>
-        <nav className="pill-nav">
-          <ul className="pill-nav__items">
-            {['unchecked_no_replied', 'unchecked_all'].map((target) => {
-              return (
-                <li className="pill-nav__item" key={target}>
-                  <a
-                    href={`/products/unchecked?target=${target}`}
-                    className={`pill-nav__item-link ${isActive(target)}`}>
-                    {target === 'unchecked_no_replied' ? '未返信' : '全て'}
-                  </a>
-                </li>
-              )
-            })}
-          </ul>
-        </nav>
+        {selectedTab !== 'all' && (
+          <nav className="pill-nav">
+            <ul className="pill-nav__items">
+              {['unchecked_no_replied', 'unchecked_all'].map((target) => {
+                return (
+                  <li className="pill-nav__item" key={target}>
+                    <a
+                      href={`/products/unchecked?target=${target}`}
+                      className={`pill-nav__item-link ${isActive(target)}`}>
+                      {target === 'unchecked_no_replied' ? '未返信' : '全て'}
+                    </a>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
+        )}
 
         <div className="page-content is-products">
           <div className="page-body__columns">

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -1,5 +1,4 @@
-import React, { useState } from 'react'
-import queryString from 'query-string'
+import React from 'react'
 import useSWR from 'swr'
 import Pagination from './Pagination'
 import LoadingListPlaceholder from './LoadingListPlaceholder'
@@ -7,7 +6,7 @@ import UnconfirmedLink from './UnconfirmedLink'
 import Product from './Product'
 import fetcher from '../fetcher'
 import ElapsedDays from './ElapsedDays'
-
+import usePage from './hooks/usePage'
 export default function Products({
   title,
   selectedTab,
@@ -16,10 +15,7 @@ export default function Products({
   currentUserId
 }) {
   const per = 50
-  const neighbours = 4
-  const defaultPage = parseInt(queryString.parse(location.search).page) || 1
-
-  const [page, setPage] = useState(defaultPage)
+  const { page, setPage } = usePage()
 
   const unconfirmedLinksName = () => {
     if (selectedTab === 'all') return '全ての提出物を一括で開く'
@@ -156,7 +152,6 @@ export default function Products({
                   <Pagination
                     sum={data.total_pages * per}
                     per={per}
-                    neighbours={neighbours}
                     page={page}
                     setPage={setPage}
                   />
@@ -177,7 +172,6 @@ export default function Products({
                   <Pagination
                     sum={data.total_pages * per}
                     per={per}
-                    neighbours={neighbours}
                     page={page}
                     setPage={setPage}
                   />

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import queryString from 'query-string'
 import useSWR from 'swr'
 import Pagination from './Pagination'
@@ -12,10 +12,6 @@ export default function Products({ title, selectedTab }) {
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
   const [page, setPage] = useState(defaultPage)
-
-  useEffect(() => {
-    setPage(page)
-  }, [page])
 
   const unconfirmedLinksName = (() => {
     return {
@@ -34,11 +30,6 @@ export default function Products({ title, selectedTab }) {
   })()
 
   const { data, error } = useSWR(`/api/products${url}?page=${page}`, fetcher)
-
-  const handlePaginate = (p) => {
-    setPage(p)
-    window.history.pushState(null, null, `/products${url}?page=${p}`)
-  }
 
   if (error) return <>エラーが発生しました。</>
   if (!data) {
@@ -70,7 +61,7 @@ export default function Products({ title, selectedTab }) {
               per={per}
               neighbours={neighbours}
               page={page}
-              onChange={(e) => handlePaginate(e.page)}
+              setPage={setPage}
             />
           )}
           <ul className="card-list a-card">
@@ -84,7 +75,7 @@ export default function Products({ title, selectedTab }) {
               per={per}
               neighbours={neighbours}
               page={page}
-              onChange={(e) => handlePaginate(e.page)}
+              setPage={setPage}
             />
           )}
           <UnconfirmedLink label={unconfirmedLinksName} />

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -23,10 +23,10 @@ export default function Products({
 
   const unconfirmedLinksName = (() => {
     return {
-      all: '全ての提出物を一覧で開く',
-      unchecked: '未完了の提出物を一覧で開く',
-      self_assigned: '自分の担当の提出物を一覧で開く',
-      unassigned: '未アサインの提出物を一覧で開く'
+      all: '全ての提出物を一括で開く',
+      unchecked: '未完了の提出物を一括で開く',
+      self_assigned: '自分の担当の提出物を一括で開く',
+      unassigned: '未アサインの提出物を一括で開く'
     }[selectedTab]
   })()
 

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -7,6 +7,7 @@ import Product from './Product'
 import fetcher from '../fetcher'
 import ElapsedDays from './ElapsedDays'
 import usePage from './hooks/usePage'
+
 export default function Products({
   title,
   selectedTab,
@@ -24,7 +25,7 @@ export default function Products({
     if (selectedTab === 'self_assigned') return '自分の担当の提出物を一括で開く'
   }
 
-  const url = () => {
+  const path = () => {
     if (selectedTab === 'all') return ''
     if (selectedTab === 'unassigned') return '/unassigned'
     if (selectedTab === 'unchecked') return '/unchecked'
@@ -35,7 +36,7 @@ export default function Products({
     const params = new URLSearchParams(location.search)
     const buildedUrl =
       '/api/products' +
-      url() +
+      path() +
       '.json' +
       '?' +
       params +

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -176,10 +176,7 @@ export default function Products({
             <UnconfirmedLink label={unconfirmedLinksName()} />
           </div>
 
-          <ElapsedDays
-            productsGroupedByElapsedDays={data.products_grouped_by_elapsed_days}
-            countProductsGroupedBy={countProductsGroupedBy}
-          />
+          <ElapsedDays countProductsGroupedBy={countProductsGroupedBy} />
         </div>
       </div>
     )

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -14,7 +14,6 @@ export default function Products({
   isMentor,
   currentUserId
 }) {
-  const per = 50
   const { page, setPage } = usePage()
 
   const unconfirmedLinksName = () => {
@@ -39,8 +38,7 @@ export default function Products({
       '.json' +
       '?' +
       params +
-      (params.target ? `&target=${params.target}` : '') +
-      `&per=${per}`
+      (params.target ? `&target=${params.target}` : '')
     return buildedUrl
   }
 
@@ -141,6 +139,7 @@ export default function Products({
       </div>
     )
   } else if (selectedTab !== 'unassigned') {
+    const per = 50
     return (
       <>
         <div className="page-content is-products">

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -21,14 +21,12 @@ export default function Products({
 
   const [page, setPage] = useState(defaultPage)
 
-  const unconfirmedLinksName = (() => {
-    return {
-      all: '全ての提出物を一括で開く',
-      unchecked: '未完了の提出物を一括で開く',
-      self_assigned: '自分の担当の提出物を一括で開く',
-      unassigned: '未アサインの提出物を一括で開く'
-    }[selectedTab]
-  })()
+  const unconfirmedLinksName = () => {
+    if (selectedTab === 'all') return '全ての提出物を一括で開く'
+    if (selectedTab === 'unchecked') return '未完了の提出物を一括で開く'
+    if (selectedTab === 'unassigned') return '未アサインの提出物を一括で開く'
+    if (selectedTab === 'self_assigned') return '自分の担当の提出物を一括で開く'
+  }
 
   const url = () => {
     if (selectedTab === 'all') return ''
@@ -177,7 +175,7 @@ export default function Products({
                     setPage={setPage}
                   />
                 )}
-                <UnconfirmedLink label={unconfirmedLinksName} />
+                <UnconfirmedLink label={unconfirmedLinksName()} />
               </div>
             </div>
           </div>
@@ -214,7 +212,7 @@ export default function Products({
                 )
               }
             )}
-            <UnconfirmedLink label={unconfirmedLinksName} />
+            <UnconfirmedLink label={unconfirmedLinksName()} />
           </div>
 
           <ElapsedDays

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -6,11 +6,19 @@ import LoadingListPlaceholder from './LoadingListPlaceholder'
 import UnconfirmedLink from './UnconfirmedLink'
 import Product from './Product'
 import fetcher from '../fetcher'
+import ElapsedDays from './ElapsedDays'
 
-export default function Products({ title, selectedTab }) {
-  const per = 20
+export default function Products({
+  title,
+  selectedTab,
+  checkerId,
+  isMentor,
+  currentUserId
+}) {
+  const per = 50
   const neighbours = 4
   const defaultPage = parseInt(queryString.parse(location.search).page) || 1
+
   const [page, setPage] = useState(defaultPage)
 
   const unconfirmedLinksName = (() => {
@@ -22,16 +30,92 @@ export default function Products({ title, selectedTab }) {
     }[selectedTab]
   })()
 
-  const url = (() => {
+  const url = () => {
     if (selectedTab === 'all') return ''
     if (selectedTab === 'unassigned') return '/unassigned'
     if (selectedTab === 'unchecked') return '/unchecked'
     if (selectedTab === 'self_assigned') return '/self_assigned'
-  })()
+  }
 
-  const { data, error } = useSWR(`/api/products${url}?page=${page}`, fetcher)
+  const ApiUrl = () => {
+    const params = new URLSearchParams(location.search)
+    const buildedUrl =
+      '/api/products' +
+      url() +
+      '.json' +
+      '?' +
+      params +
+      (checkerId ? `&checker_id=${checkerId}` : '') +
+      (params.target ? `&target=${params.target}` : '') +
+      `&per=${per}`
+    console.log(buildedUrl)
+    return buildedUrl
+  }
+
+  const isDashboard = () => {
+    return location.pathname === '/'
+  }
+
+  const { data, error } = useSWR(ApiUrl(), fetcher)
+
+  const getElementNdaysPassed = (elapsedDays, productsGroupedByElapsedDays) => {
+    const element = productsGroupedByElapsedDays.find(
+      (el) => el.elapsed_days === elapsedDays
+    )
+    return element
+  }
+
+  const countProductsGroupedBy = (elapsedDays) => {
+    console.log('elapsedDays =' + elapsedDays)
+
+    const element = getElementNdaysPassed(
+      elapsedDays,
+      data.products_grouped_by_elapsed_days
+    )
+    return element === undefined ? 0 : element.products.length
+  }
+
+  const isNotProduct5daysElapsed = () => {
+    const elapsedDays = []
+    data.productsGroupedByElapsedDays.forEach((h) => {
+      elapsedDays.push(h.elapsed_days)
+    })
+    return elapsedDays.every((day) => day < 5)
+  }
+  const elapsedDaysId = (elapsedDays) => {
+    return `${elapsedDays}days-elapsed`
+  }
+
+  function ProductHeader({ productsNDaysPassed }) {
+    let headerClass = 'card-header a-elapsed-days'
+    if (productsNDaysPassed.elapsed_days === 5) {
+      headerClass += ' is-reply-warning'
+    } else if (productsNDaysPassed.elapsed_days === 6) {
+      headerClass += ' is-reply-alert'
+    } else if (productsNDaysPassed.elapsed_days >= 7) {
+      headerClass += ' is-reply-deadline'
+    }
+
+    return (
+      <header
+        className={headerClass}
+        id={elapsedDaysId(productsNDaysPassed.elapsed_days)}>
+        <h2 className="card-header__title">
+          {productsNDaysPassed.elapsed_days === 0
+            ? '今日提出'
+            : `${productsNDaysPassed.elapsed_days}日経過`}
+          {
+            <span className="card-header__count">
+              ({countProductsGroupedBy(productsNDaysPassed.elapsed_days)})
+            </span>
+          }
+        </h2>
+      </header>
+    )
+  }
 
   if (error) return <>エラーが発生しました。</>
+
   if (!data) {
     return (
       <div className="page-body">
@@ -40,9 +124,7 @@ export default function Products({ title, selectedTab }) {
         </div>
       </div>
     )
-  }
-
-  if (data.products.length === 0) {
+  } else if (data.products.length === 0) {
     return (
       <div class="o-empty-message">
         <div class="o-empty-message__icon">
@@ -51,34 +133,94 @@ export default function Products({ title, selectedTab }) {
         <p class="o-empty-message__text">{title}はありません</p>
       </div>
     )
+  } else if (isDashboard() && isNotProduct5daysElapsed()) {
+    return (
+      <div className="o-empty-message">
+        <div className="o-empty-message__icon">
+          <i className="fa-regular fa-smile" />
+        </div>
+        <p className="o-empty-message__text">5日経過した提出物はありません</p>
+      </div>
+    )
+  } else if (selectedTab !== 'unassigned') {
+    return (
+      <>
+        <div className="page-content is-products">
+          <div className="page-body__columns">
+            <div className="page-body__column is-main">
+              <div className="container is-md">
+                {data.total_pages > 1 && (
+                  <Pagination
+                    sum={data.total_pages * per}
+                    per={per}
+                    neighbours={neighbours}
+                    page={page}
+                    setPage={setPage}
+                  />
+                )}
+                <ul className="card-list a-card">
+                  {data.products.map((product) => {
+                    return (
+                      <Product
+                        product={product}
+                        key={product.id}
+                        isMentor={isMentor}
+                        currentUserId={currentUserId}
+                      />
+                    )
+                  })}
+                </ul>
+                {data.total_pages > 1 && (
+                  <Pagination
+                    sum={data.total_pages * per}
+                    per={per}
+                    neighbours={neighbours}
+                    page={page}
+                    setPage={setPage}
+                  />
+                )}
+                <UnconfirmedLink label={unconfirmedLinksName} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </>
+    )
   } else {
     return (
-      <div className="page-body">
-        <div className="container is-md">
-          {data.total_pages > 1 && (
-            <Pagination
-              sum={data.total_pages * per}
-              per={per}
-              neighbours={neighbours}
-              page={page}
-              setPage={setPage}
-            />
-          )}
-          <ul className="card-list a-card">
-            {data.products.map((product) => {
-              return <Product product={product} key={product.id} />
-            })}
-          </ul>
-          {data.total_pages > 1 && (
-            <Pagination
-              sum={data.total_pages * per}
-              per={per}
-              neighbours={neighbours}
-              page={page}
-              setPage={setPage}
-            />
-          )}
-          <UnconfirmedLink label={unconfirmedLinksName} />
+      <div className="page-content is-products">
+        <div className="page-body__columns">
+          <div className="page-body__column is-main">
+            {data.products_grouped_by_elapsed_days.map(
+              (productsNDaysPassed) => {
+                return (
+                  <div className="a-card">
+                    <ProductHeader productsNDaysPassed={productsNDaysPassed} />
+                    <div className="card-list">
+                      <div className="card-list__items">
+                        {productsNDaysPassed.products.map((product) => {
+                          return (
+                            <Product
+                              product={product}
+                              key={product.id}
+                              isMentor={isMentor}
+                              currentUserId={currentUserId}
+                            />
+                          )
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                )
+              }
+            )}
+            <UnconfirmedLink label={unconfirmedLinksName} />
+          </div>
+
+          <ElapsedDays
+            productsGroupedByElapsedDays={data.products_grouped_by_elapsed_days}
+            countProductsGroupedBy={countProductsGroupedBy}
+          />
         </div>
       </div>
     )

--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -23,23 +23,16 @@ export default function Products({
     if (selectedTab === 'self_assigned') return '自分の担当の提出物を一括で開く'
   }
 
-  const path = () => {
-    if (selectedTab === 'all') return ''
-    if (selectedTab === 'unassigned') return '/unassigned'
-    if (selectedTab === 'unchecked') return '/unchecked'
-    if (selectedTab === 'self_assigned') return '/self_assigned'
-  }
-
   const ApiUrl = () => {
+    const path = (() => {
+      if (selectedTab === 'all') return ''
+      if (selectedTab === 'unassigned') return '/unassigned'
+      if (selectedTab === 'unchecked') return '/unchecked'
+      if (selectedTab === 'self_assigned') return '/self_assigned'
+    })()
     const params = new URLSearchParams(location.search)
-    const buildedUrl =
-      '/api/products' +
-      path() +
-      '.json' +
-      '?' +
-      params +
-      (params.target ? `&target=${params.target}` : '')
-    return buildedUrl
+
+    return `/api/products${path}?${params}`
   }
 
   const isDashboard = () => {

--- a/app/javascript/components/UnconfirmedLink.jsx
+++ b/app/javascript/components/UnconfirmedLink.jsx
@@ -3,7 +3,6 @@ import React, { useCallback } from 'react'
 export default function UnconfirmedLink({ label }) {
   const openUnconfirmedItems = useCallback(() => {
     const links = document.querySelectorAll('.card-list-item-title__link')
-    console.log(links)
     links.forEach((link) => {
       window.open(link.href, '_target', 'noopener')
     })

--- a/app/javascript/components/UnconfirmedLink.jsx
+++ b/app/javascript/components/UnconfirmedLink.jsx
@@ -2,9 +2,8 @@ import React, { useCallback } from 'react'
 
 export default function UnconfirmedLink({ label }) {
   const openUnconfirmedItems = useCallback(() => {
-    const links = document.querySelectorAll(
-      '.card-list-item .js-unconfirmed-link'
-    )
+    const links = document.querySelectorAll('.card-list-item-title__link')
+    console.log(links)
     links.forEach((link) => {
       window.open(link.href, '_target', 'noopener')
     })

--- a/app/javascript/toast_react.js
+++ b/app/javascript/toast_react.js
@@ -5,7 +5,6 @@ const isMentorsCommentToProducts = (currentUser, commentableType) => {
 }
 
 export const toast = (title, status = 'success') => {
-  console.log(title)
   Swal.fire({
     title: title,
     toast: true,

--- a/app/javascript/toast_react.js
+++ b/app/javascript/toast_react.js
@@ -1,0 +1,52 @@
+import Swal from 'sweetalert2'
+
+const isMentorsCommentToProducts = (currentUser, commentableType) => {
+  return currentUser.roles.includes('mentor') && commentableType === 'Product'
+}
+
+export const toast = (title, status = 'success') => {
+  console.log(title)
+  Swal.fire({
+    title: title,
+    toast: true,
+    position: 'top-end',
+    showConfirmButton: false,
+    timer: 3000,
+    timerProgressBar: true,
+    customClass: { popup: `is-${status}` }
+  })
+}
+
+export const displayToast = (
+  toastMessage,
+  productCheckerId,
+  checkId,
+  currentUser,
+  commentableType
+) => {
+  if (isMentorsCommentToProducts(currentUser, commentableType)) {
+    if (productCheckerId || checkId) {
+      toast(confirmOrCommentMessage(toastMessage))
+    }
+  } else {
+    toast(confirmOrCommentMessage(toastMessage))
+  }
+}
+
+export const confirmOrCommentMessage = (toastMessage) => {
+  return toastMessage ?? 'コメントを投稿しました！'
+}
+
+export const toastMessage = (commentableType) => {
+  if (commentableType === 'Product') {
+    return getToastMessage('提出物')
+  } else if (commentableType === 'Report') {
+    return getToastMessage('日報')
+  } else {
+    return null
+  }
+}
+
+export const getToastMessage = (type) => {
+  return `${type}を確認済みにしました。`
+}

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -12,5 +12,4 @@ header.page-header
 
   .page-body
     .container.is-md
-      #js-products(data-title="#{title}" data-selected-tab="all" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
-      / = react_component('Products', title: title, selectedTab: 'all')
+      = react_component('Products', title: title, selectedTab: 'all', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/app/views/products/self_assigned/_nav.html.slim
+++ b/app/views/products/self_assigned/_nav.html.slim
@@ -1,7 +1,0 @@
-nav.pill-nav
-  .container
-    ul.pill-nav__items
-      - targets = %w[self_assigned_all self_assigned_no_replied]
-      - targets.each do |target|
-        li.pill-nav__item
-          = link_to t("target.#{target}"), products_self_assigned_index_path(target: target), class: (@target == target ? ['is-active'] : []) << 'pill-nav__item-link'

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -14,5 +14,4 @@ header.page-header
 
 .page-body
   .container.is-md
-    #js-products(data-title="#{title}" data-selected-tab="self-assigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
-    / = react_component('Products', title: title, selectedTab: 'self_assigned')
+    = react_component('Products', title: title, selectedTab: 'self_assigned', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -8,7 +8,6 @@ header.page-header
         | 提出物
 
 = render 'products/tabs'
-= render 'nav'
 
 - title '未返信の担当提出物' if @target == 'self_assigned_no_replied'
 

--- a/app/views/products/unassigned/index.html.slim
+++ b/app/views/products/unassigned/index.html.slim
@@ -11,5 +11,4 @@ header.page-header
 
 .page-body
   .container.is-lg
-    #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
-    / = react_component('Products', title: title, selectedTab: 'unassigned')
+    = react_component('Products', title: title, selectedTab: 'unassigned', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/app/views/products/unchecked/_nav.html.slim
+++ b/app/views/products/unchecked/_nav.html.slim
@@ -1,6 +1,0 @@
-nav.pill-nav
-  ul.pill-nav__items
-    - targets = %w[unchecked_no_replied unchecked_all]
-    - targets.each do |target|
-      li.pill-nav__item
-        = link_to t("target.#{target}"), products_unchecked_index_path(target: target, checker_id: checker_id), class: (@target == target ? ['is-active'] : []) << 'pill-nav__item-link'

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -19,5 +19,4 @@ header.page-header
   hr.a-border
 .page-body
   .container.is-md
-    = render 'nav', checker_id: @checker_id
     = react_component('Products', title: title, selectedTab: 'unchecked', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -20,6 +20,4 @@ header.page-header
 .page-body
   .container.is-md
     = render 'nav', checker_id: @checker_id
-
-    #js-products(data-title="#{title}" data-selected-tab="unchecked" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}" data-checker-id="#{params[:checker_id]}")
-    / = react_component('Products', title: title, selectedTab: 'unchecked')
+    = react_component('Products', title: title, selectedTab: 'unchecked', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -90,10 +90,12 @@ class Notification::ProductsTest < ApplicationSystemTestCase
   end
 
   test 'send the notification of practices mentor is watching' do
-    practice = practices(:practice1)
+    practice = practices(:practice5)
 
     visit_with_auth "/practices/#{practice.id}", 'mentormentaro'
     find('div.a-watch-button', text: 'Watch').click
+
+    assert_text 'Watch中'
 
     visit_with_auth "/products/new?practice_id=#{practice.id}", 'hatsuno'
     fill_in 'product[body]', with: 'test'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -339,9 +339,10 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'click on the pager button' do
-    visit_with_auth '/products', 'komagata'
+    login_user 'komagata', 'testtest'
+    visit '/products'
     within first('.pagination') do
-      find('a', text: '2').click
+      find('button', text: '2').click
     end
 
     all('.pagination .is-active').each do |active_button|
@@ -363,10 +364,10 @@ class ProductsTest < ApplicationSystemTestCase
     login_user 'komagata', 'testtest'
     visit '/products?page=2'
     within first('.pagination') do
-      find('a', text: '1').click
+      find('button', text: '1').click
     end
     assert_current_path('/products')
-
+    assert_text '「プログラミング入門 - Rubyを使って」をやるの提出物'
     page.go_back
     assert_current_path('/products?page=2')
     all('.pagination .is-active').each do |active_button|


### PR DESCRIPTION
## Issue

- #6965 

## 概要
Products.jsx利用時に上下のページネーションが連動するよう修正しました。
`/products`において、products.vueをProducts.jsxに置き換えました。
Products.jsxを使用するにあたり不足している処理とコンポーネントを作成しました。
Products.vueはメンターのダッシュボードの提出物一覧でも使われていましたが、本PRでは対応していません。

## 変更確認方法
1. `feature/use-React-component-in-products`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを起動する
3. http://localhost:3000/にアクセスする
4. ID:komagataでログインする

## 全てページの確認
1. http://localhost:3000/products にアクセスする
2. wip、担当あり、担当なしの提出物が表示されていることを確認する
3. http://localhost:3000/products?page=2 にアクセスする
4. 確認済みの提出物が表示されていることを確認する
5. ページ最下部の一括で開くボタンが機能することを確認する

## ページネーションの確認
1. http://localhost:3000/products にアクセスする
2. ページネーションのリンク2をクリックする
3. ページネーションのリンク1をクリックし、上下のページネーションのリンク1がアクティブになっていることを確認する

## 担当するボタンとトーストの確認
1. http://localhost:3000/products にアクセスし、担当者がいる提出物に担当者のアイコンと名前が表示されていることを確認する
2. 担当するボタンをクリックし、担当になれること、トーストが表示されることを確認する
3. 担当から外れるボタンをクリックし、担当から外れられること、トーストが表示されることを確認する

## 未完了ページの確認
1. http://localhost:3000/products/unchecked にアクセスする
2. 任意の提出物タイトルをクリックする
3. 提出物ページで提出物を確認するボタンをクリックする
4. http://localhost:3000/products/unchecked にアクセスし、確認された提出物が一覧に表示されていないことを確認する
5. 任意の提出物タイトルをクリックする
6. 提出物ページでコメントする
7. http://localhost:3000/products/unchecked?target=unchecked_no_replied にアクセスし、コメントした提出物が一覧に表示されていないことを確認する
8. ページ最下部の一括で開くボタンが機能することを確認する

## 未アサインページの確認
1. http://localhost:3000/products/unassigned にアクセスする
2. 担当者のいない提出物だけが表示されることを確認する
3. 画面右、経過日数ごとのリンクが正常に機能することを確認する
4. ページ最下部の一括で開くボタンが機能することを確認する

## 自分の担当ページの確認
1. http://localhost:3000/products/self_assigned にアクセスする
2. 自分が担当している提出物が表示されていることを確認する
4. http://localhost:3000/products/self_assigned?target=self_assigned_no_replied にアクセスする
5. 未返信の提出物のみが表示されていることを確認する
6. 未返信の提出物にはユーザーアイコン左上に赤いドットが表示されることを確認する
9. ページ最下部の一括で開くボタンが機能することを確認する

## Screenshot
画面の変更はありません。

