### PR TITLE
自動退会メールのBCCにinfo@lokka.jpを追加

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -19,6 +19,6 @@ class UserMailer < ApplicationMailer
 
   def auto_retire(user)
     @user = user
-    mail to: user.email, subject: '[FBC] 重要なお知らせ：受講ステータスの変更について'
+    mail to: user.email, bcc: 'info@lokka.jp', subject: '[FBC] 重要なお知らせ：受講ステータスの変更について'
   end
 end


### PR DESCRIPTION
## Issue

- #7342

## 概要

自動退会メールのBCCにinfo@lokka.jpを追加しました。

## 変更確認方法

https://github.com/fjordllc/bootcamp/issues/7342#issuecomment-1944552953 の会話にて
> こちらGood First Issueとしては確認方法が難しいのでコードの変更だけでOKです。

とのことなので、今回は画面上での確認はしなくてよいものと思われます

## Screenshot

### 変更前

なし

### 変更後

なし