### PR TITLE
本番デプロイのmigrationにsubstitution環境を渡す

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -24,6 +24,19 @@ steps:
   args:
   - push
   - asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
+- id: WriteSubstitutionEnv
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  entrypoint: python3
+  args:
+  - ".cloudbuild/cloud-build-env"
+  - write
+  - ".cloudbuild/substitutions.env"
+  - --build
+  - "$PROJECT_ID"
+  - "$BUILD_ID"
+  - global
+  waitFor:
+  - Push
 - id: SqlProxy
   name: gcr.io/cloudsql-docker/gce-proxy:1.16
   args:
@@ -42,10 +55,12 @@ steps:
   - bash
   - "-c"
   - |-
+    source .cloudbuild/substitutions.env
     eval "$(.cloudbuild/cloud-build-env exports)"
     bin/rails db:migrate:with_data
   waitFor:
   - Push
+  - WriteSubstitutionEnv
   volumes:
   - name: db
     path: "/cloudsql"
@@ -75,6 +90,7 @@ steps:
   - |
     set -euo pipefail
 
+    source .cloudbuild/substitutions.env
     env_vars="$(.cloudbuild/cloud-build-env cloud-run-env-vars)"
 
     if gcloud run jobs describe link-checker --region=asia-northeast1 --quiet 2>/dev/null; then
@@ -107,6 +123,7 @@ steps:
   - bash
   - "-c"
   - |-
+    source .cloudbuild/substitutions.env
     eval "$(.cloudbuild/cloud-build-env exports)"
     bin/notify
   waitFor:

--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -55,6 +55,7 @@ steps:
   - bash
   - "-c"
   - |-
+    set -euo pipefail
     source .cloudbuild/substitutions.env
     eval "$(.cloudbuild/cloud-build-env exports)"
     bin/rails db:migrate:with_data
@@ -123,6 +124,7 @@ steps:
   - bash
   - "-c"
   - |-
+    set -euo pipefail
     source .cloudbuild/substitutions.env
     eval "$(.cloudbuild/cloud-build-env exports)"
     bin/notify


### PR DESCRIPTION
## 概要
- production Cloud Build に `WriteSubstitutionEnv` step を追加
- `DB_Migrate` / `Notify` / `UpdateLinkCheckerJob` で `.cloudbuild/substitutions.env` を読み込むように変更
- staging と同じ方式で trigger substitutions を Rails / Cloud Run job 更新へ渡す

## 背景
Cloud Build `076615b7-cc5e-4d40-8a47-00c3f118bac4` の production deploy が Step 4 `DB_Migrate` で失敗していました。

```
ERROR: APP_HOST_NAME environment variable is required for production but not set or blank
```

`automapSubstitutions` だけでは trigger 側の `_APP_HOST_NAME` が Rails コンテナ内で `APP_HOST_NAME` として参照できず、staging で対応済みの substitutions env 書き出しを production にも適用します。

## 確認
- `ruby -rpsych -e 'Psych.load_file(".cloudbuild/cloudbuild.yaml"); puts "yaml ok"'`
- 失敗ビルド `076615b7-cc5e-4d40-8a47-00c3f118bac4` の substitutions から `APP_HOST_NAME=bootcamp.fjord.jp` と `DB_HOST=/cloudsql/bootcamp-224405:asia-northeast1:bootcamp` が生成されることを確認
## 本番反映
この PR の時点では本番環境には反映していません。マージ後の production deploy で反映されます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ビルドパイプラインで環境変数ファイルを自動生成して読み込むようにし、DB移行の実行順序を調整しました。
  * リンクチェッカーの更新/作成処理および通知処理も新しい環境設定を使用するようになり、ビルドの信頼性と保守性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27085938253/artifacts/7461910067" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10138-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
