### PR TITLE
未ログイン時のQ&A個別ページのtitleタグの文字数を制限

### DIFF
--- a/app/views/unauthorized/_unauthorized_header.html.slim
+++ b/app/views/unauthorized/_unauthorized_header.html.slim
@@ -1,3 +1,5 @@
+- title "Q&A: #{truncate(title, length: 35, omission: '...')}"
+- set_meta_tags og: { title: "Q&A: #{title}" }
 header.unauthorized-header
   .container
     = image_tag('shared/piyo.svg', alt: 'フィヨルドブートキャンプのキャラクター画像', class: 'unauthorized-header__image')

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -135,3 +135,11 @@ question15:
   practice: practice12
   created_at: "2022-01-17"
   published_at: "2022-01-17"
+
+question16:
+  title: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問
+  description: タイトルが長い質問のtitleタグの文字数が制限されるかテストするための質問
+  user: kimura
+  practice: practice1
+  created_at: "2022-01-18"
+  published_at: "2022-01-18"

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -225,11 +225,11 @@ class PracticesTest < ApplicationSystemTestCase
   test 'add all questions to questions tab on practices page and display all questions default' do
     practice = practices(:practice1)
     visit_with_auth "/practices/#{practice.id}/questions", 'komagata'
-    assert_text '質問 （11）'
+    assert_text '質問 （12）'
     assert_text '全ての質問'
     assert_text '解決済み'
     assert_text '未解決'
-    assert_equal practice.questions.length, 11
+    assert_equal practice.questions.length, 12
   end
 
   test 'show common description on each page' do

--- a/test/system/question/not_logged_in_test.rb
+++ b/test/system/question/not_logged_in_test.rb
@@ -10,4 +10,10 @@ class Question::NotLoggedInTest < ApplicationSystemTestCase
     assert_text 'このページの閲覧にはフィヨルドブートキャンプの入会が必要です'
     assert_selector "meta[name='description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{question.title}」のページです。']", visible: false
   end
+
+  test 'title of the title tag is truncated' do
+    question = questions(:question16)
+    visit question_path(question)
+    assert_selector 'title', text: 'Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイト... | FBC', visible: false
+  end
 end

--- a/test/system/question/not_logged_in_test.rb
+++ b/test/system/question/not_logged_in_test.rb
@@ -16,4 +16,15 @@ class Question::NotLoggedInTest < ApplicationSystemTestCase
     visit question_path(question)
     assert_selector 'title', text: 'Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイト... | FBC', visible: false
   end
+
+  test 'titles in og:title, og:description, twitter:description tags is not truncated' do
+    question = questions(:question16)
+    visit question_path(question)
+    assert_selector "meta[property='og:title'][content='Q&A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問']",
+                    visible: false
+    assert_selector "meta[property='og:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
+                    visible: false
+    assert_selector "meta[name='twitter:description'][content='オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問」のページです。']",
+                    visible: false
+  end
 end


### PR DESCRIPTION
## Issue
- #7964

## 概要
- 未ログイン時のQ&Aの個別ページのtitleタグのタイトルを省略しました。

## 変更確認方法
1. `chore/truncate-qa-title-in-title-tag-logged-out` をローカルに取り込む
2. ログインして、長いタイトルの質問を作成する
    - `長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイトルの質問`
4. 作成した Q&A 個別ページの URL をコピーしておく
5. 一度ログアウトして、4 でコピーした URL に遷移
6. 右クリックで「ページのソースを表示」を選択し、HTML が表示される画面へ
7. 2 行目の title タグの質問が以下のように省略されていることを確認
    - `<title>(development) Q&amp;A: 長いタイトルの質問長いタイトルの質問長いタイトルの質問長いタイト... | FBC</title>`
8. 4 行目 `og:title` 、7 行目 `og:description`、12 行目 `twitter:description` のタイトルはそのまま表示されていることを確認

## Screenshot
### 変更前
![スクリーンショット 2024-07-30 0 42 37のコピー3](https://github.com/user-attachments/assets/5890330e-bce8-4983-b997-f9434568e335)


### 変更後
![スクリーンショット 2024-07-30 0 41 47のコピー2](https://github.com/user-attachments/assets/121f6a03-792c-480e-b7e8-0b768c13afd1)

![スクリーンショット 2024-07-30 0 41 47のコピー](https://github.com/user-attachments/assets/87cdfb10-53b4-4785-8d77-22717aec08e0)
