### PR TITLE
お知らせ通知を高速化する

### DIFF
--- a/app/jobs/post_announcement_job.rb
+++ b/app/jobs/post_announcement_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PostAnnouncementJob < ApplicationJob
+  queue_as :default
+
+  def perform(announcement, receivers)
+    receivers.each do |receiver|
+      ActivityDelivery.with(announcement:, receiver:).notify!(:post_announcement)
+    end
+  end
+end

--- a/app/models/announcement_notifier.rb
+++ b/app/models/announcement_notifier.rb
@@ -9,11 +9,7 @@ class AnnouncementNotifier
     DiscordNotifier.with(announce: announcement).announced.notify_now
     Watch.create!(user: announcement.user, watchable: announcement)
 
-    target_users = User.announcement_receiver(announcement.target)
-    target_users.each do |target|
-      next if announcement.sender == target
-
-      ActivityDelivery.with(announcement:, receiver: target).notify(:post_announcement)
-    end
+    receivers = User.announcement_receiver(announcement.target).reject { |receiver| receiver == announcement.sender }
+    PostAnnouncementJob.perform_later(announcement, receivers)
   end
 end

--- a/test/jobs/post_announcement_job_test.rb
+++ b/test/jobs/post_announcement_job_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PostAnnouncementJobTest < ActiveJob::TestCase
+  teardown do
+    ActionMailer::Base.deliveries.clear
+    AbstractNotifier::Testing::Driver.deliveries.clear
+  end
+
+  test '#perform' do
+    announcement = announcements(:announcement1)
+    receivers = [users(:machida), users(:adminonly), users(:sotugyou_with_job)]
+
+    assert_difference [-> { ActionMailer::Base.deliveries.count }, -> { AbstractNotifier::Testing::Driver.deliveries.count }], 3 do
+      perform_enqueued_jobs do
+        PostAnnouncementJob.perform_later(announcement, receivers)
+      end
+    end
+
+    assert_performed_jobs 1
+  end
+end


### PR DESCRIPTION
## Issue

- #7279

## 概要

お知らせ通知を投稿したとき、現状の実装ではユーザー１人につき２つのJob（ActiveJobのJob）を使って通知を送っている。（メール通知で１つ、サイト内通知で１つ）

そのため、通知する人数の２倍のJobが作成されてしまう。

リソース節約のために、１つのJobで対象ユーザー全員への通知を行うようにする。

## 変更確認方法

1. `feature/optimize-post-announcement`をローカルに取り込む
2. 任意のユーザーでログインをし、お知らせ作成ページ（`http://localhost:3000/announcements/new`）にアクセスする
3. タイトル、内容を入力、通知ターゲットは`全員（退会者を除く）`を選択し、「作成」ボタンをクリック
4. 以下の内容を確認する（個々の詳細な確認方法については後述）
    - お知らせ通知作成時、１つのJobだけがキューに入れられていること
    - メール通知、サイト内通知が正しく行われていること

### お知らせ通知作成時、１つのJobだけがキューに入れられていることを確認

`log/development.log`に、キューにJobを追加するログが１つしか出ていないことを確認する

以下、ログのサンプル

```
[ActiveJob] [PostAnnouncementJob] [b06939d2-4604-4856-94a2-ce648647c7e1] Performing PostAnnouncementJob (Job ID: b06939d2-4604-4856-94a2-ce648647c7e1) from GoodJob(default) enqueued at 2024-02-26T03:05:37Z with arguments:
```

### メール通知、サイト内通知が正しく行われていることを確認

#### メール通知
- `http://localhost:3000/letter_opener`にアクセスして、送信されたメールの数が正しいことを確認する
  - `メール通知が行われる数 = 全ユーザー数 - （メール通知がOFFまたは退会している人の数） - （発信者：１）`（※ 発信者はメール通知ONである前提の式です）
- `お知らせを作成した人`へのメールは存在しないことを確認する


参考：全ユーザー数
```sql
select count(*) from users;
```

参考：メール通知がOFFまたは退会者となっている人の数
```sql
select count(*) from users where mail_notification = false or retired_on is not null;
```

#### サイト内通知

- `notifications`テーブルで対象の通知のレコード数が正しいことを確認する
  - `サイト内通知が行われる数 = 全ユーザー数 - （退会している人の数） - （発信者：１）`
- `お知らせを作成した人`へはサイト内通知が作成されていないことを確認する
  - 右上の通知に、作成したお知らせが表示されていなければOKです。
![image](https://github.com/fjordllc/bootcamp/assets/131861805/c47b7203-dcfc-42cb-8ea6-45ba21a3627b)


参考：退会している人の数
```sql
select count(*) from users where retired_on is not null;
```
参考：対象のお知らせのサイト内通知の数
```sql
-- xxxxxxxxxxの部分は、対象のお知らせのidに合わせる
select count(*) from notifications where link = '/announcements/xxxxxxxxxx';
```
![image](https://github.com/fjordllc/bootcamp/assets/131861805/022331d8-c798-4edb-9589-9d64def5cdfd)


## Screenshot

内部的な変更のため無し
