### PR TITLE
メール通知をオフのテストを通りやすく修正

### DIFF
--- a/test/system/mail_notification_test.rb
+++ b/test/system/mail_notification_test.rb
@@ -6,9 +6,10 @@ class MailNotificationsTest < ApplicationSystemTestCase
   test "update user's mail_notification" do
     visit "/users/#{users(:kimura).id}/mail_notification/edit?token=#{users(:kimura).unsubscribe_email_token}"
 
+    refute_text 'ユーザーIDもしくはTOKENが違います。'
+    assert_selector 'article.unauthorized'
     assert_text 'メール通知をオフにしますか？'
     assert_title 'メール通知解除の確認'
-    assert_selector 'article.unauthorized'
     assert_selector '.unauthorized-actions a', text: 'オフにする'
 
     click_link 'オフにする'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * メール通知更新フローのテストで、未認可メッセージの不在確認と未認可表示の存在確認を冒頭に移動して検証を早期化。
  * ページ内での重複した未認可表示検証を整理し、テストの明確性と安定性を向上。
  * 未認可時の表示挙動に対する回帰検知を強化し、ユーザー向けの機能挙動自体は変更なし。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->