### PR TITLE
プラクティス画面の終了条件という誤字を修了条件へ変更（再度）

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -120,7 +120,7 @@
                   .card-footer__description
                     | このプラクティスに提出物はありません。
                     br
-                    | 終了条件をクリアしたら修了にしてください。
+                    | 修了条件をクリアしたら修了にしてください。
 
           - if @practice.coding_tests.present?
             = render partial: 'coding_tests', locals: { coding_tests: @practice.coding_tests }


### PR DESCRIPTION
## Issue
- https://github.com/fjordllc/bootcamp/issues/8282
 
## 概要
+ こちらのPR：https://github.com/fjordllc/bootcamp/pull/8284 を再度修正し、PRいたしました。
@komagata さんご承知済。