### PR TITLE
メンターページプラクティス一覧の所属カテゴリの表示を変更

### DIFF
--- a/app/javascript/components/mentor-practices.vue
+++ b/app/javascript/components/mentor-practices.vue
@@ -21,8 +21,8 @@
           a(:href='`/practices/${practice.id}`')
             | {{ practice.title }}
         td.admin-table__item-value.is-text-align-right
-          .a-text-link(@click='openModal(practice)')
-            | {{ practice.categories_practice.size }}
+          p(v-for='category_id_name in practice.category_ids_names')
+            | {{ category_id_name.category_name }}
         td.admin-table__item-value.is-text-align-right(
           v-if='practice.submission')
           a(:href='`/practices/${practice.id}/products`')


### PR DESCRIPTION
## Issue

- [メンターページ / プラクティス一覧 所属カテゴリーを数字ではなく、カテゴリー名を全て表示したい。 #6850](https://github.com/fjordllc/bootcamp/issues/6850)

## 概要
[メンターページ/プラクティス一覧](http://localhost:3000/mentor/practices)の所属カテゴリーの表示を、数字（リンクあり）→カテゴリ名（リンクなし）に変更
![image](https://github.com/fjordllc/bootcamp/assets/78665068/7b7ff6aa-31f2-4194-bc20-46891fb9f6e1)

## 変更確認方法

1. feature/change-category-of-practice-list-on-mentor-page-number-to-nameをローカルに取り込む。
2. http://localhost:3000/mentor/practices にメンターモードでアクセスする。
3. プラクティス一覧から任意のプラクティスの編集ボタンをクリックし、複数カテゴリにチェックをいれる。
<img width="1506" alt="image" src="https://github.com/fjordllc/bootcamp/assets/78665068/bcf00572-aa91-48d9-ae65-f146caff8890">
4. http://localhost:3000/mentor/practices を再度表示し、所属カテゴリ列に各プラクティスが登録されているカテゴリ名が全て表示されていることを確認する。


## Screenshot

### 変更前
<img width="980" alt="Pasted Graphic 9" src="https://github.com/fjordllc/bootcamp/assets/78665068/f1e8c16b-a218-41fc-9eb7-d080fc3aa60e">

### 変更後
<img width="987" alt="Pasted Graphic 10" src="https://github.com/fjordllc/bootcamp/assets/78665068/595b0487-bcce-49dd-af66-d9573bb01a33">

