### PR TITLE
MissionControl認証のデバッグコードを削除

### DIFF
--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 if Rails.env.production?
-  # 一時的にハードコードでテスト
-  MissionControl::Jobs.http_basic_auth_user = 'fjord'
-  MissionControl::Jobs.http_basic_auth_password = 'testtest'
-
-  Rails.logger.info "[MissionControl Init] User: #{MissionControl::Jobs.http_basic_auth_user.inspect}"
-  Rails.logger.info "[MissionControl Init] Password length: #{MissionControl::Jobs.http_basic_auth_password&.length}"
-  Rails.logger.info "[MissionControl Init] Auth enabled: #{MissionControl::Jobs.http_basic_auth_enabled}"
+  MissionControl::Jobs.http_basic_auth_user = ENV['MISSION_CONTROL_USERNAME']
+  MissionControl::Jobs.http_basic_auth_password = ENV['MISSION_CONTROL_PASSWORD']
 end


### PR DESCRIPTION
## Summary
- ハードコードとデバッグログを削除
- 環境変数を使った正しい設定に戻す

## 背景
ステージング環境ではアプリ全体に`BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD`でBasic認証がかかっているため、`/jobs`にアクセスするにはそちらの認証情報を使用する必要があります。

MissionControlの認証設定（`MISSION_CONTROL_USERNAME`/`MISSION_CONTROL_PASSWORD`）は本番環境用に残します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## チョア
* MissionControl Jobsの基本認証設定が環境変数から読み込まれるようになりました。
* 認証関連のログ出力が削除されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->