### PR TITLE
自作サービスで輪読会一覧を表示するために、輪読会一覧を返すAPIを実装した

### DIFF
--- a/app/controllers/api/reading_circles_controller.rb
+++ b/app/controllers/api/reading_circles_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class API::ReadingCirclesController < API::BaseController
+  def index
+    @reading_circles = RegularEvent.category_reading_circle
+                                   .where(wip: false)
+                                   .order(updated_at: :desc, id: :desc)
+  end
+end

--- a/app/views/api/reading_circles/_reading_circle.json.jbuilder
+++ b/app/views/api/reading_circles/_reading_circle.json.jbuilder
@@ -1,0 +1,1 @@
+json.(reading_circle, :id, :title, :finished, :updated_at)

--- a/app/views/api/reading_circles/index.json.jbuilder
+++ b/app/views/api/reading_circles/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.reading_circles @reading_circles, partial: "api/reading_circles/reading_circle", as: :reading_circle

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -89,5 +89,6 @@ Rails.application.routes.draw do
     resources :survey_question_listings, only: %i() do
       resource :position, only: %i(update), controller: "survey_question_listings/position"
     end
+    resources :reading_circles, only: %i(index)
   end
 end

--- a/test/integration/api/reading_circles_test.rb
+++ b/test/integration/api/reading_circles_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::ReadingCirclesTest < ActionDispatch::IntegrationTest
+  test 'GET /api/reading_circles.json' do
+    get api_reading_circles_path(format: :json)
+    assert_response :unauthorized
+
+    token = create_token('kimura', 'testtest')
+    get api_reading_circles_path(format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+end


### PR DESCRIPTION
## 概要
自作サービスである「輪読会ノート」で輪読会一覧を取得する必要があるので、APIを実装しました。

### 利用方法
自作サービス側での利用時の認証は、`test/supports/api_helper.rb`の`create_token`のようなメソッドを実装し、FBCと同様、自身のアカウントを利用してjwt認証をします。そして認証成功後、APIデータを取得する流れになります。
```ruby
def create_token(login_name, password)
  post api_session_url, params: { login_name:, password: }
  JSON.parse(body)['token']
end
```
なお、利用するlogin_nameとpasswordはENVファイルで管理する予定です。

FBCからAPIキーを発行し、自作サービス側でそのAPIキーを利用し...といった実装は、時間がかかりすぎてしまいそうなので上記を採用することにしました。

## 確認方法
1. サーバを立ち上げる
2. 任意ユーザーでログイン
3. `http://localhost:3000/api/reading_circles.json`にアクセスする。
4. 以下データが返ってきていたらOK
```json
{"reading_circles":[{"id":927610372,"title":"ダッシュボード表示確認用テスト定期イベント","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"},{"id":839258526,"title":"独習Git輪読会","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"},{"id":722419750,"title":"チェリー本輪読会","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"},{"id":670378901,"title":"Discord通知確認用、祝日非開催イベント(金曜日開催)","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"},{"id":470315189,"title":"Everyday Rails輪読会","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"},{"id":284302086,"title":"Discord通知確認用イベント(土曜日 + 日曜日開催)","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"},{"id":120758905,"title":"Discord通知確認用、祝日非開催イベント(金曜日 + 土曜日開催)","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"},{"id":83960073,"title":"Ruby超入門輪読会","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"},{"id":5047957,"title":"Discord通知確認用イベント(土曜日開催)","finished":false,"updated_at":"2024-10-22T20:33:49.955+09:00"}]}
```
