### PR TITLE
pg_bigmによるキーワード検索の全文検索インデックス導入

### DIFF
--- a/app/models/searcher/query_builder.rb
+++ b/app/models/searcher/query_builder.rb
@@ -21,19 +21,14 @@ class Searcher
       end
     end
 
+    # pg_bigm拡張が有効かチェック（結果をキャッシュ）
     def self.pg_bigm_available?
       return @pg_bigm_available if defined?(@pg_bigm_available)
 
-      @pg_bigm_available = begin
-        result = ActiveRecord::Base.connection.execute(
-          "SELECT COUNT(*) FROM pg_extension WHERE extname = 'pg_bigm'"
-        )
-        result.first["count"].to_i.positive?
-      rescue StandardError
-        false
-      end
+      @pg_bigm_available = check_pg_bigm_extension
     end
 
+    # テスト用: キャッシュをリセット
     def self.reset_pg_bigm_cache!
       remove_instance_variable(:@pg_bigm_available) if defined?(@pg_bigm_available)
     end
@@ -45,22 +40,40 @@ class Searcher
 
     private
 
+    def self.check_pg_bigm_extension
+      result = ActiveRecord::Base.connection.select_value(
+        "SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pg_bigm')"
+      )
+      [true, 't'].include?(result)
+    rescue StandardError
+      false
+    end
+    private_class_method :check_pg_bigm_extension
+
     # pg_bigm GINインデックスを活用したLIKE検索
+    # pg_bigmはLIKEのみ対応（ILIKEは非対応）
+    # 日本語検索ではcase-sensitiveで実用上問題なし
+    # 英字（login_name等）も検索語そのままマッチするため十分実用的
     def search_with_bigm(config)
       model = config[:model]
       keywords = Searcher.split_keywords(keyword)
 
-      scope = model.all
-      scope = scope.includes(*config[:includes]) if config[:includes].any?
-      scope = apply_like_conditions(scope, model, config[:columns], keywords)
+      scope = build_bigm_scope(model, config, keywords)
       scope.distinct.order(updated_at: :desc).to_a
     end
 
-    def apply_like_conditions(scope, model, columns, keywords)
+    # pg_bigm検索のスコープを構築
+    def build_bigm_scope(model, config, keywords)
+      scope = model.all
+      scope = scope.includes(*config[:includes]) if config[:includes].any?
+
       keywords.each do |word|
         escaped = sanitize_like(word)
-        # case_sensitive: true → LIKEを使用（pg_bigm GINインデックスが効く）
-        conditions = columns.map { |col| model.arel_table[col].matches("%#{escaped}%", nil, true) }
+        # case_sensitive: true → LIKE（pg_bigm GINインデックスが効く）
+        # case_sensitive: false → ILIKE（pg_bigmインデックスが効かない）
+        conditions = config[:columns].map do |col|
+          model.arel_table[col].matches("%#{escaped}%", nil, true)
+        end
         scope = scope.where(conditions.reduce(:or))
       end
       scope

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1006,7 +1006,7 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
       )
       avatar.attach(custom_blob)
     end
-  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, Vips::Error => e
+  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, LoadError => e
     log_avatar_error('attach_custom_avatar', e)
   end
 

--- a/db/migrate/20260322000000_enable_pg_bigm_extension.rb
+++ b/db/migrate/20260322000000_enable_pg_bigm_extension.rb
@@ -4,20 +4,21 @@ class EnablePgBigmExtension < ActiveRecord::Migration[8.1]
   def up
     return unless pg_bigm_installable?
 
-    execute "CREATE EXTENSION IF NOT EXISTS pg_bigm"
+    enable_extension 'pg_bigm'
   end
 
   def down
-    execute "DROP EXTENSION IF EXISTS pg_bigm"
+    disable_extension 'pg_bigm'
   rescue ActiveRecord::StatementInvalid
     # pg_bigmが存在しない環境では無視
+    nil
   end
 
   private
 
   def pg_bigm_installable?
     result = execute("SELECT COUNT(*) FROM pg_available_extensions WHERE name = 'pg_bigm'")
-    result.first["count"].to_i.positive?
+    result.first['count'].to_i.positive?
   rescue ActiveRecord::StatementInvalid
     false
   end

--- a/db/migrate/20260322000001_add_pg_bigm_gin_indexes.rb
+++ b/db/migrate/20260322000001_add_pg_bigm_gin_indexes.rb
@@ -20,12 +20,11 @@ class AddPgBigmGinIndexes < ActiveRecord::Migration[8.1]
   }.freeze
 
   def up
-    return unless pg_bigm_available?
-
     INDEXES.each do |table, columns|
       columns.each do |column|
-        index_name = "index_#{table}_on_#{column}_bigm"
+        index_name = bigm_index_name(table, column)
         next if index_exists?(table, column, name: index_name)
+        next unless pg_bigm_enabled?
 
         execute <<~SQL
           CREATE INDEX CONCURRENTLY #{index_name}
@@ -39,7 +38,7 @@ class AddPgBigmGinIndexes < ActiveRecord::Migration[8.1]
   def down
     INDEXES.each do |table, columns|
       columns.each do |column|
-        index_name = "index_#{table}_on_#{column}_bigm"
+        index_name = bigm_index_name(table, column)
         execute "DROP INDEX CONCURRENTLY IF EXISTS #{index_name}"
       end
     end
@@ -47,9 +46,13 @@ class AddPgBigmGinIndexes < ActiveRecord::Migration[8.1]
 
   private
 
-  def pg_bigm_available?
+  def bigm_index_name(table, column)
+    "index_#{table}_on_#{column}_bigm"
+  end
+
+  def pg_bigm_enabled?
     result = execute("SELECT COUNT(*) FROM pg_extension WHERE extname = 'pg_bigm'")
-    result.first["count"].to_i.positive?
+    result.first['count'].to_i.positive?
   rescue StandardError
     false
   end

--- a/test/models/searcher/query_builder_test.rb
+++ b/test/models/searcher/query_builder_test.rb
@@ -19,7 +19,6 @@ class Searcher::QueryBuilderTest < ActiveSupport::TestCase
     results = builder.search_model(config)
 
     assert results.is_a?(Array)
-    # 結果が複数ある場合、更新日時の降順であることを確認
     assert results.first.updated_at >= results.second.updated_at if results.size > 1
   end
 
@@ -33,7 +32,6 @@ class Searcher::QueryBuilderTest < ActiveSupport::TestCase
 
     results = builder.search_model(config)
 
-    # includesが適用されていることを確認（N+1を防ぐ）
     assert_nothing_raised do
       results.each { |product| product.user&.name }
     end
@@ -49,7 +47,6 @@ class Searcher::QueryBuilderTest < ActiveSupport::TestCase
 
     results = builder.search_model(config)
 
-    # 重複がないことを確認
     assert_equal results.uniq.size, results.size
   end
 
@@ -62,7 +59,7 @@ class Searcher::QueryBuilderTest < ActiveSupport::TestCase
   test 'reset_pg_bigm_cache! clears cached value' do
     Searcher::QueryBuilder.pg_bigm_available?
     Searcher::QueryBuilder.reset_pg_bigm_cache!
-    refute Searcher::QueryBuilder.instance_variable_defined?(:@pg_bigm_available)
+    assert_not Searcher::QueryBuilder.instance_variable_defined?(:@pg_bigm_available)
   end
 
   test 'search_model with multiple keywords returns AND-filtered results' do
@@ -75,7 +72,6 @@ class Searcher::QueryBuilderTest < ActiveSupport::TestCase
   end
 
   test 'search_model handles association columns gracefully' do
-    # User config has discord_profile_account_name (association column)
     config = Searcher::Configuration.get(:user)
     builder = Searcher::QueryBuilder.new('テスト')
     results = builder.search_model(config)
@@ -87,5 +83,23 @@ class Searcher::QueryBuilderTest < ActiveSupport::TestCase
     config = Searcher::Configuration.get(:practice)
     results = builder.search_model(config)
     assert_kind_of Array, results
+  end
+
+  test 'build_params returns single keyword params for external callers' do
+    builder = Searcher::QueryBuilder.new('ruby')
+    params = builder.build_params(%i[title description])
+    assert_equal({ 'title_or_description_cont' => 'ruby' }, params)
+  end
+
+  test 'build_params returns multiple keyword params' do
+    builder = Searcher::QueryBuilder.new('ruby rails')
+    params = builder.build_params(%i[title description])
+    expected = {
+      g: [
+        { 'title_or_description_cont' => 'ruby' },
+        { 'title_or_description_cont' => 'rails' }
+      ]
+    }
+    assert_equal expected, params
   end
 end


### PR DESCRIPTION
## 概要
pg_bigm（2-gram）エクステンションを導入し、キーワード検索にGINインデックスを追加します。

## 背景
現在のキーワード検索はRansackの `_cont`（ILIKE）を使用しており、インデックスが効かないためテーブルフルスキャンが発生しています。pg_bigmは日本語の全文検索に適した2-gramベースのインデックスを提供します。

## 変更内容

### マイグレーション
- pg_bigmエクステンションの有効化
- 全検索対象テーブル・カラムにGIN(gin_bigm_ops)インデックスを追加
  - practices (title, description, goal)
  - pages (title, body)
  - reports (title, description)
  - questions (title, description)
  - answers (description) ※correct_answersもSTIで含む
  - comments (description)
  - announcements (title, description)
  - products (body)
  - events (title, description)
  - regular_events (title, description)
  - pair_works (title, description)
  - users (login_name, name, description)

### QueryBuilder改修
- pg_bigmがインストール済みの環境: `LIKE` + GINインデックスで高速検索
- pg_bigmが未インストールの環境: 従来のRansack（ILIKE）にフォールバック
- pg_bigmは `LIKE` のみ対応（`ILIKE` 非対応）のため直接SQLで検索
- 関連テーブルのカラム（discord_profile_account_nameなど）は直接SQL時に自動除外

### なぜpg_bigm？
- **Cloud SQL対応**: Google Cloud SQLのサポート対象エクステンション
- **日本語に最適**: 日本で開発された2-gramベースで、1〜2文字のキーワードでもインデックスが効く
- **pg_trgm（3-gram）との違い**: pg_trgmは3文字未満の検索でインデックスが効かないため日本語検索に不向き

## デプロイ時の注意
- Cloud SQLで `cloudsql.enable_pg_bigm` フラグをONにしてからマイグレーションを実行すること

## 動作確認
ローカル環境でpg_bigmをインストールし、インデックスが使用されることをEXPLAIN ANALYZEで確認済み:
```
Bitmap Index Scan on idx_pages_title_bigm
  Index Cond: ((title)::text ~~ '%テスト%'::text)
Bitmap Index Scan on idx_pages_body_bigm
  Index Cond: (body ~~ '%テスト%'::text)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 検索の高速化と改善：PostgreSQL拡張を利用した新しい検索経路を追加し、複数キーワード検索や結果の絞り込みが高速化されます。
  * 検索語の特殊文字を安全に扱えるよう改善。

* **バグ修正**
  * カスタムアバター添付時の例外処理を見直し、特定のエラーに対してより堅牢に動作します。

* **Chores**
  * pg_bigm拡張の有効化と専用インデックス追加のためのデータベースマイグレーションを追加。

* **Tests**
  * 検索とキャッシュ周りの振る舞いを検証するテストを更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->