### PR TITLE
リンクチェッカーをCloud Run Jobsで実行する

### DIFF
--- a/.cloudbuild/cloudbuild-link-checker-job.yaml
+++ b/.cloudbuild/cloudbuild-link-checker-job.yaml
@@ -1,0 +1,45 @@
+steps:
+  - id: CreateOrUpdateJob
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        # Cloud Run Jobが存在するか確認
+        if gcloud run jobs describe link-checker --region=asia-northeast1 --project=$PROJECT_ID --quiet 2>/dev/null; then
+          echo "既存のジョブを更新"
+          gcloud run jobs update link-checker \
+            --region=asia-northeast1 \
+            --image=$_DOCKER_IMAGE \
+            --args="bin/rails,link_checker:run" \
+            --set-cloudsql-instances=$_CLOUD_SQL_HOST \
+            --memory=2G \
+            --cpu=1 \
+            --task-timeout=30m \
+            --max-retries=1 \
+            --set-env-vars="RAILS_ENV=production,RAILS_MASTER_KEY=$_RAILS_MASTER_KEY,APP_HOST_NAME=$_APP_HOST_NAME,DB_HOST=/cloudsql/$_CLOUD_SQL_HOST,DB_NAME=$_DB_NAME,DB_PASS=$_DB_PASS,DB_USER=$_DB_USER,DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL,RAILS_LOG_TO_STDOUT=true"
+        else
+          echo "新規ジョブを作成"
+          gcloud run jobs create link-checker \
+            --region=asia-northeast1 \
+            --image=$_DOCKER_IMAGE \
+            --args="bin/rails,link_checker:run" \
+            --set-cloudsql-instances=$_CLOUD_SQL_HOST \
+            --memory=2G \
+            --cpu=1 \
+            --task-timeout=30m \
+            --max-retries=1 \
+            --set-env-vars="RAILS_ENV=production,RAILS_MASTER_KEY=$_RAILS_MASTER_KEY,APP_HOST_NAME=$_APP_HOST_NAME,DB_HOST=/cloudsql/$_CLOUD_SQL_HOST,DB_NAME=$_DB_NAME,DB_PASS=$_DB_PASS,DB_USER=$_DB_USER,DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL,RAILS_LOG_TO_STDOUT=true"
+        fi
+options:
+  substitutionOption: ALLOW_LOOSE
+substitutions:
+  _APP_HOST_NAME: bootcamp.fjord.jp
+  _CLOUD_SQL_HOST: bootcamp-224405:asia-northeast1:bootcamp
+  _DB_NAME: _
+  _DB_PASS: _
+  _DB_USER: _
+  _DISCORD_BUG_WEBHOOK_URL: _
+  _DOCKER_IMAGE: _
+  _RAILS_MASTER_KEY: _
+timeout: 600s

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -125,6 +125,37 @@ steps:
       - '--set-env-vars=$_ENVS'
       - >-
         --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
+  - id: UpdateLinkCheckerJob
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    waitFor:
+      - Deploy
+    args:
+      - '-c'
+      - |
+        if gcloud run jobs describe link-checker --region=asia-northeast1 --quiet 2>/dev/null; then
+          gcloud run jobs update link-checker \
+            --region=asia-northeast1 \
+            --image=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA \
+            --args="bin/rails,link_checker:run" \
+            --set-cloudsql-instances=$_CLOUD_SQL_HOST \
+            --memory=2G \
+            --cpu=1 \
+            --task-timeout=30m \
+            --max-retries=1 \
+            --set-env-vars="RAILS_ENV=production,RAILS_MASTER_KEY=$_RAILS_MASTER_KEY,APP_HOST_NAME=$_APP_HOST_NAME,DB_HOST=/cloudsql/$_CLOUD_SQL_HOST,DB_NAME=$_DB_NAME,DB_PASS=$_DB_PASS,DB_USER=$_DB_USER,DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL,RAILS_LOG_TO_STDOUT=true"
+        else
+          gcloud run jobs create link-checker \
+            --region=asia-northeast1 \
+            --image=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA \
+            --args="bin/rails,link_checker:run" \
+            --set-cloudsql-instances=$_CLOUD_SQL_HOST \
+            --memory=2G \
+            --cpu=1 \
+            --task-timeout=30m \
+            --max-retries=1 \
+            --set-env-vars="RAILS_ENV=production,RAILS_MASTER_KEY=$_RAILS_MASTER_KEY,APP_HOST_NAME=$_APP_HOST_NAME,DB_HOST=/cloudsql/$_CLOUD_SQL_HOST,DB_NAME=$_DB_NAME,DB_PASS=$_DB_PASS,DB_USER=$_DB_USER,DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL,RAILS_LOG_TO_STDOUT=true"
+        fi
   - id: Notify
     name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
     args:

--- a/lib/tasks/link_checker.rake
+++ b/lib/tasks/link_checker.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :link_checker do
+  desc 'リンク切れチェックを実行し、結果をDiscordに通知する'
+  task run: :environment do
+    Rails.logger.info '[LinkChecker] リンクチェック開始'
+
+    documents = Page.all + Practice.all
+    links = LinkChecker::Extractor.extract_links_from_multi(documents)
+    Rails.logger.info "[LinkChecker] #{documents.size}件のドキュメントから#{links.size}件のリンクを抽出"
+
+    summary = LinkChecker::Checker.check_broken_links(links)
+
+    if summary.present?
+      Rails.logger.info "[LinkChecker] リンク切れを検出:\n#{summary}"
+      ChatNotifier.message(summary, username: 'リンクチェッカー', webhook_url: ENV['DISCORD_BUG_WEBHOOK_URL'])
+    else
+      Rails.logger.info '[LinkChecker] リンク切れなし'
+    end
+
+    Rails.logger.info '[LinkChecker] リンクチェック完了'
+  end
+end


### PR DESCRIPTION
## 概要
リンクチェッカーをCloud RunのHTTPエンドポイントからCloud Run Jobsに移行する。

## 背景
- リンクチェッカーはバッチ処理であり、HTTPリクエスト/レスポンスの形で実行するCloud Runよりも、Cloud Run Jobsの方が適している
- Cloud Runで実行すると、長時間のHTTPリクエストがcontainerConcurrencyを消費し、他のリクエストに影響を与える
- タイムアウト制御もCloud Run Jobsの方が柔軟

## 変更内容

### 新規追加
- `lib/tasks/link_checker.rake` — `bin/rails link_checker:run` でリンクチェック実行
- `.cloudbuild/cloudbuild-link-checker-job.yaml` — Cloud Run Job単体のセットアップ用
- `cloudbuild.yaml` にデプロイ時のJob自動更新ステップ追加

### Cloud Run Job設定
- メモリ: 2GB / CPU: 1
- タスクタイムアウト: 30分
- 最大リトライ: 1回
- Cloud SQL Proxy経由でDB接続

## デプロイ後の手順
マージ後、初回デプロイでCloud Run Job `link-checker` が自動作成される。その後Cloud Schedulerで毎日実行を設定する:

```bash
gcloud scheduler jobs create http link-checker-daily \
  --location=asia-northeast1 \
  --schedule='0 6 * * *' \
  --time-zone='Asia/Tokyo' \
  --uri='https://asia-northeast1-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/bootcamp-224405/jobs/link-checker:run' \
  --http-method=POST \
  --oauth-service-account-email=bootcamp-224405@appspot.gserviceaccount.com \
  --project=bootcamp-224405
```

## 既存のSchedulerエンドポイント
`/scheduler/link_checker` は残しておき、Job版が安定したら廃止予定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リンク検査機能を追加しました。アプリケーションが定期的にリンクをチェックし、壊れたリンクを自動検出・通知します。

* **その他**
  * クラウドビルド設定を更新し、リンク検査ジョブの自動デプロイメント環境を整備しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->