### PR TITLE
watchesとfootprintsの関連付けをそれぞれモジュールに統一

### DIFF
--- a/app/models/concerns/footprintable.rb
+++ b/app/models/concerns/footprintable.rb
@@ -4,6 +4,6 @@ module Footprintable
   extend ActiveSupport::Concern
 
   included do
-    has_many :footprints, as: :footprintable, dependent: :delete_all
+    has_many :footprints, as: :footprintable, dependent: :destroy
   end
 end

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -71,8 +71,6 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :participants,
            through: :regular_event_participations,
            source: :user
-  has_many :watches, as: :watchable, dependent: :destroy
-  has_many :footprints, as: :footprintable, dependent: :destroy
   attribute :wants_announcement, :boolean
 
   columns_for_keyword_search :title, :description


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9689

## 概要
WatchableとFootprintableではwatches と footprints に対する has_many が記述されている。
しかし、RegularEvent内でもhas_manyが書かれており二重化している。
そのため、WatchableとFootprintableに統一した。

また、Footprintableをincludeしている他のモデルでもdependentオプションがdelete_allからdestroyに上書きされているため、Footprintableモデルをdestroyに修正し、統一した。

## 変更確認方法
動作確認の準備
- chore/unify-has-many-associationsをローカルに取り込む

以下の動作をmainブランチとchore/unify-has-many-associationsで確認する

### watchesの関連付け
1. ローカルサーバを起動する
2. komagataでログインする
3. http://localhost:3000/regular_events/40690962 に遷移する
4. 参加登録していない状態かつWatch中でないことを確認する（参加、Watch中になっていれば解除する）
<img width="1265" height="816" alt="image" src="https://github.com/user-attachments/assets/fc319ff8-55fc-4065-a508-bd65c7fab0b8" />

5. 参加申込をクリックし、イベントに参加する。その時、Watch中に変更されたことを確認する
  <img width="1260" height="838" alt="image" src="https://github.com/user-attachments/assets/b6e32021-709d-4d5b-8d43-77fd9778c540" />

### footprintsの関連付け
1. ローカルサーバを起動する
2. komagataでログインする
3. http://localhost:3000/regular_events/new に遷移し、イベントを作成する
4. 作成したイベントのコメント欄の下に「みたよ」がないことを確認する
<img width="1264" height="943" alt="image" src="https://github.com/user-attachments/assets/cf3cdf17-4ec4-448d-ab63-95d0680c9793" />
5. ログアウトし、kimuraでログインする
6. http://localhost:3000/regular_events?target=not_finished に遷移し、3で作成したイベントをクリックする
7. 「みたよ」にkimuraが表示されていることを確認する
<img width="1259" height="946" alt="image" src="https://github.com/user-attachments/assets/2fdf93d6-45b7-44da-b33f-e7124576f2bf" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * フットプリントの削除処理を変更し、関連削除時に関連の破棄処理やコールバックが確実に実行されるようにしました。
  * 定期イベントの関連付けを整理し、不要な自動関連削除を削除してモデルの振る舞いを簡素化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->