### PR TITLE
未確認の日報ページのURLを修正

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,9 +14,19 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
   before_action :set_watch, only: %i[show]
 
   def index
+    # Backward compatibility: redirect old query param URL to the new path
+    return redirect_to unchecked_reports_path if params[:unchecked].present?
+
     @reports = Report.list.page(params[:page]).per(PAGER_NUMBER)
     @reports = @reports.joins(:practices).where(practices: { id: params[:practice_id] }) if params[:practice_id].present?
-    @reports = @reports.unchecked.not_wip if params[:unchecked].present? && admin_or_mentor_login?
+  end
+
+  def unchecked
+    return redirect_to reports_path unless admin_or_mentor_login?
+
+    @reports = Report.list.page(params[:page]).per(PAGER_NUMBER)
+    @reports = @reports.unchecked.not_wip
+    render :index
   end
 
   def show

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -20,10 +20,10 @@ main.page-main
     nav.pill-nav
       ul.pill-nav__items
         li.pill-nav__item
-          = link_to '全て', reports_path, class: "pill-nav__item-link#{' is-active' unless params[:unchecked]}"
+          = link_to '全て', reports_path, class: "pill-nav__item-link#{' is-active' if action_name == 'index'}"
         li.pill-nav__item
-          = link_to '未チェック', reports_path(unchecked: true), class: "pill-nav__item-link#{' is-active' if params[:unchecked]}"
-  - if params[:unchecked].blank?
+          = link_to '未チェック', unchecked_reports_path, class: "pill-nav__item-link#{' is-active' if action_name == 'unchecked'}"
+  - if action_name != 'unchecked'
     nav.page-filter.form.pb-0
       .container.is-md
         = form_with url: reports_path, local: true, method: :get do

--- a/config/routes/reports.rb
+++ b/config/routes/reports.rb
@@ -2,6 +2,9 @@
 
 Rails.application.routes.draw do
   resources :reports do
+    collection do
+      get :unchecked
+    end
     resources :checks, only: [:create, :destroy]
   end
 end

--- a/test/system/reports_practice_filter_test.rb
+++ b/test/system/reports_practice_filter_test.rb
@@ -36,7 +36,7 @@ class ReportsPracticeFilterTest < ApplicationSystemTestCase
   end
 
   test 'practice filter is hidden when unchecked parameter is present' do
-    visit reports_path(unchecked: true)
+    visit unchecked_reports_path
     assert_no_selector 'select#js-choices-single-select', wait: 5
   end
 end


### PR DESCRIPTION
新しいURLに変わっていたが、ダッシュボードからのリンクが古い物へのリンクになっていた。
新しいURLがRESTfulでないURLになっていたので元のURLに戻しました。