### PR TITLE
本番デプロイでPostmark環境変数を必須にする

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -138,6 +138,7 @@ images:
 - asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
 substitutions:
   _APP_HOST_NAME: bootcamp.fjord.jp
+  _BASIC_AUTH_PASSWORD: ''
   _BASIC_AUTH_USER: ''
   _CLOUD_RUN_HOST_NAME: ''
   _CLOUD_SQL_HOST: ''
@@ -146,6 +147,7 @@ substitutions:
   _GCS_BUCKET: ''
   _LABELS: ''
   _MEMORY: ''
+  _POSTMARK_API_TOKEN: ''
   _DEPLOY_NOTIFY_WEBHOOK_URL: ''
   _SERVICE_NAME: ''
   _TRIGGER_ID: ''

--- a/.cloudbuild/deploy-cloud-run
+++ b/.cloudbuild/deploy-cloud-run
@@ -84,6 +84,28 @@ esac
 
 "$(dirname "$0")/cloud-build-env" cloud-run-json > "$env_vars_file"
 
+case "$environment" in
+  production)
+    python3 - "$env_vars_file" <<'PY'
+import json
+import sys
+
+required = ["POSTMARK_API_TOKEN"]
+with open(sys.argv[1], encoding="utf-8") as env_file:
+    env_vars = json.load(env_file)
+
+missing = [name for name in required if not str(env_vars.get(name, "")).strip()]
+if missing:
+    print(
+        "ERROR: required production environment variable(s) are missing: "
+        + ", ".join(missing),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+    ;;
+esac
+
 cloud_run_args+=(
   --clear-secrets
   --env-vars-file

--- a/test/lib/deploy_cloud_run_test.rb
+++ b/test/lib/deploy_cloud_run_test.rb
@@ -26,6 +26,20 @@ class DeployCloudRunTest < ActiveSupport::TestCase
     end
   end
 
+  test 'fails before deploy when required production environment variables are missing' do
+    Dir.mktmpdir do |dir|
+      gcloud_log = File.join(dir, 'gcloud.log')
+      stub_gcloud(dir, gcloud_log)
+
+      env = deploy_env(dir).except('_POSTMARK_API_TOKEN')
+      _stdout, stderr, status = Open3.capture3(env, SCRIPT, 'production')
+
+      assert_not_predicate status, :success?
+      assert_includes stderr, 'POSTMARK_API_TOKEN'
+      assert_not File.exist?(gcloud_log), 'gcloud should not be called'
+    end
+  end
+
   private
 
   def stub_gcloud(dir, gcloud_log)
@@ -57,6 +71,7 @@ class DeployCloudRunTest < ActiveSupport::TestCase
       '_SERVICE_NAME' => 'bootcamp',
       '_TRIGGER_ID' => 'trigger123',
       '_RAILS_MASTER_KEY' => 'master-key',
+      '_POSTMARK_API_TOKEN' => 'postmark-token',
       '_DB_PASS' => 'db-pass'
     }
   end


### PR DESCRIPTION
## 概要
- production Cloud Build substitutions に `_POSTMARK_API_TOKEN` / `_BASIC_AUTH_PASSWORD` を明示
- production deploy 時に `POSTMARK_API_TOKEN` が欠けている場合、Cloud Run を更新する前に失敗させる
- deploy script の単体テストに必須 env 欠落時の検証を追加

## 背景
production deploy 後、現行 revision `bootcamp-00543-q2p` で `POSTMARK_API_TOKEN` が Cloud Run 環境変数から消えていました。

直前の安定 revision `bootcamp-00539-tp6` では `POSTMARK_API_TOKEN` は Secret Manager 参照 `postmark-api-token` として存在していましたが、PR #10142 の `--clear-secrets` により既存 secret env が削除され、production trigger substitutions から再投入されていませんでした。

そのため、メール送信時に Postmark API token が nil になり、本番 Rollbar のエラーにつながっている可能性が高いです。

## 注意
この PR だけでは production trigger の値は設定されません。マージ前または次回 production deploy 前に、Cloud Build trigger `cloud-run-deploy` に `_POSTMARK_API_TOKEN` を設定する必要があります。

本番環境への直接変更はこの PR では行っていません。

## 確認
- `mise exec -- rails test test/lib/deploy_cloud_run_test.rb`
- `ruby -rpsych -e 'Psych.load_file(".cloudbuild/cloudbuild.yaml"); puts "yaml ok"'`\n- 現行 production build `a99d31f5-de7e-4ab1-8ac7-543e18a2c66b` の substitutions から生成される env に `POSTMARK_API_TOKEN` が含まれないことを確認\n- Cloud Run revision 比較で `POSTMARK_API_TOKEN` が `bootcamp-00539-tp6` には存在し、`bootcamp-00543-q2p` では消えていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 本番環境へのデプロイメント実行前に必須環境変数の存在確認を強化し、デプロイメント信頼性を向上させました。
  * Cloud Build設定に認証関連の置換変数を追加し、デプロイメントプロセスの堅牢性を改善しました。
  * デプロイメント検証テストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27089507391/artifacts/7463201117" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10146-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->