### PR TITLE
`questions_test.rb`の誤字を修正

### DIFF
--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -21,7 +21,7 @@ class QuestionsTest < ApplicationSystemTestCase
     assert_equal '全てのQ&A | FBC', title
   end
 
-  test 'show a resolved qestion' do
+  test 'show a resolved question' do
     question = questions(:question3)
     visit_with_auth question_path(question), 'kimura'
     assert_text '解決済'


### PR DESCRIPTION
## Issue

- #8385

## 概要
`questions_test.rb`内の`show a resolved qestion`というテスト名を`show a resolved question`に修正しました

## 変更確認方法

1. ブランチ`chore/fixed-typo-in-questions-test`をローカルに取り込む
2. `test/system/question_test.rb`のファイルを開く
3. Screenshotの「変更後」のように、赤線の内容に修正されていることを確認する

## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/8dfe00cd-9c50-4e57-be41-f13d0bb981b2)

### 変更後
![image](https://github.com/user-attachments/assets/1acee5d9-9155-41e6-b458-cf727f83ccb1)

