### PR TITLE
開発環境で右下の赤い表示を表示した(development)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,5 +83,8 @@ Rails.application.configure do
   config.action_controller.asset_host = "http://localhost:3000"
   config.action_mailer.asset_host = "http://localhost:3000"
 
+  config.rack_dev_mark.enable = true
+  config.rack_dev_mark.theme = [:title, Rack::DevMark::Theme::GithubForkRibbon.new(position: 'right-bottom')]
+
   Rails.application.routes.default_url_options[:host] = 'localhost:3000'
 end


### PR DESCRIPTION
## Issue

- #8649 

## 概要
開発環境で右下の赤い表示を表示した(development)
削除されていた`rack-dev-mark`を再度設定し、表示が正しく機能するようにした

## 変更確認方法

1. ブランチ`bug/dev-indicator-not-appear`をローカルに取り込む
2. [トップページ](http://localhost:3000/)を開き、右下に赤い表示があることを確認する

## Screenshot

### 変更前
<img width="1371" alt="Image" src="https://github.com/user-attachments/assets/294c443c-ef43-4ff6-812e-c763ae91b5f3" />

### 変更後
<img width="1424" alt="Image" src="https://github.com/user-attachments/assets/471bc73d-f5b2-41d8-a9a4-37844e6ee8f1" />