### PR TITLE
未チェックの日報を一括で開くボタンの復活

### DIFF
--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -44,6 +44,6 @@ main.page-main
           .card-list.a-card
             .card-list__items
               = render partial: 'reports/report', collection: @reports, as: :report, locals: { user_icon_display: true, actions_display: true }
+          - if mentor_login? && params[:unchecked].present?
+            = render partial: 'unconfirmed_links_open', locals: { label: '未チェックの日報を一括で開く' }
         = paginate @reports
-        - if mentor_login?
-          = render partial: 'unconfirmed_links_open', locals: { label: '未チェックの日報を一括で開く' }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9170

## 概要
PR:https://github.com/fjordllc/bootcamp/pull/8976 で削除してしまった
「未チェックの日報を一括で開く」ボタンを復活させる

## 変更確認方法

1. `bug/reenable-bulk-open-unread-reports`をローカルに取り込む
```
git fetch origin bug/reenable-bulk-open-unread-reports
git checkout bug/reenable-bulk-open-unread-reports
```

2. `foreman start -f Procfile.dev`でローカル環境を立ち上げる
3. `komagata`でログインする
4. 「日報・みんなのブログ」ページにおいて、`日報`タブを選択し、その中の`未チェック`タブを選択した際に下部に表示される「未チェックの日報を一括で開く」ボタンを確認。（ボタンをクリックして別タブでリンクが開くことも確認）

#### 動作確認時の注意
「未チェックの日報を一括で開く」ボタンを押した際、先頭の1件しか開かない場合があります。  
これは Chrome のポップアップブロック機能（`window.open` を利用したタブの同時オープンも対象）が原因です。  

動作確認を行う場合は、以下いずれかでポップアップを許可してください。  
- Chrome の設定で「ポップアップとリダイレクト」を許可する  
- ボタン押下後、アドレスバーの通知から「常にこのサイトのポップアップを許可」を選択する


## Screenshot

### 変更前
<img width="1461" height="721" alt="スクリーンショット 2025-09-17 11 38 07" src="https://github.com/user-attachments/assets/ff0401c2-8810-4376-a8b4-405b4981509c" />

### 変更後

<img width="1410" height="703" alt="スクリーンショット 2025-09-18 17 22 01" src="https://github.com/user-attachments/assets/8ace4d2d-4a29-4acc-bb4d-9381d4434a30" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 日報一覧にメンター専用の一括操作UIを追加。メンターかつ該当パラメータがある場合、一覧とページネーションの間に「未チェックの日報を一括で開く」リンクブロックを表示し、未確認の日報をまとめて開けるようにしました。一般ユーザーの表示や既存の動作には影響ありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->