### PR TITLE
初日報投稿の通知処理を1箇所で行うように変更し、通知メールが2通送られてしまう問題を解消した

### DIFF
--- a/app/models/first_report_notifier.rb
+++ b/app/models/first_report_notifier.rb
@@ -4,8 +4,19 @@ class FirstReportNotifier
   def call(report)
     return if report.wip || !report.first? || Notification.find_by(kind: :first_report, sender_id: report.user.id).present?
 
+    notify_admins_and_mentors(report)
+    notify_to_chat(report)
+  end
+
+  private
+
+  def notify_admins_and_mentors(report)
     User.admins_and_mentors.each do |receiver|
       ActivityDelivery.with(report: report, receiver: receiver).notify(:first_report) if report.sender != receiver
     end
+  end
+
+  def notify_to_chat(report)
+    DiscordNotifier.with(report: report).first_report.notify_now
   end
 end

--- a/app/models/report_notifier.rb
+++ b/app/models/report_notifier.rb
@@ -15,7 +15,6 @@ class ReportNotifier
   private
 
   def notify_users(report)
-    notify_first_report(report) if report.first?
     notify_advisers(report) if report.user.trainee? && report.user.company_id?
     notify_consecutive_sad_report(report) if report.user.depressed?
     notify_followers(report)
@@ -23,18 +22,11 @@ class ReportNotifier
   end
 
   def notify_to_chat(report)
-    DiscordNotifier.with(report: report).first_report.notify_now if report.first?
     ChatNotifier.message(<<~TEXT, webhook_url: ENV['DISCORD_REPORT_WEBHOOK_URL'])
       #{report.user.login_name}さんが#{I18n.l report.reported_on}の日報を公開しました。
       タイトル：「#{report.title}」
       URL： https://bootcamp.fjord.jp/reports/#{report.id}
     TEXT
-  end
-
-  def notify_first_report(report)
-    User.admins_and_mentors.each do |receiver|
-      ActivityDelivery.with(report: report, receiver: receiver).notify(:first_report) if report.sender != receiver
-    end
   end
 
   def notify_advisers(report)


### PR DESCRIPTION
## Issue

- #7193 

## 概要
初日報投稿の通知処理を1箇所で行うように変更し、管理者/メンター宛に同じ通知メールが2通送られてしまう問題を解消しました。

## 変更確認方法
1. `bug/fix-duplicate-first-report-submission-notifications`をローカルに取り込む
2. 以下に記載の「Develop環境でのDiscrod通知の設定方法」でDiscord通知の準備を行う
3. foreman start -f Procfile.devを実行し、アプリを起動する
4. 日報の投稿がないユーザー`muryou`でログインする
5. [日報作成画面](http://localhost:3000/reports/new)で日報を投稿する
6. `http://localhost:3000/letter_opener`にアクセスし、`komagata`（その他管理者またはメンターでも可）に「[FBC] muryouさんがはじめての日報を書きました！」というメール通知が1通のみ届くことを確認する
7. 2で作成したDiscordサーバーに「🎉 muryouさんがはじめての日報を書きました！」通知が届いていることを確認する

<img width="422" alt="image" src="https://github.com/fjordllc/bootcamp/assets/104631303/78436b1f-c652-40e4-9bc1-bcc4b896df4a">

#### Develop環境でのDiscrod通知の設定方法
1. ウェブフックURLを取得する
以下のWikiに記載の1の方法でDiscordにサーバーを追加し、ウェブフックURLを取得する
[Develop環境でのDiscord通知の確認方法 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95#1-%E3%82%A6%E3%82%A7%E3%83%96%E3%83%95%E3%83%83%E3%82%AFurl%E3%81%AE%E5%8F%96%E5%BE%97)

2. サーバーを立ち上げるターミナルで以下を実行しておく
```
export DISCORD_INTRODUCTION_WEBHOOK_URL='{取得したウェブフックURL}'
```

## Screenshot
画面上の変更点はありません。