### PR TITLE
PageNotifierのPub/Sub実装をnewspaperからnotificationsに置き換え

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,7 +46,7 @@ class PagesController < ApplicationController
     if @page.save
       url = Redirection.determin_url(self, @page)
       if !@page.wip?
-        Newspaper.publish(:page_create, { page: @page })
+        ActiveSupport::Notifications.instrument('page.create', page: @page)
         url = new_announcement_url(page_id: @page.id) if @page.announcement_of_publication?
       end
 
@@ -65,7 +65,7 @@ class PagesController < ApplicationController
     if @page.update(page_params)
       url = Redirection.determin_url(self, @page)
       if @page.saved_change_to_attribute?(:wip, from: true, to: false) && @page.published_at.nil?
-        Newspaper.publish(:page_update, { page: @page })
+        ActiveSupport::Notifications.instrument('page.update', page: @page)
         url = new_announcement_path(page_id: @page.id) if @page.announcement_of_publication?
       end
 

--- a/app/models/page_notifier.rb
+++ b/app/models/page_notifier.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PageNotifier
-  def call(payload)
+  def call(_name, _started, _finished, _unique_id, payload)
     page = payload[:page]
     send_notification(page)
     notify_to_chat(page)

--- a/config/initializers/active_support_notifications.rb
+++ b/config/initializers/active_support_notifications.rb
@@ -17,4 +17,7 @@ Rails.application.reloader.to_prepare do
   ActiveSupport::Notifications.subscribe('product.create', ProductAuthorWatcher.new)
   ActiveSupport::Notifications.subscribe('product.create', ProductNotifierForColleague.new)
   ActiveSupport::Notifications.subscribe('product.create', ProductNotifierForPracticeWatcher.new)
+  page_notifier = PageNotifier.new
+  ActiveSupport::Notifications.subscribe('page.create', page_notifier)
+  ActiveSupport::Notifications.subscribe('page.update', page_notifier)
 end

--- a/config/initializers/newspaper.rb
+++ b/config/initializers/newspaper.rb
@@ -30,10 +30,6 @@ Rails.configuration.after_initialize do
   Newspaper.subscribe(:product_save, learning_status_updater)
   Newspaper.subscribe(:check_cancel, learning_status_updater)
 
-  page_notifier = PageNotifier.new
-  Newspaper.subscribe(:page_create, page_notifier)
-  Newspaper.subscribe(:page_update, page_notifier)
-
   mentors_watch_for_question_creator = MentorsWatchForQuestionCreator.new
   Newspaper.subscribe(:question_create, mentors_watch_for_question_creator)
   Newspaper.subscribe(:question_update, mentors_watch_for_question_creator)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8922

## 概要
- PageNotifierでDocs作成時の通知機能が実装されています
- 新規にDocsを作成・公開し、管理者とメンターに次の3種類の通知が飛ぶか確認してください。

  - メール
  - サイト内通知
  - Discord通知

### 補足
IssueではAnswerCacheDestroyerとPageNotifierの2つを置換するとなってますが、AnswerCacheDestroyerについては実装の不備が見つかったため別Issueで対応することになりました。



## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

<!-- I want to review in Japanese. -->
