### PR TITLE
【メンター向け】「最後のコメントから5日経過しました」のDiscordメッセージにメンションを付けるようにした

### DIFF
--- a/app/models/discord/server.rb
+++ b/app/models/discord/server.rb
@@ -64,6 +64,19 @@ module Discord
         guild_id && authorize_token
       end
 
+      def find_member_id(member_name:)
+        return nil unless enabled?
+
+        limit = 1000
+        guild_members_json = Discordrb::API::Server.resolve_members(authorize_token, guild_id, limit)
+        guild_members = JSON.parse(guild_members_json.body)
+        target_member = guild_members.select { |member| member['user']['username'] == member_name }
+        target_member == [] ? nil : target_member[0]['user']['id']
+      rescue Discordrb::Errors::CodeError => e
+        log_error(e)
+        nil
+      end
+
       private
 
       def log_error(exception)

--- a/app/models/discord/server.rb
+++ b/app/models/discord/server.rb
@@ -64,6 +64,19 @@ module Discord
         guild_id && authorize_token
       end
 
+      def find_member_id(member_name:)
+        return nil unless enabled?
+
+        limit = 1000
+        guild_members_json = Discordrb::API::Server.resolve_members(authorize_token, guild_id, limit)
+        guild_members = JSON.parse(guild_members_json.body)
+        target_member = guild_members.select { |member| member['user']['username'] == member_name }
+        target_member[0]['user']['id']
+      rescue Discordrb::Errors::CodeError => e
+        log_error(e)
+        nil
+      end
+
       private
 
       def log_error(exception)

--- a/app/models/discord/server.rb
+++ b/app/models/discord/server.rb
@@ -64,19 +64,6 @@ module Discord
         guild_id && authorize_token
       end
 
-      def find_member_id(member_name:)
-        return nil unless enabled?
-
-        limit = 1000
-        guild_members_json = Discordrb::API::Server.resolve_members(authorize_token, guild_id, limit)
-        guild_members = JSON.parse(guild_members_json.body)
-        target_member = guild_members.select { |member| member['user']['username'] == member_name }
-        target_member[0]['user']['id']
-      rescue Discordrb::Errors::CodeError => e
-        log_error(e)
-        nil
-      end
-
       private
 
       def log_error(exception)

--- a/app/models/discord/server.rb
+++ b/app/models/discord/server.rb
@@ -71,7 +71,7 @@ module Discord
         guild_members_json = Discordrb::API::Server.resolve_members(authorize_token, guild_id, limit)
         guild_members = JSON.parse(guild_members_json.body)
         target_member = guild_members.select { |member| member['user']['username'] == member_name }
-        target_member == [] ? nil : target_member[0]['user']['id']
+        target_member.empty? ? nil : target_member[0]['user']['id']
       rescue Discordrb::Errors::CodeError => e
         log_error(e)
         nil

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -112,12 +112,13 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
 
     comment = params[:comment]
     product_checker_name = User.find_by(id: comment.commentable.checker_id).login_name
-    product = comment.commentable
     product_checker_discord_id = Discord::Server.find_member_id(member_name: product_checker_name)
+    product_checker_discord_name = "<@#{product_checker_discord_id}>"
+    product = comment.commentable
 
     body = <<~TEXT.chomp
       ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
-      担当：<@#{product_checker_discord_id}>さん
+      担当：#{product_checker_discord_name}さん
       URL： #{Rails.application.routes.url_helpers.product_url(product)}
     TEXT
 

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -113,7 +113,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     comment = params[:comment]
     product_checker_name = User.find_by(id: comment.commentable.checker_id).login_name
     product = comment.commentable
-    product_checker_discord_id = find_member_id(member_name: product_checker_name)
+    product_checker_discord_id = Discord::Server.find_member_id(member_name: product_checker_name)
 
     body = <<~TEXT.chomp
       ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
@@ -143,18 +143,5 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
       name: 'ピヨルド',
       webhook_url: webhook_url
     )
-  end
-
-  def self.find_member_id(member_name:)
-    # Discord::Server.find_member_id(member_name:)
-    return nil unless Discord::Server.enabled?
-
-    authorize_token = Discord::Server.authorize_token
-    guild_id = Discord::Server.guild_id
-    limit = 1000
-    guild_members_json = Discordrb::API::Server.resolve_members(authorize_token, guild_id, limit)
-    guild_members = JSON.parse(guild_members_json.body)
-    target_member = guild_members.select { |member| member['user']['username'] == member_name }
-    target_member == [] ? nil : target_member[0]['user']['id']
   end
 end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -113,10 +113,11 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     comment = params[:comment]
     product_checker_name = User.find_by(id: comment.commentable.checker_id).login_name
     product = comment.commentable
+    product_checker_discord_id = find_member_id(member_name: product_checker_name)
+
     body = <<~TEXT.chomp
       ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
-      担当：#{product_checker_name}さん
-      メンション： <@#{Discord::Server.find_member_id(member_name: 'goruchan')}>さん
+      担当：<@#{product_checker_discord_id}>さん
       URL： #{Rails.application.routes.url_helpers.product_url(product)}
     TEXT
 
@@ -142,5 +143,18 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
       name: 'ピヨルド',
       webhook_url: webhook_url
     )
+  end
+
+  def self.find_member_id(member_name:)
+    # Discord::Server.find_member_id(member_name:)
+    return nil unless Discord::Server.enabled?
+
+    authorize_token = Discord::Server.authorize_token
+    guild_id = Discord::Server.guild_id
+    limit = 1000
+    guild_members_json = Discordrb::API::Server.resolve_members(authorize_token, guild_id, limit)
+    guild_members = JSON.parse(guild_members_json.body)
+    target_member = guild_members.select { |member| member['user']['username'] == member_name }
+    target_member == [] ? nil : target_member[0]['user']['id']
   end
 end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -116,7 +116,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     body = <<~TEXT.chomp
       ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
       担当：#{product_checker_name}さん
-      メンション： <@#{find_id('goruchan')}>さん
+      メンション： <@#{Discord::Server.find_member_id(member_name: 'goruchan')}>さん
       URL： #{Rails.application.routes.url_helpers.product_url(product)}
     TEXT
 
@@ -142,25 +142,5 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
       name: 'ピヨルド',
       webhook_url: webhook_url
     )
-  end
-
-  private
-
-  def find_id(discord_name = nil)
-    guild_id = Discord::Server.guild_id
-    authorize_token = Discord::Server.authorize_token
-    query_string = URI.encode_www_form({ limit: 1000, after: nil }.compact)
-
-    response = Discordrb::API.request(
-      :guilds_sid_members,
-      guild_id,
-      :get,
-      "#{Discordrb::API.api_base}/guilds/#{guild_id}/members?#{query_string}",
-      Authorization: authorize_token
-    )
-
-    members_data = JSON.parse(response.body)
-    target_member = members_data.select { |member| member['user']['username'] == discord_name }
-    target_member[0]['user']['id']
   end
 end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -116,7 +116,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     body = <<~TEXT.chomp
       ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
       担当：#{product_checker_name}さん
-      メンション： <@#{search_discord_id('goruchan')}>さん
+      メンション： <@#{find_id('goruchan')}>さん
       URL： #{Rails.application.routes.url_helpers.product_url(product)}
     TEXT
 
@@ -146,9 +146,9 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
 
   private
 
-  def search_discord_id(discord_name = nil)
-    guild_id = ENV['DISCORD_GUILD_ID'].presence
-    bot_token = ENV['DISCORD_BOT_TOKEN'].presence
+  def find_id(discord_name = nil)
+    guild_id = Discord::Server.guild_id
+    authorize_token = Discord::Server.authorize_token
     query_string = URI.encode_www_form({ limit: 1000, after: nil }.compact)
 
     response = Discordrb::API.request(
@@ -156,7 +156,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
       guild_id,
       :get,
       "#{Discordrb::API.api_base}/guilds/#{guild_id}/members?#{query_string}",
-      Authorization: "Bot #{bot_token}"
+      Authorization: authorize_token
     )
 
     members_data = JSON.parse(response.body)

--- a/test/cassettes/discord/server/find_member_id.yml
+++ b/test/cassettes/discord/server/find_member_id.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://discord.com/api/v9/guilds/1234567890123456789/members?limit=1000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - DiscordBot (https://github.com/shardlab/discordrb, v3.5.0) rest-client/2.1.0
+        ruby/3.1.4p223 discordrb/3.5.0
+      Authorization:
+      - Bot valid token
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - discord.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jan 2024 13:50:35 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfruid=b14a2dc5058a642fee78bca06bcbffcdf9c7d51e-1705067435; path=/; domain=.discord.com;
+        HttpOnly; Secure; SameSite=None
+      - __dcfduid=8f536f6ab15111ee8a05367b405f8641; Expires=Wed, 10-Jan-2029 13:50:35
+        GMT; Max-Age=157680000; Secure; HttpOnly; Path=/; SameSite=Lax
+      - __sdcfduid=8f536f6ab15111ee8a05367b405f864195624d1148ee91dd1b3413f4d9505ed35f448c401524a77c94a8730aff5bb29a;
+        Expires=Wed, 10-Jan-2029 13:50:35 GMT; Max-Age=157680000; Secure; HttpOnly;
+        Path=/; SameSite=Lax
+      - _cfuvid=DhImK3CXL7CHUOTq3mVl2rZgN0pd06AeoHHGmM0we6s-1705067435093-0-604800000;
+        path=/; domain=.discord.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Ratelimit-Bucket:
+      - 14bcf0781dad097b39d603c7d772f784
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1705067444.969'
+      X-Ratelimit-Reset-After:
+      - '10.000'
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - h3=":443"; ma=86400
+      Cf-Cache-Status:
+      - DYNAMIC
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=5GWLgmxowI0TOc7nzmNHi7PsqcoNp9bsfo3AJjsojb%2FDhHZBbsK8%2Fa2Xby3A%2B0x%2FcCk9xpyQlVxXAbF3EIYF7lSx06bXUi5j33Aa%2BhvK7N3MyKZB2V7sI4uGbrSU"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - frame-ancestors 'none'; default-src 'none'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8445de8b8fe1f5f1-NRT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        WwogIHsKICAgICJhdmF0YXIiOiBudWxsLAogICAgImNvbW11bmljYXRpb25f
+        ZGlzYWJsZWRfdW50aWwiOiBudWxsLAogICAgImZsYWdzIjogMCwKICAgICJq
+        b2luZWRfYXQiOiAiMjAyMy0xMi0yNVQwNjo1MDoxNy40NzMwMDArMDA6MDAi
+        LAogICAgIm5pY2siOiBudWxsLAogICAgInBlbmRpbmciOiBmYWxzZSwKICAg
+        ICJwcmVtaXVtX3NpbmNlIjogbnVsbCwKICAgICJyb2xlcyI6IFsKICAgICAg
+        IjExODg3MzU0NTE3ODg0OTI4MjUiCiAgICBdLAogICAgInVudXN1YWxfZG1f
+        YWN0aXZpdHlfdW50aWwiOiBudWxsLAogICAgInVzZXIiOiB7CiAgICAgICJp
+        ZCI6ICIxMTg3NzU0MTk3NzI3MzE4MDQ2IiwKICAgICAgInVzZXJuYW1lIjog
+        ImdldF91c2VyX2lkIiwKICAgICAgImF2YXRhciI6IG51bGwsCiAgICAgICJk
+        aXNjcmltaW5hdG9yIjogIjc3NzEiLAogICAgICAicHVibGljX2ZsYWdzIjog
+        MCwKICAgICAgInByZW1pdW1fdHlwZSI6IDAsCiAgICAgICJmbGFncyI6IDAs
+        CiAgICAgICJib3QiOiB0cnVlLAogICAgICAiYmFubmVyIjogbnVsbCwKICAg
+        ICAgImFjY2VudF9jb2xvciI6IG51bGwsCiAgICAgICJnbG9iYWxfbmFtZSI6
+        IG51bGwsCiAgICAgICJhdmF0YXJfZGVjb3JhdGlvbl9kYXRhIjogbnVsbCwK
+        ICAgICAgImJhbm5lcl9jb2xvciI6IG51bGwKICAgIH0sCiAgICAibXV0ZSI6
+        IGZhbHNlLAogICAgImRlYWYiOiBmYWxzZQogIH0sCiAgewogICAgImF2YXRh
+        ciI6IG51bGwsCiAgICAiY29tbXVuaWNhdGlvbl9kaXNhYmxlZF91bnRpbCI6
+        IG51bGwsCiAgICAiZmxhZ3MiOiAwLAogICAgImpvaW5lZF9hdCI6ICIyMDIz
+        LTEyLTIzVDAxOjM1OjEyLjIyMTAwMCswMDowMCIsCiAgICAibmljayI6IG51
+        bGwsCiAgICAicGVuZGluZyI6IGZhbHNlLAogICAgInByZW1pdW1fc2luY2Ui
+        OiBudWxsLAogICAgInJvbGVzIjogWwoKICAgIF0sCiAgICAidW51c3VhbF9k
+        bV9hY3Rpdml0eV91bnRpbCI6IG51bGwsCiAgICAidXNlciI6IHsKICAgICAg
+        ImlkIjogIjExODc5MjgxMDI2ODk1NzQ5NzYiLAogICAgICAidXNlcm5hbWUi
+        OiAibWVudG9ybWVudGFybyIsCiAgICAgICJhdmF0YXIiOiAiODU2OWFkY2Jk
+        MzZjNzBhNzU3OGMwMTdiZjU2MDRlYTUiLAogICAgICAiZGlzY3JpbWluYXRv
+        ciI6ICIwIiwKICAgICAgInB1YmxpY19mbGFncyI6IDAsCiAgICAgICJwcmVt
+        aXVtX3R5cGUiOiAwLAogICAgICAiZmxhZ3MiOiAwLAogICAgICAiYmFubmVy
+        IjogbnVsbCwKICAgICAgImFjY2VudF9jb2xvciI6IG51bGwsCiAgICAgICJn
+        bG9iYWxfbmFtZSI6IG51bGwsCiAgICAgICJhdmF0YXJfZGVjb3JhdGlvbl9k
+        YXRhIjogbnVsbCwKICAgICAgImJhbm5lcl9jb2xvciI6IG51bGwKICAgIH0s
+        CiAgICAibXV0ZSI6IGZhbHNlLAogICAgImRlYWYiOiBmYWxzZQogIH0KXQ==
+  recorded_at: Fri, 12 Jan 2024 13:50:35 GMT
+recorded_with: VCR 6.2.0

--- a/test/models/discord/server_test.rb
+++ b/test/models/discord/server_test.rb
@@ -186,5 +186,12 @@ module Discord
         end
       end
     end
+
+    test '.find_member_id' do
+      VCR.use_cassette 'discord/server/find_member_id' do
+        actual_discord_id = Discord::Server.find_member_id(member_name: 'mentormentaro')
+        assert_equal '1187928102689574976', actual_discord_id
+      end
+    end
   end
 end

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -159,7 +159,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     comment = Comment.create!(user: users(:kimura), commentable: products(:product8), description: '提出者による返信')
     body = <<~TEXT.chomp
       ⚠️ kimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから5日経過しました。
-      担当：komagataさん
+      担当：<@12345>さん
       URL： http://localhost:3000/products/313836099
     TEXT
 
@@ -174,14 +174,20 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       name: 'ピヨルド',
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }
-    assert_notifications_sent 2, **expected do
-      DiscordNotifier.product_review_not_completed(params).notify_now
-      DiscordNotifier.with(params).product_review_not_completed.notify_now
-    end
 
-    assert_notifications_enqueued 2, **expected do
-      DiscordNotifier.product_review_not_completed(params).notify_later
-      DiscordNotifier.with(params).product_review_not_completed.notify_later
+    discord_notifier_mock = Minitest::Mock.new
+    discord_notifier_mock.expect(:find_member_id, '12345', [{ member_name: 'komagata' }])
+
+    DiscordNotifier.stub(:new, discord_notifier_mock) do
+      assert_notifications_sent 1, **expected do
+        DiscordNotifier.product_review_not_completed(params).notify_now
+        DiscordNotifier.with(params).product_review_not_completed.notify_now
+      end
+
+      # assert_notifications_enqueued 2, **expected do
+      #   DiscordNotifier.product_review_not_completed(params).notify_later
+      #   DiscordNotifier.with(params).product_review_not_completed.notify_later
+      # end
     end
   end
 

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -175,19 +175,16 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }
 
-    discord_notifier_mock = Minitest::Mock.new
-    discord_notifier_mock.expect(:find_member_id, '12345', [{ member_name: 'komagata' }])
-
-    DiscordNotifier.stub(:new, discord_notifier_mock) do
-      assert_notifications_sent 1, **expected do
+    Discord::Server.stub(:find_member_id, '12345') do
+      assert_notifications_sent 2, **expected do
         DiscordNotifier.product_review_not_completed(params).notify_now
         DiscordNotifier.with(params).product_review_not_completed.notify_now
       end
 
-      # assert_notifications_enqueued 2, **expected do
-      #   DiscordNotifier.product_review_not_completed(params).notify_later
-      #   DiscordNotifier.with(params).product_review_not_completed.notify_later
-      # end
+      assert_notifications_enqueued 2, **expected do
+        DiscordNotifier.product_review_not_completed(params).notify_later
+        DiscordNotifier.with(params).product_review_not_completed.notify_later
+      end
     end
   end
 


### PR DESCRIPTION
## Issue

- #6986 

## 概要

メンターが生徒の提出物にコメントして５日経過した場合に送信される Discord メッセージを、メンション付きで送信されるようにしました。

## 変更確認方法

### 事前準備

FBC アプリと Discord と連携させるための準備を行います。

#### Discord サーバの立ち上げと通知用 WebhookURL の取得
  [こちら](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95#1-%E3%82%A6%E3%82%A7%E3%83%96%E3%83%95%E3%83%83%E3%82%AFurl%E3%81%AE%E5%8F%96%E5%BE%97)を参考に通知確認用 Discord サーバを立ち上げる ※ ウェブフック URL の取得のみでOKです。URLを控えてください。

#### サーバ ID の取得
立ち上げた Discord サーバの ID を控えてください
[![Image from Gyazo](https://i.gyazo.com/04415a1371c4bf9c176382b2827b3b82.png)](https://gyazo.com/04415a1371c4bf9c176382b2827b3b82)

#### サーバへの Discord Bot 導入
FBC アプリから Discord へメンションするためには Discord ID が必要になります。Discord ID 取得は Discord の[Guild Resource](https://discord.com/developers/docs/resources/guild#guild-resource)オブジェクトの[List Guild Members](https://discord.com/developers/docs/resources/guild#list-guild-members)API を用います。本メソッドは、サーバ(guild)に属するアカウントが必要です。ここでは、一般アカウントの代わりにBotを使用します。

1. https://discord.com/developers/applications/ へアクセスします
2. 『New Application』を選択
  ![image](https://github.com/fjordllc/bootcamp/assets/90775541/8d47b5ea-9be3-4e9c-adef-52ffa630cbea)
3. 任意の入力でアプリケーションを生成します
    <img width="407" alt="image" src="https://github.com/fjordllc/bootcamp/assets/90775541/a2a2383f-eaaa-44ec-a734-a1901a3a1670">

5. 下記の手順で Bot のトークンを取得します※トークン情報はコピーして控えてください。
  [![Image from Gyazo](https://i.gyazo.com/ddd653d00b4ed45d4207213d13a2cab6.png)](https://gyazo.com/ddd653d00b4ed45d4207213d13a2cab6)
  [![Image from Gyazo](https://i.gyazo.com/e57405e7474fbe6aeace2d6872326514.png)](https://gyazo.com/e57405e7474fbe6aeace2d6872326514)
  [![Image from Gyazo](https://i.gyazo.com/aa6d45045933a755609f8d080066e620.png)](https://gyazo.com/aa6d45045933a755609f8d080066e620)
6. 『Bot -> Privileged Gateway Intents -> SERVER MEMBERS INTENT』をONにする
  [![Image from Gyazo](https://i.gyazo.com/3b3131a0a1243a12cbf6c752d1229349.png)](https://gyazo.com/3b3131a0a1243a12cbf6c752d1229349)
7. Bot を Discord サーバへ参加させる 
  [![Image from Gyazo](https://i.gyazo.com/e27b72c21b916394ab2055a060cebbe0.png)](https://gyazo.com/e27b72c21b916394ab2055a060cebbe0)
  [![Image from Gyazo](https://i.gyazo.com/634d354af72ba1cb4826856a3785eb13.png)](https://gyazo.com/634d354af72ba1cb4826856a3785eb13)
  [![Image from Gyazo](https://i.gyazo.com/27cbc3758af12916b2fd36be21449353.png)](https://gyazo.com/27cbc3758af12916b2fd36be21449353)
  ![image](https://github.com/fjordllc/bootcamp/assets/90775541/f7e37b68-eb11-4785-90fe-2ccc04e616d1)

#### 自身のアカウントIDを取得する

確認用に自身のアカウントIDを下記のようにして取得してください。

[![Image from Gyazo](https://i.gyazo.com/d52fb7a3ad6fb5fb292d7223cfbaf172.png)](https://gyazo.com/d52fb7a3ad6fb5fb292d7223cfbaf172)

### 機能確認 

1. feature/feature/discord-message-mention をローカルに取り込む
2. Discord 通知用に自身の Discord ID を設定する

    メンション通知するためには、自身で作ったサーバ内に FBC アプリ内のDiscord アカウントネームが必要になります。ローカル環境では難しいため、自身のIDを設定します。
  `app/notifiers/discord_notifier.rb` 116行目を下記のように修正する

    ```diff
    - product_checker_discord_name = "<@#{product_checker_discord_id}>"
    + product_checker_discord_name = "<@自身のDiscordID>"
    ```

3. アプリを立ち上げる

    アプリ起動に使用する環境変数と事前確認にて取得した値の関係は以下です。各環境変数の詳細については[こちら](https://github.com/fjordllc/bootcamp/wiki/Discord%E9%80%9A%E7%9F%A5)が参考になります。

    - `DISCORD_GUILD_ID `：生成したサーバID
    - `DISCORD_MENTOR_WEBHOOK_URL `：生成したWebhookURL
    - `DISCORD_BOT_TOKEN `：生成したBotトークン
    - `TOKEN`：『５日経過』のDiscord通知を実施する FBC アプリのスケジュール実行用トークン

    事前確認にて取得した値を用いてアプリを起動します。

    ```bash
    % DISCORD_GUILD_ID=<生成したサーバID> DISCORD_MENTOR_WEBHOOK_URL=<生成したWebhookURL> DISCORD_BOT_TOKEN=<生成したBotトークン> TOKEN=hoge foreman start -f Procfile.dev
    ```

    ![Image from Gyazo](https://i.gyazo.com/fca9576d213b00be17b2dd50e1b782b6.png)

    環境変数設定は [direnv](https://github.com/direnv/direnv) を利用すれば、アプリ実行時に環境変数を渡す必要がなくなりますので必要があれば試してください。

4. イベントスケジューラを実行し、通知が出ないことを確認する

    『５日経過』の Discord 通知はイベントスケジューラにより実行されるため、イベント関係なく実施するために下記 URL へブラウザからアクセスします。

    http://localhost:3000/scheduler/daily/notify_product_review_not_completed?token=hoge&webhook_url=<生成したWebhookURL>

    アクセスするとブラウザ上の表示は変わりません。また、初期データに５日経過したものがないため Discord 通知も発生しません。

5. Discord 通知イベントを発生させるために DB を更新する

    1. `rails c` を実行
    2. 下記を実行する

        ```ruby
        Comment.where(commentable_type: 'Product').find_each do |product_comment|
          product_comment.created_at = Time.now - 5.days
          product_comment.save
        end
        ```

6. イベントスケジューラを実行し、メンション付き通知が出ることを確認する

    http://localhost:3000/scheduler/daily/notify_product_review_not_completed?token=hoge&webhook_url=<生成したWebhookURL> へブラウザからアクセスし、Discord を確認する。

    [![Image from Gyazo](https://i.gyazo.com/12bb3c4ee8df07c4c3b63bddc1f7b4e1.png)](https://gyazo.com/12bb3c4ee8df07c4c3b63bddc1f7b4e1)

## Screenshot

### 変更前

Discord 通知がメンション付きでない
![image](https://github.com/fjordllc/bootcamp/assets/90775541/3d601946-ea02-4000-8b79-00ba1c7acb67)

### 変更後

Discord 通知がメンション付き
![image](https://github.com/fjordllc/bootcamp/assets/90775541/57b4abd1-ac75-4ca1-8c6a-054bef550cab)

