### PR TITLE
fix: vectorのextensionを有効にするマイグレーション時にエラーが発生してもスルーされるようにした

### DIFF
--- a/db/migrate/20260119100000_enable_vector_extension.rb
+++ b/db/migrate/20260119100000_enable_vector_extension.rb
@@ -8,8 +8,7 @@ class EnableVectorExtension < ActiveRecord::Migration[8.1]
 
     rescue ActiveRecord::StatementInvalid => e
       Rails.logger.warn "Notice: pgvector extension could not be enabled."
-      Rails.logger.warn  "Error details: #{e.message}"
-    rescue => e
-      Rails.logger.warn  "An unexpected error occurred: #{e.message}"
+      Rails.logger.warn "Error details: #{e.message}"
   end
 end
+


### PR DESCRIPTION
## Issue

- 立てるの忘れました！ごめんなさい！

## 概要

PostgreSQL の vectorのextension を有効にするためにはモジュールを別途インストールする必要がある。
未インストールの場合はここのマイグレーションで失敗して、`db:migrate` が成功しない。
disable_ddl_transaction! を追加して自動トランザクションを意図的にオフにすることで、失敗しないようにした。
詳細は [Rails ガイド](https://railsguides.jp/active_record_migrations.html#%E3%83%88%E3%83%A9%E3%83%B3%E3%82%B6%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3) を参照のこと。

## 変更確認方法

以下コマンドが問題なく実行できること。

`rails db:migrate:down VERSION=20260119100000`
`rails db:rollback `rails db:migrate` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * データベース拡張の有効化が失敗した際、詳細な警告とエラーメッセージをログに残すようになりました。

* **Improvements**
  * 拡張有効化処理がトランザクション外でも安全に実行されるよう改善され、初期化の堅牢性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->