### PR TITLE
copy_practices rakeタスクを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.31
+        # komagata/flakewatch v0.6.31
+        uses: komagata/flakewatch@e734ba749bb1f8de2b9ae8a35b2cb02d63bbbf76
         with:
           junit-artifact-pattern: junit-xml-*
           source-root: ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.29
+        uses: komagata/flakewatch@v0.6.30
         with:
           junit-artifact-pattern: junit-xml-*
           source-root: ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        uses: komagata/flakewatch@v0.6.30
+        uses: komagata/flakewatch@v0.6.31
         with:
           junit-artifact-pattern: junit-xml-*
           source-root: ${{ github.workspace }}

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -51,60 +51,6 @@ namespace :bootcamp do
     end
   end
 
-  desc 'Copy practices from rails course to reskill course.'
-  task copy_practices: :environment do
-    sufix = '（Reスキル）'
-    slug = '-reskill'
-    rails_course = Course.find_by(title: 'Railsエンジニア')
-    reskill_course = Course.find_by(title: 'Railsエンジニア（Reスキル講座認定）')
-
-    if rails_course && reskill_course
-      Course.transaction do
-        # Copy categories
-        rails_course.categories.each do |category|
-          Category.exists?(name: category.name + sufix) && next
-
-          new_category = category.dup
-          new_category.id = nil
-          new_category.name = category.name + sufix
-          new_category.slug = category.slug + slug
-          puts "Copying category: #{new_category.name}"
-          reskill_course.categories << new_category
-          new_category.save!
-
-          # Copy practices
-          category.practices.each do |practice|
-            Practice.exists?(title: practice.title + sufix) && next
-
-            new_practice = practice.dup
-            new_practice.id = nil
-            new_practice.title = practice.title + sufix
-            new_practice.category_id = new_category.id
-            new_practice.source_id = practice.id
-
-            new_practice.categories << new_category
-
-            puts "Copying practice: #{new_practice.title}"
-            new_practice.save!
-
-            # Copy reports
-            practice.reports.each do |report|
-              new_practice.reports << report
-            end
-
-            # Copy books
-            practice.books.each do |book|
-              new_practice.books << book
-            end
-          end
-        end
-        puts 'Practices copied successfully.'
-      end
-    else
-      puts 'One or both courses not found.'
-    end
-  end
-
   namespace :oneshot do
     desc 'Cloud Build Task'
     task cloudbuild: :environment do


### PR DESCRIPTION
## Issue

- Closes #10182

## 概要

- 一回限りのデータ修正用と見られる `bootcamp:copy_practices` rakeタスクを削除
- `copy_practices` の参照が残っていないことを確認

## 変更確認方法

1. `copy_practices` の定義・参照が残っていないことを検索する
2. rakeタスク一覧に `bootcamp:copy_practices` が表示されないことを確認する
3. lintが通ることを確認する

## 確認

- [x] `rg -n "copy_practices|Copy practices from rails course to reskill course" .`
- [x] `mise exec -- bin/rails --tasks | rg "bootcamp:copy_practices|bootcamp:"`
- [x] `mise exec -- bundle exec rubocop lib/tasks/bootcamp.rake`
- [x] `mise exec -- ./bin/lint`

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27492297012/artifacts/7618900905" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10203-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions の flakewatch をアップデートしました（v0.6.29 → v0.6.31）

* **Refactor**
  * コース複製に関する処理を削除しました（「Railsエンジニア」から「Railsエンジニア（Reスキル講座認定）」へのカテゴリ／プラクティス／レポート／ブック複製が無効化されました）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
