### PR TITLE
ボタンとflashメッセージの文言を「コピー」から「複製」に変更した

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -26,7 +26,7 @@ class AnnouncementsController < ApplicationController
 
     if params[:id]
       @announcement = Announcement.copy_announcement(params[:id])
-      flash.now[:notice] = 'お知らせをコピーしました。'
+      flash.now[:notice] = 'お知らせを複製しました。'
     elsif params[:page_id]
       page = Page.find(params[:page_id])
       @announcement = Announcement.copy_template_by_resource('page_announcements.yml', page:)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -101,7 +101,7 @@ class EventsController < ApplicationController
     new_event.description = event.description
     new_event.job_hunting = event.job_hunting
 
-    flash.now[:notice] = '特別イベントをコピーしました。'
+    flash.now[:notice] = '特別イベントを複製しました。'
   end
 
   def update_published_at

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -112,7 +112,7 @@ class RegularEventsController < ApplicationController
     new_event.attributes = regular_event.attributes.slice('title', 'description', 'finished', 'hold_national_holiday', 'start_at', 'end_at', 'category')
     new_event.user_ids = regular_event.organizers.map(&:id)
 
-    flash.now[:notice] = '定期イベントをコピーしました。'
+    flash.now[:notice] = '定期イベントを複製しました。'
   end
 
   def set_all_user_participants_and_watchers

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -43,9 +43,9 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
 
     report              = current_user.reports.find(params[:id])
     @report.title       = report.title
-    @report.description = "<!-- #{report.reported_on} の日報をコピー -->\n" + report.description
+    @report.description = "<!-- #{report.reported_on} の日報を複製 -->\n" + report.description
     @report.practices   = report.practices
-    flash.now[:notice] = '日報をコピーしました。'
+    flash.now[:notice] = '日報を複製しました。'
   end
 
   def edit

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -60,9 +60,7 @@ hr.a-border
                       | Bookmark
                 .page-content-header-actions__end
                   .page-content-header-actions__action
-                    = link_to new_announcement_path(id: @announcement), class: 'a-button is-sm is-secondary is-block', id: 'copy' do
-                      i.fa-solid.fa-copy
-                      | コピー
+                    = link_to '複製', new_announcement_path(id: @announcement), class: 'a-button is-sm is-secondary is-block', id: 'copy'
 
         .a-card
           .card-body

--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -25,6 +25,4 @@
                   i.fa-solid.fa-align-justify
                   | 並び替え
               li.card-main-actions__item
-                = link_to new_mentor_course_path(course_id: course.id), class: 'a-button is-sm is-secondary is-block' do
-                  i.fa-solid.fa-copy
-                  | コピー
+                = link_to '複製', new_mentor_course_path(course_id: course.id), class: 'a-button is-sm is-secondary is-block'

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -34,9 +34,7 @@
             = render 'watches/watch_toggle', type: event.class.to_s, id: event.id, watch: event.watch_by(current_user)
           .page-content-header-actions__end
             .page-content-header-actions__action
-              = link_to new_event_path(id: event), class: 'a-button is-sm is-secondary is-block', id: 'copy' do
-                i.fa-solid.fa-copy
-                | コピー
+              = link_to '複製', new_event_path(id: event), class: 'a-button is-sm is-secondary is-block', id: 'copy'
 
   = render('event_meta', event:)
 

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -49,9 +49,7 @@
                 | Bookmark
           .page-content-header-actions__end
             .page-content-header-actions__action
-              = link_to new_regular_event_path(id: regular_event), class: 'a-button is-sm is-secondary is-block', id: 'copy' do
-                i.fa-solid.fa-copy
-                | コピー
+              = link_to '複製', new_regular_event_path(id: regular_event), class: 'a-button is-sm is-secondary is-block', id: 'copy'
 
   = render('regular_event_meta', regular_event:)
 

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -28,9 +28,7 @@
                         i.fa-solid.fa-pen
                         | 内容変更
                     li.card-list-item-actions__item
-                      = link_to new_report_path(id: report), class: 'card-list-item-actions__action' do
-                        i.fa-solid.fa-copy
-                        | コピー
+                      = link_to '複製', new_report_path(id: report), class: 'card-list-item-actions__action'
                   label.a-overlay(for="#{report.id}")
       .card-list-item__row
         .card-list-item-meta

--- a/app/views/reports/_report_header.html.slim
+++ b/app/views/reports/_report_header.html.slim
@@ -59,9 +59,7 @@ header.page-content-header.is-report
         .page-content-header-actions__end
           - if report.user_id == current_user.id
             .page-content-header-actions__action
-              = link_to new_report_path(id: report), class: 'a-button is-sm is-secondary is-block', id: 'copy' do
-                i.fa-solid.fa-copy
-                | コピー
+              = link_to '複製', new_report_path(id: report), class: 'a-button is-sm is-secondary is-block', id: 'copy'
           .page-content-header-actions__action
             = link_to 'Raw', report_path(format: :md), class: 'a-button is-sm is-secondary is-block', target: '_blank', rel: 'noopener'
 

--- a/test/system/announcements/crud_test.rb
+++ b/test/system/announcements/crud_test.rb
@@ -32,23 +32,23 @@ module Announcements
 
     test 'announcement has a copy form when user is admin' do
       visit_with_auth "/announcements/#{announcements(:announcement4).id}", 'komagata'
-      click_link 'コピー'
+      click_link '複製'
 
-      assert_text 'お知らせをコピーしました。'
+      assert_text 'お知らせを複製しました。'
     end
 
     test 'announcement has a copy form when user is author' do
       visit_with_auth "/announcements/#{announcements(:announcement4).id}", 'kimura'
-      click_link 'コピー'
+      click_link '複製'
 
-      assert_text 'お知らせをコピーしました。'
+      assert_text 'お知らせを複製しました。'
     end
 
     test 'general user can copy submitted announcement' do
       announcement = announcements(:announcement1)
       visit_with_auth announcement_path(announcement), 'kimura'
       within '.announcement' do
-        assert_text 'コピー'
+        assert_text '複製'
       end
     end
   end

--- a/test/system/announcements/wip_test.rb
+++ b/test/system/announcements/wip_test.rb
@@ -37,7 +37,7 @@ module Announcements
       announcement = announcements(:announcement_wip)
       visit_with_auth announcement_path(announcement), 'kimura'
       within '.announcement' do
-        assert_text 'コピー'
+        assert_text '複製'
       end
     end
 

--- a/test/system/events/crud_test.rb
+++ b/test/system/events/crud_test.rb
@@ -26,8 +26,8 @@ module Events
     test 'create copy event' do
       event = events(:event1)
       visit_with_auth event_path(event), 'kimura'
-      click_link 'コピー'
-      assert_text '特別イベントをコピーしました'
+      click_link '複製'
+      assert_text '特別イベントを複製しました'
       within 'form[name=event]' do
         fill_in 'event[start_at]', with: Time.current.next_day
         fill_in 'event[end_at]', with: Time.current.next_day + 2.hours

--- a/test/system/regular_events/crud_test.rb
+++ b/test/system/regular_events/crud_test.rb
@@ -34,8 +34,8 @@ module RegularEvents
     test 'create copy regular event' do
       regular_event = regular_events(:regular_event1)
       visit_with_auth regular_event_path(regular_event), 'komagata'
-      click_link 'コピー'
-      assert_text '定期イベントをコピーしました'
+      click_link '複製'
+      assert_text '定期イベントを複製しました'
       within 'form[name=regular_event]' do
         first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__frequency select').select('毎週')
         first('.regular-event-repeat-rule').first('.regular-event-repeat-rule__day-of-the-week select').select('月曜日')

--- a/test/system/reports/markdown_test.rb
+++ b/test/system/reports/markdown_test.rb
@@ -53,7 +53,7 @@ module Reports
 
     test 'description of the daily report is previewed when copied' do
       visit_with_auth report_path(reports(:report1)), 'komagata'
-      click_link 'コピー'
+      click_link '複製'
       within('form[name=report]') do
         fill_in('report[description]', with: "Markdown入力するとプレビューにHTMLで表示されている。\n # h1")
       end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9542

## 概要
 - 複製機能を持つボタンの文言を「コピー」から「複製」に変更する。
 - コピーのアイコンを削除する。
 - このプルリクではメッセージの文言の修正のみを行う。そのため、プログラムの変数名等はcopyのままである。

## 変更確認方法

1. feature/display-copy-to-duplicate をローカルに取り込む
2. ローカルサーバーを起動する
3. komagataでログインする
4. [お知らせ](http://localhost:3000/announcements/721644200) にアクセスする
5. ボタンが「複製」になっていることを確認する
6. 複製ボタンをクリックして、フラッシュメッセージが「xxxxを複製しました」になっていることを確認する
7. [コース一覧](http://localhost:3000/courses) にアクセスする
8. No.5と同様の確認を行う
9. [特別イベント](http://localhost:3000/events/994018171)にアクセスする
10. No.5, 6と同様の確認を行う
11. [定期イベント](http://localhost:3000/regular_events/459650222)にアクセスする
12. No.5, 6と同様の確認を行う
13. [日報](http://localhost:3000/reports/416111605)にアクセスする
14. No.5, 6と同様の確認を行う（この日報のテストデータを使用してNo.6を実施するとエラーが発生します。フラッシュメッセージが読みにくければ新規の日報を作成し、テストを実施してください）
15. 日報の「内容」に追加されたコメントが「`<!-- xxxxxxxx の日報を複製 -->`」になっていることを確認する
16. [日報一覧](http://localhost:3000/reports/)にアクセスする
17. 日報の行の3点リーダーをクリックする
18. 表示されたメニューが「複製」になっていることを確認する

## Screenshot

### 変更前

#### お知らせ
<img width="732" height="148" alt="image" src="https://github.com/user-attachments/assets/eac4e68a-e269-49ac-bda0-cfacf000c410" />
<img width="308" height="48" alt="image" src="https://github.com/user-attachments/assets/66908e87-1c42-4e81-95a8-5eef66c6cde9" />

#### コース一覧
<img width="293" height="387" alt="image" src="https://github.com/user-attachments/assets/0bbcfb9e-0063-4f09-881f-b8e7214ff2ec" />

#### 特別イベント
<img width="741" height="125" alt="image" src="https://github.com/user-attachments/assets/76a8e9b4-6990-43b2-9f51-1a20f0bc92c1" />
<img width="282" height="44" alt="image" src="https://github.com/user-attachments/assets/6b2e6b20-4a8d-4562-aba6-256597861f3b" />

#### 定期イベント
<img width="789" height="140" alt="image" src="https://github.com/user-attachments/assets/aba09f80-c035-46ba-8d8b-cbf1aa5f6a2b" />
<img width="325" height="41" alt="image" src="https://github.com/user-attachments/assets/558c63d3-4ce0-47fe-b145-8e438b747235" />

#### 日報(詳細)
<img width="848" height="148" alt="image" src="https://github.com/user-attachments/assets/d07d661d-2c18-4060-8cb3-369b03c2bd5b" />
<img width="311" height="26" alt="image" src="https://github.com/user-attachments/assets/8c391c9e-38dd-4ac9-921b-6c1e067e0fef" />


#### 日報(一覧)
<img width="738" height="154" alt="image" src="https://github.com/user-attachments/assets/093a8824-9765-4cd1-a014-c2d538cc1d1c" />

### 変更後

#### お知らせ
<img width="735" height="161" alt="image" src="https://github.com/user-attachments/assets/f29b5fa2-c629-413f-823b-e52716a024e2" />
<img width="335" height="54" alt="image" src="https://github.com/user-attachments/assets/3fc91c64-465f-4890-80e7-8db1c042484b" />

#### コース一覧
<img width="290" height="381" alt="image" src="https://github.com/user-attachments/assets/8f00200b-13c3-4a42-a070-1176d510b174" />

#### 特別イベント
<img width="751" height="153" alt="image" src="https://github.com/user-attachments/assets/2ab19437-5764-4a87-ae31-fc97f2f8d8e9" />
<img width="335" height="50" alt="image" src="https://github.com/user-attachments/assets/8bd86fcf-be97-4ea1-a6c5-6525aac9dcc4" />

#### 定期イベント
<img width="728" height="134" alt="image" src="https://github.com/user-attachments/assets/7ea0926b-ab25-4a68-80e8-13d45d1bc49b" />
<img width="334" height="52" alt="image" src="https://github.com/user-attachments/assets/7dc6e7b7-3efa-4df3-885a-2696dafac4a3" />

#### 日報(詳細)
<img width="857" height="161" alt="image" src="https://github.com/user-attachments/assets/be6b2536-9f10-498f-b314-5a6babe2e648" />
<img width="338" height="47" alt="image" src="https://github.com/user-attachments/assets/4bb774c8-96a6-4e06-840e-0c99598f751c" />

#### 日報(一覧)
<img width="715" height="98" alt="image" src="https://github.com/user-attachments/assets/6effd3c2-626d-4dad-8a56-2f95338b6131" />

<!-- I want to review in Japanese. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 各機能の複製ボタン表示を「コピー」から「複製」に統一しました。
  * 複製ボタンのアイコンを削除し、テキストのみの表示に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->