### PR TITLE
通知ページの1ページ目ですべてのデータを取るバグの修正

### DIFF
--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -18,10 +18,10 @@ export default function Notifications({ isMentor }) {
     const params = new URLSearchParams(location.search)
     if (params.get('status') === 'unread' && params.get('page') === null) {
       return '/api/notifications.json?status=unread&page=1'
+    } else if (params.size === 0) {
+      return '/api/notifications.json?page=1'
     }
-    return params.size === 0
-      ? '/api/notifications.json?page=1'
-      : `/api/notifications.json?${params}`
+    return `/api/notifications.json?${params}`
   }
 
   const { data, error } = useSWR(url, fetcher)

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -13,9 +13,15 @@ export default function Notifications({ isMentor }) {
     const params = new URLSearchParams(location.search)
     return params.get('status') !== null && params.get('status') === 'unread'
   }
+
   const url = () => {
     const params = new URLSearchParams(location.search)
-    return `/api/notifications.json?${params}`
+    if (params.get('status') === 'unread' && params.get('page') === null) {
+      return '/api/notifications.json?status=unread&page=1'
+    }
+    return params.size === 0
+      ? '/api/notifications.json?page=1'
+      : `/api/notifications.json?${params}`
   }
 
   const { data, error } = useSWR(url, fetcher)

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -164,4 +164,5 @@ notification_for_pagination<%= i %>: # 通知ページのページネーショ�
   message: "practice<%= i %>が更新されました。"
   link: "/practices/<%= ActiveRecord::FixtureSet.identify("practice#{i}".to_sym) %>"
   read: false
+  created_at: "<%= Time.current - i.days %>"
 <% end %>

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -100,6 +100,36 @@ class NotificationsTest < ApplicationSystemTestCase
     assert_current_path('/notifications?page=2')
   end
 
+  test 'show 20 notifications in first page' do
+    25.times do |n|
+      Notification.create(message: "machidaさんからメンションが届きました#{n}",
+                          kind: 'mentioned',
+                          link: "/reports/#{n}",
+                          user: users(:mentormentaro),
+                          sender: users(:machida))
+    end
+    Notification.create(message: '1番新しい通知',
+                        created_at: '2040-01-18 06:06:42',
+                        kind: 'mentioned',
+                        link: '/reports/20400118',
+                        user: users(:mentormentaro),
+                        sender: users(:machida))
+    Notification.create(message: '1番古い通知',
+                        created_at: '2000-01-18 06:06:42',
+                        kind: 'mentioned',
+                        link: '/reports/20000118',
+                        user: users(:mentormentaro),
+                        sender: users(:machida))
+    login_user 'mentormentaro', 'testtest'
+    visit '/notifications'
+    assert_text '1番新しい通知'
+    assert_equal 20, all('.card-list-item').size
+
+    visit '/notifications?status=unread'
+    assert_text '1番新しい通知'
+    assert_equal 20, all('.card-list-item').size
+  end
+
   test 'click on the pager button with query string' do
     19.times do |n|
       Notification.create(message: "machidaさんからメンションが届きました#{n}",

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -114,12 +114,6 @@ class NotificationsTest < ApplicationSystemTestCase
                         link: '/reports/20400118',
                         user: users(:mentormentaro),
                         sender: users(:machida))
-    Notification.create(message: '1番古い通知',
-                        created_at: '2000-01-18 06:06:42',
-                        kind: 'mentioned',
-                        link: '/reports/20000118',
-                        user: users(:mentormentaro),
-                        sender: users(:machida))
     login_user 'mentormentaro', 'testtest'
     visit '/notifications'
     assert_text '1番新しい通知'


### PR DESCRIPTION
## Issue

- #7002 

## 概要
通知ページの1ページ目で大量のデータが表示される不具合の修正
("全て"、"未読"の両ページで発生していました)
## 変更確認方法

1. bug/fix-notifications-first-pageをローカルに取り込む
2. Id:hatsunoでログインする
3. http://localhost:3000/notifications にアクセスする
4. 通知が20件表示されていることを確認する
5. http://localhost:3000/notifications?status=unread にアクセスする
6. 通知が20件表示されていることを確認する

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/99132547/ee24cfcf-aaa7-4b83-a21c-6d55af4825b3)
~
![image](https://github.com/fjordllc/bootcamp/assets/99132547/c707b9b9-587b-4496-82f1-0ed7bf9f5eb7)

### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/99132547/494b5261-51b1-4731-89ee-52fa1963f34f)
~
![image](https://github.com/fjordllc/bootcamp/assets/99132547/989aef7a-9378-4b8c-aef6-2a7534a8306d)

