### PR TITLE
ダイアログの影響でFlakyになっていたシステムテストを修正

### DIFF
--- a/test/system/article/sponsorships_test.rb
+++ b/test/system/article/sponsorships_test.rb
@@ -7,10 +7,7 @@ class Article::SponsorshipsTest < ApplicationSystemTestCase
     sponsorship_article = Article.create!(
       title: 'sponsorshipページに表示される記事のタイトルです。',
       body: 'sponsorshipページに表示される記事の本文です。',
-      user: users(:komagata),
-      wip: false,
-      published_at: '2022-01-01 00:00:00',
-      thumbnail_type: :prepared_thumbnail
+      user: users(:komagata)
     )
     sponsorship_article.tag_list.add('スポンサーシップ')
     sponsorship_article.save

--- a/test/system/article/sponsorships_test.rb
+++ b/test/system/article/sponsorships_test.rb
@@ -4,14 +4,18 @@ require 'application_system_test_case'
 
 class Article::SponsorshipsTest < ApplicationSystemTestCase
   test 'show listing only sponsorship articles' do
-    visit_with_auth new_article_url, 'komagata'
-    fill_in 'タイトル', with: 'sponsorshipページに表示される記事のタイトルです。'
-    fill_in '本文', with: 'sponsorshipページに表示される記事の本文です。'
-    fill_in_tag 'スポンサーシップ'
-    page.accept_confirm do
-      click_on '公開する'
-    end
-    visit sponsorships_path
+    sponsorship_article = Article.create!(
+      title: 'sponsorshipページに表示される記事のタイトルです。',
+      body: 'sponsorshipページに表示される記事の本文です。',
+      user: users(:komagata),
+      wip: false,
+      published_at: '2022-01-01 00:00:00',
+      thumbnail_type: :prepared_thumbnail
+    )
+    sponsorship_article.tag_list.add('スポンサーシップ')
+    sponsorship_article.save
+
+    visit_with_auth sponsorships_path, 'komagata'
     assert_selector '.thumbnail-card__inner', count: 1
     assert_text 'sponsorshipページに表示される記事のタイトルです。'
   end

--- a/test/system/article/sponsorships_test.rb
+++ b/test/system/article/sponsorships_test.rb
@@ -8,7 +8,9 @@ class Article::SponsorshipsTest < ApplicationSystemTestCase
     fill_in 'タイトル', with: 'sponsorshipページに表示される記事のタイトルです。'
     fill_in '本文', with: 'sponsorshipページに表示される記事の本文です。'
     fill_in_tag 'スポンサーシップ'
-    click_on '公開する'
+    page.accept_confirm do
+      click_on '公開する'
+    end
     visit sponsorships_path
     assert_selector '.thumbnail-card__inner', count: 1
     assert_text 'sponsorshipページに表示される記事のタイトルです。'


### PR DESCRIPTION
## Issue

- #8512

## 概要
https://github.com/fjordllc/bootcamp/pull/8346 で追加されたアラート機能に
sponsorships_test.rbのコードを対応させました

## 変更確認方法

1. ブランチ`bug/fix-sponsorships-test`をローカルに取り込む
   1. `git fetch origin bug/fix-sponsorships-test`
   2. `git switch bug/fix-sponsorships-test`
3. `test/system/article/sponsorships_test.rb`のファイルを開く
4. Screenshotの「変更後」のように、赤線の内容に修正されていることを確認する
5. `rails test test/system/article/sponsorships_test.rb`を実行して自動テストが合格することを確認する

## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/465740cf-eca0-44ca-ba10-8e6311c25aa8)

### 変更後
![image](https://github.com/user-attachments/assets/af6f420c-9cbe-4237-9193-3d6384d7ed98)
