### PR TITLE
DB削除前にCloud Runサービスを停止して接続を切断

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -23,6 +23,33 @@ steps:
       - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
     waitFor:
       - Build
+  # Cloud Runサービスを停止してDB接続を切断
+  # Cloud SQLでは管理者権限がないためpg_terminate_backendが使えない
+  # 代わりにCloud Runサービスを停止することで接続を確実に切断する
+  - id: StopCloudRun
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -euo pipefail
+        echo "Stopping Cloud Run service to disconnect database connections..."
+
+        # サービスが存在するか確認
+        if gcloud run services describe $_SERVICE_NAME --region=asia-northeast1 --quiet 2>/dev/null; then
+          # サービスのインスタンス数を0に設定して接続を切断
+          gcloud run services update $_SERVICE_NAME \
+            --region=asia-northeast1 \
+            --max-instances=0 \
+            --quiet
+
+          echo "Cloud Run service stopped. Waiting 30 seconds for connections to drain..."
+          sleep 30
+        else
+          echo "Cloud Run service does not exist yet. Skipping stop."
+        fi
+    waitFor:
+      - Push
   - id: SqlProxy
     name: 'gcr.io/cloudsql-docker/gce-proxy:1.16'
     args:
@@ -30,23 +57,23 @@ steps:
       - '-dir=/cloudsql'
       - '-instances=$_CLOUD_SQL_HOST'
     waitFor:
-      - '-'
+      - StopCloudRun
     volumes:
       - name: db
         path: /cloudsql
-  # 既存の接続を強制的に切断
-  - name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
+  # Cloud SQL Proxyの起動を待つ
+  - id: WaitForProxy
+    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
     args:
       - bash
       - '-c'
       - |
         set -euo pipefail
-        
-        # Cloud SQL Proxyの起動を待つ（最大60秒）
+
         echo "Waiting for Cloud SQL Proxy to be ready..."
         TIMEOUT=60
         ELAPSED=0
-        
+
         while [ $$ELAPSED -lt $$TIMEOUT ]; do
           echo "Attempting database connection... ($$ELAPSED/$$TIMEOUT seconds)"
           OUTPUT=$$(cat <<'TESTEOF' | bin/rails runner - 2>&1
@@ -63,8 +90,8 @@ steps:
           EXITCODE=$$?
           if [ $$EXITCODE -eq 0 ]; then
             echo "$$OUTPUT"
-            echo "Database connection verified, proceeding to terminate connections..."
-            break
+            echo "Cloud SQL Proxy is ready."
+            exit 0
           else
             echo "Rails runner output: $$OUTPUT"
             echo "Database not ready yet, waiting..."
@@ -72,25 +99,9 @@ steps:
           sleep 2
           ELAPSED=$$(($$ELAPSED + 2))
         done
-        
-        if [ $$ELAPSED -ge $$TIMEOUT ]; then
-          echo "ERROR: Timeout waiting for Cloud SQL Proxy to be ready after $$TIMEOUT seconds"
-          exit 1
-        fi
-        
-        # 接続を強制切断
-        echo "Terminating existing connections to bootcamp_staging database..."
-        cat <<'EOF' | bin/rails runner -
-        result = ActiveRecord::Base.connection.execute("
-          SELECT pg_terminate_backend(pid)
-          FROM pg_stat_activity
-          WHERE datname = 'bootcamp_staging'
-            AND pid <> pg_backend_pid()
-        ")
-        terminated_count = result.ntuples
-        puts "Terminated #{terminated_count} connection(s) to bootcamp_staging database"
-        EOF
-    id: TerminateConnections
+
+        echo "ERROR: Timeout waiting for Cloud SQL Proxy after $$TIMEOUT seconds"
+        exit 1
     waitFor:
       - Push
     volumes:
@@ -116,7 +127,7 @@ steps:
       - '--quiet'
     id: DeleteDB
     waitFor:
-      - TerminateConnections
+      - WaitForProxy
     entrypoint: gcloud
     volumes:
       - name: db


### PR DESCRIPTION
## Summary
- Cloud Runサービスを`--max-instances=0`で停止することで、DBへの接続を確実に切断
- Cloud SQLでは管理者権限がないため`pg_terminate_backend`が使えない問題を解決
- 30秒の待機時間で接続のドレインを確保

## 変更内容
1. **StopCloudRun**ステップを追加 - Push後、DB操作前にCloud Runサービスを停止
2. **TerminateConnections**を**WaitForProxy**に名称変更・簡略化 - pg_terminate_backendのロジックを削除
3. SqlProxyの開始をStopCloudRun完了後に変更
4. 依存関係を適切に更新

## 背景
誰かがステージング環境にアクセスしているとDB削除ができずにデプロイが失敗する問題が長年ありました。Cloud SQLでは管理者権限を持つユーザーになることができないため、`pg_terminate_backend`で接続を切断することができませんでした。

## 解決策
Cloud Runサービス自体を停止することで、アプリケーションからのDB接続を確実に切断します。

## Test plan
- [ ] ステージング環境へのデプロイが成功することを確認
- [ ] 誰かがアクセス中でもデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データベース接続管理とサービス停止のシーケンスを最適化しました。
  * クラウドインフラストラクチャのデプロイメントワークフローを改善し、信頼性と接続処理の堅牢性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->