### PR TITLE
企業の並び順を一覧ページとプルダウンで揃える

### DIFF
--- a/app/controllers/api/admin/companies_controller.rb
+++ b/app/controllers/api/admin/companies_controller.rb
@@ -4,7 +4,7 @@ class API::Admin::CompaniesController < API::Admin::BaseController
   def index
     per = params[:per] || 25
     @companies = Company.with_attached_logo
-                        .order(:id)
+                        .order(created_at: :desc)
                         .page(params[:page])
                         .per(per)
   end

--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module CompaniesHelper
-  def all_companies_with_empty
-    Company.all.to_a.unshift(Company.new(name: '所属なし'))
+  def desc_ordered_companies_with_empty
+    desc_ordered_companies = Company.order(created_at: :desc).to_a
+    desc_ordered_companies.unshift(Company.new(name: '所属なし'))
   end
 end

--- a/app/javascript/components/AdminCompanies.jsx
+++ b/app/javascript/components/AdminCompanies.jsx
@@ -62,7 +62,7 @@ const AdminCompany = ({ company }) => {
 
   return (
     <tr className="admin-table__item">
-      <td className="admin-table__item-value">
+      <td className="admin-table__item-value company-name">
         <a href={url}>{company.name}</a>
       </td>
       <td className="admin-table__item-value">

--- a/app/views/users/form/_company.html.slim
+++ b/app/views/users/form/_company.html.slim
@@ -1,7 +1,7 @@
 .form-item
   = f.label '所属企業', class: 'a-form-label'
   .is-md.is-secondary.is-select.is-block
-    = f.collection_select :company_id, all_companies_with_empty, :id, :name, {}, { id: 'js-choices-single-select' }
+    = f.collection_select :company_id, desc_ordered_companies_with_empty, :id, :name, {}, { id: 'js-choices-single-select' }
   .a-form-help
     - if user.admin?
       p フィヨルドを選択。

--- a/db/fixtures/companies.yml
+++ b/db/fixtures/companies.yml
@@ -74,4 +74,16 @@ company26:
   name: "ユーザの企業に登録しないで株式会社"
   description: "この企業は user login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
   website: "http://example.com/test"
-  created_at: 2000-01-01 00:00:05
+  created_at: 2000-01-01 00:00:06
+
+company27:
+  name: "A株式会社"
+  description: "確認用"
+  website: "http://example.com/test"
+  created_at: 2000-01-01 00:00:07
+
+company28:
+  name: "B株式会社"
+  description: "確認用"
+  website: "http://example.com/test"
+  created_at: 2000-01-01 00:00:08

--- a/db/fixtures/companies.yml
+++ b/db/fixtures/companies.yml
@@ -70,20 +70,20 @@ company<%= i %>:
   created_at: 2000-01-01 00:00:05
 <% end %>
 
-company26:
-  name: "ユーザの企業に登録しないで株式会社"
-  description: "この企業は user login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
+newest_company:
+  name: "【created_at降順確認】一番新しい株式会社"
+  description: "/admin/companies で一番最初に表示される会社です"
   website: "http://example.com/test"
-  created_at: 2000-01-01 00:00:06
+  created_at: <%= Time.now %>
 
-company27:
-  name: "A株式会社"
-  description: "確認用"
+second_newest_company:
+  name: "【created_at降順確認】二番目に新しい株式会社"
+  description: "/admin/companies で二番目に表示される会社です"
   website: "http://example.com/test"
-  created_at: 2000-01-01 00:00:07
+  created_at: <%= Time.now - 1 %>
 
-company28:
-  name: "B株式会社"
-  description: "確認用"
+oldest_company:
+  name: "【created_at降順確認】最古株式会社"
+  description: "/admin/companies で最後に表示される会社です"
   website: "http://example.com/test"
-  created_at: 2000-01-01 00:00:08
+  created_at: <%= Time.zone.parse('1900-01-01 00:00:00') %>

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1228,7 +1228,7 @@ advisernocolleguetrainee:
   twitter_account: advisernocolleguetrainee
   facebook_url: https://www.facebook.com/fjordllc
   blog_url: http://advisernocolleguetrainee.example.com
-  company: advisernocolleguetrainee_only
+  company: company26
   description: '同僚がいないアドバイザーです。'
   adviser: true
   course: course1

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1228,7 +1228,7 @@ advisernocolleguetrainee:
   twitter_account: advisernocolleguetrainee
   facebook_url: https://www.facebook.com/fjordllc
   blog_url: http://advisernocolleguetrainee.example.com
-  company: company26
+  company: advisernocolleguetrainee_only
   description: '同僚がいないアドバイザーです。'
   adviser: true
   course: course1

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -76,20 +76,22 @@ company<%= i %>:
   created_at: 2000-01-01 00:00:05
 <% end %>
 
-company26:
-  name: "ユーザの企業に登録しないで株式会社"
-  description: "この企業は user login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
+newest_company:
+  name: "【created_at降順確認】一番新しい株式会社"
+  description: "/admin/companies で一番最初に表示される会社です"
   website: "http://example.com/test"
-  created_at: 2000-01-01 00:00:06
+  created_at: <%= Time.now %>
 
-company27:
-  name: "A株式会社"
-  description: "確認用"
+second_newest_company:
+  name: "【created_at降順確認】二番目に新しい株式会社"
+  description: "/admin/companies で二番目に表示される会社です"
   website: "http://example.com/test"
-  created_at: 2000-01-01 00:00:07
+  created_at: <%= Time.now - 1 %>
 
-company28:
-  name: "B株式会社"
-  description: "確認用"
+oldest_company:
+  name: "【created_at降順確認】最古株式会社"
+  description: "/admin/companies で最後に表示される会社です"
   website: "http://example.com/test"
-  created_at: 2000-01-01 00:00:08
+  created_at: <%= Time.zone.parse('1900-01-01 00:00:00') %>
+
+

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -80,4 +80,16 @@ company26:
   name: "ユーザの企業に登録しないで株式会社"
   description: "この企業は user login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
   website: "http://example.com/test"
-  created_at: 2000-01-01 00:00:05
+  created_at: 2000-01-01 00:00:06
+
+company27:
+  name: "A株式会社"
+  description: "確認用"
+  website: "http://example.com/test"
+  created_at: 2000-01-01 00:00:07
+
+company28:
+  name: "B株式会社"
+  description: "確認用"
+  website: "http://example.com/test"
+  created_at: 2000-01-01 00:00:08

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -76,6 +76,12 @@ company<%= i %>:
   created_at: 2000-01-01 00:00:05
 <% end %>
 
+advisernocolleguetrainee_only:
+  name: "ユーザの企業に登録しないで株式会社"
+  description: "この企業は user login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
+  website: "http://example.com/test"
+  created_at: 2000-01-01 00:00:06
+
 newest_company:
   name: "【created_at降順確認】一番新しい株式会社"
   description: "/admin/companies で一番最初に表示される会社です"
@@ -93,5 +99,4 @@ oldest_company:
   description: "/admin/companies で最後に表示される会社です"
   website: "http://example.com/test"
   created_at: <%= Time.zone.parse('1900-01-01 00:00:00') %>
-
 

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -76,7 +76,7 @@ company<%= i %>:
   created_at: 2000-01-01 00:00:05
 <% end %>
 
-advisernocolleguetrainee_only:
+company26:
   name: "ユーザの企業に登録しないで株式会社"
   description: "この企業は user login_name: advisernocolleguetrainee のユーザにのみ紐づけているので、それ以外のユーザは紐づけないでください。"
   website: "http://example.com/test"

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -6,7 +6,7 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
   test 'show listing companies' do
     visit_with_auth '/admin/companies', 'komagata'
     assert_equal '管理ページ | FBC', title
-    assert has_link?(companies(:company1).name, href: company_path(companies(:company1)))
+    assert has_link?(companies(:company28).name, href: company_path(companies(:company28)))
   end
 
   test 'create company' do

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -63,8 +63,8 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
   end
 
   test 'companies are ordered by created_at desc' do
-    new_company = companies(:company3)
-    old_company = companies(:company2)
+    new_company = companies(:company26)
+    old_company = companies(:company24)
     visit_with_auth '/admin/companies', 'komagata'
     assert_selector 'table.admin-table tbody tr:first-child td:first-child a', text: new_company.name
     assert_selector 'table.admin-table tbody tr:last-child td:first-child a', text: old_company.name

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -63,10 +63,13 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
   end
 
   test 'companies are ordered by created_at desc' do
-    new_company = companies(:company26)
-    old_company = companies(:company24)
     visit_with_auth '/admin/companies', 'komagata'
-    assert_selector 'table.admin-table tbody tr:first-child td:first-child a', text: new_company.name
-    assert_selector 'table.admin-table tbody tr:last-child td:first-child a', text: old_company.name
+    company_names = all('td.admin-table__item-value a').map(&:text)
+    expected_order = [
+      companies(:company28).name,
+      companies(:company27).name,
+      companies(:company26).name
+    ]
+    assert_equal expected_order, company_names
   end
 end

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -64,14 +64,20 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
 
   test 'companies are ordered by created_at desc' do
     visit_with_auth '/admin/companies', 'komagata'
-    # Reactコンポーネント 'AdminCompanies' が表示されるまで待機
+    # ページ遷移直後なのでreactコンポーネントが表示されるまで待つ
     assert_selector "[data-testid='admin-companies']"
-    company_names = all('.admin-table__items .admin-table__item .company-name').map { |td| td.text.strip }.first(3)
-    expected_order = [
-      companies(:company28).name,
-      companies(:company27).name,
-      companies(:company26).name
-    ]
-    assert_equal expected_order, company_names
+    within all('.admin-table__item')[0] do
+      assert_selector 'td.company-name', text: '【created_at降順確認】一番新しい株式会社'
+    end
+
+    within all('.admin-table__item')[1] do
+      assert_selector 'td.company-name', text: '【created_at降順確認】二番目に新しい株式会社'
+    end
+
+    find('.pagination__item.is-next button.pagination__item-link', match: :first).click
+
+    within all('.admin-table__item').last do
+      assert_selector 'td.company-name', text: '【created_at降順確認】最古株式会社'
+    end
   end
 end

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -64,7 +64,9 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
 
   test 'companies are ordered by created_at desc' do
     visit_with_auth '/admin/companies', 'komagata'
-    company_names = all('td.admin-table__item-value a').map(&:text)
+    # Reactコンポーネント 'AdminCompanies' が表示されるまで待機
+    assert_selector "[data-testid='admin-companies']"
+    company_names = all('.admin-table__items .admin-table__item .company-name').map { |td| td.text.strip }.first(3)
     expected_order = [
       companies(:company28).name,
       companies(:company27).name,

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -74,7 +74,7 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
       assert_selector 'td.company-name', text: '【created_at降順確認】二番目に新しい株式会社'
     end
 
-    find('.pagination__item.is-next button.pagination__item-link', match: :first).click
+    all('.pagination__item.is-next button.pagination__item-link')[1].click
 
     within all('.admin-table__item').last do
       assert_selector 'td.company-name', text: '【created_at降順確認】最古株式会社'

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -6,7 +6,7 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
   test 'show listing companies' do
     visit_with_auth '/admin/companies', 'komagata'
     assert_equal '管理ページ | FBC', title
-    assert has_link?(companies(:company28).name, href: company_path(companies(:company28)))
+    assert has_link?(companies(:newest_company).name, href: company_path(companies(:newest_company)))
   end
 
   test 'create company' do

--- a/test/system/admin/companies_test.rb
+++ b/test/system/admin/companies_test.rb
@@ -61,4 +61,12 @@ class Admin::CompaniesTest < ApplicationSystemTestCase
       assert_no_selector 'nav.pagination'
     end
   end
+
+  test 'companies are ordered by created_at desc' do
+    new_company = companies(:company3)
+    old_company = companies(:company2)
+    visit_with_auth '/admin/companies', 'komagata'
+    assert_selector 'table.admin-table tbody tr:first-child td:first-child a', text: new_company.name
+    assert_selector 'table.admin-table tbody tr:last-child td:first-child a', text: old_company.name
+  end
 end


### PR DESCRIPTION
## Issue

- #7514

## 概要
[企業一覧ページ](http://localhost:3000/admin/companies) 、会社一覧ページの各会社の行から飛べる「アドバイザー招待リンク」「研修生招待リンク」先の所属企業の並び順をそれぞれ **created_atの降順（新しい順）** に統一するIssueです。

`企業一覧ページ`
![image](https://github.com/fjordllc/bootcamp/assets/105143414/7d466715-b0da-442c-965c-8b2775d5b3fc)

`「アドバイザー招待リンク」「研修生招待リンク」`
![image](https://github.com/fjordllc/bootcamp/assets/105143414/43e3ee70-8e8e-45b8-befb-482308bf0f09)

※「アドバイザー招待リンク」「研修生招待リンク」は所属企業のプルダウンで確認できます

## 変更確認方法

1. `future/sort-companies-by-created-desc`をローカルに取り込む
2. `foreman start -f Procfile.dev`で起動
3. `admin`ユーザーでログイン
4. [企業一覧ページ](http://localhost:3000/admin/companies)にアクセス
5. 2〜3件新しい企業登録し、最新の企業が先頭に来ることを確認
6. 「アドバイザー招待リンク」「研修生招待リンク」に飛び、所属企業のプルダウン
が[企業一覧ページ](http://localhost:3000/admin/companies)と同じであることを確認

## Screenshot

### 変更前
概要の画像の通り

### 変更後
`企業一覧ページ`
<img width="1129" alt="スクリーンショット 2024-03-20 0 31 43" src="https://github.com/fjordllc/bootcamp/assets/105143414/95d0b343-1433-4b64-bc97-620d5cabc455">
最終ページ最後の要素
<img width="1115" alt="スクリーンショット 2024-03-20 0 32 10" src="https://github.com/fjordllc/bootcamp/assets/105143414/9363c5df-70c2-4f46-8163-a34be3ae606b">


`アドバイザー登録`

![0567e2ad39eb56c61eae4f1615bd94c3](https://github.com/fjordllc/bootcamp/assets/105143414/48795501-5b4d-4c49-9476-c297d286ff6c)


`フィヨルドブートキャンプ参加登録(研修生招待リンク)`

![a473ff3c44a2e8a7180d16def3226510](https://github.com/fjordllc/bootcamp/assets/105143414/db2a1543-969e-418d-9992-5bbe487236ef)
