### PR TITLE
アバターファイル名をuser_idにする

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -9,6 +9,7 @@ class CurrentUserController < ApplicationController
 
   def update
     if @user.update(user_params)
+      @user.avatar_attach_with_filename
       redirect_to @user, notice: 'ユーザー情報を更新しました。'
     else
       render 'edit'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,6 +70,10 @@ class UsersController < ApplicationController
     else
       create_user!
     end
+
+    return if @user.errors.any?
+
+    @user.avatar_attach_with_filename
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -631,6 +631,13 @@ class User < ApplicationRecord
     image_url default_image_path
   end
 
+  def avatar_attach_with_filename
+    return unless avatar.attached?
+
+    icon = open_avatar_uri
+    avatar.attach(io: icon, filename: id) if icon
+  end
+
   def generation
     (created_at.year - 2013) * 4 + (created_at.month + 2) / 3
   end
@@ -819,5 +826,9 @@ class User < ApplicationRecord
 
   def category_having_unstarted_practice
     unstarted_practices&.first&.categories&.first
+  end
+
+  def open_avatar_uri
+    avatar_url == '/images/users/avatars/default.png' ? nil : URI.parse(avatar_url).open
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -65,6 +65,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal '/images/users/avatars/default.png', user.avatar_url
   end
 
+  test '#avatar_attach_with_filename' do
+    user = users(:komagata)
+    old_avatar_url = user.avatar.url
+
+    user.stub(:open_avatar_uri, File.open('test/fixtures/files/users/avatars/komagata.jpg')) do
+      user.avatar_attach_with_filename
+      assert_not_equal old_avatar_url, user.avatar.url
+    end
+  end
+
   test '#generation' do
     assert_equal 1, User.new(created_at: '2013-03-25 00:00:00').generation
     assert_equal 2, User.new(created_at: '2013-05-05 00:00:00').generation


### PR DESCRIPTION
## Issue

- #7747 

## 概要
アバターのファイル名がアップロード時のファイル名をそのまま使っているため、user_idを使うように修正しました。
`system/users_test`の`can upload heic image as user avatar`が通らない問題を解決します。

テストが通らない原因としては、
https://github.com/fjordllc/bootcamp/commit/3d1f0f1ba5a091c45bd5cde0f2272c188a4a9a76#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29b
こちらの714行目の処理でファイル名をidに変更していたのですが、削除されたことで元のファイル名をそのまま使うようになっていたようです。

本PRではファイル名をユーザーIDにする、以前の挙動に戻していますが、
https://github.com/fjordllc/bootcamp/pull/7608 でファイル名をユーザー名に変更する予定なので暫定的な実装になります。

## 変更確認方法

1. `feature/use_username_as_avatar_filename`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. 任意のユーザーで`http://localhost:3000/current_user/edit`にアクセスする 
4. ユーザーのアイコンを変更する
5. dev-toolで表示されるアイコンをクリックし、srcからファイル名がユーザーのidであることを確認する

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/99132547/4b835151-26e2-4e63-95a3-f0b5be795e53)

### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/99132547/fb8fc9db-db4e-486c-b9eb-038cf625e1f8)

