### PR TITLE
Docs新規作成フォームのプラクティス選択をChoices.jsに置き換える

### DIFF
--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -7,7 +7,7 @@
           .form-item
             = f.label :practice, class: 'a-form-label'
             .select-practices
-              = f.select(:practice_id, practice_options(categories), { include_blank: '関連プラクティスを指定しない' }, { class: 'js-select2' })
+              = f.select(:practice_id, practice_options(categories), { include_blank: '関連プラクティスを指定しない' }, { id: 'js-choices-single-select' })
             .a-form-help
               p
                 | どんな内容が書かれているドキュメントかを予想できるタイトルを付けましょう。

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -125,8 +125,8 @@ class PagesTest < ApplicationSystemTestCase
     visit_with_auth new_page_path, 'kimura'
     fill_in 'page[title]', with: 'Docに関連プラクティスを指定'
     fill_in 'page[body]', with: 'Docに関連プラクティスを指定'
-    first('.select2-container').click
-    find('li.select2-results__option[role="option"]', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
+    first('.choices__inner').click
+    find('.choices__item--choice', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
     click_button 'Docを公開'
     assert_text 'Linuxのファイル操作の基礎を覚える'
   end
@@ -182,8 +182,8 @@ class PagesTest < ApplicationSystemTestCase
     visit_with_auth new_page_path, 'kimura'
     fill_in 'page[title]', with: 'Docに関連プラクティスを指定'
     fill_in 'page[body]', with: 'Docに関連プラクティスを指定'
-    first('.select2-container').click
-    find('li.select2-results__option[role="option"]', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
+    first('.choices__inner').click
+    find('.choices__item--choice', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
     click_button 'Docを公開'
     assert_text 'Linuxのファイル操作の基礎を覚える'
 


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7498

## 概要
select2というjQueryライブラリで実装されていたDocs作成フォームのプラクティス選択部分のセレクトボックスを、
他ページでのプラクティス選択部分の実装に合わせ、Choices.jsというライブラリでの実装に変更しました。

#### 関連issue
- https://github.com/fjordllc/bootcamp/issues/4582
- https://github.com/fjordllc/bootcamp/issues/4583
- https://github.com/fjordllc/bootcamp/issues/4584


## 変更確認方法

1. `feature/replace-practice-selection-in-creation-new-docs-form-with-choices-js`をローカルに取り込む
2. http://localhost:3000/pages にアクセス
3. 右上の`+Doc作成`を押す
4. 「関連プラクティス」欄について、仕様が以下のように変わっていることを確認する
- デフォルトとして「関連プラクティスを指定しない」という文字列が「関連プラクティス」欄にグレーで表示されている
![image](https://github.com/fjordllc/bootcamp/assets/133624488/77a97959-2336-40a8-8952-631db1af02f0)

- プルダウンをクリックして、一覧の中でhoverしたプラクティスの欄がグレーになり、右側に「選択」とグレーで表示される

![image](https://github.com/fjordllc/bootcamp/assets/133624488/6efd5766-2eed-4afa-b747-102d717e16d4)

- プラクティスを一つ選択すると「関連プラクティス」欄に黒字で表示される
![image](https://github.com/fjordllc/bootcamp/assets/133624488/3ff9d372-7928-4900-a4b4-b9ee92b78cb0)


## Screenshot

### 変更前
デフォルトの「関連プラクティスを指定しない」という文字列が黒
hoverするとプラクティスの欄が濃い紫に
選択済みのプラクティスは濃いグレーに
[![Image from Gyazo](https://i.gyazo.com/a3145927cd331913aed368120d62ff72.gif)](https://gyazo.com/a3145927cd331913aed368120d62ff72)

### 変更後
デフォルトの「関連プラクティスを指定しない」という文字列がグレー
hoverするとプラクティスの欄がグレーに、かつ右側に「選択」と表示
[![Image from Gyazo](https://i.gyazo.com/7f53b2788d458385913a5e4266934aa9.gif)](https://gyazo.com/7f53b2788d458385913a5e4266934aa9)