### PR TITLE
今日の気分の選択肢の日本語化対応

### DIFF
--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -31,7 +31,7 @@
                 label.a-block-check__label.has-icon for="report_emotion_#{b.value}"
                   = image_tag b.text, id: b.value, alt: b.value, class: 'a-block-check__image'
                   span.a-block-check__name
-                    = t("activerecord.enums.report.emotion.#{b.value}")
+                    = t("activerecord.enums.emotion.#{b.value}")
       .form-item
         label.a-form-label
           | 学習時間

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -387,9 +387,9 @@ ja:
         buddy: ペア
     enums:
       emotion:
-        negative: Negative
-        neutral: Neutral
-        positive: Positive
+        negative: 不調
+        neutral: 普通
+        positive: 好調
       user:
         job:
           student: 学生


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9839

## 概要
日報の新規作成フォームの「今日の気分」を日本語表記に変更しました。

## 変更確認方法

1. `bug/report-emotion-ja`をローカルに取り込む
2. 開発サーバーを起動
3. kimura/testtestでログイン
4. [日報作成](http://localhost:3000/reports/new) にアクセス
5. 下記日報の新規作成フォームの「今日の気分」部分が日本語に変わっていることを確認

## Screenshot

### 変更前

<img width="799" height="211" alt="スクリーンショット 2026-04-10 140543" src="https://github.com/user-attachments/assets/30330560-3da6-4efa-8a86-fbef004de874" />


### 変更後
<img width="800" height="216" alt="スクリーンショット 2026-04-10 152917" src="https://github.com/user-attachments/assets/9ab0bbd6-83c1-4690-84bb-7fd1f2122364" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ローカライゼーション**
  * レポート内の感情オプションの日本語翻訳を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->