### PR TITLE
fix: イベント作成テストのフレーキーを修正する

### DIFF
--- a/test/system/events/crud_test.rb
+++ b/test/system/events/crud_test.rb
@@ -18,8 +18,8 @@ module Events
       end
       assert_difference 'Event.count', 1 do
         click_button 'イベントを公開'
+        assert_text '特別イベントを作成しました。'
       end
-      assert_text '特別イベントを作成しました。'
       assert_text 'Watch中'
     end
 


### PR DESCRIPTION
assert_differenceブロック内でclick_button後にDB書き込み完了を
待たずカウントを確認していたため、タイミングによってEvent.count
が変化しないことがあった。ブロック内でフラッシュメッセージの
表示を待つことでDB書き込み完了後にカウントを確認するようにした。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テストのアサーション実行タイミングを最適化しました。機能的な動作変更はありません。

---

**注記:** 本変更は内部的なテストの改善であり、ユーザー向けの機能変更ではありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->