### PR TITLE
「終了条件」を「修了条件」に修正

### DIFF
--- a/app/javascript/learning-status.vue
+++ b/app/javascript/learning-status.vue
@@ -30,7 +30,7 @@
           | 修了
   .practice-status-buttons__end(v-if='submission === "false"')
     .practice-status-buttons__note
-      | このプラクティスに提出物はありません。終了条件をクリアしたら修了にしてください。
+      | このプラクティスに提出物はありません。修了条件をクリアしたら修了にしてください。
 </template>
 <script>
 import 'whatwg-fetch'


### PR DESCRIPTION
## Issue

#8358 

## 概要

提出物が不要なプラクティスにおいて、ページ上部のステータス欄直下の文字列に含まれていた誤字を修正した。

## 変更確認方法
1.リモートリポジトリをローカルに取り込む。
`git fetch origin chore/replace-end-to-mastering`
`git checkout chore/replace-end-to-mastering`

2.ローカル環境を起動してログインを行う。
`foreman start -f Procfile.dev`で[ローカル環境](http://localhost:3000/)を立ち上げる。
ユーザー名 `komagata` パスワード `testtest` でログインする。

3.問題の箇所が修正されていることを確かめる。
[PC性能の見方を知る](http://localhost:3000/practices/1019809339)にアクセスする。（提出物が不要なプラクティスならどこでも可）
「このプラクティスに提出物はありません。終了条件をクリアしたら修了にしてください。」が「このプラクティスに提出物はありません。修了条件をクリアしたら修了にしてください。」に修正されていることを確認する。

## Screenshot

### 変更前
![2025-02-21_16-31](https://github.com/user-attachments/assets/6846739f-8d48-4376-9fd2-de7952f669fa)


### 変更後
![2025-02-21_16-23](https://github.com/user-attachments/assets/c3a66639-bdb9-49fc-a53c-b3d7de1996fd)
