### PR TITLE
未ログイン時のQ&A個別ページのtitleタグの文字数を制限

### DIFF
--- a/app/views/unauthorized/_unauthorized_header.html.slim
+++ b/app/views/unauthorized/_unauthorized_header.html.slim
@@ -11,3 +11,4 @@ header.unauthorized-header
         | 」
       title
         = title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"
+        - set_meta_tags og: { title: "Q&A: #{@question.title}" }

--- a/app/views/unauthorized/_unauthorized_header.html.slim
+++ b/app/views/unauthorized/_unauthorized_header.html.slim
@@ -9,3 +9,5 @@ header.unauthorized-header
       = title
       span.font-thin
         | 」
+      title
+        = title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"

--- a/app/views/unauthorized/_unauthorized_header.html.slim
+++ b/app/views/unauthorized/_unauthorized_header.html.slim
@@ -1,3 +1,5 @@
+- title "Q&A: #{truncate(title, length: 35, omission: '...')}"
+- set_meta_tags og: { title: "Q&A: #{title}" }
 header.unauthorized-header
   .container
     = image_tag('shared/piyo.svg', alt: 'フィヨルドブートキャンプのキャラクター画像', class: 'unauthorized-header__image')
@@ -9,6 +11,3 @@ header.unauthorized-header
       = title
       span.font-thin
         | 」
-      title
-        = title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"
-        - set_meta_tags og: { title: "Q&A: #{@question.title}" }

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -5,8 +5,8 @@ question1:
     どのエディターを使うのが一番良いでしょうか？
   user: machida
   practice: practice1
-  created_at: '2022-01-01'
-  published_at: '2022-01-01'
+  created_at: "2022-01-01"
+  published_at: "2022-01-01"
 
 question2:
   title: injectとreduce
@@ -14,132 +14,132 @@ question2:
     injectとreduceはどちらを使うのが一般的でしょうか？
   user: sotugyou
   practice: practice26
-  created_at: '2022-01-02'
-  published_at: '2022-01-02'
+  created_at: "2022-01-02"
+  published_at: "2022-01-02"
 
 question3:
   title: テストの質問1
   description: テスト1の内容です。
   user: komagata
   practice: practice1
-  created_at: '2022-01-03'
-  published_at: '2022-01-03'
+  created_at: "2022-01-03"
+  published_at: "2022-01-03"
 
 question4:
   title: テストの質問2
   description: テスト2の内容です。
   user: komagata
   practice: practice1
-  created_at: '2022-01-04'
-  published_at: '2022-01-04'
+  created_at: "2022-01-04"
+  published_at: "2022-01-04"
 
 question5:
   title: テストの質問3
   description: テスト3の内容です。
   user: komagata
   practice: practice1
-  created_at: '2022-01-05'
-  published_at: '2022-01-05'
+  created_at: "2022-01-05"
+  published_at: "2022-01-05"
 
 question6:
   title: テストの質問4
   description: テスト1の内容です。
   user: komagata
   practice: practice1
-  created_at: '2022-01-06'
-  published_at: '2022-01-06'
+  created_at: "2022-01-06"
+  published_at: "2022-01-06"
 
 question7:
   title: テストの質問5
   description: テスト1の内容です。
   user: komagata
   practice: practice1
-  created_at: '2022-01-07'
-  published_at: '2022-01-07'
+  created_at: "2022-01-07"
+  published_at: "2022-01-07"
 
 question8:
   title: テストの質問
   description: テストの内容です。
   user: kimura
   practice: practice1
-  created_at: '2022-01-08'
-  published_at: '2022-01-08'
+  created_at: "2022-01-08"
+  published_at: "2022-01-08"
 
 question9:
   title: 質問のタブの作り方
   description: タブをテストする1
   user: hatsuno
   practice: practice5
-  created_at: '2022-01-09'
-  published_at: '2022-01-09'
+  created_at: "2022-01-09"
+  published_at: "2022-01-09"
 
 question10:
   title: 質問のタブに関して。。。追加質問
   description: タブをテストする2
   user: hatsuno
   practice: practice5
-  created_at: '2022-01-10'
-  published_at: '2022-01-10'
+  created_at: "2022-01-10"
+  published_at: "2022-01-10"
 
 question11:
   title: Q&Aの検索結果テスト用
   description: Q&Aの検索結果テスト用
   user: komagata
   practice: practice46
-  created_at: '2022-01-11'
-  published_at: '2022-01-11'
+  created_at: "2022-01-11"
+  published_at: "2022-01-11"
 
 question12:
   title: 解決済みの質問
   description: 解決済みの内容です。
   user: hajime
   practice: practice1
-  created_at: '2022-01-12'
-  published_at: '2022-01-12'
+  created_at: "2022-01-12"
+  published_at: "2022-01-12"
 
 question13:
   title: 検索ワードが太字で表示されるかのテスト用の質問
   description: こちらの質問は検索ワードの表示に関するテスト用の質問です。検索ワードが太字で表示されるかのテスト。こちらの質問は検索ワードの表示に関するテスト用の質問です。
   user: hajime
   practice: practice1
-  created_at: '2022-01-13'
-  published_at: '2022-01-13'
+  created_at: "2022-01-13"
+  published_at: "2022-01-13"
 
 question_for_comment_count:
   title: コメント数表示テスト用の質問
   description: こちらの質問はQ&A一覧ページでコメント(回答)がついているものにのみ「回答・コメント（コメント数）」という表示がついているかどうかのテスト用の質問です。
   user: komagata
   practice: practice1
-  created_at: '2022-01-14'
-  published_at: '2022-01-14'
+  created_at: "2022-01-14"
+  published_at: "2022-01-14"
 
 question_for_wip:
   title: wipテスト用の質問(wip中)
   description: こちらの質問はwipテスト用の「wip中」の質問です。
   user: kimura
   practice: practice1
-  created_at: '2022-01-15'
+  created_at: "2022-01-15"
   wip: true
 
 question14:
   title: プラクティスを選択せずに登録したテストの質問
   description: プラクティスを選択せずに登録したテストの質問。
   user: kimura
-  created_at: '2022-01-16'
-  published_at: '2022-01-16'
+  created_at: "2022-01-16"
+  published_at: "2022-01-16"
 
 question15:
   title: プラクティス「sshdでパスワード認証を禁止にする」に関する質問
   description: 他の質問で、プラクティスを変更した後、この質問が含まれているか確認するための質問。
   user: hajime
   practice: practice12
-  created_at: '2022-01-17'
-  published_at: '2022-01-17'
+  created_at: "2022-01-17"
+  published_at: "2022-01-17"
 
 question16:
   title: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問
   description: タイトルが長い質問のtitleタグの文字数が制限されるかテストするための質問
   user: kimura
   practice: practice1
-  created_at: '2022-01-18'
-  published_at: '2022-01-18'
+  created_at: "2022-01-18"
+  published_at: "2022-01-18"

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -135,3 +135,11 @@ question15:
   practice: practice12
   created_at: "2022-01-17"
   published_at: "2022-01-17"
+
+question16:
+  title: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問
+  description: タイトルが長い質問のtitleタグの文字数が制限されるかテストするための質問
+  user: kimura
+  practice: practice1
+  created_at: "2022-01-18"
+  published_at: "2022-01-18"

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -5,8 +5,8 @@ question1:
     どのエディターを使うのが一番良いでしょうか？
   user: machida
   practice: practice1
-  created_at: "2022-01-01"
-  published_at: "2022-01-01"
+  created_at: '2022-01-01'
+  published_at: '2022-01-01'
 
 question2:
   title: injectとreduce
@@ -14,132 +14,132 @@ question2:
     injectとreduceはどちらを使うのが一般的でしょうか？
   user: sotugyou
   practice: practice26
-  created_at: "2022-01-02"
-  published_at: "2022-01-02"
+  created_at: '2022-01-02'
+  published_at: '2022-01-02'
 
 question3:
   title: テストの質問1
   description: テスト1の内容です。
   user: komagata
   practice: practice1
-  created_at: "2022-01-03"
-  published_at: "2022-01-03"
+  created_at: '2022-01-03'
+  published_at: '2022-01-03'
 
 question4:
   title: テストの質問2
   description: テスト2の内容です。
   user: komagata
   practice: practice1
-  created_at: "2022-01-04"
-  published_at: "2022-01-04"
+  created_at: '2022-01-04'
+  published_at: '2022-01-04'
 
 question5:
   title: テストの質問3
   description: テスト3の内容です。
   user: komagata
   practice: practice1
-  created_at: "2022-01-05"
-  published_at: "2022-01-05"
+  created_at: '2022-01-05'
+  published_at: '2022-01-05'
 
 question6:
   title: テストの質問4
   description: テスト1の内容です。
   user: komagata
   practice: practice1
-  created_at: "2022-01-06"
-  published_at: "2022-01-06"
+  created_at: '2022-01-06'
+  published_at: '2022-01-06'
 
 question7:
   title: テストの質問5
   description: テスト1の内容です。
   user: komagata
   practice: practice1
-  created_at: "2022-01-07"
-  published_at: "2022-01-07"
+  created_at: '2022-01-07'
+  published_at: '2022-01-07'
 
 question8:
   title: テストの質問
   description: テストの内容です。
   user: kimura
   practice: practice1
-  created_at: "2022-01-08"
-  published_at: "2022-01-08"
+  created_at: '2022-01-08'
+  published_at: '2022-01-08'
 
 question9:
   title: 質問のタブの作り方
   description: タブをテストする1
   user: hatsuno
   practice: practice5
-  created_at: "2022-01-09"
-  published_at: "2022-01-09"
+  created_at: '2022-01-09'
+  published_at: '2022-01-09'
 
 question10:
   title: 質問のタブに関して。。。追加質問
   description: タブをテストする2
   user: hatsuno
   practice: practice5
-  created_at: "2022-01-10"
-  published_at: "2022-01-10"
+  created_at: '2022-01-10'
+  published_at: '2022-01-10'
 
 question11:
   title: Q&Aの検索結果テスト用
   description: Q&Aの検索結果テスト用
   user: komagata
   practice: practice46
-  created_at: "2022-01-11"
-  published_at: "2022-01-11"
+  created_at: '2022-01-11'
+  published_at: '2022-01-11'
 
 question12:
   title: 解決済みの質問
   description: 解決済みの内容です。
   user: hajime
   practice: practice1
-  created_at: "2022-01-12"
-  published_at: "2022-01-12"
+  created_at: '2022-01-12'
+  published_at: '2022-01-12'
 
 question13:
   title: 検索ワードが太字で表示されるかのテスト用の質問
   description: こちらの質問は検索ワードの表示に関するテスト用の質問です。検索ワードが太字で表示されるかのテスト。こちらの質問は検索ワードの表示に関するテスト用の質問です。
   user: hajime
   practice: practice1
-  created_at: "2022-01-13"
-  published_at: "2022-01-13"
+  created_at: '2022-01-13'
+  published_at: '2022-01-13'
 
 question_for_comment_count:
   title: コメント数表示テスト用の質問
   description: こちらの質問はQ&A一覧ページでコメント(回答)がついているものにのみ「回答・コメント（コメント数）」という表示がついているかどうかのテスト用の質問です。
   user: komagata
   practice: practice1
-  created_at: "2022-01-14"
-  published_at: "2022-01-14"
+  created_at: '2022-01-14'
+  published_at: '2022-01-14'
 
 question_for_wip:
   title: wipテスト用の質問(wip中)
   description: こちらの質問はwipテスト用の「wip中」の質問です。
   user: kimura
   practice: practice1
-  created_at: "2022-01-15"
+  created_at: '2022-01-15'
   wip: true
 
 question14:
   title: プラクティスを選択せずに登録したテストの質問
   description: プラクティスを選択せずに登録したテストの質問。
   user: kimura
-  created_at: "2022-01-16"
-  published_at: "2022-01-16"
+  created_at: '2022-01-16'
+  published_at: '2022-01-16'
 
 question15:
   title: プラクティス「sshdでパスワード認証を禁止にする」に関する質問
   description: 他の質問で、プラクティスを変更した後、この質問が含まれているか確認するための質問。
   user: hajime
   practice: practice12
-  created_at: "2022-01-17"
-  published_at: "2022-01-17"
+  created_at: '2022-01-17'
+  published_at: '2022-01-17'
 
 question16:
-  title: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問
+  title: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問
   description: タイトルが長い質問のtitleタグの文字数が制限されるかテストするための質問
   user: kimura
   practice: practice1
-  created_at: "2022-01-18"
-  published_at: "2022-01-18"
+  created_at: '2022-01-18'
+  published_at: '2022-01-18'

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -225,11 +225,11 @@ class PracticesTest < ApplicationSystemTestCase
   test 'add all questions to questions tab on practices page and display all questions default' do
     practice = practices(:practice1)
     visit_with_auth "/practices/#{practice.id}/questions", 'komagata'
-    assert_text '質問 （11）'
+    assert_text '質問 （12）'
     assert_text '全ての質問'
     assert_text '解決済み'
     assert_text '未解決'
-    assert_equal practice.questions.length, 11
+    assert_equal practice.questions.length, 12
   end
 
   test 'show common description on each page' do

--- a/test/system/question/not_logged_in_test.rb
+++ b/test/system/question/not_logged_in_test.rb
@@ -20,11 +20,11 @@ class Question::NotLoggedInTest < ApplicationSystemTestCase
   test 'titles in og:title, og:description, twitter:description tags is not truncated' do
     question = questions(:question16)
     visit question_path(question)
-    assert_selector "meta[property='og:title'][content='Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問']",
+    assert_selector "meta[property='og:title'][content='Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問']",
                     visible: false
-    assert_selector "meta[property='og:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
+    assert_selector "meta[property='og:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
                     visible: false
-    assert_selector "meta[name='twitter:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
+    assert_selector "meta[name='twitter:description'][content='オンラインプログラミングスクール「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
                     visible: false
   end
 end

--- a/test/system/question/not_logged_in_test.rb
+++ b/test/system/question/not_logged_in_test.rb
@@ -10,4 +10,21 @@ class Question::NotLoggedInTest < ApplicationSystemTestCase
     assert_text 'このページの閲覧にはフィヨルドブートキャンプの入会が必要です'
     assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{question.title}」のページです。']", visible: false
   end
+
+  test 'title of the title tag is truncated' do
+    question = questions(:question16)
+    visit question_path(question)
+    assert_selector 'title', text: 'Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイト... | FBC', visible: false
+  end
+
+  test 'titles in og:title, og:description, twitter:description tags is not truncated' do
+    question = questions(:question16)
+    visit question_path(question)
+    assert_selector "meta[property='og:title'][content='Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問']",
+                    visible: false
+    assert_selector "meta[property='og:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
+                    visible: false
+    assert_selector "meta[name='twitter:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
+                    visible: false
+  end
 end

--- a/test/system/question/not_logged_in_test.rb
+++ b/test/system/question/not_logged_in_test.rb
@@ -24,7 +24,7 @@ class Question::NotLoggedInTest < ApplicationSystemTestCase
                     visible: false
     assert_selector "meta[property='og:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
                     visible: false
-    assert_selector "meta[name='twitter:description'][content='オンラインプログラミングスクール「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
+    assert_selector "meta[name='twitter:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
                     visible: false
   end
 end


### PR DESCRIPTION
## Issue
- #7964

## 概要
- 未ログイン時のQ&A個別ページのtitleタグの文字数を制限するようにしました。

## 変更確認方法
1. `chore/limit-qa-page-title-length-logged-out` をローカルに取り込む
2. ログインして、長いタイトルの質問を作成する
    - `長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問`
4. 作成した Q&A 個別ページの URL をコピーしておく
5. 一度ログアウトして、4 でコピーした URL に遷移
6. 右クリックで「ページのソースを表示」を選択し、HTML が表示される画面へ
7. 2 行目の title タグの質問が以下のように省略されていることを確認
    - `<title>(development) Q&amp;A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイト... | FBC</title>`
8. 4 行目 `og:title` 、7 行目 `og:description`、12 行目 `twitter:description` のタイトルはそのまま表示されていることを確認

## Screenshot
### 変更前
![スクリーンショット 2024-07-30 0 42 37のコピー3](https://github.com/user-attachments/assets/5890330e-bce8-4983-b997-f9434568e335)


### 変更後
![スクリーンショット 2024-07-30 0 41 47のコピー2](https://github.com/user-attachments/assets/121f6a03-792c-480e-b7e8-0b768c13afd1)

![スクリーンショット 2024-07-30 0 41 47のコピー](https://github.com/user-attachments/assets/87cdfb10-53b4-4785-8d77-22717aec08e0)
