### PR TITLE
フッターのフィヨルドブートキャストのリンクを変更する

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -56,7 +56,7 @@ footer.footer
             = link_to 'https://fbc-stack.vercel.app/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | FBC Stack
           li.footer-nav__item
-            = link_to 'https://circlecast.net/channels/9', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+            = link_to 'https://podcasts.apple.com/jp/podcast/フィヨルドブートキャスト/id1786658623', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | フィヨルドブートキャスト
           li.footer-nav__item
             = link_to 'https://roulette-talk.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do


### PR DESCRIPTION
## Issue

- フッターのフィヨルドブートキャストのリンクを変える #8308

## 概要
フッターのフィヨルドブートキャストのリンクをhttps://circlecast.net/channels/9 から https://podcasts.apple.com/jp/podcast/フィヨルドブートキャスト/id1786658623 に変更しました。

## 変更確認方法

1. `feature/change-fjordbootcast-link-in-footer`をローカルに取り込む
2. `foreman start -f Procfile.dev`で開発環境を立ち上げる
3. ログインする(例: ユーザー名`komagata`、パスワード`testest`)
4. フッターのフィヨルドブートキャストのリンクをクリックすると、`https://podcasts.apple.com/jp/podcast/フィヨルドブートキャスト/id1786658623`が表示されることを確認する。

## フィヨルドブートキャストのリンクをクリックしたときの流れ

### 変更前

https://github.com/user-attachments/assets/cf0dcd81-92e3-4e82-9bd1-a3e641eb413e

### 変更後

https://github.com/user-attachments/assets/9683efd6-9a67-48a3-abe7-844fc14dba33





