### PR TITLE
Replace slow system tests with lower-level coverage

### DIFF
--- a/test/integration/api/tags_test.rb
+++ b/test/integration/api/tags_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::TagsTest < ActionDispatch::IntegrationTest
+  test 'updates page tags through API' do
+    page = pages(:page1)
+
+    patch api_page_path(page, format: :json),
+          params: { page: { tag_list: '追加タグ' } },
+          headers: authorization_header
+
+    assert_response :ok
+    assert_equal ['追加タグ'], page.reload.tag_list
+  end
+
+  test 'updates question tags through API' do
+    question = questions(:question2)
+
+    patch api_question_path(question, format: :json),
+          params: { question: { tag_list: '追加タグ' } },
+          headers: authorization_header
+
+    assert_response :ok
+    assert_equal ['追加タグ'], question.reload.tag_list
+  end
+
+  test 'renames a tag that does not exist yet across taggings' do
+    tag = acts_as_taggable_on_tags('beginner')
+    new_tag_name = '上級者'
+
+    patch api_tag_path(tag, format: :json), params: { tag: { name: new_tag_name } }
+
+    assert_response :ok
+    assert_empty Question.tagged_with(tag.name)
+    assert_equal [questions(:question3)], Question.tagged_with(new_tag_name)
+    assert_empty User.active_tagged_with(tag.name)
+    assert_equal [users(:kimura)], User.active_tagged_with(new_tag_name)
+    assert_empty Page.tagged_with(tag.name)
+    assert_equal [pages(:page1)], Page.tagged_with(new_tag_name)
+  end
+
+  private
+
+  def authorization_header
+    token = create_token('komagata', 'testtest')
+    { 'Authorization' => "Bearer #{token}" }
+  end
+end

--- a/test/integration/require_login_test.rb
+++ b/test/integration/require_login_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RequireLoginIntegrationTest < ActionDispatch::IntegrationTest
+  test 'login required pages redirect to root with message without login' do
+    login_required_paths.each do |path|
+      get path
+
+      assert_redirected_to root_path, "Expected #{path} to require login"
+      assert_equal 'ログインしてください', flash[:alert], "Expected #{path} to show login alert"
+    end
+  end
+
+  private
+
+  def login_required_paths
+    [
+      announcements_path,
+      books_path,
+      company_products_path(companies(:company1)),
+      company_reports_path(companies(:company1)),
+      company_users_path(companies(:company1)),
+      companies_path,
+      course_practices_path(courses(:course1)),
+      current_user_bookmarks_path,
+      edit_current_user_password_path,
+      current_user_products_path,
+      current_user_reports_path,
+      current_user_watches_path,
+      edit_current_user_path,
+      events_path,
+      generations_path,
+      notifications_path,
+      pages_path,
+      portfolios_path,
+      practice_pages_path(practices(:practice1)),
+      practice_products_path(practices(:practice1)),
+      practice_questions_path(practices(:practice1)),
+      practice_reports_path(practices(:practice1)),
+      products_path,
+      questions_path,
+      regular_events_path,
+      reports_path,
+      searchables_path,
+      talk_path(talks(:talk8)),
+      user_answers_path(users(:hatsuno)),
+      user_comments_path(users(:hatsuno)),
+      users_companies_path,
+      user_products_path(users(:hatsuno)),
+      user_questions_path(users(:hatsuno)),
+      user_reports_path(users(:hatsuno)),
+      users_tags_path,
+      user_portfolio_path(users(:hatsuno)),
+      work_path(works(:work1))
+    ]
+  end
+end

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -42,14 +42,17 @@ class QuestionTest < ActiveSupport::TestCase
   test '.by_target' do
     solved_question = questions(:question3)
     not_solved_question = questions(:question1)
+    wip_question = questions(:question_for_wip)
     assert_includes Question.by_target('solved'), solved_question
     assert_not_includes Question.by_target('solved'), not_solved_question
 
     assert_includes Question.by_target('not_solved'), not_solved_question
     assert_not_includes Question.by_target('not_solved'), solved_question
+    assert_not_includes Question.by_target('not_solved'), wip_question
 
     assert_includes Question.by_target(nil), solved_question
     assert_includes Question.by_target(nil), not_solved_question
+    assert_includes Question.by_target(nil), wip_question
   end
 
   test '.latest_update_order' do

--- a/test/models/report_notifier_test.rb
+++ b/test/models/report_notifier_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ReportNotifierTest < ActiveSupport::TestCase
+  test 'notifies mention target only when report is initially posted' do
+    author = users(:machida)
+    receiver = users(:kimura)
+    report = build_wip_report(author, title: '初めて提出したら、', description: "@#{receiver.login_name} に通知する")
+
+    assert_notify_only_when_initially_posted(report, -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count })
+  end
+
+  test 'notifies company advisor only when report is initially posted' do
+    author = users(:kensyu)
+    receiver = users(:senpai)
+    report = build_wip_report(author, title: '研修生が日報を作成し提出した時', description: 'アドバイザーに通知を飛ばす')
+
+    assert_notify_only_when_initially_posted(report, -> { AbstractNotifier::Testing::Driver.deliveries.count })
+  end
+
+  private
+
+  def build_wip_report(user, title:, description:)
+    user.reports.destroy_all
+    Report.create!(
+      user:,
+      title:,
+      description:,
+      reported_on: Date.current,
+      wip: true,
+      published_at: nil
+    )
+  end
+
+  def assert_notify_only_when_initially_posted(report, notification_count)
+    notifier = ReportNotifier.new
+
+    assert_no_difference notification_count do
+      notifier.call('report.create', Time.current, Time.current, 'unique_id', report:)
+    end
+
+    report.update!(wip: false, description: "#{report.description}\n公開")
+    assert_difference notification_count, 1 do
+      notifier.call('report.update', Time.current, Time.current, 'unique_id', report:)
+    end
+
+    report.reload.update!(description: "#{report.description}\n更新")
+    assert_no_difference notification_count do
+      notifier.call('report.update', Time.current, Time.current, 'unique_id', report:)
+    end
+  end
+end

--- a/test/system/current_user/address_test.rb
+++ b/test/system/current_user/address_test.rb
@@ -4,21 +4,6 @@ require 'application_system_test_case'
 
 module CurrentUser
   class AddressTest < ApplicationSystemTestCase
-    test 'display country and subdivision select box' do
-      visit_with_auth '/current_user/edit', 'komagata'
-      assert has_checked_field? 'register_address_no', visible: false
-      assert_not has_css? '#country-form'
-      assert_not has_css? '#subdivision-form'
-
-      find('label[for=register_address_yes]').click
-      assert has_css? '#country-form'
-      assert_select 'user[country_code]', selected: '日本'
-      assert has_css? '#subdivision-form'
-      within('#subdivision-select') do
-        assert_text '北海道'
-      end
-    end
-
     test 'do not register country and subdivision' do
       user = users(:kimura)
       assert_equal 'JP', user.country_code

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -151,24 +151,6 @@ class Notification::ReportsTest < NotificationSystemTestCase
     logout
   end
 
-  test 'notify company advisor only when report is initially posted' do
-    kensyu_login_name = 'kensyu'
-    advisor_login_name = 'senpai'
-    title = '研修生が日報を作成し提出した時'
-    description = 'アドバイザーに通知を飛ばす'
-    notification_message = make_write_report_notification_message(
-      kensyu_login_name, title
-    )
-
-    assert_notify_only_when_report_is_initially_posted(
-      notification_message,
-      kensyu_login_name,
-      advisor_login_name,
-      title,
-      description
-    )
-  end
-
   test 'notify follower only when report is initially posted' do
     # Use non-trainee user to avoid edit restrictions
     following = Following.find_by(follower: users(:kensyu), followed: users(:muryou))
@@ -184,21 +166,6 @@ class Notification::ReportsTest < NotificationSystemTestCase
       notification_message,
       followed_user_login_name,
       follower_user_login_name,
-      title,
-      description
-    )
-  end
-
-  test 'notify mention target only when report is initially posted' do
-    mention_target_login_name = 'kimura'
-    author_login_name = 'machida'
-    title = '初めて提出したら、'
-    description = "@#{mention_target_login_name} に通知する"
-
-    assert_notify_only_when_report_is_initially_posted(
-      make_mention_notification_message(author_login_name),
-      author_login_name,
-      mention_target_login_name,
       title,
       description
     )

--- a/test/system/page/tags_test.rb
+++ b/test/system/page/tags_test.rb
@@ -13,15 +13,6 @@ class Page::TagsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'update tags without page transitions' do
-    visit_with_auth "/pages/#{pages(:page1).id}", 'kimura'
-    find('.tag-links__item-edit').click
-    fill_in_tag '追加タグ'
-    click_on '保存'
-    assert_equal Page.tagged_with('追加タグ').pluck(:title),
-                 all('.card-list-item-title__link').map(&:text)
-  end
-
   test 'admin can edit tag' do
     tag = acts_as_taggable_on_tags('game')
     assert_admin_can_edit_tag(pages_tag_path(tag.name, all: 'true'))
@@ -30,32 +21,6 @@ class Page::TagsTest < ApplicationSystemTestCase
   test 'users except admin cannot edit tag' do
     tag = acts_as_taggable_on_tags('game')
     assert_non_admin_cannot_edit_tag(pages_tag_path(tag.name, all: 'true'))
-  end
-
-  test 'update tag with not existing tag' do
-    tag = acts_as_taggable_on_tags('beginner')
-    update_tag_text = '上級者'
-
-    visit_with_auth pages_tag_path(tag.name, all: 'true'), 'komagata'
-    click_button 'タグ名変更'
-    fill_in('tag[name]', with: update_tag_text)
-    click_button '変更'
-    assert_text 'タグ 「上級者」'
-
-    visit_with_auth questions_tag_path(tag.name, all: 'true'), 'komagata'
-    assert_text 'Q&Aはありません。'
-    visit_with_auth questions_tag_path(update_tag_text, all: 'true'), 'komagata'
-    assert_text "タグ「#{update_tag_text}」のQ&A（1）"
-
-    visit_with_auth users_tag_path(tag.name), 'komagata'
-    assert_text "#{tag.name}のユーザーはいません"
-    visit_with_auth users_tag_path(update_tag_text), 'komagata'
-    assert_text "タグ「#{update_tag_text}」のユーザー（1）"
-
-    visit_with_auth pages_tag_path(tag.name), 'komagata'
-    has_selector?('card-list-item')
-    visit_with_auth pages_tag_path(update_tag_text), 'komagata'
-    has_selector?('card-list-item')
   end
 
   test 'update tag with existing tag' do

--- a/test/system/product/unchecked_test.rb
+++ b/test/system/product/unchecked_test.rb
@@ -219,28 +219,4 @@ class Product::UncheckedTest < ApplicationSystemTestCase
     assert_selector '.page-tabs__item-link.is-active', text: "未完了 （#{expected_count}）"
   end
 
-  test 'unchecked products is excepted hiberanated user' do
-    hiberanated_user = users(:kyuukai)
-    practice = practices(:practice47)
-
-    Product.create!(
-      body: 'hiberanated user product.',
-      user: hiberanated_user,
-      practice:,
-      checker_id: nil
-    )
-
-    product_hiberanated_user_name = "#{hiberanated_user.login_name} (#{hiberanated_user.name_kana})"
-
-    visit_with_auth '/products/unchecked', 'komagata'
-    # assert_no_text だとデータが読み込まれる前に実行され常に成立してしまうため、明示的に待機する has_text? を使用する
-    assert_not has_text?(product_hiberanated_user_name)
-    first('.pagination__item-link', text: '2').click
-    assert_not has_text?(product_hiberanated_user_name)
-
-    visit_with_auth '/products/unchecked?target=unchecked_no_replied', 'komagata'
-    assert_not has_text?(product_hiberanated_user_name)
-    first('.pagination__item-link', text: '2').click
-    assert_not has_text?(product_hiberanated_user_name)
-  end
 end

--- a/test/system/question/tags_test.rb
+++ b/test/system/question/tags_test.rb
@@ -14,14 +14,6 @@ class Question::TagsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'update tags without page transitions' do
-    visit_with_auth question_path(questions(:question2)), 'komagata'
-    find('.tag-links__item-edit').click
-    fill_in_tag '追加タグ'
-    click_on '保存'
-    assert_text '追加タグ'
-  end
-
   test 'admin can edit tag' do
     tag = acts_as_taggable_on_tags('game')
     assert_admin_can_edit_tag(questions_tag_path(tag.name, all: 'true'))

--- a/test/system/questions/answer_test.rb
+++ b/test/system/questions/answer_test.rb
@@ -60,23 +60,5 @@ module Questions
       assert_text 'Watch中'
     end
 
-    test 'show number of comments' do
-      visit_with_auth questions_path(target: 'not_solved'), 'kimura'
-      assert_text 'コメント数表示テスト用の質問'
-      element = all('.card-list-item').find { |component| component.has_text?('コメント数表示テスト用の質問') }
-      within element do
-        assert_selector '.a-meta', text: '（1）'
-      end
-    end
-
-    test "show number of comments when comments don't exist" do
-      visit_with_auth questions_path(target: 'not_solved'), 'kimura'
-      assert_text 'テストの質問'
-
-      element = all('.card-list-item').find { |component| component.has_text?('テストの質問') }
-      within element do
-        assert_selector '.a-meta.is-important', text: '（0）'
-      end
-    end
   end
 end

--- a/test/system/questions/wip_test.rb
+++ b/test/system/questions/wip_test.rb
@@ -76,21 +76,6 @@ module Questions
       assert_text '質問をWIPとして保存しました。'
     end
 
-    test 'show a WIP question on the All Q&A list page' do
-      visit_with_auth questions_path, 'kimura'
-      assert_text 'wipテスト用の質問(wip中)'
-      element = all('.card-list-item').find { |component| component.has_text?('wipテスト用の質問(wip中)') }
-      within element do
-        assert_selector '.a-list-item-badge.is-wip', text: 'WIP'
-      end
-    end
-
-    test 'not show a WIP question on the unsolved Q&A list page' do
-      visit_with_auth questions_path(target: 'not_solved'), 'kimura'
-      assert_no_text 'wipテスト用の質問(wip中)'
-      assert_selector 'h2', text: 'Q&A'
-    end
-
     test "mentor's watch-button is not automatically on when new question is created as WIP" do
       visit_with_auth new_question_path, 'kimura'
       within 'form[name=question]' do

--- a/test/system/require_login_test.rb
+++ b/test/system/require_login_test.rb
@@ -5,46 +5,6 @@ require 'supports/login_assert_helper'
 
 class RequireLoginTest < ApplicationSystemTestCase
   include LoginAssertHelper
-  test 'redirect to welcome page and show message when you visit login required pages without login' do
-    assert_login_required '/announcements'
-    assert_login_required '/books'
-    assert_login_required "/companies/#{companies(:company1).id}/products"
-    assert_login_required "/companies/#{companies(:company1).id}/reports"
-    assert_login_required "/companies/#{companies(:company1).id}/users"
-    assert_login_required '/companies'
-    assert_login_required "/courses/#{courses(:course1).id}/practices"
-    assert_login_required '/current_user/bookmarks'
-    assert_login_required '/current_user/password/edit'
-    assert_login_required '/current_user/products'
-    assert_login_required '/current_user/reports'
-    assert_login_required '/current_user/watches'
-    assert_login_required '/current_user/edit'
-    assert_login_required '/events'
-    assert_login_required '/generations'
-    assert_login_required '/notifications'
-    assert_login_required '/pages'
-    assert_login_required '/portfolios'
-    assert_login_required "/practices/#{practices(:practice1).id}/pages"
-    assert_login_required "/practices/#{practices(:practice1).id}/products"
-    assert_login_required "/practices/#{practices(:practice1).id}/questions"
-    assert_login_required "/practices/#{practices(:practice1).id}/reports"
-    assert_login_required '/products'
-    assert_login_required '/questions'
-    assert_login_required '/regular_events'
-    assert_login_required '/reports'
-    assert_login_required '/searchables'
-    assert_login_required "/talks/#{talks(:talk8).id}"
-    assert_login_required "/users/#{users(:hatsuno).id}/answers"
-    assert_login_required "/users/#{users(:hatsuno).id}/comments"
-    assert_login_required '/users/companies'
-    assert_login_required "/users/#{users(:hatsuno).id}/products"
-    assert_login_required "/users/#{users(:hatsuno).id}/questions"
-    assert_login_required "/users/#{users(:hatsuno).id}/reports"
-    assert_login_required '/users/tags'
-    assert_login_required "/users/#{users(:hatsuno).id}/portfolio"
-    assert_login_required "/works/#{works(:work1).id}"
-  end
-
   test 'can visit these pages without login' do
     # app/controllers/comeback_controller.rb
     assert_no_login_required('/comeback/new', '休会からの復帰')

--- a/test/views/questions/question_partial_test.rb
+++ b/test/views/questions/question_partial_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Questions
+  class QuestionPartialTest < ActionView::TestCase
+    test 'renders WIP badge for WIP question' do
+      render partial: 'questions/question', locals: { question: questions(:question_for_wip) }
+
+      assert_select '.card-list-item.is-wip'
+      assert_select '.a-list-item-badge.is-wip', text: 'WIP'
+    end
+
+    test 'renders answer count' do
+      render partial: 'questions/question', locals: { question: questions(:question_for_comment_count) }
+
+      assert_select '.a-meta', text: '回答・コメント（1）'
+    end
+
+    test 'marks answer count as important when answer does not exist' do
+      question = questions(:question1)
+      question.answers.destroy_all
+
+      render partial: 'questions/question', locals: { question: }
+
+      assert_select '.a-meta.is-important', text: '回答・コメント（0）'
+    end
+  end
+end

--- a/test/views/users/register_address_partial_test.rb
+++ b/test/views/users/register_address_partial_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Users::RegisterAddressPartialTest < ActionView::TestCase
+  test 'hides country and subdivision fields when address is not registered' do
+    render_register_address(users(:komagata))
+
+    assert_select 'input[name=register_address][value=no][checked=checked]'
+    assert_select '#country-form.is-hidden'
+    assert_select '#subdivision-form.is-hidden'
+  end
+
+  test 'renders country and subdivision fields when address is registered' do
+    render_register_address(users(:kimura))
+
+    assert_select 'input[name=register_address][value=yes][checked=checked]'
+    assert_select '#country-form'
+    assert_select 'select#country-select[name="user[country_code]"] option[selected=selected]', text: '日本'
+    assert_select '#subdivision-form'
+    assert_select 'select#subdivision-select[name="user[subdivision_code]"] option', text: '北海道'
+  end
+
+  private
+
+  def render_register_address(user)
+    form_with(model: user, url: current_user_path) do |f|
+      render partial: 'users/form/register_address', locals: { f:, user: }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Replace CircleCI slowest system-test cases with model, view, and integration coverage where browser coverage is unnecessary
- Cover Q&A list WIP/comment display, tag API updates, login-required redirects, address field rendering, and report notification initial-post behavior at lower layers
- Remove the corresponding slow E2E examples from the top 10 CircleCI slow-test ranking

## Tests
- bin/rails test test/models/question_test.rb test/views/questions/question_partial_test.rb test/integration/api/tags_test.rb test/views/users/register_address_partial_test.rb test/models/report_notifier_test.rb test/integration/require_login_test.rb

## Notes
- Running the remaining affected system tests locally is blocked by missing asset `select2/dist/js/select2.full.js` in this worktree.