### PR TITLE
トップページに卒業生の就職先企業セクションを追加

### DIFF
--- a/app/assets/stylesheets/lp.css
+++ b/app/assets/stylesheets/lp.css
@@ -36,6 +36,7 @@
 @import "./lp/blocks/lp/_lp-price.css";
 @import "./lp/blocks/lp/_lp-actions.css";
 @import "./lp/blocks/lp/_lp-company-logos.css";
+@import "./lp/blocks/lp/_lp-company-names.css";
 @import "./lp/blocks/lp/_lp-movie.css";
 @import "./lp/blocks/lp/_lp-practices-table.css";
 @import "./lp/blocks/lp/_lp-table.css";

--- a/app/assets/stylesheets/lp/blocks/lp/_lp-company-names.css
+++ b/app/assets/stylesheets/lp/blocks/lp/_lp-company-names.css
@@ -1,0 +1,15 @@
+.a-short-text > .lp-company-names {
+  display: inline;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.lp-company-names li {
+  display: inline;
+}
+.lp-company-names li::after {
+  content: "、";
+}
+.lp-company-names li:last-child::after {
+  content: "";
+}

--- a/app/views/welcome/_alumni_companies.html.slim
+++ b/app/views/welcome/_alumni_companies.html.slim
@@ -1,0 +1,81 @@
+section.lp-content.is-lp-bg-1.is-top-title
+  .l-container.is-xl
+    .lp-content__inner
+      .lp-content__start
+        header.lp-content__header
+          h2.lp-content-title.text-center.is-border-bottom
+            | 卒業生の就職先企業の一部
+      .lp-content__end
+        .lp-content-stack
+          .lp-content-stack__item
+            section.lp-content-section
+              h3.lp-content-sub-title.text-center
+                | カンファレンスでよく見る
+                br
+                | あの企業に多くの卒業生が就職しています
+              .lp-content__description
+                .l-inner-container.is-md
+                  .a-short-text
+                    p
+                      | これはほんの一部だけですが、
+                      | 受託開発、自社サービス、スタートアップ、上場企業など
+                      | 様々な企業に卒業生が就職しています。
+                      | 有名なOSSの開発者や、カンファレンスの常連登壇者が所属していたり、
+                      | カンファレンスのスポンサーをよくやっている、
+                      | ソフトウェアエンジニア業界で有名な企業に就職している人が多いのが
+                      | FBCの特徴です。
+          .lp-content-stack__item
+            .lp-company-logos
+              .lp-company-logos__item
+                = link_to 'https://www.pixiv.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/pixiv.svg', alt: 'ピクシブ株式会社')
+              .lp-company-logos__item
+                = link_to 'https://pepabo.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/gmo-pepabo.svg', alt: 'GMOペパボ株式会社')
+              //
+                .lp-company-logos__item
+                  = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                    = image_tag('company_logos/persol.svg', alt: '株式会社パーソルキャリア')
+              .lp-company-logos__item
+                = link_to 'https://esm.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/esm.svg', alt: '株式会社永和システムマネジメント')
+              .lp-company-logos__item
+                = link_to 'https://www.luxiar.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/luxiar.svg', alt: '株式会社ラグザイア')
+              .lp-company-logos__item
+                = link_to 'https://everyleaf.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/everyleaf.svg', alt: '株式会社万葉')
+              .lp-company-logos__item
+                = link_to 'https://sikmi.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/sikmi.svg', alt: 'しくみ製作所株式会社')
+              .lp-company-logos__item
+                = link_to 'https://www.enishi-tech.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/enishi.svg', alt: '株式会社えにしテック')
+              .lp-company-logos__item
+                = link_to 'https://tebiki.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/tebiki.svg', alt: 'Tebiki株式会社')
+              .lp-company-logos__item
+                = link_to 'https://catal.jp/company/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/catal.svg', alt: '株式会社キャタル')
+              .lp-company-logos__item
+                = link_to 'https://wyrd.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/wyrd.svg', alt: '株式会社ウィルド')
+              .lp-company-logos__item
+                = link_to 'https://www.ruby-dev.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/ruby-dev.svg', alt: '株式会社Ruby開発')
+              .lp-company-logos__item
+                = link_to 'https://www.netlab.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                  = image_tag('company_logos/nacl.svg', alt: '株式会社ネットワーク応用通信研究所')
+              //
+                .lp-company-logos__item
+                  = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
+                    = image_tag('company_logos/actindi.svg', alt: 'アクトインディ株式会社')
+          .lp-content-stack__item
+            = render 'welcome/company_names'
+          - if local_assigns[:show_job_support_link]
+            .lp-content-stack__item
+              .lp-actions
+                .lp-actions__items
+                  .lp-actions__item
+                    = link_to job_support_path, class: 'a-button is-xl is-primary-border is-block' do
+                      | FBCの就職支援

--- a/app/views/welcome/_company_names.html.slim
+++ b/app/views/welcome/_company_names.html.slim
@@ -1,0 +1,37 @@
+section.lp-content-section
+  h3.lp-content-sub-title.text-center
+    | 卒業生の就職先企業（2026年5月時点）
+  .lp-content__description
+    .l-inner-container.is-lg
+      .a-short-text
+        ul.lp-company-names
+          li 株式会社アイキューブドシステムズ
+          li アクトインディ株式会社
+          li 株式会社ウィルド
+          li 株式会社永和システムマネジメント
+          li エースチャイルド株式会社
+          li エス・エー・エス株式会社
+          li 株式会社えにしテック
+          li 株式会社キャタル
+          li 株式会社ギフティ
+          li Classi株式会社
+          li 株式会社クリプラ
+          li 株式会社くふうカンパニーホールディングス
+          li GMOペパボ株式会社
+          li しくみ製作所株式会社
+          li Tebiki株式会社
+          li 株式会社ネクスウェイ
+          li 株式会社ネットワーク応用通信研究所
+          li パーソルキャリア株式会社
+          li ピクシブ株式会社
+          li 株式会社B4A
+          li 株式会社マネーフォワード
+          li 株式会社メドレー
+          li 株式会社ラグザイア
+          li 株式会社リサーチ・アンド・イノベーション
+          li 株式会社RIT
+          li 株式会社Ruby開発
+          li vareal株式会社
+          li 株式会社WARC
+          li 株式会社万葉
+        |  他多数

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -40,4 +40,5 @@
 = render 'welcome/question_methods'
 = render 'welcome/articles'
 = render 'welcome/mentors', mentors: @mentors
+= render 'welcome/alumni_companies', show_job_support_link: true
 = render 'welcome/campus_insight'

--- a/app/views/welcome/job_support.html.slim
+++ b/app/views/welcome/job_support.html.slim
@@ -196,78 +196,7 @@ article.lp
                             picture-in-picture; web-share"
                       referrerpolicy="strict-origin-when-cross-origin" allowfullscreen]
 
-  section.lp-content.is-lp-bg-2.is-top-title
-    .l-container.is-xl
-      .lp-content__inner
-        .lp-content__start
-          header.lp-content__header
-            h2.lp-content-title.text-center.is-border-bottom
-              | 卒業生の就職先企業の一部
-        .lp-content__end
-          .lp-content-stack
-            .lp-content-stack__item
-              section.lp-content-section
-                h3.lp-content-sub-title.text-center
-                  | カンファレンスでよく見る
-                  br
-                  | あの企業に多くの卒業生が就職しています
-                .lp-content__description
-                  .l-inner-container.is-md
-                    .a-short-text
-                      p
-                        | これはほんの一部だけですが、
-                        | 受託開発、自社サービス、スタートアップ、上場企業など
-                        | 様々な企業に卒業生が就職しています。
-                        | 有名なOSSの開発者や、カンファレンスの常連登壇者が所属していたり、
-                        | カンファレンスのスポンサーをよくやっている、
-                        | ソフトウェアエンジニア業界で有名な企業に就職している人が多いのが
-                        | FBCの特徴です。
-            .lp-content-stack__item
-              .lp-company-logos
-                .lp-company-logos__item
-                  = link_to 'https://www.pixiv.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/pixiv.svg', alt: 'ピクシブ株式会社')
-                .lp-company-logos__item
-                  = link_to 'https://pepabo.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/gmo-pepabo.svg', alt: 'GMOペパボ株式会社')
-                //
-                  .lp-company-logos__item
-                    = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                      = image_tag('company_logos/persol.svg', alt: '株式会社パーソルキャリア')
-                .lp-company-logos__item
-                  = link_to 'https://esm.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/esm.svg', alt: '株式会社永和システムマネジメント')
-                .lp-company-logos__item
-                  = link_to 'https://www.luxiar.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/luxiar.svg', alt: '株式会社ラグザイア')
-                .lp-company-logos__item
-                  = link_to 'https://everyleaf.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/everyleaf.svg', alt: '株式会社万葉')
-                .lp-company-logos__item
-                  = link_to 'https://sikmi.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/sikmi.svg', alt: 'しくみ製作所株式会社')
-                .lp-company-logos__item
-                  = link_to 'https://www.enishi-tech.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/enishi.svg', alt: '株式会社えにしテック')
-                .lp-company-logos__item
-                  = link_to 'https://tebiki.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/tebiki.svg', alt: 'Tebiki株式会社')
-                .lp-company-logos__item
-                  = link_to 'https://catal.jp/company/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/catal.svg', alt: '株式会社キャタル')
-                .lp-company-logos__item
-                  = link_to 'https://wyrd.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/wyrd.svg', alt: '株式会社ウィルド')
-                .lp-company-logos__item
-                  = link_to 'https://www.ruby-dev.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/ruby-dev.svg', alt: '株式会社Ruby開発')
-                .lp-company-logos__item
-                  = link_to 'https://www.netlab.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                    = image_tag('company_logos/nacl.svg', alt: '株式会社ネットワーク応用通信研究所')
-                //
-                  .lp-company-logos__item
-                    = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
-                      = image_tag('company_logos/actindi.svg', alt: 'アクトインディ株式会社')
+  = render 'welcome/alumni_companies'
 
   section.lp-content.is-lp-bg-3.is-right-title
     .l-container.is-lg

--- a/app/views/welcome/training.html.slim
+++ b/app/views/welcome/training.html.slim
@@ -44,38 +44,38 @@ article.lp
         .lp-content__start
           .lp-company-logos
             .lp-company-logos__item
-              = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/gmo-pepabo.svg', alt: '株式会社GMOペパボ')
             .lp-company-logos__item
-              = link_to 'https://esm.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to 'https://esm.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/esm.svg', alt: '株式会社永和システムマネジメント')
             .lp-company-logos__item
-              = link_to 'https://www.luxiar.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to 'https://www.luxiar.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/luxiar.svg', alt: '株式会社ラグザイア')
             .lp-company-logos__item
-              = link_to 'https://everyleaf.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to 'https://everyleaf.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/everyleaf.svg', alt: '株式会社万葉')
             .lp-company-logos__item
-              = link_to 'https://www.pixiv.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to 'https://www.pixiv.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/pixiv.svg', alt: 'ピクシブ株式会社')
             //
               .lp-company-logos__item
-                = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+                = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                   = image_tag('company_logos/enishi.svg', alt: '株式会社えにしテック')
             .lp-company-logos__item
-              = link_to 'https://www.ruby-dev.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to 'https://www.ruby-dev.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/ruby-dev.svg', alt: '株式会社Ruby開発')
             .lp-company-logos__item
-              = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to '', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/genbasupport.svg', alt: '株式会社現場サポート')
             .lp-company-logos__item
-              = link_to 'https://www.vitallead.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to 'https://www.vitallead.co.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/vitallead.svg', alt: '株式会社バイタルリード')
             .lp-company-logos__item
-              = link_to 'https://www.icubedsystems.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to 'https://www.icubedsystems.com/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/icubedsystems.svg', alt: '株式会社アイキューブドシステムズ')
             .lp-company-logos__item
-              = link_to 'https://youcube.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener'  do
+              = link_to 'https://youcube.jp/', class: 'lp-company-logos__item-link', target: '_blank', rel: 'noopener' do
                 = image_tag('company_logos/youcube.svg', alt: '合同会社ユーキューブ')
           .a-short-text.is-ta-center.mt-8
             p.text-lg


### PR DESCRIPTION
就職先企業セクションをjob_supportとindexで共有できるようpartial化し、
トップページの「学習アプリの中身を見てみよう」の上に配置。
トップページからはFBCの就職支援ページへのボタンも併せて表示する。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 卒業生の就職先企業を紹介するセクションを追加。企業ロゴと企業名を一覧で表示し、LPと求人支援ページで共通利用されます。
  * 企業名リストを横並び表示にし、末尾に区切りが出ないよう表示を改善しました。
  * 条件付きで「FBCの就職支援」へのリンク（ボタン）が表示されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10102-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26935666835/artifacts/7405013927" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
