### PR TITLE
Q&A自動クローズ機能のリファクタリングと仕様改善

### DIFF
--- a/app/controllers/scheduler/daily/auto_close_questions_controller.rb
+++ b/app/controllers/scheduler/daily/auto_close_questions_controller.rb
@@ -2,8 +2,9 @@
 
 class Scheduler::Daily::AutoCloseQuestionsController < SchedulerController
   def show
-    QuestionAutoCloser.post_warning
-    QuestionAutoCloser.close_and_select_best_answer
+    question_auto_closer = QuestionAutoCloser.new
+    question_auto_closer.post_warning
+    question_auto_closer.close_and_select_best_answer
     head :ok
   end
 end

--- a/app/controllers/scheduler/daily/auto_close_questions_controller.rb
+++ b/app/controllers/scheduler/daily/auto_close_questions_controller.rb
@@ -4,7 +4,7 @@ class Scheduler::Daily::AutoCloseQuestionsController < SchedulerController
   def show
     question_auto_closer = QuestionAutoCloser.new
     question_auto_closer.post_warning
-    question_auto_closer.close_and_select_best_answer
+    question_auto_closer.close_inactive_questions
     head :ok
   end
 end

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -44,10 +44,7 @@ class QuestionAutoCloser
   end
 
   def create_warning_message(question)
-    answer = question.answers.create!(
-      user: @system_user,
-      description: WARNING_MESSAGE
-    )
+    answer = question.answers.create!(user: @system_user, description: WARNING_MESSAGE)
     ActiveSupport::Notifications.instrument('answer.create', answer:)
   end
 

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -16,7 +16,7 @@ class QuestionAutoCloser
     end
   end
 
-  def close_and_select_best_answer
+  def close_inactive_questions
     questions = extract_inactive_questions_to_close
     questions.each do |question|
       close_with_best_answer(question)

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -2,7 +2,7 @@
 
 class QuestionAutoCloser
   SYSTEM_USER_LOGIN_NAME = 'pjord'
-  AUTO_CLOSE_WARNING_MESSAGE = 'このQ&Aは1ヶ月間更新がありませんでした。このまま更新がなければ1週間後に自動的にクローズされます。'
+  WARNING_MESSAGE = 'このQ&Aは1ヶ月間更新がありませんでした。このまま更新がなければ1週間後に自動的にクローズされます。'
   AUTO_CLOSE_MESSAGE = '自動的にクローズしました。'
 
   def initialize
@@ -46,7 +46,7 @@ class QuestionAutoCloser
   def create_warning_message(question)
     answer = question.answers.create!(
       user: @system_user,
-      description: AUTO_CLOSE_WARNING_MESSAGE
+      description: WARNING_MESSAGE
     )
     ActiveSupport::Notifications.instrument('answer.create', answer:)
   end
@@ -54,7 +54,7 @@ class QuestionAutoCloser
   def should_close?(question)
     last_updated_answer = question.answers.order(updated_at: :desc, id: :desc).first
     return false unless last_updated_answer
-    return false unless last_updated_answer.user_id == @system_user.id && last_updated_answer.description == AUTO_CLOSE_WARNING_MESSAGE
+    return false unless last_updated_answer.user_id == @system_user.id && last_updated_answer.description == WARNING_MESSAGE
 
     last_warned_at = last_updated_answer.updated_at
     question.updated_at < last_warned_at && last_warned_at <= 1.week.ago

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class QuestionAutoCloser
-  SYSTEM_USER_LOGIN = 'pjord'
+  SYSTEM_USER_LOGIN_NAME = 'pjord'
   AUTO_CLOSE_WARNING_MESSAGE = 'このQ&Aは1ヶ月間更新がありませんでした。このまま更新がなければ1週間後に自動的にクローズされます。'
   AUTO_CLOSE_MESSAGE = '自動的にクローズしました。'
 
   def initialize
-    @system_user = User.find_by!(login_name: SYSTEM_USER_LOGIN)
+    @system_user = User.find_by!(login_name: SYSTEM_USER_LOGIN_NAME)
   end
 
   def post_warning

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -67,33 +67,8 @@ class QuestionAutoCloser
     end
 
     def close_with_best_answer(question, system_user)
-      ActiveRecord::Base.transaction do
-        close_answer = create_close_message(question, system_user)
-        select_as_best_answer(close_answer)
-        publish_events(close_answer)
-      end
-    end
-
-    def create_close_message(question, system_user)
-      question.answers.create!(
-        user: system_user,
-        description: AUTO_CLOSE_MESSAGE
-      )
-    end
-
-    def select_as_best_answer(close_answer)
-      correct_answer = CorrectAnswer.new(
-        id: close_answer.id,
-        question_id: close_answer.question_id,
-        user_id: close_answer.user_id,
-        description: close_answer.description,
-        created_at: close_answer.created_at,
-        updated_at: Time.current
-      )
-
-      close_answer.destroy
-      correct_answer.save!
-      correct_answer
+      close_answer = CorrectAnswer.create!(question:, user: system_user, description: AUTO_CLOSE_MESSAGE)
+      publish_events(close_answer)
     end
 
     def publish_events(correct_answer)

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -61,13 +61,8 @@ class QuestionAutoCloser
   end
 
   def create_auto_close_message(question)
-    close_answer = CorrectAnswer.create!(question:, user: @system_user, description: AUTO_CLOSE_MESSAGE)
-    publish_events(close_answer)
-  end
-
-  def publish_events(correct_answer)
-    action_name = "#{self.class.name}##{__method__}"
-    ActiveSupport::Notifications.instrument('answer.save', answer: correct_answer, action: action_name)
-    ActiveSupport::Notifications.instrument('correct_answer.save', answer: correct_answer)
+    answer = CorrectAnswer.create!(question:, user: @system_user, description: AUTO_CLOSE_MESSAGE)
+    ActiveSupport::Notifications.instrument('answer.save', answer:, action: "#{self.class.name}##{__method__}")
+    ActiveSupport::Notifications.instrument('correct_answer.save', answer:)
   end
 end

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -19,7 +19,7 @@ class QuestionAutoCloser
   def close_inactive_questions
     questions = extract_inactive_questions_to_close
     questions.each do |question|
-      close_with_best_answer(question)
+      create_auto_close_message(question)
     end
   end
 
@@ -60,7 +60,7 @@ class QuestionAutoCloser
     question.updated_at < last_warned_at && last_warned_at <= 1.week.ago
   end
 
-  def close_with_best_answer(question)
+  def create_auto_close_message(question)
     close_answer = CorrectAnswer.create!(question:, user: @system_user, description: AUTO_CLOSE_MESSAGE)
     publish_events(close_answer)
   end

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -5,73 +5,69 @@ class QuestionAutoCloser
   AUTO_CLOSE_WARNING_MESSAGE = 'このQ&Aは1ヶ月間更新がありませんでした。このまま更新がなければ1週間後に自動的にクローズされます。'
   AUTO_CLOSE_MESSAGE = '自動的にクローズしました。'
 
-  class << self
-    def post_warning
-      system_user = User.find_by(login_name: SYSTEM_USER_LOGIN)
-      return unless system_user
+  def initialize
+    @system_user = User.find_by!(login_name: SYSTEM_USER_LOGIN)
+  end
 
-      questions = extract_inactive_questions_to_warn
-      questions.each do |question|
-        create_warning_message(question, system_user)
-      end
+  def post_warning
+    questions = extract_inactive_questions_to_warn
+    questions.each do |question|
+      create_warning_message(question)
     end
+  end
 
-    def close_and_select_best_answer
-      system_user = User.find_by(login_name: SYSTEM_USER_LOGIN)
-      return unless system_user
-
-      questions = extract_inactive_questions_to_close(system_user)
-      questions.each do |question|
-        close_with_best_answer(question, system_user)
-      end
+  def close_and_select_best_answer
+    questions = extract_inactive_questions_to_close
+    questions.each do |question|
+      close_with_best_answer(question)
     end
+  end
 
-    private
+  private
 
-    def extract_inactive_questions_to_warn
-      Question.not_wip.not_solved.find_each.filter do |question|
-        should_post_warning?(question)
-      end
+  def extract_inactive_questions_to_warn
+    Question.not_wip.not_solved.find_each.filter do |question|
+      should_post_warning?(question)
     end
+  end
 
-    def extract_inactive_questions_to_close(system_user)
-      Question.not_wip.not_solved.find_each.filter do |question|
-        should_close?(question, system_user)
-      end
+  def extract_inactive_questions_to_close
+    Question.not_wip.not_solved.find_each.filter do |question|
+      should_close?(question)
     end
+  end
 
-    def should_post_warning?(question)
-      last_updated_answer = question.answers.order(updated_at: :desc, id: :desc).first
-      last_activity_at = [last_updated_answer&.updated_at, question.updated_at].compact.max
-      last_activity_at <= 1.month.ago
-    end
+  def should_post_warning?(question)
+    last_updated_answer = question.answers.order(updated_at: :desc, id: :desc).first
+    last_activity_at = [last_updated_answer&.updated_at, question.updated_at].compact.max
+    last_activity_at <= 1.month.ago
+  end
 
-    def create_warning_message(question, system_user)
-      answer = question.answers.create!(
-        user: system_user,
-        description: AUTO_CLOSE_WARNING_MESSAGE
-      )
-      ActiveSupport::Notifications.instrument('answer.create', answer:)
-    end
+  def create_warning_message(question)
+    answer = question.answers.create!(
+      user: @system_user,
+      description: AUTO_CLOSE_WARNING_MESSAGE
+    )
+    ActiveSupport::Notifications.instrument('answer.create', answer:)
+  end
 
-    def should_close?(question, system_user)
-      last_updated_answer = question.answers.order(updated_at: :desc, id: :desc).first
-      return false unless last_updated_answer
-      return false unless last_updated_answer.user_id == system_user.id && last_updated_answer.description == AUTO_CLOSE_WARNING_MESSAGE
+  def should_close?(question)
+    last_updated_answer = question.answers.order(updated_at: :desc, id: :desc).first
+    return false unless last_updated_answer
+    return false unless last_updated_answer.user_id == @system_user.id && last_updated_answer.description == AUTO_CLOSE_WARNING_MESSAGE
 
-      last_warned_at = last_updated_answer.updated_at
-      question.updated_at < last_warned_at && last_warned_at <= 1.week.ago
-    end
+    last_warned_at = last_updated_answer.updated_at
+    question.updated_at < last_warned_at && last_warned_at <= 1.week.ago
+  end
 
-    def close_with_best_answer(question, system_user)
-      close_answer = CorrectAnswer.create!(question:, user: system_user, description: AUTO_CLOSE_MESSAGE)
-      publish_events(close_answer)
-    end
+  def close_with_best_answer(question)
+    close_answer = CorrectAnswer.create!(question:, user: @system_user, description: AUTO_CLOSE_MESSAGE)
+    publish_events(close_answer)
+  end
 
-    def publish_events(correct_answer)
-      action_name = "#{name}.#{__method__}"
-      ActiveSupport::Notifications.instrument('answer.save', answer: correct_answer, action: action_name)
-      ActiveSupport::Notifications.instrument('correct_answer.save', answer: correct_answer)
-    end
+  def publish_events(correct_answer)
+    action_name = "#{self.class.name}##{__method__}"
+    ActiveSupport::Notifications.instrument('answer.save', answer: correct_answer, action: action_name)
+    ActiveSupport::Notifications.instrument('correct_answer.save', answer: correct_answer)
   end
 end

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -10,14 +10,14 @@ class QuestionAutoCloser
   end
 
   def post_warning
-    question_ids = extract_inactive_questions_to_warn
+    question_ids = extract_inactive_question_ids_to_warn
     question_ids.each do |question_id|
       create_warning_message(question_id)
     end
   end
 
   def close_inactive_questions
-    question_ids = extract_inactive_questions_to_close
+    question_ids = extract_inactive_question_ids_to_close
     question_ids.each do |question_id|
       create_auto_close_message(question_id)
     end
@@ -25,7 +25,7 @@ class QuestionAutoCloser
 
   private
 
-  def extract_inactive_questions_to_warn
+  def extract_inactive_question_ids_to_warn
     base_time = 1.month.ago
     answers_summary = Answer
                       .select(
@@ -44,7 +44,7 @@ class QuestionAutoCloser
       .ids
   end
 
-  def extract_inactive_questions_to_close
+  def extract_inactive_question_ids_to_close
     # 警告投稿日を基準とするため`last_warned_at`の計算には`updated_at`ではなく`created_at`を使用する
     # 最後の更新が自動クローズメッセージ投稿であれば解決済みになっているため「未解決である」の条件と警告の文言のチェックのいずれか一方はなくても機能する
     # ただし可読性と安全性のために両方の条件を残しておく

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -10,9 +10,9 @@ class QuestionAutoCloser
   end
 
   def post_warning
-    questions = extract_inactive_questions_to_warn
-    questions.each do |question|
-      create_warning_message(question)
+    question_ids = extract_inactive_questions_to_warn
+    question_ids.each do |question_id|
+      create_warning_message(question_id)
     end
   end
 
@@ -26,9 +26,22 @@ class QuestionAutoCloser
   private
 
   def extract_inactive_questions_to_warn
-    Question.not_wip.not_solved.find_each.filter do |question|
-      should_post_warning?(question)
-    end
+    base_time = 1.month.ago
+    answers_summary = Answer
+                      .select(
+                        :question_id,
+                        'MAX(updated_at) AS last_answer_updated_at',
+                        "BOOL_OR(type = 'CorrectAnswer') AS solved"
+                      )
+                      .group(:question_id)
+    Question
+      .with(answers_summary:)
+      .left_outer_joins(:answers_summary)
+      .where(wip: false)
+      .where('COALESCE(answers_summary.solved, false) = false') # 質問が未解決
+      .where('questions.updated_at <= ?', base_time)
+      .where('answers_summary.last_answer_updated_at IS NULL OR answers_summary.last_answer_updated_at <= ?', base_time)
+      .ids
   end
 
   def extract_inactive_questions_to_close
@@ -37,14 +50,8 @@ class QuestionAutoCloser
     end
   end
 
-  def should_post_warning?(question)
-    last_updated_answer = question.answers.order(updated_at: :desc, id: :desc).first
-    last_activity_at = [last_updated_answer&.updated_at, question.updated_at].compact.max
-    last_activity_at <= 1.month.ago
-  end
-
-  def create_warning_message(question)
-    answer = question.answers.create!(user: @system_user, description: WARNING_MESSAGE)
+  def create_warning_message(question_id)
+    answer = Answer.create!(question_id:, user: @system_user, description: WARNING_MESSAGE)
     ActiveSupport::Notifications.instrument('answer.create', answer:)
   end
 

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -35,8 +35,7 @@ class QuestionAutoCloser
                       )
                       .group(:question_id)
     Question
-      .with(answers_summary:)
-      .left_outer_joins(:answers_summary)
+      .joins("LEFT JOIN (#{answers_summary.to_sql}) answers_summary ON answers_summary.question_id = questions.id")
       .where(wip: false)
       .where('COALESCE(answers_summary.solved, false) = false') # 質問が未解決
       .where('questions.updated_at <= ?', base_time)
@@ -58,8 +57,7 @@ class QuestionAutoCloser
                       )
                       .group(:question_id)
     Question
-      .with(answers_summary:)
-      .left_outer_joins(:answers_summary)
+      .joins("LEFT JOIN (#{answers_summary.to_sql}) answers_summary ON answers_summary.question_id = questions.id")
       .where(wip: false)
       .where('COALESCE(answers_summary.solved, false) = false') # 質問が未解決
       .where('answers_summary.last_warned_at IS NOT NULL')

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -45,11 +45,14 @@ class QuestionAutoCloser
   end
 
   def extract_inactive_questions_to_close
+    # 警告投稿日を基準とするため`last_warned_at`の計算には`updated_at`ではなく`created_at`を使用する
+    # 最後の更新が自動クローズメッセージ投稿であれば解決済みになっているため「未解決である」の条件と警告の文言のチェックのいずれか一方はなくても機能する
+    # ただし可読性と安全性のために両方の条件を残しておく
     answers_summary = Answer
                       .select(
                         :question_id,
                         'MAX(updated_at) AS last_answer_updated_at',
-                        Answer.sanitize_sql_array(['MAX(CASE WHEN user_id = ? AND description = ? THEN updated_at END) AS last_warned_at',
+                        Answer.sanitize_sql_array(['MAX(CASE WHEN user_id = ? AND description = ? THEN created_at END) AS last_warned_at',
                                                    @system_user.id, WARNING_MESSAGE]),
                         "BOOL_OR(type = 'CorrectAnswer') AS solved"
                       )
@@ -61,8 +64,8 @@ class QuestionAutoCloser
       .where('COALESCE(answers_summary.solved, false) = false') # 質問が未解決
       .where('answers_summary.last_warned_at IS NOT NULL')
       .where('answers_summary.last_warned_at <= ?', 1.week.ago)
-      .where('answers_summary.last_answer_updated_at = answers_summary.last_warned_at')
-      .where('questions.updated_at <= answers_summary.last_warned_at')
+      .where('answers_summary.last_answer_updated_at = answers_summary.last_warned_at') # 最後の警告投稿以後に回答更新がない
+      .where('questions.updated_at <= answers_summary.last_warned_at') # 最後の警告投稿以後に質問更新がない
       .ids
   end
 

--- a/app/models/question_auto_closer.rb
+++ b/app/models/question_auto_closer.rb
@@ -17,9 +17,9 @@ class QuestionAutoCloser
   end
 
   def close_inactive_questions
-    questions = extract_inactive_questions_to_close
-    questions.each do |question|
-      create_auto_close_message(question)
+    question_ids = extract_inactive_questions_to_close
+    question_ids.each do |question_id|
+      create_auto_close_message(question_id)
     end
   end
 
@@ -45,9 +45,25 @@ class QuestionAutoCloser
   end
 
   def extract_inactive_questions_to_close
-    Question.not_wip.not_solved.find_each.filter do |question|
-      should_close?(question)
-    end
+    answers_summary = Answer
+                      .select(
+                        :question_id,
+                        'MAX(updated_at) AS last_answer_updated_at',
+                        Answer.sanitize_sql_array(['MAX(CASE WHEN user_id = ? AND description = ? THEN updated_at END) AS last_warned_at',
+                                                   @system_user.id, WARNING_MESSAGE]),
+                        "BOOL_OR(type = 'CorrectAnswer') AS solved"
+                      )
+                      .group(:question_id)
+    Question
+      .with(answers_summary:)
+      .left_outer_joins(:answers_summary)
+      .where(wip: false)
+      .where('COALESCE(answers_summary.solved, false) = false') # 質問が未解決
+      .where('answers_summary.last_warned_at IS NOT NULL')
+      .where('answers_summary.last_warned_at <= ?', 1.week.ago)
+      .where('answers_summary.last_answer_updated_at = answers_summary.last_warned_at')
+      .where('questions.updated_at <= answers_summary.last_warned_at')
+      .ids
   end
 
   def create_warning_message(question_id)
@@ -55,17 +71,8 @@ class QuestionAutoCloser
     ActiveSupport::Notifications.instrument('answer.create', answer:)
   end
 
-  def should_close?(question)
-    last_updated_answer = question.answers.order(updated_at: :desc, id: :desc).first
-    return false unless last_updated_answer
-    return false unless last_updated_answer.user_id == @system_user.id && last_updated_answer.description == WARNING_MESSAGE
-
-    last_warned_at = last_updated_answer.updated_at
-    question.updated_at < last_warned_at && last_warned_at <= 1.week.ago
-  end
-
-  def create_auto_close_message(question)
-    answer = CorrectAnswer.create!(question:, user: @system_user, description: AUTO_CLOSE_MESSAGE)
+  def create_auto_close_message(question_id)
+    answer = CorrectAnswer.create!(question_id:, user: @system_user, description: AUTO_CLOSE_MESSAGE)
     ActiveSupport::Notifications.instrument('answer.save', answer:, action: "#{self.class.name}##{__method__}")
     ActiveSupport::Notifications.instrument('correct_answer.save', answer:)
   end

--- a/db/fixtures/answers.yml
+++ b/db/fixtures/answers.yml
@@ -43,7 +43,7 @@ answer<%= i %>:
 <% end %>
 
 answer51:
-  description: <%= QuestionAutoCloser::AUTO_CLOSE_WARNING_MESSAGE %>
+  description: <%= QuestionAutoCloser::WARNING_MESSAGE %>
   user: pjord
   question: question51
   created_at: <%= Time.current - 1.week %>

--- a/db/fixtures/answers.yml
+++ b/db/fixtures/answers.yml
@@ -48,3 +48,66 @@ answer51:
   question: question51
   created_at: <%= Time.current - 1.week %>
   updated_at: <%= Time.current - 1.week %>
+
+answer52:
+  description: <%= QuestionAutoCloser::WARNING_MESSAGE %>
+  user: pjord
+  question: question53
+  created_at: <%= Time.current - 1.week %>
+  updated_at: <%= Time.current - 1.week %>
+
+answer53:
+  description: 回答しました。
+  user: sotugyou
+  question: question53
+  created_at: <%= Time.current - 1.day %>
+  updated_at: <%= Time.current - 1.day %>
+
+answer54:
+  description: <%= QuestionAutoCloser::WARNING_MESSAGE %>
+  user: pjord
+  question: question54
+  created_at: <%= Time.current - 2.month - 1.week %>
+  updated_at: <%= Time.current - 2.month - 1.week %>
+
+answer55:
+  description: <%= QuestionAutoCloser::AUTO_CLOSE_MESSAGE %>
+  user: pjord
+  question: question54
+  created_at: <%= Time.current - 2.month %>
+  updated_at: <%= Time.current - 2.month %>
+
+answer56:
+  description: 回答を再募集します。
+  user: kimura
+  question: question54
+  created_at: <%= Time.current - 1.month - 1.week %>
+  updated_at: <%= Time.current - 1.month - 1.week %>
+
+answer57:
+  description: <%= QuestionAutoCloser::WARNING_MESSAGE %>
+  user: pjord
+  question: question54
+  created_at: <%= Time.current - 1.week %>
+  updated_at: <%= Time.current - 1.week %>
+
+answer58:
+  description: <%= QuestionAutoCloser::WARNING_MESSAGE %>
+  user: pjord
+  question: question55
+  created_at: <%= Time.current - 2.month - 1.week %>
+  updated_at: <%= Time.current - 2.month - 1.week %>
+
+answer59:
+  description: <%= QuestionAutoCloser::AUTO_CLOSE_MESSAGE %>
+  user: pjord
+  question: question55
+  created_at: <%= Time.current - 2.month %>
+  updated_at: <%= Time.current - 2.month %>
+
+answer60:
+  description: 回答を再募集します。
+  user: kimura
+  question: question55
+  created_at: <%= Time.current - 1.month %>
+  updated_at: <%= Time.current - 1.month %>

--- a/db/fixtures/questions.yml
+++ b/db/fixtures/questions.yml
@@ -133,3 +133,30 @@ question52:
   created_at: <%= Time.current - 1.month %>
   updated_at: <%= Time.current - 1.month %>
   published_at: <%= Time.current - 1.month %>
+
+question53:
+  title: 警告後に回答があった質問
+  description: 自動クローズのカウントダウンがリセットされる質問です。
+  user: kimura
+  practice: practice1
+  created_at: <%= Time.current - 1.month - 1.week %>
+  updated_at: <%= Time.current - 1.month - 1.week %>
+  published_at: <%= Time.current - 1.month - 1.week %>
+
+question54:
+  title: 自動クローズ後に未解決に戻して1ヶ月と1週間放置した質問
+  description: 再度自動クローズされる質問です。
+  user: kimura
+  practice: practice1
+  created_at: <%= Time.current - 3.month - 1.week %>
+  updated_at: <%= Time.current - 3.month - 1.week %>
+  published_at: <%= Time.current - 3.month - 1.week %>
+
+question55:
+  title: 自動クローズ後に未解決に戻して1ヶ月放置した質問
+  description: 自動クローズ前に再度警告される質問です。
+  user: kimura
+  practice: practice1
+  created_at: <%= Time.current - 3.month %>
+  updated_at: <%= Time.current - 3.month %>
+  published_at: <%= Time.current - 3.month %>

--- a/test/models/question_auto_closer_test.rb
+++ b/test/models/question_auto_closer_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class QuestionAutoCloserTest < ActiveSupport::TestCase
-  AUTO_CLOSE_WARNING_MESSAGE = 'このQ&Aは1ヶ月間コメントがありませんでした。1週間後に自動的にクローズされます。'
+  AUTO_CLOSE_WARNING_MESSAGE = 'このQ&Aは1ヶ月間更新がありませんでした。このまま更新がなければ1週間後に自動的にクローズされます。'
   AUTO_CLOSE_MESSAGE = '自動的にクローズしました。'
 
   test '.post_warning' do
@@ -130,6 +130,133 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
       assert_no_difference -> { question.answers.count } do
         QuestionAutoCloser.post_warning
       end
+    end
+  end
+
+  test 'resets auto-close countdown when the question is updated' do
+    created_at = Time.zone.local(2025, 10, 1, 0, 0, 0)
+    question = Question.create!(
+      title: '自動クローズテスト',
+      description: 'テスト',
+      user: users(:kimura),
+      created_at:,
+      updated_at: created_at
+    )
+
+    warned_at = created_at.advance(months: 1)
+    question.answers.create!(
+      user: users(:pjord),
+      description: AUTO_CLOSE_WARNING_MESSAGE,
+      created_at: warned_at,
+      updated_at: warned_at
+    )
+    updated_at = warned_at.advance(days: 1)
+    question.update!(description: '質問内容を更新しました', updated_at:)
+
+    travel_to warned_at.advance(weeks: 1) do
+      assert_no_difference -> { question.answers.count } do
+        QuestionAutoCloser.close_and_select_best_answer
+      end
+    end
+  end
+
+  test 'resets auto-close countdown when a new answer is added' do
+    created_at = Time.zone.local(2025, 10, 1, 0, 0, 0)
+    question = Question.create!(
+      title: '自動クローズテスト',
+      description: 'テスト',
+      user: users(:kimura),
+      created_at:,
+      updated_at: created_at
+    )
+
+    warned_at = created_at.advance(months: 1)
+    question.answers.create!(
+      user: users(:pjord),
+      description: AUTO_CLOSE_WARNING_MESSAGE,
+      created_at: warned_at,
+      updated_at: warned_at
+    )
+    added_at = warned_at.advance(days: 1)
+    question.answers.create!(
+      user: users(:komagata),
+      description: '回答しました',
+      created_at: added_at,
+      updated_at: added_at
+    )
+
+    travel_to warned_at.advance(weeks: 1) do
+      assert_no_difference -> { question.answers.count } do
+        QuestionAutoCloser.close_and_select_best_answer
+      end
+    end
+  end
+
+  test 'auto-closes questions that have been reopened after auto-closing' do
+    created_at = Time.zone.local(2025, 10, 1, 0, 0, 0)
+    question = Question.create!(
+      title: '自動クローズテスト',
+      description: 'テスト',
+      user: users(:kimura),
+      created_at:,
+      updated_at: created_at
+    )
+
+    warned_at = created_at.advance(months: 1)
+    system_user = users(:pjord)
+    question.answers.create!(
+      user: system_user,
+      description: AUTO_CLOSE_WARNING_MESSAGE,
+      created_at: warned_at,
+      updated_at: warned_at
+    )
+    closed_at = warned_at.advance(weeks: 1)
+    auto_close_comment = CorrectAnswer.create!(
+      question:,
+      user: system_user,
+      description: AUTO_CLOSE_MESSAGE,
+      created_at: closed_at,
+      updated_at: closed_at
+    )
+    reopened_at = closed_at.advance(days: 1)
+    auto_close_comment.update!(type: nil, updated_at: reopened_at)
+    question.answers.create!(
+      user: users(:kimura),
+      description: '回答を再募集します',
+      created_at: reopened_at,
+      updated_at: reopened_at
+    )
+
+    travel_to reopened_at.advance(months: 1, days: -1) do
+      assert_no_difference -> { question.answers.count } do
+        QuestionAutoCloser.post_warning
+      end
+    end
+
+    again_warned_at = reopened_at.advance(months: 1)
+    travel_to again_warned_at do
+      assert_difference -> { question.answers.count }, 1 do
+        QuestionAutoCloser.post_warning
+      end
+      answer = question.answers.last
+      assert_equal system_user, answer.user
+      assert_equal AUTO_CLOSE_WARNING_MESSAGE, answer.description
+    end
+
+    travel_to again_warned_at.advance(weeks: 1, days: -1) do
+      assert_no_difference -> { question.answers.count } do
+        QuestionAutoCloser.close_and_select_best_answer
+      end
+    end
+
+    travel_to again_warned_at.advance(weeks: 1) do
+      assert_difference -> { question.answers.count }, 1 do
+        QuestionAutoCloser.close_and_select_best_answer
+      end
+      answer = question.answers.last
+      assert_equal system_user, answer.user
+      assert_equal AUTO_CLOSE_MESSAGE, answer.description
+      assert answer.is_a?(CorrectAnswer)
     end
   end
 end

--- a/test/models/question_auto_closer_test.rb
+++ b/test/models/question_auto_closer_test.rb
@@ -6,7 +6,7 @@ require 'supports/question_auto_closer_helper'
 class QuestionAutoCloserTest < ActiveSupport::TestCase
   include QuestionAutoCloserHelper
 
-  AUTO_CLOSE_WARNING_MESSAGE = 'このQ&Aは1ヶ月間更新がありませんでした。このまま更新がなければ1週間後に自動的にクローズされます。'
+  WARNING_MESSAGE = 'このQ&Aは1ヶ月間更新がありませんでした。このまま更新がなければ1週間後に自動的にクローズされます。'
   AUTO_CLOSE_MESSAGE = '自動的にクローズしました。'
 
   test 'posts warning for inactive questions' do
@@ -25,7 +25,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
       end
       answer = question.answers.last
       assert_equal users(:pjord), answer.user
-      assert_equal AUTO_CLOSE_WARNING_MESSAGE, answer.description
+      assert_equal WARNING_MESSAGE, answer.description
     end
   end
 
@@ -37,7 +37,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
     system_user = users(:pjord)
     question.answers.create!(
       user: system_user,
-      description: AUTO_CLOSE_WARNING_MESSAGE,
+      description: WARNING_MESSAGE,
       created_at: warned_at,
       updated_at: warned_at
     )
@@ -77,7 +77,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
     warned_at = question.created_at.advance(months: 1)
     question.answers.create!(
       user: users(:pjord),
-      description: AUTO_CLOSE_WARNING_MESSAGE,
+      description: WARNING_MESSAGE,
       created_at: warned_at,
       updated_at: warned_at
     )
@@ -111,7 +111,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
     warned_at = question.created_at.advance(months: 1)
     question.answers.create!(
       user: users(:pjord),
-      description: AUTO_CLOSE_WARNING_MESSAGE,
+      description: WARNING_MESSAGE,
       created_at: warned_at,
       updated_at: warned_at
     )
@@ -132,7 +132,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
     warned_at = question.created_at.advance(months: 1)
     question.answers.create!(
       user: users(:pjord),
-      description: AUTO_CLOSE_WARNING_MESSAGE,
+      description: WARNING_MESSAGE,
       created_at: warned_at,
       updated_at: warned_at
     )
@@ -159,7 +159,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
     system_user = users(:pjord)
     question.answers.create!(
       user: system_user,
-      description: AUTO_CLOSE_WARNING_MESSAGE,
+      description: WARNING_MESSAGE,
       created_at: warned_at,
       updated_at: warned_at
     )
@@ -193,7 +193,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
       end
       answer = question.answers.last
       assert_equal system_user, answer.user
-      assert_equal AUTO_CLOSE_WARNING_MESSAGE, answer.description
+      assert_equal WARNING_MESSAGE, answer.description
     end
 
     travel_to again_warned_at.advance(weeks: 1, days: -1) do

--- a/test/models/question_auto_closer_test.rb
+++ b/test/models/question_auto_closer_test.rb
@@ -9,7 +9,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
   AUTO_CLOSE_WARNING_MESSAGE = 'このQ&Aは1ヶ月間更新がありませんでした。このまま更新がなければ1週間後に自動的にクローズされます。'
   AUTO_CLOSE_MESSAGE = '自動的にクローズしました。'
 
-  test '.post_warning' do
+  test 'posts warning for inactive questions' do
     question = create_question
 
     travel_to question.created_at.advance(months: 1, days: -1) do
@@ -28,7 +28,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
     end
   end
 
-  test '.close_and_select_best_answer' do
+  test 'auto-closes inactive questions' do
     question = create_question
 
     warned_at = question.created_at.advance(months: 1)

--- a/test/models/question_auto_closer_test.rb
+++ b/test/models/question_auto_closer_test.rb
@@ -44,13 +44,13 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
 
     travel_to warned_at.advance(weeks: 1, days: -1) do
       assert_no_difference -> { question.answers.count } do
-        question_auto_closer.close_and_select_best_answer
+        question_auto_closer.close_inactive_questions
       end
     end
 
     travel_to warned_at.advance(weeks: 1) do
       assert_difference -> { question.answers.count }, 1 do
-        question_auto_closer.close_and_select_best_answer
+        question_auto_closer.close_inactive_questions
       end
       answer = question.answers.last
       assert_equal system_user, answer.user
@@ -85,7 +85,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
 
     travel_to warned_at.advance(weeks: 1) do
       assert_no_difference -> { question.answers.count } do
-        question_auto_closer.close_and_select_best_answer
+        question_auto_closer.close_inactive_questions
       end
     end
   end
@@ -120,7 +120,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
 
     travel_to warned_at.advance(weeks: 1) do
       assert_no_difference -> { question.answers.count } do
-        question_auto_closer.close_and_select_best_answer
+        question_auto_closer.close_inactive_questions
       end
     end
   end
@@ -146,7 +146,7 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
 
     travel_to warned_at.advance(weeks: 1) do
       assert_no_difference -> { question.answers.count } do
-        question_auto_closer.close_and_select_best_answer
+        question_auto_closer.close_inactive_questions
       end
     end
   end
@@ -198,13 +198,13 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
 
     travel_to again_warned_at.advance(weeks: 1, days: -1) do
       assert_no_difference -> { question.answers.count } do
-        question_auto_closer.close_and_select_best_answer
+        question_auto_closer.close_inactive_questions
       end
     end
 
     travel_to again_warned_at.advance(weeks: 1) do
       assert_difference -> { question.answers.count }, 1 do
-        question_auto_closer.close_and_select_best_answer
+        question_auto_closer.close_inactive_questions
       end
       answer = question.answers.last
       assert_equal system_user, answer.user

--- a/test/models/question_auto_closer_test.rb
+++ b/test/models/question_auto_closer_test.rb
@@ -90,6 +90,74 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
     end
   end
 
+  test 'does not post warning for solved questions' do
+    question = create_question
+    question_auto_closer = QuestionAutoCloser.new
+
+    solved_at = question.created_at.advance(days: 1)
+    CorrectAnswer.create!(
+      question:,
+      user: users(:komagata),
+      description: 'ベストアンサーです',
+      created_at: solved_at,
+      updated_at: solved_at
+    )
+
+    travel_to solved_at.advance(months: 1) do
+      assert_no_difference -> { question.answers.count } do
+        question_auto_closer.post_warning
+      end
+    end
+  end
+
+  test 'does not post auto-close messages for auto-closed questions' do
+    # 「未解決である」の条件と警告の文言のチェックのいずれか一方を外しても自動クローズ機能は仕様通り振る舞う
+    # 誤って両方の条件を外すとこのテストケースが失敗する
+    question = create_question
+    question_auto_closer = QuestionAutoCloser.new
+
+    warned_at = question.created_at.advance(months: 1)
+    system_user = users(:pjord)
+    question.answers.create!(
+      user: system_user,
+      description: WARNING_MESSAGE,
+      created_at: warned_at,
+      updated_at: warned_at
+    )
+    closed_at = warned_at.advance(weeks: 1)
+    CorrectAnswer.create!(
+      question:,
+      user: system_user,
+      description: AUTO_CLOSE_MESSAGE,
+      created_at: closed_at,
+      updated_at: closed_at
+    )
+
+    travel_to closed_at.advance(weeks: 1) do
+      assert_no_difference -> { question.answers.count } do
+        question_auto_closer.close_inactive_questions
+      end
+    end
+  end
+
+  test 'does not auto-close questions without any warning messages' do
+    question = create_question
+    question_auto_closer = QuestionAutoCloser.new
+
+    question.answers.create!(
+      user: users(:komagata),
+      description: '回答しました',
+      created_at: question.created_at,
+      updated_at: question.created_at
+    )
+
+    travel_to question.created_at.advance(weeks: 1) do
+      assert_no_difference -> { question.answers.count } do
+        question_auto_closer.close_inactive_questions
+      end
+    end
+  end
+
   test 'resets warning countdown when the question is updated' do
     question = create_question(wip: true)
     question_auto_closer = QuestionAutoCloser.new
@@ -210,6 +278,37 @@ class QuestionAutoCloserTest < ActiveSupport::TestCase
       assert_equal system_user, answer.user
       assert_equal AUTO_CLOSE_MESSAGE, answer.description
       assert answer.is_a?(CorrectAnswer)
+    end
+  end
+
+  test 'emits a notification when an warning message is posted' do
+    question = create_question
+    question_auto_closer = QuestionAutoCloser.new
+
+    travel_to question.created_at.advance(months: 1) do
+      assert_notification('answer.create') do
+        question_auto_closer.post_warning
+      end
+    end
+  end
+
+  test 'emits notifications when an auto-close message is posted' do
+    question = create_question
+    question_auto_closer = QuestionAutoCloser.new
+
+    warned_at = question.created_at.advance(months: 1)
+    system_user = users(:pjord)
+    question.answers.create!(
+      user: system_user,
+      description: WARNING_MESSAGE,
+      created_at: warned_at,
+      updated_at: warned_at
+    )
+
+    travel_to warned_at.advance(weeks: 1) do
+      assert_notifications_count(/\w*answer.save/, 2) do
+        question_auto_closer.close_inactive_questions
+      end
     end
   end
 end

--- a/test/supports/question_auto_closer_helper.rb
+++ b/test/supports/question_auto_closer_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module QuestionAutoCloserHelper
+  def create_question(wip: false)
+    # 再現性のために時刻を固定。値は任意
+    created_at = Time.zone.local(2025, 10, 1, 0, 0, 0)
+    Question.create!(
+      title: '自動クローズテスト',
+      description: 'テスト',
+      user: users(:kimura),
+      wip:,
+      created_at:,
+      updated_at: created_at
+    )
+  end
+end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9037
- https://github.com/fjordllc/bootcamp/issues/9035#issuecomment-3949558052

## 概要

- Q&A自動クローズ機能のリファクタリング
- 同機能の仕様の改善（仕様の漏れがあったため）
  - 851f359fcda084390a2410e3ac1f0bedc737168a
- 同機能の実行効率の改善（N+1問題とRubyでのデータフィルタリング処理の回避）
  - cc0dc2e118b7d33951f4863caf019a35e38162d3 e25be9aadc6ee536f882be0d55a56205d72004c6
- 上記に伴う変更
  - 警告メッセージの文言を仕様に沿った内容に変更した
  - 未解決質問数のキャッシュ削除時のログ出力の文言を設計変更に伴って変更した
  - ステージング環境での動作確認用に初期データを追加した
  - テストコードを整理した

## Q&A自動クローズ機能について

### 自動クローズ機能の仕様

一定期間更新がないQ&Aを自動的にクローズする機能。
GitHubのIssueの自動クローズ機能を想定して機能追加の要望があった（ https://github.com/fjordllc/bootcamp/issues/8086 ）ので出来る限りその仕様に合わせた。

次のステップで自動クローズする。

1. 1ヶ月以上更新がない未解決かつ公開中のQ&Aにシステムアカウント（pjord）が警告メッセージを投稿する
2. 警告投稿日から1週間更新がないとQ&Aにシステムアカウントが自動クローズメッセージを投稿してクローズする
3. 警告投稿日から1週間以内に更新があると自動クローズのカウントダウンをリセットして1に戻る
4. 解決済み（自動クローズによる解決も含む）のQ&Aを未解決に戻すと1に戻る

Q&Aの仕様上、クローズするためにはベストアンサーを一つだけ選択する必要があるため自動クローズメッセージをベストアンサーにする。

Q&Aの更新には以下が含まれる。
- 質問の更新
  - 質問の新規作成
  - タイトル、質問文、タグ、紐付けるプラクティスの変更
  - WIPと公開の切り替え
- 回答の更新
  - 回答の新規作成
  - 回答文の変更、ベストアンサーにする、ベストアンサーの取り消し
  - 警告メッセージと自動クローズメッセージもシステム上は回答の一種であるためこれらの投稿と更新も含まれる

### 警告/自動クローズ条件の詳細

※デシションテーブルの条件のセルにある`-`は値が任意という意味

#### 警告対象

次の条件がすべてYesのQ&Aに警告を出す。
- 未解決
- 公開中（WIPでない）
- 1ヶ月以上更新がない
  - 警告投稿自体も回答更新に含まれるためこの条件があれば警告が連続投稿されることはない

デシションテーブルは以下のようになる。

|      | パターン                        | 1 | 2 | 3 | 4 | 5 | 6 |
|------|---------------------------------|---|---|---|---|---|---|
| 条件 | 未解決                          | Y | Y | Y | Y | Y | N |
|      | 公開中（WIPでない）     | Y | Y | Y | Y | N | - |
|      | 質問更新から1ヶ月以上経過 | Y | Y | Y | N | - | - |
|      | 回答なし                        | Y | N | N | - | - | N |
|      | 回答更新から1ヶ月以上経過 | N | Y | N | - | - | - |
| 結果 | 警告する                        | X | X | - | - | - | - |

#### 自動クローズ対象

次の条件がすべてYesのQ&Aを自動クローズする。
- 未解決
- 公開中（WIPでない）
- 最後に警告が投稿されてから1週間以上更新がない（最後の更新が警告投稿かつその投稿から1週間以上経過）
  - 自動クローズされるまでに複数回警告されるシナリオがあるため「最後の警告」を見る必要がある

Q&Aの「最後の更新が警告投稿」という条件は「未解決」という条件を包含する広い条件であるため、「未解決」という条件は本来は不要であることに注意。
「最後の更新が警告投稿」ならば「未解決」であり、「解決済み」ならば「最後の更新が警告投稿ではない」ということ。
「解決済み」ならば
- 手動でベストアンサーを決定する（ベストアンサー決定が最後の更新になる）
- 自動クローズされる（自動クローズメッセージ投稿が最後の更新になる）

のいずれかなので「最後の更新が警告投稿ではない」。
ただし、未解決の条件がある方が直感的にわかりやすく将来のリグレッションリスクが低くなるため実装レベルでも使用することにした。

デシションテーブルは以下のようになる。

|      | パターン                    | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
|------|-----------------------------|---|---|---|---|---|---|---|
| 条件 | 未解決                      | Y | Y | Y | Y | Y | Y | N |
|      | 公開中（WIPでない） | Y | Y | Y | Y | Y | N | - |
|      | 警告メッセージあり          | Y | Y | Y | Y | N | - | - |
|      | 最後の警告後に質問更新      | N | N | N | Y | N | - | - |
|      | 最後の警告後に回答更新      | N | N | Y | - | N | - | - |
|      | 最後の警告から1週間以上経過 | Y | N | - | - | N | - | - |
| 結果 | 自動クローズする            | X | - | - | - | - | - | - |

「回答が警告メッセージである」は実装レベルでは「回答の作成者がシステムアカウント」かつ「回答の本文が警告文である」という条件で判定。

## テストコードとデシジョンテーブルの対応表

|    | テストケース名                                                     | 警告対象のパターン | 自動クローズ対象のパターン |
|----|--------------------------------------------------------------------|----------------------------|------------------------------------|
| 1  | 'posts warning for inactive questions'                             | 1,4                        | -                                  |
| 2  | 'auto-closes inactive questions'                                   | -                          | 1,2                                |
| 3  | 'does not post warning for WIP questions'                          | 5                          | -                                  |
| 4  | 'does not close WIP questions'                                     | -                          | 6                                  |
| 5  | 'does not post warning for solved questions'                       | 6                          | -                                  |
| 6  | 'does not post auto-close messages for auto-closed questions'      | -                          | 7                                  |
| 7  | 'does not auto-close questions without any warning messages'       | -                          | 5                                  |
| 8  | 'resets warning countdown when the question is updated'            | 4                          | -                                  |
| 9  | 'resets auto-close countdown when the question is updated'         | -                          | 4                                  |
| 10 | 'resets auto-close countdown when a new answer is added'           | -                          | 3                                  |
| 11 | 'auto-closes questions that have been reopened after auto-closing' | 2,3                        | 1,2                                |

デシジョンテーブルにあるパターンは網羅した上で、いくつかのパターンについては複数のシナリオをテストするようにした。

## 本番環境での定期処理実行方法

Google CloudのCloud Schedulerを使用して毎日1回`/scheduler/daily/auto_close_questions`にHTTP GETメソッドで自動アクセスすることで定期処理を実行している。
※このことはコードベースからはわからないので気にする必要はない

## 変更確認方法

自動クローズ機能が仕様通り実装されていること、自動クローズ機能に付随して実行される既存の処理にリグレッションが発生していないことを確認する。

- 自動クローズ機能
  - 非アクティブな質問に警告メッセージが投稿される
  - 警告後も非アクティブな質問にクローズメッセージが投稿されてクローズされる
  - 解決済みの質問やWIPの質問、アクティブな質問には何もしない
- 通知機能 ※
  - 回答投稿時に質問作成者と質問のwatcherに通知が飛ぶ（今回の場合警告メッセージ投稿時）
  - ベストアンサー決定時に質問のwatcherに通知が飛ぶ（今回の場合クローズメッセージがベストアンサーとして投稿されるのでその時）
- 未解決質問数のキャッシュ削除
  - アプリ画面左端のメニューのQ&Aに未解決質問数のバッジがある。この未解決質問数の値はキャッシュされており、未解決質問数が変化するタイミングでキャッシュが削除されて再計算される。今回の場合クローズメッセージ投稿時にキャッシュが削除される。

※通知機能について補足。
本PRでは通知機能の実装を変更していないため次のように詳細な動作確認は省略する。
通知にはメール通知、サイト内通知、Discord通知があるが、メール通知のみ確認する。
回答投稿時に質問のwatcherに通知が飛ぶことは確認せず質問作成者に通知が飛ぶことのみ確認する。

### 事前準備

1. `chore/refactor-question-auto-close`をローカルに取り込む
4. `bin/rails db:seed`を実行して初期データを更新する（本PRで初期データを追加したため）
5. 定期処理を実行できるようにするためローカル環境に環境変数`TOKEN`を設定する
設定方法は https://github.com/fjordllc/bootcamp/pull/9024#issue-3308775404 の事前準備の項目を参照
6. 未解決質問数のキャッシュ削除を検出できるようにする

以下を実行してローカル環境でキャッシュを有効化する（動作確認後に再度実行することでキャッシュを無効化できる）

```
bin/rails dev:cache
```

以下を実行しておくとキャッシュ削除時にログ出力される内容を標準出力できるため、確認作業が楽になる

```
tail -f log/development.log | grep "AnswerCacheDestroyer"
```

### 動作確認

1. ローカルサーバーを起動
1. hatsunoでログイン（質問作成者にはベストアンサー決定の通知を飛ばさないという元々の仕様のためkimura以外のユーザーにする。確認作業を楽にするためメール通知がONになっているユーザーにする）
1. [自動クローズされる質問](http://localhost:3000/questions/332201278) （警告メッセージが投稿されてから1週間経過した未解決のQ&A）にアクセスしてWatchボタンをクリック（この質問が解決した際に通知が飛ぶようになる）
1. http://localhost:3000/scheduler/daily/auto_close_questions?token=hoge にアクセス（定期処理が実行される）
1. [自動クローズ前に警告される質問](http://localhost:3000/questions/180726914) （直近1ヶ月間更新されていない未解決のQ&A）に警告メッセージが投稿されていることを確認
1. [自動クローズされる質問](http://localhost:3000/questions/332201278) にクローズメッセージが投稿されて解決済みになっていることを確認
1. [警告後に回答があった質問](http://localhost:3000/questions/1036164119) はクローズしていないことを確認
1. [自動クローズ後に未解決に戻して1ヶ月放置した質問](http://localhost:3000/questions/346110245) に警告メッセージが投稿されていることを確認
1. [自動クローズ後に未解決に戻して1ヶ月と1週間放置した質問](http://localhost:3000/questions/598084022) にクローズメッセージが投稿されて解決済みになっていることを確認
1. [wipの質問](http://localhost:3000/questions/818805800) （直近1ヶ月間更新されていないWIPのQ&A）と [解決済みの質問](http://localhost:3000/questions/782854533) には警告メッセージが投稿されていないことを確認
1. http://localhost:3000/letter_opener にアクセスしてメールが届いていることを確認
    1. kimura（警告される質問の作成者）宛てに「pjordさんから回答がありました。」という件名のメールが届いていることを確認
    1. hatsuno（解決した質問のwatcher）宛てに「kimuraさんの質問【 自動クローズされる質問 】でpjordさんの回答がベストアンサーに選ばれました。」という件名のメールが届いていることを確認
1. "AnswerCacheDestroyer"を含む文字列が標準出力に表示されていることを確認（ベストアンサー決定時にキャッシュが削除されている）

## Screenshot

- 警告メッセージの文言の変更
- 一度自動クローズして再度未解決にしても自動クローズの対象になるよう変更

|変更前|変更後|
|---|---|
| ![before](https://github.com/user-attachments/assets/ebb378ab-cbd4-4556-bf4e-094b873e0337) | ![after](https://github.com/user-attachments/assets/0a9feb75-bfc7-42ff-9a7d-50203c383cfa)|
| ![before2](https://github.com/user-attachments/assets/4df65a31-0187-4834-9edc-c47164419514) | ![after2](https://github.com/user-attachments/assets/480d576e-3ccc-42d5-882c-bdc8647404b0)|

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 自動クローズ処理を内部で大幅に見直し、処理の流れとデータ選定を安定化しました。

* **Bug Fixes**
  * 警告・自動クローズの選定条件やタイミングを改善し、重複検出とメッセージ生成の精度を向上しました。

* **Tests**
  * 警告から自動クローズまでの振る舞いを網羅するテストを大幅に拡充しました。

* **Chores**
  * テスト用データとテスト補助コードを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->