### PR TITLE
「未チェックの日報」タグの表示テストの作成

### DIFF
--- a/test/system/report/unchecked_test.rb
+++ b/test/system/report/unchecked_test.rb
@@ -17,4 +17,16 @@ class Report::UncheckedTest < ApplicationSystemTestCase
     visit_with_auth '/reports/unchecked', 'komagata'
     assert_button '未チェックの日報を一括で開く'
   end
+
+  test 'non-staff user can not see unchecked reports tab on reports page' do
+    visit_with_auth '/reports', 'hatsuno'
+    assert_text '日報・ブログ'
+    assert_no_link '未チェックの日報'
+  end
+
+  test 'mentor can see unchecked reports tab on reports page' do
+    visit_with_auth '/reports', 'komagata'
+    assert_text '日報・ブログ'
+    assert_link '未チェックの日報'
+  end
 end


### PR DESCRIPTION
## Issue

#8516

## 概要
以下の条件を満たすテストコードを作成しました。
```
一般ユーザーでログインし[日報・ブログページ](http://localhost:3000/reports)にアクセス
→「日報・ブログ」の表示の下に「未チェックの日報」タグが表示されない

一般ユーザー以外でログインし[日報・ブログページ](http://localhost:3000/reports)にアクセス
→「日報・ブログ」の表示の下に「未チェックの日報」タグが表示される
```
## 変更確認方法

1. `chore/unchecked-report-tag-view-test`をローカルに取り込む
・`git fetch origin chore/unchecked-report-tag-view-test`
・`git checkout chore/unchecked-report-tag-view-test`
2.  `bin/rails test test/system/report/unchecked_test.rb`を実行してエラーが検出されないことを確認する
