### PR TITLE
MissionControlをActionController::Baseから継承するよう変更

### DIFF
--- a/config/initializers/mission_control.rb
+++ b/config/initializers/mission_control.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# MissionControlはApplicationControllerではなくActionController::Baseを継承する
+# これにより、アプリのログイン認証（require_active_user_login）が適用されない
+MissionControl::Jobs.base_controller_class = 'ActionController::Base'
+
 if Rails.env.production?
   staging = ENV['DB_NAME'] == 'bootcamp_staging'
 


### PR DESCRIPTION
## Summary
- MissionControlの`base_controller_class`を`ActionController::Base`に設定
- これにより、アプリのログイン認証（`require_active_user_login`）が適用されなくなる

## 背景
MissionControlはデフォルトで`ApplicationController`を継承するため、
アプリのbefore_action（ログイン認証など）がすべて適用されていました。

`/jobs`へのアクセスはBasic認証のみで保護されるべきなので、
`ActionController::Base`を継承するよう変更しました。

## Test plan
- ステージングで`/jobs`にアクセスし、`fjord`/`Ahbai7nahmeing6b`で認証できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * MissionControl::Jobs の認証設定を変更し、アプリケーションレベルのログイン認証要件を削除しました。これにより、MissionControl へのアクセス制御が変更されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->