### PR TITLE
フッターのBookRinへのリンクを削除

### DIFF
--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -62,9 +62,6 @@ footer.footer
             = link_to 'https://discord-bot-fjord.herokuapp.com/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | DiscordBotF
           li.footer-nav__item
-            = link_to 'https://bookrin.fly.dev/login/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
-              | BookRin
-          li.footer-nav__item
             = link_to 'https://fbc-stack.vercel.app/', class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do
               | FBC Stack
           li.footer-nav__item


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- Issue番号　#10260

## 概要
サービス終了したBookRinのフッターリンクを外す

## 変更確認方法

1. {bug/remove-bookrin-link}をローカルに取り込む
2. フッター箇所まで下がり、当該リンクが削除されていることを確認する

## Screenshot

### 変更前
<img width="612" height="962" alt="スクリーンショット 2026-07-08 13 50 40" src="https://github.com/user-attachments/assets/610904ea-1a0d-4214-9dd7-26967ac17813" />

### 変更後
<img width="612" height="962" alt="スクリーンショット 2026-07-08 13 51 58" src="https://github.com/user-attachments/assets/820f1252-6952-41ce-b144-741810853210" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **変更**
  * フッター内のリンク一覧を更新し、既存の「BookRin」へのリンクを削除しました。
  * 新しい外部リンク「FBC Stack」を追加しました。
  * 外部リンクは新しいタブで開くように変更し、安全性を高めました（`noopener` 設定）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30140488204/artifacts/8614395756" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10277-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
