### PR TITLE
既存の「研修終了日」のラベルの変更、管理者が「研修完了日時」を編集できるようにする

### DIFF
--- a/app/components/products/product_component.html.slim
+++ b/app/components/products/product_component.html.slim
@@ -88,7 +88,7 @@
               - if @product.user.training_ends_on
                 time.a-meta datetime=@product.user.training_ends_on.in_time_zone.iso8601
                   span.a-meta__label
-                    | 研修終了日
+                    | 研修終了予定日
                   span.a-meta__value
                     = l(@product.user.training_ends_on)
                   - case @product.user.training_remaining_days
@@ -107,7 +107,7 @@
               - else
                 .a-meta
                   span.a-meta__label
-                    | 研修終了日
+                    | 研修終了予定日
                   span.a-meta__value
                     | 未入力
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -94,7 +94,7 @@ class Admin::UsersController < AdminController
       :trainee, :nda, :avatar,
       :graduated_on, :retired_on,
       :job_seeker, :github_collaborator,
-      :officekey_permission, :tag_list, :training_ends_on,
+      :officekey_permission, :tag_list, :training_ends_on, :training_completed_at,
       :profile_image, :profile_name, :profile_job, :mentor, :diploma_file,
       :career_path, :career_memo,
       :auto_retire, :invoice_payment, :show_mentor_profile,

--- a/app/views/products/_product_list_item.html.slim
+++ b/app/views/products/_product_list_item.html.slim
@@ -70,7 +70,7 @@ ruby:
             .card-list-item-meta__item
               - if product.user.training_ends_on.present?
                 .a-meta
-                  span.a-meta__label 研修終了日
+                  span.a-meta__label 研修終了予定日
                   time.a-meta__value datetime=product.user.training_ends_on.in_time_zone.iso8601
                     = l(product.user.training_ends_on)
                   - remaining_days = (product.user.training_ends_on.to_date - Date.current).to_i
@@ -84,7 +84,7 @@ ruby:
                     span.a-meta__value （あと#{remaining_days}日）
               - else
                 .a-meta
-                  span.a-meta__label 研修終了日
+                  span.a-meta__label 研修終了予定日
                   span.a-meta__value 未入力
       - if current_user.mentor? && product.checks.empty?
         .card-list-item__row.is-only-mentor

--- a/app/views/users/form/_training_end.html.slim
+++ b/app/views/users/form/_training_end.html.slim
@@ -10,5 +10,4 @@
     = f.label :training_completed_at, class: 'a-form-label'
     = f.date_field :training_completed_at, class: 'a-text-input training-info-date'
     .a-form-help
-      p
-        | 管理者のみ操作ができます
+      p 管理者のみ操作ができます

--- a/app/views/users/form/_training_end.html.slim
+++ b/app/views/users/form/_training_end.html.slim
@@ -5,3 +5,10 @@
     p
       | 研修終了日が明確でない場合は、現時点での予定の日にちを入力し、
       | 明確になりましたら更新、もしくはフィヨルドへ連絡をお願いします。
+.form-item
+    - if admin_login?
+      = f.label :training_completed_at, class: 'a-form-label'
+      = f.date_field :training_completed_at, class: 'a-text-input training-info-date'
+      .a-form-help
+        p
+          | 管理者のみ操作ができます

--- a/app/views/users/form/_training_end.html.slim
+++ b/app/views/users/form/_training_end.html.slim
@@ -6,9 +6,9 @@
       | 研修終了日が明確でない場合は、現時点での予定の日にちを入力し、
       | 明確になりましたら更新、もしくはフィヨルドへ連絡をお願いします。
 .form-item
-    - if admin_login?
-      = f.label :training_completed_at, class: 'a-form-label'
-      = f.date_field :training_completed_at, class: 'a-text-input training-info-date'
-      .a-form-help
-        p
-          | 管理者のみ操作ができます
+  - if admin_login?
+    = f.label :training_completed_at, class: 'a-form-label'
+    = f.date_field :training_completed_at, class: 'a-text-input training-info-date'
+    .a-form-help
+      p
+        | 管理者のみ操作ができます

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -124,7 +124,7 @@ ja:
         job_seeker: 就職サポート
         github_collaborator: GitHubチーム
         tag_list: タグ
-        training_ends_on: 研修終了日
+        training_ends_on: 研修終了予定日
         last_activity_at: 最終活動日時
         profile_image: プロフィール画像
         profile_name: プロフィール名

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -113,7 +113,6 @@ ja:
         mentor: メンター
         job_seeking: 就職活動中
         hibernated_at: 休会日時
-        training_completed_at: 研修終了日時
         retired_on: 退会日
         avatar: ユーザーアイコン
         retire_reasons: 選択入力の退会理由

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -125,6 +125,7 @@ ja:
         github_collaborator: GitHubチーム
         tag_list: タグ
         training_ends_on: 研修終了予定日
+        training_completed_at: 研修完了日時
         last_activity_at: 最終活動日時
         profile_image: プロフィール画像
         profile_name: プロフィール名

--- a/test/components/product/product_component_test.rb
+++ b/test/components/product/product_component_test.rb
@@ -140,7 +140,7 @@ class Products::ProductComponentTest < ViewComponent::TestCase
                     reply_deadline_days: @reply_deadline_days
                   ))
 
-    assert_selector '.a-meta', text: '研修終了日'
+    assert_selector '.a-meta', text: '研修終了予定日'
 
     render_inline(Products::ProductComponent.new(
                     product: trainee_product,
@@ -150,7 +150,7 @@ class Products::ProductComponentTest < ViewComponent::TestCase
                     reply_deadline_days: @reply_deadline_days
                   ))
 
-    assert_selector '.a-meta', text: '研修終了日'
+    assert_selector '.a-meta', text: '研修終了予定日'
   end
 
   def test_does_not_render_training_remaining_days_when_user_is_not_mentor_or_admin_and_product_user_is_trainee
@@ -163,7 +163,7 @@ class Products::ProductComponentTest < ViewComponent::TestCase
                     reply_deadline_days: @reply_deadline_days
                   ))
 
-    assert_no_selector '.a-meta', text: '研修終了日'
+    assert_no_selector '.a-meta', text: '研修終了予定日'
   end
 
   def test_does_not_render_training_remaining_days_when_product_user_is_not_trainee
@@ -176,7 +176,7 @@ class Products::ProductComponentTest < ViewComponent::TestCase
                     reply_deadline_days: @reply_deadline_days
                   ))
 
-    assert_no_selector '.a-meta', text: '研修終了日'
+    assert_no_selector '.a-meta', text: '研修終了予定日'
   end
 
   def test_render_product_checker_when_user_is_mentor_and_no_checks

--- a/test/system/product/product_list_test.rb
+++ b/test/system/product/product_list_test.rb
@@ -177,7 +177,7 @@ class Product::ProductListTest < ApplicationSystemTestCase
 
     visit_with_auth '/products/unchecked', 'komagata'
 
-    assert_selector '.a-meta__label', text: '研修終了日'
+    assert_selector '.a-meta__label', text: '研修終了予定日'
   end
 
   test 'pagination works on unchecked page' do

--- a/test/system/products/trainee_test.rb
+++ b/test/system/products/trainee_test.rb
@@ -40,7 +40,7 @@ module Products
       travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
         visit_with_auth '/products', 'mentormentaro'
         find('.is-products.loaded')
-        assert_selector '.a-meta__label', text: '研修終了日'
+        assert_selector '.a-meta__label', text: '研修終了予定日'
         assert_selector '.a-meta__value', text: '2022年04月01日'
         assert_selector '.a-meta__value', text: '（あと365日）'
       end
@@ -52,7 +52,7 @@ module Products
       travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
         visit_with_auth "/products/#{products(:product13).id}", 'mentormentaro'
         find('.page-content-header__before-title')
-        assert_selector '.a-meta__label', text: '研修終了日'
+        assert_selector '.a-meta__label', text: '研修終了予定日'
         assert_selector '.a-meta__value', text: '2022年04月01日'
         assert_selector '.a-meta__value', text: '（あと365日）'
       end
@@ -64,7 +64,7 @@ module Products
       travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
         visit_with_auth '/products', 'adminonly'
         find('.is-products.loaded')
-        assert_selector '.a-meta__label', text: '研修終了日'
+        assert_selector '.a-meta__label', text: '研修終了予定日'
         assert_selector '.a-meta__value', text: '2022年04月01日'
         assert_selector '.a-meta__value', text: '（あと365日）'
       end
@@ -76,7 +76,7 @@ module Products
       travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
         visit_with_auth "/products/#{products(:product13).id}", 'adminonly'
         find('.page-content-header__before-title')
-        assert_selector '.a-meta__label', text: '研修終了日'
+        assert_selector '.a-meta__label', text: '研修終了予定日'
         assert_selector '.a-meta__value', text: '2022年04月01日'
         assert_selector '.a-meta__value', text: '（あと365日）'
       end
@@ -88,7 +88,7 @@ module Products
       travel_to Time.zone.local(2021, 4, 1, 0, 0, 0) do
         visit_with_auth '/products', 'advijirou'
         find('.is-products.loaded')
-        assert_no_selector '.a-meta__label', text: '研修終了日'
+        assert_no_selector '.a-meta__label', text: '研修終了予定日'
         assert_no_selector '.a-meta__value', text: '2022年04月01日'
         assert_no_selector '.a-meta__value', text: '（あと365日）'
       end

--- a/test/system/users/profile_test.rb
+++ b/test/system/users/profile_test.rb
@@ -119,7 +119,7 @@ module Users
     test 'show training end date if user is a trainee and has a training end date' do
       user = users(:kensyu)
       visit_with_auth user_path(user.id), 'kensyu'
-      assert has_text?('研修終了日')
+      assert has_text?('研修終了予定日')
       assert has_text?('2022年04月01日')
     end
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9945

## 変更内容

* 「登録情報変更」画面内のラベルを変更
  * 「研修終了日」→「研修終了予定日」

* ユーザー編集画面に「研修完了日時」を追加
  * 管理者のみ「登録情報変更」画面で「研修完了日時」を設定できるように変更

## 変更確認方法

1. `feature/admin-edit-training-completed-at`をローカルに取り込む
2. 開発サーバーを起動
3. [http://localhost:3000/](http://localhost:3000/) にアクセスし、`kensyu` 等受講生としてログイン。
4. 「登録情報変更」をクリック。研修情報内が「研修終了日」→「研修終了予定日」に変更されていることを確認する。
   <img width="221" height="322" alt="スクリーンショット 2026-05-11 134916" src="https://github.com/user-attachments/assets/83416b18-a128-443d-a553-a8bd4c22a75d" />
   <img width="531" height="142" alt="スクリーンショット 2026-05-11 112017 - コピー" src="https://github.com/user-attachments/assets/80afc5a4-6bf2-402c-bf6d-026867cd663e" />
5. `komagata`など管理者でログイン。
6. 「ユーザー」から`kensyu`など、研修生のユーザーを検索し、「管理者としてユーザー情報変更」をクリック。
   <img width="800" height="127" alt="スクリーンショット 2026-05-11 134959" src="https://github.com/user-attachments/assets/948313fb-4c14-49c9-931d-0c4ec39b23d4" />
7. 「研修情報」内に「研修完了日時」の入力欄があることを確認。日付を入力し、「更新する」をクリック。
   <img width="649" height="335" alt="スクリーンショット 2026-05-11 112017" src="https://github.com/user-attachments/assets/a2bb2820-66d3-49a6-a48c-6cddfd8b9a0f" />
8. 修正した研修生が「研修終了」状態になっていることを確認する。
   <img width="838" height="705" alt="スクリーンショット 2026-05-11 135157" src="https://github.com/user-attachments/assets/0d1d3393-e58e-4477-a855-97034dab9533" />
9. `kensyu` で再度ログイン。添付の通り、ログインできないことを確認する。
   <img width="932" height="94" alt="スクリーンショット 2026-05-11 135340" src="https://github.com/user-attachments/assets/b8b17c4a-7a39-4a49-a699-75b77cbefa1a" /><br>
10. `komagata`など管理者でログイン。もう一度`kensyu`の「管理者としてユーザー情報変更」をクリックして、「研修完了日時」を削除して更新する。
    <img width="525" height="358" alt="スクリーンショット 2026-05-11 135443" src="https://github.com/user-attachments/assets/3417af87-1057-4d69-add8-8e27e4a6b13f" />
11. `kensyu`が研修状態に戻っていることを確認する。

## Screenshot

### 変更前

<img width="645" height="322" alt="スクリーンショット 2026-05-11 112451" src="https://github.com/user-attachments/assets/ed9f3944-0537-4d30-973f-8d93885cd53e" />
<img width="831" height="667" alt="スクリーンショット 2026-05-11 135625" src="https://github.com/user-attachments/assets/f7278633-99ab-41da-83d2-648e1448be16" />

### 変更後

<img width="649" height="335" alt="スクリーンショット 2026-05-11 112017" src="https://github.com/user-attachments/assets/68cb8bb3-12ca-4849-89f5-d4d6b3677dee" />

<img width="839" height="689" alt="スクリーンショット 2026-05-11 135734" src="https://github.com/user-attachments/assets/9df549e4-59eb-47e3-a20c-9cbe8baf44be" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 表示ラベルを「研修終了日」から「研修終了予定日」に更新しました（画面・ロケール含む）。
  * 管理画面からの更新ができるよう該当パラメータの扱いを許可しました。
* **New Features**
  * 管理者のみ操作可能な「研修完了日」入力欄を編集画面に追加し、管理者向けの案内を表示するようにしました。
* **Tests**
  * 表示文言変更に合わせて関連テストを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/9985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26425131336/artifacts/7206664698"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-9985-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->