### PR TITLE
全ての日報ページのHTMLサイズを減らす

### DIFF
--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -14,4 +14,5 @@ header.page-header
 
 = render 'reports/tabs'
 
-= react_component('Reports', all: true, practices: current_user.practices)
+- practices = current_user.practices.as_json(only: [:id, :title])
+= react_component('Reports', all: true, practices: practices)


### PR DESCRIPTION
## 概要

全ての日報ページのHTMLにプラクティスの内容（ `practices.description` ）
などの不要な情報が含まれていました。
このページではプラクティスのIDとタイトルしか使われていません。

HTMLに余計な文字列が含まれているとページの表示が遅くなるため、必要な情報
だけをReactコンポーネントに渡すように修正します。

以下で id, title しか使われていないことを確認しました。
https://github.com/fjordllc/bootcamp/blob/00ff7e03c5759c7d83f29e7746101028594d7d84/app/javascript/components/Reports.jsx
https://github.com/fjordllc/bootcamp/blob/00ff7e03c5759c7d83f29e7746101028594d7d84/app/javascript/components/PracticeFilterDropdown.jsx

## Screenshot

### 変更前

description, created_at などが含まれていました。

![スクリーンショット 2024-01-24 22 22 57](https://github.com/fjordllc/bootcamp/assets/248174/29d769d1-2037-43e6-ab9f-4ee3cb20b2ec)

### 変更後

id, title だけになりました。
![スクリーンショット 2024-01-24 22 22 40](https://github.com/fjordllc/bootcamp/assets/248174/e49efdfa-0343-4f32-bfa1-ac9064d0a285)