### PR TITLE
Font Awesome 7のatアイコン表示を修正

### DIFF
--- a/app/assets/stylesheets/shared/blocks/form/_form-item.css
+++ b/app/assets/stylesheets/shared/blocks/form/_form-item.css
@@ -134,18 +134,16 @@
 }
 
 .form-item__mention-input::before {
-  content: '@';
+  content: "\@";
   font-family: 'Font Awesome 7 Free';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 900;
   font-variant: normal;
   text-rendering: auto;
+  font-size: 1rem;
   line-height: 1;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  content: "\f1fa";
-  font-size: 1rem;
-  line-height: 1;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/test/system/admin/users_test.rb
+++ b/test/system/admin/users_test.rb
@@ -119,6 +119,26 @@ class Admin::UsersTest < ApplicationSystemTestCase
     assert_match(/\?v=\d+/, after_src)
   end
 
+  test 'shows Font Awesome at icons on user edit form mention inputs' do
+    user = users(:komagata)
+    user.update!(github_id: '1234567890')
+    visit_with_auth edit_admin_user_path(user.id), 'komagata'
+
+    assert_selector '.form-item__mention-input', count: 3
+    all('.form-item__mention-input').each do |mention_input|
+      before_style = mention_input.evaluate_script(<<~JS)
+        (() => {
+          const style = getComputedStyle(this, '::before')
+          return { content: style.content, fontFamily: style.fontFamily, fontWeight: style.fontWeight }
+        })()
+      JS
+
+      assert_equal '"@"', before_style['content']
+      assert_match(/Font Awesome 7 Free/, before_style['fontFamily'])
+      assert_equal '900', before_style['fontWeight']
+    end
+  end
+
   test 'update user with company' do
     user = users(:kensyu)
     visit_with_auth "/admin/users/#{user.id}/edit", 'komagata'


### PR DESCRIPTION
## 概要
- Closes #10163
- ユーザー編集フォームのメンション入力欄で、Font Awesome 7 の at アイコンが tofu 表示になる問題を修正
- Font Awesome 7.2.0 の fa-at 定義に合わせて content と font-weight を更新
- 管理者のユーザー編集画面で Discord / GitHub / X(Twitter) の3欄が Font Awesome 7 Free の solid アイコンとして描画されることをシステムテストで確認

## 確認
- `mise exec -- rails test test/system/admin/users_test.rb -n "test_shows_Font_Awesome_at_icons_on_user_edit_form_mention_inputs"`
- `mise exec -- ./bin/lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ユーザー編集フォームのメンション入力フィールドのアイコン表示を「@」記号に変更し、フォント設定を更新しました。

* **テスト**
  * メンション入力フィールドのアイコン表示とフォント設定を検証するシステムテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27204908882/artifacts/7507329299" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10162-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->