### PR TITLE
ブログのサムネイルが最新記事に表示されるように修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -37,9 +37,9 @@ class Article < ApplicationRecord
   paginates_per 24
   acts_as_taggable
 
-  def prepared_thumbnail_url
+  def prepared_thumbnail_url(thumbnail_size = THUMBNAIL_SIZE)
     if thumbnail.attached?
-      thumbnail.variant(resize_to_limit: THUMBNAIL_SIZE).processed.url
+      thumbnail.variant(resize_to_limit: thumbnail_size).processed.url
     else
       image_url('/ogp/blank.svg')
     end

--- a/app/views/articles/_recent_articles.html.slim
+++ b/app/views/articles/_recent_articles.html.slim
@@ -10,12 +10,14 @@
           = link_to recent_article, class: 'card-list-item__inner' do
             .card-list-item__thumbnail
               .card-list-item__thumbnail-inner
-                - if recent_article.thumbnail.attached?
-                  = image_tag recent_article.thumbnail.variant(resize_to_limit: [200, 105]).processed.url, \
+                - if recent_article.prepared_thumbnail?
+                  = image_tag recent_article.prepared_thumbnail_url([200, 105]), \
                     class: 'card-list-item__thumbnail-image', \
                     alt: "ブログ記事「#{recent_article.title}」のアイキャッチ画像"
                 - else
-                  = image_tag 'work-blank.svg', class: 'card-list-item__thumbnail-image', alt: 'ブログ記事のブランクアイキャッチ画像'
+                  = image_tag recent_article.selected_thumbnail_url, \
+                    class: 'card-list-item__thumbnail-image', \
+                    alt: "ブログ記事「#{recent_article.title}」のアイキャッチ画像"
             .card-list-item__rows
               .card-list-item__row
                 .card-list-item-title


### PR DESCRIPTION
## Issue

- #7758

## 概要
ブログにサンプルで用意されているサムネイルを設定すると、「最新記事」欄のブログのサムネイルが表示されない不具合を修正しました。

## 変更確認方法
### 
1. `fix/add-invoice-section-to-profile`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でローカルサーバを立ち上げ
4. `admin`権限のあるユーザー（例えば`pjord`）でログイン
5. [/articles/new](http://localhost:3000/articles/new)にアクセスして、下記の通りブログを作成する
    * サムネイルはサンプルから選択する
    <img width="511" alt="スクリーンショット 2024-05-26 150733" src="https://github.com/fjordllc/bootcamp/assets/117491666/e7e22269-5ed8-47a4-8bf7-efe24b9ec28d">

    * その他の項目は適当に入力する
6.  ブログ作成後に遷移した詳細ページで下記を確認する
    * [ ] 「最新記事」欄に、作成したブログのサムネイルが表示されている

## Screenshot

### 変更前
<img width="506" alt="before" src="https://github.com/fjordllc/bootcamp/assets/117491666/f142f546-b325-4f31-abe3-cca2c9f3aa25">

### 変更後
<img width="511" alt="after" src="https://github.com/fjordllc/bootcamp/assets/117491666/ca769d75-ea5c-4873-98a5-dcbe6e31056f">

