### PR TITLE
CircleCIでRerun failed tests機能を有効化

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,7 @@ jobs:
       - run:
           name: Test
           command: |
-            TEST_FILES=$(circleci tests glob "test/**/*_test.rb" | circleci tests split --split-by=timings --timings-type=filename)
-            bundle exec rails test $TEST_FILES
+            circleci tests glob "test/**/*_test.rb" | circleci tests run --command="xargs bundle exec rails test" --verbose --split-by=timings --timings-type=filename
       - store_test_results:
           path: test/reports
       - store_artifacts:


### PR DESCRIPTION
## Summary
- CircleCIのRerun failed tests機能を有効にするため設定を変更
- `circleci tests split`から`circleci tests run`に変更

## 変更内容
```diff
- TEST_FILES=$(circleci tests glob "test/**/*_test.rb" | circleci tests split --split-by=timings --timings-type=filename)
- bundle exec rails test $TEST_FILES
+ circleci tests glob "test/**/*_test.rb" | circleci tests run --command="xargs bundle exec rails test" --verbose --split-by=timings --timings-type=filename
```

## 効果
テスト失敗時に「Rerun failed tests」ボタンが使えるようになり、失敗したテストのみを再実行できる。
これにより、flaky testsの対応やデバッグが効率的になる。

## 参考
- https://circleci.com/docs/guides/test/rerun-failed-tests/

## Test plan
- [ ] CircleCIでテストが正常に実行されることを確認
- [ ] テスト失敗時にRerun failed testsが利用可能になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDテスト実行パイプラインの内部処理を最適化しました。

---

**ユーザー向け変更なし** - このリリースは内部インフラストラクチャの改善のみを含んでいます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->