### PR TITLE
FBCのHPの 給付金対象Railsエンジニアコース の講座概要に指定講座番号　1312050 - 2510011 - 2を追加

### DIFF
--- a/app/views/welcome/certified_reskill_courses/rails_developer_course/_course_overview.html.slim
+++ b/app/views/welcome/certified_reskill_courses/rails_developer_course/_course_overview.html.slim
@@ -19,6 +19,12 @@ section.lp-content.is-lp-bg-1.is-top-title
                         | 給付金対象Railsエンジニアコース
                   tr
                     th
+                      | 指定講座番号
+                    td
+                      p
+                        | 1312050-2510011-2
+                  tr
+                    th
                       | 講座内容
                     td
                       p
@@ -105,6 +111,8 @@ section.lp-content.is-lp-bg-1.is-top-title
                       ul
                         li
                           = link_to '利用規約', tos_path, class: 'a-text-link', target: '_blank', rel: 'noopener'
+                        li
+                          = link_to 'プライバシーポリシー', pp_path, class: 'a-text-link', target: '_blank', rel: 'noopener'
                         li
                           = link_to 'アンチハラスメントポリシー', coc_path, class: 'a-text-link', target: '_blank', rel: 'noopener'
                   tr


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **新機能**
  * コース概要ページにコース番号フィールドを追加しました
  * 規約セクションにプライバシーポリシーへのリンクを新たに追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->