### PR TITLE
newspaperの引数をハッシュで受け渡しするように統一した

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,7 +23,7 @@ class Admin::UsersController < AdminController
   def update
     if @user.update(user_params)
       destroy_subscription(@user)
-      Newspaper.publish(:retirement_create,{ user: @user }) if @user.saved_change_to_retired_on?
+      Newspaper.publish(:retirement_create, { user: @user }) if @user.saved_change_to_retired_on?
       redirect_to admin_users_url, notice: 'ユーザー情報を更新しました。'
     else
       render :edit

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,7 +23,7 @@ class Admin::UsersController < AdminController
   def update
     if @user.update(user_params)
       destroy_subscription(@user)
-      Newspaper.publish(:retirement_create, @user) if @user.saved_change_to_retired_on?
+      Newspaper.publish(:retirement_create,{ user: @user }) if @user.saved_change_to_retired_on?
       redirect_to admin_users_url, notice: 'ユーザー情報を更新しました。'
     else
       render :edit
@@ -35,7 +35,7 @@ class Admin::UsersController < AdminController
     # 制限をかけておく
     redirect_to admin_users_url, alert: '自分自身を削除する場合、退会から処理を行ってください。' if current_user.id == params[:id]
     user = User.find(params[:id])
-    Newspaper.publish(:learning_destroy, user)
+    Newspaper.publish(:learning_destroy, { user: })
     user.destroy
     redirect_to admin_users_url, notice: "#{user.name} さんを削除しました。"
   end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -38,7 +38,7 @@ class AnnouncementsController < ApplicationController
     set_wip
 
     if @announcement.update(announcement_params)
-      Newspaper.publish(:announcement_update, @announcement)
+      Newspaper.publish(:announcement_update, { announcement: @announcement })
       redirect_to Redirection.determin_url(self, @announcement), notice: notice_message(@announcement)
     else
       render :edit
@@ -50,7 +50,7 @@ class AnnouncementsController < ApplicationController
     @announcement.user_id = current_user.id
     set_wip
     if @announcement.save
-      Newspaper.publish(:announcement_create, @announcement)
+      Newspaper.publish(:announcement_create, { announcement: @announcement })
       redirect_to Redirection.determin_url(self, @announcement), notice: notice_message(@announcement)
     else
       render :new
@@ -59,7 +59,7 @@ class AnnouncementsController < ApplicationController
 
   def destroy
     @announcement.destroy
-    Newspaper.publish(:announcement_destroy, @announcement)
+    Newspaper.publish(:announcement_destroy, { announcement: @announcement })
     redirect_to announcements_path, notice: 'お知らせを削除しました'
   end
 

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -29,8 +29,8 @@ class API::AnswersController < API::BaseController
     @answer = question.answers.new(answer_params)
     @answer.user = current_user
     if @answer.save
-      Newspaper.publish(:answer_create, @answer)
-      Newspaper.publish(:answer_save, @answer)
+      Newspaper.publish(:answer_create, { answer: @answer })
+      Newspaper.publish(:answer_save, { answer: @answer })
       render :create, status: :created
     else
       head :bad_request
@@ -39,7 +39,7 @@ class API::AnswersController < API::BaseController
 
   def update
     if @answer.update(answer_params)
-      Newspaper.publish(:answer_save, @answer)
+      Newspaper.publish(:answer_save, { answer: @answer })
       head :ok
     else
       head :bad_request
@@ -48,7 +48,7 @@ class API::AnswersController < API::BaseController
 
   def destroy
     @answer.destroy
-    Newspaper.publish(:answer_destroy, @answer)
+    Newspaper.publish(:answer_destroy, { answer: @answer })
   end
 
   private

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -15,7 +15,7 @@ class API::ChecksController < API::BaseController
         user: current_user,
         checkable: checkable
       )
-      Newspaper.publish(:check_create, @check)
+      Newspaper.publish(:check_create, { check: @check })
       head :created
     else
       render json: { message: "この#{checkable.class.model_name.human}は確認済です。" }, status: :unprocessable_entity

--- a/app/controllers/api/correct_answers_controller.rb
+++ b/app/controllers/api/correct_answers_controller.rb
@@ -9,7 +9,7 @@ class API::CorrectAnswersController < API::BaseController
     @answer.type = 'CorrectAnswer'
     if @answer.save
       Newspaper.publish(:answer_save, @answer)
-      Newspaper.publish(:correct_answer_save, @answer)
+      Newspaper.publish(:correct_answer_save,{ answer: @answer })
       ChatNotifier.message("質問：「#{@answer.question.title}」のベストアンサーが選ばれました。\r#{url_for(@answer.question)}")
       render json: @answer
     else

--- a/app/controllers/api/correct_answers_controller.rb
+++ b/app/controllers/api/correct_answers_controller.rb
@@ -8,7 +8,7 @@ class API::CorrectAnswersController < API::BaseController
     @answer = @question.answers.find(params[:answer_id])
     @answer.type = 'CorrectAnswer'
     if @answer.save
-      Newspaper.publish(:answer_save, @answer)
+      Newspaper.publish(:answer_save, { answer: @answer })
       Newspaper.publish(:correct_answer_save,{ answer: @answer })
       ChatNotifier.message("質問：「#{@answer.question.title}」のベストアンサーが選ばれました。\r#{url_for(@answer.question)}")
       render json: @answer
@@ -20,7 +20,7 @@ class API::CorrectAnswersController < API::BaseController
   def update
     answer = @question.answers.find(params[:answer_id])
     answer.update!(type: '')
-    Newspaper.publish(:answer_save, @answer)
+    Newspaper.publish(:answer_save, { answer: @answer })
   end
 
   private

--- a/app/controllers/api/correct_answers_controller.rb
+++ b/app/controllers/api/correct_answers_controller.rb
@@ -9,7 +9,7 @@ class API::CorrectAnswersController < API::BaseController
     @answer.type = 'CorrectAnswer'
     if @answer.save
       Newspaper.publish(:answer_save, { answer: @answer })
-      Newspaper.publish(:correct_answer_save,{ answer: @answer })
+      Newspaper.publish(:correct_answer_save, { answer: @answer })
       ChatNotifier.message("質問：「#{@answer.question.title}」のベストアンサーが選ばれました。\r#{url_for(@answer.question)}")
       render json: @answer
     else

--- a/app/controllers/api/practices/learning_controller.rb
+++ b/app/controllers/api/practices/learning_controller.rb
@@ -29,7 +29,7 @@ class API::Practices::LearningController < API::BaseController
     status = learning.new_record? ? :created : :ok
 
     if learning.save
-      Newspaper.publish(:learning_create, learning.user)
+      Newspaper.publish(:learning_create, { user: learning.user })
       notify_to_chat_for_employment_counseling(learning) if status == :created && learning.practice.title == '就職相談部屋を作る'
       head status
     else

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -31,7 +31,7 @@ class API::QuestionsController < API::BaseController
   def update
     question = Question.find(params[:id])
     if question.update(question_params)
-      Newspaper.publish(:question_update, question) if question.saved_change_to_wip?
+      Newspaper.publish(:question_update, { question: }) if question.saved_change_to_wip?
       head :ok
     else
       head :bad_request

--- a/app/controllers/comeback_controller.rb
+++ b/app/controllers/comeback_controller.rb
@@ -12,7 +12,7 @@ class ComebackController < ApplicationController
     if @user
       if @user&.hibernated?
         @user.comeback!
-        Newspaper.publish(:comeback_update, @user)
+        Newspaper.publish(:comeback_update, { user: @user })
         @user.create_comebacked_comment
         redirect_to root_url, notice: '休会から復帰しました。'
       else

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,7 +23,7 @@ class EventsController < ApplicationController
     set_wip
     if @event.save
       update_published_at
-      Newspaper.publish(:event_create, @event)
+      Newspaper.publish(:event_create, { event: @event })
       url = publish_with_announcement? ? new_announcement_path(event_id: @event.id) : Redirection.determin_url(self, @event)
       redirect_to url, notice: notice_message(@event)
     else

--- a/app/controllers/graduation_controller.rb
+++ b/app/controllers/graduation_controller.rb
@@ -9,7 +9,7 @@ class GraduationController < ApplicationController
   def update
     if @user.update(graduated_on: Date.current)
       Subscription.new.destroy(@user.subscription_id) if @user.subscription_id
-      Newspaper.publish(:graduation_update, @user)
+      Newspaper.publish(:graduation_update, { user: @user })
       redirect_to @redirect_url, notice: 'ユーザー情報を更新しました。'
     else
       redirect_to @redirect_url, alert: 'ユーザー情報の更新に失敗しました'

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -42,7 +42,7 @@ class PagesController < ApplicationController
     if @page.save
       url = Redirection.determin_url(self, @page)
       if !@page.wip?
-        Newspaper.publish(:page_create, @page)
+        Newspaper.publish(:page_create, { page: @page })
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
 
@@ -60,7 +60,7 @@ class PagesController < ApplicationController
     if @page.update(page_params)
       url = Redirection.determin_url(self, @page)
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
-        Newspaper.publish(:page_update, @page)
+        Newspaper.publish(:page_update, { page: @page })
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
       end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,8 +40,8 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.save
-      Newspaper.publish(:product_create, @product)
-      Newspaper.publish(:product_save, @product)
+      Newspaper.publish(:product_create, { product: @product })
+      Newspaper.publish(:product_save, { product: @product })
       redirect_to Redirection.determin_url(self, @product), notice: notice_message(@product, :create)
     else
       render :new
@@ -56,7 +56,7 @@ class ProductsController < ApplicationController
     update_published_at
     if @product.update(product_params)
       Newspaper.publish(:product_update, { product: @product, current_user: current_user })
-      Newspaper.publish(:product_save, @product)
+      Newspaper.publish(:product_save, { product: @product })
       notice_another_mentor_assigned_as_checker
       redirect_to Redirection.determin_url(self, @product), notice: notice_message(@product, :update)
     else

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -63,7 +63,7 @@ class QuestionsController < ApplicationController
     @question.user = current_user
     @question.wip = params[:commit] == 'WIP'
     if @question.save
-      Newspaper.publish(:question_create, @question)
+      Newspaper.publish(:question_create, { question: @question })
       redirect_to @question, notice: notice_message(@question)
     else
       render :new

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -25,7 +25,7 @@ class RegularEventsController < ApplicationController
     if @regular_event.save
       update_publised_at
       Organizer.create(user_id: current_user.id, regular_event_id: @regular_event.id)
-      Newspaper.publish(:event_create, @regular_event)
+      Newspaper.publish(:event_create, { event: @regular_event })
       set_all_user_participants_and_watchers
       path = publish_with_announcement? ? new_announcement_path(regular_event_id: @regular_event.id) : Redirection.determin_url(self, @regular_event)
       redirect_to path, notice: notice_message(@regular_event)
@@ -40,7 +40,7 @@ class RegularEventsController < ApplicationController
     set_wip
     if @regular_event.update(regular_event_params)
       update_publised_at
-      Newspaper.publish(:regular_event_update, @regular_event)
+      Newspaper.publish(:regular_event_update, { regular_event: @regular_event })
       set_all_user_participants_and_watchers
       path = publish_with_announcement? ? new_announcement_path(regular_event_id: @regular_event.id) : Redirection.determin_url(self, @regular_event)
       redirect_to path, notice: notice_message(@regular_event)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -50,7 +50,7 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
     if @report.save
-      Newspaper.publish(:report_save, @report)
+      Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :new
@@ -63,7 +63,7 @@ class ReportsController < ApplicationController
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
     if @report.save
-      Newspaper.publish(:report_save, @report)
+      Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :edit
@@ -72,7 +72,7 @@ class ReportsController < ApplicationController
 
   def destroy
     @report.destroy
-    Newspaper.publish(:report_destroy, @report)
+    Newspaper.publish(:report_destroy, { report: @report })
     redirect_to reports_url, notice: '日報を削除しました。'
   end
 

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -13,7 +13,7 @@ class RetirementController < ApplicationController
     if current_user.save(context: :retirement)
       user = current_user
       current_user.delete_and_assign_new_organizer
-      Newspaper.publish(:retirement_create, user)
+      Newspaper.publish(:retirement_create, { user: })
       begin
         UserMailer.retire(user).deliver_now
       rescue Postmark::InactiveRecipientError => e

--- a/app/controllers/scheduler/daily/auto_retire_controller.rb
+++ b/app/controllers/scheduler/daily/auto_retire_controller.rb
@@ -15,7 +15,7 @@ class Scheduler::Daily::AutoRetireController < SchedulerController
       user.hibernated_at = nil
       user.save!(validate: false)
 
-      Newspaper.publish(:retirement_create, user)
+      Newspaper.publish(:retirement_create, { user: })
       begin
         UserMailer.auto_retire(user).deliver_now
       rescue Postmark::InactiveRecipientError => e

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,7 +67,7 @@ class UsersController < ApplicationController
     @user.course_id ||= Course.first.id
     @user.free = true if @user.trainee?
     @user.build_discord_profile
-    Newspaper.publish(:user_create, @user)
+    Newspaper.publish(:user_create, { user: @user })
     if @user.staff? || @user.trainee?
       create_free_user!
     else
@@ -95,7 +95,7 @@ class UsersController < ApplicationController
       UserMailer.welcome(@user).deliver_now
       notify_to_mentors(@user)
       notify_to_chat(@user)
-      Newspaper.publish(:student_or_trainee_create, @user) if @user.trainee?
+      Newspaper.publish(:student_or_trainee_create, { user: @user }) if @user.trainee?
       logger.info "[Signup] 4. after create times channel for free user. #{@user.email}"
       redirect_to root_url, notice: 'サインアップメールをお送りしました。メールからサインアップを完了させてください。'
     else
@@ -141,7 +141,7 @@ class UsersController < ApplicationController
         UserMailer.welcome(@user).deliver_now
         notify_to_mentors(@user)
         notify_to_chat(@user)
-        Newspaper.publish(:student_or_trainee_create, @user) if @user.student?
+        Newspaper.publish(:student_or_trainee_create, { user: @user }) if @user.student?
         logger.info "[Signup] 8. after create times channel. #{@user.email}"
         redirect_to root_url, notice: 'サインアップメールをお送りしました。メールからサインアップを完了させてください。'
       else

--- a/app/models/ai_answer_creator.rb
+++ b/app/models/ai_answer_creator.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AIAnswerCreator
-  def call(question)
+  def call(payload)
+    question = payload[:question]
     question.update(ai_answer: '')
     AIAnswerCreateJob.perform_later(question_id: question.id)
   end

--- a/app/models/announcement_notification_destroyer.rb
+++ b/app/models/announcement_notification_destroyer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AnnouncementNotificationDestroyer
-  def call(announce)
+  def call(payload)
+    announce = payload[:announcement]
     Notification.where(link: "/announcements/#{announce.id}").destroy_all
   end
 end

--- a/app/models/announcement_notifier.rb
+++ b/app/models/announcement_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AnnouncementNotifier
-  def call(announce)
+  def call(payload)
+    announce = payload[:announcement]
     return if announce.wip? || announce.published_at?
 
     announce.update(published_at: Time.current)

--- a/app/models/answer_cache_destroyer.rb
+++ b/app/models/answer_cache_destroyer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AnswerCacheDestroyer
-  def call(_answer)
+  def call(payload)
+    _answer = payload[:answer]
     Cache.delete_not_solved_question_count
   end
 end

--- a/app/models/answer_notifier.rb
+++ b/app/models/answer_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AnswerNotifier
-  def call(answer)
+  def call(payload)
+    answer = payload[:answer]
     return if answer.sender == answer.receiver
 
     question = answer.question

--- a/app/models/answerer_watcher.rb
+++ b/app/models/answerer_watcher.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class AnswererWatcher
-  def call(answer)
+  def call(payload)
+    answer = payload[:answer]
     question = Question.find(answer.question_id)
 
     return if question.watches.pluck(:user_id).include?(answer.sender.id)

--- a/app/models/comeback_notifier.rb
+++ b/app/models/comeback_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ComebackNotifier
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     User.admins_and_mentors.each do |admin_or_mentor|
       ActivityDelivery.with(sender: user, receiver: admin_or_mentor).notify(:comebacked)
     end

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -6,7 +6,7 @@ class Comment::AfterCreateCallback
       create_watch(comment)
       notify_to_watching_user(comment)
     elsif comment.sender != comment.receiver
-      Newspaper.publish(:came_comment, comment)
+      Newspaper.publish(:came_comment, { comment: })
     end
 
     if comment.commentable.instance_of?(Talk)
@@ -74,7 +74,7 @@ class Comment::AfterCreateCallback
   end
 
   def notify_to_admins(comment)
-    Newspaper.publish(:came_comment_in_talk, comment)
+    Newspaper.publish(:came_comment_in_talk, { comment: })
   end
 
   def update_action_completed(comment)

--- a/app/models/comment_notifier.rb
+++ b/app/models/comment_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class CommentNotifier
-  def call(comment)
+  def call(payload)
+    comment = payload[:comment]
     return if comment.nil?
 
     commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)

--- a/app/models/comment_notifier_for_admin.rb
+++ b/app/models/comment_notifier_for_admin.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class CommentNotifierForAdmin
-  def call(comment)
+  def call(payload)
+    comment = payload[:comment]
     return if comment.nil?
 
     User.admins.each do |admin_user|

--- a/app/models/correct_answer_notifier.rb
+++ b/app/models/correct_answer_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class CorrectAnswerNotifier
-  def call(answer)
+  def call(payload)
+    answer = payload[:answer]
     notify_correct_answer(answer) if answer.saved_change_to_attribute?('type', to: 'CorrectAnswer')
   end
 

--- a/app/models/event_organizer_watcher.rb
+++ b/app/models/event_organizer_watcher.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class EventOrganizerWatcher
-  def call(event)
+  def call(payload)
+    event = payload[:event]
     Watch.create!(user: event.user, watchable: event)
   end
 end

--- a/app/models/first_report_notifier.rb
+++ b/app/models/first_report_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class FirstReportNotifier
-  def call(report)
+  def call(payload)
+    report = payload[:report]
     return if report.wip || !report.first? || Notification.find_by(kind: :first_report, sender_id: report.user.id).present?
 
     User.admins_and_mentors.each do |receiver|

--- a/app/models/graduation_notifier.rb
+++ b/app/models/graduation_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class GraduationNotifier
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     User.mentor.each do |mentor|
       ActivityDelivery.with(sender: user, receiver: mentor).notify(:graduated)
     end

--- a/app/models/learning_cache_destroyer.rb
+++ b/app/models/learning_cache_destroyer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class LearningCacheDestroyer
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     Rails.cache.delete "/model/user/#{user.id}/completed_percentage"
   end
 end

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -2,13 +2,7 @@
 
 class LearningStatusUpdater
   def call(payload)
-    product_or_associated_object =
-      case payload
-      when Hash
-        payload[:product]
-      else
-        payload
-      end
+    product_or_associated_object = payload[:product] || payload[:check]
     case product_or_associated_object
     when Product
       update_after_submission(product_or_associated_object)

--- a/app/models/mentors_watch_for_question_creator.rb
+++ b/app/models/mentors_watch_for_question_creator.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class MentorsWatchForQuestionCreator
-  def call(question)
+  def call(payload)
+    question = payload[:question]
     return if question.wip? || question.watched?
 
     watch_question_records = watch_records(question)

--- a/app/models/notifier_to_watching_user.rb
+++ b/app/models/notifier_to_watching_user.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class NotifierToWatchingUser
-  def call(answer)
+  def call(payload)
+    answer = payload[:answer]
     question = Question.find(answer.question_id)
     mention_user_ids = answer.new_mention_users.ids
 

--- a/app/models/page_notifier.rb
+++ b/app/models/page_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class PageNotifier
-  def call(page)
+  def call(payload)
+    page = payload[:page]
     send_notification(page)
     notify_to_chat(page)
 

--- a/app/models/product_author_watcher.rb
+++ b/app/models/product_author_watcher.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ProductAuthorWatcher
-  def call(product)
+  def call(payload)
+    product = payload[:product]
     Watch.create!(user: product.user, watchable: product)
   end
 end

--- a/app/models/product_notifier_for_colleague.rb
+++ b/app/models/product_notifier_for_colleague.rb
@@ -2,13 +2,7 @@
 
 class ProductNotifierForColleague
   def call(payload)
-    product =
-      case payload
-      when Hash
-        payload[:product]
-      else
-        payload
-      end
+    product = payload[:product]
     return if product.wip
 
     notify_advisers product if product.user.trainee? && product.user.company

--- a/app/models/product_notifier_for_practice_watcher.rb
+++ b/app/models/product_notifier_for_practice_watcher.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ProductNotifierForPracticeWatcher
-  def call(product)
+  def call(payload)
+    product = payload[:product]
     return if product.wip
 
     practice = Practice.find(product.practice_id)

--- a/app/models/question_notifier.rb
+++ b/app/models/question_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class QuestionNotifier
-  def call(question)
+  def call(payload)
+    question = payload[:question]
     return if question.wip?
 
     ChatNotifier.message(<<~TEXT)

--- a/app/models/regular_event_update_notifier.rb
+++ b/app/models/regular_event_update_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class RegularEventUpdateNotifier
-  def call(regular_event)
+  def call(payload)
+    regular_event = payload[:regular_event]
     participants = regular_event.participants
 
     participants.each do |participant|

--- a/app/models/report_notifier.rb
+++ b/app/models/report_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ReportNotifier
-  def call(report)
+  def call(payload)
+    report = payload[:report]
     Cache.delete_unchecked_report_count
 
     return unless report.first_public?

--- a/app/models/sad_streak_updater.rb
+++ b/app/models/sad_streak_updater.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class SadStreakUpdater
-  def call(report)
+  def call(payload)
+    report = payload[:report]
     report.user.update_sad_streak
   end
 end

--- a/app/models/sign_up_notifier.rb
+++ b/app/models/sign_up_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class SignUpNotifier
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     user.unsubscribe_email_token = SecureRandom.urlsafe_base64
   end
 end

--- a/app/models/times_channel_creator.rb
+++ b/app/models/times_channel_creator.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class TimesChannelCreator
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     raise ArgumentError, "#{user.login_name}は現役生または研修生ではありません。" unless user.student_or_trainee?
 
     times_channel = Discord::TimesChannel.new(user.login_name)

--- a/app/models/times_channel_destroyer.rb
+++ b/app/models/times_channel_destroyer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class TimesChannelDestroyer
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     return unless user.discord_profile.times_id
 
     if Discord::Server.delete_text_channel(user.discord_profile.times_id)

--- a/app/models/unfinished_data_destroyer.rb
+++ b/app/models/unfinished_data_destroyer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class UnfinishedDataDestroyer
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     Product.where(user: user).unchecked.destroy_all
     Report.where(user: user).wip.destroy_all
     user.update(job_seeking: false)

--- a/test/models/event_organizer_watcher_test.rb
+++ b/test/models/event_organizer_watcher_test.rb
@@ -6,7 +6,7 @@ class EventOrganizerWatcherTest < ActiveSupport::TestCase
   test '#call' do
     event = events(:event3)
     assert_difference 'Watch.where(user: event.user, watchable: event).count', 1 do
-      EventOrganizerWatcher.new.call(event)
+      EventOrganizerWatcher.new.call({ event: })
     end
   end
 end

--- a/test/models/product_notifier_for_practice_watcher_test.rb
+++ b/test/models/product_notifier_for_practice_watcher_test.rb
@@ -24,7 +24,7 @@ class ProductNotifierForPracticeWatcherTest < ActiveSupport::TestCase
     product.save!
 
     perform_enqueued_jobs do
-      ProductNotifierForPracticeWatcher.new.call(product)
+      ProductNotifierForPracticeWatcher.new.call({ product: })
     end
     assert Notification.where(user_id: watch.user_id, sender_id: product.user_id,
                               message: "#{product.user.login_name}さんが「#{product.practice.title}」の提出物を提出しました。").exists?

--- a/test/models/times_channel_creator_test.rb
+++ b/test/models/times_channel_creator_test.rb
@@ -10,13 +10,13 @@ class TimesChannelCreatorTest < ActiveSupport::TestCase
 
     Rails.logger.stub(:warn, ->(message) { logs << message }) do
       Discord::TimesChannel.stub(:new, ->(_) { InvalidTimesChannel.new }) do
-        TimesChannelCreator.new.call(user)
+        TimesChannelCreator.new.call({ user: })
       end
       assert_nil user.discord_profile.times_id
       assert_equal "[Discord API] #{user.login_name}の分報チャンネルが作成できませんでした。", logs.pop
 
       Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
-        TimesChannelCreator.new.call(user)
+        TimesChannelCreator.new.call({ user: })
       end
       assert_equal '1234567890123456789', user.discord_profile.times_id
       assert_nil logs.last
@@ -27,21 +27,21 @@ class TimesChannelCreatorTest < ActiveSupport::TestCase
     user = users(:adminonly)
     assert user.admin?
     assert_raise ArgumentError do
-      TimesChannelCreator.new.call(user)
+      TimesChannelCreator.new.call({ user: })
     end
     assert_not user.student_or_trainee?
 
     user = users(:mentormentaro)
     assert user.mentor?
     assert_raise ArgumentError do
-      TimesChannelCreator.new.call(user)
+      TimesChannelCreator.new.call({ user: })
     end
     assert_not user.student_or_trainee?
 
     user = users(:senpai)
     assert user.adviser?
     assert_raise ArgumentError do
-      TimesChannelCreator.new.call(user)
+      TimesChannelCreator.new.call({ user: })
     end
     assert_not user.student_or_trainee?
   end

--- a/test/models/times_channel_destroyer_test.rb
+++ b/test/models/times_channel_destroyer_test.rb
@@ -9,7 +9,7 @@ class TimesChannelDestroyerTest < ActiveSupport::TestCase
     user.discord_profile.update!(times_id: '987654321987654321')
     Rails.logger.stub(:warn, ->(message) { logs << message }) do
       Discord::Server.stub(:delete_text_channel, true) do
-        TimesChannelDestroyer.new.call(user)
+        TimesChannelDestroyer.new.call({ user: })
       end
       assert_nil user.discord_profile.times_id
       assert_nil logs.last
@@ -22,7 +22,7 @@ class TimesChannelDestroyerTest < ActiveSupport::TestCase
     user.discord_profile.update!(times_id: '987654321987654321')
     Rails.logger.stub(:warn, ->(message) { logs << message }) do
       Discord::Server.stub(:delete_text_channel, nil) do
-        TimesChannelDestroyer.new.call(user)
+        TimesChannelDestroyer.new.call({ user: })
       end
       assert_equal '987654321987654321', user.discord_profile.times_id
       assert_equal "[Discord API] #{user.login_name}の分報チャンネルが削除できませんでした。", logs.last


### PR DESCRIPTION
## Issue

- #6617

## 概要
newspaperを呼び出す際に引数をハッシュで受け渡しするように統一しました。

## 変更確認方法
1. `feature/unify-newspaper-arguments-with-hash`をローカルに取り込む
2. 以下の「変更確認前の下準備」を行う
3. `foreman start -f Procfile.dev`を実行し、ローカル環境を立ち上げる
4. 「動作確認」をそれぞれ試し、newspaperの引数をハッシュでの受け渡しに変更する前と変わらない処理が行われることを確認する

### 変更確認前の下準備
#### キャッシュ削除確認のための準備
1. `models/answer_cache_destroyer.rb`の`call`メソッドの1行目に`puts "AnswerCacheDestroyer#call"`を追記する
2. `app/models/learning_cache_destroyer.rb`の`call`メソッドの1行目に`puts "LearningCacheDestroyer#call"`を追記する

#### Develop環境でのDiscrod通知の設定
##### ウェブフックURLの取得方法
以下の方法でDiscordにサーバーを追加し、ウェブフックURLを取得する
[Develop環境でのDiscord通知の確認方法 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95#1-%E3%82%A6%E3%82%A7%E3%83%96%E3%83%95%E3%83%83%E3%82%AFurl%E3%81%AE%E5%8F%96%E5%BE%97)

##### お知らせ投稿関連の通知確認用
`app/notifiers/discord_notifier.rb`の` announced`メソッド内の`webhook_url `を変更する

```
  def announced(params = {})
    params.merge!(@params)
    # 以下をコメントアウト
    # webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:all]
    # 以下を追記
    webhook_url = ENV['DISCORD_ALL_WEBHOOK_URL'] || '{取得したウェブフックURL}'
    # 省略
  end
```

##### 通知確認用

サーバーを立ち上げるターミナルで以下を実行しておく
```
# 初日報投稿関連の通知確認用
export DISCORD_INTRODUCTION_WEBHOOK_URL='{取得したウェブフックURL}'

# メンターと管理者への通知確認用
export DISCORD_MENTOR_WEBHOOK_URL='{取得したウェブフックURL}'
export DISCORD_ADMIN_WEBHOOK_URL='{取得したウェブフックURL}'
```

##### ユーザー作成時の分報自動作成用
[こちら](https://github.com/fjordllc/bootcamp/pull/6185#:~:text=%E3%81%AF%E3%81%82%E3%82%8A%E3%81%BE%E3%81%9B%E3%82%93%E3%80%82-,%E6%B3%A8%E6%84%8F%E3%83%BB%E4%BC%9D%E9%81%94%E4%BA%8B%E9%A0%85,-Discord%20Bot%20%E3%82%92)の手順に沿って環境変数を行う

### 動作確認
#### イベント作成時の処理
1. `kimura`でログインし、[定期イベント作成ページ](http://localhost:3000/regular_events/new)で自分を主催者にしてイベントを作成する
2. 作成したイベントが「Watch中」になっていることを確認する

#### 定期イベントの更新時の処理
1. `kimura`でログインする
2. [開発MTG](http://localhost:3000/regular_events/459650222)にアクセスして参加申し込みをする
4. `komagata`でログインし直す
5. [開発MTGの編集ページ](http://localhost:3000/regular_events/459650222/edit)にアクセスして、イベントの内容を変更する
　※変更内容は自由。例：開始時間を15:30に変更する
6. 再度`kimura`でログインする
7. `http://localhost:3000/letter_opener`にアクセスして`kimura`宛に「[FBC]定期イベント【開発MTG】が更新されました。」という件名のメールが届いていること、メール内の「定期イベント詳細へ」をクリックすると2のイベントページ遷移することを確認する
8. ページ右上のベルマーク通知で「定期イベント【開発MTG】が更新されました。」と表示されること、通知をクリックすると2のイベントページ遷移することを確認する

#### 質問への回答作成、削除時の処理
1.  `kimura`でログインする
2. [質問作成ページ](http://localhost:3000/questions/new)でテスト用の質問を作成する
3. Watchするためのユーザー`kensyu`でログインし、2で作成した質問をWatchする
4. 回答者用のユーザー`hajime`でログインし直す
5. 2で作成した質問にテスト用の回答をし、質問がWatch中になったことを確認する
6. 実行ターミナル画面に`AnswerCacheDestroyer#call`が出力されていることを確認する
7. 質問作成者の`kimura`で再度ログインし、ページ右上のベルマーク通知で「hajimeさんから回答がありました。」と表示されること、通知をクリックすると6の回答に遷移することを確認する
8. Watch中の`kensyu`でログインし、ページ右上のベルマーク通知で「kimuraさんの【{質問タイトル}のQ＆A】にhajimeさんが回答しました。」と表示されること、通知をクリックすると5の回答に遷移することを確認する
9. `http://localhost:3000/letter_opener`にアクセスし、質問作成者の`kimura`宛に件名「[FBC]hajimeさんから回答がありました。」のメールが届いていること、「回答へ」をクリックすると5の回答に遷移することを確認する
10. 質問Watch中の`kensyu`宛に件名「[FBC]kimuraさんの【{質問タイトル}のQ＆A】にhajimeさんが回答しました。」以下のメール通知が届いていることこと、「回答へ」をクリックすると5の回答に遷移することを確認する
11. 質問回答者の`hajime`でログインし、5で作成した回答を削除する
12. 実行ターミナル画面に`AnswerCacheDestroyer#call`が出力されていることを確認する

#### お知らせ投稿、削除時の処理
1. `komagata`でログインする
2. [お知らせ作成ページ](http://localhost:3000/announcements/new)で通知ターゲットを全員にしてお知らせを作成する
3. `kimura`でログインする
4. ページ右上のベルマーク通知で「お知らせ「テスト」」と表示されること、通知をクリックすると2で作成したお知らせページに遷移することを確認する
5. `http://localhost:3000/letter_opener`にアクセスして、`kimura`宛に件名「[FBC] お知らせ「{お知らせタイトル}」のメールが届いていること、通知をクリックすると2で作成したお知らせページに遷移することを確認する
6. Discordサーバーに2で作成したお知らせの通知「お知らせ：「{お知らせタイトル}」が届いていることを確認する
7. 再度`komagata`でログインする
8. [お知らせ作成ページ](http://localhost:3000/announcements/new)で通知ターゲットを全員にしてお知らせを作成し、WIPで保存する
9. 8でWIPで保存したお知らせを編集、公開する
10. 3~6と同様の手順で8で作成したお知らせの通知が届いていることを確認する
11. 再度`komagata`でログインし、8で作成したお知らせを削除する
12. `kimura`でログインする
13. [お知らせ一覧ページ](http://localhost:3000/notifications?target=announcement)にアクセスし、8で作成したお知らせの通知が削除されていることを確認する

#### 日報の投稿関連の処理
##### 研修生の日報投稿
1. `kimura`でログインし、`kensyu`の[プロフィールページ](http://localhost:3000/users/301971253)で`kensyu`をフォローする
2. `kensyu`でログインし、[日報作成ページ](http://localhost:3000/reports/new)で日報を投稿する
3. アドバイザーである`senpai`でログインし、以下を確認する
  - ページ右上のベルマーク通知で「kensyuさんが日報【{日報タイトル}】を書きました！」と表示されること、通知をクリックすると2で投稿した日報に遷移すること、「Watch中」になっていることを確認する
4. フォロワー`kimura`でログインし、3と同様の手順で以下を確認する
- サイト内に通知されていること
- サイト内通知から2で投稿した日報に飛び、「Watch中」になっていること

5. `http://localhost:3000/letter_opener`にアクセスして、`senpai`と`kimura`宛に件名「[FBC] kensyuさんが日報【 {日報タイトル} 】を書きました！」のメールが届いていること、「この日報へ！！！」をクリックすると2で投稿した日報に遷移することを確認する

##### 初めての日報投稿/悲しい日報2連続投稿
1. `muryou`でログインする
2. [日報作成ページ](http://localhost:3000/reports/new)で以下内容で日報を投稿する
- 1日前の日付
- 「今日の気分」はsadを選択
3. `komagata`でログインし、ページ右上のベルマーク通知で「muryouさんがはじめての日報を書きました！」と表示されること、通知をクリックすると2で投稿した日報に遷移することを確認する
4. 以下を確認する
- `http://localhost:3000/letter_opener`にアクセスして、管理者/メンターである`komagata`宛に件名「[FBC] muryouさんがはじめての日報を書きました！」のメールが届いていること、「この日報へ！！！」をクリックすると2で投稿した日報に遷移すること
- Discordに「🎉 muryouさんがはじめての日報を書きました！」通知が届いていること
5. `muryou`で再度ログインする
6.  [日報作成ページ](http://localhost:3000/reports/new)で以下内容で日報を投稿する
- 当日の日付
- 「今日の気分」はsadを選択
7. `komagata`でログインし、以下を確認する
- `http://localhost:3000/letter_opener`にアクセスして、管理者/メンターである`komagata`に「[FBC] muryouさんが2回連続でsadアイコンの日報を提出しました。」といった通知メールが届いていることを確認する
8. rails consoleで以下を実行する

```
user = User.find_by(login_name: "muryou")
# trueになることを確認する
user.sad_streak
# 6で投稿した日報のidが出力されることを確認する
user.last_sad_report_id
exit
```

9. `muryou`で再度ログインし、6で作成した日報を削除する
10. rails consoleで以下を実行する

```
user = User.find_by(login_name: "muryou")
# falseになることを確認する
user.sad_streak
#  9で出力された日報idから変わっている（=2で作成した日報idが出力される）ことを確認する
user.last_sad_report_id
exit
```

#### Learningのキャッシュ削除処理
1. `muryou`でログイン
2. 未着手のプラクティス[Debianをインストールする
](http://localhost:3000/practices/581802908)ページに行き、ステータスを着手に変更する
3. ターミナルに`"LearningCacheDestroyer#call"`が出力されていることを確認する
4. `komagata`でログインする
5. `http://localhost:3000/users/746986380`ページに行き、`muryou`を削除する
6. ターミナルに`"LearningCacheDestroyer#call"`が出力されていることを確認する

#### Q＆Aベストアンサーの決定関連の処理
1. `kimura`でログインする
2. [質問](http://localhost:3000/questions/1037106414)ページに飛び、テスト用に回答をする
3. 2の質問者である`hajime`でログインし、[質問](http://localhost:3000/questions/1037106414)ページから2の`kimura`の回答をベストアンサーにする
4. `http://localhost:3000/letter_opener/`にアクセスし、`kimura`宛に「…kimuraさんの回答がベストアンサーに選ばれました。」というメール通知が飛んでいること、 メール本文内の「回答へ」をクリックすると2で投稿した回答に遷移することを確認する
6. 再び`kimura`でログインする
7. ページ右上のベルマーク通知で、「…kimuraさんの回答がベストアンサーに選ばれました。」と表示されること、通知をクリックすると2で回答した質問に遷移することを確認する

#### ユーザー作成時の処理
1. ログアウトした状態で[フィヨルドブートキャンプ参加登録ページ](http://localhost:3000/users/new)にアクセスする
2. ユーザー情報を入力し、登録する

※カード番号については以下を参考にする
[Test payment methods | Stripe のドキュメント](https://stripe.com/docs/testing?locale=ja-JP#cards)

3. ユーザーが新規記録されたら、ターミナルで`rails console`を立ち上げる
4. `User.last`を実行し、先ほど新規記録されたユーザの情報が表示されることを確認する
5. 表示された情報のうち`unsubscribe_email_token`に値が表示されることを確認する
6. Discordに2で登録したユーザーの分報が作成されていることを確認する

#### ユーザーの卒業時の処理
1. `komagata`でログインし、`fujiyasu`の[プロフィールページ](http://localhost:3000/users/199512416)にアクセスする
2. 画面下部の「ステータス変更」内の「卒業にする」をクリックし、`fujiyasu`が卒業済みになることを確認する

<img width="1099" alt="スクリーンショット 2024-01-02 19 43 12" src="https://github.com/fjordllc/bootcamp/assets/104631303/06aa9aba-a68a-4173-813f-f5b4c9383451">

3. `http://localhost:3000/letter_opener/`にアクセスし、`komagata`宛に「[FBC] fujiyasuさんが卒業しました。」という件名のメール通知が飛んでいること、 メール本文内の「fujiyasuさんのページへ」をクリックすると`fujiyasu`のプロフィールページに遷移することを確認する
4. ページ右上のベルマーク通知で、「🎉️ fujiyasuさんが卒業しました！」と表示されること、クリックすると`fujiyasu`のプロフィールページに遷移することを確認する
6. Discordに「🎉️ fujiyasuさんが卒業しました！」と通知が飛んでいることを確認（adminとmentorに通知を送るので、2件通知が来ること確認できればOK）

#### 休会復帰時の処理
1. [休会からの復帰ページ](http://localhost:3000/comeback/new）にアクセスし、休会中ユーザー`kyuukai`の復帰手続きを行う
※メールアドレスとパスワードは[こちら](https://github.com/fjordllc/bootcamp/blob/main/db/fixtures/users.yml)

2. `http://localhost:3000/letter_opener/`にアクセスし、`komagata`宛に「[FBC] kyuukaiさんが休会から復帰しました。」というメール通知が飛んでいること、メール本文内の「kyuukaiさんのページへ」をクリックすると`kyuukai`のプロフィールページに遷移することを確認する
3. `komagata`でログインし、右上のベルマーク通知で、「kyuukaiさんが休会から復帰しました！」と表示されること、クリックすると`kyuukai`のプロフィールページに遷移することを確認する

#### 提出物関連の処理
1. `mentormentaro`でログインする
2. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスにアクセスし、「Watch」を押下する
![スクリーンショット 2024-01-02 14.21.20.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdzVUQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--5fc50a11842462003cf2ee8e38699b540ea87f68/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202024-01-02%2014.21.20.png)

3. `kensyu`でログインする
4. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスにアクセスし、提出物を作成する
5. 提出後、提出物が`Watch中`になっていることを確認
6. `http://localhost:3000/letter_opener/`にアクセスし、「[FBC] kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました。」というメール通知が以下2名に飛んでいること、メール本文内の「提出物へ」をクリックすると4で作成した提出物ページに遷移することを確認
- アドバイザーの`senpai`
- プラクティスWatch中の`mentormentaro`
7. `senpai`でログインし、ページ右上のベルマーク通知で、「kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました。」と表示されること、通知をクリックすると4で作成した提出物に遷移することを確認
8. `mentormentaro`でログインし、ページ右上のベルマーク通知で、「kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました。」と表示されること、通知をクリックすると4で作成した提出物に遷移することを確認
21. `komagata`でログインする
22. [未アサインの提出物一覧ページ](http://localhost:3000/products/unassigned)で4で作成した課題にアクセスし「担当する」
11. 再び`kensyu`でログインする
12. 4で作成した課題を更新し、 [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスのステータスが「提出」のままであることを確認
13. `http://localhost:3000/letter_opener/`にアクセスし、「[FBC] kensyuさんが「Terminalの基礎を覚える」の提出物を更新しました。」というメール通知が以下3名に飛んでいること、メール本文内の「提出物へ」をクリックすると12で更新した提出物ページに遷移することを確認
- 課題担当者の`komagata`
- アドバイザーの`senpai`
- プラクティスWatch中の`mentormentaro`
14. 以下のユーザーでログインし、ページ右上のベルマーク通知で、「kensyuさんが「Terminalの基礎を覚える」の提出物を更新しました。」と表示されること、通知をクリックすると12で更新した提出物に遷移することを確認
- 担当メンターの`komagata`
- アドバイザーの`senpai`
- プラクティスWatch中の`mentormentaro`
15. 再び｀kensyu`でログインする
16. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスのステータスを「着手」に変更する
17. 4で作成した課題を「内容修正」→下書き保存し、ステータスは「着手」のままであることを確認
18. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスのステータスを「未着手」に変更
19. 17で下書き保存した課題を「内容修正」→再び下書き保存し、ステータスが「着手」になることを確認
20.  [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスのステータスを再び「未着手」に変更
21. [Debianをインストールする](http://localhost:3000/practices/581802908)プラクティスのステータスを「着手」に変更する
22. 19で下書き保存した [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスの課題を再度下書き保存し、ステータスが「未着手」のままであることを確認
23. 19で下書き保存した[Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスの課題を提出する
24. 再び`komagata`でログインし、22で担当した課題ページに飛び「課題を確認する」を押下
25. `kensyu`でログインし直し、[Terminalの基礎を覚える
](http://localhost:3000/practices/198065840)プラクティスのステータスが「修了」になっていることを確認

#### Docs投稿時の処理
##### 新規投稿
1. `kimura`でログインする
2. [ドキュメント作成ページ](http://localhost:3000/pages/new)でDocsを作成し、「Docを公開」を押下
3. `http://localhost:3000/letter_opener/`にアクセスし、`komagata`や他メンター/管理者宛に「[FBC] kimuraさんがDocsに{Docsのタイトル}を投稿しました。」というメール通知が飛んでいること、メール本文内の「このDocsへ」をクリックすると2で作成したDocsに遷移することを確認
4. `komagata`でログインし、ページ右上のベルマーク通知で、「[FBC] kimuraさんがDocsに{ドキュメントのタイトル}を投稿しました。」と表示されること、通知をクリックすると2で作成したDocsに遷移することを確認
5. Discordに「Docs：「{Docsのタイトル}」が作成されました。」と通知が飛んでいることを確認

##### 下書き保存から更新しての新規投稿
1. `kimura`でログインする
2. [ドキュメント作成ページ](http://localhost:3000/pages/new)でDocsを作成し、「WIP」を押下
3. 2で下書き保存したDocsを「内容を更新」を押下して公開する
4. `http://localhost:3000/letter_opener/`にアクセスし、`komagata`や他メンター/管理者宛に「[FBC] kimuraさんがDocsに{Docsのタイトル}を投稿しました。」というメール通知が飛んでいること、メール本文内の「このDocsへ」をクリックすると2で作成したDocsに遷移することを確認
5. `komagata`でログインし、ページ右上のベルマーク通知で、「[FBC] kimuraさんがDocsに{ドキュメントのタイトル}を投稿しました。」と表示されること、通知をクリックすると2で作成したDocsに遷移することを確認
6. Discordに「Docs：「{Docsのタイトル}」が作成されました。」と通知が飛んでいることを確認

#### Q＆A投稿時の処理
##### 質問の新規登録
1. `kimura`でログインする
2. [質問するページ](http://localhost:3000/questions/new)で質問を登録する
3. Discordに「質問：「{質問のタイトル}」をkimuraさんが作成しました。」と通知が飛んでいることを確認
4. `komagata`でログイン
5. `http://localhost:3000/letter_opener/`にアクセスし、`komagata`や他メンター/管理者宛に「[FBC] kimuraさんから「{質問タイトル}」が投稿されました。」という件名のメール通知が飛んでいること、メール本文内の「質問へ」ををクリックすると2で登録した質問に遷移することを確認
6. `komagata`でログインし、ページ右上のベルマーク通知で、「kimuraさんから質問「{質問タイトル}」が投稿されました。」と表示されること、通知をクリックすると2で登録した質問に遷移することを確認
7. 6の遷移先で質問が「Watch中」になっていることを確認
8. 6の遷移先で「AIによって生成された解答」が表示されていることを確認

![image.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeGxUQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--f7ea16cefb38ecbd13eb8c7fda25afb260a2a892/image.png)

##### 一度下書き保存した質問の新規登録

1. `kimura`でログインする
2. [質問するページ](http://localhost:3000/questions/new)で質問を作成し、WIPを押下し一度下書き保存する
3. 2で下書き保存をした質問を「内容修正」→「質問を公開」を押下し、質問を公開する
4.  「質問の新規登録」で行った4~8の確認を行う

#### ユーザー退会時の処理
##### 【共通】ユーザーの新規作成
1. ログアウトした状態で[フィヨルドブートキャンプ参加登録ページ](http://localhost:3000/users/new)にアクセスする
2. ユーザー情報を入力し、登録する
※カード番号については以下を参考にする
[Test payment methods | Stripe のドキュメント](https://stripe.com/docs/testing?locale=ja-JP#cards)
3. 2で登録したユーザーでサインアップする
4. Discordに2で登録したユーザーの分報が生成されていることを確認する
5. `komagata`でログインする
6. 2で登録したユーザー個別ページにアクセスし、以下処理を行う
- 「就職活動中」をONにする
- 「管理者として情報変更」を押下し「ユーザー登録情報変更」でコースを「Railsプログラマー」に変更する

![スクリーンショット 2024-01-02 16.45.23.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeHBUQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--8fa693b7fff5f8d9a490e96a0955bb254473f92d/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202024-01-02%2016.45.23.png)

[![Image from Gyazo](https://i.gyazo.com/adb782c49bf58e38ed4ec2aad5e0faea.gif)](https://gyazo.com/adb782c49bf58e38ed4ec2aad5e0faea)

7. 再度2で登録したユーザーでログインする
8.  [日報作成ページ](http://localhost:3000/reports/new)で日報を作成し、WIPで保存する
9. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスページで提出物を作成する
10. `rails console`を立ち上げ、以下を実行する

```ruby
user = User.last

# 1が返ってくることを確認
Product.where(user: user).unchecked.count

# 1が返ってくることを確認
Report.where(user: user).wip.count

# trueが返ってくることを確認
user.job_seeking
```

##### 自身で退会するケース
1. 【共通】ユーザーの新規作成の手順を行う
2. 1で作成したユーザーでログイン
3. [退会手続き](http://localhost:3000/retirement/new)画面で退会手続きを行う
4. Discordから1で作成したユーザーの分報が削除されていることを確認
5. `rails console`を立ち上げ、以下を実行する

```ruby
user = User.last

# 0が返ってくることを確認
Product.where(user: user).unchecked.count

# 0が返ってくることを確認
Report.where(user: user).wip.count

# falseが返ってくることを確認
user.job_seeking
```

##### 管理者が退会処理を行うケース
1. 【共通】ユーザーの新規作成の手順を行う
2. komagataでログイン
3. 1で作成したユーザーのプロフィールページにアクセスし、「管理者として情報変更」を押下
4. 「ユーザーステータス」の「退会済」にチェックを入れ、退会日を入力して「更新する」を押下
![スクリーンショット 2024-01-02 17.04.15.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeHRUQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--dbdbc52d606165959a14f0e1ff37dc8e6ae33de5/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202024-01-02%2017.04.15.png)
5. 「自身で退会するケース」の4,5の内容を確認する

##### 休会から6ヶ月経過して自動退会になったケース
1. 【共通】ユーザーの新規作成の手順を行う
2. 1で作成したユーザーでログインし、[休会手続きページ](http://localhost:3000/hibernation/new)から休会手続きを行う
4. `komagata`でログインし、[休会ユーザー一覧](http://localhost:3000/users?target=hibernated)に1で作成したユーザーが表示されていることを確認
5. `rails console`を立ち上げ、ユーザーの退会日を6ヵ月前にする

```
user = User.find_by(login_name: 'auto-retire')
user.update!(hibernated_at: 6.months.ago)
```

6. `rails console`でkyuukai（Kyu Kai)ユーザーを削除しておく
※このユーザーにはダミーのサブスクリプション番号が登録されており、このユーザーを退会させようとすると定期支払い削除処理でエラーになるため
```
user = User.find_by(login_name: 'kyuukai')
user.destroy!
```

7. ブラウザでhttp://localhost:3000/scheduler/daily/auto_retire?token=hogeにアクセス（画面は表示されないが、処理が走る）
8. [休会ユーザー一覧](http://localhost:3000/users?target=hibernated)をリロードし、1で作成したユーザーが表示されないこと、[退会ユーザー一覧](http://localhost:3000/users?target=retired)に表示されることを確認
9.  「自身で退会するケース」の4,5の内容を確認する

#### 相談部屋のコメント投稿時の処理
1. `komagata`でログインする
2. [kimuraさんの相談部屋](http://localhost:3000/talks/868847020)にアクセスし、コメントする
3. `http://localhost:3000/letter_opener/`にアクセスし、`kimura`宛に「[FBC] 相談部屋でkomagataさんからコメントがありました。」という件名のメール通知が飛んでいること、メール本文内の「コメントへ」をクリックすると2で投稿したコメントに遷移することを確認
4. `kimura`でログインし、ページ右上のベルマーク通知で、「相談部屋でkomagataさんからコメントがありました。」と表示されること、通知をクリックすると2で投稿したコメントに遷移することを確認
5. `kimura`が[kimuraさんの相談部屋](http://localhost:3000/talks/868847020)でコメントをする
6. `http://localhost:3000/letter_opener/`にアクセスし、`komagata`宛に「[FBC] kimuraさんの相談部屋でkimuraさんからコメントが届きました。」という件名のメール通知が飛んでいること、メール本文内の「コメントへ」をクリックすると2で投稿したコメントに遷移することを確認
7. `komagata`でログインし、ページ右上のベルマーク通知で、「kimuraさんの相談部屋でkimuraさんからコメントが届きました。」と表示されること、通知をクリックすると5で投稿したコメントに遷移することを確認

## Screenshot
画面上の変更点はありません
