### PR TITLE
画像のバリデーションをMimeTypeを用いるものに変更

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -8,6 +8,7 @@ class CurrentUserController < ApplicationController
   end
 
   def update
+    @user.uploaded_avatar = user_params[:avatar]
     if @user.update(user_params)
       redirect_to @user, notice: 'ユーザー情報を更新しました。'
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -69,6 +69,7 @@ class UsersController < ApplicationController
     @user.course_id ||= Course.first.id
     @user.build_discord_profile
     @user.credit_card_payment = params[:credit_card_payment]
+    @user.uploaded_avatar = user_params[:avatar]
     Newspaper.publish(:user_create, { user: @user })
     if @user.staff? || @user.trainee?
       create_free_user!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -202,11 +202,9 @@ class User < ApplicationRecord
 
   validates :login_name, length: { minimum: 3, message: 'は3文字以上にしてください。' }
 
-  validates :avatar, attached: false,
-                     content_type: {
-                       in: %w[image/png image/jpg image/jpeg image/gif image/heic image/heif],
-                       message: 'はPNG, JPG, GIF, HEIC, HEIF形式にしてください'
-                     }
+  attr_accessor :uploaded_avatar
+
+  validate :validate_uploaded_avatar_content_type
 
   validates :country_code, inclusion: { in: ISO3166::Country.codes }, allow_blank: true
 
@@ -907,5 +905,14 @@ class User < ApplicationRecord
 
   def category_having_unstarted_practice
     unstarted_practices&.first&.categories&.first
+  end
+
+  def validate_uploaded_avatar_content_type
+    return unless uploaded_avatar
+
+    mime_type = Marcel::Magic.by_magic(uploaded_avatar)&.type
+    return if mime_type&.start_with?('image/png', 'image/jpg', 'image/jpeg', 'image/gif', 'image/heic', 'image/heif')
+
+    errors.add(:avatar, 'は指定された拡張子(PNG, JPG, JPEG, GIF, HEIC, HEIF形式)になっていないか、あるいは画像が破損している可能性があります')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   include Taggable
   include Searchable
 
-  attr_accessor :credit_card_payment, :role
+  attr_accessor :credit_card_payment, :role, :uploaded_avatar
 
   authenticates_with_sorcery!
   VALID_SORT_COLUMNS = %w[id login_name company_id last_activity_at created_at report comment asc desc].freeze
@@ -201,8 +201,6 @@ class User < ApplicationRecord
   validates :login_name, exclusion: { in: RESERVED_LOGIN_NAMES, message: 'に使用できない文字列が含まれています' }
 
   validates :login_name, length: { minimum: 3, message: 'は3文字以上にしてください。' }
-
-  attr_accessor :uploaded_avatar
 
   validate :validate_uploaded_avatar_content_type
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -704,4 +704,12 @@ class UsersTest < ApplicationSystemTestCase
     filtered_users = all('.users-item__icon .a-user-role')
     assert(filtered_users.all? { |user| user[:class].split(' ').include?('is-student') })
   end
+
+  test 'can not upload broken image as user avatar' do
+    visit_with_auth '/current_user/edit', 'hajime'
+    attach_file 'user[avatar]', 'test/fixtures/files/images/broken_image.jpg', make_visible: true
+    click_button '更新する'
+
+    assert_text 'ユーザーアイコンは指定された拡張子(PNG, JPG, JPEG, GIF, HEIC, HEIF形式)になっていないか、あるいは画像が破損している可能性があります'
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7487

## 概要
riraさんが作成したPRの概要から引用させていただきます。

> アバター画像のバリデーションにMarcelを使ったMime-Typeのチェックを加えました。
受け入れるべきファイル形式であるかをファイルの実体から判別するようになるため、拡張子偽装したファイルや形式判別不可能なファイルをアバターとして登録することを防ぐことができます。

- https://github.com/fjordllc/bootcamp/pull/7759



## 変更確認方法

1. `fix/broken-images-can-be-registered` をローカルに取り込む
2. 任意のユーザーでログインする
3. http://localhost:3000/current_user/edit にアクセス
4. 壊れた画像をアバター画像に設定し、更新ができない（エラーが出る）ことを確認。

## Screenshot

### 変更前
![スクリーンショット_2024-09-27_11_18_54](https://github.com/user-attachments/assets/b4ccbf40-305e-48a7-b263-bf86e3186134)

### 変更後
![スクリーンショット_2024-09-27_11_19_14](https://github.com/user-attachments/assets/0f49f3cf-32b4-48da-884e-c53b251927fd)


