### PR TITLE
noticeのflash通知をtoastにした

### DIFF
--- a/app/javascript/stylesheets/modules/_toasts.sass
+++ b/app/javascript/stylesheets/modules/_toasts.sass
@@ -245,9 +245,13 @@ $swal2-toast-footer-font-size: 0.8em !default
 
     &.swal2-show
       animation: $swal2-toast-show-animation
+      body.is-text &
+        animation: none
 
     &.swal2-hide
       animation: $swal2-toast-hide-animation
+      body.is-text &
+        animation: none
 
     &.is-success
       background: rgba($success, .9)

--- a/app/javascript/toast.js
+++ b/app/javascript/toast.js
@@ -62,7 +62,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const type = element.dataset.type;
     const message = element.dataset.message;
 
-    // Toastを発火
     Toast.fire({
       title: message,
       customClass: {

--- a/app/javascript/toast.js
+++ b/app/javascript/toast.js
@@ -53,20 +53,20 @@ const Toast = Swal.mixin({
   position: 'top-end',
   showConfirmButton: false,
   timer: 3000,
-  timerProgressBar: true,
+  timerProgressBar: true
 })
 
 document.addEventListener('DOMContentLoaded', () => {
-  const messages = document.querySelectorAll('.js-toast');
-  messages.forEach(element => {
-    const type = element.dataset.type;
-    const message = element.dataset.message;
+  const messages = document.querySelectorAll('.js-toast')
+  messages.forEach((element) => {
+    const type = element.dataset.type
+    const message = element.dataset.message
 
     Toast.fire({
       title: message,
       customClass: {
-        popup: `is-${type}`,
-      },
+        popup: `is-${type}`
+      }
     })
-  });
-});
+  })
+})

--- a/app/javascript/toast.js
+++ b/app/javascript/toast.js
@@ -47,3 +47,27 @@ export default {
     }
   }
 }
+
+const Toast = Swal.mixin({
+  toast: true,
+  position: 'top-end',
+  showConfirmButton: false,
+  timer: 3000,
+  timerProgressBar: true,
+})
+
+document.addEventListener('DOMContentLoaded', () => {
+  const messages = document.querySelectorAll('.js-toast');
+  messages.forEach(element => {
+    const type = element.dataset.type;
+    const message = element.dataset.message;
+
+    // Toastを発火
+    Toast.fire({
+      title: message,
+      customClass: {
+        popup: `is-${type}`,
+      },
+    })
+  });
+});

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,12 +1,7 @@
 - # rubocop:disable Rails/OutputSafety
 - if notice
-  input.a-toggle-checkbox#hide-flash(type='checkbox')
-  .flash.is-notice
-    .container
-      .flash__container
-        label.flash__close(for='hide-flash')
-        p.flash__message
-          = notice.html_safe
+  - flash.each do |type, message|
+    div.flash-message.js-toast(data-type=type data-message=message)
 - if alert
   input.a-toggle-checkbox#hide-flash(type='checkbox')
   .flash.is-alert

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,6 +1,7 @@
 - # rubocop:disable Rails/OutputSafety
 - if notice
   - flash.each do |type, message|
+    - next if type != 'notice'
     .flash-message.js-toast(data-type=type data-message=message)
 - if alert
   input.a-toggle-checkbox#hide-flash(type='checkbox')

--- a/app/views/application/_flash.html.slim
+++ b/app/views/application/_flash.html.slim
@@ -1,7 +1,7 @@
 - # rubocop:disable Rails/OutputSafety
 - if notice
   - flash.each do |type, message|
-    div.flash-message.js-toast(data-type=type data-message=message)
+    .flash-message.js-toast(data-type=type data-message=message)
 - if alert
   input.a-toggle-checkbox#hide-flash(type='checkbox')
   .flash.is-alert

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -125,7 +125,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
 
     assert has_no_button? '公開'
     click_button '作成'
-    assert has_css?('p.flash__message', text: 'お知らせを作成しました')
+    assert_text 'お知らせを作成しました'
 
     visit_with_auth '/notifications', 'hatsuno'
     assert_text 'お知らせ「タイトルtest」'
@@ -135,7 +135,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     accept_confirm do
       click_link '削除'
     end
-    assert has_css?('p.flash__message', text: 'お知らせを削除しました')
+    assert_text 'お知らせを削除しました'
 
     visit_with_auth '/notifications', 'hatsuno'
     assert_no_text 'お知らせ「タイトルtest」'


### PR DESCRIPTION
- https://github.com/fjordllc/bootcamp/issues/7954
- https://github.com/fjordllc/bootcamp/issues/6786

flashのnoticeの表示を

![image](https://github.com/fjordllc/bootcamp/assets/168265/a15dcf2e-0a0f-4969-8005-1ad8bdd24ce7)

このようにしました。「Toast」とば呼ばれているUIです。

> UIで「Toast」と呼ばれるアラートは、トーストパンがトースターからポップアップする動作に由来しています。このタイプの通知は画面の一部に一時的に表示され、その後自動的に消える特性があります。トーストのように現れては消えることから、この名前が付けられました。主にユーザーに短い情報やフィードバックを提供するのに使用され、操作の妨げにならないように設計されています。

これにしたら、テストが落ちてしまいました。
~~原因は表示までに若干の時間がかかるため、現状のテストではそれの表示を待たないためです。
テストを修正し、テストを通してください🙏~~

https://qiita.com/jnchito/items/56ba52c9a7246fc5016a#-js%E3%81%AE%E5%AE%9F%E8%A1%8C%E3%82%92%E5%BE%85%E3%81%A3%E3%81%A6%E3%81%84%E3%81%AA%E3%81%84
伊藤さんのこの記事が参考になりそうです。

---

原因を読み間違えていました！！
詳しくは以下の @motohiro-mm さんのコメントを見てください。