### PR TITLE
flakewatchの履歴を永続化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
     if: ${{ always() && !cancelled() }}
     permissions:
       actions: read
+      contents: write
       pull-requests: write
 
     steps:
@@ -218,7 +219,8 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.5.0
+        uses: komagata/flakewatch@v0.6.0
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."
+          history-branch: flakewatch-data


### PR DESCRIPTION
## 概要

flakewatch を JSONL 履歴永続化対応の `v0.6.0` に更新し、専用ブランチ `flakewatch-data` にテスト履歴を保存できるようにします。

## 変更内容

- `komagata/flakewatch@v0.5.0` を `komagata/flakewatch@v0.6.0` に更新
- `history-branch: flakewatch-data` を追加
- flakewatch job に履歴ブランチへpushするための `contents: write` を追加

## 挙動

- PR CIでは `flakewatch-data` の `history/**/*.jsonl` を読んでHTMLレポートに反映します
- `history-write: auto` のデフォルトにより、PR CIでは履歴を書き込まず、push/main系のtrusted runで今回分のJSONLを書き込みます
- HTMLレポート自体はこれまで通りPR本文の `Flakewatch Report` から `flakewatch.html` を1ファイルでダウンロードできます

## 確認

- `gh release list --repo komagata/flakewatch --limit 10` で `v0.6.0` が最新リリースであることを確認
- `gh api repos/komagata/flakewatch/compare/34ec13a...v0.6.0` でJSONL履歴PRの内容を含むことを確認
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * main ブランチへの push で CI ワークフローが実行されるよう設定を追加しました。
  * CI 実行用ツールを v0.6.0 に更新しました。
  * CI 実行に必要な権限（contents: write）を追加しました。
  * 実行履歴用のブランチ（flakewatch-data）を指定する設定を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/25998907752/artifacts/7044941207)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
