### PR TITLE
未チェックの日報が100件超えたらメンターのダッシュボードに警告を出すようにした

### DIFF
--- a/app/javascript/stylesheets/application.sass
+++ b/app/javascript/stylesheets/application.sass
@@ -21,6 +21,7 @@
 @import application/blocks/dashboard/dashboard-categories-item
 @import application/blocks/dashboard/dashboard-contents
 @import application/blocks/dashboard/welcome-message
+@import application/blocks/dashboard/unchecked-report-alert
 
 @import application/blocks/event/event-main-actions
 @import application/blocks/event/event-meta

--- a/app/javascript/stylesheets/application/blocks/dashboard/_unchecked-report-alert.sass
+++ b/app/javascript/stylesheets/application/blocks/dashboard/_unchecked-report-alert.sass
@@ -1,0 +1,30 @@
+.unchecked-report-alert__header
+  background-color: var(--danger)
+  padding: .125rem 1rem
+
+.unchecked-report-alert__header-title
+  +text-block(.75rem 1.4, 700)
+  color: var(--reversal-text)
+
+.unchecked-report-alert__inner
+  padding: .25rem 1rem
+  display: flex
+  align-items: center
+  gap: .5rem
+
+.unchecked-report-alert__icon
+  font-size: 2rem
+
+.unchecked-report-alert__message
+  +text-block(.8125rem 1.4, center)
+  flex: 1
+
+.unchecked-report-alert__message-link
+  color: var(--danger-text)
+
+.unchecked-report-alert__count
+  margin-inline:.125rem
+
+.unchecked-report-alert__count-number
+  font-size: 1.25rem
+  margin-right: .0625rem

--- a/app/views/home/_mentor_dashboard.html.slim
+++ b/app/views/home/_mentor_dashboard.html.slim
@@ -5,14 +5,18 @@
         .dashboard-contents__categories
           .dashboard-category
             - unchecked_report_count = Cache.unchecked_report_count
-            - if unchecked_report_count > 100
-              header.dashboard-category__header
-                h2.dashboard-category__title
-                  = link_to "未チェックの日報が#{unchecked_report_count}件あります。", '/reports/unchecked'
-            - if current_user.active_practices.present?
-              header.dashboard-category__header
-                h2.dashboard-category__title
-                  | 提出物状況
+            .dashboard-category__body
+              .a-card.is-danger
+                .card__description
+                  - if unchecked_report_count > 100
+                    .flex
+                      div
+                        i.far.fa-face-confounded
+                      div
+                        = link_to '/reports/unchecked' do
+                          | 未チェックの日報が
+                          br
+                          | #{unchecked_report_count}件あります。
             .dashboard-category__body
               #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
       .dashboard-contents__col.is-main

--- a/app/views/home/_mentor_dashboard.html.slim
+++ b/app/views/home/_mentor_dashboard.html.slim
@@ -4,6 +4,11 @@
       .dashboard-contents__col.is-sub.is-only-mentor
         .dashboard-contents__categories
           .dashboard-category
+            - unchecked_report_count = Cache.unchecked_report_count
+            - if unchecked_report_count > 100
+              header.dashboard-category__header
+                h2.dashboard-category__title
+                  = link_to "未チェックの日報が#{unchecked_report_count}件あります。", "/reports/unchecked"
             - if current_user.active_practices.present?
               header.dashboard-category__header
                 h2.dashboard-category__title

--- a/app/views/home/_mentor_dashboard.html.slim
+++ b/app/views/home/_mentor_dashboard.html.slim
@@ -5,18 +5,8 @@
         .dashboard-contents__categories
           .dashboard-category
             - unchecked_report_count = Cache.unchecked_report_count
-            .dashboard-category__body
-              .a-card.is-danger
-                .card__description
-                  - if unchecked_report_count > 100
-                    .flex
-                      div
-                        i.far.fa-face-confounded
-                      div
-                        = link_to '/reports/unchecked' do
-                          | 未チェックの日報が
-                          br
-                          | #{unchecked_report_count}件あります。
+            - if unchecked_report_count > 100
+              = render 'unchecked_report_alert', unchecked_report_count: unchecked_report_count
             .dashboard-category__body
               #js-products(data-title="#{title}" data-selected-tab="unassigned" data-mentor-login="#{mentor_login?}" data-current-user-id="#{current_user.id}")
       .dashboard-contents__col.is-main

--- a/app/views/home/_mentor_dashboard.html.slim
+++ b/app/views/home/_mentor_dashboard.html.slim
@@ -8,7 +8,7 @@
             - if unchecked_report_count > 100
               header.dashboard-category__header
                 h2.dashboard-category__title
-                  = link_to "未チェックの日報が#{unchecked_report_count}件あります。", "/reports/unchecked"
+                  = link_to "未チェックの日報が#{unchecked_report_count}件あります。", '/reports/unchecked'
             - if current_user.active_practices.present?
               header.dashboard-category__header
                 h2.dashboard-category__title

--- a/app/views/home/_unchecked_report_alert.html.slim
+++ b/app/views/home/_unchecked_report_alert.html.slim
@@ -1,0 +1,16 @@
+.dashboard-category__body
+  .a-card.is-danger.unchecked-report-alert
+    header.unchecked-report-alert__header
+      h2.unchecked-report-alert__header-title
+        | 日報が100件を超えました。
+    .unchecked-report-alert__inner
+      .unchecked-report-alert__icon
+        i.fa-regular.fa-triangle-exclamation
+      .unchecked-report-alert__message
+        = link_to '/reports/unchecked', class: 'unchecked-report-alert__message-link' do
+          | 未チェックの日報が
+          strong.unchecked-report-alert__count
+            span.unchecked-report-alert__count-number
+              | #{unchecked_report_count}
+            | 件
+          | あります。


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7625

## 概要
未チェックの日報が100件超えたらメンターのダッシュボードにリンク付きメッセージを出すようにした
メッセージは何件なのか表示できるようにした

## 変更確認方法

1. `feature/report-100-over-dashboard-warning`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. メンターユーザーでログインする
5. 未チェックの日報が100件を超えている場合の確認
- ダッシュボードページで、リンク付きメッセージが表示されていることを確認する
- 未チェックの日報の件数がメッセージ内容と一致しているか確認する
- リンク付きメッセージを押下すると、`/reports/unchecked`に遷移することを確認する
6. 未チェックの日報が100件を超えていない場合の確認
- `db/fixtures/reports.yml`のseedデータを100件未満にするようにコメントアウトをする
- リンク付きメッセージが表示されていないことを確認する

## Screenshot

### 変更前
<img width="361" alt="変更前" src="https://github.com/fjordllc/bootcamp/assets/126838748/cfaf8fe6-acdd-450f-b017-1c17fd18f85f">

### 変更後
<img width="364" alt="スクリーンショット 2024-04-19 14 31 19" src="https://github.com/fjordllc/bootcamp/assets/126838748/b6ee9591-8c25-4975-964d-d40b243e490c">
