### PR TITLE
スケジューライベント「最後のコメントから5日経過した際のDiscordメッセージ通知」の条件に当てはまるデータ追加

### DIFF
--- a/db/fixtures/comments.yml
+++ b/db/fixtures/comments.yml
@@ -147,3 +147,10 @@ commentOfTalk:
   commentable: talk_komagata (Talk)
   description: "これは相談部屋の会話です。"
   updated_at: "2019-01-02 00:00:00 JST"
+
+comment45:
+  user: kimura
+  commentable: product77 (Product)
+  description: "提出者の5日前にコメントしたコメントです。"
+  created_at: <%= now - 5.days%>
+  updated_at: <%= now - 5.days%>

--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -186,3 +186,11 @@ product76:
   body: 休会中ユーザの提出物です。
   published_at: <%= now.to_formatted_s(:db) %>
   created_at: <%= now.to_formatted_s(:db) %>
+
+product77:
+  practice: practice15
+  user: kimura
+  body: 『mentormentaroが担当/提出済み/最新のコメントがkimuraでコメントから5日経過した』提出物です。
+  checker: mentormentaro
+  published_at: <%= (now - 60 * 60 * 24 * 5).to_formatted_s(:db) %>
+  created_at: <%= (now - 60 * 60 * 24 * 5).to_formatted_s(:db) %>


### PR DESCRIPTION
## Issue

- #6986 

## 概要

[【メンター向け】「最後のコメントから5日経過しました」のDiscordメッセージにメンションを付けるようにした](https://github.com/fjordllc/bootcamp/pull/7194) の PR にはステージング環境で動作確認するためのデータが含まれていなかったため fixture にデータを追加しました。

## 変更確認方法

1. feature/discord-mention-five-days-passed をローカルに取り込む
2. http://localhost:3000/products/900186676 にアクセスする

## Screenshot

### 変更前

該当する提出物、およびコメントは存在しませんでした。

### 変更後

下記の通り、5日前のコメントが付与された提出物が追加されます。

[![Image from Gyazo](https://i.gyazo.com/108e0969c64110ec828592c529f2a01f.png)](https://gyazo.com/108e0969c64110ec828592c529f2a01f)

