### PR TITLE
ユーザータグのカウント方法がページによって異なっていたのを修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
     if @target == 'followings'
       current_user.followees_list(watch: @watch)
     elsif @entered_tag
-      User.tagged_with(@entered_tag)
+      User.desc_tagged_with(@entered_tag)
     else
       users = User.users_role(@target, allowed_targets: target_allowlist)
       @target == 'inactive' ? users.order(:last_activity_at) : users

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
     if @target == 'followings'
       current_user.followees_list(watch: @watch)
     elsif @entered_tag
-      User.desc_tagged_with(@entered_tag)
+      User.active_tagged_with(@entered_tag)
     else
       users = User.users_role(@target, allowed_targets: target_allowlist)
       @target == 'inactive' ? users.order(:last_activity_at) : users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -421,7 +421,7 @@ class User < ApplicationRecord
   scope :classmates, lambda { |start_date, end_date|
     where(created_at: start_date..end_date).order(:created_at, :id)
   }
-  scope :desc_tagged_with, lambda { |tag_name|
+  scope :active_tagged_with, lambda { |tag_name|
     with_attached_avatar
       .unretired
       .unhibernated

--- a/app/views/tags/_tag.html.slim
+++ b/app/views/tags/_tag.html.slim
@@ -14,5 +14,5 @@
     .a-user-icons
       .a-user-icons__items
         = render partial: 'tags/user',
-                collection: User.desc_tagged_with(tag.name),
+                collection: User.active_tagged_with(tag.name),
                 as: :user

--- a/db/fixtures/acts_as_taggable_on/taggings.yml
+++ b/db/fixtures/acts_as_taggable_on/taggings.yml
@@ -61,8 +61,8 @@ unhibernated_tag_cat:
 question13_tag_cat:
   taggable: question13 (Question)
   context: tags
-
   tag: cat
+
 question13_tag_game:
   taggable: question13 (Question)
   context: tags

--- a/db/fixtures/acts_as_taggable_on/taggings.yml
+++ b/db/fixtures/acts_as_taggable_on/taggings.yml
@@ -53,6 +53,11 @@ kimura_tag_may_j_:
   context: tags
   tag: may_j_
 
+unhibernated_tag_cat:
+  taggable: unhibernated (User)
+  context: tags
+  tag: cat
+
 question13_tag_cat:
   taggable: question13 (Question)
   context: tags


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/8571

## 概要

「ユーザー一覧」の「タグ別」ページで表示されるタグごとの人数と、タグをクリックしてからのタグページのユーザーに表示される人数が異なっていたので、ズレがないように修正しました！

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

