### PR TITLE
画像アップロードの追加機能をコメントアウト

### DIFF
--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -57,8 +57,8 @@ export default class {
         responseKey: 'url',
         csrfToken: CSRF.getToken(),
         placeholder: '%filenameをアップロード中...',
-        uploadImageTag:
-          '<img src=%url width="100" height="100" loading="lazy" decoding="async" alt="%filename">\n',
+        //uploadImageTag:
+        //  '<img src=%url width="100" height="100" loading="lazy" decoding="async" alt="%filename">\n',
         afterPreview: () => {
           autosize.update(textarea)
 


### PR DESCRIPTION
画像アップロードがバグっているので追加した機能をストップさせました。
以前の動きに戻しました。