### PR TITLE
日報・みんなのブログのtitle要素を設定した

### DIFF
--- a/app/views/external_entries/index.html.slim
+++ b/app/views/external_entries/index.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, 'みんなのブログ'
+- title 'みんなのブログ'
 - set_meta_tags description: 'みんなのブログ一覧ページです。'
 
 = render '/reports/report_blog_header'

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, '日報'
+- title '日報'
 - set_meta_tags description: '日報の一覧ページです。'
 
 = render '/reports/report_blog_header'


### PR DESCRIPTION

<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9176

## 概要
- content_for記法が使われていたが、layoutファイルにyieldする箇所がなかったためタイトルが表示されていなかった
- 他のページと合わせて使用しているgem mete-tagsの記法である`- title`に修正した(以前のやり方へ戻した)

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

<!-- I want to review in Japanese. -->
