### PR TITLE
プラクティス一覧で着手中のユーザーアイコンが縦に並んでしまう点を修正

### DIFF
--- a/app/views/courses/practices/_courses_practice.html.slim
+++ b/app/views/courses/practices/_courses_practice.html.slim
@@ -21,5 +21,5 @@
   - if practice.started_students.present?
     .a-user-icons
       .a-user-icons__items
-      - practice.started_students.each do |started_student|
-        == render 'practice_user_icon', started_student: started_student
+        - practice.started_students.each do |started_student|
+          == render 'practice_user_icon', started_student: started_student


### PR DESCRIPTION
## Issue

- #5124

## 概要
プラクティス一覧ページにてプラクティスに着手しているユーザーのアイコンが縦に並んでいる点を修正しました。
## 変更確認方法

1. `feature/courses_practices_and_courses_practice_vue_delete`をローカルに取り込む
2. http://localhost:3000/courses/829913840/practices にアクセスし、ユーザーのアイコンが横に並んでいることを確認

## Screenshot

### 変更前
![image](https://github.com/fjordllc/bootcamp/assets/88243294/3a98d9f4-45c9-466b-90dc-44b2d8630921)

### 変更後
![image](https://github.com/fjordllc/bootcamp/assets/88243294/c3c6380a-68b3-47cf-9b42-a9d9086625be)

