### PR TITLE
お知らせのメール通知に作成者のアカウントID（ログイン名）を表示する

### DIFF
--- a/app/views/notification_mailer/_mailer_style.html.erb
+++ b/app/views/notification_mailer/_mailer_style.html.erb
@@ -26,6 +26,7 @@
     padding: 0;
     -webkit-text-size-adjust: 100%;
     -ms-text-size-adjust: 100%;
+    font-family: sans-serif;
   }
 
   table,

--- a/app/views/notification_mailer/_notification_mailer_template.html.erb
+++ b/app/views/notification_mailer/_notification_mailer_template.html.erb
@@ -43,4 +43,9 @@
       </table>
     </td>
   </tr>
+  <tr>
+    <td align="center">
+      <%= "作成者：#{@announcement.user.long_name}" %>
+    </td>
+  </tr>
 </table>

--- a/app/views/notification_mailer/_notification_mailer_template.html.erb
+++ b/app/views/notification_mailer/_notification_mailer_template.html.erb
@@ -1,29 +1,30 @@
 <table style="width: 100%;">
   <tr>
-    <td style="word-wrap: break-word; font-size: 0px; padding: 16px 20px 0;" align="center">
-      <div style="cursor:auto; font-family: sans-serif ; text-align:center;">
-        <h3
-          style="font-family: sans-serif; font-size: 20px; color:#4638a0; line-height: 1.5; margin-bottom: 0; font-weight: bold">
-          <%= title %></h3>
+    <td style="word-wrap: break-word; font-size: 0px; padding: 16px 20px 0; text-align: left;">
+      <div style="cursor:auto;">
+        <h1 style="font-size: 24px; color:#4638a0; line-height: 1.5; margin-bottom: 0; font-weight: bold">
+          <%= title %></h1>
+        <p style="font-size: 13px; color:#4638a0; line-height: 1.5; margin-top: 12px; text-align: left">
+          <%= link_to @announcement.user.long_name, @announcement.user, style: "line-height: 140%; text-decoration: underline;" %>
+        </p>
       </div>
     </td>
   </tr>
   <tr>
-    <td style="word-wrap:break-word; padding:16px 24px 16px 24px;" align="left">
+    <td style="word-wrap: break-word; padding: 16px 24px 16px 24px; text-align: left;">
       <div class="a-long-text">
         <%= yield %>
       </div>
     </td>
   </tr>
   <tr>
-    <td style="word-wrap:break-word;font-size:0px;padding:0 20px 16px 20px;" align="center">
-      <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:separate;width:auto;"
-        align="center" border="0">
+    <td style="word-wrap: break-word; font-size: 0px; padding: 0 20px 16px 20px; text-align: center;">
+      <table role="presentation" cellpadding="0" cellspacing="0"
+        style="border-collapse:separate;width:auto; text-align: center; border: none; width: 100%">
         <tbody>
           <tr>
-            <td style="border:0px solid #000;border-radius:24px;color:#fff;cursor:auto;padding:12px 32px;"
-              align="center" valign="middle" bgcolor="#30ABDB">
-              <%= link_to link_text, link_url, style: "text-decoration:none; background:#30ABDB; color:#fff; font-family: sans-serif; font-size: 14px; font-weight: bold; line-height: 140%; text-transform: none; margin: 0px;" %>
+            <td style="border: none; text-align: center;" valign="middle">
+              <%= link_to link_text, link_url, style: "text-decoration: none; background: #30ABDB; color:#fff; font-size: 14px; font-weight: bold; line-height: 140%; border-radius: 24px; padding: 12px 32px; text-align: center; background-color: #30ABDB; margin: 0px; display: inline-block;" %>
             </td>
           </tr>
         </tbody>
@@ -31,21 +32,15 @@
     </td>
   </tr>
   <tr>
-    <td style="word-wrap:break-word;font-size:0px;padding:0 20px 20px 20px;" align="center">
-      <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse:separate;width:auto;"
-        align="center" border="0">
+    <td style="word-wrap: break-word; font-size:0px; padding: 0 20px 20px 20px; text-align: center;">
+      <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse: separate; width: 100%; text-align: center;">
         <tbody>
           <tr>
-            <td style="border:0px solid #000;cursor:auto;padding:12px 32px;" align="center" valign="middle">
-              <%= link_to "メールでの通知オフはこちらから", user_mail_notification_url(@user, token: @user.unsubscribe_email_token), style: "color:#4638a0; font-family: sans-serif; font-size:14px; font-weight:bold;line-height:140%; text-transform:none; margin:0px;", target: "_blank" %>
+            <td style="border: none; text-align: center;">
+              <%= link_to "メールでの通知オフはこちらから", user_mail_notification_url(@user, token: @user.unsubscribe_email_token), style: "color:#4638a0; font-size:14px; font-weight: bold; line-height:140%; margin: 0px; padding: 12px 32px; display: inline-block;", target: "_blank" %>
           </tr>
         </tbody>
       </table>
-    </td>
-  </tr>
-  <tr>
-    <td align="center">
-      <%= "作成者：#{@announcement.user.long_name}" %>
     </td>
   </tr>
 </table>

--- a/app/views/notification_mailer/_notification_mailer_template.html.erb
+++ b/app/views/notification_mailer/_notification_mailer_template.html.erb
@@ -5,7 +5,7 @@
         <h1 style="font-size: 24px; color:#4638a0; line-height: 1.5; margin-bottom: 0; font-weight: bold">
           <%= title %></h1>
         <p style="font-size: 13px; color:#4638a0; line-height: 1.5; margin-top: 12px; text-align: left">
-          <%= link_to @announcement.user.long_name, @announcement.user, style: "line-height: 140%; text-decoration: underline;" %>
+          <%= link_to @announcement.user.long_name, @announcement.user, style: "line-height: 140%; text-decoration: underline;" if @announcement %>
         </p>
       </div>
     </td>

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -184,6 +184,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_equal ['sotugyou@example.com'], email.to
     assert_equal '[FBC] お知らせ「お知らせ1」', email.subject
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">このお知らせへ</a>}, email.body.to_s)
+    assert_match(%r{<a .+ href="http://localhost:3000/users/#{announce.user.id}">}, email.body.to_s)
   end
 
   test 'post_announcement to mute email notification or retired user' do


### PR DESCRIPTION
## Issue

[お知らせのメール通知に作者を表示してほしい。 #6305](https://github.com/fjordllc/bootcamp/issues/6305)

## 概要

お知らせを作成したとき送信されるメールにお知らせ作成者の記載がないので、作成者のアカウントID（ログイン名）を表示する。

## 変更確認方法

1. feature/add-author-name-to-notification-email をローカルに取り込む。
2. bootcamp を起動する。
bundle exec foreman start -f Procfile.dev
3. 任意のユーザでログインする。
4. お知らせを作成する。
http://localhost:3000/announcements/new

5. http://localhost:3000/letter_opener に接続する。
6. 届いたメールにお知らせの作成者名が記載されていることを確認する。

## Screenshot

### 変更前
<img width="350" alt="1_development__LetterOpenerWeb" src="https://github.com/fjordllc/bootcamp/assets/83388876/df36b845-a6c6-4a73-a5c7-7469668b7ab2">


### 変更後
<img width="350" alt="2_development__LetterOpenerWeb" src="https://github.com/fjordllc/bootcamp/assets/83388876/3ac353c4-5127-41cf-84b1-a1c04ec7dd01">


