### PR TITLE
ピヨルドが日報にコメントする際に必ず 👀 リアクションを付ける

### DIFF
--- a/app/jobs/pjord_report_comment_job.rb
+++ b/app/jobs/pjord_report_comment_job.rb
@@ -34,7 +34,10 @@ class PjordReportCommentJob < ApplicationJob
     response = generate_response(report, intent)
     return if response.blank?
 
-    Comment.create!(user: pjord, commentable: report, description: response)
+    ActiveRecord::Base.transaction do
+      Comment.create!(user: pjord, commentable: report, description: response)
+      Reaction.find_or_create_by!(user: pjord, reactionable: report, kind: :eyes)
+    end
   end
 
   private

--- a/test/jobs/pjord_report_comment_job_test.rb
+++ b/test/jobs/pjord_report_comment_job_test.rb
@@ -3,13 +3,14 @@
 require 'test_helper'
 
 class PjordReportCommentJobTest < ActiveJob::TestCase
-  test 'creates a comment when intent is question' do
+  test 'creates a comment and an eyes reaction when intent is question' do
     report = reports(:report1)
     pjord = users(:pjord)
 
     Pjord.stub(:classify_report, { intent: 'question', reason: '質問あり' }) do
       Pjord.stub(:respond, 'ヒントをあげますね。') do
-        assert_difference 'Comment.count', 1 do
+        assert_difference -> { Comment.count } => 1,
+                          -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count } => 1 do
           PjordReportCommentJob.perform_now(report_id: report.id)
         end
       end
@@ -19,6 +20,22 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     assert_equal pjord, comment.user
     assert_equal report, comment.commentable
     assert_equal 'ヒントをあげますね。', comment.description
+  end
+
+  test 'does not duplicate eyes reaction when pjord already reacted to the report' do
+    report = reports(:report1)
+    pjord = users(:pjord)
+    Reaction.create!(user: pjord, reactionable: report, kind: :eyes)
+
+    Pjord.stub(:classify_report, { intent: 'question', reason: '質問あり' }) do
+      Pjord.stub(:respond, 'ヒントをあげますね。') do
+        assert_difference 'Comment.count', 1 do
+          assert_no_difference -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count } do
+            PjordReportCommentJob.perform_now(report_id: report.id)
+          end
+        end
+      end
+    end
   end
 
   test 'creates a comment when intent is struggling' do
@@ -45,11 +62,13 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'does not create a comment when intent is none' do
+  test 'does not create a comment or reaction when intent is none' do
     report = reports(:report1)
+    pjord = users(:pjord)
 
     Pjord.stub(:classify_report, { intent: 'none', reason: '通常の学習記録' }) do
-      assert_no_difference 'Comment.count' do
+      assert_no_difference ['Comment.count',
+                            -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count }] do
         PjordReportCommentJob.perform_now(report_id: report.id)
       end
     end
@@ -101,12 +120,14 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'does nothing when response is blank' do
+  test 'does not create a comment or reaction when response is blank' do
     report = reports(:report1)
+    pjord = users(:pjord)
 
     Pjord.stub(:classify_report, { intent: 'question', reason: '質問あり' }) do
       Pjord.stub(:respond, nil) do
-        assert_no_difference 'Comment.count' do
+        assert_no_difference ['Comment.count',
+                              -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count }] do
           PjordReportCommentJob.perform_now(report_id: report.id)
         end
       end


### PR DESCRIPTION
## Summary

- ピヨルド（Pjord）が日報にコメントを投稿するときに、その日報へ `eyes`（👀）リアクションを必ず付与するようにしました。
- 既に同じリアクションが存在する場合は `find_or_create_by!` により重複作成しません。
- コメント作成とリアクション作成は同一トランザクションで実行し、どちらかが失敗した場合は両方 rollback されて ActiveJob がリトライできるようにしています。
- コメントを投稿しないケース（intent=`none` / respond が blank / 分類失敗）ではリアクションも付きません。

## Test plan

- [x] `bundle exec rails test test/jobs/pjord_report_comment_job_test.rb` がグリーン（13 runs, 0 failures）
- [x] `bundle exec rubocop` でオフェンスなし
- [ ] 開発環境で日報を作成し、ピヨルドのコメントと 👀 リアクションが両方付くことを確認
- [ ] 同じ日報を再更新してもリアクションが重複しないことを確認
- [ ] intent が `none` の日報にはコメントもリアクションも付かないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * レポートコメント作成時のデータベース操作の整合性を向上。コメント作成とリアクション作成が同時に成功または失敗するように改善されました。
  * リアクションの重複作成を防ぐ機能を追加。既存のリアクションがある場合は新規作成を回避します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->