### PR TITLE
提出物の未完了のものは休会中ユーザーの提出物を含めないようにした

### DIFF
--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -8,13 +8,14 @@ class API::Products::UncheckedController < API::BaseController
     checker_id = params[:checker_id]
     @products = case @target
                 when 'unchecked_all'
-                  Product.unchecked
+                  Product.unhibernated_user_products
+                         .unchecked
                          .not_wip
                          .list
                          .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 when 'unchecked_no_replied'
-                  Product.unchecked_no_replied_products
+                  Product.unhibernated_user_products_unchecked_no_replied_products
                          .unchecked
                          .not_wip
                          .list

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -15,8 +15,8 @@ class API::Products::UncheckedController < API::BaseController
                          .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 when 'unchecked_no_replied'
-                  Product.unhibernated_user_products_unchecked_no_replied_products
-                         .unchecked
+                  Product.unhibernated_user_products
+                         .unchecked_no_replied_products
                          .not_wip
                          .list
                          .page(params[:page])

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -14,7 +14,7 @@ class Cache
 
     def unchecked_product_count
       Rails.cache.fetch 'unchecked_product_count' do
-        Product.unchecked.not_wip.count
+        Product.unchecked_not_wip_hibernated_user_products.count
       end
     end
 

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -14,7 +14,7 @@ class Cache
 
     def unchecked_product_count
       Rails.cache.fetch 'unchecked_product_count' do
-        Product.unchecked_not_wip_hibernated_user_products.count
+        Product.unhibernated_user_products.unchecked.not_wip.count
       end
     end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -107,6 +107,10 @@ class Product < ApplicationRecord
            .order(published_at: :asc, id: :asc)
   end
 
+  def self.unchecked_not_wip_hibernated_user_products
+    Product.unchecked.not_wip.reject { |product| product.user.hibernated? }
+  end
+
   def completed?(user)
     checks.where(user: user).present?
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -52,13 +52,12 @@ class Product < ApplicationRecord
   scope :ascending_by_date_of_publishing_and_id, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order('commented_at asc nulls first, published_at asc') }
   scope :unchecked_no_replied_products, lambda {
-    self_last_commented_products = where.not(commented_at: nil).select do |product|
+    self_last_commented_products = where.not(commented_at: nil).filter do |product|
       product.comments.last.user_id == product.user.id
     end
     no_comments_products = where(commented_at: nil)
     no_replied_products_ids = (self_last_commented_products + no_comments_products).map(&:id)
-    where(id: no_replied_products_ids)
-      .order(published_at: :asc, id: :asc)
+    where(id: no_replied_products_ids).order(published_at: :asc, id: :asc)
   }
   scope :unhibernated_user_products, -> { joins(:user).where(user: { hibernated_at: nil }) }
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -51,7 +51,6 @@ class Product < ApplicationRecord
   scope :order_for_all_list, -> { order(published_at: :desc, id: :asc) }
   scope :ascending_by_date_of_publishing_and_id, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order('commented_at asc nulls first, published_at asc') }
-
   scope :unhibernated_user_products, -> { Product.joins(:user).where(user: { hibernated_at: nil }) }
 
   def self.add_latest_commented_at

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -100,7 +100,7 @@ class Product < ApplicationRecord
   end
 
   def self.unhibernated_user_products_unchecked_no_replied_products
-    unhibernated_user_products = Product.joins(:user).where(user: { hibernated_at: nil })
+    unhibernated_user_products = Product.unhibernated_user_products
     self_last_commented_products = unhibernated_user_products.where.not(commented_at: nil).filter do |product|
       product.comments.last.user_id == product.user.id
     end

--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -179,3 +179,10 @@ product5:
   body: 4時間後に5日経過に到達する提出物です。
   published_at: <%= (now - 60 * 60 * 23 * 5).to_formatted_s(:db) %>
   created_at: <%= (now - 60 * 60 * 23 * 5).to_formatted_s(:db) %>
+
+product76:
+  practice: practice19
+  user: kyuukai
+  body: 休会中ユーザの提出物です。
+  published_at: <%= now.to_formatted_s(:db) %>
+  created_at: <%= now.to_formatted_s(:db) %>

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -200,7 +200,7 @@ class ProductTest < ActiveSupport::TestCase
     assert_not wip_product.updated_after_submission?
   end
 
-  test 'unhibernated user products' do
+  test '.unhibernated_user_products' do
     hiberanated_user = users(:kyuukai)
 
     hibernated_user_product = Product.create!(

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -200,7 +200,7 @@ class ProductTest < ActiveSupport::TestCase
     assert_not wip_product.updated_after_submission?
   end
 
-  test '#unhibernated_user_products' do
+  test 'unhibernated user products' do
     expected_count = Product.joins(:user).where(user: { hibernated_at: nil }).count
     assert_equal expected_count, Product.unhibernated_user_products.count
   end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -201,7 +201,16 @@ class ProductTest < ActiveSupport::TestCase
   end
 
   test 'unhibernated user products' do
-    expected_count = Product.joins(:user).where(user: { hibernated_at: nil }).count
-    assert_equal expected_count, Product.unhibernated_user_products.count
+    hiberanated_user = users(:kyuukai)
+
+    hibernated_user_product = Product.create!(
+      body: "hibernated user's product.",
+      user: hiberanated_user,
+      practice: practices(:practice7),
+      checker_id: nil
+    )
+
+    assert_includes Product.all, hibernated_user_product
+    assert_not_includes Product.unhibernated_user_products, hibernated_user_product
   end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -199,4 +199,9 @@ class ProductTest < ActiveSupport::TestCase
     wip_product.update!(body: 'product is updated.', wip: false, published_at: Time.current)
     assert_not wip_product.updated_after_submission?
   end
+
+  test '#unhibernated_user_products' do
+    expected_count = Product.joins(:user).where(user: { hibernated_at: nil }).count
+    assert_equal expected_count, Product.unhibernated_user_products.count
+  end
 end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -201,8 +201,25 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_no_selector '.card-list-item__assignee-name', text: 'machida'
   end
 
-  test 'page tab item count about unchecked product is exclude unhiberanated user products' do
+  test 'the number of products in the unchecked tab is excepted unhiberanated user' do
     visit_with_auth '/products/unchecked', 'komagata'
     assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{Product.joins(:user).where(user: { hibernated_at: nil }).unchecked.not_wip.count}）"
   end
+
+  test 'unchecked products is excepted unhiberanated user' do
+    user = users(:kyuukai)
+    product_unhiberanated_user_name = "#{user.login_name} (#{user.name_kana})"
+
+    visit_with_auth '/products/unchecked', 'komagata'
+    # assert_no_text だとデータが読み込まれる前に実行され常に成立してしまうため、明示的に待機する has_text? を使用する
+    assert_not has_text?(product_unhiberanated_user_name)
+    first('.pagination__item-link', text: '2').click
+    assert_not has_text?(product_unhiberanated_user_name)
+
+    visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
+    assert_not has_text?(product_unhiberanated_user_name)
+    first('.pagination__item-link', text: '2').click
+    assert_not has_text?(product_unhiberanated_user_name)
+  end
 end
+

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -201,7 +201,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_no_selector '.card-list-item__assignee-name', text: 'machida'
   end
 
-  test 'the number of products in the unchecked tab is excepted hiberanated user' do
+  test 'the number of products in the unchecked tab excludes hibernated user' do
     visit_with_auth '/products/unchecked', 'komagata'
     expected_count = Product.unhibernated_user_products.unchecked.not_wip.count
     assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{expected_count}）"

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -200,4 +200,9 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_selector '.card-list-item__assignee-name', text: 'komagata'
     assert_no_selector '.card-list-item__assignee-name', text: 'machida'
   end
+
+  test 'page tab item count about unchecked product is exclude unhiberanated user products' do
+    visit_with_auth '/products/unchecked', 'komagata'
+    assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{Product.joins(:user).where(user: { hibernated_at: nil }).unchecked.not_wip.count}）"
+  end
 end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -207,22 +207,27 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{expected_count}）"
   end
 
-  test 'unchecked products is excepted hiberanated user' do
+  test 'unchecked products is excepted unhiberanated user' do
     hiberanated_user = users(:kyuukai)
+    practice = practices(:practice47)
+
+    Product.create!(
+      body: 'hiberanated user product.',
+      user: hiberanated_user,
+      practice: practice,
+      checker_id: nil
+    )
+
     product_hiberanated_user_name = "#{hiberanated_user.login_name} (#{hiberanated_user.name_kana})"
 
-    # 「全て」タブの確認 :1ページ目
     visit_with_auth '/products/unchecked', 'komagata'
     # assert_no_text だとデータが読み込まれる前に実行され常に成立してしまうため、明示的に待機する has_text? を使用する
     assert_not has_text?(product_hiberanated_user_name)
-    # 「全て」タブの確認 :2ページ目
     first('.pagination__item-link', text: '2').click
     assert_not has_text?(product_hiberanated_user_name)
 
-    # 「未返信」タブの確認 :1ページ目
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
     assert_not has_text?(product_hiberanated_user_name)
-    # 「未返信」タブの確認 :2ページ目
     first('.pagination__item-link', text: '2').click
     assert_not has_text?(product_hiberanated_user_name)
   end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -201,12 +201,12 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_no_selector '.card-list-item__assignee-name', text: 'machida'
   end
 
-  test 'the number of products in the unchecked tab is excepted unhiberanated user' do
+  test 'the number of products in the unchecked tab is excepted hiberanated user' do
     visit_with_auth '/products/unchecked', 'komagata'
     assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{Product.joins(:user).where(user: { hibernated_at: nil }).unchecked.not_wip.count}）"
   end
 
-  test 'unchecked products is excepted unhiberanated user' do
+  test 'unchecked products is excepted hiberanated user' do
     user = users(:kyuukai)
     product_unhiberanated_user_name = "#{user.login_name} (#{user.name_kana})"
 

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -222,4 +222,3 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_not has_text?(product_unhiberanated_user_name)
   end
 end
-

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -203,7 +203,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
 
   test 'the number of products in the unchecked tab is excepted hiberanated user' do
     visit_with_auth '/products/unchecked', 'komagata'
-    expected_count = Product.joins(:user).where(user: { hibernated_at: nil }).unchecked.not_wip.count
+    expected_count = Product.unhibernated_user_products.unchecked.not_wip.count
     assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{expected_count}）"
   end
 

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -208,17 +208,17 @@ class Product::UncheckedTest < ApplicationSystemTestCase
 
   test 'unchecked products is excepted hiberanated user' do
     user = users(:kyuukai)
-    product_unhiberanated_user_name = "#{user.login_name} (#{user.name_kana})"
+    product_hiberanated_user_name = "#{user.login_name} (#{user.name_kana})"
 
     visit_with_auth '/products/unchecked', 'komagata'
     # assert_no_text だとデータが読み込まれる前に実行され常に成立してしまうため、明示的に待機する has_text? を使用する
-    assert_not has_text?(product_unhiberanated_user_name)
+    assert_not has_text?(product_hiberanated_user_name)
     first('.pagination__item-link', text: '2').click
-    assert_not has_text?(product_unhiberanated_user_name)
+    assert_not has_text?(product_hiberanated_user_name)
 
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
-    assert_not has_text?(product_unhiberanated_user_name)
+    assert_not has_text?(product_hiberanated_user_name)
     first('.pagination__item-link', text: '2').click
-    assert_not has_text?(product_unhiberanated_user_name)
+    assert_not has_text?(product_hiberanated_user_name)
   end
 end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -201,7 +201,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_no_selector '.card-list-item__assignee-name', text: 'machida'
   end
 
-  test 'the number of products in the unchecked tab is excepted hiberanated user' do
+  test 'the number of products in the unchecked tab is excepted unhiberanated user' do
     visit_with_auth '/products/unchecked', 'komagata'
     expected_count = Product.unhibernated_user_products.unchecked.not_wip.count
     assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{expected_count}）"

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -203,7 +203,8 @@ class Product::UncheckedTest < ApplicationSystemTestCase
 
   test 'the number of products in the unchecked tab is excepted hiberanated user' do
     visit_with_auth '/products/unchecked', 'komagata'
-    assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{Product.joins(:user).where(user: { hibernated_at: nil }).unchecked.not_wip.count}）"
+    expected_count = Product.joins(:user).where(user: { hibernated_at: nil }).unchecked.not_wip.count
+    assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{expected_count}）"
   end
 
   test 'unchecked products is excepted hiberanated user' do

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -208,17 +208,21 @@ class Product::UncheckedTest < ApplicationSystemTestCase
   end
 
   test 'unchecked products is excepted hiberanated user' do
-    user = users(:kyuukai)
-    product_hiberanated_user_name = "#{user.login_name} (#{user.name_kana})"
+    hiberanated_user = users(:kyuukai)
+    product_hiberanated_user_name = "#{hiberanated_user.login_name} (#{hiberanated_user.name_kana})"
 
+    # 「全て」タブの確認 :1ページ目
     visit_with_auth '/products/unchecked', 'komagata'
     # assert_no_text だとデータが読み込まれる前に実行され常に成立してしまうため、明示的に待機する has_text? を使用する
     assert_not has_text?(product_hiberanated_user_name)
+    # 「全て」タブの確認 :2ページ目
     first('.pagination__item-link', text: '2').click
     assert_not has_text?(product_hiberanated_user_name)
 
+    # 「未返信」タブの確認 :1ページ目
     visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
     assert_not has_text?(product_hiberanated_user_name)
+    # 「未返信」タブの確認 :2ページ目
     first('.pagination__item-link', text: '2').click
     assert_not has_text?(product_hiberanated_user_name)
   end

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -201,13 +201,13 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_no_selector '.card-list-item__assignee-name', text: 'machida'
   end
 
-  test 'the number of products in the unchecked tab is excepted unhiberanated user' do
+  test 'the number of products in the unchecked tab is excepted hiberanated user' do
     visit_with_auth '/products/unchecked', 'komagata'
     expected_count = Product.unhibernated_user_products.unchecked.not_wip.count
     assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{expected_count}）"
   end
 
-  test 'unchecked products is excepted unhiberanated user' do
+  test 'unchecked products is excepted hiberanated user' do
     hiberanated_user = users(:kyuukai)
     practice = practices(:practice47)
 


### PR DESCRIPTION
## Issue

- #7112 

## 概要

提出部の未完了タブに表示する提出物一覧から休会中ユーザの提出物を除くようにしました。

## 変更確認方法

1. `feature/unhibernated_user_products_unchecked` をローカルに取り込む
2. `foreman start -f Procfile.dev` でアプリを起動しておく
3. development 環境に休会中ユーザの提出物がないため、一度 1.のブランチに切り替え `rails db:seed` でテストデータを development 環境に読み込む
4. 変更前の状況を確認するために `main` ブランチに戻す
5. メンターである komagata でログイン後、http://localhost:3000/products/unchecked にアクセスする
6. 変更前の情報を確認する
   - 未完了タブの表示数
    ![image](https://github.com/fjordllc/bootcamp/assets/90775541/5a87bf97-c7b0-482c-b588-f795e71e7b4a)
   - 提出物一覧内の休会中データ表示：休会中ユーザの提出物があることを確認する
     - [『全て』表示時](http://localhost:3000/products/unchecked?page=2)
      ![image](https://github.com/fjordllc/bootcamp/assets/90775541/c7b6bf4e-8aba-447f-8ab7-c44810110cb8)
     - [『未返信』表示時](http://localhost:3000/products/unchecked?target=unchecked_no_replied&page=2)
      ![image](https://github.com/fjordllc/bootcamp/assets/90775541/41392e82-0a08-4ebe-93e4-1fcf63461586)
7. 変更後の状況を確認するために、再度 1. のブランチに切り替える
8. http://localhost:3000/products/unchecked にアクセスする。
9. 変更後の情報を確認する
   - 未完了タブの表示数：表示数がひとつ減っていることを確認する
    ![image](https://github.com/fjordllc/bootcamp/assets/90775541/93cbf565-c0aa-40fd-a16f-a4ae86205dd4)
   - 提出物一覧内の休会中データ表示：5. で確認した位置に休会中ユーザの提出部が表示されていないことを確認する
     - [『全て』表示時](http://localhost:3000/products/unchecked?page=2)
      ![image](https://github.com/fjordllc/bootcamp/assets/90775541/b5911a67-e900-4952-b210-3157bf4f2bb2)
     - [『未返信』表示時](http://localhost:3000/products/unchecked?target=unchecked_no_replied&page=2)
      ![image](https://github.com/fjordllc/bootcamp/assets/90775541/b5911a67-e900-4952-b210-3157bf4f2bb2)
 
## Screenshot

### 前提データ

休会中ユーザの提出物は１件です。

![image.png](https://www.evernote.com/shard/s400/sh/9383957d-bfb9-458a-9950-e33faf32e53e/Pwd7KyWfmIzjUYVXAcA46_hxIqHlduxOVSboK8dIAcY0h8ET-E0SnuU8eQ/deep/0/image.png)

### 変更前

[![Image from Gyazo](https://i.gyazo.com/b74f5dc3d4ff9601eb9e8b841f5e85dd.gif)](https://gyazo.com/b74f5dc3d4ff9601eb9e8b841f5e85dd)

### 変更後

[![Image from Gyazo](https://i.gyazo.com/ac0e17e90107a5da58915d027ca317cb.gif)](https://gyazo.com/ac0e17e90107a5da58915d027ca317cb)