### PR TITLE
タグ別のユーザーページにおいて「休会」と「退会」ユーザーが表示されない仕様に統一

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -16,7 +16,7 @@ class API::UsersController < API::BaseController
       if @target == 'followings'
         current_user.followees_list(watch: @watch)
       elsif @tag
-        User.tagged_with(@tag)
+        User.tagged_with(@tag).unhibernated.unretired
       elsif @company
         User.where(company_id: @company).users_role(@target)
       elsif @target.in? %w[hibernated retired]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -343,6 +343,7 @@ class User < ApplicationRecord
   scope :desc_tagged_with, lambda { |tag_name|
     with_attached_avatar
       .unretired
+      .unhibernated
       .order(last_activity_at: :desc)
       .tagged_with(tag_name)
   }
@@ -402,7 +403,7 @@ class User < ApplicationRecord
     end
 
     def tags
-      unretired.all_tag_counts(order: 'count desc, name asc')
+      unretired.unhibernated.all_tag_counts(order: 'count desc, name asc')
     end
 
     def depressed_reports

--- a/app/views/tags/_tag.html.slim
+++ b/app/views/tags/_tag.html.slim
@@ -4,7 +4,7 @@
       = link_to users_tag_path(tag.name), class: 'user-group__title-link'
         - rank = users_tags_rank(tag.count, @top3_tags_counts)
         - if rank.present?
-          span.user-group__title-icon(class="#{users_tags_rank(tag.count, @top3_tags_counts)}")
+          span.user-group__title-icon(class="#{rank}")
             i.fa-solid.fa-crown
         span.user-group__title-label
           | #{tag.name}
@@ -12,4 +12,6 @@
           | （#{tag.count}）
   .a-user-icons
     .a-user-icons__items
-      = render partial: 'tags/user', collection: User.desc_tagged_with(tag.name), as: :user
+      = render partial: 'tags/user',
+               collection: User.desc_tagged_with(tag.name),
+               as: :user

--- a/test/fixtures/acts_as_taggable_on/taggings.yml
+++ b/test/fixtures/acts_as_taggable_on/taggings.yml
@@ -23,6 +23,11 @@ machida_tag_guitar:
   context: tags
   tag: guitar
 
+kensyu_tag_guitar:
+  taggable: kensyu (User)
+  context: tags
+  tag: guitar
+
 kimura_tag_cat:
   taggable: kimura (User)
   context: tags


### PR DESCRIPTION
## Issue

- #6525 

## 概要
以下のタグ別ユーザーページにおいて「退会」と「休会」のユーザーが表示されない仕様に統一

- [タグ別ユーザー一覧ページ](https://bootcamp.fjord.jp/users/tags)
- タグ別ページ
  - 例：[タグ「釣り」のページ](https://bootcamp.fjord.jp/users/tags/%E9%87%A3%E3%82%8A)

## 変更確認方法

1. `feature/exclude-hibernated-and-retired-users-from-users-list-by-tag`をローカルに取り込む
2. `foreman start -f Procfile.dev`を実行し、ローカル環境を立ち上げる
3. `localhost:3000`にアクセス
4. `hajime`でログイン
5. `http://localhost:3000/users/tags/.NET_Framework`にアクセスし、ページ右側「このタグを自分に追加」をクリック

![スクリーンショット 2023-11-30 20 41 12](https://github.com/fjordllc/bootcamp/assets/104631303/9779e4ff-6357-4537-88e6-5e71f21e092b)

6. 以下ページから休会または退会手続きを行う

- [休会手続きフォーム](http://localhost:3000/hibernation/new)
- [退会手続きフォーム](http://localhost:3000/retirement/new)

7. 任意のユーザーでログインする
8. [タグ別ユーザー一覧](http://localhost:3000/users/tags)にアクセスし、以下二点を確認する

- `hajime`がユーザー数に含まれていないこと
- `hajime`のアイコンが表示されていないこと

![スクリーンショット 2023-11-30 20 53 24](https://github.com/fjordllc/bootcamp/assets/104631303/1508cf10-165f-40ed-87ce-adbe06280ff6)

9. [タグ「.NET_Framework」のユーザー](http://localhost:3000/users/tags/.NET_Framework)ページにアクセスし、以下二点を確認する

- `hajime`がユーザー数に含まれていないこと
- `hajime`がユーザーとして表示されていないこと

![スクリーンショット 2023-11-30 20 49 24](https://github.com/fjordllc/bootcamp/assets/104631303/39065fec-e000-4844-8f5f-2ad4cf2b3fbf)

## Screenshot

### 変更前

 [タグ別ユーザー一覧](http://localhost:3000/users/tags)で「休会」または「退会」ユーザーもユーザー数に含まれ、アイコンが表示されている

![スクリーンショット 2023-11-30 21 02 38](https://github.com/fjordllc/bootcamp/assets/104631303/3d8a5710-6156-4ffc-b257-8aad836eccef)

[タグ「.NET_Framework」のユーザー](http://localhost:3000/users/tags/.NET_Framework)ページではユーザー数には含まれないが、ユーザー情報は表示されている

![スクリーンショット 2023-11-30 21 05 51](https://github.com/fjordllc/bootcamp/assets/104631303/ce2ddbea-5859-45fb-b2fb-604ee1febedb)

### 変更後

 [タグ別ユーザー一覧](http://localhost:3000/users/tags)で「休会」または「退会」ユーザーはユーザー数に含まず、アイコンも表示されない

![スクリーンショット 2023-11-30 21 15 21](https://github.com/fjordllc/bootcamp/assets/104631303/5eebc1ad-965f-4cba-a8ba-c61048fe6dad)

[タグ「.NET_Framework」のユーザー](http://localhost:3000/users/tags/.NET_Framework)ページでもユーザー数には含まれず、ユーザー情報も表示されない

![スクリーンショット 2023-11-30 21 09 12](https://github.com/fjordllc/bootcamp/assets/104631303/a95746d5-31cb-44dd-b531-429a955f8ff3)

