### PR TITLE
フッタのリンクの文言変更

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -15,10 +15,10 @@ footer.footer
               | 参考書籍
           li.footer-nav__item
             = link_to 'https://github.com/fjordllc/bootcamp', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
-              | リポジトリ
+              | bootcampリポジトリ
           li.footer-nav__item
             = link_to 'https://github.com/fjordllc/bootcamp/projects/1', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
-              | GitHub Projects
+              | bootcampカンバン
           li.footer-nav__item
             = link_to 'https://suzuri.jp/FjordBootCamp', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | グッズ購入


### PR DESCRIPTION
## Issue

- #8386

## 概要
フッタのリンクの文言を以下のように修正しました。
- `リポジトリ` → `bootcampリポジトリ`
- `GitHub Projects` → `bootcampカンバン`

## 変更確認方法

1. ブランチ`chore/changed-footer-link-wording`をローカルに取り込む
    1. `git fetch origin chore/changed-footer-link-wording`
    2. `git switch chore/changed-footer-link-wording`
2.`foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. ユーザー名`hatsuno`、パスワード`testtest`でログインする
4. Screenshotの「変更後」のように、赤枠の内容に修正されていることを確認する

## Screenshot

### 変更前
<img width="617" alt="Image" src="https://github.com/user-attachments/assets/ce06d4e2-eb2a-47eb-969e-71ad67bcf6b8" />

### 変更後
<img width="617" alt="Image" src="https://github.com/user-attachments/assets/c5d39c70-81fa-4122-a78a-2fd277031468"/>

