### PR TITLE
テストでChromeの新しいヘッドレスモードを使用する様に、selenium-webdriverの設定を追加

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -24,6 +24,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     driven_by :selenium, using: :chrome
   else
     driven_by(:selenium, using: :headless_chrome) do |driver_option|
+      driver_option.add_argument('--headless=new')
       driver_option.add_argument('--no-sandbox')
       driver_option.add_argument('--disable-dev-shm-usage')
     end

--- a/test/supports/test_auth_helper.rb
+++ b/test/supports/test_auth_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module TestAuthHelper
+  # 認証のためのリクエストがテストの実行時間でかなりの部分を占めているため、高速にテスト時の認証を行うためのメソッド
   def visit_with_auth(url, login_name)
     uri = URI.parse(url)
     queries = Rack::Utils.parse_nested_query(uri.query)

--- a/test/supports/test_auth_helper.rb
+++ b/test/supports/test_auth_helper.rb
@@ -12,7 +12,7 @@ module TestAuthHelper
 
   # 特定のテストが落ちてしまうことを回避するため、明示的にログアウトを行うメソッド
   # 詳しくは Issue#7168 参照
-  def logout_by_menu
+  def logout_via_menu
     find('.test-show-menu').click
     click_link 'ログアウト'
     assert_text 'ログアウトしました。'

--- a/test/supports/test_auth_helper.rb
+++ b/test/supports/test_auth_helper.rb
@@ -2,6 +2,12 @@
 
 module TestAuthHelper
   def visit_with_auth(url, login_name)
+    if page.has_selector?('.test-show-menu')
+      find('.test-show-menu').click
+      click_link 'ログアウト'
+      assert_text 'ログアウトしました。'
+    end
+
     uri = URI.parse(url)
     queries = Rack::Utils.parse_nested_query(uri.query)
     queries['_login_name'] = login_name

--- a/test/supports/test_auth_helper.rb
+++ b/test/supports/test_auth_helper.rb
@@ -2,16 +2,18 @@
 
 module TestAuthHelper
   def visit_with_auth(url, login_name)
-    if page.has_selector?('.test-show-menu')
-      find('.test-show-menu').click
-      click_link 'ログアウト'
-      assert_text 'ログアウトしました。'
-    end
-
     uri = URI.parse(url)
     queries = Rack::Utils.parse_nested_query(uri.query)
     queries['_login_name'] = login_name
     uri.query = queries.to_query
     visit uri.to_s
+  end
+
+  # 特定のテストが落ちてしまうことを回避するため、明示的にログアウトを行うメソッド
+  # 詳しくは Issue#7168 参照
+  def logout_by_menu
+    find('.test-show-menu').click
+    click_link 'ログアウト'
+    assert_text 'ログアウトしました。'
   end
 end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -307,7 +307,7 @@ class EventsTest < ApplicationSystemTestCase
       click_link '参加申込'
     end
     assert_text '参加登録しました'
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth events_path, 'hatsuno'
     click_link '補欠者が繰り上がるイベント'
@@ -319,7 +319,7 @@ class EventsTest < ApplicationSystemTestCase
       participants = all('img').map { |img| img['alt'] }
       assert_equal %w[kimura], participants
     end
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth events_path, 'kimura'
     click_link '補欠者が繰り上がるイベント'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -307,6 +307,7 @@ class EventsTest < ApplicationSystemTestCase
       click_link '参加申込'
     end
     assert_text '参加登録しました'
+    logout_by_menu
 
     visit_with_auth events_path, 'hatsuno'
     click_link '補欠者が繰り上がるイベント'
@@ -318,6 +319,7 @@ class EventsTest < ApplicationSystemTestCase
       participants = all('img').map { |img| img['alt'] }
       assert_equal %w[kimura], participants
     end
+    logout_by_menu
 
     visit_with_auth events_path, 'kimura'
     click_link '補欠者が繰り上がるイベント'

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -81,7 +81,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{product.id}", 'komagata'
     click_button '提出物を確認'
     assert_text '提出物を確認済みにしました。'
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth '/notifications', 'kimura'
 

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -81,6 +81,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{product.id}", 'komagata'
     click_button '提出物を確認'
     assert_text '提出物を確認済みにしました。'
+    logout_by_menu
 
     visit_with_auth '/notifications', 'kimura'
 

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -99,6 +99,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
   test 'notify when a newly question was created as published' do
     visit_with_auth '/notifications', 'komagata'
     click_link '全て既読にする'
+    logout_by_menu
 
     visit_with_auth '/questions/new', 'kimura'
     within 'form[name=question]' do
@@ -107,6 +108,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     end
     click_button '登録する'
     assert_text '質問を作成しました。'
+    logout_by_menu
 
     visit_with_auth '/notifications?status=unread', 'komagata'
     assert_text 'kimuraさんから質問「公開タイトル」が投稿されました。'
@@ -264,10 +266,12 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       click_button '登録する'
       assert_text '質問を作成しました。'
     end
+    logout_by_menu
 
     visit_with_auth '/notifications', 'komagata'
     assert_text 'yameoさんが退会しました。'
     assert_text 'kimuraさんから質問「タイトルtest」が投稿されました。'
+    logout_by_menu
 
     visit_with_auth '/questions', 'komagata'
     click_on 'タイトルtest'
@@ -277,6 +281,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       end
       assert_text '質問を削除しました。'
     end
+    logout_by_menu
 
     visit_with_auth '/notifications', 'komagata'
     assert_text 'yameoさんが退会しました。'

--- a/test/system/notification/questions_test.rb
+++ b/test/system/notification/questions_test.rb
@@ -99,7 +99,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
   test 'notify when a newly question was created as published' do
     visit_with_auth '/notifications', 'komagata'
     click_link '全て既読にする'
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth '/questions/new', 'kimura'
     within 'form[name=question]' do
@@ -108,7 +108,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
     end
     click_button '登録する'
     assert_text '質問を作成しました。'
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth '/notifications?status=unread', 'komagata'
     assert_text 'kimuraさんから質問「公開タイトル」が投稿されました。'
@@ -266,12 +266,12 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       click_button '登録する'
       assert_text '質問を作成しました。'
     end
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth '/notifications', 'komagata'
     assert_text 'yameoさんが退会しました。'
     assert_text 'kimuraさんから質問「タイトルtest」が投稿されました。'
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth '/questions', 'komagata'
     click_on 'タイトルtest'
@@ -281,7 +281,7 @@ class Notification::QuestionsTest < ApplicationSystemTestCase
       end
       assert_text '質問を削除しました。'
     end
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth '/notifications', 'komagata'
     assert_text 'yameoさんが退会しました。'

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -278,6 +278,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
     find('.modal-header__close').click
+    logout_by_menu
 
     visit_with_auth '/notifications', mentor
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -278,7 +278,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
     click_button '提出'
     find('.modal-header__close').click
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth '/notifications', mentor
 

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -76,7 +76,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{product.id}", 'kimura'
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
-    logout_by_menu
+    logout_via_menu
 
     visit_with_auth '/products/unchecked', 'komagata'
     click_link '自分の担当'

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -76,6 +76,8 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{product.id}", 'kimura'
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
+    logout_by_menu
+
     visit_with_auth '/products/unchecked', 'komagata'
     click_link '自分の担当'
     assert_text product.practice.title

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -534,6 +534,7 @@ class ReportsTest < ApplicationSystemTestCase
     visit_with_auth report_path(reports(:report33)), 'kananashi'
     click_link '内容修正'
     click_button '提出'
+    find('.modal-header__close').click
 
     visit_with_auth report_path(reports(:report32)), 'komagata'
     assert_no_selector '.a-page-notice.is-only-mentor.is-danger', text: '9日ぶりの日報です'


### PR DESCRIPTION
## Issue

- #7168 

## 概要
chromedriverのバージョンを120.0.6099.109に更新し、`test/system/comments_test:238`を実行すると、次の様なエラーが発生してテストが落ちてしまいます。

※ 2023/12/29時点でchromedriverのstableなバージョンは120.0.6099.109でした。

```
% bin/rails test test/system/comments_test.rb:228                                                                                                        [main]
Running via Spring preloader in process 14053
Run options: --seed 6374

# Running:

[Screenshot Image]: /Users/kashiyamashintarou/Working/ScrumDevelopment/bootcamp/tmp/screenshots/failures_test_comment_url_is_copied_when_click_its_updated_time.png
E

Error:
CommentsTest#test_comment_url_is_copied_when_click_its_updated_time:
NoMethodError: undefined method `execute_cdp' for #<Selenium::WebDriver::Chrome::Driver:0x7e462cc0e8b31fda browser=:"chrome-headless-shell">
    test/system/comments_test.rb:238:in `block in <class:CommentsTest>'


rails test test/system/comments_test.rb:228


[Minitest::CI] Generating test report in JUnit XML format...


Finished in 4.111850s, 0.2432 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

[SeleniumのIssue](https://github.com/SeleniumHQ/selenium/issues/13319)でこのエラーについて扱われており、このエラーを解決するためにselenium-webdriverの設定で`--headless=new`オプションを指定しました。


## 変更確認方法

1. chromedriverがstableなバージョンであることを確認する([バージョン確認はこちら](https://googlechromelabs.github.io/chrome-for-testing/))
2. mainブランチに移動し、`bin/rails test test/system/comments_test.rb:228`テストを実行すると、`NoMethodError: undefined method 'execute_cdp' for`というエラーが発生してテストが落ちることを確認
3. `chore/change-settings-to-use-new-headless-mode`ブランチを取り込み、取り込んだブランチに移動して`bin/rails test test/system/comments_test.rb:228`を実行し、テストが通ることを確認する。
