### PR TITLE
Discordの「イベントのお知らせ」が一部開始時間順になっていなかった不具合を修正

### DIFF
--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -42,8 +42,8 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
   def coming_soon_regular_events(params = {})
     params.merge!(@params)
     webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:all]
-    today_events = params[:today_events].sort_by(&:start_at)
-    tomorrow_events = params[:tomorrow_events].sort_by(&:start_at)
+    today_events = params[:today_events].sort_by { |event| event.start_at.strftime('%H%M') }
+    tomorrow_events = params[:tomorrow_events].sort_by { |event| event.start_at.strftime('%H%M') }
     today = Time.current
     tomorrow = Time.current.next_day
     event_info = <<~TEXT.gsub(/^\n+/, "\n").chomp

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -94,3 +94,8 @@ regular_event_repeat_rule36:
   frequency: 1
   day_of_the_week: 3
   regular_event: regular_event34
+
+regular_event_repeat_rule37:
+  frequency: 1
+  day_of_the_week: 6
+  regular_event: regular_event33

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -155,3 +155,13 @@ regular_event32:
   user: komagata
   category: 0
   published_at: "2023-08-01 00:00:00"
+
+regular_event33:
+  title: Discord通知確認用イベント(土曜日午前8時から開催)
+  description: Discord通知確認用、土曜日午前8時開始です
+  finished: false
+  hold_national_holiday: false
+  start_at: <%= Time.zone.local(2020, 1, 1, 8, 0, 0) %>
+  end_at: <%= Time.zone.local(2020, 1, 1, 9, 0, 0) %>
+  user: komagata
+  published_at: "2023-08-01 00:00:00"

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -28,7 +28,7 @@ class RegularEventTest < ActiveSupport::TestCase
       assert_equal tomorrow_events_count, tomorrow_events.count
 
       day_after_tomorrow_date = Time.zone.today + 2.days
-      day_after_tomorrow_events_count = 1
+      day_after_tomorrow_events_count = 2
       day_after_tomorrow_events = RegularEvent.scheduled_on(day_after_tomorrow_date)
       assert_equal day_after_tomorrow_events_count, day_after_tomorrow_events.count
     end

--- a/test/models/upcoming_event_test.rb
+++ b/test/models/upcoming_event_test.rb
@@ -24,7 +24,8 @@ class UpcomingEventTest < ActiveSupport::TestCase
       ]
       day_after_tomorrow_events = [
         events(:event32),
-        regular_events(:regular_event7)
+        regular_events(:regular_event7),
+        regular_events(:regular_event33)
       ]
       today_upcoming_events = today_events.map { |e| UpcomingEvent.new(e, Time.zone.today) }
       tomorrow_upcoming_events = tomorrow_events.map { |e| UpcomingEvent.new(e, Time.zone.tomorrow) }

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -65,7 +65,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
   test '.coming_soon_regular_events' do
     params = {
       today_events: [regular_events(:regular_event26), regular_events(:regular_event30), regular_events(:regular_event31)],
-      tomorrow_events: [regular_events(:regular_event28), regular_events(:regular_event29), regular_events(:regular_event31)],
+      tomorrow_events: [regular_events(:regular_event28), regular_events(:regular_event29), regular_events(:regular_event31), regular_events(:regular_event33)],
       webhook_url: 'https://discord.com/api/webhooks/0123456789/xxxxxxxx'
     }
     event_info = <<~TEXT.chomp
@@ -84,6 +84,10 @@ class DiscordNotifierTest < ActiveSupport::TestCase
       ------------------------------
 
       < 明日 (05/06 土) 開催 >
+
+      Discord通知確認用イベント(土曜日午前8時から開催)
+      時間: 08:00〜09:00
+      詳細: <http://localhost:3000/regular_events/507245517>
 
       Discord通知確認用イベント(土曜日 + 日曜日開催)
       時間: 09:00〜10:00

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -531,7 +531,7 @@ class EventsTest < ApplicationSystemTestCase
   test 'upcoming events groups' do
     today_events_count = 5
     tomorrow_events_count = 2
-    day_after_tomorrow_events_count = 2
+    day_after_tomorrow_events_count = 3
     travel_to Time.zone.local(2017, 4, 3, 10, 0, 0) do
       visit_with_auth events_path, 'komagata'
       within('.upcoming_events_groups') do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -235,6 +235,7 @@ class HomeTest < ApplicationSystemTestCase
         { category: '特別', title: '直近イベントの表示テスト用(翌日)', start_at: '2017年04月04日(火) 22:00' }
       ]
       day_after_tomorrow_events_texts = [
+        { category: '輪読会', title: 'Discord通知確認用イベント(土曜日午前8時から開催)', start_at: '2017年04月05日(水) 08:00' },
         { category: '特別', title: '直近イベントの表示テスト用(明後日)', start_at: '2017年04月05日(水) 09:00' },
         { category: '輪読会', title: '独習Git輪読会', start_at: '2017年04月05日(水) 21:00' }
       ]

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -41,6 +41,10 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
 
       < 明日 (05/06 土) 開催 >
 
+      Discord通知確認用イベント(土曜日午前8時から開催)
+      時間: 08:00〜09:00
+      詳細: <http://localhost:3000/regular_events/507245517>
+
       Discord通知確認用イベント(土曜日 + 日曜日開催)
       時間: 09:00〜10:00
       詳細: <http://localhost:3000/regular_events/670378901>

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -196,7 +196,7 @@ class RegularEventsTest < ApplicationSystemTestCase
 
   test 'show listing not finished regular events' do
     visit_with_auth regular_events_path(target: 'not_finished'), 'kimura'
-    assert_selector '.card-list.a-card .card-list-item', count: 14
+    assert_selector '.card-list.a-card .card-list-item', count: 15
   end
 
   test 'show listing all regular events' do
@@ -368,7 +368,7 @@ class RegularEventsTest < ApplicationSystemTestCase
   test 'upcoming events groups' do
     today_events_count = 5
     tomorrow_events_count = 2
-    day_after_tomorrow_events_count = 2
+    day_after_tomorrow_events_count = 3
     travel_to Time.zone.local(2017, 4, 3, 10, 0, 0) do
       visit_with_auth events_path, 'komagata'
       within('.upcoming_events_groups') do


### PR DESCRIPTION
## Issue

- #7764 

## 概要
#7923 にて「イベントのお知らせ」に記載されるイベントを開始時間順に並べる変更がマージされましたが、ソートの条件が適切でなかったために意図した順番で表示されない不具合が発生していました。
本PRにてその修正を行なっていますのでご確認ください。

## 変更確認方法

1. `bug/corrected-events-order-in-discord-notifications`をローカルに取り込む
2. #7923 と同様に確認用のDiscordサーバーに通知が届くよう環境変数を設定する
3. `bin/rails test test/system/notification/regular_events_test.rb`を実行する
4. 届いた通知の`< 明日 (05/06 土) 開催 >`分のイベントが開始時間順に並んでいることを確認する。**特に8時開始のイベントが9時開始のものよりも上に記載されているかどうか**を確認する。

## Screenshot
<img width="616" alt="image" src="https://github.com/user-attachments/assets/4296c68d-8594-4258-8a8b-3e98f7ba711f">
