### PR TITLE
ポートフォリオページの見出し文言変更

### DIFF
--- a/app/views/works/index.html.slim
+++ b/app/views/works/index.html.slim
@@ -6,7 +6,7 @@ header.page-header
     .page-header__inner
       .page-header__start
         h2.page-header__title
-          = title
+          |みんなのポートフォリオ
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items

--- a/app/views/works/index.html.slim
+++ b/app/views/works/index.html.slim
@@ -6,7 +6,7 @@ header.page-header
     .page-header__inner
       .page-header__start
         h2.page-header__title
-          |みんなのポートフォリオ
+          | みんなのポートフォリオ
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items

--- a/test/system/works_test.rb
+++ b/test/system/works_test.rb
@@ -7,6 +7,7 @@ class WorksTest < ApplicationSystemTestCase
     visit_with_auth portfolios_path, 'kimura'
     assert_equal 'みんなのポートフォリオ | FBC', title
     assert_selector "meta[property='og:title'][content='みんなのポートフォリオ']", visible: false
+    assert_selector 'h2.page-header__title', text: 'みんなのポートフォリオ'
     assert_text works(:work1).title
   end
 


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/7894

## 概要
[ポートフォリオ一覧ページ](https://bootcamp.fjord.jp/portfolios)の見出し文言を変更しました。
- 修正前
  - ポートフォリオ
- 期待する表示
  - **みんなの**ポートフォリオ

## 変更確認方法
1. `bug/update-portfolio-headings-text`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. メンター or 管理者 or 受講生アカウントでログインする
4. [ポートフォリオ一覧ページ](http://localhost:3000/portfolios)にアクセスする

#### 確認事項
ページの見出しが`みんなのポートフォリオ`になっている

## Screenshot
### 変更前
<img width="253" alt="スクリーンショット 2024-07-05 22 31 36" src="https://github.com/fjordllc/bootcamp/assets/43412616/c6bb5f32-7f41-40e8-a24a-30c547c12027">


### 変更後
<img width="250" alt="スクリーンショット 2024-07-05 22 33 27" src="https://github.com/fjordllc/bootcamp/assets/43412616/2f021e9c-1b62-48ff-a088-3cba9f66d30f">


