### PR TITLE
提出物個別ページのタイトルタグを「{プラクティス名}の提出物 | FBC」に修正

### DIFF
--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -1,4 +1,4 @@
-- title @product.practice.title
+- title "#{@product.practice.title}の提出物"
 - set_meta_tags description: "#{@product.user.long_name}さんが提出した、プラクティス「#{@product.practice.title}」の提出物です。"
 - category = @product.category(current_user.course)
 

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -5,32 +5,32 @@ require 'application_system_test_case'
 class ProductsTest < ApplicationSystemTestCase
   test 'see my product' do
     visit_with_auth "/products/#{products(:product1).id}", 'mentormentaro'
-    assert_equal "#{products(:product1).practice.title} | FBC", title
+    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
   end
 
   test 'admin can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    assert_equal "#{products(:product1).practice.title} | FBC", title
+    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
   end
 
   test 'adviser can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'advijirou'
-    assert_equal "#{products(:product1).practice.title} | FBC", title
+    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
   end
 
   test 'graduate can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'sotugyou'
-    assert_equal "#{products(:product1).practice.title} | FBC", title
+    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
   end
 
   test "user who completed the practice can see the other user's product" do
     visit_with_auth "/products/#{products(:product1).id}", 'kimura'
-    assert_equal "#{products(:product1).practice.title} | FBC", title
+    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
   end
 
   test "can see other user's product if it is permitted" do
     visit_with_auth "/products/#{products(:product3).id}", 'hatsuno'
-    assert_equal "#{products(:product3).practice.title} | FBC", title
+    assert_equal "#{products(:product3).practice.title}の提出物 | FBC", title
   end
 
   test "can not see other user's product if it isn't permitted" do


### PR DESCRIPTION
## Issue

[提出物個別ページのtitleタグに提出物という文字を含めたい #7043](https://github.com/fjordllc/bootcamp/issues/7043)

## 概要
変更前の提出物個別ページ（一覧ではなく個別ページ）では、

<img width="632" alt="貼り付けた画像_2023_11_08_17_17" 
src="https://github.com/fjordllc/bootcamp/assets/168265/d86365ff-33ba-4a13-bc79-ff00d01b5fdb">

titleタグが、

<img width="387" alt="貼り付けた画像_2023_11_08_17_19" src="https://github.com/fjordllc/bootcamp/assets/168265/3689423b-596d-41eb-9482-f9d27c3fde37">

`{プラクティス名} | FBC` となっていましたが、

これを

`{プラクティス名}の提出物 | FBC` に修正しました。

## 変更確認方法

1. feature/include-the-word-submission-to-titleTag-of-individual-submission-pageをローカルに取り込む
2. foreman start -f Procfile.devでローカル環境を立ち上げる
3. 任意のアカウントでログイン
4. [提出物](http://localhost:3000/products)ページで任意の提出物を開く
5. 以下2点を確認する
- ブラウザのタブ名が`{プラクティス名}の提出物 | FBC`になっていること
※ブラウザのタブにマウスカーソルを乗せるとタイトルが表示されます。
- デベロッパーツールの<title>タグが<title>(development) {プラクティス名}の提出物 | FBC</title>になっていること

## Screenshot

### 変更前
<img width="635" alt="スクリーンショット 2023-11-11 12 16 12" src="https://github.com/fjordllc/bootcamp/assets/57088113/97531351-a45e-4227-8c21-a153eaea3599">

### 変更後
<img width="640" alt="スクリーンショット 2023-11-11 12 14 20" src="https://github.com/fjordllc/bootcamp/assets/57088113/7f769c68-fe97-4be4-bcf5-296ceea935de">