### PR TITLE
`RegularEvent`クラスの未使用のクラスメソッドを削除

### DIFF
--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -169,22 +169,6 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     regular_event_participations.find_by(user_id: user.id).present?
   end
 
-  class << self
-    def comming_soon_events(user)
-      [today_events, tomorrow_events].map do |regular_events|
-        regular_events.select { |event| event.participated_by?(user) }
-      end
-    end
-
-    def remove_event(events_arr, id)
-      events_arr.each do |events|
-        events.delete_if do |event|
-          event.id == id.to_i
-        end
-      end
-    end
-  end
-
   def assign_admin_as_organizer_if_none
     return if organizers.exists?
 

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -132,30 +132,6 @@ class RegularEventTest < ActiveSupport::TestCase
     assert_not regular_event.participated_by?(user)
   end
 
-  test '.comming_soon_events' do
-    regular_event = regular_events(:regular_event26)
-    user = users(:kimura)
-
-    travel_to Time.zone.local(2023, 4, 10, 0, 0, 0) do
-      today_regular_events, tomorrow_regular_events = RegularEvent.comming_soon_events(user)
-      assert today_regular_events.size == 1 && today_regular_events.include?(regular_event)
-      assert tomorrow_regular_events.size == 1 && tomorrow_regular_events.include?(regular_event)
-    end
-  end
-
-  test '.remove_event' do
-    regular_event1 = regular_events(:regular_event1)
-    regular_event2 = regular_events(:regular_event2)
-    regular_event3 = regular_events(:regular_event3)
-    regular_events1 = [regular_event1, regular_event2]
-    regular_events2 = [regular_event3]
-
-    RegularEvent.remove_event([regular_events1, regular_events2], regular_event1.id)
-    assert_not regular_events1.include?(regular_event1)
-    assert_includes regular_events1, regular_event2
-    assert_includes regular_events2, regular_event3
-  end
-
   test '#assign_admin_as_organizer_if_none' do
     regular_event = RegularEvent.new(
       title: '主催者のいないイベント',


### PR DESCRIPTION
## Issue

- なし

## 概要

検索しても利用箇所が見つからなかった、`RegularEvent`クラスの未使用のクラスメソッドを削除

## 変更確認方法

1. `bin/rails test:all`が通る