### PR TITLE
Discord認証の解除ができるようにする

### DIFF
--- a/app/controllers/connection/discord_controller.rb
+++ b/app/controllers/connection/discord_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Connection::DiscordController < ApplicationController
+  skip_before_action :require_active_user_login, raise: false
+
+  def destroy
+    current_user.discord_profile.update(account_name: nil)
+    redirect_to root_path, notice: 'Discordとの連携を解除しました。'
+  end
+end

--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -6,7 +6,7 @@
       .form-item__mention-input
         = discord_profile_fields.text_field :account_name, class: 'a-text-input', disabled: true
       .a-form-help
-        p 
+        p
           | Discord アカウントは登録されています。（
           = link_to connection_discord_path, method: :delete, class: 'a-form-help-link is-muted-text' do
             | Discord アカウントの登録を解除する

--- a/app/views/users/form/_sns.html.slim
+++ b/app/views/users/form/_sns.html.slim
@@ -6,7 +6,11 @@
       .form-item__mention-input
         = discord_profile_fields.text_field :account_name, class: 'a-text-input', disabled: true
       .a-form-help
-        p Discord アカウントは登録されています。
+        p 
+          | Discord アカウントは登録されています。（
+          = link_to connection_discord_path, method: :delete, class: 'a-form-help-link is-muted-text' do
+            | Discord アカウントの登録を解除する
+          | ）
     - else
       = link_to '/auth/discord', class: 'a-button is-sm is-primary', method: :post do
         p Discord アカウントを登録する

--- a/config/routes/connection.rb
+++ b/config/routes/connection.rb
@@ -3,5 +3,6 @@
 Rails.application.routes.draw do
   namespace :connection do
     resource :git_hub, only: %i(destroy), controller: "git_hub"
+    resource :discord, only: %i(destroy), controller: "discord"
   end
 end

--- a/test/system/authentication/discord_test.rb
+++ b/test/system/authentication/discord_test.rb
@@ -24,4 +24,14 @@ class Authentication::DiscordSystemTest < ApplicationSystemTestCase
     visit '/current_user/edit'
     assert_text 'Discord アカウントは登録されています。'
   end
+
+  test 'can cancel discord registration already setting user' do
+    visit_with_auth '/current_user/edit', 'kimura'
+
+    click_link 'Discord アカウントの登録を解除する'
+    assert_text 'Discordとの連携を解除しました。'
+
+    visit '/current_user/edit'
+    assert_link 'Discord アカウントを登録する'
+  end
 end


### PR DESCRIPTION
## Issue

- #7664 

## 概要
Discord認証の解除ができるようにしました

## 変更確認方法

1. `feature/delete-discord-account`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. Discordアカウントを登録しているのユーザーでアクセスする
4. http://localhost:3000/current_user/edit にアクセス
5. 「[Discordアカウントの登録を解除する](https://gyazo.com/0bb9d63719bc066aabc00a225b5446a2)」のリンクをクリックする
6. Discordの連携が解除されているのを確認する([この動画](https://gyazo.com/56ad1f04510c7e926996d1a58e66b9db)も参考にしてください)

下記のコマンドでDiscordアカウントを登録することもできます。
```
rails c
> user = User.find_by(login_name: "komagata")
> user.discord_profile.account_name = "komagata_dis"
> user.save
```

## Screenshot

### 変更前

[![Image from Gyazo](https://i.gyazo.com/7e147bb639ff083f041fe35b2acdc065.png)](https://gyazo.com/7e147bb639ff083f041fe35b2acdc065)

### 変更後

[![Image from Gyazo](https://i.gyazo.com/56ad1f04510c7e926996d1a58e66b9db.gif)](https://gyazo.com/56ad1f04510c7e926996d1a58e66b9db)
