### PR TITLE
コメント初期化処理で存在しない要素に対する参照エラーを防止

### DIFF
--- a/app/javascript/initializeComment.js
+++ b/app/javascript/initializeComment.js
@@ -9,8 +9,12 @@ function initializeComment(comment) {
   const commentEditor = comment.querySelector('.comment-editor')
   if (!commentEditor) return
 
-  const commentEditorPreview = commentEditor.querySelector('.a-markdown-input__preview')
-  const editorTextarea = commentEditor.querySelector('.a-markdown-input__textarea')
+  const commentEditorPreview = commentEditor.querySelector(
+    '.a-markdown-input__preview'
+  )
+  const editorTextarea = commentEditor.querySelector(
+    '.a-markdown-input__textarea'
+  )
   if (!commentEditorPreview || !editorTextarea) return
 
   let savedComment = ''

--- a/app/javascript/initializeComment.js
+++ b/app/javascript/initializeComment.js
@@ -6,27 +6,23 @@ function initializeComment(comment) {
   const commentId = comment.dataset.comment_id
   const commentDescription = comment.dataset.comment_description
 
+  const commentEditor = comment.querySelector('.comment-editor')
+  if (!commentEditor) return
+
+  const commentEditorPreview = commentEditor.querySelector('.a-markdown-input__preview')
+  const editorTextarea = commentEditor.querySelector('.a-markdown-input__textarea')
+  if (!commentEditorPreview || !editorTextarea) return
+
   let savedComment = ''
   TextareaInitializer.initialize(`#js-comment-${commentId}`)
   const markdownInitializer = new MarkdownInitializer()
 
-  const commentEditor = comment.querySelector('.comment-editor')
-  const commentEditorPreview = commentEditor.querySelector(
-    '.a-markdown-input__preview'
-  )
-  const editorTextarea = commentEditor.querySelector(
-    '.a-markdown-input__textarea'
-  )
-
   const commentDisplay = comment.querySelector('.comment-display')
-  const commentDisplayContent = commentDisplay.querySelector('.a-long-text')
-  commentDisplayContent.innerHTML =
-    markdownInitializer.render(commentDescription)
-  if (commentDescription) {
-    commentDisplayContent.innerHTML =
-      markdownInitializer.render(commentDescription)
-    commentEditorPreview.innerHTML =
-      markdownInitializer.render(commentDescription)
+  const commentDisplayContent = commentDisplay?.querySelector('.a-long-text')
+  if (commentDescription && commentDisplayContent) {
+    const rendered = markdownInitializer.render(commentDescription)
+    commentDisplayContent.innerHTML = rendered
+    commentEditorPreview.innerHTML = rendered
   }
 
   const editButton = commentDisplay.querySelector('.card-main-actions__action')


### PR DESCRIPTION
- .comment-editor や .a-markdown-input__preview が存在しない場合に処理をスキップするように修正
- Uncaught TypeError: Cannot read properties of null の回避
- 条件付きで要素を操作するようにし、安定性を向上


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **リファクタリング**
  - コメントエディターの初期化処理を整理し、必要な要素が存在しない場合は早期に処理を中断するよう改善しました。これにより、要素が見つからない場合のエラー発生を防ぎ、動作の安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->