### PR TITLE
ポートフォリオページのtitleタグ内のユーザー名に'さん'をつけるように修正

### DIFF
--- a/app/views/users/works/index.html.slim
+++ b/app/views/users/works/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}のポートフォリオ"
+- title "#{@user.login_name}さんのポートフォリオ"
 - set_meta_tags description: "#{@user.login_name}さんのポートフォリオページです。"
 
 header.page-header

--- a/test/system/user/works_test.rb
+++ b/test/system/user/works_test.rb
@@ -5,6 +5,6 @@ require 'application_system_test_case'
 class User::WorksTest < ApplicationSystemTestCase
   test 'show portfolio' do
     visit_with_auth "/users/#{users(:hatsuno).id}/portfolio", 'hatsuno'
-    assert_equal 'hatsunoのポートフォリオ | FBC', title
+    assert_equal 'hatsunoさんのポートフォリオ | FBC', title
   end
 end


### PR DESCRIPTION
## Issue

- #7826 

## 概要

ユーザーのポートフォリオページのtitleタグ内において、ユーザー名に「さん」をつけるように修正しました。

- 修正前
titleタグ：`{ユーザー名}のポートフォリオ | FBC`
og:title：`{ユーザー名}のポートフォリオ`
- 修正後
titleタグ：`{ユーザー名}さんのポートフォリオ | FBC`
og:title：`{ユーザー名}さんのポートフォリオ`

この修正に伴いタブのタイトル表示も同様に修正されます。

## 変更確認方法

1. `feature/correct-text-in-title-tag-of-portfolio-page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる。
3. 任意のユーザーでログインする
4. マイプロフィールページを開く
5. ポートフォリオタブをクリックする
6. 以下3点を確認する
- `<head>`タグ内 の `<title>`タグ内が、`(development) {ユーザー名}さんのポートフォリオ | FBC`になっていること
- `<head>`タグ内の`"og:title"`プロパティのcontentが`{ユーザー名}さんのポートフォリオ`になっていること
- ブラウザのタブ名が`(development) {ユーザー名}さんのポートフォリオ | FBC`になっていること
ブラウザのタブにカーソルを乗せるとタイトルが表示されます。

## Screenshot

### 変更前
<img src="https://github.com/fjordllc/bootcamp/assets/104712009/c784a17a-a095-4d9c-82f1-66337bb0b1d6" width="50%">

### 変更後
<img src="https://github.com/fjordllc/bootcamp/assets/104712009/4ec76b6b-744d-4efe-8195-f599507d8363" width="50%">

