### PR TITLE
uncheckedページのcontrollerを整理した

### DIFF
--- a/app/controllers/reports/unchecked_controller.rb
+++ b/app/controllers/reports/unchecked_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Reports::UncheckedController < ApplicationController
+  PAGER_NUMBER = 25
+  before_action :require_admin_or_mentor!
+
+  def index
+    @reports = Report.list.page(params[:page]).per(PAGER_NUMBER)
+    @reports = @reports.unchecked.not_wip
+    render 'reports/index'
+  end
+
+  private
+
+  def require_admin_or_mentor!
+    redirect_to reports_path unless admin_or_mentor_login?
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,19 +14,8 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
   before_action :set_watch, only: %i[show]
 
   def index
-    # Backward compatibility: redirect old query param URL to the new path
-    return redirect_to unchecked_reports_path if params[:unchecked].present?
-
     @reports = Report.list.page(params[:page]).per(PAGER_NUMBER)
     @reports = @reports.joins(:practices).where(practices: { id: params[:practice_id] }) if params[:practice_id].present?
-  end
-
-  def unchecked
-    return redirect_to reports_path unless admin_or_mentor_login?
-
-    @reports = Report.list.page(params[:page]).per(PAGER_NUMBER)
-    @reports = @reports.unchecked.not_wip
-    render :index
   end
 
   def show

--- a/app/views/home/_unchecked_report_alert.html.slim
+++ b/app/views/home/_unchecked_report_alert.html.slim
@@ -7,7 +7,7 @@
       .unchecked-report-alert__icon
         i.fa-regular.fa-triangle-exclamation
       .unchecked-report-alert__message
-        = link_to '/reports/unchecked', class: 'unchecked-report-alert__message-link' do
+        = link_to reports_unchecked_index_path, class: 'unchecked-report-alert__message-link' do
           | 未チェックの日報が
           strong.unchecked-report-alert__count
             span.unchecked-report-alert__count-number

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -20,10 +20,10 @@ main.page-main
     nav.pill-nav
       ul.pill-nav__items
         li.pill-nav__item
-          = link_to '全て', reports_path, class: "pill-nav__item-link#{' is-active' if action_name == 'index'}"
+          = link_to '全て', reports_path, class: "pill-nav__item-link#{' is-active' if controller_path == 'reports'}"
         li.pill-nav__item
-          = link_to '未チェック', unchecked_reports_path, class: "pill-nav__item-link#{' is-active' if action_name == 'unchecked'}"
-  - if action_name != 'unchecked'
+          = link_to '未チェック', reports_unchecked_index_path, class: "pill-nav__item-link#{' is-active' if controller_path == 'reports/unchecked'}"
+  - if controller_path != 'reports/unchecked'
     nav.page-filter.form.pb-0
       .container.is-md
         = form_with url: reports_path, local: true, method: :get do

--- a/config/routes/reports.rb
+++ b/config/routes/reports.rb
@@ -2,9 +2,9 @@
 
 Rails.application.routes.draw do
   resources :reports do
-    collection do
-      get :unchecked
-    end
     resources :checks, only: [:create, :destroy]
+  end
+  namespace :reports do
+    resources :unchecked, only: %i[index]
   end
 end

--- a/test/system/reports_practice_filter_test.rb
+++ b/test/system/reports_practice_filter_test.rb
@@ -34,9 +34,4 @@ class ReportsPracticeFilterTest < ApplicationSystemTestCase
     assert_text 'レポート1', wait: 5
     assert_no_text 'レポート2', wait: 5
   end
-
-  test 'practice filter is hidden when unchecked parameter is present' do
-    visit reports_unchecked_index_path
-    assert_no_selector 'select#js-choices-single-select', wait: 5
-  end
 end

--- a/test/system/reports_practice_filter_test.rb
+++ b/test/system/reports_practice_filter_test.rb
@@ -36,7 +36,7 @@ class ReportsPracticeFilterTest < ApplicationSystemTestCase
   end
 
   test 'practice filter is hidden when unchecked parameter is present' do
-    visit unchecked_reports_path
+    visit reports_unchecked_index_path
     assert_no_selector 'select#js-choices-single-select', wait: 5
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 未チェックレポートの専用ページを追加、25件ごとのページネーション対応
  - 閲覧権限を管理者・メンターに限定
- 不具合修正
  - レポート一覧タブのアクティブ表示判定を改善し表示が正しく切り替わるように
  - 固定URLからルーティングヘルパーへ切替え、不要なリダイレクトを削除
- リファクタ
  - ルーティングを整理して未チェックページのパスとナビゲーションを統一
<!-- end of auto-generated comment: release notes by coderabbit.ai -->