### PR TITLE
Layout/MultilineMethodCallBraceLayoutをslim-lintのルールに適用

### DIFF
--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -22,7 +22,6 @@ linters:
       - Layout/MultilineArrayBraceLayout
       - Layout/MultilineAssignmentLayout
       - Layout/MultilineHashBraceLayout
-      - Layout/MultilineMethodCallBraceLayout
       - Layout/MultilineMethodCallIndentation
       - Layout/MultilineMethodDefinitionBraceLayout
       - Layout/MultilineOperationIndentation


### PR DESCRIPTION
## Issue

- Issue番号 #7249 

## 概要

#7247 に記載。

## 変更確認方法

1.  feature/apply-slim-lint-rule3をローカルに取り込む
2. `./bin/lint  ` を実行
3.  `Layout/MultilineMethodCallBraceLayout` に関する指摘がないことを確認

~注意：現在は~

~app/views/reports/index.html.slim:17 [W] RuboCop: Style/SymbolArray: Use `%i` or `%I` for an array of symbols.~

~という指摘が入ります。これは別Issueで対応中です。~

修正されています。

## Screenshot

### 変更前
### 変更後

前後の変化はなかったため、写真はありません。

