### PR TITLE
動画アップロードAPIを追加

### DIFF
--- a/app/controllers/api/movies_controller.rb
+++ b/app/controllers/api/movies_controller.rb
@@ -18,6 +18,8 @@ class API::MoviesController < API::BaseController
     else
       render json: { errors: @movie.errors }, status: :unprocessable_entity
     end
+  rescue ActiveRecord::RecordNotFound
+    render json: { errors: { practice_ids: ['に存在しないIDが含まれています'] } }, status: :unprocessable_entity
   end
 
   def direct_uploads

--- a/app/controllers/api/movies_controller.rb
+++ b/app/controllers/api/movies_controller.rb
@@ -1,12 +1,34 @@
 # frozen_string_literal: true
 
 class API::MoviesController < API::BaseController
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create direct_uploads], if: -> { doorkeeper_token.present? }
   before_action :set_movie, only: %i[update]
+
+  MOVIE_CONTENT_TYPES = %w[video/mp4 video/quicktime].freeze
 
   def index; end
 
+  def create
+    @movie = current_user.movies.new(create_movie_params.except(:wip))
+    apply_wip
+    update_published_at
+
+    if @movie.save
+      render json: movie_json, status: :created
+    else
+      render json: { errors: @movie.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def direct_uploads
+    return render_bad_request('動画ファイルは mp4 または mov を指定してください。') unless movie_content_type?
+
+    blob = ActiveStorage::Blob.create_before_direct_upload!(**direct_upload_params.to_h.symbolize_keys)
+    render json: direct_upload_json(blob), status: :created
+  end
+
   def update
-    if @movie.update(movie_params)
+    if @movie.update(update_movie_params)
       head :ok
     else
       head :bad_request
@@ -19,7 +41,61 @@ class API::MoviesController < API::BaseController
     @movie = Movie.find(params[:id])
   end
 
-  def movie_params
+  def create_movie_params
+    params.require(:movie).permit(
+      :title,
+      :description,
+      :movie_data,
+      :thumbnail,
+      :tag_list,
+      :wip,
+      practice_ids: []
+    )
+  end
+
+  def update_movie_params
     params.require(:movie).permit(:tag_list)
+  end
+
+  def direct_upload_params
+    params.require(:blob).permit(:filename, :byte_size, :checksum, :content_type, metadata: {})
+  end
+
+  def movie_content_type?
+    MOVIE_CONTENT_TYPES.include?(direct_upload_params[:content_type])
+  end
+
+  def direct_upload_json(blob)
+    blob.as_json(root: false, methods: :signed_id).merge(
+      direct_upload: {
+        url: blob.service_url_for_direct_upload,
+        headers: blob.service_headers_for_direct_upload
+      }
+    )
+  end
+
+  def apply_wip
+    return unless create_movie_params.key?(:wip)
+
+    @movie.wip = ActiveModel::Type::Boolean.new.cast(create_movie_params[:wip])
+  end
+
+  def update_published_at
+    return if @movie.wip? || @movie.published_at?
+
+    @movie.published_at = Time.current
+  end
+
+  def movie_json
+    {
+      id: @movie.id,
+      title: @movie.title,
+      description: @movie.description,
+      user_id: @movie.user_id,
+      wip: @movie.wip,
+      published_at: @movie.published_at,
+      practice_ids: @movie.practice_ids,
+      tag_list: @movie.tag_list
+    }
   end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -97,7 +97,9 @@ Rails.application.routes.draw do
       resource :position, only: %i(update), controller: "survey_question_listings/position"
     end
     resources :reading_circles, only: %i(index)
-    resources :movies, only: %i(index update)
+    resources :movies, only: %i(index create update) do
+      post :direct_uploads, on: :collection
+    end
     resources :metadata, only: %i(index)
     resources :micro_reports, only: %i(update)
     resources :trainee_progresses, only: %i(index)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1140,6 +1140,89 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/JsonObject'
+    post:
+      tags: [Content]
+      summary: Create a movie with uploaded movie data.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - movie
+              properties:
+                movie:
+                  type: object
+                  required:
+                    - title
+                    - description
+                    - movie_data
+                  properties:
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    movie_data:
+                      oneOf:
+                        - type: string
+                          format: binary
+                        - type: string
+                          description: Signed blob ID returned by /api/movies/direct_uploads.
+                    thumbnail:
+                      type: string
+                      format: binary
+                    tag_list:
+                      type: string
+                    wip:
+                      type: boolean
+                    practice_ids:
+                      type: array
+                      items:
+                        type: integer
+      responses:
+        '201':
+          $ref: '#/components/responses/JsonObject'
+        '422':
+          $ref: '#/components/responses/JsonObject'
+  /api/movies/direct_uploads:
+    post:
+      tags: [Content]
+      summary: Create direct upload data for a movie file.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - blob
+              properties:
+                blob:
+                  type: object
+                  required:
+                    - filename
+                    - byte_size
+                    - checksum
+                    - content_type
+                  properties:
+                    filename:
+                      type: string
+                    byte_size:
+                      type: integer
+                    checksum:
+                      type: string
+                      description: Base64-encoded MD5 checksum.
+                    content_type:
+                      type: string
+                      enum:
+                        - video/mp4
+                        - video/quicktime
+      responses:
+        '201':
+          $ref: '#/components/responses/JsonObject'
+        '400':
+          $ref: '#/components/responses/JsonObject'
   /api/movies/{id}:
     patch:
       tags: [Content]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1150,38 +1150,35 @@ paths:
             schema:
               type: object
               required:
-                - movie
+                - movie[title]
+                - movie[description]
+                - movie[movie_data]
               properties:
-                movie:
-                  type: object
-                  required:
-                    - title
-                    - description
-                    - movie_data
-                  properties:
-                    title:
-                      type: string
-                    description:
-                      type: string
-                    movie_data:
-                      oneOf:
-                        - type: string
-                          format: binary
-                        - type: string
-                          description: Signed blob ID returned by /api/movies/direct_uploads.
-                    thumbnail:
-                      type: string
+                movie[title]:
+                  type: string
+                movie[description]:
+                  type: string
+                movie[movie_data]:
+                  oneOf:
+                    - type: string
                       format: binary
-                    tag_list:
-                      type: string
-                    wip:
-                      type: boolean
-                    practice_ids:
-                      type: array
-                      items:
-                        type: integer
+                    - type: string
+                      description: Signed blob ID returned by /api/movies/direct_uploads.
+                movie[thumbnail]:
+                  type: string
+                  format: binary
+                movie[tag_list]:
+                  type: string
+                movie[wip]:
+                  type: boolean
+                movie[practice_ids][]:
+                  type: array
+                  items:
+                    type: integer
       responses:
         '201':
+          $ref: '#/components/responses/JsonObject'
+        '403':
           $ref: '#/components/responses/JsonObject'
         '422':
           $ref: '#/components/responses/JsonObject'
@@ -1222,6 +1219,8 @@ paths:
         '201':
           $ref: '#/components/responses/JsonObject'
         '400':
+          $ref: '#/components/responses/JsonObject'
+        '403':
           $ref: '#/components/responses/JsonObject'
   /api/movies/{id}:
     patch:

--- a/public/api-docs/openapi.yaml
+++ b/public/api-docs/openapi.yaml
@@ -1140,6 +1140,89 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/JsonObject'
+    post:
+      tags: [Content]
+      summary: Create a movie with uploaded movie data.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - movie
+              properties:
+                movie:
+                  type: object
+                  required:
+                    - title
+                    - description
+                    - movie_data
+                  properties:
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    movie_data:
+                      oneOf:
+                        - type: string
+                          format: binary
+                        - type: string
+                          description: Signed blob ID returned by /api/movies/direct_uploads.
+                    thumbnail:
+                      type: string
+                      format: binary
+                    tag_list:
+                      type: string
+                    wip:
+                      type: boolean
+                    practice_ids:
+                      type: array
+                      items:
+                        type: integer
+      responses:
+        '201':
+          $ref: '#/components/responses/JsonObject'
+        '422':
+          $ref: '#/components/responses/JsonObject'
+  /api/movies/direct_uploads:
+    post:
+      tags: [Content]
+      summary: Create direct upload data for a movie file.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - blob
+              properties:
+                blob:
+                  type: object
+                  required:
+                    - filename
+                    - byte_size
+                    - checksum
+                    - content_type
+                  properties:
+                    filename:
+                      type: string
+                    byte_size:
+                      type: integer
+                    checksum:
+                      type: string
+                      description: Base64-encoded MD5 checksum.
+                    content_type:
+                      type: string
+                      enum:
+                        - video/mp4
+                        - video/quicktime
+      responses:
+        '201':
+          $ref: '#/components/responses/JsonObject'
+        '400':
+          $ref: '#/components/responses/JsonObject'
   /api/movies/{id}:
     patch:
       tags: [Content]

--- a/public/api-docs/openapi.yaml
+++ b/public/api-docs/openapi.yaml
@@ -1150,38 +1150,35 @@ paths:
             schema:
               type: object
               required:
-                - movie
+                - movie[title]
+                - movie[description]
+                - movie[movie_data]
               properties:
-                movie:
-                  type: object
-                  required:
-                    - title
-                    - description
-                    - movie_data
-                  properties:
-                    title:
-                      type: string
-                    description:
-                      type: string
-                    movie_data:
-                      oneOf:
-                        - type: string
-                          format: binary
-                        - type: string
-                          description: Signed blob ID returned by /api/movies/direct_uploads.
-                    thumbnail:
-                      type: string
+                movie[title]:
+                  type: string
+                movie[description]:
+                  type: string
+                movie[movie_data]:
+                  oneOf:
+                    - type: string
                       format: binary
-                    tag_list:
-                      type: string
-                    wip:
-                      type: boolean
-                    practice_ids:
-                      type: array
-                      items:
-                        type: integer
+                    - type: string
+                      description: Signed blob ID returned by /api/movies/direct_uploads.
+                movie[thumbnail]:
+                  type: string
+                  format: binary
+                movie[tag_list]:
+                  type: string
+                movie[wip]:
+                  type: boolean
+                movie[practice_ids][]:
+                  type: array
+                  items:
+                    type: integer
       responses:
         '201':
+          $ref: '#/components/responses/JsonObject'
+        '403':
           $ref: '#/components/responses/JsonObject'
         '422':
           $ref: '#/components/responses/JsonObject'
@@ -1222,6 +1219,8 @@ paths:
         '201':
           $ref: '#/components/responses/JsonObject'
         '400':
+          $ref: '#/components/responses/JsonObject'
+        '403':
           $ref: '#/components/responses/JsonObject'
   /api/movies/{id}:
     patch:

--- a/test/integration/api/movies_test.rb
+++ b/test/integration/api/movies_test.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::MoviesTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:kimura)
+    application = Doorkeeper::Application.create!(
+      name: 'Sample Application',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
+    @read_token = Doorkeeper::AccessToken.create!(
+      application:,
+      resource_owner_id: @user.id,
+      scopes: 'read'
+    )
+    @write_token = Doorkeeper::AccessToken.create!(
+      application:,
+      resource_owner_id: @user.id,
+      scopes: 'read write'
+    )
+  end
+
+  test 'POST /api/movies.json creates movie with uploaded movie data' do
+    movie_data = fixture_file_upload('movies/movie.mp4', 'video/mp4')
+    thumbnail = fixture_file_upload('articles/ogp_images/test.jpg', 'image/jpeg')
+
+    assert_difference('Movie.count') do
+      assert_enqueued_with(job: TranscodeJob) do
+        assert_enqueued_with(job: GenerateMovieThumbnailJob) do
+          post api_movies_path(format: :json),
+               headers: { Authorization: "Bearer #{@write_token.token}" },
+               params: {
+                 movie: {
+                   title: 'APIで作成した動画',
+                   description: 'APIから動画をアップロードしました。',
+                   movie_data:,
+                   thumbnail:,
+                   tag_list: 'API,動画',
+                   practice_ids: [practices(:practice1).id],
+                   wip: false
+                 }
+               }
+        end
+      end
+    end
+
+    assert_response :created
+    movie = Movie.find(response.parsed_body['id'])
+    assert_equal @user, movie.user
+    assert_equal 'APIで作成した動画', movie.title
+    assert_equal 'APIから動画をアップロードしました。', movie.description
+    assert movie.movie_data.attached?
+    assert movie.thumbnail.attached?
+    assert_not movie.wip?
+    assert_not_nil movie.published_at
+    assert_equal [practices(:practice1).id], movie.practice_ids
+    assert_equal %w[API 動画], movie.tag_list
+    assert_equal movie.title, response.parsed_body['title']
+    assert_equal movie.practice_ids, response.parsed_body['practice_ids']
+  end
+
+  test 'POST /api/movies.json creates movie with direct uploaded blob signed id' do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(Rails.root.join('test/fixtures/files/movies/movie.mp4')),
+      filename: 'movie.mp4',
+      content_type: 'video/mp4'
+    )
+
+    assert_difference('Movie.count') do
+      post api_movies_path(format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: {
+             movie: {
+               title: 'APIで作成した大きい動画',
+               description: 'direct upload済みの動画を登録しました。',
+               movie_data: blob.signed_id
+             }
+           }
+      assert_response :created
+    end
+
+    movie = Movie.find(response.parsed_body['id'])
+    assert_equal blob, movie.movie_data.blob
+    assert_equal blob.byte_size, movie.movie_data.byte_size
+  end
+
+  test 'POST /api/movies/direct_uploads.json returns direct upload data for movie' do
+    assert_difference('ActiveStorage::Blob.count') do
+      post direct_uploads_api_movies_path(format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: {
+             blob: {
+               filename: 'large_movie.mp4',
+               byte_size: 5.gigabytes,
+               checksum: '1B2M2Y8AsgTpgAmY7PhCfg==',
+               content_type: 'video/mp4'
+             }
+           }
+      assert_response :created
+    end
+
+    assert_equal 'large_movie.mp4', response.parsed_body['filename']
+    assert_equal 'video/mp4', response.parsed_body['content_type']
+    assert_equal 5.gigabytes, response.parsed_body['byte_size']
+    assert response.parsed_body['signed_id'].present?
+    assert response.parsed_body.dig('direct_upload', 'url').present?
+    assert_kind_of Hash, response.parsed_body.dig('direct_upload', 'headers')
+  end
+
+  test 'POST /api/movies/direct_uploads.json with read scope returns forbidden' do
+    assert_no_difference('ActiveStorage::Blob.count') do
+      post direct_uploads_api_movies_path(format: :json),
+           headers: { Authorization: "Bearer #{@read_token.token}" },
+           params: { blob: direct_upload_params }
+    end
+
+    assert_response :forbidden
+  end
+
+  test 'POST /api/movies/direct_uploads.json rejects non movie content type' do
+    assert_no_difference('ActiveStorage::Blob.count') do
+      post direct_uploads_api_movies_path(format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { blob: direct_upload_params.merge(content_type: 'image/jpeg') }
+    end
+
+    assert_response :bad_request
+    assert_equal '動画ファイルは mp4 または mov を指定してください。', response.parsed_body['message']
+  end
+
+  test 'POST /api/movies.json with read scope returns forbidden' do
+    assert_no_difference('Movie.count') do
+      post api_movies_path(format: :json),
+           headers: { Authorization: "Bearer #{@read_token.token}" },
+           params: { movie: valid_movie_params }
+    end
+
+    assert_response :forbidden
+  end
+
+  test 'POST /api/movies.json returns validation errors' do
+    assert_no_difference('Movie.count') do
+      post api_movies_path(format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { movie: valid_movie_params.merge(title: '') }
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes response.parsed_body.dig('errors', 'title'), 'を入力してください'
+  end
+
+  private
+
+  def valid_movie_params
+    {
+      title: 'APIで作成した動画',
+      description: 'APIから動画をアップロードしました。',
+      movie_data: fixture_file_upload('movies/movie.mp4', 'video/mp4')
+    }
+  end
+
+  def direct_upload_params
+    {
+      filename: 'large_movie.mp4',
+      byte_size: 5.gigabytes,
+      checksum: '1B2M2Y8AsgTpgAmY7PhCfg==',
+      content_type: 'video/mp4'
+    }
+  end
+end

--- a/test/integration/api/movies_test.rb
+++ b/test/integration/api/movies_test.rb
@@ -150,6 +150,17 @@ class API::MoviesTest < ActionDispatch::IntegrationTest
     assert_includes response.parsed_body.dig('errors', 'title'), 'を入力してください'
   end
 
+  test 'POST /api/movies.json returns validation error with unknown practice_id' do
+    assert_no_difference('Movie.count') do
+      post api_movies_path(format: :json),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { movie: valid_movie_params.merge(practice_ids: [999_999_999]) }
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes response.parsed_body.dig('errors', 'practice_ids'), 'に存在しないIDが含まれています'
+  end
+
   private
 
   def valid_movie_params


### PR DESCRIPTION
## 概要

- `POST /api/movies/direct_uploads.json` で動画ファイルのdirect upload用URLと signed_id を発行できるようにしました
- 大きい動画はファイル本体をRailsに通さず、GCSへ直接アップロードしてから `POST /api/movies.json` に signed_id を渡して登録できます
- 小さいファイル向けに従来のmultipart作成にも対応しています
- 作成系APIではOAuthトークン利用時に `write` スコープを要求します
- APIテストとOpenAPIドキュメントを追加しました

## 確認

- [x] `mise exec -- bin/rails test test/integration/api/movies_test.rb`
- [x] `mise exec -- ./bin/lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 映画の新規作成API（`POST /api/movies`）を追加し、タイトル・説明・動画データのほか任意でサムネイル、タグ、練習項目、下書き指定を送信して登録できるようになりました。
  * 動画ファイルの直アップロード（`POST /api/movies/direct_uploads`）に対応し、動画向けにメタ情報から直アップロードの情報を返します。
* **Bug Fixes**
  * 書き込み権限がある場合にのみ作成・直アップロードを許可し、無効入力には適切にエラーを返すよう改善しました。
* **Documentation**
  * OpenAPI仕様に上記エンドポイントのリクエスト/レスポンスを追記しました。
* **Tests**
  * Movies APIの統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/28733299131/artifacts/8089577050" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10251-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
