### PR TITLE
近日開催のペアワークがメンター、アドバイザーのダッシュボードでも表示されるようにした

### DIFF
--- a/app/helpers/pair_works_helper.rb
+++ b/app/helpers/pair_works_helper.rb
@@ -45,4 +45,9 @@ module PairWorksHelper
     today = upcoming_pair_work.reserved_at.to_date == Time.current.to_date
     today ? 'a-meta__label is-important' : 'a-meta__label'
   end
+
+  def meta_value_by_status(upcoming_pair_work)
+    today = upcoming_pair_work.reserved_at.to_date == Time.current.to_date
+    today ? 'a-meta__value is-important' : 'a-meta__value'
+  end
 end

--- a/app/views/home/_adviser_dashboard.html.slim
+++ b/app/views/home/_adviser_dashboard.html.slim
@@ -9,6 +9,8 @@
             .dashboard-category__body
               .a-panels
                 .a-panels__items
+                  - if @upcoming_pair_works.present?
+                    = render 'upcoming_pair_works', upcoming_pair_works: @upcoming_pair_works
                   - if @upcoming_events_groups.present?
                     = render 'upcoming_events_groups', upcoming_events_groups: @upcoming_events_groups
                   .a-panels__item

--- a/app/views/home/_mentor_dashboard.html.slim
+++ b/app/views/home/_mentor_dashboard.html.slim
@@ -3,6 +3,10 @@
     .dashboard-contents__cols
       .dashboard-contents__col.is-sub.is-only-mentor
         .dashboard-contents__categories
+          - if @upcoming_pair_works.present?
+            .dashboard-category
+              = render 'upcoming_pair_works', upcoming_pair_works: @upcoming_pair_works
+
           .dashboard-category
             - unchecked_report_count = Cache.unchecked_report_count
             - if unchecked_report_count > 100
@@ -25,8 +29,6 @@
             .dashboard-category__body
               .a-panels
                 .a-panels__items
-                  - if @upcoming_pair_works.present?
-                    = render 'upcoming_pair_works', upcoming_pair_works: @upcoming_pair_works
                   - if @upcoming_events_groups.present?
                     = render 'upcoming_events_groups', upcoming_events_groups: @upcoming_events_groups
                   - if @announcements.present?

--- a/app/views/home/_mentor_dashboard.html.slim
+++ b/app/views/home/_mentor_dashboard.html.slim
@@ -25,6 +25,8 @@
             .dashboard-category__body
               .a-panels
                 .a-panels__items
+                  - if @upcoming_pair_works.present?
+                    = render 'upcoming_pair_works', upcoming_pair_works: @upcoming_pair_works
                   - if @upcoming_events_groups.present?
                     = render 'upcoming_events_groups', upcoming_events_groups: @upcoming_events_groups
                   - if @announcements.present?

--- a/app/views/home/_upcoming_pair_work.html.slim
+++ b/app/views/home/_upcoming_pair_work.html.slim
@@ -16,6 +16,6 @@
               .a-meta
                 span class=meta_label_by_status(upcoming_pair_work)
                   | 開催日時
-                span class=meta_label_by_status(upcoming_pair_work)
+                span class=meta_value_by_status(upcoming_pair_work)
                   time datetime=upcoming_pair_work.reserved_at.iso8601
                     = l upcoming_pair_work.reserved_at

--- a/db/fixtures/pair_works.yml
+++ b/db/fixtures/pair_works.yml
@@ -26,7 +26,7 @@ pair_work3:
   reserved_at: <%= Time.current.beginning_of_day + 23.hours %>
   user: kimura
   practice: null
-  buddy: sotugyou
+  buddy: advijirou
   published_at: <%= Time.current %>
   created_at: <%= Time.current %>
   wip: false

--- a/test/helpers/pair_works_helper_test.rb
+++ b/test/helpers/pair_works_helper_test.rb
@@ -89,4 +89,19 @@ class PairWorksHelperTest < ActionView::TestCase
       assert_not_equal normal_meta_label, meta_label_by_status(pair_work)
     end
   end
+
+  test 'meta_value_by_status' do
+    pair_work = pair_works(:pair_work2)
+    normal_meta_value = 'a-meta__value'
+    important_meta_value = 'a-meta__value is-important'
+
+    assert_equal normal_meta_value, meta_value_by_status(pair_work)
+    assert_not_equal important_meta_value, meta_value_by_status(pair_work)
+
+    reserved_on = Time.zone.local(2025, 1, 2)
+    travel_to reserved_on do
+      assert_equal important_meta_value, meta_value_by_status(pair_work)
+      assert_not_equal normal_meta_value, meta_value_by_status(pair_work)
+    end
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #4267

## 概要
ペアワーク機能にて、近日開催のペアワークが受講生のダッシュボードにしか表示されていなかったのでメンター、アドバイザーのダッシュボードでも表示されるようにしたPRです。

## 変更確認方法
1. `bug/fix-upcoming-pair-works`をローカルに取り込む
2. `kimura`でログイン
3. [新規作成](http://localhost:3000/pair_works/new)にて各項目を入力し、ペアワークを作成
    1. スケジュールには、明日〜明後日辺りのどこかにチェックを入れてください（近日開催のペアワークの動作確認をするためです）
4. `komagata`でログイン
5. 先ほど作成したペアワークのページに行き、スケジュール表の✅をクリックし、ペア確定する
6. [ダッシュボード](http://localhost:3000/)にアクセスし、近日開催のペアワークが表示されているのを確認

7.` bin/rails db:seed`を実行する
8. `advijirou`でログイン
9. ダッシュボードにて、下にスクロールし、近日開催のペアワークが表示されているのを確認

## Screenshot
### 変更前
<img width="707" height="308" alt="image" src="https://github.com/user-attachments/assets/6a461f18-36af-4cd3-a777-67d97438673f" />

### 変更後
<img width="765" height="355" alt="image" src="https://github.com/user-attachments/assets/55978d14-290f-43ad-aff2-12f69d3279d3" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アドバイザー／メンターダッシュボードに「今後のペアワーク」セクションを追加して予定を表示します。
  * 予約日時の表示に状態に応じた強調（当日の予約で重要表示）を導入しました。

* **スタイル**
  * フォームのチェックボックス無効時にグレーアウトと操作不可カーソルを適用しました。

* **テスト**
  * 上記表示ロジックを検証するユニットテストを追加しました。

* **雑務**
  * テストデータの一部値を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27693405883/artifacts/7697493121" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-9755-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->