### PR TITLE
ドキュメント作成フォームプルダウン下に説明文を追加

### DIFF
--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -8,6 +8,11 @@
             = f.label :practice, class: 'a-form-label'
             .select-practices
               = f.select(:practice_id, practice_options(categories), { include_blank: '関連プラクティスを指定しない' }, { class: 'js-select2' })
+            .a-form-help
+              p
+                | どんな内容が書かれているドキュメントかを予想できるタイトルを付けましょう。
+                br
+                | また、それを探している人が検索するであろうワードを含めることを意識してください。
     .form-item
       .row
         .col-md-6.col-xs-12


### PR DESCRIPTION
## Issue

- #7367

## 概要
http://localhost:3000/pages/new ページの「関連プラクティス」のformプルダウン下に以下の説明を追加するIssue。

```
どんな内容が書かれているドキュメントかを予想できるタイトルを付けましょう。
また、それを探している人が検索するであろうワードを含めることをいしきしてください。
```

※文言の`いしき`は`意識`であることを確認済
## 変更確認方法

1.  `feature/add-title-description-to-doc-form`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを起動
3. 管理者またはメンターで開発環境にログイン
4. http://localhost:3000/pages/new にアクセス
5. 「関連プラクティス」のプルダウン下に説明文が追加されていることを確認
## Screenshot

### 変更前
<img width="557" alt="スクリーンショット 2024-03-01 13 37 55" src="https://github.com/fjordllc/bootcamp/assets/105143414/cbcaee6b-d72f-4f01-b80b-2edb51061e1f">


### 変更後
<img width="721" alt="スクリーンショット 2024-03-01 13 40 04" src="https://github.com/fjordllc/bootcamp/assets/105143414/20508ef5-3fe9-4011-876f-b751bd74d544">



