### PR TITLE
hotfix: Cloud Run concurrency=5 + RAILS_MAX_THREADS=5 + メモリ4GBで503対策

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -78,9 +78,12 @@ steps:
       - $_CLOUD_SQL_HOST
       - '--memory'
       - $_MEMORY
+      - '--concurrency'
+      - '5'
       - '--timeout'
       - '10m'
       - '--set-env-vars=LANG=ja_JP.UTF-8'
+      - '--set-env-vars=RAILS_MAX_THREADS=5'
       - '--set-env-vars=TZ=Asia/Tokyo'
       - '--set-env-vars=RAILS_SERVE_STATIC_FILES=true'
       - '--set-env-vars=RAILS_LOG_TO_STDOUT=true'


### PR DESCRIPTION
## 問題
503エラーの根本原因: Pumaスレッド数(3)とCloud Run containerConcurrency(25)の不整合

- containerConcurrency=25 → 1インスタンスに最大25リクエスト同時受付
- Pumaスレッド数=3（RAILS_MAX_THREADS未設定のデフォルト）
- **3スレッドしかないのに25リクエスト受け付ける** → キュー待ちが発生 → タイムアウト → 503

## 変更内容

### cloudbuild.yaml
- `--concurrency 5` 追加（containerConcurrency: 25→5）
- `RAILS_MAX_THREADS=5` 環境変数追加（Pumaスレッド数とDB pool数を5に統一）

### Cloud Buildトリガー（手動更新済み）
- `_MEMORY`: 2G → **4G**（デプロイで2Gに戻っていた問題を修正）

## 効果
- Pumaスレッド数 = containerConcurrency = 5 に統一
- インスタンスが処理しきれないリクエストはCloud Runがスケールアウトで別インスタンスに振る
- メモリ4GBでGC頻度が下がりレスポンス改善
- インスタンス数は自動調整されるので全体の処理能力は維持