### PR TITLE
修了プラクティスと修了したプラクティスの数がずれている問題の解消

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -28,6 +28,14 @@ module UserDecorator
     end
   end
 
+  def completed_fraction
+    "修了: #{completed_practices.size} （必須: #{completed_practices_include_progress.size}/#{practices_include_progress.size}）"
+  end
+
+  def completed_fraction_in_metas
+    "#{completed_practices.size} （必須:#{completed_practices_include_progress.size}）"
+  end
+
   def customer_url
     "https://dashboard.stripe.com/customers/#{customer_id}"
   end

--- a/app/javascript/components/UserPracticeProgress.jsx
+++ b/app/javascript/components/UserPracticeProgress.jsx
@@ -24,8 +24,16 @@ export default function UserPracticeProgress({ user }) {
           role="progressbar"
           style={{ width: roundedPercentage }}></div>
       </div>
-      <div className="completed-practices-progress__number">
-        {completedPracticesProgressNumber}
+      <div className='completed-practices-progress__counts'>
+        <input className="a-toggle-checkbox" type="checkbox" id={`userid_${user.id}`} />
+        <label className="completed-practices-progress__counts-inner" htmlFor={`userid_${user.id}`}>
+          <div className="completed-practices-progress__percentage">
+            {roundedPercentage}
+          </div>
+          <div className="completed-practices-progress__number">
+            {completedPracticesProgressNumber}
+          </div>
+        </label>
       </div>
     </div>
   )

--- a/app/javascript/components/UserPracticeProgress.jsx
+++ b/app/javascript/components/UserPracticeProgress.jsx
@@ -24,9 +24,15 @@ export default function UserPracticeProgress({ user }) {
           role="progressbar"
           style={{ width: roundedPercentage }}></div>
       </div>
-      <div className='completed-practices-progress__counts'>
-        <input className="a-toggle-checkbox" type="checkbox" id={`userid_${user.id}`} />
-        <label className="completed-practices-progress__counts-inner" htmlFor={`userid_${user.id}`}>
+      <div className="completed-practices-progress__counts">
+        <input
+          className="a-toggle-checkbox"
+          type="checkbox"
+          id={`userid_${user.id}`}
+        />
+        <label
+          className="completed-practices-progress__counts-inner"
+          htmlFor={`userid_${user.id}`}>
           <div className="completed-practices-progress__percentage">
             {roundedPercentage}
           </div>

--- a/app/javascript/components/user-practice-progress.vue
+++ b/app/javascript/components/user-practice-progress.vue
@@ -9,10 +9,9 @@
       role='progressbar',
       :style='`width: ${roundedPercentage}`')
   .completed-practices-progress__counts
-    input.a-toggle-checkbox(
-      type='checkbox',
-      :id='`userid_${this.user.id}`')
-    label.completed-practices-progress__counts-inner(:for='`userid_${this.user.id}`')
+    input.a-toggle-checkbox(type='checkbox', :id='`userid_${this.user.id}`')
+    label.completed-practices-progress__counts-inner(
+      :for='`userid_${this.user.id}`')
       .completed-practices-progress__percentage
         | {{ roundedPercentage }}
       .completed-practices-progress__number

--- a/app/javascript/components/user-practice-progress.vue
+++ b/app/javascript/components/user-practice-progress.vue
@@ -8,8 +8,15 @@
       :aria-valuenow='ariaValuenow()',
       role='progressbar',
       :style='`width: ${roundedPercentage}`')
-  .completed-practices-progress__number
-    | {{ completedPracticesProgressNumber() }}
+  .completed-practices-progress__counts
+    input.a-toggle-checkbox(
+      type='checkbox',
+      :id='`userid_${this.user.id}`')
+    label.completed-practices-progress__counts-inner(:for='`userid_${this.user.id}`')
+      .completed-practices-progress__percentage
+        | {{ roundedPercentage }}
+      .completed-practices-progress__number
+        | {{ completedPracticesProgressNumber() }}
 </template>
 <script>
 export default {

--- a/app/javascript/stylesheets/application/blocks/user/_completed-practices-progress.sass
+++ b/app/javascript/stylesheets/application/blocks/user/_completed-practices-progress.sass
@@ -1,9 +1,9 @@
 $bar-height: .75rem
 .completed-practices-progress
-  padding-block: .75rem
-  padding-inline: 1rem
+  padding: .75rem 1rem
   display: flex
   align-items: center
+  gap: .5rem
 
 .completed-practices-progress__bar-container
   flex: 1
@@ -21,22 +21,34 @@ $bar-height: .75rem
   +position(relative, top $bar-height * -1)
   box-shadow: rgba(black, .2) 0 .0625rem .0625rem
 
+.completed-practices-progress__counts
+  position: relative
+  cursor: pointer
+  display: block
+
+.completed-practices-progress__counts-inner
+  cursor: pointer
+  &:hover
+    .completed-practices-progress__percentage
+      text-decoration: underline
+
+.completed-practices-progress__percentage
+  +text-block(.8125rem, right nowrap)
+
 .completed-practices-progress__number
-  +text-block(.8125rem 1rem, right nowrap)
-  height: 1rem
-  margin-left: .5rem
+  position: absolute
+  right: 0
+  bottom: calc(100% + .5rem)
+  background-color: var(--base)
+  border: solid 1px var(--border)
+  padding: .25rem .5rem
+  +text-block(.8125rem 1.4, right nowrap)
+  border-radius: .25rem
 
-.completed-practices-progress__area input
-  display: none
+.completed-practices-progress__counts
+  input:checked ~ label .completed-practices-progress__number
+    display: block
 
-.completed-practices-progress__area input:checked ~ label .completed-practices-progress__number
-  display: block
-
-.completed-practices-progress__area input:checked ~ label .completed-practices-progress__percentage
-  display: none
-
-.completed-practices-progress__area input:not(:checked) ~ label .completed-practices-progress__number
-  display: none
-
-.completed-practices-progress__area input:not(:checked) ~ label .completed-practices-progress__percentage
-  display: block
+.completed-practices-progress__counts
+  input:not(:checked) ~ label .completed-practices-progress__number
+    display: none

--- a/app/javascript/stylesheets/application/blocks/user/_completed-practices-progress.sass
+++ b/app/javascript/stylesheets/application/blocks/user/_completed-practices-progress.sass
@@ -25,3 +25,18 @@ $bar-height: .75rem
   +text-block(.8125rem 1rem, right nowrap)
   height: 1rem
   margin-left: .5rem
+
+.completed-practices-progress__area input
+  display: none
+
+.completed-practices-progress__area input:checked ~ label .completed-practices-progress__number
+  display: block
+
+.completed-practices-progress__area input:checked ~ label .completed-practices-progress__percentage
+  display: none
+
+.completed-practices-progress__area input:not(:checked) ~ label .completed-practices-progress__number
+  display: none
+
+.completed-practices-progress__area input:not(:checked) ~ label .completed-practices-progress__percentage
+  display: block

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -474,11 +474,11 @@ class User < ApplicationRecord
   end
 
   def completed_fraction
-    "(#{completed_practices.size} 必須: #{completed_practices_include_progress.size}/#{practices_include_progress.size})"
+    "修了: #{completed_practices.size} （必須: #{completed_practices_include_progress.size}/#{practices_include_progress.size}）"
   end
 
   def completed_fraction_in_metas
-    "#{completed_practices.size} (必須:#{completed_practices_include_progress.size})"
+    "#{completed_practices.size} （必須:#{completed_practices_include_progress.size}）"
   end
 
   def completed_practices_size_by_category

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -477,6 +477,10 @@ class User < ApplicationRecord
     "#{completed_practices_include_progress.size}/#{practices_include_progress.size}"
   end
 
+  def completed_fraction_in_metas
+    "#{completed_practices.size} (必須:#{completed_practices_include_progress.size})"
+  end
+
   def completed_practices_size_by_category
     Practice
       .joins({ categories: :categories_practices }, :learnings)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -494,6 +494,11 @@ class User < ApplicationRecord
       .count('DISTINCT practices.id')
   end
 
+  def completed_practices_include_progress
+    practices_include_progress.joins(:learnings)
+                              .merge(Learning.complete.where(user_id: id))
+  end
+
   def active?
     (last_activity_at && (last_activity_at > 1.month.ago)) || created_at > 1.month.ago
   end
@@ -803,11 +808,6 @@ class User < ApplicationRecord
 
   def practices_include_progress
     course.practices.where(include_progress: true)
-  end
-
-  def completed_practices_include_progress
-    practices_include_progress.joins(:learnings)
-                              .merge(Learning.complete.where(user_id: id))
   end
 
   def unstarted_practices

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -473,14 +473,6 @@ class User < ApplicationRecord
     completed_practices_include_progress.size.to_f / practices_include_progress.size * MAX_PERCENTAGE
   end
 
-  def completed_fraction
-    "修了: #{completed_practices.size} （必須: #{completed_practices_include_progress.size}/#{practices_include_progress.size}）"
-  end
-
-  def completed_fraction_in_metas
-    "#{completed_practices.size} （必須:#{completed_practices_include_progress.size}）"
-  end
-
   def completed_practices_size_by_category
     Practice
       .joins({ categories: :categories_practices }, :learnings)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -474,7 +474,7 @@ class User < ApplicationRecord
   end
 
   def completed_fraction
-    "#{completed_practices_include_progress.size}/#{practices_include_progress.size}"
+    "(#{completed_practices.size} 必須: #{completed_practices_include_progress.size}/#{practices_include_progress.size})"
   end
 
   def completed_fraction_in_metas

--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -30,7 +30,7 @@
       .user-metas__item-label
         | 修了プラクティス
       .user-metas__item-value
-        = user.completed_practices.size
+        = user.completed_fraction_in_metas
     - unless user.admin? || user.adviser?
       .user-metas__item
         .user-metas__item-label

--- a/app/views/users/practices/_completed_practices_progress.html.slim
+++ b/app/views/users/practices/_completed_practices_progress.html.slim
@@ -8,10 +8,10 @@
   .completed-practices-progress__bar-container
     .completed-practices-progress__bar
     .completed-practices-progress__percentage-bar(aria-valuemax='100' aria-valuemin='0' aria-valuenow="#{percentage}" role='progressbar' style="width: #{number_to_percentage percentage, precision: 0};")
-  .completed-practices-progress__area
-    = check_box_tag "userid#{user.id}"
-    = label_tag "userid#{user.id}"
-      .completed-practices-progress__number
-        = fraction
+  .completed-practices-progress__counts
+    input.a-toggle-checkbox(type='checkbox' id="userid_#{user.id}")
+    label.completed-practices-progress__counts-inner(for="userid_#{user.id}")
       .completed-practices-progress__percentage
           = "#{percentage.floor(0)}%"
+      .completed-practices-progress__number
+        = fraction

--- a/app/views/users/practices/_completed_practices_progress.html.slim
+++ b/app/views/users/practices/_completed_practices_progress.html.slim
@@ -8,5 +8,10 @@
   .completed-practices-progress__bar-container
     .completed-practices-progress__bar
     .completed-practices-progress__percentage-bar(aria-valuemax='100' aria-valuemin='0' aria-valuenow="#{percentage}" role='progressbar' style="width: #{number_to_percentage percentage, precision: 0};")
-  .completed-practices-progress__number
-    = fraction
+  .completed-practices-progress__area
+    = check_box_tag "userid#{user.id}"
+    = label_tag "userid#{user.id}"
+      .completed-practices-progress__number
+        = fraction
+      .completed-practices-progress__percentage
+          = "#{percentage.floor(0)}%"

--- a/db/fixtures/categories.yml
+++ b/db/fixtures/categories.yml
@@ -102,3 +102,8 @@ category21:
   name: "ゲームのテスト"
   slug: "game-test"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
+
+category22:
+  name: "就職活動"
+  slug: "job-hunting"
+  description: "就職に向けての準備に入ります。"

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -297,3 +297,8 @@ categories_practice60:
   practice: practice60
   category: category2
   position: 6
+
+categories_practice61:
+  practice: practice61
+  category: category22
+  position: 1

--- a/db/fixtures/courses_categories.yml
+++ b/db/fixtures/courses_categories.yml
@@ -117,3 +117,8 @@ courses_category24:
   course: course3
   category: category15
   position: 3
+
+courses_category25:
+  course: course1
+  category: category22
+  position: 17

--- a/db/fixtures/discord_profiles.yml
+++ b/db/fixtures/discord_profiles.yml
@@ -300,3 +300,8 @@ discord_profile_paginataion-jirou:
   user: paginataion-jirou
   account_name:
   times_url:
+
+discord_profire_harikirio:
+  user: harikirio
+  account_name:
+  times_url:

--- a/db/fixtures/learnings.yml
+++ b/db/fixtures/learnings.yml
@@ -117,3 +117,15 @@ learning<%= i + 18 %>:
   created_at: <%= (today - 2.weeks + 2.day + 12.hours - i.day).to_formatted_s(:db) %>
   updated_at: <%= (today - 2.weeks + 2.day + 12.hours - i.day).to_formatted_s(:db) %>
 <% end %>
+
+learning23:
+  user: harikirio
+  practice: practice1
+  status: "complete"
+  completion_message_displayed: false
+
+learning24:
+  user: harikirio
+  practice: practice61
+  status: "complete"
+  completion_message_displayed: false

--- a/db/fixtures/practices.yml
+++ b/db/fixtures/practices.yml
@@ -386,3 +386,11 @@ practice60:
   description: "概要欄(概要文＆OGP画像)を表示します"
   goal: "goal..."
   memo: "memo for mentors..."
+
+practice61:
+  title: "企業研究"
+  summary: "概要です"
+  description: "就職したい企業について調べます。(進捗の計算には含めません)"
+  goal: "goal..."
+  include_progress: false
+  memo: "memo for mentors..."

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -227,3 +227,7 @@ talk_kensyu-end-over-1-week:
 talk_kensyu-not-setting-end-date:
   user: kensyu-not-setting-end-date
   action_completed: true
+
+talk_harikirio:
+  user: harikirio
+  action_completed: true

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1422,3 +1422,23 @@ pjord:
   created_at: "2024-03-05 00:00:30"
   sent_student_followup_message: true
   last_activity_at: "2021-02-01 00:00:30"
+
+harikirio: #必修でないプラクティスも修了しているユーザー
+  login_name: harikirio
+  email: harikiro@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: Hari Kirio
+  name_kana: ハリ キリオ
+  github_account: harikirio
+  twitter_account: harikirio
+  description: "必修でないプラクティスも取り組みます！"
+  course: course1
+  job: office_worker
+  experience: rails
+  job_seeker: true
+  unsubscribe_email_token: Z2tKHxSjj7FreyqQ95Yd9g
+  updated_at: "2020-01-01 00:00:12"
+  created_at: "2020-01-01 00:00:12"
+  sent_student_followup_message: true
+  last_activity_at: "2020-01-01 00:00:12"

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -13,6 +13,7 @@ class UserDecoratorTest < ActiveDecoratorTestCase
     @japanese_user = decorate(users(:kimura))
     @american_user = decorate(users(:tom))
     @subdivision_not_registered_user = decorate(users(:hatsuno))
+    @non_required_subject_completed_user = decorate(users(:harikirio))
   end
 
   test '#icon_title' do
@@ -68,5 +69,38 @@ class UserDecoratorTest < ActiveDecoratorTestCase
     assert_equal @japanese_user.editor, nil
     assert_equal @admin_mentor_user.editor_or_other_editor, 'textbringer'
     assert_equal @student_user.editor_or_other_editor, 'VSCode'
+  end
+
+  test '#completed_fraction don\'t calculate practice that include_progress: false' do
+    user = @admin_mentor_user
+    old_fraction = user.completed_practices_include_progress.size
+    user.completed_practices << practices(:practice5)
+
+    assert_not_equal old_fraction, user.completed_fraction
+
+    old_fraction = user.completed_practices_include_progress.size
+    user.completed_practices << practices(:practice53)
+
+    assert_equal old_fraction, user.completed_practices_include_progress.size
+  end
+
+  test '#completed_fraction don\'t calculate practice unrelated cource' do
+    old_fraction = @admin_mentor_user.completed_practices_include_progress.size
+    @admin_mentor_user.completed_practices << practices(:practice5)
+
+    assert_not_equal old_fraction, @admin_mentor_user.completed_practices_include_progress.size
+
+    old_fraction = @admin_mentor_user.completed_practices_include_progress.size
+    @admin_mentor_user.completed_practices << practices(:practice55)
+
+    assert_equal old_fraction, @admin_mentor_user.completed_practices_include_progress.size
+  end
+
+  test '#completed_fraction_in_metas' do
+    fraction_in_metas = '2 （必須:1）'
+    @non_required_subject_completed_user.completed_practices << practices(:practice5)
+    @non_required_subject_completed_user.completed_practices << practices(:practice61)
+
+    assert_equal @non_required_subject_completed_user.completed_fraction_in_metas, fraction_in_metas
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -101,6 +101,6 @@ class UserDecoratorTest < ActiveDecoratorTestCase
     @non_required_subject_completed_user.completed_practices << practices(:practice5)
     @non_required_subject_completed_user.completed_practices << practices(:practice61)
 
-    assert_equal @non_required_subject_completed_user.completed_fraction_in_metas, fraction_in_metas
+    assert_equal fraction_in_metas, @non_required_subject_completed_user.completed_fraction_in_metas
   end
 end

--- a/test/fixtures/discord_profiles.yml
+++ b/test/fixtures/discord_profiles.yml
@@ -209,3 +209,8 @@ discord_profile_marumarushain<%= i %>:
   account_name:
   times_url:
 <% end %>
+
+discord_profire_harikirio:
+  user: harikirio
+  account_name:
+  times_url:

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -366,3 +366,11 @@ practice57:
   goal: "goal..."
   include_progress: false
   last_updated_user: komagata
+
+practice61:
+  title: "企業研究"
+  summary: "概要です"
+  description: "就職したい企業について調べます。(進捗の計算には含めません)"
+  goal: "goal..."
+  include_progress: false
+  memo: "memo for mentors..."

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -150,3 +150,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   user: marumarushain<%= i %>
   action_completed: true
 <% end %>
+
+talk42:
+  user: harikirio
+  action_completed: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -998,3 +998,23 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   last_activity_at: "2014-01-01 00:00:0<%= 2 + (i - 1) / 2 %>"
   sent_student_followup_message: true
 <% end %>
+
+harikirio: #必修でないプラクティスも修了しているユーザー
+  login_name: harikirio
+  email: harikiro@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: Hari Kirio
+  name_kana: ハリ キリオ
+  github_account: harikirio
+  twitter_account: harikirio
+  description: "必修でないプラクティスも取り組みます！"
+  course: course1
+  job: office_worker
+  experience: rails
+  job_seeker: true
+  unsubscribe_email_token: Z2tKHxSjj7FreyqQ95Yd9g
+  updated_at: "2020-01-01 00:00:12"
+  created_at: "2020-01-01 00:00:12"
+  sent_student_followup_message: true
+  last_activity_at: "2020-01-01 00:00:12"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -124,6 +124,15 @@ class UserTest < ActiveSupport::TestCase
     assert_equal old_fraction, user.completed_fraction
   end
 
+  test '#completed_fraction_in_metas' do
+    user = users(:harikirio)
+    fraction_in_metas = '2 (必須:1)'
+    user.completed_practices << practices(:practice5)
+    user.completed_practices << practices(:practice61)
+
+    assert_equal user.completed_fraction_in_metas, fraction_in_metas
+  end
+
   test '#depressed?' do
     user = users(:kimura)
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -98,41 +98,6 @@ class UserTest < ActiveSupport::TestCase
     assert_equal old_percentage, user.completed_practices_include_progress.size
   end
 
-  test '#completed_fraction don\'t calculate practice that include_progress: false' do
-    user = users(:komagata)
-    old_fraction = user.completed_practices_include_progress.size
-    user.completed_practices << practices(:practice5)
-
-    assert_not_equal old_fraction, user.completed_fraction
-
-    old_fraction = user.completed_practices_include_progress.size
-    user.completed_practices << practices(:practice53)
-
-    assert_equal old_fraction, user.completed_practices_include_progress.size
-  end
-
-  test '#completed_fraction don\'t calculate practice unrelated cource' do
-    user = users(:komagata)
-    old_fraction = user.completed_practices_include_progress.size
-    user.completed_practices << practices(:practice5)
-
-    assert_not_equal old_fraction, user.completed_practices_include_progress.size
-
-    old_fraction = user.completed_practices_include_progress.size
-    user.completed_practices << practices(:practice55)
-
-    assert_equal old_fraction, user.completed_practices_include_progress.size
-  end
-
-  test '#completed_fraction_in_metas' do
-    user = users(:harikirio)
-    fraction_in_metas = '2 （必須:1）'
-    user.completed_practices << practices(:practice5)
-    user.completed_practices << practices(:practice61)
-
-    assert_equal user.completed_fraction_in_metas, fraction_in_metas
-  end
-
   test '#depressed?' do
     user = users(:kimura)
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -74,54 +74,54 @@ class UserTest < ActiveSupport::TestCase
 
   test '#completed_percentage don\'t calculate practice that include_progress: false' do
     user = users(:komagata)
-    old_percentage = user.completed_percentage
+    old_percentage = user.completed_practices_include_progress.size
     user.completed_practices << practices(:practice5)
 
-    assert_not_equal old_percentage, user.completed_percentage
+    assert_not_equal old_percentage, user.completed_practices_include_progress.size
 
-    old_percentage = user.completed_percentage
+    old_percentage = user.completed_practices_include_progress.size
     user.completed_practices << practices(:practice53)
 
-    assert_equal old_percentage, user.completed_percentage
+    assert_equal old_percentage, user.completed_practices_include_progress.size
   end
 
   test '#completed_percentage don\'t calculate practice unrelated cource' do
     user = users(:komagata)
-    old_percentage = user.completed_percentage
+    old_percentage = user.completed_practices_include_progress.size
     user.completed_practices << practices(:practice5)
 
-    assert_not_equal old_percentage, user.completed_percentage
+    assert_not_equal old_percentage, user.completed_practices_include_progress.size
 
-    old_percentage = user.completed_percentage
+    old_percentage = user.completed_practices_include_progress.size
     user.completed_practices << practices(:practice55)
 
-    assert_equal old_percentage, user.completed_percentage
+    assert_equal old_percentage, user.completed_practices_include_progress.size
   end
 
   test '#completed_fraction don\'t calculate practice that include_progress: false' do
     user = users(:komagata)
-    old_fraction = user.completed_fraction
+    old_fraction = user.completed_practices_include_progress.size
     user.completed_practices << practices(:practice5)
 
     assert_not_equal old_fraction, user.completed_fraction
 
-    old_fraction = user.completed_fraction
+    old_fraction = user.completed_practices_include_progress.size
     user.completed_practices << practices(:practice53)
 
-    assert_equal old_fraction, user.completed_fraction
+    assert_equal old_fraction, user.completed_practices_include_progress.size
   end
 
   test '#completed_fraction don\'t calculate practice unrelated cource' do
     user = users(:komagata)
-    old_fraction = user.completed_fraction
+    old_fraction = user.completed_practices_include_progress.size
     user.completed_practices << practices(:practice5)
 
-    assert_not_equal old_fraction, user.completed_fraction
+    assert_not_equal old_fraction, user.completed_practices_include_progress.size
 
-    old_fraction = user.completed_fraction
+    old_fraction = user.completed_practices_include_progress.size
     user.completed_practices << practices(:practice55)
 
-    assert_equal old_fraction, user.completed_fraction
+    assert_equal old_fraction, user.completed_practices_include_progress.size
   end
 
   test '#completed_fraction_in_metas' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -126,7 +126,7 @@ class UserTest < ActiveSupport::TestCase
 
   test '#completed_fraction_in_metas' do
     user = users(:harikirio)
-    fraction_in_metas = '2 (必須:1)'
+    fraction_in_metas = '2 （必須:1）'
     user.completed_practices << practices(:practice5)
     user.completed_practices << practices(:practice61)
 

--- a/test/system/user/meta_data_test.rb
+++ b/test/system/user/meta_data_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class User::MetaDataTest < ApplicationSystemTestCase
+  test 'show progress percentage and click to check the number of completions' do
+    user = users(:harikirio)
+    user.completed_practices << practices(:practice5)
+    user.completed_practices << practices(:practice61)
+    visit_with_auth "/users/#{users(:harikirio).id}", 'harikirio'
+    assert_text '1%'
+    find('.completed-practices-progress__percentage').click
+    assert_text '修了: 2 （必須: 1/51）'
+  end
+end


### PR DESCRIPTION
## Issue

- Issue番号 
 #7635 

## 概要
プラクティスを修了した数が、場所によって異なる問題がありましたが、これは仕様でした。
両者の差異をわかりやすくするため、表記方法とデザインを修正します。

### 現状
<img width="1000" alt="スクリーンショット 2024-04-20 22 57 43" src="https://github.com/fjordllc/bootcamp/assets/8443743/20c94e11-a6a9-4092-a4cf-01391ee6151c">

左の「修了プラクティス」と右の「修了したプラクティス」の数が異なる。

### 修正後

数を以下のように定義する。
```
A = 修了したプラクティスの数
B = 修了したプラクティスの内、必須の数
C = コースの全体の必須のプラクティスの数
```

**左の修了プラクティス**
```
A （必須:B）
```

**右の修了したプラクティス**

通常：`B/C*100 % `
クリック後：`修了: A （必須: B/C）`


ユーザー一覧ページの進捗の部分もデザインが変わっています。
クリックすると % ⇔ x/x 表記に切り替わります。


## 変更確認方法

1. bug/mismatch_complete_practice_counts をローカルに取り込む
2. `bin/setup` を実行してseedデータを投入する
3. 任意のアカウントでログインしてユーザー一覧ページへアクセス
4. 進捗率が%表示になっていることを確認
5. %表記をクリックすると修了数の内訳が表示されることを確認
6. ユーザー詳細ページ(user:harikiroくん) `users/527754862` へアクセス
7. %表記をクリックすると修了数の内訳が表示されることを確認
8. ユーザー登録情報の修了数が表示されていることを確認

## Screenshot

### 変更後
<img width="894" alt="スクリーンショット 2024-04-20 23 21 44" src="https://github.com/fjordllc/bootcamp/assets/8443743/a1b9e29c-4934-4a8c-88eb-9d0ee19ad1be">



クリックすると表記が切り替わります。
![動作](https://github.com/fjordllc/bootcamp/assets/8443743/bafbc7cf-1038-4d5b-aa34-12243002a18a)
