### PR TITLE
cocooned移行時のjQuery依存の解消漏れを修正

### DIFF
--- a/app/javascript/choices-ui.js
+++ b/app/javascript/choices-ui.js
@@ -61,18 +61,23 @@ document.addEventListener('DOMContentLoaded', () => {
       shouldSort: false
     })
   }
-  $('.js-add-choice').on('cocooned:after-insert', () => {
-    const elements = document.querySelectorAll('.js-choices-added-select')
-    const element = elements[elements.length - 1]
-    if (element) {
-      return new Choices(element, {
-        allowHTML: true,
-        searchResultLimit: 20,
-        searchPlaceholderValue: '検索ワード',
-        noResultsText: '一致する情報は見つかりません',
-        itemSelectText: '選択',
-        shouldSort: false
-      })
-    }
+
+  const addChoiceButtons = document.querySelectorAll('.js-add-choice')
+  addChoiceButtons.forEach((button) => {
+    button.addEventListener('cocooned:after-insert', () => {
+      const elements = document.querySelectorAll('.js-choices-added-select')
+      if (!elements) return
+      const element = elements[elements.length - 1]
+      if (element) {
+        return new Choices(element, {
+          allowHTML: true,
+          searchResultLimit: 20,
+          searchPlaceholderValue: '検索ワード',
+          noResultsText: '一致する情報は見つかりません',
+          itemSelectText: '選択',
+          shouldSort: false
+        })
+      }
+    })
   })
 })


### PR DESCRIPTION
## 概要
https://github.com/fjordllc/bootcamp/pull/8701

こちらのPRでcocooned移行をすると共に、jQuery依存の解消をしていた。
一か所解消漏れがあったので、その修正。

## 確認手順
1. `fix/change-cocooned-jquery-to-vanillaJS`をローカルに取り込む
2. `./bin/setup`
3. komagataでログインをし、`/mentor/surveys/new`にアクセス

- [x] 質問フィールドの「質問を追加」「削除」を何度か押下し、動作に問題がないこと
- [x] 上記で質問を追加して保存ボタン押下後、追加した質問が反映されていること

## Screenshot
画面の変更はありません。
