### PR TITLE
markdown-it-purifierを外した

### DIFF
--- a/app/javascript/markdown-initializer.js
+++ b/app/javascript/markdown-initializer.js
@@ -12,7 +12,6 @@ import MarkDownItContainerMessage from 'markdown-it-container-message'
 import MarkDownItContainerDetails from 'markdown-it-container-details'
 import MarkDownItLinkAttributes from 'markdown-it-link-attributes'
 import MarkDownItContainerSpeak from 'markdown-it-container-speak'
-import MarkdownItPurifier from 'markdown-it-purifier'
 import ReplaceLinkToCard from 'replace-link-to-card'
 import MarkDownItContainerFigure from 'markdown-it-container-figure'
 import MarkdownItVimeo from 'markdown-it-vimeo'
@@ -62,7 +61,6 @@ export default class {
     md.use(MarkDownItContainerFigure)
     md.use(MarkdownItVimeo)
     md.use(MarkdownItYoutube)
-    md.use(MarkdownItPurifier)
     return md.render(text)
   }
 }

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -17,7 +17,6 @@ import CSRF from 'csrf'
 import TextareaMarkdownLinkify from 'textarea-markdown-linkify'
 import ReplaceLinkToCard from 'replace-link-to-card'
 import MarkDownItContainerFigure from 'markdown-it-container-figure'
-import MarkdownItPurifier from 'markdown-it-purifier'
 import MarkdownItVimeo from 'markdown-it-vimeo'
 import MarkdownItYoutube from 'markdown-it-youtube'
 
@@ -90,8 +89,7 @@ export default class {
           MarkDownItContainerSpeak,
           MarkDownItContainerFigure,
           MarkdownItVimeo,
-          MarkdownItYoutube,
-          MarkdownItPurifier
+          MarkdownItYoutube
         ],
         markdownOptions: MarkdownOption
       })


### PR DESCRIPTION
バッククォート内のHTMLも有効になるために色々なページが
崩れてしまう問題が多発しているため。