### PR TITLE
日報一覧のプラクティスの絞り込む機能を修正

### DIFF
--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -27,9 +27,9 @@ main.page-main
     nav.page-filter.form.pb-0
       .container.is-md
         = form_with url: reports_path, local: true, method: :get do
-        .form-item.is-inline-md-up
-          = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
-          = select_tag :practice_id, options_from_collection_for_select(@current_user_practice.sorted_practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
+          .form-item.is-inline-md-up
+            = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
+            = select_tag :practice_id, options_from_collection_for_select(@current_user_practice.sorted_practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
   .page-body
     - if @reports.empty?
       .o-empty-message


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [日報一覧のプラクティスで絞り込む機能が動いていない #9217](https://github.com/fjordllc/bootcamp/issues/9217)
## 概要
日報一覧の「プラクティスで絞り込む」でプラクティスを選択してもページがリロードせずに一覧が更新されないバグを修正しました。

## 変更確認方法

1. `bug/fix-practice-filter-in-report-list`をローカルに取り込む。
2. 任意のユーザーでログインする。
3. 左のメニュー一覧から「日報・ブログ」を選択し、日報一覧のページに行く。（http://localhost:3000/reports）
4. 「プラクティスで絞り込む」で「Terminalの基礎を覚える」を選択する。
5. 日報の一覧が更新され、関連の日報のみが表示されることを確認する。

## Screenshot
UIに変化はないため省略します。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * レポート画面のフォームで、フィルタ操作（選択）の変更時にその値がGET送信されるようになりました。これにより選択項目が画面遷移や検索結果に正しく反映されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->