### PR TITLE
slim-lintの指摘点を修正する

### DIFF
--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -14,5 +14,5 @@ header.page-header
 
 = render 'reports/tabs'
 
-- practices = current_user.practices.as_json(only: [:id, :title])
+- practices = current_user.practices.as_json(only: %i[id title])
 = react_component('Reports', all: true, practices: practices)


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7255

## 概要
- 下記のコマンドでslim-lintを実行すると警告が出てしまっていたので、警告が出ないように修正
```
$ bundle exec slim-lint app/views -c config/slim_lint.yml
app/views/reports/index.html.slim:17 [W] RuboCop: Style/SymbolArray: Use `%i` or `%I` for an array of symbols.
```

## 変更確認方法

1. `bug/fix-slim-lint-issue-7255`をローカルに取り込む
2. 下記のコマンドを実行する
```
$ bundle exec slim-lint app/views -c config/slim_lint.yml
```
3. エラーが出ないことを確認する

## Screenshot

### 変更前
```
app/views/reports/index.html.slim:17 [W] RuboCop: Style/SymbolArray: Use `%i` or `%I` for an array of symbols.
```
の警告が発生する。

![image](https://github.com/fjordllc/bootcamp/assets/133615511/688c5e73-7fd2-40fe-9f4f-54dae72955fb)

### 変更後
上記の警告は発生しない(何も表示されない)

![image](https://github.com/fjordllc/bootcamp/assets/133615511/dc17cab3-214f-46ca-bc3b-4ea300fe05cc)

なお、[以前の修正](https://github.com/fjordllc/bootcamp/pull/7232)の内容(全ての日報ページのHTMLにおいて、必要な`id`, `title`のみ取得する)も保ったままであることも確認済み。

![Pasted image 20240126165035](https://github.com/fjordllc/bootcamp/assets/133615511/68d3edad-a803-49f5-a071-a7995f29731a)