### PR TITLE
質問投稿時のタイトル入力の部分に説明を追加

### DIFF
--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -15,6 +15,13 @@
           .col-md-6.col-xs-12
             = f.label :title, class: 'a-form-label'
             = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'メソッドを定義するときの考え方がわからない'
+            .a-form-help
+              p
+                | 質問の内容が予測しやすいタイトルを付けましょう。
+                br
+                | 悪い例: CSS初級課題
+                br
+                | 良い例: タイトルを左右方向に中央に配置する方法
       .form-item
         .row.js-markdown-parent
           .col-md-6.col-xs-12


### PR DESCRIPTION
## Issue

- #7328

## 概要

質問投稿時のタイトル入力の部分に説明を追加しました。

## 変更確認方法

1. {feature/add-description-to-question-title}をローカルに取り込む
2. ローカル環境を立ち上げる
3. http://127.0.0.1:3000/questions/new にアクセスする
4. タイトル入力欄の下部を確認する

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/151989679/35b1d6b3-bedb-4404-acd9-fc63c09b8022)

### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/151989679/b89a3e31-ae61-4db8-9a8c-87e873b6e16c)
