### PR TITLE
DB_MigrateステップにAPP_HOST_NAME環境変数を追加

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -52,6 +52,7 @@ steps:
       - DB_PASS=$_DB_PASS
       - DB_USER=$_DB_USER
       - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
+      - APP_HOST_NAME=$_APP_HOST_NAME
   - id: Kill_SqlProxy
     name: gcr.io/cloud-builders/docker
     entrypoint: sh


### PR DESCRIPTION
## Summary
- 本番環境のCloud BuildのDB_Migrateステップで`APP_HOST_NAME`環境変数が渡されていなかった問題を修正
- substitutionsで`_APP_HOST_NAME`を設定しても、DB_Migrateステップのenv設定に含まれていなかったためエラーが発生

## 変更内容
```yaml
env:
  - RAILS_ENV=production
  ...
  - APP_HOST_NAME=$_APP_HOST_NAME  # 追加
```

## 関連PR
- #9376 ステージング環境のsubstitutions追加
- #9378 本番環境のsubstitutions追加

## Test plan
- [ ] 本番環境でDBMigrateが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このリリースにはエンドユーザーに対する可視的な変更はありません。内部ビルド構成の最適化が行われました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->