### PR TITLE
フィクスチャの外部キー検証を無効化

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,10 @@ module Bootcamp
 
     config.active_storage.variant_processor = :vips
 
+    # Disable foreign key validation for fixtures
+    # Cloud SQL restricts access to pg_constraint system table
+    config.active_record.verify_foreign_keys_for_fixtures = false
+
     config.view_component.capture_compatibility_patch_enabled = true
 
     config.to_prepare do


### PR DESCRIPTION
## Summary
- Cloud SQLでdb:seedが失敗する問題を修正
- Rails 7.2の外部キー検証機能を無効化

## 問題
db:seedステップで以下のエラーが発生:
```
PG::InsufficientPrivilege: ERROR: permission denied for table pg_constraint
```

Rails 7.2ではフィクスチャ読み込み時に外部キー制約の検証を行いますが、
Cloud SQLでは`pg_constraint`システムテーブルへのアクセスが制限されています。

## 変更内容
`config/application.rb`に以下の設定を追加:
```ruby
config.active_record.verify_foreign_keys_for_fixtures = false
```

## Test plan
- [ ] ステージング環境へのデプロイでdb:seedが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **Chores**
  * フィクスチャの外部キー検証を無効化するための設定オプションを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->