### PR TITLE
ユーザーの定期イベント一覧に主催した定期イベントを含める

### DIFF
--- a/app/controllers/users/regular_events_controller.rb
+++ b/app/controllers/users/regular_events_controller.rb
@@ -3,7 +3,7 @@
 class Users::RegularEventsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @regular_events = @user.participate_regular_events
+    @regular_events = @user.involved_regular_events
                            .includes(:comments, :regular_event_repeat_rules, :user,
                                      { users: { avatar_attachment: :blob } })
                            .order(:finished, created_at: :desc, id: :desc)

--- a/app/helpers/page_tabs/users_helper.rb
+++ b/app/helpers/page_tabs/users_helper.rb
@@ -13,7 +13,7 @@ module PageTabs
       tabs << { name: '提出物', link: user_products_path(user), count: user.products.length }
       tabs << { name: '質問', link: user_questions_path(user), count: user.questions.length }
       tabs << { name: '回答', link: user_answers_path(user), count: user.answers.length }
-      tabs << { name: 'イベント', link: user_events_path(user), count: user.participate_events.count + user.participate_regular_events.count }
+      tabs << { name: 'イベント', link: user_events_path(user), count: user.participate_events.count + user.involved_regular_events.count }
       if Switchlet.enabled?(:micro_report) && (admin_or_mentor_login? || (Rails.env.in? %w[development test]))
         tabs << { name: '分報',
                   link: "#{user_micro_reports_path(user, page: user.latest_micro_report_page)}#latest-micro-report",

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -106,7 +106,7 @@ module UsersHelper
   def event_navs(user)
     [
       { id: 'events', name: Event.model_name.human, count: user.participate_events.length, path: user_events_path(user) },
-      { id: 'regular_events', name: RegularEvent.model_name.human, count: user.participate_regular_events.length, path: user_regular_events_path(user) }
+      { id: 'regular_events', name: RegularEvent.model_name.human, count: user.involved_regular_events.length, path: user_regular_events_path(user) }
     ]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -894,6 +894,10 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
     RegularEvent.where(id: regular_event_participations.pluck(:regular_event_id), finished: false)
   end
 
+  def involved_regular_events
+    RegularEvent.where(id: participate_regular_events).or(RegularEvent.where(id: organize_regular_events))
+  end
+
   def clear_github_data
     update(
       github_id: nil,

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -799,4 +799,11 @@ class UserTest < ActiveSupport::TestCase
     user.mark_mail_as_sent_before_auto_retire
     assert user.sent_student_before_auto_retire_mail
   end
+
+  test '#involved_regular_events returns both participating and organizing regular events' do
+    user = users(:kimura)
+    expected_ids = (user.participate_regular_events.ids + user.organize_regular_events.ids).uniq.sort
+    actual_ids = user.involved_regular_events.ids.sort
+    assert_equal expected_ids, actual_ids
+  end
 end

--- a/test/system/user/regular_events_test.rb
+++ b/test/system/user/regular_events_test.rb
@@ -10,12 +10,12 @@ class User::RegularEventsTest < ApplicationSystemTestCase
     assert nav.matches_css?('.is-active')
   end
 
-  test 'shows correct count of user participating regular events' do
+  test 'shows correct count of user involved regular events' do
     visit_with_auth "/users/#{users(:kimura).id}/regular_events", 'kimura'
-    assert_text "定期イベント(#{users(:kimura).participate_regular_events.count})"
+    assert_text "定期イベント(#{users(:kimura).involved_regular_events.count})"
   end
 
-  test 'does not show regular events the user is not participating in' do
+  test 'does not show regular events the user is not involved in' do
     visit_with_auth "/users/#{users(:kimura).id}/regular_events", 'kimura'
     assert_text '独習Git輪読会'
     assert_no_text '開発MTG'

--- a/test/system/user/regular_events_test.rb
+++ b/test/system/user/regular_events_test.rb
@@ -3,7 +3,7 @@
 require 'application_system_test_case'
 
 class User::RegularEventsTest < ApplicationSystemTestCase
-  test 'shows the regular event listing for a user ' do
+  test 'shows the regular event listing for a user' do
     visit_with_auth "/users/#{users(:komagata).id}/regular_events", 'komagata'
     assert_equal 'komagataのイベント一覧 | FBC', title
     nav = find('a.tab-nav__item-link', text: /定期イベント\(\d+\)/)

--- a/test/system/user/regular_events_test.rb
+++ b/test/system/user/regular_events_test.rb
@@ -20,4 +20,9 @@ class User::RegularEventsTest < ApplicationSystemTestCase
     assert_text '独習Git輪読会'
     assert_no_text '開発MTG'
   end
+
+  test 'shows regular events the user organizes but does not participate in' do
+    visit_with_auth "/users/#{users(:kimura).id}/regular_events", 'kimura'
+    assert_text 'チェリー本輪読会'
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9861

## 概要
1. /users/{ID}/regular_eventsに表示される定期イベント一覧に主催のみのイベントを含める
2. テストメソッド「shows the regular event listing for a user」の末尾の不要スペースの削除

## 変更確認方法

1. {feature/include-organized-regular-events}をローカルに取り込む
### 主催のみのテスト
2. ユーザー[hajime]でログインする
3. 右上のマイプロフィールボタンをクリックする
4. 一番右のタブ「イベント」の数字が「1」になっていることを確認する
5. 「イベント」タブをクリックする
6. 「定期イベント」タブの数字が「1」になっていることを確認する
7. 「定期イベント」タブをクリックする
8. 「 チェリー本輪読会」が一覧に表示されていることを確認する
### 参加者のみのテスト
9. ユーザー[hatsuno]でログインする
3. 右上のマイプロフィールボタンをクリックする
4. 一番右のタブ「イベント」の数字が「3」になっていることを確認する
5. 「イベント」タブをクリックする
6. 「定期イベント」タブの数字が「1」になっていることを確認する
7. 「定期イベント」タブをクリックする
8. 「 開発MTG」が一覧に表示されていることを確認する

## Screenshot

### 変更前
「hajime」が主催のみのイベントが表示されない。
<img width="1141" height="309" alt="image" src="https://github.com/user-attachments/assets/69e98f8c-6e3d-4af4-8c88-b0c72beb7c57" />

### 変更後
「hajime」が主催のみのイベントが表示される。
<img width="1135" height="314" alt="image" src="https://github.com/user-attachments/assets/80f082e6-e5fb-4388-b721-c01ad4cf8daa" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ユーザーの定期イベント一覧が更新され、主催しているイベントと参加しているイベントの両方が表示されるようになりました。
  * イベント関連タブとナビゲーション内のイベントカウント表示が、ユーザーの関連イベント全体に基づいて正しく更新されます。

* **テスト**
  * ユーザーが主催するが参加していないイベントが正しく表示されることを確認するテストが追加されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/9994)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->