### PR TITLE
ユーザー検索で休会・退会ユーザーも引っかかるようにする

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,6 @@ class UsersController < ApplicationController
              .preload(:avatar_attachment, :course, :taggings)
              .order(updated_at: :desc)
 
-    @users = @users.unhibernated.unretired unless @target.in? %w[hibernated retired]
     if params[:search_word]
       search_user = SearchUser.new(word: params[:search_word], users: @users, target: @target)
       @users = search_user.search

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -5,10 +5,15 @@ module Searchable
 
   COLUMN_NAMES_FOR_SEARCH_USER_ID = %i[user_id last_updated_user_id].freeze
 
+  included do
+    # 拡張する場合はこのスコープを上書きする
+    scope :search_by_keywords_scope, -> { all }
+  end
+
   # rubocop:disable Metrics/BlockLength
   class_methods do
     def search_by_keywords(searched_values = {})
-      ransack(**params_for_keyword_search(searched_values)).result
+      ransack(**params_for_keyword_search(searched_values)).result.search_by_keywords_scope
     end
 
     def columns_for_keyword_search(*column_names)

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -5,15 +5,10 @@ module Searchable
 
   COLUMN_NAMES_FOR_SEARCH_USER_ID = %i[user_id last_updated_user_id].freeze
 
-  included do
-    # 拡張する場合はこのスコープを上書きする
-    scope :search_by_keywords_scope, -> { all }
-  end
-
   # rubocop:disable Metrics/BlockLength
   class_methods do
     def search_by_keywords(searched_values = {})
-      ransack(**params_for_keyword_search(searched_values)).result.search_by_keywords_scope
+      ransack(**params_for_keyword_search(searched_values)).result
     end
 
     def columns_for_keyword_search(*column_names)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -394,7 +394,6 @@ class User < ApplicationRecord
       .order(last_activity_at: :desc)
       .tagged_with(tag_name)
   }
-  scope :search_by_keywords_scope, -> { unretired }
   scope :delayed, lambda {
     sql = Learning.select(:user_id, 'MAX(updated_at) AS completed_at')
                   .where(status: :complete)

--- a/test/models/search_user_test.rb
+++ b/test/models/search_user_test.rb
@@ -13,11 +13,11 @@ class SearchUserTest < ActiveSupport::TestCase
     assert_not_includes searched_users, komagata
   end
 
-  test 'retired user is excluded when not required' do
+  test 'retired user is included when not required' do
     yameo = users(:yameo)
     search_user = SearchUser.new(word: 'yame', require_retire_user: false)
 
-    assert_not_includes search_user.search, yameo
+    assert_includes search_user.search, yameo
   end
 
   test 'retired user is included when required' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -337,12 +337,6 @@ class UserTest < ActiveSupport::TestCase
     assert Following.find_by(follower_id: kimura.id, followed_id: hatsuno.id)
   end
 
-  test "don't return retired user data" do
-    yameo = users(:yameo)
-    result = Searcher.search(yameo.name)
-    assert_not_includes(result, yameo)
-  end
-
   test 'return not retired user data' do
     hajime = users(:hajime)
     result = Searcher.search(hajime.name)

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -190,4 +190,52 @@ class SearchablesTest < ApplicationSystemTestCase
     find('#test-search').click
     assert_no_css 'img.card-list-item-meta__icon.a-user-icon'
   end
+
+  test 'search with all scope includes retired user' do
+    visit_with_auth '/', 'hatsuno'
+    within('form[name=search]') do
+      select 'すべて'
+      fill_in 'word', with: 'yameo'
+    end
+    find('#test-search').click
+    within('.card-list-item.is-user') do
+      assert_text 'yameo'
+    end
+  end
+
+  test 'search with all scope includes hibernated user' do
+    visit_with_auth '/', 'hatsuno'
+    within('form[name=search]') do
+      select 'すべて'
+      fill_in 'word', with: 'kyuukai'
+    end
+    find('#test-search').click
+    within('.card-list-item.is-user') do
+      assert_text 'kyuukai'
+    end
+  end
+
+  test 'search with user scope includes retired user' do
+    visit_with_auth '/', 'hatsuno'
+    within('form[name=search]') do
+      select 'ユーザー'
+      fill_in 'word', with: 'yameo'
+    end
+    find('#test-search').click
+    within('.card-list-item.is-user') do
+      assert_text 'yameo'
+    end
+  end
+
+  test 'search with user scope includes hibernated user' do
+    visit_with_auth '/', 'hatsuno'
+    within('form[name=search]') do
+      select 'ユーザー'
+      fill_in 'word', with: 'kyuukai'
+    end
+    find('#test-search').click
+    within('.card-list-item.is-user') do
+      assert_text 'kyuukai'
+    end
+  end
 end

--- a/test/system/user/tags_test.rb
+++ b/test/system/user/tags_test.rb
@@ -150,7 +150,7 @@ class User::TagsTest < ApplicationSystemTestCase
     assert_includes all('.tag-links__item-link').map(&:text), 'ハッシュハッシュ'
   end
 
-  test 'hibernated users are not displayed in the user list by tag' do
+  test 'hibernated users are displayed in the user list by tag' do
     user = users(:kensyu)
     tag_name = acts_as_taggable_on_tags('guitar').name.to_s
 
@@ -179,8 +179,8 @@ class User::TagsTest < ApplicationSystemTestCase
     assert_text '休会手続きが完了しました'
 
     visit_with_auth users_tag_path(tag_name), 'komagata'
-    assert_text "タグ「#{tag_name}」のユーザー（1）"
-    assert_no_selector ".users-item__icon img[title='#{user.login_name} (#{user.name})']"
+    assert_text "タグ「#{tag_name}」のユーザー（2）"
+    assert_selector ".users-item__icon img[title='#{user.login_name} (#{user.name})']"
 
     visit_with_auth users_tags_path, 'komagata'
     displayed_users_number = find('.user-group__count').text[/\d+/]
@@ -188,7 +188,7 @@ class User::TagsTest < ApplicationSystemTestCase
     assert_no_selector ".a-user-icons__items img[title='#{user.login_name} (#{user.name})']"
   end
 
-  test 'retired users are not displayed in the user list by tag' do
+  test 'retired users are displayed in the user list by tag' do
     user = users(:kensyu)
     tag_name = acts_as_taggable_on_tags('guitar').name.to_s
 
@@ -210,8 +210,8 @@ class User::TagsTest < ApplicationSystemTestCase
     assert_text '退会処理が完了しました'
 
     visit_with_auth users_tag_path(tag_name), 'komagata'
-    assert_text "タグ「#{tag_name}」のユーザー（1）"
-    assert_no_selector ".users-item__icon img[title='#{user.login_name} (#{user.name})']"
+    assert_text "タグ「#{tag_name}」のユーザー（2）"
+    assert_selector ".users-item__icon img[title='#{user.login_name} (#{user.name})']"
 
     visit_with_auth users_tags_path, 'komagata'
     displayed_users_number = find('.user-group__count').text[/\d+/]

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -490,7 +490,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'search only trainee when target is trainee' do
     visit_with_auth '/users?target=trainee', 'komagata'
-    assert_selector '.users-item', count: 2
+    assert_selector '.users-item', count: 3 # 元々2だったが、退会ユーザーがカウントされるようになった影響で+1増えた
     fill_in 'js-user-search-input', with: 'Kensyu Seiko'
     find('#js-user-search-input').send_keys :return
     assert_text 'Kensyu Seiko', count: 1

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -512,7 +512,6 @@ class UsersTest < ApplicationSystemTestCase
     assert_text 'Machida Teppei', count: 1
   end
 
-
   test 'find retired users from all users when target is all' do
     visit_with_auth '/users?target=all', 'komagata'
     fill_in 'js-user-search-input', with: 'yameo'

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -512,6 +512,25 @@ class UsersTest < ApplicationSystemTestCase
     assert_text 'Machida Teppei', count: 1
   end
 
+
+  test 'find retired users from all users when target is all' do
+    visit_with_auth '/users?target=all', 'komagata'
+    fill_in 'js-user-search-input', with: 'yameo'
+    find('#js-user-search-input').send_keys :return
+    within('.users-item__header-end') do
+      assert_text 'yameo'
+    end
+  end
+
+  test 'find hibernated users from all users when target is all' do
+    visit_with_auth '/users?target=all', 'komagata'
+    fill_in 'js-user-search-input', with: 'kyuukai'
+    find('#js-user-search-input').send_keys :return
+    within('.users-item__header-end') do
+      assert_text 'kyuukai'
+    end
+  end
+
   test "don't show incremental search when target's users aren't exist" do
     visit_with_auth '/users?target=job_seeking', 'komagata'
     assert_no_selector '.users-item'


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/7396

## 概要
以下2つのケースでユーザー検索をする際に休会・退会ユーザーがひっかかるようにしました。
- 1️⃣ページ右上検索窓からの検索
- 2️⃣ユーザー一覧の絞り込みからの検索

### 1️⃣ページ右上検索窓からの検索
**検索範囲が「すべて」「ユーザー」どちらの場合でも、退会ユーザーがひっかかるように修正しました**

<img width="853" alt="スクリーンショット 2024-07-08 19 07 09 2" src="https://github.com/fjordllc/bootcamp/assets/43412616/0085cb4c-c904-4f49-97e1-d08274354475">

#### (1)検索範囲に「すべて」を指定
|  | 休会ユーザー | 退会ユーザー | 
| ---- | ---- |---- |
| 修正前 | ○ | × |
| **修正後** | ○ | ⭕️ |

#### (2)検索範囲に「ユーザー」を指定
|  | 休会ユーザー | 退会ユーザー | 
| ---- | ---- |---- |
| 修正前 | ○ | × |
| **修正後** | ○ | ⭕️ |

### 2️⃣ユーザー一覧の絞り込みからの検索
**絞り込みで休会ユーザー・退会ユーザー両方ともひっかかるように修正しました**

<img width="916" alt="スクリーンショット 2024-07-08 19 09 11 2" src="https://github.com/fjordllc/bootcamp/assets/43412616/55e51086-e3df-496e-b309-f9be5d58b484">

|  | 休会ユーザー | 退会ユーザー | 
| ---- | ---- |---- |
| 修正前 | × | × |
| **修正後** | ⭕️ | ⭕️ |

## 変更確認方法
1. `feature/user-search-include-all-users`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. 管理者でログインする(ID: komagata)
4. 該当ページにアクセスし、変更が反映されていることを確認する
  - トップページ: http://localhost:3000/
  - ユーザー一覧: http://localhost:3000/users?target=all

### 確認事項
- ページ右上検索窓からの検索
  - トップページにアクセスする
  - 検索範囲にすべてorユーザーを指定して、退会ユーザー名「yameo」を検索する
- ユーザー一覧からの検索
  - 検索範囲を全員にする
  - 休会ユーザー名「kyuukai」を検索する
  - 退会ユーザー名「yameo」を検索する


## ScreenShot
### ページ右上検索窓からの検索
#### 修正前:「すべて」「ユーザー」どちらの指定でも退会ユーザーが引っかからない
<img width="871" alt="スクリーンショット 2024-07-08 19 10 59" src="https://github.com/fjordllc/bootcamp/assets/43412616/9024e2fc-086e-4d7e-88d8-1b1998cf1cc0">
<img width="871" alt="スクリーンショット 2024-07-08 19 12 14" src="https://github.com/fjordllc/bootcamp/assets/43412616/8f276862-f1a8-458c-ab77-8a8f6c44eba0">

#### 修正後:
<img width="871" alt="スクリーンショット 2024-07-08 19 07 09" src="https://github.com/fjordllc/bootcamp/assets/43412616/7642a8a5-803e-43ab-8a81-eb92925ccb9c">
<img width="871" alt="スクリーンショット 2024-07-08 19 08 11" src="https://github.com/fjordllc/bootcamp/assets/43412616/a75a0fb3-fd5c-428c-a26e-e6efe28f8b11">

### ユーザー一覧の絞り込みからの検索
#### 修正前: 絞り込みで休会ユーザー・退会ユーザー両方ともひっかからない
<img width="929" alt="スクリーンショット 2024-07-08 19 14 16" src="https://github.com/fjordllc/bootcamp/assets/43412616/ac6dc58d-15ea-4d06-812c-9d2d35c8f63d">
<img width="931" alt="スクリーンショット 2024-07-08 19 13 37" src="https://github.com/fjordllc/bootcamp/assets/43412616/2fb23d47-f156-486b-b5f2-88c5febde27c">

#### 修正後:
<img width="982" alt="スクリーンショット 2024-07-08 19 09 35" src="https://github.com/fjordllc/bootcamp/assets/43412616/0babc363-761a-4a80-ab3f-87e960b54bbe">
<img width="925" alt="スクリーンショット 2024-07-08 19 09 11" src="https://github.com/fjordllc/bootcamp/assets/43412616/0b5df0d7-746d-4189-9957-e231b54ce7b5">
