### PR TITLE
textarea に画像をアップロードしたときのプレビュー画面に表示された画像をクリックすると、別タブで開かれるようにしました

### DIFF
--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -58,7 +58,7 @@ export default class {
         csrfToken: CSRF.getToken(),
         placeholder: '%filenameをアップロード中...',
         uploadImageTag:
-          '<img src="%url" width="%width" height="%height" loading="lazy" decoding="async" alt="%filename">\n',
+          '<a href="%url" target="_blank" rel="noopener noreferrer"><img src="%url" width="%width" height="%height" alt="%filename"></a>\n',
         afterPreview: () => {
           autosize.update(textarea)
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "^1.6.0",
+    "textarea-markdown": "../npm/textarea-markdown",
     "tributejs": "^5.1.3",
     "use-sync-external-store": "^1.2.0",
     "vue": "^2.6.10",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "../npm/textarea-markdown",
+    "textarea-markdown": "^1.6.1",
     "tributejs": "^5.1.3",
     "use-sync-external-store": "^1.2.0",
     "vue": "^2.6.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8961,8 +8961,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-textarea-markdown@../npm/textarea-markdown:
+textarea-markdown@^1.6.1:
   version "1.6.1"
+  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.6.1.tgz#8b9483c29dc09f0923ca8c5754dd6f5f07344032"
+  integrity sha512-Dgj4vbPcji6WkXQLIHqr1jgSpK52hZbO6KSylnBOfpbEOqxTD3jaQCO7+EK/+7o6IbSm+wXQqcZRnv22E1+Neg==
   dependencies:
     file-type "^16.5.4"
     filesize "^10.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8961,10 +8961,8 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-textarea-markdown@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.6.0.tgz#1689a8beaf17b0b11a440dfbebd4649ba3158018"
-  integrity sha512-cF4Xh54cu30fb+8a/SaN+r2ol0N8O9m5TKkxiGf7Cvv87FT4WfcQLWGanuwhKCdrZFjf7Vgv5X3XwpefVl8/gw==
+textarea-markdown@../npm/textarea-markdown:
+  version "1.6.1"
   dependencies:
     file-type "^16.5.4"
     filesize "^10.0.5"


### PR DESCRIPTION
## Issue

- #7303

## 概要

[以前のPR](https://github.com/fjordllc/bootcamp/pull/8009)にて textarea に画像をアップロードした際の記法を、マークダウン形式から HTML タグ形式にしましたが、画像をクリックすると別タブで表示できなくなってしまったため表示できるようにしました。[参考](https://github.com/fjordllc/bootcamp/issues/7303#issuecomment-2310981732)

変更に伴い [textarea-markdown npm](https://www.npmjs.com/package/textarea-markdown) を更新しています。npm のコード修正は[こちら](https://github.com/komagata/textarea-markdown/pull/50)の PR にて実施済みとなっているため確認不要です。本 PR では FBC アプリでの機能確認が主となります。

## 変更確認方法

1. bug/textarea_image_format_markdown_to_htmltag_href をローカルに取り込む
2. `bin/setup` で npm を更新
3. `foreman start -f Procfile.dev` でアプリを立ち上げる
4. 任意ユーザ でログイン
5. [お知らせ作成](http://localhost:3000/announcements/new)のフォームページにアクセスし、テキストエリアに画像をアップロードし、テキストが `<a href="{画像のURL}" target="_blank" rel="noopener noreferrer"><img src="{画像のURL}" width="xxxx" height="xxxx" alt="{画像のファイル名}"></a>` となっていることを確認する
6. 画像をクリックし、別タブで開かれるかを確認する

  > [!NOTE]
  > textarea へ画像をアップロードするページは複数ありますが、代表例として『お知らせ作成』のみを確認いただこうと思います。

## Screenshot

### 変更前

画像をテキストエリアに貼り付けて、プレビューに表示された画像をクリックしても別タブが開かれませんでした。

![edfb4642eedf5160b04aef01782cd763](https://github.com/user-attachments/assets/32da814c-6b1f-4b1d-9362-6b38cbb90d89)


### 変更後

プレビューに表示された画像をクリックすると別タブに画像が開かれるようになりました。

[![Image from Gyazo](https://i.gyazo.com/bc11f03d367779dab1d2001f99fc6326.gif)](https://gyazo.com/bc11f03d367779dab1d2001f99fc6326)

