### PR TITLE
登録ページに研修申し込み用の文言とリンクを追加

### DIFF
--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -14,6 +14,11 @@
       h1.auth-form__title
         = title
     .auth-form__body
+      .auth-form__description
+        p
+          | 法人研修でご利用の方は
+          = link_to 'こちら', new_inquiry_path, class: 'auth-form__description-link'
+          | からお問い合わせください。
       - if !@user.adviser? && Campaign.today_campaign?
         = render 'checked_campaign'
       = render 'form', from: :new, url: users_path, user: @user

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -14,11 +14,13 @@
       h1.auth-form__title
         = title
     .auth-form__body
-      .auth-form__description
-        p
-          | 法人研修でご利用の方は
-          = link_to 'こちら', new_inquiry_path, class: 'auth-form__description-link'
-          | からお問い合わせください。
+      .form-item
+        .form-notice
+          p
+            | 法人研修でのご利用については、
+            = link_to new_inquiry_path do
+              | こちらのお問い合わせフォーム
+            | からご連絡ください。
       - if !@user.adviser? && Campaign.today_campaign?
         = render 'checked_campaign'
       = render 'form', from: :new, url: users_path, user: @user


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7206

## 概要
参加登録ページに、企業研修での利用者を問い合わせフォームに誘導する文言とリンクを追加しました。

## 変更確認方法

1. `feature/add-text-and-link-to-corporate-training`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 参加登録ページ`/users/new`にアクセスする
4. 以下２点を確認する
    - 「法人研修でのご利用については、こちらのお問い合わせフォームからご連絡ください。」という文言が表示されていること
    - リンクをクリックするとお問い合わせページ（`/inquiry/new`）に移動すること

## Screenshot

### 変更前
<img width="646" alt="スクリーンショット 2024-01-24 22 13 23" src="https://github.com/fjordllc/bootcamp/assets/129706209/27821dbe-347d-47fb-b9c7-0d7a8480656a">

### 変更後
<img width="912" alt="スクリーンショット 2024-02-05 10 16 50" src="https://github.com/fjordllc/bootcamp/assets/129706209/e0acdcaa-1d1d-42d9-a669-277af7cd878d">



