### PR TITLE
提出物ページの見出しの文字列をプラクティス名のみに変更した

### DIFF
--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -12,7 +12,7 @@ header.page-header
     .page-header__inner
       .page-header__start
         h2.page-header__title
-          = title
+          = @product.practice.title
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7602

## 概要
提出物ページの見出しで`提出物：`の文字列を削除しました
title タグは変更していないようにしています

## 変更確認方法

1. feature/change-practice-headerをローカルに取り込む
2. ログインして、任意の提出物を表示する
  - 下記のScreenshotでは、http://localhost:3000/products/613458348 で確認している
3. 見出しで `提出物：`の文字列がなく、プラクティス名のみであることを確認する
4. title タグは`提出物：プラクティス名`であることを確認する

## Screenshot

### 変更前
<img width="1428" alt="スクリーンショット 2024-04-10 17 19 39" src="https://github.com/fjordllc/bootcamp/assets/126838748/cb3a1c7b-ab59-4524-ba70-f50109186509">


### 変更後
<img width="1430" alt="スクリーンショット 2024-04-10 17 18 57" src="https://github.com/fjordllc/bootcamp/assets/126838748/714d257f-470e-4fed-8346-8f0cc46e6fb2">

