### PR TITLE
本番環境のAPP_HOST_NAMEをsubstitutionsで設定

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -135,3 +135,5 @@ steps:
 timeout: 7200s
 images:
   - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
+substitutions:
+  _APP_HOST_NAME: bootcamp.fjord.jp


### PR DESCRIPTION
## Summary
- 本番環境のCloud BuildでもDBMigrateステップで`APP_HOST_NAME`が設定されておらずエラーになる問題を修正
- ステージング環境と同様に`cloudbuild.yaml`にsubstitutionsセクションを追加

## 変更内容
```yaml
substitutions:
  _APP_HOST_NAME: bootcamp.fjord.jp
```

## 関連PR
- #9376 ステージング環境の同様の修正

## Test plan
- [ ] 本番環境でDBMigrateが成功することを確認
- [ ] 本番環境でアプリケーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストにはユーザー向けの新機能やバグ修正が含まれていません。ビルド・デプロイプロセスの構成が改善されました。

* **Chores**
  * ビルド構成を更新し、デプロイ時の環境設定を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->