### PR TITLE
GemfileとGemfile.lockの不整合でCIが落ちている件を修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,9 +272,6 @@ GEM
     google-id-token (1.4.2)
       jwt (>= 1)
     google-logging-utils (0.2.0)
-    google-protobuf (4.33.3)
-      bigdecimal
-      rake (>= 13)
     google-protobuf (4.33.3-arm64-darwin)
       bigdecimal
       rake (>= 13)
@@ -298,9 +295,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    grpc (1.76.0)
-      google-protobuf (>= 3.25, < 5.0)
-      googleapis-common-protos-types (~> 1.0)
     grpc (1.76.0-arm64-darwin)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
@@ -877,9 +871,6 @@ DEPENDENCIES
   mission_control-jobs
   mutex_m (= 0.1.1)
   neighbor
-  net-imap
-  net-pop
-  net-smtp
   newspaper
   oauth2
   omniauth (~> 2.1.1)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
mainでCIのBuild, Checkが落ちてしまっていました。
原因はGemfileとGemfile.lockの不整合によるもので、このPRはそれを解決するものです。

`bundle install`を実行し、不整合を修正しました。
### CIのエラー箇所抜粋
```
/opt/hostedtoolcache/Ruby/3.4.3/x64/bin/bundle install --jobs 4
Some dependencies were deleted from your gemfile, but the lockfile can't be
updated because frozen mode is set

You have deleted from the Gemfile:
* net-imap
* net-pop
* net-smtp

Run `bundle install` elsewhere and add the updated Gemfile.lock to version
control.


If this is a development machine, remove the Gemfile.lock freeze by running
`bundle config set frozen false`.
Error: The process '/opt/hostedtoolcache/Ruby/3.4.3/x64/bin/bundle' failed with exit code 16
```
### 考えられる原因
おそらくこちらのPRでGemfile.lockの更新がされていなかったのかも。
> https://github.com/fjordllc/bootcamp/pull/9710

<!-- I want to review in Japanese. -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/26073582671/artifacts/7074082947)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
