### PR TITLE
ステージングデプロイの古いビルドをキャンセルする

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -1,11 +1,44 @@
 ---
 steps:
+- id: CancelPreviousBuilds
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  entrypoint: bash
+  args:
+  - "-c"
+  - |
+    set -euo pipefail
+
+    current_build_id="$BUILD_ID"
+    current_create_time="$(
+      gcloud builds describe "$current_build_id" \
+        --project="$PROJECT_ID" \
+        --region=global \
+        --format="value(createTime)"
+    )"
+
+    echo "Cancelling previous running staging builds..."
+    gcloud builds list \
+      --project="$PROJECT_ID" \
+      --region=global \
+      --filter="substitutions.TRIGGER_NAME=cloud-run-deploy-staging AND (status=QUEUED OR status=WORKING)" \
+      --format="value(id,createTime)" |
+      while read -r build_id create_time; do
+        if [ "$build_id" != "$current_build_id" ] && [ "$create_time" \< "$current_create_time" ]; then
+          echo "Cancelling previous build: $build_id"
+          gcloud builds cancel "$build_id" \
+            --project="$PROJECT_ID" \
+            --region=global \
+            --quiet || true
+        fi
+      done
 - id: Fetch
   name: gcr.io/cloud-builders/docker
   entrypoint: bash
   args:
   - "-c"
   - docker pull asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest || exit 0
+  waitFor:
+  - CancelPreviousBuilds
 - id: Build
   name: gcr.io/cloud-builders/docker
   args:


### PR DESCRIPTION
## 概要

ステージングデプロイの Cloud Build が `DBMigrate` step で失敗していたため、同一staging triggerの古い実行中buildを先頭でキャンセルするようにしました。

失敗を確認したBuild:

- `f3e070a0-d7f7-4a6b-8a47-e908d6b47449`
- trigger: `cloud-run-deploy-staging`
- failure: `DBMigrate` step
- error: `ActiveRecord::ConnectionFailed: PQconsumeInput() FATAL: terminating connection due to administrator command`

同じstaging triggerのbuildが短時間に連続していました。

- `b128a481-d756-4634-8c0b-2871d85737db` started at `2026-06-05T09:47:22Z` / SUCCESS
- `f3e070a0-d7f7-4a6b-8a47-e908d6b47449` started at `2026-06-05T09:48:06Z` / FAILURE

staging Cloud BuildはDBをdrop/createするため、複数buildが重なるとmigration中に別buildのDB操作や後続処理と競合します。

## 変更内容

- `.cloudbuild/cloudbuild-staging.yaml` の先頭に `CancelPreviousBuilds` stepを追加
- 現在のbuildより古い `cloud-run-deploy-staging` の `QUEUED` / `WORKING` buildをキャンセル
- `Fetch` は `CancelPreviousBuilds` 完了後に開始

## 確認したこと

- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .cloudbuild/cloudbuild-staging.yaml .cloudbuild/cloudbuild-review.yaml .cloudbuild/cloudbuild.yaml`
- `python3 -m py_compile .cloudbuild/cloud-build-env`
- `bash -n .cloudbuild/deploy-cloud-run`
- `mise exec -- rails test test/lib/cloud_build_env_test.rb`
- `git diff --check`

## 補足

- 本番環境への直接作業はしていません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルドプロセスを改善し、進行中の古いビルドを自動的にキャンセルする機能を追加しました。これによりパイプラインの実行順序が最適化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27020238055/artifacts/7439102993" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10125-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->