### PR TITLE
Markdownエディタで Ctrl + i キーを押すと、:@自分: を入力する。

### DIFF
--- a/app/javascript/shortcut.js
+++ b/app/javascript/shortcut.js
@@ -58,3 +58,11 @@ hotkeys(`${ctrl}+b`, 'all', function (event, handler) {
     allOpenButton.click()
   }
 })
+
+hotkeys(`${ctrl}+i`, 'input', function (event, handler) {
+  console.log(handler.key)
+  event.preventDefault()
+  const textarea = event.target
+  const loginName = textarea.dataset.loginName
+  textarea.value += `@${loginName}`
+})

--- a/app/javascript/shortcut.js
+++ b/app/javascript/shortcut.js
@@ -64,5 +64,11 @@ hotkeys(`${ctrl}+i`, 'input', function (event, handler) {
   event.preventDefault()
   const textarea = event.target
   const loginName = textarea.dataset.loginName
-  textarea.value += `@${loginName}`
+  if (!loginName) return
+  const mention = `@${loginName}`
+  const start = textarea.selectionStart
+  const end = textarea.selectionEnd
+  textarea.value =
+    textarea.value.slice(0, start) + mention + textarea.value.slice(end)
+  textarea.selectionStart = textarea.selectionEnd = start + mention.length
 })

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -24,6 +24,12 @@ export default class {
     const textareas = document.querySelectorAll(selector)
     if (!textareas.length) return
 
+    const loginName = document.body.dataset.loginName
+
+    textareas.forEach((textarea) => {
+      textarea.dataset.loginName = loginName
+    })
+
     // autosize
     autosize(textareas)
     textareas.forEach((textarea) => {

--- a/app/javascript/textarea-initializer.js
+++ b/app/javascript/textarea-initializer.js
@@ -24,11 +24,13 @@ export default class {
     const textareas = document.querySelectorAll(selector)
     if (!textareas.length) return
 
-    const loginName = document.body.dataset.loginName
+    const loginName = document.body.dataset.loginName ?? ''
 
-    textareas.forEach((textarea) => {
-      textarea.dataset.loginName = loginName
-    })
+    if (loginName) {
+      textareas.forEach((textarea) => {
+        textarea.dataset.loginName = loginName
+      })
+    }
 
     // autosize
     autosize(textareas)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html.is-application lang='ja'
       = stylesheet_link_tag 'application', media: 'all'
     = render 'x' if Rails.env.production?
     = content_for(:head_last) if content_for?(:head_last)
-  body.is-application#body(class="#{body_class}")
+  body.is-application#body( class=body_class data-login-name=current_user.login_name )
     = render 'x_event_tracking' if Rails.env.production?
     - if display_global_nav?
       .is-hidden-sm-down
@@ -28,3 +28,4 @@ html.is-application lang='ja'
       - if display_footer?
         = render 'application/footer/footer'
     = any_login_here if defined?(AnyLogin)
+

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html.is-application lang='ja'
       = stylesheet_link_tag 'application', media: 'all'
     = render 'x' if Rails.env.production?
     = content_for(:head_last) if content_for?(:head_last)
-  body.is-application#body( class=body_class data-login-name=current_user.login_name )
+  body.is-application#body( class=body_class data-login-name=current_user&.login_name )
     = render 'x_event_tracking' if Rails.env.production?
     - if display_global_nav?
       .is-hidden-sm-down

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,4 +28,3 @@ html.is-application lang='ja'
       - if display_footer?
         = render 'application/footer/footer'
     = any_login_here if defined?(AnyLogin)
-

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html.is-application lang='ja'
       = stylesheet_link_tag 'application', media: 'all'
     = render 'x' if Rails.env.production?
     = content_for(:head_last) if content_for?(:head_last)
-  body.is-application#body( class=body_class data-login-name=current_user&.login_name )
+  body.is-application#body(class=body_class data-login-name=current_user&.login_name)
     = render 'x_event_tracking' if Rails.env.production?
     - if display_global_nav?
       .is-hidden-sm-down

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -83,7 +83,7 @@
               = f.text_area :description,
                 **value_option,
                 class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
-                data: { 'report-template-target': 'report', 'preview': '.js-preview', 'input': '.file-input' }
+                data: { 'report-template-target': 'report','preview': '.js-preview','input': '.file-input', 'login-name': current_user.login_name }
             .form-textarea__footer
               .form-textarea__insert
                 label.a-file-insert.a-button.is-xs.is-text-reversal.is-block

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -83,7 +83,7 @@
               = f.text_area :description,
                 **value_option,
                 class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
-                data: { 'report-template-target': 'report','preview': '.js-preview','input': '.file-input' }
+                data: { 'report-template-target': 'report', 'preview': '.js-preview', 'input': '.file-input' }
             .form-textarea__footer
               .form-textarea__insert
                 label.a-file-insert.a-button.is-xs.is-text-reversal.is-block

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -83,7 +83,7 @@
               = f.text_area :description,
                 **value_option,
                 class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
-                data: { 'report-template-target': 'report','preview': '.js-preview','input': '.file-input', 'login-name': current_user.login_name }
+                data: { 'report-template-target': 'report','preview': '.js-preview','input': '.file-input' }
             .form-textarea__footer
               .form-textarea__insert
                 label.a-file-insert.a-button.is-xs.is-text-reversal.is-block

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -175,7 +175,7 @@ class MarkdownTest < ApplicationSystemTestCase
         find('#js-new-comment').send_keys([:control, 'i'])
       end
     end
-    all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    find('.a-form-tabs__tab.js-tabs__tab', text: 'プレビュー').click
     assert_text '@komagata'
     click_button 'コメントする'
     assert_text '@komagata'

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -139,4 +139,45 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_selector '.a-link-card__title'
     assert_no_selector '.embed-error'
   end
+
+  test 'When you press Ctrl + i in the report, it will type :@myself:.' do
+    visit_with_auth new_report_path, 'komagata'
+    within('form[name=report]') do
+      fill_in('report[title]', with: '日報でCtrl + i キーを押すと、:@自分: を入力される。')
+
+      if Selenium::WebDriver::Platform.mac?
+        find('#report_description').send_keys([:command, 'i'])
+      else
+        find('#report_description').send_keys([:control, 'i'])
+      end
+
+      fill_in('report[reported_on]', with: Time.current)
+
+      check '学習時間は無し', allow_label_click: true
+    end
+
+    click_button '提出'
+    assert_text '@komagata'
+    assert_no_selector '.embed-error'
+  end
+
+  test 'When you press Ctrl + i in the comments, it will type :@myself:.' do
+    visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
+    # テストが落ちやすいため、setCheckableが実行されるまで待つ
+    within('.page-content-header') do
+      find('.stamp.stamp-approve')
+    end
+
+    within('.thread-comment-form__form') do
+      if Selenium::WebDriver::Platform.mac?
+        find('#js-new-comment').send_keys([:command, 'i'])
+      else
+        find('#js-new-comment').send_keys([:control, 'i'])
+      end
+    end
+    all('.a-form-tabs__tab.js-tabs__tab')[1].click
+    assert_text '@komagata'
+    click_button 'コメントする'
+    assert_text '@komagata'
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9977

## 概要

MarkdownエディタでCtrl + i キーを押すと、 `@自分`と自分自身へのメンションが入力される設定を追加しました。

## 変更確認方法

1. `feature/ctrl-i-input-self-mention`をローカルに取り込む

2. 開発サーバーを起動

3. [http://localhost:3000/](http://localhost:3000/) にアクセスし、`kimura` 等受講生としてログイン。

4. 日報を新規に作成し、 `Ctrl` + `i` でエディタにログイン中ユーザーへのメンションが入力されるか確認。 <img width="1075" height="439" alt="スクリーンショット 2026-05-08 145409" src="https://github.com/user-attachments/assets/d7c2eb2f-9ae1-4bc6-a9a9-b0a3b165884c" />

5. 提出物を新規に作成し、 `Ctrl` + `i` でエディタにログイン中ユーザーへのメンションが入力されるか確認。 <img width="1105" height="456" alt="スクリーンショット 2026-05-08 133814" src="https://github.com/user-attachments/assets/d27fb9ef-e1da-44ae-a01c-a268629a4151" />

6. コメントを新規に作成し、 `Ctrl` + `i` でエディタにログイン中ユーザーへのメンションが入力されるか確認。 <img width="580" height="259" alt="スクリーンショット 2026-05-08 145443" src="https://github.com/user-attachments/assets/7077d401-c4ba-48de-83ca-21039dca4843" />

7. イベントを新規に作成し、 `Ctrl` + `i` でエディタにログイン中ユーザーへのメンションが入力されるか確認。 <img width="551" height="769" alt="スクリーンショット 2026-05-08 145604" src="https://github.com/user-attachments/assets/be6ce709-98d6-408f-815f-e9df2d40d2f8" />

8. お知らせを新規に作成し、 `Ctrl` + `i` でエディタにログイン中ユーザーへのメンションが入力されるか確認。 <img width="594" height="705" alt="スクリーンショット 2026-05-08 145751" src="https://github.com/user-attachments/assets/4010b907-a0f7-4bcf-a320-4b85d3753801" />

9. ログアウトし、`komagata` 等メンターででログイン。

10. メンターメニューからメンターページにアクセス。
    <img width="236" height="1073" alt="スクリーンショット 2026-05-08 161024" src="https://github.com/user-attachments/assets/5d179325-2f9e-49be-a335-46d05037dc23" />

11. タブから「プラクティス」をクリックし、「プラクティス作成」をクリック。
    <img width="852" height="425" alt="スクリーンショット 2026-05-08 161038" src="https://github.com/user-attachments/assets/2df805c3-ad28-494a-a9fb-ab073f52f61f" />

12. 内容・終了条件・メンター向けメモに、それぞれ `Ctrl` + `i` でエディタにログイン中ユーザーへのメンションが入力されるか確認。
    <img width="768" height="1253" alt="スクリーンショット 2026-05-08 161249" src="https://github.com/user-attachments/assets/692be9f7-19b7-4b56-9c22-d9b09024a8de" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テキスト入力欄でCtrl/Command+iにより選択位置へ@メンションを素早く挿入できるホットキーを追加。挿入後のカーソル位置も正しく保たれます。
  * ページ初期化でログイン名を入力欄へ自動で渡す処理を追加し、メンションや補完の初期化が確実になります。
* **テスト**
  * システムテストを追加し、ホットキーで期待どおりにメンションが展開されることを検証します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/9978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/26013760383/artifacts/7049731089)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
