### PR TITLE
定期イベントの次回開催日が祝日を考慮するように修正

### DIFF
--- a/app/decorators/regular_event_decorator.rb
+++ b/app/decorators/regular_event_decorator.rb
@@ -13,7 +13,7 @@ module RegularEventDecorator
     if finished
       '開催終了'
     elsif holding_today?
-      '本日開催'
+      !hold_national_holiday && HolidayJp.holiday?(Time.zone.today) ? "次回の開催日は #{l next_event_date} です" : '本日開催'
     else
       "次回の開催日は #{l next_event_date} です"
     end

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -132,9 +132,9 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def calculate_date_of_specific_nth_day_of_the_week(repeat_rule, first_day, days_of_the_week_count)
     # 次の第n X曜日の日付を計算する
-    date = (repeat_rule.frequency - 1) * days_of_the_week_count + repeat_rule.day_of_the_week - first_day.wday + 1
-    date += days_of_the_week_count if repeat_rule.day_of_the_week < first_day.wday
-    Date.new(first_day.year, first_day.mon, date)
+    specific_date = (repeat_rule.frequency - 1) * days_of_the_week_count + repeat_rule.day_of_the_week - first_day.wday + 1
+    specific_date += days_of_the_week_count if repeat_rule.day_of_the_week < first_day.wday
+    Date.new(first_day.year, first_day.mon, specific_date)
   end
 
   def holding_tomorrow?

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -114,13 +114,13 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def possible_next_event_date(first_day, repeat_rule)
     return next_specific_day_of_the_week(repeat_rule) if repeat_rule.frequency.zero?
 
-    possible_date = next_month_specific_day_of_the_week(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
+    possible_date = calculate_nth_weekday_date(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
 
     return possible_date if hold_national_holiday
 
     while possible_date.mon == first_day.mon && HolidayJp.holiday?(possible_date)
       first_day = first_day.next_month
-      possible_date = next_month_specific_day_of_the_week(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
+      possible_date = calculate_nth_weekday_date(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
     end
     possible_date
   end
@@ -132,7 +132,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     possible_date
   end
 
-  def next_month_specific_day_of_the_week(repeat_rule, first_day, days_of_the_week_count)
+  def calculate_nth_weekday_date(repeat_rule, first_day, days_of_the_week_count)
     # 次の第n X曜日の日付を計算する
     date = (repeat_rule.frequency - 1) * days_of_the_week_count + repeat_rule.day_of_the_week - first_day.wday + 1
     date += days_of_the_week_count if repeat_rule.day_of_the_week < first_day.wday

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -112,13 +112,13 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def possible_next_event_date(first_day, repeat_rule)
     return next_specific_day_of_the_week(repeat_rule) if repeat_rule.frequency.zero?
 
-    possible_date = calculate_nth_weekday_date(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
+    possible_date = calculate_date_of_specific_nth_day_of_the_week(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
 
     return possible_date if hold_national_holiday
 
     while possible_date.mon == first_day.mon && HolidayJp.holiday?(possible_date)
       first_day = first_day.next_month
-      possible_date = calculate_nth_weekday_date(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
+      possible_date = calculate_date_of_specific_nth_day_of_the_week(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
     end
     possible_date
   end
@@ -130,7 +130,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     possible_date
   end
 
-  def calculate_nth_weekday_date(repeat_rule, first_day, days_of_the_week_count)
+  def calculate_date_of_specific_nth_day_of_the_week(repeat_rule, first_day, days_of_the_week_count)
     # 次の第n X曜日の日付を計算する
     date = (repeat_rule.frequency - 1) * days_of_the_week_count + repeat_rule.day_of_the_week - first_day.wday + 1
     date += days_of_the_week_count if repeat_rule.day_of_the_week < first_day.wday

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -110,19 +110,31 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def possible_next_event_date(first_day, repeat_rule)
-    if repeat_rule.frequency.zero?
-      next_specific_day_of_the_week(repeat_rule) if Time.zone.today.mon == first_day.mon
-    else
-      # 次の第n X曜日の日付を計算する
-      date = (repeat_rule.frequency - 1) * DAYS_OF_THE_WEEK_COUNT + repeat_rule.day_of_the_week - first_day.wday + 1
-      date += DAYS_OF_THE_WEEK_COUNT if repeat_rule.day_of_the_week < first_day.wday
-      Date.new(first_day.year, first_day.mon, date)
+    return next_specific_day_of_the_week(repeat_rule) if repeat_rule.frequency.zero?
+
+    possible_date = next_month_specific_day_of_the_week(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
+
+    return possible_date if hold_national_holiday
+
+    while possible_date.mon == first_day.mon && HolidayJp.holiday?(possible_date)
+      first_day = first_day.next_month
+      possible_date = next_month_specific_day_of_the_week(repeat_rule, first_day, DAYS_OF_THE_WEEK_COUNT)
     end
+    possible_date
   end
 
   def next_specific_day_of_the_week(repeat_rule)
     day_of_the_week_symbol = DateAndTime::Calculations::DAYS_INTO_WEEK.key(repeat_rule.day_of_the_week)
-    0.days.ago.next_occurring(day_of_the_week_symbol).to_date
+    possible_date = 0.days.ago.next_occurring(day_of_the_week_symbol).to_date
+    possible_date = possible_date.next_occurring(day_of_the_week_symbol) while !hold_national_holiday && HolidayJp.holiday?(possible_date)
+    possible_date
+  end
+
+  def next_month_specific_day_of_the_week(repeat_rule, first_day, days_of_the_week_count)
+    # 次の第n X曜日の日付を計算する
+    date = (repeat_rule.frequency - 1) * days_of_the_week_count + repeat_rule.day_of_the_week - first_day.wday + 1
+    date += days_of_the_week_count if repeat_rule.day_of_the_week < first_day.wday
+    Date.new(first_day.year, first_day.mon, date)
   end
 
   def holding_tomorrow?

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -78,6 +78,8 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def holding_today?
+    return false if !hold_national_holiday && HolidayJp.holiday?(Time.zone.today)
+
     now = Time.current
     event_day = regular_event_repeat_rules.map do |repeat_rule|
       if repeat_rule.frequency.zero?

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -78,8 +78,6 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def holding_today?
-    return false if !hold_national_holiday && HolidayJp.holiday?(Time.zone.today)
-
     now = Time.current
     event_day = regular_event_repeat_rules.map do |repeat_rule|
       if repeat_rule.frequency.zero?

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -84,3 +84,13 @@ regular_event_repeat_rule34:
   frequency: 0
   day_of_the_week: 1
   regular_event: regular_event32
+
+regular_event_repeat_rule35:
+  frequency: 0
+  day_of_the_week: 3
+  regular_event: regular_event33
+
+regular_event_repeat_rule36:
+  frequency: 1
+  day_of_the_week: 3
+  regular_event: regular_event34

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -155,14 +155,3 @@ regular_event32:
   user: komagata
   category: 0
   published_at: "2023-08-01 00:00:00"
-
-regular_event33:
-  title: 次回開催日確認用、祝日非開催イベント(水曜日開催)
-  description: 次回開催日確認用、祝日非開催イベント(水曜日開催)
-  finished: false
-  hold_national_holiday: false
-  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
-  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
-  user: komagata
-  category: 0
-  published_at: "2023-08-01 00:00:00"

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -155,3 +155,14 @@ regular_event32:
   user: komagata
   category: 0
   published_at: "2023-08-01 00:00:00"
+
+regular_event33:
+  title: 次回開催日確認用、祝日非開催イベント(水曜日開催)
+  description: 次回開催日確認用、祝日非開催イベント(水曜日開催)
+  finished: false
+  hold_national_holiday: false
+  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
+  user: komagata
+  category: 0
+  published_at: "2023-08-01 00:00:00"

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -48,6 +48,13 @@ class RegularEventTest < ActiveSupport::TestCase
       first_day = Time.zone.today
       assert_equal Date.new(2022, 6, 5), regular_event.possible_next_event_date(first_day, regular_event_repeat_rule)
     end
+
+    holiday_not_held_event = regular_events(:regular_event33)
+    repeat_rule = regular_event_repeat_rules(:regular_event_repeat_rule36) # 第1週水曜日
+    travel_to Time.zone.local(2020, 1, 1, 0, 0, 0) do
+      first_day = Time.zone.today
+      assert_equal Date.new(2020, 2, 5), holiday_not_held_event.possible_next_event_date(first_day, repeat_rule)
+    end
   end
 
   test '#next_specific_day_of_the_week' do
@@ -55,6 +62,13 @@ class RegularEventTest < ActiveSupport::TestCase
     regular_event_repeat_rule = regular_event_repeat_rules(:regular_event_repeat_rule1)
     travel_to Time.zone.local(2022, 6, 1, 0, 0, 0) do
       assert_equal Date.new(2022, 6, 5), regular_event.next_specific_day_of_the_week(regular_event_repeat_rule)
+    end
+
+    holiday_not_held_event = regular_events(:regular_event33)
+    repeat_rule = regular_event_repeat_rules(:regular_event_repeat_rule35) # 毎週水曜日
+    travel_to Time.zone.local(2020, 1, 1, 0, 0, 0) do
+      first_day = Time.zone.today
+      assert_equal Date.new(2020, 1, 8), holiday_not_held_event.possible_next_event_date(first_day, repeat_rule)
     end
   end
 

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -49,7 +49,7 @@ class RegularEventTest < ActiveSupport::TestCase
       assert_equal Date.new(2022, 6, 5), regular_event.possible_next_event_date(first_day, regular_event_repeat_rule)
     end
 
-    holiday_not_held_event = regular_events(:regular_event33)
+    holiday_not_held_event = regular_events(:regular_event1)
     repeat_rule = regular_event_repeat_rules(:regular_event_repeat_rule36) # 第1週水曜日
     travel_to Time.zone.local(2020, 1, 1, 0, 0, 0) do
       first_day = Time.zone.today
@@ -64,7 +64,7 @@ class RegularEventTest < ActiveSupport::TestCase
       assert_equal Date.new(2022, 6, 5), regular_event.next_specific_day_of_the_week(regular_event_repeat_rule)
     end
 
-    holiday_not_held_event = regular_events(:regular_event33)
+    holiday_not_held_event = regular_events(:regular_event1)
     repeat_rule = regular_event_repeat_rules(:regular_event_repeat_rule35) # 毎週水曜日
     travel_to Time.zone.local(2020, 1, 1, 0, 0, 0) do
       first_day = Time.zone.today

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -72,6 +72,17 @@ class RegularEventTest < ActiveSupport::TestCase
     end
   end
 
+  test '#calculate_nth_weekday_date' do
+    regular_event = regular_events(:regular_event1)
+    repeat_rule = regular_event_repeat_rules(:regular_event_repeat_rule2)
+    days_of_the_week_count = 7
+
+    travel_to Time.zone.local(2020, 1, 1, 0, 0, 0) do
+      first_day = Time.zone.today
+      assert_equal Date.new(2020, 1, 6), regular_event.calculate_nth_weekday_date(repeat_rule, first_day, days_of_the_week_count)
+    end
+  end
+
   test '#holding_tomorrow?' do
     regular_event = regular_events(:regular_event1)
     travel_to Time.zone.local(2023, 2, 25, 0, 0, 0) do

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -72,14 +72,14 @@ class RegularEventTest < ActiveSupport::TestCase
     end
   end
 
-  test '#calculate_nth_weekday_date' do
+  test '#calculate_date_of_specific_nth_day_of_the_week' do
     regular_event = regular_events(:regular_event1)
     repeat_rule = regular_event_repeat_rules(:regular_event_repeat_rule2)
     days_of_the_week_count = 7
 
     travel_to Time.zone.local(2020, 1, 1, 0, 0, 0) do
       first_day = Time.zone.today
-      assert_equal Date.new(2020, 1, 6), regular_event.calculate_nth_weekday_date(repeat_rule, first_day, days_of_the_week_count)
+      assert_equal Date.new(2020, 1, 6), regular_event.calculate_date_of_specific_nth_day_of_the_week(repeat_rule, first_day, days_of_the_week_count)
     end
   end
 


### PR DESCRIPTION
## Issue

- #6487

## 概要
定期イベント個別ページに表示している次回開催日が祝日を考慮しておらず、祝日非開催の場合でも祝日が開催予定に含まれて日付や予定が表示されてしまう点を修正しました。
## 変更確認方法

1.`bug/skip_regular_events_on_holidays`をローカルに取り込む
2. OS本体の時刻を2023年1月1日に変更する
3. http://localhost:3000/regular_events にて定期イベント作成のボタンを押下する
4. 開催頻度が「毎週月曜日」、祝日の開催にチェックを入れず「祝日非開催」の定期イベントを作成する
5. 作成した定期イベントの個別ページに表示される「次回開催日」が1月2日(振替休日)、1月9日(成人の日)をスキップして、1月16日になっていることを確認する
6. 定期イベント作成のボタンを押下する
7. 開催頻度が「第1日曜日」、祝日の開催にチェックを入れず「祝日非開催」の定期イベントを作成する
8. 作成した定期イベントの個別ページに表示される「次回開催日」が1月1日(元旦)をスキップして、2月5日になっていることを確認する
## Screenshot


### 変更前
<img width="781" alt="image 2" src="https://github.com/fjordllc/bootcamp/assets/88243294/24b45118-4040-41e6-b008-eb8bae507a30">
<img width="788" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/6fc09fd3-fcb3-434e-bc7d-53521f73cc09">

### 変更後
<img width="786" alt="image 4" src="https://github.com/fjordllc/bootcamp/assets/88243294/b968f779-775d-4fc8-918a-f9b5c58149a9">
<img width="781" alt="image 3" src="https://github.com/fjordllc/bootcamp/assets/88243294/f6396bf6-7963-418e-8b52-c981fac2fc16">
