### PR TITLE
管理ページトップのタイトルのマークアップをh1に変更した

### DIFF
--- a/app/views/admin/home/index.html.slim
+++ b/app/views/admin/home/index.html.slim
@@ -3,7 +3,7 @@
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title = title
+      h1.page-header__title = title
 
 = render 'admin/admin_page_tabs'
 


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7370

## 概要
管理ページトップのタイトルのマークアップを`h2`から`h1`に変更しました。

## 変更確認方法

1. `feature/change-markup-for-title-at-top-of-admin-page`をローカルに取り込む。
2. サーバーを立ち上げる。
3. `komagata`でログインし、`/admin/`にアクセスする。
4. ブラウザのデベロッパーツールでタイトルのマークアップを確認する。

## Screenshot

### 変更前
![スクリーンショット 2024-02-21 194229](https://github.com/fjordllc/bootcamp/assets/125527162/c42d9c26-5528-477b-a667-4f2850dbe668)


### 変更後


![スクリーンショット 2024-02-21 195658](https://github.com/fjordllc/bootcamp/assets/125527162/8bb43096-0ef8-4b14-8f7b-a9690cd2f4ec)

