### PR TITLE
MissionControl認証を正しい設定に修正

### DIFF
--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 if Rails.env.production?
-  MissionControl::Jobs::Engine.middleware.use(Rack::Auth::Basic) do |username, password|
-    expected_username = ENV['MISSION_CONTROL_USERNAME'].to_s
-    expected_password = ENV['MISSION_CONTROL_PASSWORD'].to_s
-
-    Rails.logger.info "[MissionControl Auth] Expected username length: #{expected_username.length}, Got: #{username.to_s.length}"
-    Rails.logger.info "[MissionControl Auth] Expected password length: #{expected_password.length}, Got: #{password.to_s.length}"
-
-    result = ActiveSupport::SecurityUtils.secure_compare(expected_username, username.to_s) &&
-             ActiveSupport::SecurityUtils.secure_compare(expected_password, password.to_s)
-
-    Rails.logger.info "[MissionControl Auth] Result: #{result}"
-    result
-  end
+  MissionControl::Jobs.http_basic_auth_user = ENV['MISSION_CONTROL_USERNAME']
+  MissionControl::Jobs.http_basic_auth_password = ENV['MISSION_CONTROL_PASSWORD']
 end


### PR DESCRIPTION
## Summary
- Rack::Auth::BasicミドルウェアではなくMissionControl::Jobsの内蔵認証機能を使用
- 二重認証が発生していた問題を修正
- デバッグログを削除

## 原因
MissionControl::Jobsはデフォルトで`http_basic_auth_enabled: true`になっており、独自のHTTP Basic認証を行います。
これに加えてRack::Auth::Basicミドルウェアを追加していたため、二重認証になっていました。

## Test plan
- ステージングで/jobsにアクセスし、fjord/testtestで認証できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * Mission Control ジョブの認証設定を環境変数（MISSION_CONTROL_USERNAME、MISSION_CONTROL_PASSWORD）を使用した方式に更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->