### PR TITLE
コースごとの書籍一覧ページを作成

### DIFF
--- a/app/controllers/courses/books_controller.rb
+++ b/app/controllers/courses/books_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Courses::BooksController < ApplicationController
+  def index
+    @course = Course.find(params[:course_id])
+  end
+end

--- a/app/javascript/components/course-books.vue
+++ b/app/javascript/components/course-books.vue
@@ -1,11 +1,5 @@
 <template lang="pug">
 .page-body
-  nav.page-filter.form
-    .container.is-md
-      filterDropdown(
-        label='プラクティスで絞り込む',
-        :options='practices',
-        v-model='practiceId')
   .page-content.is-books
     .container
       .books
@@ -29,15 +23,12 @@
 </template>
 <script>
 import CSRF from 'csrf'
-import Choices from 'choices.js'
 import Book from './book'
-import FilterDropdown from './filterDropdown'
 
 export default {
   name: 'CourseBooks',
   components: {
-    book: Book,
-    filterDropdown: FilterDropdown
+    book: Book
   },
   props: {
     isAdmin: { type: Boolean, required: true },
@@ -47,25 +38,18 @@ export default {
   data() {
     return {
       books: null,
-      practices: [],
-      practiceId: null
+      practices: []
     }
   },
   computed: {
     filteredBooks() {
-      return this.practiceId
-        ? this.books.filter((book) =>
-            book.practices.some(
-              (practice) => practice.id === Number(this.practiceId)
-            )
+      return this.books.filter((book) =>
+        book.practices.some((practice) =>
+          this.practices.some(
+            (coursePractice) => coursePractice.id === practice.id
           )
-        : this.books.filter((book) =>
-            book.practices.some((practice) =>
-              this.practices.some(
-                (coursePractice) => coursePractice.id === practice.id
-              )
-            )
-          )
+        )
+      )
     }
   },
   created() {
@@ -112,12 +96,6 @@ export default {
       })
         .then((res) => res.json())
         .then((json) => {
-          this.practices = [
-            {
-              id: null,
-              title: '全プラクティスの参考書籍を表示'
-            }
-          ]
           json.categories.forEach((category) => {
             this.practices.push(
               ...category.practices.map(
@@ -126,22 +104,7 @@ export default {
             )
           })
         })
-        .then(() => this.choicesUi())
         .catch((err) => console.warn(err))
-    },
-    choicesUi() {
-      const element = document.querySelector('#js-choices-single-select')
-      if (element) {
-        return new Choices(element, {
-          searchEnabled: true,
-          allowHTML: true,
-          searchResultLimit: 20,
-          searchPlaceholderValue: '検索ワード',
-          noResultsText: '一致する情報は見つかりません',
-          itemSelectText: '選択',
-          shouldSort: false
-        })
-      }
     }
   }
 }

--- a/app/javascript/components/course-books.vue
+++ b/app/javascript/components/course-books.vue
@@ -1,0 +1,148 @@
+<template lang="pug">
+.page-body
+  nav.page-filter.form
+    .container.is-md
+      filterDropdown(
+        label='プラクティスで絞り込む',
+        :options='practices',
+        v-model='practiceId')
+  .page-content.is-books
+    .container
+      .books
+        .empty(v-if='books === null')
+          .fa-solid.fa-spinner.fa-pulse
+          |
+          | ロード中
+        .books__items(v-else-if='books.length !== 0')
+          .row
+            book(
+              v-for='book in filteredBooks',
+              :key='book.id',
+              :book='book',
+              :isAdmin='isAdmin',
+              :isMentor='isMentor')
+        .o-empty-message(v-else)
+          .o-empty-message__icon
+            i.fa-regular.fa-sad-tear
+          p.o-empty-message__text
+            | 登録されている本はありません
+</template>
+<script>
+import CSRF from 'csrf'
+import Choices from 'choices.js'
+import Book from './book'
+import FilterDropdown from './filterDropdown'
+
+export default {
+  name: 'CourseBooks',
+  components: {
+    book: Book,
+    filterDropdown: FilterDropdown
+  },
+  props: {
+    isAdmin: { type: Boolean, required: true },
+    isMentor: { type: Boolean, required: true },
+    course: { type: Object, required: true }
+  },
+  data() {
+    return {
+      books: null,
+      practices: [],
+      practiceId: null
+    }
+  },
+  computed: {
+    filteredBooks() {
+      return this.practiceId
+        ? this.books.filter((book) =>
+            book.practices.some(
+              (practice) => practice.id === Number(this.practiceId)
+            )
+          )
+        : this.books.filter((book) =>
+            book.practices.some((practice) =>
+              this.practices.some(
+                (coursePractice) => coursePractice.id === practice.id
+              )
+            )
+          )
+    }
+  },
+  created() {
+    this.getBooks()
+    this.getPractices()
+  },
+  methods: {
+    getBooks() {
+      const uri = '/api/books.json'
+      const urlParams = new URLSearchParams(window.location.search)
+      const status = urlParams.get('status')
+      fetch(uri, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': CSRF.getToken()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      })
+        .then((res) => res.json())
+        .then((json) => {
+          if (status === 'mustread') {
+            this.books = json.books.filter((book) => book.mustRead)
+          } else {
+            this.books = []
+            json.books.forEach((book) => this.books.push(book))
+          }
+        })
+        .catch((err) => console.warn(err))
+    },
+    getPractices() {
+      const uri = `/api/courses/${this.course.id}/practices.json`
+      fetch(uri, {
+        method: 'GET',
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': CSRF.getToken()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      })
+        .then((res) => res.json())
+        .then((json) => {
+          this.practices = [
+            {
+              id: null,
+              title: '全プラクティスの参考書籍を表示'
+            }
+          ]
+          json.categories.forEach((category) => {
+            this.practices.push(
+              ...category.practices.map(
+                (categoryPractice) => categoryPractice.practice
+              )
+            )
+          })
+        })
+        .then(() => this.choicesUi())
+        .catch((err) => console.warn(err))
+    },
+    choicesUi() {
+      const element = document.querySelector('#js-choices-single-select')
+      if (element) {
+        return new Choices(element, {
+          searchEnabled: true,
+          allowHTML: true,
+          searchResultLimit: 20,
+          searchPlaceholderValue: '検索ワード',
+          noResultsText: '一致する情報は見つかりません',
+          itemSelectText: '選択',
+          shouldSort: false
+        })
+      }
+    }
+  }
+}
+</script>

--- a/app/javascript/components/course-books.vue
+++ b/app/javascript/components/course-books.vue
@@ -57,33 +57,8 @@ export default {
     this.getPractices()
   },
   methods: {
-    getBooks() {
-      const uri = '/api/books.json'
-      const urlParams = new URLSearchParams(window.location.search)
-      const status = urlParams.get('status')
-      fetch(uri, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json; charset=utf-8',
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-CSRF-Token': CSRF.getToken()
-        },
-        credentials: 'same-origin',
-        redirect: 'manual'
-      })
-        .then((res) => res.json())
-        .then((json) => {
-          if (status === 'mustread') {
-            this.books = json.books.filter((book) => book.mustRead)
-          } else {
-            this.books = []
-            json.books.forEach((book) => this.books.push(book))
-          }
-        })
-        .catch((err) => console.warn(err))
-    },
-    getPractices() {
-      const uri = `/api/courses/${this.course.id}/practices.json`
+    fetchGetData(url, callback) {
+      const uri = `/api/${url}`
       fetch(uri, {
         method: 'GET',
         headers: {
@@ -95,16 +70,31 @@ export default {
         redirect: 'manual'
       })
         .then((res) => res.json())
-        .then((json) => {
-          json.categories.forEach((category) => {
-            this.practices.push(
-              ...category.practices.map(
-                (categoryPractice) => categoryPractice.practice
-              )
-            )
-          })
-        })
+        .then(callback)
         .catch((err) => console.warn(err))
+    },
+    getBooks() {
+      this.fetchGetData(`books.json`, (json) => {
+        const urlParams = new URLSearchParams(window.location.search)
+        const status = urlParams.get('status')
+        if (status === 'mustread') {
+          this.books = json.books.filter((book) => book.mustRead)
+        } else {
+          this.books = []
+          json.books.forEach((book) => this.books.push(book))
+        }
+      })
+    },
+    getPractices() {
+      this.fetchGetData(`courses/${this.course.id}/practices.json`, (json) => {
+        json.categories.forEach((category) => {
+          this.practices.push(
+            ...category.practices.map(
+              (categoryPractice) => categoryPractice.practice
+            )
+          )
+        })
+      })
     }
   }
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -81,6 +81,7 @@ import SadReports from '../components/sad_reports.vue'
 import UserProducts from '../components/user-products.vue'
 import MentorPractices from '../components/mentor-practices.vue'
 import ActionCompletedButton from '../components/action-completed-button.vue'
+import CourseBooks from '../components/course-books.vue'
 
 import '../stylesheets/application'
 
@@ -106,6 +107,7 @@ mounter.addComponent(SadReports)
 mounter.addComponent(UserProducts)
 mounter.addComponent(MentorPractices)
 mounter.addComponent(ActionCompletedButton)
+mounter.addComponent(CourseBooks)
 mounter.mount()
 
 // Support component names relative to this directory:

--- a/app/views/courses/_tabs.html.slim
+++ b/app/views/courses/_tabs.html.slim
@@ -1,0 +1,9 @@
+.page-tabs
+  .container
+    ul.page-tabs__items
+      li.page-tabs__item
+        = link_to course_practices_path, class: "page-tabs__item-link #{current_link(/^courses-practices-index/)}" do
+            | プラクティス
+        li.page-tabs__item
+          = link_to course_books_path, class: "page-tabs__item-link #{current_link(/^courses-books-index/)} is-sm" do
+            | 書籍

--- a/app/views/courses/books/index.html.slim
+++ b/app/views/courses/books/index.html.slim
@@ -1,0 +1,27 @@
+- title "#{@course.title}コースの参考書籍"
+- set_meta_tags description: "#{@course.title}コースの参考書籍一覧ページです。"
+
+header.page-header
+  .container
+    .page-header__inner
+      h2.page-header__title
+        = title
+      .page-header-actions
+        ul.page-header-actions__items
+          - if current_user.admin_or_mentor?
+            li.page-header-actions__item
+              = link_to new_book_path, class: 'a-button is-md is-secondary is-block' do
+                i.fas.fa-plus
+                | 参考書籍登録
+= render 'courses/tabs'
+hr.a-border
+  .page-body
+    .container.is-md
+      nav.pill-nav
+        .container
+          ul.pill-nav__items
+            li.pill-nav__item
+              = link_to '全て', course_books_path, class: "pill-nav__item-link #{params[:status] == 'mustread' ? '' : 'is-active'}"
+            li.pill-nav__item
+              = link_to '必読', course_books_path(status: 'mustread'), class: "pill-nav__item-link #{params[:status] == 'mustread' ? 'is-active' : ''}"
+div(data-vue="CourseBooks" data-vue-is-admin:boolean="#{current_user.admin?}" data-vue-is-mentor:boolean="#{current_user.mentor?}" data-vue-course:json="#{@course.to_json}")

--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -34,6 +34,7 @@ header.page-header
           li.page-header-actions__item
             = link_to courses_path, class: 'a-button is-md is-secondary is-block is-back' do
               | コース一覧
+= render 'courses/tabs'
 hr.a-border
 .page-body.js-users-visibility
   .container.is-xl

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i(create edit update)
   resources :courses, only: %i(index) do
     resources :practices, only: %i(index), controller: "courses/practices"
+    resources :books, only: %i(index), controller: "courses/books"
   end
   resources :practices, only: %i(show) do
     resources :reports, only: %i(index), controller: "practices/reports"

--- a/db/fixtures/books.yml
+++ b/db/fixtures/books.yml
@@ -9,3 +9,9 @@ book2:
   price: 2640
   page_url: https://www.amazon.co.jp/dp/4822282511
   description: ソフトウェアテストの必修技法を満載した初心者にもわかりやすい解説書です。
+
+book3:
+  title: パーフェクト Ruby on Rails
+  price: 3637
+  page_url: https://www.amazon.co.jp/dp/B08D3DW7LP
+  description: 通称パRails

--- a/db/fixtures/books.yml
+++ b/db/fixtures/books.yml
@@ -15,3 +15,15 @@ book3:
   price: 3637
   page_url: https://www.amazon.co.jp/dp/B08D3DW7LP
   description: 通称パRails
+
+book4:
+  title: 新しいLinuxの教科書
+  price: 2822
+  page_url: https://www.amazon.co.jp/dp/B072K1NH76
+  description:
+
+book5:
+  title: すらすらと手が動くようになる SQL書き方ドリル
+  price: 2700
+  page_url: https://www.amazon.co.jp/dp/B07JHHSFJX
+  description:

--- a/db/fixtures/practices_books.yml
+++ b/db/fixtures/practices_books.yml
@@ -2,3 +2,8 @@ practices_book1:
   practice: practice1
   book: book1
   must_read: true
+
+practices_book2:
+  practice: practice1
+  book: book3
+  must_read: false

--- a/db/fixtures/practices_books.yml
+++ b/db/fixtures/practices_books.yml
@@ -7,3 +7,13 @@ practices_book2:
   practice: practice1
   book: book3
   must_read: false
+
+practices_book3:
+  practice: practice5
+  book: book4
+  must_read: true
+
+practices_book4:
+  practice: practice20
+  book: book5
+  must_read: false

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -9,3 +9,9 @@ book2:
   price: 2640
   page_url: https://www.amazon.co.jp/dp/4822282511
   description: ソフトウェアテストの必修技法を満載した初心者にもわかりやすい解説書です。
+
+book3:
+  title: パーフェクト Ruby on Rails
+  price: 3637
+  page_url: https://www.amazon.co.jp/dp/B08D3DW7LP
+  description: 通称パRails

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -15,3 +15,9 @@ book3:
   price: 3637
   page_url: https://www.amazon.co.jp/dp/B08D3DW7LP
   description: 通称パRails
+
+book4:
+  title: 新しいLinuxの教科書
+  price: 2822
+  page_url: https://www.amazon.co.jp/dp/B072K1NH76
+  description:

--- a/test/fixtures/practices_books.yml
+++ b/test/fixtures/practices_books.yml
@@ -2,3 +2,8 @@ practices_book1:
   practice: practice1
   book: book1
   must_read: true
+
+practices_book2:
+  practice: practice1
+  book: book3
+  must_read: false

--- a/test/fixtures/practices_books.yml
+++ b/test/fixtures/practices_books.yml
@@ -7,3 +7,8 @@ practices_book2:
   practice: practice1
   book: book3
   must_read: false
+
+practices_book3:
+  practice: practice5
+  book: book4
+  must_read: true

--- a/test/system/course/books_test.rb
+++ b/test/system/course/books_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Course::PracticesTest < ApplicationSystemTestCase
+  test 'show the course book list page' do
+    visit_with_auth "/courses/#{courses(:course1).id}/books", 'kimura'
+    assert_equal 'Railsプログラマーコースの参考書籍 | FBC', title
+  end
+
+  test 'disply in the list is books associated with practices of that course' do
+    practice_title = 'OS X Mountain Lionをクリーンインストールする'
+    visit_with_auth "/courses/#{courses(:course1).id}/books", 'kimura'
+    assert_selector '.tag-links__item-link', text: practice_title
+
+    click_link 'プラクティス', class: 'page-tabs__item-link', exact: true
+    assert_text practice_title
+  end
+
+  test 'show only must-read books' do
+    visit_with_auth "/courses/#{courses(:course1).id}/books", 'kimura'
+    must_read_books_count = page.all('.books__items .card-books-item.a-card .a-badge.is-danger.is-sm', text: '必読').count
+
+    click_link '必読', class: 'pill-nav__item-link', exact: true
+    displayed_must_read_books_count = page.all('.books__items .card-books-item.a-card').count
+    assert_equal must_read_books_count, displayed_must_read_books_count
+  end
+end

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -123,7 +123,7 @@ class PracticesTest < ApplicationSystemTestCase
     practice = practices(:practice1)
     visit_with_auth "/mentor/practices/#{practice.id}/edit", 'komagata'
     within '#reference_books' do
-      find('.choices__list').click
+      first('.choices__list').click
       find('#choices--practice_practices_books_attributes_0_book_id-item-choice-2', text: 'はじめて学ぶソフトウェアのテスト技法').click
     end
     click_button '更新する'


### PR DESCRIPTION
## Issue

- #7105

## 概要
コーズごとに必要な参考書籍一覧ページを新たに作成いたしました。

## 変更確認方法

1. `feature/create-book-list-for-each-course`をローカルに取り込む
2.  `rails db:seed`で本PRで追加した書籍のデータを development 環境に読み込む
3. `foreman start -f Procfile.dev`を実行し、ローカル環境を立ち上げる
4. `komagata`でログインし、[Railsプログラマーコース](http://localhost:3000/courses/829913840/practices)ページにアクセスする
5. 「書籍」タブをクリックする

![スクリーンショット 2023-12-17 11 35 27](https://github.com/fjordllc/bootcamp/assets/104631303/b5be742f-e2a3-4921-8838-60a32833ffb8)

6. Railsプログラマーコースのプラクティス「OS X Mountain Lionをクリーンインストールする」の参考書籍が表示されていることを確認する

- 「全て」表示の時は必読書と必読ではない本どちらも表示される
<img width="1337" alt="スクリーンショット 2023-12-21 18 52 56" src="https://github.com/fjordllc/bootcamp/assets/104631303/c2be0ac6-bf33-47ba-b04a-916e20a726ac">

- 「必読」表示の時は必読書だけが表示される
<img width="1332" alt="スクリーンショット 2023-12-21 18 57 02" src="https://github.com/fjordllc/bootcamp/assets/104631303/d6e6631f-be11-487b-9e73-2203b4ea7686">

## Screenshot

### 変更前

- 各コースページではそのコースのプラクティスのみが表示されている
![image](https://github.com/fjordllc/bootcamp/assets/104631303/ae911310-4b2d-4e6c-a2c6-a71c8cf50152)

- [参考書籍](http://localhost:3000/books)ページではコースごとに必要な書籍に絞り込むことはできない
![スクリーンショット 2023-12-17 11 58 27](https://github.com/fjordllc/bootcamp/assets/104631303/6ee24d7a-109d-4885-9607-a5d502a6463e)


### 変更後

- 各コースページの「書籍」タブにそのコースの参考書籍一覧が表示される
  - 必読書だけの一覧表示も可能

[![Image from Gyazo](https://i.gyazo.com/385b4af30d8a005745d2d096420bb7d3.gif)](https://gyazo.com/385b4af30d8a005745d2d096420bb7d3)
