### PR TITLE
提出物を担当していない状態でコメントをするとコメントが投稿されない不具合を修正

### DIFF
--- a/app/javascript/comment-checkable.js
+++ b/app/javascript/comment-checkable.js
@@ -1,34 +1,26 @@
-import CSRF from 'csrf'
 import { toast } from './vanillaToast.js'
 import checkStamp from 'check-stamp.js'
+import { FetchRequest } from '@rails/request.js'
 
-async function sendRequest(url, method = 'GET', body = null) {
-  const options = {
-    method,
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'X-Requested-With': 'XMLHttpRequest',
-      'X-CSRF-Token': CSRF.getToken()
-    },
-    credentials: 'same-origin',
-    redirect: 'manual'
-  }
+async function sendRequest(url, method = 'get', body = null) {
+  const options = { redirect: 'manual' }
   if (body) {
-    options.body = JSON.stringify(body)
+    options.body = body
   }
 
-  const response = await fetch(url, options)
+  const request = new FetchRequest(method, url, options)
+  const response = await request.perform()
 
   let data
   if (response.ok) {
     try {
-      data = await response.json()
+      data = await response.json
     } catch {
       data = response
     }
   } else {
     try {
-      data = await response.json()
+      data = await response.json
     } catch {
       throw new Error(`HTTP error! status: ${response.status}`)
     }
@@ -78,7 +70,7 @@ export default {
     }
 
     try {
-      const json = await sendRequest('/api/products/checker', 'PATCH', params)
+      const json = await sendRequest('/api/products/checker', 'patch', params)
 
       if (json.message) {
         alert(json.message)

--- a/app/javascript/new-comment.js
+++ b/app/javascript/new-comment.js
@@ -1,5 +1,4 @@
 import autosize from 'autosize'
-import CSRF from 'csrf'
 import TextareaInitializer from 'textarea-initializer'
 import MarkdownInitializer from 'markdown-initializer'
 import { initializeComment, toggleVisibility } from './initializeComment.js'
@@ -7,6 +6,7 @@ import { initializeReaction } from './reaction.js'
 import { toast } from './vanillaToast.js'
 import { setWatchable } from './setWatchable.js'
 import commentCheckable from './comment-checkable.js'
+import { post } from '@rails/request.js'
 
 document.addEventListener('DOMContentLoaded', () => {
   const newComment = document.querySelector('.new-comment')
@@ -113,24 +113,18 @@ document.addEventListener('DOMContentLoaded', () => {
       comment: { description: savedComment }
     }
 
-    const response = await fetch('/api/comments', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'X-Requested-With': 'XMLHttpRequest',
-        'X-CSRF-Token': CSRF.getToken()
-      },
-      credentials: 'same-origin',
+    const response = await post('/api/comments', {
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
       redirect: 'manual',
-      body: JSON.stringify(params)
+      body: params
     })
 
     if (!response.ok) {
-      const data = await response.json()
+      const data = await response.json
       throw new Error(data.errors.join(', '))
     }
 
-    return await response.text()
+    return await response.text
   }
 
   const addCommentToDOM = (html) => {
@@ -161,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
       commentableType,
       commentableId,
       '/api/checks',
-      'POST'
+      'post'
     )
   }
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9174 

## 概要
- 提出物を担当していない状態でコメントをすると、提出物にはアサインされるが、コメントが投稿されない場合がある不具合を修正しました。
※使用しているPCのスペック等によって、上記不具合が発生しない場合もあると思われます。

## 原因
- 担当者へのアサイン処理の中で、`location.reload()`を実行しており、その後のコメント投稿処理がページリロードにより中断されてしまうため。

## 修正内容
- ページリロード処理とトーストの表示処理を`handleSave()`内の最後にまとめて実行するようにし、コメント投稿処理が確実に完了するようにしました。
- CodeRabbitの修正範囲外の指摘があり、`fetch`の代わりに`request.js`を使用するように修正いたしました。

## 変更確認方法

1. `bug/comment-not-posted-when-unassigned` をローカルに取り込む
2. `foreman start -f Procfile.dev` でサーバーを立ち上げる
3. 任意のメンターユーザでログイン
4. [提出物詳細ページ](http://localhost:3000/products/465290212)にアクセスする
    <details><summary>4.1. 担当者に未アサインの状態で、コメントを入力し、コメント入力欄下部の[コメントする]ボタンをクリックした場合</summary>

    - [ ] 「提出物の担当になりました。」アラートが表示されるため、[OK]をクリック
    - [ ] 「担当になりました。」のトーストが表示されること
    - [ ] Watch中になること
    - [ ] [担当者から外れる] ボタンが表示されること
    - [ ] コメントが出力されること
    </details>

    <details><summary>4.2. 担当者にアサイン済の状態で、コメントを入力し、コメント入力欄下部の[コメントする]ボタンをクリックした場合</summary>

    - [ ] 「コメントを投稿しました！」のトーストが表示されること
    - [ ] Watch中になること
    - [ ] コメントが出力されること 
    </details>

    <details><summary>4.3. 担当者に未アサインの状態で、コメントを入力し、コメント入力欄下部の [合格にする] ボタンをクリックした場合</summary>

    - [ ] 「提出物を合格にしてよろしいですか？」のアラートが表示されるため、[OK]をクリック
    - [ ] 「提出物の担当になりました。」アラートが表示されるため、[OK]をクリック
    - [ ] 「提出物を合格にしました。」のトーストが表示されること
    - [ ] Watch中になること
    - [ ] [提出物の合格を取り消す] リンクが表示されること（[担当する] | [提出物を合格にする] ボタンは表示されない）
    - [ ] コメントが出力されること
    - [ ] コメント入力欄下部のボタンが [コメントする] ボタンのみとなること（[合格にする] ボタンは表示されない）
    </details>

    <details><summary>4.4. 担当者にアサイン済の状態で、コメントを入力し、コメント入力欄下部の [合格にする] ボタンをクリックした場合</summary>

    - [ ] 「提出物を合格にしてよろしいですか？」のアラートが表示されるため、[OK]をクリック
    - [ ] 「提出物を合格にしました。」のトーストが表示されること
    - [ ] Watch中になること
    - [ ] [提出物の合格を取り消す] リンクが表示されること（[担当する] | [提出物を合格にする] ボタンは表示されない）
    - [ ] コメントが出力されること
    - [ ] コメント入力欄下部のボタンが [コメントする] ボタンのみとなること（[合格にする] ボタンは表示されない）
    </details>

5. [日報詳細ページ](http://localhost:3000/reports/431029550)にアクセスする
    <details><summary>5.1. コメントを入力し、コメント入力欄下部の[確認OKにする] ボタンをクリックした場合</summary>

    - [ ] 「日報を確認済みにしました。」のトーストが表示されること
    - [ ] Watch中になること
    - [ ] コメントが出力されること  
    - [ ] コメント入力欄下部のボタンが [コメントする] ボタンのみとなること（[確認OKにする] ボタンは表示されない）  
    </details>

    <details><summary>5.2. コメントを入力し、コメント入力欄下部の[コメントする]ボタン をクリックした場合</summary>

    - [ ] 「コメントを投稿しました！」のトーストが表示されること
    - [ ] Watch中になること
    - [ ] コメントが出力されること  
    </details>

6. [お知らせ詳細ページ](http://localhost:3000/announcements/721644200)にアクセスする
    <details><summary>6.1. コメントを入力し、コメント入力欄下部の [コメントする] ボタンをクリックした場合</summary>

    - [ ] 「コメントを投稿しました！」のトーストメッセージが表示されること
    - [ ] Watch中になること
    - [ ] コメントが出力されること
    </details>

## Screenshot

### 変更前
<details>
<img width="2308" height="1708" alt="Image" src="https://github.com/user-attachments/assets/7288c0f7-23a9-4d09-a0cc-9a74bf01b1cd" />

<img width="1154" height="848" alt="Image" src="https://github.com/user-attachments/assets/81c3afc6-d46b-441e-9692-70aecb6a5a3c" />

</details>

### 変更後
<details>
<img width="1918" height="1082" alt="image" src="https://github.com/user-attachments/assets/1cd607f2-40a3-44b6-933b-626b8097497d" />

<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/7add01b3-4c41-44f5-a306-315eee66aabc" />

</details>

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 成功通知をトーストに統一し、チェックや担当設定時に即時表示。
  * チェック対象に応じた日本語メッセージを表示（Product とそれ以外で文言を分岐）。

* **リファクタ**
  * 通信と通知の挙動を統一して操作体験を簡素化。

* **バグ修正**
  * 不要な多重トーストやアラートによる混乱を解消。部分的に従来通りページ再読み込みするケースを明確化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->