### PR TITLE
ブログ記事を published_at 順に並べる

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -67,7 +67,8 @@ class ArticlesController < ApplicationController
   end
 
   def list_articles
-    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob }).order(published_at: :desc, created_at: :desc).page(params[:page])
+    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
+                      .order(published_at: :desc, created_at: :desc).page(params[:page])
     admin_or_mentor_login? ? articles : articles.where(wip: false)
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -67,7 +67,7 @@ class ArticlesController < ApplicationController
   end
 
   def list_articles
-    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob }).order(created_at: :desc).page(params[:page])
+    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob }).order(published_at: :desc).page(params[:page])
     admin_or_mentor_login? ? articles : articles.where(wip: false)
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -67,7 +67,7 @@ class ArticlesController < ApplicationController
   end
 
   def list_articles
-    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob }).order(published_at: :desc).page(params[:page])
+    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob }).order(published_at: :desc, created_at: :desc).page(params[:page])
     admin_or_mentor_login? ? articles : articles.where(wip: false)
   end
 

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -5,6 +5,7 @@ require 'application_system_test_case'
 class ArticlesTest < ApplicationSystemTestCase
   setup do
     @article = articles(:article1)
+    @article2 = articles(:article2)
     @article3 = articles(:article3)
   end
 
@@ -411,5 +412,16 @@ class ArticlesTest < ApplicationSystemTestCase
 
     visit '/articles.atom'
     assert_no_text 'WIPの記事は atom feed に表示されない'
+  end
+
+  test 'WIP articles are listed first in desc order' do
+    visit_with_auth articles_path, 'komagata'
+    titles = all('h2.thumbnail-card__title').map(&:text)
+
+    within '.articles__items' do
+      assert_includes titles[0], @article3.title
+      assert_includes titles[1], @article2.title
+      assert_includes titles[2], @article.title
+    end
   end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -418,10 +418,8 @@ class ArticlesTest < ApplicationSystemTestCase
     visit_with_auth articles_path, 'komagata'
     titles = all('h2.thumbnail-card__title').map(&:text)
 
-    within '.articles__items' do
-      assert_includes titles[0], @article3.title
-      assert_includes titles[1], @article2.title
-      assert_includes titles[2], @article.title
-    end
+    assert_includes titles[0], @article3.title
+    assert_includes titles[1], @article2.title
+    assert_includes titles[2], @article.title
   end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -418,8 +418,6 @@ class ArticlesTest < ApplicationSystemTestCase
     visit_with_auth articles_path, 'komagata'
     titles = all('h2.thumbnail-card__title').map(&:text)
 
-    assert_includes titles[0], @article3.title
-    assert_includes titles[1], @article2.title
-    assert_includes titles[2], @article.title
+    assert_equal titles, ["WIP#{@article3.title}", @article2.title, @article.title]
   end
 end


### PR DESCRIPTION
## issue
- https://github.com/fjordllc/bootcamp/issues/7940

## 概要
現在ブログ記事は公開日時の降順で並んでおらず、[2021年の記事が先頭に表示されて](https://bootcamp.fjord.jp/articles)います。
この問題を解決するために、本PRではブログ記事を公開日時の降順で並ぶ変更を加えました。

また、メンター・管理者のみ表示されるWIP記事は[仕様についての認識擦り合わせ](https://github.com/fjordllc/bootcamp/issues/7940#issuecomment-2216503489)から以下の条件で表示させました。

- WIP記事群はブログ記事一覧の先頭に存在する
- 一度公開してWIPにした記事は、WIP記事群内での並びは考慮しない(ほぼ発生しないユースケースのため)

### 修正前
![ブログ記事の並び順(main)](https://github.com/fjordllc/bootcamp/assets/43412616/d3c84a9a-1164-40ec-99bb-1b8eb925fbbf)

### 修正後
![ブログ記事並び替え後](https://github.com/fjordllc/bootcamp/assets/43412616/ab92cce9-bd4a-4b31-965c-94f4a6572f99)

## 変更確認方法
1. `feature/order-articles-by-published_at-desc`をローカルに取り込む
3. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
4. 管理者でログインする(ID: komagata)
5. [ブログ一覧ページ](http://localhost:3000/articles)にアクセスし、変更が反映されていることを確認する

### 確認事項
- 既に存在するブログの降順確認
  - [ブログ一覧ページ](http://localhost:3000/articles)で以下が確認できること
    - WIP記事群がブログ記事の先頭に存在すること
    - 公開記事が公開日時の降順(最新記事が先頭にくる)で表示されていること
- 作成したブログの降順確認
  - 公開日時に2021年(過去日)を指定したブログの作成
    - [ブログ作成ページ](http://localhost:3000/articles/new)にアクセスし、フォームに任意の値を入力しWIPボタンを押下する
    - 押下後に自動で編集ページに遷移する。ページ下部の"記事公開日時を変更"ボタンから2021年を指定し、公開するボタンを押下する
    -  [ブログ一覧ページ](http://localhost:3000/articles)で作成記事が一覧の最後に表示されていること
  - WIP記事の作成
    -  [ブログ作成ページ](http://localhost:3000/articles/new)にアクセスし、フォームに任意の値を入力しWIPボタンを押下する
    -  [ブログ一覧ページ](http://localhost:3000/articles)で作成したWIP記事がWIP記事群に存在すること
