### PR TITLE
コメントを投稿したあと、textarea の高さが戻らないバグを修正

### DIFF
--- a/app/javascript/new-comment.js
+++ b/app/javascript/new-comment.js
@@ -1,3 +1,4 @@
+import autosize from 'autosize'
 import CSRF from 'csrf'
 import TextareaInitializer from 'textarea-initializer'
 import MarkdownInitializer from 'markdown-initializer'
@@ -64,6 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
       toggleVisibility(tabElements, 'is-active')
     }
     editorTextarea.value = ''
+    autosize.update(editorTextarea)
     updatePreviewAndButtonState()
   }
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8855 

## 概要

長文コメント投稿後、入力欄である `textarea` の高さが縮まず、広がったままになってしまう不具合を修正しました。

**修正前の状況**

長文のコメントを入力して送信すると
![image](https://github.com/user-attachments/assets/325ff367-4f28-4733-b30f-f1301d272d73)

高さが元に戻らない
![image](https://github.com/user-attachments/assets/3993dc76-34f0-4573-bd67-9153eee9c199)

## 変更確認方法

1.  `bug/reset-comment-textarea-height` ブランチをローカルに取り込む

    ```shell
    git fetch origin bug/reset-comment-textarea-height
    git checkout bug/reset-comment-textarea-height
    ```
2.  `foreman start -f Procfile.dev`でサーバーを立ち上げる
3.  任意のユーザーでログインし、コメントが投稿できるページ（例: 日報、提出物、Q\&Aなど）にアクセスする
4.  以下の手順で動作を確認する
      - [x] コメント入力欄（`textarea`）に、複数行にわたる長めの文章を入力する。
      - [x] `textarea` が入力に合わせて自動的に高くなることを確認する。
      - [x] 「コメントする」ボタンをクリックして投稿する。
      - [x] **投稿後、`textarea` の高さが初期の低い状態にリセットされていること**を確認する。

## Screenshot

### 変更後
長文コメント投稿直後もテキストエリアの高さがリセットされている。
<img width="418" alt="image" src="https://github.com/user-attachments/assets/80e7428b-4353-4732-ad16-68e7f78a8d87" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * コメントエディタをリセットした際、テキストエリアのサイズが正しく調整されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->