### PR TITLE
「AI検索」を「意味検索」にリネーム

### DIFF
--- a/app/models/searcher.rb
+++ b/app/models/searcher.rb
@@ -4,7 +4,7 @@ class Searcher
   MODES = %i[keyword semantic hybrid].freeze
   MODES_FOR_SELECT = [
     %w[キーワード検索 keyword],
-    %w[AI検索 semantic],
+    %w[意味検索 semantic],
     %w[ハイブリッド hybrid]
   ].freeze
 

--- a/test/system/smart_search_test.rb
+++ b/test/system/smart_search_test.rb
@@ -9,7 +9,7 @@ class SmartSearchTest < ApplicationSystemTestCase
     within('form[name=search]') do
       assert_text '検索方法'
       assert_text 'キーワード検索'
-      assert_text 'AI検索'
+      assert_text '意味検索'
       assert_text 'ハイブリッド'
     end
   end


### PR DESCRIPTION
検索モードの表示名を「AI検索」から「意味検索」に変更します。

## 変更内容
- `app/models/searcher.rb`: 検索モード名を変更
- `test/system/smart_search_test.rb`: テストのアサーションを更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * セマンティック検索オプションの表示ラベルが更新されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->