### PR TITLE
PairWorkテーブル　Rails8.1へアップグレードした際の差分を適用

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -552,26 +552,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_19_100001) do
   end
 
   create_table "pair_work_schedules", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.bigint "pair_work_id", null: false
     t.datetime "proposed_at", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
     t.index ["pair_work_id", "proposed_at"], name: "index_pair_work_schedules_on_pair_work_id_and_proposed_at", unique: true
     t.index ["pair_work_id"], name: "index_pair_work_schedules_on_pair_work_id"
   end
 
   create_table "pair_works", force: :cascade do |t|
-    t.string "title", null: false
-    t.text "description", null: false
-    t.datetime "reserved_at"
-    t.bigint "user_id", null: false
-    t.bigint "practice_id"
     t.bigint "buddy_id"
-    t.datetime "published_at"
-    t.boolean "wip", default: false, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.string "channel", default: "ペアワーク・モブワーク1", null: false
+    t.datetime "created_at", null: false
+    t.text "description", null: false
+    t.bigint "practice_id"
+    t.datetime "published_at"
+    t.datetime "reserved_at"
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.boolean "wip", default: false, null: false
     t.index ["buddy_id"], name: "index_pair_works_on_buddy_id"
     t.index ["practice_id"], name: "index_pair_works_on_practice_id"
     t.index ["published_at"], name: "index_pair_works_on_published_at"


### PR DESCRIPTION
[こちら](https://discord.com/channels/715806612824260640/809595476847493192/1478421417807581459)に対応したPRになります。
## 概要
PairWorkの実装中にRails8.1へのアップグレードがあったため、チームメンバーが`bin/rails db:migrate`する際に`schema.rb`に差分が発生していました。本PRはその変更を取り込むPRです。

Rails8.1で発生する差分について
> https://media.zenet-web.co.jp/entry/2025/12/15/092246
## 変更確認方法

1. `feature/support_pair_work`をローカルに取り込む
    1. `git fetch origin chore/align-pair-works-columns-with-rails-8-1`
    2. `git checkout chore/align-pair-works-columns-with-rails-8-1`
2. `bin/setup`を実行
4. 念の為`bin/rails db:schema:dump`を実行
5. 差分が出ないことを確認
6. 念の為ペアワーク機能に異常がないか一通り確認するため、`bin/dev`を実行
7. `kimura`でログイン（誰でもいいです）
8. サイドバーのQ&A ペアワークロゴをクリック。ペアワークのタブをクリックし一覧画面へ
9. 右上の「ペアを募集する」をクリックし、新規作成画面へ
10. 各項目を入力する
    1. 例：lsコマンド実装ペアプロ募集！
    2. 例：Rubyで ls コマンドのクローンを作成する課題に取り組んでいます！UNIXコマンドの基本動作をRubyで再現しながら、ファイル操作やオプション処理の理解を深めたい方、ぜひ一緒に取り組みましょう。
11. スケジュール表にチェックを入れる
    1. 当日の、現在時刻より前の時間帯はチェックがつきません。
12. 画面下部の「登録する」ボタンを押しペアワークを新規作成する

## Screenshot
スクリーンショットはありません。
