### PR TITLE
提出物の新規作成/編集画面にキャンセルボタンを追加

### DIFF
--- a/app/javascript/stylesheets/application/blocks/form/_form-actions.sass
+++ b/app/javascript/stylesheets/application/blocks/form/_form-actions.sass
@@ -23,8 +23,6 @@
     position: relative
     max-width: 45em
     margin-inline: auto
-    &.is-ais-flex-start
-      align-items: flex-start
   +media-breakpoint-down(sm)
     flex-direction: column
 

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -38,3 +38,9 @@
           | まだ作成途中
       li.form-actions__item.is-main.has-help
         = f.submit '提出する', class: 'a-button is-lg is-primary is-block'
+      li.form-actions__item.is-sub.has-help
+        - case params[:action]
+        - when 'new', 'create'
+          = link_to 'キャンセル', practice_path(params[:practice_id]), class: 'a-button is-sm is-text'
+        - when 'edit', 'update'
+          = link_to 'キャンセル', product_path, class: 'a-button is-sm is-text'

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -31,7 +31,7 @@
             = f.select(:checker_id, User.where(mentor: true).where(retired_on: nil).pluck(:login_name, :id).sort, { include_blank: true }, { class: 'js-select2' })
 
   .form-actions
-    ul.form-actions__items.is-ais-flex-start
+    ul.form-actions__items
       li.form-actions__item.is-main.has-help
         = f.submit 'WIP', class: 'a-button is-lg is-secondary is-block', id: 'js-shortcut-wip'
         .form-actions__item-help

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -41,6 +41,7 @@
       li.form-actions__item.is-sub.has-help
         - case params[:action]
         - when 'new', 'create'
-          = link_to 'キャンセル', practice_path(params[:practice_id]), class: 'a-button is-sm is-text'
+          - cancel_link_path = practice_path(params[:practice_id])
         - when 'edit', 'update'
-          = link_to 'キャンセル', product_path, class: 'a-button is-sm is-text'
+          - cancel_link_path = product_path
+        = link_to 'キャンセル', cancel_link_path, class: 'a-button is-sm is-text'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -690,4 +690,18 @@ class ProductsTest < ApplicationSystemTestCase
       assert_no_selector '.a-meta__value', text: '（あと365日）'
     end
   end
+
+  test 'return practice page when click cancel on new product page' do
+    visit_with_auth "/products/new?practice_id=#{practices(:practice1).id}", 'hatsuno'
+    click_link 'キャンセル'
+    assert_selector '.page-tabs__item-link.is-active', text: 'プラクティス'
+    assert_link '提出物を作る'
+  end
+
+  test 'return wip product page when click cancel on edit product page' do
+    visit_with_auth "/products/#{products(:product5).id}/edit", 'kimura'
+    click_link 'キャンセル'
+    assert_selector '.page-tabs__item-link.is-active', text: '提出物'
+    assert_link '内容修正'
+  end
 end


### PR DESCRIPTION
## Issue

- #7847 

## 概要

提出物の新規作成・編集画面にキャンセルボタンを追加しました。

- 修正前：キャンセルボタンなし
- 修正後：キャンセルボタンあり
  - 新規作成：元のプラクティス詳細画面に遷移
  - 編集：編集前の提出物の詳細画面に遷移

## 変更確認方法

1. `feature/add-cancel-button-to-product-edit-page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. `hatsuno`でログイン
（提出物が未作成のプラクティス、既に作成済みのプラクティスの両方があるユーザーなら誰でもOKですが、以下リンクは`hatsuno`でログインした場合のみ有効です）
4. 新規作成画面のキャンセルボタンを確認する
  - [提出物未作成のプラクティス](http://localhost:3000/practices/315059988)から「提出物を作る」をクリック
  - 「キャンセル」をクリックし、元のプラクティス詳細画面に戻ることを確認
5.  編集画面のキャンセルボタンを確認する
  - [既に作成されている提出物の詳細画面](http://localhost:3000/products/750580595)から「内容修正」をクリック
  - 「キャンセル」をクリックし、提出物詳細画面に戻ることを確認

## Screenshot

### 変更前
![スクリーンショット 2024-06-17 16 22 00](https://github.com/fjordllc/bootcamp/assets/104712009/ff12c5db-6db7-4320-8dc5-745617479f2c)

### 変更後
- 新規作成画面

https://github.com/fjordllc/bootcamp/assets/104712009/46d77703-46ee-48d5-b4fd-7da5dee33e52

- 編集画面

https://github.com/fjordllc/bootcamp/assets/104712009/82586b98-6605-491a-b3dc-84d89493f91d

