### PR TITLE
cocoonedのwarningを解消

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require cocoon
 //= require select2/dist/js/select2.full.js
 //= require activestorage

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -97,4 +97,6 @@ const componentRequireContext = require.context('components', true)
 const ReactRailsUJS = require('react_ujs')
 ReactRailsUJS.useContext(componentRequireContext)
 
-Cocooned.start()
+document.addEventListener('DOMContentLoaded', () => {
+  Cocooned.start()
+})


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [8833](https://github.com/fjordllc/bootcamp/issues/8833)
- また、以下のチケットでcocoonedへのリプレイスを行っていたため、こちらもチケットを差し戻している(このPR完了後に一緒に戻す)
  - [関連チケット 8605](https://github.com/fjordllc/bootcamp/issues/8605)
  - [関連チケット 8709](https://github.com/fjordllc/bootcamp/issues/8709)

## 概要
cocooned gem導入後以下の警告が出ていた。
```
DEPRECATION WARNING: Loading @notus.sh/cocooned/cocooned is deprecated. It will be removed from Cocooned 3.0, use @notus.sh/cocooned/jquery, @notus.sh/cocooned or `@notus.sh/cocooned/src/cocooned/cocooned` instead.
```

Webpackではcocoonedを使うようにしていたが、Sprocketsでは昔のcocoonを使うようなrequire文があったので、それを削除することで解消した。

またWebpack経由でcocoonedの読み込みもうまくできていなかったので、それも解消した。
## 変更確認方法

1. `chores/fix-cocooned-warning`をローカルに取り込む
2. 任意のユーザーでログインして、日報の新規作成ページ(`http://localhost:3000/reports/new`)に遷移する。
3. 開発者ツールを開く

- [ ] 下記エラーがconsole上で出力されていないこと
```
DEPRECATION WARNING: Loading @notus.sh/cocooned/cocooned is deprecated. It will be removed from Cocooned 3.0, use @notus.sh/cocooned/jquery, @notus.sh/cocooned or `@notus.sh/cocooned/src/cocooned/cocooned` instead.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **その他**
  * JavaScriptライブラリ「cocoon」の読み込みを停止しました。
  * 「cocoon」の初期化処理をページ読み込み完了後に実行するように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->