### PR TITLE
エディタの登録案内文を変更した

### DIFF
--- a/app/views/users/form/_editor.html.slim
+++ b/app/views/users/form/_editor.html.slim
@@ -1,11 +1,11 @@
 .form-item
   = f.label :editor, class: 'a-form-label'
-    | #{t('activerecord.attributes.user.editor')}（任意）
+    | #{t('activerecord.attributes.user.editor')}
 
   .a-form-help
     p
-      | もしプログラミング経験がある場合、その際に使用しているエディターをお知らせください。
-      | この情報はサポートを提供する際の参考にさせていただきます。
+      | 既にプログラミング経験がある場合、その際に使用しているエディターをお知らせください。
+      | それ以外の場合は、プラクティス「開発環境を作る」にて登録をしてください。この情報はサポートを提供する際の参考にさせていただきます。
 
   ul.block-checks.is-2-items.mt-4
     - editors = User.editors.keys


### PR DESCRIPTION
## Issue

- #8514 

## 概要
ユーザーが使用しているエディタを登録する箇所の案内を変更した。

## 変更確認方法

1. リモートリポジトリをローカルに取り込む
`git fetch origin chore/replace-editor-text`
`git checkout chore/replace-editor-text`

2. ローカル環境を起動してログインする
`foreman start -f Procfile.dev`で[ローカル環境](http://localhost:3000/)を立ち上げる。
ユーザー名 `komagata` パスワード `testtest` でログインする。

3. 問題の箇所が修正されていることを確かめる。
[登録情報変更ページ](http://localhost:3000/current_user/edit)にアクセスする
該当ページ中部にある、使用しているエディタの項目までスクロールする
**使用しているエディタ(任意)** が **使用しているエディタ** に変更されていること、その説明文が
**既にプログラミング経験がある場合、その際に使用しているエディターをお知らせください。それ以外の場合は、プラクティス「開発環境を作る」にて登録をしてください。この情報はサポートを提供する際の参考にさせていただきます。**
になっていることを確認する
## Screenshot

### 変更前

![修正前](https://github.com/user-attachments/assets/32bed216-f903-40f8-bbc9-6e610e58092a)


### 変更後
![修正後](https://github.com/user-attachments/assets/e2972ea3-8d67-4db6-8c22-d46ee0295c50)

