### PR TITLE
質問作成で、新規保存時にバリデーションエラーが発生すると、選択した値が取り消される問題を修正

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -47,14 +47,11 @@ class QuestionsController < ApplicationController
 
   def new
     @question = Question.new
-    @options_of_selections = { practice: { selected: params[:practice_id], include_blank: 'プラクティス選択なし' },
-                               user: { selected: current_user.id } }
+    @question.practice_id = params[:practice_id]
+    @question.user = current_user
   end
 
-  def edit
-    @options_of_selections = { practice: { include_blank: 'プラクティス選択なし' },
-                               user: {} }
-  end
+  def edit; end
 
   def create
     @question = Question.new(question_params)
@@ -64,8 +61,6 @@ class QuestionsController < ApplicationController
       Newspaper.publish(:question_create, { question: @question })
       redirect_to Redirection.determin_url(self, @question), notice: @question.generate_notice_message(:create)
     else
-      @options_of_selections = { practice: { selected: @question.practice_id, include_blank: 'プラクティス選択なし' },
-                                 user: { selected: @question.user.id } }
       render :new
     end
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -47,9 +47,14 @@ class QuestionsController < ApplicationController
 
   def new
     @question = Question.new
+    @options_of_selections = { practice: { selected: params[:practice_id], include_blank: 'プラクティス選択なし' },
+                               user: { selected: current_user.id } }
   end
 
-  def edit; end
+  def edit
+    @options_of_selections = { practice: { include_blank: 'プラクティス選択なし' },
+                               user: {} }
+  end
 
   def create
     @question = Question.new(question_params)
@@ -59,6 +64,8 @@ class QuestionsController < ApplicationController
       Newspaper.publish(:question_create, { question: @question })
       redirect_to Redirection.determin_url(self, @question), notice: @question.generate_notice_message(:create)
     else
+      @options_of_selections = { practice: { selected: @question.practice_id, include_blank: 'プラクティス選択なし' },
+                                 user: { selected: @question.user.id } }
       render :new
     end
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -46,9 +46,7 @@ class QuestionsController < ApplicationController
   end
 
   def new
-    @question = Question.new
-    @question.practice_id = params[:practice_id]
-    @question.user = current_user
+    @question = Question.new(practice_id: params[:practice_id], user_id: current_user.id)
   end
 
   def edit; end

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -8,11 +8,9 @@
             .form-item
               = f.label :practice, class: 'a-form-label'
               .select-practices
-                - include_blank = 'プラクティス選択なし'
-                - options = question.new_record? ? { selected: params[:practice_id], include_blank: } : { include_blank: }
                 = f.select :practice_id,
                   practice_options_within_course,
-                  options,
+                  options_of_selections[:practice],
                   { class: 'js-choices-singles', id: 'js-choices-practice' }
 
       .form-item
@@ -59,12 +57,11 @@
               .form-item
                 = f.label :user_id, '作成者', class: 'a-form-label'
                 .select-user
-                  - options = question.new_record? ? { selected: current_user.id } : {}
                   = f.collection_select :user_id,
                     User.order(:login_name),
                     :id,
                     :login_name,
-                    options,
+                    options_of_selections[:user],
                     { class: 'js-choices-singles', id: 'js-choices-user' }
 
   .form-actions

--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -10,7 +10,7 @@
               .select-practices
                 = f.select :practice_id,
                   practice_options_within_course,
-                  options_of_selections[:practice],
+                  { include_blank: 'プラクティス選択なし' },
                   { class: 'js-choices-singles', id: 'js-choices-practice' }
 
       .form-item
@@ -61,7 +61,7 @@
                     User.order(:login_name),
                     :id,
                     :login_name,
-                    options_of_selections[:user],
+                    {},
                     { class: 'js-choices-singles', id: 'js-choices-user' }
 
   .form-actions

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -16,4 +16,4 @@ header.page-header
 hr.a-border
 .page-body
   .container.is-xxl
-    = render 'form', question: @question
+    = render 'form', question: @question, options_of_selections: @options_of_selections

--- a/app/views/questions/edit.html.slim
+++ b/app/views/questions/edit.html.slim
@@ -16,4 +16,4 @@ header.page-header
 hr.a-border
 .page-body
   .container.is-xxl
-    = render 'form', question: @question, options_of_selections: @options_of_selections
+    = render 'form', question: @question

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -22,4 +22,4 @@ hr.a-border
           | このドキュメントを参考にして質問をしてみよう！
 .page-body
   .container.is-xxl
-    = render 'form', question: @question, categories: @categories
+    = render 'form', question: @question, options_of_selections: @options_of_selections

--- a/app/views/questions/new.html.slim
+++ b/app/views/questions/new.html.slim
@@ -22,4 +22,4 @@ hr.a-border
           | このドキュメントを参考にして質問をしてみよう！
 .page-body
   .container.is-xxl
-    = render 'form', question: @question, options_of_selections: @options_of_selections
+    = render 'form', question: @question

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -536,4 +536,21 @@ class QuestionsTest < ApplicationSystemTestCase
     click_button '更新する'
     assert_selector '.a-user-name', text: 'hatsuno (ハツノ シンジ)'
   end
+
+  test 'retain selected values when validation errors occur' do
+    visit_with_auth new_question_path, 'komagata'
+    within '.select-practices' do
+      find('.choices__inner').click
+      find('#choices--js-choices-practice-item-choice-12', text: 'sshdでパスワード認証を禁止にする').click
+    end
+    within '.select-user' do
+      find('.choices__inner').click
+      find('#choices--js-choices-user-item-choice-12', text: 'hatsuno').click
+    end
+    click_button 'WIP'
+
+    assert_text '入力内容にエラーがありました'
+    assert_text 'sshdでパスワード認証を禁止にする'
+    assert_text 'hatsuno'
+  end
 end


### PR DESCRIPTION
## Issue

- #7881 

## 概要

質問作成で新規保存時にバリデーションエラーが発生すると、選択した値（以下の２箇所）が取り消される問題を修正

- プラクティス
- 質問の作成者（メンターまたは admin のみ表示される）

## 変更確認方法

1. `bug/retain-selected-values-when-validation-errors-occur`をローカルに取り込む
2. メンターまたは admin でログインし、[\(development\) 質問作成 \| FBC](http://localhost:3000/questions/new)（`http://localhost:3000/questions/new`）にアクセスする
3. 以下の２箇所を「初期値以外」に変更する。
   - プラクティス：基本の初期値は`プラクティス選択なし`
   - 作成者：初期値はログインユーザー
4. 「タイトル」と「質問文」は空欄のまま、`WIP`ボタンを押し、バリデーションエラーを発生させる
5. 上記3で選択した各箇所が初期値にならず、値が保持されていることを確認する

## Screenshot

（表示追加等の変更はない為、省略します）

### 変更前

### 変更後

