### PR TITLE
ImageMagickからlibvipsに移行する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,9 @@ jobs:
           name: Install japanese font
           command: sudo apt-get install -y fonts-noto-cjk
       - run:
+          name: Install libvips
+          command: sudo apt-get install -y libvips
+      - run:
           name: Wait for DB
           command: 'dockerize -wait tcp://localhost:5432 -timeout 1m'
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,12 @@ jobs:
           name: Slim Lint
           command: bundle exec slim-lint app/views -c config/slim_lint.yml
       - run:
+          name: Update package list
+          command: sudo apt-get update
+      - run:
+          name: Install libvips
+          command: sudo apt-get install -y libvips
+      - run:
           name: Traceroute
           command: FAIL_ON_ERROR=1 bundle exec rake traceroute
       - node/install:

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 
 # Install OS packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends imagemagick pngcrush optipng gsfonts
+    && apt-get -y install --no-install-recommends libvips42 libvips-dev pngcrush optipng gsfonts
 
 # Install bundler
 RUN gem install --no-document bundler -v 2.2.27

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apk add --no-cache \
       tzdata && \
       cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-# ImageMagick
-RUN apk add --no-cache imagemagick imagemagick-heic imagemagick-jpeg imagemagick-pdf imagemagick-svg imagemagick-webp bash pngcrush optipng=0.7.8-r0 ghostscript-fonts
+# libvips
+RUN apk add --no-cache vips-dev orc-dev bash pngcrush optipng=0.7.8-r0 ghostscript-fonts
 
 # Install npm packages
 COPY package.json yarn.lock ./

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -20,7 +20,7 @@ class Article < ApplicationRecord
   belongs_to :user
   include ActionView::Helpers::AssetUrlHelper
 
-  THUMBNAIL_SIZE = '1200x630>'
+  THUMBNAIL_SIZE = [1200, 630].freeze
   has_one_attached :thumbnail
 
   before_validation :set_published_at, if: :will_be_published?
@@ -38,7 +38,7 @@ class Article < ApplicationRecord
 
   def prepared_thumbnail_url
     if thumbnail.attached?
-      thumbnail.variant(resize: THUMBNAIL_SIZE).processed.url
+      thumbnail.variant(resize_to_limit: THUMBNAIL_SIZE).processed.url
     else
       image_url('/images/articles/thumbnails/blank.svg')
     end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -3,7 +3,7 @@
 class Book < ApplicationRecord
   include ActionView::Helpers::AssetUrlHelper
 
-  COVER_SIZE = '100x150>'
+  COVER_SIZE = [100, 150].freeze
   has_many :practices_books, dependent: :destroy
   has_many :practices, through: :practices_books
   has_one_attached :cover
@@ -17,7 +17,7 @@ class Book < ApplicationRecord
   def cover_url
     default_image_path = '/images/books/covers/default.svg'
     if cover.attached?
-      cover.variant(resize: COVER_SIZE).processed.url
+      cover.variant(resize_to_limit: COVER_SIZE).processed.url
     else
       image_url default_image_path
     end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Company < ApplicationRecord
-  LOGO_SIZE = '88x88>'
+  LOGO_SIZE = [88, 88].freeze
   has_many :users, dependent: :nullify
   validates :name, presence: true
   has_one_attached :logo
@@ -10,7 +10,7 @@ class Company < ApplicationRecord
 
   def logo_url
     if logo.attached?
-      logo.variant(resize: LOGO_SIZE).processed.url
+      logo.variant(resize_to_limit: LOGO_SIZE).processed.url
     else
       image_url('/images/companies/logos/default.png')
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   authenticates_with_sorcery!
   VALID_SORT_COLUMNS = %w[id login_name company_id last_activity_at created_at report comment asc desc].freeze
-  AVATAR_SIZE = '88x88>'
+  AVATAR_SIZE = [88, 88].freeze
   RESERVED_LOGIN_NAMES = %w[adviser all graduate inactive job_seeking mentor retired student student_and_trainee trainee year_end_party].freeze
   MAX_PERCENTAGE = 100
   DEPRESSED_SIZE = 2
@@ -592,7 +592,7 @@ class User < ApplicationRecord
     default_image_path = '/images/users/avatars/default.png'
 
     if avatar.attached?
-      avatar.variant(resize: AVATAR_SIZE).processed.url
+      avatar.variant(resize_to_limit: AVATAR_SIZE).processed.url
     else
       image_url default_image_path
     end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Work < ApplicationRecord
-  THUMBNAIL_SIZE = '1200x630>'
+  THUMBNAIL_SIZE = [1200, 630].freeze
   belongs_to :user
   has_one_attached :thumbnail
 
@@ -15,7 +15,7 @@ class Work < ApplicationRecord
 
   def thumbnail_url
     if thumbnail.attached?
-      thumbnail.variant(resize: THUMBNAIL_SIZE).processed.url
+      thumbnail.variant(resize_to_limit: THUMBNAIL_SIZE).processed.url
     else
       image_url('/images/works/thumbnails/default.png')
     end

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,1 +1,1 @@
-= image_tag @user.avatar.variant(resize: '88x88>').processed.url
+= image_tag @user.avatar.variant(resize_to_limit: [88, 88]).processed.url

--- a/app/views/articles/_recent_articles.html.slim
+++ b/app/views/articles/_recent_articles.html.slim
@@ -11,7 +11,7 @@
             .card-list-item__thumbnail
               .card-list-item__thumbnail-inner
                 - if recent_article.thumbnail.attached?
-                  = image_tag recent_article.thumbnail.variant(resize: '200x105>').processed.url, class: 'card-list-item__thumbnail-image', alt: "ブログ記事「#{recent_article.title}」のアイキャッチ画像"
+                  = image_tag recent_article.thumbnail.variant(resize_to_limit: [200, 105]).processed.url, class: 'card-list-item__thumbnail-image', alt: "ブログ記事「#{recent_article.title}」のアイキャッチ画像"
                 - else
                   = image_tag 'work-blank.svg', class: 'card-list-item__thumbnail-image', alt: 'ブログ記事のブランクアイキャッチ画像'
             .card-list-item__rows

--- a/app/views/mentor/practices/_form.html.slim
+++ b/app/views/mentor/practices/_form.html.slim
@@ -20,7 +20,7 @@
         .form-item-file-input.js-file-input.a-file-input
           label.js-file-input__preview(for='practice_ogp_image')
             - if f.object.ogp_image.attached?
-              = image_tag f.object.ogp_image.variant(resize: '100x100')
+              = image_tag f.object.ogp_image.variant(resize_to_limit: [100, 100])
               p 画像を変更
             - else
               p 画像を選択
@@ -108,7 +108,7 @@
         .form-item-file-input.js-file-input.a-file-input
           label.js-file-input__preview(for='practice_completion_image')
             - if f.object.completion_image.attached?
-              = image_tag f.object.completion_image.variant(resize: '100x100')
+              = image_tag f.object.completion_image.variant(resize_to_limit: [100, 100])
               p 画像を変更
             - else
               p 画像を選択

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,6 @@ module Bootcamp
     end
 
     config.active_storage.resolve_model_to_route = :rails_storage_proxy
+    config.active_storage.variant_processor = :vips
   end
 end


### PR DESCRIPTION
## Issue

- #7330 

## 概要

`ImageMagick`という画像変換ライブラリから、`libvips`という画像変換ライブラリに移行する

(参考記事)
- https://qiita.com/p-baleine/items/e0eb7ea64b6cf34677dd
- https://qiita.com/west2538/items/da8c33749993d17c67e2

## 変更確認方法

1. `feature/change-imagemagick-to-libvips`をローカルに取り込む
2. `登録情報変更`でユーザアイコンを適当な画像を設定して更新する
3. 更新された画像を右クリックして「名前をつけて保存する」をする
4. 保存した画像の詳細情報を見る
5. 1~4をmainブランチ(同じ画像で！)やってみてリサイズに違いがあるかを調べる

## Screenshot

**変更前と後の両者を比較しました(左が今回の変更です)**

- png形式の画像です
[![Image from Gyazo](https://i.gyazo.com/181539faddef5dcc62e28cdc857b1168.png)](https://gyazo.com/181539faddef5dcc62e28cdc857b1168)

- jpeg形式の画像です
[![Image from Gyazo](https://i.gyazo.com/60e6dc73c1427a98b209f49e5a6ef484.png)](https://gyazo.com/60e6dc73c1427a98b209f49e5a6ef484)
