### PR TITLE
マシン、OSの情報が公開される旨の文言追加

### DIFF
--- a/app/views/users/form/_os.html.slim
+++ b/app/views/users/form/_os.html.slim
@@ -1,5 +1,9 @@
 .form-item
   = f.label :os, '学習に使うマシン・OS を選択してください', class: 'a-form-label is-required'
+  .a-form-help.mb-4
+    p
+      | この情報は他のフィヨルドブートキャンプ参加者に公開されます。
+      | 学習に使うマシン・OS が変わりましたら、この情報を更新してください。
   .form-item__groups
     .form-item-group
       .form-item-group__header


### PR DESCRIPTION
## Issue

- [#7228](https://github.com/fjordllc/bootcamp/issues/7228)

## 概要

userの登録情報変更画面の、「学習に使うマシン・OSを選択してください」の下部に、文言を追加しました。

## 変更確認方法

1. ブランチ `feature/add_message_that_machine_and_OS_info_are_published` をローカルに取り込む
2. サインインする
3. アイコンをクリックし、登録情報変更をクリック
4. 追加された文言を確認する。

## Screenshot

### 変更前

<img width="771" alt="スクリーンショット 2024-01-25 14 59 10" src="https://github.com/fjordllc/bootcamp/assets/106903482/e97103c9-1ce9-4fa1-9885-083710721f0d">


### 変更後

<img width="771" alt="スクリーンショット_2024-01-25_15_00_01" src="https://github.com/fjordllc/bootcamp/assets/106903482/b0f6a17b-1902-42cc-84ed-9358caeadc39">
