### PR TITLE
Regular Event のテストが失敗していたバグを修正

### DIFF
--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -109,8 +109,8 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def all_scheduled_dates(
-    from: Date.new(Time.current.year, 1, 1),
-    to: Date.new(Time.current.year, 12, 31)
+    from: Time.current.to_date,
+    to: Time.current.to_date.next_year
   )
     (from..to).filter { |d| date_match_the_rules?(d, regular_event_repeat_rules) }
   end
@@ -129,10 +129,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def self.fetch_participated_regular_events(user)
     participated_regular_events = []
     user.participated_regular_event_ids.find_each do |regular_event|
-      regular_event.all_scheduled_dates(
-        from: Time.current.to_date,
-        to: Time.current.to_date.next_year
-      ).each do |event_date|
+      regular_event.all_scheduled_dates.each do |event_date|
         participated_regular_events << regular_event.transform_for_subscription(event_date)
       end
     end

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -109,8 +109,8 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def all_scheduled_dates(
-    from: Time.current.to_date,
-    to: Time.current.to_date.next_year
+    from: Date.current,
+    to: Date.current.next_year
   )
     (from..to).filter { |d| date_match_the_rules?(d, regular_event_repeat_rules) }
   end

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -79,7 +79,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def next_event_date
     event_dates =
-      hold_national_holiday ? feature_scheduled_dates : feature_scheduled_dates.reject { |d| HolidayJp.holiday?(d) }
+      hold_national_holiday ? upcoming_scheduled_dates : upcoming_scheduled_dates.reject { |d| HolidayJp.holiday?(d) }
 
     event_dates.min
   end
@@ -145,7 +145,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     errors.add(:end_at, ': イベント終了時刻はイベント開始時刻よりも後の時刻にしてください。')
   end
 
-  def feature_scheduled_dates
+  def upcoming_scheduled_dates
     # 時刻が過ぎたイベントを排除するためだけに、一時的にstart_timeを与える。後でDate型に戻す。
     event_dates_with_start_time = all_scheduled_dates.map { |d| d.in_time_zone.change(hour: start_at.hour, min: start_at.min) }
 

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -126,8 +126,8 @@ class RegularEventTest < ActiveSupport::TestCase
   end
 
   test '#all_scheduled_dates' do
-    start_date = Time.current.to_date
-    end_date = Time.current.to_date.next_year
+    start_date = Date.current
+    end_date = Date.current.next_year
     wednesday_for_year = (start_date..end_date).select(&:wednesday?)
 
     regular_event = regular_events(:regular_event34)

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -126,8 +126,8 @@ class RegularEventTest < ActiveSupport::TestCase
   end
 
   test '#all_scheduled_dates' do
-    start_date = Date.new(Time.current.year, 1, 1)
-    end_date = Date.new(Time.current.year, 12, 31)
+    start_date = Time.current.to_date
+    end_date = Time.current.to_date.next_year
     wednesday_for_year = (start_date..end_date).select(&:wednesday?)
 
     regular_event = regular_events(:regular_event34)


### PR DESCRIPTION
## Issue

- #8246

## 概要
Regular Event の一部テストケースで、イベント開催日時を「第二水曜日」としており、年内にこれ以降第二水曜日が存在しない状況の時に、次回の開催日を参照する変数の中身がnilとなってしまいテストが落ちてしまっていたバグを修正しました。
## 変更確認方法

1. `bug/regular-event-test-fails`をローカルに取り込む
    1. `git fetch origin bug/regular-event-test-fails`
    2. `git checkout bug/regular-event-test-fails`
2. テストが通ることを確認する
    1. `rails test test/system/regular_events_test.rb`
    2. `rails test test/models/regular_event_test.rb`


## Screenshot
テストが落ちるバグ対応のため、画面の変更はありません！