### PR TITLE
フッターにフィヨブーファンブックへのリンクを追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -26,6 +26,9 @@ footer.footer
             = link_to 'https://suzuri.jp/FjordBootCamp', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | グッズ購入
           li.footer-nav__item
+            = link_to 'https://techbookfest.org/product/fyJf6irY7PjMLYXH7D86py?productVariantID=aRihPwt0CQSaQU0VLa2NeG', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | フィヨブーファンブック
+          li.footer-nav__item
             = link_to coc_path, class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | アンチハラスメントポリシー
           li.footer-nav__item


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [フィヨブーファンブックへのリンクをログイン後のフッターに置きたい#8726](https://github.com/orgs/fjordllc/projects/7/views/1?pane=issue&itemId=113803818&issue=fjordllc%7Cbootcamp%7C8726)

## 概要

フッターにフィヨブーファンブック購入ページへのリンクを追加しました

## 変更確認方法

1. ブランチ`feature/add-link-to-footer`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 任意のユーザでログインし、フッターのリンクを確認する

## Screenshot

### 変更前
![#8726変更前](https://github.com/user-attachments/assets/4ddc6ed6-1b46-40f8-93f7-a6e8edf74626)

### 変更後
![#8726変更後](https://github.com/user-attachments/assets/5999e16e-1bc4-40da-8de4-4be1760f641e)


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - フッターに「フィヨブーファンブック」への外部リンクを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->