### PR TITLE
FBC Stack のリンクをフッターに配置

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -49,6 +49,9 @@ footer.footer
           li.footer-nav__item
             = link_to 'https://discord-bot-fjord.herokuapp.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | DiscordBotF
+          li.footer-nav__item
+            = link_to 'https://fbc-stack.vercel.app/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | FBC Stack
 
       small.footer__copyright
         i.fa-regular.fa-copyright


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7214

## 概要
- [FBC Stack](https://fbc-stack.vercel.app/)のリンクをフッターに配置し、クリックすると別タブで開くようにする

## 変更確認方法

1. `feature/place-fbc-stack-link-in-footer`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動する
3. ログイン後、フッターまでスクロールして移動する
4. 以下を確認する
    - [FBC Stack](https://fbc-stack.vercel.app/)のリンクがあること
    - クリックすると別タブで開くこと

## Screenshot

### 変更前
![フッター_リンク_修正前](https://github.com/fjordllc/bootcamp/assets/133615511/5ebe4b1c-07c5-4956-aa66-265dcc7809b7)

### 変更後
![フッター_リンク_修正後](https://github.com/fjordllc/bootcamp/assets/133615511/f67ba5a2-91ab-46ca-bc7c-2939624e60cf)

[![Image from Gyazo](https://i.gyazo.com/10cf6e1e0d6662a3073d9fc2945a6e74.gif)](https://gyazo.com/10cf6e1e0d6662a3073d9fc2945a6e74)