### PR TITLE
お知らせにブックマーク機能を追加した

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -7,6 +7,7 @@ class Announcement < ApplicationRecord
   include Reactionable
   include WithAvatar
   include Watchable
+  include Bookmarkable
 
   enum target: {
     all: 0,

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -55,6 +55,8 @@ hr.a-border
               .page-content-header-actions
                 .page-content-header-actions__start
                   = render 'watches/watch_toggle', type: @announcement.class.to_s, id: @announcement.id, watch: @announcement.watch_by(current_user)
+                  .page-content-header-actions__action
+                    = react_component('BookmarkButton', bookmarkableId: @announcement.id, bookmarkableType: 'Announcement')
                 .page-content-header-actions__end
                   .page-content-header-actions__action
                     = link_to new_announcement_path(id: @announcement), class: 'a-button is-sm is-secondary is-block', id: 'copy' do

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,3 +1,7 @@
+bookmark32:
+  user: kimura
+  bookmarkable: announcement1 (Announcement)
+
 bookmark31:
   user: komagata
   bookmarkable: talk1 (Talk)

--- a/test/fixtures/bookmarks.yml
+++ b/test/fixtures/bookmarks.yml
@@ -1,7 +1,3 @@
-bookmark32:
-  user: kimura
-  bookmarkable: announcement1 (Announcement)
-
 bookmark31:
   user: komagata
   bookmarkable: talk1 (Talk)

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -6,6 +6,7 @@ class BookmarksTest < ApplicationSystemTestCase
   setup do
     @report = reports(:report1)
     @question = questions(:question1)
+    @announcement = announcements(:announcement1)
   end
 
   test 'show my bookmark report' do
@@ -77,5 +78,26 @@ class BookmarksTest < ApplicationSystemTestCase
 
     visit '/current_user/bookmarks'
     assert_no_text @question.title
+  end
+
+  test 'bookmark announcement' do
+    visit_with_auth "/announcements/#{@announcement.id}", 'hatsuno'
+    find('#bookmark-button').click
+    assert_selector '#bookmark-button.is-active'
+    assert_no_selector '#bookmark-button.is-inactive'
+
+    visit '/current_user/bookmarks'
+    assert_text @announcement.title
+  end
+
+  test 'unbookmark announcement' do
+    visit_with_auth "/announcements/#{@announcement.id}", 'kimura'
+    assert_selector '#bookmark-button.is-active'
+    find('#bookmark-button').click
+    assert_selector '#bookmark-button.is-inactive'
+    assert_no_selector '#bookmark-button.is-active'
+
+    visit '/current_user/bookmarks'
+    assert_no_text @announcement.title
   end
 end

--- a/test/system/bookmarks_test.rb
+++ b/test/system/bookmarks_test.rb
@@ -91,7 +91,10 @@ class BookmarksTest < ApplicationSystemTestCase
   end
 
   test 'unbookmark announcement' do
-    visit_with_auth "/announcements/#{@announcement.id}", 'kimura'
+    user = users(:kimura)
+    user.bookmarks.create!(bookmarkable: @announcement)
+
+    visit_with_auth "/announcements/#{@announcement.id}", user.login_name
     assert_selector '#bookmark-button.is-active'
     find('#bookmark-button').click
     assert_selector '#bookmark-button.is-inactive'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9164

## 概要
お知らせのページもブックーマークできるようにしました。

## 変更確認方法

1. `feature/add-bookmark-to-announcements`ブランチをローカルに取り込む
3. お知らせ一覧`http://localhost:3000/announcements`にアクセスする
4. 任意のお知らせのブックマークボタンをクリックし保存する
5. `http://localhost:3000/current_user/bookmarks`にアクセスし、先ほどクリックしたお知らせが保存されているか確認する
6. 保存されているお知らせをブックマークボタンをクリックし、削除する
7.  `http://localhost:3000/current_user/bookmarks`にアクセスし、先ほどクリックしたお知らせが削除されているか確認する

## Screenshot

### 変更前
<img width="2880" height="1626" alt="image" src="https://github.com/user-attachments/assets/a3047f11-0a61-4352-a1e0-60b224f1bc7a" />

### 変更後
<img width="2880" height="1628" alt="image" src="https://github.com/user-attachments/assets/aad758be-430c-46fe-a347-e4dc55a5e561" />



<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - お知らせにブックマーク機能を追加
  - お知らせ詳細ページのヘッダーにブックマークボタンを表示
  - ボタンでブックマーク/解除が可能になり、ユーザーのブックマークリストに反映

- テスト
  - お知らせのブックマーク/解除に関するシステムテストを追加
  - ボタン状態の切替とブックマークリストへの反映を検証

<!-- end of auto-generated comment: release notes by coderabbit.ai -->