### PR TITLE
コース別ユーザー一覧ページにおいて「その他」のコースに所属するユーザーが表示されない不具合を修正した

### DIFF
--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -7,11 +7,12 @@ class Users::CoursesController < ApplicationController
 
   def index
     @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
-    course_names = if @target == 'other_courses'
-                     Course.where(published: false).pluck(:title)
-                   else
-                     Course.where(published: true).where(title: I18n.t("course_names.#{@target}")).pluck(:title)
-                   end
+    course_names =
+      if @target == 'other_courses'
+        Course.where(published: false).pluck(:title)
+      else
+        Course.where(published: true).where(title: I18n.t("course_names.#{@target}")).pluck(:title)
+      end
 
     target_users = User.by_course(course_names).students_and_trainees
     @users = target_users

--- a/app/controllers/users/courses_controller.rb
+++ b/app/controllers/users/courses_controller.rb
@@ -7,7 +7,12 @@ class Users::CoursesController < ApplicationController
 
   def index
     @target = ALLOWED_TARGETS.include?(params[:target]) ? params[:target] : ALLOWED_TARGETS.first
-    course_names = Course.where(published: true).where(title: I18n.t("course_names.#{@target}")).pluck(:title)
+    course_names = if @target == 'other_courses'
+                     Course.where(published: false).pluck(:title)
+                   else
+                     Course.where(published: true).where(title: I18n.t("course_names.#{@target}")).pluck(:title)
+                   end
+
     target_users = User.by_course(course_names).students_and_trainees
     @users = target_users
              .page(params[:page]).per(PAGER_NUMBER)

--- a/app/views/users/courses/index.html.slim
+++ b/app/views/users/courses/index.html.slim
@@ -37,10 +37,11 @@ main.page-main
                         label.a-form-label
                           | 絞り込み
                         = hidden_field_tag :target, params[:target]
-                        = text_field_tag :search_word, params[:search_word], class: 'a-text-input',
-                                          placeholder: 'ユーザーID、ユーザー名、読み方、Discord ID など',
-                                          onchange: 'this.form.submit()',
-                                          id: 'js-user-search-input'
+                        = text_field_tag :search_word, params[:search_word],
+                          class: 'a-text-input',
+                          placeholder: 'ユーザーID、ユーザー名、読み方、Discord ID など',
+                          onchange: 'this.form.submit()',
+                          id: 'js-user-search-input'
               .page-content.is-users
                 #user_lists.users__items
                   = render 'users/user_list', users: @users

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -402,7 +402,6 @@ ja:
   course_names:
     rails_course: Railsエンジニア
     front_end_course: フロントエンドエンジニア
-    other_courses: [Unityゲームエンジニア, iOSエンジニア]
   watch:
     all: すべて
     true: コメントあり

--- a/test/system/user/courses_test.rb
+++ b/test/system/user/courses_test.rb
@@ -34,12 +34,11 @@ class User::CoursesTest < ApplicationSystemTestCase
   test 'show users sorted by other courses' do
     visit_with_auth '/users/courses?target=other_courses', 'kimura'
     assert_selector('a.tab-nav__item-link.is-active', text: 'その他')
-    assert_text 'その他のコース（0）'
-    assert_selector '.users-item', count: 0
-    assert_text 'その他のユーザーはいません'
-    assert_no_link 'unity-course'
-    assert_no_text 'Unityゲームエンジニアコースのユーザー'
-    assert_no_link 'ios-course'
-    assert_no_text 'iOSエンジニアコースのユーザー'
+    assert_text 'その他のコース（2）'
+    assert_selector '.users-item', count: 2
+    assert_link 'unity-course'
+    assert_text 'Unityゲームエンジニアコースのユーザー'
+    assert_link 'ios-course'
+    assert_text 'iOSエンジニアコースのユーザー'
   end
 end


### PR DESCRIPTION
## Issue

- #7998 

## 概要
昨日（2024/10/30）のリリースに含まれていた#8070について、「その他」のコースに所属するユーザーが表示されなくなっていたため修正したものです。（#7998 のページで@machidaさんからご指摘のあった件です。）

## 変更確認方法
1. `bug/users-in-other-courses-are-not-displayed`をローカルに取り込む
1. `http://localhost:3000/users/courses`にアクセスする
1. 「その他」のタブをクリックし、「Unityゲームエンジニアコース」及び「iOSエンジニアコース」所属ユーザーのみの一覧が表示されていることを確認する

## Screenshot
![image](https://github.com/user-attachments/assets/0088ebd6-9e61-4a71-a6ab-297ecdd55417)