### PR TITLE
update twitter.com to x.com

### DIFF
--- a/app/views/articles/_share_button_x.html.erb
+++ b/app/views/articles/_share_button_x.html.erb
@@ -1,5 +1,5 @@
 <a class="x-share-button"
-  href="https://twitter.com/intent/tweet?url=https://bootcamp.fjord.jp/articles/<%= article.id %>&hashtags=fjordbootcamp&text=<%= truncate(article.title, length: 100) %>%0a"
+  href="https://x.com/intent/tweet?url=https://bootcamp.fjord.jp/articles/<%= article.id %>&hashtags=fjordbootcamp&text=<%= truncate(article.title, length: 100) %>%0a"
   data-size="large"
   rel="noopener noreferrer"
   target="_blank">


### PR DESCRIPTION
## Issue Number
N/A - Maintenance update for social share link

## Overview
Updated the article share button component to use the new X.com domain instead of the legacy Twitter.com domain for the intent/tweet URL. This ensures share functionality works correctly with X's current infrastructure.

### Changes
- **File Modified**: `app/views/articles/_share_button_x.html.erb`
- **Change**: Updated share URL from `https://twitter.com/intent/tweet` to `https://x.com/intent/tweet`
- **Impact**: All article share buttons will now direct users to X.com instead of Twitter.com

## Verification Method
1. Navigate to any article page (e.g., https://bootcamp.fjord.jp/articles/[id])
2. Click the X share button on the article
3. Verify that the share intent opens on x.com (not twitter.com)
4. Confirm the article URL, hashtag, and title are properly included in the share text

### Before
- Share button directed to: `https://twitter.com/intent/tweet?...`

### After
- Share button directs to: `https://x.com/intent/tweet?...`

## Screenshots
### Before (twitter.com domain)
Screenshot would show the share button pointing to twitter.com domain in the URL

### After (x.com domain)
Screenshot would show the share button pointing to x.com domain in the URL

---

**Original Description:**

hey, i noticed the share button was still using twitter.com instead of x.com, so i updated it. let me know if you need any changes!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ソーシャルシェアボタンをTwitterからXに更新しました。記事をXにシェアする際のリンク先を新しいプラットフォームに変更しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->