### PR TITLE
Update flakewatch action to v0.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.3
+        uses: komagata/flakewatch@v0.6.4
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.0
+        uses: komagata/flakewatch@v0.6.2
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,4 +224,4 @@ jobs:
           junit: "test/reports/**/*.xml"
           source-root: "."
           history-branch: flakewatch-data
-          history-write: true
+          history-write: auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.2
+        uses: komagata/flakewatch@v0.6.3
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.4
+        uses: komagata/flakewatch@v0.6.5
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."


### PR DESCRIPTION
## Summary
- Update the flakewatch GitHub Action from v0.6.1 to v0.6.5.
- Use automatic flakewatch history writes so pull_request runs do not try to push history with read-only tokens.

## Verification
- Confirmed the latest komagata/flakewatch release is v0.6.5.
- Parsed .github/workflows/ci.yml with Ruby YAML successfully.
- Previous fork PR CI confirmed build/check/test/Flakewatch HTML report passed after the history-write change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD ワークフローで使用する外部ツールを更新しました。
  * 履歴書き込みの挙動を「自動」モードに変更し、品質チェック周りの小規模な改善を行いました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26206606883/artifacts/7127853306"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
