### PR TITLE
メモリキャッシュのサイズ制限を128MBに復元

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :memory_store
+  config.cache_store = :memory_store, { size: 128.megabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue


### PR DESCRIPTION
## Summary
- `config.cache_store = :memory_store` にサイズ制限 `{ size: 128.megabytes }` を復元

## 原因
solid_queue移行時（コミット 0af570b8f）に、production.rbがRails 8のテンプレートで上書きされた際、
キャッシュのサイズ制限が削除されていました。

- **変更前**: `config.cache_store = :memory_store, { size: 128.megabytes }`
- **変更後**: `config.cache_store = :memory_store`（無制限）

サイズ制限なしの`:memory_store`は無制限にメモリを使用するため、
本番環境でOOM（メモリ不足）が発生し、Service Unavailableになっていました。

## Test plan
- 本番環境でOOMが発生しなくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* プロダクション環境のメモリキャッシュ設定を更新し、メモリ使用量に制限を設定しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->