### PR TITLE
未チェックの日報を一括で開くボタンを復活させた

### DIFF
--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -44,4 +44,6 @@ main.page-main
           .card-list.a-card
             .card-list__items
               = render partial: 'reports/report', collection: @reports, as: :report, locals: { user_icon_display: true, actions_display: true }
+          - if mentor_login? && controller_path == 'reports/unchecked'
+            = render partial: 'unconfirmed_links_open', locals: { label: '未チェックの日報を一括で開く' }
         = paginate @reports

--- a/config/routes/reports.rb
+++ b/config/routes/reports.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  resources :reports do
-    resources :checks, only: [:create, :destroy]
-  end
   namespace :reports do
     resources :unchecked, only: %i[index]
+  end
+  resources :reports do
+    resources :checks, only: [:create, :destroy]
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 未チェックの日報一覧にて、メンター向けに「未チェックの日報を一括で開く」リンクを表示。既存の日報表示やページネーションには影響ありません。
- チョア
  - ルーティング定義の並び順を調整（公開ルートや動作の変更はありません）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->