### PR TITLE
pgcrypto拡張を有効化してgen_random_uuid()を利用可能に

### DIFF
--- a/db/migrate/20250828192201_create_good_jobs.rb
+++ b/db/migrate/20250828192201_create_good_jobs.rb
@@ -2,8 +2,8 @@
 
 class CreateGoodJobs < ActiveRecord::Migration[7.2]
   def change
-    # Uncomment for Postgres v12 or earlier to enable gen_random_uuid() support
-    # enable_extension 'pgcrypto'
+    # Enable pgcrypto extension for gen_random_uuid() support
+    enable_extension 'pgcrypto'
 
     create_table :good_jobs, id: :uuid do |t|
       t.text :queue_name


### PR DESCRIPTION
## Summary
- GoodJobマイグレーションでUUID型のプライマリキーを使用するために`pgcrypto`拡張を有効化
- Cloud SQLのPostgreSQLで`gen_random_uuid()`関数を使用可能に

## 問題
DBMigrateステップで以下のエラーが発生:
```
PG::UndefinedFunction: ERROR: function gen_random_uuid() does not exist
```

## 変更内容
`db/migrate/20250828192201_create_good_jobs.rb`で`enable_extension 'pgcrypto'`をコメント解除

## Test plan
- [ ] ステージング環境へのデプロイでDBMigrateステップが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **保守作業**
  * データベース拡張機能を有効化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->