### PR TITLE
Ctrl + i キーのショートカットをアイコン(:@自分:)が出るように変更

### DIFF
--- a/app/javascript/shortcut.js
+++ b/app/javascript/shortcut.js
@@ -65,10 +65,10 @@ hotkeys(`${ctrl}+i`, 'input', function (event, handler) {
   const textarea = event.target
   const loginName = textarea.dataset.loginName
   if (!loginName) return
-  const mention = `@${loginName}`
+  const userIconTag = `:@${loginName}: `
   const start = textarea.selectionStart
   const end = textarea.selectionEnd
   textarea.value =
-    textarea.value.slice(0, start) + mention + textarea.value.slice(end)
-  textarea.selectionStart = textarea.selectionEnd = start + mention.length
+    textarea.value.slice(0, start) + userIconTag + textarea.value.slice(end)
+  textarea.selectionStart = textarea.selectionEnd = start + userIconTag.length
 })

--- a/test/system/markdown_test.rb
+++ b/test/system/markdown_test.rb
@@ -140,7 +140,9 @@ class MarkdownTest < ApplicationSystemTestCase
     assert_no_selector '.embed-error'
   end
 
-  test 'When you press Ctrl + i in the report, it will type :@myself:.' do
+  test 'When you press Ctrl + i in the report, it will type the user icon.' do
+    reset_avatar(users(:komagata))
+
     visit_with_auth new_report_path, 'komagata'
     within('form[name=report]') do
       fill_in('report[title]', with: '日報でCtrl + i キーを押すと、:@自分: を入力される。')
@@ -153,11 +155,13 @@ class MarkdownTest < ApplicationSystemTestCase
     end
 
     click_button '提出'
-    assert_text '@komagata'
+    assert_selector 'a.a-user-emoji-link'
     assert_no_selector '.embed-error'
   end
 
-  test 'When you press Ctrl + i in the comments, it will type :@myself:.' do
+  test 'When you press Ctrl + i in the comments, it will type the user icon.' do
+    reset_avatar(users(:komagata))
+
     visit_with_auth "/reports/#{reports(:report1).id}", 'komagata'
     # テストが落ちやすいため、setCheckableが実行されるまで待つ
     within('.page-content-header') do
@@ -168,8 +172,8 @@ class MarkdownTest < ApplicationSystemTestCase
       find('#js-new-comment').send_keys([cmd_ctrl, 'i'])
     end
     find('.a-form-tabs__tab.js-tabs__tab', text: 'プレビュー').click
-    assert_text '@komagata'
+    assert_selector 'a.a-user-emoji-link'
     click_button 'コメントする'
-    assert_text '@komagata'
+    assert_selector 'a.a-user-emoji-link'
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 関連Issue・PR

- #9977
- #9978

## 概要

#9978 のPRで、`@user` とユーザーへのリンクを表示していた箇所を、`:@user:` とユーザーアイコンを表示する形式に変更しました。


## 変更確認方法

1. `fix/ctrl-i-input-self-mention-icon` をローカルに取り込む
2. 開発サーバーを起動
3. http://localhost:3000/ にアクセスし、`kimura` 等でログイン。
4. 日報などのMarkDownエディタ内で `Ctrl` + `i` を入力し、アイコンが表示されるかを確認。 

## Screenshot

### 変更前

<img width="1075" height="439" alt="スクリーンショット 2026-05-08 145409" src="https://github.com/user-attachments/assets/d7c2eb2f-9ae1-4bc6-a9a9-b0a3b165884c" />

<img width="580" height="259" alt="スクリーンショット 2026-05-08 145443" src="https://github.com/user-attachments/assets/7077d401-c4ba-48de-83ca-21039dca4843" />

### 変更後

<img width="912" height="712" alt="スクリーンショット 2026-05-22 103000" src="https://github.com/user-attachments/assets/48a2c2e9-010c-43e3-b1b3-2940f52ed6aa" />

<img width="813" height="401" alt="スクリーンショット 2026-05-22 102655" src="https://github.com/user-attachments/assets/b90e5927-cdae-4f94-bdce-4fdb96d11d0b" />

<!-- I want to review in Japanese. -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26262676804/artifacts/7150923621"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ホットキーでメンション挿入時の文字列形式を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->