### PR TITLE
日報の学習時間が月を跨いだ時にも、（翌日）が表示されるようにする

### DIFF
--- a/app/views/reports/_learning_times.html.slim
+++ b/app/views/reports/_learning_times.html.slim
@@ -10,4 +10,4 @@
     ul.learning-times__items
       - @report.learning_times.each do |learning_time|
         li.learning-times__item
-          | #{l learning_time.started_at, format: :time_only} 〜 #{'(翌日)' if learning_time.started_at.day < learning_time.finished_at.day}#{l learning_time.finished_at, format: :time_only}
+          | #{l learning_time.started_at, format: :time_only} 〜 #{'(翌日)' if learning_time.started_at.to_date < learning_time.finished_at.to_date}#{l learning_time.finished_at, format: :time_only}

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -277,6 +277,23 @@ class ReportsTest < ApplicationSystemTestCase
     assert_text '00:30 〜 02:30'
   end
 
+  test 'learning times when carrying over next month' do
+    visit_with_auth '/reports/new', 'komagata'
+    fill_in 'report_title', with: 'テスト日報'
+    fill_in 'report_description', with: '学習時間が月を跨いでいるパターン'
+    fill_in 'report_reported_on', with: Date.new(2024, 1, 31)
+
+    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('22')
+    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('00')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('00')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('00')
+
+    click_button '提出'
+
+    assert_text "2時間\n"
+    assert_text '22:00 〜 (翌日)00:00'
+  end
+
   test 'learning times order' do
     visit_with_auth '/reports/new', 'komagata'
     fill_in 'report_title', with: 'テスト日報'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7294

## 概要

日報で学習時間を記録する際に、月を跨ぐようにすると（翌日）が表示されない

![learning_times_fix_summary](https://github.com/fjordllc/bootcamp/assets/133615511/e069d56e-ea67-4e13-9fe6-4ecefb6dca4d)

## 変更確認方法

1. `bug/report-learning-times-extension-over-month`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動する
3. `kimura`など、日報を書くことのできるユーザーでログインする
4. 学習時間が月を跨ぐような日報を作成する
    - 例
        - 学習日：`2024/01/31`
        - 学習開始時間：`22:00`
        - 学習終了時間：`0:00`
5. 学習時間に`（翌日）`の表示がされていることを確認する

## Screenshot

### 変更前

![learning_times_before](https://github.com/fjordllc/bootcamp/assets/133615511/6c8bb877-d727-427f-9b23-b2589f3e8d85)

### 変更後

![learning_times_after](https://github.com/fjordllc/bootcamp/assets/133615511/0614baa4-10d1-44e1-a48b-e346fb466e7d)