### PR TITLE
Review AppのHostAuthorization 403エラーを修正

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -102,7 +102,7 @@ jobs:
           echo "Timeout waiting for build"
           exit 1
 
-      - name: Get Review App URL
+      - name: Get Review App URL and fix host authorization
         id: url
         run: |
           URL=$(gcloud run services describe ${SERVICE_NAME} \
@@ -110,6 +110,13 @@ jobs:
             --project=bootcamp-224405 \
             --format='value(status.url)')
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          HOSTNAME=$(echo "$URL" | sed 's|https://||')
+          echo "Updating APP_HOST_NAME and CLOUD_RUN_HOST_NAME to: $HOSTNAME"
+          gcloud run services update ${SERVICE_NAME} \
+            --region=asia-northeast1 \
+            --project=bootcamp-224405 \
+            --update-env-vars="APP_HOST_NAME=${HOSTNAME},CLOUD_RUN_HOST_NAME=${HOSTNAME}" \
+            --quiet
 
       - name: Comment PR with Review App URL
         uses: actions/github-script@v7


### PR DESCRIPTION
## 問題

Review App環境にアクセスすると403エラーが発生する。

```
[ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: bootcamp-pr-9830-fvlfu45apq-an.a.run.app
```

## 原因

Cloud RunのURL形式が想定と異なっていた:
- 想定: `bootcamp-pr-{N}-335091307227.asia-northeast1.run.app`
- 実際: `bootcamp-pr-{N}-fvlfu45apq-an.a.run.app`

`APP_HOST_NAME` と `CLOUD_RUN_HOST_NAME` に想定値がセットされ、RailsのHostAuthorizationで実際のホスト名がブロックされていた。

## 修正

デプロイ後に `gcloud run services describe` で実際のURLを取得し、`gcloud run services update --update-env-vars` でホスト名を正しい値に更新するステップを追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * レビューアプリの展開ワークフローを更新し、Cloud Run サービスの環境設定の初期化プロセスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->