### PR TITLE
ブログ投稿フォームにある、タグ入力のガイドの文言を変更

### DIFF
--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -41,8 +41,7 @@
             class: 'a-form-label'
           = render 'tags_input', taggable: article
           .a-form-help
-            p
-              | 入力してエンターキーを押すとタグになります（スペースは入力できません）。
+            p 入力してエンターキーを押すとタグになります（スペースは入力できません）。
 
     .form-item
       .row

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -37,9 +37,12 @@
     .form-item
       .row
         .col-md-6.col-xs-12
-          = f.label :tag_list, 'タグを入力してください（カンマ区切り）',
+          = f.label :tag_list, 'タグを入力してください',
             class: 'a-form-label'
           = render 'tags_input', taggable: article
+          .a-form-help
+            p
+              | 入力してエンターキーを押すとタグになります（スペースは入力できません）。
 
     .form-item
       .row


### PR DESCRIPTION
## Issue

- #7141 

## 概要

ブログ投稿フォームにある、タグ入力のガイドの文言を変更しました。

## 変更確認方法

1. `feature/change-guide-of-tag-form-in-article`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. メンターか管理者でログインする
4. /articles/newにアクセスする
5. 以下２点を確認する
   - ラベルに記載されていた`（カンマ区切り）`の文言が削除されていること
   - タグ入力欄の下に、下記文言が追加されていること
     `入力してエンターキーを押すとタグになります（スペースは入力できません）。`

## Screenshot

### 変更前

<img width="689" alt="image" src="https://github.com/fjordllc/bootcamp/assets/85104698/6c638b12-abb4-4ec6-aa2d-2f9e8877159b">

### 変更後

<img width="689" alt="image" src="https://github.com/fjordllc/bootcamp/assets/85104698/8dd7ffa9-e461-410c-9fd3-e99a924c0b2c">
