### PR TITLE
YouTubeのリンクカード取得をoEmbedで補完

### DIFF
--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -15,7 +15,9 @@ class Metadata
     http.response_body_encoding = true
 
     response = http.request_get(@uri.request_uri)
-    response.message == 'OK' ? parse(response.body) : nil
+    return fetch_youtube_oembed unless response.is_a?(Net::HTTPSuccess)
+
+    parse(response.body) || fetch_youtube_oembed
   end
 
   private
@@ -52,5 +54,31 @@ class Metadata
     else
       URI.join(@url, favicon_path).to_s
     end
+  end
+
+  def youtube?
+    @uri.host.in?(%w[www.youtube.com youtube.com youtu.be])
+  end
+
+  def fetch_youtube_oembed
+    return unless youtube?
+
+    uri = Addressable::URI.parse('https://www.youtube.com/oembed')
+    uri.query_values = { url: @url, format: 'json' }
+    response = Net::HTTP.get_response(uri.normalize)
+    return unless response.is_a?(Net::HTTPSuccess)
+
+    body = JSON.parse(response.body)
+    {
+      title: body['title'],
+      description: nil,
+      images: body['thumbnail_url'],
+      site_name: 'YouTube',
+      favicon: 'https://www.youtube.com/s/desktop/5af4fee3/img/favicon.ico',
+      url: @url,
+      site_url: 'https://www.youtube.com'
+    }
+  rescue JSON::ParserError
+    nil
   end
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class Metadata
+  NETWORK_ERRORS = [
+    SocketError,
+    Errno::ECONNREFUSED,
+    Errno::ETIMEDOUT,
+    Net::OpenTimeout,
+    Net::ReadTimeout,
+    OpenSSL::SSL::SSLError
+  ].freeze
+
   def initialize(url)
     @url = url
     @uri = Addressable::URI.parse(url).normalize
@@ -18,6 +27,8 @@ class Metadata
     return fetch_youtube_oembed unless response.is_a?(Net::HTTPSuccess)
 
     parse(response.body) || fetch_youtube_oembed
+  rescue *NETWORK_ERRORS
+    nil
   end
 
   private
@@ -78,7 +89,7 @@ class Metadata
       url: @url,
       site_url: 'https://www.youtube.com'
     }
-  rescue JSON::ParserError
+  rescue JSON::ParserError, *NETWORK_ERRORS
     nil
   end
 end

--- a/test/models/metadata_test.rb
+++ b/test/models/metadata_test.rb
@@ -23,4 +23,21 @@ class MetadataTest < ActiveSupport::TestCase
     assert_equal 'YouTube', metadata[:site_name]
     assert_equal 'https://www.youtube.com', metadata[:site_url]
   end
+
+  test '#fetch returns nil when page fetch raises network error' do
+    url = 'https://example.com/'
+    stub_request(:get, url).to_raise(SocketError)
+
+    assert_nil Metadata.new(url).fetch
+  end
+
+  test '#fetch returns nil when YouTube oEmbed raises network error' do
+    url = 'https://www.youtube.com/watch?v=8LudKmk7yPM'
+    stub_request(:get, url).to_return(status: 403, body: 'Forbidden')
+    stub_request(:get, 'https://www.youtube.com/oembed')
+      .with(query: { url:, format: 'json' })
+      .to_raise(Net::OpenTimeout)
+
+    assert_nil Metadata.new(url).fetch
+  end
 end

--- a/test/models/metadata_test.rb
+++ b/test/models/metadata_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MetadataTest < ActiveSupport::TestCase
+  test '#fetch falls back to YouTube oEmbed when YouTube page fetch fails' do
+    url = 'https://www.youtube.com/watch?v=8LudKmk7yPM'
+    stub_request(:get, url).to_return(status: 403, body: 'Forbidden')
+    stub_request(:get, 'https://www.youtube.com/oembed')
+      .with(query: { url:, format: 'json' })
+      .to_return(
+        status: 200,
+        body: {
+          title: '角谷トーク2023 本編',
+          thumbnail_url: 'https://i.ytimg.com/vi/8LudKmk7yPM/hqdefault.jpg'
+        }.to_json
+      )
+
+    metadata = Metadata.new(url).fetch
+
+    assert_equal '角谷トーク2023 本編', metadata[:title]
+    assert_equal 'https://i.ytimg.com/vi/8LudKmk7yPM/hqdefault.jpg', metadata[:images]
+    assert_equal 'YouTube', metadata[:site_name]
+    assert_equal 'https://www.youtube.com', metadata[:site_url]
+  end
+end


### PR DESCRIPTION
## 概要
- YouTubeページのHTML取得またはOGP解析に失敗した場合、YouTube oEmbed APIでリンクカード情報を補完します
- `https://www.youtube.com/watch?v=8LudKmk7yPM` のようなYouTubeリンクでリンクカードが失敗表示になるケースを直接テストしました

## 確認
- `bin/rails test test/models/metadata_test.rb test/models/link_card/card_test.rb`
- `bundle exec rubocop app/models/metadata.rb test/models/metadata_test.rb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * YouTubeコンテンツのメタデータ取得に失敗した場合、代替メタデータソースを使用するフォールバック機能を追加しました。これによりタイトル、サムネイル画像、サイト情報の取得がより確実になります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26276997192/artifacts/7156395475"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
