### PR TITLE
og:urlのパスをcampaign/basicからcampaigns/basicに修正、LPをRailsの中に組み込んだ

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,4 +2,8 @@
 
 class StaticPagesController < ApplicationController
   skip_before_action :require_active_user_login, raise: false
+
+  layout false, only: :campaign_basic
+
+  def campaign_basic; end
 end

--- a/app/views/movies/show.html.slim
+++ b/app/views/movies/show.html.slim
@@ -30,7 +30,7 @@ main.page-main
           .a-card
             .card-body
               .card__main-movie
-                = video_tag url_for(@movie.movie_data.blob), controls: true, width: '717.52', height: '403.58'
+                = video_tag url_for(@movie.movie_data.blob), controls: true, width: '717.52', height: '403.58', preload: 'none'
               .card-body__description
                 .a-long-text.is-md.js-markdown-view
                   = @movie.description

--- a/app/views/static_pages/campaign_basic.html.erb
+++ b/app/views/static_pages/campaign_basic.html.erb
@@ -68,7 +68,7 @@ function gtag_report_conversion(url) {
 						<img src="/campaigns/basic/assets/images/fv_copy.webp" alt="未経験からWeb開発エンジニア！卒業後に「現場で即戦力になれる」プログラミングスクール - フィヨルドブートキャンプ">
 					</picture>
 				</h1>
-				<p class="fvBtn"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="/campaigns/basic/assets/images/cta.webp" alt=""/></a></p>
+				<p class="fvBtn"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="/campaigns/basic/assets/images/cta.webp" alt="コース詳細を見る"/></a></p>
 			</div>
 			<div class="sp spCopy">
 				<p class="fvIllust"><img src="/campaigns/basic/assets/images/sp_fv_illust.webp" width="134" height="210"></p>

--- a/app/views/static_pages/campaign_basic.html.erb
+++ b/app/views/static_pages/campaign_basic.html.erb
@@ -434,7 +434,7 @@ function gtag_report_conversion(url) {
 				</div>
 			</li>
 			<li class="reasonList03">
-				<p class="reasonNumber"><img src="/campaigns/basic/assets/images/reason_03_number.webp" alt="02" width="96" height="91"></p>
+				<p class="reasonNumber"><img src="/campaigns/basic/assets/images/reason_03_number.webp" alt="03" width="96" height="91"></p>
 				<div class="reasonListMain">
 			    	<h3 class="reasonListTitle">
 						<picture>
@@ -1177,8 +1177,10 @@ function gtag_report_conversion(url) {
 					</li>
 					<li>
 						<div class="image">
-							<source srcset="/campaigns/basic/assets/images/sp_structure_01_b_image.webp" media="(max-width: 767px)" type="image/webp">
+							<picture>
+								<source srcset="/campaigns/basic/assets/images/sp_structure_01_b_image.webp" media="(max-width: 767px)" type="image/webp">
 								<img src="/campaigns/basic/assets/images/structure_01_b_image.webp" alt="チャット">
+							</picture>
 						</div>
 						<div class="info">
 							<h5>チャット</h5>

--- a/app/views/static_pages/campaign_basic.html.erb
+++ b/app/views/static_pages/campaign_basic.html.erb
@@ -57,10 +57,10 @@ function gtag_report_conversion(url) {
 <!-- =========================================================================== -->
 <main id="fv">
 	<div class="fv_bg">
-		<p class="fvMv big"><img src="/campaigns/basic/assets/images/fv_mv.webp" width="815" height="813"></p>
+		<p class="fvMv big"><img src="/campaigns/basic/assets/images/fv_mv.webp" alt="" width="815" height="813"></p>
 		<div class="inner">
 			<img src="/campaigns/basic/assets/images/fv_object.webp" alt="FjordBootCamp" class="fvFbc" width="1378">
-			<p class="fvMv middle"><img src="/campaigns/basic/assets/images/fv_mv.webp" width="815" height="813"></p>
+			<p class="fvMv middle"><img src="/campaigns/basic/assets/images/fv_mv.webp" alt="" width="815" height="813"></p>
 			<div class="fvCta">
 				<h1 class="fvCopy">
 					<picture>

--- a/app/views/static_pages/campaign_basic.html.erb
+++ b/app/views/static_pages/campaign_basic.html.erb
@@ -19,13 +19,13 @@
 <meta property="og:title" content="即戦力になれるプログラミングスクール">
 <meta property="og:description" content="ディスクリプション：FBC（フィヨルドブートキャンプ）は現役ソフトウェアエンジニアが理想を追求して設立されたプログラミングスクール。未経験からでも現場で即戦力になれるカリキュラム、メンター、コミュニティが揃っています。">
 <meta name="description" content="ディスクリプション：FBC（フィヨルドブートキャンプ）は現役ソフトウェアエンジニアが理想を追求して設立されたプログラミングスクール。未経験からでも現場で即戦力になれるカリキュラム、メンター、コミュニティが揃っています。">
-<meta property="og:url" content="https://bootcamp.fjord.jp/campaign/basic/">
+<meta property="og:url" content="https://bootcamp.fjord.jp/campaigns/basic/">
 <meta property="og:image" content="https://bootcamp.fjord.jp/campaigns/basic/assets/ogp.png">
-<link rel="icon" href="assets/favicon.ico" sizes="48x48">
-<link rel="stylesheet" href="assets/css/common.css">
-<link rel="stylesheet" href="assets/css/slick.css">
-<link rel="stylesheet" href="assets/css/slick-theme.css">
-<link rel="stylesheet" href="assets/css/style.css?d=0305">
+<link rel="icon" href="/campaigns/basic/assets/favicon.ico" sizes="48x48">
+<link rel="stylesheet" href="/campaigns/basic/assets/css/common.css">
+<link rel="stylesheet" href="/campaigns/basic/assets/css/slick.css">
+<link rel="stylesheet" href="/campaigns/basic/assets/css/slick-theme.css">
+<link rel="stylesheet" href="/campaigns/basic/assets/css/style.css?d=0305">
 <!-- Event snippet for 会員登録 conversion page -->
 <script>
 function gtag_report_conversion(url) {
@@ -48,8 +48,8 @@ function gtag_report_conversion(url) {
 <!-- =========================================================================== -->
 <header id="header">
 	<div class="inner">
-		<p class="headerLogo"><a href="#"><img src="assets/images/logo.webp" alt="FBC FjordBootCamp"></a></p>
-		<p class="headerBtn"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="assets/images/cta.webp" alt="参加登録はこちら"></a></p>
+		<p class="headerLogo"><a href="#"><img src="/campaigns/basic/assets/images/logo.webp" alt="FBC FjordBootCamp"></a></p>
+		<p class="headerBtn"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="/campaigns/basic/assets/images/cta.webp" alt="参加登録はこちら"></a></p>
 	</div>
 </header>
 <!-- =========================================================================== -->
@@ -57,22 +57,22 @@ function gtag_report_conversion(url) {
 <!-- =========================================================================== -->
 <main id="fv">
 	<div class="fv_bg">
-		<p class="fvMv big"><img src="assets/images/fv_mv.webp" width="815" height="813"></p>
+		<p class="fvMv big"><img src="/campaigns/basic/assets/images/fv_mv.webp" width="815" height="813"></p>
 		<div class="inner">
-			<img src="assets/images/fv_object.webp" alt="FjordBootCamp" class="fvFbc" width="1378">
-			<p class="fvMv middle"><img src="assets/images/fv_mv.webp" width="815" height="813"></p>
+			<img src="/campaigns/basic/assets/images/fv_object.webp" alt="FjordBootCamp" class="fvFbc" width="1378">
+			<p class="fvMv middle"><img src="/campaigns/basic/assets/images/fv_mv.webp" width="815" height="813"></p>
 			<div class="fvCta">
 				<h1 class="fvCopy">
 					<picture>
-						<source srcset="assets/images/sp_fv.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/fv_copy.webp" alt="未経験からWeb開発エンジニア！卒業後に「現場で即戦力になれる」プログラミングスクール - フィヨルドブートキャンプ">
+						<source srcset="/campaigns/basic/assets/images/sp_fv.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/fv_copy.webp" alt="未経験からWeb開発エンジニア！卒業後に「現場で即戦力になれる」プログラミングスクール - フィヨルドブートキャンプ">
 					</picture>
 				</h1>
-				<p class="fvBtn"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="assets/images/cta.webp" alt=""/></a></p>
+				<p class="fvBtn"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="/campaigns/basic/assets/images/cta.webp" alt=""/></a></p>
 			</div>
 			<div class="sp spCopy">
-				<p class="fvIllust"><img src="assets/images/sp_fv_illust.webp" width="134" height="210"></p>
-		    	<p class="fvCopy"><img src="assets/images/sp_copy.webp" width="52" height="557"></p>
+				<p class="fvIllust"><img src="/campaigns/basic/assets/images/sp_fv_illust.webp" width="134" height="210"></p>
+		    	<p class="fvCopy"><img src="/campaigns/basic/assets/images/sp_copy.webp" width="52" height="557"></p>
 			</div>
 		</div>
 	</div>
@@ -90,16 +90,16 @@ function gtag_report_conversion(url) {
 			<h2 class="awardTitle">第13回フクオカRuby大賞<br>福岡県知事賞を受賞</h2>
 			<p class="awardDate">（2021.1.19）</p>
 			<ul class="awardImage">
-				<li><img src="assets/images/award_image_01.webp" alt="GRAND PRIZE FUKUOKA Ruby AWARD"></li>
-				<li><img src="assets/images/award_image_02.webp" alt="福岡Ruby大賞 福岡県知事賞"></li>
+				<li><img src="/campaigns/basic/assets/images/award_image_01.webp" alt="GRAND PRIZE FUKUOKA Ruby AWARD"></li>
+				<li><img src="/campaigns/basic/assets/images/award_image_02.webp" alt="福岡Ruby大賞 福岡県知事賞"></li>
 			</ul>
 		</section>
 		<section class="awardBox">
 			<h2 class="awardTitle">Ruby biz Grand prix 2024<br>クリエイティブ賞を受賞</h2>
 			<p class="awardDate">（2024.12.4）</p>
 			<ul class="awardImage">
-				<li><img src="assets/images/award_image_03.webp" alt="Ruby biz Grand prix 2024"></li>
-				<li><img src="assets/images/award_image_04.webp" alt="Ruby biz Grand prix 2024 クリエイティブ賞"></li>
+				<li><img src="/campaigns/basic/assets/images/award_image_03.webp" alt="Ruby biz Grand prix 2024"></li>
+				<li><img src="/campaigns/basic/assets/images/award_image_04.webp" alt="Ruby biz Grand prix 2024 クリエイティブ賞"></li>
 			</ul>
 		</section>
 	</div>
@@ -115,70 +115,70 @@ function gtag_report_conversion(url) {
 				FBCでは、未経験からでもそうした力の土台となる考え方や姿勢を身につけられる学習環境を大切にしています。</p>
 			</div>
 			<div class="r">
-				<img src="assets/images/about_illust.webp">
+				<img src="/campaigns/basic/assets/images/about_illust.webp">
 			</div>
 		</div>
 		<h2 class="aboutTitle">
 			<picture>
-				<source srcset="assets/images/sp_about_title.webp" media="(max-width: 767px)" type="image/webp">
-				<img src="assets/images/about_title.webp" alt="自走力が育つFBC3つの特徴" width="478" height="120">
+				<source srcset="/campaigns/basic/assets/images/sp_about_title.webp" media="(max-width: 767px)" type="image/webp">
+				<img src="/campaigns/basic/assets/images/about_title.webp" alt="自走力が育つFBC3つの特徴" width="478" height="120">
 			</picture>
 		</h2>
 		<ol class="aboutList">
 			<li>
-				<p class="aboutListNumber"><img src="assets/images/about_number_01.webp" alt="01" width="70" height="56"></p>
-				<p class="aboutListImage"><img src="assets/images/about_image_01.webp" alt="実務に直結する実践的なカリキュラム"></p>
+				<p class="aboutListNumber"><img src="/campaigns/basic/assets/images/about_number_01.webp" alt="01" width="70" height="56"></p>
+				<p class="aboutListImage"><img src="/campaigns/basic/assets/images/about_image_01.webp" alt="実務に直結する実践的なカリキュラム"></p>
 				<p class="aboutListTitle">実務に直結する<br>実践的なカリキュラム</p>
 				<p class="aboutListText">開発現場で実際に直面する課題をもとに作られた1,000時間以上のカリキュラムを主体的にやり切れる設計。チーム開発や自作サービス開発・リリースの経験も積むことができます。</p>
 			</li>
 			<li>
-				<p class="aboutListNumber"><img src="assets/images/about_number_02.webp" alt="02" width="70" height="56"></p>
-				<p class="aboutListImage"><img src="assets/images/about_image_02.webp" alt="歴6年～20年の現役ソフトウェアエンジニアがメンター"></p>
+				<p class="aboutListNumber"><img src="/campaigns/basic/assets/images/about_number_02.webp" alt="02" width="70" height="56"></p>
+				<p class="aboutListImage"><img src="/campaigns/basic/assets/images/about_image_02.webp" alt="歴6年～20年の現役ソフトウェアエンジニアがメンター"></p>
 				<p class="aboutListTitle">歴6年～20年の現役ソフトウェア<br>エンジニアがメンター</p>
 				<p class="aboutListText">実務で毎日コードを書いている経験豊富な現役のプログラマーがメンター。開発現場で求められる考え方や調べ方、継続的に技術を学び続ける姿勢などを身につけることができます。</p>
 			</li>
 			<li>
-				<p class="aboutListNumber"><img src="assets/images/about_number_03.webp" alt="03" width="70" height="56"></p>
-				<p class="aboutListImage"><img src="assets/images/about_image_03.webp" alt="自分を変えるチャンスや機会に溢れるコミュニティ"></p>
+				<p class="aboutListNumber"><img src="/campaigns/basic/assets/images/about_number_03.webp" alt="03" width="70" height="56"></p>
+				<p class="aboutListImage"><img src="/campaigns/basic/assets/images/about_image_03.webp" alt="自分を変えるチャンスや機会に溢れるコミュニティ"></p>
 				<p class="aboutListTitle">自分を変えるチャンスや<br>機会に溢れるコミュニティ</p>
 				<p class="aboutListText">学習を挫折せずにやり切るために有志の勉強会やイベントなどが立ち上がる文化があり、同じエンジニアを目指す仲間と切磋琢磨し、励まし合いながら学ぶことができます。</p>
 			</li>
 		</ol>
 	</div>
-	<div class="aboutBtm"><img src="assets/images/circle.webp"></div>
+	<div class="aboutBtm"><img src="/campaigns/basic/assets/images/circle.webp"></div>
 </section>
 <!-- =========================================================================== -->
 <section id="reason">
 	<h2 class="reasonTitle">
 		<picture>
-			<source srcset="assets/images/sp_reason_title.webp" media="(max-width: 767px)" type="image/webp">
-			<img src="assets/images/reason_title.webp" alt="FBCが選ばれる理由" width="885" height="166">
+			<source srcset="/campaigns/basic/assets/images/sp_reason_title.webp" media="(max-width: 767px)" type="image/webp">
+			<img src="/campaigns/basic/assets/images/reason_title.webp" alt="FBCが選ばれる理由" width="885" height="166">
 		</picture>
 	</h2>
 	<div class="inner">
 		<ol class="reasonList">
 			<li class="reasonList01">
-				<p class="reasonNumber"><img src="assets/images/reason_01_number.webp" alt="01" width="96" height="91"></p>
+				<p class="reasonNumber"><img src="/campaigns/basic/assets/images/reason_01_number.webp" alt="01" width="96" height="91"></p>
 				<div class="reasonListMain">
 			    	<h3 class="reasonListTitle">
 						<picture>
-							<source srcset="assets/images/sp_reason_01_title.webp" media="(max-width: 767px)" type="image/webp">
-							<img src="assets/images/reason_01_title.webp" alt="難しいからこそ力がつく 実践的なカリキュラム" width="546" height="155">
+							<source srcset="/campaigns/basic/assets/images/sp_reason_01_title.webp" media="(max-width: 767px)" type="image/webp">
+							<img src="/campaigns/basic/assets/images/reason_01_title.webp" alt="難しいからこそ力がつく 実践的なカリキュラム" width="546" height="155">
 						</picture>
 					</h3>
-					<p class="reasonListIllust"><img src="assets/images/reason_01_illust.webp" width="209" height="244"></p>
+					<p class="reasonListIllust"><img src="/campaigns/basic/assets/images/reason_01_illust.webp" width="209" height="244"></p>
 					<p class="reasonListText">Webシステム開発会社がつくった実務直結のカリキュラム。<br>未経験からでも段階的に力がつくように体系化されています。</p>
 				</div>
 				<div class="reasonListIndex">
-					<div class="l"><img src="assets/images/reason_image.webp"></div>
+					<div class="l"><img src="/campaigns/basic/assets/images/reason_image.webp"></div>
 					<div class="r">
 						<h4 class="reasonListIndexHeading">学習の流れ</h4>
 						<ol class="reasonListIndexList">
-							<li><img src="assets/images/reason_01_flow_01.webp" alt="1" width="40" height="40">プラクティス（課題）に挑戦する</li>
-							<li><img src="assets/images/reason_01_flow_02.webp" alt="2" width="40" height="40">成果物を提出する</li>
-							<li><img src="assets/images/reason_01_flow_03.webp" alt="3" width="40" height="40">メンターによるコードレビューを受ける</li>
-							<li><img src="assets/images/reason_01_flow_04.webp" alt="4" width="40" height="40">コードを直して提出</li>
-							<li><img src="assets/images/reason_01_flow_05.webp" alt="5" width="40" height="40">日報を書く（振り返り、質問など）</li>
+							<li><img src="/campaigns/basic/assets/images/reason_01_flow_01.webp" alt="1" width="40" height="40">プラクティス（課題）に挑戦する</li>
+							<li><img src="/campaigns/basic/assets/images/reason_01_flow_02.webp" alt="2" width="40" height="40">成果物を提出する</li>
+							<li><img src="/campaigns/basic/assets/images/reason_01_flow_03.webp" alt="3" width="40" height="40">メンターによるコードレビューを受ける</li>
+							<li><img src="/campaigns/basic/assets/images/reason_01_flow_04.webp" alt="4" width="40" height="40">コードを直して提出</li>
+							<li><img src="/campaigns/basic/assets/images/reason_01_flow_05.webp" alt="5" width="40" height="40">日報を書く（振り返り、質問など）</li>
 						</ol>
 					</div>
 				</div>
@@ -187,7 +187,7 @@ function gtag_report_conversion(url) {
 					<ol class="reasonFlowList">
 						<li>
 							<div class="sp center"><p class="spStep">STEP01</p></div>
-							<h4 class="reasonFlowListTitle"><img src="assets/images/course_01_step01.webp" alt="STEP01" width="219" height="180"><span>Web開発の自走学習</span></h4>
+							<h4 class="reasonFlowListTitle"><img src="/campaigns/basic/assets/images/course_01_step01.webp" alt="STEP01" width="219" height="180"><span>Web開発の自走学習</span></h4>
 							<div class="reasonFlowListBox">
 								<div class="flex">
 									<div class="l">
@@ -195,9 +195,9 @@ function gtag_report_conversion(url) {
 									</div>
 									<div class="r">
 										<div class="appSlider" id="app01">
-									    	<div class="appSlide"><img src="assets/images/reason_step01_app_01.webp" alt="1_学習の準備"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step01_app_02.webp" alt="2_lsコマンド"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step01_app_03.webp" alt="3_日報"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step01_app_01.webp" alt="1_学習の準備"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step01_app_02.webp" alt="2_lsコマンド"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step01_app_03.webp" alt="3_日報"></div>
 										</div>
 									</div>
 								</div>
@@ -205,7 +205,7 @@ function gtag_report_conversion(url) {
 						</li>
 						<li>
 							<div class="sp center"><p class="spStep">STEP02</p></div>
-							<h4 class="reasonFlowListTitle"><img src="assets/images/course_01_step02.webp" alt="STEP02" width="226" height="180"><span>チーム開発に取り組む</span></h4>
+							<h4 class="reasonFlowListTitle"><img src="/campaigns/basic/assets/images/course_01_step02.webp" alt="STEP02" width="226" height="180"><span>チーム開発に取り組む</span></h4>
 							<div class="reasonFlowListBox">
 								<div class="flex">
 									<div class="l">
@@ -218,10 +218,10 @@ function gtag_report_conversion(url) {
 									</div>
 									<div class="r">
 										<div class="appSlider" id="app02">
-									    	<div class="appSlide"><img src="assets/images/reason_step02_app_01.webp" alt="1_team"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step02_app_02.webp" alt="2_team"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step02_app_03.webp" alt="3_team"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step02_app_04.webp" alt="4_team"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step02_app_01.webp" alt="1_team"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step02_app_02.webp" alt="2_team"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step02_app_03.webp" alt="3_team"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step02_app_04.webp" alt="4_team"></div>
 										</div>
 									</div>
 								</div>
@@ -229,7 +229,7 @@ function gtag_report_conversion(url) {
 						</li>
 						<li>
 							<div class="sp center"><p class="spStep">STEP03</p></div>
-							<h4 class="reasonFlowListTitle"><img src="assets/images/course_01_step03.webp" alt="STEP03" width="226" height="180"><span>自作サービス開発・リリース</span></h4>
+							<h4 class="reasonFlowListTitle"><img src="/campaigns/basic/assets/images/course_01_step03.webp" alt="STEP03" width="226" height="180"><span>自作サービス開発・リリース</span></h4>
 							<div class="reasonFlowListBox">
 								<div class="flex">
 									<div class="l">
@@ -242,11 +242,11 @@ function gtag_report_conversion(url) {
 									</div>
 									<div class="r">
 										<div class="appSlider" id="app03">
-									    	<div class="appSlide"><img src="assets/images/reason_step03_app_01.webp" alt="1_paper"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step03_app_02.webp" alt="2_yoko"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step03_app_03.webp" alt="3_timer"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step03_app_04.webp" alt="4_gorogoro"></div>
-									    	<div class="appSlide"><img src="assets/images/reason_step03_app_05.webp" alt="5_nijikai"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step03_app_01.webp" alt="1_paper"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step03_app_02.webp" alt="2_yoko"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step03_app_03.webp" alt="3_timer"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step03_app_04.webp" alt="4_gorogoro"></div>
+									    	<div class="appSlide"><img src="/campaigns/basic/assets/images/reason_step03_app_05.webp" alt="5_nijikai"></div>
 										</div>
 									</div>
 								</div>
@@ -257,16 +257,16 @@ function gtag_report_conversion(url) {
 				<div class="reasonPoint">
 					<h3 class="reasonPointTitle">
 						<picture>
-							<source srcset="assets/images/sp_point.webp" media="(max-width: 767px)" type="image/webp">
-							<img src="assets/images/point.webp" alt="POINT" width="126" height="47">
+							<source srcset="/campaigns/basic/assets/images/sp_point.webp" media="(max-width: 767px)" type="image/webp">
+							<img src="/campaigns/basic/assets/images/point.webp" alt="POINT" width="126" height="47">
 						</picture>
 						<strong>FBCは敢えて<span><br class="sp">「答えを教えない」</span>スタイル</strong>
 					</h3>
 					<div class="flex">
 						<div class="l">
 							<picture>
-								<source srcset="assets/images/sp_reason_01_image.webp" media="(max-width: 767px)" type="image/webp">
-								<img src="assets/images/reason_01_image.webp" alt="FBCは敢えて「答えを教えない」スタイル">
+								<source srcset="/campaigns/basic/assets/images/sp_reason_01_image.webp" media="(max-width: 767px)" type="image/webp">
+								<img src="/campaigns/basic/assets/images/reason_01_image.webp" alt="FBCは敢えて「答えを教えない」スタイル">
 							</picture>
 						</div>
 						<div class="r">
@@ -278,12 +278,12 @@ function gtag_report_conversion(url) {
 				</div>
 			</li>
 			<li class="reasonList02">
-				<p class="reasonNumber"><img src="assets/images/reason_02_number.webp" alt="02" width="96" height="91"></p>
+				<p class="reasonNumber"><img src="/campaigns/basic/assets/images/reason_02_number.webp" alt="02" width="96" height="91"></p>
 				<div class="reasonListMain">
 			    	<h3 class="reasonListTitle">
 						<picture>
-							<source srcset="assets/images/sp_reason_02_title.webp" media="(max-width: 767px)" type="image/webp">
-							<img src="assets/images/reason_02_title.webp" alt="どんな質問にも的確に対応できる" width="802" height="174">
+							<source srcset="/campaigns/basic/assets/images/sp_reason_02_title.webp" media="(max-width: 767px)" type="image/webp">
+							<img src="/campaigns/basic/assets/images/reason_02_title.webp" alt="どんな質問にも的確に対応できる" width="802" height="174">
 						</picture>
 					</h3>
 					<p class="reasonListText">エンジニアなら誰もが一度は手にする教本の著者から世界的なカンファレンスの登壇者まで。<br>安心してついていけるメンターがいるから、本気でプログラミングを学べ、楽しめます。</p>
@@ -292,7 +292,7 @@ function gtag_report_conversion(url) {
 					<!-- ------------------------------------------- -->
 					<li>
 						<div class="l">
-							<img src="assets/images/reason_face_01.webp" alt="角谷 信太郎">
+							<img src="/campaigns/basic/assets/images/reason_face_01.webp" alt="角谷 信太郎">
 							<p class="reasonDetailListTitle">
 								<span class="reasonDetailListPosition">プログラマー</span>
 								<span class="reasonDetailListName">角谷 信太郎</span>
@@ -313,18 +313,18 @@ function gtag_report_conversion(url) {
 								</div>
 							</div>
 							<ul class="reasonDetailListImage">
-								<li><img src="assets/images/reason_02_01_book_01.webp" alt="クリーンアジャイル" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_01_book_02.webp" alt="Rubyのしくみ" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_01_book_03.webp" alt="アジャイルサムライ" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_01_book_04.webp" alt="アジャイルな見積もりと計画作づくり" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_01_book_05.webp" alt="なるほどUNIXプロセス" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_01_book_01.webp" alt="クリーンアジャイル" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_01_book_02.webp" alt="Rubyのしくみ" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_01_book_03.webp" alt="アジャイルサムライ" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_01_book_04.webp" alt="アジャイルな見積もりと計画作づくり" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_01_book_05.webp" alt="なるほどUNIXプロセス" width="91" height="120"></li>
 							</ul>
 						</div>
 					</li>
 					<!-- ------------------------------------------- -->
 					<li>
 						<div class="l">
-							<img src="assets/images/reason_face_02.webp" alt="伊藤 淳一">
+							<img src="/campaigns/basic/assets/images/reason_face_02.webp" alt="伊藤 淳一">
 							<p class="reasonDetailListTitle">
 								<span class="reasonDetailListPosition">プログラマー</span>
 								<span class="reasonDetailListName">伊藤 淳一</span>
@@ -343,15 +343,15 @@ function gtag_report_conversion(url) {
 								</div>
 							</div>
 							<ul class="reasonDetailListImage">
-								<li><img src="assets/images/reason_02_02_book_01.webp" alt="RSpecによるRailsテスト入門" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_02_book_02.webp" alt="プロを目指す人Ruby入門" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_02_book_01.webp" alt="RSpecによるRailsテスト入門" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_02_book_02.webp" alt="プロを目指す人Ruby入門" width="91" height="120"></li>
 							</ul>
 						</div>
 					</li>
 					<!-- ------------------------------------------- -->
 					<li>
 						<div class="l">
-							<img src="assets/images/reason_face_03.webp" alt="五十嵐 邦明">
+							<img src="/campaigns/basic/assets/images/reason_face_03.webp" alt="五十嵐 邦明">
 							<p class="reasonDetailListTitle">
 								<span class="reasonDetailListPosition">プログラマー</span>
 								<span class="reasonDetailListName">五十嵐 邦明</span>
@@ -371,18 +371,18 @@ function gtag_report_conversion(url) {
 								</div>
 							</div>
 							<ul class="reasonDetailListImage">
-								<li><img src="assets/images/reason_02_03_book_01.webp" alt="Railsの教科書" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_03_book_02.webp" alt="RubyとRailsの学習ガイド" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_03_book_03.webp" alt="ゼロからわかるRuby超入門" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_03_book_04.webp" alt="たのしい開発スタートアップRuby" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_03_book_05.webp" alt="パーフェクト Ruby on Rails" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_03_book_01.webp" alt="Railsの教科書" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_03_book_02.webp" alt="RubyとRailsの学習ガイド" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_03_book_03.webp" alt="ゼロからわかるRuby超入門" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_03_book_04.webp" alt="たのしい開発スタートアップRuby" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_03_book_05.webp" alt="パーフェクト Ruby on Rails" width="91" height="120"></li>
 							</ul>
 						</div>
 					</li>
 					<!-- ------------------------------------------- -->
 					<li>
 						<div class="l">
-							<img src="assets/images/reason_face_04.webp" alt="大倉 雅史">
+							<img src="/campaigns/basic/assets/images/reason_face_04.webp" alt="大倉 雅史">
 							<p class="reasonDetailListTitle">
 								<span class="reasonDetailListPosition">プログラマー</span>
 								<span class=reasonDetailListName>大倉 雅史</span>
@@ -404,25 +404,25 @@ function gtag_report_conversion(url) {
 								</div>
 							</div>
 							<ul class="reasonDetailListImage">
-								<li><img src="assets/images/reason_02_04_book_01.webp" alt="マスタリングVim" width="91" height="120"></li>
-								<li><img src="assets/images/reason_02_04_book_02.webp" alt="WHAT MAKES IT RAILS？" width="206" height="120"></li>
-								<li><img src="assets/images/reason_02_04_book_03.webp" alt="Ruby Conf" width="206" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_04_book_01.webp" alt="マスタリングVim" width="91" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_04_book_02.webp" alt="WHAT MAKES IT RAILS？" width="206" height="120"></li>
+								<li><img src="/campaigns/basic/assets/images/reason_02_04_book_03.webp" alt="Ruby Conf" width="206" height="120"></li>
 							</ul>
 						</div>
 					</li>
 					<!-- ------------------------------------------- -->
 				</ul>
-				<p class="reasonIllust"><img src="assets/images/reason_02_illust.webp" width="631" height="399"></p>
+				<p class="reasonIllust"><img src="/campaigns/basic/assets/images/reason_02_illust.webp" width="631" height="399"></p>
 				<div class="reasonPoint">
 					<h3 class="reasonPointTitle">
 						<picture>
-							<source srcset="assets/images/sp_point.webp" media="(max-width: 767px)" type="image/webp">
-							<img src="assets/images/point.webp" alt="POINT" width="126" height="47">
+							<source srcset="/campaigns/basic/assets/images/sp_point.webp" media="(max-width: 767px)" type="image/webp">
+							<img src="/campaigns/basic/assets/images/point.webp" alt="POINT" width="126" height="47">
 						</picture>
 						<strong>本職でばりばりコードを書く<br class="sp"><span>第一線で活躍するメンター</span></strong>
 					</h3>
 					<div class="flex">
-						<div class="l"><img src="assets/images/reason_02_image.webp" alt="本職でばりばりコードを書く第一線で活躍するメンタースタイル"></div>
+						<div class="l"><img src="/campaigns/basic/assets/images/reason_02_image.webp" alt="本職でばりばりコードを書く第一線で活躍するメンタースタイル"></div>
 						<div class="r">
 							<p>受講生に答えを教えず、ヒントだけで解決まで導くというのは、<span>言語やコードのことを現場・実務レベルで深く理解していないとできない</span>こと。<br>
 							<br>
@@ -434,12 +434,12 @@ function gtag_report_conversion(url) {
 				</div>
 			</li>
 			<li class="reasonList03">
-				<p class="reasonNumber"><img src="assets/images/reason_03_number.webp" alt="02" width="96" height="91"></p>
+				<p class="reasonNumber"><img src="/campaigns/basic/assets/images/reason_03_number.webp" alt="02" width="96" height="91"></p>
 				<div class="reasonListMain">
 			    	<h3 class="reasonListTitle">
 						<picture>
-							<source srcset="assets/images/sp_reason_03_title.webp" media="(max-width: 767px)" type="image/webp">
-							<img src="assets/images/reason_03_title.webp" alt="有志の勉強会が盛んに立ち上げあるコミュニティ文化" width="818" height="174">
+							<source srcset="/campaigns/basic/assets/images/sp_reason_03_title.webp" media="(max-width: 767px)" type="image/webp">
+							<img src="/campaigns/basic/assets/images/reason_03_title.webp" alt="有志の勉強会が盛んに立ち上げあるコミュニティ文化" width="818" height="174">
 						</picture>
 					</h3>
 					<p class="reasonListText">性別、学歴、年齢に関係なく、同じプログラミングを学ぶ仲間と<br class="pc">
@@ -447,8 +447,8 @@ function gtag_report_conversion(url) {
 				</div>
 				<div class="reasonIllust">
 					<picture>
-						<source srcset="assets/images/sp_reason_03_schema.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/reason_03_schema.webp" alt="おすすめの勉強会・イベント">
+						<source srcset="/campaigns/basic/assets/images/sp_reason_03_schema.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/reason_03_schema.webp" alt="おすすめの勉強会・イベント">
 					</picture>
 				</div>
 				<div class="reasonPlot">
@@ -462,7 +462,7 @@ function gtag_report_conversion(url) {
 							  <p class="reasonPlotText">FBCのコミュニティ内で性別や年齢を明かす必要はなく、ニックネームで参加いただけます。ビデオチャットでの顔出しも強制ではなく、任意です。</p>
 							</div>
 							<div class="r">
-								<img src="assets/images/reason_03_illust.webp" width="156" height="248">
+								<img src="/campaigns/basic/assets/images/reason_03_illust.webp" width="156" height="248">
 							</div>
 						</div>
 					</div>
@@ -470,13 +470,13 @@ function gtag_report_conversion(url) {
 				<div class="reasonPoint">
 					<h3 class="reasonPointTitle">
 						<picture>
-							<source srcset="assets/images/sp_point.webp" media="(max-width: 767px)" type="image/webp">
-							<img src="assets/images/point.webp" alt="POINT" width="126" height="47">
+							<source srcset="/campaigns/basic/assets/images/sp_point.webp" media="(max-width: 767px)" type="image/webp">
+							<img src="/campaigns/basic/assets/images/point.webp" alt="POINT" width="126" height="47">
 						</picture>
 						<strong><span>課題解決を楽しむ</span><br class="sp">仲間に恵まれる</strong>
 					</h3>
 					<div class="flex">
-						<div class="l"><img src="assets/images/reason_03_image.webp" alt="課題解決を楽しむ仲間に恵まれる"></div>
+						<div class="l"><img src="/campaigns/basic/assets/images/reason_03_image.webp" alt="課題解決を楽しむ仲間に恵まれる"></div>
 						<div class="r">
 							<p>有志で勉強会やイベントが立ち上がるのは、カリキュラムをいかに楽しみながらモチベーション高くやり切るかを、ひとり一人が真剣に考えているから。<br>
 							<br>
@@ -494,23 +494,23 @@ function gtag_report_conversion(url) {
 <section id="reviews">
 	<h2 class="reviewsTitle">
 		<picture>
-			<source srcset="assets/images/sp_reviews_title.webp" media="(max-width: 767px)" type="image/webp">
-			<img src="assets/images/reviews_title.webp" alt="受講生＆卒業生の声" width="885" height="156">
+			<source srcset="/campaigns/basic/assets/images/sp_reviews_title.webp" media="(max-width: 767px)" type="image/webp">
+			<img src="/campaigns/basic/assets/images/reviews_title.webp" alt="受講生＆卒業生の声" width="885" height="156">
 		</picture>
 	</h2>
 	<div class="reviewsImage">
 		<picture>
-			<source srcset="assets/images/sp_reviews_image.webp" media="(max-width: 767px)" type="image/webp">
-			<img src="assets/images/reviews_image.webp" alt="受講生と卒業生がスクールの体験談を書いてくれました！FBCの特徴や雰囲気がよく伝わるので、その一部をお見せします。" width="803" height="298">
+			<source srcset="/campaigns/basic/assets/images/sp_reviews_image.webp" media="(max-width: 767px)" type="image/webp">
+			<img src="/campaigns/basic/assets/images/reviews_image.webp" alt="受講生と卒業生がスクールの体験談を書いてくれました！FBCの特徴や雰囲気がよく伝わるので、その一部をお見せします。" width="803" height="298">
 		</picture>
 	</div>
 	<div class="inner">
 	  <div class="reviewsList">
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review01.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review01.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_01.webp" alt="garammasala様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_01.webp" alt="garammasala様"></div>
 							<div class="info">
 								<p class="name">garammasala様</p>
 								<p class="time">2022年9月卒業</p>
@@ -557,10 +557,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review02.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review02.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_02.webp" alt="gogutan様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_02.webp" alt="gogutan様"></div>
 							<div class="info">
 								<p class="name">gogutan様</p>
 								<p class="time">2020年12月卒業</p>
@@ -593,10 +593,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review03.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review03.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_03.webp" alt="おぐち様（@hogucc）"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_03.webp" alt="おぐち様（@hogucc）"></div>
 							<div class="info">
 								<p class="name">おぐち様（@hogucc）</p>
 								<p class="time">2021年5月卒業</p>
@@ -639,10 +639,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review04.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review04.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_04.webp" alt="ikuma-t様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_04.webp" alt="ikuma-t様"></div>
 							<div class="info">
 								<p class="name">ikuma-t様</p>
 								<p class="time">2022年4月卒業</p>
@@ -689,10 +689,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review05.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review05.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_05.webp" alt="M.H様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_05.webp" alt="M.H様"></div>
 							<div class="info">
 								<p class="name">M.H様</p>
 								<p class="time">2022年11月卒業</p>
@@ -721,10 +721,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review06.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review06.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_06.webp" alt="maimu様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_06.webp" alt="maimu様"></div>
 							<div class="info">
 								<p class="name">maimu様</p>
 								<p class="time">2023年5月卒業</p>
@@ -753,10 +753,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review07.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review07.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_07.webp" alt="masuyama13様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_07.webp" alt="masuyama13様"></div>
 							<div class="info">
 								<p class="name">masuyama13様</p>
 								<p class="time">2021年3月卒業</p>
@@ -790,10 +790,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review08.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review08.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_08.webp" alt="regonia1様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_08.webp" alt="regonia1様"></div>
 							<div class="info">
 								<p class="name">regonia1様</p>
 								<p class="time">2021年9月卒業</p>
@@ -827,10 +827,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review09.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review09.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_09.webp" alt="odentakashi様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_09.webp" alt="odentakashi様"></div>
 							<div class="info">
 								<p class="name">odentakashi様</p>
 								<p class="time">2023年10月卒業</p>
@@ -869,10 +869,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review10.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review10.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_10.webp" alt="Rira様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_10.webp" alt="Rira様"></div>
 							<div class="info">
 								<p class="name">Rira様</p>
 								<p class="time">2023年12月卒業</p>
@@ -921,10 +921,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review11.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review11.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_11.webp" alt="siroemk様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_11.webp" alt="siroemk様"></div>
 							<div class="info">
 								<p class="name">siroemk様</p>
 								<p class="time">2023年11月卒業</p>
@@ -968,10 +968,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review12.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review12.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_12.webp" alt="siso255様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_12.webp" alt="siso255様"></div>
 							<div class="info">
 								<p class="name">siso255様</p>
 								<p class="time">2024年2月卒業</p>
@@ -1003,10 +1003,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review13.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review13.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_13.webp" alt="うにお様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_13.webp" alt="うにお様"></div>
 							<div class="info">
 								<p class="name">うにお様</p>
 								<p class="time">2025年1月卒業</p>
@@ -1041,10 +1041,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review14.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review14.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_14.webp" alt="すずか様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_14.webp" alt="すずか様"></div>
 							<div class="info">
 								<p class="name">すずか様</p>
 								<p class="time">2024年6月卒業</p>
@@ -1085,10 +1085,10 @@ function gtag_report_conversion(url) {
 				</div>
 			</div>
 			<div class="reviewsBox">
-				<div class="reviewPreview"><a href="review15.html" target="_blank" class="reviewPreviewLink"></a>
+				<div class="reviewPreview"><a href="/campaigns/basic/review15.html" target="_blank" class="reviewPreviewLink"></a>
 					<div class="reviewPreviewContent">
 						<div class="profile">
-							<div class="image"><img src="assets/images/reviews_thumbnail_15.webp" alt="百川(ももかわ)様"></div>
+							<div class="image"><img src="/campaigns/basic/assets/images/reviews_thumbnail_15.webp" alt="百川(ももかわ)様"></div>
 							<div class="info">
 								<p class="name">百川(ももかわ)様</p>
 								<p class="time">2019年8月卒業</p>
@@ -1124,13 +1124,13 @@ function gtag_report_conversion(url) {
 		<div class="inner">
 			<div class="cta01">
 				<picture>
-					<source srcset="assets/images/sp_cta1.webp" media="(max-width: 767px)" type="image/webp">
-					<img src="assets/images/cta1.webp" alt="あなたもFBCでプログラミングを始めてみませんか？" width="1037">
+					<source srcset="/campaigns/basic/assets/images/sp_cta1.webp" media="(max-width: 767px)" type="image/webp">
+					<img src="/campaigns/basic/assets/images/cta1.webp" alt="あなたもFBCでプログラミングを始めてみませんか？" width="1037">
 				</picture>
 			</div>
 			<p class="cta02"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')">
 
-			<img src="assets/images/cta.webp" alt="参加登録はこちら" width="619" height="110"></a></p>
+			<img src="/campaigns/basic/assets/images/cta.webp" alt="参加登録はこちら" width="619" height="110"></a></p>
 			<p class="cta03">※お試し期間の間に退会をすれば<br class="sp">課金されることはありません</p>
 		</div>
 	</div>
@@ -1139,8 +1139,8 @@ function gtag_report_conversion(url) {
 <section id="structure">
 	<h2 class="structureTitle">
 		<picture>
-			<source srcset="assets/images/sp_structure_title.webp" media="(max-width: 767px)" type="image/webp">
-			<img src="assets/images/structure_title.webp" alt="FBCのサポート体制" width="885" height="166">
+			<source srcset="/campaigns/basic/assets/images/sp_structure_title.webp" media="(max-width: 767px)" type="image/webp">
+			<img src="/campaigns/basic/assets/images/structure_title.webp" alt="FBCのサポート体制" width="885" height="166">
 		</picture>
 	</h2>
 	<div class="inner">
@@ -1148,26 +1148,26 @@ function gtag_report_conversion(url) {
 			<li class="structureList01">
 				<h3 class="structureListTitle">
 					<picture>
-						<source srcset="assets/images/sp_structure_01_title.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/structure_01_title.webp" alt="受講生の「分からない」をそのままにしない 01.多様な質問方法" width="495" height="140">
+						<source srcset="/campaigns/basic/assets/images/sp_structure_01_title.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/structure_01_title.webp" alt="受講生の「分からない」をそのままにしない 01.多様な質問方法" width="495" height="140">
 					</picture>
 				</h3>
 				<p class="structureImage">
 					<picture>
-						<source srcset="assets/images/sp_structure_01_image_01.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/structure_01_image_01.webp" alt="受講生によくある状況">
+						<source srcset="/campaigns/basic/assets/images/sp_structure_01_image_01.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/structure_01_image_01.webp" alt="受講生によくある状況">
 					</picture>
 				</p>
 				<h4 class="structureSecret">
 					<picture>
-						<source srcset="assets/images/sp_structure_01_heading.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/structure_01_heading.webp" alt="質問をしやすくする4つの仕組み" width="432" height="131">
+						<source srcset="/campaigns/basic/assets/images/sp_structure_01_heading.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/structure_01_heading.webp" alt="質問をしやすくする4つの仕組み" width="432" height="131">
 					</picture>
 				</h4>
 				<ul class="structureEasyList">
 					<li>
 						<div class="image">
-							<img src="assets/images/structure_01_a_image.webp" alt="日報">
+							<img src="/campaigns/basic/assets/images/structure_01_a_image.webp" alt="日報">
 						</div>
 						<div class="info">
 							<h5>日報</h5>
@@ -1177,8 +1177,8 @@ function gtag_report_conversion(url) {
 					</li>
 					<li>
 						<div class="image">
-							<source srcset="assets/images/sp_structure_01_b_image.webp" media="(max-width: 767px)" type="image/webp">
-								<img src="assets/images/structure_01_b_image.webp" alt="チャット">
+							<source srcset="/campaigns/basic/assets/images/sp_structure_01_b_image.webp" media="(max-width: 767px)" type="image/webp">
+								<img src="/campaigns/basic/assets/images/structure_01_b_image.webp" alt="チャット">
 						</div>
 						<div class="info">
 							<h5>チャット</h5>
@@ -1188,7 +1188,7 @@ function gtag_report_conversion(url) {
 					</li>
 					<li>
 						<div class="image">
-							<img src="assets/images/structure_01_c_image.webp" alt="学習アプリQ&A">
+							<img src="/campaigns/basic/assets/images/structure_01_c_image.webp" alt="学習アプリQ&A">
 						</div>
 						<div class="info">
 							<h5>学習アプリQ&amp;A</h5>
@@ -1198,7 +1198,7 @@ function gtag_report_conversion(url) {
 					</li>
 					<li>
 						<div class="image">
-							<img src="assets/images/structure_01_d_image.webp" alt="ビデオチャット/ペアワーク">
+							<img src="/campaigns/basic/assets/images/structure_01_d_image.webp" alt="ビデオチャット/ペアワーク">
 						</div>
 						<div class="info">
 							<h5>ビデオチャット<span class="pc">/</span><br class="sp">ペアワーク</h5>
@@ -1211,8 +1211,8 @@ function gtag_report_conversion(url) {
 			<li class="structureList02">
 				<h3 class="structureListTitle">
 					<picture>
-						<source srcset="assets/images/sp_structure_02_title.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/structure_02_title.webp" alt="将来の可能性を広げる 02.外部コミュニティへの参加" width="698" height="140">
+						<source srcset="/campaigns/basic/assets/images/sp_structure_02_title.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/structure_02_title.webp" alt="将来の可能性を広げる 02.外部コミュニティへの参加" width="698" height="140">
 					</picture>
 				</h3>
 				<p class="structureText">FBCでは、カンファレンスやイベントへの参加を積極的に推奨しています。<br>
@@ -1220,21 +1220,21 @@ function gtag_report_conversion(url) {
 				無料宿泊施設の提供も行っています。</p>
 				<div class="structureImage">
 					<picture>
-						<source srcset="assets/images/sp_structure_02_image.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/structure_02_image.webp" alt="カンファレンスへの参加／イベントへの参加／オフライン交流会">
+						<source srcset="/campaigns/basic/assets/images/sp_structure_02_image.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/structure_02_image.webp" alt="カンファレンスへの参加／イベントへの参加／オフライン交流会">
 					</picture>
 				</div>
 				<div class="reasonPoint">
 					<h3 class="reasonPointTitle">
 						<picture>
-							<source srcset="assets/images/sp_point.webp" media="(max-width: 767px)" type="image/webp">
-							<img src="assets/images/point.webp" alt="POINT" width="126" height="47">
+							<source srcset="/campaigns/basic/assets/images/sp_point.webp" media="(max-width: 767px)" type="image/webp">
+							<img src="/campaigns/basic/assets/images/point.webp" alt="POINT" width="126" height="47">
 						</picture>
 						<strong>FBCをきっかけに<span><br class="sp">広く活躍できるエンジニアに</span></strong>
 					</h3>
 					<div class="flex">
 						<div class="l">
-							<img src="assets/images/structure_02_photo.webp" alt="FBCは敢えて「答えを教えない」スタイル">
+							<img src="/campaigns/basic/assets/images/structure_02_photo.webp" alt="FBCは敢えて「答えを教えない」スタイル">
 						</div>
 						<div class="r">
 							<p>外部コミュニティへの参加は、学習意欲を高め、プログラミングの面白さや奥深さ、エンジニアコミュニティの温かさを知る最良の機会になります。<br>
@@ -1249,8 +1249,8 @@ function gtag_report_conversion(url) {
 			<li class="structureList03">
 				<h3 class="structureListTitle">
 					<picture>
-						<source srcset="assets/images/sp_structure_03_title.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/structure_03_title.webp" alt="幸せなキャリアをスタートするための 03.エンジニア特化の就職支援" width="698" height="140">
+						<source srcset="/campaigns/basic/assets/images/sp_structure_03_title.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/structure_03_title.webp" alt="幸せなキャリアをスタートするための 03.エンジニア特化の就職支援" width="698" height="140">
 					</picture>
 				</h3>
 				<p class="structureText">どの企業に就職するかは、その後のエンジニア人生を決める重要な決断です。<br>
@@ -1265,8 +1265,8 @@ function gtag_report_conversion(url) {
 						<div class="image">
 
 							<picture>
-								<source srcset="assets/images/sp_structure_03_a_image_01.webp" media="(max-width: 767px)" type="image/webp">
-					    	<img src="assets/images/structure_03_a_image_01.webp" alt="キャリアカウンセリング/個別相談">
+								<source srcset="/campaigns/basic/assets/images/sp_structure_03_a_image_01.webp" media="(max-width: 767px)" type="image/webp">
+					    	<img src="/campaigns/basic/assets/images/structure_03_a_image_01.webp" alt="キャリアカウンセリング/個別相談">
 							</picture>
 						</div>
 					</div>
@@ -1278,15 +1278,15 @@ function gtag_report_conversion(url) {
 						<div class="image">
 
 							<picture>
-								<source srcset="assets/images/sp_structure_03_a_image_02.webp" media="(max-width: 767px)" type="image/webp">
-								<img src="assets/images/structure_03_a_image_02.webp" alt="合同企業説明ドリンクアップ">
+								<source srcset="/campaigns/basic/assets/images/sp_structure_03_a_image_02.webp" media="(max-width: 767px)" type="image/webp">
+								<img src="/campaigns/basic/assets/images/structure_03_a_image_02.webp" alt="合同企業説明ドリンクアップ">
 							</picture>
 						</div>
 					</div>
 					<div class="structureHope">
 						<picture>
-							<source srcset="assets/images/sp_structure_03_heading.webp" media="(max-width: 767px)" type="image/webp">
-							<img src="assets/images/structure_03_heading.webp" alt="ご希望の方は、FBC提携企業の選考を受けることができます。" width="793" height="66">
+							<source srcset="/campaigns/basic/assets/images/sp_structure_03_heading.webp" media="(max-width: 767px)" type="image/webp">
+							<img src="/campaigns/basic/assets/images/structure_03_heading.webp" alt="ご希望の方は、FBC提携企業の選考を受けることができます。" width="793" height="66">
 						</picture>
 
 					</div>
@@ -1314,8 +1314,8 @@ function gtag_report_conversion(url) {
 						</div>
 						<div class="image">
 							<picture>
-								<source srcset="assets/images/sp_structure_03_b_image_01.webp" media="(max-width: 767px)" type="image/webp">
-								<img src="assets/images/structure_03_b_image_01.webp" alt="就職活動向けドキュメント">
+								<source srcset="/campaigns/basic/assets/images/sp_structure_03_b_image_01.webp" media="(max-width: 767px)" type="image/webp">
+								<img src="/campaigns/basic/assets/images/structure_03_b_image_01.webp" alt="就職活動向けドキュメント">
 							</picture>
 						</div>
 					</div>
@@ -1326,8 +1326,8 @@ function gtag_report_conversion(url) {
 						</div>
 						<div class="image">
 							<picture>
-								<source srcset="assets/images/sp_structure_03_b_image_02.webp" media="(max-width: 767px)" type="image/webp">
-					    		<img src="assets/images/structure_03_b_image_02.webp" alt="履歴書・職務経歴書サポート">
+								<source srcset="/campaigns/basic/assets/images/sp_structure_03_b_image_02.webp" media="(max-width: 767px)" type="image/webp">
+					    		<img src="/campaigns/basic/assets/images/structure_03_b_image_02.webp" alt="履歴書・職務経歴書サポート">
 							</picture>
 						</div>
 					</div>
@@ -1338,8 +1338,8 @@ function gtag_report_conversion(url) {
 						</div>
 						<div class="image">
 							<picture>
-								<source srcset="assets/images/sp_structure_03_b_image_03.webp" media="(max-width: 767px)" type="image/webp">
-					    		<img src="assets/images/structure_03_b_image_03.webp" alt="面接・技術試験のサポート">
+								<source srcset="/campaigns/basic/assets/images/sp_structure_03_b_image_03.webp" media="(max-width: 767px)" type="image/webp">
+					    		<img src="/campaigns/basic/assets/images/structure_03_b_image_03.webp" alt="面接・技術試験のサポート">
 							</picture>
 						</div>
 					</div>
@@ -1351,20 +1351,20 @@ function gtag_report_conversion(url) {
 							</div>
 							<div class="image">
 								<picture>
-									<source srcset="assets/images/sp_structure_03_b_image_04.webp" media="(max-width: 767px)" type="image/webp">
-									<img src="assets/images/structure_03_b_image_04.webp" alt="ポートフォリオ・推薦文の提出">
+									<source srcset="/campaigns/basic/assets/images/sp_structure_03_b_image_04.webp" media="(max-width: 767px)" type="image/webp">
+									<img src="/campaigns/basic/assets/images/structure_03_b_image_04.webp" alt="ポートフォリオ・推薦文の提出">
 								</picture>
 							</div>
 						</div>
 						<div class="structureHope">
 							<picture>
-								<source srcset="assets/images/sp_structure_03_c_image_04_heading.webp" media="(max-width: 767px)" type="image/webp">
-					    		<img src="assets/images/structure_03_c_image_04_heading.webp" alt="ご希望の方は、FBC提携企業の選考を受けることができます。" width="793" height="66">
+								<source srcset="/campaigns/basic/assets/images/sp_structure_03_c_image_04_heading.webp" media="(max-width: 767px)" type="image/webp">
+					    		<img src="/campaigns/basic/assets/images/structure_03_c_image_04_heading.webp" alt="ご希望の方は、FBC提携企業の選考を受けることができます。" width="793" height="66">
 							</picture>
 						</div>
 						<ul class="structurePortfolioList">
 							<li>
-								<p class="image"><img src="assets/images/structure_03_c_image_04_image_01.webp" alt="日報や課題の提出物" width="160" height="160"></p>
+								<p class="image"><img src="/campaigns/basic/assets/images/structure_03_c_image_04_image_01.webp" alt="日報や課題の提出物" width="160" height="160"></p>
 								<div class="structurePortfolioListInner">
 									<h6 class="title">日報や課題の提出物</h6>
 									<p class="text">学習過程で書き続けてきた日報や提出した課題の成果物は、学び続けられる、スキルをきちんと身につけている人であることを証明してくれます。</p>
@@ -1372,14 +1372,14 @@ function gtag_report_conversion(url) {
 							</li>
 							<li>
 								<div class="structurePortfolioListInner">
-									<p class="image"><img src="assets/images/structure_03_c_image_04_image_02.webp" alt="スクラムによるチーム開発の履歴" width="160" height="160"></p>
+									<p class="image"><img src="/campaigns/basic/assets/images/structure_03_c_image_04_image_02.webp" alt="スクラムによるチーム開発の履歴" width="160" height="160"></p>
 									<h6 class="title">スクラムによる<br>チーム開発の履歴</h6>
 									<p class="text">カンバンやPull Request、週次ミーティングの議事録などの全ては、実際の仕事でのやりとりに近いため、具体的な取り組み姿勢・対応力をアピールできます。</p>
 								</div>
 							</li>
 							<li>
 								<div class="structurePortfolioListInner">
-									<p class="image"><img src="assets/images/structure_03_c_image_04_image_03.webp" alt="最終課題の自作サービス" width="160" height="160"></p>
+									<p class="image"><img src="/campaigns/basic/assets/images/structure_03_c_image_04_image_03.webp" alt="最終課題の自作サービス" width="160" height="160"></p>
 									<h6 class="title">最終課題の<br>自作サービス</h6>
 									<p class="text">Webサービスをゼロから一人で企画・制作できる技術があることの証明になり、制作過程でどう課題と向き合い解決したかをアピールする材料になります。</p>
 								</div>
@@ -1399,15 +1399,15 @@ function gtag_report_conversion(url) {
 			<li class="structureList04">
 				<h3 class="structureListTitle">
 					<picture>
-						<source srcset="assets/images/sp_structure_04_title.webp" media="(max-width: 767px)" type="image/webp">
-						<img src="assets/images/structure_04_title.webp" alt="エンジニアのキャリアを継続的に支援する 04.卒業・就職後サポート" width="597" height="140">
+						<source srcset="/campaigns/basic/assets/images/sp_structure_04_title.webp" media="(max-width: 767px)" type="image/webp">
+						<img src="/campaigns/basic/assets/images/structure_04_title.webp" alt="エンジニアのキャリアを継続的に支援する 04.卒業・就職後サポート" width="597" height="140">
 					</picture>
 				</h3>
 				<p class="structureText">FBC受講生は、<br class="sp">卒業後も学習アプリにログインして利用できます</p>
 				<ul class="structureIcons">
-					<li><img src="assets/images/structure_04_image_01.webp" alt="学習アプリ・教材へのアクセス" width="160" height="206"></li>
-					<li><img src="assets/images/structure_04_image_02.webp" alt="勉強会やイベントへの参加" width="160" height="206"></li>
-					<li><img src="assets/images/structure_04_image_03.webp" alt="個別相談" width="160" height="206"></li>
+					<li><img src="/campaigns/basic/assets/images/structure_04_image_01.webp" alt="学習アプリ・教材へのアクセス" width="160" height="206"></li>
+					<li><img src="/campaigns/basic/assets/images/structure_04_image_02.webp" alt="勉強会やイベントへの参加" width="160" height="206"></li>
+					<li><img src="/campaigns/basic/assets/images/structure_04_image_03.webp" alt="個別相談" width="160" height="206"></li>
 				</ul>
 				<p class="structureText2">また、定期的なフォローアップとして、<br>
 				就職後の1週間、1ヶ月、半年、1年後に連絡を取り、<br>
@@ -1424,11 +1424,11 @@ function gtag_report_conversion(url) {
 	<div class="inner">
 		<div class="cta01">
 			<picture>
-				<source srcset="assets/images/sp_cta2.webp" media="(max-width: 767px)" type="image/webp">
-				<img src="assets/images/cta2.webp" alt="あなたもFBCでプログラミングを始めてみませんか？" width="933">
+				<source srcset="/campaigns/basic/assets/images/sp_cta2.webp" media="(max-width: 767px)" type="image/webp">
+				<img src="/campaigns/basic/assets/images/cta2.webp" alt="あなたもFBCでプログラミングを始めてみませんか？" width="933">
 			</picture>
 		</div>
-		<p class="cta02"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="assets/images/cta.webp" alt="参加登録はこちら" width="619" height="110"></a></p>
+		<p class="cta02"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="/campaigns/basic/assets/images/cta.webp" alt="参加登録はこちら" width="619" height="110"></a></p>
 		<p class="cta03">お試し期間の間に退会をすれば<br class="sp">課金されることはありません</p>
 	</div>
 </div>
@@ -1437,17 +1437,17 @@ function gtag_report_conversion(url) {
 	<div class="inner">
 		<h2 class="courseTitle">
 			<picture>
-				<source srcset="assets/images/sp_course_title.webp" media="(max-width: 767px)" type="image/webp">
-				<img src="assets/images/course_title.webp" alt="選べる2つのコース" width="885" height="156">
+				<source srcset="/campaigns/basic/assets/images/sp_course_title.webp" media="(max-width: 767px)" type="image/webp">
+				<img src="/campaigns/basic/assets/images/course_title.webp" alt="選べる2つのコース" width="885" height="156">
 			</picture>
 		</h2>
 		<p class="couraseText">Webサービス開発について学べる2つのコースを用意しています。<br>
 		どちらもオンライン形式なので、インターネット環境とパソコンがあればどこからでも参加できます。</p>
 		<ul class="coursesList">
 			<li>
-				<h3 class="coursesListImage"><img src="assets/images/course_image_01.webp" alt="Railsエンジニアコース"></h3>
+				<h3 class="coursesListImage"><img src="/campaigns/basic/assets/images/course_image_01.webp" alt="Railsエンジニアコース"></h3>
 				<p class="coursesListText">プログラミング言語 Ruby を用いたWebアプリケーションフレームワークである Ruby on Rails を使って Web エンジニアになるためのバックエンド・フロントエンドも含めた一通りの技術を学びます。　</p>
-				<p class="modalBtn coursesListBtn" tg="modal01"><img src="assets/images/course_btn.webp" alt="コース内容" width="380" height="80"></p>
+				<p class="modalBtn coursesListBtn" tg="modal01"><img src="/campaigns/basic/assets/images/course_btn.webp" alt="コース内容" width="380" height="80"></p>
 				<div class="modal" id="modal01" style="display: none;">
 					<div class="modalBox">
 						<h4 class="modalTitle">Railsエンジニア<br>コース</h4>
@@ -1458,9 +1458,9 @@ function gtag_report_conversion(url) {
 				</div>
 			</li>
 			<li>
-				<h3 class="coursesListImage"><img src="assets/images/course_image_02.webp" alt="フロントエンドエンジニアコース"></h3>
+				<h3 class="coursesListImage"><img src="/campaigns/basic/assets/images/course_image_02.webp" alt="フロントエンドエンジニアコース"></h3>
 				<p class="coursesListText">HTML、CSS やJavaScript/TypeScriptをつかってWebアプリケーションにおいてユーザーが直接触る部分（ユーザーインターフェース）を作るための技術を習得できます。</p>
-				<p class="modalBtn coursesListBtn" tg="modal02"><img src="assets/images/course_btn.webp" alt="コース内容" width="380" height="80"></p>
+				<p class="modalBtn coursesListBtn" tg="modal02"><img src="/campaigns/basic/assets/images/course_btn.webp" alt="コース内容" width="380" height="80"></p>
 				<div class="modal" id="modal02" style="display: none;">
 					<div class="modalBox">
 						<h4 class="modalTitle">フロントエンドエンジニア<br>コース</h4>
@@ -1476,48 +1476,48 @@ function gtag_report_conversion(url) {
 		<div class="courseInner">
 			<h3 class="courseHeading">
 				<picture>
-					<source srcset="assets/images/sp_course_01_heading.webp" media="(max-width: 767px)" type="image/webp">
-					<img src="assets/images/course_01_heading.webp" alt="学習全体の流れ" width="495" height="60">
+					<source srcset="/campaigns/basic/assets/images/sp_course_01_heading.webp" media="(max-width: 767px)" type="image/webp">
+					<img src="/campaigns/basic/assets/images/course_01_heading.webp" alt="学習全体の流れ" width="495" height="60">
 				</picture>
 			</h3>
 			<p class="courseText">どちらも最初は共通のカリキュラムからスタートし、その後に専門分野に分かれて学んでいきます。<br>
 			その後、チーム開発、自作サービス開発・リリースをクリアして卒業し、就職活動を経て就職です。</p>
 			<div class="courseFlow01">
 				<picture>
-					<source srcset="assets/images/sp_course_flow.webp" media="(max-width: 767px)" type="image/webp">
-					<img src="assets/images/course_flow.webp" alt="フロー">
+					<source srcset="/campaigns/basic/assets/images/sp_course_flow.webp" media="(max-width: 767px)" type="image/webp">
+					<img src="/campaigns/basic/assets/images/course_flow.webp" alt="フロー">
 				</picture>
 			</div>
 			<p class="courseFlow02">就職</p>
-			<p class="courseFlow03"><img src="assets/images/course_01_image.webp" width="408" height="379"></p>
+			<p class="courseFlow03"><img src="/campaigns/basic/assets/images/course_01_image.webp" width="408" height="379"></p>
 		</div>
 	</section>
 	<section class="courseUses">
 		<div class="courseInner">
 			<h3 class="courseHeading">
 				<picture>
-					<source srcset="assets/images/sp_course_02_heading.webp" media="(max-width: 767px)" type="image/webp">
-					<img src="assets/images/course_02_heading.webp" alt="学習で使うもの" width="495" height="60">
+					<source srcset="/campaigns/basic/assets/images/sp_course_02_heading.webp" media="(max-width: 767px)" type="image/webp">
+					<img src="/campaigns/basic/assets/images/course_02_heading.webp" alt="学習で使うもの" width="495" height="60">
 				</picture>
 			</h3>
 			<ul class="courseUsesList">
 				<li>
-			    	<p class="courseUsesListImage"><img src="assets/images/course_02_image_01.webp" alt="学習アプリbootcamp" width="140" height="140"></p>
+			    	<p class="courseUsesListImage"><img src="/campaigns/basic/assets/images/course_02_image_01.webp" alt="学習アプリbootcamp" width="140" height="140"></p>
 					<p class="courseUsesListName">学習アプリ<br>bootcamp</p>
 					<p class="courseUsesListText">プラクティスや日報の提出、メンターによるコードレビューやアドバイス、Q&amp;Aなど学習に必要なものは、このアプリですべて完結します。</p>
 				</li>
 			  <li>
-			    	<p class="courseUsesListImage"><img src="assets/images/course_02_image_02.webp" alt="Discord" width="140" height="140"></p>
+			    	<p class="courseUsesListImage"><img src="/campaigns/basic/assets/images/course_02_image_02.webp" alt="Discord" width="140" height="140"></p>
 					<p class="courseUsesListName">Discord</p>
 					<p class="courseUsesListText">チャットで受講生と雑談を楽しんだり、勉強会やイベントに参加したりできます。カンファレンスの案内や業界のトピックスなどもこちらでチェックできます。</p>
 				</li>
 			  <li>
-			    	<p class="courseUsesListImage"><img src="assets/images/course_02_image_03.webp" alt="GitHub" width="140" height="140"></p>
+			    	<p class="courseUsesListImage"><img src="/campaigns/basic/assets/images/course_02_image_03.webp" alt="GitHub" width="140" height="140"></p>
 					<p class="courseUsesListName">GitHub</p>
 					<p class="courseUsesListText">実際の開発現場と同じように、GitHubでコードを管理しながら学習します。プルリクエストを作成し、メンターからコードレビューを受けることで、チーム開発の流れや開発スキルが自然と身につきます。</p>
 				</li>
 			  <li>
-			    	<p class="courseUsesListImage"><img src="assets/images/course_02_image_04.webp" alt="Remo" width="140" height="140"></p>
+			    	<p class="courseUsesListImage"><img src="/campaigns/basic/assets/images/course_02_image_04.webp" alt="Remo" width="140" height="140"></p>
 					<p class="courseUsesListName">Remo</p>
 					<p class="courseUsesListText">月に1回のカンファレンスに活用します。仮想空間上で行われる卒業式や勉強会、企業説明会を、リアルな臨場感で楽しむことができます。</p>
 				</li>
@@ -1529,8 +1529,8 @@ function gtag_report_conversion(url) {
 <section id="price">
 	<h2 class="priceTitle">
 		<picture>
-			<source srcset="assets/images/sp_price_title.webp" media="(max-width: 767px)" type="image/webp">
-			<img src="assets/images/price_title.webp" alt="利用料" width="885" height="166">
+			<source srcset="/campaigns/basic/assets/images/sp_price_title.webp" media="(max-width: 767px)" type="image/webp">
+			<img src="/campaigns/basic/assets/images/price_title.webp" alt="利用料" width="885" height="166">
 		</picture>
 	</h2>
 
@@ -1538,8 +1538,8 @@ function gtag_report_conversion(url) {
 	<div class="price01">
 
 		<picture>
-			<source srcset="assets/images/sp_course_02_image_0.webp" media="(max-width: 767px)" type="image/webp">
-			<img src="assets/images/course_02_image_0.webp" alt="月額32,780円（税込）" width="586" height="97">
+			<source srcset="/campaigns/basic/assets/images/sp_course_02_image_0.webp" media="(max-width: 767px)" type="image/webp">
+			<img src="/campaigns/basic/assets/images/course_02_image_0.webp" alt="月額32,780円（税込）" width="586" height="97">
 		</picture>
 	</div>
 	<p class="price02">サブスクだからリスクは最小限</p>
@@ -1561,14 +1561,14 @@ function gtag_report_conversion(url) {
 	<div class="inner">
 		<h2 class="qandaTitle">
 			<picture>
-				<source srcset="assets/images/sp_qanda_title.webp" media="(max-width: 767px)" type="image/webp">
-				<img src="assets/images/qanda_title.webp" alt="よくあるご質問" width="885" height="166">
+				<source srcset="/campaigns/basic/assets/images/sp_qanda_title.webp" media="(max-width: 767px)" type="image/webp">
+				<img src="/campaigns/basic/assets/images/qanda_title.webp" alt="よくあるご質問" width="885" height="166">
 			</picture>
 		</h2>
 		<ul class="qandaList">
 			<li>
 				<div class="qaQ selected">
-					<p class="icon"><img src="assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
+					<p class="icon"><img src="/campaigns/basic/assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
 					<p class="title">転職は考えていないのですが、スキルアップのためプログラミングの勉強がしたいです。<br>
 					その場合、参加は可能ですか？</p>
 				</div>
@@ -1578,7 +1578,7 @@ function gtag_report_conversion(url) {
 			</li>
 			<li>
 				<div class="qaQ">
-					<p class="icon"><img src="assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
+					<p class="icon"><img src="/campaigns/basic/assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
 					<p class="title">途中でコースの変更はできますか？</p>
 				</div>
 				<div class="qaA" style="display: none">
@@ -1587,7 +1587,7 @@ function gtag_report_conversion(url) {
 			</li>
 			<li>
 				<div class="qaQ">
-					<p class="icon"><img src="assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
+					<p class="icon"><img src="/campaigns/basic/assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
 					<p class="title">就職先が決まっているのですが、就職までの間学習をしたいです。<br>その場合、参加は可能ですか？</p>
 				</div>
 				<div class="qaA" style="display: none">
@@ -1596,7 +1596,7 @@ function gtag_report_conversion(url) {
 			</li>
 			<li>
 				<div class="qaQ">
-					<p class="icon"><img src="assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
+					<p class="icon"><img src="/campaigns/basic/assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
 					<p class="title">現在、大学に在学中なのですが、参加できますか？</p>
 				</div>
 				<div class="qaA" style="display: none">
@@ -1605,7 +1605,7 @@ function gtag_report_conversion(url) {
 			</li>
 			<li>
 				<div class="qaQ">
-					<p class="icon"><img src="assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
+					<p class="icon"><img src="/campaigns/basic/assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
 					<p class="title">プログラマーは男性が多いと聞いたことがありますが、女性でも大丈夫ですか？</p>
 				</div>
 				<div class="qaA" style="display: none">
@@ -1616,7 +1616,7 @@ function gtag_report_conversion(url) {
 			</li>
 			<li>
 				<div class="qaQ">
-					<p class="icon"><img src="assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
+					<p class="icon"><img src="/campaigns/basic/assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
 					<p class="title">30代なのですが、エンジニアとして就職することは可能ですか？</p>
 				</div>
 				<div class="qaA" style="display: none">
@@ -1633,7 +1633,7 @@ function gtag_report_conversion(url) {
 			</li>
 			<li>
 				<div class="qaQ">
-					<p class="icon"><img src="assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
+					<p class="icon"><img src="/campaigns/basic/assets/images/qanda_q.webp" alt="Q" width="100" height="100"></p>
 					<p class="title">AIについて学べるカリキュラムはありますか？AIについて学べるカリキュラムはありますか？</p>
 				</div>
 				<div class="qaA" style="display: none">
@@ -1656,11 +1656,11 @@ function gtag_report_conversion(url) {
 	<div class="inner">
 		<div class="cta01">
 			<picture>
-				<source srcset="assets/images/sp_cta3.webp" media="(max-width: 767px)" type="image/webp">
-				<img src="assets/images/cta3.webp" alt="あなたもFBCでプログラミングを始めてみませんか？" width="933">
+				<source srcset="/campaigns/basic/assets/images/sp_cta3.webp" media="(max-width: 767px)" type="image/webp">
+				<img src="/campaigns/basic/assets/images/cta3.webp" alt="あなたもFBCでプログラミングを始めてみませんか？" width="933">
 			</picture>
 		</div>
-		<p class="cta02"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="assets/images/cta.webp" alt="参加登録はこちら" width="619" height="110"></a></p>
+		<p class="cta02"><a href="https://bootcamp.fjord.jp/choose_courses" target="_blank" onclick="return gtag_report_conversion('https://bootcamp.fjord.jp/choose_courses')"><img src="/campaigns/basic/assets/images/cta.webp" alt="参加登録はこちら" width="619" height="110"></a></p>
 		<p class="cta03">お試し期間の間に退会をすれば<br class="sp">課金されることはありません</p>
 	</div>
 </div>
@@ -1670,9 +1670,9 @@ function gtag_report_conversion(url) {
 </footer>
 <!-- =========================================================================== -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-<script src="assets/js/slick.js"></script>
-<script src="assets/js/jquery.heightLine.js"></script>
-<script src="assets/js/common.js"></script>
+<script src="/campaigns/basic/assets/js/slick.js"></script>
+<script src="/campaigns/basic/assets/js/jquery.heightLine.js"></script>
+<script src="/campaigns/basic/assets/js/common.js"></script>
 <script>
 $(function(){
   if (window.matchMedia( "(min-width: 768px)" ).matches) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   root to: "home#index"
 
   get "welcome", to: "welcome#index", as: "welcome"
+  get "campaigns/basic", to: "static_pages#campaign_basic", as: "campaign_basic"
   get "practices", to: "welcome#practices", as: "practices"
   get "pricing", to: "welcome#pricing", as: "pricing"
   get "alumni_voices", to: "welcome#alumni_voices", as: "alumni_voices"

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test 'shows basic campaign page through Rails' do
+    get campaign_basic_path
+
+    assert_response :success
+    assert_includes response.body, '即戦力になれるプログラミングスクール'
+    assert_includes response.body, '/campaigns/basic/assets/css/style.css'
+  end
+
+  test 'shows basic campaign page with trailing slash' do
+    get '/campaigns/basic/'
+
+    assert_response :success
+    assert_includes response.body, '即戦力になれるプログラミングスクール'
+  end
+
+  test 'saves affiliate rd_code when visiting basic campaign page' do
+    get campaign_basic_path(rd_code: 'test-rd_code_123')
+
+    assert_response :success
+    assert_equal 'test-rd_code_123', session[:affiliate_rd_code]
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 新しいキャンペーンページが /campaigns/basic で利用可能になりました（末尾スラッシュの有無どちらでも表示）。
  * アフィリエイト参照コード（rd_code）を受け取りセッションに保持します。

* **不具合修正**
  * ページ内の資産参照パスと Open Graph URL をキャンペーン用パスへ修正し表示・メタ情報を安定化。

* **テスト**
  * キャンペーンページ表示とトラッキング挙動を確認する統合テストを追加。

* **改善**
  * 動画のプリロードを無効化して読み込み負荷を軽減。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->