### PR TITLE
コード内のメンションは通知対象外にするように実装

### DIFF
--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -55,7 +55,7 @@ module Mentioner
 
   def find_users_from_mentions(mentions)
     names = extract_login_names_from_mentions(mentions)
-    names.concat(User.mentor.map(&:login_name)) if mentions.include?('@mentor')
+    names.concat(User.mentor.map(&:login_name)) if mentions_to_mentor_included_without_code?
     # find_users_from_login_names 内のwhereで重複は削除する
     find_users_from_login_names(names)
   end
@@ -72,5 +72,10 @@ module Mentioner
       Page: "Docs「#{commentable.title}」",
       Announcement: "お知らせ「#{commentable.title}」"
     }[:"#{commentable_class}"]
+  end
+
+  def mentions_to_mentor_included_without_code?
+    body_excluded_code = mentionable.gsub(/```.*?```|`.*?`/m, '')
+    body_excluded_code.include?('@mentor')
   end
 end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -54,14 +54,15 @@ module Mentioner
   end
 
   def find_users_from_mentions(mentions)
-    names = extract_login_names_from_mentions(mentions)
+    mentionable_without_code = mentionable.gsub(/```.*?```|`.*?`/m, '')
+    names = extract_login_names_from_mentions(mentions, mentionable_without_code)
     names.concat(User.mentor.map(&:login_name)) if names.include?('mentor')
     # find_users_from_login_names 内のwhereで重複は削除する
     find_users_from_login_names(names)
   end
 
-  def extract_login_names_from_mentions(mentions)
-    mentions.map { |s| s.gsub(/@/, '') if mention_without_code?(s) }
+  def extract_login_names_from_mentions(mentions, mentionable_without_code)
+    mentions.map { |s| s.gsub(/@/, '') if mentionable_without_code.include?(s) }
   end
 
   def target_of_comment(commentable_class, commentable)
@@ -72,10 +73,5 @@ module Mentioner
       Page: "Docs「#{commentable.title}」",
       Announcement: "お知らせ「#{commentable.title}」"
     }[:"#{commentable_class}"]
-  end
-
-  def mention_without_code?(mention)
-    body_without_code = mentionable.gsub(/```.*?```|`.*?`/m, '')
-    body_without_code.include?(mention)
   end
 end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -61,7 +61,8 @@ module Mentioner
   end
 
   def extract_login_names_from_mentions(mentions)
-    mentionable_without_code = mentionable.gsub(/```.*?```|`.*?`/m, '')
+    code_block_regexp = /```.*?```|`.*?`/m
+    mentionable_without_code = mentionable.gsub(code_block_regexp, '')
     mentions.map { |s| s.gsub(/@/, '') if mentionable_without_code.include?(s) }
   end
 

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -54,14 +54,14 @@ module Mentioner
   end
 
   def find_users_from_mentions(mentions)
-    mentionable_without_code = mentionable.gsub(/```.*?```|`.*?`/m, '')
-    names = extract_login_names_from_mentions(mentions, mentionable_without_code)
+    names = extract_login_names_from_mentions(mentions)
     names.concat(User.mentor.map(&:login_name)) if names.include?('mentor')
     # find_users_from_login_names 内のwhereで重複は削除する
     find_users_from_login_names(names)
   end
 
-  def extract_login_names_from_mentions(mentions, mentionable_without_code)
+  def extract_login_names_from_mentions(mentions)
+    mentionable_without_code = mentionable.gsub(/```.*?```|`.*?`/m, '')
     mentions.map { |s| s.gsub(/@/, '') if mentionable_without_code.include?(s) }
   end
 

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -55,13 +55,13 @@ module Mentioner
 
   def find_users_from_mentions(mentions)
     names = extract_login_names_from_mentions(mentions)
-    names.concat(User.mentor.map(&:login_name)) if mentions_to_mentor_included_without_code?
+    names.concat(User.mentor.map(&:login_name)) if names.include?('mentor')
     # find_users_from_login_names 内のwhereで重複は削除する
     find_users_from_login_names(names)
   end
 
   def extract_login_names_from_mentions(mentions)
-    mentions.map { |s| s.gsub(/@/, '') }
+    mentions.map { |s| s.gsub(/@/, '') if mentions_without_code?(s) }
   end
 
   def target_of_comment(commentable_class, commentable)
@@ -74,8 +74,8 @@ module Mentioner
     }[:"#{commentable_class}"]
   end
 
-  def mentions_to_mentor_included_without_code?
-    body_excluded_code = mentionable.gsub(/```.*?```|`.*?`/m, '')
-    body_excluded_code.include?('@mentor')
+  def mention_without_code?(mention)
+    body_without_code = mentionable.gsub(/```.*?```|`.*?`/m, '')
+    body_without_code.include?(mention)
   end
 end

--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -61,7 +61,7 @@ module Mentioner
   end
 
   def extract_login_names_from_mentions(mentions)
-    mentions.map { |s| s.gsub(/@/, '') if mentions_without_code?(s) }
+    mentions.map { |s| s.gsub(/@/, '') if mention_without_code?(s) }
   end
 
   def target_of_comment(commentable_class, commentable)

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -285,4 +285,33 @@ class Notification::ReportsTest < ApplicationSystemTestCase
       assert_text "#{student}さんが2回連続でsadアイコンの日報を提出しました。"
     end
   end
+
+  test 'コードブロック、インラインコードの中でメンションをしても通知が飛ばない' do
+    # 他のテストの通知に影響を受けないよう、テスト実行前に通知を削除する
+    visit_with_auth '/notifications', 'komagata'
+    click_link '全て既読にする'
+
+    visit_with_auth '/reports', 'kimura'
+    click_link '日報作成'
+
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'コードブロック内でメンション')
+      fill_in('report[description]', with: '```
+                                           @mentor
+                                           ```
+                                           ` @mentor `
+                                           ')
+    end
+
+    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
+    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
+    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+
+    click_button '提出'
+    logout
+
+    visit_with_auth '/notifications?status=unread', 'komagata'
+    assert_text '未読の通知はありません'
+  end
 end

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -302,10 +302,14 @@ class Notification::ReportsTest < ApplicationSystemTestCase
                                            ')
     end
 
-    all('.learning-time')[0].all('.learning-time__started-at select')[0].select('07')
-    all('.learning-time')[0].all('.learning-time__started-at select')[1].select('30')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[0].select('08')
-    all('.learning-time')[0].all('.learning-time__finished-at select')[1].select('30')
+    within('.learning-time__started-at') do
+      select '07'
+      select '30'
+    end
+    within('.learning-time__finished-at') do
+      select '08'
+      select '30'
+    end
 
     click_button '提出'
     logout

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -287,7 +287,6 @@ class Notification::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'コードブロック、インラインコードの中でメンションをしても通知が飛ばない' do
-    # 他のテストの通知に影響を受けないよう、テスト実行前に通知を削除する
     visit_with_auth '/notifications', 'komagata'
     click_link '全て既読にする'
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -286,7 +286,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'コードブロック、インラインコードの中でメンションをしても通知が飛ばない' do
+  test 'mentioning in code blocks and inline code does not work' do
     visit_with_auth '/notifications', 'komagata'
     click_link '全て既読にする'
 

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -293,13 +293,10 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     visit_with_auth '/reports', 'kimura'
     click_link '日報作成'
 
+    mention_in_code = '```@mentor```, ` @mentor `'
     within('form[name=report]') do
       fill_in('report[title]', with: 'コードブロック内でメンション')
-      fill_in('report[description]', with: '```
-                                           @mentor
-                                           ```
-                                           ` @mentor `
-                                           ')
+      fill_in('report[description]', with: mention_in_code)
     end
 
     within('.learning-time__started-at') do


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/1938


## 概要
Issueの概要の通りです。

## 変更確認方法

1. `bugfix/exclude-@mentor-in-the-code-from-notification` をローカルに取り込む
2. `foreman start -f Procfile.dev`
3. ID `kimura`でログイン
4. 日報の本文内容を記述し、投稿。（例は一斉通知と、個別通知を一括確認する例になっています。）
5. ID `komagata`でログインし、通知が来ていないことを確認。
<details>
<summary>日報記述例</summary>
```
@mentor 
```

` @mentor `

```
@komagata 
```

` @komagata `
</details>

## Screenshot
手順実行後の通知です。

### 変更前
<img width="241" alt="スクリーンショット 2024-03-13 18 28 54" src="https://github.com/fjordllc/bootcamp/assets/106903482/0a1190f3-6d29-4aaf-889f-f051505b5a5d">


### 変更後
<img width="241" alt="スクリーンショット 2024-03-13 18 26 57" src="https://github.com/fjordllc/bootcamp/assets/106903482/72a44c74-d385-4a6c-8126-5f069a00c1f2">

## 補足
コードブロック、インラインコード内でメンションを行っても通知が送られるのは日報だけでした。
他に考えられるシチュエーションとしては以下で、全てチェックし通知が来ないことを確認しました。
他に可能性がある事項があれば、教えていただきたいです！

- [x] 質問
- [x] 質問への回答
- [x] 提出物へのコメント
- [x] 提出物
- [x] Docs投稿
- [x] Docsへのコメント
- [x] イベント作成
- [x] イベントへのコメント
- [x] お知らせへのコメント
- [x] ポートフォリオ投稿


