### PR TITLE
提出物レビューでGitHubリンク先コードを参照する

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -288,6 +288,7 @@ steps:
       - '--set-env-vars=ROLLBAR_CLIENT_TOKEN=$_ROLLBAR_CLIENT_TOKEN'
       - '--set-env-vars=OPEN_AI_ACCESS_TOKEN=$_OPEN_AI_ACCESS_TOKEN'
       - '--set-env-vars=ANTHROPIC_API_KEY=$_ANTHROPIC_API_KEY'
+      - '--set-env-vars=PJORD_GITHUB_TOKEN=$_PJORD_GITHUB_TOKEN'
       - '--set-env-vars=STRIPE_TAX_RATE_ID=$_STRIPE_TAX_RATE_ID'
       - '--set-env-vars=DISCORD_CLIENT_ID=$_DISCORD_CLIENT_ID'
       - '--set-env-vars=DISCORD_CLIENT_SECRET=$_DISCORD_CLIENT_SECRET'

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -118,6 +118,7 @@ steps:
       - '--set-env-vars=RECAPTCHA_SECRET_KEY=$_RECAPTCHA_SECRET_KEY'
       - '--set-env-vars=ROLLBAR_CLIENT_TOKEN=$_ROLLBAR_CLIENT_TOKEN'
       - '--set-env-vars=OPEN_AI_ACCESS_TOKEN=$_OPEN_AI_ACCESS_TOKEN'
+      - '--set-env-vars=PJORD_GITHUB_TOKEN=$_PJORD_GITHUB_TOKEN'
       - '--set-env-vars=STRIPE_TAX_RATE_ID=$_STRIPE_TAX_RATE_ID'
       - '--set-env-vars=DISCORD_CLIENT_ID=$_DISCORD_CLIENT_ID'
       - '--set-env-vars=DISCORD_CLIENT_SECRET=$_DISCORD_CLIENT_SECRET'

--- a/app/models/product_ai_reviewer.rb
+++ b/app/models/product_ai_reviewer.rb
@@ -43,6 +43,9 @@ class ProductAiReviewer
         ## 提出物
         #{truncate_for_prompt(product.body)}
 
+        ## 提出物内のGitHubリンク先コード
+        #{github_code_links(product)}
+
         ## 同じ提出物に対するコメント
         #{comments(product)}
 
@@ -73,6 +76,20 @@ class ProductAiReviewer
       products.map do |other_product|
         "### #{other_product.user.login_name}さんの提出物\n#{truncate_for_prompt(other_product.body)}"
       end.join("\n\n")
+    end
+
+    def github_code_links(product)
+      entries = ProductAiReviewer::GithubCodeFetcher.fetch(product.body)
+      return 'なし' if entries.blank?
+
+      entries.map do |entry|
+        <<~TEXT
+          ### #{entry[:url]}
+          ```#{entry[:language]}
+          #{entry[:body]}
+          ```
+        TEXT
+      end.join("\n")
     end
 
     def truncate_for_prompt(text)

--- a/app/models/product_ai_reviewer/github_code_fetcher.rb
+++ b/app/models/product_ai_reviewer/github_code_fetcher.rb
@@ -6,6 +6,8 @@ require 'uri'
 class ProductAiReviewer::GithubCodeFetcher
   LINKS_LIMIT = 3
   CONTENT_LIMIT = 20_000
+  OPEN_TIMEOUT = 3
+  READ_TIMEOUT = 5
 
   class << self
     def fetch(text)
@@ -61,7 +63,15 @@ class ProductAiReviewer::GithubCodeFetcher
     def fetch_url(url)
       Rails.cache.fetch("product_ai_reviewer/github_code/#{Digest::SHA256.hexdigest(url)}", expires_in: 10.minutes) do
         uri = URI.parse(url)
-        response = Net::HTTP.get_response(uri, github_request_headers)
+        response = Net::HTTP.start(
+          uri.host,
+          uri.port,
+          use_ssl: uri.scheme == 'https',
+          open_timeout: OPEN_TIMEOUT,
+          read_timeout: READ_TIMEOUT
+        ) do |http|
+          http.get(uri.request_uri, github_request_headers)
+        end
         response.is_a?(Net::HTTPSuccess) ? response.body : nil
       end
     end

--- a/app/models/product_ai_reviewer/github_code_fetcher.rb
+++ b/app/models/product_ai_reviewer/github_code_fetcher.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+
+class ProductAiReviewer::GithubCodeFetcher
+  LINKS_LIMIT = 3
+  CONTENT_LIMIT = 20_000
+
+  class << self
+    def fetch(text)
+      github_urls(text).filter_map do |url|
+        raw_url = raw_github_url(url)
+        next unless raw_url
+
+        body = fetch_url(raw_url)
+        next if body.blank?
+
+        {
+          url: url,
+          language: language_name(url),
+          body: body.slice(0, CONTENT_LIMIT)
+        }
+      rescue StandardError => e
+        Rails.logger.warn("[ProductAiReviewer] GitHub link fetch failed: #{url} #{e.class}: #{e.message}")
+        nil
+      end
+    end
+
+    private
+
+    def github_urls(text)
+      text.to_s.scan(%r{https?://[^\s\])>"']+})
+          .map { |url| url.delete_suffix('.') }
+          .select { |url| github_code_url?(url) }
+          .uniq
+          .first(LINKS_LIMIT)
+    end
+
+    def github_code_url?(url)
+      uri = URI.parse(url)
+      return true if uri.host == 'raw.githubusercontent.com'
+
+      uri.host == 'github.com' && uri.path.include?('/blob/')
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def raw_github_url(url)
+      uri = URI.parse(url)
+      return url if uri.host == 'raw.githubusercontent.com'
+      return unless uri.host == 'github.com'
+
+      match = uri.path.match(%r{\A/([^/]+)/([^/]+)/blob/([^/]+)/(.+)\z})
+      return unless match
+
+      owner, repository, branch, path = match.captures
+      "https://raw.githubusercontent.com/#{owner}/#{repository}/#{branch}/#{path}"
+    end
+
+    def fetch_url(url)
+      Rails.cache.fetch("product_ai_reviewer/github_code/#{Digest::SHA256.hexdigest(url)}", expires_in: 10.minutes) do
+        uri = URI.parse(url)
+        response = Net::HTTP.get_response(uri, github_request_headers)
+        response.is_a?(Net::HTTPSuccess) ? response.body : nil
+      end
+    end
+
+    def github_request_headers
+      headers = { 'User-Agent' => 'fjord-bootcamp-pjord' }
+      headers['Authorization'] = "Bearer #{github_token}" if github_token.present?
+      headers
+    end
+
+    def github_token
+      ENV['PJORD_GITHUB_TOKEN'].presence
+    end
+
+    def language_name(url)
+      extension = File.extname(URI.parse(url).path).delete_prefix('.')
+      extension.presence || 'text'
+    rescue URI::InvalidURIError
+      'text'
+    end
+  end
+end

--- a/test/models/product_ai_reviewer/github_code_fetcher_test.rb
+++ b/test/models/product_ai_reviewer/github_code_fetcher_test.rb
@@ -31,9 +31,21 @@ class ProductAiReviewer::GithubCodeFetcherTest < ActiveSupport::TestCase
   test '.fetch sends Pjord GitHub token when it is configured' do
     github_url = 'https://raw.githubusercontent.com/fjordllc/bootcamp/main/app/models/product.rb'
     response = Net::HTTPSuccess.new('1.1', '200', 'OK')
+    http = Minitest::Mock.new
+    headers = {
+      'User-Agent' => 'fjord-bootcamp-pjord',
+      'Authorization' => 'Bearer token-for-pjord'
+    }
+    http.expect(:get, response, ['/fjordllc/bootcamp/main/app/models/product.rb', headers])
+
     response.stub(:body, 'class Product < ApplicationRecord; end') do
-      Net::HTTP.stub(:get_response, lambda { |_uri, headers|
-        assert_equal 'Bearer token-for-pjord', headers['Authorization']
+      Net::HTTP.stub(:start, lambda { |host, port, options, &block|
+        assert_equal 'raw.githubusercontent.com', host
+        assert_equal 443, port
+        assert options[:use_ssl]
+        assert_equal ProductAiReviewer::GithubCodeFetcher::OPEN_TIMEOUT, options[:open_timeout]
+        assert_equal ProductAiReviewer::GithubCodeFetcher::READ_TIMEOUT, options[:read_timeout]
+        block.call(http)
         response
       }) do
         mock_env('PJORD_GITHUB_TOKEN' => 'token-for-pjord') do
@@ -43,5 +55,7 @@ class ProductAiReviewer::GithubCodeFetcherTest < ActiveSupport::TestCase
         end
       end
     end
+
+    http.verify
   end
 end

--- a/test/models/product_ai_reviewer/github_code_fetcher_test.rb
+++ b/test/models/product_ai_reviewer/github_code_fetcher_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'supports/mock_env_helper'
+
+class ProductAiReviewer::GithubCodeFetcherTest < ActiveSupport::TestCase
+  include MockEnvHelper
+
+  test '.fetch converts GitHub blob links to raw URLs and returns code entries' do
+    github_url = 'https://github.com/fjordllc/bootcamp/blob/main/app/models/product.rb'
+
+    ProductAiReviewer::GithubCodeFetcher.stub(:fetch_url, lambda { |url|
+      assert_equal 'https://raw.githubusercontent.com/fjordllc/bootcamp/main/app/models/product.rb', url
+      'class Product < ApplicationRecord; end'
+    }) do
+      entries = ProductAiReviewer::GithubCodeFetcher.fetch("コード: #{github_url}")
+
+      assert_equal 1, entries.size
+      assert_equal github_url, entries.first[:url]
+      assert_equal 'rb', entries.first[:language]
+      assert_equal 'class Product < ApplicationRecord; end', entries.first[:body]
+    end
+  end
+
+  test '.fetch ignores non-code GitHub links' do
+    ProductAiReviewer::GithubCodeFetcher.stub(:fetch_url, ->(_url) { raise 'should not fetch' }) do
+      assert_empty ProductAiReviewer::GithubCodeFetcher.fetch('https://github.com/fjordllc/bootcamp/issues/1')
+    end
+  end
+
+  test '.fetch sends Pjord GitHub token when it is configured' do
+    github_url = 'https://raw.githubusercontent.com/fjordllc/bootcamp/main/app/models/product.rb'
+    response = Net::HTTPSuccess.new('1.1', '200', 'OK')
+    response.stub(:body, 'class Product < ApplicationRecord; end') do
+      Net::HTTP.stub(:get_response, lambda { |_uri, headers|
+        assert_equal 'Bearer token-for-pjord', headers['Authorization']
+        response
+      }) do
+        mock_env('PJORD_GITHUB_TOKEN' => 'token-for-pjord') do
+          entries = ProductAiReviewer::GithubCodeFetcher.fetch(github_url)
+
+          assert_equal 'class Product < ApplicationRecord; end', entries.first[:body]
+        end
+      end
+    end
+  end
+end

--- a/test/models/product_ai_reviewer_test.rb
+++ b/test/models/product_ai_reviewer_test.rb
@@ -75,4 +75,57 @@ class ProductAiReviewerTest < ActiveSupport::TestCase
     assert_not_includes asked_message, 'a' * (ProductAiReviewer::PROMPT_TEXT_LIMIT + 1)
     mock_chat.verify
   end
+
+  test '.review includes fetched GitHub code linked from product body' do
+    product = products(:product1)
+    github_url = 'https://github.com/fjordllc/bootcamp/blob/main/app/models/product.rb'
+    product.update!(body: "コードはこちらです。\n#{github_url}")
+    mock_content = Struct.new(:content).new({ body: 'レビュー本文' })
+    mock_chat = Minitest::Mock.new
+    asked_message = nil
+
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
+    mock_chat.expect(:ask, mock_content) do |message|
+      asked_message = message
+      true
+    end
+
+    github_code = [{ url: github_url, language: 'rb', body: 'class Product < ApplicationRecord; end' }]
+    ProductAiReviewer::GithubCodeFetcher.stub(:fetch, github_code) do
+      RubyLLM.stub(:chat, mock_chat) do
+        assert_equal 'レビュー本文', ProductAiReviewer.review(product)
+      end
+    end
+
+    assert_includes asked_message, '## 提出物内のGitHubリンク先コード'
+    assert_includes asked_message, "### #{github_url}"
+    assert_includes asked_message, '```rb'
+    assert_includes asked_message, 'class Product < ApplicationRecord; end'
+    mock_chat.verify
+  end
+
+  test '.review ignores non-code GitHub links in product body' do
+    product = products(:product1)
+    product.update!(body: 'https://github.com/fjordllc/bootcamp/issues/1')
+    mock_content = Struct.new(:content).new({ body: 'レビュー本文' })
+    mock_chat = Minitest::Mock.new
+    asked_message = nil
+
+    mock_chat.expect(:with_instructions, mock_chat, [String])
+    mock_chat.expect(:with_schema, mock_chat, [PjordResponse])
+    mock_chat.expect(:ask, mock_content) do |message|
+      asked_message = message
+      true
+    end
+
+    ProductAiReviewer::GithubCodeFetcher.stub(:fetch, []) do
+      RubyLLM.stub(:chat, mock_chat) do
+        assert_equal 'レビュー本文', ProductAiReviewer.review(product)
+      end
+    end
+
+    assert_includes asked_message, "## 提出物内のGitHubリンク先コード\nなし"
+    mock_chat.verify
+  end
 end


### PR DESCRIPTION
## 概要
- ピヨルドの提出物レビュー時に、提出物本文内のGitHubコードリンクを取得してレビュー用プロンプトへ追加します。
- GitHub blob URLをraw URLへ変換し、最大3件まで取得します。
- Cloud Run deploy時に `PJORD_GITHUB_TOKEN` を環境変数として渡す設定をstaging/productionのCloud Buildに追加します。

## 確認
- `SECRET_KEY_BASE=test bin/rails test test/models/product_ai_reviewer_test.rb test/models/product_ai_reviewer/github_code_fetcher_test.rb test/integration/products/review_by_pjord_test.rb`
- `bundle exec rubocop app/models/product_ai_reviewer.rb app/models/product_ai_reviewer/github_code_fetcher.rb test/models/product_ai_reviewer_test.rb test/models/product_ai_reviewer/github_code_fetcher_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI レビューが提出物内の GitHubリンク先コードを最大3件まで自動取得し、「GitHubリンク先コード」セクションとして言語付きコードブロックでプロンプトに含めるようになりました（取得できない場合は「なし」を表示）。

* **Tests**
  * GitHubコード取得とプロンプト組み込みの挙動、および認証トークン利用時の動作を検証するテストを追加しました。

* **Chores**
  * クラウドデプロイ時に渡す環境変数の設定を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26266979964/artifacts/7152419475"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
