### PR TITLE
/admin/usersですべてのユーザーが表示されるように変更

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,7 +7,7 @@ class Admin::UsersController < AdminController
   def index
     @direction = params[:direction] || 'desc'
     @target = params[:target]
-    user_scope = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'student_and_trainee')
+    user_scope = User.users_role(@target, allowed_targets: ALLOWED_TARGETS, default_target: 'all')
     user_scope = if @target == 'retired'
                    user_scope.where.not(retired_on: nil)
                  else

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -8,7 +8,7 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_equal '管理ページ | FBC', title
   end
 
-  test 'show listing students' do
+  test 'show listing users without parameters' do
     visit_with_auth '/admin/users', 'komagata'
     assert_equal '管理ページ | FBC', title
   end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9075

## 概要

## 変更確認方法

1. {bug/fix-users-index}をローカルに取り込む
2. 管理者でログインする("komagata"など)
3. http://localhost:3000/admin/users へ移動
4. 卒業生やアドバイザーやメンターが表示されていることを確認。

## Screenshot

### 変更前
<img width="397" height="735" alt="image" src="https://github.com/user-attachments/assets/df83bbd7-f259-4588-92b2-c3c5711d9e3a" />


### 変更後
<img width="348" height="432" alt="image" src="https://github.com/user-attachments/assets/b241bc1f-f3e3-4237-95d1-21038eccdf31" />

### 備考
ユーザーが正しく取得できているかはモデルテスト側の責務なので、今回の仕様変更にまつわるシステムテストの変更は、仕様変更があったことがわかる程度にとどめました。(`test/system/admin/users_test.rb`)
もし、issue側記載の`/admin/users?target=all&job=all&job_seeking=all&payment_method=all`と同様のクエリが発行されているか確認したい場合は、下記の方法で確認できます

1. 下記部分に`debugger`を記述
`app/controllers/admin/users_controller.rb`
```ruby
    user_scope = apply_payment_method_filter(user_scope, payment_method)
    debugger
    @users = user_scope.with_attached_avatar
```

2. http://localhost:3000/admin/users へ移動し、コンソールで`user_scope.to_sql`を確認

`user_scope.to_sql`
<img width="622" height="56" alt="image" src="https://github.com/user-attachments/assets/d62a0636-57b7-4d44-b568-249a050464d5" />

3. http://localhost:3000/admin/users?target=all&job=all&job_seeking=all&payment_method=all へ移動し、コンソールで`user_scope.to_sql`を確認


`user_scope.to_sql`
<img width="585" height="52" alt="image" src="https://github.com/user-attachments/assets/9c611a25-09cc-43ca-8192-96f6073fda43" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 管理者向けユーザー一覧で、パラメータ未指定時の既定表示を「学生・研修生のみ」から「全ユーザー」に拡大。退会/現役の切替は従来通り。初回アクセスで網羅的なユーザー把握が可能に。
- テスト
  - 一覧ページのシステムテスト名称を実挙動に合わせて更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->