### PR TITLE
tailwindの設定についてコンポーネントビューを反映

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,11 +2,12 @@
 module.exports = {
   content: [
     './app/views/**/*.html.slim',
-    './app/javascript/**/*.{js,vue,jsx}',
+    './app/components/**/*.html.slim',
+    './app/javascript/**/*.{js,vue,jsx}'
   ],
   theme: {
-    extend: {},
+    extend: {}
   },
   plugins: [],
-  important: true,
+  important: true
 }


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/8408
- https://github.com/fjordllc/bootcamp/issues/8328

## 概要
- `tailwind.config.js`の設定が`components`に適用されるように修正した。
    - `content:`に`'./app/components/**/*.html.slim'`を追加した。
## 変更確認方法

1.  `bug/fix-tailwind-setting`をローカルに取り込む。
    1. `git fetch origin bug/fix-tailwind-setting`
    2. `git checkout bug/fix-tailwind-setting`
2. `foreman start -f Procfile.dev`で[ローカル環境](http://localhost:3000/)を立ち上げる。
3. ユーザー名 komagata パスワード testtest でログインする。
4. ログイン後のトップページにおける左下の提出物に関するコメントを確認する。
5. `padding`（`p-3`）が適用されていることを確認する。
## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/20e02bce-33c9-48e5-86c6-d2dde40686ec)

### 変更後
![image](https://github.com/user-attachments/assets/651fb120-36bd-408c-b96a-81d8d1218a9b)

https://github.com/user-attachments/assets/b7b8f128-1643-43da-8d53-c0fbb1eee4bc

## 補足
- 確認したところバージョンは`v3`でした。バージョンの問題ではなく、`components`への設定が漏れていたことが原因でした。
- [/componentsビューへの設定に関するドキュメント](https://v3.tailwindcss.com/docs/content-configuration#working-with-third-party-libraries)
- [設定の記述に関するドキュメント](https://v3.tailwindcss.com/docs/content-configuration#configuring-source-paths)