### PR TITLE
フッターにbootcampのリポジトリのリンクを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -14,6 +14,9 @@ footer.footer
             = link_to books_path, class: 'footer-nav__item-link' do
               | 参考書籍
           li.footer-nav__item
+            = link_to 'https://github.com/fjordllc/bootcamp', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | リポジトリ
+          li.footer-nav__item
             = link_to 'https://github.com/fjordllc/bootcamp/projects/1', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | GitHub Projects
           li.footer-nav__item


### PR DESCRIPTION
## Issue

- [フッターにリポジトリのリンクを追加 #8077](https://github.com/fjordllc/bootcamp/issues/8077)

## 概要
フッター部分のリンク一覧にて、bootcampのリポジトリリンクを下図の赤矢印部分に以下の条件で追加します。
隣に表示されている`GitHub Projects`と同様の書き方での追加となります。
- アンカーテキスト：リポジトリ
- URL：https://github.com/fjordllc/bootcamp
- `target="_blank"` と `rel="noopener"` を付けて、別タブで開くようにする。

<img width="687" alt="スクリーンショット 2024-09-25 15 00 39" src="https://github.com/user-attachments/assets/51dd529d-69fa-4d8d-aef7-d2f447835a4e">

## 変更確認方法

1. `feature/add_repository_link_in_footer`をローカルに取り込む
   1. `git fetch origin pull/8091/head:feature/add_repository_link_in_footer`
   1. `git checkout feature/add_repository_link_in_footer`
1. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
1. 任意のアカウントでログイン
1. [トップページなどの任意のページ](http://localhost:3000/)を開き、フッターにリポジトリのリンクがあるかを確認
## Screenshot

### 変更前
<img width="687" alt="スクリーンショット 2024-09-25 15 00 39" src="https://github.com/user-attachments/assets/51dd529d-69fa-4d8d-aef7-d2f447835a4e">

### 変更後
<img width="769" alt="スクリーンショット 2024-09-25 15 12 17" src="https://github.com/user-attachments/assets/9ca23e6b-7dcc-4c9a-8682-fd744d1328d9">

