### PR TITLE
newspaperの引数をハッシュでの受け渡しに統一 1/2

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,7 +35,7 @@ class Admin::UsersController < AdminController
     # 制限をかけておく
     redirect_to admin_users_url, alert: '自分自身を削除する場合、退会から処理を行ってください。' if current_user.id == params[:id]
     user = User.find(params[:id])
-    Newspaper.publish(:learning_destroy, user)
+    Newspaper.publish(:learning_destroy, { user: })
     user.destroy
     redirect_to admin_users_url, notice: "#{user.name} さんを削除しました。"
   end

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -15,7 +15,7 @@ class API::ChecksController < API::BaseController
         user: current_user,
         checkable: checkable
       )
-      Newspaper.publish(:check_create, @check)
+      Newspaper.publish(:check_create, { check: @check })
       head :created
     else
       render json: { message: "この#{checkable.class.model_name.human}は確認済です。" }, status: :unprocessable_entity

--- a/app/controllers/api/practices/learning_controller.rb
+++ b/app/controllers/api/practices/learning_controller.rb
@@ -29,7 +29,7 @@ class API::Practices::LearningController < API::BaseController
     status = learning.new_record? ? :created : :ok
 
     if learning.save
-      Newspaper.publish(:learning_create, learning.user)
+      Newspaper.publish(:learning_create, { user: learning.user })
       notify_to_chat_for_employment_counseling(learning) if status == :created && learning.practice.title == '就職相談部屋を作る'
       head status
     else

--- a/app/controllers/comeback_controller.rb
+++ b/app/controllers/comeback_controller.rb
@@ -12,7 +12,7 @@ class ComebackController < ApplicationController
     if @user
       if @user&.hibernated?
         @user.comeback!
-        Newspaper.publish(:comeback_update, @user)
+        Newspaper.publish(:comeback_update, { user: @user })
         @user.create_comebacked_comment
         redirect_to root_url, notice: '休会から復帰しました。'
       else

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,8 +40,8 @@ class ProductsController < ApplicationController
     set_wip
     update_published_at
     if @product.save
-      Newspaper.publish(:product_create, @product)
-      Newspaper.publish(:product_save, @product)
+      Newspaper.publish(:product_create, { product: @product })
+      Newspaper.publish(:product_save, { product: @product })
       redirect_to Redirection.determin_url(self, @product), notice: notice_message(@product, :create)
     else
       render :new
@@ -56,7 +56,7 @@ class ProductsController < ApplicationController
     update_published_at
     if @product.update(product_params)
       Newspaper.publish(:product_update, { product: @product, current_user: current_user })
-      Newspaper.publish(:product_save, @product)
+      Newspaper.publish(:product_save, { product: @product })
       notice_another_mentor_assigned_as_checker
       redirect_to Redirection.determin_url(self, @product), notice: notice_message(@product, :update)
     else

--- a/app/models/comeback_notifier.rb
+++ b/app/models/comeback_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ComebackNotifier
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     User.admins_and_mentors.each do |admin_or_mentor|
       ActivityDelivery.with(sender: user, receiver: admin_or_mentor).notify(:comebacked)
     end

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -6,7 +6,7 @@ class Comment::AfterCreateCallback
       create_watch(comment)
       notify_to_watching_user(comment)
     elsif comment.sender != comment.receiver
-      Newspaper.publish(:came_comment, comment)
+      Newspaper.publish(:came_comment, { comment: })
     end
 
     if comment.commentable.instance_of?(Talk)
@@ -74,7 +74,7 @@ class Comment::AfterCreateCallback
   end
 
   def notify_to_admins(comment)
-    Newspaper.publish(:came_comment_in_talk, comment)
+    Newspaper.publish(:came_comment_in_talk, { comment: })
   end
 
   def update_action_completed(comment)

--- a/app/models/comment_notifier.rb
+++ b/app/models/comment_notifier.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class CommentNotifier
-  def call(comment)
+  def call(payload)
+    comment = payload[:comment]
     return if comment.nil?
 
     commentable_path = Rails.application.routes.url_helpers.polymorphic_path(comment.commentable)

--- a/app/models/comment_notifier_for_admin.rb
+++ b/app/models/comment_notifier_for_admin.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class CommentNotifierForAdmin
-  def call(comment)
+  def call(payload)
+    comment = payload[:comment]
     return if comment.nil?
 
     User.admins.each do |admin_user|

--- a/app/models/learning_cache_destroyer.rb
+++ b/app/models/learning_cache_destroyer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class LearningCacheDestroyer
-  def call(user)
+  def call(payload)
+    user = payload[:user]
     Rails.cache.delete "/model/user/#{user.id}/completed_percentage"
   end
 end

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -2,13 +2,7 @@
 
 class LearningStatusUpdater
   def call(payload)
-    product_or_associated_object =
-      case payload
-      when Hash
-        payload[:product]
-      else
-        payload
-      end
+    product_or_associated_object = payload[:product] || payload[:check]
     case product_or_associated_object
     when Product
       update_after_submission(product_or_associated_object)

--- a/app/models/product_author_watcher.rb
+++ b/app/models/product_author_watcher.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ProductAuthorWatcher
-  def call(product)
+  def call(payload)
+    product = payload[:product]
     Watch.create!(user: product.user, watchable: product)
   end
 end

--- a/app/models/product_notifier_for_colleague.rb
+++ b/app/models/product_notifier_for_colleague.rb
@@ -2,13 +2,7 @@
 
 class ProductNotifierForColleague
   def call(payload)
-    product =
-      case payload
-      when Hash
-        payload[:product]
-      else
-        payload
-      end
+    product = payload[:product]
     return if product.wip
 
     notify_advisers product if product.user.trainee? && product.user.company

--- a/app/models/product_notifier_for_practice_watcher.rb
+++ b/app/models/product_notifier_for_practice_watcher.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ProductNotifierForPracticeWatcher
-  def call(product)
+  def call(payload)
+    product = payload[:product]
     return if product.wip
 
     practice = Practice.find(product.practice_id)

--- a/test/models/product_notifier_for_practice_watcher_test.rb
+++ b/test/models/product_notifier_for_practice_watcher_test.rb
@@ -24,7 +24,7 @@ class ProductNotifierForPracticeWatcherTest < ActiveSupport::TestCase
     product.save!
 
     perform_enqueued_jobs do
-      ProductNotifierForPracticeWatcher.new.call(product)
+      ProductNotifierForPracticeWatcher.new.call({ product: })
     end
     assert Notification.where(user_id: watch.user_id, sender_id: product.user_id,
                               message: "#{product.user.login_name}さんが「#{product.practice.title}」の提出物を提出しました。").exists?


### PR DESCRIPTION
## Issue

- #6617

## 概要
newspaperを呼び出す際に引数をハッシュで受け渡しするように統一しました。
※対応範囲が広いため、2つのPRに分けています。

もう1件のPRは以下
[newspaperの引数をハッシュでの受け渡しに統一 2/2](https://github.com/fjordllc/bootcamp/pull/7174)

## 変更確認方法
1. `feature/unify-newspaper-arguments-with-hash_1/2`をローカルに取り込む
2. 以下の「変更確認前の下準備」を行う
3. `foreman start -f Procfile.dev`を実行し、ローカル環境を立ち上げる
4. 「動作確認」をそれぞれ試し、newspaperの引数をハッシュでの受け渡しに変更する前と変わらない処理が行われることを確認する

### 変更確認前の下準備
#### キャッシュ削除確認のための準備
`app/models/learning_cache_destroyer.rb`の`call`メソッドの1行目に`puts "LearningCacheDestroyer#call"`を追記する

### 動作確認
#### チェックリスト　※必要に応じてご利用いただければと思います🙇‍♀️
- [x] Learningのキャッシュ削除処理
- [x] 休会復帰時の処理
- [x] 提出物関連の処理
- [x] 相談部屋のコメント投稿時の処理

#### Learningのキャッシュ削除処理
1. `muryou`でログイン
2. 未着手のプラクティス[Debianをインストールする
](http://localhost:3000/practices/581802908)ページに行き、ステータスを着手に変更する
3. ターミナルに`"LearningCacheDestroyer#call"`が出力されていることを確認する
4. `komagata`でログインする
5. `http://localhost:3000/users/746986380`ページに行き、`muryou`を削除する
6. ターミナルに`"LearningCacheDestroyer#call"`が出力されていることを確認する

-----

#### 休会復帰時の処理
1. [休会からの復帰ページ](http://localhost:3000/comeback/new)にアクセスし、休会中ユーザー`kyuukai`の復帰手続きを行う
※メールアドレスとパスワードは[こちら](https://github.com/fjordllc/bootcamp/blob/main/db/fixtures/users.yml)

2. `http://localhost:3000/letter_opener/`にアクセスし、`komagata`宛に「[FBC] kyuukaiさんが休会から復帰しました。」というメール通知が飛んでいること、メール本文内の「kyuukaiさんのページへ」をクリックすると`kyuukai`のプロフィールページに遷移することを確認する
3. `komagata`でログインし、右上のベルマーク通知で、「kyuukaiさんが休会から復帰しました！」と表示されること、クリックすると`kyuukai`のプロフィールページに遷移することを確認する

------

#### 提出物関連の処理
1. `mentormentaro`でログインする
2. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスにアクセスし、「Watch」を押下する
![スクリーンショット 2024-01-02 14.21.20.png](https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBdzVUQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--5fc50a11842462003cf2ee8e38699b540ea87f68/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202024-01-02%2014.21.20.png)

3. `kensyu`でログインする
4. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスにアクセスし、提出物を作成する
5. 提出後、提出物が`Watch中`になっていることを確認する
6. `http://localhost:3000/letter_opener/`にアクセスし、「[FBC] kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました。」というメール通知が以下2名に飛んでいること、メール本文内の「提出物へ」をクリックすると4で作成した提出物ページに遷移することを確認する
- アドバイザーの`senpai`
- プラクティスWatch中の`mentormentaro`
7. `senpai`でログインし、ページ右上のベルマーク通知で、「kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました。」と表示されること、通知をクリックすると4で作成した提出物に遷移することを確認する
8. `mentormentaro`でログインし、ページ右上のベルマーク通知で、「kensyuさんが「Terminalの基礎を覚える」の提出物を提出しました。」と表示されること、通知をクリックすると4で作成した提出物に遷移することを確認する
9. 再び｀kensyu`でログインする
10. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスのステータスを「着手」に変更する
11. 4で作成した課題を「内容修正」→下書き保存し、プラクティスのステータスが「着手」のままであることを確認する
12. [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスのステータスを「未着手」に変更する
13. 11で下書き保存した課題を「内容修正」→再び下書き保存し、プラクティスのステータスが「着手」になることを確認する
14.  [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスのステータスを再び「未着手」に変更する
15. [Debianをインストールする](http://localhost:3000/practices/581802908)プラクティスのステータスを「着手」に変更する
16. 13で下書き保存した [Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスの課題を再度下書き保存し、プラクティスのステータスが「未着手」のままであることを確認する
17. 16で下書き保存した[Terminalの基礎を覚える](http://localhost:3000/practices/198065840)プラクティスの課題を提出する
18. `komagata`でログインし、17で提出された課題ページに飛び「課題を確認する」を押下する
19. `kensyu`でログインし直し、[Terminalの基礎を覚える
](http://localhost:3000/practices/198065840)プラクティスのステータスが「修了」になっていることを確認する

-------

#### 相談部屋のコメント投稿時の処理
1. `komagata`でログインする
2. [kimuraさんの相談部屋](http://localhost:3000/talks/868847020)にアクセスし、コメントする
3. `http://localhost:3000/letter_opener/`にアクセスし、`kimura`宛に「[FBC] 相談部屋でkomagataさんからコメントがありました。」という件名のメール通知が飛んでいること、メール本文内の「コメントへ」をクリックすると2で投稿したコメントに遷移することを確認する
4. `kimura`でログインし、ページ右上のベルマーク通知で、「相談部屋でkomagataさんからコメントがありました。」と表示されること、通知をクリックすると2で投稿したコメントに遷移することを確認する
5. `kimura`が[kimuraさんの相談部屋](http://localhost:3000/talks/868847020)でコメントをする
6. `http://localhost:3000/letter_opener/`にアクセスし、`komagata`宛に「[FBC] kimuraさんの相談部屋でkimuraさんからコメントが届きました。」という件名のメール通知が飛んでいること、メール本文内の「コメントへ」をクリックすると2で投稿したコメントに遷移することを確認する
7. `komagata`でログインし、ページ右上のベルマーク通知で、「kimuraさんの相談部屋でkimuraさんからコメントが届きました。」と表示されること、通知をクリックすると5で投稿したコメントに遷移することを確認する

## Screenshot

画面上の変更点はありません