### PR TITLE
給付金対象講座ページの最下部に受講申請のボタンを追加

### DIFF
--- a/app/views/welcome/_process.html.slim
+++ b/app/views/welcome/_process.html.slim
@@ -155,7 +155,8 @@ section.lp-content.is-lp-bg-2.is-top-title#feature
                                 | 就職に必要なのはプログラミングスキルだけではないので、
                                 | FBCを卒業したからといって、必ず就職できると断言はできませんが、
                                 | 就職を希望した卒業生のほとんどが就職しています。
-  //
+          - if is_certified_reskill_courses_page
+            = render 'welcome/certified_reskill_courses/rails_developer_course/main_actions'
     .lp-content-divider.is-lp-bg-3
       svg[data-name="lp-content-divider" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none"]
         path.shape-fill d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"

--- a/app/views/welcome/certified_reskill_courses/rails_developer_course/index.html.slim
+++ b/app/views/welcome/certified_reskill_courses/rails_developer_course/index.html.slim
@@ -47,4 +47,4 @@ hr.a-border
   = render 'welcome/certified_reskill_courses/rails_developer_course/course_details'
   = render 'welcome/certified_reskill_courses/rails_developer_course/course_requirements'
   = render 'welcome/certified_reskill_courses/rails_developer_course/course_overview'
-  = render 'welcome/process'
+  = render partial: 'welcome/process', locals: { is_certified_reskill_courses_page: true }

--- a/app/views/welcome/practices.html.slim
+++ b/app/views/welcome/practices.html.slim
@@ -78,4 +78,4 @@ article.lp
       svg[data-name="lp-content-divider" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none"]
         path.shape-fill d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
 
-= render 'welcome/process'
+= render partial: 'welcome/process', locals: { is_certified_reskill_courses_page: false }


### PR DESCRIPTION
## Issue

- #8611

## 概要
給付金対象講座ページの最下部に受講申請のボタンを追加へ追加しました。
※`/practices`ページにも同様のパーシャルが使用されていましたが、`/practices`は給付金対応コースと関連しないため、`/practices`ページには表示しないように対応しました。

## 変更確認方法

1. `chore/add-application-form-to-certified-reskill-cources-page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. `/certified_reskill_courses/rails_developer_course`へ移動
4. 最下部に給付金対応コース受講申請用の申し込みフォームがあることを確認
5. `/practices`へ移動
6. 最下部に給付金対応コース受講申請用の申し込みフォームがないことを確認


## Screenshot

### 変更前
![application_form_before_002](https://github.com/user-attachments/assets/9659281f-d3c3-45cb-be68-67443017de8e)

### 変更後
![application_form_after_000](https://github.com/user-attachments/assets/cbc21f49-43a9-44f3-a4f0-a6141784f0ff)

