### PR TITLE
都道府県別ユーザー一覧の機能がエラーで動かない問題の修正

### DIFF
--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -37,6 +37,7 @@ class Area
     end
 
     # regionとareaによって分類されたユーザー数をハッシュで取得して返す関数
+    # country_codeかsubdivision_codeのどちらかがnullのユーザーのデータは無視されます
     #
     # 返されるハッシュの例
     # {
@@ -66,6 +67,7 @@ class Area
     def country_subdivision_pairs
       User
         .select('country_code, subdivision_code')
+        .where.not(country_code: nil)
         .where.not(subdivision_code: nil)
         .pluck(:country_code, :subdivision_code)
     end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -247,7 +247,7 @@ hatsuno:
   updated_at: "2014-01-01 00:00:08"
   created_at: "2014-01-01 00:00:08"
   last_activity_at: "2014-01-01 00:00:08"
-  country_code: JP
+  country_code: JP # subdivision_codeがnilでcountry_codeがある場合
 
 hajime:
   login_name: hajime
@@ -264,6 +264,7 @@ hajime:
   job: office_worker
   os: mac
   experience: inexperienced
+  subdivision_code: '03' # country_codeがnilでsubdivision_codeがある場合
   organization: 始大学
   mail_notification: false
   unsubscribe_email_token: iHzoJxKvrBeGGT6DjAJgJQ


### PR DESCRIPTION
## Issue

こちらのIssueの機能がnullのデータを考慮出来ていなかったせいで本番で動かない問題の修正です
- https://github.com/fjordllc/bootcamp/issues/6096#issuecomment-1999668156

## 概要

Issueの方では

コード
```ruby
User
  .select('country_code, subdivision_code')
  .where.not(country_code: nil, subdivision_code: nil)
  .pluck(:country_code, :subdivision_code)
```

発行されるSQL
```sql
SELECT "users"."country_code", "users"."subdivision_code" FROM "users" WHERE NOT ("users"."country_code" IS NULL AND "users"."subdivision_code" IS NULL)
```

で直るのではないかと話しましたが、このコードでは｀(country_codeがnullでなく、かつsubdivision_codeがnullでない)でない`場合のデータを取得するSQLを発行するので、片方のみがnullである場合のデータを取得してしまいました。なのでこのPRでは下記のコードを使ってます。

コード
```ruby
User
  .select('country_code, subdivision_code')
  .where.not(country_code: nil)
  .where.not(subdivision_code: nil)
  .pluck(:country_code, :subdivision_code)
```

発行されるSQL
```sql
SELECT "users"."country_code", "users"."subdivision_code" FROM "users" WHERE "users"."country_code" IS NOT NULL AND "users"."subdivision_code" IS NOT NULL
```

これだと｀country_codeがnullでないかつ、subdivision_codeがnullでない`場合という意味になり、片方のみがnullである場合と両方がNullである場合のどちらもデータを取得しない条件になります。

また、この変更でNoMethodErrorが起こらなくなったことを確認するために、userのfixtureにcountry_codeかsubdivision_codeのどちらかがnullの場合のデータも追加しています。

テストが落ちていますが、これはmainのブランチの方ではマージされているflakyなテストなので問題ないと思います。
https://github.com/fjordllc/bootcamp/pull/7566