### PR TITLE
入って1週間のユーザーにはメンターにしか表示されないマークを表示する

### DIFF
--- a/app/components/products/product_component.html.slim
+++ b/app/components/products/product_component.html.slim
@@ -3,7 +3,7 @@
     - if @display_user_icon
       .card-list-item__user
         = link_to user_url(@product.user), class: "card-list-item__user-link" do
-          span class=["a-user-role", role_class]
+          span class=["a-user-role", role_class(user: @product.user)]
             = image_tag @product.user.avatar_url,
               class: "card-list-item__user-icon a-user-icon",
               title: @product.user.icon_title,
@@ -105,7 +105,7 @@
                       | 〜 #{l(@product.mentor_last_commented_at)}（メンター）
 
 
-      - if (@is_mentor || @is_admin) && @product.user.primary_role == 'trainee'
+      - if (@is_mentor || @is_admin) && @product.user.primary_role(user: @product.user) == 'trainee'
         .card-list-item__row
           .card-list-item-meta__items
             .card-list-item-meta__item

--- a/app/components/products/product_component.rb
+++ b/app/components/products/product_component.rb
@@ -11,8 +11,8 @@ class Products::ProductComponent < ViewComponent::Base
     @display_user_icon = display_user_icon
   end
 
-  def role_class
-    "is-#{@product.user.primary_role}"
+  def role_class(user: helpers.current_user)
+    "is-#{@product.user.primary_role(user:)}"
   end
 
   def practice_title

--- a/app/components/works/work_component.html.slim
+++ b/app/components/works/work_component.html.slim
@@ -14,7 +14,7 @@
             .thumbnail-card__author
               .thumbnail-card__icon
                 = link_to user_path(work.user) do
-                  span class="a-user-role is-#{work.user.primary_role}"
+                  span class="a-user-role is-#{work.user.primary_role(user: work.user)}"
                     = creator_avatar
               .thumbnail-card__user
                 = link_to work.user.name, user_path(work.user), class: 'a-user-name'

--- a/app/decorators/user_decorator/role.rb
+++ b/app/decorators/user_decorator/role.rb
@@ -2,7 +2,7 @@
 
 module UserDecorator
   module Role
-    def roles
+    def roles(user: current_user)
       role_list = [
         { role: 'retired', value: retired? },
         { role: 'hibernationed', value: hibernated? },
@@ -15,12 +15,13 @@ module UserDecorator
       roles = role_list.find_all { |v| v[:value] }
                        .map { |v| v[:role] }
       roles << :student if roles.empty?
+      roles.unshift('new-user') if user&.mentor? && (roles & %i[student trainee]).any? && elapsed_days <= 7
 
       roles
     end
 
-    def primary_role
-      roles.first
+    def primary_role(user: current_user)
+      roles(user:).first
     end
 
     def staff_roles
@@ -34,8 +35,8 @@ module UserDecorator
                  .join('、')
     end
 
-    def roles_to_s
-      return '' if roles.empty?
+    def roles_to_s(user: current_user)
+      return '' if roles(user:).empty?
 
       roles = [
         { role: '退会ユーザー', value: retired? },

--- a/app/views/activity_mailer/signed_up.html.slim
+++ b/app/views/activity_mailer/signed_up.html.slim
@@ -1,4 +1,4 @@
 = render '/notification_mailer/notification_mailer_template',
-title: "#{@sender.login_name}さん#{@sender.roles_to_s.empty? ? '' : "(#{@sender.roles_to_s})"}が#{@course_name}コースに入会しました！",
+title: "#{@sender.login_name}さん#{@sender.roles_to_s(user: @sender).empty? ? '' : "(#{@sender.roles_to_s})"}が#{@course_name}コースに入会しました！",
 link_url: @link_url, link_text: "#{@sender.login_name}さんのページへ" do
   = md2html(@sender.description)

--- a/app/views/users/_icon.html.slim
+++ b/app/views/users/_icon.html.slim
@@ -9,5 +9,5 @@ ruby:
     class: user.icon_classes(image_class)
   }
 = link_to user, link_options do
-  span class="a-user-role is-#{user.primary_role}"
+  span class="a-user-role is-#{user.primary_role(user:)}"
     = image_tag user.avatar_url, image_options

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -393,6 +393,7 @@ ja:
   target:
     student_and_trainee: 現役 + 研修生
     student: 現役生
+    new-user: 新入生
     job_seeking: 就職活動中
     hibernationed: 休会中
     mentor: メンター

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -325,7 +325,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
     params = {
       sender: user,
       receiver: users(:komagata),
-      sender_roles: user.roles_to_s
+      sender_roles: user.roles_to_s(user:)
     }
 
     assert_difference -> { AbstractNotifier::Testing::Driver.deliveries.count }, 1 do

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -154,7 +154,7 @@ class ActivityMailerPreview < ActionMailer::Preview
     sender = ActiveDecorator::Decorator.instance.decorate(User.find(ActiveRecord::FixtureSet.identify(:hajime)))
     receiver = User.find(ActiveRecord::FixtureSet.identify(:komagata))
 
-    ActivityMailer.with(sender:, receiver:, sender_roles: sender.roles_to_s).signed_up
+    ActivityMailer.with(sender:, receiver:, sender_roles: sender.roles_to_s(user: sender)).signed_up
   end
 
   def chose_correct_answer

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -20,7 +20,7 @@ class GenerationsTest < ApplicationSystemTestCase
     assert_text 'ユーザー一覧'
     assert_link "#{users(:otameshi).generation}期生"
     within all('.a-user-icons__items').first do
-      within first('.a-user-role.is-student') do
+      within first('.a-user-role.is-student, .a-user-role.is-new-user') do
         assert_equal first('img')['class'], 'a-user-icons__item-icon a-user-icon'
       end
     end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -692,7 +692,7 @@ class UsersTest < ApplicationSystemTestCase
     filtered_users = all('.users-item__icon .a-user-role')
     assert(filtered_users.all? do |user|
       classes = user[:class].split(' ')
-      classes.include?('is-student') || classes.include?('is-trainee')
+      classes.include?('is-student') || classes.include?('is-trainee') || classes.include?('is-new-user')
     end)
   end
 
@@ -702,7 +702,10 @@ class UsersTest < ApplicationSystemTestCase
 
     assert_selector('a.tab-nav__item-link.is-active', text: '現役生')
     filtered_users = all('.users-item__icon .a-user-role')
-    assert(filtered_users.all? { |user| user[:class].split(' ').include?('is-student') })
+    assert(filtered_users.all? do |user|
+      classes = user[:class].split(' ')
+      classes.include?('is-student') || classes.include?('is-new-user')
+    end)
   end
 
   test 'can not upload broken image as user avatar' do


### PR DESCRIPTION
## Issue

- [入って1週間のユーザーにはメンターにしか表示されないマークを表示する。 #8269](https://github.com/fjordllc/bootcamp/issues/8269)

## 概要
ログインしているユーザーがメンターの場合に、入会して1週間以内の現役生と研修生のアイコンのclassに`is-new-user`を追加しました。ユーザーアイコンのclassは、view側で`is-#{user.primary_role}`と定義されているので、`primary_role`から`new-user`を戻り値にして、`is-new-user`を生成しています。

`is-#{user.primary_role}`のclassを使ってユーザーアイコンの縁を色で囲むことができます。例えば、現在の実装では、`is-graduate`の場合には緑色で囲まれていたり、`is-trainee`の場合は黄色で囲まれています。そのため、`is-new-user`の場合にも、同様に何かしらの色で囲むことができます。

また、プロフィールページでは、`is-graduate`のclassを持つユーザーは卒業生、`is-trainee`を持つユーザーは研修生と表示されるので、`is-new-user`のクラスを持つユーザーは、プロフィールページに「新入生」と表示させるようにしました。

## 変更確認方法

1. `feature/add-mark-to-new-user`をローカルに取り込む
 i. `git fetch origin feature/add-mark-to-new-user`
 ii. `git checkout feature/add-mark-to-new-user`
2. メンター
3.  

## Screenshot

### 変更前

### 変更後

