### PR TITLE
管理画面のユーザー一覧の忘年会タブから、休会中のユーザーを外す

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -302,7 +302,12 @@ class User < ApplicationRecord
       graduated_on: nil
     )
   }
-  scope :year_end_party, -> { where(retired_on: nil) }
+  scope :year_end_party, lambda {
+    where(
+      hibernated_at: nil,
+      retired_on: nil
+    )
+  }
   scope :mentor, -> { where(mentor: true) }
   scope :mentors_sorted_by_created_at, lambda {
     with_attached_profile_image

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -503,7 +503,7 @@ class UserTest < ActiveSupport::TestCase
     assert_not_includes(target, users(:kensyuowata))
   end
 
-  test '#year_end_party' do
+  test '.year_end_party' do
     target = User.year_end_party
     assert_not_includes(target, users(:kyuukai))
     assert_not_includes(target, users(:yameo))

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -503,6 +503,13 @@ class UserTest < ActiveSupport::TestCase
     assert_not_includes(target, users(:kensyuowata))
   end
 
+  test '#year_end_party' do
+    target = User.year_end_party
+    assert_not_includes(target, users(:kyuukai))
+    assert_not_includes(target, users(:yameo))
+    assert_includes(target, users(:kimura))
+  end
+
   test '#belongs_company_and_adviser?' do
     assert_not users(:kensyu).belongs_company_and_adviser?
     assert_not users(:advijirou).belongs_company_and_adviser?

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -44,6 +44,14 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_text 'kensyu（Kensyu Seiko）'
   end
 
+  test "hibernated and retired user's emails are excluded from year-end-party invitation list" do
+    visit_with_auth '/admin/users?target=year_end_party', 'komagata'
+    assert_equal '管理ページ | FBC', title
+    assert_no_text users(:kyuukai).email
+    assert_no_text users(:yameo).email
+    assert_text users(:kimura).email
+  end
+
   test 'accessed by non-administrative users' do
     user = users(:hatsuno)
     visit_with_auth edit_admin_user_path(user.id), 'kimura'

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -44,7 +44,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_text 'kensyu（Kensyu Seiko）'
   end
 
-  test "hibernated and retired user's emails are excluded from year-end-party invitation list" do
+  test 'remove hibernated and retired user from year-end-party email list' do
     visit_with_auth '/admin/users?target=year_end_party', 'komagata'
     assert_equal '管理ページ | FBC', title
     assert_no_text users(:kyuukai).email

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -44,7 +44,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_text 'kensyu（Kensyu Seiko）'
   end
 
-  test 'remove hibernated and retired user from year-end-party email list' do
+  test 'exclude hibernated and retired users from year-end-party email list' do
     visit_with_auth '/admin/users?target=year_end_party', 'komagata'
     assert_equal '管理ページ | FBC', title
     assert_no_text users(:kyuukai).email


### PR DESCRIPTION
## Issue
- [管理画面のユーザー一覧の忘年会タブから休会中のユーザーを外す。 · Issue \#7114 · fjordllc/bootcamp](https://github.com/fjordllc/bootcamp/issues/7114)

## 概要
現状、管理画面のユーザー一覧の忘年会タブに、休会中のユーザーの行と、ページ下部の「全員のメアド」欄に休会者のアドレスが載っています。
これらから休会者のものが外れるよう、下記の方法で修正いたしました。

- `User`モデルにある、忘年会の対象となるユーザーを絞る既存のscope、`year_end_party`の検索条件を修正し、休会者が対象に入らないようにする。

## 変更確認方法

- `feature/exclude-hibernated-users-from-year-end-party-invitation-list-in-admin-panels-users-list`をローカルに取り込む。
- `foreman start -f Procfile.dev`を実行し、ローカル環境を立ち上げる。
- `komagata`でログインし、http://localhost:3000/admin/users?target=year_end_party にアクセスする。
- 以下の2点を確認する。
  - ステータスが「休会」のユーザーが一覧画面に一人もいないことを確認する（休会ユーザーの行はうっすら灰色なので、そんな行が一覧にないことを見ることで確認可能です）。
  - ページ下部の「全員のメアド」欄に、休会ユーザーのアドレスがないことを確認する。
    - お手数ですが、ブラウザの検索機能で下記のアドレスを検索してもらえるとありがたいです。ヒットするとき、しないときの例は下のスクショをご参考ください。
 
```
# dev環境でデフォルトで存在する休会中のユーザーのアドレス一覧

unhibernated@fjord.jp
nagai-kyuukai@fjord.jp
kyuukai@fjord.jp
```

## Screenshot


### 変更前
管理画面のユーザー一覧の忘年会タブに、休会ユーザー（うすい灰色の行）も含まれている。
ページ下部の「全員のメアド」欄に、休会ユーザーのユーザーのアドレスがある。
![vb3Tiegc03](https://github.com/fjordllc/bootcamp/assets/128765400/1c0262f0-45b2-44d9-baa5-9f6faac65fd0)

![image](https://github.com/fjordllc/bootcamp/assets/128765400/31abb014-6c96-4a37-a30c-7831ac154905)



### 変更後
管理画面のユーザー一覧の忘年会タブに、休会ユーザー（うすい灰色の行）が含まれていない。
ページ下部の「全員のメアド」欄に、休会ユーザーのユーザーのアドレスがない。
![IJAklxp0c7](https://github.com/fjordllc/bootcamp/assets/128765400/c4c5b5e4-b2df-48fc-b62b-ff983537b381)

![image](https://github.com/fjordllc/bootcamp/assets/128765400/09dd489a-4d77-4c46-b41d-af7abdcf30ba)


