### PR TITLE
rubocop-capybaraを導入する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-minitest
+  - rubocop-capybara
 
 inherit_from: .rubocop_todo.yml
 

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :development do
   gem 'rack-dev-mark'
   gem 'rack-mini-profiler', '~> 2.0', require: false
   gem 'rubocop', require: false
+  gem 'rubocop-capybara', require: false
   gem 'rubocop-fjord', '~> 0.3.0', require: false
   gem 'rubocop-minitest', require: false
   gem 'rubocop-performance', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,6 +461,8 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.20.0)
+      rubocop (~> 1.41)
     rubocop-fjord (0.3.0)
       rubocop (>= 1.0)
       rubocop-performance
@@ -655,6 +657,7 @@ DEPENDENCIES
   rollbar
   rss
   rubocop
+  rubocop-capybara
   rubocop-fjord (~> 0.3.0)
   rubocop-minitest
   rubocop-performance


### PR DESCRIPTION
## Issue

- [#7186](https://github.com/fjordllc/bootcamp/issues/7186)

## 概要
[rubocop-capybara](https://github.com/rubocop/rubocop-capybara)をプロジェクトに導入しました。

## 変更確認方法

1. `feature/add_rubocop-capybara`をローカルに取り込む
2. ターミナルで`bundle install`を実行する
3. ターミナルで`./bin/lint`を実行する
4. 以下のメッセージが出ていないことを確認する。
```
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-capybara (https://rubygems.org/gems/rubocop-capybara)
```

## Screenshot

### 変更前
<img width="1679" alt="image" src="https://github.com/fjordllc/bootcamp/assets/78665068/f9b53a26-1202-4b9e-acef-ec2990abfc2a">


### 変更後
<img width="1679" alt="image" src="https://github.com/fjordllc/bootcamp/assets/78665068/123bd709-a9e9-49db-8949-d104ada33a91">

