### PR TITLE
url をダブルクォーテーションでくくる

### DIFF
--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -58,7 +58,7 @@ export default class {
         csrfToken: CSRF.getToken(),
         placeholder: '%filenameをアップロード中...',
         uploadImageTag:
-          '<img src=%url width="%width" height="%height" loading="lazy" decoding="async" alt="%filename">\n',
+          '<img src="%url" width="%width" height="%height" loading="lazy" decoding="async" alt="%filename">\n',
         afterPreview: () => {
           autosize.update(textarea)
 


### PR DESCRIPTION
## Issue

- #7303 

## 概要

textarea に画像をアップロードした際のタグを Markdown 形式から HTML 形式にしたのですが、画像アップロードしてもプレビューに表示されなくなってしまいました。

![image](https://github.com/user-attachments/assets/b7df98f5-1c26-4aa6-bbf5-48b2f88e55ca)

URL 部をダブルクォートで囲み、プレビュー表示できるようにしました。

## 変更確認方法

1. bug/textarea_image_format_markdown_to_htmltag_url をローカルに取り込む
2. foreman start -f Procfile.dev でアプリを立ち上げる
3. komagata でログイン
4. [お知らせ作成](http://localhost:3000/announcements/new)のフォームページにアクセスし、テキストエリアに画像をアップロードし、テキストが `<img src="ファイルパス" width="100" height="100" loading="lazy" decoding="async" alt=”image.png”>` で、**『ファイルパス』部分がダブルクォートで囲まれている**かを確認してください。
※ textarea への画像アップロードに対応するページは複数ありますが、代表例として『お知らせ作成』のみを確認いただこうと思います。

## Screenshot

### 変更前

![image](https://github.com/user-attachments/assets/b7df98f5-1c26-4aa6-bbf5-48b2f88e55ca)

### 変更後

![image](https://github.com/user-attachments/assets/01c28312-fe5b-4b7b-8d16-e3cd1b86b0d8)

