### PR TITLE
Update flakewatch action to v0.6.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.15
+        uses: komagata/flakewatch@v0.6.16
         with:
           junit: "test/reports/**/*.xml"
           source-root: "."


### PR DESCRIPTION
## Summary
- Update the Flakewatch GitHub Action from v0.6.15 to v0.6.16.
- Use the release that supports matrix JUnit artifact fan-in and stable report ordering.

## Test
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`\n\n## Rollback\n- Revert `.github/workflows/ci.yml` to `komagata/flakewatch@v0.6.15` if the Flakewatch report job regresses.

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10088-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->