### PR TITLE
提出物詳細のSlim-Lint指摘を修正する

### DIFF
--- a/app/decorators/learning_decorator.rb
+++ b/app/decorators/learning_decorator.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module LearningDecorator
+  def completion_modal?
+    should_display_message_automatically?(current_user:)
+  end
+
   def should_display_message_automatically?(current_user:)
     user == current_user && complete? && !completion_message_displayed?
   end

--- a/app/decorators/practice_decorator.rb
+++ b/app/decorators/practice_decorator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PracticeDecorator
+  def submission_answer_button?(viewer)
+    viewer.mentor? && submission && !submission_answer
+  end
+end

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,6 +1,52 @@
 # frozen_string_literal: true
 
 module ProductDecorator
+  delegate :skipped_practices, to: :user
+
+  def meta_description
+    "#{user.long_name}さんが提出した、" \
+      "プラクティス「#{practice.title}」の提出物です。"
+  end
+
+  def after_submission_message?(viewer)
+    user == viewer &&
+      !wip? &&
+      !checked? &&
+      commented_users.mentor.empty?
+  end
+
+  def user_course_practice
+    UserCoursePractice.new(user)
+  end
+
+  def practice_content_toggle_component
+    PracticeContentToggle::PracticeContentToggleComponent.new(
+      content_type: :practice,
+      practice:
+    )
+  end
+
+  def goal_content_toggle_component
+    PracticeContentToggle::PracticeContentToggleComponent.new(
+      content_type: :goal,
+      practice:
+    )
+  end
+
+  def skipped_practice_link(skipped_practice)
+    skipped_practice_id = skipped_practice.practice.id
+    display_practice = user.practices.find_by(id: skipped_practice_id) ||
+                       skipped_practice.practice
+
+    link_to practice_path(skipped_practice_id) do
+      content_tag(
+        :span,
+        display_practice.title,
+        class: 'category-practices-item__title-link-label'
+      )
+    end
+  end
+
   def list_title(resource)
     case resource
     when Practice

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -99,6 +99,14 @@ module UserDecorator
     elapsed_days <= NEW_USER_DAYS ? 'new-user' : ''
   end
 
+  def product_sidebar_class
+    if mentor? || admin?
+      'col-xl-5 col-xs-12 is-hidden-sm-down'
+    else
+      ''
+    end
+  end
+
   def user_icon_frame_class
     classes = ['a-user-role', "is-#{primary_role}"]
     classes << 'is-new-user' if joining_status == 'new-user'

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module ProductsHelper
+  def product_category_practices_link_path(category)
+    course_practices_path(
+      current_user.course,
+      anchor: "category-#{category.id}"
+    )
+  end
+
   def unconfirmed_links_label(target)
     case target
     when 'all' then '全ての提出物を一括で開く'

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -1,11 +1,11 @@
 - title "提出物: #{@product.practice.title}"
-- set_meta_tags description: "#{@product.user.long_name}さんが提出した、プラクティス「#{@product.practice.title}」の提出物です。"
 - category = @product.category(current_user.course)
+- set_meta_tags description: @product.meta_description
 
 = render '/shared/modal_learning_completion',
   practice: @product.practice,
   tweet_url: @tweet_url,
-  should_display_message_automatically: @learning&.should_display_message_automatically?(current_user:)
+  should_display_message_automatically: @learning&.completion_modal?
 
 header.page-header
   .container
@@ -16,9 +16,10 @@ header.page-header
       .page-header__end
         .page-header-actions
           ul.page-header-actions__items
-            - if current_user.mentor? && @practice.submission && !@practice.submission_answer
+            - if @practice.submission_answer_button?(current_user)
               li.page-header-actions__item.is-hidden-sm-down.is-only-mentor
-                = link_to new_mentor_practice_submission_answer_path(@practice), class: 'a-button is-md is-secondary is-block' do
+                = link_to new_mentor_practice_submission_answer_path(@practice),
+                  class: 'a-button is-md is-secondary is-block' do
                   i.fa-regular.fa-plus
                   span
                     | 模範解答作成
@@ -32,19 +33,20 @@ header.page-header
                   span
                     | ピヨルドでレビューコメントをする
             li.page-header-actions__item
-              = link_to course_practices_path(current_user.course, anchor: "category-#{category.id}"),
+              = link_to product_category_practices_link_path(category),
                 class: 'a-button is-md is-secondary is-block is-back' do
                 | プラクティス一覧
             - if current_user.admin?
               li.page-header-actions__item.is-only-mentor
-                = link_to products_unchecked_index_path, class: 'a-button is-md is-secondary is-block is-back' do
+                = link_to products_unchecked_index_path,
+                  class: 'a-button is-md is-secondary is-block is-back' do
                   | 未完了一覧
 
 = practice_page_tabs(@product.practice, active_tab: '提出物')
 
 .page-body
 
-  - if @product.user == current_user && !@product.wip? && !@product.checked? && @product.commented_users.mentor.empty?
+  - if @product.after_submission_message?(current_user)
     = render 'message_for_after_submission'
 
   - if @product.wip? && @product.user == current_user
@@ -61,68 +63,89 @@ header.page-header
             .page-body__row
               = render 'product_header', product: @product
             .page-body__row
-              = render PracticeContentToggle::PracticeContentToggleComponent.new(content_type: :practice, practice: @product.practice)
+              = render @product.practice_content_toggle_component
             .page-body__row
-              = render PracticeContentToggle::PracticeContentToggleComponent.new(content_type: :goal, practice: @product.practice)
+              = render @product.goal_content_toggle_component
             .page-body__row.is-only-mentor
               = render 'practice_memo', practice_id: @practice.id
             .page-body__row
               = render 'product_body', product: @product
 
-        = render 'comments/comments', commentable: @product, commentable_type: 'Product'
+        = render 'comments/comments',
+          commentable: @product,
+          commentable_type: 'Product'
         .user-icons
           ul.user-icons__items
             = render '/footprints/footprints', footprints: @footprints
 
-      .is-only-mentor(class="#{current_user.mentor? || current_user.admin? ? 'col-xl-5 col-xs-12 is-hidden-sm-down' : ''}")
+      .is-only-mentor class=current_user.product_sidebar_class
         - if current_user.mentor? || current_user.admin?
           .side-tabs
-            input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
-            input.a-toggle-checkbox#side-tabs-2 type='radio' name='side-tabs-contents'
-            input.a-toggle-checkbox#side-tabs-3 type='radio' name='side-tabs-contents'
-            input.a-toggle-checkbox#side-tabs-4 type='radio' name='side-tabs-contents'
+            input.a-toggle-checkbox#side-tabs-1(
+              type='radio'
+              name='side-tabs-contents'
+              checked='checked'
+            )
+            input.a-toggle-checkbox#side-tabs-2(
+              type='radio'
+              name='side-tabs-contents'
+            )
+            input.a-toggle-checkbox#side-tabs-3(
+              type='radio'
+              name='side-tabs-contents'
+            )
+            input.a-toggle-checkbox#side-tabs-4(
+              type='radio'
+              name='side-tabs-contents'
+            )
             .side-tabs-nav
               .side-tabs-nav__items
                 .side-tabs-nav__item
-                  label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'
+                  label.side-tabs-nav__item-link#side-tabs-nav-1(
+                    for='side-tabs-1'
+                  )
                     | 直近の日報
                 .side-tabs-nav__item
-                  label.side-tabs-nav__item-link#side-tabs-nav-2 for='side-tabs-2'
+                  label.side-tabs-nav__item-link#side-tabs-nav-2(
+                    for='side-tabs-2'
+                  )
                     | ユーザーメモ
                 .side-tabs-nav__item
-                  label.side-tabs-nav__item-link#side-tabs-nav-3 for='side-tabs-3'
+                  label.side-tabs-nav__item-link#side-tabs-nav-3(
+                    for='side-tabs-3'
+                  )
                     | ユーザー情報
                 .side-tabs-nav__item
-                  label.side-tabs-nav__item-link#side-tabs-nav-4 for='side-tabs-4'
+                  label.side-tabs-nav__item-link#side-tabs-nav-4(
+                    for='side-tabs-4'
+                  )
                     | 提出物
             .side-tabs-contents
               .side-tabs-contents__item#side-tabs-content-1
-                = render partial: 'reports/recent_reports', locals: { header_display: true }
+                = render partial: 'reports/recent_reports',
+                  locals: { header_display: true }
               .side-tabs-contents__item#side-tabs-content-2
                 = render 'users/user_mentor_memo', user_id: @product.user.id
               .side-tabs-contents__item#side-tabs-content-3
                 .a-card
                   .user-data
                     .user-data__row
-                      = render 'users/user_secret_attributes', user: @product.user
+                      = render 'users/user_secret_attributes',
+                        user: @product.user
                     .user-data__row
-                      = render 'users/metas', user: @product.user, user_course_practice: UserCoursePractice.new(@product.user)
-                    ruby:
-                      skipped_practices = @product.user.skipped_practices
-                      user_practices = @product.user.practices
-                    - if skipped_practices.present?
+                      = render 'users/metas',
+                        user: @product.user,
+                        user_course_practice: @product.user_course_practice
+                    - if @product.skipped_practices.present?
                       .user-data__row
                         .user-metas.is-only-mentor
                           h2.user-metas__title
                             | スキップするプラクティス一覧
                           .user-metas__items
-                            - skipped_practices.each do |skipped_practice|
+                            - @product.skipped_practices.each do |skip|
                               .user-metas__item
                                 .user-metas__item-value
-                                  = link_to practice_path(skipped_practice.practice.id) do
-                                    - display_practice = user_practices.find_by(id: skipped_practice.practice.id)
-                                    span.category-practices-item__title-link-label
-                                      = display_practice.title
+                                  = @product.skipped_practice_link(skip)
               .side-tabs-contents__item#side-tabs-content-4
                 = render Products::UserProductsComponent.new(\
                   products: @user_products,

--- a/test/decorators/learning_decorator_test.rb
+++ b/test/decorators/learning_decorator_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_decorator_test_case'
+
+class LearningDecoratorTest < ActiveDecoratorTestCase
+  test '#completion_modal?' do
+    learning = decorate(learnings(:learning16))
+
+    def learning.current_user = user
+
+    assert learning.completion_modal?
+  end
+end

--- a/test/decorators/practice_decorator_test.rb
+++ b/test/decorators/practice_decorator_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_decorator_test_case'
+
+class PracticeDecoratorTest < ActiveDecoratorTestCase
+  test '#submission_answer_button?' do
+    practice = decorate(practices(:practice1))
+    practice.submission_answer = nil
+
+    assert practice.submission_answer_button?(users(:mentormentaro))
+    assert_not practice.submission_answer_button?(users(:kimura))
+  end
+end

--- a/test/decorators/product_decorator_test.rb
+++ b/test/decorators/product_decorator_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'active_decorator_test_case'
+
+class ProductDecoratorTest < ActiveDecoratorTestCase
+  setup do
+    @product = decorate(products(:product8))
+  end
+
+  test '#meta_description' do
+    assert_equal(
+      'kimura (キムラ タダシ)さんが提出した、プラクティス「PC性能の見方を知る」の提出物です。',
+      @product.meta_description
+    )
+  end
+
+  test '#after_submission_message?' do
+    assert @product.after_submission_message?(users(:kimura))
+    assert_not @product.after_submission_message?(users(:komagata))
+  end
+
+  test '#user_course_practice' do
+    assert_instance_of UserCoursePractice, @product.user_course_practice
+    assert_equal users(:kimura), @product.user_course_practice.user
+  end
+end

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -98,4 +98,10 @@ class UserDecoratorTest < ActiveDecoratorTestCase
     assert_equal 'a-user-role is-student is-new-user', new_user.user_icon_frame_class
     assert_equal 'a-user-role is-student', standard_user.user_icon_frame_class
   end
+
+  test '#product_sidebar_class' do
+    assert_equal 'col-xl-5 col-xs-12 is-hidden-sm-down', @mentor_user.product_sidebar_class
+    assert_equal 'col-xl-5 col-xs-12 is-hidden-sm-down', decorate(users(:adminonly)).product_sidebar_class
+    assert_equal '', @student_user.product_sidebar_class
+  end
 end

--- a/test/helpers/products_helper_test.rb
+++ b/test/helpers/products_helper_test.rb
@@ -3,6 +3,17 @@
 require 'test_helper'
 
 class ProductsHelperTest < ActionView::TestCase
+  test '#product_category_practices_link_path' do
+    def current_user = users(:kimura)
+
+    category = products(:product8).category(current_user.course)
+
+    assert_equal(
+      course_practices_path(current_user.course, anchor: "category-#{category.id}"),
+      product_category_practices_link_path(category)
+    )
+  end
+
   test 'unconfirmed_links_label returns correct label for all targets' do
     assert_equal '全ての提出物を一括で開く', unconfirmed_links_label('all')
     assert_equal '未完了の提出物を一括で開く', unconfirmed_links_label('unchecked')


### PR DESCRIPTION
## 概要

- `app/views/products/show.html.slim` の Slim-Lint `LineLength` 指摘を修正
- view 内の `ruby:` ディレクティブを削除し、表示用ロジックを既存の Decorator / Helper に移動
- `ProductShowHelper` は作らず、`ProductDecorator`・`PracticeDecorator`・`LearningDecorator`・`UserDecorator`・`ProductsHelper` に責務ごとに分散
- 追加した Decorator / Helper メソッドに対応するテストを追加
- 表示条件や権限の挙動は変更しない

## 確認

- [x] bundle exec slim-lint app/views/products/show.html.slim
- [x] bundle exec rubocop app/decorators/product_decorator.rb app/decorators/learning_decorator.rb app/decorators/practice_decorator.rb app/decorators/user_decorator.rb app/helpers/products_helper.rb test/decorators/product_decorator_test.rb test/decorators/practice_decorator_test.rb test/decorators/learning_decorator_test.rb test/decorators/user_decorator_test.rb test/helpers/products_helper_test.rb
- [x] bin/rails test test/decorators/product_decorator_test.rb test/decorators/practice_decorator_test.rb test/decorators/learning_decorator_test.rb test/decorators/user_decorator_test.rb test/helpers/products_helper_test.rb
- [x] bin/rails test test/integration/products/review_by_pjord_test.rb
- [x] bin/rails test test/system/products/mentor_test.rb:15 test/system/products/mentor_test.rb:20
- [x] bin/rails test test/system/products_test.rb:57

Refs #10051

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26276840134/artifacts/7156267395"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
