### PR TITLE
AIピヨルドが画像URLを読めるようにする

### DIFF
--- a/app/tools/external_content/web_page_reader.rb
+++ b/app/tools/external_content/web_page_reader.rb
@@ -31,9 +31,13 @@ class ExternalContent::WebPageReader
   private
 
   def fetch_response(uri)
-    Rails.cache.fetch("external_content/web_page/#{Digest::SHA256.hexdigest(uri.to_s)}", expires_in: 10.minutes) do
-      ExternalContent::HttpClient.get(uri.to_s, headers: request_headers)
-    end
+    cache_key = "external_content/web_page/#{Digest::SHA256.hexdigest(uri.to_s)}"
+    cached_response = Rails.cache.read(cache_key)
+    return cached_response if cached_response
+
+    response = ExternalContent::HttpClient.get(uri.to_s, headers: request_headers)
+    Rails.cache.write(cache_key, response, expires_in: 10.minutes) unless image?(response)
+    response
   end
 
   def format_page(url, body)
@@ -59,8 +63,22 @@ class ExternalContent::WebPageReader
 
         この画像の内容を確認して、回答やレビューに必要な文脈として使ってください。
       TEXT
-      [io]
-    )
+      []
+    ).tap do |content|
+      content.add_attachment(io, filename: image_filename(response))
+    end
+  end
+
+  def image_filename(response)
+    extension =
+      case normalized_content_type(response)
+      when 'image/jpeg' then 'jpg'
+      when 'image/svg+xml' then 'svg'
+      else
+        normalized_content_type(response).delete_prefix('image/').presence || 'image'
+      end
+
+    "image.#{extension}"
   end
 
   def extract_text(body)

--- a/app/tools/external_content/web_page_reader.rb
+++ b/app/tools/external_content/web_page_reader.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require 'stringio'
 require 'uri'
 
 class ExternalContent::WebPageReader
   CONTENT_LIMIT = 20_000
+  IMAGE_SIZE_LIMIT = 10.megabytes
+
   def self.fetch(url)
     new.fetch(url)
   end
@@ -14,6 +17,8 @@ class ExternalContent::WebPageReader
 
     response = fetch_response(uri)
     return ExternalContent::UNREADABLE_URL_MESSAGE unless response.success?
+
+    return format_image(response) if image?(response)
 
     format_page(response.url, response.body)
   rescue URI::InvalidURIError
@@ -40,11 +45,37 @@ class ExternalContent::WebPageReader
     TEXT
   end
 
+  def format_image(response)
+    return ExternalContent::UNREADABLE_URL_MESSAGE if response.body.to_s.bytesize > IMAGE_SIZE_LIMIT
+
+    io = StringIO.new(response.body.to_s.b)
+    io.binmode
+
+    RubyLLM::Content.new(
+      <<~TEXT,
+        # Image
+        - URL: #{response.url}
+        - Content-Type: #{normalized_content_type(response)}
+
+        この画像の内容を確認して、回答やレビューに必要な文脈として使ってください。
+      TEXT
+      [io]
+    )
+  end
+
   def extract_text(body)
     document = Nokogiri::HTML(body.to_s)
     document.css('script, style, noscript').remove
     node = document.at('body') || document
     node.xpath('.//text()').map { |text| text.text.squish }.reject(&:blank?).join(' ')
+  end
+
+  def image?(response)
+    normalized_content_type(response).start_with?('image/')
+  end
+
+  def normalized_content_type(response)
+    response.content_type.to_s.split(';').first.to_s.downcase
   end
 
   def request_headers

--- a/test/tools/external_content_tool_test.rb
+++ b/test/tools/external_content_tool_test.rb
@@ -60,7 +60,27 @@ class ExternalContentToolTest < ActiveSupport::TestCase
     assert_includes result.text, "URL: #{redirected_url}"
     assert_equal 1, result.attachments.size
     assert_predicate result.attachments.first, :image?
+    assert_equal 'image.jpg', result.attachments.first.filename
     assert_equal image_body, result.attachments.first.content
+
+    @tool.execute(url: blob_url)
+
+    assert_requested :get, blob_url, times: 2
+    assert_requested :get, redirected_url, times: 2
+  end
+
+  test 'returns svg image content with explicit filename' do
+    svg_body = '<svg xmlns="http://www.w3.org/2000/svg"><text>SVG</text></svg>'
+    stub_request(:get, 'https://example.com/image.svg')
+      .to_return(status: 200, body: svg_body, headers: { 'Content-Type' => 'image/svg+xml' })
+
+    result = @tool.execute(url: 'https://example.com/image.svg')
+
+    assert_instance_of RubyLLM::Content, result
+    assert_equal 1, result.attachments.size
+    assert_predicate result.attachments.first, :image?
+    assert_equal 'image.svg', result.attachments.first.filename
+    assert_equal 'image/svg+xml', result.attachments.first.mime_type
   end
 
   test 'rejects non http urls' do

--- a/test/tools/external_content_tool_test.rb
+++ b/test/tools/external_content_tool_test.rb
@@ -44,6 +44,25 @@ class ExternalContentToolTest < ActiveSupport::TestCase
     assert_includes result, 'Moved content'
   end
 
+  test 'returns image content for Active Storage blob redirect urls' do
+    image_body = Rails.root.join('test/fixtures/files/companies-logos-1.jpg').binread
+    blob_url = 'https://bootcamp.fjord.jp/rails/active_storage/blobs/redirect/signed-id/image.jpg'
+    redirected_url = 'https://bootcamp.fjord.jp/rails/active_storage/disk/key/image.jpg'
+    stub_request(:get, blob_url)
+      .to_return(status: 302, headers: { 'Location' => redirected_url })
+    stub_request(:get, redirected_url)
+      .to_return(status: 200, body: image_body, headers: { 'Content-Type' => 'image/jpeg' })
+
+    result = @tool.execute(url: blob_url)
+
+    assert_instance_of RubyLLM::Content, result
+    assert_includes result.text, '# Image'
+    assert_includes result.text, "URL: #{redirected_url}"
+    assert_equal 1, result.attachments.size
+    assert_predicate result.attachments.first, :image?
+    assert_equal image_body, result.attachments.first.content
+  end
+
   test 'rejects non http urls' do
     assert_equal 'httpまたはhttpsのURLだけ取得できます。', @tool.execute(url: 'file:///etc/passwd')
   end


### PR DESCRIPTION
## 概要

AIピヨルドの `external_content_tool` が画像URLを読めるようにしました。

## 変更内容

- `image/*` レスポンスをHTMLページとして処理せず、`RubyLLM::Content` の画像添付として返すように変更
- ActiveStorage blob redirect URLがリダイレクト後の画像として扱われるテストを追加
- 大きすぎる画像は安全のため unreadable 扱いにする制限を追加

## 背景

Bootcamp 自身にアップロードされた画像URLでも、ツールが最終的な画像バイナリをLLMへ渡していなかったため、AIピヨルドが画像内容を確認できませんでした。

## 確認

- `PATH=/home/komagata/.local/share/mise/installs/ruby/3.4.3/bin:$PATH bundle exec rails test test/tools/external_content_tool_test.rb`
- 指定された実URLを `ExternalContent.fetch` で実行し、`RubyLLM::Content`、`image/png`、画像添付1件として返ることを確認
- Anthropic向けpayloadで `tool_result` が `text,image` になり、画像が `base64` の `image/png` として渡ることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 画像URLの取得に対応し、画像コンテンツをそのまま扱えるようになりました。
  * 取得結果に応じて、本文ページではテキスト抽出、画像では画像向けの内容（添付）を返します。
* **バグ修正**
  * リダイレクトされる画像URLでも、正しく画像として認識して処理できるようになりました。
  * サイズ上限（10MB）を超える画像は取得対象外として扱うようになりました。
* **テスト**
  * リダイレクト画像取得の挙動を検証するケースを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/28845468326/artifacts/8129583982" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10264-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->