### PR TITLE
ユーザアイコンにroleを表す色枠が出ていないバグの修正

### DIFF
--- a/app/javascript/components/CommentUserIcon.jsx
+++ b/app/javascript/components/CommentUserIcon.jsx
@@ -1,11 +1,14 @@
 import React from 'react'
 
-export default function CommentUserIcon({ comment }) {
+export default function CommentUserIcon({ comment, report }) {
+  const roleClass = `is-${report.user.primary_role}`
   return (
     <a
       className="card-list-item__user-icons-icon"
       href={`/users/${comment.user_id}`}>
-      <img className="a-user-icon" src={comment.user_icon} />
+      <span className={`a-user-role ${roleClass}`}>
+        <img className="a-user-icon" src={comment.user_icon} />
+      </span>
     </a>
   )
 }

--- a/app/javascript/components/CommentUserIcon.jsx
+++ b/app/javascript/components/CommentUserIcon.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-export default function CommentUserIcon({ comment, report }) {
-  const roleClass = `is-${report.user.primary_role}`
+export default function CommentUserIcon({ comment }) {
+  const roleClass = `is-${comment.primary_role}`
   return (
     <a
       className="card-list-item__user-icons-icon"

--- a/app/javascript/components/ListComment.jsx
+++ b/app/javascript/components/ListComment.jsx
@@ -17,11 +17,7 @@ export default function ListComment({ report }) {
               <div className="card-list-item__user-icons">
                 {report.comments.map((comment) => {
                   return (
-                    <CommentUserIcon
-                      comment={comment}
-                      key={comment.user_id}
-                      report={report}
-                    />
+                    <CommentUserIcon comment={comment} key={comment.user_id} />
                   )
                 })}
               </div>

--- a/app/javascript/components/ListComment.jsx
+++ b/app/javascript/components/ListComment.jsx
@@ -17,7 +17,11 @@ export default function ListComment({ report }) {
               <div className="card-list-item__user-icons">
                 {report.comments.map((comment) => {
                   return (
-                    <CommentUserIcon comment={comment} key={comment.user_id} />
+                    <CommentUserIcon
+                      comment={comment}
+                      key={comment.user_id}
+                      report={report}
+                    />
                   )
                 })}
               </div>

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -165,12 +165,14 @@ const UserIcons = ({ users }) => {
           key={user.url}
           href={user.url}
           className="card-list-item__user-icons-icon">
-          <img
-            title={user.icon_title}
-            alt={user.icon_title}
-            src={user.avatar_url}
-            className={`a-user-icon is-${user.primary_role}`}
-          />
+          <span className={`a-user-role is-${user.primary_role}`}>
+            <img
+              title={user.icon_title}
+              alt={user.icon_title}
+              src={user.avatar_url}
+              className="a-user-icon"
+            />
+          </span>
         </a>
       ))}
     </div>

--- a/app/javascript/components/external-entry.vue
+++ b/app/javascript/components/external-entry.vue
@@ -3,10 +3,11 @@
   .card-list-item__inner
     .card-list-item__user
       a.card-list-item__user-link(:href='externalEntry.user.url')
-        img.card-list-item__user-icon.a-user-icon(
-          :title='externalEntry.user.icon_title',
-          :alt='externalEntry.user.icon_title',
-          :src='externalEntry.user.avatar_url')
+        span(:class='`a-user-role is-${externalEntry.user.primary_role}`')
+          img.card-list-item__user-icon.a-user-icon(
+            :title='externalEntry.user.icon_title',
+            :alt='externalEntry.user.icon_title',
+            :src='externalEntry.user.avatar_url')
     .card-list-item__rows
       .card-list-item__row
         .card-list-item-title

--- a/app/views/api/comments/_user_icons.json.jbuilder
+++ b/app/views/api/comments/_user_icons.json.jbuilder
@@ -1,12 +1,13 @@
-json.hasAnyComments comments.present?
-if comments.present?
-  json.numberOfComments comments.size
-  json.lastCommentDatetime comments.last.updated_at.to_datetime
-  json.lastCommentDate l comments.last.updated_at, format: :date_and_time
+json.hasAnyComments report.comments.present?
+if report.comments.present?
+  json.numberOfComments report.comments.size
+  json.lastCommentDatetime report.comments.last.updated_at.to_datetime
+  json.lastCommentDate l report.comments.last.updated_at, format: :date_and_time
   json.comments do
-    json.array! comments.commented_users do |user|
+    json.array! report.commented_users.uniq do |user|
       json.user_icon user.avatar_url
       json.user_id user.id
+      json.primary_role user.primary_role
     end
   end
 end

--- a/app/views/api/reports/index.json.jbuilder
+++ b/app/views/api/reports/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.reports @reports do |report|
   json.partial! "api/reports/report", report: report
   json.partial! "api/reports/checks", checks: report.checks
-  json.partial! "api/comments/user_icons", comments: report.comments
+  json.partial! "api/comments/user_icons", report: report
   json.user do
     json.partial! "api/users/user", user: report.user
   end

--- a/app/views/api/reports/sad_streak/index.json.jbuilder
+++ b/app/views/api/reports/sad_streak/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.reports @reports do |report|
   json.partial! "api/reports/report", report: report
   json.partial! "api/reports/checks", checks: report.checks
-  json.partial! "api/comments/user_icons", comments: report.comments
+  json.partial! "api/comments/user_icons", report: report
   json.user do
     json.partial! "api/users/user", user: report.user
   end

--- a/app/views/api/reports/unchecked/index.json.jbuilder
+++ b/app/views/api/reports/unchecked/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.reports @reports do |report|
   json.partial! "api/reports/report", report: report
-  json.partial! "api/comments/user_icons", comments: report.comments
+  json.partial! "api/comments/user_icons", report: report
   json.user do
     json.partial! "api/users/user", user: report.user
   end


### PR DESCRIPTION
## Issue

- #7516

## 概要
日報一覧ページ`/reports`のミニアイコンなど、一部のユーザアイコンでroleを表す色枠が表示されていないバグを修正するIsuseです。

下記の該当ページroleが表示されているかの確認をお願いします！

## 変更確認方法

1. `bug/fix-missing-role-border-on-icons`をローカルに取り込む
2. 管理者・アドバイザー・メンターいずれかでログイン
3. http://localhost:3000/reports?page=4 でコメントユーザーのroleを表す色枠が表示されているかを確認
4. http://localhost:3000/products でコメントユーザーのroleを表す色枠が表示されているかを確認
5. http://localhost:3000/external_entries で投稿者のroleを表す色枠が表示されているかを確認

※一般ユーザーは枠線はありません
※同じユーザーが複数回コメントをしてもアイコンの表示は1回のみ

## Screenshot

### 変更前

---

#### `/reports`のミニアイコン
<img width="706" alt="スクリーンショット 2024-03-11 17 19 19" src="https://github.com/fjordllc/bootcamp/assets/129706209/fbc9c31c-985d-4e0d-802e-f1118440ffae">

---

#### `products`のミニアイコン
<img width="547" alt="スクリーンショット 2024-03-11 17 42 43" src="https://github.com/fjordllc/bootcamp/assets/129706209/b12b4df9-0613-4309-90dc-bf233f956ca2">

---

#### `/external_entries`の普通のアイコン
<img width="708" alt="スクリーンショット 2024-03-11 17 49 33" src="https://github.com/fjordllc/bootcamp/assets/129706209/b1e38bf4-d260-41da-9b26-2f8f7c6995c0">

---

### 変更後

---

#### `/reports`のミニアイコン
<img width="722" alt="スクリーンショット 2024-03-19 17 34 40" src="https://github.com/fjordllc/bootcamp/assets/105143414/4adabde6-45f3-4e85-ba64-fa59640448e5">

---

#### `products`のミニアイコン
<img width="720" alt="スクリーンショット 2024-03-19 17 36 25" src="https://github.com/fjordllc/bootcamp/assets/105143414/cb9f1dae-0e95-4f82-a8db-b6dd0df45585">


---

#### `/external_entries`の普通のアイコン
<img width="738" alt="スクリーンショット 2024-03-19 17 37 14" src="https://github.com/fjordllc/bootcamp/assets/105143414/f5f86b77-537c-4fd4-a6f0-573281763b6c">


---