### PR TITLE
ユーザー一覧に「コース別」のページを追加した

### DIFF
--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Users::CoursesController < ApplicationController
+  ALLOWED_TARGETS = %w[rails_course front_end_course other_courses].freeze
+
+  def index
+    @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
+  end
+end

--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -15,5 +15,10 @@ class Users::CoursesController < ApplicationController
              .page(params[:page]).per(PAGER_NUMBER)
              .preload(:avatar_attachment, :course, :taggings)
              .order(updated_at: :desc)
+
+    return unless params[:search_word]
+
+    search_user = SearchUser.new(word: params[:search_word], users: @users, target: @target)
+    @users = search_user.search
   end
 end

--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -7,7 +7,8 @@ class Users::CoursesController < ApplicationController
 
   def index
     @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
-    target_users = User.by_course(Course.course_names[@target.to_sym]).students_and_trainees
+    course_names = Course.where(published: true).where(title: I18n.t("course_names.#{@target}")).pluck(:title)
+    target_users = User.by_course(course_names).students_and_trainees
     @users = target_users
              .page(params[:page]).per(PAGER_NUMBER)
              .preload(:avatar_attachment, :course, :taggings)

--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -7,7 +7,7 @@ class Users::CoursesController < ApplicationController
 
   def index
     @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
-    target_users = User.by_course(User::COURSE_NAMES[@target.to_sym]).students_and_trainees
+    target_users = User.by_course(Course.course_names[@target.to_sym]).students_and_trainees
     @users = target_users
              .page(params[:page]).per(PAGER_NUMBER)
              .preload(:avatar_attachment, :course, :taggings)

--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -3,11 +3,17 @@
 class Users::CoursesController < ApplicationController
   ALLOWED_TARGETS = %w[rails_course front_end_course other_courses].freeze
 
+  PAGER_NUMBER = 24
+
   def index
     @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
     course_names = { rails_course: 'Railsエンジニア',
                      front_end_course: 'フロントエンドエンジニア',
                      other_courses: %w[Unityゲームエンジニア iOSエンジニア] }
-    @users = User.by_course(course_names[@target.to_sym]).students_and_trainees
+    target_users = User.by_course(course_names[@target.to_sym]).students_and_trainees
+    @users = target_users
+             .page(params[:page]).per(PAGER_NUMBER)
+             .preload(:avatar_attachment, :course, :taggings)
+             .order(updated_at: :desc)
   end
 end

--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -7,10 +7,7 @@ class Users::CoursesController < ApplicationController
 
   def index
     @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
-    course_names = { rails_course: 'Railsエンジニア',
-                     front_end_course: 'フロントエンドエンジニア',
-                     other_courses: %w[Unityゲームエンジニア iOSエンジニア] }
-    target_users = User.by_course(course_names[@target.to_sym]).students_and_trainees
+    target_users = User.by_course(User::COURSE_NAMES[@target.to_sym]).students_and_trainees
     @users = target_users
              .page(params[:page]).per(PAGER_NUMBER)
              .preload(:avatar_attachment, :course, :taggings)

--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -5,5 +5,9 @@ class Users::CoursesController < ApplicationController
 
   def index
     @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
+    course_names = { rails_course: 'Railsエンジニア',
+                     front_end_course: 'フロントエンドエンジニア',
+                     other_courses: %w[Unityゲームエンジニア iOSエンジニア] }
+    @users = User.by_course(course_names[@target.to_sym]).students_and_trainees
   end
 end

--- a/app/helpers/page_tabs/users_helper.rb
+++ b/app/helpers/page_tabs/users_helper.rb
@@ -19,6 +19,7 @@ module PageTabs
     def users_page_tabs(active_tab:)
       tabs = []
       tabs << { name: '全て', link: users_path }
+      tabs << { name: 'コース別', link: users_courses_path }
       tabs << { name: '期生別', link: generations_path }
       tabs << { name: 'タグ別', link: users_tags_path }
       tabs << { name: 'フォロー中', link: users_path(target: 'followings') }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,10 +3,6 @@
 class Course < ApplicationRecord
   DEFAULT_COURSE = 'Railsエンジニア'
 
-  COURSE_NAMES = { rails_course: 'Railsエンジニア',
-                   front_end_course: 'フロントエンドエンジニア',
-                   other_courses: %w[Unityゲームエンジニア iOSエンジニア] }.freeze
-
   has_many :courses_categories, dependent: :destroy
   has_many :categories, through: :courses_categories
   has_many :practices, through: :categories
@@ -17,9 +13,5 @@ class Course < ApplicationRecord
 
   def self.default_course
     find_by(title: DEFAULT_COURSE)
-  end
-
-  def self.course_names
-    COURSE_NAMES
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,6 +3,10 @@
 class Course < ApplicationRecord
   DEFAULT_COURSE = 'Railsエンジニア'
 
+  COURSE_NAMES = { rails_course: 'Railsエンジニア',
+                   front_end_course: 'フロントエンドエンジニア',
+                   other_courses: %w[Unityゲームエンジニア iOSエンジニア] }.freeze
+
   has_many :courses_categories, dependent: :destroy
   has_many :categories, through: :courses_categories
   has_many :practices, through: :categories
@@ -13,5 +17,9 @@ class Course < ApplicationRecord
 
   def self.default_course
     find_by(title: DEFAULT_COURSE)
+  end
+
+  def self.course_names
+    COURSE_NAMES
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -286,6 +286,7 @@ class User < ApplicationRecord
   scope :auto_retire, -> { where(auto_retire: true) }
   scope :advisers, -> { where(adviser: true) }
   scope :not_advisers, -> { where(adviser: false) }
+  scope :by_course, ->(target) { joins(:course).where(courses: { title: target }) }
   scope :students_and_trainees, lambda {
     where(
       admin: false,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,10 @@ class User < ApplicationRecord
     [I18n.t('invitation_role.mentor'), :mentor]
   ].freeze
 
+  COURSE_NAMES = { rails_course: 'Railsエンジニア',
+                   front_end_course: 'フロントエンドエンジニア',
+                   other_courses: %w[Unityゲームエンジニア iOSエンジニア] }.freeze
+
   enum job: {
     student: 0,
     office_worker: 2,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,10 +35,6 @@ class User < ApplicationRecord
     [I18n.t('invitation_role.mentor'), :mentor]
   ].freeze
 
-  COURSE_NAMES = { rails_course: 'Railsエンジニア',
-                   front_end_course: 'フロントエンドエンジニア',
-                   other_courses: %w[Unityゲームエンジニア iOSエンジニア] }.freeze
-
   enum job: {
     student: 0,
     office_worker: 2,

--- a/app/views/users/_user_list.html.slim
+++ b/app/views/users/_user_list.html.slim
@@ -1,9 +1,9 @@
 - if users.present?
   .user-list
-    = paginate users, params: { controller: 'users', action: 'index' }
+    = paginate users
     .row
       - users.each do |user|
         = render 'users/user', user:
-    = paginate users, params: { controller: 'users', action: 'index' }
+    = paginate users
 - else
   = render 'users/no_match_user'

--- a/app/views/users/courses/_users_tabs.html.slim
+++ b/app/views/users/courses/_users_tabs.html.slim
@@ -1,0 +1,6 @@
+nav.tab-nav
+  .container
+    ul.tab-nav__items
+      - Users::CoursesController::ALLOWED_TARGETS.each do |target|
+        li.tab-nav__item
+          = link_to t("target.#{target}"), users_courses_path(target:), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'

--- a/app/views/users/courses/index.html.slim
+++ b/app/views/users/courses/index.html.slim
@@ -10,7 +10,7 @@ header.page-header
         .page-header-actions
           ul.page-header-actions__items
 
-= render '/users/lg_page_tabs'
+= users_page_tabs(active_tab: 'コース別')
 = render 'users_tabs'
 
 main.page-main

--- a/app/views/users/courses/index.html.slim
+++ b/app/views/users/courses/index.html.slim
@@ -18,5 +18,13 @@ main.page-main
     .container
       .page-main-header__inner
         h1.page-main-header__title
-          = 'コース別'
-          | （#{t("target.#{@target}")}）
+          - if @target == 'rails_course' || @target == 'front_end_course'
+            = "#{t("target.#{@target}")}エンジニアコース"
+            | （#{@users.total_count}）
+          - else
+            = "#{t("target.#{@target}")}のコース"
+            | （#{@users.total_count}）
+  hr.a-border
+    .page-content.is-users
+      #user_lists.users__items
+        = render 'users/user_list', users: @users

--- a/app/views/users/courses/index.html.slim
+++ b/app/views/users/courses/index.html.slim
@@ -1,0 +1,22 @@
+- title 'コース別ユーザー一覧'
+- set_meta_tags description: 'コース別ユーザー一覧ページです。'
+
+header.page-header
+  .container
+    .page-header__inner
+      .page-header__start
+        h2.page-header__title ユーザー一覧
+      .page-header__end
+        .page-header-actions
+          ul.page-header-actions__items
+
+= render '/users/lg_page_tabs'
+= render 'users_tabs'
+
+main.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        h1.page-main-header__title
+          = 'コース別'
+          | （#{t("target.#{@target}")}）

--- a/app/views/users/courses/index.html.slim
+++ b/app/views/users/courses/index.html.slim
@@ -25,6 +25,22 @@ main.page-main
             = "#{t("target.#{@target}")}のコース"
             | （#{@users.total_count}）
   hr.a-border
-    .page-content.is-users
-      #user_lists.users__items
-        = render 'users/user_list', users: @users
+    .page-body.is-users
+        .page-body__inner.has-side-nav
+          .container
+            .users
+              .page-filter.form.pt-0
+                .container.is-md.has-no-x-padding
+                  .form__items
+                    = form_with url: request.path_info, method: 'get', local: true
+                      .form-item.is-inline-md-up
+                        label.a-form-label
+                          | 絞り込み
+                        = hidden_field_tag :target, params[:target]
+                        = text_field_tag :search_word, params[:search_word], class: 'a-text-input',
+                                          placeholder: 'ユーザーID、ユーザー名、読み方、Discord ID など',
+                                          onchange: 'this.form.submit()',
+                                          id: 'js-user-search-input'
+              .page-content.is-users
+                #user_lists.users__items
+                  = render 'users/user_list', users: @users

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -399,6 +399,10 @@ ja:
     adviser: アドバイザー
     trainee: 研修生(%{payment_method})
     mentor: メンター
+  course_names:
+    rails_course: Railsエンジニア
+    front_end_course: フロントエンドエンジニア
+    other_courses: [Unityゲームエンジニア, iOSエンジニア]
   watch:
     all: すべて
     true: コメントあり

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -392,6 +392,9 @@ ja:
     unchecked_no_replied: 未返信
     unchecked_all: 全て
     campaign: お試し延長
+    rails_course: Rails
+    front_end_course: フロントエンド
+    other_courses: その他
   invitation_role:
     adviser: アドバイザー
     trainee: 研修生(%{payment_method})

--- a/config/routes/users.rb
+++ b/config/routes/users.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   # この順番が崩れると壊れるので注意
   namespace :users do
     get "tags", to: "tags#index"
+    resources :courses, only: %i(index)
     resources :companies, only: %i(index)
     resources :areas, only: %i(index)
     get "areas/:area", to: "areas#show", as: :area

--- a/db/fixtures/courses.yml
+++ b/db/fixtures/courses.yml
@@ -28,14 +28,17 @@ course1:
     主な仕事はサーバーサイドのビジネスロジックの実装、APIの開発です。
     ユーザーが見えない部分で動作する仕組みを設計・実装し、システム全体が円滑に機能するようにします。
     :::
+  published: true
 
 course2:
   title: Unityゲームエンジニア
   description: "Unity, C#を学んでゲームエンジニアになろう。"
+  published: false
 
 course3:
   title: iOSエンジニア
   description: "iOS, Swiftを学んでiOSエンジニアになろう。"
+  published: false
 
 course4:
   title: フロントエンドエンジニア
@@ -64,3 +67,4 @@ course4:
     #### フロントエンドエンジニアとは
     フロントエンドエンジニアとはユーザーが直接触れる部分を設計・開発するエンジニアです。主な仕事はユーザーインターフェース（UI）の設計と実装です。デザイナーが作成したビジュアルデザインを、HTML、CSS、JavaScriptを駆使して再現し、ユーザーが直感的に操作できるインターフェースを構築します。これにより、優れたユーザーエクスペリエンス（UX）を提供することを目指しています。
     :::
+  published: true

--- a/db/fixtures/discord_profiles.yml
+++ b/db/fixtures/discord_profiles.yml
@@ -305,3 +305,23 @@ discord_profire_harikirio:
   user: harikirio
   account_name:
   times_url:
+
+discord_profire_rails-course:
+  user: rails-course
+  account_name:
+  times_url:
+
+discord_profire_front-end-course:
+  user: front-end-course
+  account_name:
+  times_url:
+
+discord_profire_unity-course:
+  user: unity-course
+  account_name:
+  times_url:
+
+discord_profire_ios-course:
+  user: ios-course
+  account_name:
+  times_url:

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1420,3 +1420,83 @@ harikirio: #必修でないプラクティスも修了しているユーザー
   created_at: "2020-01-01 00:00:12"
   sent_student_followup_message: true
   last_activity_at: "2020-01-01 00:00:12"
+
+rails-course:
+  login_name: rails-course
+  email: rails-course@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: Railsエンジニアコースのユーザー
+  name_kana: Railsエンジニアコースノユーザー
+  twitter_account: rails-course
+  facebook_url: https://www.facebook.com/fjordllc/rails-course
+  blog_url: http://rails-course.org
+  feed_url: https://example4.com/feed
+  description: "Railsエンジニアコースを受講中のユーザーです。"
+  course: course1
+  job: office_worker
+  os: mac
+  organization: Rails大学
+  updated_at: "2014-01-01 00:00:07"
+  created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"
+
+front-end-course:
+  login_name: front-end-course
+  email: front-end@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: フロントエンドエンジニアコースのユーザー
+  name_kana: フロントエンドエンジニアコースノユーザー
+  twitter_account: front-end
+  facebook_url: https://www.facebook.com/fjordllc/front-end
+  blog_url: http://front-end.org
+  feed_url: https://example4.com/feed
+  description: "フロントエンドエンジニアコースを受講中のユーザーです。"
+  course: course4
+  job: office_worker
+  os: mac
+  organization: フロントエンド大学
+  updated_at: "2014-01-01 00:00:07"
+  created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"
+
+unity-course:
+  login_name: unity-course
+  email: unity-course@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: Unityゲームエンジニアコースのユーザー
+  name_kana: Unityゲームエンジニアコースノユーザー
+  twitter_account: unity
+  facebook_url: https://www.facebook.com/fjordllc/unity
+  blog_url: http://unity.org
+  feed_url: https://example4.com/feed
+  description: "Unityゲームエンジニアコースを受講中のユーザーです。"
+  course: course2
+  job: office_worker
+  os: mac
+  organization: Unity大学
+  updated_at: "2014-01-01 00:00:07"
+  created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"
+
+ios-course:
+  login_name: ios-course
+  email: ios-course@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: iOSエンジニアコースのユーザー
+  name_kana: iOSエンジニアコースノユーザー
+  twitter_account: ios
+  facebook_url: https://www.facebook.com/fjordllc/ios
+  blog_url: http://ios.org
+  feed_url: https://example4.com/feed
+  description: "iOSエンジニアコースを受講中のユーザーです。"
+  course: course3
+  job: office_worker
+  os: mac
+  organization: iOS大学
+  updated_at: "2014-01-01 00:00:07"
+  created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -1,15 +1,19 @@
 course1:
   title: Railsエンジニア
   description: "Linux, Web, Ruby, Railsなどを学んでRailsエンジニアになろう。"
+  published: true
 
 course2:
   title: Unityゲームエンジニア
   description: "Unity, C#を学んでゲームエンジニアになろう。"
+  published: false
 
 course3:
   title: iOSエンジニア
   description: "iOS, Swiftを学んでiOSエンジニアになろう。"
+  published: false
 
 course4:
   title: フロントエンドエンジニア
   description: "JavaScriptやTypeScriptなどを学んでフロントエンドエンジニアになろう。"
+  published: true

--- a/test/fixtures/courses_categories.yml
+++ b/test/fixtures/courses_categories.yml
@@ -127,3 +127,18 @@ courses_category26:
   course: course1
   category: category23
   position: 18
+
+courses_category27:
+  course: course4
+  category: category1
+  position: 1
+
+courses_category28:
+  course: course4
+  category: category2
+  position: 2
+
+courses_category29:
+  course: course4
+  category: category3
+  position: 3

--- a/test/fixtures/discord_profiles.yml
+++ b/test/fixtures/discord_profiles.yml
@@ -214,3 +214,23 @@ discord_profire_harikirio:
   user: harikirio
   account_name:
   times_url:
+
+discord_profire_rails-course:
+  user: rails-course
+  account_name:
+  times_url:
+
+discord_profire_front-end-course:
+  user: front-end-course
+  account_name:
+  times_url:
+
+discord_profire_unity-course:
+  user: unity-course
+  account_name:
+  times_url:
+
+discord_profire_ios-course:
+  user: ios-course
+  account_name:
+  times_url:

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -154,3 +154,19 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
 talk42:
   user: harikirio
   action_completed: true
+
+talk43:
+  user: rails-course
+  action_completed: true
+
+talk44:
+  user: front-end-course
+  action_completed: true
+
+talk45:
+  user: unity-course
+  action_completed: true
+
+talk46:
+  user: ios-course
+  action_completed: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1022,3 +1022,83 @@ pjord:
   updated_at: "2014-01-01 00:00:01"
   created_at: "2014-01-01 00:00:01"
   last_activity_at: "2014-01-01 00:00:01"
+
+rails-course:
+  login_name: rails-course
+  email: rails-course@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: Railsエンジニアコースのユーザー
+  name_kana: Railsエンジニアコースノユーザー
+  twitter_account: rails-course
+  facebook_url: https://www.facebook.com/fjordllc/rails-course
+  blog_url: http://rails-course.org
+  feed_url: https://example4.com/feed
+  description: "Railsエンジニアコースを受講中のユーザーです。"
+  course: course1
+  job: office_worker
+  os: mac
+  organization: Rails大学
+  updated_at: "2014-01-01 00:00:07"
+  created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"
+
+front-end-course:
+  login_name: front-end-course
+  email: front-end@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: フロントエンドエンジニアコースのユーザー
+  name_kana: フロントエンドエンジニアコースノユーザー
+  twitter_account: front-end
+  facebook_url: https://www.facebook.com/fjordllc/front-end
+  blog_url: http://front-end.org
+  feed_url: https://example4.com/feed
+  description: "フロントエンドエンジニアコースを受講中のユーザーです。"
+  course: course4
+  job: office_worker
+  os: mac
+  organization: フロントエンド大学
+  updated_at: "2014-01-01 00:00:07"
+  created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"
+
+unity-course:
+  login_name: unity-course
+  email: unity-course@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: Unityゲームエンジニアコースのユーザー
+  name_kana: Unityゲームエンジニアコースノユーザー
+  twitter_account: unity
+  facebook_url: https://www.facebook.com/fjordllc/unity
+  blog_url: http://unity.org
+  feed_url: https://example4.com/feed
+  description: "Unityゲームエンジニアコースを受講中のユーザーです。"
+  course: course2
+  job: office_worker
+  os: mac
+  organization: Unity大学
+  updated_at: "2014-01-01 00:00:07"
+  created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"
+
+ios-course:
+  login_name: ios-course
+  email: ios-course@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: iOSエンジニアコースのユーザー
+  name_kana: iOSエンジニアコースノユーザー
+  twitter_account: ios
+  facebook_url: https://www.facebook.com/fjordllc/ios
+  blog_url: http://ios.org
+  feed_url: https://example4.com/feed
+  description: "iOSエンジニアコースを受講中のユーザーです。"
+  course: course3
+  job: office_worker
+  os: mac
+  organization: iOS大学
+  updated_at: "2014-01-01 00:00:07"
+  created_at: "2014-01-01 00:00:07"
+  last_activity_at: "2014-01-01 00:00:07"

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -31,7 +31,7 @@ class GenerationTest < ActiveSupport::TestCase
   end
 
   test '#count_classmates_by_target' do
-    assert_equal 14, Generation.new(5).count_classmates_by_target(:students)
+    assert_equal 18, Generation.new(5).count_classmates_by_target(:students)
     assert_equal 3, Generation.new(5).count_classmates_by_target(:trainees)
     assert_equal 1, Generation.new(5).count_classmates_by_target(:hibernated)
     assert_equal 2, Generation.new(5).count_classmates_by_target(:graduated)

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -31,14 +31,20 @@ class CoursesTest < ApplicationSystemTestCase
 
   test 'show published courses' do
     visit_with_auth '/courses', 'hajime'
-    assert_text '公開コースはありません。'
-    visit_with_auth "/mentor/courses/#{courses(:course1).id}/edit", 'komagata'
+    assert_link courses(:course1).title
+    assert_text courses(:course1).description
+    assert_link courses(:course4).title
+    assert_text courses(:course4).description
+    assert_no_link courses(:course2).title
+    assert_no_text courses(:course2).description
+    visit_with_auth "/mentor/courses/#{courses(:course2).id}/edit", 'komagata'
     within 'form[name=course]' do
       find(:css, '#checkbox-published-course').set(true)
       click_button '内容を保存'
     end
     visit_with_auth '/courses', 'hajime'
-    assert_text courses(:course1).title
+    assert_link courses(:course2).title
+    assert_text courses(:course2).description
   end
 
   test 'mentors can see closed courses' do

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -62,7 +62,7 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_link '5期生'
       assert_text '2014年01月01日 ~ 2014年03月31日'
       assert_text '現役生'
-      assert_selector '.card-counts__item-value', text: '14'
+      assert_selector '.card-counts__item-value', text: '18'
       assert_text '研修生'
       assert_selector '.card-counts__item-value', text: '3'
       assert_text '休会'

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -535,7 +535,7 @@ class QuestionsTest < ApplicationSystemTestCase
     fill_in 'question[description]', with: 'テストの質問です。'
     within '.select-user' do
       find('.choices__inner').click
-      find('#choices--js-choices-user-item-choice-12', text: 'hatsuno').click
+      find('#choices--js-choices-user-item-choice-13', text: 'hatsuno').click
     end
     click_button '登録する'
     assert_selector '.a-user-name', text: 'hatsuno (ハツノ シンジ)'
@@ -547,7 +547,7 @@ class QuestionsTest < ApplicationSystemTestCase
     click_link '内容修正'
     within '.select-user' do
       find('.choices__inner').click
-      find('#choices--js-choices-user-item-choice-12', text: 'hatsuno').click
+      find('#choices--js-choices-user-item-choice-13', text: 'hatsuno').click
     end
     click_button '更新する'
     assert_selector '.a-user-name', text: 'hatsuno (ハツノ シンジ)'
@@ -561,7 +561,7 @@ class QuestionsTest < ApplicationSystemTestCase
     end
     within '.select-user' do
       find('.choices__inner').click
-      find('#choices--js-choices-user-item-choice-12', text: 'hatsuno').click
+      find('#choices--js-choices-user-item-choice-13', text: 'hatsuno').click
     end
     click_button 'WIP'
 

--- a/test/system/user/courses_test.rb
+++ b/test/system/user/courses_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class User::CoursesTest < ApplicationSystemTestCase
+  test 'show users index by course' do
+    visit_with_auth '/users/courses', 'komagata'
+    assert_equal 'コース別ユーザー一覧 | FBC', title
+    assert_selector 'h2.page-header__title', text: 'ユーザー一覧'
+  end
+
+  test 'show users sorted by rails course' do
+    visit_with_auth '/users/courses', 'kimura'
+    assert_selector('a.tab-nav__item-link.is-active', text: 'Rails')
+    assert_text 'Railsエンジニアコース（30）'
+    assert_selector '.users-item', count: 24
+    assert_link 'kimuramitai'
+    assert_text 'Kimura Mitai'
+    assert_no_link 'front-end-course'
+    assert_no_text 'フロントエンドエンジニアコースのユーザー'
+  end
+
+  test 'show users sorted by front end course' do
+    visit_with_auth '/users/courses?target=front_end_course', 'kimura'
+    assert_selector('a.tab-nav__item-link.is-active', text: 'フロントエンド')
+    assert_text 'フロントエンドエンジニアコース（1）'
+    assert_selector '.users-item', count: 1
+    assert_link 'front-end-course'
+    assert_text 'フロントエンドエンジニアコースのユーザー'
+    assert_no_link 'kimuramitai'
+    assert_no_text 'Kimura Mitai'
+  end
+
+  test 'show users sorted by other courses' do
+    visit_with_auth '/users/courses?target=other_courses', 'kimura'
+    assert_selector('a.tab-nav__item-link.is-active', text: 'その他')
+    assert_text 'その他のコース（2）'
+    assert_selector '.users-item', count: 2
+    assert_link 'unity-course'
+    assert_text 'Unityゲームエンジニアコースのユーザー'
+    assert_link 'ios-course'
+    assert_text 'iOSエンジニアコースのユーザー'
+    assert_no_link 'kimuramitai'
+    assert_no_text 'Kimura Mitai'
+    assert_no_link 'front-end-course'
+    assert_no_text 'フロントエンドエンジニアコースのユーザー'
+  end
+end

--- a/test/system/user/courses_test.rb
+++ b/test/system/user/courses_test.rb
@@ -34,15 +34,12 @@ class User::CoursesTest < ApplicationSystemTestCase
   test 'show users sorted by other courses' do
     visit_with_auth '/users/courses?target=other_courses', 'kimura'
     assert_selector('a.tab-nav__item-link.is-active', text: 'その他')
-    assert_text 'その他のコース（2）'
-    assert_selector '.users-item', count: 2
-    assert_link 'unity-course'
-    assert_text 'Unityゲームエンジニアコースのユーザー'
-    assert_link 'ios-course'
-    assert_text 'iOSエンジニアコースのユーザー'
-    assert_no_link 'kimuramitai'
-    assert_no_text 'Kimura Mitai'
-    assert_no_link 'front-end-course'
-    assert_no_text 'フロントエンドエンジニアコースのユーザー'
+    assert_text 'その他のコース（0）'
+    assert_selector '.users-item', count: 0
+    assert_text 'その他のユーザーはいません'
+    assert_no_link 'unity-course'
+    assert_no_text 'Unityゲームエンジニアコースのユーザー'
+    assert_no_link 'ios-course'
+    assert_no_text 'iOSエンジニアコースのユーザー'
   end
 end


### PR DESCRIPTION
## Issue

- #7998 

## 概要

## 変更確認方法

1. `feature/add-a-new-tab-in-which-users-are-sourted-by-courses-to-the-users-index`をローカルに取り込む
2. http://localhost:3000/users にアクセスし、「コース別」タブが追加されていることを確認
3. 「コース別」タブをクリックし、「Railsエンジニアコース」所属ユーザーの一覧が表示されることを確認
4. 絞り込み検索ができるか確認（例えば、「marumaru」と入力するとマルマル企業所属のユーザーのみに絞り込めます）
4. 「フロントエンド」のタブをクリックし、「フロントエンドエンジニアコース」所属ユーザーのみの一覧が表示されることを確認
5. 「その他」のタブをクリックし、「Unityゲームエンジニアコース」及び「iOSエンジニアコース」所属ユーザーのみの一覧が表示されていることを確認する

## Screenshot

### 変更前
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/2e6e5f1b-8447-4638-9e5b-dadf400dfa27">

### 変更後
<img width="1148" alt="_development__コース別ユーザー一覧___FBC-5" src="https://github.com/user-attachments/assets/13067e10-59b8-4116-8a97-2ed8a526dad2">
<img width="1069" alt="_development__コース別ユーザー一覧___FBC-2" src="https://github.com/user-attachments/assets/e4cb9e19-28c8-4015-9642-25701174537e">
<img width="1131" alt="_development__コース別ユーザー一覧___FBC-3" src="https://github.com/user-attachments/assets/ccd1c2db-31d2-45ac-9931-9954dc0a256c">

