### PR TITLE
rubocopのExcludeの設定を各ファイルのtodoコメントに変換した

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,20 +7,6 @@ inherit_gem:
     - config/rubocop.yml
     - config/rails.yml
 
-Metrics/ClassLength:
-  Exclude:
-    - test/**/*
-    - app/controllers/products_controller.rb
-    - app/controllers/reports_controller.rb
-    - app/controllers/users_controller.rb
-    - app/mailers/activity_mailer.rb
-    - app/models/event.rb
-    - app/models/practice.rb
-    - app/models/user.rb
-    - app/models/product.rb
-    - app/models/report.rb
-    - app/notifiers/activity_notifier.rb
-
 Metrics/ModuleLength:
   Exclude:
     - app/decorators/user_decorator.rb

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProductsController < ApplicationController
+class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLength
   before_action :check_permission!, only: %i[show]
   before_action :require_staff_login, only: :index
   before_action :set_watch, only: %i[show]

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ReportsController < ApplicationController
+class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLength
   PAGER_NUMBER = 25
 
   include Rails.application.routes.url_helpers

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UsersController < ApplicationController
+class UsersController < ApplicationController # rubocop:todo Metrics/ClassLength
   skip_before_action :require_active_user_login, raise: false, only: %i[new create show]
   before_action :require_token, only: %i[new] if Rails.env.production?
   before_action :set_user, only: %w[show]

--- a/app/mailers/activity_mailer.rb
+++ b/app/mailers/activity_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActivityMailer < ApplicationMailer
+class ActivityMailer < ApplicationMailer # rubocop:todo Metrics/ClassLength
   helper ApplicationHelper
   helper MarkdownHelper
   include Rails.application.routes.url_helpers

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Event < ApplicationRecord
+class Event < ApplicationRecord # rubocop:todo Metrics/ClassLength
   include WithAvatar
   include Commentable
   include Footprintable

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Practice < ApplicationRecord
+class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
   include Watchable
   include Searchable
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Product < ApplicationRecord
+class Product < ApplicationRecord # rubocop:todo Metrics/ClassLength
   PRODUCT_DEADLINE = 4
 
   include Commentable

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Report < ApplicationRecord
+class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
   include Commentable
   include Checkable
   include Footprintable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class User < ApplicationRecord
+class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
   include ActionView::Helpers::AssetUrlHelper
   include Taggable
   include Searchable

--- a/app/notifiers/activity_notifier.rb
+++ b/app/notifiers/activity_notifier.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActivityNotifier < ApplicationNotifier
+class ActivityNotifier < ApplicationNotifier # rubocop:todo Metrics/ClassLength
   self.driver = ActivityDriver.new
   self.async_adapter = ActivityAsyncAdapter.new
 


### PR DESCRIPTION
１ファイルずつ直していくのがやりやすくなるため。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - クラスの長さに関する静的コード解析の警告を抑制するコメントを複数のコントローラー、モデル、メーラー、ノーティファイアのクラス宣言行に追加しました。ユーザー向けの機能や挙動の変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->