### PR TITLE
slim-lintへの「Rubocopのルール」追加の検討（追加：１ルール、除外：４ルール）

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -11,16 +11,12 @@
   = render 'welcome_message_for_adviser'
 
 .page-body.is-dash-board
-  - if current_user.adviser?
-    .page-body__inner.has-side-nav
+  .page-body__inner.has-side-nav
+    - if current_user.adviser?
       = render 'adviser_dashboard'
-      = render partial: 'recent_reports'
-  - elsif current_user.mentor?
-    .page-body__inner.has-side-nav
+    - elsif current_user.mentor?
       = render 'mentor_dashboard'
-      = render partial: 'recent_reports'
-  - else
-    .page-body__inner.has-side-nav
+    - else
       .columns
         .container.is-xl
           .row
@@ -47,4 +43,4 @@
                 = render 'users/github_grass', user: current_user
               - if current_user.student_or_trainee?
                 #js-niconico_calendar(data-user-id="#{current_user.id}")
-      = render partial: 'recent_reports'
+    = render partial: 'recent_reports'

--- a/app/views/surveys/show.html.slim
+++ b/app/views/surveys/show.html.slim
@@ -53,14 +53,12 @@ header.page-header
                           .survey-questions-item__radios.radios
                             ul.radios__items
                               - survey_question.radio_button.radio_button_choices.each do |choice|
-                                - if choice.reason_for_choice_required
-                                  li.radios__item
+                                li.radios__item
+                                  - if choice.reason_for_choice_required
                                     = f.radio_button survey_question.id, choice.choices, id: "radio-#{choice.id}", class: 'a-toggle-checkbox js-questionnaire_choice js-answer_required_choice'
-                                    = f.label "#{choice.radio_button_id}_#{choice.choices}", choice.choices, for: "radio-#{choice.id}"
-                                - else
-                                  li.radios__item
+                                  - else
                                     = f.radio_button survey_question.id, choice.choices, id: "radio-#{choice.id}", class: 'a-toggle-checkbox js-questionnaire_choice'
-                                    = f.label "#{choice.radio_button_id}_#{choice.choices}", choice.choices, for: "radio-#{choice.id}"
+                                  = f.label "#{choice.radio_button_id}_#{choice.choices}", choice.choices, for: "radio-#{choice.id}"
                           - if survey_question.answer_required_choice_exists?(survey_question.id)
                             .survey-additional-question.is-hidden name="js-additional_question_#{survey_question.id}"
                               = f.label survey_question.radio_button.title_of_reason, class: 'a-form-label is-required'
@@ -73,14 +71,12 @@ header.page-header
                         .survey-questions-item__checkboxes.checkboxes
                           ul.checkboxes__items
                             - survey_question.check_box.check_box_choices.each do |choice|
-                              - if choice.reason_for_choice_required
-                                li.checkboxes__item
+                              li.checkboxes__item
+                                - if choice.reason_for_choice_required
                                   = f.check_box choice.choices, id: "checkbox-#{choice.id}", class: 'a-toggle-checkbox js-questionnaire_choice js-answer_required_choice', name: survey_question.id
-                                  = f.label choice.choices, for: "checkbox-#{choice.id}"
-                              - else
-                                li.checkboxes__item
+                                - else
                                   = f.check_box choice.choices, id: "checkbox-#{choice.id}", class: 'a-toggle-checkbox js-questionnaire_choice', name: survey_question.id
-                                  = f.label choice.choices, for: "checkbox-#{choice.id}"
+                                = f.label choice.choices, for: "checkbox-#{choice.id}"
                         - if survey_question.answer_required_choice_exists?(survey_question.id)
                           .survey-additional-question.is-hidden name="js-additional_question_#{survey_question.id}"
                             = f.label :title_of_reason_for_checkbox, survey_question.check_box.title_of_reason, class: 'a-form-label is-required'
@@ -97,20 +93,16 @@ header.page-header
                           .linear-scale__points
                             ul.linear-scale__points-items
                               - 10.times do |i|
-                                - if survey_question.linear_scale.reason_for_choice_required
-                                  li.linear-scale__points-item
+                                li.linear-scale__points-item
+                                  - if survey_question.linear_scale.reason_for_choice_required
                                     = f.radio_button survey_question.id, i + 1, id: "linear-scale-#{survey_question.id}-#{i}",
                                       class: 'a-toggle-checkbox js-questionnaire_choice js-answer_required_choice'
-                                    label.linear-scale__point for="linear-scale-#{survey_question.id}-#{i}"
-                                      .linear-scale__point-number
-                                        = i + 1
-                                - else
-                                  li.linear-scale__points-item
+                                  - else
                                     = f.radio_button survey_question.id, i + 1, id: "linear-scale-#{survey_question.id}-#{i}",
                                       class: 'a-toggle-checkbox js-questionnaire_choice'
-                                    label.linear-scale__point for="linear-scale-#{survey_question.id}-#{i}"
-                                      .linear-scale__point-number
-                                        = i + 1
+                                  label.linear-scale__point for="linear-scale-#{survey_question.id}-#{i}"
+                                    .linear-scale__point-number
+                                      = i + 1
                           .linear-scale__label
                             = survey_question.linear_scale.last
                         - if survey_question.linear_scale.reason_for_choice_required

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -36,13 +36,12 @@ main.page-main
                     = link_to 'このタグを自分に追加', "/users/tags/#{params[:tag]}", method: 'post', class: 'a-button is-sm is-secondary is-block'
         - else
           h1.page-main-header__title
+            | #{t("target.#{@target}")}
             - if @watch
-              | #{t("target.#{@target}")}：#{t("watch.#{@watch}")}（#{@users.total_count}）
-            - else
-              | #{t("target.#{@target}")}
-              - if admin_or_mentor_login?
-                span.is-only-mentor
-                  |（#{@users.total_count}）
+              |：#{t("watch.#{@watch}")}（#{@users.total_count}）
+            - elsif admin_or_mentor_login?
+              span.is-only-mentor
+                |（#{@users.total_count}）
   hr.a-border
   .page-body.is-users
     // TODO 暫定的な対応

--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -7,12 +7,12 @@ linters:
   RuboCop:
     enabled: true
     ignored_cops:
-      - Layout/ArgumentAlignment
+      - Layout/ArgumentAlignment # 検討の結果、残す。（詳細は issue #7253 参照）
       - Layout/EmptyLineAfterGuardClause
       - Layout/EndAlignment
       - Layout/FirstArrayElementIndentation
       - Layout/FirstParameterIndentation
-      - Layout/HashAlignment
+      - Layout/HashAlignment # 検討の結果、残す。（詳細は issue #7253 参照）
       - Layout/IndentationWidth
       - Layout/InitialIndentation
       - Layout/MultilineArrayBraceLayout
@@ -22,13 +22,12 @@ linters:
       - Layout/MultilineMethodDefinitionBraceLayout
       - Layout/MultilineOperationIndentation
       - Layout/ParameterAlignment
-      - Layout/TrailingEmptyLines
+      - Layout/TrailingEmptyLines # 検討の結果、残す。（詳細は issue #7253 参照）
       - Lint/Void # 除外検討したが見送り
       - Metrics/BlockLength # 除外検討したが見送り
       - Style/FrozenStringLiteralComment # 除外検討したが見送り
-      - Style/IdenticalConditionalBranches
       - Style/IfUnlessModifier # 検討の結果、残す(詳細は#7252)
       - Style/Next # 検討の結果、残す(詳細は#7252)
       - Style/WhileUntilDo
       - Style/WhileUntilModifier
-      - Style/HashSyntax
+      - Style/HashSyntax # 検討の結果、残す。（詳細は issue #7253 参照）


### PR DESCRIPTION
## Issue

- #7253 

## 概要

### 実施内容の概要

- slimファイルに対して適用を除外されているRubocopのルールの内、5つのルールの適用を検討した
- 検討結果を受けて、「除外のまま残す」又は「追加する（除外リストから削除）」対応を行なった
  - 除外のまま残したルール（`config/slim_lint.yml`に同内容を記載した）
    `Layout/ArgumentAlignment`：[検討結果](https://github.com/fjordllc/bootcamp/issues/7253#issuecomment-1935257143)
    `Layout/HashAlignment`：[検討結果](https://github.com/fjordllc/bootcamp/issues/7253#issuecomment-1938010402)
    `Layout/TrailingEmptyLines`：[検討結果](https://github.com/fjordllc/bootcamp/issues/7253#issuecomment-1947804449)
    `Style/HashSyntax`：[検討結果](https://github.com/fjordllc/bootcamp/issues/7253#issuecomment-1951709076)
  - 追加したルール（除外リストから削除）
    `Style/IdenticalConditionalBranches`

### 追加したルールの概要

- `Style/IdenticalConditionalBranches`：条件式で、分岐の内容に重複がある場合、「その重複した式を条件式の外側に出す」というルール
  [Style :: RuboCop Docs](https://docs.rubocop.org/rubocop/cops_style.html#styleidenticalconditionalbranches)

## 変更確認方法

1. ブランチ`feature/apply-slimlint-rule-7`をローカルに取り込む
2. `bundle exec slim-lint app/views/ -c config/slim_lint.yml`を実行し、エラー（警告メッセージ）が出ないことを確認する

## Screenshot

（表示内容の変更では無い為、省略）
