### PR TITLE
企業一覧の各企業に「卒業生」を追加

### DIFF
--- a/app/views/companies/_user_counts.html.slim
+++ b/app/views/companies/_user_counts.html.slim
@@ -27,6 +27,15 @@
               company.users.students_and_trainees.size,
               company_users_path(company, target: 'student_and_trainee'),
               class: 'card-counts__item-value-link'
+    .card-counts__item
+      .card-counts__item-inner
+        dt.card-counts__item-label
+          | 卒業生
+        dd.card-counts__item-value
+          = link_to_if company.users.unretired.graduated.present?,
+              company.users.graduated.size,
+              company_users_path(company, target: 'graduate'),
+              class: 'card-counts__item-value-link'
     - unless company.users.admins.empty?
       .card-counts__item
         .card-counts__item-inner


### PR DESCRIPTION
## Issue

- #7872 

## 概要

企業一覧の各企業の「メンター」「アドバイザー」「現役生」の並びに、「卒業生」も表示するようにしました。

## 変更確認方法

1. `feature/feature/add_graduate_to_each_company_in_the_companies_page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. 任意のアカウントでログイン
4. [企業一覧ページ](http://localhost:3000/companies) を開き、各企業に「卒業生の」


## Screenshot

### 変更前

### 変更後

