### PR TITLE
給付金コースの日報用スコープを追加

### DIFF
--- a/app/controllers/practices/reports_controller.rb
+++ b/app/controllers/practices/reports_controller.rb
@@ -3,6 +3,8 @@
 class Practices::ReportsController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
-    @reports = @practice.reports.list.page(params[:page])
+    @reports = Report.list.page(params[:page])
+    @reports = @reports.with_practice_and_source(params[:practice_id]) if params[:practice_id].present?
+    @reports = @reports.without_original_practice if params[:practice_id].present? && params[:grant_only] == 'true'
   end
 end

--- a/app/controllers/practices/reports_controller.rb
+++ b/app/controllers/practices/reports_controller.rb
@@ -3,8 +3,21 @@
 class Practices::ReportsController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
-    @reports = Report.list.page(params[:page])
-    @reports = @reports.with_practice_and_source(params[:practice_id]) if params[:practice_id].present?
-    @reports = @reports.without_original_practice if params[:practice_id].present? && params[:grant_only] == 'true'
+    @include_source = include_source?
+    @reports =
+      if @include_source
+        Report.for_practice_including_source(@practice)
+      else
+        @practice.reports
+      end
+    @reports = @reports.list.page(params[:page])
+  end
+
+  private
+
+  def include_source?
+    return false unless @practice.grant_course?
+
+    params.fetch(:include_source, 'true') == 'true'
   end
 end

--- a/app/controllers/practices/reports_controller.rb
+++ b/app/controllers/practices/reports_controller.rb
@@ -16,6 +16,7 @@ class Practices::ReportsController < ApplicationController
   private
 
   def include_source?
+    # 給付金コースの場合、include_sourceはデフォルトでtrue
     return false unless @practice.grant_course?
 
     params.fetch(:include_source, 'true') == 'true'

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -5,7 +5,7 @@ module PageTabs
     def practice_page_tabs(practice, active_tab:)
       tabs = []
       tabs << { name: 'プラクティス', link: practice_path(practice) }
-      tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports.length }
+      tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports_count_with_source }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
       tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length } if movie_available?

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -2,10 +2,10 @@
 
 module PageTabs
   module PracticesHelper
-    def practice_page_tabs(practice, active_tab:)
+    def practice_page_tabs(practice, active_tab:, include_source: false)
       tabs = []
       tabs << { name: 'プラクティス', link: practice_path(practice) }
-      tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports_count_with_source }
+      tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports_count(include_source:) }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
       tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length } if movie_available?

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -2,7 +2,9 @@
 
 module PageTabs
   module PracticesHelper
-    def practice_page_tabs(practice, active_tab:, include_source: false)
+    def practice_page_tabs(practice, active_tab:, include_source: nil)
+      # include_source未指定(nil)時は、給付金コースならtrue
+      include_source = practice.grant_course? if include_source.nil?
       tabs = []
       tabs << { name: 'プラクティス', link: practice_path(practice) }
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports_count(include_source:) }

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -207,6 +207,10 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     practices_books.any?(&:must_read)
   end
 
+  def grant_course?
+    source_id.present?
+  end
+
   private
 
   def total_learning_minute(report)

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -211,7 +211,7 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     source_id.present?
   end
 
-  def reports_count(include_source: false)
+  def reports_count(include_source: nil)
     return reports.count unless include_source
 
     ids = [id, source_id].compact

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -211,7 +211,9 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     source_id.present?
   end
 
-  def reports_count_with_source
+  def reports_count(include_source: false)
+    return reports.count unless include_source
+
     ids = [id, source_id].compact
     Report.joins(:practices).where(practices: { id: ids }).distinct.count
   end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -211,6 +211,11 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     source_id.present?
   end
 
+  def reports_count_with_source
+    ids = [id, source_id].compact
+    Report.joins(:practices).where(practices: { id: ids }).distinct.count
+  end
+
   private
 
   def total_learning_minute(report)

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -211,7 +211,7 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     source_id.present?
   end
 
-  def reports_count(include_source: nil)
+  def reports_count(include_source: false)
     return reports.count unless include_source
 
     ids = [id, source_id].compact

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -214,8 +214,7 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
   def reports_count(include_source: false)
     return reports.count unless include_source
 
-    ids = [id, source_id].compact
-    Report.joins(:practices).where(practices: { id: ids }).distinct.count
+    Report.for_practice_including_source(self).count
   end
 
   private

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -61,14 +61,9 @@ class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   scope :user, ->(user) { where(user_id: user.id) }
 
-  scope :with_practice_and_source, lambda { |practice_id|
-    source_id = Practice.find_by(id: practice_id)&.source_id
-    ids = [practice_id, source_id].compact
+  scope :for_practice_including_source, lambda { |practice|
+    ids = [practice.id, practice.source_id].compact
     joins(:practices).where(practices: { id: ids }).distinct
-  }
-
-  scope :without_original_practice, lambda {
-    where.not(id: Report.joins(:practices).where(practices: { source_id: nil }).select(:id))
   }
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -61,6 +61,16 @@ class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   scope :user, ->(user) { where(user_id: user.id) }
 
+  scope :with_practice_and_source, lambda { |practice_id|
+    source_id = Practice.find_by(id: practice_id)&.source_id
+    ids = [practice_id, source_id].compact
+    joins(:practices).where(practices: { id: ids }).distinct
+  }
+
+  scope :without_original_practice, lambda {
+    where.not(id: Report.joins(:practices).where(practices: { source_id: nil }).select(:id))
+  }
+
   def self.ransackable_attributes(_auth_object = nil)
     %w[title description reported_on emotion wip created_at updated_at user_id]
   end

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -9,6 +9,18 @@
 
 = practice_page_tabs(@practice, active_tab: '日報')
 
+- if @practice.grant_course?
+  nav.pill-nav
+    ul.pill-nav__items
+      li.pill-nav__item
+        = link_to '全て',
+          practice_reports_path(@practice),
+          class: ['pill-nav__item-link', ('is-active' unless params[:grant_only])]
+      li.pill-nav__item
+        = link_to '給付金コース',
+          practice_reports_path(@practice, params: { grant_only: true }),
+          class: ['pill-nav__item-link', ('is-active' if params[:grant_only])]
+
 .page-body
   .container.is-md
     - if @reports.empty?

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -7,20 +7,19 @@
   category: category,
   practice: @practice
 
-= practice_page_tabs(@practice, active_tab: '日報')
+= practice_page_tabs(@practice, active_tab: '日報', include_source: @include_source)
 
-- grant_only = params[:grant_only] == 'true'
 - if @practice.grant_course?
   nav.pill-nav
     ul.pill-nav__items
       li.pill-nav__item
         = link_to '全て',
-          practice_reports_path(@practice),
-          class: ['pill-nav__item-link', ('is-active' if !grant_only)]
+          practice_reports_path(@practice, include_source: true),
+          class: ['pill-nav__item-link', ('is-active' if @include_source)]
       li.pill-nav__item
         = link_to '給付金コース',
-          practice_reports_path(@practice, params: { grant_only: true }),
-          class: ['pill-nav__item-link', ('is-active' if grant_only)]
+          practice_reports_path(@practice, include_source: false),
+          class: ['pill-nav__item-link', ('is-active' if !@include_source)]
 
 .page-body
   .container.is-md

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -9,17 +9,18 @@
 
 = practice_page_tabs(@practice, active_tab: '日報')
 
+- grant_only = params[:grant_only] == 'true'
 - if @practice.grant_course?
   nav.pill-nav
     ul.pill-nav__items
       li.pill-nav__item
         = link_to '全て',
           practice_reports_path(@practice),
-          class: ['pill-nav__item-link', ('is-active' unless params[:grant_only])]
+          class: ['pill-nav__item-link', ('is-active' if !grant_only)]
       li.pill-nav__item
         = link_to '給付金コース',
           practice_reports_path(@practice, params: { grant_only: true }),
-          class: ['pill-nav__item-link', ('is-active' if params[:grant_only])]
+          class: ['pill-nav__item-link', ('is-active' if grant_only)]
 
 .page-body
   .container.is-md

--- a/db/fixtures/categories.yml
+++ b/db/fixtures/categories.yml
@@ -117,3 +117,8 @@ category24:
   name: 'Ruby(Reスキル)'
   slug: 'ruby'
   description: 'Rubyのプラクティスからコピーした給付金コースのプラクティスです'
+
+category25:
+  name: "Mac OS X（Reスキル）"
+  slug: "mac-os-x-reskill"
+  description: "Railsコースのカテゴリをコピーしたカテゴリです。"

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -366,3 +366,13 @@ categories_practice68:
   practice: practice114
   category: category24
   position: 17
+
+categories_practice69:
+  practice: practice115
+  category: category25
+  position: 1
+
+categories_practice70:
+  practice: practice116
+  category: category25
+  position: 2

--- a/db/fixtures/courses_categories.yml
+++ b/db/fixtures/courses_categories.yml
@@ -227,3 +227,8 @@ courses_category46:
   course: course5
   category: category24
   position: 19
+
+courses_category47:
+  course: course5
+  category: category25
+  position: 20

--- a/db/fixtures/practices.yml
+++ b/db/fixtures/practices.yml
@@ -776,3 +776,15 @@ practice114:
   description: "Railsコースのプラクティスをコピーした給付金コースのプラクティスです。"
   goal: "goal..."
   source_practice: practice24
+
+practice115:
+  title: "OS X Mountain Lionをクリーンインストールする（Reスキル）"
+  description: "Railsコースのプラクティスをコピーしたプラクティスです。"
+  goal: "goal..."
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice1) %>
+
+practice116:
+  title: "Terminalの基礎を覚える（Reスキル）"
+  description: "Railsコースのプラクティスをコピーしたプラクティスです。"
+  goal: "goal..."
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice2) %>

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -505,3 +505,38 @@ report90:
   description: |-
     たくさんのスタンプがつきました。
   reported_on: "2025-10-01 01:00:00"
+
+report91:
+  user: grant-course
+  title: 給付金コースのプラクティスの日報
+  emotion: 2
+  description: |-
+    給付金コースのプラクティスの日報です。
+  practices: practice115
+  reported_on: "2026-01-01"
+
+report92:
+  user: komagata
+  title: Railsコースのコピー元プラクティスの日報
+  emotion: 2
+  description: |-
+    Railsコースのコピー元プラクティスの日報です。
+  practices: practice1
+  reported_on: "2026-01-02"
+
+report93:
+  user: komagata
+  title: Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報報
+  emotion: 2
+  description: |-
+    Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報報
+  practices: practice1, practice115
+  reported_on: "2026-01-03"
+
+report94:
+  user: komagata
+  title: プラクティスに関連しない日報
+  emotion: 2
+  description: |-
+    プラクティスに関連しない日報
+  reported_on: "2026-01-04"

--- a/db/fixtures/reports.yml
+++ b/db/fixtures/reports.yml
@@ -526,10 +526,10 @@ report92:
 
 report93:
   user: komagata
-  title: Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報報
+  title: Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報
   emotion: 2
   description: |-
-    Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報報
+    Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報
   practices: practice1, practice115
   reported_on: "2026-01-03"
 

--- a/test/fixtures/learning_times.yml
+++ b/test/fixtures/learning_times.yml
@@ -37,3 +37,8 @@ learning_time8:
   report: report10
   started_at: 2020-09-10 12:00:00
   finished_at: 2020-09-10 13:15:00
+
+learning_time9:
+  report: report77
+  started_at: 2026-01-02 00:00:00
+  finished_at: 2026-01-02 02:00:00

--- a/test/fixtures/learning_times.yml
+++ b/test/fixtures/learning_times.yml
@@ -39,6 +39,6 @@ learning_time8:
   finished_at: 2020-09-10 13:15:00
 
 learning_time9:
-  report: report77
-  started_at: 2026-01-02 00:00:00
-  finished_at: 2026-01-02 02:00:00
+  report: report78
+  started_at: 2026-01-01 00:00:00
+  finished_at: 2026-01-01 01:00:00

--- a/test/fixtures/practices.yml
+++ b/test/fixtures/practices.yml
@@ -396,3 +396,25 @@ practice64:
   description: 'Railsコースのプラクティスをコピーした給付金コースのプラクティスです。'
   goal: 'goal...'
   source_practice: practice23
+
+practice65:
+  title: "Railsコースのコピー元プラクティス"
+  description: "Railsコースのコピー元プラクティスです。"
+  goal: "goal..."
+
+practice66:
+  title: "給付金コースのプラクティス"
+  description: "給付金コースのプラクティスです。"
+  goal: "goal..."
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice65) %>
+
+practice67:
+  title: "日報が存在しないRailsコースのコピー元プラクティス"
+  description: "日報が存在しないRailsコースのコピー元プラクティスです。"
+  goal: "goal..."
+
+practice68:
+  title: "日報が存在しない給付金コースのプラクティス"
+  description: "日報が存在しない給付金コースのプラクティスです。"
+  goal: "goal..."
+  source_id: <%= ActiveRecord::FixtureSet.identify(:practice67) %>

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -358,3 +358,50 @@ report75:
   description: WIPです
   wip: true
   reported_on: "2022-04-02"
+
+report76:
+  user: komagata
+  title: "Railsコースのプラクティスの日報"
+  emotion: 1
+  description: Railsコースのプラクティスの日報です。
+  practices: practice1
+  reported_on: "2026-01-01"
+
+report77:
+  user: komagata
+  title: "給付金コースのプラクティスの日報"
+  emotion: 1
+  description: 給付金コースのプラクティスの日報です。
+  practices: practice64
+  reported_on: "2026-01-02"
+
+report78:
+  user: komagata
+  title: "プラクティスに関連する日報"
+  emotion: 1
+  description: プラクティスに関連する日報です。
+  practices: practice1
+  reported_on: "2026-01-03"
+
+report79:
+  user: komagata
+  title: "コピー元のプラクティスの日報"
+  emotion: 1
+  description: コピー元のプラクティスの日報です。
+  practices: practice1, practice64
+  reported_on: "2026-01-04"
+
+report80:
+  user: komagata
+  title: "異なるプラクティスに関連する日報"
+  emotion: 1
+  description: 異なるプラクティスに関連する日報です。
+  practices: practice2
+  reported_on: "2026-01-05"
+
+report81:
+  user: komagata
+  title: "プラクティスに関連していない日報"
+  emotion: 1
+  description: プラクティスに関連付かない日報です。
+  reported_on: "2026-01-06"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -361,10 +361,10 @@ report75:
 
 report76:
   user: komagata
-  title: "Railsコースのプラクティスの日報"
+  title: "Railsコースのコピー元プラクティスの日報"
   emotion: 1
-  description: Railsコースのプラクティスの日報です。
-  practices: practice1
+  description: Railsコースのコピー元プラクティスの日報です。
+  practices: practice65
   reported_on: "2026-01-01"
 
 report77:
@@ -372,36 +372,28 @@ report77:
   title: "給付金コースのプラクティスの日報"
   emotion: 1
   description: 給付金コースのプラクティスの日報です。
-  practices: practice64
+  practices: practice66
   reported_on: "2026-01-02"
 
 report78:
   user: komagata
-  title: "プラクティスに関連する日報"
+  title: "Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報"
   emotion: 1
-  description: プラクティスに関連する日報です。
-  practices: practice1
+  description: Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報です。
+  practices: practice65, practice66
   reported_on: "2026-01-03"
 
 report79:
   user: komagata
-  title: "コピー元のプラクティスの日報"
+  title: "給付金コースではないプラクティスの日報"
   emotion: 1
-  description: コピー元のプラクティスの日報です。
-  practices: practice1, practice64
+  description: 給付金コースではないプラクティスの日報です。
+  practices: practice1
   reported_on: "2026-01-04"
 
 report80:
   user: komagata
-  title: "異なるプラクティスに関連する日報"
+  title: "プラクティスに関連しない日報"
   emotion: 1
-  description: 異なるプラクティスに関連する日報です。
-  practices: practice2
+  description: プラクティスに関連しない日報です。
   reported_on: "2026-01-05"
-
-report81:
-  user: komagata
-  title: "プラクティスに関連していない日報"
-  emotion: 1
-  description: プラクティスに関連付かない日報です。
-  reported_on: "2026-01-06"

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -13,6 +13,6 @@ class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
     get counts_api_reports_unchecked_index_path(format: :text),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    assert_match '65件', response.body
+    assert_match '71件', response.body
   end
 end

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -13,6 +13,6 @@ class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
     get counts_api_reports_unchecked_index_path(format: :text),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    assert_match '71件', response.body
+    assert_match '69件', response.body
   end
 end

--- a/test/integration/api/reports/unchecked_test.rb
+++ b/test/integration/api/reports/unchecked_test.rb
@@ -13,6 +13,6 @@ class API::Reports::UncheckedTest < ActionDispatch::IntegrationTest
     get counts_api_reports_unchecked_index_path(format: :text),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
-    assert_match '69件', response.body
+    assert_match '70件', response.body
   end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -92,4 +92,49 @@ class PracticeTest < ActiveSupport::TestCase
     assert Practice.new(source_id: 1).grant_course?
     assert_not Practice.new(source_id: nil).grant_course?
   end
+
+  test '#reports_count_with_source returns reports count' do
+    practice = practices(:practice66)
+    Report.create!(
+      user: users(:komagata),
+      title: '日報が存在しないプラクティスの日報',
+      description: '日報が存在しないプラクティスの日報です。',
+      practices: [practice],
+      reported_on: Time.zone.today
+    )
+    assert_equal 1, practice.reports_count_with_source
+  end
+
+  test '#reports_count_with_source returns reports count including source' do
+    source = practices(:practice67)
+    practice = practices(:practice68)
+    Report.create!(
+      user: users(:komagata),
+      title: '日報が存在しないプラクティスの日報',
+      description: '日報が存在しないプラクティスの日報です。',
+      practices: [source],
+      reported_on: Time.zone.today
+    )
+    Report.create!(
+      user: users(:komagata),
+      title: 'source_idを持っている日報が存在しないプラクティスの日報',
+      description: 'source_idを持っている日報が存在しないプラクティスの日報です。',
+      practices: [practice],
+      reported_on: Time.zone.today - 1
+    )
+    assert_equal 2, practice.reports_count_with_source
+  end
+
+  test '#reports_count_with_source does not double count reports when associated with both source and practice' do
+    source = practices(:practice67)
+    practice = practices(:practice68)
+    Report.create!(
+      user: users(:komagata),
+      title: '複数のプラクティスに関連する日報',
+      description: '複数のプラクティスに関連する日報です。',
+      practices: [source, practice],
+      reported_on: Time.zone.today
+    )
+    assert_equal 1, practice.reports_count_with_source
+  end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -93,21 +93,11 @@ class PracticeTest < ActiveSupport::TestCase
     assert_not Practice.new(source_id: nil).grant_course?
   end
 
-  test '#reports_count_with_source returns reports count' do
-    practice = practices(:practice66)
-    Report.create!(
-      user: users(:komagata),
-      title: '日報が存在しないプラクティスの日報',
-      description: '日報が存在しないプラクティスの日報です。',
-      practices: [practice],
-      reported_on: Time.zone.today
-    )
-    assert_equal 1, practice.reports_count_with_source
-  end
-
-  test '#reports_count_with_source returns reports count including source' do
+  test '#reports_count sums reports of self and source when include_source is true' do
     source = practices(:practice67)
     practice = practices(:practice68)
+
+    assert_equal 0, practice.reports_count(include_source: true)
     Report.create!(
       user: users(:komagata),
       title: '日報が存在しないプラクティスの日報',
@@ -117,24 +107,43 @@ class PracticeTest < ActiveSupport::TestCase
     )
     Report.create!(
       user: users(:komagata),
-      title: 'source_idを持っている日報が存在しないプラクティスの日報',
-      description: 'source_idを持っている日報が存在しないプラクティスの日報です。',
+      title: '日報が存在しないプラクティスをコピーしたプラクティスの日報',
+      description: '日報が存在しないプラクティスをコピーしたプラクティスの日報です。',
       practices: [practice],
       reported_on: Time.zone.today - 1
     )
-    assert_equal 2, practice.reports_count_with_source
+
+    assert_equal 1, practice.reports_count(include_source: false)
+    assert_equal 2, practice.reports_count(include_source: true)
   end
 
-  test '#reports_count_with_source does not double count reports when associated with both source and practice' do
+  test '#reports_count counts only self reports when include_source is false' do
+    practice = practices(:practice67)
+
+    assert_equal 0, practice.reports_count(include_source: false)
+    Report.create!(
+      user: users(:komagata),
+      title: '日報が存在しないプラクティスの日報',
+      description: '日報が存在しないプラクティスの日報です。',
+      practices: [practice],
+      reported_on: Time.zone.today
+    )
+
+    assert_equal 1, practice.reports_count(include_source: false)
+  end
+
+  test '#reports_count does not double count reports when associated with both source and practice' do
     source = practices(:practice67)
     practice = practices(:practice68)
     Report.create!(
       user: users(:komagata),
-      title: '複数のプラクティスに関連する日報',
-      description: '複数のプラクティスに関連する日報です。',
+      title: '日報が存在しないプラクティス、日報が存在しないプラクティスをコピーしたプラクティスの両方に関連する日報',
+      description: '日報が存在しないプラクティス、日報が存在しないプラクティスをコピーしたプラクティスの両方に関連する日報です。',
       practices: [source, practice],
       reported_on: Time.zone.today
     )
-    assert_equal 1, practice.reports_count_with_source
+
+    assert_equal 1, practice.reports_count(include_source: false)
+    assert_equal 1, practice.reports_count(include_source: true)
   end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -87,4 +87,9 @@ class PracticeTest < ActiveSupport::TestCase
       practice.update!(source_id: 99_999)
     end
   end
+
+  test '#grant_course? returns true when practice has source' do
+    assert Practice.new(source_id: 1).grant_course?
+    assert_not Practice.new(source_id: nil).grant_course?
+  end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -100,20 +100,19 @@ class PracticeTest < ActiveSupport::TestCase
     assert_equal 0, practice.reports_count(include_source: true)
     Report.create!(
       user: users(:komagata),
-      title: '日報が存在しないプラクティスの日報',
-      description: '日報が存在しないプラクティスの日報です。',
+      title: '日報が存在しないRailsコースのコピー元プラクティスの日報',
+      description: '日報が存在しないRailsコースのコピー元プラクティスの日報です。',
       practices: [source],
       reported_on: Time.zone.today
     )
     Report.create!(
       user: users(:komagata),
-      title: '日報が存在しないプラクティスをコピーしたプラクティスの日報',
-      description: '日報が存在しないプラクティスをコピーしたプラクティスの日報です。',
+      title: '日報が存在しない給付金コースのプラクティスの日報',
+      description: '日報が存在しない給付金コースのプラクティスの日報です。',
       practices: [practice],
       reported_on: Time.zone.today - 1
     )
 
-    assert_equal 1, practice.reports_count(include_source: false)
     assert_equal 2, practice.reports_count(include_source: true)
   end
 
@@ -123,8 +122,8 @@ class PracticeTest < ActiveSupport::TestCase
     assert_equal 0, practice.reports_count(include_source: false)
     Report.create!(
       user: users(:komagata),
-      title: '日報が存在しないプラクティスの日報',
-      description: '日報が存在しないプラクティスの日報です。',
+      title: '日報が存在しないRailsコースのコピー元プラクティスの日報',
+      description: '日報が存在しないRailsコースのコピー元プラクティスの日報です。',
       practices: [practice],
       reported_on: Time.zone.today
     )
@@ -137,8 +136,8 @@ class PracticeTest < ActiveSupport::TestCase
     practice = practices(:practice68)
     Report.create!(
       user: users(:komagata),
-      title: '日報が存在しないプラクティス、日報が存在しないプラクティスをコピーしたプラクティスの両方に関連する日報',
-      description: '日報が存在しないプラクティス、日報が存在しないプラクティスをコピーしたプラクティスの両方に関連する日報です。',
+      title: '日報が存在しないRailsコースのコピー元プラクティス、日報が存在しない給付金コースのプラクティスの両方に関連する日報',
+      description: '日報が存在しないRailsコースのプラクティス、日報が存在しない給付金コースのプラクティスの両方に関連する日報です。',
       practices: [source, practice],
       reported_on: Time.zone.today
     )

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -96,8 +96,8 @@ class PracticeTest < ActiveSupport::TestCase
   test '#reports_count sums reports of self and source when include_source is true' do
     source_practice = practices(:practice67)
     practice = practices(:practice68)
+    initial_count = practice.reports_count(include_source: true)
 
-    assert_equal 0, practice.reports_count(include_source: true)
     Report.create!(
       user: users(:komagata),
       title: '日報が存在しないRailsコースのコピー元プラクティスの日報',
@@ -113,13 +113,13 @@ class PracticeTest < ActiveSupport::TestCase
       reported_on: Time.zone.today - 1
     )
 
-    assert_equal 2, practice.reports_count(include_source: true)
+    assert_equal initial_count + 2, practice.reports_count(include_source: true)
   end
 
   test '#reports_count counts only self reports when include_source is false' do
     practice = practices(:practice67)
+    initial_count = practice.reports_count(include_source: false)
 
-    assert_equal 0, practice.reports_count(include_source: false)
     Report.create!(
       user: users(:komagata),
       title: '日報が存在しないRailsコースのコピー元プラクティスの日報',
@@ -128,12 +128,15 @@ class PracticeTest < ActiveSupport::TestCase
       reported_on: Time.zone.today
     )
 
-    assert_equal 1, practice.reports_count(include_source: false)
+    assert_equal initial_count + 1, practice.reports_count(include_source: false)
   end
 
   test '#reports_count does not double count reports when associated with both source and practice' do
     source_practice = practices(:practice67)
     practice = practices(:practice68)
+    initial_count = practice.reports_count(include_source: false)
+    initial_count_include_source = practice.reports_count(include_source: true)
+
     Report.create!(
       user: users(:komagata),
       title: '日報が存在しないRailsコースのコピー元プラクティス、日報が存在しない給付金コースのプラクティスの両方に関連する日報',
@@ -142,7 +145,7 @@ class PracticeTest < ActiveSupport::TestCase
       reported_on: Time.zone.today
     )
 
-    assert_equal 1, practice.reports_count(include_source: false)
-    assert_equal 1, practice.reports_count(include_source: true)
+    assert_equal initial_count + 1, practice.reports_count(include_source: false)
+    assert_equal initial_count_include_source + 1, practice.reports_count(include_source: true)
   end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -135,7 +135,7 @@ class PracticeTest < ActiveSupport::TestCase
     source_practice = practices(:practice67)
     practice = practices(:practice68)
     initial_count = practice.reports_count(include_source: false)
-    initial_count_include_source = practice.reports_count(include_source: true)
+    initial_count_including_source = practice.reports_count(include_source: true)
 
     Report.create!(
       user: users(:komagata),
@@ -146,6 +146,6 @@ class PracticeTest < ActiveSupport::TestCase
     )
 
     assert_equal initial_count + 1, practice.reports_count(include_source: false)
-    assert_equal initial_count_include_source + 1, practice.reports_count(include_source: true)
+    assert_equal initial_count_including_source + 1, practice.reports_count(include_source: true)
   end
 end

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -94,7 +94,7 @@ class PracticeTest < ActiveSupport::TestCase
   end
 
   test '#reports_count sums reports of self and source when include_source is true' do
-    source = practices(:practice67)
+    source_practice = practices(:practice67)
     practice = practices(:practice68)
 
     assert_equal 0, practice.reports_count(include_source: true)
@@ -102,7 +102,7 @@ class PracticeTest < ActiveSupport::TestCase
       user: users(:komagata),
       title: '日報が存在しないRailsコースのコピー元プラクティスの日報',
       description: '日報が存在しないRailsコースのコピー元プラクティスの日報です。',
-      practices: [source],
+      practices: [source_practice],
       reported_on: Time.zone.today
     )
     Report.create!(
@@ -132,13 +132,13 @@ class PracticeTest < ActiveSupport::TestCase
   end
 
   test '#reports_count does not double count reports when associated with both source and practice' do
-    source = practices(:practice67)
+    source_practice = practices(:practice67)
     practice = practices(:practice68)
     Report.create!(
       user: users(:komagata),
       title: '日報が存在しないRailsコースのコピー元プラクティス、日報が存在しない給付金コースのプラクティスの両方に関連する日報',
       description: '日報が存在しないRailsコースのプラクティス、日報が存在しない給付金コースのプラクティスの両方に関連する日報です。',
-      practices: [source, practice],
+      practices: [source_practice, practice],
       reported_on: Time.zone.today
     )
 

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -73,4 +73,27 @@ class ReportTest < ActiveSupport::TestCase
     assert_empty unchecked_report.checks
     assert_includes Report.unchecked, unchecked_report
   end
+
+  test '.with_practice_and_source includes practice and source reports' do
+    practice = practices(:practice1)
+    practice_report = reports(:report78)
+    source_report = reports(:report79)
+    other_report = reports(:report80)
+    unrelated_report = reports(:report81)
+    result = Report.with_practice_and_source(practice.id)
+
+    assert_includes result, practice_report
+    assert_includes result, source_report
+    assert_not_includes result, other_report
+    assert_not_includes result, unrelated_report
+  end
+
+  test '.without_original_practice excludes original practice reports' do
+    original_report = reports(:report76)
+    grant_report = reports(:report77)
+    result = Report.without_original_practice
+
+    assert_includes result, grant_report
+    assert_not_includes result, original_report
+  end
 end

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -74,26 +74,19 @@ class ReportTest < ActiveSupport::TestCase
     assert_includes Report.unchecked, unchecked_report
   end
 
-  test '.with_practice_and_source includes practice and source reports' do
-    practice = practices(:practice1)
-    practice_report = reports(:report78)
-    source_report = reports(:report79)
-    other_report = reports(:report80)
-    unrelated_report = reports(:report81)
-    result = Report.with_practice_and_source(practice.id)
+  test '.for_practice_including_source returns practice and source reports' do
+    practice = practices(:practice66)
+    practice_report = reports(:report77)
+    source_report = reports(:report76)
+    practice_and_source_report = reports(:report78)
+    other_report = reports(:report79)
+    unrelated_report = reports(:report80)
+    result = Report.for_practice_including_source(practice)
 
     assert_includes result, practice_report
     assert_includes result, source_report
+    assert_includes result, practice_and_source_report
     assert_not_includes result, other_report
     assert_not_includes result, unrelated_report
-  end
-
-  test '.without_original_practice excludes original practice reports' do
-    original_report = reports(:report76)
-    grant_report = reports(:report77)
-    result = Report.without_original_practice
-
-    assert_includes result, grant_report
-    assert_not_includes result, original_report
   end
 end

--- a/test/system/practice/reports_test.rb
+++ b/test/system/practice/reports_test.rb
@@ -11,40 +11,40 @@ class Practice::ReportsTest < ApplicationSystemTestCase
   end
 
   test 'grant filter is not present on rails course practice' do
-    visit_with_auth "/practices/#{practices(:practice1).id}/reports", 'komagata'
+    visit_with_auth "/practices/#{practices(:practice65).id}/reports", 'komagata'
 
     assert_no_selector 'a.pill-nav__item-link', text: '全て'
     assert_no_selector 'a.pill-nav__item-link', text: '給付金コース'
   end
 
   test 'grant filter is present on grant course practice' do
-    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+    visit_with_auth "/practices/#{practices(:practice66).id}/reports", 'komagata'
 
     assert_selector 'a.pill-nav__item-link', text: '全て'
     assert_selector 'a.pill-nav__item-link', text: '給付金コース'
   end
 
   test 'grant filter shows both copied and grant course reports when "全て" is selected' do
-    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+    visit_with_auth "/practices/#{practices(:practice66).id}/reports", 'komagata'
 
     assert_selector 'a.pill-nav__item-link.is-active', text: '全て'
-    assert_selector '.card-list-item-title__link', text: 'コピー元のプラクティスの日報'
+    assert_selector '.card-list-item-title__link', text: 'Railsコースのコピー元プラクティスの日報'
     assert_selector '.card-list-item-title__link', text: '給付金コースのプラクティスの日報'
   end
 
   test 'grant filter shows only grant course reports when "給付金コース" is selected' do
-    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+    visit_with_auth "/practices/#{practices(:practice66).id}/reports", 'komagata'
     within '.pill-nav' do
       click_on '給付金コース'
     end
 
     assert_selector 'a.pill-nav__item-link.is-active', text: '給付金コース'
-    assert_no_selector '.card-list-item-title__link', text: 'コピー元のプラクティスの日報'
+    assert_no_selector '.card-list-item-title__link', text: 'Railsコースのコピー元プラクティスの日報'
     assert_selector '.card-list-item-title__link', text: '給付金コースのプラクティスの日報'
   end
 
   test 'grant filter shows empty message when no reports exist' do
-    visit_with_auth "/practices/#{practices(:practice65).id}/reports", 'komagata'
+    visit_with_auth "/practices/#{practices(:practice68).id}/reports", 'komagata'
     within '.pill-nav' do
       click_on '給付金コース'
     end

--- a/test/system/practice/reports_test.rb
+++ b/test/system/practice/reports_test.rb
@@ -9,4 +9,48 @@ class Practice::ReportsTest < ApplicationSystemTestCase
     assert_selector 'img[alt="positive"]', count: 2
     assert_selector '.card-list-item-title__link', text: '1時間だけ学習'
   end
+
+  test 'grant filter is not present on rails course practice' do
+    visit_with_auth "/practices/#{practices(:practice1).id}/reports", 'komagata'
+
+    assert_no_selector 'a.pill-nav__item-link', text: '全て'
+    assert_no_selector 'a.pill-nav__item-link', text: '給付金コース'
+  end
+
+  test 'grant filter is present on grant course practice' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+
+    assert_selector 'a.pill-nav__item-link', text: '全て'
+    assert_selector 'a.pill-nav__item-link', text: '給付金コース'
+  end
+
+  test 'grant filter shows both copied and grant course reports when "全て" is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+
+    assert_selector 'a.pill-nav__item-link.is-active', text: '全て'
+    assert_selector '.card-list-item-title__link', text: 'コピー元のプラクティスの日報'
+    assert_selector '.card-list-item-title__link', text: '給付金コースのプラクティスの日報'
+  end
+
+  test 'grant filter shows only grant course reports when "給付金コース" is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/reports", 'komagata'
+    within '.pill-nav' do
+      click_on '給付金コース'
+    end
+
+    assert_selector 'a.pill-nav__item-link.is-active', text: '給付金コース'
+    assert_no_selector '.card-list-item-title__link', text: 'コピー元のプラクティスの日報'
+    assert_selector '.card-list-item-title__link', text: '給付金コースのプラクティスの日報'
+  end
+
+  test 'grant filter shows empty message when no reports exist' do
+    visit_with_auth "/practices/#{practices(:practice65).id}/reports", 'komagata'
+    within '.pill-nav' do
+      click_on '給付金コース'
+    end
+
+    assert_selector 'a.pill-nav__item-link.is-active', text: '給付金コース'
+    assert_no_selector '.card-list-item-title__link'
+    assert_selector '.o-empty-message__text', text: '日報はまだありません。'
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9292

## 前提

- 給付金コースはRailsエンジニアコースをコピーして作られたコース
- 給付金コースのカテゴリ、プラクティス、日報、書籍は既存のRailsエンジニアコースをコピーして作成される

wiki: [給付金コースの人が元コースの関連情報を見れるようにする](https://github.com/fjordllc/bootcamp/wiki/%E7%B5%A6%E4%BB%98%E9%87%91%E3%82%B3%E3%83%BC%E3%82%B9%E3%81%AE%E4%BA%BA%E3%81%8C%E5%85%83%E3%82%B3%E3%83%BC%E3%82%B9%E3%81%AE%E9%96%A2%E9%80%A3%E6%83%85%E5%A0%B1%E3%82%92%E8%A6%8B%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)

## 概要

給付金コースのプラクティスの関連日報一覧(/practices/:id/reports)にコピー元プラクティスの関連日報の表示/非表示を切り替えるフィルターを追加

- 以下の2つのボタンで表示する日報を切り替え
  - `全て`: コピー元プラクティス + 給付金コースのプラクティスの日報
  - `給付金コース`: 給付金コースのプラクティスの日報
  
## 補足

### PRについて

元々はReactベースで実装を進めていましたが`Reports.jsx` コンポーネントが廃止されたため、Viewベースの実装に変更しました。
以下PRはReactベースで作成していたものです。
https://github.com/fjordllc/bootcamp/pull/9515

---

### デザインについて

前回のPRでmachidaさんにデザイン依頼を行い、このままのデザインで問題ないことを了承済みです。
https://github.com/fjordllc/bootcamp/pull/9515#issuecomment-3808417067
前回のPRと同じデザインに統一しています。

## 変更確認方法

### 事前準備

1. `feature/reports-grant-course-filter-v2` をローカルに取り込む
2. seedで初期データ作成

```sh
# 初期データ作成
bundle exec rails db:seed
```

### フィルター表示/非表示

1. `komagata` でログイン
2. プラクティス > 「OS X Mountain Lionをクリーンインストールする」を選択 > 「日報」タブを開く(/practices/:id/reports)
3. 「全て/給付金コース」のフィルターが表示されていないことを確認
4. `grant-course` でログイン
5. プラクティス > 「OS X Mountain Lionをクリーンインストールする(Reスキル)」を選択(一覧の最下部) > 「日報」タブを開く(/practices/:id/reports)
6. 「全て/給付金コース」のフィルターが表示されることを確認

### フィルタリング

1. `grant-course` でログイン
2. プラクティス > 「OS X Mountain Lionをクリーンインストールする(Reスキル)」を選択 > 「日報」タブを開く(/practices/:id/reports)
3. 「全て/給付金コース」のボタンの選択状態で日報がフィルタリングされて表示されることを確認(以下タイトルの日報が含まれて表示されていればok)
  - `全て` 選択時:
    - 給付金コースのプラクティスの日報
    - Railsコースのコピー元プラクティスの日報 
    - Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報報
  - `給付金コース` 選択時:
    - 給付金コースのプラクティスの日報
    - Railsコースのコピー元プラクティス、給付金コースのプラクティスの両方に関連する日報報

### 日報の表示件数

1. `grant-course` でログイン
2. プラクティス > 「OS X Mountain Lionをクリーンインストールする(Reスキル)」を選択 > 「日報」タブを開く(/practices/:id/reports)
3. 「全て/給付金コース」のボタンの選択状態毎に日報タブ内の`日報（n）` の表示件数と実際に表示される日報数が同一であることを確認
4. 「日報タブ」以外のタブを開いた時に日報の`日報（n）`の表示件数がフィルターの「全て」選択時の表示件数と同一であることを確認

<img width="1609" height="670" alt="count" src="https://github.com/user-attachments/assets/0ea0bbbc-edbd-40bb-ae61-0f8b04f1603d" />

### 給付金の日報が0件時の表示

1. `grant-course` でログイン
2. プラクティス > 「Terminalの基礎を覚える（Reスキル）」を選択(一覧の最下部)  > 「日報」タブを開く(/practices/:id/reports)
3. `給付金コース` を選択
5. 「日報はまだありません。」が表示されることを確認

<img width="1412" height="375" alt="no_report" src="https://github.com/user-attachments/assets/9e00c8da-fbf5-48d9-a5ca-06ea124cbeb4" />

## Screenshot

### 変更前

<img width="1619" height="446" alt="before" src="https://github.com/user-attachments/assets/c71656a8-f94f-40b9-84bd-cb8bf522d962" />

### 変更後

<img width="1608" height="483" alt="after" src="https://github.com/user-attachments/assets/8bbfbf3b-3ec8-4eeb-b865-afa6c11bba91" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 練習レポート一覧に「全て / 給付金コース」切替タブを追加し、給付金コースのみ表示できるようになりました（ページネーション維持）。
* **表示改善**
  * 日報タブの件数表示を、コピー元と給付金コース両方を考慮した集計に更新しました。
* **データ追加**
  * 新しいカテゴリ、練習、レポート、ユーザー等のフィクスチャを追加しました。
* **テスト**
  * 給付金コース表示に関する単体・統合・システムテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/26000981385/artifacts/7045588657)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
