### PR TITLE
product-checkerのundefined event参照エラーを修正

### DIFF
--- a/app/javascript/product-checker.js
+++ b/app/javascript/product-checker.js
@@ -22,8 +22,6 @@ export class ProductChecker {
     } else {
       this.generateAssigneeDisplay()
     }
-    event.currentTarget.children[0].className = 'fas fa-times'
-    event.currentTarget.children[0].textContent = '担当から外れる'
   }
 
   updateButton(button, isAssigned) {


### PR DESCRIPTION
## Summary
- `/products/unassigned`ページでのJavaScriptエラーを修正
- `initProductChecker`メソッド内の未定義`event`変数参照を削除

## 問題
`initProductChecker`メソッド内で`event.currentTarget`を参照していたが、このメソッドはイベントハンドラーではなく初期化時に呼ばれるため、`event`変数が未定義でエラーになっていた。

```
TypeError: Cannot read properties of undefined (reading 'currentTarget')
```

## 解決策
不要なコード（`event.currentTarget.children[0].className`と`event.currentTarget.children[0].textContent`の設定）を削除。

## Test plan
- [ ] `/products/unassigned`ページにアクセスしてエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 製品チェッカーの初期化時に、ボタンの表示ラベルとアイコンが自動で上書きされる動作を削除しました。起動時の意図しない表示変更を防ぎ、既存の動作フローを保持します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->