### PR TITLE
研修を終了した研修生を、一覧に表示しないよう変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -428,7 +428,12 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
   }
   scope :admins, -> { where(admin: true) }
   scope :admins_and_mentors, -> { admins.or(mentor) }
-  scope :trainees, -> { where(trainee: true) }
+  scope :trainees, lambda {
+    where(
+      trainee: true,
+      retired_on: nil
+    )
+  }
   scope :job_seeking, -> { where(career_path: 'job_seeking') }
   scope :job_seekers, lambda {
     where(

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -32,7 +32,7 @@ class GenerationTest < ActiveSupport::TestCase
 
   test '#count_classmates_by_target' do
     assert_equal 18, Generation.new(5).count_classmates_by_target(:students)
-    assert_equal 4, Generation.new(5).count_classmates_by_target(:trainees)
+    assert_equal 3, Generation.new(5).count_classmates_by_target(:trainees)
     assert_equal 1, Generation.new(5).count_classmates_by_target(:hibernated)
     assert_equal 2, Generation.new(5).count_classmates_by_target(:graduated)
     assert_equal 3, Generation.new(5).count_classmates_by_target(:advisers)

--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -32,7 +32,7 @@ class GenerationTest < ActiveSupport::TestCase
 
   test '#count_classmates_by_target' do
     assert_equal 18, Generation.new(5).count_classmates_by_target(:students)
-    assert_equal 3, Generation.new(5).count_classmates_by_target(:trainees)
+    assert_equal 4, Generation.new(5).count_classmates_by_target(:trainees)
     assert_equal 1, Generation.new(5).count_classmates_by_target(:hibernated)
     assert_equal 2, Generation.new(5).count_classmates_by_target(:graduated)
     assert_equal 3, Generation.new(5).count_classmates_by_target(:advisers)

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -90,6 +90,9 @@ class User::CompaniesTest < ApplicationSystemTestCase
     within first('.a-user-role.is-trainee') do
       assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
     end
+    within first('.a-user-role.is-retired') do
+      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyuowata'
+    end
   end
 
   test 'show adviser belonging to each company' do

--- a/test/system/user/companies_test.rb
+++ b/test/system/user/companies_test.rb
@@ -90,9 +90,6 @@ class User::CompaniesTest < ApplicationSystemTestCase
     within first('.a-user-role.is-trainee') do
       assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyu'
     end
-    within first('.a-user-role.is-retired') do
-      assert_equal first('.a-user-icons__item-icon.a-user-icon')['data-login-name'], 'kensyuowata'
-    end
   end
 
   test 'show adviser belonging to each company' do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -511,7 +511,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'search only trainee when target is trainee' do
     visit_with_auth '/users?target=trainee', 'komagata'
-    assert_selector '.users-item', count: 4
+    assert_selector '.users-item', count: 3
     fill_in 'js-user-search-input', with: 'Kensyu Seiko'
     find('#js-user-search-input').send_keys :return
     assert_text 'Kensyu Seiko', count: 1


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8138 

## 概要
研修を終了した（退会）研修生が、研修生一覧に表示されないようにする。

## 変更確認方法

1. `feature/hide-trainees-completed-training`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げる
3. `komagata`でログインする。
4. [研修生一覧](http://localhost:3000/users?target=trainee)から、`kensyu-end-over-1-week`がいることを確認する。また、左上の研修生が計6名いることを確認する。
5. ログアウト後、`kensyu-end-over-1-week`でログインし退会手続きを行う。
6. 再度`komagata`でログインし、[研修生一覧](http://localhost:3000/users?target=trainee)に`kensyu-end-over-1-week`がいないこと、かつ左上の研修生の数が1名減っていることを確認する。

## Screenshot

### 変更前
![スクリーンショット 2025-06-24 0 36 47](https://github.com/user-attachments/assets/f00b4b87-8dbb-490c-8733-7f25b5c359d3)


### 変更後
![スクリーンショット 2025-06-24 0 39 15](https://github.com/user-attachments/assets/9385131c-318b-465f-9311-69a0d647b85f)

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 退職済みの研修生が研修生一覧に表示されないようになりました。

- **テスト**
  - 退職済み研修生に関するテスト内容を修正・削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->