### PR TITLE
ベストアンサー選択時にそのコメントが編集画面になるバグの修正

### DIFF
--- a/app/javascript/initializeAnswer.js
+++ b/app/javascript/initializeAnswer.js
@@ -13,13 +13,13 @@ export default function initializeAnswer(answer) {
 
   const answerDisplay = answer.querySelector('.answer-display')
   const answerEditor = answer.querySelector('.answer-editor')
-  const answerDisplayContent = answerDisplay.querySelector('.a-long-text')
+  const answerDisplayContent = answerDisplay.querySelector('.answer-text')
 
   const answerEditorPreview = answerEditor.querySelector(
-    '.a-markdown-input__preview'
+    '.markdown-preview'
   )
   const editorTextarea = answerEditor.querySelector(
-    '.a-markdown-input__textarea'
+    '.markdown-textarea'
   )
 
   if (answerDescription) {
@@ -29,7 +29,7 @@ export default function initializeAnswer(answer) {
       markdownInitializer.render(answerDescription)
   }
 
-  const editButton = answerDisplay.querySelector('.is-secondary')
+  const editButton = answerDisplay.querySelector('.edit-button')
   const modalElements = [answerDisplay, answerEditor]
   if (editButton) {
     editButton.addEventListener('click', () => {
@@ -40,7 +40,7 @@ export default function initializeAnswer(answer) {
     })
   }
 
-  const saveButton = answerEditor.querySelector('.is-primary')
+  const saveButton = answerEditor.querySelector('.save-button')
   if (saveButton) {
     saveButton.addEventListener('click', () => {
       toggleVisibility(modalElements, 'is-hidden')
@@ -50,7 +50,7 @@ export default function initializeAnswer(answer) {
     })
   }
 
-  const cancelButton = answerEditor.querySelector('.is-secondary')
+  const cancelButton = answerEditor.querySelector('.cancel-button')
   cancelButton.addEventListener('click', () => {
     toggleVisibility(modalElements, 'is-hidden')
     editorTextarea.value = savedAnswer
@@ -63,9 +63,9 @@ export default function initializeAnswer(answer) {
     )
   })
 
-  const makeBestAnswerButton = answerDisplay.querySelector('.is-warning')
-  const cancelBestAnswerButton = answerDisplay.querySelector('.is-muted')
-  const answerBadgeElement = answerDisplay.querySelector('.answer-badge')
+  const makeBestAnswerButton = answerDisplay.querySelector('.make-best-answer')
+  const cancelBestAnswerButton = answerDisplay.querySelector('.cancel-best-answer')
+  const answerBadgeElement = answerDisplay.querySelector('.best-answer-badge')
   if (makeBestAnswerButton) {
     makeBestAnswerButton.addEventListener('click', () => {
       if (window.confirm('本当に宜しいですか？')) {
@@ -99,10 +99,10 @@ export default function initializeAnswer(answer) {
           cancelBestAnswerButton.parentNode
         ]
         toggleVisibility(parentElements, 'is-hidden')
-        const otherCancelBestAnswerButtons = document.querySelectorAll(
+        const otherMakeBestAnswerButtons = document.querySelectorAll(
           '.make-best-answer-button'
         )
-        otherCancelBestAnswerButtons.forEach((button) => {
+        otherMakeBestAnswerButtons.forEach((button) => {
           if (button.closest('.answer').dataset.answer_id !== answerId) {
             button.classList.remove('is-hidden')
           }
@@ -112,7 +112,7 @@ export default function initializeAnswer(answer) {
   }
 
   const deleteButton = answerDisplay.querySelector(
-    '.card-main-actions__muted-action'
+    '.delete-button'
   )
   if (deleteButton) {
     deleteButton.addEventListener('click', () => {
@@ -136,7 +136,7 @@ export default function initializeAnswer(answer) {
   const editTab = answerEditor.querySelector('.edit-answer-tab')
   const editorTabContent = answerEditor.querySelector('.is-editor')
   const previewTab = answerEditor.querySelector('.answer-preview-tab')
-  const previewTabContent = answerEditor.querySelector('.is-preview')
+  const previewTabContent = answerEditor.querySelector('.preview-content')
 
   const tabElements = [editTab, editorTabContent, previewTab, previewTabContent]
   editTab.addEventListener('click', () =>
@@ -147,7 +147,7 @@ export default function initializeAnswer(answer) {
     toggleVisibility(tabElements, 'is-active')
   )
 
-  const createdAtElement = answer.querySelector('.thread-comment__created-at')
+  const createdAtElement = answer.querySelector('.created-at')
   if (createdAtElement && navigator.clipboard) {
     createdAtElement.addEventListener('click', () => {
       const answerURL = location.href.split('#')[0] + '#answer_' + answerId

--- a/app/javascript/initializeAnswer.js
+++ b/app/javascript/initializeAnswer.js
@@ -29,7 +29,7 @@ export default function initializeAnswer(answer) {
       markdownInitializer.render(answerDescription)
   }
 
-  const editButton = answerDisplay.querySelector('.card-main-actions__action')
+  const editButton = answerDisplay.querySelector('.is-secondary')
   const modalElements = [answerDisplay, answerEditor]
   if (editButton) {
     editButton.addEventListener('click', () => {

--- a/app/javascript/initializeAnswer.js
+++ b/app/javascript/initializeAnswer.js
@@ -15,12 +15,8 @@ export default function initializeAnswer(answer) {
   const answerEditor = answer.querySelector('.answer-editor')
   const answerDisplayContent = answerDisplay.querySelector('.answer-text')
 
-  const answerEditorPreview = answerEditor.querySelector(
-    '.markdown-preview'
-  )
-  const editorTextarea = answerEditor.querySelector(
-    '.markdown-textarea'
-  )
+  const answerEditorPreview = answerEditor.querySelector('.markdown-preview')
+  const editorTextarea = answerEditor.querySelector('.markdown-textarea')
 
   if (answerDescription) {
     answerDisplayContent.innerHTML =
@@ -64,7 +60,9 @@ export default function initializeAnswer(answer) {
   })
 
   const makeBestAnswerButton = answerDisplay.querySelector('.make-best-answer')
-  const cancelBestAnswerButton = answerDisplay.querySelector('.cancel-best-answer')
+  const cancelBestAnswerButton = answerDisplay.querySelector(
+    '.cancel-best-answer'
+  )
   const answerBadgeElement = answerDisplay.querySelector('.best-answer-badge')
   if (makeBestAnswerButton) {
     makeBestAnswerButton.addEventListener('click', () => {
@@ -111,9 +109,7 @@ export default function initializeAnswer(answer) {
     })
   }
 
-  const deleteButton = answerDisplay.querySelector(
-    '.delete-button'
-  )
+  const deleteButton = answerDisplay.querySelector('.delete-button')
   if (deleteButton) {
     deleteButton.addEventListener('click', () => {
       if (window.confirm('本当に宜しいですか？')) {

--- a/app/views/questions/_answer.html.slim
+++ b/app/views/questions/_answer.html.slim
@@ -8,7 +8,7 @@
         img.thread-comment__company-logo src="#{answer.user.company.logo_url}"
   .thread-comment__end
     .a-card.is-answer.answer-display
-      .answer-badge class=(answer.type == 'CorrectAnswer' ? 'correct-answer' : 'is-hidden')
+      .answer-badge.best-answer-badge class=(answer.type == 'CorrectAnswer' ? 'correct-answer' : 'is-hidden')
         .answer-badge__icon
           i.fa-solid.fa-star
         .answer-badge__label
@@ -21,14 +21,14 @@
             img.thread-comment__title-user-icon.a-user-icon src="#{answer.user.avatar_url}"
           a.thread-comment__title-link.a-text-link href="#{answer.user.url}"
             = answer.user.login_name
-        time.thread-comment__created-at
+        time.thread-comment__created-at.created-at
           = l(answer.created_at)
       hr.a-border-tint
       .thread-comment__description
         - if answer.user.company && answer.user.adviser
           a.thread-comment__company-link.is-hidden-md-up href="#{company_path(answer.user.company)}"
             img.thread-comment__company-logo src="#{answer.user.company.logo_url}"
-        .a-long-text.is-md
+        .a-long-text.is-md.answer-text
           = answer.description
       hr.a-border-tint
       .thread-comment__reactions
@@ -39,21 +39,21 @@
           ul.card-main-actions__items
             - if answer.user.id == user.id || user.admin?
               li.card-main-actions__item
-                button.card-main-actions__action.a-button.is-sm.is-secondary.is-block
+                button.card-main-actions__action.a-button.is-sm.is-secondary.is-block.edit-button
                   i.fa-solid.fa-pen
                   | 内容修正
             - if user.mentor? || user.id == question.user.id
               - make_button_hidden = (question.correct_answer && answer.type != 'CorrectAnswer') || (answer.type == 'CorrectAnswer')
               - cancel_button_hidden = (question.correct_answer && answer.type != 'CorrectAnswer') || !question.correct_answer
               li.card-main-actions__item.make-best-answer-button class=(make_button_hidden ? 'is-hidden' : '')
-                button.card-main-actions__action.a-button.is-sm.is-warning.is-block
+                button.card-main-actions__action.a-button.is-sm.is-warning.is-block.make-best-answer
                   | ベストアンサーにする
               li.card-main-actions__item.cancel-best-answer-button class=(cancel_button_hidden ? 'is-hidden' : '')
-                button.card-main-actions__action.a-button.is-sm.is-muted.is-block
+                button.card-main-actions__action.a-button.is-sm.is-muted.is-block.cancel-best-answer
                   | ベストアンサーを取り消す
             - if answer.user.id == user.id || user.mentor?
               li.card-main-actions__item.is-sub
-                button.card-main-actions__muted-action
+                button.card-main-actions__muted-action.delete-button
                   | 削除する
     .a-card.is-answer.answer-editor.is-hidden
       .thread-comment-form__form
@@ -66,21 +66,21 @@
           .a-markdown-input__inner.is-editor.js-tabs__content.is-active
             .form-textarea
               .form-textarea__body
-                textarea.a-text-input.a-markdown-input__textarea id="js-comment-#{answer.id}" data-preview="#js-comment-preview-#{answer.id}" data-input=".js-comment-file-input-#{answer.id}" name='answer[description]'
+                textarea.a-text-input.a-markdown-input__textarea.markdown-textarea id="js-comment-#{answer.id}" data-preview="#js-comment-preview-#{answer.id}" data-input=".js-comment-file-input-#{answer.id}" name='answer[description]'
                   = answer.description
               .form-textarea__footer
                 .form-textarea__insert
                   label.a-file-insert.a-button.is-xs.is-text-reversal.is-block
                     | ファイルを挿入
                     input(class="js-comment-file-input-#{answer.id}" type='file' multiple)
-          .a-markdown-input__inner.is-preview.js-tabs__content
-            .js-preview.a-long-text.is-md.a-markdown-input__preview id="js-comment-preview-#{answer.id}"
+          .a-markdown-input__inner.is-preview.js-tabs__content.preview-content
+            .js-preview.a-long-text.is-md.a-markdown-input__preview.markdown-preview id="js-comment-preview-#{answer.id}"
         .card-footer
           .card-main-actions
             .card-main-actions__items
               .card-main-actions__item
-                button.a-button.is-sm.is-primary.is-block
+                button.a-button.is-sm.is-primary.is-block.save-button
                   | 保存する
               .card-main-actions__item
-                button.a-button.is-sm.is-secondary.is-block
+                button.a-button.is-sm.is-secondary.is-block.cancel-button
                   | キャンセル


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8854 

## 概要
管理者または質問作成者が自身のコメント以外をベストアンサーに選択またはキャンセルするとそのコメントの編集画面が表示されてしまうバグの修正を行った。また回答表示の各要素にCSSとは別のJS用のクラスを追加し対応させるように修正した。
## 変更確認方法

1. ```bug/best-answer-cancel```をローカルに取り込む
2. ```foreman start -f Procfile.dev```でサーバーを立ち上げる
3. ユーザー（例：hajime）でログインし[質問作成ページ](http://localhost:3000/questions/new)にアクセス、質問を作成する。
4. 別のユーザー（例：kimura）でログインし質問に答える
5. 質問を作成したユーザー（hajime）でログインし回答したユーザー（kimura）の回答をベストアンサーに選択、本当に宜しいですか？でキャンセルをクリックし選択した回答が編集画面に移行しないことを確認する。また、本当に宜しいですか？をOKし選択した回答が編集画面に移行しないことを確認する。

## Screenshot

### 変更前

![バグ修正前](https://github.com/user-attachments/assets/de1ad389-69e9-4962-9d8e-220e7959a498)


### 変更後
![ベストアンサー選択バグ修正](https://github.com/user-attachments/assets/87ba77c7-4f14-4eee-b5d7-7689df88c010)

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **バグ修正**
  * 回答表示エリアの編集ボタンの選択方法を修正し、編集機能の動作を改善しました。
* **改善**
  * 回答表示や編集画面の各要素により具体的で意味のあるCSSクラスを追加し、スタイリングと操作性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->