### PR TITLE
ユーザーアイコンにhoverしたときにユーザー名を表示する

### DIFF
--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -11,7 +11,7 @@ export default (md) => {
         return `<div class="speak">
                   <div class="speak__speaker">
                     <a href="/users/${speakerName}" class="a-user-emoji-link">
-                      <img class="js-user-icon a-user-emoji" data-user="${speakerName}">
+                      <img title="@${speakerName}" class="js-user-icon a-user-emoji" data-user="${speakerName}">
                       <spanv class="speak__speaker-name">${speakerName}</span>
                     </a>
                   </div>

--- a/app/javascript/markdown-it-user-icon.js
+++ b/app/javascript/markdown-it-user-icon.js
@@ -4,6 +4,6 @@ export default MarkdownItRegexp(
   /:@(?!mentor:)([a-zA-Z0-9_-]+):/,
 
   (match) => {
-    return `<a href="/users/${match[1]}" class="a-user-emoji-link"><img class="js-user-icon a-user-emoji" data-user="${match[1]}" width="40" height="40"></a>`
+    return `<a href="/users/${match[1]}" class="a-user-emoji-link"><img title="@${match[1]}" class="js-user-icon a-user-emoji" data-user="${match[1]}" width="40" height="40"></a>`
   }
 )

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -13,6 +13,7 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_css '.a-long-text.is-md.js-markdown-view'
     assert_css '.speak'
     assert_css "a[href='/users/mentormentaro']"
+    assert_includes find('.js-user-icon.a-user-emoji')['title'], '@mentormentaro'
     assert_includes find('.js-user-icon.a-user-emoji')['data-user'], 'mentormentaro'
   end
 

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -25,6 +25,7 @@ class MarkdownTest < ApplicationSystemTestCase
 
     assert_css '.a-long-text.is-md.js-markdown-view'
     assert_css "a[href='/users/mentormentaro']"
+    assert_includes find('.js-user-icon.a-user-emoji')['title'], '@mentormentaro'
     assert_includes find('.js-user-icon.a-user-emoji')['data-user'], 'mentormentaro'
   end
 

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -13,8 +13,9 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_css '.a-long-text.is-md.js-markdown-view'
     assert_css '.speak'
     assert_css "a[href='/users/mentormentaro']"
-    assert_includes find('.js-user-icon.a-user-emoji')['title'], '@mentormentaro'
-    assert_includes find('.js-user-icon.a-user-emoji')['data-user'], 'mentormentaro'
+    emoji = find('.js-user-icon.a-user-emoji')
+    assert_includes emoji['title'], '@mentormentaro'
+    assert_includes emoji['data-user'], 'mentormentaro'
   end
 
   test 'user profile image markdown test' do
@@ -26,8 +27,9 @@ class MarkdownTest < ApplicationSystemTestCase
 
     assert_css '.a-long-text.is-md.js-markdown-view'
     assert_css "a[href='/users/mentormentaro']"
-    assert_includes find('.js-user-icon.a-user-emoji')['title'], '@mentormentaro'
-    assert_includes find('.js-user-icon.a-user-emoji')['data-user'], 'mentormentaro'
+    emoji = find('.js-user-icon.a-user-emoji')
+    assert_includes emoji['title'], '@mentormentaro'
+    assert_includes emoji['data-user'], 'mentormentaro'
   end
 
   def cmd_ctrl


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7203

## 概要
ユーザーのアイコンにhoverした時にユーザー名を表示するようにする

## 変更確認方法

1. `feature/display-user-name-when-hovering-user-icon`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動する
3. 日報・Docs等の入力画面を開き、以下の２点を確認する
	- `:@name:`の記法でユーザー名を入力
		- ユーザーアイコンにhoverすると`@name`が表示される
	- インタビュー記法でユーザー名を入力
		- ユーザーアイコンにhoverすると`@name`が表示される
		- 参考：[Markdownの中で独自記法でインタビューブロックを書けるようにした](https://github.com/fjordllc/bootcamp/pull/5368)
		```
		:::speak @name
		// 内容
		:::
		```

## Screenshot

### 変更前
[![Image from Gyazo](https://i.gyazo.com/02e256bc73868b93d8045ee336939eab.gif)](https://gyazo.com/02e256bc73868b93d8045ee336939eab)

### 変更後
[![Image from Gyazo](https://i.gyazo.com/985e83a555b0d3b29c7b8a36f288dc33.gif)](https://gyazo.com/985e83a555b0d3b29c7b8a36f288dc33)