### PR TITLE
Pjordの内部手順説明をコメントに出さない

### DIFF
--- a/app/models/pjord.rb
+++ b/app/models/pjord.rb
@@ -117,7 +117,10 @@ class Pjord
     end
 
     def parse_response_body(content)
-      JSON.parse(content)['body']
+      parsed = JSON.parse(content)
+      return parsed['body'] if parsed.is_a?(Hash)
+
+      content
     rescue JSON::ParserError
       content
     end

--- a/app/models/pjord.rb
+++ b/app/models/pjord.rb
@@ -38,7 +38,8 @@ class Pjord
       chat.with_instructions(system_prompt(context, instructions:))
       chat.with_tool(BootcampSearchTool)
       chat.with_tool(UserInfoTool)
-      result = remove_internal_preamble(chat.ask(message).content)
+      chat.with_schema(PjordResponse)
+      result = extract_public_response_body(chat.ask(message).content)
       result.presence
     end
 
@@ -104,10 +105,27 @@ class Pjord
       parts.join("\n\n")
     end
 
-    def remove_internal_preamble(content)
-      return content unless content.is_a?(String)
+    def extract_public_response_body(content)
+      body =
+        if content.is_a?(String)
+          parse_response_body(content)
+        elsif content.respond_to?(:to_h)
+          content.to_h['body'] || content.to_h[:body]
+        end
 
-      content.sub(/\A(?:検索結果を踏まえて、)?(?:日報へのコメント|回答|コメント)を作成します。\s*/, '')
+      remove_internal_preamble(body)
+    end
+
+    def parse_response_body(content)
+      JSON.parse(content)['body']
+    rescue JSON::ParserError
+      content
+    end
+
+    def remove_internal_preamble(body)
+      return body unless body.is_a?(String)
+
+      body.sub(/\A\s*(?:検索結果を踏まえて、)?(?:日報へのコメント|回答|コメント)を作成します。\s*/, '')
     end
   end
 end

--- a/app/models/pjord.rb
+++ b/app/models/pjord.rb
@@ -110,7 +110,8 @@ class Pjord
         if content.is_a?(String)
           parse_response_body(content)
         elsif content.respond_to?(:to_h)
-          content.to_h['body'] || content.to_h[:body]
+          parsed = content.to_h
+          parsed['body'] || parsed[:body] if parsed.is_a?(Hash)
         end
 
       remove_internal_preamble(body)
@@ -118,9 +119,7 @@ class Pjord
 
     def parse_response_body(content)
       parsed = JSON.parse(content)
-      return parsed['body'] if parsed.is_a?(Hash)
-
-      content
+      parsed.is_a?(Hash) ? parsed['body'] : content
     rescue JSON::ParserError
       content
     end

--- a/app/models/pjord.rb
+++ b/app/models/pjord.rb
@@ -18,6 +18,7 @@ class Pjord
     - 簡潔にわかりやすく答える
     - ユーザーが書いた言語で返答する
     - 語尾に「ピヨ」など特徴的な語尾は付けず、通常の丁寧な日本語で話す
+    - 検索結果を踏まえたこと、ツールを使ったこと、コメントや回答を作成することなど、内部の手順説明は出力しない
 
     ## ツールの使い方
     - bootcampのカリキュラム、ドキュメント、Q&Aに関する質問には、bootcamp_search_toolで検索してから回答する
@@ -37,7 +38,7 @@ class Pjord
       chat.with_instructions(system_prompt(context, instructions:))
       chat.with_tool(BootcampSearchTool)
       chat.with_tool(UserInfoTool)
-      result = chat.ask(message).content
+      result = remove_internal_preamble(chat.ask(message).content)
       result.presence
     end
 
@@ -101,6 +102,12 @@ class Pjord
       parts << "## メンションしてきたユーザー\nログイン名: #{context[:sender_login_name]}" if context[:sender_login_name].present?
 
       parts.join("\n\n")
+    end
+
+    def remove_internal_preamble(content)
+      return content unless content.is_a?(String)
+
+      content.sub(/\A(?:検索結果を踏まえて、)?(?:日報へのコメント|回答|コメント)を作成します。\s*/, '')
     end
   end
 end

--- a/app/models/pjord_response.rb
+++ b/app/models/pjord_response.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'ruby_llm/schema'
+
+class PjordResponse < RubyLLM::Schema
+  description 'ピヨルドがユーザーに公開する返答本文'
+
+  string :body,
+         description: 'ユーザーにそのまま見せる本文。検索やツール使用などの内部手順説明は含めない。'
+end

--- a/test/models/pjord_test.rb
+++ b/test/models/pjord_test.rb
@@ -15,6 +15,7 @@ class PjordTest < ActiveSupport::TestCase
     mock_chat.expect(:with_instructions, mock_chat, [String])
     mock_chat.expect(:with_tool, mock_chat, [BootcampSearchTool])
     mock_chat.expect(:with_tool, mock_chat, [UserInfoTool])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
     mock_chat.expect(:ask, mock_content, [String])
 
     RubyLLM.stub(:chat, mock_chat) do
@@ -31,6 +32,7 @@ class PjordTest < ActiveSupport::TestCase
     mock_chat.expect(:with_instructions, mock_chat, [String])
     mock_chat.expect(:with_tool, mock_chat, [BootcampSearchTool])
     mock_chat.expect(:with_tool, mock_chat, [UserInfoTool])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
     mock_chat.expect(:ask, mock_content, [String])
 
     RubyLLM.stub(:chat, mock_chat) do
@@ -41,17 +43,35 @@ class PjordTest < ActiveSupport::TestCase
 
   test '.respond removes internal preamble from response' do
     mock_content = Minitest::Mock.new
-    mock_content.expect(:content, "検索結果を踏まえて、日報へのコメントを作成します。\n\n少しずつ進められていますね。")
+    mock_content.expect(:content, "\n検索結果を踏まえて、日報へのコメントを作成します。\n\n少しずつ進められていますね。")
 
     mock_chat = Minitest::Mock.new
     mock_chat.expect(:with_instructions, mock_chat, [String])
     mock_chat.expect(:with_tool, mock_chat, [BootcampSearchTool])
     mock_chat.expect(:with_tool, mock_chat, [UserInfoTool])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
     mock_chat.expect(:ask, mock_content, [String])
 
     RubyLLM.stub(:chat, mock_chat) do
       response = Pjord.respond(message: 'test')
       assert_equal '少しずつ進められていますね。', response
+    end
+  end
+
+  test '.respond extracts body from structured response' do
+    mock_content = Minitest::Mock.new
+    mock_content.expect(:content, '{"body":"公開する本文です。"}')
+
+    mock_chat = Minitest::Mock.new
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_tool, mock_chat, [BootcampSearchTool])
+    mock_chat.expect(:with_tool, mock_chat, [UserInfoTool])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
+    mock_chat.expect(:ask, mock_content, [String])
+
+    RubyLLM.stub(:chat, mock_chat) do
+      response = Pjord.respond(message: 'test')
+      assert_equal '公開する本文です。', response
     end
   end
 

--- a/test/models/pjord_test.rb
+++ b/test/models/pjord_test.rb
@@ -75,6 +75,23 @@ class PjordTest < ActiveSupport::TestCase
     end
   end
 
+  test '.respond returns original response when JSON is not an object' do
+    mock_content = Minitest::Mock.new
+    mock_content.expect(:content, '["公開する本文です。"]')
+
+    mock_chat = Minitest::Mock.new
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_tool, mock_chat, [BootcampSearchTool])
+    mock_chat.expect(:with_tool, mock_chat, [UserInfoTool])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
+    mock_chat.expect(:ask, mock_content, [String])
+
+    RubyLLM.stub(:chat, mock_chat) do
+      response = Pjord.respond(message: 'test')
+      assert_equal '["公開する本文です。"]', response
+    end
+  end
+
   test '.respond raises on API error for job retry' do
     RubyLLM.stub(:chat, ->(*) { raise StandardError, 'API error' }) do
       assert_raises(StandardError) do

--- a/test/models/pjord_test.rb
+++ b/test/models/pjord_test.rb
@@ -39,6 +39,22 @@ class PjordTest < ActiveSupport::TestCase
     end
   end
 
+  test '.respond removes internal preamble from response' do
+    mock_content = Minitest::Mock.new
+    mock_content.expect(:content, "検索結果を踏まえて、日報へのコメントを作成します。\n\n少しずつ進められていますね。")
+
+    mock_chat = Minitest::Mock.new
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_tool, mock_chat, [BootcampSearchTool])
+    mock_chat.expect(:with_tool, mock_chat, [UserInfoTool])
+    mock_chat.expect(:ask, mock_content, [String])
+
+    RubyLLM.stub(:chat, mock_chat) do
+      response = Pjord.respond(message: 'test')
+      assert_equal '少しずつ進められていますね。', response
+    end
+  end
+
   test '.respond raises on API error for job retry' do
     RubyLLM.stub(:chat, ->(*) { raise StandardError, 'API error' }) do
       assert_raises(StandardError) do

--- a/test/models/pjord_test.rb
+++ b/test/models/pjord_test.rb
@@ -92,6 +92,28 @@ class PjordTest < ActiveSupport::TestCase
     end
   end
 
+  test '.respond returns nil when structured response cannot be converted to a hash' do
+    content = Struct.new(:body) do
+      def to_h
+        ['公開する本文です。']
+      end
+    end.new
+
+    mock_content = Minitest::Mock.new
+    mock_content.expect(:content, content)
+
+    mock_chat = Minitest::Mock.new
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_tool, mock_chat, [BootcampSearchTool])
+    mock_chat.expect(:with_tool, mock_chat, [UserInfoTool])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
+    mock_chat.expect(:ask, mock_content, [String])
+
+    RubyLLM.stub(:chat, mock_chat) do
+      assert_nil Pjord.respond(message: 'test')
+    end
+  end
+
   test '.respond raises on API error for job retry' do
     RubyLLM.stub(:chat, ->(*) { raise StandardError, 'API error' }) do
       assert_raises(StandardError) do


### PR DESCRIPTION
## 概要
Pjordの生成コメントに「検索結果を踏まえて、日報へのコメントを作成します。」のような内部手順の説明が表示されないようにします。

## 変更内容
- Pjordのシステムプロンプトに内部手順説明を出力しない指示を追加
- 生成結果の先頭に内部手順の前置きが混ざった場合に取り除く処理を追加
- 回帰テストを追加

## 確認
- `bin/rails test test/models/pjord_test.rb test/jobs/pjord_report_comment_job_test.rb`
- `bin/rubocop app/models/pjord.rb test/models/pjord_test.rb --format progress`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM応答を明確な「本文(body)」フィールドで返すスキーマを導入し、表示内容を安定化しました。

* **Bug Fixes**
  * 応答から内部手順説明や検索参照などのプリアンブルを自動除去し、ユーザー向けコメント・回答のみを表示するよう改善しました。
  * システムプロンプトを強化し、内部処理の出力を抑制しました。

* **Tests**
  * 本文抽出とプリアンブル除去を検証するユニットテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->