### PR TITLE
participated_byスコープを削除

### DIFF
--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -51,7 +51,6 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   scope :not_finished, -> { where(finished: false, wip: false) }
-  scope :participated_by, ->(user) { where(id: all.filter { |e| e.participated_by?(user) }.map(&:id)) }
   scope :organizer_event, ->(user) { joins(:regular_event_organizers).where(regular_event_organizers: { user: user }) }
 
   scope :fetch_target_events, lambda { |target|
@@ -124,10 +123,6 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def cancel_participation(user)
     regular_event_participation = regular_event_participations.find_by(user_id: user.id)
     regular_event_participation.destroy
-  end
-
-  def participated_by?(user)
-    regular_event_participations.find_by(user_id: user.id).present?
   end
 
   def all_scheduled_dates(

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -118,15 +118,6 @@ class RegularEventTest < ActiveSupport::TestCase
     assert_not regular_event.regular_event_participations.find_by(user_id: participant.id)
   end
 
-  test '#participated_by?' do
-    regular_event = regular_events(:regular_event1)
-    user = users(:hatsuno)
-    assert regular_event.participated_by?(user)
-
-    user = users(:komagata)
-    assert_not regular_event.participated_by?(user)
-  end
-
   test '#close_or_destroy_organizer closes the event when only one organizer exists' do
     user = users(:kimura)
     regular_event = regular_events(:regular_event5) # kimuraが1人で主催しているイベント


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9711

## 概要
issueにて`scope :participated_by`が使用されていないことが確認できたので、関連するテストとともに削除した。
## 変更確認方法

1. `refactoring/delete-scope-participated_by`をローカルに取り込む
2. ターミナルで`grep -rn "participated_by" app lib test config `を実行してアプリ内で使用されていないか確認する
[Linux　grepコマンドの使い方 \#centos7 \- Qiita](https://qiita.com/LIB/items/6950acebedd576780ced)
<img width="908" height="65" alt="image" src="https://github.com/user-attachments/assets/95c73ceb-3198-4723-8929-21a9901e5d7e" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * イベント参加状況の確認に関する内部インターフェースを削除し、コード構造を簡素化しました。対応するテストも削除されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10216-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27763019245/artifacts/7726750924" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
