### PR TITLE
`bugfix/duplicate-image-on-report-update`ブランチ変更部分の取り消し

### DIFF
--- a/app/javascript/controllers/report_template_controller.js
+++ b/app/javascript/controllers/report_template_controller.js
@@ -56,7 +56,6 @@ export default class extends Controller {
     e.preventDefault()
     this.modalTarget.classList.remove('is-hidden')
     this.templateInputTarget.value = this.registeredTemplateValue
-    TextareaInitializer.uninitialize('#js-template-content')
     TextareaInitializer.initialize('#js-template-content')
     this.updateSubmitButtonState()
   }

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -82,7 +82,7 @@
               - value_option = report.description.blank? && registered_template.present? ? { value: registered_template } : {}
               = f.text_area :description,
                 **value_option,
-                class: 'a-text-input js-warning-form js-report-content markdown-form__text-area',
+                class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
                 data: { 'report-template-target': 'report', 'preview': '.js-preview', 'input': '.file-input' }
             .form-textarea__footer
               .form-textarea__insert


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9274

## 概要
日報の画像に関するバグ修正PR https://github.com/fjordllc/bootcamp/pull/9276 がmainにマージされましたが、ステージング環境で確認したところ、テンプレート内の画像のバグが発生してしてしまいました。
一旦https://github.com/fjordllc/bootcamp/pull/9276 のPRの反映を削除するためにこちらのPRを作り対応しました。


## 変更確認方法

日報の画像に関するPR https://github.com/fjordllc/bootcamp/pull/9276 で変更された箇所を変更前と同じかどうか確認する。


## Screenshot
該当箇所を外すためのPRのためスクリーンショットはありません。

<!-- I want to review in Japanese. -->
