### PR TITLE
[codex] Rollback Stripe resources on signup failure

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -129,6 +129,8 @@ class UsersController < ApplicationController # rubocop:todo Metrics/ClassLength
   # rubocop:disable Metrics/MethodLength, Metrics/BlockLength
   def create_user!
     logger.info "[Signup] 2. start create user. #{@user.email}"
+    customer = nil
+    subscription = nil
     @user.with_lock do
       unless @user.validate
         render 'new'
@@ -173,8 +175,32 @@ class UsersController < ApplicationController # rubocop:todo Metrics/ClassLength
         render 'new'
       end
     end
+  rescue StandardError
+    rollback_stripe_resources(customer, subscription)
+    raise
   end
   # rubocop:enable Metrics/MethodLength, Metrics/BlockLength
+
+  def rollback_stripe_resources(customer, subscription)
+    return if customer.blank?
+
+    customer_id = customer['id']
+    subscription_id = subscription&.[]('id')
+    rollback_stripe_subscription(subscription_id) if subscription_id.present?
+    rollback_stripe_customer(customer_id)
+  end
+
+  def rollback_stripe_subscription(subscription_id)
+    Subscription.new.cancel_immediately(subscription_id)
+  rescue Stripe::StripeError => e
+    logger.error "[Payment] subscriptionのロールバック時にエラーが発生しました: #{e.message}"
+  end
+
+  def rollback_stripe_customer(customer_id)
+    Card.new.destroy(customer_id)
+  rescue Stripe::StripeError => e
+    logger.error "[Payment] customerのロールバック時にエラーが発生しました: #{e.message}"
+  end
 
   def send_affiliate_kickback(user)
     rd_code = session[:affiliate_rd_code]

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -31,6 +31,10 @@ class Card
     Stripe::Customer.update(customer_id, source: card_token)
   end
 
+  def destroy(customer_id)
+    Stripe::Customer.delete(customer_id)
+  end
+
   def search(email:)
     result = Stripe::Customer.list(email:, limit: 1)
     return unless result.data.size.positive?

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -29,6 +29,10 @@ class Subscription
     Stripe::Subscription.update(subscription_id, cancel_at_period_end: true)
   end
 
+  def cancel_immediately(subscription_id)
+    Stripe::Subscription.cancel(subscription_id)
+  end
+
   def all
     Stripe::Subscription.list({ status: 'all' }).auto_paging_each.map { |sub| sub }
   end

--- a/test/integration/discord/users_controller_test.rb
+++ b/test/integration/discord/users_controller_test.rb
@@ -44,6 +44,49 @@ module Discord
       assert_not_nil student.discord_profile.times_id
     end
 
+    test 'POST create by student rolls back Stripe resources when notification fails after user save' do
+      FakeCard.reset
+      FakeSubscription.reset
+
+      mock_env('DISCORD_GUILD_ID' => '111') do
+        Card.stub(:new, -> { FakeCard.new }) do
+          Subscription.stub(:new, -> { FakeSubscription.new }) do
+            Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
+              UserMailer.stub(:welcome, ->(_) { FailingMail.new }) do
+                assert_no_difference 'User.students.count' do
+                  assert_raises Postmark::InvalidApiKeyError do
+                    post users_path,
+                         params: {
+                           user: {
+                             adviser: 'false',
+                             trainee: 'false',
+                             company_id: '',
+                             login_name: 'Piyopiyo-student-failed',
+                             email: 'piyopiyo-student-failed@example.com',
+                             name: '登録失敗です',
+                             name_kana: 'トウロクシッパイデス',
+                             description: '登録失敗のテストです。',
+                             job: 'part_time_worker',
+                             os: 'linux',
+                             experiences: 0,
+                             password: 'passW0rd1234',
+                             password_confirmation: 'passW0rd1234',
+                             coc: 1,
+                             tos: 2
+                           }
+                         }
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      assert_equal ['fake_subscription_0123456789'], FakeSubscription.canceled_subscription_ids
+      assert_equal ['fake_customer_0123456789'], FakeCard.destroyed_customer_ids
+    end
+
     test 'POST create by trainee' do
       mock_env('DISCORD_GUILD_ID' => '222') do
         Discord::TimesChannel.stub(:new, ->(_) { ValidTimesChannel.new }) do
@@ -141,6 +184,16 @@ module Discord
     end
 
     class FakeCard
+      class << self
+        attr_reader :destroyed_customer_ids
+
+        def reset
+          @destroyed_customer_ids = []
+        end
+      end
+
+      reset
+
       def search(*)
         nil
       end
@@ -150,13 +203,31 @@ module Discord
           id: 'fake_customer_0123456789'
         }.stringify_keys
       end
+
+      def destroy(customer_id)
+        self.class.destroyed_customer_ids << customer_id
+      end
     end
 
     class FakeSubscription
+      class << self
+        attr_reader :canceled_subscription_ids
+
+        def reset
+          @canceled_subscription_ids = []
+        end
+      end
+
+      reset
+
       def create(*)
         {
           id: 'fake_subscription_0123456789'
         }.stringify_keys
+      end
+
+      def cancel_immediately(subscription_id)
+        self.class.canceled_subscription_ids << subscription_id
       end
     end
 
@@ -167,6 +238,12 @@ module Discord
 
       def id
         '1234567890123456789'
+      end
+    end
+
+    class FailingMail
+      def deliver_now
+        raise Postmark::InvalidApiKeyError, 'Request does not contain a valid Server token.'
       end
     end
   end


### PR DESCRIPTION
## Summary
- Cancel the just-created Stripe subscription and delete the Stripe customer when paid user signup fails after Stripe creation.
- Add small Stripe wrapper methods for immediate subscription cancellation and customer deletion.
- Add a regression test for a post-save mail delivery failure during signup.

## Why
A Postmark error after `@user.save` could roll back the local user transaction while leaving Stripe customer/subscription records behind. A retry then failed because Stripe already had a customer for the email.

Fixes #9974

## Checks
- `mise exec -- bin/rails test test/integration/discord/users_controller_test.rb`
- `mise exec -- bin/rails test test/models/card_test.rb test/models/subscription_test.rb`
- `mise exec -- bundle exec rubocop app/controllers/users_controller.rb app/models/card.rb app/models/subscription.rb test/integration/discord/users_controller_test.rb`