### PR TITLE
通知既読APIを追加

### DIFF
--- a/app/controllers/api/notifications/all_read_marks_controller.rb
+++ b/app/controllers/api/notifications/all_read_marks_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class API::Notifications::AllReadMarksController < API::BaseController
+  def update
+    notifications = current_user.notifications.unreads
+    count = notifications.count
+    current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: notifications)
+    render json: { count: }, status: :ok
+  end
+end

--- a/app/controllers/api/notifications/category_read_marks_controller.rb
+++ b/app/controllers/api/notifications/category_read_marks_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class API::Notifications::CategoryReadMarksController < API::BaseController
+  def update
+    notifications = current_user.notifications.by_target(validated_target).unreads
+    count = notifications.count
+    current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: notifications)
+    render json: { count: }, status: :ok
+  end
+
+  private
+
+  def validated_target
+    target = params[:target].presence&.to_sym
+    Notification::TARGETS_TO_KINDS.key?(target) ? target : nil
+  end
+end

--- a/app/controllers/api/notifications/category_read_marks_controller.rb
+++ b/app/controllers/api/notifications/category_read_marks_controller.rb
@@ -2,7 +2,10 @@
 
 class API::Notifications::CategoryReadMarksController < API::BaseController
   def update
-    notifications = current_user.notifications.by_target(validated_target).unreads
+    target = validated_target
+    return render json: { message: 'targetが不正です。' }, status: :bad_request unless target
+
+    notifications = current_user.notifications.by_target(target).unreads
     count = notifications.count
     current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: notifications)
     render json: { count: }, status: :ok

--- a/app/controllers/api/notifications/read_marks_controller.rb
+++ b/app/controllers/api/notifications/read_marks_controller.rb
@@ -7,7 +7,6 @@ class API::Notifications::ReadMarksController < API::BaseController
 
     notification.update!(read: true)
     Cache.delete_mentioned_and_unread_notification_count(current_user.id)
-    notification.reload
-    render json: { id: notification.id, read: notification.read }, status: :ok
+    render json: { id: notification.id, read: true }, status: :ok
   end
 end

--- a/app/controllers/api/notifications/read_marks_controller.rb
+++ b/app/controllers/api/notifications/read_marks_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class API::Notifications::ReadMarksController < API::BaseController
+  def update
+    notification = current_user.notifications.find_by(id: params[:notification_id])
+    return render json: { message: '通知が見つかりません。' }, status: :not_found unless notification
+
+    notification.update!(read: true)
+    Cache.delete_mentioned_and_unread_notification_count(current_user.id)
+    notification.reload
+    render json: { id: notification.id, read: notification.read }, status: :ok
+  end
+end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -13,4 +13,35 @@ class API::NotificationsController < API::BaseController
     per = params[:per]
     @notifications = per ? @notifications.page(page).per(per) : @notifications.page(page)
   end
+
+  def read
+    notification = current_user.notifications.find_by(id: params[:id])
+    return render json: { message: '通知が見つかりません。' }, status: :not_found unless notification
+
+    notification.update!(read: true)
+    Cache.delete_mentioned_and_unread_notification_count(current_user.id)
+    notification.reload
+    render json: { id: notification.id, read: notification.read }, status: :ok
+  end
+
+  def read_by_category
+    notifications = current_user.notifications.by_target(validated_target).unreads
+    count = notifications.count
+    current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: notifications)
+    render json: { count: }, status: :ok
+  end
+
+  def read_all
+    notifications = current_user.notifications.unreads
+    count = notifications.count
+    current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: notifications)
+    render json: { count: }, status: :ok
+  end
+
+  private
+
+  def validated_target
+    target = params[:target].presence&.to_sym
+    Notification::TARGETS_TO_KINDS.key?(target) ? target : nil
+  end
 end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -13,35 +13,4 @@ class API::NotificationsController < API::BaseController
     per = params[:per]
     @notifications = per ? @notifications.page(page).per(per) : @notifications.page(page)
   end
-
-  def read
-    notification = current_user.notifications.find_by(id: params[:id])
-    return render json: { message: '通知が見つかりません。' }, status: :not_found unless notification
-
-    notification.update!(read: true)
-    Cache.delete_mentioned_and_unread_notification_count(current_user.id)
-    notification.reload
-    render json: { id: notification.id, read: notification.read }, status: :ok
-  end
-
-  def read_by_category
-    notifications = current_user.notifications.by_target(validated_target).unreads
-    count = notifications.count
-    current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: notifications)
-    render json: { count: }, status: :ok
-  end
-
-  def read_all
-    notifications = current_user.notifications.unreads
-    count = notifications.count
-    current_user.mark_all_as_read_and_delete_cache_of_unreads(target_notifications: notifications)
-    render json: { count: }, status: :ok
-  end
-
-  private
-
-  def validated_target
-    target = params[:target].presence&.to_sym
-    Notification::TARGETS_TO_KINDS.key?(target) ? target : nil
-  end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -22,7 +22,11 @@ Rails.application.routes.draw do
     resources :categories_practices, only: %i() do
       resource :position, only: %i(update), controller: "categories_practices/position"
     end
-    resources :notifications, only: %i(index)
+    resources :notifications, only: %i(index) do
+      post :read, on: :member
+      post :read_by_category, on: :collection
+      post :read_all, on: :collection
+    end
     resources :subscriptions, only: %i(index)
     resources :comments, only: %i(index create update destroy)
     resources :answers, only: %i(index create update destroy) do

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -23,9 +23,11 @@ Rails.application.routes.draw do
       resource :position, only: %i(update), controller: "categories_practices/position"
     end
     resources :notifications, only: %i(index) do
-      post :read, on: :member
-      post :read_by_category, on: :collection
-      post :read_all, on: :collection
+      resource :read_mark, only: %i(update), controller: 'notifications/read_marks'
+    end
+    namespace :notifications do
+      resource :all_read_mark, only: %i(update)
+      resource :category_read_mark, only: %i(update)
     end
     resources :subscriptions, only: %i(index)
     resources :comments, only: %i(index create update destroy)

--- a/test/integration/api/notifications_test.rb
+++ b/test/integration/api/notifications_test.rb
@@ -23,12 +23,12 @@ class API::NotificationsTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
-  test 'POST /api/notifications/:id/read.json' do
+  test 'PATCH /api/notifications/:notification_id/read_mark.json' do
     token = create_token('kimura', 'testtest')
     notification = notifications('notification_mentioned_and_unread_1')
 
-    post read_api_notification_path(notification, format: :json),
-         headers: { 'Authorization' => "Bearer #{token}" }
+    patch api_notification_read_mark_path(notification, format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" }
 
     assert_response :ok
     assert_equal notification.id, response.parsed_body['id']
@@ -36,12 +36,12 @@ class API::NotificationsTest < ActionDispatch::IntegrationTest
     assert notification.reload.read?
   end
 
-  test 'POST /api/notifications/read_by_category.json' do
+  test 'PATCH /api/notifications/category_read_mark.json' do
     token = create_token('kimura', 'testtest')
 
-    post read_by_category_api_notifications_path(format: :json),
-         headers: { 'Authorization' => "Bearer #{token}" },
-         params: { target: 'mention' }
+    patch api_notifications_category_read_mark_path(format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" },
+          params: { target: 'mention' }
 
     assert_response :ok
     assert_equal 2, response.parsed_body['count']
@@ -50,12 +50,12 @@ class API::NotificationsTest < ActionDispatch::IntegrationTest
     assert_not notifications(:notification_watching).reload.read?
   end
 
-  test 'POST /api/notifications/read_all.json' do
+  test 'PATCH /api/notifications/all_read_mark.json' do
     token = create_token('kimura', 'testtest')
     unread_count = users(:kimura).notifications.unreads.count
 
-    post read_all_api_notifications_path(format: :json),
-         headers: { 'Authorization' => "Bearer #{token}" }
+    patch api_notifications_all_read_mark_path(format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" }
 
     assert_response :ok
     assert_equal unread_count, response.parsed_body['count']
@@ -65,8 +65,8 @@ class API::NotificationsTest < ActionDispatch::IntegrationTest
   test 'returns not found when reading other user notification' do
     token = create_token('kimura', 'testtest')
 
-    post read_api_notification_path(notifications(:notification_submitted), format: :json),
-         headers: { 'Authorization' => "Bearer #{token}" }
+    patch api_notification_read_mark_path(notifications(:notification_submitted), format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" }
 
     assert_response :not_found
     assert_equal '通知が見つかりません。', response.parsed_body['message']

--- a/test/integration/api/notifications_test.rb
+++ b/test/integration/api/notifications_test.rb
@@ -22,4 +22,54 @@ class API::NotificationsTest < ActionDispatch::IntegrationTest
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
   end
+
+  test 'POST /api/notifications/:id/read.json' do
+    token = create_token('kimura', 'testtest')
+    notification = notifications('notification_mentioned_and_unread_1')
+
+    post read_api_notification_path(notification, format: :json),
+         headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :ok
+    assert_equal notification.id, response.parsed_body['id']
+    assert response.parsed_body['read']
+    assert notification.reload.read?
+  end
+
+  test 'POST /api/notifications/read_by_category.json' do
+    token = create_token('kimura', 'testtest')
+
+    post read_by_category_api_notifications_path(format: :json),
+         headers: { 'Authorization' => "Bearer #{token}" },
+         params: { target: 'mention' }
+
+    assert_response :ok
+    assert_equal 2, response.parsed_body['count']
+    assert notifications('notification_mentioned_and_unread_1').reload.read?
+    assert notifications('notification_mentioned_and_unread_2').reload.read?
+    assert_not notifications(:notification_watching).reload.read?
+  end
+
+  test 'POST /api/notifications/read_all.json' do
+    token = create_token('kimura', 'testtest')
+    unread_count = users(:kimura).notifications.unreads.count
+
+    post read_all_api_notifications_path(format: :json),
+         headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :ok
+    assert_equal unread_count, response.parsed_body['count']
+    assert_equal 0, users(:kimura).notifications.unreads.count
+  end
+
+  test 'returns not found when reading other user notification' do
+    token = create_token('kimura', 'testtest')
+
+    post read_api_notification_path(notifications(:notification_submitted), format: :json),
+         headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :not_found
+    assert_equal '通知が見つかりません。', response.parsed_body['message']
+    assert_not notifications(:notification_submitted).reload.read?
+  end
 end

--- a/test/integration/api/notifications_test.rb
+++ b/test/integration/api/notifications_test.rb
@@ -47,7 +47,30 @@ class API::NotificationsTest < ActionDispatch::IntegrationTest
     assert_equal 2, response.parsed_body['count']
     assert notifications('notification_mentioned_and_unread_1').reload.read?
     assert notifications('notification_mentioned_and_unread_2').reload.read?
-    assert_not notifications(:notification_watching).reload.read?
+    assert_not notifications('notification_watching').reload.read?
+  end
+
+  test 'PATCH /api/notifications/category_read_mark.json with invalid target' do
+    token = create_token('kimura', 'testtest')
+
+    patch api_notifications_category_read_mark_path(format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" },
+          params: { target: 'invalid' }
+
+    assert_response :bad_request
+    assert_equal 'targetが不正です。', response.parsed_body['message']
+    assert_unread_notifications_remain
+  end
+
+  test 'PATCH /api/notifications/category_read_mark.json without target' do
+    token = create_token('kimura', 'testtest')
+
+    patch api_notifications_category_read_mark_path(format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :bad_request
+    assert_equal 'targetが不正です。', response.parsed_body['message']
+    assert_unread_notifications_remain
   end
 
   test 'PATCH /api/notifications/all_read_mark.json' do
@@ -70,6 +93,14 @@ class API::NotificationsTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
     assert_equal '通知が見つかりません。', response.parsed_body['message']
-    assert_not notifications(:notification_submitted).reload.read?
+    assert_not notifications('notification_submitted').reload.read?
+  end
+
+  private
+
+  def assert_unread_notifications_remain
+    assert_not notifications('notification_mentioned_and_unread_1').reload.read?
+    assert_not notifications('notification_mentioned_and_unread_2').reload.read?
+    assert_not notifications('notification_watching').reload.read?
   end
 end


### PR DESCRIPTION
## 概要

- 個別通知を既読にするAPIを追加
- target/category 単位で未読通知を既読にするAPIを追加
- 自分の未読通知を全既読にするAPIを追加

## 確認

- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/notifications_test.rb
- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/notifications_controller.rb test/integration/api/notifications_test.rb

Closes #10003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新機能
- 通知の既読化APIを追加
  - 個別の通知を既読にするエンドポイント（存在しない通知は404を返します）
  - カテゴリ指定（例: メンション）で該当通知を一括既読にするエンドポイント（不正/未指定のカテゴリは400でエラーを返します）
  - すべての通知を一括既読にするエンドポイント

## テスト
- 通知既読化APIの統合テストを追加（各種成功/エラーケースを検証）

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->