### PR TITLE
3クラス分のnewspaperをActiveSupport::Notificationsに移行

### DIFF
--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -30,7 +30,6 @@ class API::AnswersController < API::BaseController
     @answer.user = current_user
     if @answer.save
       ActiveSupport::Notifications.instrument('answer.create', answer: @answer)
-      Newspaper.publish(:answer_create, { answer: @answer })
       Newspaper.publish(:answer_save, { answer: @answer })
       render partial: 'questions/answer', locals: { question:, answer: @answer, user: current_user }, status: :created
     else

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,7 +28,7 @@ class EventsController < ApplicationController
     set_wip
     if @event.save
       update_published_at
-      Newspaper.publish(:event_create, { event: @event })
+      ActiveSupport::Notifications.instrument('event.create', event: @event)
       url = publish_with_announcement? ? new_announcement_path(event_id: @event.id) : Redirection.determin_url(self, @event)
       redirect_to url, notice: notice_message(@event)
     else

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -30,7 +30,7 @@ class RegularEventsController < ApplicationController
     if @regular_event.save
       update_published_at
       Organizer.create(user_id: current_user.id, regular_event_id: @regular_event.id)
-      Newspaper.publish(:event_create, { event: @regular_event })
+      ActiveSupport::Notifications.instrument('regular_event.create', regular_event: @regular_event)
       set_all_user_participants_and_watchers
       select_redirect_path
     else

--- a/app/models/answer_notifier.rb
+++ b/app/models/answer_notifier.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AnswerNotifier
-  def call(payload)
+  def call(_name, _started, _finished, _unique_id, payload)
     answer = payload[:answer]
     return if answer.sender == answer.receiver
 

--- a/app/models/event_organizer_watcher.rb
+++ b/app/models/event_organizer_watcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EventOrganizerWatcher
-  def call(payload)
+  def call(_name, _started, _finished, _unique_id, payload)
     event = payload[:event]
     Watch.create!(user: event.user, watchable: event)
   end

--- a/app/models/notifier_to_watching_user.rb
+++ b/app/models/notifier_to_watching_user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class NotifierToWatchingUser
-  def call(payload)
+  def call(_name, _started, _finished, _unique_id, payload)
     answer = payload[:answer]
     question = Question.find(answer.question_id)
     mention_user_ids = answer.new_mention_users.ids

--- a/app/models/regular_event_organizer_watcher.rb
+++ b/app/models/regular_event_organizer_watcher.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RegularEventOrganizerWatcher
+  def call(_name, _started, _finished, _unique_id, payload)
+    regular_event = payload[:regular_event]
+    Watch.create!(user: regular_event.user, watchable: regular_event)
+  end
+end

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -2,4 +2,5 @@
 
 Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('answer.create', AnswererWatcher.new)
+  ActiveSupport::Notifications.subscribe('event.create', EventOrganizerWatcher.new)
 end

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -3,5 +3,6 @@
 Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('answer.create', AnswererWatcher.new)
   ActiveSupport::Notifications.subscribe('answer.create', AnswerNotifier.new)
+  ActiveSupport::Notifications.subscribe('answer.create', NotifierToWatchingUser.new)
   ActiveSupport::Notifications.subscribe('event.create', EventOrganizerWatcher.new)
 end

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -5,4 +5,5 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('answer.create', AnswerNotifier.new)
   ActiveSupport::Notifications.subscribe('answer.create', NotifierToWatchingUser.new)
   ActiveSupport::Notifications.subscribe('event.create', EventOrganizerWatcher.new)
+  ActiveSupport::Notifications.subscribe('regular_event.create', RegularEventOrganizerWatcher.new)
 end

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -2,5 +2,6 @@
 
 Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('answer.create', AnswererWatcher.new)
+  ActiveSupport::Notifications.subscribe('answer.create', AnswerNotifier.new)
   ActiveSupport::Notifications.subscribe('event.create', EventOrganizerWatcher.new)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.configuration.after_initialize do
-  Newspaper.subscribe(:answer_create, NotifierToWatchingUser.new)
   Newspaper.subscribe(:announcement_destroy, AnnouncementNotificationDestroyer.new)
 
   announcement_notifier = AnnouncementNotifier.new

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.configuration.after_initialize do
-  Newspaper.subscribe(:answer_create, AnswerNotifier.new)
   Newspaper.subscribe(:answer_create, NotifierToWatchingUser.new)
   Newspaper.subscribe(:announcement_destroy, AnnouncementNotificationDestroyer.new)
 

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.configuration.after_initialize do
-  Newspaper.subscribe(:event_create, EventOrganizerWatcher.new)
   Newspaper.subscribe(:answer_create, AnswerNotifier.new)
   Newspaper.subscribe(:answer_create, NotifierToWatchingUser.new)
   Newspaper.subscribe(:announcement_destroy, AnnouncementNotificationDestroyer.new)

--- a/test/models/event_organizer_watcher_test.rb
+++ b/test/models/event_organizer_watcher_test.rb
@@ -5,8 +5,9 @@ require 'test_helper'
 class EventOrganizerWatcherTest < ActiveSupport::TestCase
   test '#call' do
     event = events(:event3)
+    payload = { event: event }
     assert_difference 'Watch.where(user: event.user, watchable: event).count', 1 do
-      EventOrganizerWatcher.new.call({ event: })
+      EventOrganizerWatcher.new.call('event.create', Time.current, Time.current, 'unique_id', payload)
     end
   end
 end

--- a/test/models/event_organizer_watcher_test.rb
+++ b/test/models/event_organizer_watcher_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class EventOrganizerWatcherTest < ActiveSupport::TestCase
   test '#call' do
     event = events(:event3)
-    payload = { event: event }
+    payload = { event: }
     assert_difference 'Watch.where(user: event.user, watchable: event).count', 1 do
       EventOrganizerWatcher.new.call('event.create', Time.current, Time.current, 'unique_id', payload)
     end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8836 

## 概要

アプリケーション内でPub/Sub（出版/購読）機構を担っている外部gem `newspaper`への依存を削減するため、**Rails標準機能である `ActiveSupport::Notifications` へ置き換えるリファクタリング**を行いました。

今回は、以下の3つの購読者（Subscriber）クラス及び、関連するイベント発行部分を対象としました。

  - `EventOrganizerWatcher`
  - `AnswerNotifier`
  - `NotifierToWatchingUser`

## 変更確認方法

1.  `chore/replace-to-activesupport-notifications` ブランチをローカルに取り込みます。

    ```shell
    git fetch origin chore/replace-to-activesupport-notifications
    git checkout chore/replace-to-activesupport-notifications
    ```
2.  `foreman start -f Procfile.dev`でサーバーを立ち上げます。

-----

### 1\. `EventOrganizerWatcher` の動作確認

イベントを新規作成した際に、そのイベントの作成者自身を、そのイベントの「ウォッチャー」（更新通知を受け取る人）として自動的に登録する機能です。
この自動登録が正しく行われ、その結果、他のユーザーからのコメント通知が作成者に届くことを確認します。

1.  **任意のユーザーA**としてログインします。
2.  特別イベントを新規作成し、公開します。
3.  一度ログアウトし、**任意のユーザーB**としてログインします。
4.  ユーザーBで、先ほどユーザーAが作成したイベントのページにアクセスし、コメントを投稿します。
5.  再度ログアウトし、再び**ユーザーA**としてログインします。

**確認項目**:

  - [x] ログイン後、ヘッダーの通知アイコンに未読を示すバッジが表示されていること。
  - [x] 通知一覧ページ（`/notifications`）にアクセスし、「（あなたのイベント名）にユーザーBさんがコメントしました」という趣旨の通知が届いていることを確認する。

-----

### 2\. `AnswerNotifier` の動作確認

質問に新しい回答がついた時に、その質問の投稿者**以外**の関係者（主にウォッチャー）に「新しい回答がありました」という通知を送る機能です。
質問をウォッチしているユーザー（質問者ではない）に対して、この通知が正しく届くことを確認します。

1.  \*\*任意のユーザーA（質問者）\*\*としてログインし、質問を新規作成します。
2.  一度ログアウトし、\*\*任意のユーザーB（ウォッチャー）\*\*としてログインします。
3.  ユーザーBで、先ほどユーザーAが作成した質問のページにアクセスし、「Watch」ボタンをクリックしてウォッチ状態にします。
4.  再度ログアウトし、\*\*任意のユーザーC（回答者）\*\*としてログインします。
5.  ユーザーCで、ユーザーAが作成した質問のページにアクセスし、回答を投稿します。
6.  最後にログアウトし、再び\*\*ユーザーB（ウォッチャー）\*\*としてログインします。

**確認項目**:

  - [x] ログイン後、ヘッダーの通知アイコンに未読を示すバッジが表示されていること。
  - [x] 通知一覧ページ（`/notifications`）にアクセスし、「（ユーザーAさんの質問）にユーザーCさんが回答しました」という趣旨の通知が届いていることを確認する。

-----

### 3\. `NotifierToWatchingUser` の動作確認

質問に新しい回答がついた時に、より条件を絞って「純粋なウォッチャー」にだけ通知を送る機能です。通知が重複しないよう、ウォッチャーが「回答者自身」や「回答文中でメンションされた人」である場合は、通知対象から除外します。
「純粋なウォッチャー」には通知が届き、「回答者でもあるウォッチャー」には（この機能からは）通知が届かない、という除外ロジックが正しく働くことを確認します。

1.  **事前準備**:
    1.  \*\*任意のユーザーA（質問者）\*\*としてログインし、質問を新規作成します。
    2.  一度ログアウトし、\*\*任意のユーザーB（純粋なウォッチャー）\*\*としてログインし、上記質問をウォッチします。
    3.  再度ログアウトし、\*\*任意のユーザーC（回答者兼ウォッチャー）\*\*としてログインし、同じ質問をウォッチします。
2.  **操作**:
    1.  ユーザーCのまま、その質問に回答を投稿します。
3.  **結果確認**:
    1.  まず**ユーザーB**として再度ログインし直し、通知を確認します。
          - [x] ヘッダーに通知バッジが表示されていること。
          - [x] 通知一覧に「ウォッチ中の質問に新しい回答がありました」という趣旨の通知が**届いている**こと。
    2.  次に**ユーザーC**として再度ログインし直し、通知を確認します。
          - [x] `NotifierToWatchingUser`からの「ウォッチ中の質問に新しい回答がありました」という趣旨の通知は**届いていない**こと。

※変更前（`main`ブランチなど）の挙動と、変更後の挙動が同じであることをご確認ください。

## Screenshot

※内部的なリファクタリングであり、見た目の変更はないためスクリーンショットはありません。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 通知システムの内部処理を見直し、イベント発生時の通知や監視の仕組みを最適化しました。  
  - イベントや回答の作成時に関連ユーザーへの通知がより適切に行われるようになりました。  
  - 新たに定期イベントの通知監視機能が追加されました。  
  - ユーザー体験に影響する機能やフローに変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->