### PR TITLE
GoodJobの不足しているテーブルを追加

### DIFF
--- a/db/migrate/20251223000001_add_missing_good_job_tables.rb
+++ b/db/migrate/20251223000001_add_missing_good_job_tables.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class AddMissingGoodJobTables < ActiveRecord::Migration[7.2]
+  def change
+    # Create good_job_batches table if it doesn't exist
+    unless table_exists?(:good_job_batches)
+      create_table :good_job_batches, id: :uuid do |t|
+        t.timestamps
+        t.text :description
+        t.jsonb :serialized_properties
+        t.text :on_finish
+        t.text :on_success
+        t.text :on_discard
+        t.text :callback_queue_name
+        t.integer :callback_priority
+        t.datetime :enqueued_at
+        t.datetime :discarded_at
+        t.datetime :finished_at
+        t.datetime :jobs_finished_at
+      end
+    end
+
+    # Create good_job_executions table if it doesn't exist
+    unless table_exists?(:good_job_executions)
+      create_table :good_job_executions, id: :uuid do |t|
+        t.timestamps
+
+        t.uuid :active_job_id, null: false
+        t.text :job_class
+        t.text :queue_name
+        t.jsonb :serialized_params
+        t.datetime :scheduled_at
+        t.datetime :finished_at
+        t.text :error
+        t.integer :error_event, limit: 2
+        t.text :error_backtrace, array: true
+        t.uuid :process_id
+        t.interval :duration
+      end
+
+      add_index :good_job_executions, [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+      add_index :good_job_executions, [:process_id, :created_at], name: :index_good_job_executions_on_process_id_and_created_at
+    end
+
+    # Create good_job_processes table if it doesn't exist
+    unless table_exists?(:good_job_processes)
+      create_table :good_job_processes, id: :uuid do |t|
+        t.timestamps
+        t.jsonb :state
+        t.integer :lock_type, limit: 2
+      end
+    end
+
+    # Create good_job_settings table if it doesn't exist
+    unless table_exists?(:good_job_settings)
+      create_table :good_job_settings, id: :uuid do |t|
+        t.timestamps
+        t.text :key
+        t.jsonb :value
+      end
+      add_index :good_job_settings, :key, unique: true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `good_job_batches`, `good_job_executions`, `good_job_processes`, `good_job_settings` テーブルを追加
- 既存の `good_jobs` テーブルが存在したため、`CreateGoodJobs` マイグレーションがスキップされ、これらのテーブルが作成されていなかった

## 問題
- GoodJobダッシュボードの Processes タブで500エラーが発生
- キューにジョブが溜まっているが実行されない
- サイト内通知が作成されない

## 原因
`20250828192201_create_good_jobs.rb` の最初に `return if table_exists?(:good_jobs)` があり、本番環境で `good_jobs` テーブルが既に存在していたため、マイグレーション全体がスキップされていた。

## Test plan
- [ ] マイグレーション実行後、GoodJobダッシュボードのProcessesタブが正常に表示される
- [ ] ジョブが正常に実行される
- [ ] Q&A投稿時にサイト内通知が作成される
- [ ] お知らせ投稿時にサイト内通知が作成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)