### PR TITLE
ダッシュボードに分報タブを追加 

### DIFF
--- a/app/helpers/page_tabs/dashboard_helper.rb
+++ b/app/helpers/page_tabs/dashboard_helper.rb
@@ -5,15 +5,15 @@ module PageTabs
     def dashboard_page_tabs(active_tab:)
       tabs = []
       tabs << { name: 'ダッシュボード', link: '/' }
+      if Rails.env.in? %w[development test]
+        tabs << { name: '自分の分報',
+                  link: "#{user_micro_reports_path(current_user, page: current_user.latest_micro_report_page)}#latest-micro-report",
+                  count: current_user.micro_reports.length }
+      end
       tabs << { name: '自分の日報', link: current_user_reports_path, count: current_user.reports.length }
       tabs << { name: '自分の提出物', link: current_user_products_path, count: current_user.products.length }
       tabs << { name: 'ブックマーク', link: current_user_bookmarks_path, count: current_user.bookmarks.length }
       tabs << { name: 'Watch中', link: current_user_watches_path }
-      if Rails.env.in? %w[development test]
-        tabs << { name: '分報',
-                  link: "#{user_micro_reports_path(current_user, page: current_user.latest_micro_report_page)}#latest-micro-report",
-                  count: current_user.micro_reports.length }
-      end
       render PageTabsComponent.new(tabs:, active_tab:)
     end
   end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9171

## 概要

ダッシュボードに「自分の分報」タブを追加しました。
本番環境では非表示（開発・テスト環境のみ表示）です。

 こちらのPRは、以前に作ったやつが見づらくなってしまった＆変更点が多かったのでチェリーピックして作り直しました。以下は以前のPRです。
https://github.com/fjordllc/bootcamp/pull/9198

## 変更確認方法

変更確認方法
1.{feature/micro-report-tab-newest-version}をローカルに取り込む
2.`komagata`でログイン
3.ダッシュボードのページにアクセスし、ダッシュボートタブの横に自分の分報のタブが追加されていることを確認する
4.自分の分報タブをクリックし、分報ページに遷移できることを確認する
5.遷移先が`/users/459775584/micro_reports?page=1#latest-micro-report`というURLであることを確認する

## Screenshot

### 変更前
<img width="2878" height="492" alt="image" src="https://github.com/user-attachments/assets/e4a1b2f0-afce-4cde-b92b-99a8166b7071" />

### 変更後
<img width="1918" height="325" alt="image" src="https://github.com/user-attachments/assets/08f849da-d813-43e3-ab10-cb4526f22d86" />
<img width="1915" height="1027" alt="image" src="https://github.com/user-attachments/assets/d78fddc5-5344-47c4-af40-bd3edc7b6daf" />


<!-- I want to review in Japanese. -->
