### PR TITLE
提出物の自分の担当タブの絞り込みの順番を逆にする

### DIFF
--- a/app/javascript/components/Products.jsx
+++ b/app/javascript/components/Products.jsx
@@ -232,7 +232,7 @@ function ProductHeader({
 const FilterButtons = ({ selectedTab }) => {
   let targets
   if (selectedTab === 'self_assigned') {
-    targets = ['self_assigned_no_replied', 'self_assigned_all']
+    targets = ['self_assigned_all', 'self_assigned_no_replied']
   } else {
     targets = ['unchecked_no_replied', 'unchecked_all']
   }


### PR DESCRIPTION
## Issue
- [提出物 > 自分の担当 にある タブ の順序を逆にする。 #7110
](https://github.com/fjordllc/bootcamp/issues/7110)

## 概要
提出物の「自分の担当」タブの絞り込みの順番を逆（「全て」を左、「未返信」を右）にしました。

## 変更確認方法

1. ブランチ`feature/reverse-refinement-order-in-responsibilities-tabs-of-submissions`をローカルに取り込む
2. サーバーを立ち上げ、メンターロールでhttp://localhost:3000/products/self_assigned にアクセスする。
3. 絞り込み用のボタンの配置を確認する（「全て」が左側に、「未返信」が右側に配置されていること）

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/131861805/69a34819-0cda-4f8c-ac29-944938c8fe27)

### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/131861805/b098fb81-fb06-4e85-a526-79e4176d1054)
