### PR TITLE
READMEからDockerの環境づくりへのリンクを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ $ PROFILE=1 rails server
 - [Develop環境でログインする方法](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
 - [Develop環境でのメールの確認方法](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AE%E3%83%A1%E3%83%BC%E3%83%AB%E3%81%AE%E7%A2%BA%E8%AA%8D%E6%96%B9%E6%B3%95)
 - [nodeのバージョン切り替え](https://github.com/fjordllc/bootcamp/wiki/node%E3%81%AE%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E5%88%87%E3%82%8A%E6%9B%BF%E3%81%88)
-- [Develop環境をDockerで動かす方法](doc/development_on_docker.md)
 
 ## その他
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue
- https://github.com/fjordllc/bootcamp/issues/9683


## 概要

READMEから「Develop環境をDockerで動かす方法」というリンクを削除した


## 変更確認方法

1. [https://github.com/fjordllc/bootcamp/tree/chore/remove-link-about-docker-config-from-the-readme](https://github.com/fjordllc/bootcamp/tree/chore/remove-link-about-docker-config-from-the-readme)から閲覧して頂き、[READMEの環境構築](https://github.com/fjordllc/bootcamp?tab=readme-ov-file#%E7%92%B0%E5%A2%83%E6%A7%8B%E7%AF%89)の[Develop環境をDockerで動かす方法](https://github.com/fjordllc/bootcamp/blob/main/doc/development_on_docker.md)リンクが削除されていることを確認してください。


## Screenshot

### 変更前


<img width="792" height="530" alt="スクリーンショット 2026-03-01 22 40 20" src="https://github.com/user-attachments/assets/d72c5e9a-2ce7-4898-864f-b1c025b8e601" />


### 変更後

<img width="605" height="461" alt="スクリーンショット 2026-03-01 22 42 26" src="https://github.com/user-attachments/assets/d932613d-887b-405f-b038-dd9390322bde" />




<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* README.mdの環境構築セクションから、Docker開発環境構築に関するドキュメントリンクを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->