### PR TITLE
トップページの企業リンクをfjord.jpからlokka.jpに変更した

### DIFF
--- a/app/views/welcome/_administrator.slim
+++ b/app/views/welcome/_administrator.slim
@@ -30,4 +30,4 @@ section.welcome-section.is-administrator#administrator
               th URL
               td
                 = link_to 'https://lokka.jp', target: '_blank', rel: 'noopener', class: 'welcome-child-section__description-link' do
-                  | fjord.jp
+                  | lokka.jp


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7496

## 概要
トップページの企業リンクの文言をfjord.jpからlokka.jpに変更した
リンク先は、lokka.jpになっていた

## 変更確認方法

1. `feature/change-corporate-link`をローカルに取り込む
2. ログインして、トップページ(http://localhost:3000/welcome) の会社概要のURLが以下になっているか確認する
  - 文言
    - lokka.jp
  - リンク先
    - https://lokka.jp

## Screenshot

### 変更前
<img width="716" alt="スクリーンショット 2024-04-12 15 09 37" src="https://github.com/fjordllc/bootcamp/assets/126838748/aedba28e-939c-4b32-bb83-20603a1ddf63">

### 変更後
<img width="678" alt="スクリーンショット 2024-04-12 15 20 00" src="https://github.com/fjordllc/bootcamp/assets/126838748/cf47f2df-4e0c-4ddd-a294-f6e309345161">

