### PR TITLE
日報リアクションAPIを追加

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,7 @@ class API::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token, if: -> { doorkeeper_token.present? }
   before_action :doorkeeper_authorize!, if: -> { doorkeeper_token.present? }
   before_action :require_login_for_api, unless: -> { doorkeeper_token.present? }
+  rescue_from Doorkeeper::Errors::DoorkeeperError, with: :render_doorkeeper_error
 
   private
 
@@ -18,5 +19,26 @@ class API::BaseController < ApplicationController
 
   def current_action_name
     "#{self.class.name}##{action_name}"
+  end
+
+  def doorkeeper_unauthorized_render_options(error:)
+    { json: doorkeeper_error_body(error) }
+  end
+
+  def doorkeeper_forbidden_render_options(error:)
+    { json: doorkeeper_error_body(error) }
+  end
+
+  def render_doorkeeper_error(error)
+    response = error.response
+    render json: response.body, status: response.status
+  end
+
+  def doorkeeper_error_body(error)
+    {
+      error: error.name,
+      error_description: error.description,
+      state: error.state
+    }.compact_blank
   end
 end

--- a/app/controllers/api/reports/reactions_controller.rb
+++ b/app/controllers/api/reports/reactions_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class API::Reports::ReactionsController < API::BaseController
+  before_action :set_report
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create destroy], if: -> { doorkeeper_token.present? }
+
+  def index
+    reactions = @report.reactions.includes(user: { avatar_attachment: :blob }).order(created_at: :asc)
+    grouped_reactions = reactions.group_by(&:kind)
+    result = Reaction.emojis.each_with_object({}) do |(kind, emoji), hash|
+      users = grouped_reactions[kind]&.map { |reaction| user_payload(reaction.user) } || []
+      hash[kind] = { emoji:, users: } unless users.empty?
+    end
+    render json: result
+  end
+
+  def create
+    reaction = @report.reactions.build(user: current_user, kind: params[:kind])
+
+    if reaction.save
+      render json: { id: reaction.id }, status: :created
+    else
+      render json: { errors: reaction.errors }, status: :unprocessable_entity
+    end
+  rescue ArgumentError
+    render json: { errors: { kind: ['利用できない絵文字です。'] } }, status: :unprocessable_entity
+  end
+
+  def destroy
+    reaction = current_user.reactions.find_by(id: params[:id], reactionable: @report)
+    return render json: { message: 'リアクションが見つかりません。' }, status: :not_found unless reaction
+
+    reaction.destroy
+    render json: {}, status: :ok
+  end
+
+  private
+
+  def set_report
+    @report = Report.find_by(id: params[:report_id])
+    render json: { message: '日報が見つかりません。' }, status: :not_found unless @report
+  end
+
+  def user_payload(user)
+    user = ActiveDecorator::Decorator.instance.decorate(user)
+    {
+      id: user.id,
+      login_name: user.login_name,
+      avatar_url: user.avatar_url,
+      user_icon_frame_class: user.user_icon_frame_class
+    }
+  end
+end

--- a/app/views/api/reports/_report.json.jbuilder
+++ b/app/views/api/reports/_report.json.jbuilder
@@ -1,4 +1,5 @@
 json.id report.id
+json.reactionable_gid report.to_global_id.to_s
 json.title report.title
 json.description report.description
 json.reportedOn l(report.reported_on)

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -49,7 +49,9 @@ Rails.application.routes.draw do
       end
       resources :recents, only: %i(index)
     end
-    resources :reports, only: %i(index show)
+    resources :reports, only: %i(index show) do
+      resources :reactions, only: %i(index create destroy), controller: 'reports/reactions'
+    end
     resources :watches, only: %i(index create destroy)
     namespace 'watches' do
       resources :toggle, only: %i(index)

--- a/test/integration/api/reactions_test.rb
+++ b/test/integration/api/reactions_test.rb
@@ -3,6 +3,24 @@
 require 'test_helper'
 
 class API::ReactionTest < ActionDispatch::IntegrationTest
+  def setup
+    user = users(:komagata)
+    application = Doorkeeper::Application.create!(
+      name: 'Sample Application',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
+    @read_token = Doorkeeper::AccessToken.create!(
+      application:,
+      resource_owner_id: user.id,
+      scopes: 'read'
+    )
+    @write_token = Doorkeeper::AccessToken.create!(
+      application:,
+      resource_owner_id: user.id,
+      scopes: 'read write'
+    )
+  end
+
   test 'POST /api/reactions returns created' do
     report = reports(:report4)
 
@@ -84,5 +102,95 @@ class API::ReactionTest < ActionDispatch::IntegrationTest
                             headers: { 'Authorization' => "Bearer #{token}" }
 
     assert_response :not_found
+  end
+
+  test 'report response includes reactionable_gid' do
+    get api_report_path(reports(:report4), format: :json),
+        headers: { Authorization: "Bearer #{@read_token.token}" }
+
+    assert_response :ok
+    assert_equal reports(:report4).to_global_id.to_s, response.parsed_body['reactionable_gid']
+  end
+
+  test 'POST /api/reports/:report_id/reactions returns created' do
+    report = reports(:report4)
+
+    assert_difference('Reaction.count') do
+      post api_report_reactions_path(report, format: :json),
+           params: { kind: 'smile' },
+           headers: { Authorization: "Bearer #{@write_token.token}" }
+      assert_response :created
+    end
+
+    reaction = Reaction.find(response.parsed_body['id'])
+    assert_equal report, reaction.reactionable
+    assert_equal users(:komagata), reaction.user
+    assert_equal 'smile', reaction.kind
+  end
+
+  test 'GET /api/reports/:report_id/reactions returns reactions' do
+    report = reports(:report4)
+    Reaction.create!(reactionable: report, user: users(:komagata), kind: 'thumbsup')
+
+    get api_report_reactions_path(report, format: :json),
+        headers: { Authorization: "Bearer #{@read_token.token}" }
+
+    assert_response :ok
+    assert_equal Reaction.emojis['thumbsup'], response.parsed_body.dig('thumbsup', 'emoji')
+    assert_equal users(:komagata).id, response.parsed_body.dig('thumbsup', 'users', 0, 'id')
+  end
+
+  test 'DELETE /api/reports/:report_id/reactions/:id returns ok' do
+    report = reports(:report4)
+    reaction = Reaction.create!(reactionable: report, user: users(:komagata), kind: 'heart')
+
+    assert_difference('Reaction.count', -1) do
+      delete api_report_reaction_path(report, reaction, format: :json),
+             headers: { Authorization: "Bearer #{@write_token.token}" }
+      assert_response :ok
+    end
+  end
+
+  test 'POST /api/reports/:report_id/reactions with read scope returns forbidden' do
+    post api_report_reactions_path(reports(:report4), format: :json),
+         params: { kind: 'smile' },
+         headers: { Authorization: "Bearer #{@read_token.token}" }
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
+  end
+
+  test 'POST /api/reports/:report_id/reactions with unknown report returns not_found' do
+    post api_report_reactions_path(0, format: :json),
+         params: { kind: 'smile' },
+         headers: { Authorization: "Bearer #{@write_token.token}" }
+
+    assert_response :not_found
+    assert_equal '日報が見つかりません。', response.parsed_body['message']
+  end
+
+  test 'POST /api/reports/:report_id/reactions with invalid kind returns unprocessable_entity' do
+    assert_no_difference('Reaction.count') do
+      post api_report_reactions_path(reports(:report4), format: :json),
+           params: { kind: 'invalid' },
+           headers: { Authorization: "Bearer #{@write_token.token}" }
+    end
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body.dig('errors', 'kind').present?
+  end
+
+  test 'POST /api/reports/:report_id/reactions with duplicate kind returns unprocessable_entity' do
+    report = reports(:report4)
+    Reaction.create!(reactionable: report, user: users(:komagata), kind: 'smile')
+
+    assert_no_difference('Reaction.count') do
+      post api_report_reactions_path(report, format: :json),
+           params: { kind: 'smile' },
+           headers: { Authorization: "Bearer #{@write_token.token}" }
+    end
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body['errors'].present?
   end
 end


### PR DESCRIPTION
## 概要

- `GET /api/reports/:report_id/reactions.json` を追加しました。
- `POST /api/reports/:report_id/reactions.json` を追加し、日報IDと `kind` でリアクションを作成できるようにしました。
- `DELETE /api/reports/:report_id/reactions/:id.json` を追加しました。
- 日報 JSON に `reactionable_gid` を追加しました。
- scope不足、存在しない日報、不正な `kind`、重複リアクションのJSONエラーを追加しました。

## 確認

- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/reactions_test.rb`
- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/base_controller.rb app/controllers/api/reports/reactions_controller.rb test/integration/api/reactions_test.rb`
- [x] 自己レビューを実施しました。

Closes #9996