### PR TITLE
slim-lintのルール「Layout/LineLength」を適用する

### DIFF
--- a/app/views/activity_mailer/assigned_as_checker.html.slim
+++ b/app/views/activity_mailer/assigned_as_checker.html.slim
@@ -1,2 +1,4 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@product.user.login_name}さんの提出物#{@product.title}の担当になりました。", link_url: @link_url, link_text: 'この提出物へ' do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@product.user.login_name}さんの提出物#{@product.title}の担当になりました。",
+  link_url: @link_url, link_text: 'この提出物へ' do
   = md2html @product.description

--- a/app/views/activity_mailer/came_answer.html.slim
+++ b/app/views/activity_mailer/came_answer.html.slim
@@ -1,2 +1,4 @@
-= render '/notification_mailer/notification_mailer_template', title: "質問「#{@answer.question.title}」に#{@answer.user.login_name}さんが回答しました。", link_url: @link_url, link_text: '回答へ' do
+= render '/notification_mailer/notification_mailer_template',
+  title: "質問「#{@answer.question.title}」に#{@answer.user.login_name}さんが回答しました。",
+  link_url: @link_url, link_text: '回答へ' do
   = md2html(@answer.description)

--- a/app/views/activity_mailer/consecutive_sad_report.html.slim
+++ b/app/views/activity_mailer/consecutive_sad_report.html.slim
@@ -1,4 +1,6 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。", link_url: @link_url, link_text: 'この日報へ' do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。",
+  link_url: @link_url, link_text: 'この日報へ' do
   p #{@report.user.login_name}さんが#{User::DEPRESSED_SIZE}回連続でsadアイコンの日報を提出しました。メンターのみなさんはフォローいただけると幸いです。
   div(style='border-top: solid 1px #ccc; height: 0;')
   = md2html(@report.description)

--- a/app/views/activity_mailer/create_page.html.slim
+++ b/app/views/activity_mailer/create_page.html.slim
@@ -1,2 +1,4 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。", link_url: @link_url, link_text: 'このDocsへ' do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@page.user.login_name}さんがDocsに#{@page.title}を投稿しました。",
+  link_url: @link_url, link_text: 'このDocsへ' do
   = md2html(@page.body)

--- a/app/views/activity_mailer/hibernated.html.slim
+++ b/app/views/activity_mailer/hibernated.html.slim
@@ -1,1 +1,3 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@sender.login_name}さんが休会しました。", link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ" do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@sender.login_name}さんが休会しました。",
+  link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ" do

--- a/app/views/activity_mailer/mentioned.html.slim
+++ b/app/views/activity_mailer/mentioned.html.slim
@@ -1,2 +1,4 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@mentionable.user.login_name}さんからメンションがありました", link_url: @link_url, link_text: 'このメンションへ' do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@mentionable.user.login_name}さんからメンションがありました",
+  link_url: @link_url, link_text: 'このメンションへ' do
   = md2html @mentionable.body

--- a/app/views/activity_mailer/no_correct_answer.html.slim
+++ b/app/views/activity_mailer/no_correct_answer.html.slim
@@ -1,1 +1,3 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@user.login_name}さんの質問【 #{@question.title} 】のベストアンサーがまだ選ばれていません。", link_url: @link_url, link_text: "#{@user.login_name}さんの質問へ"
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@user.login_name}さんの質問【 #{@question.title} 】のベストアンサーがまだ選ばれていません。",
+  link_url: @link_url, link_text: "#{@user.login_name}さんの質問へ"

--- a/app/views/activity_mailer/product_update.html.slim
+++ b/app/views/activity_mailer/product_update.html.slim
@@ -1,2 +1,4 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@product.user.login_name}さんが#{@product.title}を更新しました。", link_url: @link_url, link_text: '提出物へ' do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@product.user.login_name}さんが#{@product.title}を更新しました。",
+  link_url: @link_url, link_text: '提出物へ' do
   = md2html(@product.body)

--- a/app/views/activity_mailer/submitted.html.slim
+++ b/app/views/activity_mailer/submitted.html.slim
@@ -1,2 +1,4 @@
-= render '/notification_mailer/notification_mailer_template', title: "#{@product.user.login_name}さんが#{@product.title}を提出しました。", link_url: @link_url, link_text: '提出物へ' do
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@product.user.login_name}さんが#{@product.title}を提出しました。",
+  link_url: @link_url, link_text: '提出物へ' do
   = md2html(@product.body)

--- a/app/views/application/_required_field.html.slim
+++ b/app/views/application/_required_field.html.slim
@@ -21,4 +21,5 @@
                 .card-list-item__row
                   .card-list-item-title
                     h3.card-list-item-title__title.is-sm
-                      = link_to error.message, edit_current_user_path(anchor: anchor_to_required_field(error.attribute)), class: "card-list-item-title__link  a-text-link is-#{error.attribute}"
+                      = link_to error.message, edit_current_user_path(anchor: anchor_to_required_field(error.attribute)),
+                        class: "card-list-item-title__link  a-text-link is-#{error.attribute}"

--- a/app/views/application/_tags_input.slim
+++ b/app/views/application/_tags_input.slim
@@ -1,1 +1,3 @@
-= react_component('Tags/TagsInput', { tagsInitialValue: taggable.tag_list.join(',').to_s, tagsParamName: "#{taggable.class.to_s.tableize.singularize}[tag_list]", taggableType: taggable.class.to_s.capitalize.to_s })
+= react_component('Tags/TagsInput', { tagsInitialValue: taggable.tag_list.join(',').to_s,
+                                      tagsParamName: "#{taggable.class.to_s.tableize.singularize}[tag_list]",
+                                      taggableType: taggable.class.to_s.capitalize.to_s })

--- a/app/views/articles/_recent_articles.html.slim
+++ b/app/views/articles/_recent_articles.html.slim
@@ -11,9 +11,9 @@
             .card-list-item__thumbnail
               .card-list-item__thumbnail-inner
                 - if recent_article.thumbnail.attached?
-
-                  = image_tag recent_article.thumbnail.variant(resize: '200x105>').processed.url,
-                    class: 'card-list-item__thumbnail-image', alt: "ブログ記事「#{recent_article.title}」のアイキャッチ画像"
+                  = image_tag recent_article.thumbnail.variant(resize_to_limit: [200, 105]).processed.url, \
+                    class: 'card-list-item__thumbnail-image', \
+                    alt: "ブログ記事「#{recent_article.title}」のアイキャッチ画像"
                 - else
                   = image_tag 'work-blank.svg', class: 'card-list-item__thumbnail-image', alt: 'ブログ記事のブランクアイキャッチ画像'
             .card-list-item__rows

--- a/app/views/articles/_recent_articles.html.slim
+++ b/app/views/articles/_recent_articles.html.slim
@@ -11,7 +11,9 @@
             .card-list-item__thumbnail
               .card-list-item__thumbnail-inner
                 - if recent_article.thumbnail.attached?
-                  = image_tag recent_article.thumbnail.variant(resize_to_limit: [200, 105]).processed.url, class: 'card-list-item__thumbnail-image', alt: "ブログ記事「#{recent_article.title}」のアイキャッチ画像"
+
+                  = image_tag recent_article.thumbnail.variant(resize: '200x105>').processed.url,
+                    class: 'card-list-item__thumbnail-image', alt: "ブログ記事「#{recent_article.title}」のアイキャッチ画像"
                 - else
                   = image_tag 'work-blank.svg', class: 'card-list-item__thumbnail-image', alt: 'ブログ記事のブランクアイキャッチ画像'
             .card-list-item__rows

--- a/app/views/events/_participation.html.slim
+++ b/app/views/events/_participation.html.slim
@@ -14,7 +14,8 @@
         | 参加登録しています。
     ul.event-main-actions__items
       li.event-main-actions__item
-        = link_to event_participation_path(event_id: event), method: :delete, data: { confirm: '特別イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+        = link_to event_participation_path(event_id: event), method: :delete,
+          data: { confirm: '特別イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
           | 参加を取り消す
 - elsif event.opening?
   .event-main-actions.is-unparticipationed(class="#{event.capacity > event.participants.count ? 'is-available' : 'is-capacity-over'}")
@@ -30,8 +31,10 @@
       li.event-main-actions__item
         - if event.capacity > event.participants.count
           // TODO helprtにしてわかりやすくしたい↑
-          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '特別イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-md is-block' do
+          = link_to event_participations_path(event_id: event), method: :post,
+            data: { confirm: '特別イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-md is-block' do
             | 参加申込
         - else
-          = link_to event_participations_path(event_id: event), method: :post, data: { confirm: '補欠として特別イベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-md is-block' do
+          = link_to event_participations_path(event_id: event), method: :post,
+            data: { confirm: '補欠として特別イベント参加申込をします。よろしいですか?' }, class: 'a-button is-warning is-md is-block' do
             | 補欠登録

--- a/app/views/notification_mailer/trainee_report.html.slim
+++ b/app/views/notification_mailer/trainee_report.html.slim
@@ -1,2 +1,4 @@
-= render 'notification_mailer_template', title: "#{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！", link_url: notification_url(@notification), link_text: 'この日報へ！！！' do
+= render 'notification_mailer_template',
+  title: "#{@report.user.login_name}さんが日報【 #{@report.title} 】を書きました！",
+  link_url: notification_url(@notification), link_text: 'この日報へ！！！' do
   = md2html(@report.description)

--- a/app/views/pages/_doc_header.html.slim
+++ b/app/views/pages/_doc_header.html.slim
@@ -76,4 +76,8 @@ header.page-content-header
 
     .page-content-header__row
       .page-content-header__tags
-        = react_component('Tags/Tags', { tagsInitialValue: page.tag_list.join(',').to_s, tagsParamName: 'page[tag_list]', tagsInputId: 'page_tag_list', tagsType: 'Page', tagsTypeId: page.id.to_s })
+        = react_component('Tags/Tags', { tagsInitialValue: page.tag_list.join(',').to_s,
+                                         tagsParamName: 'page[tag_list]',
+                                         tagsInputId: 'page_tag_list',
+                                         tagsType: 'Page',
+                                         tagsTypeId: page.id.to_s })

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -9,11 +9,14 @@ nav.tab-nav
   .container
     ul.tab-nav__items
       li.tab-nav__item
-        = link_to '全ての質問', practice_questions_path(@practice), class: "tab-nav__item-link #{params[:target] == 'not_solved' || params[:target] == 'solved' ? '' : 'is-active'}"
+        = link_to '全ての質問', practice_questions_path(@practice),
+          class: "tab-nav__item-link #{params[:target] == 'not_solved' || params[:target] == 'solved' ? '' : 'is-active'}"
       li.tab-nav__item
-        = link_to '解決済み', practice_questions_path(@practice, target: 'solved'), class: "tab-nav__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
+        = link_to '解決済み', practice_questions_path(@practice, target: 'solved'),
+          class: "tab-nav__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
       li.tab-nav__item
-        = link_to '未解決', practice_questions_path(@practice, target: 'not_solved'), class: "tab-nav__item-link #{params[:target] == 'not_solved' ? 'is-active' : ''}"
+        = link_to '未解決', practice_questions_path(@practice, target: 'not_solved'),
+          class: "tab-nav__item-link #{params[:target] == 'not_solved' ? 'is-active' : ''}"
 
 .page-body
   .container.is-md

--- a/app/views/products/unchecked/index.html.slim
+++ b/app/views/products/unchecked/index.html.slim
@@ -15,7 +15,8 @@ header.page-header
         .form__items
           .form-item.is-inline-md-up
             = label_tag :checker_id, '担当メンター', class: 'a-form-label'
-            = select_tag :checker_id, options_from_collection_for_select(User.mentor.order(:login_name), :id, :login_name, selected: params[:checker_id]), include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
+            = select_tag :checker_id, options_from_collection_for_select(User.mentor.order(:login_name), :id, :login_name, selected: params[:checker_id]),
+              include_blank: '全ての提出物を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
   hr.a-border
 .page-body
   .container.is-md

--- a/app/views/questions/_question_body.html.slim
+++ b/app/views/questions/_question_body.html.slim
@@ -14,7 +14,9 @@
             i#new.fa-solid.fa-pen
             | 内容修正
         li.card-main-actions__item.is-sub.is-only-mentor class=(current_user.mentor ? '' : 'is-hidden')
-          =link_to '削除する', question_path(question), data: { confirm: '本当に削除しますか？質問はなるべく消さず、もし質問者が自己解決した場合も、質問者自身で解決した手段や手順を回答に記入し、それをベストアンサーにしてこの質問を解決することを即すようにしてください。' }, method: :delete, class: 'card-main-actions__muted-action'
+          =link_to '削除する', question_path(question),
+           data: { confirm: '本当に削除しますか？質問はなるべく消さず、もし質問者が自己解決した場合も、質問者自身で解決した手段や手順を回答に記入し、それをベストアンサーにしてこの質問を解決することを即すようにしてください。' }, method: :delete,
+           class: 'card-main-actions__muted-action'
         li.card-main-actions__item.is-sub class=(current_user.mentor ? 'is-hidden' : '')
           label.card-main-actions__muted-action for='modal-delete-request'
             | 削除申請

--- a/app/views/questions/_question_header.html.slim
+++ b/app/views/questions/_question_header.html.slim
@@ -65,4 +65,8 @@ header.page-content-header
 
     .page-content-header__row
       .page-content-header__tags
-        = react_component('Tags/Tags', { tagsInitialValue: question.tag_list.join(','), tagsParamName: 'question[tag_list]', tagsInputId: 'question_tag_list', tagsType: 'Question', tagsTypeId: question.id.to_s })
+        = react_component('Tags/Tags', { tagsInitialValue: question.tag_list.join(','),
+                                         tagsParamName: 'question[tag_list]',
+                                         tagsInputId: 'question_tag_list',
+                                         tagsType: 'Question',
+                                         tagsTypeId: question.id.to_s })

--- a/app/views/questions/_tabs.html.slim
+++ b/app/views/questions/_tabs.html.slim
@@ -2,13 +2,16 @@
   .container
     ul.page-tabs__items
       li.page-tabs__item
-        = link_to questions_path(target: 'not_solved', practice_id: params[:practice_id]), class: "page-tabs__item-link #{params[:target] == 'not_solved' ? 'is-active' : ''}" do
+        = link_to questions_path(target: 'not_solved', practice_id: params[:practice_id]),
+          class: "page-tabs__item-link #{params[:target] == 'not_solved' ? 'is-active' : ''}" do
           | 未解決
           - if Question.not_solved.not_wip.size.positive? && current_user.admin_or_mentor?
             .page-tabs__item-count.a-notification-count
               #not-solved-count
                 = params[:practice_id].present? ? Question.not_solved.not_wip.where(practice_id: params[:practice_id]).size : Question.not_solved.not_wip.size
       li.page-tabs__item
-        = link_to '解決済み', questions_path(target: 'solved', practice_id: params[:practice_id]), class: "page-tabs__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
+        = link_to '解決済み', questions_path(target: 'solved', practice_id: params[:practice_id]),
+          class: "page-tabs__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
       li.page-tabs__item
-        = link_to '全て', questions_path(practice_id: params[:practice_id], title: params[:title]), class: "page-tabs__item-link #{params[:target] == 'not_solved' || params[:target] == 'solved' ? '' : 'is-active'}"
+        = link_to '全て', questions_path(practice_id: params[:practice_id], title: params[:title]),
+          class: "page-tabs__item-link #{params[:target] == 'not_solved' || params[:target] == 'solved' ? '' : 'is-active'}"

--- a/app/views/regular_events/_participation.html.slim
+++ b/app/views/regular_events/_participation.html.slim
@@ -5,11 +5,13 @@
         | 参加登録しています。
     ul.event-main-actions__items
       li.event-main-actions__item
-        = link_to regular_event_participation_path(regular_event_id: regular_event), method: :delete, data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+        = link_to regular_event_participation_path(regular_event_id: regular_event), method: :delete,
+          data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
           | 参加を取り消す
 - else
   .event-main-actions.is-unparticipationed.is-available
     ul.event-main-actions__items
       li.event-main-actions__item
-        = link_to regular_event_participations_path(regular_event_id: regular_event), method: :post, data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-md is-block' do
+        = link_to regular_event_participations_path(regular_event_id: regular_event), method: :post,
+          data: { confirm: 'イベント参加申込をします。よろしいですか?' }, class: 'a-button is-primary is-md is-block' do
           | 参加申込

--- a/app/views/reports/_learning_time_fields.html.slim
+++ b/app/views/reports/_learning_time_fields.html.slim
@@ -1,6 +1,7 @@
 .form-times
   .nested-fields.form-times__inner
-    - tag = '</div></div><div class="form-selects__item"><div class="a-button is-md is-secondary is-select a-select is-block form-selects__item-select form-item__select">'
+    - tag = '</div></div>'\
+            '<div class="form-selects__item"><div class="a-button is-md is-secondary is-select a-select is-block form-selects__item-select form-item__select">'
     .form-times__items.learning-time
       .form-times__time
         = f.label :started_at, class: 'form-times__time-label'

--- a/app/views/survey_questions/edit.html.slim
+++ b/app/views/survey_questions/edit.html.slim
@@ -24,4 +24,5 @@ header.page-header
   hr.a-border
   .page-body
     .container.is-md
-      = render 'form', survey_question: @survey_question, linear_scale: @linear_scale, radio_button: @radio_button, check_box: @check_box, radio_button_choices: @radio_button_choices, check_box_choices: @check_box_choices
+      = render 'form', survey_question: @survey_question, linear_scale: @linear_scale, radio_button: @radio_button,
+        check_box: @check_box, radio_button_choices: @radio_button_choices, check_box_choices: @check_box_choices

--- a/app/views/survey_questions/new.html.slim
+++ b/app/views/survey_questions/new.html.slim
@@ -24,4 +24,5 @@ header.page-header
   hr.a-border
   .page-body
     .container.is-md
-      = render 'form', survey_question: @survey_question, linear_scale: @linear_scale, radio_button: @radio_button, check_box: @check_box, radio_button_choices: @radio_button_choices, check_box_choices: @check_box_choices
+      = render 'form', survey_question: @survey_question, linear_scale: @linear_scale, radio_button: @radio_button,
+        check_box: @check_box, radio_button_choices: @radio_button_choices, check_box_choices: @check_box_choices

--- a/app/views/surveys/show.html.slim
+++ b/app/views/surveys/show.html.slim
@@ -99,13 +99,15 @@ header.page-header
                               - 10.times do |i|
                                 - if survey_question.linear_scale.reason_for_choice_required
                                   li.linear-scale__points-item
-                                    = f.radio_button survey_question.id, i + 1, id: "linear-scale-#{survey_question.id}-#{i}", class: 'a-toggle-checkbox js-questionnaire_choice js-answer_required_choice'
+                                    = f.radio_button survey_question.id, i + 1, id: "linear-scale-#{survey_question.id}-#{i}",
+                                      class: 'a-toggle-checkbox js-questionnaire_choice js-answer_required_choice'
                                     label.linear-scale__point for="linear-scale-#{survey_question.id}-#{i}"
                                       .linear-scale__point-number
                                         = i + 1
                                 - else
                                   li.linear-scale__points-item
-                                    = f.radio_button survey_question.id, i + 1, id: "linear-scale-#{survey_question.id}-#{i}", class: 'a-toggle-checkbox js-questionnaire_choice'
+                                    = f.radio_button survey_question.id, i + 1, id: "linear-scale-#{survey_question.id}-#{i}",
+                                      class: 'a-toggle-checkbox js-questionnaire_choice'
                                     label.linear-scale__point for="linear-scale-#{survey_question.id}-#{i}"
                                       .linear-scale__point-number
                                         = i + 1

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -46,7 +46,12 @@
                   - if @user.tag_list.present? || current_user == @user
                     .user-data__row
                       .user-data__tags
-                        - tags_props = { tagsInitialValue: @user.tag_list.join(',').to_s, tagsParamName: 'user[tag_list]', tagsInputId: 'user_tag_list', tagsType: 'User', tagsTypeId: @user.id.to_s, tagsEditable: @user.id == current_user.id }
+                        - tags_props = { tagsInitialValue: @user.tag_list.join(',').to_s,
+                                         tagsParamName: 'user[tag_list]',
+                                         tagsInputId: 'user_tag_list',
+                                         tagsType: 'User',
+                                         tagsTypeId: @user.id.to_s,
+                                         tagsEditable: @user.id == current_user.id }
                         = react_component('Tags/Tags', tags_props)
                   - if admin_or_mentor_login? && @user.hibernated?
                     .user-data__row
@@ -94,4 +99,5 @@
                           class: 'a-button is-sm is-danger is-block'
                   - if @user != current_user
                     .user-statuses__delete
-                      = link_to 'このユーザーを削除する', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: 'a-muted-text-link', data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }
+                      = link_to 'このユーザーを削除する', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: 'a-muted-text-link',
+                        data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }

--- a/app/views/welcome/_mentors.html.slim
+++ b/app/views/welcome/_mentors.html.slim
@@ -4,10 +4,10 @@ section.welcome-child-section
   .welcome-members
     .row.is-gutter-width-32
       - mentors.each do |mentor|
-        - if mentor.profile_image.present? &&
-             mentor.profile_name.present? &&
-             mentor.profile_job.present? &&
-             mentor.profile_text.present? &&
+        - if mentor.profile_image.present? && \
+             mentor.profile_name.present? && \
+             mentor.profile_job.present? && \
+             mentor.profile_text.present? && \
              mentor.login_name != 'achamixx'
-             .col-xs-12.col-md-6.col-lg-4
-              = render 'welcome/mentor', mentor:, page: 'welcome-index'
+          .col-xs-12.col-md-6.col-lg-4
+            = render 'welcome/mentor', mentor:, page: 'welcome-index'

--- a/app/views/welcome/_mentors.html.slim
+++ b/app/views/welcome/_mentors.html.slim
@@ -4,6 +4,10 @@ section.welcome-child-section
   .welcome-members
     .row.is-gutter-width-32
       - mentors.each do |mentor|
-        - if mentor.profile_image.present? && mentor.profile_name.present? && mentor.profile_job.present? && mentor.profile_text.present? && mentor.login_name != 'achamixx'
-          .col-xs-12.col-md-6.col-lg-4
-            = render 'welcome/mentor', mentor:, page: 'welcome-index'
+        - if mentor.profile_image.present? &&
+             mentor.profile_name.present? &&
+             mentor.profile_job.present? &&
+             mentor.profile_text.present? &&
+             mentor.login_name != 'achamixx'
+             .col-xs-12.col-md-6.col-lg-4
+              = render 'welcome/mentor', mentor:, page: 'welcome-index'

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -16,7 +16,6 @@ linters:
       - Layout/HashAlignment
       - Layout/IndentationWidth
       - Layout/InitialIndentation
-      - Layout/LineLength
       - Layout/MultilineArrayBraceLayout
       - Layout/MultilineAssignmentLayout
       - Layout/MultilineHashBraceLayout


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7254
slim-lintの5つのルールを適用させるissueのうちの1つめのルールを適用しています
残り4ルール↓
https://github.com/fjordllc/bootcamp/pull/7395
　
## 概要
slim-lintが指摘するルールで無視する設定になっているもののうち、`Layout/LineLength`を有効化する

### Layout/LineLengthとは
一行の長さが長すぎないかを確認するルール。160文字を越えると指摘がはいるようになっている。
[Layout/LineLength - Rubocop Docs](https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength)

```
# bad
{foo: "0000000000", bar: "0000000000", baz: "0000000000"}

# good
{foo: "0000000000",
bar: "0000000000", baz: "0000000000"}

# good (with recommended cops enabled)
{
  foo: "0000000000",
  bar: "0000000000",
  baz: "0000000000",
}
```

このルールを適用したところ、以下の30の指摘が付いたため修正を行った。
(長すぎるためたたんでおります)

<details>


```
app/views/activity_mailer/assigned_as_checker.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [174/160]
app/views/activity_mailer/came_answer.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [177/160]
app/views/activity_mailer/consecutive_sad_report.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [187/160]
app/views/activity_mailer/create_page.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [169/160]
app/views/activity_mailer/hibernated.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [167/160]
app/views/activity_mailer/mentioned.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [162/160]
app/views/activity_mailer/no_correct_answer.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [196/160]
app/views/activity_mailer/product_update.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [167/160]
app/views/activity_mailer/submitted.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [167/160]
app/views/application/_required_field.html.slim:24 [W] RuboCop: Layout/LineLength: Line is too long. [168/160]
app/views/application/_tags_input.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [212/160]
app/views/articles/_recent_articles.html.slim:14 [W] RuboCop: Layout/LineLength: Line is too long. [166/160]
app/views/events/_participation.html.slim:17 [W] RuboCop: Layout/LineLength: Line is too long. [161/160]
app/views/events/_participation.html.slim:36 [W] RuboCop: Layout/LineLength: Line is too long. [164/160]
app/views/notification_mailer/trainee_report.html.slim:1 [W] RuboCop: Layout/LineLength: Line is too long. [175/160]
app/views/pages/_doc_header.html.slim:79 [W] RuboCop: Layout/LineLength: Line is too long. [187/160]
app/views/practices/questions/index.html.slim:12 [W] RuboCop: Layout/LineLength: Line is too long. [165/160]
app/views/products/unchecked/index.html.slim:18 [W] RuboCop: Layout/LineLength: Line is too long. [231/160]
app/views/questions/_tabs.html.slim:5 [W] RuboCop: Layout/LineLength: Line is too long. [167/160]
app/views/questions/_tabs.html.slim:12 [W] RuboCop: Layout/LineLength: Line is too long. [164/160]
app/views/questions/_tabs.html.slim:14 [W] RuboCop: Layout/LineLength: Line is too long. [202/160]
app/views/regular_events/_participation.html.slim:8 [W] RuboCop: Layout/LineLength: Line is too long. [183/160]
app/views/regular_events/_participation.html.slim:14 [W] RuboCop: Layout/LineLength: Line is too long. [181/160]
app/views/reports/_learning_time_fields.html.slim:3 [W] RuboCop: Layout/LineLength: Line is too long. [165/160]
app/views/survey_questions/edit.html.slim:27 [W] RuboCop: Layout/LineLength: Line is too long. [213/160]
app/views/survey_questions/new.html.slim:27 [W] RuboCop: Layout/LineLength: Line is too long. [213/160]
app/views/surveys/show.html.slim:102 [W] RuboCop: Layout/LineLength: Line is too long. [165/160]
app/views/users/show.html.slim:48 [W] RuboCop: Layout/LineLength: Line is too long. [215/160]
app/views/users/show.html.slim:96 [W] RuboCop: Layout/LineLength: Line is too long. [178/160]
app/views/welcome/_mentors.html.slim:7 [W] RuboCop: Layout/LineLength: Line is too long. [162/160]
```


</details>

指摘が付いていた箇所のコードは長くて読みにくいものになっていたため、可読性がよくなるような箇所のカンマで改行をいれ対応しました

確認したファイルの中で、指摘がついていない箇所であっても、指摘が付いている箇所と同じ構造になっていて、1行が長めで可読性が低かった箇所は、形式を合わせておいた方がのちのメンテナンスの際など見やすそうだと考えたため適宜改行をいれました

よって修正箇所は指摘されていた箇所以外も含まれ30か所以上になっています

基本的に改行のみで対応したのですが、以下2ファイルに関しては、改行+バックスラッシュ追加を行いました
app/views/reports/_learning_time_fields.html.slimの[文字列部分](https://github.com/fjordllc/bootcamp/pull/7345/commits/de6ce9bb1d6e92c05d66396cfa0deaf14940b636#diff-650f64fc7aff8e4daf9c7c41886ef07b350f97bca062f0efd810d2e349457d62R3-R4)
app/views/welcome/_mentors.html.slimの[ifの条件節部分](https://github.com/fjordllc/bootcamp/pull/7345/commits/6d329650e266b5a01617b44f43c95ecb9d780391#diff-2ecbd0c391ac4933a305d5dec560778c9163d9316a180a318a185ff5d680fd79R7-R10)

slim lintのきまりとして、一続きのコードを改行を挟んで記述するさいは、バックスラッシュが必要なため、上記2ファイルはバックスラッシュも追加する形で対応しました

## 変更確認方法

1. `feature/apply-layout-line-length`をローカルに取り込む
2. `bundle exec slim-lint app/views -c config/slim_lint.yml`を実行する
3. 指摘がないことを確認する

## Screenshot
機能の変更はないので、見た目の変化はありません。

