### PR TITLE
フッターにYoutubeチャンネルのリンクを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -68,7 +68,7 @@ footer.footer
             = link_to 'https://github.com/orgs/fjordllc/projects/4/views/2', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | agentカンバン
           li.footer-nav__item
-            = link_to 'https://www.youtube.com/@%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%89%E3%83%96%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%97', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+            = link_to 'https://www.youtube.com/@フィヨルドブートキャンプ', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | YouTubeチャンネル
           li.footer-nav__item
             = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do

--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -68,6 +68,9 @@ footer.footer
             = link_to 'https://github.com/orgs/fjordllc/projects/4/views/2', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | agentカンバン
           li.footer-nav__item
+            = link_to 'https://www.youtube.com/@%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%89%E3%83%96%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%97', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | YouTubeチャンネル
+          li.footer-nav__item
             = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
               i.fa-solid.fa-rss
       small.footer__copyright


### PR DESCRIPTION
## Issue
- #8388 


## 概要

- [Youtubeチャンネル](https://www.youtube.com/@%E3%83%95%E3%82%A3%E3%83%A8%E3%83%AB%E3%83%89%E3%83%96%E3%83%BC%E3%83%88%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%97)のリンクをフッターに追加し、クリックすると別タグで開くようにしました

## 変更確認方法

1. `feature/add-youtube-link-to-footer`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. ログインしてページ下部のフッターに「Youtubeチャンネル」が追加されていることを確認する

## Screenshot

### 変更前
<img width="906" alt="image" src="https://github.com/user-attachments/assets/d47c3671-9c2d-4fb2-8759-67d62b634386" />

### 変更後
<img width="908" alt="image" src="https://github.com/user-attachments/assets/7292bfa0-b9fe-4b54-88a2-36217c98abeb" />

![2025-03-07134931-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/e87e2fb7-777d-4ccd-b77c-6dcf0758ccc1)
