### PR TITLE
ドラッグ&ドロップで画像選択できるように修正

### DIFF
--- a/app/javascript/fileinput.js
+++ b/app/javascript/fileinput.js
@@ -29,9 +29,9 @@ function initializeFileInput(target) {
   if (!inputs) return null
 
   inputs.forEach((input) => {
-    const dropZone = input.closest('.js-file-input')
-    dropZone.addEventListener('dragover', (e) => e.preventDefault())
-    dropZone.addEventListener('drop', (e) => {
+    const dropArea = input.closest('.js-file-input')
+    dropArea.addEventListener('dragover', (e) => e.preventDefault())
+    dropArea.addEventListener('drop', (e) => {
       e.preventDefault()
       input.files = e.dataTransfer.files
       input.dispatchEvent(new Event('change'))


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9296

## 概要

ドラッグ&ドロップで画像選択できるように修正

## 変更確認方法

1. `bug/portfolio-thumbnail-drag-drop` ブランチをローカルに取り込む
2. ポートフォリオ作成ページ(/works/new)にアクセス
3. サムネイル画像に画像をドラッグ&ドロップ
4. 画像が選択状態になっていることを確認

## Screenshot

見た目の変更はありません

<!-- I want to review in Japanese. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ファイル入力にドラッグ＆ドロップ対応を追加しました。入力エリアへファイルをドラッグ＆ドロップすると選択され、既存の変更イベント処理やHEIC→JPEG変換のフローはそのまま動作します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->