### PR TITLE
OAuth scopeの要求を整理

### DIFF
--- a/app/controllers/api/answers_controller.rb
+++ b/app/controllers/api/answers_controller.rb
@@ -4,6 +4,7 @@ class API::AnswersController < API::BaseController
   include Rails.application.routes.url_helpers
   before_action :set_answer, only: %i[update destroy]
   before_action :set_available_emojis, only: %i[index create]
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create update destroy], if: -> { doorkeeper_token.present? }
 
   def index
     if params[:question_id].present?

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,7 @@ class API::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token, if: -> { doorkeeper_token.present? }
   before_action :doorkeeper_authorize!, if: -> { doorkeeper_token.present? }
   before_action :require_login_for_api, unless: -> { doorkeeper_token.present? }
+  rescue_from Doorkeeper::Errors::DoorkeeperError, with: :render_doorkeeper_error
 
   private
 
@@ -18,5 +19,26 @@ class API::BaseController < ApplicationController
 
   def current_action_name
     "#{self.class.name}##{action_name}"
+  end
+
+  def doorkeeper_unauthorized_render_options(error:)
+    { json: doorkeeper_error_body(error) }
+  end
+
+  def doorkeeper_forbidden_render_options(error:)
+    { json: doorkeeper_error_body(error) }
+  end
+
+  def render_doorkeeper_error(error)
+    response = error.response
+    render json: response.body, status: response.status
+  end
+
+  def doorkeeper_error_body(error)
+    {
+      error: error.name,
+      error_description: error.description,
+      state: error.state
+    }.compact_blank
   end
 end

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -2,6 +2,8 @@
 
 class API::ChecksController < API::BaseController
   before_action :require_staff_login_for_api, only: %i[create destroy]
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create destroy], if: -> { doorkeeper_token.present? }
+  before_action -> { doorkeeper_authorize! :mentor }, only: %i[create destroy], if: -> { doorkeeper_token.present? }
 
   def index
     @checks = Check.where(

--- a/app/controllers/api/mentor_memos_controller.rb
+++ b/app/controllers/api/mentor_memos_controller.rb
@@ -2,6 +2,8 @@
 
 class API::MentorMemosController < API::BaseController
   before_action :require_mentor_login_for_api
+  before_action -> { doorkeeper_authorize! :write }, only: %i[update], if: -> { doorkeeper_token.present? }
+  before_action -> { doorkeeper_authorize! :mentor }, only: %i[update], if: -> { doorkeeper_token.present? }
   before_action :set_user, only: %i[update]
 
   def update

--- a/app/controllers/api/practices_controller.rb
+++ b/app/controllers/api/practices_controller.rb
@@ -3,6 +3,9 @@
 class API::PracticesController < API::BaseController
   include Rails.application.routes.url_helpers
   before_action :require_mentor_login_for_api, only: %i[show update]
+  before_action -> { doorkeeper_authorize! :mentor }, only: %i[show], if: -> { doorkeeper_token.present? }
+  before_action -> { doorkeeper_authorize! :write }, only: %i[update], if: -> { doorkeeper_token.present? }
+  before_action -> { doorkeeper_authorize! :mentor }, only: %i[update], if: -> { doorkeeper_token.present? }
   before_action :set_practice, only: %i[show update]
 
   def show; end

--- a/app/controllers/api/products/checker_controller.rb
+++ b/app/controllers/api/products/checker_controller.rb
@@ -2,6 +2,9 @@
 
 class API::Products::CheckerController < API::BaseController
   before_action :require_mentor_login_for_api
+  before_action -> { doorkeeper_authorize! :mentor }, only: %i[show], if: -> { doorkeeper_token.present? }
+  before_action -> { doorkeeper_authorize! :write }, only: %i[update destroy], if: -> { doorkeeper_token.present? }
+  before_action -> { doorkeeper_authorize! :mentor }, only: %i[update destroy], if: -> { doorkeeper_token.present? }
   before_action :set_product, only: %i[show update destroy]
 
   def show

--- a/app/controllers/api/reactions_controller.rb
+++ b/app/controllers/api/reactions_controller.rb
@@ -2,6 +2,7 @@
 
 class API::ReactionsController < API::BaseController
   before_action :set_reactionable, only: %i[create index]
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create destroy], if: -> { doorkeeper_token.present? }
 
   def create
     return head :not_found unless @reactionable

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Doorkeeper.configure do
-orm :active_record
+  orm :active_record
   resource_owner_authenticator do
     current_user || redirect_to(login_path)
   end
@@ -19,11 +19,10 @@ orm :active_record
 
   # クライアントアプリが、BootCampアプリのリソースをどの範囲まで使用できるかを設定
   # Scopesのドキュメント：https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
-  # read = 読み取り, write = 書き込み 
+  # read = 読み取り, write = 書き込み, mentor = メンター業務, admin = 管理者業務
   default_scopes :read # Scopesが未設定（空白）の場合、設定されるスコープ
-  
-  optional_scopes :write # Scopesで指定されたときに設定されるスコープ
 
+  optional_scopes :write, :mentor, :admin # Scopesで指定されたときに設定されるスコープ
 
   # defalut_scopeとoptional_scopeで定義されたスコープのみ要求できるようになる
   enforce_configured_scopes

--- a/test/integration/api/answers_test.rb
+++ b/test/integration/api/answers_test.rb
@@ -3,6 +3,13 @@
 require 'test_helper'
 
 class API::AnswersTest < ActionDispatch::IntegrationTest
+  setup do
+    @application = Doorkeeper::Application.create!(
+      name: 'Sample Application',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
+  end
+
   test 'GET /api/answers.json?user_id=253826460' do
     user = users(:hajime)
     get api_answers_path(user_id: user.id, format: :json)
@@ -12,5 +19,20 @@ class API::AnswersTest < ActionDispatch::IntegrationTest
     get api_answers_path(user_id: user.id, format: :json),
         headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
+  end
+
+  test 'POST /api/answers.json with read scope returns forbidden' do
+    token = Doorkeeper::AccessToken.create!(
+      application: @application,
+      resource_owner_id: users(:hajime).id,
+      scopes: 'read'
+    )
+
+    post api_answers_path(format: :json),
+         params: { question_id: questions(:question1).id, answer: { description: '回答します。' } },
+         headers: { Authorization: "Bearer #{token.token}" }
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
   end
 end

--- a/test/integration/api/checks_test.rb
+++ b/test/integration/api/checks_test.rb
@@ -10,6 +10,10 @@ class API::ChecksTest < ActionDispatch::IntegrationTest
     @check2 = checks(:report1_check_machida)
     @check3 = checks(:report3_check_machida)
     @check4 = checks(:report5_check_machida)
+    @application = Doorkeeper::Application.create!(
+      name: 'Sample Application',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
   end
 
   test 'GET /api/checks.json' do
@@ -86,5 +90,20 @@ class API::ChecksTest < ActionDispatch::IntegrationTest
     delete api_check_path(@check4.id, format: :json),
            headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :no_content
+  end
+
+  test 'POST /api/checks.json with write scope but without mentor scope returns forbidden' do
+    token = Doorkeeper::AccessToken.create!(
+      application: @application,
+      resource_owner_id: users(:mentormentaro).id,
+      scopes: 'read write'
+    )
+
+    post api_checks_path(format: :json),
+         params: { checkable_type: @check4.checkable_type, checkable_id: @check4.checkable_id },
+         headers: { Authorization: "Bearer #{token.token}" }
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
   end
 end

--- a/test/integration/api/reactions_test.rb
+++ b/test/integration/api/reactions_test.rb
@@ -3,6 +3,13 @@
 require 'test_helper'
 
 class API::ReactionTest < ActionDispatch::IntegrationTest
+  setup do
+    @application = Doorkeeper::Application.create!(
+      name: 'Sample Application',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
+  end
+
   test 'POST /api/reactions returns created' do
     report = reports(:report4)
 
@@ -21,6 +28,22 @@ class API::ReactionTest < ActionDispatch::IntegrationTest
                              headers: { 'Authorization' => "Bearer #{token}" }
 
     assert_response :not_found
+  end
+
+  test 'POST /api/reactions with read scope returns forbidden' do
+    token = Doorkeeper::AccessToken.create!(
+      application: @application,
+      resource_owner_id: users(:komagata).id,
+      scopes: 'read'
+    )
+
+    post api_reactions_path,
+         params: { reactionable_gid: reports(:report4).to_global_id.to_s, kind: 'smile' },
+         as: :json,
+         headers: { Authorization: "Bearer #{token.token}" }
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
   end
 
   test 'DELETE /api/reactions/reactionID returns ok' do


### PR DESCRIPTION
## 概要

- Doorkeeper の optional scope に `mentor` / `admin` を追加
- 更新系 API で OAuth token 利用時に `write` scope を要求
- メンター業務 API で OAuth token 利用時に `mentor` scope も要求
- scope 不足時のJSONエラーレスポンスを追加

## 確認

- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/answers_test.rb test/integration/api/checks_test.rb test/integration/api/reactions_test.rb test/integration/api/users_test.rb
- [x] SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rubocop config/initializers/doorkeeper.rb app/controllers/api/base_controller.rb app/controllers/api/answers_controller.rb app/controllers/api/checks_controller.rb app/controllers/api/reactions_controller.rb app/controllers/api/mentor_memos_controller.rb app/controllers/api/practices_controller.rb app/controllers/api/products/checker_controller.rb test/integration/api/answers_test.rb test/integration/api/checks_test.rb test/integration/api/reactions_test.rb

Closes #10006