### PR TITLE
Product.unchecked_no_replied_productsをQueryObjectへ移行

### DIFF
--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -17,8 +17,7 @@ class API::Products::UncheckedController < API::BaseController
                 when 'unchecked_no_replied'
                   UncheckedNoRepliedProductsQuery.new.call
                                                  .unhibernated_user_products
-                                                 .not_wip
-                                                 .list
+                                                 .not_wip.list
                                                  .ascending_by_date_of_publishing_and_id
                                                  .page(params[:page])
                 end

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -19,6 +19,7 @@ class API::Products::UncheckedController < API::BaseController
                                                  .unhibernated_user_products
                                                  .not_wip
                                                  .list
+                                                 .ascending_by_date_of_publishing_and_id
                                                  .page(params[:page])
                 end
     @products = @products.where(checker_id:) if checker_id.present?

--- a/app/controllers/api/products/unchecked_controller.rb
+++ b/app/controllers/api/products/unchecked_controller.rb
@@ -15,11 +15,11 @@ class API::Products::UncheckedController < API::BaseController
                          .ascending_by_date_of_publishing_and_id
                          .page(params[:page])
                 when 'unchecked_no_replied'
-                  Product.unhibernated_user_products
-                         .unchecked_no_replied_products
-                         .not_wip
-                         .list
-                         .page(params[:page])
+                  UncheckedNoRepliedProductsQuery.new.call
+                                                 .unhibernated_user_products
+                                                 .not_wip
+                                                 .list
+                                                 .page(params[:page])
                 end
     @products = @products.where(checker_id:) if checker_id.present?
     @products_grouped_by_elapsed_days = @products.group_by(&:elapsed_days)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -55,14 +55,6 @@ class Product < ApplicationRecord # rubocop:todo Metrics/ClassLength
   scope :order_for_all_list, -> { order(published_at: :desc, id: :asc) }
   scope :ascending_by_date_of_publishing_and_id, -> { order(published_at: :asc, id: :asc) }
   scope :order_for_self_assigned_list, -> { order('commented_at asc nulls first, published_at asc') }
-  scope :unchecked_no_replied_products, lambda {
-    self_last_commented_products = where.not(commented_at: nil).filter do |product|
-      product.comments.last.user_id == product.user.id
-    end
-    no_comments_products = where(commented_at: nil)
-    no_replied_products_ids = (self_last_commented_products + no_comments_products).map(&:id)
-    unchecked.where(id: no_replied_products_ids).order(published_at: :asc, id: :asc)
-  }
   scope :unhibernated_user_products, -> { joins(:user).where(user: { hibernated_at: nil }) }
 
   def self.add_latest_commented_at

--- a/app/queries/unchecked_no_replied_products_query.rb
+++ b/app/queries/unchecked_no_replied_products_query.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class UncheckedNoRepliedProductsQuery < Patterns::Query
+  queries Product
+
+  private
+
+  def query
+    self_last_commented_products = relation
+                                   .includes(:user, :comments)
+                                   .where.not(commented_at: nil)
+                                   .find_each.filter do |product|
+      product.comments.last.user_id == product.user.id
+    end
+
+    no_comments_products = relation.where(commented_at: nil)
+
+    no_replied_products_ids = (self_last_commented_products + no_comments_products).map(&:id)
+
+    relation
+      .unchecked
+      .where(id: no_replied_products_ids)
+      .order(published_at: :asc, id: :asc)
+  end
+
+  def initialize(relation = Product.all)
+    super(relation)
+  end
+end

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -39,6 +39,16 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'GET /api/products/unchecked.json?target=unchecked_no_replied' do
+    get api_products_unchecked_index_path(target: 'unchecked_no_replied', format: :json)
+    assert_response :unauthorized
+
+    token = create_token('mentormentaro', 'testtest')
+    get api_products_unchecked_index_path(target: 'unchecked_no_replied', format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+  end
+
   test 'GET /api/products/self_assigned.json' do
     get api_products_self_assigned_index_path(format: :json)
     assert_response :unauthorized

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -201,7 +201,7 @@ class ProductTest < ActiveSupport::TestCase
   end
 
   test '.unchecked_no_replied_products' do
-    unchecked_no_replied_products = Product.unchecked_no_replied_products
+    unchecked_no_replied_products = UncheckedNoRepliedProductsQuery.new.call
 
     unchecked_no_replied_product = products(:product6)
     unchecked_only_self_replied_product = products(:product1)

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -200,20 +200,6 @@ class ProductTest < ActiveSupport::TestCase
     assert_not wip_product.updated_after_submission?
   end
 
-  test '.unchecked_no_replied_products' do
-    unchecked_no_replied_products = UncheckedNoRepliedProductsQuery.new.call
-
-    unchecked_no_replied_product = products(:product6)
-    unchecked_only_self_replied_product = products(:product1)
-    unchecked_replied_product = products(:product10)
-    checked_product = products(:product2)
-
-    assert_includes unchecked_no_replied_products, unchecked_no_replied_product
-    assert_includes unchecked_no_replied_products, unchecked_only_self_replied_product
-    assert_not_includes unchecked_no_replied_products, unchecked_replied_product
-    assert_not_includes unchecked_no_replied_products, checked_product
-  end
-
   test '.unhibernated_user_products' do
     hiberanated_user = users(:kyuukai)
 

--- a/test/queries/unchecked_no_replied_products_test.rb
+++ b/test/queries/unchecked_no_replied_products_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UncheckedNoRepliedProductsQueryTest < ActiveSupport::TestCase
+  setup do
+    @query = UncheckedNoRepliedProductsQuery.new
+  end
+
+  test 'should extracted as unchecked and no replied objects' do
+    unchecked_no_replied_products = @query.call
+
+    unchecked_no_replied_product = products(:product6)
+    unchecked_only_self_replied_product = products(:product1)
+
+    assert_includes unchecked_no_replied_products, unchecked_no_replied_product
+    assert_includes unchecked_no_replied_products, unchecked_only_self_replied_product
+  end
+
+  test 'should not extracted as unchecked and no replied objects' do
+    unchecked_no_replied_products = @query.call
+
+    unchecked_replied_product = products(:product10)
+    checked_product = products(:product2)
+
+    assert_not_includes unchecked_no_replied_products, unchecked_replied_product
+    assert_not_includes unchecked_no_replied_products, checked_product
+  end
+end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8927

## 概要

`Product.unchecked_no_replied_products`は、以下の条件を全て満たす提出物の抽出を行うscopeです。

1. 提出物に対してコメントがない、もしくは提出者のコメントに対して返信がない
2. 合格判定がなされていない

上記scopeを[QueryObject](https://github.com/fjordllc/bootcamp/wiki/QueryObject)へ移行し、かつ以下の観点でリファクタリングを行うものです。

1. N+1問題: filter内でproduct.comments.lastを呼び出してN+1問題が発生
2. メモリ効率: 全レコードをRubyメモリに読み込んでからフィルタリング
3. スケーラビリティ: データ量の増加でパフォーマンスが大幅に悪化
4. データベース最適化の機会損失: データベースレベルで処理可能なロジックをRuby側で実行

## 変更確認方法

1. `chore/unchecked-no-replied-products-to-queryobj`をローカルに取り込む
2.  以下のテストが通ることを確認
    * `rails test test/integration/api/products_test.rb`
    * `rails test test/models/product_test.rb`
3. メンターでログイン後、以下のURLにアクセスしデータが取得できることを確認する。
    * http://localhost:3000/api/products/unchecked.json?target=unchecked_no_replied

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - なし
- バグ修正
  - 「未チェック（未返信）」の判定精度を改善。
  - 「未チェック（すべて）」と同様に公開日時＋IDの昇順で並ぶようソートを統一。
- リファクタ
  - 未返信判定ロジックを専用クエリに移行し、旧スコープを整理して保守性を向上。
- テスト
  - 未返信向けの単体・統合テストを追加し、API認可と応答を検証。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->