### PR TITLE
未チェックの日報のアイコンがmarginがない配置になっていたため、配置を下げた

### DIFF
--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -126,21 +126,29 @@ export default function Reports({
 
 const NoReports = ({ unchecked }) => {
   return (
-    <div className="o-empty-message">
-      <div className="o-empty-message__icon">
-        {unchecked ? (
-          <>
-            <i className="fa-regular fa-smile" />
-            <p className="o-empty-message__text">
-              未チェックの日報はありません
-            </p>
-          </>
-        ) : (
-          <>
-            <i className="fa-regular fa-sad-tear" />
-            <p className="o-empty-message__text">日報はまだありません。</p>
-          </>
-        )}
+    <div className="page-main">
+      <div className="page-body">
+        <div className="container is-md">
+          <div className="o-empty-message">
+            <div className="o-empty-message__icon">
+              {unchecked ? (
+                <>
+                  <i className="fa-regular fa-smile" />
+                  <p className="o-empty-message__text">
+                    未チェックの日報はありません
+                  </p>
+                </>
+              ) : (
+                <>
+                  <i className="fa-regular fa-sad-tear" />
+                  <p className="o-empty-message__text">
+                    日報はまだありません。
+                  </p>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/app/javascript/stylesheets/application/blocks/page/_o-empty-message.sass
+++ b/app/javascript/stylesheets/application/blocks/page/_o-empty-message.sass
@@ -8,7 +8,6 @@
 
 .o-empty-message__icon
   +text-block(5rem 1)
-  margin-top: 1.5rem
 
 .o-empty-message__text
   +text-block(1rem 1.4 1em, center)

--- a/app/javascript/stylesheets/application/blocks/page/_o-empty-message.sass
+++ b/app/javascript/stylesheets/application/blocks/page/_o-empty-message.sass
@@ -8,6 +8,7 @@
 
 .o-empty-message__icon
   +text-block(5rem 1)
+  margin-top: 1.5rem
 
 .o-empty-message__text
   +text-block(1rem 1.4 1em, center)


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7167

## 概要
未チェックの日報のアイコンが上にくっついており、marginがない配置になっていたため、配置を下げました

## 変更確認方法

1. `bug/no-report-icon-margin-adjustment`をローカルに取り込む
2. 管理者/メンターユーザーでログインする
3. 日報・ブログページ(http://localhost:3000/reports/unchecked) に遷移する
4. 未チェックの日報タブを選択し、`未チェックの日報はありません`とアイコンが上から離れているか確認する
  - 日報がある場合に、日報を削除する手順
    - db/fixtures/reports.ymlをコメントアウトまたは削除
    - `rails db:reset`
    - `bin/setup`
    - サーバー起動
    
## Screenshot

### 変更前
<img width="1433" alt="スクリーンショット 2024-04-11 18 27 41" src="https://github.com/fjordllc/bootcamp/assets/126838748/ac7f2bfe-00db-416e-8a79-ad55dfae60bb">

### 変更
<img width="1428" alt="スクリーンショット 2024-04-12 9 35 22" src="https://github.com/fjordllc/bootcamp/assets/126838748/4475f2da-f7fa-4068-8626-c0a870526445">

