### PR TITLE
レビューアプリ削除時のDB接続確認を修正

### DIFF
--- a/.cloudbuild/cloudbuild-review-cleanup.yaml
+++ b/.cloudbuild/cloudbuild-review-cleanup.yaml
@@ -27,17 +27,17 @@ steps:
       - name: db
         path: /cloudsql
   - id: WaitForProxy
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
+    name: postgres:16-alpine
+    entrypoint: sh
     args:
       - '-c'
       - |
-        set -euo pipefail
+        set -eu
         echo "Waiting for Cloud SQL Proxy..."
         TIMEOUT=60
         ELAPSED=0
         while [ $$ELAPSED -lt $$TIMEOUT ]; do
-          if PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c "SELECT 1" 2>/dev/null; then
+          if PGPASSWORD=$_DB_PASS PGCONNECT_TIMEOUT=2 psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c "SELECT 1"; then
             echo "Proxy ready."
             exit 0
           fi
@@ -52,12 +52,18 @@ steps:
       - name: db
         path: /cloudsql
   - id: DropDB
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
+    name: postgres:16-alpine
+    entrypoint: sh
     args:
       - '-c'
       - |
-        set -euo pipefail
+        set -eu
+        case "${_PR_NUMBER}" in
+          (*[!0-9]*|'')
+            echo "Invalid PR number: ${_PR_NUMBER}" >&2
+            exit 1
+            ;;
+        esac
         DB_NAME="bootcamp_pr_${_PR_NUMBER}"
         echo "Terminating connections to $${DB_NAME}..."
         PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c \


### PR DESCRIPTION
## 概要

- review app cleanup の Cloud Build で `psql` を実行するステップを PostgreSQL クライアント入りのイメージに変更
- Cloud SQL Proxy 待機時のエラーをログに出すように変更
- DB 削除前に PR 番号が数値であることを検証

## 確認

- [x] `ruby -e 'require "yaml"; YAML.load_file(".cloudbuild/cloudbuild-review-cleanup.yaml"); puts "YAML OK"'`
- [x] `git diff --check`
- [x] `gcloud builds log 02449e8d-c679-4faa-9ab4-d5194055e2c4 --project=bootcamp-224405 --region=asia-northeast1` で失敗原因を確認

## 補足

直近の失敗ログでは Cloud SQL Proxy 自体は `Ready for new connections` になっていましたが、cleanup の `WaitForProxy` がタイムアウトしていました。`gcr.io/google.com/cloudsdktool/cloud-sdk` には `psql` がないため、接続確認が成功できない状態でした。

`claude` によるレビューは実行しましたが応答が返らず、プロセスを停止しました。手元で別視点レビューは実施済みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Cloud SQLプロキシの接続確認プロセスを改善しました
  * エラー出力の処理方法を変更しました

* **Chores**
  * プルリクエストのクリーンアップ処理に検証ステップを追加しました
  * コンテナイメージをpostgres:16-alpineに更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10103-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->