### PR TITLE
テスト実行時の"ActionView::Template::Error: Nil location provided. Can't build URI."エラーを回避する

### DIFF
--- a/test/fixtures/active_storage/variant_records.yml
+++ b/test/fixtures/active_storage/variant_records.yml
@@ -1,0 +1,5 @@
+# NOTE:
+# 何らかの理由で active_storage_variant_records テーブルのデータが残ったままになっていた場合、データの不整合が発生して、画像のURLがnilになる。
+# (active_storage_attachments と active_storage_blobs のみが削除されるため）
+# この空のymlファイルを用意することで、テスト実行時に active_storage_variant_records テーブルのデータが削除され、データの不整合を回避できる。
+# (Railsはfixturesにymlファイルがあれば、そのファイル名に合致するテーブルのデータを全件削除する)


### PR DESCRIPTION
https://bootcamp.fjord.jp/questions/1787 で報告されていた問題を修正します。

## 発生していた問題

何らかの理由で `active_storage_variant_records` テーブルが残ったままになっていると、 `PARALLEL_WORKERS=1` でテストを実行した場合に、 "ActionView::Template::Error: Nil location provided. Can't build URI." というエラーが発生する。

## エラーの原因

これまではfixturesに `active_storage_attachments` と `active_storage_blobs` のymlファイルしかなかった。
このためテスト実行時に、

- `active_storage_attachments` → 古いデータは削除される
- `active_storage_blobs` → 古いデータは削除される
- `active_storage_variant_records` → 古いデータは残ったまま

という状態になり、DB上のデータに不整合が発生するため。

## 解決策

fixturesに `active_storage_variant_records` 用のymlファイルを用意して、他のテーブルと同様に古いデータを削除する。
（データの削除が目的なのでymlの中身は空でよい）

## 動作確認手順

### 事前準備

test/test_helper.rb に以下の行を追加する。

```ruby 
class ActiveSupport::TestCase
  # ...
  self.use_transactional_tests = false
  # ...
```

以下のコマンドで任意のテストを実行する。

```
$ PARALLEL_WORKERS=1 bin/rails test test/system/notification/followings_test.rb:15
```

これで、 `active_storage_variant_records` テーブルにデータが残ったままになる。

test/test_helper.rb の変更は元に戻す（ここではコメントアウト）。

```ruby 
class ActiveSupport::TestCase
  # ...
  # self.use_transactional_tests = false
  # ...
```

### 以前の動作

このPRを導入する以前は、テストを実行すると以下のようなエラーが発生する。
（ `active_storage_variant_records` だけが古いデータを保持し、データの不整合が発生するため）

```
$ PARALLEL_WORKERS=1 bin/rails test test/system/notification/followings_test.rb:15
Running via Spring preloader in process 55556
Run options: --seed 7592

# Running:

[Screenshot Image]: /Users/jnito/dev/fjord/bootcamp/tmp/screenshots/failures_test_receive_a_notification_when_following_user_create_a_report.png
E

Error:
Notification::FollowingsTest#test_receive_a_notification_when_following_user_create_a_report:
ActionView::Template::Error: Nil location provided. Can't build URI.
    app/views/users/_profile.html.slim:6
    app/views/users/_profile.html.slim:4
    app/views/users/show.html.slim:39


rails test test/system/notification/followings_test.rb:15


[Minitest::CI] Generating test report in JUnit XML format...


Finished in 3.272485s, 0.3056 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

### このPRの動作

このPRの変更を導入すると、テストがパスする。
（他のActiveStorage関連のテーブルと同様 `active_storage_variant_records` も削除されて、データの不整合がなくなるため）

```
$ PARALLEL_WORKERS=1 bin/rails test test/system/notification/followings_test.rb:15
Running via Spring preloader in process 55811
Run options: --seed 20053

# Running:

.
[Minitest::CI] Generating test report in JUnit XML format...


Finished in 8.344214s, 0.1198 runs/s, 0.3595 assertions/s.
1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```