### PR TITLE
提出物がWIP状態のとき、WIPであることのアラートが提出物作成者にだけ表示されるように修正

### DIFF
--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -30,7 +30,7 @@ header.page-header
   - if @product.user == current_user && !@product.wip? && !@product.checked? && @product.commented_users.mentor.empty?
     = render 'message_for_after_submission'
 
-  - if @product.wip?
+  - if @product.user == current_user && @product.wip?
     = render 'message_for_wip'
 
   - if @product.user == current_user && @learning&.complete?

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -30,7 +30,7 @@ header.page-header
   - if @product.user == current_user && !@product.wip? && !@product.checked? && @product.commented_users.mentor.empty?
     = render 'message_for_after_submission'
 
-  - if @product.user == current_user && @product.wip?
+  - if @product.wip? && @product.user == current_user
     = render 'message_for_wip'
 
   - if @product.user == current_user && @learning&.complete?

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -245,6 +245,19 @@ class ProductsTest < ApplicationSystemTestCase
     assert_text '本文を入力してください'
   end
 
+  test 'user who has submitted a WIP product is alerted in the product page' do
+    wip_product = products(:product5)
+    visit_with_auth "/products/#{wip_product.id}", 'kimura'
+    assert_text "提出物はまだ提出されていません。\n完成したら「提出する」をクリック！"
+  end
+
+  test "user is not alerted in the other's WIP product page" do
+    wip_product = products(:product5)
+    visit_with_auth "/products/#{wip_product.id}", 'hatsuno'
+    assert_equal "#{wip_product.practice.title} | FBC", title
+    assert_no_text "提出物はまだ提出されていません。\n完成したら「提出する」をクリック！"
+  end
+
   test "Don't notify if create product as WIP" do
     visit_with_auth '/notifications', 'komagata'
     click_link '全て既読にする'


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/6045

## 概要
WIP状態の提出物ページ上に表示される『提出物はまだ提出されていません。完成したら「提出する」をクリック！』というアラートが、提出物作成者以外にも表示される不具合を、下記の内容で修正しました。

- 提出物作成者にのみ、WIPアラートが表示されるようにする。

## 変更確認方法

- `bug/make-alert-about-wip-product-visible-only-to-the-product-submitter`をローカルに取り込む。
- `foreman start -f Procfile.dev`を実行し、ローカル環境を立ち上げる。
- `localhost:3000`にアクセス。
- `kimura`でログインし、「Terminalの基礎を覚える」のプラクティスの提出物をWIPで保存する。
- `kimura`のまま、さきほど保存した提出物ページに移動し、『提出物はまだ提出されていません。完成したら「提出する」をクリック！』というアラートが表示されていることを確認する。
- 任意の`kimura`以外のユーザーでログインし、↑で保存された提出物ページに移動する。
- 『提出物はまだ提出されていません。完成したら「提出する」をクリック！』というアラートが表示されていないことを確認する。
## Screenshot

### 変更前
提出者本人以外にも、WIPアラートが表示される。
「変更確認方法」のシナリオの場合、`hatsuno`でログインし、`kimura`のWIPの提出物ページを見たときに、WIPのアラートが表示されている。

![Dz8NIYdCKK](https://github.com/fjordllc/bootcamp/assets/128765400/0173494a-74e4-459d-a436-098b59abf9b1)

### 変更後
提出者本人にのみ、WIPアラートが表示される。
「変更確認方法」のシナリオの場合、以下の通り。

- `hatsuno`でログインし、`kimura`のWIPの提出物ページを見たときは、WIPのアラートが表示されない。
- `kimura`でログインし、当該の提出物ページを見たときは、WIPのアラートが表示されている。

`hatsuno`で`kimura`のWIPの提出物ページを見る↓
![rTRg2iftsT](https://github.com/fjordllc/bootcamp/assets/128765400/6e64c657-1f49-45eb-897c-ba03f8190d7d)

`kimura`で自分のWIPの提出物ページを見る↓
![6S6fYtkli7](https://github.com/fjordllc/bootcamp/assets/128765400/de2ab68f-dc2f-4cb8-91ac-24ced7d842d8)

