### PR TITLE
APIレスポンス生成処理を共通化

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -33,6 +33,30 @@ class API::BaseController < ApplicationController
     render json: { message: }, status: :bad_request
   end
 
+  def check_json(check)
+    {
+      id: check.id,
+      checkable_type: check.checkable_type,
+      checkable_id: check.checkable_id,
+      user: {
+        id: check.user.id,
+        login_name: check.user.login_name,
+        name: check.user.name
+      },
+      created_at: check.created_at
+    }
+  end
+
+  def reaction_summary_json(reactionable)
+    reactions = reactionable.reactions.includes(user: { avatar_attachment: :blob }).order(created_at: :asc)
+    grouped_reactions = reactions.group_by(&:kind)
+
+    Reaction.emojis.each_with_object({}) do |(kind, emoji), hash|
+      users = grouped_reactions[kind]&.map { |reaction| reaction_user_json(reaction.user) } || []
+      hash[kind] = { emoji:, users: } unless users.empty?
+    end
+  end
+
   def require_login_for_api
     login_from_jwt unless logged_in?
     render json: { error: 'unauthorized' }, status: :unauthorized unless logged_in?
@@ -57,5 +81,15 @@ class API::BaseController < ApplicationController
       error_description: error.description,
       state: error.state
     }.compact_blank
+  end
+
+  def reaction_user_json(user)
+    user = ActiveDecorator::Decorator.instance.decorate(user)
+    {
+      id: user.id,
+      login_name: user.login_name,
+      avatar_url: user.avatar_url,
+      user_icon_frame_class: user.user_icon_frame_class
+    }
   end
 end

--- a/app/controllers/api/checks_controller.rb
+++ b/app/controllers/api/checks_controller.rb
@@ -44,18 +44,4 @@ class API::ChecksController < API::BaseController
   def checkable
     params[:checkable_type].constantize.find_by(id: params[:checkable_id])
   end
-
-  def check_json(check)
-    {
-      id: check.id,
-      checkable_type: check.checkable_type,
-      checkable_id: check.checkable_id,
-      user: {
-        id: check.user.id,
-        login_name: check.user.login_name,
-        name: check.user.name
-      },
-      created_at: check.created_at
-    }
-  end
 end

--- a/app/controllers/api/reactions_controller.rb
+++ b/app/controllers/api/reactions_controller.rb
@@ -25,15 +25,7 @@ class API::ReactionsController < API::BaseController
   def index
     return render_not_found('リアクション対象が見つかりません。') unless @reactionable
 
-    reactions = @reactionable
-                .reactions
-                .includes(user: { avatar_attachment: :blob }).order(created_at: :asc)
-    grouped_reactions = reactions.group_by(&:kind)
-    result = Reaction.emojis.each_with_object({}) do |(kind, emoji), hash|
-      users = grouped_reactions[kind]&.map { |reaction| user_payload(reaction.user) } || []
-      hash[kind] = { emoji:, users: } unless users.empty?
-    end
-    render json: result
+    render json: reaction_summary_json(@reactionable)
   end
 
   private
@@ -41,15 +33,5 @@ class API::ReactionsController < API::BaseController
   def set_reactionable
     gid = params[:reactionable_gid]
     @reactionable = GlobalID::Locator.locate(gid)
-  end
-
-  def user_payload(user)
-    user = ActiveDecorator::Decorator.instance.decorate(user)
-    {
-      id: user.id,
-      login_name: user.login_name,
-      avatar_url: user.avatar_url,
-      user_icon_frame_class: user.user_icon_frame_class
-    }
   end
 end

--- a/app/controllers/api/reports/reactions_controller.rb
+++ b/app/controllers/api/reports/reactions_controller.rb
@@ -5,13 +5,7 @@ class API::Reports::ReactionsController < API::BaseController
   before_action -> { doorkeeper_authorize! :write }, only: %i[create destroy], if: -> { doorkeeper_token.present? }
 
   def index
-    reactions = @report.reactions.includes(user: { avatar_attachment: :blob }).order(created_at: :asc)
-    grouped_reactions = reactions.group_by(&:kind)
-    result = Reaction.emojis.each_with_object({}) do |(kind, emoji), hash|
-      users = grouped_reactions[kind]&.map { |reaction| user_payload(reaction.user) } || []
-      hash[kind] = { emoji:, users: } unless users.empty?
-    end
-    render json: result
+    render json: reaction_summary_json(@report)
   end
 
   def create
@@ -39,15 +33,5 @@ class API::Reports::ReactionsController < API::BaseController
   def set_report
     @report = Report.find_by(id: params[:report_id])
     render json: { message: '日報が見つかりません。' }, status: :not_found unless @report
-  end
-
-  def user_payload(user)
-    user = ActiveDecorator::Decorator.instance.decorate(user)
-    {
-      id: user.id,
-      login_name: user.login_name,
-      avatar_url: user.avatar_url,
-      user_icon_frame_class: user.user_icon_frame_class
-    }
   end
 end


### PR DESCRIPTION
## 概要

- APIの確認処理レスポンス生成を `API::BaseController#check_json` に共通化
- リアクション一覧レスポンス生成を `API::BaseController#reaction_summary_json` に共通化
- 既存のレスポンス形式は変えず、重複していたJSON組み立てだけを整理

## 確認

- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rails test test/integration/api/checks_test.rb test/integration/api/reactions_test.rb`
- [x] `bundle exec rubocop app/controllers/api/base_controller.rb app/controllers/api/checks_controller.rb app/controllers/concerns/api/checkable_check.rb app/controllers/api/reactions_controller.rb app/controllers/api/reports/reactions_controller.rb`
- [x] `SECRET_KEY_BASE=0123456789abcdef0123456789abcdef bundle exec rake traceroute`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * API応答の生成処理を統一化し、複数のエンドポイント間での一貫性を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->