### PR TITLE
ユーザー登録のemailにバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,7 +153,7 @@ class User < ApplicationRecord
 
   after_create UserCallbacks.new
 
-  validates :email, presence: true, uniqueness: true
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
   validates :name, presence: true
   validates :description, presence: true
   validates :nda, presence: true

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -163,6 +163,34 @@ class UserTest < ActiveSupport::TestCase
     assert user.save(context: :retire_reason_presence)
   end
 
+  test 'email' do
+    user = users(:kimura)
+    user.email = 'abcdABCD1234@fjord.jp'
+    assert user.valid?
+    user.email = 'abcd.AB-CD_12/34@fjord.jp'
+    assert user.valid?
+    user.email = 'abcdABCD1234@fjord-fjord.jp'
+    assert user.valid?
+    user.email = 'abcdABCD1234.fjord.jp'
+    assert user.invalid?
+    user.email = 'abcd ABCD 1234@fjord.jp'
+    assert user.invalid?
+    user.email = '(abcdABCD1234)@fjord.jp'
+    assert user.invalid?
+    user.email = 'abcd@ABCD@1234@fjord.jp'
+    assert user.invalid?
+    user.email = 'あいうえお@fjord.jp'
+    assert user.invalid?
+    user.email = 'アイウエオ@fjord.jp'
+    assert user.invalid?
+    user.email = '１２３４５@fjord.jp'
+    assert user.invalid?
+    user.email = 'abcdABCD1234@.fjord.jp'
+    assert user.invalid?
+    user.email = 'abcdABCD1234@fjord_fjord.jp'
+    assert user.invalid?
+  end
+
   test 'login_name' do
     user = users(:komagata)
     user.login_name = 'abcdABCD1234'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7444

## 概要

ユーザー登録のemailにバリデーションが何も設定されていなかったので設定した。
[こちらのコメント](https://github.com/fjordllc/bootcamp/issues/7444#issuecomment-1970680020)で議論(検討)し、`URI::MailTo::EMAIL_REGEXP`を用いることにした。

- 利用可能なemailの例
    - `abcdABCD1234@fjord.jp`
    - `abcd.AB-CD_12/34@fjord.jp`
    - `abcdABCD1234@fjord-fjord.jp`
- 利用不可能なemailの例
    - `abcd ABCD 1234@fjord.jp`
    - `(abcdABCD1234)@fjord.jp`
    - `abcd@ABCD@1234@fjord.jp`
    - `abcdABCD1234@.fjord.jp`
    - `abcdABCD1234@fjord_fjord.jp`
    - その他全角文字が入るもの

## 変更確認方法

1. `feature/add-validation-to-user-email`をローカルに取り込む
2. http://localhost:3000/users/new にアクセスする
3. カード番号を入力する
    - 補足
        - ref: https://github.com/fjordllc/bootcamp/pull/7440
        - カード番号に関しては他の必須項目とは別のバリデーションの仕組みになっており、この項目が未入力だとカード番号のバリデーションが先に動いてしまうため、この手順を入れている
        - ダミーの番号として、`4242 4242 4242 4242`が使用可能（有効期限は任意の将来の日付、セキュリティコードは任意の3桁の数字）
4. 概要欄の例に記載しているEmailを入力する
5. 規約の同意にチェックを入れ、参加するを押す
6. 正しい値であればユーザー登録が行われ、不正な値であれば「Emailは不正な値です」と表示されることを確認する

## Screenshot
不正な値を入力し、ユーザー作成を行った場合

### 変更前
![email_before](https://github.com/fjordllc/bootcamp/assets/133615511/3c89cacb-24f6-4d70-a0d5-4ac1432d78b8)

### 変更後
![email_after](https://github.com/fjordllc/bootcamp/assets/133615511/8ccbdd42-1f36-423d-a020-dad7a487346e)