### PR TITLE
Q&A Answer部分の非Vue化の不具合修正（追加）

### DIFF
--- a/app/javascript/answer.js
+++ b/app/javascript/answer.js
@@ -14,10 +14,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const answers = document.querySelectorAll('.answer')
   const loadingContent = document.querySelector('.loading-content')
   const answerContent = document.querySelector('.answer-content')
-  if (answers.length > 0) {
+
+  if (loadingContent && answerContent) {
     loadingContent.style.display = 'none'
     answerContent.style.display = 'block'
+  }
 
+  if (answers.length > 0) {
     answers.forEach((answer) => {
       initializeAnswer(answer)
     })

--- a/app/javascript/answer.js
+++ b/app/javascript/answer.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const answers = document.querySelectorAll('.answer')
   const loadingContent = document.querySelector('.loading-content')
   const answerContent = document.querySelector('.answer-content')
-  if (answers) {
+  if (answers.length > 0) {
     loadingContent.style.display = 'none'
     answerContent.style.display = 'block'
 

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -35,7 +35,7 @@ hr.a-border
       .answer-content style='display: none;'
         - if @question.ai_answer
           = render 'ai_answer', question: @question
-        header.thread-comments__header.answer-content
+        header.thread-comments__header
           h2.thread-comments__title
             | 回答・コメント
         .answers-list


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/5116

## 概要

下記PRの動作確認を @komagata さんが行なっていたところ、エラーが出ているとお知らせいただいた。
```
answer.js:18 Uncaught TypeError: Cannot read properties of null (reading 'style')
    at HTMLDocument.<anonymous> (answer.js:18:1)
```

- https://github.com/fjordllc/bootcamp/pull/8033
- https://github.com/fjordllc/bootcamp/pull/8275

### 追記
同時に以下の不具合も見つけたので修正。

- 回答がない場合、回答のローディングスケルトンがずっと表示される。
- watchしていない質問に回答した後、watch状態にならない。

## 原因
### 一つ目（コンソールエラー）
下記で、回答要素（`_answer.html.slim`の要素群）を取得しています。
`const answers = document.querySelectorAll('.answer')`

回答がなければ、下記の処理は実行されないはずと考えていたが誤りでした。
```js
  if (answers) {
    loadingContent.style.display = 'none'
    answerContent.style.display = 'block'

    answers.forEach((answer) => {
      initializeAnswer(answer)
    })
  }
```

`document.querySelectorAll`は該当する要素が存在しない場合でも、空のNodeListを返します。NodeListは常に真として評価されるため、`if(answers)`の条件は常に成立してしまい、意図した挙動になっていませんでした。
そのため、lengthを用いることで取得した回答数を確認するようにしました。

### 2つ目（回答がない場合、回答のローディングスケルトンがずっと表示される。）
一つ目の不具合を修正した後のコードが以下。
```js
  if (answers.length > 0) {
    loadingContent.style.display = 'none'
    answerContent.style.display = 'block'

    answers.forEach((answer) => {
      initializeAnswer(answer)
    })
  }
```

この修正により、ローディングスケルトンと回答の切り替えが「回答があった場合」にのみ行われるようになったため、回答がない場合延々とスケルトンが表示されてしまいました。
そのため、この「ローディングスケルトンと回答の切り替え」を回答の有無に関わらず実行できるように、処理を分けました。

### 3つ目（watchしていない質問に回答した後、watch状態にならない。）
回答フォームの「コメントする」ボタンを押下すると、回答の作成や回答数の更新などが行われます。その処理の中には、質問のwatch状態を更新する処理も含まれています。
watch状態の更新は、以下の updateWatchable 関数で実現しています。
```js
function updateWatchable(questionId) {
  store.dispatch('setWatchable', {
    watchableId: questionId,
    watchableType: 'Question'
  })
}
```
`setWatchable`は対象のwatch状態を取得して、更新してくれる処理です。
また、回答を作成すると、AnswerWatcher がその回答を自動的にwatch状態にします。
```ruby
# app/controllers/api/answers_controller.rb
def create
  question = Question.find(params[:question_id])
  @answer = question.answers.new(answer_params)
  @answer.user = current_user
  if @answer.save
    Newspaper.publish(:answer_create, { answer: @answer }) # ここでAnswerWatcherの処理を発火してる
```
本来の想定フローは以下の通りです：

1. 回答を作成する。この作成処理には、質問をwatch状態にする処理が含まれている。
2. watch状態を取得して更新する。

しかし、回答の作成が非同期で行われていたため、作成処理が完了する前にwatch状態を取得していました。その結果、watch状態が正しく更新されない問題が発生していました。
そこで、回答の作成が完了したことを確認してから、watch状態の更新を行うように変更しました。

## 変更確認方法

1. `chore/handle-answerjs-warning`をローカルに取り込む
2. 質問詳細ページ以外のページを開く
3. コンソールを確認し、エラーが出ていないことを確認

## Screenshot

### JSのコンソールエラー

#### 変更前
<img width="827" alt="スクリーンショット 2025-01-21 21 01 53" src="https://github.com/user-attachments/assets/fa0411ad-1c21-478e-8887-91d55882aec2" />

#### 変更後
<img width="827" alt="スクリーンショット 2025-01-21 21 02 23" src="https://github.com/user-attachments/assets/64964171-35a5-4e1c-ad0f-5c6b576a58ff" />

### 回答がない場合、回答のローディングスケルトンがずっと表示される。

#### 変更後
<img width="600" alt="スクリーンショット 2025-01-27 10 46 21" src="https://github.com/user-attachments/assets/5504e24f-8160-49d6-9098-ddb698ec6a5e" />


### watchしていない質問に回答した後、watch状態にならない。

#### 変更前

https://github.com/user-attachments/assets/bacbc809-34e5-47d5-8392-9d9451c410a1

#### 変更後

https://github.com/user-attachments/assets/5c41c3d6-cf29-40c6-9a17-ee0fc5e32c65

