### PR TITLE
key_generator_hash_digest_classをSHA1に設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,10 @@ module Bootcamp
     # Rails 7.2 defaults to :json, which cannot read old URLs
     config.active_support.message_serializer = :json_allow_marshal
 
+    # Use SHA1 for key generator to support legacy Active Storage URLs
+    # Old URLs were signed with SHA1-based keys
+    config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
+
     # Disable foreign key validation for fixtures
     # Cloud SQL restricts access to pg_constraint system table
     config.active_record.verify_foreign_keys_for_fixtures = false


### PR DESCRIPTION
## Summary
- 前回のPR（#9408）で`message_serializer`を設定しましたが、まだ画像が表示されない問題を修正
- `key_generator_hash_digest_class`を`SHA1`に設定

## 原因
古いActive Storage URLは、SHA1ベースの鍵で署名されていました。
Rails 7.0以降のデフォルトはSHA256のため、古いURLの署名検証が失敗していました。

## 修正内容
```ruby
config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
```

## 関連PR
- #9410 production向けhotfix

## Test plan
- [ ] CIが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **互換性向上**
  * SHA1ベースのキーを使用して署名されたレガシーなActive Storage URLのサポートを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->