### PR TITLE
ステージング環境デプロイでのCloud Build変数参照を修正

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -47,8 +47,8 @@ steps:
         TIMEOUT=60
         ELAPSED=0
         
-        while [ $ELAPSED -lt $TIMEOUT ]; do
-          echo "Attempting database connection... ($ELAPSED/$TIMEOUT seconds)"
+        while [ $$ELAPSED -lt $$TIMEOUT ]; do
+          echo "Attempting database connection... ($$ELAPSED/$$TIMEOUT seconds)"
           if cat <<'TESTEOF' | bin/rails runner - 2>/dev/null
         begin
           ActiveRecord::Base.connection.execute("SELECT 1")
@@ -66,11 +66,11 @@ steps:
             echo "Database not ready yet, waiting..."
           fi
           sleep 2
-          ELAPSED=$((ELAPSED + 2))
+          ELAPSED=$$(($$ELAPSED + 2))
         done
         
-        if [ $ELAPSED -ge $TIMEOUT ]; then
-          echo "ERROR: Timeout waiting for Cloud SQL Proxy to be ready after $TIMEOUT seconds"
+        if [ $$ELAPSED -ge $$TIMEOUT ]; then
+          echo "ERROR: Timeout waiting for Cloud SQL Proxy to be ready after $$TIMEOUT seconds"
           exit 1
         fi
         


### PR DESCRIPTION
## Summary
- Cloud Build YAMLファイルで変数参照の構文を `$VAR` から `$$VAR` に修正
- Cloud Buildの環境で正しく変数が展開されるように改善

## Test plan
- [ ] ステージング環境へのデプロイが正常に動作することを確認
- [ ] Cloud SQL Proxyの起動待機ロジックが正常に機能することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* バグ修正
  * Cloud Build スクリプトの変数展開を修正し、CI 実行時に経過時間・タイムアウトなどが正しくログ出力され、進捗ループとタイムアウト判定が安定動作。機能面の変更なし。
* 雑務
  * ステージング向けビルド設定の堅牢性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->