### PR TITLE
メンター or 管理者でログインしたときだけユーザー一覧の期生別ページに現役生、卒業生、退会者の人数を表示する

### DIFF
--- a/app/javascript/generation.vue
+++ b/app/javascript/generation.vue
@@ -9,7 +9,8 @@
           | {{ generation.number }}期生
         .user-group__date
           | {{ dateFormat(generation.start_date) }} ~ {{ dateFormat(generation.end_date) }}
-        .user-group__counts.is-only-mentor(v-if="isAdminOrMentor() && target === 'all'")
+        .user-group__counts.is-only-mentor(
+          v-if='isAdminOrMentor() && target === "all"')
           .card-counts
             .card-counts__items
               .card-counts__item
@@ -108,8 +109,8 @@ export default {
     },
     isAdminOrMentor() {
       return (
-        this.currentUser.roles.includes("admin") ||
-        this.currentUser.roles.includes("mentor")
+        this.currentUser.roles.includes('admin') ||
+        this.currentUser.roles.includes('mentor')
       )
     }
   }

--- a/app/javascript/generation.vue
+++ b/app/javascript/generation.vue
@@ -9,8 +9,27 @@
           | {{ generation.number }}期生
         .user-group__date
           | {{ dateFormat(generation.start_date) }} ~ {{ dateFormat(generation.end_date) }}
-        .user-group__status-count.is-admin-and-mentor(v-if="isAdminOrMentor() && target === 'all'") 
-          |  現役生 {{ generation.students_and_trainees_count }}人  卒業生 {{ generation.graduates_count }}人  退会者 {{ generation.retirees_count }}人 
+        .user-group__counts.is-only-mentor(v-if="isAdminOrMentor() && target === 'all'")
+          .card-counts
+            .card-counts__items
+              .card-counts__item
+                .card-counts__item-inner
+                  .card-counts__item-label
+                    | 現役生
+                  .card-counts__item-value
+                    | {{ generation.students_and_trainees_count }}
+              .card-counts__item
+                .card-counts__item-inner
+                  .card-counts__item-label
+                    | 卒業生
+                  .card-counts__item-value
+                    | {{ generation.graduates_count }}
+              .card-counts__item
+                .card-counts__item-inner
+                  .card-counts__item-label
+                    | 退会者
+                  .card-counts__item-value
+                    | {{ generation.retirees_count }}
   .a-user-icons
     .a-user-icons__items
       .a-user-icons__item(v-for='user in users', :key='user.id')

--- a/app/javascript/generation.vue
+++ b/app/javascript/generation.vue
@@ -1,0 +1,98 @@
+<template lang="pug">
+.a-card.user-group.is-loading(v-if='!loaded')
+  loadingGenerationsPageGenerationPlaceholder
+.a-card.user-group(v-else-if='users.length !== 0')
+  header.user-group__header
+    h2.user-group__title
+      a.user-group__title-link(:href='generation_url')
+        span.user-group__title-label
+          | {{ generation.number }}期生
+        .user-group__date
+          | {{ dateFormat(generation.start_date) }} ~ {{ dateFormat(generation.end_date) }}
+        .user-group__status-count.is-admin-and-mentor(v-if="isAdminOrMentor() && target === 'all'") 
+          |  現役生 {{ generation.students_and_trainees_count }}人  卒業生 {{ generation.graduates_count }}人  退会者 {{ generation.retirees_count }}人 
+  .a-user-icons
+    .a-user-icons__items
+      .a-user-icons__item(v-for='user in users', :key='user.id')
+        a.a-user-icons__item-link(:href='user.url')
+          span(:class='["a-user-role", `is-${user.primary_role}`]')
+            img(
+              :src='user.avatar_url',
+              :title='user.icon_title',
+              :data-login-name='user.login_name',
+              :class='"a-user-icons__item-icon a-user-icon"')
+</template>
+<script>
+import CSRF from 'csrf'
+import loadingGenerationsPageGenerationPlaceholder from './loading-generations-page-generation-placeholder.vue'
+
+export default {
+  components: {
+    loadingGenerationsPageGenerationPlaceholder:
+      loadingGenerationsPageGenerationPlaceholder
+  },
+  props: {
+    generation: {
+      type: Object,
+      required: true
+    },
+    target: {
+      type: String,
+      required: false,
+      default: 'all'
+    },
+    currentUser: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      loaded: false,
+      users: []
+    }
+  },
+  computed: {
+    generation_users_url() {
+      return `/api/generations/${this.generation.number}/users.json?target=${this.target}`
+    },
+    generation_url() {
+      return `/generations/${this.generation.number}`
+    }
+  },
+  created() {
+    this.getUsers()
+  },
+  methods: {
+    getUsers() {
+      fetch(this.generation_users_url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': CSRF.getToken()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      })
+        .then((response) => response.json())
+        .then((json) => {
+          this.users = json.users
+          this.loaded = true
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
+    },
+    dateFormat(date) {
+      return date.replace('-', '年').replace('-', '月') + '日'
+    },
+    isAdminOrMentor() {
+      return (
+        this.currentUser.roles.includes("admin") ||
+        this.currentUser.roles.includes("mentor")
+      )
+    }
+  }
+}
+</script>

--- a/app/javascript/generations.js
+++ b/app/javascript/generations.js
@@ -6,7 +6,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const generations = document.querySelector(selector)
   if (generations) {
     const target = generations.getAttribute('data-target')
-    const currentUserId = generations.getAttribute('data-current-user-id:number')
+    const currentUserId = generations.getAttribute(
+      'data-current-user-id:number'
+    )
     new Vue({
       render: (h) =>
         h(Generations, {

--- a/app/javascript/generations.js
+++ b/app/javascript/generations.js
@@ -1,0 +1,20 @@
+import Vue from 'vue'
+import Generations from 'generations.vue'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const selector = '#js-generations'
+  const generations = document.querySelector(selector)
+  if (generations) {
+    const target = generations.getAttribute('data-target')
+    const currentUserId = generations.getAttribute('data-current-user-id:number')
+    new Vue({
+      render: (h) =>
+        h(Generations, {
+          props: {
+            target: target,
+            currentUserId: currentUserId
+          }
+        })
+    }).$mount(selector)
+  }
+})

--- a/app/javascript/generations.vue
+++ b/app/javascript/generations.vue
@@ -14,7 +14,7 @@
       :key='generation.number',
       :generation='generation',
       :target='target',
-      :currentUser = 'currentUser')
+      :currentUser='currentUser')
   nav.pagination(v-if='totalPages > 1')
     pager(v-bind='pagerProps')
 </template>

--- a/app/javascript/generations.vue
+++ b/app/javascript/generations.vue
@@ -1,0 +1,126 @@
+<template lang="pug">
+.page-body
+  nav.pagination(v-if='totalPages > 1')
+    pager(v-bind='pagerProps')
+  .container.is-lg(v-if='generations.length == 0 && loaded')
+    .o-empty-message
+      .o-empty-message__icon
+        i.fa-regular.fa-smile
+      p.o-empty-message__text
+        | ユーザーはありません
+  .container.is-lg(v-else)
+    generation(
+      v-for='generation in generations',
+      :key='generation.number',
+      :generation='generation',
+      :target='target',
+      :currentUser = 'currentUser')
+  nav.pagination(v-if='totalPages > 1')
+    pager(v-bind='pagerProps')
+</template>
+<script>
+import CSRF from 'csrf'
+import Generation from './generation.vue'
+import Pager from './pager.vue'
+
+export default {
+  components: {
+    generation: Generation,
+    pager: Pager
+  },
+  props: {
+    target: {
+      type: String,
+      required: false,
+      default: 'all'
+    },
+    currentUserId: {
+      type: Number,
+      required: true
+    }
+  },
+  data() {
+    return {
+      generations: [],
+      loaded: false,
+      currentPage: this.getCurrentPage(),
+      totalPages: 0,
+      currentUser: {}
+    }
+  },
+  computed: {
+    pagerProps() {
+      return {
+        initialPageNumber: this.currentPage,
+        pageCount: this.totalPages,
+        pageRange: 5,
+        clickHandle: this.paginateClickCallback
+      }
+    },
+    api_url() {
+      return `/api/generations.json?page=${this.currentPage}&target=${this.target}`
+    }
+  },
+  created() {
+    this.getGenerations()
+    this.fetchUser(this.currentUserId)
+  },
+  methods: {
+    getGenerations() {
+      this.loaded = false
+      fetch(this.api_url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': CSRF.getToken()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      })
+        .then((response) => response.json())
+        .then((json) => {
+          this.generations = json.generations
+          this.totalPages = json.totalPages
+          this.loaded = true
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
+    },
+    getCurrentPage() {
+      const urlParams = new URLSearchParams(window.location.search)
+      return Number(urlParams.get('page')) || 1
+    },
+    paginateClickCallback(pageNumber) {
+      this.currentPage = pageNumber
+      this.getGenerations()
+      history.pushState(
+        null,
+        null,
+        location.pathname + (pageNumber === 1 ? '' : `?page=${pageNumber}`)
+      )
+      window.scrollTo(0, 0)
+    },
+    fetchUser(id) {
+      fetch(`/api/users/${id}.json`, {
+        method: 'GET',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest'
+        },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      })
+        .then((response) => {
+          return response.json()
+        })
+        .then((user) => {
+          this.currentUser = user
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
+    }
+  }
+}
+</script>

--- a/app/javascript/stylesheets/application/blocks/user/_user-group.sass
+++ b/app/javascript/stylesheets/application/blocks/user/_user-group.sass
@@ -4,6 +4,7 @@
     border-top: solid 1px var(--border-tint)
 
 .user-group__title
+  position: relative
   +media-breakpoint-up(md)
     font-size: 1.125rem
   +media-breakpoint-down(sm)
@@ -12,9 +13,12 @@
 .user-group__title-link
   text-decoration: none
   color: var(--main-text)
+  display: flex
   +media-breakpoint-up(md)
-    display: flex
     align-items: flex-end
+  +media-breakpoint-down(sm)
+    flex-direction: column
+    gap: .5rem
   .user-group__title.is-inline &
     display: flex
     align-items: flex-end
@@ -41,8 +45,9 @@
   font-weight: 400
   color: var(--muted-text)
 
-.user-group__count
-  font-size: .75rem
-  font-weight: 400
-  color: var(--muted-text)
-  margin-left: .25rem
+.user-group__counts
+  +media-breakpoint-up(md)
+    +position(absolute, right 0, top -.5rem)
+  .card-counts__item
+    width: 4rem
+    color: var(--default-text)

--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -44,4 +44,12 @@ class Generation
     # 退会者は「退会」フィルター時のみ表示させたいため、絞り込みを行う
     target == 'retired' ? users : users.unretired
   end
+
+  def user_status_counts
+    {
+      students_and_trainees_count: classmates.students_and_trainees.count,
+      graduates_count: classmates.graduated.count,
+      retirees_count: classmates.retired.count
+    }
+  end
 end

--- a/app/views/api/generations/_generation.json.jbuilder
+++ b/app/views/api/generations/_generation.json.jbuilder
@@ -1,3 +1,6 @@
 json.number generation.number
 json.start_date generation.start_date.to_date
 json.end_date generation.end_date.to_date
+json.students_and_trainees_count generation.user_status_counts[:students_and_trainees_count]
+json.graduates_count generation.user_status_counts[:graduates_count]
+json.retirees_count generation.user_status_counts[:retirees_count]

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -29,4 +29,10 @@ class GenerationTest < ActiveSupport::TestCase
     assert_not_includes Generation.new(5).target_users('retired'), users(:komagata)
     assert_not_includes Generation.new(5).target_users('all'), users(:yameo)
   end
+
+  test '#user_status_counts' do
+    assert_equal 14, Generation.new(5).user_status_counts[:students_and_trainees_count]
+    assert_equal 2, Generation.new(5).user_status_counts[:graduates_count]
+    assert_equal 2, Generation.new(5).user_status_counts[:retirees_count]
+  end
 end

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -153,4 +153,16 @@ class GenerationsTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test 'users status count for generation' do
+    travel_to Time.zone.local(2014, 4, 1, 0, 0, 0) do
+      visit_with_auth '/generations?target=all', 'komagata'
+
+      assert_selector('a.tab-nav__item-link.is-active', text: '全員')
+      assert_text '期生別（全員）'
+      assert_link '5期生'
+      assert_text '2014年01月01日 ~ 2014年03月31日'
+      assert_text '現役生 14人 卒業生 2人 退会者 2人'
+    end
+  end
 end

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -162,7 +162,12 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_text '期生別（全員）'
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
-      assert_text '現役生 14人 卒業生 2人 退会者 2人'
+      assert_selector '.card-counts__item-label', text: '現役生'
+      assert_selector '.card-counts__item-value', text: 14
+      assert_selector '.card-counts__item-label', text: '卒業生'
+      assert_selector '.card-counts__item-value', text: 2
+      assert_selector '.card-counts__item-label', text: '退会者'
+      assert_selector '.card-counts__item-value', text: 2
     end
   end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7364

## 概要
ユーザー一覧ページのうち、期生別ページの全員のページに、メンター or 管理者でログインしたときだけ、現役生、卒業生、退会者の人数を表示するようにしました

## 変更確認方法

1. `display-number-of-category-users-on-generations-list`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる。
3. `komagata`でログインし、[/generations?target=all](http://localhost:3000/generations?target=all)にアクセスする
4. 期生別（全員）のページに現役生・卒業生・退会者の人数が表示されていることを確認する
5. 期生別の他のページには現役生・卒業生・退会者の人数が表示がされていないことを確認する
6. `kimura`でログインしなおして、[/generations?target=all](http://localhost:3000/generations?target=all)にアクセスする
7. 期生別ページに現役生・卒業生・退会者の人数が表示がされていないことを確認する

## Screenshot

### 変更前

![image](https://github.com/fjordllc/bootcamp/assets/133624488/e0ac6050-4ef1-423e-a2b6-38a98c631b11)


### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/133624488/d13e9d42-bf92-44f5-99bb-7adaf1141449)

