### PR TITLE
Docを初回公開する時のみ「Doc公開」、それ以外は「内容を更新」と表示するようボタンテキストを変更

### DIFF
--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -75,10 +75,9 @@
                 i.fa-solid.fa-question
 
         = button_tag(class: 'a-button is-lg is-primary is-block') do
-          - case params[:action]
-          - when 'new', 'create'
+          - if page.published_at.blank?
             | Docを公開
-          - when 'edit', 'update'
+          - else
             | 内容を更新
       li.form-actions__item.is-sub
         - case params[:action]

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -66,7 +66,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
 
     click_link '内容変更'
     click_button 'Docを公開'
-    assert_text 'ドキュメントを更新しました。'
+    assert_text 'ドキュメントを作成しました。'
 
     visit_with_auth '/notifications', 'machida'
 

--- a/test/system/notification/pages_test.rb
+++ b/test/system/notification/pages_test.rb
@@ -65,7 +65,7 @@ class Notification::PagesTest < ApplicationSystemTestCase
     visit_with_auth page_path(page), 'komagata'
 
     click_link '内容変更'
-    click_button '内容を更新'
+    click_button 'Docを公開'
     assert_text 'ドキュメントを更新しました。'
 
     visit_with_auth '/notifications', 'machida'

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -224,7 +224,7 @@ class PagesTest < ApplicationSystemTestCase
     stub_info = proc { |i| mock_log << i }
 
     Rails.logger.stub(:info, stub_info) do
-      click_button '内容を更新'
+      click_button 'Docを公開'
     end
 
     assert_text 'ドキュメントを更新しました。'
@@ -312,7 +312,7 @@ class PagesTest < ApplicationSystemTestCase
     click_button 'WIP'
 
     check 'ドキュメント公開のお知らせを書く', allow_label_click: true
-    click_button '内容を更新'
+    click_button 'Docを公開'
 
     assert_text 'ドキュメントを更新しました。'
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -227,7 +227,7 @@ class PagesTest < ApplicationSystemTestCase
       click_button 'Docを公開'
     end
 
-    assert_text 'ドキュメントを更新しました。'
+    assert_text 'ドキュメントを作成しました。'
     assert_match 'Message to Discord.', mock_log.to_s
   end
 
@@ -314,7 +314,7 @@ class PagesTest < ApplicationSystemTestCase
     check 'ドキュメント公開のお知らせを書く', allow_label_click: true
     click_button 'Docを公開'
 
-    assert_text 'ドキュメントを更新しました。'
+    assert_text 'ドキュメントを作成しました。'
     assert has_field?('announcement[title]', with: 'ドキュメント「お知らせにチェックを入れてWIP状態から新規Docを作成」を公開しました。')
     assert_text '「お知らせにチェックを入れてWIP状態から新規Docを作成」の本文です。'
   end


### PR DESCRIPTION
## Issue

- [DocsをWIP状態からの初回の公開を行った際のボタンの文言を違和感のない状態に変更したい #7830](https://github.com/fjordllc/bootcamp/issues/7830)

## 概要

Doc作成の際、公開していない状態でWIPとした場合、下図の赤枠部分のボタンテキストが「内容を更新」と表示されているが、公開していない場合は「Docを公開」と表示されるように変更いたします。

<img width="618" alt="スクリーンショット 2024-10-01 15 11 28" src="https://github.com/user-attachments/assets/e4158636-1f9a-47d1-8815-250ef226521a">


## 変更確認方法

1. `chore/change-button-text-update-content-to-publish-doc`をローカルに取り込む
  I. `git fetch origin pull/8100/head:chore/change-button-text-update-content-to-publish-doc`
  Ⅱ. `git checkout chore/change-button-text-update-content-to-publish-doc`
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. 任意のアカウントでログイン
4. 下記の要領で、ボタンテキストの確認を行う
  I. [Doc作成ページ](http://localhost:3000/pages/new)を開き、ボタンテキストが`Docを公開`になっているか確認
  Ⅱ. データ入力後WIPボタンを押しても、ボタンテキストが`Docを公開`のままになっているか確認
  Ⅲ. `Docを公開`ボタンを押した後、`内容変更`ボタンを押し編集画面に移動する。そして、ボタンテキストが`内容を更新`になっているか確認
  Ⅳ. WIPボタンを押す。公開後、WIP状態にしてもボタンテキストが`内容を更新`になっているか確認

## Screenshot

### 変更前

<img width="618" alt="スクリーンショット 2024-10-01 15 11 28" src="https://github.com/user-attachments/assets/ec084f3b-336c-4894-908a-d9d36814a71d">

### 変更後

<img width="587" alt="スクリーンショット 2024-10-01 15 15 28" src="https://github.com/user-attachments/assets/d023bd4b-69f2-4470-94ab-d3b9451678ce">
