### PR TITLE
LearningCacheDestroyerにloggerを追記した

### DIFF
--- a/app/models/learning_cache_destroyer.rb
+++ b/app/models/learning_cache_destroyer.rb
@@ -4,5 +4,6 @@ class LearningCacheDestroyer
   def call(payload)
     user = payload[:user]
     Rails.cache.delete "/model/user/#{user.id}/completed_percentage"
+    Rails.logger.info "[LearningCacheDestroyer] Cache destroyed for user #{user.id}"
   end
 end


### PR DESCRIPTION
## Issue

- #6617 

## 概要
[newspaperの引数をハッシュでの受け渡しに統一 1/2](https://github.com/fjordllc/bootcamp/pull/7175)

上記のPRで変更した
[LearningCacheDestroyer](https://github.com/fjordllc/bootcamp/blob/b60e9b4127c5bffa057220e56a86656089e3a304/app/models/learning_cache_destroyer.rb)に`logger`を追記することで、
開発/ステージング/本番いずれの環境でもログによる動作確認を行えるようにしました。

### 経緯
開発環境ではPR[newspaperの引数をハッシュでの受け渡しに統一 1/2](https://github.com/fjordllc/bootcamp/pull/7175)
の「[動作確認](https://github.com/fjordllc/bootcamp/pull/7175#:~:text=%E6%99%82%E3%81%AE%E5%87%A6%E7%90%86-,Learning%E3%81%AE%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5%E5%89%8A%E9%99%A4%E5%87%A6%E7%90%86,-muryou%E3%81%A7%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3)」に記載したrailsコンソールを使用した方法で確認をしていましたが、
ステージング環境でkomagataさん、machidaさんに確認いただく方法に悩んでいたところご提案いただいた以下の方法を取り入れることにしました。

1. `logger`を追記し、`LearningCacheDestroyer`を呼び出した際にログに`info`を出力する
2. ログに`info`の出力があることをkomagataさん、machidaさんに確認していただく

## 動作確認方法
※ログが流れてしまう場合があるので、動作確認時に`app/models/learning_cache_destroyer.rb`内`Rails.logger.info "[LearningCacheDestroyer] Cache destroyed for user #{user.id}"`の次の行に`byebug`と追記してから以下動作を行うと、
デバッグモードが開始するので出力を確認しやすくなります💡

例
```
class LearningCacheDestroyer
  def call(payload)
    user = payload[:user]
    Rails.cache.delete "/model/user/#{user.id}/completed_percentage"
    Rails.logger.info "[LearningCacheDestroyer] Cache destroyed for user #{user.id}"
    byebug # これを追記
  end
end
```

1. `feature/add-logger-to-learning-cache-destroyer`をローカルに取り込む
2. `foreman start -f Procfile.dev`を実行し、ローカル環境を立ち上げる
3. `muryou`でログイン
未着手のプラクティス[Debianをインストールする](http://localhost:3000/practices/581802908)
ページに行き、ステータスを着手に変更する
4. ターミナルに"[LearningCacheDestroyer] Cache destroyed for user #{user.id}"が出力されていることを確認する

<img width="596" alt="image" src="https://github.com/fjordllc/bootcamp/assets/104631303/c541e127-858b-418b-a9a6-78737e1d7f25">

5. `komagata`でログインする
6. `muryou`の[ユーザーページ](http://localhost:3000/users/746986380)ページに行き、`muryou`を削除する
7. ターミナルに"[LearningCacheDestroyer] Cache destroyed for user #{user.id}"が出力されていることを確認する

## Screenshot
画面上の変更はありません。
