### PR TITLE
ユーザーメモで同じテキストが2回ペーストされるバグを修正

### DIFF
--- a/app/javascript/practice_memo.js
+++ b/app/javascript/practice_memo.js
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       })
       .then(() => {
-        TextareaInitializer.initialize('.a-markdown-input__textarea')
+        TextareaInitializer.initialize('#js-practice-memo')
       })
       .catch((error) => {
         console.warn(error)


### PR DESCRIPTION
## Issue

- #8065 

## 概要
提出物ページの「ユーザーメモ」にCtril+vで任意の文字列を貼り付けると貼り付けが2回実行されるバグを修正しました

## 変更確認方法

1. ブランチ`bug/user-memo-paste-issue`をローカルに取り込む
   1. `git fetch origin bug/user-memo-paste-issue`
   2. `git switch bug/user-memo-paste-issue`
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 管理者・メンターアカウントでログインする
   - 例: ユーザー名: `komagata`、パスワード: `testtest`
4. 提出物タブから[提出物ページ](http://localhost:3000/products)に移動し、適当な提出物を選択する
5. 画面右側の欄にある`ユーザーメモ`から編集を選択する
   - 2分割表示でブラウザの横幅が小さいと表示されないため注意
6. 入力フォームに事前に用意した任意のテキストをペーストして
   同じテキストが2回ペーストされていないことを確認する

## Screenshot

### 変更前
- `ここにユーザーメモを記入`をペーストした場合（同じテキストが2回ペーストされる）
![image](https://github.com/user-attachments/assets/ba403bf7-c9f6-4d00-a789-c2dfa7b662eb)

### 変更後
- `ここにユーザーメモを記入`をペーストした場合
![image](https://github.com/user-attachments/assets/af0cb6bf-7aaa-4e65-ab6c-e09fbfedfee4)