### PR TITLE
deprecatedなassert_equalの使い方を修正

### DIFF
--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -66,7 +66,7 @@ class UserDecoratorTest < ActiveDecoratorTestCase
     @admin_mentor_user.editor = 99
     @student_user.editor = 0
 
-    assert_equal @japanese_user.editor, nil
+    assert_nil @japanese_user.editor
     assert_equal @admin_mentor_user.editor_or_other_editor, 'textbringer'
     assert_equal @student_user.editor_or_other_editor, 'VSCode'
   end


### PR DESCRIPTION
下記の修正

> DEPRECATED: Use assert_nil if expecting nil from test/decorators/user_decorator_test.rb:69. This will fail in Minitest 6.
