### PR TITLE
プラクティス編集ページで参考書籍の選択箇所のレイアウト崩れを修正

### DIFF
--- a/app/assets/stylesheets/shared/blocks/form/_books-form.css
+++ b/app/assets/stylesheets/shared/blocks/form/_books-form.css
@@ -4,10 +4,6 @@
   border-radius: .25rem;
 }
 
-.books-form + .books-form {
-  margin-top: 2rem;
-}
-
 .books-form__header {
   position: relative;
 }
@@ -39,9 +35,6 @@
 .books-form__delete-link:hover {
   color: var(--danger);
   border-color: var(--danger);
-}
-
-.books-form__items {
 }
 
 @media (min-width: 48em) {

--- a/app/views/mentor/practices/_book_fields.html.slim
+++ b/app/views/mentor/practices/_book_fields.html.slim
@@ -1,16 +1,14 @@
-= cocooned_item do
-  .col-xl-4.col-md-6.col-xs-12
-    .books-form
-      .books-form__header
-        .books-form__delete
-          = cocooned_remove_item_link f, class: 'books-form__delete-link' do
-            i.fas.fa-times
-      .books-form__items
-        .books-form-item
-          = f.label '参考書籍', class: 'a-form-label'
-          = f.collection_select :book_id, all_books, :first, :last, {}, { class: 'js-book-select' }
-        .books-form-item.is-inline
-          = f.label '必読', class: 'a-form-label'
-          label.a-on-off-checkbox.is-sm.books-form-item__must-read
-            = f.check_box :must_read
-            span
+= cocooned_item class: 'books-form' do
+  .books-form__header
+    .books-form__delete
+      = cocooned_remove_item_link f, class: 'books-form__delete-link' do
+        i.fas.fa-times
+  .books-form__items
+    .books-form-item
+      = f.label '参考書籍', class: 'a-form-label'
+      = f.collection_select :book_id, all_books, :first, :last, {}, { class: 'js-book-select' }
+    .books-form-item.is-inline
+      = f.label '必読', class: 'a-form-label'
+      label.a-on-off-checkbox.is-sm.books-form-item__must-read
+        = f.check_box :must_read
+        span


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7?pane=issue&itemId=159907258&issue=fjordllc%7Cbootcamp%7C9681

## 概要

## 変更確認方法

1. `bug/reference-book-is-distorted-in-the-editing`をローカルに取り込む
2. メンター（`komagata` もしくは `machida`）でログイン後、[プラクティスの編集ページ](http://localhost:3000/mentor/practices/1019809339/edit)へ移動します
3. 参考書籍の「+書籍を選択」ボタンをクリックし、レイアウトが崩れてないか確認してください

## Screenshot

### 変更前

<img width="361" height="317" alt="変更前" src="https://github.com/user-attachments/assets/f679717a-f427-4ea9-a0b0-5f0bbc604b51" />


### 変更後


https://github.com/user-attachments/assets/ba62c316-59fc-411e-a523-14607d4e6a34




<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 繰り返し表示されるフォーム要素のラッパー構造を簡素化し、要素の入れ子を整理しました。
* **Style**
  * 隣接するフォーム間の余白を与える冗長なルールと、効果のない空のスタイル定義を削除してCSSを整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->