### PR TITLE
マイプロフィールのヘッダーに日報作成ボタンを追加

### DIFF
--- a/app/views/users/_page_title.html.slim
+++ b/app/views/users/_page_title.html.slim
@@ -17,6 +17,12 @@ header.page-header
               - else
                 li.page-main-header-actions__item
                   = render 'users/following', user:
+            - else
+              li.page-header-actions__item
+                = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+                  i.fa-regular.fa-plus
+                  span
+                    | 日報作成
             li.page-header-actions__item
               = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
                 | ユーザー一覧

--- a/app/views/users/works/index.html.slim
+++ b/app/views/users/works/index.html.slim
@@ -10,6 +10,12 @@ header.page-header
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items
+            - if current_user == @user
+              li.page-header-actions__item
+                = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
+                  i.fa-regular.fa-plus
+                  span
+                    | 日報作成
             li.page-header-actions__item
               = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
                 | ユーザー一覧


### PR DESCRIPTION
## Issue

- [プロフィールの動線からも日報作成ボタンが欲しい #8302](https://github.com/fjordllc/bootcamp/issues/8302)

## 概要
他のユーザーから見た、自分のプロフィール(マイプロフィール)や日報などの各ページのヘッダーに「日報作成」ボタンを追加しました。

## 変更確認方法

1. `feature/add-create-report-button-to-my-profile-header`をローカルに取り込む
 i.`git fetch origin feature/add-create-report-button-to-my-profile-header`
 ii.`git checkout feature/add-create-report-button-to-my-profile-header`
3. `foreman start -f Procfile.dev`で開発環境を立ち上げる
4. ユーザー名`komagata`、パスワード`testtest`でログインする
5. [マイプロフィール](http://localhost:3000/users/459775584)に移動する
6. 他のユーザーから見た、自分(`komagata`)のプロフィールや日報などの各ページのヘッダーに「日報作成」ボタンが表示されていることを確認する

## Screenshot

### 変更前
![profile](https://github.com/user-attachments/assets/911d213c-2542-4fe4-a5a0-498a23087649)


### 変更後
![profile2](https://github.com/user-attachments/assets/3b9cb2fc-efab-4437-8030-8eb514fd107e)

## マイプロフィールから日報作成ボタンを押したときの流れ
https://github.com/user-attachments/assets/0a2d5ce9-8808-422f-9783-610d269f92c3

