### PR TITLE
footprint.vue, footprints.vueを非vue化したい

### DIFF
--- a/app/javascript/footprint.js
+++ b/app/javascript/footprint.js
@@ -1,0 +1,13 @@
+export default {
+  props: {
+    footprint: { type: Object, required: true }
+  },
+  computed: {
+    loginNameClass() {
+      return `is-${this.footprint.user.login_name}`
+    },
+    primaryRoleClass() {
+      return `is-${this.footprint.user.primary_role}`
+    }
+  }
+}

--- a/app/javascript/footprints.js
+++ b/app/javascript/footprints.js
@@ -1,0 +1,73 @@
+import CSRF from 'csrf'
+import Footprint from './footprint.js'
+
+export default {
+  name: 'Footprints',
+  components: {
+    footprint: Footprint
+  },
+  props: {
+    footprintableId: { type: String, required: true },
+    footprintableType: { type: String, required: true }
+  },
+  data() {
+    return {
+      footprints: [],
+      isDisplay: true,
+      footprintTotalCount: null,
+      loaded: null
+    }
+  },
+  computed: {
+    url() {
+      const params = new URL(location.href).searchParams
+      params.set('footprintableType', this.footprintableType)
+      params.set('footprintableId', this.footprintableId)
+      return `/api/footprints.json?footprintable_type=${this.footprintableType}&footprintable_id=${this.footprintableId}`
+    },
+    limitedDisplayOnPage() {
+      return this.footprints.slice(0, 10)
+    },
+    tenOrLessFootprints() {
+      return this.footprintTotalCount <= 10
+    },
+    moreThanTenFoorptints() {
+      return this.footprintTotalCount > 10
+    },
+    numberOfRemainingFootprints() {
+      return this.footprintTotalCount - 10
+    }
+  },
+  created() {
+    this.getFootprints()
+  },
+  methods: {
+    getFootprints() {
+      fetch(this.url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-Token': CSRF.getToken()
+        },
+        credentials: 'same-origin',
+        redirect: 'manual'
+      })
+        .then((response) => response.json())
+        .then((json) => {
+          this.footprints = []
+          json.footprints.forEach((footprint) => {
+            this.footprints.push(footprint)
+          })
+          this.footprintTotalCount = json.footprint_total_count
+          this.loaded = true
+        })
+        .catch((error) => {
+          console.warn(error)
+        })
+    },
+    showRemainingFootprints() {
+      this.isDisplay = false
+    }
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -56,6 +56,7 @@ import '../register-address.js'
 import '../upload-image-to-article.js'
 import '../header-dropdown.js'
 import '../editor-selection-form.js'
+import '../footprints.js'
 
 import VueMounter from '../VueMounter.js'
 import Announcements from '../components/announcements.vue'
@@ -69,7 +70,7 @@ import Watches from '../components/watches.vue'
 import WatchToggle from '../components/watch-toggle.vue'
 import UserMentorMemo from '../components/user_mentor_memo.vue'
 import UserRecentReports from '../components/user-recent-reports.vue'
-import Footprints from '../components/footprints.vue'
+// import Footprints from '../components/footprints.vue'
 import QuestionAnswers from '../components/question-answers.vue'
 import SadReports from '../components/sad_reports.vue'
 import UserProducts from '../components/user-products.vue'
@@ -90,7 +91,7 @@ mounter.addComponent(Watches)
 mounter.addComponent(WatchToggle)
 mounter.addComponent(UserMentorMemo)
 mounter.addComponent(UserRecentReports)
-mounter.addComponent(Footprints)
+// mounter.addComponent(Footprints)
 mounter.addComponent(QuestionAnswers)
 mounter.addComponent(SadReports)
 mounter.addComponent(UserProducts)

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -19,3 +19,4 @@ hr.a-border
     = render 'announcement', announcement: @announcement
     #js-comments(data-commentable-id="#{@announcement.id}" data-commentable-type='Announcement' data-current-user-id="#{current_user.id}")
     div(data-vue='Footprints' data-vue-footprintable-id="#{@announcement.id}" data-vue-footprintable-type='Announcement')
+     = render 'users/footprints', user_id: @announcement.id

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -61,3 +61,4 @@
       = render 'event', event: @event
       #js-comments(data-commentable-id="#{@event.id}" data-commentable-type='Event' data-current-user-id="#{current_user.id}")
       div(data-vue='Footprints' data-vue-footprintable-id="#{@event.id}" data-vue-footprintable-type='Event')
+      = render 'users/footprints', user_id: @event.id

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -48,6 +48,7 @@ header.page-header
 
         #js-comments(data-commentable-id="#{@product.id}" data-commentable-type='Product' data-current-user-id="#{current_user.id}")
         div(data-vue='Footprints' data-vue-footprintable-id="#{@product.id}" data-vue-footprintable-type='Product')
+        = render 'users/footprints', user_id: @product.id
 
       .is-only-mentor(class="#{current_user.mentor? || current_user.admin? ? 'col-xl-5 col-xs-12 is-hidden-sm-down' : ''}")
         - if current_user.mentor? || current_user.admin?

--- a/app/views/regular_events/show.html.slim
+++ b/app/views/regular_events/show.html.slim
@@ -41,3 +41,4 @@
       = render 'regular_event', regular_event: @regular_event
       #js-comments(data-commentable-id="#{@regular_event.id}" data-commentable-type='RegularEvent' data-current-user-id="#{current_user.id}")
       div(data-vue='Footprints' data-vue-footprintable-id="#{@regular_event.id}" data-vue-footprintable-type='RegularEvent')
+      = render 'users/footprints', user_id: @regular_event.id

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -39,6 +39,7 @@
         #js-comments(data-commentable-id="#{@report.id}" data-commentable-type='Report' data-current-user-id="#{current_user.id}")
 
         div(data-vue='Footprints' data-vue-footprintable-id="#{@report.id}" data-vue-footprintable-type='Report')
+        = render 'users/footprints', user_id: @report.id
 
       .col-xl-5.col-xs-12
         - if current_user.mentor? || current_user.admin?

--- a/app/views/users/_footprint.html.slim
+++ b/app/views/users/_footprint.html.slim
@@ -1,0 +1,8 @@
+li.user-icons__item
+  a.user-icons__item-link(:href='`${footprint.user.url}`')
+    span(:class='["a-user-role", primaryRoleClass]')
+      img.a-user-icon.is-sm(
+        :title='footprint.user.icon_title',
+        :alt='footprint.user.icon_title',
+        :src='footprint.user.avatar_url',
+        :class='loginNameClass')

--- a/app/views/users/_footprints.html.slim
+++ b/app/views/users/_footprints.html.slim
@@ -1,0 +1,22 @@
+.user-icons(v-if='!loaded')
+  .fa-solid.fa-spinner.fa-pulse
+  |
+  | ロード中
+.user-icons(v-else)
+  h3.user-icons__title(v-if='footprints.length > 0')
+    | 見たよ
+  ul.user-icons__items(
+    v-if='tenOrLessFootprints || (moreThanTenFoorptints && isDisplay)')
+    footprint(
+      v-for='footprint in limitedDisplayOnPage',
+      :key='footprint.key',
+      :footprint='footprint')
+  .user-icons__more(
+    v-if='moreThanTenFoorptints && isDisplay',
+    @click='showRemainingFootprints')
+    | その他{{ numberOfRemainingFootprints }}人
+  ul.user-icons__items(v-if='moreThanTenFoorptints && !isDisplay')
+    footprint(
+      v-for='footprint in footprints',
+      :key='footprint.key',
+      :footprint='footprint')


### PR DESCRIPTION
## Issue
- #7591

## 概要
vueを使わないようにするためにタイトルになっているファイルを使っている箇所を普通のHTMLでの実装に変える。
元々Reactに変更する予定でしたが、最終的にはHotwireにする予定なので、VueもReactも使わない実装にしたいです。（普通にviewに表示する方式）

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

