### PR TITLE
本番デプロイでPostmark secretを渡す

### DIFF
--- a/.cloudbuild/cloudbuild.yaml
+++ b/.cloudbuild/cloudbuild.yaml
@@ -77,6 +77,8 @@ steps:
   name: gcr.io/google.com/cloudsdktool/cloud-sdk
   automapSubstitutions: true
   entrypoint: bash
+  secretEnv:
+  - POSTMARK_API_TOKEN_FROM_SECRET
   args:
   - ".cloudbuild/deploy-cloud-run"
   - production
@@ -84,6 +86,8 @@ steps:
   name: gcr.io/google.com/cloudsdktool/cloud-sdk
   automapSubstitutions: true
   entrypoint: bash
+  secretEnv:
+  - POSTMARK_API_TOKEN_FROM_SECRET
   waitFor:
   - Deploy
   args:
@@ -91,7 +95,12 @@ steps:
   - |
     set -euo pipefail
 
+    postmark_api_token_from_secret_env="$${POSTMARK_API_TOKEN_FROM_SECRET:-}"
     source .cloudbuild/substitutions.env
+    if [[ -z "$${_POSTMARK_API_TOKEN:-}" && -n "$${postmark_api_token_from_secret_env}" ]]; then
+      export _POSTMARK_API_TOKEN="$${postmark_api_token_from_secret_env}"
+    fi
+
     env_vars="$(.cloudbuild/cloud-build-env cloud-run-env-vars)"
 
     if gcloud run jobs describe link-checker --region=asia-northeast1 --quiet 2>/dev/null; then
@@ -136,6 +145,10 @@ options:
 timeout: 7200s
 images:
 - asia.gcr.io/$PROJECT_ID/$REPO_NAME:latest
+availableSecrets:
+  secretManager:
+  - versionName: projects/$PROJECT_ID/secrets/bootcamp-production-postmark-api-token/versions/latest
+    env: POSTMARK_API_TOKEN_FROM_SECRET
 substitutions:
   _APP_HOST_NAME: bootcamp.fjord.jp
   _BASIC_AUTH_PASSWORD: ''

--- a/.cloudbuild/deploy-cloud-run
+++ b/.cloudbuild/deploy-cloud-run
@@ -6,9 +6,13 @@ env_vars_file="$(mktemp)"
 trap 'rm -f "$env_vars_file"' EXIT
 
 substitution_env_file="${SUBSTITUTION_ENV_FILE:-.cloudbuild/substitutions.env}"
+postmark_api_token_from_secret_env="${POSTMARK_API_TOKEN_FROM_SECRET:-}"
 if [[ -f "$substitution_env_file" ]]; then
   # shellcheck source=/dev/null
   source "$substitution_env_file"
+fi
+if [[ -z "${_POSTMARK_API_TOKEN:-}" && -n "$postmark_api_token_from_secret_env" ]]; then
+  export _POSTMARK_API_TOKEN="$postmark_api_token_from_secret_env"
 fi
 
 image_for_environment() {

--- a/test/lib/deploy_cloud_run_test.rb
+++ b/test/lib/deploy_cloud_run_test.rb
@@ -40,6 +40,24 @@ class DeployCloudRunTest < ActiveSupport::TestCase
     end
   end
 
+  test 'uses postmark token from secret env when substitution file contains an empty placeholder' do
+    Dir.mktmpdir do |dir|
+      gcloud_log = File.join(dir, 'gcloud.log')
+      stub_gcloud(dir, gcloud_log)
+      substitutions_env = File.join(dir, 'substitutions.env')
+      File.write(substitutions_env, "export _POSTMARK_API_TOKEN=''\n")
+
+      env = deploy_env(dir).merge(
+        'SUBSTITUTION_ENV_FILE' => substitutions_env,
+        'POSTMARK_API_TOKEN_FROM_SECRET' => 'postmark-token-from-secret'
+      )
+      _stdout, stderr, status = Open3.capture3(env, SCRIPT, 'production')
+
+      assert_predicate status, :success?, stderr
+      assert File.exist?(gcloud_log), 'gcloud should be called'
+    end
+  end
+
   private
 
   def stub_gcloud(dir, gcloud_log)

--- a/test/lib/deploy_cloud_run_test.rb
+++ b/test/lib/deploy_cloud_run_test.rb
@@ -45,7 +45,11 @@ class DeployCloudRunTest < ActiveSupport::TestCase
       gcloud_log = File.join(dir, 'gcloud.log')
       stub_gcloud(dir, gcloud_log)
       substitutions_env = File.join(dir, 'substitutions.env')
-      File.write(substitutions_env, "export _POSTMARK_API_TOKEN=''\n")
+      File.write(
+        substitutions_env,
+        "export _POSTMARK_API_TOKEN=''\n" \
+        "export POSTMARK_API_TOKEN=''\n"
+      )
 
       env = deploy_env(dir).merge(
         'SUBSTITUTION_ENV_FILE' => substitutions_env,


### PR DESCRIPTION
## 概要

production Cloud Build の `Deploy` step で `POSTMARK_API_TOKEN` が空になり、本番デプロイが失敗していた問題を修正します。

失敗した build: b97935b9-3640-4073-9a72-d68df5af2db0

```text
ERROR: required production environment variable(s) are missing: POSTMARK_API_TOKEN
```

## 修正内容

- production の `.cloudbuild/cloudbuild.yaml` で Secret Manager の `bootcamp-production-postmark-api-token` を `POSTMARK_API_TOKEN_FROM_SECRET` として利用
- `Deploy` step と `UpdateLinkCheckerJob` step に `secretEnv` を追加
- `.cloudbuild/substitutions.env` にある空の `_POSTMARK_API_TOKEN` placeholder が secretEnv の値を上書きしないよう補完処理を追加
- substitution に `_POSTMARK_API_TOKEN` が設定された場合は従来通りそれを優先

## 確認

- `mise exec -- rails test test/lib/deploy_cloud_run_test.rb test/lib/cloud_build_env_test.rb`
- `ruby -e 'require "yaml"; YAML.load_file(".cloudbuild/cloudbuild.yaml"); puts "ok"'`
- `mise exec -- ./bin/lint`

## 補足

この PR は production trigger を直接変更せず、repo 側の Cloud Build config で既存の Secret Manager secret を参照します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ビルド／デプロイ工程でSecret Managerのシークレットを取得する仕組みを導入。デプロイとリンクチェッカー実行時に、置換ファイルでトークン未指定の場合はシークレット値で補完されるようにしました。

* **Tests**
  * 置換ファイル内の空プレースホルダを補完してデプロイが成功することを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27098277612/artifacts/7466034529" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10149-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->