### PR TITLE
次に遅いsystem testをmodel testへ置き換える

### DIFF
--- a/test/models/first_report_notifier_test.rb
+++ b/test/models/first_report_notifier_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class FirstReportNotifierTest < ActiveSupport::TestCase
+  test 'notifies admins and mentors only when first report is initially posted' do
+    report = build_wip_report(users(:nippounashi))
+    notifier = FirstReportNotifier.new
+
+    assert_no_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count } do
+      notifier.call('report.create', Time.current, Time.current, 'unique_id', report:)
+    end
+
+    report.update!(wip: false)
+    assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, User.admins_and_mentors.count do
+      notifier.call('report.update', Time.current, Time.current, 'unique_id', report:)
+    end
+
+    Notification.create!(
+      kind: :first_report,
+      user: users(:machida),
+      sender: report.user,
+      message: "#{report.user.login_name}さんがはじめての日報を書きました！",
+      link: "/reports/#{report.id}",
+      read: false
+    )
+
+    assert_no_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count } do
+      notifier.call('report.update', Time.current, Time.current, 'unique_id', report:)
+    end
+  end
+
+  private
+
+  def build_wip_report(user)
+    user.reports.destroy_all
+    Report.create!(
+      user:,
+      title: '初めての日報を提出したら',
+      description: 'ユーザーに通知をする',
+      reported_on: Date.current,
+      wip: true,
+      published_at: nil
+    )
+  end
+end

--- a/test/models/report_notifier_test.rb
+++ b/test/models/report_notifier_test.rb
@@ -18,6 +18,14 @@ class ReportNotifierTest < ActiveSupport::TestCase
     assert_notify_only_when_initially_posted(report, -> { AbstractNotifier::Testing::Driver.deliveries.count })
   end
 
+  test 'notifies follower only when report is initially posted' do
+    following = Following.find_by!(follower: users(:kensyu), followed: users(:muryou))
+    author = following.followed
+    report = build_wip_report(author, title: '初めて提出した時だけ', description: 'フォローされているユーザーに通知を飛ばす')
+
+    assert_notify_only_when_initially_posted(report, -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count })
+  end
+
   private
 
   def build_wip_report(user, title:, description:)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -203,6 +203,22 @@ class UserTest < ActiveSupport::TestCase
     assert user.invalid?
   end
 
+  test 'reserved login_name is invalid' do
+    user = users(:komagata)
+    user.login_name = 'mentor'
+
+    assert user.invalid?
+    assert_includes user.errors[:login_name], 'に使用できない文字列が含まれています'
+  end
+
+  test 'description is required' do
+    user = users(:komagata)
+    user.description = nil
+
+    assert user.invalid?
+    assert_includes user.errors[:description], 'を入力してください'
+  end
+
   test 'twitter_account' do
     user = users(:komagata)
     user.twitter_account = ''

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -151,40 +151,6 @@ class Notification::ReportsTest < NotificationSystemTestCase
     logout
   end
 
-  test 'notify follower only when report is initially posted' do
-    # Use non-trainee user to avoid edit restrictions
-    following = Following.find_by(follower: users(:kensyu), followed: users(:muryou))
-    followed_user_login_name = User.find(following.followed_id).login_name
-    follower_user_login_name = User.find(following.follower_id).login_name
-    title = '初めて提出した時だけ'
-    description = 'フォローされているユーザーに通知を飛ばす'
-    notification_message = make_write_report_notification_message(
-      followed_user_login_name, title
-    )
-
-    assert_notify_only_when_report_is_initially_posted(
-      notification_message,
-      followed_user_login_name,
-      follower_user_login_name,
-      title,
-      description
-    )
-  end
-
-  test 'notify user only when first report is initially posted' do
-    check_notification_login_name = 'machida'
-    author_login_name = 'nippounashi'
-    title = '初めての日報を提出したら'
-    description = 'ユーザーに通知をする'
-    assert_notify_only_when_report_is_initially_posted(
-      "#{author_login_name}さんがはじめての日報を書きました！",
-      author_login_name,
-      check_notification_login_name,
-      title,
-      description
-    )
-  end
-
   test 'notify to mentors when a student submitted reports with negative icon at twice in a row' do
     student = 'kimura'
     mentor = 'mentormentaro'

--- a/test/system/sign_up/validation_test.rb
+++ b/test/system/sign_up/validation_test.rb
@@ -16,55 +16,6 @@ module SignUp
       Discord::Server.authorize_token = @bot_token
     end
 
-    test 'sign up with reserved login name' do
-      visit '/users/new'
-      within 'form[name=user]' do
-        fill_in 'user[login_name]', with: 'mentor'
-        fill_in 'user[email]', with: 'akiko@example.com'
-        fill_in 'user[name]', with: 'テスト 秋子'
-        fill_in 'user[name_kana]', with: 'テスト アキコ'
-        fill_in 'user[description]', with: 'テスト秋子です。'
-        fill_in 'user[password]', with: 'testtest'
-        fill_in 'user[password_confirmation]', with: 'testtest'
-        select '学生', from: 'user[job]'
-        find('label', text: 'Mac（Intel チップ）').click
-        check 'Rubyの経験あり', allow_label_click: true
-        find('label', text: 'アンチハラスメントポリシーに同意').click
-        find('label', text: '利用規約に同意').click
-      end
-
-      fill_stripe_element('4242 4242 4242 4242', '12 / 50', '111')
-
-      VCR.use_cassette 'sign_up/valid-card', record: :once do
-        click_button '参加する'
-        assert_text 'に使用できない文字列が含まれています'
-      end
-    end
-
-    test 'sign up with empty description ' do
-      visit '/users/new'
-      within 'form[name=user]' do
-        fill_in 'user[login_name]', with: 'foo'
-        fill_in 'user[email]', with: 'siro@example.com'
-        fill_in 'user[name]', with: 'テスト 四郎'
-        fill_in 'user[name_kana]', with: 'テスト シロウ'
-        fill_in 'user[password]', with: 'testtest'
-        fill_in 'user[password_confirmation]', with: 'testtest'
-        select '学生', from: 'user[job]'
-        find('label', text: 'Mac（Intel チップ）').click
-        check 'Rubyの経験あり', allow_label_click: true
-        find('label', text: 'アンチハラスメントポリシーに同意').click
-        find('label', text: '利用規約に同意').click
-      end
-
-      fill_stripe_element('5555 5555 5555 4444', '12 / 50', '111')
-
-      VCR.use_cassette 'sign_up/valid-card', record: :once do
-        click_button '参加する'
-        assert_text '自己紹介を入力してください'
-      end
-    end
-
     test 'hidden input learning time frames table' do
       visit '/users/new'
       assert_no_selector ".form-item.a-form-label[for='user_learning_time_frames']", text: '主な活動予定時間'


### PR DESCRIPTION
## 概要
- 前回対応分の次に遅い候補のうち、model testで確認できるsystem testを置き換えました。
- 日報通知の初回提出時のみ通知する挙動をnotifierのmodel testへ移しました。
- サインアップの予約login_name・自己紹介必須バリデーションをUser model testへ移しました。
- Stripeカードエラー系は外部決済連携の境界確認なので残しています。

## 確認
- bin/rails test test/models/report_notifier_test.rb test/models/first_report_notifier_test.rb test/models/user_test.rb