### PR TITLE
slim-lintのルール「Layout/TrailingWhitespace」を適用する 

### DIFF
--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -27,7 +27,7 @@
     tbody.admin-table__items
       - users.each do |user|
         - next if params[:target] == 'campaign' && user.adviser?
-        tr.admin-table__item class="#{user.retired_on? ? 'is-retired' : '' } #{user.hibernated? ? 'is-retired' : '' }"
+        tr.admin-table__item class="#{user.retired_on? ? 'is-retired' : ''} #{user.hibernated? ? 'is-retired' : ''}"
           td.admin-table__item-value
             - if user.admin? && user.mentor?
               span.admin-table__role

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -30,7 +30,7 @@
           .a-page-notice__inner
             p
               | このページは他のユーザーから見た、あなたのプロフィールページです。
-              | （ #{ link_to '登録情報変更', edit_current_user_path } ）
+              | （ #{link_to '登録情報変更', edit_current_user_path} ）
     .container.is-xl
       .columns
         .row

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -26,7 +26,6 @@ linters:
       - Layout/MultilineOperationIndentation
       - Layout/ParameterAlignment
       - Layout/TrailingEmptyLines
-      - Layout/TrailingWhitespace
       - Lint/Void
       - Metrics/BlockLength
       - Metrics/BlockNesting


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7250
	- ( https://github.com/fjordllc/bootcamp/issues/7247 )

## 概要
- slim-lintが指摘するルールで無視する設定になっているものが多くあるため、`Layout/TrailingWhitespace`を有効化する。

### Layout/TrailingWhitespaceとは
- ソースコード内の末尾の空白をがないか確認するルール
	- [Layout/TrailingWhitespace - Rubocop Docs](https://docs.rubocop.org/rubocop/cops_layout.html#layouttrailingwhitespace)
```ruby
# 以下のコードは、0の後ろにスペースが入っている
# bad
x = 0 

# 以下のコードは、0の後ろに不要なスペースが入っていない
# good
x = 0
```

- このルールを適用したところ、２つのファイルが引っかかったので修正を行った。
	```
	$ bundle exec slim-lint app/views -c config/slim_lint.yml
	app/views/admin/users/_table.html.slim:30 [W] RuboCop: Layout/TrailingWhitespace: Trailing whitespace detected.
	app/views/admin/users/_table.html.slim:30 [W] RuboCop: Layout/TrailingWhitespace: Trailing whitespace detected.
	app/views/users/show.html.slim:33 [W] RuboCop: Layout/TrailingWhitespace: Trailing whitespace detected.
	```
	- `app/views/admin/users/_table.html.slim`の[こちら](https://github.com/fjordllc/bootcamp/pull/7275/files#diff-b6bccc9aeeb3684cec258c8eaa2c99eeadad1510b880d9355028d2f0c8bbe94eL30)
		- クラス名の指定の部分であり、空白を消去しても影響がない
	- `app/views/users/show.html.slim`の[こちら](https://github.com/fjordllc/bootcamp/pull/7275/files#diff-060a0ed16e6c0855976a219c964923b17eed1218d9e114692af6d79c558320f4L33)
		- `link_to`を埋め込んでいる`{}`付近に空白があるが、消去しても問題がない
		- なお、`link_to`の前の空白は消去しなくても警告が出ないが、以下の理由から消去している
			- 空白がなくても影響がないため
			- 他のファイルで、`link_to`の前に空白を入れている箇所がないため

## 変更確認方法

1. `feature/apply-layout-trailing-white-space`をローカルに取り込む
2. `bundle exec slim-lint app/views -c config/slim_lint.yml`を実行する
3.  指摘がないことを確認する

## Screenshot
機能の変更はないので、見た目の変化はありません。