### PR TITLE
Rails7アップグレード後に残っていた残TODOの対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,9 +52,6 @@ gem 'mini_magick'
 gem 'mission_control-jobs'
 gem 'mutex_m', '0.1.1'
 gem 'neighbor'
-gem 'net-imap', require: false
-gem 'net-pop', require: false
-gem 'net-smtp', require: false # TODO: Remove it if you use rails 7.0.1
 gem 'newspaper'
 gem 'oauth2'
 gem 'omniauth', '~> 2.1.1'

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -4,13 +4,9 @@ class Campaign < ApplicationRecord
   validates :start_at, presence: true
   validates :end_at, presence: true
 
-  # TODO: Rails 7に更新後、 `ComparisonValidator` を使うように直す。
-  # refs: https://github.com/rails/rails/pull/40095
-  # validates :end_at, greater_than: :start_at
-  with_options if: -> { start_at && end_at && trial_period } do
-    validate :start_at_cannot_be_greater_than_end_at
-  end
-
+  validates :end_at, comparison: {
+    greater_than: :start_at
+  }
   validates :title, presence: true
   validates :trial_period, presence: true, numericality: { greater_than_or_equal_to: 4 }
 
@@ -55,13 +51,5 @@ class Campaign < ApplicationRecord
         return camp.trial_period if (camp.start_at..camp.end_at).cover?(join_date)
       end
     end
-  end
-
-  private
-
-  def start_at_cannot_be_greater_than_end_at
-    return if end_at > start_at
-
-    errors.add(:end_at, :format, shortest_end_at: I18n.l(start_at, format: :short))
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -5,7 +5,11 @@ class Campaign < ApplicationRecord
   validates :end_at, presence: true
 
   validates :end_at, comparison: {
-    greater_than: :start_at
+    greater_than: :start_at,
+    message: lambda { |object, _data|
+      I18n.t('activerecord.errors.models.campaign.attributes.end_at.greater_than_start_at',
+             shortest_end_at: I18n.l(object.start_at, format: :short))
+    }
   }
   validates :title, presence: true
   validates :trial_period, presence: true, numericality: { greater_than_or_equal_to: 4 }

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -473,7 +473,7 @@ ja:
         campaign:
           attributes:
             end_at:
-              format: 'は%{shortest_end_at}以降を入力してください。'
+              greater_than_start_at: 'は%{shortest_end_at}以降を入力してください。'
         doorkeeper/application:
           attributes:
             redirect_uri:

--- a/test/system/attachments_test.rb
+++ b/test/system/attachments_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Pull Request #4182(https://github.com/fjordllc/bootcamp/pull/4182) で Rails 7 への移行完了後に削除する
 require 'application_system_test_case'
 
 class AttachmentsTest < ApplicationSystemTestCase


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9324

## 概要
Rails 7にアップグレード後に対応を予定していたTODOコメント3つの対応を実施する。

## 詳細

1.  Todoコメント：https://github.com/fjordllc/bootcamp/blob/8de3e3d8c5e66ed6347c10318948c242a889d301/test/system/attachments_test.rb#L3
対応：下記にコードコメントを消すだけで問題無しとコメントがあるので、コメント削除のみ。
https://github.com/fjordllc/bootcamp/issues/9324#issuecomment-3625625238

2. Todoコメント：https://github.com/fjordllc/bootcamp/blob/8de3e3d8c5e66ed6347c10318948c242a889d301/app/models/campaign.rb#L7-L9
対応：日付の比較に`ComparisonValidator`を使用する。
参考リンク
https://github.com/fjordllc/bootcamp/pull/4030#discussion_r795147756

3. Todoコメント：https://github.com/fjordllc/bootcamp/blob/8de3e3d8c5e66ed6347c10318948c242a889d301/Gemfile#L50-L52
対応：Ruby 3.1でnet-imap, net-pop, net-smtp, が削除されたので個別に記述していたが、Rails側で対応するようになったのでこの3つのrequireを削除する。
参考リンク
[rails - Commit 48f2f1a](https://github.com/rails/rails/commit/48f2f1aa07832b4fdc6ce1409644b102c07b0edb)
[Temporarily add net-gems as dependencies of frameworks that use mail](https://github.com/rails/rails/pull/44083/changes#diff-255c7f2238e1f8a8a5ad57f7a634a9058bec5e1943b246cfa0ac35e3171e03bfR44
)
使用箇所の調査：net-smtpのみ使用されていたのでメール送信のみテストを実施する。
以下、メール受信機能が使われていないことを確認したときの調査結果
```
# Query: ActionMailbox
# Flags: IgnoreExcludeSettings
# Including: app/**/*.rb
# ContextLines: 1

結果はありません。
```
## 変更確認方法

1. {chore/cleanup-rails7-code-comments}をローカルに取り込む
### ComparisonValidator使用の確認
2. komagataでログインする
3. [お試し延長作成](http://localhost:3000/admin/campaigns/new)にアクセスする
4. 「終了日時」コントロールの日付を「開始日時」コントロールの日付よりも過去に設定する
終了日時 < 開始日時とする
5. 「内容を保存」ボタンをクリックする
6. エラーメッセージが「終了日時は2026/04/18 00:00以降を入力してください。」と出力されることを確認する
日付は開始日時のYYYY/MM/DDが表示されていること。
### net-imap, net-pop, net-smtp削除の確認
7. hatsunoでログインする
8. 左のメニューの相談をクリックする
9. コメントを入力して、「コメントする」ボタンをクリックする
10. エラーが出ないことを確認する
11. [Letters](http://localhost:3000/letter_opener/)にアクセスする
12. 先ほど入力したメッセージのメールが届いていることを確認する

## Screenshot
修正前と修正後で変更無し
### 変更前
<img width="493" height="103" alt="image" src="https://github.com/user-attachments/assets/c96f8f31-e661-43f7-b267-29d12ec26289" />

### 変更後
<img width="486" height="94" alt="image" src="https://github.com/user-attachments/assets/40f9e3e4-dbe2-4926-b400-0969fc69b2f7" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * キャンペーン期間の検証ロジックを改善しました。キャンペーン終了日は開始日より後の日付である必要があります。エラーメッセージをより正確に表示するようにしました。

* **その他**
  * 不要な依存ライブラリとテストコメントをクリーンアップしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->