### PR TITLE
日報一覧で検索できないバグの修正

### DIFF
--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -27,9 +27,9 @@ main.page-main
     nav.page-filter.form.pb-0
       .container.is-md
         = form_with url: reports_path, local: true, method: :get do
-        .form-item.is-inline-md-up
-          = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
-          = select_tag :practice_id, options_from_collection_for_select(@current_user_practice.sorted_practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
+          .form-item.is-inline-md-up
+            = label_tag :practice_id, 'プラクティスで絞り込む', class: 'a-form-label'
+            = select_tag :practice_id, options_from_collection_for_select(@current_user_practice.sorted_practices, :id, :title, selected: params[:practice_id]), include_blank: '全ての日報を表示', onchange: 'this.form.submit()', id: 'js-choices-single-select'
   .page-body
     - if @reports.empty?
       .o-empty-message


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9256

## 概要

日報一覧ページの検索機能が動くように修正

## 変更確認方法

1. `bug/daily-report-search-not-working`をローカルに取り込む
2. `komagata` でログイン
3. 日報一覧画面(/reports)にアクセス
3. 「全て」タブ内の検索セレクトボックスの選択時の以下の動作を確認
  - `全ての日報を表示` を選択時: 日報が表示される
  - `OS X Mountain Lionをクリーンインストールする`を選択時: `OS X Mountain Lionをクリーンインストールする` の日報のみが表示される
  - `検索ワード` 選択時に文字列を入力: 文字列にヒットしたプラクティスが絞り込まれ、選択すると選択したプラクティスの日報のみが表示される

## Screenshot

見た目の変更は無し

<!-- I want to review in Japanese. -->