### PR TITLE
金額が前のものだったので修正

### DIFF
--- a/app/views/welcome/training.html.slim
+++ b/app/views/welcome/training.html.slim
@@ -342,9 +342,9 @@ article.lp
                         td.text-right
                           | 利用料
                         td.text-center
-                          | 月額￥29,800（税込み）
+                          | 月額￥32,780（税込み）
                         td.text-center
-                          | 月額￥99,800（税込み）
+                          | 月額￥109,780（税込み）
                       tr
                         td.text-right
                           | 請求方法


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 企業研修プランの月額料金を更新しました。基本プランは月額32,780円、プレミアムプランは月額109,780円に改定されています（税込）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->