### PR TITLE
メール通知テストのFlaky修正

### DIFF
--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class CompanyTest < ActiveSupport::TestCase
   test '#logo_url' do
     company_with_logo = companies(:company1)
+    company_with_logo.logo.variant(resize_to_limit: [88, 88], format: :webp).processed
     assert_includes company_with_logo.logo_url, '1.webp'
 
     company_without_logo = companies(:company5)

--- a/test/system/mail_notification_test.rb
+++ b/test/system/mail_notification_test.rb
@@ -6,21 +6,12 @@ class MailNotificationsTest < ApplicationSystemTestCase
   test "update user's mail_notification" do
     visit "/users/#{users(:kimura).id}/mail_notification/edit?token=#{users(:kimura).unsubscribe_email_token}"
 
-    # Wait for page body to load first before checking title
-    assert_selector '.page-body'
-    assert_selector 'article.unauthorized'
-
-    # Now check the title after ensuring the page is loaded
     assert page.has_title?('メール通知解除の確認')
     assert_text 'メール通知をオフにしますか？'
-
-    # Ensure the actions section is loaded before interacting
-    assert_selector '.unauthorized-actions'
+    assert_selector 'article.unauthorized'
     assert_selector '.unauthorized-actions a', text: 'オフにする'
 
-    within '.unauthorized-actions' do
-      click_link 'オフにする'
-    end
+    click_link 'オフにする'
 
     assert_text 'メール配信を停止しました。'
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- テスト
  - ロゴ画像のバリアントを事前処理する手順を追加し、URL検証の安定性を向上。
  - メール通知のシステムテストの操作フローを簡素化し、不要な待機を削減して実行を安定化。
  - いずれもテストのみの変更で、機能・UI・公開APIの挙動への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->