### PR TITLE
FacebookのURLとブログのURLにバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,7 +235,7 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
                                            message: 'か「クレジットカード払い」のいずれかを選択してください。' },
                               if: -> { role == 'trainee_select_a_payment_method' && !credit_card_payment }
 
-  validates :feed_url,
+  validates :facebook_url, :feed_url, :blog_url,
             format: {
               allow_blank: true,
               with: URI::DEFAULT_PARSER.make_regexp(%w[http https]),


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [ユーザーのブログ URLにURL形式のバリデーションを追加 #9177](https://github.com/fjordllc/bootcamp/issues/9177)

## 概要
ユーザーの登録情報変更ページで、ブログURLとFacebookのURLが`http`や`https`以外のものでも設定できる状態だったため、バリデーションを追加しました。

## 変更確認方法

1. `bug/add-url-validation-for-user-profile-edit`をローカルに取り込む
2. 任意のユーザーでログインする
3. `/current_user/edit`にアクセスする（Meメニューの登録情報変更）
4. URL形式でない文字列を入力して更新するとエラーメッセージが表示されることを確認
5. URL形式で入力して更新すると問題なく更新されることを確認

## Screenshot
UIに変化はないためスクリーンショットは省略しています。

<!-- I want to review in Japanese. -->
