### PR TITLE
pjordが日報コメントで「質問なし」等のメタ文言を書かないよう修正

### DIFF
--- a/app/jobs/pjord_report_comment_job.rb
+++ b/app/jobs/pjord_report_comment_job.rb
@@ -6,11 +6,17 @@ class PjordReportCommentJob < ApplicationJob
 
   INSTRUCTIONS = <<~TEXT
     日報（学習記録）を読んで、質問や困っている内容があればアドバイスしてください。
-    - 日報に質問的な内容や困っている記述がない場合は「質問なし」とだけ返答してください
+    - 日報に質問的な内容や困っている記述がない場合は、他に一切何も書かず `[NO_QUESTION]` という文字列だけを返してください。挨拶・感想・「質問はありません」等の説明も書かないでください。
+    - 質問や困りごとがある場合のみ、通常のコメント（アドバイス）を返してください。その際、コメント本文に「質問なし」「質問はありません」「質問は見当たりません」等の、質問の有無に言及するメタな文言は絶対に含めないでください。生徒宛のアドバイスだけを書いてください。
     - 答えそのものを教えるのではなく、調べ方・ヒント・考え方をアドバイスする
   TEXT
 
-  NO_QUESTION_MARKER = '質問なし'
+  NO_QUESTION_MARKER = '[NO_QUESTION]'
+  NO_QUESTION_PATTERNS = [
+    /\A\[?NO_QUESTION\]?\z/i,
+    /\A質問(?:的な内容|らしい内容|事項)?(?:は|も)?(?:特に)?(?:あり(?:ま)?せん|ないです|無いです|なし|見当たり(?:ま)?せん|見受けられ(?:ま)?せん)[。！!.\sねよな～っ]*\z/,
+    /\A日報(?:中|内|の中)?に(?:は)?質問.*?(?:あり(?:ま)?せん|ないです|無いです|なし|見当たり(?:ま)?せん)[。！!.\sねよな～っ]*\z/
+  ].freeze
 
   def perform(report_id:)
     report = Report.find_by(id: report_id)
@@ -30,17 +36,23 @@ class PjordReportCommentJob < ApplicationJob
     end
 
     return if response.blank?
-    return if response.strip.start_with?(NO_QUESTION_MARKER)
+    return if no_question_response?(response)
 
     Comment.create!(user: pjord, commentable: report, description: response)
   end
 
   private
 
+  def no_question_response?(response)
+    stripped = response.strip
+    NO_QUESTION_PATTERNS.any? { |pattern| stripped.match?(pattern) }
+  end
+
   def build_message(report)
     <<~MESSAGE
       以下の日報を読んで、質問や困っている内容があればアドバイスしてください。
-      質問的な内容がなければ「質問なし」とだけ返答してください。
+      質問的な内容がなければ `[NO_QUESTION]` とだけ返答してください。
+      コメントを書く場合は、質問の有無に言及するメタな文言（例:「質問なし」「質問はありません」）を本文に一切含めないでください。
 
       ## 日報タイトル
       #{report.title}

--- a/test/jobs/pjord_report_comment_job_test.rb
+++ b/test/jobs/pjord_report_comment_job_test.rb
@@ -19,12 +19,31 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     assert_equal 'ヒントをあげるね！', comment.description
   end
 
-  test 'does not create a comment when report has no question' do
+  test 'does not create a comment when response is the no_question marker' do
     report = reports(:report1)
 
-    Pjord.stub(:respond, '質問なし') do
+    Pjord.stub(:respond, '[NO_QUESTION]') do
       assert_no_difference 'Comment.count' do
         PjordReportCommentJob.perform_now(report_id: report.id)
+      end
+    end
+  end
+
+  test 'does not create a comment for common "no question" paraphrases' do
+    report = reports(:report1)
+
+    [
+      '質問なし',
+      '質問はありません。',
+      '質問は特にありません',
+      '質問的な内容は見当たりません。',
+      '日報中に質問はないですね。',
+      '日報に質問はありません'
+    ].each do |phrase|
+      Pjord.stub(:respond, phrase) do
+        assert_no_difference 'Comment.count', "should skip: #{phrase}" do
+          PjordReportCommentJob.perform_now(report_id: report.id)
+        end
       end
     end
   end
@@ -85,7 +104,7 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     captured_context = nil
     mock_respond = lambda { |message:, context:, instructions: nil| # rubocop:disable Lint/UnusedBlockArgument
       captured_context = context
-      '質問なし'
+      '[NO_QUESTION]'
     }
 
     Pjord.stub(:respond, mock_respond) do


### PR DESCRIPTION
## Summary
- pjordが日報コメントで「質問なし」「日報中に質問はないですね」等のメタ文言を投稿してしまう問題を修正
- 質問有無の判定はpjordとメンター間の内部的な話で、生徒向けコメントに現れるべきではないため
- マーカーを `質問なし` → `[NO_QUESTION]` に変更し、通常のコメント本文に紛れ込まないようにした
- プロンプトでメタ文言の禁止を明示
- LLMの揺れに備えて `NO_QUESTION_PATTERNS` で「質問なし」系の言い回しを検出し、該当する場合はコメント投稿をスキップ

## Test plan
- [x] `bin/rails test test/jobs/pjord_report_comment_job_test.rb` がパスすること
- [x] `[NO_QUESTION]` マーカーでスキップされること
- [x] 「質問なし」「質問はありません」「日報中に質問はないですね」等の言い回しでもスキップされること
- [x] 「質問なし」が本文中に紛れた通常コメント（例:「この問題は質問なしでも解決できます。」）は投稿されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * レポートコメント生成時の「質問なし」検出ロジックを改善しました。複数の言語表現や異なる表記パターンに対応するようになりました。

* **テスト**
  * 「質問なし」判定に関するテストケースを追加し、様々なバリエーションのカバレッジを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->