### PR TITLE
期生別のユーザー人数で現役生がマイナス人数になっているのを修正

### DIFF
--- a/app/models/generation.rb
+++ b/app/models/generation.rb
@@ -46,8 +46,6 @@ class Generation
   end
 
   def count_classmates_by_target(target)
-    return classmates.students.count - classmates.hibernated.count if target == :students
-
     classmates.send(target).count
   end
 end

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -31,7 +31,7 @@ class GenerationTest < ActiveSupport::TestCase
   end
 
   test '#count_classmates_by_target' do
-    assert_equal 13, Generation.new(5).count_classmates_by_target(:students)
+    assert_equal 14, Generation.new(5).count_classmates_by_target(:students)
     assert_equal 3, Generation.new(5).count_classmates_by_target(:trainees)
     assert_equal 1, Generation.new(5).count_classmates_by_target(:hibernated)
     assert_equal 2, Generation.new(5).count_classmates_by_target(:graduated)

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -62,7 +62,7 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       assert_text '現役生'
-      assert_selector '.card-counts__item-value', text: '13'
+      assert_selector '.card-counts__item-value', text: '14'
       assert_text '研修生'
       assert_selector '.card-counts__item-value', text: '3'
       assert_text '休会'


### PR DESCRIPTION
現役生 - 休会中
という式になっていたが、現役生の時点で休会中の人数を除外していたため。

Fix: #8021