### PR TITLE
テストがfixtureのデータ数に依存しないように修正

### DIFF
--- a/test/models/generation_test.rb
+++ b/test/models/generation_test.rb
@@ -39,9 +39,8 @@ class GenerationTest < ActiveSupport::TestCase
       advisers: 3,
       retired: 1
     }
-    generation = Generation.new(5)
-    expected.each do |target, count|
-      assert_equal count, generation.count_classmates_by_target(target), "#{target} of 5th generation count mismatch"
-    end
+    gen5 = Generation.new(5)
+    actual = expected.keys.index_with { |t| gen5.count_classmates_by_target(t) }
+    assert_equal expected, actual
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9671

## 概要
~~fixtureにある5期生のデータ数が変動しても既存のテストが落ちないように修正しました。~~
→テストがfailuresになった時の出力を分かりやすくした。
経緯 : https://github.com/fjordllc/bootcamp/pull/9771#discussion_r2952281445 

## 変更確認方法

1. `chore/fragile-test`をローカルに取り込む
2. `test/fixtures/users.yml` から以下のユーザーを削除
- hatsuno
3. `test/models/generation_test.rb`の`test '#count_classmates_by_target'`を実行
`rails test test/models/generation_test.rb:33`
4. テストの結果の出力が以下のようになっていることを確認する
```
F

Failure:
GenerationTest#test_#count_classmates_by_target [test/models/generation_test.rb:44]:
--- expected
+++ actual
@@ -1 +1 @@
-{students: 18, trainees: 3, hibernated: 1, graduated: 2, advisers: 3, retired: 1}
+{students: 17, trainees: 3, hibernated: 1, graduated: 2, advisers: 3, retired: 1}
```
5. 変更を破棄
`g restore test/fixtures/users.yml`
<!-- I want to review in Japanese. -->

## screenshot
### 変更前
<img width="997" height="547" alt="image" src="https://github.com/user-attachments/assets/3ea8e7c2-3621-465f-80ca-e63f39c3c826" />


### 変更後
<img width="1081" height="555" alt="image" src="https://github.com/user-attachments/assets/09d3db6f-8c92-4aff-bd06-0839356b2e96" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 同種の複数アサーションをデータ駆動型に整理し、個別の断続的検証を一括で検証するようにしました。
  * テスト内のインスタンス作成を最小化して実行効率を向上させました。
  * 既存の動作や公開APIに影響はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->