### PR TITLE
buzzesの年別リンクで不正な年を除外

### DIFF
--- a/app/models/buzz.rb
+++ b/app/models/buzz.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Buzz < ApplicationRecord
+  ROUTABLE_YEAR_RANGE = 1000..9999
+  ROUTABLE_PUBLISHED_AT_RANGE = Date.new(ROUTABLE_YEAR_RANGE.begin, 1, 1)..Date.new(ROUTABLE_YEAR_RANGE.end, 12, 31)
+
   validates :title, presence: true
   validates :published_at, presence: true
   validates :url, presence: true, uniqueness: { message: 'はすでに登録されています' }
@@ -53,11 +56,11 @@ class Buzz < ApplicationRecord
     end
 
     def latest_year
-      maximum('published_at')&.year
+      where(published_at: ROUTABLE_PUBLISHED_AT_RANGE).maximum(:published_at)&.year
     end
 
     def years
-      pluck('published_at').map(&:year).uniq.sort.reverse
+      where(published_at: ROUTABLE_PUBLISHED_AT_RANGE).pluck('published_at').map(&:year).uniq.sort.reverse
     end
 
     def doc_from_url(url)

--- a/test/models/buzz_test.rb
+++ b/test/models/buzz_test.rb
@@ -15,9 +15,35 @@ class BuzzTest < ActiveSupport::TestCase
     assert_equal latest_year, Buzz.latest_year
   end
 
+  test '.latest_year excludes years that cannot be routed' do
+    Buzz.create!(
+      title: '不正な年の記事',
+      url: 'https://www.example-latest-invalid-year.com',
+      published_at: Date.new(202_672, 1, 1)
+    )
+
+    assert_equal buzzes(:buzz1).published_at.year, Buzz.latest_year
+  end
+
   test '.years' do
     years = [2025, 2024]
     assert_equal years, Buzz.years
+  end
+
+  test '.years excludes years that cannot be routed' do
+    [
+      ['https://www.example-invalid-future-year.com', Date.new(202_672, 1, 1)],
+      ['https://www.example-invalid-past-year.com', Date.new(999, 1, 1)]
+    ].each do |url, published_at|
+      Buzz.create!(
+        title: '不正な年の記事',
+        url:,
+        published_at:
+      )
+    end
+
+    assert_not_includes Buzz.years, 202_672
+    assert_not_includes Buzz.years, 999
   end
 
   test '.doc_from_url returns nokogori object when succeeded' do


### PR DESCRIPTION
## 概要

- buzzes の年一覧と最新年から、ルート制約に合わない4桁外の年を除外
- 不正な年の buzz が存在しても年別リンク生成で 500 にならないように修正
- 不正な未来年・過去年を除外するモデルテストを追加

## 確認

- [x] mise exec -- bundle exec rails test test/models/buzz_test.rb
- [x] mise exec -- bundle exec rails test test/system/buzzes_test.rb
- [x] mise exec -- bundle exec rubocop app/models/buzz.rb test/models/buzz_test.rb

Closes #10255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 年別一覧と最新年の表示が、表示対象として適切な年のみを使うようになりました。
  * 極端な過去・未来など、ルーティングできない年が集計結果に含まれなくなりました。
* **Tests**
  * ルーティング対象外の年が一覧や最新年に表示されないことを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10270-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/28874945177/artifacts/8141843669" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
