### PR TITLE
イベントの日時を秒単位で変更してもエラーが出ないように修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,9 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: ci_test
+          LANG: 'ja_JP.UTF-8'
       - image: cimg/postgres:14.4
+          LANG: 'ja_JP.UTF-8'
     resource_class: large
     environment:
       BUNDLE_JOBS: '3'
@@ -58,7 +60,6 @@ jobs:
       DATABASE_URL: 'postgres://postgres:postgres@localhost/ci_test'
       TZ: Asia/Tokyo
       PARALLEL_WORKERS: 2
-      LANG: 'ja_JP.UTF-8'
     parallelism: 3
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ jobs:
           POSTGRES_DB: ci_test
           LANG: 'ja_JP.UTF-8'
       - image: cimg/postgres:14.4
-          LANG: 'ja_JP.UTF-8'
     resource_class: large
     environment:
       BUNDLE_JOBS: '3'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,15 +49,16 @@ jobs:
       - image: cimg/postgres:14.4
     resource_class: large
     environment:
-      BUNDLE_JOBS: "3"
-      BUNDLE_RETRY: "3"
+      BUNDLE_JOBS: '3'
+      BUNDLE_RETRY: '3'
       PGHOST: 127.0.0.1
       PGUSER: postgres
-      PGPASSWORD: "postgres"
+      PGPASSWORD: 'postgres'
       RAILS_ENV: test
-      DATABASE_URL: "postgres://postgres:postgres@localhost/ci_test"
+      DATABASE_URL: 'postgres://postgres:postgres@localhost/ci_test'
       TZ: Asia/Tokyo
       PARALLEL_WORKERS: 2
+      LANG: 'ja_JP.UTF-8'
     parallelism: 3
     steps:
       - checkout
@@ -84,7 +85,7 @@ jobs:
       - run:
           name: Assets precompile
           command: 'bundle exec rails assets:clean assets:precompile NODE_OPTIONS=--openssl-legacy-provider'
-      - run:  
+      - run:
           command: 'gem install stringio -v 3.1.0'
       - run:
           name: Test
@@ -105,5 +106,4 @@ workflows:
       - test:
           requires:
             - build
-
 # VS Code Extension Version: 1.5.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,8 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: ci_test
+          - LOCALE=ja
+          - LANG=ja_JP.UTF-8
       - image: cimg/postgres:14.4
     resource_class: large
     environment:
@@ -62,6 +64,9 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update # TODO: remove it https://github.com/CircleCI-Public/browser-tools-orb/issues/75#issuecomment-1641031119
+      - run: echo 'ja_JP.UTF-8 UTF-8' | sudo tee -a  /etc/locale.gen
+      - run: sudo locale-gen
+      - run: sudo update-locale LANG=ja_JP.UTF-8
       - browser-tools/install-chrome:
           chrome-version: 121.0.6167.160
       - browser-tools/install-chromedriver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: ci_test
-          LANG: 'ja_JP.UTF-8'
       - image: cimg/postgres:14.4
     resource_class: large
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: ci_test
-          - LOCALE=ja
-          - LANG=ja_JP.UTF-8
+          LOCALE: ja
+          LANG: ja_JP.UTF-8
       - image: cimg/postgres:14.4
     resource_class: large
     environment:

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -13,16 +13,16 @@
         = f.text_field :capacity, class: 'a-text-input js-warning-form', placeholder: '100'
       .form-item
         = f.label :start_at, class: 'a-form-label'
-        = f.datetime_field :start_at, class: 'a-text-input js-warning-form'
+        = f.datetime_field :start_at, class: 'a-text-input js-warning-form', step: 1
       .form-item
         = f.label :end_at, class: 'a-form-label'
-        = f.datetime_field :end_at, class: 'a-text-input js-warning-form'
+        = f.datetime_field :end_at, class: 'a-text-input js-warning-form', step: 1
       .form-item
         = f.label :open_start_at, class: 'a-form-label'
-        = f.datetime_field :open_start_at, class: 'a-text-input js-warning-form'
+        = f.datetime_field :open_start_at, class: 'a-text-input js-warning-form', step: 1
       .form-item
         = f.label :open_end_at, class: 'a-form-label'
-        = f.datetime_field :open_end_at, class: 'a-text-input js-warning-form'
+        = f.datetime_field :open_end_at, class: 'a-text-input js-warning-form', step: 1
       .form-item
         label.a-form-label
           | イベント内容

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -29,7 +29,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       driver_option.add_argument('--headless=old')
       driver_option.add_argument('--no-sandbox')
       driver_option.add_argument('--disable-dev-shm-usage')
-      driver_option.add_argument('--lang=ja_JP.UTF-8')
+      driver_option.add_argument('--lang=ja_JP')
     end
   end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -23,16 +23,17 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ArticleHelper
 
   if ENV['HEADFULL']
-    driven_by(:selenium, using: :chrome, options:{
-      options: Selenium::WebDriver::Chrome::Options.new(
-        prefs: { 'general.useragent.locale' => 'ja-JP' }
-      )
-    })
+    driven_by(:selenium, using: :chrome, options: {
+                options: Selenium::WebDriver::Chrome::Options.new(
+                  prefs: { 'general.useragent.locale' => 'ja-JP' }
+                )
+              })
   else
-    driven_by(:selenium, using: :headless_chrome, options:{
-      options: Selenium::WebDriver::Chrome::Options.new(
-        prefs: { 'general.useragent.locale' => 'ja-JP' }
-      )}) do |driver_option|
+    driven_by(:selenium, using: :headless_chrome, options: {
+                options: Selenium::WebDriver::Chrome::Options.new(
+                  prefs: { 'general.useragent.locale' => 'ja-JP' }
+                )
+              }) do |driver_option|
       driver_option.add_argument('--headless=old')
       driver_option.add_argument('--no-sandbox')
       driver_option.add_argument('--disable-dev-shm-usage')

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -21,15 +21,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include TagHelper
   include MockEnvHelper
   include ArticleHelper
-
   if ENV['HEADFULL']
-    driven_by :selenium, using: :chrome
+    driven_by(:selenium, using: :chrome) do |driver_option|
+      driver_option.add_argument('--lang=ja')
+    end
   else
     driven_by(:selenium, using: :headless_chrome) do |driver_option|
       driver_option.add_argument('--headless=old')
       driver_option.add_argument('--no-sandbox')
       driver_option.add_argument('--disable-dev-shm-usage')
-      driver_option.add_argument('--lang=ja_JP')
+      driver_option.add_argument('--lang=ja')
     end
   end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -23,14 +23,20 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ArticleHelper
   if ENV['HEADFULL']
     driven_by(:selenium, using: :chrome) do |driver_option|
-      driver_option.add_argument('--lang=ja')
+      options = driver_option.args
+      options << '--lang=ja'
+      options << '--user-agent=ja-JP'
+      driver_option.args = options
     end
   else
     driven_by(:selenium, using: :headless_chrome) do |driver_option|
-      driver_option.add_argument('--headless=old')
-      driver_option.add_argument('--no-sandbox')
-      driver_option.add_argument('--disable-dev-shm-usage')
-      driver_option.add_argument('--lang=ja')
+      options = driver_option.args
+      options << '--headless=old'
+      options << '--no-sandbox'
+      options << '--disable-dev-shm-usage'
+      options << '--lang=ja'
+      options << '--user-agent=ja-JP'
+      driver_option.args = options
     end
   end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -25,13 +25,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   if ENV['HEADFULL']
     driven_by(:selenium, using: :chrome, options: {
                 options: Selenium::WebDriver::Chrome::Options.new(
-                  prefs: { 'general.useragent.locale' => 'ja-JP' }
+                  prefs: { 'intl.accept_languages' => 'ja-JP' }
                 )
               })
   else
     driven_by(:selenium, using: :headless_chrome, options: {
                 options: Selenium::WebDriver::Chrome::Options.new(
-                  prefs: { 'general.useragent.locale' => 'ja-JP' }
+                  prefs: { 'intl.accept_languages' => 'ja-JP' }
                 )
               }) do |driver_option|
       driver_option.add_argument('--headless=old')

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -29,6 +29,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       driver_option.add_argument('--headless=old')
       driver_option.add_argument('--no-sandbox')
       driver_option.add_argument('--disable-dev-shm-usage')
+      driver_option.add_argument('--lang=ja_JP.UTF-8')
     end
   end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -21,22 +21,21 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include TagHelper
   include MockEnvHelper
   include ArticleHelper
+
   if ENV['HEADFULL']
-    driven_by(:selenium, using: :chrome) do |driver_option|
-      options = driver_option.args
-      options << '--lang=ja'
-      options << '--user-agent=ja-JP'
-      driver_option.args = options
-    end
+    driven_by(:selenium, using: :chrome, options:{
+      options: Selenium::WebDriver::Chrome::Options.new(
+        prefs: { 'general.useragent.locale' => 'ja-JP' }
+      )
+    })
   else
-    driven_by(:selenium, using: :headless_chrome) do |driver_option|
-      options = driver_option.args
-      options << '--headless=old'
-      options << '--no-sandbox'
-      options << '--disable-dev-shm-usage'
-      options << '--lang=ja'
-      options << '--user-agent=ja-JP'
-      driver_option.args = options
+    driven_by(:selenium, using: :headless_chrome, options:{
+      options: Selenium::WebDriver::Chrome::Options.new(
+        prefs: { 'general.useragent.locale' => 'ja-JP' }
+      )}) do |driver_option|
+      driver_option.add_argument('--headless=old')
+      driver_option.add_argument('--no-sandbox')
+      driver_option.add_argument('--disable-dev-shm-usage')
     end
   end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -23,20 +23,15 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ArticleHelper
 
   if ENV['HEADFULL']
-    driven_by(:selenium, using: :chrome, options: {
-                options: Selenium::WebDriver::Chrome::Options.new(
-                  prefs: { 'intl.accept_languages' => 'ja-JP' }
-                )
-              })
+    driven_by(:selenium, using: :chrome) do |driver_option|
+      driver_option.add_argument('--lang=ja-JP')
+    end
   else
-    driven_by(:selenium, using: :headless_chrome, options: {
-                options: Selenium::WebDriver::Chrome::Options.new(
-                  prefs: { 'intl.accept_languages' => 'ja-JP' }
-                )
-              }) do |driver_option|
+    driven_by(:selenium, using: :headless_chrome) do |driver_option|
       driver_option.add_argument('--headless=old')
       driver_option.add_argument('--no-sandbox')
       driver_option.add_argument('--disable-dev-shm-usage')
+      driver_option.add_argument('--lang=ja-JP')
     end
   end
 

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -90,11 +90,10 @@ class EventsTest < ApplicationSystemTestCase
       fill_in 'event[description]', with: 'ミートアップを開催します(修正2)'
       fill_in 'event[capacity]', with: 30
       fill_in 'event[location]', with: 'FJORDオフィス'
-      fill_in 'event[start_at]', with: Time.zone.parse('2019-12-21 19:00:01')
-      fill_in 'event[end_at]', with: Time.zone.parse('2019-12-21 22:30:01')
-      fill_in 'event[open_start_at]', with: Time.zone.parse('2019-12-11 09:00:01')
-      fill_in 'event[open_end_at]', with: Time.zone.parse('2019-12-20 23:59:01')
-      binding.irb
+      fill_in 'event[start_at]', with: '002019-12-21T19:00:01', fill_options: { clear: :backspace }
+      fill_in 'event[end_at]', with: '002019-12-21T22:30:01', fill_options: { clear: :backspace }
+      fill_in 'event[open_start_at]', with: '002019-12-11T09:00:01', fill_options: { clear: :backspace }
+      fill_in 'event[open_end_at]', with: '002019-12-20T23:59:01', fill_options: { clear: :backspace }
       click_button '内容を更新'
     end
     assert_text '特別イベントを更新しました。'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -83,6 +83,28 @@ class EventsTest < ApplicationSystemTestCase
     assert_text '特別イベントを更新しました。'
   end
 
+  test 'update event in seconds' do
+    visit_with_auth edit_event_path(events(:event1)), 'kimura'
+    within 'form[name=event]' do
+      fill_in 'event[title]', with: 'ミートアップ(修正2)'
+      fill_in 'event[description]', with: 'ミートアップを開催します(修正2)'
+      fill_in 'event[capacity]', with: 30
+      fill_in 'event[location]', with: 'FJORDオフィス'
+      fill_in 'event[start_at]', with: '002019-12-21T19:00:01'
+      fill_in 'event[end_at]', with: '002019-12-21T22:30:01'
+      fill_in 'event[open_start_at]', with: '002019-12-11T09:00:01'
+      fill_in 'event[open_end_at]', with: '002019-12-20T23:59:01'
+      click_button '内容を更新'
+    end
+    assert_text '特別イベントを更新しました。'
+    assert_equal 1, Event.where(\
+      start_at: Time.zone.parse('2019-12-21 19:00:01'),\
+      end_at: Time.zone.parse('2019-12-21 22:30:01'),\
+      open_start_at: Time.zone.parse('2019-12-11 09:00:01'),\
+      open_end_at: Time.zone.parse('2019-12-20 23:59:01')
+    ).count
+  end
+
   test 'destroy event' do
     visit_with_auth event_path(events(:event1)), 'kimura'
     find 'h2', text: 'コメント'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -90,10 +90,10 @@ class EventsTest < ApplicationSystemTestCase
       fill_in 'event[description]', with: 'ミートアップを開催します(修正2)'
       fill_in 'event[capacity]', with: 30
       fill_in 'event[location]', with: 'FJORDオフィス'
-      page.execute_script("document.getElementById('event_start_at').value = '2019-12-21T19:00:01'")
-      page.execute_script("document.getElementById('event_end_at').value = '2019-12-21T22:30:01'")
-      page.execute_script("document.getElementById('event_open_start_at').value = '2019-12-11T09:00:01'")
-      page.execute_script("document.getElementById('event_open_end_at').value = '2019-12-20T23:59:01'")
+      fill_in 'event[start_at]', with: '002019-12-21T19:00:01'
+      fill_in 'event[end_at]', with: '002019-12-21T22:30:01'
+      fill_in 'event[open_start_at]', with: '002019-12-11T09:00:01'
+      fill_in 'event[open_end_at]', with: '002019-12-20T23:59:01'
       click_button '内容を更新'
     end
     assert_text '特別イベントを更新しました。'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -90,10 +90,10 @@ class EventsTest < ApplicationSystemTestCase
       fill_in 'event[description]', with: 'ミートアップを開催します(修正2)'
       fill_in 'event[capacity]', with: 30
       fill_in 'event[location]', with: 'FJORDオフィス'
-      fill_in 'event[start_at]', with: '002019-12-21T19:00:01', fill_options: { clear: :backspace }
-      fill_in 'event[end_at]', with: '002019-12-21T22:30:01', fill_options: { clear: :backspace }
-      fill_in 'event[open_start_at]', with: '002019-12-11T09:00:01', fill_options: { clear: :backspace }
-      fill_in 'event[open_end_at]', with: '002019-12-20T23:59:01', fill_options: { clear: :backspace }
+      page.execute_script("document.getElementById('event_start_at').value = '2019-12-21T19:00:01'")
+      page.execute_script("document.getElementById('event_end_at').value = '2019-12-21T22:30:01'")
+      page.execute_script("document.getElementById('event_open_start_at').value = '2019-12-11T09:00:01'")
+      page.execute_script("document.getElementById('event_open_end_at').value = '2019-12-20T23:59:01'")
       click_button '内容を更新'
     end
     assert_text '特別イベントを更新しました。'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -90,10 +90,10 @@ class EventsTest < ApplicationSystemTestCase
       fill_in 'event[description]', with: 'ミートアップを開催します(修正2)'
       fill_in 'event[capacity]', with: 30
       fill_in 'event[location]', with: 'FJORDオフィス'
-      fill_in 'event[start_at]', with: '002019-12-21T19:00:01'
-      fill_in 'event[end_at]', with: '002019-12-21T22:30:01'
-      fill_in 'event[open_start_at]', with: '002019-12-11T09:00:01'
-      fill_in 'event[open_end_at]', with: '002019-12-20T23:59:01'
+      fill_in 'event[start_at]', with: Time.zone.parse('2019-12-21 19:00:01')
+      fill_in 'event[end_at]', with: Time.zone.parse('2019-12-21 22:30:01')
+      fill_in 'event[open_start_at]', with: Time.zone.parse('2019-12-11 09:00:01')
+      fill_in 'event[open_end_at]', with: Time.zone.parse('2019-12-20 23:59:01')
       click_button '内容を更新'
     end
     assert_text '特別イベントを更新しました。'

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -94,6 +94,7 @@ class EventsTest < ApplicationSystemTestCase
       fill_in 'event[end_at]', with: Time.zone.parse('2019-12-21 22:30:01')
       fill_in 'event[open_start_at]', with: Time.zone.parse('2019-12-11 09:00:01')
       fill_in 'event[open_end_at]', with: Time.zone.parse('2019-12-20 23:59:01')
+      binding.irb
       click_button '内容を更新'
     end
     assert_text '特別イベントを更新しました。'


### PR DESCRIPTION
## Issue

- Issue番号 #5744 

## 概要

　Issueを参照。
　イベントの日時において、秒単位の変更を行なってもエラーが発生して保存ができない。

　それを修正した。

## 変更確認方法

1. {`bug/cannot_set_seconds_units_on_event_page`}をローカルに取り込む
2. `foreman start -f Procfile.dev ` を実行し、アプリを立ち上げる
3. 有料メンバーまたはメンターのアカウントでログイン 
4. イベントの詳細ページ（ http://localhost:3000/events/308029005 )へアクセス 
5. 任意の日付のフォームを秒単位で変更して保存またはWIPを押す
6. データが変更されたことを確認する

## Screenshot

### 変更前
<img width="615" alt="スクリーンショット 2024-02-04 20 14 21" src="https://github.com/fjordllc/bootcamp/assets/8443743/340c0702-853e-4b7d-ab35-868665e2b2bc">

### 変更後

<img width="625" alt="スクリーンショット 2024-02-04 20 18 45" src="https://github.com/fjordllc/bootcamp/assets/8443743/3dcf1ffd-6ae7-4de5-a515-4a6aa891b8c5">

