### PR TITLE
ローカル環境で通らなかったテストnotify comment and checkを通るように修正

### DIFF
--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -4,6 +4,7 @@ module ReportHelper
   def create_report(title, description, wip)
     before_count = Report.count
     visit new_report_path
+    assert_selector 'h2.page-header__title', text: '日報作成'
 
     edit_report(title, description)
 

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -20,7 +20,9 @@ module ReportHelper
       assert_selector 'h1.page-content-header__title', text: title
     end
 
-    current_path.match(%r{^/reports/(\d+)(/edit|)$})[1].to_i
+    report_match_id = current_path.match(%r{^/reports/(\d+)(/edit|)$})
+    assert report_match_id, "Unexpected path after creating report: #{current_path}"
+    report_match_id[1].to_i
   end
 
   def update_report(id, title, description, wip)

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -15,7 +15,7 @@ module ReportHelper
     click_button(wip ? 'WIP' : '提出')
 
     if wip
-      assert_selector 'h2.page-header__title', text: '日報編集', wait: 5
+      assert_selector 'h2.page-header__title', text: '日報編集'
     else
       assert_selector 'h1.page-content-header__title', text: title
     end

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -20,6 +20,7 @@ module ReportHelper
       assert_selector 'h1.page-content-header__title', text: title
     end
 
+    # 作成した日報のpathからidを返す
     report_match_id = current_path.match(%r{^/reports/(\d+)(/edit)?$})
     assert report_match_id, "Unexpected path after creating report: #{current_path}"
     report_match_id[1].to_i

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -2,6 +2,7 @@
 
 module ReportHelper
   def create_report(title, description, wip)
+    before_count = Report.count
     visit new_report_path
 
     edit_report(title, description)
@@ -13,7 +14,7 @@ module ReportHelper
 
     click_button(wip ? 'WIP' : '提出')
 
-    # 作成した日報のidを返す
+    wait_for_report_created(before_count, timeout: 5)
     Report.last.id
   end
 
@@ -34,5 +35,13 @@ module ReportHelper
   def edit_report(title, description)
     fill_in('report[title]', with: title)
     fill_in('report[description]', with: description)
+  end
+
+  def wait_for_report_created(before_count, timeout: 5)
+    (timeout * 10).times do
+      return if Report.count > before_count
+
+      sleep 0.1
+    end
   end
 end

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -14,10 +14,11 @@ module ReportHelper
 
     click_button(wip ? 'WIP' : '提出')
 
-    assert(
-      page.has_selector?('h1.page-content-header__title', text: title, wait: 5) ||
-        page.has_selector?('h2.page-header__title', text: '日報編集')
-    )
+    if wip
+      assert_selector 'h2.page-header__title', text: '日報編集', wait: 5
+    else
+      assert_selector 'h1.page-content-header__title', text: title
+    end
 
     current_path.match(%r{^/reports/(\d+)(/edit|)$})[1].to_i
   end

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -2,7 +2,6 @@
 
 module ReportHelper
   def create_report(title, description, wip)
-    before_count = Report.count
     visit new_report_path
     assert_selector 'h2.page-header__title', text: '日報作成'
 
@@ -15,8 +14,12 @@ module ReportHelper
 
     click_button(wip ? 'WIP' : '提出')
 
-    wait_for_report_created(before_count, timeout: 5)
-    Report.last.id
+    assert(
+      page.has_selector?('h1.page-content-header__title', text: title, wait: 5) ||
+        page.has_selector?('h2.page-header__title', text: '日報編集')
+    )
+
+    current_path.match(%r{^/reports/(\d+)(/edit|)$})[1].to_i
   end
 
   def update_report(id, title, description, wip)
@@ -36,13 +39,5 @@ module ReportHelper
   def edit_report(title, description)
     fill_in('report[title]', with: title)
     fill_in('report[description]', with: description)
-  end
-
-  def wait_for_report_created(before_count, timeout: 5)
-    (timeout * 10).times do
-      return if Report.count > before_count
-
-      sleep 0.1
-    end
   end
 end

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -20,7 +20,7 @@ module ReportHelper
       assert_selector 'h1.page-content-header__title', text: title
     end
 
-    report_match_id = current_path.match(%r{^/reports/(\d+)(/edit|)$})
+    report_match_id = current_path.match(%r{^/reports/(\d+)(/edit)?$})
     assert report_match_id, "Unexpected path after creating report: #{current_path}"
     report_match_id[1].to_i
   end

--- a/test/supports/report_helper.rb
+++ b/test/supports/report_helper.rb
@@ -21,9 +21,9 @@ module ReportHelper
     end
 
     # 作成した日報のpathからidを返す
-    report_match_id = current_path.match(%r{^/reports/(\d+)(/edit)?$})
-    assert report_match_id, "Unexpected path after creating report: #{current_path}"
-    report_match_id[1].to_i
+    path_match = current_path.match(%r{^/reports/(\d+)(/edit)?$})
+    assert path_match, "Unexpected path after creating report: #{current_path}"
+    path_match[1].to_i
   end
 
   def update_report(id, title, description, wip)

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -263,6 +263,7 @@ class NotificationsTest < ApplicationSystemTestCase
       fill_in 'new_comment[description]', with: 'コメントと確認した'
       click_button '確認OKにする'
       assert_text 'コメントと確認した'
+      logout
       visit_with_auth "/reports/#{report}", 'hatsuno'
       assert_text 'コメントと確認した'
       find('.header-links__link.test-show-notifications').click

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -259,7 +259,6 @@ class NotificationsTest < ApplicationSystemTestCase
 
     perform_enqueued_jobs do
       visit_with_auth "/reports/#{report}", 'komagata'
-      visit "/reports/#{report}"
       fill_in 'new_comment[description]', with: 'コメントと確認した'
       click_button '確認OKにする'
       assert_text 'コメントと確認した'

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -261,7 +261,6 @@ class NotificationsTest < ApplicationSystemTestCase
       visit_with_auth "/reports/#{report}", 'komagata'
       fill_in 'new_comment[description]', with: 'コメントと確認した'
       click_button '確認OKにする'
-      assert_text 'コメントと確認した'
       logout
       visit_with_auth '/', 'hatsuno'
       assert_selector 'h2.page-header__title', text: 'ダッシュボード'

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -255,10 +255,12 @@ class NotificationsTest < ApplicationSystemTestCase
 
   test 'notify comment and check' do
     login_user 'hatsuno', 'testtest'
+    assert_selector 'h2.page-header__title', text: 'ダッシュボード'
     report = create_report 'コメントと', '確認があった', false
 
     perform_enqueued_jobs do
       visit_with_auth "/reports/#{report}", 'komagata'
+      assert_selector 'h1.page-content-header__title', text: 'コメントと'
       fill_in 'new_comment[description]', with: 'コメントと確認した'
       click_button '確認OKにする'
       logout

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -256,10 +256,10 @@ class NotificationsTest < ApplicationSystemTestCase
   test 'notify comment and check' do
     login_user 'hatsuno', 'testtest'
     assert_selector 'h2.page-header__title', text: 'ダッシュボード'
-    report = create_report 'コメントと', '確認があった', false
+    report_id = create_report 'コメントと', '確認があった', false
 
     perform_enqueued_jobs do
-      visit_with_auth "/reports/#{report}", 'komagata'
+      visit_with_auth "/reports/#{report_id}", 'komagata'
       assert_selector 'h1.page-content-header__title', text: 'コメントと'
       fill_in 'new_comment[description]', with: 'コメントと確認した'
       click_button '確認OKにする'

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -264,7 +264,7 @@ class NotificationsTest < ApplicationSystemTestCase
       fill_in 'new_comment[description]', with: 'コメントと確認した'
       click_button '確認OKにする'
       logout
-      visit_with_auth '/', 'hatsuno'
+      visit_with_auth root_path, 'hatsuno'
       assert_selector 'h2.page-header__title', text: 'ダッシュボード'
       find('.header-links__link.test-show-notifications').click
       assert_text 'hatsunoさんの日報「コメントと」にkomagataさんがコメントしました。'

--- a/test/system/notifications_test.rb
+++ b/test/system/notifications_test.rb
@@ -263,8 +263,8 @@ class NotificationsTest < ApplicationSystemTestCase
       click_button '確認OKにする'
       assert_text 'コメントと確認した'
       logout
-      visit_with_auth "/reports/#{report}", 'hatsuno'
-      assert_text 'コメントと確認した'
+      visit_with_auth '/', 'hatsuno'
+      assert_selector 'h2.page-header__title', text: 'ダッシュボード'
       find('.header-links__link.test-show-notifications').click
       assert_text 'hatsunoさんの日報「コメントと」にkomagataさんがコメントしました。'
     end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9029

## 概要
issueの通りです。テストが通るように修正しました。
修正のポイントは以下の通りです。
- 新規作成の日報がDBに保存される前に`Report.last.id`を実行すると違う日報のidを返してしまうので、日報の保存を待つ処理を追加
- `visit_with_auth`を使ってログイン状態を切り替える際に、`logout`を利用し明示的にログインセッションを破棄することでログイン状態を切り替える
- `visit`等で画面を移動する際に、`assert_selector`を使って移動先のDOMが構築されるのを待つ
## 変更確認方法

1. `chore/fix-notify_comment_and_check-test`をローカルに取り込み、ブランチを切り替える。
```
git fetch origin chore/fix-notify_comment_and_check-test
```
```
git checkout chore/fix-notify_comment_and_check-test
```
2. テストが通ることを確認する。
```
bin/rails test test/system/notifications_test.rb:256
```

## Screenshot
内部的な修正のため無し。

## Summary by CodeRabbit

- テスト
  - 日報作成フローのE2Eテストを安定化（作成完了を待機するロジックを追加し、「日報作成」見出しの表示を検証）
  - コメント通知テストを改善（ログイン直後のダッシュボード確認、ページ見出しの検証、投稿内容と通知文言の明示的チェック、不要な遷移の削除）
  - 全体としてテストの信頼性と再現性を向上し、フレークを低減

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- テスト
  - レポート作成後にページヘッダーの表示を確認するアサーションを追加。
  - 作成レポートの参照をデータベース参照から画面遷移（URL）ベースに変更し、遷移先の整合性を検証する保護を追加。
  - 通知確認シナリオを見直し、ダッシュボード／詳細ページのヘッダー確認やルート経由の遷移を導入。
  - クロスユーザーでの通知内容確認とE2Eテストの安定性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->