### PR TITLE
hotfix: calendars.ics user_idなしアクセス時の500エラーを修正

### DIFF
--- a/app/controllers/events/calendars_controller.rb
+++ b/app/controllers/events/calendars_controller.rb
@@ -4,8 +4,12 @@ class Events::CalendarsController < ApplicationController
   skip_before_action :require_active_user_login, raise: false, only: :index
 
   def index
-    user_id = params[:user_id]
-    user = User.find_by(id: user_id)
+    user = User.find_by(id: params[:user_id])
+
+    unless user
+      head :not_found
+      return
+    end
 
     events_calendar = EventsCalendar.new
     events_calendar.fetch_events(user)


### PR DESCRIPTION
## 問題
`/events/calendars.ics` に `user_id` パラメータなしでアクセスすると、`User.find_by` が `nil` を返し、`RegularEvent.fetch_participated_regular_events(nil)` で `NoMethodError (undefined method 'participations' for nil)` が発生して500エラーになっていた。

iOSのカレンダー同期（dataaccessd）からのアクセスで頻発。

## 修正
`user` が見つからない場合は `404 Not Found` を返すようにガード追加。