### PR TITLE
ログイン時のQ&A個別ページのtitleタグの文字数を制限

### DIFF
--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -1,4 +1,5 @@
-- title "Q＆A: #{@question.title}"
+- title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"
+- set_meta_tags og: { title: "Q&A: #{@question.title}" }
 - if @question.practice
   - set_meta_tags description: "#{@question.user.long_name}さんが投稿した、プラクティス「#{@question.practice.title}」に関する質問「#{@question.title}」のページです。"
 - else

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -135,3 +135,11 @@ question15:
   practice: practice12
   created_at: "2022-01-17"
   published_at: "2022-01-17"
+
+question16:
+  title: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問
+  description: タイトルが長い質問のtitleタグの文字数が制限されるかテストするための質問
+  user: kimura
+  practice: practice1
+  created_at: "2022-01-18"
+  published_at: "2022-01-18"

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -225,11 +225,11 @@ class PracticesTest < ApplicationSystemTestCase
   test 'add all questions to questions tab on practices page and display all questions default' do
     practice = practices(:practice1)
     visit_with_auth "/practices/#{practice.id}/questions", 'komagata'
-    assert_text '質問 （11）'
+    assert_text '質問 （12）'
     assert_text '全ての質問'
     assert_text '解決済み'
     assert_text '未解決'
-    assert_equal practice.questions.length, 11
+    assert_equal practice.questions.length, 12
   end
 
   test 'show common description on each page' do

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -39,6 +39,16 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_selector 'title', text: 'Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイト... | FBC', visible: false
   end
 
+  test 'titles in og:title, og:description, twitter:description tags is not truncated' do
+    question = questions(:question16)
+    visit_with_auth question_path(question), 'kimura'
+    meta_title = '長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問'
+    meta_description = "kimura (キムラ タダシ)さんが投稿した、プラクティス「OS X Mountain Lionをクリーンインストールする」に関する質問「#{meta_title}」のページです。"
+    assert_selector "meta[property='og:title'][content='Q&A: #{meta_title}']", visible: false
+    assert_selector "meta[property='og:description'][content='#{meta_description}']", visible: false
+    assert_selector "meta[name='twitter:description'][content='#{meta_description}']", visible: false
+  end
+
   test 'create a question' do
     visit_with_auth new_question_path, 'kimura'
     within 'form[name=question]' do

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -30,7 +30,13 @@ class QuestionsTest < ApplicationSystemTestCase
   test 'show a question' do
     question = questions(:question8)
     visit_with_auth question_path(question), 'kimura'
-    assert_equal 'Q＆A: テストの質問 | FBC', title
+    assert_equal 'Q&A: テストの質問 | FBC', title
+  end
+
+  test 'title of the title tag is truncated' do
+    question = questions(:question16)
+    visit_with_auth question_path(question), 'kimura'
+    assert_selector 'title', text: 'Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイト... | FBC', visible: false
   end
 
   test 'create a question' do


### PR DESCRIPTION
## Issue
- #7963 

## 概要
1. ログイン時のQ&Aの個別ページのtitleタグのタイトルを省略しました。
2. Q&A個別ページのタブのタイトルに「Q&A」文字列を全角から半角にしました。

## 変更確認方法

1. `chore/truncate-qa-title-in-title-tag-logged-in` をローカルに取り込む
2. ログインして、長いタイトルの質問を作成する
    - `長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問`
4. 作成した Q&A 個別ページから右クリックで「ページのソースを表示」を選択し、HTML が表示される画面へ
5. 2 行目の title タグの質問が以下のように省略されていることを確認
    - `<title>(development) Q&amp;A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイト... | FBC</title>`
6. 4 行目 `og:title` 、7 行目 `og:description`、12 行目 `twitter:description` のタイトルはそのまま表示されていることを確認

## Screenshot
### 変更前
![スクリーンショット 2024-07-30 0 42 37のコピー3](https://github.com/user-attachments/assets/5890330e-bce8-4983-b997-f9434568e335)


### 変更後
![スクリーンショット 2024-07-30 0 41 47のコピー2](https://github.com/user-attachments/assets/121f6a03-792c-480e-b7e8-0b768c13afd1)

![スクリーンショット 2024-07-30 0 41 47のコピー](https://github.com/user-attachments/assets/87cdfb10-53b4-4785-8d77-22717aec08e0)

2. title タグ、og:title の`Q&A` を半角にする

### 変更前
タブのタイトルに表示される Q&A の「&」が全角になっている
![スクリーンショット 2024-08-04 1 02 24](https://github.com/user-attachments/assets/de177aa7-0484-453e-829f-9872cb80f34f)

`title` タグ、`og:title` の Q&A の「&」が全角になっている
![スクリーンショット 2024-08-04 1 02 49](https://github.com/user-attachments/assets/ad07ec28-8a07-401d-af64-a98bee7fb5b0)

### 変更後
タブのタイトルに表示される Q&A の「&」は半角になっている
![スクリーンショット 2024-08-04 0 59 29](https://github.com/user-attachments/assets/33e500d4-cfe3-4bd0-9b97-1a7c2edd4517)

半角にしたため、`title` タグ、`og:title` の「&」がアンパサンド(`&amp;`)になる
![スクリーンショット 2024-08-04 1 00 50](https://github.com/user-attachments/assets/dc8e56ff-f8d8-4f3d-801e-8e19dc163bb6)