### PR TITLE
ユーザー一覧ページにおいてメンターと管理者には休会中ユーザーの休会日と経過日数の表示されるようにした

### DIFF
--- a/app/javascript/components/user.vue
+++ b/app/javascript/components/user.vue
@@ -2,13 +2,14 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
   .users-item
     .users-item__inner.a-card
-      .users-item__inactive-message.is-only-mentor(
-        v-if='currentUser.mentor && user.student_or_trainee && !user.active')
-        | 1ヶ月以上ログインがありません
-      header.users-item__header
-        .is-only-mentor(
-          v-if='(currentUser.mentor || currentUser.admin) && user.roles.includes("hibernationed")')
+      .users-item__inactive-message-container(v-if='(currentUser.mentor || currentUser.admin) && user.student_or_trainee')
+        .users-item__inactive-message.is-only-mentor(v-if='user.roles.includes("retired")')
+          | 退会しました
+        .users-item__inactive-message.is-only-mentor(v-else-if='user.roles.includes("hibernationed")')
           | 休会中: {{ user.hibernated_at }}〜({{ user.hibernation_elapsed_days }}日経過)
+        .users-item__inactive-message.is-only-mentor(v-else-if='!user.active')
+          | 1ヶ月以上ログインがありません
+      header.users-item__header
         .users-item__header-inner
           .users-item__header-start
             .users-item__icon

--- a/app/javascript/components/user.vue
+++ b/app/javascript/components/user.vue
@@ -6,7 +6,7 @@
         v-if='currentUser.mentor && user.student_or_trainee && !user.active')
         | 1ヶ月以上ログインがありません
       header.users-item__header
-        div(
+        .is-only-mentor(
           v-if='(currentUser.mentor || currentUser.admin) && user.roles.includes("hibernationed")')
           | 休会中: {{ user.hibernated_at }}〜({{ user.hibernation_elapsed_days }}日経過)
         .users-item__header-inner
@@ -19,12 +19,12 @@
                     :alt='user.icon_title',
                     :src='user.avatar_url')
           .users-item__header-end
-          .card-list-item__rows
-            .card-list-item__row
-              .card-list-item-title
-                a.card-list-item-title__title.is-lg.a-text-link(
-                  :href='user.url')
-                  | {{ loginName }}
+            .card-list-item__rows
+              .card-list-item__row
+                .card-list-item-title
+                  a.card-list-item-title__title.is-lg.a-text-link(
+                    :href='user.url')
+                    | {{ loginName }}
                   a(
                     v-if='user.company && user.company.logo_url',
                     :href='user.company.url')

--- a/app/javascript/components/user.vue
+++ b/app/javascript/components/user.vue
@@ -2,10 +2,12 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
   .users-item
     .users-item__inner.a-card
-      .users-item__inactive-message-container.is-only-mentor(v-if='(currentUser.mentor || currentUser.admin) && user.student_or_trainee')
+      .users-item__inactive-message-container.is-only-mentor(
+        v-if='(currentUser.mentor || currentUser.admin) && user.student_or_trainee')
         .users-item__inactive-message(v-if='user.roles.includes("retired")')
           | 退会しました
-        .users-item__inactive-message(v-else-if='user.roles.includes("hibernationed")')
+        .users-item__inactive-message(
+          v-else-if='user.roles.includes("hibernationed")')
           | 休会中: {{ user.hibernated_at }}〜({{ user.hibernation_elapsed_days }}日経過)
         .users-item__inactive-message(v-else-if='!user.active')
           | 1ヶ月以上ログインがありません

--- a/app/javascript/components/user.vue
+++ b/app/javascript/components/user.vue
@@ -2,12 +2,12 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
   .users-item
     .users-item__inner.a-card
-      .users-item__inactive-message-container(v-if='(currentUser.mentor || currentUser.admin) && user.student_or_trainee')
-        .users-item__inactive-message.is-only-mentor(v-if='user.roles.includes("retired")')
+      .users-item__inactive-message-container.is-only-mentor(v-if='(currentUser.mentor || currentUser.admin) && user.student_or_trainee')
+        .users-item__inactive-message(v-if='user.roles.includes("retired")')
           | 退会しました
-        .users-item__inactive-message.is-only-mentor(v-else-if='user.roles.includes("hibernationed")')
+        .users-item__inactive-message(v-else-if='user.roles.includes("hibernationed")')
           | 休会中: {{ user.hibernated_at }}〜({{ user.hibernation_elapsed_days }}日経過)
-        .users-item__inactive-message.is-only-mentor(v-else-if='!user.active')
+        .users-item__inactive-message(v-else-if='!user.active')
           | 1ヶ月以上ログインがありません
       header.users-item__header
         .users-item__header-inner

--- a/app/javascript/components/user.vue
+++ b/app/javascript/components/user.vue
@@ -6,6 +6,9 @@
         v-if='currentUser.mentor && user.student_or_trainee && !user.active')
         | 1ヶ月以上ログインがありません
       header.users-item__header
+        div(
+          v-if='(currentUser.mentor || currentUser.admin) && user.roles.includes("hibernationed")')
+          | 休会中: {{ user.hibernated_at }}〜({{ user.hibernation_elapsed_days }}日経過)
         .users-item__header-inner
           .users-item__header-start
             .users-item__icon
@@ -16,12 +19,12 @@
                     :alt='user.icon_title',
                     :src='user.avatar_url')
           .users-item__header-end
-            .card-list-item__rows
-              .card-list-item__row
-                .card-list-item-title
-                  a.card-list-item-title__title.is-lg.a-text-link(
-                    :href='user.url')
-                    | {{ loginName }}
+          .card-list-item__rows
+            .card-list-item__row
+              .card-list-item-title
+                a.card-list-item-title__title.is-lg.a-text-link(
+                  :href='user.url')
+                  | {{ loginName }}
                   a(
                     v-if='user.company && user.company.logo_url',
                     :href='user.company.url')

--- a/app/javascript/stylesheets/application/blocks/user/_users-item.sass
+++ b/app/javascript/stylesheets/application/blocks/user/_users-item.sass
@@ -2,11 +2,11 @@
   height: 100%
 
 .users-item__inactive-message
-  background-color: var(--background)
+  background-color: var(--disabled)
   +text-block(.625rem 1.4, center)
   padding: .25rem
   +border-radius(top, .1875rem)
-  margin-bottom: -.25rem
+  margin: -1px -1px -.25rem
 
 .users-item__inner
   +media-breakpoint-up(md)

--- a/app/javascript/stylesheets/application/blocks/user/_users-item.sass
+++ b/app/javascript/stylesheets/application/blocks/user/_users-item.sass
@@ -16,7 +16,7 @@
 
 .users-item__header
   +position(relative)
-  padding: 1rem
+  padding: .75rem 1rem
   border-bottom: solid 1px var(--border-tint)
 
 .users-item__header-inner

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -712,6 +712,10 @@ class User < ApplicationRecord
     hibernations.order(:created_at).last
   end
 
+  def hibernation_elapsed_days
+    (Time.zone.today - hibernated_at.to_date).to_i
+  end
+
   def update_last_returned_at!
     hibernation = last_hibernation
     hibernation.returned_at = Date.current

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -39,3 +39,8 @@ json.company do
     json.url company_url(user.company)
   end
 end
+
+if user.hibernated?
+  json.hibernated_at l(user.hibernated_at, format: :year_and_date)
+  json.hibernation_elapsed_days user.hibernation_elapsed_days
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -623,6 +623,16 @@ class UserTest < ActiveSupport::TestCase
     assert target.sent_student_followup_message
   end
 
+  test '#hibernation_elapsed_days' do
+    user = users(:kyuukai)
+
+    travel_to Time.zone.local(2020, 1, 10) do
+      elapsed_days = user.hibernation_elapsed_days
+
+      assert assert_equal 9, elapsed_days
+    end
+  end
+
   test '#country_name' do
     assert_equal '日本', users(:kimura).country_name
     assert_equal '米国', users(:tom).country_name

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -629,4 +629,18 @@ class UsersTest < ApplicationSystemTestCase
     visit_with_auth user_path(user), 'komagata'
     assert_no_text '休会中 / 休会から'
   end
+
+  test 'show retirement message on users page' do
+    visit_with_auth users_path, 'komagata'
+    click_link('退会')
+    assert_selector '.users-item__inactive-message-container.is-only-mentor .users-item__inactive-message', text: '退会しました'
+  end
+
+  test 'show hibernation elasped days message on users page' do
+    travel_to Time.zone.local(2020, 1, 11, 0, 0, 0) do
+      visit_with_auth users_path, 'komagata'
+      click_link('休会')
+      assert_selector '.users-item__inactive-message-container.is-only-mentor .users-item__inactive-message', text: '休会中: 2020年01月01日〜(10日経過)'
+    end
+  end
 end


### PR DESCRIPTION
## Issue

- #6613 

## 概要

ユーザー一覧ページにおいてメンターと管理者には休会中ユーザーの休会日と経過日数の表示がされるようにしました。
それに伴って以下のようにユーザー一覧ページの表示を整理しました。
- 休会中ユーザー：休会日と経過日数の表示
- 退会ユーザー：「退会しました」と表示
- 上記以外の非アクティブ（1ヶ月以上ログインがない）ユーザー：「1ヶ月以上ログインがありません」と表示

## 変更確認方法

1. `feature/display-elapsed-days-number-for-hibernated-user-on-users-list`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 管理者/メンターである`komagata`でログイン
4. [休会中のユーザー一覧ページ](http://localhost:3000/users?target=hibernated)にアクセスする
5. 各ユーザーに`休会中: yyyy年mm月dd日〜（dd日経過）`という表示がされていることを確認する

<img width="889" alt="確認方法：休会" src="https://github.com/fjordllc/bootcamp/assets/104631303/c1bcf7ec-0070-4404-9510-fe62e86e0853">

6. [退会ユーザーの一覧ページ](http://localhost:3000/users?target=retired)にアクセスする
7. 各ユーザーに「退会しました」という表示がされていることを確認する

<img width="888" alt="スクリーンショット 2023-12-17 21 37 25" src="https://github.com/fjordllc/bootcamp/assets/104631303/b5b2bdb1-5789-4bcf-a7ea-5b511ddae107">

## Screenshot

### 変更前

管理者とメンターでログインし、メンターモードがONでも`休会中: yyyy年mm月dd日〜（dd日経過）`という表示はされない
<img width="887" alt="変更前：休会" src="https://github.com/fjordllc/bootcamp/assets/104631303/a7f4c7cc-e810-4426-aa6d-efbe91a64724">

退会ユーザーに「退会しました」という表示はされない
<img width="885" alt="スクリーンショット 2023-12-17 21 53 12" src="https://github.com/fjordllc/bootcamp/assets/104631303/3afe4bbc-15a5-4d0c-bbbd-5e96089b002f">

### 変更後
- 休会経過日数の表示
管理者とメンターでログインし、メンターモードがONの時は各ユーザーに`休会中: yyyy年mm月dd日〜（dd日経過）`という表示がされる
<img width="889" alt="確認方法：休会" src="https://github.com/fjordllc/bootcamp/assets/104631303/471a4ae7-c07e-43ef-ad9b-4a3b4cbd2317">

メンターモードがOFFの時は表示されない
<img width="887" alt="スクリーンショット 2023-12-17 21 43 07" src="https://github.com/fjordllc/bootcamp/assets/104631303/3f536abf-683c-48fc-94a1-a0d4dddf6715">

- 退会ユーザーの表示
管理者とメンターでログインし、メンターモードがONの時は各ユーザーに「退会しました」という表示がされる
<img width="888" alt="スクリーンショット 2023-12-17 21 37 25" src="https://github.com/fjordllc/bootcamp/assets/104631303/8d0c3f4b-822e-4386-8565-a2dfcc7f8cd4">

メンターモードがOFFの時は表示されない
<img width="885" alt="スクリーンショット 2023-12-17 21 46 20" src="https://github.com/fjordllc/bootcamp/assets/104631303/9f825a83-97b4-42f2-92f9-ab78ba156dcc">

