### PR TITLE
ポートフォリオページのタイトルタグ文言変更

### DIFF
--- a/app/views/works/index.html.slim
+++ b/app/views/works/index.html.slim
@@ -1,4 +1,4 @@
-- title 'ポートフォリオ'
+- title 'みんなのポートフォリオ'
 - set_meta_tags description: '作品の一覧ページです。'
 
 header.page-header

--- a/test/system/works_test.rb
+++ b/test/system/works_test.rb
@@ -5,7 +5,8 @@ require 'application_system_test_case'
 class WorksTest < ApplicationSystemTestCase
   test 'user can see portfolio list page' do
     visit_with_auth portfolios_path, 'kimura'
-    assert_equal 'ポートフォリオ | FBC', title
+    assert_equal 'みんなのポートフォリオ | FBC', title
+    assert_selector "meta[property='og:title'][content='みんなのポートフォリオ']", visible: false
     assert_text works(:work1).title
   end
 


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/7895

## 概要
[ポートフォリオ一覧ページ](https://bootcamp.fjord.jp/portfolios)の**タイトルタグ**の文言を変更しました。

期待する表示
- `<title>` 
  - テキストが`みんなのポートフォリオ | FBC`
- `<meta proterty="og:title">`
  - テキストが`みんなのポートフォリオ`

## 変更確認方法
1. `bug/update-portfolio-title-tag`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. メンターor管理者or受講生アカウントでログインする
4. [ポートフォリオ一覧ページ](http://localhost:3000/portfolios)にアクセスする
5. ブラウザの検証ツールを開き、`Elements`から`<head>`を確認する

## Screenshot
### 変更前
<img width="416" alt="スクリーンショット 2024-07-06 11 43 28" src="https://github.com/fjordllc/bootcamp/assets/43412616/2b2e8276-1521-400c-8237-854c497fcffd">


### 変更後
<img width="438" alt="スクリーンショット 2024-07-06 11 44 37" src="https://github.com/fjordllc/bootcamp/assets/43412616/485964e2-e75b-4f88-b5ba-f961e0b831b5">


