### PR TITLE
/sponsorshipsページの新規作成

### DIFF
--- a/app/controllers/articles/sponsorships_controller.rb
+++ b/app/controllers/articles/sponsorships_controller.rb
@@ -2,12 +2,12 @@
 
 class Articles::SponsorshipsController < ApplicationController
   skip_before_action :require_active_user_login, raise: false, only: %i[index]
-  MAX_PAGE_COUNT = 12
+  PAGER_NUMBER = 12
 
   layout 'lp'
 
   def index
-    @articles = sponsorships_articles.per(MAX_PAGE_COUNT)
+    @articles = sponsorships_articles.per(PAGER_NUMBER)
   end
 
   private

--- a/app/controllers/articles/sponsorships_controller.rb
+++ b/app/controllers/articles/sponsorships_controller.rb
@@ -14,6 +14,6 @@ class Articles::SponsorshipsController < ApplicationController
 
   def sponsorships_articles
     Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
-           .where(thumbnail_type: :sponsorship, wip: false).order(created_at: :desc).page(params[:page])
+           .where(thumbnail_type: :sponsorship, wip: false).order(published_at: :desc).page(params[:page])
   end
 end

--- a/app/controllers/articles/sponsorships_controller.rb
+++ b/app/controllers/articles/sponsorships_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Articles::SponsorshipsController < ApplicationController
+  skip_before_action :require_active_user_login, raise: false, only: %i[index]
+  MAX_PAGE_COUNT = 12
+
+  layout 'lp'
+
+  def index
+    @articles = sponsorships_articles.per(MAX_PAGE_COUNT)
+  end
+
+  private
+
+  def sponsorships_articles
+    Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
+           .where(thumbnail_type: :sponsorship, wip: false).order(created_at: :desc).page(params[:page])
+  end
+end

--- a/app/views/articles/sponsorships/index.html.slim
+++ b/app/views/articles/sponsorships/index.html.slim
@@ -1,0 +1,5 @@
+ruby:
+  title 'ブログ'
+  set_meta_tags(site: 'FJORD BOOT CAMP（フィヨルドブートキャンプ）')
+  description 'オンラインプログラミングフィヨルドブートキャンプのスポンサーに関するブログ記事一覧ページです。'
+= render '/articles/articles', { articles: @articles, is_published: true }

--- a/app/views/shared/_not_logged_in_footer.html.slim
+++ b/app/views/shared/_not_logged_in_footer.html.slim
@@ -29,6 +29,9 @@ footer.not-logged-in-footer
         li.not-logged-in-footer__nav-item
           = link_to press_kit_path, class: 'not-logged-in-footer__nav-item-link' do
             | プレスキット
+        li.not-logged-in-footer__nav-item
+          = link_to sponsorships_path, class: 'not-logged-in-footer__nav-item-link' do
+            | スポンサー実績
         - if admin_login?
           // TODO リスキル講座 公開したら if を外す
           li.not-logged-in-footer__nav-item

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
   resource :billing_portal, only: :create, controller: "billing_portal"
   resources :external_entries, only: %i(index)
   get "articles/tags/:tag", to: "articles#index", as: :tag, tag: /.+/
+  get 'sponsorships', to: 'articles/sponsorships#index'
   get "pages/tags/:tag", to: "pages#index", as: :pages_tag, tag: /.+/, format: "html"
   get "questions/tags/:tag", to: "questions#index", as: :questions_tag, tag: /.+/, format: "html"
   get "login" => "user_sessions#new", as: :login

--- a/db/fixtures/articles.yml
+++ b/db/fixtures/articles.yml
@@ -90,3 +90,14 @@ article<%= id %>:
   wip: false
   published_at: "2022-03-14 00:00:00"
 <% end %>
+
+<% (41..55).each do |id| %>
+article<%= id %>:
+  title: test title<%= id %>
+  body: |-
+    test body<%= id %>
+  user: komagata
+  wip: false
+  published_at: "2022-03-14 00:00:00"
+  thumbnail_type: :sponsorship
+<% end %>

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -23,8 +23,8 @@ article3:
   token: abcdef123456
 
 article4:
-  title: タイトル４
-  body: sponsorshipページに表示される記事です。
+  title: sponsorshipページに表示される記事のタイトルです。
+  body: sponsorshipページに表示される記事の本文です。
   user: komagata
   wip: false
   published_at: '2022-01-01 00:00:00'

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -3,7 +3,7 @@ article1:
   body: サムネイルは「/public/ogp/」配下にある画像を使っています。
   user: komagata
   wip: false
-  published_at: "2022-01-01 00:00:00"
+  published_at: '2022-01-01 00:00:00'
   thumbnail_type: :ruby_on_rails
 
 article2:
@@ -11,7 +11,7 @@ article2:
   body: サムネイルにはデフォルトの画像を使います。
   user: machida
   wip: false
-  published_at: "2022-01-02 00:00:00"
+  published_at: '2022-01-02 00:00:00'
   thumbnail_type: :prepared_thumbnail
 
 article3:
@@ -20,4 +20,12 @@ article3:
   user: komagata
   wip: true
   thumbnail_type: :prepared_thumbnail
+  token: abcdef123456
+
+article4:
+  title: タイトル４
+  body: sponsorshipページに表示される記事です。
+  user: komagata
+  wip: false
+  thumbnail_type: :sponsorship
   token: abcdef123456

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -27,5 +27,5 @@ article4:
   body: sponsorshipページに表示される記事です。
   user: komagata
   wip: false
+  published_at: '2022-01-01 00:00:00'
   thumbnail_type: :sponsorship
-  token: abcdef123456

--- a/test/system/article/sponsorships_test.rb
+++ b/test/system/article/sponsorships_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Article::SponsorshipsTest < ApplicationSystemTestCase
+  test 'show listing sponsorship articles' do
+    visit_with_auth sponsorships_path, 'komagata'
+    assert_selector '.thumbnail-card__inner', count: 1
+    click_link_or_button 'ブログ記事のブランクアイキャッチ画像'
+    assert_text 'sponsorshipページに表示される記事です。'
+  end
+end

--- a/test/system/article/sponsorships_test.rb
+++ b/test/system/article/sponsorships_test.rb
@@ -3,10 +3,13 @@
 require 'application_system_test_case'
 
 class Article::SponsorshipsTest < ApplicationSystemTestCase
-  test 'show listing sponsorship articles' do
+  test 'show listing only sponsorship articles' do
     visit_with_auth sponsorships_path, 'komagata'
     assert_selector '.thumbnail-card__inner', count: 1
+    assert_no_text 'タイトル１'
+    assert_no_text 'タイトル２'
+    assert_text 'sponsorshipページに表示される記事のタイトルです。'
     click_link_or_button 'ブログ記事のブランクアイキャッチ画像'
-    assert_text 'sponsorshipページに表示される記事です。'
+    assert_text 'sponsorshipページに表示される記事の本文です。'
   end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/8254

## 概要
+ `/sponsorships`ページを新規に追加し、`sponsorship`タグの付いたブログ記事を1ページ当たり最新12個表示。
ログインしていない状態でも該当のページを閲覧可能。

## 変更確認方法

1. `feature/create-sponsorships-page`をローカルに取り込む。
   1. `git fetch origin feature/create-sponsorships-page`
   2. `git checkout feature/create-sponsorships-page`
2. `rails db:seed`を実行して`sponsorship`タグのブログ記事の初期データを追加する。
3. foreman start -f Procfile.devで[ローカル環境](http://localhost:3000/)を立ち上げる。
4. 未ログイン状態でヘッダー部の[ブログ](http://localhost:3000/articles)をクリックする。
   1. 全ての記事が表示されていることを確認する。
![image](https://github.com/user-attachments/assets/acc0b120-def5-455d-b60c-6075a8f17d6f)

5. 未ログイン状態で[`/sponsorships`](http://localhost:3000/sponsorships)ページへアクセスする
   1. 以下の画面キャプチャのような`Sponsorships`サムネイル画像の記事のみが表示されることを確認する。
![image](https://github.com/user-attachments/assets/2753a733-8c03-49c1-89d7-dcf742899903)

6. ユーザー名 `komagata` パスワード `testtest` でログインする。
7. ログイン状態で[`/sponsorships`](http://localhost:3000/sponsorships)ページへアクセスする
   1. 以下の画面キャプチャのような`Sponsorships`サムネイル画像の記事のみが表示されることを確認する。
![image](https://github.com/user-attachments/assets/76d01f99-6c30-44be-8875-ff0af0318921)


## Screenshot

### 変更前
+  `/sponsorships`ページへのアクセス
![image](https://github.com/user-attachments/assets/f5309f41-9571-4f2d-a503-f49a50b75c5f)

+ フッター（ログイン前）
![image](https://github.com/user-attachments/assets/e3367c64-192f-4fbd-9bf8-247fea5f6507)


### 変更後
+  `/sponsorships`ページへのアクセス
![image](https://github.com/user-attachments/assets/2753a733-8c03-49c1-89d7-dcf742899903)

+ フッター（ログイン前）
![image](https://github.com/user-attachments/assets/b6151009-6b75-4090-b179-2e0e1b02c93c)

