### PR TITLE
コメントが存在していないのに"前のコメント"表記が出てしまうバグの修正

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -1,7 +1,7 @@
 import { initializeComment } from './initializeComment.js'
 
 document.addEventListener('DOMContentLoaded', () => {
-  const comments = document.querySelectorAll('.comment')
+  const comments = document.querySelectorAll('.thread-comment')
   const loadingContent = document.querySelector('.loading-content')
   if (!loadingContent) {
     return


### PR DESCRIPTION
コードブロック内のコメントアウトのタグ(`token comment`class)まで拾ってしまっていた

<!-- I want to review in Japanese. -->
## Issue

- Issue番号

## 概要

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

<!-- I want to review in Japanese. -->
