### PR TITLE
日報のテンプレートが画面遷移するときに自動で挿入されてしまうバグを解消

### DIFF
--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -79,7 +79,7 @@
               data: { 'registered-template-value': registered_template }
           .form-textarea
             .form-textarea__body
-              - value_option = registered_template.present? ? { value: registered_template } : {}
+              - value_option = report.description.blank? && registered_template.present? ? { value: registered_template } : {}
               = f.text_area :description,
                 **value_option,
                 class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9270  

## 概要

テンプレートを登録しているユーザーが日報を提出してできずにエラーが起きた時や、編集しようとした時（提出済みも含む）、自動でテンプレートが挿入されてしまい、元々の本文が消えてしまうバグを解消しました。
@yokomaru さんに画面共有で確認してもらいました。

## 変更確認方法

1. `bug/automatically-insert-report-temlate-anytime`をローカルに取り込む
2. machidaでログイン
 ID: `machida`
PASS: `testtest`
3. http://localhost:3000/reports/430404470 にアクセスする。
4. 内容を修正するをクリック。
5. 内容が変更されていないことを確認する。
6. テンプレートを反映するをクリックし、テンプレートが反映されることを確認する。
（もし、テンプレートが作成されていなかったら任意の文字列を登録する。）

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* フォーム説明欄の自動入力動作を改善しました。登録済みテンプレートは、ユーザーによる説明入力がない場合にのみ適用されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->