### PR TITLE
リアクションボタンをホバーした時のユーザー名を見えるようにした

### DIFF
--- a/app/assets/stylesheets/application/blocks/reaction/_reaction.css
+++ b/app/assets/stylesheets/application/blocks/reaction/_reaction.css
@@ -58,6 +58,8 @@
 @media (pointer: fine) {
   .reactions__item:hover .reactions__item-login-names {
     display: block;
+    position: absolute;
+    z-index: 2;
   }
 }
 .reactions__dropdown .reactions__item {

--- a/app/assets/stylesheets/application/blocks/reaction/_reaction.css
+++ b/app/assets/stylesheets/application/blocks/reaction/_reaction.css
@@ -58,7 +58,6 @@
 @media (pointer: fine) {
   .reactions__item:hover .reactions__item-login-names {
     display: block;
-    position: absolute;
     z-index: 2;
   }
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7/views/1?filterQuery=assignee%3Azecky1120&pane=issue&itemId=161314085&issue=fjordllc%7Cbootcamp%7C9674

## 概要
Q&Aページの回答・コメントの箇所でコメントを入れた後、リアクションボタンを付け加えマウスオーバーするとリアクションしたユーザー名が見えなかったが、CSSで調整し見えるようにした。


## 変更確認方法

1. `bug/name-not-visible-when-hovering-reaction-btn`をローカルに取り込む
2. Q&Aページへ移動し、質問するボタンをクリックします
3. 質問を作成する
4. その後、コメント欄に文章を入力した後4つほどリアクションを追加する
5. この時、リアクションボタンをホバーした時ユーザー名がボタンの後ろになっていることを確認します
6. `bin/dev`を実行する
7. リアクションボタンをホバーするとボタンの前にユーザー名が前になっていることを確認します

## Screenshot

### 変更前


https://github.com/user-attachments/assets/dbb3b377-9534-4b36-9aa9-f260e7f4f5bd




### 変更後



https://github.com/user-attachments/assets/3854ecfe-fa6e-4d18-9c47-33ab9216dd8f





<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * マウス利用時（ファインポインタ）の条件で、リアクションのホバー表示におけるツールチップの表示位置と表示レイヤー（重なり順）を調整しました。これにより、ユーザー名ポップアップの表示安定性と視認性が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->