### PR TITLE
ブラウザのタブのタイトルとページの種類が一致しないのを修正

### DIFF
--- a/app/views/pages/unauthorized_show.slim
+++ b/app/views/pages/unauthorized_show.slim
@@ -1,10 +1,10 @@
-- title @page.title
+- title "Docs: #{@page.title}"
 - description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のドキュメント「#{@page.title}」のページです。"
 - content_for :extra_body_classes
 
 .page-body
   article.unauthorized
-    = render '/unauthorized/unauthorized_header', label: 'ドキュメント', title: title
+    = render '/unauthorized/unauthorized_header', label: 'ドキュメント', title: @page.title
     .unauthorized__body
       .container.is-md
         .unauthorized__contents

--- a/app/views/practices/unauthorized_show.slim
+++ b/app/views/practices/unauthorized_show.slim
@@ -1,4 +1,4 @@
-- title @practice.title
+- title "プラクティス #{@practice.title}"
 - description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のプラクティス「#{@practice.title}」のページです。"
 - content_for :extra_body_classes
 
@@ -10,7 +10,7 @@ ruby:
 
 .page-body
   article.unauthorized
-    = render '/unauthorized/unauthorized_header', label: 'プラクティス', title: title
+    = render '/unauthorized/unauthorized_header', label: 'プラクティス', title: @practice.title
 
     .unauthorized__body
       .container.is-md

--- a/app/views/questions/unauthorized_show.slim
+++ b/app/views/questions/unauthorized_show.slim
@@ -1,10 +1,10 @@
-- title @question.title
+- title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"
 - description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{@question.title}」のページです。"
 - content_for :extra_body_classes
 
 .page-body
   article.unauthorized
-    = render '/unauthorized/unauthorized_header', label: 'Q&A', title: title
+    = render '/unauthorized/unauthorized_header', label: 'Q&A', title: @question.title
     .unauthorized__body
       .container.is-md
         .unauthorized__contents

--- a/app/views/questions/unauthorized_show.slim
+++ b/app/views/questions/unauthorized_show.slim
@@ -1,6 +1,8 @@
-- title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"
-- description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{@question.title}」のページです。"
-- content_for :extra_body_classes
+ruby:
+ title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"
+ set_meta_tags og: { title: "Q&A: #{@question.title}" }
+ description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{@question.title}」のページです。"
+ content_for :extra_body_classes
 
 .page-body
   article.unauthorized

--- a/app/views/questions/unauthorized_show.slim
+++ b/app/views/questions/unauthorized_show.slim
@@ -1,8 +1,8 @@
 ruby:
- title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"
- set_meta_tags og: { title: "Q&A: #{@question.title}" }
- description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{@question.title}」のページです。"
- content_for :extra_body_classes
+  title "Q&A: #{truncate(@question.title, length: 35, omission: '...')}"
+  set_meta_tags og: { title: "Q&A: #{@question.title}" }
+  description "オンラインプログラミングスクール「フィヨルドブートキャンプ」のQ&A「#{@question.title}」のページです。"
+  content_for :extra_body_classes
 
 .page-body
   article.unauthorized

--- a/app/views/unauthorized/_unauthorized_header.html.slim
+++ b/app/views/unauthorized/_unauthorized_header.html.slim
@@ -6,5 +6,5 @@ header.unauthorized-header
         = label
       h1.unauthorized-header__title
         span.font-thin 「
-        = truncate(title, length: 35, omission: '...')
+        = title
         span.font-thin 」

--- a/app/views/unauthorized/_unauthorized_header.html.slim
+++ b/app/views/unauthorized/_unauthorized_header.html.slim
@@ -1,5 +1,3 @@
-- title "Q&A: #{truncate(title, length: 35, omission: '...')}"
-- set_meta_tags og: { title: "Q&A: #{title}" }
 header.unauthorized-header
   .container
     = image_tag('shared/piyo.svg', alt: 'フィヨルドブートキャンプのキャラクター画像', class: 'unauthorized-header__image')
@@ -8,5 +6,5 @@ header.unauthorized-header
         = label
       h1.unauthorized-header__title
         span.font-thin 「
-        = title
+        = truncate(title, length: 35, omission: '...')
         span.font-thin 」

--- a/app/views/users/unauthorized_show.slim
+++ b/app/views/users/unauthorized_show.slim
@@ -1,11 +1,11 @@
-- title "@#{@user.login_name}"
+- title "#{@user.login_name}さんのプロフィール"
 - description "オンラインプログラミングスクール「フィヨルドブートキャンプ」の@#{@user.login_name}さんのプロフィールページ"
 - content_for :extra_body_classes
 
 .page-body
   article.unauthorized
     = render '/unauthorized/unauthorized_header',
-      label: 'ユーザープロフィールページ', title: title.to_s
+      label: 'ユーザープロフィールページ', title: title
     .unauthorized__body
       .container.is-md
         .unauthorized__contents


### PR DESCRIPTION
## Issue
[プラクティスなのにタイトルが"Q&A"になっている #8053](https://github.com/fjordllc/bootcamp/issues/8053)

## 概要
未ログインの状態で特定のページにアクセスすると、ブラウザのタブのタイトルがページの種類と一致しない問題を修正しました。

#### 原因
`_unauthorized_header.html.slim`というパーシャルで間違ったタイトルが設定されていました。
```ruby
- title "Q&A: #{truncate(title, length: 35, omission: '...')}"
- set_meta_tags og: { title: "Q&A: #{title}" }
```
* 上記のようにどのページでもタイトルに“Q&A” がつくようになっていました。

#### 対処
* 原因のパーシャルを呼び出している`unauthorized_show.slim`でもタイトルを設定しているので、パーシャル側のタイトル設定は不要だと思い削除しました。
* `set_meta_tags og: { title: "Q&A: #{title}" }`は無くても、デフォルトでog:titleにtitleタグの内容が入るように設定されていたので削除しました。
* `unauthorized_show.slim`のタイトル設定をログイン時のタイトルと一致するように修正しました。

## 変更確認方法

1. `bug/fix-tab-title`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げ
3. 未ログイン状態でプラクティスの詳細ページにアクセスhttp://localhost:3000/practices/315059988
4. タブのタイトルが、ログイン状態のタブのタイトル：`(development) プラクティス OS X Mountain Lionをクリーンインストールする | FBC`と一致することを確認
5. 未ログイン状態でDocsの詳細ページにアクセスhttp://localhost:3000/pages/1069065928
6. タブのタイトルが、ログイン状態のタブのタイトル：`(development) Docs: プラクティスに紐付いたDocs3 | FBC`と一致することを確認
7. 未ログイン状態でQ&Aの詳細ページにアクセス
http://localhost:3000/questions/1037106414
8. タブのタイトルが、ログイン状態のタブのタイトル：`(development) Q&A: テストの質問40 | FBC`と一致することを確認
9. 未ログイン状態でユーザーの詳細ページにアクセス
http://localhost:3000/users/991528156
10. タブのタイトルが、ログイン状態のタブのタイトル：`(development) kimuraさんのプロフィール | FBC`と一致することを確認

## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/b0968436-566c-4618-956e-215350df761f)

### 変更後
![image](https://github.com/user-attachments/assets/75ce1b2c-4314-4f4a-a2f6-186fbfd7aee8)
