### PR TITLE
escapeHTML関数内のタイポを修正し共通化した

### DIFF
--- a/app/javascript/escapeHtml.js
+++ b/app/javascript/escapeHtml.js
@@ -1,0 +1,8 @@
+export default function escapeHTML(string) {
+  return string
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+}

--- a/app/javascript/markdown-it-container-details.js
+++ b/app/javascript/markdown-it-container-details.js
@@ -1,4 +1,5 @@
 import MarkdownItContainer from 'markdown-it-container'
+import escapeHTML from './escapeHtml.js'
 
 export default (md) => {
   md.use(MarkdownItContainer, 'details', {
@@ -14,13 +15,4 @@ export default (md) => {
       }
     }
   })
-}
-
-function escapeHTML(string) {
-  return string
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
 }

--- a/app/javascript/markdown-it-container-details.js
+++ b/app/javascript/markdown-it-container-details.js
@@ -18,7 +18,7 @@ export default (md) => {
 
 function escapeHTML(string) {
   return string
-    .replace(/&/g, '&lt;')
+    .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')

--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -1,4 +1,5 @@
 import MarkdownItContainer from 'markdown-it-container'
+import escapeHTML from './escapeHtml.js'
 
 export default (md) => {
   md.use(MarkdownItContainer, 'speak', {
@@ -21,13 +22,4 @@ export default (md) => {
       }
     }
   })
-}
-
-function escapeHTML(string) {
-  return string
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
 }

--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -25,7 +25,7 @@ export default (md) => {
 
 function escapeHTML(string) {
   return string
-    .replace(/&/g, '&lt;')
+    .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')

--- a/app/javascript/replace-link-to-card.js
+++ b/app/javascript/replace-link-to-card.js
@@ -84,7 +84,7 @@ const isValidHttpUrl = (str) => {
 }
 function escapeHTML(string) {
   return string
-    .replace(/&/g, '&lt;')
+    .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')

--- a/app/javascript/replace-link-to-card.js
+++ b/app/javascript/replace-link-to-card.js
@@ -1,5 +1,6 @@
 import CSRF from 'csrf'
 import { debounce } from './debounce.js'
+import escapeHTML from './escapeHtml.js'
 
 export default (selector) => {
   const textareas = document.querySelectorAll(selector)
@@ -81,14 +82,6 @@ const isValidHttpUrl = (str) => {
   } catch (_) {
     return false
   }
-}
-function escapeHTML(string) {
-  return string
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
 }
 
 const isTweet = (url) => {


### PR DESCRIPTION
## Issue

- https://github.com/fjordllc/bootcamp/issues/8674

## 概要

JavaScript内で定義されていた`escapeHTML`という関数の中に誤字があり、本来 `&` と表示されるべき箇所が `<` と表示されてしまう状態だったので、修正しました。
また、該当する関数が3つのファイルで全く同じ定義をされていたので、今回の修正に合わせて共通化も行いました。

## 変更確認方法

### 修正前の状態の確認

1. mainブランチにいることを確認する
2. foreman start -f Procfile.devでローカルサーバを立ち上げる
3. 任意のユーザーでログインし、日報作成ページ等のテキスト入力欄に以下の貼り付け用テキストをコピー＆ペーストする

### 修正後の状態の確認

1. {feature/bug/fix-typo-in-escape-html-function}をローカルに取り込む
   - git fetch origin pull/8696/head:feature/bug/fix-typo-in-escape-html-function
   - git switch bug/fix-typo-in-escape-html-function
2. foreman start -f Procfile.devでローカルサーバを立ち上げる
3. 任意のユーザーでログインし、日報作成ページ等のテキスト入力欄に以下の貼り付け用テキストをコピー＆ペーストする

```
# 確認用に日報に貼り付けるためのテキスト
---

:::details aaa&aaa

Detailタイトルの「＆」が「＜」にならないか確認

:::

---

:::speak @aaa&aaa

上の話者の「＆」が「＜」にならないか確認

:::

---

@[card](https://boot&camp.fjord.jp/)

上のURL内の「＆」が「＜」にならないか確認

---
```

## Screenshot

### 変更前

![20250523_1](https://github.com/user-attachments/assets/a87fdab6-ef1b-49d2-b2f2-8a6543f4c8a6)

### 変更後

![20250523_2](https://github.com/user-attachments/assets/b78d130f-b9dc-41e4-9c3f-b1393c310976)
