### PR TITLE
ユーザー個別ページ、一覧ページのカウント数一覧にポートフォリオを追加

### DIFF
--- a/app/javascript/components/user-activity-counts.vue
+++ b/app/javascript/components/user-activity-counts.vue
@@ -21,6 +21,10 @@
       activity-name='回答',
       :activity-count='user.answer_count',
       :activity-url='`${user.url}/answers`')
+    user-activity-count(
+      activity-name='ポートフォリオ',
+      :activity-count='user.work_count',
+      :activity-url='`${user.url}/portfolio`')
 </template>
 <script>
 import UserActivityCount from './user-activity-count.vue'

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -20,6 +20,7 @@ if user.student_or_trainee?
   json.product_count user.products.size
   json.question_count user.questions.size
   json.answer_count user.answers.size
+  json.work_count user.works.size
 end
 
 

--- a/app/views/users/_activity_counts.html.slim
+++ b/app/views/users/_activity_counts.html.slim
@@ -4,28 +4,34 @@ dl.card-counts__items
       dt.card-counts__item-label
         | 日報
       dd.card-counts__item-value
-        = link_to user.reports.count, user_reports_path(user)
+        = link_to user.reports.size, user_reports_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | 提出物
       dd.card-counts__item-value
-        = link_to user.products.count, user_products_path(user)
+        = link_to user.products.size, user_products_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | コメント
       dd.card-counts__item-value
-        = link_to user.comments.count, user_comments_path(user)
+        = link_to user.comments.size, user_comments_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | 質問
       dd.card-counts__item-value
-        = link_to user.questions.count, user_questions_path(user)
+        = link_to user.questions.size, user_questions_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | 回答
       dd.card-counts__item-value
-        = link_to user.answers.count, user_answers_path(user)
+        = link_to user.answers.size, user_answers_path(user)
+  .card-counts__item
+    .card-counts__item-inner
+      dt.card-counts__item-label
+        | ポートフォリオ
+      dd.card-counts__item-value
+        = link_to user.works.size, user_portfolio_path(user)

--- a/app/views/users/_activity_counts.html.slim
+++ b/app/views/users/_activity_counts.html.slim
@@ -4,34 +4,40 @@ dl.card-counts__items
       dt.card-counts__item-label
         | 日報
       dd.card-counts__item-value
-        = link_to user.reports.size, user_reports_path(user)
+        = link_to_if !user.reports.empty?,
+            user.reports.size, user_reports_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | 提出物
       dd.card-counts__item-value
-        = link_to user.products.size, user_products_path(user)
+        = link_to_if !user.products.empty?,
+            user.products.size, user_products_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | コメント
       dd.card-counts__item-value
-        = link_to user.comments.size, user_comments_path(user)
+        = link_to_if !user.comments.empty?,
+            user.comments.size, user_comments_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | 質問
       dd.card-counts__item-value
-        = link_to user.questions.size, user_questions_path(user)
+        = link_to_if !user.questions.empty?,
+            user.questions.size, user_questions_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | 回答
       dd.card-counts__item-value
-        = link_to user.answers.size, user_answers_path(user)
+        = link_to_if !user.answers.empty?,
+            user.answers.size, user_answers_path(user)
   .card-counts__item
     .card-counts__item-inner
       dt.card-counts__item-label
         | ポートフォリオ
       dd.card-counts__item-value
-        = link_to user.works.size, user_portfolio_path(user)
+        = link_to_if !user.works.empty?,
+            user.works.size, user_portfolio_path(user)


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7517

## 概要
ユーザー個別ページ、一覧ページのカウント数一覧にポートフォリオを追加しました。
また、ユーザー個別ページのカウント数一覧において、カウント数が0の場合はリンクしないよう変更しました。

## 変更確認方法

1. `feature/add-portfolio-count-to-user`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. 任意のアカウントでログインし、`/users`にアクセス
5. 次の2点を確認する
	-  各ユーザーのカウント数一覧に「ポートフォリオ」項目が追加されている
	- カウントの数字部分のリンクが次の状態になっている
		- **カウントが0ではない場合**
		ユーザー個別ページの対応するタブにリンクにしている。
		- **カウントが0の場合**
		リンクなし。
6. `/users`からユーザー`hatsuno`をクリック
7. 次の2点を確認する
	- カウント数一覧に「ポートフォリオ」項目が追加されている
	- カウントの数字部分のリンクが次の状態になっている
		- **カウントが0ではない場合**
		対応するタブにリンクにしている。
		- **カウントが0の場合**
		リンクなし。

## Screenshot

### 変更前
#### /users
![Issue#7517変更前（一覧）](https://github.com/fjordllc/bootcamp/assets/125527162/4737a5ad-6b7b-4bbf-861b-5af67b7f746f)

#### /users/show
![Issue#7517変更前（個別）](https://github.com/fjordllc/bootcamp/assets/125527162/0a7efe19-f80c-47bf-8f7c-934cd205dc35)


### 変更後
#### /users
![Issue#7517変更後（一覧）](https://github.com/fjordllc/bootcamp/assets/125527162/ce827dd3-360e-4083-a870-d3afa1d75d13)

#### /users/show
![Issue#7517変更後（個別）](https://github.com/fjordllc/bootcamp/assets/125527162/43b79961-b13b-4a11-8680-1b6e6c545471)
