### PR TITLE
書籍一覧ページから不要なボーダーを削除

### DIFF
--- a/app/views/courses/books/index.html.slim
+++ b/app/views/courses/books/index.html.slim
@@ -14,14 +14,13 @@ header.page-header
                 i.fas.fa-plus
                 | 参考書籍登録
 = render 'courses/tabs'
-hr.a-border
-  .page-body
-    .container.is-md
-      nav.pill-nav
-        .container
-          ul.pill-nav__items
-            li.pill-nav__item
-              = link_to '全て', course_books_path, class: "pill-nav__item-link #{params[:status] == 'mustread' ? '' : 'is-active'}"
-            li.pill-nav__item
-              = link_to '必読', course_books_path(status: 'mustread'), class: "pill-nav__item-link #{params[:status] == 'mustread' ? 'is-active' : ''}"
+.page-body
+  .container.is-md
+    nav.pill-nav
+      .container
+        ul.pill-nav__items
+          li.pill-nav__item
+            = link_to '全て', course_books_path, class: "pill-nav__item-link #{params[:status] == 'mustread' ? '' : 'is-active'}"
+          li.pill-nav__item
+            = link_to '必読', course_books_path(status: 'mustread'), class: "pill-nav__item-link #{params[:status] == 'mustread' ? 'is-active' : ''}"
 div(data-vue="CourseBooks" data-vue-is-admin:boolean="#{current_user.admin?}" data-vue-is-mentor:boolean="#{current_user.mentor?}" data-vue-course:json="#{@course.to_json}")


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7227

## 概要
プラクティスの書籍一覧ページに不要なボーダーが入っていたため、削除しました。

## 変更確認方法

1. `feature/remove-border-from-book-page`をローカルに取り込む
2. `foreman start -f Procfile.dev`を実行し、アプリを起動する
3. 任意のユーザでログインする
4. プラクティスページを開き、書籍タブをクリックする
5. 以下の点を確認する
    - タブの下に不要な線が入っていないこと
    - HTMLを調べ、タブの下に`<hr class="a-border">`が存在しないこと

## Screenshot

### 変更前
![スクリーンショット 2024-01-25 11 36 16](https://github.com/fjordllc/bootcamp/assets/129706209/13d72126-650e-4ed6-9bd0-144458db50ea)

### 変更後
![スクリーンショット 2024-01-25 11 44 52](https://github.com/fjordllc/bootcamp/assets/129706209/f1dd137f-e712-4e58-802b-9cd1f18a7a69)
