### PR TITLE
管理者権限からみた相談部屋内の「ユーザー日報」タブの表示バグを修正

### DIFF
--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -126,31 +126,29 @@ export default function Reports({
 
 const NoReports = ({ unchecked }) => {
   return (
-    <div className="page-main">
-      <div className="page-body">
-        <div className="container is-md">
-          <div className="o-empty-message">
-            <div className="o-empty-message__icon">
-              {unchecked ? (
-                <>
-                  <i className="fa-regular fa-smile" />
-                  <p className="o-empty-message__text">
-                    未チェックの日報はありません
-                  </p>
-                </>
-              ) : (
-                <div className="card-list a-card">
-            <div className="card-list__items">
+    <div className="o-empty-message">
+      <div className="o-empty-message__icon">
+        {unchecked ? (
+          <>
+            <i className="fa-regular fa-smile" />
+            <p className="o-empty-message__text">
+              未チェックの日報はありません
+            </p>
+          </>
+        ) : (
+          <div className="card-list a-card">
+            <div className="card-body">
+              <div className="card__description">
+                <div className="o-empty-message">
+                  <div className="o-empty-message__icon">
                     <i className="fa-regular fa-sad-tear" />
-                    <p className="o-empty-message__text">
-                    日報はまだありません。
-                  </p>
-            </div>
+                  </div>
+                  <p className="o-empty-message__text">日報はまだありません。</p>
                 </div>
-              )}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -139,12 +139,14 @@ const NoReports = ({ unchecked }) => {
                   </p>
                 </>
               ) : (
-                <>
-                  <i className="fa-regular fa-sad-tear" />
-                  <p className="o-empty-message__text">
+                <div className="card-list a-card">
+            <div className="card-list__items">
+                    <i className="fa-regular fa-sad-tear" />
+                    <p className="o-empty-message__text">
                     日報はまだありません。
                   </p>
-                </>
+            </div>
+                </div>
               )}
             </div>
           </div>

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -143,7 +143,9 @@ const NoReports = ({ unchecked }) => {
                   <div className="o-empty-message__icon">
                     <i className="fa-regular fa-sad-tear" />
                   </div>
-                  <p className="o-empty-message__text">日報はまだありません。</p>
+                  <p className="o-empty-message__text">
+                    日報はまだありません。
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Issue

- #7476

## 概要
`admin`アカウントの相談部屋詳細において、ユーザーの日報を表示するタブをクリックした際、ユーザーの日報がない場合CSSが適用されておらず、そのバグを修正するIssueです。



## 変更確認方法

1. `bug/reports-tab-missing-border`をローカルに取り込む
2. komagataさんまたはmachidaさんどちらかの管理者権限でログイン
3. http://localhost:3000/talks にアクセス
4. 日報がないユーザーの詳細に入る
5. `ユーザーの日報`タブをクリックし、CSSが正しく適用されていることを確認する
- 枠線が表示されているかの確認
- 枠線内はバックグラウンドカラー適用されているか

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/105143414/13cf67a2-0c72-4879-8ca8-5e4fb0d4d867)


### 変更後

<img width="1226" alt="スクリーンショット 2024-03-28 10 52 31" src="https://github.com/fjordllc/bootcamp/assets/105143414/ecf291a4-6801-41c0-a390-76b43676b66c">

