### PR TITLE
コース一覧に「コースのコピー」が欲しい

### DIFF
--- a/app/controllers/mentor/courses_controller.rb
+++ b/app/controllers/mentor/courses_controller.rb
@@ -8,7 +8,12 @@ class Mentor::CoursesController < MentorController
   end
 
   def new
-    @course = Course.new
+    if params[:course_id].present?
+      original_course = Course.find(params[:course_id])
+      @course = Course.new(title: original_course.title)
+    else
+      @course = Course.new
+    end
   end
 
   def edit; end

--- a/app/controllers/mentor/courses_controller.rb
+++ b/app/controllers/mentor/courses_controller.rb
@@ -10,7 +10,7 @@ class Mentor::CoursesController < MentorController
   def new
     if params[:course_id].present?
       original_course = Course.find(params[:course_id])
-      @course = Course.new(title: original_course.title)
+      @course = Course.new(category_ids: original_course.category_ids)
     else
       @course = Course.new
     end

--- a/app/javascript/stylesheets/shared/blocks/card/_card-footer.sass
+++ b/app/javascript/stylesheets/shared/blocks/card/_card-footer.sass
@@ -1,6 +1,7 @@
 .card-footer
+  container: card-footer / inline-size
   +media-breakpoint-up(md)
-    padding: .5rem 1.25rem
+    padding: .5rem 1rem
     min-height: 3rem
   +media-breakpoint-down(sm)
     padding: .5rem .75rem

--- a/app/javascript/stylesheets/shared/blocks/card/_card-main-actions.sass
+++ b/app/javascript/stylesheets/shared/blocks/card/_card-main-actions.sass
@@ -5,29 +5,29 @@
 .card-main-actions__items
   display: flex
   gap: .75rem
-  +media-breakpoint-up(md)
+  @container card-footer (min-width: 20em)
     +position(relative)
     justify-content: center
     flex-wrap: wrap
     align-items: flex-end
     min-height: 1.875rem
-  +media-breakpoint-down(sm)
+  @container card-footer (max-width: 19.9375em)
     flex-direction: column
   &.is-sub-actions
     justify-content: flex-end
-    +media-breakpoint-down(sm)
+    @container card-footer (max-width: 19.9375em)
       flex-direction: row
     .card-main-actions__item.is-sub
       position: static
       flex: 0 0 auto
 
 .card-main-actions__item
-  +media-breakpoint-up(md)
-    flex: 0 0 12rem
-    max-width: calc(50% - .375rem)
+  @container card-footer (min-width: 20em)
+    flex: 1
+    max-width: 15rem
     &.is-sub
       +position(absolute, right 0, bottom 0)
-  +media-breakpoint-down(sm)
+  @container card-footer (max-width: 19.9375em)
     flex-basis: 100%
     max-width: 100%
     &.is-sub
@@ -37,6 +37,10 @@
   &.is-end
     margin-left: auto
     flex-basis: 2.5rem
+  .card-main-actions.is-3-items &
+    @container card-footer (min-width: 20em)
+      flex: 1 0 0
+
 
 .card-main-actions__muted-action
   +hover-link-reversal

--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -14,7 +14,7 @@
       - if mentor_login?
         hr.a-border-tint
         footer.card-footer
-          .card-main-actions
+          .card-main-actions.is-3-items
             ul.card-main-actions__items
               li.card-main-actions__item
                 = link_to edit_mentor_course_path(course), class: 'a-button is-sm is-secondary is-block' do

--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -24,3 +24,7 @@
                 = link_to mentor_course_categories_path(course), class: 'a-button is-sm is-secondary is-block' do
                   i.fa-solid.fa-align-justify
                   | 並び替え
+              li.card-main-actions__item
+                = link_to new_mentor_course_path(course_id: course.id), class: 'a-button is-sm is-secondary is-block' do
+                  i.fa-solid.fa-align-justify
+                  | コピー

--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -26,5 +26,5 @@
                   | 並び替え
               li.card-main-actions__item
                 = link_to new_mentor_course_path(course_id: course.id), class: 'a-button is-sm is-secondary is-block' do
-                  i.fa-solid.fa-align-justify
+                  i.fa-solid.fa-copy
                   | コピー

--- a/app/views/mentor/courses/categories/index.html.slim
+++ b/app/views/mentor/courses/categories/index.html.slim
@@ -23,7 +23,7 @@ header.page-header
                   | コース一覧
   hr.a-border
   .page-body
-    .container.is-lg
+    .container.is-md
       .admin-table.is-grab
         table.admin-table__table
           thead.admin-table__header


### PR DESCRIPTION
## Issue

- #7321

## 概要
新しいコースを作るときにカテゴリーをたくさん選ぶのが大変なので、コースのコピー機能が欲しい。
対象のコースからコピーを選ぶと、元のコースの情報（カテゴリー情報だけで良い）が最初から入った形でコース選択画面に遷移してほしい。
![image](https://github.com/fjordllc/bootcamp/assets/57862327/ffb8ae38-73c2-4d41-ade8-517d46adb0c8)
![image](https://github.com/fjordllc/bootcamp/assets/57862327/312d286a-8a3f-47e2-a6a8-25292a68ef76)

## 変更確認方法

1. feature/course-list-copyをローカルに取り込む。
2. メンターの権限でログインをする。（https://bootcamp.fjord.jp/practices/159）※ 下部のログイン方法参考
4. `http://localhost:3000/courses`にアクセスをする。
5. 各コースごとに「コピー」ボタンが実装されていることを確認する。
6. 「Railsプログラマー」の編集ボタンを押下する。
7. 画面の下部のCategory欄でチェックボックスにチェックがついているカテゴリーを確認する。
8. 画面を一つ前に戻って、「Railsプログラマー」の「コピー」ボタンを押す。
9. 新規作成画面になったことを確認して、5で確認したカテゴリーがすでにチェックされていることを確認する。
10. タイトルと説明欄に任意の文字を入力し、「内容の保存」を押下する。
11. 新規にコースが作成されたことを確認し内容が「Railsプログラマー」と同じチェックボックスにチェックが入っていることを確認する。
※ 他のコースも確認したい場合は同様の手順を実施する

## Screenshot

### 変更前
![スクリーンショット 2024-02-11 12 30 20](https://github.com/fjordllc/bootcamp/assets/57862327/de705739-c6ab-4516-a08b-04736a3c5552)

### 変更後
![スクリーンショット 2024-02-11 12 26 38](https://github.com/fjordllc/bootcamp/assets/57862327/c1f17bdb-4562-41de-9a92-3bef2431a9b6)
![スクリーンショット 2024-02-11 12 27 11](https://github.com/fjordllc/bootcamp/assets/57862327/b87c0c93-67db-4a28-b7bf-8fb3ebfb4335)