### PR TITLE
RegularEvent#ended? が今日以外の日付でも正しく動作するよう修正

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -15,7 +15,7 @@ class AnnouncementsController < ApplicationController
   end
 
   def show
-    Footprint.find_or_create_by(footprintable: @announcement, user: current_user) unless @announcement.user == current_user
+    Footprint.find_or_create_for(@announcement, current_user)
     @footprints = Footprint.fetch_for_resource(@announcement)
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.with_avatar.find(params[:id])
-    Footprint.find_or_create_by(footprintable: @event, user: current_user) unless @event.user == current_user
+    Footprint.find_or_create_for(@event, current_user)
     @footprints = Footprint.fetch_for_resource(@event)
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -17,7 +17,7 @@ class ProductsController < ApplicationController
     @learning = @product.learning # decoratorメソッド用にcontrollerでインスタンス変数化
     @tweet_url = @practice.tweet_url(practice_completion_url(@practice.id))
     @recent_reports = Report.list.where(user_id: @product.user.id).limit(10)
-    Footprint.find_or_create_by(footprintable: @product, user: current_user) unless @product.user == current_user
+    Footprint.find_or_create_for(@product, current_user)
     @footprints = Footprint.fetch_for_resource(@product)
     respond_to do |format|
       format.html

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -9,7 +9,7 @@ class RegularEventsController < ApplicationController
 
   def show
     @regular_event = RegularEvent.find(params[:id])
-    Footprint.find_or_create_by(footprintable: @regular_event, user: current_user) unless @regular_event.user == current_user
+    Footprint.find_or_create_for(@regular_event, current_user)
     @footprints = Footprint.fetch_for_resource(@regular_event)
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,7 +21,7 @@ class ReportsController < ApplicationController
   def show
     @products = @report.user.products.not_wip.order(published_at: :desc)
     @recent_reports = Report.list.where(user_id: @report.user.id).limit(10)
-    Footprint.find_or_create_by(footprintable: @report, user: current_user) unless @report.user == current_user
+    Footprint.find_or_create_for(@report, current_user)
     @footprints = Footprint.fetch_for_resource(@report)
     respond_to do |format|
       format.html

--- a/app/models/footprint.rb
+++ b/app/models/footprint.rb
@@ -17,4 +17,14 @@ class Footprint < ApplicationRecord
   def self.count_for_resource(resource)
     fetch_for_resource(resource).count
   end
+
+  def self.find_or_create_for(footprintable, user)
+    return if footprintable.user == user
+
+    transaction do
+      find_or_create_by(footprintable:, user:)
+    end
+  rescue ActiveRecord::RecordNotUnique
+    find_by(footprintable:, user:)
+  end
 end

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -58,7 +58,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :participated_by, ->(user) { where(id: all.filter { |e| e.participated_by?(user) }.map(&:id)) }
   scope :organizer_event, ->(user) { where(id: user.organizers.map(&:regular_event_id)) }
   scope :scheduled_on, ->(date) { holding.filter { |event| event.scheduled_on?(date) } }
-  scope :scheduled_on_without_ended, ->(date) { holding.filter { |event| event.scheduled_on?(date) && !event.ended? } }
+  scope :scheduled_on_without_ended, ->(date) { holding.filter { |event| event.scheduled_on?(date) && !event.ended?(date) } }
 
   belongs_to :user
   has_many :organizers, dependent: :destroy
@@ -79,9 +79,9 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     all_scheduled_dates.include?(date)
   end
 
-  def ended?
-    end_time_of_today_event = Time.current.change(hour: end_at.hour, min: end_at.min)
-    Time.current >= end_time_of_today_event
+  def ended?(date)
+    end_time_of_event = date.in_time_zone.change(hour: end_at.hour, min: end_at.min)
+    Time.current >= end_time_of_event
   end
 
   def next_event_date

--- a/test/fixtures/regular_event_repeat_rules.yml
+++ b/test/fixtures/regular_event_repeat_rules.yml
@@ -109,3 +109,8 @@ regular_event_repeat_rule39:
   frequency: 0
   day_of_the_week: 0
   regular_event: regular_event37
+
+regular_event_repeat_rule40:
+  frequency: 0
+  day_of_the_week: 1
+  regular_event: regular_event38

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -207,3 +207,13 @@ regular_event37:
   end_at: <%= Time.zone.local(2024, 12, 1, 10, 0, 0) %>
   user: komagata
   published_at: "2024-12-01 00:00:00"
+
+regular_event38:
+  title: 明日開催で、時間は本日の時刻以降の定期イベント
+  description: 明日開催で時間は本日の時刻以降の定期イベントの表示テスト用
+  finished: false
+  hold_national_holiday: false
+  start_at: <%= Time.zone.local(2024, 12, 2, 9, 0, 0) %>
+  end_at: <%= Time.zone.local(2024, 12, 2, 10, 0, 0) %>
+  user: komagata
+  published_at: "2024-12-01 00:00:00"

--- a/test/fixtures/regular_events.yml
+++ b/test/fixtures/regular_events.yml
@@ -189,8 +189,8 @@ regular_event35:
   published_at: "2023-08-01 00:00:00"
 
 regular_event36:
-  title: 本日開催でまだ終了時刻を迎えていない定期イベント
-  description: 本日開催でまだ終了時刻を迎えていない定期イベントの表示テスト用
+  title: 日曜日開催で12:00に終了する定期イベント
+  description: 日曜日開催で12:00に終了する定期イベントの表示テスト用
   finished: false
   hold_national_holiday: false
   start_at: <%= Time.zone.local(2024, 12, 1, 9, 0, 0) %>
@@ -199,8 +199,8 @@ regular_event36:
   published_at: "2024-12-01 00:00:00"
 
 regular_event37:
-  title: 本日開催で終了時刻を過ぎた定期イベント
-  description: 本日開催で終了時刻を過ぎた定期イベントの表示テスト用
+  title: 日曜日開催で10:00に終了する定期イベント
+  description: 日曜日開催で10:00に終了する定期イベントの表示テスト用
   finished: false
   hold_national_holiday: false
   start_at: <%= Time.zone.local(2024, 12, 1, 9, 0, 0) %>
@@ -209,8 +209,8 @@ regular_event37:
   published_at: "2024-12-01 00:00:00"
 
 regular_event38:
-  title: 明日開催で、時間は本日の時刻以降の定期イベント
-  description: 明日開催で時間は本日の時刻以降の定期イベントの表示テスト用
+  title: 月曜日開催で10:00に終了する定期イベント
+  description: 月曜日開催で10:00に終了する定期イベントの表示テスト用
   finished: false
   hold_national_holiday: false
   start_at: <%= Time.zone.local(2024, 12, 2, 9, 0, 0) %>

--- a/test/models/footprint_test.rb
+++ b/test/models/footprint_test.rb
@@ -9,27 +9,41 @@ class FootprintTest < ActiveSupport::TestCase
   end
 
   test 'fetch_for_resource returns footprints associated with the resource' do
-    user2 = users(:machida)
-    Footprint.find_or_create_by(footprintable: @resource, user: user2)
-
+    user = users(:machida)
+    Footprint.find_or_create_by(footprintable: @resource, user:)
     footprints = Footprint.fetch_for_resource(@resource)
     assert_equal 1, footprints.count
-    assert_equal user2, footprints.first.user
+    assert_equal user, footprints.first.user
   end
 
   test 'fetch_for_resource excludes footprints of the resource owner' do
     Footprint.find_or_create_by(footprintable: @resource, user: @user)
-
     footprints = Footprint.fetch_for_resource(@resource)
     assert_equal 0, footprints.count
   end
 
   test 'count_for_resource returns the correct count of footprints for the resource' do
-    user2 = users(:machida)
-    Footprint.find_or_create_by(footprintable: @resource, user: user2)
+    user = users(:machida)
+    Footprint.find_or_create_by(footprintable: @resource, user:)
     Footprint.find_or_create_by(footprintable: @resource, user: @user)
-
     count = Footprint.count_for_resource(@resource)
     assert_equal 1, count
+  end
+
+  test 'find_or_create_for handles race conditions' do
+    user = users(:machida)
+    footprint1 = Footprint.find_or_create_for(@resource, user)
+    footprint2 = Footprint.find_or_create_for(@resource, user)
+    assert_equal footprint1.id, footprint2.id
+
+    count = Footprint.where(footprintable: @resource, user:).count
+    assert_equal 1, count
+  end
+
+  test 'find_or_create_for returns nil when footprintable user is the same as current user' do
+    result = Footprint.find_or_create_for(@resource, @user)
+    assert_nil result
+    count = Footprint.where(footprintable: @resource, user: @user).count
+    assert_equal 0, count
   end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -167,4 +167,13 @@ class RegularEventTest < ActiveSupport::TestCase
       assert_not_includes regular_events, regular_event_ended
     end
   end
+
+  test '.scheduled_on_without_ended in tomorrow’s event' do
+    travel_to Time.zone.local(2024, 12, 1, 10, 0, 0) do
+      tomorrow = Time.zone.tomorrow
+      regular_events = RegularEvent.scheduled_on_without_ended(tomorrow)
+      regular_event_scheduled_for_tomorrow = regular_events(:regular_event38)
+      assert_includes regular_events, regular_event_scheduled_for_tomorrow
+    end
+  end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -42,7 +42,7 @@ class RegularEventTest < ActiveSupport::TestCase
   test '.scheduled_on(date)' do
     travel_to Time.zone.local(2017, 4, 3, 23, 0, 0) do
       today_date = Time.zone.today
-      today_events_count = 3
+      today_events_count = 4
       today_events = RegularEvent.scheduled_on(today_date)
       assert_equal today_events_count, today_events.count
 

--- a/test/models/upcoming_event_test.rb
+++ b/test/models/upcoming_event_test.rb
@@ -14,6 +14,7 @@ class UpcomingEventTest < ActiveSupport::TestCase
       today_events = [
         events(:event27),
         events(:event33),
+        regular_events(:regular_event38),
         regular_events(:regular_event2),
         regular_events(:regular_event26),
         regular_events(:regular_event32)

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -529,7 +529,7 @@ class EventsTest < ApplicationSystemTestCase
   end
 
   test 'upcoming events groups' do
-    today_events_count = 5
+    today_events_count = 6
     tomorrow_events_count = 2
     day_after_tomorrow_events_count = 4
     travel_to Time.zone.local(2017, 4, 3, 8, 0, 0) do

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -257,6 +257,7 @@ class HomeTest < ApplicationSystemTestCase
       today_events_texts = [
         { category: '特別', title: '直近イベントの表示テスト用(当日)', start_at: '2017年04月03日(月) 09:00' },
         { category: '特別', title: 'kimura専用イベント', start_at: '2017年04月03日(月) 09:00' },
+        { category: '輪読会', title: '月曜日開催で10:00に終了する定期イベント', start_at: '2017年04月03日(月) 09:00' },
         { category: '質問', title: '質問・雑談タイム', start_at: '2017年04月03日(月) 16:00' },
         { category: '輪読会', title: 'ダッシュボード表示確認用テスト定期イベント', start_at: '2017年04月03日(月) 21:00' },
         { category: '輪読会', title: 'ダッシュボード表示確認用テスト定期イベント', start_at: '2017年04月03日(月) 21:00' }

--- a/test/system/regular_events_test.rb
+++ b/test/system/regular_events_test.rb
@@ -196,7 +196,7 @@ class RegularEventsTest < ApplicationSystemTestCase
 
   test 'show listing not finished regular events' do
     visit_with_auth regular_events_path(target: 'not_finished'), 'kimura'
-    assert_selector '.card-list.a-card .card-list-item', count: 19
+    assert_selector '.card-list.a-card .card-list-item', count: 20
   end
 
   test 'show listing all regular events' do
@@ -366,7 +366,7 @@ class RegularEventsTest < ApplicationSystemTestCase
   end
 
   test 'upcoming events groups' do
-    today_events_count = 5
+    today_events_count = 6
     tomorrow_events_count = 2
     day_after_tomorrow_events_count = 4
     travel_to Time.zone.local(2017, 4, 3, 8, 0, 0) do


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/8221

## 概要

マージされた https://github.com/fjordllc/bootcamp/pull/8280 で、以下の不具合を確認しました。

- 期待する動作：ダッシュボードの「近日開催のイベント 今日開催」のところで、終了時間が現時刻を過ぎたイベント（＝終了イベント）だけが非表示になる
- 実際の動作：本日分だけでなく、「明日開催・明後日開催」においても現時刻以降のイベントが非表示になってしまっている

そこで、「本日であること」が前提となっていた`ended?`を修正し、本日以外のイベントでも正しい判定ができるように修正いたしました。

## 変更確認方法

1. {hotfix/fix-regular-event-ended-logic}をローカルに取り込む
   - `git fetch origin pull/8655/head:feature/hotfix/fix-regular-event-ended-logic`
   - `git switch hotfix/fix-regular-event-ended-logic`
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. ローカルで確認用の定期イベントを2つ作成する
   - 本日開催で、終了時刻を（すぐ確認できるよう）3分後に設定したイベント
   - 明日開催で、同じく終了時刻を3分後に設定したイベント
4. ダッシュボード左上の「近日開催のイベント」に、上で作成した2つのイベントが表示されていることを確認
（1つは「今日開催」、もう1つは「明日開催」の欄に表示されている）
5. 3分後（本日のイベント終了後）、「近日開催のイベント」の一覧から「今日開催」の方だけが消えて「明日開催」の方は残っていることを確認

### 例

10:37に、本日の10:40に終わる定期イベントと明日の10:40に終わる定期イベントが表示されている↓
![20250512a](https://github.com/user-attachments/assets/e8fa64b8-15b6-482a-9ddf-043f726a8c5e)

10:40になると、「本日の10:40に終わる定期イベント」は非表示になり「明日の10:40に終わる定期イベント」は表示されたままになっている↓
![20250512b](https://github.com/user-attachments/assets/8ee10a5c-c293-42c7-ae7f-5c442cc1e9e1)
