### PR TITLE
classの重複によるCSSバグを修正

### DIFF
--- a/app/javascript/components/Searchable.jsx
+++ b/app/javascript/components/Searchable.jsx
@@ -39,9 +39,7 @@ export default function Searchable({ searchable, word }) {
         ティス
       </span>
     ) : (
-      <span className="card-list-item__label">
-        {searchable.model_name_with_i18n}
-      </span>
+      <span>{searchable.model_name_with_i18n}</span>
     )
 
   const badgeContent = searchable.wip ? (


### PR DESCRIPTION
## Issue

- #7313

## 概要
検索結果のラベルが二重になってしまっているバグの解消になります。現状では「定期イベント」「特別イベント」「プラクティス」以外のラベルがすべて二重の囲いになっています。

<img width="691" alt="スクリーンショット 2024-03-02 20 28 01" src="https://github.com/fjordllc/bootcamp/assets/105143414/747184cb-f1cf-4143-af88-c007cdeacbc1">

![image](https://github.com/fjordllc/bootcamp/assets/105143414/153b279f-bc6d-43cd-a62c-871484b24db8)
このように同じCSSが当たってしまってる。


## 変更確認方法

1. `bug/fix-duplicate-search-labels`をローカルに取り込む
2. ログイン（権限は一般ユーザーでもOK）
3. 空欄のまま検索
<img width="813" alt="スクリーンショット 2024-03-02 20 20 48" src="https://github.com/fjordllc/bootcamp/assets/105143414/aa3b27c2-8baa-4d85-8b1e-712fc6faea0b">
4. 「定期イベント」「特別イベント」「プラクティス」以外のラベルが二重になっていないことを確認


## Screenshot

### 変更前
<img width="759" alt="スクリーンショット 2024-03-02 20 33 57" src="https://github.com/fjordllc/bootcamp/assets/105143414/68c17889-5100-457a-8034-1480b2a616ba">



### 変更後
<img width="803" alt="スクリーンショット 2024-03-02 20 31 04" src="https://github.com/fjordllc/bootcamp/assets/105143414/c1d66b50-4a56-42b9-b9ff-f92064c14d89">

