### PR TITLE
「近日開催のイベント」で、当日の開催時間を過ぎたイベントは非表示にする

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -44,6 +44,8 @@ class Event < ApplicationRecord
   scope :wip, -> { where(wip: true) }
   scope :related_to, ->(user) { user.job_seeker ? all : where.not(job_hunting: true) }
   scope :scheduled_on, ->(date) { where(start_at: date.midnight...(date + 1.day).midnight) }
+  scope :not_ended, -> { where('end_at > ?', Time.current) }
+  scope :scheduled_on_without_ended, ->(date) { scheduled_on(date).not_ended }
 
   def opening?
     Time.current.between?(open_start_at, open_end_at)

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -58,6 +58,8 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :participated_by, ->(user) { where(id: all.filter { |e| e.participated_by?(user) }.map(&:id)) }
   scope :organizer_event, ->(user) { where(id: user.organizers.map(&:regular_event_id)) }
   scope :scheduled_on, ->(date) { holding.filter { |event| event.scheduled_on?(date) } }
+  scope :not_ended, -> { where('end_at > ?', Time.current) }
+  scope :scheduled_on_without_ended, ->(date) { holding.not_ended.filter { |event| event.scheduled_on?(date) } }
 
   belongs_to :user
   has_many :organizers, dependent: :destroy

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -58,8 +58,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :participated_by, ->(user) { where(id: all.filter { |e| e.participated_by?(user) }.map(&:id)) }
   scope :organizer_event, ->(user) { where(id: user.organizers.map(&:regular_event_id)) }
   scope :scheduled_on, ->(date) { holding.filter { |event| event.scheduled_on?(date) } }
-  scope :not_ended, -> { where('end_at > ?', Time.current) }
-  scope :scheduled_on_without_ended, ->(date) { holding.not_ended.filter { |event| event.scheduled_on?(date) } }
+  scope :scheduled_on_without_ended, ->(date) { holding.filter { |event| event.scheduled_on?(date) && event.not_ended? } }
 
   belongs_to :user
   has_many :organizers, dependent: :destroy
@@ -77,6 +76,10 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def scheduled_on?(date)
     all_scheduled_dates.include?(date)
+  end
+
+  def not_ended?
+    Time.current.strftime('%H:%M') < end_at.strftime('%H:%M')
   end
 
   def next_event_date

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -58,7 +58,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :participated_by, ->(user) { where(id: all.filter { |e| e.participated_by?(user) }.map(&:id)) }
   scope :organizer_event, ->(user) { where(id: user.organizers.map(&:regular_event_id)) }
   scope :scheduled_on, ->(date) { holding.filter { |event| event.scheduled_on?(date) } }
-  scope :scheduled_on_without_ended, ->(date) { holding.filter { |event| event.scheduled_on?(date) && event.not_ended? } }
+  scope :scheduled_on_without_ended, ->(date) { holding.filter { |event| event.scheduled_on?(date) && !event.ended? } }
 
   belongs_to :user
   has_many :organizers, dependent: :destroy
@@ -78,8 +78,9 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     all_scheduled_dates.include?(date)
   end
 
-  def not_ended?
-    Time.current.strftime('%H:%M') < end_at.strftime('%H:%M')
+  def ended?
+    end_time_of_today_event = Time.current.change(hour: end_at.hour, min: end_at.min)
+    Time.current >= end_time_of_today_event
   end
 
   def next_event_date

--- a/app/models/upcoming_event.rb
+++ b/app/models/upcoming_event.rb
@@ -86,7 +86,7 @@ class UpcomingEvent
 
     def original_events_scheduled_on(date)
       [Event, RegularEvent].map do |model|
-        model.public_send(:scheduled_on, date)
+        model.public_send(:scheduled_on_without_ended, date)
       end.flatten
     end
   end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -191,3 +191,25 @@ event34:
   open_start_at: 2024-02-26 10:00
   open_end_at: 2024-03-26 09:00
   user: kimura
+
+event35:
+  title: "2024/12/1(日)9:00〜12:00開催の特別イベント"
+  description: "本日開催でまだ終了時刻を迎えていない特別イベントの表示テスト用"
+  location: "FJORDオフィス"
+  capacity: 40
+  start_at: <%= Time.zone.local(2024, 12, 1, 9, 0, 0) %>
+  end_at: <%= Time.zone.local(2024, 12, 1, 12, 0, 0) %>
+  open_start_at: <%= Time.zone.local(2024, 11, 1, 9, 0, 0) %>
+  open_end_at: <%= Time.zone.local(2024, 12, 1, 9, 0, 0) %>
+  user: kimura
+
+event36:
+  title: "2024/12/1(日)6:00〜7:00開催の特別イベント"
+  description: "本日開催で終了時刻を過ぎた特別イベントの表示テスト用"
+  location: "FJORDオフィス"
+  capacity: 40
+  start_at: <%= Time.zone.local(2024, 12, 1, 6, 0, 0) %>
+  end_at: <%= Time.zone.local(2024, 12, 1, 7, 0, 0) %>
+  open_start_at: <%= Time.zone.local(2024, 11, 1, 6, 0, 0) %>
+  open_end_at: <%= Time.zone.local(2024, 12, 1, 6, 0, 0) %>
+  user: kimura

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -99,3 +99,13 @@ regular_event_repeat_rule37:
   frequency: 1
   day_of_the_week: 6
   regular_event: regular_event33
+
+regular_event_repeat_rule38:
+  frequency: 0
+  day_of_the_week: 0
+  regular_event: regular_event36
+
+regular_event_repeat_rule39:
+  frequency: 0
+  day_of_the_week: 0
+  regular_event: regular_event37

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -187,3 +187,23 @@ regular_event35:
   user: komagata
   category: 0
   published_at: "2023-08-01 00:00:00"
+
+regular_event36:
+  title: 本日開催でまだ終了時刻を迎えていない定期イベント
+  description: 本日開催でまだ終了時刻を迎えていない定期イベントの表示テスト用
+  finished: false
+  hold_national_holiday: false
+  start_at: <%= Time.zone.local(2024, 12, 1, 9, 0, 0) %>
+  end_at: <%= Time.zone.local(2024, 12, 1, 12, 0, 0) %>
+  user: komagata
+  published_at: "2024-12-01 00:00:00"
+
+regular_event37:
+  title: 本日開催で終了時刻を過ぎた定期イベント
+  description: 本日開催で終了時刻を過ぎた定期イベントの表示テスト用
+  finished: false
+  hold_national_holiday: false
+  start_at: <%= Time.zone.local(2024, 12, 1, 9, 0, 0) %>
+  end_at: <%= Time.zone.local(2024, 12, 1, 10, 0, 0) %>
+  user: komagata
+  published_at: "2024-12-01 00:00:00"

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class EventTest < ActiveSupport::TestCase
   test '.scheduled_on(date)' do
-    travel_to Time.zone.local(2017, 4, 3, 10, 0, 0) do
+    travel_to Time.zone.local(2017, 4, 3, 8, 0, 0) do
       today_date = Time.zone.today
       today_events_count = 2
       today_events = Event.scheduled_on(today_date)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -136,19 +136,14 @@ class EventTest < ActiveSupport::TestCase
     assert 205_042_674, ids
   end
 
-  test 'Events in progress today should be displayed' do
+  test '.scheduled_on_without_ended' do
     travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
       today_date = Time.zone.today
       events = Event.scheduled_on_without_ended(today_date)
-      assert_includes events, events(:event35)
-    end
-  end
-
-  test 'Events that have already ended today should not be displayed' do
-    travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
-      today_date = Time.zone.today
-      events = Event.scheduled_on_without_ended(today_date)
-      assert_not_includes events, events(:event36)
+      event_in_progress = events(:event35)
+      event_ended = events(:event36)
+      assert_includes events, event_in_progress
+      assert_not_includes events, event_ended
     end
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -135,4 +135,20 @@ class EventTest < ActiveSupport::TestCase
     assert 994_018_171, ids
     assert 205_042_674, ids
   end
+
+  test 'Events in progress today should be displayed' do
+    travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
+      today_date = Time.zone.today
+      events = Event.scheduled_on_without_ended(today_date)
+      assert_includes events, events(:event35)
+    end
+  end
+
+  test 'Events that have already ended today should not be displayed' do
+    travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
+      today_date = Time.zone.today
+      events = Event.scheduled_on_without_ended(today_date)
+      assert_not_includes events, events(:event36)
+    end
+  end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -154,4 +154,20 @@ class RegularEventTest < ActiveSupport::TestCase
       assert_equal 157, participated_regular_events.count
     end
   end
+
+  test 'Regular event in progress today should be displayed' do
+    travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
+      today_date = Time.zone.today
+      regular_event = RegularEvent.scheduled_on_without_ended(today_date)
+      assert_includes regular_event, regular_events(:regular_event36)
+    end
+  end
+
+  test 'Regular event that have already ended today should not be displayed' do
+    travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
+      today_date = Time.zone.today
+      regular_event = RegularEvent.scheduled_on_without_ended(today_date)
+      assert_not_includes regular_event, regular_events(:regular_event37)
+    end
+  end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -155,19 +155,14 @@ class RegularEventTest < ActiveSupport::TestCase
     end
   end
 
-  test 'Regular event in progress today should be displayed' do
+  test '.scheduled_on_without_ended' do
     travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
       today_date = Time.zone.today
-      regular_event = RegularEvent.scheduled_on_without_ended(today_date)
-      assert_includes regular_event, regular_events(:regular_event36)
-    end
-  end
-
-  test 'Regular event that have already ended today should not be displayed' do
-    travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
-      today_date = Time.zone.today
-      regular_event = RegularEvent.scheduled_on_without_ended(today_date)
-      assert_not_includes regular_event, regular_events(:regular_event37)
+      regular_events = RegularEvent.scheduled_on_without_ended(today_date)
+      regular_event_in_progress = regular_events(:regular_event36)
+      regular_event_ended = regular_events(:regular_event37)
+      assert_includes regular_events, regular_event_in_progress
+      assert_not_includes regular_events, regular_event_ended
     end
   end
 end

--- a/test/models/upcoming_event_test.rb
+++ b/test/models/upcoming_event_test.rb
@@ -10,7 +10,7 @@ class UpcomingEventTest < ActiveSupport::TestCase
 
   # not testing '.build_group' because this method is used in '.upcoming_events_grpups'.
   test '.upcoming_events_groups' do
-    travel_to Time.zone.local(2017, 4, 3, 10, 0, 0) do
+    travel_to Time.zone.local(2017, 4, 3, 8, 0, 0) do
       today_events = [
         events(:event27),
         events(:event33),

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -532,7 +532,7 @@ class EventsTest < ApplicationSystemTestCase
     today_events_count = 5
     tomorrow_events_count = 2
     day_after_tomorrow_events_count = 4
-    travel_to Time.zone.local(2017, 4, 3, 10, 0, 0) do
+    travel_to Time.zone.local(2017, 4, 3, 8, 0, 0) do
       visit_with_auth events_path, 'komagata'
       within('.upcoming_events_groups') do
         assert_text '近日開催のイベント'

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -217,7 +217,7 @@ class HomeTest < ApplicationSystemTestCase
   end
 
   test 'show all regular events and special events on dashbord' do
-    travel_to Time.zone.local(2017, 4, 3, 10, 0, 0) do
+    travel_to Time.zone.local(2017, 4, 3, 8, 0, 0) do
       visit_with_auth '/', 'kimura'
       today_event_label = find('.card-list__label', text: '今日開催')
       tomorrow_event_label = find('.card-list__label', text: '明日開催')

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -196,7 +196,7 @@ class RegularEventsTest < ApplicationSystemTestCase
 
   test 'show listing not finished regular events' do
     visit_with_auth regular_events_path(target: 'not_finished'), 'kimura'
-    assert_selector '.card-list.a-card .card-list-item', count: 17
+    assert_selector '.card-list.a-card .card-list-item', count: 19
   end
 
   test 'show listing all regular events' do

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -369,7 +369,7 @@ class RegularEventsTest < ApplicationSystemTestCase
     today_events_count = 5
     tomorrow_events_count = 2
     day_after_tomorrow_events_count = 4
-    travel_to Time.zone.local(2017, 4, 3, 10, 0, 0) do
+    travel_to Time.zone.local(2017, 4, 3, 8, 0, 0) do
       visit_with_auth events_path, 'komagata'
       within('.upcoming_events_groups') do
         assert_text '近日開催のイベント'


### PR DESCRIPTION
## Issue

- #8221

## 概要

## 変更確認方法

feature/do-not-display-finished-events-in-upcoming-events-group

1. {feature/do-not-display-finished-events-in-upcoming-events-group}をローカルに取り込む
   - `git fetch origin pull/8280/head:feature/do-not-display-finished-events-in-upcoming-events-group`
   - `git switch feature/do-not-display-finished-events-in-upcoming-events-group`
2. `rails c`で rails console を立ち上げる
3. 以下のコマンドを使い、テスト用のイベント2つを作成する
```
# 変数userの作成
user = User.find(253826460)

# 1つ目：特別イベント
 Event.create!(
  title: "5分後に「近日開催」の一覧から消える特別イベント",
  description: "終了後にダッシュボード等の「近日開催のイベント」の一覧から消えるかを確認するための特別イベントです",
  location: "Lokkaオフィス",
  capacity: 10,
  start_at: Time.current,
  end_at: Time.current + 5.minute,
  open_start_at: Time.current - 3.hour,
  open_end_at: Time.current - 10.minute,
  user: user
)

# 2つ目：定期イベント
regular_event = RegularEvent.new(
  title: "5分後に「近日開催」の一覧から消える定期イベント",
  description: "終了後にダッシュボード等の「近日開催のイベント」の一覧から消えるかを確認するための定期イベントです",
  finished: false,
  hold_national_holiday: false,
  start_at: Time.current,
  end_at: Time.current + 5.minute,
  user: user
)
regular_event.regular_event_repeat_rules.build(
  frequency: 0,
  day_of_the_week: Time.current.wday,
)
regular_event.user_ids << user
regular_event.save!
```

4. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
5. ダッシュボード左上の「近日開催のイベント」に、上で作成した２つのイベントが表示されていることを確認
6. 5分後（＝イベント終了後）、「近日開催のイベント」の一覧から上記２つのイベント表示が消えていることを確認
※どちらのイベントも、`end_at: Time.current + 5.minute`により5分後に終了する状態となっております。もしご確認ステップの3〜5の間で5分以上経ってしまった場合は初めからイベントが表示されていない状態になりますので、お手数ですが改めてイベントを作成してください（`end_at: Time.current + 10.minute`にするなど終了時刻を調整することで時間に余裕を持たせることができます）

## Screenshot

### 変更前

※各スクリーンショットで、画面右上に表示されている時間についても併せてご覧ください

#### イベント作成直後（イベント終了前）
- 元から入っていたテスト用のイベントと今回追加したテスト用のイベントが表示されています
<img width="908" alt="before1" src="https://github.com/user-attachments/assets/cba8d0b1-e15f-4490-b510-f94f2f91fac5" />

#### イベント作成から5分以上経過後（イベント終了後）
- 全てのイベントがそのまま表示されています
<img width="906" alt="before2" src="https://github.com/user-attachments/assets/586f4dc9-6e45-4524-9f65-ee8f1932e31e" />


### 変更後

#### イベント作成直後（イベント終了前）
- 元から入っていたテスト用のイベントは9:00開催で終了しているので、この段階で既に非表示になっています
<img width="904" alt="after1" src="https://github.com/user-attachments/assets/c8e73f51-83b0-4ce2-aa44-4835864ea9cd" />

#### イベント作成から5分以上経過後（イベント終了後）
- 今回追加したイベントも5分が経過して終了となったので、非表示になっています
<img width="904" alt="after2" src="https://github.com/user-attachments/assets/b383e373-0bd2-4624-be8e-54adbd5ebac8" />

#### 参考までに、イベント一覧画面の方では勿論イベントの情報は確認できます
<img width="910" alt="after3" src="https://github.com/user-attachments/assets/28a7f39d-8c6d-4012-9aed-cdc8ec52093b" />
<img width="912" alt="after4" src="https://github.com/user-attachments/assets/0e442bc0-ce50-4e9b-ae0c-ebff316db98f" />
