### PR TITLE
トップページの文言「魚を与えるのではなく...」「FBCでは、受講生が...」の文言を変更

### DIFF
--- a/app/views/welcome/_about.html.slim
+++ b/app/views/welcome/_about.html.slim
@@ -66,30 +66,24 @@ section.lp-content.is-lp-bg-1.is-top-title#about
                     .lp-capture-section__content
                       header.lp-capture-section__header
                         h3.lp-content-sub-title
-                          | 魚を与えるのではなく、
-                          br
-                          | 釣り方を教え、
+                          | 答えを教えるのではなく、
                           br
                           strong
-                            | 自走力を身につける
+                            | 考える力を育てる
+                          br
+                          | AI時代に自走できるエンジニアへ
                       hr.lp-capture-section__border
                       .lp-capture-section__body
                         = image_tag('self-learning-skills.svg', class: 'lp-capture-section__image is-hidden-md-up', alt: 'FBCのみんなが釣りをしているイラスト')
                         .a-short-text
                           p
-                            | FBCでは、受講生が解答にたどり着くプロセスを理解し、
-                            | 自ら解決する力を養うことに注力しています。
+                            | FBCが大切にしているのは、答えを与えることではありません。
                           p
-                            | 課題に間違いがある際、正解を教えるのは簡単ですが、
-                            | そうではなく、正解にたどり着くための次の一手を提示し、
-                            | 理解へと導くよう努めています。
+                            | 「魚を与えるのではなく、釣り方を教える」という考え方のもと、受講生が自ら考え、解決にたどり着く力を育てています。
                           p
-                            | このアプローチは、現役エンジニアのメンターでなければ難しく、
-                            | 高い専門性が求められ、大きなコストと努力も必要です。
-                            | しかし、卒業後も自立して課題に対応できる力を育てるためには不可欠です。
+                            | AIの進化により変化のスピードが増す今、その場の正解を知る力よりも、考え続けられる力がより重要になっています。
                           p
-                            | 結果として、FBCの卒業生は技術的なスキルだけでなく、
-                            | 継続的な学習と自己成長を支える自走力も身につけています。
+                            | 現役ソフトウェアエンジニアのメンターが、受講生一人ひとりの考え方に寄り添いながらサポートし、卒業後も、自分で考えながら学び続けられる「自走力」を身につけていきます。
 
             .lp-content-stack__item
               section.lp-capture-section


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7/views/1?pane=issue&itemId=152563949&issue=fjordllc%7Cbootcamp%7C9560

## 概要
トップページのフィヨルドブートキャンプについての2番目のタイトルと文章の変更

## 変更確認方法

1. `chore/change-text-on-the-homepage-of-rather-than-giving-fish`をローカルに取り込む
2. ローカルサーバを起動する
3. ログイン状態の場合は、ログアウトする

## Screenshot

### 変更前

<img width="1321" height="531" alt="変更前" src="https://github.com/user-attachments/assets/15066a4c-f4a1-401a-9f48-f4ec16164274" />





### 変更後

<img width="1312" height="479" alt="スクリーンショット 2026-03-03 21 12 01" src="https://github.com/user-attachments/assets/81a1b164-d518-4c8d-a40d-9d34240ad04a" />





<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **コンテンツ更新**
  * アバウトセクションのメッセージングを刷新しました。プロセス重視から将来志向の思考スキル開発とメンターサポート中心のナレーティブへ変更されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->