### PR TITLE
Prettier実行時のglob展開が環境に依存しないようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "lint": "run-p lint:*",
     "lint:eslint": "eslint 'app/javascript/**/*.{js,jsx}' --max-warnings=0",
-    "lint:prettier": "prettier app/javascript/**/*.{js,jsx} --check"
+    "lint:prettier": "prettier 'app/javascript/**/*.{js,jsx}' --check"
   },
   "dependencies": {
     "@babel/core": "^7.23.7",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9469

## 概要

Prettierの実行コマンド中でglobパターンを引用符で囲んでいなかったため、シェル（`bin/sh`）がglob展開を実行しており、実行環境によっては意図した通りに展開されていなかった。
引用符で囲むようにしたことでglobの展開主体が実行環境によらずPrettier（内部的に`node-glob`を使用してglob展開を実行）に統一されるようにした。

### 補足

修正前は`bin/sh`がBashバージョン4.0より前を指す環境では`app/javascript/**/*.{js,jsx}`が`app/javascript/*/*.{js,jsx}`と解釈されていた。
そのため、`app/javascript/`直下のJavaScriptファイルなどがPrettierの対象外となっていて、検出されるべきエラーが検出されていなかった。

参考
- [Why you should always quote your globs in NPM scripts\. \| by Jakub Synowiec \| Medium](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784)
- [CLI · Prettier](https://prettier.io/docs/cli)

## 変更確認方法

1. `chore/fix-inconsistent-glob-expansion-in-lint`をローカルに取り込む
2. `app/javascript/action_completed_button.js`の適当な行末に`;`を追記する
    - `app/javascript/**/*.{js,jsx}`にマッチして`app/javascript/*/*.{js,jsx}`にはマッチしないファイルであれば何でも良い
    - 加える変更はPrettierで検出されるものであれば何でも良い
3. ターミナル上で`bin/yarn lint`を実行すると2でlintエラーを混入させたファイルにエラーが検出されることを確認する

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リント処理の構成を改善し、ゴブパターンのシェル展開を防ぐために処理スクリプトを更新しました。

---

**注:** この変更は内部開発プロセスの改善であり、ユーザー向け機能への直接的な影響はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->