### PR TITLE
jquery-ujs依存を削除

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,4 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 //= require jquery
-//= require jquery_ujs
 //= require activestorage

--- a/app/javascript/importmap_application.js
+++ b/app/javascript/importmap_application.js
@@ -1,4 +1,5 @@
 import 'controllers'
+import Rails from '@rails/ujs'
 import 'textarea'
 import 'markdown'
 import 'shortcut'
@@ -82,6 +83,8 @@ import 'bookmark-button'
 import 'notifications_remove_after_open'
 import 'notifications-bell'
 import 'products-checker-init'
+
+Rails.start()
 
 document.addEventListener('DOMContentLoaded', () => {
   Cocooned.start()

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,6 +7,7 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin "@notus.sh/cocooned", to: "https://ga.jspm.io/npm:@notus.sh/cocooned@3.0.1/index.js" # @3.0.1
 pin "@rails/request.js", to: "https://ga.jspm.io/npm:@rails/request.js@0.0.13/src/index.js" # @0.0.13
+pin "@rails/ujs", to: "https://ga.jspm.io/npm:@rails/ujs@7.1.3-4/app/assets/javascripts/rails-ujs.esm.js" # @7.1.3-4
 pin "@yaireo/tagify", to: "https://ga.jspm.io/npm:@yaireo/tagify@4.37.1/dist/tagify.esm.js" # @4.37.1
 pin "ace-builds", to: "https://ga.jspm.io/npm:ace-builds@1.44.0/src-noconflict/ace.js" # @1.44.0
 pin "autosize", to: "https://ga.jspm.io/npm:autosize@6.0.1/dist/autosize.esm.js" # @6.0.1


### PR DESCRIPTION
## 概要

- app/assets/javascripts/application.js から jquery_ujs の読み込みを削除
- importmap 経由で @rails/ujs を読み込み、既存の data-method / data-confirm の挙動を維持
- jquery-ujs / remote: true / $.ajax 依存が残っていないことを確認

## 確認

- [x] mise exec -- rails test test/system/works_test.rb test/system/notifications_bell_test.rb
- [x] mise exec -- npm run lint:eslint
- [x] mise exec -- npm run lint:prettier
- [x] mise exec -- ./bin/lint

Closes #10168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chore**
  * Rails UJS（Unobtrusive JavaScript）ライブラリの構成と初期化処理を改善しました。
  * ActiveStorageのサポートを統合しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27281013689/artifacts/7538036659" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10171-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->