### PR TITLE
模範解答がないときにページとタブを非表示にした

### DIFF
--- a/app/controllers/practices/submission_answer_controller.rb
+++ b/app/controllers/practices/submission_answer_controller.rb
@@ -6,6 +6,7 @@ class Practices::SubmissionAnswerController < ApplicationController
   def show
     @practice = Practice.find(params[:practice_id])
     @submission_answer = @practice.submission_answer
+    raise ActiveRecord::RecordNotFound if @submission_answer.nil?
   end
 
   private

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -9,7 +9,7 @@ module PageTabs
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
       tabs << { name: '提出物', link: practice_products_path(practice) }
-      tabs << { name: '模範解答', link: practice_submission_answer_path(practice) }
+      tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?
       tabs << { name: 'コーディングテスト', link: practice_coding_tests_path(practice) } if practice.coding_tests.present?
       render PageTabsComponent.new(tabs:, active_tab:)
     end


### PR DESCRIPTION
模範解答がない場合のページがおかしな表示になっているため。

Fixed: #8341 #8342