### PR TITLE
担当が決まっていない提出物にメンターがコメントをした場合にアラートを出す

### DIFF
--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -54,7 +54,7 @@ export default {
           console.warn(error)
         })
     },
-    checkProduct(productId, currentUserId, url, method, token) {
+    checkProduct(productId, currentUserId, url, method, token, commented) {
       const params = {
         product_id: productId,
         current_user_id: currentUserId
@@ -81,6 +81,9 @@ export default {
             this.id = json.checker_id
             this.name = json.checker_name
             if (this.id !== null) {
+              if (commented) {
+                alert('提出物の担当になりました。') // 担当が決まっていない提出物にメンターがコメントをした場合にアラートを出す
+              }
               this.toast('担当になりました。')
             } else {
               this.toast('担当から外れました。')

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -54,7 +54,14 @@ export default {
           console.warn(error)
         })
     },
-    checkProduct(productId, currentUserId, url, method, token, commented) {
+    checkProduct(
+      productId,
+      currentUserId,
+      url,
+      method,
+      token,
+      isChargeFromComment
+    ) {
       const params = {
         product_id: productId,
         current_user_id: currentUserId
@@ -81,7 +88,7 @@ export default {
             this.id = json.checker_id
             this.name = json.checker_name
             if (this.id !== null) {
-              if (commented) {
+              if (isChargeFromComment) {
                 alert('提出物の担当になりました。') // 担当が決まっていない提出物にメンターがコメントをした場合にアラートを出す
               }
               this.toast('担当になりました。')

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -301,7 +301,8 @@ export default {
           this.currentUserId,
           '/api/products/checker',
           'PATCH',
-          CSRF.getToken()
+          CSRF.getToken(),
+          true
         )
       }
     },

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 button(
   v-if='!checkerId || checkerId === currentUserId',
-  :class='["a-button", "is-block", id ? "is-warning" : "is-secondary", checkableType ? "is-sm" : "is-sm"]',
+  :class='["a-button", "is-block", productCheckerId ? "is-warning" : "is-secondary", checkableType ? "is-sm" : "is-sm"]',
   @click='checkInCharge')
   i(
     v-if='!checkerId || checkerId === currentUserId',

--- a/app/javascript/product_checker.vue
+++ b/app/javascript/product_checker.vue
@@ -64,7 +64,8 @@ export default {
         this.currentUserId,
         '/api/products/checker',
         this.productCheckerId ? 'DELETE' : 'PATCH',
-        CSRF.getToken()
+        CSRF.getToken(),
+        false
       )
     }
   }

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -140,6 +140,7 @@ class CommentsTest < ApplicationSystemTestCase
       fill_in('new_comment[description]', with: 'test')
     end
     click_button 'コメントする'
+    accept_alert '提出物の担当になりました。'
     assert_text 'test'
     assert_text 'Watch中'
   end

--- a/test/system/product/checker_test.rb
+++ b/test/system/product/checker_test.rb
@@ -14,6 +14,7 @@ class Product::CheckerTest < ApplicationSystemTestCase
     visit "/products/#{products(:product1).id}"
 
     post_comment('担当者がいない提出物の場合、担当者になる')
+    accept_alert '提出物の担当になりました。'
     assert_text '担当になりました。'
     assert_text '担当から外れる'
 

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -106,6 +106,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{product.id}", 'mentormentaro'
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
+    accept_alert '提出物の担当になりました。'
     within('.thread-comment.is-latest') do
       assert_text 'mentormentaro'
       assert_text 'test'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -359,6 +359,7 @@ class ProductsTest < ApplicationSystemTestCase
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
     fill_in 'new_comment[description]', with: 'コメントしたら担当になるテスト'
     click_button 'コメントする'
+    accept_alert '提出物の担当になりました。'
     assert_text 'コメントしたら担当になるテスト'
     visit current_path
     assert_text '担当から外れる'


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/7943

## 概要
現在、担当が決まっていない提出物にメンターがコメントをした際には、緑のFlashで"担当になりました"と通知が出ます。
通知を見逃しがちなので、今回の変更ではブラウザのアラート表示後に緑のFlashで通知を出しました。

## 変更確認方法
1. `feature/alert-dialog-on-unassigned-products`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. 管理者でログインする(ID: komagata)
4. [提出物一覧ページ](http://localhost:3000/products/unassigned)にアクセスする
5. 担当が決まっていない提出物の詳細ページにアクセスする
6. ページ下部のコメントフォームからコメントを投稿する

#### 確認事項
- コメントをする提出物の担当が決まっていない状態でコメントをすると以下が発生すること
  - "提出物の担当になりました。"の文言をもつブラウザのアラートが表示されること
  - アラートのOKボタンを押下するとアラートの表示が消えること
  - アラートの表示が消えると"担当になりました"の文言を持つ緑のFlashが表示されること

### Screenshot
#### 修正前
担当が決まっていない提出物にコメントをすると緑のFlashが出る

https://github.com/fjordllc/bootcamp/assets/43412616/672d169d-2169-47e1-a198-5228fc07d741

### 今回の修正
アラートのOKボタン押下後に緑のFlashが出る

https://github.com/fjordllc/bootcamp/assets/43412616/9da18ebb-435c-4fcc-b716-590aad839c18


