### PR TITLE
提出物の最終コメントが5日経過したことを知らせる通知のメンション部分が空になってしまうバグを修正

### DIFF
--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -111,7 +111,7 @@ class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLengt
     webhook_url = params[:webhook_url] || Rails.application.secrets[:webhook][:mentor]
 
     comment = params[:comment]
-    product_checker_name = User.find_by(id: comment.commentable.checker_id).login_name
+    product_checker_name = comment.commentable.checker.discord_profile&.account_name
     product_checker_discord_id = Discord::Server.find_member_id(member_name: product_checker_name)
     product_checker_discord_name = "<@#{product_checker_discord_id}>"
     product = comment.commentable


### PR DESCRIPTION
## Issue
- [最終コメントから3日経過したら送るDiscordメッセージの問題 #8201](https://github.com/fjordllc/bootcamp/issues/8201)

## 概要
提出物の担当をしてるメンターに送られる、提出物の最終コメントが5日経過したことを知らせる通知があります。
通知のメンション部分には担当しているメンターの名前が入るはずですが、それが空になってしまうバグを修正しました。
※issueだと3日経過なのですが、その変更のPRはまだマージされてないです。

#### 原因
Discord上でメンションをするためにDiscordユーザーIDが必要なのですが、Usersテーブルのlogin_nameとDiscordのユーザー名が一致しない場合にDiscordのユーザーIDを取得できず、メンションが空になっていました。

#### 対処
login_nameだとDiscord上の名前と必ずしも一致しないので使うのをやめてDiscordProfilsテーブルにあるaccount_nameを使うことにしました。


## 変更確認方法
#### 事前準備
環境変数としてDiscordの`サーバーID`、`ウェブフックURL`、`Discord Botトークン`が必要です。

1. 自分のDiscordサーバーを準備
    * [サーバーの作成方法](https://support.discord.com/hc/ja/articles/204849977-%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%81%AE%E4%BD%9C%E6%88%90%E6%96%B9%E6%B3%95)
3. 作ったサーバーのIDを取得
    * [ユーザー/サーバー/メッセージIDはどこで見つけられる？](https://support.discord.com/hc/ja/articles/206346498-%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC-%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC-%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8ID%E3%81%AF%E3%81%A9%E3%81%93%E3%81%A7%E8%A6%8B%E3%81%A4%E3%81%91%E3%82%89%E3%82%8C%E3%82%8B)
4. Discordと連携するために`ウェブフックURL`を用意します
    * [外部サービスからDiscordにメッセージを送る Webhook](https://zenn.dev/lambta/articles/5edbda4ccb1ec6)
    * [Discord通知](https://github.com/fjordllc/bootcamp/wiki/Discord%E9%80%9A%E7%9F%A5)
5. Discord Botの作成とトークンの取得
     * [Discordボットアプリケーションのトークンを取得する方法](https://www.nocodeai.jp/ja/post/discord%E3%83%9C%E3%83%83%E3%83%88%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%82%92%E5%8F%96%E5%BE%97%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
     * 参考サイトには書いてないのですが、Botを作成した後にBotの**Server Members Intent**という項目をONにしてください。これをしないと`Discordrb::Errors::NoPermission in Scheduler::Daily::NotifyProductReviewNotCompletedController#show`というエラーが出てしまいます。

![717196dc603f82dbb3e934a5657595d29940779ec26806928d36acd28b380671](https://github.com/user-attachments/assets/5dd96076-6d8c-446b-bd47-669d3b33b7ca)
 

#### 動作確認
1. `bug/discord-notification-empty-mention`をローカルに取り込む
    1. `git fetch origin pull/8218/head:bug/discord-notification-empty-mention`
    2. `git checkout bug/discord-notification-empty-mention`
2. 環境変数を含めてローカルサーバーを立ち上げる
`DISCORD_GUILD_ID=<サーバーID> DISCORD_MENTOR_WEBHOOK_URL=<ウェブフックURL> DISCORD_BOT_TOKEN=<Discord Botトークン> TOKEN=token foreman start -f Procfile.dev `
3. `komagata`(メンター)でログイン
4. [提出物のページ](http://localhost:3000/products/613458348)にアクセスして`担当する`を押す
5. `kensyu`(提出した人)でログイン
6. [提出物のページ](http://localhost:3000/products/613458348)にアクセスしてコメントする
7. Discord 通知イベントを発生させるために下記を実行して DB を更新する

    1. `rails c` を実行
    2. 下記を実行する

      ```ruby
      Comment.where(commentable_type: 'Product').find_each do |product_comment|
        product_comment.created_at = Time.now - 5.days
        product_comment.save
      end
      ```
8. 自分のDiscordユーザー名を登録する
    1. `rails c` を実行
    2. 下記を実行する

    ```ruby
    user = User.find_by(name: 'Komagata Masaki')
    user.discord_profile.account_name = '<自分のDiscordユーザー名>'
    user.save
    ```
9. `http://localhost:3000/scheduler/daily/notify_product_review_not_completed?token=token&webhook_url=<ウェブフックURL>`にアクセスしてDiscordに自分がメンションされた通知が送られることを確認

## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/c00d2921-26d0-4903-84c3-17b490d542a6)


### 変更後
![image](https://github.com/user-attachments/assets/fe327378-1c6b-43be-8ed6-8f7a87940d13)

