### PR TITLE
提出物未チェックの場合、学習ステータスを修了にできないように変更

### DIFF
--- a/app/javascript/learning.js
+++ b/app/javascript/learning.js
@@ -18,10 +18,16 @@ document.addEventListener('DOMContentLoaded', () => {
         redirect: 'manual',
         body: params
       })
-        .then(() => {
-          completeButton.classList.add('is-disabled')
-          completeButton.textContent = '修了しています'
-          document.getElementById('modal-learning_completion').checked = true // 修了モーダル表示のためのフラグを立てる
+        .then((response) => {
+          if (response.ok) {
+            completeButton.classList.add('is-disabled')
+            completeButton.textContent = '修了しています'
+            document.getElementById('modal-learning_completion').checked = true // 修了モーダル表示のためのフラグを立てる
+          } else {
+            response.json().then((data) => {
+              alert(data.error)
+            })
+          }
         })
         .catch((error) => {
           console.warn(error)

--- a/app/models/learning.rb
+++ b/app/models/learning.rb
@@ -21,8 +21,7 @@ class Learning < ApplicationRecord
   end
 
   def submission_checked_for_completion
-    product = practice.product(user)
-    return if product&.checked?
+    return if practice.product(user)&.checked?
 
     errors.add :error, '提出物がチェックされていないため、修了にできません'
   end

--- a/app/models/learning.rb
+++ b/app/models/learning.rb
@@ -10,6 +10,7 @@ class Learning < ApplicationRecord
             presence: true,
             uniqueness: { scope: :user_id }
   validate :startable_practice
+  validate :submission_checked_for_completion, if: -> { practice.submission && status == 'complete' }
 
   private
 
@@ -17,5 +18,12 @@ class Learning < ApplicationRecord
     return unless started? && Learning.exists?(user_id:, status: 'started')
 
     errors.add :error, "すでに着手しているプラクティスがあります。\n提出物を提出するか修了すると新しいプラクティスを開始できます。"
+  end
+
+  def submission_checked_for_completion
+    product = practice.product(user)
+    return if product&.checked?
+
+    errors.add :error, '提出物がチェックされていないため、修了にできません'
   end
 end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'supports/product_helper'
 require 'active_decorator_test_case'
 
 class UserDecoratorTest < ActiveDecoratorTestCase
+  include ProductHelper
   setup do
     @admin_mentor_user = decorate(users(:komagata))
     @student_user = decorate(users(:hajime))
@@ -74,11 +76,13 @@ class UserDecoratorTest < ActiveDecoratorTestCase
   test '#completed_fraction don\'t calculate practice that include_progress: false' do
     user = @admin_mentor_user
     old_fraction = user.completed_practices_include_progress_size
+    create_checked_product(user, practices(:practice5))
     user.completed_practices << practices(:practice5)
 
     assert_not_equal old_fraction, user.completed_fraction
 
     old_fraction = user.completed_practices_include_progress_size
+    create_checked_product(user, practices(:practice53))
     user.completed_practices << practices(:practice53)
 
     assert_equal old_fraction, user.completed_practices_include_progress_size
@@ -86,11 +90,13 @@ class UserDecoratorTest < ActiveDecoratorTestCase
 
   test '#completed_fraction don\'t calculate practice unrelated cource' do
     old_fraction = @admin_mentor_user.completed_practices_include_progress_size
+    create_checked_product(@admin_mentor_user, practices(:practice5))
     @admin_mentor_user.completed_practices << practices(:practice5)
 
     assert_not_equal old_fraction, @admin_mentor_user.completed_practices_include_progress_size
 
     old_fraction = @admin_mentor_user.completed_practices_include_progress_size
+    create_checked_product(@admin_mentor_user, practices(:practice55))
     @admin_mentor_user.completed_practices << practices(:practice55)
 
     assert_equal old_fraction, @admin_mentor_user.completed_practices_include_progress_size
@@ -99,6 +105,8 @@ class UserDecoratorTest < ActiveDecoratorTestCase
   test '#completed_fraction_in_metas' do
     fraction_in_metas = '2 （必須:1）'
     @non_required_subject_completed_user.completed_practices = []
+    create_checked_product(@non_required_subject_completed_user, practices(:practice5))
+    create_checked_product(@non_required_subject_completed_user, practices(:practice61))
     @non_required_subject_completed_user.completed_practices << practices(:practice5)
     @non_required_subject_completed_user.completed_practices << practices(:practice61)
     assert_equal fraction_in_metas, @non_required_subject_completed_user.completed_fraction_in_metas

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -6,6 +6,7 @@ require 'active_decorator_test_case'
 
 class UserDecoratorTest < ActiveDecoratorTestCase
   include ProductHelper
+
   setup do
     @admin_mentor_user = decorate(users(:komagata))
     @student_user = decorate(users(:hajime))

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -53,9 +53,9 @@ class ProductTest < ActiveSupport::TestCase
       practice:
     )
 
-    status = :complete
+    status = :started
     product.change_learning_status(status)
-    assert Learning.find_by(user:, practice:, status: :complete)
+    assert Learning.find_by(user:, practice:, status: :started)
   end
 
   test '#category' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'supports/product_helper'
 
 class UserTest < ActiveSupport::TestCase
+  include ProductHelper
   test '#admin?' do
     assert users(:komagata).admin?
     assert users(:machida).admin?
@@ -75,11 +77,13 @@ class UserTest < ActiveSupport::TestCase
   test '#completed_percentage don\'t calculate practice that include_progress: false' do
     user = users(:komagata)
     old_percentage = user.completed_percentage
+    create_checked_product(user, practices(:practice5))
     user.completed_practices << practices(:practice5)
 
     assert_not_equal old_percentage, user.completed_percentage
 
     old_percentage = user.completed_percentage
+    create_checked_product(user, practices(:practice53))
     user.completed_practices << practices(:practice53)
 
     assert_equal old_percentage, user.completed_percentage
@@ -88,11 +92,13 @@ class UserTest < ActiveSupport::TestCase
   test '#completed_percentage don\'t calculate practice unrelated cource' do
     user = users(:komagata)
     old_percentage = user.completed_percentage
+    create_checked_product(user, practices(:practice5))
     user.completed_practices << practices(:practice5)
 
     assert_not_equal old_percentage, user.completed_percentage
 
     old_percentage = user.completed_percentage
+    create_checked_product(user, practices(:practice55))
     user.completed_practices << practices(:practice55)
 
     assert_equal old_percentage, user.completed_percentage
@@ -381,6 +387,7 @@ class UserTest < ActiveSupport::TestCase
     practice2 = practices(:practice2)
     today = Time.zone.today
 
+    create_checked_product(user, practice1)
     Learning.create!(
       user:,
       practice: practice1,
@@ -389,6 +396,7 @@ class UserTest < ActiveSupport::TestCase
       updated_at: (today - 2.weeks).to_formatted_s(:db)
     )
 
+    create_checked_product(user, practice2)
     Learning.create!(
       user:,
       practice: practice2,
@@ -425,6 +433,7 @@ class UserTest < ActiveSupport::TestCase
     practice1 = practices(:practice1)
     today = Time.zone.today
 
+    create_checked_product(user, practice1)
     Learning.create!(
       user:,
       practice: practice1,
@@ -450,6 +459,7 @@ class UserTest < ActiveSupport::TestCase
 
     machida = users(:machida)
     practice1 = practices(:practice1)
+    create_checked_product(machida, practice1)
     Learning.create!(
       user: machida,
       practice: practice1,

--- a/test/supports/product_helper.rb
+++ b/test/supports/product_helper.rb
@@ -16,4 +16,9 @@ module ProductHelper
 
     products[2..products.size].each(&:delete)
   end
+
+  def create_checked_product(user, practice)
+    product = Product.create(user:, practice:, body: 'test')
+    Check.create(user:, checkable: product)
+  end
 end

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -19,7 +19,7 @@ class PracticesTest < ApplicationSystemTestCase
   end
 
   test 'finish a practice' do
-    visit_with_auth "/practices/#{practices(:practice1).id}", 'komagata'
+    visit_with_auth "/practices/#{practices(:practice3).id}", 'komagata'
     find('#js-complete').click
     assert_not has_link? '修了'
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -50,6 +50,9 @@ class ProductsTest < ApplicationSystemTestCase
   end
 
   test 'not display learning completion message when a user of the completed product visits after the second time' do
+    visit_with_auth "/products/#{products(:product65).id}", 'komagata'
+    click_button '提出物を確認'
+    assert_text '提出物の確認を取り消す'
     visit_with_auth "/products/#{products(:product65).id}", 'kimura'
     first('label.card-main-actions__muted-action.is-closer').click
     assert_no_text '喜びをXにポストする！'


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7959

## 概要

表題の通りです。
プラクティスを修了していなくても、他の方の回答が見れてしまうため修正しました。

## 変更確認方法

1. `bugfix/show-answers-incomplete-practice`をローカルに取り込む
2. `hajime`で http://localhost:3000/practices/315059988 にアクセス。
3. 学習ステータスを「修了」に変更しようとすると、変更できない旨のalertが出ることを確認。
4. 念のため、他の人の提出物（どれでも構いません）をクリックし、他の提出物が見れないことを確認。

## Screenshot

### 変更前
提出物がない状態でも、修了に変更できてしまう。
<img width="550" alt="スクリーンショット 2024-08-05 16 41 52" src="https://github.com/user-attachments/assets/f4ee89bf-4116-4708-8bed-65d281243e9c">


### 変更後

<img width="500" alt="スクリーンショット 2024-08-05 16 40 54" src="https://github.com/user-attachments/assets/98c1f281-138a-44b2-845b-725fcd5f16ff">



