### PR TITLE
プラクティス着手状態から提出物をWIPにしても未着手にならないように修正

### DIFF
--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -32,7 +32,7 @@ class LearningStatusUpdater
                :complete
              elsif product.wip
                started_practice = product.user.learnings.map(&:status).include?('started')
-               started_practice ? :unstarted : :started
+               started_practice ? previous_learning.status.to_sym : :started
              else
                :submitted
              end

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -32,7 +32,7 @@ class LearningStatusUpdater
                :complete
              elsif product.wip
                started_practice = product.user.learnings.map(&:status).include?('started')
-               started_practice ? previous_learning.status.to_sym : :started
+               started_practice && previous_learning.status != 'started' ? :unstarted : :started
              else
                :submitted
              end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -127,6 +127,20 @@ class ProductsTest < ApplicationSystemTestCase
     assert find_button(class: 'is-started', disabled: true).matches_css?('.is-active')
   end
 
+  test 'should unchange learning status when change wip status' do
+    product = products(:product8)
+    product_path = "/products/#{product.id}"
+    practice_path = "/practices/#{product.practice.id}"
+
+    visit_with_auth "#{product_path}/edit", 'kimura'
+    product.change_learning_status(:started)
+    visit "#{product_path}/edit"
+    click_button 'WIP'
+    visit practice_path
+
+    assert find_button(class: 'is-started', disabled: true).matches_css?('.is-active')
+  end
+
   test 'update product' do
     product = products(:product1)
     visit_with_auth "/products/#{product.id}/edit", 'mentormentaro'


### PR DESCRIPTION
## Issue

- #6381 

## 概要

プラクティスのステータスを「着手」の状態から、そのプラクティスの提出物をWIPで保存するとステータスが「未着手」に変わる。
WIP で保存してもプラクティスのステータスが「着手」を維持するように修正しました。

## 変更確認方法

1. `bug/practice-state-set-undone-in-wip-saved` をローカルに取り込む
2. 1.のブランチに切り替え `bin/rails s` でアプケーション起動
3. 提出物のあるプラクティス個別ページにアクセス。（『Terminalの基礎を覚える』等）
4. ステータス「着手」をクリック。
5. 提出物編集ページにアクセス。
6. WIPで途中保存する
7. 3.のページに再度アクセス。
8. ステータス「着手」のままであることを確認

## Screenshot

### 変更前

[![Image from Gyazo](https://i.gyazo.com/781b0d12f45349eb33f2227355491cca.gif)](https://gyazo.com/781b0d12f45349eb33f2227355491cca)

### 変更後

[![Image from Gyazo](https://i.gyazo.com/048293765e2fd2470fd935d30968ef79.gif)](https://gyazo.com/048293765e2fd2470fd935d30968ef79)