### PR TITLE
ユーザー一覧ページの絞り込みにおける現役生と研修生のルールを整理

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -46,7 +46,7 @@ class API::UsersController < API::BaseController
   end
 
   def target_allowlist
-    target_allowlist = %w[student_and_trainee student followings mentor graduate adviser trainee year_end_party]
+    target_allowlist = %w[student_and_trainee student trainee followings mentor graduate adviser year_end_party]
     target_allowlist.push('job_seeking') if current_user.adviser?
     target_allowlist.push('all') if @company
     target_allowlist.concat(%w[job_seeking hibernated retired inactive all]) if current_user.mentor? || current_user.admin?

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -46,7 +46,7 @@ class API::UsersController < API::BaseController
   end
 
   def target_allowlist
-    target_allowlist = %w[student_and_trainee followings mentor graduate adviser trainee year_end_party]
+    target_allowlist = %w[student_and_trainee student followings mentor graduate adviser trainee year_end_party]
     target_allowlist.push('job_seeking') if current_user.adviser?
     target_allowlist.push('all') if @company
     target_allowlist.concat(%w[job_seeking hibernated retired inactive all]) if current_user.mentor? || current_user.admin?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -86,7 +86,7 @@ class UsersController < ApplicationController
   end
 
   def target_allowlist
-    target_allowlist = %w[student_and_trainee followings mentor graduate adviser trainee year_end_party]
+    target_allowlist = %w[student_and_trainee student followings mentor graduate adviser trainee year_end_party]
     target_allowlist.push('job_seeking') if current_user.adviser?
     target_allowlist.concat(%w[job_seeking hibernated retired inactive all]) if current_user.mentor? || current_user.admin?
     target_allowlist

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -86,7 +86,7 @@ class UsersController < ApplicationController
   end
 
   def target_allowlist
-    target_allowlist = %w[student_and_trainee student followings mentor graduate adviser trainee year_end_party]
+    target_allowlist = %w[student_and_trainee student trainee followings mentor graduate adviser year_end_party]
     target_allowlist.push('job_seeking') if current_user.adviser?
     target_allowlist.concat(%w[job_seeking hibernated retired inactive all]) if current_user.mentor? || current_user.admin?
     target_allowlist

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,13 +11,15 @@ class User < ApplicationRecord
   RESERVED_LOGIN_NAMES = %w[adviser all graduate inactive job_seeking mentor retired student student_and_trainee trainee year_end_party].freeze
   MAX_PERCENTAGE = 100
   DEPRESSED_SIZE = 2
-  ALL_ALLOWED_TARGETS = %w[adviser all campaign graduate hibernated inactive job_seeking mentor retired student_and_trainee trainee year_end_party].freeze
+  ALL_ALLOWED_TARGETS = %w[adviser all campaign graduate hibernated inactive job_seeking mentor retired student_and_trainee student trainee
+                           year_end_party].freeze
   # 本来であればtarget = scope名としたいが、歴史的経緯によりtargetとscope名が一致しないものが多数あるため、名前が一致しない場合はこのハッシュを使ってscope名に変換する
   TARGET_TO_SCOPE = {
     'student_and_trainee' => :students_and_trainees,
+    'student' => :students,
     'graduate' => :graduated,
     'adviser' => :advisers,
-    'trainee' => :trainees
+    'trainee' => :trainees  
   }.freeze
   DEFAULT_REGULAR_EVENT_ORGANIZER = 'komagata'
   HIBERNATION_LIMIT = 6.months

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,9 +17,9 @@ class User < ApplicationRecord
   TARGET_TO_SCOPE = {
     'student_and_trainee' => :students_and_trainees,
     'student' => :students,
+    'trainee' => :trainees,
     'graduate' => :graduated,
-    'adviser' => :advisers,
-    'trainee' => :trainees  
+    'adviser' => :advisers
   }.freeze
   DEFAULT_REGULAR_EVENT_ORGANIZER = 'komagata'
   HIBERNATION_LIMIT = 6.months

--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -8,7 +8,7 @@ nav.tab-nav
           li.tab-nav__item
             = link_to t("watch.#{watch}"), users_path(target: @target, watch:), class: (@watch == watch ? ['is-active'] : []) << 'tab-nav__item-link'
       - else
-        - targets = %w[student_and_trainee mentor graduate adviser trainee]
+        - targets = %w[student_and_trainee student mentor graduate adviser trainee]
         - if current_user.mentor?
           - targets += %w[job_seeking hibernated retired all]
         - elsif current_user.adviser?

--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -8,7 +8,7 @@ nav.tab-nav
           li.tab-nav__item
             = link_to t("watch.#{watch}"), users_path(target: @target, watch:), class: (@watch == watch ? ['is-active'] : []) << 'tab-nav__item-link'
       - else
-        - targets = %w[student_and_trainee student mentor graduate adviser trainee]
+        - targets = %w[student_and_trainee student trainee mentor graduate adviser]
         - if current_user.mentor?
           - targets += %w[job_seeking hibernated retired all]
         - elsif current_user.adviser?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -351,7 +351,7 @@ ja:
             end_at:
               format: 'は%{shortest_end_at}以降を入力してください。'
   target:
-    student_and_trainee: 現役生
+    student_and_trainee: 現役 + 研修生
     student: 現役生
     job_seeking: 就職活動中
     hibernationed: 休会中

--- a/test/system/company/users_test.rb
+++ b/test/system/company/users_test.rb
@@ -10,14 +10,14 @@ class Company::UsersTest < ApplicationSystemTestCase
 
   test 'show users by user category' do
     visit_with_auth "/companies/#{companies(:company2).id}/users", 'kimura'
-    # デフォルトは現役生のユーザーを表示
+    # デフォルトは現役 + 研修生のユーザーを表示
     # Kensyu Owata は研修を終えている研修生
     assert_no_text 'Kensyu Owata'
 
     click_link '全員'
     assert_text 'Kensyu Owata'
 
-    click_link '現役生'
+    click_link '現役 + 研修生'
     assert_no_text 'Kensyu Owata'
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -650,4 +650,25 @@ class UsersTest < ApplicationSystemTestCase
       assert_selector '.users-item__inactive-message-container.is-only-mentor .users-item__inactive-message', text: '休会中: 2020年01月01日〜(10日経過)'
     end
   end
+
+  test 'students and trainees filter' do
+    visit_with_auth '/users', 'komagata'
+    click_link '現役 + 研修生'
+
+    assert_selector('a.tab-nav__item-link.is-active', text: '現役 + 研修生')
+    filtered_users = all('.users-item__icon .a-user-role')
+    assert(filtered_users.all? do |user|
+      classes = user[:class].split(' ')
+      classes.include?('is-student') || classes.include?('is-trainee')
+    end)
+  end
+
+  test 'students filter' do
+    visit_with_auth '/users', 'komagata'
+    click_link '現役生'
+
+    assert_selector('a.tab-nav__item-link.is-active', text: '現役生')
+    filtered_users = all('.users-item__icon .a-user-role')
+    assert(filtered_users.all? { |user| user[:class].split(' ').include?('is-student') })
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7614

## 概要
ユーザー一覧ページの絞り込みタ絞り込みタブを次のように整理しました。
- **変更前**
「現役生」タブを選択すると現役生と研修生が表示される。
- **変更後**
  - 「現役 + 研修生」タブを選択すると現役生と研修生が表示される
  - 「現役生」タブを選択すると現役生だけが表示される
  - 「研修生」タブの表示位置を現役生の隣に変更

## 変更確認方法

1. `feature/update-users-filtering-rules-about-student-and-trainee`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. メンターアカウント（`komagata`等）でログインし、`/users`にアクセス
5. 絞り込みタブから「現役生」をクリックし、次の作業を行う
	1. ページタイトル横の数値をメモする
	2. 現役生のユーザーのみが表示されることを確認する
6. 絞り込みタブから「研修生」をクリックし、ページタイトル横の数値をメモする
7. 絞り込みタブから「現役 + 研修生」をクリックし次の点を確認する
	1. ページタイトル横の数値が`現役生 + 研修生`となっている
	2. 現役生と研修生のユーザーが表示される

## Screenshot

### 変更前

![#7614(変更前)](https://github.com/fjordllc/bootcamp/assets/125527162/a04e19b9-5776-4811-9fd0-a16e320b60ad)

### 変更後

![#7614(変更後)1](https://github.com/fjordllc/bootcamp/assets/125527162/6f6b0c7c-e6ff-4ddc-a111-08e94ad68915)

![#7614(変更後)2](https://github.com/fjordllc/bootcamp/assets/125527162/096bf56f-1aab-45a6-9d3f-a4c621d2f310)
