### PR TITLE
コース一覧読み込み時のローディングを作成

### DIFF
--- a/app/javascript/components/LoadingMentorPageCoursesPlaceholder.jsx
+++ b/app/javascript/components/LoadingMentorPageCoursesPlaceholder.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import MentorPageLoadingView from './MentorPageLoadingView'
+
+const LoadingMentorPageCoursesPlaceholder = () => {
+  const columnsForCategories = 3
+  const rowsForCategories = 12
+
+  return (
+    <MentorPageLoadingView
+      columns={columnsForCategories}
+      rows={rowsForCategories}
+    />
+  )
+}
+
+export default LoadingMentorPageCoursesPlaceholder

--- a/app/javascript/components/MentorCourses.jsx
+++ b/app/javascript/components/MentorCourses.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import useSWR from 'swr'
 import fetcher from '../fetcher'
+import LoadingMentorPageCoursesPlaceholder from './LoadingMentorPageCoursesPlaceholder'
 
 const Header = () => {
   return (
@@ -17,7 +18,7 @@ const Header = () => {
 export default function MentorCourses() {
   const { data, error } = useSWR('/api/courses.json', fetcher)
   if (error) return <>An error has occurred.</>
-  if (!data) return <>Loading...</>
+  if (!data) return <LoadingMentorPageCoursesPlaceholder />
   const courses = data.courses
 
   return (


### PR DESCRIPTION
## Issue

- #6845

## 概要

[メンターページのコース一覧のページ](http://127.0.0.1:3000/mentor/courses)で、読み込み中に空のテーブルが表示されるようになります。

## 変更確認方法

1. `feature/mentor_page_course_list_loading_view`をローカルに取り込む
2.  メンターのアカウントでログイン
3. [メンターページのコース一覧のページ](http://127.0.0.1:3000/mentor/courses)にアクセス
4. 読み込み時に変更後のローディング(以下のスクリーンショットの変更後を参照)が表示されることを確認

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/151989679/9737c455-ff34-42fe-8002-c1ee0f37a1fb)

### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/151989679/b75af7d2-7200-49ee-a5c8-11ce7a5cabee)
