### PR TITLE
Flakewatchレポート生成を修正する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,9 +223,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.26
+        uses: komagata/flakewatch@v0.6.27
         with:
           junit-artifact-pattern: junit-xml-*
-          source-root: "."
+          source-root: ${{ github.workspace }}
           history-branch: flakewatch-data
           history-write: auto


### PR DESCRIPTION
## 概要
- Flakewatch action を `komagata/flakewatch@v0.6.27` に更新
- `source-root` を `${{ github.workspace }}` にして、source link 推定に利用する root を明示

## 背景
PR #10142 の Flakewatch artifact が `Flakewatch report unavailable` になっていました。

調査したところ、CI の `Flakewatch HTML report` job 自体は成功していましたが、アップロードされた `flakewatch.html` は 101 bytes の fallback HTML でした。ログでは `flakewatch` が `wrote flakewatch.html` と出した直後に `flakewatch did not create a non-empty` warning が出ており、実レポートが 0 byte で生成されていました。

原因は `komagata/flakewatch@v0.6.26` の action 実行時に、flakewatch 本体がテンプレートを action directory 相対ではなく利用側 repo の CWD 相対で探していたことです。`komagata/flakewatch@v0.6.27` で action 側を修正し、JUnit/output/source-root を workspace 絶対パスに正規化してから action directory で本体を実行するようにしました。

## 確認
- `ruby -rpsych -e 'Psych.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `komagata/flakewatch` 側で `tya test tests/flakewatch_test.tya`
- PR #10142 の JUnit artifacts 相当を使い、修正後の実行条件で 14KB 程度の HTML report が生成されることを確認

## 備考
PR #10142 はすでに merge 済みだったため、この PR で follow-up します。

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27087707911/artifacts/7462563706" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->