### PR TITLE
speakブロックに引数を渡し、アバターと名前を表示

### DIFF
--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -19,8 +19,10 @@ export default (md) => {
         if (tokens[idx].nesting === 1) {
           return `<div class="speak">
                     <div class="speak__speaker">
-                      <img src="${avatarUrl}" alt="${speakerName}" title="@${speakerName}" class="a-user-emoji speak__speaker-avatar">
-                      <span class="speak__speaker-name">${speakerName}</span>
+                      <a class="a-user-emoji-link">
+                        <img src="${avatarUrl}" alt="${speakerName}" title="@${speakerName}" class="a-user-emoji speak__speaker-avatar">
+                        <span class="speak__speaker-name">${speakerName}</span>
+                      </a>
                     </div>
                     <div class="speak__body">`
         }
@@ -46,8 +48,10 @@ export default (md) => {
           } else {
             return `<div class="speak">
                       <div class="speak__speaker">
-                        <img src="/images/users/avatars/default.png" alt="${speakerName}" title="${speakerName}" class="a-user-emoji speak__speaker-avatar">
-                        <span class="speak__speaker-name">${speakerName}</span>
+                        <a class="a-user-emoji-link">
+                          <img src="/images/users/avatars/default.png" alt="${speakerName}" title="${speakerName}" class="a-user-emoji speak__speaker-avatar">
+                          <span class="speak__speaker-name">${speakerName}</span>
+                        </a>
                       </div>
                       <div class="speak__body">`
           }

--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -19,10 +19,8 @@ export default (md) => {
         if (tokens[idx].nesting === 1) {
           return `<div class="speak">
                     <div class="speak__speaker">
-                      <a href="/users/${speakerName}" class="a-user-emoji-link">
-                        <img src="${avatarUrl}" alt="${speakerName}" title="@${speakerName}" class="a-user-emoji speak__speaker-avatar">
-                        <span class="speak__speaker-name">${speakerName}</span>
-                      </a>
+                      <img src="${avatarUrl}" alt="${speakerName}" title="@${speakerName}" class="a-user-emoji speak__speaker-avatar">
+                      <span class="speak__speaker-name">${speakerName}</span>
                     </div>
                     <div class="speak__body">`
         }

--- a/app/javascript/markdown-it-container-speak.js
+++ b/app/javascript/markdown-it-container-speak.js
@@ -3,23 +3,60 @@ import escapeHTML from './escapeHtml.js'
 
 export default (md) => {
   md.use(MarkdownItContainer, 'speak', {
+    marker: ':',
+    validate: function (params) {
+      return params.trim().match(/^speak(\s|$|(\s*\([^)]+\)\s*$))/)
+    },
     render: (tokens, idx) => {
-      const speakerName = escapeHTML(tokens[idx].info)
-        .replace('speak @', '')
-        .trim()
+      const info = tokens[idx].info.trim()
 
-      if (tokens[idx].nesting === 1) {
-        return `<div class="speak">
-                  <div class="speak__speaker">
-                    <a href="/users/${speakerName}" class="a-user-emoji-link">
-                      <img title="@${speakerName}" class="js-user-icon a-user-emoji" data-user="${speakerName}">
-                      <spanv class="speak__speaker-name">${speakerName}</span>
-                    </a>
-                  </div>
-                  <div class="speak__body">`
+      const parenMatch = info.match(/^speak\s*\(\s*([^,]+)\s*,\s*([^)]+)\s*\)$/)
+
+      if (parenMatch) {
+        const speakerName = escapeHTML(parenMatch[1].trim())
+        const avatarUrl = parenMatch[2].trim()
+
+        if (tokens[idx].nesting === 1) {
+          return `<div class="speak">
+                    <div class="speak__speaker">
+                      <a href="/users/${speakerName}" class="a-user-emoji-link">
+                        <img src="${avatarUrl}" alt="${speakerName}" title="@${speakerName}" class="a-user-emoji speak__speaker-avatar">
+                        <span class="speak__speaker-name">${speakerName}</span>
+                      </a>
+                    </div>
+                    <div class="speak__body">`
+        }
       } else {
-        return '</div></div>\n'
+        const speakerName = escapeHTML(info)
+          .replace('speak @', '')
+          .replace('speak', '')
+          .trim()
+          .replace(/^\*\*@?/, '')
+          .replace(/\*\*$/, '')
+          .trim()
+
+        if (tokens[idx].nesting === 1) {
+          if (info.includes('@')) {
+            return `<div class="speak">
+                      <div class="speak__speaker">
+                        <a href="/users/${speakerName}" class="a-user-emoji-link">
+                          <img title="@${speakerName}" class="js-user-icon a-user-emoji" data-user="${speakerName}">
+                          <span class="speak__speaker-name">${speakerName}</span>
+                        </a>
+                      </div>
+                      <div class="speak__body">`
+          } else {
+            return `<div class="speak">
+                      <div class="speak__speaker">
+                        <img src="/images/users/avatars/default.png" alt="${speakerName}" title="${speakerName}" class="a-user-emoji speak__speaker-avatar">
+                        <span class="speak__speaker-name">${speakerName}</span>
+                      </div>
+                      <div class="speak__body">`
+          }
+        }
       }
+
+      return '</div></div>\n'
     }
   })
 }


### PR DESCRIPTION
## Issue

- #8885 

## 概要
Markdown内の独自記法のspeakブロック機能を追加しました。
引数として`@ユーザー名`、`(名前, 画像URL)`、`名前のみ`の3パターンに対応するようにしています。
それぞれに適したアバターと名前を表示。
`(名前, 画像URL)`の画像はランダムです。

## 変更確認方法

1. `feature/add-arguments-to-speak-block`をローカルに取り込む
2. `foreman start -f Procfile.dev`でサーバーを立ち上げます。
3. `komagata`でログイン
4. http://localhost:3000/articles/new で記事を作成。本文を以下にする
5. プレビュー画面がScreenshotの変更後のようになっていることを確認
6. タグを`注目の記事`にして公開する
7. 公開後画面がScreenshotの変更後のようになっていることを確認



```
:::speak @machida
@ユーザー名ver
:::

:::speak(ゲスト, https://picsum.photos/150)
(名前, 画像URL)ver
:::

:::speak ゲスト
名前のみver
:::

```

## Screenshot

### 変更前

#### プレビュー画面
<img width="1498" height="550" alt="image" src="https://github.com/user-attachments/assets/aa19baeb-f476-4c00-9abc-7be6be705c6c" />

#### 公開後画面
<img width="914" height="1197" alt="image" src="https://github.com/user-attachments/assets/7a0c8b79-1cd6-44c9-93f7-07d147495e05" />


### 変更後
#### プレビュー画面

<img width="1166" height="581" alt="image" src="https://github.com/user-attachments/assets/a28db0c4-2fca-4b31-8d72-e3a0bb895ee4" />


#### 公開後画面
<img width="942" height="1206" alt="image" src="https://github.com/user-attachments/assets/41fa850f-6f84-4092-95a7-130e4ec8bc37" />

