### PR TITLE
メンター or 管理者でログインしたときだけユーザー一覧の期生別ページに現役生、卒業生、退会者の人数を表示する

### DIFF
--- a/app/javascript/agreements.js
+++ b/app/javascript/agreements.js
@@ -4,15 +4,20 @@ document.addEventListener('DOMContentLoaded', () => {
   )
   const submit = document.querySelector('.js-agreements-submit')
 
-  checkboxes.forEach((element) => {
-    element.addEventListener('click', () => {
-      const isSubmit = checkboxes.every((element) => element.checked)
+  const updateSubmitButtonStateFromCheckbox = () => {
+    const isSubmit = checkboxes.every((element) => element.checked)
+    if (isSubmit) {
+      submit.classList.remove('is-disabled')
+    } else {
+      submit.classList.add('is-disabled')
+    }
+  }
 
-      if (isSubmit) {
-        submit.classList.remove('is-disabled')
-      } else {
-        submit.classList.add('is-disabled')
-      }
+  if (checkboxes.length) {
+    checkboxes.forEach((element) => {
+      element.addEventListener('click', updateSubmitButtonStateFromCheckbox)
     })
-  })
+
+    updateSubmitButtonStateFromCheckbox()
+  }
 })

--- a/app/javascript/generation.vue
+++ b/app/javascript/generation.vue
@@ -9,6 +9,8 @@
           | {{ generation.number }}期生
         .user-group__date
           | {{ dateFormat(generation.start_date) }} ~ {{ dateFormat(generation.end_date) }}
+        .user-group__status-count.is-admin-and-mentor(v-if="isAdminOrMentor() && target === 'all'") 
+          |  現役生 {{ generation.students_and_trainees_count }}人  卒業生 {{ generation.graduates_count }}人  退会者 {{ generation.retirees_count }}人 
   .a-user-icons
     .a-user-icons__items
       .a-user-icons__item(v-for='user in users', :key='user.id')
@@ -38,6 +40,10 @@ export default {
       type: String,
       required: false,
       default: 'all'
+    },
+    currentUser: {
+      type: Object,
+      required: true
     }
   },
   data() {
@@ -80,6 +86,12 @@ export default {
     },
     dateFormat(date) {
       return date.replace('-', '年').replace('-', '月') + '日'
+    },
+    isAdminOrMentor() {
+      return (
+        this.currentUser.roles.includes("admin") ||
+        this.currentUser.roles.includes("mentor")
+      )
     }
   }
 }

--- a/app/javascript/generations.js
+++ b/app/javascript/generations.js
@@ -6,11 +6,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const generations = document.querySelector(selector)
   if (generations) {
     const target = generations.getAttribute('data-target')
+    const currentUserId = generations.getAttribute('data-current-user-id:number')
     new Vue({
       render: (h) =>
         h(Generations, {
           props: {
-            target: target
+            target: target,
+            currentUserId: currentUserId
           }
         })
     }).$mount(selector)

--- a/app/javascript/generations.vue
+++ b/app/javascript/generations.vue
@@ -14,7 +14,8 @@
         v-for='generation in generations',
         :key='generation.number',
         :generation='generation',
-        :target='target')
+        :target='target',
+        :currentUser = 'currentUser')
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')
 </template>
@@ -33,6 +34,10 @@ export default {
       type: String,
       required: false,
       default: 'all'
+    },
+    currentUserId: {
+      type: Number,
+      required: true
     }
   },
   data() {
@@ -40,7 +45,8 @@ export default {
       generations: [],
       loaded: false,
       currentPage: this.getCurrentPage(),
-      totalPages: 0
+      totalPages: 0,
+      currentUser: {}
     }
   },
   computed: {
@@ -58,6 +64,7 @@ export default {
   },
   created() {
     this.getGenerations()
+    this.fetchUser(this.currentUserId)
   },
   methods: {
     getGenerations() {
@@ -95,6 +102,25 @@ export default {
         location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
       )
       window.scrollTo(0, 0)
+    },
+    fetchUser(id) {
+      fetch(`/api/users/${id}.json`, {
+        method: 'GET',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest'
+        },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      })
+        .then((response) => {
+          return response.json()
+        })
+        .then((user) => {
+          this.currentUser = user
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
     }
   }
 }

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -44,4 +44,12 @@ class Generation
     # 退会者は「退会」フィルター時のみ表示させたいため、絞り込みを行う
     target == 'retired' ? users : users.unretired
   end
+
+  def user_counts
+    {
+      students_and_trainees_count: classmates.users_role('student_and_trainee', allowed_targets: %w[student_and_trainee]).count,
+      graduates_count: classmates.users_role('graduate', allowed_targets: %w[graduate]).count,
+      retirees_count: classmates.users_role('retired', allowed_targets: %w[retired]).count
+    }
+  end
 end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -47,9 +47,9 @@ class Generation
 
   def user_status_counts
     {
-      students_and_trainees_count: classmates.users_role('student_and_trainee', allowed_targets: %w[student_and_trainee]).count,
-      graduates_count: classmates.users_role('graduate', allowed_targets: %w[graduate]).count,
-      retirees_count: classmates.users_role('retired', allowed_targets: %w[retired]).count
+      students_and_trainees_count: classmates.students_and_trainees.count,
+      graduates_count: classmates.graduated.count,
+      retirees_count: classmates.retired.count
     }
   end
 end

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -45,7 +45,7 @@ class Generation
     target == 'retired' ? users : users.unretired
   end
 
-  def user_counts
+  def user_status_counts
     {
       students_and_trainees_count: classmates.users_role('student_and_trainee', allowed_targets: %w[student_and_trainee]).count,
       graduates_count: classmates.users_role('graduate', allowed_targets: %w[graduate]).count,

--- a/app/views/api/generations/_generation.json.jbuilder
+++ b/app/views/api/generations/_generation.json.jbuilder
@@ -1,6 +1,6 @@
 json.number generation.number
 json.start_date generation.start_date.to_date
 json.end_date generation.end_date.to_date
-json.students_and_trainees_count generation.user_counts[:students_and_trainees_count]
-json.graduates_count generation.user_counts[:graduates_count]
-json.retirees_count generation.user_counts[:retirees_count]
+json.students_and_trainees_count generation.user_status_counts[:students_and_trainees_count]
+json.graduates_count generation.user_status_counts[:graduates_count]
+json.retirees_count generation.user_status_counts[:retirees_count]

--- a/app/views/api/generations/_generation.json.jbuilder
+++ b/app/views/api/generations/_generation.json.jbuilder
@@ -1,3 +1,6 @@
 json.number generation.number
 json.start_date generation.start_date.to_date
 json.end_date generation.end_date.to_date
+json.students_and_trainees_count generation.user_counts[:students_and_trainees_count]
+json.graduates_count generation.user_counts[:graduates_count]
+json.retirees_count generation.user_counts[:retirees_count]

--- a/app/views/generations/index.html.slim
+++ b/app/views/generations/index.html.slim
@@ -19,4 +19,4 @@ main.page-main
           = '期生別'
           | （#{t("target.#{@target}")}）
   hr.a-border
-  #js-generations(data-target="#{@target}")
+  #js-generations(data-target="#{@target}" data-current-user-id:number="#{current_user.id}")

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -140,7 +140,7 @@
         ul.block-checks.is-1-item
           li.block-checks__item
             .a-block-check.is-checkbox
-              = check_box_tag :coc, 1, false, class: 'a-toggle-checkbox js-agreements-checkbox'
+              = check_box_tag :coc, 1, params[:coc], class: 'a-toggle-checkbox js-agreements-checkbox'
               label.a-block-check__label.is-ta-left(for='coc')
                 | アンチハラスメントポリシーに同意
         .a-form-help
@@ -149,7 +149,7 @@
         ul.block-checks.is-1-item
           li.block-checks__item
             .a-block-check.is-checkbox
-              = check_box_tag :tos, 2, false, class: 'a-toggle-checkbox js-agreements-checkbox'
+              = check_box_tag :tos, 2, params[:tos], class: 'a-toggle-checkbox js-agreements-checkbox'
               label.a-block-check__label.is-ta-left(for='tos')
                 | 利用規約に同意
         .a-form-help

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -29,4 +29,10 @@ class GenerationTest < ActiveSupport::TestCase
     assert_not_includes Generation.new(5).target_users('retired'), users(:komagata)
     assert_not_includes Generation.new(5).target_users('all'), users(:yameo)
   end
+
+  test '#user_status_counts' do
+    assert_equal 14, Generation.new(5).user_status_counts[:students_and_trainees_count]
+    assert_equal 2, Generation.new(5).user_status_counts[:graduates_count]
+    assert_equal 2, Generation.new(5).user_status_counts[:retirees_count]
+  end
 end

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -153,4 +153,16 @@ class GenerationsTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test 'users status count for generation' do
+    travel_to Time.zone.local(2014, 4, 1, 0, 0, 0) do
+      visit_with_auth '/generations?target=all', 'komagata'
+
+      assert_selector('a.tab-nav__item-link.is-active', text: '全員')
+      assert_text '期生別（全員）'
+      assert_link '5期生'
+      assert_text '2014年01月01日 ~ 2014年03月31日'
+      assert_text '現役生 14人 卒業生 2人 退会者 2人'
+    end
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7364

## 概要
ユーザー一覧ページのうち、期生別ページの全員のページに、メンター or 管理者でログインしたときだけ、現役生、卒業生、退会者の人数を表示するようにしました

## 変更確認方法

1. `display-number-of-category-users-on-generations-list`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる。
3. `komagata`でログインし、[/generations?target=all](http://localhost:3000/generations?target=all)にアクセスする
4. 期生別（全員）のページに現役生・卒業生・退会者の人数が表示されていることを確認する

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/133624488/e0ac6050-4ef1-423e-a2b6-38a98c631b11)


### 変更後
仮
![image](https://github.com/fjordllc/bootcamp/assets/133624488/40c7e1ca-8645-48f5-b54b-4954a7bdd13e)
