### PR TITLE
管理者側のユーザー一覧にある項目を変更

### DIFF
--- a/app/javascript/stylesheets/application/blocks/admin/_admin-table.sass
+++ b/app/javascript/stylesheets/application/blocks/admin/_admin-table.sass
@@ -93,12 +93,12 @@
 .admin-table__user
   display: inline-flex
   align-items: center
-  flex-wrap: wrap
   gap: .25rem .25rem
 
 .admin-table__user-icon
   +size(2.125rem)
   display: inline-block
+  flex: 0 0 2.125rem
   &:not(:last-child)
     margin-right: .5rem
 

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -27,7 +27,7 @@
     tbody.admin-table__items
       - users.each do |user|
         - next if params[:target] == 'campaign' && user.adviser?
-        tr.admin-table__item class="#{user.retired_on? ? 'is-retired' : ''} #{user.hibernated? ? 'is-retired' : ''}"
+        tr.admin-table__item class="text-center #{user.retired_on? ? 'is-retired' : ''} #{user.hibernated? ? 'is-retired' : ''}"
           td.admin-table__item-value
             - if user.admin? && user.mentor?
               span.admin-table__role
@@ -63,41 +63,44 @@
               span.admin-table__role
                 | 現役生
             - if !user.active? && (!user.hibernated? || !user.retired_on?)
+                br
                 span.a-badge.is-secondary.is-xs
                   | 非ア
-          td.admin-table__item-value
+          td.admin-table__item-value.text-left
             = link_to user, class: 'admin-table__user', target: '_blank', rel: 'noopener' do
-              span(class="a-user-role  is-#{user.primary_role}")
-                = image_tag user.avatar_url, title: user.icon_title, class: 'admin-table__user-icon a-user-icon'
+              span.admin-table__user-icon
+                span(class="a-user-role is-#{user.primary_role}")
+                  = image_tag user.avatar_url, title: user.icon_title, class: 'admin-table__user-icon a-user-icon'
               span.admin-table__user-login-name
                 = user.login_name
                 | （#{user.name}）
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
             = user.email
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
             - if user.company.present?
               = user.company.name
             - else
               | -
-          td.admin-table__item-value.is-text-align-center
-            - if user.job
-              = t("activerecord.enums.user.job.#{user.job}")
-            - else
-              | 回答なし
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
+            span.whitespace-nowrap
+              - if user.job
+                = t("activerecord.enums.user.job.#{user.job}")
+              - else
+                | 回答なし
+          td.admin-table__item-value.text-center
             - if user.discord_profile.present?
               = user.discord_profile.account_name || '-'
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
             - if user.last_activity_at?
               = l user.last_activity_at
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
             = l user.created_at
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
             - if user.talk
-              = link_to '相談部屋', talk_url(user.talk, anchor: 'latest-comment')
+              = link_to '相談部屋', talk_url(user.talk, anchor: 'latest-comment'), class: 'whitespace-nowrap'
             - else
               | -
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
             - if user.card?
               = link_to user.customer_url,
                 class: 'a-button is-sm is-success is-icon',
@@ -105,7 +108,7 @@
                 i.fa-solid.fa-credit-card
             - else
               | -
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
             - if user.subscription_id?
               = link_to user.subscription_url,
                 class: 'subscription-status',
@@ -115,7 +118,7 @@
                 i.fa-solid.fa-spinner.fa-pulse
             - else
               | -
-          td.admin-table__item-value.is-text-align-center
+          td.admin-table__item-value.text-center
             = link_to edit_admin_user_path(user), id: "edit-#{user.id}", class: 'a-button is-sm is-secondary is-icon' do
               i.fa-solid.fa-pen
 

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -11,6 +11,7 @@
         th.admin-table__label
           | 企業
           = render 'sort_column', order_by: 'company_id', direction: direction, target: @target
+        th.admin-table__label 職業
         th.admin-table__label Discord
         th.admin-table__label
           |
@@ -19,10 +20,9 @@
         th.admin-table__label
           | 登録日時
           = render 'sort_column', order_by: 'created_at', direction: direction, target: @target
+        th.admin-table__label 相談部屋
         th.admin-table__label カード登録
         th.admin-table__label サブスク
-        th.admin-table__label 卒業
-        th.admin-table__label 外部サービス
         th.admin-table__label 操作
     tbody.admin-table__items
       - users.each do |user|
@@ -80,6 +80,11 @@
             - else
               | -
           td.admin-table__item-value.is-text-align-center
+            - if user.job
+              = t("activerecord.enums.user.job.#{user.job}")
+            - else
+              | 回答なし
+          td.admin-table__item-value.is-text-align-center
             - if user.discord_profile.present?
               = user.discord_profile.account_name || '-'
           td.admin-table__item-value.is-text-align-center
@@ -87,6 +92,8 @@
               = l user.last_activity_at
           td.admin-table__item-value.is-text-align-center
             = l user.created_at
+          td.admin-table__item-value.is-text-align-center
+            = link_to "相談部屋", talk_path(user.talk)
           td.admin-table__item-value.is-text-align-center
             - if user.card?
               = link_to user.customer_url,
@@ -105,23 +112,6 @@
                 i.fa-solid.fa-spinner.fa-pulse
             - else
               | -
-          td.admin-table__item-value.is-text-align-center
-            - if user.graduated_on?
-              .a-button.is-sm.is-disabled
-                | 卒業済
-            - else
-              = link_to '卒業', user_graduation_path(user), method: :patch, data: { confirm: '本当によろしいですか？' }, class: 'a-button is-sm is-primary'
-          td.admin-table__item-value.is-text-align-center
-            - if user.github_collaborator?
-              = link_to 'https://github.com/orgs/fjordllc/people', class: 'a-button is-sm is-warning is-icon', target: '_blank', rel: 'noopener' do
-                i.fa-brands.fa-github-alt
-            - else
-              .a-button.is-sm.is-disabled.is-icon
-                i.fa-brands.fa-github-alt
-            - if user.retired_on? && user.github_collaborator?
-              .admin-table__item-block-link-container
-                = link_to edit_admin_user_path(user, anchor: 'external-services') do
-                  | 外部サービス設定変更
           td.admin-table__item-value.is-text-align-center
             = link_to edit_admin_user_path(user), id: "edit-#{user.id}", class: 'a-button is-sm is-secondary is-icon' do
               i.fa-solid.fa-pen

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -93,7 +93,7 @@
           td.admin-table__item-value.is-text-align-center
             = l user.created_at
           td.admin-table__item-value.is-text-align-center
-            = link_to "相談部屋", talk_path(user.talk)
+            = link_to '相談部屋', talk_path(user.talk)
           td.admin-table__item-value.is-text-align-center
             - if user.card?
               = link_to user.customer_url,

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -93,7 +93,10 @@
           td.admin-table__item-value.is-text-align-center
             = l user.created_at
           td.admin-table__item-value.is-text-align-center
-            = link_to '相談部屋', talk_path(user.talk)
+            - if user.talk
+              = link_to '相談部屋', talk_url(user.talk, anchor: 'latest-comment')
+            - else
+              | -
           td.admin-table__item-value.is-text-align-center
             - if user.card?
               = link_to user.customer_url,


### PR DESCRIPTION
## Issue

- #7410

## 概要

管理者側のユーザー一覧にある項目を変更しました。
「職業」と「相談部屋」のカラムが追加され、「卒業」と「外部サービス」のカラムは削除されました。
「相談部屋」カラムのリンクをクリックすると、当該ユーザーの相談部屋に遷移するようになっています。

## 変更確認方法

1. fearure/modify-user-list-item-in-admin-pageをローカルに取り込む
2. admin/users/ にアクセスする
3. 「職業」および「相談部屋」のカラムが表示されていることを確認する
4. 「卒業」および「外部サービス」のカラムが表示されていないことを確認する
5. 「相談部屋」カラムのリンクをクリックすると、当該ユーザーの相談部屋に遷移することを確認する

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/151989679/c41cfc6e-661a-4d45-af62-f879e6a3de67)

### 変更後

![image](https://github.com/fjordllc/bootcamp/assets/151989679/88d9488a-a7f2-4fdb-a29a-0ad8be85c6d8)
