### PR TITLE
二重に関連付けされている箇所を削除

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -15,8 +15,6 @@ class Announcement < ApplicationRecord
     job_seekers: 2
   }, prefix: true
 
-  has_many :watches, as: :watchable, dependent: :destroy
-  has_many :footprints, as: :footprintable, dependent: :destroy
   belongs_to :user
   alias sender user
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7/views/1?pane=issue&itemId=162711888&issue=fjordllc%7Cbootcamp%7C9743

## 概要
FootprintableとWatchableには既に`has_many` が記載されているにも関わらず、Announcementにも`has_many`が二重に記載されていたので、削除した。
補足情報：
Footprintableに記載されていた`dependent: :delete_all`は[こちらのイシュー](https://github.com/fjordllc/bootcamp/pull/9738)で既にマージされていたので修正は無しとする。

## 変更確認方法
### watchesの関連付け
1. `chore/resolving-double-defined-association-in-the-Announcement`をローカルに取り込む
2. `komagata`でログインする
3. [お知らせ作成](http://localhost:3000/announcements/new) に遷移し、お知らせを作成する
4. お知らせを作成すると`Watch中`になっているので、<img width="759" height="375" alt="watch関連付け01" src="https://github.com/user-attachments/assets/382bb59a-9439-42d6-ae02-056fe6b41901" />[Watchしているページへ移動](http://localhost:3000/current_user/watches) し先ほど作ったページがあるか確認する<img width="729" height="266" alt="watch関連付け02" src="https://github.com/user-attachments/assets/8f53cbfa-2237-43bd-a738-11f2d9e55d4c" />


5. `Watch中`ボタンを押して外します<img width="762" height="384" alt="watch関連付け03" src="https://github.com/user-attachments/assets/47a38983-a506-44cb-b8fe-e18aac32ad02" />



6. [Watchしているページへ移動](http://localhost:3000/current_user/watches) しWatchしたページがないか確認する<img width="498" height="290" alt="watch関連付け04" src="https://github.com/user-attachments/assets/0d269167-a437-483a-9883-dc91ceebf932" />


### footprintsの関連付け
1. `komagata`以外でログインする
2. 先ほど作ったお知らせ（watchesの関連付けの3で工程）に遷移する
3. 「見たよ」のユーザーが自分であることを確認する<img width="802" height="435" alt="footprintsの関連ずけ02" src="https://github.com/user-attachments/assets/80bb831f-5a49-46b2-973c-588957e86522" />






<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor（リファクタリング）**
  * アナウンスメント機能から不要なアソシエーション定義を削除し、内部構造を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->