### PR TITLE
提出物コメントAPIを追加

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -31,7 +31,7 @@ class API::BaseController < ApplicationController
 
   def render_doorkeeper_error(error)
     response = error.response
-    render json: response.body, status: response.status
+    render json: doorkeeper_error_body(error), status: response.status
   end
 
   def doorkeeper_error_body(error)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,7 @@ class API::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token, if: -> { doorkeeper_token.present? }
   before_action :doorkeeper_authorize!, if: -> { doorkeeper_token.present? }
   before_action :require_login_for_api, unless: -> { doorkeeper_token.present? }
+  rescue_from Doorkeeper::Errors::DoorkeeperError, with: :render_doorkeeper_error
 
   private
 
@@ -18,5 +19,26 @@ class API::BaseController < ApplicationController
 
   def current_action_name
     "#{self.class.name}##{action_name}"
+  end
+
+  def doorkeeper_unauthorized_render_options(error:)
+    { json: doorkeeper_error_body(error) }
+  end
+
+  def doorkeeper_forbidden_render_options(error:)
+    { json: doorkeeper_error_body(error) }
+  end
+
+  def render_doorkeeper_error(error)
+    response = error.response
+    render json: response.body, status: response.status
+  end
+
+  def doorkeeper_error_body(error)
+    {
+      error: error.name,
+      error_description: error.description,
+      state: error.state
+    }.compact_blank
   end
 end

--- a/app/controllers/api/products/comments_controller.rb
+++ b/app/controllers/api/products/comments_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class API::Products::CommentsController < API::BaseController
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create], if: -> { doorkeeper_token.present? }
+
+  def create
+    product = Product.find_by(id: params[:product_id])
+    return render json: { message: '提出物が見つかりません。' }, status: :not_found unless product
+
+    comment = product.comments.new(comment_params)
+    comment.user = current_user
+
+    if comment.save
+      render json: comment_json(comment), status: :created
+    else
+      render json: { errors: comment.errors }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def comment_params
+    params.fetch(:comment, ActionController::Parameters.new).permit(:description)
+  end
+
+  def comment_json(comment)
+    {
+      id: comment.id,
+      description: comment.description,
+      commentable_type: comment.commentable_type,
+      commentable_id: comment.commentable_id,
+      user: {
+        id: comment.user.id,
+        login_name: comment.user.login_name,
+        name: comment.user.name
+      },
+      created_at: comment.created_at,
+      updated_at: comment.updated_at
+    }
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -68,7 +68,9 @@ Rails.application.routes.draw do
       resource :checker, only: %i(show update destroy), controller: 'checker'
       resource :passed, only: %i(show), controller: 'passed'
     end
-    resources :products, only: %i(index show)
+    resources :products, only: %i(index show) do
+      resources :comments, only: %i(create), controller: 'products/comments'
+    end
     resources :bookmarks, only: %i(index create destroy)
     resources :report_templates, only: %i(create update)
     resources :markdown_tasks, only: %i(create)

--- a/test/integration/api/comments_test.rb
+++ b/test/integration/api/comments_test.rb
@@ -153,4 +153,58 @@ class API::CommentsTest < ActionDispatch::IntegrationTest
       assert_response :not_found
     end
   end
+
+  test 'can create product comment with read, write scope' do
+    product = products(:product8)
+
+    assert_difference('Comment.count') do
+      post api_product_comments_url(product, format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { comment: { description: 'New product comment' } }
+      assert_response :created
+    end
+
+    comment = Comment.find(response.parsed_body['id'])
+    assert_equal 'New product comment', comment.description
+    assert_equal product, comment.commentable
+
+    assert_equal comment.id, response.parsed_body['id']
+    assert_equal 'New product comment', response.parsed_body['description']
+    assert_equal 'Product', response.parsed_body['commentable_type']
+    assert_equal product.id, response.parsed_body['commentable_id']
+    assert_equal users(:komagata).id, response.parsed_body.dig('user', 'id')
+    assert response.parsed_body['created_at'].present?
+    assert response.parsed_body['updated_at'].present?
+  end
+
+  test 'can not create product comment with read scope' do
+    post api_product_comments_url(products(:product8), format: :json),
+         headers: { Authorization: "Bearer #{@read_token.token}" },
+         params: { comment: { description: 'New product comment' } }
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
+  end
+
+  test 'returns not found when creating comment on missing product' do
+    assert_no_difference('Comment.count') do
+      post api_product_comments_url(0, format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { comment: { description: 'New product comment' } }
+    end
+
+    assert_response :not_found
+    assert_equal '提出物が見つかりません。', response.parsed_body['message']
+  end
+
+  test 'returns validation error when creating blank product comment' do
+    assert_no_difference('Comment.count') do
+      post api_product_comments_url(products(:product8), format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { comment: { description: '' } }
+    end
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body.dig('errors', 'description').present?
+  end
 end

--- a/test/integration/api/comments_test.rb
+++ b/test/integration/api/comments_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class API::CommentsTest < ActionDispatch::IntegrationTest
-  fixtures :comments, :users
+  fixtures :comments, :products, :users
 
   def setup
     user = users(:komagata)


### PR DESCRIPTION
## 概要

- `POST /api/products/:product_id/comments.json` を追加しました。
- Bearer token の `write` scope で提出物IDを指定してコメントを作成できるようにしました。
- 成功時に作成されたコメントの `id`, `description`, `commentable_type`, `commentable_id`, `user`, `created_at`, `updated_at` をJSONで返すようにしました。
- scope不足、存在しない提出物、本文未入力のJSONエラーを追加しました。

## 確認

- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/comments_test.rb`
- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/base_controller.rb app/controllers/api/products/comments_controller.rb test/integration/api/comments_test.rb`
- [x] 自己レビューを実施しました。

Closes #10007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 製品へのコメント作成APIエンドポイントを追加しました（書き込みスコープを持つトークンが必要）。

* **改善**
  * APIエラーのJSON出力を統一し、認可/例外発生時に一貫したエラーボディとHTTPステータスで返すようにしました（エラー名・説明・状態を含む）。

* **テスト**
  * コメント作成の成功、権限不足、存在しない製品、バリデーション失敗等を検証する統合テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10011)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->