### PR TITLE
提出物CRUD APIを追加

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -21,16 +21,29 @@ class API::BaseController < ApplicationController
     "#{self.class.name}##{action_name}"
   end
 
+  def require_login_for_api
+    login_from_jwt unless logged_in?
+    render json: { error: 'unauthorized' }, status: :unauthorized unless logged_in?
+  end
+
   def doorkeeper_unauthorized_render_options(error:)
-    { json: error.body }
+    { json: doorkeeper_error_body(error) }
   end
 
   def doorkeeper_forbidden_render_options(error:)
-    { json: error.body }
+    { json: doorkeeper_error_body(error) }
   end
 
   def render_doorkeeper_error(error)
     response = error.response
     render json: response.body, status: response.status
+  end
+
+  def doorkeeper_error_body(error)
+    {
+      error: error.name,
+      error_description: error.description,
+      state: error.state
+    }.compact_blank
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,7 @@ class API::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token, if: -> { doorkeeper_token.present? }
   before_action :doorkeeper_authorize!, if: -> { doorkeeper_token.present? }
   before_action :require_login_for_api, unless: -> { doorkeeper_token.present? }
+  rescue_from Doorkeeper::Errors::DoorkeeperError, with: :render_doorkeeper_error
 
   private
 
@@ -18,5 +19,18 @@ class API::BaseController < ApplicationController
 
   def current_action_name
     "#{self.class.name}##{action_name}"
+  end
+
+  def doorkeeper_unauthorized_render_options(error:)
+    { json: error.body }
+  end
+
+  def doorkeeper_forbidden_render_options(error:)
+    { json: error.body }
+  end
+
+  def render_doorkeeper_error(error)
+    response = error.response
+    render json: response.body, status: response.status
   end
 end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -2,6 +2,8 @@
 
 class API::ProductsController < API::BaseController
   before_action :require_login_for_api, only: %i[index show]
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create update destroy], if: -> { doorkeeper_token.present? }
+  before_action :set_product, only: %i[update destroy]
 
   def index
     @company = Company.find(params[:company_id]) if params[:company_id]
@@ -18,5 +20,81 @@ class API::ProductsController < API::BaseController
 
   def show
     @product = Product.find(params[:id])
+  end
+
+  def create
+    @product = current_user.products.new(product_attributes)
+    @product.practice = Practice.find_by(id: product_params[:practice_id])
+    apply_wip
+    update_published_at
+
+    if @product.save
+      ActiveSupport::Notifications.instrument('product.create', product: @product)
+      ActiveSupport::Notifications.instrument('product.save', product: @product)
+      render_product_json :created
+    else
+      render json: { errors: @product.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @product.assign_attributes(product_attributes)
+    apply_wip
+    update_published_at
+
+    if @product.save
+      ActiveSupport::Notifications.instrument('product.update', { product: @product, current_user: })
+      ActiveSupport::Notifications.instrument('product.save', product: @product)
+      render_product_json :ok
+    else
+      render json: { errors: @product.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @product.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_product
+    @product = Product.find_by(id: params[:id])
+    return render json: { message: '提出物が見つかりません。' }, status: :not_found unless @product
+    return if current_user.admin? || current_user.mentor? || @product.user == current_user
+
+    render json: { message: 'この提出物を操作する権限がありません。' }, status: :forbidden
+  end
+
+  def product_params
+    params.fetch(:product, ActionController::Parameters.new).permit(:practice_id, :body, :wip)
+  end
+
+  def product_attributes
+    product_params.except(:practice_id, :wip)
+  end
+
+  def apply_wip
+    return unless product_params.key?(:wip)
+
+    @product.wip = ActiveModel::Type::Boolean.new.cast(product_params[:wip])
+  end
+
+  def update_published_at
+    if @product.wip
+      @product.published_at = nil
+    elsif @product.published_at.blank?
+      @product.published_at = Time.current
+    end
+  end
+
+  def render_product_json(status)
+    render json: {
+      id: @product.id,
+      practice_id: @product.practice_id,
+      body: @product.body,
+      wip: @product.wip,
+      published_at: @product.published_at
+    }, status:
   end
 end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class API::ProductsController < API::BaseController
-  before_action :require_login_for_api, only: %i[index show]
   before_action -> { doorkeeper_authorize! :write }, only: %i[create update destroy], if: -> { doorkeeper_token.present? }
   before_action :set_product, only: %i[update destroy]
+  before_action :authorize_product, only: %i[update destroy]
 
   def index
     @company = Company.find(params[:company_id]) if params[:company_id]
@@ -38,6 +38,8 @@ class API::ProductsController < API::BaseController
   end
 
   def update
+    return render json: { message: '提出物のプラクティスは変更できません。' }, status: :bad_request if product_params.key?(:practice_id)
+
     @product.assign_attributes(product_attributes)
     apply_wip
     update_published_at
@@ -60,7 +62,11 @@ class API::ProductsController < API::BaseController
 
   def set_product
     @product = Product.find_by(id: params[:id])
-    return render json: { message: '提出物が見つかりません。' }, status: :not_found unless @product
+    render json: { message: '提出物が見つかりません。' }, status: :not_found unless @product
+  end
+
+  def authorize_product
+    return if performed?
     return if current_user.admin? || current_user.mentor? || @product.user == current_user
 
     render json: { message: 'この提出物を操作する権限がありません。' }, status: :forbidden

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
       resource :checker, only: %i(show update destroy), controller: 'checker'
       resource :passed, only: %i(show), controller: 'passed'
     end
-    resources :products, only: %i(index show)
+    resources :products, only: %i(index show create update destroy)
     resources :bookmarks, only: %i(index create destroy)
     resources :report_templates, only: %i(create update)
     resources :markdown_tasks, only: %i(create)

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -31,6 +31,14 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'returns json error with invalid token' do
+    get api_products_path(format: :json),
+        headers: { Authorization: 'Bearer invalid-token' }
+
+    assert_response :unauthorized
+    assert_equal 'unauthorized', response.parsed_body['error']
+  end
+
   test 'GET /api/products/unchecked.json' do
     get api_products_unchecked_index_path(format: :json)
     assert_response :unauthorized
@@ -104,7 +112,7 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
   end
 
   test 'can create product with write scope' do
-    practice = Practice.where.not(id: @user.products.select(:practice_id)).first
+    practice = first_unsubmitted_practice(@user)
 
     assert_difference('Product.count') do
       post api_products_path(format: :json),
@@ -150,7 +158,7 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
   end
 
   test 'can not create product with read scope' do
-    practice = Practice.where.not(id: @user.products.select(:practice_id)).first
+    practice = first_unsubmitted_practice(@user)
 
     post api_products_path(format: :json),
          headers: { Authorization: "Bearer #{@read_token.token}" },
@@ -184,7 +192,7 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
   end
 
   test 'returns validation error when creating invalid product' do
-    practice = Practice.where.not(id: @user.products.select(:practice_id)).first
+    practice = first_unsubmitted_practice(@user)
 
     assert_no_difference('Product.count') do
       post api_products_path(format: :json),
@@ -194,6 +202,17 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     assert response.parsed_body.dig('errors', 'body').present?
+  end
+
+  test 'returns bad request when updating product practice' do
+    product = products(:product8)
+
+    patch api_product_path(product, format: :json),
+          headers: { Authorization: "Bearer #{@write_token.token}" },
+          params: { product: { practice_id: practices(:practice1).id } }
+
+    assert_response :bad_request
+    assert_equal '提出物のプラクティスは変更できません。', response.parsed_body['message']
   end
 
   test 'returns permission error when updating another user product' do
@@ -233,5 +252,11 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_equal 'メンターがAPIから更新します。', product.reload.body
+  end
+
+  private
+
+  def first_unsubmitted_practice(user)
+    Practice.where.not(id: user.products.select(:practice_id)).order(:id).first
   end
 end

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -3,6 +3,24 @@
 require 'test_helper'
 
 class API::ProductsTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:kimura)
+    application = Doorkeeper::Application.create!(
+      name: 'Sample Application',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
+    @read_token = Doorkeeper::AccessToken.create!(
+      application:,
+      resource_owner_id: @user.id,
+      scopes: 'read'
+    )
+    @write_token = Doorkeeper::AccessToken.create!(
+      application:,
+      resource_owner_id: @user.id,
+      scopes: 'read write'
+    )
+  end
+
   test 'GET /api/products.json' do
     get api_products_path(format: :json)
     assert_response :unauthorized
@@ -83,5 +101,137 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     get api_products_path(company_id: company.id, format: :json),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
+  end
+
+  test 'can create product with write scope' do
+    practice = Practice.where.not(id: @user.products.select(:practice_id)).first
+
+    assert_difference('Product.count') do
+      post api_products_path(format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { product: { practice_id: practice.id, body: 'APIから提出します。', wip: false } }
+      assert_response :created
+    end
+
+    product = Product.find(response.parsed_body['id'])
+    assert_equal @user, product.user
+    assert_equal practice, product.practice
+    assert_equal 'APIから提出します。', product.body
+    assert_not product.wip
+    assert_not_nil product.published_at
+    assert_equal product.body, response.parsed_body['body']
+    assert_equal practice.id, response.parsed_body['practice_id']
+  end
+
+  test 'can update own product with write scope' do
+    product = products(:product8)
+
+    patch api_product_path(product, format: :json),
+          headers: { Authorization: "Bearer #{@write_token.token}" },
+          params: { product: { body: 'APIからWIP更新します。', wip: true } }
+
+    assert_response :ok
+    product.reload
+    assert_equal 'APIからWIP更新します。', product.body
+    assert product.wip
+    assert_nil product.published_at
+    assert_equal product.body, response.parsed_body['body']
+    assert response.parsed_body['wip']
+  end
+
+  test 'can delete own product with write scope' do
+    product = products(:product8)
+
+    assert_difference('Product.count', -1) do
+      delete api_product_path(product, format: :json),
+             headers: { Authorization: "Bearer #{@write_token.token}" }
+      assert_response :no_content
+    end
+  end
+
+  test 'can not create product with read scope' do
+    practice = Practice.where.not(id: @user.products.select(:practice_id)).first
+
+    post api_products_path(format: :json),
+         headers: { Authorization: "Bearer #{@read_token.token}" },
+         params: { product: { practice_id: practice.id, body: 'APIから提出します。', wip: false } }
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
+  end
+
+  test 'can not update product with read scope' do
+    product = products(:product8)
+
+    patch api_product_path(product, format: :json),
+          headers: { Authorization: "Bearer #{@read_token.token}" },
+          params: { product: { body: 'APIから更新します。' } }
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
+  end
+
+  test 'can not delete product with read scope' do
+    product = products(:product8)
+
+    assert_no_difference('Product.count') do
+      delete api_product_path(product, format: :json),
+             headers: { Authorization: "Bearer #{@read_token.token}" }
+    end
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
+  end
+
+  test 'returns validation error when creating invalid product' do
+    practice = Practice.where.not(id: @user.products.select(:practice_id)).first
+
+    assert_no_difference('Product.count') do
+      post api_products_path(format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { product: { practice_id: practice.id, body: '', wip: false } }
+    end
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body.dig('errors', 'body').present?
+  end
+
+  test 'returns permission error when updating another user product' do
+    product = products(:product11)
+
+    patch api_product_path(product, format: :json),
+          headers: { Authorization: "Bearer #{@write_token.token}" },
+          params: { product: { body: '他人の提出物を更新します。' } }
+
+    assert_response :forbidden
+    assert_equal 'この提出物を操作する権限がありません。', response.parsed_body['message']
+  end
+
+  test 'returns permission error when deleting another user product' do
+    product = products(:product11)
+
+    assert_no_difference('Product.count') do
+      delete api_product_path(product, format: :json),
+             headers: { Authorization: "Bearer #{@write_token.token}" }
+    end
+
+    assert_response :forbidden
+    assert_equal 'この提出物を操作する権限がありません。', response.parsed_body['message']
+  end
+
+  test 'mentor can update another user product with write scope' do
+    product = products(:product8)
+    mentor_token = Doorkeeper::AccessToken.create!(
+      application: @write_token.application,
+      resource_owner_id: users(:mentormentaro).id,
+      scopes: 'read write'
+    )
+
+    patch api_product_path(product, format: :json),
+          headers: { Authorization: "Bearer #{mentor_token.token}" },
+          params: { product: { body: 'メンターがAPIから更新します。' } }
+
+    assert_response :ok
+    assert_equal 'メンターがAPIから更新します。', product.reload.body
   end
 end


### PR DESCRIPTION
## 概要

- `POST /api/products.json` を追加し、Bearer token 認証ユーザーが提出物を作成できるようにしました。
- `PATCH /api/products/:id.json` を追加し、自分の提出物を更新できるようにしました。
- `DELETE /api/products/:id.json` を追加し、自分の提出物を削除できるようにしました。
- HTML 側の提出物操作に合わせて、WIP でない公開時は `published_at` を設定し、WIP 化した場合は `published_at` を外すようにしました。
- Doorkeeper の scope 不足などの API 認証エラーを JSON で返すようにしました。
- 作成・更新・削除・scope 不足・権限不足・validation error の integration test を追加しました。

## 確認

- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/products_test.rb`
- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/base_controller.rb app/controllers/api/products_controller.rb test/integration/api/products_test.rb`
- [x] 別人格レビューを実施し、指摘を反映しました。

Closes #10000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * API製品エンドポイントでトークン認可された書き込み（作成／更新／削除）を追加しました。
  * 認証失敗時にJSONで一貫したエラーレスポンスを返すようになりました。

* **バグ修正 / 挙動改善**
  * 更新時の公開状態や下書きフラグ処理を一貫化し、不正な関連変更を拒否するようにしました。
  * 権限チェックを強化し、管理者／メンター／所有者以外の操作をブロックします。

* **テスト**
  * トークンスコープ、認可、エラー経路（無効トークン・スコープ不足・バリデーション等）を網羅する統合テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10010)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->