### PR TITLE
メンターの提出物一覧の「自分の担当」ページに、休会者の提出物を含めないようにする

### DIFF
--- a/app/controllers/api/products/self_assigned_controller.rb
+++ b/app/controllers/api/products/self_assigned_controller.rb
@@ -7,13 +7,15 @@ class API::Products::SelfAssignedController < API::BaseController
     @target = 'self_assigned_all' unless target_allowlist.include?(@target)
     @products = case @target
                 when 'self_assigned_all'
-                  Product.self_assigned_product(current_user.id)
+                  Product.unhibernated_user_products
+                         .self_assigned_product(current_user.id)
                          .unchecked
                          .list
                          .order_for_self_assigned_list
                          .page(params[:page])
                 when 'self_assigned_no_replied'
-                  Product.self_assigned_no_replied_products(current_user.id)
+                  Product.unhibernated_user_products
+                         .self_assigned_no_replied_products(current_user.id)
                          .unchecked
                          .list
                          .page(params[:page])

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -34,7 +34,7 @@ class Cache
 
     def self_assigned_no_replied_product_count(user_id)
       Rails.cache.fetch("#{user_id}-self_assigned_no_replied_product_count") do
-        Product.self_assigned_no_replied_products(user_id).unchecked.count
+        Product.unhibernated_user_products.self_assigned_no_replied_products(user_id).unchecked.count
       end
     end
 

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -15,7 +15,7 @@
                 = Cache.unassigned_product_count
         li.page-tabs__item
           = link_to products_self_assigned_index_path, class: "page-tabs__item-link #{current_link(/^products-self_assigned-index/)}" do
-            | 自分の担当 （#{Product.self_assigned_product(current_user.id).unchecked.size}）
+            | 自分の担当 （#{Product.unhibernated_user_products.self_assigned_product(current_user.id).unchecked.size}）
             - if Cache.self_assigned_no_replied_product_count(current_user.id).positive?
               .page-tabs__item-count.a-notification-count.is-only-mentor
                 = Cache.self_assigned_no_replied_product_count(current_user.id)


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6222

## 概要

メンターの提出物一覧の「自分の担当」ページ（`/products/self_assigned`）において、リストされる提出物の中に休会者のものが含まれないようにしました。

## 変更確認方法
変更前 -> 変更後 の順でご確認いただきますようお願いいたします。

### 変更前の確認
1. `main`ブランチに切り替える。
2. `foreman start -f Procfile.dev`でサーバーを起動する。
3. `mentormentarou`でログインする。
4. http://localhost:3000/products/self_assigned にアクセスし、「自分の担当」タブ上に表示されている提出物の以下の件数を確認する。
    - 「自分の担当（`件数`）」部分の数字
    - 未返信分を表すタブ右肩の赤い数字
5. 「担当者がいない休会者の提出物」のページ http://localhost:3000/products/44102309 にアクセスする。
    - もしここで提出物が存在しなければ、最新の`origin/main`を取り込んでから`rails db:seed`を実行し、上記の提出物をDBに反映させてください。
6. 提出物ページ下部の「担当する」ボタンをクリックし、その提出物の担当者になる。
7. http://localhost:3000/products/self_assigned にアクセスし、以下を確認する。
    - 5.で担当した提出物（ユーザー名: kyuukai (キュウ カイ)）の提出物がリストされていること
    - 4.で確認した件数が1件ずつ増えていること


### 変更後の確認
1. `feature/exclude-hibernated-users-products-from-self-assigned-tab-in-products-page`をローカルに取り込む
2. ↑のブランチに切り替え、`foreman start -f Procfile.dev`でサーバーを起動する。
3. `mentormentarou`で http://localhost:3000/products/self_assigned にアクセスし、以下を確認する。
    - 変更前の5.で担当した提出物（ユーザー名: kyuukai (キュウ カイ)）の提出物がリストされていないこと
    - 変更前の4.で確認した件数が1件ずつ減っていること

## Screenshot
### ※前提条件
メンターが、確認OK前の休会者の提出物を自分の担当にしている。
開発環境では、下の提出物を使うことで再現できます。
- nginxで自己認証した証明書を使ったssl対応サイトを作るの提出物（提出者: `kyuukai`）
http://localhost:3000/products/44102309

![image](https://github.com/fjordllc/bootcamp/assets/128765400/ca288368-e5af-4cd1-a47d-930be1d3953f)

以降のスクショは、`mentormentarou`で上の提出物を担当した状態で撮影しています。

### 変更前
メンターロールでの「提出物」->「自分の担当」ページ上において、以下の状態になります。
- 休会者の提出物が表示される
- タブ上に表示される件数が、休会者の提出物も含まれて計算される
http://localhost:3000/products/self_assigned
![image](https://github.com/fjordllc/bootcamp/assets/128765400/46fe4a3d-d0eb-4238-8e16-9fc58812eecc)

### 変更後
メンターロールでの「提出物」->「自分の担当」ページ上において、以下の状態になります。
- 休会者の提出物が表示されない
- タブ上に表示される件数が、休会者の提出物も含まれず計算される
![image](https://github.com/fjordllc/bootcamp/assets/128765400/354c52d5-37aa-4b58-8261-da21d4d69f7a)


