### PR TITLE
ユーザーのプロフィールページのtitleタグ内が、「{ユーザー名}さんのプロフィール」になるように修正

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,4 @@
-- title @user.login_name
+- title "#{@user.login_name}さんのプロフィール"
 - set_meta_tags description: "#{@user.login_name}さんのプロフィールページ"
 
 = render 'users/page_title', user: @user

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -11,7 +11,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'show profile' do
     visit_with_auth "/users/#{users(:hatsuno).id}", 'hatsuno'
-    assert_equal 'hatsuno | FBC', title
+    assert_equal 'hatsunoさんのプロフィール | FBC', title
   end
 
   test 'autolink profile when url is included' do


### PR DESCRIPTION
## Issue

- #7825 

## 概要

ユーザーのプロフィールページのtitleタグ内が、「{ユーザー名}さんのプロフィール」になるように修正しました。

- 修正前
titleタグ：`{ユーザー名} | FBC`
og:title：`{ユーザー名}`
- 修正後
titleタグ：`{ユーザー名}さんのプロフィール | FBC`
og:title：`{ユーザー名}さんのプロフィール`

この修正に伴いタブのタイトル表示も同様に修正されます。

## 変更確認方法

1. `feature/correct-text-in-title-tag-of-user-profile-page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. 任意のユーザーでログインする
4. 自分以外のユーザーのプロフィールページを開く
5. 以下3点を確認する
- `<head>`タグ内 の `<title>`タグ内が、`(development) {ユーザー名}さんのプロフィール | FBC`になっていること
- `<head>`タグ内の`"og:title"`プロパティのcontentが`{ユーザー名}さんのプロフィール`になっていること
- ブラウザのタブ名が`(development) {ユーザー名}さんのプロフィール | FBC`になっていること
ブラウザのタブにカーソルを乗せるとタイトルが表示されます。

## Screenshot

### 変更前

<img src="https://github.com/fjordllc/bootcamp/assets/104712009/904da24d-9ba9-4e31-9d1a-f78724c5fa69" width="50%">

### 変更後

<img src="https://github.com/fjordllc/bootcamp/assets/104712009/03e9ccb3-6790-4429-8ac5-50a5304a9fee" width="50%">

