### PR TITLE
switchletの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem 'sorcery-jwt'
 gem 'stringio', '3.0.1.2'
 gem 'stripe'
 gem 'stripe-i18n', git: 'https://github.com/komagata/stripe-i18n', branch: 'update-depencency'
+gem 'switchlet'
 gem 'tzinfo', '~> 2.0', '>= 2.0.6'
 gem 'view_component'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    base64 (0.2.0)
+    base64 (0.3.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
@@ -301,7 +301,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.6)
-    loofah (2.24.0)
+    loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -325,7 +325,7 @@ GEM
       benchmark
       logger
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
@@ -340,7 +340,7 @@ GEM
     mutex_m (0.1.1)
     net-http (0.6.0)
       uri
-    net-imap (0.5.6)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -352,12 +352,12 @@ GEM
     netrc (0.11.0)
     newspaper (0.2.0)
     nio4r (2.7.4)
-    nokogiri (1.18.8)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.8-arm64-darwin)
+    nokogiri (1.18.9-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth (1.1.0)
       oauth-tty (~> 1.0, >= 1.0.1)
@@ -415,7 +415,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.14)
+    rack (2.2.17)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-dev-mark (0.8.0)
@@ -447,7 +447,7 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.7.10)
       sprockets-rails (>= 2.0.0)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -473,7 +473,7 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     ransack (3.1.0)
       activerecord (>= 6.0.4)
       activesupport (>= 6.0.4)
@@ -578,8 +578,9 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.2.1)
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
+      logger
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.5.2)
       actionpack (>= 6.1)
@@ -587,8 +588,10 @@ GEM
       sprockets (>= 3.0.0)
     stringio (3.0.1.2)
     stripe (13.5.0)
+    switchlet (0.3.1)
+      rails (>= 6.1)
     temple (0.10.3)
-    thor (1.3.2)
+    thor (1.4.0)
     thread_safe (0.3.6)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -636,7 +639,7 @@ GEM
       event_emitter
       mutex_m
       websocket
-    websocket-driver (0.7.7)
+    websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -744,6 +747,7 @@ DEPENDENCIES
   stringio (= 3.0.1.2)
   stripe
   stripe-i18n!
+  switchlet
   traceroute
   tzinfo (~> 2.0, >= 2.0.6)
   vcr

--- a/app/views/application/header/_header_search.html.slim
+++ b/app/views/application/header/_header_search.html.slim
@@ -6,6 +6,10 @@
           | カテゴリー
         .a-button.is-md.is-secondary.is-select.is-block
           = select_tag 'document_type', options_for_select(Searcher::DOCUMENT_TYPES, params[:document_type]), id: select_id
+      - if Switchlet.enabled?('smart_search')
+        .form-item
+          label.a-form-label
+            | 検索方法
       .form-item
         label.a-form-label
           | 絞り込み条件

--- a/config/initializers/switchlet.rb
+++ b/config/initializers/switchlet.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Switchlet.configure do |config|
+  config.authenticate_with do |controller|
+    User.find_by(id: controller.session[:user_id])&.admin?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount Switchlet::Engine => "/switchlet"
+  
   root to: "home#index"
 
   get "test", to: "home#test", as: "test"

--- a/db/migrate/20250820212112_create_switchlet_flags.rb
+++ b/db/migrate/20250820212112_create_switchlet_flags.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateSwitchletFlags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :switchlet_flags do |t|
+      t.string  :name,        null: false
+      t.boolean :enabled,     null: false, default: false
+      t.text    :description
+      t.timestamps
+    end
+    add_index :switchlet_flags, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_07_18_134145) do
+ActiveRecord::Schema.define(version: 2025_08_20_212112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -866,6 +866,15 @@ ActiveRecord::Schema.define(version: 2025_07_18_134145) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_surveys_on_user_id"
+  end
+
+  create_table "switchlet_flags", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "enabled", default: false, null: false
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_switchlet_flags_on_name", unique: true
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
## Summary
- switchlet gemをローカルではなくリモートから最新版を使うように変更
- switchlet関連のmigrationファイルを一つに統合
- フィーチャーフラグ機能の基盤を整備

## Test plan
- [ ] `bin/setup`でセットアップが正常に動作すること
- [ ] `/switchlet`のルートが正常にアクセスできること
- [ ] migrationが正常に実行されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ヘッダー検索フォームに「検索方法」ラベルを追加（機能フラグで段階的公開）
  - 管理者向けの機能フラグ管理画面を /switchlet に追加（管理画面をマウント）
- チョア
  - ランタイム依存パッケージとして switchlet を追加
  - 機能フラグの初期化処理と管理者判定による認可を追加
- データベース
  - 機能フラグ管理用テーブルと一意制約を追加、スキーマを更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->