### PR TITLE
管理者がユーザーの休会・復帰情報を変更できるようにする

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,7 +36,7 @@ class Admin::UsersController < AdminController
     if @user.update(user_params)
       complete_graduation_or_retirement(@user)
       if params[:hibernate_user]
-        return unless hibernate(`@user`)
+        return unless hibernate(@user)
       elsif params[:comeback_user]
         @user.comeback!
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,7 +36,7 @@ class Admin::UsersController < AdminController
     if @user.update(user_params)
       complete_graduation_or_retirement(@user)
       if params[:hibernate_user]
-        hibernate(@user)
+        return unless hibernate(`@user`)
       elsif params[:comeback_user]
         @user.comeback!
       end
@@ -122,11 +122,12 @@ class Admin::UsersController < AdminController
       reason: '管理者操作',
       scheduled_return_on: params[:scheduled_return_on]
     )
-    hibernation.user = @user
+    hibernation.user = user
     if hibernation.save
       hibernation.execute
     else
-      render :edit, alert: '休会に失敗しました。'
+      render :edit
+      false
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::UsersController < AdminController
+class Admin::UsersController < AdminController # rubocop:todo Metrics/ClassLength
   before_action :set_user, only: %i[show edit update]
   ALLOWED_TARGETS = %w[all student_and_trainee inactive hibernated retired graduate adviser mentor trainee year_end_party campaign].freeze
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::UsersController < AdminController # rubocop:todo Metrics/ClassLength
+class Admin::UsersController < AdminController
   before_action :set_user, only: %i[show edit update]
   ALLOWED_TARGETS = %w[all student_and_trainee inactive hibernated retired graduate adviser mentor trainee year_end_party campaign].freeze
 
@@ -19,6 +19,7 @@ class Admin::UsersController < AdminController # rubocop:todo Metrics/ClassLengt
     user_scope = apply_job_seeking_filter(user_scope, job_seeking)
     payment_method = params[:payment_method]
     user_scope = apply_payment_method_filter(user_scope, payment_method)
+
     @users = user_scope.with_attached_avatar
                        .preload(:company, :course)
                        .order_by_counts(params[:order_by] || 'id', @direction)
@@ -36,7 +37,7 @@ class Admin::UsersController < AdminController # rubocop:todo Metrics/ClassLengt
     if @user.update(user_params)
       complete_graduation_or_retirement(@user)
       if params[:hibernate_user]
-        return unless hibernate(@user)
+        return unless Hibernation.hibernate_by_admin(user: @user, scheduled_return_on: params[:scheduled_return_on])
       elsif params[:comeback_user]
         @user.comeback!
       end
@@ -96,10 +97,8 @@ class Admin::UsersController < AdminController # rubocop:todo Metrics/ClassLengt
       :password, :password_confirmation, :job,
       :organization, :os, :study_place,
       { experiences: [] }, :company_id,
-      :trainee, :nda, :avatar,
-      :hibernated_at,
-      :graduated_on, :retired_on,
-      :job_seeker, :github_collaborator,
+      :trainee, :nda, :avatar, :hibernated_at,
+      :graduated_on, :retired_on, :job_seeker, :github_collaborator,
       :officekey_permission, :tag_list, :training_ends_on, :training_completed_at,
       :profile_image, :profile_name, :profile_job, :mentor, :diploma_file,
       :career_path, :career_memo,
@@ -114,20 +113,6 @@ class Admin::UsersController < AdminController # rubocop:todo Metrics/ClassLengt
       Retirement.by_admin(user:).execute
     elsif user.saved_change_to_graduated_on? && user.graduated_on_before_last_save.nil?
       Subscription.new.destroy(user.subscription_id) if user.subscription_id?
-    end
-  end
-
-  def hibernate(user)
-    hibernation = Hibernation.new(
-      reason: '管理者操作',
-      scheduled_return_on: params[:scheduled_return_on]
-    )
-    hibernation.user = user
-    if hibernation.save
-      hibernation.execute
-    else
-      render :edit
-      false
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,6 +35,11 @@ class Admin::UsersController < AdminController
     @user.diploma_file = nil if params[:user][:remove_diploma] == '1'
     if @user.update(user_params)
       complete_graduation_or_retirement(@user)
+      if params[:hibernate_user]
+        hibernate(@user)
+      elsif params[:comeback_user]
+        @user.comeback!
+      end
       redirect_to user_url(@user), notice: 'ユーザー情報を更新しました。'
     else
       render :edit
@@ -92,6 +97,7 @@ class Admin::UsersController < AdminController
       :organization, :os, :study_place,
       { experiences: [] }, :company_id,
       :trainee, :nda, :avatar,
+      :hibernated_at,
       :graduated_on, :retired_on,
       :job_seeker, :github_collaborator,
       :officekey_permission, :tag_list, :training_ends_on, :training_completed_at,
@@ -108,6 +114,19 @@ class Admin::UsersController < AdminController
       Retirement.by_admin(user:).execute
     elsif user.saved_change_to_graduated_on? && user.graduated_on_before_last_save.nil?
       Subscription.new.destroy(user.subscription_id) if user.subscription_id?
+    end
+  end
+
+  def hibernate(user)
+    hibernation = Hibernation.new(
+      reason: '管理者操作',
+      scheduled_return_on: params[:scheduled_return_on]
+    )
+    hibernation.user = @user
+    if hibernation.save
+      hibernation.execute
+    else
+      render :edit, alert: '休会に失敗しました。'
     end
   end
 end

--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -15,7 +15,7 @@ class HibernationController < ApplicationController
     @hibernation.user = current_user
 
     if @hibernation.save
-      @hibernation.excute
+      @hibernation.execute
 
       logout
       redirect_to hibernation_path

--- a/app/controllers/hibernation_controller.rb
+++ b/app/controllers/hibernation_controller.rb
@@ -15,11 +15,8 @@ class HibernationController < ApplicationController
     @hibernation.user = current_user
 
     if @hibernation.save
-      update_hibernated_at!
-      destroy_subscription!
-      notify_to_chat
-      notify_to_mentors_and_admins
-      current_user.clean_up_regular_events
+      @hibernation.excute
+
       logout
       redirect_to hibernation_path
     else
@@ -32,26 +29,5 @@ class HibernationController < ApplicationController
 
   def hibernation_params
     params.require(:hibernation).permit(:reason, :scheduled_return_on, :returned_on)
-  end
-
-  def update_hibernated_at!
-    current_user.hibernated_at = @hibernation.created_at
-    current_user.save!(validate: false)
-  end
-
-  def destroy_subscription!
-    return nil if !Rails.env.production? || staging?
-
-    Subscription.new.destroy(current_user.subscription_id) if current_user.subscription_id
-  end
-
-  def notify_to_mentors_and_admins
-    User.admins_and_mentors.each do |admin_or_mentor|
-      ActivityDelivery.with(sender: current_user, receiver: admin_or_mentor).notify(:hibernated)
-    end
-  end
-
-  def notify_to_chat
-    DiscordNotifier.with(sender: current_user).hibernated.notify_now
   end
 end

--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -4,4 +4,35 @@ class Hibernation < ApplicationRecord
   belongs_to :user
   validates :reason, presence: true
   validates :scheduled_return_on, presence: true
+
+  def excute
+    update_hibernated_at!
+    destroy_subscription!
+    notify_to_chat
+    notify_to_mentors_and_admins
+    user.clean_up_regular_events
+  end
+
+  private
+
+  def update_hibernated_at!
+    user.hibernated_at = created_at
+    user.save!(validate: false)
+  end
+
+  def destroy_subscription!
+    return nil if !Rails.env.production? || staging?
+
+    Subscription.new.destroy(user.subscription_id) if user.subscription_id
+  end
+
+  def notify_to_mentors_and_admins
+    User.admins_and_mentors.each do |admin_or_mentor|
+      ActivityDelivery.with(sender: user, receiver: admin_or_mentor).notify(:hibernated)
+    end
+  end
+
+  def notify_to_chat
+    DiscordNotifier.with(sender: user).hibernated.notify_now
+  end
 end

--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -23,7 +23,7 @@ class Hibernation < ApplicationRecord
   def destroy_subscription!
     return nil if !Rails.env.production? || staging?
 
-    Subscription.new.destroy(user.subscription_id) if user.subscription_id
+    Subscription.new.destroy(user.subscription_id) if user.subscription_id?
   end
 
   def notify_to_mentors_and_admins

--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -20,6 +20,10 @@ class Hibernation < ApplicationRecord
     user.save!(validate: false)
   end
 
+  def staging?
+    ENV['DB_NAME'] == 'bootcamp_staging'
+  end
+
   def destroy_subscription!
     return nil if !Rails.env.production? || staging?
 

--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -5,7 +5,7 @@ class Hibernation < ApplicationRecord
   validates :reason, presence: true
   validates :scheduled_return_on, presence: true
 
-  def excute
+  def execute
     update_hibernated_at!
     destroy_subscription!
     notify_to_chat

--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -13,6 +13,20 @@ class Hibernation < ApplicationRecord
     user.clean_up_regular_events
   end
 
+  def self.hibernate_by_admin(user:, scheduled_return_on:)
+    hibernation = new(
+      user:,
+      reason: '管理者操作',
+      scheduled_return_on:
+    )
+    if hibernation.save
+      hibernation.execute
+    else
+      render :edit
+      false
+    end
+  end
+
   private
 
   def update_hibernated_at!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -847,10 +847,12 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
   def comeback!
     update_last_returned_at!
 
-    subscription = Subscription.new.create(customer_id, trial: 0)
+    unless Rails.env.development?
+      subscription = Subscription.new.create(customer_id, trial: 0)
+      self.subscription_id = subscription['id']
+    end
 
     self.hibernated_at = nil
-    self.subscription_id = subscription['id']
     save!(validate: false)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -847,7 +847,7 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
   def comeback!
     update_last_returned_at!
 
-    unless Rails.env.development?
+    if Rails.env.production? && !staging?
       subscription = Subscription.new.create(customer_id, trial: 0)
       self.subscription_id = subscription['id']
     end

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -103,26 +103,26 @@
             .form-item-block__title
               | 休会管理
 
-          - if @user.hibernated?
-            .block-checks.is-1-item
-              .block-checks__item
-                .a-block-check.is-checkbox
-                  = check_box_tag :comeback_user, 1, false, class: 'a-toggle-checkbox', id: 'comeback-user'
-                  .a-block-check__label.is-ta-left
-                    = label_tag :comeback_user, '復帰させる', for: 'comeback-user'
+          .form-item-block__items
+            .form-item-block__item
+              .block-checks.is-1-item
+                .block-checks__item
+                  - if @user.hibernated?
+                    .a-block-check.is-checkbox
+                      = check_box_tag :comeback_user, 1, false, class: 'a-toggle-checkbox', id: 'comeback-user'
+                      .a-block-check__label.is-ta-left
+                        = label_tag :comeback_user, '復帰させる', for: 'comeback-user'
 
-          - else
-            .block-checks.is-1-item
-              .block-checks__item
-                .a-block-check.is-checkbox.js-date-input-toggler
-                  = check_box_tag :hibernate_user, 1, false, class: 'a-toggle-checkbox js-date-input-toggler-checkbox', id: 'hibernate-user'
-                  .a-block-check__label.is-ta-left.has-input
-                    = label_tag :hibernate_user, '休会させる', for: 'hibernate-user'
+                  - else
+                    .a-block-check.is-checkbox.js-date-input-toggler
+                      = check_box_tag :hibernate_user, 1, false, class: 'a-toggle-checkbox js-date-input-toggler-checkbox', id: 'hibernate-user'
+                      .a-block-check__label.is-ta-left.has-input
+                        = label_tag :hibernate_user, '休会させる', for: 'hibernate-user'
 
-                    .form-item__inline-form-item.js-date-input-toggler-date-area
-                      .is-block.w-full
-                        p 復帰予定日
-                        = date_field_tag :scheduled_return_on, nil, class: 'a-text-input js-date-input-toggler-date w-full'
+                        .form-item__inline-form-item.js-date-input-toggler-date-area
+                          .is-block.w-full
+                            p 復帰予定日
+                            = date_field_tag :scheduled_return_on, nil, class: 'a-text-input js-date-input-toggler-date w-full'
         .a-form-help
           p
             - if @user.hibernated?

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -118,8 +118,11 @@
                   = check_box_tag :hibernate_user, 1, false, class: 'a-toggle-checkbox js-date-input-toggler-checkbox', id: 'hibernate-user'
                   .a-block-check__label.is-ta-left.has-input
                     = label_tag :hibernate_user, '休会させる', for: 'hibernate-user'
+
                     .form-item__inline-form-item.js-date-input-toggler-date-area
-                      = date_field_tag :scheduled_return_on, nil, class: 'a-text-input js-date-input-toggler-date'
+                      .is-block.w-full
+                        p 復帰予定日
+                        = date_field_tag :scheduled_return_on, nil, class: 'a-text-input js-date-input-toggler-date w-full'
         .a-form-help
           p
             - if @user.hibernated?

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -101,6 +101,36 @@
         .form-item-block__inner
           header.form-item-block__header
             .form-item-block__title
+              | 休会管理
+
+          - if @user.hibernated?
+            .block-checks.is-1-item
+              .block-checks__item
+                .a-block-check.is-checkbox
+                  = check_box_tag :comeback_user, 1, false, class: 'a-toggle-checkbox', id: 'comeback-user'
+                  .a-block-check__label.is-ta-left
+                    = label_tag :comeback_user, '復帰させる', for: 'comeback-user'
+
+          - else
+            .block-checks.is-1-item
+              .block-checks__item
+                .a-block-check.is-checkbox.js-date-input-toggler
+                  = check_box_tag :hibernate_user, 1, false, class: 'a-toggle-checkbox js-date-input-toggler-checkbox', id: 'hibernate-user'
+                  .a-block-check__label.is-ta-left.has-input
+                    = label_tag :hibernate_user, '休会させる', for: 'hibernate-user'
+                    .form-item__inline-form-item.js-date-input-toggler-date-area
+                      = date_field_tag :scheduled_return_on, nil, class: 'a-text-input js-date-input-toggler-date'
+        .a-form-help
+          p
+            - if @user.hibernated?
+              | 現在このユーザーは、休会中です。
+            - else
+              | 現在このユーザーは、利用中です。
+
+      .form-item-block
+        .form-item-block__inner
+          header.form-item-block__header
+            .form-item-block__title
               | ユーザーステータス
           .form-item-block__items
             .form-item-block__item


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9756

## 概要

管理者が「管理者として情報変更」から、ユーザーの休会・復帰を編集できる機能を新しく追加しました。

## 変更確認方法

1. `feature/admin-user-hibernation`をローカルに取り込む
2. 開発サーバーを起動
3. [http://localhost:3000/](http://localhost:3000/) にアクセスし、`komagata` 等管理者としてログイン。
4. ナビゲーションの[ユーザー](http://localhost:3000/users)から`hatsuno`を検索し、「管理者として情報変更」をクリック。
   <img width="800" height="127" alt="スクリーンショット 2026-05-11 134959" src="https://github.com/user-attachments/assets/948313fb-4c14-49c9-931d-0c4ec39b23d4" />
5. 「以下管理者のみ操作ができます」内に「休会管理」があることを確認。「休会させる」をクリックし、復帰予定日を入力して更新する。
   <img width="666" height="422" alt="スクリーンショット 2026-05-18 153631" src="https://github.com/user-attachments/assets/ca072e16-ef73-4c24-ab00-560e099e752d" />
6. `hatsuno`の情報を確認。区分が「休会中」になっていること、休会履歴が表示されていることを確認する。
   <img width="812" height="1291" alt="スクリーンショット 2026-05-18 155244" src="https://github.com/user-attachments/assets/d7055033-7ca7-498e-bf90-bf4364a8e8e4" />
7. `hatsuno`でログイン。休会中のためエラーが出ることを確認。
   <img width="613" height="52" alt="スクリーンショット 2026-05-18 154504" src="https://github.com/user-attachments/assets/617cfcf6-e79f-4e44-be31-9d05744d82dc" />
8. 再度 `komagata` 等管理者でログインし、`hatsuno`を検索し、「管理者として情報変更」をクリック。
9. 復帰情報の入力が表示されることを確認し、「復帰させる」をクリックし、更新する。
   <img width="614" height="367" alt="スクリーンショット 2026-05-18 154540" src="https://github.com/user-attachments/assets/1efb3d32-1816-4976-85b7-571ed4d405dd" />
10. `hatsuno`の情報を確認。休会履歴の「休会期間」が変更されていることを確認する。
    <img width="791" height="180" alt="スクリーンショット 2026-05-18 155649" src="https://github.com/user-attachments/assets/20a42fa1-67a6-4540-af80-b979c0aea86e" />



## Screenshot

### 変更前

<img width="614" height="372" alt="スクリーンショット 2026-05-18 160204" src="https://github.com/user-attachments/assets/cc8c5fbe-42a0-4419-8949-7a34eb70b7eb" />

### 変更後

<img width="666" height="422" alt="スクリーンショット 2026-05-18 153631" src="https://github.com/user-attachments/assets/57d41edb-ff8c-4d55-8a99-24b853e86e39" />
<img width="614" height="367" alt="スクリーンショット 2026-05-18 154540" src="https://github.com/user-attachments/assets/4abdf589-c898-40f7-bd9e-a6bac270e6c6" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 管理画面からユーザーを休会・復帰できる管理用フォームを追加しました。
  * 休会時に復帰予定日を指定できるようになりました。
  * 休会処理を一括実行に集約し、休会時にサブスクリプション解除、管理者・メンターへの通知、外部連携、定期イベントの後処理が自動で行われます。
  * 復帰時のサブスクリプション再作成は本番環境でのみ実行されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27661841384/artifacts/7684829788" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10022-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
