### PR TITLE
定期イベントの次回開催日算出処理を見直し、表示速度を改善した

### DIFF
--- a/app/decorators/regular_event_decorator.rb
+++ b/app/decorators/regular_event_decorator.rb
@@ -12,12 +12,16 @@ module RegularEventDecorator
   def next_holding_date
     if finished
       '開催終了'
-    elsif next_event_date.nil?
-      '次回の開催日は未定です'
-    elsif next_event_date == Time.zone.today
-      '本日開催'
     else
-      "次回の開催日は #{l next_event_date} です"
+      date = next_event_date
+
+      if date.nil?
+        '次回の開催日は未定です'
+      elsif date == Time.zone.today
+        '本日開催'
+      else
+        "次回の開催日は #{l date} です"
+      end
     end
   end
 

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -102,7 +102,19 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def next_event_date
-    upcoming_scheduled_dates.reject { |date| skip_event?(date) }.min
+    now = Time.zone.now
+    today = Time.zone.today
+
+    # all_scheduled_dates は実行日から1年分の開催日を取得している(昇順でソート済み)
+    all_scheduled_dates.find do |date|
+      # 開催日が今日の場合、開始時間を過ぎているか判定する
+      if date == today
+        event_start_at = date.in_time_zone.change(hour: start_at.hour, min: start_at.min)
+        next false if now > event_start_at
+      end
+
+      !skip_event?(date)
+    end
   end
 
   def organizers
@@ -203,13 +215,6 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
     return unless diff <= 0
 
     errors.add(:end_at, ': イベント終了時刻はイベント開始時刻よりも後の時刻にしてください。')
-  end
-
-  def upcoming_scheduled_dates
-    # 時刻が過ぎたイベントを排除するためだけに、一時的にstart_timeを与える。後でDate型に戻す。
-    event_dates_with_start_time = all_scheduled_dates.map { |d| d.in_time_zone.change(hour: start_at.hour, min: start_at.min) }
-
-    event_dates_with_start_time.reject { |d| d < Time.zone.now }.map(&:to_date)
   end
 
   def nth_wday(date)

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -94,6 +94,22 @@ class RegularEventTest < ActiveSupport::TestCase
     end
   end
 
+  test '#next_event_date returns today if today is one of the holding days and start time has NOT passed' do
+    regular_event = regular_events(:regular_event29) # 土日の9~10時に開催
+
+    travel_to Time.zone.local(2026, 5, 23, 8, 0, 0) do
+      assert_equal Date.new(2026, 5, 23), regular_event.next_event_date
+    end
+  end
+
+  test '#next_event_date returns next holding day within the same week if today is one of the holding days and start time HAS passed' do
+    regular_event = regular_events(:regular_event29) # 土日の9~10時に開催
+
+    travel_to Time.zone.local(2026, 5, 23, 12, 0, 0) do
+      assert_equal Date.new(2026, 5, 24), regular_event.next_event_date
+    end
+  end
+
   test '#cancel_participation' do
     regular_event = regular_events(:regular_event1)
     participant = regular_event_participations(:regular_event_participation1).user


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue・PR

- Issue番号
    - #9332 
- PR
    - #9879
## 概要
- 定期イベント画面の表示が遅くなっていたため、ボトルネックを計測して修正した

### 遅くなっていた原因
- 次回開催日を求める処理(`next_event_date` )でSQLが多く発行されていた
- `next_event_date` では今日から1年後までの開催候補日に対して`skip_event?` を呼ぶ
  - `skip_event?` 内の `exists?` により、候補日ごとにSQLが発行される
  - 週1開催なら約52回、毎日開催なら最大約365回SQLが発行される

- さらに `next_holding_date` で `next_event_date` をelseifの分岐にて最大3回呼んでいた
  - 毎日開催の場合は最大で約365 × 3 = 1095回のクエリが発行されており、ページの表示速度に影響が出ていた

- WIP状態や終了済みイベントでは `next_event_date` が呼ばれないため、表示は遅くなっていなかった

## 対応方法
- `next_holding_date` で `next_event_date` を1回だけ呼び、結果を変数に入れて使うようにした
- `next_event_date` で次回開催日を取得する際に`開催しない日付をreject + その中からminで最小値を取得` していたが、`find`を使い次回開催日が見つかった時点で処理を終了するようにした
    - 併せて全ての開催候補日に開始時刻を付与していた処理(`upcoming_scheduled_dates `)を削除し、開催日が今日の場合のみ開始時間を過ぎているか判定するようにした

## 計測
- 以下のメソッドで`next_holding_date`と`next_event_date`を囲ってクエリ数と秒数を計測

```rb
def measure_performance(label)
  sql_count = 0

  callback = lambda do |_name, _started, _finished, _unique_id, payload|
    sql = payload[:sql] #実行されたSQL文を取り出す

    next if payload[:name] == "SCHEMA" #数えなくていいSQLを除外
    next if sql.match?(/\A(?:BEGIN|COMMIT|ROLLBACK)/)

    sql_count += 1
  end

  time = Benchmark.realtime do # 処理にかかった時間を測る
    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do # sql.active_record は、ActiveRecordがSQLを実行したときに発生する
      yield
    end
  end

      Rails.logger.info("[#{label}] time=#{format('%.6f', time)}s sql_count=#{sql_count}")
end
```

### 変更前と変更後の比較

#### 通常ケース
- 次回開催日が早い段階で見つかるケースでは、`find` によって処理を早期終了できるためSQL発行回数が大きく減った
    - 毎日開催のイベントに関してはSQLが1000以上削減した

| 条件 | メソッド | 変更前 | 変更後 |
|---|---|---:|---:|
| 開催ルールが1つ（毎週日曜日開催） | `next_holding_date` | `0.085064s / 156 SQL` | `0.006632s / 1 SQL` |
| 開催ルールが1つ（毎週日曜日開催） | `next_event_date` | `0.024723s / 52 SQL` | `0.005825s / 1 SQL` |
| 開催ルールが7つ（毎日開催） | `next_holding_date` | `1.480489s / 1098 SQL` | `0.004169s / 1 SQL` |
| 開催ルールが7つ（毎日開催） | `next_event_date` | `0.763048s / 366 SQL` | `0.004059s / 1 SQL` |

#### 最も時間がかかるケース
- 1年分のスキップ日が登録されており、次回開催日が見つかるまで1年分の日付を確認するケース
    - このケースでは、変更後も1年分の日付に対して `skip_event?` が呼ばれるため`next_event_date` 単体のSQL発行回数は大きく変わらない(1秒未満のため画面表示に影響はないレベル)
    - `next_holding_date` で `next_event_date` を複数回呼ばなくなったため、SQL発行回数は1098回から366回に減った

| メソッド | 変更前 | 変更後 |
|---|---:|---:|
| `next_event_date` | `0.402988s / 366 SQL` | `0.457944s / 366 SQL` |
| `next_holding_date` | `1.520662s / 1098 SQL` | `0.458335s / 366 SQL` |


## 変更確認方法

1. `fix/optimize-regular-event-next-date`をローカルに取り込む
2. Railsサーバーを起動する
3. 定期イベント詳細画面を開く
4. 開発ログで処理時間とSQL発行回数を確認する
5. 表示文言が想定通りになっていることを確認する
- [x] 通常の定期イベント画面が表示できること
- [x] 今日が開催日かつ開始時間前の場合、「本日開催」と表示されること
- [x] 今日が開催日かつ開始時間後の場合、次の開催日が表示されること
- [x] スキップ日が設定されている場合、その日を飛ばして次の開催日が表示されること
- [x] WIP状態のイベント画面が表示できること
- [x] 終了済みイベントでは「開催終了」と表示されること

## ScreenShot
###  画面上での計測
#### 開催中の場合
##### 開催ルールが1つの場合（毎週日曜日開催）
###### 変更前
- ページを開くのに1秒ほどかかっていた
<img width="1582" height="326" alt="スクリーンショット 2026-05-27 1 17 35" src="https://github.com/user-attachments/assets/dcd0335e-a20a-49e1-bfdf-42ccd04f3b31" />

###### 変更後
- 1秒未満で開く
<img width="1578" height="388" alt="スクリーンショット 2026-05-27 1 17 06" src="https://github.com/user-attachments/assets/07a08108-46d4-47ab-b1f3-e81298321954" />



##### 開催ルールが7つの場合（毎日開催）
###### 変更前
- ページを開くのに2秒弱かかっていた
<img width="1582" height="378" alt="スクリーンショット 2026-05-27 1 15 10" src="https://github.com/user-attachments/assets/2a4d6260-9f11-427a-b540-7d3b3abfe0dc" />

###### 変更後
- 1秒未満で開く
<img width="1580" height="382" alt="スクリーンショット 2026-05-27 1 15 48" src="https://github.com/user-attachments/assets/930d83d4-7b2f-4056-b3dc-da0f45e56d90" />


- イベント終了済みの場合
<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **Bug Fixes**
  * 次回イベント開催日の計算ロジックを改善し、当日判定と開始時刻経過判定の精度を向上させました。

* **Tests**
  * 開催日判定に関するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10085?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10085-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->