### PR TITLE
[hotfix] good_jobsテーブルに不足しているカラムを追加

### DIFF
--- a/db/migrate/20251220000001_add_missing_columns_to_good_jobs.rb
+++ b/db/migrate/20251220000001_add_missing_columns_to_good_jobs.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class AddMissingColumnsToGoodJobs < ActiveRecord::Migration[7.2]
+  def change
+    # Add missing columns to good_jobs table if they don't exist
+    add_column :good_jobs, :error_event, :integer, limit: 2 unless column_exists?(:good_jobs, :error_event)
+    add_column :good_jobs, :labels, :text, array: true unless column_exists?(:good_jobs, :labels)
+    add_column :good_jobs, :locked_by_id, :uuid unless column_exists?(:good_jobs, :locked_by_id)
+    add_column :good_jobs, :locked_at, :datetime unless column_exists?(:good_jobs, :locked_at)
+    add_column :good_jobs, :is_discrete, :boolean unless column_exists?(:good_jobs, :is_discrete)
+    add_column :good_jobs, :executions_count, :integer unless column_exists?(:good_jobs, :executions_count)
+    add_column :good_jobs, :job_class, :text unless column_exists?(:good_jobs, :job_class)
+    add_column :good_jobs, :batch_id, :uuid unless column_exists?(:good_jobs, :batch_id)
+    add_column :good_jobs, :batch_callback_id, :uuid unless column_exists?(:good_jobs, :batch_callback_id)
+
+    # Add missing indexes
+    unless index_exists?(:good_jobs, :labels, name: 'index_good_jobs_on_labels')
+      add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)", name: :index_good_jobs_on_labels
+    end
+
+    unless index_exists?(:good_jobs, :locked_by_id, name: 'index_good_jobs_on_locked_by_id')
+      add_index :good_jobs, :locked_by_id, where: "locked_by_id IS NOT NULL", name: "index_good_jobs_on_locked_by_id"
+    end
+
+    unless index_exists?(:good_jobs, :batch_id, name: 'index_good_jobs_on_batch_id')
+      add_index :good_jobs, [:batch_id], where: "batch_id IS NOT NULL", name: 'index_good_jobs_on_batch_id'
+    end
+
+    unless index_exists?(:good_jobs, :batch_callback_id, name: 'index_good_jobs_on_batch_callback_id')
+      add_index :good_jobs, [:batch_callback_id], where: "batch_callback_id IS NOT NULL", name: 'index_good_jobs_on_batch_callback_id'
+    end
+
+    unless index_exists?(:good_jobs, :job_class, name: 'index_good_jobs_on_job_class')
+      add_index :good_jobs, :job_class, name: :index_good_jobs_on_job_class
+    end
+
+    unless index_exists?(:good_jobs, [:priority, :scheduled_at], name: 'index_good_jobs_on_priority_scheduled_at_unfinished_unlocked')
+      add_index :good_jobs, [:priority, :scheduled_at], order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+        where: "finished_at IS NULL AND locked_by_id IS NULL", name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- 本番環境の`good_jobs`テーブルが古いスキーマで作成されていたため、`error_event`等のカラムが存在せずエラーが発生
- 不足している可能性のあるカラムとインデックスを条件付きで追加するマイグレーションを作成

## エラー内容
```
Undeclared attribute type for enum 'error_event' in GoodJob::Job.
Enums must be backed by a database column or declared with an explicit type via `attribute`.
```

## 追加するカラム（存在しない場合のみ）
- `error_event` (integer)
- `labels` (text[])
- `locked_by_id` (uuid)
- `locked_at` (datetime)
- `is_discrete` (boolean)
- `executions_count` (integer)
- `job_class` (text)
- `batch_id` (uuid)
- `batch_callback_id` (uuid)

## 動作確認
- [x] ローカル環境でマイグレーション実行確認（既存カラムはスキップ）
- [x] ロールバック・再実行の動作確認
- [x] テスト実行確認

## Test plan
- [ ] 本番環境でマイグレーションが成功することを確認
- [ ] エラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)