### PR TITLE
退会したらGitHubアカウントとの連携のデータを空になるように修正

### DIFF
--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -15,12 +15,8 @@ class RetirementController < ApplicationController
       current_user.cancel_participation_from_regular_events
       current_user.delete_and_assign_new_organizer
       Newspaper.publish(:retirement_create, { user: })
+      UserRetirement.new(user).execute
 
-      destroy_subscription(user)
-      destroy_card(user)
-      notify_to_user(user)
-      notify_to_admins(user)
-      notify_to_mentors(user)
       logout
       redirect_to retirement_url
     else
@@ -33,31 +29,5 @@ class RetirementController < ApplicationController
 
   def retire_reason_params
     params.require(:user).permit(:retire_reason, :satisfaction, :opinion, retire_reasons: [])
-  end
-
-  def destroy_subscription(user)
-    Subscription.new.destroy(user.subscription_id) if user.subscription_id?
-  end
-
-  def destroy_card(user)
-    Card.destroy_all(user.customer_id) if user.customer_id?
-  end
-
-  def notify_to_user(user)
-    UserMailer.retire(user).deliver_now
-  rescue Postmark::InactiveRecipientError => e
-    logger.warn "[Postmark] 受信者由来のエラーのためメールを送信できませんでした。：#{e.message}"
-  end
-
-  def notify_to_admins(user)
-    User.admins.each do |admin_user|
-      ActivityDelivery.with(sender: user, receiver: admin_user).notify(:retired)
-    end
-  end
-
-  def notify_to_mentors(user)
-    User.mentor.each do |mentor_user|
-      ActivityDelivery.with(sender: user, receiver: mentor_user).notify(:retired)
-    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -860,7 +860,7 @@ class User < ApplicationRecord
   def participated_regular_event_ids
     RegularEvent.where(id: regular_event_participations.pluck(:regular_event_id), finished: false)
   end
-  
+
   def clear_github_data
     update(
       github_id: nil,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -860,6 +860,14 @@ class User < ApplicationRecord
   def participated_regular_event_ids
     RegularEvent.where(id: regular_event_participations.pluck(:regular_event_id), finished: false)
   end
+  
+  def clear_github_data
+    update(
+      github_id: nil,
+      github_account: nil,
+      github_collaborator: false
+    )
+  end
 
   def area
     if country_code == 'JP'

--- a/app/models/user_retirement.rb
+++ b/app/models/user_retirement.rb
@@ -12,7 +12,7 @@ class UserRetirement
     notify_to_user
     notify_to_admins
     notify_to_mentors
- end
+  end
 
   private
 

--- a/app/models/user_retirement.rb
+++ b/app/models/user_retirement.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class UserRetirement
+  def initialize(user)
+    @user = user
+  end
+
+  def execute
+    @user.clear_github_data
+    destroy_subscription
+    destroy_card
+    notify_to_user
+    notify_to_admins
+    notify_to_mentors
+ end
+
+  private
+
+  def destroy_subscription
+    Subscription.new.destroy(@user.subscription_id) if @user.subscription_id?
+  end
+
+  def destroy_card
+    Card.destroy_all(@user.customer_id) if @user.customer_id?
+  end
+
+  def notify_to_user
+    UserMailer.retire(@user).deliver_now
+  rescue Postmark::InactiveRecipientError => e
+    Rails.logger.warn "[Postmark] 受信者由来のエラーのためメールを送信できませんでした。：#{e.message}"
+  end
+
+  def notify_to_admins
+    User.admins.each do |admin_user|
+      ActivityDelivery.with(sender: @user, receiver: admin_user).notify(:retired)
+    end
+  end
+
+  def notify_to_mentors
+    User.mentor.each do |mentor_user|
+      ActivityDelivery.with(sender: @user, receiver: mentor_user).notify(:retired)
+    end
+  end
+end

--- a/test/models/user_retirement_test.rb
+++ b/test/models/user_retirement_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserRetirementTest < ActiveSupport::TestCase
+  test 'execute method performs all retirement steps' do
+    user = users(:kimura)
+    retirement = UserRetirement.new(user)
+
+    methods_called = []
+
+    user.define_singleton_method(:clear_github_data) do
+      methods_called << :clear_github_data
+    end
+
+    %i[destroy_subscription destroy_card notify_to_user notify_to_admins notify_to_mentors].each do |method_name|
+      retirement.define_singleton_method(method_name) do
+        methods_called << method_name
+      end
+    end
+
+    retirement.execute
+
+    expected_methods = %i[
+      clear_github_data
+      destroy_subscription
+      destroy_card
+      notify_to_user
+      notify_to_admins
+      notify_to_mentors
+    ]
+
+    assert_equal expected_methods, methods_called
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -754,4 +754,18 @@ class UserTest < ActiveSupport::TestCase
     america_users = [users(:neverlogin), users(:tom)]
     assert_equal User.by_area('米国').to_a.sort, america_users.sort
   end
+
+  test 'clear_github_data should clear GitHub related fields' do
+    user = users(:kimura)
+    user.github_id = '12345'
+    user.github_account = 'github_kimura'
+    user.github_collaborator = true
+    user.save!(validate: false)
+
+    user.clear_github_data
+
+    assert_nil user.github_id
+    assert_nil user.github_account
+    assert_not user.github_collaborator
+  end
 end

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -229,4 +229,21 @@ class RetirementTest < ApplicationSystemTestCase
     assert_no_selector '.is-kimura'
     assert_selector '.is-komagata'
   end
+
+  test 'should clear github data on account deletion' do
+    user = users(:kimura)
+    user.github_id = '12345'
+    user.github_account = 'kimura'
+    user.github_collaborator = true
+    user.save!(validate: false)
+    visit_with_auth new_retirement_path, 'kimura'
+    find('label', text: 'とても良い').click
+    click_on '退会する'
+    page.driver.browser.switch_to.alert.accept
+    assert_text '退会処理が完了しました'
+    user.reload
+    assert_nil user.github_id
+    assert_nil user.github_account
+    assert_not user.github_collaborator
+  end
 end

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -233,7 +233,7 @@ class RetirementTest < ApplicationSystemTestCase
   test 'should clear github data on account deletion' do
     user = users(:kimura)
     user.github_id = '12345'
-    user.github_account = 'kimura'
+    user.github_account = 'github_kimura'
     user.github_collaborator = true
     user.save!(validate: false)
     visit_with_auth new_retirement_path, 'kimura'

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -238,8 +238,9 @@ class RetirementTest < ApplicationSystemTestCase
     user.save!(validate: false)
     visit_with_auth new_retirement_path, 'kimura'
     find('label', text: 'とても良い').click
-    click_on '退会する'
-    page.driver.browser.switch_to.alert.accept
+    page.accept_confirm '本当によろしいですか？' do
+      click_on '退会する'
+    end
     assert_text '退会処理が完了しました'
     user.reload
     assert_nil user.github_id


### PR DESCRIPTION
## Issue

- #7814

## 概要


## 変更確認方法

1. chore/clear-github-data-on-account-deletion`をローカルに取り込む
2. `rails console`でRailsコンソールを立ち上げる
3. `User.where(name: 'Kensyu Seiko').select(:name, :github_account, :github_id, :github_collaborator)`でKensyu SeikoのGitHubアカウントとの連携のデータを確認
4. `foreman start -f Procfile.dev`でサーバーを立ち上げる
5. Kensyu Seiko(github_accountがある為)でログイン
6. 退会する
7. 再度 `User.where(name: 'Kensyu Seiko').select(:name, :github_account, :github_id, :github_collaborator)`でKensyu SeikoのGitHubアカウントとの連携のデータが空になっていることを確認

## Screenshot

### 変更前
<img width="973" alt="708c4c91a4c34c5b15d86332b61827a1" src="https://github.com/fjordllc/bootcamp/assets/76871360/afe5cc95-3c81-4351-bd73-c2ca6758020d">

### 変更後

<img width="971" alt="8d3e5af9d76e6965ca1c25166207d945" src="https://github.com/fjordllc/bootcamp/assets/76871360/4e94e790-0d58-4cdd-ab30-37e06d16ac76">


