### PR TITLE
お問合せ一覧にページネーションを追加した

### DIFF
--- a/app/controllers/admin/inquiries_controller.rb
+++ b/app/controllers/admin/inquiries_controller.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class Admin::InquiriesController < AdminController
+  PAGER_NUMBER = 20
+
   def index
-    @inquiries = Inquiry.order(created_at: :desc)
+    per = params[:per] || PAGER_NUMBER
+    @inquiries = Inquiry.order(created_at: :desc).page(params[:page]).per(per)
   end
 
   def show

--- a/app/views/admin/inquiries/index.html.slim
+++ b/app/views/admin/inquiries/index.html.slim
@@ -19,6 +19,8 @@ hr.a-border
   .page-body__inner
     .container.is-md
       - if @inquiries.present?
+        = paginate @inquiries
         .card-list.a-card
           .card-list__items
             = render partial: 'inquiries_item', collection: @inquiries, as: :inquiry
+        = paginate @inquiries


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7663

## 概要
お問合せ一覧ページに1ページ20件のページネーションを追加した

## 変更確認方法

1. `feature/inquiry-pagination`をローカルに取り込む
2. 管理者でログインし、 `/admin/inquiries` にアクセスし、お問合せ一覧を開く
3. 1ページ20件のページネーションが、お問合せ一覧の上下の2箇所に実装されているか確認する
- お問い合わせを21件以上にする方法
  - Railsコンソールを実行する
    `rails c`
  - 以下を実行して、お問い合わせを23件にする
    ```
    21.times do |i|
      name = "inquiry#{i + 3}"
      email = "inquiry#{i + 3}@example.com"
      created_at = Time.zone.now - (i + 1).days
      body = "お問い合わせのテスト#{i + 3}です。"
      Inquiry.create!(name: name, email: email, created_at: created_at, body: body)
    end
    ```

## Screenshot

### 変更前
- お問い合わせ一覧(上)
<img width="983" alt="スクリーンショット 2024-04-15 14 41 02" src="https://github.com/fjordllc/bootcamp/assets/126838748/5e8829f3-8b89-49c5-8222-8df744f99fc8">

- お問い合わせ一覧(下)
<img width="1356" alt="スクリーンショット 2024-04-15 15 14 21" src="https://github.com/fjordllc/bootcamp/assets/126838748/ba39f1cb-4c21-4565-8df9-cd6a88256582">

### 変更後
- お問い合わせ一覧(上)
<img width="986" alt="スクリーンショット 2024-04-15 14 39 47" src="https://github.com/fjordllc/bootcamp/assets/126838748/e180207b-e6aa-4a65-b97f-76469ad3d7aa">


- お問い合わせ一覧(下)
<img width="1351" alt="スクリーンショット 2024-04-15 15 15 04" src="https://github.com/fjordllc/bootcamp/assets/126838748/cee7eafc-e1e2-4d96-b1e9-5e6862e577f2">

