### PR TITLE
Footprintableをincludeしているモデルの重複した関連付けの削除

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -16,7 +16,6 @@ class Product < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   belongs_to :practice
   belongs_to :user, touch: true
-  has_many :footprints, as: :footprintable, dependent: :destroy
   belongs_to :checker, class_name: 'User', optional: true
   alias sender user
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -24,7 +24,6 @@ class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
   validates_associated :learning_times
   accepts_nested_attributes_for :learning_times, reject_if: :all_blank, allow_destroy: true
   has_and_belongs_to_many :practices # rubocop:disable Rails/HasAndBelongsToMany
-  has_many :footprints, as: :footprintable, dependent: :destroy
   belongs_to :user, touch: true
   alias sender user
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9750

## 概要

Footprintableをincludeしているモデルの重複した関連付けの削除

## 補足

- issueにはProductモデルと記載ありますが、Reportモデルも同じ状況だったので一緒に対応しました。
- issueにはdependentオプションの統一の記載ありますが、以下PRで対応済みでしたのでこちらのPRでは対応していません。
  - https://github.com/fjordllc/bootcamp/pull/9738/changes

## 変更確認方法

1. `chore/remove-duplicate-association-for-footprintable` をローカルに取り込む
2. `komagata` でログイン
3. 他のユーザの日報詳細画面(/reports/:id)にアクセス
4. 画面最下部の「見たよ」に`komagata` のアイコンが表示されることを確認
5. 他のユーザの提出物詳細(/products/:id)にアクセス
6. 画面最下部の「見たよ」に`komagata` のアイコンが表示されることを確認

## Screenshot

無し

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Internal data relationship adjustments for improved system architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/26189918793/artifacts/7121833024)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
