### PR TITLE
給付金コースユーザーが通常コースのプラクティスの提出物を提出できないようにする

### DIFF
--- a/app/assets/stylesheets/application/blocks/practice/_practice-status-buttons.css
+++ b/app/assets/stylesheets/application/blocks/practice/_practice-status-buttons.css
@@ -120,3 +120,23 @@
   color: var(--muted-text);
   margin-top: .5em;
 }
+
+.practice-status-buttons__grant-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 16rem;
+}
+
+.practice-status-buttons__grant-guidance {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .75rem;
+}
+
+.practice-status-buttons__grant-note {
+  margin-top: 0;
+  text-align: center;
+}

--- a/app/components/learnings/learning_component.html.slim
+++ b/app/components/learnings/learning_component.html.slim
@@ -1,6 +1,10 @@
 .card-main-actions
   ul.card-main-actions__items
-    - if submission? && @practice.source_id.present? || !@current_user.grant_course?
+    - if @current_user.grant_course? && @practice.source_id.blank?
+      li.card-main-actions__item
+        = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm is-block' do
+          | 給付金コースへ遷移する
+    - else
       li.card-main-actions__item
         = link_to product_link, class: 'a-button is-sm is-primary is-block test-product' do
           i.fa-solid.fa-file
@@ -15,7 +19,3 @@
           = button_tag type: 'button', class: 'a-button is-sm is-warning is-block', id: 'js-complete', data: { practice_id: @practice.id } do
             i.fa-solid.fa-check
             | 修了
-    - else
-      li.card-main-actions__item
-        = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm is-block' do
-          | 給付金コースへ遷移する

--- a/app/components/learnings/learning_component.html.slim
+++ b/app/components/learnings/learning_component.html.slim
@@ -5,6 +5,10 @@
         = link_to product_link, class: 'a-button is-sm is-primary is-block test-product' do
           i.fa-solid.fa-file
           | #{product_label}
+    - else
+      li.card-main-actions__item
+        = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm is-block' do
+          | Reスキルコースへ遷移する
     - if @practice.completed?(@current_user)
       li.card-main-actions__item
         button.a-button.is-sm.is-secondary.is-block.is-disabled.test-completed

--- a/app/components/learnings/learning_component.html.slim
+++ b/app/components/learnings/learning_component.html.slim
@@ -1,6 +1,6 @@
 .card-main-actions
   ul.card-main-actions__items
-    - if submission?
+    - if submission? && @practice.source_id.present? || !@current_user.grant_course?
       li.card-main-actions__item
         = link_to product_link, class: 'a-button is-sm is-primary is-block test-product' do
           i.fa-solid.fa-file

--- a/app/components/learnings/learning_component.html.slim
+++ b/app/components/learnings/learning_component.html.slim
@@ -1,4 +1,4 @@
-- if @current_user.grant_course? && @practice.source_id.blank?
+- if @practice.guide_to_grant_course?(@current_user)
   .practice-status-buttons
     .practice-status-buttons__grant-guidance
       = link_to practice_path(@practice.copied_practices.first || @practice), class: 'practice-status-buttons__grant-link a-button is-sm is-secondary' do

--- a/app/components/learnings/learning_component.html.slim
+++ b/app/components/learnings/learning_component.html.slim
@@ -1,10 +1,13 @@
-.card-main-actions
-  ul.card-main-actions__items
-    - if @current_user.grant_course? && @practice.source_id.blank?
-      li.card-main-actions__item
-        = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm is-block' do
-          | 給付金コースへ遷移する
-    - else
+- if @current_user.grant_course? && @practice.source_id.blank?
+  .practice-status-buttons
+    .practice-status-buttons__grant-guidance
+      = link_to practice_path(@practice.copied_practices.first || @practice), class: 'practice-status-buttons__grant-link a-button is-sm is-secondary' do
+        | 給付金コースへ移動する
+      .practice-status-buttons__note.practice-status-buttons__grant-note
+        | 提出・修了は、給付金コースのプラクティス側で行ってください。
+- else
+  .card-main-actions
+    ul.card-main-actions__items
       - if @practice.submission?
         li.card-main-actions__item
           = link_to product_link, class: 'a-button is-sm is-primary is-block test-product' do

--- a/app/components/learnings/learning_component.html.slim
+++ b/app/components/learnings/learning_component.html.slim
@@ -5,17 +5,17 @@
         = link_to product_link, class: 'a-button is-sm is-primary is-block test-product' do
           i.fa-solid.fa-file
           | #{product_label}
+      - if @practice.completed?(@current_user)
+        li.card-main-actions__item
+          button.a-button.is-sm.is-secondary.is-block.is-disabled.test-completed
+            i.fa-solid.fa-check
+            | 修了しています
+      - else
+        li.card-main-actions__item
+          = button_tag type: 'button', class: 'a-button is-sm is-warning is-block', id: 'js-complete', data: { practice_id: @practice.id } do
+            i.fa-solid.fa-check
+            | 修了
     - else
       li.card-main-actions__item
         = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm is-block' do
           | 給付金コースへ遷移する
-    - if @practice.completed?(@current_user)
-      li.card-main-actions__item
-        button.a-button.is-sm.is-secondary.is-block.is-disabled.test-completed
-          i.fa-solid.fa-check
-          | 修了しています
-    - else
-      li.card-main-actions__item
-        = button_tag type: 'button', class: 'a-button is-sm is-warning is-block', id: 'js-complete', data: { practice_id: @practice.id } do
-          i.fa-solid.fa-check
-          | 修了

--- a/app/components/learnings/learning_component.html.slim
+++ b/app/components/learnings/learning_component.html.slim
@@ -5,10 +5,11 @@
         = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm is-block' do
           | 給付金コースへ遷移する
     - else
-      li.card-main-actions__item
-        = link_to product_link, class: 'a-button is-sm is-primary is-block test-product' do
-          i.fa-solid.fa-file
-          | #{product_label}
+      - if @practice.submission?
+        li.card-main-actions__item
+          = link_to product_link, class: 'a-button is-sm is-primary is-block test-product' do
+            i.fa-solid.fa-file
+            | #{product_label}
       - if @practice.completed?(@current_user)
         li.card-main-actions__item
           button.a-button.is-sm.is-secondary.is-block.is-disabled.test-completed

--- a/app/components/learnings/learning_component.html.slim
+++ b/app/components/learnings/learning_component.html.slim
@@ -8,7 +8,7 @@
     - else
       li.card-main-actions__item
         = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm is-block' do
-          | Reスキルコースへ遷移する
+          | 給付金コースへ遷移する
     - if @practice.completed?(@current_user)
       li.card-main-actions__item
         button.a-button.is-sm.is-secondary.is-block.is-disabled.test-completed

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -211,6 +211,10 @@ class Practice < ApplicationRecord # rubocop:todo Metrics/ClassLength
     source_id.present?
   end
 
+  def guide_to_grant_course?(user)
+    user.grant_course? && source_id.blank?
+  end
+
   def reports_count(include_source: false)
     return reports.count unless include_source
 

--- a/app/views/practices/_learning-status.html.slim
+++ b/app/views/practices/_learning-status.html.slim
@@ -1,6 +1,13 @@
 .js-learning-status(id="practice" data-id="#{@practice.id}")
 .practice-status-buttons
-  - unless @practice.guide_to_grant_course?(current_user)
+  - if @practice.guide_to_grant_course?(current_user)
+    .practice-status-buttons
+      .practice-status-buttons__grant-guidance
+        = link_to practice_path(@practice.copied_practices.first || @practice), class: 'practice-status-buttons__grant-link a-button is-sm is-secondary' do
+          | 給付金コースへ移動する
+        .practice-status-buttons__note.practice-status-buttons__grant-note
+          | 進捗のステータス変更は、給付金コースのプラクティス側で行ってください。
+  - else
     .practice-status-buttons__start
       .practice-status-buttons__label
         | ステータス
@@ -23,10 +30,3 @@
       .practice-status-buttons__end
         .practice-status-buttons__note
           | このプラクティスに提出物はありません。修了条件をクリアしたら修了にしてください。
-  - else
-    .practice-status-buttons
-      .practice-status-buttons__grant-guidance
-        = link_to practice_path(@practice.copied_practices.first || @practice), class: 'practice-status-buttons__grant-link a-button is-sm is-secondary' do
-          | 給付金コースへ移動する
-        .practice-status-buttons__note.practice-status-buttons__grant-note
-          | 進捗のステータス変更は、給付金コースのプラクティス側で行ってください。

--- a/app/views/practices/_learning-status.html.slim
+++ b/app/views/practices/_learning-status.html.slim
@@ -1,24 +1,27 @@
 .js-learning-status(id="practice" data-id="#{@practice.id}")
 .practice-status-buttons
-  .practice-status-buttons__start
-    .practice-status-buttons__label
-      | ステータス
-    ul.practice-status-buttons__items.is-button-group
-      - button_base_class = 'practice-status-buttons__button a-button is-sm is-block'
-      li.practice-status-buttons__item
-        - button_class = "#{button_base_class} is-unstarted js-unstarted #{@status == 'unstarted' ? 'is-active' : 'is-inactive'}"
-        = content_tag :button, '未着手', class: button_class, disabled: @status == 'unstarted', data: { status: 'unstarted' }
-      - if @practice.source_id.present? || !current_user.grant_course?
+  - if @practice.source_id.present? || !current_user.grant_course?
+    .practice-status-buttons__start
+      .practice-status-buttons__label
+        | ステータス
+      ul.practice-status-buttons__items.is-button-group
+        - button_base_class = 'practice-status-buttons__button a-button is-sm is-block'
         li.practice-status-buttons__item
-          - button_class = "#{button_base_class} is-started js-started #{@status == 'started' ? 'is-active' : 'is-inactive'}"
-          = content_tag :button, '着手', class: button_class, disabled: @status == 'started', data: { status: 'started' }
-      - if @practice.submission
+          - button_class = "#{button_base_class} is-unstarted js-unstarted #{@status == 'unstarted' ? 'is-active' : 'is-inactive'}"
+          = content_tag :button, '未着手', class: button_class, disabled: @status == 'unstarted', data: { status: 'unstarted' }
+          li.practice-status-buttons__item
+            - button_class = "#{button_base_class} is-started js-started #{@status == 'started' ? 'is-active' : 'is-inactive'}"
+            = content_tag :button, '着手', class: button_class, disabled: @status == 'started', data: { status: 'started' }
+        - if @practice.submission
+          li.practice-status-buttons__item
+            - button_class = "#{button_base_class} is-submitted js-submitted #{@status == 'submitted' ? 'is-active' : 'is-inactive'}"
+            = content_tag :button, '提出', class: button_class, disabled: @status == 'submitted', data: { status: 'submitted' }
         li.practice-status-buttons__item
-          - button_class = "#{button_base_class} is-submitted js-submitted #{@status == 'submitted' ? 'is-active' : 'is-inactive'}"
-          = content_tag :button, '提出', class: button_class, disabled: @status == 'submitted', data: { status: 'submitted' }
-      li.practice-status-buttons__item
-        - button_class = "#{button_base_class} is-complete js-complete #{@status == 'complete' ? 'is-active' : 'is-inactive'}"
-        = content_tag :button, '修了', class: button_class, disabled: @status == 'complete', data: { status: 'complete' }
+          - button_class = "#{button_base_class} is-complete js-complete #{@status == 'complete' ? 'is-active' : 'is-inactive'}"
+          = content_tag :button, '修了', class: button_class, disabled: @status == 'complete', data: { status: 'complete' }
+  - else
+    = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm' do
+      | 給付金コースへ遷移する
 - if !@practice.submission
   .practice-status-buttons__end
     .practice-status-buttons__note

--- a/app/views/practices/_learning-status.html.slim
+++ b/app/views/practices/_learning-status.html.slim
@@ -9,9 +9,9 @@
         li.practice-status-buttons__item
           - button_class = "#{button_base_class} is-unstarted js-unstarted #{@status == 'unstarted' ? 'is-active' : 'is-inactive'}"
           = content_tag :button, '未着手', class: button_class, disabled: @status == 'unstarted', data: { status: 'unstarted' }
-          li.practice-status-buttons__item
-            - button_class = "#{button_base_class} is-started js-started #{@status == 'started' ? 'is-active' : 'is-inactive'}"
-            = content_tag :button, '着手', class: button_class, disabled: @status == 'started', data: { status: 'started' }
+        li.practice-status-buttons__item
+          - button_class = "#{button_base_class} is-started js-started #{@status == 'started' ? 'is-active' : 'is-inactive'}"
+          = content_tag :button, '着手', class: button_class, disabled: @status == 'started', data: { status: 'started' }
         - if @practice.submission
           li.practice-status-buttons__item
             - button_class = "#{button_base_class} is-submitted js-submitted #{@status == 'submitted' ? 'is-active' : 'is-inactive'}"
@@ -26,4 +26,3 @@
   - else
     = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm' do
       | 給付金コースへ遷移する
-

--- a/app/views/practices/_learning-status.html.slim
+++ b/app/views/practices/_learning-status.html.slim
@@ -19,10 +19,11 @@
         li.practice-status-buttons__item
           - button_class = "#{button_base_class} is-complete js-complete #{@status == 'complete' ? 'is-active' : 'is-inactive'}"
           = content_tag :button, '修了', class: button_class, disabled: @status == 'complete', data: { status: 'complete' }
+    - if !@practice.submission
+      .practice-status-buttons__end
+        .practice-status-buttons__note
+          | このプラクティスに提出物はありません。修了条件をクリアしたら修了にしてください。
   - else
     = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm' do
       | 給付金コースへ遷移する
-- if !@practice.submission
-  .practice-status-buttons__end
-    .practice-status-buttons__note
-      | このプラクティスに提出物はありません。修了条件をクリアしたら修了にしてください。
+

--- a/app/views/practices/_learning-status.html.slim
+++ b/app/views/practices/_learning-status.html.slim
@@ -8,9 +8,10 @@
       li.practice-status-buttons__item
         - button_class = "#{button_base_class} is-unstarted js-unstarted #{@status == 'unstarted' ? 'is-active' : 'is-inactive'}"
         = content_tag :button, '未着手', class: button_class, disabled: @status == 'unstarted', data: { status: 'unstarted' }
-      li.practice-status-buttons__item
-        - button_class = "#{button_base_class} is-started js-started #{@status == 'started' ? 'is-active' : 'is-inactive'}"
-        = content_tag :button, '着手', class: button_class, disabled: @status == 'started', data: { status: 'started' }
+      - if @practice.source_id.present? || !current_user.grant_course?
+        li.practice-status-buttons__item
+          - button_class = "#{button_base_class} is-started js-started #{@status == 'started' ? 'is-active' : 'is-inactive'}"
+          = content_tag :button, '着手', class: button_class, disabled: @status == 'started', data: { status: 'started' }
       - if @practice.submission
         li.practice-status-buttons__item
           - button_class = "#{button_base_class} is-submitted js-submitted #{@status == 'submitted' ? 'is-active' : 'is-inactive'}"

--- a/app/views/practices/_learning-status.html.slim
+++ b/app/views/practices/_learning-status.html.slim
@@ -1,6 +1,6 @@
 .js-learning-status(id="practice" data-id="#{@practice.id}")
 .practice-status-buttons
-  - if @practice.source_id.present? || !current_user.grant_course?
+  - unless @practice.guide_to_grant_course?(current_user)
     .practice-status-buttons__start
       .practice-status-buttons__label
         | ステータス

--- a/app/views/practices/_learning-status.html.slim
+++ b/app/views/practices/_learning-status.html.slim
@@ -24,5 +24,9 @@
         .practice-status-buttons__note
           | このプラクティスに提出物はありません。修了条件をクリアしたら修了にしてください。
   - else
-    = link_to practice_path(@practice.copied_practices.first || @practice), class: 'a-button is-sm' do
-      | 給付金コースへ遷移する
+    .practice-status-buttons
+      .practice-status-buttons__grant-guidance
+        = link_to practice_path(@practice.copied_practices.first || @practice), class: 'practice-status-buttons__grant-link a-button is-sm is-secondary' do
+          | 給付金コースへ移動する
+        .practice-status-buttons__note.practice-status-buttons__grant-note
+          | 進捗のステータス変更は、給付金コースのプラクティス側で行ってください。

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -124,7 +124,7 @@
               hr.a-border-tint
               footer.card-footer
                 = render(Learnings::LearningComponent.new(practice: @practice, current_user:))
-                - if @practice.submission
+                - if @practice.submission && !(@practice.source_id.blank? && current_user.grant_course?)
                   .card-footer__alert
                     = link_to '提出の前に、提出時の注意点を確認しよう',
                       'https://bootcamp.fjord.jp/pages/info-for-product',
@@ -134,7 +134,7 @@
                     | 提出物を作成し提出し、メンターから確認をもらったら
                     br
                     | このプラクティスを修了にしてください。
-                - else
+                - elsif !(@practice.source_id.blank? && current_user.grant_course?)
                   .card-footer__description
                     | このプラクティスに提出物はありません。
                     br

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -134,11 +134,12 @@
                     | 提出物を作成し提出し、メンターから確認をもらったら
                     br
                     | このプラクティスを修了にしてください。
-                - elsif !@practice.guide_to_grant_course?(current_user)
-                  .card-footer__description
-                    | このプラクティスに提出物はありません。
-                    br
-                    | 修了条件をクリアしたら修了にしてください。
+                - else
+                  - unless @practice.guide_to_grant_course?(@current_user)
+                    .card-footer__description
+                      | このプラクティスに提出物はありません。
+                      br
+                      | 修了条件をクリアしたら修了にしてください。
 
           - if @practice.coding_tests.present?
             = render partial: 'coding_tests', locals: { coding_tests: @practice.coding_tests }

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -124,7 +124,7 @@
               hr.a-border-tint
               footer.card-footer
                 = render(Learnings::LearningComponent.new(practice: @practice, current_user:))
-                - if @practice.submission && !(@practice.source_id.blank? && current_user.grant_course?)
+                - if @practice.submission && !@practice.guide_to_grant_course?(current_user)
                   .card-footer__alert
                     = link_to '提出の前に、提出時の注意点を確認しよう',
                       'https://bootcamp.fjord.jp/pages/info-for-product',
@@ -134,7 +134,7 @@
                     | 提出物を作成し提出し、メンターから確認をもらったら
                     br
                     | このプラクティスを修了にしてください。
-                - elsif !(@practice.source_id.blank? && current_user.grant_course?)
+                - elsif !@practice.guide_to_grant_course?(current_user)
                   .card-footer__description
                     | このプラクティスに提出物はありません。
                     br

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -129,4 +129,25 @@ class PracticesTest < ApplicationSystemTestCase
     assert_no_text 'このプラクティスに提出物はありません。'
     assert_no_text '修了条件をクリアしたら修了にしてください。'
   end
+
+  test 'show normal status buttons on source practice for non grant course user' do
+    source_practice = practices(:practice23)
+
+    visit_with_auth practice_path(source_practice), 'kimura'
+
+    assert_selector '.practice-status-buttons__button'
+    assert_no_link '給付金コースへ移動する'
+    assert_no_text '進捗のステータス変更は、給付金コースのプラクティス側で行ってください。'
+    assert_no_text '提出・修了は、給付金コースのプラクティス側で行ってください。'
+  end
+
+  test 'show normal status buttons on grant course practice for grant course user' do
+    grant_course_practice = practices(:practice64)
+
+    visit_with_auth practice_path(grant_course_practice), 'grant-course'
+
+    assert_selector '.practice-status-buttons__button'
+    assert_no_link '給付金コースへ移動する'
+    assert_no_text '進捗のステータス変更は、給付金コースのプラクティス側で行ってください。'
+  end
 end

--- a/test/system/practices_test.rb
+++ b/test/system/practices_test.rb
@@ -114,4 +114,19 @@ class PracticesTest < ApplicationSystemTestCase
     assert_text 'rubyをインストールする'
     assert_no_link '給付金コース'
   end
+
+  test 'show status guidance link on source practice for grant course user' do
+    source_practice = practices(:practice23)
+
+    visit_with_auth practice_path(source_practice), 'grant-course'
+
+    assert_link '給付金コースへ移動する', href: practice_path(practices(:practice64))
+    assert_text '進捗のステータス変更は、給付金コースのプラクティス側で行ってください。'
+    assert_text '提出・修了は、給付金コースのプラクティス側で行ってください。'
+    assert_no_text '提出の前に、提出時の注意点を確認しよう'
+    assert_no_text '提出物を作成し提出し、メンターから確認をもらったら'
+    assert_no_text 'このプラクティスを修了にしてください。'
+    assert_no_text 'このプラクティスに提出物はありません。'
+    assert_no_text '修了条件をクリアしたら修了にしてください。'
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7/views/1?pane=issue&itemId=182170113&issue=fjordllc%7Cbootcamp%7C9965

## 概要
給付金コースユーザーが通常コースのプラクティスに提出させないようにする間違いをなくしたい。
通常プラクティスに移動したら、
- 提出物作成のボタンをクリックできないようにし、給付金コースへ遷移するボタンを配置する。
- ステータスの箇所を給付金コースへ遷移するボタンを配置する。


## 変更確認方法

1. `feature/prevent-students-in-Reskill-course-from-submitting-regular-practice-assignments`をローカルに取り込む
2. `grant-course`でログインする
3. [rubyをインストールする](http://localhost:3000/practices/473419339)に移動する
4. 大見出しの上部に「元プラクティス」「給付金コース」というボタンが設置されているか確認する
5. 「元プラクティス」ボタンをクリックする
6. 「給付金コースに移動する」ボタンと「進捗のステータス変更は、給付金コースのプラクティス側で行ってください。」というテキストが2箇所に設置されているか確認する
7. 「給付金コース」ボタンをクリックする
8. 進捗のステータスと修了ボタンがあるか確認する

## Screenshot

### 変更前
<img width="831" height="1177" alt="6f97d81d-83ba-4c04-b381-ca8ae9272866" src="https://github.com/user-attachments/assets/22816ffa-8c42-4da3-bdcd-595dbb8634ac" />




### 変更後

<img width="845" height="1141" alt="e390c201-c8c7-4cb7-a094-1754ea2ba1b4" src="https://github.com/user-attachments/assets/3da948ee-742d-40ba-99e0-2358f9b8e3da" />

<img width="824" height="1145" alt="2ef801b3-48c6-473c-8bf5-b3e21e1d2fe9" src="https://github.com/user-attachments/assets/3afc5eea-5b02-44f4-b167-eb7f869ac800" />



<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート
* **改善**
  * 給付金コース対象の学習ページで、「先頭アクション」やガイダンス文言を条件に応じて切り替えました。
  * 給付金コース対象では「給付金コースへ移動する」リンクと注意文を表示し、通常のステータスボタンや提出物なしの文言は抑止します（非対象・対象ページでも表示を整理）。
* **テスト**
  * 給付金コース／非対象それぞれでの表示内容を確認するシステムテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29227885520/artifacts/8270628713" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10224-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
