### PR TITLE
Cloud Run: concurrency=5, RAILS_MAX_THREADS=5 に設定し503対策

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -78,9 +78,12 @@ steps:
       - $_CLOUD_SQL_HOST
       - '--memory'
       - $_MEMORY
+      - '--concurrency'
+      - '5'
       - '--timeout'
       - '10m'
       - '--set-env-vars=LANG=ja_JP.UTF-8'
+      - '--set-env-vars=RAILS_MAX_THREADS=5'
       - '--set-env-vars=TZ=Asia/Tokyo'
       - '--set-env-vars=RAILS_SERVE_STATIC_FILES=true'
       - '--set-env-vars=RAILS_LOG_TO_STDOUT=true'


### PR DESCRIPTION
PR #9702 と同内容のmain向けPR。

cloudbuild.yamlに `--concurrency 5` と `RAILS_MAX_THREADS=5` を追加。
Pumaスレッド数とcontainerConcurrencyを一致させることで、スレッド枯渇による503を防止。