### PR TITLE
Q&A個別ページでのcomments.js TypeError修正

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -9,6 +9,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const commentContent = document.querySelector(
     '#comments.thread-comments.loaded'
   )
+  if (!commentContent) {
+    return
+  }
   if (comments) {
     loadingContent.classList.add('is-hidden')
     commentContent.classList.remove('is-hidden')


### PR DESCRIPTION
## 問題
Q&Aの個別ページにアクセスすると以下のJavaScriptエラーがConsoleに出る:

```
Uncaught TypeError: can't access property "classList", n is null
    comments.js:14
    comments.js:3
```

## 原因
`comments.js` が `#comments.thread-comments.loaded` 要素を `querySelector` で取得しているが、Q&Aページでは `comments/_comments` パーシャルを使わず独自の回答表示（`.answer-content`）をしているため、この要素が存在しない。結果として `commentContent` が `null` になり `classList.remove` でTypeErrorが発生。

## 修正
`commentContent` が `null` の場合に early return するガードを追加。Q&Aページのようにcomments構造が異なるページでは `comments.js` の処理をスキップする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * コメント機能の安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->