### PR TITLE
welcomeメールのbccにinfo@lokka.jpを追加

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,7 +9,7 @@ class UserMailer < ApplicationMailer
 
   def welcome(user)
     @user = user
-    mail to: user.email, subject: '[FBC] フィヨルドブートキャンプへようこそ'
+    mail to: user.email, bcc: 'info@lokka.jp', subject: '[FBC] フィヨルドブートキャンプへようこそ'
   end
 
   def retire(user)


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7393

## 概要
ユーザが入会した時に届くwelcomeメールにbccを追加し、info@lokka.jpにもメールが送られるようにしました。

## 変更確認方法

1. `add-bcc-to-welcome-mail`をローカルに取り込む
2. サーバーを立ち上げる。
3. ログインしている場合は、ログアウトする。
4. フィヨルドブートキャンプ参加登録ページ(/users/new)にアクセスし、必要な情報を入力し「参加する」をクリックし、新規ユーザーを登録する。(有効なカード番号は、[sign_up_test.rb](https://github.com/fjordllc/bootcamp/blob/d57bb4cdc3b45c577c21f651d6b51fe85df3f9ce/test/system/sign_up_test.rb#L33) を参照)
5. LetterOpenerWeb(/letter_opener/)にアクセスし、「[FBC] フィヨルドブートキャンプへようこそ」というSubjectのメールを開く。
6. bccが追加され、宛先が`info@lokka.jp`であることを確認する。
## Screenshot

### 変更前
![#7393変更前](https://github.com/fjordllc/bootcamp/assets/125527162/796f5279-f948-4021-a9d3-62586818c9a1)

### 変更後
![#7393変更後](https://github.com/fjordllc/bootcamp/assets/125527162/859d4f24-aea7-490b-b9df-fe4ace2f5173)

