### PR TITLE
見たよ表示のモデルにバリデーションを追加

### DIFF
--- a/app/models/footprint.rb
+++ b/app/models/footprint.rb
@@ -5,7 +5,7 @@ class Footprint < ApplicationRecord
 
   belongs_to :user
   belongs_to :footprintable, polymorphic: true
-  validates :user_id, presence: true
+  validates :user_id, presence: true, uniqueness: { scope: %i[footprintable_id footprintable_type] }
 
   def self.fetch_for_resource(resource)
     where(footprintable: resource)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8517 

## 概要
お知らせ等のリソースの「見たよ」欄に同じユーザーのアイコンが複数表示されないようユニーク制約のバリデーションを追加した。

## 変更確認方法

1. ```bug/unique-violation-error```をローカルに取り込む
2. ```foreman start -f Procfile.dev```でローカル環境を立ち上げる
3. 2つのブラウザで同じ任意のユーザーでログインする
4. [お知らせ一覧](http://localhost:3000/announcements)にアクセスする
5. アクセスしたことがない同じお知らせに同時にアクセスし```ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint  "index_footprintable"```というエラーが表示されないことを確認する


## Screenshot
コード変更のみで画面の変更はなし

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **バグ修正**
  * 同じユーザーが同一リソースに複数のフットプリントを作成できないよう制限しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->