### PR TITLE
Cloud Runサービスを削除して接続を切断するように変更

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -23,9 +23,9 @@ steps:
       - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
     waitFor:
       - Build
-  # Cloud Runサービスを停止してDB接続を切断
+  # Cloud Runサービスを削除してDB接続を切断
   # Cloud SQLでは管理者権限がないためpg_terminate_backendが使えない
-  # 代わりにCloud Runサービスを停止することで接続を確実に切断する
+  # サービスを削除することで接続を確実に切断し、Deployで再作成される
   - id: StopCloudRun
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     entrypoint: bash
@@ -33,20 +33,18 @@ steps:
       - '-c'
       - |
         set -euo pipefail
-        echo "Stopping Cloud Run service to disconnect database connections..."
+        echo "Deleting Cloud Run service to disconnect database connections..."
 
-        # サービスが存在するか確認
+        # サービスが存在するか確認して削除
         if gcloud run services describe $_SERVICE_NAME --region=asia-northeast1 --quiet 2>/dev/null; then
-          # サービスのインスタンス数を0に設定して接続を切断
-          gcloud run services update $_SERVICE_NAME \
+          gcloud run services delete $_SERVICE_NAME \
             --region=asia-northeast1 \
-            --max-instances=0 \
             --quiet
 
-          echo "Cloud Run service stopped. Waiting 30 seconds for connections to drain..."
-          sleep 30
+          echo "Cloud Run service deleted. Waiting 10 seconds for connections to close..."
+          sleep 10
         else
-          echo "Cloud Run service does not exist yet. Skipping stop."
+          echo "Cloud Run service does not exist yet. Skipping delete."
         fi
     waitFor:
       - Push


### PR DESCRIPTION
## Summary
- `--max-instances=0`を`gcloud run services delete`に変更
- サービスを削除することで、DB接続を確実に切断

## 問題
`--max-instances=0`は無効な値で、Cloud Runの`autoscaling.knative.dev/maxScale`アノテーションは正の整数が必要だった。

## 解決策
`gcloud run services delete`でサービスを完全に削除し、Deployステップで再作成されるようにした。
これにより、DB接続が確実に切断される。

## Test plan
- [ ] ステージング環境へのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cloud Run サービスの動作を停止から完全削除に変更。データベース接続の確実な切断を実現。ユーザーメッセージを更新し、デプロイメント後の待機時間を短縮。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->