### PR TITLE
学習しているマシン/OSを非公開から公開情報に変更した

### DIFF
--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -20,6 +20,14 @@
         = link_to user.course.title, course_practices_path(user.course), target: '_blank', rel: 'noopener'
     .user-metas__item
       .user-metas__item-label
+        | マシンのOS
+      .user-metas__item-value
+        - if user.os
+          = t("activerecord.enums.user.os.#{user.os}")
+        - else
+          | 回答なし
+    .user-metas__item
+      .user-metas__item-label
         | 日報
       .user-metas__item-value
         = user.reports.count

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -35,14 +35,6 @@
           | 回答なし
     .user-metas__item
       .user-metas__item-label
-        | マシンのOS
-      .user-metas__item-value
-        - if user.os
-          = t("activerecord.enums.user.os.#{user.os}")
-        - else
-          | 回答なし
-    .user-metas__item
-      .user-metas__item-label
         | 経験
       .user-metas__item-value
         - if user.experience


### PR DESCRIPTION
## Issue

- Issue番号 #7233 

## 概要

https://bootcamp.fjord.jp/announcements/952

> Q&Aなどの質問に答える際に、質問者の環境を知ることで、それに合わせた回答やアドバイスができるようにするためです。

とのこと。


## 変更確認方法

1. `feature/change-os-information-from-private-to-public` をローカルに取り込む
2.  メンターの方のアカウントでサインイン
3.  ユーザー一覧から任意のユーザーを選択
4. 詳細を確認

## Screenshot

### 変更前
<img width="551" alt="スクリーンショット 2024-01-26 5 51 05" src="https://github.com/fjordllc/bootcamp/assets/8443743/430a808f-c7b0-4d21-bbc1-fb73e7bc0b51">


### 変更後
<img width="548" alt="スクリーンショット 2024-01-26 5 57 20" src="https://github.com/fjordllc/bootcamp/assets/8443743/38a8a4c8-a873-4d46-97f5-3f591150bcd6">
