### PR TITLE
誤って追加された内容をschemeから削除

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -413,14 +413,6 @@ ActiveRecord::Schema.define(version: 2024_08_21_190009) do
     t.index ["survey_question_id"], name: "index_linear_scales_on_survey_question_id"
   end
 
-  create_table "micro_reports", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.text "content", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id"], name: "index_micro_reports_on_user_id"
-  end
-
   create_table "notifications", force: :cascade do |t|
     t.integer "kind", default: 0, null: false
     t.bigint "user_id"
@@ -822,7 +814,6 @@ ActiveRecord::Schema.define(version: 2024_08_21_190009) do
   add_foreign_key "learning_minute_statistics", "practices"
   add_foreign_key "learning_times", "reports"
   add_foreign_key "linear_scales", "survey_questions"
-  add_foreign_key "micro_reports", "users"
   add_foreign_key "notifications", "users"
   add_foreign_key "notifications", "users", column: "sender_id"
   add_foreign_key "organizers", "regular_events"


### PR DESCRIPTION
## Issue

- #8151

## 概要
以下のPRで誤って`scheme.rb`に追加された変更を削除した。
[都道府県別ユーザー一覧の非React化 #8034](https://github.com/fjordllc/bootcamp/pull/8034/files#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R416-R422)

## 変更確認方法
- [ ]`scheme.rb`から`micro_reports`に関する内容が削除されていることを確認する

https://github.com/fjordllc/bootcamp/blob/b3b5fdfb34630aec19d0818de35e520ce9e6895a/db/schema.rb#L416-L422

https://github.com/fjordllc/bootcamp/blob/b3b5fdfb34630aec19d0818de35e520ce9e6895a/db/schema.rb#L825-L825


## Screenshot

`scheme.rb`の修正のみのため、変更はなし

