### PR TITLE
企業研修申し込みのリンクをMeメニューに追加

### DIFF
--- a/app/views/application/_admin_menu.html.slim
+++ b/app/views/application/_admin_menu.html.slim
@@ -21,6 +21,9 @@
       = link_to admin_inquiries_path, class: 'header-dropdown__item-link' do
         | お問い合わせ
     li.header-dropdown__item
+      = link_to admin_corporate_training_inquiries_path, class: 'header-dropdown__item-link' do
+        | 企業研修申し込み
+    li.header-dropdown__item
       = link_to admin_grant_course_applications_path, class: 'header-dropdown__item-link' do
         | 給付金対応コース受講申請
     li.header-dropdown__item


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/8872

## 概要
adminでログインした時のMeメニューに企業研修申し込みリンクを追加しました。

## 変更確認方法

1. `feature/add-corporate-training-inquiries-link-for-admin`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルサーバーを立ち上げる
3. 管理者ユーザー（`machida` または `komagata`）でログインする
4. 画面右上の Me メニューを開き、管理者メニュー内に`企業研修申し込み` のリンクが表示されているか確認する
5. `企業研修申し込み`をクリックし、`/admin/corporate_training_inquiries`に遷移するか確認する

## Screenshot

### 変更前
<img width="760" height="1628" alt="image" src="https://github.com/user-attachments/assets/93c59e53-1d57-447a-9dc9-fc4184d0a8dd" />


### 変更後
<img width="656" height="1622" alt="image" src="https://github.com/user-attachments/assets/eac25e55-3e14-4de6-aa7a-898443f1e245" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 管理者メニューに「企業研修申し込み」項目が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->