### PR TITLE
ユーザーアイコンのファイル名をidに変更する

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -9,6 +9,7 @@ class CurrentUserController < ApplicationController
 
   def update
     if @user.update(user_params)
+      @user.rename_avatar
       redirect_to @user, notice: 'ユーザー情報を更新しました。'
     else
       render 'edit'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,6 +70,10 @@ class UsersController < ApplicationController
     else
       create_user!
     end
+
+    return unless @user.errors.empty?
+
+    @user.rename_avatar
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -791,6 +791,13 @@ class User < ApplicationRecord
     hibernated_at + User::HIBERNATION_LIMIT if hibernated_at?
   end
 
+  def rename_avatar
+    return unless avatar.attached?
+
+    icon = open_avatar_uri
+    avatar.attach(io: icon, filename: id) if icon
+  end
+
   private
 
   def password_required?
@@ -819,5 +826,9 @@ class User < ApplicationRecord
 
   def category_having_unstarted_practice
     unstarted_practices&.first&.categories&.first
+  end
+
+  def open_avatar_uri
+    avatar_url == '/images/users/avatars/default.png' ? nil : URI.parse(avatar_url).open
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -724,4 +724,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal '2020-07-01 09:00:00 +0900', users(:kyuukai).scheduled_retire_at.to_s
     assert_nil users(:hatsuno).scheduled_retire_at
   end
+
+  test '#rename_avatar' do
+    user = users(:komagata)
+    old_avatar_url = user.avatar.url
+
+    user.stub(:open_avatar_uri, File.open('test/fixtures/files/users/avatars/komagata.jpg')) do
+      user.rename_avatar
+      assert_not_equal old_avatar_url, user.avatar.url
+    end
+  end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -298,6 +298,33 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_no_selector 'img[class=article__image]'
   end
 
+  test 'display user icon when not logged in' do
+    visit_with_auth '/current_user/edit', 'hatsuno'
+
+    attach_file 'user[avatar]', Rails.root.join('test/fixtures/files/users/avatars/hatsuno.jpg'), make_visible: true
+    click_on '更新する'
+
+    find('.test-show-menu').click
+    click_link 'ログアウト'
+
+    visit_with_auth new_article_url, 'machida'
+    fill_in 'article[title]', with: 'test'
+    fill_in 'article[body]', with: ':@hatsuno:'
+
+    click_on '公開する'
+
+    click_link 'プラクティス'
+
+    find('.test-show-menu').click
+    click_link 'ログアウト'
+
+    visit articles_path
+    click_on 'test'
+
+    assert_selector "img[src$='#{users(:hatsuno).id}.png']"
+    users(:hatsuno).avatar.purge
+  end
+
   test 'WIP articles are not included in recent articles' do
     wip_article1 = Article.create(
       title: '未公開の記事',

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -321,7 +321,7 @@ class ArticlesTest < ApplicationSystemTestCase
     visit articles_path
     click_on 'test'
 
-    assert_selector "img[src$='#{users(:hatsuno).id}.png']"
+    assert_selector "img[src$='#{users(:hatsuno).id}']"
     users(:hatsuno).avatar.purge
   end
 


### PR DESCRIPTION
## Issue

- #7747 

## 概要
ユーザー更新・登録したときのユーザー画像のファイル名を`ユーザーID`にしました。

## 変更確認方法

### 前準備
1. `fix/rename_avatar_test`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる

#### ユーザー登録
1. ユーザーを新規作成する
2. `/users/:user_id`に遷移して、アイコンにカーソルを合わせて検証ツールを開く[(参考)](https://gyazo.com/3394b0cf390cc1ea6684bb14882deb57)
3. imgタグのsrcがユーザーIDになっているかを確認する[(参考)](https://gyazo.com/18a1c3c06a7277726219c559658686f9)

#### ユーザー更新
1. 一般ユーザーでログインする(例: `kimura`・`testtest`)
4. http://localhost:3000/current_user/edit に遷移
5. ユーザーアイコンを更新する[(参考)](https://gyazo.com/28480052f2fd90cbc7a35f81cfe6b9c5)
2. `/users/:user_id`に遷移して、アイコンにカーソルを合わせて検証ツールを開く[(参考)](https://gyazo.com/3394b0cf390cc1ea6684bb14882deb57)
3. imgタグのsrcがユーザーIDになっているかを確認する[(参考)](https://gyazo.com/18a1c3c06a7277726219c559658686f9)

#### (一応)日報内で確認する
1. ユーザーアイコンが表示される日報を書く

内容は下記のように設定してユーザーアイコンが表示されるようにしてください
```
:@kimura: 

↑のように :@(ユーザー名): でOKです
```
2. 「検証」からファイル名がユーザーIDになっていることを[確認](https://gyazo.com/700dfb1ae8e7dd7bb8c33ef14191ba5a)する

## Screenshot

### 変更前

[![Image from Gyazo](https://i.gyazo.com/3394b0cf390cc1ea6684bb14882deb57.png)](https://gyazo.com/3394b0cf390cc1ea6684bb14882deb57)

[![Image from Gyazo](https://i.gyazo.com/c09ca700555cc76ca9919093b8f30901.png)](https://gyazo.com/c09ca700555cc76ca9919093b8f30901)
### 変更後

[![Image from Gyazo](https://i.gyazo.com/18a1c3c06a7277726219c559658686f9.png)](https://gyazo.com/18a1c3c06a7277726219c559658686f9)