### PR TITLE
管理者メニューに管理ページのタブごとのリンクを追加

### DIFF
--- a/app/views/application/_admin_menu.html.slim
+++ b/app/views/application/_admin_menu.html.slim
@@ -5,3 +5,12 @@
     li.header-dropdown__item
       = link_to admin_root_path, class: 'header-dropdown__item-link' do
         | 管理ページ
+    li.header-dropdown__item
+      = link_to admin_users_path, class: 'header-dropdown__item-link' do
+        | ユーザー
+    li.header-dropdown__item
+      = link_to admin_companies_path, class: 'header-dropdown__item-link' do
+        | 企業
+    li.header-dropdown__item
+      = link_to admin_campaigns_path, class: 'header-dropdown__item-link' do
+        | お試し延長


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7425

## 概要

## 変更確認方法

1. `feature/add-link-for-each-admin-page`をローカルに取り込む。
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる。
3. `komagata`でログインし、`/admin/`にアクセスする。
4. 画面右上のユーザーアイコンをクリックし、プルダウンメニューの「管理者メニュー」に次の３項目が追加されていることを確認する。
	- ユーザー
	- 企業
	- お試し延長
5. 追加した項目をクリックすると、対応する管理ページのタブが開くことを確認する。

## Screenshot

### 変更前

![スクリーンショット 2024-02-29 165517](https://github.com/fjordllc/bootcamp/assets/125527162/44c48723-fee1-47eb-b34f-dad5a49babae)

### 変更後

![スクリーンショット 2024-02-29 170023](https://github.com/fjordllc/bootcamp/assets/125527162/ebcddde7-619f-4f3e-a296-501a7c0086cc)