### PR TITLE
プラクティス未選択で質問を作成した場合にメール通知が届かないバグの修正

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -124,6 +124,7 @@ class ActivityMailer < ApplicationMailer
     @question ||= args[:question]
 
     @user = @receiver
+    @title = @question.practice.present? ? "「#{@question.practice.title}」についての質問がありました。" : '質問がありました。'
     @link_url = notification_redirector_url(
       link: "/questions/#{@question.id}",
       kind: Notification.kinds[:came_question]

--- a/app/views/activity_mailer/came_question.html.slim
+++ b/app/views/activity_mailer/came_question.html.slim
@@ -1,5 +1,5 @@
 = render '/notification_mailer/notification_mailer_template',
-  title: "「#{@question.practice.title}」についての質問がありました。",
+  title: @title,
   link_url: @link_url,
   link_text: '質問へ' do
   p #{@question.user.login_name}さんから質問がありました。アドバイスや回答を投稿しよう！！

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -264,6 +264,26 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">質問へ</a>}, email.body.to_s)
   end
 
+  test 'came_question with no practice' do
+    question = questions(:question14)
+    user = question.user
+    mentor = users(:komagata)
+
+    ActivityMailer.came_question(
+      sender: user,
+      receiver: mentor,
+      question:
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    query = CGI.escapeHTML({ kind: 6, link: "/questions/#{question.id}" }.to_param)
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] kimuraさんから質問「プラクティスを選択せずに登録したテストの質問」が投稿されました。', email.subject
+    assert_match(%r{<a .+ href="http://localhost:3000/notification/redirector\?#{query}">質問へ</a>}, email.body.to_s)
+  end
+
   test 'mentioned' do
     mentionable = comments(:comment9)
     mentioned = notifications(:notification_mentioned)


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7623

## 概要

Q&Aでプラクティスを選択せずに質問を投稿した場合、メンターへの投稿通知メールが届かないバグを修正しました。


## 変更確認方法

1. `bug/not-receive-mail-notification-of-question`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. 任意のアカウントでログインし、`/questions/new`にアクセス
5. プラクティスを選択せずに任意のタイトルと質問文を入力し、ページ下部の「登録する」をクリック
6. `/letter_opener`にアクセス
7. メンターアカウント（投稿者を除く）に5の質問の投稿を通知するメールが届いていることを確認する
※ 届かない場合は画面左上の「Refresh」を押してみてください

## Screenshot

### 変更前
![#7623変更前](https://github.com/fjordllc/bootcamp/assets/125527162/6f607e70-b472-40a8-a026-79d88f56f90a)


### 変更後

![#7623変更後](https://github.com/fjordllc/bootcamp/assets/125527162/a9037cf5-70b0-472e-95d7-4bdd94767ec3)
