### PR TITLE
ダッシュボードに表示した最新10件の表示順が『全ての日報』の表示順と異なっていたので修正

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -45,7 +45,7 @@ class HomeController < ApplicationController
     @collegue_trainees = current_user.collegue_trainees&.with_attached_avatar&.includes(:reports, :products, :comments)
     collegue_trainees_reports = Report.with_avatar.where(wip: false).where(user: current_user.collegue_trainees&.with_attached_avatar)
     @collegue_trainees_recent_reports = collegue_trainees_reports.order(reported_on: :desc).limit(10)
-    @recent_reports = Report.with_avatar.where(wip: false).order(reported_on: :desc).limit(10)
+    @recent_reports = Report.with_avatar.where(wip: false).order(reported_on: :desc, created_at: :desc).limit(10)
   end
 
   def display_events_on_dashboard

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -45,7 +45,7 @@ class HomeController < ApplicationController
     @collegue_trainees = current_user.collegue_trainees&.with_attached_avatar&.includes(:reports, :products, :comments)
     collegue_trainees_reports = Report.with_avatar.where(wip: false).where(user: current_user.collegue_trainees&.with_attached_avatar)
     @collegue_trainees_recent_reports = collegue_trainees_reports.order(reported_on: :desc).limit(10)
-    @recent_reports = Report.with_avatar.where(wip: false).order(reported_on: :desc, id: :asc).limit(10)
+    @recent_reports = Report.with_avatar.where(wip: false).order(reported_on: :desc).limit(10)
   end
 
   def display_events_on_dashboard


### PR DESCRIPTION
## Issue

- #7102

## 概要

ステージング環境での確認時に、ダッシュボードに表示した最新10件の表示順と、『日報・ブログ＞全ての日報』の表示順が異なっていたことに気づきました。

## 確認方法

1. feature/display-most-recent-5reports-on-dashboard をローカルに取り込む
2. foreman start -f Procfile.dev でアプリを立ち上げる
3. ブラウザで http://localhost:3000/ へアクセスし、最新10件の日報を表示する
4. ブラウザで http://localhost:3000/reports へアクセスし、日報・ブログを表示する
5. 2. と 3. で表示した日報の順序を確認し、一致することを確認する

## Screenshot

### 変更前

[![Image from Gyazo](https://i.gyazo.com/de3c7056e986073e62ff134bc83514bc.png)](https://gyazo.com/de3c7056e986073e62ff134bc83514bc)

### 変更後

表示順が一致するようになりました

[![Image from Gyazo](https://i.gyazo.com/bb9edbce21737e026c59cd2bfec5dfed.png)](https://gyazo.com/bb9edbce21737e026c59cd2bfec5dfed)