### PR TITLE
給付金コースのプラクティスの関連Docs一覧に、元コースの関連Docsが表示できるようにする。

### DIFF
--- a/app/controllers/practices/pages_controller.rb
+++ b/app/controllers/practices/pages_controller.rb
@@ -6,12 +6,17 @@ class Practices::PagesController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
     @include_source = include_source?
-    @pages = Page.with_avatar
-                 .includes(:comments, :practice, { last_updated_user: { avatar_attachment: :blob } })
-                 .where(practice_id: params[:practice_id])
-                 .order(updated_at: :desc, id: :desc)
-                 .page(params[:page])
-                 .per(PAGER_NUMBER)
+    @pages =
+      if @include_source
+        Page.for_practice_including_source(@practice)
+      else
+        @practice.pages
+      end
+      .with_avatar
+      .includes(:comments, :practice, { last_updated_user: { avatar_attachment: :blob } })
+      .order(updated_at: :desc, id: :desc)
+      .page(params[:page])
+      .per(PAGER_NUMBER)
   end
 
   private

--- a/app/controllers/practices/pages_controller.rb
+++ b/app/controllers/practices/pages_controller.rb
@@ -5,6 +5,7 @@ class Practices::PagesController < ApplicationController
 
   def index
     @practice = Practice.find(params[:practice_id])
+    @include_source = include_source?
     @pages = Page.with_avatar
                  .includes(:comments, :practice, { last_updated_user: { avatar_attachment: :blob } })
                  .where(practice_id: params[:practice_id])

--- a/app/controllers/practices/pages_controller.rb
+++ b/app/controllers/practices/pages_controller.rb
@@ -12,4 +12,13 @@ class Practices::PagesController < ApplicationController
                  .page(params[:page])
                  .per(PAGER_NUMBER)
   end
+
+  private
+
+  def include_source?
+    # 給付金コースの場合、include_sourceはデフォルトでtrue
+    return false unless @practice.grant_course?
+
+    params.fetch(:include_source, 'true') == 'true'
+  end
 end

--- a/app/controllers/practices/pages_controller.rb
+++ b/app/controllers/practices/pages_controller.rb
@@ -13,7 +13,7 @@ class Practices::PagesController < ApplicationController
         @practice.pages
       end
       .with_avatar
-      .includes(:comments, :practice, { last_updated_user: { avatar_attachment: :blob } })
+      .preload(:comments, :practice, { last_updated_user: { avatar_attachment: :blob } })
       .order(updated_at: :desc, id: :desc)
       .page(params[:page])
       .per(PAGER_NUMBER)

--- a/app/controllers/practices/pages_controller.rb
+++ b/app/controllers/practices/pages_controller.rb
@@ -6,17 +6,18 @@ class Practices::PagesController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
     @include_source = include_source?
-    @pages =
-      if @include_source
-        Page.for_practice_including_source(@practice)
-      else
-        @practice.pages
-      end
-      .with_avatar
-      .preload(:comments, :practice, { last_updated_user: { avatar_attachment: :blob } })
-      .order(updated_at: :desc, id: :desc)
-      .page(params[:page])
-      .per(PAGER_NUMBER)
+
+    base_pages = if @include_source
+                   Page.for_practice_including_source(@practice)
+                 else
+                   @practice.pages
+                 end
+    @pages = base_pages
+             .with_avatar
+             .preload(:comments, :practice, { last_updated_user: { avatar_attachment: :blob } })
+             .order(updated_at: :desc, id: :desc)
+             .page(params[:page])
+             .per(PAGER_NUMBER)
   end
 
   private

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -9,7 +9,7 @@ module PageTabs
       tabs << { name: 'プラクティス', link: practice_path(practice) }
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports_count(include_source:) }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice_questions_count(practice, active_tab:) }
-      tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.count }
+      tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages_count(include_source:) }
       tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.count } if movie_available?
       tabs << { name: '提出物', link: practice_products_path(practice) } if practice.submission
       tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -23,6 +23,11 @@ class Page < ApplicationRecord
 
   before_validation :empty_slug_to_nil
 
+  scope :for_practice_including_source, lambda { |practice|
+    ids = [practice.id, practice.source_id].compact
+    where(practice_id: ids)
+  }
+
   def self.ransackable_attributes(_auth_object = nil)
     %w[title body slug wip created_at updated_at user_id last_updated_user_id practice_id]
   end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -221,6 +221,12 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     Report.for_practice_including_source(self).count
   end
 
+  def pages_count(include_source: false)
+    return pages.count unless include_source
+
+    Page.for_practice_including_source(self).count
+  end
+
   private
 
   def total_learning_minute(report)

--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -22,7 +22,6 @@
           class: ['pill-nav__item-link', ('is-active' if !@include_source)]
 
 .page-body
-  = paginate @pages
   .container.is-md
     - if @pages.empty?
       .o-empty-message
@@ -31,7 +30,8 @@
         p.o-empty-message__text
           | Docはまだありません
     - else
+      = paginate @pages
       .card-list.a-card
         .card-list__items
           = render partial: 'pages/page', collection: @pages
-  = paginate @pages
+      = paginate @pages

--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -7,7 +7,19 @@
   category: category,
   practice: @practice
 
-= practice_page_tabs(@practice, active_tab: 'Docs')
+= practice_page_tabs(@practice, active_tab: 'Docs', include_source: @include_source)
+
+- if @practice.grant_course?
+  nav.pill-nav
+    ul.pill-nav__items
+      li.pill-nav__item
+        = link_to '全て',
+          practice_pages_path(@practice, include_source: true),
+          class: ['pill-nav__item-link', ('is-active' if @include_source)]
+      li.pill-nav__item
+        = link_to '給付金コース',
+          practice_pages_path(@practice, include_source: false),
+          class: ['pill-nav__item-link', ('is-active' if !@include_source)]
 
 .page-body
   = paginate @pages

--- a/db/fixtures/pages.yml
+++ b/db/fixtures/pages.yml
@@ -294,7 +294,7 @@ page35:
   user: komagata
   published_at: "2023-02-05 00:00:00"
 
-page34:
+page36:
   title: OS X Mountain Lionをクリーンインストールする（Reスキル）のDoc
   body: 給付金コースのDoc
   created_at: "2026-07-07 19:00:00"

--- a/db/fixtures/pages.yml
+++ b/db/fixtures/pages.yml
@@ -293,3 +293,13 @@ page35:
   slug: help-adviser
   user: komagata
   published_at: "2023-02-05 00:00:00"
+
+page34:
+  title: OS X Mountain Lionをクリーンインストールする（Reスキル）のDoc
+  body: 給付金コースのDoc
+  created_at: "2026-07-07 19:00:00"
+  updated_at: "2026-07-07 19:00:00"
+  user: grant-course
+  practice: practice115
+  published_at: "2026-06-30 19:00:00"
+  last_updated_user: grant-course

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -101,3 +101,17 @@ page11:
   body: test
   user: long-id-mentor
   published_at: "2022-04-15 00:00:00"
+
+page12:
+  title: rubyをインストールするには(Reスキル)Doc
+  body: 給付金プラクティスのDoc
+  practice: practice64
+  user: grant-course
+  published_at: "2026-04-15 00:00:00"
+
+page13:
+  title: rubyをインストールするにはDoc
+  body: 通常プラクティスのDoc。元プラクティスはpractice113。
+  practice: practice23
+  user: grant-course
+  published_at: "2026-04-15 00:00:00"

--- a/test/fixtures/pages.yml
+++ b/test/fixtures/pages.yml
@@ -111,7 +111,7 @@ page12:
 
 page13:
   title: rubyをインストールするにはDoc
-  body: 通常プラクティスのDoc。元プラクティスはpractice113。
+  body: 通常プラクティスのDoc。元プラクティスはpractice23。
   practice: practice23
   user: grant-course
   published_at: "2026-04-15 00:00:00"

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PageTest < ActiveSupport::TestCase
+  test '.for_practice_including_source returns practice and source pages' do
+    practice_page = pages(:page12)
+    source_page = pages(:page13)
+    other_page = pages(:page11)
+    result = Page.for_practice_including_source(practice_page.practice)
+
+    assert_includes result, practice_page
+    assert_includes result, source_page
+    assert_not_includes result, other_page
+  end
+end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -148,4 +148,52 @@ class PracticeTest < ActiveSupport::TestCase
     assert_equal initial_count + 1, practice.reports_count(include_source: false)
     assert_equal initial_count_including_source + 1, practice.reports_count(include_source: true)
   end
+
+  test '#pages_count sums pages of self and source when include_source is true' do
+    source_practice = practices(:practice23)
+    practice = practices(:practice64)
+
+    Page.where(practice: [source_practice, practice]).destroy_all
+
+    Page.create!(
+      user: users(:'grant-course'),
+      title: 'rubyをインストールするにはDoc',
+      body: '通常プラクティスのDoc。',
+      practice: source_practice,
+      published_at: Time.zone.today
+    )
+    Page.create!(
+      user: users(:komagata),
+      title: 'rubyをインストールするには(Reスキル)Doc',
+      body: '給付金プラクティスのDoc',
+      practice: practice,
+      published_at: Time.zone.today - 1
+    )
+
+    assert_equal 2, practice.pages_count(include_source: true)
+  end
+
+  test '#pages_count counts only self pages when include_source is false' do
+    source_practice = practices(:practice23)
+    practice = practices(:practice64)
+
+    Page.where(practice: [source_practice, practice]).destroy_all
+
+    Page.create!(
+      user: users(:'grant-course'),
+      title: 'rubyをインストールするにはDoc',
+      body: '通常プラクティスのDoc。',
+      practice: source_practice,
+      published_at: Time.zone.today
+    )
+    Page.create!(
+      user: users(:komagata),
+      title: 'rubyをインストールするには(Reスキル)Doc',
+      body: '給付金プラクティスのDoc',
+      practice: practice,
+      published_at: Time.zone.today - 1
+    )
+
+    assert_equal 1, practice.pages_count(include_source: false)
+  end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -150,50 +150,44 @@ class PracticeTest < ActiveSupport::TestCase
   end
 
   test '#pages_count sums pages of self and source when include_source is true' do
-    source_practice = practices(:practice23)
-    practice = practices(:practice64)
-
-    Page.where(practice: [source_practice, practice]).destroy_all
-
-    Page.create!(
-      user: users(:'grant-course'),
-      title: 'rubyをインストールするにはDoc',
-      body: '通常プラクティスのDoc。',
-      practice: source_practice,
-      published_at: Time.zone.today
+    normal_practice = Practice.create!(
+      title: 'テスト用プラクティス 通常コース',
+      description: 'テスト用',
+      categories: [categories(:category1)],
+      goal: 'goal...'
     )
-    Page.create!(
-      user: users(:komagata),
-      title: 'rubyをインストールするには(Reスキル)Doc',
-      body: '給付金プラクティスのDoc',
-      practice: practice,
-      published_at: Time.zone.today - 1
+    grant_practice = Practice.create!(
+      title: 'テスト用プラクティス 給付金コース',
+      description: 'テスト用',
+      categories: [categories(:category1)],
+      goal: 'goal...',
+      source_practice: normal_practice
     )
 
-    assert_equal 2, practice.pages_count(include_source: true)
+    Page.create!(title: '通常のプラクティスDoc', body: '本文', user: users(:kimura), practice: normal_practice)
+    Page.create!(title: '給付金のプラクティスDoc', body: '本文', user: users(:kimura), practice: grant_practice)
+
+    assert_equal 2, grant_practice.pages_count(include_source: true)
   end
 
   test '#pages_count counts only self pages when include_source is false' do
-    source_practice = practices(:practice23)
-    practice = practices(:practice64)
-
-    Page.where(practice: [source_practice, practice]).destroy_all
-
-    Page.create!(
-      user: users(:'grant-course'),
-      title: 'rubyをインストールするにはDoc',
-      body: '通常プラクティスのDoc。',
-      practice: source_practice,
-      published_at: Time.zone.today
+    normal_practice = Practice.create!(
+      title: 'テスト用プラクティス 通常コース',
+      description: 'テスト用',
+      categories: [categories(:category1)],
+      goal: 'goal...'
     )
-    Page.create!(
-      user: users(:komagata),
-      title: 'rubyをインストールするには(Reスキル)Doc',
-      body: '給付金プラクティスのDoc',
-      practice: practice,
-      published_at: Time.zone.today - 1
+    grant_practice = Practice.create!(
+      title: 'テスト用プラクティス 給付金コース',
+      description: 'テスト用',
+      categories: [categories(:category1)],
+      goal: 'goal...',
+      source_practice: normal_practice
     )
 
-    assert_equal 1, practice.pages_count(include_source: false)
+    Page.create!(title: '通常のプラクティスDoc', body: '本文', user: users(:kimura), practice: normal_practice)
+    Page.create!(title: '給付金のプラクティスDoc', body: '本文', user: users(:kimura), practice: grant_practice)
+
+    assert_equal 1, grant_practice.pages_count(include_source: false)
   end
 end

--- a/test/system/practice/pages_test.rb
+++ b/test/system/practice/pages_test.rb
@@ -24,4 +24,29 @@ class Practice::PagesTest < ApplicationSystemTestCase
       assert_selector 'img[class="card-list-item-meta__icon a-user-icon"]'
     end
   end
+
+  test 'show grant filter with all tab active by default' do
+    normal_practice = Practice.create!(
+      title: 'テスト用プラクティス 通常コース',
+      description: 'テスト用',
+      categories: [categories(:category1)],
+      goal: 'goal...'
+    )
+    grant_practice = Practice.create!(
+      title: 'テスト用プラクティス 給付金コース',
+      description: 'テスト用',
+      categories: [categories(:category1)],
+      goal: 'goal...',
+      source_practice: normal_practice
+    )
+    normal_page = Page.create!(title: '通常のプラクティスDoc', body: '本文', user: users(:kimura), practice: normal_practice)
+    grant_page = Page.create!(title: '給付金のプラクティスDoc', body: '本文', user: users(:kimura), practice: grant_practice)
+
+    visit_with_auth "/practices/#{grant_practice.id}/pages", 'grant-course'
+    assert_selector 'a.pill-nav__item-link', count: 2
+    assert_selector 'a.pill-nav__item-link.is-active', text: '全て'
+    assert_selector 'a.pill-nav__item-link', text: '給付金コース'
+    assert_selector '.card-list-item-title__link', text: normal_page.title
+    assert_selector '.card-list-item-title__link', text: grant_page.title
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9564
- 合わせてページネートはDocが1つ以上ある場合のみ実行されるように調整しました。

関連Issue
- https://github.com/fjordllc/bootcamp/issues/9292
- https://github.com/fjordllc/bootcamp/issues/9563

## 概要
プラクティスページで給付金コースを選択時に、給付金コースの元となったプラクティスのDocsも一覧に表示する。

## 変更確認方法
1.`feature/docs-grant-course-filter`をローカルに取り込む
2.`grant-course`ユーザーでログインする

**タブ上のDocの件数を確認するテスト**
3. 左のメニューの「プラクティス」をクリック
4. 「OS X Mountain Lionをクリーンインストールする」のリンクをクリック
5. プル型のタブ「給付金コース」をクリック
6. Docsタブに表示されているDoc数が変わることを確認

**元コースの関連Docと給付金コースのDocを表示するテスト**
7. Docsタブをクリック
8. ピル型タブで「全て」と「給付金コース」が表示されていることを確認
9. 一覧に「OS X Mountain Lionをクリーンインストールする」と「OS X Mountain Lionをクリーンインストールする（Reスキル）」のDocが表示されていることを確認
(Reスキル)付きのDocは一番後ろに入っていると思います。
10. ピル型タブで「給付金コース」をクリック
11. 「OS X Mountain Lionをクリーンインストールする（Reスキル）」のDocだけが表示されていることを確認

**ページネーションのテスト**
12. 左のメニューの「プラクティス」をクリック
13. 「OS X Mountain Lionをクリーンインストールする」のリンクをクリック
14. 「Docs」タブをクリック
15. ページネーションが正しく表示されていることを確認

## Screenshot

### 変更前
<img width="845" height="199" alt="image" src="https://github.com/user-attachments/assets/ed3913bc-40b7-43b3-bf4b-3686c659cdd9" />

### 変更後
<img width="812" height="376" alt="image" src="https://github.com/user-attachments/assets/8718ba29-be9c-4801-aee8-bd57cb3c8151" />
<img width="815" height="222" alt="image" src="https://github.com/user-attachments/assets/24d20b8a-7049-4cb5-b81a-ff6064dfdcef" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 給付金コース向けのドキュメント絞り込みUIを追加（「全て」「給付金コース」）。該当時のみ表示。

* **改善**
  * ページ一覧でコピー元のドキュメントを併合して表示できるようにし、絞り込み後に一括で並び替え・ページングを適用。
  * Docsタブの件数表示を給付金コース判定に応じて集計するよう変更。

* **テスト**
  * フィルター表示・動作を検証するシステム／モデルテストを追加。

* **雑多**
  * 表示や検証に使うデータセット（fixtures）を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30306922844/artifacts/8669107569" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-9650-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
