### PR TITLE
Docの個別ページのtitleタグ及びmetaタグのog:titleはタイトルの頭にDocと表示するように変更

### DIFF
--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -1,4 +1,4 @@
-- title @page.title
+- title "Doc #{@page.title}"
 - set_meta_tags description: "ドキュメント「#{@page.title}」のページです"
 
 header.page-header

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -22,7 +22,7 @@ class PagesTest < ApplicationSystemTestCase
 
   test 'show page' do
     visit_with_auth "/pages/#{pages(:page1).id}", 'kimura'
-    assert_equal 'test1 | FBC', title
+    assert_equal 'Doc test1 | FBC', title
   end
 
   test 'show edit page' do


### PR DESCRIPTION
## Issue

- #7014 

## 概要
Docの個別ページでは、titleタグとmetaタグのog:titleの先頭に`Doc`と表示するように変更しました。

## 変更確認方法

1. ブランチ`feature/change-title-tag-and-og-title`をローカルに取り込む
2. `rails s`でローカル環境を立ち上げる
3. 任意のアカウントでログイン
4. Docs内の任意のページを開く
5. デベロッパーツールで確認

## 該当箇所
### 変更前
#### デベロッパーツール
<img width="571" alt="image" src="https://github.com/fjordllc/bootcamp/assets/66000707/8a944442-9f72-410f-a5e8-cfb83eed41b4">

### 変更後
#### デベロッパーツール
<img width="575" alt="image" src="https://github.com/fjordllc/bootcamp/assets/66000707/2e5ec8d6-84d3-4d5b-b20d-0a72add29e12">
