### PR TITLE
質問の自動クローズテストの挙動を修正

### DIFF
--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -137,7 +137,7 @@ class QuestionTest < ActiveSupport::TestCase
   end
 
   test '.post_warning' do
-    question_create_date = 2.month.ago.floor
+    question_create_date = 2.months.ago.floor
 
     question = Question.create!(
       title: '自動クローズテスト',

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -137,12 +137,14 @@ class QuestionTest < ActiveSupport::TestCase
   end
 
   test '.post_warning' do
+    question_create_date = 2.month.ago.floor
+
     question = Question.create!(
       title: '自動クローズテスト',
       description: 'テスト',
       user: users(:kimura),
-      created_at: 2.months.ago,
-      updated_at: 2.months.ago
+      created_at: question_create_date,
+      updated_at: question_create_date
     )
     travel_to 1.month.ago + 1.day do
       assert_difference -> { question.answers.count }, 1 do


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9105

## 概要

8/30に`QuestionTest#test_.post_warning`を実行すると、`QuestionTest#test_.post_warning`内のテストデータが自動クローズの対象にならないため、対象となるよう修正した。

## 変更確認方法

1. `bug/question-auto-closer-test-work-correct`をローカルに取り込む
2. `rails test test/models/question_test.rb`を実行し、テストが成功することを確認する。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * 日付生成を統一し、テストの再現性を向上。
  * 時刻の丸め差による境界ケースのフレークを低減。
  * ユーザー向け機能への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->