### PR TITLE
定期イベントでメンション付きのコメントをした時、通知メッセージにイベント名がセットされないバグの修正

### DIFF
--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Commentable
+  include Notifiable
   extend ActiveSupport::Concern
 
   included do
@@ -21,17 +22,5 @@ module Commentable
 
   def body
     self[:body] || self[:description]
-  end
-
-  def commentable_notification_title
-    {
-      Report: "#{user.login_name}さんの日報「#{title}」",
-      Product: "#{user.login_name}さんの#{title}",
-      Event: "特別イベント「#{title}」",
-      Page: "Docs「#{title}」",
-      Announcement: "お知らせ「#{title}」",
-      RegularEvent: "定期イベント「#{title}」",
-      Talk: "#{user.login_name}さんの相談部屋"
-    }[:"#{self.class}"]
   end
 end

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -26,5 +26,14 @@ module Commentable
     else
       self[:body]
     end
+  def commentable_notification_title
+    {
+      Report: "#{user.login_name}さんの日報「#{title}」",
+      Product: "#{user.login_name}さんの#{title}",
+      Event: "特別イベント「#{title}」",
+      Page: "Docs「#{title}」",
+      Announcement: "お知らせ「#{title}」",
+      RegularEvent: "定期イベント「#{title}」"
+    }[:"#{self.class}"]
   end
 end

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -30,7 +30,8 @@ module Commentable
       Event: "特別イベント「#{title}」",
       Page: "Docs「#{title}」",
       Announcement: "お知らせ「#{title}」",
-      RegularEvent: "定期イベント「#{title}」"
+      RegularEvent: "定期イベント「#{title}」",
+      Talk: "#{user.login_name}さんの相談部屋"
     }[:"#{self.class}"]
   end
 end

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -20,12 +20,9 @@ module Commentable
   end
 
   def body
-    case self
-    when Announcement, Event, Report
-      self[:description]
-    else
-      self[:body]
-    end
+    self[:body] || self[:description]
+  end
+
   def commentable_notification_title
     {
       Report: "#{user.login_name}さんの日報「#{title}」",

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -18,7 +18,7 @@ module Mentioner
     when Report
       "#{user.login_name}さんの日報「#{self[:title]}」"
     when Comment
-      "#{target_of_comment(commentable.class, commentable)}へのコメント"
+      "#{commentable.commentable_notification_title}へのコメント"
     when Answer
       "#{receiver.login_name}さんのQ&A「#{question[:title]}」へのコメント"
     when Question
@@ -61,15 +61,5 @@ module Mentioner
 
   def extract_login_names_from_mentions(mentions)
     mentions.map { |s| s.gsub(/@/, '') }
-  end
-
-  def target_of_comment(commentable_class, commentable)
-    {
-      Report: "#{commentable.user.login_name}さんの日報「#{commentable.title}」",
-      Product: "#{commentable.user.login_name}さんの#{commentable.title}",
-      Event: "特別イベント「#{commentable.title}」",
-      Page: "Docs「#{commentable.title}」",
-      Announcement: "お知らせ「#{commentable.title}」"
-    }[:"#{commentable_class}"]
   end
 end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Mentioner
+  include Notifiable
+
   def after_save_mention(new_mentions)
     return if instance_of?(Report)
 
@@ -12,18 +14,7 @@ module Mentioner
   end
 
   def where_mention
-    case self
-    when Product
-      "#{user.login_name}さんの提出物「#{practice[:title]}」"
-    when Report
-      "#{user.login_name}さんの日報「#{self[:title]}」"
-    when Comment
-      "#{commentable.commentable_notification_title}へのコメント"
-    when Answer
-      "#{receiver.login_name}さんのQ&A「#{question[:title]}」へのコメント"
-    when Question
-      "#{user.login_name}さんのQ&A「#{practice[:title]}」"
-    end
+    notification_title
   end
 
   def body

--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Notifiable
+  def notification_title
+    send("notification_title_for_#{self.class.name.downcase}")
+  rescue NoMethodError
+    nil
+  end
+
+  private
+
+  def notification_title_for_answer
+    "#{receiver.login_name}さんのQ&A「#{question.title}」へのコメント"
+  end
+
+  def notification_title_for_announcement
+    "お知らせ「#{title}」"
+  end
+
+  def notification_title_for_comment
+    "#{commentable.notification_title}へのコメント"
+  end
+
+  def notification_title_for_event
+    "特別イベント「#{title}」"
+  end
+
+  def notification_title_for_page
+    "Docs「#{title}」"
+  end
+
+  def notification_title_for_practice
+    "プラクティス「#{title}」"
+  end
+
+  def notification_title_for_product
+    "#{user.login_name}さんの#{title}"
+  end
+
+  def notification_title_for_question
+    "#{user.login_name}さんのQ&A「#{title}」"
+  end
+
+  def notification_title_for_regular_event
+    "定期イベント「#{title}」"
+  end
+
+  def notification_title_for_report
+    "#{user.login_name}さんの日報「#{title}」"
+  end
+
+  def notification_title_for_talk
+    "#{user.login_name}さんの相談部屋"
+  end
+end

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -33,12 +33,7 @@ module Watchable
   end
 
   def body
-    case self
-    when Question, Event, RegularEvent, Report, Announcement
-      self[:description]
-    else
-      self[:body]
-    end
+    self[:body] || self[:description]
   end
 
   def time

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Watchable
+  include Notifiable
   extend ActiveSupport::Concern
 
   included do
@@ -11,25 +12,6 @@ module Watchable
 
   def watched?
     watches.present?
-  end
-
-  def notification_title
-    case self
-    when Product
-      "提出物「#{practice[:title]}」"
-    when Report
-      "日報「#{self[:title]}」"
-    when Question
-      "Q&A「#{self[:title]}」"
-    when Event
-      "特別イベント「#{self[:title]}」"
-    when RegularEvent
-      "定期イベント「#{self[:title]}」"
-    when Page
-      "Docs「#{self[:title]}」"
-    when Announcement
-      "お知らせ「#{self[:title]}」"
-    end
   end
 
   def body

--- a/test/models/concerns/commentable_test.rb
+++ b/test/models/concerns/commentable_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CommentableTest < ActiveSupport::TestCase
+  # Announcement, Event, Page, Product, RegularEvent, Report, Talk にincludeされている
+  test 'commentable_notification_title for Announcement' do
+    announcement = announcements(:announcement1)
+    expected = 'お知らせ「お知らせ1」'
+    assert_equal expected, announcement.commentable_notification_title
+  end
+
+  test 'commentable_notification_title for Event' do
+    event = events(:event1)
+    expected = '特別イベント「ミートアップ」'
+    assert_equal expected, event.commentable_notification_title
+  end
+
+  test 'commentable_notification_title for Page' do
+    page = pages(:page1)
+    expected = 'Docs「test1」'
+    assert_equal expected, page.commentable_notification_title
+  end
+
+  test 'commentable_notification_title for Product' do
+    product = products(:product1)
+    expected = 'mentormentaroさんの「OS X Mountain Lionをクリーンインストールする」の提出物'
+    assert_equal expected, product.commentable_notification_title
+  end
+
+  test 'commentable_notification_title for RegularEvent' do
+    regular_event = regular_events(:regular_event1)
+    expected = '定期イベント「開発MTG」'
+    assert_equal expected, regular_event.commentable_notification_title
+  end
+
+  test 'commentable_notification_title for Report' do
+    report = reports(:report1)
+    expected = 'komagataさんの日報「作業週1日目」'
+    assert_equal expected, report.commentable_notification_title
+  end
+
+  test 'commentable_notification_title for Talk' do
+    talk = talks(:talk1)
+    expected = 'komagataさんの相談部屋'
+    assert_equal expected, talk.commentable_notification_title
+  end
+end

--- a/test/models/concerns/mentioner_test.rb
+++ b/test/models/concerns/mentioner_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MentionerTest < ActiveSupport::TestCase
+  test 'where_mention for Answer' do
+    answer = answers(:answer1)
+    expected = 'machidaさんのQ&A「どのエディターを使うのが良いでしょうか」へのコメント'
+    assert_equal expected, answer.where_mention
+  end
+
+  test 'where_mention for Comment' do
+    comment = comments(:comment1)
+    expected = 'komagataさんの日報「作業週1日目」へのコメント'
+    assert_equal expected, comment.where_mention
+  end
+
+  test 'where_mention for Product' do
+    product = products(:product2)
+    expected = 'kimuraさんの提出物「OS X Mountain Lionをクリーンインストールする」'
+    assert_equal expected, product.where_mention
+  end
+
+  test 'where_mention for Question' do
+    question = questions(:question1)
+    expected = 'machidaさんのQ&A「OS X Mountain Lionをクリーンインストールする」'
+    assert_equal expected, question.where_mention
+  end
+
+  test 'where_mention for Report' do
+    report = reports(:report1)
+    expected = 'komagataさんの日報「作業週1日目」'
+    assert_equal expected, report.where_mention
+  end
+end

--- a/test/system/notification/comments_test.rb
+++ b/test/system/notification/comments_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'application_system_test_case'
+require 'supports/notification_helper'
 
 class Notification::CommentsTest < ApplicationSystemTestCase
   setup do
@@ -28,4 +29,103 @@ class Notification::CommentsTest < ApplicationSystemTestCase
     end
     assert_selector '.header-notification-count', text: '1'
   end
+
+  test 'Users mentioned in comments on the Report page are notified' do
+    post_mention = lambda { |comment|
+      visit report_path(reports(:report1).id)
+      within('.thread-comment-form__form') do
+        fill_in('new_comment[description]', with: comment)
+      end
+      click_button 'コメントする'
+    }
+    title = "#{reports(:report1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
+  end
+
+  test 'Users mentioned in comments on the product page are notified' do
+    post_mention = lambda { |comment|
+      visit product_path(products(:product1).id)
+      within('.thread-comment-form__form') do
+        fill_in('new_comment[description]', with: comment)
+      end
+      click_button 'コメントする'
+    }
+    title = "#{products(:product1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
+  end
+
+  test 'Users mentioned in comments on the Event page are notified' do
+    post_mention = lambda { |comment|
+      visit event_path(events(:event1).id)
+      within('.thread-comment-form__form') do
+        fill_in('new_comment[description]', with: comment)
+      end
+      click_button 'コメントする'
+    }
+    title = "#{events(:event1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
+  end
+
+  test 'Users mentioned in comments on the Docs page are notified' do
+    post_mention = lambda { |comment|
+      visit page_path(pages(:page1).id)
+      within('.thread-comment-form__form') do
+        fill_in('new_comment[description]', with: comment)
+      end
+      click_button 'コメントする'
+    }
+    title = "#{pages(:page1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
+  end
+
+  test 'Users mentioned in comments on the Announcement page are notified' do
+    post_mention = lambda { |comment|
+      visit announcement_path(announcements(:announcement1).id)
+      within('.thread-comment-form__form') do
+        fill_in('new_comment[description]', with: comment)
+      end
+      click_button 'コメントする'
+    }
+    title = "#{announcements(:announcement1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
+  end
+
+  test 'Users mentioned in comments on the Regular event page are notified' do
+    post_mention = lambda { |comment|
+      visit regular_event_path(regular_events(:regular_event1).id)
+      within('.thread-comment-form__form') do
+        fill_in('new_comment[description]', with: comment)
+      end
+      click_button 'コメントする'
+    }
+    title = "#{regular_events(:regular_event1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
+  end
+
+  test 'Users mentioned in comments on the Talk page are NOT notified' do
+    user = users(:kimura)
+    post_mention = lambda { |comment|
+      visit talk_path(user.talk.id)
+      within('.thread-comment-form__form') do
+        fill_in('new_comment[description]', with: comment)
+      end
+      click_button 'コメントする'
+    }
+    login_user 'kimura', 'testtest'
+    post_mention.call('@hatsuno にメンション通知がいくかのテスト')
+    logout
+    login_user 'hatsuno', 'testtest'
+
+    assert_not exists_unread_notification?('kimuraさんからメンションがきました。')
+  end
+end
+
+def assert_commentable_notification(
+  title, writer_login_name, mention_target_login_name, post_mention
+)
+  login_user writer_login_name, 'testtest'
+  post_mention.call("@#{mention_target_login_name} にメンション通知がいくかのテスト")
+  logout
+  login_user mention_target_login_name, 'testtest'
+  assert exists_unread_notification?(title)
 end

--- a/test/system/notification/comments_test.rb
+++ b/test/system/notification/comments_test.rb
@@ -38,7 +38,7 @@ class Notification::CommentsTest < ApplicationSystemTestCase
       end
       click_button 'コメントする'
     }
-    title = "#{reports(:report1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    title = "#{reports(:report1).notification_title}へのコメントでkimuraさんからメンションがきました。"
     assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
   end
 
@@ -50,7 +50,7 @@ class Notification::CommentsTest < ApplicationSystemTestCase
       end
       click_button 'コメントする'
     }
-    title = "#{products(:product1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    title = "#{products(:product1).notification_title}へのコメントでkimuraさんからメンションがきました。"
     assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
   end
 
@@ -62,7 +62,7 @@ class Notification::CommentsTest < ApplicationSystemTestCase
       end
       click_button 'コメントする'
     }
-    title = "#{events(:event1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    title = "#{events(:event1).notification_title}へのコメントでkimuraさんからメンションがきました。"
     assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
   end
 
@@ -74,7 +74,7 @@ class Notification::CommentsTest < ApplicationSystemTestCase
       end
       click_button 'コメントする'
     }
-    title = "#{pages(:page1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    title = "#{pages(:page1).notification_title}へのコメントでkimuraさんからメンションがきました。"
     assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
   end
 
@@ -86,7 +86,7 @@ class Notification::CommentsTest < ApplicationSystemTestCase
       end
       click_button 'コメントする'
     }
-    title = "#{announcements(:announcement1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    title = "#{announcements(:announcement1).notification_title}へのコメントでkimuraさんからメンションがきました。"
     assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
   end
 
@@ -98,7 +98,7 @@ class Notification::CommentsTest < ApplicationSystemTestCase
       end
       click_button 'コメントする'
     }
-    title = "#{regular_events(:regular_event1).commentable_notification_title}へのコメントでkimuraさんからメンションがきました。"
+    title = "#{regular_events(:regular_event1).notification_title}へのコメントでkimuraさんからメンションがきました。"
     assert_commentable_notification(title, 'kimura', 'hatsuno', post_mention)
   end
 


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6365

## 概要

定期イベントでメンション付きのコメントをした時、メンション先ユーザーにアプリ内通知とメール通知が飛ぶが、そのタイトルの冒頭部分が欠けてしまっていた問題に対応しました。

- 修正前
    - （アプリ内通知）`へのコメントで[ユーザー名]さんからメンションがきました。`
    - （メール通知）`[FBC] へのコメントで`ユーザー名`さんからメンションがありました。`
- 修正後
    - （アプリ内通知）`定期イベント「[イベント名]」へのコメントで[ユーザー名]さんからメンションがきました。`
    - （メール通知）`[FBC] 定期イベント「[イベント名]」へのコメントで`ユーザー名`さんからメンションがありました。`

## バグの直接原因

`RegularEvent`モデルには`Commentable`が include されており、`Comment`と関連付けられています。
`Comment`モデルには `Mentioner`が include されており、通知のタイトル文言をセットする際に`Mentioner`の`where_mention`メソッドが呼び出されています。

アプリ内の通知：
https://github.com/fjordllc/bootcamp/blob/d634b57673bbb4d41ac130a15262cbd20aaf08fb/app/notifiers/activity_notifier.rb#L205-L218

メールの通知：
https://github.com/fjordllc/bootcamp/blob/d634b57673bbb4d41ac130a15262cbd20aaf08fb/app/mailers/activity_mailer.rb#L173-L187

`Mentioner`モジュールの`where_mention`メソッド内で呼び出している`target_of_comment`メソッドの返り値は、include 先のクラスが何かによって条件分岐していますが、この分岐に`RegularEvents`が存在しないため、返り値が`nil`となっていることがバグの原因でした。

https://github.com/fjordllc/bootcamp/blob/d634b57673bbb4d41ac130a15262cbd20aaf08fb/app/models/concerns/mentioner.rb#L66-L74

## 修正方法

- `Commentable`を include するモデルを作成した際に、その影響を`Comment`の先の`Mentioner`にまで反映させるのは対応漏れが起きやすいだろう
- コメントした対象物の情報を返すのは、`Mentioner`ではなく`Commentable`が行うほうが役割として分かりやすいだろう

と考え、`Mentioner`の`target_of_comment`メソッドを削除し、`Commentable`に`commentable_notification_title`メソッドを追加しました。
`commentable_notification_title`メソッド内に、不足していた`RegularEvents`の分岐も追加しました。


## 類似の問題（確認中）

`Watchable`、`Commentable`モジュール内の body メソッドについて、条件をクラスごとに指定する形になっており、`Commentable`の body メソッドにはRegularEventクラスの追加漏れがでていました。
対応 issue と類似の問題とみなし、修正をしています。

## 変更確認方法

1. `bug/regular-event-comment-mentions`をローカルに取り込む
2. 任意のアカウントでbootcampにログインする（`kimura`を利用）
3. 定期イベント「開発MTG」詳細ページ（ http://localhost:3000/regular_events/[:定期イベントid] ）にアクセスする
3. 定期イベントのコメント欄に、別なユーザーへのメンションを含めたコメントを登録する（`hatsuno`へメンション）<img src="https://github.com/fjordllc/bootcamp/assets/40317050/c4910a85-bed2-4c1c-83fb-52b64cf286d1" width="500">
4. ログアウトする
5. メンション先のユーザー（`hatsuno`）でbootcampにログインし直す
6. `定期イベント「開発MTG」へのコメントでkimuraさんからメンションがきました。`というタイトルの未読通知があることを確認する
7. LetterOpenerWebで、`[FBC] 定期イベント「開発MTG」へのコメントでkimuraさんからメンションがありました。`というタイトルのメールが送信されていることを確認する

## Screenshot

### 変更前

#### アプリ内通知

![スクリーンショット 2024-01-28 15 06 25](https://github.com/fjordllc/bootcamp/assets/40317050/95449b11-9997-4611-857a-c4d0ea153bee)
![スクリーンショット 2024-01-28 15 06 53](https://github.com/fjordllc/bootcamp/assets/40317050/7537b54f-2b01-498c-a8b5-bdeafbc31b6f)

#### メール通知

![スクリーンショット 2024-01-28 15 07 33](https://github.com/fjordllc/bootcamp/assets/40317050/da2f92be-e35e-47fb-922d-63ee771706fa)

### 変更後

#### アプリ内通知

![スクリーンショット 2024-01-28 14 48 08](https://github.com/fjordllc/bootcamp/assets/40317050/1c797945-dc7b-49e8-9ea4-0334077633fc)
![スクリーンショット 2024-01-28 14 48 24](https://github.com/fjordllc/bootcamp/assets/40317050/ff51f76d-40b1-43c9-9747-6cc3af346a31)

#### メール通知

![スクリーンショット 2024-01-28 14 49 39](https://github.com/fjordllc/bootcamp/assets/40317050/7d4b92bc-21ed-4235-9a5c-060611c6c4cf)


