### PR TITLE
退会完了メールのBCCにinfo@lokka.jpを追加する

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,7 +14,7 @@ class UserMailer < ApplicationMailer
 
   def retire(user)
     @user = user
-    mail to: user.email, subject: '[FBC] 退会処理が完了しました'
+    mail to: user.email, bcc: 'info@lokka.jp', subject: '[FBC] 退会処理が完了しました'
   end
 
   def auto_retire(user)

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -21,6 +21,7 @@ class UserMailerTest < ActionMailer::TestCase
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['kimura@fjord.jp'], email.to
+    assert_equal ['info@lokka.jp'], email.bcc
     assert_equal '[FBC] 退会処理が完了しました', email.subject
     assert_match(/ご利用いただきありがとうございました/, email.body.to_s)
     assert_match("#{user.name}様の今後のご活躍を心からお祈り申し上げます。", email.body.to_s)


### PR DESCRIPTION
## Issue

- #7352 

## 概要
ユーザが退会した時にbccでinfo@lokka.jpにもメールが飛ぶようにしました

## 変更確認方法

1. ブランチ`feat/yocchan/retire-bcc`をローカルに取り込む
2. `bin/rails s`でローカル環境を立ち上げる
3. ログインして、退会をする
4. http://localhost:3000/letter_opener にアクセスしてbccで`info@lokka.jp`も追加されているか確認する
5. (必要なら) `rails db:migrate:reset`と`rails db:seed`で退会を元に戻せます！

## 変更前

[![Image from Gyazo](https://i.gyazo.com/359a0fd5293f0335b85fd914d7c0ab18.png)](https://gyazo.com/359a0fd5293f0335b85fd914d7c0ab18)

## 変更後

[![Image from Gyazo](https://i.gyazo.com/a43c8ac178cf0d9ee6e66dc288daafd2.png)](https://gyazo.com/a43c8ac178cf0d9ee6e66dc288daafd2)

