### PR TITLE
refactor: GenerateMovieThumbnailJob のエラーハンドリングを retry_on に置き換え

### DIFF
--- a/app/jobs/generate_movie_thumbnail_job.rb
+++ b/app/jobs/generate_movie_thumbnail_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class GenerateMovieThumbnailJob < ApplicationJob
+  retry_on ActiveStorage::PreviewError, wait: :polynomially_longer, attempts: 3
+
   def perform(movie)
     return if movie.thumbnail.attached?
     return unless movie.movie_data.attached? && movie.movie_data.previewable?
@@ -8,7 +10,5 @@ class GenerateMovieThumbnailJob < ApplicationJob
     preview = movie.movie_data.preview({})
     preview.processed
     movie.thumbnail.attach(preview.image.blob)
-  rescue ActiveStorage::PreviewError => e
-    Rails.logger.warn("Failed to generate thumbnail for Movie #{movie.id}: #{e.message}")
   end
 end


### PR DESCRIPTION
## Summary
- `ActiveStorage::PreviewError` の握り潰し (`Rails.logger.warn` のみ) をやめ、ActiveJob 標準の `retry_on ActiveStorage::PreviewError, wait: :polynomially_longer, attempts: 3` に置き換えて ffmpeg の一時的失敗を自動リトライする。

## 検討メモ

1. **`attempts: 3`**: 既存の `EmbeddingGenerateJob` / `PjordRespondJob` が同じ `wait: :polynomially_longer, attempts: 3` を採用しているのでそれに揃えた。ffmpeg 再実行コストはキュー負荷に対して十分小さい (最悪 ~100秒)。
2. **`discard_on` は併用しない**: 既存の `discard_on` は `ActiveJob::DeserializationError`（回復不能）にのみ使われている。サムネイル生成失敗は運用上の観測対象として残したいため、3 回失敗したらジョブキューの failed に入れて可視化する。`app/models/movie.rb:59-64` の `generate_default_thumbnail` も `logger.error` + `raise` で可視化する方針と整合。
3. **テスト変更は含めない**: PR #9937 の最新コミット (`485b7f668`) で本 PR が予定していたテスト内リトライの削除は完了済み。残るは本番環境向けの ffmpeg 一時的失敗対策（`retry_on`）のみで、既存テストはそのまま通る。

## Base branch

PR #9937 (`claude/friendly-grothendieck-2fcc89`) がマージされる前提でそちらをベースブランチに指定している。#9937 がマージされ次第、GitHub 上で base を `main` に切り替える。

## Scope

out of scope:
- ffmpeg 本体の安定化（運用/インフラ）
- 他ジョブの同種パターンの洗い出し

## Test plan
- [ ] CI の `test/jobs/generate_movie_thumbnail_job_test.rb` がグリーンになること
- [ ] （本番）ffmpeg の一時的失敗時にジョブキューのダッシュボードで retry が観測できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)