### PR TITLE
Update flakewatch to v0.6.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,17 +222,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download JUnit XML
-        uses: actions/download-artifact@v4
-        with:
-          pattern: junit-xml-*
-          path: test/reports
-          merge-multiple: true
-
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.16
+        uses: komagata/flakewatch@v0.6.20
         with:
-          junit: "test/reports/**/*.xml"
+          junit-artifact-pattern: junit-xml-*
           source-root: "."
           history-branch: flakewatch-data
           history-write: auto


### PR DESCRIPTION
## Issue

なし

## 概要

- Flakewatch GitHub Action を v0.6.20 に更新しました。
- `junit-artifact-pattern` input を使い、Flakewatch action 内で JUnit XML artifact を download するようにしました。
- Flakewatch report job から個別の JUnit artifact download step を削除しました。

## 変更確認方法

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `git diff --check`

## Screenshot

GitHub Actions workflow の変更のみのためなし

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10109-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->