### PR TITLE
ブログのX共有時にタイトルが表示されるように修正

### DIFF
--- a/app/views/articles/_share_button_facebook.html.erb
+++ b/app/views/articles/_share_button_facebook.html.erb
@@ -1,8 +1,8 @@
 <div id="fb-root"></div>
 <script async defer crossorigin="anonymous" src="https://connect.facebook.net/ja_JP/sdk.js#xfbml=1&version=v18.0" nonce="eqECzFUd"></script>
-<div class="fb-share-button" data-href="https://bootcamp.fjord.jp/articles/<%= article %>" data-layout="box_count" data-size="small">
+<div class="fb-share-button" data-href="https://bootcamp.fjord.jp/articles/<%= article_id %>" data-layout="box_count" data-size="small">
   <a class="fb-xfbml-parse-ignore"
-    href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fbootcamp.fjord.jp%2Farticles%2F<%= article %>&amp;src=sdkpreparse"
+    href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fbootcamp.fjord.jp%2Farticles%2F<%= article_id %>&amp;src=sdkpreparse"
     rel="noopener noreferrer"
     target="_blank">シェアする</a>
 </div>

--- a/app/views/articles/_share_button_hatena.html.erb
+++ b/app/views/articles/_share_button_hatena.html.erb
@@ -1,5 +1,5 @@
 <a class="hatena-bookmark-button"
-  href="https://b.hatena.ne.jp/entry/s/bootcamp.fjord.jp/articles/<%= article %>"
+  href="https://b.hatena.ne.jp/entry/s/bootcamp.fjord.jp/articles/<%= article_id %>"
   data-hatena-bookmark-layout="vertical-normal"
   data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加">
   <img src="https://b.st-hatena.com/images/v4/public/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" />

--- a/app/views/articles/_share_button_x.html.erb
+++ b/app/views/articles/_share_button_x.html.erb
@@ -1,5 +1,5 @@
 <a class="x-share-button"
-  href="https://twitter.com/intent/tweet?url=https://bootcamp.fjord.jp/articles/<%= article %>&hashtags=fjordbootcamp"
+  href="https://twitter.com/intent/tweet?url=https://bootcamp.fjord.jp/articles/<%= article.id %>&hashtags=fjordbootcamp&text=<%= truncate(article.title, length: 100) %>%0a"
   data-size="large"
   rel="noopener noreferrer"
   target="_blank">

--- a/app/views/articles/_share_buttons.html.slim
+++ b/app/views/articles/_share_buttons.html.slim
@@ -3,6 +3,6 @@
     li.share-buttons__item.is-x
       = render 'share_button_x', article: article
     li.share-buttons__item
-      = render 'share_button_facebook', article: article.id
+      = render 'share_button_facebook', article_id: article.id
     li.share-buttons__item
-      = render 'share_button_hatena', article: article.id
+      = render 'share_button_hatena', article_id: article.id

--- a/app/views/articles/_share_buttons.html.slim
+++ b/app/views/articles/_share_buttons.html.slim
@@ -3,6 +3,6 @@
     li.share-buttons__item.is-x
       = render 'share_button_x', article: article
     li.share-buttons__item
-      = render 'share_button_facebook', article: article
+      = render 'share_button_facebook', article: article.id
     li.share-buttons__item
-      = render 'share_button_hatena', article: article
+      = render 'share_button_hatena', article: article.id

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -46,7 +46,7 @@ ruby:
                         = l(@article.created_at)
                       - else
                         = l(@article.published_at)
-                = render 'share_buttons', article: @article.id
+                = render 'share_buttons', article: @article
                 - if @article.display_thumbnail_in_body?
                   - if @article.prepared_thumbnail?
                     = image_tag @article.prepared_thumbnail_url, class: 'article__image'
@@ -55,7 +55,7 @@ ruby:
               .article__body
                 .js-markdown-view.a-long-text.is-md
                   = @article.body
-                = render 'share_buttons', article: @article.id
+                = render 'share_buttons', article: @article
             - if admin_or_mentor_login?
               hr.a-border
               .card-footer


### PR DESCRIPTION
## Issue

- #7753

## 概要

## 変更確認方法

1. `fix/add-blog-title-on-x-sharing`をローカルに取り込む
2. `bin/setup`を実行
3. `foreman start -f Procfile.dev`でローカルサーバを立ち上げ
4. 任意のアカウントでログインし、[ブログ記事一覧](http://localhost:3000/articles)にアクセス
5. 任意のブログ記事をクリックし、詳細ページを開く
6. `Postする`ボタンをクリックし、下記を確認する
    * [ ] ブログ記事のタイトルがポストの最初に入力されている
    * [ ] ブログ記事のリンクがポストに表示されている
    * [ ] ハッシュタグ`#fjordbootcamp`がポストに表示されている

## Screenshot

### 変更前
* タイトルが表示されていない
![image](https://github.com/fjordllc/bootcamp/assets/117491666/9ff29307-a622-42ba-9df9-3591c71cb4c0)

### 変更後
* タイトルが追加されている
![image](https://github.com/fjordllc/bootcamp/assets/117491666/16db7d77-1ecd-4f02-9cf5-48f1a5b89fbd)

