### PR TITLE
ステージング環境のAPP_HOST_NAMEをsubstitutionsで設定

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -265,3 +265,5 @@ steps:
 timeout: 7200s
 images:
   - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
+substitutions:
+  _APP_HOST_NAME: bootcamp-staging.fjord.jp


### PR DESCRIPTION
## Summary
- Cloud BuildのDBMigrateステップで`APP_HOST_NAME`環境変数が設定されておらずエラーになる問題を修正
- `cloudbuild-staging.yaml`にsubstitutionsセクションを追加し、`_APP_HOST_NAME`のデフォルト値を設定

## 変更内容
```yaml
substitutions:
  _APP_HOST_NAME: bootcamp-staging.fjord.jp
```

## Test plan
- [ ] ステージング環境でDBMigrateが成功することを確認
- [ ] ステージング環境でアプリケーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **メンテナンス**
  * ステージング環境のデプロイメント設定を改善し、環境変数の置換機能が正常に機能するようになりました。これにより、デプロイメント時の設定値がより確実に反映されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->