### PR TITLE
APIレスポンス形式を統一

### DIFF
--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -30,7 +30,7 @@ class API::AnswersController < API::BaseController
     @answer.user = current_user
     if @answer.save
       ActiveSupport::Notifications.instrument('answer.create', answer: @answer)
-      render json: answer_json(@answer), status: :created
+      render_created_answer(question)
     else
       render_validation_errors(@answer)
     end
@@ -38,7 +38,7 @@ class API::AnswersController < API::BaseController
 
   def update
     if @answer.update(answer_params)
-      render json: answer_json(@answer), status: :ok
+      request.format.json? ? render(json: answer_json(@answer), status: :ok) : head(:ok)
     else
       render_validation_errors(@answer)
     end
@@ -47,7 +47,7 @@ class API::AnswersController < API::BaseController
   def destroy
     @answer.destroy
     ActiveSupport::Notifications.instrument('answer.destroy', answer: @answer, action: current_action_name) if @answer.type == 'CorrectAnswer'
-    render json: { id: @answer.id }, status: :ok
+    request.format.json? ? render(json: { id: @answer.id }, status: :ok) : head(:no_content)
   end
 
   private
@@ -63,6 +63,14 @@ class API::AnswersController < API::BaseController
 
   def answer_params
     params.require(:answer).permit(:description)
+  end
+
+  def render_created_answer(question)
+    if request.format.json?
+      render json: answer_json(@answer), status: :created
+    else
+      render partial: 'questions/answer', locals: { question:, answer: @answer, user: current_user }, status: :created
+    end
   end
 
   def answer_json(answer)

--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -30,29 +30,31 @@ class API::AnswersController < API::BaseController
     @answer.user = current_user
     if @answer.save
       ActiveSupport::Notifications.instrument('answer.create', answer: @answer)
-      render partial: 'questions/answer', locals: { question:, answer: @answer, user: current_user }, status: :created
+      render json: answer_json(@answer), status: :created
     else
-      head :bad_request
+      render_validation_errors(@answer)
     end
   end
 
   def update
     if @answer.update(answer_params)
-      head :ok
+      render json: answer_json(@answer), status: :ok
     else
-      head :bad_request
+      render_validation_errors(@answer)
     end
   end
 
   def destroy
     @answer.destroy
     ActiveSupport::Notifications.instrument('answer.destroy', answer: @answer, action: current_action_name) if @answer.type == 'CorrectAnswer'
+    render json: { id: @answer.id }, status: :ok
   end
 
   private
 
   def set_answer
-    @answer = current_user.admin? ? Answer.find(params[:id]) : current_user.answers.find(params[:id])
+    @answer = current_user.admin? ? Answer.find_by(id: params[:id]) : current_user.answers.find_by(id: params[:id])
+    render_not_found('回答が見つかりません。') unless @answer
   end
 
   def question
@@ -61,5 +63,20 @@ class API::AnswersController < API::BaseController
 
   def answer_params
     params.require(:answer).permit(:description)
+  end
+
+  def answer_json(answer)
+    {
+      id: answer.id,
+      description: answer.description,
+      question_id: answer.question_id,
+      user: {
+        id: answer.user.id,
+        login_name: answer.user.login_name,
+        name: answer.user.name
+      },
+      created_at: answer.created_at,
+      updated_at: answer.updated_at
+    }
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -19,4 +19,16 @@ class API::BaseController < ApplicationController
   def current_action_name
     "#{self.class.name}##{action_name}"
   end
+
+  def render_validation_errors(resource)
+    render json: { errors: resource.errors }, status: :unprocessable_entity
+  end
+
+  def render_not_found(message = 'リソースが見つかりません。')
+    render json: { message: }, status: :not_found
+  end
+
+  def render_bad_request(message = 'リクエストが不正です。')
+    render json: { message: }, status: :bad_request
+  end
 end

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -16,7 +16,7 @@ class API::ChecksController < API::BaseController
           @check = Check.create!(user: current_user, checkable:)
           ActiveSupport::Notifications.instrument('check.create', check: @check)
         end
-        head :created
+        render json: check_json(@check), status: :created
       rescue StandardError => e
         Rails.logger.error("[API::ChecksController#create] チェック作成でエラー: #{e.message}")
         render json: { message: 'エラーが発生しました。' }, status: :internal_server_error
@@ -31,7 +31,7 @@ class API::ChecksController < API::BaseController
       @check = Check.find(params[:id]).destroy!
       ActiveSupport::Notifications.instrument('check.cancel', check: @check)
     end
-    head :no_content
+    render json: { id: @check.id }, status: :ok
   rescue StandardError => e
     Rails.logger.error("[API::ChecksController#destroy] チェック削除でエラー: #{e.message}")
     render json: { message: 'エラーが発生しました。' }, status: :internal_server_error
@@ -41,5 +41,19 @@ class API::ChecksController < API::BaseController
 
   def checkable
     params[:checkable_type].constantize.find_by(id: params[:checkable_id])
+  end
+
+  def check_json(check)
+    {
+      id: check.id,
+      checkable_type: check.checkable_type,
+      checkable_id: check.checkable_id,
+      user: {
+        id: check.user.id,
+        login_name: check.user.login_name,
+        name: check.user.name
+      },
+      created_at: check.created_at
+    }
   end
 end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -14,7 +14,7 @@ class API::CommentsController < API::BaseController
       @comments = @comments.limit(params[:comment_limit])
                            .offset(params[:comment_offset])
     else
-      head :bad_request
+      render_bad_request
     end
   end
 
@@ -23,22 +23,23 @@ class API::CommentsController < API::BaseController
     @comment.user = current_user
     @comment.commentable = commentable
     if @comment.save
-      render partial: 'comments/comment', locals: { commentable:, comment: @comment, user: current_user, latest_comment: @comment }, status: :created
+      render json: comment_json(@comment), status: :created
     else
-      head :bad_request
+      render_validation_errors(@comment)
     end
   end
 
   def update
     if @comment.update(comment_params)
-      head :ok
+      render json: comment_json(@comment), status: :ok
     else
-      head :bad_request
+      render_validation_errors(@comment)
     end
   end
 
   def destroy
     @comment.destroy!
+    render json: { id: @comment.id }, status: :ok
   end
 
   private
@@ -52,6 +53,23 @@ class API::CommentsController < API::BaseController
   end
 
   def set_my_comment
-    @comment = current_user.admin? || current_user.mentor? ? Comment.find(params[:id]) : current_user.comments.find(params[:id])
+    @comment = current_user.admin? || current_user.mentor? ? Comment.find_by(id: params[:id]) : current_user.comments.find_by(id: params[:id])
+    render_not_found('コメントが見つかりません。') unless @comment
+  end
+
+  def comment_json(comment)
+    {
+      id: comment.id,
+      description: comment.description,
+      commentable_type: comment.commentable_type,
+      commentable_id: comment.commentable_id,
+      user: {
+        id: comment.user.id,
+        login_name: comment.user.login_name,
+        name: comment.user.name
+      },
+      created_at: comment.created_at,
+      updated_at: comment.updated_at
+    }
   end
 end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -23,7 +23,7 @@ class API::CommentsController < API::BaseController
     @comment.user = current_user
     @comment.commentable = commentable
     if @comment.save
-      render json: comment_json(@comment), status: :created
+      render_created_comment
     else
       render_validation_errors(@comment)
     end
@@ -31,7 +31,7 @@ class API::CommentsController < API::BaseController
 
   def update
     if @comment.update(comment_params)
-      render json: comment_json(@comment), status: :ok
+      request.format.json? ? render(json: comment_json(@comment), status: :ok) : head(:ok)
     else
       render_validation_errors(@comment)
     end
@@ -39,7 +39,7 @@ class API::CommentsController < API::BaseController
 
   def destroy
     @comment.destroy!
-    render json: { id: @comment.id }, status: :ok
+    request.format.json? ? render(json: { id: @comment.id }, status: :ok) : head(:no_content)
   end
 
   private
@@ -55,6 +55,16 @@ class API::CommentsController < API::BaseController
   def set_my_comment
     @comment = current_user.admin? || current_user.mentor? ? Comment.find_by(id: params[:id]) : current_user.comments.find_by(id: params[:id])
     render_not_found('コメントが見つかりません。') unless @comment
+  end
+
+  def render_created_comment
+    if request.format.json?
+      render json: comment_json(@comment), status: :created
+    else
+      render partial: 'comments/comment',
+             locals: { commentable:, comment: @comment, user: current_user, latest_comment: @comment },
+             status: :created
+    end
   end
 
   def comment_json(comment)

--- a/app/controllers/api/reactions_controller.rb
+++ b/app/controllers/api/reactions_controller.rb
@@ -4,14 +4,14 @@ class API::ReactionsController < API::BaseController
   before_action :set_reactionable, only: %i[create index]
 
   def create
-    return head :not_found unless @reactionable
+    return render_not_found('リアクション対象が見つかりません。') unless @reactionable
 
     reaction = @reactionable.reactions.build(user: current_user, kind: params[:kind])
 
     if reaction.save
       render json: { id: reaction.id }, status: :created
     else
-      head :bad_request
+      render_validation_errors(reaction)
     end
   end
 
@@ -22,7 +22,7 @@ class API::ReactionsController < API::BaseController
   end
 
   def index
-    return head :not_found unless @reactionable
+    return render_not_found('リアクション対象が見つかりません。') unless @reactionable
 
     reactions = @reactionable
                 .reactions

--- a/test/integration/api/checks_test.rb
+++ b/test/integration/api/checks_test.rb
@@ -73,18 +73,21 @@ class API::ChecksTest < ActionDispatch::IntegrationTest
     token = create_token('komagata', 'testtest')
     delete api_check_path(@check2.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :no_content
+    assert_response :ok
+    assert_equal @check2.id, response.parsed_body['id']
 
     # adviser login
     token = create_token('advijirou', 'testtest')
     delete api_check_path(@check3.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :no_content
+    assert_response :ok
+    assert_equal @check3.id, response.parsed_body['id']
 
     # mentor login
     token = create_token('mentormentaro', 'testtest')
     delete api_check_path(@check4.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
-    assert_response :no_content
+    assert_response :ok
+    assert_equal @check4.id, response.parsed_body['id']
   end
 end

--- a/test/integration/api/comments_test.rb
+++ b/test/integration/api/comments_test.rb
@@ -88,7 +88,8 @@ class API::CommentsTest < ActionDispatch::IntegrationTest
     assert_difference('Comment.count', -1) do
       delete api_comment_url(@comment.id, format: :json),
              headers: { Authorization: "Bearer #{@write_token.token}" }
-      assert_response :no_content
+      assert_response :ok
+      assert_equal @comment.id, response.parsed_body['id']
     end
   end
 
@@ -119,7 +120,8 @@ class API::CommentsTest < ActionDispatch::IntegrationTest
     assert_difference('Comment.count', -1) do
       delete api_comment_url(other_user_comment.id, format: :json),
              headers: { Authorization: "Bearer #{admin_token.token}" }
-      assert_response :no_content
+      assert_response :ok
+      assert_equal other_user_comment.id, response.parsed_body['id']
     end
   end
 


### PR DESCRIPTION
## 概要

- API共通の validation error / not found / bad request 用JSON helperを追加
- コメント・回答・チェック・リアクションAPIの代表的な成功/失敗レスポンスをJSONに統一
- 削除成功時は削除対象IDをJSONで返すように変更

## 確認

- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/comments_test.rb test/integration/api/answers_test.rb test/integration/api/checks_test.rb test/integration/api/reactions_test.rb
- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop app/controllers/api/base_controller.rb app/controllers/api/comments_controller.rb app/controllers/api/answers_controller.rb app/controllers/api/checks_controller.rb app/controllers/api/reactions_controller.rb test/integration/api/comments_test.rb test/integration/api/answers_test.rb test/integration/api/checks_test.rb test/integration/api/reactions_test.rb

Closes #10005