### PR TITLE
テストを移動し、重複と責務過多を解消

### DIFF
--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -12,18 +12,12 @@ class CoursesTest < ApplicationSystemTestCase
     visit_with_auth '/courses', 'hajime'
     assert_link courses(:course1).title
     assert_text courses(:course1).description
-    assert_link courses(:course4).title
-    assert_text courses(:course4).description
+  end
+
+  test 'cant see unpublished courses' do
+    visit_with_auth '/courses', 'hajime'
     assert_no_link courses(:course2).title
     assert_no_text courses(:course2).description
-    visit_with_auth "/mentor/courses/#{courses(:course2).id}/edit", 'komagata'
-    within 'form[name=course]' do
-      find(:css, '#checkbox-published-course').set(true)
-      click_button '内容を保存'
-    end
-    visit_with_auth '/courses', 'hajime'
-    assert_link courses(:course2).title
-    assert_text courses(:course2).description
   end
 
   test 'mentors can see closed courses' do

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -20,15 +20,6 @@ class CoursesTest < ApplicationSystemTestCase
     assert_no_text courses(:course2).description
   end
 
-  test 'mentors can see closed courses' do
-    visit_with_auth "/mentor/courses/#{courses(:course1).id}/edit", 'komagata'
-    within 'form[name=course]' do
-      assert_not find(:css, '#checkbox-published-course').checked?
-    end
-    visit_with_auth '/courses', 'mentormentaro'
-    assert_text courses(:course1).title
-  end
-
   test 'show welcome page when user isnt logged in' do
     visit '/courses'
     assert_text 'コースを選択してください'

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -8,27 +8,6 @@ class CoursesTest < ApplicationSystemTestCase
     assert_equal 'コース一覧 | FBC', title
   end
 
-  test 'create course' do
-    visit_with_auth '/mentor/courses/new', 'komagata'
-    within 'form[name=course]' do
-      fill_in 'course[title]', with: 'テストコース'
-      fill_in 'course[description]', with: 'テストのコースです。'
-      click_button '内容を保存'
-    end
-    assert_text 'コースを作成しました。'
-  end
-
-  test 'update course' do
-    visit_with_auth "/mentor/courses/#{courses(:course1).id}/edit", 'komagata'
-    within 'form[name=course]' do
-      fill_in 'course[title]', with: 'テストコース'
-      find(:css, '#checkbox-published-course').set(true)
-      fill_in 'course[description]', with: 'テストのコースです。'
-      click_button '内容を保存'
-    end
-    assert_text 'コースを更新しました。'
-  end
-
   test 'show published courses' do
     visit_with_auth '/courses', 'hajime'
     assert_link courses(:course1).title

--- a/test/system/mentor/courses_test.rb
+++ b/test/system/mentor/courses_test.rb
@@ -47,5 +47,6 @@ class Mentor::CoursesTest < ApplicationSystemTestCase
   test 'can see closed courses' do
     visit_with_auth '/courses', 'mentormentaro'
     assert_text courses(:course2).title
+    assert_text courses(:course2).description
   end
 end

--- a/test/system/mentor/courses_test.rb
+++ b/test/system/mentor/courses_test.rb
@@ -43,4 +43,9 @@ class Mentor::CoursesTest < ApplicationSystemTestCase
     visit "/mentor/courses/#{courses(:course1).id}/edit"
     assert_no_checked_field('course_published', visible: false)
   end
+
+  test 'can see closed courses' do
+    visit_with_auth '/courses', 'mentormentaro'
+    assert_text courses(:course2).title
+  end
 end

--- a/test/system/mentor/courses_test.rb
+++ b/test/system/mentor/courses_test.rb
@@ -27,4 +27,20 @@ class Mentor::CoursesTest < ApplicationSystemTestCase
     end
     assert_text 'コースを更新しました。'
   end
+
+  test 'can published course' do
+    visit_with_auth "/mentor/courses/#{courses(:course2).id}/edit", 'komagata'
+    check 'course_published', allow_label_click: true, visible: false
+    click_button '内容を保存'
+    visit "/mentor/courses/#{courses(:course2).id}/edit"
+    assert has_checked_field?('course_published', visible: false)
+  end
+
+  test 'can hide course' do
+    visit_with_auth "/mentor/courses/#{courses(:course1).id}/edit", 'komagata'
+    uncheck 'course_published', allow_label_click: true, visible: false
+    click_button '内容を保存'
+    visit "/mentor/courses/#{courses(:course1).id}/edit"
+    assert_no_checked_field('course_published', visible: false)
+  end
 end

--- a/test/system/mentor/courses_test.rb
+++ b/test/system/mentor/courses_test.rb
@@ -28,8 +28,8 @@ class Mentor::CoursesTest < ApplicationSystemTestCase
     assert_text 'コースを更新しました。'
   end
 
-  test 'can published course' do
-    visit_with_auth "/mentor/courses/#{courses(:course2).id}/edit", 'komagata'
+  test 'can publish course' do
+    visit_with_auth "/mentor/courses/#{courses(:course2).id}/edit", 'mentormentaro'
     check 'course_published', allow_label_click: true, visible: false
     click_button '内容を保存'
     visit "/mentor/courses/#{courses(:course2).id}/edit"
@@ -37,7 +37,7 @@ class Mentor::CoursesTest < ApplicationSystemTestCase
   end
 
   test 'can hide course' do
-    visit_with_auth "/mentor/courses/#{courses(:course1).id}/edit", 'komagata'
+    visit_with_auth "/mentor/courses/#{courses(:course1).id}/edit", 'mentormentaro'
     uncheck 'course_published', allow_label_click: true, visible: false
     click_button '内容を保存'
     visit "/mentor/courses/#{courses(:course1).id}/edit"

--- a/test/system/mentor/courses_test.rb
+++ b/test/system/mentor/courses_test.rb
@@ -28,20 +28,18 @@ class Mentor::CoursesTest < ApplicationSystemTestCase
     assert_text 'コースを更新しました。'
   end
 
-  test 'can publish course' do
-    visit_with_auth "/mentor/courses/#{courses(:course2).id}/edit", 'mentormentaro'
-    check 'course_published', allow_label_click: true, visible: false
-    click_button '内容を保存'
-    visit "/mentor/courses/#{courses(:course2).id}/edit"
-    assert has_checked_field?('course_published', visible: false)
-  end
-
-  test 'can hide course' do
+  test 'can publish and hide course' do
     visit_with_auth "/mentor/courses/#{courses(:course1).id}/edit", 'mentormentaro'
     uncheck 'course_published', allow_label_click: true, visible: false
     click_button '内容を保存'
     visit "/mentor/courses/#{courses(:course1).id}/edit"
     assert_no_checked_field('course_published', visible: false)
+
+    visit_with_auth "/mentor/courses/#{courses(:course2).id}/edit", 'mentormentaro'
+    check 'course_published', allow_label_click: true, visible: false
+    click_button '内容を保存'
+    visit "/mentor/courses/#{courses(:course2).id}/edit"
+    assert has_checked_field?('course_published', visible: false)
   end
 
   test 'can see closed courses' do


### PR DESCRIPTION
## Issue

- #8552 

## 概要
本PRでは、以下の対応を行います。

*   `/courses` 関連のテストファイルから `/mentor/courses` に関連するテストを `test/system/mentor/courses_test.rb` に移動
*   移動後のテストコードの重複を解消
*   一部テストが複数の責務を持っていたので解消

## 変更確認方法

1. `chore/move-mentor-courses-system-tests`をローカルに取り込む
    - `git checkout chore/move-mentor-courses-system-tests`
2. テストコードを確認する

* ローカルで立ち上げて確認する必要はないため、Files changedからも全ての変更点を確認できます。 

