### PR TITLE
ブログを更新するたびに通知されていたバグを初回公開時のみ通知されるように修正

### DIFF
--- a/app/models/article_notifier.rb
+++ b/app/models/article_notifier.rb
@@ -3,7 +3,7 @@
 class ArticleNotifier
   def call(payload)
     article = payload[:article]
-    return if article.wip?
+    return unless article.saved_change_to_attribute?(:published_at, from: nil)
 
     receivers = User.students_trainees_mentors_and_admins.reject { |receiver| receiver == article.user }
     send_notification(article:, receivers:)

--- a/test/system/notification/articles_test.rb
+++ b/test/system/notification/articles_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class ArticlesTest < ApplicationSystemTestCase
+  setup do
+    @article = articles(:article1)
+    @delivery_mode = AbstractNotifier.delivery_mode
+    AbstractNotifier.delivery_mode = :normal
+  end
+
+  teardown do
+    AbstractNotifier.delivery_mode = @delivery_mode
+  end
+
+  test 'the notification is sent only when the article is first published' do
+    visit_with_auth new_article_path, 'komagata'
+    fill_in('article_title', with: '通知テスト1回目')
+    fill_in('article_body', with: 'test')
+    click_on '公開する'
+    assert_text '記事を作成しました'
+
+    visit_with_auth notifications_path, 'hajime'
+    within first('.card-list-item.is-unread') do
+      assert_text 'komagataさんがブログに「通知テスト1回目」を投稿しました。'
+    end
+    click_link '全て既読にする'
+
+    visit_with_auth edit_article_path(@article), 'komagata'
+    fill_in('article_title', with: '通知テスト2回目')
+    click_on '更新する'
+
+    visit_with_auth notifications_path, 'hajime'
+    assert_no_selector '.card-list-item.is-unread'
+    assert_no_text 'komagataさんがブログに「通知テスト2回目」を投稿しました。'
+  end
+
+  test 'the notification is not sent when the article with WIP is saved' do
+    visit_with_auth new_article_path, 'komagata'
+    fill_in('article_title', with: '通知テストwip')
+    fill_in('article_body', with: 'test')
+    click_on 'WIP'
+    assert_text '記事をWIPとして保存しました'
+
+    visit_with_auth notifications_path, 'hajime'
+    assert_no_selector '.card-list-item.is-unread'
+    assert_no_text 'komagataさんがブログに「通知テストwip」を投稿しました。'
+  end
+end


### PR DESCRIPTION
## Issue

- #7862 

## 概要
FBCの公式ブログを編集し更新するたびに通知されていたバグを修正し、初回公開時のみ通知されるようにしました。

以下に出てくる「2回目公開」は、「一度公開したあとに編集し更新」を意味しています。

- 修正前
  - WIP：通知されない
  - 初回公開：通知される
  - 2回目公開以降：**通知される**
- 修正後
  - WIP：通知されない
  - 初回公開：通知される
  - 2回目公開以降：**通知されない**

## 変更確認方法

1. `bug/notify_only_when_blog_first_published`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. メンター（`komagata`等）でログイン
4. [ブログ記事作成](http://localhost:3000/articles/new)でブログ記事を作成
5. 以下の3点を確認
- WIPは通知されない
- 初回公開時は通知される
- 2回目公開以降は通知されない

ブログ著者以外に通知されるため、ユーザーを変えて通知の確認をお願いいたします。
あわせてメール通知の確認もお願いいたします。

## Screenshot

以下の動画は全て、ブログ記事作成を`komagata`、通知の確認は`hajime`で行っています。
ユーザーの切り替えの都合上、別ブラウザでそれぞれ立ち上げて確認を行っています。

### 変更前

- 初回公開時：通知される
初回公開時の通知は変更箇所ではありませんが、2回目公開時通知の参考資料として添付しました。

https://github.com/fjordllc/bootcamp/assets/104712009/c4ba95b9-9ad3-4130-a42a-32b20359724e

- 2回目公開時：通知される（要修正箇所）

https://github.com/fjordllc/bootcamp/assets/104712009/6d1748d1-fb2b-4fac-9459-5b7e3be3e1ce

### 変更後

- WIP：通知されない

https://github.com/fjordllc/bootcamp/assets/104712009/b09e9be9-01eb-4e50-9f59-4c8d01c71b87

- 初回公開時：通知される

https://github.com/fjordllc/bootcamp/assets/104712009/dcef2af8-842b-4ab8-b17c-121766f687c8

- 2回目公開時：通知されない

https://github.com/fjordllc/bootcamp/assets/104712009/01121e0d-f314-434f-ae18-b17edf168782

