### PR TITLE
通知ターゲットに関わらず、メンターにはお知らせの通知が届くようにする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -391,9 +391,9 @@ class User < ApplicationRecord
       when 'all'
         User.unretired
       when 'students'
-        User.admins.or(User.students)
+        User.admins_and_mentors.or(User.students)
       when 'job_seekers'
-        User.admins.or(User.job_seekers)
+        User.admins_and_mentors.or(User.job_seekers)
       else
         User.none
       end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -239,9 +239,9 @@ class UserTest < ActiveSupport::TestCase
     target = User.announcement_receiver('students')
     assert_includes(target, users(:kimura))
     assert_includes(target, users(:komagata))
+    assert_includes(target, users(:mentormentaro))
     assert_not_includes(target, users(:yameo))
     assert_not_includes(target, users(:sotugyou))
-    assert_not_includes(target, users(:mentormentaro))
     assert_not_includes(target, users(:advijirou))
     assert_not_includes(target, users(:kensyu))
   end
@@ -251,6 +251,7 @@ class UserTest < ActiveSupport::TestCase
     assert_includes(target, users(:jobseeker))
     assert_includes(target, users(:komagata))
     assert_includes(target, users(:sotugyou))
+    assert_includes(target, users(:mentormentaro))
     assert_not_includes(target, users(:sotugyou_with_job))
     assert_not_includes(target, users(:kimura))
     assert_not_includes(target, users(:yameo))

--- a/test/system/notification/announcements_test.rb
+++ b/test/system/notification/announcements_test.rb
@@ -51,26 +51,19 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
     click_button '作成'
     assert_text 'お知らせを作成しました'
 
-    visit_with_auth '/notifications', 'komagata'
-    assert_text 'お知らせ「現役生にのみお知らせtest」'
+    message = 'お知らせ「現役生にのみお知らせtest」'
 
-    visit_with_auth '/notifications', 'kimura'
-    assert_text 'お知らせ「現役生にのみお知らせtest」'
+    notified_users = %w[kimura komagata mentormentaro]
+    notified_users.each do |user|
+      visit_with_auth '/notifications', user
+      assert_text message
+    end
 
-    visit_with_auth '/notifications', 'mentormentaro'
-    assert_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'sotugyou'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'advijirou'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'yameo'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-
-    visit_with_auth '/notifications', 'kensyu'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
+    not_notified_users = %w[sotugyou advijirou yameo kensyu]
+    not_notified_users.each do |user|
+      visit_with_auth '/notifications', user
+      assert_no_text message
+    end
   end
 
   test 'announcement to Only Job Seekers notifies the job seekers, admins, mentors' do
@@ -83,16 +76,18 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
     click_button '作成'
     assert_text 'お知らせを作成しました'
 
-    visit_with_auth '/notifications', 'komagata'
-    assert_text 'お知らせ「就活希望者のみお知らせします」'
+    message = 'お知らせ「就活希望者のみお知らせします」'
 
-    visit_with_auth '/notifications', 'jobseeker'
-    assert_text 'お知らせ「就活希望者のみお知らせします」'
+    notified_users = %w[jobseeker komagata mentormentaro]
+    notified_users.each do |user|
+      visit_with_auth '/notifications', user
+      assert_text message
+    end
 
-    visit_with_auth '/notifications', 'mentormentaro'
-    assert_text 'お知らせ「就活希望者のみお知らせします」'
-
-    visit_with_auth '/notifications', 'kimura'
-    assert_no_text 'お知らせ「就活希望者のみお知らせします」'
+    not_notified_users = %w[kimura]
+    not_notified_users.each do |user|
+      visit_with_auth '/notifications', user
+      assert_no_text message
+    end
   end
 end

--- a/test/system/notification/announcements_test.rb
+++ b/test/system/notification/announcements_test.rb
@@ -41,7 +41,7 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
     assert_equal expected, actual
   end
 
-  test 'announcement notification receive only active users' do
+  test 'announcement to Only Active Users notifies the active users, admins, mentors' do
     visit_with_auth '/announcements', 'machida'
     click_link 'お知らせ作成'
     fill_in 'announcement[title]', with: '現役生にのみお知らせtest'
@@ -57,6 +57,9 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'kimura'
     assert_text 'お知らせ「現役生にのみお知らせtest」'
 
+    visit_with_auth '/notifications', 'mentormentaro'
+    assert_text 'お知らせ「現役生にのみお知らせtest」'
+
     visit_with_auth '/notifications', 'sotugyou'
     assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
@@ -66,14 +69,11 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'yameo'
     assert_no_text 'お知らせ「現役生にのみお知らせtest」'
 
-    visit_with_auth '/notifications', 'mentormentaro'
-    assert_no_text 'お知らせ「現役生にのみお知らせtest」'
-
     visit_with_auth '/notifications', 'kensyu'
     assert_no_text 'お知らせ「現役生にのみお知らせtest」'
   end
 
-  test 'announcement notifications are only recived by job seekers' do
+  test 'announcement to Only Job Seekers notifies the job seekers, admins, mentors' do
     visit_with_auth '/announcements', 'machida'
     click_link 'お知らせ作成'
     fill_in 'announcement[title]', with: '就活希望者のみお知らせします'
@@ -87,6 +87,9 @@ class Notification::AnnouncementsTest < ApplicationSystemTestCase
     assert_text 'お知らせ「就活希望者のみお知らせします」'
 
     visit_with_auth '/notifications', 'jobseeker'
+    assert_text 'お知らせ「就活希望者のみお知らせします」'
+
+    visit_with_auth '/notifications', 'mentormentaro'
     assert_text 'お知らせ「就活希望者のみお知らせします」'
 
     visit_with_auth '/notifications', 'kimura'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7317

## 概要
`/announcements/new`でお知らせを作成時、通知ターゲットが「現役生のみ」「就活希望者のみ」の場合、メンターには通知が届いてませんでした。
これをメンターにも通知が届くようにします。


## 変更確認方法

1. `feature/notify_mentors_all_announcements`をローカルに取り込む
2. `foreman start -f Procfile.dev`で起動
3. `machida`でログイン
4. `/announcements/new`にアクセス
5. 適当に内容を入力し、通知ターゲットを「現役生のみ」にしてお知らせを作成
6. `/letter_opener`にアクセスをする
7. **ユーザー名：kimura、komagata、mentormentaroに手順5のお知らせメールが届いている事を確認する**(ページ内検索でユーザー名で検索するとヒットします)

![無題](https://github.com/fjordllc/bootcamp/assets/111285341/a236e842-08cb-461c-a61a-b4d61880ffc5)

9. 確認後、letter_openerのClearボタンを押して、データをクリアしておく
10. `/announcements/new`にアクセス
11. 適当に内容を入力し、通知ターゲットを「就活希望者のみ」にしてお知らせを作成
12. **ユーザー名：jobseeker、komagata、mentormentaroに手順11のお知らせメールが届いている事を確認する**

## Screenshot
画面の変更はありません。

