### PR TITLE
日報CRUD APIを追加

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,7 @@ class API::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token, if: -> { doorkeeper_token.present? }
   before_action :doorkeeper_authorize!, if: -> { doorkeeper_token.present? }
   before_action :require_login_for_api, unless: -> { doorkeeper_token.present? }
+  rescue_from Doorkeeper::Errors::DoorkeeperError, with: :render_doorkeeper_error
 
   private
 
@@ -18,5 +19,26 @@ class API::BaseController < ApplicationController
 
   def current_action_name
     "#{self.class.name}##{action_name}"
+  end
+
+  def doorkeeper_unauthorized_render_options(error:)
+    { json: doorkeeper_error_body(error) }
+  end
+
+  def doorkeeper_forbidden_render_options(error:)
+    { json: doorkeeper_error_body(error) }
+  end
+
+  def render_doorkeeper_error(error)
+    response = error.response
+    render json: response.body, status: response.status
+  end
+
+  def doorkeeper_error_body(error)
+    {
+      error: error.name,
+      error_description: error.description,
+      state: error.state
+    }.compact_blank
   end
 end

--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class API::ReportsController < API::BaseController
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create update destroy], if: -> { doorkeeper_token.present? }
+  before_action :set_editable_report, only: %i[update]
+  before_action :set_my_report, only: %i[destroy]
+
   def index
     @company = Company.find(params[:company_id]) if params[:company_id]
     @reports = Report.list.page(params[:page])
@@ -16,5 +20,84 @@ class API::ReportsController < API::BaseController
 
   def show
     @report = Report.includes(:user, :practices, :checks, comments: :user).find(params[:id])
+  end
+
+  def create
+    @report = Report.new(report_params)
+    @report.user = current_user
+    canonicalize_learning_times(@report)
+
+    if @report.save_uniquely
+      ActiveSupport::Notifications.instrument('report.create', report: @report)
+      render :show, status: :created
+    else
+      render json: { errors: @report.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @report.practice_ids = nil if params[:report][:practice_ids].nil?
+    @report.assign_attributes(report_params)
+    @report.learning_times.each(&:mark_for_destruction) if @report.no_learn
+    canonicalize_learning_times(@report)
+
+    if @report.save_uniquely
+      ActiveSupport::Notifications.instrument('report.update', report: @report)
+      render :show, status: :ok
+    else
+      render json: { errors: @report.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @report.destroy
+    ActiveSupport::Notifications.instrument('report.destroy', report: @report)
+    render json: {}, status: :ok
+  end
+
+  private
+
+  def report_params
+    params.require(:report).permit(
+      :title,
+      :reported_on,
+      :emotion,
+      :no_learn,
+      :description,
+      :wip,
+      practice_ids: [],
+      learning_times_attributes: %i[id started_at finished_at _destroy]
+    )
+  end
+
+  def set_my_report
+    @report = current_user.reports.find_by(id: params[:id])
+    render json: { message: '日報が見つかりません。' }, status: :not_found unless @report
+  end
+
+  def set_editable_report
+    @report = current_user.mentor? ? Report.find_by(id: params[:id]) : current_user.reports.find_by(id: params[:id])
+    render json: { message: '日報が見つかりません。' }, status: :not_found unless @report
+  end
+
+  def canonicalize_learning_times(report)
+    return if report.reported_on.blank?
+
+    report.learning_times.each do |learning_time|
+      next if learning_time.started_at.blank? || learning_time.finished_at.blank?
+
+      new_started_at = learning_time.started_at.change(
+        year: report.reported_on.year,
+        month: report.reported_on.month,
+        day: report.reported_on.day
+      )
+      new_finished_at = learning_time.finished_at.change(
+        year: report.reported_on.year,
+        month: report.reported_on.month,
+        day: report.reported_on.day
+      )
+      new_finished_at += 1.day if new_started_at > new_finished_at
+      learning_time.assign_attributes(started_at: new_started_at, finished_at: new_finished_at)
+    end
   end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
       end
       resources :recents, only: %i(index)
     end
-    resources :reports, only: %i(index show)
+    resources :reports, only: %i(index show create update destroy)
     resources :watches, only: %i(index create destroy)
     namespace 'watches' do
       resources :toggle, only: %i(index)

--- a/test/integration/api/reports_test.rb
+++ b/test/integration/api/reports_test.rb
@@ -44,4 +44,112 @@ class API::ReportsTest < ActionDispatch::IntegrationTest
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
   end
+
+  test 'POST /api/reports.json' do
+    token = create_token('kimura', 'testtest')
+
+    assert_difference('Report.count') do
+      post api_reports_path(format: :json),
+           headers: { 'Authorization' => "Bearer #{token}" },
+           params: { report: report_params }
+      assert_response :created
+    end
+
+    report = Report.find(response.parsed_body['id'])
+    assert_equal users(:kimura), report.user
+    assert_equal 'APIで作成した日報', report.title
+    assert_equal Date.new(2026, 5, 1), report.reported_on
+    assert_equal 'positive', report.emotion
+    assert_equal [practices(:practice1).id], report.practice_ids
+    assert report.wip?
+    assert_equal Time.zone.local(2026, 5, 1, 9, 0), report.learning_times.first.started_at
+    assert_equal Time.zone.local(2026, 5, 1, 10, 0), report.learning_times.first.finished_at
+  end
+
+  test 'PATCH /api/reports/:id.json' do
+    report = reports(:report1)
+    token = create_token('komagata', 'testtest')
+
+    patch api_report_path(report, format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" },
+          params: {
+            report: {
+              title: 'APIで更新した日報',
+              description: 'APIで本文を更新しました。',
+              emotion: 'neutral',
+              wip: false,
+              practice_ids: [practices(:practice2).id],
+              learning_times_attributes: {
+                '0' => {
+                  id: report.learning_times.first.id,
+                  started_at: '08:00',
+                  finished_at: '09:30'
+                }
+              }
+            }
+          }
+
+    assert_response :ok
+    report.reload
+    assert_equal 'APIで更新した日報', report.title
+    assert_equal 'APIで本文を更新しました。', report.description
+    assert_equal 'neutral', report.emotion
+    assert_equal [practices(:practice2).id], report.practice_ids
+    assert_equal Time.zone.local(2017, 1, 1, 8, 0), report.learning_times.first.started_at
+    assert_equal Time.zone.local(2017, 1, 1, 9, 30), report.learning_times.first.finished_at
+  end
+
+  test 'DELETE /api/reports/:id.json' do
+    report = reports(:report1)
+    token = create_token('komagata', 'testtest')
+
+    assert_difference('Report.count', -1) do
+      delete api_report_path(report, format: :json),
+             headers: { 'Authorization' => "Bearer #{token}" }
+      assert_response :ok
+    end
+  end
+
+  test 'returns not found when updating other user report' do
+    token = create_token('kimura', 'testtest')
+
+    patch api_report_path(reports(:report1), format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" },
+          params: { report: { title: '更新できない日報' } }
+
+    assert_response :not_found
+    assert_equal '日報が見つかりません。', response.parsed_body['message']
+  end
+
+  test 'returns validation error when creating invalid report' do
+    token = create_token('kimura', 'testtest')
+
+    assert_no_difference('Report.count') do
+      post api_reports_path(format: :json),
+           headers: { 'Authorization' => "Bearer #{token}" },
+           params: { report: report_params.merge(title: '') }
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes response.parsed_body.dig('errors', 'title'), 'を入力してください'
+  end
+
+  private
+
+  def report_params
+    {
+      title: 'APIで作成した日報',
+      reported_on: '2026-05-01',
+      emotion: 'positive',
+      description: 'APIから日報を作成しました。',
+      wip: true,
+      practice_ids: [practices(:practice1).id],
+      learning_times_attributes: {
+        '0' => {
+          started_at: '09:00',
+          finished_at: '10:00'
+        }
+      }
+    }
+  end
 end


### PR DESCRIPTION
## 概要

- 日報の作成・更新・削除APIを追加
- APIでも `save_uniquely` と学習時間の日時補正を適用
- validation error と権限不足時のJSONレスポンスを追加

## 確認

- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/reports_test.rb
- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/base_controller.rb app/controllers/api/reports_controller.rb test/integration/api/reports_test.rb

Closes #10001