### PR TITLE
日報作成時の気分のデフォルトを soso に変更

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -108,7 +108,7 @@ class Report < ApplicationRecord
   end
 
   def set_default_emotion
-    self.emotion ||= 2
+    self.emotion ||= 0
   end
 
   def total_learning_time


### PR DESCRIPTION
## Issue

- #8665

## 概要
日報を作成する時の、気分のデフォルトをhappyからsosoに変更したい。

## 変更確認方法

1. `feature/change_default_mood_when_creating_report_to_soso`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 任意のアカウントでログイン
4. ダッシュボード（またはマイプロフィール）ページにある`日報作成`ボタンを押した時に、「今日の気分」のところでデフォルトが `soso`になっているかを確認。

## Screenshot

### 変更前

https://github.com/user-attachments/assets/a9ad1813-4d3c-48ea-9227-ef45934a2301

### 変更後

https://github.com/user-attachments/assets/f3026753-f056-435c-9c56-fcc7215e48aa



