### PR TITLE
ポートフォリオのサムネイル画像のトリミング方法を変更

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -21,7 +21,7 @@ class Work < ApplicationRecord
 
   def thumbnail_url
     if thumbnail.attached?
-      thumbnail.variant(resize_to_limit: THUMBNAIL_SIZE).processed.url
+      thumbnail.variant(resize_to_fill: THUMBNAIL_SIZE).processed.url
     else
       image_url('/images/works/thumbnails/default.png')
     end


### PR DESCRIPTION
# Issue

- Issue番号
- #7383 

## 概要

　ポートフォリオページのサムネイルについて、画像のサイズのトリミング方法を変更した。
変更前：
`resize_to_fill` 
https://www.rubydoc.info/gems/carrierwave/CarrierWave/Vips#resize_to_fill-instance_method
アスペクト比を維持せずに指定サイズで切り抜く

変更後：
`resize_to_limit`
https://www.rubydoc.info/gems/carrierwave/CarrierWave/Vips#resize_to_limit-instance_method
アスペクト比を維持して指定サイズに切り抜く

## 画像のトリミングの仕様
https://github.com/fjordllc/bootcamp/pull/6483#issuecomment-2018841300

## 変更確認方法

1. ブランチ名 ` feature/constantize-size-of-thumbnails-in-portfolio` をローカルに取り込む
2. `foreman start -f Procfile.dev ` を実行してアプリを立ち上げる
3. ポートフォリオを追加できる任意のアカウントでログイン
4. `/works/new` へアクセス
5. ポートフォリオのサムネイルを添付して投稿
6. 画像が以下の要領で切り取れることを確認

画像はここのコードに使われているものを使いました。
https://codepen.io/machida/pen/yLrXvqE

## Screenshot

### 画像サイズ 1495x2232の場合

<img width="100" alt="1495" src="https://github.com/fjordllc/bootcamp/assets/8443743/7b48de5a-3ee7-47ea-aa70-acf091f5dbb62">

　
<img width="300" alt="スクリーンショット 2024-04-21 14 57 40" src="https://github.com/fjordllc/bootcamp/assets/8443743/af878df1-3e19-4e4b-a781-63024d68e242">

### 画像サイズ 2232x757の場合

<img width="200" alt="2232" src="https://github.com/fjordllc/bootcamp/assets/8443743/abfff399-a3e5-42c1-b6a9-1dec319872f4">

　
<img width="300" alt="スクリーンショット 2024-04-21 14 57 08" src="https://github.com/fjordllc/bootcamp/assets/8443743/a44fdd39-2477-4d7c-95a5-7bc31321baad">


