### PR TITLE
コピーしたメッセージの背景色が出ていないのを修正

### DIFF
--- a/app/assets/stylesheets/application/blocks/thread/_thread-comment.css
+++ b/app/assets/stylesheets/application/blocks/thread/_thread-comment.css
@@ -213,7 +213,7 @@
 .thread-comment__created-at.is-active::after {
   content: "Copied!";
   display: block;
-  background-color: rgba(black, .4);
+  background-color: #00000085;
   border-radius: .125rem;
   padding: .25rem;
   font-size: .625rem;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * コピー完了時に表示されるツールチップバブルの背景色を調整し、より良い視覚的な一貫性を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->