### PR TITLE
Update flakewatch action to v0.6.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,18 @@ jobs:
           pkg-manager: npm
       - run:
           name: Install Playwright browser
-          command: npx playwright install --with-deps chromium
+          command: |
+            for attempt in 1 2 3; do
+              if npx playwright install --with-deps chromium; then
+                exit 0
+              fi
+
+              sudo rm -rf /var/lib/apt/lists/*
+              sudo apt-get clean
+              sleep "$((attempt * 10))"
+            done
+
+            npx playwright install --with-deps chromium
       - run:
           name: Install japanese font
           command: sudo apt-get install -y fonts-noto-cjk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.9
+        uses: komagata/flakewatch@v0.6.10
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.8
+        uses: komagata/flakewatch@v0.6.9
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.11
+        uses: komagata/flakewatch@v0.6.12
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.12
+        uses: komagata/flakewatch@v0.6.14
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.7
+        uses: komagata/flakewatch@v0.6.8
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,18 @@ jobs:
           done
 
       - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if npx playwright install --with-deps chromium; then
+              exit 0
+            fi
+
+            sudo rm -rf /var/lib/apt/lists/*
+            sudo apt-get clean
+            sleep "$((attempt * 10))"
+          done
+
+          npx playwright install --with-deps chromium
 
       - name: Enable pgvector extension
         run: psql -h localhost -U postgres -d ci_test -c "CREATE EXTENSION IF NOT EXISTS vector;"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.14
+        uses: komagata/flakewatch@v0.6.15
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.5
+        uses: komagata/flakewatch@v0.6.7
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.10
+        uses: komagata/flakewatch@v0.6.11
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."


### PR DESCRIPTION
## Summary
- Update the Flakewatch GitHub Action from v0.6.5 to v0.6.7.
- v0.6.7 reads single-quoted JUnit XML attributes, so minitest-ci durations are included in slow test rankings.

## Test
- Not run locally; GitHub Actions workflow reference only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CIのブラウザ導入手順を失敗時に最大3回リトライするように変更し、各試行でキャッシュ削除と待機を挟むことでインストールの安定性を向上させました。
  * flakewatchアクションを v0.6.5 → v0.6.10 に更新しました。これにより自動生成されるflakeレポートの信頼性が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10081-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26415202556/artifacts/7203578283" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
