### PR TITLE
日報を100回提出したテストデータを削除

### DIFF
--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -338,29 +338,3 @@ report88:
   description: |-
     お世話になりました
   reported_on: <%= Time.now - 1.month - 1.day %>
-
-# ステージング環境で日報100回目のお祝いメッセージの動作確認が終わり次第、削除します
-
-<% 95.times do |i| %>
-report<%= i + 88 %>:
-  user: komagata
-  title: <%= "テスト日報 #{i + 4}" %>
-  description: 動作確認が終わり次第、削除します
-  reported_on: <%= Time.zone.today - (97 - i) %>
-  wip: false
-  emotion: 2
-  created_at: <%= Time.zone.today - (96 - i).days %>
-  updated_at: <%= Time.zone.today - (96 - i).days %>
-  published_at: <%= Time.zone.today - (96 - i).days %>
-<% end %>
-
-report184:
-  user: komagata
-  title: "テスト日報（下書き） 99"
-  description: 動作確認が終わり次第、削除します
-  reported_on: <%= Time.zone.today - 2 %>
-  wip: true
-  emotion: 2
-  created_at: <%= Time.zone.today - 1 %>
-  updated_at: <%= Time.zone.today - 1 %>
-  published_at: <%= Time.zone.today - 1 %>


### PR DESCRIPTION
## Issue

- [#7885 特定の回数で表示される日報提出お祝いメッセージが、下書きの日報もカウントしている](https://github.com/fjordllc/bootcamp/issues/7885)

## 概要

こちらのPRのステージング環境の動作確認が終了したため、追加したテストユーザを削除しました。

- [#8123 特定の提出回数で表示されるお祝いメッセージは下書きの日報をカウントしないように変更、n日目からn回目に文言を変更](https://github.com/fjordllc/bootcamp/pull/8123)

※同じブランチでテストデータを削除したコミットをpushしたのですが、リリース後はそのブランチに新しいコミットは積むことが出来ず、新しいPRを作成する必要がありましたので、こちらのPRで対応する形となりました。
※ブランチ名を変更できておりませんがご了承ください。