### PR TITLE
タブのデザイン崩れを修正

### DIFF
--- a/app/javascript/stylesheets/application/blocks/side/_side-tabs-nav.sass
+++ b/app/javascript/stylesheets/application/blocks/side/_side-tabs-nav.sass
@@ -1,6 +1,9 @@
 .side-tabs-nav__items
   display: flex
   +position(relative, 2)
+  overflow-y: hidden
+  overflow-x: auto
+  transform: translateY(1px)
 
 .side-tabs-nav__item
   min-width: 6.5rem
@@ -14,6 +17,7 @@
 
 .side-tabs-nav__item-link
   +text-block(.8125rem 1.4, flex 600 center)
+  white-space: nowrap
   justify-content: center
   cursor: pointer
   padding: .75em 1em


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * サイドタブナビゲーションの項目が横スクロール可能になり、リンクテキストが折り返されず1行で表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->