### PR TITLE
ログイン前のフッターにYouTubeリンクを追加

### DIFF
--- a/app/views/shared/_not_logged_in_footer.html.slim
+++ b/app/views/shared/_not_logged_in_footer.html.slim
@@ -36,6 +36,9 @@ footer.not-logged-in-footer
           = link_to certified_reskill_courses_rails_developer_course_root_path, class: 'not-logged-in-footer__nav-item-link' do
             | Reスキル認定講座対応コース
         li.not-logged-in-footer__nav-item
+          = link_to 'https://www.youtube.com/@フィヨルドブートキャンプ', class: 'not-logged-in-footer__nav-item-link', target: '_blank', rel: 'noopener' do
+            | YouTubeチャンネル
+        li.not-logged-in-footer__nav-item
           = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
             i.fa-solid.fa-rss
     small.not-logged-in-footer-copyright


### PR DESCRIPTION
## Issue

- #8530 

## 概要
ログイン前のフッターにYouTubeリンクを追加した。
## 変更確認方法

1. ```chore/add-youtube-link-to-footer```をローカルに取り込む。
i. ```git fetch origin chore/add-youtube-link-to-footer```
ii. ```git checkout chore/add-youtube-link-to-footer```
2. ```foreman start -f Procfile.dev``` でサーバーを立ち上げる。
3. スクリーンショットのようにフッターにリンクが追加されていることを確認する。

## Screenshot
### 変更前
<img width="1015" alt="スクリーンショット 2025-04-08 12 00 50" src="https://github.com/user-attachments/assets/8c825164-4710-404b-9429-749fccdab43e" />

### 変更後
<img width="1019" alt="スクリーンショット 2025-04-08 12 10 09" src="https://github.com/user-attachments/assets/286fdc1a-016b-4c59-b358-b9d52e60c7f9" />

