### PR TITLE
お問い合わせメールの送信先を変更

### DIFF
--- a/app/mailers/inquiry_mailer.rb
+++ b/app/mailers/inquiry_mailer.rb
@@ -3,6 +3,6 @@
 class InquiryMailer < ApplicationMailer
   def incoming(inquiry)
     @inquiry = inquiry
-    mail to: 'info@fjord.jp', reply_to: @inquiry.email, subject: '[FBC] お問い合わせ'
+    mail to: 'info@lokka.jp', reply_to: @inquiry.email, subject: '[FBC] お問い合わせ'
   end
 end

--- a/test/mailers/inquiry_mailer_test.rb
+++ b/test/mailers/inquiry_mailer_test.rb
@@ -11,7 +11,7 @@ class InquiryMailerTest < ActionMailer::TestCase
     )
     mail = InquiryMailer.incoming(inquiry)
     assert_equal '[FBC] お問い合わせ', mail.subject
-    assert_equal ['info@fjord.jp'], mail.to
+    assert_equal ['info@lokka.jp'], mail.to
     assert_equal ['noreply@bootcamp.fjord.jp'], mail.from
     assert_equal ['komagata@example.com'], mail.reply_to
     assert_match(/お問い合わせ/, mail.body.to_s)


### PR DESCRIPTION
## Issue

- #7183 

## 概要

お問い合わせメールの送信先を、[info@fjord.jp](mailto:info@fjord.jp) から [info@lokka.jp](mailto:info@lokka.jp) に変更

## 変更確認方法

1. `change-inquiry-mail-address`をローカルに取り込む
1. foreman start -f Procfile.devでローカル環境を立ち上げる
1. /inquiry/newにアクセスし、必要事項を記入し送信する
1. `localhost:3000/letter_opener`にアクセスし、以下を確認する
   送信先（To:）がinfo@lokka.jpであること

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/85104698/09ba8f33-8308-45d8-abd7-c465361bc4d7)

### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/85104698/7095f597-a494-4ec1-be6f-61bc10a29916)
