### PR TITLE
calendars.ics: user_idなしアクセス時の500エラーを修正

### DIFF
--- a/app/controllers/events/calendars_controller.rb
+++ b/app/controllers/events/calendars_controller.rb
@@ -4,8 +4,12 @@ class Events::CalendarsController < ApplicationController
   skip_before_action :require_active_user_login, raise: false, only: :index
 
   def index
-    user_id = params[:user_id]
-    user = User.find_by(id: user_id)
+    user = User.find_by(id: params[:user_id])
+
+    unless user
+      head :not_found
+      return
+    end
 
     events_calendar = EventsCalendar.new
     events_calendar.fetch_events(user)


### PR DESCRIPTION
PR #9700 と同内容のmain向けPR。

## 問題
`/events/calendars.ics` に `user_id` パラメータなしでアクセスすると `NoMethodError (undefined method 'participations' for nil)` で500エラー。

## 修正
`user` が見つからない場合は `404 Not Found` を返すようにガード追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ユーザーが見つからない場合に、より適切なエラーハンドリングを実装しました。これによりカレンダー機能の信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->