### PR TITLE
Uncaught runtime errors が表示されないようにする

### DIFF
--- a/app/javascript/product-checker.js
+++ b/app/javascript/product-checker.js
@@ -22,8 +22,6 @@ export class ProductChecker {
     } else {
       this.generateAssigneeDisplay()
     }
-    event.currentTarget.children[0].className = 'fas fa-times'
-    event.currentTarget.children[0].textContent = '担当から外れる'
   }
 
   updateButton(button, isAssigned) {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要

http://localhost:3000/products/unassigned にアクセスすると添付画像の警告が表示されるバグを解消。

<img width="1540" height="767" alt="error" src="https://github.com/user-attachments/assets/8e001db6-ec6a-4232-97a0-1cd74b93f641" />

- 原因: #9278 でコンフリクト解消時に不要なコードが含まれていたため
- やったこと: 不要部分を削除

## 変更確認方法

1. hotfix/eslint-ecma2022をローカルに取り込む
2. http://localhost:3000/products/unassigned にアクセスして警告が表示されないことを確認

<!-- I want to review in Japanese. -->