### PR TITLE
コメント文の先頭#の後ろに半角スペースを入れるよう修正

### DIFF
--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -428,7 +428,7 @@ senpai:
   sent_student_followup_message: true
   last_activity_at: "2014-01-01 00:00:12"
 
-kananashi: #name_kanaを持たないユーザー
+kananashi: # name_kanaを持たないユーザー
   login_name: kananashi
   email: kananashi@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -449,7 +449,7 @@ kananashi: #name_kanaを持たないユーザー
   sent_student_followup_message: true
   last_activity_at: "2014-01-01 00:00:12"
 
-osnashi: #osを持たないユーザー
+osnashi: # osを持たないユーザー
   login_name: osnashi
   email: osnashi@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -470,7 +470,7 @@ osnashi: #osを持たないユーザー
   sent_student_followup_message: true
   last_activity_at: "2014-01-01 00:00:12"
 
-jobseeker: #就活希望するユーザー
+jobseeker: # 就活希望するユーザー
   login_name: jobseeker
   email: jobseeker@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -1037,7 +1037,7 @@ unhibernated:
   sent_student_followup_message: false
   last_activity_at: <%= Time.current - 10.days %>
 
-discordinvalid: #Discord IDが不正なユーザー
+discordinvalid: # Discord IDが不正なユーザー
   login_name: discordinvalid
   email: discordinvalid@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -1058,7 +1058,7 @@ discordinvalid: #Discord IDが不正なユーザー
   sent_student_followup_message: true
   last_activity_at: "2014-01-01 00:00:12"
 
-twitterinvalid: #X（Twitter） IDが不正なユーザー
+twitterinvalid: # X（Twitter） IDが不正なユーザー
   login_name: twitterinvalid
   email: twitterinvalid@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -1401,7 +1401,7 @@ pjord:
   sent_student_followup_message: true
   last_activity_at: "2021-02-01 00:00:30"
 
-harikirio: #必修でないプラクティスも修了しているユーザー
+harikirio: # 必修でないプラクティスも修了しているユーザー
   login_name: harikirio
   email: harikiro@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -343,7 +343,7 @@ senpai:
   created_at: "2014-01-01 00:00:12"
   last_activity_at: "2014-01-01 00:00:12"
 
-kananashi: #name_kanaを持たないユーザー
+kananashi: # name_kanaを持たないユーザー
   login_name: kananashi
   email: kananashi@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -364,7 +364,7 @@ kananashi: #name_kanaを持たないユーザー
   last_activity_at: "2014-01-01 00:00:12"
   sent_student_followup_message: true
 
-osnashi: #osを持たないユーザー
+osnashi: # osを持たないユーザー
   login_name: osnashi
   email: osnashi@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -385,7 +385,7 @@ osnashi: #osを持たないユーザー
   last_activity_at: "2014-01-01 00:00:12"
   sent_student_followup_message: true
 
-discordinvalid: #Discord IDが不正なユーザー
+discordinvalid: # Discord IDが不正なユーザー
   login_name: discordinvalid
   email: discordinvalid@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -406,7 +406,7 @@ discordinvalid: #Discord IDが不正なユーザー
   last_activity_at: "2014-01-01 00:00:12"
   sent_student_followup_message: true
 
-twitterinvalid: #X（Twitter） IDが不正なユーザー
+twitterinvalid: # X（Twitter） IDが不正なユーザー
   login_name: twitterinvalid
   email: twitterinvalid@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -427,7 +427,7 @@ twitterinvalid: #X（Twitter） IDが不正なユーザー
   last_activity_at: "2020-01-01 00:00:12"
   sent_student_followup_message: true
 
-jobseeker: #就活希望するユーザー
+jobseeker: # 就活希望するユーザー
   login_name: jobseeker
   email: jobseeker@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -908,7 +908,7 @@ advisernocolleaguetrainee:
   created_at: "2022-07-01 00:00:00"
   last_activity_at: "2022-07-01 00:00:00"
 
-tom: #アメリカ在住のユーザー
+tom: # アメリカ在住のユーザー
   login_name: tom
   email: tom@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
@@ -1009,7 +1009,7 @@ marumarushain<%= i %>: # ページネーション確認のためのユーザー
   sent_student_followup_message: true
 <% end %>
 
-harikirio: #必修でないプラクティスも修了しているユーザー
+harikirio: # 必修でないプラクティスも修了しているユーザー
   login_name: harikirio
   email: harikiro@fjord.jp
   crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest


### PR DESCRIPTION
## 概要

`db/fixtures/users.yml`と`test/fixtures/users.yml`のコメント文に、先頭`#`の後に半角スペースを含まないものがあるため、半角スペースを入れた。

## 関連PR

#8468 
<img width="792" alt="image" src="https://github.com/user-attachments/assets/17076532-6327-4b01-8840-870dcf2a3d70" />
