### PR TITLE
ピヨルドの提出物コメント追随返信を停止する

### DIFF
--- a/app/models/comment/after_create_callback.rb
+++ b/app/models/comment/after_create_callback.rb
@@ -23,7 +23,6 @@ class Comment::AfterCreateCallback
     comment.commentable.update_commented_at(comment)
     delete_product_cache(comment.commentable.id)
     delete_assigned_and_unreplied_product_count_cache(comment)
-    notify_pjord_if_comment_replies_to_pjord_review(comment)
   end
 
   private
@@ -88,14 +87,5 @@ class Comment::AfterCreateCallback
       本文： #{comment.description}
       URL： <https://bootcamp.fjord.jp/talks/#{comment.commentable_id}#latest-comment>
     TEXT
-  end
-
-  def notify_pjord_if_comment_replies_to_pjord_review(comment)
-    pjord = Pjord.user
-    return if pjord.nil? || comment.user_id == pjord.id
-    return if comment.body&.match?(/(?<!\w)@#{Regexp.escape(Pjord::LOGIN_NAME)}(?!\w)/)
-    return unless comment.commentable.comments.where(user: pjord).where('created_at < ?', comment.created_at).exists?
-
-    PjordRespondJob.perform_later(mentionable_type: comment.class.name, mentionable_id: comment.id)
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -75,7 +75,7 @@ class CommentTest < ActiveSupport::TestCase
     )
   end
 
-  test 'enqueue Pjord response when product comment follows Pjord comment' do
+  test 'does not enqueue Pjord response when product comment follows Pjord comment without mention' do
     product = products(:product8)
     Comment.create!(
       user: users(:pjord),
@@ -83,7 +83,7 @@ class CommentTest < ActiveSupport::TestCase
       description: '修正点をレビューしました。'
     )
 
-    assert_enqueued_with(job: PjordRespondJob) do
+    assert_no_enqueued_jobs only: PjordRespondJob do
       Comment.create!(
         user: product.user,
         commentable: product,
@@ -109,7 +109,7 @@ class CommentTest < ActiveSupport::TestCase
     end
   end
 
-  test 'does not enqueue duplicate Pjord response when product comment mentions Pjord' do
+  test 'enqueues Pjord response when product comment mentions Pjord' do
     product = products(:product8)
     Comment.create!(
       user: users(:pjord),


### PR DESCRIPTION
## 概要
- production 向け hotfix PR です
- 提出物コメントで、過去にピヨルドがコメントしているだけではピヨルド返信ジョブを enqueue しないようにしました
- 既存の @pjord メンションによる返信機能に任せるため、提出物専用の追随返信処理を削除しました
- 無メンション追随返信を enqueue しないテストに更新しました

## 確認
- mise exec -- rails test test/models/comment_test.rb test/jobs/pjord_respond_job_test.rb
- mise exec -- bundle exec rubocop app/models/comment/after_create_callback.rb test/models/comment_test.rb test/jobs/pjord_respond_job_test.rb app/jobs/pjord_respond_job.rb
- git diff --check

## 関連
- main 向けPR: #10173