### PR TITLE
【メンター向け】新しく受講生が入会したことをメンターに知らせるメールにコース名を記載

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -370,6 +370,8 @@ class ActivityMailer < ApplicationMailer
     @sender_roles ||= args[:sender_roles]
 
     @user = @receiver
+    @course_name = Course.find(@sender.course_id).title
+
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:signed_up]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -370,7 +370,7 @@ class ActivityMailer < ApplicationMailer
     @sender_roles ||= args[:sender_roles]
 
     @user = @receiver
-    @course_name = Course.find(@sender.course_id).title
+    @course_name = @sender.course[:title]
 
     @link_url = notification_redirector_url(
       link: "/users/#{@sender.id}",

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -377,7 +377,7 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:signed_up]
     )
 
-    subject = "[FBC] #{@sender.login_name}さん#{@sender_roles}が#{@course_name}コースに新しく入会しました！"
+    subject = "[FBC] #{@sender.login_name}さん#{@sender_roles}が#{@course_name}コースに入会しました！"
     message = mail(to: @user.email, subject:)
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -377,7 +377,7 @@ class ActivityMailer < ApplicationMailer
       kind: Notification.kinds[:signed_up]
     )
 
-    subject = "[FBC] #{@sender.login_name}さん#{@sender_roles}が新しく入会しました！"
+    subject = "[FBC] #{@sender.login_name}さん#{@sender_roles}が#{@course_name}コースに新しく入会しました！"
     message = mail(to: @user.email, subject:)
     message.perform_deliveries = @user.mail_notification? && !@user.retired?
 

--- a/app/views/activity_mailer/signed_up.html.slim
+++ b/app/views/activity_mailer/signed_up.html.slim
@@ -1,3 +1,4 @@
 = render '/notification_mailer/notification_mailer_template',
-title: "#{@sender.login_name}さん#{@sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"}が#{@course_name}コースに新しく入会しました！",
-link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ"
+title: "#{@sender.login_name}さん#{@sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"}が#{@course_name}コースに入会しました！",
+link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ" do
+  = md2html(@sender.description)

--- a/app/views/activity_mailer/signed_up.html.slim
+++ b/app/views/activity_mailer/signed_up.html.slim
@@ -1,3 +1,3 @@
 = render '/notification_mailer/notification_mailer_template',
-title: "#{@sender.login_name}さん#{@sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"}が新しく入会しました！",
+title: "#{@sender.login_name}さん#{@sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"}が#{@course_name}コースに新しく入会しました！",
 link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ"

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -905,7 +905,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] hajimeさんが新しく入会しました！', email.subject
+    assert_equal '[FBC] hajimeさんがRailsエンジニアコースに新しく入会しました！', email.subject
     assert_match(/入会/, email.body.to_s)
   end
 
@@ -933,7 +933,35 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] hajimeさんが新しく入会しました！', email.subject
+    assert_equal '[FBC] hajimeさんがRailsエンジニアコースに新しく入会しました！', email.subject
+    assert_match(/入会/, email.body.to_s)
+  end
+
+  test 'mentor receives email when user joins frontend engineer course' do
+    user = User.create!(
+      login_name: 'frontend',
+      email: 'frontend@fjord.jp',
+      password: 'testtest',
+      name: 'フロント 極め太郎',
+      name_kana: 'フロント キワメタロウ',
+      description: 'フロントエンドエンジニアコースに入会したユーザーです',
+      course: courses(:course4),
+      job: 'unemployed',
+      os: 'mac',
+      experience: 'ruby'
+    )
+    mentor = users(:komagata)
+
+    ActivityMailer.signed_up(
+      sender: user,
+      receiver: mentor
+    ).deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['noreply@bootcamp.fjord.jp'], email.from
+    assert_equal ['komagata@fjord.jp'], email.to
+    assert_equal '[FBC] frontendさんがフロントエンドエンジニアコースに新しく入会しました！', email.subject
     assert_match(/入会/, email.body.to_s)
   end
 

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -905,7 +905,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] hajimeさんがRailsエンジニアコースに新しく入会しました！', email.subject
+    assert_equal '[FBC] hajimeさんがRailsエンジニアコースに入会しました！', email.subject
     assert_match(/入会/, email.body.to_s)
   end
 
@@ -933,7 +933,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] hajimeさんがRailsエンジニアコースに新しく入会しました！', email.subject
+    assert_equal '[FBC] hajimeさんがRailsエンジニアコースに入会しました！', email.subject
     assert_match(/入会/, email.body.to_s)
   end
 
@@ -961,7 +961,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] frontendさんがフロントエンドエンジニアコースに新しく入会しました！', email.subject
+    assert_equal '[FBC] frontendさんがフロントエンドエンジニアコースに入会しました！', email.subject
     assert_match(/入会/, email.body.to_s)
   end
 


### PR DESCRIPTION
## Issue
- #7914 

## 概要
1. 新しく受講生が入会した際に、メンターに送信されるメールの件名および本文に「Railsエンジニアコース」または「フロントエンドエンジニアコース」のコース名を記載し、どちらのコースに入会したかがメールで一目でわかるようにしました。
2. 入会した受講生の自己紹介文がメールに表示されるようになりました。

## 変更確認方法

1. `feature/notify-mentor-of-new-student-joined-with-course-name` をローカルに取り込む
3. `foreman start -f Procfile.dev` でローカル環境を立ち上げる
4. メール送信されたことを確認するため [letter_opener_web](http://localhost:3000/letter_opener/) にアクセスしページを開いておく
5. Bootcamp のログイン画面から「参加登録」を押下し、コース選択画面でコースを選択
6. フィヨルドブートキャンプ参加登録画面で参加に必要な必須項目を入力し「参加する」ボタンを押下
7. 3 で開いていたページを開いて、画面左上の青色の「Refresh」ボタンを押下
8. メンターに送信されたメールの件名及び本文に 4 で選択したコース名が記載されていることを確認

## Screenshot

### 変更前
![スクリーンショット 2024-08-27 2 27 01](https://github.com/user-attachments/assets/07db1e14-65fc-4718-94b2-447ac1e13b53)


### 変更後
![スクリーンショット 2024-09-13 15 45 16](https://github.com/user-attachments/assets/8644da57-0769-4947-ab5f-ca1d8192b435)




