### PR TITLE
お試し延長作成のボタンの位置を変更した

### DIFF
--- a/app/views/admin/campaigns/index.html.slim
+++ b/app/views/admin/campaigns/index.html.slim
@@ -6,14 +6,6 @@ header.page-header
       .page-header__start
         h2.page-header__title
           | 管理ページ
-      .page-header__end
-        .page-header-actions
-          .page-header-actions__items
-            .page-header-actions__item
-              = link_to new_admin_campaign_path, class: 'a-button is-md is-secondary is-block' do
-                i.fa-regular.fa-plus
-                span
-                  | お試し延長作成
 
 = render 'admin/admin_page_tabs'
 
@@ -24,6 +16,14 @@ main.page-main
         .page-main-header__start
           h1.page-main-header__title
             | お試し延長一覧
+        .page-main-header__end
+          .page-main-header-actions
+            .page-main-header-actions__items
+              .page-main-header-actions__item
+                = link_to new_admin_campaign_path, class: 'a-button is-md is-secondary is-block' do
+                  i.fa-regular.fa-plus
+                  span
+                    | お試し延長作成
   hr.a-border
   .page-body
     .container.is-lg

--- a/app/views/admin/campaigns/new.html.slim
+++ b/app/views/admin/campaigns/new.html.slim
@@ -17,9 +17,9 @@ main.page-main
           h1.page-main-header__title
             | お試し延長作成
         .page-main-header__end
-          .page-header-actions
-            .page-header-actions__items
-              .page-header-actions__item
+          .page-main-header-actions
+            .page-main-header-actions__items
+              .page-main-header-actions__item
                 = link_to admin_campaigns_path, class: 'a-button is-md is-secondary is-block is-back' do
                   | お試し延長一覧
   hr.a-border


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue
- #9091

## 概要
- 管理者のお試し延長画面を表示した際、メニュータブの上に「+お試し延長作成」ボタンが配置されていたが、タブより上の部分で変化を起こしたくないため**お試し延長一覧**の表示と同じ高さで右部に表示させるように変更
- 「+お試し延長作成」ボタンを `header.page-header` から `header.page-main-header` に移動するので、ボタンのCSSのを`page-header-actions`から`page-main-header-actions` に変更
    - 併せて、お試し延長新規作成の同位置に表示している「< お試し延長一覧」ボタンのCSSを`page-main-header-actions` に統一(編集画面は`page-main-header-actions`が適用されているため非修正対象)

## 変更確認方法
### 確認前準備
1. `chore/move-campaign-create-button`をローカルに取り込む
2. `foreman start -f Procfile.dev`でローカルサーバーを起動
1. 管理者ユーザー（id: `machida` または `komagata`/ pass: `testtest` ）でログインする

### お試し延長作成 ボタン
1. 管理者用メニューのお試し延長一覧画面(http://localhost:3000/admin/campaigns) へ移動
1. 「+お試し延長作成」ボタンが、**お試し延長一覧**の表示と同じ高さで右部に表示されていることを確認
3. 「+お試し延長作成」ボタンをクリックするとお試し延長作成画面(http://localhost:3000/admin/campaigns/new) が表示されることを確認

### お試し延長一覧 ボタン
1. 管理者用メニューのお試し延長作成画面(http://localhost:3000/admin/campaigns/new) へ移動
1. 「< お試し延長一覧」ボタンが、**お試し延長作成**の表示と同じ高さで右部に表示されていることを確認
2. 「< お試し延長一覧」ボタンをクリックするとお試し延長一覧画面(http://localhost:3000/admin/campaigns) が表示されることを確認

## Screenshot

### お試し延長作成 ボタン
- ボタンの位置が変更されていることを確認

||変更前|変更後|
|---|---|---|
|ブラウザ<br>表示 | <img src="https://github.com/user-attachments/assets/723698a0-8950-40ea-a936-843b862982f4" width="800"> | <img src="https://github.com/user-attachments/assets/70d33406-7d89-40e2-a037-5b1123582e23" width="800">|
|レスポンシブ<br>表示(念の為) | <img src="https://github.com/user-attachments/assets/84d7e608-b04e-4707-89e6-902e00de3908" height="300"> | <img src="https://github.com/user-attachments/assets/51674292-9625-4a08-951c-287e2a6bd8d4" height="300">|

### お試し延長一覧 ボタン

- 見た目や位置が変わっていないことを確認

||変更前|変更後|
|---|---|---|
|ブラウザ<br>表示 | <img src="https://github.com/user-attachments/assets/15aeed8b-255c-4674-8860-710c7176a358" width="800"> | <img src="https://github.com/user-attachments/assets/20899ca1-e0c5-47dd-a83e-55a1d76ef1c8" width="800">|
|レスポンシブ<br>表示(念の為) | <img src="https://github.com/user-attachments/assets/7ee3e8fb-eda5-4065-9414-38c3c0afaa11" height="300"> | <img src="https://github.com/user-attachments/assets/19f332a0-3823-42a5-b068-265609bd9e68" height="300"> |
<!-- I want to review in Japanese. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- スタイル
  - 管理画面のキャンペーン一覧で、作成ボタンをヘッダー右上からページ本文のヘッダー右側（.page-main-header__end 等）へ移動し、視認性と配置を改善しました。
  - ボタンの文言は引き続き「お試し延長作成」、アイコン・見た目・遷移先は従来どおり保持しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->