### PR TITLE
未ログインでユーザー個別ページにアクセスした時のページを作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  skip_before_action :require_active_user_login, raise: false, only: %i[new create]
+  skip_before_action :require_active_user_login, raise: false, only: %i[new create show]
   before_action :require_token, only: %i[new] if Rails.env.production?
   before_action :set_user, only: %w[show]
 
@@ -40,6 +40,12 @@ class UsersController < ApplicationController
                            .includes(:practice)
                            .where(status: 3)
                            .order(updated_at: :desc)
+
+    if logged_in?
+      render :show
+    else
+      render :unauthorized_show, layout: 'not_logged_in'
+    end
   end
 
   def new

--- a/app/views/unauthorized/_unauthorized_header.html.slim
+++ b/app/views/unauthorized/_unauthorized_header.html.slim
@@ -4,4 +4,8 @@ header.unauthorized-header
     h1.unauthorized-header__title
       span.unauthorized-header__title-label
         = label
-      | 「#{title}」
+      span.font-thin
+        | 「
+      = title
+      span.font-thin
+        | 」

--- a/app/views/users/unauthorized_show.slim
+++ b/app/views/users/unauthorized_show.slim
@@ -1,11 +1,11 @@
-- title @user.login_name
-- description "オンラインプログラミングスクール「フィヨルドブートキャンプ」の#{@user.login_name}さんのプロフィールページ"
+- title '@' + @user.login_name
+- description "オンラインプログラミングスクール「フィヨルドブートキャンプ」の@#{@user.login_name}さんのプロフィールページ"
 - content_for :extra_body_classes
 
 .page-body
   article.unauthorized
     = render '/unauthorized/unauthorized_header',
-      label: 'プロフィールページ', title: title.to_s
+      label: 'ユーザープロフィールページ', title: title.to_s
     .unauthorized__body
       .container.is-md
         .unauthorized__contents

--- a/app/views/users/unauthorized_show.slim
+++ b/app/views/users/unauthorized_show.slim
@@ -1,0 +1,17 @@
+- title @user.login_name
+- description "オンラインプログラミングスクール「フィヨルドブートキャンプ」の#{@user.login_name}さんのプロフィールページ"
+- content_for :extra_body_classes
+
+.page-body
+  article.unauthorized
+    = render '/unauthorized/unauthorized_header', label: 'プロフィールページ', title: "#{title}"
+    .unauthorized__body
+      .container.is-md
+        .unauthorized__contents
+          .unauthorized__content
+            = render '/unauthorized/must_be_enrolled'
+          hr.unauthorized__content-separalor
+          .unauthorized__content
+            = render '/unauthorized/about_fbc'
+          .unauthorized__content
+            = render '/unauthorized/join_us'

--- a/app/views/users/unauthorized_show.slim
+++ b/app/views/users/unauthorized_show.slim
@@ -1,4 +1,4 @@
-- title '@' + @user.login_name
+- title "@#{@user.login_name}"
 - description "オンラインプログラミングスクール「フィヨルドブートキャンプ」の@#{@user.login_name}さんのプロフィールページ"
 - content_for :extra_body_classes
 

--- a/app/views/users/unauthorized_show.slim
+++ b/app/views/users/unauthorized_show.slim
@@ -4,7 +4,8 @@
 
 .page-body
   article.unauthorized
-    = render '/unauthorized/unauthorized_header', label: 'プロフィールページ', title: "#{title}"
+    = render '/unauthorized/unauthorized_header',
+      label: 'プロフィールページ', title: title.to_s
     .unauthorized__body
       .container.is-md
         .unauthorized__contents

--- a/test/system/require_login/users_test.rb
+++ b/test/system/require_login/users_test.rb
@@ -9,10 +9,6 @@ class UsersLoginTest < ApplicationSystemTestCase
     assert_login_required('/users')
   end
 
-  test 'cannot access user detail without login' do
-    assert_login_required("/users/#{users(:hatsuno).id}")
-  end
-
   test 'can access user create screen without login' do
     assert_no_login_required('/users/new', 'フィヨルドブートキャンプ参加登録')
   end

--- a/test/system/user/not_logged_in_test.rb
+++ b/test/system/user/not_logged_in_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class User::NotLoggedInTest < ApplicationSystemTestCase
+  test 'appropriate meta description is displayed when accessed by non-logged-in user' do
+    target_user = users(:kimura)
+    visit user_path(target_user)
+    assert_selector 'head', visible: false do
+      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」の#{target_user.login_name}さんのプロフィールページ']", visible: false
+    end
+  end
+end

--- a/test/system/user/not_logged_in_test.rb
+++ b/test/system/user/not_logged_in_test.rb
@@ -7,7 +7,7 @@ class User::NotLoggedInTest < ApplicationSystemTestCase
     target_user = users(:kimura)
     visit user_path(target_user)
     assert_selector 'head', visible: false do
-      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」の#{target_user.login_name}さんのプロフィールページ']", visible: false
+      assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」の@#{target_user.login_name}さんのプロフィールページ']", visible: false
     end
   end
 end


### PR DESCRIPTION
## Issue

- #6886 

## 概要
「ログインしていない人向けのユーザー個別ページ」を作成し、
未ログイン時にユーザー個別ページへアクセスすると表示する仕様に変更しました。

## 変更確認方法

1. `feature/create-individual-user-page-for-when-not-logged-in`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. ユーザー個別ページのURLをコピーする
    1. 任意のユーザーでログイン
    1. [ユーザー一覧ページ](http://localhost:3000/users)で任意のユーザーをクリックし、ユーザー個別ページに遷移
    1. ユーザー個別ページのURLをコピーする  
4. ログアウトする
5. ログアウトした状態のまま、3でコピーしたURLへリクエストする
6. ログインしていない人向けのユーザー個別ページが表示されることを確認する

## Screenshot

### 変更前

未ログイン状態でユーザー個別ページへリクエストすると、トップページにリダイレクト & ログインを求めるアラートが表示される

![スクリーンショット 2023-12-06 8 45 32](https://github.com/fjordllc/bootcamp/assets/104631303/33b69202-542a-48ab-99fc-209f27c9f605)


### 変更後

#### 未ログイン時
- ログインしていない人向けのユーザー個別ページが表示される

<img width="1368" alt="スクリーンショット 2023-12-16 10 12 56" src="https://github.com/fjordllc/bootcamp/assets/104631303/d5054ab7-b417-4704-a4c5-5aedee57d0eb">

#### ログイン時

<img width="1373" alt="スクリーンショット 2023-12-16 10 14 29" src="https://github.com/fjordllc/bootcamp/assets/104631303/ba79a509-ef69-4fbb-b802-b67717a3f08b">

