### PR TITLE
本番環境以外で動画一覧タブとプラクティスごとの動画タブを表示する

### DIFF
--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -8,8 +8,8 @@ module PageTabs
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports.length }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
-      # TODO: 動画機能の完成時に公開。動画リンクを隠した状態でのリリース。
-      # tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length }
+      # TODO: 動画機能の完成時に本番環境で公開。動画リンクを隠した状態でのリリース。
+      tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length } unless Rails.env.production?
       tabs << { name: '提出物', link: practice_products_path(practice) }
       tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?
       tabs << { name: 'コーディングテスト', link: practice_coding_tests_path(practice) } if practice.coding_tests.present?

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -45,10 +45,10 @@ nav.global-nav
             .global-nav-links__link-icon
               i.fa-solid.fa-file
             .global-nav-links__link-label
-              - if Rails.env.development?
-                | Docs・動画
-              - else
+              - if Rails.env.production?
                 | Docs
+              - else
+                | Docs・動画
         li.global-nav-links__item
           = link_to portfolios_path, class: "global-nav-links__link #{current_link(/^works/)}" do
             .global-nav-links__link-icon

--- a/app/views/pages/_doc_movie_header.html.slim
+++ b/app/views/pages/_doc_movie_header.html.slim
@@ -3,8 +3,8 @@ header.page-header
     .page-header__inner
       .page-main-header__start
         h2.page-header__title
-          - if Rails.env.development?
+          - if Rails.env.production?
             // 動画リンクを隠した状態でのリリース。リリース後にDocs・動画に変更する
-            | Docs・動画
-          - else
             | Docs
+          - else
+            | Docs・動画

--- a/app/views/pages/_tabs.html.slim
+++ b/app/views/pages/_tabs.html.slim
@@ -4,7 +4,7 @@
       li.page-tabs__item
         = link_to pages_path, class: "page-tabs__item-link #{current_link(/^pages/)}"
           | Docs
-      - if Rails.env.development?
+      - unless Rails.env.production?
         // リンクを隠した状態でのリリース
         li.page-tabs__item
           = link_to movies_path, class: "page-tabs__item-link #{current_link(/^movies/)}"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8896

## 概要

動画一覧(全体)とプラクティスに紐づく動画一覧のタブについて、本番環境以外で表示するように変更した。

## 変更確認方法

1. `feature/display-video-tab-dev-env`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを起動
3. 任意のユーザーでログインし、プラクティス一覧の画面に移動
4. `OS X Mountain Lionをクリーンインストールする`を選択し、動画タブが表示されていることを確認する。
5. 動画タブをクリックし、関連する動画一覧が表示されることを確認する。

動画一覧(全体)については、元々開発環境で表示されているため、見た目の変更はありません。

## Screenshot

### 変更前

<img width="1284" height="427" alt="image" src="https://github.com/user-attachments/assets/467ef316-eaed-41f6-828b-a0ea6709e4e9" />


### 変更後

<img width="1024" height="382" alt="image" src="https://github.com/user-attachments/assets/676f2395-12f5-4ead-aba4-1c90eb0413ec" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 「動画」タブおよび「Docs・動画」ラベルが本番環境以外で表示されるようになりました。

* **スタイル**
  * 本番環境では「Docs」のみ表示され、その他の環境では「Docs・動画」と表示されるようにラベル表示を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->