### PR TITLE
通知ベルのピル型タブでcursor: pointerが効かない問題を修正

### DIFF
--- a/app/assets/stylesheets/shared/blocks/_pill-nav.css
+++ b/app/assets/stylesheets/shared/blocks/_pill-nav.css
@@ -48,6 +48,6 @@
   border-color: var(--main);
 }
 
-div.pill-nav__item-link {
+.pill-nav__item-link {
   cursor: pointer;
 }


### PR DESCRIPTION
## 問題
通知ベル（画面右上）のモーダル内にある「未読」「全て」のピル型タブをマウスオーバーしてもポインターが変わらない。

## 原因
`_pill-nav.css` で `cursor: pointer` が `div.pill-nav__item-link` にのみ適用されていた。通知ベルのタブは `button.pill-nav__item-link` なので、`div` セレクタにマッチしなかった。

## 修正
`div.pill-nav__item-link` → `.pill-nav__item-link` に変更し、要素タイプに関係なく `cursor: pointer` が適用されるようにした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ピルナビゲーション要素のカーソルスタイルの適用範囲を拡大しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->