### PR TITLE
ユーザープロフィールの非公開情報の欄に「請求書払いのユーザー」の項目を実装

### DIFF
--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -65,3 +65,11 @@
           = link_to 'カード登録', user.customer_url
         - else
           | カード未登録
+    .user-metas__item
+      .user-metas__item-label
+        | 請求書払いユーザー
+      .user-metas__item-value
+        - if user.invoice_payment?
+          | はい
+        - else
+          | いいえ


### PR DESCRIPTION
## Issue

- #7513

## 概要

ユーザープロフィールの非公開情報の欄に「請求書払いユーザー」の項目を追加しました。

## 変更確認方法
### 
1. `feature/add-invoice-section-to-profile`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でローカルサーバを立ち上げ
4. `admin`権限のあるユーザー（例えば`pjord`）でログイン
5.  [/users?target=&search_word=kimura](http://localhost:3000/users?target=&search_word=kimura)にアクセス
6. `kimura`のプロフィールを開く
7. 下記を確認する
    * [ ] ユーザー非公開情報の欄に`請求書払いユーザー`項目があり、内容が`いいえ`となっている
8. `管理者として情報変更`ボタンからユーザーの編集画面を開く
9. `請求書払いユーザーである`にチェックを入れて更新する
10. 下記を確認する
    * [ ] ユーザー非公開情報の欄に`請求書払いユーザー`項目があり、内容が`はい`となっている
## Screenshot

### 変更前
<img width="251" alt="image" src="https://github.com/fjordllc/bootcamp/assets/117491666/3672b67b-6d0f-4d29-b6ba-b2bcbe1ebeb6">

### 変更後

<img width="254" alt="スクリーンショット 2024-05-20 195338" src="https://github.com/fjordllc/bootcamp/assets/117491666/46ce6e05-2596-4d65-a411-cb701cc3cf2f">

