### PR TITLE
Fix NoMethodError when a comment's commentable has no user

### DIFF
--- a/app/models/concerns/mentioner.rb
+++ b/app/models/concerns/mentioner.rb
@@ -90,14 +90,21 @@ module Mentioner
   end
 
   def target_of_comment(commentable_class, commentable)
-    {
-      Report: "#{commentable.user.login_name}さんの日報「#{commentable.title}」",
-      Product: "#{commentable.user.login_name}さんの#{commentable.title}",
-      Event: "特別イベント「#{commentable.title}」",
-      RegularEvent: "定期イベント「#{commentable.title}」",
-      Page: "Docs「#{commentable.title}」",
-      Announcement: "お知らせ「#{commentable.title}」",
-      PairWork: "ペアワーク「#{commentable.title}」"
-    }[:"#{commentable_class}"]
+    case commentable_class.to_s
+    when 'Report'
+      "#{commentable.user&.login_name}さんの日報「#{commentable.title}」"
+    when 'Product'
+      "#{commentable.user&.login_name}さんの#{commentable.title}"
+    when 'Event'
+      "特別イベント「#{commentable.title}」"
+    when 'RegularEvent'
+      "定期イベント「#{commentable.title}」"
+    when 'Page'
+      "Docs「#{commentable.title}」"
+    when 'Announcement'
+      "お知らせ「#{commentable.title}」"
+    when 'PairWork'
+      "ペアワーク「#{commentable.title}」"
+    end
   end
 end

--- a/test/models/concerns/mentioner_test.rb
+++ b/test/models/concerns/mentioner_test.rb
@@ -30,4 +30,11 @@ class MentionerTest < ActiveSupport::TestCase
 
     assert_equal %w[komagata machida], report.notify_all_mention_user.map(&:login_name).sort
   end
+
+  test '#where_mention does not raise when the commentable has no user' do
+    comment = comments(:comment1)
+    comment.commentable.stub(:user, nil) do
+      assert_nothing_raised { comment.where_mention }
+    end
+  end
 end


### PR DESCRIPTION
## Issue

- #10117

## 概要

`Mentioner#target_of_comment` がハッシュリテラルで全ての項目を先に評価していたため、`commentable_class` が `Report` や `Product` 以外でも `commentable.user.login_name` が実行されていました。`commentable.user` が `nil`（`Comment#user` は `commentable` が user を持たない場合に `nil` を返します）のときに `NoMethodError: undefined method 'login_name' for nil` が発生します。

`where_mention` と同じく `case` に変更し、該当するクラスの分岐だけを評価するようにしました。あわせて Report / Product の分岐は `user&.login_name` にして user が無い場合でも落ちないようにしています。

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. `bin/rails test test/models/concerns/mentioner_test.rb` を実行し、追加した `#where_mention does not raise when the commentable has no user` が通ることを確認する

## Screenshot

### 変更前

（表示に影響のない内部処理の修正のため、スクリーンショットはありません）

### 変更後


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ユーザー情報を持たない対象へのコメント処理で、エラーが発生しないよう改善しました。
  * 対象種別ごとのコメント表示内容は維持しつつ、文言生成ロジックの分岐と安定性を向上しました。
* **テスト**
  * ユーザーが `nil` の場合でも例外を投げないことを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->