### PR TITLE
プラクティスページのtitleタグに表示される文字列の先頭に「プラクティス 」の文言を追加

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -3,7 +3,7 @@
 - category = @practice.category(current_user.course)
 
 = render '/shared/modal_learning_completion', practice: @practice, tweet_url: @tweet_url, should_display_message_automatically: false
-= render '/practices/page_header', title: title, category: category
+= render '/practices/page_header', title: @practice.title, category: category
 = render 'page_tabs', resource: @practice
 
 .page-body

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -1,4 +1,4 @@
-- title @practice.title
+- title "プラクティス #{@practice.title}"
 - set_meta_tags description: "プラクティス「#{@practice.title}」のページです。"
 - category = @practice.category(current_user.course)
 

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class PracticesTest < ApplicationSystemTestCase
   test 'show practice' do
     visit_with_auth "/practices/#{practices(:practice1).id}", 'hatsuno'
-    assert_equal 'OS X Mountain Lionをクリーンインストールする | FBC', title
+    assert_equal 'プラクティス OS X Mountain Lionをクリーンインストールする | FBC', title
   end
 
   test 'show link to all practices with same category' do
@@ -196,7 +196,7 @@ class PracticesTest < ApplicationSystemTestCase
     end
     assert_text 'プラクティスを更新しました'
     visit "/practices/#{practice.id}"
-    assert_equal 'テストプラクティス | FBC', title
+    assert_equal 'プラクティス テストプラクティス | FBC', title
   end
 
   test 'show last updated user icon' do


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6967

## 概要
- プラクティスページのタイトルタグに表示される内容は以下のような形式で表示されるように変更。
berfore；各プラクティス名 | FBC
after；プラクティス 各プラクティス名 | FBC

## 変更確認方法

1. feature/add-practice-to-title-tag-on-practice-pageをローカルに取り込む
2. foreman start -f Procfile.devでローカル環境を立ち上げる
3. 任意のアカウントでログイン
4. 任意のプラクティスページを開く

## Screenshot

### 変更前
<img width="390" alt="PC性能の見方を知る" src="https://github.com/fjordllc/bootcamp/assets/78665068/2d19978f-c1fd-45e4-92af-c7528f89b49b">

### 変更後
<img width="348" alt="image" src="https://github.com/fjordllc/bootcamp/assets/78665068/2a169c4b-1661-4fb1-a12b-53bf78c1c5fe">
