### PR TITLE
提出物のOKボタンの文言を変更した

### DIFF
--- a/app/components/products/product_component.html.slim
+++ b/app/components/products/product_component.html.slim
@@ -148,7 +148,7 @@
     - if @product.checks.size > 0
       .stamp.stamp-approve
         h2.stamp__content.is-title
-          | 確認済
+          | 合格
         time.stamp__content.is-created-at
           = last_checked_at
         .stamp__content.is-user-name

--- a/app/javascript/check.vue
+++ b/app/javascript/check.vue
@@ -57,9 +57,17 @@ export default {
       return this.$store.getters.checkId
     },
     buttonLabel() {
-      return (
-        this.checkableLabel + (this.checkId ? 'の確認を取り消す' : 'を確認')
-      )
+      const path = window.location.pathname
+      if (path.includes('/products')) {
+        return (
+          this.checkableLabel +
+          (this.checkId ? 'の合格を取り消す' : 'を合格にする')
+        )
+      } else {
+        return (
+          this.checkableLabel + (this.checkId ? 'の確認を取り消す' : 'を確認')
+        )
+      }
     },
     url() {
       return this.checkId ? `/api/checks/${this.checkId}` : '/api/checks'

--- a/app/javascript/checkable.js
+++ b/app/javascript/checkable.js
@@ -46,7 +46,7 @@ export default {
             checkStamp()
             if (!this.checkId) {
               if (checkableType === 'Product') {
-                this.toast('提出物を確認済みにしました。')
+                this.toast('提出物を合格にしました。')
               } else if (checkableType === 'Report') {
                 this.toast('日報を確認済みにしました。')
               }

--- a/app/javascript/comments.vue
+++ b/app/javascript/comments.vue
@@ -79,7 +79,7 @@
                   @click='commentAndCheck',
                   :disabled='!validation || buttonDisabled')
                   i.fa-solid.fa-check
-                  | 確認OKにする
+                  | {{ checkButtonLabel }}
 </template>
 <script>
 import CSRF from 'csrf'
@@ -137,6 +137,14 @@ export default {
     },
     productCheckerId() {
       return this.$store.getters.productCheckerId
+    },
+    checkButtonLabel() {
+      const path = window.location.pathname
+      if (path.includes('/products/')) {
+        return '合格にする'
+      } else {
+        return '確認OKにする'
+      }
     }
   },
   created() {
@@ -277,7 +285,7 @@ export default {
     commentAndCheck() {
       if (
         this.commentableType === 'Product' &&
-        !window.confirm('提出物を確認済にしてよろしいですか？')
+        !window.confirm('提出物を合格にしてよろしいですか？')
       ) {
         return null
       } else {

--- a/app/javascript/components/Product.jsx
+++ b/app/javascript/components/Product.jsx
@@ -96,7 +96,7 @@ export default function Product({
         </div>
         {product.checks.size > 0 && (
           <div className=" stamp stamp-approve">
-            <h2 className="stamp__content is-title">確認済</h2>
+            <h2 className="stamp__content is-title">合格</h2>
             <time className="stamp__content is-created-at">
               {product.checks.last_created_at}
             </time>

--- a/app/javascript/product.vue
+++ b/app/javascript/product.vue
@@ -106,7 +106,7 @@
 
     .stamp.stamp-approve(v-if='product.checks.size > 0')
       h2.stamp__content.is-title
-        | 確認済
+        | 合格
       time.stamp__content.is-created-at
         | {{ product.checks.last_created_at }}
       .stamp__content.is-user-name

--- a/app/views/checks/_check-stamp.html.slim
+++ b/app/views/checks/_check-stamp.html.slim
@@ -1,6 +1,9 @@
 .stamp.stamp-approve.is-hidden
   h2.stamp__content.is-title
-    | 確認済
+    - if request.path.include?('/products')
+      | 合格
+    - else
+      | 確認済
   time.stamp__content.is-created-at
   .stamp__content.is-user-name
     .stamp__content-inner

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -74,7 +74,7 @@
 
   - if product.checks.any?
     .stamp.stamp-approve
-      h2.stamp__content.is-title 確認済
+      h2.stamp__content.is-title 合格
       time.stamp__content.is-created-at
         = l product.checks.last.created_at.to_date, format: :short
       .stamp__content.is-user-name

--- a/app/views/reports/_product.html.slim
+++ b/app/views/reports/_product.html.slim
@@ -40,7 +40,7 @@
 
     - if product.checks.any?
       .stamp.stamp-approve
-        h2.stamp__content.is-title 確認済
+        h2.stamp__content.is-title 合格
         time.stamp__content.is-created-at
           = l product.checks.last.created_at.to_date, format: :short
         .stamp__content.is-user-name

--- a/test/components/product/product_component_test.rb
+++ b/test/components/product/product_component_test.rb
@@ -216,7 +216,7 @@ class Products::ProductComponentTest < ViewComponent::TestCase
                   ))
 
     assert_selector '.stamp.stamp-approve' do
-      assert_text '確認済'
+      assert_text '合格'
       assert_text I18n.l(Time.zone.today, format: :short)
       assert_text 'komagata'
     end

--- a/test/system/api/check/products_test.rb
+++ b/test/system/api/check/products_test.rb
@@ -5,21 +5,21 @@ require 'application_system_test_case'
 class Check::ProductsTest < ApplicationSystemTestCase
   test 'user can see stamp' do
     visit_with_auth "/products/#{products(:product3).id}", 'kimura'
-    assert_text '確認済'
+    assert_text '合格'
   end
 
   test 'success product checking' do
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    click_button '提出物を確認'
-    assert_text '確認済'
-    assert has_button? '提出物の確認を取り消す'
+    click_button '提出物を合格にする'
+    assert_text '合格'
+    assert has_button? '提出物の合格を取り消す'
   end
 
   test 'when product checked learning status to complete' do
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    click_button '提出物を確認'
-    assert_text '確認済'
-    assert has_button? '提出物の確認を取り消す'
+    click_button '提出物を合格にする'
+    assert_text '合格'
+    assert has_button? '提出物の合格を取り消す'
 
     visit_with_auth "/practices/#{products(:product1).practice.id}", 'mentormentaro'
     assert_text '修了しています'
@@ -27,30 +27,29 @@ class Check::ProductsTest < ApplicationSystemTestCase
 
   test 'success product checking cancel' do
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    click_button '提出物を確認'
-    click_button '提出物の確認を取り消す'
-    assert_no_text '確認済'
-    assert has_button? '提出物を確認'
+    click_button '提出物を合格にする'
+    click_button '提出物の合格を取り消す'
+    assert has_button? '提出物を合格にする'
   end
 
   test 'comment and check product' do
     visit_with_auth "/products/#{products(:product1).id}", 'komagata'
-    fill_in 'new_comment[description]', with: '提出物でcomment+確認OKにするtest'
+    fill_in 'new_comment[description]', with: '提出物でcomment+合格にするtest'
     page.accept_confirm do
-      click_on '確認OKにする'
+      click_on '合格にする'
     end
-    assert_text '確認済'
-    assert_text '提出物でcomment+確認OKにするtest'
+    assert_text '合格'
+    assert_text '提出物でcomment+合格にするtest'
   end
 
   test 'comment and check product by mentor' do
     visit_with_auth "/products/#{products(:product1).id}", 'mentormentaro'
-    fill_in 'new_comment[description]', with: '提出物でcomment+確認OKにするtest'
+    fill_in 'new_comment[description]', with: '提出物でcomment+合格にするtest'
     page.accept_confirm do
-      click_on '確認OKにする'
+      click_on '合格にする'
     end
-    assert_text '確認済'
-    assert_text '提出物でcomment+確認OKにするtest'
+    assert_text '合格'
+    assert_text '提出物でcomment+合格にするtest'
   end
 
   test 'display error message when checking confirmed product' do
@@ -63,12 +62,13 @@ class Check::ProductsTest < ApplicationSystemTestCase
     end
 
     using_session :mentormentaro do
-      click_button '提出物を確認'
-      assert_text '確認済'
+      click_button '提出物を合格にする'
+      assert_text '合格'
+      sleep 1
     end
 
     using_session :komagata do
-      click_button '提出物を確認'
+      click_button '提出物を合格にする'
       assert_text 'この提出物は確認済です'
     end
   end

--- a/test/system/comments_test.rb
+++ b/test/system/comments_test.rb
@@ -330,9 +330,9 @@ class CommentsTest < ApplicationSystemTestCase
 
     accept_confirm do
       fill_in 'new_comment[description]', with: 'comment test'
-      click_button '確認OKにする'
+      click_button '合格にする'
     end
-    assert_text '提出物を確認済みにしました'
+    assert_text '提出物を合格にしました'
     assert_text 'comment test'
   end
 
@@ -343,9 +343,9 @@ class CommentsTest < ApplicationSystemTestCase
 
     accept_confirm do
       fill_in 'new_comment[description]', with: 'comment test'
-      click_button '確認OKにする'
+      click_button '合格にする'
     end
-    assert_text '提出物を確認済みにしました'
+    assert_text '提出物を合格にしました'
     assert_text 'comment test'
   end
 

--- a/test/system/learning_status_test.rb
+++ b/test/system/learning_status_test.rb
@@ -11,8 +11,8 @@ class LearningStatusTest < ApplicationSystemTestCase
     )
     visit_with_auth "/products/#{product.id}", 'machida'
     click_button '担当する'
-    click_button '提出物を確認'
-    click_button '提出物の確認を取り消す'
+    click_button '提出物を合格にする'
+    click_button '提出物の合格を取り消す'
     visit_with_auth "/products/#{product.id}", 'kimuramitai'
     assert_no_selector 'h2', text: 'このプラクティスは修了しました🎉'
   end
@@ -27,9 +27,9 @@ class LearningStatusTest < ApplicationSystemTestCase
     click_button '担当する'
     fill_in('new_comment[description]', with: 'LGTMです。')
     accept_alert do
-      click_button '確認OKにする'
+      click_button '合格にする'
     end
-    click_button '提出物の確認を取り消す'
+    click_button '提出物の合格を取り消す'
     visit_with_auth "/products/#{product.id}", 'kimuramitai'
     assert_no_selector 'h2', text: 'このプラクティスは修了しました🎉'
   end

--- a/test/system/notification/products_test.rb
+++ b/test/system/notification/products_test.rb
@@ -79,8 +79,8 @@ class Notification::ProductsTest < ApplicationSystemTestCase
       checker_id: checker.id
     )
     visit_with_auth "/products/#{product.id}", 'komagata'
-    click_button '提出物を確認'
-    assert_text '提出物を確認済みにしました。'
+    click_button '提出物を合格にする'
+    assert_text '提出物を合格にしました。'
 
     visit_with_auth '/notifications', 'kimura'
 

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -58,7 +58,7 @@ class Product::UncheckedTest < ApplicationSystemTestCase
       checker_id: checker.id
     )
     visit_with_auth "/products/#{product.id}", 'komagata'
-    click_button '提出物を確認'
+    click_button '提出物を合格にする'
     visit_with_auth '/products/unchecked?target=unchecked_all', 'komagata'
     assert_no_text product.practice.title
   end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -51,8 +51,8 @@ class ProductsTest < ApplicationSystemTestCase
 
   test 'not display learning completion message when a user of the completed product visits after the second time' do
     visit_with_auth "/products/#{products(:product65).id}", 'komagata'
-    click_button '提出物を確認'
-    assert_text '提出物の確認を取り消す'
+    click_button '提出物を合格にする'
+    assert_text '提出物の合格を取り消す'
     visit_with_auth "/products/#{products(:product65).id}", 'kimura'
     first('label.card-main-actions__muted-action.is-closer').click
     assert_no_text '喜びをXにポストする！'
@@ -217,7 +217,7 @@ class ProductsTest < ApplicationSystemTestCase
   test 'hide checker button at product checked' do
     visit_with_auth "/products/#{products(:product1).id}", 'machida'
     assert_button '担当する'
-    click_button '提出物を確認'
+    click_button '提出物を合格にする'
     assert_no_button '担当する'
     assert_no_button '担当から外れる'
   end


### PR DESCRIPTION
## Issue

#8610 

## 概要

「提出物を確認」ボタンを「提出物を合格にする」に、「確認OKにする」ボタンを「合格にする」ボタンにそれぞれ変更しました。同様にスタンプの表記も「確認済」から「合格」に変更しています。これらの変更を適用するためにテストの修正も行いました。

## 変更確認方法

1. `chore/change-wording-ok-button`をローカルに取り込む。
　・`git fetch origin chore/change-wording-ok-button`
　・`git checkout chore/change-wording-ok-button`
2. `foreman start -f Procfile.dev`で開発環境を立ち上げる。
　・ユーザー名`komagata`、パスワード`testtest`でログインする。
3. 任意の[提出物ページ](http://localhost:3000/products/90577869)にアクセスしてボタンラベルが「提出物を合格にする」と「合格にする」に変化していることを確認する。
4. ボタンを押した際に表示されるスタンプが「合格」に変化していることを確認する。

## Screenshot

![2025-05-12_10-24](https://github.com/user-attachments/assets/e01aa924-c329-44df-9773-b0da2e9f7fe9)

![2025-05-12_10-24_1](https://github.com/user-attachments/assets/f5041198-6c2e-42d8-a1bd-d30ed0eb9591)
![2025-05-12_10-24_2](https://github.com/user-attachments/assets/f96ebc75-3f35-47b9-8453-2eb695336c19)
![2025-05-12_10-25](https://github.com/user-attachments/assets/63724bea-26e0-4051-b044-22a85989e4f5)
![2025-05-12_10-26](https://github.com/user-attachments/assets/dd54626c-1245-40ed-a928-ef5fd83e26cf)
![2025-05-12_10-26_1](https://github.com/user-attachments/assets/73d24547-a7da-4034-9225-930d38eca939)
