### PR TITLE
企業研修の申し込みフォームを作成

### DIFF
--- a/app/controllers/corporate_trainings_controller.rb
+++ b/app/controllers/corporate_trainings_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class CorporateTrainingsController < ApplicationController
+  include Recaptchable::V3
+  skip_before_action :require_active_user_login, raise: false
+
+  def new
+    @corporate_training = CorporateTraining.new
+  end
+
+  def create
+    @corporate_training = CorporateTraining.new(corporate_training_params)
+
+    result = valid_recaptcha?('corporate_training')
+    if result && @corporate_training.save
+      CorporateTrainingMailer.incoming(@corporate_training).deliver_later
+      redirect_to new_corporate_training_url, notice: 'お問い合わせを送信しました。'
+    else
+      flash.now[:alert] = 'Bot対策のため送信を拒否しました。しばらくしてからもう一度送信してください。' unless result
+      render :new
+    end
+  end
+
+  private
+
+  def corporate_training_params
+    params.require(:corporate_training).permit(
+      :company_name,
+      :name,
+      :email,
+      :meeting_date1,
+      :meeting_date2,
+      :meeting_date3,
+      :participants_count,
+      :training_duration,
+      :how_did_you_hear,
+      :additional_information,
+      :privacy_policy
+    )
+  end
+end

--- a/app/mailers/corporate_training_mailer.rb
+++ b/app/mailers/corporate_training_mailer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CorporateTrainingMailer < ApplicationMailer
+  def incoming(corporate_training)
+    @corporate_training = corporate_training
+    mail to: 'info@lokka.jp', reply_to: @corporate_training.email, subject: '[FBC] 企業研修の申し込み'
+  end
+end

--- a/app/models/corporate_training.rb
+++ b/app/models/corporate_training.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CorporateTraining < ApplicationRecord
+  validates :company_name, presence: true
+  validates :name, presence: true
+  validates :email, presence: true,
+                    format: {
+                      with: URI::MailTo::EMAIL_REGEXP,
+                      message: 'Emailに使える文字のみ入力してください'
+                    }
+  validates :meeting_date1, presence: true
+  validates :meeting_date2, presence: true
+  validates :meeting_date3, presence: true
+  validates :participants_count, presence: true
+  validates :training_duration, presence: true
+  validates :how_did_you_hear, presence: true
+  validates :additional_information, length: { maximum: 10_000 }
+  validates :privacy_policy, acceptance: { message: 'に同意してください' }
+  validate :unique_meeting_dates
+  validate :meeting_dates_not_in_past
+
+  private
+
+  def unique_meeting_dates
+    return unless [meeting_date1, meeting_date2, meeting_date3].uniq.length < 3
+
+    errors.add(:base, '研修打ち合わせ希望日時はそれぞれ別の日付を選択してください')
+  end
+
+  def meeting_dates_not_in_past
+    [meeting_date1, meeting_date2, meeting_date3].each do |meeting_date|
+      return errors.add(:base, '研修打ち合わせ希望日時に過去の日付は入力できません') if meeting_date.present? && meeting_date < Time.zone.today
+    end
+  end
+end

--- a/app/views/corporate_training_mailer/incoming.html.erb
+++ b/app/views/corporate_training_mailer/incoming.html.erb
@@ -1,0 +1,36 @@
+<table width="100%">
+  <tr>
+    <td style="word-wrap:break-word;font-size:0px;padding:0px 20px 0px 20px;" align="center">
+      <div style="cursor:auto; font-family: sans-serif ;text-align:center;">
+        <h3 style="font-family: sans-serif; font-size: 20px; color:#4638a0; line-height: 1.4; margin-bottom: 0; font-weight: bold">企業研修の申し込み</h3>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td style="word-wrap:break-word;font-size:0px;padding:16px 24px 16px 24px;" align="left">
+      <div style="cursor:auto;font-family:sans-serif; font-size:14px; line-height:1.8; text-align:left;">
+        <p><b>企業名：</b></p>
+        <p><%= @corporate_training.company_name %></p>
+        <p><b>名前：</b></p>
+        <p><%= @corporate_training.name %></p>
+        <p><b>Email：</b></p>
+        <p><%= @corporate_training.email %></p>
+        <p><b>研修打ち合わせ希望日時：</b></p>
+          <p><b>第1希望</b></p>
+          <p><%= l @corporate_training.meeting_date1, format: :default %></p>
+          <p><b>第2希望</b></p>
+          <p><%= l @corporate_training.meeting_date2, format: :default %></p>
+          <p><b>第3希望</b></p>
+          <p><%= l @corporate_training.meeting_date3, format: :default%></p>
+        <p><b>研修を受ける方の人数：</b></p>
+        <p><%= @corporate_training.participants_count %>人</p>
+        <p><b>研修期間：</b></p>
+        <p><%= @corporate_training.training_duration %></p>
+        <p><b>どこでフィヨルドブートキャンプを知りましたか？：</b></p>
+        <p><%= @corporate_training.how_did_you_hear %></p>
+        <p><b>その他伝えておきたいこと：</b></p>
+        <p><%= @corporate_training.additional_information %></p>
+      </div>
+    </td>
+  </tr>
+</table>

--- a/app/views/corporate_trainings/_form.html.slim
+++ b/app/views/corporate_trainings/_form.html.slim
@@ -1,0 +1,52 @@
+= form_with model: corporate_training, url: corporate_training_path, method: :post, local: true do |f|
+  = render 'errors', object: corporate_training
+  .form__items
+    .form-item
+      = f.label :name, class: 'a-form-label is-required'
+      = f.text_field :name, class: 'a-text-input'
+    .form-item
+      = f.label :company_name, class: 'a-form-label is-required'
+      = f.text_field :company_name, class: 'a-text-input'
+    .form-item
+      = f.label :email, class: 'a-form-label is-required'
+      = f.email_field :email, class: 'a-text-input'
+    .form__items-inner
+      .form-item
+        = f.label :meeting_dates, class: 'a-form-label is-required'
+        .form-item
+          = f.label :meeting_date1, class: 'a-form-label'
+          = f.datetime_field :meeting_date1
+        .form-item
+          = f.label :meeting_date2, class: 'a-form-label'
+          = f.datetime_field :meeting_date2
+        .form-item
+          = f.label :meeting_date3, class: 'a-form-label'
+          = f.datetime_field :meeting_date3
+      .form-item
+        = f.label :participants_count, class: 'a-form-label is-required'
+        = f.number_field :participants_count, min: 1, max: 10_000, placeholder: 1
+    .form-item
+      = f.label :training_duration, class: 'a-form-label is-required'
+      = f.text_field :training_duration, class: 'a-text-input'
+    .form-item
+      = f.label :how_did_you_hear, class: 'a-form-label is-required'
+      = f.text_field :how_did_you_hear, class: 'a-text-input'
+    .form-item
+      = f.label :additional_information, class: 'a-form-label'
+      = f.text_area :additional_information, class: 'a-text-input is-md'
+    .form-item
+      .a-form-label
+        | 個人情報の取り扱いについて
+      label.form-item__one-checkbox.a-checkbox
+        = f.check_box :privacy_policy
+        span
+          | 下記の個人情報の取り扱いに同意する
+      .a-form-frame.form-item__pp
+        = render('pp')
+
+    .form-actions
+      ul.form-actions__items
+        li.form-actions__item.is-main
+          = f.submit '送信', class: 'a-button is-lg is-primary is-block'
+
+  = recaptcha_v3(action: 'corporate_training', callback: 'skipOnLoadReCaptcha') if recaptcha_enabled?

--- a/app/views/corporate_trainings/new.html.slim
+++ b/app/views/corporate_trainings/new.html.slim
@@ -1,0 +1,19 @@
+ruby:
+  title '企業研修申し込みフォーム'
+  content_for :extra_body_classes, 'no-header no-footer no-global-nav is-auth-page is-piyo-background'
+  set_meta_tags(site: 'FJORD BOOT CAMP（フィヨルドブートキャンプ）')
+- if recaptcha_enabled?
+  - content_for :head_last do
+    = javascript_include_tag 'recaptcha'
+.auth-form.is-sign-up.a-card
+  header.auth-form__header
+    h1.auth-form__title = title
+  .auth-form__body
+    = render 'form', corporate_training: @corporate_training
+  footer.auth-form__footer
+    nav.auth-form-nav
+      ul.auth-form-nav__items
+        li.auth-form-nav__item
+          = link_to 'トップページ', welcome_path, class: 'auth-form-nav__item-link'
+        li.auth-form-nav__item
+          = link_to 'FAQ', faq_path, class: 'auth-form-nav__item-link'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -185,6 +185,19 @@ ja:
         email: メールアドレス
         body: 内容
         privacy_policy: 個人情報の取り扱い
+      corporate_training:
+        name: 名前
+        company_name: 企業名
+        email: メールアドレス
+        meeting_dates: 研修打ち合わせ希望日時
+        meeting_date1: 第1希望
+        meeting_date2: 第2希望
+        meeting_date3: 第3希望
+        participants_count: 参加人数
+        training_duration: 研修期間
+        how_did_you_hear: どこでフィヨルドブートキャンプを知りましたか？
+        additional_information: その他伝えておきたいこと
+        privacy_policy: 個人情報の取り扱い
       article:
         title: タイトル
         body: 本文

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
   resources :questions
   resources :courses, only: :index
   resource :inquiry, only: %i(new create)
+  resource :corporate_training, only: %i(new create)
   resources :articles
   resources :survey_questions, except: %i(show destroy)
   namespace :events do

--- a/db/migrate/20240126180444_create_corporate_trainings.rb.rb
+++ b/db/migrate/20240126180444_create_corporate_trainings.rb.rb
@@ -1,0 +1,17 @@
+class CreateCorporateTrainings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :corporate_trainings do |t|
+      t.string :company_name
+      t.string :name
+      t.string :email
+      t.datetime :meeting_date1
+      t.datetime :meeting_date2
+      t.datetime :meeting_date3
+      t.integer :participants_count
+      t.string :training_duration
+      t.string :how_did_you_hear
+      t.text :additional_information
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -195,6 +195,21 @@ ActiveRecord::Schema.define(version: 2024_03_14_023555) do
     t.text "memo"
   end
 
+  create_table "corporate_trainings", force: :cascade do |t|
+    t.string "company_name"
+    t.string "name"
+    t.string "email"
+    t.datetime "meeting_date1"
+    t.datetime "meeting_date2"
+    t.datetime "meeting_date3"
+    t.integer "participants_count"
+    t.string "training_duration"
+    t.string "how_did_you_hear"
+    t.text "additional_information"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "courses", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false

--- a/test/fixtures/corporate_training.yml
+++ b/test/fixtures/corporate_training.yml
@@ -1,0 +1,11 @@
+corporate_training1:
+  company_name: '株式会社カンパニー'
+  name: '研修 する世'
+  email: 'corporate_training@example.com'
+  meeting_date1: Time.zone.parse('2030-01-01-08:00')
+  meeting_date2: Time.zone.parse('2030-01-02-10:00')
+  meeting_date3: Time.zone.parse('2023-01-03-12:00')
+  participants_count: 10
+  training_duration: '1ヶ月'
+  how_did_you_hear: 'インターネットで知った'
+  additional_information: 'よろしくお願いします。'

--- a/test/mailers/corporate_training_mailer_test.rb
+++ b/test/mailers/corporate_training_mailer_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CorporateTrainingMailerTest < ActionMailer::TestCase
+  test 'incoming' do
+    corporate_training = CorporateTraining.new(
+      company_name: '株式会社ロッカ',
+      name: '駒形真幸',
+      email: 'komagata@example.com',
+      meeting_date1: Time.zone.parse('2030-01-01 08:00:00'),
+      meeting_date2: Time.zone.parse('2030-01-02 10:00:00'),
+      meeting_date3: Time.zone.parse('2030-01-03 12:00:00'),
+      participants_count: 10,
+      training_duration: '1ヶ月',
+      how_did_you_hear: 'インターネットで知った',
+      additional_information: 'よろしくお願いします。'
+    )
+    mail = CorporateTrainingMailer.incoming(corporate_training)
+    assert_equal '[FBC] 企業研修の申し込み', mail.subject
+    assert_equal ['info@lokka.jp'], mail.to
+    assert_equal ['noreply@bootcamp.fjord.jp'], mail.from
+    assert_equal ['komagata@example.com'], mail.reply_to
+    assert_match(/企業研修の申し込み/, mail.body.to_s)
+    assert_match(/駒形真幸/, mail.body.to_s)
+    assert_match(/2030年01月01日\(火\)\s08:00/, mail.body.to_s)
+    assert_match(/2030年01月02日\(水\)\s10:00/, mail.body.to_s)
+    assert_match(/2030年01月03日\(木\)\s12:00/, mail.body.to_s)
+    assert_match(/10人/, mail.body.to_s)
+    assert_match(/1ヶ月/, mail.body.to_s)
+    assert_match(/インターネットで知った/, mail.body.to_s)
+    assert_match(/よろしくお願いします。/, mail.body.to_s)
+  end
+end

--- a/test/mailers/previews/corporate_training_mailer_preview.rb
+++ b/test/mailers/previews/corporate_training_mailer_preview.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CorporateTrainingMailerPreview < ActionMailer::Preview
+  def incoming
+    corporate_training = CorporateTraining.new(
+      company_name: '株式会社カンパニー',
+      name: '研修 する世',
+      email: 'corporate_training@example.com',
+      meeting_date1: Time.zone.parse('2030-01-01-08:00'),
+      meeting_date2: Time.zone.parse('2030-01-02-10:00'),
+      meeting_date3: Time.zone.parse('2030-01-03-12:00'),
+      participants_count: 10,
+      training_duration: '1ヶ月',
+      how_did_you_hear: 'インターネットで知った',
+      additional_information: 'よろしくお願いします。'
+    )
+    CorporateTrainingMailer.incoming(corporate_training)
+  end
+end

--- a/test/models/corporate_training_test.rb
+++ b/test/models/corporate_training_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CorporateTrainingTest < ActiveSupport::TestCase
+  test '#unique_meeting_dates' do
+    corporate_training = corporate_training(:corporate_training1)
+    corporate_training.meeting_date1 = Time.zone.parse('2030-01-01-10:00')
+    corporate_training.meeting_date2 = corporate_training.meeting_date1
+    assert_not corporate_training.valid?
+    assert_includes corporate_training.errors[:base], '研修打ち合わせ希望日時はそれぞれ別の日付を選択してください'
+  end
+
+  test '#meeting_dates_not_in_past' do
+    corporate_training = corporate_training(:corporate_training1)
+    corporate_training.meeting_date1 = Time.zone.today - 1.day
+    assert_not corporate_training.valid?
+    assert_includes corporate_training.errors[:base], '研修打ち合わせ希望日時に過去の日付は入力できません'
+  end
+end

--- a/test/system/corporate_training_system_test.rb
+++ b/test/system/corporate_training_system_test.rb
@@ -2,7 +2,7 @@
 
 require 'application_system_test_case'
 
-class CorporateTrainingTest < ApplicationSystemTestCase
+class CorporateTrainingSystemTest < ApplicationSystemTestCase
   setup do
     @site_key = Recaptcha.configuration.site_key
     @secret_key = Recaptcha.configuration.secret_key

--- a/test/system/corporate_training_test.rb
+++ b/test/system/corporate_training_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class CorporateTrainingTest < ApplicationSystemTestCase
+  setup do
+    @site_key = Recaptcha.configuration.site_key
+    @secret_key = Recaptcha.configuration.secret_key
+
+    Recaptcha.configuration.site_key = nil
+    Recaptcha.configuration.secret_key = nil
+  end
+
+  teardown do
+    Recaptcha.configuration.site_key = @site_key
+    Recaptcha.configuration.secret_key = @secret_key
+  end
+
+  test 'GET /corporate_training/new' do
+    visit '/corporate_training/new'
+    assert_equal '企業研修申し込みフォーム | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+
+    fill_in '名前', with: '研修 する世'
+    fill_in '企業名', with: '株式会社カンパニー'
+    fill_in 'メールアドレス', with: 'corporate_training@example.com'
+    fill_in '第1希望', with: Time.zone.parse('2030-01-01-08:00')
+    fill_in '第2希望', with: Time.zone.parse('2030-01-02-10:00')
+    fill_in '第3希望', with: Time.zone.parse('2030-01-03-12:00')
+    fill_in '参加人数', with: '10'
+    fill_in '研修期間', with: '1ヶ月'
+    fill_in 'どこでフィヨルドブートキャンプを知りましたか？', with: 'インターネットで知った'
+    fill_in 'その他伝えておきたいこと', with: 'よろしくお願いします。'
+    check '下記の個人情報の取り扱いに同意する', allow_label_click: true
+
+    assert_difference 'ActionMailer::Base.deliveries.count', 1 do
+      click_button '送信'
+    end
+    mail = ActionMailer::Base.deliveries.last
+    assert_equal '[FBC] 企業研修の申し込み', mail.subject
+
+    assert_text 'お問い合わせを送信しました。'
+    assert_no_text 'Bot対策のため送信を拒否しました。しばらくしてからもう一度送信してください。'
+  end
+end

--- a/test/system/require_login_test.rb
+++ b/test/system/require_login_test.rb
@@ -50,6 +50,9 @@ class RequireLoginTest < ApplicationSystemTestCase
     # app/controllers/comeback_controller.rb
     assert_no_login_required('/comeback/new', '休会からの復帰')
 
+    # app/controllers/corporate_training_comtroller.rb
+    assert_no_login_required('/corporate_training/new', '企業研修申し込みフォーム')
+
     # app/controllers/home_controller.rb
     assert_no_login_required('/', 'フィヨルドブートキャンプとは？')
     assert_no_login_required('/test', 'TEST')


### PR DESCRIPTION
## Issue

- #7171

## 概要
現在はお問い合わせフォームから研修の申し込みをしてもらっているため、企業研修申し込み専用のフォームを作成しました。
※Gitの操作を誤ったためブランチを切り直しました。過去のPRは #7319 です
## 変更確認方法

1. `feature/corporate_training_form_create`をローカルに取り込む
2. http://localhost:3000/corporate_training/new にアクセス
3. 必須項目(*)を入力し、下記の個人情報の取り扱いに同意するのチェックボックスをチェック
4. 送信ボタンを押下
5. http://localhost:3000/letter_opener で`info@lokka.jp`宛てにメールが届くことを確認

## Screenshot
<img width="625" alt="image" src="https://github.com/fjordllc/bootcamp/assets/88243294/ffbb486c-97b7-4d2e-ba2e-e791c38633cd">

