### PR TITLE
リンクカードの失敗レスポンスをキャッシュしない

### DIFF
--- a/app/models/link_card/card.rb
+++ b/app/models/link_card/card.rb
@@ -8,12 +8,16 @@ module LinkCard
     end
 
     def metadata
-      Rails.cache.fetch @url, expires_in: 3.days do
+      Rails.cache.fetch cache_key, expires_in: 3.days, skip_nil: true do
         request
       end
     end
 
     private
+
+    def cache_key
+      ['link_card', @tweet ? 'tweet' : 'metadata', @url]
+    end
 
     def request
       return unless LinkChecker::Checker.valid_url?(@url)

--- a/test/models/link_card/card_test.rb
+++ b/test/models/link_card/card_test.rb
@@ -42,5 +42,20 @@ module LinkCard
         assert_includes metadata[:description], 'フィヨルドブートキャンプの顧問、角谷信太郎氏によるプログラミング学習者に向けたトークイベント'
       end
     end
+
+    test '#metadata does not cache failed fetch' do
+      store = ActiveSupport::Cache::MemoryStore.new
+      params = { url: 'https://www.youtube.com/watch?v=8LudKmk7yPM', tweet: nil }
+      card = LinkCard::Card.new(params[:url], params[:tweet])
+      metadata = { title: '角谷トーク2023 本編' }
+      requests = [nil, metadata]
+
+      Rails.stub(:cache, store) do
+        card.stub(:request, -> { requests.shift }) do
+          assert_nil card.metadata
+          assert_equal metadata, card.metadata
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
- LinkCard::Card のメタデータ取得で nil をキャッシュしないようにしました
- 通常メタデータと tweet のキャッシュキーを分けました
- 失敗後の再取得でメタデータを返せることをモデルテストに追加しました

## 確認
- bin/rails test test/models/link_card/card_test.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * リンクカード取得の失敗がキャッシュされないようになりました。メタデータの再取得を確実にします。

* **改善**
  * キャッシュキーの構造を改善し、より適切なメタデータ管理が可能になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26210410222/artifacts/7129312263"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
