### PR TITLE
検索クエリでcommented_atを使わないようにする

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -98,10 +98,10 @@ class Product < ApplicationRecord
   end
 
   def self.unchecked_no_replied_products
-    self_last_commented_products = Product.where.not(commented_at: nil).filter do |product|
+    self_last_commented_products =  Product.joins(:comments).where.not(comments: { id: nil }).filter do |product|
       product.comments.last.user_id == product.user.id
     end
-    no_comments_products = Product.where(commented_at: nil)
+    no_comments_products = Product.where.missing(:comments)
     no_replied_products_ids = (self_last_commented_products + no_comments_products).map(&:id)
     Product.where(id: no_replied_products_ids)
            .order(published_at: :asc, id: :asc)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -98,7 +98,7 @@ class Product < ApplicationRecord
   end
 
   def self.unchecked_no_replied_products
-    self_last_commented_products =  Product.joins(:comments).where.not(comments: { id: nil }).filter do |product|
+    self_last_commented_products = Product.joins(:comments).where.not(comments: { id: nil }).filter do |product|
       product.comments.last.user_id == product.user.id
     end
     no_comments_products = Product.where.missing(:comments)


### PR DESCRIPTION
## Issue

- #6965

## 概要
https://bootcamp.fjord.jp/products/unchecked?target=unchecked_no_replied でcommented_atが存在するが、コメントは存在しない提出物が存在し、ページが表示されないという不具合が起きている。
commented_atが存在することをもってコメントが存在することを担保しようとしていたが、実際には何らかの理由でcommented_atは存在するがコメントが存在しないデータが作られることで起こっている。
これを回避するために、検索クエリでcommented_atを使わないように修正した。

## 変更確認方法
### データの準備
1. bug/fix-not-commented-product-displayをローカルに取り込む
2. rails consoleを開く
3. `product = Product.find(613458348)`を実行する
4. `product.commented_at= Time.now`を実行する
5. `product.save!`を実行する

### 表示されることの確認
1. localhost:3000/products/unchecked?target=unchecked_no_replied にアクセスする
2. 正常に表示されることを確認する

## Screenshot
### 修正前
![image](https://github.com/fjordllc/bootcamp/assets/99132547/4bdb658f-ae29-40bd-a62e-e14ec5057c77)

### 修正後
![image](https://github.com/fjordllc/bootcamp/assets/99132547/dbf8d88d-6dbd-46eb-8192-e7e0497da601)

