### PR TITLE
開発環境において休会中ユーザーのプロフィールに休会情報が表示されないバグを修正

### DIFF
--- a/db/fixtures/hibernations.yml
+++ b/db/fixtures/hibernations.yml
@@ -15,41 +15,41 @@ hibernation2:
 hibernation3:
   user: unhibernated
   scheduled_return_on: <%= Time.current + 30.days %>
-  reason: 学習時間が取れないため
+  reason: メンタル不調のため
   created_at: <%= Time.current - 13.days %>
 
 hibernation4:
   user: autoretire-within-1-hour
   scheduled_return_on: <%= Time.current + 30.days %>
-  reason: 学習時間が取れないため
+  reason: 家庭の事情
   created_at: <%= Time.current - 3.months + 30.minutes %>
 
 hibernation5:
   user: autoretire-within-24-hour
   scheduled_return_on: <%= Time.current + 30.days %>
-  reason: 学習時間が取れないため
+  reason: 時間が無くなったため
   created_at: <%= Time.current - 3.months + 23.hours %>
 
 hibernation6:
   user: autoretire-within-1-week
   scheduled_return_on: <%= Time.current + 30.days %>
-  reason: 学習時間が取れないため
+  reason: お金が足りなくなったため
   created_at: <%= Time.current - 3.months + 1.week %>
 
 hibernation7:
   user: autoretire-over-1-week
   scheduled_return_on: <%= Time.current + 30.days %>
-  reason: 学習時間が取れないため
+  reason: 事故でしばらく動けないため
   created_at: <%= Time.current - 3.months + 1.week + 1.day %>
 
 hibernation8:
   user: not-autoretire
   scheduled_return_on: <%= Time.current + 30.days %>
-  reason: 学習時間が取れないため
+  reason: 指を骨折してプログラミングができないため
   created_at: <%= Time.current - 6.months%>
 
 hibernation9:
   user: nagai-kyuukai
   scheduled_return_on: <%= Time.current + 30.days %>
-  reason: 学習時間が取れないため
+  reason: オンラインでのコミュニケーションが向いていないと感じたため
   created_at: <%= Time.current - 3.months %>


### PR DESCRIPTION


<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9670

## 概要
休会情報を持たない休会中ユーザーという矛盾したシードデータが存在していたため、開発環境において休会中ユーザーのプロフィールに休会情報が表示されないバグが発生していた。

## 変更確認方法

1. bug/inconsistent-seed-dataをローカルに取り込む
2. bug/inconsistent-seed-dataを作業ブランチにした状態で以下のコマンドを実行
`rails db:reset`　※開発環境のデータが全て削除されるので注意してください
3. 開発サーバーを起動
4. 管理者でログイン
- komagata
- testtest
5. http://localhost:3000/users?target=hibernated にアクセス
6. kyuukai以外のユーザーのプロフィールを開く（以下プロフィールリンク）
- [unhibernated](http://localhost:3000/users/519124454)
- [autoretire-within-1-hour](http://localhost:3000/users/772691557)
- [autoretire-within-24-hour](http://localhost:3000/users/157214610)
- [autoretire-over-1-week](http://localhost:3000/users/961813672)
- [autoretire-within-1-week](http://localhost:3000/users/88747759)
- [not-autoretire](http://localhost:3000/users/276661214)
- [nagai-kyuukai](http://localhost:3000/users/430620763)
7. 休会情報の欄に以下の項目があることを確認する
- 1回目の休会
  - 復帰予定日
  - 休会理由
8. kyuukai以外のユーザーのプロフィール全てを確認するまで手順6~7を繰り返す。


## Screenshot

### 変更前
<img width="667" height="545" alt="551878797-7e9294bc-c0ed-4711-af28-219071b505c5" src="https://github.com/user-attachments/assets/8dfe1939-39c1-459f-83e2-c65ba3fd53bb" />

### 変更後
<img width="600" height="545" alt="シードデータ変更後" src="https://github.com/user-attachments/assets/ea591b17-e8c5-4f2f-8d0f-659c0f7d0c78" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * テスト/開発用のハイバネーション（非稼働）データを複数追加しました（開発・検証向けのダミーエントリを追加）。
* **影響**
  * エンドユーザーが直接目にする変更や動作への影響はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->