### PR TITLE
動画機能の表示制御をフィーチャーフラグに変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,8 @@ module ApplicationHelper
   def smart_search_available?
     Rails.env.local? || Switchlet.enabled?(:smart_search)
   end
+
+  def movie_available?
+    Rails.env.local? || Switchlet.enabled?(:movie)
+  end
 end

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -8,8 +8,7 @@ module PageTabs
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports.length }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
-      # TODO: 動画機能の完成時に本番環境で公開。動画リンクを隠した状態でのリリース。
-      tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length } unless Rails.env.production?
+      tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length } if movie_available?
       tabs << { name: '提出物', link: practice_products_path(practice) }
       tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?
       tabs << { name: 'コーディングテスト', link: practice_coding_tests_path(practice) } if practice.coding_tests.present?

--- a/app/views/pages/_doc_movie_header.html.slim
+++ b/app/views/pages/_doc_movie_header.html.slim
@@ -3,8 +3,7 @@ header.page-header
     .page-header__inner
       .page-header__start
         h2.page-header__title
-          - if Rails.env.production?
-            // 動画リンクを隠した状態でのリリース。リリース後にDocs・動画に変更する
-            | Docs
-          - else
+          - if movie_available?
             | Docs・動画
+          - else
+            | Docs

--- a/app/views/pages/_tabs.html.slim
+++ b/app/views/pages/_tabs.html.slim
@@ -4,8 +4,7 @@
       li.page-tabs__item
         = link_to pages_path, class: "page-tabs__item-link #{current_link(/^pages/)}"
           | Docs
-      - unless Rails.env.production?
-        // リンクを隠した状態でのリリース
+      - if movie_available?
         li.page-tabs__item
           = link_to movies_path, class: "page-tabs__item-link #{current_link(/^movies/)}"
             | 動画


### PR DESCRIPTION
## Summary
- `Rails.env.production?` による動画機能の表示制御を `movie_available?` ヘルパーに変更
- development/test環境では常に有効、本番環境では `Switchlet.enabled?(:movie)` で制御
- `smart_search_available?` と同じパターン

### 変更箇所
- `app/helpers/application_helper.rb`: `movie_available?` ヘルパー追加
- `app/views/pages/_doc_movie_header.html.slim`: ヘッダータイトルの表示制御
- `app/views/pages/_tabs.html.slim`: 動画タブの表示制御
- `app/helpers/page_tabs/practices_helper.rb`: プラクティス内の動画タブの表示制御

## Test plan
- [ ] development環境で「Docs・動画」ヘッダーと動画タブが表示されることを確認
- [ ] プラクティス詳細ページに動画タブが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 動画コンテンツの利用可能状況がより柔軟に制御できるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->