### PR TITLE
アドミンメニューにFAQを追加

### DIFF
--- a/app/views/application/_admin_menu.html.slim
+++ b/app/views/application/_admin_menu.html.slim
@@ -14,3 +14,5 @@
     li.header-dropdown__item
       = link_to admin_campaigns_path, class: 'header-dropdown__item-link' do
         | お試し延長
+    = link_to admin_faq_categories_path, class: 'header-dropdown__item-link' do
+        | FAQ


### PR DESCRIPTION
## Issue

- #8608

## 概要
アドミンメニューに対して、FAQを追加しました

## 変更確認方法

1.`chore/add_admin_faq_categories_path_to_admin_menu`をローカルに取り込む
2.`foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 管理者でログインをする(komagata/machida)
4. 管理者メニューに`FAQ`のリンクが追加されていることを確認

## Screenshot

### 変更前
![FAQ_before](https://github.com/user-attachments/assets/a44a5a7d-4690-425e-88c4-47fdc5e3f21d)

### 変更後
![FAQ_AFTER](https://github.com/user-attachments/assets/82b6d188-db75-46ee-8b9f-afd6cf4723c9)

