### PR TITLE
JWT認証を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'doorkeeper'
 gem 'good_job', '~> 3.14', github: 'komagata/good_job'
 gem 'google-cloud-storage', '~> 1.25', require: false
 gem 'google-cloud-video-transcoder', '~> 1.5'
+gem 'google-id-token'
 gem 'holiday_jp'
 gem 'icalendar', '~> 2.8'
 gem 'interactor', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,8 @@ GEM
     google-cloud-video-transcoder-v1 (1.2.0)
       gapic-common (>= 0.25.0, < 2.a)
       google-cloud-errors (~> 1.0)
+    google-id-token (1.4.2)
+      jwt (>= 1)
     google-logging-utils (0.2.0)
     google-protobuf (4.30.2)
       bigdecimal
@@ -722,6 +724,7 @@ DEPENDENCIES
   good_job (~> 3.14)!
   google-cloud-storage (~> 1.25)
   google-cloud-video-transcoder (~> 1.5)
+  google-id-token
   holiday_jp
   icalendar (~> 2.8)
   image_processing (~> 1.12)

--- a/app/controllers/api/pub_sub_controller.rb
+++ b/app/controllers/api/pub_sub_controller.rb
@@ -3,6 +3,7 @@
 class API::PubSubController < API::BaseController
   skip_before_action :verify_authenticity_token
   skip_before_action :require_login_for_api
+  before_action :authenticate_pubsub_token
 
   def create
     result = ProcessTranscodingNotification.call(body: request.body.read)
@@ -10,5 +11,24 @@ class API::PubSubController < API::BaseController
     Rails.logger.error("Failed to process transcoding notification: #{result.error}") unless result.success?
 
     head :ok
+  end
+
+  private
+
+  def authenticate_pubsub_token
+    token = request.headers['Authorization']&.delete_prefix('Bearer ')
+    return if token && valid_pubsub_token?(token)
+
+    Rails.logger.warn('Unauthorized Pub/Sub request')
+    head :unauthorized
+  end
+
+  def valid_pubsub_token?(token)
+    validator = GoogleIDToken::Validator.new
+    current_audience = request.original_url
+    validator.check(token, current_audience)
+  rescue GoogleIDToken::ValidationError => e
+    Rails.logger.warn("Invalid JWT: #{e.message}")
+    false
   end
 end

--- a/app/controllers/api/pub_sub_controller.rb
+++ b/app/controllers/api/pub_sub_controller.rb
@@ -25,8 +25,13 @@ class API::PubSubController < API::BaseController
 
   def valid_pubsub_token?(token)
     validator = GoogleIDToken::Validator.new
-    current_audience = request.original_url
-    validator.check(token, current_audience)
+    expected_audience = ENV['PUBSUB_AUDIENCE'].presence
+    payload = validator.check(token, expected_audience)
+
+    expected_sa_email = ENV['PUBSUB_SERVICE_ACCOUNT_EMAIL'].presence
+
+    sa_email_claim = payload['email']
+    sa_email_claim == expected_sa_email
   rescue GoogleIDToken::ValidationError => e
     Rails.logger.warn("Invalid JWT: #{e.message}")
     false


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8595 

## 概要
Pub/Sub Push の JWT 認証 を追加しました。
Push メッセージ送信時にサービスアカウントで署名し、サーバー側で以下を検証します。

1. 署名したサービスアカウントが想定通りか,

2. 正しいエンドポイント向けに発行されたトークンか,

検証に失敗した場合は 401 Unauthorized を返します。

## 変更確認方法
[機能実装時の方法](https://github.com/fjordllc/bootcamp/pull/8659)を参照して正しく動画が投稿されることを確認する。

別途JWT認証用の設定が必要

1. Pushサブスクリプションに認証用サービスアカウントを設定
2. サービスアカウントにPub/Sub Subscriber 権限を付与
3. 環境変数`PUBSUB_SERVICE_ACCOUNT_EMAIL`にサービスアカウントのEMAILを設定
4. 環境変数`PUBSUB_AUDIENCE`にエンドポイントのURLを設定

[参考](https://cloud.google.com/pubsub/docs/authenticate-push-subscriptions?hl=ja)


<!--  I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - Pub/Sub 受信エンドポイントに認証を追加。Bearer トークンを検証し、正当なリクエストのみ受理。認証に失敗した場合は 401 を返却し、警告をログに記録。

- 雑務
  - ID トークン検証用の外部ライブラリを依存関係に追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->