### PR TITLE
ユーザー画像のファイル名・拡張子が変換されることで落ちるようになったテストを修正

### DIFF
--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -601,7 +601,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_text 'Kimura', count: 2
   end
 
-  test 'can upload heic image as user avatar' do
+  test 'can upload heic image and converts it to webp with login_name' do
     skip 'HEICのサポートがないため、CI では実行されません。' if ENV['CI']
 
     visit_with_auth '/current_user/edit', 'hajime'
@@ -610,7 +610,7 @@ class UsersTest < ApplicationSystemTestCase
 
     assert_text 'ユーザー情報を更新しました。'
     img = find('img.user-profile__user-icon-image', visible: false)
-    assert_match(/heic-sample-file\.png$/, img.native['src'])
+    assert_match(/hajime\.webp$/, img.native['src'])
   end
 
   test 'mentor can see retired and hibernated tabs' do


### PR DESCRIPTION
## Issue

- Issue番号

## 概要

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

