### PR TITLE
ProductUpdateNotifier、CommentNotifierをNewspaperからActiveSupport::Notificationsに移行

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -66,6 +66,7 @@ class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLen
     update_published_at
     if @product.update(product_params)
       Newspaper.publish(:product_update, { product: @product, current_user: })
+      ActiveSupport::Notifications.instrument('product.update', { product: @product, current_user: })
       ActiveSupport::Notifications.instrument('product.save', product: @product)
       notice_another_mentor_assigned_as_checker
       redirect_to Redirection.determin_url(self, @product), notice: notice_message(@product, :update)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -65,7 +65,6 @@ class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLen
     set_wip
     update_published_at
     if @product.update(product_params)
-      Newspaper.publish(:product_update, { product: @product, current_user: })
       ActiveSupport::Notifications.instrument('product.update', { product: @product, current_user: })
       ActiveSupport::Notifications.instrument('product.save', product: @product)
       notice_another_mentor_assigned_as_checker

--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -6,7 +6,7 @@ class Comment::AfterCreateCallback
       create_watch(comment)
       notify_to_watching_user(comment)
     elsif comment.receiver.present? && comment.receiver != comment.sender
-      Newspaper.publish(:came_comment, { comment: })
+      ActiveSupport::Notifications.instrument('came.comment', comment:)
     end
 
     if comment.commentable.instance_of?(Talk)

--- a/app/models/comment_notifier.rb
+++ b/app/models/comment_notifier.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CommentNotifier
-  def call(payload)
+  def call(_name, _started, _finished, _id, payload)
     comment = payload[:comment]
     return if comment.nil?
 

--- a/app/models/product_update_notifier_for_checker.rb
+++ b/app/models/product_update_notifier_for_checker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProductUpdateNotifierForChecker
-  def call(payload)
+  def call(_name, _started, _finished, _id, payload)
     product = payload[:product]
     current_user = payload[:current_user]
     return if product.wip? || product.checker_id.nil? || !current_user.nil? && current_user.admin_or_mentor?

--- a/app/models/product_update_notifier_for_watcher.rb
+++ b/app/models/product_update_notifier_for_watcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProductUpdateNotifierForWatcher
-  def call(payload)
+  def call(_name, _started, _finished, _id, payload)
     product = payload[:product]
     current_user = payload[:current_user]
     return if product.wip? || product.watches.nil? || !current_user.nil? && current_user.admin_or_mentor?

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -27,7 +27,7 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('came.inquiry', InquiryNotifier.new)
   ActiveSupport::Notifications.subscribe('regular_event.update', RegularEventUpdateNotifier.new)
   ActiveSupport::Notifications.subscribe('student_or_trainee.create', TimesChannelCreator.new)
-
+  ActiveSupport::Notifications.subscribe('product.update', ProductUpdateNotifierForWatcher.new)
   ActiveSupport::Notifications.subscribe('product.update', ProductUpdateNotifierForChecker.new)
   ActiveSupport::Notifications.subscribe('came.comment', CommentNotifier.new)
   

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -28,6 +28,7 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('regular_event.update', RegularEventUpdateNotifier.new)
   ActiveSupport::Notifications.subscribe('student_or_trainee.create', TimesChannelCreator.new)
 
+  ActiveSupport::Notifications.subscribe('product.update', ProductUpdateNotifierForChecker.new)
   ActiveSupport::Notifications.subscribe('came.comment', CommentNotifier.new)
   
   learning_status_updater = LearningStatusUpdater.new

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -28,6 +28,8 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('regular_event.update', RegularEventUpdateNotifier.new)
   ActiveSupport::Notifications.subscribe('student_or_trainee.create', TimesChannelCreator.new)
 
+  ActiveSupport::Notifications.subscribe('came.comment', CommentNotifier.new)
+  
   learning_status_updater = LearningStatusUpdater.new
   ActiveSupport::Notifications.subscribe('product.save', learning_status_updater)
   ActiveSupport::Notifications.subscribe('check.create', learning_status_updater)

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -31,6 +31,5 @@ Rails.configuration.after_initialize do
   Newspaper.subscribe(:question_update, question_notifier)
 
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForWatcher.new)
-  Newspaper.subscribe(:product_update, ProductUpdateNotifierForChecker.new)
   Newspaper.subscribe(:came_comment_in_talk, CommentNotifierForAdmin.new)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -30,6 +30,5 @@ Rails.configuration.after_initialize do
   Newspaper.subscribe(:question_create, question_notifier)
   Newspaper.subscribe(:question_update, question_notifier)
 
-  Newspaper.subscribe(:product_update, ProductUpdateNotifierForWatcher.new)
   Newspaper.subscribe(:came_comment_in_talk, CommentNotifierForAdmin.new)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -32,6 +32,5 @@ Rails.configuration.after_initialize do
 
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForWatcher.new)
   Newspaper.subscribe(:product_update, ProductUpdateNotifierForChecker.new)
-  Newspaper.subscribe(:came_comment, CommentNotifier.new)
   Newspaper.subscribe(:came_comment_in_talk, CommentNotifierForAdmin.new)
 end

--- a/test/models/product_update_notifier_for_checker_test.rb
+++ b/test/models/product_update_notifier_for_checker_test.rb
@@ -15,7 +15,7 @@ class ProductUpdateNotifierForCheckerTest < ActiveSupport::TestCase
     product.save!
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-      ProductUpdateNotifierForChecker.new.call({ product:, current_user: product.user })
+      ProductUpdateNotifierForChecker.new.call(nil, nil, nil, nil, { product:, current_user: product.user })
     end
   end
 
@@ -30,7 +30,7 @@ class ProductUpdateNotifierForCheckerTest < ActiveSupport::TestCase
     product.save!
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 0 do
-      ProductUpdateNotifierForChecker.new.call({ product:, current_user: product.user })
+      ProductUpdateNotifierForChecker.new.call(nil, nil, nil, nil, { product:, current_user: product.user })
     end
   end
 
@@ -44,7 +44,7 @@ class ProductUpdateNotifierForCheckerTest < ActiveSupport::TestCase
     product.save!
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 0 do
-      ProductUpdateNotifierForChecker.new.call({ product:, current_user: product.user })
+      ProductUpdateNotifierForChecker.new.call(nil, nil, nil, nil, { product:, current_user: product.user })
     end
   end
 
@@ -58,7 +58,7 @@ class ProductUpdateNotifierForCheckerTest < ActiveSupport::TestCase
     product.save!
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 0 do
-      ProductUpdateNotifierForChecker.new.call({ product:, current_user: users(:mentormentaro) })
+      ProductUpdateNotifierForChecker.new.call(nil, nil, nil, nil, { product:, current_user: users(:mentormentaro) })
     end
   end
 end

--- a/test/models/product_update_notifier_for_watcher_test.rb
+++ b/test/models/product_update_notifier_for_watcher_test.rb
@@ -10,7 +10,7 @@ class ProductUpdateNotifierForWatcherTest < ActiveSupport::TestCase
     product = products(:product6)
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 1 do
-      ProductUpdateNotifierForWatcher.new.call({ product:, current_user: product.user })
+      ProductUpdateNotifierForWatcher.new.call(nil, nil, nil, nil, { product:, current_user: product.user })
     end
   end
 
@@ -19,7 +19,7 @@ class ProductUpdateNotifierForWatcherTest < ActiveSupport::TestCase
     product = products(:product5)
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 0 do
-      ProductUpdateNotifierForWatcher.new.call({ product:, current_user: product.user })
+      ProductUpdateNotifierForWatcher.new.call(nil, nil, nil, nil, { product:, current_user: product.user })
     end
   end
 
@@ -28,7 +28,7 @@ class ProductUpdateNotifierForWatcherTest < ActiveSupport::TestCase
     product = products(:product73)
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 0 do
-      ProductUpdateNotifierForWatcher.new.call({ product:, current_user: product.user })
+      ProductUpdateNotifierForWatcher.new.call(nil, nil, nil, nil, { product:, current_user: product.user })
     end
   end
 
@@ -37,7 +37,7 @@ class ProductUpdateNotifierForWatcherTest < ActiveSupport::TestCase
     product = products(:product6)
 
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, 0 do
-      ProductUpdateNotifierForWatcher.new.call({ product:, current_user: users(:mentormentaro) })
+      ProductUpdateNotifierForWatcher.new.call(nil, nil, nil, nil, { product:, current_user: users(:mentormentaro) })
     end
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [3クラス分newspaperの利用を置き換える #8917](https://github.com/fjordllc/bootcamp/issues/8917)

## 概要
ProductUpdateNotifierForWatcher、ProductUpdateNotifierForChecker、CommentNotifierをNewspaperからActiveSupport::Notificationsのsubscribeの仕組みに移行しました。

[AnswererWatcherをnewspaperからActiveSupport::Notificationsに移行](https://github.com/fjordllc/bootcamp/pull/8835)のPRを参考にしました。

## 変更確認方法

1. ブランチ`chore/replace-newspaper-with-activesupport-nofitications-for-product-and-comment`をローカルに取り込む

3. UIでの確認
- 相談室でAdminがコメントした際、相談者に通知メールが送られることを確認。
<img width="43" height="299" alt="スクリーンショット 2025-07-28 6 09 54" src="https://github.com/user-attachments/assets/958acaa5-8335-4ebb-b3ac-171ba86de3ea" />

- 提出物を更新した際に、担当しているメンターとwatchしている人に通知メールが送られることを確認。
＊メールは http://localhost:3000/letter_opener/ で確認

## Screenshot
UIに変化がなかったためスクリーンショットは省略しています。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 製品更新とコメント受信の通知ルートが新しいイベント仕組みへ移行され、通知配信が統一されました。

* **リファクタ**
  * 通知処理を標準的なイベント基盤に移行して管理を簡素化しました。
  * 通知ハンドラの受け取り引数が変更され、将来の拡張に備えた互換性対応が行われました。

* **テスト**
  * テスト呼び出しを新しいハンドラ仕様に合わせて更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->