### PR TITLE
夏のキャンペーン表示を追加

### DIFF
--- a/app/javascript/stylesheets/atoms/_a-short-text.sass
+++ b/app/javascript/stylesheets/atoms/_a-short-text.sass
@@ -111,9 +111,10 @@
     &:visited
       color: var(--main)
 
-
   .is-danger
-    color: var(--danger)
+    color: var(--danger) !important
+  .is-warning
+    color: var(--warning) !important
   &.is-ta-center,
   .is-ta-center
     text-align: center

--- a/app/javascript/stylesheets/initializers/_reset.sass
+++ b/app/javascript/stylesheets/initializers/_reset.sass
@@ -70,3 +70,6 @@ textarea
 
 p
   word-wrap: break-word
+
+em
+  font-style: normal

--- a/app/javascript/stylesheets/lp/blocks/lp/_lp-content.sass
+++ b/app/javascript/stylesheets/lp/blocks/lp/_lp-content.sass
@@ -28,8 +28,8 @@
       padding-bottom: 2.5rem
   &.is-campaign
     background-color: var(--main)
-    padding-top: 2.5rem
-    padding-bottom: 5rem
+    padding-top: 1.5rem
+    padding-bottom: 4rem
     color: var(--reversal-text)
   &.is-lp-bg-1
     background-color: var(--lp-bg-1)

--- a/app/views/welcome/_campaign.html.slim
+++ b/app/views/welcome/_campaign.html.slim
@@ -5,7 +5,7 @@ section.lp-content.is-top-title.is-campaign
     svg[data-name="lp-content-divider" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none"]
       path.shape-fill d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
 
-  .l-container.is-xl
+  .l-container.is-lg
     .lp-content__inner.gap-6
       .lp-content__start
         header.lp-content__header
@@ -14,20 +14,26 @@ section.lp-content.is-top-title.is-campaign
 
       .lp-content__end
         .lp-content__description
-          .l-container.is-md
-            .a-short-text
-              h3.font-semibold.text-center
-                | お試し期間が
-                = '倍以上に' if trial_period >= 6
-                | 延長！！
-              p.font-semibold
-                | #{l Campaign.recently_campaign.first, format: :mdw_unique}〜
-                | #{l Campaign.recently_campaign.last, format: :mdw_unique}の期間中にご入会いただくと、
-                | 通常 <em class='em'>3日間</em> のお試し期間が <em class='em is-danger'>
-                = trial_period
-                | 日間</em> となります。
-                = trial_period
-                | 日以内に退会すれば受講料はかかりません。この機会にぜひフィヨルドブートキャンプをガッツリお試しください！！
+          .a-short-text
+            h3.font-semibold.text-center
+              | お試し期間が
+              = '倍以上に' if trial_period >= 6
+              | 延長、
+              | プレゼントもあります！！
+            p.font-semibold
+              | #{l Campaign.recently_campaign.first, format: :mdw_unique}〜
+              | #{l Campaign.recently_campaign.last, format: :mdw_unique}の期間中にご入会いただくと、
+              | 通常 <em class='em'>3日間</em> のお試し期間が <em class='em is-warning'>
+              = trial_period
+              | 日間</em> になります。
+              = trial_period
+              | 日以内に退会すれば受講料はかかりません。
+              | この機会にぜひフィヨルドブートキャンプをガッツリお試しください！！
+            p.font-semibold
+              = link_to 'https://bootcamp.fjord.jp/articles/176',
+              class: 'a-text-link is-warning',
+              target: '_blank', rel: 'noopener' do
+                | キャンペーンについてくわしくはこちら
         .lp-actions.mt-6
           ul.lp-actions__items
             li.lp-actions__item

--- a/app/views/welcome/_welcome_campaign_info.html.slim
+++ b/app/views/welcome/_welcome_campaign_info.html.slim
@@ -1,0 +1,6 @@
+.welcome-top-info
+  .l-container.is-xl
+    p.welcome-top-info__inner
+      = link_to 'https://bootcamp.fjord.jp/articles/176', class: 'welcome-top-info__link', target: '_blank', rel: 'noopener' do
+        | 8/31までお得なキャンペーン開催中！！
+        | 内容はこちらをクリック

--- a/app/views/welcome/certified_reskill_courses/rails_developer_course/index.html.slim
+++ b/app/views/welcome/certified_reskill_courses/rails_developer_course/index.html.slim
@@ -2,6 +2,7 @@
 - set_meta_tags(site: 'FJORD BOOT CAMP（フィヨルドブートキャンプ）',
   description: '最大受講料の80%が給付金で返ってくる、専門実践教育訓練給付制度の対象講座Railsエンジニア（Reスキル認定講座対応）コースの説明です。')
 
+= render 'welcome/welcome_campaign_info'
 .lp-content.is-lp-bg-main.is-hero
   .l-container.is-xl
     .lp-content__inner

--- a/app/views/welcome/certified_reskill_courses/rails_developer_course/index.html.slim
+++ b/app/views/welcome/certified_reskill_courses/rails_developer_course/index.html.slim
@@ -2,7 +2,7 @@
 - set_meta_tags(site: 'FJORD BOOT CAMP（フィヨルドブートキャンプ）',
   description: '最大受講料の80%が給付金で返ってくる、専門実践教育訓練給付制度の対象講座Railsエンジニア（Reスキル認定講座対応）コースの説明です。')
 
-= render 'welcome/welcome_campaign_info'
+= render 'welcome/welcome_campaign_info' if Campaign.today_campaign?
 .lp-content.is-lp-bg-main.is-hero
   .l-container.is-xl
     .lp-content__inner

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -40,7 +40,7 @@
         path.shape-fill d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z"
 
 //= render 'welcome/welcome_top_banners'
-//= render 'welcome/campaign' if Campaign.today_campaign?
+= render 'welcome/campaign' if Campaign.today_campaign?
 = render 'welcome/about'
 = render 'welcome/pricing'
 = render 'welcome/course-select'


### PR DESCRIPTION
@komagata 

夏のキャンペーン表示のためのちょっとしたviewの変更しました。
mainではなく、prodauctionからブランチを生やしてます。
キャンペーンは明日00:00から開始ですが、キャンペーン中にしか表示しない分岐を入れたので、その前にリリースして大丈夫です。

<img width="1213" height="445" alt="image" src="https://github.com/user-attachments/assets/06f7f5d8-378a-4ef7-8edc-fe09b1130f3e" />

<img width="1181" height="355" alt="image" src="https://github.com/user-attachments/assets/52d84f82-7f80-4650-a25b-04fb354dbebf" />
