### PR TITLE
Discordのみんなの日報に「今日の気分」の絵文字を載せる

### DIFF
--- a/app/models/report_notifier.rb
+++ b/app/models/report_notifier.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ReportNotifier
+  EMOTION_EMOJIS = { 'positive' => '😄',
+                     'neutral' => '🙂',
+                     'negative' => '😰' }.freeze
+
   def call(_name, _started, _finished, _unique_id, payload)
     report = payload[:report]
     Cache.delete_unchecked_report_count
@@ -26,7 +30,7 @@ class ReportNotifier
   def notify_to_chat(report)
     ChatNotifier.message(<<~TEXT, webhook_url: ENV['DISCORD_REPORT_WEBHOOK_URL'])
       #{report.user.login_name}さんが#{I18n.l report.reported_on}の日報を公開しました。
-      タイトル：「#{report.title}」
+      タイトル：#{EMOTION_EMOJIS[report.emotion]}「#{report.title}」
       URL： <https://bootcamp.fjord.jp/reports/#{report.id}>
     TEXT
   end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/8810

## 概要
日報を作成した際、Discordの「みんなの日報」チャンネルにユーザー名、日にち、日報のタイトルが通知されます。
その通知の日報タイトル前に「今日の気分」の絵文字😰🙂😄が表示されるようにしました。



## 変更確認方法

1. `feature/display-emotion-emojis-in-discord-notifications`をローカルに取り込む
```
git fetch origin feature/display-emotion-emojis-in-discord-notifications
```
```
git checkout feature/display-emotion-emojis-in-discord-notifications
```
2. ローカルでサーバーを立ち上げる
```
bin/dev
```
3. Develop環境でのDiscord通知を確認できるように設定する
[Develop環境でのDiscord通知の確認方法 · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDiscord%E9%80%9A%E7%9F%A5%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95)
4. 任意のユーザーでログインし、日報を作成する
任意のユーザーでログインし、http://localhost:3000/reports/new にアクセスする。
以下の内容で新規日報を入力し、提出ボタンを押す。
- タイトル
既存の日報と重複しない任意の値を入力。
- 学習日
他の日報と重複しない有効な日付を入力。
- 今日の気分
`Positive`を選択
- 学習時間
学習時間として有効な任意の値を入力。
- 内容
任意の内容を入力。
5. 3で追加したDiscordサーバーを確認する。
- [x] 「{user名}さんが{学習日}の日報を公開しました。」という通知が届いている。
- [x] 通知内の日報タイトルの前に「😄」の絵文字が付されている。
<img width="493" height="82" alt="Cursor_と__general___ティレル_s_server_-_Discord" src="https://github.com/user-attachments/assets/3658f5d0-92b3-48f2-932d-1ee336730c89" />

6. 上記4~5の手順について、「今日の気分」の箇所を`Neutral`、`Negative`に変更した上で日報を作成し、それぞれのDiscord通知を確認する。
- `Neutral`
  - [x] 「{user名}さんが{学習日}の日報を公開しました。」という通知が届いている。
  - [x] 日報のタイトルの前に「🙂」の絵文字が付いている。
  
<img width="483" height="77" alt="_general___ティレル_s_server_-_Discord" src="https://github.com/user-attachments/assets/decc6610-d6a7-4889-b465-2a487796bb4c" />
  
- `Negative`
  - [x] 「{user名}さんが{学習日}の日報を公開しました。」という通知が届いている。
  - [x] 日報のタイトルの前に「😰」の絵文字が付いている。

<img width="478" height="83" alt="Notification_Center" src="https://github.com/user-attachments/assets/b8d64a27-d3e3-45fd-a2e4-5846be1e37be" />

## 絵文字の種類について
日報の「今日の気分の顔スタンプ」についてはbootcampアプリ内に保存しているsvgファイルをそれぞれ参照しています。
<img width="589" height="121" alt="日報作成___FBC" src="https://github.com/user-attachments/assets/33e52898-bcb2-446f-92a4-79b60f57ebe2" />
しかしDiscord上では上記svgファイルを参照できないため、近い意味のUnicode絵文字で代替する方針としました。
上記方針はチーム開発ミーティングにて駒形さん、町田さんに了承を得ています。
`Positive` -> 😄
`Neutral` -> 🙂
`Negative` -> 😰

## テストについて
Discord用通知の文言に変更を加えたので、想定通りの文言になっているかのテストを作成すべきか検討しましたが以下理由によりテストを作成していません。
- `ReportNotifier`クラスに関するテストが現状存在していない。
- `ReportNotifier`は日報初公開時に通知処理を行うクラスであるが、私が今回行った修正はDiscord用通知の文言の一部であり、`ReportNotifier#call`の処理全般に関するテストを書くのは手間がかかる上、テスト方針も難しくかつ今回のPRのスコープ外であると考えた。
- そもそも、今回は通知用の文言に定数参照部分を付け加えただけなので、定数参照を全て網羅するような動作確認のみでコードの正当性を担保できると考えた。



## Screenshot

### 変更前
<img width="777" height="334" alt="_general___ティレル_s_server_-_Discord" src="https://github.com/user-attachments/assets/549e2580-2972-46f6-b1e7-3e392cce4d8b" />


### 変更後
<img width="778" height="334" alt="_general___ティレル_s_server_-_Discord" src="https://github.com/user-attachments/assets/019ef731-8bce-48cf-8f4c-9fafbc5f9eef" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャット通知に感情を表す絵文字を追加しました。レポートの感情（ポジティブ、ニュートラル、ネガティブ）に対応した絵文字がレポートタイトルの前に表示され、一目でレポートの感情状態を識別できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->