### PR TITLE
給付金コースのプラクティスの質問一覧に元コースのプラクティスの質問も表示できるようにした

### DIFF
--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -4,14 +4,14 @@ class Practices::QuestionsController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
     practices =
-      if scope == 'grant_course'
+      if selected_scope == 'grant_course'
         @practice
       else
         [@practice, @practice.source_practice].compact
       end
     @questions = Question.where(practice: practices)
                          .includes(%i[correct_answer answers])
-                         .by_target(target)
+                         .by_target(selected_target)
                          .order(created_at: :desc)
                          .page(params[:page])
     @empty_message = empty_message
@@ -30,11 +30,11 @@ class Practices::QuestionsController < ApplicationController
     end
   end
 
-  def target
+  def selected_target
     params[:target] if %w[solved not_solved].include?(params[:target])
   end
 
-  def scope
+  def selected_scope
     params[:scope] if %w[grant_course].include?(params[:scope])
   end
 end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -25,7 +25,7 @@ class Practices::QuestionsController < ApplicationController
   end
 
   def question_practices
-    if selected_scope == 'grant_course'
+    if params[:scope] == 'grant_course'
       [@practice]
     else
       [@practice, @practice.source_practice].compact
@@ -34,9 +34,5 @@ class Practices::QuestionsController < ApplicationController
 
   def selected_target
     params[:target] if %w[solved not_solved].include?(params[:target])
-  end
-
-  def selected_scope
-    params[:scope] if %w[grant_course].include?(params[:scope])
   end
 end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -3,13 +3,7 @@
 class Practices::QuestionsController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
-    practices =
-      if selected_scope == 'grant_course'
-        [@practice]
-      else
-        [@practice, @practice.source_practice].compact
-      end
-    @questions = Question.where(practice: practices)
+    @questions = Question.where(practice: question_practices)
                          .includes(%i[correct_answer answers])
                          .by_target(selected_target)
                          .order(created_at: :desc)
@@ -27,6 +21,14 @@ class Practices::QuestionsController < ApplicationController
       '未解決のQ&Aはありません。'
     else
       '質問はありません。'
+    end
+  end
+
+  def question_practices
+    if selected_scope == 'grant_course'
+      [@practice]
+    else
+      [@practice, @practice.source_practice].compact
     end
   end
 

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -5,11 +5,19 @@ class Practices::QuestionsController < ApplicationController
     @practice = Practice.find(params[:practice_id])
     allowed_targets = %w[solved not_solved].freeze
     target = allowed_targets.include?(params[:target]) ? params[:target] : nil
-    @questions = @practice.questions
-                          .includes(%i[correct_answer answers])
-                          .by_target(target)
-                          .order(created_at: :desc)
-                          .page(params[:page])
+    allowed_scopes = %w[grant_course].freeze
+    scope = allowed_scopes.include?(params[:scope]) ? params[:scope] : nil
+    practices =
+      if scope == 'grant_course'
+        @practice
+      else
+        [@practice, @practice.source_practice].compact
+      end
+    @questions = Question.where(practice: practices)
+                         .includes(%i[correct_answer answers])
+                         .by_target(target)
+                         .order(created_at: :desc)
+                         .page(params[:page])
     @empty_message = empty_message
   end
 

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -5,7 +5,7 @@ class Practices::QuestionsController < ApplicationController
     @practice = Practice.find(params[:practice_id])
     practices =
       if selected_scope == 'grant_course'
-        @practice
+        [@practice]
       else
         [@practice, @practice.source_practice].compact
       end

--- a/app/controllers/practices/questions_controller.rb
+++ b/app/controllers/practices/questions_controller.rb
@@ -3,10 +3,6 @@
 class Practices::QuestionsController < ApplicationController
   def index
     @practice = Practice.find(params[:practice_id])
-    allowed_targets = %w[solved not_solved].freeze
-    target = allowed_targets.include?(params[:target]) ? params[:target] : nil
-    allowed_scopes = %w[grant_course].freeze
-    scope = allowed_scopes.include?(params[:scope]) ? params[:scope] : nil
     practices =
       if scope == 'grant_course'
         @practice
@@ -32,5 +28,13 @@ class Practices::QuestionsController < ApplicationController
     else
       '質問はありません。'
     end
+  end
+
+  def target
+    params[:target] if %w[solved not_solved].include?(params[:target])
+  end
+
+  def scope
+    params[:scope] if %w[grant_course].include?(params[:scope])
   end
 end

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -8,13 +8,26 @@ module PageTabs
       tabs = []
       tabs << { name: 'プラクティス', link: practice_path(practice) }
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports_count(include_source:) }
-      tabs << { name: '質問', link: practice_questions_path(practice), count: practice.questions.length }
+      tabs << { name: '質問', link: practice_questions_path(practice), count: practice_questions_count(practice, active_tab:) }
       tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
       tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length } if movie_available?
       tabs << { name: '提出物', link: practice_products_path(practice) } if practice.submission
       tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?
       tabs << { name: 'コーディングテスト', link: practice_coding_tests_path(practice) } if practice.coding_tests.present?
       render PageTabsComponent.new(tabs:, active_tab:)
+    end
+
+    private
+
+    def practice_questions_count(practice, active_tab:)
+      practices =
+        if active_tab == '質問' && params[:scope] == 'grant_course'
+          [practice]
+        else
+          [practice, practice.source_practice].compact
+        end
+
+      Question.where(practice: practices).count
     end
   end
 end

--- a/app/helpers/page_tabs/practices_helper.rb
+++ b/app/helpers/page_tabs/practices_helper.rb
@@ -9,8 +9,8 @@ module PageTabs
       tabs << { name: 'プラクティス', link: practice_path(practice) }
       tabs << { name: '日報', link: practice_reports_path(practice), count: practice.reports_count(include_source:) }
       tabs << { name: '質問', link: practice_questions_path(practice), count: practice_questions_count(practice, active_tab:) }
-      tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.length }
-      tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.length } if movie_available?
+      tabs << { name: 'Docs', link: practice_pages_path(practice), count: practice.pages.count }
+      tabs << { name: '動画', link: practice_movies_path(practice), count: practice.movies.count } if movie_available?
       tabs << { name: '提出物', link: practice_products_path(practice) } if practice.submission
       tabs << { name: '模範解答', link: practice_submission_answer_path(practice) } if practice.submission_answer.present?
       tabs << { name: 'コーディングテスト', link: practice_coding_tests_path(practice) } if practice.coding_tests.present?

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -13,14 +13,24 @@ nav.tab-nav
   .container
     ul.tab-nav__items
       li.tab-nav__item
-        = link_to '全ての質問', practice_questions_path(@practice),
+        = link_to '全ての質問', practice_questions_path(@practice, scope: params[:scope]),
           class: "tab-nav__item-link #{%w[not_solved solved].include?(params[:target]) ? '' : 'is-active'}"
       li.tab-nav__item
-        = link_to '解決済み', practice_questions_path(@practice, target: 'solved'),
+        = link_to '解決済み', practice_questions_path(@practice, target: 'solved', scope: params[:scope]),
           class: "tab-nav__item-link #{params[:target] == 'solved' ? 'is-active' : ''}"
       li.tab-nav__item
-        = link_to '未解決', practice_questions_path(@practice, target: 'not_solved'),
+        = link_to '未解決', practice_questions_path(@practice, target: 'not_solved', scope: params[:scope]),
           class: "tab-nav__item-link #{params[:target] == 'not_solved' ? 'is-active' : ''}"
+
+- if @practice.source_id.present?
+  nav.pill-nav
+    ul.pill-nav__items
+      li.pill-nav__item
+        = link_to '全て', practice_questions_path(@practice, target: params[:target]),
+          class: "pill-nav__item-link #{params[:scope] == 'grant_course' ? '' : 'is-active'}"
+      li.pill-nav__item
+        = link_to '給付金コース', practice_questions_path(@practice, target: params[:target], scope: 'grant_course'),
+          class: "pill-nav__item-link #{params[:scope] == 'grant_course' ? 'is-active' : ''}"
 
 .page-body
   .container.is-md

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -362,17 +362,12 @@ categories_practice67:
   category: category24
   position: 16
 
-categories_practice68:
-  practice: practice114
-  category: category24
-  position: 17
-
 categories_practice69:
-  practice: practice115
+  practice: practice114
   category: category25
   position: 1
 
 categories_practice70:
-  practice: practice116
+  practice: practice115
   category: category25
   position: 2

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -316,6 +316,7 @@ categories_practice63:
 categories_practice64:
   practice: practice64
   category: category10
+  position: 3
 
 categories_practice65:
   practice: practice111
@@ -340,7 +341,7 @@ categories_practice68:
 categories_practice69:
   practice: practice65
   category: category6
-  position: 14
+  position: 16
 
 categories_practice70:
   practice: practice65
@@ -350,7 +351,7 @@ categories_practice70:
 categories_practice71:
   practice: practice66
   category: category6
-  position: 15
+  position: 17
 
 categories_practice72:
   practice: practice66
@@ -360,7 +361,7 @@ categories_practice72:
 categories_practice73:
   practice: practice113
   category: category24
-  position: 16
+  position: 1
 
 categories_practice74:
   practice: practice114

--- a/db/fixtures/categories_practices.yml
+++ b/db/fixtures/categories_practices.yml
@@ -317,57 +317,57 @@ categories_practice64:
   practice: practice64
   category: category10
 
-categories_practice111_1:
+categories_practice65:
   practice: practice111
   category: category6
   position: 14
 
-categories_practice111_2:
+categories_practice66:
   practice: practice111
   category: category23
   position: 2
-
-categories_practice112_1:
-  practice: practice112
-  category: category6
-  position: 15
-
-categories_practice112_2:
-  practice: practice112
-  category: category23
-  position: 3
-
-categories_practice65_1:
-  practice: practice65
-  category: category6
-  position: 14
-
-categories_practice65_2:
-  practice: practice65
-  category: category22
-  position: 2
-
-categories_practice66_1:
-  practice: practice66
-  category: category6
-  position: 15
-
-categories_practice66_2:
-  practice: practice66
-  category: category22
-  position: 3
 
 categories_practice67:
+  practice: practice112
+  category: category6
+  position: 15
+
+categories_practice68:
+  practice: practice112
+  category: category23
+  position: 3
+
+categories_practice69:
+  practice: practice65
+  category: category6
+  position: 14
+
+categories_practice70:
+  practice: practice65
+  category: category22
+  position: 2
+
+categories_practice71:
+  practice: practice66
+  category: category6
+  position: 15
+
+categories_practice72:
+  practice: practice66
+  category: category22
+  position: 3
+
+categories_practice73:
   practice: practice113
   category: category24
   position: 16
 
-categories_practice69:
+categories_practice74:
   practice: practice114
   category: category25
   position: 1
 
-categories_practice70:
+categories_practice75:
   practice: practice115
   category: category25
   position: 2

--- a/db/fixtures/correct_answers.yml
+++ b/db/fixtures/correct_answers.yml
@@ -15,3 +15,15 @@ correct_answer3:
   user: machida
   question: question1
   type: "CorrectAnswer"
+
+correct_answer4:
+  description: ベストアンサーです。
+  user: machida
+  question: question57
+  type: "CorrectAnswer"
+
+correct_answer5:
+  description: ベストアンサーです。
+  user: machida
+  question: question59
+  type: "CorrectAnswer"

--- a/db/fixtures/courses_categories.yml
+++ b/db/fixtures/courses_categories.yml
@@ -135,100 +135,10 @@ courses_category27:
 
 courses_category28:
   course: course5
-  category: category1
+  category: category24
   position: 1
 
 courses_category29:
   course: course5
-  category: category2
-  position: 2
-
-courses_category30:
-  course: course5
-  category: category3
-  position: 3
-
-courses_category31:
-  course: course5
-  category: category4
-  position: 4
-
-courses_category32:
-  course: course5
-  category: category5
-  position: 5
-
-courses_category33:
-  course: course5
-  category: category6
-  position: 6
-
-courses_category34:
-  course: course5
-  category: category7
-  position: 7
-
-courses_category35:
-  course: course5
-  category: category8
-  position: 8
-
-courses_category36:
-  course: course5
-  category: category9
-  position: 9
-
-courses_category37:
-  course: course5
-  category: category10
-  position: 10
-
-courses_category38:
-  course: course5
-  category: category11
-  position: 11
-
-courses_category39:
-  course: course5
-  category: category12
-  position: 12
-
-courses_category40:
-  course: course5
-  category: category13
-  position: 13
-
-courses_category41:
-  course: course5
-  category: category14
-  position: 14
-
-courses_category42:
-  course: course5
-  category: category15
-  position: 15
-
-courses_category43:
-  course: course5
-  category: category16
-  position: 16
-
-courses_category44:
-  course: course5
-  category: category22
-  position: 17
-
-courses_category45:
-  course: course5
-  category: category23
-  position: 18
-
-courses_category46:
-  course: course5
-  category: category24
-  position: 19
-
-courses_category47:
-  course: course5
   category: category25
-  position: 20
+  position: 2

--- a/db/fixtures/practices.yml
+++ b/db/fixtures/practices.yml
@@ -772,18 +772,12 @@ practice113:
   source_practice: practice23
 
 practice114:
-  title: "rbenvをインストールする（Reスキル）"
-  description: "Railsコースのプラクティスをコピーした給付金コースのプラクティスです。"
-  goal: "goal..."
-  source_practice: practice24
-
-practice115:
   title: "OS X Mountain Lionをクリーンインストールする（Reスキル）"
   description: "Railsコースのプラクティスをコピーしたプラクティスです。"
   goal: "goal..."
   source_id: <%= ActiveRecord::FixtureSet.identify(:practice1) %>
 
-practice116:
+practice115:
   title: "Terminalの基礎を覚える（Reスキル）"
   description: "Railsコースのプラクティスをコピーしたプラクティスです。"
   goal: "goal..."

--- a/db/fixtures/questions.yml
+++ b/db/fixtures/questions.yml
@@ -160,3 +160,35 @@ question55:
   created_at: <%= Time.current - 3.month %>
   updated_at: <%= Time.current - 3.month %>
   published_at: <%= Time.current - 3.month %>
+
+question56:
+  title: 給付金コースのプラクティスの質問
+  description: 給付金コースのプラクティスの質問です。
+  user: grant-course
+  practice: practice113
+  created_at: "2026-05-15"
+  published_at: "2026-05-15"
+
+question57:
+  title: 給付金コースのプラクティスの質問(解決済み)
+  description: 解決済みです。
+  user: grant-course
+  practice: practice113
+  created_at: "2026-05-15"
+  published_at: "2026-05-15"
+
+question58:
+  title: 給付金コースのコピー元プラクティスの質問
+  description: 給付金コースのコピー元プラクティスの質問
+  user: grant-course
+  practice: practice23
+  created_at: "2026-05-15"
+  published_at: "2026-05-15"
+
+question59:
+  title: 給付金コースのコピー元プラクティスの質問(解決済み)
+  description: 解決済みです。
+  user: grant-course
+  practice: practice23
+  created_at: "2026-05-15"
+  published_at: "2026-05-15"

--- a/test/fixtures/correct_answers.yml
+++ b/test/fixtures/correct_answers.yml
@@ -9,3 +9,15 @@ correct_answer2:
   user: advijirou
   question: question12
   type: "CorrectAnswer"
+
+correct_answer3:
+  description: ベストアンサーです。
+  user: machida
+  question: question18
+  type: "CorrectAnswer"
+
+correct_answer4:
+  description: ベストアンサーです。
+  user: machida
+  question: question20
+  type: "CorrectAnswer"

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -143,3 +143,35 @@ question16:
   practice: practice1
   created_at: "2022-01-18"
   published_at: "2022-01-18"
+
+question17:
+  title: 給付金コースのプラクティスの質問
+  description: 給付金コースのプラクティスの質問です。
+  user: grant-course
+  practice: practice64
+  created_at: "2026-05-15"
+  published_at: "2026-05-15"
+
+question18:
+  title: 給付金コースのプラクティスの質問(解決済み)
+  description: 解決済みです。
+  user: grant-course
+  practice: practice64
+  created_at: "2026-05-15"
+  published_at: "2026-05-15"
+
+question19:
+  title: 給付金コースのコピー元プラクティスの質問
+  description: 給付金コースのコピー元プラクティスの質問
+  user: grant-course
+  practice: practice23
+  created_at: "2026-05-15"
+  published_at: "2026-05-15"
+
+question20:
+  title: 給付金コースのコピー元プラクティスの質問(解決済み)
+  description: 解決済みです。
+  user: grant-course
+  practice: practice23
+  created_at: "2026-05-15"
+  published_at: "2026-05-15"

--- a/test/system/practice/questions_test.rb
+++ b/test/system/practice/questions_test.rb
@@ -18,4 +18,95 @@ class Practice::QuestionsTest < ApplicationSystemTestCase
     assert_no_text 'wipテスト用の質問(wip中)'
     assert_selector('a.tab-nav__item-link.is-active', text: '未解決')
   end
+
+  test 'show grant course filter tabs only for grant course practices' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    assert_selector '.pill-nav__item-link', exact_text: '全て'
+    assert_selector '.pill-nav__item-link', exact_text: '給付金コース'
+
+    visit_with_auth "/practices/#{practices(:practice1).id}/questions", 'grant-course'
+    assert_no_selector '.pill-nav__item-link', exact_text: '全て'
+    assert_no_selector '.pill-nav__item-link', exact_text: '給付金コース'
+  end
+
+  test 'show all questions from both grant and source practices when all filter is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    assert_selector '.pill-nav__item-link.is-active', exact_text: '全て'
+    assert_selector '.tab-nav__item-link.is-active', exact_text: '全ての質問'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問(解決済み)'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問(解決済み)'
+  end
+
+  test 'show solved questions from both grant and source practices when solved filter is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    within '.tab-nav' do
+      click_on '解決済み'
+    end
+    assert_selector '.pill-nav__item-link.is-active', exact_text: '全て'
+    assert_selector '.tab-nav__item-link.is-active', exact_text: '解決済み'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問(解決済み)'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問(解決済み)'
+  end
+
+  test 'show unsolved questions from both grant and source practices when unsolved filter is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    within '.tab-nav' do
+      click_on '未解決'
+    end
+    assert_selector '.pill-nav__item-link.is-active', exact_text: '全て'
+    assert_selector '.tab-nav__item-link.is-active', exact_text: '未解決'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問(解決済み)'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問(解決済み)'
+  end
+
+  test 'show all questions only from the grant practice when grant course scope is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    within '.pill-nav' do
+      click_on '給付金コース'
+    end
+    assert_selector '.pill-nav__item-link.is-active', exact_text: '給付金コース'
+    assert_selector '.tab-nav__item-link.is-active', exact_text: '全ての質問'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問(解決済み)'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問(解決済み)'
+  end
+
+  test 'show solved questions only from the grant practice when solved filter and grant course scope are selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    within '.pill-nav' do
+      click_on '給付金コース'
+    end
+    within '.tab-nav' do
+      click_on '解決済み'
+    end
+    assert_selector '.pill-nav__item-link.is-active', exact_text: '給付金コース'
+    assert_selector '.tab-nav__item-link.is-active', exact_text: '解決済み'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問(解決済み)'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問(解決済み)'
+  end
+
+  test 'show unsolved questions only from the grant practice when unsolved filter and grant course scope are selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    within '.pill-nav' do
+      click_on '給付金コース'
+    end
+    within '.tab-nav' do
+      click_on '未解決'
+    end
+    assert_selector '.pill-nav__item-link.is-active', exact_text: '給付金コース'
+    assert_selector '.tab-nav__item-link.is-active', exact_text: '未解決'
+    assert_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのプラクティスの質問(解決済み)'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問'
+    assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問(解決済み)'
+  end
 end

--- a/test/system/practice/questions_test.rb
+++ b/test/system/practice/questions_test.rb
@@ -109,4 +109,22 @@ class Practice::QuestionsTest < ApplicationSystemTestCase
     assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問'
     assert_no_selector '.card-list-item-title__link', exact_text: '給付金コースのコピー元プラクティスの質問(解決済み)'
   end
+
+  test 'show total question count from grant and source practices when all scope is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    assert_selector '.page-tabs__item-link.is-active', exact_text: '質問 （4）'
+  end
+
+  test 'show question count from grant practice only when grant course scope is selected' do
+    visit_with_auth "/practices/#{practices(:practice64).id}/questions", 'grant-course'
+    within '.pill-nav' do
+      click_on '給付金コース'
+    end
+    assert_selector '.page-tabs__item-link.is-active', exact_text: '質問 （2）'
+  end
+
+  test 'show total question count from grant and source practices on non-question pages' do
+    visit_with_auth "/practices/#{practices(:practice64).id}", 'grant-course'
+    assert_selector '.page-tabs__item-link', exact_text: '質問 （4）'
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9563

## 概要
- 給付金コースのプラクティスの質問一覧に質問の表示範囲を切り替えるタブを追加しました。
  - 「元コース + 給付金コース」と「給付金コース」を切り替える。
  - このタブは給付金コースのプラクティスの質問一覧画面でのみ表示されます。
- 質問タブの件数表示を質問の表示範囲に応じて変更するようにしました。
  - 「全て」では元コースを含む合算件数を表示
  - 「給付金コース」では給付金コースのみの件数を表示
  - 質問ページ以外では合算件数を表示

※ 給付金コース = Railsエンジニア（Reスキル講座認定）コース(https://bootcamp.fjord.jp/courses/47/practices)

## 変更確認方法
1. `feature/show-source-practice-qas-in-grant-course-practice`をローカルに取り込む
1. `bin/rails db:seed:replant`を実行
1. `bin/dev`でサーバーを起動
1. `localhost:3000`にアクセスし、`grant-course`でログイン

### 質問表示切り替えタブの表示・非表示の確認
1. `/practices/200789251/questions`(給付金コースのプラクティスの質問一覧)にアクセスし、質問表示切り替えタブが表示されていることを確認する
1. `/practices/473419339/questions`(給付金コース以外のプラクティスの質問一覧)にアクセスし、質問表示切り替えタブが表示されていないことを確認する

### 質問の表示・非表示の確認
質問A → 給付金コースのプラクティスの質問
質問B → 給付金コースのプラクティスの質問(解決済み)
質問C → 給付金コースのコピー元プラクティスの質問
質問D → 給付金コースのコピー元プラクティスの質問(解決済み)

1. `/practices/200789251/questions`(給付金コースのプラクティスの質問一覧)にアクセス
1. 解決・未解決フィルターが「全ての質問」、質問表示切り替えタブが「全て」であることを確認して、全ての質問が表示されていることを確認する
1. 解決・未解決フィルターが「解決済み」、質問表示切り替えタブが「全て」を選択して、質問B・Dのみ表示されていることを確認する
1. 解決・未解決フィルターが「未解決」、質問表示切り替えタブが「全て」を選択して、質問A・Cのみ表示されていることを確認する
1. 解決・未解決フィルターが「全ての質問」、質問表示切り替えタブが「給付金コース」を選択して、質問A・Bのみ表示されていることを確認する
1. 解決・未解決フィルターが「解決済み」、質問表示切り替えタブが「給付金コース」を選択して、質問Bのみ表示されていることを確認する
1. 解決・未解決フィルターが「未解決」、質問表示切り替えタブが「給付金コース」を選択して、質問Aのみ表示されていることを確認する

### 質問タブの件数表示の確認
1. `/practices/200789251/questions`(給付金コースのプラクティスの質問一覧)にアクセス
1. 質問表示切り替えタブが「全て」であることを確認して、質問タブに`質問（4）`と表示されていることを確認する
1. 質問表示切り替えタブが「給付金コース」を選択して、質問タブに`質問（2）`と表示されていることを確認する
1. `/practices/200789251/`にアクセスして、質問タブに`質問（4）`と表示されていることを確認する
## Screenshot

### 変更前
<img width="1357" height="468" alt="before" src="https://github.com/user-attachments/assets/1079d138-a710-4733-a32a-8128bca4d914" />

### 変更後
<img width="1357" height="719" alt="after" src="https://github.com/user-attachments/assets/cddc8881-8a42-441d-aa0a-b522da700dd5" />

## 参考
- [給付金コースの人が元コースの関連情報を見れるようにする · fjordllc/bootcamp Wiki](https://github.com/fjordllc/bootcamp/wiki/%E7%B5%A6%E4%BB%98%E9%87%91%E3%82%B3%E3%83%BC%E3%82%B9%E3%81%AE%E4%BA%BA%E3%81%8C%E5%85%83%E3%82%B3%E3%83%BC%E3%82%B9%E3%81%AE%E9%96%A2%E9%80%A3%E6%83%85%E5%A0%B1%E3%82%92%E8%A6%8B%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)
- #8293
- #9650
- #9821 
- #9733 

<!-- I want to review in Japanese. -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30060747934/artifacts/8584627587" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プラクティスの質問一覧に「全て／給付金コース」スコープ切替を追加し、表示対象を切り替え可能にしました。
  * 質問タブ（全て／解決済み／未解決）が現在のスコープ／フィルタを保持して遷移するよう改善しました。
  * 付与元があるプラクティスでのみスコープ切替用のピルを表示します。

* **テスト**
  * スコープ×解決状態の組み合わせ表示や件数表示を検証するシステムテストを追加しました。

* **その他**
  * 一覧表示の件数集計ロジックとテスト用データ（質問・正解・分類等）を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/9975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-9975-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
