### PR TITLE
Checkを提出物ごとに一意にする

### DIFF
--- a/app/interactors/copy_check.rb
+++ b/app/interactors/copy_check.rb
@@ -17,7 +17,7 @@ class CopyCheck
   private
 
   def find_original_checks
-    context.original_checks = context.original_product.checks.to_a
+    context.original_checks = context.original_product.checks.order(:created_at, :id).limit(1).to_a
 
     context.message = if context.original_checks.empty?
                         'No checks found to copy'
@@ -32,28 +32,15 @@ class CopyCheck
     results = process_checks
     store_results(results)
     update_completion_message(results)
-  rescue ActiveRecord::RecordInvalid => e
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
     context.fail!(error: "Failed to create check: #{e.message}")
   end
 
   def process_checks
-    copied_count = 0
-    skipped_count = 0
+    return { copied: 0, skipped: 1 } if Check.exists?(checkable: context.copied_product)
 
-    # Fetch all existing check user IDs for the copied product in one query
-    existing_user_ids = Check.where(checkable: context.copied_product)
-                             .pluck(:user_id)
-                             .to_set
-
-    context.original_checks.each do |original_check|
-      if copy_check(original_check, existing_user_ids)
-        copied_count += 1
-      else
-        skipped_count += 1
-      end
-    end
-
-    { copied: copied_count, skipped: skipped_count }
+    copy_check(context.original_checks.first)
+    { copied: 1, skipped: 0 }
   end
 
   def store_results(results)
@@ -73,17 +60,10 @@ class CopyCheck
     "Copied #{results[:copied]} check(s), skipped #{results[:skipped]} existing check(s)"
   end
 
-  def copy_check(original_check, existing_user_ids)
-    # Check if this user already has a check for the copied product
-    return false if existing_user_ids.include?(original_check.user_id)
-
+  def copy_check(original_check)
     Check.create!(
       user: original_check.user,
       checkable: context.copied_product
     )
-
-    # Add the new user ID to the set to avoid duplicates in subsequent iterations
-    existing_user_ids.add(original_check.user_id)
-    true
   end
 end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -7,7 +7,7 @@ class Check < ApplicationRecord
   after_destroy_commit -> { CheckCallbacks.new.after_destroy(self) }
   alias sender user
 
-  validates :user_id, uniqueness: { scope: %i[checkable_id checkable_type] }
+  validates :checkable_id, uniqueness: { scope: :checkable_type }
 
   def receiver
     checkable.user

--- a/db/data/20260707000000_delete_duplicate_checks.rb
+++ b/db/data/20260707000000_delete_duplicate_checks.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class DeleteDuplicateChecks < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      DELETE FROM checks
+      WHERE id IN (
+        SELECT id
+        FROM (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY checkable_id, checkable_type
+                   ORDER BY created_at ASC, id ASC
+                 ) AS row_number
+          FROM checks
+        ) duplicate_checks
+        WHERE duplicate_checks.row_number > 1
+      )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_03_25_014711)
+DataMigrate::Data.define(version: 2026_07_07_000000)

--- a/db/fixtures/checks.yml
+++ b/db/fixtures/checks.yml
@@ -14,10 +14,6 @@ report5_check_machida:
   user: machida
   checkable: report5 (Report)
 
-report5_check_komagata:
-  user: komagata
-  checkable: report5 (Report)
-
 report6_check_komagata:
   user: komagata
   checkable: report6 (Report)

--- a/db/migrate/20260707000000_change_checks_unique_index_to_checkable.rb
+++ b/db/migrate/20260707000000_change_checks_unique_index_to_checkable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class ChangeChecksUniqueIndexToCheckable < ActiveRecord::Migration[8.1]
+  def up
+    delete_duplicate_checks
+
+    remove_index :checks, name: 'index_checks_on_user_id_and_checkable_id_and_checkable_type'
+    add_index :checks, %i[checkable_id checkable_type], unique: true
+  end
+
+  def down
+    remove_index :checks, %i[checkable_id checkable_type]
+    add_index :checks, %i[user_id checkable_id checkable_type],
+              unique: true,
+              name: 'index_checks_on_user_id_and_checkable_id_and_checkable_type'
+  end
+
+  private
+
+  def delete_duplicate_checks
+    execute <<~SQL.squish
+      DELETE FROM checks
+      WHERE id IN (
+        SELECT id
+        FROM (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY checkable_id, checkable_type
+                   ORDER BY created_at ASC, id ASC
+                 ) AS row_number
+          FROM checks
+        ) duplicate_checks
+        WHERE duplicate_checks.row_number > 1
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -173,8 +173,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_000000) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id", null: false
+    t.index ["checkable_id", "checkable_type"], name: "index_checks_on_checkable_id_and_checkable_type", unique: true
     t.index ["checkable_id"], name: "index_checks_on_checkable_id"
-    t.index ["user_id", "checkable_id", "checkable_type"], name: "index_checks_on_user_id_and_checkable_id_and_checkable_type", unique: true
     t.index ["user_id"], name: "index_checks_on_user_id"
   end
 

--- a/test/fixtures/checks.yml
+++ b/test/fixtures/checks.yml
@@ -14,10 +14,6 @@ report5_check_machida:
   user: machida
   checkable: report5 (Report)
 
-report5_check_komagata:
-  user: komagata
-  checkable: report5 (Report)
-
 report6_check_komagata:
   user: komagata
   checkable: report6 (Report)

--- a/test/interactors/copy_check_test.rb
+++ b/test/interactors/copy_check_test.rb
@@ -30,7 +30,6 @@ class CopyCheckTest < ActiveSupport::TestCase
   test 'successfully copies checks when original has checks and target has none' do
     # Create checks for original product
     Check.create!(user: @user1, checkable: @original_product)
-    Check.create!(user: @user2, checkable: @original_product)
 
     result = CopyCheck.call(
       original_product: @original_product,
@@ -38,24 +37,22 @@ class CopyCheckTest < ActiveSupport::TestCase
     )
 
     assert result.success?
-    assert_equal 'Copied 2 check(s), skipped 0 existing check(s)', result.message
-    assert_equal 2, result.copied_checks_count
+    assert_equal 'Copied 1 check(s), skipped 0 existing check(s)', result.message
+    assert_equal 1, result.copied_checks_count
     assert_equal 0, result.skipped_checks_count
 
     # Verify the checks were copied
     copied_checks = Check.where(checkable: @copied_product)
-    assert_equal 2, copied_checks.count
+    assert_equal 1, copied_checks.count
     assert_includes copied_checks.pluck(:user_id), @user1.id
-    assert_includes copied_checks.pluck(:user_id), @user2.id
   end
 
-  test 'skips existing checks and only copies new ones' do
+  test 'skips when copied product already has a check' do
     # Create checks for original product
     Check.create!(user: @user1, checkable: @original_product)
-    Check.create!(user: @user2, checkable: @original_product)
 
     # Create one existing check for copied product
-    Check.create!(user: @user1, checkable: @copied_product)
+    Check.create!(user: @user2, checkable: @copied_product)
 
     result = CopyCheck.call(
       original_product: @original_product,
@@ -63,13 +60,13 @@ class CopyCheckTest < ActiveSupport::TestCase
     )
 
     assert result.success?
-    assert_equal 'Copied 1 check(s), skipped 1 existing check(s)', result.message
-    assert_equal 1, result.copied_checks_count
+    assert_equal 'Copied 0 check(s), skipped 1 existing check(s)', result.message
+    assert_equal 0, result.copied_checks_count
     assert_equal 1, result.skipped_checks_count
 
-    # Verify only one new check was added
     copied_checks = Check.where(checkable: @copied_product)
-    assert_equal 2, copied_checks.count
+    assert_equal 1, copied_checks.count
+    assert_equal @user2.id, copied_checks.first.user_id
   end
 
   test 'succeeds when original product has no checks' do

--- a/test/models/check_test.rb
+++ b/test/models/check_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CheckTest < ActiveSupport::TestCase
+  test 'cannot create multiple checks for the same checkable even by different users' do
+    report = Report.left_outer_joins(:checks).where(checks: { id: nil }).first
+
+    Check.create!(user: users(:komagata), checkable: report)
+    check = Check.new(user: users(:mentormentaro), checkable: report)
+
+    assert_not check.valid?
+    assert_includes check.errors[:checkable_id], 'はすでに存在します'
+  end
+end


### PR DESCRIPTION
## 概要

- Checkの一意性を `user_id, checkable_id, checkable_type` から `checkable_id, checkable_type` に変更
- 既存の重複Checkは最古の1件を残して削除するmigration/data migrationを追加
- 新仕様に合わせてfixtureとCopyCheckの挙動、テストを更新

## 確認

- [x] `env -u RUBYOPT /home/komagata/.local/share/mise/installs/ruby/3.4.3/bin/ruby bin/rails test test/models/check_test.rb test/interactors/copy_check_test.rb test/integration/api/checks_test.rb`
- [x] `env -u RUBYOPT /home/komagata/.local/share/mise/installs/ruby/3.4.3/bin/ruby -S bundle exec rubocop app/models/check.rb app/interactors/copy_check.rb db/migrate/20260707000000_change_checks_unique_index_to_checkable.rb db/data/20260707000000_delete_duplicate_checks.rb test/models/check_test.rb test/interactors/copy_check_test.rb`
- [x] `env -u RUBYOPT /home/komagata/.local/share/mise/installs/ruby/3.4.3/bin/ruby bin/rails db:migrate`
- [x] `env -u RUBYOPT /home/komagata/.local/share/mise/installs/ruby/3.4.3/bin/ruby bin/rails data:migrate:up VERSION=20260707000000`

補足: `data:migrate` 全体は、既存の `20201122113956_change_komagata` が空のdevelopment DBで対象ユーザーを見つけられず失敗するため、今回追加分は単体で確認しました。

Closes #10267