### PR TITLE
WIP状態の日報を提出する際に入力内容にエラーがある場合のバグを解消

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -58,6 +58,7 @@ class ReportsController < ApplicationController
   end
 
   def update
+    before_wip_status = @report.wip
     set_wip
     @report.practice_ids = nil if params[:report][:practice_ids].nil?
     @report.assign_attributes(report_params)
@@ -66,6 +67,7 @@ class ReportsController < ApplicationController
       Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
+      @report.wip = before_wip_status
       render :edit
     end
   end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -735,4 +735,23 @@ class ReportsTest < ApplicationSystemTestCase
     end
     assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
+
+  test 'submit wip report with error' do
+    report = reports(:report9)
+    visit_with_auth "/reports/#{report.id}", 'sotugyou'
+
+    click_link '内容修正'
+    uncheck '学習時間は無し', allow_label_click: true
+    click_link '学習時間追加'
+
+    first('.learning-time').all('.learning-time__started-at select')[0].select('07')
+    first('.learning-time').all('.learning-time__started-at select')[1].select('30')
+    first('.learning-time').all('.learning-time__finished-at select')[0].select('07')
+    first('.learning-time').all('.learning-time__finished-at select')[1].select('30')
+
+    click_button '提出'
+    assert_text '学習時間は不正な値です'
+    assert_no_text 'この日報はすでに提出済みです。'
+    assert_button '提出'
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7537

## 概要
WIP状態の日報を提出する際に入力内容にエラーがある場合、DB上はWIPのままであるにも関わらず、提出済み日報の編集ページが表示されてしまうバグを解消しました。

## 変更確認方法

1. `bug/incorrect-wip-report-submission-status-message`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. ユーザー名`sotugyou`でログイン
5. [/reports](http://localhost:3000/reports/)にアクセス
6. WIP状態の日報を選択し、`内容編集`ボタンをクリック
7. エラー(学習時間の不正、内容の未入力など)が発生するように編集し、`提出`ボタンをクリック
8. 次の点を確認する
   - [ ] 適切なエラーメッセージが表示されている
   - [ ] `この日報はすでに提出済みです。`というメッセージが出ない
   - [ ] `提出`ボタンが表示されている（`内容変更`ボタンがない）

## Screenshot

いずれもWIP状態の日報をエラーを含むよう編集して提出ボタンを押した際の画面。

### 変更前
![Issue#7537変更前](https://github.com/fjordllc/bootcamp/assets/125527162/d696b963-e167-4b96-bace-3b9fad0e71b0)


### 変更後

![Issue#7537変更後](https://github.com/fjordllc/bootcamp/assets/125527162/517e9407-98cf-4783-b157-54fca2defb10)
