### PR TITLE
通知一覧画面が、タブの切り替え時に自動で最新のお知らせデータをフェッチしないようにする

### DIFF
--- a/app/javascript/components/Notifications.jsx
+++ b/app/javascript/components/Notifications.jsx
@@ -36,7 +36,7 @@ export default function Notifications({ isMentor }) {
   }
 
   const { page, setPage } = usePage()
-  const { data, error } = useSWR(apiUrl, fetcher)
+  const { data, error } = useSWR(apiUrl, fetcher, { revalidateOnFocus: false })
 
   if (error) {
     console.warn(error)


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7017

## 概要
メンター画面では、未読のお知らせ一覧画面の「未読の通知を一括で開く」ボタンを押すと、別タブで未読のお知らせを開くことができます。
その後、元の一覧タブに戻った際に、表示画面が「未読の通知はありません」状態になり、ボタンを押す前のお知らせ一覧を確認することができない現象を、下記の方法で修正しました。

- お知らせのAPIを叩くためのReactの`useSWR`フックに、タブ切り替え時の自動フェッチを行わないように設定するオプションを追加する。

### 現象の原因
- https://github.com/fjordllc/bootcamp/pull/6979 の修正で、お知らせのデータフェッチ方法が従来のものから変更された（Reactの`SWR`フックを使うようになった）。https://github.com/fjordllc/bootcamp/blob/33b4ffd5cb02dcfd30905eb50c03af71578d20e3/app/javascript/components/Notifications.jsx#L21
- それにより、タブ切り替えのタイミングで自動的にデータフェッチされる設定に変わった（`SWR`のデフォルトの設定がそうなっている）。

### 現象の解消方法
- お知らせ画面のコンポーネント内での`useSWR`フックの使用時に、`{ revalidateOnFocus: false }`オプションを指定する。

https://swr.vercel.app/ja/docs/revalidation#revalidate-on-focus
このオプションはデフォルトでは`true`に設定されている、タブ切り替え時に自動で再フェッチを行うための設定です。

「未読の通知を一括で開く」ボタンを押した段階で、それぞれの通知は`unread`状態ではなくなります（＝未読の通知が0になる）。
その後、元のタブに戻った際にデータフェッチが行われると、上記の最新状態のお知らせデータがフェッチされてからコンポーネントが描画されるため、「未読の通知はありません」状態になってしまいます。

`{ revalidateOnFocus: false }`を指定することで、一覧タブに戻ってきた際のデータフェッチを防ぐことが可能です。
※マウント時のデータフェッチ機能はオフにしていないので、その後にブラウザを更新すれば最新のデータがフェッチされ、「未読の通知はありません」状態になります。

## 変更確認方法

1. `feature/prevent-unread-notifications-from-automatically-refreshing-when-tab-switching
`をローカルに取り込む
2. サーバーを立ち上げ、未読のお知らせを持つメンターロールでhttp://localhost:3000/notifications?status=unread にアクセスする（未読のお知らせがなければ、`kimura`の日報で`komagata`にメンションするなどして作る）
3. 「未読の通知を一括で開く」ボタンを押す
4. 未読の通知タブに移動したことを確認する
5. 元の未読お知らせ一覧のタブにもどる
6. 2でアクセスした際と同じように未読のお知らせが画面に表示されていることを確認する（＝「未読の通知はありません」状態でないことを確認する）

## Screenshot

### 変更前

未読の通知一覧を開く（★）
↓
「未読の通知を一括で開く」ボタンをクリックする
↓
（未読の日報や提出物が別タブで開く）
↓
ブラウザ上で未読の通知一覧のタブに戻る
↓
★で表示されていた未読通知がすべて消えて「未読の通知はありません」が表示される
![ZM9nBdyhr1](https://github.com/fjordllc/bootcamp/assets/128765400/09961177-50fd-47e5-82f0-9c80da8b5be8)



### 変更後
未読の通知一覧を開く（★）
↓
「未読の通知を一括で開く」ボタンをクリックする
↓
（未読の日報や提出物が別タブで開く）
↓
ブラウザ上で未読の通知一覧のタブに戻る
↓
★で表示されていた未読通知を確認できる
![9MhdfZtHTz](https://github.com/fjordllc/bootcamp/assets/128765400/e678a6bc-130c-4116-84f4-7b15623999e8)

