### PR TITLE
コーディングテストの並び順を変更できるようにした

### DIFF
--- a/app/controllers/api/coding_tests/position_controller.rb
+++ b/app/controllers/api/coding_tests/position_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class API::CodingTests::PositionController < API::BaseController
+  def update
+    @coding_test = CodingTest.find(params[:coding_test_id])
+    if @coding_test.insert_at(params[:insert_at])
+      head :no_content
+    else
+      render json: @coding_test.errors, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/mentor/practices/coding_tests_controller.rb
+++ b/app/controllers/mentor/practices/coding_tests_controller.rb
@@ -1,0 +1,10 @@
+class Mentor::Practices::CodingTestsController < ApplicationController
+  before_action :require_mentor_login
+
+  def index
+    @practice = Practice.find(params[:practice_id])
+    @practices_coding_tests = @practice
+                          .coding_tests
+                          .order(:position)
+  end
+end

--- a/app/controllers/mentor/practices/coding_tests_controller.rb
+++ b/app/controllers/mentor/practices/coding_tests_controller.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class Mentor::Practices::CodingTestsController < ApplicationController
   before_action :require_mentor_login
 
   def index
     @practice = Practice.find(params[:practice_id])
     @practices_coding_tests = @practice
-                          .coding_tests
-                          .order(:position)
+                              .coding_tests
+                              .order(:position)
   end
 end

--- a/app/javascript/coding_tests_sort.js
+++ b/app/javascript/coding_tests_sort.js
@@ -1,0 +1,22 @@
+import Sortable from 'sortablejs'
+import Bootcamp from 'bootcamp'
+
+document.addEventListener('DOMContentLoaded', () => {
+  const element = document.querySelector('#js-coding-test-sortable')
+  if (!element) {
+    return null
+  }
+
+  Sortable.create(element, {
+    handle: '.js-grab',
+    onEnd(event) {
+      const id = event.item.dataset.practice_coding_test_id
+      const params = { insert_at: event.newIndex + 1 }
+      const url = `/api/coding_tests/${id}/position.json`
+
+      Bootcamp.patch(url, params).catch((error) => {
+        console.warn(error)
+      })
+    }
+  })
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -73,6 +73,7 @@ import '../survey_result_chart.js'
 import '../footprints.js'
 import '../article-target.js'
 import '../referral-source-selection-form.js'
+import '../coding_tests_sort.js'
 
 import VueMounter from '../VueMounter.js'
 import Questions from '../components/questions.vue'

--- a/app/views/mentor/_mentor_page_tabs.html.slim
+++ b/app/views/mentor/_mentor_page_tabs.html.slim
@@ -8,11 +8,11 @@
       li.page-tabs__item
         = link_to 'コーディングテスト',
                 mentor_coding_tests_path,
-                class: "page-tabs__item-link #{current_link(/^mentor-coding_tests/)}"
+                class: "page-tabs__item-link #{current_link(/mentor(-practices)?-coding_tests/)}"
       li.page-tabs__item
         = link_to 'プラクティス',
                 mentor_practices_path,
-                class: "page-tabs__item-link #{current_link(/^mentor-practices/)}"
+                class: "page-tabs__item-link #{current_link(/^mentor-practices(?!-coding_tests)/)}"
       li.page-tabs__item
         = link_to 'カテゴリー',
                 mentor_categories_path,

--- a/app/views/mentor/coding_tests/index.html.slim
+++ b/app/views/mentor/coding_tests/index.html.slim
@@ -68,5 +68,8 @@ main.page-main
                       = link_to edit_mentor_coding_test_path(coding_test),
                         class: 'a-button is-sm is-secondary is-icon'
                         i.fa-solid.fa-pen
+                    li
+                      = link_to mentor_practice_coding_tests_path(coding_test.practice), class: 'a-button is-sm is-secondary is-icon is-block' do
+                        i.fa-solid.fa-align-justify
 
         = paginate @coding_tests

--- a/app/views/mentor/practices/coding_tests/index.html.slim
+++ b/app/views/mentor/practices/coding_tests/index.html.slim
@@ -1,0 +1,42 @@
+- title "コーディングテスト並び替え | #{@practice.title}プラクティス"
+
+header.page-header
+  .container
+    .page-header__inner
+      .page-header__start
+        .page-header__title
+          | メンターページ
+
+= render 'mentor/mentor_page_tabs'
+
+.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        .page-main-header__start
+          h1.page-main-header__title
+            | #{@practice.title}プラクティクスのコーディングテスト並び替え
+        .page-main-header__end
+          .page-main-header-actions
+            .page-main-header-actions__items
+              .page-main-header-actions__item
+                = link_to mentor_courses_path, class: 'a-button is-md is-secondary is-block is-back' do
+                  | テスト一覧
+  hr.a-border
+  .page-body
+    .container.is-md
+      .admin-table.is-grab
+        table.admin-table__table
+          thead.admin-table__header
+            tr.admin-table__labels
+              th.admin-table__label 名前
+              th.admin-table__label.handle 並び順
+          tbody.admin-table__items#js-coding-test-sortable
+            - @practices_coding_tests.each do |practice_coding_test|
+              tr.admin-table__item(data-practice_coding_test_id="#{practice_coding_test.id}")
+                td.admin-table__item-value
+                  = practice_coding_test.title
+                  = practice_coding_test.position
+                td.admin-table__item-value.is-text-align-center.is-grab
+                  span.js-grab.a-grab
+                    i.fa-solid.fa-align-justify

--- a/app/views/mentor/practices/coding_tests/index.html.slim
+++ b/app/views/mentor/practices/coding_tests/index.html.slim
@@ -36,7 +36,6 @@ header.page-header
               tr.admin-table__item(data-practice_coding_test_id="#{practice_coding_test.id}")
                 td.admin-table__item-value
                   = practice_coding_test.title
-                  = practice_coding_test.position
                 td.admin-table__item-value.is-text-align-center.is-grab
                   span.js-grab.a-grab
                     i.fa-solid.fa-align-justify

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -41,6 +41,9 @@ Rails.application.routes.draw do
         resource :completion_message, only: %i(update), controller: "practices/learning/completion_message"
       end
     end
+    resources :coding_tests, only: %i() do
+      resource :position, only: %i(update), controller: "coding_tests/position"
+    end
     resources :coding_test_submissions, only: %i(create)
     resources :reports, only: %i(index)
     namespace "reports" do

--- a/config/routes/mentor.rb
+++ b/config/routes/mentor.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :practices, only: %i(index), controller: "categories/practices"
     end
     resources :practices, only: %i(index new edit create update destroy) do
+      resources :coding_tests, only: %i(index), controller: "practices/coding_tests"
       resource :submission_answer, only: %i(new edit create update), controller: "practices/submission_answer"
     end
     resources :coding_tests, only: %i(index new edit create update destroy)

--- a/db/fixtures/coding_test_cases.yml
+++ b/db/fixtures/coding_test_cases.yml
@@ -53,29 +53,29 @@ coding_test_case11:
   input: world
   output: w o r l d
 
-coding_test_case12:
-  coding_test: coding_test6
-  input: ""
-  output: hello
-
-coding_test_case13:
-  coding_test: coding_test7
-  input: 3
-  output: Fizz
-
-coding_test_case14:
-  coding_test: coding_test7
-  input: 5
-  output: Buzz
-
-coding_test_case15:
-  coding_test: coding_test7
-  input: 15
-  output: FizzBuzz
-
-<% 16.upto(29) do |i| %>
+<% 12.upto(27) do |i| %>
 coding_test_case<%= i %>:
-  coding_test: coding_test<%= i - 8 %>
+  coding_test: coding_test<%= i - 6 %>
   input: ""
   output: hello
 <% end %>
+
+coding_test_case28:
+  coding_test: coding_test22
+  input: ""
+  output: hello
+
+coding_test_case29:
+  coding_test: coding_test23
+  input: 3
+  output: Fizz
+
+coding_test_case30:
+  coding_test: coding_test23
+  input: 5
+  output: Buzz
+
+coding_test_case31:
+  coding_test: coding_test23
+  input: 15
+  output: FizzBuzz

--- a/db/fixtures/coding_tests.yml
+++ b/db/fixtures/coding_tests.yml
@@ -55,7 +55,19 @@ coding_test5:
   hint: 文字列を分割するにはsplitが使えます。
   position: 5
 
-coding_test6:
+<% 6.upto(21) do |i| %>
+coding_test<%= i %>:
+  practice: practice62
+  user: komagata
+  language: javascript
+  title: 最初の出力
+  description: |-
+    `hello`という文字列を出力しなさい。
+  hint: ""
+  position: <%= i %>
+<% end %>
+
+coding_test22:
   practice: practice26
   user: komagata
   language: ruby
@@ -65,7 +77,7 @@ coding_test6:
   hint: ""
   position: 1
 
-coding_test7:
+coding_test23:
   practice: practice26
   user: komagata
   language: ruby
@@ -78,15 +90,3 @@ coding_test7:
     どれでもないならaを出力してください。
   hint: 条件分岐にはifが使えます。
   position: 2
-
-<% 8.upto(21) do |i| %>
-coding_test<%= i %>:
-  practice: practice62
-  user: komagata
-  language: javascript
-  title: 最初の出力
-  description: |-
-    `hello`という文字列を出力しなさい。
-  hint: ""
-  position: <%= i - 6 %>
-<% end %>

--- a/test/fixtures/coding_tests.yml
+++ b/test/fixtures/coding_tests.yml
@@ -7,3 +7,14 @@ coding_test1:
     `hello`という文字列を出力しなさい。
   hint: ""
   position: 1
+
+coding_test2:
+  practice: practice1
+  user: komagata
+  language: javascript
+  title: 2番目の出力
+  description: |-
+    文字列sが与えられます。
+    `hello `とsをつなげて出力しなさい。
+  hint: ""
+  position: 2

--- a/test/system/mentor/practice/coding_tests_test.rb
+++ b/test/system/mentor/practice/coding_tests_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Mentor::Practices::CodingTestsTest < ApplicationSystemTestCase
+  test 'coding tests can be reordered' do
+    visit_with_auth "/mentor/practices/#{practices(:practice1).id}/coding_tests", 'komagata'
+    assert_equal coding_tests(:coding_test1).title, all('td.admin-table__item-value')[0].text
+    assert_equal coding_tests(:coding_test2).title, all('td.admin-table__item-value')[2].text
+    source = all('.js-grab')[0]
+    target = all('.js-grab')[1]
+    source.drag_to(target)
+
+    visit_with_auth "/mentor/practices/#{practices(:practice1).id}/coding_tests", 'komagata'
+    assert_equal coding_tests(:coding_test2).title, all('td.admin-table__item-value')[0].text
+    assert_equal coding_tests(:coding_test1).title, all('td.admin-table__item-value')[2].text
+  end
+end


### PR DESCRIPTION
## Issue

- #8554

## 概要
コーディングテストの順序をプラクティス毎に並び替えるためのページ及び機能を作成しました

## 変更確認方法

1. `feature/sort-coding-tests`をローカルに取り込む
    - `git fetch origin feature/sort-coding-tests`
    - `git checkout feature/sort-coding-tests`
2. データベースをリセットする
    - `rails db:reset`
3. id:`komagata` pass:`testtest` でログインする
4. [メンター用コーディングテストページ](http://localhost:3000/mentor/coding_tests)にアクセスする
5.  所属プラクティスがJavaScript初級になっているテストの一番右側のアイコンをクリックし、プラクティス毎の並び替えページにアクセスできることを確認する
6. 並び替えページで並び替え用のアイコンをドラッグし、適切に並び替えが出来ることを確認する
7. 画面を更新し、並び順が保持されていることを確認する
## Screenshot

### 変更前

##### コーディングテストページ
![image](https://github.com/user-attachments/assets/1adf0881-3eeb-437c-bea0-c8dc2aa45de4)

##### コーディングテスト並び替えページ
実装無し

### 変更後

##### コーディングテストページ
![image](https://github.com/user-attachments/assets/b9a361d0-128b-4202-8be5-ff7eb9de57b8)

##### コーディングテスト並び替えページ
![image](https://github.com/user-attachments/assets/b96a4239-04d1-40f9-85a7-886a171b9a1a)

