### PR TITLE
日本語のテスト名を英語に変更

### DIFF
--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -123,7 +123,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     assert_no_text 'kimuraさんがはじめての日報を書きました！'
   end
 
-  test '複数の日報が投稿されているときは通知が飛ばない' do
+  test 'no notification if report already posted' do
     # 他のテストの通知に影響を受けないよう、テスト実行前に通知を削除する
     visit_with_auth '/notifications', 'muryou'
     click_link '全て既読にする'
@@ -180,7 +180,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     end
   end
 
-  test '研修生が日報を作成し提出した時、企業のアドバイザーに通知する' do
+  test 'notify company advisor only on first report posted' do
     kensyu_login_name = 'kensyu'
     advisor_login_name = 'senpai'
     title = '研修生が日報を作成し提出した時'
@@ -197,7 +197,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test '初めて提出した時だけ、フォローされているユーザーに通知する' do
+  test 'notify follower only on first report posted' do
     following = Following.first
     followed_user_login_name = User.find(following.followed_id).login_name
     follower_user_login_name = User.find(following.follower_id).login_name
@@ -215,7 +215,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test '初めて提出した時だけ、メンション通知する' do
+  test 'notify mention target only on first report posted' do
     mention_target_login_name = 'kimura'
     author_login_name = 'machida'
     title = '初めて提出したら、'
@@ -229,7 +229,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test '初日報は初めて公開した時だけ通知する' do
+  test 'notify user only on first report posted' do
     check_notification_login_name = 'machida'
     author_login_name = 'nippounashi'
     title = '初めての日報を提出したら'

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -180,7 +180,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'notify company advisor only on first report posted' do
+  test 'notify company advisor only when report is initially posted' do
     kensyu_login_name = 'kensyu'
     advisor_login_name = 'senpai'
     title = '研修生が日報を作成し提出した時'
@@ -197,7 +197,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test 'notify follower only on first report posted' do
+  test 'notify follower only when report is initially posted' do
     following = Following.first
     followed_user_login_name = User.find(following.followed_id).login_name
     follower_user_login_name = User.find(following.follower_id).login_name
@@ -215,7 +215,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test 'notify mention target only on first report posted' do
+  test 'notify mention target only when report is initially posted' do
     mention_target_login_name = 'kimura'
     author_login_name = 'machida'
     title = '初めて提出したら、'
@@ -229,7 +229,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test 'notify user only on first report posted' do
+  test 'notify user only when report is initially posted' do
     check_notification_login_name = 'machida'
     author_login_name = 'nippounashi'
     title = '初めての日報を提出したら'

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -229,7 +229,7 @@ class Notification::ReportsTest < ApplicationSystemTestCase
     )
   end
 
-  test 'notify user only when report is initially posted' do
+  test 'notify user only when first report is initially posted' do
     check_notification_login_name = 'machida'
     author_login_name = 'nippounashi'
     title = '初めての日報を提出したら'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8826

## 概要

日本語のテスト名を英語に変更

## 変更確認方法

1. `chore/fix-japanese-test-title`をローカルに取り込む
2. `test/system/notification/reports_test.rb` 内の以下のテスト名が英語になっていることを確認 

```rb
126:  test '複数の日報が投稿されているときは通知が飛ばない' do
183:  test '研修生が日報を作成し提出した時、企業のアドバイザーに通知する' do
200:  test '初めて提出した時だけ、フォローされているユーザーに通知する' do
218:  test '初めて提出した時だけ、メンション通知する' do
232:  test '初日報は初めて公開した時だけ通知する' do
```

3. 以下のコマンドでテストが全てパスすることを確認

```rb
bin/rails test test/system/notification/reports_test.rb:126
bin/rails test test/system/notification/reports_test.rb:183
bin/rails test test/system/notification/reports_test.rb:200
bin/rails test test/system/notification/reports_test.rb:218
bin/rails test test/system/notification/reports_test.rb:232
```

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * テスト名を日本語から英語に翻訳しました（テスト内容は変更なし）。
  * メンション対象の一部を kimura→komagata に変更しました（振る舞いは維持）。
  * ログイン後やダッシュボード、通知、日報作成・編集画面の表示確認を追加しました。
  * 日報作成完了を待つ仕組みと通知の未読チェックの待機方法を改善しました。
  * 日報関連テストを支援する待機ヘルパーを追加・調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->