### PR TITLE
イベントテストファイルの主催者を変更

### DIFF
--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -190,7 +190,7 @@ event34:
   end_at: 2024-03-26 12:00
   open_start_at: 2024-02-26 10:00
   open_end_at: 2024-03-26 09:00
-  user: kimura
+  user: komagata
 
 event35:
   title: "2024/12/1(日)9:00〜12:00開催の特別イベント"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9989

## 概要

build_and_test にて以下エラーが発生しました。

```
Failure:
User::EventsTest#test_does_not_show_events_the_user_is_not_participating_in:
expected not to find text "未来のイベント(未参加)" in "..."
```

`test/system/user/events_test.rb` にて、以下の fixture が「未参加イベント」として扱われています。

https://github.com/fjordllc/bootcamp/blob/f8649fadf79911aace2ffb1d74dc5a9cc2b3d73c/test/fixtures/events.yml#L184-L193

現在は「主催イベントも表示する」仕様となっているため、`kimura` が主催者であるこのイベントは、未参加でもイベント一覧へ表示されます。

テスト内の以下期待値と fixture の状態が矛盾してしまっているため、
event34 の user を別ユーザーへ変更し、「未参加かつ主催でもないイベント」として扱うよう修正しました。

https://github.com/fjordllc/bootcamp/blob/f8649fadf79911aace2ffb1d74dc5a9cc2b3d73c/test/system/user/events_test.rb#L21

## 変更確認方法

1. `bug/events-test-organizer-fixture`をローカルに取り込む
2. `bin/rails test test/system/user/events_test.rb`を行い、エラーが発生しないことを確認

## Screenshot

### 変更前

<img width="1556" height="1038" alt="image" src="https://github.com/user-attachments/assets/bb62ac48-1777-4152-9e30-c810341dcbb1" />


### 変更後

<img width="1575" height="501" alt="image" src="https://github.com/user-attachments/assets/038d42c9-f79a-485a-915a-7746adc6c8de" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストはテスト用のフィクスチャデータの更新のみで、ユーザーに対する目に見える変更はありません。

* **テスト**
  * テストフィクスチャデータを更新

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/9990)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->