### PR TITLE
pratice要素がないページにアクセスした際、コンソール上でエラーが表示されるバグの修正

### DIFF
--- a/app/javascript/learning-status.js
+++ b/app/javascript/learning-status.js
@@ -2,8 +2,14 @@ import 'whatwg-fetch'
 import CSRF from 'csrf'
 
 document.addEventListener('DOMContentLoaded', () => {
+  const practiceElement = document.querySelector('#practice')
+
+  if (!practiceElement) {
+    return
+  }
+
   const buttons = document.querySelectorAll('.practice-status-buttons__button')
-  const practiceId = document.querySelector('#practice').dataset.id
+  const practiceId = practiceElement.dataset.id
 
   const updateButtonsStates = (clickedButton) => {
     buttons.forEach((button) => {


### PR DESCRIPTION
## Issue

- #8625 

## 概要

`practice`要素がないページのアクセスした時、コンソール上でエラーが表示されていたバグを修正しました

## 変更確認方法

1. `fix/null-check-for-practice-element`をローカルに取り込む
2. [プラクティス一覧ページ](http://localhost:3000/courses/829913840/practices#category-685020562)にアクセスし、開発者ツールのコンソールを確認し、エラーが出ていないことを確認する

## Screenshot

### 変更前
![変更前](https://github.com/user-attachments/assets/c0a66040-2340-416f-8e78-177341b1e383)

### 変更後
![変更後](https://github.com/user-attachments/assets/062756b5-0cfc-4ae2-8c15-217467ad3c39)

