### PR TITLE
お知らせの個別ページに最新のお知らせを10件表示するようにした

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -6,7 +6,9 @@ class AnnouncementsController < ApplicationController
 
   def index; end
 
-  def show; end
+  def show
+    @announcements = Announcement.with_avatar.where(wip: false).order(published_at: :desc).limit(10)
+  end
 
   def new
     @announcement = Announcement.new(target: 'students')

--- a/app/views/announcements/_recent_announcements.html.slim
+++ b/app/views/announcements/_recent_announcements.html.slim
@@ -1,0 +1,14 @@
+.a-side-nav
+  .a-side-nav__inner
+    header.a-side-nav__header
+      h2.a-side-nav__title
+        | 最新のお知らせ
+    hr.a-border
+    .a-side-nav__body
+      .card-list
+        = render partial: 'home/announcement', collection: @announcements, as: :announcement
+    hr.a-border
+    footer.a-side-nav__footer
+      = link_to announcements_path, class: 'a-side-nav__footer-link' do
+        | 全てのお知らせ
+

--- a/app/views/announcements/_recent_announcements.html.slim
+++ b/app/views/announcements/_recent_announcements.html.slim
@@ -11,4 +11,3 @@
     footer.a-side-nav__footer
       = link_to announcements_path, class: 'a-side-nav__footer-link' do
         | 全てのお知らせ
-

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -16,6 +16,7 @@ header.page-header
 hr.a-border
 .page-body
   .container.is-md
-    = render 'announcement', announcement: @announcement
-    #js-comments(data-commentable-id="#{@announcement.id}" data-commentable-type='Announcement' data-current-user-id="#{current_user.id}")
-    div(data-vue='Footprints' data-vue-footprintable-id="#{@announcement.id}" data-vue-footprintable-type='Announcement')
+      = render 'announcement', announcement: @announcement
+      #js-comments(data-commentable-id="#{@announcement.id}" data-commentable-type='Announcement' data-current-user-id="#{current_user.id}")
+      div(data-vue='Footprints' data-vue-footprintable-id="#{@announcement.id}" data-vue-footprintable-type='Announcement')
+  = render partial: 'recent_announcements'

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -15,8 +15,9 @@ header.page-header
               | お知らせ一覧へ
 hr.a-border
 .page-body
-  .container.is-md
+  .page-body__inner.has-side-nav
+    .container.is-md
       = render 'announcement', announcement: @announcement
       #js-comments(data-commentable-id="#{@announcement.id}" data-commentable-type='Announcement' data-current-user-id="#{current_user.id}")
       div(data-vue='Footprints' data-vue-footprintable-id="#{@announcement.id}" data-vue-footprintable-type='Announcement')
-  = render partial: 'recent_announcements'
+    = render partial: 'recent_announcements'

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -269,7 +269,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 
-  test 'show the latest 10 announcements' do
+  test 'show the latest announcements' do
     visit_with_auth "/announcements/#{announcements(:announcement1).id}", 'kimura'
     assert_text '最新のお知らせ'
   end

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -268,4 +268,9 @@ class AnnouncementsTest < ApplicationSystemTestCase
     end
     assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
+
+  test 'show the latest 10 announcements' do
+    visit_with_auth "/announcements/#{announcements(:announcement1).id}", 'kimura'
+    assert_text '最新のお知らせ'
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7493

## 概要
お知らせの個別ページの右側に最新のお知らせを10件表示するようにしました

## 変更確認方法

1. `feature/display-latest-10-notifications-on-individual-notification-page`をローカルに取り込む
2. `http://localhost:3000/announcements`にアクセス
3. どれか一つお知らせをクリックして個別ページを開く
4. 右側に最新のお知らせが10件表示されていることを確認する

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/133624488/017897d7-b69f-4095-9c8b-22c12ea8c586)



### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/133624488/879c9832-d20e-4d9d-b357-69bfbc22b235)


