### PR TITLE
bookmark削除のトーストの文言を日本語に変更

### DIFF
--- a/app/javascript/components/BookmarkButton.jsx
+++ b/app/javascript/components/BookmarkButton.jsx
@@ -58,7 +58,7 @@ export default function BookmarkButton({ bookmarkableId, bookmarkableType }) {
     Bootcamp.delete(`/api/bookmarks/${bookmarkId}`)
       .then(() => {
         setIsBookmark(false)
-        toast.methods.toast('Bookmarkを削除しました')
+        toast.methods.toast('ブックマークを削除しました')
       })
       .catch((error) => {
         console.warn(error)

--- a/app/javascript/components/BookmarksInDashboard.jsx
+++ b/app/javascript/components/BookmarksInDashboard.jsx
@@ -84,7 +84,7 @@ const Bookmark = ({ bookmark, editable, bookmarksUrl }) => {
     Bootcamp.delete(`/api/bookmarks/${id}.json`)
       .then((_response) => {
         mutate(bookmarksUrl)
-        toast('Bookmarkを削除しました。')
+        toast('ブックマークを削除しました。')
       })
       .catch((error) => {
         console.warn(error)

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -466,7 +466,7 @@ class HomeTest < ApplicationSystemTestCase
     visit '/'
     first('.spec-bookmark-edit').click
     first('.js-bookmark-delete-button').click
-    assert_text 'Bookmarkを削除しました。'
+    assert_text 'ブックマークを削除しました。'
     assert_no_text '名前の長いメンター用'
   end
 


### PR DESCRIPTION
## Issue

- #7856
## 概要
bookmark削除のトーストの文言を「Bookmarkを削除しました」から「ブックマークを削除しました。」に変更しました。

## 変更確認方法

1. `bug/toast-japanese-bookmark-deletion`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. kimuraでログイン(ブックマークがはじめからある為)
4. ダッシュボードの最新のブックマークからブックマークを削除
5. トーストの文言がカタカナでブックマークになっているか確認
6. 最新のブックマークから登録している記事をクリック
7. Bookmark中をクリック
8. トーストの文言がカタカナでブックマークになっているか確認

## Screenshot

### 変更前

ダッシュボードからブックマークを削除
![スクリーンショット (577)](https://github.com/fjordllc/bootcamp/assets/76871360/20042710-c9f7-408c-89e2-c04a3a23e948)

ブックマークした記事からブックマークを削除
<img width="472" alt="4e3a5ce200c883837945e78e84632dc1" src="https://github.com/fjordllc/bootcamp/assets/76871360/31b1f67c-6084-4920-95dd-2caa620f5799">



### 変更後

ダッシュボードからブックマークを削除
![スクリーンショット (578)](https://github.com/fjordllc/bootcamp/assets/76871360/127d049e-6b06-4f11-86e8-70e9d8cd4c4e)


ブックマークした記事からブックマークを削除

<img width="1128" alt="cf33d49cbbc83ccde082eda3427272be" src="https://github.com/fjordllc/bootcamp/assets/76871360/b2dcf511-e4c3-4700-921d-b16d492d6703">
