### PR TITLE
「日報を確認」と「提出物を合格にする」ボタンが確認後も表示されている

### DIFF
--- a/app/views/shared/_check_actions.html.slim
+++ b/app/views/shared/_check_actions.html.slim
@@ -22,8 +22,9 @@
                   = checkable.checker.login_name
 
         li.card-main-actions__item class=(checkable.checks.any? ? 'is-sub' : '')
-          - if check
-            = form_with url: polymorphic_path([checkable, check]), method: :delete, local: true do |f|
+          - checked_checkable = checkable.checks.first
+          - if checked_checkable
+            = form_with url: polymorphic_path([checkable, checked_checkable]), method: :delete, local: true do |f|
               - if checkable_type == 'Product'
                 = f.submit "#{checkable_label}の合格を取り消す", class: 'card-main-actions__muted-action'
               - else


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9076 

## 概要
Aメンターが確認した「日報」と「提出物」を、Bメンターが確認しに行くと「日報の確認を取り消す」や「提出物の合格を取り消す」という表示ではなく「日報を確認」と「提出物を合格にする」のボタンのままになっていました。
そのバグを解消しました。

## 変更確認方法

1. `bug/check-button-disappear-after-check`をローカルに取り込む
```
git fetch origin bug/check-button-disappear-after-check
git checkout bug/check-button-disappear-after-check
```
2. `komagata`でログイン
ID: `komagata`
PASS: `testtest`
3. `foreman start -f Procfile.dev1`でローカル環境を立ち上げる。
4. [任意の日報](http://localhost:3000/reports/152035515)にアクセスし、「日報を確認」する
5. [任意の提出物](http://localhost:3000/products/178176131)にアクセスし、「提出物を合格」にする
6. `machida`でログイン
ID: `machida`
PASS: `testtest`
7. [任意の日報](http://localhost:3000/reports/152035515)にアクセスし、「日報を確認を取り消す」になっていることを確認
  ii)「日報を確認を取り消す」をクリック
  i) 取り消した日報のページに戻っていることを確認
8. [任意の提出物](http://localhost:3000/products/178176131)にアクセスし、「提出物の合格を取り消す」になっていることを確認
  i)「提出物の合格を取り消す」をクリック
  ii) 取り消した提出物のページに戻っていることを確認

## Screenshot

### 変更前

#### 日報
<img width="682" height="668" alt="image" src="https://github.com/user-attachments/assets/3102ddbd-3026-439b-accc-510635aa5280" />

#### 提出物
<img width="711" height="678" alt="image" src="https://github.com/user-attachments/assets/a0dc55ca-ad05-4c92-bc5f-6e91a140daf3" />

### 変更後
#### 日報
<img width="749" height="672" alt="image" src="https://github.com/user-attachments/assets/57739835-dbef-4968-aff1-35059b6d2727" />

#### 提出物

<img width="755" height="681" alt="image" src="https://github.com/user-attachments/assets/e3315e5e-c11f-4d4b-8dc8-106b766c2f47" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 不具合修正
  - 確認の有無に応じてボタン表示を適正化。未確認時は「確認する/合格にする」のみ、確認済み時は「確認を取り消す/合格を取り消す」のみ表示。
  - 確認が存在しないのに取り消しUIが表示される不具合を解消し、誤操作やエラーを防止。
- リファクタリング
  - 表示ロジックを整理し、操作時の一貫性と分かりやすさを向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->