### PR TITLE
ユーザーメモ欄、提出物ページのプラクティスメモ欄でユーザーアイコンが表示されるようにした

### DIFF
--- a/app/javascript/practice_memo.js
+++ b/app/javascript/practice_memo.js
@@ -6,7 +6,6 @@ import { toast } from 'toast_react'
 document.addEventListener('DOMContentLoaded', () => {
   const practiceMemo = document.querySelector('.practice-memo')
   if (practiceMemo) {
-    TextareaInitializer.initialize('.a-markdown-input__textarea')
     const markdownInitializer = new MarkdownInitializer()
     const practiceId = practiceMemo.dataset.practice_id
     let savedMemo = ''
@@ -40,6 +39,9 @@ document.addEventListener('DOMContentLoaded', () => {
           memoDisplayContent.innerHTML = markdownInitializer.render(savedMemo)
           memoEditorPreview.innerHTML = markdownInitializer.render(savedMemo)
         }
+      })
+      .then(() => {
+        TextareaInitializer.initialize('.a-markdown-input__textarea')
       })
       .catch((error) => {
         console.warn(error)

--- a/app/javascript/practice_memo.js
+++ b/app/javascript/practice_memo.js
@@ -66,6 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
       toggleClass(modalElements, 'is-hidden')
       editorTextarea.value = savedMemo
       memoEditorPreview.innerHTML = markdownInitializer.render(savedMemo)
+      TextareaInitializer.initialize('#js-practice-memo')
     })
 
     editorTextarea.addEventListener('change', () => {

--- a/app/javascript/practice_memo.js
+++ b/app/javascript/practice_memo.js
@@ -72,6 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
       memoEditorPreview.innerHTML = markdownInitializer.render(
         editorTextarea.value
       )
+      TextareaInitializer.initialize('#js-practice-memo')
     })
 
     const editorTab = memoEditor.querySelector('.editor-tab')

--- a/app/javascript/practice_memo.js
+++ b/app/javascript/practice_memo.js
@@ -57,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
       savedMemo = editorTextarea.value
       updateMemo(savedMemo, practiceId)
       memoDisplayContent.innerHTML = markdownInitializer.render(savedMemo)
+      TextareaInitializer.initialize('#js-practice-memo')
       switchMemoDisplay(memoDisplay, savedMemo)
     })
 

--- a/app/javascript/user_mentor_memo.js
+++ b/app/javascript/user_mentor_memo.js
@@ -67,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
       savedMemo = editorTextarea.value
       updateMemo(savedMemo, userId)
       memoDisplayContent.innerHTML = markdownInitializer.render(savedMemo)
+      TextareaInitializer.initialize('#js-user-mentor-memo')
       switchMemoDisplay(memoDisplay, savedMemo)
     })
 

--- a/app/javascript/user_mentor_memo.js
+++ b/app/javascript/user_mentor_memo.js
@@ -5,7 +5,6 @@ import MarkdownInitializer from 'markdown-initializer'
 document.addEventListener('DOMContentLoaded', () => {
   const mentorMemo = document.querySelector('.user-mentor-memo')
   if (mentorMemo) {
-    TextareaInitializer.initialize('#js-user-mentor-memo')
     const markdownInitializer = new MarkdownInitializer()
     const userId = mentorMemo.dataset.user_id
     let savedMemo = ''
@@ -50,6 +49,9 @@ document.addEventListener('DOMContentLoaded', () => {
           memoDisplayContent.innerHTML = markdownInitializer.render(savedMemo)
           memoEditorPreview.innerHTML = markdownInitializer.render(savedMemo)
         }
+      })
+      .then(() => {
+        TextareaInitializer.initialize('#js-user-mentor-memo')
       })
       .catch((error) => {
         console.warn(error)

--- a/app/javascript/user_mentor_memo.js
+++ b/app/javascript/user_mentor_memo.js
@@ -82,6 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
       memoEditorPreview.innerHTML = markdownInitializer.render(
         editorTextarea.value
       )
+      TextareaInitializer.initialize('#js-user-mentor-memo')
     })
 
     const editorTab = memoEditor.querySelector('.editor-tab')

--- a/app/javascript/user_mentor_memo.js
+++ b/app/javascript/user_mentor_memo.js
@@ -76,6 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
       toggleClass(modalElements, 'is-hidden')
       editorTextarea.value = savedMemo
       memoEditorPreview.innerHTML = markdownInitializer.render(savedMemo)
+      TextareaInitializer.initialize('#js-user-mentor-memo')
     })
 
     editorTextarea.addEventListener('change', () => {

--- a/app/views/products/_practice_memo.html.slim
+++ b/app/views/products/_practice_memo.html.slim
@@ -12,7 +12,7 @@
       hr.a-border-tint
       .card-body
         .card__description.any-memo.is-hidden
-          .a-long-text.is-md
+          .a-long-text.is-md.js-markdown-view
         .card-list.no-memo
           .card-list__message
             .container

--- a/app/views/users/_user_mentor_memo.html.slim
+++ b/app/views/users/_user_mentor_memo.html.slim
@@ -7,7 +7,7 @@ section.a-card.is-memo.is-only-mentor.user-mentor-memo data-user_id=user_id
       hr.a-border-tint
     .card-body
       .card-body__description
-        .a-long-text.is-md.a-placeholder
+        .a-long-text.is-md.a-placeholder.js-markdown-view
           p
           p
           p


### PR DESCRIPTION
## Issue

- #7335

## 概要

## 変更確認方法

1. `bug/fix-user-icon-in-user-notes-field`をローカルに取り込む。
    1. `git fetch origin bug/fix-user-icon-in-user-notes-field`
    2. `git checkout bug/fix-user-icon-in-user-notes-field`
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる。
3. ユーザー名`komagata`、パスワード`testtest`でログインする。（メンターであれば誰でもいいです）
4. [ユーザープロフィール](http://localhost:3000/users/253826460)にアクセスする。
5. メンター向けユーザーメモに`:@komagata:`を貼り付けて保存する。（←の文字列を貼り付けるとなぜかアイコンが増殖するかもしれませんが[こちらのissue](https://github.com/fjordllc/bootcamp/issues/8065)と同じ問題と思われます）
6. メンター向けユーザーメモのテキストエリアにユーザーアイコンが表示されることを確認する。
7. 画面を再読み込みする。
8. 同じようにユーザーアイコンが表示されることを確認する。
9. 編集時のプレビューでもユーザーアイコンが表示されることを確認する。
10. [ユーザーの提出物詳細](http://localhost:3000/products/613458348)にアクセスする。
11. ページ下部に4つ並んでいるタブから"プラクティスメモ"を選び、ユーザープロフィールと同様にユーザーアイコンが表示されることを確認する。

## Screenshot

### 変更前
ユーザープロフィール
<img width="505" alt="image" src="https://github.com/user-attachments/assets/e9326990-fc30-46db-a1b0-0d908f031132" />
ユーザーの提出物詳細
<img width="706" alt="image" src="https://github.com/user-attachments/assets/0b82d243-e178-4f69-b856-8ebcc77d9a70" />

### 変更後
ユーザープロフィール
<img width="502" alt="image" src="https://github.com/user-attachments/assets/0a80910e-fa64-418b-8927-1f0ca2a5d3e7" />
ユーザーの提出物詳細
<img width="648" alt="image" src="https://github.com/user-attachments/assets/90a8e041-40bd-429c-abb9-feddeeda73b1" />

