### PR TITLE
アップロードされた画像からEXifデータを削除

### DIFF
--- a/app/controllers/api/image_controller.rb
+++ b/app/controllers/api/image_controller.rb
@@ -3,33 +3,11 @@
 class API::ImageController < API::BaseController
   def create
     @image = Image.new(user: current_user, image: params[:file])
+
     if @image.save
-      begin
-        strip_exif
-        render :create, status: :created
-      rescue StandardError => e
-        Rails.logger.error("Failed to strip EXIF: #{e.message}")
-        @image.destroy
-        render json: { error: '画像処理に失敗しました' }, status: :unprocessable_entity
-      end
+      render :create, status: :created
     else
       render json: @image.errors, status: :unprocessable_entity
     end
-  end
-
-  private
-
-  def strip_exif
-    original_image = @image.image
-    copied_image = MiniMagick::Image.read(original_image.download)
-    copied_image.strip
-
-    ext = File.extname(original_image.filename.to_s)
-    timestamp = Time.current.strftime('%Y%m%d%H%M%S%L')
-    File.open(copied_image.path) do |file|
-      original_image.attach(io: file, filename: "#{current_user.id}_#{timestamp}#{ext}")
-    end
-  ensure
-    copied_image&.destroy!
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -3,4 +3,24 @@
 class Image < ApplicationRecord
   belongs_to :user
   has_one_attached :image
+
+  after_commit :strip_exif, on: :create
+
+  private
+
+  def strip_exif
+    original_image = image
+    copied_image = MiniMagick::Image.read(original_image.download)
+    copied_image.strip
+
+    ext = File.extname(original_image.filename.to_s)
+    timestamp = Time.current.strftime('%Y%m%d%H%M%S%L')
+    File.open(copied_image.path) do |file|
+      original_image.attach(io: file, filename: "#{user.id}_#{timestamp}#{ext}")
+    end
+  rescue StandardError => e
+    Rails.logger.error("Failed to strip EXIF: #{e.message}")
+  ensure
+    copied_image&.destroy!
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [Markdownエディタにアップロードした画像のExif情報を削除する #9282](https://github.com/fjordllc/bootcamp/issues/9282)

## 概要
Markdownエディタにアップロードした画像にはEifFデータが残っており、情報漏洩のリスクがありました。
今回の変更でEXif情報が削除される処理を追加し、セキュリティを向上させました。
## 変更確認方法

1. `feature/strip-exif-from-image-in-markdown-editor`をローカルに取り込む
2. 適当な画像を用意する
3. **画像にEXifデータがあることを以下の手順で確認する（Macの場合）**
- 画像を開き「プレビュー」画面を表示する。
- 上部メニューの「ツール」→「インスペクタを表示」をクリックする。
- 以下のようにEXifデータが表示されることを確認する。
<img width="214" height="131" alt="スクリーンショット 2025-11-06 21 37 58" src="https://github.com/user-attachments/assets/d7ac2ad1-f4e4-4f63-be9d-e0bed84b21e7" />

4. サーバーを起動する（`foreman start -f Procfile.dev`）
5. 任意のユーザーでログインする
6. 日報を作成し、用意した画像をアップロードする
7. 作成した日報を開き、画像をローカルに保存する
8. 先ほどを同じように画像を「プレビュー」画面で表示する
9. EXifデータが表示されないことを確認する

## 補足
[プロフィール画像をアップロードするときにExif情報を削除してリネームするようにした #4963](https://github.com/fjordllc/bootcamp/pull/4963)を参考にしました。

## Screenshot
アプリ自体にはUIの変化はないため、スクリーンショットは省略します。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 画像アップロード時に自動でEXIF（位置情報やカメラ情報など）を削除するようになりました。アップロード処理中にメタデータを除去し、処理に失敗した場合はアップロードを取り消してエラーを返します。プライバシー保護が向上します。

* **テスト**
  * EXIF削除の動作を検証する統合テストを追加しました。アップロード後にメタデータが確実に除去されていることを確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->