### PR TITLE
プラクティス一覧ページの不要なborderを削除する

### DIFF
--- a/app/views/courses/practices/index.html.slim
+++ b/app/views/courses/practices/index.html.slim
@@ -35,7 +35,6 @@ header.page-header
             = link_to courses_path, class: 'a-button is-md is-secondary is-block is-back' do
               | コース一覧
 = render 'courses/tabs'
-hr.a-border
 .page-body.js-users-visibility
   .container.is-xl
     #js-courses-practices(course-id="#{@course.id}")


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7226

## 概要
- プラクティス一覧ページの不要なborderを削除する
<img width="599" alt="299212281-747c73f9-3f7a-45af-9b4b-a19bd23c2122" src="https://github.com/fjordllc/bootcamp/assets/133615511/d2872296-ebc7-4562-9acc-3bd7c2075dc7">

## 変更確認方法

1. `feature/remove-unnecessary-border`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動する
3. ログイン後、画面の左上から２番目にある「プラクティス」をクリックし、プラクティス一覧画面に移動する
4. 以下を確認する
	- 上記に添付している画像のborderがなくなっていること

## Screenshot

### 変更前
![border_before](https://github.com/fjordllc/bootcamp/assets/133615511/23c8c144-6537-4063-a9f2-abc32182828d)

### 変更後
![border_after](https://github.com/fjordllc/bootcamp/assets/133615511/577ea4fa-bdcd-4231-b0f8-e6f9574c99d4)