### PR TITLE
コーディングテストページのリンク先が間違っていたのを修正

### DIFF
--- a/app/views/mentor/practices/coding_tests/index.html.slim
+++ b/app/views/mentor/practices/coding_tests/index.html.slim
@@ -20,7 +20,7 @@ header.page-header
           .page-main-header-actions
             .page-main-header-actions__items
               .page-main-header-actions__item
-                = link_to mentor_courses_path, class: 'a-button is-md is-secondary is-block is-back' do
+                = link_to mentor_coding_tests_path, class: 'a-button is-md is-secondary is-block is-back' do
                   | テスト一覧
   hr.a-border
   .page-body


### PR DESCRIPTION
## Issue

- #8554 

## 概要

[コーディングテストの並び替え機能の実装](https://github.com/fjordllc/bootcamp/pull/8582#event-17767639727)をした際に作成したページでリンク先に間違いがあったのを修正

## 変更確認方法

1. `bug/fix-coding-tests-links`をローカルに取り込む
2. [コーディングテストの並び変えページ](http://localhost:3000/mentor/practices/257702873/coding_tests)にアクセスする
3. ページ右上のテスト一覧ボタンをクリックし、正しくコーディングテスト一覧ページに遷移することを確認する

## Movie

### 変更前
https://github.com/user-attachments/assets/35f1e0dd-57ca-49ff-bf68-991fa3d4f2b7
### 変更後
https://github.com/user-attachments/assets/13529fea-ffe8-4ac2-8254-3b3f5c9cbe18