### PR TITLE
ステージング環境でのイベント購読の動作確認のため、一時的にcalendars_controller.rbのBASIC認証を無効化する

### DIFF
--- a/app/controllers/events/calendars_controller.rb
+++ b/app/controllers/events/calendars_controller.rb
@@ -2,6 +2,8 @@
 
 class Events::CalendarsController < ApplicationController
   skip_before_action :require_active_user_login, raise: false, only: :index
+  # ステージング環境での動作確認のため追加、確認後削除予定
+  skip_before_action :basic_auth, if: :staging?
 
   def index
     user_id = params[:user_id]


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/6607

## 概要

- https://github.com/fjordllc/bootcamp/pull/7639

イベント購読の機能追加を行いましたがBASIC認証が設定されているため、ステージング環境での動作確認がうまくできません。
ステージング環境での動作確認実施のため、一時的にcalendars_controller.rbのBASIC認証を無効化します。
動作確認が修了後、該当のコードを削除します。

## 変更確認方法

1. `feature/skip_basic_auth_in_calendars_controller`をmainにマージ
2. https://bootcamp-staging.fjord.jp/events にアクセス
3. 以下のPRでの確認方法に沿ってイベント購読機能が動作することを確認
- https://github.com/fjordllc/bootcamp/pull/6276
- https://github.com/fjordllc/bootcamp/pull/7639