### PR TITLE
Q&A個別ページでコメントへのページ内リンクが機能するようにidを追加

### DIFF
--- a/app/javascript/answers.vue
+++ b/app/javascript/answers.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
-.thread-comments(v-if='loaded === false')
+#comments.thread-comments(v-if='loaded === false')
   commentPlaceholder(v-for='num in placeholderCount', :key='num')
-.thread-comments(v-else)
+#comments.thread-comments(v-else)
   header.thread-comments__header
     h2.thread-comments__title 回答・コメント
   .thread-comments__items


### PR DESCRIPTION
## Issue
- [# Q\&A個別ページ、コメントへのページ内リンクが機能していない #6264
](https://github.com/fjordllc/bootcamp/issues/6264)

## 概要

- リンク元である「質問への回答数」には、ページ内リンクが設定されているが、リンク先となる「回答・コメント」にidが設定されていないため追加

## 変更確認方法
1. ブランチ`bug/anchor-link-to-comments-on-qa-pages`をローカルに取り込む。
2. サーバーを立ち上げ、`http://localhost:3000/questions`にアクセスする。
3. 任意の質問をクリックし、個別の質問ページへ移動する。
4. 縦スクロールバーが表示されるように、ウインドウサイズを調整する。
5. 回答数をクリックし、「回答・コメント」の場所に移動することを確認する。

## Screenshot

### 変更前
[![Image from Gyazo](https://i.gyazo.com/2c65f234e8cf8ba161bd36f757bc4d5e.gif)](https://gyazo.com/2c65f234e8cf8ba161bd36f757bc4d5e)

### 変更後
[![Image from Gyazo](https://i.gyazo.com/a7bc432e3919411bf029c0c77561cb16.gif)](https://gyazo.com/a7bc432e3919411bf029c0c77561cb16)
