### PR TITLE
お知らせ作成フォームのタイトル部分に説明文を追加した

### DIFF
--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -11,11 +11,11 @@
             = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
             .a-form-help
               p
-                | 質問の内容が予測しやすいタイトルを付けましょう。
+                | お知らせの内容本文がタイトルから予想できる、具体的なタイトルを付けましょう。
                 br
-                | 悪い例: CSS初級課題
+                | 悪い例: フィヨブーハウス
                 br
-                | 良い例: タイトルを左右方向に中央に配置する方法
+                | 良い例: RubyKaigi 2024 フィヨブーハウス宿泊希望者申し込みを開始しました
     .form-item
       .row.js-markdown-parent
         .col-md-6.col-xs-12

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -9,12 +9,13 @@
           .form-item
             = f.label :title, class: 'a-form-label'
             = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
-            p
-              | お知らせの内容本文がタイトルから予想できる、具体的なタイトルを付けましょう。
-              br
-              | 悪い例: フィヨブーハウス
-              br
-              | 良い例: RubyKaigi 2024 フィヨブーハウス宿泊希望者申し込みを開始しました
+            .a-form-help
+              p
+                | 質問の内容が予測しやすいタイトルを付けましょう。
+                br
+                | 悪い例: CSS初級課題
+                br
+                | 良い例: タイトルを左右方向に中央に配置する方法
     .form-item
       .row.js-markdown-parent
         .col-md-6.col-xs-12

--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -9,6 +9,12 @@
           .form-item
             = f.label :title, class: 'a-form-label'
             = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: '今週のリリース2023年12月22日'
+            p
+              | お知らせの内容本文がタイトルから予想できる、具体的なタイトルを付けましょう。
+              br
+              | 悪い例: フィヨブーハウス
+              br
+              | 良い例: RubyKaigi 2024 フィヨブーハウス宿泊希望者申し込みを開始しました
     .form-item
       .row.js-markdown-parent
         .col-md-6.col-xs-12


### PR DESCRIPTION
## Issue

- Issue番号
#7368
## 概要
お知らせ作成フォームのタイトル下に説明文を追加しました。
## 変更確認方法

1. `feature/added-description-to-the-create-notice-form`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルでアプリを起動する
3. komagata(testtest)(ユーザーは誰でも良いです)でログインする
4. `localhost:3000/announcements/new`にアクセスする
5. タイトルバーの下に注釈が表示されていることを確認する。

## Screenshot

### 変更前
<img width="524" alt="image" src="https://github.com/fjordllc/bootcamp/assets/112623765/c4b0501b-ace2-4672-ac9f-6299854ea070">

### 変更後


<img width="599" alt="貼り付けた画像_2024_03_02_13_06" src="https://github.com/fjordllc/bootcamp/assets/112623765/f8a10586-41bd-44dd-bfe3-d74e59ebdcd6">

