### PR TITLE
質問投稿時のタグ入力の部分に説明を追加

### DIFF
--- a/app/views/questions/_form.html.slim
+++ b/app/views/questions/_form.html.slim
@@ -49,6 +49,9 @@
           .col-md-6.col-xs-12
             = f.label :tag_list, 'タグを入力してください', class: 'a-form-label'
             = render partial: 'tags_input', locals: { taggable: @question }
+            .a-form-help
+              p
+                | タグは、質問の内容を示すキーワードです。関連するトピックや技術でタグを付けることで、質問が見つけやすくなります（例: Ruby, CSS, ボーリング）。入力してエンターキーを押すとタグになります。
 
       - if admin_or_mentor_login?
         .form-item.is-only-mentor


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8942

## 概要
質問投稿ページのタグ入力欄部分に説明文を追加しました。

## 変更確認方法

1. `feature/add-description-to-tag-input-field-for-question-registration-page`をローカルに取り込む
2. ローカル環境を立ち上げる
3. 任意のユーザーでログインし、`http://127.0.0.1:3000/questions/new` にアクセスする
4. タグ入力欄(ページ下部)の下部を確認する

## Screenshot

### 変更前
<img width="595" height="164" alt="SCR-20250718-hexp" src="https://github.com/user-attachments/assets/31c93771-d9bc-40fb-97ec-8b2eb194f0ab" />


### 変更後
<img width="585" height="213" alt="SCR-20250718-hegz" src="https://github.com/user-attachments/assets/1082f9f0-e973-40d4-a224-65873e2fed30" />
<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 質問フォームのタグ入力欄の下に、タグの使い方や例、登録方法についてのヘルプテキストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->