### PR TITLE
FirstReportNotifier及び他2クラスのnewspaperの利用をActiveSupport::Notificationsに置き換える

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -49,7 +49,7 @@ class AnnouncementsController < ApplicationController
     set_wip
 
     if @announcement.update(announcement_params)
-      Newspaper.publish(:announcement_update, { announcement: @announcement })
+      ActiveSupport::Notifications.instrument('announcement.update', announcement: @announcement)
       redirect_to Redirection.determin_url(self, @announcement), notice: notice_message(@announcement)
     else
       render :edit
@@ -61,7 +61,7 @@ class AnnouncementsController < ApplicationController
     @announcement.user_id = current_user.id
     set_wip
     if @announcement.save
-      Newspaper.publish(:announcement_create, { announcement: @announcement })
+      ActiveSupport::Notifications.instrument('announcement.create', announcement: @announcement)
       redirect_to Redirection.determin_url(self, @announcement), notice: notice_message(@announcement)
     else
       render :new

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -70,7 +70,7 @@ class AnnouncementsController < ApplicationController
 
   def destroy
     @announcement.destroy
-    Newspaper.publish(:announcement_destroy, { announcement: @announcement })
+    ActiveSupport::Notifications.instrument('announcement.destroy', announcement: @announcement)
     redirect_to announcements_path, notice: 'お知らせを削除しました'
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -59,6 +59,7 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
     canonicalize_learning_times(@report)
 
     if @report.save_uniquely
+      ActiveSupport::Notifications.instrument('report.create', report: @report)
       Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else
@@ -75,6 +76,7 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
     canonicalize_learning_times(@report)
 
     if @report.save_uniquely
+      ActiveSupport::Notifications.instrument('report.update', report: @report)
       Newspaper.publish(:report_save, { report: @report })
       redirect_to redirect_url(@report), notice: notice_message(@report), flash: flash_contents(@report)
     else

--- a/app/models/announcement_notification_destroyer.rb
+++ b/app/models/announcement_notification_destroyer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AnnouncementNotificationDestroyer
-  def call(payload)
+  def call(_name, _started, _finished, _unique_id, payload)
     announcement = payload[:announcement]
     Notification.where(link: "/announcements/#{announcement.id}").destroy_all
   end

--- a/app/models/announcement_notifier.rb
+++ b/app/models/announcement_notifier.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AnnouncementNotifier
-  def call(payload)
+  def call(_name, _started, _finished, _unique_id, payload)
     announcement = payload[:announcement]
     return if announcement.wip? || announcement.published_at?
 

--- a/app/models/first_report_notifier.rb
+++ b/app/models/first_report_notifier.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FirstReportNotifier
-  def call(payload)
+  def call(_name, _started, _finished, _unique_id, payload)
     report = payload[:report]
     return if report.wip || !report.first? || Notification.find_by(kind: :first_report, sender_id: report.user.id).present?
 

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -6,4 +6,6 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('answer.create', NotifierToWatchingUser.new)
   ActiveSupport::Notifications.subscribe('event.create', EventOrganizerWatcher.new)
   ActiveSupport::Notifications.subscribe('regular_event.create', RegularEventOrganizerWatcher.new)
+  ActiveSupport::Notifications.subscribe('report.create', FirstReportNotifier.new)
+  ActiveSupport::Notifications.subscribe('report.update', FirstReportNotifier.new)
 end

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -8,4 +8,6 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('regular_event.create', RegularEventOrganizerWatcher.new)
   ActiveSupport::Notifications.subscribe('report.create', FirstReportNotifier.new)
   ActiveSupport::Notifications.subscribe('report.update', FirstReportNotifier.new)
+  ActiveSupport::Notifications.subscribe('announcement.create', AnnouncementNotifier.new)
+  ActiveSupport::Notifications.subscribe('announcement.update', AnnouncementNotifier.new)
 end

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -10,4 +10,5 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('report.update', FirstReportNotifier.new)
   ActiveSupport::Notifications.subscribe('announcement.create', AnnouncementNotifier.new)
   ActiveSupport::Notifications.subscribe('announcement.update', AnnouncementNotifier.new)
+  ActiveSupport::Notifications.subscribe('announcement.destroy', AnnouncementNotificationDestroyer.new)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -11,7 +11,6 @@ Rails.configuration.after_initialize do
   Newspaper.subscribe(:report_save, sad_streak_updater)
   Newspaper.subscribe(:report_destroy, sad_streak_updater)
 
-  Newspaper.subscribe(:report_save, FirstReportNotifier.new)
   Newspaper.subscribe(:report_save, ReportNotifier.new)
 
   learning_cache_destroyer = LearningCacheDestroyer.new

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 Rails.configuration.after_initialize do
-  Newspaper.subscribe(:announcement_destroy, AnnouncementNotificationDestroyer.new)
-
   sad_streak_updater = SadStreakUpdater.new
   Newspaper.subscribe(:report_save, sad_streak_updater)
   Newspaper.subscribe(:report_destroy, sad_streak_updater)

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -3,10 +3,6 @@
 Rails.configuration.after_initialize do
   Newspaper.subscribe(:announcement_destroy, AnnouncementNotificationDestroyer.new)
 
-  announcement_notifier = AnnouncementNotifier.new
-  Newspaper.subscribe(:announcement_create, announcement_notifier)
-  Newspaper.subscribe(:announcement_update, announcement_notifier)
-
   sad_streak_updater = SadStreakUpdater.new
   Newspaper.subscribe(:report_save, sad_streak_updater)
   Newspaper.subscribe(:report_destroy, sad_streak_updater)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7/views/1?filterQuery=assignee%3A%40me&pane=issue&itemId=116270773&issue=fjordllc%7Cbootcamp%7C8837

## 概要
下記の３クラスの実装をnewspaperからActiveSupport::Notificationsに置き換えました。

- AnnouncementNotificationDestroyer
- AnnouncementNotifier
- FirstReportNotifier

## 変更確認方法
### 事前準備
1. `chore/replace-newspaper-with-activesupport_notifications-in-notifiers`をローカルに取り込む
  1-1. `git fetch origin chore/replace-newspaper-with-activesupport_notifications-in-notifiers`
  1-2. `git checkout chore/replace-newspaper-with-activesupport_notifications-in-notifiers`

2. `bin/setup`でセットアップ
3.  `foreman start -f Procfile.dev`でローカルサーバーの立ち上げ
### 1. `FirstReportNotifier`での各イベント動作確認
`FirstReportNotifier`は「ユーザーが初日報を提出したことを通知する」ためのクラスです。
以下で各イベントがsubscribeできているかどうかを、`FirstReportNotifier`の通知機能を通じて確認していきます。

#### `report.create`イベントがsubscribeできているかの確認
http://localhost:3000/
1. 任意の「日報作成件数が0件」のユーザー(例:osnashi)でログイン。
2. 日報を新規作成、提出する（内容は適当で構いません)。
3. アカウントを管理者もしくはメンターの権限を持つユーザー(例: komagata)に切り替える。

確認項目:
- [x] 右上の通知アイコンにて、今回作成した「はじめての日報」に関する通知が存在することを確認する。

#### `report.update`イベントがsubscribeできているかの確認
http://localhost:3000/
1. 任意の「日報作成件数が0件」のユーザー(例: muryou)でログイン。
2. 日報の内容を入力（内容は適当で構いません)した後、wipで保存。
3. アカウントを管理者もしくはメンターの権限を持つユーザー(例: komagata)に切り替え、右上の通知アイコンにて、wip状態の日報に関する通知が存在しないことを確認する。
4. アカウントを日報作成者中のユーザーに切り替え、wip状態の日報の提出ボタンを押す。
5. アカウントを管理者もしくはメンターの権限を持つユーザー(例: komagata)に切り替える。

確認項目:
- [x] 右上の通知アイコンにて、今回作成した「はじめての日報」に関する通知が存在することを確認する。

### 2. `AnnouncementNotifier`での各イベント動作確認
`AnnouncementNotifier`は「お知らせが公開されたことを通知する」ためのクラスです。
以下で各イベントがsubscribeできているかどうかを、`AnnouncementNotifier`の通知機能を通じて確認していきます。

#### `announcement.create`イベントがsubscribeできているかの確認
http://localhost:3000/
1. 任意のユーザー(誰でもいいです)でログイン。
2. お知らせを新規作成、公開する（内容は適当で構いませんが、通知ターゲットは「全員」にしてください)。
3. アカウントを別の任意のユーザー(誰でもいいです)に切り替える。

確認項目:
- [x] 右上の通知アイコンにて、今回作成したお知らせに関する通知が存在することを確認する。

#### `announcement.update`イベントがsubscribeできているかの確認
http://localhost:3000/
1. 任意のユーザー(誰でもいいです)でログイン。
2. お知らせの内容を入力（内容は適当で構いませんが、通知ターゲットは「全員」にしてください)した後、wipで保存。
3. アカウントを別の任意のユーザー(誰でもいいです)に切り替え、右上の通知アイコンにて、wip状態のお知らせに関する通知が存在しないことを確認する。
4. アカウントをお知らせ作成者中のユーザーに切り替え、wip状態のお知らせの公開ボタンを押す。
5. アカウントを別の任意のユーザーに切り替える。

確認項目:
- [x] 右上の通知アイコンにて、今回作成したお知らせに関する通知が存在することを確認する。

### 3. `AnnouncementNotificationDestroyer`での各イベント動作確認
`AnnouncementNotificationDestroyer`は「削除されたお知らせに対応する通知を削除する」ためのクラスです。
以下で各イベントがsubscribeできているかどうかを、`AnnouncementNotificationDestroyer`の通知削除機能を通じて確認していきます。

以下では「お知らせが削除された際に、それに関連する通知も削除される」ことを確認するので、`AnnouncementNotifier`の動作確認後の「お知らせが作成され、それに対する通知が存在することを確認した状態」から本件動作確認をしてください。

#### `announcement.destroy`イベントがsubscribeできているかの確認
http://localhost:3000/
1. お知らせ作成済みのユーザーでログイン、作成したお知らせを削除する。
2. アカウントを別の任意のユーザー(`AnnouncementNotifier`の動作確認時に、お知らせに関する通知の存在を確認した際に使用したユーザーが良い)に切り替える。

確認項目:
- [x] 右上の通知アイコンを確認、お知らせに関する通知が削除されていることを確認する。


## Screenshot
内部的な変更なのでスクリーンショットはありません。

## テストについて
現在ローカル環境でnotificationに関するテスト`test/system/notification/reports_test.rb`が非常に通りづらい状況です。
- 通らないテストの内容は一応確認し今回の修正に関連しない点
- CIは通っている点

を考慮してそのままレビューに出させていただいています。
この点で何かあれば適時ご質問ください🙏

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * お知らせとレポートの作成・更新・削除時に新しい通知イベントが導入されました。

* **リファクタリング**
  * 通知処理の内部構造が改善され、イベントの管理と連携が強化されました。

* **メンテナンス**
  * 通知関連の内部処理が更新されましたが、ユーザーの操作や表示には影響ありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->