### PR TITLE
Docs個別ページの title タグの文言の微調整。

### DIFF
--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -1,4 +1,4 @@
-- title "Doc #{@page.title}"
+- title "Doc: #{@page.title}"
 - set_meta_tags description: "ドキュメント「#{@page.title}」のページです"
 
 header.page-header

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -1,4 +1,4 @@
-- title "Doc: #{@page.title}"
+- title "Docs: #{@page.title}"
 - set_meta_tags description: "ドキュメント「#{@page.title}」のページです"
 
 header.page-header

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -22,7 +22,7 @@ class PagesTest < ApplicationSystemTestCase
 
   test 'show page' do
     visit_with_auth "/pages/#{pages(:page1).id}", 'kimura'
-    assert_equal 'Doc: test1 | FBC', title
+    assert_equal 'Docs: test1 | FBC', title
   end
 
   test 'show edit page' do

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -22,7 +22,7 @@ class PagesTest < ApplicationSystemTestCase
 
   test 'show page' do
     visit_with_auth "/pages/#{pages(:page1).id}", 'kimura'
-    assert_equal 'Doc test1 | FBC', title
+    assert_equal 'Doc: test1 | FBC', title
   end
 
   test 'show edit page' do


### PR DESCRIPTION
## Issue

- #7084 

## 概要

Docs 個別ページの title タグの文言を微調整しました。

## 変更確認方法

1. ブランチ `feature/change-Doc-title-format` をローカルに取り込む
2. `bin/rails s`  でローカル環境と立ち上げる
3. ログインしていなければ [Develop環境でログインする方法 ](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95) を参考にログインする
5. http://localhost:3000/pages にアクセスする
6. 適当な個別 Doc を開く
7. タイトルバーやデベロッパーツールで title タグが変わっていることを確認する

## Screenshot

### 変更前

![image](https://www.evernote.com/shard/s400/sh/827f7599-deb8-4650-8070-3dbd7d9ec45b/7JGgyBCZeXEA0W8eAIzo86VpWEkp8qeEmcwDwdfeURFeMCzuXmOp6pJKNA/deep/0/image.png)

### 変更後

`Doc` が `Docs: `になりました。

![image](https://www.evernote.com/shard/s400/sh/33e7a00c-193c-4479-b7cc-c20d8b17de5e/ii1b2C8Evqu0ExdVquEKd5sKHv0ZQYsTdPA8Y93B4zGzXpBmY9YPwUsBcg/deep/0/image.png)

