### PR TITLE
production環境に活動時間のマスタデータを投入する

### DIFF
--- a/db/data/20250317034528_add_learning_time_frames.rb
+++ b/db/data/20250317034528_add_learning_time_frames.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddThisToThat < ActiveRecord::Migration[6.1]
+  def up
+    week_days = { '日' => 'sun', '月' => 'mon', '火' => 'tue', '水' => 'wed', '木' => 'thu', '金' => 'fri', '土' => 'sat' }
+
+    week_days.each_with_index do |(day_name, _day_prefix), day_index|
+      (0..23).each_with_index do |hour, hour_index|
+        LearningTimeFrame.create!(
+          id: day_index * 24 + hour_index + 1,
+          week_day: day_name,
+          activity_time: hour
+        )
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION

## Issue

- https://github.com/fjordllc/bootcamp/issues/6229

## 概要
#8263 でdata-migrateのファイルを作成していなかったために、production環境でマスタデータが投入されず404が発生していました。
これは、環境毎にどのデータが投入されるか理解していなかったために発生していた問題でした。
fixturesファイルの追加のみではproduction環境のDBにデータは投入されません。

### 環境毎のまとめ
| 環境 | 状態 | 補足 |
| ---- | ---- | ---- |
| local | fixturesのデータが投入されている(アプリ立ち上げ時) | [`bin/setup`で、`db:prepare`が実行されている。](https://github.com/fjordllc/bootcamp/blob/3b5363ef8a5f76c986c6fb65590c1059c188d3dd/bin/setup#L29)これは内部的に`db:seed`を実行しているので、fixturesのデータがDBに投入されている
| staging | fixturesのデータが投入されている。**data-migrateのファイルは実行されていない** | [`.cloudbuild/cloudbuild-staging.yaml`で`db:seed`のみが実行されているため](https://github.com/fjordllc/bootcamp/blob/3b5363ef8a5f76c986c6fb65590c1059c188d3dd/.cloudbuild/cloudbuild-staging.yaml#L72)
| production | data-migrateのファイルが実行されている。**fixturesのデータは投入されていない** | [`.cloudbuild/cloudbuild.yaml`で`db:migrate:with_data`のみが実行されているため](https://github.com/fjordllc/bootcamp/blob/3b5363ef8a5f76c986c6fb65590c1059c188d3dd/.cloudbuild/cloudbuild.yaml#L41)
## 変更の確認

- [x] ローカル環境で`VERBOSE=true VERSION=20250317034528 bundle exec rake data:migrate:up`を実行しデータが投入されていることの確認
- [x] 実際のブラウザ操作で活動時間が更新されていることの確認
