### PR TITLE
reports_user_idインデックスのマイグレーションファイルを追加

### DIFF
--- a/db/migrate/20260415000000_add_reports_user_id_index.rb
+++ b/db/migrate/20260415000000_add_reports_user_id_index.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddReportsUserIdIndex < ActiveRecord::Migration[7.2]
-  def change
-    add_index :reports, :user_id, name: 'reports_user_id', if_not_exists: true
-  end
-end

--- a/db/migrate/20260415000000_add_reports_user_id_index.rb
+++ b/db/migrate/20260415000000_add_reports_user_id_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReportsUserIdIndex < ActiveRecord::Migration[7.2]
+  def change
+    add_index :reports, :user_id, name: 'reports_user_id', if_not_exists: true
+  end
+end

--- a/db/migrate/20260415000000_remove_reports_user_id_index.rb
+++ b/db/migrate/20260415000000_remove_reports_user_id_index.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveReportsUserIdIndex < ActiveRecord::Migration[7.2]
+  def up
+    remove_index :reports, name: 'reports_user_id', if_exists: true
+  end
+
+  def down
+    add_index :reports, :user_id, name: 'reports_user_id', if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_30_072542) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -764,7 +764,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
     t.index ["created_at"], name: "index_reports_on_created_at"
     t.index ["user_id", "reported_on"], name: "index_reports_on_user_id_and_reported_on", unique: true
     t.index ["user_id", "title"], name: "index_reports_on_user_id_and_title", unique: true
-    t.index ["user_id"], name: "reports_user_id"
   end
 
   create_table "request_retirements", force: :cascade do |t|


### PR DESCRIPTION
## 関連issue
closes #9479

## 概要

`reports` テーブルの `user_id` カラムに対する `reports_user_id` インデックスが、本番環境DBおよび `db/schema.rb` には存在するがマイグレーションファイルが存在しなかった。

`db:migrate:reset` を実行すると `db/schema.rb` からこのインデックスが消える不整合があったため、マイグレーションファイルを追加して整合させた。

本番環境には既にインデックスが存在するため、`if_not_exists: true` を指定して冪等にしている。

## Test plan

- [ ] `bin/rails db:migrate:reset` を実行しても `db/schema.rb` の `reports_user_id` インデックスが消えないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データベースメンテナンスが実施されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->