### PR TITLE
未使用ファイルを削除

### DIFF
--- a/app/views/practices/_tab.html.slim
+++ b/app/views/practices/_tab.html.slim
@@ -1,6 +1,0 @@
-ul.nav.nav-tabs
-  li(class="#{params['target'].blank? || params['target'] == 'all' ? 'active' : ''}")
-    = link_to '全て', practices_path(target: 'all')
-  - if current_user
-    li(class="#{params['target'] == 'me' ? 'active' : ''}")
-      = link_to 'マイプラクティス', practices_path(target: 'me')


### PR DESCRIPTION
## Issue

- #8042

## 概要

使用していないパーシャルファイルがあるため、以下の変更・確認を行いました。

- app/views/practices/_tab.html.slimを削除
- app/views/practices/_tab.html.slimがどこからも使用されていないかの確認

## 変更確認方法

1. `chore/delete-_tab.html.slim`をローカルに取り込む
2. ルートディレクトリに移動する
3. `ls app/views/practices`を実行し`_tab.html.slim` が存在していないかを確認する

## Screenshot

### 変更前

<img width="626" alt="スクリーンショット 2024-09-19 18 52 48" src="https://github.com/user-attachments/assets/7518b601-436b-44ca-8c89-0e745ab2e556">


### 変更後

<img width="631" alt="スクリーンショット 2024-09-19 18 51 08" src="https://github.com/user-attachments/assets/6e9c3c93-0e62-4d12-9b95-dcf06301d4ad">

## 未使用ファイルの確認

### 方法

ターミナルの`grep`コマンドで文字列検索を行い、`render 'tab'`などのような記載がないかを確認しました。

<img width="670" alt="スクリーンショット 2024-09-20 20 48 44" src="https://github.com/user-attachments/assets/a5e2a25f-8487-434e-9b02-021d3949ab76">

1. viewsディレクトリ以下にある全てファイルを対象に`practices/tab` を検索
2. viewsディレクトリ以下にある全てファイルを対象に`practices/_tab` を検索
4. `app/views/practices`ディレクトリ内の`.html.slim`ファイルを対象に `tab` を検索

### 結果

1と2の条件の場合はヒット無し、3の条件の場合`render page_tabs`がヒットしましたが、今回の削除したファイルではありません。
上記より、`_tab.html.slim`は未使用ファイルだと判断します。