### PR TITLE
休会時のお知らせメール内に復帰予定日と理由を表示するようにした

### DIFF
--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -287,6 +287,7 @@ class ActivityMailer < ApplicationMailer
       link: "/users/#{@sender.id}",
       kind: Notification.kinds[:hibernated]
     )
+    @hibernation = Hibernation.find_by(user_id: @sender.id)
 
     subject = "[FBC] #{@sender.login_name}さんが休会しました。"
     message = mail(to: @user.email, subject:)

--- a/app/views/activity_mailer/hibernated.html.slim
+++ b/app/views/activity_mailer/hibernated.html.slim
@@ -1,3 +1,10 @@
 = render '/notification_mailer/notification_mailer_template',
   title: "#{@sender.login_name}さんが休会しました。",
   link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ" do
+  .a-long-text
+    h2
+      = Hibernation.human_attribute_name('scheduled_return_on')
+    = @hibernation.scheduled_return_on
+    h2
+      = Hibernation.human_attribute_name('reason')
+    = md2html(@hibernation.reason)

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -721,13 +721,13 @@ class ActivityMailerTest < ActionMailer::TestCase
   end
 
   test 'hibernated using synchronous mailer' do
-    user = users(:kimura)
+    user = users(:kyuukai)
     mentor = users(:komagata)
     Notification.create!(
       kind: 19,
       sender: user,
       user: mentor,
-      message: 'kimuraさんが休会しました。',
+      message: 'kyuukaiさんが休会しました。',
       link: "/users/#{user.id}",
       read: false
     )
@@ -740,18 +740,18 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] kimuraさんが休会しました。', email.subject
+    assert_equal '[FBC] kyuukaiさんが休会しました。', email.subject
     assert_match(/休会/, email.body.to_s)
   end
 
   test 'hibernated with params using asynchronous mailer' do
-    user = users(:kimura)
+    user = users(:kyuukai)
     mentor = users(:komagata)
     Notification.create!(
       kind: 19,
       sender: user,
       user: mentor,
-      message: 'kimuraさんが休会しました。',
+      message: 'kyuukaiさんが休会しました。',
       link: "/users/#{user.id}",
       read: false
     )
@@ -768,7 +768,7 @@ class ActivityMailerTest < ActionMailer::TestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['noreply@bootcamp.fjord.jp'], email.from
     assert_equal ['komagata@fjord.jp'], email.to
-    assert_equal '[FBC] kimuraさんが休会しました。', email.subject
+    assert_equal '[FBC] kyuukaiさんが休会しました。', email.subject
     assert_match(/休会/, email.body.to_s)
   end
 


### PR DESCRIPTION
## Issue

- [#8094 「休会しました」の通知メールに復帰予定日と休会の理由が載っていると嬉しい](https://github.com/fjordllc/bootcamp/issues/8094)

## 概要

休会時のお知らせメール内に「復帰予定日」と「休会理由」が載っていないため、メールを開いた時点で「復帰予定日」と「休会理由」を表示するようにしました。

## 変更確認方法

1.   `chore/add-return-date-and-reason-to-suspension-notification` をローカルに取り込む
  i.  `git fetch origin pull/8144/head:chore/add-return-date-and-reason-to-suspension-notification`
  ii.  `git checkout chore/add-return-date-and-reason-to-suspension-notification`
2.  `foreman start -f Procfile.dev` でローカルサーバーを立ち上げる
3.  ユーザー名`kimura`、パスワード`testtest`でログインする
4. [休会手続き](http://localhost:3000/hibernation/new)にアクセスする
5. 復帰予定日と休会理由（自由記入）を入力する。
6. 「休会についての注意を読みましたか？」の下にあるチェックボックスを選択し「休会する」ボタンを押す
7. [letter_opener_web](http://localhost:3000/letter_opener)にアクセスする
8. メール本文内に「復帰予定日」と「休会理由」が表示されているか確認する

## Screenshot

### 変更前

<img width="1456" alt="スクリーンショット 2024-10-22 14 45 05" src="https://github.com/user-attachments/assets/5368968c-c1b2-40a8-a4e7-fd259aa880f7">

### 変更後

<img width="1467" alt="スクリーンショット 2024-10-22 14 43 04" src="https://github.com/user-attachments/assets/f59d5db2-1e13-4147-ad30-388981639edd">

## 出力フォーマットについて

退会時のお知らせメールでは、退会理由が表示されるようになっています。今回の休会時のお知らせメールは、退会時のお知らせメールと同じ出力形式にしています。

参照先：app/views/activity_mailer/retired.html.slim

<img width="602" alt="スクリーンショット 2024-10-22 15 01 45" src="https://github.com/user-attachments/assets/aab87934-a1c5-4df7-b2bc-c4cb315b397a">