### PR TITLE
ログイン後のフッターに Fjord Minutes へのリンクを置いた

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -20,6 +20,9 @@ footer.footer
             = link_to 'https://github.com/fjordllc/bootcamp/projects/1', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | bootcampカンバン
           li.footer-nav__item
+            = link_to 'https://fjord-minutes.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | Fjord Minutes
+          li.footer-nav__item
             = link_to 'https://suzuri.jp/FjordBootCamp', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | グッズ購入
           li.footer-nav__item


### PR DESCRIPTION
## Issue

- #8603

## 概要

ログイン後のフッターに Fjord Minutes へのリンクを置いた

## 変更確認方法

1.ブランチ `feature/add-fjordminutes-link-to-footer`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 任意のアカウントでログイン
4. [トップページなどの任意のページ](http://localhost:3000/)を開き、フッターにFjord Minutesのリンクがあるかを確認

## Screenshot

### 変更前

<img width="1286" alt="Screenshot 2025-05-07 at 16 33 38" src="https://github.com/user-attachments/assets/0ca182ff-8058-468b-8049-e665ad9b8917" />


### 変更後

<img width="1288" alt="Screenshot 2025-05-07 at 16 35 18" src="https://github.com/user-attachments/assets/ff10bd6c-fd53-4f95-8078-6365dc7ba9b8" />
