### PR TITLE
不要な div を削除

### DIFF
--- a/app/views/courses/books/index.html.slim
+++ b/app/views/courses/books/index.html.slim
@@ -16,13 +16,12 @@ header.page-header
                   i.fas.fa-plus
                   | 参考書籍登録
 = render 'courses/tabs'
-.page-body
-  .container.is-md
-    nav.pill-nav
-      .container
-        ul.pill-nav__items
-          li.pill-nav__item
-            = link_to '全て', course_books_path, class: "pill-nav__item-link #{params[:status] == 'mustread' ? '' : 'is-active'}"
-          li.pill-nav__item
-            = link_to '必読', course_books_path(status: 'mustread'), class: "pill-nav__item-link #{params[:status] == 'mustread' ? 'is-active' : ''}"
+.container.is-md
+  nav.pill-nav
+    .container
+      ul.pill-nav__items
+        li.pill-nav__item
+          = link_to '全て', course_books_path, class: "pill-nav__item-link #{params[:status] == 'mustread' ? '' : 'is-active'}"
+        li.pill-nav__item
+          = link_to '必読', course_books_path(status: 'mustread'), class: "pill-nav__item-link #{params[:status] == 'mustread' ? 'is-active' : ''}"
 div(data-vue="CourseBooks" data-vue-is-admin:boolean="#{current_user.admin?}" data-vue-is-mentor:boolean="#{current_user.mentor?}" data-vue-course:json="#{@course.to_json}")


### PR DESCRIPTION
## Issue

無し

## 概要
https://bootcamp.fjord.jp/courses/1/books にアクセスするとレイアウトが大きく崩れていたので修正しました
## 変更確認方法
左側のメニューからプラクティスをクリック -> 書籍タブをクリック

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/75117116/5b658cda-f1d3-4ba9-a212-8a3b5e75b9d9)

### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/75117116/1d6b8149-a47a-4936-8b39-3fc032941864)

