### PR TITLE
管理者メニューに「企業研修申込」を追加

### DIFF
--- a/app/views/application/_admin_menu.html.slim
+++ b/app/views/application/_admin_menu.html.slim
@@ -21,6 +21,9 @@
       = link_to admin_inquiries_path, class: 'header-dropdown__item-link' do
         | お問い合わせ
     li.header-dropdown__item
+      = link_to admin_corporate_training_inquiries_path, class: 'header-dropdown__item-link' do
+        | 企業研修申込
+    li.header-dropdown__item
       = link_to admin_grant_course_applications_path, class: 'header-dropdown__item-link' do
         | 給付金対応コース受講申請
     li.header-dropdown__item


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [#8873 企業研修申込 をadminのMeメニューに追加したい](https://github.com/fjordllc/bootcamp/issues/8873)

## 概要
AdminのMeメニューに「企業研修申込」を追加しました。
リンク先`/admin/corporate_training_inquiries`を`link_to`を使い`xxx_path` という形で指定しました。

## 変更確認方法

1. ブランチ`chore/add-corporate-training-inquiries-to-admin-me-menu`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. Adminでログインし、Meメニューのドロップダウンに「企業研修申込」があることを確認
4. 「企業研修申込」をクリックすると`/admin/corporate_training_inquiries`に遷移することを確認

## Screenshot

### 変更前
<img width="238" alt="スクリーンショット 2025-07-07 16 50 23" src="https://github.com/user-attachments/assets/2e674e97-9b5d-41ce-bb8a-34ecaa73b3d8" />


### 変更後
<img width="230" alt="スクリーンショット 2025-07-07 17 57 05" src="https://github.com/user-attachments/assets/f91f0308-02ec-45a8-aeb4-c89b644a6925" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 管理者用ドロップダウンメニューに「企業研修申込」メニュー項目を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->