### PR TITLE
給付制度対象講座のFAQを登録、表示 #8707

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -5,7 +5,8 @@ class WelcomeController < ApplicationController
   skip_before_action :require_active_user_login, raise: false
   layout 'lp'
   DEFAULT_COURSE = 'Railsエンジニア'
-  FAQ_CATEGORY_NAME = '法人利用について'
+  FAQ_CATEGORY_NAME_FOR_CORPORATE = '法人利用について'
+  FAQ_CATEGORY_NAME_FOR_GRANT_COURSE = '給付制度対象講座について'
 
   def index
     @mentors = current_user ? User.mentors_sorted_by_created_at : User.visible_sorted_mentors
@@ -33,7 +34,7 @@ class WelcomeController < ApplicationController
   end
 
   def training
-    @faqs = FAQCategory.find_by(name: FAQ_CATEGORY_NAME).faqs
+    @faqs = FAQCategory.find_by(name: FAQ_CATEGORY_NAME_FOR_CORPORATE).faqs
   end
 
   def practices; end
@@ -53,6 +54,7 @@ class WelcomeController < ApplicationController
   def logo; end
 
   def rails_developer_course
+    @faqs = FAQCategory.find_by(name: FAQ_CATEGORY_NAME_FOR_GRANT_COURSE).faqs
     render template: 'welcome/certified_reskill_courses/rails_developer_course/index'
   end
 

--- a/app/views/welcome/certified_reskill_courses/rails_developer_course/_faq.html.slim
+++ b/app/views/welcome/certified_reskill_courses/rails_developer_course/_faq.html.slim
@@ -1,0 +1,22 @@
+section.lp-content.is-lp-bg-1.is-left-title.lp-faqs
+  .l-container.is-lg
+    .lp-content__inner
+      .lp-content__start
+        header.lp-content__header
+           h3.lp-content-title.is-vertical.is-border-left
+            | 給付制度対象講座について
+            br
+            strong
+              | よくある質問
+      .lp-content__end
+        .lp-faqs__items
+          - @faqs.each do |faq|
+            section.lp-faq
+              .lp-faq__inner
+                header.lp-faq__header
+                  h4.lp-faq__title
+                    = faq.question
+                .lp-faq__body
+                  .a-short-text.js-markdown-view
+                    = faq.answer
+            hr.a-border

--- a/app/views/welcome/certified_reskill_courses/rails_developer_course/index.html.slim
+++ b/app/views/welcome/certified_reskill_courses/rails_developer_course/index.html.slim
@@ -48,3 +48,4 @@ hr.a-border
   = render 'welcome/certified_reskill_courses/rails_developer_course/course_requirements'
   = render 'welcome/certified_reskill_courses/rails_developer_course/course_overview'
   = render partial: 'welcome/process', locals: { is_certified_reskill_courses_page: true }
+  = render 'welcome/certified_reskill_courses/rails_developer_course/faq'

--- a/db/fixtures/faq_categories.yml
+++ b/db/fixtures/faq_categories.yml
@@ -25,3 +25,7 @@ faq_categories6:
 faq_categories7:
   name: 法人利用について
   position: 7
+
+faq_categories8:
+  name: 給付制度対象講座について
+  position: 8

--- a/db/fixtures/faqs.yml
+++ b/db/fixtures/faqs.yml
@@ -215,3 +215,26 @@ faq26:
   answer: |-
     「Railsエンジニアコース」、「フロントエンドエンジニアコース」間のコース変更は可能です。メンターからレビューを受けている途中の課題がないキリのいいタイミングであれば、好きなタイミングで変更をすることができます。変更の回数制限もありません。
   faq_category: faq_categories1
+
+faq27:
+  position: 27
+  question: 専門実践教育訓練給付制度とはどのような制度ですか？
+  answer: |-
+    専門実線共育訓練給付制度とは、働く方々の主体的な能力開発やキャリア形成を支援し、雇用の安定と就職の促進を図ることを目的に、厚生労働大臣が指定する教育訓練を修了した際に、教育訓練経費の一部が支給される制度です。
+
+    詳しくは厚生労働省のホームページ(https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/koyou_roudou/jinzaikaihatsu/kyouiku.html)をご確認ください。
+  faq_category: faq_categories8
+
+faq28:
+  position: 28
+  question: 誰でもこの給付金制度を利用できますか？
+  answer: |-
+    雇用保険の被保険者期間が2年以上など、一定の条件を満たす方が対象となります。ご自身が対象となるかどうかの正式な確認は、お手数ですがお近くのハローワークにてお願いいたします。
+  faq_category: faq_categories8
+
+faq29:
+  position: 29
+  question: プログラミングは全くの未経験ですが、このコースについていけますか？
+  answer: |-
+    はい、問題ありません。本コースは、プログラミング未経験から自律したWebエンジニアとして就職・転職することを目指す方々を対象にカリキュラムが設計されていますので、ご安心ください。
+  faq_category: faq_categories8


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8707 

## 概要
「[給付金制度対象講座](https://bootcamp.fjord.jp/certified_reskill_courses/rails_developer_course)」のページ(`/certified_reskill_courses/rails_developer_course`)最下部に、「給付制度対象講座について」カテゴリーのFAQセクションを追加しました。

実装に当たっては、「[法人利用](https://bootcamp.fjord.jp/training)」のページを参考にしています。

### 影響範囲
今回のFAQカテゴリ追加に伴い、以下のページでも「給付制度対象講座について」のカテゴリが表示されるようになります。
この挙動が意図通りであるか、念のためご確認をお願いいたします。

1. FAQ一覧ページ (`/faq`)
カテゴリ一覧の中に「給付制度対象講座について」が追加されます。
2. 管理者用のFAQカテゴリ管理ページ (`/admin/faq_categories`)
カテゴリ一覧の中に「給付制度対象講座について」が追加され、ここから編集・削除が可能です。(管理者ユーザーでログイン)

## 変更確認方法

1. `feature/add-faq-to-certified-reskill-course`をローカルに取り込む
      1. `git fetch origin feature/add-faq-to-certified-reskill-course`
    2. `git checkout feature/add-faq-to-certified-reskill-course`
2. `bin/rails db:seed`を実行し、seedデータをデータベースに反映させる
3.  `foreman start -f Procfile.dev` でサーバーを立ち上げる
4. http://localhost:3000/certified_reskill_courses/rails_developer_course にアクセス
5. ページ最下部付近に、**給付制度対象講座についてのよくある質問**という見出しのFAQセクションが追加されていることを確認する
6. FAQの質問と回答が、Fixturesで定義した内容で正しく表示されていることを確認する

## Screenshot

### 変更前
<img width="466" alt="image" src="https://github.com/user-attachments/assets/e8cb2bae-2fc3-451c-bb7c-3ac3d641cbda" />

### 変更後
<img width="467" alt="image" src="https://github.com/user-attachments/assets/a4181c0a-bd10-4578-a550-f017a31402a1" />
<!-- I want to review in Japanese. -->
