### PR TITLE
ブログ記事作成時に通知が飛ばないよう、該当部分のコードをコメントアウト

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -38,7 +38,10 @@ class ArticlesController < ApplicationController
     @article.user = current_user if @article.user.nil?
     set_wip
     if @article.save
-      Newspaper.publish(:create_article, { article: @article })
+      # Newspaper.publish(:create_article, { article: @article })
+      # 上のコードのコメントアウトは、以下のissueのための一時的なものなので、mergeされ次第コメントアウトを外すこと。
+      # https://github.com/fjordllc/bootcamp/issues/8244
+
       redirect_to redirect_url(@article), notice: notice_message(@article)
     else
       render :new

--- a/test/system/notification/articles_test.rb
+++ b/test/system/notification/articles_test.rb
@@ -13,27 +13,29 @@ class ArticlesTest < ApplicationSystemTestCase
     AbstractNotifier.delivery_mode = @delivery_mode
   end
 
-  test 'the notification is sent only when the article is first published' do
-    visit_with_auth new_article_path, 'komagata'
-    fill_in('article_title', with: '通知テスト1回目')
-    fill_in('article_body', with: 'test')
-    click_on '公開する'
-    assert_text '記事を作成しました'
+  # test 'the notification is sent only when the article is first published' do
+  #   visit_with_auth new_article_path, 'komagata'
+  #   fill_in('article_title', with: '通知テスト1回目')
+  #   fill_in('article_body', with: 'test')
+  #   click_on '公開する'
+  #   assert_text '記事を作成しました'
 
-    visit_with_auth notifications_path, 'hajime'
-    within first('.card-list-item.is-unread') do
-      assert_text 'komagataさんがブログに「通知テスト1回目」を投稿しました。'
-    end
-    click_link '全て既読にする'
+  #   visit_with_auth notifications_path, 'hajime'
+  #   within first('.card-list-item.is-unread') do
+  #     assert_text 'komagataさんがブログに「通知テスト1回目」を投稿しました。'
+  #   end
+  #   click_link '全て既読にする'
 
-    visit_with_auth edit_article_path(@article), 'komagata'
-    fill_in('article_title', with: '通知テスト2回目')
-    click_on '更新する'
+  #   visit_with_auth edit_article_path(@article), 'komagata'
+  #   fill_in('article_title', with: '通知テスト2回目')
+  #   click_on '更新する'
 
-    visit_with_auth notifications_path, 'hajime'
-    assert_no_selector '.card-list-item.is-unread'
-    assert_no_text 'komagataさんがブログに「通知テスト2回目」を投稿しました。'
-  end
+  #   visit_with_auth notifications_path, 'hajime'
+  #   assert_no_selector '.card-list-item.is-unread'
+  #   assert_no_text 'komagataさんがブログに「通知テスト2回目」を投稿しました。'
+  # end
+  # 上のコードのコメントアウトは、以下のissueのための一時的なものなので、mergeされ次第コメントアウトを外すこと。
+  # https://github.com/fjordllc/bootcamp/issues/8244
 
   test 'the notification is not sent when the article with WIP is saved' do
     visit_with_auth new_article_path, 'komagata'


### PR DESCRIPTION
## Issue

- #8247 

## 概要
ブログ記事を作成した時に通知が飛ばないように該当部分をコメントアウトしました。
この変更は #8244 の変更作業のための一時的な処理です。

## 変更確認方法

1. {chore/pause-article-submission-notifications}をローカルに取り込む
   1. `git fetch origin pull/8281/head:chore/pause-article-submission-notifications` を取り込む （２度目以降は--forceをつけてください）
   2. `git switch chore/pause-article-submission-notifications`でブランチ移動
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる。 
3. 適当なメンター（例： user:komagata, password: testtest）でログインする。
4. [ブログ記事作成ページ](http://localhost:3000/articles/new)において、適当にタイトルと本文を入力し、公開するボタンをクリックする。
5. [ブログ記事一覧](http://localhost:3000/articles)に移動し、作成した記事が公開されているか確認する。
6. 現在のユーザーからログアウトし、適当な他ユーザーでログインする。（例：user: machida, password: testtest）
   通知が飛んでいるかどうかの確認なので、ユーザーのロール（メンターか受講生か、等）は問いません。
7.  ページ右上の通知で、先ほど公開したブログ記事の**通知が飛んでいないこと**を確認する。

## Screenshot

### 変更前
- 記事作成時に以下のような通知した旨の表示が別タブで出ます。
<img width="973" alt="スクリーンショット 2025-01-23 17 07 06" src="https://github.com/user-attachments/assets/f416f51f-d4a5-4f1a-be06-6b74cd622ff6" />

- 他ユーザーでログインすると通知が**飛んでいること**が確認できます。
<img width="502" alt="スクリーンショット 2025-01-23 17 08 03" src="https://github.com/user-attachments/assets/057ea037-cd3d-40e1-9c12-20915986897a" />

### 変更後
- 変更前と同様に記事を作成しますが、公開するボタンを押してもそのまま公開記事に移動します。
記事一覧に行くとちゃんと公開されていることが確認できます。
<img width="1044" alt="スクリーンショット 2025-01-23 17 12 19" src="https://github.com/user-attachments/assets/1a9bd91c-c72a-4586-922e-bd0d3ad0b306" />

<img width="990" alt="スクリーンショット 2025-01-23 17 12 45" src="https://github.com/user-attachments/assets/93d4218d-f6b8-4cde-8d58-4f1f18b47766" />

- 他ユーザーでログインすると通知が**飛んでいないこと**が確認できます。
<img width="545" alt="スクリーンショット 2025-01-23 17 13 21" src="https://github.com/user-attachments/assets/561b5c75-c212-4178-b8c9-ee610a1066a3" />
