### PR TITLE
ハッシュの値を省略し警告を解消

### DIFF
--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -42,7 +42,7 @@
                 i.fa-solid.fa-copy
                 | コピー
 
-  = render('regular_event_meta', regular_event: regular_event)
+  = render('regular_event_meta', regular_event:)
 
   .a-card
     .card-header.is-sm
@@ -57,7 +57,7 @@
         = regular_event.description
 
     - unless regular_event.wip? || regular_event.all
-      = render 'regular_events/participation', regular_event: regular_event
+      = render 'regular_events/participation', regular_event:
     = render 'reactions/reactions', reactionable: regular_event
     - if admin_or_mentor_login? || regular_event.organizers.ids.include?(current_user.id)
       hr.a-border-tint

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -69,7 +69,7 @@
                 .card-list.a-card
                   - if @products.present?
                     - @products.each do |product|
-                      = render partial: 'product', locals: { product: product }
+                      = render partial: 'product', locals: { product: }
                   - else
                     .card-list__message
                       .container

--- a/app/views/talks/_nav.html.slim
+++ b/app/views/talks/_nav.html.slim
@@ -3,4 +3,4 @@ nav.tab-nav
     ul.tab-nav__items
       - API::TalksController::TARGETS.each do |target|
         li.tab-nav__item
-          = link_to t("target.#{target}"), talks_path(target: target), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'
+          = link_to t("target.#{target}"), talks_path(target:), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -83,7 +83,7 @@
                       = link_to 'ユーザー情報変更', edit_admin_user_path(@talk.user), class: 'card-main-actions__action a-button is-sm is-secondary is-block'
                     .user-statuses__item
                       = form_with model: @user, local: true, url: user_job_seek_path(@user), class: 'form', html: { name: 'jobseeking' } do |f|
-                        = render 'talks/seeking_switch', f: f
+                        = render 'talks/seeking_switch', f:
                     .user-statuses__item
                       .graduation_button
                         - if @user.graduated_on?


### PR DESCRIPTION
## Issue

- [slim\-lint 対応\-4 · Issue \#6997](https://github.com/fjordllc/bootcamp/issues/6997)

## 概要

上記Issueに記載されている対象のファイルで警告が出ている箇所を修正しました。

- 出ていた警告
`[W] RuboCop: Style/HashSyntax: Omit the hash value.`

- 対象ファイル
> - app/views/regular_events/_regular_event.html.slim
> - app/views/reports/show.html.slim
> - app/views/talks/_nav.html.slim
> - app/views/talks/show.html.slim

- 削除済みのため、修正対象外になったファイル
>  - app/views/products/unchecked/_nav.html.slim

## 変更確認方法
1. `bug/fix-slim-lint-issues-6997`をローカルに取り込む
2. `config/slim_lint.yml`に追加されていた除外ルール（`- Style/HashSyntax`）を削除
3. `bundle exec slim-lint app/views -c config/slim_lint.yml`または`bundle exec slim-lint {対象のファイルパス} -c config/slim_lint.yml`を実行し、警告が解消されているかを確認


## Screenshot
以下、変更前後の`bundle exec slim-lint {対象のファイルパス} -c config/slim_lint.yml`の実行結果です。

※Issue作成時点ではなく最新の状態を取得した結果のため、上記Issueでslim-lintに引っかかってる対象のファイルの行が異なる箇所があります。

### 変更前

- `app/views/regular_events/_regular_event.html.slim`

<img width="759" alt="before_app:views:regular_events:_regular_event html slim" src="https://github.com/fjordllc/bootcamp/assets/104631303/ad3d1736-e8ed-4717-a05c-d12d3aec2b6c">

- `app/views/reports/show.html.slim`

<img width="639" alt="before_app:views:reports:show html slim" src="https://github.com/fjordllc/bootcamp/assets/104631303/2f334ae1-0807-4cfe-ba11-d3546c096850">

- `app/views/talks/_nav.html.slim`

<img width="615" alt="before_app:views:talks:_nav html slim" src="https://github.com/fjordllc/bootcamp/assets/104631303/e3492418-46b8-4d00-97a9-d111846e6132">

- `app/views/talks/show.html.slim`

<img width="627" alt="before_app:views:talks:show html slim" src="https://github.com/fjordllc/bootcamp/assets/104631303/e3f6acfd-1f88-4e4a-8521-c62560b57b68">

### 変更後

- `app/views/regular_events/_regular_event.html.slim`

<img width="711" alt="after_app:views:regular_events:_regular_event html slim" src="https://github.com/fjordllc/bootcamp/assets/104631303/a92fb463-8ced-45b8-9340-f7e798eca5b5">

- `app/views/reports/show.html.slim`

<img width="620" alt="after_app:views:reports:show html slim" src="https://github.com/fjordllc/bootcamp/assets/104631303/b1e239f6-eb60-46de-aecf-a91851ab6aeb">

- `app/views/talks/_nav.html.slim`

<img width="585" alt="after_app:views:talks:_nav html slim" src="https://github.com/fjordllc/bootcamp/assets/104631303/9c8a7768-7b8d-4179-b2e0-61c08f89bd8c">

- `app/views/talks/show.html.slim`

<img width="583" alt="after_app:views:talks:show html slim" src="https://github.com/fjordllc/bootcamp/assets/104631303/c1b1bd6a-6d9f-4671-b9ff-73080409d77b">
