### PR TITLE
プラクティスの個別ページにそのプラクティスに関連する動画の一覧画面を追加した

### DIFF
--- a/app/controllers/practices/movies_controller.rb
+++ b/app/controllers/practices/movies_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Practices::MoviesController < ApplicationController
+  PAGER_NUMBER = 24
+
+  def index
+    @practice = Practice.find(params[:practice_id])
+    @movies = @practice.movies
+                       .includes(:user)
+                       .order(updated_at: :desc, id: :desc)
+                       .page(params[:page])
+                       .per(PAGER_NUMBER)
+  end
+end

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -8,7 +8,7 @@ module PageTabs
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports.length }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
-      # 動画リンクを隠した状態でのリリース。
+      # TODO: 動画機能の完成時に公開。動画リンクを隠した状態でのリリース。
       # tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length }
       tabs << { name: '提出物', link: practice_products_path(practice) }
       tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -8,6 +8,7 @@ module PageTabs
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports.length }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
+      tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length }
       tabs << { name: '提出物', link: practice_products_path(practice) }
       tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?
       tabs << { name: 'コーディングテスト', link: practice_coding_tests_path(practice) } if practice.coding_tests.present?

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -8,7 +8,8 @@ module PageTabs
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports.length }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
-      tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length }
+      # 動画リンクを隠した状態でのリリース。
+      # tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length }
       tabs << { name: '提出物', link: practice_products_path(practice) }
       tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?
       tabs << { name: 'コーディングテスト', link: practice_coding_tests_path(practice) } if practice.coding_tests.present?

--- a/app/views/practices/movies/index.html.slim
+++ b/app/views/practices/movies/index.html.slim
@@ -1,0 +1,30 @@
+- title "#{@practice.title}に関する動画"
+- set_meta_tags description: "プラクティス「#{@practice.title}」に関する動画一覧です。"
+- category = @practice.category(current_user.course)
+
+= render '/practices/page_header',
+  title: @practice.title,
+  category: category,
+  practice: @practice
+
+= practice_page_tabs(@practice, active_tab: '動画')
+
+.page-body
+  = paginate @movies
+  - if @movies.empty?
+    .o-empty-message
+      .o-empty-message__icon
+        i.fa-regular.fa-sad-tear
+      p.o-empty-message__text
+        | 動画はまだありません
+  - else
+    .page-body.is-movies
+      .page-body__inner
+        .container
+          .movies
+            .page-content.is-movies
+              .movies__items
+                .movie-list
+                  .row
+                    = render partial: 'movies/movie_list', collection: @movies, as: :movie
+  = paginate @movies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     resource :completion, only: %i(show), controller: "practices/completion"
     resource :submission_answer, only: %i(show), controller: "practices/submission_answer"
     resources :coding_tests, only: %i(index), controller: "practices/coding_tests"
+    resources :movies, only: %i(index), controller: "practices/movies"
   end
   resources :coding_tests, only: %i(show) do
     resources :coding_test_submissions,

--- a/db/fixtures/movies.yml
+++ b/db/fixtures/movies.yml
@@ -24,3 +24,17 @@ movie4:
   description: userが削除された時のmovの動画です
   user: null
   published_at: '2024-04-09 00:00:00'
+
+movie5:
+  title: Terminalの基礎を覚える mp4動画
+  description: Terminalの基礎を覚えるに関連する動画です。
+  user: komagata
+  published_at: '2024-04-10 00:00:00'
+
+<% (6..10).each do |id| %>
+movie<%= id %>:
+  title: OS X Mountain Lionに関する mp4動画<%= id %> mp4動画
+  description: OS X Mountain Lionをクリーンインストールするに関連する動画<%= id %>です。
+  user: komagata
+  published_at: '2024-04-10 00:00:00'
+<% end %>

--- a/db/fixtures/movies.yml
+++ b/db/fixtures/movies.yml
@@ -33,7 +33,7 @@ movie5:
 
 <% (6..10).each do |id| %>
 movie<%= id %>:
-  title: OS X Mountain Lionに関する mp4動画<%= id %> mp4動画
+  title: OS X Mountain Lionをクリーンインストールする 動画<%= id %> mp4動画
   description: OS X Mountain Lionをクリーンインストールするに関連する動画<%= id %>です。
   user: komagata
   published_at: '2024-04-10 00:00:00'

--- a/db/fixtures/practices_movies.yml
+++ b/db/fixtures/practices_movies.yml
@@ -1,0 +1,9 @@
+practices_movie5:
+  practice: practice2
+  movie: movie5
+
+<% (6..10).each do |id| %>
+practices_movie<%= id %>:
+  practice: practice1
+  movie: movie<%= id %>
+<% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -889,7 +889,6 @@ ActiveRecord::Schema.define(version: 2025_03_24_002043) do
     t.boolean "trainee", default: false, null: false
     t.string "customer_id"
     t.boolean "job_seeking", default: false, null: false
-    t.string "customer_id"
     t.string "subscription_id"
     t.boolean "mail_notification", default: true, null: false
     t.boolean "job_seeker", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -889,6 +889,7 @@ ActiveRecord::Schema.define(version: 2025_03_24_002043) do
     t.boolean "trainee", default: false, null: false
     t.string "customer_id"
     t.boolean "job_seeking", default: false, null: false
+    t.string "customer_id"
     t.string "subscription_id"
     t.boolean "mail_notification", default: true, null: false
     t.boolean "job_seeker", default: false, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,6 +72,7 @@ tables = %i[
   coding_test_submissions
   skipped_practices
   grant_course_applications
+  practices_movies
 ]
 
 ActiveRecord::FixtureSet.create_fixtures 'db/fixtures', tables

--- a/test/fixtures/movies.yml
+++ b/test/fixtures/movies.yml
@@ -21,3 +21,9 @@ movie4:
   description: userが削除された動画です
   user: null
   published_at: '2024-04-09 00:00:00'
+
+movie5:
+  title: OS X Mountain Lionをクリーンインストールするに関連する動画
+  description: OS X Mountain Lionをクリーンインストールするに関連する動画です
+  user: kimura
+  published_at: '2024-04-09 00:00:00'

--- a/test/fixtures/practices_movies.yml
+++ b/test/fixtures/practices_movies.yml
@@ -1,0 +1,3 @@
+practices_movie1:
+  practice: practice1
+  movie: movie5

--- a/test/system/practice/movies_test.rb
+++ b/test/system/practice/movies_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Practice::MoviesTest < ApplicationSystemTestCase
+  test 'show listing movies' do
+    visit_with_auth "/practices/#{practices(:practice1).id}/movies", 'hatsuno'
+    assert_equal 'OS X Mountain Lionをクリーンインストールするに関する動画 | FBC', title
+    assert_selector 'h2.page-header__title', text: 'OS X Mountain Lionをクリーンインストールする'
+    assert_selector '.page-tabs__item-link.is-active', text: '動画 （1）'
+  end
+end

--- a/test/system/practice/movies_test.rb
+++ b/test/system/practice/movies_test.rb
@@ -9,4 +9,12 @@ class Practice::MoviesTest < ApplicationSystemTestCase
     assert_selector 'h2.page-header__title', text: 'OS X Mountain Lionをクリーンインストールする'
     assert_selector '.page-tabs__item-link.is-active', text: '動画 （1）'
   end
+
+  test 'show listing no movies' do
+    visit_with_auth "/practices/#{practices(:practice10).id}/movies", 'hatsuno'
+    assert_equal 'sshdをインストールするに関する動画 | FBC', title
+    assert_selector 'h2.page-header__title', text: 'sshdをインストールする'
+    assert_selector '.page-tabs__item-link.is-active', text: '動画 （0）'
+    assert_text '動画はまだありません'
+  end
 end

--- a/test/system/practice/movies_test.rb
+++ b/test/system/practice/movies_test.rb
@@ -15,7 +15,6 @@ class Practice::MoviesTest < ApplicationSystemTestCase
     visit_with_auth "/practices/#{practices(:practice10).id}/movies", 'hatsuno'
     assert_equal 'sshdをインストールするに関する動画 | FBC', title
     assert_selector 'h2.page-header__title', text: 'sshdをインストールする'
-    assert_selector '.page-tabs__item-link.is-active', text: '動画 （0）'
     assert_text '動画はまだありません'
   end
 end

--- a/test/system/practice/movies_test.rb
+++ b/test/system/practice/movies_test.rb
@@ -7,7 +7,8 @@ class Practice::MoviesTest < ApplicationSystemTestCase
     visit_with_auth "/practices/#{practices(:practice1).id}/movies", 'hatsuno'
     assert_equal 'OS X Mountain Lionをクリーンインストールするに関する動画 | FBC', title
     assert_selector 'h2.page-header__title', text: 'OS X Mountain Lionをクリーンインストールする'
-    assert_selector '.page-tabs__item-link.is-active', text: '動画 （1）'
+    click_link_or_button 'OS X Mountain Lionをクリーンインストールするに関連する動画'
+    assert_current_path movie_path(movies(:movie5))
   end
 
   test 'show listing no movies' do
@@ -16,15 +17,5 @@ class Practice::MoviesTest < ApplicationSystemTestCase
     assert_selector 'h2.page-header__title', text: 'sshdをインストールする'
     assert_selector '.page-tabs__item-link.is-active', text: '動画 （0）'
     assert_text '動画はまだありません'
-  end
-
-  test 'show movie related to practices when click title link' do
-    visit_with_auth "/practices/#{practices(:practice1).id}/movies", 'hatsuno'
-    assert_equal 'OS X Mountain Lionをクリーンインストールするに関する動画 | FBC', title
-    assert_selector '.thumbnail-card__title-link.a-text-link', text: 'OS X Mountain Lionをクリーンインストールするに関連する動画'
-    click_link_or_button 'OS X Mountain Lionをクリーンインストールするに関連する動画'
-
-    assert_current_path movie_path(movies(:movie5))
-    assert_selector 'h1.page-content-header__title', text: 'OS X Mountain Lionをクリーンインストールするに関連する動画'
   end
 end

--- a/test/system/practice/movies_test.rb
+++ b/test/system/practice/movies_test.rb
@@ -17,4 +17,14 @@ class Practice::MoviesTest < ApplicationSystemTestCase
     assert_selector '.page-tabs__item-link.is-active', text: '動画 （0）'
     assert_text '動画はまだありません'
   end
+
+  test 'show movie related to practices when click title link' do
+    visit_with_auth "/practices/#{practices(:practice1).id}/movies", 'hatsuno'
+    assert_equal 'OS X Mountain Lionをクリーンインストールするに関する動画 | FBC', title
+    assert_selector '.thumbnail-card__title-link.a-text-link', text: 'OS X Mountain Lionをクリーンインストールするに関連する動画'
+    click_link_or_button 'OS X Mountain Lionをクリーンインストールするに関連する動画'
+
+    assert_current_path movie_path(movies(:movie5))
+    assert_selector 'h1.page-content-header__title', text: 'OS X Mountain Lionをクリーンインストールするに関連する動画'
+  end
 end


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/7648

## 概要

## 変更確認方法
### 初期セットアップからログインまで
1. `feature/add-index-page-for-movies-related-to-practice`をローカルに取り込む。
    1. `git fetch origin feature/add-index-page-for-movies-related-to-practice`
    2. `git checkout feature/add-index-page-for-movies-related-to-practice`
2. `bin/setup`を実施する。
3. `rails db:seed`を実行してプラクティスに関連する動画の初期データを追加する。
4. `foreman start -f Procfile.dev`で[ローカル環境](http://localhost:3000/)を立ち上げる。
5. ユーザー名 kimura パスワード testtest でログインする。（誰でも良いです。）
### 『プラクティスに関連する動画』に移動するタブが表示されるか
6. 画面左にあるプラクティスタブをクリックし、『OS X Mountain Lionをクリーンインストールする』をクリックする。
7. プラクティスタブに『動画』が追加され、プラクティスに関連する動画の数が表示されていることを確認する。
### 『プラクティスに関連する動画』内のビューの確認：関連動画のみ表示されるか
8. 『動画 （5）』タブをクリックする。
9. プラクティスに関連する動画のみが表示されていることを確認する。
   - 各動画のタイトルをクリックすると個別ページへ遷移する。
   - 個別ページのプラクティスタグに『OS X Mountain Lionをクリーンインストールする』が登録されている。
![タグ](https://github.com/user-attachments/assets/ab3820a6-8f0f-4004-88f8-8a2a9c605ef7)

10. プラクティスから『Terminalの基礎を覚える』のプラクティスページを表示し、動画タブが『動画 （1）』が表示されることを確認する。
11. 『動画 （1）』をクリックする。
12. プラクティスに関連する動画のみが表示されていることを確認する。
    - 動画のタイトルをクリックすると個別ページへ遷移する。
    - 個別ページのプラクティスタグに『Terminalの基礎を覚える』が登録されている。
![キャプチャ](https://github.com/user-attachments/assets/21bb5d9e-de4d-4c61-9899-b33ea08f9060)

### 『プラクティスに関連する動画』内のビューの確認：関連動画がない場合
13. プラクティスから『PC性能の見方を知る』のプラクティスページを表示し、動画タブが『動画 （0）』が表示されることを確認する。
14. 『動画 （0）』をクリックすると『動画はまだありません』が表示されることを確認する。

### 補足事項
- [動画の一覧ページ](http://localhost:3000/movies)へのリンクは現在隠した状態になっています。[こちらのPR](https://github.com/fjordllc/bootcamp/pull/7535#issuecomment-2742066822)で隠した状態でのリリースとなりました。

## Screenshot

### 変更前
- プラクティスのタブ
![image](https://github.com/user-attachments/assets/9576a370-4bff-4945-a287-e8bc3f7770d2)

- プラクティスに関連する動画ページ（ルーティングエラー）
![image](https://github.com/user-attachments/assets/f7ec34c0-265a-4d86-bb1a-b27cceb1b9b6)


### 変更後
- プラクティスに追加された『動画タブ』 
![変更後タブ](https://github.com/user-attachments/assets/5ed0f6ac-4bfe-45b6-b157-948d9f3fe0f0)

- プラクティスに関連する動画一覧ページ
![image](https://github.com/user-attachments/assets/77c655d3-58e1-4dde-acae-3faa4e8c9dc0)

- プラクティスに関連する動画が未登録の場合
![image](https://github.com/user-attachments/assets/bc2b445a-1242-4f27-a24a-ec5e118e4308)
