### PR TITLE
新規登録者のユーザーロールをディスコード通知に追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -162,7 +162,7 @@ class UsersController < ApplicationController
   end
 
   def notify_to_chat(user)
-    ChatNotifier.message "#{user.login_name}さんが新たなメンバーとしてJOINしました🎉\r<#{url_for(user)}>"
+    ChatNotifier.message "#{user.login_name}さん#{user.roles_to_s.empty? ? '' : "（#{user.roles_to_s}）"}が新たなメンバーとしてJOINしました🎉\r<#{url_for(user)}>"
   end
 
   def user_params


### PR DESCRIPTION
## Issue

- #8541

## 概要
新規ユーザー登録があったときにDiscordの通知チャンネルに表示される通知（```ログイン名```さんが新たなメンバーとしてJOINしました🎉）にユーザーロールを追加した。
## 変更確認方法
### Discordの用意
[参考](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95)
1. Discordで検証用のサーバーを作成する。
2. テキストチャンネルの設定から連携サービスのウェブフックを作成する。
### 検証
1. ```feature/add-user-role-to-discord-notification```をローカルに取り込む。
i. ```git fetch origin feature/add-user-role-to-discord-notification```
ii. ```git checkout feature/add-user-role-to-discord-notification```
2. 作成したウェブフックのURLをコピーする。
3. ```app/models/chat_notifier.rb```を以下のように編集する。
```diff
  def self.message(
    message,
    username: 'ピヨルド',
    webhook_url: ENV['DISCORD_NOTICE_WEBHOOK_URL']
  )

    if Rails.env.production?
      Discord::Notifier.message(message, username:, url: webhook_url)
    else
+     Discord::Notifier.message(message, username:, url: '取得したウェブフックURL')
      Rails.logger.info 'Message to Discord.'
    end
  end
```
4. ```foreman start -f Procfile.dev``` でサーバーを立ち上げる。
5. 管理者（例：komagata）としてログインする。
6. [管理者ページ](http://localhost:3000/admin/invitation_url)にアクセスしロール（アドバイザー・研修生・メンター）を選択して招待URLへ移行する。
7. 必要事項を記入して登録する。
8. Discordのテキストチャンネルの通知にスクリーンショットのようにロールが追加されたテキストが表示されることを確認する。
9. 一般受講生についてはログイン画面から参加登録をクリックし、必要事項を記入して登録する。通知はスクリーンショットのように変更がない。

## Screenshot

### 変更前
<img width="445" alt="スクリーンショット 2025-04-15 12 03 58" src="https://github.com/user-attachments/assets/60245779-c58a-4435-a24c-ec71178038ec" />

### 変更後
#### アドバイザー・研修生・メンター
<img width="562" alt="スクリーンショット 2025-04-15 13 37 12" src="https://github.com/user-attachments/assets/7f716fb0-dc5b-4bc0-9b63-389dcae0da52" />

#### 一般受講生
<img width="431" alt="スクリーンショット 2025-04-15 13 37 36" src="https://github.com/user-attachments/assets/555b3479-6ce7-482a-9abc-1d2d43984e25" />

