### PR TITLE
ユーザ個別ページで、提出物等のカウントを表示しリンクにする

### DIFF
--- a/app/javascript/components/user-activity-counts.vue
+++ b/app/javascript/components/user-activity-counts.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.card-counts.mt-3(v-if='user.student_or_trainee')
+.card-counts.is-users.mt-3(v-if='user.student_or_trainee')
   dl.card-counts__items
     .card-counts__item
       .card-counts__item-inner

--- a/app/javascript/loading-users-list-placeholder.vue
+++ b/app/javascript/loading-users-list-placeholder.vue
@@ -18,7 +18,7 @@
                     .card-list-item-meta__item.a-placeholder
         .sns-links
           .sns-links__items.is-button-group.a-placeholder
-        .card-counts.mt-3
+        .card-counts.is-users.mt-3
           .card-counts__items
             .card-counts__item
               .card-counts__item-inner.a-placeholder

--- a/app/javascript/stylesheets/application/blocks/cards/_card-counts.sass
+++ b/app/javascript/stylesheets/application/blocks/cards/_card-counts.sass
@@ -1,3 +1,10 @@
+.card-counts
+  &.is-user
+    +media-breakpoint-up(md)
+      margin-bottom: 2rem
+    +media-breakpoint-down(sm)
+      margin-bottom: 1.25rem
+
 .card-counts__items
   display: flex
   gap: .5rem
@@ -7,29 +14,46 @@
   flex: 0 0 calc((100% - (.5rem * (#{$one-line-items-count} - 1))) / $one-line-items-count)
 
 .card-counts__item
-  +media-breakpoint-up(xxl)
-    +nowrap-items(5)
-  +media-breakpoint-only(xl)
-    +nowrap-items(4)
-  +media-breakpoint-only(lg)
-    +nowrap-items(3)
-  +media-breakpoint-only(md)
-    +nowrap-items(4)
-  +media-breakpoint-down(sm)
-    +nowrap-items(3)
+  background-color: var(--base)
+  .is-users &
+    +media-breakpoint-up(xxl)
+      +nowrap-items(5)
+    +media-breakpoint-only(xl)
+      +nowrap-items(4)
+    +media-breakpoint-only(lg)
+      +nowrap-items(3)
+    +media-breakpoint-only(md)
+      +nowrap-items(4)
+    +media-breakpoint-down(sm)
+      +nowrap-items(3)
+  .is-user &
+    +media-breakpoint-up(xxl)
+      +nowrap-items(5)
+    +media-breakpoint-only(xl)
+      +nowrap-items(5)
+    +media-breakpoint-only(lg)
+      +nowrap-items(4)
+    +media-breakpoint-only(md)
+      +nowrap-items(5)
+    +media-breakpoint-down(sm)
+      +nowrap-items(4)
 
 .card-counts__item-inner
-  border: solid 1px var(--border-tint)
+  border: solid 1px var(--border)
   border-radius: 3px
 
 .card-counts__item-label
   +text-block(.625rem 1.4, center)
   color: var(--semi-muted-text)
   padding-block: .125rem
-  border-bottom: solid 1px var(--border-tint)
+  border-bottom: solid 1px var(--border)
 
 .card-counts__item-value
   +text-block(.875rem 1.4, center)
   padding-bottom: .125rem
   &.is-empty
     color: var(--muted-text)
+  a
+    +hover-link
+    display: block
+    color: var(--default-text)

--- a/app/views/companies/_user_counts.html.slim
+++ b/app/views/companies/_user_counts.html.slim
@@ -1,4 +1,4 @@
-.card-counts
+.card-counts.is-users
   dl.card-counts__items
     - unless users.mentor.empty?
       .card-counts__item

--- a/app/views/users/_activity_counts.html.slim
+++ b/app/views/users/_activity_counts.html.slim
@@ -1,0 +1,31 @@
+dl.card-counts__items
+  .card-counts__item
+    .card-counts__item-inner
+      dt.card-counts__item-label
+        | 日報
+      dd.card-counts__item-value
+        = link_to user.reports.count, user_reports_path(@user)
+  .card-counts__item
+    .card-counts__item-inner
+      dt.card-counts__item-label
+        | 提出物
+      dd.card-counts__item-value
+        = link_to user.products.count, user_products_path(@user)
+  .card-counts__item
+    .card-counts__item-inner
+      dt.card-counts__item-label
+        | コメント
+      dd.card-counts__item-value
+        = link_to user.comments.count, user_comments_path(@user)
+  .card-counts__item
+    .card-counts__item-inner
+      dt.card-counts__item-label
+        | 質問
+      dd.card-counts__item-value
+        = link_to user.questions.count, user_questions_path(@user)
+  .card-counts__item
+    .card-counts__item-inner
+      dt.card-counts__item-label
+        | 回答
+      dd.card-counts__item-value
+        = link_to user.answers.count, user_answers_path(@user)

--- a/app/views/users/_activity_counts.html.slim
+++ b/app/views/users/_activity_counts.html.slim
@@ -1,31 +1,32 @@
-dl.card-counts__items
-  .card-counts__item
-    .card-counts__item-inner
-      dt.card-counts__item-label
-        | 日報
-      dd.card-counts__item-value
-        = link_to user.reports.count, user_reports_path(@user)
-  .card-counts__item
-    .card-counts__item-inner
-      dt.card-counts__item-label
-        | 提出物
-      dd.card-counts__item-value
-        = link_to user.products.count, user_products_path(@user)
-  .card-counts__item
-    .card-counts__item-inner
-      dt.card-counts__item-label
-        | コメント
-      dd.card-counts__item-value
-        = link_to user.comments.count, user_comments_path(@user)
-  .card-counts__item
-    .card-counts__item-inner
-      dt.card-counts__item-label
-        | 質問
-      dd.card-counts__item-value
-        = link_to user.questions.count, user_questions_path(@user)
-  .card-counts__item
-    .card-counts__item-inner
-      dt.card-counts__item-label
-        | 回答
-      dd.card-counts__item-value
-        = link_to user.answers.count, user_answers_path(@user)
+.card-counts.is-user
+  dl.card-counts__items
+    .card-counts__item
+      .card-counts__item-inner
+        dt.card-counts__item-label
+          | 日報
+        dd.card-counts__item-value
+          = link_to user.reports.count, user_reports_path(@user)
+    .card-counts__item
+      .card-counts__item-inner
+        dt.card-counts__item-label
+          | 提出物
+        dd.card-counts__item-value
+          = link_to user.products.count, user_products_path(@user)
+    .card-counts__item
+      .card-counts__item-inner
+        dt.card-counts__item-label
+          | コメント
+        dd.card-counts__item-value
+          = link_to user.comments.count, user_comments_path(@user)
+    .card-counts__item
+      .card-counts__item-inner
+        dt.card-counts__item-label
+          | 質問
+        dd.card-counts__item-value
+          = link_to user.questions.count, user_questions_path(@user)
+    .card-counts__item
+      .card-counts__item-inner
+        dt.card-counts__item-label
+          | 回答
+        dd.card-counts__item-value
+          = link_to user.answers.count, user_answers_path(@user)

--- a/app/views/users/_activity_counts.html.slim
+++ b/app/views/users/_activity_counts.html.slim
@@ -5,28 +5,28 @@
         dt.card-counts__item-label
           | 日報
         dd.card-counts__item-value
-          = link_to user.reports.count, user_reports_path(@user)
+          = link_to user.reports.count, user_reports_path(user)
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label
           | 提出物
         dd.card-counts__item-value
-          = link_to user.products.count, user_products_path(@user)
+          = link_to user.products.count, user_products_path(user)
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label
           | コメント
         dd.card-counts__item-value
-          = link_to user.comments.count, user_comments_path(@user)
+          = link_to user.comments.count, user_comments_path(user)
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label
           | 質問
         dd.card-counts__item-value
-          = link_to user.questions.count, user_questions_path(@user)
+          = link_to user.questions.count, user_questions_path(user)
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label
           | 回答
         dd.card-counts__item-value
-          = link_to user.answers.count, user_answers_path(@user)
+          = link_to user.answers.count, user_answers_path(user)

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -28,16 +28,6 @@
           | 回答なし
     .user-metas__item
       .user-metas__item-label
-        | 日報
-      .user-metas__item-value
-        = user.reports.count
-    .user-metas__item
-      .user-metas__item-label
-        | コメント
-      .user-metas__item-value
-        = user.comments.count
-    .user-metas__item
-      .user-metas__item-label
         | 修了プラクティス
       .user-metas__item-value
         = user.completed_practices.size

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -37,6 +37,7 @@
           .col-xs-12.col-lg-6.col-xxl-6
             .page-content.is-user
               = render 'users/profile', user: @user
+              = render 'users/activity_counts', user: @user
               .a-card
                 .user-data
                   .user-data__row


### PR DESCRIPTION
## Issue

- #7181 

## 概要

- ユーザ個別ページで、提出物等のカウントを表示（見本：ユーザ一覧で各ユーザー毎に表示されているもの）
- 上記の各カウントから、各一覧ページへリンクを貼る
- ユーザ個別ページの「ユーザー公開情報」で、上記カウントと重複する内容を削除

## 変更確認方法

1. `feature/add-activity-counts-with-links-on-each-user-page`をローカルに取り込む
1. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
1. /usersにアクセスし、そこから任意のユーザ個別ページに移動する
1. 以下３点を確認する
   - 日報等５種類のカウントが表示されていること（見本：ユーザ一覧で各ユーザー毎に表示されているもの）
   - 各カウント数値から、各一覧ページへリンクされていること
   - 「ユーザー公開情報」で、重複した情報（日報、コメント）が無いこと

## Screenshot

### 変更前

<details><summary>カウント追加部分</summary>

![image](https://github.com/fjordllc/bootcamp/assets/85104698/d4a153ad-7aaf-4ca2-b623-31915bf813e8)
</details>

<details><summary>削除部分</summary>

![image](https://github.com/fjordllc/bootcamp/assets/85104698/7f3d6c85-9d0c-4f6a-bafe-f4ad1adda6b8)
</details>

### 変更後

<details><summary>カウント追加部分</summary>

![image](https://github.com/fjordllc/bootcamp/assets/85104698/f1301de8-77b6-4bd7-b60f-18fc6c0d1b05)
</details>

<details><summary>削除部分</summary>

![image](https://github.com/fjordllc/bootcamp/assets/85104698/a53b1bf4-e78f-4f0d-b15e-85b3eaa1c72f)
</details>