### PR TITLE
プロフィールページに決済情報のリンクを追加

### DIFF
--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -65,3 +65,11 @@
             = simple_format(user.after_graduation_hope)
         - else
           | 未入力
+    .user-metas__item
+      .user-metas__item-label
+        | 決済情報
+      .user-metas__item-value
+        - if user.card?
+          = link_to 'カード登録', user.customer_url
+        - else
+          | カード未登録


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7273

## 概要
管理画面のユーザー一覧にだけあった「カード情報」へのリンクを、ユーザーのプロフィールページの非公開情報に追加しました。

## 変更確認方法

1. `feature/add_payment_info_link_to_profile`をローカルに取り込む
1. `foreman start -f Procfile.dev`でアプリを起動する
1. ユーザー名 : `komagata`・パスワード`testtest`でログインする
1. `/admin/users`にアクセスし、検証ツールでユーザー「hatsuno」の「カード登録」アイコンのリンク先URLを確認する
1. hatsunoのプロフィールページ(`/users/655153192`)を開き、以下を確認する
    - ユーザの非公開情報に「決済情報 | カード登録」と表示されていること
    - 「カード登録」のリンク先URLが4と同じであること（検証ツールで確認する）
1. `/admin/users`からhatsuno以外のユーザのプロフィールページ(`/users/1059691192`など)を開き、以下を確認する
    - ユーザの非公開情報に「決済情報 | カード未登録」と表示されていること
### 補足
リンク先はStripeの管理画面内なので、アクセスできない状態で問題ありません。

## Screenshot
### 変更前

![スクリーンショット 2024-01-30 15 50 03](https://github.com/fjordllc/bootcamp/assets/129706209/2f4fd2fb-df4b-4391-9e36-c51e367eb498)


### 変更後
![スクリーンショット 2024-01-30 15 54 25](https://github.com/fjordllc/bootcamp/assets/129706209/206a16e5-f8d7-4c65-987b-3f49c9c2f2a0)

