### PR TITLE
meta description中にプラクティス名が表示されるように修正

### DIFF
--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -1,6 +1,6 @@
 - title "Q＆A: #{@question.title}"
 - if @question.practice
-  - set_meta_tags description: "#{@question.user.long_name}さんが投稿した、プラクティス「#{@question.practice}」に関する質問「#{@question.title}」のページです。"
+  - set_meta_tags description: "#{@question.user.long_name}さんが投稿した、プラクティス「#{@question.practice.title}」に関する質問「#{@question.title}」のページです。"
 - else
   - set_meta_tags description: "#{@question.user.long_name}さんが投稿した、質問「#{@question.title}」のページです。この質問に関連するプラクティスはありません。"
 


### PR DESCRIPTION
## Issue

- #7855

## 概要
Q&A個別ページのmeta description中にプラクティス名が表示されるように修正いたしました。

## 変更確認方法

1.`bug/correct-practice-name-in-meta-description`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. ログイン後、左のQ&Aをクリック
4. 個別のQ&Aにアクセス
5. head内のmeta description内にプラクティス名が表示されていることを確認。

## Screenshot

### 変更前
<img width="1043" alt="e6ed3cca7fc55a961cd022af4514bd43" src="https://github.com/fjordllc/bootcamp/assets/76871360/c5f8d719-4a28-4702-ad52-ad3c5819faf2">

### 変更後
<img width="1047" alt="a5c0162dd191a55cada2c6e0ba112d98" src="https://github.com/fjordllc/bootcamp/assets/76871360/a841b239-8031-4b16-9f57-b8c9445b316e">


