### PR TITLE
Docsの並び順を一覧ページと記事ページで統一

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -10,7 +10,7 @@ class Page < ApplicationRecord
   include Bookmarkable
 
   belongs_to :user
-  belongs_to :practice, optional: true
+  belongs_to :practice, optional: true, inverse_of: :pages
   belongs_to :last_updated_user, class_name: 'User', optional: true
   has_many :watches, as: :watchable, dependent: :destroy
   validates :title, presence: true

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -26,7 +26,10 @@ class Practice < ApplicationRecord
   has_many :skipped_practices, dependent: :destroy
   has_many :products, dependent: :destroy
   has_many :questions, dependent: :nullify
-  has_many :pages, dependent: :nullify
+  has_many :pages,
+           -> { order(updated_at: :desc, id: :desc) },
+           dependent: :nullify,
+           inverse_of: :practice
   has_many :practices_movies, dependent: :nullify
   has_many :movies, through: :practices_movies
   has_one :learning_minute_statistic, dependent: :destroy

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -326,4 +326,20 @@ class PagesTest < ApplicationSystemTestCase
     end
     assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
+
+  test 'check if Docs are sorted by update order' do
+    practice = practices(:practice1)
+    page1 = Page.create!(title: '三番目に新しい更新のDocs', body: 'test', user: users(:komagata), practice:, updated_at: Time.current,
+                         published_at: Time.current)
+    page2 = Page.create!(title: '二番目に新しい更新のDocs', body: 'test', user: users(:komagata), practice:, updated_at: Time.current,
+                         published_at: Time.current)
+    page3 = Page.create!(title: '一番新しい更新のDocs', body: 'test', user: users(:komagata), practice:, updated_at: Time.current, published_at: Time.current)
+
+    visit_with_auth "/pages/#{page1.id}", 'kimura'
+
+    sidebar_titles = all('li.a-side-nav__item .a-side-nav__item-link-inner').take(3).map(&:text)
+
+    expected_order = [page3.title, page2.title, page1.title]
+    assert_equal expected_order, sidebar_titles, 'サイドバーのDocsのタイトルの順番が更新順と一致しません。'
+  end
 end

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -329,11 +329,11 @@ class PagesTest < ApplicationSystemTestCase
 
   test 'check if Docs are sorted by update order' do
     practice = practices(:practice1)
-    page1 = Page.create!(title: '三番目に新しい更新のDocs', body: 'test', user: users(:komagata), practice:, updated_at: Time.current,
-                         published_at: Time.current)
-    page2 = Page.create!(title: '二番目に新しい更新のDocs', body: 'test', user: users(:komagata), practice:, updated_at: Time.current,
-                         published_at: Time.current)
-    page3 = Page.create!(title: '一番新しい更新のDocs', body: 'test', user: users(:komagata), practice:, updated_at: Time.current, published_at: Time.current)
+    user = users(:komagata)
+    now = Time.current
+    page1 = Page.create!(title: '三番目に新しい更新のDocs', body: '三番目に新しいです。', user:, practice:, updated_at: now + 1.hour)
+    page2 = Page.create!(title: '二番目に新しい更新のDocs', body: '二番目に新しいです。', user:, practice:, updated_at: now + 2.hours)
+    page3 = Page.create!(title: '一番新しい更新のDocs', body: '一番新しいです。', user:, practice:, updated_at: now + 3.hours)
 
     visit_with_auth "/pages/#{page1.id}", 'kimura'
 

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -326,20 +326,4 @@ class PagesTest < ApplicationSystemTestCase
     end
     assert_equal '.file-input', find('textarea.a-text-input')['data-input']
   end
-
-  test 'check if Docs are sorted by update order' do
-    practice = practices(:practice1)
-    user = users(:komagata)
-    now = Time.current
-    page1 = Page.create!(title: '三番目に新しい更新のDocs', body: '三番目に新しいです。', user:, practice:, updated_at: now + 1.hour)
-    page2 = Page.create!(title: '二番目に新しい更新のDocs', body: '二番目に新しいです。', user:, practice:, updated_at: now + 2.hours)
-    page3 = Page.create!(title: '一番新しい更新のDocs', body: '一番新しいです。', user:, practice:, updated_at: now + 3.hours)
-
-    visit_with_auth "/pages/#{page1.id}", 'kimura'
-
-    sidebar_titles = all('li.a-side-nav__item .a-side-nav__item-link-inner').take(3).map(&:text)
-
-    expected_order = [page3.title, page2.title, page1.title]
-    assert_equal expected_order, sidebar_titles, 'サイドバーのDocsのタイトルの順番が更新順と一致しません。'
-  end
 end


### PR DESCRIPTION
## Issue

- #8239 

## 概要
下記2つの画面において、DOCs一覧の並び順が異なっている

- プラクティスページ内のDOCsタブでのDOCs一覧
- DOCs記事ページのサイドバナーでのDOCs一覧

## 変更確認方法

1. `bug/unify-order-of-Docs`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. 「OS X Mountain Lionをクリーンインストールする」（最初のプラクティス）ページのDocsタブでDocsの一覧を確認
4. その内のどれか１つの開く（どれでもいいです）
5. 右側のDocs一覧が先ほどのDocs一覧のページの並び順と同じであることを確認
※更新順の表示にしました

## Screenshot
![スクリーンショット 2025-03-17 144306](https://github.com/user-attachments/assets/9bb05286-0529-4d73-bb1c-6fc5a97ce448)

### 変更前
<img width="946" alt="スクリーンショット 2025-03-17 144416" src="https://github.com/user-attachments/assets/a7646d8b-2bc2-4901-b802-9451547638b0" />

### 変更後
<img width="950" alt="スクリーンショット 2025-03-17 144609" src="https://github.com/user-attachments/assets/7898514d-a407-488f-b693-171e1dfb4b6e" />


