### PR TITLE
未ログイン時のmeta description表示のテストファイル名を統一

### DIFF
--- a/test/system/practice/completion_test.rb
+++ b/test/system/practice/completion_test.rb
@@ -8,14 +8,6 @@ class Practice::CompletionTest < ApplicationSystemTestCase
     assert_text '「OS X Mountain Lionをクリーンインストールする」'
   end
 
-  test 'appropriate meta description is displayed when accessed by non-logged-in user' do
-    visit "/practices/#{practices(:practice1).id}"
-
-    assert_selector 'head', visible: false do
-      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「#{practices(:practice1).title}」のページです。']", visible: false
-    end
-  end
-
   test 'completion ogp image is displayed' do
     practice = practices(:practice1)
     visit_with_auth "/mentor/practices/#{practice.id}/edit", 'komagata'

--- a/test/system/practice/not_logged_in_test.rb
+++ b/test/system/practice/not_logged_in_test.rb
@@ -28,4 +28,12 @@ class Practice::NotLoggedInTest < ApplicationSystemTestCase
     assert_equal 'ogp.png', ogp_image
     assert_equal 'ogp.png', twitter_card_image
   end
+
+  test 'appropriate meta description is displayed when accessed by non-logged-in user' do
+    visit "/practices/#{practices(:practice1).id}"
+
+    assert_selector 'head', visible: false do
+      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「#{practices(:practice1).title}」のページです。']", visible: false
+    end
+  end
 end


### PR DESCRIPTION
## Issue

- [未ログイン時のmeta description表示のテストファイル名を統一したい · Issue \#6524](https://github.com/fjordllc/bootcamp/issues/6524)

## 概要

## 変更確認方法

1. `feature/unify-test-file-names-for-display-meta-description-without-login`をローカルに取り込む
2. 以下2つのファイルを開き、テストが正しい箇所に記載されていることを確認する
- 未ログイン時のテストを記載するファイル`test/system/practice/not_logged_in_test.rb`に記載されていることを確認
- `test/system/practice/completion_test.rb`に記載されていないことを確認

↓記載箇所を確認するテストコード
```ruby
  test 'appropriate meta description is displayed when accessed by non-logged-in user' do
    visit "/practices/#{practices(:practice1).id}"

    assert_selector 'head', visible: false do
      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「#{practices(:practice1).title}」のページです。']", visible: false
    end
  end
```

## Screenshot

以下、変更前後のテストコード記載箇所です。

### 変更前

`test/system/practice/completion_test.rb`に`test 'appropriate meta description is displayed when accessed by non-logged-in user' `の記載が有り

![スクリーンショット 2023-11-15 23 14 14](https://github.com/fjordllc/bootcamp/assets/104631303/a0f38b4e-3e3e-4b0b-b3c1-660b894df219)

`test/system/practice/not_logged_in_test.rb`には`test 'appropriate meta description is displayed when accessed by non-logged-in user' `の記載は無し

![スクリーンショット 2023-11-15 23 15 25](https://github.com/fjordllc/bootcamp/assets/104631303/f192a3c1-5ce9-4b57-8b24-77791d54d8e9)


### 変更後

`test/system/practice/completion_test.rb`に`test 'appropriate meta description is displayed when accessed by non-logged-in user' `の記載は無し

![スクリーンショット 2023-11-15 23 17 39](https://github.com/fjordllc/bootcamp/assets/104631303/9961cb68-e44a-4066-b9b3-e45ab40da79c)

`test/system/practice/not_logged_in_test.rb`には`test 'appropriate meta description is displayed when accessed by non-logged-in user' `の記載が有り

![スクリーンショット 2023-11-15 23 12 30](https://github.com/fjordllc/bootcamp/assets/104631303/2369b665-d378-474d-8b7d-c834a0cb07ef)
