### PR TITLE
企業情報ページを更新後のリダイレクト先を企業一覧から詳細画面に変更

### DIFF
--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -23,7 +23,7 @@ class Admin::CompaniesController < AdminController
 
   def update
     if @company.update(company_params)
-      redirect_to admin_companies_url, notice: '企業を更新しました。'
+      redirect_to company_url, notice: '企業を更新しました。'
     else
       render 'edit'
     end

--- a/app/controllers/admin/companies_controller.rb
+++ b/app/controllers/admin/companies_controller.rb
@@ -23,7 +23,7 @@ class Admin::CompaniesController < AdminController
 
   def update
     if @company.update(company_params)
-      redirect_to company_url, notice: '企業を更新しました。'
+      redirect_to @company, notice: '企業を更新しました。'
     else
       render 'edit'
     end


### PR DESCRIPTION
## Issue

[企業に"管理者メモ"が欲しい #7341](https://github.com/fjordllc/bootcamp/issues/7341)

## 概要
企業詳細ページを更新した後のリダイレクト先を企業一覧から企業詳細ページに変更する。
詳細ページに遷移した方が更新情報を確認できるため。

【経緯】
https://github.com/fjordllc/bootcamp/pull/7401#pullrequestreview-1965264220
> - UI

## 変更確認方法
1. `feature/add-admin-memo-to-company-info`をローカルに取り込む。
2. bootcamp を起動する。`foreman start -f Procfile.dev`
3. 管理者でログインする。
4. 任意の企業詳細ページを開く。`http://localhost:3000/companies/id`
5. ページ内の情報を更新して更新ボタンを押し、リダイレクト先が更新した企業詳細ページに遷移するかを確認する。

### 変更前
http://localhost:3000/admin/companies に遷移する。
![52afabb1b49d41afc43fb3285fc44b77](https://github.com/fjordllc/bootcamp/assets/83388876/ef44f994-99f8-4f70-8b38-3947bcefa28c)

### 変更後
http://localhost:3000/companies/id 更新した企業の詳細ページに遷移する。