### PR TITLE
相談部屋のヘッダーのタイトルとリンク先を変更した

### DIFF
--- a/app/views/users/_page_title.html.slim
+++ b/app/views/users/_page_title.html.slim
@@ -3,7 +3,10 @@ header.page-header
     .page-header__inner
       .page-header__start
         h2.page-header__title
-          = user.login_name
+          - if current_user.admin?
+            = user.login_name
+          - else
+            | 相談部屋
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items
@@ -19,5 +22,9 @@ header.page-header
                   li.page-main-header-actions__item
                     = render 'users/following', user:
             li.page-header-actions__item
-              = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
-                | ユーザー一覧
+              - if current_user.admin?
+                = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
+                  | ユーザー一覧
+              - else
+                = link_to root_path, class: 'a-button is-md is-secondary is-block is-back' do
+                  | ダッシュボード


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/7595

## 概要
- 管理者ではないユーザーの相談部屋ページを、以下のように変更しました
  - ヘッダーの見出しを`相談部屋`の文言に変更
  - ヘッダーのリンク先を`ダッシュボード`に変更
- 管理者の相談部屋ページは変更していません

## 変更確認方法

1. `feature/change-talk-header`をローカルに取り込む
2. 管理者でないユーザーでログインする
3. 相談部屋ページに遷移し、以下を確認する
  - ヘッダーのタイトルが`相談部屋`の文言になっているか
  - ヘッダーのリンク先が`ダッシュボード`になっているか
4. 管理者ユーザーでログインする
5. 相談部屋ページに遷移し変更箇所がないか、以下を確認する
  - ヘッダーのタイトルが`ユーザー名`になっているか
  - ヘッダーのリンク先が`ユーザー一覧`になっているか

## Screenshot

### 変更前
- 管理者以外のユーザー
<img width="1432" alt="変更前" src="https://github.com/fjordllc/bootcamp/assets/126838748/2562bea6-11f5-40f4-8641-e8eebde9e7a5">

- 管理者ユーザー
<img width="1433" alt="admin" src="https://github.com/fjordllc/bootcamp/assets/126838748/350d11e6-840d-47f7-8a33-3498e80eded3">


### 変更後
- 管理者以外のユーザー
<img width="1434" alt="変更後" src="https://github.com/fjordllc/bootcamp/assets/126838748/591c6301-3ee9-456b-bd52-2cfef10bec03">

- 管理者ユーザー
<img width="1433" alt="admin" src="https://github.com/fjordllc/bootcamp/assets/126838748/95f4462b-fae2-4aab-8c39-59922a102e98">
