### PR TITLE
spanタグのタイポ修正

### DIFF
--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -13,7 +13,7 @@ export default (md) => {
                   <div class="speak__speaker">
                     <a href="/users/${speakerName}" class="a-user-emoji-link">
                       <img title="@${speakerName}" class="js-user-icon a-user-emoji" data-user="${speakerName}">
-                      <spanv class="speak__speaker-name">${speakerName}</span>
+                      <span class="speak__speaker-name">${speakerName}</span>
                     </a>
                   </div>
                   <div class="speak__body">`


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [#8875 jsファイルのタイポ修正](https://github.com/fjordllc/bootcamp/issues/8875#event-18426328141)

## 概要
タイポ修正をしました。
`/app/javascript/markdown-it-container-speak.js`の１６行目にあるコード
`<spanv class="speak__speaker-name">${speakerName}</span>`
`spanv`を`span`に修正しました。

## 変更確認方法
UIや機能に影響がないため、変更内容は「Files changed」タブからご確認ください。

## Screenshot
UIに変化がなかったためスクリーンショットは省略しています。

### 変更前

### 変更後

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 「speak」マークダウンコンテナで表示されるHTMLタグのタイプミスを修正し、正しいHTMLマークアップが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->