### PR TITLE
開発環境とステージング環境において、5期生のユーザ一覧ページが正しく表示されるように修正

### DIFF
--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -164,10 +164,6 @@ talk_discordinvalid:
   user: discordinvalid
   action_completed: true
 
-talk_nodiscordprofile:
-  user: nodiscordprofile
-  action_completed: true
-
 talk_twitterinvalid:
   user: twitterinvalid
   action_completed: true

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -962,28 +962,6 @@ discordinvalid: #Discord IDが不正なユーザー
   sent_student_followup_message: true
   last_activity_at: "2014-01-01 00:00:12"
 
-nodiscordprofile: #Discord情報が未登録のユーザー
-  login_name: nodiscordprofile
-  email: nodiscordprofile@fjord.jp
-  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
-  salt: zW3kQ9ubsxQQtzzzs4ap
-  name: Discord 未登録
-  name_kana: ディスコード ミトウロク
-  github_account: nodiscordprofile
-  twitter_account: nodiscord
-  facebook_url: https://www.facebook.com/fjordllc/nodiscordprofile
-  blog_url: http://nodiscordprofile.org
-  description: "Discord情報が未登録のユーザーです"
-  course: course1
-  job: office_worker
-  os: mac
-  experience: rails
-  unsubscribe_email_token: JgunX7Zejd-r1Vhqev401w
-  updated_at: "2014-01-01 00:00:12"
-  created_at: "2014-01-01 00:00:12"
-  sent_student_followup_message: true
-  last_activity_at: "2014-01-01 00:00:12"
-
 twitterinvalid: #X（Twitter） IDが不正なユーザー
   login_name: twitterinvalid
   email: twitterinvalid@fjord.jp


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7057

## 概要
開発環境において、5期生のユーザ一覧ページが「ロード中」から進まず正しく表示されないバグを、下記の方法で修正しました。

- 自らと紐づく`discord_profile`を持たないユーザーであった`nodiscordprofile`に関連するデータを、開発環境のseedsファイルから削除

## 変更確認方法

1. `bug/correctly-display-users-list-of-5th-generation-in-dev-and-staging-environments`をローカルに取り込む。
2. `bin/rails db:reset` を実行する。
3. `bin/setup` を実行する。
4. サーバーを立ち上げ、任意のユーザーでログインする。
5.  http://localhost:3000/generations/5 に行き、ユーザー一覧が表示されていることを確認する。

## バグの原因
説明のため、Issueに掲載されているエラーログを引用します。
![image](https://github.com/fjordllc/bootcamp/assets/128765400/0a5abd9c-9473-4f5b-a52c-fabe0b018b43)

```
irb(main):005:0> user = User.find(320383523)
  User Load (0.8ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 320383523], ["LIMIT", 1]]
=>                                                   
#<User:0x000000010c02ea60                            
...                                                  
irb(main):006:0> user.name
=> "Discord 未登録"
irb(main):007:0> user.discord_profile
  DiscordProfile Load (0.7ms)  SELECT "discord_profiles".* FROM "discord_profiles" WHERE "discord_profiles"."user_id" = $1 LIMIT $2  [["user_id", 320383523], ["LIMIT", 1]]
=> nil 
irb(main):008:0> user.discord_profile.account_name
(irb):8:in `<main>': undefined method `account_name' for nil:NilClass (NoMethodError)
```

`user.discord_profile`が`nil`になる、つまり`discord_profile`を持たない5期のユーザー（「Discord 未登録」、`nodiscordprofile`）が存在することが原因です。
https://github.com/fjordllc/bootcamp/blob/695d68d8f3ff87bfa07c5e58954c9c3c9f8e2509/db/fixtures/users.yml#L965C1-L965C17

もともとこのユーザーは、下のPRにおいて、`discord_profile`を持たないユーザーがいた場合の挙動を確認するためのテストデータとして作られた模様です。
- PR: https://github.com/fjordllc/bootcamp/pull/6447
- ユーザーが追加されたコミット: https://github.com/fjordllc/bootcamp/pull/6447/commits/88f423136e30e54e4a1d53d61ba3abd56fdc4d59

このユーザーが追加されたタイミングでは、「`discord_profile`を持たないユーザーもいる」ことが仕様として許容されていましたが、最終的に「すべてのユーザーが`discord_profile`を持つ」という仕様に変更され、その内容でマージされました（当該コミットは以下の通りです）。
- https://github.com/fjordllc/bootcamp/pull/6447/commits/6e60e3b174cf14211ca3a3f8966f1ff07b91bb04
- https://github.com/fjordllc/bootcamp/pull/6447/commits/f17bca97fcd72695d3fa2781bee9bd0c8e10e985

すべてのユーザーが`discord_profile`を持つ仕様にしたタイミングで、`discord_profile`を持たない上記のテストユーザーが消去されず残ったので、そのユーザーの`discord_profile`を参照すると`nil`が返り、そこに`account_name`メソッドをチェーンしてエラーになり読み込めなくなる、というのが今回のエラーの原因と思われます。

修正の方法として、
- 当該ユーザーと紐づく`discord_profile`データを一件追加する
- 当該ユーザーに関連するデータを削除する

の2種類があると考えましたが、このユーザーが追加された経緯（現在に無い仕様をチェックためのテスト）を考えると、ユーザーを残す必要はないと判断し、後者を選択しました。

## Screenshot
画面上の変更はありません（問題のあった5期生の一覧が、他の期の一覧と同じように読み込まれます）。

### 変更前
5期生の一覧画面に遷移すると、ローディング状態が終わらずユーザーが表示されない。
![ssI3Modaj9](https://github.com/fjordllc/bootcamp/assets/128765400/59984143-d360-4e8b-a036-27143eaccc22)


### 変更後
正しくユーザーが表示される。
![gOPpobAGE0](https://github.com/fjordllc/bootcamp/assets/128765400/4442c5fc-d07a-4c6b-9b72-0b3e03a53d51)

※元Issueでの「期待される振る舞い」として、

> 5期生のデータは以下の通り22人分存在するはずなので、22人のユーザーが表示される。

とありますが、

- 変更前の5期生の数は24人。
- 期別index画面では、デフォルトでは退会済みのユーザーは表示されない（5期生に退会者は二人います）。
- 上記の通り5期生から一人削除したので、全体が23人、退会済みでないものが21人。

上記の理由から、変更後では期別indexでは21人、一覧画面では23人表示されます。
（↓では21人しか表示されず、一覧では23人いるのが、正しい挙動です。）
![image](https://github.com/fjordllc/bootcamp/assets/128765400/ac724886-76a7-47b9-8d05-ffb618a47f4d)
