### PR TITLE
ピヨルドが日報に必ずリアクションするように修正

### DIFF
--- a/app/jobs/pjord_report_comment_job.rb
+++ b/app/jobs/pjord_report_comment_job.rb
@@ -25,11 +25,9 @@ class PjordReportCommentJob < ApplicationJob
   private
 
   def add_eyes_reaction(pjord, report)
-    begin
-      Reaction.find_or_create_by!(user: pjord, reactionable: report, kind: :eyes)
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
-      Rails.logger.error("[PjordReportCommentJob] reaction failed: #{e.class}: #{e.message}")
-    end
+    Reaction.find_or_create_by!(user: pjord, reactionable: report, kind: :eyes)
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+    Rails.logger.error("[PjordReportCommentJob] reaction failed: #{e.class}: #{e.message}")
   end
 
   def classify(report)

--- a/app/jobs/pjord_report_comment_job.rb
+++ b/app/jobs/pjord_report_comment_job.rb
@@ -11,6 +11,8 @@ class PjordReportCommentJob < ApplicationJob
     pjord = Pjord.user
     return if pjord.nil?
 
+    add_eyes_reaction(pjord, report)
+
     intent = classify(report)
     return if intent == 'none'
 
@@ -18,15 +20,17 @@ class PjordReportCommentJob < ApplicationJob
     return if response.blank?
 
     Comment.create!(user: pjord, commentable: report, description: response)
+  end
 
+  private
+
+  def add_eyes_reaction(pjord, report)
     begin
       Reaction.find_or_create_by!(user: pjord, reactionable: report, kind: :eyes)
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
       Rails.logger.error("[PjordReportCommentJob] reaction failed: #{e.class}: #{e.message}")
     end
   end
-
-  private
 
   def classify(report)
     result = Pjord::ReportClassifierAgent.classify(report)

--- a/test/jobs/pjord_report_comment_job_test.rb
+++ b/test/jobs/pjord_report_comment_job_test.rb
@@ -81,9 +81,23 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'does not create a comment or reaction when intent is none' do
+  test 'creates only an eyes reaction when intent is none' do
     report = reports(:report1)
     pjord = users(:pjord)
+
+    Pjord::ReportClassifierAgent.stub(:classify, { intent: 'none', reason: '通常の学習記録' }) do
+      assert_difference -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count }, 1 do
+        assert_no_difference 'Comment.count' do
+          PjordReportCommentJob.perform_now(report_id: report.id)
+        end
+      end
+    end
+  end
+
+  test 'does not duplicate eyes reaction when intent is none' do
+    report = reports(:report1)
+    pjord = users(:pjord)
+    Reaction.create!(user: pjord, reactionable: report, kind: :eyes)
 
     Pjord::ReportClassifierAgent.stub(:classify, { intent: 'none', reason: '通常の学習記録' }) do
       assert_no_difference ['Comment.count',
@@ -93,14 +107,15 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'does not create a comment or reaction when classification returns nil' do
+  test 'creates only an eyes reaction when classification returns nil' do
     report = reports(:report1)
     pjord = users(:pjord)
 
     Pjord::ReportClassifierAgent.stub(:classify, nil) do
-      assert_no_difference ['Comment.count',
-                            -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count }] do
-        PjordReportCommentJob.perform_now(report_id: report.id)
+      assert_difference -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count }, 1 do
+        assert_no_difference 'Comment.count' do
+          PjordReportCommentJob.perform_now(report_id: report.id)
+        end
       end
     end
   end
@@ -142,15 +157,16 @@ class PjordReportCommentJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'does not create a comment or reaction when response is blank' do
+  test 'creates only an eyes reaction when response is blank' do
     report = reports(:report1)
     pjord = users(:pjord)
 
     Pjord::ReportClassifierAgent.stub(:classify, { intent: 'question', reason: '質問あり' }) do
       Pjord::ReportCommentAgent.stub(:comment, nil) do
-        assert_no_difference ['Comment.count',
-                              -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count }] do
-          PjordReportCommentJob.perform_now(report_id: report.id)
+        assert_difference -> { Reaction.where(user: pjord, reactionable: report, kind: :eyes).count }, 1 do
+          assert_no_difference 'Comment.count' do
+            PjordReportCommentJob.perform_now(report_id: report.id)
+          end
         end
       end
     end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- なし（報告: https://bootcamp.fjord.jp/reports/124471）

## 概要

- ピヨルドの日報コメントジョブで、コメント生成前に必ず 👀 リアクションを作成するようにしました。
- コメント不要判定、分類結果なし、コメント生成結果が空の場合でも、リアクションだけは残るようにしました。
- 既存の 👀 リアクションがある場合は重複作成しないことをテストしました。

## 変更確認方法

1. `codex/pjord-report-eyes-reaction` をローカルに取り込む
2. `mise exec -- bin/rails test test/jobs/pjord_report_comment_job_test.rb` を実行する

## Screenshot

### 変更前

なし（ジョブの挙動変更のため）

### 変更後

なし（ジョブの挙動変更のため）

<!-- I want to review in Japanese. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * コメントの生成が行われない場合でも、目玉（eyes）リアクションが確実に付与されるよう挙動を変更しました。例外発生時のログ出力は維持します。

* **Tests**
  * 分類や応答が無効な場合に「目玉リアクションのみが作成され、コメントは作成されない」ことを検証するようテストを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjordllc/bootcamp/pull/10086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26497611230/artifacts/7234814450" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
