### PR TITLE
提出物をピヨルドでレビューできるようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@2.5.4
   node: circleci/node@7.1.1
-  browser-tools: circleci/browser-tools@2.3.2
 jobs:
   build:
     docker:
@@ -75,12 +74,6 @@ jobs:
     parallelism: 8
     steps:
       - checkout
-      - browser-tools/install_browser_tools
-      - run:
-          command: |
-            google-chrome --version
-            chromedriver --version
-          name: Check install
       - run:
           name: Configure Bundler
           command: |
@@ -92,6 +85,9 @@ jobs:
           node-version: '22.19.0'
       - node/install-packages:
           pkg-manager: npm
+      - run:
+          name: Install Playwright browser
+          command: npx playwright install --with-deps chromium
       - run:
           name: Install japanese font
           command: sudo apt-get install -y fonts-noto-cjk

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,6 +3,7 @@
 class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLength
   before_action :check_permission!, only: %i[show]
   before_action :require_staff_login, only: :index
+  before_action :require_mentor_login, only: :review_by_pjord
   before_action :set_watch, only: %i[show]
   before_action :set_target, only: %i[index]
 
@@ -81,12 +82,31 @@ class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLen
     redirect_to @product.practice, notice: '提出物を削除しました。'
   end
 
+  def review_by_pjord
+    @product = find_product
+    reviewer = Pjord.user
+    body = review_body_by_pjord(reviewer)
+    if body.present? && reviewer
+      @product.comments.create!(user: reviewer, description: body)
+      redirect_to product_path(@product, anchor: 'comments'), notice: 'ピヨルドのレビューコメントを作成しました。'
+    else
+      redirect_to @product, alert: 'ピヨルドのレビューコメントを作成できませんでした。'
+    end
+  end
+
   private
 
   def update_published_at
     return if @product.wip || @product.published_at?
 
     @product.published_at = Time.current
+  end
+
+  def review_body_by_pjord(reviewer)
+    ProductAiReviewer.review(@product) if reviewer
+  rescue StandardError => e
+    Rails.logger.error("[ProductsController#review_by_pjord] #{e.class}: #{e.message}")
+    nil
   end
 
   def find_product

--- a/app/models/product_ai_reviewer.rb
+++ b/app/models/product_ai_reviewer.rb
@@ -3,6 +3,7 @@
 class ProductAiReviewer
   MODEL = 'claude-opus-4-1-20250805'
   OTHER_PRODUCTS_LIMIT = 10
+  PROMPT_TEXT_LIMIT = 2_000
 
   class << self
     def review(product)
@@ -37,10 +38,10 @@ class ProductAiReviewer
         ## プラクティス
         - タイトル: #{product.practice.title}
         - 説明:
-        #{product.practice.description}
+        #{truncate_for_prompt(product.practice.description)}
 
         ## 提出物
-        #{product.body}
+        #{truncate_for_prompt(product.body)}
 
         ## 同じ提出物に対するコメント
         #{comments(product)}
@@ -57,12 +58,12 @@ class ProductAiReviewer
       return 'なし' if product.comments.blank?
 
       product.comments.order(:created_at).map do |comment|
-        "- #{comment.user.login_name}: #{comment.description}"
+        "- #{comment.user.login_name}: #{truncate_for_prompt(comment.description)}"
       end.join("\n")
     end
 
     def submission_answer(product)
-      product.practice.submission_answer&.description.presence || 'なし'
+      truncate_for_prompt(product.practice.submission_answer&.description).presence || 'なし'
     end
 
     def other_products(product)
@@ -70,8 +71,12 @@ class ProductAiReviewer
       return 'なし' if products.blank?
 
       products.map do |other_product|
-        "### #{other_product.user.login_name}さんの提出物\n#{other_product.body}"
+        "### #{other_product.user.login_name}さんの提出物\n#{truncate_for_prompt(other_product.body)}"
       end.join("\n\n")
+    end
+
+    def truncate_for_prompt(text)
+      text.to_s.slice(0, PROMPT_TEXT_LIMIT)
     end
 
     def completed_percentage(user_course_practice)

--- a/app/models/product_ai_reviewer.rb
+++ b/app/models/product_ai_reviewer.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+class ProductAiReviewer
+  MODEL = 'claude-opus-4-1-20250805'
+  OTHER_PRODUCTS_LIMIT = 10
+
+  class << self
+    def review(product)
+      chat = RubyLLM.chat(model: MODEL)
+      chat.with_instructions(instructions)
+      chat.with_schema(PjordResponse)
+      extract_public_response_body(chat.ask(message(product)).content).presence
+    end
+
+    private
+
+    def instructions
+      <<~TEXT
+        あなたはFJORD BOOT CAMPのマスコット「ピヨルド」として、提出物にレビューコメントを書きます。
+        受講生を励ましつつ、提出物の内容を具体的に確認し、改善点があれば短く実行可能な形で伝えてください。
+        模範解答や他の提出物の内容をそのままコピーせず、答えを丸ごと教えないでください。
+        レビューコメント本文だけをmarkdownで出力してください。
+      TEXT
+    end
+
+    def message(product)
+      user_course_practice = UserCoursePractice.new(product.user)
+      <<~TEXT
+        以下の情報を参考に、提出物へのレビューコメントを書いてください。
+
+        ## 提出者
+        - ログイン名: #{product.user.login_name}
+        - 名前: #{product.user.name}
+        - プロフィール: #{product.user.description.presence || '未入力'}
+        - 進捗率: #{completed_percentage(user_course_practice)}
+
+        ## プラクティス
+        - タイトル: #{product.practice.title}
+        - 説明:
+        #{product.practice.description}
+
+        ## 提出物
+        #{product.body}
+
+        ## 同じ提出物に対するコメント
+        #{comments(product)}
+
+        ## 模範解答
+        #{submission_answer(product)}
+
+        ## 同じプラクティスの他の提出物
+        #{other_products(product)}
+      TEXT
+    end
+
+    def comments(product)
+      return 'なし' if product.comments.blank?
+
+      product.comments.order(:created_at).map do |comment|
+        "- #{comment.user.login_name}: #{comment.description}"
+      end.join("\n")
+    end
+
+    def submission_answer(product)
+      product.practice.submission_answer&.description.presence || 'なし'
+    end
+
+    def other_products(product)
+      products = product.practice.products.not_wip.where.not(id: product.id).includes(:user).order(published_at: :desc, id: :desc).limit(OTHER_PRODUCTS_LIMIT)
+      return 'なし' if products.blank?
+
+      products.map do |other_product|
+        "### #{other_product.user.login_name}さんの提出物\n#{other_product.body}"
+      end.join("\n\n")
+    end
+
+    def completed_percentage(user_course_practice)
+      return '不明' unless user_course_practice.user.course
+
+      "#{format('%.1f', user_course_practice.completed_percentage)}%"
+    end
+
+    def extract_public_response_body(content)
+      if content.is_a?(String)
+        parse_response_body(content)
+      elsif content.respond_to?(:to_h)
+        parsed = content.to_h
+        parsed['body'] || parsed[:body] if parsed.is_a?(Hash)
+      end
+    end
+
+    def parse_response_body(content)
+      parsed = JSON.parse(content)
+      parsed.is_a?(Hash) ? parsed['body'] : content
+    rescue JSON::ParserError
+      content
+    end
+  end
+end

--- a/app/models/product_ai_reviewer.rb
+++ b/app/models/product_ai_reviewer.rb
@@ -57,7 +57,7 @@ class ProductAiReviewer
     def comments(product)
       return 'なし' if product.comments.blank?
 
-      product.comments.order(:created_at).map do |comment|
+      product.comments.includes(:user).order(:created_at).map do |comment|
         "- #{comment.user.login_name}: #{truncate_for_prompt(comment.description)}"
       end.join("\n")
     end

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -22,6 +22,15 @@ header.page-header
                   i.fa-regular.fa-plus
                   span
                     | 模範解答作成
+            - if current_user.mentor?
+              li.page-header-actions__item.is-only-mentor
+                = link_to review_by_pjord_product_path(@product),
+                  class: 'a-button is-md is-secondary is-block',
+                  method: :post,
+                  data: { confirm: 'ピヨルドでレビューコメントを作成しますか？' } do
+                  i.fa-regular.fa-comment
+                  span
+                    | ピヨルドでレビューコメントをする
             li.page-header-actions__item
               = link_to course_practices_path(current_user.course, anchor: "category-#{category.id}"),
                 class: 'a-button is-md is-secondary is-block is-back' do

--- a/config/routes/products.rb
+++ b/config/routes/products.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   end
 
   resources :products do
+    post :review_by_pjord, on: :member
     resources :checks, only: %i[create destroy]
   end
 end

--- a/test/integration/products/review_by_pjord_test.rb
+++ b/test/integration/products/review_by_pjord_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Products::ReviewByPjordTest < ActionDispatch::IntegrationTest
+  test 'mentor can create product review comment by Pjord' do
+    product = products(:product1)
+
+    ProductAiReviewer.stub(:review, 'レビュー本文') do
+      assert_difference -> { product.comments.count } do
+        post review_by_pjord_product_path(product, _login_name: 'komagata')
+      end
+    end
+
+    comment = product.comments.order(:created_at).last
+    assert_redirected_to product_path(product, anchor: 'comments')
+    assert_equal users(:pjord), comment.user
+    assert_equal 'レビュー本文', comment.description
+  end
+
+  test 'student cannot create product review comment by Pjord' do
+    product = products(:product1)
+
+    assert_no_difference -> { product.comments.count } do
+      post review_by_pjord_product_path(product, _login_name: 'kimura')
+    end
+
+    assert_redirected_to root_path
+  end
+
+  test 'admin without mentor role cannot create product review comment by Pjord' do
+    product = products(:product1)
+
+    assert_no_difference -> { product.comments.count } do
+      post review_by_pjord_product_path(product, _login_name: 'adminonly')
+    end
+
+    assert_redirected_to root_path
+  end
+
+  test 'redirects with alert when Pjord user is missing' do
+    product = products(:product1)
+
+    Pjord.stub(:user, nil) do
+      assert_no_difference -> { product.comments.count } do
+        post review_by_pjord_product_path(product, _login_name: 'komagata')
+      end
+    end
+
+    assert_redirected_to product_path(product)
+    assert_equal 'ピヨルドのレビューコメントを作成できませんでした。', flash[:alert]
+  end
+
+  test 'redirects with alert when product review fails' do
+    product = products(:product1)
+
+    ProductAiReviewer.stub(:review, ->(_product) { raise StandardError, 'error' }) do
+      assert_no_difference -> { product.comments.count } do
+        post review_by_pjord_product_path(product, _login_name: 'komagata')
+      end
+    end
+
+    assert_redirected_to product_path(product)
+    assert_equal 'ピヨルドのレビューコメントを作成できませんでした。', flash[:alert]
+  end
+end

--- a/test/models/product_ai_reviewer_test.rb
+++ b/test/models/product_ai_reviewer_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProductAiReviewerTest < ActiveSupport::TestCase
+  test '.review asks latest Opus model with product review context' do
+    product = products(:product1)
+    mock_content = Struct.new(:content).new({ body: 'レビュー本文' })
+    mock_chat = Minitest::Mock.new
+    asked_message = nil
+
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
+    mock_chat.expect(:ask, mock_content) do |message|
+      asked_message = message
+      true
+    end
+
+    RubyLLM.stub(:chat, lambda { |model:|
+      assert_equal ProductAiReviewer::MODEL, model
+      mock_chat
+    }) do
+      assert_equal 'レビュー本文', ProductAiReviewer.review(product)
+    end
+
+    assert_includes asked_message, product.user.login_name
+    assert_includes asked_message, product.practice.title
+    assert_includes asked_message, product.body
+    assert_includes asked_message, product.practice.submission_answer.description
+    assert_includes asked_message, products(:product15).body
+    mock_chat.verify
+  end
+
+  test '.review handles user without course' do
+    product = products(:product1)
+    product.user.update_column(:course_id, nil) # rubocop:disable Rails/SkipsModelValidations
+    mock_content = Struct.new(:content).new({ body: 'レビュー本文' })
+    mock_chat = Minitest::Mock.new
+    asked_message = nil
+
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
+    mock_chat.expect(:ask, mock_content) do |message|
+      asked_message = message
+      true
+    end
+
+    RubyLLM.stub(:chat, mock_chat) do
+      assert_equal 'レビュー本文', ProductAiReviewer.review(product)
+    end
+
+    assert_includes asked_message, '進捗率: 不明'
+    mock_chat.verify
+  end
+end

--- a/test/models/product_ai_reviewer_test.rb
+++ b/test/models/product_ai_reviewer_test.rb
@@ -52,4 +52,27 @@ class ProductAiReviewerTest < ActiveSupport::TestCase
     assert_includes asked_message, '進捗率: 不明'
     mock_chat.verify
   end
+
+  test '.review truncates long text in prompt' do
+    product = products(:product1)
+    product.update!(body: 'a' * (ProductAiReviewer::PROMPT_TEXT_LIMIT + 1))
+    mock_content = Struct.new(:content).new({ body: 'レビュー本文' })
+    mock_chat = Minitest::Mock.new
+    asked_message = nil
+
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
+    mock_chat.expect(:ask, mock_content) do |message|
+      asked_message = message
+      true
+    end
+
+    RubyLLM.stub(:chat, mock_chat) do
+      assert_equal 'レビュー本文', ProductAiReviewer.review(product)
+    end
+
+    assert_includes asked_message, 'a' * ProductAiReviewer::PROMPT_TEXT_LIMIT
+    assert_not_includes asked_message, 'a' * (ProductAiReviewer::PROMPT_TEXT_LIMIT + 1)
+    mock_chat.verify
+  end
 end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -54,6 +54,15 @@ class ProductsTest < ApplicationSystemTestCase
     assert_selector '.thread-comment-form'
   end
 
+  test 'show Pjord product review button only to mentor' do
+    product = products(:product1)
+    visit_with_auth "/products/#{product.id}", 'mentormentaro'
+    assert_link 'ピヨルドでレビューコメントをする'
+
+    visit_with_auth "/products/#{product.id}", 'kimura'
+    assert_no_link 'ピヨルドでレビューコメントをする'
+  end
+
   test 'show user name_kana next to name' do
     product = products(:product1)
     visit_with_auth "/products/#{product.id}", 'kimura'

--- a/test/system/user/events_test.rb
+++ b/test/system/user/events_test.rb
@@ -16,6 +16,24 @@ class User::EventsTest < ApplicationSystemTestCase
   end
 
   test 'does not show events the user is not participating in' do
+    participated_event = events(:event30)
+    non_participated_event = events(:event34)
+    start_at = 1.month.from_now
+
+    participated_event.update!(
+      start_at:,
+      end_at: start_at + 2.hours,
+      open_start_at: start_at - 1.month,
+      open_end_at: start_at - 1.hour
+    )
+    non_participated_event.update!(
+      user: users(:komagata),
+      start_at:,
+      end_at: start_at + 2.hours,
+      open_start_at: start_at - 1.month,
+      open_end_at: start_at - 1.hour
+    )
+
     visit_with_auth "/users/#{users(:kimura).id}/events", 'kimura'
     assert_text '未来のイベント(参加済)'
     assert_no_text '未来のイベント(未参加)'


### PR DESCRIPTION
## 概要

- メンターだけが提出物ページから「ピヨルドでレビューコメントをする」を実行できるようにしました
- 最新 Opus モデルで提出者プロフィール、進捗率、既存コメント、模範解答、同じプラクティスの他提出物を文脈にレビュー本文を生成します
- 生成結果をピヨルドユーザーの提出物コメントとして保存します
- 生成失敗時はコメントを作らずアラート表示にします

## 確認

- [x] `bundle exec rubocop app/models/product_ai_reviewer.rb app/controllers/products_controller.rb test/models/product_ai_reviewer_test.rb test/integration/products/review_by_pjord_test.rb test/system/products_test.rb`
- [x] `bundle exec slim-lint app/views/products/show.html.slim -c config/slim_lint.yml`
- [x] `bin/rails test test/models/product_ai_reviewer_test.rb test/integration/products/review_by_pjord_test.rb test/system/products_test.rb:57`
- [x] `RAILS_ENV=test bin/shakapacker`
- [x] `git merge-tree --write-tree HEAD origin/main`

## レビュー

- 自己レビューで実装範囲、権限、失敗時の挙動を確認しました
- 別人格レビューで、メンター限定仕様と失敗系テストを確認しました
- Claude Codeレビューの指摘を受け、private API依存の解消、LLM例外時のリダイレクト、他提出物文脈の件数制限、失敗系テスト追加を行いました
- Claude Codeの非同期化提案は、今回はボタン押下で即時コメントを作る最小実装を優先し、別課題候補として見送りました

Closes #10037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * メンター向けにAI自動レビューコメント生成を追加。プロダクト詳細から「ピヨルドでレビューコメントをする」でAIがレビューを生成・投稿します。
  * プロダクトページのメタ情報（タイトル/説明/カテゴリ）を改善。

* **Bug Fixes**
  * メンター権限でのみ実行可能に制限。生成失敗や設定不足時は製品ページへリダイレクトしてアラート表示。

* **Tests**
  * 統合・モデル・システムテストを追加・拡充し権限・表示・例外処理を検証。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/26116542510/artifacts/7092118880)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
