### PR TITLE
ユーザーの「無料」フラグを削除

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -63,7 +63,7 @@ class Admin::UsersController < AdminController
       :organization, :os, :study_place,
       { experiences: [] }, :company_id,
       :trainee, :job_seeking, :nda,
-      :graduated_on, :retired_on, :free,
+      :graduated_on, :retired_on,
       :job_seeker, :github_collaborator,
       :officekey_permission, :tag_list, :training_ends_on,
       :auto_retire, :invoice_payment, :hide_mentor_profile,

--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -33,13 +33,18 @@ class CurrentUserController < ApplicationController
       :profile_name, :profile_job, :profile_text, { authored_books_attributes: %i[id title url cover _destroy] },
       :feed_url, :country_code, :subdivision_code, { discord_profile_attributes: %i[id account_name times_url] }
     ]
-    if current_user.admin?
-      user_attribute.push(:retired_on, :graduated_on, :free, :github_collaborator, :auto_retire, :invoice_payment, :mentor, :subscription_id)
-    end
+    user_attribute.concat(admin_user_attributes) if current_user.admin?
     params.require(:user).permit(user_attribute)
   end
 
   def set_user
     @user = current_user
+  end
+
+  def admin_user_attributes
+    %i[
+      retired_on graduated_on github_collaborator
+      auto_retire invoice_payment mentor subscription_id
+    ]
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -64,7 +64,6 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     @user.course_id = params[:user][:course_id] if params[:user][:course_id].present?
     @user.course_id ||= Course.first.id
-    @user.free = true if @user.trainee?
     @user.build_discord_profile
     Newspaper.publish(:user_create, { user: @user })
     if @user.staff? || @user.trainee?

--- a/app/policies/practice_policy.rb
+++ b/app/policies/practice_policy.rb
@@ -10,6 +10,6 @@ class PracticePolicy < ApplicationPolicy
   end
 
   def show?
-    user.staff? || user.free? || user.card?
+    user.staff? || user.card?
   end
 end

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -1,4 +1,4 @@
-json.(user, :id, :login_name, :name, :description, :github_account, :twitter_account, :facebook_url, :blog_url, :job_seeker, :free, :job, :os, :email, :roles, :primary_role, :icon_title, :cached_completed_percentage, :completed_fraction, :graduated_on)
+json.(user, :id, :login_name, :name, :description, :github_account, :twitter_account, :facebook_url, :blog_url, :job_seeker, :job, :os, :experience, :email, :roles, :primary_role, :icon_title, :cached_completed_percentage, :completed_fraction, :graduated_on)
 json.tag_list user.tags.pluck(:name)
 json.url user_url(user)
 json.updated_at l(user.updated_at)

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -116,8 +116,6 @@
             .form-item-block__item
               = render 'users/form/trainee', f: f
             .form-item-block__item
-              = render 'users/form/free', f: f
-            .form-item-block__item
               = render 'users/form/mentor', f: f
 
       .form-item-block#external-services

--- a/app/views/users/_user_secret_attributes.html.slim
+++ b/app/views/users/_user_secret_attributes.html.slim
@@ -13,8 +13,6 @@
       .user-metas__item-value
         - if user.card?
           | 課金中
-        - elsif user.free
-          = User.human_attribute_name :free
         - else
           | 要確認
     .user-metas__item

--- a/app/views/users/form/_free.html.slim
+++ b/app/views/users/form/_free.html.slim
@@ -1,6 +1,0 @@
-.block-checks.is-1-item
-  .block-checks__item
-    .a-block-check.is-checkbox
-      = f.check_box :free, class: 'a-toggle-checkbox'
-      = f.label :free, class: 'a-block-check__label is-ta-left' do
-        = User.human_attribute_name :free

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -87,7 +87,6 @@ ja:
         job_seeking: 就職活動中
         hibernated_at: 休会日時
         retired_on: 退会日
-        free: 無料
         avatar: ユーザーアイコン
         retire_reasons: 選択入力の退会理由
         retire_reason: 自由記入の退会理由

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -265,7 +265,6 @@ muryou:
   job: office_worker
   os: mac
   organization: 無料大学
-  free: true
   unsubscribe_email_token: V8qOxq82MrYh6P_jwx9CQQ
   updated_at: "2014-01-01 00:00:10"
   created_at: "2014-01-01 00:00:10"
@@ -291,7 +290,6 @@ kensyu:
   experiences: 6
   organization: 研修大学
   trainee: true
-  free: true
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
@@ -318,7 +316,6 @@ kensyu-end-within-24-hour:
   experiences: 6
   organization: 研修大学
   trainee: true
-  free: true
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
@@ -345,7 +342,6 @@ kensyu-end-within-1-week:
   experiences: 6
   organization: 研修大学
   trainee: true
-  free: true
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
@@ -372,7 +368,6 @@ kensyu-end-over-1-week:
   experiences: 6
   organization: 研修大学
   trainee: true
-  free: true
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
@@ -399,7 +394,6 @@ kensyu-not-setting-end-date:
   experiences: 6
   organization: 研修大学
   trainee: true
-  free: true
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
@@ -823,7 +817,6 @@ kensyuowata:
   experiences: 6
   organization: 研修大学
   trainee: true
-  free: true
   retired_on: "2015-01-01"
   unsubscribe_email_token: Vb3zzFj5oO4zcwOURn14qW
   updated_at: "2014-01-01 00:00:11"
@@ -1099,7 +1092,6 @@ nocompanykensyu: # 所属企業のない研修生
   os: mac
   experiences: 6
   trainee: true
-  free: true
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
@@ -1119,7 +1111,6 @@ neverlogin: # 1度もログインしたことがないユーザー
   experiences: 6
   country_code: US
   subdivision_code: HI
-  free: true
   updated_at: "2022-07-11 00:00:00"
   created_at: "2022-07-11 00:00:00"
   sent_student_followup_message: true

--- a/db/migrate/20240821190009_remove_free_from_users.rb
+++ b/db/migrate/20240821190009_remove_free_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveFreeFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :free, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_12_074411) do
+ActiveRecord::Schema.define(version: 2024_08_21_190009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -733,7 +733,6 @@ ActiveRecord::Schema.define(version: 2024_07_12_074411) do
     t.integer "experience"
     t.text "retire_reason"
     t.boolean "trainee", default: false, null: false
-    t.boolean "free", default: false, null: false
     t.string "customer_id"
     t.boolean "job_seeking", default: false, null: false
     t.string "subscription_id"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -284,7 +284,6 @@ muryou:
   job: office_worker
   os: mac
   organization: 無料大学
-  free: true
   unsubscribe_email_token: V8qOxq82MrYh6P_jwx9CQQ
   updated_at: "2014-01-01 00:00:10"
   created_at: "2014-01-01 00:00:10"
@@ -310,7 +309,6 @@ kensyu:
   organization: 研修大学
   trainee: true
   training_ends_on: "2022-04-01"
-  free: true
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 00:00:11"
   created_at: "2014-01-01 00:00:11"
@@ -508,7 +506,6 @@ kensyuowata: # 研修が終わったユーザー
   experiences: 6
   organization: 研修大学
   trainee: true
-  free: true
   retired_on: "2015-01-01"
   unsubscribe_email_token: Vb3zzFj5oO4zcwOURn14qW
   updated_at: "2014-01-01 00:00:11"
@@ -755,7 +752,6 @@ nocompanykensyu: # 所属企業のない研修生
   os: mac
   experiences: 6
   trainee: true
-  free: true
   unsubscribe_email_token: VbTzzFj5oO4zHqOURnO4qA
   updated_at: "2014-01-01 01:00:11"
   created_at: "2014-01-01 01:00:11"
@@ -773,7 +769,6 @@ neverlogin: # 1度もログインしたことがないユーザー
   course: course1
   os: mac
   experiences: 6
-  free: true
   updated_at: "2022-07-11 00:00:00"
   created_at: "2022-07-11 00:00:00"
   sent_student_followup_message: true
@@ -813,7 +808,6 @@ neverlogin: # 1度もログインしたことがないユーザー
   experiences: 6
   country_code: US
   subdivision_code: HI
-  free: true
   updated_at: "2022-07-11 00:00:00"
   created_at: "2022-07-11 00:00:00"
   sent_student_followup_message: true

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -128,17 +128,6 @@ class CurrentUserTest < ApplicationSystemTestCase
     assert_match user.reload.graduated_on.to_s, '2022-05-01'
   end
 
-  test 'update admin user\'s free' do
-    user = users(:komagata)
-
-    visit_with_auth '/current_user/edit', 'komagata'
-    check '無料', allow_label_click: true
-
-    click_on '更新する'
-
-    assert user.reload.free
-  end
-
   test 'update admin user\'s github_collaborator' do
     user = users(:komagata)
 


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/7869

## 概要
FBCが無料でテスト運営していたときに使用していた無料フラグは、現在では不要です。
そのため、DBとUIから削除しました。

UIの削除該当箇所は以下です。
- ユーザー登録情報変更ページ(表示にはAdminユーザーでのログインが必須)
  - `/admin/users/user.id/edit`
- ユーザのプロフィールページ
  - `users/user.id`

### 修正前
#### ユーザー登録情報変更ページ
<img width="512" alt="スクリーンショット 2024-07-06 21 55 03" src="https://github.com/fjordllc/bootcamp/assets/43412616/8653e802-75fc-4263-a22b-e6c20f9c6871">

#### ユーザのプロフィールページ
<img width="485" alt="スクリーンショット 2024-07-06 22 12 32" src="https://github.com/fjordllc/bootcamp/assets/43412616/9821779c-0336-4a6b-b3bd-383d2b0743f5">

### 修正後
#### ユーザー登録情報変更ページ
<img width="521" alt="スクリーンショット 2024-07-06 16 27 11" src="https://github.com/fjordllc/bootcamp/assets/43412616/851aa799-4cbd-4e9e-80ca-3a4ea80d9b52">


#### ユーザのプロフィールページ
<img width="625" alt="スクリーンショット 2024-07-06 16 28 21" src="https://github.com/fjordllc/bootcamp/assets/43412616/ab8cbf0f-7e49-4040-9ae7-57b604b4afc3">

## 変更確認方法
1. `feature/delete-user-free-flag`をローカルに取り込む
2. `bin/rails db:migrate`でマイグレーションによる変更をローカルDBに反映させる
3. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
4. 管理者でログインする(ID: komagata)
5. 該当ページにアクセスし、変更が反映されていることを確認する

### 確認事項
- ユーザー登録情報変更ページ(表示にはAdminユーザーでのログインが必須)
  - `/admin/users/user.id/edit`にアクセスし、特殊ユーザー属性に"無料"のラベルを持ったチェックボックスが表示されていないこと
- ユーザのプロフィールページ
  - 課金状態が無料だったユーザーのプロフィールページ(`users/746986380`)にアクセスし、課金状態が**要確認**になっていること
  - ⚠️**要確認**が正しい表示です。修正前は、課金中/無料/要確認の3つの条件で表示を切り替えていましたが、今回の修正で"無料"の条件が削除されるため。