### PR TITLE
agentリポジトリとagentカンバンのリンクをフッターに追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -62,6 +62,12 @@ footer.footer
             = link_to 'https://roulette-talk.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | RouletteTalk
           li.footer-nav__item
+            = link_to 'https://github.com/fjordllc/agent', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | agentリポジトリ
+          li.footer-nav__item
+            = link_to 'https://github.com/orgs/fjordllc/projects/4/views/2', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | agentカンバン
+          li.footer-nav__item
             = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
               i.fa-solid.fa-rss
       small.footer__copyright


### PR DESCRIPTION
## Issue

- #8387 

## 概要

- [agentリポジトリ](https://github.com/fjordllc/agent)と[agentカンバン](https://github.com/orgs/fjordllc/projects/4/views/2)のリンクをフッターに追加し、クリックすると別タグで開くようにしました

## 変更確認方法

1. `feature/add-agent-repo-kanban-links-footer`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. ログインしてページ下部のフッターに「agentリポジトリ」と「agentカンバン」が追加されていることを確認する

## Screenshot

### 変更前
<img width="875" alt="image" src="https://github.com/user-attachments/assets/2023b8c5-a488-4127-a2c1-1e8943c83a26" />


### 変更後
<img width="884" alt="image" src="https://github.com/user-attachments/assets/0207f9d4-56dc-4b5a-8d69-582fe0a6ce90" />

![2025-03-06131114-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/285ad1f6-5b7e-46a3-a8a7-694fb5974c56)


