### PR TITLE
ユーザー検索で休会・退会ユーザーも引っかかるようにする

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -43,6 +43,7 @@ class API::UsersController < API::BaseController
     # search_by_keywords内では { unretired } というスコープが設定されている
     # 退会したユーザーに対しキーワード検索を行う場合は、一旦 unscope(where: :retired_on) で { unretired } スコープを削除し、その後で retired スコープを設定する必要がある
     target == 'retired' ? users.unscope(where: :retired_on).retired : users
+    target == 'all' ? users.unscope(where: %i[retired_on hibernated_at]) : users
   end
 
   def target_allowlist

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -13,7 +13,7 @@ module Searchable
   # rubocop:disable Metrics/BlockLength
   class_methods do
     def search_by_keywords(searched_values = {})
-      ransack(**params_for_keyword_search(searched_values)).result.search_by_keywords_scope
+      ransack(**params_for_keyword_search(searched_values)).result
     end
 
     def columns_for_keyword_search(*column_names)

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -5,10 +5,10 @@ module Searchable
 
   COLUMN_NAMES_FOR_SEARCH_USER_ID = %i[user_id last_updated_user_id].freeze
 
-  included do
-    # 拡張する場合はこのスコープを上書きする
-    scope :search_by_keywords_scope, -> { all }
-  end
+  # included do
+  # 拡張する場合はこのスコープを上書きする
+  #   scope :search_by_keywords_scope, -> { all }
+  # end
 
   # rubocop:disable Metrics/BlockLength
   class_methods do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -371,7 +371,7 @@ class User < ApplicationRecord
       .order(last_activity_at: :desc)
       .tagged_with(tag_name)
   }
-  scope :search_by_keywords_scope, -> { unretired }
+  # scope :search_by_keywords_scope, -> { unretired }
   scope :delayed, lambda {
     sql = Learning.select(:user_id, 'MAX(updated_at) AS completed_at')
                   .where(status: :complete)

--- a/test/models/search_user_test.rb
+++ b/test/models/search_user_test.rb
@@ -17,7 +17,7 @@ class SearchUserTest < ActiveSupport::TestCase
     yameo = users(:yameo)
     search_user = SearchUser.new(word: 'yame', require_retire_user: false)
 
-    assert_not_includes search_user.search, yameo
+    assert_includes search_user.search, yameo
   end
 
   test 'retired user is included when required' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -363,7 +363,7 @@ class UserTest < ActiveSupport::TestCase
     assert Following.find_by(follower_id: kimura.id, followed_id: hatsuno.id)
   end
 
-  test "return retired user data" do
+  test 'return retired user data' do
     yameo = users(:yameo)
     result = Searcher.search(yameo.name)
     assert_includes(result, yameo)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -363,10 +363,10 @@ class UserTest < ActiveSupport::TestCase
     assert Following.find_by(follower_id: kimura.id, followed_id: hatsuno.id)
   end
 
-  test "don't return retired user data" do
+  test "return retired user data" do
     yameo = users(:yameo)
     result = Searcher.search(yameo.name)
-    assert_not_includes(result, yameo)
+    assert_includes(result, yameo)
   end
 
   test 'return not retired user data' do


### PR DESCRIPTION
## Issue
- #7396
## 概要
ユーザー検索で休会・退会ユーザーも引っかかるようにする
## 変更確認方法
1. `feature/searchable_suspended_and_unsubscribed_users`をローカルに取り込む
2. メンターでログインをする
3. `http://localhost:3000/users`にアクセスし、ユーザー一覧を表示する
4. 「全員」タブを選択する
5. 検索欄から休会ユーザー名、退会ユーザー名を検索して表示されることを確認する（ユーザー例: yameo, kyuukai）
6. 右上の検索バーから休会ユーザー名、退会ユーザー名を検索して表示されることを確認する（ユーザー例: yameo, kyuukai）
※ 右上の検索バーから休会ユーザー名は元々表示されます。
## Screenshot
### 変更前
<img width="1172" alt="スクリーンショット 2024-02-25 19 22 49" src="https://github.com/fjordllc/bootcamp/assets/57862327/7bafc8f2-0f7f-4291-b934-61a08e72a73d">
<img width="1115" alt="スクリーンショット 2024-02-25 19 23 04" src="https://github.com/fjordllc/bootcamp/assets/57862327/38e6bdd1-b8ad-4506-81dc-159f7022bdd8">
<img width="1225" alt="スクリーンショット 2024-02-25 19 24 00" src="https://github.com/fjordllc/bootcamp/assets/57862327/b790b3de-161c-4775-82e2-ff80cfb89007">
<img width="1236" alt="スクリーンショット 2024-02-25 19 24 13" src="https://github.com/fjordllc/bootcamp/assets/57862327/d4798d89-3c9e-471e-9023-c1ae12a8760b">

### 変更後
<img width="1354" alt="スクリーンショット 2024-02-25 19 17 38" src="https://github.com/fjordllc/bootcamp/assets/57862327/1964609c-69b1-4076-ab39-e07d802e1479">
<img width="1361" alt="スクリーンショット 2024-02-25 19 17 52" src="https://github.com/fjordllc/bootcamp/assets/57862327/8d99469d-9e44-4552-bc7e-0705ee6e2865">
<img width="1222" alt="スクリーンショット 2024-02-25 19 19 48" src="https://github.com/fjordllc/bootcamp/assets/57862327/50444d41-5c4b-4c9e-89e7-fc05a24ef992">
<img width="1214" alt="スクリーンショット 2024-02-25 19 20 04" src="https://github.com/fjordllc/bootcamp/assets/57862327/5455df24-41ff-4862-893a-1fbd5e10407f">

