### PR TITLE
質問一覧・詳細表示機能の非Vue化

### DIFF
--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -5,21 +5,7 @@ class Practices::QuestionsController < ApplicationController
 
   def index
     @practice = Practice.find(params[:practice_id])
-    @empty_message = empty_message
     @questions = @practice.questions.includes(%i[correct_answer practice answers tag_taggings tags]).order(created_at: :desc).page(params[:page])
     @questions_property = QuestionsProperty.new('全ての質問', '質問はありません。')
-  end
-
-  private
-
-  def empty_message
-    case params[:target]
-    when 'solved'
-      '解決済みのQ&Aはありません。'
-    when 'not_solved'
-      '未解決のQ&Aはありません。'
-    else
-      '質問はありません。'
-    end
   end
 end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class Practices::QuestionsController < ApplicationController
+  QuestionsProperty = Struct.new(:title, :empty_message)
+
   def index
     @practice = Practice.find(params[:practice_id])
     @empty_message = empty_message
+    @questions = @practice.questions.includes(%i[correct_answer practice answers tag_taggings tags]).order(created_at: :desc).page(params[:page])
+    @questions_property = QuestionsProperty.new('全ての質問', '質問はありません。')
   end
 
   private

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 
 class Practices::QuestionsController < ApplicationController
-  QuestionsProperty = Struct.new(:title, :empty_message)
-
   def index
     @practice = Practice.find(params[:practice_id])
-    @questions = @practice.questions.includes(%i[correct_answer practice answers tag_taggings tags]).by_target(params[:target]).order(created_at: :desc).page(params[:page])
-    @questions_property = QuestionsProperty.new('全ての質問', '質問はありません。')
+    @questions = @practice.questions.includes(%i[correct_answer practice answers tag_taggings
+                                                 tags]).by_target(params[:target]).order(created_at: :desc).page(params[:page])
+    @empty_message = empty_message
+  end
+
+  private
+
+  def empty_message
+    case params[:target]
+    when 'solved'
+      '解決済みのQ&Aはありません。'
+    when 'not_solved'
+      '未解決のQ&Aはありません。'
+    else
+      '質問はありません。'
+    end
   end
 end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -3,7 +3,13 @@
 class Practices::QuestionsController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
-    @questions = @practice.questions.includes(%i[correct_answer answers]).by_target(params[:target]).order(created_at: :desc).page(params[:page])
+    allowed_targets = %w[solved not_solved].freeze
+    target = allowed_targets.include?(params[:target]) ? params[:target] : nil
+    @questions = @practice.questions
+                          .includes(%i[correct_answer answers])
+                          .by_target(target)
+                          .order(created_at: :desc)
+                          .page(params[:page])
     @empty_message = empty_message
   end
 

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -5,7 +5,7 @@ class Practices::QuestionsController < ApplicationController
 
   def index
     @practice = Practice.find(params[:practice_id])
-    @questions = @practice.questions.includes(%i[correct_answer practice answers tag_taggings tags]).order(created_at: :desc).page(params[:page])
+    @questions = @practice.questions.includes(%i[correct_answer practice answers tag_taggings tags]).by_target(params[:target]).order(created_at: :desc).page(params[:page])
     @questions_property = QuestionsProperty.new('全ての質問', '質問はありません。')
   end
 end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -3,8 +3,7 @@
 class Practices::QuestionsController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
-    @questions = @practice.questions.includes(%i[correct_answer practice answers tag_taggings
-                                                 tags]).by_target(params[:target]).order(created_at: :desc).page(params[:page])
+    @questions = @practice.questions.includes(%i[correct_answer answers]).by_target(params[:target]).order(created_at: :desc).page(params[:page])
     @empty_message = empty_message
   end
 

--- a/app/controllers/users/questions_controller.rb
+++ b/app/controllers/users/questions_controller.rb
@@ -5,7 +5,7 @@ class Users::QuestionsController < ApplicationController
 
   def index
     @user = User.find(params[:user_id])
-    @questions = @user.questions.includes(%i[correct_answer practice answers tag_taggings tags]).order(created_at: :desc)
+    @questions = @user.questions.includes(%i[correct_answer practice answers tag_taggings tags]).order(created_at: :desc).page(params[:page])
     @questions_property = QuestionsProperty.new('全ての質問', '質問はありません。')
   end
 end

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -24,4 +24,4 @@ nav.tab-nav
 
 .page-body
   .container.is-md
-    = render 'questions/questions', questions: @questions
+    = render 'questions/questions', questions: @questions, empty_message: @empty_message

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -24,4 +24,4 @@ nav.tab-nav
 
 .page-body
   .container.is-md
-    div(data-vue='Questions' data-vue-empty-message="#{@empty_message}" data-vue-practice-id="#{params[:practice_id]}")
+    = render 'questions/questions', questions: @questions

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -27,7 +27,7 @@
       .card-list-item__row
         .card-list-item-meta
           .card-list-item-meta__items
-            - if question.wip
+            - if question.wip?
               .card-list-item-meta__item
                 .a-meta
                   | 質問作成中
@@ -37,7 +37,7 @@
       .card-list-item__row
         .card-list-item-meta
           .card-list-item-meta__items
-            - if !question.wip
+            - if !question.wip?
               .card-list-item-meta__item
                 time.a-meta
                   span.a-meta__label

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -1,6 +1,4 @@
-- question_class = 'is-solved' if question.correct_answer.present?
-- question_class = 'is-wip' if question.wip?
-.card-list-item.(class="#{question_class}")
+.card-list-item.(class="#{(question.correct_answer.present? && 'is-solved') || (question.wip? && 'is-wip')}")
   .card-list-item__inner
     .card-list-item__user
       = link_to question.user, class: 'card-list-item__user-link'

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -1,0 +1,62 @@
+.card-list-item.(class="#{question.correct_answer.present? ? 'is-solved' : (question.wip? ? 'is-wip' : '')}")
+  .card-list-item__inner
+    .card-list-item__user
+      = link_to question.user, class: 'card-list-item__user-link'
+        span.a-user-role.(class="is-#{question.user.primary_role}")
+          img.card-list-item__user-icon.a-user-icon title="#{question.user.icon_title}" alt="#{question.user.icon_title}" src="#{question.user.avatar_url}"
+    .card-list-item__rows
+      .card-list-item__row
+        .card-list-item-title
+          - if question.wip
+            .a-list-item-badge.is-wip
+              span
+                | WIP
+          h1.card-list-item-title__title itemprop='name'
+            = link_to question_path(question), class: 'card-list-item-title__link a-text-link', itemprop: 'url' do
+              = question.title
+
+      - if question.practice
+        .card-list-item__row
+          .card-list-item-meta
+            .card-list-item-meta__items
+              .card-list-item-meta__item
+                = link_to practice_path(question.practice), class: 'a-meta is-practice'
+                  - if question.practice_id != nil
+                    = question.practice.title
+
+      .card-list-item__row
+        .card-list-item-meta
+          .card-list-item-meta__items
+            - if question.wip
+              .card-list-item-meta__item
+                .a-meta
+                  | 質問作成中
+            .card-list-item-meta__item
+              = link_to question.user, class: 'a-user-name'
+                = question.user.long_name
+
+      .card-list-item__row
+        .card-list-item-meta
+          .card-list-item-meta__items
+            - if !question.wip
+              .card-list-item-meta__item
+                time.a-meta
+                  span.a-meta__label
+                    | 公開
+                  span.a-meta__value
+                    = l question.published_at, format: :default
+            - if !question.wip
+              .card-list-item-meta__item
+                time.a-meta
+                  span.a-meta__label
+                    | 更新
+                  span.a-meta__value
+                    = l question.updated_at, format: :default
+            .card-list-item-meta__item
+              .a-meta.(class="#{question.answers.size == 0 ? 'is-important' : ''}")
+                | 回答・コメント
+                = "\(#{question.answers.size}\)"
+    - if question.correct_answer.present?
+      .stamp.is-circle.is-solved
+        .stamp__content.is-icon 解
+        .stamp__content.is-icon 決

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -16,7 +16,6 @@
           h1.card-list-item-title__title itemprop='name'
             = link_to question, class: 'card-list-item-title__link a-text-link', itemprop: 'url' do
               = question.title
-
       - if question.practice
         .card-list-item__row
           .card-list-item-meta
@@ -25,7 +24,6 @@
                 = link_to question.practice, class: 'a-meta is-practice'
                   - if !question.practice_id.nil?
                     = question.practice.title
-
       .card-list-item__row
         .card-list-item-meta
           .card-list-item-meta__items
@@ -36,7 +34,6 @@
             .card-list-item-meta__item
               = link_to question.user, class: 'a-user-name'
                 = question.user.long_name
-
       .card-list-item__row
         .card-list-item-meta
           .card-list-item-meta__items

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -47,7 +47,6 @@
                     | 公開
                   span.a-meta__value
                     = l question.published_at, format: :default
-            - if !question.wip
               .card-list-item-meta__item
                 time.a-meta
                   span.a-meta__label
@@ -57,7 +56,7 @@
             .card-list-item-meta__item
               .a-meta.(class="#{question.answers.empty? ? 'is-important' : ''}")
                 | 回答・コメント
-                = "\(#{question.answers.size}\)"
+                = "（#{question.answers.size}）"
     - if question.correct_answer.present?
       .stamp.is-circle.is-solved
         .stamp__content.is-icon 解

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -1,4 +1,6 @@
-.card-list-item.(class="#{question.correct_answer.present? ? 'is-solved' : (question.wip? ? 'is-wip' : '')}")
+- question_class = 'is-solved' if question.correct_answer.present?
+- question_class = 'is-wip' if question.wip?
+.card-list-item.(class="#{question_class}")
   .card-list-item__inner
     .card-list-item__user
       = link_to question.user, class: 'card-list-item__user-link'
@@ -21,7 +23,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 = link_to practice_path(question.practice), class: 'a-meta is-practice'
-                  - if question.practice_id != nil
+                  - if question.practice_id.nil?
                     = question.practice.title
 
       .card-list-item__row
@@ -53,7 +55,7 @@
                   span.a-meta__value
                     = l question.updated_at, format: :default
             .card-list-item-meta__item
-              .a-meta.(class="#{question.answers.size == 0 ? 'is-important' : ''}")
+              .a-meta.(class="#{question.answers.empty? ? 'is-important' : ''}")
                 | 回答・コメント
                 = "\(#{question.answers.size}\)"
     - if question.correct_answer.present?

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -14,7 +14,7 @@
               span
                 | WIP
           h1.card-list-item-title__title itemprop='name'
-            = link_to question_path(question), class: 'card-list-item-title__link a-text-link', itemprop: 'url' do
+            = link_to question, class: 'card-list-item-title__link a-text-link', itemprop: 'url' do
               = question.title
 
       - if question.practice
@@ -22,7 +22,7 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                = link_to practice_path(question.practice), class: 'a-meta is-practice'
+                = link_to question.practice, class: 'a-meta is-practice'
                   - if !question.practice_id.nil?
                     = question.practice.title
 

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -7,7 +7,7 @@
     .card-list-item__rows
       .card-list-item__row
         .card-list-item-title
-          - if question.wip
+          - if question.wip?
             .a-list-item-badge.is-wip
               span
                 | WIP
@@ -20,8 +20,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 = link_to question.practice, class: 'a-meta is-practice'
-                  - if !question.practice_id.nil?
-                    = question.practice.title
+                  = question.practice.title
       .card-list-item__row
         .card-list-item-meta
           .card-list-item-meta__items

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -23,7 +23,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 = link_to practice_path(question.practice), class: 'a-meta is-practice'
-                  - if question.practice_id.nil?
+                  - if !question.practice_id.nil?
                     = question.practice.title
 
       .card-list-item__row

--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -12,6 +12,6 @@
     .card-list.a-card
       .card-list__items
         - questions.each do |question|
-          = render 'questions/question', question:
+          = render 'questions/question', question: question
   nav.pagination
     = paginate questions

--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -17,7 +17,7 @@
       .o-empty-message__icon
         i.fa-regular.fa-sad-tear
       p.o-empty-message__text
-        = @empty_message
+        = @questions_property.empty_message
 - else
   nav.pagination
     = paginate questions

--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -1,17 +1,5 @@
 - if questions.nil?
-  .card-list.a-card.is-loading
-    - 8.times do
-     .card-list-item
-        .card-list-item__inner
-          .card-list-item__user
-            .card-list-item__user-icon.a-user-icon.a-placeholder
-          .card-list-item__rows
-            .card-list-item__row
-              .card-list-item-title.a-placeholder
-            .card-list-item__row
-              .card-list-item-meta__items.a-placeholder
-                .card-list-item-meta__item
-                .card-list-item-meta__item
+  = render 'shared/loading_list_placeholder'
 - elsif questions.empty?
   .o-empty-message
       .o-empty-message__icon

--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -22,7 +22,7 @@
   nav.pagination
     = paginate questions
     .card-list.a-card
-     .card-list__items
+      .card-list__items
         - questions.each do |question|
           = render 'questions/question', question:
   nav.pagination

--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -1,4 +1,4 @@
-- if questions == nil
+- if questions.nil?
   .card-list.a-card.is-loading
     - 8.times do
      .card-list-item
@@ -24,6 +24,6 @@
     .card-list.a-card
      .card-list__items
         - questions.each do |question|
-          = render 'questions/question', question: question
+          = render 'questions/question', question:
   nav.pagination
     = paginate questions

--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -1,0 +1,29 @@
+- if questions == nil
+  .card-list.a-card.is-loading
+    - 8.times do
+     .card-list-item
+        .card-list-item__inner
+          .card-list-item__user
+            .card-list-item__user-icon.a-user-icon.a-placeholder
+          .card-list-item__rows
+            .card-list-item__row
+              .card-list-item-title.a-placeholder
+            .card-list-item__row
+              .card-list-item-meta__items.a-placeholder
+                .card-list-item-meta__item
+                .card-list-item-meta__item
+- elsif questions.empty?
+  .o-empty-message
+      .o-empty-message__icon
+        i.fa-regular.fa-sad-tear
+      p.o-empty-message__text
+        = @empty_message
+- else
+  nav.pagination
+    = paginate questions
+    .card-list.a-card
+     .card-list__items
+        - questions.each do |question|
+          = render 'questions/question', question: question
+  nav.pagination
+    = paginate questions

--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -17,7 +17,7 @@
       .o-empty-message__icon
         i.fa-regular.fa-sad-tear
       p.o-empty-message__text
-        = @questions_property.empty_message
+        = empty_message
 - else
   nav.pagination
     = paginate questions

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -52,7 +52,7 @@ header.page-header
       .container.is-md
         .page-body__columns
           .page-body__column.is-main
-            = render 'questions/questions', questions: @questions
+            = render 'questions/questions', questions: @questions, empty_message: @questions_property.empty_message
 
       - if @tags.any?
         nav.a-side-nav

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -52,7 +52,8 @@ header.page-header
       .container.is-md
         .page-body__columns
           .page-body__column.is-main
-            div(data-vue='Questions' data-vue-empty-message="#{@questions_property.empty_message}" data-vue-selected-tag="#{params[:tag]}")
+            = render 'questions/questions', questions: @questions
+
       - if @tags.any?
         nav.a-side-nav
           .a-side-nav__inner

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -53,7 +53,6 @@ header.page-header
         .page-body__columns
           .page-body__column.is-main
             = render 'questions/questions', questions: @questions, empty_message: @questions_property.empty_message
-
       - if @tags.any?
         nav.a-side-nav
           .a-side-nav__inner

--- a/app/views/shared/_loading_list_placeholder.html.slim
+++ b/app/views/shared/_loading_list_placeholder.html.slim
@@ -1,0 +1,13 @@
+.card-list.a-card.is-loading
+  - 8.times do
+    .card-list-item
+      .card-list-item__inner
+        .card-list-item__user
+          .card-list-item__user-icon.a-user-icon.a-placeholder
+        .card-list-item__rows
+          .card-list-item__row
+            .card-list-item-title.a-placeholder
+          .card-list-item__row
+            .card-list-item-meta__items.a-placeholder
+              .card-list-item-meta__item
+              .card-list-item-meta__item

--- a/app/views/users/questions/index.html.slim
+++ b/app/views/users/questions/index.html.slim
@@ -6,4 +6,4 @@
 
 .page-body
   .container.is-md
-    div(data-vue='Questions' data-vue-empty-message="#{@questions_property.empty_message}" data-vue-selected-tag="#{params[:tag]}" data-vue-user-id:number="#{params[:user_id]}")
+    = render 'questions/questions', questions: @questions

--- a/app/views/users/questions/index.html.slim
+++ b/app/views/users/questions/index.html.slim
@@ -6,4 +6,4 @@
 
 .page-body
   .container.is-md
-    = render 'questions/questions', questions: @questions
+    = render 'questions/questions', questions: @questions, empty_message: @questions_property.empty_message


### PR DESCRIPTION
## Issue

- #8499 

## 概要
質問一覧表示からvueを廃止した。
## 変更確認方法

1. chore/question_index_vue_to_vanilla_jsをローカルに取り込む
2. ユーザーhajimeでログインする
3. [質問一覧ページ](http://localhost:3000/questions?target=not_solved)にアクセスし、質問一覧が表示されることを確認する
4. 未解決・解決済み・全ての質問をクリックするとそれぞれに対応して質問一覧が入れ替わることを確認する
5. [OS X Mountain Lionをクリーンインストールするの質問一覧ページ](http://localhost:3000/practices/315059988/questions)にアクセスし、全て・解決済み・未解決の質問に対応した質問一覧が表示されることを確認する
6. [PC性能の見方を知るの質問一覧ページ](http://localhost:3000/practices/1019809339/questions)にアクセスし、全ての質問には「質問はありません」解決済みでは「解決済みのQ&Aはありません」未解決の欄では「未解決のQ&Aはありません」と表示されることを確認する
7. [ユーザーごとの質問一覧ページ](http://localhost:3000/users/253826460/questions)に質問一覧が表示されることを確認する
8. ログアウトし、ユーザーhatsunoでログインする
9. [ユーザーの質問一覧ページ](http://localhost:3000/users/655153192/questions)に「質問はありません」と表示されることを確認する

## Screenshot
vue.js廃止のため画面の変更はなし。
質問一覧表示の一例が以下のようになっている。
### 変更前
<img width="1440" alt="Q A変更前" src="https://github.com/user-attachments/assets/761ab10f-d328-4fcc-b6aa-5eb76c9a03a5" />

### 変更後
<img width="1440" alt="スクリーンショット 2025-06-05 15 40 32" src="https://github.com/user-attachments/assets/f2672f4c-52df-47ca-ac73-d344d379993f" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - 質問リストやカードのサーバーサイド描画用パーシャルテンプレートを追加しました。
  - 質問リストのローディング用プレースホルダーを追加しました。

- **改善**
  - 質問一覧ページでVue.jsコンポーネントの利用を廃止し、Railsパーシャルによるサーバーサイド描画に変更しました。
  - 質問一覧にページネーション機能を追加しました。
  - 質問取得時に関連情報を効率的に読み込み、表示順を作成日時の降順に統一しました。
  - 質問の絞り込み機能を追加し、解決済み・未解決の質問をフィルタリング可能にしました。

- **スタイル**
  - 質問カードに状態に応じたバッジやアイコンを表示するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->