### PR TITLE
研修が終了(退会)したユーザーを取得しないようにする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -380,7 +380,12 @@ class User < ApplicationRecord
   }
   scope :admins, -> { where(admin: true) }
   scope :admins_and_mentors, -> { admins.or(mentor) }
-  scope :trainees, -> { where(trainee: true) }
+  scope :trainees, lambda {
+    where(
+      trainee: true,
+      retired_on: nil
+    )
+  }
   scope :job_seeking, -> { where(job_seeking: true) }
   scope :job_seekers, lambda {
     where(

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -32,7 +32,7 @@ class GenerationTest < ActiveSupport::TestCase
 
   test '#count_classmates_by_target' do
     assert_equal 18, Generation.new(5).count_classmates_by_target(:students)
-    assert_equal 3, Generation.new(5).count_classmates_by_target(:trainees)
+    assert_equal 2, Generation.new(5).count_classmates_by_target(:trainees)
     assert_equal 1, Generation.new(5).count_classmates_by_target(:hibernated)
     assert_equal 2, Generation.new(5).count_classmates_by_target(:graduated)
     assert_equal 3, Generation.new(5).count_classmates_by_target(:advisers)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -464,6 +464,13 @@ class UserTest < ActiveSupport::TestCase
     assert user.invalid?
   end
 
+  test 'trainees_method_does_not_include_retired_trainee' do
+    target = User.trainees
+    assert_includes(target, users(:kensyu))
+    users(:kensyu).update!(retired_on: '2022-07-01')
+    assert_not_includes(target, users(:kensyu))
+  end
+
   test '.depressed_reports' do
     assert_equal 1, User.depressed_reports.size
   end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -506,7 +506,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'search only trainee when target is trainee' do
     visit_with_auth '/users?target=trainee', 'komagata'
-    assert_selector '.users-item', count: 3 # 元々2だったが、退会ユーザーがカウントされるようになった影響で+1増えた
+    assert_selector '.users-item', count: 2
     fill_in 'js-user-search-input', with: 'Kensyu Seiko'
     find('#js-user-search-input').send_keys :return
     assert_text 'Kensyu Seiko', count: 1


### PR DESCRIPTION
## Issue

- #8138 

## 概要

現在、[研修生一覧](https://bootcamp.fjord.jp/users?target=trainee)のページを表示すると、研修が終了(退会)した研修生も表示される。
今回の変更で、研修が終了した研修生については一覧のページに表示されないようにする。

## 変更確認方法

1. feature/trainees-completed-training-not-displayed をローカルに取り込む
2. foreman start -f Procfile.dev でローカルサーバーを立ち上げる
3. **管理者**でログインし、ユーザー→研修生を表示する
4. それぞれのユーザーについて、上部に「退会しました」という表示がないことを確認する

## Screenshot

### 変更前
<img width="1043" alt="スクリーンショット 2024-12-15 0 55 43" src="https://github.com/user-attachments/assets/b103533a-684a-4b3c-9a53-040d96eccd86" />

<img width="1080" alt="スクリーンショット 2024-12-15 0 55 23" src="https://github.com/user-attachments/assets/a52738ac-2b24-4a6b-87a5-135d7819c858" />

### 変更後
<img width="1066" alt="スクリーンショット 2024-12-15 0 57 44" src="https://github.com/user-attachments/assets/bc198d91-abe7-42ee-b958-cbf8c48c3d56" />



