### PR TITLE
特別イベント一覧、定期イベント一覧に、直近のイベント一覧を表示したい。 #7162

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,9 @@
 class EventsController < ApplicationController
   before_action :set_event, only: %i[edit update destroy]
 
-  def index; end
+  def index
+    display_events
+  end
 
   def show
     @event = Event.with_avatar.find(params[:id])
@@ -110,5 +112,14 @@ class EventsController < ApplicationController
 
   def publish_with_announcement?
     !@event.wip? && @event.announcement_of_publication?
+  end
+
+  def display_events
+    @today_events = (Event.today_events + RegularEvent.today_events)
+                    .sort_by { |e| e.start_at.strftime('%H:%M') }
+    @tomorrow_events = (Event.tomorrow_events + RegularEvent.tomorrow_events)
+                       .sort_by { |e| e.start_at.strftime('%H:%M') }
+    @day_after_tomorrow_events = (Event.day_after_tomorrow_events + RegularEvent.day_after_tomorrow_events)
+                                 .sort_by { |e| e.start_at.strftime('%H:%M') }
   end
 end

--- a/app/javascript/components/Events.jsx
+++ b/app/javascript/components/Events.jsx
@@ -6,7 +6,7 @@ import UserIcon from './UserIcon'
 import fetcher from '../fetcher'
 import usePage from './hooks/usePage'
 
-export default function Events() {
+export default function Events({today_events, tomorrow_events, day_after_tomorrow_events}) {
   const per = 20
   const { page, setPage } = usePage()
 

--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -19,4 +19,7 @@
                   i.fa-regular.fa-plus
                   | 特別イベント作成
   hr.a-border
-  = react_component 'Events'
+  = react_component 'Events',
+      today_events: @today_events,
+      tomorrow_events: @tomorrow_events,
+      day_after_tomorrow_events: @day_after_tomorrow_events


### PR DESCRIPTION
## Issue
- [特別イベント一覧、定期イベント一覧に、直近のイベント一覧を表示したい。 #7162](https://github.com/fjordllc/bootcamp/issues/7162)

## 概要
特別イベント一覧`/events`・定期イベント一覧`/regular_events`および、`/regular_events?target=not_finished`ページの右カラムに、「近日開催のイベント一覧」を表示させました。

現在のダッシュボード(ルートページ)にある「近日開催のイベント一覧」と同様のものですが、デザインは変更します。

## 変更確認方法

1. `feature/list_upcoming_events_on_events_page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバ起動する
3. 任意のユーザーでログインする
4. `/events`, `/regular_events`, `/regular_events?target=not_finished`にアクセスする
5. 右カラムに「近日開催のイベント一覧」が表示されていることを確認する

## Screenshot
### 変更前
![【修正前】events](https://github.com/fjordllc/bootcamp/assets/111285341/45b0a67a-e3cd-4709-b2df-30b1e70533b8)
![【修正前】regular_events_not_finish](https://github.com/fjordllc/bootcamp/assets/111285341/bf9c9e43-ac25-470f-b22b-3ecd7f5479e1)

![【修正前】regular_events_all](https://github.com/fjordllc/bootcamp/assets/111285341/7977f564-9bdb-4258-b898-7644792dfee7)

### 変更後

