### PR TITLE
ステージングのmigrationにsubstitution環境を渡す

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -24,6 +24,19 @@ steps:
   - asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
   waitFor:
   - Build
+- id: WriteSubstitutionEnv
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  entrypoint: python3
+  args:
+  - ".cloudbuild/cloud-build-env"
+  - write
+  - ".cloudbuild/substitutions.env"
+  - --build
+  - "$PROJECT_ID"
+  - "$BUILD_ID"
+  - global
+  waitFor:
+  - Push
 - id: StopCloudRun
   name: gcr.io/google.com/cloudsdktool/cloud-sdk
   entrypoint: bash
@@ -165,10 +178,12 @@ steps:
   - bash
   - "-c"
   - |-
+    source .cloudbuild/substitutions.env
     eval "$(.cloudbuild/cloud-build-env exports)"
     bin/rails db:migrate db:seed
   waitFor:
   - EnablePgvector
+  - WriteSubstitutionEnv
   volumes:
   - name: db
     path: "/cloudsql"
@@ -194,6 +209,7 @@ steps:
   - bash
   - "-c"
   - |-
+    source .cloudbuild/substitutions.env
     eval "$(.cloudbuild/cloud-build-env exports)"
     bin/notify
   waitFor:


### PR DESCRIPTION
## 概要

ステージングデプロイの Cloud Build が `DBMigrate` step で失敗していたため、staging の migration / notify step でも Cloud Build substitutions を source するようにしました。

失敗を確認したBuild:

- `52480313-f272-48d0-8de4-b1f3283e33f0`
- trigger: `cloud-run-deploy-staging`
- failure: `DBMigrate` step
- error: `APP_HOST_NAME environment variable is required for production but not set or blank`

Build substitutions には `_APP_HOST_NAME` が入っていましたが、`DBMigrate` のアプリコンテナ内で `APP_HOST_NAME` として渡っていませんでした。Review App と同じく `.cloudbuild/cloud-build-env write` で `.cloudbuild/substitutions.env` を作成し、`DBMigrate` / `Notify` で source します。

## 変更内容

- staging Cloud Build に `WriteSubstitutionEnv` step を追加
- `DBMigrate` step で `.cloudbuild/substitutions.env` を source
- `Notify` step で `.cloudbuild/substitutions.env` を source
- `DBMigrate` は `EnablePgvector` と `WriteSubstitutionEnv` の両方を待つように変更

## 確認したこと

- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .cloudbuild/cloudbuild-staging.yaml .cloudbuild/cloudbuild-review.yaml .cloudbuild/cloudbuild.yaml`
- `python3 -m py_compile .cloudbuild/cloud-build-env`
- `bash -n .cloudbuild/deploy-cloud-run`
- `mise exec -- rails test test/lib/cloud_build_env_test.rb`
- `git diff --check`

## 補足

- 本番環境への直接作業はしていません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - ビルドパイプラインの依存関係を最適化し、環境変数生成プロセスの実行タイミングを改善しました。
  - ビルドステップ間の前提条件を強化し、必要な構成ファイルの準備完了を確実にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27005609950/artifacts/7433055124" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10124-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->