### PR TITLE
AIモデルをClaude Sonnet 5に更新

### DIFF
--- a/.cloudbuild/deploy-cloud-run
+++ b/.cloudbuild/deploy-cloud-run
@@ -48,12 +48,12 @@ fi
 case "$environment" in
   production)
     export _RAILS_MAX_THREADS=5
-    export _PJORD_LLM_MODEL=claude-sonnet-4-6
+    export _PJORD_LLM_MODEL=claude-sonnet-5
     cloud_run_args+=(--concurrency 5)
     ;;
   staging)
     export _MISSION_CONTROL_USERNAME="${_MISSION_CONTROL_USERNAME:-fjord}"
-    export _PJORD_LLM_MODEL=claude-sonnet-4-6
+    export _PJORD_LLM_MODEL=claude-sonnet-5
     ;;
   review)
     export _DISCORD_NOTICE_WEBHOOK_URL=


### PR DESCRIPTION
## 概要
- Cloud Run の production/staging 向け `PJORD_LLM_MODEL` を `claude-sonnet-5` に更新
- アプリコード側のデフォルトモデル指定は変更しない

## 確認
- `git diff HEAD~1..HEAD --stat`
- `rg -n "claude-sonnet-5|claude-sonnet-4-6" .cloudbuild/deploy-cloud-run app/agents test/agents --glob "!vendor/**"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * デプロイ設定を更新し、本番・ステージング環境で使用するモデルを新しい版に切り替えました。
  * 本番環境の同時実行設定はこれまでどおり維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/28733254584/artifacts/8089566641" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
