### PR TITLE
[DEBUG] MissionControl認証にログを追加

### DIFF
--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -2,7 +2,16 @@
 
 if Rails.env.production?
   MissionControl::Jobs::Engine.middleware.use(Rack::Auth::Basic) do |username, password|
-    ActiveSupport::SecurityUtils.secure_compare(ENV['MISSION_CONTROL_USERNAME'], username) &&
-      ActiveSupport::SecurityUtils.secure_compare(ENV['MISSION_CONTROL_PASSWORD'], password)
+    expected_username = ENV['MISSION_CONTROL_USERNAME'].to_s
+    expected_password = ENV['MISSION_CONTROL_PASSWORD'].to_s
+
+    Rails.logger.info "[MissionControl Auth] Expected username length: #{expected_username.length}, Got: #{username.to_s.length}"
+    Rails.logger.info "[MissionControl Auth] Expected password length: #{expected_password.length}, Got: #{password.to_s.length}"
+
+    result = ActiveSupport::SecurityUtils.secure_compare(expected_username, username.to_s) &&
+             ActiveSupport::SecurityUtils.secure_compare(expected_password, password.to_s)
+
+    Rails.logger.info "[MissionControl Auth] Result: #{result}"
+    result
   end
 end


### PR DESCRIPTION
## Summary
- MissionControl管理画面（/jobs）の認証が失敗する問題を調査するためのデバッグログを追加
- 環境変数の長さと認証結果をログに出力

## Test plan
- ステージングにデプロイ後、/jobsにアクセスして認証を試みる
- Cloud Runのログで`[MissionControl Auth]`を確認

## Note
原因特定後、このデバッグログは削除します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 認証処理の入力値の正規化と検証ロジックを改善

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->