### PR TITLE
 非メンターの管理者でも研修生の提出物詳細ページで研修終了日が表示されるようにした

### DIFF
--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -11,7 +11,7 @@ header.page-content-header
       .page-content-header__before-title
         = link_to product.user, class: 'a-user-name' do
           = product.user.long_name
-        - if current_user&.mentor? && @product.user.trainee?
+        - if current_user&.admin_or_mentor? && @product.user.trainee?
           .a-meta
             span.a-meta__label
               = User.human_attribute_name :training_ends_on

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -639,6 +639,19 @@ class ProductsTest < ApplicationSystemTestCase
     end
   end
 
+  test 'display training end date in product show for mentor only' do
+    # 1ページ内に企業研修生の提出物を表示するために、作成者がkensyu以外のものを削除する
+    Product.where.not(user: users(:kensyu)).delete_all
+
+    travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
+      visit_with_auth "/products/#{products(:product13).id}", 'mentormentaro'
+      find('.page-content-header__before-title')
+      assert_selector '.a-meta__label', text: '研修終了日'
+      assert_selector '.a-meta__value', text: '2022年04月01日'
+      assert_selector '.a-meta__value', text: '（あと365日）'
+    end
+  end
+
   test 'display training end date in products for admin only' do
     # 1ページ内に企業研修生の提出物を表示するために、作成者がkensyu以外のものを削除する
     Product.where.not(user: users(:kensyu)).delete_all
@@ -646,6 +659,19 @@ class ProductsTest < ApplicationSystemTestCase
 
     travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
       find('.is-products.loaded', wait: 10)
+      assert_selector '.a-meta__label', text: '研修終了日'
+      assert_selector '.a-meta__value', text: '2022年04月01日'
+      assert_selector '.a-meta__value', text: '（あと365日）'
+    end
+  end
+
+  test 'display training end date in product show for admin only' do
+    # 1ページ内に企業研修生の提出物を表示するために、作成者がkensyu以外のものを削除する
+    Product.where.not(user: users(:kensyu)).delete_all
+
+    travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
+      visit_with_auth "/products/#{products(:product13).id}", 'adminonly'
+      find('.page-content-header__before-title')
       assert_selector '.a-meta__label', text: '研修終了日'
       assert_selector '.a-meta__value', text: '2022年04月01日'
       assert_selector '.a-meta__value', text: '（あと365日）'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -629,9 +629,9 @@ class ProductsTest < ApplicationSystemTestCase
   test 'display training end date in products for mentor only' do
     # 1ページ内に企業研修生の提出物を表示するために、作成者がkensyu以外のものを削除する
     Product.where.not(user: users(:kensyu)).delete_all
-    visit_with_auth '/products', 'mentormentaro'
 
     travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
+      visit_with_auth '/products', 'mentormentaro'
       find('.is-products.loaded', wait: 10)
       assert_selector '.a-meta__label', text: '研修終了日'
       assert_selector '.a-meta__value', text: '2022年04月01日'
@@ -655,9 +655,9 @@ class ProductsTest < ApplicationSystemTestCase
   test 'display training end date in products for admin only' do
     # 1ページ内に企業研修生の提出物を表示するために、作成者がkensyu以外のものを削除する
     Product.where.not(user: users(:kensyu)).delete_all
-    visit_with_auth '/products', 'adminonly'
 
     travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
+      visit_with_auth '/products', 'adminonly'
       find('.is-products.loaded', wait: 10)
       assert_selector '.a-meta__label', text: '研修終了日'
       assert_selector '.a-meta__value', text: '2022年04月01日'
@@ -681,9 +681,9 @@ class ProductsTest < ApplicationSystemTestCase
   test 'display training end date in products for adviser' do
     # 1ページ内に企業研修生の提出物を表示するために、作成者がkensyu以外のものを削除する
     Product.where.not(user: users(:kensyu)).delete_all
-    visit_with_auth '/products', 'advijirou'
 
     travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
+      visit_with_auth '/products', 'advijirou'
       find('.is-products.loaded', wait: 10)
       assert_no_selector '.a-meta__label', text: '研修終了日'
       assert_no_selector '.a-meta__value', text: '2022年04月01日'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7603

## 概要
非メンターの管理者ユーザーが研修生の提出物詳細ページを閲覧した際に、研修終了日が表示されるようにしました。
これにより、提出物一覧画面と詳細画面のどちらでも、管理者とメンターに研修終了日が表示されるようになります。

## 変更確認方法

1. `bug/display-training-end-date-for-admin`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. `adminonly`でログインし、`/products`にアクセス
5. 研修生に研修終了日が表示されることを確認する
6. 任意の研修生の提出物をクリックする
7. タイトル上部に研修終了日が表示されることを確認する

## Screenshot

### 変更前
![スクリーンショット 2024-04-24 172627](https://github.com/fjordllc/bootcamp/assets/125527162/eadfa1f3-2d64-454a-8281-df06d38a8fe9)


### 変更後

![スクリーンショット 2024-04-24 172418](https://github.com/fjordllc/bootcamp/assets/125527162/e4f09203-ea1e-4cde-8ef2-f140a52af924)
