### PR TITLE
テスト環境におけるイベント日時の秒数入力フォームを削除

### DIFF
--- a/db/fixtures/events.yml
+++ b/db/fixtures/events.yml
@@ -16,10 +16,10 @@ event2:
   description: "募集期間中のイベントです。参加申込ができます。補欠者はまだいません。"
   location: "FJORDオフィス"
   capacity: 40
-  start_at: <%= Time.current.next_year - 1.day %>
-  end_at: <%= Time.current.next_year %>
-  open_start_at: <%= Time.current %>
-  open_end_at: <%= Time.current.next_year %>
+  start_at: <%= Time.current.change(sec:0).next_year - 1.day %>
+  end_at: <%= Time.current.change(sec:0).next_year %>
+  open_start_at: <%= Time.current.change(sec:0) %>
+  open_end_at: <%= Time.current.change(sec:0).next_year %>
   user: komagata
 
 event3:
@@ -27,10 +27,10 @@ event3:
   description: "募集期間中のイベントです。参加申込ができます。補欠者がいます。"
   location: "FJORDオフィス"
   capacity: 1
-  start_at: <%= Time.current.next_year - 1.day %>
-  end_at: <%= Time.current.next_year %>
-  open_start_at: <%= Time.current %>
-  open_end_at: <%= Time.current.next_year %>
+  start_at: <%= Time.current.change(sec:0).next_year - 1.day %>
+  end_at: <%= Time.current.change(sec:0).next_year %>
+  open_start_at: <%= Time.current.change(sec:0) %>
+  open_end_at: <%= Time.current.change(sec:0).next_year %>
   user: komagata
 
 event4:
@@ -38,10 +38,10 @@ event4:
   description: "募集期間前のイベントです。"
   location: "FJORDオフィス"
   capacity: 10
-  start_at: <%= Time.current.next_year - 1.hour %>
-  end_at: <%= Time.current.next_year %>
-  open_start_at: <%= Time.current.next_year - 1.day %>
-  open_end_at: <%= Time.current.next_year %>
+  start_at: <%= Time.current.change(sec:0).next_year - 1.hour %>
+  end_at: <%= Time.current.change(sec:0).next_year %>
+  open_start_at: <%= Time.current.change(sec:0).next_year - 1.day %>
+  open_end_at: <%= Time.current.change(sec:0).next_year %>
   user: komagata
 
 event5:
@@ -49,10 +49,10 @@ event5:
   description: "募集が終了したイベントです。"
   location: "FJORDオフィス"
   capacity: 10
-  start_at: <%= Time.current.next_year - 1.hour %>
-  end_at: <%= Time.current.next_year %>
-  open_start_at: <%= Time.current.yesterday %>
-  open_end_at: <%= Time.current.yesterday + 1.hour %>
+  start_at: <%= Time.current.change(sec:0).next_year - 1.hour %>
+  end_at: <%= Time.current.change(sec:0).next_year %>
+  open_start_at: <%= Time.current.change(sec:0).yesterday %>
+  open_end_at: <%= Time.current.change(sec:0).yesterday + 1.hour %>
   user: komagata
 
 event6:


### PR DESCRIPTION
## Issue

- #7412

## 概要
テスト環境において、特別イベントを編集するとき画面上に表示される秒数入力の部分を表示されないようにしました。

## 変更確認方法
1. `bug/remove_seconds_input_form_of_event_date_in_test_environment`をローカルに取り込む
2. `git checkout bug/remove_seconds_input_form_of_event_date_in_test_environment`でローカルブランチを移動
3. `rails db:reset`
4. `bin/setup`を実行
5. `foreman start -f Procfile.dev`を実行
6. 以下4つのページにアクセスし、`イベント開始日時`、`イベント終了日時`、`募集開始日時`、`募集終了日時`の入力欄で秒数が表示されていないことを確認
[募集期間前のイベント](http://localhost:3000/events/994018171/edit)
[募集期間後のイベント](http://localhost:3000/events/205042674/edit)
[募集期間中のイベント(補欠者なし)](http://localhost:3000/events/308029005/edit)
[募集期間中のイベント(補欠者あり)](http://localhost:3000/events/626726618/edit)

## Screenshot

### 変更前
<img width="717" alt="スクリーンショット 2024-02-26 22 15 53" src="https://github.com/fjordllc/bootcamp/assets/57088113/23c1a39c-4bfa-44b3-aece-0ecee4deed48">

### 変更後
<img width="711" alt="スクリーンショット 2024-02-26 21 56 49" src="https://github.com/fjordllc/bootcamp/assets/57088113/ca225c88-a30f-4167-821b-a9d02fe6288b">
