### PR TITLE
スキーマファイルから不要な行を削除

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -265,9 +265,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_07_000002) do
     t.index ["course_id", "category_id"], name: "index_courses_categories_on_course_id_and_category_id", unique: true
   end
 
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
-  end
-
   create_table "discord_profiles", force: :cascade do |t|
     t.string "account_name"
     t.datetime "created_at", null: false


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9307
- https://github.com/fjordllc/bootcamp/issues/9475

## 概要

スキーマファイル（`db/schema.rb`）の2箇所の不備を修正してマイグレーションファイルとの不整合を解消した。
詳細はIssueを参照。

### 補足

既存のプロダクションコードとテストコードに`users`テーブルの`job_seeking`カラムに依存した箇所はなかった。
リポジトリ内に`job_seeking`という変数は以下の2つに関連したものとして見つかるが、元々存在していた`users`テーブルの`job_seeking`カラム（卒業生が就職活動中かどうかを表すブール値）に依存したものではない。

- `users`テーブルの`career_path`カラムのenum値としての`job_seeking`
- ユーザーを就職希望かどうかで絞り込むためのパラメータとしての`job_seeking`（https://github.com/fjordllc/bootcamp/pull/8737 で追加された機能。`users`テーブルの`job_seeker`カラムに依存）

## 変更確認方法

UI、振る舞い、ロジックの変更はない。
Issueに記載されている不要な行（マイグレーションをやり直すと削除される行）が`db/schema.rb`から削除されていることをFiles changedを見て確認する。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **チョア**
  * ユーザー情報から職務経歴に関連するカラム（job_seeking）を削除しました。
  * 不要なデータベーステーブル（データ移行用テーブル）を削除してスキーマを整理しました。

<sub>✏️ Tip: この高レベル概要はレビュー設定でカスタマイズできます。</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->