### PR TITLE
管理者でユーザー情報を変更したときのリダイレクト先をそのユーザーのプロフィールページに変更

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -24,7 +24,7 @@ class Admin::UsersController < AdminController
     if @user.update(user_params)
       destroy_subscription(@user)
       Newspaper.publish(:retirement_create, { user: @user }) if @user.saved_change_to_retired_on?
-      redirect_to admin_users_url, notice: 'ユーザー情報を更新しました。'
+      redirect_to user_url(@user), notice: 'ユーザー情報を更新しました。'
     else
       render :edit
     end


### PR DESCRIPTION
## Issue

- #7322

## 概要

管理者がユーザー情報を変更したときのリダイレクト先を、管理者のユーザー一覧ページから、編集を加えたユーザーのプロフィールページに変更しました。

## 変更確認方法

1. feature/editing-user-information-redirects-to-profile-pageをローカルに取り込む
2. ローカル環境を立ち上げる
3. 管理者でログインする
4. 任意のユーザーのプロフィールページを開き、「管理者として情報変更」ボタンを押下する
5. ユーザー登録情報変更ページで、「更新する」ボタンを押下する
6. リダイレクト先が、登録情報を編集していたユーザーのプロフィールページであることを確認する

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/151989679/831abdc4-0357-4fb1-832d-5b1007b75a9e)

↓　「更新する」ボタンを押下する

![image](https://github.com/fjordllc/bootcamp/assets/151989679/f3257a4b-809d-4a82-8415-7b1dd10c9b2a)

### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/151989679/9e940c94-4a6d-4846-b1a5-19f82afbae1e)

↓　「更新する」ボタンを押下する

![image](https://github.com/fjordllc/bootcamp/assets/151989679/6b80185e-d754-4388-bfcf-55184337ee4e)


