### PR TITLE
プラクティスの難易度をアイコンで表示する

### DIFF
--- a/app/assets/stylesheets/application/blocks/practice/_category-practices-item.css
+++ b/app/assets/stylesheets/application/blocks/practice/_category-practices-item.css
@@ -151,39 +151,3 @@
 a.category-practices-item__title-link:hover .category-practices-item__title-link-label {
   text-decoration: underline;
 }
-
-.category-practices-item__learning-time {
-  font-size: .75rem;
-  line-height: 1.4;
-  color: var(--muted-text);
-}
-
-@media (width >= 48em) {
-  .category-practices-item__learning-time {
-    margin-top: -.25rem;
-  }
-}
-
-@media (width <= 47.9375em) {
-  .category-practices-item__learning-time {
-    margin-top: .5rem;
-  }
-}
-
-.category-practices-item__practice-difficulty {
-  font-size: .75rem;
-  line-height: 1.4;
-  color: var(--muted-text);
-}
-
-@media (min-width: 48em) {
-  .category-practices-item__practice-difficulty {
-    margin-top: -.25rem;
-  }
-}
-
-@media (max-width: 47.9375em) {
-  .category-practices-item__practice-difficulty {
-    margin-top: .5rem;
-  }
-}

--- a/app/assets/stylesheets/application/blocks/practice/_category-practices-item.css
+++ b/app/assets/stylesheets/application/blocks/practice/_category-practices-item.css
@@ -169,3 +169,21 @@ a.category-practices-item__title-link:hover .category-practices-item__title-link
     margin-top: .5rem;
   }
 }
+
+.category-practices-item__practice-difficulty {
+  font-size: .75rem;
+  line-height: 1.4;
+  color: var(--muted-text);
+}
+
+@media (min-width: 48em) {
+  .category-practices-item__practice-difficulty {
+    margin-top: -.25rem;
+  }
+}
+
+@media (max-width: 47.9375em) {
+  .category-practices-item__practice-difficulty {
+    margin-top: .5rem;
+  }
+}

--- a/app/helpers/practices_helper.rb
+++ b/app/helpers/practices_helper.rb
@@ -25,4 +25,16 @@ module PracticesHelper
       twitter: { image: image_url, url: request.url }
     )
   end
+
+  def difficulty_icon(minutes)
+    return '' if minutes.nil?
+
+    case minutes
+    when ..300 then '🔥' # 5時間以下
+    when ..600 then '🔥🔥' # 10時間以下
+    when ..900 then '🔥🔥🔥' # 15時間以下
+    when ..1200 then '🔥🔥🔥🔥' # 20時間以下
+    else '🔥🔥🔥🔥🔥' # 20時間超
+    end
+  end
 end

--- a/app/helpers/practices_helper.rb
+++ b/app/helpers/practices_helper.rb
@@ -27,9 +27,7 @@ module PracticesHelper
   end
 
   def difficulty_icon(minutes)
-    return '' if minutes.nil?
-
-    case minutes
+    case minutes.to_i # nilの場合は0として扱う（nil.to_i == 0）
     when ..300 then '🔥' # 5時間以下
     when ..600 then '🔥🔥' # 10時間以下
     when ..900 then '🔥🔥🔥' # 15時間以下

--- a/app/helpers/practices_helper.rb
+++ b/app/helpers/practices_helper.rb
@@ -27,7 +27,9 @@ module PracticesHelper
   end
 
   def difficulty_icon(minutes)
-    case minutes.to_i # nilの場合は0として扱う（nil.to_i == 0）
+    case minutes
+    when nil then ''
+    when 0 then 'データ収集中'
     when ..300 then '🔥' # 5時間以下
     when ..600 then '🔥🔥' # 10時間以下
     when ..900 then '🔥🔥🔥' # 15時間以下

--- a/app/views/courses/practices/_courses_practice.html.slim
+++ b/app/views/courses/practices/_courses_practice.html.slim
@@ -21,11 +21,30 @@
 
   - learning_statistic = practice.learning_minute_statistic
   - if learning_statistic.present?
-    .category-practices-item__practice-difficulty
-      | 難易度: #{difficulty_icon(learning_statistic.median)}
-    .category-practices-item__learning-time.is-only-mentor
-      | 所要時間の目安: #{convert_to_hour_minute(learning_statistic.median)}
-      |  （平均: #{convert_to_hour_minute(learning_statistic.average)}）
+    .card-list-item__rows
+      .card-list-item__row
+        .card-list-item-meta
+          .card-list-item-meta__items
+            .card-list-item-meta__item
+              .a-meta
+                .a-meta__label
+                  | 難易度
+                .a-meta__value
+                  = difficulty_icon(learning_statistic.median)
+            - if current_user.mentor? || current_user.admin?
+              .card-list-item-meta__item.is-only-mentor
+                .a-meta
+                  .a-meta__label
+                    | 所要時間の目安
+                  .a-meta__value
+                    = convert_to_hour_minute(learning_statistic.median)
+              .card-list-item-meta__item.is-only-mentor
+                .a-meta
+                  .a-meta__label
+                    | （平均
+                  .a-meta__value
+                    = convert_to_hour_minute(learning_statistic.average)
+                    | ）
   - if practice.started_or_submitted_students.present?
     .a-user-icons
       .a-user-icons__items

--- a/app/views/courses/practices/_courses_practice.html.slim
+++ b/app/views/courses/practices/_courses_practice.html.slim
@@ -19,11 +19,13 @@
         href="#{practice_path(practice.id)}#learning-Status")
           = t("activerecord.enums.learning.status.#{learning_status}")
 
-  .category-practices-item__learning-time.is-only-mentor
-    - unless practice.learning_minute_statistic.nil?
-      - learning_minute_statistic = practice.learning_minute_statistic
-      | 所要時間の目安: #{convert_to_hour_minute(learning_minute_statistic.median)}
-      |  （平均: #{convert_to_hour_minute(learning_minute_statistic.average)}）
+  - learning_statistic = practice.learning_minute_statistic
+  - if learning_statistic.present?
+    .category-practices-item__practice-difficulty
+      | 難易度: #{difficulty_icon(learning_statistic.median)}
+    .category-practices-item__learning-time.is-only-mentor
+      | 所要時間の目安: #{convert_to_hour_minute(learning_statistic.median)}
+      |  （平均: #{convert_to_hour_minute(learning_statistic.average)}）
   - if practice.started_or_submitted_students.present?
     .a-user-icons
       .a-user-icons__items

--- a/test/fixtures/learning_minute_statistics.yml
+++ b/test/fixtures/learning_minute_statistics.yml
@@ -1,0 +1,4 @@
+learning_minute_statistic1:
+  average: 30
+  median: 30
+  practice: practice1

--- a/test/helpers/practices_helper_test.rb
+++ b/test/helpers/practices_helper_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PracticesHelperTest < ActionView::TestCase
+  test 'difficulty_icon' do
+    assert_equal '', difficulty_icon(nil)
+    assert_equal '🔥', difficulty_icon(0)
+    assert_equal '🔥', difficulty_icon(300)
+    assert_equal '🔥🔥', difficulty_icon(301)
+    assert_equal '🔥🔥', difficulty_icon(600)
+    assert_equal '🔥🔥🔥', difficulty_icon(601)
+    assert_equal '🔥🔥🔥', difficulty_icon(900)
+    assert_equal '🔥🔥🔥🔥', difficulty_icon(901)
+    assert_equal '🔥🔥🔥🔥', difficulty_icon(1200)
+    assert_equal '🔥🔥🔥🔥🔥', difficulty_icon(1201)
+  end
+end

--- a/test/helpers/practices_helper_test.rb
+++ b/test/helpers/practices_helper_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 
 class PracticesHelperTest < ActionView::TestCase
   test 'difficulty_icon' do
-    assert_equal '', difficulty_icon(nil)
     assert_equal '🔥', difficulty_icon(0)
     assert_equal '🔥', difficulty_icon(300)
     assert_equal '🔥🔥', difficulty_icon(301)

--- a/test/helpers/practices_helper_test.rb
+++ b/test/helpers/practices_helper_test.rb
@@ -4,7 +4,9 @@ require 'test_helper'
 
 class PracticesHelperTest < ActionView::TestCase
   test 'difficulty_icon' do
-    assert_equal '🔥', difficulty_icon(0)
+    assert_equal '', difficulty_icon(nil)
+    assert_equal 'データ収集中', difficulty_icon(0)
+    assert_equal '🔥', difficulty_icon(1)
     assert_equal '🔥', difficulty_icon(300)
     assert_equal '🔥🔥', difficulty_icon(301)
     assert_equal '🔥🔥', difficulty_icon(600)

--- a/test/system/course/practices_test.rb
+++ b/test/system/course/practices_test.rb
@@ -45,23 +45,23 @@ class Course::PracticesTest < ApplicationSystemTestCase
 
   test 'difficulty icon is displayed for all users' do
     visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
-    assert_selector '.category-practices-item__practice-difficulty', text: '難易度:'
+    assert_selector '.card-list-item-meta__item .a-meta__label', text: '難易度'
     logout
     visit_with_auth course_practices_path(courses(:course1).id), 'komagata'
-    assert_selector '.category-practices-item__practice-difficulty', text: '難易度:'
+    assert_selector '.card-list-item-meta__item .a-meta__label', text: '難易度'
     logout
     visit_with_auth course_practices_path(courses(:course1).id), 'mentormentaro'
-    assert_selector '.category-practices-item__practice-difficulty', text: '難易度:'
+    assert_selector '.card-list-item-meta__item .a-meta__label', text: '難易度'
   end
 
   test 'learning time is displayed only for admin and mentor' do
     visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
-    assert_no_selector '.category-practices-item__learning-time.is-only-mentor', text: '所要時間の目安:'
+    assert_no_selector '.card-list-item-meta__item.is-only-mentor .a-meta__label', text: '所要時間の目安'
     logout
     visit_with_auth course_practices_path(courses(:course1).id), 'komagata'
-    assert_selector '.category-practices-item__learning-time.is-only-mentor', text: '所要時間の目安:'
+    assert_selector '.card-list-item-meta__item.is-only-mentor .a-meta__label', text: '所要時間の目安'
     logout
     visit_with_auth course_practices_path(courses(:course1).id), 'mentormentaro'
-    assert_selector '.category-practices-item__learning-time.is-only-mentor', text: '所要時間の目安:'
+    assert_selector '.card-list-item-meta__item.is-only-mentor .a-meta__label', text: '所要時間の目安'
   end
 end

--- a/test/system/course/practices_test.rb
+++ b/test/system/course/practices_test.rb
@@ -42,4 +42,26 @@ class Course::PracticesTest < ApplicationSystemTestCase
       assert_text 'OS X Mountain Lionをクリーンインストールする'
     end
   end
+
+  test 'difficulty icon is displayed for all users' do
+    visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
+    assert_selector '.category-practices-item__practice-difficulty', text: '難易度:'
+    logout
+    visit_with_auth course_practices_path(courses(:course1).id), 'komagata'
+    assert_selector '.category-practices-item__practice-difficulty', text: '難易度:'
+    logout
+    visit_with_auth course_practices_path(courses(:course1).id), 'mentormentaro'
+    assert_selector '.category-practices-item__practice-difficulty', text: '難易度:'
+  end
+
+  test 'learning time is displayed only for admin and mentor' do
+    visit_with_auth course_practices_path(courses(:course1).id), 'kimura'
+    assert_no_selector '.category-practices-item__learning-time.is-only-mentor', text: '所要時間の目安:'
+    logout
+    visit_with_auth course_practices_path(courses(:course1).id), 'komagata'
+    assert_selector '.category-practices-item__learning-time.is-only-mentor', text: '所要時間の目安:'
+    logout
+    visit_with_auth course_practices_path(courses(:course1).id), 'mentormentaro'
+    assert_selector '.category-practices-item__learning-time.is-only-mentor', text: '所要時間の目安:'
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Issue

- #9328

## 概要

プラクティスの難易度をアイコンで表示する

- 全ユーザに対して難易度を表示する
- 管理者、メンターのみ難易度 + 学習時間の統計情報を表示する
- 難易度のアイコン数はプラクティスの学習時間を元に以下のように表示する
    - 0時間: データ収集中
    - 1-5時間: 🔥
    - 6-10時間: 🔥🔥
    - 11-15時間: 🔥🔥🔥
    - 16-20時間: 🔥🔥🔥🔥
    - 21時間以上: 🔥🔥🔥🔥🔥
      
---

0時間時のアイコン表示は「🔥」から「データ収集中」に仕様変更になった
https://github.com/fjordllc/bootcamp/pull/9918#discussion_r3525853472

## 変更確認方法

### 事前準備

1. `feature/practice-difficulty-icon` ブランチをローカルに取り込む
2. `bundle exec rake bootcamp:statistics:save_learning_minute_statistics` を実行(難易度/学習時間の統計情報表示用のデータを用意)

### 管理者、メンター以外

1. `kimura` でログイン
2. プラクティス一覧(/courses/:id/practices)にアクセス
3. `OS X Mountain Lionをクリーンインストールする` のプラクティスで以下を確認
    - 「難易度: 🔥」の表示

### 管理者

1. `komagata` でログイン
2. プラクティス一覧(/courses/:id/practices)にアクセス
3. `OS X Mountain Lionをクリーンインストールする` のプラクティスで以下を確認
    - 「難易度: 🔥」の表示
    - 「所要時間の目安:◯時間(平均:◯時間ま◯分」の表示

### メンター

1. `mentormentaro` でログイン
2. プラクティス一覧(/courses/:id/practices)にアクセス
3. `OS X Mountain Lionをクリーンインストールする` のプラクティスで以下を確認
    - 「難易度: 🔥」の表示
    - 「所要時間の目安:◯時間(平均:◯時間ま◯分」の表示
 
## Screenshot

### 変更前

管理者、メンター以外

<img width="1684" height="460" alt="before_other" src="https://github.com/user-attachments/assets/884d85fc-9f73-4d2a-9cc8-576f8e6c2834" />

管理者

<img width="1682" height="333" alt="before_admin" src="https://github.com/user-attachments/assets/91c93806-a9df-4223-bad5-302a76cb4691" />

メンター

<img width="1681" height="334" alt="before_mentor" src="https://github.com/user-attachments/assets/30614b50-3d21-4f4e-b16b-a48bafff7604" />

### 変更後

管理者、メンター以外

<img width="1633" height="424" alt="after_other" src="https://github.com/user-attachments/assets/f4e55a12-0beb-4806-ae13-f79cba73c531" />

管理者

<img width="1632" height="426" alt="after_admin" src="https://github.com/user-attachments/assets/53743143-86a6-4d71-b422-fab3d9c910e2" />

メンター

<img width="1635" height="424" alt="after_mentor" src="https://github.com/user-attachments/assets/023361ca-4ee2-465c-b2c1-950c62bc5cf0" />

<!-- I want to review in Japanese. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 学習時間の統計に基づく難易度表示を追加しました。
  * 学生には難易度アイコンを表示します。
  * メンターには中央値と平均の学習時間（時間/分表記）を表示します。
  * 学習時間データがない場合は該当表示を抑制します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29123692856/artifacts/8239743192" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-9918-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
