### PR TITLE
メンションがリンクにならないバグを修正

### DIFF
--- a/app/javascript/markdown-it-mention.js
+++ b/app/javascript/markdown-it-mention.js
@@ -9,7 +9,9 @@ export default MarkdownItRegexp(mentionRegexp, (match) => {
     )
     return output
       ? output[1].match(mentionRegexp)[0]
-      : ('[' + match.input).match(mentionRegexp)[0]
+      : `<a href="${
+          match[0] === '@mentor' ? `/users?target=mentor` : `/users/${match[1]}`
+        }" class="mention-link">${match[0]}</a>`
   } else {
     return `<a href="${
       match[0] === '@mentor' ? `/users?target=mentor` : `/users/${match[1]}`


### PR DESCRIPTION
## Issue

- #6800

## 概要
markdown上で、同じ p タグの中にリンクがあると、メンションがリンクにならないバグがあったので修正をした。

↓ この Markdown だと、

```md
@sochi419  [あああ](http://fjord.jp)
```

↓ このような HTML になってしまう。

```html
<p>@sochi419 <a href="http://fjord.jp" target="_blank">あああ</a></p>
```

↓  本当はこうなって欲しい。

```html
<p><a href="https://bootcamp.fjord.jp/users/1319">@sochi419</a> <a href="http://fjord.jp" target="_blank">あああ</a></p>
```

## 変更確認方法

1. `bug/some_mentions_links_may_not_work`をローカルに取り込む
2. `http://localhost:3000/reports/new`にアクセス
3.  内容フォーム内に`@komagata  [あああ](http://fjord.jp)`と記載する。
4. プレビュー上で`@komagata`を選択してkomagataのユーザページに遷移するかを確認する。
5. プレビュー上で`あああ`を選択して、`http://fjord.jp`に遷移するか確認する。

## Screenshot

### 変更前
- markdownプレビュー
<img width="853" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/0d8220dd-e151-4716-9fc2-c6f55a70a26b">

- HTML上
<img width="349" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/6011d354-1096-411c-8e05-193eb13c3072">


### 変更後
- markdownプレビュー
<img width="890" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/df3ba9fe-c1ce-4bfe-9516-cda53df0767e">

- HTML上
<img width="442" alt="image" src="https://github.com/fjordllc/bootcamp/assets/92995093/86b9101c-caa0-4e56-afc1-b6186b328833">


