### PR TITLE
給付金対象コースのプラクティスページに元プラクティスへのリンクを追加

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -124,6 +124,17 @@
           - if @practice.coding_tests.present?
             = render partial: 'coding_tests', locals: { coding_tests: @practice.coding_tests }
 
+          - if @practice.source_id
+            .a-card
+              header.card-header
+                h2.card-header__title 元プラクティス
+              hr.a-border-tint
+              .card-body
+                .card-body__description
+                  = link_to practice_path(@practice.source_id), class: 'a-button is-sm is-secondary' do
+                    i.fa-solid.fa-link
+                    | 元プラクティスを見る
+
           - if current_user.admin_or_mentor?
             = render 'memo', practice: @practice
 


### PR DESCRIPTION
## Issue
- #9288

## 概要
給付金対応コースのプラクティスページに元コースへのリンクを追加する。

## 変更確認方法

1. source_idを既存のレコードに追加する。
2. UIにてsource_idがある場合のみ、元プラクティス欄が表示される。
3. リンクをクリックした際、source_idのプラクティスページが表示される。

## Screenshot

<img width="575" height="351" alt="image" src="https://github.com/user-attachments/assets/2d05a757-3cc3-4266-b1d0-60781dda263f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プラクティスに元プラクティスがある場合、それへのリンクを表示する機能を追加しました。プラクティス詳細画面に新しいカードが表示され、「元プラクティスを見る」ボタンからオリジナルのプラクティスにアクセスできます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->