### PR TITLE
トップページの最下部に参加登録ボタンを設置

### DIFF
--- a/app/views/welcome/_campus_insight.html.slim
+++ b/app/views/welcome/_campus_insight.html.slim
@@ -35,3 +35,12 @@ section.lp-content.is-lp-bg-3.is-left-title#campus-insight
                 .lp-actions__item
                   = link_to article_path(34), class: 'a-button is-xl is-primary-border is-block', rel: 'noopener noreferrer' do
                     | 中身を見てみる
+          .lp-content-stack__item
+            .lp-actions
+              ul.lp-actions__items
+                li.lp-actions__item
+                  = link_to new_inquiry_path, class: 'a-button is-xl is-primary-border is-block' do
+                    | お問い合わせ
+                li.lp-actions__item
+                  = link_to choose_courses_path, class: 'a-button is-xl is-warning is-block' do
+                    | 参加登録


### PR DESCRIPTION
## Issue

- #8632

## 概要
トップページの最下部に参加登録ボタンを設置しました。

## 変更確認方法

1.  `chore/add-inquery-and-choose-courses-paths-to-campus-insight`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. トップページに移動
4. 参加登録ボタンが登録されていることを確認


## Screenshot

### 変更前
![add_path_before_002](https://github.com/user-attachments/assets/1e817886-da12-461c-b4cc-024f2f28bcce)
### 変更後
![add_paths_after_002](https://github.com/user-attachments/assets/d7205910-e4d5-4bad-88fe-4e8b4a8ae904)

