### PR TITLE
定期イベントのスキップ日更新時における重複エラーの解消

### DIFF
--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -223,7 +223,6 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def validate_skip_on_uniqueness
-    # 削除対象(_destroy: 1)ではないskip_onの中から重複を検知
     active_skip_ons = regular_event_skip_dates
                       .map(&:skip_on)
                       .compact

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -225,12 +225,11 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def validate_skip_on_uniqueness
     # 削除対象(_destroy: 1)ではないskip_onの中から重複を検知
     active_skip_ons = regular_event_skip_dates
-                      .reject(&:marked_for_destruction?)
                       .map(&:skip_on)
                       .compact
 
     return unless active_skip_ons.size != active_skip_ons.uniq.size
 
-    errors.add(:base, 'スキップする日に重複した日付が含まれています。')
+    errors.add(:base, 'スキップする日に重複した日付が含まれています')
   end
 end

--- a/app/models/regular_event_skip_date.rb
+++ b/app/models/regular_event_skip_date.rb
@@ -4,4 +4,5 @@ class RegularEventSkipDate < ApplicationRecord
   belongs_to :regular_event
 
   validates :skip_on, presence: true
+  validates :skip_on, uniqueness: { scope: :regular_event_id, message: '(%<value>s)は既に登録されています' }
 end

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -90,7 +90,8 @@
             | 主催者の都合などにより開催できない日がある場合は、
             | こちらでご指定ください。
         = cocooned_container do
-          = f.fields_for :regular_event_skip_dates, regular_event.regular_event_skip_dates.order(skip_on: :asc) do |regular_event_skip_date|
+          - sorted_skip_dates = regular_event.regular_event_skip_dates.to_a.sort_by { |d| d.skip_on || Date.new(9999, 12, 31) }
+          = f.fields_for :regular_event_skip_dates, sorted_skip_dates do |regular_event_skip_date|
             = render 'regular_event_skip_date_fields', f: regular_event_skip_date
           .form-item__add-times
               = cocooned_add_item_link f, :regular_event_skip_dates, class: 'a-button is-md is-primary' do

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -90,7 +90,7 @@
             | 主催者の都合などにより開催できない日がある場合は、
             | こちらでご指定ください。
         = cocooned_container do
-          = f.fields_for :regular_event_skip_dates, regular_event.regular_event_skip_dates do |regular_event_skip_date|
+          = f.fields_for :regular_event_skip_dates, regular_event.regular_event_skip_dates.order(skip_on: :asc) do |regular_event_skip_date|
             = render 'regular_event_skip_date_fields', f: regular_event_skip_date
           .form-item__add-times
               = cocooned_add_item_link f, :regular_event_skip_dates, class: 'a-button is-md is-primary' do

--- a/test/models/regular_event_skip_date_test.rb
+++ b/test/models/regular_event_skip_date_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RegularEventSkipDateTest < ActiveSupport::TestCase
+  test 'invalid when skip_on already exists for the same regular_event' do
+    regular_event = regular_events(:regular_event7)
+
+    regular_event.regular_event_skip_dates.create!(skip_on: '2026-06-01', reason: '既存')
+
+    duplicate_skip_date = regular_event.regular_event_skip_dates.build(skip_on: '2026-06-01', reason: '重複')
+
+    assert_not duplicate_skip_date.valid?
+    assert_includes duplicate_skip_date.errors[:skip_on], '(2026-06-01)は既に登録されています'
+  end
+end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -279,7 +279,7 @@ class RegularEventTest < ActiveSupport::TestCase
       regular_event.regular_event_skip_dates.build(skip_on: Date.new(2026, 4, 8))
 
       assert_not regular_event.save
-      assert_includes regular_event.errors[:base], 'スキップする日に重複した日付が含まれています。'
+      assert_includes regular_event.errors[:base], 'スキップする日に重複した日付が含まれています'
     end
   end
 

--- a/test/system/regular_events/skip_date_test.rb
+++ b/test/system/regular_events/skip_date_test.rb
@@ -76,19 +76,5 @@ module RegularEvents
         assert_no_selector('.a-card.is-out-of-rule-skip-dates')
       end
     end
-
-    test 'skip dates are ordered by skip_on asc in edit form' do
-      regular_event = regular_events(:regular_event7)
-
-      regular_event.regular_event_skip_dates.create!(skip_on: Date.new(2026, 6, 15), reason: '遅い日')
-      regular_event.regular_event_skip_dates.create!(skip_on: Date.new(2026, 5, 28), reason: '早い日')
-
-      visit_with_auth edit_regular_event_path(regular_event), 'kimura'
-
-      skip_date_fields = all('input[id*="_skip_on"]')
-
-      assert_equal '2026-05-28', skip_date_fields[0].value
-      assert_equal '2026-06-15', skip_date_fields[1].value
-    end
   end
 end

--- a/test/system/regular_events/skip_date_test.rb
+++ b/test/system/regular_events/skip_date_test.rb
@@ -76,5 +76,19 @@ module RegularEvents
         assert_no_selector('.a-card.is-out-of-rule-skip-dates')
       end
     end
+
+    test 'skip dates are ordered by skip_on asc in edit form' do
+      regular_event = regular_events(:regular_event7)
+
+      regular_event.regular_event_skip_dates.create!(skip_on: Date.new(2026, 6, 15), reason: '遅い日')
+      regular_event.regular_event_skip_dates.create!(skip_on: Date.new(2026, 5, 28), reason: '早い日')
+
+      visit_with_auth edit_regular_event_path(regular_event), 'kimura'
+
+      skip_date_fields = all('input[id*="_skip_on"]')
+
+      assert_equal '2026-05-28', skip_date_fields[0].value
+      assert_equal '2026-06-15', skip_date_fields[1].value
+    end
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- Issue
    - #9332
- 関連PR
    - #9879 

## 概要
- 定期イベントのスキップ日を更新時に既存のスキップ日の値を入れ替えて更新すると`RecordNotUnique`で500エラーになるケースがあったため、親モデルと子モデル両方でより厳密に重複チェックを行うように修正した
- フォームのソートを昇順に修正した

### 詳細
- すでに以下の2件が登録されているとする。
    - `2026-05-25`
    - `2026-06-01`
- これらを次のように入れ替える場合、バリデーションは通るもののDBのunique制約に引っかかって `RecordNotUnique` が発生する
    - `2026-05-25` → `2026-06-01`
    - `2026-06-01` → `2026-05-25`
   
### 発生した理由
- スキップ日は`regular_event_id`と`skip_on`の組み合わせで一意にする必要があったので、重複チェックを親モデル側でメモリ上のデータの重複チェックを行うようにしていた(https://github.com/fjordllc/bootcamp/pull/9879/changes/c7639bdefd2cc6dd7b1657d957e142611d9051fe )
- 値を入れ替えて更新するパターンはメモリ上ではユニークになっているが、実際の保存時には既存レコードに対して順に `UPDATE`が走るため一時的にDBのunique制約に引っかかり500エラーが起きていた

## 対応内容
- 現状の親モデル(`RegularEvent`)での重複チェックに加えて、子モデル(`RegularEventSkipDate`)に`regular_event_id`と`skip_on`の組み合わせで`uniqueness`バリデーションを追加
    - 子モデルのバリデーションのみでは新規で同じ日付を登録しようとすると`RecordNotUnique` が発生するため組み合わせが必要
- 親モデル側の重複チェックで削除予定のレコードも含めて`skip_on`をの重複をチェックするように変更
  - 親モデル側で削除予定の`skip_on`を除外しても、DB保存時点ではまだ対象レコードがDB上に存在しており結局子モデルのバリデーションでエラーになるため
- 子モデル側のエラーメッセージで、具体的な重複した日付を表示するように修正
- 入れ替えたい需要として先に日付の新しいスキップ日を入力→後からそれより前の日付を入力した際に昇順にしたいというのがありそうなため、フォームのソートを事前に昇順になるように変更した

## 変更確認方法

1. `feature/fix-unique-validation-for-skip-dates`をローカルに取り込む
2. 適当な定期イベントで以下のパターンでスキップ日を登録して検証を行う

### 正常系
- [x] 既存が`2026-05-25`, `2026-06-01`の状態で、`2026-06-08` を追加できること
- [x] 既存の`2026-05-25`, `2026-06-01`を変更せず保存した場合はバリデーションエラーにならないこと

### 異常系
- [x] 既存が`2026-05-25`, `2026-06-01`の状態で、`2026-05-25` を追加するとバリデーションエラーになること
- [x] 既存が`2026-05-25`, `2026-06-01`の状態で、`2026-06-08` を同時に2件追加するとバリデーションエラーになること
- [x] 既存の`2026-05-25`, `2026-06-01`を、`2026-06-01`, `2026-05-25`に入れ替えるとバリデーションエラーになること
- [x] 既存の`2026-05-25`を削除（`_destroy`）しつつ、新しく `2026-05-25`を追加するとバリデーションエラーになること

### ソート
-  [x] 既存が`2026-06-01`,`2026-05-25`の順順不同でDBに登録されている場合、編集画面を開いた際に日付の昇順(`2026-05-25` → `2026-06-01`)で表示されること
- [x] スキップ日を追加し、別件でバリデーションエラー（タイトルを空にするなど）が発生して画面が再レンダリングされた際も、未保存の入力を含めてスキップ日が昇順にソートされて保持されていること

## 補足
- スキップ日のリレーションは`accepts_nesed_attributes_for`を使用している
- `accepts_nested_attributes_for` で一意制約のある子レコードをまとめて更新する場合、既存値の入れ替えや削除予定レコードとの重複により、保存途中で今回起きたようなDBのunique制約に抵触することがある(現在も対応については議論中の模様)
    - https://codewithrails.com/ja/blog/rails-nested-attributes-uniqueness-validation/
    - https://github.com/rails/rails/issues/20676  
- 回避策として[保存前に一度ユニークな仮値へ退避してから更新する](https://qiita.com/jnchito/items/6c3dd155ea71cd946082) などの回避方法もあるが実装が複雑になりやすい
- 既存のスキップ日を入れ替える操作は頻繁には起こらなそうなため、今回は500エラーを出さないことを優先し、重複しうる操作はすべてバリデーションエラーとして扱う方針にした

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * スキップ日設定フォームで、登録済みのスキップ日が日付順に表示されるようになりました

* **Bug Fixes**
  * 定期イベントのスキップ日重複検出のロジックを改善し、より正確に重複を検出するようになりました

* **Tests**
  * スキップ日の重複バリデーションに関するテストを追加・更新しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/26155000473/artifacts/7107373647)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
