### PR TITLE
ステージングDB作成時にpgvector拡張を有効化

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -164,6 +164,12 @@ steps:
         ActiveRecord::Base.connection.execute("CREATE DATABASE bootcamp_staging")
         puts "Database created successfully"
         SQLEOF
+
+        echo "Enabling pgvector extension..."
+        cat <<'SQLEOF' | DB_NAME=bootcamp_staging bin/rails runner - 2>&1
+        ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        puts "pgvector extension enabled"
+        SQLEOF
     waitFor:
       - DeleteDB
     volumes:


### PR DESCRIPTION
## Summary
- ステージングデプロイのCreateDBステップでDB作成直後に`CREATE EXTENSION IF NOT EXISTS vector`を実行
- DB DROP/CREATE後にマイグレーションのガードでvector拡張の有効化がスキップされ、embeddingカラムが作成されない問題を修正

## Test plan
- [ ] ステージングデプロイを実行し、`embedding`カラムが作成されることを確認
- [ ] `bootcamp-task-staging`トリガーでembeddingが生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ステージング環境のデータベース設定を更新し、ベクター拡張機能を有効化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->