### PR TITLE
ハッシュの値を省略し警告を解消

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -589,6 +589,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,4 +1,4 @@
 - # rubocop:disable Rails/OutputSafety
 li.pagination__item.is-first
-  = link_to_unless current_page.first?, raw('<i class="fas fa-angle-double-left"></i>'), url, remote: remote, class: 'pagination__item-link is-first'
+  = link_to_unless current_page.first?, raw('<i class="fas fa-angle-double-left"></i>'), url, remote:, class: 'pagination__item-link is-first'
 - # rubocop:enable Rails/OutputSafety

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,4 +1,4 @@
 - # rubocop:disable Rails/OutputSafety
 li.pagination__item.is-last
-  = link_to_unless current_page.last?, raw('<i class="fas fa-angle-double-right"></i>'), url, remote: remote, class: 'pagination__item-link is-last'
+  = link_to_unless current_page.last?, raw('<i class="fas fa-angle-double-right"></i>'), url, remote:, class: 'pagination__item-link is-last'
 - # rubocop:enable Rails/OutputSafety

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,4 +1,4 @@
 - # rubocop:disable Rails/OutputSafety
 li.pagination__item.is-next
-  = link_to_unless current_page.last?, raw('<i class="fas fa-angle-right"></i>'), url, rel: 'next', remote: remote, class: 'pagination__item-link is-next'
+  = link_to_unless current_page.last?, raw('<i class="fas fa-angle-right"></i>'), url, rel: 'next', remote:, class: 'pagination__item-link is-next'
 - # rubocop:enable Rails/OutputSafety

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -6,7 +6,7 @@ ruby:
         end
 - if page.current?
   li.pagination__item.is-active
-    = tag.a page, remote: remote, rel: rel, class: 'pagination__item-link is-active'
+    = tag.a page, remote:, rel:, class: 'pagination__item-link is-active'
 - else
   li.pagination__item
-    = link_to page, url, remote: remote, rel: rel, class: 'pagination__item-link'
+    = link_to page, url, remote:, rel:, class: 'pagination__item-link'

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,4 +1,4 @@
 - # rubocop:disable Rails/OutputSafety
 li.pagination__item.is-prev
-  = link_to_unless current_page.first?, raw('<i class="fas fa-angle-left"></i>'), url, rel: 'prev', remote: remote, class: 'pagination__item-link is-prev'
+  = link_to_unless current_page.first?, raw('<i class="fas fa-angle-left"></i>'), url, rel: 'prev', remote:, class: 'pagination__item-link is-prev'
 - # rubocop:enable Rails/OutputSafety

--- a/app/views/notifications/_tabs.html.slim
+++ b/app/views/notifications/_tabs.html.slim
@@ -9,7 +9,7 @@
               = current_user.notifications.unreads.latest_of_each_link.size
       - Notification::TARGETS_TO_KINDS.each_key do |target|
         li.page-tabs__item
-          = link_to notifications_path(status: 'unread', target: target), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip do
+          = link_to notifications_path(status: 'unread', target:), class: "page-tabs__item-link #{'is-active' if @target == target.to_s}".strip do
             = t("notification.#{target}")
             - if ensure_notifications?(target)
               .page-tabs__item-count.a-notification-count

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -12,4 +12,4 @@ header.page-header
 
   .page-body
     .container.is-md
-      = react_component('Products', title: title, selectedTab: 'all', isMentor: mentor_login?, currentUserId: current_user.id)
+      = react_component('Products', title:, selectedTab: 'all', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/app/views/products/self_assigned/index.html.slim
+++ b/app/views/products/self_assigned/index.html.slim
@@ -13,4 +13,4 @@ header.page-header
 
 .page-body
   .container.is-md
-    = react_component('Products', title: title, selectedTab: 'self_assigned', isMentor: mentor_login?, currentUserId: current_user.id)
+    = react_component('Products', title:, selectedTab: 'self_assigned', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -5,7 +5,7 @@
 = render '/shared/modal_learning_completion',
   practice: @product.practice,
   tweet_url: @tweet_url,
-  should_display_message_automatically: @learning&.should_display_message_automatically?(current_user: current_user)
+  should_display_message_automatically: @learning&.should_display_message_automatically?(current_user:)
 
 header.page-header
   .container

--- a/app/views/products/unassigned/index.html.slim
+++ b/app/views/products/unassigned/index.html.slim
@@ -11,4 +11,4 @@ header.page-header
 
 .page-body
   .container.is-lg
-    = react_component('Products', title: title, selectedTab: 'unassigned', isMentor: mentor_login?, currentUserId: current_user.id)
+    = react_component('Products', title:, selectedTab: 'unassigned', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -19,4 +19,4 @@ header.page-header
   hr.a-border
 .page-body
   .container.is-md
-    = react_component('Products', title: title, selectedTab: 'unchecked', isMentor: mentor_login?, currentUserId: current_user.id)
+    = react_component('Products', title:, selectedTab: 'unchecked', isMentor: mentor_login?, currentUserId: current_user.id)

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -39,3 +39,4 @@ linters:
       - Style/Next
       - Style/WhileUntilDo
       - Style/WhileUntilModifier
+      - Style/HashSyntax

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -39,4 +39,4 @@ linters:
       - Style/Next
       - Style/WhileUntilDo
       - Style/WhileUntilModifier
-      - Style/HashSyntax
+#      - Style/HashSyntax

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -39,4 +39,3 @@ linters:
       - Style/Next
       - Style/WhileUntilDo
       - Style/WhileUntilModifier
-#      - Style/HashSyntax


### PR DESCRIPTION
## Issue

- [slim\-lint 対応\-4 · Issue \#6996](https://github.com/fjordllc/bootcamp/issues/6996)

## 概要

上記Issueに記載されている対象のファイルで警告が出ている箇所を修正しました。

`app/views/products/`については、上記Issueに記載されていないファイルでも同様の警告が出たため、
それらのファイルを修正対象として追加しました。

- 出ていた警告
`[W] RuboCop: Style/HashSyntax: Omit the hash value.`

- 対象ファイル
  - app/views/kaminari/_first_page.html.slim
  - app/views/kaminari/_last_page.html.slim
  - app/views/kaminari/_next_page.html.slim
  - app/views/kaminari/_page.html.slim
  - app/views/kaminari/_prev_page.html.slim
  - app/views/notifications/_tabs.html.slim
  - app/views/products/self_assigned/_nav.html.slim
  - app/views/products/show.html.slim

- 対象ファイル（追加分）
  - app/views/products/index.html.slim
  - app/views/products/unassigned/index.html.slim
  - app/views/products/unchecked/index.html.slim

## 変更確認方法
1. `bug/fix-slim-lint-issues-6996`をローカルに取り込む
2. `config/slim_lint.yml`に追加されていた除外ルール（`- Style/HashSyntax`）を削除
3. `bundle exec slim-lint app/views -c config/slim_lint.yml`または`bundle exec slim-lint {対象のファイルパス} -c config/slim_lint.yml`を実行し、警告が解消されているかを確認

## Screenshot
以下、変更前後の`bundle exec slim-lint {対象のファイルパス} -c config/slim_lint.yml`の実行結果です。

※Issue作成時点ではなく最新の状態を取得した結果のため、上記Issueでslim-lintに引っかかってる対象のファイルの行が異なる箇所があります。

### 変更前
- `app/views/kaminari/`
![スクリーンショット 2023-11-25 18 39 35](https://github.com/fjordllc/bootcamp/assets/57088113/f5254ca2-fe33-41d0-ba09-cc76239631cb)

- `app/views/notifications/`
![スクリーンショット 2023-11-25 18 41 06](https://github.com/fjordllc/bootcamp/assets/57088113/d903177a-1eed-4fdb-ba38-0a719d4b1345)

- `app/views/products/`
![スクリーンショット 2023-11-25 18 41 38](https://github.com/fjordllc/bootcamp/assets/57088113/de9335dd-d60b-4231-ba10-b8f91368aed1)

### 変更後
- `app/views/kaminari/`
![スクリーンショット 2023-11-25 22 15 02](https://github.com/fjordllc/bootcamp/assets/57088113/b45ba2cc-79a2-415c-a985-3a88bce552dd)

- `app/views/notifications/`
![スクリーンショット 2023-11-26 10 35 22](https://github.com/fjordllc/bootcamp/assets/57088113/6c2e4549-a177-433a-a557-38cbb6def6ee)

- `app/views/products/`
![スクリーンショット 2023-11-25 22 15 32](https://github.com/fjordllc/bootcamp/assets/57088113/371b6ebd-4bdd-4e1b-8748-ad36fc8504ff)