### PR TITLE
提出物の確認を取り消しても、プラクティスの進捗ステータスが「修了」のままだったバグを修正

### DIFF
--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -23,7 +23,10 @@ class API::ChecksController < API::BaseController
   end
 
   def destroy
-    @check = Check.find(params[:id]).destroy
+    @check = Check.find(params[:id])
+    @check.destroy
+    Newspaper.publish(:check_cancel, { check: @check })
+
     head :no_content
   end
 

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -23,8 +23,7 @@ class API::ChecksController < API::BaseController
   end
 
   def destroy
-    @check = Check.find(params[:id])
-    @check.destroy
+    @check = Check.find(params[:id]).destroy
     Newspaper.publish(:check_cancel, { check: @check })
 
     head :no_content

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -7,20 +7,15 @@ class LearningStatusUpdater
     when Product
       update_after_submission(product_or_associated_object)
     when Check
-      handle_check(product_or_associated_object)
+      update_after_check(product_or_associated_object)
     end
   end
 
   def update_after_check(check)
     return unless check.checkable_type == 'Product'
 
-    check.checkable.change_learning_status(:complete)
-  end
-
-  def update_after_cancel_check(check)
-    return unless check.checkable_type == 'Product'
-
-    check.checkable.change_learning_status(:submitted)
+    learning_status = check.checkable.checked? ? :complete : :submitted
+    check.checkable.change_learning_status(learning_status)
   end
 
   def update_after_submission(product)
@@ -37,11 +32,5 @@ class LearningStatusUpdater
                :submitted
              end
     product.change_learning_status status
-  end
-
-  private
-
-  def handle_check(check)
-    Check.exists?(check.id) ? update_after_check(check) : update_after_cancel_check(check)
   end
 end

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -7,7 +7,7 @@ class LearningStatusUpdater
     when Product
       update_after_submission(product_or_associated_object)
     when Check
-      update_after_check(product_or_associated_object)
+      Check.exists?(product_or_associated_object.id) ? update_after_check(product_or_associated_object) : update_after_cancel_check(product_or_associated_object)
     end
   end
 
@@ -15,6 +15,12 @@ class LearningStatusUpdater
     return unless check.checkable_type == 'Product'
 
     check.checkable.change_learning_status(:complete)
+  end
+
+  def update_after_cancel_check(check)
+    return unless check.checkable_type == 'Product'
+
+    check.checkable.change_learning_status(:submitted)
   end
 
   def update_after_submission(product)

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -7,7 +7,11 @@ class LearningStatusUpdater
     when Product
       update_after_submission(product_or_associated_object)
     when Check
-      Check.exists?(product_or_associated_object.id) ? update_after_check(product_or_associated_object) : update_after_cancel_check(product_or_associated_object)
+      if Check.exists?(product_or_associated_object.id)
+        update_after_check(product_or_associated_object)
+      else
+        update_after_cancel_check(product_or_associated_object)
+      end
     end
   end
 

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -7,11 +7,7 @@ class LearningStatusUpdater
     when Product
       update_after_submission(product_or_associated_object)
     when Check
-      if Check.exists?(product_or_associated_object.id)
-        update_after_check(product_or_associated_object)
-      else
-        update_after_cancel_check(product_or_associated_object)
-      end
+      handle_check(product_or_associated_object)
     end
   end
 
@@ -41,5 +37,11 @@ class LearningStatusUpdater
                :submitted
              end
     product.change_learning_status status
+  end
+
+  private
+
+  def handle_check(check)
+    Check.exists?(check.id) ? update_after_check(check) : update_after_cancel_check(check)
   end
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -41,6 +41,7 @@ Rails.configuration.to_prepare do
   learning_status_updater = LearningStatusUpdater.new
   Newspaper.subscribe(:check_create, learning_status_updater)
   Newspaper.subscribe(:product_save, learning_status_updater)
+  Newspaper.subscribe(:check_cancel, learning_status_updater)
 
   page_notifier = PageNotifier.new
   Newspaper.subscribe(:page_create, page_notifier)

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -438,3 +438,8 @@ product73:
   user: hajime
   body: 担当者がいなくてwatchされていない提出物です
   checker_id: nil
+
+product74:
+  practice: practice1
+  user: kimuramitai
+  body: 提出、確認が必要なプラクティスの提出物

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -438,3 +438,11 @@ product73:
   user: hajime
   body: 担当者がいなくてwatchされていない提出物です
   checker_id: nil
+
+product74:
+  practice: practice1
+  user: hajime
+  body: メンターが確認を取り消した後の、learningstatusのテスト用提出物です
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+  published_at: <%= Time.current %>

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -438,8 +438,3 @@ product73:
   user: hajime
   body: 担当者がいなくてwatchされていない提出物です
   checker_id: nil
-
-product74:
-  practice: practice1
-  user: kimuramitai
-  body: 提出、確認が必要なプラクティスの提出物

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -438,11 +438,3 @@ product73:
   user: hajime
   body: 担当者がいなくてwatchされていない提出物です
   checker_id: nil
-
-product74:
-  practice: practice1
-  user: hajime
-  body: メンターが確認を取り消した後の、learningstatusのテスト用提出物です
-  created_at: <%= Time.current %>
-  updated_at: <%= Time.current %>
-  published_at: <%= Time.current %>

--- a/test/system/learning_status_test.rb
+++ b/test/system/learning_status_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class LearningStatusTest < ApplicationSystemTestCase
+  test 'learning status changes to submitted after the mentor cancels the confirmation' do
+    visit_with_auth "/products/#{products(:product74).id}", 'machida'
+    click_button '担当する'
+    click_button '提出物を確認'
+    click_button '提出物の確認を取り消す'
+    visit_with_auth course_practices_path(courses(:course1).id), 'hajime'
+    assert_selector 'a', text: '提出'
+  end
+
+  test 'learning status changes to submitted after the mentor cancels the confirmation with comment' do
+    visit_with_auth "/products/#{products(:product74).id}", 'machida'
+    click_button '担当する'
+    fill_in('new_comment[description]', with: 'LGTMです。')
+    accept_alert do
+      click_button '確認OKにする'
+    end
+    click_button '提出物の確認を取り消す'
+    visit_with_auth course_practices_path(courses(:course1).id), 'hajime'
+    assert_selector 'a', text: '提出'
+  end
+end

--- a/test/system/learning_status_test.rb
+++ b/test/system/learning_status_test.rb
@@ -4,23 +4,33 @@ require 'application_system_test_case'
 
 class LearningStatusTest < ApplicationSystemTestCase
   test 'learning status changes to submitted after the mentor cancels the confirmation' do
-    visit_with_auth "/products/#{products(:product74).id}", 'machida'
+    product = Product.create!(
+      body: '直接確認する提出物',
+      user: users(:kimuramitai),
+      practice: practices(:practice1)
+    )
+    visit_with_auth "/products/#{product.id}", 'machida'
     click_button '担当する'
     click_button '提出物を確認'
     click_button '提出物の確認を取り消す'
-    visit_with_auth "/products/#{products(:product74).id}", 'kimuramitai'
+    visit_with_auth "/products/#{product.id}", 'kimuramitai'
     assert_no_selector 'h2', text: 'このプラクティスは修了しました🎉'
   end
 
   test 'learning status changes to submitted after the mentor cancels the confirmation with comment' do
-    visit_with_auth "/products/#{products(:product74).id}", 'machida'
+    product = Product.create!(
+      body: 'コメントで確認する提出物',
+      user: users(:kimuramitai),
+      practice: practices(:practice1)
+    )
+    visit_with_auth "/products/#{product.id}", 'machida'
     click_button '担当する'
     fill_in('new_comment[description]', with: 'LGTMです。')
     accept_alert do
       click_button '確認OKにする'
     end
     click_button '提出物の確認を取り消す'
-    visit_with_auth "/products/#{products(:product74).id}", 'kimuramitai'
+    visit_with_auth "/products/#{product.id}", 'kimuramitai'
     assert_no_selector 'h2', text: 'このプラクティスは修了しました🎉'
   end
 end

--- a/test/system/learning_status_test.rb
+++ b/test/system/learning_status_test.rb
@@ -4,23 +4,23 @@ require 'application_system_test_case'
 
 class LearningStatusTest < ApplicationSystemTestCase
   test 'learning status changes to submitted after the mentor cancels the confirmation' do
-    visit_with_auth "/products/#{products(:product8).id}", 'machida'
+    visit_with_auth "/products/#{products(:product74).id}", 'machida'
     click_button '担当する'
     click_button '提出物を確認'
     click_button '提出物の確認を取り消す'
-    visit_with_auth "/products/#{products(:product8).id}", 'kimura'
+    visit_with_auth "/products/#{products(:product74).id}", 'kimuramitai'
     assert_no_selector 'h2', text: 'このプラクティスは修了しました🎉'
   end
 
   test 'learning status changes to submitted after the mentor cancels the confirmation with comment' do
-    visit_with_auth "/products/#{products(:product8).id}", 'machida'
+    visit_with_auth "/products/#{products(:product74).id}", 'machida'
     click_button '担当する'
     fill_in('new_comment[description]', with: 'LGTMです。')
     accept_alert do
       click_button '確認OKにする'
     end
     click_button '提出物の確認を取り消す'
-    visit_with_auth "/products/#{products(:product8).id}", 'kimura'
+    visit_with_auth "/products/#{products(:product74).id}", 'kimuramitai'
     assert_no_selector 'h2', text: 'このプラクティスは修了しました🎉'
   end
 end

--- a/test/system/learning_status_test.rb
+++ b/test/system/learning_status_test.rb
@@ -9,7 +9,7 @@ class LearningStatusTest < ApplicationSystemTestCase
     click_button '提出物を確認'
     click_button '提出物の確認を取り消す'
     visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
-    assert_selector 'a', text: '提出'
+    assert_no_selector 'a', text: '修了'
   end
 
   test 'learning status changes to submitted after the mentor cancels the confirmation with comment' do
@@ -21,6 +21,6 @@ class LearningStatusTest < ApplicationSystemTestCase
     end
     click_button '提出物の確認を取り消す'
     visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
-    assert_selector 'a', text: '提出'
+    assert_no_selector 'a', text: '修了'
   end
 end

--- a/test/system/learning_status_test.rb
+++ b/test/system/learning_status_test.rb
@@ -8,8 +8,8 @@ class LearningStatusTest < ApplicationSystemTestCase
     click_button '担当する'
     click_button '提出物を確認'
     click_button '提出物の確認を取り消す'
-    visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
-    assert_no_selector 'a', text: '修了'
+    visit_with_auth "/products/#{products(:product8).id}", 'kimura'
+    assert_no_selector 'h2', text: 'このプラクティスは修了しました🎉'
   end
 
   test 'learning status changes to submitted after the mentor cancels the confirmation with comment' do
@@ -20,7 +20,7 @@ class LearningStatusTest < ApplicationSystemTestCase
       click_button '確認OKにする'
     end
     click_button '提出物の確認を取り消す'
-    visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
-    assert_no_selector 'a', text: '修了'
+    visit_with_auth "/products/#{products(:product8).id}", 'kimura'
+    assert_no_selector 'h2', text: 'このプラクティスは修了しました🎉'
   end
 end

--- a/test/system/learning_status_test.rb
+++ b/test/system/learning_status_test.rb
@@ -4,23 +4,23 @@ require 'application_system_test_case'
 
 class LearningStatusTest < ApplicationSystemTestCase
   test 'learning status changes to submitted after the mentor cancels the confirmation' do
-    visit_with_auth "/products/#{products(:product74).id}", 'machida'
+    visit_with_auth "/products/#{products(:product8).id}", 'machida'
     click_button '担当する'
     click_button '提出物を確認'
     click_button '提出物の確認を取り消す'
-    visit_with_auth course_practices_path(courses(:course1).id), 'hajime'
+    visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
     assert_selector 'a', text: '提出'
   end
 
   test 'learning status changes to submitted after the mentor cancels the confirmation with comment' do
-    visit_with_auth "/products/#{products(:product74).id}", 'machida'
+    visit_with_auth "/products/#{products(:product8).id}", 'machida'
     click_button '担当する'
     fill_in('new_comment[description]', with: 'LGTMです。')
     accept_alert do
       click_button '確認OKにする'
     end
     click_button '提出物の確認を取り消す'
-    visit_with_auth course_practices_path(courses(:course1).id), 'hajime'
+    visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
     assert_selector 'a', text: '提出'
   end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6642

## 概要

メンターの方が提出物の確認を取り消しても、プラクティス一覧画面で修了になっているバグを解消。

## 変更確認方法

1. `bug/status-remains-completed-after-the-mentor-cancels-confirmation-of-the=submission` をローカルに取り込む
2. `bin/rails db:seed`
3. `foreman start -f Procfile.dev`
4. ID `hajime`でログイン。
5. メンターの方の提出物確認方法は、「直接確認する」と「コメントと共に確認する」の2つあるため、テストのため提出物を2つ作成。
（課題は任意ですが、提出物の作成必要がある上から2つでいいと思います。）
http://localhost:3000/practices/315059988 と、
http://localhost:3000/practices/198065840 が上の2つです。
<img width="50%" alt="スクリーンショット_2024-02-07_16_17_29" src="https://github.com/fjordllc/bootcamp/assets/106903482/11608330-b22e-49b9-9cab-8567da84f9ac">

6. ID `machida`でログイン。
7. 5で作成した提出物の担当になったあと、提出物をそれぞれ直接 or コメントで確認済みにする。
http://localhost:3000/products/1071056610
http://localhost:3000/products/1071056611
8. 念のため、再度 `hajime`でログインし上記プラクティス2つが「修了」になっていることを確認。
http://localhost:3000/courses/829913840/practices#category-685020562
9. 再度 `machida`でログインし、これらの提出物の確認を取り消す。
http://localhost:3000/products/1071056610
http://localhost:3000/products/1071056611
10. 再度 `hajime`でログインし、プラクティス2つのステータスが「提出」になっていることを確認。
http://localhost:3000/courses/829913840/practices#category-685020562


## Screenshot
上記手順を行った後、10の画面。

### 変更前
<img width="70%" alt="スクリーンショット 2024-02-07 16 33 57" src="https://github.com/fjordllc/bootcamp/assets/106903482/d3b4e8f1-9a63-479b-9066-da93fa321ef8">


### 変更後
<img width="70%" alt="スクリーンショット 2024-02-07 16 29 26" src="https://github.com/fjordllc/bootcamp/assets/106903482/423f9cd3-69a6-49ea-9927-a836da9a63c8">

<details>

<summary>下記議論により、handle_checkメソッドはなくなりました。</summary>

## 懸念点
新たに `learning_status_updater.rb` に作成した `handle_check`についてです。
変化の経緯は、コミット履歴を参照ください。
要は、`call`メソッド内で完結していましたが、rubocopにひっかかってしまったので、やむなくprivateメソッドを作成した、という経緯です。
このメソッドの命名が今現在応急処置的な名前になっています。
自分では、なかなかいいネーミングを思いつかないので、できればレビュアーの方と一緒に考えれたらと思っています。。 🙇 （引き続き自分でも考えてはみます。）

</details>
