### PR TITLE
ベストアンサースタンプに改行を追加

### DIFF
--- a/app/views/questions/_answer.html.slim
+++ b/app/views/questions/_answer.html.slim
@@ -12,7 +12,9 @@
         .answer-badge__icon
           i.fa-solid.fa-star
         .answer-badge__label
-          | ベストアンサー
+          | ベスト
+          br
+          | アンサー
       header.card-header
         h2.thread-comment__title
           a.thread-comment__title-user-link.is-hidden-md-up href="#{answer.user.url}"


### PR DESCRIPTION
## Issue

- #8620

## 概要

Q&Aのベストアンサースタンプに、ベスト（改行）アンサーと改行を入れたい。
ベスト
アンサー
となるようにする。


## 変更確認方法

1. `chore/insert_a-line_break_into_the_best_answer_stamp`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 任意のアカウントでログイン
4. [解決済みのQ＆Aのページ](http://localhost:3000/questions/302937193)に遷移して、一番下にある最新のコメントがベストアンサーとなっています。そのコメントについている`ベストアンサースタンプ`に改行が含まれているかを確認。

## Screenshot

### 変更前
<img width="1339" alt="スクリーンショット 2025-05-20 11 50 21" src="https://github.com/user-attachments/assets/a9aab613-9f4f-4a8a-adbf-c3a719dc5afb" />

### 変更後
<img width="1333" alt="スクリーンショット 2025-05-20 11 56 52" src="https://github.com/user-attachments/assets/260045ca-34a1-4d36-9e3b-5298eab34b26" />

