### PR TITLE
Cloud Run deployで秘密値削除の中間revisionを作らない

### DIFF
--- a/.cloudbuild/deploy-cloud-run
+++ b/.cloudbuild/deploy-cloud-run
@@ -19,48 +19,6 @@ image_for_environment() {
   fi
 }
 
-remove_existing_secret_env_vars() {
-  local service_json
-  local secret_env_vars
-
-  service_json="$(mktemp)"
-  trap 'rm -f "$service_json"' RETURN
-
-  if ! gcloud run services describe "${_SERVICE_NAME}" \
-    --platform=managed \
-    --region=asia-northeast1 \
-    --format=json > "$service_json" 2>/dev/null; then
-    return
-  fi
-
-  secret_env_vars="$(
-    python3 - "$service_json" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as service_json:
-    service = json.load(service_json)
-
-containers = service.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
-names = []
-for container in containers:
-    for env in container.get("env", []):
-        if "valueFrom" in env and env.get("name"):
-            names.append(env["name"])
-
-print(",".join(sorted(set(names))))
-PY
-  )"
-
-  if [[ -n "$secret_env_vars" ]]; then
-    gcloud run services update "${_SERVICE_NAME}" \
-      --platform=managed \
-      --region=asia-northeast1 \
-      --remove-secrets="$secret_env_vars" \
-      --quiet
-  fi
-}
-
 cloud_run_args=(
   run
   deploy
@@ -124,10 +82,10 @@ case "$environment" in
     ;;
 esac
 
-remove_existing_secret_env_vars
 "$(dirname "$0")/cloud-build-env" cloud-run-json > "$env_vars_file"
 
 cloud_run_args+=(
+  --clear-secrets
   --env-vars-file
   "$env_vars_file"
 )

--- a/test/lib/deploy_cloud_run_test.rb
+++ b/test/lib/deploy_cloud_run_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+require 'test_helper'
+
+class DeployCloudRunTest < ActiveSupport::TestCase
+  SCRIPT = Rails.root.join('.cloudbuild/deploy-cloud-run').to_s
+
+  test 'deploys with clear-secrets without creating an intermediate service update revision' do
+    Dir.mktmpdir do |dir|
+      gcloud_log = File.join(dir, 'gcloud.log')
+      stub_gcloud(dir, gcloud_log)
+
+      stdout, stderr, status = Open3.capture3(deploy_env(dir), SCRIPT, 'production')
+      assert_predicate status, :success?, stderr
+      assert_empty stdout
+
+      commands = File.read(gcloud_log)
+      assert_includes commands, 'run deploy bootcamp'
+      assert_includes commands, '--clear-secrets'
+      assert_includes commands, '--env-vars-file'
+      assert_not_includes commands, 'services update'
+      assert_not_includes commands, '--remove-secrets'
+    end
+  end
+
+  private
+
+  def stub_gcloud(dir, gcloud_log)
+    File.write(
+      File.join(dir, 'gcloud'),
+      <<~BASH
+        #!/usr/bin/env bash
+        printf '%q ' "$@" >> "#{gcloud_log}"
+        printf '\\n' >> "#{gcloud_log}"
+      BASH
+    )
+    FileUtils.chmod('+x', File.join(dir, 'gcloud'))
+  end
+
+  def deploy_env(dir)
+    {
+      'PATH' => "#{dir}:#{ENV.fetch('PATH')}",
+      'PROJECT_ID' => 'bootcamp-224405',
+      'REPO_NAME' => 'bootcamp',
+      'COMMIT_SHA' => 'abc123',
+      'BUILD_ID' => 'build123',
+      '_APP_HOST_NAME' => 'bootcamp.example.com',
+      '_CLOUD_SQL_HOST' => 'project:region:instance',
+      '_DB_NAME' => 'bootcamp_production',
+      '_DB_USER' => 'production',
+      '_GCS_BUCKET' => 'bootcamp-bucket',
+      '_LABELS' => 'env=production',
+      '_MEMORY' => '4G',
+      '_SERVICE_NAME' => 'bootcamp',
+      '_TRIGGER_ID' => 'trigger123',
+      '_RAILS_MASTER_KEY' => 'master-key',
+      '_DB_PASS' => 'db-pass'
+    }
+  end
+end


### PR DESCRIPTION
## 概要
- `.cloudbuild/deploy-cloud-run` が事前に `gcloud run services update --remove-secrets` を実行する処理を削除
- 既存 Secret Manager 参照の削除は、最終的な `gcloud run deploy` の `--clear-secrets` にまとめた
- deploy スクリプトが中間 revision を作らず `--clear-secrets` / `--env-vars-file` で deploy することをテストで固定

## 原因
本番 Cloud Build `a20a341e-27fc-4cd4-ab8d-b90fac71d375` は `DB_Migrate` までは成功していましたが、step 7 `Deploy` で Cloud Run revision `bootcamp-00542-rm9` の起動に失敗しました。

Cloud Run ログでは Rails 起動時に `Missing secret_key_base for production` が出ていました。失敗 revision の環境変数を確認すると `RAILS_MASTER_KEY` などの秘密値が入っていませんでした。

原因は deploy スクリプトが、最終 deploy の前に `gcloud run services update --remove-secrets` を実行していたことです。このコマンド自体が秘密値を削除した中間 revision を作成し、その revision が起動失敗して、後続の `gcloud run deploy --env-vars-file` まで到達していませんでした。

## 確認したこと
- `gcloud builds describe a20a341e-27fc-4cd4-ab8d-b90fac71d375 --project=bootcamp-224405 --region=global`
- `gcloud builds log a20a341e-27fc-4cd4-ab8d-b90fac71d375 --project=bootcamp-224405 --region=global`
- `gcloud logging read` で `bootcamp-00542-rm9` の `Missing secret_key_base` を確認
- `gcloud run revisions describe bootcamp-00542-rm9` で `RAILS_MASTER_KEY` が欠けていることを確認
- `mise exec -- rails test test/lib/deploy_cloud_run_test.rb test/lib/cloud_build_env_test.rb`
- `bash -n .cloudbuild/deploy-cloud-run`
- `git diff --check`
- `mise exec -- ./bin/lint`

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27087131724/artifacts/7462361559" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Cloud Run デプロイメント時のシークレット環境変数クリア処理を簡略化しました。

* **Tests**
  * デプロイメントスクリプトの動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->