### PR TITLE
textarea に画像をアップロードした際にHTMLタグ形式で表示する

### DIFF
--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -57,8 +57,8 @@ export default class {
         responseKey: 'url',
         csrfToken: CSRF.getToken(),
         placeholder: '%filenameをアップロード中...',
-        //  uploadImageTag:
-        //  '<img src=%url width="100" height="100" loading="lazy" decoding="async" alt="%filename">\n',
+        uploadImageTag:
+        '<img src=%url width="%width" height="%height" loading="lazy" decoding="async" alt="%filename">\n',
         afterPreview: () => {
           autosize.update(textarea)
 

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -58,7 +58,7 @@ export default class {
         csrfToken: CSRF.getToken(),
         placeholder: '%filenameをアップロード中...',
         uploadImageTag:
-        '<img src=%url width="%width" height="%height" loading="lazy" decoding="async" alt="%filename">\n',
+          '<img src=%url width="%width" height="%height" loading="lazy" decoding="async" alt="%filename">\n',
         afterPreview: () => {
           autosize.update(textarea)
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "^1.5.1",
+    "textarea-markdown": "/Users/ryo/fjord/npm/textarea-markdown",
     "tributejs": "^5.1.3",
     "use-sync-external-store": "^1.2.0",
     "vue": "^2.6.10",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "/Users/ryo/fjord/npm/textarea-markdown",
+    "textarea-markdown": "^1.6.0",
     "tributejs": "^5.1.3",
     "use-sync-external-store": "^1.2.0",
     "vue": "^2.6.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8976,10 +8976,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-textarea-markdown@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.5.1.tgz#90530d6292ba17972538ba20139006fbd0ac76fa"
-  integrity sha512-WAwxa1n7CG0ySfGSVll/G0cIFKP47fqwr64PiDiHhlXTrknOEyTnz+OKR3OWvEi9125SC+QbuZiJ20nE22F7vw==
+textarea-markdown@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.6.0.tgz#1689a8beaf17b0b11a440dfbebd4649ba3158018"
+  integrity sha512-cF4Xh54cu30fb+8a/SaN+r2ol0N8O9m5TKkxiGf7Cvv87FT4WfcQLWGanuwhKCdrZFjf7Vgv5X3XwpefVl8/gw==
   dependencies:
     file-type "^16.5.4"
     filesize "^10.0.5"


### PR DESCRIPTION
## Issue

- #7303

## 概要

[以前のPR](https://github.com/fjordllc/bootcamp/pull/7448)にて textarea に画像をアップロードした際の記法を、マークダウン形式から HTML タグ形式にしましたが、画像の縦横サイズが取得できなかったバグについての修正です。

変更に伴い [textarea-markdown npm](https://www.npmjs.com/package/textarea-markdown) を更新しています。npm のコード修正は[こちら](https://github.com/komagata/textarea-markdown/pull/49)の PR にて実施済みとなっているため確認不要です。本 PR では fjord アプリでの機能確認が主となります。

## 変更確認方法

1. bug/textarea_image_format_markdown_to_htmltag をローカルに取り込む
2. `bin/setup` で npm を更新
3. `foreman start -f Procfile.dev` でアプリを立ち上げる
4. 任意ユーザ でログイン
5. [お知らせ作成](http://localhost:3000/announcements/new)のフォームページにアクセスし、テキストエリアに画像をアップロードし、テキストが `<img src="ファイルパス" width="画像横サイズ" height="画像縦サイズ" loading="lazy" decoding="async" alt=”image.png”>` となっていることを確認する  
※ textarea へ画像をアップロードするページは複数ありますが、代表例として『お知らせ作成』のみを確認いただこうと思います。

## Screenshot

### 変更前

- ファイル名がある場合

    <img width="552" alt="image" src="https://github.com/fjordllc/bootcamp/assets/90775541/d54af3dc-957c-4a0d-a278-fd5584fd78e7">

- ファイル名がない場合

    <img width="536" alt="image" src="https://github.com/fjordllc/bootcamp/assets/90775541/654e817a-237a-4e13-a47f-18ef5ce3d9ee">

### 変更後

- ファイル名がある場合

    [![Image from Gyazo](https://i.gyazo.com/64d375ccf57836c43c945544f28db105.png)](https://gyazo.com/64d375ccf57836c43c945544f28db105)

- ファイル名がない場合

     [![Image from Gyazo](https://i.gyazo.com/4a9c292247d907033dac77b77799bafc.png)](https://gyazo.com/4a9c292247d907033dac77b77799bafc)

