### PR TITLE
リンクカード　フォールバック処理を追加

### DIFF
--- a/app/javascript/replace-link-to-card.js
+++ b/app/javascript/replace-link-to-card.js
@@ -166,7 +166,7 @@ const embedToLinkCard = async (targetLink, url) => {
 
     const descriptionSection = metaData.description
       ? `<p>${metaData.description}</p>`
-      : `<p><a href="${url}" target="_blank" rel="noopener" class="a-link-card__body-url-link">${url}</a></p>`
+      : ''
 
     const faviconSection = metaData.favicon
       ? `

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -50,7 +50,7 @@ class Metadata
 
   def favicon(html)
     doc = Nokogiri::HTML(html)
-    favicon_path = doc.at_css('link[rel="icon"], link[rel="shortcut icon"]')&.attr('href')
+    favicon_path = doc.at_css('link[rel="icon"], link[rel="shortcut icon"]')&.[]('href')
     return unless favicon_path
 
     absolute_regexp = URI::DEFAULT_PARSER.make_regexp

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -15,7 +15,7 @@ class Metadata
 
   def parse(html)
     object = OpenGraphReader.parse(html)
-    return unless object
+    return metadata_fallback(html) if object.nil?
 
     {
       title: object.og.title,
@@ -26,6 +26,22 @@ class Metadata
       url: @url,
       site_url: site_url
     }
+  end
+
+  def metadata_fallback(html)
+    doc = Nokogiri::HTML(html)
+    metadata = {
+      title: fallback_title(doc),
+      description: fallback_description(doc),
+      images: fallback_images(doc),
+      site_name: fallback_site_name(doc) || @uri.host,
+      favicon: favicon(html),
+      url: @url,
+      site_url: site_url
+    }
+    return nil if metadata[:title].blank?
+
+    metadata
   end
 
   def site_url
@@ -45,5 +61,26 @@ class Metadata
     else
       URI.join(@url, favicon_path).to_s
     end
+  end
+
+  def fallback_title(doc)
+    card_content(doc, 'title') || doc.at_css('title')&.text&.strip
+  end
+
+  def fallback_description(doc)
+    card_content(doc, 'description') || doc.at_css('meta[name="description"]')&.[]('content')
+  end
+
+  def fallback_images(doc)
+    card_content(doc, 'image') || doc.at_css('link[rel="image_src"]')&.[]('href')
+  end
+
+  def fallback_site_name(doc)
+    card_content(doc, 'site_name') || doc.at_css('meta[name="application-name"]')&.[]('content')
+  end
+
+  def card_content(doc, type)
+    card_nodes = doc.css("meta[property='og:#{type}'], meta[name='twitter:#{type}']")
+    card_nodes.find { |n| n['property'] == "og:#{type}" || n['name'] == "twitter:#{type}" }&.[]('content')
   end
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -80,7 +80,7 @@ class Metadata
   end
 
   def card_content(doc, type)
-    doc.at_css("meta[property='og:#{type}']")&.[]('content') ||
-      doc.at_css("meta[name='twitter:#{type}']")&.[]('content')
+    doc.at_css("meta[property='og:#{type}']")&.[]('content').presence ||
+      doc.at_css("meta[name='twitter:#{type}']")&.[]('content').presence
   end
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -80,7 +80,7 @@ class Metadata
   end
 
   def card_content(doc, type)
-    card_nodes = doc.css("meta[property='og:#{type}'], meta[name='twitter:#{type}']")
-    card_nodes.find { |n| n['property'] == "og:#{type}" || n['name'] == "twitter:#{type}" }&.[]('content')
+    doc.at_css("meta[property='og:#{type}']")&.[]('content') ||
+      doc.at_css("meta[name='twitter:#{type}']")&.[]('content')
   end
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -35,7 +35,7 @@ class Metadata
 
   def parse(html)
     object = OpenGraphReader.parse(html)
-    return unless object
+    return metadata_fallback(html) if object.nil?
 
     {
       title: object.og.title,
@@ -91,5 +91,42 @@ class Metadata
     }
   rescue JSON::ParserError, *NETWORK_ERRORS
     nil
+  end
+
+  def metadata_fallback(html)
+    doc = Nokogiri::HTML(html)
+    metadata = {
+      title: fallback_title(doc),
+      description: fallback_description(doc),
+      images: fallback_images(doc),
+      site_name: fallback_site_name(doc) || @uri.host,
+      favicon: favicon(html),
+      url: @url,
+      site_url: site_url
+    }
+    return nil if metadata[:title].blank?
+
+    metadata
+  end
+
+  def fallback_title(doc)
+    card_content(doc, 'title') || doc.at_css('title')&.text&.strip
+  end
+
+  def fallback_description(doc)
+    card_content(doc, 'description') || doc.at_css('meta[name="description"]')&.[]('content')
+  end
+
+  def fallback_images(doc)
+    card_content(doc, 'image') || doc.at_css('link[rel="image_src"]')&.[]('href')
+  end
+
+  def fallback_site_name(doc)
+    card_content(doc, 'site_name') || doc.at_css('meta[name="application-name"]')&.[]('content')
+  end
+
+  def card_content(doc, type)
+    doc.at_css("meta[property='og:#{type}']")&.[]('content').presence ||
+      doc.at_css("meta[name='twitter:#{type}']")&.[]('content').presence
   end
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -35,7 +35,8 @@ class Metadata
   private
 
   def parse(html)
-    object = OpenGraphReader.parse(html)
+    OpenGraphReader.config.synthesize_full_image_url = true
+    object = OpenGraphReader.parse(html, @url)
     return metadata_fallback(html) if object.nil?
 
     {
@@ -119,7 +120,10 @@ class Metadata
   end
 
   def fallback_images(doc)
-    card_content(doc, 'image') || doc.at_css('link[rel="image_src"]')&.[]('href')
+    image_path = card_content(doc, 'image') || doc.at_css('link[rel="image_src"]')&.[]('href')
+    return nil if image_path.blank?
+
+    URI.join(@url, image_path).to_s
   end
 
   def fallback_site_name(doc)

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -23,7 +23,8 @@ class Metadata
     end
     http.response_body_encoding = true
 
-    response = http.request_get(@uri.request_uri)
+    header = { 'User-Agent' => 'Bootcamp-LinkCard (+https://github.com/fjordllc/bootcamp)' }
+    response = http.request_get(@uri.request_uri, header)
     return fetch_youtube_oembed unless response.is_a?(Net::HTTPSuccess)
 
     parse(response.body) || fetch_youtube_oembed

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -152,7 +152,7 @@ class MarkdownTest < ApplicationSystemTestCase
 
     click_button '提出'
     assert_selector '.a-link-card__title'
-    assert_no_selector 'a.before-replacement-link-card[href="https://bootcamp.fjord.jp/"]', visible: true
+    assert_no_selector 'a.before-replacement-link-card[href="https://ja.wikipedia.org/wiki/日本語"]', visible: true
     assert_no_selector '.embed-error'
   end
 end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -110,10 +110,10 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_no_selector '.embed-error'
   end
 
-  test 'expands link card even when og:url is missing' do
+  test 'expands link card even when og:url is empty' do
     visit_with_auth new_report_path, 'komagata'
     within('form[name=report]') do
-      fill_in('report[title]', with: 'リンクカードが展開される')
+      fill_in('report[title]', with: 'og:urlが空のサイトでもリンクカードが展開される')
       fill_in('report[description]', with: '@[card](https://www.wikipedia.org/)')
       fill_in('report[reported_on]', with: Time.current)
 
@@ -137,6 +137,22 @@ class MarkdownTest < ApplicationSystemTestCase
 
     click_button '提出'
     assert_selector '.a-link-card__title'
+    assert_no_selector '.embed-error'
+  end
+
+  test 'expands link card even when og:url is missing' do
+    visit_with_auth new_report_path, 'komagata'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'og:urlがないサイトでもリンクカードが展開される')
+      fill_in('report[description]', with: '@[card](https://ja.wikipedia.org/wiki/日本語)')
+      fill_in('report[reported_on]', with: Time.current)
+
+      check '学習時間は無し', allow_label_click: true
+    end
+
+    click_button '提出'
+    assert_selector '.a-link-card__title'
+    assert_no_selector 'a.before-replacement-link-card[href="https://bootcamp.fjord.jp/"]', visible: true
     assert_no_selector '.embed-error'
   end
 end

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -56,6 +56,23 @@ class MarkdownTest < ApplicationSystemTestCase
   end
 
   test 'expands link card' do
+    stub_request(:get, 'https://bootcamp.fjord.jp/')
+      .to_return(status: 200, body: <<~HTML, headers: { 'Content-Type' => 'text/html; charset=utf-8' })
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta property="og:title" content="FJORD BOOT CAMP（フィヨルドブートキャンプ）">
+        <meta property="og:type" content="website">
+        <meta property="og:site_name" content="fjord bootcamp">
+        <meta property="og:description" content="現場の即戦力になるためのスキルとプログラミングの楽しさを伝えるオンラインプログラミングスクール">
+        <meta property="og:image" content="https://bootcamp.fjord.jp/ogp/ogp.png">
+        <meta property="og:url" content="https://bootcamp.fjord.jp">
+        <link rel="icon" href="https://bootcamp.fjord.jp/favicon.ico">
+        </head>
+        <body></body>
+        </html>
+      HTML
+
     visit_with_auth new_report_path, 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: 'リンクカードが展開される')
@@ -126,10 +143,26 @@ class MarkdownTest < ApplicationSystemTestCase
   end
 
   test 'expands link card even when favicon is missing' do
+    stub_request(:get, 'https://example.com/favicon-missing')
+      .to_return(status: 200, body: <<~HTML, headers: { 'Content-Type' => 'text/html; charset=utf-8' })
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta property="og:title" content="faviconが存在しないURLでもリンクカードを展開できる">
+        <meta property="og:type" content="website">
+        <meta property="og:site_name" content="Example">
+        <meta property="og:description" content="faviconタグが無いページの説明文">
+        <meta property="og:image" content="https://example.com/favicon-missing/ogp.png">
+        <meta property="og:url" content="https://example.com/favicon-missing">
+        </head>
+        <body></body>
+        </html>
+      HTML
+
     visit_with_auth new_report_path, 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: 'リンクカードが展開される')
-      fill_in('report[description]', with: '@[card](https://zenn.dev/)')
+      fill_in('report[description]', with: '@[card](https://example.com/favicon-missing)')
       fill_in('report[reported_on]', with: Time.current)
 
       check '学習時間は無し', allow_label_click: true

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -127,21 +127,6 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_no_selector '.embed-error'
   end
 
-  test 'expands link card even when og:url is missing' do
-    visit_with_auth new_report_path, 'komagata'
-    within('form[name=report]') do
-      fill_in('report[title]', with: 'リンクカードが展開される')
-      fill_in('report[description]', with: '@[card](https://www.wikipedia.org/)')
-      fill_in('report[reported_on]', with: Time.current)
-
-      check '学習時間は無し', allow_label_click: true
-    end
-
-    click_button '提出'
-    assert_selector '.a-link-card__title'
-    assert_no_selector '.embed-error'
-  end
-
   test 'expands link card even when favicon is missing' do
     stub_request(:get, 'https://example.com/favicon-missing')
       .to_return(status: 200, body: <<~HTML, headers: { 'Content-Type' => 'text/html; charset=utf-8' })

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -140,6 +140,31 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_no_selector '.embed-error'
   end
 
+  test 'expands link card as long as og:title is present' do
+    html = <<~HTML
+      <html>
+        <head>
+          <meta property="og:title" content="OGPプロパティがtitleのみのURLでもリンクカードを展開できる">
+        </head>
+      </html>
+    HTML
+    stub_request(:get, 'https://example.com/og-title-only').to_return(status: 200, body: html, headers: { 'Content-Type' => 'text/html' })
+
+    visit_with_auth new_report_path, 'komagata'
+    within('form[name=report]') do
+      fill_in('report[title]', with: 'リンクカードが展開される')
+      fill_in('report[description]', with: '@[card](https://example.com/og-title-only)')
+      fill_in('report[reported_on]', with: Time.current)
+
+      check '学習時間は無し', allow_label_click: true
+    end
+
+    click_button '提出'
+    assert_selector '.a-link-card__title'
+    assert_no_selector 'a.before-replacement-link-card[href="https://example.com/og-title-only"]', visible: true
+    assert_no_selector '.embed-error'
+  end
+
   test 'When you press Ctrl + i in the report, it will type the user icon.' do
     reset_avatar(users(:komagata))
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9920

## 概要
このPRは`https://ja.wikipedia.org/wiki/日本語`のURLがリンクカードとして展開できないバグを修正するものです。
リンクカードでOGPを取得する際、OGP取得に使っているGemが`nil`を返す場合のフォールバック処理を追加しました。

## 変更確認方法
1. `bug/fix-link-card-expansion-opengraph-fallback`をローカルに取り込み、チェックアウト
2. `bin/dev`でサーバーを起動
3. [日報を作成](http://localhost:3000/reports/new)(ログインしていなければログイン　誰でも良いです)
4. 以下テキストを"内容"に貼り付けする
```
@[card](https://ja.wikipedia.org/wiki/日本語)
```
5. プレビューにて、リンクカードが正常に展開されることを確認

## Screenshot

### 変更前
<img width="650" height="102" alt="image" src="https://github.com/user-attachments/assets/3bfcb9d1-9dd8-4229-930b-aa0c13dbe236" />

### 変更後
<img width="600" height="184" alt="image" src="https://github.com/user-attachments/assets/3d808abc-5ae8-473f-a6ee-f7d4b27ff604" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * OpenGraphタグが利用できない場合も、HTMLのタイトルやdescription、画像、サイト名などからリンクカードの情報を補完できるようになりました。
  * タイトルが取得できない場合は、不要な空のリンクカードを表示しないよう改善しました。
  * 説明文がないリンクカードで、URLが重複表示される問題を修正しました。
  * 外部ページの解析時にUser-Agentを送信するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-9958-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->