### PR TITLE
ダッシュボードのタブの順番を変更する #8725

### DIFF
--- a/app/helpers/page_tabs/dashboard_helper.rb
+++ b/app/helpers/page_tabs/dashboard_helper.rb
@@ -7,8 +7,8 @@ module PageTabs
       tabs << { name: 'ダッシュボード', link: '/' }
       tabs << { name: '自分の日報', link: current_user_reports_path, count: current_user.reports.length }
       tabs << { name: '自分の提出物', link: current_user_products_path, count: current_user.products.length }
-      tabs << { name: 'Watch中', link: current_user_watches_path }
       tabs << { name: 'ブックマーク', link: current_user_bookmarks_path, count: current_user.bookmarks.length }
+      tabs << { name: 'Watch中', link: current_user_watches_path }
       render PageTabsComponent.new(tabs:, active_tab:)
     end
   end


### PR DESCRIPTION
## Issue

- [ダッシュボードのタブの順番を変更する #8725](https://github.com/fjordllc/bootcamp/issues/8725#event-17975060545)

## 概要
ダッシュボードにある**Watch中**と**ブックマークのタブ**の順番を変更する
![image](https://github.com/user-attachments/assets/9137c245-6fab-4978-ba08-f3be3b435eca)

## 変更確認方法

1. `chore/reordering-dashboard-tabs`をローカルに取り込む
　　i. `git fetch origin chore/reordering-dashboard-tabs`
       ii. `git checkout chore/reordering-dashboard-tabs`
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. ログインする(誰でもよい)
4. ダッシュボードにアクセスし、以下を確認する
    - [x] ダッシュボードのタブの順番が以下の通りになっている
    **ダッシュボード**→**自分の日報**→**自分の提出物**→**ブックマーク**→**Watch中**

## Screenshot

### 変更前
<img width="465" alt="ダッシュボードタブ変更" src="https://github.com/user-attachments/assets/614c0364-1ec4-4636-bb69-b88c673c192d" />

### 変更後
<img width="455" alt="(修正後)ダッシュボードタブ変更" src="https://github.com/user-attachments/assets/fbfe3517-7e17-4fe9-98d0-5d7c04daf9bd" />
