### PR TITLE
分報チャンネル作成後、生成されたチャンネルのURLをユーザーのプロフィールに自動で設定

### DIFF
--- a/app/models/times_channel_creator.rb
+++ b/app/models/times_channel_creator.rb
@@ -7,7 +7,8 @@ class TimesChannelCreator
 
     times_channel = Discord::TimesChannel.new(user.login_name)
     if times_channel.save
-      user.discord_profile.update(times_id: times_channel.id)
+      times_url = "https://discord.com/channels/#{ENV['DISCORD_GUILD_ID']}/#{times_channel.id}"
+      user.discord_profile.update(times_id: times_channel.id, times_url:)
     else
       Rails.logger.warn "[Discord API] #{user.login_name}の分報チャンネルが作成できませんでした。"
     end

--- a/app/models/times_channel_destroyer.rb
+++ b/app/models/times_channel_destroyer.rb
@@ -7,6 +7,7 @@ class TimesChannelDestroyer
 
     if Discord::Server.delete_text_channel(user.discord_profile.times_id)
       user.discord_profile.times_id = nil
+      user.discord_profile.times_url = nil
       user.discord_profile.save!(context: :retirement)
     else
       Rails.logger.warn "[Discord API] #{user.login_name}の分報チャンネルが削除できませんでした。"

--- a/test/integration/discord/users_controller_test.rb
+++ b/test/integration/discord/users_controller_test.rb
@@ -1,34 +1,39 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'supports/mock_env_helper'
 
 module Discord
   class UsersControllerTest < ActionDispatch::IntegrationTest
+    include MockEnvHelper
+
     test 'POST create by student' do
-      Card.stub(:new, -> { FakeCard.new }) do
-        Subscription.stub(:new, -> { FakeSubscription.new }) do
-          Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
-            assert_difference 'User.students.count', 1 do
-              post users_path,
-                   params: {
-                     user: {
-                       adviser: 'false',
-                       trainee: 'false',
-                       company_id: '',
-                       login_name: 'Piyopiyo-student',
-                       email: 'piyopiyo-student@example.com',
-                       name: '現役生です',
-                       name_kana: 'ゲンエキセイデス',
-                       description: '現役生と言います。よろしくお願いします。',
-                       job: 'part_time_worker',
-                       os: 'linux',
-                       experience: 'inexperienced',
-                       password: 'passW0rd1234',
-                       password_confirmation: 'passW0rd1234',
-                       coc: 1,
-                       tos: 2
+      mock_env('DISCORD_GUILD_ID' => '111') do
+        Card.stub(:new, -> { FakeCard.new }) do
+          Subscription.stub(:new, -> { FakeSubscription.new }) do
+            Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
+              assert_difference 'User.students.count', 1 do
+                post users_path,
+                     params: {
+                       user: {
+                         adviser: 'false',
+                         trainee: 'false',
+                         company_id: '',
+                         login_name: 'Piyopiyo-student',
+                         email: 'piyopiyo-student@example.com',
+                         name: '現役生です',
+                         name_kana: 'ゲンエキセイデス',
+                         description: '現役生と言います。よろしくお願いします。',
+                         job: 'part_time_worker',
+                         os: 'linux',
+                         experience: 'inexperienced',
+                         password: 'passW0rd1234',
+                         password_confirmation: 'passW0rd1234',
+                         coc: 1,
+                         tos: 2
+                       }
                      }
-                   }
+              end
             end
           end
         end
@@ -36,43 +41,39 @@ module Discord
       assert_redirected_to root_url
 
       student = User.find_by(login_name: 'Piyopiyo-student')
-      student.create_discord_profile unless student.discord_profile
-      student.discord_profile.times_id = ValidTimesChannel.new.id
-      student.discord_profile.save!
       assert_not_nil student.discord_profile.times_id
     end
 
     test 'POST create by trainee' do
-      Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
-        assert_difference 'User.trainees.count', 1 do
-          post users_path,
-               params: {
-                 user: {
-                   adviser: 'false',
-                   trainee: 'true',
-                   company_id: '123456789',
-                   login_name: 'Piyopiyo-trainee',
-                   email: 'piyopiyo-trainee@example.com',
-                   name: '研修生です',
-                   name_kana: 'ケンシュウセイデス',
-                   description: '研修生と言います。よろしくお願いします。',
-                   job: 'office_worker',
-                   os: 'windows_wsl2',
-                   experience: 'ruby',
-                   password: 'passW0rd1234',
-                   password_confirmation: 'passW0rd1234',
-                   coc: 1,
-                   tos: 2
+      mock_env('DISCORD_GUILD_ID' => '222') do
+        Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
+          assert_difference 'User.trainees.count', 1 do
+            post users_path,
+                 params: {
+                   user: {
+                     adviser: 'false',
+                     trainee: 'true',
+                     company_id: '123456789',
+                     login_name: 'Piyopiyo-trainee',
+                     email: 'piyopiyo-trainee@example.com',
+                     name: '研修生です',
+                     name_kana: 'ケンシュウセイデス',
+                     description: '研修生と言います。よろしくお願いします。',
+                     job: 'office_worker',
+                     os: 'windows_wsl2',
+                     experience: 'ruby',
+                     password: 'passW0rd1234',
+                     password_confirmation: 'passW0rd1234',
+                     coc: 1,
+                     tos: 2
+                   }
                  }
-               }
+          end
         end
       end
       assert_redirected_to root_url
 
       trainee = User.find_by(login_name: 'Piyopiyo-trainee')
-      trainee.create_discord_profile unless trainee.discord_profile
-      trainee.discord_profile.times_id = ValidTimesChannel.new.id
-      trainee.discord_profile.save!
       assert_not_nil trainee.discord_profile.times_id
     end
 
@@ -130,7 +131,7 @@ module Discord
       end
 
       def id
-        'fake_times_snowflake_0123456789'
+        '1234567890123456789'
       end
     end
   end

--- a/test/integration/discord/users_controller_test.rb
+++ b/test/integration/discord/users_controller_test.rb
@@ -36,6 +36,9 @@ module Discord
       assert_redirected_to root_url
 
       student = User.find_by(login_name: 'Piyopiyo-student')
+      student.create_discord_profile unless student.discord_profile
+      student.discord_profile.times_id = ValidTimesChannel.new.id
+      student.discord_profile.save!
       assert_not_nil student.discord_profile.times_id
     end
 
@@ -67,6 +70,9 @@ module Discord
       assert_redirected_to root_url
 
       trainee = User.find_by(login_name: 'Piyopiyo-trainee')
+      trainee.create_discord_profile unless trainee.discord_profile
+      trainee.discord_profile.times_id = ValidTimesChannel.new.id
+      trainee.discord_profile.save!
       assert_not_nil trainee.discord_profile.times_id
     end
 

--- a/test/models/times_channel_creator_test.rb
+++ b/test/models/times_channel_creator_test.rb
@@ -46,6 +46,20 @@ class TimesChannelCreatorTest < ActiveSupport::TestCase
     assert_not user.student_or_trainee?
   end
 
+  test '#call creates times_url' do
+    user = users(:hajime)
+    assert_nil user.discord_profile.times_id
+    assert_nil user.discord_profile.times_url
+
+    Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
+      TimesChannelCreator.new.call({ user: })
+    end
+
+    assert_equal '1234567890123456789', user.discord_profile.times_id
+    expected_url = "https://discord.com/channels/#{ENV['DISCORD_GUILD_ID']}/1234567890123456789"
+    assert_equal expected_url, user.discord_profile.times_url
+  end
+
   class ValidTimesChannel
     def save
       true

--- a/test/models/times_channel_creator_test.rb
+++ b/test/models/times_channel_creator_test.rb
@@ -19,6 +19,8 @@ class TimesChannelCreatorTest < ActiveSupport::TestCase
         TimesChannelCreator.new.call({ user: })
       end
       assert_equal '1234567890123456789', user.discord_profile.times_id
+      expected_url = "https://discord.com/channels/#{ENV['DISCORD_GUILD_ID']}/1234567890123456789"
+      assert_equal expected_url, user.discord_profile.times_url
       assert_nil logs.last
     end
   end
@@ -54,10 +56,6 @@ class TimesChannelCreatorTest < ActiveSupport::TestCase
     Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
       TimesChannelCreator.new.call({ user: })
     end
-
-    assert_equal '1234567890123456789', user.discord_profile.times_id
-    expected_url = "https://discord.com/channels/#{ENV['DISCORD_GUILD_ID']}/1234567890123456789"
-    assert_equal expected_url, user.discord_profile.times_url
   end
 
   class ValidTimesChannel

--- a/test/models/times_channel_creator_test.rb
+++ b/test/models/times_channel_creator_test.rb
@@ -13,6 +13,7 @@ class TimesChannelCreatorTest < ActiveSupport::TestCase
         TimesChannelCreator.new.call({ user: })
       end
       assert_nil user.discord_profile.times_id
+      assert_nil user.discord_profile.times_url
       assert_equal "[Discord API] #{user.login_name}の分報チャンネルが作成できませんでした。", logs.pop
 
       Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
@@ -46,16 +47,6 @@ class TimesChannelCreatorTest < ActiveSupport::TestCase
       TimesChannelCreator.new.call({ user: })
     end
     assert_not user.student_or_trainee?
-  end
-
-  test '#call creates times_url' do
-    user = users(:hajime)
-    assert_nil user.discord_profile.times_id
-    assert_nil user.discord_profile.times_url
-
-    Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
-      TimesChannelCreator.new.call({ user: })
-    end
   end
 
   class ValidTimesChannel

--- a/test/models/times_channel_destroyer_test.rb
+++ b/test/models/times_channel_destroyer_test.rb
@@ -15,6 +15,7 @@ class TimesChannelDestroyerTest < ActiveSupport::TestCase
         TimesChannelDestroyer.new.call({ user: })
       end
       assert_nil user.discord_profile.times_id
+      assert_nil user.discord_profile.times_url
       assert_nil logs.last
     end
   end

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -55,6 +55,7 @@ class RetirementTest < ApplicationSystemTestCase
     end
     assert_equal Date.current, user.reload.retired_on
     assert_nil user.discord_profile.times_id
+    assert_nil user.discord_profile.times_url
   end
 
   test 'retire user with postmark error' do


### PR DESCRIPTION
## Issue

- #6907

## 概要

ユーザーの新規登録時に分報チャンネルを自動で作成した際に、プロフィールページの分報URLも自動で入力されるようにしました。また、退会時には分報URLが削除されるようにしました。

## 変更確認方法

1. 下記PRのディスクリプションにある「変更確認方法」「準備」の手順に従い、テスト用Discordサーバーの作成、Discord Botの作成、環境変数の設定を行う
    - [退会時に分報チャンネルを自動で削除する #6626](https://github.com/fjordllc/bootcamp/pull/6626)
1. `feature/auto-fill-times-url-on-registration`をローカルに取り込む
1. `bin/rails db:seed`を実行し、初期データを追加
1. `bin/rails s`でサーバを立ち上げる

**分報チャンネル作成後、生成されたチャンネルのURLがユーザーのプロフィールページに自動で設定されているか確認する**

1. ログアウトした状態で参加登録ページから適当な名前で参加登録する
2. クレジットカード番号にはテスト用の番号を入力する
    - https://stripe.com/docs/testing?locale=ja-JP#cards
3. テスト用のDiscordサーバーに分報チャンネルが作成されていることを確認する
4. 登録したユーザーでログイン
5. ユーザープロフィールページの分報のリンクから、作成した分報チャンネルに遷移することを確認する

<img width="655" alt="_development__jidouchanelurlsakusei___FBC" src="https://github.com/fjordllc/bootcamp/assets/79001972/095dd0ee-6e1d-444b-9670-a143fc4839af">

6. [登録情報変更ページ](http://localhost:3000/current_user/edit)の「分報URL」にDiscordの分報チャンネルのURLが作成されていることを確認する

<img width="546" alt="_development__登録情報変更___FBC" src="https://github.com/fjordllc/bootcamp/assets/79001972/d3233a5f-c224-4c53-a65e-8df6404f638b">

**ユーザーが自ら退会するときの動作確認**

1. ログアウトした状態で参加登録ページから適当な名前で参加登録する
    - クレジットカード番号にはテスト用の番号を入れる
        - https://stripe.com/docs/testing?locale=ja-JP#cards
2. テスト用のDiscordサーバーに分報チャンネルが作られていることを確認する
3. 先ほど登録したユーザーでログインし、画面右上のユーザーメニューから「退会手続き」を選択して退会する
4. Discordから分報チャンネルが削除されていることを確認する
5. Railsコンソールでユーザーの分報チャンネルのURLが削除されているかを確認する

```
ユーザーを検索

> user = User.find_by(login_name: 'jidouchanelurlsakusei')

検索したユーザーのdiscord_profileに関連付けられたtimes_urlを確認

> user.discord_profile.times_url

=> nil
```

**管理ページから退会させるときの動作確認**

1. ログアウトした状態で参加登録ページから適当な名前で参加登録する
    - クレジットカード番号にはテスト用の番号を入れる
        - https://stripe.com/docs/testing?locale=ja-JP#cards
2. テスト用のDiscordサーバーに分報チャンネルが作られていることを確認する
3. komagata（管理者）でログインしなおす
4. 右上のユーザーメニューから管理ページに遷移し、ユーザー一覧ページから先ほど作成したユーザーを探し、表右端の「操作」からユーザー登録情報変更画面に遷移する
5. ユーザーステータスを「退会済」に変更して「更新する」

<img width="497" alt="_development__ユーザー登録情報変更___FBC" src="https://github.com/fjordllc/bootcamp/assets/79001972/180fb77d-20d3-43f7-8757-48fc1b5fa544">

6. Discordから分報チャンネルが削除されていることを確認する
7. Railsコンソールでユーザーの分報チャンネルのURLが削除されているかを確認する

```
ユーザーを検索

> user = User.find_by(login_name: 'jidouchanelurlsakusei')

検索したユーザーのdiscord_profileに関連付けられたtimes_urlを確認

> user.discord_profile.times_url

=> nil
```

