### PR TITLE
Font Awesomeの疑似要素フォントを修正

### DIFF
--- a/app/assets/stylesheets/application/blocks/page/_page-body.css
+++ b/app/assets/stylesheets/application/blocks/page/_page-body.css
@@ -175,7 +175,7 @@
 
 .page-body__description .message::before {
   content: "\f06a";
-  font-family: 'Font Awesome 6 Pro';
+  font-family: 'Font Awesome 7 Free';
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/application/blocks/tags/_random-tags.css
+++ b/app/assets/stylesheets/application/blocks/tags/_random-tags.css
@@ -49,7 +49,7 @@
 .is-first .random-tags-item__name::before, .is-second .random-tags-item__name::before, .is-third .random-tags-item__name::before {
   margin-right: 0.5em;
   content: "\f521";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/application/blocks/user/_active-practices-list.css
+++ b/app/assets/stylesheets/application/blocks/user/_active-practices-list.css
@@ -21,7 +21,7 @@
 }
 .active-practices-list-item__link::before {
   content: "\f060";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/application/blocks/user/_following.css
+++ b/app/assets/stylesheets/application/blocks/user/_following.css
@@ -34,7 +34,7 @@
 }
 .following-option.is-active .following-option__inner::before {
   content: "\f00c";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/atoms/_a-block-check.css
+++ b/app/assets/stylesheets/atoms/_a-block-check.css
@@ -93,7 +93,7 @@ input:checked + .a-block-check__label {
   border-color: var(--primary);
   background-color: var(--primary);
   content: "\f00c";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/atoms/_a-button.css
+++ b/app/assets/stylesheets/atoms/_a-button.css
@@ -38,7 +38,7 @@
 }
 .a-button.is-select::before {
   content: "\f0d7";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;
@@ -104,7 +104,7 @@
 }
 .a-button.is-checkbox::after {
   content: "\f00c";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;
@@ -484,7 +484,7 @@ input:checked + .a-button.is-checkbox::after {
 }
 .a-button.is-back::before {
   content: "\f104";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/atoms/_a-checkbox.css
+++ b/app/assets/stylesheets/atoms/_a-checkbox.css
@@ -35,7 +35,7 @@
 
 .a-checkbox input:checked + span::before {
   content: "\f00c";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/atoms/_a-form-label.css
+++ b/app/assets/stylesheets/atoms/_a-form-label.css
@@ -11,7 +11,7 @@
 }
 .a-form-label.is-required::after {
   content: "\f069";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;
@@ -69,7 +69,7 @@
 }
 .form-item__label-checkbox input:checked + .a-form-label::after {
   content: "\f00c";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/atoms/_a-image-check.css
+++ b/app/assets/stylesheets/atoms/_a-image-check.css
@@ -77,7 +77,7 @@ input:checked + .a-image-check__inner .a-image-check__start {
   border-color: var(--primary);
   background-color: var(--primary);
   content: "\f00c";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/atoms/_a-long-text.css
+++ b/app/assets/stylesheets/atoms/_a-long-text.css
@@ -249,7 +249,7 @@
 }
 .a-long-text .message::before {
   content: "\f06a";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/atoms/_a-notice-block.css
+++ b/app/assets/stylesheets/atoms/_a-notice-block.css
@@ -52,7 +52,7 @@
 }
 .a-notice-block .message::before {
   content: "\f06a";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/shared/blocks/form/_checkboxes.css
+++ b/app/assets/stylesheets/shared/blocks/form/_checkboxes.css
@@ -60,7 +60,7 @@
   background-color: var(--primary);
   border-color: var(--primary);
   content: "\f00c";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;

--- a/app/assets/stylesheets/shared/blocks/form/_form-item.css
+++ b/app/assets/stylesheets/shared/blocks/form/_form-item.css
@@ -135,7 +135,7 @@
 
 .form-item__mention-input::before {
   content: '@';
-  font-family: 'Font Awesome 6 Pro';
+  font-family: 'Font Awesome 7 Free';
   font-style: normal;
   font-weight: 400;
   font-variant: normal;

--- a/app/assets/stylesheets/shared/blocks/form/_form-table.css
+++ b/app/assets/stylesheets/shared/blocks/form/_form-table.css
@@ -47,7 +47,7 @@
 .form-table .form-table__check:has(:checked) label::after {
   border: none;
   content: "\f00c";
-  font-family: "Font Awesome 6 Pro";
+  font-family: "Font Awesome 7 Free";
   font-style: normal;
   font-weight: 900;
   font-variant: normal;


### PR DESCRIPTION
## 概要
- CSS の疑似要素で参照していた Font Awesome のフォントファミリを `Font Awesome 7 Free` に更新
- `@fortawesome/fontawesome-free` 7.2.0 と実際の webfont 名を一致させ、日報作成画面の「日報一覧」ボタンなどのアイコン表示崩れを修正

## 背景
PR #10135 の review 環境で、`/reports/new` の「日報一覧」ボタンの戻るアイコンが別の記号として表示されていました。CSS 側が存在しない `Font Awesome 6 Pro` を指定していたことが原因です。

## 確認
- `mise exec -- npm run lint`
- `mise exec -- ./bin/lint`
- ローカル `http://localhost:3000/reports/new` で `日報一覧` ボタンの `::before` が `Font Awesome 7 Free` / `\f104` になり、左向きアイコンで表示されることを確認