### PR TITLE
プロフィールの「使用しているエディタ」の項目にハッシュが表示されてしまうため、エディタ登録前は空欄になるようにした。

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -85,6 +85,8 @@ module UserDecorator
   end
 
   def editor_or_other_editor
+    return nil if editor.nil?
+
     editor == 'other_editor' ? other_editor : t("activerecord.enums.user.editor.#{editor}")
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -65,6 +65,7 @@ class UserDecoratorTest < ActiveDecoratorTestCase
     @admin_mentor_user.editor = 99
     @student_user.editor = 0
 
+    assert_equal @japanese_user.editor, nil
     assert_equal @admin_mentor_user.editor_or_other_editor, 'textbringer'
     assert_equal @student_user.editor_or_other_editor, 'VSCode'
   end


### PR DESCRIPTION
## Issue

[プロフィール欄に「使用しているエディタ」を追加する #6650](https://github.com/fjordllc/bootcamp/issues/6650)

## 概要
エディタ登録前では、プロフィール画面のエディタの項目にenum editorのハッシュが直接表示されてしまうため、空欄になるよう修正する。

元のPRコメント : https://github.com/fjordllc/bootcamp/pull/7176#issuecomment-2028010646

## 確認方法
1. feature/add-field-for-editor-in-profile をローカルに取り込む。
2. bootcamp を起動する。
bundle exec foreman start -f Procfile.dev
3. 任意のユーザでログインする。
4. 「マイプロフィール」にアクセスして、「使用しているエディタ」の項目が空欄になっていることを確認する。(Screenshot参照)
5. 「登録情報変更」 にアクセスする。
6. 「使用しているエディタ」の項目でエディタを登録する。
以下2通りの確認をお願いします。
- その他以外の選択肢を選ぶ
- その他を選んで、テキストボックスにエディタを入力
7. エディタを選択後、「更新する」ボタンを押下。
8. プロフィール画面で、選択または入力したエディタが登録されているかを確認する。

## Screenshot

### 変更前
<img width="566" alt="komagata___FBC" src="https://github.com/fjordllc/bootcamp/assets/83388876/6adbae93-5063-419d-9e9b-bf45e983a4b1">

### 変更後
<img width="566" alt="2_development__komagata___FBC" src="https://github.com/fjordllc/bootcamp/assets/83388876/cc59c80f-d4a8-4cff-accd-7fe0906ed138">

##### Vimを選択した場合
<img width="564" alt="3_development__komagata___FBC" src="https://github.com/fjordllc/bootcamp/assets/83388876/2e8006c4-8dff-4a5e-bb8f-5b89728d64b9">

##### その他の選択肢で任意のテキストを入力した場合
<img width="565" alt="4_development__komagata___FBC" src="https://github.com/fjordllc/bootcamp/assets/83388876/3a8430fd-7bba-4b61-bbe4-bc9e6775ea40">