### PR TITLE
ユーザーのイベント一覧に主催イベントも表示されるよう修正

### DIFF
--- a/app/controllers/users/events_controller.rb
+++ b/app/controllers/users/events_controller.rb
@@ -4,7 +4,7 @@ class Users::EventsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
     @events = Event.where(id: @user.participate_events.select(:id))
-                   .or(Event.where(user_id: current_user.id))
+                   .or(Event.where(user_id: @user.id))
                    .includes(:comments, :users)
                    .order(start_at: :desc)
                    .page(params[:page])

--- a/app/controllers/users/events_controller.rb
+++ b/app/controllers/users/events_controller.rb
@@ -3,7 +3,8 @@
 class Users::EventsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @events = @user.participate_events
+    @events = Event.where(id: @user.participate_events.select(:id))
+                   .or(Event.where(user_id: current_user.id))
                    .includes(:comments, :users)
                    .order(start_at: :desc)
                    .page(params[:page])

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -20,7 +20,7 @@ event2:
   end_at: <%= Time.current.next_year %>
   open_start_at: <%= Time.current %>
   open_end_at: <%= Time.current.next_year %>
-  user: kimura
+  user: komagata
 
 event3:
   title: "募集期間中のイベント(補欠者あり)"
@@ -175,10 +175,10 @@ event33:
   description: "kimura専用イベント"
   location: "FJORDオフィス"
   capacity: 10
-  start_at: 2017-04-03 00:00:00
-  end_at: 2017-4-3 12:00:00
-  open_start_at: 2017-3-25 9:00
-  open_end_at: 2017-4-01 9:00
+  start_at: 2030-01-01 00:00:00
+  end_at: 2030-01-01 12:00:00
+  open_start_at: 2029-12-01 09:00:00
+  open_end_at: 2029-12-31 09:00:00
   user: kimura
 
 event34:

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -42,7 +42,7 @@ event4:
   end_at: <%= Time.current.next_year %>
   open_start_at: <%= Time.current.next_year - 1.day %>
   open_end_at: <%= Time.current.next_year %>
-  user: kimura
+  user: komagata
 
 event5:
   title: "募集期間後のイベント"
@@ -53,7 +53,7 @@ event5:
   end_at: <%= Time.current.next_year %>
   open_start_at: <%= Time.current.yesterday %>
   open_end_at: <%= Time.current.yesterday + 1.hour %>
-  user: kimura
+  user: komagata
 
 event6:
   title: "終了したイベント"
@@ -64,7 +64,7 @@ event6:
   end_at: 2019-12-17 12:00:00
   open_start_at: 2019-12-10 9:00
   open_end_at: 2019-12-16 9:00
-  user: kimura
+  user: komagata
 
 event7:
   title: "テストのイベント"
@@ -75,7 +75,7 @@ event7:
   end_at: 2019-12-17 12:00:00
   open_start_at: 2019-12-10 9:00
   open_end_at: 2019-12-16 9:00
-  user: kimura
+  user: komagata
 
 event8:
   title: "イベントの検索結果テスト用"
@@ -86,7 +86,7 @@ event8:
   end_at: 2018-5-20 12:00:00
   open_start_at: 2018-5-14 9:00
   open_end_at: 2018-5-20 9:00
-  user: kimura
+  user: komagata
 
 <% (9..26).each do |i| %>
 event<%= i %>:
@@ -100,7 +100,7 @@ event<%= i %>:
   open_end_at: <%= Time.zone.local(2018, 5, 20, 9).ago(i.days) %>
   created_at: <%= Time.zone.local(2018, 5, 14, 9).ago(i.days) %>
   updated_at: <%= Time.zone.local(2018, 5, 14, 9).ago(i.days) %>
-  user: kimura
+  user: komagata
 <% end %>
 
 event27:
@@ -112,7 +112,7 @@ event27:
   end_at: 2017-4-3 12:00:00
   open_start_at: 2017-3-25 9:00
   open_end_at: 2017-4-01 9:00
-  user: kimura
+  user: komagata
 
 event28:
   title: "直近イベントの表示テスト用(翌日)"
@@ -123,7 +123,7 @@ event28:
   end_at: 2017-4-4 13:00:00
   open_start_at: 2017-3-26 9:00
   open_end_at: 2017-4-02 9:00
-  user: kimura
+  user: komagata
 
 event29:
   title: "就職関係かつ直近イベントの表示テスト用"
@@ -135,7 +135,7 @@ event29:
   open_start_at: 2017-3-26 9:00
   open_end_at: 2017-4-02 9:00
   job_hunting: true
-  user: kimura
+  user: komagata
 
 event30:
   title: "未来のイベント(参加済)"
@@ -146,7 +146,7 @@ event30:
   end_at: 2024-03-26 12:00
   open_start_at: 2024-02-26 10:00
   open_end_at: 2024-03-26 09:00
-  user: kimura
+  user: komagata
 
 event31:
   title: "過去のイベント"
@@ -157,7 +157,7 @@ event31:
   end_at: 2024-03-24 12:00
   open_start_at: 2024-02-24 10:00
   open_end_at: 2024-03-24 09:00
-  user: kimura
+  user: komagata
 
 event32:
   title: "直近イベントの表示テスト用(明後日)"
@@ -175,10 +175,10 @@ event33:
   description: "kimura専用イベント"
   location: "FJORDオフィス"
   capacity: 10
-  start_at: 2030-01-01 00:00:00
-  end_at: 2030-01-01 12:00:00
-  open_start_at: 2029-12-01 09:00:00
-  open_end_at: 2029-12-31 09:00:00
+  start_at: 2017-04-03 00:00:00
+  end_at: 2017-4-3 12:00:00
+  open_start_at: 2017-3-25 9:00
+  open_end_at: 2017-4-01 9:00
   user: kimura
 
 event34:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9633

## 概要

`/users/{ID}/events` にはユーザーが参加した特別イベント一覧が表示されますが、
ここにユーザーが主催した特別イベントは一覧に含まれていなかったため
こちらを一覧に入れるよう修正しました。

## 変更確認方法

1. `feature/user-events-include-organized`をローカルに取り込む
2. 開発サーバーを起動
3. http://localhost:3000/ にアクセスし、`kimura` 等通常ユーザーでログイン。
4. ナビゲーションから「[イベント](http://localhost:3000/events)」をクリックし、イベントを新規作成する。
<img width="422" height="378" alt="スクリーンショット 2026-04-20 102845" src="https://github.com/user-attachments/assets/8c66ecce-b0dc-4e2f-bbd0-af9fe716455d" />

5. ヘッダーの「Me」をクリックし、メニュー内の「マイプロフィール」をクリック。
<img width="421" height="162" alt="スクリーンショット 2026-04-20 103808" src="https://github.com/user-attachments/assets/98dcdff8-4244-4650-b54e-622b9de1678f" />

6. バーを右にスクロールし、イベントタブをクリック。
<img width="421" height="105" alt="スクリーンショット 2026-04-20 103730" src="https://github.com/user-attachments/assets/7f03a122-646c-4774-be01-d4f58ba2769c" />

7. 主催イベントが一覧に追加されていることを確認。
<img width="419" height="326" alt="スクリーンショット 2026-04-20 104136" src="https://github.com/user-attachments/assets/eb0b322a-1e43-44e1-8ec4-442cfa9a0a85" />

## Screenshot

### 変更前
<img width="833" height="497" alt="スクリーンショット 2026-04-20 104123" src="https://github.com/user-attachments/assets/cf4f2737-21f2-4f3c-baec-b97093b68bfd" />

### 変更後
<img width="838" height="652" alt="スクリーンショット 2026-04-20 104136" src="https://github.com/user-attachments/assets/f7c232e6-d39f-4290-82bb-20980e5ca163" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ユーザーのイベント一覧表示を改善しました：参加中のイベントに加えて本人が作成したイベントも正しく表示され、並び順・ページネーションは維持されます。
* **テスト**
  * テスト用データを更新しました（イベントの所有者や日時の調整）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->