### PR TITLE
プラクティスごとにPjordレビューを無効化できるようにする

### DIFF
--- a/app/controllers/mentor/practices_controller.rb
+++ b/app/controllers/mentor/practices_controller.rb
@@ -55,6 +55,7 @@ class Mentor::PracticesController < ApplicationController
       :goal,
       :submission,
       :open_product,
+      :disable_pjord_review,
       :include_progress,
       :completion_image,
       :memo,

--- a/app/controllers/mentor/practices_controller.rb
+++ b/app/controllers/mentor/practices_controller.rb
@@ -11,7 +11,7 @@ class Mentor::PracticesController < ApplicationController
   end
 
   def new
-    @practice = Practice.new
+    @practice = Practice.new(pjord_review: true)
   end
 
   def edit; end
@@ -55,7 +55,7 @@ class Mentor::PracticesController < ApplicationController
       :goal,
       :submission,
       :open_product,
-      :disable_pjord_review,
+      :pjord_review,
       :include_progress,
       :completion_image,
       :memo,

--- a/app/jobs/pjord_product_review_job.rb
+++ b/app/jobs/pjord_product_review_job.rb
@@ -8,7 +8,7 @@ class PjordProductReviewJob < ApplicationJob
   def perform(product_id:)
     product = Product.find_by(id: product_id)
     return if product.nil?
-    return if product.practice.disable_pjord_review?
+    return unless product.practice.pjord_review?
 
     pjord = Pjord.user
     return if pjord.nil?

--- a/app/jobs/pjord_product_review_job.rb
+++ b/app/jobs/pjord_product_review_job.rb
@@ -8,6 +8,7 @@ class PjordProductReviewJob < ApplicationJob
   def perform(product_id:)
     product = Product.find_by(id: product_id)
     return if product.nil?
+    return if product.practice.disable_pjord_review?
 
     pjord = Pjord.user
     return if pjord.nil?

--- a/app/models/pjord_review.rb
+++ b/app/models/pjord_review.rb
@@ -12,6 +12,7 @@ class PjordReview
 
   def call
     return unless submitted_on_save?
+    return if product.practice.disable_pjord_review?
 
     PjordProductReviewJob.perform_later(product_id: product.id)
   end

--- a/app/models/pjord_review.rb
+++ b/app/models/pjord_review.rb
@@ -12,7 +12,7 @@ class PjordReview
 
   def call
     return unless submitted_on_save?
-    return if product.practice.disable_pjord_review?
+    return unless product.practice.pjord_review?
 
     PjordProductReviewJob.perform_later(product_id: product.id)
   end

--- a/app/views/mentor/practices/_form.html.slim
+++ b/app/views/mentor/practices/_form.html.slim
@@ -95,9 +95,9 @@
           = f.label :open_product
             | OKをもらっていない人も提出物を見られるようにする場合はチェック
         li.checkboxes__item
-          = f.check_box :disable_pjord_review, class: 'a-toggle-checkbox'
-          = f.label :disable_pjord_review
-            | ピヨルドの提出物レビューをしない場合はチェック
+          = f.check_box :pjord_review, class: 'a-toggle-checkbox'
+          = f.label :pjord_review
+            | ピヨルドの提出物レビューをする場合はチェック
     = f.label :progress, class: 'a-form-label'
     .checkboxes
       ul.checkboxes__items

--- a/app/views/mentor/practices/_form.html.slim
+++ b/app/views/mentor/practices/_form.html.slim
@@ -94,6 +94,10 @@
           = f.check_box :open_product, class: 'a-toggle-checkbox'
           = f.label :open_product
             | OKをもらっていない人も提出物を見られるようにする場合はチェック
+        li.checkboxes__item
+          = f.check_box :disable_pjord_review, class: 'a-toggle-checkbox'
+          = f.label :disable_pjord_review
+            | ピヨルドの提出物レビューをしない場合はチェック
     = f.label :progress, class: 'a-form-label'
     .checkboxes
       ul.checkboxes__items

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -161,7 +161,7 @@ ja:
         goal: 修了条件
         target: ターゲット
         submission: 提出物
-        disable_pjord_review: ピヨルドの提出物レビュー
+        pjord_review: ピヨルドの提出物レビュー
         submission_answer: 模範解答
         progress: 進捗の計算
         completion_image: 修了おめでとう画像

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -161,6 +161,7 @@ ja:
         goal: 修了条件
         target: ターゲット
         submission: 提出物
+        disable_pjord_review: ピヨルドの提出物レビュー
         submission_answer: 模範解答
         progress: 進捗の計算
         completion_image: 修了おめでとう画像

--- a/db/migrate/20260630000000_add_disable_pjord_review_to_practices.rb
+++ b/db/migrate/20260630000000_add_disable_pjord_review_to_practices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDisablePjordReviewToPractices < ActiveRecord::Migration[8.0]
+  def change
+    add_column :practices, :disable_pjord_review, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20260630000000_add_disable_pjord_review_to_practices.rb
+++ b/db/migrate/20260630000000_add_disable_pjord_review_to_practices.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddDisablePjordReviewToPractices < ActiveRecord::Migration[8.0]
-  def change
-    add_column :practices, :disable_pjord_review, :boolean, null: false, default: false
-  end
-end

--- a/db/migrate/20260630000000_add_pjord_review_to_practices.rb
+++ b/db/migrate/20260630000000_add_pjord_review_to_practices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPjordReviewToPractices < ActiveRecord::Migration[8.0]
+  def change
+    add_column :practices, :pjord_review, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_062046) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -590,6 +590,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_062046) do
     t.integer "category_id"
     t.datetime "created_at", precision: nil
     t.text "description"
+    t.boolean "disable_pjord_review", default: false, null: false
     t.text "goal"
     t.boolean "include_progress", default: true, null: false
     t.integer "last_updated_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -590,12 +590,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_000000) do
     t.integer "category_id"
     t.datetime "created_at", precision: nil
     t.text "description"
-    t.boolean "disable_pjord_review", default: false, null: false
     t.text "goal"
     t.boolean "include_progress", default: true, null: false
     t.integer "last_updated_user_id"
     t.text "memo"
     t.boolean "open_product", default: false, null: false
+    t.boolean "pjord_review", default: true, null: false
     t.integer "source_id"
     t.boolean "submission", default: false, null: false
     t.text "summary"

--- a/test/integration/products/pjord_review_comment_test.rb
+++ b/test/integration/products/pjord_review_comment_test.rb
@@ -27,6 +27,25 @@ class Products::PjordReviewCommentTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'does not create product review comment by Pjord when practice disables Pjord review' do
+    practice = practices(:practice6)
+    practice.update!(disable_pjord_review: true)
+
+    Pjord::ProductReviewAgent.stub(:review, ->(_product) { raise 'should not be called' }) do
+      assert_no_enqueued_jobs only: PjordProductReviewJob do
+        post products_path(_login_name: 'hatsuno'),
+             params: { practice_id: practice.id, product: { body: '提出物です。' }, commit: '提出する' }
+      end
+    end
+
+    product = Product.order(:created_at).last
+    assert_redirected_to product_path(product)
+    assert_predicate product, :published_at?
+    assert_no_difference -> { product.comments.where(user: users(:pjord)).count } do
+      PjordProductReviewJob.perform_now(product_id: product.id)
+    end
+  end
+
   test 'creates product review comment by Pjord when WIP product is submitted' do
     product = products(:product5)
 

--- a/test/integration/products/pjord_review_comment_test.rb
+++ b/test/integration/products/pjord_review_comment_test.rb
@@ -27,9 +27,9 @@ class Products::PjordReviewCommentTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'does not create product review comment by Pjord when practice disables Pjord review' do
+  test 'does not create product review comment by Pjord when practice does not enable Pjord review' do
     practice = practices(:practice6)
-    practice.update!(disable_pjord_review: true)
+    practice.update!(pjord_review: false)
 
     Pjord::ProductReviewAgent.stub(:review, ->(_product) { raise 'should not be called' }) do
       assert_no_enqueued_jobs only: PjordProductReviewJob do

--- a/test/integration/products/pjord_review_comment_test.rb
+++ b/test/integration/products/pjord_review_comment_test.rb
@@ -33,8 +33,10 @@ class Products::PjordReviewCommentTest < ActionDispatch::IntegrationTest
 
     Pjord::ProductReviewAgent.stub(:review, ->(_product) { raise 'should not be called' }) do
       assert_no_enqueued_jobs only: PjordProductReviewJob do
-        post products_path(_login_name: 'hatsuno'),
-             params: { practice_id: practice.id, product: { body: '提出物です。' }, commit: '提出する' }
+        assert_no_difference -> { Comment.where(user: users(:pjord)).count } do
+          post products_path(_login_name: 'hatsuno'),
+               params: { practice_id: practice.id, product: { body: '提出物です。' }, commit: '提出する' }
+        end
       end
     end
 

--- a/test/jobs/pjord_product_review_job_test.rb
+++ b/test/jobs/pjord_product_review_job_test.rb
@@ -25,9 +25,9 @@ class PjordProductReviewJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'does nothing when practice disables Pjord review' do
+  test 'does nothing when practice does not enable Pjord review' do
     product = products(:product8)
-    product.practice.update!(disable_pjord_review: true)
+    product.practice.update!(pjord_review: false)
 
     Pjord::ProductReviewAgent.stub(:review, ->(_product) { raise 'should not be called' }) do
       assert_no_difference -> { product.comments.reload.count } do

--- a/test/jobs/pjord_product_review_job_test.rb
+++ b/test/jobs/pjord_product_review_job_test.rb
@@ -25,6 +25,17 @@ class PjordProductReviewJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'does nothing when practice disables Pjord review' do
+    product = products(:product8)
+    product.practice.update!(disable_pjord_review: true)
+
+    Pjord::ProductReviewAgent.stub(:review, ->(_product) { raise 'should not be called' }) do
+      assert_no_difference -> { product.comments.reload.count } do
+        PjordProductReviewJob.perform_now(product_id: product.id)
+      end
+    end
+  end
+
   test 'does nothing when pjord user is missing' do
     product = products(:product8)
 

--- a/test/system/practices/mentor_test.rb
+++ b/test/system/practices/mentor_test.rb
@@ -21,9 +21,11 @@ module Practices
         end
         fill_in 'practice[goal]', with: 'テストのゴールの内容です'
         fill_in 'practice[memo]', with: 'テストのメンター向けメモの内容です'
+        check 'practice[disable_pjord_review]', allow_label_click: true
         click_button '登録する'
       end
       assert_text 'プラクティスを作成しました'
+      assert_predicate Practice.order(:created_at).last, :disable_pjord_review?
     end
 
     test 'create practice as a mentor' do

--- a/test/system/practices/mentor_test.rb
+++ b/test/system/practices/mentor_test.rb
@@ -21,11 +21,11 @@ module Practices
         end
         fill_in 'practice[goal]', with: 'テストのゴールの内容です'
         fill_in 'practice[memo]', with: 'テストのメンター向けメモの内容です'
-        check 'practice[disable_pjord_review]', allow_label_click: true
+        uncheck 'practice[pjord_review]', allow_label_click: true
         click_button '登録する'
       end
       assert_text 'プラクティスを作成しました'
-      assert_predicate Practice.order(:created_at).last, :disable_pjord_review?
+      assert_not_predicate Practice.order(:created_at).last, :pjord_review?
     end
 
     test 'create practice as a mentor' do


### PR DESCRIPTION
## 概要

- プラクティスにピヨルドの提出物レビューを無効化するフラグを追加
- フラグが有効なプラクティスでは、提出時の自動レビューキュー投入と手動レビューコメント作成を行わないように変更
- メンターのプラクティス作成・編集フォームからフラグを設定できるように変更

## 確認

- [x] mise exec -- rails test test/jobs/pjord_product_review_job_test.rb test/integration/products/pjord_review_comment_test.rb
- [x] mise exec -- rails test test/system/practices/mentor_test.rb
- [x] mise exec -- ./bin/lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 実践作成時に、提出物レビューの有効/無効を選べるようになりました。
  * 設定画面の文言を追加し、レビュー設定が分かりやすくなりました。

* **バグ修正**
  * レビューを無効にした実践では、レビューコメントの作成や処理が行われないようになりました。
  * 実践作成時の設定が正しく保存されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/28424685438/artifacts/7972739298" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10247-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
