### PR TITLE
チーム開発ミーティングのDiscord通知を追加

### DIFF
--- a/.github/workflows/notify-team-dev-meeting.yml
+++ b/.github/workflows/notify-team-dev-meeting.yml
@@ -53,13 +53,13 @@ jobs:
             exit 1
           fi
 
-          mention="@bootcampスクラムチーム"
-          allowed_mentions='{"parse":[]}'
-
-          if [ -n "$SCRUM_TEAM_ROLE_ID" ]; then
-            mention="<@&${SCRUM_TEAM_ROLE_ID}>"
-            allowed_mentions="{\"roles\":[\"${SCRUM_TEAM_ROLE_ID}\"]}"
+          if [ -z "$SCRUM_TEAM_ROLE_ID" ]; then
+            echo "DISCORD_BOOTCAMP_SCRUM_TEAM_ROLE_ID is not set." >&2
+            exit 1
           fi
+
+          mention="<@&${SCRUM_TEAM_ROLE_ID}>"
+          allowed_mentions="{\"roles\":[\"${SCRUM_TEAM_ROLE_ID}\"]}"
 
           message="$(cat <<EOF
           ${mention} 本日のミーティングは下記で行います。

--- a/.github/workflows/notify-team-dev-meeting.yml
+++ b/.github/workflows/notify-team-dev-meeting.yml
@@ -1,0 +1,77 @@
+name: Notify team development meeting
+
+on:
+  schedule:
+    # 10:00 JST every Wednesday. The job skips even year weeks.
+    - cron: "0 1 * * 3"
+  workflow_dispatch:
+    inputs:
+      force_send:
+        description: Send even when the current year week is even
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+env:
+  TZ: Asia/Tokyo
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check odd week
+        id: odd-week
+        run: |
+          day_of_year="$(date +%j)"
+          week_number="$(((10#$day_of_year - 1) / 7 + 1))"
+          echo "week-number=${week_number}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force_send }}" = "true" ]; then
+            echo "should-send=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$((10#$week_number % 2))" -eq 1 ]; then
+            echo "should-send=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-send=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Discord
+        if: steps.odd-week.outputs.should-send == 'true'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_TEAM_DEV_BOOTCAMP_WEBHOOK_URL }}
+          SCRUM_TEAM_ROLE_ID: ${{ secrets.DISCORD_BOOTCAMP_SCRUM_TEAM_ROLE_ID }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_TEAM_DEV_BOOTCAMP_WEBHOOK_URL is not set." >&2
+            exit 1
+          fi
+
+          mention="@bootcampスクラムチーム"
+          allowed_mentions='{"parse":[]}'
+
+          if [ -n "$SCRUM_TEAM_ROLE_ID" ]; then
+            mention="<@&${SCRUM_TEAM_ROLE_ID}>"
+            allowed_mentions="{\"roles\":[\"${SCRUM_TEAM_ROLE_ID}\"]}"
+          fi
+
+          message="$(cat <<EOF
+          ${mention} 本日のミーティングは下記で行います。
+          昼の部：https://meet.google.com/kzg-rywc-nrs
+          夜の部：https://meet.google.com/xvv-iyeg-xdz
+          EOF
+          )"
+
+          jq -n \
+            --arg content "$message" \
+            --argjson allowed_mentions "$allowed_mentions" \
+            '{content: $content, allowed_mentions: $allowed_mentions}' > payload.json
+
+          curl -f \
+            -H 'Content-Type: application/json' \
+            -d @payload.json \
+            "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/notify-team-dev-meeting.yml
+++ b/.github/workflows/notify-team-dev-meeting.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   TZ: Asia/Tokyo
+  SCRUM_TEAM_ROLE_ID: "1372122463831588995"
 
 jobs:
   notify:
@@ -46,15 +47,9 @@ jobs:
         if: steps.odd-week.outputs.should-send == 'true'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_TEAM_DEV_BOOTCAMP_WEBHOOK_URL }}
-          SCRUM_TEAM_ROLE_ID: ${{ secrets.DISCORD_BOOTCAMP_SCRUM_TEAM_ROLE_ID }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
             echo "DISCORD_TEAM_DEV_BOOTCAMP_WEBHOOK_URL is not set." >&2
-            exit 1
-          fi
-
-          if [ -z "$SCRUM_TEAM_ROLE_ID" ]; then
-            echo "DISCORD_BOOTCAMP_SCRUM_TEAM_ROLE_ID is not set." >&2
             exit 1
           fi
 

--- a/.github/workflows/notify-team-dev-meeting.yml
+++ b/.github/workflows/notify-team-dev-meeting.yml
@@ -2,12 +2,12 @@ name: Notify team development meeting
 
 on:
   schedule:
-    # 10:00 JST every Wednesday. The job skips even year weeks.
+    # 10:00 JST every Wednesday. The job skips even ISO weeks.
     - cron: "0 1 * * 3"
   workflow_dispatch:
     inputs:
       force_send:
-        description: Send even when the current year week is even
+        description: Send even when the current ISO week is even
         required: false
         default: "false"
 
@@ -24,12 +24,14 @@ jobs:
     steps:
       - name: Check odd week
         id: odd-week
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FORCE_SEND: ${{ github.event.inputs.force_send || 'false' }}
         run: |
-          day_of_year="$(date +%j)"
-          week_number="$(((10#$day_of_year - 1) / 7 + 1))"
+          week_number="$(date +%V)"
           echo "week-number=${week_number}" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force_send }}" = "true" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$FORCE_SEND" = "true" ]; then
             echo "should-send=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## 概要
- 1年の奇数週の水曜日 10:00 JST に #チーム開発-bootcamp🍕 へミーティング案内を投稿する GitHub Actions ワークフローを追加しました
- GitHub Actions の cron は毎週水曜 10:00 JST に起動し、ジョブ内で ISO 週番号が奇数のときだけ送信します
- `workflow_dispatch` と `force_send` を用意し、手動テストもできるようにしました
- `@bootcampスクラムチーム` は文字列ではなく、Discord Role ID `1372122463831588995` を使った `<@&1372122463831588995>` 形式で送信します

## 必要な GitHub Secrets
- `DISCORD_TEAM_DEV_BOOTCAMP_WEBHOOK_URL`: #チーム開発-bootcamp🍕 チャンネルの Discord Webhook URL

## 確認
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/notify-team-dev-meeting.yml"); puts "YAML OK"'`
- payload が `<@&1372122463831588995>` と `allowed_mentions.roles` を含むことを確認
- `git diff --check`
- `mise exec -- ./bin/lint`

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10214-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27745642991/artifacts/7717922370" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
