### PR TITLE
修了したプラクティスを重複して計算してしまう不具合を修正

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -29,11 +29,11 @@ module UserDecorator
   end
 
   def completed_fraction
-    "修了: #{completed_practices.size} （必須: #{completed_practices_include_progress.size}/#{practices_include_progress.size}）"
+    "修了: #{completed_practices.size} （必須: #{completed_practices_include_progress_size}/#{practices_include_progress.pluck(:id).uniq.size}）"
   end
 
   def completed_fraction_in_metas
-    "#{completed_practices.size} （必須:#{completed_practices_include_progress.size}）"
+    "#{completed_practices.size} （必須:#{completed_practices_include_progress_size}）"
   end
 
   def customer_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -488,7 +488,7 @@ class User < ApplicationRecord
   end
 
   def completed_percentage
-    completed_practices_include_progress.size.to_f / practices_include_progress.size * MAX_PERCENTAGE
+    completed_practices_include_progress_size.to_f / practices_include_progress.pluck(:id).uniq.size * MAX_PERCENTAGE
   end
 
   def completed_practices_size_by_category
@@ -504,9 +504,9 @@ class User < ApplicationRecord
       .count('DISTINCT practices.id')
   end
 
-  def completed_practices_include_progress
+  def completed_practices_include_progress_size
     practices_include_progress.joins(:learnings)
-                              .merge(Learning.complete.where(user_id: id))
+                              .merge(Learning.complete.where(user_id: id)).pluck(:id).uniq.size
   end
 
   def active?

--- a/db/fixtures/categories.yml
+++ b/db/fixtures/categories.yml
@@ -107,3 +107,8 @@ category22:
   name: "就職活動"
   slug: "job-hunting"
   description: "就職に向けての準備に入ります。"
+
+category23:
+  name: "Ruby on Rails(Rails 6.1版)"
+  slug: "ruby-on-rails"
+  description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -324,7 +324,7 @@ categories_practice111_1:
 
 categories_practice111_2:
   practice: practice111
-  category: category22
+  category: category23
   position: 2
 
 categories_practice112_1:
@@ -334,5 +334,5 @@ categories_practice112_1:
 
 categories_practice112_2:
   practice: practice112
-  category: category22
+  category: category23
   position: 3

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -316,4 +316,23 @@ categories_practice63:
 categories_practice64:
   practice: practice64
   category: category10
+
+categories_practice111_1:
+  practice: practice111
+  category: category6
+  position: 14
+
+categories_practice111_2:
+  practice: practice111
+  category: category22
+  position: 2
+
+categories_practice112_1:
+  practice: practice112
+  category: category6
+  position: 15
+
+categories_practice112_2:
+  practice: practice112
+  category: category22
   position: 3

--- a/db/fixtures/courses_categories.yml
+++ b/db/fixtures/courses_categories.yml
@@ -127,3 +127,8 @@ courses_category26:
   course: course4
   category: category10
   position: 18
+
+courses_category27:
+  course: course1
+  category: category23
+  position: 19

--- a/db/fixtures/learnings.yml
+++ b/db/fixtures/learnings.yml
@@ -120,12 +120,24 @@ learning<%= i + 18 %>:
 
 learning23:
   user: harikirio
-  practice: practice1
+  practice: practice5
   status: "complete"
   completion_message_displayed: false
 
 learning24:
   user: harikirio
   practice: practice61
+  status: "complete"
+  completion_message_displayed: false
+
+learning25:
+  user: harikirio
+  practice: practice62
+  status: "complete"
+  completion_message_displayed: false
+
+learning26:
+  user: harikirio
+  practice: practice63
   status: "complete"
   completion_message_displayed: false

--- a/db/fixtures/learnings.yml
+++ b/db/fixtures/learnings.yml
@@ -132,12 +132,12 @@ learning24:
 
 learning25:
   user: harikirio
-  practice: practice62
+  practice: practice111
   status: "complete"
   completion_message_displayed: false
 
 learning26:
   user: harikirio
-  practice: practice63
+  practice: practice112
   status: "complete"
   completion_message_displayed: false

--- a/db/fixtures/practices.yml
+++ b/db/fixtures/practices.yml
@@ -733,4 +733,19 @@ practice110:
   summary: "概要です"
   description: "概要欄(概要文＆OGP画像)を表示します"
   goal: "goal..."
+
+practice111:
+  title: "複数カテゴリに所属するプラクティス1"
+  summary: "概要です"
+  description: "複数のカテゴリに所属しているプラクティスです(必修ではありません)"
+  goal: "goal..."
+  include_progress: false
+  memo: "memo for mentors..."
+
+practice112:
+  title: "複数カテゴリに所属するプラクティス2"
+  summary: "概要です"
+  description: "複数のカテゴリに所属しているプラクティスです(必修です)"
+  goal: "goal..."
+  include_progress: true
   memo: "memo for mentors..."

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -73,34 +73,34 @@ class UserDecoratorTest < ActiveDecoratorTestCase
 
   test '#completed_fraction don\'t calculate practice that include_progress: false' do
     user = @admin_mentor_user
-    old_fraction = user.completed_practices_include_progress.size
+    old_fraction = user.completed_practices_include_progress_size
     user.completed_practices << practices(:practice5)
 
     assert_not_equal old_fraction, user.completed_fraction
 
-    old_fraction = user.completed_practices_include_progress.size
+    old_fraction = user.completed_practices_include_progress_size
     user.completed_practices << practices(:practice53)
 
-    assert_equal old_fraction, user.completed_practices_include_progress.size
+    assert_equal old_fraction, user.completed_practices_include_progress_size
   end
 
   test '#completed_fraction don\'t calculate practice unrelated cource' do
-    old_fraction = @admin_mentor_user.completed_practices_include_progress.size
+    old_fraction = @admin_mentor_user.completed_practices_include_progress_size
     @admin_mentor_user.completed_practices << practices(:practice5)
 
-    assert_not_equal old_fraction, @admin_mentor_user.completed_practices_include_progress.size
+    assert_not_equal old_fraction, @admin_mentor_user.completed_practices_include_progress_size
 
-    old_fraction = @admin_mentor_user.completed_practices_include_progress.size
+    old_fraction = @admin_mentor_user.completed_practices_include_progress_size
     @admin_mentor_user.completed_practices << practices(:practice55)
 
-    assert_equal old_fraction, @admin_mentor_user.completed_practices_include_progress.size
+    assert_equal old_fraction, @admin_mentor_user.completed_practices_include_progress_size
   end
 
   test '#completed_fraction_in_metas' do
     fraction_in_metas = '2 （必須:1）'
+    @non_required_subject_completed_user.completed_practices = []
     @non_required_subject_completed_user.completed_practices << practices(:practice5)
     @non_required_subject_completed_user.completed_practices << practices(:practice61)
-
     assert_equal fraction_in_metas, @non_required_subject_completed_user.completed_fraction_in_metas
   end
 end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -102,3 +102,13 @@ category21:
   name: "ゲームのテスト"
   slug: "game-test"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
+
+category22:
+  name: "就職活動"
+  slug: "job-hunting"
+  description: "就職に向けての準備に入ります。"
+
+category23:
+  name: "Ruby on Rails(Rails 6.1版)"
+  slug: "ruby-on-rails"
+  description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"

--- a/test/fixtures/categories_practices.yml
+++ b/test/fixtures/categories_practices.yml
@@ -282,3 +282,28 @@ categories_practice57:
   practice: practice57
   category: category2
   position: 3
+
+categories_practice61:
+  practice: practice61
+  category: category22
+  position: 1
+
+categories_practice62_1:
+  practice: practice62
+  category: category6
+  position: 14
+
+categories_practice62_2:
+  practice: practice62
+  category: category23
+  position: 1
+
+categories_practice63_1:
+  practice: practice63
+  category: category6
+  position: 15
+
+categories_practice63_2:
+  practice: practice63
+  category: category23
+  position: 2

--- a/test/fixtures/courses_categories.yml
+++ b/test/fixtures/courses_categories.yml
@@ -117,3 +117,13 @@ courses_category24:
   course: course3
   category: category15
   position: 3
+
+courses_category25:
+  course: course1
+  category: category22
+  position: 17
+
+courses_category26:
+  course: course1
+  category: category23
+  position: 18

--- a/test/fixtures/learnings.yml
+++ b/test/fixtures/learnings.yml
@@ -117,3 +117,28 @@ learning<%= i + 18 %>:
   created_at: <%= (today - (2.weeks - 1.day) - i.day).to_formatted_s(:db) %>
   updated_at: <%= (today - (2.weeks - 1.day) - i.day).to_formatted_s(:db) %>
 <% end %>
+
+
+learning23:
+  user: harikirio
+  practice: practice5
+  status: "complete"
+  completion_message_displayed: false
+
+learning24:
+  user: harikirio
+  practice: practice61
+  status: "complete"
+  completion_message_displayed: false
+
+learning25:
+  user: harikirio
+  practice: practice62
+  status: "complete"
+  completion_message_displayed: false
+
+learning26:
+  user: harikirio
+  practice: practice63
+  status: "complete"
+  completion_message_displayed: false

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -374,3 +374,19 @@ practice61:
   goal: "goal..."
   include_progress: false
   memo: "memo for mentors..."
+
+practice62:
+  title: "複数カテゴリに所属するプラクティス1"
+  summary: "概要です"
+  description: "複数のカテゴリに所属しているプラクティスです(必修ではありません)"
+  goal: "goal..."
+  include_progress: false
+  memo: "memo for mentors..."
+
+practice63:
+  title: "複数カテゴリに所属するプラクティス2"
+  summary: "概要です"
+  description: "複数のカテゴリに所属しているプラクティスです(必修です)"
+  goal: "goal..."
+  include_progress: true
+  memo: "memo for mentors..."

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -74,28 +74,28 @@ class UserTest < ActiveSupport::TestCase
 
   test '#completed_percentage don\'t calculate practice that include_progress: false' do
     user = users(:komagata)
-    old_percentage = user.completed_practices_include_progress.size
+    old_percentage = user.completed_percentage
     user.completed_practices << practices(:practice5)
 
-    assert_not_equal old_percentage, user.completed_practices_include_progress.size
+    assert_not_equal old_percentage, user.completed_percentage
 
-    old_percentage = user.completed_practices_include_progress.size
+    old_percentage = user.completed_percentage
     user.completed_practices << practices(:practice53)
 
-    assert_equal old_percentage, user.completed_practices_include_progress.size
+    assert_equal old_percentage, user.completed_percentage
   end
 
   test '#completed_percentage don\'t calculate practice unrelated cource' do
     user = users(:komagata)
-    old_percentage = user.completed_practices_include_progress.size
+    old_percentage = user.completed_percentage
     user.completed_practices << practices(:practice5)
 
-    assert_not_equal old_percentage, user.completed_practices_include_progress.size
+    assert_not_equal old_percentage, user.completed_percentage
 
-    old_percentage = user.completed_practices_include_progress.size
+    old_percentage = user.completed_percentage
     user.completed_practices << practices(:practice55)
 
-    assert_equal old_percentage, user.completed_practices_include_progress.size
+    assert_equal old_percentage, user.completed_percentage
   end
 
   test '#depressed?' do

--- a/test/system/mentor/categories/practices_test.rb
+++ b/test/system/mentor/categories/practices_test.rb
@@ -19,7 +19,6 @@ class Mentor::Categories::PracticesTest < ApplicationSystemTestCase
     visit_with_auth course_practices_path(courses(:course1)), 'kimura'
     assert_equal all('span.category-practices-item__title-link-label')[0].text, practices(:practice1).title
     assert_equal all('span.category-practices-item__title-link-label')[1].text, practices(:practice3).title
-
     visit_with_auth mentor_category_practices_path(categories(:category2)), 'komagata'
     source = all('.js-grab')[0] # practice1
     target = all('.js-grab')[2] # practice3

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -114,9 +114,9 @@ class ReportsTest < ApplicationSystemTestCase
     report_practices = page.all('.choices__item--choice').map(&:text)
     current_user = users(:komagata)
     category_ids = current_user.course.category_ids
-    assert_equal report_practices.count, Practice.joins(:categories).merge(Category.where(id: category_ids)).count
+    assert_equal report_practices.count, Practice.joins(:categories).merge(Category.where(id: category_ids)).distinct.count
     assert_match(/OS X Mountain Lionをクリーンインストールする/, first('.choices__item--choice').text)
-    assert_match(/sslの基礎を理解する/, all('.choices__item--choice').last.text)
+    assert_match(/企業研究/, all('.choices__item--choice').last.text)
   end
 
   test 'equal practices order in practices and edit report' do
@@ -125,9 +125,9 @@ class ReportsTest < ApplicationSystemTestCase
     report_practices = page.all('.choices__item--choice').map(&:text)
     current_user = users(:komagata)
     category_ids = current_user.course.category_ids
-    assert_equal report_practices.count, Practice.joins(:categories).merge(Category.where(id: category_ids)).count
+    assert_equal report_practices.count, Practice.joins(:categories).merge(Category.where(id: category_ids)).distinct.count
     assert_match(/OS X Mountain Lionをクリーンインストールする/, first('.choices__item--choice').text)
-    assert_match(/sslの基礎を理解する/, all('.choices__item--choice').last.text)
+    assert_match(/企業研究/, all('.choices__item--choice').last.text)
   end
 
   test 'issue #360 duplicate' do

--- a/test/system/user/meta_data_test.rb
+++ b/test/system/user/meta_data_test.rb
@@ -5,11 +5,13 @@ require 'application_system_test_case'
 class User::MetaDataTest < ApplicationSystemTestCase
   test 'show progress percentage and click to check the number of completions' do
     user = users(:harikirio)
-    user.completed_practices << practices(:practice5)
+    user.completed_practices = []
     user.completed_practices << practices(:practice61)
+    user.completed_practices << practices(:practice62)
+    user.completed_practices << practices(:practice63)
     visit_with_auth "/users/#{users(:harikirio).id}", 'harikirio'
     assert_text '1%'
     find('.completed-practices-progress__percentage').click
-    assert_text '修了: 2 （必須: 1/51）'
+    assert_text '修了: 3 （必須: 1/52）'
   end
 end


### PR DESCRIPTION
## Issue

-  #7804

## 概要

以前 #7635 のIssueを解消するため下記のPRを作成しました。
https://github.com/fjordllc/bootcamp/pull/7699
その後本番環境に反映されましたが、修了した数が正しい状態になりませんでした。



それを解消するPRです。

## 変更確認方法

1. `bug/mismatch_complete_practice_size`をローカルに取り込む
2. bootcamp を起動
3. 任意のアカウントでログイン
4. 複数のカテゴリに所属するプラクティスを修了しているユーザー（harikirio)のページへログイン
(`http://localhost:3000/users/527754862`)
5. 修了プラクティス が「4 （必須:2）」 修了したプラクティスが「3% 」→ 「修了: 4 （必須: 2/56）」となるのを確認

### プラクティスの説明

- Linuxのファイル操作の基礎を覚える: 必修
- 企業研究　:必修ではない
- 複数カテゴリに所属するプラクティス1 : 必修ではない
- 複数カテゴリに所属するプラクティス2: 必修

## Screenshot

### 変更前

### 変更後

<img width="999" alt="スクリーンショット 2024-05-31 6 18 42" src="https://github.com/fjordllc/bootcamp/assets/8443743/4a09a961-6f5f-471b-a288-31610357dadf">


