### PR TITLE
退会したアドバイザーはアドバイザー一覧に表示されないようにし、退会したユーザーを退会ユーザー一覧に表示するようにした

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,6 +8,11 @@ class Admin::UsersController < AdminController
     @direction = params[:direction] || 'desc'
     @target = params[:target]
     user_scope = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
+    user_scope = if @target == 'retired'
+                   user_scope.where.not(retired_on: nil)
+                 else
+                   user_scope.where(retired_on: nil)
+                 end
     @users = user_scope.with_attached_avatar
                        .preload(:company, :course)
                        .order_by_counts(params[:order_by] || 'id', @direction)


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7685

## 概要
- 退会したアドバイザーはアドバイザー一覧に表示されないようにした
- 退会者一覧はロール関係なく（研修生も）全ての退会者が表示されるようにした

## 変更確認方法

1. `bug/add_retired_advisors_to_retired_list`をローカルに取り込む
2. 管理者ユーザーでログインする
3. [ユーザー一覧](http://localhost:3000/admin/users)を開く
4. 下記に所属しているユーザーを1人ずつ任意で退会ユーザーにする
  - 管理者
  - 現役生
  - 卒業生
  - 休会
  - メンター
  - アドバイザー
5. 退会ユーザーにしたユーザーが[退会ユーザー一覧](http://localhost:3000/admin/users?target=retired)に表示されているか確認
6. 退会ユーザーが退会する前に所属していた一覧ページに表示されていないか確認

- 退会ユーザーにする方法
  - 上記のユーザー詳細ページを開く
  - ステータス変更の`管理者として情報変更`ボタンを押す
  - ユーザーステータスの`退会済み`にチェックを入れる
  - `更新する`ボタンを押す


## Screenshot

### 変更前
- 退会したアドバイザーがアドバイザー一覧に表示されている
<img width="1345" alt="スクリーンショット 2024-04-19 16 50 06" src="https://github.com/fjordllc/bootcamp/assets/126838748/4ef8b7cf-e006-45d3-8518-2ace598c4458">

### 変更後
- 退会したアドバイザーがアドバイザー一覧に表示されない
<img width="1347" alt="スクリーンショット 2024-04-19 16 57 25" src="https://github.com/fjordllc/bootcamp/assets/126838748/bf3b8e16-1bab-4421-a359-192142962ad6">
