### PR TITLE
相談部屋のタイトルとリンク先を変更したが、ユーザー画面のタイトルとリンク先も変更してしまったので修正した

### DIFF
--- a/app/views/talks/_page_title.html.slim
+++ b/app/views/talks/_page_title.html.slim
@@ -3,7 +3,10 @@ header.page-header
     .page-header__inner
       .page-header__start
         h2.page-header__title
-          = user.login_name
+          - if current_user.admin?
+            = user.login_name
+          - else
+            | 相談部屋
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items
@@ -19,5 +22,9 @@ header.page-header
                   li.page-main-header-actions__item
                     = render 'users/following', user:
             li.page-header-actions__item
-              = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
-                | ユーザー一覧
+              - if current_user.admin?
+                = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
+                  | ユーザー一覧
+              - else
+                = link_to root_path, class: 'a-button is-md is-secondary is-block is-back' do
+                  | ダッシュボード

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -1,7 +1,7 @@
 - title "#{@user.login_name}さんの相談部屋"
 - set_meta_tags description: "#{@user.login_name}さんの相談部屋ページです。"
 
-= render 'users/page_title', user: @user
+= render 'talks/page_title', user: @user
 
 - if admin_login?
   = render 'users/page_tabs', user: @user


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/pull/7656

## 概要
[#7595](https://github.com/fjordllc/bootcamp/issues/7595)で相談部屋のタイトルとリンク先を変更したが、マイプロフィールページなどのユーザーページ全体のヘッダーが変更されてしまったので、修正した
新しく`app/views/talks/_page_title.html.slim`を作成して、相談部屋のみのヘッダーを作成した

## 変更確認方法

1. `bug/talk_page_title`をローカルに取り込む
2. 管理者でないユーザーでログインする
3. 相談部屋ページに遷移し、以下を確認する
  - ヘッダーのタイトルが相談部屋の文言になっているか
  - ヘッダーのリンク先がダッシュボードになっているか
4. 管理者ユーザーでログインする
5. 相談部屋ページに遷移し変更箇所がないか、以下を確認する
  - ヘッダーのタイトルがユーザー名になっているか
  - ヘッダーのリンク先がユーザー一覧になっているか
6. マイプロフィールページに遷移し、タイトルとリンク先が以下になっているか確認する
  - ヘッダーのタイトルがユーザー名になっているか
  - ヘッダーのリンク先がユーザー一覧になっているか

## Screenshot

### 変更前
- 相談部屋ページ
<img width="1103" alt="スクリーンショット 2024-04-18 19 06 52" src="https://github.com/fjordllc/bootcamp/assets/126838748/b370bd9e-5eb0-433a-ac4a-4c415fae039b">

- マイプロフィールページ
<img width="1107" alt="スクリーンショット 2024-04-18 19 07 54" src="https://github.com/fjordllc/bootcamp/assets/126838748/46f92bc4-8c3d-4480-8ea8-a691a79e099b">

### 変更後
- 相談部屋ページ(見た目は変更なし)
<img width="1103" alt="スクリーンショット 2024-04-18 19 06 52" src="https://github.com/fjordllc/bootcamp/assets/126838748/b370bd9e-5eb0-433a-ac4a-4c415fae039b">

- マイプロフィールページ
<img width="1103" alt="スクリーンショット 2024-04-18 19 07 19" src="https://github.com/fjordllc/bootcamp/assets/126838748/40379407-5112-49cc-8cae-f0ab8cd74f68">
