### PR TITLE
Flakewatchの履歴をPRでも保存する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,3 +224,4 @@ jobs:
           junit: "test/reports/**/*.xml"
           source-root: "."
           history-branch: flakewatch-data
+          history-write: true


### PR DESCRIPTION
## 概要

- Flakewatch の `history-write` を `true` にして、PR 実行でも `flakewatch-data` ブランチへ履歴 JSONL を保存するようにしました。

## Issue

- #10039

## 変更確認方法

- PR の GitHub Actions で `Flakewatch HTML report` が成功し、履歴書き込みステップが実行されることを確認します。

## 確認

- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'`\n- [x] `git diff --check`\n- [x] `komagata/flakewatch@v0.6.0` の `history-write` input と書き込み条件を確認\n\nCloses #10039