### PR TITLE
定期イベントでメンション付きのコメントをしたときにメール通知とメッセージが不適切になるバグを修正

### DIFF
--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -71,6 +71,7 @@ module Mentioner
       Report: "#{commentable.user.login_name}さんの日報「#{commentable.title}」",
       Product: "#{commentable.user.login_name}さんの#{commentable.title}",
       Event: "特別イベント「#{commentable.title}」",
+      RegularEvent: "定期イベント「#{commentable.title}」",
       Page: "Docs「#{commentable.title}」",
       Announcement: "お知らせ「#{commentable.title}」"
     }[:"#{commentable_class}"]

--- a/test/system/notification/regular_events_test.rb
+++ b/test/system/notification/regular_events_test.rb
@@ -78,4 +78,13 @@ class Notification::RegularEventsTest < ApplicationSystemTestCase
 
     assert_requested(stub_message)
   end
+
+  test 'notify correct message when mentioned' do
+    regular_event = regular_events(:regular_event1)
+    visit_with_auth regular_event_path(regular_event), 'komagata'
+    fill_in 'new_comment[description]', with: '@machida test'
+    click_button 'コメントする'
+    visit_with_auth '/notifications', 'machida'
+    assert_text '定期イベント「開発MTG」へのコメントでkomagataさんからメンションがきました。'
+  end
 end


### PR DESCRIPTION
## Issue
[定期イベントでメンション付きのコメントをした場合、メールと通知のメッセージが不適切 #6365](https://github.com/fjordllc/bootcamp/issues/6365)

## 概要
定期イベントのページでメンション付きのコメントをしたときにメール通知とメッセージが不適切になるバグを修正 しました。
issueに書かれているように`RegularEvent`クラスに対応するメンションメッセージがなかったので追加して対応しました。

## 変更確認方法
1. `bug/fix-event-mention-notification`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げ
3. 定期イベントページにアクセス
http://localhost:3000/regular_events/459650222
4. 定期イベントページでメンション付きのコメントをする
5. メンションされたユーザーでログイン
6. `定期イベント「開発MTG」へのコメントで<ユーザー名>さんからメンションがきました。`という通知が来ていることを確認
7. letter_opennerにアクセス 
http://localhost:3000/letter_opener/
9. subjectが`[FBC] komagataさんの定期イベント「開発MTG」に<ユーザー名>さんがコメントしました。`というメールが来ていることを確認

## Screenshot

### 変更前

* #### 通知
---
![bcfea81fc50f663a40f2cf72da8746d075440ffaa6103e97a195c9a92118f347のコピー](https://github.com/user-attachments/assets/d677d6c5-14d3-4e7e-9a94-80d6cdfa0bd2)

* #### メール
---
![234840cb10f334ac2120e95b1535fef082415b6fd928c4fa7b8c060df547df30のコピー](https://github.com/user-attachments/assets/208226d7-0baa-492c-a892-11a621ac5955)

### 変更後
* #### 通知
---
![28e48a0e34fc2ca3a873012eb67c2f8b577d557ab93c9e4463d47fb8cfa5da35のコピー](https://github.com/user-attachments/assets/0ee1134b-5e71-433a-aeb1-e558a2b71aa5)

* #### メール
---
![7404a7e05d74028a25878bfbd494d6f4c5c6fa05b06fb6a8be5177c2f45128deのコピー](https://github.com/user-attachments/assets/f74beb1e-37ed-4908-98d9-2ae2309a1139)

