### PR TITLE
企業研修の申し込みフォームを作成(再修正)

### DIFF
--- a/db/migrate/20240501051341_add_not_null_to_corporate_trainings.rb
+++ b/db/migrate/20240501051341_add_not_null_to_corporate_trainings.rb
@@ -1,0 +1,13 @@
+class AddNotNullToCorporateTrainings < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :corporate_trainings, :company_name, false
+    change_column_null :corporate_trainings, :name, false
+    change_column_null :corporate_trainings, :email, false
+    change_column_null :corporate_trainings, :meeting_date1, false
+    change_column_null :corporate_trainings, :meeting_date2, false
+    change_column_null :corporate_trainings, :meeting_date3, false
+    change_column_null :corporate_trainings, :participants_count, false
+    change_column_null :corporate_trainings, :training_duration, false
+    change_column_null :corporate_trainings, :how_did_you_hear, false
+  end
+end

--- a/db/migrate/20240502051341_change_corporate_trainings_to_corporate_training_inquiries.rb
+++ b/db/migrate/20240502051341_change_corporate_trainings_to_corporate_training_inquiries.rb
@@ -1,0 +1,5 @@
+class ChangeCorporateTrainingsToCorporateTrainingInquiries < ActiveRecord::Migration[6.1]
+  def change
+    rename_table :corporate_trainings, :corporate_training_inquiries
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_20_081440) do
+ActiveRecord::Schema.define(version: 2024_05_02_051341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -743,9 +743,9 @@ ActiveRecord::Schema.define(version: 2024_03_20_081440) do
     t.string "country_code"
     t.string "subdivision_code"
     t.boolean "auto_retire", default: true
-    t.boolean "invoice_payment", default: false, null: false
     t.integer "editor"
     t.string "other_editor"
+    t.boolean "invoice_payment", default: false, null: false
     t.boolean "hide_mentor_profile", default: false, null: false
     t.index ["course_id"], name: "index_users_on_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## Issue

- #7171 
## PR
- #7319
- #7382
- #7740
## 概要
#7740 で失念したリネームとNOT NULL制約追加のmigrationファイルを生成しました。
## 変更確認方法

1. `feature/corporate_training_form_create`をローカルに取り込む
2. `db:migrate`(解決しない場合は`db:migrate:reset`)を実行
3. http://localhost:3000/corporate_training_inquiry/new にアクセス
4. 必須項目(*)を入力し、下記の個人情報の取り扱いに同意するのチェックボックスをチェック
5. 送信ボタンを押下
6. http://localhost:3000/letter_opener で`info@lokka.jp`宛てにメールが届くことを確認


## Screenshot
![image](https://github.com/fjordllc/bootcamp/assets/88243294/37d69a13-77e3-44be-9cac-9bd0980b0dab)
