### PR TITLE
ユーザー個別ページにイベントタブを追加し、参加した特別イベントの一覧を表示

### DIFF
--- a/app/controllers/users/events_controller.rb
+++ b/app/controllers/users/events_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Users::EventsController < ApplicationController
+  def index
+    @user = User.find(params[:user_id])
+    @events = @user.participate_events
+                   .includes(:comments, :users)
+                   .order(start_at: :desc)
+                   .page(params[:page])
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -12,4 +12,26 @@ module EventsHelper
       }.to_param
     uri.to_s
   end
+
+  def event_comment_count(event, styled: true)
+    length = event.comments.length
+
+    if styled
+      link_to '#comments', class: "a-meta #{'is-disabled' if length.zero?}" do
+        'コメント（'.html_safe +
+          content_tag(:span, length, class: length.zero? ? 'is-muted' : 'is-emphasized') +
+          '）'.html_safe
+      end
+    else
+      "コメント（#{length}名）"
+    end
+  end
+
+  def event_participant_count(event)
+    "参加者（#{event.participants.count}名/#{event.capacity}名）"
+  end
+
+  def event_waitlist_count(event)
+    "補欠者（#{event.waitlist.count}名）"
+  end
 end

--- a/app/helpers/page_tabs/users_helper.rb
+++ b/app/helpers/page_tabs/users_helper.rb
@@ -12,6 +12,7 @@ module PageTabs
       tabs << { name: '提出物', link: user_products_path(user), count: user.products.length }
       tabs << { name: '質問', link: user_questions_path(user), count: user.questions.length }
       tabs << { name: '回答', link: user_answers_path(user), count: user.answers.length }
+      tabs << { name: 'イベント', link: user_events_path(user), count: user.participate_events.length }
       tabs << { name: '分報',
                 link: "#{user_micro_reports_path(user, page: user.latest_micro_report_page)}#latest-micro-report",
                 count: user.micro_reports.length }

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -58,7 +58,7 @@ nav.global-nav
               i.fa-solid.fa-users
             .global-nav-links__link-label ユーザー
         li.global-nav-links__item
-          = link_to events_path, class: "global-nav-links__link #{current_link(/events|regular_events/)}" do
+          = link_to events_path, class: "global-nav-links__link #{current_link(/^events|^regular_events/)}" do
             .global-nav-links__link-icon
               i.fa-solid.fa-beer
             .global-nav-links__link-label イベント

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -26,12 +26,7 @@
                   = l event.updated_at
           .page-content-header-metas__end
             .page-content-header-metas__meta
-              - length = event.comments.length
-              a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
-                | コメント（
-                span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
-                  = length
-                | ）
+              = event_comment_count(event, styled: true)
 
       .page-content-header__row
         .page-content-header-actions
@@ -75,7 +70,7 @@
     .a-card.participants
       header.card-header.is-sm
         h2.card-header__title
-          | 参加者（#{event.participants.count}名/#{event.capacity}名）
+          = event_participant_count(event)
       hr.a-border-tint
       .card-body
         .card-body__description
@@ -97,7 +92,7 @@
     .a-card.waitlist
       header.card-header.is-sm
         h2.card-header__title
-          | 補欠者（#{event.waitlist.count}名）
+          = event_waitlist_count(event)
       hr.a-border-tint
       .card-body
         .card-body__description

--- a/app/views/users/events/index.html.slim
+++ b/app/views/users/events/index.html.slim
@@ -4,60 +4,64 @@
 = render 'users/page_title', user: @user
 = user_page_tabs(@user, active_tab: 'イベント')
 
-.page-body
-  .container.is-md
-    - if @events.present?
-      .pagination
-        = paginate @events
-      .card-list.a-card
-        - @events.each do |event|
-          .card-list-item.is-event
-            .card-list-item__inner
-              .card-list-item__user
-                = render 'users/icon',
-                  user: event.user,
-                  link_class: 'card-list-item__user-link',
-                  image_class: 'card-list-item__user-icon'
-              .card-list-item__rows
-                .card-list-item__row
-                  .card-list-item-title
-                    .card-list-item-title__start
-                      - if event.wip
-                        .a-list-item-badge.is-wip
-                          <span>WIP</span>
-                      - elsif event.ended?
-                        .a-list-item-badge.is-ended
-                          <span>終了</span>
-                      h2.card-list-item-title__title
-                        = link_to event.title, event, class: 'card-list-item-title__link a-text-link'
-                .card-list-item__row
-                  .card-list-item-meta
-                    .card-list-item-meta__items
-                      .card-list-item-meta__item
-                        .a-meta
-                          | 名前: #{event.user.name}
-                .card-list-item__row
-                  .card-list-item-meta
-                    .card-list-item-meta__items
-                      .card-list-item-meta__item
-                        time.a-meta(datetime="#{event.start_at}")
-                          | 開催日時:#{l event.start_at}
-                      .card-list-item-meta__item
-                        .a-meta
-                          | 参加者（#{event.participants.count}名 / #{event.capacity}名）
-                      - if event.waitlist.count.positive?
-                        .card-list-item-meta__item
-                          .a-meta
-                            | 補欠者（#{event.waitlist.count}名）
-                      - if event.comments.size.positive?
-                        .card-list-item-meta__item
-                          .a-meta
-                            | コメント（#{event.comments.size}名）
-      .pagination
-        = paginate @events
-    - else
-      .o-empty-message
-        .o-empty-message__icon
-          i.fa-regular.fa-sad-tear
-        p.o-empty-message__text
-          | イベントはまだありません。
+.page-main
+  hr.a-border
+  .page-body
+    .page-body__inner.has-side-nav
+      .container.is-md
+        - if @events.present?
+          .pagination
+            = paginate @events
+          .card-list.a-card
+            - @events.each do |event|
+              .card-list-item.is-event
+                .card-list-item__inner
+                  .card-list-item__user
+                    = render 'users/icon',
+                      user: event.user,
+                      link_class: 'card-list-item__user-link',
+                      image_class: 'card-list-item__user-icon'
+                  .card-list-item__rows
+                    .card-list-item__row
+                      .card-list-item-title
+                        .card-list-item-title__start
+                          - if event.wip
+                            .a-list-item-badge.is-wip
+                              <span>WIP</span>
+                          - elsif event.ended?
+                            .a-list-item-badge.is-ended
+                              <span>終了</span>
+                          h2.card-list-item-title__title
+                            = link_to event.title, event, class: 'card-list-item-title__link a-text-link'
+                    .card-list-item__row
+                      .card-list-item-meta
+                        .card-list-item-meta__items
+                          .card-list-item-meta__item
+                            .a-meta
+                              = link_to event.user, class: 'a-user-name' do
+                                = event.user.long_name
+                    .card-list-item__row
+                      .card-list-item-meta
+                        .card-list-item-meta__items
+                          .card-list-item-meta__item
+                            time.a-meta(datetime="#{event.start_at}")
+                              | 開催日時:#{l event.start_at}
+                          .card-list-item-meta__item
+                            .a-meta
+                              = event_participant_count(event)
+                          - if event.waitlist.count.positive?
+                            .card-list-item-meta__item
+                              .a-meta
+                                = event_waitlist_count(event)
+                          - if event.comments.size.positive?
+                            .card-list-item-meta__item
+                              .a-meta
+                                = event_comment_count(event, styled: false)
+          .pagination
+            = paginate @events
+        - else
+          .o-empty-message
+            .o-empty-message__icon
+              i.fa-regular.fa-sad-tear
+            p.o-empty-message__text
+              | イベントはまだありません。

--- a/app/views/users/events/index.html.slim
+++ b/app/views/users/events/index.html.slim
@@ -1,0 +1,63 @@
+- title "#{@user.login_name}さんのイベント"
+- set_meta_tags description: "#{@user.login_name}さんのイベントページです。"
+
+= render 'users/page_title', user: @user
+= user_page_tabs(@user, active_tab: 'イベント')
+
+.page-body
+  .container.is-md
+    - if @events.present?
+      .pagination
+        = paginate @events
+      .card-list.a-card
+        - @events.each do |event|
+          .card-list-item.is-event
+            .card-list-item__inner
+              .card-list-item__user
+                = render 'users/icon',
+                  user: @user,
+                  link_class: 'card-list-item__user-link',
+                  image_class: 'card-list-item__user-icon'
+              .card-list-item__rows
+                .card-list-item__row
+                  .card-list-item-title
+                    .card-list-item-title__start
+                      - if event.wip
+                        .a-list-item-badge.is-wip
+                          <span>WIP</span>
+                      - elsif event.ended?
+                        .a-list-item-badge.is-ended
+                          <span>終了</span>
+                      h2.card-list-item-title__title
+                        = link_to event.title, event, class: 'card-list-item-title__link a-text-link'
+                .card-list-item__row
+                  .card-list-item-meta
+                    .card-list-item-meta__items
+                      .card-list-item-meta__item
+                        .a-meta
+                          | 名前: #{event.user.name}
+                .card-list-item__row
+                  .card-list-item-meta
+                    .card-list-item-meta__items
+                      .card-list-item-meta__item
+                        time.a-meta(datetime="#{event.start_at}")
+                          | 開催日時:#{l event.start_at}
+                      .card-list-item-meta__item
+                        .a-meta
+                          | 参加者（#{event.participants.count}名 / #{event.capacity}名）
+                      - if event.waitlist.count.positive?
+                        .card-list-item-meta__item
+                          .a-meta
+                            | 補欠者（#{event.waitlist.count}名）
+                      - if event.comments.size.positive?
+                        .card-list-item-meta__item
+                          .a-meta
+                            | コメント（#{event.comments.size}名）
+      .pagination
+        = paginate @events
+    - else
+      .o-empty-message
+        .o-empty-message__icon
+          i.fa-regular.fa-sad-tear
+        p.o-empty-message__text
+          | イベントはまだありません。

--- a/app/views/users/events/index.html.slim
+++ b/app/views/users/events/index.html.slim
@@ -15,7 +15,7 @@
             .card-list-item__inner
               .card-list-item__user
                 = render 'users/icon',
-                  user: @user,
+                  user: event.user,
                   link_class: 'card-list-item__user-link',
                   image_class: 'card-list-item__user-icon'
               .card-list-item__rows

--- a/app/views/users/events/index.html.slim
+++ b/app/views/users/events/index.html.slim
@@ -1,4 +1,4 @@
-- title "#{@user.login_name}さんのイベント"
+- title "#{@user.login_name}のイベント一覧"
 - set_meta_tags description: "#{@user.login_name}さんのイベントページです。"
 
 = render 'users/page_title', user: @user

--- a/config/routes/users.rb
+++ b/config/routes/users.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     resources :questions, only: %i(index), controller: "users/questions"
     resources :answers, only: %i(index), controller: "users/answers"
     resources :micro_reports, only: %i[index create destroy], controller: "users/micro_reports"
+    resources :events, only: %i(index), controller: "users/events"
     get "portfolio" => "users/works#index", as: :portfolio
     patch "graduation", to: "graduation#update", as: :graduation
     resource :mail_notification, only: %i(edit update), controller: "users/mail_notification"

--- a/test/system/user/events_test.rb
+++ b/test/system/user/events_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class User::EventsTest < ApplicationSystemTestCase
+  test 'shows the event listing for a user' do
+    visit_with_auth "/users/#{users(:komagata).id}/events", 'komagata'
+    assert_equal 'komagataのイベント一覧 | FBC', title
+  end
+
+  test 'shows only events the user is participating in' do
+    visit_with_auth "/users/#{users(:kimura).id}/events", 'kimura'
+    assert_text 'kimura専用イベント'
+    assert_no_text '募集期間中のイベント(補欠者なし)'
+  end
+end


### PR DESCRIPTION
## Issue

- #8466 

## 概要
ユーザー個別ページ（例：http://localhost:3000/users/xxxxxxxx）にイベントタブを追加し、
そのユーザーが参加、または参加予定の特別イベントの一覧が表示されるようにしました。

## 変更確認方法

1. `feature/user-events-tab`をローカルに取り込む
    1. `git fetch origin feature/user-events-tab`
    2. `git switch feature/user-events-tab`
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 適当なアカウントでログインする
   - 例: ユーザー名: `hatsuno`、パスワード: `testtest`
4. 右上のユーザーアイコンからマイプロフィール（ユーザー個別ページ）に移動する
5. イベントタブが存在することを確認
6. イベントタブに移動して、実際にそのユーザーが参加しているイベントのみ表示されていることを確認する

## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/b6375cee-e5bb-40a2-bea9-84dc3dfa4d39)

### 変更後
![image](https://github.com/user-attachments/assets/1f5fadb1-a4ec-4cfb-ba59-01c4fd59eb03)
