### PR TITLE
commentsテーブルの重複したインデックスを削除

### DIFF
--- a/db/migrate/20260107094500_remove_comment_user_id_index_from_comments.rb
+++ b/db/migrate/20260107094500_remove_comment_user_id_index_from_comments.rb
@@ -1,0 +1,7 @@
+class RemoveCommentUserIdIndexFromComments < ActiveRecord::Migration[7.2]
+  def change
+    # このインデックスを追加したマイグレーションファイルは存在しない
+    # マイグレーションをやり直せるようにするために`if_exists: true`が必要
+    remove_index :comments, :user_id, name: 'comment_user_id', if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_07_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_07_094500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -216,7 +216,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_07_000002) do
     t.datetime "updated_at", precision: nil
     t.integer "user_id"
     t.index ["commentable_id"], name: "index_comments_on_commentable_id"
-    t.index ["user_id"], name: "comment_user_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9473

## 概要

`comments`テーブルの`user_id`カラムに対して`comment_user_id`と`index_comments_on_user_id`の2つのインデックスが存在していた。
`comment_user_id`はマイグレーションファイルを使用せずに追加された可能性が高い。
詳細はIssueを参照。

- 冗長なインデックスを削除する
- マイグレーションファイルとスキーマファイルを整合させる

ために`comment_user_id`のインデックスを削除するマイグレーションファイルを作成した。

## 変更確認方法

UI、振る舞い、ロジックの変更はない。

Files changedの`db/schema.rb`のdiffを見て`comment_user_id`のインデックスだけが削除されていることを確認する。

念のため、`comments`テーブルについてマイグレーションファイルとスキーマファイルが整合していることを以下の手順で確認する。

1. `chore/remove-duplicate-comment-user-index`をローカルに取り込む
2. マイグレーションを最初からやり直す

```
bin/rails db:migrate:reset
```

3. `db/schema.rb`の`comments`テーブルの箇所に変更が生じていないことを確認する

※`comments`テーブル以外の不整合は本PRでは解消していないため変更自体は多数生じることに注意。
※確認後は以下の手順でローカルのDBをあるべき状態に戻す。

1. `git restore .`で変更を戻す
2. `bin/rails db:reset`を実行する

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **その他（Chores）**
  * データベーススキーマの最適化を行いました。冗長なインデックスを整理してスキーマを更新し、システムのパフォーマンスと保守性を向上させます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->