### PR TITLE
FjordContributionsのリンクをフッターに追加

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -53,6 +53,9 @@ footer.footer
             = link_to 'https://fjord-choice.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | Fjord Choice
           li.footer-nav__item
+            = link_to 'https://fjordcontributions.onrender.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | FjordContributions
+          li.footer-nav__item
             = link_to 'https://buzzcord-fjord-jp.herokuapp.com', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | Buzzcord
           li.footer-nav__item


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/8572

## 概要
FjordContributionsのリンクをフッターに追加しました。
場所は、Fjord Choiceの右隣です。

## 変更確認方法

1. `feature/add-fjordcontributions-link-to-footer`をローカルに取り込む
2.  `foreman start -f Procfile.dev`でローカルサーバーを起動
3. ログインする
4.  ダッシュボード`https://bootcamp.fjord.jp/`にアクセスし、下までスクロールしフッターを確認する

## Screenshot

### 変更前
![image](https://github.com/user-attachments/assets/6e267285-674e-47fd-8043-8c1e823c1f2b)


### 変更後
![image](https://github.com/user-attachments/assets/5fd0e42a-f54e-43e7-8fc0-907feacb9986)



<!-- I want to review in Japanese. -->
