### PR TITLE
インタビューのアイコン下のマージンを削除

### DIFF
--- a/app/javascript/stylesheets/config/mixins/_long-text-style.sass
+++ b/app/javascript/stylesheets/config/mixins/_long-text-style.sass
@@ -408,6 +408,8 @@
     display: inline-block
     &:not(:first-child)
       margin-left: .5em
+    .a-user-emoji
+      margin-block: 0
   .header-anchor + .a-user-emoji-link
     margin-left: 0
   .a-user-emoji


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - `.a-user-emoji-link`内の絵文字表示の余白を調整し、見た目を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->