### PR TITLE
LearningStatusUpdaterをNewspaperからActiveSupport::Notificationsに移行

### DIFF
--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -15,7 +15,7 @@ class API::ChecksController < API::BaseController
         user: current_user,
         checkable:
       )
-      Newspaper.publish(:check_create, { check: @check })
+      ActiveSupport::Notifications.instrument('check.create', check: @check)
       head :created
     else
       render json: { message: "この#{checkable.class.model_name.human}は確認済です。" }, status: :unprocessable_entity
@@ -24,7 +24,7 @@ class API::ChecksController < API::BaseController
 
   def destroy
     @check = Check.find(params[:id]).destroy
-    Newspaper.publish(:check_cancel, { check: @check })
+    ActiveSupport::Notifications.instrument('check.cancel', check: @check)
 
     head :no_content
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -46,7 +46,7 @@ class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLen
     update_published_at
     if @product.save
       ActiveSupport::Notifications.instrument('product.create', product: @product)
-      Newspaper.publish(:product_save, { product: @product })
+      ActiveSupport::Notifications.instrument('product.save', product: @product)
       redirect_to Redirection.determin_url(self, @product), notice: notice_message(@product, :create)
     else
       render :new
@@ -61,7 +61,7 @@ class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLen
     update_published_at
     if @product.update(product_params)
       Newspaper.publish(:product_update, { product: @product, current_user: })
-      Newspaper.publish(:product_save, { product: @product })
+      ActiveSupport::Notifications.instrument('product.save', product: @product)
       notice_another_mentor_assigned_as_checker
       redirect_to Redirection.determin_url(self, @product), notice: notice_message(@product, :update)
     else

--- a/app/models/learning_status_updater.rb
+++ b/app/models/learning_status_updater.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LearningStatusUpdater
-  def call(payload)
+  def call(_name, _started, _finished, _id, payload)
     product_or_associated_object = payload[:product] || payload[:check]
     case product_or_associated_object
     when Product

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -21,4 +21,9 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('product.create', ProductNotifierForColleague.new)
   ActiveSupport::Notifications.subscribe('product.create', ProductNotifierForPracticeWatcher.new)
   ActiveSupport::Notifications.subscribe('came.inquiry', InquiryNotifier.new)
+  
+  learning_status_updater = LearningStatusUpdater.new
+  ActiveSupport::Notifications.subscribe('product.save', learning_status_updater)
+  ActiveSupport::Notifications.subscribe('check.create', learning_status_updater)
+  ActiveSupport::Notifications.subscribe('check.cancel', learning_status_updater)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -23,11 +23,6 @@ Rails.configuration.after_initialize do
 
   Newspaper.subscribe(:comeback_update, ComebackNotifier.new)
 
-  learning_status_updater = LearningStatusUpdater.new
-  Newspaper.subscribe(:check_create, learning_status_updater)
-  Newspaper.subscribe(:product_save, learning_status_updater)
-  Newspaper.subscribe(:check_cancel, learning_status_updater)
-
   page_notifier = PageNotifier.new
   Newspaper.subscribe(:page_create, page_notifier)
   Newspaper.subscribe(:page_update, page_notifier)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [3箇所分newspaperの利用を置き換える #8909](https://github.com/fjordllc/bootcamp/issues/8909#event-18568025235)

## 概要
LearningStatusUpdaterクラスをnewspaperからActiveSupport::Notificationsのsubscribeの仕組みに移行しました。
[AnswererWatcherをnewspaperからActiveSupport::Notificationsに移行](https://github.com/fjordllc/bootcamp/pull/8835)のPRを参考にしました。

## 変更確認方法

1. ブランチ`chore/replace-newspaper-with-activesupport-nofitications-for-learning-status-updater`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. 以下のテストが通ることを確認
`bin/rails test test/system/products_test.rb:105`
`bin/rails test test/system/products_test.rb:133`
4. 以下の動作を確認
- 提出物をWIPにした時や提出した際に、プラクティスのステータスが「未着手」から適切なステータスに変更されること
（「着手」や「提出」）

<img width="83" height="54" alt="スクリーンショット 2025-07-16 19 41 19" src="https://github.com/user-attachments/assets/f8eb0c1a-b488-4028-bb89-ae6a66df56de" />

- 提出物が合格した時にプラティスのステータスが「修了」に変更されてること

<img width="93" height="51" alt="スクリーンショット 2025-07-16 19 40 18" src="https://github.com/user-attachments/assets/ec48f56b-e78a-41ad-b553-179e42d46459" />

## Screenshot
UIに変化がなかったためスクリーンショットは省略しています。



<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **新機能**
  * プロダクト作成・更新時やチェック作成・キャンセル時に新しい通知イベントが追加されました。

* **リファクタ**
  * イベント通知の仕組みが標準的な通知システムに置き換えられ、より一貫性が向上しました。

* **その他**
  * イベント購読設定が整理され、通知の管理が最適化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->