### PR TITLE
CodeRabbitのテストルールにテストケース間の空行を追加

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,5 +23,6 @@ reviews:
         # Test
         - TestCase名は英語で書く。
         - どうしても避けられない時以外にsystem testでsleepは使わない。
+        - 各テストケースの間には空行を設ける。
         # Unit Test
         model, helper, decorator, view_componentについてはメソッドを追加した場合は必ず対応したUnit TestのTestCaseを1つは書く。


### PR DESCRIPTION
https://github.com/fjordllc/bootcamp/issues/9707
これの対応。

## 概要

CodeRabbitのテストルールに「各テストケースの間には空行を設ける」を追加する。

## 背景

テストケース間の空行はレビュー時に指摘されることがあるが（参考: #9626）、RuboCopのEmptyLineAfterExampleはRSpec専用であり、このプロジェクトで使用しているMinitestには対応していない。

 機械的に検出できるものは機械に任せ、レビュー時の人的リソースの消費を減らすため、CodeRabbitで検出できるようにする。

## 変更内容

coderabbit.yaml の test/**/* ルールに以下を追記。

- 各テストケースの間には空行を設ける。