### PR TITLE
メンターメニューの中身を追加

### DIFF
--- a/app/views/application/_mentor_menu.html.slim
+++ b/app/views/application/_mentor_menu.html.slim
@@ -7,9 +7,25 @@
         class: 'header-dropdown__item-link' do
         | メンターページ
     li.header-dropdown__item
-      = link_to new_article_path,
+      = link_to mentor_practices_path,
         class: 'header-dropdown__item-link' do
-        | ブログ記事作成
+        | プラクティス
+    li.header-dropdown__item
+      = link_to mentor_categories_path,
+        class: 'header-dropdown__item-link' do
+        | カテゴリー
+    li.header-dropdown__item
+      = link_to mentor_courses_path,
+        class: 'header-dropdown__item-link' do
+        | コース
+    li.header-dropdown__item
+      = link_to edit_buzz_path,
+        class: 'header-dropdown__item-link' do
+        | 紹介・言及記事
+    li.header-dropdown__item
+      = link_to articles_path,
+        class: 'header-dropdown__item-link' do
+        | ブログ
     - if Rails.env.development? || Rails.env.test?
       li.header-dropdown__item
         = link_to survey_questions_path,


### PR DESCRIPTION
## Issue

- #7767

## 概要
メンターページに存在するページの内、メンターメニューに無いリンクを追加しました。
具体的には以下のリンクを追加しました。
* プラクティス
* カテゴリー
* コース
* 紹介・言及記事
* ブログ

また、下記は`ブログ`と内容が重複するため削除しました。
* ブログ記事作成

## 変更確認方法

1. `chore/add-mentor-menu-contents`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でローカルサーバを立ち上げ
4. ユーザー名`mentormentaro`でログイン
5. 画面右上のユーザーアイコンをクリック
6. 表示されるリストから下記を確認する
    * [ ] `プラクティス`をクリックして[/mentor/practices](http://localhost:3000/mentor/practices)に遷移する
    * [ ] `カテゴリー`をクリックして[/mentor/categories](http://localhost:3000/mentor/categories)に遷移する
    * [ ] `コース`をクリックして[/mentor/courses](http://localhost:3000/mentor/courses)に遷移する
    * [ ] `紹介・言及記事`をクリックして[/buzz/edit](http://localhost:3000/buzz/edit)に遷移する
    * [ ] `ブログ`をクリックして[/articles](http://localhost:3000/articles)に遷移する

## Screenshot
いずれもユーザーアイコンをクリックして表示されるリストです。
変更後はメンターメニューにリンクが追加されています。

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/117491666/2d717c1b-ad05-43ff-af23-b2f3ac46c8a7)

### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/117491666/90240b85-d077-4d78-bc7b-0a8a96851a83)

