### PR TITLE
api/pubsubでのみステージングでのBasic認証を解除した

### DIFF
--- a/app/controllers/api/pub_sub_controller.rb
+++ b/app/controllers/api/pub_sub_controller.rb
@@ -3,6 +3,7 @@
 class API::PubSubController < API::BaseController
   skip_before_action :verify_authenticity_token
   skip_before_action :require_login_for_api
+  skip_before_action :basic_auth
   before_action :authenticate_pubsub_token
 
   def create


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8595 

## 概要
api/pubsubに置いてBASIC認証の変わりにJWT認証を実装したので、BASIC認証を解除

## 変更確認方法

1. `fix/skip-basic-auth-pubsub`をローカルに取り込む
2. `application_controller`で設定されている`before_action :basic_auth, if: :staging?`を変更し、開発環境でもbasic認証を適用する
3. curlコマンド等で`api/pubsub`にアクセスし、basic認証が行われることを確認する


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Pub/Sub APIエンドポイントの認証をトークン方式に統一し、Basic認証を不要化しました。トークンによるアクセスはこれまでどおり利用できます。
  - 既存でトークン認証を使用しているクライアントは変更不要です。Basic認証に依存していたクライアントは、発行済みトークンまたは新規トークンへ切り替えてください。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->