### PR TITLE
給付金コースのプラクティスの関連日報一覧に元コースの関連日報を表示切替のフィルターを追加

### DIFF
--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -8,6 +8,7 @@ class API::ReportsController < API::BaseController
     @reports = @reports.where(user_id: params[:user_id]) if params[:user_id].present?
     @reports = @reports.limit(params[:limit].to_i) if params[:limit].present?
     @reports = @reports.joins(:user).where(users: { company_id: params[:company_id] }) if params[:company_id]
+    @reports = @reports.without_copied_practice if params[:course_type] == 'grant'
     return unless params[:target] == 'unchecked_reports'
     return head :forbidden unless current_user.admin_or_mentor?
 

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -8,7 +8,7 @@ class API::ReportsController < API::BaseController
     @reports = @reports.where(user_id: params[:user_id]) if params[:user_id].present?
     @reports = @reports.limit(params[:limit].to_i) if params[:limit].present?
     @reports = @reports.joins(:user).where(users: { company_id: params[:company_id] }) if params[:company_id]
-    @reports = @reports.without_copied_practice if params[:with_grant] == 'true'
+    @reports = @reports.with_grant_practices if params[:with_grant] == 'true'
     return unless params[:target] == 'unchecked_reports'
     return head :forbidden unless current_user.admin_or_mentor?
 

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -8,7 +8,7 @@ class API::ReportsController < API::BaseController
     @reports = @reports.where(user_id: params[:user_id]) if params[:user_id].present?
     @reports = @reports.limit(params[:limit].to_i) if params[:limit].present?
     @reports = @reports.joins(:user).where(users: { company_id: params[:company_id] }) if params[:company_id]
-    @reports = @reports.without_copied_practice if params[:course_type] == 'grant'
+    @reports = @reports.without_copied_practice if params[:with_grant] == 'true'
     return unless params[:target] == 'unchecked_reports'
     return head :forbidden unless current_user.admin_or_mentor?
 

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -4,7 +4,7 @@ class API::ReportsController < API::BaseController
   def index # rubocop:disable Metrics/PerceivedComplexity
     @company = Company.find(params[:company_id]) if params[:company_id]
     @reports = Report.list.page(params[:page])
-    @reports = @reports.joins(:practices).where(practices: { id: params[:practice_id] }) if params[:practice_id].present?
+    @reports = @reports.by_practice_with_source(params[:practice_id]) if params[:practice_id].present?
     @reports = @reports.where(user_id: params[:user_id]) if params[:user_id].present?
     @reports = @reports.limit(params[:limit].to_i) if params[:limit].present?
     @reports = @reports.joins(:user).where(users: { company_id: params[:company_id] }) if params[:company_id]

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class API::ReportsController < API::BaseController
-  def index
+  def index # rubocop:disable Metrics/PerceivedComplexity
     @company = Company.find(params[:company_id]) if params[:company_id]
     @reports = Report.list.page(params[:page])
     @reports = @reports.joins(:practices).where(practices: { id: params[:practice_id] }) if params[:practice_id].present?

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -4,11 +4,11 @@ class API::ReportsController < API::BaseController
   def index # rubocop:disable Metrics/PerceivedComplexity
     @company = Company.find(params[:company_id]) if params[:company_id]
     @reports = Report.list.page(params[:page])
-    @reports = @reports.by_practice_with_source(params[:practice_id]) if params[:practice_id].present?
+    @reports = @reports.with_practice_and_source(params[:practice_id]) if params[:practice_id].present?
+    @reports = @reports.without_original_practice if params[:practice_id].present? && params[:grant_only] == 'true'
     @reports = @reports.where(user_id: params[:user_id]) if params[:user_id].present?
     @reports = @reports.limit(params[:limit].to_i) if params[:limit].present?
     @reports = @reports.joins(:user).where(users: { company_id: params[:company_id] }) if params[:company_id]
-    @reports = @reports.with_grant_practices if params[:with_grant] == 'true'
     return unless params[:target] == 'unchecked_reports'
     return head :forbidden unless current_user.admin_or_mentor?
 

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -5,7 +5,7 @@ module PageTabs
     def practice_page_tabs(practice, active_tab:)
       tabs = []
       tabs << { name: 'プラクティス', link: practice_path(practice) }
-      tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports.length }
+      tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports_count_with_source }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
       tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length } if movie_available?

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -22,7 +22,7 @@ export default function Reports({
   const isGrantCourse = practiceSourceId !== null
   const { page, setPage } = usePage()
   const [selectedPracticeId, setSelectedPracticeId] = useState('')
-  const [courseType, setCourseType] = useState('all')
+  const [withGrant, setWithGrant] = useState(false)
 
   let reportsUrl = `/api/reports.json?page=${page}`
   if (userId) reportsUrl += `&user_id=${userId}`
@@ -30,7 +30,7 @@ export default function Reports({
   const pid = selectedPracticeId || practiceId
   if (pid) reportsUrl += `&practice_id=${pid}`
   if (unchecked) reportsUrl += `&target=unchecked_reports`
-  if (isGrantCourse) reportsUrl += `&course_type=${courseType}`
+  if (isGrantCourse && withGrant) reportsUrl += `&with_grant=true`
 
   const { data, error } = useSWR(reportsUrl, fetcher)
 
@@ -68,22 +68,22 @@ export default function Reports({
   useEffect(() => {
     if (!isGrantCourse || !data) return
 
-    let courseTypeFilter = null
-    const initCourseTypeFilter = async () => {
-      const targetElement = document.querySelector('[data-course-type-filter]')
-      const CourseTypeFilter = (await import('../course-type-filter')).default
-      courseTypeFilter = new CourseTypeFilter(courseType, setCourseType)
-      courseTypeFilter.render(targetElement)
+    let grantFilter = null
+    const initGrantFilter = async () => {
+      const targetElement = document.querySelector('[data-grant-filter]')
+      const GrantFilter = (await import('../grant-filter')).default
+      grantFilter = new GrantFilter(withGrant, setWithGrant)
+      grantFilter.render(targetElement)
     }
-    initCourseTypeFilter()
+    initGrantFilter()
 
     return () => {
-      if (courseTypeFilter) {
-        courseTypeFilter.destroy()
-        courseTypeFilter = null
+      if (grantFilter) {
+        grantFilter.destroy()
+        grantFilter = null
       }
     }
-  }, [data, courseType])
+  }, [data, withGrant])
 
   if (error) return <>エラーが発生しました。</>
   if (!data) {
@@ -108,7 +108,7 @@ export default function Reports({
       )}
       {data.totalPages > 0 && (
         <div>
-          {isGrantCourse && <div data-course-type-filter></div>}
+          {isGrantCourse && <div data-grant-filter></div>}
           {practices && <div data-practice-filter-dropdown></div>}
           <div className="page-body">
             <div className="container is-md">

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -16,10 +16,9 @@ export default function Reports({
   companyId = '',
   practiceId = '',
   displayPagination = true,
-  practiceSourceId = null
+  isGrantCourse = false
 }) {
   const per = 20
-  const isGrantCourse = practiceSourceId !== null
   const { page, setPage } = usePage()
   const [selectedPracticeId, setSelectedPracticeId] = useState('')
   const [withGrant, setWithGrant] = useState(false)

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -29,7 +29,7 @@ export default function Reports({
   const pid = selectedPracticeId || practiceId
   if (pid) reportsUrl += `&practice_id=${pid}`
   if (unchecked) reportsUrl += `&target=unchecked_reports`
-  if (isGrantCourse && withGrant) reportsUrl += `&with_grant=true`
+  if (isGrantCourse && withGrant) reportsUrl += `&grant_only=true`
 
   const { data, error } = useSWR(reportsUrl, fetcher)
 

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -19,7 +19,7 @@ export default function Reports({
   practiceSourceId = null
 }) {
   const per = 20
-  const isGrantCourse = practiceSourceId !== null;
+  const isGrantCourse = practiceSourceId !== null
   const { page, setPage } = usePage()
   const [selectedPracticeId, setSelectedPracticeId] = useState('')
   const [courseType, setCourseType] = useState('all')
@@ -68,25 +68,22 @@ export default function Reports({
   useEffect(() => {
     if (!isGrantCourse || !data) return
 
-    let courseTypeFilter = null;
+    let courseTypeFilter = null
     const initCourseTypeFilter = async () => {
       const targetElement = document.querySelector('[data-course-type-filter]')
-      const CourseTypeFilter = (
-        await import('../course-type-filter')
-      ).default
-      courseTypeFilter = new CourseTypeFilter(setCourseType);
+      const CourseTypeFilter = (await import('../course-type-filter')).default
+      courseTypeFilter = new CourseTypeFilter(courseType, setCourseType)
       courseTypeFilter.render(targetElement)
     }
     initCourseTypeFilter()
 
     return () => {
       if (courseTypeFilter) {
-        courseTypeFilter.destroy();
-        courseTypeFilter = null;
+        courseTypeFilter.destroy()
+        courseTypeFilter = null
       }
     }
-
-  },[data])
+  }, [data, courseType])
 
   if (error) return <>エラーが発生しました。</>
   if (!data) {
@@ -155,7 +152,7 @@ export default function Reports({
   )
 }
 
-const NoReports = ({unchecked}) => {
+const NoReports = ({ unchecked }) => {
   return (
     <div className="o-empty-message">
       <div className="o-empty-message__icon">

--- a/app/javascript/components/Reports.jsx
+++ b/app/javascript/components/Reports.jsx
@@ -66,11 +66,13 @@ export default function Reports({
   }, [data, practices, setSelectedPracticeId])
 
   useEffect(() => {
-    if (!isGrantCourse || !data) return
+    if (!isGrantCourse) return
 
     let grantFilter = null
     const initGrantFilter = async () => {
       const targetElement = document.querySelector('[data-grant-filter]')
+      if (!targetElement) return
+
       const GrantFilter = (await import('../grant-filter')).default
       grantFilter = new GrantFilter(withGrant, setWithGrant)
       grantFilter.render(targetElement)
@@ -102,6 +104,7 @@ export default function Reports({
     <div className="page-main is-react">
       {data.totalPages === 0 && (
         <div>
+          {isGrantCourse && <div data-grant-filter></div>}
           {practices && <div data-practice-filter-dropdown></div>}
           <NoReports unchecked={unchecked} />
         </div>

--- a/app/javascript/course-type-filter.js
+++ b/app/javascript/course-type-filter.js
@@ -1,0 +1,49 @@
+export default class {
+  constructor(setCourseType) {
+    this.setCourseType = setCourseType;
+    this.tabs = null;
+    this.handleSelect = null;
+  }
+
+  render(element){
+    element.innerHTML = `
+    <nav class="tab-nav">
+      <ul class="tab-nav__items">
+        <li class="tab-nav__item">
+          <a class="tab-nav__item-link is-active" href="#" data-course-type="all">全て</a>
+        </li>
+        <li class="tab-nav__item">
+          <a class="tab-nav__item-link" href="#" data-course-type="grant">給付金コース</a>
+        </li>
+      </ul>
+    </nav>
+    `
+
+    this.tabs = element.querySelectorAll('.tab-nav__item-link');
+
+    this.handleSelect = (event) => {
+      event.preventDefault();
+      const currentTab = event.currentTarget;
+      this.tabs.forEach(tab => {
+        tab.classList.remove('is-active');
+      })
+      currentTab.classList.add('is-active');
+      this.setCourseType(currentTab.dataset.courseType);
+    }
+
+    this.tabs.forEach(tab => {
+      tab.addEventListener('click', this.handleSelect)
+    })
+  }
+
+  destroy() {
+    if (!this.tabs || !this.handleSelect) return;
+
+    this.tabs.forEach(tab => {
+      tab.removeEventListener('click', this.handleSelect);
+    })
+
+    this.tabs = null;
+    this.handleSelect = null;
+  }
+}

--- a/app/javascript/course-type-filter.js
+++ b/app/javascript/course-type-filter.js
@@ -1,16 +1,17 @@
 export default class {
-  constructor(setCourseType) {
-    this.setCourseType = setCourseType;
-    this.tabs = null;
-    this.handleSelect = null;
+  constructor(courseType, setCourseType) {
+    this.courseType = courseType
+    this.setCourseType = setCourseType
+    this.tabs = null
+    this.handleSelect = null
   }
 
-  render(element){
+  render(element) {
     element.innerHTML = `
     <nav class="tab-nav">
       <ul class="tab-nav__items">
         <li class="tab-nav__item">
-          <a class="tab-nav__item-link is-active" href="#" data-course-type="all">全て</a>
+          <a class="tab-nav__item-link" href="#" data-course-type="all">全て</a>
         </li>
         <li class="tab-nav__item">
           <a class="tab-nav__item-link" href="#" data-course-type="grant">給付金コース</a>
@@ -19,31 +20,37 @@ export default class {
     </nav>
     `
 
-    this.tabs = element.querySelectorAll('.tab-nav__item-link');
+    this.tabs = element.querySelectorAll('.tab-nav__item-link')
+
+    this.tabs.forEach((tab) => {
+      if (tab.dataset.courseType === this.courseType) {
+        tab.classList.add('is-active')
+      }
+    })
 
     this.handleSelect = (event) => {
-      event.preventDefault();
-      const currentTab = event.currentTarget;
-      this.tabs.forEach(tab => {
-        tab.classList.remove('is-active');
+      event.preventDefault()
+      const selectedTab = event.currentTarget
+      this.tabs.forEach((tab) => {
+        tab.classList.remove('is-active')
       })
-      currentTab.classList.add('is-active');
-      this.setCourseType(currentTab.dataset.courseType);
+      selectedTab.classList.add('is-active')
+      this.setCourseType(selectedTab.dataset.courseType)
     }
 
-    this.tabs.forEach(tab => {
+    this.tabs.forEach((tab) => {
       tab.addEventListener('click', this.handleSelect)
     })
   }
 
   destroy() {
-    if (!this.tabs || !this.handleSelect) return;
+    if (!this.tabs || !this.handleSelect) return
 
-    this.tabs.forEach(tab => {
-      tab.removeEventListener('click', this.handleSelect);
+    this.tabs.forEach((tab) => {
+      tab.removeEventListener('click', this.handleSelect)
     })
 
-    this.tabs = null;
-    this.handleSelect = null;
+    this.tabs = null
+    this.handleSelect = null
   }
 }

--- a/app/javascript/grant-filter.js
+++ b/app/javascript/grant-filter.js
@@ -8,19 +8,19 @@ export default class {
 
   render(element) {
     element.innerHTML = `
-    <nav class="tab-nav">
-      <ul class="tab-nav__items">
-        <li class="tab-nav__item">
-          <a class="tab-nav__item-link" href="#" data-with-grant="false">全て</a>
+    <nav class="pill-nav">
+      <ul class="pill-nav__items">
+        <li class="pill-nav__item">
+          <button class="pill-nav__item-link" data-with-grant="false">全て</button>
         </li>
-        <li class="tab-nav__item">
-          <a class="tab-nav__item-link" href="#" data-with-grant="true">給付金コース</a>
+        <li class="pill-nav__item">
+          <button class="pill-nav__item-link" data-with-grant="true">給付金コース</button>
         </li>
       </ul>
     </nav>
     `
 
-    this.tabs = element.querySelectorAll('.tab-nav__item-link')
+    this.tabs = element.querySelectorAll('.pill-nav__item-link')
 
     this.tabs.forEach((tab) => {
       const tabWithGrant = tab.dataset.withGrant === 'true'
@@ -30,7 +30,6 @@ export default class {
     })
 
     this.handleSelect = (event) => {
-      event.preventDefault()
       const selectedTab = event.currentTarget
       this.tabs.forEach((tab) => {
         tab.classList.remove('is-active')

--- a/app/javascript/grant-filter.js
+++ b/app/javascript/grant-filter.js
@@ -1,7 +1,7 @@
 export default class {
-  constructor(courseType, setCourseType) {
-    this.courseType = courseType
-    this.setCourseType = setCourseType
+  constructor(withGrant, setWithGrant) {
+    this.withGrant = withGrant
+    this.setWithGrant = setWithGrant
     this.tabs = null
     this.handleSelect = null
   }
@@ -11,10 +11,10 @@ export default class {
     <nav class="tab-nav">
       <ul class="tab-nav__items">
         <li class="tab-nav__item">
-          <a class="tab-nav__item-link" href="#" data-course-type="all">全て</a>
+          <a class="tab-nav__item-link" href="#" data-with-grant="false">全て</a>
         </li>
         <li class="tab-nav__item">
-          <a class="tab-nav__item-link" href="#" data-course-type="grant">給付金コース</a>
+          <a class="tab-nav__item-link" href="#" data-with-grant="true">給付金コース</a>
         </li>
       </ul>
     </nav>
@@ -23,7 +23,8 @@ export default class {
     this.tabs = element.querySelectorAll('.tab-nav__item-link')
 
     this.tabs.forEach((tab) => {
-      if (tab.dataset.courseType === this.courseType) {
+      const tabWithGrant = tab.dataset.withGrant === 'true'
+      if (tabWithGrant === this.withGrant) {
         tab.classList.add('is-active')
       }
     })
@@ -35,7 +36,8 @@ export default class {
         tab.classList.remove('is-active')
       })
       selectedTab.classList.add('is-active')
-      this.setCourseType(selectedTab.dataset.courseType)
+      const tabWithGrant = selectedTab.dataset.withGrant === 'true'
+      this.setWithGrant(tabWithGrant)
     }
 
     this.tabs.forEach((tab) => {

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -207,6 +207,10 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     practices_books.any?(&:must_read)
   end
 
+  def grant_course?
+    source_id.present?
+  end
+
   private
 
   def total_learning_minute(report)

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -211,6 +211,11 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     source_id.present?
   end
 
+  def reports_count_with_source
+    ids = [id, source_id].compact
+    Report.joins(:practices).where(practices: { id: ids }).distinct.count
+  end
+
   private
 
   def total_learning_minute(report)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -61,7 +61,7 @@ class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   scope :user, ->(user) { where(user_id: user.id) }
 
-  scope :without_copied_practice, lambda {
+  scope :with_grant_practices, lambda {
     joins(:practices).where.not(id: Report.joins(:practices).where(practices: { source_id: nil })).distinct
   }
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -61,6 +61,10 @@ class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   scope :user, ->(user) { where(user_id: user.id) }
 
+  scope :without_copied_practice, lambda {
+    joins(:practices).where.not(id: Report.joins(:practices).where(practices: { source_id: nil })).distinct
+  }
+
   def self.ransackable_attributes(_auth_object = nil)
     %w[title description reported_on emotion wip created_at updated_at user_id]
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -61,6 +61,12 @@ class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   scope :user, ->(user) { where(user_id: user.id) }
 
+  scope :by_practice_with_source, lambda { |practice_id|
+    source_id = Practice.find_by(id: practice_id)&.source_id
+    ids = [practice_id, source_id].compact
+    joins(:practices).where(practices: { id: ids }).distinct
+  }
+
   scope :with_grant_practices, lambda {
     joins(:practices).where.not(id: Report.joins(:practices).where(practices: { source_id: nil })).distinct
   }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -61,14 +61,14 @@ class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   scope :user, ->(user) { where(user_id: user.id) }
 
-  scope :by_practice_with_source, lambda { |practice_id|
+  scope :with_practice_and_source, lambda { |practice_id|
     source_id = Practice.find_by(id: practice_id)&.source_id
     ids = [practice_id, source_id].compact
     joins(:practices).where(practices: { id: ids }).distinct
   }
 
-  scope :with_grant_practices, lambda {
-    joins(:practices).where.not(id: Report.joins(:practices).where(practices: { source_id: nil })).distinct
+  scope :without_original_practice, lambda {
+    where.not(id: Report.joins(:practices).where(practices: { source_id: nil }).select(:id))
   }
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -11,4 +11,4 @@
 
 .page-body
   .container.is-md
-    = react_component('Reports', practiceId: @practice.id)
+    = react_component('Reports', practiceId: @practice.id, practiceSourceId: @practice.source_id)

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -11,4 +11,4 @@
 
 .page-body
   .container.is-md
-    = react_component('Reports', practiceId: @practice.id, practiceSourceId: @practice.source_id)
+    = react_component('Reports', practiceId: @practice.id, isGrantCourse: @practice.grant_course?)

--- a/db/fixtures/categories.yml
+++ b/db/fixtures/categories.yml
@@ -112,3 +112,8 @@ category23:
   name: "Ruby on Rails(Rails 6.1版)"
   slug: "ruby-on-rails"
   description: "まずはここからはじめましょう。ここでの学習の進め方を学びます。"
+
+category24:
+  name: "Mac OS X（Reスキル）"
+  slug: "ready-for-learn-reskill"
+  description: "Railsコースのカテゴリをコピーしたカテゴリです。"

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -356,3 +356,13 @@ categories_practice66_2:
   practice: practice66
   category: category22
   position: 3
+
+categories_practice67:
+  practice: practice113
+  category: category24
+  position: 16
+
+categories_practice68:
+  practice: practice114
+  category: category24
+  position: 17

--- a/db/fixtures/courses_categories.yml
+++ b/db/fixtures/courses_categories.yml
@@ -222,3 +222,8 @@ courses_category45:
   course: course5
   category: category23
   position: 18
+
+courses_category46:
+  course: course5
+  category: category24
+  position: 19

--- a/db/fixtures/discord_profiles.yml
+++ b/db/fixtures/discord_profiles.yml
@@ -335,3 +335,8 @@ discord_profile_new-mentor:
   user: new-mentor
   account_name: new-mentor
   times_url:
+
+discord_profile_grant-course:
+  user: grant-course
+  account_name: grant-course
+  times_url:

--- a/db/fixtures/practices.yml
+++ b/db/fixtures/practices.yml
@@ -764,3 +764,13 @@ practice112:
   goal: "goal..."
   include_progress: true
   memo: "memo for mentors..."
+
+practice113:
+  title: "OS X Mountain Lionをクリーンインストールする（Reスキル）"
+  description: "Railsコースのプラクティスをコピーしたプラクティスです。"
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice1) %>
+
+practice114:
+  title: "Terminalの基礎を覚える（Reスキル）"
+  description: "Railsコースのプラクティスをコピーしたプラクティスです。"
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice2) %>

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -5,7 +5,7 @@ report1:
   description: |-
     今日はローカルで怖話を動かしてみました。
     rbenv で ruby を動かすのは初めてだったので、色々手間取りました。
-  practices: practice1
+  practices: practice1, practice113
   reported_on: "2017-01-01"
   created_at: "2017-01-01 00:00:00"
 
@@ -505,3 +505,12 @@ report90:
   description: |-
     たくさんのスタンプがつきました。
   reported_on: "2025-10-01 01:00:00"
+
+report91:
+  user: grant-course
+  title: 給付金コースの日報
+  emotion: 2
+  description: |-
+    給付金コースの日報です。
+  practices: practice113
+  reported_on: "2026-01-01"

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -5,7 +5,7 @@ report1:
   description: |-
     今日はローカルで怖話を動かしてみました。
     rbenv で ruby を動かすのは初めてだったので、色々手間取りました。
-  practices: practice1, practice113
+  practices: practice1
   reported_on: "2017-01-01"
   created_at: "2017-01-01 00:00:00"
 
@@ -508,9 +508,35 @@ report90:
 
 report91:
   user: grant-course
-  title: 給付金コースの日報
+  title: 給付金コースのプラクティスの日報
   emotion: 2
   description: |-
-    給付金コースの日報です。
+    給付金コースのプラクティスの日報です。
   practices: practice113
   reported_on: "2026-01-01"
+
+report92:
+  user: komagata
+  title: 元コースのプラクティスの日報
+  emotion: 2
+  description: |-
+    元コースのプラクティスの日報です。
+  practices: practice1
+  reported_on: "2026-01-02"
+
+report93:
+  user: komagata
+  title: コピーされた元コースのプラクティスの日報
+  emotion: 2
+  description: |-
+    コピーされた元コースのプラクティスの日報です。
+  practices: practice1, practice113
+  reported_on: "2026-01-03"
+
+report94:
+  user: komagata
+  title: プラクティスに関連付かない日報
+  emotion: 2
+  description: |-
+    プラクティスに関連付かない日報
+  reported_on: "2026-01-04"

--- a/db/fixtures/talks.yml
+++ b/db/fixtures/talks.yml
@@ -235,3 +235,7 @@ talk_pjord:
 talk_new-mentor:
   user: new-mentor
   action_completed: true
+
+talk_grant_course:
+  user: grant-course
+  action_completed: true

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1555,3 +1555,23 @@ new-mentor:
   created_at: <%= Time.current %>
   sent_student_followup_message: true
   last_activity_at: <%= Time.current %>
+
+grant-course:
+  login_name: grant-course
+  email: grant-course@fjord.jp
+  crypted_password: $2a$10$n/xv4/1luueN6plzm2OyDezWlZFyGHjQEf4hwAW1r3k.lCm0frPK. # testtest
+  salt: zW3kQ9ubsxQQtzzzs4ap
+  name: 給付金コースのユーザー
+  name_kana: キュウフキンコースノユーザー
+  github_account: grant-course
+  twitter_account: grant-course
+  facebook_url: https://www.facebook.com/fjordllc/grant-course
+  blog_url: http://grant-course.org
+  description: "給付金コースを受講中のユーザーです。"
+  course: course5
+  job: office_worker
+  os: mac
+  organization: Rails大学
+  updated_at: "2025-01-01 00:00:00"
+  created_at: "2025-01-01 00:00:00"
+  last_activity_at: "2025-01-01 00:00:00"

--- a/test/fixtures/learning_times.yml
+++ b/test/fixtures/learning_times.yml
@@ -37,3 +37,8 @@ learning_time8:
   report: report10
   started_at: 2020-09-10 12:00:00
   finished_at: 2020-09-10 13:15:00
+
+learning_time9:
+  report: report77
+  started_at: 2026-01-02 00:00:00
+  finished_at: 2026-01-02 02:00:00

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -390,3 +390,8 @@ practice63:
   goal: "goal..."
   include_progress: true
   memo: "memo for mentors..."
+
+practice64:
+  title: "給付金コースのプラクティス"
+  description: "Railsコースのプラクティスをコピーしたプラクティスです。"
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice1) %>

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -395,3 +395,8 @@ practice64:
   title: "給付金コースのプラクティス"
   description: "Railsコースのプラクティスをコピーしたプラクティスです。"
   source_id: <%= ActiveRecord::FixtureSet.identify(:practice1) %>
+
+practice65:
+  title: "日報が存在しない給付金コースのプラクティス"
+  description: "Railsコースのプラクティスをコピーしたプラクティスです。"
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice2) %>

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -400,3 +400,12 @@ practice65:
   title: "日報が存在しない給付金コースのプラクティス"
   description: "Railsコースのプラクティスをコピーしたプラクティスです。"
   source_id: <%= ActiveRecord::FixtureSet.identify(:practice2) %>
+
+practice66:
+  title: "日報が存在しないプラクティス"
+  description: "日報が存在しないプラクティスです。"
+
+practice67:
+  title: "source_idを持っている日報が存在しないプラクティス"
+  description: "source_idを持っている日報が存在しないプラクティスです。"
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice66) %>

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -358,3 +358,26 @@ report75:
   description: WIPです
   wip: true
   reported_on: "2022-04-02"
+
+report76:
+  user: komagata
+  title: "Railsコースのプラクティスの日報"
+  emotion: 1
+  description: Railsコースのプラクティスの日報です。
+  practices: practice1
+  reported_on: "2026-01-01"
+
+report77:
+  user: komagata
+  title: "給付金コースのプラクティスの日報"
+  emotion: 1
+  description: 給付金コースのプラクティスの日報です。
+  practices: practice64
+  reported_on: "2026-01-02"
+
+report78:
+  user: komagata
+  title: "プラクティスに関連付かない日報"
+  emotion: 1
+  description: プラクティスに関連付かない日報です。
+  reported_on: "2026-01-03"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -381,3 +381,11 @@ report78:
   emotion: 1
   description: プラクティスに関連付かない日報です。
   reported_on: "2026-01-03"
+
+report79:
+  user: komagata
+  title: "コピー元のRailsコースのプラクティスの日報"
+  emotion: 1
+  description: コピー元のRailsコースのプラクティスの日報です。
+  practices: practice1, practice64
+  reported_on: "2026-01-04"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -377,15 +377,31 @@ report77:
 
 report78:
   user: komagata
-  title: "プラクティスに関連付かない日報"
+  title: "プラクティスに関連する日報"
   emotion: 1
-  description: プラクティスに関連付かない日報です。
+  description: プラクティスに関連する日報です。
+  practices: practice1
   reported_on: "2026-01-03"
 
 report79:
   user: komagata
-  title: "コピー元のRailsコースのプラクティスの日報"
+  title: "コピー元のプラクティスの日報"
   emotion: 1
-  description: コピー元のRailsコースのプラクティスの日報です。
+  description: コピー元のプラクティスの日報です。
   practices: practice1, practice64
   reported_on: "2026-01-04"
+
+report80:
+  user: komagata
+  title: "異なるプラクティスに関連する日報"
+  emotion: 1
+  description: 異なるプラクティスに関連する日報です。
+  practices: practice2
+  reported_on: "2026-01-05"
+
+report81:
+  user: komagata
+  title: "プラクティスに関連していない日報"
+  emotion: 1
+  description: プラクティスに関連付かない日報です。
+  reported_on: "2026-01-06"

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -13,6 +13,6 @@ class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
     get counts_api_reports_unchecked_index_path(format: :text),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    assert_match '65件', response.body
+    assert_match '68件', response.body
   end
 end

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -13,6 +13,6 @@ class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
     get counts_api_reports_unchecked_index_path(format: :text),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    assert_match '68件', response.body
+    assert_match '69件', response.body
   end
 end

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -13,6 +13,6 @@ class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
     get counts_api_reports_unchecked_index_path(format: :text),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    assert_match '69件', response.body
+    assert_match '71件', response.body
   end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -92,4 +92,49 @@ class PracticeTest < ActiveSupport::TestCase
     assert Practice.new(source_id: 1).grant_course?
     assert_not Practice.new(source_id: nil).grant_course?
   end
+
+  test '#reports_count_with_source returns reports count' do
+    practice = practices(:practice66)
+    Report.create!(
+      user: users(:komagata),
+      title: '日報が存在しないプラクティスの日報',
+      description: '日報が存在しないプラクティスの日報です。',
+      practices: [practice],
+      reported_on: Time.zone.today
+    )
+    assert_equal 1, practice.reports_count_with_source
+  end
+
+  test '#reports_count_with_source returns reports count including source' do
+    source = practices(:practice66)
+    practice = practices(:practice67)
+    Report.create!(
+      user: users(:komagata),
+      title: '日報が存在しないプラクティスの日報',
+      description: '日報が存在しないプラクティスの日報です。',
+      practices: [source],
+      reported_on: Time.zone.today
+    )
+    Report.create!(
+      user: users(:komagata),
+      title: 'source_idを持っている日報が存在しないプラクティスの日報',
+      description: 'source_idを持っている日報が存在しないプラクティスの日報です。',
+      practices: [practice],
+      reported_on: Time.zone.today - 1
+    )
+    assert_equal 2, practice.reports_count_with_source
+  end
+
+  test '#reports_count_with_source does not double count reports when associated with both source and practice' do
+    source = practices(:practice66)
+    practice = practices(:practice67)
+    Report.create!(
+      user: users(:komagata),
+      title: '複数のプラクティスに関連する日報',
+      description: '複数のプラクティスに関連する日報です。',
+      practices: [source, practice],
+      reported_on: Time.zone.today
+    )
+    assert_equal 1, practice.reports_count_with_source
+  end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -87,4 +87,9 @@ class PracticeTest < ActiveSupport::TestCase
       practice.update!(source_id: 99_999)
     end
   end
+
+  test '#grant_course? returns true when practice has source' do
+    assert Practice.new(source_id: 1).grant_course?
+    assert_not Practice.new(source_id: nil).grant_course?
+  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -73,4 +73,12 @@ class ReportTest < ActiveSupport::TestCase
     assert_empty unchecked_report.checks
     assert_includes Report.unchecked, unchecked_report
   end
+
+  test '.with_grant_practices returns only grant course reports' do
+    rails_course_report = reports(:report76)
+    grant_course_report = reports(:report77)
+    unrelated_report = reports(:report78)
+    mixed_reports = Report.where(id: [rails_course_report.id, grant_course_report.id, unrelated_report.id])
+    assert_equal [grant_course_report], mixed_reports.with_grant_practices.to_a
+  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -74,11 +74,26 @@ class ReportTest < ActiveSupport::TestCase
     assert_includes Report.unchecked, unchecked_report
   end
 
-  test '.with_grant_practices returns only grant course reports' do
-    rails_course_report = reports(:report76)
-    grant_course_report = reports(:report77)
-    unrelated_report = reports(:report78)
-    mixed_reports = Report.where(id: [rails_course_report.id, grant_course_report.id, unrelated_report.id])
-    assert_equal [grant_course_report], mixed_reports.with_grant_practices.to_a
+  test '.with_practice_and_source includes practice and source reports' do
+    practice = practices(:practice1)
+    practice_report = reports(:report78)
+    source_report = reports(:report79)
+    other_report = reports(:report80)
+    unrelated_report = reports(:report81)
+    result = Report.with_practice_and_source(practice.id)
+
+    assert_includes result, practice_report
+    assert_includes result, source_report
+    assert_not_includes result, other_report
+    assert_not_includes result, unrelated_report
+  end
+
+  test '.without_original_practice excludes original practice reports' do
+    original_report = reports(:report76)
+    grant_report = reports(:report77)
+    result = Report.without_original_practice
+
+    assert_includes result, grant_report
+    assert_not_includes result, original_report
   end
 end

--- a/test/system/practice/reports_test.rb
+++ b/test/system/practice/reports_test.rb
@@ -9,4 +9,41 @@ class Practice::ReportsTest < ApplicationSystemTestCase
     assert_selector 'img[alt="positive"]', count: 2
     assert_selector '.card-list-item-title__link', text: '1時間だけ学習'
   end
+
+  test 'grant filter is not present on rails course practice' do
+    visit_with_auth "/practices/#{practices(:practice1).id}/reports", 'komagata'
+    assert_selector '.card-list-item-title__link'
+    assert_no_selector '[data-grant-filter]'
+  end
+
+  test 'grant filter is present on grant course practice' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+    assert_selector '.card-list-item-title__link'
+    assert_selector '[data-grant-filter]'
+  end
+
+  test 'grant filter shows both copied and grant course reports when "全て" is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+    assert_selector '.card-list-item-title__link'
+    assert_selector 'button.pill-nav__item-link.is-active[data-with-grant="false"]', text: '全て'
+    assert_selector '.card-list-item-title__link', text: 'コピー元のRailsコースのプラクティスの日報'
+    assert_selector '.card-list-item-title__link', text: '給付金コースのプラクティスの日報'
+  end
+
+  test 'grant filter shows only grant course reports when "給付金コース" is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+    assert_selector '.card-list-item-title__link'
+    find('button[data-with-grant="true"]').click
+    assert_selector 'button.pill-nav__item-link.is-active[data-with-grant="true"]', text: '給付金コース'
+    assert_no_selector '.card-list-item-title__link', text: 'コピー元のRailsコースのプラクティスの日報'
+    assert_selector '.card-list-item-title__link', text: '給付金コースのプラクティスの日報'
+  end
+
+  test 'grant filter shows empty message when no reports exist' do
+    visit_with_auth "/practices/#{practices(:practice65).id}/reports", 'komagata'
+    assert_selector '[data-grant-filter]'
+    find('button[data-with-grant="true"]').click
+    assert_selector 'button.pill-nav__item-link.is-active[data-with-grant="true"]', text: '給付金コース'
+    assert_selector '.o-empty-message__text', text: '日報はまだありません。'
+  end
 end

--- a/test/system/practice/reports_test.rb
+++ b/test/system/practice/reports_test.rb
@@ -3,13 +3,6 @@
 require 'application_system_test_case'
 
 class Practice::ReportsTest < ApplicationSystemTestCase
-  test 'show listing reports' do
-    visit_with_auth "/practices/#{practices(:practice1).id}/reports", 'hatsuno'
-    assert_equal 'OS X Mountain Lionをクリーンインストールするに関する日報 | FBC', title
-    assert_selector 'img[alt="positive"]', count: 2
-    assert_selector '.card-list-item-title__link', text: '1時間だけ学習'
-  end
-
   test 'grant filter is not present on rails course practice' do
     visit_with_auth "/practices/#{practices(:practice1).id}/reports", 'komagata'
     assert_selector '.card-list-item-title__link'
@@ -26,7 +19,7 @@ class Practice::ReportsTest < ApplicationSystemTestCase
     visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
     assert_selector '.card-list-item-title__link'
     assert_selector 'button.pill-nav__item-link.is-active[data-with-grant="false"]', text: '全て'
-    assert_selector '.card-list-item-title__link', text: 'コピー元のRailsコースのプラクティスの日報'
+    assert_selector '.card-list-item-title__link', text: 'コピー元のプラクティスの日報'
     assert_selector '.card-list-item-title__link', text: '給付金コースのプラクティスの日報'
   end
 
@@ -35,7 +28,7 @@ class Practice::ReportsTest < ApplicationSystemTestCase
     assert_selector '.card-list-item-title__link'
     find('button[data-with-grant="true"]').click
     assert_selector 'button.pill-nav__item-link.is-active[data-with-grant="true"]', text: '給付金コース'
-    assert_no_selector '.card-list-item-title__link', text: 'コピー元のRailsコースのプラクティスの日報'
+    assert_no_selector '.card-list-item-title__link', text: 'コピー元のプラクティスの日報'
     assert_selector '.card-list-item-title__link', text: '給付金コースのプラクティスの日報'
   end
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9292

## 前提

- 給付金コースはRailsエンジニアコースをコピーして作られたコース
- 給付金コースのカテゴリ、プラクティス、日報、書籍は既存のRailsエンジニアコースをコピーして作成される

wiki: [給付金コースの人が元コースの関連情報を見れるようにする](https://github.com/fjordllc/bootcamp/wiki/%E7%B5%A6%E4%BB%98%E9%87%91%E3%82%B3%E3%83%BC%E3%82%B9%E3%81%AE%E4%BA%BA%E3%81%8C%E5%85%83%E3%82%B3%E3%83%BC%E3%82%B9%E3%81%AE%E9%96%A2%E9%80%A3%E6%83%85%E5%A0%B1%E3%82%92%E8%A6%8B%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)

## 概要

給付金コースのプラクティスの関連日報一覧(/practices/:id/reports)に元コースの関連日報の表示/非表示を切り替えるフィルターを追加

- 以下の2つのボタンで表示する日報を切り替え
  - `全て`: コピー元プラクティス + 給付金コース
  - `給付金コース`: 給付金コースのみ

## robocopの警告への対応について
 
処理を追加したことでrubocopの警告への対応が必要でしたが当issueのスコープを外れると判断しました。
そのため、当PRでは暫定対応としてコメントアウト、恒久対応として別issueでリファクタリングを行います。

- 経緯: https://github.com/fjordllc/bootcamp/pull/9515#issuecomment-3781327004
- 対応issue: https://github.com/fjordllc/bootcamp/issues/9603

## 変更確認方法

### 事前準備

1. `feature/reports-grant-course-filter` をローカルに取り込む
2. seedで初期データ作成

```sh
# seed
bundle exec rails db:seed
```

### フィルター表示/非表示

1. `komagata` でログイン
2. プラクティス > 「OS X Mountain Lionをクリーンインストールする」を選択 > 「日報」タブを開く(/practices/:id/reports)
3. 「全て/給付金コース」のフィルターが表示されていないことを確認
4. `grant-course` でログイン
5. プラクティス > 「OS X Mountain Lionをクリーンインストールする(Reスキル)」を選択(一覧の最下部) > 「日報」タブを開く(/practices/:id/reports)
6. 「全て/給付金コース」のフィルターが表示されることを確認

### フィルタリング

1. `grant-course` でログイン
2. プラクティス > 「OS X Mountain Lionをクリーンインストールする(Reスキル)」を選択 > 「日報」タブを開く(/practices/:id/reports)
3. フィルターのボタンで以下のように日報がフィルタリングされることを確認
  - `全て`: コピー元 + 給付金コース
  - `給付金コース`: 給付金コースのみ

### 給付金が日報が0件時の表示

1. `grant-course` でログイン
2. プラクティス > 「Terminalの基礎を覚える（Reスキル）」を選択(一覧の最下部)  > 「日報」タブを開く(/practices/:id/reports)
3. 「給付金コース」ボタンを押下
4. 「日報はまだありません。」が表示されることを確認

<img width="1412" height="375" alt="no_report" src="https://github.com/user-attachments/assets/9e00c8da-fbf5-48d9-a5ca-06ea124cbeb4" />

## Screenshot

### 変更前

<img width="1619" height="446" alt="before" src="https://github.com/user-attachments/assets/c71656a8-f94f-40b9-84bd-cb8bf522d962" />

### 変更後

<img width="1608" height="483" alt="after" src="https://github.com/user-attachments/assets/8bbfbf3b-3ec8-4eeb-b865-afa6c11bba91" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * レポート画面に給付金コース用の切替フィルターUIを追加し、表示切替が可能に。
  * サーバーからフロントへ給付金判定用の識別子を渡すように変更。

* **Bug Fixes / Improvements**
  * APIで「給付金コース」に該当するレポートのみを絞り込めるように改良。

* **Tests**
  * 給付金関連の挙動を検証する単体テストを追加。

* **Chores**
  * テスト/開発用のダミーデータを追加・一部削除。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->