### PR TITLE
卒業生の声ページのheadタグを正しいものに修正した

### DIFF
--- a/app/views/welcome/alumni_voices.html.slim
+++ b/app/views/welcome/alumni_voices.html.slim
@@ -1,7 +1,7 @@
 - content_for :extra_body_classes, 'welcome'
-- title 'FAQ'
+- title '卒業生の声'
 - set_meta_tags(site: 'FJORD BOOT CAMP（フィヨルドブートキャンプ）',
-  description: 'フィヨルドブートキャンプに寄せられたよくあるお問い合わせとその回答の一覧です。')
+  description: 'フィヨルドブートキャンプ卒業生のインタビューやプレゼンテーションの記事を紹介しています。')
 
 article.lp
   header.lp-content.is-lp-bg-main.is-hero

--- a/test/system/welcome_test.rb
+++ b/test/system/welcome_test.rb
@@ -80,6 +80,13 @@ class WelcomeTest < ApplicationSystemTestCase
     assert_selector "meta[name='twitter:title'][content='アンチハラスメントポリシー']", visible: false
   end
 
+  test 'GET /alumni_voices' do
+    visit '/alumni_voices'
+    assert_equal '卒業生の声 | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+    assert_selector "meta[property='og:title'][content='卒業生の声']", visible: false
+    assert_selector "meta[name='twitter:title'][content='卒業生の声']", visible: false
+  end
+
   test 'mentors can update their profiles' do
     visit_with_auth '/current_user/edit', 'komagata'
     attach_file 'user[profile_image]', Rails.root.join('test/fixtures/files/users/avatars/komagata.jpg'), make_visible: true


### PR DESCRIPTION
ブランチ名を間違えて作成してしまったのでPRを作り直しました🙇‍♂️
> [closeしたプルリク](https://github.com/fjordllc/bootcamp/pull/8228)

## Issue

- #8216

## 概要
[/alumni_voices](http://localhost:3000/alumni_voices)のtitle, og:title, twitter:title, description, og:description, twitter:description を正しいものに修正しました。
## 変更確認方法

1. `bug/fix-alumni-voices-head-tag`をローカルに取り込む
    1. git fetch origin bug/fix-alumni-voices-head-tag
    2. git checkout bug/fix-alumni-voices-head-tag
2. `foreman start -f Procfile.dev` でローカルサーバーを立ち上げる 
3.  [卒業生の声ページ](http://localhost:3000/alumni_voices)に飛ぶ
4. 開発者ツールでtitle, og:title, twitter:title, description, og:description, twitter:descriptionが卒業生の声のページのものになっていることを確認 (`title` `description`でそれぞれ検索すると簡単です)

## Screenshot

### 変更前
FAQのものになってしまっている
![image](https://github.com/user-attachments/assets/948ce765-b26e-47d7-b30c-769dfadf5bfb)


### 変更後
卒業生の声のページに相応しいものになっている
<img width="1486" alt="貼り付けた画像_2024_11_28_22_25" src="https://github.com/user-attachments/assets/0447109f-d8cf-4a8b-9bd5-4a8f98f0fb0d">
