### PR TITLE
不要なダブルクォーテーションを削除

### DIFF
--- a/app/views/pair_works/_body.html.slim
+++ b/app/views/pair_works/_body.html.slim
@@ -83,7 +83,7 @@
                       - else
                         = l pair_work.reserved_at
                   - else
-                    p "開催日時は#{l pair_work.reserved_at, format: :mdw_and_time}に確定しました。"
+                    p 開催日時は#{l pair_work.reserved_at, format: :mdw_and_time}に確定しました。
                   - if pair_work.buddy == current_user
                     .pair-work-schedule-dates__action-item-description
                       p.pair-work-schedule-dates__text-danger あなたがペアとして確定しています。


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue
ペアワークの画面において、不要なダブルクォーテーションが出てしまっていたため削除した
## 変更前
<img width="605" height="319" alt="スクリーンショット 2026-05-21 134906" src="https://github.com/user-attachments/assets/5b9308a6-8a2c-4011-a7c0-ea08301396c2" />

## 変更後
<img width="596" height="291" alt="スクリーンショット 2026-05-21 141551" src="https://github.com/user-attachments/assets/2a3d953a-c2cc-46bd-a670-59b17b1a5a33" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * ペアワークの日時表示のレンダリング方法を最適化しました。ユーザーへの表示内容に変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

[Download flakewatch.html](https://github.com/fjordllc/bootcamp/actions/runs/26206822867/artifacts/7127955904)

Download the single HTML artifact and open it in your browser.
<!-- flakewatch-report:end -->
