### PR TITLE
管理画面のタブにある「お試し延長」のタブの位置を修正

### DIFF
--- a/app/views/admin/_admin_page_tabs.html.slim
+++ b/app/views/admin/_admin_page_tabs.html.slim
@@ -18,6 +18,10 @@
           admin_faq_categories_path,
           class: "page-tabs__item-link #{current_link(/^admin-faq_categories|^admin-faqs/)}"
       li.page-tabs__item
+        = link_to 'お試し延長',
+          admin_campaigns_path,
+          class: "page-tabs__item-link #{current_link(/^admin-campaigns/)}"
+      li.page-tabs__item
         = link_to 'お問い合わせ',
           admin_inquiries_path,
           class: "page-tabs__item-link #{current_link(/^admin-inquiries/)}"
@@ -25,10 +29,6 @@
         = link_to '企業研修',
           admin_corporate_training_inquiries_path,
           class: "page-tabs__item-link #{current_link(/^admin-corporate_training_inquiries/)}"
-      li.page-tabs__item
-        = link_to 'お試し延長',
-          admin_campaigns_path,
-          class: "page-tabs__item-link #{current_link(/^admin-campaigns/)}"
       li.page-tabs__item
         = link_to '給付金対応コース受講申請',
           admin_grant_course_applications_path,


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/8872

## 概要
管理画面のタブにある「お試し延長」のタブの位置を変更しました。

## 変更確認方法

1. `chore/fix-trial-tab-position`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動する
3. 管理者である`komagata`または`machida`でログインする
4. 右上のMeアイコンをクリックし、管理者メニュー欄にある、`管理者ページ`をクリックする
5. 「お試し延長」のタブが、「FAQ」と「お問い合わせ」の間にあるか確認する

## Screenshot

### 変更前
<img width="2686" height="398" alt="image" src="https://github.com/user-attachments/assets/cc395cf3-bbdf-4d3c-a740-8ae690be2116" />

### 変更後
<img width="2716" height="344" alt="image" src="https://github.com/user-attachments/assets/610ce6bc-a13a-48bc-9800-75230b5a1d6f" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 管理画面のタブ順を変更し、「お試し延長」タブが「FAQ」タブの直後、「お問い合わせ」タブの前に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->