### PR TITLE
「管理ページ」のマークアップをh1に変更

### DIFF
--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -3,7 +3,7 @@
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title
+      h1.page-header__title
         = title
 
 = render 'admin/admin_page_tabs'


### PR DESCRIPTION
## Issue

- #7371

## 概要

`/admin/users`ページのタイトルである「管理ページ」のマークアップをh1に修正しました！

## 変更確認方法

1. `feat/yocchan/change-h1-admin-users-title`をローカルに取り込む
2. http://localhost:3000/admin/users にアクセスする
3. 「検証」で管理ページのタグを確認する

## Screenshot

### 変更前

[![Image from Gyazo](https://i.gyazo.com/722a098b99554f306ea708a49b89a304.png)](https://gyazo.com/722a098b99554f306ea708a49b89a304)

### 変更後

[![Image from Gyazo](https://i.gyazo.com/955633c610f1cc937578bf85c36d5905.png)](https://gyazo.com/955633c610f1cc937578bf85c36d5905)

