### PR TITLE
検索結果に、ユーザーの職業での検索結果も含めるように変更。

### DIFF
--- a/app/controllers/api/searchables_controller.rb
+++ b/app/controllers/api/searchables_controller.rb
@@ -4,7 +4,7 @@ class API::SearchablesController < API::BaseController
   PAGER_NUMBER = 50
 
   def index
-    result = Searcher.search(params[:word], document_type: document_type_param)
+    result = Searcher.search(params[:word], current_user, document_type: document_type_param)
     @searchables = Kaminari.paginate_array(result).page(params[:page]).per(PAGER_NUMBER)
   end
 

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -23,13 +23,13 @@ class Searcher
       searchables =
         case document_type
         when :all
-          result_for_all(word) + (search_user_job(word, current_user) || [])
+          result_for_all(word) + (search_users_by_job(word, current_user) || [])
         when commentable?
           result_for_comments(document_type, word)
         when :questions
           result_for_questions(document_type, word)
         when :users
-          result_for(document_type, word) + (search_user_job(word, current_user) || [])
+          result_for(document_type, word) + (search_users_by_job(word, current_user) || [])
         else
           result_for(document_type, word)
         end
@@ -78,7 +78,7 @@ class Searcher
       end
     end
 
-    def search_user_job(word, current_user)
+    def search_users_by_job(word, current_user)
       User.ransack(job_eq: USER_JOBS[word]).result if USER_JOBS.key?(word) && current_user.admin_or_mentor?
     end
   end

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -206,4 +206,23 @@ class SearchableTest < ActiveSupport::TestCase
     assert_includes(result, practices(:practice55))
     assert_not_includes(result, practices(:practice56))
   end
+
+  test 'returns search results by job' do
+    result = Searcher.search('学生', @test_user)
+    User.where(job: 'student').find_each do |user|
+      assert_includes result, user
+    end
+  end
+
+  test 'returns search results by job when user is mentor' do
+    result = Searcher.search('学生', users(:mentormentaro))
+    User.where(job: 'student').find_each do |user|
+      assert_includes result, user
+    end
+  end
+
+  test 'does not return search results by job when user is other than admin or mentor' do
+    result = Searcher.search('学生', users(:advijirou))
+    assert_empty result
+  end
 end

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -5,6 +5,10 @@ require 'test_helper'
 class SearchableTest < ActiveSupport::TestCase
   SEARCHABLE_CLASSES = [Report, Page, Practice, Question, Announcement, Event, RegularEvent, Comment, Answer, CorrectAnswer, User].freeze
 
+  setup do
+    @test_user = users(:komagata)
+  end
+
   def assert_includes_classes(results, *expected_classes)
     actual_classes = results.map(&:class).map(&:name).uniq
     expected_classes.each do |klass|
@@ -17,166 +21,166 @@ class SearchableTest < ActiveSupport::TestCase
   end
 
   test "returns all types when document_type argument isn't specified" do
-    results = Searcher.search('テスト')
+    results = Searcher.search('テスト', @test_user, document_type: :all)
     assert_includes_classes(results, Report, Page, Practice, Question, Announcement, Event, RegularEvent, Comment, Answer, CorrectAnswer, User)
   end
 
   test 'returns all types when document_type argument is :all' do
-    results = Searcher.search('テスト', document_type: :all)
+    results = Searcher.search('テスト', @test_user, document_type: :all)
     assert_includes_classes(results, Report, Page, Practice, Question, Announcement, Event, RegularEvent, Comment, Answer, CorrectAnswer, User)
   end
 
   test 'returns only report type when document_type argument is :reports' do
-    results = Searcher.search('テスト', document_type: :reports)
+    results = Searcher.search('テスト', @test_user, document_type: :reports)
     assert_includes_classes(results, Report, Comment)
   end
 
   test 'returns only page type when document_type argument is :pages' do
-    results = Searcher.search('テスト', document_type: :pages)
+    results = Searcher.search('テスト', @test_user, document_type: :pages)
     assert_includes_classes(results, Page)
   end
 
   test 'returns only practice type when document_type argument is :practices' do
-    results = Searcher.search('テスト', document_type: :practices)
+    results = Searcher.search('テスト', @test_user, document_type: :practices)
     assert_includes_classes(results, Practice)
   end
 
   test 'returns only question type when document_type argument is :questions' do
-    results = Searcher.search('テスト', document_type: :questions)
+    results = Searcher.search('テスト', @test_user, document_type: :questions)
     assert_includes_classes(results, Question, Answer, CorrectAnswer)
   end
 
   test 'returns only announcement type when document_type argument is :announcements' do
-    results = Searcher.search('テスト', document_type: :announcements)
+    results = Searcher.search('テスト', @test_user, document_type: :announcements)
     assert_includes_classes(results, Announcement, Comment)
   end
 
   test 'returns only event type when document_type argument is :events' do
-    results = Searcher.search('テスト', document_type: :events)
+    results = Searcher.search('テスト', @test_user, document_type: :events)
     assert_includes_classes(results, Event, Comment)
   end
 
   test 'returns only event type when document_type argument is :regular_events' do
-    results = Searcher.search('テスト', document_type: :regular_events)
+    results = Searcher.search('テスト', @test_user, document_type: :regular_events)
     assert_includes_classes(results, RegularEvent, Comment)
   end
 
   test 'returns only announcement type when document_type argument is :users' do
-    results = Searcher.search('テスト', document_type: :users)
+    results = Searcher.search('テスト', @test_user, document_type: :users)
     assert_includes_classes(results, User)
   end
 
   test 'sort search results in descending order of updated date' do
-    result = Searcher.search('検索結果確認用', document_type: :reports)
+    result = Searcher.search('検索結果確認用', @test_user, document_type: :reports)
     assert_equal [reports(:report12), reports(:report14), reports(:report13)], result
     assert_not_includes(result, Answer)
   end
 
   test 'returns only reports having all keywords' do
-    result = Searcher.search('日報', document_type: :reports)
+    result = Searcher.search('日報', @test_user, document_type: :reports)
     assert_includes(result, reports(:report9))
     assert_includes(result, reports(:report8))
 
-    result = Searcher.search('日報 WIP', document_type: :reports)
+    result = Searcher.search('日報 WIP', @test_user, document_type: :reports)
     assert_includes(result, reports(:report9))
     assert_not_includes(result, reports(:report8))
 
-    result = Searcher.search('日報　WIP', document_type: :reports)
+    result = Searcher.search('日報　WIP', @test_user, document_type: :reports)
     assert_includes(result, reports(:report9))
     assert_not_includes(result, reports(:report8))
   end
 
   test 'returns only pages having all keywords' do
-    result = Searcher.search('テスト', document_type: :pages)
+    result = Searcher.search('テスト', @test_user, document_type: :pages)
     assert_includes(result, pages(:page4))
     assert_includes(result, pages(:page3))
 
-    result = Searcher.search('テスト Bootcamp', document_type: :pages)
+    result = Searcher.search('テスト Bootcamp', @test_user, document_type: :pages)
     assert_includes(result, pages(:page4))
     assert_not_includes(result, pages(:page3))
 
-    result = Searcher.search('テスト　Bootcamp', document_type: :pages)
+    result = Searcher.search('テスト　Bootcamp', @test_user, document_type: :pages)
     assert_includes(result, pages(:page4))
     assert_not_includes(result, pages(:page3))
   end
 
   test 'returns only practices having all keywords' do
-    result = Searcher.search('OS', document_type: :practices)
+    result = Searcher.search('OS', @test_user, document_type: :practices)
     assert_includes(result, practices(:practice1))
     assert_includes(result, practices(:practice3))
 
-    result = Searcher.search('OS クリーンインストール', document_type: :practices)
+    result = Searcher.search('OS クリーンインストール', @test_user, document_type: :practices)
     assert_includes(result, practices(:practice1))
     assert_not_includes(result, practices(:practice3))
 
-    result = Searcher.search('OS　クリーンインストール', document_type: :practices)
+    result = Searcher.search('OS　クリーンインストール', @test_user, document_type: :practices)
     assert_includes(result, practices(:practice1))
     assert_not_includes(result, practices(:practice3))
   end
 
   test 'returns only questions having all keywords' do
-    result = Searcher.search('使う', document_type: :questions)
+    result = Searcher.search('使う', @test_user, document_type: :questions)
     assert_includes(result, questions(:question2))
     assert_includes(result, questions(:question1))
 
-    result = Searcher.search('使う エディター', document_type: :questions)
+    result = Searcher.search('使う エディター', @test_user, document_type: :questions)
     assert_includes(result, questions(:question1))
     assert_not_includes(result, questions(:question2))
 
-    result = Searcher.search('使う　エディター', document_type: :questions)
+    result = Searcher.search('使う　エディター', @test_user, document_type: :questions)
     assert_includes(result, questions(:question1))
     assert_not_includes(result, questions(:question2))
   end
 
   test 'returns only answers of questions having all keywords' do
-    result = Searcher.search('です', document_type: :questions)
+    result = Searcher.search('です', @test_user, document_type: :questions)
     assert_includes(result, answers(:answer1))
     assert_includes(result, answers(:answer5))
 
-    result = Searcher.search('です atom', document_type: :questions)
+    result = Searcher.search('です atom', @test_user, document_type: :questions)
     assert_includes(result, answers(:answer1))
     assert_not_includes(result, answers(:answer5))
 
-    result = Searcher.search('です　atom', document_type: :questions)
+    result = Searcher.search('です　atom', @test_user, document_type: :questions)
     assert_includes(result, answers(:answer1))
     assert_not_includes(result, answers(:answer5))
   end
 
   test 'returns only announcements having all keywords' do
-    result = Searcher.search('お知らせ', document_type: :announcements)
+    result = Searcher.search('お知らせ', @test_user, document_type: :announcements)
     assert_includes(result, announcements(:announcement3))
     assert_includes(result, announcements(:announcement_notification_active_user))
 
-    result = Searcher.search('お知らせ 通知', document_type: :announcements)
+    result = Searcher.search('お知らせ 通知', @test_user, document_type: :announcements)
     assert_includes(result, announcements(:announcement_notification_active_user))
     assert_not_includes(result, announcements(:announcement3))
 
-    result = Searcher.search('お知らせ　通知', document_type: :announcements)
+    result = Searcher.search('お知らせ　通知', @test_user, document_type: :announcements)
     assert_includes(result, announcements(:announcement_notification_active_user))
     assert_not_includes(result, announcements(:announcement3))
   end
 
   test 'returns only comments having all keywords' do
-    result = Searcher.search('report_id', document_type: :reports)
+    result = Searcher.search('report_id', @test_user, document_type: :reports)
     assert_includes(result, comments(:comment6))
     assert_includes(result, comments(:comment5))
 
-    result = Searcher.search('report_id typo', document_type: :reports)
+    result = Searcher.search('report_id typo', @test_user, document_type: :reports)
     assert_includes(result, comments(:comment6))
     assert_not_includes(result, comments(:comment5))
 
-    result = Searcher.search('report_id　typo', document_type: :reports)
+    result = Searcher.search('report_id　typo', @test_user, document_type: :reports)
     assert_includes(result, comments(:comment6))
     assert_not_includes(result, comments(:comment5))
   end
 
   test 'returns only comments associated to specified document_type' do
-    result = Searcher.search('コメント', document_type: :reports)
+    result = Searcher.search('コメント', @test_user, document_type: :reports)
     assert_equal [comments(:comment11)], result
   end
 
   test 'returns all comments when document_type is not specified' do
-    result = Searcher.search('コメント')
+    result = Searcher.search('コメント', @test_user)
     assert_includes(result, comments(:comment8))
     assert_includes(result, comments(:comment10))
     assert_includes(result, comments(:comment11))
@@ -188,17 +192,17 @@ class SearchableTest < ActiveSupport::TestCase
   end
 
   test 'can not search a comment of talk' do
-    assert_equal 0, Searcher.search('相談部屋').size
+    assert_equal 0, Searcher.search('相談部屋', @test_user).size
   end
 
   test 'returns only kimuras report when user param' do
-    result = Searcher.search('ユーザーネームで検索できるよ user:kimura')
+    result = Searcher.search('ユーザーネームで検索できるよ user:kimura', @test_user)
     assert_includes(result, reports(:report24))
     assert_not_includes(result, reports(:report25))
   end
 
   test 'returns only updated-by-komagata practice when user param' do
-    result = Searcher.search('ユーザーネーム（最終更新者）で検索できるよ user:komagata')
+    result = Searcher.search('ユーザーネーム（最終更新者）で検索できるよ user:komagata', @test_user)
     assert_includes(result, practices(:practice55))
     assert_not_includes(result, practices(:practice56))
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -336,13 +336,13 @@ class UserTest < ActiveSupport::TestCase
 
   test "don't return retired user data" do
     yameo = users(:yameo)
-    result = Searcher.search(yameo.name)
+    result = Searcher.search(yameo.name, yameo)
     assert_not_includes(result, yameo)
   end
 
   test 'return not retired user data' do
     hajime = users(:hajime)
-    result = Searcher.search(hajime.name)
+    result = Searcher.search(hajime.name, hajime)
     assert_includes(result, hajime)
   end
 


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7348

## 概要
- ログインユーザーが管理者 or メンター
- セレクトで "全て" or "ユーザー"を選択している
上記2つを満たす時、ユーザーでの職業での検索結果も含めるように変更。

**セレクトで全てを選択している場合**
これまでの検索結果に、職業での検索結果も含めて更新日順に並び替えて表示。

**セレクトでユーザーを選択している場合**
同上。
## 変更確認方法

1. `feature/allow-search-by-job`をローカルに取り込む
2. `bin/rails db:seed`
3. ID `advijirou`でログインし、登録情報の自己紹介に「学生」の文言追加。
http://localhost:3000/current_user/edit
※職業のワードで検索した時、職業検索結果以外の検索結果も含まれること確認するため。
4. ID `machida`（`komagata`でも可）でログインし、学生で検索。職業でも検索されることを確認。
5. ID `mentormentaro`でログインし、4と同様に確認。
他のワードでも確かめる場合は、「学生」を以下に置き換える。
- 会社員
- フリーター
- 休職中
- 働いていない

## Screenshot
ワードが学生の場合。

### 変更前
<img width="60%" alt="スクリーンショット 2024-02-17 13 55 32" src="https://github.com/fjordllc/bootcamp/assets/106903482/dd21819d-45cd-40b8-a7a6-06b261bbdd9d">


### 変更後
<img width="60%" alt="スクリーンショット 2024-02-17 13 54 52" src="https://github.com/fjordllc/bootcamp/assets/106903482/8b748dfb-ca71-4887-b09b-d7179d13895d">


