### PR TITLE
Staging環境のDB削除にリトライロジックを追加

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -114,19 +114,36 @@ steps:
       - DB_USER=$_DB_USER
       - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
       - APP_HOST_NAME=$_APP_HOST_NAME
-  # データベースを削除
+  # データベースを削除（リトライ付き）
+  # WaitForProxyの接続がCloud SQL Proxy経由で残っている場合があるため、
+  # 接続が切れるまでリトライする
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    args:
-      - sql
-      - databases
-      - delete
-      - bootcamp_staging
-      - '--instance=bootcamp'
-      - '--quiet'
     id: DeleteDB
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -euo pipefail
+        MAX_RETRIES=5
+        RETRY_DELAY=5
+
+        for i in $$(seq 1 $$MAX_RETRIES); do
+          echo "Attempt $$i/$$MAX_RETRIES: Deleting database bootcamp_staging..."
+          if gcloud sql databases delete bootcamp_staging --instance=bootcamp --quiet 2>&1; then
+            echo "Database deleted successfully."
+            exit 0
+          else
+            if [ $$i -lt $$MAX_RETRIES ]; then
+              echo "Database delete failed (likely still has connections). Waiting $$RETRY_DELAY seconds before retry..."
+              sleep $$RETRY_DELAY
+            fi
+          fi
+        done
+
+        echo "ERROR: Failed to delete database after $$MAX_RETRIES attempts."
+        exit 1
     waitFor:
       - WaitForProxy
-    entrypoint: gcloud
     volumes:
       - name: db
         path: /cloudsql


### PR DESCRIPTION
## Summary
- Staging環境デプロイ時のDeleteDBステップが「database is being accessed by other users」エラーで失敗する問題を修正
- WaitForProxyステップの接続がCloud SQL Proxy経由で残っている場合があるため、5回まで5秒間隔でリトライするロジックを追加

## 原因
1. WaitForProxyステップが`postgres`データベースに接続してCloud SQL Proxyの起動確認を実行
2. 接続確認後、Railsプロセスは終了するが、Cloud SQL Proxyの接続プールが残る場合がある
3. DeleteDBステップが`bootcamp_staging`を削除しようとした際、他の接続が残っていてエラーになる

## Test plan
- [ ] Stagingブランチにマージしてデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善 (Chores)**
  * ステージング環境のデプロイメント信頼性を向上させました。データベース削除プロセスに再試行メカニズムを追加し、接続の問題が発生した場合でも確実に完了するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->