### PR TITLE
一般ユーザーだと日報一覧に「未チェックの日報」タグが表示されないように修正

### DIFF
--- a/app/helpers/page_tabs/reports_helper.rb
+++ b/app/helpers/page_tabs/reports_helper.rb
@@ -5,7 +5,7 @@ module PageTabs
     def report_page_tabs(active_tab:)
       tabs = []
       tabs << { name: '日報', link: reports_path }
-      tabs << { name: '未チェックの日報', link: reports_unchecked_index_path, badge: Cache.unchecked_report_count }
+      tabs << { name: '未チェックの日報', link: reports_unchecked_index_path, badge: Cache.unchecked_report_count } if staff_login?
       tabs << { name: 'みんなのブログ', link: external_entries_path }
       render PageTabsComponent.new(tabs:, active_tab:)
     end


### PR DESCRIPTION
## Issue

- #8112 

## 概要
一般ユーザーでも日報一覧に「未チェックの日報」タブが表示されるため、一般ユーザーには「未チェックの日報」タブを非表示にする

## 変更確認方法

1. `bug/delete-unchecked-daily-report-tags-for-general-users`をローカルに取り込む
    1. `git fetch origin bug/delete-unchecked-daily-report-tags-for-general-users`
    2. `git checkout bug/delete-unchecked-daily-report-tags-for-general-users`
3. `foreman start -f Procfile.dev`でサーバーを立ち上げる
4. 「kimura」でログインし、「日報・ブログ」にアクセス
5. タグに「日報」と「みんなのブログ」しかないことを確認（「未チェックの日報」タグが無い）
6. 「komagata」でログインし、「日報・ブログ」にアクセスする
7. タグに「日報」と「みんなのブログ」と「未チェックの日報」があることを確認

## Screenshot

### 変更前
<img width="570" alt="image" src="https://github.com/user-attachments/assets/fcda77dd-fc85-4537-9133-71cc42b75beb" />

### 変更後
<img width="565" alt="image" src="https://github.com/user-attachments/assets/182b688f-22ee-49a4-8abc-d0d4a0b5c548" />