### PR TITLE
管理者の登録情報変更からの変更をDBに反映されるように修正

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -33,7 +33,9 @@ class CurrentUserController < ApplicationController
       :profile_name, :profile_job, :profile_text, { authored_books_attributes: %i[id title url cover _destroy] },
       :feed_url, :country_code, :subdivision_code, { discord_profile_attributes: %i[id account_name times_url] }
     ]
-    user_attribute.push(:retired_on, :graduated_on, :free, :github_collaborator) if current_user.admin?
+    if current_user.admin?
+      user_attribute.push(:retired_on, :graduated_on, :free, :github_collaborator, :auto_retire, :invoice_payment, :mentor, :subscription_id)
+    end
     params.require(:user).permit(user_attribute)
   end
 

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -221,8 +221,6 @@ class CurrentUserTest < ApplicationSystemTestCase
   test 'update admin user\'s auto_retire' do
     user = users(:komagata)
 
-    # auto_retireはデフォルトでtrue
-    # チェックボックスにチェックを入れると、auto_retireはfalseになる
     visit_with_auth '/current_user/edit', 'komagata'
     check '休会六ヶ月後に自動退会しない', allow_label_click: true
     click_on '更新する'

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -219,42 +219,34 @@ class CurrentUserTest < ApplicationSystemTestCase
   end
 
   test 'update admin user\'s auto_retire' do
-    user = users(:komagata)
-
     visit_with_auth '/current_user/edit', 'komagata'
     check '休会六ヶ月後に自動退会しない', allow_label_click: true
     click_on '更新する'
 
-    assert_not user.reload.auto_retire
+    assert_not users(:komagata).reload.auto_retire
   end
 
   test 'update admin user\'s invoice_payment' do
-    user = users(:komagata)
-
     visit_with_auth '/current_user/edit', 'komagata'
     check '請求書払いのユーザーである', allow_label_click: true
     click_on '更新する'
 
-    assert user.reload.invoice_payment
+    assert users(:komagata).reload.invoice_payment
   end
 
   test 'update admin user\'s mentor' do
-    user = users(:komagata)
-
     visit_with_auth '/current_user/edit', 'komagata'
     uncheck 'メンター', allow_label_click: true
     click_on '更新する'
 
-    assert_not user.reload.mentor
+    assert_not users(:komagata).reload.mentor
   end
 
   test 'update admin user\'s subscription_id' do
-    user = users(:komagata)
-
     visit_with_auth '/current_user/edit', 'komagata'
     fill_in 'サブスクリプションID', with: 'sub_987654321'
     click_on '更新する'
 
-    assert_match user.reload.subscription_id, 'sub_987654321'
+    assert_match users(:komagata).reload.subscription_id, 'sub_987654321'
   end
 end

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -217,4 +217,46 @@ class CurrentUserTest < ApplicationSystemTestCase
 
     assert_text 'textbringer'
   end
+
+  test 'update admin user\'s auto_retire' do
+    user = users(:komagata)
+
+    # auto_retireはデフォルトでtrue
+    # チェックボックスにチェックを入れると、auto_retireはfalseになる
+    visit_with_auth '/current_user/edit', 'komagata'
+    check '休会六ヶ月後に自動退会しない', allow_label_click: true
+    click_on '更新する'
+
+    assert_not user.reload.auto_retire
+  end
+
+  test 'update admin user\'s invoice_payment' do
+    user = users(:komagata)
+
+    visit_with_auth '/current_user/edit', 'komagata'
+    check '請求書払いのユーザーである', allow_label_click: true
+    click_on '更新する'
+
+    assert user.reload.invoice_payment
+  end
+
+  test 'update admin user\'s mentor' do
+    user = users(:komagata)
+
+    visit_with_auth '/current_user/edit', 'komagata'
+    uncheck 'メンター', allow_label_click: true
+    click_on '更新する'
+
+    assert_not user.reload.mentor
+  end
+
+  test 'update admin user\'s subscription_id' do
+    user = users(:komagata)
+
+    visit_with_auth '/current_user/edit', 'komagata'
+    fill_in 'サブスクリプションID', with: 'sub_987654321'
+    click_on '更新する'
+
+    assert_match user.reload.subscription_id, 'sub_987654321'
+  end
 end


### PR DESCRIPTION
## Issue

- #7874

## 概要
管理者で「登録情報変更」リンクから、自身の登録情報変更を更新してもDBに反映されない項目があったため、それらをDBに反映されるように修正しました。

- 修正前：以下の項目が反映されない
  - 自動退会設定の「休会六ヶ月後に自動退会しない」
  - 請求書払いの設定の「請求書払いのユーザーである」
  - サブスクリプションID
  - 特殊ユーザー属性の「メンター」

- 修正後
  - 上記項目の変更が反映される
 
## 変更確認方法

1.  `bug/fix_to_update_admin_attributes`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. `komagata`など管理者権限をもつユーザーでログイン
4. [ 登録情報変更 ](http://localhost:3000/current_user/edit)をクリック
5. 以下の項目について情報を変更し「更新する」をクリック
・自動退会設定の「休会六ヶ月後に自動退会しない」
・請求書払いの設定の「請求書払いのユーザーである」
・サブスクリプションID
・特殊ユーザー属性の「メンター」
6. 再度[ 登録情報変更 ](http://localhost:3000/current_user/edit)をクリックして、今行った変更が全て反映されているかを確認

## Screenshot

### 変更前

https://github.com/fjordllc/bootcamp/assets/104712009/1790a56a-7bd4-4c49-93b4-0759874b08b8


### 変更後

https://github.com/fjordllc/bootcamp/assets/104712009/e8748e9c-2f6c-4ff6-b97d-66a716c4d560

