### PR TITLE
プラクティス個別ページ配下のDocsが0の場合に泣き顔を表示するようにした

### DIFF
--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -136,9 +136,18 @@ const NoReports = ({ unchecked }) => {
             </p>
           </>
         ) : (
-          <div className="o-empty-message">
-            <div className="o-empty-message__icon">
-              <i className="fa-regular fa-sad-tear" />
+          <div className="card-list">
+            <div className="card-body">
+              <div className="card__description">
+                <div className="o-empty-message">
+                  <div className="o-empty-message__icon">
+                    <i className="fa-regular fa-sad-tear" />
+                  </div>
+                  <p className="o-empty-message__text">
+                    日報はまだありません。
+                  </p>
+                </div>
+              </div>
             </div>
             <p className="o-empty-message__text">日報はまだありません。</p>
           </div>

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -149,7 +149,6 @@ const NoReports = ({ unchecked }) => {
                 </div>
               </div>
             </div>
-            <p className="o-empty-message__text">日報はまだありません。</p>
           </div>
         )}
       </div>

--- a/app/javascript/components/questions.vue
+++ b/app/javascript/components/questions.vue
@@ -6,7 +6,7 @@ div
     loadingListPlaceholder
   .o-empty-message(v-else-if='questions.length === 0')
     .o-empty-message__icon
-      i.fa-regular.fa-smile
+      i.fa-regular.fa-sad-tear
     p.o-empty-message__text
       | {{ emptyMessage }}
   .card-list.a-card(v-else)

--- a/app/views/application/_page_tab.html.slim
+++ b/app/views/application/_page_tab.html.slim
@@ -1,13 +1,13 @@
 li.page-tabs__item
   - case tab[:display_name]
   - when '質問'
-    = link_to tab[:path], class: "page-tabs__item-link #{current_page_tab_or_not(tab[:target_name])} #{@practice.questions.empty? ? 'is-inactive' : ''}" do
+    = link_to tab[:path], class: "page-tabs__item-link #{current_page_tab_or_not(tab[:target_name])}" do
       = tab[:display_name] + " （#{@practice.questions.length}）"
   - when 'Docs'
-    = link_to tab[:path], class: "page-tabs__item-link #{current_page_tab_or_not(tab[:target_name])} #{@practice.pages.empty? ? 'is-inactive' : ''}" do
+    = link_to tab[:path], class: "page-tabs__item-link #{current_page_tab_or_not(tab[:target_name])}" do
       = tab[:display_name] + " （#{@practice.pages.length}）"
   - when '日報'
-    = link_to tab[:path], class: "page-tabs__item-link #{current_page_tab_or_not(tab[:target_name])} #{@practice.reports.empty? ? 'is-inactive' : ''}" do
+    = link_to tab[:path], class: "page-tabs__item-link #{current_page_tab_or_not(tab[:target_name])}" do
       = tab[:display_name] + " （#{@practice.reports.length}）"
   - else
     = link_to tab[:path], class: "page-tabs__item-link #{current_page_tab_or_not(tab[:target_name])}" do

--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -11,7 +11,7 @@
     - if @pages.empty?
       .o-empty-message
         .o-empty-message__icon
-          i.fa-regular.fa-smile
+          i.fa-regular.fa-sad-tear
         p.o-empty-message__text
           | Docはまだありません
     - else


### PR DESCRIPTION
## Issue

- #3393 

## 概要
- プラクティス個別ページ配下のDocsが0件の場合の表示を泣き顔マークに変更しました。
- プラクティス個別ページ配下の「日報」、「質問」、「Docs」の各タブは0件の場合クリックができない仕様でしたが、クリックできるように変更しました。
- 「質問」のみ、0件の場合に表示されるのが笑顔マークとなっていたため、泣き顔マークへ変更し「日報」、「Docs」が0件だった場合の表示と統一しました。
- 「日報」のみ、0件の場合に表示されるメッセージの背景が他と異なり白背景が表示されていたため、何も表示しないように変更しました。

「Docsページへの泣き顔マーク追加」以外の変更点については#3393 のページにて相談のうえ実施したものになりますので、そちらのやりとりもご参照ください。
## 変更確認方法

1. `feature/display-sad-mark-on-a-docs-page-in-an-individual-practice-page-when-no-docs`をローカルに取り込む。
2. http://localhost:3000/practices へアクセスし、任意のプラクティス個別ページにアクセスする。（日報、質問、Docsが0件のものであればどのプラクティスでも大丈夫です。）
3. Docsタブをクリックし、泣き顔マークが表示されていることを確認する。
4. 0件の場合でも日報、質問、Docsの各タブをクリックできることを確認する。
5. 日報のページで泣き顔マークの背景が白背景ではないことを確認する。

## Screenshot

### 【Docs】
#### 変更前
<img width="1055" alt="image" src="https://github.com/fjordllc/bootcamp/assets/66000707/336b6726-05c6-44d6-8312-9152def36db7">

#### 変更後
<img width="1065" alt="image" src="https://github.com/fjordllc/bootcamp/assets/66000707/ab380b00-0ae6-49c4-9fa1-6c1efcc67d68">

### 【日報】
#### 変更前
<img width="1181" alt="日報" src="https://github.com/fjordllc/bootcamp/assets/66000707/f3b8467f-1664-4e17-a5aa-5c2e972957e6">

### 変更後
<img width="1049" alt="image" src="https://github.com/fjordllc/bootcamp/assets/66000707/ad3d5601-5ae5-4f18-933c-da3aae9d52c7">
