### PR TITLE
ユーザーイベント一覧の件数表示を修正

### DIFF
--- a/app/controllers/users/events_controller.rb
+++ b/app/controllers/users/events_controller.rb
@@ -3,7 +3,7 @@
 class Users::EventsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @events = Event.where(id: @user.participate_events.select(:id))
+    @events = Event.where(id: @user.involved_events.select(:id))
                    .or(Event.where(user_id: @user.id))
                    .includes(:comments, :users)
                    .order(start_at: :desc)

--- a/app/helpers/page_tabs/users_helper.rb
+++ b/app/helpers/page_tabs/users_helper.rb
@@ -13,7 +13,7 @@ module PageTabs
       tabs << { name: '提出物', link: user_products_path(user), count: user.products.length }
       tabs << { name: '質問', link: user_questions_path(user), count: user.questions.length }
       tabs << { name: '回答', link: user_answers_path(user), count: user.answers.length }
-      tabs << { name: 'イベント', link: user_events_path(user), count: user.participate_events.count + user.involved_regular_events.count }
+      tabs << { name: 'イベント', link: user_events_path(user), count: user.involved_events.count + user.involved_regular_events.count }
       if Switchlet.enabled?(:micro_report) && (admin_or_mentor_login? || (Rails.env.in? %w[development test]))
         tabs << { name: '分報',
                   link: "#{user_micro_reports_path(user, page: user.latest_micro_report_page)}#latest-micro-report",

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -105,7 +105,7 @@ module UsersHelper
 
   def event_navs(user)
     [
-      { id: 'events', name: Event.model_name.human, count: user.participate_events.length, path: user_events_path(user) },
+      { id: 'events', name: Event.model_name.human, count: user.involved_events.length, path: user_events_path(user) },
       { id: 'regular_events', name: RegularEvent.model_name.human, count: user.involved_regular_events.length, path: user_regular_events_path(user) }
     ]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -894,6 +894,10 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
     RegularEvent.where(id: regular_event_participations.pluck(:regular_event_id), finished: false)
   end
 
+  def involved_events
+    Event.where(id: participate_events.select(:id)).or(Event.where(user_id: id))
+  end
+
   def involved_regular_events
     RegularEvent.where(id: participate_regular_events).or(RegularEvent.where(id: organize_regular_events))
   end

--- a/app/views/users/events/index.html.slim
+++ b/app/views/users/events/index.html.slim
@@ -26,6 +26,9 @@
                     .card-list-item__row
                       .card-list-item-title
                         .card-list-item-title__start
+                          - if event.user == @user
+                            .a-list-item-badge.is-active
+                              <span>主催</span>
                           - if event.wip
                             .a-list-item-badge.is-wip
                               <span>WIP</span>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -806,4 +806,11 @@ class UserTest < ActiveSupport::TestCase
     actual_ids = user.involved_regular_events.ids.sort
     assert_equal expected_ids, actual_ids
   end
+
+  test '#involved_events returns both participating and organizing events' do
+    user = users(:kimura)
+    expected_ids = (user.participate_events.ids + Event.where(user_id: user.id).ids).uniq.sort
+    actual_ids = user.involved_events.ids.sort
+    assert_equal expected_ids, actual_ids
+  end
 end

--- a/test/system/user/events_test.rb
+++ b/test/system/user/events_test.rb
@@ -10,12 +10,12 @@ class User::EventsTest < ApplicationSystemTestCase
     assert nav.matches_css?('.is-active')
   end
 
-  test 'shows correct count of user participating events' do
+  test 'shows correct count of user involved events' do
     visit_with_auth "/users/#{users(:kimura).id}/events", 'kimura'
-    assert_selector '.tab-nav__item-link', text: "特別イベント(#{users(:kimura).participate_events.count})"
+    assert_selector '.tab-nav__item-link', text: "特別イベント(#{users(:kimura).involved_events.count})"
   end
 
-  test 'does not show events the user is not participating in' do
+  test 'does not show events the user is not involved in' do
     participated_event = events(:event30)
     non_participated_event = events(:event34)
     start_at = 1.month.from_now
@@ -37,5 +37,13 @@ class User::EventsTest < ApplicationSystemTestCase
     visit_with_auth "/users/#{users(:kimura).id}/events", 'kimura'
     assert_text '未来のイベント(参加済)'
     assert_no_text '過去のイベント'
+  end
+
+  test 'shows events the user organizes but does not participate in' do
+    visit_with_auth "/users/#{users(:kimura).id}/events", 'kimura'
+
+    within('.card-list-item', text: 'ミートアップ') do
+      assert_text '主催'
+    end
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 関連Issue・PR

- #9633 
- #9929

## 概要

#9929 で漏れてしまっていた以下３点を修正しました。

- 主催しているイベントもイベント数に含まれるよう修正
- 主催イベントに「主催」ラベルを表示するよう修正
- 主催イベントが一覧・件数に正しく反映されることを確認するテストを追加

## 変更確認方法

1. `feature/user-events-include-organized`をローカルに取り込む
2. 開発サーバーを起動
3. http://localhost:3000/ にアクセスし、`kimura` 等通常ユーザーでログイン。
4. ナビゲーションから「[イベント](http://localhost:3000/events)」をクリックし、イベントを新規作成する。
5. ヘッダーの「Me」をクリックし、メニュー内の「マイプロフィール」をクリック。
6. バーを右にスクロールし、イベントタブをクリック。
7. イベントタブ部分と「特別イベント」タブの数字が正しいイベント数になっていることを確認する。
8. 主催のイベントには、「主催」とイベント名の前に表示されるかを確認する。

## Screenshot

### 変更前

<img width="840" height="717" alt="スクリーンショット 2026-05-21 115026" src="https://github.com/user-attachments/assets/97f1c909-e8f3-4ec0-b4c3-2a9b1965a68f" />

### 変更後

<img width="834" height="674" alt="スクリーンショット 2026-05-21 115104" src="https://github.com/user-attachments/assets/e0858318-8f3f-4ac9-a1a8-fc1317d10a68" />

<!-- I want to review in Japanese. -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26211752980/artifacts/7129886829"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ユーザーのイベント一覧で「参加」だけでなく「関与する（参加＋主催）」イベントを表示するようになりました。
  * ユーザーが主催するイベントに「主催」バッジを表示するようになりました。
  * イベント数カウントが関与イベントを反映するよう更新されました。

* **テスト**
  * 関与イベントの件数表示や非関与イベント非表示、主催のみのイベント表示を検証するテストを追加／更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
