### PR TITLE
メンター、管理者でログインしてるときは、給付金コースのプラクティスからオリジナルのプラクティスへのリンクを表示する

### DIFF
--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -164,9 +164,9 @@
                         = link_to practice_path(practice), class: 'a-button is-sm is-secondary is-block' do
                           i.fa-solid.fa-pen
                           - if @practice.copied_practices.many?
-                            | 元プラクティスへ（#{practice.title}）
+                            | Reスキル側へ（#{practice.title}）
                           - if @practice.copied_practices.one?
-                            | 元プラクティスへ
+                            | Reスキル側へ
                     li.card-main-actions__item
                       = link_to edit_mentor_practice_path(@practice), class: 'a-button is-sm is-secondary is-block' do
                         i.fa-solid.fa-pen

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -154,6 +154,19 @@
               footer.card-footer
                 .card-main-actions
                   ul.card-main-actions__items
+                    - if @practice.source_practice.present?
+                      li.card-main-actions__item
+                        = link_to practice_path(@practice.source_practice), class: 'a-button is-sm is-secondary is-block' do
+                          i.fa-solid.fa-pen
+                          | 元プラクティスへ
+                    - @practice.copied_practices.each do |practice|
+                      li.card-main-actions__item
+                        = link_to practice_path(practice), class: 'a-button is-sm is-secondary is-block' do
+                          i.fa-solid.fa-pen
+                          - if @practice.copied_practices.many?
+                            | 元プラクティスへ（#{practice.title}）
+                          - if @practice.copied_practices.one?
+                            | 元プラクティスへ
                     li.card-main-actions__item
                       = link_to edit_mentor_practice_path(@practice), class: 'a-button is-sm is-secondary is-block' do
                         i.fa-solid.fa-pen

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -157,16 +157,16 @@
                     - if @practice.source_practice.present?
                       li.card-main-actions__item
                         = link_to practice_path(@practice.source_practice), class: 'a-button is-sm is-secondary is-block' do
-                          i.fa-solid.fa-pen
+                          i.fa-solid.fa-right-left
                           | 元プラクティスへ
                     - @practice.copied_practices.each do |practice|
                       li.card-main-actions__item
                         = link_to practice_path(practice), class: 'a-button is-sm is-secondary is-block' do
-                          i.fa-solid.fa-pen
+                          i.fa-solid.fa-right-left
                           - if @practice.copied_practices.many?
-                            | Reスキル側へ（#{practice.title}）
+                            | 助成金コースへ（#{practice.title}）
                           - if @practice.copied_practices.one?
-                            | Reスキル側へ
+                            | 助成金コースへ
                     li.card-main-actions__item
                       = link_to edit_mentor_practice_path(@practice), class: 'a-button is-sm is-secondary is-block' do
                         i.fa-solid.fa-pen


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- Issue番号　#10274

## 概要
メンター・管理者が、コピー元⇄コピー先のプラクティスを行き来できるように、
メンター・管理者用メニューに元プラクティスへのリンクを設置する

## 変更確認方法

1. komagataでログインする（メンター/管理者権限が必要なアカウント）
2. コピーがあるプラクティス（例:「OS X Mountain Lionをクリーンインストールする」）を開く
3. 「管理者・メンター用メニュー」に元プラクティスへのリンクが表示されていることを確認する
4. リンクをクリックして正しく遷移することを確認する
5. 逆に、コピーではない普通のプラクティスではリンクそのものが表示されないことを確認する

## Screenshot

### 変更前
<img width="1994" height="1924" alt="image" src="https://github.com/user-attachments/assets/8629c4b3-be33-46c4-949c-55fb9ffc76ed" />


### 変更後
<img width="849" height="900" alt="image" src="https://github.com/user-attachments/assets/dd124101-435a-4300-9f5a-deabf8a8d60e" />


<!-- I want to review in Japanese. -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10279-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/32227279295/artifacts/9390290640" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 管理者・メンター向けメニューの元プラクティスおよびコピー先プラクティスへの導線アイコンを、鉛筆から左右矢印に変更しました。
  - コピー先プラクティスへの案内文を「Reスキル側へ」から「助成金コースへ」に変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
