### PR TITLE
本番環境にのみ存在したpages_backup_vimeo_conversionテーブルを削除

### DIFF
--- a/db/migrate/20260415000001_drop_pages_backup_vimeo_conversion.rb
+++ b/db/migrate/20260415000001_drop_pages_backup_vimeo_conversion.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DropPagesBackupVimeoConversion < ActiveRecord::Migration[7.2]
+  def up
+    drop_table :pages_backup_vimeo_conversion, if_exists: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_30_072542) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"


### PR DESCRIPTION
## 関連issue
closes #9472

## 概要

`pages_backup_vimeo_conversion` テーブルが本番環境DBにのみ存在し、マイグレーションファイルもなく `db/schema.rb` にも記載がなかった。

名前からして過去のVimeo変換作業時にバックアップ用として本番DBに直接作成されたテーブルと思われる。不要なテーブルであるため、マイグレーションで削除して本番DBを `db/schema.rb` と整合させる。

本番環境にのみ存在するテーブルのため `if_exists: true` を指定し、ローカル等で実行しても失敗しないようにしている。また、バックアップ目的のテーブルのためロールバックは非可逆とした。

## Test plan

- [ ] 本番環境でマイグレーション適用後、`pages_backup_vimeo_conversion` テーブルが存在しないことを確認