### PR TITLE
休会・退会したら参加している定期イベントはキャンセルされる

### DIFF
--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -15,10 +15,10 @@ class HibernationController < ApplicationController
 
     if @hibernation.save
       update_hibernated_at!
-      cancel_participation_from_regular_events
       destroy_subscription!
       notify_to_chat
       notify_to_mentors_and_admins
+      current_user.cancel_participation_from_regular_events
       current_user.delete_and_assign_new_organizer
       logout
       redirect_to hibernation_path
@@ -36,10 +36,6 @@ class HibernationController < ApplicationController
   def update_hibernated_at!
     current_user.hibernated_at = @hibernation.created_at
     current_user.save!(validate: false)
-  end
-
-  def cancel_participation_from_regular_events
-    current_user.regular_event_participations.destroy_all
   end
 
   def destroy_subscription!

--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -15,6 +15,7 @@ class HibernationController < ApplicationController
 
     if @hibernation.save
       update_hibernated_at!
+      cancel_participation_from_regular_events
       destroy_subscription!
       notify_to_chat
       notify_to_mentors_and_admins
@@ -35,6 +36,10 @@ class HibernationController < ApplicationController
   def update_hibernated_at!
     current_user.hibernated_at = @hibernation.created_at
     current_user.save!(validate: false)
+  end
+
+  def cancel_participation_from_regular_events
+    current_user.regular_event_participations.destroy_all
   end
 
   def destroy_subscription!

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -15,6 +15,7 @@ class RetirementController < ApplicationController
       current_user.delete_and_assign_new_organizer
       Newspaper.publish(:retirement_create, { user: })
 
+      cancel_participation_from_regular_events
       destroy_subscription(user)
       destroy_card(user)
       notify_to_user(user)
@@ -32,6 +33,10 @@ class RetirementController < ApplicationController
 
   def retire_reason_params
     params.require(:user).permit(:retire_reason, :satisfaction, :opinion, retire_reasons: [])
+  end
+
+  def cancel_participation_from_regular_events
+    current_user.regular_event_participations.destroy_all
   end
 
   def destroy_subscription(user)

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -12,10 +12,10 @@ class RetirementController < ApplicationController
     current_user.retired_on = Date.current
     if current_user.save(context: :retirement)
       user = current_user
+      current_user.cancel_participation_from_regular_events
       current_user.delete_and_assign_new_organizer
       Newspaper.publish(:retirement_create, { user: })
 
-      cancel_participation_from_regular_events
       destroy_subscription(user)
       destroy_card(user)
       notify_to_user(user)
@@ -33,10 +33,6 @@ class RetirementController < ApplicationController
 
   def retire_reason_params
     params.require(:user).permit(:retire_reason, :satisfaction, :opinion, retire_reasons: [])
-  end
-
-  def cancel_participation_from_regular_events
-    current_user.regular_event_participations.destroy_all
   end
 
   def destroy_subscription(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -845,6 +845,10 @@ class User < ApplicationRecord
     watches.find_or_create_by!(watchable:)
   end
 
+  def cancel_participation_from_regular_events
+    regular_event_participations.destroy_all
+  end
+
   def delete_and_assign_new_organizer
     organizers.each(&:delete_and_assign_new)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -706,6 +706,14 @@ class UserTest < ActiveSupport::TestCase
     assert_empty User.users_role(not_scope_name, allowed_targets:)
   end
 
+  test '#cancel_participation_from_regular_events' do
+    user = users(:hatsuno)
+
+    assert_changes -> { RegularEventParticipation.where(user:).exists? }, from: true, to: false do
+      user.cancel_participation_from_regular_events
+    end
+  end
+
   test '#delete_and_assign_new_organizer' do
     user = users(:hajime)
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -707,7 +707,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test '#cancel_participation_from_regular_events' do
-    user = users(:hatsuno)
+    user = users(:kimura)
 
     assert_changes -> { RegularEventParticipation.where(user:).exists? }, from: true, to: false do
       user.cancel_participation_from_regular_events

--- a/test/system/hibernation_test.rb
+++ b/test/system/hibernation_test.rb
@@ -38,6 +38,25 @@ class HibernationTest < ApplicationSystemTestCase
     assert_text '復帰予定日を入力してください'
   end
 
+  test 'cancel participation in regular event upon hibernation' do
+    visit_with_auth new_hibernation_path, 'hatsuno'
+    within('form[name=hibernation]') do
+      fill_in(
+        'hibernation[scheduled_return_on]',
+        with: (Date.current + 30)
+      )
+      fill_in('hibernation[reason]', with: 'test')
+    end
+    find('.check-box-to-read').click
+    click_on '休会する'
+    page.driver.browser.switch_to.alert.accept
+    assert_text '休会手続きが完了しました'
+
+    regular_event = regular_events(:regular_event1)
+    visit_with_auth "regular_events/#{regular_event.id}", 'komagata'
+    assert_no_selector '.is-hatsuno'
+  end
+
   test 'hibernate with event organizer' do
     visit_with_auth new_hibernation_path, 'hajime'
     within('form[name=hibernation]') do

--- a/test/system/retirement_test.rb
+++ b/test/system/retirement_test.rb
@@ -190,6 +190,24 @@ class RetirementTest < ApplicationSystemTestCase
     assert_equal 'FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
   end
 
+  test 'cancel participation in regular event upon retirement' do
+    regular_event = regular_events(:regular_event1)
+    visit_with_auth regular_event_path(regular_event), 'kimura'
+    accept_confirm do
+      click_link '参加申込'
+    end
+    assert_text '参加登録しました。'
+
+    visit_with_auth new_retirement_path, 'kimura'
+    find('label', text: 'とても良い').click
+    click_on '退会する'
+    page.driver.browser.switch_to.alert.accept
+    assert_text '退会処理が完了しました'
+
+    visit_with_auth "regular_events/#{regular_event.id}", 'komagata'
+    assert_no_selector '.is-kimura'
+  end
+
   test 'retire with event organizer' do
     visit_with_auth new_retirement_path, 'hajime'
     find('label', text: 'とても良い').click


### PR DESCRIPTION
## Issue

- #8073

## 概要
休会・退会したら参加している定期イベントはキャンセルされるようにしました

## 変更確認方法

### 事前準備
1. 変更確認をするために Chrome とは別にブラウザを用意 
2. `feature/on-hibernation-remove-from-regular-events` をローカルに取り込む
3. `rails db:seed` を実行して初期データ投入（このコマンドはローカルのDBを初期化します。初期化しても問題ないタイミングで行ってください。）
4. ログイン画面で「ユーザー名 or メールアドレス」komagata、「パスワード」testtest でログイン
5. 定期イベント「開発MTG」ページ（URL：`http://localhost:3000/regular_events/459650222`）に遷移
6. 参加者に hatsuno が**存在していること**を確認

### 休会時の確認手順
1. 事前準備完了後、もう 1 つのブラウザで hatsuno でログインし、休会ページから休会を実施
2. komagata でログインしているブラウザをリロード
3. 参加者に hatsuno が**いなくなっていること**を確認 

### 退会時の確認手順
1. 事前準備の手順 3 以降を実施
2. 退会するときは、存在する支払い情報が必要なので、もう 1 つのブラウザで、一度ユーザを新規作成（クレジットカード情報は https://docs.stripe.com/testing?locale=ja-JP#cards を参考に入力してください。）
3. users テーブルにある hatsuno のレコード の customer_id と subscription_id を新規作成したユーザの customer_id とsubscription_id と同じものに更新
4. 2 で新規作成したブラウザで hatsuno でログインし、退会ページから退会を実施
5. komagata でログインしているブラウザをリロード
6. 参加者に hatsuno が**いなくなっていること**を確認 

## Screenshot

### 変更前

休会（または退会）したユーザが定期イベントに残っている

https://github.com/user-attachments/assets/8340e8a7-7704-44b1-a01a-c6c078993617

### 変更後

休会したら参加している定期イベントからいなくなる

https://github.com/user-attachments/assets/73e24833-a8ea-4a90-a957-fcec3b092534

退会したら参加している定期イベントからいなくなる

https://github.com/user-attachments/assets/3868c4d7-1f62-48b9-b026-c8864fc1658f
