### PR TITLE
[Markdown]Blockquotes内にユーザー名(@user_name)を記述してもメンションが通知されないようにする

### DIFF
--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -62,8 +62,10 @@ module Mentioner
 
   def extract_login_names_from_mentions(mentions)
     code_block_regexp = /```.*?```|`.*?`/m
-    mentionable_without_code = mentionable.gsub(code_block_regexp, '')
-    mentions.map { |s| s.gsub(/@/, '') if mentionable_without_code.include?(s) }
+    block_quotes_regexp = /^>.+?\n{2}|^>.+?\Z/m
+    regexps = Regexp.union(code_block_regexp, block_quotes_regexp)
+    mentionable_without_code_quotes = mentionable.gsub(regexps, '')
+    mentions.map { |s| s.gsub(/@/, '') if mentionable_without_code_quotes.include?(s) }
   end
 
   def target_of_comment(commentable_class, commentable)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -948,7 +948,6 @@ ActiveRecord::Schema.define(version: 2025_06_24_141527) do
     t.integer "os"
     t.boolean "trainee", default: false, null: false
     t.text "retire_reason"
-    t.boolean "job_seeking", default: false, null: false
     t.string "customer_id"
     t.string "subscription_id"
     t.boolean "mail_notification", default: true, null: false

--- a/test/models/concerns/mentioner_test.rb
+++ b/test/models/concerns/mentioner_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MentionerTest < ActiveSupport::TestCase
+  test '#notify_all_mention_user' do
+    markdown = <<~TEXT
+       @komagata
+       文中に > を含む @machida
+
+      ```
+      @hatsuno
+      ```
+      `@kananashi`　　
+
+      > @sotugyou\n\n
+      > 改行を含む
+      @hajime
+
+      > テキストエリアと
+      最終行が一致 @kensyu
+    TEXT
+
+    report = Report.create!(
+      user: users(:hajime),
+      reported_on: Time.zone.today,
+      title: 'メンションテスト',
+      description: markdown
+    )
+
+    assert %w[komagata machida], report.notify_all_mention_user
+  end
+end

--- a/test/models/concerns/mentioner_test.rb
+++ b/test/models/concerns/mentioner_test.rb
@@ -28,6 +28,6 @@ class MentionerTest < ActiveSupport::TestCase
       description: markdown
     )
 
-    assert %w[komagata machida], report.notify_all_mention_user
+    assert_equal %w[komagata machida], report.notify_all_mention_user.map(&:login_name).sort
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8861

## 概要
元々は、コードブロックにユーザー名を記述してもメンションが飛ばないようになっていた。今回、ブロッククォートでもそうなるように正規表現を追加した。

## 変更確認方法

1.  foreman start -f Procfile.devでサーバーを起動する
2. 「feature/disable-mention-in-blockquotes」をローカルに取り込む
3. app/models/concerns/mentionor.rbを開く
4. extract_login_names_from_mentionsメソッドにbinding.pryを挿入
5. railsコンソールを起動する
6. 「メンションテスト(変更後)」のreportインスタンスを取得
```
report = Report.find_by(id: 1066585830)
```
7. report.descriptionで内容を確認(下のスクショのテキストエリアの内容と同じ)
```
report.description
=> "## メンションできる\r\n\r\nトップレベルではメンションできる @komagata\r\n\r\n文中に > を含む場合はメンションできる @machida\r\n\r\n## メンションできない....
```
8. notify_all_mention_userメソッドを呼び出す
```
report.notify_all_mention_user
```
9. nextコマンドで、find_user_from_mentionsメソッドの中に入る
10. names変数の中身を確認し、以下のようにユーザー名が除去されていればOK
```
 ["komagata", "machida", nil, nil, nil, nil, nil, nil, nil]
```



## Screenshot

ブラウザで動作確認済み

![スクリーンショット 2025-07-11 14 23 12](https://github.com/user-attachments/assets/1d8441cc-15f5-4ceb-be2b-d0fae28fe001)


---

## 補足
db/schema.rbの差分については、git pull --rebase後に反映されたものになります。

---




<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * コードブロックや引用ブロック、インラインコード内のメンションが正しく無視されるようになりました。

* **テスト**
  * メンション通知機能が正しく動作することを確認するテストを追加しました。

* **データベース**
  * ユーザーテーブルから「job_seeking」カラムを削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->