### PR TITLE
ユーザー個別ページにイベントの出席回数を表示

### DIFF
--- a/app/views/users/_activity_counts.html.slim
+++ b/app/views/users/_activity_counts.html.slim
@@ -6,14 +6,16 @@ dl.card-counts__items
       { name: 'コメント', count: user.comments.without_private_comment.size, url: user_comments_path(user) },
       { name: '質問', count: user.questions.size, url: user_questions_path(user) },
       { name: '回答', count: user.answers.size, url: user_answers_path(user) },
-      { name: 'ポートフォリオ', count: user.works.size, url: user_portfolio_path(user) }
+      { name: 'ポートフォリオ', count: user.works.size, url: user_portfolio_path(user) },
+      { name: '特別イベント', count: user.participations.size, url: nil },
+      { name: '定期イベント', count: user.regular_event_participations.size, url: nil }
     ]
   - activities.each do |activity|
     .card-counts__item
       .card-counts__item-inner
         dt.card-counts__item-label = activity[:name]
-        dd.card-counts__item-value class=('is-empty' if activity[:count].zero?)
-          - if activity[:count].zero?
-            span = activity[:count]
+        dd.card-counts__item-value class=('is-empty' if activity[:count].zero? || activity[:url].nil?)
+          - if activity[:count].zero? || activity[:url].nil?
+            = activity[:count]
           - else
             = link_to activity[:count], activity[:url], class: 'a-text-link'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8763

## 概要

ユーザーの個別ページ（`/users/:id`）の活動実績に、そのユーザーが参加登録した**特別イベント**と**定期イベント**の数を表示する項目を追加しました。

![image](https://github.com/user-attachments/assets/78265ed5-c85b-4571-b8c8-1388a4b27fc0)

## 変更確認方法

1.  `feature/display-event-participation-count` をローカルに取り込む
    ```shell
    git fetch origin feature/display-event-participation-count
    git checkout feature/display-event-participation-count
    ```
2.  `foreman start -f Procfile.dev`でサーバーを立ち上げる

3.  任意のユーザーでログインする

4.  任意のユーザーのプロフィールページ（例: `/users/kimura`）にアクセスし、以下を確認する

      - [x] プロフィールページの活動実績に「特別イベント」と「定期イベント」の項目が追加されていること。
      - [x] 各イベントの参加回数が正しく表示されていること。
      - [x] イベント出席回数はリンクがないこと。

※回数の正しさを確実に確認するには、`bin/rails c`でコンソールを立ち上げ、`user = User.find_by(login_name: '確認したいユーザー名')`に続けて`user.participations.size`などを実行して、表示と一致するかを確認してください。
※定期イベントの出席回数とは**定期イベントに出席した回数ではなくメンバー登録した定期イベントの数**のことを指します。

## Screenshot

### 変更前
<img width="211" alt="image" src="https://github.com/user-attachments/assets/317715ba-eded-42bb-892c-12340e20182d" />

### 変更後
<img width="211" alt="image" src="https://github.com/user-attachments/assets/177b830e-fb3b-49db-9b73-78aee58a0f0b" />

<!-- I want to review in Japanese. -->
