### PR TITLE
Pageで二重定義されている関連づけされてる箇所を削除

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -12,7 +12,6 @@ class Page < ApplicationRecord
   belongs_to :user
   belongs_to :practice, optional: true, inverse_of: :pages
   belongs_to :last_updated_user, class_name: 'User', optional: true
-  has_many :watches, as: :watchable, dependent: :destroy
   validates :title, presence: true
   validates :body, presence: true
   validates :slug, length: { maximum: 200 }, format: { with: /\A[a-z][a-z0-9_-]*\z/ }, uniqueness: true, allow_nil: true


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9752

## 概要

PageモデルはWatchableモジュールをincludeしているのにも関わらず、
Pageモデルにwatchesに対するhas_manyが定義されていたため
こちらを削除しました。

## 変更確認方法

1. `chore/resolving-double-defined-association-in-the-Page`をローカルに取り込む
2. `http://localhost:3000/`にアクセスし、kimuraでログイン
3. [Docs](http://localhost:3000/pages) にアクセス
4. Docsを新たに作成し、自動でWatch中になっていることを確認する
<img width="833" height="572" alt="スクリーンショット 2026-04-17 103242" src="https://github.com/user-attachments/assets/27d8342c-36c1-4874-9403-408c75d46665" />

5. ダッシュボードへ移動し、[Watch中](http://localhost:3000/current_user/watches) から先ほど作成した記事が一覧に表示されているかを確認。
<img width="825" height="233" alt="スクリーンショット 2026-04-17 103256" src="https://github.com/user-attachments/assets/21de3c41-1d86-41d5-a065-2cebf07ba48f" />

6. 該当記事にアクセスし、Watch状態を外す
<img width="842" height="431" alt="スクリーンショット 2026-04-17 103305" src="https://github.com/user-attachments/assets/866393fa-835f-447f-a3f6-b239f30267c0" />

7. ダッシュボードへ移動し、[Watch中](http://localhost:3000/current_user/watches) から該当記事が消えていることを確認する。
<img width="833" height="339" alt="スクリーンショット 2026-04-17 103321" src="https://github.com/user-attachments/assets/f8001424-624d-4164-b735-bc7b0b49f841" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 内部モデルの関連付け宣言を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->