### PR TITLE
ピヨルドのレポート応答をTool callingに移行（[NO_QUESTION]マーカー方式を廃止）

### DIFF
--- a/app/jobs/pjord_report_comment_job.rb
+++ b/app/jobs/pjord_report_comment_job.rb
@@ -5,54 +5,46 @@ class PjordReportCommentJob < ApplicationJob
   discard_on ActiveJob::DeserializationError
 
   INSTRUCTIONS = <<~TEXT
-    日報（学習記録）を読んで、質問や困っている内容があればアドバイスしてください。
-    - 日報に質問的な内容や困っている記述がない場合は、他に一切何も書かず `[NO_QUESTION]` という文字列だけを返してください。挨拶・感想・「質問はありません」等の説明も書かないでください。
-    - 質問や困りごとがある場合のみ、通常のコメント（アドバイス）を返してください。その際、コメント本文に「質問なし」「質問はありません」「質問は見当たりません」等の、質問の有無に言及するメタな文言は絶対に含めないでください。生徒宛のアドバイスだけを書いてください。
-    - 答えそのものを教えるのではなく、調べ方・ヒント・考え方をアドバイスする
-  TEXT
+    日報（学習記録）を読んで、応答内容を pjord_report_response_tool ツールを使って返してください。
 
-  NO_QUESTION_MARKER = '[NO_QUESTION]'
-  NO_QUESTION_PATTERNS = [
-    /\A\[?NO_QUESTION\]?\z/i,
-    /\A質問(?:的な内容|らしい内容|事項)?(?:は|も)?(?:特に)?(?:あり(?:ま)?せん|ないです|無いです|なし|見当たり(?:ま)?せん|見受けられ(?:ま)?せん)[。！!.\sねよな～っ]*\z/,
-    /\A日報(?:中|内|の中)?に(?:は)?質問.*?(?:あり(?:ま)?せん|ないです|無いです|なし|見当たり(?:ま)?せん)[。！!.\sねよな～っ]*\z/
-  ].freeze
+    - 日報に質問や困っている記述がない場合は、ツールを action="skip" で呼んでください。
+    - 質問や困りごとがある場合は、ツールを action="post" で呼び、advice にアドバイス本文（markdown形式、生徒宛）を渡してください。
+    - advice には「質問なし」「質問はありません」等のメタな文言は含めず、生徒宛のアドバイスだけを書いてください。
+    - 答えそのものを教えるのではなく、調べ方・ヒント・考え方をアドバイスしてください。
+    - 必要に応じて bootcamp_search_tool や user_info_tool で情報を集めたあと、最後に pjord_report_response_tool を呼んで応答を確定してください。
+  TEXT
 
   def perform(report_id:)
     report = Report.find_by(id: report_id)
     return if report.nil?
 
-    pjord = Pjord.user
-    return if pjord.nil?
+    pjord_user = Pjord.user
+    return if pjord_user.nil?
 
-    message = build_message(report)
-    context = build_context(report)
+    response_tool = PjordReportResponseTool.new
+    chat = Pjord.build_chat(
+      context: build_context(report),
+      instructions: INSTRUCTIONS,
+      extra_tools: [response_tool]
+    )
 
     begin
-      response = Pjord.respond(message: message, context: context, instructions: INSTRUCTIONS)
+      chat.ask(build_message(report))
     rescue StandardError => e
       Rails.logger.error("[PjordReportCommentJob] #{e.class}: #{e.message}")
       return
     end
 
-    return if response.blank?
-    return if no_question_response?(response)
+    return unless response_tool.post?
 
-    Comment.create!(user: pjord, commentable: report, description: response)
+    Comment.create!(user: pjord_user, commentable: report, description: response_tool.advice)
   end
 
   private
 
-  def no_question_response?(response)
-    stripped = response.strip
-    NO_QUESTION_PATTERNS.any? { |pattern| stripped.match?(pattern) }
-  end
-
   def build_message(report)
     <<~MESSAGE
-      以下の日報を読んで、質問や困っている内容があればアドバイスしてください。
-      質問的な内容がなければ `[NO_QUESTION]` とだけ返答してください。
-      コメントを書く場合は、質問の有無に言及するメタな文言（例:「質問なし」「質問はありません」）を本文に一切含めないでください。
+      以下の日報を読んで、pjord_report_response_tool で応答を返してください。
 
       ## 日報タイトル
       #{report.title}

--- a/app/jobs/pjord_report_comment_job.rb
+++ b/app/jobs/pjord_report_comment_job.rb
@@ -22,13 +22,13 @@ class PjordReportCommentJob < ApplicationJob
     return if pjord_user.nil?
 
     response_tool = PjordReportResponseTool.new
-    chat = Pjord.build_chat(
-      context: build_context(report),
-      instructions: INSTRUCTIONS,
-      extra_tools: [response_tool]
-    )
 
     begin
+      chat = Pjord.build_chat(
+        context: build_context(report),
+        instructions: INSTRUCTIONS,
+        extra_tools: [response_tool]
+      )
       chat.ask(build_message(report))
     rescue StandardError => e
       Rails.logger.error("[PjordReportCommentJob] #{e.class}: #{e.message}")

--- a/app/models/pjord.rb
+++ b/app/models/pjord.rb
@@ -32,12 +32,18 @@ class Pjord
     end
 
     def respond(message:, context: {}, instructions: nil)
+      chat = build_chat(context: context, instructions: instructions)
+      result = chat.ask(message).content
+      result.presence
+    end
+
+    def build_chat(context: {}, instructions: nil, extra_tools: [])
       chat = RubyLLM.chat(model: model_name)
       chat.with_instructions(system_prompt(context, instructions:))
       chat.with_tool(BootcampSearchTool)
       chat.with_tool(UserInfoTool)
-      result = chat.ask(message).content
-      result.presence
+      extra_tools.each { |tool| chat.with_tool(tool) }
+      chat
     end
 
     private

--- a/app/tools/pjord_report_response_tool.rb
+++ b/app/tools/pjord_report_response_tool.rb
@@ -6,13 +6,14 @@ class PjordReportResponseTool < RubyLLM::Tool
               '質問や困っている内容があり、アドバイスする場合は action="post" を指定し、advice にアドバイス本文を渡す。' \
               '質問や困っている内容がない場合は action="skip" を指定する（adviceは不要）。'
 
-  param :action,
-        type: :string,
-        desc: '"post"（アドバイスを投稿する）または "skip"（質問なしのため投稿しない）'
-  param :advice,
-        type: :string,
-        desc: 'action="post"のときのアドバイス本文（markdown形式、生徒宛）。skipのときは不要',
-        required: false
+  params do
+    string :action,
+           enum: %w[post skip],
+           description: '"post"（アドバイスを投稿する）または "skip"（質問なしのため投稿しない）'
+    string :advice,
+           required: false,
+           description: 'action="post"のときのアドバイス本文（markdown形式、生徒宛）。skipのときは不要'
+  end
 
   attr_reader :action, :advice
 

--- a/app/tools/pjord_report_response_tool.rb
+++ b/app/tools/pjord_report_response_tool.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class PjordReportResponseTool < RubyLLM::Tool
+  description '日報への応答を確定する。' \
+              'このツールを必ず最後に1回だけ呼ぶこと。' \
+              '質問や困っている内容があり、アドバイスする場合は action="post" を指定し、advice にアドバイス本文を渡す。' \
+              '質問や困っている内容がない場合は action="skip" を指定する（adviceは不要）。'
+
+  param :action,
+        type: :string,
+        desc: '"post"（アドバイスを投稿する）または "skip"（質問なしのため投稿しない）'
+  param :advice,
+        type: :string,
+        desc: 'action="post"のときのアドバイス本文（markdown形式、生徒宛）。skipのときは不要',
+        required: false
+
+  attr_reader :action, :advice
+
+  def execute(action:, advice: nil)
+    @action = action
+    @advice = advice
+    'OK'
+  end
+
+  def post?
+    action == 'post' && advice.present?
+  end
+end

--- a/app/tools/pjord_report_response_tool.rb
+++ b/app/tools/pjord_report_response_tool.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class PjordReportResponseTool < RubyLLM::Tool
+  ACTION_POST = 'post'
+  ACTION_SKIP = 'skip'
+  ACTIONS = [ACTION_POST, ACTION_SKIP].freeze
+
   description '日報への応答を確定する。' \
               'このツールを必ず最後に1回だけ呼ぶこと。' \
               '質問や困っている内容があり、アドバイスする場合は action="post" を指定し、advice にアドバイス本文を渡す。' \
@@ -8,7 +12,7 @@ class PjordReportResponseTool < RubyLLM::Tool
 
   params do
     string :action,
-           enum: %w[post skip],
+           enum: ACTIONS,
            description: '"post"（アドバイスを投稿する）または "skip"（質問なしのため投稿しない）'
     string :advice,
            required: false,
@@ -24,6 +28,6 @@ class PjordReportResponseTool < RubyLLM::Tool
   end
 
   def post?
-    action == 'post' && advice.present?
+    action == ACTION_POST && advice.present?
   end
 end

--- a/test/jobs/pjord_report_comment_job_test.rb
+++ b/test/jobs/pjord_report_comment_job_test.rb
@@ -104,6 +104,16 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'rescues errors from Pjord.build_chat (e.g. missing API key)' do
+    report = reports(:report1)
+
+    Pjord.stub(:build_chat, ->(**_) { raise StandardError, 'Missing configuration' }) do
+      assert_no_difference 'Comment.count' do
+        PjordReportCommentJob.perform_now(report_id: report.id)
+      end
+    end
+  end
+
   test 'includes context with location and sender' do
     report = reports(:report1)
 

--- a/test/jobs/pjord_report_comment_job_test.rb
+++ b/test/jobs/pjord_report_comment_job_test.rb
@@ -3,11 +3,32 @@
 require 'test_helper'
 
 class PjordReportCommentJobTest < ActiveJob::TestCase
-  test 'creates a comment by pjord when report has a question' do
+  class FakeChat
+    def initialize(tool, behavior)
+      @tool = tool
+      @behavior = behavior
+    end
+
+    def ask(_message)
+      @behavior.call(@tool)
+      Struct.new(:content).new(nil)
+    end
+  end
+
+  def stub_pjord_with(behavior, &block)
+    stub = lambda { |context:, instructions:, extra_tools:| # rubocop:disable Lint/UnusedBlockArgument
+      FakeChat.new(extra_tools.first, behavior)
+    }
+    Pjord.stub(:build_chat, stub, &block)
+  end
+
+  test 'creates a comment when tool is called with action=post' do
     report = reports(:report1)
     pjord = users(:pjord)
 
-    Pjord.stub(:respond, 'ヒントをあげるね！') do
+    behavior = ->(tool) { tool.execute(action: 'post', advice: 'ヒントをあげるね！') }
+
+    stub_pjord_with(behavior) do
       assert_difference 'Comment.count', 1 do
         PjordReportCommentJob.perform_now(report_id: report.id)
       end
@@ -19,46 +40,40 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     assert_equal 'ヒントをあげるね！', comment.description
   end
 
-  test 'does not create a comment when response is the no_question marker' do
+  test 'does not create a comment when tool is called with action=skip' do
     report = reports(:report1)
 
-    Pjord.stub(:respond, '[NO_QUESTION]') do
+    behavior = ->(tool) { tool.execute(action: 'skip') }
+
+    stub_pjord_with(behavior) do
       assert_no_difference 'Comment.count' do
         PjordReportCommentJob.perform_now(report_id: report.id)
       end
     end
   end
 
-  test 'does not create a comment for common "no question" paraphrases' do
+  test 'does not create a comment when tool is called with action=post but advice is blank' do
     report = reports(:report1)
 
-    [
-      '質問なし',
-      '質問はありません。',
-      '質問は特にありません',
-      '質問的な内容は見当たりません。',
-      '日報中に質問はないですね。',
-      '日報に質問はありません'
-    ].each do |phrase|
-      Pjord.stub(:respond, phrase) do
-        assert_no_difference 'Comment.count', "should skip: #{phrase}" do
-          PjordReportCommentJob.perform_now(report_id: report.id)
-        end
+    behavior = ->(tool) { tool.execute(action: 'post', advice: '') }
+
+    stub_pjord_with(behavior) do
+      assert_no_difference 'Comment.count' do
+        PjordReportCommentJob.perform_now(report_id: report.id)
       end
     end
   end
 
-  test 'creates a comment when response contains no_question_marker in middle of text' do
+  test 'does not create a comment when tool is never called' do
     report = reports(:report1)
-    pjord = users(:pjord)
 
-    Pjord.stub(:respond, 'この問題は質問なしでも解決できます。') do
-      assert_difference 'Comment.count', 1 do
+    behavior = ->(_tool) {}
+
+    stub_pjord_with(behavior) do
+      assert_no_difference 'Comment.count' do
         PjordReportCommentJob.perform_now(report_id: report.id)
       end
     end
-
-    assert_equal pjord, Comment.last.user
   end
 
   test 'does nothing when report is not found' do
@@ -77,21 +92,12 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'does nothing when response is blank' do
+  test 'rescues errors from chat.ask' do
     report = reports(:report1)
 
-    Pjord.stub(:respond, nil) do
-      assert_no_difference 'Comment.count' do
-        PjordReportCommentJob.perform_now(report_id: report.id)
-      end
-    end
-  end
+    behavior = ->(_tool) { raise StandardError, 'API error' }
 
-  test 'rescues errors from Pjord.respond' do
-    report = reports(:report1)
-    error_respond = ->(**_args) { raise StandardError, 'API error' }
-
-    Pjord.stub(:respond, error_respond) do
+    stub_pjord_with(behavior) do
       assert_no_difference 'Comment.count' do
         PjordReportCommentJob.perform_now(report_id: report.id)
       end
@@ -102,12 +108,12 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     report = reports(:report1)
 
     captured_context = nil
-    mock_respond = lambda { |message:, context:, instructions: nil| # rubocop:disable Lint/UnusedBlockArgument
+    stub = lambda { |context:, instructions:, extra_tools:| # rubocop:disable Lint/UnusedBlockArgument
       captured_context = context
-      '[NO_QUESTION]'
+      FakeChat.new(extra_tools.first, ->(tool) { tool.execute(action: 'skip') })
     }
 
-    Pjord.stub(:respond, mock_respond) do
+    Pjord.stub(:build_chat, stub) do
       PjordReportCommentJob.perform_now(report_id: report.id)
     end
 


### PR DESCRIPTION
## 概要

#9931 の根本的な修正。

これまで `[NO_QUESTION]` という文字列マーカーで「コメントしない」意図を表現し、正規表現でフィルタする方式を採っていたが、AIが以下のように予期しない形式で返すたびにフィルタを通り抜けてバグになる構造的な脆さがあった。

- `[NO_QUESTION]` （マーカーそのもの）
- `` `[NO_QUESTION]` `` （バッククォート付き ← 今回の#9931の原因）
- 「質問はありません」等のパラフレーズ（多数）

この方式自体を廃止し、RubyLLMの **Tool calling** で投稿判断を構造化する。

## 設計

新ツール `PjordReportResponseTool` を導入：

```ruby
class PjordReportResponseTool < RubyLLM::Tool
  param :action, desc: '"post" or "skip"'
  param :advice, desc: 'action="post"のときの本文', required: false
end
```

AIはレポートを読んだあと、必ずこのツールを `action: "post"` または `action: "skip"` で1回呼ぶ。`PjordReportCommentJob` はツールの呼び出し結果を読んで投稿判断する。

## 変更点

- `app/tools/pjord_report_response_tool.rb` 新設
- `app/models/pjord.rb` に `build_chat`（追加ツールを差し込めるchat builder）を公開
- `app/jobs/pjord_report_comment_job.rb` から文字列マーカー・正規表現フィルタを完全削除し、ツール呼び出し結果で判定
- テストを新APIに合わせて書き直し

## 利点

- AIの返答形式の揺れに強い（バッククォート、パラフレーズ等で壊れない）
- 投稿/スキップの意図が型として明示される
- プロンプトを将来変更してもパース層は壊れない

## 既存PRとの関係

- #9932 (main向けの暫定パッチ) → このPRがマージされたら不要なのでクローズ予定
- #9933 (production向けhotfix) → 即時リリース用なのでそのまま継続

## テスト

```
12 runs, 23 assertions, 0 failures, 0 errors, 0 skips
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * レポートのコメント生成フローを再設計し、外部ツールを通じた応答生成と投稿可否判定を導入してより柔軟かつ拡張しやすい仕組みにしました。

* **テスト**
  * 新フローに合わせてテストを更新し、チャット／ツールの挙動を模擬してコメント作成条件やエラー処理を検証するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->