### PR TITLE
mentor_last_commented_atがあるのにcommentがない場合のエラーを抑制

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -99,7 +99,7 @@ class Product < ApplicationRecord
 
   def self.unchecked_no_replied_products
     self_last_commented_products = Product.where.not(commented_at: nil).filter do |product|
-      product.comments.last.user_id == product.user.id
+      product.comments&.last&.user_id == product.user.id
     end
     no_comments_products = Product.where(commented_at: nil)
     no_replied_products_ids = (self_last_commented_products + no_comments_products).map(&:id)


### PR DESCRIPTION
comment削除時にmentor_last_commented_atを空にしてないのが原因。

ref: #6965