### PR TITLE
Flakewatchの履歴生成を高速化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.27
+        uses: komagata/flakewatch@v0.6.29
         with:
           junit-artifact-pattern: junit-xml-*
           source-root: ${{ github.workspace }}


### PR DESCRIPTION
## 概要

Flakewatch の履歴生成を無効化するのではなく、履歴 JSONL の読み込み処理を高速化した upstream 版へ更新します。

- komagata/flakewatch#6 で flakewatch 生成済み JSONL 向けの固定スキーマ読み込みを追加
- komagata/flakewatch#7 で GitHub Action の既定インストール版を v0.6.29 に更新
- bootcamp 側は `komagata/flakewatch@v0.6.29` へ更新
- `history-branch: flakewatch-data` と `history-write: auto` は維持

## 確認

- flakewatch upstream: `tya test tests/flakewatch_test.tya`
- flakewatch upstream: `tya lint src tests`
- komagata/flakewatch v0.6.29 release workflow 成功
- bootcamp PR CI: Flakewatch HTML report 成功
- bootcamp workflow_dispatch run 27096020853: 履歴ありで Flakewatch HTML report 成功
  - `FLAKEWATCH_VERSION="v0.6.29"` を確認
  - `HISTORY_PATTERN` が設定されていることを確認
  - `flakewatch.html` と `run-27096020853-attempt-1.jsonl` の書き込みを確認

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10148-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->