### PR TITLE
ピヨルドのリアクション失敗で日報コメント投稿が落ちないようにする

### DIFF
--- a/app/jobs/pjord_report_comment_job.rb
+++ b/app/jobs/pjord_report_comment_job.rb
@@ -34,9 +34,12 @@ class PjordReportCommentJob < ApplicationJob
     response = generate_response(report, intent)
     return if response.blank?
 
-    ActiveRecord::Base.transaction do
-      Comment.create!(user: pjord, commentable: report, description: response)
+    Comment.create!(user: pjord, commentable: report, description: response)
+
+    begin
       Reaction.find_or_create_by!(user: pjord, reactionable: report, kind: :eyes)
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+      Rails.logger.error("[PjordReportCommentJob] reaction failed: #{e.class}: #{e.message}")
     end
   end
 

--- a/test/jobs/pjord_report_comment_job_test.rb
+++ b/test/jobs/pjord_report_comment_job_test.rb
@@ -38,6 +38,25 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'still creates a comment even when reaction fails' do
+    report = reports(:report1)
+    pjord = users(:pjord)
+
+    Pjord.stub(:classify_report, { intent: 'question', reason: '質問あり' }) do
+      Pjord.stub(:respond, 'ヒントをあげますね。') do
+        Reaction.stub(:find_or_create_by!, ->(**_args) { raise ActiveRecord::RecordInvalid }) do
+          assert_difference 'Comment.count', 1 do
+            assert_no_difference -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count } do
+              assert_nothing_raised do
+                PjordReportCommentJob.perform_now(report_id: report.id)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
   test 'creates a comment when intent is struggling' do
     report = reports(:report1)
 


### PR DESCRIPTION
## Summary

- `PjordReportCommentJob#perform` で Comment 作成と Reaction 付与を同一トランザクションに入れていたため、Reaction 側で例外が出るとコメント投稿まで道連れロールバックされる構造だった
- コメントの方が主役なので Reaction を best-effort に変更。`ActiveRecord::RecordInvalid` / `ActiveRecord::RecordNotUnique` を rescue してログに残すだけにし、コメントは必ず残るようにする
- テストは Reaction.find_or_create_by! が例外を投げても Comment が作成されることを検証するケースを追加

## 背景

2026-04-23 デプロイ以降、pjord の日報コメントが動かなくなっていた件の調査中に見つけた構造上の欠陥の修正。

直接の停止原因は別で、Cloud Run の `PJORD_LLM_MODEL` 環境変数が古いモデル名（`claude-sonnet-4-20250514`、構造化出力未対応）を指しており、24a840ac1 で導入した `chat.with_schema(PjordReportIntent)` と衝突して classify_report が必ず `RubyLLM::BadRequestError` を返していたもの。そちらは本 PR ではなく、Cloud Build trigger `cloud-run-deploy` の `_ENVS` と Cloud Run サービスの環境変数を `claude-sonnet-4-6` に更新して即時復旧済み。

本 PR は将来 Reaction 側が失敗したときに同じ事故を繰り返さないための予防修正。

## Test plan

- [x] `bin/rails test test/jobs/pjord_report_comment_job_test.rb`（14 runs, 42 assertions, 0 failures / 0 errors）
- [x] `rubocop app/jobs/pjord_report_comment_job.rb test/jobs/pjord_report_comment_job_test.rb`（offense 0）
- [ ] マージ後、本番で新規日報へのコメントが引き続き正常に行われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * コメント作成時の信頼性を向上しました。リアクション作成に失敗してもコメントが正常に作成されるようになり、エラーはシステムログに記録されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->