### PR TITLE
ピヨルドレビューを管理者専用にする

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,7 +3,7 @@
 class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLength
   before_action :check_permission!, only: %i[show]
   before_action :require_staff_login, only: :index
-  before_action :require_mentor_login, only: :review_by_pjord
+  before_action :require_admin_login, only: :review_by_pjord
   before_action :set_watch, only: %i[show]
   before_action :set_target, only: %i[index]
 

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -22,7 +22,7 @@ header.page-header
                   i.fa-regular.fa-plus
                   span
                     | 模範解答作成
-            - if current_user.mentor?
+            - if current_user.admin?
               li.page-header-actions__item.is-only-mentor
                 = link_to review_by_pjord_product_path(@product),
                   class: 'a-button is-md is-secondary is-block',

--- a/test/integration/products/review_by_pjord_test.rb
+++ b/test/integration/products/review_by_pjord_test.rb
@@ -3,12 +3,12 @@
 require 'test_helper'
 
 class Products::ReviewByPjordTest < ActionDispatch::IntegrationTest
-  test 'mentor can create product review comment by Pjord' do
+  test 'admin can create product review comment by Pjord' do
     product = products(:product1)
 
     ProductAiReviewer.stub(:review, 'レビュー本文') do
       assert_difference -> { product.comments.count } do
-        post review_by_pjord_product_path(product, _login_name: 'komagata')
+        post review_by_pjord_product_path(product, _login_name: 'adminonly')
       end
     end
 
@@ -16,6 +16,16 @@ class Products::ReviewByPjordTest < ActionDispatch::IntegrationTest
     assert_redirected_to product_path(product, anchor: 'comments')
     assert_equal users(:pjord), comment.user
     assert_equal 'レビュー本文', comment.description
+  end
+
+  test 'mentor cannot create product review comment by Pjord' do
+    product = products(:product1)
+
+    assert_no_difference -> { product.comments.count } do
+      post review_by_pjord_product_path(product, _login_name: 'mentormentaro')
+    end
+
+    assert_redirected_to root_path
   end
 
   test 'student cannot create product review comment by Pjord' do
@@ -28,22 +38,12 @@ class Products::ReviewByPjordTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
-  test 'admin without mentor role cannot create product review comment by Pjord' do
-    product = products(:product1)
-
-    assert_no_difference -> { product.comments.count } do
-      post review_by_pjord_product_path(product, _login_name: 'adminonly')
-    end
-
-    assert_redirected_to root_path
-  end
-
   test 'redirects with alert when Pjord user is missing' do
     product = products(:product1)
 
     Pjord.stub(:user, nil) do
       assert_no_difference -> { product.comments.count } do
-        post review_by_pjord_product_path(product, _login_name: 'komagata')
+        post review_by_pjord_product_path(product, _login_name: 'adminonly')
       end
     end
 
@@ -56,7 +56,7 @@ class Products::ReviewByPjordTest < ActionDispatch::IntegrationTest
 
     ProductAiReviewer.stub(:review, ->(_product) { raise StandardError, 'error' }) do
       assert_no_difference -> { product.comments.count } do
-        post review_by_pjord_product_path(product, _login_name: 'komagata')
+        post review_by_pjord_product_path(product, _login_name: 'adminonly')
       end
     end
 

--- a/test/system/products/mentor_test.rb
+++ b/test/system/products/mentor_test.rb
@@ -12,6 +12,16 @@ module Products
       assert_selector '#side-tabs-nav-4', text: '提出物'
     end
 
+    test 'mentors cannot see review by Pjord button' do
+      visit_with_auth "/products/#{products(:product2).id}", 'mentormentaro'
+      assert_no_text 'ピヨルドでレビューコメントをする'
+    end
+
+    test 'admins can see review by Pjord button' do
+      visit_with_auth "/products/#{products(:product2).id}", 'adminonly'
+      assert_text 'ピヨルドでレビューコメントをする'
+    end
+
     test 'students can not see block for mentors' do
       visit_with_auth "/products/#{products(:product2).id}", 'hatsuno'
       assert_no_text '直近の日報'

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -54,9 +54,9 @@ class ProductsTest < ApplicationSystemTestCase
     assert_selector '.thread-comment-form'
   end
 
-  test 'show Pjord product review button only to mentor' do
+  test 'show Pjord product review button only to admin' do
     product = products(:product1)
-    visit_with_auth "/products/#{product.id}", 'mentormentaro'
+    visit_with_auth "/products/#{product.id}", 'adminonly'
     assert_link 'ピヨルドでレビューコメントをする'
 
     visit_with_auth "/products/#{product.id}", 'kimura'


### PR DESCRIPTION
## 概要

- 提出物詳細の「ピヨルドでレビューコメントをする」ボタンを管理者だけに表示するように変更
- ピヨルドレビューコメント作成のPOST権限も管理者専用に変更
- 管理者・メンター・受講生の権限テストを更新

## 確認

- [x] bin/rails test test/integration/products/review_by_pjord_test.rb
- [x] bin/rails test test/system/products/mentor_test.rb:15 test/system/products/mentor_test.rb:20
- [x] bin/rails test test/system/products_test.rb:57
- [x] bundle exec rubocop app/controllers/products_controller.rb test/integration/products/review_by_pjord_test.rb test/system/products/mentor_test.rb test/system/products_test.rb
- [x] bundle exec slim-lint app/views/products/show.html.slim（既存のLineLength警告で失敗）

Closes #10051
