### PR TITLE
生徒サポートコンテキストAPIを追加

### DIFF
--- a/app/controllers/api/users/support_contexts_controller.rb
+++ b/app/controllers/api/users/support_contexts_controller.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+class API::Users::SupportContextsController < API::BaseController # rubocop:todo Metrics/ClassLength
+  SUPPORT_CONTEXT_LIMIT = 5
+
+  before_action :require_admin_or_mentor
+  before_action :set_user
+
+  def show
+    render json: {
+      user: support_user_json,
+      current_practices: @user.active_practices.map { |practice| practice_json(practice) },
+      recent_reports: recent_reports.map { |report| report_json(report) },
+      recent_products: recent_products.map { |product| product_json(product) },
+      recent_questions: recent_questions.map { |question| question_json(question) },
+      talk: talk_json,
+      mentor_memo: @user.mentor_memo,
+      learning_progress: learning_progress_json
+    }
+  end
+
+  private
+
+  def require_admin_or_mentor
+    render json: { message: '権限がありません。' }, status: :forbidden unless current_user.admin_or_mentor?
+  end
+
+  def set_user
+    @user = User.find_by(id: params[:user_id])
+    render json: { message: 'ユーザーが見つかりません。' }, status: :not_found unless @user
+  end
+
+  def support_user_json
+    {
+      id: @user.id,
+      login_name: @user.login_name,
+      name: @user.name,
+      long_name: "#{@user.login_name} (#{@user.name_kana})",
+      roles: user_roles,
+      primary_role: user_roles.first,
+      company: company_json,
+      course: course_json
+    }
+  end
+
+  def company_json
+    return unless @user.company
+
+    { id: @user.company.id, name: @user.company.name }
+  end
+
+  def user_roles
+    roles = %i[retired training_completed hibernationed admin mentor adviser graduate trainee].filter do |role|
+      role_value(role)
+    end
+    roles.presence || [:student]
+  end
+
+  def role_value(role)
+    case role
+    when :hibernationed
+      @user.hibernated?
+    when :graduate
+      @user.graduated?
+    else
+      @user.public_send("#{role}?")
+    end
+  end
+
+  def course_json
+    return unless @user.course
+
+    { id: @user.course.id, title: @user.course.title }
+  end
+
+  def recent_reports
+    @recent_reports ||= @user.reports.not_wip.order(reported_on: :desc, created_at: :desc).limit(SUPPORT_CONTEXT_LIMIT)
+  end
+
+  def recent_products
+    @recent_products ||= @user.products.not_wip.includes(:practice, :checks, :checker).order(published_at: :desc, id: :desc).limit(SUPPORT_CONTEXT_LIMIT)
+  end
+
+  def recent_questions
+    @recent_questions ||= @user.questions.not_wip
+                               .includes(:practice, :answers, :correct_answer)
+                               .order(updated_at: :desc, id: :desc)
+                               .limit(SUPPORT_CONTEXT_LIMIT)
+  end
+
+  def practice_json(practice)
+    {
+      id: practice.id,
+      title: practice.title
+    }
+  end
+
+  def report_json(report)
+    {
+      id: report.id,
+      title: report.title,
+      reported_on: report.reported_on,
+      wip: report.wip?,
+      checked: report.checked?,
+      updated_at: report.updated_at
+    }
+  end
+
+  def product_json(product)
+    {
+      id: product.id,
+      practice: practice_json(product.practice),
+      body: product.body,
+      checked: product.checked?,
+      checker_id: product.checker_id,
+      commented_at: product.commented_at,
+      published_at: product.published_at,
+      updated_at: product.updated_at
+    }
+  end
+
+  def question_json(question)
+    {
+      id: question.id,
+      title: question.title,
+      practice: question.practice && practice_json(question.practice),
+      solved: question.correct_answer.present?,
+      answers_count: question.answers.size,
+      published_at: question.published_at,
+      updated_at: question.updated_at
+    }
+  end
+
+  def talk_json
+    talk = @user.talk
+    return unless talk
+
+    {
+      id: talk.id,
+      action_completed: talk.action_completed,
+      comments_count: talk.comments.size,
+      updated_at: talk.updated_at
+    }
+  end
+
+  def learning_progress_json
+    user_course_practice = UserCoursePractice.new(@user)
+    required_practices_count = user_course_practice.required_practices.size
+    completed_practices_count = user_course_practice.completed_required_practices.size
+    {
+      completed_practices_count:,
+      required_practices_count:,
+      completed_percentage: completed_percentage(completed_practices_count, required_practices_count)
+    }
+  end
+
+  def completed_percentage(completed_practices_count, required_practices_count)
+    return 0.0 unless required_practices_count.positive?
+
+    (completed_practices_count.to_f / required_practices_count * 100).round(1)
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -32,7 +32,9 @@ Rails.application.routes.draw do
     resources :reactions, only: %i(create destroy index)
     resources :checks, only: %i(index create destroy)
     resources :mention_users, only: %i(index)
-    resources :users, only: %i(index show update)
+    resources :users, only: %i(index show update) do
+      resource :support_context, only: %i(show), controller: 'users/support_contexts'
+    end
     get "users/tags/:tag", to: "users#index", as: :users_tag, tag: /.+/
     resources :practices, only: %i(index show update) do
       resource :learning, only: %i(show update), controller: "practices/learning" do

--- a/test/integration/api/users_test.rb
+++ b/test/integration/api/users_test.rb
@@ -216,4 +216,44 @@ class API::UsersTest < ActionDispatch::IntegrationTest
     authorized_keys = %w[id login_name long_name url roles primary_role joining_status icon_title adviser avatar_url]
     assert_equal authorized_keys.sort, response_body.keys.sort
   end
+
+  test 'GET /api/users/:id/support_context.json as mentor' do
+    target_user = users(:kimura)
+    token = create_token('mentormentaro', 'testtest')
+
+    get api_user_support_context_path(target_user, format: :json),
+        headers: { Authorization: "Bearer #{token}", Accept: 'application/json' }
+
+    assert_response :ok
+    response_body = response.parsed_body
+    assert_equal target_user.id, response_body.dig('user', 'id')
+    assert_includes response_body.keys, 'current_practices'
+    assert_includes response_body.keys, 'recent_reports'
+    assert_includes response_body.keys, 'recent_products'
+    assert_includes response_body.keys, 'recent_questions'
+    assert_includes response_body.keys, 'talk'
+    assert_includes response_body.keys, 'mentor_memo'
+    assert_includes response_body.keys, 'learning_progress'
+    assert response_body['recent_reports'].size <= API::Users::SupportContextsController::SUPPORT_CONTEXT_LIMIT
+  end
+
+  test 'GET /api/users/:id/support_context.json as student returns forbidden' do
+    token = create_token('kimura', 'testtest')
+
+    get api_user_support_context_path(users(:hajime), format: :json),
+        headers: { Authorization: "Bearer #{token}", Accept: 'application/json' }
+
+    assert_response :forbidden
+    assert_equal '権限がありません。', response.parsed_body['message']
+  end
+
+  test 'GET /api/users/:id/support_context.json with missing user returns not found' do
+    token = create_token('mentormentaro', 'testtest')
+
+    get api_user_support_context_path(0, format: :json),
+        headers: { Authorization: "Bearer #{token}", Accept: 'application/json' }
+
+    assert_response :not_found
+    assert_equal 'ユーザーが見つかりません。', response.parsed_body['message']
+  end
 end


### PR DESCRIPTION
## 概要

- `GET /api/users/:user_id/support_context.json` を追加
- admin / mentor が対象ユーザーの基本情報、現在のプラクティス、直近日報、提出物、質問、Talk、メンター用メモ、学習進捗を取得できるようにした
- 権限不足と存在しないユーザーのJSONレスポンスを追加

## 確認

- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/users_test.rb
- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/users_controller.rb app/controllers/api/users/support_contexts_controller.rb test/integration/api/users_test.rb

Closes #10004