### PR TITLE
お知らせ通知用のジョブに例外処理を追加

### DIFF
--- a/app/jobs/post_announcement_job.rb
+++ b/app/jobs/post_announcement_job.rb
@@ -21,7 +21,14 @@ class PostAnnouncementJob < ApplicationJob
   end
 
   def send_on_site_notification(announcement, receiver)
-    ActivityNotifier.post_announcement(announcement:, receiver:).notify_now
+    Notification.create!(
+      kind: Notification.kinds[:announced],
+      user: receiver,
+      sender: announcement.sender,
+      link: Rails.application.routes.url_helpers.polymorphic_path(announcement),
+      message: "お知らせ「#{announcement.title}」",
+      read: false
+    )
   rescue StandardError => e
     Rails.logger.warn(e)
   end

--- a/app/jobs/post_announcement_job.rb
+++ b/app/jobs/post_announcement_job.rb
@@ -5,7 +5,24 @@ class PostAnnouncementJob < ApplicationJob
 
   def perform(announcement, receivers)
     receivers.each do |receiver|
-      ActivityDelivery.with(announcement:, receiver:).notify!(:post_announcement)
+      send_mail_notification(announcement, receiver)
+      send_on_site_notification(announcement, receiver)
     end
+  end
+
+  private
+
+  def send_mail_notification(announcement, receiver)
+    ActivityMailer.post_announcement(announcement:, receiver:).deliver_now
+  rescue Postmark::InactiveRecipientError => e
+    Rails.logger.warn "[Postmark] 受信者由来のエラーのためメールを送信できませんでした。：#{e.message}"
+  rescue StandardError => e
+    Rails.logger.warn(e)
+  end
+
+  def send_on_site_notification(announcement, receiver)
+    ActivityNotifier.post_announcement(announcement:, receiver:).notify_now
+  rescue StandardError => e
+    Rails.logger.warn(e)
   end
 end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -126,21 +126,6 @@ class ActivityNotifier < ApplicationNotifier
     )
   end
 
-  def post_announcement(params = {})
-    params.merge!(@params)
-    announce = params[:announcement]
-    receiver = params[:receiver]
-
-    notification(
-      body: "お知らせ「#{announce.title}」",
-      kind: :announced,
-      sender: announce.user,
-      receiver:,
-      link: Rails.application.routes.url_helpers.polymorphic_path(announce),
-      read: false
-    )
-  end
-
   def retired(params = {})
     params.merge!(@params)
     sender = params[:sender]

--- a/test/jobs/post_announcement_job_test.rb
+++ b/test/jobs/post_announcement_job_test.rb
@@ -5,14 +5,13 @@ require 'test_helper'
 class PostAnnouncementJobTest < ActiveJob::TestCase
   teardown do
     ActionMailer::Base.deliveries.clear
-    AbstractNotifier::Testing::Driver.deliveries.clear
   end
 
   test '#perform' do
     announcement = announcements(:announcement1)
     receivers = [users(:machida), users(:adminonly), users(:sotugyou_with_job)]
 
-    assert_difference [-> { ActionMailer::Base.deliveries.count }, -> { AbstractNotifier::Testing::Driver.deliveries.count }], 3 do
+    assert_difference [-> { ActionMailer::Base.deliveries.count }, -> { Notification.count }], 3 do
       perform_enqueued_jobs do
         PostAnnouncementJob.perform_later(announcement, receivers)
       end

--- a/test/notifiers/activity_notifier_test.rb
+++ b/test/notifiers/activity_notifier_test.rb
@@ -62,18 +62,6 @@ class ActivityNotifierTest < ActiveSupport::TestCase
     end
   end
 
-  test '#announcement' do
-    notification = ActivityNotifier.with(announcement: announcements(:announcement1), receiver: users(:kimura)).post_announcement
-
-    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
-      notification.notify_now
-    end
-
-    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-      notification.notify_later
-    end
-  end
-
   test '#hibernated' do
     notification = ActivityNotifier.with(sender: users(:kimura), receiver: users(:komagata)).hibernated
 


### PR DESCRIPTION
## Issue

- #7538

## 概要
通知用のジョブの中に例外処理が抜けていたため、例えば特定のアドレスへの送信を失敗すると、ジョブ自体が中断され、以降の通知が送られていなかった。

## 変更確認方法

1. `bug/add-exception-handling-to-announcement-job`をローカルに取り込む
2. 一時的にコードを変更し、特定の受信者への通知でエラーが発生するようにする（例えば`ActivityMailer#post_announcement`に以下のようなコードを追加）
    ```
    raise Postmark::InactiveRecipientError if @receiver.email == 'kimura@fjord.jp'
    ```
3. `kimura`以外のユーザーでお知らせを作成する
4. 以下を確認する
  - `good_job`のダッシュボード（`localhost:3000/good_job/jobs`）へアクセスして、該当のJobが`Succeeded`になっていること
  - メール通知が`kimura`以外に送られていること
  - サイト内通知が`kimura`を含む全員へ送られていること
 

