### PR TITLE
コメントの不要な余白を削除

### DIFF
--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -36,16 +36,16 @@
       .thread-comment__reactions
         = render 'reactions/reactions', reactionable: comment
       hr.a-border-tint
-      - if comment.user.id == user.id || user.admin? || user.mentor?
+      - if comment.user == user || user.admin? || user.mentor?
         footer.card-footer
           .card-main-actions
             ul.card-main-actions__items
-              - if comment.user.id == user.id || user.admin?
+              - if comment.user == user || user.admin?
                 li.card-main-actions__item
                   button.card-main-actions__action.a-button.is-sm.is-secondary.is-block
                     i.fa-solid.fa-pen
                     | 編集
-              - if comment.user.id == user.id || user.mentor?
+              - if comment.user == user || user.mentor?
                 li.card-main-actions__item.is-sub
                   button.card-main-actions__muted-action
                     | 削除する

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -36,16 +36,16 @@
       .thread-comment__reactions
         = render 'reactions/reactions', reactionable: comment
       hr.a-border-tint
-      - if comment.user == user || user.admin? || user.mentor?
+      - if user == comment.user || user.admin? || user.mentor?
         footer.card-footer
           .card-main-actions
             ul.card-main-actions__items
-              - if comment.user == user || user.admin?
+              - if user == comment.user || user.admin?
                 li.card-main-actions__item
                   button.card-main-actions__action.a-button.is-sm.is-secondary.is-block
                     i.fa-solid.fa-pen
                     | 編集
-              - if comment.user == user || user.mentor?
+              - if user == comment.user || user.mentor?
                 li.card-main-actions__item.is-sub
                   button.card-main-actions__muted-action
                     | 削除する

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -36,6 +36,7 @@
       .thread-comment__reactions
         = render 'reactions/reactions', reactionable: comment
       hr.a-border-tint
+    - if comment.user.id == user.id || user.admin? || user.mentor?
       footer.card-footer
         .card-main-actions
           ul.card-main-actions__items

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -36,19 +36,19 @@
       .thread-comment__reactions
         = render 'reactions/reactions', reactionable: comment
       hr.a-border-tint
-    - if comment.user.id == user.id || user.admin? || user.mentor?
-      footer.card-footer
-        .card-main-actions
-          ul.card-main-actions__items
-            - if comment.user.id == user.id || user.admin?
-              li.card-main-actions__item
-                button.card-main-actions__action.a-button.is-sm.is-secondary.is-block
-                  i.fa-solid.fa-pen
-                  | 編集
-            - if comment.user.id == user.id || user.mentor?
-              li.card-main-actions__item.is-sub
-                button.card-main-actions__muted-action
-                  | 削除する
+      - if comment.user.id == user.id || user.admin? || user.mentor?
+        footer.card-footer
+          .card-main-actions
+            ul.card-main-actions__items
+              - if comment.user.id == user.id || user.admin?
+                li.card-main-actions__item
+                  button.card-main-actions__action.a-button.is-sm.is-secondary.is-block
+                    i.fa-solid.fa-pen
+                    | 編集
+              - if comment.user.id == user.id || user.mentor?
+                li.card-main-actions__item.is-sub
+                  button.card-main-actions__muted-action
+                    | 削除する
     .a-card.is-comment.comment-editor.js-comment-editor.is-hidden
       .thread-comment-form__form
         .a-form-tabs.js-tabs

--- a/app/views/questions/_answer.html.slim
+++ b/app/views/questions/_answer.html.slim
@@ -35,6 +35,7 @@
       .thread-comment__reactions
         = render 'reactions/reactions', reactionable: answer
       hr.a-border-tint
+    - if answer.user.id == user.id || user.admin? || user.mentor? || user.id == question.user.id
       footer.card-footer
         .card-main-actions
           ul.card-main-actions__items

--- a/app/views/questions/_answer.html.slim
+++ b/app/views/questions/_answer.html.slim
@@ -35,16 +35,16 @@
       .thread-comment__reactions
         = render 'reactions/reactions', reactionable: answer
       hr.a-border-tint
-        - if answer.user.id == user.id || user.admin? || user.mentor? || user.id == question.user.id
+        - if user == (answer.user || question.user) || user.admin? || user.mentor?
           footer.card-footer
             .card-main-actions
               ul.card-main-actions__items
-                - if answer.user.id == user.id || user.admin?
+                - if user == answer.user || user.admin?
                   li.card-main-actions__item
                     button.card-main-actions__action.a-button.is-sm.is-secondary.is-block.edit-button
                       i.fa-solid.fa-pen
                       | 内容修正
-                - if user.mentor? || user.id == question.user.id
+                - if user == question.user || user.mentor?
                   - make_button_hidden = (question.correct_answer && answer.type != 'CorrectAnswer') || (answer.type == 'CorrectAnswer')
                   - cancel_button_hidden = (question.correct_answer && answer.type != 'CorrectAnswer') || !question.correct_answer
                   li.card-main-actions__item.make-best-answer-button class=(make_button_hidden ? 'is-hidden' : '')
@@ -53,7 +53,7 @@
                   li.card-main-actions__item.cancel-best-answer-button class=(cancel_button_hidden ? 'is-hidden' : '')
                     button.card-main-actions__action.a-button.is-sm.is-muted.is-block.cancel-best-answer
                       | ベストアンサーを取り消す
-                - if answer.user.id == user.id || user.mentor?
+                - if user == answer.user || user.mentor?
                   li.card-main-actions__item.is-sub
                     button.card-main-actions__muted-action.delete-button
                       | 削除する

--- a/app/views/questions/_answer.html.slim
+++ b/app/views/questions/_answer.html.slim
@@ -35,28 +35,28 @@
       .thread-comment__reactions
         = render 'reactions/reactions', reactionable: answer
       hr.a-border-tint
-    - if answer.user.id == user.id || user.admin? || user.mentor? || user.id == question.user.id
-      footer.card-footer
-        .card-main-actions
-          ul.card-main-actions__items
-            - if answer.user.id == user.id || user.admin?
-              li.card-main-actions__item
-                button.card-main-actions__action.a-button.is-sm.is-secondary.is-block.edit-button
-                  i.fa-solid.fa-pen
-                  | 内容修正
-            - if user.mentor? || user.id == question.user.id
-              - make_button_hidden = (question.correct_answer && answer.type != 'CorrectAnswer') || (answer.type == 'CorrectAnswer')
-              - cancel_button_hidden = (question.correct_answer && answer.type != 'CorrectAnswer') || !question.correct_answer
-              li.card-main-actions__item.make-best-answer-button class=(make_button_hidden ? 'is-hidden' : '')
-                button.card-main-actions__action.a-button.is-sm.is-warning.is-block.make-best-answer
-                  | ベストアンサーにする
-              li.card-main-actions__item.cancel-best-answer-button class=(cancel_button_hidden ? 'is-hidden' : '')
-                button.card-main-actions__action.a-button.is-sm.is-muted.is-block.cancel-best-answer
-                  | ベストアンサーを取り消す
-            - if answer.user.id == user.id || user.mentor?
-              li.card-main-actions__item.is-sub
-                button.card-main-actions__muted-action.delete-button
-                  | 削除する
+        - if answer.user.id == user.id || user.admin? || user.mentor? || user.id == question.user.id
+          footer.card-footer
+            .card-main-actions
+              ul.card-main-actions__items
+                - if answer.user.id == user.id || user.admin?
+                  li.card-main-actions__item
+                    button.card-main-actions__action.a-button.is-sm.is-secondary.is-block.edit-button
+                      i.fa-solid.fa-pen
+                      | 内容修正
+                - if user.mentor? || user.id == question.user.id
+                  - make_button_hidden = (question.correct_answer && answer.type != 'CorrectAnswer') || (answer.type == 'CorrectAnswer')
+                  - cancel_button_hidden = (question.correct_answer && answer.type != 'CorrectAnswer') || !question.correct_answer
+                  li.card-main-actions__item.make-best-answer-button class=(make_button_hidden ? 'is-hidden' : '')
+                    button.card-main-actions__action.a-button.is-sm.is-warning.is-block.make-best-answer
+                      | ベストアンサーにする
+                  li.card-main-actions__item.cancel-best-answer-button class=(cancel_button_hidden ? 'is-hidden' : '')
+                    button.card-main-actions__action.a-button.is-sm.is-muted.is-block.cancel-best-answer
+                      | ベストアンサーを取り消す
+                - if answer.user.id == user.id || user.mentor?
+                  li.card-main-actions__item.is-sub
+                    button.card-main-actions__muted-action.delete-button
+                      | 削除する
     .a-card.is-answer.answer-editor.is-hidden
       .thread-comment-form__form
         .a-form-tabs.js-tabs


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

-[9107](https://github.com/fjordllc/bootcamp/issues/9107)

## 概要
コメントとQ&Aのアンサーに対してアクション出来ないユーザーには不要な余白を表示しないように変更

## 変更確認方法

1. {bug/comment-extra-space}をローカルに取り込む
2. コメントの投稿主でも、メンター(もしくはアドミン)でもないユーザーでログイン。(例：muryou)
3. `/reports/130279127`へアクセス
4. コメントに不要な余白がないことを確認
5. `/questions/700755356`へアクセス
6. 回答に不要な余白がないことを確認

## Screenshot

### 変更前
1. コメントの表示
<img width="919" height="329" alt="image" src="https://github.com/user-attachments/assets/26b0856a-3e7e-47b6-a12a-b4bd9d689744" />

2.  回答の表示
<img width="816" height="309" alt="image" src="https://github.com/user-attachments/assets/312047f0-cb8e-4ea7-9f28-d891cfcf9dbf" />



### 変更後
1. コメントの表示
<img width="918" height="269" alt="image" src="https://github.com/user-attachments/assets/bcec6cde-76e3-46d6-8106-dd1beff738ee" />

3. 回答の表示
<img width="806" height="262" alt="image" src="https://github.com/user-attachments/assets/1dfa1cea-505c-4094-9ea9-ba57e9afb55b" />


<!-- I want to review in Japanese. -->
