### PR TITLE
ポートフォリオページにフォローボタンを追加

### DIFF
--- a/app/views/users/works/index.html.slim
+++ b/app/views/users/works/index.html.slim
@@ -1,25 +1,7 @@
 - title "#{@user.login_name}さんのポートフォリオ"
 - set_meta_tags description: "#{@user.login_name}さんのポートフォリオページです。"
 
-header.page-header
-  .container
-    .page-header__inner
-      .page-header__start
-        h2.page-header__title
-          = @user.login_name
-      .page-header__end
-        .page-header-actions
-          ul.page-header-actions__items
-            - if current_user == @user
-              li.page-header-actions__item
-                = link_to new_report_path, class: 'a-button is-md is-secondary is-block' do
-                  i.fa-regular.fa-plus
-                  span
-                    | 日報作成
-            li.page-header-actions__item
-              = link_to users_path, class: 'a-button is-md is-secondary is-block is-back' do
-                | ユーザー一覧
-
+= render 'users/page_title', user: @user
 = user_page_tabs(@user, active_tab: 'ポートフォリオ')
 
 .page-main


### PR DESCRIPTION
## Issue

- #8614

## 概要
ログインしたユーザーが他のユーザーのプロフィールページを見た時に、
日報や提出物には右上に「フォローする」ボタンがあるが、ポートフォリオページにはなかったので
ポートフォリオページにも「フォローする」ボタンを追加しました。

## 変更確認方法

1. `feature/add_follow_button_to_my_portfolio_page`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 任意のアカウントでログイン
4. ログインしたユーザーではない他のユーザーのページよりポートフォリオページを開き、右上の`ユーザー 一覧`ボタンと同じ並びに  `フォローする`ボタンがあるかを確認

## Screenshot

### 変更前
<img width="1323" alt="Screenshot 2025-05-16 at 13 51 25" src="https://github.com/user-attachments/assets/553bfa72-6106-467e-84e3-2dc1431edcaf" />

### 変更後
<img width="1321" alt="スクリーンショット 2025-05-19 16 55 30" src="https://github.com/user-attachments/assets/4385220d-110d-4b0a-a423-00a34907ad50" />

