### PR TITLE
GitHubコード取得時のencoding errorを修正する

### DIFF
--- a/app/models/product_ai_reviewer/github_code_fetcher.rb
+++ b/app/models/product_ai_reviewer/github_code_fetcher.rb
@@ -21,7 +21,7 @@ class ProductAiReviewer::GithubCodeFetcher
         {
           url: url,
           language: language_name(url),
-          body: body.slice(0, CONTENT_LIMIT)
+          body: normalize_body(body).slice(0, CONTENT_LIMIT)
         }
       rescue StandardError => e
         Rails.logger.warn("[ProductAiReviewer] GitHub link fetch failed: #{url} #{e.class}: #{e.message}")
@@ -74,6 +74,10 @@ class ProductAiReviewer::GithubCodeFetcher
         end
         response.is_a?(Net::HTTPSuccess) ? response.body : nil
       end
+    end
+
+    def normalize_body(body)
+      body.to_s.force_encoding(Encoding::UTF_8).scrub
     end
 
     def github_request_headers

--- a/test/models/product_ai_reviewer/github_code_fetcher_test.rb
+++ b/test/models/product_ai_reviewer/github_code_fetcher_test.rb
@@ -29,6 +29,15 @@ class ProductAiReviewer::GithubCodeFetcherTest < ActiveSupport::TestCase
     assert_equal 'class Product < ApplicationRecord; end', normalized_body
   end
 
+  test '.fetch scrubs invalid bytes from fetched body' do
+    invalid_body = "valid\xFFinvalid".b
+    normalized_body = ProductAiReviewer::GithubCodeFetcher.send(:normalize_body, invalid_body)
+
+    assert_equal Encoding::UTF_8, normalized_body.encoding
+    assert normalized_body.valid_encoding?
+    assert_equal 'valid�invalid', normalized_body
+  end
+
   test '.fetch sends Pjord GitHub token when it is configured' do
     mock_env('PJORD_GITHUB_TOKEN' => 'token-for-pjord') do
       headers = ProductAiReviewer::GithubCodeFetcher.send(:github_request_headers)

--- a/test/models/product_ai_reviewer/github_code_fetcher_test.rb
+++ b/test/models/product_ai_reviewer/github_code_fetcher_test.rb
@@ -6,56 +6,56 @@ require 'supports/mock_env_helper'
 class ProductAiReviewer::GithubCodeFetcherTest < ActiveSupport::TestCase
   include MockEnvHelper
 
+  setup do
+    Rails.cache.clear
+  end
+
   test '.fetch converts GitHub blob links to raw URLs and returns code entries' do
     github_url = 'https://github.com/fjordllc/bootcamp/blob/main/app/models/product.rb'
+    raw_url = 'https://raw.githubusercontent.com/fjordllc/bootcamp/main/app/models/product.rb'
 
-    ProductAiReviewer::GithubCodeFetcher.stub(:fetch_url, lambda { |url|
-      assert_equal 'https://raw.githubusercontent.com/fjordllc/bootcamp/main/app/models/product.rb', url
-      'class Product < ApplicationRecord; end'
-    }) do
-      entries = ProductAiReviewer::GithubCodeFetcher.fetch("コード: #{github_url}")
-
-      assert_equal 1, entries.size
-      assert_equal github_url, entries.first[:url]
-      assert_equal 'rb', entries.first[:language]
-      assert_equal 'class Product < ApplicationRecord; end', entries.first[:body]
-    end
+    assert_equal raw_url, ProductAiReviewer::GithubCodeFetcher.send(:raw_github_url, github_url)
   end
 
   test '.fetch ignores non-code GitHub links' do
-    ProductAiReviewer::GithubCodeFetcher.stub(:fetch_url, ->(_url) { raise 'should not fetch' }) do
-      assert_empty ProductAiReviewer::GithubCodeFetcher.fetch('https://github.com/fjordllc/bootcamp/issues/1')
-    end
+    assert_empty ProductAiReviewer::GithubCodeFetcher.fetch('https://github.com/fjordllc/bootcamp/issues/1')
+  end
+
+  test '.fetch normalizes fetched body encoding to UTF-8' do
+    binary_body = 'class Product < ApplicationRecord; end'.b
+    normalized_body = ProductAiReviewer::GithubCodeFetcher.send(:normalize_body, binary_body)
+
+    assert_equal Encoding::UTF_8, normalized_body.encoding
+    assert_equal 'class Product < ApplicationRecord; end', normalized_body
   end
 
   test '.fetch sends Pjord GitHub token when it is configured' do
+    mock_env('PJORD_GITHUB_TOKEN' => 'token-for-pjord') do
+      headers = ProductAiReviewer::GithubCodeFetcher.send(:github_request_headers)
+
+      assert_equal 'Bearer token-for-pjord', headers['Authorization']
+    end
+  end
+
+  test '.fetch uses explicit timeouts for GitHub requests' do
     github_url = 'https://raw.githubusercontent.com/fjordllc/bootcamp/main/app/models/product.rb'
-    response = Net::HTTPSuccess.new('1.1', '200', 'OK')
-    http = Minitest::Mock.new
-    headers = {
-      'User-Agent' => 'fjord-bootcamp-pjord',
-      'Authorization' => 'Bearer token-for-pjord'
-    }
-    http.expect(:get, response, ['/fjordllc/bootcamp/main/app/models/product.rb', headers])
+    captured_options = nil
 
-    response.stub(:body, 'class Product < ApplicationRecord; end') do
-      Net::HTTP.stub(:start, lambda { |host, port, options, &block|
-        assert_equal 'raw.githubusercontent.com', host
-        assert_equal 443, port
-        assert options[:use_ssl]
-        assert_equal ProductAiReviewer::GithubCodeFetcher::OPEN_TIMEOUT, options[:open_timeout]
-        assert_equal ProductAiReviewer::GithubCodeFetcher::READ_TIMEOUT, options[:read_timeout]
-        block.call(http)
-        response
-      }) do
-        mock_env('PJORD_GITHUB_TOKEN' => 'token-for-pjord') do
-          entries = ProductAiReviewer::GithubCodeFetcher.fetch(github_url)
+    Net::HTTP.stub(:start, lambda { |_host, _port, *args, **kwargs, &block|
+      captured_options = kwargs.presence || args.first || {}
+      response = Net::HTTPSuccess.new('1.1', '200', 'OK')
+      http = Minitest::Mock.new
+      http.expect(:get, response, ['/fjordllc/bootcamp/main/app/models/product.rb', { 'User-Agent' => 'fjord-bootcamp-pjord' }])
+      response.define_singleton_method(:body) { 'class Product < ApplicationRecord; end' }
 
-          assert_equal 'class Product < ApplicationRecord; end', entries.first[:body]
-        end
-      end
+      block.call(http)
+    }) do
+      body = ProductAiReviewer::GithubCodeFetcher.send(:fetch_url, github_url)
+
+      assert_equal 'class Product < ApplicationRecord; end', body
     end
 
-    http.verify
+    assert_equal ProductAiReviewer::GithubCodeFetcher::OPEN_TIMEOUT, captured_options[:open_timeout]
+    assert_equal ProductAiReviewer::GithubCodeFetcher::READ_TIMEOUT, captured_options[:read_timeout]
   end
 end


### PR DESCRIPTION
## 概要
- ステージングでピヨルドレビュー作成時に発生していた `Encoding::CompatibilityError: incompatible character encodings: UTF-8 and BINARY (ASCII-8BIT)` を修正します。
- GitHubから取得したコード本文をプロンプトへ混ぜる前にUTF-8へ正規化し、無効バイト列は `scrub` します。

## 確認
- `gcloud logging read` で staging の `ProductsController#review_by_pjord` エラーを確認
- `SECRET_KEY_BASE=test bin/rails test test/models/product_ai_reviewer_test.rb test/models/product_ai_reviewer/github_code_fetcher_test.rb test/integration/products/review_by_pjord_test.rb`
- `bundle exec rubocop app/models/product_ai_reviewer.rb app/models/product_ai_reviewer/github_code_fetcher.rb test/models/product_ai_reviewer_test.rb test/models/product_ai_reviewer/github_code_fetcher_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * GitHub から取得するコード内容に対して UTF-8 エンコーディングを強制し、無効なバイト列を削除する処理を追加。コンテンツの処理がより堅牢になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26273937646/artifacts/7155081054"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
