### PR TITLE
ブログの公開済み記事が公開日順で並ぶようにした

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -75,17 +75,6 @@ class ArticlesController < ApplicationController
     Article.with_attachments_and_user.order(published_at: :desc)
   end
 
-  def list_articles
-    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
-                      .order(published_at: :desc, created_at: :desc).page(params[:page])
-    admin_or_mentor_login? ? articles : articles.where(wip: false)
-  end
-
-  def list_recent_articles(number)
-    Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
-           .where(wip: false).order(published_at: :desc).limit(number)
-  end
-
   def article_params
     article_attributes = %i[
       title

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,10 +6,10 @@ class ArticlesController < ApplicationController
   before_action :require_admin_or_mentor_login, except: %i[index show]
 
   def index
-    @articles = Article.with_attachments_and_user.order(created_at: :desc).page(params[:page])
+    @articles = sorted_articles.page(params[:page])
     @articles = @articles.tagged_with(params[:tag]) if params[:tag]
     number_per_page = @articles.page(1).limit_value
-    @atom_articles = Article.with_attachments_and_user.order(published_at: :desc).limit(number_per_page)
+    @atom_articles = sorted_articles.limit(number_per_page)
     respond_to do |format|
       format.html { render layout: 'lp' }
       format.atom
@@ -65,6 +65,14 @@ class ArticlesController < ApplicationController
 
   def set_article
     @article = Article.find(params[:id])
+  end
+
+  def skip_before_action
+    Article.with_attachments_and_user.order(published_at: :desc)
+  end
+
+  def sorted_articles
+    Article.with_attachments_and_user.order(published_at: :desc)
   end
 
   def list_articles

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -18,7 +18,7 @@ class ArticlesController < ApplicationController
 
   def show
     @mentor = @article.user
-    @recent_articles = Article.with_attachments_and_user.order(published_at: :desc).limit(10)
+    @recent_articles = sorted_articles.limit(10)
     if @article.published? || @article.token == params[:token] || admin_or_mentor_login?
       render layout: 'lp'
     else

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -67,6 +67,17 @@ class ArticlesController < ApplicationController
     @article = Article.find(params[:id])
   end
 
+  def list_articles
+    articles = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
+                      .order(published_at: :desc, created_at: :desc).page(params[:page])
+    admin_or_mentor_login? ? articles : articles.where(wip: false)
+  end
+
+  def list_recent_articles(number)
+    Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
+           .where(wip: false).order(published_at: :desc).limit(number)
+  end
+
   def sorted_articles
     Article.with_attachments_and_user.order(published_at: :desc)
   end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -67,10 +67,6 @@ class ArticlesController < ApplicationController
     @article = Article.find(params[:id])
   end
 
-  def skip_before_action
-    Article.with_attachments_and_user.order(published_at: :desc)
-  end
-
   def sorted_articles
     Article.with_attachments_and_user.order(published_at: :desc)
   end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -444,8 +444,8 @@ class ArticlesTest < ApplicationSystemTestCase
     )
 
     visit articles_url
-    titles = all('h2.thumbnail-card__title').map(&:text)
-    assert_equal [one_day_ago_article.title, two_days_ago_article.title, three_days_ago_article.title, @article2.title, @article.title], titles
+    top_three_titles = all('h2.thumbnail-card__title').take(3).map(&:text)
+    assert_equal [one_day_ago_article.title, two_days_ago_article.title, three_days_ago_article.title], top_three_titles
   end
 
   test 'WIP articles are listed first in desc order' do

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -414,6 +414,40 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_no_text 'WIPの記事は atom feed に表示されない'
   end
 
+  test 'articles are displayed from the most recent publication date' do
+    article4 = Article.create(
+      title: 'タイトル4',
+      body: 'テスト用のWIP記事4',
+      user: users(:komagata),
+      wip: false,
+      created_at: Date.current - 4.days,
+      updated_at: Date.current - 4.days,
+      published_at: Date.current - 3.days
+    )
+    article5 = Article.create(
+      title: 'タイトル5',
+      body: 'テスト用のWIP記事5',
+      user: users(:komagata),
+      wip: false,
+      created_at: Date.current - 5.days,
+      updated_at: Date.current - 5.days,
+      published_at: Date.current - 2.days
+    )
+    article6 = Article.create(
+      title: 'タイトル6',
+      body: 'テスト用のWIP記事6',
+      user: users(:komagata),
+      wip: false,
+      created_at: Date.current - 6.days,
+      updated_at: Date.current - 6.days,
+      published_at: Date.current - 1.day
+    )
+
+    visit articles_url
+    titles = all('h2.thumbnail-card__title').map(&:text)
+    assert_equal [article6.title, article5.title, article4.title, @article2.title, @article.title], titles
+  end
+
   test 'WIP articles are listed first in desc order' do
     # テストがわかりやすいように test/fixtures/article.yml の article3(WIP記事) からの連番で作成
     wip_article4 = Article.create(

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -415,27 +415,27 @@ class ArticlesTest < ApplicationSystemTestCase
   end
 
   test 'articles are displayed from the most recent publication date' do
-    article4 = Article.create(
-      title: 'タイトル4',
-      body: 'テスト用のWIP記事4',
+    three_days_ago_article = Article.create(
+      title: '3日前に公開された記事',
+      body: 'test',
       user: users(:komagata),
       wip: false,
       created_at: Date.current - 4.days,
       updated_at: Date.current - 4.days,
       published_at: Date.current - 3.days
     )
-    article5 = Article.create(
-      title: 'タイトル5',
-      body: 'テスト用のWIP記事5',
+    two_days_ago_article = Article.create(
+      title: '2日前に公開された記事',
+      body: 'test',
       user: users(:komagata),
       wip: false,
       created_at: Date.current - 5.days,
       updated_at: Date.current - 5.days,
       published_at: Date.current - 2.days
     )
-    article6 = Article.create(
-      title: 'タイトル6',
-      body: 'テスト用のWIP記事6',
+    one_day_ago_article = Article.create(
+      title: '1日前に公開された記事',
+      body: 'test',
       user: users(:komagata),
       wip: false,
       created_at: Date.current - 6.days,
@@ -445,7 +445,7 @@ class ArticlesTest < ApplicationSystemTestCase
 
     visit articles_url
     titles = all('h2.thumbnail-card__title').map(&:text)
-    assert_equal [article6.title, article5.title, article4.title, @article2.title, @article.title], titles
+    assert_equal [one_day_ago_article.title, two_days_ago_article.title, three_days_ago_article.title, @article2.title, @article.title], titles
   end
 
   test 'WIP articles are listed first in desc order' do


### PR DESCRIPTION
## Issue

- #8058 

## 概要
[こちら](https://github.com/fjordllc/bootcamp/pull/7299/) のプルリクの対応により、ブログ一覧のソート順が作成日時の降順で並んでいました。今回のバグ修正対応では、ブログの公開日順で並ぶようにしました。

## 変更確認方法

1. `bug/articles-are-displayed-from-the-date-of-latest-publication` をローカルに取り込む
2. `rails db:seed` を実行して初期データ投入（このコマンドはローカルの DB データを初期化するので、初期化しても問題ないタイミングで行ってください。DB のデータが初期状態の場合実行する必要はありません。）
3. コマンドライン環境で `rails c` を起動し、下記の「テストーデータ」を投入する ruby のコマンドを実行
4. `foreman start -f Procfile.dev` でサーバを起動し、http://localhost:3000/articles/ にアクセス
5. 「1..3番目に表示されてほしいブログ」の順にブログが表示されていることを確認

## Screenshot

### 変更前

![スクリーンショット 2024-11-02 3 21 20](https://github.com/user-attachments/assets/6b331930-4505-48b7-90f0-46a283e6664e)



### 変更後

![スクリーンショット 2024-11-02 3 21 47](https://github.com/user-attachments/assets/8311a84e-a0ea-45d6-a38b-1404120756d8)

# テストデータ
```ruby
Article.create(
  title: '1番目に表示されてほしいブログ',
  body: 'test',
  created_at: Date.current - 6.day,
  updated_at: Date.current - 6.day,
  user_id: 459775584,
  published_at: Date.current - 1.day
)

Article.create(
  title: '2番目に表示されてほしいブログ',
  body: 'test',
  created_at: Date.current - 5.day,
  updated_at: Date.current - 5.day,
  user_id: 459775584,
  published_at: Date.current - 2.day
)

Article.create(
  title: '3番目に表示されてほしいブログ',
  body: 'test',
  created_at: Date.current - 4.day,
  updated_at: Date.current - 4.day,
  user_id: 459775584,
  published_at: Date.current - 3.day
)

```
