### PR TITLE
お試し延長一覧ページのタイトルをh1に変更し他のタブと統一

### DIFF
--- a/app/views/admin/campaigns/index.html.slim
+++ b/app/views/admin/campaigns/index.html.slim
@@ -3,7 +3,7 @@
 header.page-header
   .container
     .page-header__inner
-      h2.page-header__title
+      h1.page-header__title
         | 管理ページ
       .page-header-actions
         .page-header-actions__items


### PR DESCRIPTION
## Issue

- #7369

## 概要
[お試し延長一覧ページ](http://localhost:3000/admin/campaigns)のタイトル（「管理者ページ」）をh2タグからh1タグに変更するissue。

## 変更確認方法

1. `feature/trial-extension-list-update-title`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを起動
3. 管理者ユーザーで開発環境にログイン
4. http://localhost:3000/admin/campaigns にアクセス
5. タイトルの「管理者ページ」のタイトルがh1になっているかデベロッパーツールで確認

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/105143414/04ef169e-9591-47dd-b1e6-abcafe5a6efa)


### 変更後

<img width="1086" alt="スクリーンショット 2024-02-29 18 16 07" src="https://github.com/fjordllc/bootcamp/assets/105143414/73fce840-5be2-4dca-b93d-54007120cdf4">



