### PR TITLE
本番・ステージング環境でのリダイレクトURLに「http://」を許可する設定を追加

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -14,6 +14,9 @@ orm :active_record
     end
   end
 
+  # 本番・ステージング環境でもリダイレクトURLに「http://」を許可
+  force_ssl_in_redirect_uri false
+
   # クライアントアプリが、BootCampアプリのリソースをどの範囲まで使用できるかを設定
   # Scopesのドキュメント：https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
   # read = 読み取り, write = 書き込み 


### PR DESCRIPTION
## Issue

- Issue番号

## 概要
[OAuth2.0 プロバイダー機能](https://github.com/fjordllc/bootcamp/pull/8250)追加の修正です。本番・ステージング環境でのリダイレクトURLに「http://」を許可する設定を追加しました。

参考記事
- https://blog.piyo.tech/posts/2015-12-06-000000/

## 変更確認方法

本番・ステージング環境でのみ変更を確認できるため、Develop 環境での変更確認はありません。

## Screenshot

### 変更前

### 変更後

