### PR TITLE
Q&A個別ページの title タグの文言の微調整しました

### DIFF
--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -1,4 +1,4 @@
-- title "Q＆A #{@question.title}"
+- title "Q＆A: #{@question.title}"
 - if @question.practice
   - set_meta_tags description: "#{@question.user.long_name}さんが投稿した、プラクティス「#{@question.practice}」に関する質問「#{@question.title}」のページです。"
 - else

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -30,7 +30,7 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'show a question' do
     question = questions(:question8)
     visit_with_auth question_path(question), 'kimura'
-    assert_equal 'Q＆A テストの質問 | FBC', title
+    assert_equal 'Q＆A: テストの質問 | FBC', title
   end
 
   test 'create a question' do


### PR DESCRIPTION
## Issue

- #7085 

## 概要

Q＆A個別ページの title タグの文言を微調整しました。

## 変更確認方法

1. ブランチ `feature/change-QA-title-format` をローカルに取り込む
2. `bin/rails s`  でローカル環境と立ち上げる
3. ログインしていなければ [Develop環境でログインする方法 ](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95) を参考にログインする
5. http://localhost:3000/questions にアクセスする
6. 適当な個別 Q&A を開く
7. タイトルバーやデベロッパーツールで title タグが変わっていることを確認する

## Screenshot

### 変更前

![image](https://www.evernote.com/shard/s400/sh/8ad96a91-6b64-4d85-95b9-be67328067cc/nkJl4Zkdbknutl_02HDBtBnknym4MdxDEbdKRYpxZSmEQwf59xLTerO_1A/deep/0/image.png)

### 変更後

`Q&A` の後ろに `: ` がつき、`Q&A: ` となりました。

![image](https://www.evernote.com/shard/s400/sh/624c2002-1b75-4f8c-a696-1b5ecc9caacf/o6kaFRmsFYucHcU-NkCQLOJrcnk6de4Yna3qcZswtf1y_DYMy6pE48SmDA/deep/0/image.png)

