### PR TITLE
日報の個別ページにそのユーザーの未チェックの日報数を表示した

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -5,12 +5,7 @@ module UserDecorator
 
   include Role
   include Retire
-
-  SUCCESS = (0..1)
-  LAST_UNCHECKED_REPORT_COUNT = 1
-  PRIMARY = (2..4)
-  WARNING = (5..9)
-  DANGER = (10..)
+  include ReportStatus
 
   def twitter_url
     "https://twitter.com/#{twitter_account}"
@@ -48,19 +43,6 @@ module UserDecorator
 
   def private_name
     "#{name} (#{name_kana})"
-  end
-
-  def user_report_count_class(count)
-    case count
-    when SUCCESS
-      'is-success'
-    when PRIMARY
-      'is-primary'
-    when WARNING
-      'is-warning'
-    else
-      'is-danger'
-    end
   end
 
   def enrollment_period
@@ -121,15 +103,5 @@ module UserDecorator
     classes = ['a-user-role', "is-#{primary_role}"]
     classes << 'is-new-user' if joining_status == 'new-user'
     classes.join(' ')
-  end
-
-  def unchecked_report_message(count, user)
-    if count.zero?
-      "#{user.login_name}さんの日報へ"
-    elsif count == LAST_UNCHECKED_REPORT_COUNT
-      "#{user.login_name}さんの未チェックの日報はこれで最後です。"
-    else
-      "#{user.login_name}さんの未チェックの日報が#{count}件あります。"
-    end
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -6,6 +6,12 @@ module UserDecorator
   include Role
   include Retire
 
+  SUCCESS = (0..1)
+  LAST_UNCHECKED_REPORT_COUNT = 1
+  PRIMARY = (2..4)
+  WARNING = (5..9)
+  DANGER = (10..)
+
   def twitter_url
     "https://twitter.com/#{twitter_account}"
   end
@@ -42,6 +48,19 @@ module UserDecorator
 
   def private_name
     "#{name} (#{name_kana})"
+  end
+
+  def user_report_count_class(count)
+    case count
+    when SUCCESS
+      'is-success'
+    when PRIMARY
+      'is-primary'
+    when WARNING
+      'is-warning'
+    else
+      'is-danger'
+    end
   end
 
   def enrollment_period
@@ -102,5 +121,15 @@ module UserDecorator
     classes = ['a-user-role', "is-#{primary_role}"]
     classes << 'is-new-user' if joining_status == 'new-user'
     classes.join(' ')
+  end
+
+  def unchecked_report_message(count, user)
+    if count.zero?
+      "#{user.login_name}さんの日報へ"
+    elsif count == LAST_UNCHECKED_REPORT_COUNT
+      "#{user.login_name}さんの未チェックの日報はこれで最後です。"
+    else
+      "#{user.login_name}さんの未チェックの日報が#{count}件あります。"
+    end
   end
 end

--- a/app/decorators/user_decorator/report_status.rb
+++ b/app/decorators/user_decorator/report_status.rb
@@ -2,25 +2,16 @@
 
 module UserDecorator
   module ReportStatus
-    # 色分けのための定数
-    SUCCESS = (0..1)
-    PRIMARY = (2..4)
-    WARNING = (5..9)
-    DANGER = (10..)
+    REPORT_COUNT_LEVELS = {
+      'is-success' => 0..1,
+      'is-primary' => 2..4,
+      'is-warning' => 5..9
+    }.freeze
 
-    LAST_UNCHECKED_REPORT_COUNT = 1 # unchecked_report_messageのための定数
+    LAST_UNCHECKED_REPORT_COUNT = 1
 
     def user_report_count_class(count)
-      case count
-      when SUCCESS
-        'is-success'
-      when PRIMARY
-        'is-primary'
-      when WARNING
-        'is-warning'
-      else
-        'is-danger'
-      end
+      REPORT_COUNT_LEVELS.find { |_, range| range.include?(count) }&.first || 'is-danger'
     end
 
     def unchecked_report_message(count, user)

--- a/app/decorators/user_decorator/report_status.rb
+++ b/app/decorators/user_decorator/report_status.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module UserDecorator
+  module ReportStatus
+    # 色分けのための定数
+    SUCCESS = (0..1)
+    PRIMARY = (2..4)
+    WARNING = (5..9)
+    DANGER = (10..)
+
+    LAST_UNCHECKED_REPORT_COUNT = 1 # unchecked_report_messageのための定数
+
+    def user_report_count_class(count)
+      case count
+      when SUCCESS
+        'is-success'
+      when PRIMARY
+        'is-primary'
+      when WARNING
+        'is-warning'
+      else
+        'is-danger'
+      end
+    end
+
+    def unchecked_report_message(count, user)
+      if count.zero?
+        "#{user.login_name}さんの日報へ"
+      elsif count == LAST_UNCHECKED_REPORT_COUNT
+        "#{user.login_name}さんの未チェックの日報はこれで最後です。"
+      else
+        "#{user.login_name}さんの未チェックの日報が#{count}件あります。"
+      end
+    end
+  end
+end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module ReportsHelper
+  SUCCESS = (0..1)
+  LAST_UNCHECKED_REPORT_COUNT = 1
+  PRIMARY = (2..4)
+  WARNING = (5..9)
+  DANGER = (10..)
+
   def practice_options(categories)
     categories.flat_map do |category|
       category.practices.map do |practice|

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -52,4 +52,14 @@ module ReportsHelper
       'is-danger'
     end
   end
+
+  def unchecked_report_message(count, user)
+    if count.zero?
+      "#{user.login_name}さんの日報へ"
+    elsif count == LAST_UNCHECKED_REPORT_COUNT
+      "#{user.login_name}さんの未チェックの日報はこれで最後です。"
+    else
+      "#{user.login_name}さんの未チェックの日報が#{count}件あります。"
+    end
+  end
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module ReportsHelper
-
   def practice_options(categories)
     categories.flat_map do |category|
       category.practices.map do |practice|
@@ -34,6 +33,4 @@ module ReportsHelper
   def category_practices(report)
     report.practices.eager_load(:categories).order('categories_practices.position')
   end
-
-
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 module ReportsHelper
-  SUCCESS = (0..1)
-  LAST_UNCHECKED_REPORT_COUNT = 1
-  PRIMARY = (2..4)
-  WARNING = (5..9)
-  DANGER = (10..)
 
   def practice_options(categories)
     categories.flat_map do |category|
@@ -40,26 +35,5 @@ module ReportsHelper
     report.practices.eager_load(:categories).order('categories_practices.position')
   end
 
-  def user_report_count_class(count)
-    case count
-    when SUCCESS
-      'is-success'
-    when PRIMARY
-      'is-primary'
-    when WARNING
-      'is-warning'
-    else
-      'is-danger'
-    end
-  end
 
-  def unchecked_report_message(count, user)
-    if count.zero?
-      "#{user.login_name}さんの日報へ"
-    elsif count == LAST_UNCHECKED_REPORT_COUNT
-      "#{user.login_name}さんの未チェックの日報はこれで最後です。"
-    else
-      "#{user.login_name}さんの未チェックの日報が#{count}件あります。"
-    end
-  end
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -39,4 +39,17 @@ module ReportsHelper
   def category_practices(report)
     report.practices.eager_load(:categories).order('categories_practices.position')
   end
+
+  def user_report_count_class(count)
+    case count
+    when SUCCESS
+      'is-success'
+    when PRIMARY
+      'is-primary'
+    when WARNING
+      'is-warning'
+    else
+      'is-danger'
+    end
+  end
 end

--- a/app/javascript/stylesheets/application.sass
+++ b/app/javascript/stylesheets/application.sass
@@ -13,6 +13,7 @@
 @import application/blocks/auth-form/skip-practices
 
 @import application/blocks/cards/card-counts
+@import application/blocks/cards/card-body-main-actions
 
 @import application/blocks/company/company-links
 @import application/blocks/company/company-profile

--- a/app/javascript/stylesheets/application/blocks/cards/_card-body-main-actions.sass
+++ b/app/javascript/stylesheets/application/blocks/cards/_card-body-main-actions.sass
@@ -1,4 +1,4 @@
-.event-main-actions
+.card-body-main-actions
   +position(relative, 1)
   padding-block: .75rem
   margin-inline: 1rem
@@ -9,39 +9,39 @@
   +media-breakpoint-down(sm)
     padding-inline: .75rem
     margin-bottom: 1rem
-  &.is-participationed
+  &.is-success
     background-color: #f8fff2
     border: 1px solid var(--success)
-    color: #4e732e
-  &.is-unparticipationed.is-available
+    color: var(--success-text)
+  &.is-primary
     border: 1px solid var(--primary)
     background-color: #f5f5ff
-    color: #28248c
-  &.is-unparticipationed.is-capacity-over
+    color: var(--primary-text)
+  &.is-warning
     border: 1px solid var(--warning)
     background-color: #fff9e7
-    color: #6f5819
-  &.is-non-participationed
+    color: var(--warning-text)
+  &.is-danger
     border: 1px solid var(--danger)
     background-color: var(--danger-tint)
-    color: var(--danger)
+    color: var(--danger-text)
 
-.event-main-actions__description
+.card-body-main-actions__description
   +text-block(.875rem 1.4)
   margin-bottom: .75em
   text-align: center
 
-.event-main-actions__items
+.card-body-main-actions__items
   display: flex
   justify-content: center
 
-.event-main-actions__item
+.card-body-main-actions__item
   text-align: center
   flex: 1
   +media-breakpoint-up(md)
     max-width: 16rem
 
-.event-main-actions__item-cancel
+.card-body-main-actions__item-cancel
   +hover-link-reversal
   color: var(--muted-text)
   font-size: .8125rem

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -12,6 +12,16 @@ class Cache
       Rails.cache.delete 'unchecked_report_count'
     end
 
+    def user_unchecked_report_count(user)
+      Rails.cache.fetch "#{user.id}-user_unchecked_report_count" do
+        Report.unchecked.not_wip.user(user).count
+      end
+    end
+
+    def delete_user_unchecked_report_count(user_id)
+      Rails.cache.delete "#{user_id}-user_unchecked_report_count"
+    end
+
     def unchecked_product_count
       Rails.cache.fetch 'unchecked_product_count' do
         Product.unhibernated_user_products.unchecked.not_wip.count

--- a/app/models/check_callbacks.rb
+++ b/app/models/check_callbacks.rb
@@ -24,7 +24,9 @@ class CheckCallbacks
   def delete_report_cache(check)
     return unless check.checkable_type == 'Report'
 
+    report = check.checkable
     Cache.delete_unchecked_report_count
+    Cache.delete_user_unchecked_report_count(report.user_id)
   end
 
   def delete_product_cache(check)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -60,6 +60,8 @@ class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
       .default_order
   }
 
+  scope :user, ->(user) { where(user_id: user.id) }
+
   class << self
     def faces
       @faces ||= emotions.keys

--- a/app/models/report_callbacks.rb
+++ b/app/models/report_callbacks.rb
@@ -7,6 +7,7 @@ class ReportCallbacks
 
   def after_destroy(report)
     Cache.delete_unchecked_report_count
+    Cache.delete_user_unchecked_report_count(report.user_id)
     delete_notification(report)
   end
 

--- a/app/models/report_notifier.rb
+++ b/app/models/report_notifier.rb
@@ -4,6 +4,7 @@ class ReportNotifier
   def call(_name, _started, _finished, _unique_id, payload)
     report = payload[:report]
     Cache.delete_unchecked_report_count
+    Cache.delete_user_unchecked_report_count(report.user_id)
 
     return unless report.first_public?
 

--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -6,7 +6,7 @@
     .card-body__description
       .a-long-text.is-md.js-markdown-view(data-taskable-id="#{report.id}" data-taskable-type='Report' data-taskable="#{report.taskable?(current_user).to_s}")
         = report.description
-    .card-body__user_report_count
+    .card-body__user_report_count(class="#{mentor_login? ? 'is-only-mentor' : ''}")
       == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
   hr.a-border-tint
   = render 'reactions/reactions', reactionable: report

--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -8,13 +8,13 @@
         = report.description
     - if staff_login?
       - count = Cache.user_unchecked_report_count(report.user)
-      .card-body-main-actions(class="#{user_report_count_class(count)} #{mentor_login? ? 'is-only-mentor' : ''}")
+      .card-body-main-actions(class="#{report.user.user_report_count_class(count)} #{mentor_login? ? 'is-only-mentor' : ''}")
         .card-body-main-actions__description
           p
-            = unchecked_report_message(count, report.user)
+            = report.user.unchecked_report_message(count, report.user)
         ul.card-body-main-actions__items
           li.card-body-main-actions__item
-            = link_to user_reports_path(report.user), class: "card-body-main-actions__action a-button is-sm #{user_report_count_class(count)} is-block", target: '_blank', rel: 'noopener' do
+            = link_to user_reports_path(report.user), class: "card-body-main-actions__action a-button is-sm #{report.user.user_report_count_class(count)} is-block", target: '_blank', rel: 'noopener' do
               | #{report.user.login_name}さんの日報一覧へ
     - else
       .card-body-main-actions.p-0

--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -6,6 +6,8 @@
     .card-body__description
       .a-long-text.is-md.js-markdown-view(data-taskable-id="#{report.id}" data-taskable-type='Report' data-taskable="#{report.taskable?(current_user).to_s}")
         = report.description
+    .card-body__user_report_count
+      == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
   hr.a-border-tint
   = render 'reactions/reactions', reactionable: report
 

--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -7,50 +7,14 @@
       .a-long-text.is-md.js-markdown-view(data-taskable-id="#{report.id}" data-taskable-type='Report' data-taskable="#{report.taskable?(current_user).to_s}")
         = report.description
     - if staff_login?
-      // 1件〜4件の場合
-      .card-body-main-actions.is-primary(class="#{mentor_login? ? 'is-only-mentor' : ''}")
+      - count = Cache.user_unchecked_report_count(report.user)
+      .card-body-main-actions(class="#{user_report_count_class(count)} #{mentor_login? ? 'is-only-mentor' : ''}")
         .card-body-main-actions__description
           p
-            == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
+            = unchecked_report_message(count, report.user)
         ul.card-body-main-actions__items
           li.card-body-main-actions__item
-            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-primary is-block' do
-              | #{report.user.login_name}さんの日報一覧へ
-      // 5件〜9件の場合
-      .card-body-main-actions.is-warning(class="#{mentor_login? ? 'is-only-mentor' : ''}")
-        .card-body-main-actions__description
-          p
-            == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
-        ul.card-body-main-actions__items
-          li.card-body-main-actions__item
-            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-warning is-block' do
-              | #{report.user.login_name}さんの日報一覧へ
-      // 10件以上の場合
-      .card-body-main-actions.is-danger(class="#{mentor_login? ? 'is-only-mentor' : ''}")
-        .card-body-main-actions__description
-          p
-            == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
-        ul.card-body-main-actions__items
-          li.card-body-main-actions__item
-            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-danger is-block' do
-              | #{report.user.login_name}さんの日報一覧へ
-      // 1件でかつそれがこの日報の場合
-      .card-body-main-actions.is-success(class="#{mentor_login? ? 'is-only-mentor' : ''}")
-        .card-body-main-actions__description
-          p
-            == "#{report.user.login_name}さんの未チェックの日報はこれで最後です。"
-        ul.card-body-main-actions__items
-          li.card-body-main-actions__item
-            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-success is-block' do
-              | #{report.user.login_name}さんの日報一覧へ
-      // 0の場合
-      .card-body-main-actions.is-success(class="#{mentor_login? ? 'is-only-mentor' : ''}")
-        .card-body-main-actions__description
-          p
-            == "#{report.user.login_name}さんの日報へ"
-        ul.card-body-main-actions__items
-          li.card-body-main-actions__item
-            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-success is-block' do
+            = link_to user_reports_path(report.user), class: "card-body-main-actions__action a-button is-sm #{user_report_count_class(count)} is-block" do
               | #{report.user.login_name}さんの日報一覧へ
     - else
       .card-body-main-actions.p-0

--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -6,8 +6,9 @@
     .card-body__description
       .a-long-text.is-md.js-markdown-view(data-taskable-id="#{report.id}" data-taskable-type='Report' data-taskable="#{report.taskable?(current_user).to_s}")
         = report.description
-    .card-body__user_report_count(class="#{mentor_login? ? 'is-only-mentor' : ''}")
-      == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
+    - if staff_login?
+      .card-body__user_report_count(class="#{mentor_login? ? 'is-only-mentor' : ''}")
+        == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
   hr.a-border-tint
   = render 'reactions/reactions', reactionable: report
 

--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -7,8 +7,58 @@
       .a-long-text.is-md.js-markdown-view(data-taskable-id="#{report.id}" data-taskable-type='Report' data-taskable="#{report.taskable?(current_user).to_s}")
         = report.description
     - if staff_login?
-      .card-body__user_report_count(class="#{mentor_login? ? 'is-only-mentor' : ''}")
-        == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
+      // 1件〜4件の場合
+      .card-body-main-actions.is-primary(class="#{mentor_login? ? 'is-only-mentor' : ''}")
+        .card-body-main-actions__description
+          p
+            == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
+        ul.card-body-main-actions__items
+          li.card-body-main-actions__item
+            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-primary is-block' do
+              | #{report.user.login_name}さんの日報一覧へ
+      // 5件〜9件の場合
+      .card-body-main-actions.is-warning(class="#{mentor_login? ? 'is-only-mentor' : ''}")
+        .card-body-main-actions__description
+          p
+            == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
+        ul.card-body-main-actions__items
+          li.card-body-main-actions__item
+            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-warning is-block' do
+              | #{report.user.login_name}さんの日報一覧へ
+      // 10件以上の場合
+      .card-body-main-actions.is-danger(class="#{mentor_login? ? 'is-only-mentor' : ''}")
+        .card-body-main-actions__description
+          p
+            == "#{report.user.login_name}さんの未チェックの日報が#{Cache.user_unchecked_report_count(report.user)}件あります。"
+        ul.card-body-main-actions__items
+          li.card-body-main-actions__item
+            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-danger is-block' do
+              | #{report.user.login_name}さんの日報一覧へ
+      // 1件でかつそれがこの日報の場合
+      .card-body-main-actions.is-success(class="#{mentor_login? ? 'is-only-mentor' : ''}")
+        .card-body-main-actions__description
+          p
+            == "#{report.user.login_name}さんの未チェックの日報はこれで最後です。"
+        ul.card-body-main-actions__items
+          li.card-body-main-actions__item
+            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-success is-block' do
+              | #{report.user.login_name}さんの日報一覧へ
+      // 0の場合
+      .card-body-main-actions.is-success(class="#{mentor_login? ? 'is-only-mentor' : ''}")
+        .card-body-main-actions__description
+          p
+            == "#{report.user.login_name}さんの日報へ"
+        ul.card-body-main-actions__items
+          li.card-body-main-actions__item
+            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-success is-block' do
+              | #{report.user.login_name}さんの日報一覧へ
+    - else
+      .card-body-main-actions.p-0
+        ul.card-body-main-actions__items
+          li.card-body-main-actions__item
+            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-secondary is-block' do
+              | #{report.user.login_name}さんの日報一覧へ
+
   hr.a-border-tint
   = render 'reactions/reactions', reactionable: report
 

--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -14,13 +14,13 @@
             = unchecked_report_message(count, report.user)
         ul.card-body-main-actions__items
           li.card-body-main-actions__item
-            = link_to user_reports_path(report.user), class: "card-body-main-actions__action a-button is-sm #{user_report_count_class(count)} is-block" do
+            = link_to user_reports_path(report.user), class: "card-body-main-actions__action a-button is-sm #{user_report_count_class(count)} is-block", target: '_blank', rel: 'noopener' do
               | #{report.user.login_name}さんの日報一覧へ
     - else
       .card-body-main-actions.p-0
         ul.card-body-main-actions__items
           li.card-body-main-actions__item
-            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-secondary is-block' do
+            = link_to user_reports_path(report.user), class: 'card-body-main-actions__action a-button is-sm is-secondary is-block', target: '_blank', rel: 'noopener' do
               | #{report.user.login_name}さんの日報一覧へ
 
   hr.a-border-tint

--- a/test/decorators/user_decorator/report_status.rb
+++ b/test/decorators/user_decorator/report_status.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_decorator_test_case'
+
+module UserDecorator
+  class ReportStatusTest < ActiveDecoratorTestCase
+    test 'user_report_count_class' do
+      assert_equal 'is-success', user_report_count_class(0)
+      assert_equal 'is-success', user_report_count_class(1)
+
+      assert_equal 'is-primary', user_report_count_class(2)
+      assert_equal 'is-primary', user_report_count_class(4)
+
+      assert_equal 'is-warning', user_report_count_class(5)
+      assert_equal 'is-warning', user_report_count_class(9)
+
+      assert_equal 'is-danger', user_report_count_class(10)
+      assert_equal 'is-danger', user_report_count_class(100)
+    end
+
+    test 'unchecked_report_message' do
+      user = users(:hajime)
+      assert_equal "#{user.login_name}さんの日報へ", unchecked_report_message(0, user)
+      assert_equal "#{user.login_name}さんの未チェックの日報はこれで最後です。", unchecked_report_message(1, user)
+      assert_equal "#{user.login_name}さんの未チェックの日報が2件あります。", unchecked_report_message(2, user)
+    end
+  end
+end

--- a/test/helpers/reports_helper_test.rb
+++ b/test/helpers/reports_helper_test.rb
@@ -28,4 +28,11 @@ class ReportsHelperTest < ActionView::TestCase
     assert_equal 'is-danger', user_report_count_class(10)
     assert_equal 'is-danger', user_report_count_class(100)
   end
+
+  test 'unchecked_report_message' do
+    user = users(:hajime)
+    assert_equal "#{user.login_name}さんの日報へ", unchecked_report_message(0, user)
+    assert_equal "#{user.login_name}さんの未チェックの日報はこれで最後です。", unchecked_report_message(1, user)
+    assert_equal "#{user.login_name}さんの未チェックの日報が2件あります。", unchecked_report_message(2, user)
+  end
 end

--- a/test/helpers/reports_helper_test.rb
+++ b/test/helpers/reports_helper_test.rb
@@ -14,4 +14,18 @@ class ReportsHelperTest < ActionView::TestCase
       CategoriesPractice.create!(category_id: categories(:category2).id, practice_id: practices(:practice2).id, position: 7)
     end
   end
+
+  test 'user_report_count_class' do
+    assert_equal 'is-success', user_report_count_class(0)
+    assert_equal 'is-success', user_report_count_class(1)
+
+    assert_equal 'is-primary', user_report_count_class(2)
+    assert_equal 'is-primary', user_report_count_class(4)
+
+    assert_equal 'is-warning', user_report_count_class(5)
+    assert_equal 'is-warning', user_report_count_class(9)
+
+    assert_equal 'is-danger', user_report_count_class(10)
+    assert_equal 'is-danger', user_report_count_class(100)
+  end
 end

--- a/test/helpers/reports_helper_test.rb
+++ b/test/helpers/reports_helper_test.rb
@@ -14,25 +14,4 @@ class ReportsHelperTest < ActionView::TestCase
       CategoriesPractice.create!(category_id: categories(:category2).id, practice_id: practices(:practice2).id, position: 7)
     end
   end
-
-  test 'user_report_count_class' do
-    assert_equal 'is-success', user_report_count_class(0)
-    assert_equal 'is-success', user_report_count_class(1)
-
-    assert_equal 'is-primary', user_report_count_class(2)
-    assert_equal 'is-primary', user_report_count_class(4)
-
-    assert_equal 'is-warning', user_report_count_class(5)
-    assert_equal 'is-warning', user_report_count_class(9)
-
-    assert_equal 'is-danger', user_report_count_class(10)
-    assert_equal 'is-danger', user_report_count_class(100)
-  end
-
-  test 'unchecked_report_message' do
-    user = users(:hajime)
-    assert_equal "#{user.login_name}さんの日報へ", unchecked_report_message(0, user)
-    assert_equal "#{user.login_name}さんの未チェックの日報はこれで最後です。", unchecked_report_message(1, user)
-    assert_equal "#{user.login_name}さんの未チェックの日報が2件あります。", unchecked_report_message(2, user)
-  end
 end


### PR DESCRIPTION
## Issue

- #8702

## 概要
日報の個別ページにそのユーザーの未チェックの日報数を表示した

## 変更確認方法

1. `feature/show-user-unchecked-report-count-only-mentor`をローカルに取り込む
```
git fetch origin feature/show-user-unchecked-report-count-only-mentor
git checkout feature/show-user-unchecked-report-count-only-mentor
```
2. ユーザー名`komagata`、password`testtest`でログインをする。
3. 左上のメンターモードがオンであることを確認する。
4. サイドバーの「日報・ブログ」をクリックし、未チェックの日報に飛ぶ。
5. 以下の日報に移動し、日報本文下にそれぞれの文言を確認する。
  i.「[MaruMaru Inc.の研修生のテスト日報14です](http://localhost:3000/reports/293279706)」で「marumarushain14さんの未チェックの日報はこれで最後です。」という文言を確認し、「日報を確認」をクリック。
 ii.ページを更新し、「marumarushain14さんの日報へ」と変更されていることを確認する。
 iii.「[ 2日目 昨日よりできなかった ](http://localhost:3000/reports/469634013)」で「hatsunoさんの未チェックの日報が3件あります。」の文言を確認する。
 IV.「[ 今日は頑張りました](http://localhost:3000/reports/12168338)」で「hajimeさんの未チェックの日報が5件あります。」
 V.「[ 日報70 ](http://localhost:3000/reports/646578073)」で「with-hyphenさんの未チェックの日報が34件あります。」の文言を確認する
6.メンターモードをオフにして、表示が消えることを確認する。

## Screenshot
### 変更前
<img width="726" alt="image" src="https://github.com/user-attachments/assets/ed91efad-8962-4f23-972a-08bc72171f2f" />

### 変更後

<img width="724" alt="image" src="https://github.com/user-attachments/assets/a7d611e3-1ae0-4752-ad19-43aed8e1ab52" />

<img width="702" alt="image" src="https://github.com/user-attachments/assets/90036c24-2448-4e2e-9839-ad6c9f157768" />

<img width="709" alt="image" src="https://github.com/user-attachments/assets/8c224cca-e7cf-44f8-82c8-764c82988203" />

<img width="722" alt="image" src="https://github.com/user-attachments/assets/2caaf9ce-5ed1-4799-b438-68f506d3acfb" />

<img width="709" alt="image" src="https://github.com/user-attachments/assets/e8637272-cc47-4a9a-b8f9-f2563b5dc9eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * スタッフユーザー向けに、各ユーザーの未チェックレポート数をレポート詳細画面で表示する機能を追加しました。未チェックレポート数に応じて表示メッセージやボタンの色が変化します。

* **スタイル**
  * レポートアクションやカード要素の新しいスタイルを追加・調整しました。

* **バグ修正**
  * 未チェックレポート数のキャッシュがユーザーごとに適切にクリアされるよう改善しました。

* **テスト**
  * レポート数による表示クラスやメッセージのテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->