### PR TITLE
提出物を更新した時の通知の末尾に句読点を追加、他のものと統一する形にした

### DIFF
--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -282,7 +282,7 @@ class ActivityNotifier < ApplicationNotifier
     receiver = params[:receiver]
 
     notification(
-      body: "#{product.user.login_name}さんの「#{product.practice.title}」の提出物が更新されました",
+      body: "#{product.user.login_name}さんの「#{product.practice.title}」の提出物が更新されました。",
       kind: :product_update,
       receiver:,
       sender: product.sender,

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -41,7 +41,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'komagata'
 
     within first('.card-list-item.is-unread') do
-      assert_text "kimuraさんの「#{product.practice.title}」の提出物が更新されました"
+      assert_text "kimuraさんの「#{product.practice.title}」の提出物が更新されました。"
     end
   end
 
@@ -64,7 +64,7 @@ class Notification::ProductsTest < ApplicationSystemTestCase
     visit_with_auth '/notifications', 'komagata'
 
     within first('.card-list-item.is-unread') do
-      assert_text "hajimeさんの「#{product.practice.title}」の提出物が更新されました"
+      assert_text "hajimeさんの「#{product.practice.title}」の提出物が更新されました。"
     end
   end
 


### PR DESCRIPTION
## Issue
- Issue番号
 #7374
## 概要
### 修正前
ユーザーが提出物を再提出すると、「⚪︎⚪︎さんの「XXX」の提出物が更新されました」という通知がメンターやアドバイザーに飛ぶ様になっていました。

###  修正後
ユーザーが提出物を再提出すると「⚪︎⚪︎さんの「XXX」の提出物が更新されました。」のように他の通知と同様に、**末尾に句読点** をつけるようにしました。
## 変更確認方法

1.ブランチ`feature/added-punctuation-end-of-notice-of-submission-update`をローカルに取り込む。
2.  `bin/setup`, `foreman start -f Procfile.dev`でサーバーを起動する。
3. kimura(testtest)でログイン、提出物を作成する。
4. komagata(testtest)でログイン、上記の提出物を担当する。
5. kimuraのアカウントで提出物を更新する。
6. komagataのアカウントで **通知の文言の末尾に句読点が追加されている** ことを確認する。

## Screenshot

### 変更前
<img width="249" alt="スクリーンショット 2024-02-28 17 17 49" src="https://github.com/fjordllc/bootcamp/assets/112623765/d4079609-71d9-4918-b622-e3c2ff570e85">

### 変更後
<img width="239" alt="スクリーンショット 2024-02-28 17 27 20" src="https://github.com/fjordllc/bootcamp/assets/112623765/e34d6aaf-4958-4ee5-8b1f-517f01b1fda8">


