### PR TITLE
ブログ一覧(articles)の上部にもページャーを追加

### DIFF
--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -19,6 +19,7 @@ description: 'オンラインプログラミングフィヨルドブートキャ
   .articles
     .articles__body
       .container.is-xl
+        = paginate @articles
         .articles__items
           .row
             - @articles.each do |article|

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -134,7 +134,7 @@ class ArticlesTest < ApplicationSystemTestCase
     end
 
     visit_with_auth articles_url, 'komagata'
-    find 'nav.pagination'
+    assert_selector 'nav.pagination', count: 2
   end
 
   test "general user can't see edit and delete buttons" do


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/7157

## 概要
ブログ一覧画面の上部にもページャーを追加（下部にはもともとある）。

## 変更確認方法
- 参考リンク：[ページングに関するQA](https://bootcamp.fjord.jp/questions/787)

1. {feature/articles-pagination}をローカルに取り込む
2. `/bootcamp/app/models/article.rb`をテキストエディタで開く
3. article.rb内の`paginates_per 24`を、一時的に、`paginates_per 10`に変更する
4. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
5. 任意のアカウントでログインする
6. `http://localhost:3000/articles`にアクセスし、下記を確認する

- **画面上部にページャーが表示されていること**

## Screenshot
### 変更前
![修正前_#7157](https://github.com/fjordllc/bootcamp/assets/111285341/8669e8fc-8cc3-4ae6-9cc8-ed64554f31b7)

### 変更後
![修正後_#7157](https://github.com/fjordllc/bootcamp/assets/111285341/4aa38c99-05ec-4929-8359-48191b4453e6)

