### PR TITLE
slim-lintのルールを適用する5

### DIFF
--- a/config/slim_lint.yml
+++ b/config/slim_lint.yml
@@ -13,7 +13,7 @@ linters:
       - Layout/FirstArrayElementIndentation
       - Layout/FirstParameterIndentation
       - Layout/HashAlignment # 検討の結果、残す。（詳細は issue #7253 参照）
-      - Layout/IndentationWidth
+      - Layout/IndentationWidth # 検討の結果、残す(詳細は#7251)
       - Layout/InitialIndentation
       - Layout/MultilineArrayBraceLayout
       - Layout/MultilineAssignmentLayout


### PR DESCRIPTION
## Issue
- #7251 

## 概要
slim-lintの指摘するルールの内、多くのルールを除外する設定にしている。
このIssueでは1つのルールを有効化し、指摘されるviewファイルをルールに沿うように修正してください。
1Issueにつき1ルールとします。

適用するルールは`Layout/IndentationWidth`ですが、検討の結果このルールは適応対象外とします。
検討内容の詳細については #7251 をご確認お願いします

## 変更確認方法
特になし、問題なくアプリが動くこと
（除外にするやりとりについては issue を確認 #7251）

## Screenshot
特になし

### 変更前
特になし

### 変更後
特になし
