### PR TITLE
メンターの場合のみ、日報のリンク先を変更

### DIFF
--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -22,8 +22,8 @@ nav.global-nav
             .global-nav-links__link-label
               | プラクティス
         li.global-nav-links__item
-          - products_link = mentor_login? ? reports_unchecked_index_path : reports_path
-          = link_to products_link, class: "global-nav-links__link #{current_link(/^(reports|external_entries)/)}" do
+          - reports_link = mentor_login? ? reports_unchecked_index_path : reports_path
+          = link_to reports_link, class: "global-nav-links__link #{current_link(/^(reports|external_entries)/)}" do
             .global-nav-links__link-icon
               i.fa-solid.fa-pen
             - if admin_or_mentor_login? && Cache.unchecked_report_count.positive?

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -22,7 +22,8 @@ nav.global-nav
             .global-nav-links__link-label
               | プラクティス
         li.global-nav-links__item
-          = link_to reports_path, class: "global-nav-links__link #{current_link(/^(reports|external_entries)/)}" do
+          - products_link = mentor_login? ? reports_unchecked_index_path : reports_path
+          = link_to products_link, class: "global-nav-links__link #{current_link(/^(reports|external_entries)/)}" do
             .global-nav-links__link-icon
               i.fa-solid.fa-pen
             - if admin_or_mentor_login? && Cache.unchecked_report_count.positive?


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9889

## 概要

ナビゲーション部分が全て日報一覧ページにリンクされていましたが、
メンターでログインした場合は、「未チェック」の日報一覧にリンクされるよう修正しました。

## 変更確認方法

1. `chore/global-nav-report-link-mentor-unchecked`をローカルに取り込む
2. 開発サーバーを起動
3. http://localhost:3000/ にアクセスし、`mentormentaro`(メンター)でログイン。
4. ナビゲーションから「日報」をクリック。
5. URLが`http://localhost:3000/reports/unchecked`かどうか確認。
6. 日報を確認済みにする。
7. 再度「日報」をクリックし、一覧から5で確認済みにしたものが消えているか確認。
8. `kimura`(メンターではないユーザー)ログイン
9. 「日報」をクリックし、5で確認済みにした日報がメンター以外のユーザーでは表示されているか確認
10. URLが`http://localhost:3000/reports`かどうか確認。

## Screenshot

### 変更前
<img width="948" height="709" alt="image" src="https://github.com/user-attachments/assets/f45c873e-6fed-49bc-a729-8de8ea691de4" />

### 変更後

<img width="1379" height="790" alt="スクリーンショット 2026-04-11 10 36 20" src="https://github.com/user-attachments/assets/b6e56aea-1f29-4486-9df2-529edd450213" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * メンターユーザーの「日報/ブログ」ナビゲーションリンクの遷移先を最適化しました。メンター権限がある場合は確認待ちの日報一覧にアクセスできるようになります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->