### PR TITLE
public/assets を .gitignore に追加 + 重複した行を削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ vendor/bundle/
 /yarn-error.log
 
 .byebug_history
+/public/assets
 /public/packs
 /public/packs-test
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ vendor/bundle/
 /public/packs-test
 
 /public/system
-/public/packs
-/public/packs-test
-/node_modules
 yarn-debug.log*
 .yarn-integrity
 
@@ -38,11 +35,5 @@ storage/
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
-/public/packs
-/public/packs-test
-/node_modules
-/yarn-error.log
-yarn-debug.log*
-.yarn-integrity
 .envrc
 /test/reports


### PR DESCRIPTION
デバッグ目的でローカルで `rails assets:precompile` を実行した際に、誤って public/assets 配下のファイルをgit管理されないようにしました。

また、.gitignoreを編集する際に重複した設定をいくつか見つけたので、それも削除しています。