### PR TITLE
db:migrate:resetが途中で失敗する問題を修正

### DIFF
--- a/db/migrate/20230504083810_add_ai_answer_to_questions.rb
+++ b/db/migrate/20230504083810_add_ai_answer_to_questions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: tru
 
-class AddAIAnswerToQuestions < ActiveRecord::Migration[6.1]
+class AddAiAnswerToQuestions < ActiveRecord::Migration[6.1]
   def change
     add_column :questions, :ai_answer, :text
   end

--- a/db/migrate/20230504083810_add_ai_answer_to_questions.rb
+++ b/db/migrate/20230504083810_add_ai_answer_to_questions.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: tru
+# frozen_string_literal: true
 
 class AddAiAnswerToQuestions < ActiveRecord::Migration[6.1]
   def change

--- a/db/migrate/20260119100001_add_embedding_to_searchable_tables.rb
+++ b/db/migrate/20260119100001_add_embedding_to_searchable_tables.rb
@@ -9,21 +9,8 @@ class AddEmbeddingToSearchableTables < ActiveRecord::Migration[8.1]
   ].freeze
 
   def change
-    # pgvectorが利用不可の環境（テスト用SQLite等）ではスキップ
-    return unless vector_extension_available?
-
     TABLES.each do |table|
       add_column table, :embedding, :vector, limit: 1536
     end
-  end
-
-  private
-
-  def vector_extension_available?
-    # 前のマイグレーションで有効化されていなければ、ここで試みる
-    execute("CREATE EXTENSION IF NOT EXISTS vector")
-    true
-  rescue ActiveRecord::StatementInvalid
-    false
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9687

## 概要

`rails db:migrate:reset` 実行時に下記エラーが出ておりました。

```
bin/rails aborted!
NameError: uninitialized constant AddAiAnswerToQuestions (NameError)

      Object.const_get(camel_cased_word)
            ^^^^^^^^^^
Did you mean?  AddAIAnswerToQuestions


Caused by:
NameError: uninitialized constant AddAiAnswerToQuestions (NameError)

      Object.const_get(camel_cased_word)
            ^^^^^^^^^^
Did you mean?  AddAIAnswerToQuestions
```

原因は以下の2点です。
- migrationファイルのクラス名とファイル名の不一致により、migrationの読み込みに失敗していた
- pgvector拡張の重複定義および未設定により、vector型のカラム追加時にエラーが発生していた

上記を修正し、すべてのmigrationが正常に実行されるようにしました。

### 修正内容
- migrationのクラス名をファイル名に合わせて修正
- `CREATE EXTENSION vector` を実行しているメソッド`vector_extension_available?`を削除

## 動作確認方法

以下の手順でDBの再構築が正常に完了することを確認しました。

1. DBを削除・再作成

```bash
bin/rails db:drop db:create
```

2. migrationを実行

```bash
bin/rails db:migrate
```

または

```bash
bin/rails db:migrate:reset
```
3. エラーが発生せず、最後まで完了することを確認

4. schema.rb に対象カラム（embedding など）が正しく追加されていることを確認

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データベーススキーマの更新を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->