### PR TITLE
eventにて二重に関連付けされている箇所を削除

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -37,8 +37,6 @@ class Event < ApplicationRecord # rubocop:todo Metrics/ClassLength
   belongs_to :user
   has_many :participations, dependent: :destroy
   has_many :users, through: :participations
-  has_many :watches, as: :watchable, dependent: :destroy
-  has_many :footprints, as: :footprintable, dependent: :destroy
   attribute :announcement_of_publication, :boolean
 
   columns_for_keyword_search :title, :description


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9747

## 概要
FootprintableとWatchableには既にhas_many が記載されているにも関わらず、Eventにもhas_manyが二重に記載されていたので、削除した。

## 変更確認方法

### watchesの関連付け

1. `chore/resolving-double-defined-association-in-the-Event`をローカルに取り込む
2. `komagata`でログインする
3. [イベント作成](http://localhost:3000/events/new) に遷移し、イベントを作成する
4. イベントを作成するとWatch中になっているので、<img width="772" height="528" alt="watch関連付け01" src="https://github.com/user-attachments/assets/78c7f16f-6f0d-4069-b9b1-d61fc9a94e4f" />

5. 一旦、`Watch`を外します<img width="517" height="260" alt="watch関連付け02" src="https://github.com/user-attachments/assets/2b0eaa52-dbbe-4dc3-bee7-9c171d417833" />

6. 参加申込をクリックし、`Watch`がアクティブになったことを確認します
 

https://github.com/user-attachments/assets/7ec857e2-897e-45db-a037-555249acc8bb


### footprintsの関連付け
1. `komagara`以外でログインし直す
2. 先ほど作ったイベント（watchesの関連付けの3で工程）に遷移する
3. 「見たよ」のユーザーがログインしているユーザーであることを確認する<img width="774" height="446" alt="footprintsの関連ずけ02" src="https://github.com/user-attachments/assets/4e4296ce-f877-4052-bc5e-60b5223675df" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * イベントモデルの関連付け定義を整理しました。機能への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->