### PR TITLE
Cloud Build substitutionsを自動マッピングしてデプロイ環境変数に使う

### DIFF
--- a/.cloudbuild/cloud-build-env
+++ b/.cloudbuild/cloud-build-env
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+
+DEPLOY_ONLY_VARS = {
+    "CLOUD_SQL_HOST",
+    "DOCKER_IMAGE",
+    "ENVS",
+    "LABELS",
+    "MEMORY",
+    "PLATFORM",
+    "PR_NUMBER",
+    "SERVICE_ACCOUNT",
+    "SERVICE_NAME",
+    "STAGING",
+    "TRIGGER_ID",
+}
+
+DEFAULT_ENV = {
+    "LANG": "ja_JP.UTF-8",
+    "TZ": "Asia/Tokyo",
+    "RAILS_SERVE_STATIC_FILES": "true",
+    "RAILS_LOG_TO_STDOUT": "true",
+    "RAILS_ENV": "production",
+    "RACK_ENV": "production",
+}
+
+
+def usage():
+    print(
+        """Usage:
+  cloud-build-env exports
+  cloud-build-env cloud-run-json
+  cloud-build-env cloud-run-env-vars
+  cloud-build-env write OUTPUT_FILE BUILD_JSON
+  cloud-build-env write OUTPUT_FILE --build PROJECT_ID BUILD_ID [REGION]""",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def is_cloud_build_substitution(name):
+    return (
+        re.fullmatch(r"_[A-Z0-9_]+", name) is not None
+        and not name.startswith(("__", "_CF_", "_MISE_"))
+        and name[1:] != ""
+    )
+
+
+def app_env():
+    env_vars = dict(DEFAULT_ENV)
+
+    for name, value in sorted(os.environ.items()):
+        if not is_cloud_build_substitution(name):
+            continue
+
+        exported_name = name[1:]
+        if exported_name in DEPLOY_ONLY_VARS:
+            continue
+
+        env_vars[exported_name] = value
+
+    for env_var in os.environ.get("_ENVS", "").split(","):
+        if not env_var:
+            continue
+
+        name, separator, value = env_var.partition("=")
+        if separator and name:
+            env_vars[name] = value
+
+    cloud_sql_host = os.environ.get("_CLOUD_SQL_HOST")
+    if cloud_sql_host:
+        env_vars["DB_HOST"] = f"/cloudsql/{cloud_sql_host}"
+
+    return env_vars
+
+
+def export_lines(env_vars):
+    return "\n".join(f"export {name}={shlex.quote(str(value))}" for name, value in env_vars.items())
+
+
+def build_json_from_gcloud(project_id, build_id, region):
+    return subprocess.check_output(
+        [
+            "gcloud",
+            "builds",
+            "describe",
+            build_id,
+            f"--project={project_id}",
+            f"--region={region}",
+            "--format=json",
+        ],
+        text=True,
+    )
+
+
+def write_substitutions(output_file, build_json):
+    build = json.loads(build_json)
+    substitutions = build.get("substitutions", {})
+    env_vars = {
+        "PROJECT_ID": build.get("projectId", ""),
+        "BUILD_ID": build.get("id", ""),
+        "COMMIT_SHA": substitutions.get("COMMIT_SHA", "unknown"),
+        "REPO_NAME": substitutions.get("REPO_NAME", "bootcamp"),
+    }
+
+    for key, value in sorted(substitutions.items()):
+        if not key.startswith("_"):
+            continue
+
+        exported_name = key[1:]
+        if not exported_name or re.fullmatch(r"[A-Z0-9_]+", exported_name) is None:
+            continue
+
+        env_vars[key] = value
+        env_vars[exported_name] = value
+
+    with open(output_file, "w", encoding="utf-8") as output:
+        output.write(export_lines(env_vars))
+        output.write("\n")
+
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+
+    command = sys.argv[1]
+    if command == "exports":
+        env_vars = {
+            "RAILS_ENV": "production",
+            "DISABLE_DATABASE_ENVIRONMENT_CHECK": "1",
+        }
+        for name, value in sorted(os.environ.items()):
+            if is_cloud_build_substitution(name):
+                env_vars[name[1:]] = value
+
+        cloud_sql_host = env_vars.get("CLOUD_SQL_HOST")
+        if cloud_sql_host:
+            env_vars["DB_HOST"] = f"/cloudsql/{cloud_sql_host}"
+
+        print(export_lines(env_vars))
+    elif command == "cloud-run-json":
+        print(json.dumps(app_env(), ensure_ascii=False))
+    elif command == "cloud-run-env-vars":
+        print(",".join(f"{name}={value}" for name, value in app_env().items()))
+    elif command == "write":
+        if len(sys.argv) < 4:
+            usage()
+
+        output_file = sys.argv[2]
+        if sys.argv[3] == "--build":
+            if len(sys.argv) < 6:
+                usage()
+
+            project_id = sys.argv[4]
+            build_id = sys.argv[5]
+            region = sys.argv[6] if len(sys.argv) > 6 else "asia-northeast1"
+            write_substitutions(output_file, build_json_from_gcloud(project_id, build_id, region))
+        else:
+            with open(sys.argv[3], encoding="utf-8") as build_json:
+                write_substitutions(output_file, build_json.read())
+    else:
+        usage()
+
+
+if __name__ == "__main__":
+    main()

--- a/.cloudbuild/cloudbuild-link-checker-job.yaml
+++ b/.cloudbuild/cloudbuild-link-checker-job.yaml
@@ -1,10 +1,15 @@
 steps:
   - id: CreateOrUpdateJob
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    automapSubstitutions: true
     entrypoint: bash
     args:
       - '-c'
       - |
+        set -euo pipefail
+
+        env_vars="$(.cloudbuild/cloud-build-env cloud-run-env-vars)"
+
         # Cloud Run Jobが存在するか確認
         if gcloud run jobs describe link-checker --region=asia-northeast1 --project=$PROJECT_ID --quiet 2>/dev/null; then
           echo "既存のジョブを更新"
@@ -17,7 +22,7 @@ steps:
             --cpu=1 \
             --task-timeout=30m \
             --max-retries=1 \
-            --set-env-vars="RAILS_ENV=production,RAILS_MASTER_KEY=$_RAILS_MASTER_KEY,APP_HOST_NAME=$_APP_HOST_NAME,DB_HOST=/cloudsql/$_CLOUD_SQL_HOST,DB_NAME=$_DB_NAME,DB_PASS=$_DB_PASS,DB_USER=$_DB_USER,DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL,RAILS_LOG_TO_STDOUT=true"
+            --set-env-vars="$${env_vars}"
         else
           echo "新規ジョブを作成"
           gcloud run jobs create link-checker \
@@ -29,10 +34,11 @@ steps:
             --cpu=1 \
             --task-timeout=30m \
             --max-retries=1 \
-            --set-env-vars="RAILS_ENV=production,RAILS_MASTER_KEY=$_RAILS_MASTER_KEY,APP_HOST_NAME=$_APP_HOST_NAME,DB_HOST=/cloudsql/$_CLOUD_SQL_HOST,DB_NAME=$_DB_NAME,DB_PASS=$_DB_PASS,DB_USER=$_DB_USER,DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL,RAILS_LOG_TO_STDOUT=true"
+            --set-env-vars="$${env_vars}"
         fi
 options:
   substitutionOption: ALLOW_LOOSE
+  automapSubstitutions: true
 substitutions:
   _APP_HOST_NAME: bootcamp.fjord.jp
   _CLOUD_SQL_HOST: bootcamp-224405:asia-northeast1:bootcamp

--- a/.cloudbuild/cloudbuild-reset.yaml
+++ b/.cloudbuild/cloudbuild-reset.yaml
@@ -1,44 +1,54 @@
+---
 steps:
-  - id: Build
-    name: gcr.io/cloud-builders/docker
-    args:
-      - 'build'
-      - '--cache-from'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-      - '-t'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-      - '.'
-      - '-f'
-      - 'Dockerfile'
-  - id: SqlProxy
-    name: "gcr.io/cloudsql-docker/gce-proxy:1.16"
-    waitFor: ["-"]
-    volumes:
-      - name: db
-        path: "/cloudsql"
-    args: ["/cloud_sql_proxy", "-dir=/cloudsql", "-instances=$_CLOUD_SQL_HOST"]
-  - id: Task
-    name: "asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"
-    waitFor: ["Build"]
-    volumes:
-      - name: db
-        path: "/cloudsql"
-    args: ['bin/rails', 'bootcamp:reset']
-    env:
-      - 'RAILS_ENV=production'
-      - 'RAILS_MASTER_KEY=$_RAILS_MASTER_KEY'
-      - 'DB_HOST=/cloudsql/$_CLOUD_SQL_HOST'
-      - 'DB_NAME=$_DB_NAME'
-      - 'DB_PASS=$_DB_PASS'
-      - 'DB_USER=$_DB_USER'
-  - id: Kill_SqlProxy
-    name: "gcr.io/cloud-builders/docker"
-    waitFor: ["Task"]
-    entrypoint: "sh"
-    args: ["-c", 'docker kill -s TERM $(docker ps -q --filter "volume=db")']
-images: ['asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
+- id: Build
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - "--cache-from"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+  - "-t"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  - "."
+  - "-f"
+  - Dockerfile
+- id: SqlProxy
+  name: gcr.io/cloudsql-docker/gce-proxy:1.16
+  waitFor:
+  - "-"
+  volumes:
+  - name: db
+    path: "/cloudsql"
+  args:
+  - "/cloud_sql_proxy"
+  - "-dir=/cloudsql"
+  - "-instances=$_CLOUD_SQL_HOST"
+- id: Task
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  automapSubstitutions: true
+  waitFor:
+  - Build
+  volumes:
+  - name: db
+    path: "/cloudsql"
+  args:
+  - bash
+  - "-c"
+  - |-
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    bin/rails bootcamp:reset
+- id: Kill_SqlProxy
+  name: gcr.io/cloud-builders/docker
+  waitFor:
+  - Task
+  entrypoint: sh
+  args:
+  - "-c"
+  - docker kill -s TERM $(docker ps -q --filter "volume=db")
+images:
+- asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
 options:
   substitutionOption: ALLOW_LOOSE
+  automapSubstitutions: true
 substitutions:
   _CLOUD_SQL_HOST: _
   _DB_NAME: _
@@ -46,6 +56,6 @@ substitutions:
   _DB_USER: _
   _RAILS_MASTER_KEY: _
 tags:
-  - gcp-cloud-build-task
-  - bootcamp
+- gcp-cloud-build-task
+- bootcamp
 timeout: 1800s

--- a/.cloudbuild/cloudbuild-review-cleanup.yaml
+++ b/.cloudbuild/cloudbuild-review-cleanup.yaml
@@ -1,105 +1,108 @@
+---
 steps:
-  - id: DeleteCloudRun
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        SERVICE_NAME="bootcamp-pr-${_PR_NUMBER}"
-        echo "Deleting Cloud Run service: $${SERVICE_NAME}..."
-        if gcloud run services describe $${SERVICE_NAME} --region=asia-northeast1 --quiet 2>/dev/null; then
-          gcloud run services delete $${SERVICE_NAME} --region=asia-northeast1 --quiet
-          echo "Service deleted. Waiting 30s for connections to close..."
-          sleep 30
-        else
-          echo "Service does not exist. Skipping."
-        fi
-  - id: SqlProxy
-    name: 'gcr.io/cloudsql-docker/gce-proxy:1.16'
-    args:
-      - /cloud_sql_proxy
-      - '-dir=/cloudsql'
-      - '-instances=$_CLOUD_SQL_HOST'
-    waitFor:
-      - DeleteCloudRun
-    volumes:
-      - name: db
-        path: /cloudsql
-  - id: WaitForProxy
-    name: postgres:16-alpine
-    entrypoint: sh
-    args:
-      - '-c'
-      - |
-        set -eu
-        echo "Waiting for Cloud SQL Proxy..."
-        TIMEOUT=60
-        ELAPSED=0
-        while [ $$ELAPSED -lt $$TIMEOUT ]; do
-          if PGPASSWORD=$_DB_PASS PGCONNECT_TIMEOUT=2 psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c "SELECT 1"; then
-            echo "Proxy ready."
-            exit 0
-          fi
-          sleep 2
-          ELAPSED=$$(($$ELAPSED + 2))
-        done
-        echo "ERROR: Timeout"
+- id: DeleteCloudRun
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    set -euo pipefail
+    SERVICE_NAME="bootcamp-pr-${_PR_NUMBER}"
+    echo "Deleting Cloud Run service: $${SERVICE_NAME}..."
+    if gcloud run services describe $${SERVICE_NAME} --region=asia-northeast1 --quiet 2>/dev/null; then
+      gcloud run services delete $${SERVICE_NAME} --region=asia-northeast1 --quiet
+      echo "Service deleted. Waiting 30s for connections to close..."
+      sleep 30
+    else
+      echo "Service does not exist. Skipping."
+    fi
+- id: SqlProxy
+  name: gcr.io/cloudsql-docker/gce-proxy:1.16
+  args:
+  - "/cloud_sql_proxy"
+  - "-dir=/cloudsql"
+  - "-instances=$_CLOUD_SQL_HOST"
+  waitFor:
+  - DeleteCloudRun
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: WaitForProxy
+  name: postgres:16-alpine
+  entrypoint: sh
+  args:
+  - "-c"
+  - |
+    set -eu
+    echo "Waiting for Cloud SQL Proxy..."
+    TIMEOUT=60
+    ELAPSED=0
+    while [ $$ELAPSED -lt $$TIMEOUT ]; do
+      if PGPASSWORD=$_DB_PASS PGCONNECT_TIMEOUT=2 psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c "SELECT 1"; then
+        echo "Proxy ready."
+        exit 0
+      fi
+      sleep 2
+      ELAPSED=$$(($$ELAPSED + 2))
+    done
+    echo "ERROR: Timeout"
+    exit 1
+  waitFor:
+  - DeleteCloudRun
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: DropDB
+  name: postgres:16-alpine
+  entrypoint: sh
+  args:
+  - "-c"
+  - |
+    set -eu
+    case "${_PR_NUMBER}" in
+      (*[!0-9]*|'')
+        echo "Invalid PR number: ${_PR_NUMBER}" >&2
         exit 1
-    waitFor:
-      - DeleteCloudRun
-    volumes:
-      - name: db
-        path: /cloudsql
-  - id: DropDB
-    name: postgres:16-alpine
-    entrypoint: sh
-    args:
-      - '-c'
-      - |
-        set -eu
-        case "${_PR_NUMBER}" in
-          (*[!0-9]*|'')
-            echo "Invalid PR number: ${_PR_NUMBER}" >&2
-            exit 1
-            ;;
-        esac
-        DB_NAME="bootcamp_pr_${_PR_NUMBER}"
-        echo "Terminating connections to $${DB_NAME}..."
-        PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c \
-          "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$${DB_NAME}' AND pid <> pg_backend_pid();"
-        echo "Dropping database $${DB_NAME}..."
-        PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c \
-          "DROP DATABASE IF EXISTS $${DB_NAME};"
-        echo "Done."
-    waitFor:
-      - WaitForProxy
-    volumes:
-      - name: db
-        path: /cloudsql
-  - id: Kill_SqlProxy
-    name: gcr.io/cloud-builders/docker
-    entrypoint: sh
-    args:
-      - '-c'
-      - 'CONTAINER=$$(docker ps -q --filter "volume=db"); [ -n "$$CONTAINER" ] && docker kill -s TERM $$CONTAINER || echo "No proxy container found"'
-    waitFor:
-      - DropDB
-  - id: DeleteImage
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        IMAGE="asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}"
-        echo "Deleting image $${IMAGE}..."
-        gcloud container images delete $${IMAGE} --quiet --force-delete-tags 2>/dev/null || echo "Image not found, skipping."
-    waitFor:
-      - Kill_SqlProxy
+        ;;
+    esac
+    DB_NAME="bootcamp_pr_${_PR_NUMBER}"
+    echo "Terminating connections to $${DB_NAME}..."
+    PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c \
+      "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$${DB_NAME}' AND pid <> pg_backend_pid();"
+    echo "Dropping database $${DB_NAME}..."
+    PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c \
+      "DROP DATABASE IF EXISTS $${DB_NAME};"
+    echo "Done."
+  waitFor:
+  - WaitForProxy
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: Kill_SqlProxy
+  name: gcr.io/cloud-builders/docker
+  entrypoint: sh
+  args:
+  - "-c"
+  - CONTAINER=$$(docker ps -q --filter "volume=db"); [ -n "$$CONTAINER" ] && docker kill -s TERM $$CONTAINER || echo "No proxy container found"
+  waitFor:
+  - DropDB
+- id: DeleteImage
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    set -euo pipefail
+    IMAGE="asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}"
+    echo "Deleting image $${IMAGE}..."
+    gcloud container images delete $${IMAGE} --quiet --force-delete-tags 2>/dev/null || echo "Image not found, skipping."
+  waitFor:
+  - Kill_SqlProxy
 timeout: 1800s
 substitutions:
   _PR_NUMBER: '0'
-  _CLOUD_SQL_HOST: 'bootcamp-224405:asia-northeast1:bootcamp'
-  _DB_USER: 'review'
+  _CLOUD_SQL_HOST: bootcamp-224405:asia-northeast1:bootcamp
+  _DB_USER: review
   _DB_PASS: ''
+options:
+  automapSubstitutions: true

--- a/.cloudbuild/cloudbuild-review.yaml
+++ b/.cloudbuild/cloudbuild-review.yaml
@@ -1,218 +1,161 @@
+---
 steps:
-  - id: Fetch
-    name: gcr.io/cloud-builders/docker
-    entrypoint: bash
-    args:
-      - '-c'
-      - 'docker pull asia.gcr.io/bootcamp-224405/bootcamp:latest || exit 0'
-  - id: Build
-    name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '-t'
-      - 'asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}'
-      - .
-      - '-f'
-      - Dockerfile
-  - id: Push
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - 'asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}'
-    waitFor:
-      - Build
-  - id: SqlProxy
-    name: 'gcr.io/cloudsql-docker/gce-proxy:1.16'
-    args:
-      - /cloud_sql_proxy
-      - '-dir=/cloudsql'
-      - '-instances=$_CLOUD_SQL_HOST'
-    waitFor:
-      - Push
-    volumes:
-      - name: db
-        path: /cloudsql
-  - id: WaitForProxy
-    name: 'asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}'
-    args:
-      - bash
-      - '-c'
-      - |
-        echo "Waiting for Cloud SQL Proxy to be ready..."
-        TIMEOUT=300
-        ELAPSED=0
-        while [ $$ELAPSED -lt $$TIMEOUT ]; do
-          if OUTPUT=$$(cat <<'TESTEOF' | bin/rails runner - 2>&1
-        begin
-          ActiveRecord::Base.connection.execute("SELECT 1")
-          puts "Database connection successful"
-          exit 0
-        rescue => e
-          puts "Connection failed: #{e.message}"
-          exit 1
-        end
-        TESTEOF
-          ); then
-            echo "$$OUTPUT"
-            echo "Cloud SQL Proxy is ready."
-            exit 0
-          fi
-          echo "Database not ready yet, waiting..."
-          sleep 2
-          ELAPSED=$$(($$ELAPSED + 2))
-        done
-        echo "ERROR: Timeout waiting for Cloud SQL Proxy"
+- id: Fetch
+  name: gcr.io/cloud-builders/docker
+  entrypoint: bash
+  args:
+  - "-c"
+  - docker pull asia.gcr.io/bootcamp-224405/bootcamp:latest || exit 0
+- id: Build
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - "-t"
+  - asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}
+  - "."
+  - "-f"
+  - Dockerfile
+- id: Push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}
+  waitFor:
+  - Build
+- id: WriteSubstitutionEnv
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  entrypoint: python3
+  args:
+  - ".cloudbuild/cloud-build-env"
+  - write
+  - ".cloudbuild/substitutions.env"
+  - --build
+  - "$PROJECT_ID"
+  - "$BUILD_ID"
+  - asia-northeast1
+  waitFor:
+  - Push
+- id: SqlProxy
+  name: gcr.io/cloudsql-docker/gce-proxy:1.16
+  args:
+  - "/cloud_sql_proxy"
+  - "-dir=/cloudsql"
+  - "-instances=$_CLOUD_SQL_HOST"
+  waitFor:
+  - Push
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: WaitForProxy
+  name: postgres:16-alpine
+  entrypoint: sh
+  args:
+  - "-c"
+  - |
+    set -eu
+    echo "Waiting for Cloud SQL Proxy to be ready..."
+    TIMEOUT=300
+    ELAPSED=0
+    while [ $$ELAPSED -lt $$TIMEOUT ]; do
+      if PGPASSWORD=$_DB_PASS PGCONNECT_TIMEOUT=2 psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c "SELECT 1"; then
+        echo "Cloud SQL Proxy is ready."
+        exit 0
+      fi
+      echo "Database not ready yet, waiting..."
+      sleep 2
+      ELAPSED=$$(($$ELAPSED + 2))
+    done
+    echo "ERROR: Timeout waiting for Cloud SQL Proxy"
+    exit 1
+  waitFor:
+  - Push
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: CreateDB
+  name: postgres:16-alpine
+  entrypoint: sh
+  args:
+  - "-c"
+  - |
+    set -eu
+    case "$_DB_NAME" in
+      (*[!a-zA-Z0-9_]*|'')
+        echo "Invalid DB name: $_DB_NAME" >&2
         exit 1
-    waitFor:
-      - Push
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=postgres
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  - id: CreateDB
-    name: 'asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}'
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        echo "Creating database $_DB_NAME (drop if exists)..."
-        cat <<'SQLEOF' | bin/rails runner - 2>&1
-        db_name = ENV.fetch("TARGET_DB_NAME")
-        quoted = ActiveRecord::Base.connection.quote(db_name)
-        ActiveRecord::Base.connection.execute(<<~SQL)
-          SELECT pg_terminate_backend(pid)
-          FROM pg_stat_activity
-          WHERE datname = #{quoted}
-            AND pid <> pg_backend_pid()
-        SQL
-        ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS #{db_name}")
-        ActiveRecord::Base.connection.execute("CREATE DATABASE #{db_name}")
-        puts "Database #{db_name} created successfully"
-        SQLEOF
-    waitFor:
-      - WaitForProxy
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=postgres
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-      - TARGET_DB_NAME=$_DB_NAME
-  - id: EnablePgvector
-    name: 'asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}'
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        echo "Enabling pgvector extension..."
-        cat <<'SQLEOF' | bin/rails runner - 2>&1
-        ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
-        puts "pgvector extension enabled"
-        SQLEOF
-    waitFor:
-      - CreateDB
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=$_DB_NAME
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  - id: DBMigrate
-    name: 'asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}'
-    args:
-      - bin/rails
-      - db:migrate
-      - db:seed
-    waitFor:
-      - EnablePgvector
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=$_DB_NAME
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  - id: Kill_SqlProxy
-    name: gcr.io/cloud-builders/docker
-    entrypoint: sh
-    args:
-      - '-c'
-      - 'CONTAINER=$$(docker ps -q --filter "volume=db"); [ -n "$$CONTAINER" ] && docker kill -s TERM $$CONTAINER || echo "No proxy container found"'
-    waitFor:
-      - DBMigrate
-  - id: Deploy
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
-    args:
-      - .cloudbuild/deploy-cloud-run
-      - review
-    env:
-      - PROJECT_ID=$PROJECT_ID
-      - COMMIT_SHA=$COMMIT_SHA
-      - BUILD_ID=$BUILD_ID
-      - _ANTHROPIC_API_KEY=$_ANTHROPIC_API_KEY
-      - _APP_HOST_NAME=$_APP_HOST_NAME
-      - _BASIC_AUTH_PASSWORD=$_BASIC_AUTH_PASSWORD
-      - _BASIC_AUTH_USER=$_BASIC_AUTH_USER
-      - _CLOUD_RUN_HOST_NAME=$_CLOUD_RUN_HOST_NAME
-      - _CLOUD_SQL_HOST=$_CLOUD_SQL_HOST
-      - _DB_NAME=$_DB_NAME
-      - _DB_PASS=$_DB_PASS
-      - _DB_USER=$_DB_USER
-      - _GCS_BUCKET=$_GCS_BUCKET
-      - _GITHUB_KEY=$_GITHUB_KEY
-      - _GITHUB_SECRET=$_GITHUB_SECRET
-      - _GOOGLE_CREDENTIALS=$_GOOGLE_CREDENTIALS
-      - _MEMORY=$_MEMORY
-      - _MISSION_CONTROL_PASSWORD=$_MISSION_CONTROL_PASSWORD
-      - _MISSION_CONTROL_USERNAME=$_MISSION_CONTROL_USERNAME
-      - _OPEN_AI_ACCESS_TOKEN=$_OPEN_AI_ACCESS_TOKEN
-      - _POSTMARK_API_TOKEN=$_POSTMARK_API_TOKEN
-      - _PR_NUMBER=$_PR_NUMBER
-      - _RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - _RECAPTCHA_SECRET_KEY=$_RECAPTCHA_SECRET_KEY
-      - _RECAPTCHA_SITE_KEY=$_RECAPTCHA_SITE_KEY
-      - _SERVICE_NAME=$_SERVICE_NAME
-      - _STRIPE_PUBLIC_KEY=$_STRIPE_PUBLIC_KEY
-      - _STRIPE_SECRET_KEY=$_STRIPE_SECRET_KEY
-      - _TOKEN=$_TOKEN
-    waitFor:
-      - Kill_SqlProxy
+        ;;
+    esac
+    echo "Creating database $_DB_NAME (drop if exists)..."
+    PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c \
+      "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$_DB_NAME' AND pid <> pg_backend_pid();"
+    PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c \
+      "DROP DATABASE IF EXISTS $_DB_NAME;"
+    PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d postgres -c \
+      "CREATE DATABASE $_DB_NAME;"
+    echo "Database $_DB_NAME created successfully"
+  waitFor:
+  - WaitForProxy
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: EnablePgvector
+  name: postgres:16-alpine
+  entrypoint: sh
+  args:
+  - "-c"
+  - |
+    set -eu
+    echo "Enabling pgvector extension..."
+    PGPASSWORD=$_DB_PASS psql -h /cloudsql/$_CLOUD_SQL_HOST -U $_DB_USER -d $_DB_NAME -c \
+      "CREATE EXTENSION IF NOT EXISTS vector;"
+    echo "pgvector extension enabled"
+  waitFor:
+  - CreateDB
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: DBMigrate
+  name: asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}
+  automapSubstitutions: true
+  args:
+  - bash
+  - "-c"
+  - |-
+    source .cloudbuild/substitutions.env
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    bin/rails db:migrate db:seed
+  waitFor:
+  - EnablePgvector
+  - WriteSubstitutionEnv
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: Kill_SqlProxy
+  name: gcr.io/cloud-builders/docker
+  entrypoint: sh
+  args:
+  - "-c"
+  - CONTAINER=$$(docker ps -q --filter "volume=db"); [ -n "$$CONTAINER" ] && docker kill -s TERM $$CONTAINER || echo "No proxy container found"
+  waitFor:
+  - DBMigrate
+- id: Deploy
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  automapSubstitutions: true
+  entrypoint: bash
+  args:
+  - ".cloudbuild/deploy-cloud-run"
+  - review
+  waitFor:
+  - Kill_SqlProxy
 options:
   substitutionOption: ALLOW_LOOSE
+  automapSubstitutions: true
 timeout: 7200s
 images:
-  - 'asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}'
+- asia.gcr.io/bootcamp-224405/bootcamp:pr-${_PR_NUMBER}
 substitutions:
   _PR_NUMBER: '0'
-  _MEMORY: '2G'
+  _MEMORY: 2G
   _ANTHROPIC_API_KEY: ''
   _APP_HOST_NAME: ''
   _BASIC_AUTH_PASSWORD: ''

--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -1,307 +1,226 @@
+---
 steps:
-  - id: Fetch
-    name: gcr.io/cloud-builders/docker
-    entrypoint: bash
-    args:
-      - '-c'
-      - 'docker pull asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest || exit 0'
-  - id: Build
-    name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '-t'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-      - '-t'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-      - .
-      - '-f'
-      - Dockerfile
-  - id: Push
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-    waitFor:
-      - Build
-  # Cloud Runサービスを削除してDB接続を切断し、Deployで再作成される
-  - id: StopCloudRun
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
-        echo "Deleting Cloud Run service to disconnect database connections..."
+- id: Fetch
+  name: gcr.io/cloud-builders/docker
+  entrypoint: bash
+  args:
+  - "-c"
+  - docker pull asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest || exit 0
+- id: Build
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - "-t"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  - "-t"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+  - "."
+  - "-f"
+  - Dockerfile
+- id: Push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  waitFor:
+  - Build
+- id: StopCloudRun
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    set -euo pipefail
+    echo "Deleting Cloud Run service to disconnect database connections..."
 
-        # サービスが存在するか確認して削除
-        if gcloud run services describe $_SERVICE_NAME --region=asia-northeast1 --quiet 2>/dev/null; then
-          gcloud run services delete $_SERVICE_NAME \
-            --region=asia-northeast1 \
-            --quiet
+    # サービスが存在するか確認して削除
+    if gcloud run services describe $_SERVICE_NAME --region=asia-northeast1 --quiet 2>/dev/null; then
+      gcloud run services delete $_SERVICE_NAME \
+        --region=asia-northeast1 \
+        --quiet
 
-          echo "Cloud Run service deleted. Waiting 60 seconds for connections to close..."
-          sleep 60
-        else
-          echo "Cloud Run service does not exist yet. Skipping delete."
-        fi
-    waitFor:
-      - Push
-  - id: SqlProxy
-    name: 'gcr.io/cloudsql-docker/gce-proxy:1.16'
-    args:
-      - /cloud_sql_proxy
-      - '-dir=/cloudsql'
-      - '-instances=$_CLOUD_SQL_HOST'
-    waitFor:
-      - StopCloudRun
-    volumes:
-      - name: db
-        path: /cloudsql
-  # Cloud SQL Proxyの起動を待つ
-  - id: WaitForProxy
-    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-    args:
-      - bash
-      - '-c'
-      - |
-        set -euo pipefail
+      echo "Cloud Run service deleted. Waiting 60 seconds for connections to close..."
+      sleep 60
+    else
+      echo "Cloud Run service does not exist yet. Skipping delete."
+    fi
+  waitFor:
+  - Push
+- id: SqlProxy
+  name: gcr.io/cloudsql-docker/gce-proxy:1.16
+  args:
+  - "/cloud_sql_proxy"
+  - "-dir=/cloudsql"
+  - "-instances=$_CLOUD_SQL_HOST"
+  waitFor:
+  - StopCloudRun
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: WaitForProxy
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  automapSubstitutions: true
+  args:
+  - bash
+  - "-c"
+  - |
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    set -euo pipefail
 
-        echo "Waiting for Cloud SQL Proxy to be ready..."
-        TIMEOUT=60
-        ELAPSED=0
+    echo "Waiting for Cloud SQL Proxy to be ready..."
+    TIMEOUT=60
+    ELAPSED=0
 
-        while [ $$ELAPSED -lt $$TIMEOUT ]; do
-          echo "Attempting database connection... ($$ELAPSED/$$TIMEOUT seconds)"
-          OUTPUT=$$(cat <<'TESTEOF' | bin/rails runner - 2>&1
-        begin
-          ActiveRecord::Base.connection.execute("SELECT 1")
-          puts "Database connection successful"
-          exit 0
-        rescue => e
-          puts "Connection failed: #{e.message}"
-          exit 1
-        end
-        TESTEOF
-          )
-          EXITCODE=$$?
-          if [ $$EXITCODE -eq 0 ]; then
-            echo "$$OUTPUT"
-            echo "Cloud SQL Proxy is ready."
-            exit 0
-          else
-            echo "Rails runner output: $$OUTPUT"
-            echo "Database not ready yet, waiting..."
-          fi
-          sleep 2
-          ELAPSED=$$(($$ELAPSED + 2))
-        done
+    while [ $$ELAPSED -lt $$TIMEOUT ]; do
+      echo "Attempting database connection... ($$ELAPSED/$$TIMEOUT seconds)"
+      OUTPUT=$$(cat <<'TESTEOF' | bin/rails runner - 2>&1
+    begin
+      ActiveRecord::Base.connection.execute("SELECT 1")
+      puts "Database connection successful"
+      exit 0
+    rescue => e
+      puts "Connection failed: #{e.message}"
+      exit 1
+    end
+    TESTEOF
+      )
+      EXITCODE=$$?
+      if [ $$EXITCODE -eq 0 ]; then
+        echo "$$OUTPUT"
+        echo "Cloud SQL Proxy is ready."
+        exit 0
+      else
+        echo "Rails runner output: $$OUTPUT"
+        echo "Database not ready yet, waiting..."
+      fi
+      sleep 2
+      ELAPSED=$$(($$ELAPSED + 2))
+    done
 
-        echo "ERROR: Timeout waiting for Cloud SQL Proxy after $$TIMEOUT seconds"
-        exit 1
-    waitFor:
-      - StopCloudRun
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=postgres
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  # bootcamp_stagingへの接続を強制切断してからデータベースを削除
-  - id: DeleteDB
-    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
+    echo "ERROR: Timeout waiting for Cloud SQL Proxy after $$TIMEOUT seconds"
+    exit 1
+  waitFor:
+  - StopCloudRun
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: DeleteDB
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  automapSubstitutions: true
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    set -euo pipefail
 
-        echo "Terminating all connections to bootcamp_staging..."
-        cat <<'SQLEOF' | bin/rails runner - 2>&1
-        result = ActiveRecord::Base.connection.execute(<<~SQL)
-          SELECT pg_terminate_backend(pid)
-          FROM pg_stat_activity
-          WHERE datname = 'bootcamp_staging'
-            AND pid <> pg_backend_pid()
-        SQL
-        puts "Terminated #{result.count} connection(s)"
-        SQLEOF
+    echo "Terminating all connections to bootcamp_staging..."
+    cat <<'SQLEOF' | bin/rails runner - 2>&1
+    result = ActiveRecord::Base.connection.execute(<<~SQL)
+      SELECT pg_terminate_backend(pid)
+      FROM pg_stat_activity
+      WHERE datname = 'bootcamp_staging'
+        AND pid <> pg_backend_pid()
+    SQL
+    puts "Terminated #{result.count} connection(s)"
+    SQLEOF
 
-        echo "Dropping database bootcamp_staging..."
-        cat <<'SQLEOF' | bin/rails runner - 2>&1
-        ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS bootcamp_staging")
-        puts "Database dropped successfully"
-        SQLEOF
-    waitFor:
-      - WaitForProxy
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=postgres
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  - id: CreateDB
-    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
+    echo "Dropping database bootcamp_staging..."
+    cat <<'SQLEOF' | bin/rails runner - 2>&1
+    ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS bootcamp_staging")
+    puts "Database dropped successfully"
+    SQLEOF
+  waitFor:
+  - WaitForProxy
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: CreateDB
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  automapSubstitutions: true
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    set -euo pipefail
 
-        echo "Creating database bootcamp_staging..."
-        cat <<'SQLEOF' | bin/rails runner - 2>&1
-        ActiveRecord::Base.connection.execute("CREATE DATABASE bootcamp_staging")
-        puts "Database created successfully"
-        SQLEOF
-    waitFor:
-      - DeleteDB
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=postgres
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  - id: EnablePgvector
-    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-    entrypoint: bash
-    args:
-      - '-c'
-      - |
-        set -euo pipefail
+    echo "Creating database bootcamp_staging..."
+    cat <<'SQLEOF' | bin/rails runner - 2>&1
+    ActiveRecord::Base.connection.execute("CREATE DATABASE bootcamp_staging")
+    puts "Database created successfully"
+    SQLEOF
+  waitFor:
+  - DeleteDB
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: EnablePgvector
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  automapSubstitutions: true
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    set -euo pipefail
 
-        echo "Enabling pgvector extension on bootcamp_staging..."
-        cat <<'SQLEOF' | bin/rails runner - 2>&1
-        ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
-        puts "pgvector extension enabled"
-        SQLEOF
-    waitFor:
-      - CreateDB
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=$_DB_NAME
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  - id: DBMigrate
-    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-    args:
-      - bin/rails
-      - db:migrate
-      - db:seed
-    waitFor:
-      - EnablePgvector
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=$_DB_NAME
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  - id: Kill_SqlProxy
-    name: gcr.io/cloud-builders/docker
-    entrypoint: sh
-    args:
-      - '-c'
-      - docker kill -s TERM $(docker ps -q --filter "volume=db")
-    waitFor:
-      - DBMigrate
-  - id: Deploy
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
-    args:
-      - .cloudbuild/deploy-cloud-run
-      - staging
-    env:
-      - PROJECT_ID=$PROJECT_ID
-      - REPO_NAME=$REPO_NAME
-      - COMMIT_SHA=$COMMIT_SHA
-      - BUILD_ID=$BUILD_ID
-      - _ANTHROPIC_API_KEY=$_ANTHROPIC_API_KEY
-      - _APP_HOST_NAME=$_APP_HOST_NAME
-      - _BASIC_AUTH_PASSWORD=$_BASIC_AUTH_PASSWORD
-      - _BASIC_AUTH_USER=$_BASIC_AUTH_USER
-      - _CLOUD_RUN_HOST_NAME=$_CLOUD_RUN_HOST_NAME
-      - _CLOUD_SQL_HOST=$_CLOUD_SQL_HOST
-      - _DB_NAME=$_DB_NAME
-      - _DB_PASS=$_DB_PASS
-      - _DB_USER=$_DB_USER
-      - _DISCORD_ADMIN_WEBHOOK_URL=$_DISCORD_ADMIN_WEBHOOK_URL
-      - _DISCORD_ALL_WEBHOOK_URL=$_DISCORD_ALL_WEBHOOK_URL
-      - _DISCORD_AUTHENTICATION_URL=$_DISCORD_AUTHENTICATION_URL
-      - _DISCORD_BOT_TOKEN=$_DISCORD_BOT_TOKEN
-      - _DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL
-      - _DISCORD_CLIENT_ID=$_DISCORD_CLIENT_ID
-      - _DISCORD_CLIENT_SECRET=$_DISCORD_CLIENT_SECRET
-      - _DISCORD_GUILD_ID=$_DISCORD_GUILD_ID
-      - _DISCORD_INTRODUCTION_WEBHOOK_URL=$_DISCORD_INTRODUCTION_WEBHOOK_URL
-      - _DISCORD_MENTOR_WEBHOOK_URL=$_DISCORD_MENTOR_WEBHOOK_URL
-      - _DISCORD_NOTICE_WEBHOOK_URL=$_DISCORD_NOTICE_WEBHOOK_URL
-      - _DISCORD_REPORT_WEBHOOK_URL=$_DISCORD_REPORT_WEBHOOK_URL
-      - _DISCORD_TIMES_CHANNEL_CATEGORY_ID=$_DISCORD_TIMES_CHANNEL_CATEGORY_ID
-      - _ENVS=$_ENVS
-      - _GCS_BUCKET=$_GCS_BUCKET
-      - _GOOGLE_CREDENTIALS=$_GOOGLE_CREDENTIALS
-      - _LABELS=$_LABELS
-      - _MEMORY=$_MEMORY
-      - _MISSION_CONTROL_PASSWORD=$_MISSION_CONTROL_PASSWORD
-      - _MISSION_CONTROL_USERNAME=$_MISSION_CONTROL_USERNAME
-      - _OPEN_AI_ACCESS_TOKEN=$_OPEN_AI_ACCESS_TOKEN
-      - _PJORD_GITHUB_TOKEN=$_PJORD_GITHUB_TOKEN
-      - _PUBSUB_AUDIENCE=$_PUBSUB_AUDIENCE
-      - _PUBSUB_SERVICE_ACCOUNT_EMAIL=$_PUBSUB_SERVICE_ACCOUNT_EMAIL
-      - _PUBSUB_TOPIC=$_PUBSUB_TOPIC
-      - _RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - _RECAPTCHA_SECRET_KEY=$_RECAPTCHA_SECRET_KEY
-      - _RECAPTCHA_SITE_KEY=$_RECAPTCHA_SITE_KEY
-      - _ROLLBAR_CLIENT_TOKEN=$_ROLLBAR_CLIENT_TOKEN
-      - _SERVICE_ACCOUNT=$_SERVICE_ACCOUNT
-      - _SERVICE_NAME=$_SERVICE_NAME
-      - _STRIPE_ENDPOINT_SECRET=$_STRIPE_ENDPOINT_SECRET
-      - _STRIPE_TAX_RATE_ID=$_STRIPE_TAX_RATE_ID
-      - _TOKEN=$_TOKEN
-      - _TRIGGER_ID=$_TRIGGER_ID
-  - id: Notify
-    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-    args:
-      - bin/notify
-    waitFor:
-      - Deploy
-    env:
-      - DB_NAME=$_DB_NAME
-      - DEPLOY_NOTIFY_WEBHOOK_URL=$_DEPLOY_NOTIFY_WEBHOOK_URL
+    echo "Enabling pgvector extension on bootcamp_staging..."
+    cat <<'SQLEOF' | bin/rails runner - 2>&1
+    ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    puts "pgvector extension enabled"
+    SQLEOF
+  waitFor:
+  - CreateDB
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: DBMigrate
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  automapSubstitutions: true
+  args:
+  - bash
+  - "-c"
+  - |-
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    bin/rails db:migrate db:seed
+  waitFor:
+  - EnablePgvector
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: Kill_SqlProxy
+  name: gcr.io/cloud-builders/docker
+  entrypoint: sh
+  args:
+  - "-c"
+  - docker kill -s TERM $(docker ps -q --filter "volume=db")
+  waitFor:
+  - DBMigrate
+- id: Deploy
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  automapSubstitutions: true
+  entrypoint: bash
+  args:
+  - ".cloudbuild/deploy-cloud-run"
+  - staging
+- id: Notify
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+  automapSubstitutions: true
+  args:
+  - bash
+  - "-c"
+  - |-
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    bin/notify
+  waitFor:
+  - Deploy
 options:
   substitutionOption: ALLOW_LOOSE
+  automapSubstitutions: true
 timeout: 7200s
 images:
-  - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
+- asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
 substitutions:
   _APP_HOST_NAME: bootcamp-staging.fjord.jp
   _BASIC_AUTH_USER: ''
@@ -312,6 +231,7 @@ substitutions:
   _GCS_BUCKET: ''
   _LABELS: ''
   _MEMORY: ''
+  _DEPLOY_NOTIFY_WEBHOOK_URL: ''
   _SERVICE_ACCOUNT: staging@bootcamp-224405.iam.gserviceaccount.com
   _SERVICE_NAME: ''
   _TRIGGER_ID: ''

--- a/.cloudbuild/cloudbuild-task.yaml
+++ b/.cloudbuild/cloudbuild-task.yaml
@@ -1,46 +1,54 @@
+---
 steps:
-  - id: Build
-    name: gcr.io/cloud-builders/docker
-    args:
-      - 'build'
-      - '--cache-from'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-      - '-t'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-      - '.'
-      - '-f'
-      - 'Dockerfile'
-  - id: SqlProxy
-    name: "gcr.io/cloudsql-docker/gce-proxy:1.16"
-    waitFor: ["-"]
-    volumes:
-      - name: db
-        path: "/cloudsql"
-    args: ["/cloud_sql_proxy", "-dir=/cloudsql", "-instances=$_CLOUD_SQL_HOST"]
-  - id: Task
-    name: "asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"
-    waitFor: ["Build"]
-    volumes:
-      - name: db
-        path: "/cloudsql"
-    args: ['bin/rails', 'bootcamp:oneshot:cloudbuild']
-    env:
-      - 'RAILS_ENV=production'
-      - 'RAILS_MASTER_KEY=$_RAILS_MASTER_KEY'
-      - 'APP_HOST_NAME=$_APP_HOST_NAME'
-      - 'DB_HOST=/cloudsql/$_CLOUD_SQL_HOST'
-      - 'DB_NAME=$_DB_NAME'
-      - 'DB_PASS=$_DB_PASS'
-      - 'DB_USER=$_DB_USER'
-      - 'OPEN_AI_ACCESS_TOKEN=$_OPEN_AI_ACCESS_TOKEN'
-  - id: Kill_SqlProxy
-    name: "gcr.io/cloud-builders/docker"
-    waitFor: ["Task"]
-    entrypoint: "sh"
-    args: ["-c", 'docker kill -s TERM $(docker ps -q --filter "volume=db")']
-images: ['asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
+- id: Build
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - "--cache-from"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+  - "-t"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  - "."
+  - "-f"
+  - Dockerfile
+- id: SqlProxy
+  name: gcr.io/cloudsql-docker/gce-proxy:1.16
+  waitFor:
+  - "-"
+  volumes:
+  - name: db
+    path: "/cloudsql"
+  args:
+  - "/cloud_sql_proxy"
+  - "-dir=/cloudsql"
+  - "-instances=$_CLOUD_SQL_HOST"
+- id: Task
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  automapSubstitutions: true
+  waitFor:
+  - Build
+  volumes:
+  - name: db
+    path: "/cloudsql"
+  args:
+  - bash
+  - "-c"
+  - |-
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    bin/rails bootcamp:oneshot:cloudbuild
+- id: Kill_SqlProxy
+  name: gcr.io/cloud-builders/docker
+  waitFor:
+  - Task
+  entrypoint: sh
+  args:
+  - "-c"
+  - docker kill -s TERM $(docker ps -q --filter "volume=db")
+images:
+- asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
 options:
   substitutionOption: ALLOW_LOOSE
+  automapSubstitutions: true
 substitutions:
   _APP_HOST_NAME: _
   _CLOUD_SQL_HOST: _
@@ -50,6 +58,6 @@ substitutions:
   _OPEN_AI_ACCESS_TOKEN: _
   _RAILS_MASTER_KEY: _
 tags:
-  - gcp-cloud-build-task
-  - bootcamp
+- gcp-cloud-build-task
+- bootcamp
 timeout: 43200s

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -1,133 +1,122 @@
+---
 steps:
-  - id: Fetch
-    name: gcr.io/cloud-builders/docker
-    entrypoint: bash
-    args:
-      - '-c'
-      - 'docker pull asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest || exit 0'
-  - id: Build
-    name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '-t'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-      - '-t'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-      - '--cache-from'
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-      - .
-      - '-f'
-      - Dockerfile
-  - id: Push
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-  - id: SqlProxy
-    name: 'gcr.io/cloudsql-docker/gce-proxy:1.16'
-    args:
-      - /cloud_sql_proxy
-      - '-dir=/cloudsql'
-      - '-instances=$_CLOUD_SQL_HOST'
-    waitFor:
-      - '-'
-    volumes:
-      - name: db
-        path: /cloudsql
-  - id: DB_Migrate
-    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-    args:
-      - bin/rails
-      - db:migrate:with_data
-    waitFor:
-      - Push
-    volumes:
-      - name: db
-        path: /cloudsql
-    env:
-      - RAILS_ENV=production
-      - DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-      - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
-      - DB_NAME=$_DB_NAME
-      - DB_PASS=$_DB_PASS
-      - DB_USER=$_DB_USER
-      - RAILS_MASTER_KEY=$_RAILS_MASTER_KEY
-      - APP_HOST_NAME=$_APP_HOST_NAME
-  - id: Kill_SqlProxy
-    name: gcr.io/cloud-builders/docker
-    entrypoint: sh
-    args:
-      - '-c'
-      - docker kill -s TERM $(docker ps -q --filter "volume=db")
-    waitFor:
-      - DB_Migrate
-  - id: Deploy
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
-    args:
-      - .cloudbuild/deploy-cloud-run
-      - production
-    env:
-      - PROJECT_ID=$PROJECT_ID
-      - REPO_NAME=$REPO_NAME
-      - COMMIT_SHA=$COMMIT_SHA
-      - BUILD_ID=$BUILD_ID
-      - _APP_HOST_NAME=$_APP_HOST_NAME
-      - _BASIC_AUTH_USER=$_BASIC_AUTH_USER
-      - _CLOUD_RUN_HOST_NAME=$_CLOUD_RUN_HOST_NAME
-      - _CLOUD_SQL_HOST=$_CLOUD_SQL_HOST
-      - _DB_NAME=$_DB_NAME
-      - _DB_USER=$_DB_USER
-      - _GCS_BUCKET=$_GCS_BUCKET
-      - _LABELS=$_LABELS
-      - _MEMORY=$_MEMORY
-      - _SERVICE_NAME=$_SERVICE_NAME
-      - _TRIGGER_ID=$_TRIGGER_ID
-  - id: UpdateLinkCheckerJob
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: bash
-    waitFor:
-      - Deploy
-    args:
-      - '-c'
-      - |
-        if gcloud run jobs describe link-checker --region=asia-northeast1 --quiet 2>/dev/null; then
-          gcloud run jobs update link-checker \
-            --region=asia-northeast1 \
-            --image=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA \
-            --args="bin/rails,link_checker:run" \
-            --set-cloudsql-instances=$_CLOUD_SQL_HOST \
-            --memory=2G \
-            --cpu=1 \
-            --task-timeout=30m \
-            --max-retries=1 \
-            --set-env-vars="RAILS_ENV=production,RAILS_MASTER_KEY=$_RAILS_MASTER_KEY,APP_HOST_NAME=$_APP_HOST_NAME,DB_HOST=/cloudsql/$_CLOUD_SQL_HOST,DB_NAME=$_DB_NAME,DB_PASS=$_DB_PASS,DB_USER=$_DB_USER,DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL,RAILS_LOG_TO_STDOUT=true"
-        else
-          gcloud run jobs create link-checker \
-            --region=asia-northeast1 \
-            --image=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA \
-            --args="bin/rails,link_checker:run" \
-            --set-cloudsql-instances=$_CLOUD_SQL_HOST \
-            --memory=2G \
-            --cpu=1 \
-            --task-timeout=30m \
-            --max-retries=1 \
-            --set-env-vars="RAILS_ENV=production,RAILS_MASTER_KEY=$_RAILS_MASTER_KEY,APP_HOST_NAME=$_APP_HOST_NAME,DB_HOST=/cloudsql/$_CLOUD_SQL_HOST,DB_NAME=$_DB_NAME,DB_PASS=$_DB_PASS,DB_USER=$_DB_USER,DISCORD_BUG_WEBHOOK_URL=$_DISCORD_BUG_WEBHOOK_URL,RAILS_LOG_TO_STDOUT=true"
-        fi
-  - id: Notify
-    name: 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
-    args:
-      - bin/notify
-    waitFor:
-      - Deploy
-    env:
-      - DB_NAME=$_DB_NAME
-      - DEPLOY_NOTIFY_WEBHOOK_URL=$_DEPLOY_NOTIFY_WEBHOOK_URL
+- id: Fetch
+  name: gcr.io/cloud-builders/docker
+  entrypoint: bash
+  args:
+  - "-c"
+  - docker pull asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest || exit 0
+- id: Build
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - "-t"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  - "-t"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+  - "--cache-from"
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+  - "."
+  - "-f"
+  - Dockerfile
+- id: Push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+- id: SqlProxy
+  name: gcr.io/cloudsql-docker/gce-proxy:1.16
+  args:
+  - "/cloud_sql_proxy"
+  - "-dir=/cloudsql"
+  - "-instances=$_CLOUD_SQL_HOST"
+  waitFor:
+  - "-"
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: DB_Migrate
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+  automapSubstitutions: true
+  args:
+  - bash
+  - "-c"
+  - |-
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    bin/rails db:migrate:with_data
+  waitFor:
+  - Push
+  volumes:
+  - name: db
+    path: "/cloudsql"
+- id: Kill_SqlProxy
+  name: gcr.io/cloud-builders/docker
+  entrypoint: sh
+  args:
+  - "-c"
+  - docker kill -s TERM $(docker ps -q --filter "volume=db")
+  waitFor:
+  - DB_Migrate
+- id: Deploy
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  automapSubstitutions: true
+  entrypoint: bash
+  args:
+  - ".cloudbuild/deploy-cloud-run"
+  - production
+- id: UpdateLinkCheckerJob
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  automapSubstitutions: true
+  entrypoint: bash
+  waitFor:
+  - Deploy
+  args:
+  - "-c"
+  - |
+    set -euo pipefail
+
+    env_vars="$(.cloudbuild/cloud-build-env cloud-run-env-vars)"
+
+    if gcloud run jobs describe link-checker --region=asia-northeast1 --quiet 2>/dev/null; then
+      gcloud run jobs update link-checker \
+        --region=asia-northeast1 \
+        --image=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA \
+        --args="bin/rails,link_checker:run" \
+        --set-cloudsql-instances=$_CLOUD_SQL_HOST \
+        --memory=2G \
+        --cpu=1 \
+        --task-timeout=30m \
+        --max-retries=1 \
+        --set-env-vars="$${env_vars}"
+    else
+      gcloud run jobs create link-checker \
+        --region=asia-northeast1 \
+        --image=asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA \
+        --args="bin/rails,link_checker:run" \
+        --set-cloudsql-instances=$_CLOUD_SQL_HOST \
+        --memory=2G \
+        --cpu=1 \
+        --task-timeout=30m \
+        --max-retries=1 \
+        --set-env-vars="$${env_vars}"
+    fi
+- id: Notify
+  name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+  automapSubstitutions: true
+  args:
+  - bash
+  - "-c"
+  - |-
+    eval "$(.cloudbuild/cloud-build-env exports)"
+    bin/notify
+  waitFor:
+  - Deploy
 options:
   substitutionOption: ALLOW_LOOSE
+  automapSubstitutions: true
 timeout: 7200s
 images:
-  - 'asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest'
+- asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
 substitutions:
   _APP_HOST_NAME: bootcamp.fjord.jp
   _BASIC_AUTH_USER: ''
@@ -138,5 +127,6 @@ substitutions:
   _GCS_BUCKET: ''
   _LABELS: ''
   _MEMORY: ''
+  _DEPLOY_NOTIFY_WEBHOOK_URL: ''
   _SERVICE_NAME: ''
   _TRIGGER_ID: ''

--- a/.cloudbuild/deploy-cloud-run
+++ b/.cloudbuild/deploy-cloud-run
@@ -2,17 +2,14 @@
 set -euo pipefail
 
 environment=${1:?Usage: deploy-cloud-run ENVIRONMENT}
+env_vars_file="$(mktemp)"
+trap 'rm -f "$env_vars_file"' EXIT
 
-join_by_comma() {
-  local IFS=,
-  echo "$*"
-}
-
-secret_ref() {
-  local name
-  name=$(echo "$1" | tr '[:upper:]_' '[:lower:]-')
-  echo "$1=bootcamp-${environment}-${name}:latest"
-}
+substitution_env_file="${SUBSTITUTION_ENV_FILE:-.cloudbuild/substitutions.env}"
+if [[ -f "$substitution_env_file" ]]; then
+  # shellcheck source=/dev/null
+  source "$substitution_env_file"
+fi
 
 image_for_environment() {
   if [[ "$environment" == review ]]; then
@@ -22,21 +19,47 @@ image_for_environment() {
   fi
 }
 
-common_env_vars=(
-  LANG=ja_JP.UTF-8
-  TZ=Asia/Tokyo
-  RAILS_SERVE_STATIC_FILES=true
-  RAILS_LOG_TO_STDOUT=true
-  RAILS_ENV=production
-  RACK_ENV=production
-  APP_HOST_NAME="${_APP_HOST_NAME}"
-  CLOUD_RUN_HOST_NAME="${_CLOUD_RUN_HOST_NAME}"
-  DB_NAME="${_DB_NAME}"
-  DB_USER="${_DB_USER}"
-  DB_HOST="/cloudsql/${_CLOUD_SQL_HOST}"
-  GCS_BUCKET="${_GCS_BUCKET}"
-  BASIC_AUTH_USER="${_BASIC_AUTH_USER}"
-)
+remove_existing_secret_env_vars() {
+  local service_json
+  local secret_env_vars
+
+  service_json="$(mktemp)"
+  trap 'rm -f "$service_json"' RETURN
+
+  if ! gcloud run services describe "${_SERVICE_NAME}" \
+    --platform=managed \
+    --region=asia-northeast1 \
+    --format=json > "$service_json" 2>/dev/null; then
+    return
+  fi
+
+  secret_env_vars="$(
+    python3 - "$service_json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as service_json:
+    service = json.load(service_json)
+
+containers = service.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+names = []
+for container in containers:
+    for env in container.get("env", []):
+        if "valueFrom" in env and env.get("name"):
+            names.append(env["name"])
+
+print(",".join(sorted(set(names))))
+PY
+  )"
+
+  if [[ -n "$secret_env_vars" ]]; then
+    gcloud run services update "${_SERVICE_NAME}" \
+      --platform=managed \
+      --region=asia-northeast1 \
+      --remove-secrets="$secret_env_vars" \
+      --quiet
+  fi
+}
 
 cloud_run_args=(
   run
@@ -62,130 +85,32 @@ fi
 
 case "$environment" in
   production)
-    env_vars=("${common_env_vars[@]}" RAILS_MAX_THREADS=5 PJORD_LLM_MODEL=claude-sonnet-4-6)
-    secret_names=(
-      RAILS_MASTER_KEY
-      DB_PASS
-      GOOGLE_CREDENTIALS
-      TOKEN
-      DISCORD_NOTICE_WEBHOOK_URL
-      DISCORD_INTRODUCTION_WEBHOOK_URL
-      DISCORD_ALL_WEBHOOK_URL
-      DISCORD_ADMIN_WEBHOOK_URL
-      DISCORD_MENTOR_WEBHOOK_URL
-      DISCORD_BUG_WEBHOOK_URL
-      DISCORD_REPORT_WEBHOOK_URL
-      DISCORD_GUILD_ID
-      DISCORD_TIMES_CHANNEL_CATEGORY_ID
-      DISCORD_BOT_TOKEN
-      MISSION_CONTROL_USERNAME
-      MISSION_CONTROL_PASSWORD
-      STRIPE_ENDPOINT_SECRET
-      BASIC_AUTH_PASSWORD
-      RECAPTCHA_SITE_KEY
-      RECAPTCHA_SECRET_KEY
-      ROLLBAR_CLIENT_TOKEN
-      OPEN_AI_ACCESS_TOKEN
-      ANTHROPIC_API_KEY
-      PJORD_GITHUB_TOKEN
-      STRIPE_TAX_RATE_ID
-      DISCORD_CLIENT_ID
-      DISCORD_CLIENT_SECRET
-      DISCORD_AUTHENTICATION_URL
-      PUBSUB_AUDIENCE
-      PUBSUB_SERVICE_ACCOUNT_EMAIL
-      PUBSUB_TOPIC
-      GITHUB_KEY
-      GITHUB_SECRET
-      ROLLBAR_ACCESS_TOKEN
-      SLACK_WEBHOOK_URL
-      STRIPE_PUBLIC_KEY
-      STRIPE_SECRET_KEY
-      POSTMARK_API_TOKEN
-    )
-    secret_vars=()
-    for secret_name in "${secret_names[@]}"; do
-      secret_vars+=("$(secret_ref "$secret_name")")
-    done
+    export _RAILS_MAX_THREADS=5
+    export _PJORD_LLM_MODEL=claude-sonnet-4-6
     cloud_run_args+=(--concurrency 5)
-    cloud_run_args+=("--set-secrets=$(join_by_comma "${secret_vars[@]}")")
     ;;
   staging)
-    env_vars=(
-      "${common_env_vars[@]}"
-      RAILS_MASTER_KEY="${_RAILS_MASTER_KEY}"
-      DB_PASS="${_DB_PASS}"
-      GOOGLE_CREDENTIALS="${_GOOGLE_CREDENTIALS}"
-      TOKEN="${_TOKEN}"
-      DISCORD_NOTICE_WEBHOOK_URL="${_DISCORD_NOTICE_WEBHOOK_URL}"
-      DISCORD_INTRODUCTION_WEBHOOK_URL="${_DISCORD_INTRODUCTION_WEBHOOK_URL}"
-      DISCORD_ALL_WEBHOOK_URL="${_DISCORD_ALL_WEBHOOK_URL}"
-      DISCORD_ADMIN_WEBHOOK_URL="${_DISCORD_ADMIN_WEBHOOK_URL}"
-      DISCORD_MENTOR_WEBHOOK_URL="${_DISCORD_MENTOR_WEBHOOK_URL}"
-      DISCORD_BUG_WEBHOOK_URL="${_DISCORD_BUG_WEBHOOK_URL}"
-      DISCORD_REPORT_WEBHOOK_URL="${_DISCORD_REPORT_WEBHOOK_URL}"
-      DISCORD_GUILD_ID="${_DISCORD_GUILD_ID}"
-      DISCORD_TIMES_CHANNEL_CATEGORY_ID="${_DISCORD_TIMES_CHANNEL_CATEGORY_ID}"
-      DISCORD_BOT_TOKEN="${_DISCORD_BOT_TOKEN}"
-      MISSION_CONTROL_USERNAME="${_MISSION_CONTROL_USERNAME}"
-      MISSION_CONTROL_PASSWORD="${_MISSION_CONTROL_PASSWORD}"
-      STRIPE_ENDPOINT_SECRET="${_STRIPE_ENDPOINT_SECRET}"
-      BASIC_AUTH_PASSWORD="${_BASIC_AUTH_PASSWORD}"
-      RECAPTCHA_SITE_KEY="${_RECAPTCHA_SITE_KEY}"
-      RECAPTCHA_SECRET_KEY="${_RECAPTCHA_SECRET_KEY}"
-      ROLLBAR_CLIENT_TOKEN="${_ROLLBAR_CLIENT_TOKEN}"
-      OPEN_AI_ACCESS_TOKEN="${_OPEN_AI_ACCESS_TOKEN}"
-      ANTHROPIC_API_KEY="${_ANTHROPIC_API_KEY}"
-      PJORD_GITHUB_TOKEN="${_PJORD_GITHUB_TOKEN}"
-      STRIPE_TAX_RATE_ID="${_STRIPE_TAX_RATE_ID}"
-      DISCORD_CLIENT_ID="${_DISCORD_CLIENT_ID}"
-      DISCORD_CLIENT_SECRET="${_DISCORD_CLIENT_SECRET}"
-      DISCORD_AUTHENTICATION_URL="${_DISCORD_AUTHENTICATION_URL}"
-      PUBSUB_AUDIENCE="${_PUBSUB_AUDIENCE}"
-      PUBSUB_SERVICE_ACCOUNT_EMAIL="${_PUBSUB_SERVICE_ACCOUNT_EMAIL}"
-      PUBSUB_TOPIC="${_PUBSUB_TOPIC}"
-    )
-    if [[ -n "${_ENVS:-}" ]]; then
-      IFS=',' read -ra extra_env_vars <<< "${_ENVS}"
-      env_vars+=("${extra_env_vars[@]}")
-    fi
+    export _MISSION_CONTROL_USERNAME="${_MISSION_CONTROL_USERNAME:-fjord}"
+    export _PJORD_LLM_MODEL=claude-sonnet-4-6
     ;;
   review)
-    env_vars=(
-      "${common_env_vars[@]}"
-      RAILS_MASTER_KEY="${_RAILS_MASTER_KEY}"
-      DB_PASS="${_DB_PASS}"
-      GOOGLE_CREDENTIALS="${_GOOGLE_CREDENTIALS}"
-      TOKEN="${_TOKEN}"
-      BASIC_AUTH_PASSWORD="${_BASIC_AUTH_PASSWORD}"
-      DISCORD_NOTICE_WEBHOOK_URL=
-      DISCORD_INTRODUCTION_WEBHOOK_URL=
-      DISCORD_ALL_WEBHOOK_URL=
-      DISCORD_ADMIN_WEBHOOK_URL=
-      DISCORD_MENTOR_WEBHOOK_URL=
-      DISCORD_BUG_WEBHOOK_URL=
-      DISCORD_REPORT_WEBHOOK_URL=
-      DISCORD_GUILD_ID=
-      DISCORD_TIMES_CHANNEL_CATEGORY_ID=
-      DISCORD_BOT_TOKEN=
-      DISCORD_CLIENT_ID=
-      DISCORD_CLIENT_SECRET=
-      DISCORD_AUTHENTICATION_URL=
-      MISSION_CONTROL_USERNAME="${_MISSION_CONTROL_USERNAME}"
-      MISSION_CONTROL_PASSWORD="${_MISSION_CONTROL_PASSWORD}"
-      STRIPE_ENDPOINT_SECRET=
-      RECAPTCHA_SITE_KEY="${_RECAPTCHA_SITE_KEY}"
-      RECAPTCHA_SECRET_KEY="${_RECAPTCHA_SECRET_KEY}"
-      ROLLBAR_CLIENT_TOKEN=
-      OPEN_AI_ACCESS_TOKEN="${_OPEN_AI_ACCESS_TOKEN}"
-      ANTHROPIC_API_KEY="${_ANTHROPIC_API_KEY}"
-      STRIPE_TAX_RATE_ID=
-      GITHUB_KEY="${_GITHUB_KEY}"
-      GITHUB_SECRET="${_GITHUB_SECRET}"
-      STRIPE_PUBLIC_KEY="${_STRIPE_PUBLIC_KEY}"
-      STRIPE_SECRET_KEY="${_STRIPE_SECRET_KEY}"
-      POSTMARK_API_TOKEN="${_POSTMARK_API_TOKEN}"
-    )
+    export _DISCORD_NOTICE_WEBHOOK_URL=
+    export _DISCORD_INTRODUCTION_WEBHOOK_URL=
+    export _DISCORD_ALL_WEBHOOK_URL=
+    export _DISCORD_ADMIN_WEBHOOK_URL=
+    export _DISCORD_MENTOR_WEBHOOK_URL=
+    export _DISCORD_BUG_WEBHOOK_URL=
+    export _DISCORD_REPORT_WEBHOOK_URL=
+    export _DISCORD_GUILD_ID=
+    export _DISCORD_TIMES_CHANNEL_CATEGORY_ID=
+    export _DISCORD_BOT_TOKEN=
+    export _DISCORD_CLIENT_ID=
+    export _DISCORD_CLIENT_SECRET=
+    export _DISCORD_AUTHENTICATION_URL=
+    export _MISSION_CONTROL_USERNAME=fjord
+    export _STRIPE_ENDPOINT_SECRET=
+    export _ROLLBAR_CLIENT_TOKEN=
+    export _STRIPE_TAX_RATE_ID=
     cloud_run_args+=(--min-instances=0 --max-instances=2)
     ;;
   *)
@@ -194,8 +119,12 @@ case "$environment" in
     ;;
 esac
 
+remove_existing_secret_env_vars
+"$(dirname "$0")/cloud-build-env" cloud-run-json > "$env_vars_file"
+
 cloud_run_args+=(
-  "--set-env-vars=$(join_by_comma "${env_vars[@]}")"
+  --env-vars-file
+  "$env_vars_file"
 )
 
 case "$environment" in

--- a/test/lib/cloud_build_env_test.rb
+++ b/test/lib/cloud_build_env_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'open3'
+require 'tempfile'
+require 'test_helper'
+
+class CloudBuildEnvTest < ActiveSupport::TestCase
+  COMMAND = Rails.root.join('.cloudbuild/cloud-build-env').to_s
+
+  test 'outputs cloud run environment variables as json' do
+    env_vars = run_json(
+      'cloud-run-json',
+      '_' => 'ignored',
+      '_APP_HOST_NAME' => 'bootcamp-pr-10119.example.com',
+      '_CLOUD_SQL_HOST' => 'project:region:instance',
+      '_DB_PASS' => 'p,a,s,s',
+      '_GOOGLE_CREDENTIALS' => '{"client_email":"test@example.com","private_key":"a,b,c"}',
+      '_MEMORY' => '2G',
+      '_SERVICE_NAME' => 'bootcamp-pr-10119'
+    )
+
+    assert_equal 'production', env_vars['RAILS_ENV']
+    assert_equal 'bootcamp-pr-10119.example.com', env_vars['APP_HOST_NAME']
+    assert_equal 'p,a,s,s', env_vars['DB_PASS']
+    assert_equal '{"client_email":"test@example.com","private_key":"a,b,c"}', env_vars['GOOGLE_CREDENTIALS']
+    assert_equal '/cloudsql/project:region:instance', env_vars['DB_HOST']
+    assert_nil env_vars['MEMORY']
+    assert_nil env_vars['SERVICE_NAME']
+    assert_nil env_vars['CLOUD_SQL_HOST']
+    assert_nil env_vars['']
+  end
+
+  test 'outputs sourceable exports for app commands' do
+    exports = run_command(
+      'exports',
+      '_APP_HOST_NAME' => 'bootcamp.example.com',
+      '_CLOUD_SQL_HOST' => 'project:region:instance',
+      '_DB_PASS' => 'p a,s'
+    )
+
+    assert_includes exports, "export RAILS_ENV=production\n"
+    assert_includes exports, "export DISABLE_DATABASE_ENVIRONMENT_CHECK=1\n"
+    assert_includes exports, "export APP_HOST_NAME=bootcamp.example.com\n"
+    assert_includes exports, "export DB_PASS='p a,s'\n"
+    assert_includes exports, "export DB_HOST=/cloudsql/project:region:instance\n"
+  end
+
+  test 'outputs comma separated env vars for commands that still use set-env-vars' do
+    env_vars = run_command(
+      'cloud-run-env-vars',
+      '_APP_HOST_NAME' => 'bootcamp.example.com',
+      '_CLOUD_SQL_HOST' => 'project:region:instance',
+      '_ENVS' => 'EXTRA=1,FEATURE_FLAG=true',
+      '_SERVICE_NAME' => 'bootcamp'
+    )
+
+    assert_includes env_vars, 'APP_HOST_NAME=bootcamp.example.com'
+    assert_includes env_vars, 'DB_HOST=/cloudsql/project:region:instance'
+    assert_includes env_vars, 'EXTRA=1'
+    assert_includes env_vars, 'FEATURE_FLAG=true'
+    assert_not_includes env_vars, 'SERVICE_NAME=bootcamp'
+  end
+
+  test 'writes sourceable exports from cloud build json' do
+    build_json = Tempfile.create('build.json')
+    output = Tempfile.create('substitutions.env')
+    build_json_path = build_json.path
+    output_path = output.path
+
+    build_json.write(
+      {
+        projectId: 'bootcamp-224405',
+        id: 'build-id',
+        substitutions: {
+          'COMMIT_SHA' => 'abc123',
+          'REPO_NAME' => 'bootcamp',
+          '_' => 'ignored',
+          '_APP_HOST_NAME' => 'bootcamp-pr.example.com',
+          '_DB_PASS' => 'p a,s',
+          '_invalid_name' => 'ignored'
+        }
+      }.to_json
+    )
+    build_json.close
+
+    assert system(COMMAND, 'write', output_path, build_json_path)
+    exports = output.read
+
+    assert_includes exports, "export PROJECT_ID=bootcamp-224405\n"
+    assert_includes exports, "export BUILD_ID=build-id\n"
+    assert_includes exports, "export COMMIT_SHA=abc123\n"
+    assert_includes exports, "export REPO_NAME=bootcamp\n"
+    assert_includes exports, "export _APP_HOST_NAME=bootcamp-pr.example.com\n"
+    assert_includes exports, "export APP_HOST_NAME=bootcamp-pr.example.com\n"
+    assert_includes exports, "export _DB_PASS='p a,s'\n"
+    assert_includes exports, "export DB_PASS='p a,s'\n"
+    assert_not_includes exports, 'export ='
+    assert_not_includes exports, '_invalid_name'
+  ensure
+    FileUtils.rm_f(build_json_path)
+    FileUtils.rm_f(output_path)
+  end
+
+  private
+
+  def run_json(command, env)
+    JSON.parse(run_command(command, env))
+  end
+
+  def run_command(command, env)
+    stdout, stderr, status = Open3.capture3(env, COMMAND, command)
+    assert_predicate status, :success?, stderr
+    stdout
+  end
+end


### PR DESCRIPTION
## 概要

Cloud Build / Cloud Run の秘密値受け渡しを Secret Manager 参照ではなく、Cloud Build substitutions と `automapSubstitutions: true` に寄せます。

- production / staging / review の Cloud Build に `options.automapSubstitutions: true` を設定
- `.cloudbuild/cloud-build-env` に `_FOO` 変換、Review App 用 env file 書き出し、Cloud Run env 生成を集約
- Cloud Run deploy は `--set-secrets` を使わず、`--env-vars-file <(.cloudbuild/cloud-run-env-vars --format=json)` で env を反映
- JSON やカンマを含む値でも壊れないよう、Cloud Run env は `--set-env-vars` のカンマ区切り文字列ではなく JSON 出力経由で渡す
- deploy 用の `_SERVICE_NAME`, `_MEMORY`, `_CLOUD_SQL_HOST` などは Cloud Run のアプリ env から除外
- Review App の DB 作成と pgvector 有効化は Rails runner ではなく `psql` で実行
- 既存 Cloud Run service に残っている Secret 型 env は deploy 前に削除し、文字列 env へ切り替え
- Review App は GitHub Actions から Cloud Build を submit するため、GitHub Secrets を Cloud Build substitutions として渡す形を維持

## 方針

Cloud Build の user-defined substitutions は `_` prefix が必須なので、trigger には `_DB_PASS`, `_RAILS_MASTER_KEY` のように設定します。

Cloud Build step では `automapSubstitutions: true` を基本にしつつ、Review App の app image step では substitutions が env として渡らないことを確認したため、`.cloudbuild/cloud-build-env` で Cloud Build API から取得した substitutions を sourceable な env に変換して Rails / Cloud Run に渡します。trigger ごとに必要な substitution を設定すれば、YAML / deploy script 側でアプリ用 env を個別列挙せずに反映されます。

## GCP 側の注意

この PR の現在のコードは Secret Manager を参照しません。以前の試行で production / staging / review 用の Secret Manager secret と IAM は作成済みですが、この PR からは使われません。

production は PR の時点では反映されませんが、production 用 Cloud Build 設定の修正も含めています。

## 確認したこと

- `ruby -ryaml` で変更対象の Cloud Build YAML を parse
- `bash -n .cloudbuild/export-substitutions .cloudbuild/deploy-cloud-run .cloudbuild/write-substitution-env`
- `git diff --check`
- `.cloudbuild/cloud-build-env` の単体テストで `_FOO` 変換、deploy 専用変数除外、空キー除外、カンマ入り値、`DB_HOST` 生成、Cloud Build JSON からの env file 生成を確認
- Review App Cloud Build `2348116c-fad6-490d-b15a-225842011f0a` が成功
- PR checks が全て pass
- commit 履歴は 1 本の日本語 commit に整理済み

## 未実施

- staging deploy
- production deploy

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/26967321832/artifacts/7418338654" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10119-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
