### PR TITLE
管理者メニューにお問い合わせを追加

### DIFF
--- a/app/views/application/_admin_menu.html.slim
+++ b/app/views/application/_admin_menu.html.slim
@@ -18,6 +18,9 @@
       = link_to admin_faq_categories_path, class: 'header-dropdown__item-link' do
         | FAQ
     li.header-dropdown__item
+      = link_to admin_inquiries_path, class: 'header-dropdown__item-link' do
+        | お問い合わせ
+    li.header-dropdown__item
       = link_to admin_grant_course_applications_path, class: 'header-dropdown__item-link' do
         | 給付金対応コース受講申請
     li.header-dropdown__item


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/8876

## 概要

管理者メニューにお問い合わせを追加。
リンク先: `/admin/inquiries`
`link_to`を使い、`xxx_path`という形で指定。

## 変更確認方法

1. `feature/add-inquiries-link-to-admin-menu`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルサーバーを起動
3. 管理者でログインし、Meメニューの管理者メニュー内のFAQの下にお問い合わせがあることを確認
4. お問い合わせをクリックすると`/admin/inquiries`へ遷移することを確認

## Screenshot

### 変更前

![before_change_8876](https://github.com/user-attachments/assets/30096ae1-c2e1-45f0-bde7-27855395384b)

### 変更後

![after_change_8876](https://github.com/user-attachments/assets/6f9ca297-49bb-45f3-a198-b0311f0002fa)

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 管理者メニューに「お問い合わせ」項目が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->