### PR TITLE
stripeの古いメソッドを使わないように修正

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -11,9 +11,7 @@ class Card
   end
 
   def update(customer_id, card_token)
-    customer = Stripe::Customer.retrieve(customer_id)
-    customer.source = card_token
-    customer.save
+    Stripe::Customer.update(customer_id, source: card_token)
   end
 
   def search(email:)


### PR DESCRIPTION
## Issue

- Issue番号 #7298 

## 概要

Issueに記載してます。

## 変更確認方法

1. feature/collect-the-use-of-old-stripe-methodsをローカルに取り込む
2. `rails test test/models/card_test.rb `  を実行
3. 警告が表示されないことを確認

以前は以下のような警告がありました。

```
.NOTE: Stripe::Customer#save is deprecated; use the `update` class method (for examples see https://github.com/stripe/stripe-ruby/wiki/Migration-guide-for-v8) instead. It will be removed on or after 2022-11.
```
## Screenshot

特にありません。
