### PR TITLE
GitHubリンク確認用の提出物seedを追加する

### DIFF
--- a/db/fixtures/products.yml
+++ b/db/fixtures/products.yml
@@ -222,3 +222,16 @@ product81:
   body: 研修終了日が未入力のユーザーの提出物です。
   published_at: <%= now.to_formatted_s(:db) %>
   created_at: <%= now.to_formatted_s(:db) %>
+
+product82:
+  practice: practice27
+  user: kensyu
+  body: |
+    GitHubにコードをpushしました。
+    実装はこちらです。
+
+    https://github.com/fjordllc/bootcamp/blob/main/app/models/product.rb
+
+    ピヨルドのレビューで、リンク先のコードも確認できるかを検証するための提出物です。
+  published_at: <%= now.to_formatted_s(:db) %>
+  created_at: <%= now.to_formatted_s(:db) %>


### PR DESCRIPTION
## 概要
- ステージングでピヨルドのGitHubリンク先コード取得をブラウザ確認しやすいように、GitHub上のコードURLを本文に含む提出物fixtureを追加します。
- 追加提出物は `product82` で、seed後のURLは `/products/39135861` です。

## 確認
- `SECRET_KEY_BASE=test bin/rails test test/models/product_ai_reviewer_test.rb test/models/product_ai_reviewer/github_code_fetcher_test.rb test/integration/products/review_by_pjord_test.rb`
- `bundle exec rubocop app/models/product_ai_reviewer.rb app/models/product_ai_reviewer/github_code_fetcher.rb test/models/product_ai_reviewer_test.rb test/models/product_ai_reviewer/github_code_fetcher_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * データベースフィクスチャに新しい製品データを追加しました。新規追加されたアイテムは関連する学習教材に紐づけられ、説明フィールドにはGitHubリンクとレビュー検証用の詳細情報を含みます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26269220702/artifacts/7153187999"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
