### PR TITLE
箇条書きが正しく表示されるようCSSを修正

### DIFF
--- a/app/assets/stylesheets/atoms/_a-long-text.css
+++ b/app/assets/stylesheets/atoms/_a-long-text.css
@@ -159,12 +159,6 @@
 .a-long-text ol.is-aiu {
   list-style: katakana;
 }
-.a-long-text > ul {
-  list-style-type: disc;
-}
-.a-long-text > ol {
-  list-style-type: decimal;
-}
 .a-long-text li ul,
 .a-long-text li ol {
   margin-block: 0.375em;
@@ -176,12 +170,6 @@
 .a-long-text li ul:last-child,
 .a-long-text li ol:last-child {
   margin-bottom: 0.375em;
-}
-.a-long-text li > ul {
-  list-style-type: circle;
-}
-.a-long-text li > ul > li > ul {
-  list-style-type: square;
 }
 .a-long-text .speak.is-mc {
   font-weight: 700;
@@ -298,18 +286,29 @@
 .a-long-text .message.success::before {
   color: var(--success);
 }
-.a-long-text ul.contains-task-list {
-  list-style: none;
-  margin-left: 0;
+.a-long-text > ul,
+.a-long-text details > ul,
+.a-long-text div > ul,
+.a-long-text blockquote > ul {
+  list-style-type: disc;
 }
-.a-long-text li.task-list-item {
-  position: relative;
-  padding-left: 1.375em;
+.a-long-text > ol,
+.a-long-text details > ol,
+.a-long-text div > ol,
+.a-long-text blockquote > ol {
+  list-style-type: decimal;
 }
-.a-long-text li.task-list-item .task-list-item-checkbox {
-  left: 0;
-  position: absolute;
-  top: 0.5em;
+.a-long-text ul ul {
+  list-style-type: circle;
+}
+.a-long-text ul ul ul {
+  list-style-type: square;
+}
+.a-long-text li.task-list-item:has(input[type="checkbox"]) {
+  list-style-type: none;
+}
+.a-long-text li.task-list-item input[type="checkbox"] {
+  margin-left: -1.3rem;
 }
 .a-long-text p {
   font-size: 1em;
@@ -486,12 +485,6 @@
 .a-long-text div ol.is-aiu {
   list-style: katakana;
 }
-.a-long-text div > ul {
-  list-style-type: disc;
-}
-.a-long-text div > ol {
-  list-style-type: decimal;
-}
 .a-long-text div li ul,
 .a-long-text div li ol {
   margin-block: 0.375em;
@@ -503,12 +496,6 @@
 .a-long-text div li ul:last-child,
 .a-long-text div li ol:last-child {
   margin-bottom: 0.375em;
-}
-.a-long-text div li > ul {
-  list-style-type: circle;
-}
-.a-long-text div li > ul > li > ul {
-  list-style-type: square;
 }
 .a-long-text blockquote {
   padding-left: 1.5em;

--- a/app/assets/stylesheets/atoms/_a-long-text.css
+++ b/app/assets/stylesheets/atoms/_a-long-text.css
@@ -308,7 +308,7 @@
   list-style-type: none;
 }
 .a-long-text li.task-list-item input[type="checkbox"] {
-  margin-left: -1.3rem;
+  margin-left: -1.4em;
 }
 .a-long-text p {
   font-size: 1em;


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9988

## 概要

Markdownエディタ内で、以下条件の時に1つ目の箇条書き「・」が表示されない問題を修正しました。

- 前後にチェックボックスがある状態
- 折りたたみ要素で囲まれている状態

調査したところ、以下2点が原因でした。

- `.a-long-text ul.contains-task-list` に `list-style: none;` が指定されていた点
   - `<ul class="contains-task-list">` はチェックボックス専用のクラスではないため、通常の箇条書きにも `list-style: none;` が適用されてしまう。
https://github.com/fjordllc/bootcamp/blob/82ed31538dc5bcba1ea5b60a23743827c7aa3603/app/assets/stylesheets/atoms/_a-long-text.css#L301-L304
- `.a-long-text > ul` に `list-style-type: disc;` が指定されていた点
   - details の中は、.a-long-text の直下ではないため、反応しなくなってしまう。
https://github.com/fjordllc/bootcamp/blob/82ed31538dc5bcba1ea5b60a23743827c7aa3603/app/assets/stylesheets/atoms/_a-long-text.css#L162-L164

## 変更確認方法

1. `bug/markdown-details-list`をローカルに取り込む
2. 開発サーバーを起動
3. [http://localhost:3000/](http://localhost:3000/) にアクセスし、`kensyu` 等受講生としてログイン。
4. [日報を新規に作成](http://localhost:3000/reports/new) し、以下を入力して登録する。全て正しく表示されるか確認する。

```md
:::details 折りたたみ要素

- test
   - test
      - test

:::

:::details 折りたたみ要素
- [ ] test
- test
   - test
      - test

:::

- [ ] test
- test
   - test
      - test

---

- test
   - test
      - test
- [ ] test

---

- test
   - test
      - test

```

## Screenshot

### 変更前

<img width="493" height="935" alt="スクリーンショット 2026-05-26 141824" src="https://github.com/user-attachments/assets/b3e1ba12-5f6f-44a1-9eec-0c8cea8ab9ad" />

### 変更後

<img width="491" height="929" alt="スクリーンショット 2026-05-26 141857" src="https://github.com/user-attachments/assets/cc3c0c54-eaa9-496f-881a-6c5bbb353d79" />

<!-- I want to review in Japanese. -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27005416782/artifacts/7433018548" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10082-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * リスト表示を整理・統一しました。本文・details・blockquote等でul/olのマーカーを統一し、ネスト深度に応じて disc→circle→square と段階的に表示されます。タスクリストはマーカーを非表示にし、チェックボックス位置を調整して見た目を一貫化。旧来の個別レイアウト指定を削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
