### PR TITLE
Flakewatchをv0.6.1に更新する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.0
+        uses: komagata/flakewatch@v0.6.1
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."


### PR DESCRIPTION
## 概要

- Flakewatch GitHub Action を `v0.6.1` に更新しました。
- PR で履歴書き込みがスキップされる場合の warning など、最新の action 側改善を取り込みます。

## Issue

- 関連: #10039

## 変更確認方法

- PR の GitHub Actions で `Flakewatch HTML report` が成功することを確認します。

## 確認

- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'`\n- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD パイプラインで使用するツール依存関係をマイナーバージョンアップデートしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/26150161110/artifacts/7105491756)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
