### PR TITLE
markdown-it-anchor の slugify が十分使えそうなので @sindresorhus/slugify の代わりにデフォルトのものを使うようにする

### DIFF
--- a/app/javascript/markdown-it-headings.js
+++ b/app/javascript/markdown-it-headings.js
@@ -1,13 +1,11 @@
 import plugin from 'markdown-it-anchor'
-import slugify from '@sindresorhus/slugify'
 
 const options = {
   permalink: plugin.permalink.linkInsideHeader({
     symbol: '<i class="fas fa-link"></i>',
     placement: 'before',
     ariaHidden: true
-  }),
-  slugify: (s) => slugify(s)
+  })
 }
 
 export default function (md) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@babel/preset-react": "^7.18.6",
     "@johmun/vue-tags-input": "^2.0.1",
     "@rails/webpacker": "5.4.3",
-    "@sindresorhus/slugify": "^2.1.0",
     "@yaireo/tagify": "^4.17.6",
     "autosize": "^4.0.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,21 +1319,6 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.11.0.tgz#e0e45ac3fff9d8a126916f166809825537e9f955"
   integrity sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==
 
-"@sindresorhus/slugify@^2.1.0":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/slugify/-/slugify-2.2.1.tgz#fa2e2e25d6e1e74a2eeb5e2c37f5ccc516ed2c4b"
-  integrity sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==
-  dependencies:
-    "@sindresorhus/transliterate" "^1.0.0"
-    escape-string-regexp "^5.0.0"
-
-"@sindresorhus/transliterate@^1.0.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz#2309fff65a868047e6d2dd70dec747c5b36a8327"
-  integrity sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==
-  dependencies:
-    escape-string-regexp "^5.0.0"
-
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
@@ -3523,11 +3508,6 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
-escape-string-regexp@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
-  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 eslint-config-prettier@^8.2.0:
   version "8.10.0"


### PR DESCRIPTION
## Issue

- #4607

## 概要

Markdown 中のアンカーリンクが重複する問題を部分的に解決します。具体的には、アンカーリンクの slug 化に使っているライブラリを別のものに置き換えます。詳細は https://github.com/fjordllc/bootcamp/issues/4607#issuecomment-2171366745

## 変更確認方法

1. `use-default-slugify-instead-of-sindresorhus-slugify` をローカルに取り込む
2. 適当なユーザーでログイン
3. 適当なプラクティスのページを開く
4. 見出しのアンカーリンクが見出しの内容を URL エスケープしたものになっていることを確認

## Screenshot

### 変更前

(h2 の id 属性が空だったり `-1` だったり、a の href 属性も `#` だったり `#-1` だったり)
<img width="1145" alt="Screenshot 2024-06-17 at 9 29 37" src="https://github.com/fjordllc/bootcamp/assets/7645585/fadc12b5-1b93-48c6-93ca-c9034b31c0b6">

### 変更後

(h2 の id 属性が見出しのテキストを URL エスケープしたもの、a の href 属性も同様)
<img width="1145" alt="Screenshot 2024-06-17 at 9 30 30" src="https://github.com/fjordllc/bootcamp/assets/7645585/12796790-1b42-4515-84ad-40de8720c299">