### PR TITLE
重複するユニークインデックスマイグレーションを削除

### DIFF
--- a/db/migrate/20250618143741_add_unique_index_to_users_email_and_login_name.rb
+++ b/db/migrate/20250618143741_add_unique_index_to_users_email_and_login_name.rb
@@ -1,6 +1,0 @@
-class AddUniqueIndexToUsersEmailAndLoginName < ActiveRecord::Migration[6.1]
-  def change
-    add_index :users, :email, unique: true
-    add_index :users, :login_name, unique: true
-  end
-end


### PR DESCRIPTION
## 概要
usersテーブルのemailとlogin_nameに対する重複したユニークインデックスマイグレーションを削除

## 変更内容
- `20250618143741_add_unique_index_to_users_email_and_login_name.rb` を削除

## 修正理由
2020年12月3日のマイグレーション（`20201203040100_add_index_to_users.rb`）で既にemailとlogin_nameにユニークインデックスが作成されていたため、新しいマイグレーションが重複していた。

これにより `PG::DuplicateTable: ERROR: relation "index_users_on_email" already exists` エラーが発生していた。

## テスト計画
- [x] マイグレーション実行時のエラーが解消されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
  - ユーザーのメールアドレスおよびログイン名に対する一意性制約を追加する変更を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->