### PR TITLE
Shift + {Key} のショートカットが Command + Shift + {Key } でも動いてしまうバグの修正

### DIFF
--- a/app/javascript/shortcut.js
+++ b/app/javascript/shortcut.js
@@ -39,6 +39,7 @@ const insertUserIconTag = (textarea) => {
 document.addEventListener('keydown', (event) => {
   if (event.isComposing || event.keyCode === 229) return
   if (!isModifierPressed(event)) return
+  if (event.shiftKey) return
 
   const key = event.key.toLowerCase()
   const editable = isEditableTarget(event.target)


### PR DESCRIPTION
バグ報告 : https://github.com/fjordllc/bootcamp/issues/10166

Shift キーを押しながら修飾キー付きショートカットを入力した場合は処理しないようにしました。
これにより Shift 併用の通常入力や別ショートカットと競合しないようになります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* キーボードショートカットの動作を改善しました。修飾キー（Command/Ctrl）とShiftキーを同時に押した場合、既存のショートカット処理が実行されなくなります。これにより、キーボードショートカットの競合を防ぎます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27858337038/artifacts/7761577606" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10221-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->