### PR TITLE
phantomでgit worktree使用時のブランチ固有データベース対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ storage/
 /config/master.key
 
 .envrc
+.env.local
 /test/reports

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
   # not default
+  gem 'dotenv-rails'
   gem 'pry-byebug'
   gem 'traceroute'
 end
@@ -95,7 +96,6 @@ group :development do
   gem 'web-console', '>= 4.1.0'
 
   # not default
-  gem 'dotenv-rails'
   gem 'bullet'
   gem 'foreman'
   gem 'letter_opener_web', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :development do
   gem 'web-console', '>= 4.1.0'
 
   # not default
+  gem 'dotenv-rails'
   gem 'bullet'
   gem 'foreman'
   gem 'letter_opener_web', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,10 @@ GEM
     domain_name (0.6.20240107)
     doorkeeper (5.8.2)
       railties (>= 5)
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -674,6 +678,7 @@ DEPENDENCIES
   discord-notifier
   discordrb (~> 3.5)
   doorkeeper
+  dotenv-rails
   ffi (= 1.17.1)
   foreman
   good_job (~> 3.14)!

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,7 +24,7 @@ default: &default
 
 development:
   <<: *default
-  database: bootcamp_development
+  database: bootcamp_development<%= ENV['BRANCH_DB_SUFFIX'] || '' %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,7 +58,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: bootcamp_test
+  database: bootcamp_test<%= ENV['BRANCH_DB_SUFFIX'] || '' %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/phantom.config.json
+++ b/phantom.config.json
@@ -4,13 +4,13 @@
       "CLAUDE.md"
     ],
     "commands": [
-      "branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" != \"main\" ]; then suffix=\"_$(echo $branch | tr '/' '_' | tr '-' '_')\"; echo \"BRANCH_DB_SUFFIX=$suffix\" > .env.local; echo \"Set BRANCH_DB_SUFFIX=$suffix for branch $branch\"; else echo \"Main branch detected, no DB suffix needed\"; fi",
+      "branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" != \"main\" ]; then suffix=\"_$(echo $branch | tr '/' '_' | tr '-' '_')\"; if [ -f .env.local ] && grep -q '^BRANCH_DB_SUFFIX=' .env.local; then sed -i.bak \"s/^BRANCH_DB_SUFFIX=.*/BRANCH_DB_SUFFIX=$suffix/\" .env.local && rm .env.local.bak; else echo \"BRANCH_DB_SUFFIX=$suffix\" >> .env.local; fi; echo \"Set BRANCH_DB_SUFFIX=$suffix for branch $branch\"; else echo \"Main branch detected, no DB suffix needed\"; fi",
       "bin/setup"
     ]
   },
   "preDelete": {
     "commands": [
-      "branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" != \"main\" ]; then suffix=\"_$(echo $branch | tr '/' '_' | tr '-' '_')\"; dev_db=\"bootcamp_development$suffix\"; test_db=\"bootcamp_test$suffix\"; echo \"Dropping databases: $dev_db and $test_db\"; dropdb \"$dev_db\" 2>/dev/null || echo \"Database $dev_db not found (already deleted?)\"; dropdb \"$test_db\" 2>/dev/null || echo \"Database $test_db not found (already deleted?)\"; else echo \"Main branch detected, no DB cleanup needed\"; fi"
+      "set +e; branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" != \"main\" ]; then suffix=\"_$(echo $branch | tr '/' '_' | tr '-' '_')\"; dev_db=\"bootcamp_development$suffix\"; test_db=\"bootcamp_test$suffix\"; echo \"Dropping databases: $dev_db and $test_db\"; dropdb \"$dev_db\" || true; dropdb \"$test_db\" || true; else echo \"Main branch detected, no DB cleanup needed\"; fi; set -e"
     ]
   }
 }

--- a/phantom.config.json
+++ b/phantom.config.json
@@ -1,0 +1,16 @@
+{
+  "postCreate": {
+    "copyFiles": [
+      "CLAUDE.md"
+    ],
+    "commands": [
+      "branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" != \"main\" ]; then suffix=\"_$(echo $branch | tr '/' '_' | tr '-' '_')\"; echo \"BRANCH_DB_SUFFIX=$suffix\" > .env.local; echo \"Set BRANCH_DB_SUFFIX=$suffix for branch $branch\"; else echo \"Main branch detected, no DB suffix needed\"; fi",
+      "bin/setup"
+    ]
+  },
+  "preDelete": {
+    "commands": [
+      "branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" != \"main\" ]; then suffix=\"_$(echo $branch | tr '/' '_' | tr '-' '_')\"; dev_db=\"bootcamp_development$suffix\"; test_db=\"bootcamp_test$suffix\"; echo \"Dropping databases: $dev_db and $test_db\"; dropdb \"$dev_db\" 2>/dev/null || echo \"Database $dev_db not found (already deleted?)\"; dropdb \"$test_db\" 2>/dev/null || echo \"Database $test_db not found (already deleted?)\"; else echo \"Main branch detected, no DB cleanup needed\"; fi"
+    ]
+  }
+}


### PR DESCRIPTION
## 概要
phantomを使ったgit worktree使用時に、ブランチごとに独立したデータベースを使用できるようにする機能を追加しました。

## 変更内容

### 1. database.yml の修正
- `development` と `test` セクションに `BRANCH_DB_SUFFIX` 環境変数を追加
- 環境変数が未設定の場合は元のDB名を維持（既存ユーザーへの影響なし）

### 2. dotenv-rails の追加
- `Gemfile` の `development` グループに `dotenv-rails` を追加
- `.env.local` ファイルを自動読み込み可能に

### 3. .gitignore の更新
- `.env.local` を追加（ブランチ固有設定の誤コミット防止）

### 4. phantom.config.json の設定
- **postCreate**: worktree作成時の自動設定
  - ブランチ名取得・変換（`/`,`-` → `_`）
  - 環境変数設定（`.env.local`に出力）
  - `bin/setup` 実行（Railsアプリ初期設定）
- **preDelete**: worktree削除時の自動削除
  - ブランチ固有DBの削除（development/test両方）
  - エラーハンドリング（DB未存在でも処理続行）

## 動作例
- `main` ブランチ: `bootcamp_development`（変化なし）
- `feature/user-auth` ブランチ: `bootcamp_development_feature_user_auth`
- `bugfix/fix-login` ブランチ: `bootcamp_development_bugfix_fix_login`

## 安全性
- phantom未使用者: 一切の影響なし、従来通りの動作
- `main` ブランチ: 特別な処理なし、元のDB名維持
- production環境: `ENV["DB_NAME"]` 使用のため影響なし

## テスト計画
- [ ] phantom未使用環境での動作確認
- [ ] mainブランチでの動作確認  
- [ ] フィーチャーブランチでのworktree作成・削除確認
- [ ] データベース分離の確認
- [ ] 既存開発フローへの影響確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Gitブランチごとに動的なデータベース名を利用できるようになりました。
  - ブランチ作成時や削除時に自動で環境変数やデータベースのセットアップ・クリーンアップが行われるようになりました。

- **その他**
  - `.env.local` ファイルがバージョン管理から除外されるようになりました。
  - 開発環境に `dotenv-rails` が追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->