### PR TITLE
Product.unchecked_no_replied_productsが未チェックかつ他者のコメントがない提出物を参照するように修正

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -61,7 +61,9 @@ class Product < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
     no_comments_products = where(commented_at: nil)
     no_replied_products_ids = (self_last_commented_products + no_comments_products).map(&:id)
-    where(id: no_replied_products_ids).order(published_at: :asc, id: :asc)
+    unchecked_products_ids = unchecked.pluck(:id)
+    unchecked_no_replied_ids = no_replied_products_ids & unchecked_products_ids
+    where(id: unchecked_no_replied_ids).order(published_at: :asc, id: :asc)
   }
   scope :unhibernated_user_products, -> { joins(:user).where(user: { hibernated_at: nil }) }
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -61,9 +61,7 @@ class Product < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
     no_comments_products = where(commented_at: nil)
     no_replied_products_ids = (self_last_commented_products + no_comments_products).map(&:id)
-    unchecked_products_ids = unchecked.pluck(:id)
-    unchecked_no_replied_ids = no_replied_products_ids & unchecked_products_ids
-    where(id: unchecked_no_replied_ids).order(published_at: :asc, id: :asc)
+    unchecked.where(id: no_replied_products_ids).order(published_at: :asc, id: :asc)
   }
   scope :unhibernated_user_products, -> { joins(:user).where(user: { hibernated_at: nil }) }
 

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -3,6 +3,7 @@ product1: # 自分のコメントあり(2つ)
   user: mentormentaro
   body: テストの提出物1です。
   checker_id: nil
+  commented_at: <%= 1.day.ago %>
 
 product2: # チェック済
   practice: practice1

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,8 +1,9 @@
-product1: # 自分のコメントあり(2つ)
+product1: # 自分(メンター)のコメントあり(2つ)
   practice: practice1
   user: mentormentaro
   body: テストの提出物1です。
   checker_id: nil
+  mentor_last_commented_at: <%= 1.day.ago %>
   commented_at: <%= 1.day.ago %>
 
 product2: # チェック済
@@ -14,13 +15,15 @@ product2: # チェック済
   published_at: <%= 1.day.ago %>
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:komagata) %>"
 
-product3: # チェック済, 他者のコメントあり
+product3: # チェック済, 他者(メンター)からのコメントあり
   practice: practice2
   user: sotugyou
   body: 確認済みの提出物
   created_at: <%= 2.day.ago %>
   updated_at: <%= 2.day.ago %>
   published_at: <%= 2.day.ago %>
+  commented_at: <%= 2.day.ago %>
+  mentor_last_commented_at: <%= 2.day.ago %>
 
 product4: # チェック済
   practice: practice2
@@ -63,15 +66,17 @@ product8:
   updated_at: <%= 7.day.ago %>
   published_at: <%= 7.day.ago %>
 
-product9: # チェック済
+product9: # チェック済, 他者(メンター)からのコメントあり
   practice: practice4
   user: mentormentaro
   body: テストの提出物9です。
   created_at: <%= 8.day.ago %>
   updated_at: <%= 8.day.ago %>
   published_at: <%= 8.day.ago %>
+  commented_at: <%= 8.day.ago %>
+  mentor_last_commented_at: <%= 8.day.ago %>
 
-product10: # 他者のコメントあり
+product10: # 他者(メンター)のコメントあり
   practice: practice4
   user: kimura
   body: テストの提出物10です。
@@ -79,14 +84,17 @@ product10: # 他者のコメントあり
   updated_at: <%= 9.day.ago %>
   published_at: <%= 9.day.ago %>
   commented_at: <%= 9.day.ago %>
+  mentor_last_commented_at: <%= 9.day.ago %>
 
-product11:
+product11: # 他者(メンター)のコメントあり
   practice: practice2
   user: hatsuno
   body: テストの提出物11です。
   created_at: <%= 10.day.ago %>
   updated_at: <%= 10.day.ago %>
   published_at: <%= 10.day.ago %>
+  commented_at: <%= 10.day.ago %>
+  mentor_last_commented_at: <%= 10.day.ago %>
 
 product12:
   practice: practice5
@@ -373,6 +381,8 @@ product63:
   published_at: <%= 2.day.ago %>
   wip: false
   checker_id: <%= ActiveRecord::FixtureSet.identify(:machida) %>
+  commented_at: <%= 2.day.ago %>
+  mentor_last_commented_at: <%= 2.day.ago %>
 
 product64:
   practice: practice10
@@ -394,11 +404,13 @@ product66:
   body: publish_atがnilの提出物です。
   published_at: nil
 
-product67:
+product67: # チェック済, 他者(メンター)からのコメントあり
   practice: practice3
   user: kimuramitai
   body: 確認済みの提出物67です。
   checker_id: "<%= ActiveRecord::FixtureSet.identify(:'long-id-mentor') %>"
+  commented_at: <%= 1.day.ago %>
+  mentor_last_commented_at: <%= 1.day.ago %>
 
 product68:
   practice: practice5

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -77,6 +77,7 @@ product10: # 他者のコメントあり
   created_at: <%= 9.day.ago %>
   updated_at: <%= 9.day.ago %>
   published_at: <%= 9.day.ago %>
+  commented_at: <%= 9.day.ago %>
 
 product11:
   practice: practice2

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -59,7 +59,7 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     get api_products_self_assigned_index_path(format: :json),
         headers: { 'Authorization' => "Bearer #{token}" }
 
-    expected = products(:product15, :product63, :product62, :product64).map { |product| product.practice.title }
+    expected = products(:product15, :product62, :product64, :product63).map { |product| product.practice.title }
     actual = response.parsed_body['products'].map { |product| product['practice']['title'] }
     assert_equal expected, actual
   end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -205,7 +205,7 @@ class ProductTest < ActiveSupport::TestCase
 
     only_self_replied_product = products(:product1)
     checked_product = products(:product2)
-    unchecked_replied_product = products(:product3)
+    unchecked_replied_product = products(:product10)
 
     assert_includes unchecked_no_replied_products, only_self_replied_product
     assert_not_includes unchecked_no_replied_products, checked_product

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -203,13 +203,15 @@ class ProductTest < ActiveSupport::TestCase
   test '.unchecked_no_replied_products' do
     unchecked_no_replied_products = Product.unchecked_no_replied_products
 
-    only_self_replied_product = products(:product1)
-    checked_product = products(:product2)
+    unchecked_no_replied_product = products(:product6)
+    unchecked_only_self_replied_product = products(:product1)
     unchecked_replied_product = products(:product10)
+    checked_product = products(:product2)
 
-    assert_includes unchecked_no_replied_products, only_self_replied_product
-    assert_not_includes unchecked_no_replied_products, checked_product
+    assert_includes unchecked_no_replied_products, unchecked_no_replied_product
+    assert_includes unchecked_no_replied_products, unchecked_only_self_replied_product
     assert_not_includes unchecked_no_replied_products, unchecked_replied_product
+    assert_not_includes unchecked_no_replied_products, checked_product
   end
 
   test '.unhibernated_user_products' do

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -200,6 +200,18 @@ class ProductTest < ActiveSupport::TestCase
     assert_not wip_product.updated_after_submission?
   end
 
+  test '.unchecked_no_replied_products' do
+    unchecked_no_replied_products = Product.unchecked_no_replied_products
+
+    only_self_replied_product = products(:product1)
+    checked_product = products(:product2)
+    unchecked_replied_product = products(:product3)
+
+    assert_includes unchecked_no_replied_products, only_self_replied_product
+    assert_not_includes unchecked_no_replied_products, checked_product
+    assert_not_includes unchecked_no_replied_products, unchecked_replied_product
+  end
+
   test '.unhibernated_user_products' do
     hiberanated_user = users(:kyuukai)
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8993

## 概要

`Product.unchecked_no_replied_products`について、本来期待する動作になるよう修正を行いました。

### 何に使用するメソッドであるか
メンター・管理者が、提出物の内、`合格判定を行っていない`かつ`(提出者以外の)コメントがない`物を分かるようにするためのメソッド。

### 期待する動作
上記の通り、提出物の内、`合格判定を行っていない`かつ`(提出者以外の)コメントがない`物を抽出すること。

### 現在の動作
期待する動作の内、`合格判定を行っていない`という条件が満たされていないため、合格判定が行われている(checked)な提出物も抽出されてしまう。

### 今回行った修正
提出物を抽出する際の条件に、`合格判定を行っていない`を加えました。

## 変更確認方法

1. `bug/do-not-include-checked-products`をローカルに取り込む
2. `rails test test/models/product_test.rb`を実行し、テストが通ることを確認する。
3. `foreman start -f Procfile.dev`でサーバーを起動
4. 任意のユーザーで提出物を作成し、その提出物に`提出物を作成したユーザー`でコメントを残す
5. 別の提出物も作成し、管理者等でチェック済みにする
6. ターミナルで`rails c`を入力し、コンソールを起動する
7. `Product.unchecked_no_replied_products`を実行し、4の提出物が含まれていることを確認する
8. `Product.unchecked_no_replied_products`を実行し、5の提出物が含まれていないことを確認する

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 未確認かつ未返信の商品抽出ロジックを調整し、自己返信のみの項目を含め、確認済みや他者返信のある商品を除外するよう改善しました。

* **テスト**
  * 上記挙動を検証する単体テストを追加しました。
  * 統合テストの期待順序を更新しました。

* **テストデータ**
  * テスト用データにメンター関連の時刻情報と表示ヘッダーの調整を追加し、再現性を高めました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->