### PR TITLE
Stripe Billing Portalへのリダイレクトを修正

### DIFF
--- a/app/controllers/billing_portal_controller.rb
+++ b/app/controllers/billing_portal_controller.rb
@@ -3,6 +3,6 @@
 class BillingPortalController < ApplicationController
   def create
     session = Stripe::BillingPortal::Session.create(customer: current_user.customer_id)
-    redirect_to session.url
+    redirect_to session.url, allow_other_host: true
   end
 end


### PR DESCRIPTION
## Summary
- `redirect_to`に`allow_other_host: true`を追加

## 問題
```
ActionController::Redirecting::UnsafeRedirectError: Unsafe redirect to "https://billing.stripe.com/..."
```

## 原因
Rails 7.2で外部ホストへのリダイレクトにはセキュリティ対策として`allow_other_host: true`オプションが必要になった。

## Test plan
- [ ] Stripe Billing Portalへの遷移が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)