### PR TITLE
提出物が0のときも、[未返信/全て]のナビゲーションを表示する

### DIFF
--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -79,12 +79,22 @@ export default function Products({
     )
   } else if (data.products.length === 0) {
     return (
-      <div className="o-empty-message">
-        <div className="o-empty-message__icon">
-          <i className="fa-regular fa-smile"></i>
+      <>
+        {selectedTab === 'unchecked' || selectedTab === 'self_assigned' ? (
+          <nav className="pill-nav">
+            <ul className="pill-nav__items">
+              <FilterButtons selectedTab={selectedTab} />
+            </ul>
+          </nav>
+        ) : null}
+
+        <div className="o-empty-message">
+          <div className="o-empty-message__icon">
+            <i className="fa-regular fa-smile"></i>
+          </div>
+          <p className="o-empty-message__text">{title}はありません</p>
         </div>
-        <p className="o-empty-message__text">{title}はありません</p>
-      </div>
+      </>
     )
   } else if (isDashboard() && isNotProduct5daysElapsed()) {
     return (


### PR DESCRIPTION
## Issue
- #7111

## 概要
未完了の提出物・自分の担当の提出物ページにおいて、常に[未返信/全て]のナビゲーションを表示するように修正しました。

## 変更確認方法
1. ブランチ`bug/show-pill-navigation-always`をローカルに取り込む
2. `bin/rails server`でローカル環境を立ち上げる
3. メンターでログインし、提出物ページにアクセスする
   - 未完了の提出物ページ（`/products/unchecked`）
   - 未完了の提出物ページ・未返信（`/products/unchecked?target=unchecked_no_replied`）
   - 自分の担当の提出物ページ（`/products/self_assigned`）
   - 自分の担当の提出物ページ・未返信（`/products/self_assigned?target=self_assigned_no_replied`）
4. 提出物が0のときも、[未返信/全て]のナビゲーションが表示されていることを確認

## Screenshot
### 変更前
- 未完了の提出物ページ
<img width="1273" alt="screenshot-2023-12-11-01" src="https://github.com/fjordllc/bootcamp/assets/60736158/b6cf082e-bb9a-4e6c-87ae-34c36278b479">

- 未完了の提出物ページ・未返信
<img width="1273" alt="screenshot-2023-12-11-02" src="https://github.com/fjordllc/bootcamp/assets/60736158/a8faad3b-bb99-4b33-9838-89340dc7bbf2">

- 自分の担当の提出物ページ
<img width="1273" alt="screenshot-2023-12-11-03" src="https://github.com/fjordllc/bootcamp/assets/60736158/680e7229-4f43-497d-834f-a869ec234b1b">

- 自分の担当の提出物ページ・未返信
<img width="1273" alt="screenshot-2023-12-11-04" src="https://github.com/fjordllc/bootcamp/assets/60736158/1f71142a-2b73-4f94-a9f1-7af4ed7c404b">

### 変更後
- 未完了の提出物ページ
<img width="1273" alt="screenshot-2023-12-11-01a" src="https://github.com/fjordllc/bootcamp/assets/60736158/938b10c6-ea63-45d4-aaa8-4e4ad6294f48">

- 未完了の提出物ページ・未返信
<img width="1273" alt="screenshot-2023-12-11-02a" src="https://github.com/fjordllc/bootcamp/assets/60736158/ba281237-500e-4f3c-b851-bbb09102097c">

- 自分の担当の提出物ページ
<img width="1273" alt="screenshot-2023-12-11-03a" src="https://github.com/fjordllc/bootcamp/assets/60736158/7a9d941a-32db-431e-b5eb-d547b2575b68">

- 自分の担当の提出物ページ・未返信
<img width="1273" alt="screenshot-2023-12-11-04a" src="https://github.com/fjordllc/bootcamp/assets/60736158/605da160-6b7d-4a20-b8d3-272e21def0a4">
