### PR TITLE
ShakapackerのNode modules bin pathを設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY . ./
 
 # Compile assets (now with devDependencies available)
 ENV RAILS_LOG_TO_STDOUT true
+ENV SHAKAPACKER_NODE_MODULES_BIN_PATH ./node_modules/.bin
 RUN SECRET_KEY_BASE=dummy bundle exec rails assets:precompile
 
 # Production stage - minimal runtime image


### PR DESCRIPTION
## Summary
- Cloud Buildでshakapackerが`yarn bin`を実行しようとしてエラーになる問題を修正

## Changes
- `SHAKAPACKER_NODE_MODULES_BIN_PATH`環境変数を設定して、yarnを使わずにnode_modules/.binを直接参照

## Context
shakapackerは`yarn bin`コマンドでnode_modules/.binのパスを取得しようとするが、
yarnがインストールされていないため失敗していた。
環境変数で直接パスを指定することでyarnへの依存を回避。

## Test plan
- [ ] Cloud Buildが正常に完了すること