### PR TITLE
ステージング環境で復帰ができない問題を修正

### DIFF
--- a/app/models/concerns/staging_environment.rb
+++ b/app/models/concerns/staging_environment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module StagingEnvironment
+  extend ActiveSupport::Concern
+
+  private
+
+  def staging?
+    ENV['DB_NAME'] == 'bootcamp_staging'
+  end
+end

--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Hibernation < ApplicationRecord
+  include StagingEnvironment
+
   belongs_to :user
   validates :reason, presence: true
   validates :scheduled_return_on, presence: true
@@ -32,10 +34,6 @@ class Hibernation < ApplicationRecord
   def update_hibernated_at!
     user.hibernated_at = created_at
     user.save!(validate: false)
-  end
-
-  def staging?
-    ENV['DB_NAME'] == 'bootcamp_staging'
   end
 
   def destroy_subscription!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
   include ActionView::Helpers::AssetUrlHelper
   include Taggable
   include Searchable
+  include StagingEnvironment
 
   attr_accessor :credit_card_payment, :role, :uploaded_avatar
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -668,6 +668,23 @@ class UserTest < ActiveSupport::TestCase
     assert_equal description, comment.body
   end
 
+  test 'comeback skips subscription in staging environment' do
+    user = users(:kyuukai)
+
+    original_db_name = ENV['DB_NAME']
+    ENV['DB_NAME'] = 'bootcamp_staging'
+
+    Rails.env.stub(:production?, true) do
+      assert_nothing_raised do
+        user.comeback!
+      end
+    end
+
+    assert_nil user.reload.hibernated_at
+  ensure
+    ENV['DB_NAME'] = original_db_name
+  end
+
   test '#become_watcher!' do
     watchable = pages(:page1)
     user = users(:kimura)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue・PR

- #9756
- #10022
- #10155 

## 概要

#10022 をステージング環境で動作確認したところ、復帰ボタン押下時に `500 Internal Server Error`が出るエラーが発生しておりました。

User モデル内で staging?が定義されていないことが原因とわかりました。

共通化するため、`StagingEnvironment` concern を追加し、User / Hibernation で include するよう修正しました。

## 変更確認方法

1. `fix/staging-user-comeback`をローカルに取り込む
2. `bin/rails test test/models/user_test.rb`をし、テストが通ることを確認。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ステージング環境の判定ロジックを共通化し、関連する機能で一貫して利用できるようになりました。
* **Bug Fixes**
  * ステージング環境でのサブスクリプション破棄/復帰条件が、意図した判定に基づいて動作するよう整理されました。
* **Tests**
  * ステージング環境での復帰処理が例外なく実行され、状態が正しく維持されることを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/28146596053/artifacts/7868851347" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10237-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
