### PR TITLE
質問を更新した際にDiscordに通知が走らないようにした

### DIFF
--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -31,6 +31,7 @@ class API::QuestionsController < API::BaseController
   def update
     question = Question.find(params[:id])
     if question.update(question_params)
+      Newspaper.publish(:question_update, question)
       head :ok
     else
       head :bad_request

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -31,7 +31,6 @@ class API::QuestionsController < API::BaseController
   def update
     question = Question.find(params[:id])
     if question.update(question_params)
-      Newspaper.publish(:question_update, question)
       head :ok
     else
       head :bad_request

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -31,7 +31,7 @@ class API::QuestionsController < API::BaseController
   def update
     question = Question.find(params[:id])
     if question.update(question_params)
-      Newspaper.publish(:question_update, question)
+      Newspaper.publish(:question_update, question) if question.saved_change_to_wip?
       head :ok
     else
       head :bad_request

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -63,7 +63,6 @@ Rails.configuration.to_prepare do
 
   question_notifier = QuestionNotifier.new
   Newspaper.subscribe(:question_create, question_notifier)
-  Newspaper.subscribe(:question_update, question_notifier)
 
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForWatcher.new)
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForChecker.new)

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -63,6 +63,7 @@ Rails.configuration.to_prepare do
 
   question_notifier = QuestionNotifier.new
   Newspaper.subscribe(:question_create, question_notifier)
+  Newspaper.subscribe(:question_update, question_notifier)
 
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForWatcher.new)
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForChecker.new)

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -316,4 +316,35 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       assert_text 'Q&A「テストの質問」のベストアンサーがまだ選ばれていません。'
     end
   end
+
+  test 'do not notify discord when questions are updated' do
+    visit_with_auth questions_path(target: 'not_solved'), 'komagata'
+
+    click_link '質問する'
+    fill_in 'question[title]', with: 'testタイトル(新規投稿)'
+    fill_in 'question[description]', with: 'test本文(新規投稿)'
+
+    mock_log = []
+    stub_info = proc { |i| mock_log << i }
+    Rails.logger.stub(:info, stub_info) do
+      click_button '登録する'
+    end
+
+    assert_text '質問を作成しました。'
+    assert_match 'Message to Discord.', mock_log.to_s
+
+    click_button '内容修正'
+    within 'form[name=question]' do
+      fill_in 'question[title]', with: 'testタイトル(更新)'
+      fill_in 'question[description]', with: 'test本文(更新)'
+    end
+
+    mock_log = []
+    Rails.logger.stub(:info, stub_info) do
+      click_button '更新する'
+    end
+
+    assert_text '質問を更新しました'
+    assert_no_match 'Message to Discord.', mock_log.to_s
+  end
 end


### PR DESCRIPTION
## Issue

- #6799 
## 概要
質問投稿時と質問更新時に重複してdiscordに通知が走っていたため、質問投稿時とwip公開時のみ通知が走るようにしました。
## 変更確認方法
1. `feature/discord question notification only for new posts`ブランチをローカルに取り込む
2. [Develop環境でのDiscord通知の確認方法](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95) を参考にテスト用のサーバーを用意する
3. http://localhost:3000/questions で質問を作成
4. discordで質問投稿の通知を受け取る
5. 作成した質問の本文を編集して更新する
6. discordに通知が走らないことを確認する
7. 作成した質問の本文を編集してwipにする
8. wipを公開し、discordで質問投稿の通知を受け取る

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/88243294/0acd88de-9df1-430e-9906-49b6b83015d9)

### 変更後
<img width="872" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/69c07ea2-7604-4eae-96d2-b28c73cb9a49">