### PR TITLE
Q&A Answer部分の非Vue化の不具合修正

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -33,6 +33,7 @@ class QuestionsController < ApplicationController
                           .includes(:correct_answer)
                           .latest_update_order
                           .limit(MAX_PRACTICE_QUESTIONS_DISPLAYED)
+    @answers = @question.answers.order(created_at: :asc)
     respond_to do |format|
       format.html
       format.md

--- a/app/javascript/initializeAnswer.js
+++ b/app/javascript/initializeAnswer.js
@@ -14,8 +14,18 @@ export default function initializeAnswer(answer) {
   const answerEditor = answer.querySelector('.answer-editor')
   const answerDisplayContent = answerDisplay.querySelector('.a-long-text')
   const answerDescription = answerDisplayContent.innerHTML
+
+  const answerEditorPreview = answerEditor.querySelector(
+    '.a-markdown-input__preview'
+  )
+  const editorTextarea = answerEditor.querySelector(
+    '.a-markdown-input__textarea'
+  )
+
   if (answerDescription) {
     answerDisplayContent.innerHTML =
+      markdownInitializer.render(answerDescription)
+    answerEditorPreview.innerHTML =
       markdownInitializer.render(answerDescription)
   }
 
@@ -39,13 +49,6 @@ export default function initializeAnswer(answer) {
       answerDisplayContent.innerHTML = markdownInitializer.render(savedAnswer)
     })
   }
-
-  const answerEditorPreview = answerEditor.querySelector(
-    '.a-markdown-input__preview'
-  )
-  const editorTextarea = answerEditor.querySelector(
-    '.a-markdown-input__textarea'
-  )
 
   const cancelButton = answerEditor.querySelector('.is-secondary')
   cancelButton.addEventListener('click', () => {

--- a/app/javascript/initializeAnswer.js
+++ b/app/javascript/initializeAnswer.js
@@ -6,6 +6,7 @@ import MarkdownInitializer from 'markdown-initializer'
 export default function initializeAnswer(answer) {
   const questionId = answer.dataset.question_id
   const answerId = answer.dataset.answer_id
+  const answerDescription = answer.dataset.answer_description
   let savedAnswer = ''
   TextareaInitializer.initialize(`#js-comment-${answerId}`)
   const markdownInitializer = new MarkdownInitializer()
@@ -13,7 +14,6 @@ export default function initializeAnswer(answer) {
   const answerDisplay = answer.querySelector('.answer-display')
   const answerEditor = answer.querySelector('.answer-editor')
   const answerDisplayContent = answerDisplay.querySelector('.a-long-text')
-  const answerDescription = answerDisplayContent.innerHTML
 
   const answerEditorPreview = answerEditor.querySelector(
     '.a-markdown-input__preview'

--- a/app/javascript/new-answer.js
+++ b/app/javascript/new-answer.js
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     saveButton.addEventListener('click', () => {
       savedAnswer = editorTextarea.value
-      createAnswer(savedAnswer, questionId)
+      createAnswer(savedAnswer, questionId, tabElements)
       editorTextarea.value = ''
       answerEditorPreview.innerHTML = markdownInitializer.render(
         editorTextarea.value
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 })
 
-function createAnswer(description, questionId) {
+function createAnswer(description, questionId, tabElements) {
   if (description.length < 1) {
     return null
   }
@@ -103,6 +103,11 @@ function createAnswer(description, questionId) {
       initializeReaction(reactionElement)
       updateAnswerCount(true)
       updateWatchable(questionId)
+      const [, , previewTab] = tabElements
+      if (previewTab.classList.contains('is-active')) {
+        toggleVisibility(tabElements, 'is-active')
+      }
+
       toast('回答を投稿しました！')
     })
     .catch((error) => {

--- a/app/javascript/new-answer.js
+++ b/app/javascript/new-answer.js
@@ -11,6 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const newAnswer = document.querySelector('.new-answer')
   if (newAnswer) {
     TextareaInitializer.initialize('#js-new-comment')
+    const defaultTextareaSize =
+      document.getElementById('js-new-comment').scrollHeight
     const markdownInitializer = new MarkdownInitializer()
     const questionId = newAnswer.dataset.question_id
     let savedAnswer = ''
@@ -39,6 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
         editorTextarea.value
       )
       saveButton.disabled = true
+      resizeTextarea(editorTextarea, defaultTextareaSize)
     })
 
     const editTab = answerEditor.querySelector('.edit-answer-tab')
@@ -126,4 +129,8 @@ function updateWatchable(questionId) {
     watchableId: questionId,
     watchableType: 'Question'
   })
+}
+
+function resizeTextarea(textarea, defaultTextareaSize) {
+  textarea.style.height = `${defaultTextareaSize}px`
 }

--- a/app/javascript/new-answer.js
+++ b/app/javascript/new-answer.js
@@ -10,7 +10,7 @@ import store from './check-store.js'
 document.addEventListener('DOMContentLoaded', () => {
   const newAnswer = document.querySelector('.new-answer')
   if (newAnswer) {
-    TextareaInitializer.initialize('#new-comment')
+    TextareaInitializer.initialize('#js-new-comment')
     const markdownInitializer = new MarkdownInitializer()
     const questionId = newAnswer.dataset.question_id
     let savedAnswer = ''

--- a/app/javascript/new-answer.js
+++ b/app/javascript/new-answer.js
@@ -35,12 +35,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     saveButton.addEventListener('click', () => {
       savedAnswer = editorTextarea.value
-      createAnswer(savedAnswer, questionId, tabElements)
+      createAnswer(savedAnswer, questionId)
       editorTextarea.value = ''
       answerEditorPreview.innerHTML = markdownInitializer.render(
         editorTextarea.value
       )
       saveButton.disabled = true
+      updateAnswerCount(true)
+      updateWatchable(questionId)
+      if (previewTab.classList.contains('is-active')) {
+        toggleVisibility(tabElements, 'is-active')
+      }
       resizeTextarea(editorTextarea, defaultTextareaSize)
     })
 
@@ -65,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 })
 
-function createAnswer(description, questionId, tabElements) {
+function createAnswer(description, questionId) {
   if (description.length < 1) {
     return null
   }
@@ -96,21 +101,7 @@ function createAnswer(description, questionId, tabElements) {
       }
     })
     .then((html) => {
-      const answersList = document.querySelector('.answers-list')
-      const answerDiv = document.createElement('div')
-      answerDiv.innerHTML = html
-      const newAnswerElement = answerDiv.firstElementChild
-      answersList.appendChild(newAnswerElement)
-      initializeAnswer(newAnswerElement)
-      const reactionElement = newAnswerElement.querySelector('.js-reactions')
-      initializeReaction(reactionElement)
-      updateAnswerCount(true)
-      updateWatchable(questionId)
-      const [, , previewTab] = tabElements
-      if (previewTab.classList.contains('is-active')) {
-        toggleVisibility(tabElements, 'is-active')
-      }
-
+      initializeNewAnswer(html)
       toast('回答を投稿しました！')
     })
     .catch((error) => {
@@ -133,4 +124,15 @@ function updateWatchable(questionId) {
 
 function resizeTextarea(textarea, defaultTextareaSize) {
   textarea.style.height = `${defaultTextareaSize}px`
+}
+
+function initializeNewAnswer(html) {
+  const answersList = document.querySelector('.answers-list')
+  const answerDiv = document.createElement('div')
+  answerDiv.innerHTML = html
+  const newAnswerElement = answerDiv.firstElementChild
+  answersList.appendChild(newAnswerElement)
+  initializeAnswer(newAnswerElement)
+  const reactionElement = newAnswerElement.querySelector('.js-reactions')
+  initializeReaction(reactionElement)
 }

--- a/app/views/questions/_answer.html.slim
+++ b/app/views/questions/_answer.html.slim
@@ -1,4 +1,4 @@
-.thread-comment.answer id="answer_#{answer.id}" data-question_id="#{question.id}" data-answer_id="#{answer.id}"
+.thread-comment.answer id="answer_#{answer.id}" data-question_id="#{question.id}" data-answer_id="#{answer.id}" data-answer_description="#{answer.description}"
   .thread-comment__start
     a.thread-comment__user-link href="#{answer.user.url}"
       span class="a-user-role is-#{answer.user.primary_role}"
@@ -64,7 +64,7 @@
           .a-markdown-input__inner.is-editor.js-tabs__content.is-active
             .form-textarea
               .form-textarea__body
-                textarea.a-text-input.a-markdown-input__textarea data-id="#js-comment-#{answer.id}" data-preview="#js-comment-preview-#{answer.id}" data-input=".js-comment-file-input-#{answer.id}" name='answer[description]'
+                textarea.a-text-input.a-markdown-input__textarea id="js-comment-#{answer.id}" data-preview="#js-comment-preview-#{answer.id}" data-input=".js-comment-file-input-#{answer.id}" name='answer[description]'
                   = answer.description
               .form-textarea__footer
                 .form-textarea__insert

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -39,7 +39,7 @@ hr.a-border
           h2.thread-comments__title
             | 回答・コメント
         .answers-list
-          - @question.answers.each do |answer|
+          - @answers.each do |answer|
             = render 'answer', question: @question, user: current_user, answer: answer
         = render 'new_answer', question: @question, user: current_user
     nav.a-side-nav


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5116

## 概要

下記PRの動作確認をステージング環境で行っていたところ、以下の不具合を発見したため修正。

- https://github.com/fjordllc/bootcamp/pull/8033

### 不具合
- 回答のプレビューが、初回のページ読み込み時（およびリロード時）には反映されていない
- 回答に画像の添付ができない
- 回答が投稿順になっていない（不規則）
- 回答を投稿した後、回答フォームのtextareaのサイズがそのまま（10行の回答を投稿したら、回答フォームの行数が10行のまま）& 改行しても高さが広がらない

また、 @ayu-0505 さんから`test/system/comments_test.rbの193行目`に引っかかるとお知らせいただいたので併せて修正。
（コメントを入力後プレビューに変更してからコメントを投稿した際、新規投稿フォームにてプレビューからコメントフォームにアクティブが戻っているか、というテスト内容）

## 変更確認方法

1. `bugfix/answer-preview-and-insert-button`をローカルに取り込む
2. `foreman start -f Procfile.dev`
3. 適当な質問のページにアクセス。
4. 上記事象が起こらないことを順番に確認。

## Screenshot
動画、画像共に、**変更前**、**変更後**の順番です。

- 回答のプレビューが、初回のページ読み込み時（およびリロード時）には反映されていない

https://github.com/user-attachments/assets/dfd955ce-5b41-47c8-b8e6-b613842dd21d

https://github.com/user-attachments/assets/254e59c5-a505-4624-993f-021c23a0baf8

- 回答に画像の添付ができない

https://github.com/user-attachments/assets/2bd121ee-b51f-48ff-814d-6686ca08975d


https://github.com/user-attachments/assets/3184329e-f19c-46a8-b713-1ece9d99c642

- 回答が投稿順になっていない（不規則）

<img width="500" alt="スクリーンショット 2025-01-17 23 33 28" src="https://github.com/user-attachments/assets/2fb1ae78-66e8-462c-a43a-5303572e1c87" />

<img width="500" alt="スクリーンショット 2025-01-17 23 31 14" src="https://github.com/user-attachments/assets/6d6d9f75-ed34-4209-97b9-950e51d35c7c" />


- 回答を投稿した後、回答フォームのtextareaのサイズがそのまま & 改行しても高さが広がらない

この項目だけ、以下の順番です。
1つ目 : 回答を投稿した後、回答フォームのtextareaのサイズがそのまま
2つ目 : 改行しても高さが広がらない
3つ目 : 変更後（同時に上記2つの不具合を解消しています。）

https://github.com/user-attachments/assets/31481e51-524d-4beb-bf9c-8ff2f09fca5a


https://github.com/user-attachments/assets/f87814ad-a7ca-4d12-9c99-92a167addfe6


https://github.com/user-attachments/assets/6c2b5374-d798-48cd-acee-628a80880053


- コメントを入力後プレビューに変更してからコメントを投稿した際、新規投稿フォームにてプレビューからコメントフォームにアクティブが戻っているか

https://github.com/user-attachments/assets/714cf3d8-1adf-4a70-9ddf-78518d21e82f

https://github.com/user-attachments/assets/fbfcc4bd-a543-44cd-b389-a20478df7291
