### PR TITLE
クレジットカードに関する問題を受けるアドレスの変更

### DIFF
--- a/app/views/application/_card_notice.html.slim
+++ b/app/views/application/_card_notice.html.slim
@@ -6,7 +6,7 @@
     - if current_user
       | （#{link_to '退会はこちらから', new_retirement_path}）。
   p
-    | クレジットカードに関して問題がありましたら #{mail_to 'info@fjord.jp'} までお問い合わせください。
+    | クレジットカードに関して問題がありましたら #{mail_to 'info@lokka.jp'} までお問い合わせください。
   p
     | クレジットカード情報は当社のサーバーには保存せず、
     = link_to 'Stripe.com', 'https://stripe.com/docs/security/stripe', target: '_blank', rel: 'noopener'


### PR DESCRIPTION
## Issue

- [#7235](https://github.com/fjordllc/bootcamp/issues/7235)

## 概要
クレジットカードに関する問題を受けるアドレスをinfo@fjord.jp ⇨ info@lokka.jpに変更

## 変更確認方法

1. feature/creditcard_address_to_lokkaをローカルに取り込む
2. foreman start -f Procfile.dev でローカル環境で起動
3. 対象のページ（http://localhost:3000/users/new）に画面を遷移
4. 対象のメールアドレスが「info@lokka.jp」に変更になっていることを確認する

## Screenshot

### 変更前
<img width="510" alt="スクリーンショット 2024-01-27 20 42 11" src="https://github.com/fjordllc/bootcamp/assets/57862327/fb4208c0-ab62-4d6f-a476-96dd6f1c4403">


### 変更後
<img width="521" alt="スクリーンショット 2024-01-26 8 22 42" src="https://github.com/fjordllc/bootcamp/assets/57862327/187d729f-ced3-4958-b613-59e0b6344eca">

