### PR TITLE
[hotfix] Active Storageの古いURLを読み取れるように修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,10 @@ module Bootcamp
 
     config.active_storage.variant_processor = :vips
 
+    # Allow reading legacy Active Storage URLs that were signed with Marshal serializer
+    # Rails 7.2 defaults to :json, which cannot read old URLs
+    config.active_support.message_serializer = :json_allow_marshal
+
     # Disable foreign key validation for fixtures
     # Cloud SQL restricts access to pg_constraint system table
     config.active_record.verify_foreign_keys_for_fixtures = false


### PR DESCRIPTION
## Summary
- Rails 7.2へのアップデート後、古いActive Storage画像URLがリンク切れになっている問題を修正
- `config.active_support.message_serializer = :json_allow_marshal`を設定

## 原因
Rails 7.2では`message_serializer`のデフォルトが`:json`に変更されました。
古いActive Storage URLは`Marshal`形式で署名されていたため、新しいRailsバージョンでは読み取れなくなっていました。

## 修正内容
`:json_allow_marshal`を設定することで、新しいJSON形式で署名しつつ、古いMarshal形式のURLも読み取れるようにしました。

## 影響を受けていたURL例
```
https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM29sQkE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--abaf45a9d99f317c2102ead6cf6e6617c5d1b9dd/image.png
```

## Test plan
- [ ] 本番環境でデプロイ後、上記URLで画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)