### PR TITLE
企業研修詳細ページにコメント機能を追加

### DIFF
--- a/app/controllers/admin/corporate_training_inquiries_controller.rb
+++ b/app/controllers/admin/corporate_training_inquiries_controller.rb
@@ -9,5 +9,6 @@ class Admin::CorporateTrainingInquiriesController < AdminController
 
   def show
     @corporate_training_inquiry = CorporateTrainingInquiry.find(params[:id])
+    @comments = @corporate_training_inquiry.comments.order(:created_at)
   end
 end

--- a/app/controllers/users/comments_controller.rb
+++ b/app/controllers/users/comments_controller.rb
@@ -15,7 +15,7 @@ class Users::CommentsController < ApplicationController
   def set_comments
     @comments =
       Comment
-      .where.not(commentable_type: %w[Talk Inquiry])
+      .where.not(commentable_type: %w[Talk Inquiry CorporateTrainingInquiry])
       .preload(commentable: { user: { avatar_attachment: :blob } })
       .eager_load(:user)
       .where(user_id: user)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -18,7 +18,7 @@ class Comment < ApplicationRecord
 
   mentionable_as :description, hook_name: :after_commit
 
-  scope :without_private_comment, -> { where.not(commentable_type: %w[Talk Inquiry]) }
+  scope :without_private_comment, -> { where.not(commentable_type: %w[Talk Inquiry CorporateTrainingInquiry]) }
 
   class << self
     def commented_users

--- a/app/models/corporate_training_inquiry.rb
+++ b/app/models/corporate_training_inquiry.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CorporateTrainingInquiry < ApplicationRecord
+  include Commentable
+
   validates :company_name, presence: true
   validates :name, presence: true
   validates :email, presence: true,

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -30,7 +30,7 @@ class Searcher
           result_for(document_type, word).sort_by(&:updated_at).reverse
         end
 
-      delete_private_comment!(searchables) # 相談部屋とお問い合わせのコメント内容は検索できないようにする
+      delete_private_comment!(searchables) # 相談部屋とお問い合わせ、企業研修のコメント内容は検索できないようにする
     end
 
     private
@@ -72,7 +72,7 @@ class Searcher
 
     def delete_private_comment!(searchables)
       searchables.reject do |searchable|
-        searchable.instance_of?(Comment) && searchable.commentable.class.in?([Talk, Inquiry])
+        searchable.instance_of?(Comment) && searchable.commentable.class.in?([Talk, Inquiry CorporateTrainingInquiry])
       end
     end
   end

--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -72,7 +72,7 @@ class Searcher
 
     def delete_private_comment!(searchables)
       searchables.reject do |searchable|
-        searchable.instance_of?(Comment) && searchable.commentable.class.in?([Talk, Inquiry CorporateTrainingInquiry])
+        searchable.instance_of?(Comment) && searchable.commentable.class.in?([Talk, Inquiry, CorporateTrainingInquiry])
       end
     end
   end

--- a/app/views/admin/corporate_training_inquiries/show.html.slim
+++ b/app/views/admin/corporate_training_inquiries/show.html.slim
@@ -125,3 +125,4 @@ main.page-main
                         = CorporateTrainingInquiry.human_attribute_name(:how_did_you_hear)
                       .a-short-text
                         = simple_format(@corporate_training_inquiry.how_did_you_hear)
+      = render 'comments/comments', commentable: @corporate_training_inquiry, commentable_type: 'CorporateTrainingInquiry'

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -157,6 +157,25 @@ comment<%= i + 44 %>:
   updated_at: <%= Time.current + i.minute %>
 <% end %>
 
+comment65:
+  user: komagata
+  commentable: corporate_training_inquiry1 (CorporateTrainingInquiry)
+  description: "テスト用 corporate_training_inquiry1へのコメント"
+
+comment66:
+  user: komagata
+  commentable: corporate_training_inquiry2 (CorporateTrainingInquiry)
+  description: "corporate_training_inquiryにて削除するコメント"
+
+<% (1..20).each do |i| %>
+comment<%= i + 66 %>:
+  user: komagata
+  commentable: corporate_training_inquiry3 (CorporateTrainingInquiry)
+  description: <%= "テスト用 corporate_training_inquiry3へのコメント。No.#{i}" %>
+  created_at: <%= Time.current + i.minute %>
+  updated_at: <%= Time.current + i.minute %>
+<% end %>
+
 commentOfTalk:
   user: komagata
   commentable: talk1 (Talk)

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -17,7 +17,7 @@ class CommentTest < ActiveSupport::TestCase
   test '.without_private_comment' do
     non_talk_comment_count = Comment.without_private_comment.count
     all_comment_count = Comment.count
-    only_talk_comment_count = Comment.where(commentable_type: %w[Talk Inquiry]).count
+    only_talk_comment_count = Comment.where(commentable_type: %w[Talk Inquiry CorporateTrainingInquiry]).count
     assert_equal non_talk_comment_count, all_comment_count - only_talk_comment_count
   end
 

--- a/test/system/comment/corporate_training_inquiry_comments_test.rb
+++ b/test/system/comment/corporate_training_inquiry_comments_test.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class CorporateTrainingInquiryCommentsTest < ApplicationSystemTestCase
+  test 'post new comment for corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    assert_text 'test'
+    click_button 'コメントする'
+    assert_text 'test'
+  end
+
+  test 'comment form found in /admin/corporate_training_inquiries/:corporate_training_inquiry_id' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    assert has_field?('new_comment[description]')
+  end
+
+  test 'comment form in corporate_training_inquiry/:id has comment tab and preview tab' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    within('.a-form-tabs') do
+      assert_text 'コメント'
+      assert_text 'プレビュー'
+    end
+  end
+
+  test 'edit comment form has comment tab and preview tab at corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    within('.thread-comment:first-child') do
+      click_button '編集'
+      assert_text 'コメント'
+      assert_text 'プレビュー'
+    end
+  end
+
+  test 'post new comment with emoji for corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    # Wait for comments section to load
+    if has_css?('#comments.loaded')
+      find('#comments.loaded')
+    else
+      # Fallback: wait for comments section or form to be present
+      find('.thread-comment-form, .thread-comment')
+    end
+
+    Timeout.timeout(Capybara.default_max_wait_time, StandardError) do
+      until find('#js-new-comment').value == '絵文字の補完テスト: 😺 '
+        find('#js-new-comment').set('')
+        find('#js-new-comment').set("絵文字の補完テスト: :cat\n")
+      end
+    end
+
+    click_button 'コメントする'
+    assert_text '絵文字の補完テスト: 😺'
+  end
+
+  test 'post new comment with image for corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    # Wait for comments section to load
+    if has_css?('#comments.loaded')
+      find('#comments.loaded')
+    else
+      # Fallback: wait for comments section or form to be present
+      find('.thread-comment-form, .thread-comment')
+    end
+    find('#js-new-comment').set('画像付きで説明します。 ![Image](https://example.com/test.png)')
+    click_button 'コメントする'
+    assert_text '画像付きで説明します。'
+    assert_match '<a href="https://example.com/test.png" target="_blank" rel="noopener noreferrer"><img src="https://example.com/test.png" alt="Image"></a>',
+                 page.body
+  end
+
+  test 'post new comment with linked image for corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    # Wait for comments section to load
+    if has_css?('#comments.loaded')
+      find('#comments.loaded')
+    else
+      # Fallback: wait for comments section or form to be present
+      find('.thread-comment-form, .thread-comment')
+    end
+    find('#js-new-comment').set('[![Image](https://example.com/test.png)](https://example.com)')
+    click_button 'コメントする'
+    assert_text 'コメントを投稿しました！'
+    assert_match '<a href="https://example.com" target="_blank" rel="noopener"><img src="https://example.com/test.png" alt="Image"></a>', page.body
+  end
+
+  test 'edit the comment for corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    within('.thread-comment:first-child') do
+      click_button '編集'
+      within(:css, '.thread-comment-form__form') do
+        fill_in('comment[description]', with: 'edit test')
+      end
+      click_button '保存する'
+    end
+    assert_text 'edit test'
+  end
+
+  test 'destroy the comment for corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry2).id}", 'komagata'
+    within('.thread-comment:last-child') do
+      accept_alert do
+        click_button('削除')
+      end
+    end
+    assert_no_text 'corporate_training_inquiryにて削除するコメント'
+  end
+
+  test 'comment tab is active after a comment has been posted at corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    assert_selector '.a-form-tabs__tab.is-active', text: 'コメント'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    find('.a-form-tabs__tab', text: 'プレビュー').click
+    assert_selector '.a-form-tabs__tab.is-active', text: 'プレビュー'
+    click_button 'コメントする'
+    assert_selector '.a-form-tabs__tab.is-active', text: 'コメント'
+  end
+
+  test 'prevent double submit at corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+
+    # Click button once and verify it becomes disabled
+    button = find('#js-shortcut-post-comment', text: 'コメントする')
+    button.click
+
+    # Try to click again - should be intercepted or disabled
+    begin
+      button.click
+      # If we reach here, the button was clickable twice (bad)
+      flunk 'Button should be disabled after first click'
+    rescue Selenium::WebDriver::Error::ElementClickInterceptedError, Selenium::WebDriver::Error::ElementNotInteractableError
+      # This is expected - button should be disabled/not clickable
+    end
+  end
+
+  test 'comment url is copied when click its updated_time at corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    # Wait for comments section to load
+    if has_css?('#comments.loaded')
+      find('#comments.loaded')
+    else
+      # Fallback: wait for comments section or form to be present
+      find('.thread-comment-form, .thread-comment')
+    end
+    first(:css, '.thread-comment__created-at').click
+    # 参考：https://gist.github.com/KonnorRogers/5fe937ee60695ff1d227f18fe4b1d5c4
+    cdp_permission = {
+      origin: page.server_url,
+      permission: { name: 'clipboard-read' },
+      setting: 'granted'
+    }
+    page.driver.browser.execute_cdp('Browser.setPermission', **cdp_permission)
+    clip_text = page.evaluate_async_script('navigator.clipboard.readText().then(arguments[0])')
+    assert_equal current_url + "#comment_#{comments(:comment65).id}", clip_text
+  end
+
+  test 'text change "see more comments" button by remaining comment amount at corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry3).id}", 'komagata'
+
+    assert_selector '.a-button.is-lg.is-text.is-block', text: '前のコメント（ 8 / 12 ）'
+
+    find('.a-button.is-lg.is-text.is-block').click
+    assert_selector '.a-button.is-lg.is-text.is-block', text: '前のコメント（ 4 ）'
+
+    find('.a-button.is-lg.is-text.is-block').click
+    assert_no_selector '.a-button.is-lg.is-text.is-block'
+  end
+
+  test 'submit_button is enabled after a post is done at corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'test')
+    end
+    click_button 'コメントする'
+    assert_text 'test'
+    within('.thread-comment-form__form') do
+      fill_in('new_comment[description]', with: 'testtest')
+    end
+    click_button 'コメントする'
+    assert_text 'testtest'
+  end
+
+  test 'comments added 8 or within the last 8 at corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry3).id}", 'komagata'
+
+    assert_text 'テスト用 corporate_training_inquiry3へのコメント。No.20'
+    assert_text 'テスト用 corporate_training_inquiry3へのコメント。No.13'
+    assert_no_text 'テスト用 corporate_training_inquiry3へのコメント。No.12'
+
+    find('.a-button.is-lg.is-text.is-block').click
+    assert_text 'テスト用 corporate_training_inquiry3へのコメント。No.20'
+    assert_text 'テスト用 corporate_training_inquiry3へのコメント。No.12'
+    assert_text 'テスト用 corporate_training_inquiry3へのコメント。No.5'
+    assert_no_text 'テスト用 corporate_training_inquiry3へのコメント。No.4'
+
+    find('.a-button.is-lg.is-text.is-block').click
+    assert_text 'テスト用 corporate_training_inquiry3へのコメント。No.20'
+    assert_text 'テスト用 corporate_training_inquiry3へのコメント。No.4'
+    assert_text 'テスト用 corporate_training_inquiry3へのコメント。No.1'
+  end
+
+  test 'clear preview after posting new comment for corporate_training_inquiry' do
+    visit_with_auth "/admin/corporate_training_inquiries/#{corporate_training_inquiries(:corporate_training_inquiry1).id}", 'komagata'
+    find('#js-new-comment').set('test')
+    click_button 'コメントする'
+    assert_text 'test'
+    find('.a-form-tabs__tab.js-tabs__tab', text: 'プレビュー').click
+    assert_selector '.a-form-tabs__tab.is-active', text: 'プレビュー'
+    within('#new-comment-preview') do
+      assert_no_text :all, 'test'
+    end
+  end
+end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8455 

## 概要
企業研修申し込み詳細ページにコメント機能を追加した。実装は[個別のお問い合わせにコメントがつけられるようにした](https://github.com/fjordllc/bootcamp/pull/8262)を参考に行った。
## 変更確認方法

1. feature/add-comment-to-corporate-training-inquiriesをローカルに取り込む
2. foreman start -f Procfile.devでサーバーを立ち上げる
3. 管理者komagataでログインする
4. [企業研修申し込み一覧](http://localhost:3000/admin/corporate_training_inquiries)ページから個別の申し込み詳細ページにアクセスする
5. コメントを入力し、コメントするをクリックしてコメントが投稿されることを確認する

## Screenshot

### 変更前
<img width="1440" alt="スクリーンショット 2025-06-17 17 05 20" src="https://github.com/user-attachments/assets/39efdd4a-2133-4c70-ac0c-a5e36cd087c3" />

### 変更後
<img width="1440" alt="スクリーンショット 2025-06-17 15 53 33" src="https://github.com/user-attachments/assets/5d436cb9-bae8-4966-a74b-6cfd457ade0f" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 企業研修問い合わせにコメント機能を追加し、管理画面でコメントの閲覧・投稿・編集・削除が可能になりました。

- **バグ修正**
  - コメント一覧や検索から企業研修問い合わせに紐づくコメントが除外されるようになりました。

- **テスト**
  - 企業研修問い合わせのコメント機能に関するシステムテストを追加しました。
  - コメントの投稿・編集・削除・プレビュー・クリップボードコピー・ページネーション等の動作を検証するテストを追加しました。

- **その他**
  - コメントのテストデータ（fixture）に企業研修問い合わせ用のコメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->