### PR TITLE
次に遅いsystem testをmodel testへ置き換える

### DIFF
--- a/test/models/first_report_notifier_test.rb
+++ b/test/models/first_report_notifier_test.rb
@@ -15,6 +15,7 @@ class FirstReportNotifierTest < ActiveSupport::TestCase
     assert_difference -> { AbstractNotifier::Testing::Driver.enqueued_deliveries.count }, User.admins_and_mentors.count do
       notifier.call('report.update', Time.current, Time.current, 'unique_id', report:)
     end
+    assert_equal User.admins_and_mentors.sort, AbstractNotifier::Testing::Driver.enqueued_deliveries.pluck(:receiver).sort
 
     Notification.create!(
       kind: :first_report,

--- a/test/system/notification/reports_test.rb
+++ b/test/system/notification/reports_test.rb
@@ -13,17 +13,6 @@ class Notification::ReportsTest < NotificationSystemTestCase
     AbstractNotifier.delivery_mode = @delivery_mode
   end
 
-  test 'the first daily report notification is sent only to mentors' do
-    create_report_as('muryou', '初日報です', '初日報の内容です', save_as_wip: false)
-
-    notification_message = 'muryouさんがはじめての日報を書きました！'
-
-    assert_user_has_notification(user: users(:machida), kind: Notification.kinds[:first_report], text: notification_message)
-    assert_user_has_no_notification(user: users(:kimura), kind: Notification.kinds[:first_report], text: notification_message)
-    assert_user_has_no_notification(user: users(:advijirou), kind: Notification.kinds[:first_report], text: notification_message)
-    assert_user_has_no_notification(user: users(:sotugyou), kind: Notification.kinds[:first_report], text: notification_message)
-  end
-
   test 'notify when WIP report submitted' do
     Report.all.find_each(&:destroy)
 
@@ -118,36 +107,6 @@ class Notification::ReportsTest < NotificationSystemTestCase
 
     visit_with_auth '/notifications?status=unread', 'komagata'
     assert_text '未読の通知はありません'
-    logout
-  end
-
-  def assert_notify_only_when_report_is_initially_posted(
-    notification_message,
-    author_login_name,
-    received_user_login_name,
-    title,
-    description
-  )
-    report_id = create_report_as(author_login_name, title, description, save_as_wip: true)
-
-    # 日報を WIP -> 提出 -> 内容変更 の流れで作成・更新し通知の有無を確認する
-    visit_with_auth notifications_path(status: 'unread'), received_user_login_name
-    assert_no_selector(notification_selector,
-                       text: notification_message)
-    logout
-
-    update_report_as_author(report_id, title, description, save_as_wip: false)
-    visit_with_auth notifications_path(status: 'unread'), received_user_login_name
-    assert_selector(notification_selector,
-                    text: notification_message)
-    click_link(notification_message)
-    assert_equal current_path, report_path(report_id)
-    logout
-
-    update_report_as_author(report_id, title, description, save_as_wip: false)
-    visit_with_auth notifications_path(status: 'unread'), received_user_login_name
-    assert_no_selector(notification_selector,
-                       text: notification_message)
     logout
   end
 


### PR DESCRIPTION
## 概要
同じような内容を確認している重いsystem testを削除し、通知・バリデーションの主題をmodel testで確認するようにします。

## 変更内容
- 初日報通知の条件を `FirstReportNotifier` のmodel testで確認
- フォロー中ユーザーの日報通知を `ReportNotifier` のmodel testで確認
- サインアップ時の予約済みログイン名・自己紹介必須を `User` のmodel testで確認
- 上記と重複するsystem testを削除

## 確認
- `bin/rails test test/models/first_report_notifier_test.rb test/system/notification/reports_test.rb test/models/report_notifier_test.rb test/models/user_test.rb test/system/sign_up/validation_test.rb`
- `bin/rubocop test/models/first_report_notifier_test.rb test/system/notification/reports_test.rb test/models/report_notifier_test.rb test/models/user_test.rb test/system/sign_up/validation_test.rb --format progress`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト

* **Tests**
  * 通知配信動作に関するユニットテストを追加（管理者、メンター、フォロワーへの通知を検証）
  * ユーザー検証テストを追加（予約済みログイン名と必須フィールドの検証）
  * 通知関連のシステムテストを統合・再構成しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->