### PR TITLE
Docの作者をWatch中になるようにした

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,7 +46,7 @@ class PagesController < ApplicationController
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      current_user.become_watcher!(@page)
+      become_watcher!(@page, [current_user, @page.user])
 
       redirect_to url, notice: notice_message(@page, :create)
     else
@@ -64,7 +64,7 @@ class PagesController < ApplicationController
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
       end
 
-      current_user.become_watcher!(@page)
+      become_watcher!(@page, [current_user, @page.user])
 
       redirect_to url, notice: notice_message(@page, :update)
     else
@@ -116,5 +116,9 @@ class PagesController < ApplicationController
     return if @page.slug.nil?
 
     redirect_to request.original_url.sub(params[:slug_or_id], @page.slug) unless params[:slug_or_id].start_with?(/[a-z]/)
+  end
+
+  def become_watcher!(page, users)
+    users.each { |user| user.become_watcher!(page) }
   end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -250,6 +250,42 @@ class PagesTest < ApplicationSystemTestCase
     assert_text 'Watch中'
   end
 
+  test 'author becomes watcher' do
+    author = 'kimura'
+    # 編集前にWatch中になってないかチェック
+    visit_with_auth page_path(pages(:page1)), author
+    assert_text 'Watch'
+    visit page_path(pages(:page2))
+    assert_text 'Watch'
+
+    logout
+
+    # 編集者もwatch中になるため、作者と編集者を別にする
+    editor = 'machida'
+    visit_with_auth edit_page_path(pages(:page1)), editor
+
+    within('.form') do
+      find('#select2-page_user_id-container').click
+      select(author, from: 'page[user_id]')
+    end
+    click_button '内容を更新'
+
+    visit edit_page_path(pages(:page2))
+
+    within('.form') do
+      find('#select2-page_user_id-container').click
+      select(author, from: 'page[user_id]')
+    end
+    click_button 'WIP'
+
+    logout
+
+    visit_with_auth page_path(pages(:page1)), author
+    assert_text 'Watch中'
+    visit page_path(pages(:page2))
+    assert_text 'Watch中'
+  end
+
   test 'Check the list of columns on the right of the document' do
     visit_with_auth "/pages/#{pages(:page7).id}", 'kimura'
     assert_link 'OS X Mountain Lionをクリーンインストールする'

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -231,7 +231,7 @@ class PagesTest < ApplicationSystemTestCase
     assert_match 'Message to Discord.', mock_log.to_s
   end
 
-  test 'non-author docs editor becomes Watcher when editing docs' do
+  test 'non-author docs editor becomes watcher' do
     # 編集前にWatch中になってないかチェック(作成者を除くDocs編集者)
     editor = 'machida'
     visit_with_auth page_path(pages(:page1)), editor


### PR DESCRIPTION
## Issue

- #6225 

## 概要
Docsの作者を自動でWatch中にしました。（編集形式「WIP」、「内容を更新」に関わらずWatch中となります。）

### 補足説明
本PRのコードは 類似PR #6319 を参考にしております。

## 変更確認方法
1. `feature/put-the-changed-author-on-watch-if-you-change-the-author-of-docs`をローカルに取り込む
1. `foreman start -f Procfile.dev`でサーバー起動
1. `localhost:3000`にアクセス
1. `kimura`でログイン
1. `pages/595633515`にアクセス（DocがWatch中でなければどのページでもOKです。）
1. DocsがWatch中でないことを確認する
1. `komagata`でログイン
1. `/pages/{page_id}/edit`にアクセス（page_idは手順5.でアクセスしたDocsのid）
1. 「ユーザー」プルダウンをクリックし、`kimura`を選択する
1. 「WIP」ボタン、または「内容を更新」ボタンをクリックし、Docsを編集する
1. `kimura`でログイン
1. `/pages/{page_id}`にアクセス（page_idは手順5.でアクセスしたDocsのid）
1. 「Watch中」が表示されることを確認する


## Screenshot
変更の差分はないためスクリーンショットは割愛します。

