### PR TITLE
日報の学習日入力部分に範囲バリデーションを追加した

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -33,7 +33,6 @@ class Report < ApplicationRecord
   validates :reported_on, presence: true, uniqueness: { scope: :user }
   validates :emotion, presence: true
   validate :limit_date_within_range
-  # validate :reported_on_or_before_today
 
   after_create ReportCallbacks.new
   after_destroy ReportCallbacks.new
@@ -114,10 +113,6 @@ class Report < ApplicationRecord
   def total_learning_time
     (learning_times.sum(&:diff) / 60).to_i
   end
-
-  # def reported_on_or_before_today
-  #   errors.add(:reported_on, 'は今日以前の日付にしてください') if reported_on > Date.current
-  # end
 
   def limit_date_within_range
     min_date = Date.new(2013, 1, 1)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -135,7 +135,7 @@ class Report < ApplicationRecord
 
   def limit_date_within_range
     min_date = Date.new(2013, 1, 1)
-    return if min_date < reported_on && reported_on < Date.current
+    return if min_date < reported_on && reported_on <= Date.current
 
     errors.add(:reported_on, "は#{I18n.l min_date, format: :default}から今日以前の間の日付にしてください")
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -135,7 +135,7 @@ class Report < ApplicationRecord
 
   def limit_date_within_range
     min_date = Date.new(2013, 1, 1)
-    return if min_date < reported_on && reported_on <= Date.current
+    return if min_date <= reported_on && reported_on <= Date.current
 
     errors.add(:reported_on, "は#{I18n.l min_date, format: :default}から今日以前の間の日付にしてください")
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -32,7 +32,8 @@ class Report < ApplicationRecord
   validates :user, presence: true
   validates :reported_on, presence: true, uniqueness: { scope: :user }
   validates :emotion, presence: true
-  validate :reported_on_or_before_today
+  validate :limit_date_within_range
+  # validate :reported_on_or_before_today
 
   after_create ReportCallbacks.new
   after_destroy ReportCallbacks.new
@@ -114,8 +115,15 @@ class Report < ApplicationRecord
     (learning_times.sum(&:diff) / 60).to_i
   end
 
-  def reported_on_or_before_today
-    errors.add(:reported_on, 'は今日以前の日付にしてください') if reported_on > Date.current
+  # def reported_on_or_before_today
+  #   errors.add(:reported_on, 'は今日以前の日付にしてください') if reported_on > Date.current
+  # end
+
+  def limit_date_within_range
+    min_date = Date.new(2013, 1, 1)
+    return if min_date < reported_on && reported_on < Date.current
+
+    errors.add(:reported_on, "は#{I18n.l min_date, format: :default}から今日以前の間の日付にしてください")
   end
 
   def latest_of_user?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -114,13 +114,6 @@ class Report < ApplicationRecord
     (learning_times.sum(&:diff) / 60).to_i
   end
 
-  def limit_date_within_range
-    min_date = Date.new(2013, 1, 1)
-    return if min_date < reported_on && reported_on < Date.current
-
-    errors.add(:reported_on, "は#{I18n.l min_date, format: :default}から今日以前の間の日付にしてください")
-  end
-
   def latest_of_user?
     self == Report.not_wip
                   .where(user:, wip: false)
@@ -136,5 +129,14 @@ class Report < ApplicationRecord
     Report.where(user:, wip: false)
           .order(reported_on: :desc)
           .second
+  end
+
+  private
+
+  def limit_date_within_range
+    min_date = Date.new(2013, 1, 1)
+    return if min_date < reported_on && reported_on < Date.current
+
+    errors.add(:reported_on, "は#{I18n.l min_date, format: :default}から今日以前の間の日付にしてください")
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -32,7 +32,7 @@ class Report < ApplicationRecord
   validates :user, presence: true
   validates :reported_on, presence: true, uniqueness: { scope: :user }
   validates :emotion, presence: true
-  validate :limit_date_within_range
+  validate :limited_date_within_range
 
   after_create ReportCallbacks.new
   after_destroy ReportCallbacks.new
@@ -133,10 +133,10 @@ class Report < ApplicationRecord
 
   private
 
-  def limit_date_within_range
+  def limited_date_within_range
     min_date = Date.new(2013, 1, 1)
     return if min_date <= reported_on && reported_on <= Date.current
 
-    errors.add(:reported_on, "は#{I18n.l min_date, format: :default}から今日以前の間の日付にしてください")
+    errors.add(:reported_on, "は#{I18n.l min_date}から今日以前の間の日付にしてください")
   end
 end

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -20,8 +20,7 @@
 
       .form-item
         = f.label :reported_on, class: 'a-form-label'
-        = f.date_field :reported_on, class: 'a-text-input'
-        / = f.date_field :reported_on, min: '2013-01-01', class: 'a-text-input'
+        = f.date_field :reported_on, min: '2013-01-01', class: 'a-text-input'
       .form-item.is-sm
         = f.label :emotion, class: 'a-form-label'
         ul.block-checks.is-3-items.is-inline

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -20,7 +20,7 @@
 
       .form-item
         = f.label :reported_on, class: 'a-form-label'
-        = f.date_field :reported_on, class: 'a-text-input'
+        = f.date_field :reported_on, min: '2013-01-01', class: 'a-text-input'
       .form-item.is-sm
         = f.label :emotion, class: 'a-form-label'
         ul.block-checks.is-3-items.is-inline

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -20,7 +20,8 @@
 
       .form-item
         = f.label :reported_on, class: 'a-form-label'
-        = f.date_field :reported_on, min: '2013-01-01', class: 'a-text-input'
+        = f.date_field :reported_on, class: 'a-text-input'
+        / = f.date_field :reported_on, min: '2013-01-01', class: 'a-text-input'
       .form-item.is-sm
         = f.label :emotion, class: 'a-form-label'
         ul.block-checks.is-3-items.is-inline

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -43,4 +43,11 @@ class ReportTest < ActiveSupport::TestCase
   test '#interval' do
     assert_equal 10, reports(:report32).interval
   end
+
+  test '#limit_date_within_range' do
+    past_report = Report.new(reported_on: '2012-12-31')
+    assert_not past_report.valid?
+    future_report = Report.new(reported_on: Date.tomorrow)
+    assert_not future_report.valid?
+  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -43,11 +43,4 @@ class ReportTest < ActiveSupport::TestCase
   test '#interval' do
     assert_equal 10, reports(:report32).interval
   end
-
-  test '#limit_date_within_range' do
-    past_report = Report.new(reported_on: '2012-12-31')
-    assert_not past_report.valid?
-    future_report = Report.new(reported_on: Date.tomorrow)
-    assert_not future_report.valid?
-  end
 end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -475,10 +475,12 @@ class ReportsTest < ApplicationSystemTestCase
     within('form[name=report]') do
       fill_in('report[title]', with: '学習日が2013年1月1日より前では日報を作成できない')
       fill_in('report[description]', with: 'エラーになる')
-      fill_in('report[reported_on]', with: Date.new(2013, 1, 1))
+      fill_in('report[reported_on]', with: Date.new(2012, 12, 31))
     end
     click_button '提出'
-    assert_text '学習日は2013年01月01日から今日以前の間の日付にしてください'
+    html_validataion_message = page.find('#report_reported_on').native.attribute('validationMessage')
+    assert_not_nil html_validataion_message
+    assert_not_empty html_validataion_message
   end
 
   test 'display recently reports' do

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -473,7 +473,7 @@ class ReportsTest < ApplicationSystemTestCase
   test 'cannot post a new report with min date' do
     visit_with_auth '/reports/new', 'komagata'
     within('form[name=report]') do
-      fill_in('report[title]', with: '学習日が2013年1月1日以前では日報を作成できない')
+      fill_in('report[title]', with: '学習日が2013年1月1日より前では日報を作成できない')
       fill_in('report[description]', with: 'エラーになる')
       fill_in('report[reported_on]', with: Date.new(2013, 1, 1))
     end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -467,7 +467,18 @@ class ReportsTest < ApplicationSystemTestCase
       fill_in('report[reported_on]', with: Date.current.next_day)
     end
     click_button '提出'
-    assert_text '学習日は今日以前の日付にしてください'
+    assert_text '学習日は2013年01月01日から今日以前の間の日付にしてください'
+  end
+
+  test 'cannot post a new report with min date' do
+    visit_with_auth '/reports/new', 'komagata'
+    within('form[name=report]') do
+      fill_in('report[title]', with: '学習日が2013年1月1日以前では日報を作成できない')
+      fill_in('report[description]', with: 'エラーになる')
+      fill_in('report[reported_on]', with: Date.new(2013, 1, 1))
+    end
+    click_button '提出'
+    assert_text '学習日は2013年01月01日から今日以前の間の日付にしてください'
   end
 
   test 'display recently reports' do


### PR DESCRIPTION
## Issue

- #6899

## 概要
日報の学習日入力部分において、通常あり得ないほど過去の年月日が選択され日報が作られてしまうのを防ぐために、範囲バリデーションを作成しました。
**2013年1月1日**より前の日時を選択して提出ボタンを押しても、HTMLとモデルの双方のバリデーションでDBへの登録が防止されます。

<img width="697" alt="スクリーンショット 2024-11-08 16 39 26" src="https://github.com/user-attachments/assets/3c0075c2-b540-4dfa-a033-f773bcf31434">


## 変更確認方法
HTMLバリデーション確認後、モデルバリデーションを確認する流れです。

1. `feature/add-validation-to-date-in-report`をローカルに取り込む
   1. `git fetch origin pull/8181/head:feature/add-validation-to-date-in-report`
   （２度目以降は上記ブランチのローカル変更に気をつけながら`--force`をつけてください）
   2. `git switch feature/add-validation-to-date-in-report`
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. 任意のアカウントでログイン
4. [日報作成ページ](http://localhost:3000/reports/new)にアクセス
5. 一度タイトルを選択し、キーボードのTabキーを1回押して学習日を選択してください
6. `2000/01/01`のような2013年1月1日より前の日時を入力します
7. タイトル、内容、学習時間を適当に入力した後、ページ下部の提出ボタンをクリックします
8. **HTMLによるバリデーションコメント**が表示されているか確認します（コメントの言語はユーザーのブラウザに依存します）
10. モデルによるバリデーション確認のために、HTMLバリデーションを無効化します
    1. Google Chromeデベロッパーツールを開いてください。（Macユーザーは`opt`+`cmd`+`i`）
    2. 要素タグの中から、`学習日`の`input`を見つけてください
    3. `min="2013-01-01"`部分をダブルクリックします
    4. 編集可能となるので`min="2013-01-01"`を消去してエンターを押してください
11. `2000/01/01`のような2013年1月1日より前の日時を入力します
12. **モデルによるバリデーションコメント**が表示されているか確認します（`学習日は2013年01月01日から今日以前の間の日付にしてください`）

## Screenshot

### 変更前
変更前はバリデーションがないため、そのまま保存されます。

### 変更後
基本的にはHTMLバリデーションが表示されます。
デベロッパーツールなどを使用し、HTMLバリデーションを無効化した場合のみ、モデルバリデーションが表示されます。
- HTMLバリデーション
<img width="530" alt="スクリーンショット 2024-11-08 14 58 36" src="https://github.com/user-attachments/assets/86362e9e-6e9d-4673-b1f1-c5e95238eb77">

- モデルバリデーション
<img width="488" alt="スクリーンショット 2024-11-08 16 30 40" src="https://github.com/user-attachments/assets/394e6cc0-a19a-4b26-b297-c657d5341869">
