### PR TITLE
研修生にもニコニコカレンダーを表示する

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -65,7 +65,7 @@
               div(data-vue="UserMentorMemo" data-vue-user-id:number="#{@user.id}")
             - unless @user.total_learning_time.zero? || @user.mentor?
               = react_component 'Grass', { userId: @user.id }, { class: 'a-card' }
-            - if @user.student?
+            - if @user.student_or_trainee?
               #js-niconico_calendar(data-user-id="#{@user.id}")
             - if @user.completed_practices.present?
               - cache [@user, @completed_learnings] do


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7477

## 概要
ユーザーの詳細画面で現役生にはニコニコカレンダーが表示されますが、
研修生の場合は表示されていませんでした。
そのため、研究生にもニコニコカレンダーが表示されるようにしました

## 変更確認方法

1. `feature/display-niconico-calendar-to-trainees`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. http://localhost:3000/users?target=trainee にアクセスする
4. 研修生の中から任意のユーザーをクリックする
5. ニコニコカレンダーが表示されるのを確認する

## Screenshot


### 変更前
右側には何も表示されない
![image](https://github.com/fjordllc/bootcamp/assets/133624488/b290ff25-abc6-4510-95d4-417d032d166e)


### 変更後
現役生と同様にニコニコカレンダーが表示されるように
![image](https://github.com/fjordllc/bootcamp/assets/133624488/1da9359e-11d6-426f-a6f3-a1fb582128dd)


