### PR TITLE
ステージング環境のデプロイ時にデータベース削除エラーを修正

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -34,6 +34,35 @@ steps:
     volumes:
       - name: db
         path: /cloudsql
+  # 既存の接続を強制的に切断
+  - name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
+    args:
+      - bash
+      - '-c'
+      - |
+        cat <<'EOF' | bin/rails runner -
+        ActiveRecord::Base.connection.execute("
+          SELECT pg_terminate_backend(pid)
+          FROM pg_stat_activity
+          WHERE datname = 'bootcamp_staging'
+            AND pid <> pg_backend_pid()
+        ")
+        EOF
+    id: TerminateConnections
+    waitFor:
+      - Push
+    volumes:
+      - name: db
+        path: /cloudsql
+    env:
+      - RAILS_ENV=production
+      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
+      - DB_NAME=bootcamp_production
+      - DB_PASS=$_DB_PASS
+      - DB_USER=$_DB_USER
+      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
+  # データベースを削除
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     args:
       - sql
@@ -44,7 +73,7 @@ steps:
       - '--quiet'
     id: DeleteDB
     waitFor:
-      - Push
+      - TerminateConnections
     entrypoint: gcloud
     volumes:
       - name: db

--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -44,31 +44,26 @@ steps:
         
         # Cloud SQL Proxyの起動を待つ（最大60秒）
         echo "Waiting for Cloud SQL Proxy to be ready..."
-        SOCKET_PATH="/cloudsql/$_CLOUD_SQL_HOST"
         TIMEOUT=60
         ELAPSED=0
         
         while [ $ELAPSED -lt $TIMEOUT ]; do
-          if [ -S "$SOCKET_PATH" ]; then
-            echo "Cloud SQL Proxy socket found at $SOCKET_PATH"
-            # ソケットが存在してもすぐには使えない場合があるため、実際に接続を試みる
-            if cat <<'TESTEOF' | bin/rails runner - 2>/dev/null
+          echo "Attempting database connection... ($ELAPSED/$TIMEOUT seconds)"
+          if cat <<'TESTEOF' | bin/rails runner - 2>/dev/null
         begin
           ActiveRecord::Base.connection.execute("SELECT 1")
           puts "Database connection successful"
           exit 0
         rescue => e
+          puts "Connection failed: #{e.message}"
           exit 1
         end
         TESTEOF
-            then
-              echo "Database connection verified, proceeding to terminate connections..."
-              break
-            else
-              echo "Socket exists but connection not ready yet, waiting..."
-            fi
+          then
+            echo "Database connection verified, proceeding to terminate connections..."
+            break
           else
-            echo "Waiting for Cloud SQL Proxy socket at $SOCKET_PATH... ($ELAPSED/$TIMEOUT seconds)"
+            echo "Database not ready yet, waiting..."
           fi
           sleep 2
           ELAPSED=$((ELAPSED + 2))
@@ -101,7 +96,7 @@ steps:
       - RAILS_ENV=production
       - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
       - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=bootcamp_production
+      - DB_NAME=postgres
       - DB_PASS=$_DB_PASS
       - DB_USER=$_DB_USER
       - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY

--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -40,13 +40,56 @@ steps:
       - bash
       - '-c'
       - |
+        set -euo pipefail
+        
+        # Cloud SQL Proxyの起動を待つ（最大60秒）
+        echo "Waiting for Cloud SQL Proxy to be ready..."
+        SOCKET_PATH="/cloudsql/$_CLOUD_SQL_HOST"
+        TIMEOUT=60
+        ELAPSED=0
+        
+        while [ $ELAPSED -lt $TIMEOUT ]; do
+          if [ -S "$SOCKET_PATH" ]; then
+            echo "Cloud SQL Proxy socket found at $SOCKET_PATH"
+            # ソケットが存在してもすぐには使えない場合があるため、実際に接続を試みる
+            if cat <<'TESTEOF' | bin/rails runner - 2>/dev/null
+        begin
+          ActiveRecord::Base.connection.execute("SELECT 1")
+          puts "Database connection successful"
+          exit 0
+        rescue => e
+          exit 1
+        end
+        TESTEOF
+            then
+              echo "Database connection verified, proceeding to terminate connections..."
+              break
+            else
+              echo "Socket exists but connection not ready yet, waiting..."
+            fi
+          else
+            echo "Waiting for Cloud SQL Proxy socket at $SOCKET_PATH... ($ELAPSED/$TIMEOUT seconds)"
+          fi
+          sleep 2
+          ELAPSED=$((ELAPSED + 2))
+        done
+        
+        if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "ERROR: Timeout waiting for Cloud SQL Proxy to be ready after $TIMEOUT seconds"
+          exit 1
+        fi
+        
+        # 接続を強制切断
+        echo "Terminating existing connections to bootcamp_staging database..."
         cat <<'EOF' | bin/rails runner -
-        ActiveRecord::Base.connection.execute("
+        result = ActiveRecord::Base.connection.execute("
           SELECT pg_terminate_backend(pid)
           FROM pg_stat_activity
           WHERE datname = 'bootcamp_staging'
             AND pid <> pg_backend_pid()
         ")
+        terminated_count = result.ntuples
+        puts "Terminated #{terminated_count} connection(s) to bootcamp_staging database"
         EOF
     id: TerminateConnections
     waitFor:


### PR DESCRIPTION
## 概要
ステージング環境へのデプロイ時に発生していたデータベース削除エラーを修正しました。

## 問題
Cloud Buildでステージング環境にデプロイする際、以下のエラーが頻発していました：
```
ERROR: (gcloud.sql.databases.delete) HTTPError 400: Invalid request: failed to delete database bootcamp_staging. Detail: pq: database "bootcamp_staging" is being accessed by other users.
```

## 原因
誰かがブラウザからステージング環境にアクセスしている時に、データベースの削除が行われるとアクティブな接続が残っているためエラーになっていました。

## 解決策
データベース削除前に、すべてのアクティブな接続を強制的に切断するステップ（`TerminateConnections`）を追加しました。

### 変更内容
- PostgreSQLの`pg_terminate_backend`を使用して、`bootcamp_staging`データベースへの全接続を強制切断
- その後、安全にデータベースを削除

これにより、誰かがステージング環境にアクセス中でもデプロイが確実に成功するようになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ステージング環境のデータベース再作成フローを更新し、削除前に既存接続を強制切断する手順を追加。
  * データベース削除が切断完了を待つよう順序を調整。
  * 手順内に目的を示す日本語コメントを追記。
  * これによりデプロイ時のステージングDB削除・再作成・移行の一貫性と安定性が向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->