### PR TITLE
Product.self_assigned_no_replied_product_idsメソッドををQueryオブジェクトにリファクタリング

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -65,41 +65,8 @@ class Product < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
-  def self.self_assigned_no_replied_product_ids(user_id)
-    sql = <<~SQL
-      WITH last_comments AS (
-        SELECT *
-        FROM comments AS parent
-        WHERE commentable_type = 'Product' AND id = (
-          SELECT id
-          FROM comments AS child
-          WHERE parent.commentable_id = child.commentable_id
-            AND commentable_type = 'Product'
-          ORDER BY created_at DESC LIMIT 1
-        )
-      ),
-      self_assigned_products AS (
-        SELECT products.*
-        FROM products
-        WHERE checker_id = ?
-        AND wip = false
-      )
-      SELECT self_assigned_products.id
-      FROM self_assigned_products
-      LEFT JOIN last_comments ON self_assigned_products.id = last_comments.commentable_id
-      WHERE last_comments.id IS NULL
-      OR self_assigned_products.checker_id != last_comments.user_id
-      ORDER BY self_assigned_products.created_at DESC
-    SQL
-    Product.find_by_sql([sql, user_id]).map(&:id)
-  end
-  # rubocop:enable Metrics/MethodLength
-
   def self.self_assigned_no_replied_products(user_id)
-    no_replied_product_ids = self_assigned_no_replied_product_ids(user_id)
-    Product.where(id: no_replied_product_ids)
-           .order(published_at: :asc, id: :asc)
+    ProductSelfAssignedNoRepliedQuery.new(user_id:).call
   end
 
   def self.require_assignment_products

--- a/app/queries/product_self_assigned_no_replied_query.rb
+++ b/app/queries/product_self_assigned_no_replied_query.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class ProductSelfAssignedNoRepliedQuery < Patterns::Query
+  queries Product
+
+  private
+
+  def initialize(relation = Product.all, user_id:)
+    super(relation)
+    @user_id = user_id
+  end
+
+  def query
+    no_replied_product_ids = self_assigned_no_replied_product_ids
+    relation
+      .where(id: no_replied_product_ids)
+      .order(published_at: :asc, id: :asc)
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def self_assigned_no_replied_product_ids
+    sql = <<~SQL
+      WITH last_comments AS (
+        SELECT *
+        FROM comments AS parent
+        WHERE commentable_type = 'Product' AND id = (
+          SELECT id
+          FROM comments AS child
+          WHERE parent.commentable_id = child.commentable_id
+            AND commentable_type = 'Product'
+          ORDER BY created_at DESC LIMIT 1
+        )
+      ),
+      self_assigned_products AS (
+        SELECT products.*
+        FROM products
+        WHERE checker_id = ?
+        AND wip = false
+      )
+      SELECT self_assigned_products.id
+      FROM self_assigned_products
+      LEFT JOIN last_comments ON self_assigned_products.id = last_comments.commentable_id
+      WHERE last_comments.id IS NULL
+      OR self_assigned_products.checker_id != last_comments.user_id
+      ORDER BY self_assigned_products.created_at DESC
+    SQL
+    Product.find_by_sql([sql, @user_id]).map(&:id)
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/test/queries/product_self_assigned_no_replied_query_test.rb
+++ b/test/queries/product_self_assigned_no_replied_query_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProductSelfAssignedNoRepliedQueryTest < ActiveSupport::TestCase
+  test 'should return product self assigned no replied' do
+    mentor = users(:mentormentaro)
+    no_replied_product = Product.create!(
+      body: 'test',
+      user: users(:kimura),
+      practice: practices(:practice5),
+      checker_id: mentor.id,
+      published_at: Time.current.to_formatted_s(:db)
+    )
+
+    result = ProductSelfAssignedNoRepliedQuery.new(user_id: mentor.id).call
+
+    assert_includes result, no_replied_product
+  end
+
+  test 'should not include products where user has already replied' do
+    mentor = users(:mentormentaro)
+
+    product = Product.create!(
+      body: 'already replied',
+      user: users(:kimura),
+      practice: practices(:practice5),
+      checker_id: mentor.id,
+      published_at: Time.current
+    )
+
+    Comment.create!(
+      commentable: product,
+      user: mentor,
+      description: '返信コメント'
+    )
+
+    result = ProductSelfAssignedNoRepliedQuery.new(user_id: mentor.id).call
+
+    assert_not_includes result, product
+  end
+
+  test 'should be ordered by published_at asc' do
+    mentor = users(:mentormentaro)
+
+    result = ProductSelfAssignedNoRepliedQuery.new(user_id: mentor.id).call
+
+    assert_equal result, result.sort_by(&:published_at)
+  end
+end


### PR DESCRIPTION
Product.self_assigned_no_replied_product_idsメソッドをリファクタリング

<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/8926

## 概要

## 変更確認方法

1. {chore/refactor-product-self-assigned-no-replied-to-query}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

<!-- I want to review in Japanese. -->
