### PR TITLE
イベント作成時にサムネイルを設定できるようにした

### DIFF
--- a/app/assets/stylesheets/shared/blocks/card-list/_card-list-item.css
+++ b/app/assets/stylesheets/shared/blocks/card-list/_card-list-item.css
@@ -292,20 +292,18 @@ input:checked + .card-list-item__user-detail {
 }
 
 .card-list-item__thumbnail {
-  flex: 0 0 6rem;
+  flex: 0 0 8rem;
 }
 
 .card-list-item__thumbnail-inner {
-  position: relative;
-  padding-top: 52.5%;
   display: block;
+  aspect-ratio: 1.91 / 1;
 }
 
 .card-list-item__thumbnail-image {
+  display: block;
   height: 100%;
   width: 100%;
-  position: absolute;
-  inset: 0;
   object-fit: cover;
   border-radius: 4px;
 }

--- a/app/assets/stylesheets/shared/blocks/card-list/_card-list-item.css
+++ b/app/assets/stylesheets/shared/blocks/card-list/_card-list-item.css
@@ -302,20 +302,18 @@ input:checked + .card-list-item__user-detail {
 }
 
 .card-list-item__thumbnail {
-  flex: 0 0 6rem;
+  flex: 0 0 8rem;
 }
 
 .card-list-item__thumbnail-inner {
-  position: relative;
-  padding-top: 52.5%;
   display: block;
+  aspect-ratio: 1.91 / 1;
 }
 
 .card-list-item__thumbnail-image {
+  display: block;
   height: 100%;
   width: 100%;
-  position: absolute;
-  inset: 0;
   object-fit: cover;
   border-radius: 4px;
 }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,7 +6,7 @@ class EventsController < ApplicationController
   before_action :set_event, only: %i[edit update destroy]
 
   def index
-    @events = Event.with_avatar.includes(:comments, :users).order(start_at: :desc).page(params[:page]).per(PAGER_NUMBER)
+    @events = Event.with_avatar.includes(:comments, :users).with_attached_thumbnail.order(start_at: :desc).page(params[:page]).per(PAGER_NUMBER)
     @upcoming_events_groups = UpcomingEvent.upcoming_events_groups
   end
 
@@ -71,7 +71,8 @@ class EventsController < ApplicationController
       :open_start_at,
       :open_end_at,
       :job_hunting,
-      :announcement_of_publication
+      :announcement_of_publication,
+      :thumbnail
     )
   end
 

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -96,6 +96,7 @@ class RegularEventsController < ApplicationController # rubocop:disable Metrics/
       :category,
       :all,
       :wants_announcement,
+      :thumbnail,
       user_ids: [],
       regular_event_repeat_rules_attributes: %i[id regular_event_id frequency day_of_the_week _destroy],
       regular_event_skip_dates_attributes: %i[id reason skip_on _destroy]

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,8 @@ class Event < ApplicationRecord # rubocop:todo Metrics/ClassLength
   include Searchable
   include Bookmarkable
 
+  THUMBNAIL_SIZE = [1200, 630].freeze
+
   validates :title, presence: true
   validates :description, presence: true
   validates :location, presence: true
@@ -17,6 +19,9 @@ class Event < ApplicationRecord # rubocop:todo Metrics/ClassLength
   validates :end_at, presence: true
   validates :open_start_at, presence: true
   validates :open_end_at, presence: true
+  validates :thumbnail,
+            content_type: %w[image/png image/jpeg],
+            size: { less_than: 10.megabytes }
 
   with_options if: -> { start_at && end_at } do
     validate :end_at_be_greater_than_start_at
@@ -38,6 +43,7 @@ class Event < ApplicationRecord # rubocop:todo Metrics/ClassLength
   has_many :participations, dependent: :destroy
   has_many :users, through: :participations
   attribute :announcement_of_publication, :boolean
+  has_one_attached :thumbnail
 
   columns_for_keyword_search :title, :description
 
@@ -122,6 +128,14 @@ class Event < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   def self.fetch_upcoming_ids
     Event.where('start_at > ?', Date.current).pluck(:id)
+  end
+
+  def thumbnail_url
+    if thumbnail.attached?
+      thumbnail.variant(resize_to_fill: THUMBNAIL_SIZE).processed.url
+    else
+      ActionController::Base.helpers.asset_path('work-blank.svg')
+    end
   end
 
   private

--- a/app/models/regular_event.rb
+++ b/app/models/regular_event.rb
@@ -5,6 +5,8 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   DAYS_OF_THE_WEEK_COUNT = 7
 
+  THUMBNAIL_SIZE = [1200, 630].freeze
+
   FREQUENCY_LIST = [
     ['毎週', 0],
     ['第1', 1],
@@ -41,6 +43,9 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :regular_event_repeat_rules, presence: true
   validates_associated :regular_event_repeat_rules
   validates_associated :regular_event_skip_dates
+  validates :thumbnail,
+            content_type: %w[image/png image/jpeg],
+            size: { less_than: 10.megabytes }
 
   validate :validate_skip_on_uniqueness
 
@@ -65,6 +70,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :list, lambda {
     with_avatar
       .includes(:comments, :users, :regular_event_repeat_rules)
+      .with_attached_thumbnail
       .order(created_at: :desc)
   }
 
@@ -79,6 +85,7 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :participants,
            through: :regular_event_participations,
            source: :user
+  has_one_attached :thumbnail
   attribute :wants_announcement, :boolean
 
   columns_for_keyword_search :title, :description
@@ -155,6 +162,14 @@ class RegularEvent < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def publish_with_announcement?
     wants_announcement? && !wip?
+  end
+
+  def thumbnail_url
+    if thumbnail.attached?
+      thumbnail.variant(resize_to_fill: THUMBNAIL_SIZE).processed.url
+    else
+      ActionController::Base.helpers.asset_path('work-blank.svg')
+    end
   end
 
   def skip_event?(date)

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -42,6 +42,9 @@
 
   = render('event_meta', event:)
 
+  .event-thumbnail
+    = image_tag event.thumbnail_url, class: 'event-thumbnail__image', alt: event.title
+
   .a-card
     .card-header.is-sm
       h2.card-header__title

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -42,6 +42,9 @@ article.event.page-content
 
   = render('event_meta', event:)
 
+  .event-thumbnail
+    = image_tag event.thumbnail_url, class: 'event-thumbnail__image', alt: event.title
+
   section.a-card
     header.card-header.is-sm
       h2.card-header__title

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -3,6 +3,9 @@ ul.card-list.a-card
   - @events.each do |event|
     li.card-list-item
       .card-list-item__inner
+        / .card-list-item__thumbnail
+        /   = link_to event, class: 'card-list-item__thumbnail-link' do
+        /     = image_tag event.thumbnail_url, class: 'card-list-item__thumbnail-image', alt: event.title
         .card-list-item__user
           = render 'users/icon', user: event.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'
         .card-list-item__rows

--- a/app/views/events/_events.html.slim
+++ b/app/views/events/_events.html.slim
@@ -3,9 +3,6 @@ ul.card-list.a-card
   - @events.each do |event|
     li.card-list-item
       .card-list-item__inner
-        / .card-list-item__thumbnail
-        /   = link_to event, class: 'card-list-item__thumbnail-link' do
-        /     = image_tag event.thumbnail_url, class: 'card-list-item__thumbnail-image', alt: event.title
         .card-list-item__user
           = render 'users/icon', user: event.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'
         .card-list-item__rows
@@ -43,4 +40,7 @@ ul.card-list.a-card
                   .card-list-item-meta__item
                     .a-meta
                       = comment_count(event)
+        .card-list-item__thumbnail
+          = link_to event, class: 'card-list-item__thumbnail-inner' do
+            = image_tag event.thumbnail_url, class: 'card-list-item__thumbnail-image', alt: event.title
 = paginate @events

--- a/app/views/events/_form.html.slim
+++ b/app/views/events/_form.html.slim
@@ -24,6 +24,21 @@
         = f.label :open_end_at, class: 'a-form-label'
         = f.datetime_field :open_end_at, class: 'a-text-input js-warning-form'
       .form-item
+        = f.label :thumbnail, class: 'a-form-label'
+        .form-item-file-input.js-file-input.a-file-input.is-thumbnail
+          label.js-file-input__preview
+            - if event.thumbnail.attached?
+              = image_tag event.thumbnail
+              p サムネイル画像を変更
+            - else
+              p サムネイル画像を選択
+            = f.file_field :thumbnail,
+              accept: 'image/png, image/jpeg',
+              direct_upload: true
+        .a-form-help
+          p
+            | 未設定の場合は、デフォルト画像が表示されます。
+      .form-item
         label.a-form-label
           | イベント内容
         .checkboxes

--- a/app/views/regular_events/_form.html.slim
+++ b/app/views/regular_events/_form.html.slim
@@ -47,6 +47,22 @@
               = f.label :hold_national_holiday do
                 | 祝日も開催する場合はチェック
 
+      .form-item
+        = f.label :thumbnail, class: 'a-form-label'
+        .form-item-file-input.js-file-input.a-file-input.is-thumbnail
+          label.js-file-input__preview
+            - if regular_event.thumbnail.attached?
+              = image_tag regular_event.thumbnail
+              p サムネイル画像を変更
+            - else
+              p サムネイル画像を選択
+            = f.file_field :thumbnail,
+              accept: 'image/png, image/jpeg',
+              direct_upload: true
+        .a-form-help
+          p
+            | 未設定の場合は、デフォルト画像が表示されます。
+
   .form__items
     .form-item
       .row.js-markdown-parent

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -40,6 +40,9 @@
 
   = render('regular_event_meta', regular_event:)
 
+  .event-thumbnail
+    = image_tag regular_event.thumbnail_url, class: 'event-thumbnail__image', alt: regular_event.title
+
   .a-card
     .card-header.is-sm
       h2.card-header__title

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -40,9 +40,6 @@ article.page-content
 
   = render('regular_event_meta', regular_event:)
 
-  .event-thumbnail
-    = image_tag regular_event.thumbnail_url, class: 'event-thumbnail__image', alt: regular_event.title
-
   section.a-card
     header.card-header.is-sm
       h2.card-header__title

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -40,9 +40,6 @@
 
   = render('regular_event_meta', regular_event:)
 
-  .event-thumbnail
-    = image_tag regular_event.thumbnail_url, class: 'event-thumbnail__image', alt: regular_event.title
-
   .a-card
     .card-header.is-sm
       h2.card-header__title

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -40,6 +40,9 @@ article.page-content
 
   = render('regular_event_meta', regular_event:)
 
+  .event-thumbnail
+    = image_tag regular_event.thumbnail_url, class: 'event-thumbnail__image', alt: regular_event.title
+
   section.a-card
     header.card-header.is-sm
       h2.card-header__title

--- a/app/views/regular_events/_regular_event_meta.html.slim
+++ b/app/views/regular_events/_regular_event_meta.html.slim
@@ -1,4 +1,6 @@
-.event-meta.a-card
+.event-meta.a-card.overflow-hidden
+  .event-thumbnail
+    = image_tag regular_event.thumbnail_url, class: 'event-thumbnail__image', alt: regular_event.title
   .event-meta__inner
     dl.event-meta__items
       .event-meta__item

--- a/app/views/regular_events/_regular_event_meta.html.slim
+++ b/app/views/regular_events/_regular_event_meta.html.slim
@@ -1,4 +1,6 @@
-aside.event-meta.a-card
+aside.event-meta.a-card.overflow-hidden
+  .event-thumbnail
+    = image_tag regular_event.thumbnail_url, class: 'event-thumbnail__image', alt: regular_event.title
   .event-meta__inner
     dl.event-meta__items
       .event-meta__item

--- a/app/views/regular_events/_regular_events.html.slim
+++ b/app/views/regular_events/_regular_events.html.slim
@@ -14,6 +14,9 @@ ul.card-list.a-card
       .card-list-item__inner
         .card-list-item__label class="#{event.category}"
           = t("activerecord.enums.regular_event.category.#{event.category}")
+        / .card-list-item__thumbnail
+        /   = link_to event, class: 'card-list-item__thumbnail-link' do
+        /     = image_tag event.thumbnail_url, class: 'card-list-item__thumbnail-image', alt: event.title
         .card-list-item__user
           = render 'users/icon', user: event.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'
         .card-list-item__rows

--- a/app/views/regular_events/_regular_events.html.slim
+++ b/app/views/regular_events/_regular_events.html.slim
@@ -14,9 +14,6 @@ ul.card-list.a-card
       .card-list-item__inner
         .card-list-item__label class="#{event.category}"
           = t("activerecord.enums.regular_event.category.#{event.category}")
-        / .card-list-item__thumbnail
-        /   = link_to event, class: 'card-list-item__thumbnail-link' do
-        /     = image_tag event.thumbnail_url, class: 'card-list-item__thumbnail-image', alt: event.title
         .card-list-item__user
           = render 'users/icon', user: event.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'
         .card-list-item__rows
@@ -54,4 +51,7 @@ ul.card-list.a-card
                   .card-list-item-meta__item
                     .a-meta
                       = comment_count(event)
+        .card-list-item__thumbnail
+          = link_to event, class: 'card-list-item__thumbnail-inner' do
+            = image_tag event.thumbnail_url, class: 'card-list-item__thumbnail-image', alt: event.title
 = paginate @regular_events

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -158,4 +158,24 @@ class EventTest < ActiveSupport::TestCase
       assert_not_includes events, event_start_at_tomorrow_midnight
     end
   end
+
+  test 'thumbnail_url returns custom thumbnail when attached' do
+    event = events(:event1)
+    event.thumbnail.attach(
+      io: File.open(Rails.root.join('test/fixtures/files/articles/ogp_images/test.jpg')),
+      filename: 'test.jpg',
+      content_type: 'image/jpeg'
+    )
+
+    assert event.thumbnail.attached?
+    assert event.thumbnail_url.present?
+    assert_no_match(/work-blank/, event.thumbnail_url)
+  end
+
+  test 'thumbnail_url returns default image when custom thumbnail is not attached' do
+    event = events(:event1)
+    event.thumbnail.purge
+
+    assert_match(/work-blank/, event.thumbnail_url)
+  end
 end

--- a/test/models/regular_event_test.rb
+++ b/test/models/regular_event_test.rb
@@ -297,4 +297,24 @@ class RegularEventTest < ActiveSupport::TestCase
     assert_not_includes events, wip_event
     assert_not_includes events, finished_event
   end
+
+  test 'thumbnail_url returns custom thumbnail when attached' do
+    regular_event = regular_events(:regular_event1)
+    regular_event.thumbnail.attach(
+      io: File.open(Rails.root.join('test/fixtures/files/articles/ogp_images/test.jpg')),
+      filename: 'test.jpg',
+      content_type: 'image/jpeg'
+    )
+
+    assert regular_event.thumbnail.attached?
+    assert regular_event.thumbnail_url.present?
+    assert_no_match(/work-blank/, regular_event.thumbnail_url)
+  end
+
+  test 'thumbnail_url returns default image when custom thumbnail is not attached' do
+    regular_event = regular_events(:regular_event1)
+    regular_event.thumbnail.purge
+
+    assert_match(/work-blank/, regular_event.thumbnail_url)
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/10225

## 概要

## 変更確認方法

1. feature/events-show-thumbnailをローカルに取り込む
2. イベントページで、特別イベントをサムネイルを指定せずに作成する
3. 特別イベント一覧、詳細ページでデフォルトのサムネイルが表示されている。
4. 定例イベントをサムネイルを指定して作成する
5. 定例イベント一覧、詳細ページで指定したサムネイルが表示されている。

## Screenshot

### 変更前

### 変更後

<!-- I want to review in Japanese. -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/32228107029/artifacts/9357425595" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10258-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
