### PR TITLE
管理者メニューに「給付金対応コース受講申請」を追加

### DIFF
--- a/app/views/application/_admin_menu.html.slim
+++ b/app/views/application/_admin_menu.html.slim
@@ -18,5 +18,8 @@
       = link_to admin_faq_categories_path, class: 'header-dropdown__item-link' do
         | FAQ
     li.header-dropdown__item
+      = link_to admin_grant_course_applications_path, class: 'header-dropdown__item-link' do
+        | 給付金対応コース受講申請
+    li.header-dropdown__item
       = link_to oauth_applications_path, class: 'header-dropdown__item-link' do
         | OAuth2 Provider


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7/views/1?filterQuery=assignee%3Azamami&pane=issue&itemId=115917645&issue=fjordllc%7Cbootcamp%7C8811

## 概要
管理者メニューに給付金対応コース受講申請を追加。
リンク先は `admin/grant_course_applications` 。
link_to を使い、xxxx_path の形式で指定。
## 変更確認方法

1. `feature/add-link-to-admin-menu`をローカルに取り込む
2. 管理者でログインし、管理者メニューに「給付金対応コース受講申請 」がFAQのリンクの下にあることを確認
3. クリック後、「給付金対応コース受講申請」に遷移しているか確認

## Screenshot

### 変更前
<img width="265" alt="456570051-f1c51c69-ac34-4e2e-8e01-1ebe31818cc0" src="https://github.com/user-attachments/assets/41b49b0f-7d1f-4905-bd8d-df0fee100984" />

### 変更後
![C2D1E321-3804-42EF-A04B-0A4A3A7C993B_4_5005_c](https://github.com/user-attachments/assets/561c5652-9336-4967-a190-69a4462c4acc)

<!-- I want to review in Japanese. -->
