### PR TITLE
企業のロゴを表示する際、WebP形式に変換する

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Company < ApplicationRecord
+  include ActionView::Helpers::AssetUrlHelper
+
   LOGO_SIZE = [88, 88].freeze
   has_many :users, dependent: :nullify
   validates :name, presence: true

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -10,7 +10,7 @@ class Company < ApplicationRecord
 
   def logo_url
     if logo.attached?
-      logo.variant(resize_to_limit: LOGO_SIZE).processed.url
+      logo.variant(resize_to_limit: LOGO_SIZE, format: :webp).processed.url
     else
       image_url('/images/companies/logos/default.png')
     end

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CompanyTest < ActiveSupport::TestCase
+  test '#logo_url' do
+    company_with_logo = companies(:company1)
+    assert_includes company_with_logo.logo_url, '1.webp'
+
+    company_without_logo = companies(:company5)
+    assert_equal '/images/companies/logos/default.png', company_without_logo.logo_url
+  end
+end

--- a/test/system/answers_test.rb
+++ b/test/system/answers_test.rb
@@ -118,7 +118,7 @@ class AnswersTest < ApplicationSystemTestCase
     page.all('.a-form-tabs__tab.js-tabs__tab')[1].click
     click_button 'コメントする'
     assert_text 'test'
-    assert_includes ['2.png', 'default.png'], File.basename(find('img.thread-comment__company-logo')['src'])
+    assert_includes ['2.webp', 'default.png'], File.basename(find('img.thread-comment__company-logo')['src'])
   end
 
   test 'using file uploading by file selection dialogue in textarea' do

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -12,6 +12,6 @@ class AttachmentsTest < ApplicationSystemTestCase
   test 'attachment company-logo in reports' do
     report = reports(:report11)
     visit_with_auth "/reports/#{report.id}", 'kensyu'
-    assert_includes ['2.png', 'default.png'], File.basename(find('img.page-content-header__company-logo-image')['src'])
+    assert_includes ['2.webp', 'default.png'], File.basename(find('img.page-content-header__company-logo-image')['src'])
   end
 end

--- a/test/system/comment/mention_and_interaction_test.rb
+++ b/test/system/comment/mention_and_interaction_test.rb
@@ -23,7 +23,7 @@ class MentionAndInteractionTest < ApplicationSystemTestCase
     fill_in('new_comment[description]', with: 'test')
     click_button 'コメントする'
     assert_text 'test'
-    assert_includes ['2.png', 'default.png'], File.basename(find('img.thread-comment__company-logo')['src'])
+    assert_includes ['2.webp', 'default.png'], File.basename(find('img.thread-comment__company-logo')['src'])
   end
 
   test 'using file uploading by file selection dialogue in textarea' do


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8710 

## 概要
企業のロゴを表示する際、データ形式をWebPで表示するようにしました。

## 変更確認方法

1. `chore/convert-company-logo-format-to-WebP`をローカルに取り込み、取り込んだブランチにチェックアウトする
2. `foreman start -f Procfile.dev`でローカルサーバーを起動
3. 管理者(komagata)でログイン
4. 企業作成ページ(`http://localhost:3000/admin/companies/new`)にアクセスし、各項目に適当な値を入力して企業を作成する。この時、ロゴに適当な画像を選択しておく。
5. 企業を作成すると企業一覧ページに遷移する。デベロッパーツールの`Network`を開き、作成した企業のロゴがwebp形式となっていることを確認する
![98268008-CD29-4561-A55A-32DE370A2FB9](https://github.com/user-attachments/assets/1fb4db57-4116-4a92-9e81-7b52784afab6)

## Screenshot

### 変更前

![FD85307C-7232-475E-BCAC-641F6D689BB1](https://github.com/user-attachments/assets/86e1bf24-3c4b-4743-b632-7d37f9c0aa0d)

### 変更後

![98268008-CD29-4561-A55A-32DE370A2FB9](https://github.com/user-attachments/assets/a4fa5199-ad7e-4ab8-a3d3-b08f78065a8b)


<!-- I want to review in Japanese. -->
