### PR TITLE
提出物の最終コメント経過日数通知を5日後から3日後に変更

### DIFF
--- a/app/controllers/scheduler/daily/notify_product_review_not_completed_controller.rb
+++ b/app/controllers/scheduler/daily/notify_product_review_not_completed_controller.rb
@@ -11,7 +11,7 @@ class Scheduler::Daily::NotifyProductReviewNotCompletedController < SchedulerCon
   def notify_product_review_not_completed
     Comment.where(commentable_type: 'Product').find_each do |product_comment|
       product = product_comment.commentable
-      if product_comment.certain_period_passed_since_the_last_comment_by_submitter?(5.days) && !product.unassigned? && !product.checked?
+      if product_comment.certain_period_passed_since_the_last_comment_by_submitter?(3.days) && !product.unassigned? && !product.checked?
         DiscordNotifier.with(comment: product_comment).product_review_not_completed.notify_now
       end
     end

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -117,7 +117,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     product = comment.commentable
 
     body = <<~TEXT.chomp
-      ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから5日経過しました。
+      ⚠️ #{comment.user.login_name}さんの「#{comment.commentable.practice.title}」の提出物が、最後のコメントから3日経過しました。
       担当：#{product_checker_discord_name}さん
       URL： <#{Rails.application.routes.url_helpers.product_url(product)}>
     TEXT

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -89,16 +89,16 @@ class CommentTest < ActiveSupport::TestCase
       user: users(:komagata),
       commentable: products(:product8),
       description: '提出物への最初のコメント',
-      created_at: Time.current.ago(6.days)
+      created_at: Time.current.ago(4.days)
     )
 
     last_comment = Comment.create!(
       user: users(:kimura),
       commentable: products(:product8),
-      description: '提出物への提出者による最後のコメントかつ、投稿から5日経過',
-      created_at: Time.current.ago(5.days)
+      description: '提出物への提出者による最後のコメントかつ、投稿から3日経過',
+      created_at: Time.current.ago(3.days)
     )
 
-    assert last_comment.certain_period_passed_since_the_last_comment_by_submitter?(5.days)
+    assert last_comment.certain_period_passed_since_the_last_comment_by_submitter?(3.days)
   end
 end

--- a/test/notifiers/discord_notifier_test.rb
+++ b/test/notifiers/discord_notifier_test.rb
@@ -162,7 +162,7 @@ class DiscordNotifierTest < ActiveSupport::TestCase
     products(:product8).update!(checker_id: users(:komagata).id)
     comment = Comment.create!(user: users(:kimura), commentable: products(:product8), description: '提出者による返信')
     body = <<~TEXT.chomp
-      ⚠️ kimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから5日経過しました。
+      ⚠️ kimuraさんの「PC性能の見方を知る」の提出物が、最後のコメントから3日経過しました。
       担当：<@12345>さん
       URL： <http://localhost:3000/products/313836099>
     TEXT


### PR DESCRIPTION
## Issue
- [【メンター向け】最後のコメントから5日経過したら通知を「3日経過したら」に変更したい #8173](https://github.com/fjordllc/bootcamp/issues/8173)

## 概要
提出物の

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

