### PR TITLE
管理者・メンターでログイン時にブログ記事のタグを表示

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,6 +6,8 @@ class ArticlesController < ApplicationController
   before_action :require_admin_or_mentor_login, except: %i[index show]
 
   def index
+    return redirect_to articles_path, alert: '管理者・メンターとしてログインしてください' if params[:tag] && !admin_or_mentor_login?
+
     @articles = sorted_articles.preload([:tags]).page(params[:page])
     @articles = @articles.tagged_with(params[:tag]) if params[:tag]
     number_per_page = @articles.page(1).limit_value

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,10 +4,9 @@ class ArticlesController < ApplicationController
   before_action :set_article, only: %i[show edit update destroy]
   skip_before_action :require_active_user_login, raise: false, only: %i[index show]
   before_action :require_admin_or_mentor_login, except: %i[index show]
+  before_action -> { require_admin_or_mentor_login if params[:tag] }, only: %i[index]
 
   def index
-    return redirect_to articles_path, alert: '管理者・メンターとしてログインしてください' if params[:tag] && !admin_or_mentor_login?
-
     @articles = sorted_articles.preload([:tags]).page(params[:page])
     @articles = @articles.tagged_with(params[:tag]) if params[:tag]
     number_per_page = @articles.page(1).limit_value

--- a/app/javascript/stylesheets/atoms/_a-tags.sass
+++ b/app/javascript/stylesheets/atoms/_a-tags.sass
@@ -1,0 +1,4 @@
+.a-tags__items
+  display: flex
+  flex-wrap: wrap
+  gap: .5rem

--- a/app/javascript/stylesheets/lp/blocks/articles/_article.sass
+++ b/app/javascript/stylesheets/lp/blocks/articles/_article.sass
@@ -87,3 +87,7 @@
     gap: 1rem
   li
     flex: 1
+
+.article__header-row
+  &:not(:first-child)
+    margin-top: .75rem

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -66,4 +66,9 @@ hr.a-border-tint
                               = l(article.created_at)
                             - else
                               = l(article.published_at)
+                    .thumbnail-card__row
+                      - if current_user&.admin_or_mentor_login?
+                        .tags-list
+                          - article.tag_list.each do |tag|
+                            = link_to tag, articles_path(tag: tag), class: 'a-badge is-sm'
         = paginate articles

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -66,9 +66,12 @@ hr.a-border-tint
                               = l(article.created_at)
                             - else
                               = l(article.published_at)
-                    .thumbnail-card__row
-                      - if current_user&.admin_or_mentor_login?
-                        .tags-list
-                          - article.tag_list.each do |tag|
-                            = link_to tag, articles_path(tag: tag), class: 'a-badge is-sm'
+                    - if current_user&.admin_or_mentor_login? && article.tag_list.present?
+                      .thumbnail-card__row
+                        .a-tags
+                          ul.a-tags__items
+                            - article.tag_list.each do |tag|
+                              li.a-tags__item
+                                .a-badge.is-muted.is-sm
+                                  = tag
         = paginate articles

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -53,6 +53,11 @@ hr.a-border-tint
                       = l(@article.created_at)
                     - else
                       = l(@article.published_at)
+              .thumbnail-card__row
+                - if current_user&.admin_or_mentor_login?
+                  .tags-list
+                    - @article.tag_list.each do |tag|
+                      = link_to tag, articles_path(tag: tag), class: 'a-badge is-sm'
               = render 'share_buttons', article: @article
               - if @article.display_thumbnail_in_body?
                 - if @article.prepared_thumbnail?

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -35,35 +35,41 @@ hr.a-border-tint
         .a-card
           .article__inner
             header.article__header
-              h1.article__title
-                - if @article.wip?
-                  span.article__title-label
-                    | WIP
-                = @article.title
-              .article__metas
-                .article__meta
-                  .article__author
-                    = image_tag @article.user.avatar_url
-                    = @article.user.login_name
-                .article__meta
-                  .article__published-at
-                    - if @article.wip?
-                      = '執筆中'
-                    - elsif @article.published_at.nil?
-                      = l(@article.created_at)
-                    - else
-                      = l(@article.published_at)
-              .thumbnail-card__row
-                - if current_user&.admin_or_mentor_login?
-                  .tags-list
-                    - @article.tag_list.each do |tag|
-                      = link_to tag, articles_path(tag: tag), class: 'a-badge is-sm'
-              = render 'share_buttons', article: @article
+              .article__header-row
+                h1.article__title
+                  - if @article.wip?
+                    span.article__title-label
+                      | WIP
+                  = @article.title
+              .article__header-row
+                .article__metas
+                  .article__meta
+                    .article__author
+                      = image_tag @article.user.avatar_url
+                      = @article.user.login_name
+                  .article__meta
+                    .article__published-at
+                      - if @article.wip?
+                        = '執筆中'
+                      - elsif @article.published_at.nil?
+                        = l(@article.created_at)
+                      - else
+                        = l(@article.published_at)
+              - if current_user&.admin_or_mentor_login? && @article.tag_list.present?
+                .article__header-row
+                  .a-tags
+                    ul.a-tags__items
+                      - @article.tag_list.each do |tag|
+                        li.a-tags__item
+                          = link_to tag, articles_path(tag: tag), class: 'a-badge is-muted is-sm'
+              .article__header-row
+                = render 'share_buttons', article: @article
               - if @article.display_thumbnail_in_body?
-                - if @article.prepared_thumbnail?
-                  = image_tag @article.prepared_thumbnail_url, class: 'article__image'
-                - else
-                  = image_tag @article.selected_thumbnail_url, class: 'article__image'
+                .article__header-row
+                  - if @article.prepared_thumbnail?
+                    = image_tag @article.prepared_thumbnail_url, class: 'article__image'
+                  - else
+                    = image_tag @article.selected_thumbnail_url, class: 'article__image'
             .article__body
               - if @article.wip? && @article.token == params[:token]
                 .article__message.a-notice-block.mb-8

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -3,6 +3,16 @@
 require 'application_system_test_case'
 
 class Article::TagsTest < ApplicationSystemTestCase
+  setup do
+    @article = Article.create!(
+      user: users(:mentormentaro),
+      title: 'タグ付きテスト記事',
+      body: '2つタグが付与された記事です',
+      tag_list: %w[FirstTag SecondTag],
+      wip: false
+    )
+  end
+
   test 'cat add tag to article' do
     visit_with_auth new_article_url, 'komagata'
     fill_in 'タイトル', with: 'タグ追加のテスト記事'
@@ -21,23 +31,21 @@ class Article::TagsTest < ApplicationSystemTestCase
     assert_equal tags, created_article.tag_list.sort
   end
 
-  test 'mentor can view and use tags' do
-    article = Article.create!(
-      user: users(:mentormentaro),
-      title: 'タグ付きテスト記事',
-      body: '2つタグが付与された記事です',
-      tag_list: %w[FirstTag SecondTag],
-      wip: false
-    )
-
-    visit_with_auth article_path(article), 'mentormentaro'
+  test 'mentor can view tags' do
+    visit article_path(@article)
+    assert_no_selector 'ul.a-tags__items li.a-tags__item'
+    visit_with_auth article_path(@article), 'mentormentaro'
     assert_selector 'ul.a-tags__items li.a-tags__item', text: 'FirstTag'
     assert_selector 'ul.a-tags__items li.a-tags__item', text: 'SecondTag'
+  end
+
+  test 'mentor can use tags' do
+    visit_with_auth article_path(@article), 'mentormentaro'
     click_link 'SecondTag'
     assert_text 'タグ付きテスト記事'
+  end
 
-    visit_with_auth article_path(article), 'hatsuno'
-    assert_no_selector 'ul.a-tags__items li.a-tags__item'
+  test 'non-mentor cannot access tag filter page' do
     visit articles_path(tag: 'SecretTag')
     assert_current_path articles_path
     assert_text '管理者・メンターとしてログインしてください'

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -47,7 +47,7 @@ class Article::TagsTest < ApplicationSystemTestCase
 
   test 'non-mentor cannot access tag filter page' do
     visit articles_path(tag: 'SecretTag')
-    assert_current_path articles_path
+    assert_current_path root_path
     assert_text '管理者・メンターとしてログインしてください'
   end
 end

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -13,7 +13,7 @@ class Article::TagsTest < ApplicationSystemTestCase
     )
   end
 
-  test 'cat add tag to article' do
+  test 'can add tag to article' do
     visit_with_auth new_article_url, 'komagata'
     fill_in 'タイトル', with: 'タグ追加のテスト記事'
     fill_in '本文', with: '2つタグが付与された記事です'

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -20,4 +20,26 @@ class Article::TagsTest < ApplicationSystemTestCase
     created_article = Article.find_by(title: 'タグ追加のテスト記事')
     assert_equal tags, created_article.tag_list.sort
   end
+
+  test 'mentor can view and use tags' do
+    article = Article.create!(
+      user: users(:mentormentaro),
+      title: 'タグ付きテスト記事',
+      body: '2つタグが付与された記事です',
+      tag_list: %w[FirstTag SecondTag],
+      wip: false
+    )
+
+    visit_with_auth article_path(article), 'mentormentaro'
+    assert_selector 'ul.a-tags__items li.a-tags__item', text: 'FirstTag'
+    assert_selector 'ul.a-tags__items li.a-tags__item', text: 'SecondTag'
+    click_link 'SecondTag'
+    assert_text 'タグ付きテスト記事'
+
+    visit_with_auth article_path(article), 'hatsuno'
+    assert_no_selector 'ul.a-tags__items li.a-tags__item'
+    visit articles_path(tag: 'SecretTag')
+    assert_current_path articles_path
+    assert_text '管理者・メンターとしてログインしてください'
+  end
 end


### PR DESCRIPTION
## Issue

- #8447

## 概要
管理者・メンターでログインしたとき、
記事の一覧（http://localhost:3000/articles ）または個別の記事のページで記事に付けられたタグが表示される。
また、そのタグはリンクになっており、それをクリックするとそのタグを持った記事だけの一覧が表示される。
ただし、現時点では __管理者・メンターでログインしたときだけの表示__ されるように機能を制限している。

## 変更確認方法

1. `feature/show-blog-tags-for-admin-mentor`をローカルに取り込む
    1. `git fetch origin feature/show-blog-tags-for-admin-mentor`
    2. `git switch feature/show-blog-tags-for-admin-mentor`
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる

### 管理者・メンターアカウントでタグありの記事を作成
1. 管理者・メンターアカウントでログインする
   - 例: ユーザー名: `komagata`、パスワード: `testtest`
2. 記事の一覧（http://localhost:3000/articles ）から記事を選択して編集し、タグありの記事を作成する

### 管理者・メンターアカウントでタグが表示されるか確認
1. 記事の一覧（http://localhost:3000/articles ）に移動しタイトル下部にタグが表示されていることを確認する
2. 個別の記事に移動しタイトル下部にタグが表示されていることを確認する
3. タグを選択し、そのタグを持つ記事の一覧ページが表示されることを確認する

### 管理者・メンターアカウント以外ではタグが表示されないことを確認
1. 管理者・メンターアカウントでログアウトする
2. 記事の一覧（http://localhost:3000/articles ）および個別の記事に移動しタイトル下部にタグが表示されていないことを確認する
3. `http://localhost:3000/articles?tag=[タグ名] `でURLを直接指定した場合にエラーが表示されることを確認する

## Screenshot

### 変更前
- 記事の一覧（http://localhost:3000/articles ）にアクセスしたとき
![image](https://github.com/user-attachments/assets/6a4922d7-d11f-4c42-9e4f-e7d36924e895)
- 個別の記事にアクセスしたとき
![image](https://github.com/user-attachments/assets/fde2b6b9-d2ec-440e-a3a6-d4cc7b65d23e)

### 変更後
#### 管理者・メンターでログインしたとき
- 記事の一覧（http://localhost:3000/articles ）にアクセスしたとき
![image](https://github.com/user-attachments/assets/0ee329de-6af6-4c9f-866d-b2cf65cdbe80)

- 個別の記事にアクセスしたとき
![image](https://github.com/user-attachments/assets/ee83ad9a-6434-42d7-b3bc-ac278d923bfa)

- そのタグを持った記事（http://localhost:3000/articles?tag=[タグ名] ）の一覧にアクセスしたとき
![image](https://github.com/user-attachments/assets/5c0c243c-2b2a-48c8-b8b4-8ec6d5d02be5)

#### それ以外の場合
- そのタグを持った記事（http://localhost:3000/articles?tag=[タグ名] ）の一覧にアクセスしたとき
  - `?tag=[タグ名]`を使用できないように制限
![image](https://github.com/user-attachments/assets/dc4bc78c-97a2-4774-aefd-d8fc88933364)



