### PR TITLE
ブログ記事の一覧にて、feature タグがついてるブログ記事はメンター・管理者にだけ目印が表示される。

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,7 +6,7 @@ class ArticlesController < ApplicationController
   before_action :require_admin_or_mentor_login, except: %i[index show]
 
   def index
-    @articles = sorted_articles.page(params[:page])
+    @articles = sorted_articles.preload([:tags]).page(params[:page])
     @articles = @articles.tagged_with(params[:tag]) if params[:tag]
     number_per_page = @articles.page(1).limit_value
     @atom_articles = sorted_articles.limit(number_per_page)

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -18,4 +18,8 @@ module ArticlesHelper
     content = logged_in? ? 'none' : 'noindex, nofollow'
     tag.meta(name: 'robots', content:)
   end
+
+  def feature_tag?(article)
+    article.tags.pluck(:name).include?('feature')
+  end
 end

--- a/app/javascript/stylesheets/_common-imports.sass
+++ b/app/javascript/stylesheets/_common-imports.sass
@@ -163,6 +163,7 @@
 @import "shared/blocks/card/congrats-card-body"
 @import "shared/blocks/card/practice-books"
 @import "shared/blocks/card/thumbnail-card"
+@import "shared/blocks/card/tags-highlight"
 
 @import "shared/blocks/card-list/card-list-item-actions"
 @import "shared/blocks/card-list/card-list-item-meta"

--- a/app/javascript/stylesheets/config/mixins/_badge.sass
+++ b/app/javascript/stylesheets/config/mixins/_badge.sass
@@ -12,6 +12,12 @@
     margin-left: .1875em
   &:not(:last-child)
     margin-right: .1875em
+  &.is-block
+    width: 100%
+    display: flex
+    .a-badge__inner
+      overflow: hidden
+      text-overflow: ellipsis
 
 =badge-color($color)
   background-color: $color

--- a/app/javascript/stylesheets/shared/blocks/card/_tags-highlight.sass
+++ b/app/javascript/stylesheets/shared/blocks/card/_tags-highlight.sass
@@ -1,0 +1,15 @@
+.tags-highlight
+  position: absolute
+  left: 0
+  top: 0
+  padding: .5rem .75rem
+  display: flex
+  gap: .25rem
+  width: 100%
+  flex-wrap: wrap
+
+.tags-highlight__item
+  width: 25%
+  max-width: 6rem
+  .a-badge
+    border: solid 1px var(--base)

--- a/app/javascript/stylesheets/shared/blocks/card/_thumbnail-card.sass
+++ b/app/javascript/stylesheets/shared/blocks/card/_thumbnail-card.sass
@@ -1,4 +1,5 @@
 .thumbnail-card
+  padding: 1rem
   +media-breakpoint-up(md)
     height: 100%
   +media-breakpoint-down(sm)
@@ -6,10 +7,10 @@
       height: 100%
 
 .thumbnail-card__inner
-  padding: 1rem
   display: flex
   flex-direction: column
   gap: 1rem
+  position: relative
 
 a.thumbnail-card__inner
   +flex-link

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -60,4 +60,10 @@ hr.a-border-tint
                               = l(article.created_at)
                             - else
                               = l(article.published_at)
+                        / クラスは適当なので修正
+                        / N+1を修正
+                        .thumbnail-card__meta
+                          .thumbnail-card__tag
+                            - if article.tag_list.include?('feature')
+                              = 'feature'
         = paginate articles

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -35,6 +35,12 @@ hr.a-border-tint
               .col-lg-4.col-md-6.col-xs-12
                 .thumbnail-card.a-card class=(article.wip? ? ' is-wip' : '')
                   = link_to article, class: 'thumbnail-card__inner' do
+                    - if current_user&.admin_or_mentor_login? && article.tags.pluck(:name).include?('feature')
+                      .tags-highlight
+                        .tags-highlight__item
+                          .a-badge.is-sm.is-primary.is-block
+                            .a-badge__inner
+                              | 注目の記事
                     .thumbnail-card__row
                       - if article.prepared_thumbnail?
                         = image_tag article.prepared_thumbnail_url, class: 'thumbnail-card__image', alt: "ブログ記事「#{article.title}」のアイキャッチ画像"
@@ -60,7 +66,4 @@ hr.a-border-tint
                               = l(article.created_at)
                             - else
                               = l(article.published_at)
-                        .thumbnail-card__meta
-                          - if current_user&.admin_or_mentor_login? && article.tags.pluck(:name).include?('feature')
-                            | feature
         = paginate articles

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -61,7 +61,6 @@ hr.a-border-tint
                             - else
                               = l(article.published_at)
                         .thumbnail-card__meta
-                          - if current_user&.admin_or_mentor_login?
-                            - if article.tags.pluck(:name).include?('feature')
-                              | feature
+                          - if current_user&.admin_or_mentor_login? && article.tags.pluck(:name).include?('feature')
+                            | feature
         = paginate articles

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -61,9 +61,8 @@ hr.a-border-tint
                             - else
                               = l(article.published_at)
                         / クラスは適当なので修正
-                        / N+1を修正
                         .thumbnail-card__meta
                           .thumbnail-card__tag
-                            - if article.tag_list.include?('feature')
+                            - if article.tags.pluck(:name).include?('feature')
                               = 'feature'
         = paginate articles

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -60,10 +60,8 @@ hr.a-border-tint
                               = l(article.created_at)
                             - else
                               = l(article.published_at)
-                        / クラスは適当なので修正
                         .thumbnail-card__meta
-                          .thumbnail-card__tag
-                            - if current_user&.admin_or_mentor_login?
-                              - if article.tags.pluck(:name).include?('feature')
-                                = 'feature'
+                          - if current_user&.admin_or_mentor_login?
+                            - if article.tags.pluck(:name).include?('feature')
+                              | feature
         = paginate articles

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -63,6 +63,7 @@ hr.a-border-tint
                         / クラスは適当なので修正
                         .thumbnail-card__meta
                           .thumbnail-card__tag
-                            - if article.tags.pluck(:name).include?('feature')
-                              = 'feature'
+                            - if current_user&.admin_or_mentor_login?
+                              - if article.tags.pluck(:name).include?('feature')
+                                = 'feature'
         = paginate articles

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -35,7 +35,7 @@ hr.a-border-tint
               .col-lg-4.col-md-6.col-xs-12
                 .thumbnail-card.a-card class=(article.wip? ? ' is-wip' : '')
                   = link_to article, class: 'thumbnail-card__inner' do
-                    - if current_user&.admin_or_mentor_login? && article.tags.pluck(:name).include?('feature')
+                    - if current_user&.admin_or_mentor_login? && feature_tag?(article)
                       .tags-highlight
                         .tags-highlight__item
                           .a-badge.is-sm.is-primary.is-block

--- a/test/helpers/articles_helper_test.rb
+++ b/test/helpers/articles_helper_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ArticlesHelperTest < ActionView::TestCase
+  test '#feature_tag?' do
+    article = articles(:article1).dup
+    assert_not feature_tag?(article)
+    article.tag_list = [:feature]
+    article.save!
+    assert feature_tag?(article)
+  end
+end


### PR DESCRIPTION
## Issue

- #7495 

## 概要
ブログ記事の一覧にて、`feature` タグがついてるブログ記事は、メンター・管理者にのみ目印である`feature`という文言が表示されるように変更しました。

## 変更確認方法

1. `feature/highlight-blogs-with-a-feature-tag`をローカルに取り込む
   1. `git fetch origin pull/8186/head:feature/highlight-blogs-with-a-feature-tag`
    （２度目以降は上記ブランチのローカル変更に気をつけながら`--force`をつけてください）
   2. `git switch feature/highlight-blogs-with-a-feature-tag`
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. メンターまたは管理者（例: user:`komagata`, password: `testtest`）でログインする。
4. [ブログの新規作成ページ](http://localhost:3000/articles/new)にアクセスし、タグ入力欄で`feature`を入力し、エンターを押してタグを登録する。
5. タイトル、本文、サムネイル画像を適当に入力し、`公開する`ボタンをクリックする。
6. [ブログ記事の一覧](http://localhost:3000/articles)にアクセスし、先ほど作成したブログ記事に目印である`注目の記事`の文字が表示されているか確認する。
7. 一旦ログアウトし、[ブログ記事の一覧](http://localhost:3000/articles)に再度アクセス。
8. 先ほど作成したブログ記事に目印である`注目の記事`の文字が**表示されていない**か確認する。
9. メンターまたは管理者以外で再度ログインする（例: user:`kimura`, password: `testtest`）
10. [ブログ記事の一覧](http://localhost:3000/articles)にアクセスし、先ほど作成したブログ記事に目印である`注目の記事`の文字が**表示されていない**か確認する。

## Screenshot

### 変更前
`tag-test`のブログには`feature`タグをつけており、メンターまたは管理者としてログインしているが、目印は表示されない
<img width="1354" alt="スクリーンショット 2024-11-12 12 59 23" src="https://github.com/user-attachments/assets/ef41ed3b-8fd8-400e-a12b-fa4ed8a435c2">

### 変更後
#### メンターまたは管理者としてログイン時
<img width="1404" alt="スクリーンショット 2024-11-19 11 58 36" src="https://github.com/user-attachments/assets/6d70d324-70da-4de8-be5b-22fa6b5cdab6">

#### 非ログイン時
<img width="1410" alt="スクリーンショット 2024-11-19 11 59 35" src="https://github.com/user-attachments/assets/29bb7c2f-1ea4-474f-8149-7eeec5608741">

#### 管理者外でログイン中
<img width="1407" alt="スクリーンショット 2024-11-19 12 09 47" src="https://github.com/user-attachments/assets/42301bcb-398d-4f55-ad0d-871af4faaf75">
