### PR TITLE
Cloud Build: DBMigrateにAPP_HOST_NAMEを追加

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -155,6 +155,7 @@ steps:
       - DB_PASS=$_DB_PASS
       - DB_USER=$_DB_USER
       - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
+      - APP_HOST_NAME=$_APP_HOST_NAME
   - id: Kill_SqlProxy
     name: gcr.io/cloud-builders/docker
     entrypoint: sh


### PR DESCRIPTION
## Summary
- production.rbで`APP_HOST_NAME`が必須になっているため、DBMigrateステップでRailsが起動できなかった
- DBMigrateステップに`APP_HOST_NAME=$_APP_HOST_NAME`を追加

## Test plan
- [ ] マージ後にCloud Buildを実行してデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  - ステージング環境のビルド構成を更新しました。システムの安定性と配備プロセスの改善に関連する内部変更です。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->