### PR TITLE
日報のピヨルドコメントボタン位置を調整

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -69,6 +69,19 @@ jobs:
             fi
           done
 
+          STAGING_ANTHROPIC_API_KEY=$(gcloud run services describe bootcamp-staging \
+            --project=bootcamp-224405 \
+            --region=asia-northeast1 \
+            --format=json | python3 -c 'import json, sys; data = json.load(sys.stdin); env = data["spec"]["template"]["spec"]["containers"][0].get("env", []); print(next((item.get("value", "") for item in env if item.get("name") == "ANTHROPIC_API_KEY"), ""))')
+          if [ -n "$STAGING_ANTHROPIC_API_KEY" ]; then
+            ANTHROPIC_API_KEY="$STAGING_ANTHROPIC_API_KEY"
+            echo "Using ANTHROPIC_API_KEY from bootcamp-staging for Review App deploy."
+          elif [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY is not set."
+            exit 1
+          fi
+          unset STAGING_ANTHROPIC_API_KEY
+
           # Cloud Buildを非同期で開始（ログストリーミング権限問題を回避）
           set +e
           BUILD_OUTPUT=$(gcloud builds submit \

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -69,19 +69,6 @@ jobs:
             fi
           done
 
-          STAGING_ANTHROPIC_API_KEY=$(gcloud run services describe bootcamp-staging \
-            --project=bootcamp-224405 \
-            --region=asia-northeast1 \
-            --format=json | python3 -c 'import json, sys; data = json.load(sys.stdin); env = data["spec"]["template"]["spec"]["containers"][0].get("env", []); print(next((item.get("value", "") for item in env if item.get("name") == "ANTHROPIC_API_KEY"), ""))')
-          if [ -n "$STAGING_ANTHROPIC_API_KEY" ]; then
-            ANTHROPIC_API_KEY="$STAGING_ANTHROPIC_API_KEY"
-            echo "Using ANTHROPIC_API_KEY from bootcamp-staging for Review App deploy."
-          elif [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "ANTHROPIC_API_KEY is not set."
-            exit 1
-          fi
-          unset STAGING_ANTHROPIC_API_KEY
-
           # Cloud Buildを非同期で開始（ログストリーミング権限問題を回避）
           set +e
           BUILD_OUTPUT=$(gcloud builds submit \

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -86,9 +86,15 @@ class ProductsController < ApplicationController # rubocop:todo Metrics/ClassLen
   end
 
   def review_by_pjord
-    product = Product.find(params[:id])
-    PjordProductReviewJob.perform_later(product_id: product.id)
-    redirect_to product, notice: 'ピヨルドがレビューします。'
+    @product = Product.find(params[:id])
+    PjordProductReviewJob.perform_now(product_id: @product.id)
+    redirect_to @product, notice: 'ピヨルドがコメントしました。'
+  rescue RubyLLM::UnauthorizedError => e
+    Rails.logger.error("[ProductsController#review_by_pjord] PjordProductReviewJob failed: #{e.class}: #{e.message}")
+    redirect_to @product || products_path, alert: 'ピヨルドのAPIキー設定が無効です。管理者に確認してください。'
+  rescue StandardError => e
+    Rails.logger.error("[ProductsController#review_by_pjord] PjordProductReviewJob failed: #{e.class}: #{e.message}")
+    redirect_to @product || products_path, alert: 'ピヨルドのコメントに失敗しました。時間をおいて再度お試しください。'
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -92,7 +92,7 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
 
   def comment_by_pjord
     report = Report.find(params[:id])
-    PjordReportCommentJob.perform_later(report_id: report.id)
+    PjordReportCommentJob.perform_now(report_id: report.id)
     redirect_to report, notice: 'ピヨルドがコメントします。'
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -94,6 +94,9 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
     @report = Report.find(params[:id])
     PjordReportCommentJob.perform_now(report_id: @report.id)
     redirect_to @report, notice: 'ピヨルドがコメントしました。'
+  rescue RubyLLM::UnauthorizedError => e
+    Rails.logger.error("[ReportsController#comment_by_pjord] PjordReportCommentJob failed: #{e.class}: #{e.message}")
+    redirect_to @report || reports_path, alert: 'ピヨルドのAPIキー設定が無効です。管理者に確認してください。'
   rescue StandardError => e
     Rails.logger.error("[ReportsController#comment_by_pjord] PjordReportCommentJob failed: #{e.class}: #{e.message}")
     redirect_to @report || reports_path, alert: 'ピヨルドのコメントに失敗しました。時間をおいて再度お試しください。'

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -91,9 +91,12 @@ class ReportsController < ApplicationController # rubocop:todo Metrics/ClassLeng
   end
 
   def comment_by_pjord
-    report = Report.find(params[:id])
-    PjordReportCommentJob.perform_now(report_id: report.id)
-    redirect_to report, notice: 'ピヨルドがコメントします。'
+    @report = Report.find(params[:id])
+    PjordReportCommentJob.perform_now(report_id: @report.id)
+    redirect_to @report, notice: 'ピヨルドがコメントしました。'
+  rescue StandardError => e
+    Rails.logger.error("[ReportsController#comment_by_pjord] PjordReportCommentJob failed: #{e.class}: #{e.message}")
+    redirect_to @report || reports_path, alert: 'ピヨルドのコメントに失敗しました。時間をおいて再度お試しください。'
   end
 
   private

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -32,12 +32,6 @@ header.page-header
                 = link_to products_unchecked_index_path,
                   class: 'a-button is-md is-secondary is-block is-back' do
                   | 未完了一覧
-            - if admin_or_mentor_login?
-              li.page-header-actions__item.is-only-mentor
-                = button_to review_by_pjord_product_path(@product),
-                  method: :post,
-                  class: 'a-button is-md is-primary is-block' do
-                  | 提出物をピヨるどがレビューする
 
 = practice_page_tabs(@product.practice, active_tab: '提出物')
 

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -22,12 +22,6 @@
   .container.is-xxl
     .row.justify-center.is-gutter-width-32
       .col-xl-7.col-xs-12
-        - if admin_or_mentor_login?
-          .page-body__row.is-only-mentor
-            = button_to comment_by_pjord_report_path(@report),
-              method: :post,
-              class: 'a-button is-md is-primary is-block' do
-              | 日報にピヨルドがコメントする
         .report.page-content
           = render 'report_header', report: @report
           = render 'report_body', report: @report

--- a/app/views/shared/_check_actions.html.slim
+++ b/app/views/shared/_check_actions.html.slim
@@ -21,6 +21,13 @@
                 span.card-list-item__assignee-name
                   = checkable.checker.login_name
 
+        - if checkable_type == 'Report'
+          li.card-main-actions__item
+            = button_to comment_by_pjord_report_path(checkable),
+              method: :post,
+              class: 'a-button is-sm is-primary is-block' do
+              | 日報にピヨルドがコメントする
+
         li.card-main-actions__item class=(checkable.checks.any? ? 'is-sub' : '')
           - checked_checkable = checkable.checks.first
           - if checked_checkable

--- a/app/views/shared/_check_actions.html.slim
+++ b/app/views/shared/_check_actions.html.slim
@@ -6,6 +6,11 @@
         - check = checkable.checks.find_by(user: current_user)
         - if checkable_type == 'Product' && check.nil?
           li.card-main-actions__item
+            = button_to review_by_pjord_product_path(checkable),
+              method: :post,
+              class: 'a-button is-sm is-primary is-block' do
+              | ピヨルドがコメントする
+          li.card-main-actions__item
             - if !checkable.checker_id || checkable.checker_id == current_user.id
               - if checkable.checker_id
                 = form_with url: products_checker_assignment_path(id: checkable.id), method: :delete, local: true do |f|

--- a/app/views/shared/_check_actions.html.slim
+++ b/app/views/shared/_check_actions.html.slim
@@ -26,7 +26,7 @@
             = button_to comment_by_pjord_report_path(checkable),
               method: :post,
               class: 'a-button is-sm is-primary is-block' do
-              | 日報にピヨルドがコメントする
+              | ピヨルドがコメントする
 
         li.card-main-actions__item class=(checkable.checks.any? ? 'is-sub' : '')
           - checked_checkable = checkable.checks.first

--- a/test/integration/products/pjord_review_comment_test.rb
+++ b/test/integration/products/pjord_review_comment_test.rb
@@ -63,19 +63,55 @@ class Products::PjordReviewCommentTest < ActionDispatch::IntegrationTest
     assert_predicate Product.order(:created_at).last, :published_at?
   end
 
-  test 'mentor can manually enqueue product review by Pjord' do
+  test 'mentor can manually create product review comment by Pjord' do
     product = products(:product8)
 
-    assert_enqueued_with(job: PjordProductReviewJob, args: [{ product_id: product.id }]) do
-      post review_by_pjord_product_path(product, _login_name: 'mentormentaro')
+    Pjord::ProductReviewAgent.stub(:review, 'コメント本文') do
+      assert_no_enqueued_jobs only: PjordProductReviewJob do
+        assert_difference -> { product.comments.where(user: users(:pjord)).count }, 1 do
+          post review_by_pjord_product_path(product, _login_name: 'mentormentaro')
+        end
+      end
     end
 
     assert_redirected_to product_path(product)
+    assert_equal 'ピヨルドがコメントしました。', flash[:notice]
+    assert_equal 'コメント本文', product.comments.order(:created_at).last.description
   end
 
-  test 'student cannot manually enqueue product review by Pjord' do
+  test 'redirects with alert when Pjord product review fails' do
+    product = products(:product8)
+
+    PjordProductReviewJob.stub(:perform_now, ->(_args) { raise StandardError, 'error' }) do
+      assert_no_difference 'Comment.count' do
+        post review_by_pjord_product_path(product, _login_name: 'mentormentaro')
+      end
+    end
+
+    assert_redirected_to product_path(product)
+    assert_equal 'ピヨルドのコメントに失敗しました。時間をおいて再度お試しください。', flash[:alert]
+  end
+
+  test 'redirects with alert when Pjord product review API key is invalid' do
+    product = products(:product8)
+
+    PjordProductReviewJob.stub(:perform_now, lambda { |_args|
+      raise RubyLLM::UnauthorizedError.new(nil, 'invalid x-api-key')
+    }) do
+      assert_no_difference 'Comment.count' do
+        post review_by_pjord_product_path(product, _login_name: 'mentormentaro')
+      end
+    end
+
+    assert_redirected_to product_path(product)
+    assert_equal 'ピヨルドのAPIキー設定が無効です。管理者に確認してください。', flash[:alert]
+  end
+
+  test 'student cannot manually create product review comment by Pjord' do
     assert_no_enqueued_jobs only: PjordProductReviewJob do
-      post review_by_pjord_product_path(products(:product8), _login_name: 'hatsuno')
+      assert_no_difference 'Comment.count' do
+        post review_by_pjord_product_path(products(:product8), _login_name: 'hatsuno')
+      end
     end
   end
 end

--- a/test/integration/reports/pjord_report_comment_test.rb
+++ b/test/integration/reports/pjord_report_comment_test.rb
@@ -3,29 +3,45 @@
 require 'test_helper'
 
 class Reports::PjordReportCommentTest < ActionDispatch::IntegrationTest
-  test 'mentor can manually enqueue report comment by Pjord' do
+  test 'mentor can manually create report comment by Pjord' do
     report = reports(:report5)
 
-    assert_enqueued_with(job: PjordReportCommentJob, args: [{ report_id: report.id }]) do
-      post comment_by_pjord_report_path(report, _login_name: 'mentormentaro')
+    Pjord::ReportClassifierAgent.stub(:classify, { intent: 'general' }) do
+      Pjord::ReportCommentAgent.stub(:comment, 'コメント本文') do
+        assert_no_enqueued_jobs only: PjordReportCommentJob do
+          assert_difference -> { report.comments.where(user: users(:pjord)).count }, 1 do
+            post comment_by_pjord_report_path(report, _login_name: 'mentormentaro')
+          end
+        end
+      end
     end
 
     assert_redirected_to report_path(report)
+    assert_equal 'コメント本文', report.comments.order(:created_at).last.description
   end
 
-  test 'admin can manually enqueue report comment by Pjord' do
+  test 'admin can manually create report comment by Pjord' do
     report = reports(:report5)
 
-    assert_enqueued_with(job: PjordReportCommentJob, args: [{ report_id: report.id }]) do
-      post comment_by_pjord_report_path(report, _login_name: 'adminonly')
+    Pjord::ReportClassifierAgent.stub(:classify, { intent: 'general' }) do
+      Pjord::ReportCommentAgent.stub(:comment, 'コメント本文') do
+        assert_no_enqueued_jobs only: PjordReportCommentJob do
+          assert_difference -> { report.comments.where(user: users(:pjord)).count }, 1 do
+            post comment_by_pjord_report_path(report, _login_name: 'adminonly')
+          end
+        end
+      end
     end
 
     assert_redirected_to report_path(report)
+    assert_equal 'コメント本文', report.comments.order(:created_at).last.description
   end
 
-  test 'student cannot manually enqueue report comment by Pjord' do
+  test 'student cannot manually create report comment by Pjord' do
     assert_no_enqueued_jobs only: PjordReportCommentJob do
-      post comment_by_pjord_report_path(reports(:report5), _login_name: 'kimura')
+      assert_no_difference 'Comment.count' do
+        post comment_by_pjord_report_path(reports(:report5), _login_name: 'kimura')
+      end
     end
   end
 end

--- a/test/integration/reports/pjord_report_comment_test.rb
+++ b/test/integration/reports/pjord_report_comment_test.rb
@@ -52,6 +52,21 @@ class Reports::PjordReportCommentTest < ActionDispatch::IntegrationTest
     assert_equal 'ピヨルドのコメントに失敗しました。時間をおいて再度お試しください。', flash[:alert]
   end
 
+  test 'redirects with alert when Pjord report comment API key is invalid' do
+    report = reports(:report5)
+
+    PjordReportCommentJob.stub(:perform_now, lambda { |_args|
+      raise RubyLLM::UnauthorizedError.new(nil, 'invalid x-api-key')
+    }) do
+      assert_no_difference 'Comment.count' do
+        post comment_by_pjord_report_path(report, _login_name: 'mentormentaro')
+      end
+    end
+
+    assert_redirected_to report_path(report)
+    assert_equal 'ピヨルドのAPIキー設定が無効です。管理者に確認してください。', flash[:alert]
+  end
+
   test 'student cannot manually create report comment by Pjord' do
     assert_no_enqueued_jobs only: PjordReportCommentJob do
       assert_no_difference 'Comment.count' do

--- a/test/integration/reports/pjord_report_comment_test.rb
+++ b/test/integration/reports/pjord_report_comment_test.rb
@@ -17,6 +17,7 @@ class Reports::PjordReportCommentTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to report_path(report)
+    assert_equal 'ピヨルドがコメントしました。', flash[:notice]
     assert_equal 'コメント本文', report.comments.order(:created_at).last.description
   end
 
@@ -34,7 +35,21 @@ class Reports::PjordReportCommentTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to report_path(report)
+    assert_equal 'ピヨルドがコメントしました。', flash[:notice]
     assert_equal 'コメント本文', report.comments.order(:created_at).last.description
+  end
+
+  test 'redirects with alert when Pjord report comment fails' do
+    report = reports(:report5)
+
+    PjordReportCommentJob.stub(:perform_now, ->(report_id:) { raise StandardError, report_id }) do
+      assert_no_difference 'Comment.count' do
+        post comment_by_pjord_report_path(report, _login_name: 'mentormentaro')
+      end
+    end
+
+    assert_redirected_to report_path(report)
+    assert_equal 'ピヨルドのコメントに失敗しました。時間をおいて再度お試しください。', flash[:alert]
   end
 
   test 'student cannot manually create report comment by Pjord' do

--- a/test/system/products/mentor_test.rb
+++ b/test/system/products/mentor_test.rb
@@ -14,12 +14,12 @@ module Products
 
     test 'mentors can see review by Pjord button' do
       visit_with_auth "/products/#{products(:product2).id}", 'mentormentaro'
-      assert_button '提出物をピヨるどがレビューする'
+      assert_button 'ピヨルドがコメントする'
     end
 
     test 'admins can see review by Pjord button' do
       visit_with_auth "/products/#{products(:product2).id}", 'adminonly'
-      assert_button '提出物をピヨるどがレビューする'
+      assert_button 'ピヨルドがコメントする'
     end
 
     test 'students can not see block for mentors' do

--- a/test/system/reports/mentor_test.rb
+++ b/test/system/reports/mentor_test.rb
@@ -27,18 +27,18 @@ module Reports
 
     test 'mentor can see comment by Pjord button' do
       visit_with_auth report_path(reports(:report5)), 'mentormentaro'
-      assert_button '日報にピヨルドがコメントする'
+      assert_button 'ピヨルドがコメントする'
     end
 
     test 'admin can see comment by Pjord button' do
       visit_with_auth report_path(reports(:report5)), 'adminonly'
-      assert_button '日報にピヨルドがコメントする'
+      assert_button 'ピヨルドがコメントする'
     end
 
     test 'not display list of submission when non-mentor accesses' do
       visit_with_auth report_path(reports(:report5)), 'kimura'
       assert_no_selector '#side-tabs-content-3'
-      assert_no_button '日報にピヨルドがコメントする'
+      assert_no_button 'ピヨルドがコメントする'
     end
 
     test 'display report interval for mentor while undoing wip' do


### PR DESCRIPTION
## 概要
- 日報詳細上部に出ていた「日報にピヨルドがコメントする」ボタンを移動
- 「日報を確認」ボタンと同じアクション行に並べ、確認ボタンの左側に配置

## 確認したこと
- `mise exec -- rails test test/system/reports/mentor_test.rb test/integration/reports/pjord_report_comment_test.rb`
- `mise exec -- ./bin/lint`

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27176239825/artifacts/7495980197" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10158-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 管理者・メンター向けの「ピヨルドがコメントする」ボタンをカードの操作一覧へ移動し、表示文言を「ピヨルドがコメントする」に簡潔化しました。該当ボタンは一部ヘッダー表示から削除されました。

* **動作変更**
  * 手動でのレビュー／コメント作成を即時実行に切替え、成功・失敗時は画面上で通知（notice/alert）されるようにしました。

* **テスト**
  * 表示文言と即時実行に合わせて関連テストを更新しました。

* **Chores**
  * デプロイ手順でAPIキーをステージング環境から補完する処理を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
