### PR TITLE
外部公開ブログに atom フィードを追加

### DIFF
--- a/app/javascript/stylesheets/application/blocks/footer/_footer-nav.sass
+++ b/app/javascript/stylesheets/application/blocks/footer/_footer-nav.sass
@@ -2,6 +2,7 @@
   display: flex
   line-height: 1.4
   flex-wrap: wrap
+  align-items: center
   +media-breakpoint-up(md)
     font-size: .8125rem
     justify-content: center

--- a/app/javascript/stylesheets/shared/blocks/_not-logged-in-footer.sass
+++ b/app/javascript/stylesheets/shared/blocks/_not-logged-in-footer.sass
@@ -13,6 +13,7 @@
   +media-breakpoint-up(lg)
     gap: 1rem
     justify-content: center
+    align-items: center
   +media-breakpoint-up(md)
     display: flex
     flex-wrap: wrap
@@ -44,6 +45,12 @@
     align-items: center
     padding-inline: 1rem
     +size(100% 2.75rem)
+  i
+    font-size: .75em
+    position: relative
+    top: -.0625em
+  i:first-child
+    margin-right: .375em
   body.is-welcome &
     color: var(--default-text)
 

--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -52,7 +52,9 @@ footer.footer
           li.footer-nav__item
             = link_to 'https://fbc-stack.vercel.app/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | FBC Stack
-
+          li.footer-nav__item
+            = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
+              i.fa-solid.fa-rss
       small.footer__copyright
         i.fa-regular.fa-copyright
         = link_to 'Lokka Inc.', 'https://lokka.jp', class: 'footer__copyright-link'

--- a/app/views/articles/index.atom.builder
+++ b/app/views/articles/index.atom.builder
@@ -1,0 +1,17 @@
+atom_feed do |feed|
+  feed.title("ブログ | FJORD BOOT CAMP（フィヨルドブートキャンプ）")
+  feed.updated(@atom_articles.first.created_at)
+  @atom_articles.each do |article|
+    feed.entry(article) do |entry|
+      entry.title(article.title)
+      summary_html = md2html(article.summary)
+      entry.summary(summary_html, type: 'html')
+      body_html = md2html(article.body)
+      entry.content(body_html, type: 'html')
+
+      entry.author do |author|
+        author.name(article.user.login_name)
+      end
+    end
+  end
+end

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -1,6 +1,7 @@
 - title 'ブログ'
 - set_meta_tags(site: 'FJORD BOOT CAMP（フィヨルドブートキャンプ）',
 description: 'オンラインプログラミングフィヨルドブートキャンプのブログ記事一覧ページです。')
+= auto_discovery_link_tag(:atom, 'https://bootcamp.fjord.jp/articles.atom', { title: 'Atom Feed' })
 = render '/head/fontawsome'
 
 .welcome-page-header
@@ -52,5 +53,3 @@ description: 'オンラインプログラミングフィヨルドブートキャ
                             - else
                               = l(article.published_at)
         = paginate @articles
-
-= auto_discovery_link_tag(:atom, 'https://bootcamp.fjord.jp/articles.atom', { title: 'Atom Feed' })

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -52,3 +52,5 @@ description: 'オンラインプログラミングフィヨルドブートキャ
                             - else
                               = l(article.published_at)
         = paginate @articles
+
+= auto_discovery_link_tag(:atom, 'https://bootcamp.fjord.jp/articles.atom', { title: 'Atom Feed' })

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -24,6 +24,7 @@ html.is-application lang='ja'
     = stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/yakuhanjp@3.2.0/dist/css/yakuhanjp_s-narrow.min.css', media: 'all'
     = stylesheet_link_tag 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;700;900&display=swap', media: 'all'
     = render '/head/fontawsome'
+    link(rel='alternate' type='application/atom+xml' title='フィヨルドブートキャンプブログ' href='/articles.atom')
     = content_for(:head_last) if content_for?(:head_last)
   body.is-application#body(class="#{body_class}")
     = render 'google_analytics' if Rails.env.production? && !staging?

--- a/app/views/layouts/welcome.html.slim
+++ b/app/views/layouts/welcome.html.slim
@@ -21,9 +21,10 @@ html.is-application lang='ja'
     = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Source+Code+Pro', media: 'all'
     = stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/yakuhanjp@3.2.0/dist/css/yakuhanjp_s-narrow.min.css', media: 'all'
     = render '/head/fontawsome'
+    link(rel='alternate' type='application/atom+xml' title='フィヨルドブートキャンプブログ' href='/articles.atom')
     = content_for(:head_last) if content_for?(:head_last)
     - if defined?(@article) && @article.wip?
-      meta name="robots" content="none"
+      meta(name="robots" content="none")
   body.is-welcome#body class="#{body_class}"
     = render 'google_analytics' if Rails.env.production? && !staging?
     .wrapper

--- a/app/views/shared/_not_logged_in_footer.html.slim
+++ b/app/views/shared/_not_logged_in_footer.html.slim
@@ -23,6 +23,9 @@ footer.not-logged-in-footer
         li.not-logged-in-footer__nav-item
           = link_to new_comeback_path, class: 'not-logged-in-footer__nav-item-link' do
             | 休会からの復帰
+        li.not-logged-in-footer__nav-item
+          = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
+            i.fa-solid.fa-rss
     small.not-logged-in-footer-copyright
       i.fa-regular.fa-copyright
       span.not-logged-in-footer-copyright__author

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -381,4 +381,35 @@ class ArticlesTest < ApplicationSystemTestCase
       assert_selector "a[href='https://b.hatena.ne.jp/entry/s/bootcamp.fjord.jp/articles/#{@article.id}#bbutton']"
     end
   end
+
+  test 'items of article shown in atom feed' do
+    visit_with_auth new_article_url, 'komagata'
+
+    fill_in 'article[title]', with: 'エントリーのタイトル（text）'
+    fill_in 'article[summary]', with: 'サマリー（HTML）'
+    fill_in 'article[body]', with: '本文（HTML）'
+    within '.select-users' do
+      find('.choices__inner').click
+      find('#choices--js-choices-single-select-item-choice-6', text: 'mentormentaro').click
+    end
+    click_on '公開する'
+
+    visit '/articles.atom'
+    assert_text 'エントリーのタイトル（text）'
+    assert_text '&lt;p&gt;サマリー（HTML）&lt;/p&gt;'
+    assert_text '&lt;p&gt;本文（HTML）&lt;/p&gt;'
+    assert_text 'mentormentaro'
+  end
+
+  test 'WIP article is not shown in atom feed' do
+    visit_with_auth new_article_url, 'komagata'
+
+    fill_in 'article[title]', with: 'WIPの記事は atom feed に表示されない'
+    fill_in 'article[body]', with: 'WIPの記事は atom feed に表示されない'
+    click_on 'WIP'
+    assert_text '記事をWIPとして保存しました'
+
+    visit '/articles.atom'
+    assert_no_text 'WIPの記事は atom feed に表示されない'
+  end
 end


### PR DESCRIPTION
## Issue

- #7792 

## 概要

- 外部公開ブログにatomフィードを追加した

## 変更確認方法

1. `feature/add-atom-feed` をローカルに取り込む
1. atomフィードへのリンクの確認
   1. 外部向けページのフッターに配置されたリンク（Screenshot参照）からatomフィードにアクセスできる事を確認する
1. RSS / atomリーダーでの表示確認
   1. RSS / atomリーダーを準備し、atomフィードのアドレス(`http://localhost:3000/articles.atom`)を登録する
      ※動作確認したところ、ReadKit（AppStoreからダウンロード）が、ローカルホストでのatomフィードのアドレスを認識できた。Feedly（ウェブアプリ）は、アドレスを認識できなかった
   1. [\(development\) ブログ \| FJORD BOOT CAMP（フィヨルドブートキャンプ）](http://localhost:3000/articles)（`http://localhost:3000/articles`）にアクセスする
   1. 「リーダー」と「元のサイト側」の表示を比較し、表示内容が同じであることを確認する
      表示と操作について
      - WIPの記事は、「メンター」または「管理者」でログインすると「元のサイト側」では確認できるが、atomフィード（＝リーダー）には表示されない
      - atomフィード自体で表示される記事数は、ブログの1ページ当たりの表示数（24） と同じ。ただし、大抵のリーダーでは、一度取り込まれた記事は蓄積されていくので、初期のみ24記事、それ以降は増加する
      - 記事を書く場合、「メンター」または「管理者」でのログインが必要

## Screenshot

### 変更前　（外部向けページのフッター）

![image](https://github.com/fjordllc/bootcamp/assets/85104698/1144e263-6f85-484c-864f-ec9d652fa83e)

### 変更後　（外部向けページのフッター）

![image](https://github.com/fjordllc/bootcamp/assets/85104698/2963ae0b-e871-4c66-a6b7-837be5670271)
