### PR TITLE
日報コピー時の気分ステータスの引き継ぎを無効化

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -40,7 +40,6 @@ class ReportsController < ApplicationController
 
     report              = current_user.reports.find(params[:id])
     @report.title       = report.title
-    @report.emotion = report.emotion
     @report.description = "<!-- #{report.reported_on} の日報をコピー -->\n" + report.description
     @report.practices   = report.practices
     flash.now[:notice] = '日報をコピーしました。'


### PR DESCRIPTION
## Issue

- #8383 

## 概要

日報コピー時に、コピー元の日報の気分ステータスを引き継がないようにした。

## 変更確認方法

1. `chore/disable-emotion-copy`をローカルに取り込む
    1. `git fetch origin chore/disable-emotion-copy`
    2. `git switch chore/disable-emotion-copy`
2. `foreman start -f Procfile.dev`でローカルサーバーを起動する
3. ユーザー名hatsuno、パスワードtesttestでログインする
4. [自分の日報一覧ページ](http://localhost:3000/current_user/reports)にアクセスする
5. 気分がhappyでない日報（[2日目 昨日よりできなかった \| FBC](http://localhost:3000/reports/469634013)）の詳細ページを開く
6. [コピーボタン](http://localhost:3000/reports/new?id=469634013) をクリックする
7. 今日の気分が【happy】に選択されていることを確認する
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d879b7b0-b03e-4684-b01a-e30357ec3974" />



## Screenshot

![image](https://github.com/user-attachments/assets/2a246b4d-4115-4705-a838-aa4ebc5662ea)

### 変更前
![image](https://github.com/user-attachments/assets/aa916741-824c-4bcc-8cad-cb98077fe4c9)

### 変更後
![image](https://github.com/user-attachments/assets/3207c322-f80d-42ca-b1c8-96f07bc79a87)

