### PR TITLE
定期イベント更新時の通知を、イベント作成者ではなく更新者から通知が送られるように変更

### DIFF
--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -42,7 +42,7 @@ class RegularEventsController < ApplicationController
     set_wip
     if @regular_event.update(regular_event_params)
       update_publised_at
-      Newspaper.publish(:regular_event_update, { regular_event: @regular_event })
+      Newspaper.publish(:regular_event_update, { regular_event: @regular_event, sender: current_user })
       set_all_user_participants_and_watchers
       path = publish_with_announcement? ? new_announcement_path(regular_event_id: @regular_event.id) : Redirection.determin_url(self, @regular_event)
       redirect_to path, notice: notice_message(@regular_event)

--- a/app/models/regular_event_update_notifier.rb
+++ b/app/models/regular_event_update_notifier.rb
@@ -3,10 +3,11 @@
 class RegularEventUpdateNotifier
   def call(payload)
     regular_event = payload[:regular_event]
+    sender = payload[:sender]
     participants = regular_event.participants
 
     participants.each do |participant|
-      ActivityDelivery.with(regular_event:, receiver: participant).notify(:update_regular_event) if regular_event.user != participant
+      ActivityDelivery.with(regular_event:, sender:, receiver: participant).notify(:update_regular_event) if regular_event.user != participant
     end
   end
 end

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -297,12 +297,13 @@ class ActivityNotifier < ApplicationNotifier
     params.merge!(@params)
     regular_event = params[:regular_event]
     receiver = params[:receiver]
+    sender = params[:sender]
 
     notification(
       body: "定期イベント【#{regular_event.title}】が更新されました。",
       kind: :regular_event_updated,
       receiver:,
-      sender: regular_event.user,
+      sender:,
       link: Rails.application.routes.url_helpers.polymorphic_path(regular_event),
       read: false
     )


### PR DESCRIPTION
## Issue
- [定期イベントのページ更新時は、イベントの作成者ではなく、更新者のアイコンでサイト内通知してほしい。 #8193](https://github.com/fjordllc/bootcamp/issues/8193)

## 概要
これまで定期イベントを更新した際、通知の送信者は常に「イベントの作成者」になっていました。この仕様を変更し、「実際にイベントを更新した人」が通知の送信者となるようにしました。

## 変更確認方法
1. `feature/update-notification-with-updater-icon`をローカルに取り込む
    1. `git fetch origin pull/8226/head:feature/update-notification-with-updater-icon`
    2. `git checkout feature/update-notification-with-updater-icon`
2. `foreman start -f Procfile.dev `でローカルサーバーを立ち上げ
3. `komagata`(イベント主催者)でログイン
4. [定期イベント編集ページ](http://localhost:3000/regular_events/459650222/edit)にアクセスして更新する
5. `hatsuno`(イベント参加者)でログイン
6. [通知一覧](http://localhost:3000/notifications)にアクセスして`komagata`から通知が来ていることを確認
7. `machida`(イベント主催者)でログイン
8. [定期イベント編集ページ](http://localhost:3000/regular_events/459650222/edit)にアクセスして更新する
9. `hatsuno`(イベント参加者)でログイン
10. [通知一覧](http://localhost:3000/notifications)にアクセスして`machida`から通知が来ていることを確認

## Screenshot
### `komagata`でログインして定期イベントを更新した場合の通知
![image](https://github.com/user-attachments/assets/29a9fce2-ebbe-4cde-92c8-4311c1216006)
---
### `machida`でログインして定期イベントを更新した場合の通知
![image](https://github.com/user-attachments/assets/e4c936ac-8758-4b41-85ce-cda4eb5762fc)

