### PR TITLE
rubocop-minitestのルールを有効化して指摘点を修正する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,9 +28,6 @@ Metrics/ClassLength:
     - app/models/report.rb
     - app/notifiers/activity_notifier.rb
 
-Minitest/AssertEmpty:
-  Enabled: false
-
 Minitest/AssertTruthy:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,9 +28,6 @@ Metrics/ClassLength:
     - app/models/report.rb
     - app/notifiers/activity_notifier.rb
 
-Minitest/AssertTruthy:
-  Enabled: false
-
 Minitest/RefuteFalse:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,9 +28,6 @@ Metrics/ClassLength:
     - app/models/report.rb
     - app/notifiers/activity_notifier.rb
 
-Minitest/AssertIncludes:
-  Enabled: false
-
 Minitest/AssertEmpty:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,9 +28,6 @@ Metrics/ClassLength:
     - app/models/report.rb
     - app/notifiers/activity_notifier.rb
 
-Minitest/RefuteFalse:
-  Enabled: false
-
 AllCops:
   Exclude:
     - '**/templates/**/*'

--- a/test/integration/api/products/unassigned_counts_test.rb
+++ b/test/integration/api/products/unassigned_counts_test.rb
@@ -21,6 +21,6 @@ class API::Products::UnassignedTextTest < ActionDispatch::IntegrationTest
       - 6日経過：2件
       - 5日経過：1件
     BODY
-    assert response.body.include?(expected)
+    assert_includes response.body, expected
   end
 end

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -47,7 +47,7 @@ class ActivityMailerTest < ActionMailer::TestCase
       receiver: users(:hajime)
     ).deliver_now
 
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
   end
 
   test 'comebacked' do
@@ -94,7 +94,7 @@ class ActivityMailerTest < ActionMailer::TestCase
       receiver: users(:hajime)
     ).deliver_now
 
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
   end
 
   test 'came_answer' do
@@ -133,15 +133,15 @@ class ActivityMailerTest < ActionMailer::TestCase
 
     receiver.update_columns(mail_notification: false, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.came_answer(answer: answer.reload).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: false, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.came_answer(answer: answer.reload).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: true, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.came_answer(answer: answer.reload).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: true, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.came_answer(answer: answer.reload).deliver_now
@@ -195,21 +195,21 @@ class ActivityMailerTest < ActionMailer::TestCase
       announcement: announce,
       receiver: receiver
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: false, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.post_announcement(
       announcement: announce,
       receiver: receiver
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: true, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.post_announcement(
       announcement: announce,
       receiver: receiver
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: true, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.post_announcement(
@@ -310,21 +310,21 @@ class ActivityMailerTest < ActionMailer::TestCase
       mentionable: mentionable,
       receiver: mentioned.user
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     mentioned.user.update_columns(mail_notification: false, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.mentioned(
       mentionable: mentionable,
       receiver: mentioned.user
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     mentioned.user.update_columns(mail_notification: true, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.mentioned(
       mentionable: mentionable,
       receiver: mentioned.user
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     mentioned.user.update_columns(mail_notification: true, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.mentioned(
@@ -378,7 +378,7 @@ class ActivityMailerTest < ActionMailer::TestCase
       receiver: users(:hajime)
     ).deliver_now
 
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
   end
 
   test 'checked' do
@@ -427,7 +427,7 @@ class ActivityMailerTest < ActionMailer::TestCase
       check: check
     ).deliver_now
 
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
   end
 
   test 'create_page' do
@@ -557,7 +557,7 @@ class ActivityMailerTest < ActionMailer::TestCase
       product: product
     ).deliver_now
 
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
   end
 
   test 'following_report' do
@@ -675,21 +675,21 @@ class ActivityMailerTest < ActionMailer::TestCase
       product: product,
       receiver: receiver
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: false, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.assigned_as_checker(
       product: product,
       receiver: receiver
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: true, retired_on: Date.current) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.assigned_as_checker(
       product: product,
       receiver: receiver
     ).deliver_now
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
 
     receiver.update_columns(mail_notification: true, retired_on: nil) # rubocop:disable Rails/SkipsModelValidations
     ActivityMailer.assigned_as_checker(
@@ -970,7 +970,7 @@ class ActivityMailerTest < ActionMailer::TestCase
       mailer.deliver_later
     end
 
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
   end
 
   test 'not send chose_correct_answer email to retired user' do
@@ -987,7 +987,7 @@ class ActivityMailerTest < ActionMailer::TestCase
       mailer.deliver_later
     end
 
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
   end
 
   test 'no_correct_answer using synchronous mailer' do
@@ -1112,6 +1112,6 @@ class ActivityMailerTest < ActionMailer::TestCase
       receiver: comment.receiver
     ).deliver_now
 
-    assert ActionMailer::Base.deliveries.empty?
+    assert_empty ActionMailer::Base.deliveries
   end
 end

--- a/test/models/discord/times_channel_test.rb
+++ b/test/models/discord/times_channel_test.rb
@@ -40,7 +40,7 @@ module Discord
       Discord::Server.stub(:create_text_channel, ->(*) { nil }) do
         times_channel = Discord::TimesChannel.new('piyo')
 
-        assert_equal false, times_channel.save
+        assert_not times_channel.save
         assert_nil times_channel.id
         assert_nil times_channel.category_id
       end

--- a/test/models/discord/times_channel_test.rb
+++ b/test/models/discord/times_channel_test.rb
@@ -19,7 +19,7 @@ module Discord
         Discord::Server.stub(:create_text_channel, @stub_create_text_channel) do
           times_channel = Discord::TimesChannel.new('piyo')
 
-          assert_equal true, times_channel.save
+          assert times_channel.save
           assert_equal '1234567890', times_channel.id
           assert_equal '9876543210', times_channel.category_id
         end
@@ -29,7 +29,7 @@ module Discord
         Discord::Server.stub(:create_text_channel, @stub_create_text_channel) do
           times_channel = Discord::TimesChannel.new('piyo')
 
-          assert_equal true, times_channel.save
+          assert times_channel.save
           assert_equal '1234567890', times_channel.id
           assert_nil times_channel.category_id
         end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -152,8 +152,8 @@ class RegularEventTest < ActiveSupport::TestCase
 
     RegularEvent.remove_event([regular_events1, regular_events2], regular_event1.id)
     assert_not regular_events1.include?(regular_event1)
-    assert regular_events1.include?(regular_event2)
-    assert regular_events2.include?(regular_event3)
+    assert_includes regular_events1, regular_event2
+    assert_includes regular_events2, regular_event3
   end
 
   test '#assign_admin_as_organizer_if_none' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -536,7 +536,7 @@ class UserTest < ActiveSupport::TestCase
     user.rename_avatar_and_strip_exif
 
     image = MiniMagick::Image.read(user.avatar.download)
-    assert image.exif.empty?
+    assert_empty image.exif
     assert user.avatar.filename, user.id
 
     user.avatar.purge

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -6,12 +6,12 @@ require 'application_system_test_case'
 class AttachmentsTest < ApplicationSystemTestCase
   test 'attachment user avatar' do
     visit_with_auth "/users/#{users(:komagata).id}", 'komagata'
-    assert find('img.user-profile__user-icon-image')['src'].include?('komagata.png')
+    assert_includes find('img.user-profile__user-icon-image')['src'], 'komagata.png'
   end
 
   test 'attachment company icons in reports' do
     report = reports(:report11)
     visit_with_auth "/reports/#{report.id}", 'kensyu'
-    assert find('img.page-content-header__company-logo')['src'].include?('2.png')
+    assert_includes find('img.page-content-header__company-logo')['src'], '2.png'
   end
 end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -13,7 +13,7 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_css '.a-long-text.is-md.js-markdown-view'
     assert_css '.speak'
     assert_css "a[href='/users/mentormentaro']"
-    assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
+    assert_includes find('.js-user-icon.a-user-emoji')['data-user'], 'mentormentaro'
   end
 
   test 'user profile image markdown test' do
@@ -25,7 +25,7 @@ class MarkdownTest < ApplicationSystemTestCase
 
     assert_css '.a-long-text.is-md.js-markdown-view'
     assert_css "a[href='/users/mentormentaro']"
-    assert find('.js-user-icon.a-user-emoji')['data-user'].include?('mentormentaro')
+    assert_includes find('.js-user-icon.a-user-emoji')['data-user'], 'mentormentaro'
   end
 
   def cmd_ctrl

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -569,7 +569,7 @@ class ProductsTest < ApplicationSystemTestCase
       - 6日経過：1件
       - 5日経過：1件
     BODY
-    assert page.body.include?(expected)
+    assert_includes page.body, expected
   end
 
   test 'no company trainee create product' do

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -175,7 +175,7 @@ class SearchablesTest < ApplicationSystemTestCase
       fill_in 'word', with: '提出物のコメントです。'
     end
     find('#test-search').click
-    assert find('img.card-list-item-meta__icon.a-user-icon')['src'].include?('komagata.png')
+    assert_includes find('img.card-list-item-meta__icon.a-user-icon')['src'], 'komagata.png'
 
     find('img.card-list-item-meta__icon.a-user-icon').click
     assert_selector 'h1.page-content-header__title', text: 'komagata'


### PR DESCRIPTION
## Issue
- [testのrubocopの指摘点を修正する #7160
](https://github.com/fjordllc/bootcamp/issues/7160)

## 概要
[#7158](https://github.com/fjordllc/bootcamp/pull/7158)において、`rubocop-minitest`が有効化されましたが、`Enabled: false`が設定されているため、`rubocop`から指摘は出ない状態でした。

本Issueでは、`Enabled: false`を削除し`rubocop`が出す指摘点を修正しました。

## 変更確認方法

1. `feature/fix-suggestions-of-rubocop-in-tests`をローカルに取り込む。
2. `bundle exec rubocop`を実行し、`minitest`関連の指摘が出ないことを確認する。

## Screenshot

テストコードで使用するメソッド変更のため、画面の変更はありません。
