### PR TITLE
コメントとメンションの通知メールフォーマット統一

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -251,7 +251,7 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:watched]
     )
     @action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
-    subject = "[FBC] #{@watchable.user.login_name}さんの#{@watchable.notification_title}で#{@sender.login_name}さんが#{@action}しました。"
+    subject = "[FBC] #{@watchable.user.login_name}さんの#{@watchable.notification_title}に#{@sender.login_name}さんが#{@action}しました。"
 
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -251,7 +251,7 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:watched]
     )
     @action = @watchable.instance_of?(Question) ? '回答' : 'コメント'
-    subject = "[FBC] #{@watchable.user.login_name}さんの【 #{@watchable.notification_title} 】に#{@sender.login_name}さんが#{@action}しました。"
+    subject = "[FBC] #{@watchable.user.login_name}さんの#{@watchable.notification_title}で#{@sender.login_name}さんが#{@action}しました。"
 
     message = mail to: @user.email, subject: subject
     message.perform_deliveries = @user.mail_notification? && !@user.retired?

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -14,7 +14,7 @@ module Mentioner
   def where_mention
     case self
     when Product
-      "#{user.login_name}さんの「#{practice[:title]}」の提出物"
+      "#{user.login_name}さんの提出物「#{practice[:title]}」"
     when Report
       "#{user.login_name}さんの日報「#{self[:title]}」"
     when Comment

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -28,7 +28,7 @@ module Watchable
     when Page
       "Docs「#{self[:title]}」"
     when Announcement
-      " お知らせ[#{self[:title]}]"
+      "お知らせ「#{self[:title]}」"
     end
   end
 

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -16,19 +16,19 @@ module Watchable
   def notification_title
     case self
     when Product
-      "「#{practice[:title]}」の提出物"
+      "提出物「#{practice[:title]}」"
     when Report
-      "「#{self[:title]}」の日報"
+      "日報「#{self[:title]}」"
     when Question
-      "「#{self[:title]}」のQ&A"
+      "Q&A「#{self[:title]}」"
     when Event
-      "「#{self[:title]}」の特別イベント"
+      "特別イベント「#{self[:title]}」"
     when RegularEvent
-      "「#{self[:title]}」の定期イベント"
+      "定期イベント「#{self[:title]}」"
     when Page
-      "「#{self[:title]}」のDocs"
+      "Docs「#{self[:title]}」"
     when Announcement
-      " [#{self[:title]}]のお知らせ"
+      " お知らせ[#{self[:title]}]"
     end
   end
 

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -299,7 +299,7 @@ class ActivityNotifier < ApplicationNotifier
     action = watchable.instance_of?(Question) ? '回答' : 'コメント'
 
     notification(
-      body: "#{watchable.user.login_name}さんの#{watchable.notification_title}で#{sender.login_name}さんが#{action}しました。",
+      body: "#{watchable.user.login_name}さんの#{watchable.notification_title}に#{sender.login_name}さんが#{action}しました。",
       kind: :watching,
       receiver: receiver,
       sender: sender,

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -299,7 +299,7 @@ class ActivityNotifier < ApplicationNotifier
     action = watchable.instance_of?(Question) ? '回答' : 'コメント'
 
     notification(
-      body: "#{watchable.user.login_name}さんの【 #{watchable.notification_title} 】に#{sender.login_name}さんが#{action}しました。",
+      body: "#{watchable.user.login_name}さんの#{watchable.notification_title}で#{sender.login_name}さんが#{action}しました。",
       kind: :watching,
       receiver: receiver,
       sender: sender,

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -622,7 +622,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['kimura@fjord.jp'], email.to
-    assert_equal '[FBC] komagataさんの【 「作業週1日目」の日報 】にmachidaさんがコメントしました。', email.subject
+    assert_equal '[FBC] komagataさんの日報「作業週1日目」でmachidaさんがコメントしました。', email.subject
     assert_match(/コメント/, email.body.to_s)
   end
 

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -622,7 +622,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['kimura@fjord.jp'], email.to
-    assert_equal '[FBC] komagataさんの日報「作業週1日目」でmachidaさんがコメントしました。', email.subject
+    assert_equal '[FBC] komagataさんの日報「作業週1日目」にmachidaさんがコメントしました。', email.subject
     assert_match(/コメント/, email.body.to_s)
   end
 

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -58,7 +58,7 @@ class CommentTest < ActiveSupport::TestCase
       assert users(:kimura).notifications.exists?(
         kind: 'watching',
         sender: users(:mentormentaro),
-        message: 'kimuraさんの【 「PC性能の見方を知る」の提出物 】にmentormentaroさんがコメントしました。'
+        message: 'kimuraさんの提出物「PC性能の見方を知る」でmentormentaroさんがコメントしました。'
       )
     end
     assert_not users(:mentormentaro).notifications.exists?(

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -58,7 +58,7 @@ class CommentTest < ActiveSupport::TestCase
       assert users(:kimura).notifications.exists?(
         kind: 'watching',
         sender: users(:mentormentaro),
-        message: 'kimuraさんの提出物「PC性能の見方を知る」でmentormentaroさんがコメントしました。'
+        message: 'kimuraさんの提出物「PC性能の見方を知る」にmentormentaroさんがコメントしました。'
       )
     end
     assert_not users(:mentormentaro).notifications.exists?(

--- a/test/system/followings_test.rb
+++ b/test/system/followings_test.rb
@@ -120,9 +120,9 @@ class FollowingsTest < ApplicationSystemTestCase
     assert_text comment
 
     visit_with_auth '/notifications', 'kimura'
-    assert_text 'hatsunoさんの日報「test title」でhatsunoさんがコメントしました。'
+    assert_text 'hatsunoさんの日報「test title」にhatsunoさんがコメントしました。'
 
     visit_with_auth '/notifications', 'mentormentaro'
-    assert_no_text 'hatsunoさんの日報「test title」でhatsunoさんがコメントしました。'
+    assert_no_text 'hatsunoさんの日報「test title」にhatsunoさんがコメントしました。'
   end
 end

--- a/test/system/followings_test.rb
+++ b/test/system/followings_test.rb
@@ -120,9 +120,9 @@ class FollowingsTest < ApplicationSystemTestCase
     assert_text comment
 
     visit_with_auth '/notifications', 'kimura'
-    assert_text 'hatsunoさんの【 「test title」の日報 】にhatsunoさんがコメントしました。'
+    assert_text 'hatsunoさんの日報「test title」でhatsunoさんがコメントしました。'
 
     visit_with_auth '/notifications', 'mentormentaro'
-    assert_no_text 'hatsunoさんの【 「test title」の日報 】にhatsunoさんがコメントしました。'
+    assert_no_text 'hatsunoさんの日報「test title」でhatsunoさんがコメントしました。'
   end
 end

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -32,13 +32,13 @@ class Notification::WatchesTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'kimura'
 
     within first('.card-list-item.is-unread') do
-      assert_text "komagataさんの【 「#{reports(:report1).title}」の日報 】にkomagataさんがコメントしました。"
+      assert_text "komagataさんの日報「#{reports(:report1).title}」でkomagataさんがコメントしました。"
     end
 
     visit_with_auth '/notifications', 'machida'
 
     within first('.card-list-item.is-unread') do
-      assert_text "komagataさんの【 「#{reports(:report1).title}」の日報 】にkomagataさんがコメントしました。"
+      assert_text "komagataさんの日報「#{reports(:report1).title}」でkomagataさんがコメントしました。"
     end
   end
 
@@ -62,13 +62,13 @@ class Notification::WatchesTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'kimura'
 
     within first('.card-list-item.is-unread') do
-      assert_text "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんが回答しました。"
+      assert_text "machidaさんのQ&A「#{questions(:question1).title}」でmachidaさんが回答しました。"
     end
 
     visit_with_auth '/notifications', 'komagata'
 
     within first('.card-list-item.is-unread') do
-      assert_text "machidaさんの【 「#{questions(:question1).title}」のQ&A 】にmachidaさんが回答しました。"
+      assert_text "machidaさんのQ&A「#{questions(:question1).title}」でmachidaさんが回答しました。"
     end
   end
 end

--- a/test/system/notification/watches_test.rb
+++ b/test/system/notification/watches_test.rb
@@ -32,13 +32,13 @@ class Notification::WatchesTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'kimura'
 
     within first('.card-list-item.is-unread') do
-      assert_text "komagataさんの日報「#{reports(:report1).title}」でkomagataさんがコメントしました。"
+      assert_text "komagataさんの日報「#{reports(:report1).title}」にkomagataさんがコメントしました。"
     end
 
     visit_with_auth '/notifications', 'machida'
 
     within first('.card-list-item.is-unread') do
-      assert_text "komagataさんの日報「#{reports(:report1).title}」でkomagataさんがコメントしました。"
+      assert_text "komagataさんの日報「#{reports(:report1).title}」にkomagataさんがコメントしました。"
     end
   end
 
@@ -62,13 +62,13 @@ class Notification::WatchesTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'kimura'
 
     within first('.card-list-item.is-unread') do
-      assert_text "machidaさんのQ&A「#{questions(:question1).title}」でmachidaさんが回答しました。"
+      assert_text "machidaさんのQ&A「#{questions(:question1).title}」にmachidaさんが回答しました。"
     end
 
     visit_with_auth '/notifications', 'komagata'
 
     within first('.card-list-item.is-unread') do
-      assert_text "machidaさんのQ&A「#{questions(:question1).title}」でmachidaさんが回答しました。"
+      assert_text "machidaさんのQ&A「#{questions(:question1).title}」にmachidaさんが回答しました。"
     end
   end
 end

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -266,7 +266,7 @@ class NotificationsTest < ApplicationSystemTestCase
       visit_with_auth "/reports/#{report}", 'hatsuno'
       assert_text 'コメントと確認した'
       find('.header-links__link.test-show-notifications').click
-      assert_text 'hatsunoさんの【 「コメントと」の日報 】にkomagataさんがコメントしました。'
+      assert_text 'hatsunoさんの日報「コメントと」でkomagataさんがコメントしました。'
     end
   end
 

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -266,7 +266,7 @@ class NotificationsTest < ApplicationSystemTestCase
       visit_with_auth "/reports/#{report}", 'hatsuno'
       assert_text 'コメントと確認した'
       find('.header-links__link.test-show-notifications').click
-      assert_text 'hatsunoさんの日報「コメントと」でにomagataさんがコメントしました。'
+      assert_text 'hatsunoさんの日報「コメントと」にkomagataさんがコメントしました。'
     end
   end
 

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -266,7 +266,7 @@ class NotificationsTest < ApplicationSystemTestCase
       visit_with_auth "/reports/#{report}", 'hatsuno'
       assert_text 'コメントと確認した'
       find('.header-links__link.test-show-notifications').click
-      assert_text 'hatsunoさんの日報「コメントと」でkomagataさんがコメントしました。'
+      assert_text 'hatsunoさんの日報「コメントと」でにomagataさんがコメントしました。'
     end
   end
 


### PR DESCRIPTION
## Issue

- [#6558](https://github.com/fjordllc/bootcamp/issues/6558)

## 概要
日報などでコメントがついた時と、メンションをされた時でメールの件名を統一するように修正しました。


## 変更確認方法

1. `feature/unified-notification-email-format`をローカルに取り込む
1. 任意のユーザーで日報（提出物等でも可）を作成する
1. 別のユーザーに切り替えて、前手順で作成した日報にコメントとメンションをつけてのコメントをそれぞれ行う
3. `http://localhost:3000/letter_opener`からメール通知の件名を確認し、下記の変更後のスクリーンショットと同様のフォーマットであればOK

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/78665068/9226c519-3046-4694-93aa-4737f9dfb623)


### 変更後
- コメントの場合
<img width="641" alt="image" src="https://github.com/fjordllc/bootcamp/assets/78665068/046599a7-1f01-41cf-b83b-fc0f0996e5fa">


- メンションの場合
<img width="708" alt="image" src="https://github.com/fjordllc/bootcamp/assets/78665068/4ba3c3cb-b9eb-4d1a-9c12-563f4614ef99">

