### PR TITLE
プレスキットページ内に最新のプレスリリース記事を６つまで表示し、プレスリリース記事の一覧表示ページを作成

### DIFF
--- a/app/controllers/press_releases_controller.rb
+++ b/app/controllers/press_releases_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class PressReleasesController < ApplicationController
+  skip_before_action :require_active_user_login, raise: false, only: %i[index]
+
+  layout 'lp'
+
+  def index
+    @press_releases = Article.press_releases.page(params[:page])
+  end
+end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -46,7 +46,9 @@ class WelcomeController < ApplicationController
 
   def coc; end
 
-  def press_kit; end
+  def press_kit
+    @press_releases = Article.press_releases(6)
+  end
 
   def logo; end
 

--- a/app/javascript/stylesheets/_common-imports.sass
+++ b/app/javascript/stylesheets/_common-imports.sass
@@ -204,5 +204,6 @@
 @import shared/blocks/form/vue-tags-input
 @import shared/blocks/form/form-textarea
 @import shared/blocks/form/form-table
+@import shared/blocks/o-empty-message
 
-@import "shared/helpers/state"
+@import shared/helpers/state

--- a/app/javascript/stylesheets/shared/blocks/_o-empty-message.sass
+++ b/app/javascript/stylesheets/shared/blocks/_o-empty-message.sass
@@ -1,0 +1,15 @@
+.o-empty-message
+  max-width: 50rem
+  margin-inline: auto
+  text-align: center
+  color: var(--semi-muted-text)
+  &:not(:first-child)
+    margin-top: 1.5rem
+
+.o-empty-message__icon
+  +text-block(5rem 1)
+
+.o-empty-message__text
+  +text-block(1rem 1.4)
+  margin-top: 1em
+  text-align: center

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -48,6 +48,13 @@ class Article < ApplicationRecord
     with_attached_thumbnail.includes(user: { avatar_attachment: :blob }).where(wip: false)
   }
   scope :alumni_voices, -> { with_attachments_and_user.tagged_with('卒業生の声').order(published_at: :desc) }
+  scope :press_releases, lambda { |limit = nil|
+    where(wip: false)
+      .tagged_with('プレスリリース')
+      .includes(%i[user thumbnail_attachment])
+      .order(published_at: :desc)
+      .limit(limit)
+  }
 
   def prepared_thumbnail_url(thumbnail_size = THUMBNAIL_SIZE)
     if thumbnail.attached?

--- a/app/views/press_releases/_press_releases.html.slim
+++ b/app/views/press_releases/_press_releases.html.slim
@@ -1,0 +1,37 @@
+header.lp-page-header
+  .l-container
+    .lp-page-header__inner
+      .lp-page-header__start
+        h1.lp-page-header__title
+          = title
+hr.a-border-tint
+
+.lp-page-body
+  .articles
+    .articles__body
+      .articles__items
+        = paginate press_releases
+        .container.is-xl
+          .row
+            - press_releases.each do |press_release|
+              .col-lg-4.col-md-6.col-xs-12
+                .thumbnail-card.a-card
+                  = link_to press_release, class: 'thumbnail-card__inner' do
+                    .thumbnail-card__row
+                      - if press_release.prepared_thumbnail?
+                        = image_tag press_release.prepared_thumbnail_url, class: 'thumbnail-card__image', alt: "ブログ記事「#{press_release.title}」のアイキャッチ画像"
+                      - else
+                        = image_tag(press_release.selected_thumbnail_url, class: 'thumbnail-card__image', alt: 'ブログ記事のブランクアイキャッチ画像')
+                    .thumbnail-card__row
+                      h2.thumbnail-card__title
+                        = press_release.title
+                    .thumbnail-card__row
+                      .thumbnail-card__metas
+                        .thumbnail-card__meta
+                          .thumbnail-card__author
+                            = image_tag press_release.user.avatar_url
+                            = press_release.user.login_name
+                        .thumbnail-card__meta
+                          .thumbnail-card__date
+                              = l(press_release.published_at)
+        = paginate press_releases

--- a/app/views/press_releases/index.html.slim
+++ b/app/views/press_releases/index.html.slim
@@ -1,0 +1,5 @@
+ruby:
+  title 'プレスリリース'
+  set_meta_tags(site: 'FJORD BOOT CAMP（フィヨルドブートキャンプ）')
+  description 'オンラインプログラミングフィヨルドブートキャンプのプレスリリース一覧ページです。'
+= render 'press_releases', { press_releases: @press_releases }

--- a/app/views/welcome/press_kit.html.slim
+++ b/app/views/welcome/press_kit.html.slim
@@ -76,3 +76,52 @@ hr.a-border
                     li
                       = link_to 'https://x.com/fjordbootcamp', class: 'a-text-link' do
                         | X
+    .lp-content-divider.is-lp-bg-2
+      svg[data-name="lp-content-divider" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none"]
+        path.shape-fill d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
+  .lp-content.is-lp-bg-2.is-top-title
+    .l-container.is-xl
+      .lp-content__inner
+        .lp-content__start
+          header.lp-content__header
+            h2.lp-content-title.text-center.is-border-bottom
+              | 最新のプレスリリース
+        .lp-content__end
+          .lp-content-stack
+            - if @press_releases.present?
+              .lp-content-stack__item
+                .row
+                  - @press_releases.each do |press_release|
+                    .col-lg-4.col-md-6.col-xs-12
+                      .thumbnail-card.a-card
+                        = link_to press_release, class: 'thumbnail-card__inner' do
+                          .thumbnail-card__row
+                            - if press_release.prepared_thumbnail?
+                              = image_tag press_release.prepared_thumbnail_url, class: 'thumbnail-card__image', alt: "ブログ記事「#{press_release.title}」のアイキャッチ画像"
+                            - else
+                              = image_tag press_release.selected_thumbnail_url, class: 'thumbnail-card__image', alt: 'ブログ記事のブランクアイキャッチ画像'
+                          .thumbnail-card__row
+                            h3.thumbnail-card__title
+                              = press_release.title
+                          .thumbnail-card__row
+                            .thumbnail-card__metas
+                              .thumbnail-card__meta
+                                .thumbnail-card__author
+                                  = image_tag press_release.user.avatar_url
+                                  = press_release.user.login_name
+                              .thumbnail-card__meta
+                                .thumbnail-card__date
+                                  = l(press_release.published_at)
+              .lp-content-stack__item
+                .lp-actions
+                  .lp-actions__items
+                    .lp-actions__item
+                      = link_to press_releases_path, class: 'a-button is-xl is-primary-border is-block' do
+                        | 全てのプレスリリース
+            - else
+              .lp-content-stack__item
+                .o-empty-message
+                  .o-empty-message__icon
+                    i.fa-regular.fa-sad-tear
+                  .o-empty-message__text
+                    | プレスリリースはまだありません。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
       get :created
     end
   end
+  resources :press_releases, only: %i(index)
   get "articles/tags/:tag", to: "articles#index", as: :tag, tag: /.+/
   get 'sponsorships', to: 'articles/sponsorships#index'
   get "pages/tags/:tag", to: "pages#index", as: :pages_tag, tag: /.+/, format: "html"

--- a/db/fixtures/acts_as_taggable_on/taggings.yml
+++ b/db/fixtures/acts_as_taggable_on/taggings.yml
@@ -122,3 +122,10 @@ article58_tag_alumni_voice:
   taggable: article58 (Article)
   context: tags
   tag: alumni_voice
+
+<% (101..130).each do |id| %>
+article<%= id %>_tag_press_release:
+  taggable: article<%= id %> (Article)
+  context: tags
+  tag: press_release
+<% end %>

--- a/db/fixtures/acts_as_taggable_on/tags.yml
+++ b/db/fixtures/acts_as_taggable_on/tags.yml
@@ -27,3 +27,6 @@ may_j_:
 
 alumni_voice:
   name: 卒業生の声
+
+press_release:
+  name: プレスリリース

--- a/db/fixtures/articles.yml
+++ b/db/fixtures/articles.yml
@@ -132,3 +132,13 @@ article58:
   wip: false
   published_at: "2024-03-12 00:00:00"
 
+<% date = Date.parse("2023-01-01") %>
+<% (101..130).each do |id| %>
+article<%= id %>:
+  <% number = id - 100 %>
+  title: プレスリリース<%= number %>
+  body: 「プレスリリース」タグを持つブログ
+  user: komagata
+  wip: false
+  published_at: <%= "#{date + number} 00:00:00" %>
+<% end %>

--- a/db/migrate/20240321092012_create_movies.rb
+++ b/db/migrate/20240321092012_create_movies.rb
@@ -3,7 +3,9 @@ class CreateMovies < ActiveRecord::Migration[6.1]
     create_table :movies do |t|
       t.string :title , null: false
       t.text :description
-      t.references :user, foreign_key: true, null: true
+      t.string :tag_list
+      t.references :user, foreign_key: true, null: false
+      t.references :practice, foreign_key: true
 
       t.timestamps
     end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -22,3 +22,11 @@ article3:
   thumbnail_type: :prepared_thumbnail
   token: abcdef123456
   target: :all
+
+article4:
+  title: sponsorshipページに表示される記事のタイトルです。
+  body: sponsorshipページに表示される記事の本文です。
+  user: komagata
+  wip: false
+  published_at: '2022-01-01 00:00:00'
+  thumbnail_type: :sponsorship

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -13,6 +13,119 @@ class ArticleTest < ActiveSupport::TestCase
     end
   end
 
+  test '.press_release includes only not wip articles with press release tag' do
+    article1 = Article.create(
+      title: 'プレスリリースタグのみを持つブログ',
+      body: 'test',
+      user: users(:komagata),
+      wip: false
+    )
+    article1.tag_list.add('プレスリリース')
+    article1.save
+
+    article2 = Article.create(
+      title: '2つのタグを持つブログ',
+      body: 'test',
+      user: users(:komagata),
+      wip: false
+    )
+    article2.tag_list.add('test', 'プレスリリース')
+    article2.save
+
+    wip_article = Article.create(
+      title: 'プレスリリースタグを持つwipブログ',
+      body: 'test',
+      user: users(:komagata),
+      wip: true
+    )
+    wip_article.tag_list.add('プレスリリース')
+    wip_article.save
+
+    press_releases = Article.press_releases
+    assert_equal [article2, article1], press_releases
+    press_releases.each do |press_release|
+      assert_includes press_release.tag_list, 'プレスリリース'
+      assert_not press_release.wip
+    end
+  end
+
+  test '.press_release orders by published_at in descending order' do
+    three_days_ago_press_release = Article.create(
+      title: '3日前に公開されたプレスリリース',
+      body: 'test',
+      user: users(:komagata),
+      wip: false,
+      created_at: Date.current - 4.days,
+      updated_at: Date.current - 4.days,
+      published_at: Date.current - 3.days
+    )
+    three_days_ago_press_release.tag_list.add('プレスリリース')
+    three_days_ago_press_release.save
+
+    two_days_ago_press_release = Article.create(
+      title: '2日前に公開されたプレスリリース',
+      body: 'test',
+      user: users(:komagata),
+      wip: false,
+      created_at: Date.current - 5.days,
+      updated_at: Date.current - 5.days,
+      published_at: Date.current - 2.days
+    )
+    two_days_ago_press_release.tag_list.add('プレスリリース')
+    two_days_ago_press_release.save
+
+    one_day_ago_press_release = Article.create(
+      title: '1日前に公開されたプレスリリース',
+      body: 'test',
+      user: users(:komagata),
+      wip: false,
+      created_at: Date.current - 6.days,
+      updated_at: Date.current - 6.days,
+      published_at: Date.current - 1.day
+    )
+    one_day_ago_press_release.tag_list.add('プレスリリース')
+    one_day_ago_press_release.save
+
+    press_releases = Article.press_releases
+    assert_equal [one_day_ago_press_release, two_days_ago_press_release, three_days_ago_press_release], press_releases
+  end
+
+  test '.press_release return all records when no limit is specified' do
+    records_count = 10
+    records_count.times do |i|
+      press_release = Article.create(
+        title: "press releases #{i}",
+        body: 'プレスリリースのタグを持つブログ記事',
+        user: users(:komagata),
+        wip: false,
+        published_at: "2022-1-1 00:00:#{i}"
+      )
+      press_release.tag_list.add('プレスリリース')
+      press_release.save
+    end
+
+    press_releases = Article.press_releases
+    assert_equal records_count, press_releases.length
+  end
+
+  test '.press_release return the specified number of records by limit' do
+    10.times do |i|
+      press_release = Article.create(
+        title: "press releases #{i}",
+        body: 'プレスリリースのタグを持つブログ記事',
+        user: users(:komagata),
+        wip: false,
+        published_at: "2022-1-1 00:00:#{i}"
+      )
+      press_release.tag_list.add('プレスリリース')
+      press_release.save
+    end
+
+    limit = 5
+    press_releases = Article.press_releases(limit)
+    assert_equal limit, press_releases.length
+  end
+
   test '#prepared_thumbnail_url' do
     article = articles(:article3)
     assert_equal '/ogp/blank.svg', article.prepared_thumbnail_url

--- a/test/system/press_kit_test.rb
+++ b/test/system/press_kit_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class PressKitTest < ApplicationSystemTestCase
+  test 'show listing press kit' do
+    visit press_kit_url
+    assert_equal 'プレスキット | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+  end
+end

--- a/test/system/press_releases_test.rb
+++ b/test/system/press_releases_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class PressReleasesTest < ApplicationSystemTestCase
+  test 'show listing press releases' do
+    visit press_releases_path
+    assert_equal 'プレスリリース | FJORD BOOT CAMP（フィヨルドブートキャンプ）', title
+  end
+end


### PR DESCRIPTION
## Issue

- [#8242 プレスキットのページにブログ記事の「プレスリリース」タグを持つ最新の記事（公開済のもの）を6個を表示させる。](https://github.com/fjordllc/bootcamp/issues/8242)

## 概要

プレスキットのページ内に、プレスリリースタグを持つブログ記事を最大６つまで表示するようにしました。
また「全てのプレスリリース」ボタンを押すと、プレスリリースタグを持つブログ記事の一覧表示されるページにアクセスするようにしました。

## 変更確認方法

1.  `feature/show_latest_press_release_articles_in_presskit` をローカルに取り込む
  i.  `git fetch origin pull/8350/head:feature/show_latest_press_release_articles_in_presskit`
  ii.  `git checkout feature/show_latest_press_release_articles_in_presskit`
2. `bin/rails db:migrate RAILS_ENV=test `でfixtureのデータをDBに取り入れる
3.  `foreman start -f Procfile.dev` でローカルサーバーを立ち上げる
4.  [プレスキット](http://localhost:3000/press_kit)にアクセスする
5. 最新のプレスリリースとして６つブログ記事が表示されていることを確認する

<img width="1034" alt="スクリーンショット 2025-03-12 18 59 40" src="https://github.com/user-attachments/assets/9de40697-0289-4d4b-80dc-dbf74b52b10b" />

6. 上記画像の下部の「全てのプレスリリース」ボタンを押し、[プレスリリース一覧ページ](http://localhost:3000/press_releases)にアクセスできることを確認する
7. 全てのプレスリリース記事（３０個）が表示されていることを確認する

<img width="1453" alt="スクリーンショット 2025-03-12 19 02 27" src="https://github.com/user-attachments/assets/951a8bb6-31e6-4585-84f9-272c7f70ed31" />


## Screenshot

### 変更前

![スクリーンショット 2025-03-12 19 04 19](https://github.com/user-attachments/assets/702ae781-8a6c-4605-a06e-4eb93ab4a871)


### 変更後

<img width="1034" alt="スクリーンショット 2025-03-12 18 59 40" src="https://github.com/user-attachments/assets/06ea6073-863a-4eef-977d-d49ce0ca5533" />

<img width="1453" alt="スクリーンショット 2025-03-12 19 02 27" src="https://github.com/user-attachments/assets/83a2a0e4-db84-4ea8-9afb-7fe74c5173e4" />

