### PR TITLE
Cloud Run削除後のDB接続クローズ待機時間を60秒に延長

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -41,8 +41,8 @@ steps:
             --region=asia-northeast1 \
             --quiet
 
-          echo "Cloud Run service deleted. Waiting 10 seconds for connections to close..."
-          sleep 10
+          echo "Cloud Run service deleted. Waiting 60 seconds for connections to close..."
+          sleep 60
         else
           echo "Cloud Run service does not exist yet. Skipping delete."
         fi


### PR DESCRIPTION
## Summary
- ステージングデプロイ時にDeleteDBステップで「database is being accessed by other users」エラーが発生していた問題を修正
- Cloud Runサービス削除後のDB接続クローズ待機時間を10秒から60秒に延長

## Test plan
- ステージングへのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ステージング環境のクラウドビルド設定において、サービス停止後の待機時間を調整しました。これにより、デプロイメントプロセスの安定性が向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->