### PR TITLE
ダッシュボードの未アサインの提出物の表示のバグを解消した

### DIFF
--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -3,18 +3,6 @@
   div
     loadingListPlaceholder
 
-.o-empty-message(v-else-if='filteredProducts.length === 0')
-  .o-empty-message__icon
-    i.fa-regular.fa-smile
-  p.o-empty-message__text
-    | {{ title }}はありません
-
-.o-empty-message(v-else-if='isDashboard && isNotProductSelectedDaysElapsed')
-  .o-empty-message__icon
-    i.fa-regular.fa-smile
-  p.o-empty-message__text
-    | {{ selectedDays }}日経過した提出物はありません
-
 //- ダッシュボード
 .is-vue(v-else-if='isDashboard')
   template(v-for='product_n_days_passed in filteredProducts') <!-- product_n_days_passedはn日経過の提出物 -->
@@ -75,14 +63,19 @@
     .under-cards__links.mt-4.text-center.leading-normal.text-sm
       a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
         class='hover\:bg-black',
-        v-bind:href='`/products/unassigned#${selectedDays}days-elapsed`',
-        v-if='countAlmostPassedSelectedDays() === 0')
+        v-bind:href='`/products/unassigned#${selectedDays - 1}days-elapsed`',
+        v-if='filteredProducts.length === 0 && countAlmostPassedSelectedDays() === 0')
         | しばらく{{ selectedDays }}日経過に到達する<br>提出物はありません。
       a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
         class='hover\:bg-black',
-        v-bind:href='`/products/unassigned#${selectedDays}days-elapsed`',
-        v-else)
+        v-bind:href='`/products/unassigned#${selectedDays - 1}days-elapsed`',
+        v-else-if='countAlmostPassedSelectedDays() > 0')
         | <strong>{{ countAlmostPassedSelectedDays() }}件</strong>の提出物が、<br>8時間以内に{{ selectedDays }}日経過に到達します。
+      a.divide-indigo-800.block.p-3.border.rounded.border-solid.text-indigo-800.a-hover-link(
+        class='hover\:bg-black',
+        v-bind:href='`/products/unassigned#${selectedDays - 1}days-elapsed`',
+        v-else)
+        | しばらく{{ selectedDays }}日経過に到達する<br>提出物はありません。        
 </template>
 
 <script>

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -75,7 +75,7 @@
         class='hover\:bg-black',
         v-bind:href='`/products/unassigned#${selectedDays - 1}days-elapsed`',
         v-else)
-        | しばらく{{ selectedDays }}日経過に到達する<br>提出物はありません。        
+        | しばらく{{ selectedDays }}日経過に到達する<br>提出物はありません。
 </template>
 
 <script>
@@ -108,10 +108,12 @@ export default {
       if (!this.productsGroupedByElapsedDays) {
         return []
       }
-      return this.productsGroupedByElapsedDays.filter(group => {
-        return group.elapsed_days === this.selectedDays ||
-               group.elapsed_days === this.selectedDays + 1 ||
-               group.elapsed_days === this.selectedDays + 2
+      return this.productsGroupedByElapsedDays.filter((group) => {
+        return (
+          group.elapsed_days === this.selectedDays ||
+          group.elapsed_days === this.selectedDays + 1 ||
+          group.elapsed_days === this.selectedDays + 2
+        )
       })
     },
     url() {

--- a/app/javascript/products.vue
+++ b/app/javascript/products.vue
@@ -3,7 +3,7 @@
   div
     loadingListPlaceholder
 
-.o-empty-message(v-else-if='products.length === 0')
+.o-empty-message(v-else-if='filteredProducts.length === 0')
   .o-empty-message__icon
     i.fa-regular.fa-smile
   p.o-empty-message__text
@@ -17,7 +17,7 @@
 
 //- ダッシュボード
 .is-vue(v-else-if='isDashboard')
-  template(v-for='product_n_days_passed in productsGroupedByElapsedDays') <!-- product_n_days_passedはn日経過の提出物 -->
+  template(v-for='product_n_days_passed in filteredProducts') <!-- product_n_days_passedはn日経過の提出物 -->
     .a-card.h-auto(
       v-if='!isDashboard || (isDashboard && product_n_days_passed.elapsed_days >= 0 && product_n_days_passed.elapsed_days <= selectedDays + 2)')
       //- TODO 以下を共通化する
@@ -29,7 +29,7 @@
           | 今日提出
           span.card-header__count
             | （{{ countProductsGroupedBy(product_n_days_passed) }}）
-      //- prettier-ignore: need space between v-else-if and id
+      //- prettier-ignore: need space between v-else-if and id            
       header.card-header.a-elapsed-days.is-reply-warning(
         v-else-if='product_n_days_passed.elapsed_days === selectedDays', id='first-alert'
       )
@@ -111,6 +111,16 @@ export default {
     }
   },
   computed: {
+    filteredProducts() {
+      if (!this.productsGroupedByElapsedDays) {
+        return []
+      }
+      return this.productsGroupedByElapsedDays.filter(group => {
+        return group.elapsed_days === this.selectedDays ||
+               group.elapsed_days === this.selectedDays + 1 ||
+               group.elapsed_days === this.selectedDays + 2
+      })
+    },
     url() {
       return '/api/products/unassigned'
     },

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -493,7 +493,8 @@ class HomeTest < ApplicationSystemTestCase
     Product.create(practice_id: practice.id, user_id: user.id, body: 'test body', published_at: Time.current.ago(1.day))
     travel_to Time.current do
       visit_with_auth '/', 'komagata'
-      assert_text '4日経過した提出物はありません'
+      assert_text 'しばらく4日経過に到達する'
+      assert_text '提出物はありません。'
     end
   end
 


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/8121

## 概要
- 以下の2つのバグを修正した
  1. ダッシュボードの未アサインの提出物がすべて表示されている
    - 全ての提出物が一覧で表示されている
    - しかし、メンターダッシュボードに表示される提出物一覧は急いで対応しなくてはいけないものだけを表示する場所でした
    - メンターダッシュボードには、色が付いたカードに所属する提出物だけ表示するように修正した
      - 逆に言うと、3日経過を含むそれ以下の経過日数の提出物はそこに表示しないようにする
  2. メンターダッシュボードに表示する提出物一覧がないときにリンク付きテキストを表示する
    - メンターダッシュボードに表示する提出物一覧がないとき、つまり、ヘッダーに色がついた提出物のカードがないとき（4日以上経過提出物がないとき）は、以下のリンク付きテキストを表示する
      ```
      しばらく4日経過に到達する
      提出物はありません。
      ```
      もしくは、
      ```
      n件の提出物が、
      8時間以内に4日経過にに到達します。
      ```
      というメッセージを表示し、
      そのメッセージには提出物一覧のページにリンク（/products/unassigned#3days-elapsed）を貼る

## 変更確認方法
1. 環境構築
  1. `feature/change-alert-for-unassigned-products`をローカルに取り込む
  2. `feature/change-alert-for-unassigned-products`をローカルに取り込む
  3. `rails db:reset`を実行する
  4. `bin/setup`を実行する
  5. `foreman start -f Procfile.dev`を実行する
  6. メンターユーザーでログインする

2. ダッシュボードの未アサインの提出物の表示確認
  - ダッシュボードの未アサインの提出物がすべて表示されていないか
    - 色が付いたカードに所属する提出物だけ表示するようになっているか

3. メンターダッシュボードに表示する提出物一覧がないときにリンク付きテキストを表示する
  - 提出物一覧がないときに以下のリンク付きテキストが表示されているか
      ```
      しばらく4日経過に到達する
      提出物はありません。
      ```
      もしくは、
      ```
      n件の提出物が、
      8時間以内に4日経過にに到達します。
      ```

## Screenshot

### 変更前
- アラートと提出物
  - <img width="358" alt="スクリーンショット 2024-10-04 21 37 54" src="https://github.com/user-attachments/assets/803a8bd4-6fb8-4383-bb40-99b8993a0c51">
  
  - <img width="351" alt="スクリーンショット 2024-10-04 21 38 06" src="https://github.com/user-attachments/assets/90fd6ed7-683a-4821-b81b-30e5c38a80c6">
  
  - <img width="358" alt="スクリーンショット 2024-10-04 21 38 13" src="https://github.com/user-attachments/assets/f0049f3c-4006-42cd-b0bb-021725d1ab0d">
  
  - <img width="368" alt="スクリーンショット 2024-10-04 21 38 23" src="https://github.com/user-attachments/assets/c48900e3-52ff-4965-8c63-5c13801ecc57">


- 提出物がない時のテキスト
  - <img width="357" alt="スクリーンショット 2024-10-04 21 40 17" src="https://github.com/user-attachments/assets/1f53cbbe-c47c-4b0d-bf74-2d4c342209f5">

### 変更後
- アラートと提出物
  - <img width="356" alt="スクリーンショット 2024-10-04 21 42 39" src="https://github.com/user-attachments/assets/71465ea0-cfc7-43ef-8c4a-c073f6fcbe6f">
  
  - <img width="346" alt="スクリーンショット 2024-10-04 21 42 46" src="https://github.com/user-attachments/assets/8cb7b36d-cd1a-4496-bfbd-f3580bc983e1">


- 提出物がない時のテキスト

  - <img width="362" alt="スクリーンショット 2024-10-04 20 39 56" src="https://github.com/user-attachments/assets/d376dab1-2526-4792-9427-4620dd269482">
  
  - <img width="356" alt="スクリーンショット 2024-10-04 21 18 21" src="https://github.com/user-attachments/assets/0c8f5c1d-4356-4c63-b44f-c13153ec05ba">
