### PR TITLE
good_job_processesテーブルにlock_typeカラムを追加

### DIFF
--- a/db/migrate/20251223000002_add_lock_type_to_good_job_processes.rb
+++ b/db/migrate/20251223000002_add_lock_type_to_good_job_processes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddLockTypeToGoodJobProcesses < ActiveRecord::Migration[7.2]
+  def change
+    return unless table_exists?(:good_job_processes)
+    return if column_exists?(:good_job_processes, :lock_type)
+
+    add_column :good_job_processes, :lock_type, :integer, limit: 2
+  end
+end


### PR DESCRIPTION
## Summary
- `good_job_processes`テーブルに`lock_type`カラムを追加

## 問題
GoodJobダッシュボードのProcessesタブで以下のエラーが発生:
```
RuntimeError: Undeclared attribute type for enum 'lock_type' in GoodJob::Process
```

## 原因
`good_job_processes`テーブルが古いバージョンのGoodJobで作成されていたため、`lock_type`カラムが存在しなかった。

## Test plan
- [ ] マイグレーション実行後、GoodJobダッシュボードのProcessesタブが正常に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)