### PR TITLE
未ログイン状態のトップ画面にGitHubのリンクを追加

### DIFF
--- a/app/views/shared/_not_logged_in_footer.html.slim
+++ b/app/views/shared/_not_logged_in_footer.html.slim
@@ -15,6 +15,9 @@ footer.not-logged-in-footer
           = link_to coc_path, class: 'not-logged-in-footer__nav-item-link' do
             | アンチハラスメントポリシー
         li.not-logged-in-footer__nav-item
+          = link_to 'https://github.com/fjordllc/bootcamp', class: 'not-logged-in-footer__nav-item-link' do
+            | ソースコード
+        li.not-logged-in-footer__nav-item
           = link_to law_path, class: 'not-logged-in-footer__nav-item-link' do
             | 特定商取引法に基づく表記
         li.not-logged-in-footer__nav-item


### PR DESCRIPTION
## Issue
[ログイン前にGitHubへのリンクが欲しい #8159](https://github.com/fjordllc/bootcamp/issues/8159)

## 概要
未ログイン状態のトップ画面にリポジトリリンクを追加しました。

* アンカーテキスト：ソースコード
* URL：'https://github.com/fjordllc/bootcamp'

## 変更確認方法
1. `feature/add-github-link`をローカルに取り込む
2. 'foreman start -f Procfile.dev 'でローカルサーバーを立ち上げ
3. 未ログイン状態でトップ画面にアクセスしてフッター部分にリンクが追加さ
れていることを確認
http://localhost:3000/
## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/db64ac1f-b17c-4c58-aa56-492d6a25d278)

### 変更後
![227f7ed549bd662a6b2bf73312798d45a3bbe16f0c4d42506de71feb56b2d4e9](https://github.com/user-attachments/assets/bad4e0a8-6c14-4ec5-b50a-a8f1c3547b86)
