### PR TITLE
Vimeoビデオ埋め込み用のmarkdown-itプラグインを追加

### DIFF
--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -15,6 +15,7 @@ import MarkDownItContainerSpeak from 'markdown-it-container-speak'
 import MarkdownItPurifier from 'markdown-it-purifier'
 import ReplaceLinkToCard from 'replace-link-to-card'
 import MarkDownItContainerFigure from 'markdown-it-container-figure'
+import MarkdownItVimeo from 'markdown-it-vimeo'
 
 export default class {
   replace(selector) {
@@ -58,6 +59,7 @@ export default class {
     })
     md.use(MarkDownItContainerSpeak)
     md.use(MarkDownItContainerFigure)
+    md.use(MarkdownItVimeo)
     md.use(MarkdownItPurifier)
     return md.render(text)
   }

--- a/app/javascript/markdown-it-vimeo.js
+++ b/app/javascript/markdown-it-vimeo.js
@@ -1,0 +1,14 @@
+import MarkdownItRegexp from 'markdown-it-regexp'
+
+const vimeoRegexp = /\[vimeo:(\d+)\]/
+
+export default MarkdownItRegexp(vimeoRegexp, (match) => {
+  const videoId = match[1]
+
+  // Basic validation - ensure it's a numeric video ID
+  if (!/^\d+$/.test(videoId)) {
+    return match[0] // Return original text if invalid
+  }
+
+  return `<div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/${videoId}?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Vimeo video"></iframe></div>`
+})

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -18,6 +18,7 @@ import TextareaMarkdownLinkify from 'textarea-markdown-linkify'
 import ReplaceLinkToCard from 'replace-link-to-card'
 import MarkDownItContainerFigure from 'markdown-it-container-figure'
 import MarkdownItPurifier from 'markdown-it-purifier'
+import MarkdownItVimeo from 'markdown-it-vimeo'
 
 export default class {
   static initialize(selector) {
@@ -87,6 +88,7 @@ export default class {
           MarkDownItLinkAttributes,
           MarkDownItContainerSpeak,
           MarkDownItContainerFigure,
+          MarkdownItVimeo,
           MarkdownItPurifier
         ],
         markdownOptions: MarkdownOption


### PR DESCRIPTION
## 概要
markdownエディター内でJavaScriptが禁止されたため、Vimeoビデオが表示できなくなった問題を解決しました。
`[vimeo:123456789]` 形式でVimeoビデオを安全に埋め込めるようにしました。

## 変更内容
- `markdown-it-vimeo`プラグインを新規作成
- `[vimeo:ビデオID]` 記法をサポート
- レスポンシブ対応（16:9アスペクト比）のiframe埋め込み
- ビデオIDの数値バリデーション実装
- `markdown-it-purifier`と互換性あり
- JavaScriptなしでも動作

## 実装詳細
- `app/javascript/markdown-it-vimeo.js` - 新規プラグイン
- `app/javascript/markdown-initializer.js` - プラグイン登録

## テスト確認済み
- Playwright MCPでブラウザ動作確認済み
- ESLint・Prettier適用済み
- Vimeoビデオの正常な埋め込みと再生を確認

## 使用例
```markdown
[vimeo:1108372419]
```

## 関連
- JavaScript禁止対応
- セキュリティ対策（XSS防止）
- レスポンシブ対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - MarkdownでVimeo動画の埋め込みに対応。書式：[vimeo:動画ID] を入力すると16:9のレスポンシブプレーヤーで表示されます。
  - 自動再生・フルスクリーン等に対応した安全な埋め込み属性を適用。
  - 不正なIDは元のテキストのまま表示し、既存の表示や操作に影響しません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->