### PR TITLE
「'日報はまだありません。'」の表示よりシングルクォーテーションを削除

### DIFF
--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -138,7 +138,7 @@ const NoReports = ({ unchecked }) => {
         ) : (
           <>
             <i className="fa-regular fa-sad-tear" />
-            <p className="o-empty-message__text">'日報はまだありません。'</p>
+            <p className="o-empty-message__text">日報はまだありません。</p>
           </>
         )}
       </div>


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7078#event-11092393686

## 概要
日報が1件も投稿されていないときに表示される「'日報はまだありません。'」からシングルクォーテーションを削除し、
「日報はまだありません。」と表示されるように修正しました。

## 変更確認方法
1. `bug/remove_single_quotes_from_display_of_No_daily_report_yet`をローカルに取り込む
2. `muryou`でログインする
3. ダッシュボードの自分の日報タブをクリック
4. 「日報はまだありません。」と表示されていることを確認

## Screenshot

### 変更前
<img width="1341" alt="スクリーンショット 2023-12-02 15 26 03" src="https://github.com/fjordllc/bootcamp/assets/57088113/3f394610-b507-4468-a977-033d6205ba37">

### 変更後
<img width="1354" alt="スクリーンショット 2023-12-02 15 27 15" src="https://github.com/fjordllc/bootcamp/assets/57088113/5626a51f-b0ca-46c3-8ea8-a15549c71ed2">

