### PR TITLE
提出物個別ページの title タグの文言の微調整。

### DIFF
--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -1,4 +1,4 @@
-- title "#{@product.practice.title}の提出物"
+- title "提出物: #{@product.practice.title}"
 - set_meta_tags description: "#{@product.user.long_name}さんが提出した、プラクティス「#{@product.practice.title}」の提出物です。"
 - category = @product.category(current_user.course)
 

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -5,32 +5,32 @@ require 'application_system_test_case'
 class ProductsTest < ApplicationSystemTestCase
   test 'see my product' do
     visit_with_auth "/products/#{products(:product1).id}", 'mentormentaro'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
+    assert_equal "提出物: #{products(:product1).practice.title} | FBC", title
   end
 
   test 'admin can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
+    assert_equal "提出物: #{products(:product1).practice.title} | FBC", title
   end
 
   test 'adviser can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'advijirou'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
+    assert_equal "提出物: #{products(:product1).practice.title} | FBC", title
   end
 
   test 'graduate can see a product' do
     visit_with_auth "/products/#{products(:product1).id}", 'sotugyou'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
+    assert_equal "提出物: #{products(:product1).practice.title} | FBC", title
   end
 
   test "user who completed the practice can see the other user's product" do
     visit_with_auth "/products/#{products(:product1).id}", 'kimura'
-    assert_equal "#{products(:product1).practice.title}の提出物 | FBC", title
+    assert_equal "提出物: #{products(:product1).practice.title} | FBC", title
   end
 
   test "can see other user's product if it is permitted" do
     visit_with_auth "/products/#{products(:product3).id}", 'hatsuno'
-    assert_equal "#{products(:product3).practice.title}の提出物 | FBC", title
+    assert_equal "提出物: #{products(:product3).practice.title} | FBC", title
   end
 
   test "can not see other user's product if it isn't permitted" do
@@ -268,7 +268,7 @@ class ProductsTest < ApplicationSystemTestCase
   test "user is not alerted in the other's WIP product page" do
     wip_product = products(:product5)
     visit_with_auth "/products/#{wip_product.id}", 'hatsuno'
-    assert_equal "#{wip_product.practice.title}の提出物 | FBC", title
+    assert_equal "提出物: #{wip_product.practice.title} | FBC", title
     assert_no_text "提出物はまだ提出されていません。\n完成したら「提出する」をクリック！"
   end
 


### PR DESCRIPTION
## はじめに
https://github.com/fjordllc/bootcamp/pull/7192
このPRにおけるブランチ名を変更したため、再度PRを出します。

## Issue
- #7086 

## 概要
- 提出物個別ページのtitleタグ(bodyではなく、headタグ内)の文言を微修正しました。
  - `(development) {課題名}の提出物 | FBC`→`(development) 提出物: {課題名} | FBC`
  - タブに表示されるタイトルも変更されます。

## 変更確認方法
1. `feature/adjust_title_tag_of_individual_submission_page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 任意のアカウントでログインする
4. 任意の提出物個別ページに遷移する
5. 以下２点を確認する

- ブラウザのタブ名が`(development) 提出物: {課題名} | FBC`になっていること 
  - ※ブラウザのタブにマウスカーソルを乗せるとタイトルが表示されます。
- 開発者ツール の`<head>`タグ内 の `<title>`タグ内文言が、`(development) 提出物: {課題名} | FBC`になっていること

## Screenshot
### 変更前
![修正前_#7086](https://github.com/fjordllc/bootcamp/assets/111285341/56571aeb-faa0-4da5-8f31-7003f71d554d)
### 変更後
![修正後_#7086](https://github.com/fjordllc/bootcamp/assets/111285341/06215eaa-c3e7-4be0-84d1-a9c9e8dbd429)