### PR TITLE
プラクティス個別ページの終了条件を修了条件にするためにlocalesの日本語訳を変更

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -124,7 +124,7 @@ ja:
       practice:
         title: タイトル
         description: 内容
-        goal: 終了条件
+        goal: 修了条件
         target: ターゲット
         submission: 提出物
         submission_answer: 模範解答


### PR DESCRIPTION
## Issue

- [プラクティス個別ページの終了条件を修了条件に変更。 #8078](https://github.com/fjordllc/bootcamp/issues/8078)

## 概要
プラクティス個別ページ下部の修了条件が記載されている箇所において、
「終了条件」となっていた文言を「修了条件」に変更します。

<img width="470" alt="スクリーンショット 2024-09-19 15 18 42" src="https://github.com/user-attachments/assets/a2cf42ce-cf97-4b79-bc86-777cc457486c">


## 変更確認方法

1. `feature/change_text_of_practice_goal`をローカルに取り込む
   1.  `git fetch origin pull/8089/head:feature/change_text_of_practice_goal`
   2. `git checkout feature/change_text_of_practice_goal`
3. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
4. 任意のアカウントでログイン
5. [プラクティス個別ページ](http://localhost:3000/practices/315059988)を開き、下部にある修了条件を確認

## Screenshot

### 変更前
<img width="293" alt="スクリーンショット 2024-09-19 15 18 23" src="https://github.com/user-attachments/assets/442eb3b5-9ea1-4a29-8be4-ef8746d4e2eb">

### 変更後
<img width="491" alt="スクリーンショット 2024-09-20 16 14 09" src="https://github.com/user-attachments/assets/7b2692e6-9c84-4526-86f3-d3e50dffb9bf">