### PR TITLE
「リンク切れを調べてメールを出す」機能の、メール宛先をlokkaに更新する

### DIFF
--- a/app/mailers/check_url_mailer.rb
+++ b/app/mailers/check_url_mailer.rb
@@ -5,6 +5,6 @@ class CheckUrlMailer < ApplicationMailer
     @page_error_url = page_error_url
     @practice_error_url = practice_error_url
     @number_of_error_url = page_error_url.size + practice_error_url.size
-    mail to: 'info@fjord.jp', subject: '[FBC Admin] リンク切れ報告'
+    mail to: 'info@lokka.jp', subject: '[FBC Admin] リンク切れ報告'
   end
 end

--- a/test/mailers/check_url_mailer_test.rb
+++ b/test/mailers/check_url_mailer_test.rb
@@ -14,7 +14,7 @@ class CheckUrlMailerTest < ActionMailer::TestCase
     mail = CheckUrlMailer.notify_error_url(page_error_url, practice_error_url).deliver_now
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal '[FBC Admin] リンク切れ報告', mail.subject
-    assert_equal ['info@fjord.jp'], mail.to
+    assert_equal ['info@lokka.jp'], mail.to
     assert_equal ['noreply@bootcamp.fjord.jp'], mail.from
     assert_match(/リンク切れがありました。/, mail.body.to_s)
   end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7256

## 概要
「リンク切れを調べてメールを出す」機能の、メール宛先が`info@fjord.jp`になっているものを`info@lokka.jp`に更新する

## 変更確認方法

1. `feature/update-check-broken-link-function-email-destination-to-lokka`をローカルに取り込む
2. 該当の2ファイル`pp/mailers/check_url_mailer.rb`、`test/mailers/check_url_mailer_test.rb`の送信先アドレス箇所を確認する
※現在動いていない機能なので動作確認は不要です

## Screenshot
画面のない機能であるため、コードの該当箇所のスクリーンショットです。

### 変更前
![メールアドレス変更前　対象コード](https://github.com/fjordllc/bootcamp/assets/133624488/13979b01-3c31-4cd7-802f-3d02767f51bd)

![メールアドレス変更前　テストコード](https://github.com/fjordllc/bootcamp/assets/133624488/500ab4cb-9ace-4c8d-bc9c-9cf47adcb535)

### 変更後
![メールアドレス変更後　対象コード](https://github.com/fjordllc/bootcamp/assets/133624488/8d04b5d7-8902-4bc7-82c0-73893783859f)

![スクショ　メールアドレス変更後　テストコード](https://github.com/fjordllc/bootcamp/assets/133624488/ea11eb5b-5331-41ca-910c-db10e2ffafa1)
