### PR TITLE
ユーザー登録画面でアンチハラスメントポリシーと利用規約のチェック状態をエラー時に残す

### DIFF
--- a/app/javascript/agreements.js
+++ b/app/javascript/agreements.js
@@ -4,15 +4,20 @@ document.addEventListener('DOMContentLoaded', () => {
   )
   const submit = document.querySelector('.js-agreements-submit')
 
-  checkboxes.forEach((element) => {
-    element.addEventListener('click', () => {
-      const isSubmit = checkboxes.every((element) => element.checked)
+  const updateSubmitButtonStateFromCheckbox = () => {
+    const isSubmit = checkboxes.every((element) => element.checked)
+    if (isSubmit) {
+      submit.classList.remove('is-disabled')
+    } else {
+      submit.classList.add('is-disabled')
+    }
+  }
 
-      if (isSubmit) {
-        submit.classList.remove('is-disabled')
-      } else {
-        submit.classList.add('is-disabled')
-      }
+  if (checkboxes.length) {
+    checkboxes.forEach((element) => {
+      element.addEventListener('click', updateSubmitButtonStateFromCheckbox)
     })
-  })
+
+    updateSubmitButtonStateFromCheckbox()
+  }
 })

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -140,7 +140,7 @@
         ul.block-checks.is-1-item
           li.block-checks__item
             .a-block-check.is-checkbox
-              = check_box_tag :coc, 1, false, class: 'a-toggle-checkbox js-agreements-checkbox'
+              = check_box_tag :coc, 1, params[:coc], class: 'a-toggle-checkbox js-agreements-checkbox'
               label.a-block-check__label.is-ta-left(for='coc')
                 | アンチハラスメントポリシーに同意
         .a-form-help
@@ -149,7 +149,7 @@
         ul.block-checks.is-1-item
           li.block-checks__item
             .a-block-check.is-checkbox
-              = check_box_tag :tos, 2, false, class: 'a-toggle-checkbox js-agreements-checkbox'
+              = check_box_tag :tos, 2, params[:tos], class: 'a-toggle-checkbox js-agreements-checkbox'
               label.a-block-check__label.is-ta-left(for='tos')
                 | 利用規約に同意
         .a-form-help


### PR DESCRIPTION
## Issue

- #7414

## 概要

- 名前が未入力などの入力エラー時に、以下のチェックボックスのチェック状態を維持するようにしました
  - `アンチハラスメントポリシーに同意`
  - `利用規約に同意`

## 変更確認方法

1. `feature/maintain-states-of-code-of-conduct-and-terms-of-service-in-user-registration`をローカルに取り込む
2. `http://localhost:3000/users/new`にアクセスする
3. `カード番号`を入力する
    - 補足
      - カード番号に関しては他の必須項目とは別のバリデーションの仕組みになっており、この項目が未入力だとカード番号のバリデーションが先に動き本`Issue`の目的であるチェックボックスが外れた状態に遷移しないためこの手順を入れています
      - ダミーの番号として、`4242 4242 4242 4242`が使用可能（有効期限は任意の将来の日付、セキュリティコードは任意の3桁の数字）
4. 他の入力必須項目を未入力のまま、以下のチェックボックスにチェックを入れ、`参加する`ボタンをクリックする
    - `アンチハラスメントポリシーに同意`
    - `利用規約に同意`
5. 以下の項目を確認する
    - `アンチハラスメントポリシーに同意`のチェックボックスがチェック状態のままであること
    - `利用規約に同意`のチェックボックスがチェック状態のままであること
    - `参加する`ボタンが有効（クリックできる状態）であること

## Screenshot

### 変更前
[![Image from Gyazo](https://i.gyazo.com/7dd3a95a6e7d4ff63b74cf0daeffe258.gif)](https://gyazo.com/7dd3a95a6e7d4ff63b74cf0daeffe258)

### 変更後
[![Image from Gyazo](https://i.gyazo.com/6e2172c437fa059820699ce7bdd3d700.gif)](https://gyazo.com/6e2172c437fa059820699ce7bdd3d700)
