### PR TITLE
作品追加時に管理者とメンターへ通知する機能を追加

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -44,6 +44,7 @@ class WorksController < ApplicationController
 
   def destroy
     @work.destroy
+    Newspaper.publish(:work_destroy, { work: @work })
     redirect_to user_portfolio_url(@work.user), notice: 'ポートフォリオから作品を削除しました。'
   end
 

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -27,6 +27,7 @@ class WorksController < ApplicationController
     @work = Work.new(work_params)
     @work.user = current_user
     if @work.save
+      Newspaper.publish(:work_create, { work: @work })
       redirect_to @work, notice: 'ポートフォリオに作品を追加しました。'
     else
       render :new

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -429,7 +429,23 @@ class ActivityMailer < ApplicationMailer
     subject = "新しいブログ「#{@article.title}」を#{@article.user.login_name}さんが投稿しました！"
     message = mail(to: @user.email, subject:)
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
+    message
+  end
 
+  # required params: work, receiver
+  def added_work(args = {})
+    @work = params&.key?(:work) ? params[:work] : args[:work]
+    @receiver ||= args[:receiver]
+    @user = @receiver
+
+    @link_url = notification_redirector_url(
+      link: "/works/#{@work.id}",
+      kind: Notification.kinds[:added_work]
+    )
+
+    subject = "[FBC] #{@work.user.login_name}さんがポートフォリオに作品「#{@work.title}」を追加しました。"
+    message = mail(to: @user.email, subject:)
+    message.perform_deliveries = @user.mail_notification? && !@user.retired?
     message
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -40,7 +40,8 @@ class Notification < ApplicationRecord
     regular_event_updated: 21,
     no_correct_answer: 22,
     comebacked: 23,
-    create_article: 24
+    create_article: 24,
+    added_work: 25
   }
 
   scope :unreads, -> { where(read: false) }

--- a/app/models/work_notification_destroyer.rb
+++ b/app/models/work_notification_destroyer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class WorkNotificationDestroyer
+  def call(payload)
+    work = payload[:work]
+
+    Notification.where(link: "/works/#{work.id}").destroy_all
+  end
+end

--- a/app/models/work_notifier.rb
+++ b/app/models/work_notifier.rb
@@ -2,7 +2,7 @@
 
 class WorkNotifier
   def call(payload)
-    work = payload[:work]
+    work = Work.eager_load(:user).find(payload[:work].id)
 
     User.admins_and_mentors.each do |receiver|
       ActivityDelivery.with(work:, receiver:).notify(:added_work)

--- a/app/models/work_notifier.rb
+++ b/app/models/work_notifier.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class WorkNotifier
+  def call(payload)
+    work = payload[:work]
+
+    User.admins_and_mentors.each do |receiver|
+      ActivityDelivery.with(work:, receiver:).notify(:added_work)
+    end
+  end
+end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -367,4 +367,19 @@ class ActivityNotifier < ApplicationNotifier
       read: false
     )
   end
+
+  def added_work(params = {})
+    params.merge!(@params)
+    work = params[:work]
+    receiver = params[:receiver]
+
+    notification(
+      body: "#{work.user.login_name}さんがポートフォリオに作品「#{work.title}」を追加しました。",
+      kind: :added_work,
+      receiver:,
+      sender: work.user,
+      link: Rails.application.routes.url_helpers.polymorphic_path(work),
+      read: false
+    )
+  end
 end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -372,12 +372,13 @@ class ActivityNotifier < ApplicationNotifier
     params.merge!(@params)
     work = params[:work]
     receiver = params[:receiver]
+    sender = work.user
 
     notification(
-      body: "#{work.user.login_name}さんがポートフォリオに作品「#{work.title}」を追加しました。",
+      body: "#{sender.login_name}さんがポートフォリオに作品「#{work.title}」を追加しました。",
       kind: :added_work,
       receiver:,
-      sender: work.user,
+      sender:,
       link: Rails.application.routes.url_helpers.polymorphic_path(work),
       read: false
     )

--- a/app/views/activity_mailer/added_work.html.slim
+++ b/app/views/activity_mailer/added_work.html.slim
@@ -1,4 +1,5 @@
 = render '/notification_mailer/notification_mailer_template',
   title: "#{@work.user.login_name}さんがポートフォリオに作品「#{@work.title}」を追加しました。",
   link_url: @link_url, link_text: 'この作品へ' do
+  h5 【作品の説明】
   = md2html(@work.description)

--- a/app/views/activity_mailer/added_work.html.slim
+++ b/app/views/activity_mailer/added_work.html.slim
@@ -1,5 +1,4 @@
 = render '/notification_mailer/notification_mailer_template',
   title: "#{@work.user.login_name}さんがポートフォリオに作品「#{@work.title}」を追加しました。",
   link_url: @link_url, link_text: 'この作品へ' do
-  h5 【作品の説明】
   = md2html(@work.description)

--- a/app/views/activity_mailer/added_work.html.slim
+++ b/app/views/activity_mailer/added_work.html.slim
@@ -1,0 +1,4 @@
+= render '/notification_mailer/notification_mailer_template',
+  title: "#{@work.user.login_name}さんがポートフォリオに作品「#{@work.title}」を追加しました。",
+  link_url: @link_url, link_text: 'この作品へ' do
+  = md2html(@work.description)

--- a/app/views/notification_mailer/_notification_mailer_template.html.erb
+++ b/app/views/notification_mailer/_notification_mailer_template.html.erb
@@ -7,7 +7,7 @@
         </h1>
         <% if @announcement %>
           <p style="font-size: 13px; color:#4638a0; line-height: 1.5; margin-top: 12px; text-align: left">
-            <%= link_to @announcement.user.long_name, @announcement.user, style: "line-height: 140%; text-decoration: underline;" %>
+            <%= link_to @announcement.user.long_name, @announcement.user, style: "line-height: 1.4; text-decoration: underline;" %>
           </p>
         <% end %>
       </div>
@@ -23,11 +23,11 @@
   <tr>
     <td style="padding: 0 20px 16px 20px; text-align: center;">
       <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%"
-        style="border-collapse:separate;width:auto; text-align: center; border: none;">
+        style="text-align: center; border: none;">
         <tbody>
           <tr>
             <td style="border: none; text-align: center;" valign="middle">
-              <%= link_to link_text, link_url, style: "text-decoration: none; background: #30ABDB; color:#fff; font-size: 14px; font-weight: bold; line-height: 140%; border-radius: 24px; padding: 12px 32px; text-align: center; background-color: #30ABDB; margin: 0px; display: inline-block;" %>
+              <%= link_to link_text, link_url, style: "text-decoration: none; background: #30ABDB; color:#fff; font-size: 14px; font-weight: bold; line-height: 1.4; border-radius: 24px; padding: 12px 32px; text-align: center; background-color: #30ABDB; margin: 0px; display: inline-block;" %>
             </td>
           </tr>
         </tbody>
@@ -40,7 +40,7 @@
         <tbody>
           <tr>
             <td style="border: none; text-align: center;">
-              <%= link_to "メールでの通知オフはこちらから", user_mail_notification_url(@user, token: @user.unsubscribe_email_token), style: "color:#4638a0; font-size:14px; font-weight: bold; line-height:140%; margin: 0px; padding: 12px 32px; display: inline-block;", target: "_blank" %>
+              <%= link_to "メールでの通知オフはこちらから", user_mail_notification_url(@user, token: @user.unsubscribe_email_token), style: "color:#4638a0; font-size:14px; font-weight: bold; line-height:1.4; margin: 0px; padding: 12px 32px; display: inline-block;", target: "_blank" %>
           </tr>
         </tbody>
       </table>

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -75,4 +75,5 @@ Rails.configuration.to_prepare do
   Newspaper.subscribe(:destroy_article, ArticleNotificationDestroyer.new)
   
   Newspaper.subscribe(:work_create, WorkNotifier.new)
+  Newspaper.subscribe(:work_destroy, WorkNotificationDestroyer.new)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -73,4 +73,6 @@ Rails.configuration.to_prepare do
 
   Newspaper.subscribe(:create_article, ArticleNotifier.new)
   Newspaper.subscribe(:destroy_article, ArticleNotificationDestroyer.new)
+  
+  Newspaper.subscribe(:work_create, WorkNotifier.new)
 end

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -475,4 +475,27 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
       ActivityDelivery.with(**params).notify(:create_article)
     end
   end
+
+  test '.notify(:added_work)' do
+    params = {
+      work: works(:work1),
+      receiver: users(:komagata)
+    }
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.notify!(:added_work, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.notify(:added_work, **params)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify!(:added_work)
+    end
+
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
+      ActivityDelivery.with(**params).notify(:added_work)
+    end
+  end
 end

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -178,4 +178,12 @@ class ActivityMailerPreview < ActionMailer::Preview
 
     ActivityMailer.with(article:, receiver:, sender: user).create_article
   end
+
+  def added_work
+    work = Work.find(ActiveRecord::FixtureSet.identify(:work1))
+    user = User.find(work.user_id)
+    receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
+
+    ActivityMailer.with(work:, sender: user, receiver:).added_work
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7526

## 概要
ポートレートへ作品が追加された際に、管理者とメンターへアプリ内通知とメール通知が送られる機能を追加しました。

## 変更確認方法

1. `feature/add-notification-for-new-work`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. アカウント名`komagata`でログインし、`/portfolios`にアクセス
5. ページ右上の「＋作品を追加」ボタンをクリック
6. 必須事項を入力し、ページ下部の「登録する」ボタンをクリック
7. メール通知の動作を確認する
	1. `/rails/mailers/activity_mailer/added_work`にアクセスし、通知メールのプレビューが表示されることを確認する
	2. `/letter_opener`にアクセスし、追加した作品に関する通知メールが、プレビューと同じ様式で管理者とメンター宛に送られていることを確認する
	3. メール文中の「この作品へ」ボタンをクリック
	4. 対象の作品のページが表示されることを確認する
8. アプリ内通知の動作を確認する
	1. ページ右上の通知ベルに新たな通知がきていることを確認し、クリック
	2. 追加した作品のページが表示されることを確認する
	3. 作品ページ白枠内右下の「削除する」ボタンをクリック
	4. 通知ベルから「全て」タブを選択し、削除した作品に関する通知が消えていることを確認する


## Screenshot

### 変更前
#### アプリ内通知

![Issue#7526変更前](https://github.com/fjordllc/bootcamp/assets/125527162/340fb092-db1e-4eae-9de1-605c21759172)

#### 通知メール

![Issue#7526変更前(メール)](https://github.com/fjordllc/bootcamp/assets/125527162/645f5e5b-2ff2-40c4-842f-7ba16759a85d)

### 変更後
#### アプリ内通知

![Issue#7526変更後](https://github.com/fjordllc/bootcamp/assets/125527162/81e7634a-d81c-4c3e-992a-c71bf99ba17c)

#### 通知メール

![Issue#7526変更後(メール)](https://github.com/fjordllc/bootcamp/assets/125527162/9bd75b15-700f-45fd-9b0c-73d96742eda3)
