### PR TITLE
ログイン後のフッターにFBCのXアカウントへのリンクを置いた

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -71,6 +71,9 @@ footer.footer
             = link_to 'https://www.youtube.com/@フィヨルドブートキャンプ', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | YouTubeチャンネル
           li.footer-nav__item
+            = link_to 'https://x.com/fjordbootcamp', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | FBCのXアカウント
+          li.footer-nav__item
             = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
               i.fa-solid.fa-rss
       small.footer__copyright


### PR DESCRIPTION
## Issue

- #8607 

## 概要
ログイン後のフッターにFBCのXアカウントへのリンクを置いた

## 変更確認方法

1. ブランチ `feature/add-x-link-to-footer`をローカルに取り込む
2.  `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3.任意のアカウントでログイン
4.[トップページなどの任意のページ](http://localhost:3000/)を開き、フッターにXのリンクがあるかを確認
## Screenshot

### 変更前
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/a327ba8c-4dbd-4312-b7a2-d4f5a997352d" />

### 変更後
<img width="1353" alt="image" src="https://github.com/user-attachments/assets/9778ea30-3f86-4424-b5c9-f4f4e05a69d2" />
