### PR TITLE
企業研修申し込みフォームの機能していない送信ボタンを修正

### DIFF
--- a/app/views/corporate_training_inquiries/_form.html.slim
+++ b/app/views/corporate_training_inquiries/_form.html.slim
@@ -66,4 +66,4 @@
         li.form-actions__item.is-main
           = f.submit '送信', class: 'a-button is-lg is-primary is-block'
 
-  = recaptcha_v3(action: 'corporate_training_inquiry', callback: 'skipOnLoadReCaptcha') if recaptcha_enabled?
+  = recaptcha_v3(action: 'inquiry', callback: 'skipOnLoadReCaptcha') if recaptcha_enabled?


### PR DESCRIPTION
## Issue

- #7171 
## PR
- #7319
- #7382
- #7740
- #7754
## 概要
#7754 でフォームの送信ボタンが機能していない点の修正です。
## 変更確認方法

1. `feature/corporate_training_form_create`をローカルに取り込む
2. `db:migrate`(解決しない場合は`db:migrate:reset`)を実行
3. http://localhost:3000/corporate_training_inquiry/new にアクセス
4. 必須項目(*)を入力し、下記の個人情報の取り扱いに同意するのチェックボックスをチェック
5. 送信ボタンを押下
6. http://localhost:3000/letter_opener で`info@lokka.jp`宛てにメールが届くことを確認


## Screenshot
![image](https://github.com/fjordllc/bootcamp/assets/88243294/37d69a13-77e3-44be-9cac-9bd0980b0dab)
