### PR TITLE
slim-lintの５個のルールを調査し、３個を適用、２個を除外したままにした。

### DIFF
--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -8,7 +8,6 @@ linters:
     enabled: true
     ignored_cops:
       - Layout/ArgumentAlignment
-      - Layout/BlockAlignment
       - Layout/EmptyLineAfterGuardClause
       - Layout/EndAlignment
       - Layout/FirstArrayElementIndentation

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -26,7 +26,6 @@ linters:
       - Layout/TrailingEmptyLines
       - Lint/Void # 除外検討したが見送り
       - Metrics/BlockLength # 除外検討したが見送り
-      - Naming/FileName
       - Style/FrozenStringLiteralComment # 除外検討したが見送り
       - Style/IdenticalConditionalBranches
       - Style/IfUnlessModifier

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -28,7 +28,7 @@ linters:
       - Metrics/BlockLength # 除外検討したが見送り
       - Style/FrozenStringLiteralComment # 除外検討したが見送り
       - Style/IdenticalConditionalBranches
-      - Style/IfUnlessModifier
+      - Style/IfUnlessModifier # 除外検討したが見送り
       - Style/Next
       - Style/WhileUntilDo
       - Style/WhileUntilModifier

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -28,8 +28,8 @@ linters:
       - Metrics/BlockLength # 除外検討したが見送り
       - Style/FrozenStringLiteralComment # 除外検討したが見送り
       - Style/IdenticalConditionalBranches
-      - Style/IfUnlessModifier # 除外検討したが見送り
-      - Style/Next
+      - Style/IfUnlessModifier # 検討の結果、残す(詳細は#7252)
+      - Style/Next # 検討の結果、残す(詳細は#7252)
       - Style/WhileUntilDo
       - Style/WhileUntilModifier
       - Style/HashSyntax

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -26,7 +26,6 @@ linters:
       - Layout/TrailingEmptyLines
       - Lint/Void # 除外検討したが見送り
       - Metrics/BlockLength # 除外検討したが見送り
-      - Metrics/BlockNesting
       - Naming/FileName
       - Style/FrozenStringLiteralComment # 除外検討したが見送り
       - Style/IdenticalConditionalBranches


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/7252

## 概要
slim-lintで除外（記載）されている以下の５つのルールについて調査を行い、問題がなければ除外せずに適用しました。
```yml
- Layout/BlockAlignment 
- Metrics/BlockNesting
- Naming/FileName
- Style/IfUnlessModifier
- Style/Next
```

## 調査内容
適用をしたルールは３つです。適用に至った理由は以下のリンクに記載しています。
- [Layout/BlockAlignment](https://github.com/fjordllc/bootcamp/issues/7252#issuecomment-1976479359) 
- [Metrics/BlockNesting](https://github.com/fjordllc/bootcamp/issues/7252#issuecomment-1976480131)
- [Naming/FileName](https://github.com/fjordllc/bootcamp/issues/7252#issuecomment-1976481133)

除外をしたままにするルールは２つです。除外のままに至った理由は以下のリンクに記載しています。
- [Style/IfUnlessModifier](https://github.com/fjordllc/bootcamp/issues/7252#issuecomment-1976484005)
- [Style/Next](https://github.com/fjordllc/bootcamp/issues/7252#issuecomment-1976494456)

## 変更確認方法

1. `feature/apply-slimlint-rule-6`をローカルに取り込む。
2. `bundle exec slim-lint app/views/ -c config/slim_lint.yml`を実行し、エラー（警告メッセージ）が出ないことを確認する。

## Screenshot
UI上の変化はないため割愛します。
