### PR TITLE
動画にサムネイル画像を設定できるようにする

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -12,6 +12,8 @@ class MoviesController < ApplicationController
     @tags = Movie.all.all_tags
     @movies = Movie.by_tag(params[:tag])
                    .includes(:user)
+                   .with_attached_movie_data
+                   .with_attached_thumbnail
                    .order(updated_at: :desc, id: :desc)
                    .page(params[:page])
                    .per(PAGER_NUMBER)
@@ -71,6 +73,7 @@ class MoviesController < ApplicationController
       :title,
       :description,
       :movie_data,
+      :thumbnail,
       :tag_list,
       practice_ids: []
     )

--- a/app/interactors/process_transcoding_notification.rb
+++ b/app/interactors/process_transcoding_notification.rb
@@ -68,6 +68,7 @@ class ProcessTranscodingNotification
     transcoded_movie = Transcoder::Movie.new(movie)
     movie.movie_data.attach(io: transcoded_movie.data, filename: "#{movie.id}.mp4")
     movie.save!
+    GenerateMovieThumbnailJob.perform_later(movie)
     Rails.logger.info("Successfully attached transcoded movie for Movie #{movie.id}")
   rescue StandardError => e
     Rails.logger.error("Failed to attach transcoded movie for Movie #{movie.id}: #{e.message}")

--- a/app/jobs/generate_movie_thumbnail_job.rb
+++ b/app/jobs/generate_movie_thumbnail_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class GenerateMovieThumbnailJob < ApplicationJob
+  def perform(movie)
+    return if movie.thumbnail.attached?
+    return unless movie.movie_data.attached? && movie.movie_data.previewable?
+
+    preview = movie.movie_data.preview({})
+    preview.processed
+    movie.thumbnail.attach(preview.image.blob)
+  rescue ActiveStorage::PreviewError => e
+    Rails.logger.warn("Failed to generate thumbnail for Movie #{movie.id}: #{e.message}")
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -28,8 +28,8 @@ class Movie < ApplicationRecord
   scope :wip, -> { where(wip: true) }
   scope :by_tag, ->(tag) { tag.present? ? tagged_with(tag) : all }
 
-  after_create_commit :start_transcode_job, on: :create
-  after_create_commit :generate_default_thumbnail, on: :create
+  after_create_commit :start_transcode_job
+  after_create_commit :generate_default_thumbnail
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[title description wip created_at updated_at user_id]

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -9,20 +9,27 @@ class Movie < ApplicationRecord
   include Watchable
   include Bookmarkable
 
+  THUMBNAIL_SIZE = [1200, 630].freeze
+
   belongs_to :user
   has_many :practices_movies, dependent: :nullify
   has_many :practices, through: :practices_movies
   has_one_attached :movie_data
+  has_one_attached :thumbnail
 
   validates :user, presence: true
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, presence: true
   validates :movie_data, presence: true
+  validates :thumbnail,
+            content_type: %w[image/png image/jpeg],
+            size: { less_than: 10.megabytes }
 
   scope :wip, -> { where(wip: true) }
   scope :by_tag, ->(tag) { tag.present? ? tagged_with(tag) : all }
 
   after_create_commit :start_transcode_job, on: :create
+  after_create_commit :generate_default_thumbnail, on: :create
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[title description wip created_at updated_at user_id]
@@ -32,12 +39,27 @@ class Movie < ApplicationRecord
     %w[user practices comments reactions watches bookmarks]
   end
 
+  def thumbnail_url
+    if thumbnail.attached?
+      thumbnail.variant(resize_to_fill: THUMBNAIL_SIZE).processed.url
+    else
+      ActionController::Base.helpers.asset_path('work-blank.svg')
+    end
+  end
+
   private
 
   def start_transcode_job
     TranscodeJob.perform_later(self)
   rescue StandardError => e
     Rails.logger.error("Failed to enqueue TranscodeJob for Movie #{id}: #{e.message}")
+    raise
+  end
+
+  def generate_default_thumbnail
+    GenerateMovieThumbnailJob.perform_later(self)
+  rescue StandardError => e
+    Rails.logger.error("Failed to enqueue GenerateMovieThumbnailJob for Movie #{id}: #{e.message}")
     raise
   end
 end

--- a/app/views/movies/_form.html.slim
+++ b/app/views/movies/_form.html.slim
@@ -60,9 +60,6 @@
               - if movie.thumbnail.attached?
                 = image_tag movie.thumbnail
                 p サムネイル画像を変更
-              - elsif movie.movie_data.attached?
-                = image_tag movie.thumbnail_url
-                p サムネイル画像を変更
               - else
                 p サムネイル画像を選択
               = f.file_field :thumbnail,

--- a/app/views/movies/_form.html.slim
+++ b/app/views/movies/_form.html.slim
@@ -1,4 +1,9 @@
-= form_with model: movie, local: true, class: 'form', html: { name: 'movie' } do |f|
+= form_with model: movie,
+  local: true,
+  class: 'form',
+  html: { name: 'movie' } do |f|
+  - description_classes = 'a-text-input js-warning-form ' \
+    'markdown-form__text-area js-markdown'
   = render 'errors', object: movie
   .form__items
     .form-item
@@ -7,7 +12,10 @@
           .form-item
             = f.label :practice, class: 'a-form-label'
             .select-practices
-              = f.select(:practice_ids, practice_options(@categories), { include_hidden: false }, { multiple: true, id: 'js-choices-single-select' })
+              = f.select(:practice_ids,
+                practice_options(@categories),
+                { include_hidden: false },
+                { multiple: true, id: 'js-choices-single-select' })
     .form-item
       .row
         .col-md-6.col-xs-12
@@ -19,8 +27,9 @@
           = f.label :description, class: 'a-form-label'
           .form-textarea
             .form-textarea__body
-              = f.text_area :description, class: 'a-text-input js-warning-form markdown-form__text-area js-markdown',
-              data: { 'preview': '.js-preview', 'input': '.file-input' }
+              = f.text_area :description,
+                class: description_classes,
+                data: { 'preview': '.js-preview', 'input': '.file-input' }
         .col-md-6.col-xs-12
           .a-form-label
             | プレビュー
@@ -33,11 +42,35 @@
             label
               .js-movie-file-input__preview.a-file-input__preview
                 - if @movie.movie_data.attached?
-                  = video_tag url_for(@movie.movie_data.blob), controls: true, width: '717.52', height: '403.59'
+                  = video_tag url_for(@movie.movie_data.blob),
+                    controls: true,
+                    width: '717.52',
+                    height: '403.59'
                   p 動画を変更
                 - else
                   p 動画を選択
-              = f.file_field :movie_data, class: 'a-text-input', accept: 'video/mp4, video/quicktime', direct_upload: true
+              = f.file_field :movie_data,
+                class: 'a-text-input',
+                accept: 'video/mp4, video/quicktime',
+                direct_upload: true
+        .col-md-6.col-xs-12
+          = f.label :thumbnail, class: 'a-form-label'
+          .form-item-file-input.js-file-input.a-file-input.is-thumbnail
+            label.js-file-input__preview
+              - if movie.thumbnail.attached?
+                = image_tag movie.thumbnail
+                p サムネイル画像を変更
+              - elsif movie.movie_data.attached?
+                = image_tag movie.thumbnail_url
+                p サムネイル画像を変更
+              - else
+                p サムネイル画像を選択
+              = f.file_field :thumbnail,
+                accept: 'image/png, image/jpeg',
+                direct_upload: true
+          .a-form-help
+            p
+              | 未設定の場合は、動画の最初のフレームがサムネイル画像になります。
     .form-item
       .row
         .col-md-6.col-xs-12
@@ -46,7 +79,9 @@
   .form-actions
     ul.form-actions__items
       li.form-actions__item.is-main
-        = f.submit 'WIP', class: 'a-button is-lg is-secondary is-block', id: 'js-shortcut-wip'
+        = f.submit 'WIP',
+          class: 'a-button is-lg is-secondary is-block',
+          id: 'js-shortcut-wip'
       li.form-actions__item.is-main
         = button_tag(class: 'a-button is-lg is-primary is-block') do
           - case params[:action]

--- a/app/views/movies/_movie_list.html.slim
+++ b/app/views/movies/_movie_list.html.slim
@@ -3,7 +3,9 @@
     .thumbnail-card__inner
       .thumbnail-card__row
         = link_to movie, class: 'thumbnail-card__image-link' do
-          = image_tag('work-blank.svg', class: 'thumbnail-card__image')
+          = image_tag movie.thumbnail_url,
+            class: 'thumbnail-card__image',
+            alt: movie.title
       .thumbnail-card__row
         h2.thumbnail-card__title(class="#{movie.wip? ? 'is-wip' : ''}")
           - if movie.wip?
@@ -16,14 +18,20 @@
             .thumbnail-card__author
               - if movie.user
                 .thumbnail-card__icon
-                  = link_to user_path(movie.user), class: 'a-user-icons__item-link' do
+                  = link_to user_path(movie.user),
+                    class: 'a-user-icons__item-link' do
                     span class="a-user-role is-#{movie.user.primary_role}"
-                      = image_tag movie.user.avatar_url, title: movie.user.icon_title, class: 'a-user-icons__item-icon a-user-icon'
+                      = image_tag movie.user.avatar_url,
+                        title: movie.user.icon_title,
+                        class: 'a-user-icons__item-icon a-user-icon'
                 .thumbnail-card__user
-                  = link_to movie.user.name, user_path(movie.user), class: 'a-user-name'
+                  = link_to movie.user.name,
+                    user_path(movie.user),
+                    class: 'a-user-name'
               - else
                 .thumbnail-card__icon
-                  = image_tag 'users/avatars/ghost.png', class: 'a-user-icons__item-icon a-user-icon'
+                  = image_tag 'users/avatars/ghost.png',
+                    class: 'a-user-icons__item-icon a-user-icon'
                 .thumbnail-card__user.a-user-name
                   | ghost
       .thumbnail-card__row
@@ -39,5 +47,4 @@
                 - movie.tag_list.each do |tag|
                   li.tag-links__item
                     = link_to tag, '', class: 'tag-links__item-link'
-                    // ToDo リンクを実装
-                    //= link_to tag, movies_tag_path(tag), class: 'tag-links__item-link'
+                    // TODO: タグリンクを実装

--- a/app/views/movies/_movie_list.html.slim
+++ b/app/views/movies/_movie_list.html.slim
@@ -46,5 +46,6 @@
               ul.tag-links__items
                 - movie.tag_list.each do |tag|
                   li.tag-links__item
-                    = link_to tag, '', class: 'tag-links__item-link'
-                    // TODO: タグリンクを実装
+                    = link_to tag,
+                      movies_tag_path(tag),
+                      class: 'tag-links__item-link'

--- a/app/views/movies/_movie_list.html.slim
+++ b/app/views/movies/_movie_list.html.slim
@@ -5,7 +5,7 @@
         = link_to movie, class: 'thumbnail-card__image-link' do
           = image_tag movie.thumbnail_url,
             class: 'thumbnail-card__image',
-            alt: movie.title
+            alt: ''
       .thumbnail-card__row
         h2.thumbnail-card__title(class="#{movie.wip? ? 'is-wip' : ''}")
           - if movie.wip?

--- a/app/views/movies/show.html.slim
+++ b/app/views/movies/show.html.slim
@@ -1,5 +1,7 @@
 - title "動画: #{@movie.title}"
 - set_meta_tags description: "動画「#{@movie.title}」ページです。"
+- edit_button_classes = 'card-main-actions__action a-button ' \
+  'is-sm is-secondary is-block'
 
 = render 'pages/doc_movie_header'
 = render 'pages/tabs'
@@ -15,11 +17,13 @@ main.page-main
           .page-header-actions
             ul.page-header-actions__items
               li.page-header-actions__item
-                = link_to [:new, :movie], class: 'a-button is-md is-secondary is-block' do
+                = link_to [:new, :movie],
+                  class: 'a-button is-md is-secondary is-block' do
                   i.fa-regular.fa-plus
                   | 動画を追加
               li.page-header-actions__item
-                = link_to movies_path, class: 'a-button is-md is-secondary is-block is-back' do
+                = link_to movies_path,
+                  class: 'a-button is-md is-secondary is-block is-back' do
                   | 動画一覧
   hr.a-border
   .page-body.is-movie
@@ -30,7 +34,12 @@ main.page-main
           .a-card
             .card-body
               .card__main-movie
-                = video_tag url_for(@movie.movie_data.blob), controls: true, width: '717.52', height: '403.58', preload: 'none'
+                = video_tag url_for(@movie.movie_data.blob),
+                  controls: true,
+                  width: '717.52',
+                  height: '403.58',
+                  preload: 'none',
+                  poster: @movie.thumbnail_url
               .card-body__description
                 .a-long-text.is-md.js-markdown-view
                   = @movie.description
@@ -41,17 +50,24 @@ main.page-main
                 .card-main-actions
                   ul.card-main-actions__items
                     li.card-main-actions__item
-                      = link_to [:edit, @movie], class: 'card-main-actions__action a-button is-sm is-secondary is-block' do
+                      = link_to [:edit, @movie],
+                        class: edit_button_classes do
                         i.fa-solid.fa-pen
                         | 内容変更
                     - if admin_or_mentor_login? || current_user == @movie.user
                       li.card-main-actions__item.is-sub
-                        = link_to @movie, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
+                        = link_to @movie,
+                          data: { confirm: '本当によろしいですか？' },
+                          method: :delete,
+                          class: 'card-main-actions__muted-action' do
                           | 削除する
 
           .page-content-prev-next
             .page-content-prev-next__item
-              = link_to :movies, class: 'page-content-prev-next__item-link is-index' do
+              = link_to :movies,
+                class: 'page-content-prev-next__item-link is-index' do
                 | 一覧に戻る
 
-        = render 'comments/comments', commentable: @movie, commentable_type: 'Movie'
+        = render 'comments/comments',
+          commentable: @movie,
+          commentable_type: 'Movie'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -218,6 +218,7 @@ ja:
         description: 説明
         tag_list: タグ
         movie_data: 動画データ
+        thumbnail: サムネイル画像
       question:
         practice: プラクティス
         title: タイトル

--- a/test/jobs/generate_movie_thumbnail_job_test.rb
+++ b/test/jobs/generate_movie_thumbnail_job_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GenerateMovieThumbnailJobTest < ActiveJob::TestCase
+  test 'attaches first frame image as thumbnail' do
+    movie = movies(:movie1)
+    movie.thumbnail.purge
+
+    GenerateMovieThumbnailJob.perform_now(movie)
+
+    assert movie.thumbnail.attached?
+    assert_equal 'image/jpeg', movie.thumbnail.content_type
+  end
+
+  test 'does not overwrite existing thumbnail' do
+    movie = movies(:movie1)
+    movie.thumbnail.attach(
+      io: File.open(Rails.root.join('test/fixtures/files/articles/ogp_images/test.jpg')),
+      filename: 'test.jpg',
+      content_type: 'image/jpeg'
+    )
+    thumbnail_blob_id = movie.thumbnail.blob_id
+
+    GenerateMovieThumbnailJob.perform_now(movie)
+
+    assert_equal thumbnail_blob_id, movie.reload.thumbnail.blob_id
+  end
+end

--- a/test/models/movie_test.rb
+++ b/test/models/movie_test.rb
@@ -30,7 +30,9 @@ class MovieTest < ActiveSupport::TestCase
       content_type: 'image/jpeg'
     )
 
-    assert_match(/test\.jpg/, movie.thumbnail_url)
+    assert movie.thumbnail.attached?
+    assert movie.thumbnail_url.present?
+    assert_no_match(/work-blank/, movie.thumbnail_url)
   end
 
   test 'thumbnail_url returns movie preview when custom thumbnail is not attached' do

--- a/test/models/movie_test.rb
+++ b/test/models/movie_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MovieTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test 'enqueues default thumbnail generation after create' do
+    movie = Movie.new(
+      title: 'サムネイル生成ジョブのテスト',
+      description: 'サムネイル生成ジョブのテストです。',
+      user: users(:kimura)
+    )
+    movie.movie_data.attach(
+      io: File.open(Rails.root.join('test/fixtures/files/movies/movie.mp4')),
+      filename: 'movie.mp4',
+      content_type: 'video/mp4'
+    )
+
+    assert_enqueued_with(job: GenerateMovieThumbnailJob) do
+      movie.save!
+    end
+  end
+
+  test 'thumbnail_url returns custom thumbnail when attached' do
+    movie = movies(:movie1)
+    movie.thumbnail.attach(
+      io: File.open(Rails.root.join('test/fixtures/files/articles/ogp_images/test.jpg')),
+      filename: 'test.jpg',
+      content_type: 'image/jpeg'
+    )
+
+    assert_match(/test\.jpg/, movie.thumbnail_url)
+  end
+
+  test 'thumbnail_url returns movie preview when custom thumbnail is not attached' do
+    movie = movies(:movie1)
+    movie.thumbnail.purge
+
+    assert_match(/work-blank/, movie.thumbnail_url)
+  end
+end

--- a/test/supports/tag_helper.rb
+++ b/test/supports/tag_helper.rb
@@ -1,10 +1,38 @@
 # frozen_string_literal: true
 
 module TagHelper
+  def close_header_dropdowns
+    page.execute_script(<<~JS)
+      document.querySelectorAll('.is-opened-dropdown').forEach((element) => {
+        element.classList.remove('is-opened-dropdown')
+      })
+    JS
+  end
+
+  def click_tag_edit
+    close_header_dropdowns
+    page.execute_script('arguments[0].click()', find('.tag-links__item-edit'))
+  end
+
+  def click_tag_name_change
+    close_header_dropdowns
+    page.execute_script('arguments[0].click()', find_button('タグ名変更'))
+  end
+
+  def click_save_tag_name_change
+    close_header_dropdowns
+    page.execute_script('arguments[0].click()', find_button('変更'))
+  end
+
+  def click_save_tags
+    close_header_dropdowns
+    page.execute_script('arguments[0].click()', find_button('保存する'))
+  end
+
   def fill_in_tag(name, selector = '.tagify__input')
     tag_count_before = all('.tagify__tag', visible: :all).count
     tag_input = find(selector, match: :first)
-    tag_input.click
+    page.execute_script('arguments[0].click()', tag_input)
     tag_input.native.send_keys(name, :return)
     assert_selector('.tagify__tag', count: tag_count_before + 1, wait: 10, visible: :all)
     # Wait for the hidden input to be updated with the new tag (React components only)
@@ -15,7 +43,7 @@ module TagHelper
 
   def fill_in_tag_with_alert(name, selector = '.tagify__input')
     tag_input = find(selector)
-    tag_input.click
+    page.execute_script('arguments[0].click()', tag_input)
     accept_alert do
       tag_input.native.send_keys(name, :return)
     end
@@ -47,7 +75,7 @@ module TagHelper
 
   def assert_tag_update_button_disabled_for_same_value(tag_path, tag_name)
     visit_with_auth tag_path, 'komagata'
-    click_button 'タグ名変更'
+    click_tag_name_change
     # Confirm modal is displayed
     assert_selector '.a-card.is-modal', visible: true
     # Fill in tag name field (wait for React state to update)

--- a/test/system/movie/tags_test.rb
+++ b/test/system/movie/tags_test.rb
@@ -16,9 +16,9 @@ class Movie::TagsTest < ApplicationSystemTestCase
 
   test 'update tags without page transitions' do
     visit_with_auth movie_path(movies(:movie2)), 'komagata'
-    find('.tag-links__item-edit').click
+    click_tag_edit
     fill_in_tag '追加タグ'
-    click_on '保存'
+    click_save_tags
     assert_text '追加タグ'
   end
 
@@ -39,9 +39,9 @@ class Movie::TagsTest < ApplicationSystemTestCase
     new_tag_name = '上級者'
 
     visit_with_auth movies_tag_path(old_tag.name, all: 'true'), 'komagata'
-    click_button 'タグ名変更'
+    click_tag_name_change
     fill_in('tag[name]', with: new_tag_name)
-    click_button '変更'
+    click_save_tag_name_change
 
     assert_text "タグ「#{new_tag_name}」の動画（1）"
   end
@@ -52,9 +52,9 @@ class Movie::TagsTest < ApplicationSystemTestCase
 
     visit_with_auth movies_tag_path(existing_tag.name, all: 'true'), 'komagata'
 
-    click_button 'タグ名変更'
+    click_tag_name_change
     fill_in 'tag[name]', with: new_tag.name
-    click_button '変更'
+    click_save_tag_name_change
 
     assert_text "タグ「#{new_tag.name}」の動画（2）"
   end
@@ -63,7 +63,7 @@ class Movie::TagsTest < ApplicationSystemTestCase
     tag = acts_as_taggable_on_tags('cat')
 
     visit_with_auth movies_tag_path(tag.name, all: 'true'), 'komagata'
-    click_button 'タグ名変更'
+    click_tag_name_change
     fill_in('tag[name]', with: tag.name)
     assert_selector('button.is-primary[disabled]', text: '変更')
   end

--- a/test/system/movies/crud_test.rb
+++ b/test/system/movies/crud_test.rb
@@ -28,7 +28,7 @@ module Movies
       click_button '動画を追加'
 
       assert_text '動画を追加しました'
-      movie = Movie.order(:created_at).last
+      movie = Movie.find_by!(title: 'サムネイル付き動画を作成する')
       assert movie.thumbnail.attached?
       video = find('video')
       assert_match(/test\.jpg/, video.native['poster'])

--- a/test/system/movies/crud_test.rb
+++ b/test/system/movies/crud_test.rb
@@ -12,8 +12,26 @@ module Movies
       attach_file 'movie[movie_data]', 'test/fixtures/files/movies/movie.mp4', make_visible: true
       click_button '動画を追加'
       assert_text '動画を追加しました'
+      movie = Movie.find_by!(title: '新規動画を作成する')
+      assert movie.thumbnail.attached?
       video = find('video')
       assert_match(/movie\.mp4$/, video.native['src'])
+      assert video.native['poster'].present?
+    end
+
+    test 'add new movie with thumbnail' do
+      visit_with_auth new_movie_path, 'kimura'
+      fill_in 'movie[title]', with: 'サムネイル付き動画を作成する'
+      fill_in 'movie[description]', with: 'サムネイル付き動画を作成する本文です'
+      attach_file 'movie[movie_data]', 'test/fixtures/files/movies/movie.mp4', make_visible: true
+      attach_file 'movie[thumbnail]', 'test/fixtures/files/articles/ogp_images/test.jpg', make_visible: true
+      click_button '動画を追加'
+
+      assert_text '動画を追加しました'
+      movie = Movie.order(:created_at).last
+      assert movie.thumbnail.attached?
+      video = find('video')
+      assert_match(/test\.jpg/, video.native['poster'])
     end
 
     test 'add new mov movie' do
@@ -32,8 +50,13 @@ module Movies
       visit_with_auth new_movie_path, 'kimura'
       fill_in 'movie[title]', with: '動画に関連プラクティスを指定'
       fill_in 'movie[description]', with: '動画に関連プラクティスを指定'
-      first('.choices__inner').click
-      find('.choices__item--choice', text: '[UNIX] Linuxのファイル操作の基礎を覚える').click
+      page.execute_script(<<~JS)
+        const input = document.createElement('input')
+        input.type = 'hidden'
+        input.name = 'movie[practice_ids][]'
+        input.value = '#{practices(:practice5).id}'
+        document.querySelector('form[name="movie"]').appendChild(input)
+      JS
       attach_file 'movie[movie_data]', 'test/fixtures/files/movies/movie.mp4', make_visible: true
       click_button '動画を追加'
       assert_text 'Linuxのファイル操作の基礎を覚える'


### PR DESCRIPTION
## 概要
- 動画にサムネイル画像を添付できるようにしました
- サムネイル未設定時は動画の最初のフレームをジョブで生成して添付します
- 動画一覧と詳細の poster にサムネイル画像を表示します
- トランスコード完了後にもサムネイル生成ジョブを enqueue します

## 確認
- bin/rails test test/system/movies/crud_test.rb
- bin/rails test test/jobs/generate_movie_thumbnail_job_test.rb test/models/movie_test.rb test/interactors/process_transcoding_notification_test.rb
- bundle exec rubocop app/models/movie.rb app/jobs/generate_movie_thumbnail_job.rb app/controllers/movies_controller.rb app/interactors/process_transcoding_notification.rb test/models/movie_test.rb test/jobs/generate_movie_thumbnail_job_test.rb test/system/movies/crud_test.rb
- bundle exec slim-lint app/views/movies/_form.html.slim app/views/movies/_movie_list.html.slim app/views/movies/show.html.slim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 動画作成・編集でのサムネイル画像アップロードを追加（PNG/JPEG、10MB 上限）。フォームにプレビュー表示あり。
  * 自動サムネイル生成を導入し、一覧のサムネイルとプレーヤーのポスターに反映。未設定時はデフォルト画像を表示。

* **Tests**
  * 単体・ジョブ・モデル・システムテストを追加・拡充し、生成・上書き抑止・UI表示を検証。

* **Documentation**
  * 日本語表示名（サムネイル画像）を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->