### PR TITLE
曜日配列の管理場所をRailsに統一するためdatasetでJS側に渡すようにした

### DIFF
--- a/app/components/grass/grass_component.html.slim
+++ b/app/components/grass/grass_component.html.slim
@@ -20,4 +20,4 @@
               i.fa-solid.fa-angle-right
         - else
           .user-grass-nav__next.is-blank
-      canvas.grass.a-grass data-times="#{times.to_json}" width="650" height="130"
+      canvas.grass.a-grass data-times="#{times.to_json}" data-dotw=I18n.t('date.abbr_day_names').to_json width="650" height="130"

--- a/app/javascript/grass.js
+++ b/app/javascript/grass.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ctx.clearRect(0, 0, 650, 130)
 
     const colors = ['#e2e5ec', '#98A5DA', '#5D72C4', '#223FAF', '#06063e']
-    const dotw = ['日', '月', '火', '水', '木', '金', '土']
+    const dotw = JSON.parse(canvas.dataset.dotw)
     for (let i = 0; i < dotw.length; i++) {
       ctx.strokeText(dotw[i], 0, startY + 8 + (height + spanY) * i)
     }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- Issue番号

## 概要

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. 

## Screenshot

### 変更前

### 変更後

<!-- I want to review in Japanese. -->
