### PR TITLE
Discordアカウント名が不正だと退会時にエラーが発生する不具合を修正

### DIFF
--- a/app/models/times_channel_destroyer.rb
+++ b/app/models/times_channel_destroyer.rb
@@ -6,7 +6,8 @@ class TimesChannelDestroyer
     return unless user.discord_profile.times_id
 
     if Discord::Server.delete_text_channel(user.discord_profile.times_id)
-      user.discord_profile.update!(times_id: nil)
+      user.discord_profile.times_id = nil
+      user.discord_profile.save!(context: :retirement)
     else
       Rails.logger.warn "[Discord API] #{user.login_name}の分報チャンネルが削除できませんでした。"
     end

--- a/test/models/times_channel_destroyer_test.rb
+++ b/test/models/times_channel_destroyer_test.rb
@@ -6,7 +6,10 @@ class TimesChannelDestroyerTest < ActiveSupport::TestCase
   test '#call' do
     logs = []
     user = users(:hajime)
-    user.discord_profile.update!(times_id: '987654321987654321')
+    user.discord_profile.times_id = '987654321987654321'
+    user.discord_profile.account_name = 'hajime#1234'
+    user.save!(validate: false)
+
     Rails.logger.stub(:warn, ->(message) { logs << message }) do
       Discord::Server.stub(:delete_text_channel, true) do
         TimesChannelDestroyer.new.call({ user: })

--- a/test/system/auto_retire_test.rb
+++ b/test/system/auto_retire_test.rb
@@ -111,7 +111,9 @@ class AutoRetireTest < ApplicationSystemTestCase
 
   test 'delete times channel when retire' do
     user = users(:kyuukai)
-    user.discord_profile.update!(times_id: '987654321987654321')
+    user.discord_profile.times_id = '987654321987654321'
+    user.discord_profile.account_name = 'kyuukai#1234'
+    user.discord_profile.save!(validate: false)
 
     travel_to Time.zone.local(2020, 7, 2, 0, 0, 0) do
       Discord::Server.stub(:delete_text_channel, true) do

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -42,7 +42,10 @@ class RetirementTest < ApplicationSystemTestCase
 
   test 'retire user with times_channel' do
     user = users(:hajime)
-    user.discord_profile.update!(times_id: '987654321987654321')
+    user.discord_profile.times_id = '987654321987654321'
+    user.discord_profile.account_name = 'hatsuno#1234'
+    user.save!(validate: false)
+
     Discord::Server.stub(:delete_text_channel, true) do
       visit_with_auth new_retirement_path, user.login_name
       find('label', text: 'とても良い').click


### PR DESCRIPTION
## Issue

- #6423 
- #6424 
- #6102 

## 概要
下記PRで休会から六ヶ月後に自動で退会される機能を実装しましたが、実際には休会から六ヶ月以上経ったユーザーも退会していませんでした。
https://github.com/fjordllc/bootcamp/pull/6490

原因を調査したところ、ユーザーのDiscordアカウント名が不正なときに退会処理に失敗するようになっていたことが分かりました。退会時に分報チャンネルを削除するとき、ユーザーに紐づくDiscordProfileモデルのtimes_idをnilに更新するのですが、このときにアカウント名が不正だとDiscordProfileモデルのバリデーションに引っかかっていました。
https://github.com/fjordllc/bootcamp/pull/6490#issuecomment-1978316435

そこで、退会時にDiscordProfileモデルを更新するときは、account_nameのバリデーションを無効にするように変更しました。
問題のバリデーションは下記の場所で定義されており、バリデーションコンテキストに`:retirement`を指定することで無効化することができます。
https://github.com/fjordllc/bootcamp/blob/f22f9f7f0cb8dc4a1ce7fdee63744b45339386e4/app/models/discord_profile.rb#L12-L21

ちなみに、Discordアカウント名が不正なユーザーが存在する理由は、下記PRによりアカウント名のバリデーションルールが変更されたことでした。
https://github.com/fjordllc/bootcamp/pull/6855/files#diff-f7b1ee506d31db4da441d303c2f736fcc14e1069bb26bb6e6dc5d20b869df2e1


## 変更確認方法
Discordのアカウント名が不正かつ六ヶ月以上休会しているユーザーを作成し、六ヶ月以上休会しているユーザーを自動退会させるAPIが正常に動作していることを確認する。

1. 下記PRのディスクリプションにある「変更確認方法」「準備」の手順に従い、テスト用Discordサーバーの作成、Discord Botの作成、環境変数の設定を行う（このあとの手順で追加の環境変数を設定するのでまだサーバは立ち上げなくてよい）
    - https://github.com/fjordllc/bootcamp/pull/6626
1. `bug/delete-times-channel-with-invalid-account-name-when-retire`をローカルに取り込む
2. `bin/rails db:seed`を実行してDBを初期化
6. ターミナルでコマンドを実行し、環境変数TOKENを適当に設定する（このあとの手順で、六ヶ月以上休会しているユーザを自動退会させるURLを叩くため）
```
> export TOKEN=hoge
```
7. そのままサーバを立ち上げる
8. ログアウトした状態で参加登録ページから適当な名前（ここでは`nagai-kyuukai-invalid-discord`とする）で参加登録する
    - クレジットカード番号にはテスト用の番号を入れる
      - https://stripe.com/docs/testing?locale=ja-JP#cards
9. テスト用のDiscordサーバーに分報チャンネルが作られていることを確認する
10. Railsコンソールを操作し、さきほど作成したユーザーの休会日を6ヵ月前にする
```ruby
> user = User.find_by(login_name: 'nagai-kyuukai-invalid-discord')
> user.update!(hibernated_at: 6.months.ago)
```
11. さらに、ユーザーのDiscordアカウント名を不正なもの（`#`を用いたもの）に変更する
```ruby
> user.discord_profile.account_name = 'hoge#1234'
> user.discord_profile.save!(validate: false)
```
10. komagataでログインしなおし、管理ページの休会ユーザー一覧ページ（`/admin/users?target=hibernated`に遷移する。そこにさきほど作成したユーザーがいることを確認する。さらに、休会日が6ヵ月前かつDiscordアカウント名が不正なものになっていることを確認する
![image](https://github.com/fjordllc/bootcamp/assets/46841037/18e6ab0c-3869-4091-aa2b-ee8215dbc403)
![image](https://github.com/fjordllc/bootcamp/assets/46841037/d35fa689-d24a-48d1-add0-0abb568f5075)

12. また、`kyuukai（Kyu Kai）`ユーザーがいれば、Railsコンソールを操作し、`kyuukai（Kyu Kai)`ユーザーを削除しておく
    - ※このユーザーにはダミーのサブスクリプション番号が登録されており、このユーザーを退会させようとすると定期支払い削除処理でエラーになるため
```ruby
> user = User.find_by(login_name: 'kyuukai')
> user.destroy!
```
13. さらに、`nagai-kyuukai（Nagai Kyu Kai）`ユーザーがいることも確認しておく
7. 六ヶ月以上休会しているユーザーを自動退会させるURL（http://localhost:3000/scheduler/daily/auto_retire?token=hoge ）にブラウザでアクセスし、エラーが出ないことを確認する（画面は真っ白になる）（クエリパラメータに先ほど環境変数に設定した`TOKEN`の値を指定することに注意）
13. 管理ページをリロードし、`nagai-kyuukai-invalid-discord`ユーザーと`nagai-kyuukai（Nagai Kyu Kai）`ユーザーが休会ユーザー一覧に表示されておらず、退会ユーザー一覧に表示されることを確認する
14. `nagai-kyuukai-invalid-discord`ユーザーの分報チャンネルが消えていることを確認する
