### PR TITLE
給付金対応コース一覧に戻るボタンの文言変更

### DIFF
--- a/app/views/admin/grant_course_applications/show.html.slim
+++ b/app/views/admin/grant_course_applications/show.html.slim
@@ -20,7 +20,7 @@ main.page-main
             ul.page-main-header-actions__items
               li.page-main-header-actions__item
                 = link_to admin_grant_course_applications_path, class: 'a-button is-md is-secondary is-block is-back' do
-                  | 給付金対応コース受講申請へ
+                  | 受講申請一覧へ
   hr.a-border
   .page-body
     .container.is-md


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue
[#8812](https://github.com/fjordllc/bootcamp/issues/8812)
- https://github.com/fjordllc/bootcamp/issues/8812

## 概要
給付金対応コース一覧に戻るボタンの文言を変更しました。

## 変更確認方法

1. `feature/change-button-text`をローカルに取り込み、
ブランチを `feature/change-button-text`に変更する。

参考:ローカルへの取り込み
```git fetch origin feature/change-button-text```
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる。
3. 管理者でログインし、
http://localhost:3000/admin/grant_course_applications
にアクセス。
4. 一覧のどれかをクリック。
5. ボタンが「受講申請一覧へ」という文言になっていることを確認する。

## Screenshot

### 変更前
![_development__給付金対応コース受講申請___FBC](https://github.com/user-attachments/assets/e3a8750d-4626-40f0-b41c-4bb6d662cf4b)
更前

### 変更後
![_development__給付金対応コース受講申請___FBC](https://github.com/user-attachments/assets/605aa5f1-8ab8-40a4-ab83-10afeacf3e2f)

<!-- I want to review in Japanese. -->
