### PR TITLE
学習時間が日付を跨いだ場合の表記を追加

### DIFF
--- a/app/views/reports/_learning_times.html.slim
+++ b/app/views/reports/_learning_times.html.slim
@@ -10,4 +10,4 @@
     ul.learning-times__items
       - @report.learning_times.each do |learning_time|
         li.learning-times__item
-          | #{l learning_time.started_at, format: :time_only} 〜 #{l learning_time.finished_at, format: :time_only}
+          | #{l learning_time.started_at, format: :time_only} 〜 #{'(翌日)' if learning_time.started_at.day < learning_time.finished_at.day}#{l learning_time.finished_at, format: :time_only}

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -237,7 +237,7 @@ class ReportsTest < ApplicationSystemTestCase
     within '.learning-times__total-time' do
       assert_text '1時間', exact: true
     end
-    assert_text '23:00 〜 00:00'
+    assert_text '23:00 〜 (翌日)00:00'
 
     click_link '内容修正'
 
@@ -273,7 +273,7 @@ class ReportsTest < ApplicationSystemTestCase
     click_button '提出'
 
     assert_text "4時間\n"
-    assert_text '22:00 〜 00:00'
+    assert_text '22:00 〜 (翌日)00:00'
     assert_text '00:30 〜 02:30'
   end
 


### PR DESCRIPTION
## Issue

- #6723
## 概要
日報の学習時間が日付を跨いだときに(翌日)の文言を表示するようにしました。
こちらのIssueは日報の学習時間を30時間まで延長するものでしたが、開発MTGでの談義の結果、日付を跨いだ場合は終了時刻の先頭に`(翌日)`の文言を表示する修正に変更になりました。
## 変更確認方法

1. `feature/report_learning_times_extension`をローカルに取り込む
2. 任意のユーザーでログインする
3. ダッシュボード(http://localhost:3000/) で日報作成のボタンを押下
4. 各項目を記入、学習時間が日付を跨ぐように選択し、提出ボタンを押下(例: 開始時間 23:00 ~ 終了時間 06:00)
5. 提出された日報の学習時間の終了時刻に`(翌日)`が表示されていることを確認
## Screenshot

### 変更前
<img width="796" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/cd11a7b1-0b9f-4cdd-918e-f01a66f26912">
### 変更後
<img width="796" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/7bf61e3a-cc29-43d3-b107-eda0979c0f8b">


