### PR TITLE
会員登録完了時のコンバージョンタグに拡張コンバージョン用のuser_dataを追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,6 +82,7 @@ class UsersController < ApplicationController # rubocop:todo Metrics/ClassLength
 
   def created
     @role = params[:role] || 'student'
+    @email = flash[:signup_email]
   end
 
   def toggle_show_study_streak
@@ -120,6 +121,7 @@ class UsersController < ApplicationController # rubocop:todo Metrics/ClassLength
       notify_to_chat(@user)
       ActiveSupport::Notifications.instrument('student_or_trainee.create', user: @user) if @user.trainee?
       logger.info "[Signup] 4. after create times channel for free user. #{@user.email}"
+      flash[:signup_email] = @user.email
       redirect_to created_users_path(role: determine_user_role(@user))
     else
       render 'new', locals: { user: @user }
@@ -167,6 +169,7 @@ class UsersController < ApplicationController # rubocop:todo Metrics/ClassLength
         ActiveSupport::Notifications.instrument('student_or_trainee.create', user: @user) if @user.student?
         send_affiliate_kickback(@user)
         flash[:x_conversion] = 'signup'
+        flash[:signup_email] = @user.email
         logger.info "[Signup] 8. after create times channel. #{@user.email}"
         redirect_to created_users_path(role: determine_user_role(@user))
       else

--- a/app/views/users/created.html.slim
+++ b/app/views/users/created.html.slim
@@ -15,6 +15,7 @@ ruby:
 - if Rails.env.production? && !staging? && @role == 'student'
   - content_for :head_last do
     script
+      | gtag('set', 'user_data', { email: '#{@email}' });
       | gtag('event', 'conversion', {
       |     'send_to': 'AW-17419900911/A8LTCJzqyIkbEO-vuvJA',
       |     'transaction_id': ''


### PR DESCRIPTION
 変更内容：
  - users_controller.rb — create_free_user! と create_user! の両方で
  flash[:signup_email] = @user.email を追加
  - users_controller.rb — created アクションで @email = flash[:signup_email]
  を受け取る
  - users/created.html.slim — コンバージョンタグの直前に gtag('set',
  'user_data', { email: '...' }) を追加

  これにより、会員登録完了ページでGoogleがメールアドレスをSHA256ハッシュ化して拡
  張コンバージョンデータとして送信します。