### PR TITLE
AI検索のFeatureフラグを削除して全ユーザーに公開

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,11 +7,6 @@ module ApplicationHelper
     [:everyone, current_user.job].include?(practice.target)
   end
 
-  # development/test環境では常に有効、それ以外はフィーチャーフラグで制御
-  def smart_search_available?
-    Rails.env.local? || Switchlet.enabled?(:smart_search)
-  end
-
   def movie_available?
     Rails.env.local? || Switchlet.enabled?(:movie)
   end

--- a/app/views/application/header/_header_search.html.slim
+++ b/app/views/application/header/_header_search.html.slim
@@ -6,17 +6,16 @@
           | カテゴリー
         .a-button.is-md.is-secondary.is-select.is-block
           = select_tag 'document_type', options_for_select(Searcher::Configuration.available_types_for_select, params[:document_type]), id: select_id
-      - if smart_search_available?
-        .form-item
-          label.a-form-label
-            | 検索方法
-          ul.block-checks.is-vertical
-            - Searcher::MODES_FOR_SELECT.each do |label, value|
-              li.block-checks__item
-                .a-block-check.is-radio
-                  = radio_button_tag 'mode', value, (params[:mode] || 'keyword') == value, id: "#{mode_id_prefix}-#{value}", class: 'a-toggle-checkbox'
-                  label.a-block-check__label(for="#{mode_id_prefix}-#{value}")
-                    = label
+      .form-item
+        label.a-form-label
+          | 検索方法
+        ul.block-checks.is-vertical
+          - Searcher::MODES_FOR_SELECT.each do |label, value|
+            li.block-checks__item
+              .a-block-check.is-radio
+                = radio_button_tag 'mode', value, (params[:mode] || 'keyword') == value, id: "#{mode_id_prefix}-#{value}", class: 'a-toggle-checkbox'
+                label.a-block-check__label(for="#{mode_id_prefix}-#{value}")
+                  = label
       .form-item
         label.a-form-label
           | 絞り込み条件


### PR DESCRIPTION
## 概要
AI検索（意味検索/ハイブリッド検索）のFeatureフラグを削除し、すべてのユーザーが検索方法を選択できるようにします。

## 変更内容
- `ApplicationHelper#smart_search_available?`メソッドを削除
- 検索フォーム（`_header_search.html.slim`）のFeatureフラグによる条件分岐を削除
- 検索方法の選択UIが全ユーザーに表示されるようになる

## 影響範囲
- すべてのユーザーが検索時に以下の3つの検索方法を選択可能になります
  - キーワード検索（デフォルト）
  - 意味検索（セマンティック検索）
  - ハイブリッド（両方の結果をマージ）

## 確認項目
- [x] RuboCopで違反がないことを確認
- [x] ログイン前/ログイン後の両方で検索方法の選択UIが表示されることを確認
- [x] 各検索モードが正常に動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 検索方法の選択肢がすべてのユーザーに表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->