### PR TITLE
未使用のloading-user-icon-placeholder.vueを削除

### DIFF
--- a/app/javascript/loading-user-icon-placeholder.vue
+++ b/app/javascript/loading-user-icon-placeholder.vue
@@ -1,5 +1,0 @@
-<template lang="pug">
-.a-user-icons__item
-  .a-user-icons__item-link
-    .a-user-icons__item-icon.a-user-icon.a-placeholder
-</template>


### PR DESCRIPTION
## 概要
Vue.jsの利用箇所を調査した結果、`loading-user-icon-placeholder.vue`がどこからも使用されていないことが判明したため削除します。

## 変更内容
- `app/javascript/loading-user-icon-placeholder.vue`を削除

## 調査結果
- `loading-list-item-placeholder.vue` → `loading-list-placeholder.vue`内で使用中
- `loading-list-placeholder.vue` → `components/questions.vue`内で使用中
- `loading-user-icon-placeholder.vue` → **未使用**

## テスト
- [ ] ローカルでアプリケーションが正常に動作することを確認
- [ ] ビルドが成功することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタ**
  * ユーザーアイコンのプレースホルダーコンポーネントを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->