### PR TITLE
ユーザー画像のファイル名をログイン名で表示し、データ形式をwebpに変換する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -665,7 +665,7 @@ class User < ApplicationRecord
     default_image_path = '/images/users/avatars/default.png'
 
     if avatar.attached?
-      avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }).processed.url
+      avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }, format: :webp).processed.url
     else
       image_url default_image_path
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -663,9 +663,11 @@ class User < ApplicationRecord
 
   def avatar_url
     default_image_path = '/images/users/avatars/default.png'
+    format = 'webp'
 
     if avatar.attached?
-      avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }, format: :webp).processed.url
+      avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 },
+                     format:).processed.url(filename: "#{login_name}.#{format}")
     else
       image_url default_image_path
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -64,8 +64,11 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test '#avatar_url' do
-    user = users(:kimura)
-    assert_equal '/images/users/avatars/default.png', user.avatar_url
+    user_with_default_avatar = users(:kimura)
+    assert_equal '/images/users/avatars/default.png', user_with_default_avatar.avatar_url
+
+    user_with_custom_avatar = users(:komagata)
+    assert_includes user_with_custom_avatar.avatar_url, "#{user_with_custom_avatar.login_name}.webp"
   end
 
   test '#generation' do

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -81,7 +81,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
 
     visit_with_auth "/users/#{user.id}", 'komagata'
     icon_before = find('img.user-profile__user-icon-image', visible: false)
-    assert icon_before.native['src'].end_with?('hatsuno.jpg')
+    assert icon_before.native['src'].end_with?('hatsuno.webp')
 
     visit "/admin/users/#{user.id}/edit"
     within 'form[name=user]' do
@@ -92,7 +92,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
 
     assert_text 'ユーザー情報を更新しました。'
     icon_after = find('img.user-profile__user-icon-image', visible: false)
-    assert_includes icon_after.native['src'], 'komagata'
+    assert_includes icon_after.native['src'], 'hatsuno'
   end
 
   test 'update user with company' do

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -6,7 +6,7 @@ require 'application_system_test_case'
 class AttachmentsTest < ApplicationSystemTestCase
   test 'attachment user avatar' do
     visit_with_auth "/users/#{users(:komagata).id}", 'komagata'
-    assert_includes find('img.user-profile__user-icon-image')['src'], 'komagata.png'
+    assert_includes find('img.user-profile__user-icon-image')['src'], 'komagata.webp'
   end
 
   test 'attachment company icons in reports' do

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -177,7 +177,7 @@ class SearchablesTest < ApplicationSystemTestCase
       fill_in 'word', with: '提出物のコメントです。'
     end
     find('#test-search').click
-    assert_includes find('img.card-list-item-meta__icon.a-user-icon')['src'], 'komagata.png'
+    assert_includes find('img.card-list-item-meta__icon.a-user-icon')['src'], 'komagata.webp'
 
     find('img.card-list-item-meta__icon.a-user-icon').click
     assert_selector 'h1.page-content-header__title', text: 'komagata'


### PR DESCRIPTION
## Issue

- [#7747 ユーザー画像のファイル名をログイン名に修正したい](https://github.com/fjordllc/bootcamp/issues/7747)

## 概要

本PRにて下記２点の変更を行いました。

1. ユーザー画像のファイル名が表示されるようになっていましたが、セキュリティの観点より「login-name.webp」で表示するようにしました。（login-nameは各ユーザーのログイン名とする）
2. ユーザー画像のデータ形式は、元のデータ形式ではなくwebpに変換して表示するようにしました。

## 変更確認方法

1.  `bug/avatar_filename_to_loginname_and_format_to_webp`をローカルに取り込む
  i.  `git fetch origin bug/avatar_filename_to_loginname_and_format_to_webp`
  ii.  `git checkout bug/avatar_filename_to_loginname_and_format_to_webp`
2.  `foreman start -f Procfile.dev` でローカルサーバーを立ち上げる。
3.   ログインする。（ユーザーは任意）
4. [ユーザー](http://localhost:3000/users/655153192)にアクセスする。
5. デベロッパーツールの「Elements」を開き、下記画像の赤枠部のsrc属性値が「login-name.webp」になっていることを確認する。

![スクリーンショット 2025-03-31 16 51 28](https://github.com/user-attachments/assets/85c9b477-c045-4521-be19-03308e48b06e)

6.  デベロッパーツールの「Network」を開き、下記画像の赤枠type部が「webp」になっていることを確認する。

![スクリーンショット 2025-03-31 17 01 09](https://github.com/user-attachments/assets/409e78e4-e9e4-498b-bb4c-d8a21fa1cab3)


## Screenshot

### 変更前

![スクリーンショット 2025-03-31 17 11 32](https://github.com/user-attachments/assets/1ddd9502-5b4f-4354-b420-5eebc9a19a18)

![スクリーンショット 2025-03-31 17 11 58](https://github.com/user-attachments/assets/1459e735-76e4-4443-8d35-381b7e8b0819)


### 変更後

![スクリーンショット 2025-03-31 16 51 28](https://github.com/user-attachments/assets/6d0ef3e1-6e03-498f-bb84-e96728532983)

![スクリーンショット 2025-03-31 17 01 09](https://github.com/user-attachments/assets/6a57f002-557a-4321-9094-6bef9c88c114)

## 参考記事

- [variantメソッドのformatオプション](https://github.com/rails/rails/issues/40356)
- [urlメソッドのfilenameオプション](https://api.rubyonrails.org/v7.2/classes/ActiveStorage/Variant.html#method-i-url)