### PR TITLE
/admin/usersですべてのユーザーが表示されるように変更

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,7 +7,7 @@ class Admin::UsersController < AdminController
   def index
     @direction = params[:direction] || 'desc'
     @target = params[:target]
-    user_scope = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
+    user_scope = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
     user_scope = if @target == 'retired'
                    user_scope.where.not(retired_on: nil)
                  else

--- a/app/views/admin/faqs/_form.html.slim
+++ b/app/views/admin/faqs/_form.html.slim
@@ -1,7 +1,7 @@
 = form_with model: [:admin, faq], local: true, html: { name: 'faq' } do |f|
+  = render 'errors', object: faq
   .form__items
     .form-item
-      = render 'errors', object: faq
       label.a-form-label
         | カテゴリー
       .checkboxes

--- a/app/views/admin/faqs/_form.html.slim
+++ b/app/views/admin/faqs/_form.html.slim
@@ -1,6 +1,16 @@
 = form_with model: [:admin, faq], local: true, html: { name: 'faq' } do |f|
   .form__items
     .form-item
+      = render 'errors', object: faq
+      label.a-form-label
+        | カテゴリー
+      .checkboxes
+        .checkboxes__items
+          - @faq_categories.each do |faq_category|
+            .checkboxes__item.is-radio
+              = f.radio_button :faq_category_id, faq_category.id, class: 'a-toggle-checkbox'
+              = f.label :faq_category_id, faq_category.name, value: faq_category.id
+    .form-item
       = f.label :question, class: 'a-form-label'
       = f.text_area :question, class: 'a-text-input is-xs'
     .form-item
@@ -14,16 +24,6 @@
           .a-form-label
             | プレビュー
           .js-preview.a-long-text.is-md.markdown-form__preview
-    .form-item
-      = render 'errors', object: faq
-      label.a-form-label
-        | カテゴリー
-      .checkboxes
-        .checkboxes__items
-          - @faq_categories.each do |faq_category|
-            .checkboxes__item.is-radio
-              = f.radio_button :faq_category_id, faq_category.id, class: 'a-toggle-checkbox'
-              = f.label :faq_category_id, faq_category.name, value: faq_category.id
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main

--- a/app/views/shared/_check_actions.html.slim
+++ b/app/views/shared/_check_actions.html.slim
@@ -22,8 +22,9 @@
                   = checkable.checker.login_name
 
         li.card-main-actions__item class=(checkable.checks.any? ? 'is-sub' : '')
-          - if check
-            = form_with url: polymorphic_path([checkable, check]), method: :delete, local: true do |f|
+          - checked_checkable = checkable.checks.first
+          - if checked_checkable
+            = form_with url: polymorphic_path([checkable, checked_checkable]), method: :delete, local: true do |f|
               - if checkable_type == 'Product'
                 = f.submit "#{checkable_label}の合格を取り消す", class: 'card-main-actions__muted-action'
               - else

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -8,7 +8,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_equal '管理ページ | FBC', title
   end
 
-  test 'show listing students' do
+  test 'show listing users without parameters' do
     visit_with_auth '/admin/users', 'komagata'
     assert_equal '管理ページ | FBC', title
   end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [#9075](https://github.com/fjordllc/bootcamp/issues/9075)

## 概要
/admin/usersでアドバイザーやメンターが表示されないのを、すべてのユーザーが表示されるようにした。


## 変更確認方法

1. {bug/not-properly-display-users-index}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

<!-- I want to review in Japanese. -->
