### PR TITLE
提出物のPRのリンクが間違っているとき警告を出すようにした

### DIFF
--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module ProductDecorator
+  include ActionView::Helpers::UrlHelper
   def list_title(resource)
     case resource
     when Practice
@@ -8,5 +9,9 @@ module ProductDecorator
     when User
       practice.title
     end
+  end
+
+  def reject_message_for_wrong_repository
+    "中のPRのURLが間違っています。#{link_to '提出物のPRのやり方 - YouTube', 'https://www.youtube.com/watch?v=XMgLL4qIyEA'}を確認してPRを作り直してください"
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -209,6 +209,6 @@ class Product < ApplicationRecord
   end
 
   def reject_wrong_url
-    errors.add(:body, 'PRのURLが間違っています。PRを作り直してください') if body.match?(/fjordllc\/ruby-practices\/pull\/\d+/)
+    errors.add(:body, 'PRのURLが間違っています。PRを作り直してください') if body.match?(/fjordllc\/.+\/pull\/\d+/)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -211,6 +211,6 @@ class Product < ApplicationRecord
   end
 
   def reject_wrong_repository_url
-    errors.add(:body, 'PRのURLが間違っています。PRを作り直してください') if body.match?(/#{GITHUB_ACCOUNT_NAME}\/.+\/pull\/\d+/)
+    errors.add(:body, '中のPRのURLが間違っています。PRを作り直してください') if body.match?(/#{GITHUB_ACCOUNT_NAME}\/.+\/pull\/\d+/)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -11,6 +11,7 @@ class Product < ApplicationRecord
   include Searchable
   include Bookmarkable
   include Taskable
+  include ProductDecorator
 
   GITHUB_ACCOUNT_NAME = 'fjordllc'
 
@@ -211,6 +212,6 @@ class Product < ApplicationRecord
   end
 
   def reject_wrong_repository_url
-    errors.add(:body, '中のPRのURLが間違っています。フォークした自分のリポジトリ向けにPRを作り直してください(参考: https://www.youtube.com/watch?v=XMgLL4qIyEA)') if body.match?(/#{GITHUB_ACCOUNT_NAME}\/.+\/pull\/\d+/)
+    errors.add(:body, reject_message_for_wrong_repository) if body.match?(%r{#{GITHUB_ACCOUNT_NAME}/.+/pull/\d+})
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,6 +12,8 @@ class Product < ApplicationRecord
   include Bookmarkable
   include Taskable
 
+  GITHUB_ACCOUNT_NAME = 'fjordllc'
+
   belongs_to :practice
   belongs_to :user, touch: true
   belongs_to :checker, class_name: 'User', optional: true
@@ -209,6 +211,6 @@ class Product < ApplicationRecord
   end
 
   def reject_wrong_repository_url
-    errors.add(:body, 'PRのURLが間違っています。PRを作り直してください') if body.match?(/fjordllc\/.+\/pull\/\d+/)
+    errors.add(:body, 'PRのURLが間違っています。PRを作り直してください') if body.match?(/#{GITHUB_ACCOUNT_NAME}\/.+\/pull\/\d+/)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -26,7 +26,7 @@ class Product < ApplicationRecord
 
   validates :user, presence: true, uniqueness: { scope: :practice, message: '既に提出物があります。' }
   validates :body, presence: true
-  validate :reject_wrong_url
+  validate :reject_wrong_repository_url
 
   paginates_per 50
 
@@ -208,7 +208,7 @@ class Product < ApplicationRecord
     created_at != updated_at
   end
 
-  def reject_wrong_url
+  def reject_wrong_repository_url
     errors.add(:body, 'PRのURLが間違っています。PRを作り直してください') if body.match?(/fjordllc\/.+\/pull\/\d+/)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -26,6 +26,7 @@ class Product < ApplicationRecord
 
   validates :user, presence: true, uniqueness: { scope: :practice, message: '既に提出物があります。' }
   validates :body, presence: true
+  validate :reject_wrong_url
 
   paginates_per 50
 
@@ -205,5 +206,9 @@ class Product < ApplicationRecord
     return false if saved_change_to_attribute?('published_at', from: nil)
 
     created_at != updated_at
+  end
+
+  def reject_wrong_url
+    errors.add(:body, 'PRのURLが間違っています。PRを作り直してください') if body.match?(/fjordllc\/ruby-practices\/pull\/\d+/)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -211,6 +211,6 @@ class Product < ApplicationRecord
   end
 
   def reject_wrong_repository_url
-    errors.add(:body, '中のPRのURLが間違っています。PRを作り直してください') if body.match?(/#{GITHUB_ACCOUNT_NAME}\/.+\/pull\/\d+/)
+    errors.add(:body, '中のPRのURLが間違っています。フォークした自分のリポジトリ向けにPRを作り直してください(参考: https://www.youtube.com/watch?v=XMgLL4qIyEA)') if body.match?(/#{GITHUB_ACCOUNT_NAME}\/.+\/pull\/\d+/)
   end
 end

--- a/app/views/application/_errors.slim
+++ b/app/views/application/_errors.slim
@@ -6,4 +6,4 @@
       ul.errors__items
         - object.errors.full_messages.each do |msg|
           li.errors__item
-            = msg
+            == msg

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -207,6 +207,6 @@ class ProductTest < ActiveSupport::TestCase
       practice: practices(:practice5)
     )
     product.valid?
-    assert_equal '中のPRのURLが間違っています。フォークした自分のリポジトリ向けにPRを作り直してください(参考: https://www.youtube.com/watch?v=XMgLL4qIyEA)', product.errors[:body].first
+    assert_equal '中のPRのURLが間違っています。<a href="https://www.youtube.com/watch?v=XMgLL4qIyEA">提出物のPRのやり方 - YouTube</a>を確認してPRを作り直してください', product.errors[:body].first
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -202,7 +202,7 @@ class ProductTest < ActiveSupport::TestCase
 
   test 'reject wrong url' do
     product = Product.new(
-      body: 'https://github.com/fjordllc/ruby-practices/pull/35',
+      body: 'https://github.com/fjordllc/hoge/pull/35',
       user: users(:kimura),
       practice: practices(:practice5)
     )

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -200,7 +200,7 @@ class ProductTest < ActiveSupport::TestCase
     assert_not wip_product.updated_after_submission?
   end
 
-  test 'reject wrong url' do
+  test 'reject wrong repository url' do
     product = Product.new(
       body: 'https://github.com/fjordllc/hoge/pull/35',
       user: users(:kimura),

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -207,6 +207,6 @@ class ProductTest < ActiveSupport::TestCase
       practice: practices(:practice5)
     )
     product.valid?
-    assert_equal 'PRのURLが間違っています。PRを作り直してください', product.errors[:body].first
+    assert_equal '中のPRのURLが間違っています。フォークした自分のリポジトリ向けにPRを作り直してください(参考: https://www.youtube.com/watch?v=XMgLL4qIyEA)', product.errors[:body].first
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -199,4 +199,14 @@ class ProductTest < ActiveSupport::TestCase
     wip_product.update!(body: 'product is updated.', wip: false, published_at: Time.current)
     assert_not wip_product.updated_after_submission?
   end
+
+  test 'reject wrong url' do
+    product = Product.new(
+      body: 'https://github.com/fjordllc/ruby-practices/pull/35',
+      user: users(:kimura),
+      practice: practices(:practice5)
+    )
+    product.valid?
+    assert_equal 'PRのURLが間違っています。PRを作り直してください', product.errors[:body].first
+  end
 end


### PR DESCRIPTION
## Issue

- #3992

## 概要

プラクティスの成果物として提出物を作成する際、`fjordllc`が含まれるPRのURLが本文中にある場合にバリデーションエラーを発生させるようにしました。
Issueには、`fjordllc/ruby-practices`のみに対応するよう記載されていますが、別のリポジトリ(`fjordllc/bug_cafe`や`fjordllc/fjord-books_app-2023`など)の場合も対応するように正規表現を変更しています。

## 懸念点
本番に反映する際、既存データに今回追加したバリデーションを含むデータがある場合このままマージするとたいへん良くなさそう。駒形さんに本番のデータを見ていただき、ご判断お願いしたいです🙇

## 変更確認方法

1. `eatplaynap:validate-product-body`をローカルに取り込む
2. プラクティスの提出物新規作成画面にアクセスする
3. `https://github.com/fjordllc/hoge/pull/35` を提出物本文にコピペし、「提出する」ボタンを押下
4. バリデーションエラーが走り、提出物作成が行えないことを確認
5. `https://github.com/fuga/hoge/pull/35` を提出物本文にコピペし、「提出する」ボタンを押下
6. バリデーションエラーが走らず、提出物作成が正常に行えることを確認

## Screenshot

### 変更前
フォーク元の`fjordllc`が入ったURLが記載されている場合もエラーが表示されず、提出物作成が行える。

### 変更後
![CleanShot 2023-10-30 at 18 15 12@2x](https://github.com/fjordllc/bootcamp/assets/63531341/49adf3a3-911d-4db6-b71d-b1f66a15bea4)

不正なURLが本文中に含まれている場合バリデーションエラーが走り、提出物作成が行えない。