### PR TITLE
日報本文でのpjordメンションにも応答するように修正

### DIFF
--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -2,7 +2,10 @@
 
 module Mentioner
   def after_save_mention(new_mentions)
-    return if instance_of?(Report)
+    if instance_of?(Report)
+      notify_pjord_if_mentioned(new_mentions)
+      return
+    end
 
     notify_users_found_by_mentions(new_mentions)
   end
@@ -41,6 +44,13 @@ module Mentioner
   end
 
   private
+
+  def notify_pjord_if_mentioned(mentions)
+    names = extract_login_names_from_mentions(mentions)
+    return unless names.include?(Pjord::LOGIN_NAME)
+
+    PjordRespondJob.perform_later(mentionable_type: self.class.name, mentionable_id: id)
+  end
 
   def notify_users_found_by_mentions(mentions)
     notify_mentions(find_users_from_mentions(mentions))


### PR DESCRIPTION
## 概要

日報本文で `@pjord` とメンションしても応答がなかった問題を修正。

## 原因

`Mentioner#after_save_mention` で `return if instance_of?(Report)` としており、Reportの場合は全てのメンション通知がスキップされていた。これはReport本文での通常メンション通知を抑制するための既存の仕様だが、pjord宛のメンションまで除外されてしまっていた。

## 修正内容

Reportの場合でも、pjord宛のメンションだけは `PjordRespondJob` をenqueueするように変更。通常のメンション通知（他ユーザーへの通知）は引き続きスキップ。

## 変更ファイル

- `app/models/concerns/mentioner.rb`
  - `notify_pjord_if_mentioned` メソッドを追加
  - Report本文でのpjordメンション検知 → JobのenqueueZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * レポート内の特定メンション処理が改善されました。メンション通知の制御フローが最適化され、レポートに対する適切な処理がより確実に実行されるようになります。

* **Refactor**
  * 内部の通知ロジックが整理されました。既存のモデル向け機能に影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->