### PR TITLE
企業情報ページに管理者のみが登録・閲覧・編集できるメモを実装

### DIFF
--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -51,7 +51,8 @@ class Admin::CompaniesController < AdminController
       :description,
       :website,
       :logo,
-      :blog_url
+      :blog_url,
+      :memo
     )
   end
 end

--- a/app/javascript/stylesheets/application/blocks/cards/_card-counts.sass
+++ b/app/javascript/stylesheets/application/blocks/cards/_card-counts.sass
@@ -1,7 +1,7 @@
 .card-counts
   &.is-user
     +media-breakpoint-up(md)
-      margin-bottom: 2rem
+      margin-bottom: 1.5rem
     +media-breakpoint-down(sm)
       margin-bottom: 1.25rem
 

--- a/app/javascript/stylesheets/application/blocks/company/_company-profile.sass
+++ b/app/javascript/stylesheets/application/blocks/company/_company-profile.sass
@@ -37,3 +37,9 @@
 
 .company-profile__body
   padding: 1rem
+
+.company-profile__description
+  +media-breakpoint-up(md)
+    font-size: .9375rem
+  +media-breakpoint-down(sm)
+    font-size: .8125rem

--- a/app/javascript/stylesheets/application/blocks/company/_company-profile.sass
+++ b/app/javascript/stylesheets/application/blocks/company/_company-profile.sass
@@ -37,4 +37,3 @@
 
 .company-profile__body
   padding: 1rem
-  border-top: solid 1px var(--border-tint)

--- a/app/javascript/stylesheets/application/blocks/user/_user-data.sass
+++ b/app/javascript/stylesheets/application/blocks/user/_user-data.sass
@@ -13,10 +13,12 @@
 
 .user-data__description
   flex: 0 0 100%
+  +media-breakpoint-up(md)
+    font-size: .9375rem
+  +media-breakpoint-down(sm)
+    font-size: .8125rem
   p
-    +text-block(.875rem 1.8 0 .8em)
-    +media-breakpoint-down(sm)
-      font-size: .8125rem
+    +text-block(1em 1.8 0 .8em)
     &:last-child
       margin-bottom: 0
 

--- a/app/javascript/stylesheets/application/blocks/user/_user-profile.sass
+++ b/app/javascript/stylesheets/application/blocks/user/_user-profile.sass
@@ -9,3 +9,9 @@
     +size(5rem)
   +media-breakpoint-down(sm)
     +size(4rem)
+
+.user-company-profile__description
+  +media-breakpoint-up(md)
+    font-size: .9375rem
+  +media-breakpoint-down(sm)
+    font-size: .8125rem

--- a/app/javascript/stylesheets/atoms/_a-placeholder.sass
+++ b/app/javascript/stylesheets/atoms/_a-placeholder.sass
@@ -66,7 +66,7 @@
     background-color: transparent
     p
       background-color: var(--placeholder)
-      height: 1.2em
+      height: auto
       margin-bottom: 0
       &:not(:first-child)
         margin-top: .5em

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -5,7 +5,7 @@
       = f.text_field :name, class: 'a-text-input'
     .form-item
       = f.label :description, class: 'a-form-label'
-      = f.text_area :description, size: '10x20', class: 'a-text-input'
+      = f.text_area :description, class: 'a-text-input'
     .form-item
       = f.label :website, class: 'a-form-label'
       = f.text_field :website, class: 'a-text-input'
@@ -25,9 +25,9 @@
       .a-form-help
         p
           | 正方形に切り抜かれるので、正方形で加工したものをアップロードする必要があります。
-    .form-item
+    .form-item#company_memo
       = f.label :memo, class: 'a-form-label'
-      = f.text_area :memo, size: '10x20', class: 'a-text-input'
+      = f.text_area :memo, class: 'a-text-input'
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main

--- a/app/views/admin/companies/_form.html.slim
+++ b/app/views/admin/companies/_form.html.slim
@@ -25,6 +25,9 @@
       .a-form-help
         p
           | 正方形に切り抜かれるので、正方形で加工したものをアップロードする必要があります。
+    .form-item
+      = f.label :memo, class: 'a-form-label'
+      = f.text_area :memo, size: '10x20', class: 'a-text-input'
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -19,7 +19,3 @@
         .companies-item__body-row
           .companies-item__description.a-short-text
             = simple_format(company.description)
-        - if current_user.admin?
-          .companies-item__body-row
-            .companies-item__description.a-short-text
-              = simple_format(company.memo)

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -19,3 +19,7 @@
         .companies-item__body-row
           .companies-item__description.a-short-text
             = simple_format(company.description)
+        - if current_user.admin?
+          .companies-item__body-row
+            .companies-item__description.a-short-text
+              = simple_format(company.memo)

--- a/app/views/companies/_profile.html.slim
+++ b/app/views/companies/_profile.html.slim
@@ -1,19 +1,21 @@
+header.page-content-header
+  .page-content-header__start
+    .page-content-header__user
+      = link_to company, class: 'page-content-header__user-link' do
+        = image_tag company.logo_url, title: company.name, alt: company.name, class: 'company-profile__logo-image a-user-icon'
+
+  .page-content-header__end
+    .page-content-header__row
+      h1.page-content-header__title
+        = company.name
+    .page-content-header__row
+      = render 'links', company: company
+
+= render 'user_counts', users: company.users
+
 .a-card.is-user
   .company-profile
-    header.company-profile__header
-      .company-profile__header-inner
-        .company-profile__header-start
-          .company-profile__logo
-            = image_tag company.logo_url, title: company.name, alt: company.name, class: 'company-profile__logo-image a-user-icon'
-        .company-profile__header-end
-          h1.company-profile__name
-            = company.name
-          .companies-item__body-row
-            = render 'links', company: company
-
     .company-profile__body
-      .companies-item__body-row
-        = render 'user_counts', users: company.users
       .companies-item__body-row
         .companies-item__description.a-short-text
           = simple_format(company.description)

--- a/app/views/companies/_profile.html.slim
+++ b/app/views/companies/_profile.html.slim
@@ -17,6 +17,10 @@
       .companies-item__body-row
         .companies-item__description.a-short-text
           = simple_format(company.description)
+      - if current_user.admin?
+        .companies-item__body-row
+          .companies-item__description.a-short-text
+            = simple_format(company.memo)
 
   - if current_user.admin?
     hr.a-border-tint

--- a/app/views/companies/_profile.html.slim
+++ b/app/views/companies/_profile.html.slim
@@ -16,14 +16,8 @@ header.page-content-header
 .a-card.is-user
   .company-profile
     .company-profile__body
-      .companies-item__body-row
-        .companies-item__description.a-short-text
-          = simple_format(company.description)
-      - if current_user.admin?
-        .companies-item__body-row
-          .companies-item__description.a-short-text
-            = simple_format(company.memo)
-
+      .company-profile__description.a-long-text
+        = simple_format(company.description)
   - if current_user.admin?
     hr.a-border-tint
     footer.card-footer.is-only-mentor

--- a/app/views/companies/_user_counts.html.slim
+++ b/app/views/companies/_user_counts.html.slim
@@ -1,4 +1,4 @@
-.card-counts.is-users
+.card-counts.is-user
   dl.card-counts__items
     - unless users.mentor.empty?
       .card-counts__item

--- a/app/views/companies/show.html.slim
+++ b/app/views/companies/show.html.slim
@@ -20,5 +20,7 @@ header.page-header
   .container.is-xl
     .columns
       .row
-        .col-xxl-6.col-lg-5.col-xs-12
+        .col-xs-12.col-lg-6.col-xxl-6
           = render 'companies/profile', company: @company
+        .col-xs-12.col-lg-6.col-xxl-6
+          | aasaa

--- a/app/views/companies/show.html.slim
+++ b/app/views/companies/show.html.slim
@@ -33,7 +33,7 @@ header.page-header
                 .card__description
                   - if @company.memo.present?
                     .a-long-text.is-md.a-placeholder
-                      = simple_format(company.memo)
+                      = simple_format(@company.memo)
                   - else
                     .o-empty-message
                       .o-empty-message__icon

--- a/app/views/companies/show.html.slim
+++ b/app/views/companies/show.html.slim
@@ -32,7 +32,7 @@ header.page-header
               .card-body
                 .card__description
                   - if @company.memo.present?
-                    .a-long-text.is-md.a-placeholder
+                    .a-long-text.is-md
                       = simple_format(@company.memo)
                   - else
                     .o-empty-message

--- a/app/views/companies/show.html.slim
+++ b/app/views/companies/show.html.slim
@@ -23,4 +23,28 @@ header.page-header
         .col-xs-12.col-lg-6.col-xxl-6
           = render 'companies/profile', company: @company
         .col-xs-12.col-lg-6.col-xxl-6
-          | aasaa
+          - if current_user.admin?
+            section.a-card.is-memo.is-only-mentor
+              header.card-header.is-sm
+                h2.card-header__title
+                  | 管理者向け企業メモ
+              hr.a-border-tint
+              .card-body
+                .card__description
+                  - if @company.memo.present?
+                    .a-long-text.is-md.a-placeholder
+                      = simple_format(company.memo)
+                  - else
+                    .o-empty-message
+                      .o-empty-message__icon
+                        i.fa-regular.fa-sad-tear
+                      .o-empty-message__text
+                        | 企業メモはまだありません。
+              hr.a-border-tint
+              footer.card-footer
+                .card-main-actions
+                  .card-main-actions__items
+                    .card-main-actions__item
+                      = link_to edit_admin_company_path(anchor: 'company_memo'), class: 'card-footer-actions__action a-button is-sm is-secondary is-block' do
+                        i.fa-solid.fa-pen
+                        | 編集

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -145,6 +145,7 @@ ja:
         website: ウェブサイト
         logo: ロゴ
         blog_url: Techブログ
+        memo: 管理者向けメモ
       category:
         name: 名前
         slug: URLスラッグ

--- a/db/migrate/20240211080647_add_memo_to_companies.rb
+++ b/db/migrate/20240211080647_add_memo_to_companies.rb
@@ -1,0 +1,5 @@
+class AddMemoToCompanies < ActiveRecord::Migration[6.1]
+  def change
+    add_column :companies, :memo, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 2024_02_28_105218) do
     t.datetime "updated_at"
     t.text "tos"
     t.string "blog_url"
+    t.text "memo"
   end
 
   create_table "courses", force: :cascade do |t|

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -80,4 +80,22 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
       assert_selector 'td.company-name', text: '【created_at降順確認】最古株式会社'
     end
   end
+
+  test 'don\'t show adomin memo on company show' do
+    visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
+    fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'
+    click_button '更新する'
+    visit_with_auth company_path(companies(:company1)), 'mentormentaro'
+
+    assert_no_text '管理者のみが閲覧できるメモです。。'
+  end
+
+  test 'don\'t show adomin memo on company index' do
+    visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
+    fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'
+    click_button '更新する'
+    visit_with_auth users_companies_path, 'kimura'
+
+    assert_no_text '管理者のみが閲覧できるメモです。'
+  end
 end

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -81,6 +81,15 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
     end
   end
 
+  test 'show admin memo on company show' do
+    visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
+    fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'
+    click_button '更新する'
+    visit_with_auth company_path(companies(:company1)), 'komagata'
+
+    assert_text '管理者のみが閲覧できるメモです。'
+  end
+
   test 'don\'t show adomin memo on company show' do
     visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
     fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -90,20 +90,11 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
     assert_text '管理者のみが閲覧できるメモです。'
   end
 
-  test 'don\'t show adomin memo on company show' do
+  test 'admin memo not shown on company show' do
     visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
     fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'
     click_button '更新する'
     visit_with_auth company_path(companies(:company1)), 'mentormentaro'
-
-    assert_no_text '管理者のみが閲覧できるメモです。。'
-  end
-
-  test 'don\'t show adomin memo on company index' do
-    visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
-    fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'
-    click_button '更新する'
-    visit_with_auth users_companies_path, 'kimura'
 
     assert_no_text '管理者のみが閲覧できるメモです。'
   end

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -85,12 +85,8 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
     end
   end
 
-  test 'admin memo not shown on company show' do
-    visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
-    fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'
-    click_button '更新する'
+  test 'admin memo is not visible to non-admin users' do
     visit_with_auth company_path(companies(:company1)), 'mentormentaro'
-
-    assert_no_text '管理者のみが閲覧できるメモです。'
+    assert_no_text '管理者向け企業メモ'
   end
 end

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -16,9 +16,13 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
       fill_in 'company[description]', with: 'テストの企業です。'
       fill_in 'company[website]', with: 'https://example.com'
       fill_in 'company[blog_url]', with: 'https://example.com'
+      fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'
       click_button '登録する'
     end
     assert_text '企業を作成しました。'
+
+    visit_with_auth company_path(Company.last), 'komagata'
+    assert_text '管理者のみが閲覧できるメモです。'
   end
 
   test 'update company' do
@@ -79,15 +83,6 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
     within all('.admin-table__item').last do
       assert_selector 'td.company-name', text: '【created_at降順確認】最古株式会社'
     end
-  end
-
-  test 'show admin memo on company show' do
-    visit_with_auth "/admin/companies/#{companies(:company1).id}/edit", 'komagata'
-    fill_in 'company[memo]', with: '管理者のみが閲覧できるメモです。'
-    click_button '更新する'
-    visit_with_auth company_path(companies(:company1)), 'komagata'
-
-    assert_text '管理者のみが閲覧できるメモです。'
   end
 
   test 'admin memo not shown on company show' do


### PR DESCRIPTION
## Issue

[企業に"管理者メモ"が欲しい #7341](https://github.com/fjordllc/bootcamp/issues/7341)

## 概要
企業情報ページに管理者のみが登録・閲覧・編集できるメモを実装する。
#### 主なユースケース
- 研修全体の管理者（研修に問題があった時連絡する人）を記載する
- 企業特有の問題（内定者研修でのみ利用するなど）を記載する

## 変更確認方法

1. `feature/add-admin-memo-to-company-info`をローカルに取り込む
2. bootcamp を起動する`foreman start -f Procfile.dev`
3. 管理者でログインする
4. 任意の企業情報ページを開く`http://localhost:3000/companies/id`
5. 管理者向けメモを登録し、登録したメモが表示されるかを確認する。
7. 管理者以外でログインして、上記ページで管理者向けメモが表示されないことも確認する。

## Screenshot
### 企業詳細画面 `http://localhost:3000/companies/id`
#### 変更前
<img width="800" alt="2-1-1_development__MaruMaru_Inc_の企業情報___FBC" src="https://github.com/fjordllc/bootcamp/assets/83388876/41b6d191-e5ae-48a9-91e2-144a6847cd74">

### 変更後
<img width="1409" alt="10_development__MaruMaru_Inc_の企業情報___FBC" src="https://github.com/fjordllc/bootcamp/assets/83388876/aa248d80-ec2f-4832-b199-22071fbba5f5">

### 企業編集画面 `http://localhost:3000/admin/companies/id/edit`
#### 変更前
<img width="800" alt="2-1-2_development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/83388876/3d5b846b-a1c2-476d-9837-348c161b545f">

#### 変更後
<img width="800" alt="2-2-2Cursor_と__development__管理ページ___FBC" src="https://github.com/fjordllc/bootcamp/assets/83388876/91823d32-c87f-404e-836d-5505d64efafd">



