### PR TITLE
開催前の定期イベントは次回開催日を表示しない

### DIFF
--- a/app/views/regular_events/_regular_event_meta.html.slim
+++ b/app/views/regular_events/_regular_event_meta.html.slim
@@ -22,4 +22,7 @@
         dt.event-meta__item-label
           | 次回開催日
         dd.event-meta__item-value
-          = regular_event.next_holding_date
+          - if regular_event.wip?
+            | イベント編集中のため次回開催日は未定です
+          - else
+            = regular_event.next_holding_date

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -67,6 +67,29 @@ class RegularEventsTest < ApplicationSystemTestCase
     assert_text regular_event.description
   end
 
+  test 'show regular event as WIP' do
+    visit_with_auth new_regular_event_path, 'komagata'
+    within 'form[name=regular_event]' do
+      fill_in 'regular_event[title]', with: 'WIPの定期イベント表示確認用'
+      first('.choices__inner').click
+      find('#choices--js-choices-multiple-select-item-choice-1').click
+      find('label', text: '主催者').click
+      find('label', text: '質問').click
+      fill_in 'regular_event[start_at]', with: Time.zone.parse('21:00')
+      fill_in 'regular_event[end_at]', with: Time.zone.parse('22:00')
+      fill_in 'regular_event[description]', with: '定期イベントがWIPのときの次回開催日時の表示確認を行うための定期イベント'
+      assert_difference 'RegularEvent.count', 1 do
+        click_button 'WIP'
+      end
+    end
+
+    visit_with_auth regular_event_path(RegularEvent.last), 'komagata'
+    assert_equal 'WIPの定期イベント表示確認用 | FBC', title
+    assert_text '毎週日曜日21:00 〜 22:00（祝日は休み）'
+    assert_text 'イベント編集中のため次回開催日は未定です'
+    assert_text '定期イベントがWIPのときの次回開催日時の表示確認を行うための定期イベント'
+  end
+
   test 'update regular event' do
     visit_with_auth edit_regular_event_path(regular_events(:regular_event1)), 'komagata'
     assert_no_selector 'label', text: '定期イベント公開のお知らせを書く'


### PR DESCRIPTION
## Issue

- #7798 

## 概要
- 開催前の定期イベントは次回開催日を表示しないようにしました。

## 変更確認方法

1. `feature/next-date-not-displayed-for-wip-regular-event` をローカルに取り込む
2. ログインして、WIP の定期イベントを作成
3. 2 で作成した WIP の定期イベントの詳細ページにアクセス
4. 次回開催日が「イベント編集中のため次回開催日は未定です」となっていることを確認する

## Screenshot

### 変更前
![スクリーンショット 2024-08-07 21 46 02](https://github.com/user-attachments/assets/88047231-d527-4e80-9689-c45fefade3a9)

### 変更後
![スクリーンショット 2024-08-07 21 46 40](https://github.com/user-attachments/assets/c15ce252-bf0f-439d-bf8d-675de0176a20)
