### PR TITLE
お住まいの地域が未登録時はnilが保存され、既存のデータベース内の空文字列はnilへと変換する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,7 +190,7 @@ class User < ApplicationRecord
   has_one_attached :profile_image
 
   after_create UserCallbacks.new
-  before_validation :convert_blank_of_country_code_to_nil, :convert_blank_of_subdivision_code_to_nil
+  before_validation :convert_blank_of_address_to_nil
 
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
   validates :name, presence: true
@@ -892,11 +892,8 @@ class User < ApplicationRecord
     course.practices.where(id: practice_ids_skipped, include_progress: true).size
   end
 
-  def convert_blank_of_country_code_to_nil
+  def convert_blank_of_address_to_nil
     self.country_code = nil if country_code.blank?
-  end
-
-  def convert_blank_of_subdivision_code_to_nil
     self.subdivision_code = nil if subdivision_code.blank?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,6 +190,7 @@ class User < ApplicationRecord
   has_one_attached :profile_image
 
   after_create UserCallbacks.new
+  before_validation :convert_blank_of_country_code_to_nil, :convert_blank_of_subdivision_code_to_nil
 
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
   validates :name, presence: true
@@ -218,9 +219,9 @@ class User < ApplicationRecord
 
   validate :validate_uploaded_avatar_content_type
 
-  validates :country_code, inclusion: { in: ISO3166::Country.codes }, allow_blank: true
+  validates :country_code, inclusion: { in: ISO3166::Country.codes }, allow_nil: true
 
-  validates :subdivision_code, inclusion: { in: ->(user) { user.subdivision_codes } }, allow_blank: true, if: -> { country_code.present? }
+  validates :subdivision_code, inclusion: { in: ->(user) { user.subdivision_codes } }, allow_nil: true, if: -> { country_code.present? }
 
   with_options if: -> { %i[create update].include? validation_context } do
     validates :login_name, presence: true, uniqueness: true,
@@ -889,5 +890,13 @@ class User < ApplicationRecord
 
   def required_practices_size_with_skip
     course.practices.where(id: practice_ids_skipped, include_progress: true).size
+  end
+
+  def convert_blank_of_country_code_to_nil
+    self.country_code = nil if country_code.blank?
+  end
+
+  def convert_blank_of_subdivision_code_to_nil
+    self.subdivision_code = nil if subdivision_code.blank?
   end
 end

--- a/db/data/20250314075905_convert_blank_of_country_code_and_subdivision_code_to_nil.rb
+++ b/db/data/20250314075905_convert_blank_of_country_code_and_subdivision_code_to_nil.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ConvertBlankOfCountryCodeAndSubdivisionCodeToNil < ActiveRecord::Migration[6.1]
+  def up
+    User.find_each do |user|
+      if user.country_code.blank?
+        user.country_code = nil
+        user.subdivision_code = nil
+      elsif user.subdivision_code.blank?
+        user.subdivision_code = nil
+      end
+      user.save!(validate: false)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -745,13 +745,13 @@ class UserTest < ActiveSupport::TestCase
     user = users(:hajime)
     user.country_code = ""
     user.save!
-    assert_equal nil, user.country_code
+    assert_nil user.country_code
   end
 
   test 'convert to nil during saving when subdivision_code is empty string' do
     user = users(:hajime)
     user.subdivision_code = ""
     user.save!
-    assert_equal nil, user.subdivision_code
+    assert_nil user.subdivision_code
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -741,17 +741,12 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 2, user.latest_micro_report_page
   end
 
-  test 'convert to nil during saving when country_code is empty string' do
+  test 'convert to nil during saving when country_code and subdivision_code is empty string' do
     user = users(:hajime)
     user.country_code = ''
-    user.save!
-    assert_nil user.country_code
-  end
-
-  test 'convert to nil during saving when subdivision_code is empty string' do
-    user = users(:hajime)
     user.subdivision_code = ''
     user.save!
+    assert_nil user.country_code
     assert_nil user.subdivision_code
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -740,4 +740,18 @@ class UserTest < ActiveSupport::TestCase
     user.micro_reports.create!(Array.new(25) { |i| { content: "分報#{i + 1}" } })
     assert_equal 2, user.latest_micro_report_page
   end
+
+  test 'convert to nil during saving when country_code is empty string' do
+    user = users(:hajime)
+    user.country_code = ""
+    user.save!
+    assert_equal nil, user.country_code
+  end
+
+  test 'convert to nil during saving when subdivision_code is empty string' do
+    user = users(:hajime)
+    user.subdivision_code = ""
+    user.save!
+    assert_equal nil, user.subdivision_code
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -743,14 +743,14 @@ class UserTest < ActiveSupport::TestCase
 
   test 'convert to nil during saving when country_code is empty string' do
     user = users(:hajime)
-    user.country_code = ""
+    user.country_code = ''
     user.save!
     assert_nil user.country_code
   end
 
   test 'convert to nil during saving when subdivision_code is empty string' do
     user = users(:hajime)
-    user.subdivision_code = ""
+    user.subdivision_code = ''
     user.save!
     assert_nil user.subdivision_code
   end

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -181,8 +181,8 @@ class CurrentUserTest < ApplicationSystemTestCase
     find('label[for=register_address_no]').click
     click_on '更新する'
 
-    assert_equal '', user.reload.country_code
-    assert_equal '', user.reload.subdivision_code
+    assert_nil user.reload.country_code
+    assert_nil user.reload.subdivision_code
   end
 
   test 'change subdivisions' do


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7628

## 概要

## 変更確認方法
- 変更確認方法１→変更確認方法２の順番で実施をお願いいたします。
   - 変更確認方法１でブラウザからデータベースの更新を実施しているのはテストデータにお住まいの地域『`country_code`と`subdivision_code`』に空文字列のデータがないため（テストデータに設定がない場合は`nil`で保存されている）です。
   - 空文字列が登録されたユーザデータは本PRのマージ後は`nil`となるため、テストデータでは用意せずに変更確認方法１の手順で手動で作成する手順としております。

### 変更確認方法１：本番環境のデータベース更新の動作確認
1. `main`ブランチで`foreman start -f Procfile.dev`で[ローカル環境](http://localhost:3000/)を立ち上げる。
2. ユーザー名 hatsuno パスワード testtest でログインする。
3. 右上のユーザアイコンをクリックし『登録情報変更』をクリックする。
4. 登録情報変更ページから『お住まいの地域（都道府県・州まで）』で『登録しない』を選択し、画面下にある『更新する』ボタンをクリックする。
![image](https://github.com/user-attachments/assets/c351c55f-dcb2-4083-8672-9ba98ed783d0)
5. ログアウトし、ユーザー名 hajime パスワード testtest でログインする。
6. 右上のユーザアイコンをクリックし『登録情報変更』をクリックする。
7. 『お住まいの地域（都道府県・州まで）』で『登録する』を選択し、『国』だけ選択し『都道府県・州』は『選択してください』のまま画面下にある『更新する』ボタンをクリックする。
![image](https://github.com/user-attachments/assets/958e767d-110e-497c-ba9a-e37f13f491df)
8. 別ターミナルを起動し、ローカル環境を立ち上げているディレクトリへ移動後に`rails c`を実行してコンソールを立ち上げる。
9. コンソール上で以下を入力し確認する。
    1.`User.where(email: 'hatsuno@fjord.jp')`を入力し、`country_code`と`subdivision_code`に空文字列が保存されていることを確認する。
    ![image](https://github.com/user-attachments/assets/4987bac2-a98c-49ef-b6f3-d7dee03c0bb5)
    2.`User.where(email: 'hajime@fjord.jp')`を入力し、`country_code`には選択した国のコード、`subdivision_code`には空文字列が保存されていることを確認する。
    ![image](https://github.com/user-attachments/assets/0d7e2ade-7038-4540-ad38-0f930baf5dee)
    3.`User.where(email: 'komagata@fjord.jp')`を入力し、`country_code`と`subdivision_code`にそれぞれ以下のコードが保存されていることを確認する。
    ![image](https://github.com/user-attachments/assets/ff1f1a62-3fd2-493d-be1d-699b74e96004)
10. `bug/fix-empty-string-for-country-code-and-subdivision-code`をローカルに取り込む。
    1. `git fetch origin bug/fix-empty-string-for-country-code-and-subdivision-code`
    2. `git checkout bug/fix-empty-string-for-country-code-and-subdivision-code`

11.`rake data:migrate:up VERSION=20250314075905`を実施する。

- `db/data/20250314075905_convert_blank_of_country_code_and_subdivision_code_to_nil.rb`の`up`メソッドをローカル環境で実施するコマンド。
- 本番環境では`gem data-migrate`で実施する。ローカル環境では上記のコマンドで動作確認をする。[Wiki](https://github.com/fjordllc/bootcamp/wiki/DB%E3%81%AE%E3%83%87%E3%83%BC%E3%82%BF%E3%82%92migrate%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
-  成功するとターミナル上に以下のようなログが出力される。
    ![image](https://github.com/user-attachments/assets/befd3818-b69f-4707-9af5-87aa78698463)
12. コンソール上で`country_code`と`subdivision_code`が正しく`nil`に変更されていることを確認する
    1. `User.where(email: 'hatsuno@fjord.jp')`はどちらも`nil`
    ![image](https://github.com/user-attachments/assets/d5005959-e567-46bc-b139-3dd59f7d1bdb)
    2. `User.where(email: 'hajime@fjord.jp')`は`subdivision_code`だけが`nil`
    ![image](https://github.com/user-attachments/assets/65152c10-94bc-4e40-8fde-0202c380b1b7)
    3. `User.where(email: 'komagata@fjord.jp')`は変更なし。
    ![image](https://github.com/user-attachments/assets/ff1f1a62-3fd2-493d-be1d-699b74e96004)


### 変更確認方法２：登録情報の`country_code`と`subdivision_code`の保存時に未登録の場合は`nil`が保存される動作確認
1.  `bug/fix-empty-string-for-country-code-and-subdivision-code`をローカルに取り込む。（既に済の場合は省略）
    1. `git fetch origin bug/fix-empty-string-for-country-code-and-subdivision-code`
    2. `git checkout bug/fix-empty-string-for-country-code-and-subdivision-code`
2. `foreman start -f Procfile.dev`で[ローカル環境](http://localhost:3000/)を立ち上げる。
3. ユーザー名 komagata パスワード testtest でログインする。
4. 右上のユーザアイコンをクリックし『登録情報変更』をクリックする。
5. 別ターミナルを起動し、ローカル環境を立ち上げているディレクトリへ移動後に`rails c`を実行してコンソールを立ち上げる。
6. コンソール上で以下を入力し`country_code`と`subdivision_code`に登録情報が設定されていることを確認する。
```
User.where(email: 'komagata@fjord.jp')
```
- 登録情報（コンソール上）
![image](https://github.com/user-attachments/assets/ff1f1a62-3fd2-493d-be1d-699b74e96004)

7. ブラウザで登録情報変更ページから『お住まいの地域（都道府県・州まで）』で『登録しない』を選択し、画面下にある『更新する』ボタンをクリックする。
![image](https://github.com/user-attachments/assets/c351c55f-dcb2-4083-8672-9ba98ed783d0)

8. 再度コンソール上で`User.where(email: 'komagata@fjord.jp')`を入力し、`country_code`と`subdivision_code`に`nil`が保存されていることを確認する。
![image](https://github.com/user-attachments/assets/da399f7c-09ac-4d19-bfab-d570daf7223c)

9. ブラウザで右上のユーザアイコンをクリック後に『登録情報変更』をクリックし『登録情報変更』ページへアクセスする。
10. 『お住まいの地域（都道府県・州まで）』で『登録する』を選択し、『国』だけ選択し『都道府県・州』は『選択してください』のまま画面下にある『更新する』ボタンをクリックする。
![image](https://github.com/user-attachments/assets/958e767d-110e-497c-ba9a-e37f13f491df)

11. コンソール上で`User.where(email: 'komagata@fjord.jp')`を実行し、`country_code`には選択した国のコード、`subdivision_code`には`nil`が保存されていることを確認する。
![image](https://github.com/user-attachments/assets/588eef55-c0f3-43c6-8199-81e0fd291495)

12. ブラウザで右上のユーザアイコンをクリック後に『登録情報変更』をクリックし『登録情報変更』ページへアクセスする。
13. 『お住まいの地域（都道府県・州まで）』で『登録する』を選択し、『国』と『都道府県・州』を選択して画面下にある『更新する』ボタンをクリックする。
![image](https://github.com/user-attachments/assets/26512f34-446d-4d26-963c-06ac9787e899)

14. コンソール上で`User.where(email: 'komagata@fjord.jp')`を実行し、`country_code`には選択した国のコード、`subdivision_code`には選択した都道府県・州のコードが保存されていることを確認する。
![image](https://github.com/user-attachments/assets/8ccbc83c-5e0f-4f3b-8aec-80f76f425bdb)

## Screenshot

### 変更前：コンソール上で確認（画面の変更はなし）
- `country_code`と`subdivision_code`が共に未登録の場合はともに空文字列
![image](https://github.com/user-attachments/assets/4987bac2-a98c-49ef-b6f3-d7dee03c0bb5)
- `country_code`だけ登録、`subdivision_code`は未登録の場合は`subdivision_code`だけ空文字列
![image](https://github.com/user-attachments/assets/0d7e2ade-7038-4540-ad38-0f930baf5dee)

### 変更後：コンソール上で確認（画面の変更はなし）
- `country_code`と`subdivision_code`が共に未登録の場合はともに`nil`
![image](https://github.com/user-attachments/assets/da399f7c-09ac-4d19-bfab-d570daf7223c)
- `country_code`だけ登録、`subdivision_code`は未登録の場合は`subdivision_code`だけ`nil`
![image](https://github.com/user-attachments/assets/588eef55-c0f3-43c6-8199-81e0fd291495)
