### PR TITLE
Talksテーブルのunrepliedカラムを削除した

### DIFF
--- a/db/migrate/20231120101451_remove_unreplied_from_talks.rb
+++ b/db/migrate/20231120101451_remove_unreplied_from_talks.rb
@@ -1,0 +1,5 @@
+class RemoveUnrepliedFromTalks < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :talks, :unreplied, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_01_031818) do
+ActiveRecord::Schema.define(version: 2023_11_20_101451) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -667,7 +667,6 @@ ActiveRecord::Schema.define(version: 2023_10_01_031818) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "unreplied", default: false, null: false
     t.boolean "action_completed", default: true, null: false
     t.index ["user_id"], name: "index_talks_on_user_id"
   end


### PR DESCRIPTION
## Issue

- #6673

## 概要
Talksテーブルからunrepliedのカラムを削除するmigrationファイルを作成しました。
## 変更確認方法

1. `feature/delete_unreplied_column_in_talks_table`をローカルに取り込む
2. `db/migrate/20231120101451_remove_unreplied_from_talks.rb`のmigrationファイルが存在することを確認する
3. `rails db:migrate`を実行する
4. `schema.rb`を確認し、Talksテーブルからunrepliedのカラムが削除されたことを確認する



## Screenshot

### 変更前
<img width="569" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/b7eb96fe-98c4-45ed-8683-25f05f012313">

### 変更後
<img width="576" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/a974302a-113d-481d-8d6e-0595ed9df714">

