### PR TITLE
管理者は定期イベント参加者を削除できるように変更

### DIFF
--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -11,10 +11,12 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def destroy
-    return if !correct_user? && !current_user.mentor?
-
-    user = User.find(params[:user_id])
-    @regular_event.cancel_participation(user)
+    if params[:participant_id] && current_user.mentor?
+      user = User.find(params[:participant_id])
+      @regular_event.cancel_participation(user)
+    else
+      @regular_event.cancel_participation(current_user)
+    end
     redirect_to regular_event_path(@regular_event), notice: '参加を取り消しました。'
   end
 
@@ -32,9 +34,5 @@ class RegularEvents::ParticipationsController < ApplicationController
       watchable: @regular_event
     )
     watch.save!
-  end
-
-  def correct_user?
-    current_user.id == params[:user_id].to_i
   end
 end

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -11,7 +11,8 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def destroy
-    @regular_event.cancel_participation(current_user)
+    @user = User.find(params[:user_id])
+    @regular_event.cancel_participation(@user)
     redirect_to regular_event_path(@regular_event), notice: '参加を取り消しました。'
   end
 

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -11,7 +11,9 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def destroy
-    user = User.find(params[:user_id]) if current_user.mentor? || correct_user?
+    return if !correct_user? && !current_user.mentor?
+
+    user = User.find(params[:user_id])
     @regular_event.cancel_participation(user)
     redirect_to regular_event_path(@regular_event), notice: '参加を取り消しました。'
   end

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -11,7 +11,7 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def destroy
-    if params[:participant_id] && current_user.mentor?
+    if params[:participant_id] && current_user.admin?
       user = User.find(params[:participant_id])
       @regular_event.cancel_participation(user)
     else

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -11,7 +11,7 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def destroy
-    @user = User.find(params[:user_id])
+    @user = User.find(params[:user_id]) if current_user.mentor? || correct_user?
     @regular_event.cancel_participation(@user)
     redirect_to regular_event_path(@regular_event), notice: '参加を取り消しました。'
   end
@@ -30,5 +30,9 @@ class RegularEvents::ParticipationsController < ApplicationController
       watchable: @regular_event
     )
     watch.save!
+  end
+
+  def correct_user?
+    current_user.id == params[:user_id].to_i
   end
 end

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -11,8 +11,8 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def destroy
-    @user = User.find(params[:user_id]) if current_user.mentor? || correct_user?
-    @regular_event.cancel_participation(@user)
+    user = User.find(params[:user_id]) if current_user.mentor? || correct_user?
+    @regular_event.cancel_participation(user)
     redirect_to regular_event_path(@regular_event), notice: '参加を取り消しました。'
   end
 

--- a/app/javascript/stylesheets/shared/blocks/_footprints.sass
+++ b/app/javascript/stylesheets/shared/blocks/_footprints.sass
@@ -21,6 +21,10 @@
 .user-icons-item
   display: flex
   align-items: center
+  gap: .25rem
+
+.user-icons-item__delete
+  +text-block(.75rem 1.4)
 
 .user-icons__more
   +text-block(.8125rem 1.4, block nowrap)

--- a/app/views/regular_events/_participation.html.slim
+++ b/app/views/regular_events/_participation.html.slim
@@ -5,7 +5,7 @@
         | 参加登録しています。
     ul.event-main-actions__items
       li.event-main-actions__item
-        = link_to regular_event_participation_path(regular_event_id: regular_event), method: :delete,
+        = link_to regular_event_participation_path(regular_event_id: regular_event, user_id: current_user.id), method: :delete,
           data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
           | 参加を取り消す
 - else

--- a/app/views/regular_events/_participation.html.slim
+++ b/app/views/regular_events/_participation.html.slim
@@ -5,7 +5,7 @@
         | 参加登録しています。
     ul.event-main-actions__items
       li.event-main-actions__item
-        = link_to regular_event_participation_path(regular_event_id: regular_event, user_id: current_user.id), method: :delete,
+        = link_to regular_event_participation_path(regular_event_id: regular_event), method: :delete,
           data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
           | 参加を取り消す
 - else

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -87,6 +87,9 @@
                   = link_to participant do
                     span class="a-user-role is-#{participant.primary_role}"
                       = image_tag participant.avatar_url, title: participant.icon_title, class: "a-user-icon is-sm is-#{participant.login_name}", alt: participant.login_name
+                  = link_to regular_event_participation_path(regular_event_id: regular_event, user_id: participant.id), method: :delete,
+                    data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+                    | 削除する
           - else
             .o-empty-message
               .o-empty-message__icon

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -90,7 +90,7 @@
                   - if admin_login?
                     = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant), class: 'user-icons-item__delete a-text-link is-only-mentor', method: :delete,
                       data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' } do
-                    | 削除する
+                      | 削除する
           - else
             .o-empty-message
               .o-empty-message__icon

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -88,7 +88,7 @@
                     span class="a-user-role is-#{participant.primary_role}"
                       = image_tag participant.avatar_url, title: participant.icon_title, class: "a-user-icon is-sm is-#{participant.login_name}", alt: participant.login_name
                   = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant), method: :delete,
-                    data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
+                    data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' } do
                     | 削除する
           - else
             .o-empty-message

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -87,7 +87,7 @@
                   = link_to participant do
                     span class="a-user-role is-#{participant.primary_role}"
                       = image_tag participant.avatar_url, title: participant.icon_title, class: "a-user-icon is-sm is-#{participant.login_name}", alt: participant.login_name
-                  = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant), method: :delete,
+                  = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant), class: 'user-icons-item__delete a-text-link is-only-mentor', method: :delete,
                     data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' } do
                     | 削除する
           - else

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -87,8 +87,9 @@
                   = link_to participant do
                     span class="a-user-role is-#{participant.primary_role}"
                       = image_tag participant.avatar_url, title: participant.icon_title, class: "a-user-icon is-sm is-#{participant.login_name}", alt: participant.login_name
-                  = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant), class: 'user-icons-item__delete a-text-link is-only-mentor', method: :delete,
-                    data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' } do
+                  - if admin_login?
+                    = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant), class: 'user-icons-item__delete a-text-link is-only-mentor', method: :delete,
+                      data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' } do
                     | 削除する
           - else
             .o-empty-message

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -88,7 +88,9 @@
                     span class="a-user-role is-#{participant.primary_role}"
                       = image_tag participant.avatar_url, title: participant.icon_title, class: "a-user-icon is-sm is-#{participant.login_name}", alt: participant.login_name
                   - if admin_login?
-                    = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant), class: 'user-icons-item__delete a-text-link is-only-mentor', method: :delete,
+                    = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant),
+                      class: 'user-icons-item__delete a-text-link is-only-mentor',
+                      method: :delete,
                       data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' } do
                       | 削除する
           - else

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -87,7 +87,7 @@
                   = link_to participant do
                     span class="a-user-role is-#{participant.primary_role}"
                       = image_tag participant.avatar_url, title: participant.icon_title, class: "a-user-icon is-sm is-#{participant.login_name}", alt: participant.login_name
-                  = link_to regular_event_participation_path(regular_event_id: regular_event, user_id: participant.id), method: :delete,
+                  = link_to regular_event_participation_path(regular_event_id: regular_event, participant_id: participant), method: :delete,
                     data: { confirm: 'イベントの参加をキャンセルします。よろしいですか?' }, class: 'event-main-actions__item-cancel' do
                     | 削除する
           - else

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -115,7 +115,7 @@ class RegularEventsTest < ApplicationSystemTestCase
     find 'h2', text: 'コメント'
     find 'div.container > div.user-icons > ul.user-icons__items', visible: :all
     accept_confirm do
-      click_link '削除'
+      find('.card-main-actions__muted-action', text: '削除').click
     end
     assert_text '定期イベントを削除しました。'
   end

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -386,7 +386,7 @@ class RegularEventsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'mentor can remove others from participation' do
+  test 'admin can remove others from participation' do
     regular_event = regular_events(:regular_event1)
     visit_with_auth regular_event_path(regular_event), 'komagata'
     assert_difference 'regular_event.participants.count', -1 do

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -385,4 +385,17 @@ class RegularEventsTest < ApplicationSystemTestCase
       end
     end
   end
+
+  test 'mentor can remove others from participation' do
+    regular_event = regular_events(:regular_event1)
+    visit_with_auth regular_event_path(regular_event), 'komagata'
+    assert_difference 'regular_event.participants.count', -1 do
+      accept_confirm do
+        within('.a-card.participants') do
+          first('a', text: '削除する').click
+        end
+      end
+      assert_text '参加を取り消しました。'
+    end
+  end
 end


### PR DESCRIPTION
## Issue

- #8074 

## 概要
管理者は定期イベントの参加者を削除できるように変更いたしました。


## 変更確認方法

1. `feature/mentor_can_remove_others_from_participation`をローカルに取り込む
    1. `git fetch origin pull/8129/head:feature/mentor_can_remove_others_from_participation`
    2. `git switch feature/mentor_can_remove_others_from_participation`
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. 管理者でログインする（例： id: `komagata`）
4. [参加者が登録されている定期イベント](http://localhost:3000/regular_events/459650222)の個別ページを開く
5. 参加者一覧にて、ログインしているアカウント以外のユーザーアイコン横の`削除する`リンクをクリックする。
6. ページ更新後`参加を取り消しました。`という文言が表示され、クリックしたユーザーが参加者一覧からなくなっている。

<img width="731" alt="スクリーンショット 2024-10-11 14 51 16" src="https://github.com/user-attachments/assets/e92db09c-3f90-49d8-b00e-4ffac80b0fb2">

<img width="724" alt="スクリーンショット 2024-10-21 9 55 49" src="https://github.com/user-attachments/assets/130270fa-d643-4fad-96b3-299040ad2ef2">

## Screenshot

### 変更前
<img width="731" alt="スクリーンショット 2024-10-03 10 58 07" src="https://github.com/user-attachments/assets/8366c472-429d-40a7-a321-ded50a220d6c">

### 変更後
<img width="724" alt="スクリーンショット 2024-10-21 9 55 49" src="https://github.com/user-attachments/assets/130270fa-d643-4fad-96b3-299040ad2ef2">

## 追記
 - 10/21
 上記のPRの説明欄とissue内容が「メンターは、参加者を削除できるようにしたい。」のままになっていたので
「管理者は、参加者を削除できるようにしたい。」に修正いたしました。
合わせてスクリーンショット等を最新のものに変更しました。