### PR TITLE
スマホ表示時の企業アイコンの位置を左側に修正

### DIFF
--- a/app/javascript/stylesheets/application/blocks/page-content/_page-content-header.sass
+++ b/app/javascript/stylesheets/application/blocks/page-content/_page-content-header.sass
@@ -78,7 +78,7 @@
     +size(3.5rem)
   +media-breakpoint-down(sm)
     +size(2.75rem)
-    +position(absolute, right 0, top 0)
+    +position(absolute, left 0, top 0)
 
 .page-content-header__before-title
   gap: .25rem 1rem


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8773 

## 概要
スマホ表示の場合、合格スタンプと企業アイコンが重なっているため、重ならないよう企業アイコンの位置を左側に修正

## 変更確認方法

1. `bug/mobile-icon-overlap`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動する
3. `sotugyo`でログインする
4. ダッシュボード画面の[自分の提出物]タグをクリック
5. 合格している[Terminalの基礎を覚えるの提出物]をクリック
6. デベロッパーツールでサイズを iPhone 等のスマートフォンにする
7. 企業アイコンがユーザアイコンの左側にあり、合格スタンプと重なっていないことを確認する

## Screenshot

### 変更前
![提出物_修正前](https://github.com/user-attachments/assets/857cff1d-6f92-482c-a0af-f0eb2c972cbf)

### 変更後
![提出物_修正後](https://github.com/user-attachments/assets/486bafcf-943d-426e-b34f-231fb6c5549f)

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 小さい画面サイズで会社ロゴ画像の配置が画面右上から左上に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->