### PR TITLE
Layout/EmptyLineAfterGuardClauseを有効化

### DIFF
--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -27,6 +27,7 @@
     tbody.admin-table__items
       - users.each do |user|
         - next if params[:target] == 'campaign' && user.adviser?
+      ruby
         tr.admin-table__item class="#{user.retired_on? ? 'is-retired' : '' } #{user.hibernated? ? 'is-retired' : '' }"
           td.admin-table__item-value
             - if user.admin? && user.mentor?

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -10,7 +10,6 @@ linters:
       - Layout/ArgumentAlignment
       - Layout/ArrayAlignment
       - Layout/BlockAlignment
-      - Layout/EmptyLineAfterGuardClause
       - Layout/EndAlignment
       - Layout/FirstArrayElementIndentation
       - Layout/FirstParameterIndentation


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7248

## 概要
slim-lintの指摘するルールの内、多くのルールを除外する設定にしている。
本PRでは以下のルールを有効化した。
```
- Layout/EmptyLineAfterGuardClause 
```

その際、 `app/views/admin/users/_table.html.slim`の以下の行のみ、指摘に引っかかったので修正を行なっています。
https://github.com/fjordllc/bootcamp/blob/4c9e3f772f21c41708f96d556345a2398c588a5e/app/views/admin/users/_table.html.slim#L29

```
% bundle exec slim-lint app/views/ -c config/slim_lint.yml
app/views/admin/users/_table.html.slim:29 [W] RuboCop: Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
```


## 変更確認方法

1. `chore/apply-the-rule-empty-line-after-guard-clause-in-slim-lint`をローカルに取り込む
2. `bin/rails db:seed`
3. `foreman start -f Procfile.dev`
4. 参加登録し、user（user名はotamesi_adviser）を作成。
6. ログアウトし、komagata（管理者）でログイン。
7. 管理ページのユーザー一覧、そして「お試し延長」絞り込みで、otamesi_adviserが一番上に来る（表示される）ことを確認。
8. 管理ページから、otamesi_adviserを選択し、アドバイザーに設定。
9. 管理ページのユーザー一覧、そしてユーザーの「お試し延長」絞り込みで、otamesi_adviserが出てこないことを確認。

## 何故9の画面2つを確認すれば良い、と判断したか。

## Screenshot
変更前後で画面表示に変化がないため、添付していません。
