### PR TITLE
Review App cleanupのsubstitutionsを修正

### DIFF
--- a/.github/workflows/review-app-cleanup.yml
+++ b/.github/workflows/review-app-cleanup.yml
@@ -31,11 +31,7 @@ jobs:
         run: |
           gcloud builds submit \
             --config=.cloudbuild/cloudbuild-review-cleanup.yaml \
-            --substitutions="\
-              _PR_NUMBER=${PR_NUMBER},\
-              _CLOUD_SQL_HOST=bootcamp-224405:asia-northeast1:bootcamp,\
-              _DB_USER=review,\
-              _DB_PASS=${{ secrets.REVIEW_DB_PASS }}" \
+            --substitutions="_PR_NUMBER=${PR_NUMBER},_CLOUD_SQL_HOST=bootcamp-224405:asia-northeast1:bootcamp,_DB_USER=review,_DB_PASS=${{ secrets.REVIEW_DB_PASS }}" \
             --project=bootcamp-224405 \
             --region=asia-northeast1 \
             --no-source \


### PR DESCRIPTION
## 概要
- Review App cleanup workflow の `gcloud builds submit --substitutions` を1行にし、改行インデントが substitution key に混入しないようにします
- cleanup 実行時の `INVALID_ARGUMENT: key "    _PR_NUMBER" ... is not matched in the template` を防ぎます

## 確認
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/review-app-cleanup.yml"); puts "yaml ok"'`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チア**
  * CI/CDワークフローの内部実装を最適化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26282192069/artifacts/7158442165"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
