### PR TITLE
tributeのselectTemplate/menuItemTemplateでitemがundefinedの場合のガードを追加

### DIFF
--- a/app/javascript/textarea-autocomplte-emoji.js
+++ b/app/javascript/textarea-autocomplte-emoji.js
@@ -16,9 +16,11 @@ export default class {
         this._filterValues(text, callback)
       },
       selectTemplate: (item) => {
+        if (!item) return ''
         return item.original.value
       },
       menuItemTemplate: (item) => {
+        if (!item) return ''
         if (item.original.isUser) {
           return (
             `<span class='mention'>${escapeHtml(

--- a/app/javascript/textarea-autocomplte-mention.js
+++ b/app/javascript/textarea-autocomplte-mention.js
@@ -18,6 +18,7 @@ export default class {
         return person.login_name + person.name
       },
       menuItemTemplate: (item) => {
+        if (!item) return ''
         return (
           `<span class='mention'>${escapeHtml(
             item.original.login_name


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

https://github.com/fjordllc/bootcamp/issues/9859

## 概要

  絵文字・メンションのオートコンプリートで `item` が `undefined`
  の場合にエラーが発生するバグを修正する。

  ## 原因

  tribute.js の `selectTemplate` / `menuItemTemplate` コールバックは、メニューを
  開いた状態でEscキーを押すなど、アイテムが存在しない状態で選択が走った際に
  `item` が `undefined` になることがある。その状態で `item.original`
  にアクセスしようとしてエラーが発生していた。

  TypeError: Cannot read properties of undefined (reading 'original')

  参考: #9859

  ## 変更内容

  `item` が `undefined` の場合に早期リターンするガードを追加した。

  - `textarea-autocomplte-emoji.js` — `selectTemplate`、`menuItemTemplate`
  - `textarea-autocomplte-mention.js` — `menuItemTemplate`