### PR TITLE
【hotfix】buzzesの年別リンクで不正な年を除外

### DIFF
--- a/app/models/buzz.rb
+++ b/app/models/buzz.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class Buzz < ApplicationRecord
+  ROUTABLE_YEAR_RANGE = 1000..9999
+  ROUTABLE_PUBLISHED_AT_RANGE = Date.new(ROUTABLE_YEAR_RANGE.begin, 1, 1)..Date.new(ROUTABLE_YEAR_RANGE.end, 12, 31)
+
   validates :title, presence: true
   validates :published_at, presence: true
   validates :url, presence: true, uniqueness: { message: 'はすでに登録されています' }
   validate :url_format
+  validate :published_at_year_is_routable
 
   require 'net/http'
 
@@ -45,6 +49,12 @@ class Buzz < ApplicationRecord
     true
   end
 
+  def published_at_year_is_routable
+    return if published_at.blank? || ROUTABLE_YEAR_RANGE.cover?(published_at.year)
+
+    errors.add(:published_at, 'は4桁の年で入力してください')
+  end
+
   class << self
     def for_year(year)
       start_date = start_of_year(year)
@@ -53,11 +63,11 @@ class Buzz < ApplicationRecord
     end
 
     def latest_year
-      maximum('published_at')&.year
+      where(published_at: ROUTABLE_PUBLISHED_AT_RANGE).maximum(:published_at)&.year
     end
 
     def years
-      pluck('published_at').map(&:year).uniq.sort.reverse
+      where(published_at: ROUTABLE_PUBLISHED_AT_RANGE).pluck('published_at').map(&:year).uniq.sort.reverse
     end
 
     def doc_from_url(url)

--- a/test/models/buzz_test.rb
+++ b/test/models/buzz_test.rb
@@ -15,9 +15,46 @@ class BuzzTest < ActiveSupport::TestCase
     assert_equal latest_year, Buzz.latest_year
   end
 
+  test '.latest_year excludes years that cannot be routed' do
+    Buzz.new(
+      title: '不正な年の記事',
+      url: 'https://www.example-latest-invalid-year.com',
+      published_at: Date.new(202_672, 1, 1)
+    ).save!(validate: false)
+
+    assert_equal buzzes(:buzz1).published_at.year, Buzz.latest_year
+  end
+
   test '.years' do
     years = [2025, 2024]
     assert_equal years, Buzz.years
+  end
+
+  test '.years excludes years that cannot be routed' do
+    [
+      ['https://www.example-invalid-future-year.com', Date.new(202_672, 1, 1)],
+      ['https://www.example-invalid-past-year.com', Date.new(999, 1, 1)]
+    ].each do |url, published_at|
+      Buzz.new(
+        title: '不正な年の記事',
+        url:,
+        published_at:
+      ).save!(validate: false)
+    end
+
+    assert_not_includes Buzz.years, 202_672
+    assert_not_includes Buzz.years, 999
+  end
+
+  test 'invalid when published_at year cannot be routed' do
+    buzz = Buzz.new(
+      title: '不正な年の記事',
+      url: 'https://www.example-invalid-published-at-year.com',
+      published_at: Date.new(202_672, 1, 1)
+    )
+
+    assert_not buzz.valid?
+    assert_includes buzz.errors[:published_at], 'は4桁の年で入力してください'
   end
 
   test '.doc_from_url returns nokogori object when succeeded' do


### PR DESCRIPTION
## 概要

- #10270 と同じ修正を production 向け hotfix として適用
- buzzes の年一覧と最新年から、ルート制約に合わない4桁外の年を除外
- 不正な年の buzz が存在しても年別リンク生成で 500 にならないように修正
- 今後同じ不正な published_at 年を保存できないように validation を追加
- 不正な未来年・過去年を除外するモデルテストと validation テストを追加

## 確認

- [x] mise exec -- bundle exec rails test test/models/buzz_test.rb
- [x] mise exec -- bundle exec rails test test/system/buzzes_test.rb
- [x] mise exec -- bundle exec rubocop app/models/buzz.rb test/models/buzz_test.rb

関連: #10255
元PR: #10270