### PR TITLE
Flakyなテストの改善

### DIFF
--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -23,8 +23,8 @@ class User::TagsTest < ApplicationSystemTestCase
     %i[cat shinjuku_rb neovim_v_zero_five_zero _net_framework may_j_].each do |key|
       name = acts_as_taggable_on_tags(key).name
       within '.random-tags' do
-        find('a.random-tags-item__link', text: /^#{name}$/)
-        click_on name
+        target_name = find('a.random-tags-item__link', text: /^#{name}$/)
+        target_name.click
       end
       assert_text "タグ「#{name}」のユーザー"
       assert_text user.name

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -23,7 +23,7 @@ class User::TagsTest < ApplicationSystemTestCase
     %i[cat shinjuku_rb neovim_v_zero_five_zero _net_framework may_j_].each do |key|
       name = acts_as_taggable_on_tags(key).name
       within '.random-tags' do
-        find('a.random-tags-item__link', text: /^#{Regexp.escape(name)}$/)
+        find('a.random-tags-item__link', text: /^#{name}$/)
         click_on name
       end
       assert_text "タグ「#{name}」のユーザー"

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -23,8 +23,7 @@ class User::TagsTest < ApplicationSystemTestCase
     %i[cat shinjuku_rb neovim_v_zero_five_zero _net_framework may_j_].each do |key|
       name = acts_as_taggable_on_tags(key).name
       within '.random-tags' do
-        target_name = find('a.random-tags-item__link', text: /^#{name}$/)
-        target_name.click
+        find('a.random-tags-item__link', text: /^#{name}$/).click
       end
       assert_text "タグ「#{name}」のユーザー"
       assert_text user.name

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -23,7 +23,7 @@ class User::TagsTest < ApplicationSystemTestCase
     %i[cat shinjuku_rb neovim_v_zero_five_zero _net_framework may_j_].each do |key|
       name = acts_as_taggable_on_tags(key).name
       within '.random-tags' do
-        click_on name, exact_text: true
+        find('a.random-tags-item__link', text: /^#{Regexp.escape(name)}$/).click
       end
       assert_text "タグ「#{name}」のユーザー"
       assert_text user.name

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -23,7 +23,8 @@ class User::TagsTest < ApplicationSystemTestCase
     %i[cat shinjuku_rb neovim_v_zero_five_zero _net_framework may_j_].each do |key|
       name = acts_as_taggable_on_tags(key).name
       within '.random-tags' do
-        find('a.random-tags-item__link', text: /^#{Regexp.escape(name)}$/).click
+        find('a.random-tags-item__link', text: /^#{Regexp.escape(name)}$/)
+        click_on name
       end
       assert_text "タグ「#{name}」のユーザー"
       assert_text user.name


### PR DESCRIPTION
## Issue

- #7565

## 概要
Flakyなテストとしてもともと存在した`test/system/user/tags_test.rb:19`が2024年3月20日頃からCIで極端にパスしなくなり、Success Rateが50％を切っている状況を緊急で改善するIssueになります

2024年3月21日現在[Flakyなテストを直したい](https://github.com/fjordllc/bootcamp/issues/7485)のPRがmergeされていますが下記テストは含まれていないためIssueを別途作成しました。

JavaScriptの実行中にXPath式の評価でエラーが発生していました(`click_on`の部分)。  

またJavaScriptによる動的なコンテンツの読み込みが原因で要素が見つからないため、Capybaraのウェイト機能を活用して要素が現れるのを待つように変更しました。


## 変更確認方法

1. `bug/fix-flaky-tags-test`をローカルに取り込む
2. 変更したコードの内容を確認
3. ローカルのターミナルで`bin/rails test test/system/user/tags_test.rb:19`を実行しパスすることを確認
4. CIでパスしないことが原因のため、このPRのテストの結果を確認

## Screenshot

### 変更前
<img width="846" alt="スクリーンショット 2024-03-21 14 14 40" src="https://github.com/fjordllc/bootcamp/assets/105143414/fbd70a15-59c3-4dee-9f5e-ac3c93b01854">

### 変更後
<img width="848" alt="スクリーンショット 2024-03-21 14 21 05" src="https://github.com/fjordllc/bootcamp/assets/105143414/1877f876-b0eb-412c-872f-751932128c61">
