### PR TITLE
プルダウンメニューにマイプロフィールを追加

### DIFF
--- a/app/views/application/_user_menu.html.slim
+++ b/app/views/application/_user_menu.html.slim
@@ -5,6 +5,10 @@
         class: 'header-dropdown__item-link' do
         | ダッシュボード
     li.header-dropdown__item
+      = link_to user_path(id: current_user.id),
+        class: 'header-dropdown__item-link' do
+        | マイプロフィール
+    li.header-dropdown__item
       = link_to edit_current_user_path,
         class: 'header-dropdown__item-link' do
         | 登録情報変更


### PR DESCRIPTION
## Issue

- #7815

## 右上のアイコンをクリックした時に出るプルダウンメニューにマイプロフィールを追加しました。

## 変更確認方法

1. `feature/move-to-my-profile-from-pull-down-menu`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. ログイン後、右上のアイコンをクリック
4. ドロップダウンに`マイプロフィール`が追加されていることを確認

## Screenshot

### 変更前

<img width="1128" alt="9772a439e58b55ee8d1b27e0dc711bba (1)" src="https://github.com/fjordllc/bootcamp/assets/76871360/4e5afcae-d49e-4ae3-946e-eb8793e61fe8">


### 変更後
<img width="1128" alt="00e38b6fb74ebb97ae145217a4dca09c (1)" src="https://github.com/fjordllc/bootcamp/assets/76871360/9e2109b2-572e-4e66-b6fd-556c39e91fd2">

