### PR TITLE
フッターにfjord-calendarへのリンクを追加した

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -86,6 +86,9 @@ footer.footer
             = link_to 'https://x.com/fjordbootcamp', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | FBCのXアカウント
           li.footer-nav__item
+            = link_to 'https://fjord-calendar.jp/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
+              | アドベントカレンダー
+          li.footer-nav__item
             = link_to '/articles.atom', class: 'a-button is-sm is-secondary is-icon', target: '_blank', rel: 'noopener', title: 'フィヨルドブートキャンプブログフィード' do
               i.fa-solid.fa-rss
       small.footer__copyright


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9726

## 概要

- フッターにFjord Calendarへのリンクを追加した

## 変更確認方法

1. {feature/add-fjord-calendar-link-to-footer}をローカルに取り込む
2. 任意のユーザーでログインする
3. フッターのリンク集の末尾に「アドベントカレンダー」と表示されていることを確認する
4. 「アドベントカレンダー」リンクをクリックして、新しいタブでfjord-calendar(https://fjord-calendar.jp/) が開くことを確認する

## Screenshot

### 変更前
<img width="1211" height="153" alt="image" src="https://github.com/user-attachments/assets/e6650d27-a914-4321-90b1-e39c7900f349" />

### 変更後
<img width="1208" height="158" alt="image" src="https://github.com/user-attachments/assets/0ee51103-0853-412d-a360-125007152454" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新機能
* フッターナビゲーションに「アドベントカレンダー」への新しいリンク項目を追加しました。外部リンクとして新しいタブで開き、ユーザーが関連コンテンツに簡単にアクセスできるようになります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->