### PR TITLE
UserCoursePractice.unstarted_practicesメソッドのリファクタリング

### DIFF
--- a/app/models/user_course_practice.rb
+++ b/app/models/user_course_practice.rb
@@ -94,11 +94,7 @@ class UserCoursePractice
   private
 
   def unstarted_practices
-    practices = @user.course.practices
-    @unstarted_practices ||= practices -
-                             practices.joins(:learnings).where(learnings: { user_id: @user.id, status: :started })
-                                      .or(practices.joins(:learnings).where(learnings: { user_id: @user.id, status: :submitted }))
-                                      .or(practices.joins(:learnings).where(learnings: { user_id: @user.id, status: :complete }))
+    @unstarted_practices ||= UserUnstartedPracticesQuery.new(user: @user).call
   end
 
   def category_having_active_practice

--- a/app/queries/user_unstarted_practices_query.rb
+++ b/app/queries/user_unstarted_practices_query.rb
@@ -13,7 +13,7 @@ class UserUnstartedPracticesQuery < Patterns::Query
 
   def query
     relation
-      .joins(categories: :courses_categories)
+      .joins(categories_practices: { category: :courses_categories })
       .where(courses_categories: { course_id: @course_id })
       .where.not(id: learned_practice_ids)
       .select('practices.*')

--- a/app/queries/user_unstarted_practices_query.rb
+++ b/app/queries/user_unstarted_practices_query.rb
@@ -8,13 +8,13 @@ class UserUnstartedPracticesQuery < Patterns::Query
   def initialize(relation = Practice.all, user:)
     super(relation)
     @user = user
-    @course = user.course
+    @course_id = user.course_id
   end
 
   def query
     relation
       .joins(categories: :courses_categories)
-      .where(courses_categories: { course_id: @course.id })
+      .where(courses_categories: { course_id: @course_id })
       .where.not(id: learned_practice_ids)
       .select('practices.*')
       .order('categories_practices.position ASC, courses_categories.position ASC')

--- a/app/queries/user_unstarted_practices_query.rb
+++ b/app/queries/user_unstarted_practices_query.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class UserUnstartedPracticesQuery < Patterns::Query
+  queries Practice
+
+  private
+
+  def initialize(relation = Practice.all, user:)
+    super(relation)
+    @user = user
+    @course = user.course
+  end
+
+  def query
+    relation
+      .joins(categories: :courses_categories)
+      .where(courses_categories: { course_id: @course.id })
+      .where.not(id: learned_practice_ids)
+      .select('practices.*')
+      .order('categories_practices.position ASC, courses_categories.position ASC')
+  end
+
+  def learned_practice_ids
+    statuses = Learning.statuses.values_at(:started, :submitted, :complete)
+    Learning.where(user_id: @user.id, status: statuses).select(:practice_id)
+  end
+end

--- a/test/queries/user_unstarted_practices_query_test.rb
+++ b/test/queries/user_unstarted_practices_query_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserUnstartedPracticesQueryTest < ActiveSupport::TestCase
+  test 'should return unstarted practices for given user' do
+    user = users(:komagata)
+    started_practice = practices(:practice1)
+    completed_practice = practices(:practice2)
+    submitted_practice = practices(:practice4)
+    unstarted_practice = practices(:practice9)
+
+    result = UserUnstartedPracticesQuery.new(user:).call
+
+    assert_not_includes result, started_practice
+    assert_not_includes result, completed_practice
+    assert_not_includes result, submitted_practice
+    assert_includes result, unstarted_practice
+  end
+
+  test 'should exclude practices with started status' do
+    user = users(:komagata)
+    started_practice = practices(:practice1)
+
+    result = UserUnstartedPracticesQuery.new(user:).call
+
+    assert_not_includes result, started_practice
+  end
+
+  test 'should exclude practices with submitted status' do
+    user = users(:komagata)
+    submitted_practice = practices(:practice4)
+
+    result = UserUnstartedPracticesQuery.new(user:).call
+
+    assert_not_includes result, submitted_practice
+  end
+
+  test 'should exclude practices with complete status' do
+    user = users(:komagata)
+    completed_practice = practices(:practice2)
+
+    result = UserUnstartedPracticesQuery.new(user:).call
+
+    assert_not_includes result, completed_practice
+  end
+
+  test 'should return different results for different users' do
+    user1 = users(:komagata)
+    user2 = users(:machida)
+
+    result1 = UserUnstartedPracticesQuery.new(user: user1).call
+    result2 = UserUnstartedPracticesQuery.new(user: user2).call
+
+    assert_not_equal result1.to_a.sort, result2.to_a.sort
+  end
+end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8929 

## 概要
`UserCoursePractice.unstarted_practices`メソッドのrails-patterns gemのQueryオブジェクトの`UserUnstartedPracticesQuery`クラスにリファクタリングしました。
戻り値としてプラクティスの配列を返していましたが、`ActiveRecord::Relation`を返すようにしています。

また変更前は`practices`を下記で取得していましたが、
```ruby
practices = @user.course.practices
```
`practices`のソートを`Course`と`Practice`の中間テーブルのデフォルトスコープに依存していたので、`UserUnstartedPracticesQuery`クラス内で明示的に並び順を指定するようにしました。

<details>
<summary>issueで挙げられていた問題点の改善まとめ</summary>

## **可読性の低さ**: 3つのORクエリーがチェーンされて非常に読みにくい
変更後:  “OR”でつないでいた複数の条件を、配列を使った“IN”句へと書き換えてシンプルにした
## **重複したJOIN**: 同じ`practices.joins(:learnings)`が3回繰り返されている
変更後: `learning`テーブルへのJOINを行ず、条件を満たす`practice_id`を`learning`テーブルから直接取り出すサブクエリにすることでJOINを一箇所にまとめた
## **保守性**: 学習ステータスの追加時に3箇所を修正する必要がある
変更後: ステータスの管理を`learned_practice_ids`メソッド1箇所に切り出し
## **パフォーマンス**: 効率的な1つのクエリーにまとめられる可能性
変更後
- `.where.not(id: learned_practice_ids)`の利用で「未着手」のみを直接抽出
- 変更前はすべてのプラクティスと未着手ステータス以外のプラクティスを配列の差集合で`unstarted_practices`を計算していたため、クエリが二回発生していた。変更後は一回のクエリで済むよう改善


</details><details>
<summary>発行されるSQL</summary>

## **変更前**
```sql
-- 1つ目のクエリ
SELECT "practices".* 
FROM "practices" 
INNER JOIN "categories_practices" 
  ON "practices"."id" = "categories_practices"."practice_id" 
INNER JOIN "categories" 
  ON "categories_practices"."category_id" = "categories"."id" 
INNER JOIN "courses_categories" 
  ON "categories"."id" = "courses_categories"."category_id" 
WHERE "courses_categories"."course_id" = $1 
ORDER BY 
  "categories_practices"."position" ASC, 
  "courses_categories"."position" ASC;

-- パラメータ
-- [["course_id", 829913840]]



-- 2つ目のクエリ
SELECT "practices".* 
FROM "practices" 
INNER JOIN "categories_practices" 
  ON "practices"."id" = "categories_practices"."practice_id" 
INNER JOIN "categories" 
  ON "categories_practices"."category_id" = "categories"."id" 
INNER JOIN "courses_categories" 
  ON "categories"."id" = "courses_categories"."category_id" 
INNER JOIN "learnings" 
  ON "learnings"."practice_id" = "practices"."id" 
WHERE "courses_categories"."course_id" = $1 
  AND "learnings"."user_id" = $2 
  AND (
    "learnings"."status" = $3 
    OR "learnings"."status" = $4 
    OR "learnings"."status" = $5
  )
ORDER BY 
  "categories_practices"."position" ASC, 
  "courses_categories"."position" ASC;

-- パラメータ
-- [["course_id", 829913840], ["user_id", 253826460], ["status", 1], ["status", 2], ["status", 3]]

```

## **変更後**
```sql
SELECT 
  practices.*, 
  courses_categories.position AS category_position, 
  categories_practices.position AS practice_position 
FROM "practices" 
INNER JOIN "categories_practices" 
  ON "categories_practices"."practice_id" = "practices"."id" 
INNER JOIN "categories" 
  ON "categories"."id" = "categories_practices"."category_id" 
INNER JOIN "courses_categories" 
  ON "courses_categories"."category_id" = "categories"."id" 
WHERE "courses_categories"."course_id" = $1 
  AND "practices"."id" NOT IN (
    SELECT "learnings"."practice_id" 
    FROM "learnings" 
    WHERE "learnings"."user_id" = $2 
      AND "learnings"."status" IN ($3, $4, $5)
  ) 
ORDER BY 
  categories_practices.position ASC, 
  courses_categories.position ASC;

-- パラメータ
-- [["course_id", 829913840], ["user_id", 655153192], ["status", 1], ["status", 2], ["status", 3]]

```

</details>

## 変更確認方法
ブランチをローカルに取り込む
```
git fetch origin refactor-unstarted_practices-method 
```

```
git checkout refactor-unstarted_practices-method 
```
ローカルサーバーの立ち上げ
```
rails db:reset
```

```
bin/setup
```

```
foreman start -f Procfile.dev
```

1. `ユーザー`hatsuno`でログイン
	- ユーザー名: `hatsuno`
	-  パスワード: `testtest`
2. プラクティス一覧ページに行き下記を確認する
	1. **着手**ステータスのプラクティスがないことを確認する
	2. **Mac OS X**カテゴリの**OS X Mountain Lionをクリーンインストールする**が未着手になっていることを確認する。なっていなければ未着手にしておく。
	3. どこでも良いのでアプリ内別のページに遷移し、サイドナビゲーションバーのプラクティスをクリックしプラクティスページに戻る。
		- [x] **Mac OS X**カテゴリのスクロール位置でページが表示されることを確認する
	4. **UNIX**カテゴリの**Terminalの基礎を覚える**が未着手になっていることを確認する。なっていなければ未着手にしておく。
	5. **OS X Mountain Lionをクリーンインストールする**のプラクティスページに行き、ステータスを修了にする
	6. どこでも良いのでアプリ内別のページに遷移し、サイドナビゲーションバーのプラクティスをクリックしプラクティスページに戻る。
		- [x] **UNIX**カテゴリにスクロールされた位置でページが表示されることを確認する
※ ステータス変更時はナビゲーションバーのリンクが更新されないので、別ページに遷移してからプラクティスページのリンクをクリックするか、リンクを2回クリックするとスクロール位置が更新されます。

## Screenshot
**Mac OS X**カテゴリの**OS X Mountain Lionをクリーンインストールする**を修了すると、
[![Image from Gyazo](https://i.gyazo.com/0b481aa375a364073df9aa2636f05da8.png)](https://gyazo.com/0b481aa375a364073df9aa2636f05da8)
次回からのプラクティスページ一覧に遷移したときは次の**UNIX**カテゴリに遷移された状態で表示されます。
[![Image from Gyazo](https://i.gyazo.com/71cc53c6fee60f9c78212619eafcfea4.png)](https://gyazo.com/71cc53c6fee60f9c78212619eafcfea4)
<!-- I want to review in Japanese. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * ユーザーごとの未開始プラクティス取得処理を内部で整理・分離し、責務と可読性を向上しました。動作や利用者向けの挙動には影響ありません。
  * 内部で専用のクエリを導入してキャッシュを活用し、将来的な保守性とパフォーマンスを高めました（実装の詳細は非公開）。

* **テスト**
  * 各ユーザーごとに未開始のプラクティスのみが返ることを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->