### PR TITLE
コメント数の実装を見直し

### DIFF
--- a/app/assets/stylesheets/atoms/_a-meta.css
+++ b/app/assets/stylesheets/atoms/_a-meta.css
@@ -22,6 +22,10 @@
   font-weight: 600;
 }
 
+.a-meta.is-important  .is-emphasized {
+  color: inherit;
+}
+
 a.a-meta {
   text-decoration: none;
   cursor: pointer;

--- a/app/components/products/product_component.html.slim
+++ b/app/components/products/product_component.html.slim
@@ -63,13 +63,13 @@
                 - else
                   | 約#{until_next_elapsed_days}時間
 
-      - if @product.comments.size > 0
+      - if @product.comments.any?
         hr.card-list-item__row-separator
         .card-list-item__row
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                .a-meta コメント（#{@product.comments.size}）
+                .a-meta = helpers.event_comment_count(@product)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   - @product.commented_users.distinct.each do |user|

--- a/app/components/products/product_component.html.slim
+++ b/app/components/products/product_component.html.slim
@@ -69,7 +69,7 @@
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
-                .a-meta = helpers.event_comment_count(@product)
+                .a-meta = helpers.comment_count(@product)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   - @product.commented_users.distinct.each do |user|

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,7 +14,7 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
   before_action :set_watch, only: %i[show]
 
   def index
-    @reports = Report.list.page(params[:page]).per(PAGER_NUMBER)
+    @reports = Report.list.includes(:comments).page(params[:page]).per(PAGER_NUMBER)
     @reports = @reports.joins(:practices).where(practices: { id: params[:practice_id] }) if params[:practice_id].present?
   end
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -13,8 +13,8 @@ module EventsHelper
     uri.to_s
   end
 
-  def event_comment_count(event)
-    safe_join(['コメント（', content_tag(:span, event.comments.size, class: 'is-emphasized'), '）'])
+  def comment_count(commentable)
+    safe_join(['コメント（', content_tag(:span, commentable.comments.size, class: 'is-emphasized'), '）'])
   end
 
   def event_participant_count(event)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -14,7 +14,7 @@ module EventsHelper
   end
 
   def event_comment_count(event)
-    safe_join(['コメント（', content_tag(:span, event.comments.length, class: 'is-emphasized'), '）'])
+    safe_join(['コメント（', content_tag(:span, event.comments.size, class: 'is-emphasized'), '）'])
   end
 
   def event_participant_count(event)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -13,18 +13,8 @@ module EventsHelper
     uri.to_s
   end
 
-  def event_comment_count(event, styled: true)
-    length = event.comments.length
-
-    if styled
-      link_to '#comments', class: "a-meta #{'is-disabled' if length.zero?}" do
-        'コメント（'.html_safe +
-          content_tag(:span, length, class: length.zero? ? 'is-muted' : 'is-emphasized') +
-          '）'.html_safe
-      end
-    else
-      "コメント（#{length}名）"
-    end
+  def event_comment_count(event)
+    'コメント（'.html_safe + content_tag(:span, event.comments.length, class: 'is-emphasized') + '）'.html_safe
   end
 
   def event_participant_count(event)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -14,7 +14,7 @@ module EventsHelper
   end
 
   def event_comment_count(event)
-    'コメント（'.html_safe + content_tag(:span, event.comments.length, class: 'is-emphasized') + '）'.html_safe
+    safe_join(['コメント（', content_tag(:span, event.comments.length, class: 'is-emphasized'), '）'])
   end
 
   def event_participant_count(event)

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -30,6 +30,7 @@
                   | 公開
                 time.a-meta__value datetime=announcement.published_at.iso8601
                   | #{l announcement.published_at}
-          .card-list-item-meta__item
-            .a-meta
-              | コメント（#{announcement.comments.length}）
+          - if announcement.comments.any?
+            .card-list-item-meta__item
+              .a-meta
+                = event_comment_count(announcement)

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -33,4 +33,4 @@
           - if announcement.comments.any?
             .card-list-item-meta__item
               .a-meta
-                = event_comment_count(announcement)
+                = comment_count(announcement)

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -47,7 +47,7 @@ hr.a-border
                   .page-content-header-metas__meta
                     - if @announcement.comments.any?
                       a.a-meta(href='#comments')
-                        = event_comment_count(@announcement)
+                        = comment_count(@announcement)
             .page-content-header__row
               .page-content-header-actions
                 .page-content-header-actions__start

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -45,12 +45,9 @@ hr.a-border
                       = @announcement.user.long_name
                 .page-content-header-metas__end
                   .page-content-header-metas__meta
-                    - length = @announcement.comments.length
-                    a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
-                      | コメント（
-                      span#comment_count(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
-                        = length
-                      | ）
+                    - if @announcement.comments.any?
+                      a.a-meta(href='#comments')
+                        = event_comment_count(@announcement)
             .page-content-header__row
               .page-content-header-actions
                 .page-content-header-actions__start

--- a/app/views/companies/products/_product.html.slim
+++ b/app/views/companies/products/_product.html.slim
@@ -37,14 +37,14 @@
                   time.a-meta datetime=product.updated_at.iso8601
                     span.a-meta__label 更新
                     | #{l product.updated_at}
-      - if !product.comments.empty?
+      - if product.comments.any?
         hr.card-list-item__row-separator
         .card-list-item__row
           .card-list-item-meta
             .card-list-item-meta__items
               .card-list-item-meta__item
                 .a-meta
-                  | コメント（#{product.comments.size}）
+                  = event_comment_count(product)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   - commented_users[product.id].uniq.each do |user|

--- a/app/views/companies/products/_product.html.slim
+++ b/app/views/companies/products/_product.html.slim
@@ -44,7 +44,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 .a-meta
-                  = event_comment_count(product)
+                  = comment_count(product)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   - commented_users[product.id].uniq.each do |user|

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -26,7 +26,9 @@
                   = l event.updated_at
           .page-content-header-metas__end
             .page-content-header-metas__meta
-              = event_comment_count(event, styled: true)
+              - if event.comments.any?
+                a.a-meta(href='#comments')
+                  = event_comment_count(event)
 
       .page-content-header__row
         .page-content-header-actions

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -28,7 +28,7 @@
             .page-content-header-metas__meta
               - if event.comments.any?
                 a.a-meta(href='#comments')
-                  = event_comment_count(event)
+                  = comment_count(event)
 
       .page-content-header__row
         .page-content-header-actions

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -39,5 +39,5 @@ ul.card-list.a-card
                 - if event.comments.any?
                   .card-list-item-meta__item
                     .a-meta
-                      = event_comment_count(event)
+                      = comment_count(event)
 = paginate @events

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -36,8 +36,8 @@ ul.card-list.a-card
                   .card-list-item-meta__item
                     .a-meta
                       | 補欠者（#{event.waitlist.count}名）
-                - if event.comments.size.positive?
+                - if event.comments.any?
                   .card-list-item-meta__item
                     .a-meta
-                      | コメント（#{event.comments.size}）
+                      = event_comment_count(event)
 = paginate @events

--- a/app/views/home/_colleague_trainee.html.slim
+++ b/app/views/home/_colleague_trainee.html.slim
@@ -19,7 +19,7 @@
               .card-list-item-meta__item
                 = link_to user_products_path(user), class: 'card-list-item-meta__item-link a-text-link' do
                   | 提出物一覧（#{user.products.count}）
-            - if user.comments.present?
+            - if user.comments.any?
               .card-list-item-meta__item
                 = link_to user_comments_path(user), class: 'card-list-item-meta__item-link a-text-link' do
-                  = event_comment_count(user)
+                  = comment_count(user)

--- a/app/views/home/_colleague_trainee.html.slim
+++ b/app/views/home/_colleague_trainee.html.slim
@@ -22,4 +22,4 @@
             - if user.comments.present?
               .card-list-item-meta__item
                 = link_to user_comments_path(user), class: 'card-list-item-meta__item-link a-text-link' do
-                  | コメント（#{user.comments.count}）
+                  = event_comment_count(user)

--- a/app/views/movies/_movie_header.html.slim
+++ b/app/views/movies/_movie_header.html.slim
@@ -56,12 +56,9 @@ header.page-content-header
         .page-content-header-metas__end
           .page-content-header-metas
             .page-content-header-metas__meta
-              - length = movie.comments.length
-              a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
-                | コメント（
-                span#comment_count(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
-                  = length
-                | ）
+              - if movie.comments.any?
+                a.a-meta(href='#comments')
+                  = event_comment_count(movie)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/movies/_movie_header.html.slim
+++ b/app/views/movies/_movie_header.html.slim
@@ -52,13 +52,12 @@ header.page-content-header
                           = image_tag 'users/avatars/ghost.png', class: 'thread-header__user-icon a-user-icon'
                       .a-user-name
                         | ghost
-
-        .page-content-header-metas__end
-          .page-content-header-metas
-            .page-content-header-metas__meta
-              - if movie.comments.any?
-                a.a-meta(href='#comments')
-                  = event_comment_count(movie)
+        - if movie.comments.any?
+          .page-content-header-metas__end
+            .page-content-header-metas
+                .page-content-header-metas__meta
+                  a.a-meta(href='#comments')
+                    = event_comment_count(movie)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/movies/_movie_header.html.slim
+++ b/app/views/movies/_movie_header.html.slim
@@ -57,7 +57,7 @@ header.page-content-header
             .page-content-header-metas
                 .page-content-header-metas__meta
                   a.a-meta(href='#comments')
-                    = event_comment_count(movie)
+                    = comment_count(movie)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/pages/_doc_header.html.slim
+++ b/app/views/pages/_doc_header.html.slim
@@ -59,12 +59,9 @@ header.page-content-header
         .page-content-header-metas__end
           .page-content-header-metas
             .page-content-header-metas__meta
-              - length = page.comments.length
-              a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
-                | コメント（
-                span#comment_count(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
-                  = length
-                | ）
+              - if page.comments.any?
+                a.a-meta(href='#comments')
+                  = event_comment_count(page)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/pages/_doc_header.html.slim
+++ b/app/views/pages/_doc_header.html.slim
@@ -60,7 +60,7 @@ header.page-content-header
             .page-content-header-metas
               .page-content-header-metas__meta
                 a.a-meta(href='#comments')
-                  = event_comment_count(page)
+                  = comment_count(page)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/pages/_doc_header.html.slim
+++ b/app/views/pages/_doc_header.html.slim
@@ -55,11 +55,10 @@ header.page-content-header
                       image_class: 'thread-header__user-icon'
                     = link_to page.last_updated_user, class: 'a-user-name' do
                       | #{page.last_updated_user.login_name}
-
-        .page-content-header-metas__end
-          .page-content-header-metas
-            .page-content-header-metas__meta
-              - if page.comments.any?
+        - if page.comments.any?
+          .page-content-header-metas__end
+            .page-content-header-metas
+              .page-content-header-metas__meta
                 a.a-meta(href='#comments')
                   = event_comment_count(page)
 

--- a/app/views/pages/_page.html.slim
+++ b/app/views/pages/_page.html.slim
@@ -52,4 +52,4 @@
             - if page.comments.any?
               .card-list-item-meta__item
                 .a-meta
-                  | コメント（#{page.comments.length}）
+                  = event_comment_count(page)

--- a/app/views/pages/_page.html.slim
+++ b/app/views/pages/_page.html.slim
@@ -52,4 +52,4 @@
             - if page.comments.any?
               .card-list-item-meta__item
                 .a-meta
-                  = event_comment_count(page)
+                  = comment_count(page)

--- a/app/views/pair_works/_pair_work.html.slim
+++ b/app/views/pair_works/_pair_work.html.slim
@@ -40,9 +40,10 @@
                 - else
                   time.a-meta__value datetime=pair_work.published_at.iso8601
                     = l pair_work.published_at
-            .card-list-item-meta__item
-              .a-meta(class="#{pair_work.important? ? 'is-important' : ''}")
-                | コメント（#{pair_work.comments.length}）
+            - if pair_work.comments.any?
+              .card-list-item-meta__item
+                .a-meta(class="is-important")
+                  = event_comment_count(pair_work)
 
     - if pair_work.solved?
       .stamp.is-circle.is-solved

--- a/app/views/pair_works/_pair_work.html.slim
+++ b/app/views/pair_works/_pair_work.html.slim
@@ -43,7 +43,7 @@
             - if pair_work.comments.any?
               .card-list-item-meta__item
                 .a-meta(class="is-important")
-                  = event_comment_count(pair_work)
+                  = comment_count(pair_work)
 
     - if pair_work.solved?
       .stamp.is-circle.is-solved

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -50,7 +50,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 .a-meta
-                  | コメント（#{product.comments.size}）
+                  = event_comment_count(product)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   = render partial: 'users/icon',

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -50,7 +50,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 .a-meta
-                  = event_comment_count(product)
+                  = comment_count(product)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   = render partial: 'users/icon',

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -71,12 +71,9 @@ header.page-content-header.is-product
 
         .page-content-header-metas__end
           .page-content-header-metas__meta
-            - length = product.comments.length
-            a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
-              | コメント（
-              span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
-                = length
-              | ）
+            - if product.comments.any?
+              a.a-meta(href='#comments')
+                = event_comment_count(product)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -72,7 +72,7 @@ header.page-content-header.is-product
           .page-content-header-metas__end
             .page-content-header-metas__meta
               a.a-meta(href='#comments')
-                = event_comment_count(product)
+                = comment_count(product)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -68,10 +68,9 @@ header.page-content-header.is-product
                   | 更新
                 time.a-meta__value datetime=product.updated_at.iso8601
                   = l product.updated_at
-
-        .page-content-header-metas__end
-          .page-content-header-metas__meta
-            - if product.comments.any?
+        - if product.comments.any?
+          .page-content-header-metas__end
+            .page-content-header-metas__meta
               a.a-meta(href='#comments')
                 = event_comment_count(product)
 

--- a/app/views/products/_product_list_item.html.slim
+++ b/app/views/products/_product_list_item.html.slim
@@ -54,7 +54,7 @@ ruby:
         hr.card-list-item__row-separator
         .card-list-item-meta__items
           .card-list-item-meta__item
-            .a-meta コメント（#{product.comments.size}）
+            .a-meta = event_comment_count(product)
           .card-list-item-meta__item
             .card-list-item__user-icons
               = render partial: 'users/icon',

--- a/app/views/products/_product_list_item.html.slim
+++ b/app/views/products/_product_list_item.html.slim
@@ -54,7 +54,7 @@ ruby:
         hr.card-list-item__row-separator
         .card-list-item-meta__items
           .card-list-item-meta__item
-            .a-meta = event_comment_count(product)
+            .a-meta = comment_count(product)
           .card-list-item-meta__item
             .card-list-item__user-icons
               = render partial: 'users/icon',

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -24,12 +24,9 @@
                   = l regular_event.updated_at
           .page-content-header-metas__end
             .page-content-header-metas__meta
-              - length = regular_event.comments.length
-              a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
-                | コメント（
-                span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
-                  = length
-                | ）
+              - if regular_event.comments.any?
+                a.a-meta(href='#comments')
+                  = event_comment_count(regular_event)
 
       .page-content-header__row
         .page-content-header-actions

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -22,9 +22,9 @@
               .a-meta
                 time.a-meta__value datetime=regular_event.updated_at.iso8601
                   = l regular_event.updated_at
-          .page-content-header-metas__end
-            .page-content-header-metas__meta
-              - if regular_event.comments.any?
+          - if regular_event.comments.any?
+            .page-content-header-metas__end
+              .page-content-header-metas__meta
                 a.a-meta(href='#comments')
                   = event_comment_count(regular_event)
 

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -26,7 +26,7 @@
             .page-content-header-metas__end
               .page-content-header-metas__meta
                 a.a-meta(href='#comments')
-                  = event_comment_count(regular_event)
+                  = comment_count(regular_event)
 
       .page-content-header__row
         .page-content-header-actions

--- a/app/views/regular_events/_regular_events.html.slim
+++ b/app/views/regular_events/_regular_events.html.slim
@@ -48,8 +48,8 @@ ul.card-list.a-card
                     span.a-meta__label 開催日時
                     span.a-meta__value = "#{event.holding_cycles} #{l event.start_at, format: :time_only} ~ #{l event.end_at, format: :time_only}"
                   .card-list-item-meta__item
-                - if event.comments.size.positive?
+                - if event.comments.any?
                   .card-list-item-meta__item
                     .a-meta
-                      | コメント（#{event.comments.size}）
+                      = event_comment_count(event)
 = paginate @regular_events

--- a/app/views/regular_events/_regular_events.html.slim
+++ b/app/views/regular_events/_regular_events.html.slim
@@ -50,5 +50,5 @@ ul.card-list.a-card
                 - if event.comments.any?
                   .card-list-item-meta__item
                     .a-meta
-                      = event_comment_count(event)
+                      = comment_count(event)
 = paginate @regular_events

--- a/app/views/regular_events/_regular_events.html.slim
+++ b/app/views/regular_events/_regular_events.html.slim
@@ -47,7 +47,6 @@ ul.card-list.a-card
                   .a-meta
                     span.a-meta__label 開催日時
                     span.a-meta__value = "#{event.holding_cycles} #{l event.start_at, format: :time_only} ~ #{l event.end_at, format: :time_only}"
-                  .card-list-item-meta__item
                 - if event.comments.any?
                   .card-list-item-meta__item
                     .a-meta

--- a/app/views/reports/_product.html.slim
+++ b/app/views/reports/_product.html.slim
@@ -31,7 +31,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 .a-meta
-                  | コメント（#{product.comments.size}）
+                  = event_comment_count(product)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   = render partial: 'comments/user_icons', collection: product.comments.commented_users, as: :user

--- a/app/views/reports/_product.html.slim
+++ b/app/views/reports/_product.html.slim
@@ -31,7 +31,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 .a-meta
-                  = event_comment_count(product)
+                  = comment_count(product)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   = render partial: 'comments/user_icons', collection: product.comments.commented_users, as: :user

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -48,7 +48,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 .a-meta
-                  = event_comment_count(report)
+                  = comment_count(report)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   = render partial: 'comments/user_icons', collection: report.comments.commented_users, as: :user

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -48,7 +48,7 @@
             .card-list-item-meta__items
               .card-list-item-meta__item
                 .a-meta
-                  | コメント（#{report.comments.size}）
+                  = event_comment_count(report)
               .card-list-item-meta__item
                 .card-list-item__user-icons
                   = render partial: 'comments/user_icons', collection: report.comments.commented_users, as: :user

--- a/app/views/reports/_report_header.html.slim
+++ b/app/views/reports/_report_header.html.slim
@@ -40,12 +40,9 @@ header.page-content-header.is-report
 
         .page-content-header-metas__end
           .page-content-header-metas__meta
-            - length = report.comments.length
-            a.a-meta(href='#comments' class="#{length.zero? ? 'is-disabled' : ''}")
-              | コメント（
-              span(class="#{length.zero? ? 'is-muted' : 'is-emphasized'}")
-                = length
-              | ）
+            - if report.comments.any?
+              a.a-meta(href='#comments')
+                = event_comment_count(report)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/reports/_report_header.html.slim
+++ b/app/views/reports/_report_header.html.slim
@@ -42,7 +42,7 @@ header.page-content-header.is-report
           .page-content-header-metas__meta
             - if report.comments.any?
               a.a-meta(href='#comments')
-                = event_comment_count(report)
+                = comment_count(report)
 
     .page-content-header__row
       .page-content-header-actions

--- a/app/views/talks/_talk.html.slim
+++ b/app/views/talks/_talk.html.slim
@@ -8,31 +8,30 @@
           h2.card-list-item-title__title(itemprop='name')
             = link_to "/talks/#{talk.id}#latest-comment", itemprop: 'url', class: 'card-list-item-title__link a-text-link' do
               | #{talk.user.long_name} さんの相談部屋
-      - if talk.comments.present?
+      - if talk.comments.any?
         hr.card-list-item__row-separator
-      - if talk.comments.present?
-        .card-list-item__row
-          .card-list-item-meta__items
-            .card-list-item-meta__item
-              .card-list-item-meta
-                .card-list-item-meta__items
-                  .card-list-item-meta__item
-                    .a-meta
-                      | コメント（#{talk.comments.size}）
-                  .card-list-item-meta__item
-                    .card-list-item__user-icons
-                      = render partial: 'users/icon',
-                        collection: talk.commented_users.distinct,
-                        locals: { link_class: 'card-list-item__user-icons-icon', image_class: 'a-user-icon' },
-                        as: :user,
-                        cached: true
-                  .card-list-item-meta__item
-                    .a-meta
-                      | 〜 #{l talk.comments.last.updated_at}
-                  .card-list-item-meta__item
-                    - if talk.comments.last.user.admin
+          .card-list-item__row
+            .card-list-item-meta__items
+              .card-list-item-meta__item
+                .card-list-item-meta
+                  .card-list-item-meta__items
+                    .card-list-item-meta__item
                       .a-meta
-                        | （管理者）
-                    - else
+                        = event_comment_count(talk)
+                    .card-list-item-meta__item
+                      .card-list-item__user-icons
+                        = render partial: 'users/icon',
+                          collection: talk.commented_users.distinct,
+                          locals: { link_class: 'card-list-item__user-icons-icon', image_class: 'a-user-icon' },
+                          as: :user,
+                          cached: true
+                    .card-list-item-meta__item
                       .a-meta
-                        | （#{talk.user.login_name}）
+                        | 〜 #{l talk.comments.last.updated_at}
+                    .card-list-item-meta__item
+                      - if talk.comments.last.user.admin
+                        .a-meta
+                          | （管理者）
+                      - else
+                        .a-meta
+                          | （#{talk.user.login_name}）

--- a/app/views/talks/_talk.html.slim
+++ b/app/views/talks/_talk.html.slim
@@ -17,7 +17,7 @@
                 .card-list-item-meta__items
                   .card-list-item-meta__item
                     .a-meta
-                      = event_comment_count(talk)
+                      = comment_count(talk)
                   .card-list-item-meta__item
                     .card-list-item__user-icons
                       = render partial: 'users/icon',

--- a/app/views/talks/_talk.html.slim
+++ b/app/views/talks/_talk.html.slim
@@ -10,28 +10,28 @@
               | #{talk.user.long_name} さんの相談部屋
       - if talk.comments.any?
         hr.card-list-item__row-separator
-          .card-list-item__row
-            .card-list-item-meta__items
-              .card-list-item-meta__item
-                .card-list-item-meta
-                  .card-list-item-meta__items
-                    .card-list-item-meta__item
+        .card-list-item__row
+          .card-list-item-meta__items
+            .card-list-item-meta__item
+              .card-list-item-meta
+                .card-list-item-meta__items
+                  .card-list-item-meta__item
+                    .a-meta
+                      = event_comment_count(talk)
+                  .card-list-item-meta__item
+                    .card-list-item__user-icons
+                      = render partial: 'users/icon',
+                        collection: talk.commented_users.distinct,
+                        locals: { link_class: 'card-list-item__user-icons-icon', image_class: 'a-user-icon' },
+                        as: :user,
+                        cached: true
+                  .card-list-item-meta__item
+                    .a-meta
+                      | 〜 #{l talk.comments.last.updated_at}
+                  .card-list-item-meta__item
+                    - if talk.comments.last.user.admin
                       .a-meta
-                        = event_comment_count(talk)
-                    .card-list-item-meta__item
-                      .card-list-item__user-icons
-                        = render partial: 'users/icon',
-                          collection: talk.commented_users.distinct,
-                          locals: { link_class: 'card-list-item__user-icons-icon', image_class: 'a-user-icon' },
-                          as: :user,
-                          cached: true
-                    .card-list-item-meta__item
+                        | （管理者）
+                    - else
                       .a-meta
-                        | 〜 #{l talk.comments.last.updated_at}
-                    .card-list-item-meta__item
-                      - if talk.comments.last.user.admin
-                        .a-meta
-                          | （管理者）
-                      - else
-                        .a-meta
-                          | （#{talk.user.login_name}）
+                        | （#{talk.user.login_name}）

--- a/app/views/users/events/index.html.slim
+++ b/app/views/users/events/index.html.slim
@@ -57,10 +57,10 @@
                             .card-list-item-meta__item
                               .a-meta
                                 = event_waitlist_count(event)
-                          - if event.comments.size.positive?
+                          - if event.comments.any?
                             .card-list-item-meta__item
                               .a-meta
-                                = event_comment_count(event, styled: false)
+                                = event_comment_count(event)
           .pagination
             = paginate @events
         - else

--- a/app/views/users/events/index.html.slim
+++ b/app/views/users/events/index.html.slim
@@ -60,7 +60,7 @@
                           - if event.comments.any?
                             .card-list-item-meta__item
                               .a-meta
-                                = event_comment_count(event)
+                                = comment_count(event)
           .pagination
             = paginate @events
         - else

--- a/app/views/users/regular_events/index.html.slim
+++ b/app/views/users/regular_events/index.html.slim
@@ -59,7 +59,7 @@
                           - if event.comments.any?
                             .card-list-item-meta__item
                               .a-meta
-                                = event_comment_count(event)
+                                = comment_count(event)
           .pagination
             = paginate @regular_events
         - else

--- a/app/views/users/regular_events/index.html.slim
+++ b/app/views/users/regular_events/index.html.slim
@@ -56,10 +56,10 @@
                             time.a-meta(datetime="#{event.start_at}")
                               | 開催日時:
                               | #{event.holding_cycles} #{l event.start_at, format: :time_only} ～ #{l event.end_at, format: :time_only}
-                          - if event.comments.size.positive?
+                          - if event.comments.any?
                             .card-list-item-meta__item
                               .a-meta
-                                = event_comment_count(event, styled: false)
+                                = event_comment_count(event)
           .pagination
             = paginate @regular_events
         - else

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -44,7 +44,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_selector 'p', text: 'コメント数表示のテストです。'
 
     visit current_path
-    assert_selector 'span', text: '2'
+    assert_selector 'a.a-meta[href="#comments"] span.is-emphasized', text: '2'
   end
 
   test 'using file uploading by file selection dialogue in textarea' do

--- a/test/system/announcements_test.rb
+++ b/test/system/announcements_test.rb
@@ -44,7 +44,7 @@ class AnnouncementsTest < ApplicationSystemTestCase
     assert_selector 'p', text: 'コメント数表示のテストです。'
 
     visit current_path
-    assert_selector '#comment_count', text: '2'
+    assert_selector 'span', text: '2'
   end
 
   test 'using file uploading by file selection dialogue in textarea' do

--- a/test/system/movies_test.rb
+++ b/test/system/movies_test.rb
@@ -41,14 +41,13 @@ class MoviesTest < ApplicationSystemTestCase
       content_type: 'video/mp4'
     )
     visit_with_auth "/movies/#{movie.id}", 'kimura'
-    assert_selector '#comment_count', text: 0
 
     wait_for_comment_form
     post_comment('コメント数表示のテストです。')
 
     visit_with_auth "/movies/#{movie.id}", 'kimura'
     wait_for_javascript_components
-    assert_selector '#comment_count', text: 1
+    assert_selector 'span', text: 1
   end
 
   test 'show the edit movie page' do

--- a/test/system/movies_test.rb
+++ b/test/system/movies_test.rb
@@ -47,7 +47,7 @@ class MoviesTest < ApplicationSystemTestCase
 
     visit_with_auth "/movies/#{movie.id}", 'kimura'
     wait_for_javascript_components
-    assert_selector 'span', text: 1
+    assert_selector 'a.a-meta[href="#comments"] span.is-emphasized', text: 1
   end
 
   test 'show the edit movie page' do

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -46,7 +46,7 @@ class PagesTest < ApplicationSystemTestCase
 
     visit current_path
     wait_for_javascript_components
-    assert_selector 'span', text: 1
+    assert_selector 'span.is-emphasized', text: 1
   end
 
   test 'show last updated user icon' do

--- a/test/system/pages_test.rb
+++ b/test/system/pages_test.rb
@@ -40,14 +40,13 @@ class PagesTest < ApplicationSystemTestCase
   test 'show comment count' do
     page = pages(:page1)
     visit_with_auth "/pages/#{page.id}", 'kimura'
-    assert_selector '#comment_count', text: 0
 
     wait_for_comment_form
     post_comment('コメント数表示のテストです。')
 
     visit current_path
     wait_for_javascript_components
-    assert_selector '#comment_count', text: 1
+    assert_selector 'span', text: 1
   end
 
   test 'show last updated user icon' do

--- a/test/system/product/product_list_test.rb
+++ b/test/system/product/product_list_test.rb
@@ -37,7 +37,7 @@ class Product::ProductListTest < ApplicationSystemTestCase
     visit_with_auth '/products', 'komagata'
     product_item = find("a[href='/products/#{product.id}']").ancestor('.card-list-item')
     within product_item do
-      assert_text "コメント（#{product.comments.size}）"
+      assert_text(/コメント（\s*#{product.comments.size}\s*）/)
       assert_selector '.card-list-item__user-icons'
     end
   end

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -19,9 +19,7 @@ class ReportsTest < ApplicationSystemTestCase
 
   test 'show number of comments' do
     visit_with_auth report_path(reports(:report1)), 'komagata'
-    within(:css, '.is-emphasized') do
-      assert_text '2'
-    end
+    assert_selector '.is-emphasized', text: '2'
   end
 
   test 'hide user icon from recent reports in report show' do

--- a/test/system/talks/user_list_test.rb
+++ b/test/system/talks/user_list_test.rb
@@ -51,7 +51,7 @@ module Talks
       within('.card-list-item-meta') do
         assert_text 'コメント'
         assert_selector 'img.a-user-icon'
-        assert_text '1'
+        assert_selector 'span.is-emphasized', text: 1
         assert_text '2019年01月02日(水) 00:00'
         assert_text '（hajime）'
       end

--- a/test/system/talks/user_list_test.rb
+++ b/test/system/talks/user_list_test.rb
@@ -51,7 +51,7 @@ module Talks
       within('.card-list-item-meta') do
         assert_text 'コメント'
         assert_selector 'img.a-user-icon'
-        assert_text '（1）'
+        assert_text '1'
         assert_text '2019年01月02日(水) 00:00'
         assert_text '（hajime）'
       end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7/views/1?pane=issue&itemId=182738571&issue=fjordllc%7Cbootcamp%7C9860

## 概要
- コメント数を表示している箇所（ヘルパーメソッド）が使われていない場所があったので整合性を保持するため全ての箇所に設置
- リンク付きとそうでないとで条件分岐されていたので見直しをし、詳細ページはリンク付きに統一した
- 詳細ページでコメントなしの場合はコメント数の表示を非表示し、コメントがある場合は文字の箇所を太字にして統一させた

## 変更確認方法

1. `bug/review-of-event_comment_count`をローカルに取り込む
2. `komagata`のアカウントでログインする。
下記に箇条書きにて変更した箇所を記載します。
- [お知らせ一覧](http://127.0.0.1:3000/announcements) 
※コメントがない箇所はコメント数は表示されません。（以下同様です）
- [お知らせ詳細](http://127.0.0.1:3000/announcements/1061722993)
- [特別イベント](http://127.0.0.1:3000/events)
- [特別イベント詳細](http://127.0.0.1:3000/events/994018171)
- [定期イベント](http://127.0.0.1:3000/regular_events)
- [定期イベント詳細](http://127.0.0.1:3000/regular_events/40690962)
- [ユーザーイベント（特別イベント）](http://127.0.0.1:3000/users/459775584/events)
- [ユーザーイベント（定期イベント）](http://127.0.0.1:3000/users/459775584/regular_events)
- [Docs・動画](http://127.0.0.1:3000/pages)
- [動画詳細](http://127.0.0.1:3000/movies) （お好きなページでコメントをしてください。その後リロードしてください）
- [提出物](http://127.0.0.1:3000/products)
- [提出物詳細](http://127.0.0.1:3000/products/34332630) （当該URLがなければ一覧からコメントがあるものを選んでください）
サイドカラムの箇所にもコメント数（直近の日報と提出物）が記載されています。
- [日報](http://127.0.0.1:3000/reports/unchecked)
- [日報詳細](http://127.0.0.1:3000/reports/253723259)
- [ペアワーク](http://127.0.0.1:3000/pair_works?target=not_solved) ※詳細ページはコメント表示なし
- [相談部屋](http://127.0.0.1:3000/talks)  （お好きなページを選んでコメントをしてください。その後一覧にお戻りください）※詳細ページはコメント表示なし
- [BatsuBatsu Inc](http://127.0.0.1:3000/companies/1022975240/products)

3. アカウントを`marumarushain1`に変更しお知らせにコメントをしてください
4. アカウントを`advijirou`に変更し[登録情報変更](http://127.0.0.1:3000/current_user/edit)から所属企業情報を「MaruMaru Inc」にして更新してください
- [トップ](http://127.0.0.1:3000/)に移動し、 **MaruMaru Inc. の研修状況** の **研修生** から`marumarushain1`を見つけコメント数が出ているか確認する






## Screenshot

### 変更前
<img width="403" height="165" alt="スクリーンショット 2026-06-01 20 53 40" src="https://github.com/user-attachments/assets/70b8705c-83ef-48f8-b32e-815a8721bb63" />

<img width="767" height="205" alt="スクリーンショット 2026-06-01 20 52 20" src="https://github.com/user-attachments/assets/4d016090-ce5d-4fb0-b26a-4b757eb883a6" />


https://github.com/user-attachments/assets/53b20652-777c-4f14-88d2-134f31ff7112

### 変更後

<img width="469" height="167" alt="スクリーンショット 2026-06-01 21 13 52" src="https://github.com/user-attachments/assets/285f94c0-cfcb-4329-a7c5-e8c2881c17c2" />

<img width="788" height="206" alt="スクリーンショット 2026-06-01 21 14 47" src="https://github.com/user-attachments/assets/f710ec5d-ad27-469b-b015-6d26edf68ff6" />


https://github.com/user-attachments/assets/aaeb2d25-eb7f-4fda-b98a-3bc6b860362c








<!-- I want to review in Japanese. -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10107-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * コメントがない場合、コメント用のメタリンクや件数表示を非表示にし、画面をすっきりさせました。
* **リファクタリング（表示統一）**
  * コメント件数の文言・強調の見え方を共通化し、各画面で表示を統一しました。
* **スタイル**
  * 「重要」状態の強調表示が親の色を継承するよう調整しました。
* **テスト**
  * コメント件数表示に関する検証内容を更新しました。
* **パフォーマンス**
  * レポート一覧の読み込みを改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27528555441/artifacts/7630851608" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
