### PR TITLE
Q&A回答(コメント)投稿ボタン（saveButton）を disabled = true にする処理の位置を変更

### DIFF
--- a/app/javascript/new-answer.js
+++ b/app/javascript/new-answer.js
@@ -34,6 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
     })
 
     saveButton.addEventListener('click', async () => {
+      saveButton.disabled = true
       savedAnswer = editorTextarea.value
       const answerCreated = await createAnswer(savedAnswer, questionId)
       if (answerCreated) {
@@ -41,13 +42,14 @@ document.addEventListener('DOMContentLoaded', () => {
         answerEditorPreview.innerHTML = markdownInitializer.render(
           editorTextarea.value
         )
-        saveButton.disabled = true
         updateAnswerCount(true)
         setWatchable(questionId, 'Question')
         if (previewTab.classList.contains('is-active')) {
           toggleVisibility(tabElements, 'is-active')
         }
         resizeTextarea(editorTextarea, defaultTextareaSize)
+      } else {
+        saveButton.disabled = false
       }
     })
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8925 

## 概要
- 発生事象
「コメントする」ボタンを複数回クリックすると、同じ内容のコメントが複数回投稿される。
Q&A機能においてこの現象が比較的頻繁に確認されてた。

- 原因
Q&Aのコメント（回答）処理では、コメントが正常に投稿された場合にのみ[コメントする]ボタンを無効化してたため。
投稿完了までの間にボタンが複数回クリック可能な状態になっており、重複投稿が発生していた。

- 修正内容
[コメントする]ボタンクリック後、即座にこのボタンを無効化するように修正。
また、投稿に失敗した場合は、元の仕様と同じにするため、ボタンを再び有効化するようにした。

- 補足
Q&Aのコメント（回答）処理と、日報・提出物等へのコメント処理は別のソースで実装されてる。
日報や提出物のコメント機能については、既に二重クリック防止の対策が実装されているため、今回の修正は Q&Aのコメント（回答）機能のみ対象としている。

## 変更確認方法

1. `bug/comment-multiple-post`をローカルに取り込む
2. `foreman start -f Procfile.dev`でアプリを起動する
3. 任意のユーザでログインする
4. 左側の[Q&A]をクリックする
5. Q&A一覧から任意の質問を選択
6. developer tools を開き、[パフォーマンス]タブを開く
7. 右上の[設定]ボタンをクリックし、CPUを「6倍減速」、ネットワークを「3G」に変更<img width="1150" height="167" alt="image" src="https://github.com/user-attachments/assets/7ad3e025-90bd-4c79-a606-c2a89ea7775a" /> 
8. コメントを入力し、複数回クリックしても1回分しか投稿されないことを確認する


## Screenshot(GIF)

### 変更前
[![Image from Gyazo](https://i.gyazo.com/53ed08a292dc1fd39ae90111dc1b0092.gif)](https://gyazo.com/53ed08a292dc1fd39ae90111dc1b0092)

### 変更後
[![Image from Gyazo](https://i.gyazo.com/1faee214f53f377df47d1bc70d986a67.gif)](https://gyazo.com/1faee214f53f377df47d1bc70d986a67)

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 回答作成時、保存ボタンがクリック直後に無効化されるようになり、複数回の送信を防止します。失敗時のみ再度有効化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->