### PR TITLE
模範解答作成ボタンを提出物確認ページに追加

### DIFF
--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -16,6 +16,11 @@ header.page-header
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items
+            - if current_user.admin?
+              li.page-header-actions__item.is-only-mentor
+                = link_to new_product_path(practice_id: @product.practice.id), class: 'a-button is-md is-secondary is-block' do
+                  i.fa-regular.fa-plus
+                  | 模範解答作成
             li.page-header-actions__item
               = link_to course_practices_path(current_user.course, anchor: "category-#{category.id}"),
                 class: 'a-button is-md is-secondary is-block is-back' do

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -16,11 +16,12 @@ header.page-header
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items
-            - if current_user.admin?
-              li.page-header-actions__item.is-only-mentor
-                = link_to new_product_path(practice_id: @product.practice.id), class: 'a-button is-md is-secondary is-block' do
+            - if current_user.mentor? && @practice.submission && !@practice.submission_answer
+              li.page-header-actions__item.is-hidden-sm-down.is-only-mentor
+                = link_to new_mentor_practice_submission_answer_path(@practice), class: 'a-button is-md is-secondary is-block' do
                   i.fa-regular.fa-plus
-                  | 模範解答作成
+                  span
+                    | 模範解答作成
             li.page-header-actions__item
               = link_to course_practices_path(current_user.course, anchor: "category-#{category.id}"),
                 class: 'a-button is-md is-secondary is-block is-back' do


### PR DESCRIPTION
## Issue

#8351 

## 概要

提出物の確認ページの右上に「模範解答作成」ボタンを追加しました。

## 変更確認方法

1.`feature/add-model-answer-button`ブランチをローカルに取り込む。
　・`git fetch origin feature/add-model-answer-button`
　・`git checkout feature/add-model-answer-button`
2.`foreman start -f Procfile.dev`で開発環境を立ち上げる。
　・ユーザー名`komagata`、パスワード`testtest`でログインする。
3.任意の[提出物確認ページ](http://localhost:3000/products/90577869)に移動する。
4.右上に「模範解答作成」ボタンが設置されていることを確認する。

## Screenshot

### 変更前
![2025-03-05_10-36](https://github.com/user-attachments/assets/bb4c4563-36b1-4a95-a853-b399591bb221)

### 変更後
![2025-03-05_10-27](https://github.com/user-attachments/assets/4ba36704-220b-4457-bbdd-8fa8f122b2ac)