### PR TITLE
相談部屋の個別ページに管理者でアクセスした際、ユーザー情報→環境情報のOSの出力がおかしくなるバグを修正

### DIFF
--- a/app/views/users/_metas.html.slim
+++ b/app/views/users/_metas.html.slim
@@ -22,7 +22,7 @@
         | 環境
       .user-metas__item-value
         | OS:
-        = t("activerecord.enums.user.os.#{user.os}") || '回答なし'
+        = user.os.present? ? t("activerecord.enums.user.os.#{user.os}") : '回答なし'
         | 、エディタ:
         = user.editor_or_other_editor || '回答なし'
     .user-metas__item


### PR DESCRIPTION
## Issue

- #8421 

## 概要
相談部屋の個別ページに管理者でアクセスした時の右カラムのユーザー情報の環境情報のOSが下記のようになってしまっている。

<img width="643" alt="Image" src="https://github.com/user-attachments/assets/bd40c418-8b6d-42ed-8671-97f749e8fb4d" />

## 変更確認方法

1. `bug/talkdisplay-OSinfo-abnormal`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. 管理者でログインし、「相談」タブ（画面左）→「全て」→個人ページを開く
4. 右カラムのユーザー情報の環境情報のOSが正しく表示されているかを確認（修正前ではOSの情報が設定されていない場合に表示がおかしくなっていた）
※「advijirou」、「advisernocolleguetrainee」、「jobseeker」、「osnashi」などはOSの設定をしておりませんでした（デフォルト）

## Screenshot

### 変更前
<img width="958" alt="スクリーンショット 2025-03-13 153713" src="https://github.com/user-attachments/assets/7b1dab42-0863-41b5-940a-2c6e59878ac8" />

### 変更後
<img width="959" alt="スクリーンショット 2025-03-13 154024" src="https://github.com/user-attachments/assets/865ab0fd-4323-4f48-a0fe-2075dfa47545" />

