### PR TITLE
他のユーザーがWIPの提出物を閲覧したときのページタイトルの不一致を修正

### DIFF
--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -268,7 +268,7 @@ class ProductsTest < ApplicationSystemTestCase
   test "user is not alerted in the other's WIP product page" do
     wip_product = products(:product5)
     visit_with_auth "/products/#{wip_product.id}", 'hatsuno'
-    assert_equal "#{wip_product.practice.title} | FBC", title
+    assert_equal "#{wip_product.practice.title}の提出物 | FBC", title
     assert_no_text "提出物はまだ提出されていません。\n完成したら「提出する」をクリック！"
   end
 


### PR DESCRIPTION
## Issue

- #7146

## 概要

他のユーザーがWIPの提出物を閲覧した際、期待したページタイトルと実際のページタイトルが一致していない問題が発生していたためCIが落ちていました（test_user_is_not_alerted_in_the_other's_WIP_product_pageが失敗）
期待するページタイトルの文字列に「の提出物」を追加しました。
