### PR TITLE
ユーザー個別ページの提出物一覧のtitelタグを修正

### DIFF
--- a/app/views/users/products/index.html.slim
+++ b/app/views/users/products/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}の提出物一覧"
+- title "#{@user.login_name}さんの提出物一覧"
 - set_meta_tags description: "#{@user.login_name}さんの提出物一覧ページです。"
 
 = render 'users/page_title', user: @user

--- a/test/system/user/products_test.rb
+++ b/test/system/user/products_test.rb
@@ -5,7 +5,7 @@ require 'application_system_test_case'
 class User::ProductsTest < ApplicationSystemTestCase
   test 'show listing products' do
     visit_with_auth "/users/#{users(:hatsuno).id}/products", 'komagata'
-    assert_equal 'hatsunoの提出物一覧 | FBC', title
+    assert_equal 'hatsunoさんの提出物一覧 | FBC', title
   end
 
   test 'show self assigned products to mentor' do


### PR DESCRIPTION
## Issue

- #7828

## 概要

titelタグ、og:titleのユーザー名がさん付けになるように修正しました。

## 変更確認方法

1. `feature/correct-title-tag-user-products-list-page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. ユーザー（sotugyou等）でログイン後`マイプロフィール`をクリック
4. `提出物`をクリック
5. titelタグが`○○さんの提出物一覧`となっていることを確認　(development) はローカル環境時にだけ表示されるものなので無視
6. og:titleも`○○さんの提出物一覧`となっていることを確認

## Screenshot

### 変更前

<img width="1030" alt="4141118494140f733320e5d7d0c2729d" src="https://github.com/fjordllc/bootcamp/assets/76871360/131f9476-3804-4d8e-a4f5-2447763a80a6">


### 変更後

<img width="1041" alt="55d1b915fa4d7b3df84dcda5dc9400ae" src="https://github.com/fjordllc/bootcamp/assets/76871360/9b4053a4-f4a9-4704-84fc-b88ec0805a57">
