### PR TITLE
未読通知を100件以上取得できるようにした

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -46,7 +46,7 @@ class Notification < ApplicationRecord
 
   scope :unreads, -> { where(read: false) }
   scope :with_avatar, -> { preload(sender: { avatar_attachment: :blob }) }
-  scope :by_read_status, ->(status) { status == 'unread' ? unreads.with_avatar.limit(99) : with_avatar }
+  scope :by_read_status, ->(status) { status == 'unread' ? unreads.with_avatar : with_avatar }
 
   scope :by_target, lambda { |target|
     target ? where(kind: TARGETS_TO_KINDS[target]) : all

--- a/db/fixtures/notifications.yml
+++ b/db/fixtures/notifications.yml
@@ -156,8 +156,8 @@ notification_regular_event_updated:
   link: "/regular_events/<%= ActiveRecord::FixtureSet.identify(:regular_event1) %>"
   read: false
 
-<% 1.upto(25) do |i| %>
-notification_for_pagination<%= i %>: # 通知ページのページネーション動作確認のための通知
+<% 1.upto(110) do |i| %>
+notification_for_pagination<%= i %>: # 通知ページのページネーション動作と取得数制限確認のための通知
   kind: 5
   user: hatsuno
   sender: komagata

--- a/db/fixtures/practices.yml
+++ b/db/fixtures/practices.yml
@@ -412,3 +412,325 @@ practice64:
   description: "description..."
   goal: "goal..."
   memo: "memo for mentors..."
+
+practice65:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice66:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice67:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice68:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice69:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice70:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice71:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice72:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice73:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice74:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice75:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice76:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice77:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice78:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice79:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice80:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice81:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice82:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice83:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice84:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice85:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice86:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice87:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice88:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice89:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice90:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice91:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice92:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice93:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice94:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice95:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice96:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice97:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice98:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice99:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice100:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice101:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice102:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice103:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice104:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice105:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice106:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice107:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice108:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice109:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."
+
+practice110:
+  title: "概要あり / OGP画像あり"
+  summary: "概要です"
+  description: "概要欄(概要文＆OGP画像)を表示します"
+  goal: "goal..."
+  memo: "memo for mentors..."

--- a/test/models/notifications_test.rb
+++ b/test/models/notifications_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class NotificationTest < ActiveSupport::TestCase
   setup do
+    Notification.destroy_all
     @receiver = users(:mentormentaro)
     @sender = users(:machida)
     @link = 'path/to/link'
@@ -11,7 +12,6 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   test '.latest_of_each_link' do
-    Notification.destroy_all
     old_notification = Notification.create!(user: @receiver, sender: @sender, link: @link, created_at: @now)
     new_notification = Notification.create!(user: @receiver, sender: @sender, link: @link, created_at: @now + 1)
 
@@ -22,7 +22,6 @@ class NotificationTest < ActiveSupport::TestCase
   end
 
   test '.latest_of_each_link returns only one notification of the latest notifications created at the same time in the same link' do
-    Notification.destroy_all
     notification_without_max_id_of_latests = Notification.create!(id: 1, user: @receiver, sender: @sender, link: @link, created_at: @now)
     notification_with_max_id_of_latests = Notification.create!(id: 2, user: @receiver, sender: @sender, link: @link, created_at: @now)
 
@@ -30,5 +29,12 @@ class NotificationTest < ActiveSupport::TestCase
 
     assert_not_includes latest_notifications_of_each_link, notification_without_max_id_of_latests
     assert_includes latest_notifications_of_each_link, notification_with_max_id_of_latests
+  end
+
+  test '.by_read_status returns over 99 unread notifications' do
+    120.times { Notification.create!(user: @receiver, sender: @sender, link: @link, created_at: @now, read: false) }
+    unread_notifications = @receiver.notifications.unreads
+
+    assert_equal unread_notifications, Notification.by_read_status('unread').where(user: @receiver)
   end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7539

## 概要
99件までとされていた未読通知のデータ取得を取り払いました。
これにより、通知数が101件を超えても5ページまでしか表示されなかった未読通知一覧ページが、6ページ以上表示されるようになります。

## 変更確認方法

1. `bug/unread-notifications-only-5-pages`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. ユーザー名`hatsuno`でログイン
5. 画面右上の通知ベルの表示が`99+`となっていることを確認し、プルダウンメニューから「全ての未読通知一覧へ」をクリック
	- 通知数が少ない場合は、`bin/rails db:seed`を実行してください
7. 未読通知一覧ページが6ページ以上あることを確認する

## Screenshot
いずれも未読通知数100件以上で撮影しています。

### 変更前


![#7539修正前](https://github.com/fjordllc/bootcamp/assets/125527162/5aea5dca-4352-4e47-88c4-a6d8b822182b)


### 変更後

![#7539修正後](https://github.com/fjordllc/bootcamp/assets/125527162/fe340193-0602-493a-a827-fdf3c35678ed)

