### PR TITLE
BookRinのリンクをフッターに配置

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -62,6 +62,9 @@ footer.footer
             = link_to 'https://discord-bot-fjord.herokuapp.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | DiscordBotF
           li.footer-nav__item
+            = link_to 'https://bookrin.fly.dev/login/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | BookRin
+          li.footer-nav__item
             = link_to 'https://fbc-stack.vercel.app/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | FBC Stack
           li.footer-nav__item


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8936 

## 概要
ログイン後のフッターに、`BookRin`のリンクをおきました。
## 変更確認方法

1. ブランチ`feature/add-bookrin-link-to-footer`をローカルに取り込む
```
git fetch origin feature/add-bookrin-link-to-footer
git checkout feature/add-bookrin-link-to-footer
```
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 任意のアカウントでログイン
4. [トップページなどの任意のページ](http://localhost:3000/)を開き、フッターに`BookRin`のリンクがあるかを確認

## Screenshot

### 変更前
<img width="1256" height="206" alt="スクリーンショット 2025-07-17 10 38 03" src="https://github.com/user-attachments/assets/7b874967-73cd-4a63-963f-f92df913e410" />

### 変更後
<img width="1282" height="192" alt="スクリーンショット 2025-07-17 10 37 18" src="https://github.com/user-attachments/assets/4aea88ed-b41f-42b4-b58a-c21d27bfb86f" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * フッターに「BookRin」への外部リンクを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->