### PR TITLE
通知ページのユーザーアイコンからプロフィールページに飛べるように変更

### DIFF
--- a/app/javascript/components/Notification.jsx
+++ b/app/javascript/components/Notification.jsx
@@ -17,7 +17,6 @@ export default function Notification({ notification }) {
       <div className="card-list-item__inner">
         <div className="card-list-item__user">
           <UserIcon
-            key={notification.id}
             user={notification.sender}
             blockClassSuffix="card-list-item"
           />

--- a/app/javascript/components/Notification.jsx
+++ b/app/javascript/components/Notification.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import UserIcon from './UserIcon'
 import dayjs from 'dayjs'
 import ja from 'dayjs/locale/ja'
 dayjs.locale(ja)
@@ -7,7 +8,6 @@ export default function Notification({ notification }) {
   const createdAt = dayjs(notification.created_at).format(
     'YYYY年MM月DD日(ddd) HH:mm'
   )
-  const roleClass = `is-${notification.sender.primary_role}`
 
   return (
     <div
@@ -16,10 +16,10 @@ export default function Notification({ notification }) {
       }`}>
       <div className="card-list-item__inner">
         <div className="card-list-item__user">
-          <img
-            className={`card-list-item__user-icon a-user-icon ${roleClass}`}
-            title={notification.sender.icon_title}
-            src={notification.sender.avatar_url}
+          <UserIcon
+            key={notification.id}
+            user={notification.sender}
+            blockClassSuffix="card-list-item"
           />
         </div>
         <div className="card-list-item__rows">


### PR DESCRIPTION
## Issue

- [通知ページのユーザーアイコンからプロフィールページに飛べるようにしたい · Issue \#6581](https://github.com/fjordllc/bootcamp/issues/6581)

## 概要
通知ページのユーザーアイコンからプロフィールページに飛べるように変更しました。

## 変更確認方法

1. `feature/add-profile-link-on-notification-page-user-icon`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. `hatsuno`（下記Screenshotで使用しているため、推奨）またはその他任意の**通知が存在する**アカウントでログイン
4. [通知](http://localhost:3000/notifications?status=unread)ページで任意のタブを開く
5. ユーザーアイコンをクリックすると、アイコンのユーザーのプロフィールページに飛べることを確認する

## Screenshot

### 変更前

アイコンをクリックしてもユーザーのプロフィールページに飛ばない（ページ遷移しない）

[![Image from Gyazo](https://i.gyazo.com/005063574a60a7aa1da784847656cdff.gif)](https://gyazo.com/005063574a60a7aa1da784847656cdff)

### 変更後

アイコンをクリックするとアイコンのユーザーのプロフィールページに飛ぶ

[![Image from Gyazo](https://i.gyazo.com/9b4b4c97f46eff0c4ada137217becad1.gif)](https://gyazo.com/9b4b4c97f46eff0c4ada137217becad1)
