### PR TITLE
reports.created_atにインデックスを貼る

### DIFF
--- a/db/migrate/20240128205255_add_index_to_reports_created_at.rb
+++ b/db/migrate/20240128205255_add_index_to_reports_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToReportsCreatedAt < ActiveRecord::Migration[6.1]
+  def change
+    add_index :reports, [:created_at]
+  end
+end

--- a/db/migrate/20240202100641_add_index_to_reports_created_at.rb
+++ b/db/migrate/20240202100641_add_index_to_reports_created_at.rb
@@ -1,5 +1,5 @@
 class AddIndexToReportsCreatedAt < ActiveRecord::Migration[6.1]
   def change
-    add_index :reports, [:created_at]
+    add_index :reports, :created_at
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_28_205255) do
+ActiveRecord::Schema.define(version: 2024_02_02_100641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_20_101451) do
+ActiveRecord::Schema.define(version: 2024_01_28_205255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -602,6 +602,7 @@ ActiveRecord::Schema.define(version: 2023_11_20_101451) do
     t.boolean "wip", default: false, null: false
     t.integer "emotion"
     t.datetime "published_at"
+    t.index ["created_at"], name: "index_reports_on_created_at"
     t.index ["user_id", "reported_on"], name: "index_reports_on_user_id_and_reported_on", unique: true
     t.index ["user_id", "title"], name: "index_reports_on_user_id_and_title", unique: true
   end


### PR DESCRIPTION
## Issue

- Issue番号 #7246 

## 概要

 #7238 

レスポンス速度を向上させるため、`reports.created_at` にインデックスを貼る。

## 変更確認方法

1. feature/add-index-to-reports-created-atをローカルに取り込む
2. `foreman start -f Procfile.dev ` を打ち、bootcamp　起動
3.  ログインして日報一覧を確認

## 変更前後

開発者MTGで質問した際に、@komagata さんから変更前後の時間の測定は不要と回答をいただきました。
