### PR TITLE
通知ページのバグを修正する

### DIFF
--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -15,10 +15,39 @@ export default function Notifications({ isMentor }) {
   }
   const params = new URLSearchParams(location.search)
   const url = () => {
-    const target = params.get('target') ? `&target=${params.get('target')}` : ''
-    const status = params.get('status') ? `&status=${params.get('status')}` : ''
-    const page = params.get('page') ? `page=${params.get('page')}` : 'page=1'
-    return `/api/notifications.json?${page}${target}${status}`
+    const target = params.get('target')
+    const status = params.get('status')
+    const page = params.get('page') ? params.get('page') : 1
+    const url = new URL('api/notifications.json', location.origin)
+
+    const searchParams = new URLSearchParams()
+    if (target) {
+      searchParams.set('target', target)
+    }
+
+    if (status) {
+      searchParams.set('status', status)
+    }
+
+    searchParams.set('page', page)
+    url.search = searchParams
+
+    return url.toString()
+  }
+
+  const filterButtonUrl = (status) => {
+    const url = new URL('/notifications', location.origin)
+    const target = params.get('target')
+    const searchParams = new URLSearchParams()
+    if (target) {
+      searchParams.set('target', target)
+    }
+    if (status) {
+      searchParams.set('status', status)
+    }
+
+    url.search = searchParams
+    return url.toString()
   }
 
   const { data, error } = useSWR(url, fetcher)
@@ -58,11 +87,7 @@ export default function Notifications({ isMentor }) {
                   className={`pill-nav__item-link ${
                     params.get('status') === 'unread' ? 'is-active' : ''
                   }`}
-                  href={`/notifications?status=unread${
-                    params.get('target')
-                      ? `&target=${params.get('target')}`
-                      : ''
-                  }`}>
+                  href={filterButtonUrl('unread')}>
                   未読
                 </a>
               </li>
@@ -71,11 +96,7 @@ export default function Notifications({ isMentor }) {
                   className={`pill-nav__item-link ${
                     params.get('status') === 'unread' ? '' : 'is-active'
                   }`}
-                  href={`/notifications${
-                    params.get('target')
-                      ? `?target=${params.get('target')}`
-                      : ''
-                  }`}>
+                  href={filterButtonUrl(null)}>
                   全て
                 </a>
               </li>

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -35,24 +35,6 @@ export default function Notifications({ isMentor }) {
     return url.toString()
   }
 
-  const filterButtonUrl = (status) => {
-    const searchParams = new URLSearchParams()
-    const params = new URLSearchParams(location.search)
-    const target = params.get('target')
-    if (target) {
-      searchParams.set('target', target)
-    }
-
-    if (status) {
-      searchParams.set('status', status)
-    }
-
-    const url = new URL('/notifications', location.origin)
-    url.search = searchParams
-
-    return url.toString()
-  }
-
   const { data, error } = useSWR(apiUrl, fetcher)
   if (error) {
     console.warn(error)
@@ -68,43 +50,22 @@ export default function Notifications({ isMentor }) {
     )
   } else if (data.notifications.length === 0) {
     return (
-      <div className="o-empty-message">
-        <div className="o-empty-message__icon">
-          <i className="fa-regular fa-smile" />
+      <>
+        <FilterButton />
+        <div className="o-empty-message">
+          <div className="o-empty-message__icon">
+            <i className="fa-regular fa-smile" />
+          </div>
+          <p className="o-empty-message__text">
+            {isUnreadPage() ? '未読の通知はありません' : '通知はありません'}
+          </p>
         </div>
-        <p className="o-empty-message__text">
-          {isUnreadPage() ? '未読の通知はありません' : '通知はありません'}
-        </p>
-      </div>
+      </>
     )
   } else {
-    const params = new URLSearchParams(location.search)
     return (
       <>
-        <nav className="pill-nav">
-          <div className="container">
-            <ul className="pill-nav__items">
-              <li className="pill-nav__item">
-                <a
-                  className={`pill-nav__item-link ${
-                    params.get('status') === 'unread' ? 'is-active' : ''
-                  }`}
-                  href={filterButtonUrl('unread')}>
-                  未読
-                </a>
-              </li>
-              <li className="pill-nav__item">
-                <a
-                  className={`pill-nav__item-link ${
-                    params.get('status') === 'unread' ? '' : 'is-active'
-                  }`}
-                  href={filterButtonUrl()}>
-                  全て
-                </a>
-              </li>
-            </ul>
-          </div>
-        </nav>
+        <FilterButton />
         <div id="notifications" className="page-content loaded">
           {data.total_pages > 1 && (
             <nav className="pagination">
@@ -143,4 +104,52 @@ export default function Notifications({ isMentor }) {
       </>
     )
   }
+}
+
+const FilterButton = () => {
+  const filterButtonUrl = (status) => {
+    const searchParams = new URLSearchParams()
+    const params = new URLSearchParams(location.search)
+    const target = params.get('target')
+    if (target) {
+      searchParams.set('target', target)
+    }
+
+    if (status) {
+      searchParams.set('status', status)
+    }
+
+    const url = new URL('/notifications', location.origin)
+    url.search = searchParams
+
+    return url.toString()
+  }
+
+  const params = new URLSearchParams(location.search)
+  return (
+    <nav className="pill-nav">
+      <div className="container">
+        <ul className="pill-nav__items">
+          <li className="pill-nav__item">
+            <a
+              className={`pill-nav__item-link ${
+                params.get('status') === 'unread' ? 'is-active' : ''
+              }`}
+              href={filterButtonUrl('unread')}>
+              未読
+            </a>
+          </li>
+          <li className="pill-nav__item">
+            <a
+              className={`pill-nav__item-link ${
+                params.get('status') === 'unread' ? '' : 'is-active'
+              }`}
+              href={filterButtonUrl()}>
+              全て
+            </a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  )
 }

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -15,21 +15,21 @@ export default function Notifications({ isMentor }) {
   }
   const params = new URLSearchParams(location.search)
   const apiUrl = () => {
-    const target = params.get('target')
-    const status = params.get('status')
-    const page = params.get('page') ?? 1
-    const url = new URL('api/notifications.json', location.origin)
     const searchParams = new URLSearchParams()
-
+    const target = params.get('target')
     if (target) {
       searchParams.set('target', target)
     }
 
+    const status = params.get('status')
     if (status) {
       searchParams.set('status', status)
     }
 
+    const page = params.get('page') ?? 1
     searchParams.set('page', page)
+
+    const url = new URL('api/notifications.json', location.origin)
     url.search = searchParams
 
     return url.toString()

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -35,14 +35,13 @@ export default function Notifications({ isMentor }) {
     return url.toString()
   }
 
+  const { page, setPage } = usePage()
   const { data, error } = useSWR(apiUrl, fetcher)
+
   if (error) {
     console.warn(error)
     return <div>failed to load</div>
-  }
-
-  const { page, setPage } = usePage()
-  if (!data) {
+  } else if (!data) {
     return (
       <div id="notifications" className="page-content loading">
         <LoadingListPlaceholder />
@@ -62,48 +61,45 @@ export default function Notifications({ isMentor }) {
         </div>
       </>
     )
-  } else {
-    return (
-      <>
-        <FilterButton />
-        <div id="notifications" className="page-content loaded">
-          {data.total_pages > 1 && (
-            <nav className="pagination">
-              <Pagination
-                sum={data.total_pages * per}
-                per={per}
-                page={page}
-                setPage={setPage}
-              />
-            </nav>
-          )}
-          <div className="card-list a-card">
-            {data.notifications.map((notification) => {
-              return (
-                <Notification
-                  key={notification.id}
-                  notification={notification}
-                />
-              )
-            })}
-          </div>
-          {isMentor && isUnreadPage() && (
-            <UnconfirmedLink label="未読の通知を一括で開く" />
-          )}
-          {data.total_pages > 1 && (
-            <nav className="pagination">
-              <Pagination
-                sum={data.total_pages * per}
-                per={per}
-                page={page}
-                setPage={setPage}
-              />
-            </nav>
-          )}
-        </div>
-      </>
-    )
   }
+
+  return (
+    <>
+      <FilterButton />
+      <div id="notifications" className="page-content loaded">
+        {data.total_pages > 1 && (
+          <nav className="pagination">
+            <Pagination
+              sum={data.total_pages * per}
+              per={per}
+              page={page}
+              setPage={setPage}
+            />
+          </nav>
+        )}
+        <div className="card-list a-card">
+          {data.notifications.map((notification) => {
+            return (
+              <Notification key={notification.id} notification={notification} />
+            )
+          })}
+        </div>
+        {isMentor && isUnreadPage() && (
+          <UnconfirmedLink label="未読の通知を一括で開く" />
+        )}
+        {data.total_pages > 1 && (
+          <nav className="pagination">
+            <Pagination
+              sum={data.total_pages * per}
+              per={per}
+              page={page}
+              setPage={setPage}
+            />
+          </nav>
+        )}
+      </div>
+    </>
+  )
 }
 
 const FilterButton = () => {

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -36,18 +36,19 @@ export default function Notifications({ isMentor }) {
   }
 
   const filterButtonUrl = (status) => {
-    const url = new URL('/notifications', location.origin)
-    const target = params.get('target')
     const searchParams = new URLSearchParams()
-
+    const target = params.get('target')
     if (target) {
       searchParams.set('target', target)
     }
+
     if (status) {
       searchParams.set('status', status)
     }
 
+    const url = new URL('/notifications', location.origin)
     url.search = searchParams
+
     return url.toString()
   }
 

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -72,7 +72,7 @@ export default function Notifications({ isMentor }) {
           <i className="fa-regular fa-smile" />
         </div>
         <p className="o-empty-message__text">
-          {isUnreadPage ? '未読の通知はありません' : '通知はありません'}
+          {isUnreadPage() ? '未読の通知はありません' : '通知はありません'}
         </p>
       </div>
     )

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -13,18 +13,11 @@ export default function Notifications({ isMentor }) {
     const params = new URLSearchParams(location.search)
     return params.get('status') !== null && params.get('status') === 'unread'
   }
-
+  const params = new URLSearchParams(location.search)
   const url = () => {
-    const params = new URLSearchParams(location.search)
-    console.log(params)
+    const target = params.get('target') ? `&target=${params.get('target')}` : ''
+    const status = params.get('status') ? `&status=${params.get('status')}` : ''
     const page = params.get('page') ? `page=${params.get('page')}` : 'page=1'
-    const target = params.get('target')
-      ? `&target=${params.get('target')}`
-      : null
-    const status = params.get('status')
-      ? `&status=${params.get('status')}`
-      : null
-
     return `/api/notifications.json?${page}${target}${status}`
   }
 
@@ -55,7 +48,6 @@ export default function Notifications({ isMentor }) {
       </div>
     )
   } else {
-    const params = new URLSearchParams(location.search)
     return (
       <>
         <nav className="pill-nav">
@@ -66,7 +58,11 @@ export default function Notifications({ isMentor }) {
                   className={`pill-nav__item-link ${
                     params.get('status') === 'unread' ? 'is-active' : ''
                   }`}
-                  href={`/notifications?status=unread`}>
+                  href={`/notifications?status=unread${
+                    params.get('target')
+                      ? `&target=${params.get('target')}`
+                      : ''
+                  }`}>
                   未読
                 </a>
               </li>
@@ -75,7 +71,11 @@ export default function Notifications({ isMentor }) {
                   className={`pill-nav__item-link ${
                     params.get('status') === 'unread' ? '' : 'is-active'
                   }`}
-                  href="/notifications">
+                  href={`/notifications${
+                    params.get('target')
+                      ? `?target=${params.get('target')}`
+                      : ''
+                  }`}>
                   全て
                 </a>
               </li>

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -11,7 +11,7 @@ export default function Notifications({ isMentor }) {
   const per = 20
   const isUnreadPage = () => {
     const params = new URLSearchParams(location.search)
-    return params.get('status') !== null && params.get('status') === 'unread'
+    return params.get('status') === 'unread'
   }
   const params = new URLSearchParams(location.search)
   const apiUrl = () => {

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -16,13 +16,16 @@ export default function Notifications({ isMentor }) {
 
   const url = () => {
     const params = new URLSearchParams(location.search)
-    if (params.get('status') === 'unread' && params.get('page') === null) {
-      return '/api/notifications?status=unread&page=1'
-    } else if (params.get('page')) {
-      return `/api/notifications.json?${params}`
-    } else {
-      return '/api/notifications?page=1'
-    }
+    console.log(params)
+    const page = params.get('page') ? `page=${params.get('page')}` : 'page=1'
+    const target = params.get('target')
+      ? `&target=${params.get('target')}`
+      : null
+    const status = params.get('status')
+      ? `&status=${params.get('status')}`
+      : null
+
+    return `/api/notifications.json?${page}${target}${status}`
   }
 
   const { data, error } = useSWR(url, fetcher)

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -13,9 +13,9 @@ export default function Notifications({ isMentor }) {
     const params = new URLSearchParams(location.search)
     return params.get('status') === 'unread'
   }
-  const params = new URLSearchParams(location.search)
   const apiUrl = () => {
     const searchParams = new URLSearchParams()
+    const params = new URLSearchParams(location.search)
     const target = params.get('target')
     if (target) {
       searchParams.set('target', target)
@@ -37,6 +37,7 @@ export default function Notifications({ isMentor }) {
 
   const filterButtonUrl = (status) => {
     const searchParams = new URLSearchParams()
+    const params = new URLSearchParams(location.search)
     const target = params.get('target')
     if (target) {
       searchParams.set('target', target)
@@ -79,6 +80,7 @@ export default function Notifications({ isMentor }) {
       </div>
     )
   } else {
+    const params = new URLSearchParams(location.search)
     return (
       <>
         <nav className="pill-nav">

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -17,7 +17,7 @@ export default function Notifications({ isMentor }) {
   const apiUrl = () => {
     const target = params.get('target')
     const status = params.get('status')
-    const page = params.get('page') ? params.get('page') : 1
+    const page = params.get('page') ?? 1
     const url = new URL('api/notifications.json', location.origin)
     const searchParams = new URLSearchParams()
 

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -19,8 +19,8 @@ export default function Notifications({ isMentor }) {
     const status = params.get('status')
     const page = params.get('page') ? params.get('page') : 1
     const url = new URL('api/notifications.json', location.origin)
-
     const searchParams = new URLSearchParams()
+
     if (target) {
       searchParams.set('target', target)
     }
@@ -39,6 +39,7 @@ export default function Notifications({ isMentor }) {
     const url = new URL('/notifications', location.origin)
     const target = params.get('target')
     const searchParams = new URLSearchParams()
+
     if (target) {
       searchParams.set('target', target)
     }

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -14,7 +14,7 @@ export default function Notifications({ isMentor }) {
     return params.get('status') !== null && params.get('status') === 'unread'
   }
   const params = new URLSearchParams(location.search)
-  const url = () => {
+  const apiUrl = () => {
     const target = params.get('target')
     const status = params.get('status')
     const page = params.get('page') ? params.get('page') : 1
@@ -50,7 +50,7 @@ export default function Notifications({ isMentor }) {
     return url.toString()
   }
 
-  const { data, error } = useSWR(url, fetcher)
+  const { data, error } = useSWR(apiUrl, fetcher)
 
   const { page, setPage } = usePage()
 

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -54,14 +54,12 @@ export default function Notifications({ isMentor }) {
   }
 
   const { data, error } = useSWR(apiUrl, fetcher)
-
-  const { page, setPage } = usePage()
-
   if (error) {
     console.warn(error)
     return <div>failed to load</div>
   }
 
+  const { page, setPage } = usePage()
   if (!data) {
     return (
       <div id="notifications" className="page-content loading">

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -98,7 +98,7 @@ export default function Notifications({ isMentor }) {
                   className={`pill-nav__item-link ${
                     params.get('status') === 'unread' ? '' : 'is-active'
                   }`}
-                  href={filterButtonUrl(null)}>
+                  href={filterButtonUrl()}>
                   全て
                 </a>
               </li>

--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -17,11 +17,12 @@ export default function Notifications({ isMentor }) {
   const url = () => {
     const params = new URLSearchParams(location.search)
     if (params.get('status') === 'unread' && params.get('page') === null) {
-      return '/api/notifications.json?status=unread&page=1'
-    } else if (params.size === 0) {
-      return '/api/notifications.json?page=1'
+      return '/api/notifications?status=unread&page=1'
+    } else if (params.get('page')) {
+      return `/api/notifications.json?${params}`
+    } else {
+      return '/api/notifications?page=1'
     }
-    return `/api/notifications.json?${params}`
   }
 
   const { data, error } = useSWR(url, fetcher)

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -422,4 +422,13 @@ class NotificationsTest < ApplicationSystemTestCase
       assert_no_selector '.a-notification-count'
     end
   end
+
+  test 'Unread and All buttons should always be displayed' do
+    user = users(:kimura)
+    visit_with_auth '/notifications', user.login_name
+    assert_selector '.pill-nav__item-link.is-active'
+
+    visit '/notifications?status=unread&target=check'
+    assert_selector '.pill-nav__item-link.is-active'
+  end
 end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -262,7 +262,9 @@ class NotificationsTest < ApplicationSystemTestCase
       visit "/reports/#{report}"
       fill_in 'new_comment[description]', with: 'コメントと確認した'
       click_button '確認OKにする'
+      assert_text 'コメントと確認した'
       visit_with_auth "/reports/#{report}", 'hatsuno'
+      assert_text 'コメントと確認した'
       find('.header-links__link.test-show-notifications').click
       assert_text 'hatsunoさんの【 「コメントと」の日報 】にkomagataさんがコメントしました。'
     end
@@ -270,6 +272,7 @@ class NotificationsTest < ApplicationSystemTestCase
 
   test 'notify user class name role contains' do
     visit_with_auth '/', 'komagata'
+    assert_text '7日以上経過'
     find('.header-links__link.test-show-notifications').click
     assert_selector 'span.a-user-role.is-admin'
     assert_selector 'span.a-user-role.is-student'


### PR DESCRIPTION
## Issue

- #7002 

## 概要
* iOS17以前で通知ページにアクセスすると、大量のデータが表示される不具合を修正しました。
* 通知ページの各タブの"全て"、"未読"ボタンが一律で全てタブの内容を表示してしまう不具合を修正しました。
* 未読でフィルタリングしていない状態で、通知が無い状態を示すメッセージが「未読の通知はありません」になる不具合を修正しました。
* 通知が無い状態で"全て"、"未読"ボタンが表示されない不具合を修正しました。
* Flakyなテストを修正しました。

## 変更確認方法
### 事前準備
1. bug/fix-notifications-first-page-with-iOSをローカルに取り込む

### iOSでの表示確認
<details><summary>WSL2環境の場合のサーバー起動手順</summary>

1. https://qiita.com/yosse95ai/items/691be530a3f183f113b0 を参考にWSLへのポートフォワードを設定する

2. config/environments/development.rb で以下を書き換える
`config.action_controller.asset_host = "http://<ホストコンピューターのIPアドレス>:3000"`

3. config/webpacker.ymlで以下を書き換える
```
dev_server:
    host: 0.0.0.0
    public: http://<ホストコンピューターのIPアドレス>:3035
```

4. `rails s -b 0.0.0.0`でサーバーを立ちあげる
5. `bin/webpack-dev-server` を実行する
---
</details>

<details><summary>Mac環境の場合のサーバー起動手順</summary>

 [簡単localhost:3000をスマホ（iPhone）でも確認する方法 \#Rails \- Qiita](https://qiita.com/i3no29/items/dc70cf04c30223e6f8b0) を参考にrailsサーバーを起動する

</details>

1. iOS17以前のiOS端末からbootcampアプリにアクセスする。
5. ID:hatsuno でログインする
6. /notifications?status=unread にアクセスする
7. 通知が20件表示されていることを確認する

### "全て"、"未読"ボタンの挙動確認
1. ID:sotugyouでログインする
2. localhost:3000/notifications?status=unread&target=announcement にアクセスする
3. ページネーションの上にある"全てボタン"をクリックし、お知らせカテゴリの内容だけを表示することを確認する

### "未読"、"全て"ボタンの表示確認
1. http://localhost:3000/notifications?status=unread&target=following_report にアクセスする
2. 通知が無い状態で"未読"、"全て"ボタンが表示されることを確認する

### 通知が無い状態を示すメッセージの確認
1. 全てボタンをクリックする
2. 画面に「通知はありません」と表示されることを確認する

## Screenshot
### iOSでの表示確認
#### 変更前
![S__524294](https://github.com/fjordllc/bootcamp/assets/99132547/d250f71c-6e20-464b-b37d-4943926579a1)
~
![S__524292](https://github.com/fjordllc/bootcamp/assets/99132547/9dc77c84-df5e-44ef-9f6e-e6c3c9151efc)


#### 変更後
![S__524296](https://github.com/fjordllc/bootcamp/assets/99132547/1505ed8c-ae36-410b-9edc-5885b651e55d)
~
![S__524295](https://github.com/fjordllc/bootcamp/assets/99132547/27a80322-d19d-42bd-92f6-57a7b6822afd)

### "全て"、"未読"ボタンの挙動確認
#### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/99132547/4f47959f-41ca-4156-8fdc-b50cfefb7675)

#### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/99132547/a2d18212-fbb2-4e39-a829-c36ea29d9a2a)

### "未読"、"全て"ボタンの表示確認
#### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/99132547/c89d793e-762e-4799-938b-da9db0757462)

#### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/99132547/5c4bf0fd-b493-4d5e-91e6-17ee132203fb)


### 通知が無い状態を示すメッセージの確認
#### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/99132547/703b4ca5-9614-4867-bf5c-67d972773ee7)

#### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/99132547/f96a75d3-da54-4ac4-b9f9-58dfd5fcf925)

