### PR TITLE
フッターメニューにRouletteTalkを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -59,6 +59,9 @@ footer.footer
             = link_to 'https://circlecast.net/channels/9', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | フィヨルドブートキャスト
           li.footer-nav__item
+            = link_to 'https://roulette-talk.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | RouletteTalk
+          li.footer-nav__item
             = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
               i.fa-solid.fa-rss
       small.footer__copyright


### PR DESCRIPTION
## Issue

- #8236 

## 概要
ログイン画面のフッターメニューに「RouletteTalk」を追加しました。

## 変更確認方法

1. ブランチ`chore/add-roulette-talk-link-to-footer`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. ユーザー名komagata、パスワードtesttestでログインする。（誰でもいいです）
4. [トップページ](http://localhost:3000/)にアクセスする。
5. フッターメニューの「フィヨルドブートキャスト」の右に「RouletteTalk」が追加されていることを確認する

## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/36e698a3-cf8f-481f-82b7-f935c803792d)


### 変更後
![image](https://github.com/user-attachments/assets/a6315184-ad16-4141-bb5c-839a7baf81b0)

