### PR TITLE
横断検索APIを追加

### DIFF
--- a/app/controllers/api/searchables_controller.rb
+++ b/app/controllers/api/searchables_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class API::SearchablesController < API::BaseController
+  PER_PAGE = 50
+
+  rescue_from ArgumentError, with: :render_bad_request
+
+  def index
+    results = searcher.search
+    @searchables = Kaminari.paginate_array(results).page(params[:page]).per(PER_PAGE)
+
+    render json: {
+      searchables: @searchables.map { |searchable| searchable_json(searchable) },
+      total_pages: @searchables.total_pages
+    }
+  end
+
+  private
+
+  def searcher
+    Searcher.new(
+      keyword: params[:word],
+      document_type: params[:document_type],
+      only_me: ActiveModel::Type::Boolean.new.cast(params[:only_me]),
+      current_user:,
+      mode: params[:mode]
+    )
+  end
+
+  def searchable_json(searchable)
+    {
+      type: searchable.search_model_name,
+      id: searchable.id,
+      title: searchable.search_title,
+      label: searchable.search_label,
+      content: searchable.search_content,
+      url: searchable.search_url,
+      user: user_json(searchable),
+      updated_at: searchable.updated_at
+    }
+  end
+
+  def user_json(searchable)
+    user = search_user(searchable)
+    return unless user
+
+    {
+      id: user.id,
+      login_name: user.login_name,
+      name: user.name
+    }
+  end
+
+  def search_user(searchable)
+    return searchable if searchable.is_a?(User)
+    return searchable.user if searchable.respond_to?(:user)
+
+    nil
+  end
+
+  def render_bad_request(error)
+    render json: { message: error.message }, status: :bad_request
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
       resource :passed, only: %i(show), controller: 'passed'
     end
     resources :products, only: %i(index show)
+    resources :searchables, only: %i(index)
     resources :bookmarks, only: %i(index create destroy)
     resources :report_templates, only: %i(create update)
     resources :markdown_tasks, only: %i(create)

--- a/test/integration/api/searchables_test.rb
+++ b/test/integration/api/searchables_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::SearchablesTest < ActionDispatch::IntegrationTest
+  test 'GET /api/searchables.json requires authentication' do
+    get api_searchables_path(format: :json), params: { word: '作業' }
+
+    assert_response :unauthorized
+  end
+
+  test 'GET /api/searchables.json searches by keyword' do
+    token = create_token('kimura', 'testtest')
+
+    get api_searchables_path(format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" },
+        params: { word: '作業', document_type: 'report', mode: 'keyword' }
+
+    assert_response :ok
+    searchables = response.parsed_body['searchables']
+    assert searchables.any?
+    assert(searchables.all? { |searchable| searchable['type'] == 'report' })
+    assert_includes searchables.first.keys, 'title'
+    assert_includes searchables.first.keys, 'content'
+    assert_includes searchables.first.keys, 'url'
+    assert_includes searchables.first.keys, 'user'
+    assert_includes searchables.first.keys, 'updated_at'
+  end
+
+  test 'GET /api/searchables.json filters by only_me' do
+    token = create_token('komagata', 'testtest')
+
+    get api_searchables_path(format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" },
+        params: { word: '作業', document_type: 'report', only_me: true }
+
+    assert_response :ok
+    assert response.parsed_body['searchables'].any?
+    assert(response.parsed_body['searchables'].all? { |searchable| searchable.dig('user', 'id') == users(:komagata).id })
+  end
+
+  test 'GET /api/searchables.json searches by semantic mode' do
+    token = create_token('kimura', 'testtest')
+
+    report = reports(:report1)
+    semantic_searcher = Object.new
+    semantic_searcher.define_singleton_method(:search) { |*| [report] }
+
+    SmartSearch::SemanticSearcher.stub(:new, semantic_searcher) do
+      get api_searchables_path(format: :json),
+          headers: { 'Authorization' => "Bearer #{token}" },
+          params: { word: '作業', document_type: 'report', mode: 'semantic' }
+    end
+
+    assert_response :ok
+    assert_equal [reports(:report1).id], response.parsed_body['searchables'].pluck('id')
+  end
+
+  test 'GET /api/searchables.json returns bad request with invalid document_type' do
+    token = create_token('kimura', 'testtest')
+
+    get api_searchables_path(format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" },
+        params: { word: '作業', document_type: 'unknown' }
+
+    assert_response :bad_request
+    assert_match 'Invalid document_type', response.parsed_body['message']
+  end
+end


### PR DESCRIPTION
## 概要

- `GET /api/searchables.json` を追加
- 既存の `Searcher` を使って keyword / semantic 検索をAPIから利用可能にする
- document_type と only_me による絞り込み、検索結果JSONを追加

## 確認

- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/searchables_test.rb
- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/searchables_controller.rb test/integration/api/searchables_test.rb

Closes #10002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 新しい検索 API エンドポイントを追加しました。キーワード、ドキュメントタイプ、検索モードなどの条件で検索結果を取得できます。
  * ページング機能（1ページあたり50件）を実装し、大量の検索結果を効率的に表示できるようになりました。
  * セマンティック検索モードに対応し、より高度な検索が可能になりました。
  * 自分の検索結果のみを表示するオプションを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10017)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->