### PR TITLE
Flakyなテストを2つ修正した

### DIFF
--- a/test/system/course/practices_test.rb
+++ b/test/system/course/practices_test.rb
@@ -11,6 +11,7 @@ class Course::PracticesTest < ApplicationSystemTestCase
   test 'show/hide the progress of others' do
     visit_with_auth practice_path(practices(:practice1)), 'hatsuno'
     click_button '着手'
+    assert_selector '.js-started.is-active'
     visit course_practices_path(courses(:course1).id)
 
     assert page.find(:css, '#display-progress', visible: false).checked?

--- a/test/system/discord_profiles_test.rb
+++ b/test/system/discord_profiles_test.rb
@@ -27,12 +27,16 @@ class DiscordProfilesTest < ApplicationSystemTestCase
   test 'show times link on user list page' do
     visit_with_auth '/users', 'hatsuno'
     assert_selector '.page-header__title', text: 'ユーザー'
+
+    fill_in 'js-user-search-input', with: 'Kimura Tadasi'
+    find('#js-user-search-input').send_keys :return
+    assert_text 'Kimura Tadasi'
     assert_no_link(href: 'https://discord.com/channels/715806612824260640/123456789000000007')
 
     kimura = users(:kimura)
     kimura.discord_profile.update!(times_url: 'https://discord.com/channels/715806612824260640/123456789000000007')
 
-    visit current_path
+    visit current_url
     assert_link(href: 'https://discord.com/channels/715806612824260640/123456789000000007')
   end
 end


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/7921

## 概要
[CircleCIのFlakyなテスト](https://app.circleci.com/insights/github/fjordllc/bootcamp/workflows/build_and_test/tests?branch=main)から、以下2つについて修正しました
- 1️⃣ [ユーザー一覧画面]
  - ユーザーのdiscord urlを設定した場合、更新がユーザー一覧画面で反映されるか？のテスト
  - `test/system/discord_profiles_test.rb:27`の「`show times link on user list page`」
- 2️⃣ [プラクティス一覧画面・詳細画面]
  - みんなの進捗ON/OFFによってユーザーアイコン表示/非表示が切り替わるか？のテスト
  - `test/system/course/practices_test.rb:11`の`「show/hide the progress of others`」

## 1️⃣ show times link on user list page
### テスト概要
1. 「ユーザー一覧画面において、テスト対象のユーザーにdiscord urlが設定されていないこと」の確認
2. テスト対象ユーザーにdiscord urlを設定し、更新する
3. 「ユーザー一覧画面において、テスト対象ユーザーにdiscord urlが設定されていること」の確認

### テスト詳細
1を確認する記述で、そもそもテスト対象のユーザーが一覧画面に表示されていない(ページネーションの1ページ目には存在しない)ため、「URLが存在しないこと」のチェックを素通りしていた。
また、2によってテスト対象ユーザーがページネーションの1ページ目に移動するので、3がパスしたように見えていた。

### エラーメッセージ
<details>

<summary>CIのログ</summary>


```
expected to find link nil with href "https://discord.com/channels/715806612824260640/123456789000000007" but there were no matches
test/system/discord_profiles_test.rb:36:in `block in <class:DiscordProfilesTest>'
```

</details>

### Flakyである原因

<details>
<summary>初回の仮説(誤り)</summary>

~~3の画面リロード時が完了するのを待たずに、更新前の画面で`assert_link`のテストを先に処理してしまったと考えられる。
`assert_link`は[デフォルトで2秒待機してくれる](https://github.com/teamcapybara/capybara/blob/4895195726a355810b523b3f96b1aae43bcb4c53/README.md#asynchronous-javascript-ajax-and-friends)のだが、ページ描画にそれ以上の時間がかかったと思われる。
ローカル環境でテストコードと同様の操作をしたところ、リロードで画面描画されるまで2秒以上時間がかかっていることを確認した。(n=10)~~
<img width="370" alt="スクリーンショット 2024-11-14 15 34 03" src="https://github.com/user-attachments/assets/8fad489b-b353-4905-ab86-026ecfb8ca01">


~~ローカル環境とCI環境の違いがあるので断定はできないが、可能性は高いと考えている。~~

</details>

本当の原因: [fixtureで、同じ`update_at`を持つユーザーが複数存在したこと ](https://github.com/fjordllc/bootcamp/pull/8196#pullrequestreview-2440360744)


### 本PRでの修正
該当commit: [b6741d4](https://github.com/fjordllc/bootcamp/pull/8196/commits/b6741d46b51fb7152b10d09872697690b48477e6)

そもそもテストしたいことがテストできていない状態だったので、「テスト対象のユーザーが確実にユーザー一覧画面に存在すること」を担保するために、検索でテスト対象ユーザーを絞り込んで表示させるテストコードに変更した。
~~また、リロード後の`assert_link`の待ち時間を倍の4秒で指定した。~~

## 2️⃣ show/hide the progress of others
### テスト概要
1. プラクティス詳細ページでステータスを"着手"にする
2. プラクティス一覧ページで、みんなの進捗トグルスイッチがONかつユーザーアイコンが表示されることを確認する
3. プラクティス一覧ページで、みんなの進捗トグルスイッチをONにし、ユーザーアイコンが表示されないことを確認する

### テスト詳細
ユーザーアイコンの表示/非表示のチェックは、ログインユーザーのアイコンで確認している。

### エラーメッセージ
<details>
<summary>CIのログ</summary>

```
Expected false to be truthy.
```

</details>

### Flakyである原因
サーバーからのレスポンスが届く前に画面遷移したことが原因。
ステータスを"着手"にすると、`api/practices/learning_controller.rb`の`update`メソッドが実行され、ステータスが更新される。
`update`メソッドの始めに`sleep`を記述し、1~2の工程を行うことでFlakyテストが再現できる。

### 本PRでの修正
該当commit: [8fa727a](https://github.com/fjordllc/bootcamp/pull/8196/commits/8fa727a662e611bcd6aecbaa19fd111bb58363b6)

ステータスが確実に"着手"になってから画面遷移させるために、`assert_selector '.js-started.is-active'`を追加した。

## 変更確認方法
1. `このブランチ`をローカルに取り込む
2. ローカル環境で以下を実行し、テストが落ちないことを確認する
```
bin/rails test test/system/discord_profiles_test.rb:27
```
```
bin/rails test test/system/course/practices_test.rb:11
```
3. CIで2のテストが落ちていないことを確認する
