### PR TITLE
ブログ記事のタグ入力ショートカットを作成

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -77,6 +77,7 @@ import '../coding_tests_sort.js'
 import '../watches.js'
 import '../watch-toggle.js'
 import '../diploma-upload.js'
+import '../tag-shortcut.js'
 import Cocooned from '@notus.sh/cocooned'
 import '../action_completed_button.js'
 

--- a/app/javascript/stylesheets/application.sass
+++ b/app/javascript/stylesheets/application.sass
@@ -97,6 +97,7 @@
 
 @import application/blocks/tags/random-tags
 @import application/blocks/tags/tag-links
+@import application/blocks/tags/tag-input
 
 @import application/blocks/thread/thread-comment-form
 @import application/blocks/thread/thread-comment

--- a/app/javascript/stylesheets/application/blocks/tags/_tag-input.sass
+++ b/app/javascript/stylesheets/application/blocks/tags/_tag-input.sass
@@ -1,0 +1,14 @@
+.tag-input
+  margin-top: .5rem
+  border-radius: .25rem
+  background-color: var(--background-more-tint)
+  padding: .75rem 1rem
+  border: dashed 1px var(--border)
+
+.tag-input__title
+  +text-block(.875rem 1.5 0 .5rem, block 600)
+
+.tag-input__items
+  display: flex
+  flex-wrap: wrap
+  gap: .5rem

--- a/app/javascript/tag-shortcut.js
+++ b/app/javascript/tag-shortcut.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.tag-item').forEach((button) => {
+    button.addEventListener('click', () => {
+      const tag = button.dataset.tag
+      const tagifyScope = document.querySelector('.tagify')
+      if (!tagifyScope) return
+
+      const event = new CustomEvent('add-tag-from-shortcut', {
+        detail: { tag },
+        bubbles: true
+      })
+      tagifyScope.dispatchEvent(event)
+    })
+  })
+})

--- a/app/javascript/tag-shortcut.js
+++ b/app/javascript/tag-shortcut.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.tag-item').forEach((button) => {
+  document.querySelectorAll('.js-tag-input-button').forEach((button) => {
     button.addEventListener('click', () => {
       const tag = button.dataset.tag
       const tagifyScope = document.querySelector('.tagify')

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -40,24 +40,30 @@
           = f.label :tag_list, 'タグを入力してください',
             class: 'a-form-label'
           = render 'tags_input', taggable: article
-          .a-form-help
-            p 入力してエンターキーを押すとタグになります（スペースは入力できません）。
 
-    .form-item
-      .row
-        .col-md-6.col-xs-12
-          = 'タグ入力'
-      ul.tab-nav__items
-        li
-          = button_tag '注目の記事', type: 'button', class: 'tag-item', data: { tag: '注目の記事' }
-        li
-          = button_tag '卒業生の声', type: 'button', class: 'tag-item', data: { tag: '卒業生の声' }
-        li
-          = button_tag 'プレスリリース', type: 'button', class: 'tag-item', data: { tag: 'プレスリリース' }
-        li
-          = button_tag 'スポンサーシップ', type: 'button', class: 'tag-item', data: { tag: 'スポンサーシップ' }
-        li
-          = button_tag '受賞実績', type: 'button', class: 'tag-item', data: { tag: '受賞実績' }
+          .tag-input
+            .tag-input__title
+              | 簡単タグ入力
+            .tag-input__tags
+              ul.tag-input__items
+                li.tag-input__item
+                  = button_tag '注目の記事', type: 'button', class: 'a-button is-sm is-primary-border js-tag-input-button', data: { tag: '注目の記事' }
+                li.tag-input__item
+                  = button_tag '卒業生の声', type: 'button', class: 'a-button is-sm is-primary-border js-tag-input-button', data: { tag: '卒業生の声' }
+                li.tag-input__item
+                  = button_tag 'プレスリリース', type: 'button', class: 'a-button is-sm is-primary-border js-tag-input-button', data: { tag: 'プレスリリース' }
+                li.tag-input__item
+                  = button_tag 'スポンサーシップ', type: 'button', class: 'a-button is-sm is-primary-border js-tag-input-button', data: { tag: 'スポンサーシップ' }
+                li.tag-input__item
+                  = button_tag '受賞実績', type: 'button', class: 'a-button is-sm is-primary-border js-tag-input-button', data: { tag: '受賞実績' }
+
+          .a-form-help
+            p 注目の記事...トップページの注目の記事一覧に表示されます。
+            p 卒業生の声...卒業生の声ページの記事一覧に表示されます。
+            p プレスリリース...プレスキットの記事一覧に表示されます。
+            p スポンサーシップ...スポンサー実績ページの記事一覧に表示されます。
+            p 受賞実績...受賞実績ページの記事一覧に表示されます。
+            p タグは手入力でも登録できます。入力してエンターキーを押すとタグになります（スペースは入力できません）。
 
     .form-item
       .row

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -46,6 +46,22 @@
     .form-item
       .row
         .col-md-6.col-xs-12
+          = 'タグ入力'
+      ul.tab-nav__items
+        li
+          = button_tag '注目の記事', type: 'button', class: 'tag-item', data: { tag: '注目の記事' }
+        li
+          = button_tag '卒業生の声', type: 'button', class: 'tag-item', data: { tag: '卒業生の声' }
+        li
+          = button_tag 'プレスリリース', type: 'button', class: 'tag-item', data: { tag: 'プレスリリース' }
+        li
+          = button_tag 'スポンサーシップ', type: 'button', class: 'tag-item', data: { tag: 'スポンサーシップ' }
+        li
+          = button_tag '受賞実績', type: 'button', class: 'tag-item', data: { tag: '受賞実績' }
+
+    .form-item
+      .row
+        .col-md-6.col-xs-12
           label.a-form-label
             | サムネイル画像選択
           .a-form-help.mb-4

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -47,7 +47,7 @@ class Article::TagsTest < ApplicationSystemTestCase
     visit_with_auth new_article_url, 'komagata'
     fill_in 'タイトル', with: 'ショートカットボタンからのタグ追加テスト'
     fill_in '本文', with: 'タグショートカットボタンのテストです'
-    find('button.tag-item', text: '注目の記事').click
+    find('button.js-tag-input-button', text: '注目の記事').click
     find('.tagify__input')
     assert_text '注目の記事'
     page.accept_confirm do

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -53,6 +53,9 @@ class Article::TagsTest < ApplicationSystemTestCase
       click_on '公開する'
     end
     assert_text '記事を作成しました'
-    assert_text '注目の記事'
+
+    assert_selector('a.a-badge') do
+      assert_text '注目の記事'
+    end
   end
 end

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -48,14 +48,11 @@ class Article::TagsTest < ApplicationSystemTestCase
     fill_in 'タイトル', with: 'ショートカットボタンからのタグ追加テスト'
     fill_in '本文', with: 'タグショートカットボタンのテストです'
     find('button.js-tag-input-button', text: '注目の記事').click
-    find('.tagify__input')
-    assert_text '注目の記事'
+    assert_selector('.tagify__tag', text: '注目の記事')
     page.accept_confirm do
       click_on '公開する'
     end
     assert_text '記事を作成しました'
-
-    created_article = Article.find_by(title: 'ショートカットボタンからのタグ追加テスト')
-    assert_includes created_article.tag_list, '注目の記事'
+    assert_text '注目の記事'
   end
 end

--- a/test/system/article/tags_test.rb
+++ b/test/system/article/tags_test.rb
@@ -42,4 +42,20 @@ class Article::TagsTest < ApplicationSystemTestCase
     click_link 'SecondTag'
     assert_text 'タグ付きテスト記事'
   end
+
+  test 'can add tag using shortcut buttons' do
+    visit_with_auth new_article_url, 'komagata'
+    fill_in 'タイトル', with: 'ショートカットボタンからのタグ追加テスト'
+    fill_in '本文', with: 'タグショートカットボタンのテストです'
+    find('button.tag-item', text: '注目の記事').click
+    find('.tagify__input')
+    assert_text '注目の記事'
+    page.accept_confirm do
+      click_on '公開する'
+    end
+    assert_text '記事を作成しました'
+
+    created_article = Article.find_by(title: 'ショートカットボタンからのタグ追加テスト')
+    assert_includes created_article.tag_list, '注目の記事'
+  end
 end


### PR DESCRIPTION
## Issue

- #8431

## 概要
いくつかの重要なタグをタイポしないように選択肢から入力できるようにしました。

## 変更確認方法

1. `feature/add-shortcut-for-blog-tag`をローカルに取り込む
    1. `git fetch origin feature/add-shortcut-for-blog-tag`
    2. `git switch feature/add-shortcut-for-blog-tag`
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3.  管理者・メンターアカウントでログインする
    - 例: ユーザー名: `komagata`、パスワード: `testtest`
4. 記事の一覧（http://localhost:3000/articles ）から記事の新規作成、または編集ページに移動する
5. タグ入力欄の下にある「タグ入力」の項目からタグを選択し、タグ入力欄にタグが反映されることを確認する
6. 記事を保存し、「タグ入力」から選択したタグが実際に保存できていることを確認する

## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/e86f0eaa-ebfc-46be-852f-30d3b08229db)

### 変更後
![レコーディング 2025-04-15 050050](https://github.com/user-attachments/assets/36f00c1b-89c9-432f-a9b5-940841caf845)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 記事投稿フォームに「簡単タグ入力」セクションを追加し、よく使われるタグをワンクリックで入力できるボタンを設置しました。
- **スタイル**
  - タグ入力エリアおよびショートカットボタンのデザインを改善しました。
- **テスト**
  - タグショートカットボタンでタグを追加できることを確認するシステムテストを追加しました。
- **ドキュメント**
  - タグ入力方法に関する説明文を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->