### PR TITLE
ピヨルドにAIバッジを表示する hotfix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,10 @@ module ApplicationHelper
   def pair_work_available?
     Rails.env.local? || Switchlet.enabled?(:pair_work)
   end
+
+  def pjord_ai_badge(user)
+    return unless user.login_name == Pjord::LOGIN_NAME
+
+    tag.span 'AI', class: 'a-badge is-xs is-info', title: 'AIアシスタント'
+  end
 end

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -17,6 +17,7 @@
                 img.thread-comment__title-user-icon.a-user-icon src="#{comment.user.avatar_url}"
             a.thread-comment__title-link.a-text-link href="#{comment.user.url}"
               = comment.user.login_name
+            = pjord_ai_badge(comment.user)
           time.thread-comment__created-at
             = l(comment.created_at)
           .raw-button

--- a/app/views/questions/_answer.html.slim
+++ b/app/views/questions/_answer.html.slim
@@ -22,6 +22,7 @@
               img.thread-comment__title-user-icon.a-user-icon src="#{answer.user.avatar_url}"
           a.thread-comment__title-link.a-text-link href="#{answer.user.url}"
             = answer.user.login_name
+          = pjord_ai_badge(answer.user)
         time.thread-comment__created-at.created-at
           = l(answer.created_at)
       hr.a-border-tint

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -3,6 +3,15 @@
 require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
-  # ApplicationHelper specific tests can be added here
-  # search_summary related tests have been moved to SearchHelperTest
+  test 'pjord_ai_badge returns AI badge for Pjord' do
+    badge = pjord_ai_badge(users(:pjord))
+
+    assert_includes badge, 'AI'
+    assert_includes badge, 'AIアシスタント'
+    assert_includes badge, 'a-badge'
+  end
+
+  test 'pjord_ai_badge returns nil for other users' do
+    assert_nil pjord_ai_badge(users(:komagata))
+  end
 end


### PR DESCRIPTION
## 概要
- production向けhotfix PRです
- ピヨルド（pjord）のコメント・Q&A回答のユーザー名横に `AI` バッジを表示
- main向けPR: https://github.com/fjordllc/bootcamp/pull/10175 と同内容

## 確認
- `mise exec -- rails test test/helpers/application_helper_test.rb`
- `mise exec -- ./bin/lint`