### PR TITLE
assets:precompile時のAPP_HOST_NAMEチェックをスキップ

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,15 +104,19 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  # Validate APP_HOST_NAME at boot time
+  # Validate APP_HOST_NAME at boot time (skip during asset precompilation)
   app_host_name = ENV["APP_HOST_NAME"]
-  if app_host_name.nil? || app_host_name.strip.empty?
-    abort "ERROR: APP_HOST_NAME environment variable is required for production but not set or blank"
+  unless ENV["SECRET_KEY_BASE"] == "dummy"
+    if app_host_name.nil? || app_host_name.strip.empty?
+      abort "ERROR: APP_HOST_NAME environment variable is required for production but not set or blank"
+    end
   end
 
-  config.action_mailer.default_url_options = { host: app_host_name, protocol: "https" }
-  config.action_mailer.asset_host = "https://#{app_host_name}"
-  config.action_controller.asset_host = "https://#{app_host_name}"
+  if app_host_name.present?
+    config.action_mailer.default_url_options = { host: app_host_name, protocol: "https" }
+    config.action_mailer.asset_host = "https://#{app_host_name}"
+    config.action_controller.asset_host = "https://#{app_host_name}"
+  end
 
   config.action_mailer.delivery_method = :postmark
   config.action_mailer.postmark_settings = { api_token: ENV["POSTMARK_API_TOKEN"] }


### PR DESCRIPTION
## Summary
- Dockerビルド時に`SECRET_KEY_BASE=dummy`で`assets:precompile`を実行する際、`APP_HOST_NAME`が未設定でもエラーにならないように修正

## Background
`config/environments/production.rb`で`APP_HOST_NAME`のバリデーションがブート時に実行されるため、Dockerビルド時の`assets:precompile`で以下のエラーが発生していた：

```
ERROR: APP_HOST_NAME environment variable is required for production but not set or blank
```

## Changes
- `SECRET_KEY_BASE == "dummy"`の場合は`APP_HOST_NAME`のバリデーションをスキップ
- `APP_HOST_NAME`が設定されている場合のみ、mailerとasset_hostの設定を行う

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 本番環境でのアセットプリコンパイル時に環境変数が未設定の場合でもビルドが成功するよう改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->