### PR TITLE
Active Storageの古いURLを読み取れるように修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,10 @@ module Bootcamp
 
     config.active_storage.variant_processor = :vips
 
+    # Allow reading legacy Active Storage URLs that were signed with Marshal serializer
+    # Rails 7.2 defaults to :json, which cannot read old URLs
+    config.active_support.message_serializer = :json_allow_marshal
+
     # Disable foreign key validation for fixtures
     # Cloud SQL restricts access to pg_constraint system table
     config.active_record.verify_foreign_keys_for_fixtures = false


### PR DESCRIPTION
## Summary
- Rails 7.2へのアップデート後、古いActive Storage画像URLがリンク切れになっている問題を修正
- `config.active_support.message_serializer = :json_allow_marshal`を設定

## 原因
Rails 7.2では`message_serializer`のデフォルトが`:json`に変更されました。
古いActive Storage URLは`Marshal`形式で署名されていたため、新しいRailsバージョンでは読み取れなくなっていました。

## 修正内容
`:json_allow_marshal`を設定することで、新しいJSON形式で署名しつつ、古いMarshal形式のURLも読み取れるようにしました。

## 関連PR
- #9407 production向けhotfix

## Test plan
- [ ] CIが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の変更**
  * アプリケーション設定を更新し、既存のデータ形式が継続してサポートされるようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->