### PR TITLE
日報が確認OKされていない場合、メンターがコメントした時にアラートが出るように実装

### DIFF
--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -294,6 +294,17 @@ export default {
       }
     },
     postComment() {
+      if (this.commentableType === 'Report' && this.isRole('mentor')) {
+        const noConfirmed = !this.checkId
+        if (noConfirmed) {
+          const confirmResult = window.confirm(
+            '日報を確認済みにしていませんがよろしいですか？'
+          )
+          if (!confirmResult) {
+            return
+          }
+        }
+      }
       this.createComment()
       if (this.isUnassignedAndUnchekedProduct) {
         this.checkProduct(

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -295,12 +295,11 @@ export default {
     },
     postComment() {
       if (this.commentableType === 'Report' && this.isRole('mentor')) {
-        const noConfirmed = !this.checkId
-        if (noConfirmed) {
-          const confirmResult = window.confirm(
-            '日報を確認済みにしていませんがよろしいですか？'
-          )
-          if (!confirmResult) {
+        const notChecked = !this.checkId
+        if (notChecked) {
+          if (
+            !window.confirm('日報を確認済みにしていませんがよろしいですか？')
+          ) {
             return
           }
         }

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -296,12 +296,11 @@ export default {
     postComment() {
       if (this.commentableType === 'Report' && this.isRole('mentor')) {
         const notChecked = !this.checkId
-        if (notChecked) {
-          if (
-            !window.confirm('日報を確認済みにしていませんがよろしいですか？')
-          ) {
-            return
-          }
+        if (
+          notChecked &&
+          !window.confirm('日報を確認済みにしていませんがよろしいですか？')
+        ) {
+          return
         }
       }
       this.createComment()

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -353,9 +353,9 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text '確認OKにする'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'comment test')
+      click_button 'コメントする'
     end
     accept_confirm '日報を確認済みにしていませんがよろしいですか？' do
-      click_button 'コメントする'
     end
     assert_text 'comment test'
   end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -359,5 +359,4 @@ class CommentsTest < ApplicationSystemTestCase
     end
     assert_text 'comment test'
   end
-  
 end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -353,9 +353,9 @@ class CommentsTest < ApplicationSystemTestCase
     assert_text '確認OKにする'
     within('.thread-comment-form__form') do
       fill_in('new_comment[description]', with: 'comment test')
-      click_button 'コメントする'
     end
     accept_confirm '日報を確認済みにしていませんがよろしいですか？' do
+      click_button 'コメントする'
     end
     assert_text 'comment test'
   end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -347,4 +347,17 @@ class CommentsTest < ApplicationSystemTestCase
     end
     assert_equal '.new-comment-file-input', find('textarea.a-text-input')['data-input']
   end
+
+  test 'show confirm dialog if report is not confirmed' do
+    visit_with_auth "/reports/#{reports(:report2).id}", 'machida'
+    assert_text '確認OKにする'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'comment test')
+    end
+    accept_confirm '日報を確認済みにしていませんがよろしいですか？' do
+      click_button 'コメントする'
+    end
+    assert_text 'comment test'
+  end
+  
 end


### PR DESCRIPTION
元々メンターが日報にコメントをだけ入れて確認済みにしないまま画面を離れようとしたらアラートを出す。
というイシューだったのですが、ブラウザの仕様によりbeforeunloadイベントではカスタムメッセージを表示することができないことがわかりました。
そのことを町田さんに相談させていただいて、確認済になっていないとき、Bではなく、Aをクリックしたら、
「日報を確認済みにしていませんがよろしいですか？」
とアラートを出るようにしたいということで進めました。
![image](https://github.com/user-attachments/assets/8a4f5eed-6c04-4194-bdbd-a13f30b9e166)


## Issue

- #6928 

## 概要
日報が確認OKされていない場合、メンターがコメントした時にアラートが出るように実装しました。

## 変更確認方法

1. `feature/alert-for-unconfirmed-daily-report-comment`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. `machida`でログイン
4. 未チェックの日報をクリック
5. コメントを書いて`コメントする`をクリック
6. 「日報を確認済みにしていませんがよろしいですか？」とアラートが出ることを確認
## Screenshot

### 変更前
![スクリーンショット (609)](https://github.com/user-attachments/assets/f98fa9e2-5e35-4bf2-8ac3-45130fbae1df)

### 変更後

![スクリーンショット (610)](https://github.com/user-attachments/assets/bf394041-99c0-4718-94ec-b4ff6a7be45a)


念のため、以下の２つも確認しました。
メンター以外がコメントしてもアラートが出ないことも確認しました。
![スクリーンショット (611)](https://github.com/user-attachments/assets/f5c1a0de-a4bf-4070-8153-002caf555d42)

メンターが日報が以外にコメントしてもアラートが出ないことを確認しました。
![スクリーンショット (613)](https://github.com/user-attachments/assets/a5ed6ae0-e048-4790-96bf-fa28c7515848)

