### PR TITLE
卒業生を含む全ロールでユーザー非公開情報を表示するよう修正

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -63,9 +63,8 @@
                   - if @user.retired?
                     .user-data__row
                       = render 'users/retire_info', user: @user
-                  - if @user.student_or_trainee_or_retired?
-                    .user-data__row
-                      = render 'users/user_secret_attributes', user: @user
+                  .user-data__row
+                    = render 'users/user_secret_attributes', user: @user
 
             - if admin_or_mentor_login? && @user.hibernations.present?
               = render 'users/hibernation_history', user: @user

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -49,6 +49,16 @@ class UsersTest < ApplicationSystemTestCase
     assert_no_selector 'label.a-form-label', text: '活動時間'
   end
 
+  test 'mentor can see secret attributes of graduated user' do
+    visit_with_auth "/users/#{users(:sotugyou).id}", 'mentormentaro'
+    assert_text users(:sotugyou).email
+  end
+
+  test 'non-mentor cannot see secret attributes of graduated user' do
+    visit_with_auth "/users/#{users(:sotugyou).id}", 'hatsuno'
+    assert_no_text users(:sotugyou).email
+  end
+
   test 'delete user' do
     user = users(:kimura)
     visit_with_auth "users/#{user.id}", 'komagata'


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/issues/9904
こちらを対応しました。

 ユーザー個別ページの「ユーザー非公開情報」が、卒業生のユーザーを閲覧した際に
  admin/mentor でログインしていても表示されない問題を修正。

  `show.html.slim` で `_user_secret_attributes` パーシャルの表示を
  `student_or_trainee_or_retired?` で制限していたが、このメソッドは
  `!staff? && !graduated?` の実装のため卒業生では false を返していた。

  admin/mentor ログイン時は外側の `admin_or_mentor_login?` で既にアクセスを
  制御しているため、内側の `student_or_trainee_or_retired?` の条件を除去した。

  あわせて、メンター・管理者以外には非公開情報が見えないことを保証するテストを追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * メンターおよび管理者ユーザーがアクセスした際、ユーザープロフィール情報がより一貫して表示されるようになりました。

* **テスト**
  * ユーザープロフィール表示の権限制御に関する新しいシステムテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->