### PR TITLE
日報のWatch解除後に、コメントを削除・編集しても再度Watch中にならないことを確認するテストの追加

### DIFF
--- a/test/system/watches_test.rb
+++ b/test/system/watches_test.rb
@@ -49,8 +49,6 @@ class WatchesTest < ApplicationSystemTestCase
       end
     end
 
-    visit current_path
-    assert_selector '#watch-button', exact_text: 'Watch'
     visit '/current_user/watches'
     assert_text 'OS X Mountain Lionをクリーンインストールする'
     assert_no_text '作業週1日目'
@@ -77,8 +75,6 @@ class WatchesTest < ApplicationSystemTestCase
     end
     assert_text 'ウォッチ確認用のtestコメントを編集'
 
-    visit current_path
-    assert_selector '#watch-button', exact_text: 'Watch'
     visit '/current_user/watches'
     assert_text 'OS X Mountain Lionをクリーンインストールする'
     assert_no_text '作業週1日目'

--- a/test/system/watches_test.rb
+++ b/test/system/watches_test.rb
@@ -32,14 +32,18 @@ class WatchesTest < ApplicationSystemTestCase
   end
 
   test "deleting a comment in a report after removing a watch to the report shouldn't change the watching status" do
-    visit_with_auth "/reports/#{reports(:report1).id}", 'mentormentaro'
+    target_report_path = "/reports/#{reports(:report1).id}"
+    visit_with_auth target_report_path, 'mentormentaro'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'ウォッチ確認用のtestコメント')
     end
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     click_button 'コメントする'
 
-    visit current_path
+    visit '/current_user/watches'
+    assert_text '作業週1日目'
+
+    visit target_report_path
     assert_text 'Watch中'
     find('#watch-button').click
     assert_text 'Watchを外しました'
@@ -55,14 +59,18 @@ class WatchesTest < ApplicationSystemTestCase
   end
 
   test "updating a comment in a report after removing a watch to the report shouldn't change the watching status" do
-    visit_with_auth "/reports/#{reports(:report1).id}", 'mentormentaro'
+    target_report_path = "/reports/#{reports(:report1).id}"
+    visit_with_auth target_report_path, 'mentormentaro'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'ウォッチ確認用のtestコメント')
     end
     all('.a-form-tabs__tab.js-tabs__tab')[1].click
     click_button 'コメントする'
 
-    visit current_path
+    visit '/current_user/watches'
+    assert_text '作業週1日目'
+
+    visit target_report_path
     assert_text 'Watch中'
     find('#watch-button').click
     assert_text 'Watchを外しました'

--- a/test/system/watches_test.rb
+++ b/test/system/watches_test.rb
@@ -30,4 +30,57 @@ class WatchesTest < ApplicationSystemTestCase
     visit_with_auth '/current_user/watches', 'komagata'
     assert_no_text 'injectとreduce'
   end
+
+  test "deleting a comment in a report after removing a watch to the report shouldn't change the watching status" do
+    visit_with_auth "/reports/#{reports(:report1).id}", 'mentormentaro'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'ウォッチ確認用のtestコメント')
+    end
+    all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    click_button 'コメントする'
+
+    visit current_path
+    assert_text 'Watch中'
+    find('#watch-button').click
+    assert_text 'Watchを外しました'
+    within('.thread-comment:last-child') do
+      accept_alert do
+        click_button('削除')
+      end
+    end
+
+    visit current_path
+    assert_selector '#watch-button', exact_text: 'Watch'
+    visit '/current_user/watches'
+    assert_text 'OS X Mountain Lionをクリーンインストールする'
+    assert_no_text '作業週1日目'
+  end
+
+  test "updating a comment in a report after removing a watch to the report shouldn't change the watching status" do
+    visit_with_auth "/reports/#{reports(:report1).id}", 'mentormentaro'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'ウォッチ確認用のtestコメント')
+    end
+    all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    click_button 'コメントする'
+
+    visit current_path
+    assert_text 'Watch中'
+    find('#watch-button').click
+    assert_text 'Watchを外しました'
+    within('.thread-comment:last-child') do
+      click_button '編集'
+      within('.thread-comment-form__form') do
+        fill_in('comment[description]', with: 'ウォッチ確認用のtestコメントを編集')
+      end
+      click_button '保存する'
+    end
+    assert_text 'ウォッチ確認用のtestコメントを編集'
+
+    visit current_path
+    assert_selector '#watch-button', exact_text: 'Watch'
+    visit '/current_user/watches'
+    assert_text 'OS X Mountain Lionをクリーンインストールする'
+    assert_no_text '作業週1日目'
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6480

## 概要

当該Issueのバグ「Watchしていない状態でコメントを削除・編集するとWatch中になってしまう」は、調査の結果、Issue起票後の別のPR（ https://github.com/fjordllc/bootcamp/pull/6854 ）によって、現時点では修正されていることが判明しました。

当該バグのデグレーションを防ぐため、

1. 日報を新規追加 （ここでWatch中になる）
1. Watchボタンを押してWatch解除
1. その日報を削除or更新

の流れのあとに、再度その日報がWatch中になっていないことを確認するテストを追加しました。

バグの解消原因については、下記のコメントにまとめておりますのでご参照ください。
https://github.com/fjordllc/bootcamp/issues/6480#issuecomment-1850253061

## 変更確認方法

1. `feature/add-tests-about-deleting-and-updating-a-comment-in-a-report-after-unwatching-the-report`をローカルに取り込む。
2. `rails test test/system/watches_test.rb:34`と`rails test test/system/watches_test.rb:57`を実行し、テストがパスすることを確認する。
3. 下の`after_create_commit`を`after_commit`に一時的に変更し（バグが修正される前の状態にする）、上記二つのテストが落ちることを確認する。

https://github.com/fjordllc/bootcamp/blob/5a71f978085f793111443058fd68f101ae39dcc0/app/models/comment.rb#L10

## Screenshot
テストのみの追加のため、画面の変更はありません。

