### PR TITLE
ステージング環境でMissionControl認証を無効化

### DIFF
--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 if Rails.env.production?
-  MissionControl::Jobs.http_basic_auth_user = ENV['MISSION_CONTROL_USERNAME']
-  MissionControl::Jobs.http_basic_auth_password = ENV['MISSION_CONTROL_PASSWORD']
+  staging = ENV['DB_NAME'] == 'bootcamp_staging'
+
+  if staging
+    # ステージング環境ではアプリ全体にBasic認証がかかっているため、
+    # MissionControlの認証を無効にして二重認証を防ぐ
+    MissionControl::Jobs.http_basic_auth_enabled = false
+  else
+    # 本番環境ではMissionControlの認証を有効にする
+    MissionControl::Jobs.http_basic_auth_user = ENV['MISSION_CONTROL_USERNAME']
+    MissionControl::Jobs.http_basic_auth_password = ENV['MISSION_CONTROL_PASSWORD']
+  end
 end


### PR DESCRIPTION
## Summary
- ステージング環境ではMissionControlの認証を無効化
- 本番環境ではMissionControlの認証を有効のまま維持

## 背景
ステージング環境ではアプリ全体に`BASIC_AUTH_USER`/`BASIC_AUTH_PASSWORD`でBasic認証がかかっています。
MissionControlの認証も有効だと二重認証になり、認証ループが発生していました。

## Test plan
- ステージングで`/jobs`にアクセスし、`fjord`/`Ahbai7nahmeing6b`で認証できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * MissionControl認証の環境別設定を更新しました
  * ステージング環境ではMissionControl認証が無効になります
  * 本番環境の認証動作を条件付きで制御できるようになりました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->