### PR TITLE
DockerfileのNode.jsバージョン固定を解除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,10 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
       libvips-dev && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 22.19.0
+# Install Node.js 22.x
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nodejs=22.19.0-1nodesource1 && \
-    apt-mark hold nodejs && \
+    apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # Install latest yarn
@@ -71,6 +70,8 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
       postgresql-client \
       libpq-dev \
       tzdata \
+      curl \
+      gnupg2 \
       ca-certificates \
       libvips && \
     rm -rf /var/lib/apt/lists/*
@@ -78,11 +79,10 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
 # Set timezone
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-# Install Node.js 22.19.0 (runtime only)
+# Install Node.js 22.x (runtime only)
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nodejs=22.19.0-1nodesource1 && \
-    apt-mark hold nodejs && \
+    apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # Install yarn for runtime


### PR DESCRIPTION
## Summary
- Node.js 22.19.0-1nodesource1がNodeSourceリポジトリから削除されたため、特定バージョンの固定をやめてNode.js 22.xの最新版をインストールするように変更
- production stageでcurlとgnupg2が不足していたため追加

## Test plan
- [ ] Dockerビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Node.js のインストール設定を更新し、より柔軟なバージョン管理を実装しました。
  * 本番環境ランタイムの依存関係を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->