### PR TITLE
ブログサムネイルのリサイズ方法を変更

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -39,7 +39,7 @@ class Article < ApplicationRecord
 
   def prepared_thumbnail_url(thumbnail_size = THUMBNAIL_SIZE)
     if thumbnail.attached?
-      thumbnail.variant(resize_to_limit: thumbnail_size).processed.url
+      thumbnail.variant(resize_to_fill: thumbnail_size).processed.url
     else
       image_url('/ogp/blank.svg')
     end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6415
### 関連PR

- https://github.com/fjordllc/bootcamp/pull/6483


## 概要
https://github.com/fjordllc/bootcamp/pull/6483#issuecomment-2018841300 が仕様です。
関連PRでリサイズの処理をモデル化していただいていたが、画像ライブラリの変更に伴いリサイズのオプションが使えるようになったため、そちらを利用することになりました。
画像ライブラリの変更 -> https://github.com/fjordllc/bootcamp/pull/7397
リサイズオプションについて -> [9 画像を変形する](https://railsguides.jp/active_storage_overview.html#%E7%94%BB%E5%83%8F%E3%82%92%E5%A4%89%E5%BD%A2%E3%81%99%E3%82%8B)
今回使用した `resize_to_fill`オプションの説明は https://github.com/fjordllc/bootcamp/pull/6483#issuecomment-2019575820 がわかりやすいです。


## 変更確認方法

1. `chore/constantize-size-of-thumbnails-in-blog`をローカルに取り込む
2. `foreman start -f Procfile.dev`にkomagataでログイン
3. 下記のリンク内の画像それぞれをブログのサムネイルにし投稿後、想定されるトリミング結果になるか確認。
https://codepen.io/machida/pen/BaEZYMZ
https://codepen.io/machida/pen/yLrXvqE

## Screenshot
左が横長、右が縦長です。

### 変更前

<img width="1662" alt="スクリーンショット 2024-07-22 22 29 32" src="https://github.com/user-attachments/assets/965a3926-0783-4ded-8b91-867d69408bff">



### 変更後

<img width="1662" alt="スクリーンショット 2024-07-22 22 31 14" src="https://github.com/user-attachments/assets/427d67df-e9c9-47d0-93b7-690e142b19ff">




