### PR TITLE
stagingデプロイ時のDB削除を安定化する

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -34,7 +34,7 @@ steps:
         echo "Deleting Cloud Run service to disconnect database connections..."
 
         # サービスが存在するか確認して削除
-        if gcloud run services describe $_SERVICE_NAME --region=asia-northeast1 --quiet 2>/dev/null; then
+        if gcloud run services describe $_SERVICE_NAME --region=asia-northeast1 --format='value(metadata.name)' --quiet >/dev/null 2>&1; then
           gcloud run services delete $_SERVICE_NAME \
             --region=asia-northeast1 \
             --quiet
@@ -112,7 +112,7 @@ steps:
       - DB_USER=$_DB_USER
       - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
       - APP_HOST_NAME=$_APP_HOST_NAME
-  # bootcamp_stagingへの接続を強制切断してからデータベースを削除
+  # bootcamp_stagingへの新規接続を止め、残存接続を強制切断してからデータベースを削除
   - id: DeleteDB
     name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
     entrypoint: bash
@@ -121,21 +121,50 @@ steps:
       - |
         set -euo pipefail
 
-        echo "Terminating all connections to bootcamp_staging..."
-        cat <<'SQLEOF' | bin/rails runner - 2>&1
-        result = ActiveRecord::Base.connection.execute(<<~SQL)
-          SELECT pg_terminate_backend(pid)
-          FROM pg_stat_activity
-          WHERE datname = 'bootcamp_staging'
-            AND pid <> pg_backend_pid()
-        SQL
-        puts "Terminated #{result.count} connection(s)"
-        SQLEOF
-
         echo "Dropping database bootcamp_staging..."
         cat <<'SQLEOF' | bin/rails runner - 2>&1
-        ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS bootcamp_staging")
-        puts "Database dropped successfully"
+        db_name = "bootcamp_staging"
+        quoted_db_name = ActiveRecord::Base.connection.quote(db_name)
+        quoted_identifier = ActiveRecord::Base.connection.quote_table_name(db_name)
+
+        database_exists = ActiveRecord::Base.connection.select_value(<<~SQL)
+          SELECT 1 FROM pg_database WHERE datname = #{quoted_db_name}
+        SQL
+
+        unless database_exists
+          puts "Database #{db_name} does not exist. Skipping drop."
+          exit 0
+        end
+
+        ActiveRecord::Base.connection.execute("ALTER DATABASE #{quoted_identifier} WITH ALLOW_CONNECTIONS false")
+
+        deadline = Time.now + 120
+        attempt = 0
+
+        loop do
+          attempt += 1
+          result = ActiveRecord::Base.connection.execute(<<~SQL)
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = #{quoted_db_name}
+              AND pid <> pg_backend_pid()
+          SQL
+          puts "Terminated #{result.count} connection(s) on attempt #{attempt}"
+
+          begin
+            ActiveRecord::Base.connection.execute("DROP DATABASE #{quoted_identifier}")
+            puts "Database dropped successfully"
+            break
+          rescue ActiveRecord::StatementInvalid => e
+            if Time.now >= deadline
+              ActiveRecord::Base.connection.execute("ALTER DATABASE #{quoted_identifier} WITH ALLOW_CONNECTIONS true")
+              raise
+            end
+
+            puts "Drop failed: #{e.message}"
+            sleep 5
+          end
+        end
         SQLEOF
     waitFor:
       - WaitForProxy


### PR DESCRIPTION
## 概要

staging 環境への Cloud Build デプロイ時に、`bootcamp_staging` への接続が残っていると `DROP DATABASE` が失敗する問題を修正します。

## 調査結果

既存の失敗ビルドログでは `DeleteDB` step で以下のエラーが発生していました。

```text
PG::ObjectInUse: ERROR: database "bootcamp_staging" is being accessed by other users
DETAIL: There are 2 other sessions using the database.
```

`staging` DB ユーザーの権限も確認しました。

- `bootcamp_staging` の owner は `staging`
- `staging` は `CREATEDB` を持つ
- `staging` は `cloudsqlsuperuser` の member
- 既存ログでも `pg_terminate_backend` は成功している

そのため主因は権限不足ではなく、接続切断後から `DROP DATABASE` までの間に Rails / Solid Queue のセッションが残る、または再接続することでした。

## 変更内容

- Cloud Run の存在確認で `gcloud run services describe` の詳細出力を抑制
  - 環境変数などが Cloud Build ログに出ないようにする
- `DROP DATABASE` 前に `ALTER DATABASE bootcamp_staging WITH ALLOW_CONNECTIONS false` を実行
  - 新規接続を止めてから残存接続を切断する
- `pg_terminate_backend` と `DROP DATABASE` を最大 120 秒リトライ
- タイムアウト時は `ALLOW_CONNECTIONS true` に戻してから失敗させる

## 確認

```bash
ruby -e 'require "yaml"; YAML.load_file(".cloudbuild/cloudbuild-staging.yaml"); puts "yaml ok"'
git diff --check
```
