### PR TITLE
Release 2024-04-11 11:25:49

### DIFF
--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -70,6 +70,10 @@ class Area
         .where.not(country_code: nil)
         .where.not(subdivision_code: nil)
         .pluck(:country_code, :subdivision_code)
+        .filter do |country_code, _|
+          # country_codeが間違っている場合は配列から削除する
+          ISO3166::Country.codes.include?(country_code)
+        end
     end
 
     def translate(country_subdivision_pairs)

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -70,9 +70,12 @@ class Area
         .where.not(country_code: nil)
         .where.not(subdivision_code: nil)
         .pluck(:country_code, :subdivision_code)
-        .filter do |country_code, _|
+        .filter do |country_code, subdivision_code|
           # country_codeが間違っている場合は配列から削除する
-          ISO3166::Country.codes.include?(country_code)
+          return false unless ISO3166::Country.codes.include?(country_code)
+
+          # subdivision_codeが間違っている場合は配列から削除する
+          ISO3166::Country[country_code].subdivisions.keys.include?[subdivision_code]
         end
     end
 

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -72,10 +72,12 @@ class Area
         .pluck(:country_code, :subdivision_code)
         .filter do |country_code, subdivision_code|
           # country_codeが間違っている場合は配列から削除する
-          return false unless ISO3166::Country.codes.include?(country_code)
-
-          # subdivision_codeが間違っている場合は配列から削除する
-          ISO3166::Country[country_code].subdivisions.keys.include?[subdivision_code]
+          if ISO3166::Country.codes.include?(country_code)
+            # subdivision_codeが間違っている場合は配列から削除する
+            ISO3166::Country[country_code].subdivisions.key?(subdivision_code)
+          else
+            false
+          end
         end
     end
 

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -67,8 +67,8 @@ class Area
     def country_subdivision_pairs
       User
         .select('country_code, subdivision_code')
-        .where.not(country_code: nil)
-        .where.not(subdivision_code: nil)
+        .where.not(country_code: [nil, ''])
+        .where.not(subdivision_code: [nil, ''])
         .pluck(:country_code, :subdivision_code)
         .filter do |country_code, subdivision_code|
           # country_codeが間違っている場合は配列から削除する

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,6 +178,8 @@ class User < ApplicationRecord
                        message: 'はPNG, JPG, GIF, HEIC, HEIF形式にしてください'
                      }
 
+  validates :country_code, inclusion: { in: ISO3166::Country.codes, message: 'はcountry codeではありません' }, allow_nil: true
+
   with_options if: -> { %i[create update].include? validation_context } do
     validates :login_name, presence: true, uniqueness: true,
                            format: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,7 +178,9 @@ class User < ApplicationRecord
                        message: 'はPNG, JPG, GIF, HEIC, HEIF形式にしてください'
                      }
 
-  validates :country_code, inclusion: { in: ISO3166::Country.codes, message: 'はcountry codeではありません' }, allow_nil: true
+  validates :country_code, inclusion: { in: ISO3166::Country.codes }, allow_blank: true
+
+  validates :subdivision_code, inclusion: { in: ->(user) { user.subdivision_codes } }, allow_blank: true, if: -> { country_code.present? }
 
   with_options if: -> { %i[create update].include? validation_context } do
     validates :login_name, presence: true, uniqueness: true,
@@ -747,6 +749,11 @@ class User < ApplicationRecord
     country = ISO3166::Country[country_code]
     subdivision = country.subdivisions[subdivision_code]
     subdivision.translations[I18n.locale.to_s]
+  end
+
+  def subdivision_codes
+    country = ISO3166::Country[country_code]
+    country ? country.subdivisions.keys : []
   end
 
   def create_comebacked_comment

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -638,6 +638,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 'ニューヨーク州', users(:tom).subdivision_name
   end
 
+  test 'country_code must be valid ISO 3166-1 alpha-2 country code' do
+    user = users(:kimura)
+    user.country_code = 'invalid_country_code'
+    assert user.invalid?
+    user.country_code = 'ZW' # ジンバブエ
+    assert user.valid?
+  end
+
   test '#create_comebacked_comment' do
     hajime = users(:hajime)
     comment =

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -638,11 +638,22 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 'ニューヨーク州', users(:tom).subdivision_name
   end
 
-  test 'country_code must be valid ISO 3166-1 alpha-2 country code' do
-    user = users(:kimura)
+  test '#subdivision_codes' do
+    assert_equal ISO3166::Country['JP'].subdivisions.keys, users(:kimura).subdivision_codes
+    assert_equal ISO3166::Country['US'].subdivisions.keys, users(:tom).subdivision_codes
+    assert_empty users(:yameo).subdivision_codes
+  end
+
+  test 'country_code and subdivision_code must be valid ISO 3166-1 and 3166-2 code' do
+    user = users(:hatsuno)
     user.country_code = 'invalid_country_code'
+    user.subdivision_code = nil
     assert user.invalid?
     user.country_code = 'ZW' # ジンバブエ
+    assert user.valid?
+    user.subdivision_code = 'invalid_subdivision_code'
+    assert user.invalid?
+    user.subdivision_code = 'BU'
     assert user.valid?
   end
 


### PR DESCRIPTION
- [x] #7176 プロフィール欄に「使用しているエディタ」の項目を追加 @88-99
- [x] #7416 日報提出のお祝いメッセージを特定の回数で表示する @SuzukaHori
- [x] #7426 ユーザー一覧の非Vue化をする @yocchan-git
- [x] #7431 正方形に切り抜くように修正する @yocchan-git
- [x] #7436 Discord認証ができるようにする @yocchan-git
- [x] #7529 slim-lintのルールを適用する5 @kurumadaisuke
- [x] #7575 rollbarをアップデート @komagata
- [x] #7609 Side card @machida
- [x] #7612 Bump express from 4.18.2 to 4.19.2 @dependabot[bot]
- [x] #7620 プロフィールの「使用しているエディタ」の項目にハッシュが表示されてしまうため、エディタ登録前は空欄になるようにした。 @88-99
- [x] #7633 Mailのリファクタ @machida
- [x] #7653 nagai-kyuukaiユーザに分報チャンネルを紐づける @ogawa-tomo
- [x] #7654 count-badgeがタイトルにかぶるのを修正 @machida
- [x] #7658 修了モーダルのボタンの配置ズレを修正 @machida
- [x] #7659 ブレイクポイント追加 @machida
