### PR TITLE
活動時間別の一覧ページを実装

### DIFF
--- a/app/controllers/users/activity_times_controller.rb
+++ b/app/controllers/users/activity_times_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class Users::ActivityTimesController < ApplicationController
+  PAGER_NUMBER = 24
+
+  def index
+    set_current_time
+    @target_day_of_week = params[:day_of_week] || @current_day_of_week
+    @target_hour = params[:hour] || @current_hour
+
+    Rails.logger.debug "ActivityTimes: day_of_week=#{@target_day_of_week}, hour=#{@target_hour}"
+
+    target_users = fetch_users_by_activity_time(@target_day_of_week, @target_hour)
+    Rails.logger.debug "ActivityTimes: target_users.count=#{target_users.count}"
+
+    @users = target_users
+             .page(params[:page]).per(PAGER_NUMBER)
+             .preload(:avatar_attachment, :course, :taggings)
+             .order(updated_at: :desc)
+
+    Rails.logger.debug "ActivityTimes: @users.count=#{@users.count}"
+    Rails.logger.debug "ActivityTimes: @users.total_count=#{@users.total_count}"
+  end
+
+  private
+
+  def set_current_time
+    now = Time.current
+    @current_day_of_week = now.wday.to_s
+    @current_hour = now.hour.to_s
+  end
+
+  def fetch_users_by_activity_time(day_of_week, hour)
+    return User.none unless valid_day_of_week?(day_of_week) && valid_hour?(hour)
+
+    # 曜日名を数値から文字列に変換
+    week_day_name = convert_day_of_week_to_name(day_of_week)
+
+    # 指定された曜日と時間に活動時間を設定しているユーザーを取得
+    User.joins(:learning_time_frames)
+        .where(learning_time_frames: { week_day: week_day_name, activity_time: hour.to_i })
+        .students_and_trainees
+        .distinct
+  end
+
+  def convert_day_of_week_to_name(day_of_week)
+    day_names = %w[日 月 火 水 木 金 土]
+    day_names[day_of_week.to_i]
+  end
+
+  def valid_day_of_week?(day_of_week)
+    day_of_week.to_s.match?(/\A[0-6]\z/)
+  end
+
+  def valid_hour?(hour)
+    hour.to_s.match?(/\A(?:[0-9]|1[0-9]|2[0-3])\z/)
+  end
+end

--- a/app/controllers/users/activity_times_controller.rb
+++ b/app/controllers/users/activity_times_controller.rb
@@ -8,18 +8,12 @@ class Users::ActivityTimesController < ApplicationController
     @target_day_of_week = params[:day_of_week] || @current_day_of_week
     @target_hour = params[:hour] || @current_hour
 
-    Rails.logger.debug "ActivityTimes: day_of_week=#{@target_day_of_week}, hour=#{@target_hour}"
-
     target_users = fetch_users_by_activity_time(@target_day_of_week, @target_hour)
-    Rails.logger.debug "ActivityTimes: target_users.count=#{target_users.count}"
 
     @users = target_users
              .page(params[:page]).per(PAGER_NUMBER)
              .preload(:avatar_attachment, :course, :taggings)
              .order(updated_at: :desc)
-
-    Rails.logger.debug "ActivityTimes: @users.count=#{@users.count}"
-    Rails.logger.debug "ActivityTimes: @users.total_count=#{@users.total_count}"
   end
 
   private
@@ -31,28 +25,13 @@ class Users::ActivityTimesController < ApplicationController
   end
 
   def fetch_users_by_activity_time(day_of_week, hour)
-    return User.none unless valid_day_of_week?(day_of_week) && valid_hour?(hour)
+    return User.none unless day_of_week.to_s.match?(/\A[0-6]\z/) && hour.to_s.match?(/\A(?:[0-9]|1[0-9]|2[0-3])\z/)
 
-    # 曜日名を数値から文字列に変換
-    week_day_name = convert_day_of_week_to_name(day_of_week)
+    week_day_name = helpers.day_of_the_week[day_of_week.to_i]
 
-    # 指定された曜日と時間に活動時間を設定しているユーザーを取得
-    User.joins(:learning_time_frames)
+    User.joins(learning_time_frames_users: :learning_time_frame)
         .where(learning_time_frames: { week_day: week_day_name, activity_time: hour.to_i })
-        .students_and_trainees
+        .students_trainees_mentors_and_admins
         .distinct
-  end
-
-  def convert_day_of_week_to_name(day_of_week)
-    day_names = %w[日 月 火 水 木 金 土]
-    day_names[day_of_week.to_i]
-  end
-
-  def valid_day_of_week?(day_of_week)
-    day_of_week.to_s.match?(/\A[0-6]\z/)
-  end
-
-  def valid_hour?(hour)
-    hour.to_s.match?(/\A(?:[0-9]|1[0-9]|2[0-3])\z/)
   end
 end

--- a/app/helpers/page_tabs/users_helper.rb
+++ b/app/helpers/page_tabs/users_helper.rb
@@ -24,6 +24,7 @@ module PageTabs
     def users_page_tabs(active_tab:)
       tabs = []
       tabs << { name: '全て', link: users_path }
+      tabs << { name: '活動時間別', link: users_activity_times_path }
       tabs << { name: 'コース別', link: users_courses_path }
       tabs << { name: '期生別', link: generations_path }
       tabs << { name: 'タグ別', link: users_tags_path }

--- a/app/javascript/stylesheets/_common-imports.sass
+++ b/app/javascript/stylesheets/_common-imports.sass
@@ -156,6 +156,7 @@
 @import shared/blocks/pill-nav
 @import shared/blocks/prism-ghcolors
 @import shared/blocks/tab-nav
+@import shared/blocks/hour-filter
 @import shared/blocks/not-logged-in-footer
 
 @import shared/blocks/card/card-body

--- a/app/javascript/stylesheets/shared/blocks/_hour-filter.sass
+++ b/app/javascript/stylesheets/shared/blocks/_hour-filter.sass
@@ -106,15 +106,7 @@
 @media (max-width: 768px)
   .activity-time-filter__controls
     flex-direction: column
-    align-items: stretch
     gap: .75rem
-  
-  .dropdown-group
-    justify-content: space-between
-  
-  .dropdown-wrapper
-    flex: 1
   
   .dropdown-button
     width: 100%
-    justify-content: space-between

--- a/app/javascript/stylesheets/shared/blocks/_hour-filter.sass
+++ b/app/javascript/stylesheets/shared/blocks/_hour-filter.sass
@@ -1,0 +1,120 @@
+.activity-time-filter
+  padding-block: .875rem
+  border-bottom: solid 1px var(--border)
+
+.activity-time-filter__form
+  width: 100%
+
+.activity-time-filter__controls
+  display: flex
+  gap: 1rem
+  align-items: center
+  flex-wrap: wrap
+
+.dropdown-group
+  display: flex
+  gap: .5rem
+  align-items: center
+
+.dropdown-wrapper
+  position: relative
+  display: inline-block
+
+.dropdown-button
+  +block-link
+  +text-block(.75rem 2.3, left nowrap)
+  color: var(--semi-muted-text)
+  border: solid 1px var(--border-shade)
+  border-radius: 20rem
+  transition: all .2s ease-out
+  padding: .5rem 1rem
+  background-color: var(--background)
+  cursor: pointer
+  display: flex
+  align-items: center
+  gap: .5rem
+  min-width: 8rem
+  &:hover
+    background-color: var(--background-semi-shade)
+  &:focus
+    outline: none
+    box-shadow: 0 0 0 2px var(--main-alpha)
+
+.dropdown-button__text
+  flex: 1
+
+.dropdown-button__icon
+  font-size: .75rem
+  transition: transform .2s ease-out
+
+.dropdown-menu
+  position: absolute
+  top: 100%
+  left: 0
+  z-index: 1000
+  background-color: var(--background)
+  border: solid 1px var(--border-shade)
+  border-radius: .5rem
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1)
+  min-width: 100%
+  max-height: 200px
+  overflow-y: auto
+  opacity: 0
+  visibility: hidden
+  transform: translateY(-10px)
+  transition: all .2s ease-out
+  &.is-open
+    opacity: 1
+    visibility: visible
+    transform: translateY(0)
+    .dropdown-button__icon
+      transform: rotate(180deg)
+
+.dropdown-item
+  padding: .5rem 1rem
+  cursor: pointer
+  transition: background-color .2s ease-out
+  +text-block(.75rem 1.5, left nowrap)
+  &:hover
+    background-color: var(--background-semi-shade)
+  &:first-child
+    border-radius: .5rem .5rem 0 0
+  &:last-child
+    border-radius: 0 0 .5rem .5rem
+
+.search-button
+  +block-link
+  +text-block(.75rem 2.3, center nowrap)
+  background-color: var(--main)
+  border: solid 1px var(--main)
+  color: var(--reversal-text)
+  border-radius: 20rem
+  transition: all .2s ease-out
+  padding: .5rem 1.5rem
+  cursor: pointer
+  display: flex
+  align-items: center
+  gap: .5rem
+  &:hover
+    background-color: var(--main-shade)
+    border-color: var(--main-shade)
+  &:focus
+    outline: none
+    box-shadow: 0 0 0 2px var(--main-alpha)
+
+// レスポンシブ対応
+@media (max-width: 768px)
+  .activity-time-filter__controls
+    flex-direction: column
+    align-items: stretch
+    gap: .75rem
+  
+  .dropdown-group
+    justify-content: space-between
+  
+  .dropdown-wrapper
+    flex: 1
+  
+  .dropdown-button
+    width: 100%
+    justify-content: space-between

--- a/app/views/users/activity_times/_activity_time_tabs.html.slim
+++ b/app/views/users/activity_times/_activity_time_tabs.html.slim
@@ -1,0 +1,80 @@
+.activity-time-filter
+  .container
+    = form_with url: users_activity_times_path, method: 'get', local: true, class: 'activity-time-filter__form' do |f|
+      .activity-time-filter__controls
+        .dropdown-group
+          .dropdown-wrapper
+            button.dropdown-button type="button" data-target="day-dropdown"
+              - day_names = ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日']
+              span.dropdown-button__text = day_names[@target_day_of_week.to_i]
+              i.fas.fa-chevron-down.dropdown-button__icon
+            .dropdown-menu id="day-dropdown"
+              - day_names.each_with_index do |day_name, index|
+                .dropdown-item data-value=index
+                  = day_name
+            = hidden_field_tag :day_of_week, @target_day_of_week, id: 'selected-day'
+
+          .dropdown-wrapper
+            button.dropdown-button type="button" data-target="hour-dropdown"
+              span.dropdown-button__text = "#{@target_hour}:00-#{(@target_hour.to_i + 1) % 24}:00"
+              i.fas.fa-chevron-down.dropdown-button__icon
+            .dropdown-menu id="hour-dropdown"
+              - (0..23).each do |hour|
+                .dropdown-item data-value=hour
+                  = "#{hour}:00-#{(hour + 1) % 24}:00"
+            = hidden_field_tag :hour, @target_hour, id: 'selected-hour'
+
+        button.search-button type="submit"
+          i.fas.fa-search
+          span 検索
+
+javascript:
+  document.addEventListener('DOMContentLoaded', function() {
+    // プルダウンメニューの動作
+    const dropdownButtons = document.querySelectorAll('.dropdown-button');
+    const dropdownMenus = document.querySelectorAll('.dropdown-menu');
+    
+    dropdownButtons.forEach(button => {
+      button.addEventListener('click', function(e) {
+        e.preventDefault();
+        const targetId = this.getAttribute('data-target');
+        const targetMenu = document.getElementById(targetId);
+        
+        // 他のメニューを閉じる
+        dropdownMenus.forEach(menu => {
+          if (menu.id !== targetId) {
+            menu.classList.remove('is-open');
+          }
+        });
+        
+        // 対象メニューをトグル
+        targetMenu.classList.toggle('is-open');
+      });
+    });
+    
+    // プルダウンアイテムの選択
+    const dropdownItems = document.querySelectorAll('.dropdown-item');
+    dropdownItems.forEach(item => {
+      item.addEventListener('click', function() {
+        const value = this.getAttribute('data-value');
+        const text = this.textContent.trim();
+        const dropdown = this.closest('.dropdown-wrapper');
+        const button = dropdown.querySelector('.dropdown-button__text');
+        const hiddenField = dropdown.querySelector('input[type="hidden"]');
+        const menu = dropdown.querySelector('.dropdown-menu');
+        
+        button.textContent = text;
+        hiddenField.value = value;
+        menu.classList.remove('is-open');
+      });
+    });
+    
+    // 外部クリックで閉じる
+    document.addEventListener('click', function(e) {
+      if (!e.target.closest('.dropdown-wrapper')) {
+        dropdownMenus.forEach(menu => {
+          menu.classList.remove('is-open');
+        });
+      }
+    });
+  });

--- a/app/views/users/activity_times/_activity_time_tabs.html.slim
+++ b/app/views/users/activity_times/_activity_time_tabs.html.slim
@@ -1,16 +1,16 @@
 .activity-time-filter
   .container
-    = form_with url: users_activity_times_path, method: 'get', local: true, class: 'activity-time-filter__form' do |f|
+    = form_with url: users_activity_times_path, method: 'get', local: true, class: 'activity-time-filter__form' do
       .activity-time-filter__controls
         .dropdown-group
           .dropdown-wrapper
             button.dropdown-button type="button" data-target="day-dropdown"
-              - day_names = ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日']
+              - day_names = day_of_the_week.map { |d| "#{d}曜日" }
               span.dropdown-button__text = day_names[@target_day_of_week.to_i]
               i.fas.fa-chevron-down.dropdown-button__icon
             .dropdown-menu id="day-dropdown"
-              - day_names.each_with_index do |day_name, index|
-                .dropdown-item data-value=index
+              - day_names.each_with_index do |day_name, _index|
+                .dropdown-item data-value=_index
                   = day_name
             = hidden_field_tag :day_of_week, @target_day_of_week, id: 'selected-day'
 
@@ -19,7 +19,7 @@
               span.dropdown-button__text = "#{@target_hour}:00-#{(@target_hour.to_i + 1) % 24}:00"
               i.fas.fa-chevron-down.dropdown-button__icon
             .dropdown-menu id="hour-dropdown"
-              - (0..23).each do |hour|
+              - 24.times do |hour|
                 .dropdown-item data-value=hour
                   = "#{hour}:00-#{(hour + 1) % 24}:00"
             = hidden_field_tag :hour, @target_hour, id: 'selected-hour'
@@ -30,51 +30,41 @@
 
 javascript:
   document.addEventListener('DOMContentLoaded', function() {
-    // プルダウンメニューの動作
     const dropdownButtons = document.querySelectorAll('.dropdown-button');
     const dropdownMenus = document.querySelectorAll('.dropdown-menu');
-    
+
+    // プルダウンメニューの開閉
     dropdownButtons.forEach(button => {
       button.addEventListener('click', function(e) {
         e.preventDefault();
-        const targetId = this.getAttribute('data-target');
-        const targetMenu = document.getElementById(targetId);
-        
-        // 他のメニューを閉じる
+        const targetMenu = document.getElementById(this.getAttribute('data-target'));
+
         dropdownMenus.forEach(menu => {
-          if (menu.id !== targetId) {
-            menu.classList.remove('is-open');
-          }
+          if (menu !== targetMenu) menu.classList.remove('is-open');
         });
-        
-        // 対象メニューをトグル
+
         targetMenu.classList.toggle('is-open');
       });
     });
-    
+
     // プルダウンアイテムの選択
-    const dropdownItems = document.querySelectorAll('.dropdown-item');
-    dropdownItems.forEach(item => {
+    document.querySelectorAll('.dropdown-item').forEach(item => {
       item.addEventListener('click', function() {
-        const value = this.getAttribute('data-value');
-        const text = this.textContent.trim();
         const dropdown = this.closest('.dropdown-wrapper');
         const button = dropdown.querySelector('.dropdown-button__text');
         const hiddenField = dropdown.querySelector('input[type="hidden"]');
         const menu = dropdown.querySelector('.dropdown-menu');
-        
-        button.textContent = text;
-        hiddenField.value = value;
+
+        button.textContent = this.textContent.trim();
+        hiddenField.value = this.getAttribute('data-value');
         menu.classList.remove('is-open');
       });
     });
-    
+
     // 外部クリックで閉じる
     document.addEventListener('click', function(e) {
       if (!e.target.closest('.dropdown-wrapper')) {
-        dropdownMenus.forEach(menu => {
-          menu.classList.remove('is-open');
-        });
+        dropdownMenus.forEach(menu => menu.classList.remove('is-open'));
       }
     });
   });

--- a/app/views/users/activity_times/index.html.slim
+++ b/app/views/users/activity_times/index.html.slim
@@ -18,32 +18,17 @@ main.page-main
     .container
       .page-main-header__inner
         h1.page-main-header__title
-          | 活動時間別ユーザー一覧
-          - if @users.respond_to?(:total_count)
-            | （#{@users.total_count}）
-          - else
-            | （0）
+          ruby:
+            day_names = day_of_the_week.map { |d| "#{d}曜日" }
+            day_index = @target_day_of_week.to_i.clamp(0, 6)
+            hour_display = @target_hour.to_i.clamp(0, 23)
+            count = @users.respond_to?(:total_count) ? @users.total_count : 0
+          | (#{day_names[day_index]})#{hour_display}:00-#{(hour_display + 1) % 24}:00(#{count})
   hr.a-border
   .page-body.is-users
     .page-body__inner
       .container
         .users
-          .page-filter.form.pt-0
-            .container.is-md.has-no-x-padding
-              .form__items
-                .form-item.is-inline-md-up
-                  label.a-form-label
-                    | 現在の絞り込み（検索条件）
-                  .form-item-text
-                    - begin
-                      - day_names = ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日']
-                      - day_index = [@target_day_of_week.to_i, 0].max
-                      - day_index = [day_index, 6].min
-                      - hour_display = [@target_hour.to_i, 0].max
-                      - hour_display = [hour_display, 23].min
-                      strong = "#{day_names[day_index]} #{hour_display}:00-#{(hour_display + 1) % 24}:00を活動時間として設定しているユーザー"
-                    - rescue => e
-                      span.text-danger 絞り込み条件にエラーがあります
           .page-content.is-users
             #user_lists.users__items
               - if @users.present?

--- a/app/views/users/activity_times/index.html.slim
+++ b/app/views/users/activity_times/index.html.slim
@@ -1,0 +1,56 @@
+- title '活動時間別ユーザー一覧'
+- set_meta_tags description: '活動時間別ユーザー一覧ページです。'
+
+header.page-header
+  .container
+    .page-header__inner
+      .page-header__start
+        h2.page-header__title ユーザー一覧
+      .page-header__end
+        .page-header-actions
+          ul.page-header-actions__items
+
+= users_page_tabs(active_tab: '活動時間別')
+= render 'activity_time_tabs'
+
+main.page-main
+  header.page-main-header
+    .container
+      .page-main-header__inner
+        h1.page-main-header__title
+          | 活動時間別ユーザー一覧
+          - if @users.respond_to?(:total_count)
+            | （#{@users.total_count}）
+          - else
+            | （0）
+  hr.a-border
+  .page-body.is-users
+    .page-body__inner
+      .container
+        .users
+          .page-filter.form.pt-0
+            .container.is-md.has-no-x-padding
+              .form__items
+                .form-item.is-inline-md-up
+                  label.a-form-label
+                    | 現在の絞り込み（検索条件）
+                  .form-item-text
+                    - begin
+                      - day_names = ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日']
+                      - day_index = [@target_day_of_week.to_i, 0].max
+                      - day_index = [day_index, 6].min
+                      - hour_display = [@target_hour.to_i, 0].max
+                      - hour_display = [hour_display, 23].min
+                      strong = "#{day_names[day_index]} #{hour_display}:00-#{(hour_display + 1) % 24}:00を活動時間として設定しているユーザー"
+                    - rescue => e
+                      span.text-danger 絞り込み条件にエラーがあります
+          .page-content.is-users
+            #user_lists.users__items
+              - if @users.present?
+                = render 'users/user_list', users: @users
+              - else
+                .empty-state
+                  p.empty-state__message
+                    | 指定された時間帯を活動時間として設定しているユーザーは見つかりませんでした。
+                  p.empty-state__suggestion
+                    | 別の曜日や時間帯を試してみてください。

--- a/config/routes/users.rb
+++ b/config/routes/users.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     resources :courses, only: %i(index)
     resources :companies, only: %i(index)
     resources :areas, only: %i(index)
+    resources :activity_times, only: %i(index)
     get "areas/:area", to: "areas#show", as: :area
   end
 

--- a/test/system/users/activity_times_test.rb
+++ b/test/system/users/activity_times_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class Users::ActivityTimesTest < ApplicationSystemTestCase
+  setup do
+    # kimuraの活動時間を設定: 日曜日の21時と月曜日の10時
+    kimura = users(:kimura)
+    sunday_twenty_one = learning_time_frames(:sun21)
+    monday_ten = learning_time_frames(:mon10)
+
+    LearningTimeFramesUser.create!(user: kimura, learning_time_frame: sunday_twenty_one)
+    LearningTimeFramesUser.create!(user: kimura, learning_time_frame: monday_ten)
+
+    # hatsunoの活動時間を設定: 火曜日の15時
+    hatsuno = users(:hatsuno)
+    tuesday_fifteen = learning_time_frames(:tue15)
+
+    LearningTimeFramesUser.create!(user: hatsuno, learning_time_frame: tuesday_fifteen)
+  end
+
+  test 'show users by activity time on sunday twenty one' do
+    visit_with_auth '/users/activity_times?day_of_week=0&hour=21', 'kimura'
+
+    assert_text 'Kimura Tadasi'
+    assert_no_text 'Hatsuno Shinji'
+  end
+
+  test 'show users by activity time on monday ten' do
+    visit_with_auth '/users/activity_times?day_of_week=1&hour=10', 'kimura'
+
+    assert_text 'Kimura Tadasi'
+    assert_no_text 'Hatsuno Shinji'
+  end
+
+  test 'show users by activity time on tuesday fifteen' do
+    visit_with_auth '/users/activity_times?day_of_week=2&hour=15', 'kimura'
+
+    assert_text 'Hatsuno Shinji'
+    assert_no_text 'Kimura Tadasi'
+  end
+
+  test 'show no users when no one is active at that time' do
+    visit_with_auth '/users/activity_times?day_of_week=3&hour=5', 'kimura'
+
+    assert_no_text 'Kimura Tadasi'
+    assert_no_text 'Hatsuno Shinji'
+  end
+
+  test 'show users with current time as default' do
+    travel_to Time.zone.local(2024, 1, 7, 21, 0, 0) do
+      visit_with_auth '/users/activity_times', 'kimura'
+
+      assert_text 'Kimura Tadasi'
+      assert_no_text 'Hatsuno Shinji'
+    end
+  end
+
+  test 'show different users when changing time parameters' do
+    visit_with_auth '/users/activity_times?day_of_week=0&hour=21', 'kimura'
+    assert_text 'Kimura Tadasi'
+    assert_no_text 'Hatsuno Shinji'
+
+    # パラメータを変更して火曜日の15時にアクセス
+    visit '/users/activity_times?day_of_week=2&hour=15'
+    assert_text 'Hatsuno Shinji'
+    assert_no_text 'Kimura Tadasi'
+  end
+
+  test 'admin, mentor, student, and trainee users are included in results' do
+    # 管理者・メンター・受講生・研修生の活動時間を設定
+    komagata = users(:komagata) # 管理者・メンター
+    kensyu = users(:kensyu)     # 研修生
+    users(:kimura) # 受講生
+    sunday_twenty_one = learning_time_frames(:sun21)
+    LearningTimeFramesUser.create!(user: komagata, learning_time_frame: sunday_twenty_one)
+    LearningTimeFramesUser.create!(user: kensyu, learning_time_frame: sunday_twenty_one)
+
+    visit_with_auth '/users/activity_times?day_of_week=0&hour=21', 'kimura'
+
+    # すべて表示される
+    assert_text 'Kimura Tadasi'
+    assert_text 'Kensyu Seiko'
+    assert_text 'Komagata Masaki'
+  end
+
+  test 'graduated and retired users are excluded from results' do
+    # 卒業生の活動時間を設定してみる
+    sotugyou = users(:sotugyou)
+    sunday_twenty_one = learning_time_frames(:sun21)
+    LearningTimeFramesUser.create!(user: sotugyou, learning_time_frame: sunday_twenty_one)
+
+    # 退会者の活動時間を設定してみる
+    yameo = users(:yameo)
+    LearningTimeFramesUser.create!(user: yameo, learning_time_frame: sunday_twenty_one)
+
+    visit_with_auth '/users/activity_times?day_of_week=0&hour=21', 'kimura'
+
+    # kimuraは受講生なので表示される
+    assert_text 'Kimura Tadasi'
+    # 卒業生・退会者は表示されない
+    assert_no_text '卒業 太郎'
+    assert_no_text '辞目 辞目夫'
+  end
+
+  test 'trainee users are included in results' do
+    # 研修生の活動時間を設定
+    kensyu = users(:kensyu)
+    sunday_twenty_one = learning_time_frames(:sun21)
+    LearningTimeFramesUser.create!(user: kensyu, learning_time_frame: sunday_twenty_one)
+
+    visit_with_auth '/users/activity_times?day_of_week=0&hour=21', 'kimura'
+
+    # kimura（受講生）とkensyu（研修生）の両方が表示される
+    assert_text 'Kimura Tadasi'
+    assert_text 'Kensyu Seiko'
+  end
+
+  test 'invalid day_of_week parameter shows no users' do
+    visit_with_auth '/users/activity_times?day_of_week=7&hour=21', 'kimura'
+
+    assert_no_text 'Kimura Tadasi'
+    assert_no_text 'Hatsuno Shinji'
+  end
+
+  test 'invalid hour parameter shows no users' do
+    visit_with_auth '/users/activity_times?day_of_week=0&hour=25', 'kimura'
+
+    assert_no_text 'Kimura Tadasi'
+    assert_no_text 'Hatsuno Shinji'
+  end
+end


### PR DESCRIPTION
## Issue

#8579 

## 概要

/usersに「活動時間別」タブを実装しました。曜日と時間で該当する活動時間のユーザを絞り込み検索できます。ページを開いた時点では現在の曜日と時間帯にもとづいて検索が行われます。

## 変更確認方法

1. `feature/add-user-activity-time-tab`をローカルに取り込む。
　・`git fetch origin feature/add-user-activity-time-tab`
　・`git checkout feature/add-user-activity-time-tab`
2. `foreman start -f Procfile.dev`で開発環境を立ち上げる。
　・ユーザー名`komagata`、パスワード`testtest`でログインする。
3. [登録情報変更ページ](http://localhost:3000/current_user/edit)で任意の活動時間を選択する。
4. [活動時間別ページ](http://localhost:3000/users/activity_times)で設定通りにユーザがヒットすることを確認する。同様に、設定していない曜日と時間帯でなにもヒットしないことを確認する。
5. `bin/rails test test/system/users/activity_times_test.rb`を実行してテストが通過することを確認する。

## Screenshot


![2025-05-27_07-46](https://github.com/user-attachments/assets/c5fec23c-5f0b-480c-bcc2-d832552d5ddb)

![2025-05-27_08-56](https://github.com/user-attachments/assets/761d03d6-a53e-41b3-8b97-050ff07cb782)

![2025-05-27_08-57](https://github.com/user-attachments/assets/041c0213-ede6-4104-be84-97f3bd399132)

