### PR TITLE
Discordの通知チャンネルのURLプレビューを表示させないように変更

### DIFF
--- a/app/controllers/mentor/practices_controller.rb
+++ b/app/controllers/mentor/practices_controller.rb
@@ -18,7 +18,7 @@ class Mentor::PracticesController < ApplicationController
   def create
     @practice = Practice.new(practice_params)
     if @practice.save
-      ChatNotifier.message("プラクティス：「#{@practice.title}」を#{current_user.login_name}さんが作成しました。\r#{url_for(@practice)}")
+      ChatNotifier.message("プラクティス：「#{@practice.title}」を#{current_user.login_name}さんが作成しました。\r<#{url_for(@practice)}>")
       redirect_to @practice, notice: 'プラクティスを作成しました。'
     else
       render :new
@@ -28,7 +28,7 @@ class Mentor::PracticesController < ApplicationController
   def update
     @practice.last_updated_user = current_user
     if @practice.update(practice_params)
-      ChatNotifier.message("プラクティス：「#{@practice.title}」を#{current_user.login_name}さんが編集しました。\r#{url_for(@practice)}")
+      ChatNotifier.message("プラクティス：「#{@practice.title}」を#{current_user.login_name}さんが編集しました。\r<#{url_for(@practice)}>")
       redirect_to @practice, notice: 'プラクティスを更新しました。'
     else
       render :edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -163,7 +163,7 @@ class UsersController < ApplicationController
   end
 
   def notify_to_chat(user)
-    ChatNotifier.message "#{user.login_name}さんが新たなメンバーとしてJOINしました🎉\r#{url_for(user)}"
+    ChatNotifier.message "#{user.login_name}さんが新たなメンバーとしてJOINしました🎉\r<#{url_for(user)}>"
   end
 
   def user_params

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -85,7 +85,7 @@ class Comment::AfterCreateCallback
     ChatNotifier.message(<<~TEXT, webhook_url: ENV['DISCORD_ADMIN_WEBHOOK_URL'])
       相談部屋にて#{comment.user.login_name}さんからコメントがありました。
       本文： #{comment.description}
-      URL： https://bootcamp.fjord.jp/talks/#{comment.commentable_id}#latest-comment
+      URL： <https://bootcamp.fjord.jp/talks/#{comment.commentable_id}#latest-comment>
     TEXT
   end
 end

--- a/app/models/page_notifier.rb
+++ b/app/models/page_notifier.rb
@@ -28,7 +28,7 @@ class PageNotifier
 
     ChatNotifier.message(<<~TEXT)
       Docs：「#{page.title}」が作成されました。
-      #{page_url}
+      <#{page_url}>
     TEXT
   end
 end

--- a/app/models/question_notifier.rb
+++ b/app/models/question_notifier.rb
@@ -7,7 +7,7 @@ class QuestionNotifier
 
     ChatNotifier.message(<<~TEXT)
       質問：「#{question.title}」を#{question.user.login_name}さんが作成しました。
-      #{Rails.application.routes.url_helpers.question_url(question)}
+      <#{Rails.application.routes.url_helpers.question_url(question)}>
     TEXT
   end
 end

--- a/app/models/report_notifier.rb
+++ b/app/models/report_notifier.rb
@@ -26,7 +26,7 @@ class ReportNotifier
     ChatNotifier.message(<<~TEXT, webhook_url: ENV['DISCORD_REPORT_WEBHOOK_URL'])
       #{report.user.login_name}さんが#{I18n.l report.reported_on}の日報を公開しました。
       タイトル：「#{report.title}」
-      URL： https://bootcamp.fjord.jp/reports/#{report.id}
+      URL： <https://bootcamp.fjord.jp/reports/#{report.id}>
     TEXT
   end
 

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -33,7 +33,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     url = "https://bootcamp.fjord.jp#{path}"
 
     notification(
-      body: "お知らせ：「#{params[:announce].title}」\r#{url}",
+      body: "お知らせ：「#{params[:announce].title}」\r<#{url}>",
       name: 'ピヨルド',
       webhook_url:
     )
@@ -74,7 +74,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     held_events.each do |event|
       event_info += "#{event.title}\n"
       event_info += "時間: #{event.start_at.strftime('%H:%M')}〜#{event.end_at.strftime('%H:%M')}\n"
-      event_info += "詳細: #{Rails.application.routes.url_helpers.regular_event_url(event)}\n\n"
+      event_info += "詳細: <#{Rails.application.routes.url_helpers.regular_event_url(event)}>\n\n"
     end
     not_held_events.each do |event|
       event_info += "⚠️ #{event.title}\n"
@@ -119,7 +119,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     body = <<~TEXT.chomp
       ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
       担当：#{product_checker_discord_name}さん
-      URL： #{Rails.application.routes.url_helpers.product_url(product)}
+      URL： <#{Rails.application.routes.url_helpers.product_url(product)}>
     TEXT
 
     notification(
@@ -136,7 +136,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     body = <<~TEXT.chomp
       🎉 #{report.user.login_name}さんがはじめての日報を書きました！
       タイトル：「#{report.title}」
-      URL： #{Rails.application.routes.url_helpers.report_url(report)}
+      URL： <#{Rails.application.routes.url_helpers.report_url(report)}>
     TEXT
 
     notification(

--- a/app/views/api/products/unassigned/counts.text.erb
+++ b/app/views/api/products/unassigned/counts.text.erb
@@ -1,6 +1,6 @@
 <% if @passed5 + @passed6 + @over7 > 0 %>
 提出されてから日数が経っている提出物の数をお知らせします。
-https://bootcamp.fjord.jp/products/unassigned
+<https://bootcamp.fjord.jp/products/unassigned>
 
 <% if @over7 > 0 %>
 - 7日以上経過：<%= @over7 %>件

--- a/app/views/api/reports/unchecked/counts.text.erb
+++ b/app/views/api/reports/unchecked/counts.text.erb
@@ -1,4 +1,4 @@
 未確認の日報の数をお知らせします。
-https://bootcamp.fjord.jp/reports/unchecked
+<https://bootcamp.fjord.jp/reports/unchecked>
 
 - <%= @reports.count %>件

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -46,7 +46,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     }
 
     expected = {
-      body: "お知らせ：「お知らせ1」\rhttps://bootcamp.fjord.jp/announcements/395315747",
+      body: "お知らせ：「お知らせ1」\r<https://bootcamp.fjord.jp/announcements/395315747>",
       name: 'ピヨルド',
       webhook_url: 'https://discord.com/api/webhooks/0123456789/all'
     }
@@ -75,7 +75,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
 
       ダッシュボード表示確認用テスト定期イベント
       時間: 21:00〜22:00
-      詳細: http://localhost:3000/regular_events/927610372
+      詳細: <http://localhost:3000/regular_events/927610372>
 
       ⚠️ Discord通知確認用、祝日非開催イベント(金曜日開催)
       ⚠️ Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
@@ -87,15 +87,15 @@ class DiscordNotifierTest < ActiveSupport::TestCase
 
       Discord通知確認用イベント(土曜日開催)
       時間: 21:00〜22:00
-      詳細: http://localhost:3000/regular_events/284302086
+      詳細: <http://localhost:3000/regular_events/284302086>
 
       Discord通知確認用イベント(土曜日 + 日曜日開催)
       時間: 21:00〜22:00
-      詳細: http://localhost:3000/regular_events/670378901
+      詳細: <http://localhost:3000/regular_events/670378901>
 
       Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
       時間: 21:00〜22:00
-      詳細: http://localhost:3000/regular_events/808817380
+      詳細: <http://localhost:3000/regular_events/808817380>
 
       ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
     TEXT
@@ -160,7 +160,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     body = <<~TEXT.chomp
       ⚠️ kimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから5日経過しました。
       担当：<@12345>さん
-      URL： http://localhost:3000/products/313836099
+      URL： <http://localhost:3000/products/313836099>
     TEXT
 
     params = {
@@ -222,7 +222,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     body = <<~TEXT.chomp
       🎉 hajimeさんがはじめての日報を書きました！
       タイトル：「初日報です」
-      URL： http://localhost:3000/reports/819157022
+      URL： <http://localhost:3000/reports/819157022>
     TEXT
     expected = {
       body:,

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -43,15 +43,15 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
 
       Discord通知確認用イベント(土曜日開催)
       時間: 21:00〜22:00
-      詳細: http://localhost:3000/regular_events/284302086
+      詳細: <http://localhost:3000/regular_events/284302086>
 
       Discord通知確認用イベント(土曜日 + 日曜日開催)
       時間: 21:00〜22:00
-      詳細: http://localhost:3000/regular_events/670378901
+      詳細: <http://localhost:3000/regular_events/670378901>
 
       Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)
       時間: 21:00〜22:00
-      詳細: http://localhost:3000/regular_events/808817380
+      詳細: <http://localhost:3000/regular_events/808817380>
 
       ⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️⚡️
     TEXT


### PR DESCRIPTION
## Issue

- #7760 

## 概要
現状、BootcampからDiscord宛に自動送信される通知の中には、通知本文にURLが含まれているものが複数存在します。
Discordは通常、投稿の本文にURLがある場合に自動で以下のようなプレビューが表示されますが、文字入力の際にURLを`<>`で囲うとこのプレビューを表示させないようにすることができます。
*`<>`なし*
<img width="656" alt="image" src="https://github.com/fjordllc/bootcamp/assets/66000707/5468ff18-cbad-4fc0-a849-4fc863e689a8">
*`<>`あり*
<img width="388" alt="image" src="https://github.com/fjordllc/bootcamp/assets/66000707/1dbc20e4-1846-456c-8964-c412142082fd">

このPRでは上記のBootcampから自動送信される通知の中で本文中にURLが含まれているものについて、Discord上でプレビューを表示させないように変更しました。

## 変更確認方法
**⚠️このPRにおける動作確認については、Discordに対して行われる通知の内容を確認するため、Discordサーバー(FBCとは別のもの)の用意とチャンネルの作成及び当該チャンネルのWebhook URLの取得をしていただく必要があります。お手数ですが、以下の手順にて確認をお願いいたします🙇‍♂️（既に何らかのissueで確認用のDiscordサーバーをお持ちの方はそちらをご使用いただいて差し支えございません🙆‍♂️）**
### Discordサーバーの準備
1. BootcampのWikiにある、[Develop環境でのDiscord通知の確認方法
](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95)に記載の手順にしたがってサーバー追加、チャンネル作成、当該チャンネルのWebhook URLの取得を行ってください。

### 環境変数の設定
1. 同じくBootcampのWikiにある[Discord通知](https://github.com/fjordllc/bootcamp/wiki/Discord%E9%80%9A%E7%9F%A5)を参照し、環境変数の設定をしてください。Wikiにも言及のある[direnv](https://direnv.net/)を利用するのが手軽で便利です。
direnvの導入の仕方については公式のほか、以下のページもわかりやすかったので適宜ご参照ください。
参考：[direnvを使おう](https://qiita.com/kompiro/items/5fc46089247a56243a62)

今回は上記Wikiの[Discord通知](https://github.com/fjordllc/bootcamp/wiki/Discord%E9%80%9A%E7%9F%A5)に記載されている5つの環境変数を全て設定してください。`.envrc`の中は以下のようにすると全てのDiscord通知の送信先が上記で取得したDiscordサーバーになります。
```
export DISCORD_ADMIN_WEBHOOK_URL=取得したWebhook URL
export DISCORD_MENTOR_WEBHOOK_URL=取得したWebhook URL
export DISCORD_REPORT_WEBHOOK_URL=取得したWebhook URL
export DISCORD_INTRODUCTION_WEBHOOK_URL=取得したWebhook URL
export DISCORD_ALL_WEBHOOK_URL=取得したWebhook URL

```

### 動作確認
1. `feature/remove-url-previews-for-discord-notification-channels`をローカルに取り込む
1. 以下の通知について`()`内のテストを実行し、プレビューが表示されないことを確認する

- イベントのお知らせ(bootcamp/test/system/notification/regular_events_test.rb)
- お知らせ投稿(bootcamp/test/system/announcements_test.rb)
- XXXさんが新たなメンバーとしてJOINしました🎉(bootcamp/test/system/sign_up_test.rb)
- プラクティス関連(bootcamp/test/system/practices_test.rb)
- Docs関連(bootcamp/test/system/pages_test.rb)
- 質問関連(bootcamp/test/system/questions_test.rb)
- 🎉 XXXXさんがはじめての日報を書きました！(bootcamp/test/system/notification/reports_test.rb)
- XXXXさんがXXXX年XX月XX日の日報を公開しました。(同上)
- XXXさんの「XXXX」の提出物が、最後のコメントから5日経過しました。担当：@xxxxx さん(bootcamp/test/notifiers/discord_notifier_test.rb)⚠️これだけ単体テストのため実行しても通知は飛びません。テストが通っていればOKとのことなので、通ることをご確認ください。

なお、以下の2つについてはBootcampから通知しているわけではなく、外部に通知文のテキストをAPIとして提供しているだけのものです。
こちらについて駒形さんへ確認したところ、ステージングで確認する術がないことから、確認不要とのことです。
- 未確認の日報の数をお知らせします。
- 提出されてから日数が経っている提出物の数をお知らせします。

**⚠️`test/system/regular_events_test.rb`や`test/system/sign_up_test.rb`の実行時にテストが失敗したりエラーが出る場合がありますが、これは上記で設定したとおり確認用のDiscordサーバーに通知を送信するためにDevelopment環境で独自の環境変数(`DISCORD_ALL_WEBHOOK_URL`等)を設定していることによるものです。これらの環境変数に何も設定しない状態(= 本番と同じ状態)で実行すると通ります。**


## Screenshot

### 変更前
全て以下のようにプレビューが表示されます。
<img width="656" alt="image" src="https://github.com/fjordllc/bootcamp/assets/66000707/5468ff18-cbad-4fc0-a849-4fc863e689a8">

### 変更後
各通知についてURLが記載されているだけで、プレビューがない状態です。
#### イベントのお知らせ
![image](https://github.com/fjordllc/bootcamp/assets/66000707/49e3b3e0-58c7-41fe-b43e-fdb74cdb3ee3)

#### お知らせ投稿
![image](https://github.com/fjordllc/bootcamp/assets/66000707/1b557070-69ad-4c13-9393-4bfb938216ce)

#### XXXさんが新たなメンバーとしてJOINしました🎉
![image](https://github.com/fjordllc/bootcamp/assets/66000707/94948a83-87f8-4b9d-9e99-ef1aecf319ff)

#### プラクティス関連
![image](https://github.com/fjordllc/bootcamp/assets/66000707/c2b3fecd-ddb2-401e-b56a-ce32e9d82f98)

#### Docs関連
![image](https://github.com/fjordllc/bootcamp/assets/66000707/a7033dba-c3cf-4999-9825-dd8cee10e9db)

#### 質問関連
![image](https://github.com/fjordllc/bootcamp/assets/66000707/a44d4c1f-f006-4f08-ac06-da194aaecd0c)

#### 🎉 XXXXさんがはじめての日報を書きました！
#### XXXXさんがXXXX年XX月XX日の日報を公開しました。
![image](https://github.com/fjordllc/bootcamp/assets/66000707/afa25d37-625e-4281-b4ab-611114ad9898)
