### PR TITLE
Cloud Build: エラー出力を表示するように修正

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -49,7 +49,7 @@ steps:
         
         while [ $$ELAPSED -lt $$TIMEOUT ]; do
           echo "Attempting database connection... ($$ELAPSED/$$TIMEOUT seconds)"
-          if cat <<'TESTEOF' | bin/rails runner - 2>/dev/null
+          OUTPUT=$$(cat <<'TESTEOF' | bin/rails runner - 2>&1
         begin
           ActiveRecord::Base.connection.execute("SELECT 1")
           puts "Database connection successful"
@@ -59,10 +59,14 @@ steps:
           exit 1
         end
         TESTEOF
-          then
+          )
+          EXITCODE=$$?
+          if [ $$EXITCODE -eq 0 ]; then
+            echo "$$OUTPUT"
             echo "Database connection verified, proceeding to terminate connections..."
             break
           else
+            echo "Rails runner output: $$OUTPUT"
             echo "Database not ready yet, waiting..."
           fi
           sleep 2


### PR DESCRIPTION
## Summary
- Cloud BuildのTerminateConnectionsステップで`bin/rails runner`が失敗している原因を特定するため、`2>/dev/null`をやめてエラーメッセージを出力するように変更

## Test plan
- [ ] マージ後にCloud Buildを実行してエラーメッセージを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* ビルドプロセスの出力キャプチャーとエラーハンドリングが改善されました。ビルド実行時のすべての出力とエラーメッセージがより正確に記録されるようになり、ビルドの失敗検出がより確実になり、ログ報告の精度が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->