### PR TITLE
good_jobsテーブルが既に存在する場合はマイグレーションをスキップ

### DIFF
--- a/db/migrate/20250828192201_create_good_jobs.rb
+++ b/db/migrate/20250828192201_create_good_jobs.rb
@@ -2,6 +2,9 @@
 
 class CreateGoodJobs < ActiveRecord::Migration[7.2]
   def change
+    # Skip if good_jobs table already exists (e.g., created manually before this migration)
+    return if table_exists?(:good_jobs)
+
     # Enable pgcrypto extension for gen_random_uuid() support
     enable_extension 'pgcrypto'
 


### PR DESCRIPTION
## Summary
- 本番環境で`good_jobs`テーブルが既に存在するが、マイグレーション履歴（schema_migrations）に記録されていなかったためエラーが発生
- `table_exists?(:good_jobs)`でチェックし、既に存在する場合はマイグレーション全体をスキップするように修正

## エラー内容
```
PG::DuplicateTable: ERROR:  relation "good_jobs" already exists
```

## 変更内容
```ruby
def change
  # Skip if good_jobs table already exists
  return if table_exists?(:good_jobs)
  # ...
end
```

## Test plan
- [ ] 本番環境でDBMigrateが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* データベースマイグレーションの堅牢性が向上しました。既存のテーブルを確認してから処理を進めるようになり、複数回の実行でもエラーが発生しにくくなります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->