### PR TITLE
プラクティス削除を実装

### DIFF
--- a/app/controllers/mentor/practices_controller.rb
+++ b/app/controllers/mentor/practices_controller.rb
@@ -2,9 +2,9 @@
 
 class Mentor::PracticesController < ApplicationController
   PER_PAGE = 50
-  before_action :require_admin_or_mentor_login, only: %i[index new create edit update]
+  before_action :require_admin_or_mentor_login, only: %i[index new create edit update destroy]
   before_action :set_course, only: %i[new]
-  before_action :set_practice, only: %i[edit update]
+  before_action :set_practice, only: %i[edit update destroy]
 
   def index
     @practices = Practice.for_mentor_index.page(params[:page]).per(PER_PAGE)
@@ -33,6 +33,16 @@ class Mentor::PracticesController < ApplicationController
       redirect_to @practice, notice: 'プラクティスを更新しました。'
     else
       render :edit
+    end
+  end
+
+  def destroy
+    title = @practice.title
+    if @practice.destroy
+      ChatNotifier.message("プラクティス：「#{title}」を#{current_user.login_name}さんが削除しました。")
+      redirect_to mentor_practices_path, notice: 'プラクティスを削除しました。'
+    else
+      redirect_to @practice, alert: 'プラクティスの削除に失敗しました。'
     end
   end
 

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -139,6 +139,10 @@
                       = link_to edit_mentor_practice_path(@practice), class: 'a-button is-sm is-secondary is-block' do
                         i.fa-solid.fa-pen
                         | 編集
+                    li.card-main-actions__item
+                      = link_to mentor_practice_path(@practice), method: :delete, class: 'a-button is-sm is-danger is-block', data: { confirm: '本当にこのプラクティスを削除しますか？この操作は取り消せません。' } do
+                        i.fa-solid.fa-trash
+                        | 削除する
       .col-lg-4.col-xs-12
         nav.page-nav.a-card
           header.page-nav__header

--- a/config/routes/mentor.rb
+++ b/config/routes/mentor.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :categories do
       resources :practices, only: %i(index), controller: "categories/practices"
     end
-    resources :practices, only: %i(index new edit create update) do
+    resources :practices, only: %i(index new edit create update destroy) do
       resource :submission_answer, only: %i(new edit create update), controller: "practices/submission_answer"
     end
     resources :coding_tests, only: %i(index new edit create update destroy)

--- a/test/system/mentor/practices_test.rb
+++ b/test/system/mentor/practices_test.rb
@@ -12,4 +12,52 @@ class Mentor::PracticesTest < ApplicationSystemTestCase
     visit_with_auth mentor_practices_path, 'mentormentaro'
     first('.admin-table__item').assert_text 'sshdでパスワード認証を禁止にする'
   end
+
+  test 'admin can delete practice' do
+    practice = practices(:practice7)
+    visit_with_auth "/practices/#{practice.id}", 'komagata'
+
+    assert_text practice.title
+
+    accept_confirm do
+      click_link '削除する'
+    end
+
+    assert_text 'プラクティスを削除しました。'
+    assert_current_path mentor_practices_path
+
+    assert_no_text practice.title
+  end
+
+  test 'mentor can delete practice' do
+    practice = practices(:practice7)
+    visit_with_auth "/practices/#{practice.id}", 'mentormentaro'
+
+    assert_text practice.title
+
+    accept_confirm do
+      click_link '削除する'
+    end
+
+    assert_text 'プラクティスを削除しました。'
+    assert_current_path mentor_practices_path
+
+    assert_no_text practice.title
+  end
+
+  test 'adviser cannot delete practice' do
+    practice = practices(:practice7)
+    visit_with_auth "/practices/#{practice.id}", 'advijirou'
+
+    assert_text practice.title
+    assert_no_link '削除する'
+  end
+
+  test 'student cannot delete practice' do
+    practice = practices(:practice7)
+    visit_with_auth "/practices/#{practice.id}", 'kimura'
+
+    assert_text practice.title
+    assert_no_link '削除する'
+  end
 end


### PR DESCRIPTION
コピーしたReスキル関連のプラクティスで不要なものがあり、
手で削除するのは関連データがたくさんあり大変なため。
