### PR TITLE
動画ページのWatchボタンを修正

### DIFF
--- a/app/views/movies/_movie_header.html.slim
+++ b/app/views/movies/_movie_header.html.slim
@@ -66,8 +66,7 @@ header.page-content-header
     .page-content-header__row
       .page-content-header-actions
         .page-content-header-actions__start
-          .page-content-header-actions__action
-            div(data-vue="WatchToggle" data-vue-watchable-id:number="#{movie.id}" data-vue-watchable-type='Movie')
+          = render 'watches/watch_toggle', type: movie.class.to_s, id: movie.id, watch: movie.watch_by(current_user)
           .page-content-header-actions__action
             = render 'bookmarks/button', bookmarkable: movie
           = render 'application/url_copy_button'

--- a/test/system/watches_test.rb
+++ b/test/system/watches_test.rb
@@ -87,4 +87,10 @@ class WatchesTest < ApplicationSystemTestCase
     assert_text 'OS X Mountain Lionをクリーンインストールする'
     assert_no_text '作業週1日目'
   end
+
+  test 'the Watch button is displayed on a movie page' do
+    visit_with_auth "/movies/#{movies(:movie1).id}", 'komagata'
+    assert_selector '.watch-toggle'
+    assert_text 'Watch'
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/9838

## 概要
- `_movie_header.html.slim` の `data-vue="WatchToggle"` の記述を削除し、[他ページ](https://github.com/fjordllc/bootcamp/blame/aaebf7020200f1929e6ed88e098c2d8a06ef2a16/app/views/pages/_doc_header.html.slim#L72)と同じく `render 'watches/watch_toggle'` に統一
- 動画ページにWatchボタンが表示されることを確認するシステムテストを追加
## 変更確認方法

1. bug/movie-watch-toggleをローカルに取り込む
2. 任意のユーザーでログイン
3. http://localhost:3000/movies ページのどれかをクリックし、Watchが表示されていることを確認する。
4. クリックで「Watch中」に切り替わり、`/current_user/watches` にその動画が追加される
5. Watchに切り替えて、`/current_user/watches` でその動画が削除される

<img width="853" height="767" alt="_development__Watch中___FBC_と__development__動画__OS_X_M…ンストールする_動画7_mp4動画___FBC" src="https://github.com/user-attachments/assets/4ae9ed36-857f-4bdd-9615-07a08c057d9f" />

<img width="827" height="805" alt="_development__Watch中___FBC_と__development__動画__OS_X_M…ンストールする_動画7_mp4動画___FBC" src="https://github.com/user-attachments/assets/b34533e2-d96d-41fb-ad83-d4d2c256138e" />


## Screenshot

### 変更前
<img width="701" height="753" alt="_development__動画__OS_X_M…ンストールする_動画7_mp4動画___FBC" src="https://github.com/user-attachments/assets/d2b9a889-9779-4e27-af06-d4c550b7f868" />

### 変更後
<img width="712" height="742" alt="_development__動画__OS_X_M…ンストールする_動画7_mp4動画___FBC" src="https://github.com/user-attachments/assets/e69cbb0c-0f66-4ed1-ac2a-7b76c7114c1e" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 映画ページでのウォッチボタン表示を確認するシステムテストを追加しました。

* **リファクター**
  * 映画ページのウォッチトグル機能の実装を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/27866245501/artifacts/7763954331" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10223-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->