### PR TITLE
ユーザーAPIから必要な時だけemailを返すようにした

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -25,7 +25,12 @@ class API::UsersController < API::BaseController
       end
   end
 
-  def show; end
+  def show
+    # Doorkeeperで認証された本人の情報取得時のみemailを返す
+    @include_email = doorkeeper_token.present? &&
+                     @user.present? &&
+                     @user.id == doorkeeper_token.resource_owner_id
+  end
 
   def update
     if @user == current_user && @user.update(user_params)

--- a/app/views/api/products/not_responded/index.json.jbuilder
+++ b/app/views/api/products/not_responded/index.json.jbuilder
@@ -1,9 +1,0 @@
-json.products do
-  json.array! @products do |product|
-    json.partial! "api/products/product", product: product
-  end
-end
-json.total_pages 1
-json.latest_product_submitted_just_5days @latest_product_submitted_just_5days
-json.latest_product_submitted_just_6days @latest_product_submitted_just_6days
-json.latest_product_submitted_over_7days @latest_product_submitted_over_7days

--- a/app/views/api/users/_list_user.json.jbuilder
+++ b/app/views/api/users/_list_user.json.jbuilder
@@ -1,6 +1,6 @@
 user_course_practice = ActiveDecorator::Decorator.instance.decorate(UserCoursePractice.new(user))
 
-json.(user, :id, :login_name, :name, :description, :github_account, :twitter_account, :facebook_url, :blog_url, :job_seeker, :job, :os, :experiences, :email, :roles, :primary_role, :icon_title, :graduated_on, :joining_status)
+json.(user, :id, :login_name, :name, :description, :github_account, :twitter_account, :facebook_url, :blog_url, :job_seeker, :job, :os, :experiences, :roles, :primary_role, :icon_title, :graduated_on, :joining_status)
 json.tag_list user.tags.pluck(:name)
 json.url user_url(user)
 json.updated_at l(user.updated_at)

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -1,4 +1,4 @@
-columns = %i(id login_name email long_name url roles primary_role icon_title joining_status)
+columns = %i(id login_name long_name url roles primary_role icon_title joining_status)
 columns << :mentor_memo if admin_or_mentor_login?
 json.(user, *columns)
 json.avatar_url user.avatar_url

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -1,1 +1,2 @@
 json.partial! "api/users/user", user: @user
+json.email @user.email if @include_email

--- a/test/integration/api/users_test.rb
+++ b/test/integration/api/users_test.rb
@@ -161,4 +161,54 @@ class API::UsersTest < ActionDispatch::IntegrationTest
     response_body = JSON.parse(@response.body)
     assert_equal 'invalid_scope', response_body['error']
   end
+
+  test 'returns email for resource owner with doorkeeper token' do
+    user = users(:komagata)
+
+    doorkeeper_token = Doorkeeper::AccessToken.create!(
+      application_id: @application.id,
+      resource_owner_id: user.id,
+      scopes: 'read'
+    )
+
+    get api_user_path(id: 'show'),
+        headers: { Authorization: "Bearer #{doorkeeper_token.token}", Accept: 'application/json' }
+    assert_response :ok
+
+    response_body = JSON.parse(@response.body)
+
+    assert_includes response_body.keys, 'email'
+    assert_equal user.email, response_body['email']
+  end
+
+  test 'does not return email for another user even with doorkeeper token' do
+    user = users(:komagata)
+    other_user = users(:kimura)
+    doorkeeper_token = Doorkeeper::AccessToken.create!(
+      application_id: @application.id,
+      resource_owner_id: user.id,
+      scopes: 'read'
+    )
+
+    get api_user_path(other_user),
+        headers: { Authorization: "Bearer #{doorkeeper_token.token}", Accept: 'application/json' }
+    assert_response :ok
+
+    response_body = JSON.parse(@response.body)
+    assert_not_includes response_body.keys, 'email'
+  end
+
+  test 'does not return email when authenticated without doorkeeper token' do
+    user = users(:hajime)
+    token = create_token(user.login_name, 'testtest')
+
+    get api_user_path(user),
+        headers: { Authorization: "Bearer #{token}", Accept: 'application/json' }
+    assert_response :ok
+
+    response_body = JSON.parse(@response.body)
+
+    authorized_keys = %w[id login_name long_name url roles primary_role joining_status icon_title adviser avatar_url]
+    assert_equal authorized_keys.sort, response_body.keys.sort
+  end
 end

--- a/test/integration/api/users_test.rb
+++ b/test/integration/api/users_test.rb
@@ -21,6 +21,11 @@ class API::UsersTest < ActionDispatch::IntegrationTest
     get api_users_path(format: :json),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
+    # emailはレスポンスに含まないことを確認
+    response_body = JSON.parse(@response.body)
+    response_body['users'].each do |user|
+      assert_not_includes user.keys, 'email'
+    end
   end
 
   test 'GET /api/users/1234.json as admin' do


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
- ユーザー情報を返却するAPIから`email`を削除
    - Doorkeeper連携時のみ`email`を返却する
        - DoorKeeperアクセストークンがある かつ トークン所有者自身の情報を返す時のみ
- 不要なパーシャルも併せて整理した

## 変更確認方法

1. `bug/delete-email-from-user-jbuilder` をローカルに取り込む

2. Doorkeeper の検証環境を準備
- [Develop環境でのDoorkeeper(OAuth2)検証手順](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDoorkeeper%28OAuth2%29%E6%A4%9C%E8%A8%BC%E6%89%8B%E9%A0%86) の[セットアップ](https://github.com/fjordllc/bootcamp/wiki/Develop%E7%92%B0%E5%A2%83%E3%81%A7%E3%81%AEDoorkeeper%28OAuth2%29%E6%A4%9C%E8%A8%BC%E6%89%8B%E9%A0%86#%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97) の章を参考にDoorkeeperアクセストークンを取得しておく

3. 各APIの検証
  - ユーザー情報
    - [x] Doorkeeperのトークンで自分の情報を取得した場合のみ`email`が含まれること
    - [x] 上記以外では`email`が含まれないこと
  - ユーザー一覧情報
    - [x] `email`が含まれないこと
  - その他API
    - ユーザー情報がパーシャルとして含まれる場合でも、`email`が含まれないこと
- ユーザー一覧情報
    - [x] email が含まれないこと

※ 詳細は別途ご案内いたします。

<!-- I want to review in Japanese. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * APIユーザーエンドポイントの認証状況に応じたメールアドレス表示制御機能を追加しました。ユーザー一覧表示ではメールアドレスを非表示にし、認証済みユーザーが本人データを取得する場合のみメールアドレスを表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->