### PR TITLE
Fix test environment public_path for webpacker

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -27,8 +27,7 @@ if (sassLoaderConfig) {
     'image-url($path)': function(path) {
       const sass = require('sass')
       const pathValue = path.getValue().replace(/['"]/g, '')
-      // Use relative path to let Rails asset host handle the domain
-      return new sass.types.String(`url("/packs/media/${pathValue}")`)
+      return new sass.types.String(`url("~images/${pathValue}")`)
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **修正**
  * テスト環境のパック公開パスを本番環境と同じ `/packs/` に統一しました。
  * Sassの画像URL解決をWebpackのエイリアスから固定の相対パスに変更し、Railsのアセットホストでの画像配信に対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->