### PR TITLE
カレンダーアプリ上で定期イベントの開始・終了時間が UTC 基準になる問題を修正

### DIFF
--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -167,11 +167,8 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def parse_event_time(event_date, event_time)
-    tz = ActiveSupport::TimeZone['Asia/Tokyo']
-
-    time = event_time ? event_time.strftime('%H:%M') : '00:00'
-    date_time = DateTime.parse("#{event_date} #{time}")
-
-    tz.local_to_utc(date_time)
+    str_date = event_date.strftime('%F')
+    str_time = event_time.strftime('%R')
+    Time.zone.parse([str_date, str_time].join(' '))
   end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -136,13 +136,15 @@ class RegularEventTest < ActiveSupport::TestCase
     assert_equal wednesday_for_year, scheduled_dates
   end
 
-  test '#format_event_date' do
+  test '#transform_for_subscription' do
     travel_to Time.zone.local(2024, 8, 5, 23, 0, 0) do
-      regular_event = regular_events(:regular_event34)
+      regular_event = RegularEvent.new(start_at: '21:00', end_at: '22:00')
       event_date = Date.new(2024, 8, 7)
       transformed_regular_event = regular_event.transform_for_subscription(event_date)
-      assert_equal DateTime.new(2024, 8, 7, 21, 0, 0, '+09:00'), transformed_regular_event.start_on
-      assert_equal DateTime.new(2024, 8, 7, 22, 0, 0, '+09:00'), transformed_regular_event.end_on
+
+      assert_equal Time.zone.parse('2024-08-07 21:00'), transformed_regular_event.start_on
+      assert_equal Time.zone.parse('2024-08-07 22:00'), transformed_regular_event.end_on
+      assert_equal 'JST', transformed_regular_event.start_on.zone, 'タイムゾーンが日本標準時(Japan Standard Time)と異なります'
     end
   end
 


### PR DESCRIPTION
## Issue

- #8287

## 概要

イベント購読機能を利用してカレンダーアプリに FBC のイベント予定を取り込んだ際、定期イベントの開始時間がユーザーのタイムゾーン(日本)と異なっている問題を修正しました。


## 原因

定期イベントは特別イベントと異なり、開催する"時間"の情報しか持っていないため購読される際に"年/月/日"も加えた完全な日付を作成する必要があります。

以下のコードで完全な日付の作成を行ってますが、`local_to_utc` メソッドにより時刻の基準が UTC へ変更されているため、該当箇所を削除しました。

https://github.com/fjordllc/bootcamp/blob/1a9a8d34ff92a95786247acd5680f8aa21a05dd5/app/models/regular_event.rb#L169-L176

また、上記のメソッドはイベント購読処理でのみ利用されているため他のコードへの影響は無いと思われます。

## 変更確認方法

1. `bug/start_time_of_regular_event_is_shifted` をローカルに取り込む
2. `foreman start -f Procfile.dev` を実行し、任意のユーザーでログインする
3. [定期イベントページ](http://localhost:3000/regular_events?target=not_finished) にアクセスする
4. 任意の定期イベントに参加する
5. 画面右上にある `イベント購読ボタン` をクリックし、カレンダーアプリへ取り込む
![イベント購読ボタン](https://github.com/user-attachments/assets/41671868-c4a1-43f2-9f1f-a7121807fa56)

6. カレンダー上で表示される定期イベントの時間が FBC 上の定期イベントの時間と同じになっている

## Screenshot

以下は、定期イベントである「Everyday Rails輪読会 ( 17:00 ~ 18:00 ) 」に参加した場合のカレンダーアプリ上の表示になります。

### 修正前

予定に表示されている時間が 8:00 になっている。( UTC 基準での時刻 )

![定期イベントの開始時間_修正前](https://github.com/user-attachments/assets/1d8203f0-c178-4b17-a360-ab15e70b7bda)


### 修正後

予定に表示されている時間が 17:00 になっている。( 東京での時刻 )

![定期イベントの開始時間_修正後](https://github.com/user-attachments/assets/f8052415-926b-41d5-b780-df4b16c59dd6)

