### PR TITLE
ログイン前の画面のフッターにFBCのXアカウントへのリンクを追加

### DIFF
--- a/app/views/shared/_not_logged_in_footer.html.slim
+++ b/app/views/shared/_not_logged_in_footer.html.slim
@@ -39,6 +39,9 @@ footer.not-logged-in-footer
           = link_to 'https://www.youtube.com/@フィヨルドブートキャンプ', class: 'not-logged-in-footer__nav-item-link', target: '_blank', rel: 'noopener' do
             | YouTubeチャンネル
         li.not-logged-in-footer__nav-item
+          = link_to 'https://x.com/fjordbootcamp', class: 'not-logged-in-footer__nav-item-link', target: '_blank', rel: 'noopener' do
+            | FBCのXアカウント
+        li.not-logged-in-footer__nav-item
           = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
             i.fa-solid.fa-rss
     small.not-logged-in-footer-copyright


### PR DESCRIPTION
## Issue

- #8606

## 概要

ログイン前の画面のフッターにFBCのXアカウントのリンクを追加しました

## 変更確認方法

1. `chore/add-fbc-x-account-link-to-footer`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる。
3. ログイン前の画面でフッターにFBCのXアカウントのリンクがあるかを確認

## Screenshot

### 変更前
<img width="1221" alt="Screenshot 2025-05-08 at 10 49 44" src="https://github.com/user-attachments/assets/4787a1f5-bc7d-454d-b77c-7c28e42b1b35" />

### 変更後
<img width="1213" alt="Screenshot 2025-05-08 at 11 01 33" src="https://github.com/user-attachments/assets/1328d327-13ef-4883-b3d3-b0db67a871a4" />

