### PR TITLE
pgvector有効化を別ステップに分離してbootcamp_stagingに接続

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -164,12 +164,6 @@ steps:
         ActiveRecord::Base.connection.execute("CREATE DATABASE bootcamp_staging")
         puts "Database created successfully"
         SQLEOF
-
-        echo "Enabling pgvector extension..."
-        cat <<'SQLEOF' | DB_NAME=bootcamp_staging bin/rails runner - 2>&1
-        ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
-        puts "pgvector extension enabled"
-        SQLEOF
     waitFor:
       - DeleteDB
     volumes:
@@ -184,6 +178,33 @@ steps:
       - DB_USER=$_DB_USER
       - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
       - APP_HOST_NAME=$_APP_HOST_NAME
+  - id: EnablePgvector
+    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        set -euo pipefail
+
+        echo "Enabling pgvector extension on bootcamp_staging..."
+        cat <<'SQLEOF' | bin/rails runner - 2>&1
+        ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        puts "pgvector extension enabled"
+        SQLEOF
+    waitFor:
+      - CreateDB
+    volumes:
+      - name: db
+        path: /cloudsql
+    env:
+      - RAILS_ENV=production
+      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
+      - DB_NAME=$_DB_NAME
+      - DB_PASS=$_DB_PASS
+      - DB_USER=$_DB_USER
+      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
+      - APP_HOST_NAME=$_APP_HOST_NAME
   - id: DBMigrate
     name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
     args:
@@ -191,7 +212,7 @@ steps:
       - db:migrate
       - db:seed
     waitFor:
-      - CreateDB
+      - EnablePgvector
     volumes:
       - name: db
         path: /cloudsql


### PR DESCRIPTION
## Summary
- CreateDBステップ内のpgvector有効化が`postgres`DBに対して実行されていた問題を修正
- `EnablePgvector`ステップとして分離し、`DB_NAME=$_DB_NAME`で`bootcamp_staging`に接続して`CREATE EXTENSION`を実行
- DBMigrateの依存先を`EnablePgvector`に変更

## Test plan
- [ ] ステージングデプロイでEnablePgvectorステップが成功することを確認
- [ ] db:migrateでembeddingカラムが作成されることを確認
- [ ] タスクトリガーでembedding生成が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストはステージング環境の内部インフラストラクチャ構成の更新に関するものです。エンドユーザーに直接影響を与える変更はありません。

* **その他**
  * ステージング環境のデプロイメント設定を最適化しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->