### PR TITLE
Solid Queueをasyncモードに変更してお知らせ通知バグを修正

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,6 +35,8 @@ port ENV.fetch("PORT", 3000)
 plugin :tmp_restart
 
 # Run solid_queue supervisor within puma
+# Use async mode for Cloud Run compatibility (fork mode doesn't work reliably in containers)
+solid_queue_mode :async
 plugin :solid_queue
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.


### PR DESCRIPTION
## Summary
- お知らせ（announcements）を新規作成・公開してもサイト内通知が飛ばないバグを修正
- Solid QueueのPumaプラグインをasyncモードに変更

## 原因
Solid QueueのPumaプラグインはデフォルトで`fork`モードを使用しています。
Cloud Runのコンテナ環境では、forkされた子プロセスが正しく動作しない（または早期に終了する）ため、ジョブが処理されませんでした。

```ruby
# lib/puma/plugin/solid_queue.rb
if launcher.options[:solid_queue_mode] == :async
  start_async(launcher)
else
  start_forked(launcher)  # ← デフォルトはforkモード
end
```

## 修正内容
`config/puma.rb`に`solid_queue_mode :async`を追加することで、フォークを使わずPumaプロセス内のスレッドでSolid Queueスーパーバイザーを実行するように変更しました。

## Test plan
- [ ] ステージング環境でお知らせを新規作成（WIPではなく公開）し、通知が届くことを確認
- [ ] WIPのお知らせを公開に変更し、通知が届くことを確認
- [ ] 既存の通知機能（質問、コメント、日報など）が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * クラウド環境での互換性向上のため、非同期処理モードの設定を追加しました。これにより、より安定した運用環境での動作が実現します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->