### PR TITLE
flakewatch HTMLレポートの導線をわかりやすくする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
           if-no-files-found: ignore
 
   flakewatch:
+    name: Flakewatch HTML report - download artifact
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: test
@@ -225,7 +226,7 @@ jobs:
         id: upload-flakewatch-report
         uses: actions/upload-artifact@v4
         with:
-          name: flakewatch-report
+          name: flakewatch-report-download-and-open-html
           path: flakewatch.html
           if-no-files-found: error
 
@@ -236,7 +237,7 @@ jobs:
             echo ""
             echo "- flakewatch action: \`komagata/flakewatch@v0.4.0\`"
             echo "- JUnit XML artifacts: \`junit-xml-*\`"
-            echo "- HTML report: [Download flakewatch-report](${{ steps.upload-flakewatch-report.outputs.artifact-url }})"
+            echo "- HTML report: [Download flakewatch-report-download-and-open-html](${{ steps.upload-flakewatch-report.outputs.artifact-url }})"
             echo ""
             echo "Download the artifact and open \`flakewatch.html\` in a browser."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 env:
   RUBY_VERSION: 3.4.3
@@ -241,3 +242,41 @@ jobs:
             echo ""
             echo "Download the artifact and open \`flakewatch.html\` in a browser."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update PR description with flakewatch report
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPORT_URL: ${{ steps.upload-flakewatch-report.outputs.artifact-url }}
+        run: |
+          marker_start="<!-- flakewatch-report:start -->"
+          marker_end="<!-- flakewatch-report:end -->"
+
+          gh pr view "$PR_NUMBER" --json body --jq '.body // ""' > current_body.md
+
+          cat > flakewatch_block.md <<EOF
+          $marker_start
+          ## Flakewatch Report
+
+          [Download flakewatch-report-download-and-open-html]($REPORT_URL)
+
+          GitHub Actions artifacts cannot preview HTML directly. Download the artifact, unzip it, and open \`flakewatch.html\` in your browser.
+          $marker_end
+          EOF
+
+          node <<'NODE'
+          const fs = require("fs")
+
+          const body = fs.readFileSync("current_body.md", "utf8").trimEnd()
+          const block = fs.readFileSync("flakewatch_block.md", "utf8").trim()
+          const pattern = /<!-- flakewatch-report:start -->[\s\S]*?<!-- flakewatch-report:end -->/
+
+          const nextBody = pattern.test(body)
+            ? body.replace(pattern, block)
+            : `${body}\n\n${block}`.trim()
+
+          fs.writeFileSync("new_body.md", `${nextBody}\n`)
+          NODE
+
+          gh pr edit "$PR_NUMBER" --body-file new_body.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
 
       - name: Update PR description with flakewatch report
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 概要

flakewatch の HTML レポートの場所に気づきやすくします。

## 変更内容

- PR の Checks 一覧で気づけるように job 名を `Flakewatch HTML report - download artifact` に変更
- Artifacts 一覧で用途がわかるように artifact 名を `flakewatch-report-download-and-open-html` に変更
- Job Summary のリンク文言も新しい artifact 名に合わせて更新
- CI 実行後に PR description の `Flakewatch Report` ブロックを自動更新

## HTMLレポートの見方

CI が成功すると、この PR description の末尾に `Flakewatch Report` ブロックが追加・更新されます。そこにある `Download flakewatch-report-download-and-open-html` リンクから artifact をダウンロードし、zip 内の `flakewatch.html` をブラウザで開きます。

GitHub Actions artifact は HTML を直接プレビューできないため、ダウンロードしてローカルブラウザで開く必要があります。

## 確認

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD ワークフローの権限設定を更新し、PR本文の自動更新機能を強化しました。
  * Flakewatch レポート生成ジョブの構成を改善し、HTMLレポートリンクのPR本文への反映プロセスを最適化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10024)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->