### PR TITLE
プラクティス画面の終了条件という誤字を修了条件へ変更

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -114,7 +114,7 @@
                 .card-footer__description
                   | このプラクティスに提出物はありません。
                   br
-                  | 終了条件をクリアしたら修了にしてください。
+                  | 修了条件をクリアしたら修了にしてください。
 
           - if @practice.coding_tests.present?
             = render partial: 'coding_tests', locals: { coding_tests: @practice.coding_tests }


### PR DESCRIPTION
## Issue

- [終了を修了に変更 #8282](https://github.com/fjordllc/bootcamp/issues/8282)

## 概要
+ 提出物が不要なプラクティスのプラクティス画面における誤字を修正いたしました。
誤：『終』了
正：『修』了

## 変更確認方法

1. `chore/change-end-to-completion-in-practice-screen`をローカルに取り込む。
   1. `git fetch origin chore/change-end-to-completion-in-practice-screen`
   2. `git checkout chore/change-end-to-completion-in-practice-screen`
2. `foreman start -f Procfile.dev`で[ローカル環境](http://localhost:3000/)を立ち上げる。
3. ユーザー名 `komagata`、パスワード `testtest` でログインする。（ 誰でもよいです。）
4. [プラクティス](http://localhost:3000/courses/829913840/practices#category-917504053)にアクセスする。
5. [PC性能の見方を知る](http://localhost:3000/practices/1019809339)にアクセスする。
6. 修了条件の【✓修了】ボタン下の文言が『修了条件をクリアしたら修了にしてください。』に変更されていることを確認する。
## Screenshot

### 変更前
![変更前](https://github.com/user-attachments/assets/d516a98f-3af5-4607-8732-79314a5831c7)

### 変更後
![変更後](https://github.com/user-attachments/assets/06bb19dd-03e4-4657-a7ab-c750d1cb533a)
