### PR TITLE
organizer_eventスコープを削除

### DIFF
--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -7,7 +7,7 @@ class HibernationController < ApplicationController
 
   def new
     @hibernation = Hibernation.new
-    @holding_regular_events = RegularEvent.organizer_event(current_user).holding
+    @holding_regular_events = current_user.organize_regular_events.holding
   end
 
   def create
@@ -23,7 +23,7 @@ class HibernationController < ApplicationController
       logout
       redirect_to hibernation_path
     else
-      @holding_regular_events = RegularEvent.organizer_event(current_user).holding
+      @holding_regular_events = current_user.organize_regular_events.holding
       render :new
     end
   end

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -64,7 +64,7 @@ class RegularEventsController < ApplicationController # rubocop:disable Metrics/
   private
 
   def set_regular_event
-    @regular_event = current_user.mentor? ? RegularEvent.find(params[:id]) : RegularEvent.organizer_event(current_user).find(params[:id])
+    @regular_event = current_user.mentor? ? RegularEvent.find(params[:id]) : current_user.organize_regular_events.holding.find(params[:id])
   end
 
   def select_redirect_path

--- a/app/controllers/retirement_controller.rb
+++ b/app/controllers/retirement_controller.rb
@@ -6,7 +6,7 @@ class RetirementController < ApplicationController
   def show; end
 
   def new
-    @holding_regular_events = RegularEvent.organizer_event(current_user).holding
+    @holding_regular_events = current_user.organize_regular_events.holding
   end
 
   def create
@@ -17,7 +17,7 @@ class RetirementController < ApplicationController
       redirect_to retirement_url
     else
       current_user.retired_on = nil
-      @holding_regular_events = RegularEvent.organizer_event(current_user).holding
+      @holding_regular_events = current_user.organize_regular_events.holding
       render :new
     end
   end

--- a/app/controllers/training_completion_controller.rb
+++ b/app/controllers/training_completion_controller.rb
@@ -7,7 +7,7 @@ class TrainingCompletionController < ApplicationController
   def show; end
 
   def new
-    @holding_regular_events = RegularEvent.organizer_event(current_user).holding
+    @holding_regular_events = current_user.organize_regular_events.holding
   end
 
   def create
@@ -26,7 +26,7 @@ class TrainingCompletionController < ApplicationController
       redirect_to training_completion_url
     else
       current_user.training_completed_at = nil
-      @holding_regular_events = RegularEvent.organizer_event(current_user).holding
+      @holding_regular_events = current_user.organize_regular_events.holding
       render :new
     end
   end

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -49,7 +49,6 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   scope :holding, -> { where(finished: false) }
   scope :participated_by, ->(user) { where(id: all.filter { |e| e.participated_by?(user) }.map(&:id)) }
-  scope :organizer_event, ->(user) { joins(:organizers).where(organizers: { user_id: user.id }) }
   scope :scheduled_on, ->(date) { holding.filter { |event| event.scheduled_on?(date) } }
   scope :scheduled_on_without_ended, ->(date) { holding.filter { |event| event.scheduled_on?(date) && !event.ended?(date) } }
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9682
    - https://github.com/fjordllc/bootcamp/pull/9732#discussion_r2889667682
## 概要
- organizer_event(user)スコープはcurrent_userの開催中のイベントを取得するために使用されている(現状はその用途のみ)
    - `RegularEvent.organizer_event(current_user).holding`
- `current_user`に紐づく開催中のイベントは、associationで`current_user.organize_regular_events.holding`と表現できるので修正してスコープを削除した

## 変更確認方法

1. `chore/delete-organizer-event-scope`をローカルに取り込む
2. `kimura`でログイン
3. [休会画面](http://localhost:3000/hibernation/new) にアクセス ※ 共通のロジックのため代表して休会で確認
4. 休会画面の警告に自分が主催している開催中のイベントが表示されること
![スクリーンショット 2026-04-10 11 19 49](https://github.com/user-attachments/assets/eb4c3521-345b-4f45-8879-ebbe9e793b84)


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 複数の機能における定期イベントへのアクセスロジックを統一しました。内部実装の構造を再編成しており、ユーザーが利用できる機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->