### PR TITLE
User.users_roleの修正をおこなった

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -9,7 +9,7 @@ class Admin::UsersController < AdminController
     @target = params[:target]
     user_scope = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
     @users = user_scope.with_attached_avatar
-                       .preload(%i[company course])
+                       .preload(:company, :course)
                        .order_by_counts(params[:order_by] || 'id', @direction)
     @emails = user_scope.pluck(:email)
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,7 +6,7 @@ class Admin::UsersController < AdminController
 
   def index
     @direction = params[:direction] || 'desc'
-    @target = params[:target] || 'student_and_trainee'
+    @target = params[:target]
     @users = User.with_attached_avatar
                  .preload(%i[company course])
                  .order_by_counts(params[:order_by] || 'id', @direction)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,6 +2,7 @@
 
 class Admin::UsersController < AdminController
   before_action :set_user, only: %i[show edit update]
+  TARGETS = %w[all student_and_trainee inactive hibernated retired graduate adviser mentor trainee year_end_party campaign].freeze
 
   def index
     @direction = params[:direction] || 'desc'
@@ -9,8 +10,8 @@ class Admin::UsersController < AdminController
     @users = User.with_attached_avatar
                  .preload(%i[company course])
                  .order_by_counts(params[:order_by] || 'id', @direction)
-                 .users_role(@target)
-    @emails = User.users_role(@target).pluck(:email)
+                 .users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee')
+    @emails = User.users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee').pluck(:email)
   end
 
   def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@
 
 class Admin::UsersController < AdminController
   before_action :set_user, only: %i[show edit update]
-  TARGETS = %w[all student_and_trainee inactive hibernated retired graduate adviser mentor trainee year_end_party campaign].freeze
+  ALLOWED_TARGETS = %w[all student_and_trainee inactive hibernated retired graduate adviser mentor trainee year_end_party campaign].freeze
 
   def index
     @direction = params[:direction] || 'desc'
@@ -10,8 +10,8 @@ class Admin::UsersController < AdminController
     @users = User.with_attached_avatar
                  .preload(%i[company course])
                  .order_by_counts(params[:order_by] || 'id', @direction)
-                 .users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee')
-    @emails = User.users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee').pluck(:email)
+                 .users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
+    @emails = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee').pluck(:email)
   end
 
   def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,11 +7,11 @@ class Admin::UsersController < AdminController
   def index
     @direction = params[:direction] || 'desc'
     @target = params[:target]
-    @users = User.with_attached_avatar
-                 .preload(%i[company course])
-                 .order_by_counts(params[:order_by] || 'id', @direction)
-                 .users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
-    @emails = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee').pluck(:email)
+    user_scope = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
+    @users = user_scope.with_attached_avatar
+                       .preload(%i[company course])
+                       .order_by_counts(params[:order_by] || 'id', @direction)
+    @emails = user_scope.pluck(:email)
   end
 
   def show

--- a/app/controllers/api/generations_controller.rb
+++ b/app/controllers/api/generations_controller.rb
@@ -6,7 +6,7 @@ class API::GenerationsController < API::BaseController
 
   def show
     generation = params[:id].to_i
-    @users = Generation.new(generation).users.page(params[:page]).per(PAGER_NUMBER)
+    @users = Generation.new(generation).same_generation_users.page(params[:page]).per(PAGER_NUMBER)
   end
 
   def index

--- a/app/controllers/api/generations_controller.rb
+++ b/app/controllers/api/generations_controller.rb
@@ -6,7 +6,7 @@ class API::GenerationsController < API::BaseController
 
   def show
     generation = params[:id].to_i
-    @users = Generation.new(generation).same_generation_users.page(params[:page]).per(PAGER_NUMBER)
+    @users = Generation.new(generation).classmates.page(params[:page]).per(PAGER_NUMBER)
   end
 
   def index

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -15,10 +15,10 @@ class API::TalksController < API::BaseController
         @talks.merge(
           User.search_by_keywords({ word: params[:search_word] })
               .unscope(where: :retired_on)
-              .users_role(@target)
+              .users_role(@target, allowed_targets: TARGETS, default_target: 'all')
         )
       else
-        @talks.merge(User.users_role(@target))
+        @talks.merge(User.users_role(@target, allowed_targets: TARGETS, default_target: 'all'))
               .page(params[:page]).per(PAGER_NUMBER)
       end
   end

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -12,7 +12,7 @@ class API::TalksController < API::BaseController
     users = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
     @talks =
       if params[:search_word]
-        searched_users = users.search_by_keywords({ word: params[:search_word] }).unscope(where: :retired_on)
+        searched_users = users.search_by_keywords(word: params[:search_word]).unscope(where: :retired_on)
         @talks.merge(
           @target == 'retired' ? searched_users.retired : searched_users
         )

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -13,9 +13,9 @@ class API::TalksController < API::BaseController
     @talks =
       if params[:search_word]
         # search_by_keywords内では { unretired } というスコープが設定されている
-        # 引退したユーザーも検索対象に含めたいので、unscope(where: :retired_on) で上記のスコープを削除
+        # 退会したユーザーも検索対象に含めたいので、unscope(where: :retired_on) で上記のスコープを削除
         searched_users = users.search_by_keywords(word: params[:search_word]).unscope(where: :retired_on)
-        # 引退したユーザーに絞ってキーワード検索を行う場合は、retired スコープを設定する
+        # もし検索対象が退会したユーザーである場合、searched_usersには退会していないユーザーも含まれているため、retired スコープを設定する
         searched_users = searched_users.retired if @target == 'retired'
         @talks.merge(searched_users)
       else

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -6,7 +6,6 @@ class API::TalksController < API::BaseController
 
   def index
     @target = params[:target]
-    @target = 'all' unless ALLOWED_TARGETS.include?(@target)
     @talks = Talk.joins(:user)
                  .includes(user: [{ avatar_attachment: :blob }, :discord_profile])
                  .order(updated_at: :desc, id: :asc)

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -12,10 +12,11 @@ class API::TalksController < API::BaseController
     users = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
     @talks =
       if params[:search_word]
-        searched_users = users.search_by_keywords(word: params[:search_word]).unscope(where: :retired_on)
         # search_by_keywords内では { unretired } というスコープが設定されている
-        # 引退したユーザーに対しキーワード検索を行う場合は、一旦 unscope(where: :retired_on) で { unretired } スコープを削除し、その後で retired スコープを設定する必要がある
-        searched_users = searched_users.unscope(where: :retired_on).retired if @target == 'retired'
+        # 引退したユーザーも検索対象に含めたいので、unscope(where: :retired_on) で上記のスコープを削除
+        searched_users = users.search_by_keywords(word: params[:search_word]).unscope(where: :retired_on)
+        # 引退したユーザーに絞ってキーワード検索を行う場合は、retired スコープを設定する
+        searched_users = searched_users.retired if @target == 'retired'
         @talks.merge(searched_users)
       else
         @talks.merge(users)

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class API::TalksController < API::BaseController
-  TARGETS = %w[all student_and_trainee mentor graduate adviser trainee retired].freeze
+  ALLOWED_TARGETS = %w[all student_and_trainee mentor graduate adviser trainee retired].freeze
   PAGER_NUMBER = 20
 
   def index
     @target = params[:target]
-    @target = 'all' unless TARGETS.include?(@target)
+    @target = 'all' unless ALLOWED_TARGETS.include?(@target)
     @talks = Talk.joins(:user)
                  .includes(user: [{ avatar_attachment: :blob }, :discord_profile])
                  .order(updated_at: :desc, id: :asc)
@@ -15,10 +15,10 @@ class API::TalksController < API::BaseController
         @talks.merge(
           User.search_by_keywords({ word: params[:search_word] })
               .unscope(where: :retired_on)
-              .users_role(@target, allowed_targets: TARGETS, default_target: 'all')
+              .users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
         )
       else
-        @talks.merge(User.users_role(@target, allowed_targets: TARGETS, default_target: 'all'))
+        @talks.merge(User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'all'))
               .page(params[:page]).per(PAGER_NUMBER)
       end
   end

--- a/app/controllers/api/talks_controller.rb
+++ b/app/controllers/api/talks_controller.rb
@@ -13,9 +13,10 @@ class API::TalksController < API::BaseController
     @talks =
       if params[:search_word]
         searched_users = users.search_by_keywords(word: params[:search_word]).unscope(where: :retired_on)
-        @talks.merge(
-          @target == 'retired' ? searched_users.retired : searched_users
-        )
+        # search_by_keywords内では { unretired } というスコープが設定されている
+        # 引退したユーザーに対しキーワード検索を行う場合は、一旦 unscope(where: :retired_on) で { unretired } スコープを削除し、その後で retired スコープを設定する必要がある
+        searched_users = searched_users.unscope(where: :retired_on).retired if @target == 'retired'
+        @talks.merge(searched_users)
       else
         @talks.merge(users)
               .page(params[:page]).per(PAGER_NUMBER)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -13,7 +13,7 @@ class API::UsersController < API::BaseController
     @target = target_allowlist.include?(params[:target]) ? params[:target] : 'student_and_trainee'
 
     users = target_users
-    users.order(:last_activity_at) if @target == 'inactive'
+    users = users.order(:last_activity_at) if @target == 'inactive'
     @users = users
              .preload(:company, :avatar_attachment, :course, :tags)
              .order(updated_at: :desc)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -59,7 +59,7 @@ class API::UsersController < API::BaseController
     elsif @tag
       User.tagged_with(@tag)
     else
-      user_scope =
+      users_scope =
         if @company
           User.where(company_id: @company)
         elsif @target.in? %w[hibernated retired]
@@ -67,7 +67,7 @@ class API::UsersController < API::BaseController
         else
           User.unhibernated.unretired
         end
-      user_scope.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
+      users_scope.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
     end
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -67,7 +67,7 @@ class API::UsersController < API::BaseController
         else
           User.unhibernated.unretired
         end
-      users_scope.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
+      users_scope.users_role(@target, allowed_targets: target_allowlist)
     end
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -13,7 +13,11 @@ class API::UsersController < API::BaseController
     @target = target_allowlist.include?(params[:target]) ? params[:target] : 'student_and_trainee'
 
     target_users = retrieve_target_users
-    @users = target_users.page(params[:page]).per(PAGER_NUMBER).preload(:company, :avatar_attachment, :course, :tags).order(updated_at: :desc)
+    @users = target_users
+             .preload(:company, :avatar_attachment, :course, :tags)
+             .order(updated_at: :desc)
+             .page(params[:page])
+             .per(PAGER_NUMBER)
 
     @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -14,13 +14,16 @@ class API::UsersController < API::BaseController
 
     users = target_users
     users = users.order(:last_activity_at) if @target == 'inactive'
-    @users = users
-             .preload(:company, :avatar_attachment, :course, :tags)
-             .order(updated_at: :desc)
-             .page(params[:page])
-             .per(PAGER_NUMBER)
-
-    @users = search_for_users(@target, users, params[:search_word]) if params[:search_word]
+    @users =
+      if params[:search_word]
+        search_for_users(@target, users, params[:search_word])
+      else
+        users
+          .preload(:company, :avatar_attachment, :course, :tags)
+          .order(updated_at: :desc)
+          .page(params[:page])
+          .per(PAGER_NUMBER)
+      end
   end
 
   def show; end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -37,6 +37,8 @@ class API::UsersController < API::BaseController
 
   def search_for_users(target, target_users, search_word)
     users = target_users.search_by_keywords({ word: search_word })
+    # search_by_keywords内では { unretired } というスコープが設定されている
+    # 引退したユーザーに対しキーワード検索を行う場合は、一旦 unscope(where: :retired_on) で { unretired } スコープを削除し、その後で retired スコープを設定する必要がある
     target == 'retired' ? users.unscope(where: :retired_on).retired : users
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -12,14 +12,14 @@ class API::UsersController < API::BaseController
 
     @target = target_allowlist.include?(params[:target]) ? params[:target] : 'student_and_trainee'
 
-    target_users = retrieve_target_users
-    @users = target_users
+    users = target_users
+    @users = users
              .preload(:company, :avatar_attachment, :course, :tags)
              .order(updated_at: :desc)
              .page(params[:page])
              .per(PAGER_NUMBER)
 
-    @users = search_for_users(@target, target_users, params[:search_word]) if params[:search_word]
+    @users = search_for_users(@target, users, params[:search_word]) if params[:search_word]
   end
 
   def show; end
@@ -47,8 +47,8 @@ class API::UsersController < API::BaseController
     target_allowlist
   end
 
-  def retrieve_target_users
-    target_users =
+  def target_users
+    users =
       if @target == 'followings'
         current_user.followees_list(watch: @watch)
       elsif @tag
@@ -61,7 +61,7 @@ class API::UsersController < API::BaseController
         User.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee').unhibernated.unretired
       end
 
-    @target == 'inactive' ? target_users.order(:last_activity_at) : target_users
+    @target == 'inactive' ? users.order(:last_activity_at) : users
   end
 
   def set_user

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -41,7 +41,7 @@ class API::UsersController < API::BaseController
   def search_for_users(target, target_users, search_word)
     users = target_users.search_by_keywords({ word: search_word })
     # search_by_keywords内では { unretired } というスコープが設定されている
-    # 引退したユーザーに対しキーワード検索を行う場合は、一旦 unscope(where: :retired_on) で { unretired } スコープを削除し、その後で retired スコープを設定する必要がある
+    # 退会したユーザーに対しキーワード検索を行う場合は、一旦 unscope(where: :retired_on) で { unretired } スコープを削除し、その後で retired スコープを設定する必要がある
     target == 'retired' ? users.unscope(where: :retired_on).retired : users
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -36,11 +36,7 @@ class API::UsersController < API::BaseController
 
   def search_for_users(target, target_users, search_word)
     users = target_users.search_by_keywords({ word: search_word })
-    if target == 'retired'
-      users = User.search_by_keywords({ word: search_word }).unscope(where: :retired_on)
-                  .users_role(target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
-    end
-    users
+    target == 'retired' ? users.unscope(where: :retired_on).retired : users
   end
 
   def target_allowlist

--- a/app/controllers/companies/users_controller.rb
+++ b/app/controllers/companies/users_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class Companies::UsersController < ApplicationController
-  TARGETS = %w[all student_and_trainee graduate adviser mentor].freeze
+  ALLOWED_TARGETS = %w[all student_and_trainee graduate adviser mentor].freeze
 
   def index
     @target = params[:target]
-    @target = 'student_and_trainee' unless TARGETS.include?(@target)
+    @target = 'student_and_trainee' unless ALLOWED_TARGETS.include?(@target)
     @company = Company.find(params[:company_id])
 
-    target_users = User.users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee')
+    target_users = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
 
     @users = target_users.with_attached_avatar.where(company: @company).order(updated_at: :desc)
   end

--- a/app/controllers/companies/users_controller.rb
+++ b/app/controllers/companies/users_controller.rb
@@ -8,7 +8,7 @@ class Companies::UsersController < ApplicationController
     @target = 'student_and_trainee' unless ALLOWED_TARGETS.include?(@target)
     @company = Company.find(params[:company_id])
 
-    target_users = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
+    target_users = User.users_role(@target, allowed_targets: ALLOWED_TARGETS)
 
     @users = target_users.with_attached_avatar.where(company: @company).order(updated_at: :desc)
   end

--- a/app/controllers/companies/users_controller.rb
+++ b/app/controllers/companies/users_controller.rb
@@ -8,7 +8,7 @@ class Companies::UsersController < ApplicationController
     @target = 'student_and_trainee' unless TARGETS.include?(@target)
     @company = Company.find(params[:company_id])
 
-    target_users = User.users_role(@target)
+    target_users = User.users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee')
 
     @users = target_users.with_attached_avatar.where(company: @company).order(updated_at: :desc)
   end

--- a/app/controllers/generations_controller.rb
+++ b/app/controllers/generations_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class GenerationsController < ApplicationController
-  TARGETS = %w[all trainee adviser graduate mentor retired].freeze
+  ALLOWED_TARGETS = %w[all trainee adviser graduate mentor retired].freeze
 
   def show
     @generation = params[:id].to_i
   end
 
   def index
-    @target = TARGETS.include?(params[:target]) ? params[:target] : TARGETS.first
+    @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
     redirect_to root_path, alert: '管理者としてログインしてください' if @target == 'retired' && !current_user.admin?
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -9,7 +9,6 @@ class TalksController < ApplicationController
 
   def index
     @target = params[:target]
-    @target = 'all' unless API::TalksController::ALLOWED_TARGETS.include?(@target)
   end
 
   def show; end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -9,7 +9,7 @@ class TalksController < ApplicationController
 
   def index
     @target = params[:target]
-    @target = 'all' unless API::TalksController::TARGETS.include?(@target)
+    @target = 'all' unless API::TalksController::ALLOWED_TARGETS.include?(@target)
   end
 
   def show; end

--- a/app/controllers/users/companies_controller.rb
+++ b/app/controllers/users/companies_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Users::CompaniesController < ApplicationController
-  TARGETS = %w[all trainee adviser graduate mentor].freeze
+  ALLOWED_TARGETS = %w[all trainee adviser graduate mentor].freeze
 
   def index
-    @target = TARGETS.include?(params[:target]) ? params[:target] : TARGETS.first
+    @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
       elsif params[:tag]
         User.tagged_with(params[:tag])
       else
-        users = User.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
+        users = User.users_role(@target, allowed_targets: target_allowlist)
         @target == 'inactive' ? users.order(:last_activity_at) : users
       end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,7 @@ class UsersController < ApplicationController
         User.tagged_with(params[:tag])
       else
         User.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
+            .then { |users| @target == 'inactive' ? users.order(:last_activity_at) : users }
       end
 
     @users = target_users

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,8 +18,8 @@ class UsersController < ApplicationController
       elsif params[:tag]
         User.tagged_with(params[:tag])
       else
-        User.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
-            .then { |users| @target == 'inactive' ? users.order(:last_activity_at) : users }
+        users = User.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
+        @target == 'inactive' ? users.order(:last_activity_at) : users
       end
 
     @users = target_users

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
       elsif params[:tag]
         User.tagged_with(params[:tag])
       else
-        User.users_role(@target)
+        User.users_role(@target, allowed_targets: target_allowlist, default_target: 'student_and_trainee')
       end
 
     @users = target_users

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -41,6 +41,7 @@ class Generation
 
   def target_users(target)
     users = classmates.users_role(target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
+    # 退会者は「退会」フィルター時のみ表示させたいため、絞り込みを行う
     target == 'retired' ? users : users.unretired
   end
 end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -40,7 +40,7 @@ class Generation
   end
 
   def target_users(target)
-    users = classmates.users_role(target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
+    users = classmates.users_role(target, allowed_targets: ALLOWED_TARGETS)
     # 退会者は「退会」フィルター時のみ表示させたいため、絞り込みを行う
     target == 'retired' ? users : users.unretired
   end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -2,7 +2,7 @@
 
 class Generation
   START_YEAR = 2013
-  TARGETS = %w[all trainee adviser graduate mentor retired].freeze
+  ALLOWED_TARGETS = %w[all trainee adviser graduate mentor retired].freeze
 
   class << self
     def generations(target)
@@ -40,7 +40,7 @@ class Generation
   end
 
   def target_users(target)
-    target_users = users.users_role(target, allowed_targets: TARGETS, default_target: 'all')
+    target_users = users.users_role(target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
     target == 'retired' ? target_users : target_users.unretired
   end
 end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -35,12 +35,12 @@ class Generation
     (next_generation.start_date - 1).end_of_day
   end
 
-  def same_generation_users
-    User.with_attached_avatar.same_generations(start_date, end_date)
+  def classmates
+    User.with_attached_avatar.classmates(start_date, end_date)
   end
 
   def target_users(target)
-    users = same_generation_users.users_role(target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
+    users = classmates.users_role(target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
     target == 'retired' ? users : users.unretired
   end
 end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -2,6 +2,7 @@
 
 class Generation
   START_YEAR = 2013
+  TARGETS = %w[all trainee adviser graduate mentor retired].freeze
 
   class << self
     def generations(target)
@@ -39,7 +40,7 @@ class Generation
   end
 
   def target_users(target)
-    target_users = users.users_role(target)
+    target_users = users.users_role(target, allowed_targets: TARGETS, default_target: 'all')
     target == 'retired' ? target_users : target_users.unretired
   end
 end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -35,12 +35,12 @@ class Generation
     (next_generation.start_date - 1).end_of_day
   end
 
-  def users
+  def same_generation_users
     User.with_attached_avatar.same_generations(start_date, end_date)
   end
 
   def target_users(target)
-    target_users = users.users_role(target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
-    target == 'retired' ? target_users : target_users.unretired
+    users = same_generation_users.users_role(target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
+    target == 'retired' ? users : users.unretired
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -397,12 +397,8 @@ class User < ApplicationRecord
     # allowed_targets:　呼び出したいscope名に対応するtargetを過不足なく指定した配列。
     # default_target: targetに不正な値が渡された際、users_roleが返すスコープ名に対応するtargetを指定する。デフォルトでは:noneを指定しているため何も返さない。
     def users_role(target, allowed_targets: [], default_target: :none)
-      scope_name =
-        if (ALL_ALLOWED_TARGETS & allowed_targets).include?(target)
-          TARGET_TO_SCOPE.fetch(target, target)
-        else
-          TARGET_TO_SCOPE.fetch(default_target, default_target)
-        end
+      key = (ALL_ALLOWED_TARGETS & allowed_targets).include?(target) ? target : default_target
+      scope_name = TARGET_TO_SCOPE.fetch(key, key)
       send(scope_name)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -397,8 +397,12 @@ class User < ApplicationRecord
     # allowed_targets:　呼び出したいscope名に対応するtargetを過不足なく指定した配列。
     # default_target: targetに不正な値が渡された際、users_roleが返すスコープ名に対応するtargetを指定する。デフォルトでは:noneを指定しているため何も返さない。
     def users_role(target, allowed_targets: [], default_target: :none)
-      default_scope = TARGET_TO_SCOPE.fetch(default_target, default_target)
-      scope_name = (ALL_ALLOWED_TARGETS & allowed_targets).include?(target) ? TARGET_TO_SCOPE.fetch(target, target) : default_scope
+      scope_name =
+        if (ALL_ALLOWED_TARGETS & allowed_targets).include?(target)
+          TARGET_TO_SCOPE.fetch(target, target)
+        else
+          TARGET_TO_SCOPE.fetch(default_target, default_target)
+        end
       send(scope_name)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -397,8 +397,7 @@ class User < ApplicationRecord
     # allowed_targets:　呼び出したいscope名に対応するtargetを過不足なく指定した配列。
     # default_target: targetに不正な値が渡された際、users_roleが返すスコープ名に対応するtargetを指定する。デフォルトでは:noneを指定しているため何も返さない。
     def users_role(target, allowed_targets: [], default_target: :none)
-      default_scope = (ALL_ALLOWED_TARGETS & allowed_targets).include?(default_target) ? TARGET_TO_SCOPE.fetch(default_target, default_target) : :none
-      scope_name = (ALL_ALLOWED_TARGETS & allowed_targets).include?(target) ? TARGET_TO_SCOPE.fetch(target, target) : default_scope
+      scope_name = (ALL_ALLOWED_TARGETS & allowed_targets).include?(target) ? TARGET_TO_SCOPE.fetch(target, target) : default_target
       send(scope_name)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -397,7 +397,8 @@ class User < ApplicationRecord
     # allowed_targets:　呼び出したいscope名に対応するtargetを過不足なく指定した配列。
     # default_target: targetに不正な値が渡された際、users_roleが返すスコープ名に対応するtargetを指定する。デフォルトでは:noneを指定しているため何も返さない。
     def users_role(target, allowed_targets: [], default_target: :none)
-      scope_name = (ALL_ALLOWED_TARGETS & allowed_targets).include?(target) ? TARGET_TO_SCOPE.fetch(target, target) : default_target
+      default_scope = TARGET_TO_SCOPE.fetch(default_target, default_target)
+      scope_name = (ALL_ALLOWED_TARGETS & allowed_targets).include?(target) ? TARGET_TO_SCOPE.fetch(target, target) : default_scope
       send(scope_name)
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -345,7 +345,7 @@ class User < ApplicationRecord
       order(order_by.to_sym => direction.to_sym, created_at: :asc)
     end
   }
-  scope :same_generations, lambda { |start_date, end_date|
+  scope :classmates, lambda { |start_date, end_date|
     where(created_at: start_date..end_date).order(:created_at, :id)
   }
   scope :desc_tagged_with, lambda { |tag_name|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -397,7 +397,8 @@ class User < ApplicationRecord
     # allowed_targets:　呼び出したいscope名に対応するtargetを過不足なく指定した配列。
     # default_target: targetに不正な値が渡された際、users_roleが返すスコープ名に対応するtargetを指定する。デフォルトでは:noneを指定しているため何も返さない。
     def users_role(target, allowed_targets: [], default_target: :none)
-      scope_name = (ALL_ALLOWED_TARGETS & allowed_targets).include?(target) ? TARGET_TO_SCOPE.fetch(target, target) : default_target
+      default_scope = (ALL_ALLOWED_TARGETS & allowed_targets).include?(default_target) ? TARGET_TO_SCOPE.fetch(default_target, default_target) : :none
+      scope_name = (ALL_ALLOWED_TARGETS & allowed_targets).include?(target) ? TARGET_TO_SCOPE.fetch(target, target) : default_scope
       send(scope_name)
     end
 

--- a/app/views/api/users/companies/_company.json.jbuilder
+++ b/app/views/api/users/companies/_company.json.jbuilder
@@ -6,5 +6,5 @@ json.description company.description
 json.logo_url company.logo_url
 json.users_url company_users_url(company)
 
-targets = %w[all trainee adviser graduate mentor]
-json.users company.users.users_role(@target, allowed_targets: targets, default_target: 'all').order(:id), partial: "api/users/user", as: :user
+allowed_targets = %w[all trainee adviser graduate mentor]
+json.users company.users.users_role(@target, allowed_targets: allowed_targets, default_target: 'all').order(:id), partial: "api/users/user", as: :user

--- a/app/views/api/users/companies/_company.json.jbuilder
+++ b/app/views/api/users/companies/_company.json.jbuilder
@@ -7,5 +7,5 @@ json.logo_url company.logo_url
 json.users_url company_users_url(company)
 
 allowed_targets = %w[all trainee adviser graduate mentor]
-users = company.users.users_role(@target, allowed_targets: allowed_targets, default_target: 'all').order(:id)
+users = company.users.users_role(@target, allowed_targets: allowed_targets).order(:id)
 json.users users, partial: "api/users/user", as: :user

--- a/app/views/api/users/companies/_company.json.jbuilder
+++ b/app/views/api/users/companies/_company.json.jbuilder
@@ -7,5 +7,5 @@ json.logo_url company.logo_url
 json.users_url company_users_url(company)
 
 allowed_targets = %w[all trainee adviser graduate mentor]
-users = company.users.users_role(@target, allowed_targets: allowed_targets).order(:id)
+users = company.users.users_role(target, allowed_targets: allowed_targets).order(:id)
 json.users users, partial: "api/users/user", as: :user

--- a/app/views/api/users/companies/_company.json.jbuilder
+++ b/app/views/api/users/companies/_company.json.jbuilder
@@ -7,4 +7,5 @@ json.logo_url company.logo_url
 json.users_url company_users_url(company)
 
 allowed_targets = %w[all trainee adviser graduate mentor]
-json.users company.users.users_role(@target, allowed_targets: allowed_targets, default_target: 'all').order(:id), partial: "api/users/user", as: :user
+users = company.users.users_role(@target, allowed_targets: allowed_targets, default_target: 'all').order(:id)
+json.users users, partial: "api/users/user", as: :user

--- a/app/views/api/users/companies/_company.json.jbuilder
+++ b/app/views/api/users/companies/_company.json.jbuilder
@@ -6,4 +6,5 @@ json.description company.description
 json.logo_url company.logo_url
 json.users_url company_users_url(company)
 
-json.users company.users.users_role(@target).order(:id), partial: "api/users/user", as: :user
+targets = %w[all trainee adviser graduate mentor]
+json.users company.users.users_role(@target, allowed_targets: targets, default_target: 'all').order(:id), partial: "api/users/user", as: :user

--- a/app/views/api/users/companies/index.json.jbuilder
+++ b/app/views/api/users/companies/index.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.array! @companies, partial: "api/users/companies/company", as: :company
+json.array! @companies, partial: "api/users/companies/company", as: :company, target: @target

--- a/app/views/companies/users/_users_tabs.html.slim
+++ b/app/views/companies/users/_users_tabs.html.slim
@@ -1,6 +1,6 @@
 nav.tab-nav
   .container
     ul.tab-nav__items
-        - Companies::UsersController::TARGETS.each do |target|
+        - Companies::UsersController::ALLOWED_TARGETS.each do |target|
           li.tab-nav__item
             = link_to t("target.#{target}"), company_users_path(target:), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/talks/_nav.html.slim
+++ b/app/views/talks/_nav.html.slim
@@ -1,6 +1,6 @@
 nav.tab-nav
   .container
     ul.tab-nav__items
-      - API::TalksController::TARGETS.each do |target|
+      - API::TalksController::ALLOWED_TARGETS.each do |target|
         li.tab-nav__item
           = link_to t("target.#{target}"), talks_path(target:), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/users/companies/_users_tabs.html.slim
+++ b/app/views/users/companies/_users_tabs.html.slim
@@ -1,6 +1,6 @@
 nav.tab-nav
   .container
     ul.tab-nav__items
-      - Users::CompaniesController::TARGETS.each do |target|
+      - Users::CompaniesController::ALLOWED_TARGETS.each do |target|
         li.tab-nav__item
           = link_to t("target.#{target}"), users_companies_path(target:), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -14,13 +14,13 @@ class GenerationTest < ActiveSupport::TestCase
     assert_equal Time.zone.local(2020, 12, 31).end_of_day, Generation.new(32).end_date
   end
 
-  test '#users' do
-    assert_includes Generation.new(5).same_generation_users, users(:komagata)
-    assert_includes Generation.new(29).same_generation_users, users(:jobseeker)
+  test '#classmates' do
+    assert_includes Generation.new(5).classmates, users(:komagata)
+    assert_includes Generation.new(29).classmates, users(:jobseeker)
     users(:komagata).created_at = Time.zone.local(2020, 12, 31, 23, 59, 59)
     users(:komagata).save
-    assert_includes Generation.new(32).same_generation_users, users(:komagata)
-    assert_not_includes Generation.new(33).same_generation_users, users(:komagata)
+    assert_includes Generation.new(32).classmates, users(:komagata)
+    assert_not_includes Generation.new(33).classmates, users(:komagata)
   end
 
   test '#target_users' do

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -15,12 +15,12 @@ class GenerationTest < ActiveSupport::TestCase
   end
 
   test '#users' do
-    assert_includes Generation.new(5).users, users(:komagata)
-    assert_includes Generation.new(29).users, users(:jobseeker)
+    assert_includes Generation.new(5).same_generation_users, users(:komagata)
+    assert_includes Generation.new(29).same_generation_users, users(:jobseeker)
     users(:komagata).created_at = Time.zone.local(2020, 12, 31, 23, 59, 59)
     users(:komagata).save
-    assert_includes Generation.new(32).users, users(:komagata)
-    assert_not_includes Generation.new(33).users, users(:komagata)
+    assert_includes Generation.new(32).same_generation_users, users(:komagata)
+    assert_not_includes Generation.new(33).same_generation_users, users(:komagata)
   end
 
   test '#target_users' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -676,5 +676,6 @@ class UserTest < ActiveSupport::TestCase
     assert_equal User.students_and_trainees, User.users_role(not_allowed_target, allowed_targets: allowed_targets, default_target: 'student_and_trainee')
     not_scope_name = 'destroy_all'
     assert_equal User.students_and_trainees, User.users_role(not_scope_name, allowed_targets: allowed_targets, default_target: 'student_and_trainee')
+    assert_empty User.users_role(not_scope_name, allowed_targets: allowed_targets)
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -660,24 +660,16 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test '.users_role' do
-    allowed_targets = %w[student_and_trainee]
-    assert_equal User.students_and_trainees, User.users_role('student_and_trainee', allowed_targets: allowed_targets, default_target: 'student_and_trainee')
+    allowed_targets = %w[student_and_trainee mentor graduate adviser trainee year_end_party]
+    assert_equal User.mentor, User.users_role('mentor', allowed_targets: allowed_targets, default_target: 'student_and_trainee')
+    assert_equal User.students_and_trainees, User.users_role('', allowed_targets: allowed_targets, default_target: 'student_and_trainee')
   end
 
   test '.users_role return default_target when invalid target is passed' do
-    allowed_targets = %w[student_and_trainee]
-    invalid_target = 'retired'
-    assert_equal User.students_and_trainees, User.users_role(invalid_target, allowed_targets: allowed_targets, default_target: 'student_and_trainee')
-  end
-
-  test '.users_role return default_target when invalid allwed_targets is passed' do
-    invalid_allowed_targets = %w[student_and_trainee working]
-    assert_equal User.students_and_trainees, User.users_role('working', allowed_targets: invalid_allowed_targets, default_target: 'student_and_trainee')
-  end
-
-  test '.users_role return nothing when invalid default_target is passed' do
-    invalid_default_target = 'retired'
-    # default_target で指定したスコープが呼ばれるように引数 target と allowed_targets を指定する
-    assert_empty User.users_role('invalid', allowed_targets: [], default_target: invalid_default_target)
+    allowed_targets = %w[student_and_trainee mentor graduate adviser trainee year_end_party]
+    not_allowed_target = 'retired'
+    assert_equal User.students_and_trainees, User.users_role(not_allowed_target, allowed_targets: allowed_targets, default_target: 'student_and_trainee')
+    not_scope_name = 'destroy_all'
+    assert_equal User.students_and_trainees, User.users_role(not_scope_name, allowed_targets: allowed_targets, default_target: 'student_and_trainee')
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -670,7 +670,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal User.students_and_trainees, User.users_role('', allowed_targets: allowed_targets, default_target: 'student_and_trainee')
   end
 
-  test '.users_role return default_target when invalid target is passed' do
+  test '.users_role returns default_target when invalid target is passed' do
     allowed_targets = %w[student_and_trainee mentor graduate adviser trainee year_end_party]
     not_allowed_target = 'retired'
     assert_equal User.students_and_trainees, User.users_role(not_allowed_target, allowed_targets: allowed_targets, default_target: 'student_and_trainee')

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -661,7 +661,12 @@ class UserTest < ActiveSupport::TestCase
 
   test '.users_role' do
     allowed_targets = %w[student_and_trainee mentor graduate adviser trainee year_end_party]
+
+    # target引数とdefault_target引数に関して、targetとscope名が一致しているケースと一致していないケースを順にテストする
     assert_equal User.mentor, User.users_role('mentor', allowed_targets: allowed_targets, default_target: 'student_and_trainee')
+    assert_equal User.graduated, User.users_role('graduate', allowed_targets: allowed_targets, default_target: 'student_and_trainee')
+
+    assert_equal User.year_end_party, User.users_role('', allowed_targets: allowed_targets, default_target: 'year_end_party')
     assert_equal User.students_and_trainees, User.users_role('', allowed_targets: allowed_targets, default_target: 'student_and_trainee')
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -658,4 +658,26 @@ class UserTest < ActiveSupport::TestCase
     user.become_watcher!(watchable)
     assert user.watches.exists?(watchable:)
   end
+
+  test '.users_role' do
+    allowed_targets = %w[student_and_trainee]
+    assert_equal User.students_and_trainees, User.users_role('student_and_trainee', allowed_targets: allowed_targets, default_target: 'student_and_trainee')
+  end
+
+  test '.users_role return default_target when invalid target is passed' do
+    allowed_targets = %w[student_and_trainee]
+    invalid_target = 'retired'
+    assert_equal User.students_and_trainees, User.users_role(invalid_target, allowed_targets: allowed_targets, default_target: 'student_and_trainee')
+  end
+
+  test '.users_role return default_target when invalid allwed_targets is passed' do
+    invalid_allowed_targets = %w[student_and_trainee working]
+    assert_equal User.students_and_trainees, User.users_role('working', allowed_targets: invalid_allowed_targets, default_target: 'student_and_trainee')
+  end
+
+  test '.users_role return nothing when invalid default_target is passed' do
+    invalid_default_target = 'retired'
+    # default_target で指定したスコープが呼ばれるように引数 target と allowed_targets を指定する
+    assert_empty User.users_role('invalid', allowed_targets: [], default_target: invalid_default_target)
+  end
 end


### PR DESCRIPTION
## Issue

- #6511 

## 概要
`User.users_role`内でユーザから送られてきた値を`send`が渡していますが、現状実装者とレビュワーが不正な値が実行されないように気をつけて運用するという形になっています。

このままですとリスキーなため、`Use.users_role`に関して以下の修正を行いました。
- 引数として、呼び出したい(スコープに対応した)ターゲットを指定する`allowed_targets`と、不正な値が渡された時に呼び出される(スコープに対応した)ターゲットを指定する`default_targets`を追加しました
- `users_role`メソッド内で、渡された`target`が不正な値でないかどうか確認を行うようにしました


また、既存の実装では`users_role('inactive')`で返される値は`order(:last_activity_at)`で並び替えを行なっていましたが、メソッド内で並び替えを行わず、メソッドを呼び出す側で並び替えを行うように修正しました。
```ruby
    def users_role(target)
      case target
      when 'inactive'
        inactive.order(:last_activity_at)
```

## 変更確認方法

1. `feature/fix-users_role`をローカルに取り込む
2. `app/models/user.rb`の`users_role`メソッドが変更されていることを確認する
3. `User.users_role`が使用されている箇所(以下参照)が変更されていることを確認する
  - app/controllers/admin/users_controller.rb
  - app/controllers/api/talks_controller.rb
  - app/controllers/api/users_controller.rb
  - app/controllers/companies/users_controller.rb
  - app/controllers/users_controller.rb
  - app/models/generation.rb
  - app/models/user.rb
  - app/views/api/users/companies/_company.json.jbuilder



## order(:last_activity_at) について
`users_role`の引数として`'inactive'`が渡されている箇所は以下の三箇所です。
- app/controllers/admin/users_controller.rb
- app/controllers/api/users_controller.rb
- app/controllers/users_controller.rb

このうちapp/controllers/api/users_controller.rb と app/controllers/users_controller.rb に関しては`order(:last_activity_at)`で並び替えを行いましたが、app/controllers/admin/users_controller.rb は並び替えを行いませんでした。

app/controllers/admin/users_controller.rb 内では、`@users`と`@emails`の2箇所で`users_role`が使われています。

```ruby
  def index
    @direction = params[:direction] || 'desc'
    @target = params[:target] || 'student_and_trainee'
    @users = User.with_attached_avatar
                 .preload(%i[company course])
                 .order_by_counts(params[:order_by] || 'id', @direction)
                 .users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee')
    @emails = User.users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee').pluck(:email)
  end
```

1. `@users`を取得している箇所に関して、`order(:last_activity_at)`で並び替えを行なった際のSQLを確認してみます。
```ruby
    @users = User.with_attached_avatar
                 .preload(%i[company course])
                 .order_by_counts(params[:order_by] || 'id', @direction)
                 .users_role(@target, allowed_targets: TARGETS, default_target: 'student_and_trainee')
                 .then { |users| @target == 'inactive' ? users.order(:last_activity_at) : users }  # 並び替えを追加
```
SQLの実行結果
※ `admin/users?target=inactive`にリクエストが送られた場合を想定。`@direction`は`'desc'`, `params[:order_by]`は`nil`,`@target`は`'inactive'`が格納される。
```
% bin/rails c                                                                                                                                

irb(main):001:0>   TARGETS = %w[all student_and_trainee inactive hibernated retired graduate adviser mentor trainee year_end_party campaign].freeze

irb(main):002:1' puts User.with_attached_avatar.preload(%i[company course]).order_by_counts('id', 'desc').users_role('inactive', allowed_targets: TARGETS, default_targ
et: 'student_and_trainee').then { |users| 'inactive' == 'inactive' ? users.order(:last_activity_at) : users }.to_sql
SELECT "users".* FROM "users" WHERE "users"."last_activity_at" BETWEEN '4713-01-01 BC' AND '2023-10-23 23:36:04.635565' AND "users"."adviser" = FALSE AND "users"."hibernated_at" IS NULL AND "users"."retired_on" IS NULL AND "users"."graduated_on" IS NULL ORDER BY "users"."id" DESC, "users"."created_at" ASC, "users"."last_activity_at" ASC 
```

発行されたSQLは最後に`ORDER BY "users"."id" DESC, "users"."created_at" ASC, "users"."last_activity_at" ASC`で並び替えを行なっています。
`ORDER BY`に複数の式が指定された場合、前の式の値が等しい行を並べ替える際に後の式の値が使用されるため、この並び替えは次の様になります。

[7\.5\. 行の並べ替え\(ORDER BY\)](https://www.postgresql.jp/document/14/html/queries-order.html)

- `id`の値に基づいて降順で並び替える
- `id`の値が同じカラムは`created_at`に基づいて昇順で並び替える
- `created_at`の値が同じカラムは`last_activity`に基づいて昇順で並び替える

`id`の値は全て異なっているため、この並び替えは一番最初の` "users"."id" DESC`で並び順が固定されてしまいます。
そのため、この箇所では`order(:last_activity_at)`による並び替えは不要だと考えました。

2. `@emails`を取得している箇所は、このコードが追加されたPRを確認するとメールアドレスの並び順に関する言及はなかったため、わざわざ並び替える必要性はないかなと判断し、並び替えを行なっていません。

> ユーザー画面下部にある「全員のメアド」には全ページのユーザーのメアドの一覧を表示させるようにしました。

[Admin画面のユーザー一覧にページャーを付ける by yana\-gi · Pull Request \#2847 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/pull/2847)
