### PR TITLE
お知らせ通知の順序を変更: サイト内通知を先に実行

### DIFF
--- a/app/jobs/post_announcement_job.rb
+++ b/app/jobs/post_announcement_job.rb
@@ -5,8 +5,8 @@ class PostAnnouncementJob < ApplicationJob
 
   def perform(announcement, receivers)
     receivers.each do |receiver|
-      send_mail_notification(announcement, receiver)
       send_on_site_notification(announcement, receiver)
+      send_mail_notification(announcement, receiver)
     end
   end
 


### PR DESCRIPTION
## Summary
- メール送信エラーが発生してもサイト内通知が確実に作成されるように修正

## Changes
- `PostAnnouncementJob` の実行順序を変更
  - Before: メール通知 → サイト内通知
  - After: サイト内通知 → メール通知

## Background
Postmarkで非アクティブな受信者にメール送信しようとするとエラーが発生し、
メール送信とサイト内通知が連動していたため、サイト内通知も作成されない問題があった。

## Test plan
- [ ] お知らせを作成し、サイト内通知が作成されることを確認
- [ ] メール送信エラーが発生してもサイト内通知は作成されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * お知らせ通知の配信順序を改善しました。サイト内通知がメール通知より前に配信されるようになります。

---

**単語数**: 23語

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->