### PR TITLE
日報の個別ページにそのユーザーの未チェックの日報数を表示をstaffからmentorに変更した

### DIFF
--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -6,7 +6,7 @@
     .card-body__description
       .a-long-text.is-md.js-markdown-view(data-taskable-id="#{report.id}" data-taskable-type='Report' data-taskable="#{report.taskable?(current_user).to_s}")
         = report.description
-    - if staff_login?
+    - if mentor_login?
       - count = Cache.user_unchecked_report_count(report.user)
       .card-body-main-actions(class="#{report.user.user_report_count_class(count)} #{mentor_login? ? 'is-only-mentor' : ''}")
         .card-body-main-actions__description


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8994 

## 概要
アドバイザーでログインした際、日報の個別ページにそのユーザーの未チェックの日報数が表示されてしまうのを非表示にし、adminとmentorのみに公開範囲を変更した

## 変更確認方法

1. `bug/hide-user-unchecked-report-count-on-advisor-page`をローカルに取り込む
2. `senpai`でログイン
ID: `senpai`
PASS: `testest`
3. 任意の日報を表示し、本文下に未チェックの日報数の表示がないことを確認

## Screenshot

### 変更前
<img width="880" height="550" alt="image" src="https://github.com/user-attachments/assets/b5a99ee0-f6f4-4826-8286-49eba8d54722" />

### 変更後
<img width="867" height="532" alt="image" src="https://github.com/user-attachments/assets/d33d2a73-ba3e-47dd-800c-de84fe394347" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 未チェックレポート数の表示条件が「スタッフログイン時」から「メンターログイン時」に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->