### PR TITLE
管理者が自分以外のユーザーアイコンを変更できないバグを修正

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -62,7 +62,7 @@ class Admin::UsersController < AdminController
       :password, :password_confirmation, :job,
       :organization, :os, :study_place,
       { experiences: [] }, :company_id,
-      :trainee, :job_seeking, :nda,
+      :trainee, :job_seeking, :nda, :avatar,
       :graduated_on, :retired_on,
       :job_seeker, :github_collaborator,
       :officekey_permission, :tag_list, :training_ends_on,

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -78,12 +78,21 @@ class Admin::UsersTest < ApplicationSystemTestCase
 
   test 'update user' do
     user = users(:hatsuno)
-    visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'
+
+    visit_with_auth "/users/#{user.id}", 'komagata'
+    icon_before = find('img.user-profile__user-icon-image', visible: false)
+    assert icon_before.native['src'].end_with?('hatsuno.jpg')
+
+    visit "/admin/users/#{user.id}/edit"
     within 'form[name=user]' do
       fill_in 'user[login_name]', with: 'hatsuno-1'
+      attach_file 'user[avatar]', 'test/fixtures/files/users/avatars/komagata.jpg', make_visible: true
       click_on '更新する'
     end
+
     assert_text 'ユーザー情報を更新しました。'
+    icon_after = find('img.user-profile__user-icon-image', visible: false)
+    assert icon_after.native['src'].end_with?('komagata.png')
   end
 
   test 'update user with company' do


### PR DESCRIPTION
## Issue

- #8243 

## 概要

管理者でログインをすると、ユーザーの個別ページからそのユーザーのプロフィール編集ページに入ることができ、プロフィールの編集が行える。
しかし、現状管理者ではその機能を使ってユーザーのアイコンを変更しようとしても変更が反映されない。
そのバグの修正を行った。

## 変更確認方法

1. `bug/admin-cannot-update-user-icon`をローカルに取り込む
    1. `git fetch origin bug/admin-cannot-update-user-icon`
    2. `git switch bug/admin-cannot-update-user-icon`
2. `foreman start -f Procfile.dev`でローカルサーバーを起動する
3. ユーザー名machida、パスワードtesttestでログインする（管理者であれば誰でも可）
4. [hatsunoさんのプロフィールページ](http://localhost:3000/users/655153192)にアクセスする
5. 右下「管理者として情報変更」ボタンを押下する
6. 「ユーザーアイコン」エリアの「画像を変更」ボタンを押下し、任意の画像をアップロードする
7. 一番下「更新する」ボタンを押下する
8. ユーザーアイコンがアップロードした画像に更新されていることを確認する

## Screenshot

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/ab7d9b90-0c57-436a-a7a0-cf44c1b32e5f" />

<img width="573" alt="image" src="https://github.com/user-attachments/assets/319120d7-64ce-465e-aa82-d1130250032d" />

<img width="1260" alt="image" src="https://github.com/user-attachments/assets/3393fea2-195f-45f7-b4fc-7f288175e8a2" />

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/3d7bb11d-745c-409d-aa90-28bdaeccc012" />
