### PR TITLE
ActiveRecord::RecordNotUniqueのエラーが出ないように修正

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,6 +21,8 @@ class ReportsController < ApplicationController
   def show
     @products = @report.user.products.not_wip.order(published_at: :desc)
     @recent_reports = Report.list.where(user_id: @report.user.id).limit(10)
+    Footprint.find_or_create_by(footprintable: @report, user: current_user) unless @report.user == current_user
+    @footprints = Footprint.fetch_for_resource(@report)
     respond_to do |format|
       format.html
       format.md

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -151,7 +151,7 @@ class ReportsController < ApplicationController
   def celebrating_count(report)
     return nil if report.wip
 
-    report_count = current_user.reports.count
+    report_count = current_user.reports.not_wip.count
     CELEBRATING_COUNTS.find { |count| count == report_count }
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -55,7 +55,7 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
 
-    if @report.save_with_lock
+    if @report.save_uniquely
       Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
@@ -69,7 +69,8 @@ class ReportsController < ApplicationController
     @report.practice_ids = nil if params[:report][:practice_ids].nil?
     @report.assign_attributes(report_params)
     canonicalize_learning_times(@report)
-    if @report.save
+
+    if @report.save_uniquely
       Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -54,10 +54,15 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
 
-    if @report.save
-      Newspaper.publish(:report_save, { report: @report })
-      redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
-    else
+    begin
+      if @report.save
+        Newspaper.publish(:report_save, { report: @report })
+        redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
+      else
+        render :new
+      end
+    rescue ActiveRecord::RecordNotUnique
+      @report.errors.add(:reported_on, 'はすでに存在します')
       render :new
     end
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -55,15 +55,9 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
 
-    begin
-      if @report.save
-        Newspaper.publish(:report_save, { report: @report })
-        redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
-      else
-        render :new
-      end
-    rescue ActiveRecord::RecordNotUnique
-      @report.errors.add(:reported_on, 'はすでに存在します')
+    if @report.save_with_uniqueness_handling
+      redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
+    else
       render :new
     end
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,6 +20,7 @@ class ReportsController < ApplicationController
 
   def show
     @products = @report.user.products.not_wip.order(published_at: :desc)
+    @recent_reports = Report.list.where(user_id: @report.user.id).limit(10)
     respond_to do |format|
       format.html
       format.md

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -55,7 +55,7 @@ class ReportsController < ApplicationController
     set_wip
     canonicalize_learning_times(@report)
 
-    if @report.save_with_uniqueness_handling
+    if @report.save_with_lock
       Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -56,6 +56,7 @@ class ReportsController < ApplicationController
     canonicalize_learning_times(@report)
 
     if @report.save_with_uniqueness_handling
+      Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
       render :new

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,9 +20,6 @@ class ReportsController < ApplicationController
 
   def show
     @products = @report.user.products.not_wip.order(published_at: :desc)
-    @recent_reports = Report.list.where(user_id: @report.user.id).limit(10)
-    Footprint.find_or_create_by(footprintable: @report, user: current_user) unless @report.user == current_user
-    @footprints = Footprint.fetch_for_resource(@report)
     respond_to do |format|
       format.html
       format.md
@@ -56,6 +53,7 @@ class ReportsController < ApplicationController
     @report.user = current_user
     set_wip
     canonicalize_learning_times(@report)
+
     if @report.save
       Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
@@ -153,7 +151,7 @@ class ReportsController < ApplicationController
   def celebrating_count(report)
     return nil if report.wip
 
-    report_count = current_user.reports.not_wip.count
+    report_count = current_user.reports.count
     CELEBRATING_COUNTS.find { |count| count == report_count }
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -132,15 +132,13 @@ class Report < ApplicationRecord
           .second
   end
 
-  def save_with_lock
-    Report.transaction do
-      if user.reports.lock.find_by(reported_on:)
-        valid?
-        false
-      else
-        save
-      end
+  def save_uniquely
+    transaction do
+      save
     end
+  rescue ActiveRecord::RecordNotUnique
+    errors.add(:base, '同じ日付のレポートが既に存在します。')
+    false
   end
 
   private

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -137,7 +137,7 @@ class Report < ApplicationRecord
       save
     end
   rescue ActiveRecord::RecordNotUnique
-    errors.add(:base, '同じ日付のレポートが既に存在します。')
+    errors.add(:base, '学習日はすでに存在します')
     false
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -132,11 +132,15 @@ class Report < ApplicationRecord
           .second
   end
 
-  def save_with_uniqueness_handling(*args, &block)
-    save(*args, &block)
-  rescue ActiveRecord::RecordNotUnique
-    errors.add(:reported_on, 'はすでに存在します')
-    false
+  def save_with_lock
+    Report.transaction do
+      if user.reports.lock.find_by(reported_on:)
+        valid?
+        false
+      else
+        save
+      end
+    end
   end
 
   private

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -132,6 +132,13 @@ class Report < ApplicationRecord
           .second
   end
 
+  def save_with_uniqueness_handling(*args, &block)
+    save(*args, &block)
+  rescue ActiveRecord::RecordNotUnique
+    errors.add(:reported_on, 'はすでに存在します')
+    false
+  end
+
   private
 
   def limited_date_within_range

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -45,21 +45,11 @@ class ReportTest < ActiveSupport::TestCase
   end
 
   test '#save_with_uniqueness_check' do
-    user = users(:muryou)
-    report1 = Report.new
-    report1.user = user
-    report1.reported_on = '2024-08-05'
-    report1.title = 'test1'
-    report1.description = 'test1'
-    report1.emotion = 'happy'
+    report1 = reports(:report1)
     report1.save_with_uniqueness_check
 
-    report2 = Report.new
-    report2.user = user
-    report2.reported_on = '2024-08-05'
+    report2 = report1.dup
     report2.title = 'test2'
-    report2.description = 'test2'
-    report2.emotion = 'happy'
     report2.save_with_uniqueness_check
 
     assert_includes report2.errors.full_messages, '学習日はすでに存在します'

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -43,11 +43,4 @@ class ReportTest < ActiveSupport::TestCase
   test '#interval' do
     assert_equal 10, reports(:report32).interval
   end
-
-  test '#save_with_uniqueness_check' do
-    report1 = reports(:report1)
-    report2 = report1.dup
-    report2.save_with_uniqueness_check
-    assert_includes report2.errors.full_messages, '学習日はすでに存在します'
-  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -43,4 +43,21 @@ class ReportTest < ActiveSupport::TestCase
   test '#interval' do
     assert_equal 10, reports(:report32).interval
   end
+
+  test 'save_with_lock does not save duplicate report and adds validation errors' do
+    Report.create!(
+      user: users(:komagata),
+      reported_on: Time.zone.today,
+      title: 'report1',
+      description: 'report1本文'
+    )
+
+    duplicate_report = Report.new(
+      user: users(:komagata),
+      reported_on: Time.zone.today,
+      title: 'report2',
+      description: 'report2本文'
+    )
+    assert_not duplicate_report.save_with_lock
+  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -59,6 +59,6 @@ class ReportTest < ActiveSupport::TestCase
       description: 'report2本文'
     )
     assert_not duplicate_report.save_uniquely
-    assert_includes duplicate_report.errors.full_messages, '同じ日付のレポートが既に存在します。'
+    assert_includes duplicate_report.errors.full_messages, '学習日はすでに存在します'
   end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -44,7 +44,7 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal 10, reports(:report32).interval
   end
 
-  test '#reported_on_uniqueness_check' do
+  test '#save_with_uniqueness_check' do
     user = users(:muryou)
     report1 = Report.new
     report1.user = user

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -43,4 +43,25 @@ class ReportTest < ActiveSupport::TestCase
   test '#interval' do
     assert_equal 10, reports(:report32).interval
   end
+
+  test '#reported_on_uniqueness_check' do
+    user = users(:muryou)
+    report1 = Report.new
+    report1.user = user
+    report1.reported_on = '2024-08-05'
+    report1.title = 'test1'
+    report1.description = 'test1'
+    report1.emotion = 'happy'
+    report1.save_with_uniqueness_check
+
+    report2 = Report.new
+    report2.user = user
+    report2.reported_on = '2024-08-05'
+    report2.title = 'test2'
+    report2.description = 'test2'
+    report2.emotion = 'happy'
+    report2.save_with_uniqueness_check
+
+    assert_includes report2.errors.full_messages, '学習日はすでに存在します'
+  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -46,12 +46,8 @@ class ReportTest < ActiveSupport::TestCase
 
   test '#save_with_uniqueness_check' do
     report1 = reports(:report1)
-    report1.save_with_uniqueness_check
-
     report2 = report1.dup
-    report2.title = 'test2'
     report2.save_with_uniqueness_check
-
     assert_includes report2.errors.full_messages, '学習日はすでに存在します'
   end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -44,7 +44,7 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal 10, reports(:report32).interval
   end
 
-  test 'save_with_lock does not save duplicate report and adds validation errors' do
+  test 'save_uniquely does not save duplicate report and adds validation errors' do
     Report.create!(
       user: users(:komagata),
       reported_on: Time.zone.today,
@@ -58,6 +58,7 @@ class ReportTest < ActiveSupport::TestCase
       title: 'report2',
       description: 'report2本文'
     )
-    assert_not duplicate_report.save_with_lock
+    assert_not duplicate_report.save_uniquely
+    assert_includes duplicate_report.errors.full_messages, '同じ日付のレポートが既に存在します。'
   end
 end


### PR DESCRIPTION
2つPRをcloseしている理由なのですが、push前に`git pull --rebase origin main`しておらず、自分のコミットでないものが入ってしまいました。1度目はそこから修正しようとしましたが余計に分からなくなった為closeしました。2度目は解決方法が分かったので、closeしました。


## Issue

- #7888


## 概要
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_reports_on_user_id_and_reported_on" DETAIL: Key (user_id, reported_on)=(2018, 2024-06-24) already exists.

とエラーが出るのを回避するための修正を行いました。

## 変更確認方法

1. ブランチ `bug/fix-unique-violation-cleanup` をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. `hajime` でログイン
4. `http://localhost:3000/reports/new` にアクセスし、日報作成画面を2つのタブで表示
5. タイトルはそれぞれ別のタイトルにする。日付は同じにして同時に提出ボタンをクリック。
![image](https://github.com/user-attachments/assets/34382192-7648-4359-8345-ec54a27ba27b)
6. 片方の日報は保存され、もう片方の日報はバリデーションが表示されることを確認。



## 変更前

重複が起こった際にActiveRecord::RecordNotUniqueのエラーが表示され、エラーハンドリングが行われていませんでした。

![image](https://github.com/user-attachments/assets/3360817f-9e0c-461e-89a1-57cb5d2411b0)


## 変更後

変更後は、バリデーションエラーが画面上に表示されるようになりました。

![image](https://github.com/user-attachments/assets/ae0854d5-2d7a-4598-b62c-c178a0250077)
