### PR TITLE
WIPブログのテストデータにtokenを設定

### DIFF
--- a/db/fixtures/articles.yml
+++ b/db/fixtures/articles.yml
@@ -55,6 +55,7 @@ article3:
     物理マシンでしたらインストールCD（やUSB）をマシンに入れてインストールしますが、仮想マシンの場合は、仮想のCDドライブにCDイメージをセットしてインストールします。
   user: komagata
   wip: true
+  token: <%= SecureRandom.urlsafe_base64 %>
 
 article4:
   title: Debianでzshを使う
@@ -78,6 +79,7 @@ article4:
   user: komagata
   wip: true
   published_at: "2022-04-04 00:00:00"
+  token: <%= SecureRandom.urlsafe_base64 %>
 
 <% (5..20).each do |id| %>
 article<%= id %>:


### PR DESCRIPTION
## Issue

- #7199 

## 概要

[WIP ブログ一覧ページと各 WIP ブログのプレビューページを用意した](https://github.com/fjordllc/bootcamp/pull/7299)にてWIPブログ一覧とプレビューページを追加しましたが、テストデータにトークンが設定されていなかったため設定しました。

## 変更確認方法

1. bug/blog_preview_page_publish_set-token をローカルに取り込む
2. 下記コマンドでまっさらなDBにしてテストデータを読み込む
  1. rails db:drop
  2. rails db:create
  3. rails db:migrate
  4. rails db:seed
3. ID `komagata` でログインする
4. http://localhost:3000/articles/wips にアクセスし、WIP 一覧に表示されている WIP ブログの適当な一つを開く
5. `token` が表示されることを確認する

### 変更前

`token` が設定されていない

![image](https://github.com/user-attachments/assets/7117eb47-1989-4807-afa8-ee7884c2e75b)

### 変更後

`token` が設定されている

![image](https://github.com/user-attachments/assets/90c2958b-ffce-45eb-8411-c2654730b4d1)



