### PR TITLE
ユーザー一覧ページの各アクション数をリンクに変更

### DIFF
--- a/app/javascript/components/user-activity-count.vue
+++ b/app/javascript/components/user-activity-count.vue
@@ -1,0 +1,20 @@
+<template lang="pug">
+.card-counts__item
+  .card-counts__item-inner
+    dt.card-counts__item-label
+      | {{ activityName }}
+    dd.card-counts__item-value(:class='activityCount == 0 ? "is-empty" : ""')
+      span(v-if='activityCount == 0')
+        | {{ activityCount }}
+      a.a-text-link(v-else)(:href='activityUrl')
+        | {{ activityCount }}
+</template>
+<script>
+export default {
+  props: {
+    activityName: { type: Object, required: true },
+    activityCount: { type: Object, required: true },
+    activityUrl: { type: Object, required: true }
+  }
+}
+</script>

--- a/app/javascript/components/user-activity-counts.vue
+++ b/app/javascript/components/user-activity-counts.vue
@@ -2,23 +2,23 @@
 .card-counts.mt-3(v-if='user.student_or_trainee')
   dl.card-counts__items
     user-activity-count(
-      :activity-name='`日報`',
+      activity-name='日報',
       :activity-count='user.report_count',
       :activity-url='`${user.url}/reports`')
     user-activity-count(
-      :activity-name='`提出物`',
+      activity-name='提出物',
       :activity-count='user.product_count',
       :activity-url='`${user.url}/products`')
     user-activity-count(
-      :activity-name='`コメント`',
+      activity-name='コメント',
       :activity-count='user.comment_count',
       :activity-url='`${user.url}/comments`')
     user-activity-count(
-      :activity-name='`質問`',
+      activity-name='質問',
       :activity-count='user.question_count',
       :activity-url='`${user.url}/questions`')
     user-activity-count(
-      :activity-name='`回答`',
+      activity-name='回答',
       :activity-count='user.answer_count',
       :activity-url='`${user.url}/answers`')
 </template>

--- a/app/javascript/components/user-activity-counts.vue
+++ b/app/javascript/components/user-activity-counts.vue
@@ -7,35 +7,50 @@
           | 日報
         dd.card-counts__item-value(
           :class='user.report_count == 0 ? "is-empty" : ""')
-          | {{ user.report_count }}
+          span(v-if='user.report_count == 0')
+            | {{ user.report_count }}
+          a.a-text-link(v-else)(:href='`${user.url}/reports`')
+            | {{ user.report_count }}
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label
           | 提出物
         dd.card-counts__item-value(
           :class='user.product_count == 0 ? "is-empty" : ""')
-          | {{ user.product_count }}
+          span(v-if='user.product_count == 0')
+            | {{ user.product_count }}
+          a.a-text-link(v-else)(:href='`${user.url}/products`')
+            | {{ user.product_count }}
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label
           | コメント
         dd.card-counts__item-value(
           :class='user.comment_count == 0 ? "is-empty" : ""')
-          | {{ user.comment_count }}
+          span(v-if='user.comment_count == 0')
+            | {{ user.comment_count }}
+          a.a-text-link(v-else)(:href='`${user.url}/comments`')
+            | {{ user.comment_count }}
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label
           | 質問
         dd.card-counts__item-value(
           :class='user.question_count == 0 ? "is-empty" : ""')
-          | {{ user.question_count }}
+          span(v-if='user.question_count == 0')
+            | {{ user.question_count }}
+          a.a-text-link(v-else)(:href='`${user.url}/questions`')
+            | {{ user.question_count }}
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label
           | 回答
         dd.card-counts__item-value(
           :class='user.answer_count == 0 ? "is-empty" : ""')
-          | {{ user.answer_count }}
+          span(v-if='user.answer_count == 0')
+            | {{ user.answer_count }}
+          a.a-text-link(v-else)(:href='`${user.url}/answers`')
+            | {{ user.answer_count }}
 </template>
 <script>
 export default {

--- a/app/javascript/components/user-activity-counts.vue
+++ b/app/javascript/components/user-activity-counts.vue
@@ -1,59 +1,33 @@
 <template lang="pug">
 .card-counts.mt-3(v-if='user.student_or_trainee')
   dl.card-counts__items
-    .card-counts__item
-      .card-counts__item-inner
-        dt.card-counts__item-label
-          | 日報
-        dd.card-counts__item-value(
-          :class='user.report_count == 0 ? "is-empty" : ""')
-          span(v-if='user.report_count == 0')
-            | {{ user.report_count }}
-          a.a-text-link(v-else)(:href='`${user.url}/reports`')
-            | {{ user.report_count }}
-    .card-counts__item
-      .card-counts__item-inner
-        dt.card-counts__item-label
-          | 提出物
-        dd.card-counts__item-value(
-          :class='user.product_count == 0 ? "is-empty" : ""')
-          span(v-if='user.product_count == 0')
-            | {{ user.product_count }}
-          a.a-text-link(v-else)(:href='`${user.url}/products`')
-            | {{ user.product_count }}
-    .card-counts__item
-      .card-counts__item-inner
-        dt.card-counts__item-label
-          | コメント
-        dd.card-counts__item-value(
-          :class='user.comment_count == 0 ? "is-empty" : ""')
-          span(v-if='user.comment_count == 0')
-            | {{ user.comment_count }}
-          a.a-text-link(v-else)(:href='`${user.url}/comments`')
-            | {{ user.comment_count }}
-    .card-counts__item
-      .card-counts__item-inner
-        dt.card-counts__item-label
-          | 質問
-        dd.card-counts__item-value(
-          :class='user.question_count == 0 ? "is-empty" : ""')
-          span(v-if='user.question_count == 0')
-            | {{ user.question_count }}
-          a.a-text-link(v-else)(:href='`${user.url}/questions`')
-            | {{ user.question_count }}
-    .card-counts__item
-      .card-counts__item-inner
-        dt.card-counts__item-label
-          | 回答
-        dd.card-counts__item-value(
-          :class='user.answer_count == 0 ? "is-empty" : ""')
-          span(v-if='user.answer_count == 0')
-            | {{ user.answer_count }}
-          a.a-text-link(v-else)(:href='`${user.url}/answers`')
-            | {{ user.answer_count }}
+    user-activity-count(
+      :activity-name='`日報`',
+      :activity-count='user.report_count',
+      :activity-url='`${user.url}/reports`')
+    user-activity-count(
+      :activity-name='`提出物`',
+      :activity-count='user.product_count',
+      :activity-url='`${user.url}/products`')
+    user-activity-count(
+      :activity-name='`コメント`',
+      :activity-count='user.comment_count',
+      :activity-url='`${user.url}/comments`')
+    user-activity-count(
+      :activity-name='`質問`',
+      :activity-count='user.question_count',
+      :activity-url='`${user.url}/questions`')
+    user-activity-count(
+      :activity-name='`回答`',
+      :activity-count='user.answer_count',
+      :activity-url='`${user.url}/answers`')
 </template>
 <script>
+import UserActivityCount from './user-activity-count.vue'
 export default {
+  components: {
+    'user-activity-count': UserActivityCount
+  },
   props: {
     user: { type: Object, required: true }
   }


### PR DESCRIPTION
## Issue
- [ユーザー一覧にある数字一覧をリンクにしたい。 #7182
](https://github.com/fjordllc/bootcamp/issues/7182)

## 概要

- ユーザー一覧ページにおいて、各ユーザーの以下の数字をリンクに変更しました（数字が0の場合を除く）。
  - 日報
    - 対象ユーザーの日報一覧へのリンク
  - 提出物
    - 対象ユーザーの提出物一覧へのリンク
  - コメント
    - 対象ユーザーのコメント一覧へのリンク
  - 質問
    - 対象ユーザーの質問一覧へのリンク
  - 回答
    - 対象ユーザーの回答一覧へのリンク

## 変更確認方法

1. `feature/replace-num-of-actions-on-user-list-page-with-link`ブランチをローカルに取り込む。
2. サーバーを起動、任意のユーザーでログインする。
3. `http://localhost:3000/users`にアクセスし、以下を確認する
  - 日報、提出物、コメント、質問、回答の各数字がリンクになっていること（ただし、数字が0の場合はリンクになっていないこと）
  - 各リンクをクリックしすると、それぞれの一覧ページへ移動すること
    - 例えば、日報の数のリンクであれば対象ユーザーの日報一覧ページへ移動すること

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/131861805/a2dd36cb-e3d4-4e00-af2c-2ab4970c496a)

### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/131861805/0e0a2ede-95bf-45ff-b19d-810fe4510059)
