### PR TITLE
ブラウザのバックボタンで戻った時にユーザー登録ボタンの状態を更新する

### DIFF
--- a/app/javascript/agreements.js
+++ b/app/javascript/agreements.js
@@ -18,6 +18,6 @@ document.addEventListener('DOMContentLoaded', () => {
       element.addEventListener('click', updateSubmitButtonStateFromCheckbox)
     })
 
-    updateSubmitButtonStateFromCheckbox()
+    window.addEventListener(`pageshow`, updateSubmitButtonStateFromCheckbox)
   }
 })


### PR DESCRIPTION
## Issue

- #7553

## 概要
`DOMContentLoaded`イベントでチェックボックスの状態を元に「参加する」ボタンの有効無効を切り替えていたが、ブラウザのバックボタンで戻った場合、`DOMContentLoaded`イベント時にはまだチェックボックスの状態が復元されておらず、結果、チェックボックスの状態と「参加する」ボタンの状態が合わせられていなかった。

※ブラウザによって挙動が異なっていたため、違いの調査については上記Issueのコメントに記載しています。
- https://github.com/fjordllc/bootcamp/issues/7553#issuecomment-2008631911

## 変更確認方法

1. `bug/fix-submit-button-on-browser-back`をローカルに取り込む
2. `localhost:3000/users/new`にアクセスする
3. `カード番号`を入力する
    - ダミーの番号として、`4242 4242 4242 4242`が使用可能（有効期限は任意の将来の日付、セキュリティコードは任意の3桁の数字）
4. 他の入力必須項目を未入力のまま、以下のチェックボックスにチェックを入れ、`参加する`ボタンをクリックする
    - `アンチハラスメントポリシーに同意`
    - `利用規約に同意`
5. 未入力項目があるため、未入力エラーが出る。その画面で以下の項目を確認する
    - `アンチハラスメントポリシーに同意`のチェックボックスがチェック状態のままであること
    - `利用規約に同意`のチェックボックスがチェック状態のままであること
    - `参加する`ボタンが有効（クリックできる状態）であること
6. ブラウザのバックボタンで戻る
7. 以下の項目を確認する
    - `アンチハラスメントポリシーに同意`のチェックボックスがチェック状態のままであること
    - `利用規約に同意`のチェックボックスがチェック状態のままであること
    - `参加する`ボタンが有効（クリックできる状態）であること

## Screenshot

### 変更前
[![Image from Gyazo](https://i.gyazo.com/6ca4783b8db7bc7ebe891e996fd89b3a.gif)](https://gyazo.com/6ca4783b8db7bc7ebe891e996fd89b3a)

### 変更後
[![Image from Gyazo](https://i.gyazo.com/d00ed970511c507f9eb99f906e2e8ea3.gif)](https://gyazo.com/d00ed970511c507f9eb99f906e2e8ea3)
