### PR TITLE
日報一覧（全て、未読）を非JS化

### DIFF
--- a/app/controllers/reports/unchecked_controller.rb
+++ b/app/controllers/reports/unchecked_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Reports::UncheckedController < ApplicationController
+  PAGER_NUMBER = 25
+
   before_action :require_staff_login
-  def index; end
+  def index
+    @reports = Report.unchecked.not_wip.list.page(params[:page]).per(PAGER_NUMBER)
+  end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReportsController < ApplicationController
+  PAGER_NUMBER = 25
+
   include Rails.application.routes.url_helpers
   before_action :set_report, only: %i[show]
   before_action :set_my_report, only: %i[destroy]
@@ -11,7 +13,10 @@ class ReportsController < ApplicationController
   before_action :set_categories, only: %i[create update]
   before_action :set_watch, only: %i[show]
 
-  def index; end
+  def index
+    @reports = Report.list.page(params[:page]).per(PAGER_NUMBER)
+    @reports = @reports.joins(:practices).where(practices: { id: params[:practice_id] }) if params[:practice_id].present?
+  end
 
   def show
     @products = @report.user.products.not_wip.order(published_at: :desc)

--- a/app/views/application/_unconfirmed_links_open.html.slim
+++ b/app/views/application/_unconfirmed_links_open.html.slim
@@ -1,7 +1,7 @@
-hr.a-border
+hr.a-border-tint
 .card-footer
   .card-main-actions
     ul.card-main-actions__items
       li.card-main-actions__item
-        button#js-shortcut-unconfirmed-links-open.thread-unconfirmed-links-form__action(class="a-button is-sm is-secondary")
+        button#js-shortcut-unconfirmed-links-open.thread-unconfirmed-links-form__action(class="a-button is-sm is-block is-secondary")
           | #{label}

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -1,0 +1,66 @@
+.card-list-item(class="#{report.wip? ? 'is-wip' : ''}")
+  .card-list-item__inner
+    .card-list-item__user
+      = render 'users/icon', user: report.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'
+    .card-list-item__rows
+      .card-list-item__row
+        .card-list-item-title
+          .card-list-item-title__start
+            - if report.wip?
+              .a-list-item-badge.is-wip
+                span
+                  | WIP
+            h2.card-list-item-title__title(itemprop='name')
+              = link_to report, itemprop: 'url', class: 'card-list-item-title__link a-text-link js-unconfirmed-link' do
+                = image_tag("emotion/#{report.emotion}.svg", alt: report.emotion, class: 'card-list-item-title__emotion-image')
+                = report.title
+          - if current_user == report.user
+            .card-list-item-title__end
+              label.card-list-item-actions__trigger(for="#{report.id}")
+                i.fa-solid.fa-ellipsis-h
+              .card-list-item-actions
+                input.a-toggle-checkbox(type="checkbox" id=="#{report.id}")
+                .card-list-item-actions__inner
+                  ul.card-list-item-actions__items
+                    li.card-list-item-actions__item
+                      = link_to edit_report_path(report), class: 'card-list-item-actions__action' do
+                        i.fa-solid.fa-pen
+                        | 内容変更
+                    li.card-list-item-actions__item
+                      = link_to new_report_path(id: report), class: 'card-list-item-actions__action' do
+                        i.fa-solid.fa-copy
+                        | コピー
+                  label.a-overlay(for="#{report.id}")
+      .card-list-item__row
+        .card-list-item-meta
+          .card-list-item-meta__items
+            .card-list-item-meta__item
+              = link_to report.user, class: 'a-user-name' do
+                = report.user.long_name
+            .card-list-item-meta__item
+              time.a-meta(datetime="#{report.reported_on.to_datetime}")
+                = l report.reported_on
+                | の日報
+      - if report.comments.any?
+        hr.card-list-item__row-separator
+        .card-list-item__row
+          .card-list-item-meta
+            .card-list-item-meta__items
+              .card-list-item-meta__item
+                .a-meta
+                  | コメント（#{report.comments.size}）
+              .card-list-item-meta__item
+                .card-list-item__user-icons
+                  = render partial: 'comments/user_icons', collection: report.comments.commented_users, as: :user
+              .card-list-item-meta__item
+                time.a-meta(datetime="#{report.comments.last.updated_at.to_datetime}" pubdate='pubdate')
+                  | 〜 #{l report.comments.last.updated_at, format: :date_and_time}
+
+    - if report.checks.any?
+      .stamp.stamp-approve
+        h2.stamp__content.is-title 確認済
+        time.stamp__content.is-created-at
+          = l report.checks.last.created_at.to_date, format: :short
+        .stamp__content.is-user-name
+          .stamp__content-inner
+            = report.checks.last.user.login_name

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -16,5 +16,30 @@ header.page-header
 
 = render 'reports/tabs'
 
-- practices = current_user.practices.as_json(only: %i[id title])
-= react_component('Reports', all: true, practices: practices)
+.page-main
+  nav.page-filter.form
+    .container.is-md
+      = form_with url: reports_path, local: true, method: 'get'
+      .form-item.is-inline-md-up
+        = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
+        = select_tag :practice_id, options_from_collection_for_select(current_user.practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
+  hr.a-border
+  - if @reports.empty?
+    .o-empty-message
+      .o-empty-message__icon
+        .card-list.a-card
+          .card__description
+            .o-empty-message
+              .o-empty-message__icon
+                i.fa-regular.fa-sad-tear
+              .o-empty-message__text
+                | 日報はまだありません。
+  - else
+    .page-body
+      .container.is-md
+        .page-content.reports
+          = paginate @reports
+          .card-list.a-card
+            .card-list__items
+              = render partial: 'reports/report', collection: @reports, as: :report
+          = paginate @reports

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -1,9 +1,5 @@
-- title @search_words.present? ? "'#{@search_words.join(' ')}'の検索結果" : '日報'
-
-- if @search_words.present?
-  - set_meta_tags description: "日報'#{@search_words.join(' ')}'の検索結果の一覧ページです。"
-- else
-  - set_meta_tags description: '日報の一覧ページです。'
+- title '日報'
+- set_meta_tags description: '日報の一覧ページです。'
 
 header.page-header
   .container

--- a/app/views/reports/unchecked/index.html.slim
+++ b/app/views/reports/unchecked/index.html.slim
@@ -11,4 +11,21 @@ header.page-header
 
 = render 'reports/tabs'
 
-= react_component('Reports', unchecked: true)
+.page-main
+  - if @reports.empty?
+    .o-empty-message
+      .o-empty-message__icon
+        i.fa-regular.fa-smile
+        p.o-empty-message__text
+          | 未チェックの日報はありません
+  - else
+    .page-body
+      .container.is-md
+        .page-content.reports
+          = paginate @reports
+          .card-list.a-card
+            .card-list__items
+              = render partial: 'reports/report', collection: @reports, as: :report
+            - if mentor_login?
+              = render partial: 'unconfirmed_links_open', locals: { label: '未チェックの日報を一括で開く' }
+          = paginate @reports


### PR DESCRIPTION
## Issue

- #7718

## 概要

現在Reactで実装されている以下のページを通常のviewでの実装に変更しました。
- 全ての日報（`/reports`）
- 未チェックの日報（`/reports/unchecked`）

※ React関連のファイルに関しては、他の部分で使用されているため削除できませんでした。

## 変更確認方法

1. `chore/convert-daily-reports-to-slim`をローカルに取り込む
2. 全ての日報（`/reports`）、未チェックの日報（`/reports/unchecked`）にアクセスして、以下を確認する（※未チェックの日報に関してはメンターアカウントでログインする必要があります）
    - 表示・動作がReactでの実装時と同じであること

## 補足

以下の部分がReactバージョンと表示が異なりますが、React化の際に表示されなくなっていた不具合という認識です。

### コメントのアバターアイコンの枠

![image](https://github.com/fjordllc/bootcamp/assets/131861805/8091c933-375b-49bb-9aed-9a1a45278bf5)

![image](https://github.com/fjordllc/bootcamp/assets/131861805/3800804a-44be-4eb6-8479-535b68f230f0)

### 自身の日報での３点メニューボタン

![image](https://github.com/fjordllc/bootcamp/assets/131861805/a8daa03f-9ef2-4ec3-a55c-33f6ced4eb53)

![image](https://github.com/fjordllc/bootcamp/assets/131861805/ee7cff64-74c4-4b17-9920-b321465fb865)

## Screenshot

- 実装方法の変更のため省略