### PR TITLE
日報の学習日入力部分に範囲バリデーションを追加

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -126,9 +126,12 @@ class Report < ApplicationRecord
       day: 1
     }
 
-    errors.add(:reported_on, "は#{selectable_start_date[:year]}年#{selectable_start_date[:month]}月#{selectable_start_date[:day]}日以後の日付にしてください") if reported_on < Date.new(
+    if reported_on < Date.new(
       selectable_start_date[:year], selectable_start_date[:month], selectable_start_date[:day]
     )
+      errors.add(:reported_on,
+                 "は#{selectable_start_date[:year]}年#{selectable_start_date[:month]}月#{selectable_start_date[:day]}日以後の日付にしてください")
+    end
   end
 
   def latest_of_user?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -119,8 +119,14 @@ class Report < ApplicationRecord
     errors.add(:reported_on, 'は今日以前の日付にしてください') if reported_on > Date.current
   end
 
+  VALIDATION_STARTS_YEAR = 2013
+  VALIDATION_STARTS_MONTH = 1
+  VALIDATION_STARTS_DAY = 1
+
   def reported_on_or_after_specific_date
-    errors.add(:reported_on, 'は2013年1月1日以後の日付にしてください') if reported_on < Date.new(2013, 1, 1) # 通常あり得る日付になるよう、スクラムマスター(komagata)により決定
+    errors.add(:reported_on, "は#{VALIDATION_STARTS_YEAR}年#{VALIDATION_STARTS_MONTH}月#{VALIDATION_STARTS_DAY}日以後の日付にしてください") if reported_on < Date.new(
+      VALIDATION_STARTS_YEAR, VALIDATION_STARTS_MONTH, VALIDATION_STARTS_DAY
+    )
   end
 
   def latest_of_user?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -119,13 +119,15 @@ class Report < ApplicationRecord
     errors.add(:reported_on, 'は今日以前の日付にしてください') if reported_on > Date.current
   end
 
-  VALIDATION_STARTS_YEAR = 2013
-  VALIDATION_STARTS_MONTH = 1
-  VALIDATION_STARTS_DAY = 1
-
   def reported_on_or_after_specific_date
-    errors.add(:reported_on, "は#{VALIDATION_STARTS_YEAR}年#{VALIDATION_STARTS_MONTH}月#{VALIDATION_STARTS_DAY}日以後の日付にしてください") if reported_on < Date.new(
-      VALIDATION_STARTS_YEAR, VALIDATION_STARTS_MONTH, VALIDATION_STARTS_DAY
+    selectable_start_date = {
+      year: 2013,
+      month: 1,
+      day: 1
+    }
+
+    errors.add(:reported_on, "は#{selectable_start_date[:year]}年#{selectable_start_date[:month]}月#{selectable_start_date[:day]}日以後の日付にしてください") if reported_on < Date.new(
+      selectable_start_date[:year], selectable_start_date[:month], selectable_start_date[:day]
     )
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -33,6 +33,7 @@ class Report < ApplicationRecord
   validates :reported_on, presence: true, uniqueness: { scope: :user }
   validates :emotion, presence: true
   validate :reported_on_or_before_today
+  validate :reported_on_or_after_specific_date
 
   after_create ReportCallbacks.new
   after_destroy ReportCallbacks.new
@@ -116,6 +117,10 @@ class Report < ApplicationRecord
 
   def reported_on_or_before_today
     errors.add(:reported_on, 'は今日以前の日付にしてください') if reported_on > Date.current
+  end
+
+  def reported_on_or_after_specific_date
+    errors.add(:reported_on, 'は2013年1月1日以後の日付にしてください') if reported_on < Date.new(2013,1,1) #通常あり得る日付になるよう、スクラムマスター(komagata)により決定
   end
 
   def latest_of_user?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -120,7 +120,7 @@ class Report < ApplicationRecord
   end
 
   def reported_on_or_after_specific_date
-    errors.add(:reported_on, 'は2013年1月1日以後の日付にしてください') if reported_on < Date.new(2013,1,1) #通常あり得る日付になるよう、スクラムマスター(komagata)により決定
+    errors.add(:reported_on, 'は2013年1月1日以後の日付にしてください') if reported_on < Date.new(2013, 1, 1) # 通常あり得る日付になるよう、スクラムマスター(komagata)により決定
   end
 
   def latest_of_user?

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -20,7 +20,7 @@
 
       .form-item
         = f.label :reported_on, class: 'a-form-label'
-        = f.date_field :reported_on, class: 'a-text-input'
+        = f.date_field :reported_on, min: '2013-01-01', class: 'a-text-input'
       .form-item.is-sm
         = f.label :emotion, class: 'a-form-label'
         ul.block-checks.is-3-items.is-inline

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,7 +77,6 @@ ActiveRecord::Schema.define(version: 2024_05_02_051341) do
     t.datetime "published_at"
     t.text "summary"
     t.integer "thumbnail_type", default: 0, null: false
-    t.boolean "display_thumbnail_in_body", default: true, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2024_05_02_051341) do
     t.datetime "published_at"
     t.text "summary"
     t.integer "thumbnail_type", default: 0, null: false
+    t.boolean "display_thumbnail_in_body", default: true, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -43,4 +43,9 @@ class ReportTest < ActiveSupport::TestCase
   test '#interval' do
     assert_equal 10, reports(:report32).interval
   end
+
+  test '#date' do
+    report = Report.new(reported_on: Date.new(2012, 12, 31))
+    assert report.invalid?
+  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -44,7 +44,7 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal 10, reports(:report32).interval
   end
 
-  test '#date' do
+  test '#selectable_date?' do
     report = Report.new(reported_on: Date.new(2012, 12, 31))
     assert report.invalid?
   end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -470,6 +470,17 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '学習日は今日以前の日付にしてください'
   end
 
+  test 'cannot post a new report before specific date' do
+    visit_with_auth '/reports/new', 'komagata'
+    within('form[name=report]') do
+      fill_in('report[title]', with: '学習日が特定の日付以前では日報を作成できない')
+      fill_in('report[description]', with: 'エラーになる')
+      fill_in('report[reported_on]', with: Date.new(2012, 12, 31))
+    end
+    click_button '提出'
+    assert_text '学習日は2013年1月1日以後の日付にしてください'
+  end
+
   test 'display recently reports' do
     visit_with_auth report_path(reports(:report10)), 'mentormentaro'
     assert_selector 'img[alt="happy"]'

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -474,11 +474,11 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: '学習日が特定の日付以前では日報を作成できない')
-      fill_in('report[description]', with: 'エラーになる')
+      fill_in('report[description]', with: 'ページ遷移しない')
       fill_in('report[reported_on]', with: Date.new(2012, 12, 31))
     end
     click_button '提出'
-    assert_select '', text: '2013/01/01 以降の値を指定する必要があります。'
+    assert_current_path '/reports/new?_login_name=komagata'
   end
 
   test 'display recently reports' do

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -470,6 +470,17 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '学習日は今日以前の日付にしてください'
   end
 
+  test 'cannot post a new report with before specific date' do
+    visit_with_auth '/reports/new', 'komagata'
+    within('form[name=report]') do
+      fill_in('report[title]', with: '学習日が2013年より前の日付では日報を作成できない')
+      fill_in('report[description]', with: 'エラーになる')
+      fill_in('report[reported_on]', with: Date.new(2012, 12, 31))
+    end
+    click_button '提出'
+    assert_text '学習日は2013年1月1日以後の日付にしてください'
+  end
+
   test 'display recently reports' do
     visit_with_auth report_path(reports(:report10)), 'mentormentaro'
     assert_selector 'img[alt="happy"]'

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -470,17 +470,6 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '学習日は今日以前の日付にしてください'
   end
 
-  test 'cannot post a new report with before specific date' do
-    visit_with_auth '/reports/new', 'komagata'
-    within('form[name=report]') do
-      fill_in('report[title]', with: '学習日が2013年より前の日付では日報を作成できない')
-      fill_in('report[description]', with: 'エラーになる')
-      fill_in('report[reported_on]', with: Date.new(2012, 12, 31))
-    end
-    click_button '提出'
-    assert_text '学習日は2013年1月1日以後の日付にしてください'
-  end
-
   test 'display recently reports' do
     visit_with_auth report_path(reports(:report10)), 'mentormentaro'
     assert_selector 'img[alt="happy"]'

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -478,7 +478,7 @@ class ReportsTest < ApplicationSystemTestCase
       fill_in('report[reported_on]', with: Date.new(2012, 12, 31))
     end
     click_button '提出'
-    assert_text '学習日は2013年1月1日以後の日付にしてください'
+    assert_select '', text: '2013/01/01 以降の値を指定する必要があります。'
   end
 
   test 'display recently reports' do


### PR DESCRIPTION
## Issue

- #6899 

## 概要
日報を作成するときの日付として、2013年1月1日以前を選択できないようにしました。

## 変更確認方法
1. `feature/add_validation_to_date_of_report`をローカルに取り込む
2. `development`環境に`komagata`でログイン
3. `http://localhost:3000/reports/new`にアクセス
4. 学習日のカレンダーに2013年以前が表示されないことを確認
5. タイトルの入力欄からTabキーを押下して、学習日の年の入力欄へ移動
6. 年に`1990`を入力
7. 月日、タイトル、学習時間、内容、に任意の文字を入力して[提出]をクリック
8. `2013/01/01以降の値を指定する必要があります。`のアラートが出ることを確認

## Screenshot

### 変更前
- 2013年以前の年数が表示されていました。
<img width="799" alt="スクリーンショット 2023-12-10 17 37 06" src="https://github.com/fjordllc/bootcamp/assets/57088113/50efe39b-b79a-42bc-a6d1-c0091d5967db">

### 変更後
- 2013年以前の年数は表示されなくなりました。
<img width="812" alt="スクリーンショット 2023-12-10 17 38 04" src="https://github.com/fjordllc/bootcamp/assets/57088113/926d26c4-088d-4f16-94c0-50b62574992e">

- 2013年1月1日以前の日付を指定して日報を提出しようとすると、アラートが出るようになりました。
<img width="808" alt="スクリーンショット 2023-12-11 7 36 25" src="https://github.com/fjordllc/bootcamp/assets/57088113/f7586bc4-9f9d-405a-8680-101102bb4f29">