### PR TITLE
SolidQueueのスレッド数を削減してCPU負荷を軽減

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -4,7 +4,7 @@ default: &default
       batch_size: 500
   workers:
     - queues: "*"
-      threads: 3
+      threads: 1
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1
 


### PR DESCRIPTION
## Summary
- SolidQueueのワーカースレッド数を3から1に削減
- CPU使用率99%頻発による `ProcessPrunedError` を解消するため

## Background
本番環境でCPU使用率が頻繁に99%に達し、SolidQueueワーカーがハートビートを送信できず、プロセスがpruneされるエラーが頻発していた。

## 併せて行うCloud Run設定変更
- CPU: `1000m` → `2000m`
- 最小インスタンス数を増やす

## Test plan
- [ ] 本番デプロイ後、CPU使用率を監視
- [ ] ProcessPrunedErrorの発生頻度を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ワーカー設定の並行処理数を削減しました。キューの処理効率が調整されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->