### PR TITLE
「イベントのお知らせ」に記載されるイベントの並び順を開始時間順に変更した

### DIFF
--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -49,11 +49,11 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     event_info = <<~TEXT.gsub(/^\n+/, "\n").chomp
       ⚡️⚡️⚡️イベントのお知らせ⚡️⚡️⚡️
 
-      #{add_event_info(today_events, '今日', today)}
+      #{add_event_info(today_events.sort_by(&:start_at), '今日', today)}
 
       #{'------------------------------' if today_events.present?}
 
-      #{add_event_info(tomorrow_events, '明日', tomorrow)}
+      #{add_event_info(tomorrow_events.sort_by(&:start_at), '明日', tomorrow)}
 
       ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
     TEXT

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -42,18 +42,18 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
   def coming_soon_regular_events(params = {})
     params.merge!(@params)
     webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:all]
-    today_events = params[:today_events]
-    tomorrow_events = params[:tomorrow_events]
+    today_events = params[:today_events].sort_by(&:start_at)
+    tomorrow_events = params[:tomorrow_events].sort_by(&:start_at)
     today = Time.current
     tomorrow = Time.current.next_day
     event_info = <<~TEXT.gsub(/^\n+/, "\n").chomp
       ⚡️⚡️⚡️イベントのお知らせ⚡️⚡️⚡️
 
-      #{add_event_info(today_events.sort_by(&:start_at), '今日', today)}
+      #{add_event_info(today_events, '今日', today)}
 
       #{'------------------------------' if today_events.present?}
 
-      #{add_event_info(tomorrow_events.sort_by(&:start_at), '明日', tomorrow)}
+      #{add_event_info(tomorrow_events, '明日', tomorrow)}
 
       ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
     TEXT

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -110,8 +110,8 @@ regular_event28:
   description: Discord通知確認用イベント(土曜日開催)
   finished: false
   hold_national_holiday: true
-  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
-  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
+  start_at: <%= Time.zone.local(2020, 1, 1, 10, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 11, 0, 0) %>
   user: komagata
   published_at: "2023-08-01 00:00:00"
 
@@ -120,8 +120,8 @@ regular_event29:
   description: Discord通知確認用イベント(土曜日 + 日曜日開催)
   finished: false
   hold_national_holiday: true
-  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
-  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
+  start_at: <%= Time.zone.local(2020, 1, 1, 9, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 10, 0, 0) %>
   user: komagata
   published_at: "2023-08-01 00:00:00"
 
@@ -140,8 +140,8 @@ regular_event31:
   description: Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
   finished: false
   hold_national_holiday: false
-  start_at: <%= Time.zone.local(2020, 1, 1, 21, 0, 0) %>
-  end_at: <%= Time.zone.local(2020, 1, 1, 22, 0, 0) %>
+  start_at: <%= Time.zone.local(2020, 1, 1, 11, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 12, 0, 0) %>
   user: komagata
   published_at: "2023-08-01 00:00:00"
 

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -77,25 +77,25 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       時間: 21:00〜22:00
       詳細: <http://localhost:3000/regular_events/927610372>
 
-      ⚠️ Discord通知確認用、祝日非開催イベント(金曜日開催)
       ⚠️ Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
+      ⚠️ Discord通知確認用、祝日非開催イベント(金曜日開催)
       はお休みです。
 
       ------------------------------
 
       < 明日 (05/06 土) 開催 >
 
-      Discord通知確認用イベント(土曜日開催)
-      時間: 21:00〜22:00
-      詳細: <http://localhost:3000/regular_events/284302086>
-
       Discord通知確認用イベント(土曜日 + 日曜日開催)
-      時間: 21:00〜22:00
-      詳細: <http://localhost:3000/regular_events/670378901>
+      時間: 09:00〜10:00
+      詳細: http://localhost:3000/regular_events/670378901
+
+      Discord通知確認用イベント(土曜日開催)
+      時間: 10:00〜11:00
+      詳細: http://localhost:3000/regular_events/284302086
 
       Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
-      時間: 21:00〜22:00
-      詳細: <http://localhost:3000/regular_events/808817380>
+      時間: 11:00〜12:00
+      詳細: http://localhost:3000/regular_events/808817380
 
       ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
     TEXT

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -87,15 +87,15 @@ class DiscordNotifierTest < ActiveSupport::TestCase
 
       Discord通知確認用イベント(土曜日 + 日曜日開催)
       時間: 09:00〜10:00
-      詳細: http://localhost:3000/regular_events/670378901
+      詳細: <http://localhost:3000/regular_events/670378901>
 
       Discord通知確認用イベント(土曜日開催)
       時間: 10:00〜11:00
-      詳細: http://localhost:3000/regular_events/284302086
+      詳細: <http://localhost:3000/regular_events/284302086>
 
       Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
       時間: 11:00〜12:00
-      詳細: http://localhost:3000/regular_events/808817380
+      詳細: <http://localhost:3000/regular_events/808817380>
 
       ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
     TEXT

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -43,15 +43,15 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
 
       Discord通知確認用イベント(土曜日 + 日曜日開催)
       時間: 09:00〜10:00
-      詳細: http://localhost:3000/regular_events/670378901
+      詳細: <http://localhost:3000/regular_events/670378901>
 
       Discord通知確認用イベント(土曜日開催)
       時間: 10:00〜11:00
-      詳細: http://localhost:3000/regular_events/284302086
+      詳細: <http://localhost:3000/regular_events/284302086>
 
       Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
       時間: 11:00〜12:00
-      詳細: http://localhost:3000/regular_events/808817380
+      詳細: <http://localhost:3000/regular_events/808817380>
 
       ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
     TEXT

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -33,25 +33,25 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
 
       < 今日 (05/05 金) 開催 >
 
-      ⚠️ Discord通知確認用、祝日非開催イベント(金曜日開催)
       ⚠️ Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
+      ⚠️ Discord通知確認用、祝日非開催イベント(金曜日開催)
       はお休みです。
 
       ------------------------------
 
       < 明日 (05/06 土) 開催 >
 
-      Discord通知確認用イベント(土曜日開催)
-      時間: 21:00〜22:00
-      詳細: <http://localhost:3000/regular_events/284302086>
-
       Discord通知確認用イベント(土曜日 + 日曜日開催)
-      時間: 21:00〜22:00
-      詳細: <http://localhost:3000/regular_events/670378901>
+      時間: 09:00〜10:00
+      詳細: http://localhost:3000/regular_events/670378901
+
+      Discord通知確認用イベント(土曜日開催)
+      時間: 10:00〜11:00
+      詳細: http://localhost:3000/regular_events/284302086
 
       Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
-      時間: 21:00〜22:00
-      詳細: <http://localhost:3000/regular_events/808817380>
+      時間: 11:00〜12:00
+      詳細: http://localhost:3000/regular_events/808817380
 
       ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
     TEXT


### PR DESCRIPTION
## Issue

- #7764 

## 概要
・Discordに通知される「イベントのお知らせ」の通知に記載されるイベントが複数ある場合に開始時間順に並ぶように変更しました。この変更に伴い、テストの際にイベントの並び順を確認できるようにfixturesのデータとテストの記載も変更しました。

## 変更確認方法
**⚠️このPRにおける動作確認については、Discordに対して行われる通知の内容を確認するため、Discordサーバー(FBCとは別のもの)の用意とチャンネルの作成及び当該チャンネルのWebhook URLの取得をしていただく必要があります。お手数ですが、以下の手順にて確認をお願いいたします🙇‍♂️（既に何らかのissueで確認用のDiscordサーバーをお持ちの方はそちらをご使用いただいて差し支えございません🙆‍♂️）**
### Discordサーバーの準備
1. BootcampのWikiにある、[Develop環境でのDiscord通知の確認方法
](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95)に記載の手順にしたがってサーバー追加、チャンネル作成、当該チャンネルのWebhook URLの取得を行ってください。

### 環境変数の設定
1. 同じくBootcampのWikiにある[Discord通知](https://github.com/fjordllc/bootcamp/wiki/Discord%E9%80%9A%E7%9F%A5)を参照し、環境変数の設定をしてください。Wikiにも言及のある[direnv](https://direnv.net/)を利用するのが手軽で便利です。
direnvの導入の仕方については公式のほか、以下のページもわかりやすかったので適宜ご参照ください。
参考：[direnvを使おう](https://qiita.com/kompiro/items/5fc46089247a56243a62)

今回であれば`.envrc`の中に以下のとおり設定すると全員宛のDiscord通知の送信先が上記で取得したDiscordサーバーになります。
```
export DISCORD_ALL_WEBHOOK_URL=取得したWebhook URL
```

### 動作確認
システムテストを実行して実際に通知をとばし、本文を確認します。
1. `feature/change-events-order-in-events-notifications-into-chronological-order`をローカルに取り込む
1. `bin/rails test test/system/notification/regular_events_test.rb`を実行する
1. 上記で作成したDiscordチャンネルに「イベントのお知らせ」が届くので、5/6開催分のイベントが開始時間の早い順に並んでいることを確認する

**⚠️notify_coming_soon_regular_eventsのテストが失敗しますが、これは上記で設定したとおり確認用のDiscordサーバーに通知を送信するためにDevelopment環境で独自の環境変数(`DISCORD_ALL_WEBHOOK_URL`)を設定していることによるものです。`DISCORD_ALL_WEBHOOK_URL`に何も設定しない状態(= 本番と同じ状態)で実行すると通ります。**

## Screenshot

### 変更前
<img width="671" alt="_全員への通知___ham-cap_ハム_のサーバー_-_Discord-2" src="https://github.com/fjordllc/bootcamp/assets/66000707/b55e0f9f-6920-4cb5-aec4-2f8ae2084a81">

### 変更後
<img width="723" alt="_全員への通知___ham-cap_ハム_のサーバー_-_Discord" src="https://github.com/fjordllc/bootcamp/assets/66000707/f2a9029f-58fb-4b69-9475-e4d99980ca88">


