### PR TITLE
WaitForProxyの依存関係をStopCloudRunに修正

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -103,7 +103,7 @@ steps:
         echo "ERROR: Timeout waiting for Cloud SQL Proxy after $$TIMEOUT seconds"
         exit 1
     waitFor:
-      - Push
+      - StopCloudRun
     volumes:
       - name: db
         path: /cloudsql


### PR DESCRIPTION
## Summary
- WaitForProxyステップの`waitFor`を`Push`から`StopCloudRun`に変更
- SqlProxyとWaitForProxyが同時に開始されるように修正

## 問題
WaitForProxyが`Push`完了後に開始されていたため、SqlProxyより先に実行されてしまい、DB接続が確立できずタイムアウトしていた。

## 解決策
WaitForProxyの`waitFor`を`StopCloudRun`に変更することで、SqlProxyと同時に開始されるようにした。これにより、SqlProxyが起動しながらWaitForProxyが接続を待つことができる。

## Test plan
- [ ] ステージング環境へのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **修正（Chores）**
  * ステージング環境のデプロイメント処理における同期順序を改善し、クラウドサービス間の連携信頼性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->