### PR TITLE
日報コメントAPIを追加

### DIFF
--- a/app/controllers/api/reports/comments_controller.rb
+++ b/app/controllers/api/reports/comments_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class API::Reports::CommentsController < API::BaseController
+  before_action :set_available_emojis, only: %i[create]
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create], if: -> { doorkeeper_token.present? }
+
+  def create
+    report = Report.find_by(id: params[:report_id])
+    return render json: { message: '日報が見つかりません。' }, status: :not_found unless report
+
+    @comment = report.comments.new(comment_params)
+    @comment.user = current_user
+
+    if @comment.save
+      render 'api/comments/create', status: :created
+    else
+      render json: { errors: @comment.errors }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def comment_params
+    params.fetch(:comment, ActionController::Parameters.new).permit(:description)
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -49,7 +49,9 @@ Rails.application.routes.draw do
       end
       resources :recents, only: %i(index)
     end
-    resources :reports, only: %i(index show)
+    resources :reports, only: %i(index show) do
+      resources :comments, only: %i[create], controller: 'reports/comments'
+    end
     resources :watches, only: %i(index create destroy)
     namespace 'watches' do
       resources :toggle, only: %i(index)

--- a/test/integration/api/comments_test.rb
+++ b/test/integration/api/comments_test.rb
@@ -77,6 +77,67 @@ class API::CommentsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'can create report comment with read, write scope' do
+    report = reports(:report1)
+
+    assert_difference('Comment.count') do
+      post api_report_comments_url(report, format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { comment: { description: 'New report comment' } }
+      assert_response :created
+    end
+
+    comment = Comment.find(response.parsed_body['id'])
+    assert_equal 'New report comment', comment.description
+    assert_equal report, comment.commentable
+
+    assert_equal comment.id, response.parsed_body['id']
+    assert_equal 'New report comment', response.parsed_body['description']
+    assert_equal 'Report', response.parsed_body['commentable_type']
+    assert_equal report.id, response.parsed_body['commentable_id']
+    assert_equal users(:komagata).id, response.parsed_body.dig('user', 'id')
+  end
+
+  test 'can not create report comment with read scope' do
+    post api_report_comments_url(reports(:report1), format: :json),
+         headers: { Authorization: "Bearer #{@read_token.token}" },
+         params: { comment: { description: 'New report comment' } }
+
+    assert_response :forbidden
+  end
+
+  test 'returns not found when creating comment on missing report' do
+    assert_no_difference('Comment.count') do
+      post api_report_comments_url(0, format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { comment: { description: 'New report comment' } }
+    end
+
+    assert_response :not_found
+    assert_equal '日報が見つかりません。', response.parsed_body['message']
+  end
+
+  test 'returns validation error when creating blank report comment' do
+    assert_no_difference('Comment.count') do
+      post api_report_comments_url(reports(:report1), format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { comment: { description: '' } }
+    end
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body.dig('errors', 'description').present?
+  end
+
+  test 'returns validation error when creating report comment without comment parameter' do
+    assert_no_difference('Comment.count') do
+      post api_report_comments_url(reports(:report1), format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" }
+    end
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body.dig('errors', 'description').present?
+  end
+
   test 'can update comment with read, write scope' do
     patch api_comment_url(@comment.id, format: :json),
           headers: { Authorization: "Bearer #{@write_token.token}" },


### PR DESCRIPTION
## 概要

- `POST /api/reports/:report_id/comments` を追加しました
- 成功時に作成したコメントを既存のコメントJSON形式で返すようにしました
- write scope不足、存在しない日報、本文未入力の integration test を追加しました

## 確認

- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/comments_test.rb`
- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/reports/comments_controller.rb test/integration/api/comments_test.rb`
- [x] 別人格レビューで指摘なしを確認

Closes #9995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * レポートへのコメント機能を追加しました。認可スコープに基づいてアクセス制御されます。

* **テスト**
  * コメント作成機能の統合テストを追加しました。認可、検証、エラーハンドリングをカバーしています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10008)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->