### PR TITLE
iframeの利用を許可した

### DIFF
--- a/app/javascript/config/markdown-it-purifier.js
+++ b/app/javascript/config/markdown-it-purifier.js
@@ -1,0 +1,3 @@
+const ADD_TAGS = ['iframe']
+
+export default ADD_TAGS

--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -16,6 +16,7 @@ import MarkdownItPurifier from 'markdown-it-purifier'
 import ReplaceLinkToCard from 'replace-link-to-card'
 import MarkDownItContainerFigure from 'markdown-it-container-figure'
 import MarkdownItVimeo from 'markdown-it-vimeo'
+import ADD_TAGS from './config/markdown-it-purifier'
 
 export default class {
   replace(selector) {
@@ -60,7 +61,7 @@ export default class {
     md.use(MarkDownItContainerSpeak)
     md.use(MarkDownItContainerFigure)
     md.use(MarkdownItVimeo)
-    md.use(MarkdownItPurifier)
+    md.use(MarkdownItPurifier, { ADD_TAGS: ADD_TAGS })
     return md.render(text)
   }
 }

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -19,6 +19,7 @@ import ReplaceLinkToCard from 'replace-link-to-card'
 import MarkDownItContainerFigure from 'markdown-it-container-figure'
 import MarkdownItPurifier from 'markdown-it-purifier'
 import MarkdownItVimeo from 'markdown-it-vimeo'
+import ADD_TAGS from './config/markdown-it-purifier'
 
 export default class {
   static initialize(selector) {
@@ -89,7 +90,7 @@ export default class {
           MarkDownItContainerSpeak,
           MarkDownItContainerFigure,
           MarkdownItVimeo,
-          MarkdownItPurifier
+          [MarkdownItPurifier, { ADD_TAGS: ADD_TAGS }]
         ],
         markdownOptions: MarkdownOption
       })

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "sweetalert2": "^11.1.5",
     "swr": "^1.3.0",
     "tailwindcss": "^3.1.8",
-    "textarea-markdown": "^1.6.1",
+    "textarea-markdown": "^1.7.0",
     "tributejs": "^5.1.3",
     "use-sync-external-store": "^1.2.0",
     "webpack": "^4.46.0",

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -53,6 +53,21 @@ class MarkdownTest < ApplicationSystemTestCase
     end
   end
 
+  test 'iframe tag is preserved when allowed' do
+    visit_with_auth new_page_path, 'komagata'
+    fill_in 'page[title]', with: 'iframe許可テスト'
+
+    fill_in 'page[body]', with: <<~HTML
+      <iframe src="https://example.com" width="300" height="200" frameborder="0" allowfullscreen></iframe>
+    HTML
+
+    click_button 'Docを公開'
+
+    within '.a-long-text.is-md.js-markdown-view' do
+      assert_selector 'iframe[src="https://example.com"]'
+    end
+  end
+
   test 'speak block test' do
     reset_avatar(users(:mentormentaro))
     visit_with_auth new_page_path, 'komagata'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9248,10 +9248,10 @@ text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-textarea-markdown@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/textarea-markdown/-/textarea-markdown-1.6.1.tgz"
-  integrity sha512-Dgj4vbPcji6WkXQLIHqr1jgSpK52hZbO6KSylnBOfpbEOqxTD3jaQCO7+EK/+7o6IbSm+wXQqcZRnv22E1+Neg==
+textarea-markdown@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/textarea-markdown/-/textarea-markdown-1.7.0.tgz#abc3356e4d28524677224746c0e5516ca2a91751"
+  integrity sha512-IkYyrKUQ40accLbFqIFZbWVUSY6fPTk5/JdEuSWaXZoD3Tvxlstx3uZ/qmcoQmspzzr2T/ZVLaYl/IabQnvErA==
   dependencies:
     file-type "^16.5.4"
     filesize "^10.0.5"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #8450 

## 概要
動画の埋め込みにおいて使われるiframeタグの利用を許可した。

## 変更確認方法

1. `feature/aalow-iframe-tag`をローカルに取り込む
2. 以下の文字列をmarkdownを用いてる箇所で使用し、正常に動画が埋め込まれることを確認する

```
<div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/453249297?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="サンプル動画　野の花"></iframe></div>
```

<!-- I want to review in Japanese. -->
