### PR TITLE
使用されていないインデックスを削除

### DIFF
--- a/db/migrate/20260306064800_remove_unused_indices_from_regular_events.rb
+++ b/db/migrate/20260306064800_remove_unused_indices_from_regular_events.rb
@@ -1,0 +1,7 @@
+class RemoveUnusedIndicesFromRegularEvents < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :regular_events, column: :finished
+    remove_index :regular_events, column: :start_at
+    remove_index :regular_events, column: :end_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_17_092056) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_06_064800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -730,9 +730,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_17_092056) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.boolean "wip", default: false, null: false
-    t.index ["end_at"], name: "index_regular_events_on_end_at"
-    t.index ["finished"], name: "index_regular_events_on_finished"
-    t.index ["start_at"], name: "index_regular_events_on_start_at"
     t.index ["user_id"], name: "index_regular_events_on_user_id"
   end
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9684

## 概要
regular_eventsに使用されていないインデックスが複数あったため、コスト削減のために削除した。
## 変更確認方法
今回はUI、振る舞い、ロジックの変更はない
1. Files changedのdb/schema.rbのdiffを見て以下のインデックスだけが削除されていることを確認する。
```
  t.index ["end_at"], name: "index_regular_events_on_end_at"
  t.index ["finished"], name: "index_regular_events_on_finished"
  t.index ["start_at"], name: "index_regular_events_on_start_at"
```
<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * データベーススキーマを更新しました（スキーマバージョンの更新）。
  * 定期イベントに関連する未使用のインデックス（開始・終了・完了）を削除し、ストレージ削減と一部クエリ挙動への影響が見込まれます。運用監視とクエリの見直しを推奨します。
* **バグ修正**
  * スキーマ整合性に関するマージ競合を解消しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->