### PR TITLE
フッターにフィヨルドブートキャストのリンクを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -56,6 +56,9 @@ footer.footer
             = link_to 'https://fbc-stack.vercel.app/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | FBC Stack
           li.footer-nav__item
+            = link_to 'https://circlecast.net/channels/9', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | フィヨルドブートキャスト
+          li.footer-nav__item
             = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
               i.fa-solid.fa-rss
       small.footer__copyright


### PR DESCRIPTION
## Issue

- #8093

## 概要

フッターにフィヨルドブートキャストのリンクを追加しました。

## 変更確認方法

1. `feature/add_podcast_link_in_footer`をローカルに取り込む
2.  `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. 任意のアカウントでログイン
4. [トップページなどの任意のページ](http://localhost:3000/)を開き、フッターにフィヨルドブートキャストのリンクがあるかを確認

## Screenshot

### 変更前

<img width="1325" alt="20241108a" src="https://github.com/user-attachments/assets/e27cefc2-3293-4a5f-af9c-5dd74d6a8cb5">

### 変更後

<img width="1301" alt="20241108b" src="https://github.com/user-attachments/assets/8d4634c2-7ab7-4ba1-af71-9e5e62c0f0dc">

