### PR TITLE
意図せず混入した不要なルーティングを削除

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -85,12 +85,6 @@ Rails.application.routes.draw do
     resources :metadata, only: %i(index)
     resources :micro_reports, only: %i(update)
     resources :trainee_progresses, only: %i(index)
-    resources :buzzes, only: %i(create)
-    resources :buzzes, only: %i(create destroy)
-    resource :buzz, only: %i(create destroy)
-    namespace 'buzzes' do
-      resource :buzz, only: %i(show), controller: 'buzz'
-    end
     resource :buzz, only: %i(show create destroy), controller: 'buzzes'
   end
 end


### PR DESCRIPTION
## Issue
- #8895
- #9253

## 概要
おそらくだが、#9102でコンフリクト解消時に不要なルーティングを誤って混入させてしまった。原因を調査したがはっきりと特定できなかったため、過去の履歴を修正するよりも、削除のPRで対応すべきと判断。

## 変更確認方法
- 動作確認はありません。
- File changedで不要なルーティングが削除されていることを確認してください。

