### PR TITLE
「スポンサーシップ」タグを付けるとsponsorshipページに表示されるように修正

### DIFF
--- a/app/controllers/articles/sponsorships_controller.rb
+++ b/app/controllers/articles/sponsorships_controller.rb
@@ -14,6 +14,6 @@ class Articles::SponsorshipsController < ApplicationController
 
   def sponsorships_articles
     Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
-           .where(thumbnail_type: :sponsorship, wip: false).order(published_at: :desc).page(params[:page])
+           .tagged_with('スポンサーシップ').where(wip: false).order(published_at: :desc).page(params[:page])
   end
 end

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -21,11 +21,3 @@ article3:
   wip: true
   thumbnail_type: :prepared_thumbnail
   token: abcdef123456
-
-article4:
-  title: sponsorshipページに表示される記事のタイトルです。
-  body: sponsorshipページに表示される記事の本文です。
-  user: komagata
-  wip: false
-  published_at: '2022-01-01 00:00:00'
-  thumbnail_type: :sponsorship

--- a/test/system/article/sponsorships_test.rb
+++ b/test/system/article/sponsorships_test.rb
@@ -4,12 +4,12 @@ require 'application_system_test_case'
 
 class Article::SponsorshipsTest < ApplicationSystemTestCase
   test 'show listing only sponsorship articles' do
-    visit_with_auth sponsorships_path, 'komagata'
-    assert_selector '.thumbnail-card__inner', count: 1
-    assert_no_text 'タイトル１'
-    assert_no_text 'タイトル２'
+    visit_with_auth new_article_url, 'komagata'
+    fill_in 'タイトル', with: 'sponsorshipページに表示される記事のタイトルです。'
+    fill_in '本文', with: 'sponsorshipページに表示される記事の本文です。'
+    fill_in_tag 'スポンサーシップ'
+    click_on '公開する'
+    visit sponsorships_path
     assert_text 'sponsorshipページに表示される記事のタイトルです。'
-    click_link_or_button 'ブログ記事のブランクアイキャッチ画像'
-    assert_text 'sponsorshipページに表示される記事の本文です。'
   end
 end

--- a/test/system/article/sponsorships_test.rb
+++ b/test/system/article/sponsorships_test.rb
@@ -10,6 +10,7 @@ class Article::SponsorshipsTest < ApplicationSystemTestCase
     fill_in_tag 'スポンサーシップ'
     click_on '公開する'
     visit sponsorships_path
+    assert_selector '.thumbnail-card__inner', count: 1
     assert_text 'sponsorshipページに表示される記事のタイトルです。'
   end
 end


### PR DESCRIPTION
## Issue

- #8454 

## 概要
[sponsorshipページ](http://localhost:3000/sponsorships)に表示される条件を
サムネイル画像をsponsorshipに設定する
<img width="400" alt="Image" src="https://github.com/user-attachments/assets/0995efd4-dd37-461d-b301-df9befeac47c" />
から

タグを「スポンサーシップ」に設定する
![Image](https://github.com/user-attachments/assets/3bc48235-9288-458f-8c1a-a84c8223dc18)

に変更しました。

## 変更確認方法
1. ブランチ`feature/change-tag-to-sponsorship-tag`をローカルに取り込む
   1. `git fetch origin feature/change-tag-to-sponsorship-tag`
   2. `git switch feature/change-tag-to-sponsorship-tag`
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 管理者・メンターアカウントでログインする
   - 例: ユーザー名: `komagata`、パスワード: `testtest`
4. 記事の一覧（http://localhost:3000/articles ）から以下の3パターンの記事を作成する
   1. 「スポンサーシップ」というタグが設定された記事
   2. 「sponsorship」というサムネイル画像が設定された記事
   3. 上記の2つが設定された記事
5. スポンサーシップのリンク（http://localhost:3000/sponsorships ）に移動し
「スポンサーシップ」というタグの記事のみ(`ⅰ`と`ⅲ`）表示され、
「sponsorship」というサムネイル画像が設定された記事（`ⅱ`）は表示されないことを確認する

## Screenshot

### 変更前
- 「sponsorship」というサムネイル画像が設定された記事のみ表示される
![image](https://github.com/user-attachments/assets/b43e3c0c-6bcc-4fcf-bda8-3662b53c6839)

### 変更後
- 「スポンサーシップ」というタグが設定された記事のみ表示される
![image](https://github.com/user-attachments/assets/a8368e34-7c49-4136-a2ea-51a6d6793ace)