### PR TITLE
slim-lintのルール「Layout/ArrayAlignment」を適応する

### DIFF
--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -8,7 +8,6 @@ linters:
     enabled: true
     ignored_cops:
       - Layout/ArgumentAlignment
-      - Layout/ArrayAlignment
       - Layout/BlockAlignment
       - Layout/EmptyLineAfterGuardClause
       - Layout/EndAlignment


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7247

## 概要
slim-lintが指摘するルールで無視する設定になっているものが多くあるため、`Layout/ArrayAlignment`を有効化する。

### Layout/ArrayAlignmentとは
複数行の配列内の要素が揃っているかどうかを確認するルール。[Layout/ArrayAlignment - Rubocop Docs](https://docs.rubocop.org/rubocop/cops_layout.html#layoutarrayalignment)
```ruby
# good
array = [1, 2, 3,
         4, 5, 6]

# bad
array = [1, 2, 3,
  4, 5, 6]
```

このルールを適応しても、該当する不揃いな配列はありませんでしたので、このプルリクエストではignored_copsからの削除のみ行なっています。

## 変更確認方法

1. `feature/apply-excluded-slim-lint-rule`をローカルに取り込む
2. `bundle exec slim-lint app/views -c config/slim_lint.yml`を実行する
3. 配列に関わる指摘がないことを確認する
現在、https://github.com/fjordllc/bootcamp/issues/7255 で対応中の` Style/SymbolArray: Use %i or %Ifor an array of symbols.`という指摘があります。

## Screenshot
機能の変更はないので、見た目の変化はありません。
