### PR TITLE
webp関連テストを安定して通るようにした

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -953,28 +953,21 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
   end
 
   def attach_custom_avatar
-    target_key = "avatars/#{login_name}.#{AVATAR_FORMAT}"
+    custom_key = "avatars/#{login_name}.#{AVATAR_FORMAT}"
+    variant_avatar = avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }, format: AVATAR_FORMAT).processed
+    io = StringIO.new(variant_avatar.download)
+
     with_lock do
-      existing = ActiveStorage::Blob.find_by(key: target_key)
-      if existing
-        avatar.attach(existing) unless avatar.blob_id == existing.id
-      else
-        variant_avatar = avatar.variant(
-          resize_to_fill: AVATAR_SIZE,
-          autorot: true,
-          saver: { strip: true, quality: 60 },
-          format: AVATAR_FORMAT
-        ).processed
-        io = StringIO.new(variant_avatar.download)
-        custom_blob = ActiveStorage::Blob.create_and_upload!(
-          io: io,
-          key: target_key,
-          filename: "#{login_name}.#{AVATAR_FORMAT}",
-          content_type: "image/#{AVATAR_FORMAT}",
-          identify: false
-        )
-        avatar.attach(custom_blob)
-      end
+      return if ActiveStorage::Blob.find_by(key: custom_key)
+
+      custom_blob = ActiveStorage::Blob.create_and_upload!(
+        io:,
+        key: custom_key,
+        filename: "#{login_name}.#{AVATAR_FORMAT}",
+        content_type: "image/#{AVATAR_FORMAT}",
+        identify: false
+      )
+      avatar.attach(custom_blob)
     end
   rescue ActiveStorage::FileNotFoundError, ActiveStorage::InvariableError, Vips::Error => e
     log_avatar_error('attach_custom_avatar', e)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -953,20 +953,28 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
   end
 
   def attach_custom_avatar
-    variant_avatar = avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }, format: AVATAR_FORMAT).processed
-    io = StringIO.new(variant_avatar.download)
-
+    target_key = "avatars/#{login_name}.#{AVATAR_FORMAT}"
     with_lock do
-      return if ActiveStorage::Blob.find_by(key: "avatars/#{login_name}.#{AVATAR_FORMAT}")
-
-      custom_blob = ActiveStorage::Blob.create_and_upload!(
-        io:,
-        key: "avatars/#{login_name}.#{AVATAR_FORMAT}",
-        filename: "#{login_name}.#{AVATAR_FORMAT}",
-        content_type: "image/#{AVATAR_FORMAT}",
-        identify: false
-      )
-      avatar.attach(custom_blob)
+      existing = ActiveStorage::Blob.find_by(key: target_key)
+      if existing
+        avatar.attach(existing) unless avatar.blob_id == existing.id
+      else
+        variant_avatar = avatar.variant(
+          resize_to_fill: AVATAR_SIZE,
+          autorot: true,
+          saver: { strip: true, quality: 60 },
+          format: AVATAR_FORMAT
+        ).processed
+        io = StringIO.new(variant_avatar.download)
+        custom_blob = ActiveStorage::Blob.create_and_upload!(
+          io: io,
+          key: target_key,
+          filename: "#{login_name}.#{AVATAR_FORMAT}",
+          content_type: "image/#{AVATAR_FORMAT}",
+          identify: false
+        )
+        avatar.attach(custom_blob)
+      end
     end
   rescue ActiveStorage::FileNotFoundError, ActiveStorage::InvariableError, Vips::Error => e
     log_avatar_error('attach_custom_avatar', e)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -955,14 +955,19 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
   def attach_custom_avatar
     variant_avatar = avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }, format: AVATAR_FORMAT).processed
     io = StringIO.new(variant_avatar.download)
-    custom_blob = ActiveStorage::Blob.create_and_upload!(
-      io:,
-      key: "avatars/#{login_name}.#{AVATAR_FORMAT}",
-      filename: "#{login_name}.#{AVATAR_FORMAT}",
-      content_type: "image/#{AVATAR_FORMAT}",
-      identify: false
-    )
-    avatar.attach(custom_blob)
+
+    with_lock do
+      return if ActiveStorage::Blob.find_by(key: "avatars/#{login_name}.#{AVATAR_FORMAT}")
+
+      custom_blob = ActiveStorage::Blob.create_and_upload!(
+        io:,
+        key: "avatars/#{login_name}.#{AVATAR_FORMAT}",
+        filename: "#{login_name}.#{AVATAR_FORMAT}",
+        content_type: "image/#{AVATAR_FORMAT}",
+        identify: false
+      )
+      avatar.attach(custom_blob)
+    end
   rescue ActiveStorage::FileNotFoundError, ActiveStorage::InvariableError, Vips::Error => e
     log_avatar_error('attach_custom_avatar', e)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -956,19 +956,19 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
     custom_key = "avatars/#{login_name}.#{AVATAR_FORMAT}"
     variant_avatar = avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }, format: AVATAR_FORMAT).processed
     io = StringIO.new(variant_avatar.download)
-
-    with_lock do
-      return if ActiveStorage::Blob.find_by(key: custom_key)
-
-      custom_blob = ActiveStorage::Blob.create_and_upload!(
-        io:,
-        key: custom_key,
-        filename: "#{login_name}.#{AVATAR_FORMAT}",
-        content_type: "image/#{AVATAR_FORMAT}",
-        identify: false
-      )
-      avatar.attach(custom_blob)
+    created = false
+    custom_blob = ActiveStorage::Blob.create_or_find_by!(key: custom_key) do |blob|
+      blob.filename = "#{login_name}.#{AVATAR_FORMAT}"
+      blob.content_type = "image/#{AVATAR_FORMAT}"
+      blob.byte_size = io.size
+      blob.checksum = Digest::MD5.base64digest(io.read)
+      io.rewind
+      created = true
     end
+    return unless created
+
+    custom_blob.upload(io, identify: false)
+    avatar.attach(custom_blob)
   rescue ActiveStorage::FileNotFoundError, ActiveStorage::InvariableError, Vips::Error => e
     log_avatar_error('attach_custom_avatar', e)
   end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,6 +1,6 @@
 test:
   service: Disk
-  root: <%= ENV['ACTIVE_STORAGE_TEST_ROOT'] || Rails.root.join("tmp/storage") %>
+  root: <%= Rails.root.join("tmp/storage") %>
   public: true
 
 local:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -12,6 +12,7 @@ require 'supports/mock_env_helper'
 require 'supports/article_helper'
 require 'supports/javascript_helper'
 require 'supports/product_helper'
+require 'supports/avatar_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include LoginHelper
@@ -25,6 +26,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ArticleHelper
   include JavascriptHelper
   include ProductHelper
+  include AvatarHelper
 
   if ENV['HEADFUL']
     driven_by :selenium, using: :chrome
@@ -53,13 +55,5 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
         # Ignore cleanup errors in tests
       end
     end
-  end
-
-  parallelize_setup do |worker|
-    ENV['ACTIVE_STORAGE_TEST_ROOT'] = "#{ActiveStorage::Blob.service.root}-#{worker}"
-  end
-
-  parallelize_teardown do |_|
-    FileUtils.rm_rf(ENV['ACTIVE_STORAGE_TEST_ROOT'])
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -75,7 +75,9 @@ class UserTest < ActiveSupport::TestCase
     assert_equal '/images/users/avatars/default.png', user_with_default_avatar.avatar_url
 
     user_with_custom_avatar = users(:komagata)
-    user_with_custom_avatar.avatar_url
+    # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
+    # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
+    reset_avatar(user_with_custom_avatar)
     assert_includes user_with_custom_avatar.avatar_url, "#{user_with_custom_avatar.login_name}.webp"
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,9 +2,11 @@
 
 require 'test_helper'
 require 'supports/product_helper'
+require 'supports/avatar_helper'
 
 class UserTest < ActiveSupport::TestCase
   include ProductHelper
+  include AvatarHelper
 
   test '#admin?' do
     assert users(:komagata).admin?
@@ -73,6 +75,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal '/images/users/avatars/default.png', user_with_default_avatar.avatar_url
 
     user_with_custom_avatar = users(:komagata)
+    user_with_custom_avatar.avatar_url
     assert_includes user_with_custom_avatar.avatar_url, "#{user_with_custom_avatar.login_name}.webp"
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -75,8 +75,6 @@ class UserTest < ActiveSupport::TestCase
     assert_equal '/images/users/avatars/default.png', user_with_default_avatar.avatar_url
 
     user_with_custom_avatar = users(:komagata)
-    # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
-    # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
     reset_avatar(user_with_custom_avatar)
     assert_includes user_with_custom_avatar.avatar_url, "#{user_with_custom_avatar.login_name}.webp"
   end

--- a/test/supports/avatar_helper.rb
+++ b/test/supports/avatar_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module AvatarHelper
+  # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
+  # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
   def reset_avatar(user)
     filename = "#{user.login_name}.jpg"
     path = Rails.root.join('test/fixtures/files/users/avatars', filename)

--- a/test/supports/avatar_helper.rb
+++ b/test/supports/avatar_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module AvatarHelper
+  def reset_avatar(user)
+    filename = "#{user.login_name}.jpg"
+    path = Rails.root.join('test/fixtures/files/users/avatars', filename)
+    user.avatar.attach(
+      io: File.open(path, 'rb'),
+      filename:,
+      content_type: 'image/jpeg'
+    )
+  end
+end

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -97,6 +97,10 @@ class Admin::UsersTest < ApplicationSystemTestCase
   test 'update user' do
     user = users(:hatsuno)
 
+    # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
+    # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
+    reset_avatar(user)
+
     visit_with_auth "/users/#{user.id}", 'komagata'
     icon_before = find('img.user-profile__user-icon-image', visible: false)
     assert_includes icon_before.native['src'], 'hatsuno.webp'

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -96,11 +96,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
 
   test 'update user' do
     user = users(:hatsuno)
-
-    # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
-    # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
     reset_avatar(user)
-
     visit_with_auth "/users/#{user.id}", 'komagata'
     icon_before = find('img.user-profile__user-icon-image', visible: false)
     assert_includes icon_before.native['src'], 'hatsuno.webp'

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -6,11 +6,7 @@ require 'application_system_test_case'
 class AttachmentsTest < ApplicationSystemTestCase
   test 'attachment user avatar' do
     user = users(:komagata)
-
-    # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
-    # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
     reset_avatar(user)
-
     visit_with_auth "/users/#{user.id}", 'komagata'
     assert_includes find('img.user-profile__user-icon-image')['src'], 'komagata.webp'
   end

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -5,7 +5,13 @@ require 'application_system_test_case'
 
 class AttachmentsTest < ApplicationSystemTestCase
   test 'attachment user avatar' do
-    visit_with_auth "/users/#{users(:komagata).id}", 'komagata'
+    user = users(:komagata)
+
+    # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
+    # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
+    reset_avatar(user)
+
+    visit_with_auth "/users/#{user.id}", 'komagata'
     assert_includes find('img.user-profile__user-icon-image')['src'], 'komagata.webp'
   end
 

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -186,6 +186,10 @@ class SearchablesTest < ApplicationSystemTestCase
   end
 
   test 'show icon and go profile page when click icon' do
+    # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
+    # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
+    reset_avatar(users(:komagata))
+
     visit_with_auth '/', 'hatsuno'
     find('.js-modal-search-shown-trigger').click
     within('form[name=search]') do

--- a/test/system/searchables_test.rb
+++ b/test/system/searchables_test.rb
@@ -186,10 +186,7 @@ class SearchablesTest < ApplicationSystemTestCase
   end
 
   test 'show icon and go profile page when click icon' do
-    # ユーザーアイコンがwebpに変換されていることを確認するテストは、対象となるavatarをresetする。
-    # （テスト環境では、複数のテストでavatarを共有する影響で、avatarに不具合が生じ画像変換処理が出来ない可能性があるため。）
     reset_avatar(users(:komagata))
-
     visit_with_auth '/', 'hatsuno'
     find('.js-modal-search-shown-trigger').click
     within('form[name=search]') do


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9021 

## 概要

ユーザーアイコンがwebpになっていることを期待するテストがFlakyとなっていましたので、改善をいたしました。

## 改善内容
### ユーザー画像リセットによる安定化

webp関連のテストメソッド内で、ユーザー画像をリセットする処理を導入し、テストを安定させました。
（複数テストで画像変換処理が行われることにより、元データが削除されテストがFlakyとなっていたため）

### key重複による一意制約エラーを回避

`create_and_upload!`メソッドでは、並列処理時にkey重複が起こる場合があり、一意制約エラーが発生してました。
`create_or_find_by!`メソッドに変更し、keyが重複していればcreateしないようにし、一意制約エラーを回避しました。

## 変更確認方法

下記テストが問題ないことを確認する。

- `rails test test/system/admin/users_test.rb ci=1`
  - 「update user」テストが通ることを確認する
- `rails test test/system/searchables_test.rb ci=1`
  - 「show icon and go profile page when click icon」テストが通ることを確認する。
- `rails test test/system/attachments_test.rb ci=1`
  - 「attachment user avatar」テストが通ることを確認する。
- `rails test test/models/user_test.rb ci=1 `
  - 「#avatar_url」テストが通ることを確認する。
- `rails test test/system/notifications_test.rb ci=1`
  - `RuntimeError: Neutered Exception ActionView::Template::Error`でテストが失敗しないことを確認する。
- `rails test test/system/current_user_test.rb ci=1`
  - `ActionView::Template::Error`でテストが失敗しないことを確認する。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * テスト環境でユーザーのアバターをリセットするヘルパーを追加し、複数のシステム／モデルテストで利用するようにしました。
  * 一部の並列テスト用セットアップ／後処理を削除しました。
* **改善**
  * アバター登録処理を重複作成を避ける仕組みに変更し、既存データの再アップロードを抑制しました。
* **設定変更**
  * テスト用ストレージのルートを環境変数に依存しない固定パスに変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->