### PR TITLE
nagai-kyuukaiユーザに分報チャンネルを紐づける

### DIFF
--- a/db/fixtures/discord_profiles.yml
+++ b/db/fixtures/discord_profiles.yml
@@ -282,8 +282,9 @@ discord_profile_advisernocolleguetrainee:
 
 discord_profile_nagai-kyuukai:
   user: nagai-kyuukai
-  account_name:
-  times_url:
+  account_name: nagaikyuukai#1234
+  times_url: https://discord.com/channels/1079802367970656257/1224708078847397908
+  times_id: 1224708078847397908
 
 discord_profire_pjord:
   user: pjord


### PR DESCRIPTION
## Issue

- #6423 
- #6424 
- #6102 

## 概要
こちらのPRのステージング動作確認用にseedデータを追加するだけのPRです。
- https://github.com/fjordllc/bootcamp/pull/7515

このPRの動作確認をするためには、以下の条件を満たすユーザーを作成する必要があります。
・分報チャンネルが存在する
・休会日が六ヶ月以上前である
・Discordアカウント名が不正な値である

そのため、もともと休会日が六ヶ月以上前であるnagai-kyuukaiユーザにステージング環境Discordサーバに存在するチャンネルを紐づけ、さらにDiscordアカウント名を不正にします。
ステージング動作確認に成功すると当然ながらこの分報チャンネルは消えるので、この1回の動作確認のためだけのPRとなります。

## 変更確認方法

1. `chore/make-times-channel-for-nagai-kyuukai-user`をローカルに取り込む
2. komagataでログイン
3. 休会中のユーザー一覧から、「nagai-kyuukai」のプロフィールページに遷移し、分報が紐づいていることを確認する

![image](https://github.com/fjordllc/bootcamp/assets/46841037/0876d326-840c-4c76-9f66-977cc0dd44a5)
4. 分報のリンクをクリックすると、ステージング環境Discordサーバ（fjordbootcamp-staging）の「jidoutaikai20240402」チャンネルに遷移することを確認する

![image](https://github.com/fjordllc/bootcamp/assets/46841037/4810f978-14c7-4935-ab59-6a03d2ad8d24)


