### PR TITLE
プロフィールのXリンク先をx.comに変更

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -8,7 +8,7 @@ module UserDecorator
   include ReportStatus
 
   def twitter_url
-    "https://twitter.com/#{twitter_account}"
+    "https://x.com/#{twitter_account}"
   end
 
   def icon_title

--- a/app/views/companies/users/_user_sns.html.slim
+++ b/app/views/companies/users/_user_sns.html.slim
@@ -9,7 +9,7 @@
           i.fa-brands.fa-github-alt
     li.sns-links__item
       - if user.twitter_account
-        = link_to "https://twitter.com/#{user.twitter_account}", class: 'sns-links__item-link a-button is-sm is-secondary is-icon'
+        = link_to user.twitter_url, class: 'sns-links__item-link a-button is-sm is-secondary is-icon'
           i.fa-brands.fa-x-twitter
       - else
         .sns-links__item-link.a-button.is-sm.is-disabled.is-icon

--- a/app/views/generations/_user_sns.html.slim
+++ b/app/views/generations/_user_sns.html.slim
@@ -10,7 +10,7 @@ ul.sns-links__items.is-button-group
   li.sns-links__item
     - if user.twitter_account
       a[class="sns-links__item-link a-button is-sm is-secondary is-icon"
-        href="https://twitter.com/#{user.twitter_account}"]
+        href=user.twitter_url]
         i.fa-brands.fa-x-twitter
     - else
       .sns-links__item-link.a-button.is-sm.is-disabled.is-icon

--- a/app/views/welcome/_author.html.slim
+++ b/app/views/welcome/_author.html.slim
@@ -28,7 +28,7 @@ section.article-author.a-card(class="is-#{page}")
                 i.fa-solid.fa-home
           - if mentor.twitter_account.present?
             li.article-author__sns-item
-              = link_to "https://twitter.com/#{mentor.twitter_account}", class: 'article-author__sns-item-link' do
+              = link_to mentor.twitter_url, class: 'article-author__sns-item-link' do
                 i.fa-brands.fa-x-twitter
           - if mentor.facebook_url.present?
             li.article-author__sns-item

--- a/app/views/welcome/_mentor.html.slim
+++ b/app/views/welcome/_mentor.html.slim
@@ -24,7 +24,7 @@ section.lp-mentor.a-card(class="is-#{page}")
                 i.fa-solid.fa-home
           - if mentor.twitter_account.present?
             li.lp-mentor__sns-item
-              = link_to "https://twitter.com/#{mentor.twitter_account}", class: 'lp-mentor__sns-item-link' do
+              = link_to mentor.twitter_url, class: 'lp-mentor__sns-item-link' do
                 i.fa-brands.fa-x-twitter
           - if mentor.facebook_url.present?
             li.lp-mentor__sns-item

--- a/app/views/welcome/_mentor_modal.html.slim
+++ b/app/views/welcome/_mentor_modal.html.slim
@@ -25,7 +25,7 @@
                   i.fa-solid.fa-home
             - if mentor.twitter_account.present?
               li.lp-mentor__sns-item
-                = link_to "https://twitter.com/#{mentor.twitter_account}", class: 'lp-mentor__sns-item-link' do
+                = link_to mentor.twitter_url, class: 'lp-mentor__sns-item-link' do
                   i.fa-brands.fa-x-twitter
             - if mentor.facebook_url.present?
               li.lp-mentor__sns-item

--- a/test/decorators/user_decorator_test.rb
+++ b/test/decorators/user_decorator_test.rb
@@ -24,6 +24,10 @@ class UserDecoratorTest < ActiveDecoratorTestCase
     assert_equal 'hajime (Hajime Tayo)', @student_user.icon_title
   end
 
+  test '#twitter_url' do
+    assert_equal 'https://x.com/komagata', @admin_mentor_user.twitter_url
+  end
+
   test '#long_name' do
     assert_equal 'hajime (ハジメ タヨ)', @student_user.long_name
   end

--- a/test/system/company/users_test.rb
+++ b/test/system/company/users_test.rb
@@ -8,6 +8,15 @@ class Company::UsersTest < ApplicationSystemTestCase
     assert_equal 'Lokka Inc.所属ユーザー | FBC', title
   end
 
+  test 'profile X links use x.com' do
+    user = users(:komagata)
+    visit_with_auth "/companies/#{companies(:company1).id}/users?target=all", 'kimura'
+
+    within('.users-item', text: user.name) do
+      assert_selector "a[href='https://x.com/#{user.twitter_account}'] i.fa-x-twitter", visible: :all
+    end
+  end
+
   test 'show users by user category' do
     visit_with_auth "/companies/#{companies(:company2).id}/users", 'kimura'
     # デフォルトは現役 + 研修生のユーザーを表示

--- a/test/system/generations_test.rb
+++ b/test/system/generations_test.rb
@@ -42,7 +42,7 @@ class GenerationsTest < ApplicationSystemTestCase
       assert_selector 'ul.sns-links__items'
       assert_selector 'li.sns-links__item', count: 5
       assert_selector "a.is-secondary[href='https://github.com/#{user.github_account}'] i.fa-github-alt", visible: :all
-      assert_selector "a.is-secondary[href='https://twitter.com/#{user.twitter_account}'] i.fa-x-twitter", visible: :all
+      assert_selector "a.is-secondary[href='https://x.com/#{user.twitter_account}'] i.fa-x-twitter", visible: :all
       assert_selector "a.is-secondary[href='#{user.facebook_url}'] i.fa-facebook-square", visible: :all
       assert_selector "a.is-secondary[href='#{user.blog_url}'] i.fa-blog", visible: :all
       assert_selector "a.is-secondary[href='#{user.discord_profile.times_url}'] i.fa-clock", visible: :all

--- a/test/system/users/profile_test.rb
+++ b/test/system/users/profile_test.rb
@@ -5,8 +5,10 @@ require 'application_system_test_case'
 module Users
   class ProfileTest < ApplicationSystemTestCase
     test 'show profile' do
-      visit_with_auth "/users/#{users(:hatsuno).id}", 'hatsuno'
+      user = users(:hatsuno)
+      visit_with_auth "/users/#{user.id}", 'hatsuno'
       assert_equal 'hatsunoさんのプロフィール | FBC', title
+      assert_selector "a[href='https://x.com/#{user.twitter_account}'] i.fa-x-twitter", visible: :all
     end
 
     test 'autolink profile when url is included' do

--- a/test/system/welcome_test.rb
+++ b/test/system/welcome_test.rb
@@ -3,6 +3,13 @@
 require 'application_system_test_case'
 
 class WelcomeTest < ApplicationSystemTestCase
+  test 'profile X links use x.com' do
+    user = users(:komagata)
+    visit '/welcome'
+
+    assert_selector "a.lp-mentor__sns-item-link[href='https://x.com/#{user.twitter_account}'] i.fa-x-twitter", visible: :all
+  end
+
   test 'mentors can update their profiles' do
     visit_with_auth '/current_user/edit', 'komagata'
     attach_file 'user[profile_image]', Rails.root.join('test/fixtures/files/users-avatars-komagata.jpg'), make_visible: true


### PR DESCRIPTION
## Issue

- Closes #9773

## 概要

プロフィールに表示されるXリンクのホストを `twitter.com` から `x.com` に変更しました。

ユーザープロフィール、所属企業、期生一覧、メンター紹介、記事著者の各表示で `UserDecorator#twitter_url` を共通利用するようにしています。投稿用リンク、埋め込み、ハッシュタグへのリンクは変更していません。

確認済み:

- 対象のdecorator・システムテスト: 5 runs / 12 assertions
- Railsテスト: 1,313 runs / 4,825 assertions
- `./bin/lint`

## 変更確認方法

1. `fix/use-x-profile-links` をローカルに取り込む
2. ユーザープロフィール、所属企業のユーザー一覧、期生一覧、またはメンター紹介を開く
3. Xアイコンのリンク先が `https://x.com/<アカウント名>` になっていることを確認する

## Screenshot

表示上の変更はなく、リンク先URLのみの変更のため省略します。

### 変更前

`https://twitter.com/<アカウント名>`

### 変更後

`https://x.com/<アカウント名>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * プロフィールやメンター情報に表示されるX（旧Twitter）リンクの参照先を `x.com` へ更新しました。
  * SNSリンクは従来の組み立て方式から、登録済みのURLをそのまま利用するよう変更し、遷移先の整合性を高めました。
* **テスト**
  * 各画面・システムテストでXリンクが `x.com` を指すことを確認するケースを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->