### PR TITLE
Q&Aで、メンターと管理者が「質問作成者」を変更できるようにする

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -53,7 +53,7 @@ class QuestionsController < ApplicationController
 
   def create
     @question = Question.new(question_params)
-    @question.user = current_user unless admin_login? || current_user.mentor?
+    @question.user = current_user if !admin_or_mentor_login?
     set_wip
     if @question.save
       Newspaper.publish(:question_create, { question: @question })

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -52,7 +52,8 @@ class QuestionsController < ApplicationController
   def edit; end
 
   def create
-    @question = current_user.questions.new(question_params)
+    @question = Question.new(question_params)
+    @question.user = current_user unless admin_login? || current_user.mentor?
     set_wip
     if @question.save
       Newspaper.publish(:question_create, { question: @question })

--- a/app/javascript/choices-ui.js
+++ b/app/javascript/choices-ui.js
@@ -31,6 +31,22 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
 
+  const elementsOfSingles = document.querySelectorAll('.js-choices-singles')
+  if (elementsOfSingles.length > 0) {
+    for (const element of elementsOfSingles) {
+      // eslint-disable-next-line no-new
+      new Choices(element, {
+        removeItemButton: true,
+        allowHTML: true,
+        searchResultLimit: 20,
+        searchPlaceholderValue: '検索ワード',
+        noResultsText: '一致する情報は見つかりません',
+        itemSelectText: '選択',
+        shouldSort: false
+      })
+    }
+  }
+
   const elements = document.querySelectorAll('.js-choices-added-select')
   const elementsCount = elements.length
   if (!elements) return

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -24,7 +24,6 @@ class Question < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 256 }
   validates :description, presence: true
-  validates :user, presence: true
   validates :published_at, presence: true, if: :will_be_published?
 
   scope :solved, -> { where(id: CorrectAnswer.select(:question_id)) }

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -8,12 +8,9 @@
             .form-item
               = f.label :practice, class: 'a-form-label'
               .select-practices
-                - if question.new_record?
-                  = f.select(:practice_id, practice_options_within_course, { selected: params[:practice_id], include_blank: 'プラクティス選択なし' },
-                             { class: 'js-choices-singles', id: 'js-choices-practice' })
-                - else
-                  = f.select(:practice_id, practice_options_within_course, { include_blank: 'プラクティス選択なし' },
-                             { class: 'js-choices-singles', id: 'js-choices-practice' })
+                = f.select(:practice_id, practice_options_within_course,
+                           question.new_record? ? { selected: params[:practice_id], include_blank: 'プラクティス選択なし' } : { include_blank: 'プラクティス選択なし' },
+                           { class: 'js-choices-singles', id: 'js-choices-practice' })
 
       .form-item
         .row.js-markdown-parent
@@ -59,12 +56,9 @@
               .form-item
                 = f.label :user_id, '作成者', class: 'a-form-label'
                 .select-user
-                  - if question.new_record?
-                    = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, { selected: current_user.id },
-                                          { class: 'js-choices-singles', id: 'js-choices-user' })
-                  - else
-                    = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, {},
-                                          { class: 'js-choices-singles', id: 'js-choices-user' })
+                  = f.collection_select(:user_id, User.order(:login_name), :id, :login_name,
+                                        question.new_record? ? { selected: current_user.id } : {},
+                                        { class: 'js-choices-singles', id: 'js-choices-user' })
 
   .form-actions
     ul.form-actions__items

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -52,7 +52,7 @@
             = f.label :tag_list, 'タグを入力してください', class: 'a-form-label'
             = render partial: 'tags_input', locals: { taggable: @question }
 
-      - if admin_login? || current_user.mentor?
+      - if admin_or_mentor_login?
         .form-item.is-only-mentor
           .row
             .col-md-3.col-xs-12

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -8,8 +8,9 @@
             .form-item
               = f.label :practice, class: 'a-form-label'
               .select-practices
+                - include_blank = 'プラクティス選択なし'
                 = f.select(:practice_id, practice_options_within_course,
-                           question.new_record? ? { selected: params[:practice_id], include_blank: 'プラクティス選択なし' } : { include_blank: 'プラクティス選択なし' },
+                           question.new_record? ? { selected: params[:practice_id], include_blank: } : { include_blank: },
                            { class: 'js-choices-singles', id: 'js-choices-practice' })
 
       .form-item

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -60,7 +60,7 @@
                 = f.label :user_id, '作成者', class: 'a-form-label'
                 .select-user
                   - if question.new_record?
-                    = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, { selected: current_user },
+                    = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, { selected: current_user.id },
                                           { class: 'js-choices-singles', id: 'js-choices-user' })
                   - else
                     = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, {},

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -9,9 +9,11 @@
               = f.label :practice, class: 'a-form-label'
               .select-practices
                 - if question.new_record?
-                  = f.select(:practice_id, practice_options_within_course, { selected: params[:practice_id], include_blank: 'プラクティス選択なし' }, { id: 'js-choices-single-select' })
+                  = f.select(:practice_id, practice_options_within_course, { selected: params[:practice_id], include_blank: 'プラクティス選択なし' },
+                             { class: 'js-choices-singles', id: 'js-choices-practice' })
                 - else
-                  = f.select(:practice_id, practice_options_within_course, { include_blank: 'プラクティス選択なし' }, { id: 'js-choices-single-select' })
+                  = f.select(:practice_id, practice_options_within_course, { include_blank: 'プラクティス選択なし' },
+                             { class: 'js-choices-singles', id: 'js-choices-practice' })
 
       .form-item
         .row.js-markdown-parent
@@ -49,6 +51,21 @@
           .col-md-6.col-xs-12
             = f.label :tag_list, 'タグを入力してください', class: 'a-form-label'
             = render partial: 'tags_input', locals: { taggable: @question }
+
+      - if admin_login? || current_user.mentor?
+        .form-item
+          .row
+            .col-md-6.col-xs-12
+              .form-item
+                = f.label :user_id, 'Question作成者変更', class: 'a-form-label'
+                .select-user
+                  - if question.new_record?
+                    = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, { selected: current_user },
+                                          { class: 'js-choices-singles', id: 'js-choices-user' })
+                  - else
+                    = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, {},
+                                          { class: 'js-choices-singles', id: 'js-choices-user' })
+
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -9,9 +9,11 @@
               = f.label :practice, class: 'a-form-label'
               .select-practices
                 - include_blank = 'プラクティス選択なし'
-                = f.select(:practice_id, practice_options_within_course,
-                           question.new_record? ? { selected: params[:practice_id], include_blank: } : { include_blank: },
-                           { class: 'js-choices-singles', id: 'js-choices-practice' })
+                - options = question.new_record? ? { selected: params[:practice_id], include_blank: } : { include_blank: }
+                = f.select :practice_id,
+                  practice_options_within_course,
+                  options,
+                  { class: 'js-choices-singles', id: 'js-choices-practice' }
 
       .form-item
         .row.js-markdown-parent
@@ -57,9 +59,13 @@
               .form-item
                 = f.label :user_id, '作成者', class: 'a-form-label'
                 .select-user
-                  = f.collection_select(:user_id, User.order(:login_name), :id, :login_name,
-                                        question.new_record? ? { selected: current_user.id } : {},
-                                        { class: 'js-choices-singles', id: 'js-choices-user' })
+                  - options = question.new_record? ? { selected: current_user.id } : {}
+                  = f.collection_select :user_id,
+                    User.order(:login_name),
+                    :id,
+                    :login_name,
+                    options,
+                    { class: 'js-choices-singles', id: 'js-choices-user' }
 
   .form-actions
     ul.form-actions__items

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -53,11 +53,11 @@
             = render partial: 'tags_input', locals: { taggable: @question }
 
       - if admin_login? || current_user.mentor?
-        .form-item
+        .form-item.is-only-mentor
           .row
-            .col-md-6.col-xs-12
+            .col-md-3.col-xs-12
               .form-item
-                = f.label :user_id, 'Question作成者変更', class: 'a-form-label'
+                = f.label :user_id, '質問作成者', class: 'a-form-label'
                 .select-user
                   - if question.new_record?
                     = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, { selected: current_user },

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -57,7 +57,7 @@
           .row
             .col-md-3.col-xs-12
               .form-item
-                = f.label :user_id, '質問作成者', class: 'a-form-label'
+                = f.label :user_id, '作成者', class: 'a-form-label'
                 .select-user
                   - if question.new_record?
                     = f.collection_select(:user_id, User.order(:login_name), :id, :login_name, { selected: current_user },

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -65,13 +65,14 @@ class QuestionsTest < ApplicationSystemTestCase
     visit_with_auth question_path(question), 'kimura'
 
     click_link '内容修正'
-    within 'form[name=question]' do
-      fill_in 'question[title]', with: 'テストの質問（修正）'
-      fill_in 'question[description]', with: 'テストの質問です。（修正）'
+    fill_in 'question[title]', with: 'テストの質問（修正）'
+    fill_in 'question[description]', with: 'テストの質問です。（修正）'
+    within '.select-practices' do
       find('.choices__inner').click
-      find('#choices--js-choices-single-select-item-choice-12', text: 'sshdでパスワード認証を禁止にする').click
-      click_button '更新する'
+      find('#choices--js-choices-practice-item-choice-12', text: 'sshdでパスワード認証を禁止にする').click
     end
+    click_button '更新する'
+
     assert_text 'テストの質問（修正）'
     assert_text 'テストの質問です。（修正）'
     assert_selector 'a.a-category-link', text: 'sshdでパスワード認証を禁止にする'
@@ -423,8 +424,10 @@ class QuestionsTest < ApplicationSystemTestCase
     visit_with_auth new_question_path, 'kimura'
     fill_in 'question[title]', with: 'Questionに関連プラクティスを指定'
     fill_in 'question[description]', with: 'Questionに関連プラクティスを指定'
-    find('.choices__inner').click
-    find('#choices--js-choices-single-select-item-choice-7', text: 'Linuxのファイル操作の基礎を覚える').click
+    within '.select-practices' do
+      find('.choices__inner').click
+      find('#choices--js-choices-practice-item-choice-7', text: 'Linuxのファイル操作の基礎を覚える').click
+    end
     click_button '登録する'
     assert_text 'Questionに関連プラクティスを指定'
 
@@ -503,5 +506,34 @@ class QuestionsTest < ApplicationSystemTestCase
       assert_selector 'input.file-input', visible: false
     end
     assert_equal '.file-input', find('textarea.a-text-input')['data-input']
+  end
+
+  test 'The Change Questioner form is not visible to general users' do
+    visit_with_auth new_question_path, 'hatsuno'
+    assert_no_selector('.select-user')
+  end
+
+  test 'admin can change the questioner when creating a new question' do
+    visit_with_auth new_question_path, 'adminonly'
+    fill_in 'question[title]', with: 'テストの質問'
+    fill_in 'question[description]', with: 'テストの質問です。'
+    within '.select-user' do
+      find('.choices__inner').click
+      find('#choices--js-choices-user-item-choice-11', text: 'hatsuno').click
+    end
+    click_button '登録する'
+    assert_selector '.a-user-name', text: 'hatsuno (ハツノ シンジ)'
+  end
+
+  test 'mentor can change the questioner when editing a question' do
+    question = questions(:question8)
+    visit_with_auth question_path(question), 'mentormentaro'
+    click_link '内容修正'
+    within '.select-user' do
+      find('.choices__inner').click
+      find('#choices--js-choices-user-item-choice-11', text: 'hatsuno').click
+    end
+    click_button '更新する'
+    assert_selector '.a-user-name', text: 'hatsuno (ハツノ シンジ)'
   end
 end

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -519,7 +519,7 @@ class QuestionsTest < ApplicationSystemTestCase
     fill_in 'question[description]', with: 'テストの質問です。'
     within '.select-user' do
       find('.choices__inner').click
-      find('#choices--js-choices-user-item-choice-11', text: 'hatsuno').click
+      find('#choices--js-choices-user-item-choice-12', text: 'hatsuno').click
     end
     click_button '登録する'
     assert_selector '.a-user-name', text: 'hatsuno (ハツノ シンジ)'
@@ -531,7 +531,7 @@ class QuestionsTest < ApplicationSystemTestCase
     click_link '内容修正'
     within '.select-user' do
       find('.choices__inner').click
-      find('#choices--js-choices-user-item-choice-11', text: 'hatsuno').click
+      find('#choices--js-choices-user-item-choice-12', text: 'hatsuno').click
     end
     click_button '更新する'
     assert_selector '.a-user-name', text: 'hatsuno (ハツノ シンジ)'

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -508,7 +508,7 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
 
-  test 'The Change Questioner form is not visible to general users' do
+  test 'users except for admin or mentor cannot change the questioner' do
     visit_with_auth new_question_path, 'hatsuno'
     assert_no_selector('.select-user')
   end


### PR DESCRIPTION
## Issue

- #7632 

## 概要

- Q&Aの「質問の編集画面」で、質問者を指定できる欄を追加した
  （メンターと管理者だけの機能。他のユーザーには表示されない）

## 変更確認方法

1. `feature/questioner-can-be-changed-by-mentor-or-admin` をローカルに取り込む
2. 機能の表示と動作の確認
   1. 「メンター」または「管理者」でログインする
   1. 「[\(development\) 未解決のQ&A \| FBC](http://localhost:3000/questions?target=not_solved). 
（`http://localhost:3000/questions?target=not_solved`）」にアクセスする
   1. 「`＋ 質問する`ボタン」または「既存の質問」をクリックし、編集画面に移動する
   1. 入力画面に「作成者」欄が在ることを確認する（位置は、下記「Screenshot」を参照）
   1. 「作成者」欄で、質問者名を「選択」または「入力」する
   （新規作成の場合は、「タイトル」と「質問文」の入力が必要）
   1. 登録・更新する。（ボタンは以下のどれかが表示される）
      - `登録する`：新規作成の場合
      - `質問を公開`：`WIP`ボタンで途中保存した質問の場合
      - `更新する`：既に公開されている質問を編集した場合
   1. 「個別の質問の画面」または「一覧の画面」で、指定した「質問者」が質問タイトル下に表示されていることを確認する
3. 一般ユーザーで非表示になる確認
   1. 一般ユーザー（「メンター」「管理者」以外）でログインする
   1. 上記「ⅱ、ⅲ」を行う
   1. 入力画面に「作成者」欄が無いことを確認する

## Screenshot

### 変更前（質問の編集画面）

![image](https://github.com/fjordllc/bootcamp/assets/85104698/bc2645d1-05cc-4c9b-a480-b413aa398bff)

### 変更後（質問の編集画面）

![image](https://github.com/fjordllc/bootcamp/assets/85104698/5167ed99-af4e-4be3-b57c-a23a6b3e0bd0)
