### PR TITLE
ArticleのCRUD APIを追加

### DIFF
--- a/app/controllers/api/articles/summaries_controller.rb
+++ b/app/controllers/api/articles/summaries_controller.rb
@@ -5,6 +5,10 @@ class API::Articles::SummariesController < API::BaseController
   before_action :require_admin_or_mentor_login_for_api
 
   def create
-    render json: Article.agent_summary(params[:body])
+    return render json: { error: '本文が空です' }, status: :unprocessable_entity if params[:body].blank?
+
+    result = Article.agent_summary(params[:body])
+    status = result[:error] ? :internal_server_error : :ok
+    render json: result, status:
   end
 end

--- a/app/controllers/api/articles/summaries_controller.rb
+++ b/app/controllers/api/articles/summaries_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class API::Articles::SummariesController < API::BaseController
+  before_action -> { doorkeeper_authorize! :write }, if: -> { doorkeeper_token.present? }
+  before_action :require_admin_or_mentor_login_for_api
+
+  def create
+    render json: Article.agent_summary(params[:body])
+  end
+end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -102,10 +102,7 @@ class API::ArticlesController < API::BaseController
   def update_article_params = permitted_article_params(UPDATE_ARTICLE_ATTRIBUTES)
 
   def permitted_article_params(attributes)
-    permitted = params.require(:article).permit(*attributes)
-    raw_tag_list = params[:article][:tag_list]
-    permitted[:tag_list] = raw_tag_list.map(&:to_s) if raw_tag_list.is_a?(Array)
-    permitted
+    params.require(:article).permit(*attributes, tag_list: [])
   end
 
   def assign_contributor(article, user_id, fallback: nil)

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+class API::ArticlesController < API::BaseController
+  ARTICLE_ATTRIBUTES = %i[
+    title body tag_list user_id thumbnail thumbnail_type summary display_thumbnail_in_body target wip
+  ].freeze
+  UPDATE_ARTICLE_ATTRIBUTES = [*ARTICLE_ATTRIBUTES, :published_at].freeze
+
+  before_action -> { doorkeeper_authorize! :write }, only: %i[create update destroy], if: -> { doorkeeper_token.present? }
+  before_action :require_admin_or_mentor_login_for_api, only: %i[create update destroy]
+  before_action :authorize_wip_index, only: %i[index]
+  before_action :set_article, only: %i[show update destroy]
+  before_action :authorize_wip_preview, only: %i[show]
+
+  def index
+    @articles = article_scope.preload(:tags).page(params[:page])
+    @articles = @articles.tagged_with(params[:tag]) if params[:tag].present?
+  end
+
+  def show; end
+
+  def create
+    attributes = create_article_params
+    user_id = attributes.delete(:user_id)
+    @article = Article.new
+    apply_wip_param(@article, attributes)
+    @article.assign_attributes(attributes)
+
+    return unless assign_contributor(@article, user_id, fallback: current_user)
+
+    if @article.save
+      ActiveSupport::Notifications.instrument('article.create', article: @article)
+      render :show, status: :created
+    else
+      render_validation_errors(@article)
+    end
+  end
+
+  def update
+    attributes = update_article_params
+
+    if attributes.key?(:user_id)
+      user_id = attributes.delete(:user_id)
+      return unless assign_contributor(@article, user_id)
+    end
+
+    apply_wip_param(@article, attributes)
+    apply_published_at_param(@article, attributes)
+    @article.assign_attributes(attributes)
+
+    if @article.save
+      ActiveSupport::Notifications.instrument('article.create', article: @article)
+      render :show, status: :ok
+    else
+      render_validation_errors(@article)
+    end
+  end
+
+  def destroy
+    @article.destroy
+    ActiveSupport::Notifications.instrument('article.destroy', article: @article)
+    head :no_content
+  end
+
+  private
+
+  def article_scope
+    scope = Article.with_attached_thumbnail.includes(user: { avatar_attachment: :blob })
+    if wip_requested?
+      scope.where(wip: true).order(created_at: :desc)
+    else
+      scope.where(wip: false).order(published_at: :desc, created_at: :desc)
+    end
+  end
+
+  def set_article
+    @article = Article.with_attached_thumbnail.includes(:tags, user: { avatar_attachment: :blob })
+                      .find_by(id: params[:id])
+    render_not_found('記事が見つかりません。') unless @article
+  end
+
+  def authorize_wip_index
+    return unless wip_requested?
+    return if current_user.admin_or_mentor?
+
+    render json: { error: '権限がありません' }, status: :forbidden
+  end
+
+  def authorize_wip_preview
+    return if performed? || @article.published? || current_user.admin_or_mentor?
+    return if params[:token].present? && @article.token == params[:token]
+
+    render json: { error: '権限がありません' }, status: :forbidden
+  end
+
+  def wip_requested?
+    ActiveModel::Type::Boolean.new.cast(params[:wip])
+  end
+
+  def create_article_params = permitted_article_params(ARTICLE_ATTRIBUTES)
+
+  def update_article_params = permitted_article_params(UPDATE_ARTICLE_ATTRIBUTES)
+
+  def permitted_article_params(attributes)
+    permitted = params.require(:article).permit(*attributes)
+    raw_tag_list = params[:article][:tag_list]
+    permitted[:tag_list] = raw_tag_list.map(&:to_s) if raw_tag_list.is_a?(Array)
+    permitted
+  end
+
+  def assign_contributor(article, user_id, fallback: nil)
+    contributor = user_id.present? ? User.admins_and_mentors.find_by(id: user_id) : fallback
+    return article.user = contributor if contributor
+
+    render json: { errors: { user_id: ['に指定できないユーザーです'] } }, status: :unprocessable_entity
+    false
+  end
+
+  def apply_wip_param(article, attributes)
+    return unless attributes.key?(:wip)
+
+    article.wip = ActiveModel::Type::Boolean.new.cast(attributes.delete(:wip))
+    article.generate_token! if article.wip?
+  end
+
+  def apply_published_at_param(article, attributes)
+    return unless attributes.key?(:published_at)
+
+    published_at = attributes.delete(:published_at)
+    article.published_at = published_at unless article.wip?
+  end
+end

--- a/app/views/api/articles/_article.json.jbuilder
+++ b/app/views/api/articles/_article.json.jbuilder
@@ -1,0 +1,21 @@
+json.id article.id
+json.title article.title
+json.body article.body
+json.summary article.summary
+json.target article.target
+json.wip article.wip?
+json.published_at article.published_at
+json.created_at article.created_at
+json.updated_at article.updated_at
+json.tags article.tag_list
+json.thumbnail_type article.thumbnail_type
+json.thumbnail_attached article.thumbnail.attached?
+json.thumbnail_url article.prepared_thumbnail? ? article.prepared_thumbnail_url : article.selected_thumbnail_url
+json.display_thumbnail_in_body article.display_thumbnail_in_body?
+json.token article.token if article.wip? && admin_or_mentor_login?
+
+json.user do
+  json.id article.user.id
+  json.login_name article.user.login_name
+  json.name article.user.name
+end

--- a/app/views/api/articles/index.json.jbuilder
+++ b/app/views/api/articles/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.articles @articles do |article|
+  json.partial! 'api/articles/article', article:
+end
+
+json.total_pages @articles.total_pages

--- a/app/views/api/articles/show.json.jbuilder
+++ b/app/views/api/articles/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'api/articles/article', article: @article

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -101,6 +101,10 @@ Rails.application.routes.draw do
     resources :movies, only: %i(index create update) do
       post :direct_uploads, on: :collection
     end
+    namespace :articles do
+      resource :summary, only: %i(create), controller: 'summaries'
+    end
+    resources :articles, only: %i(index show create update destroy)
     resources :metadata, only: %i(index)
     resources :micro_reports, only: %i(update)
     resources :trainee_progresses, only: %i(index)

--- a/test/integration/api/articles_test.rb
+++ b/test/integration/api/articles_test.rb
@@ -101,6 +101,15 @@ class API::ArticlesTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'can create an article with a comma-separated tag list' do
+    post api_articles_path(format: :json),
+         headers: authorization_header(@admin_token),
+         params: { article: valid_article_params.merge(tag_list: 'API,記事') }
+
+    assert_response :created
+    assert_equal %w[API 記事], response.parsed_body['tags']
+  end
+
   test 'can specify an admin or mentor as the contributor' do
     post api_articles_path(format: :json),
          headers: authorization_header(@admin_token),

--- a/test/integration/api/articles_test.rb
+++ b/test/integration/api/articles_test.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::ArticlesTest < ActionDispatch::IntegrationTest
+  def setup
+    application = Doorkeeper::Application.create!(
+      name: 'Article API Test',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
+    @admin = users(:komagata)
+    @mentor = users(:mentormentaro)
+    @student = users(:kimura)
+    @admin_token = create_access_token(application, @admin, 'read write')
+    @admin_read_token = create_access_token(application, @admin, 'read')
+    @mentor_token = create_access_token(application, @mentor, 'read write')
+    @student_token = create_access_token(application, @student, 'read write')
+  end
+
+  test 'requires login for article API' do
+    get api_articles_path(format: :json)
+    assert_response :unauthorized
+
+    get api_article_path(articles(:article1), format: :json)
+    assert_response :unauthorized
+
+    post api_articles_path(format: :json), params: { article: valid_article_params }
+    assert_response :unauthorized
+  end
+
+  test 'logged-in user can get published articles and filter them by tag' do
+    tagged_article = articles(:article1)
+    tagged_article.tag_list = ['API確認用']
+    tagged_article.save!
+
+    get api_articles_path(format: :json), headers: authorization_header(@student_token)
+
+    assert_response :ok
+    article_ids = response.parsed_body['articles'].pluck('id')
+    assert_includes article_ids, tagged_article.id
+    assert_not_includes article_ids, articles(:article3).id
+    assert response.parsed_body['total_pages'].positive?
+
+    get api_articles_path(format: :json, tag: 'API確認用'), headers: authorization_header(@student_token)
+
+    assert_response :ok
+    assert_equal [tagged_article.id], response.parsed_body['articles'].pluck('id')
+  end
+
+  test 'logged-in user can get a published article' do
+    article = articles(:article1)
+
+    get api_article_path(article, format: :json), headers: authorization_header(@student_token)
+
+    assert_response :ok
+    assert_equal article.id, response.parsed_body['id']
+    assert_equal article.title, response.parsed_body['title']
+    assert_equal article.body, response.parsed_body['body']
+    assert_equal article.user.login_name, response.parsed_body.dig('user', 'login_name')
+    assert response.parsed_body.key?('thumbnail_url')
+  end
+
+  test 'only admin or mentor can get the WIP list' do
+    get api_articles_path(format: :json, wip: true), headers: authorization_header(@student_token)
+    assert_response :forbidden
+
+    get api_articles_path(format: :json, wip: true), headers: authorization_header(@mentor_token)
+
+    assert_response :ok
+    article_ids = response.parsed_body['articles'].pluck('id')
+    assert_includes article_ids, articles(:article3).id
+    assert(response.parsed_body['articles'].all? { |article| article['wip'] })
+  end
+
+  test 'logged-in user can preview WIP article with its token' do
+    article = articles(:article3)
+
+    get api_article_path(article, format: :json), headers: authorization_header(@student_token)
+    assert_response :forbidden
+
+    get api_article_path(article, format: :json, token: article.token), headers: authorization_header(@student_token)
+
+    assert_response :ok
+    assert_equal article.id, response.parsed_body['id']
+    assert_nil response.parsed_body['token']
+  end
+
+  test 'admin and mentor can create articles' do
+    [@admin_token, @mentor_token].each do |token|
+      assert_difference('Article.count') do
+        post api_articles_path(format: :json),
+             headers: authorization_header(token),
+             params: { article: valid_article_params }
+      end
+
+      assert_response :created
+      assert_equal 'APIから作成した記事', response.parsed_body['title']
+      assert_equal %w[API 記事], response.parsed_body['tags']
+      assert_not response.parsed_body['wip']
+      assert response.parsed_body['published_at'].present?
+    end
+  end
+
+  test 'can specify an admin or mentor as the contributor' do
+    post api_articles_path(format: :json),
+         headers: authorization_header(@admin_token),
+         params: { article: valid_article_params.merge(user_id: @mentor.id) }
+
+    assert_response :created
+    assert_equal @mentor.id, response.parsed_body.dig('user', 'id')
+    assert_equal @mentor, Article.find(response.parsed_body['id']).user
+  end
+
+  test 'cannot specify a student as the contributor' do
+    assert_no_difference('Article.count') do
+      post api_articles_path(format: :json),
+           headers: authorization_header(@admin_token),
+           params: { article: valid_article_params.merge(user_id: @student.id) }
+    end
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body.dig('errors', 'user_id').present?
+  end
+
+  test 'can create and replace a custom thumbnail using multipart form data' do
+    thumbnail = fixture_file_upload('articles/ogp_images/test.jpg', 'image/jpeg')
+
+    post api_articles_path(format: :json),
+         headers: authorization_header(@admin_token),
+         params: {
+           article: valid_article_params.merge(
+             thumbnail_type: 'prepared_thumbnail',
+             thumbnail:,
+             display_thumbnail_in_body: true,
+             published_at: '2026-07-01T12:34:56+09:00',
+             wip: true
+           )
+         }
+
+    assert_response :created
+    article = Article.find(response.parsed_body['id'])
+    assert article.thumbnail.attached?
+    assert_nil article.published_at
+    assert response.parsed_body['thumbnail_attached']
+    assert response.parsed_body['display_thumbnail_in_body']
+    assert_equal 'prepared_thumbnail', response.parsed_body['thumbnail_type']
+    assert response.parsed_body['token'].present?
+
+    replacement = fixture_file_upload('articles/ogp_images/test.jpg', 'image/jpeg')
+    patch api_article_path(article, format: :json),
+          headers: authorization_header(@admin_token),
+          params: { article: { thumbnail: replacement } }
+
+    assert_response :ok
+    assert article.reload.thumbnail.attached?
+  end
+
+  test 'can update and publish a WIP article' do
+    article = articles(:article3)
+
+    patch api_article_path(article, format: :json),
+          headers: authorization_header(@mentor_token),
+          params: {
+            article: {
+              title: 'APIから更新したWIP記事',
+              tag_list: %w[更新 公開],
+              display_thumbnail_in_body: false,
+              wip: false
+            }
+          }
+
+    assert_response :ok
+    article.reload
+    assert_equal 'APIから更新したWIP記事', article.title
+    assert_equal %w[更新 公開], article.tag_list
+    assert_not article.wip?
+    assert article.published_at.present?
+  end
+
+  test 'can change published at of a published article' do
+    article = articles(:article1)
+    published_at = '2026-07-01T12:34:56+09:00'
+
+    patch api_article_path(article, format: :json),
+          headers: authorization_header(@admin_token),
+          params: { article: { published_at: } }
+
+    assert_response :ok
+    assert_equal Time.zone.parse(published_at), article.reload.published_at
+  end
+
+  test 'returns validation errors as JSON' do
+    assert_no_difference('Article.count') do
+      post api_articles_path(format: :json),
+           headers: authorization_header(@admin_token),
+           params: { article: valid_article_params.merge(title: '', body: '') }
+    end
+
+    assert_response :unprocessable_entity
+    assert response.parsed_body.dig('errors', 'title').present?
+    assert response.parsed_body.dig('errors', 'body').present?
+  end
+
+  test 'student cannot create update or destroy articles' do
+    article = articles(:article1)
+
+    post api_articles_path(format: :json),
+         headers: authorization_header(@student_token),
+         params: { article: valid_article_params }
+    assert_response :forbidden
+
+    patch api_article_path(article, format: :json),
+          headers: authorization_header(@student_token),
+          params: { article: { title: '更新できない記事' } }
+    assert_response :forbidden
+
+    assert_no_difference('Article.count') do
+      delete api_article_path(article, format: :json), headers: authorization_header(@student_token)
+    end
+    assert_response :forbidden
+  end
+
+  test 'write operations require write scope' do
+    post api_articles_path(format: :json),
+         headers: authorization_header(@admin_read_token),
+         params: { article: valid_article_params }
+
+    assert_response :forbidden
+    assert_equal 'invalid_scope', response.parsed_body['error']
+  end
+
+  test 'admin can destroy an article' do
+    article = articles(:article1)
+
+    assert_difference('Article.count', -1) do
+      delete api_article_path(article, format: :json), headers: authorization_header(@admin_token)
+    end
+
+    assert_response :no_content
+  end
+
+  test 'returns not found as JSON' do
+    get api_article_path('missing', format: :json), headers: authorization_header(@student_token)
+
+    assert_response :not_found
+    assert_equal '記事が見つかりません。', response.parsed_body['message']
+  end
+
+  test 'admin or mentor can generate an article summary' do
+    Article.stub(:agent_summary, { summary: 'APIで生成した概要' }) do
+      post api_articles_summary_path(format: :json),
+           headers: authorization_header(@admin_token),
+           params: { body: '概要を生成する記事本文' }
+    end
+
+    assert_response :ok
+    assert_equal 'APIで生成した概要', response.parsed_body['summary']
+  end
+
+  private
+
+  def create_access_token(application, user, scopes)
+    Doorkeeper::AccessToken.create!(application:, resource_owner_id: user.id, scopes:)
+  end
+
+  def authorization_header(token)
+    { Authorization: "Bearer #{token.token}" }
+  end
+
+  def valid_article_params
+    {
+      title: 'APIから作成した記事',
+      body: 'APIから作成した記事の本文です。',
+      summary: 'APIから作成した記事の概要です。',
+      tag_list: %w[API 記事],
+      thumbnail_type: 'ruby_on_rails',
+      display_thumbnail_in_body: true,
+      target: 'none',
+      wip: false
+    }
+  end
+end

--- a/test/integration/api/articles_test.rb
+++ b/test/integration/api/articles_test.rb
@@ -257,6 +257,26 @@ class API::ArticlesTest < ActionDispatch::IntegrationTest
     assert_equal 'APIで生成した概要', response.parsed_body['summary']
   end
 
+  test 'returns unprocessable entity when article body for summary is blank' do
+    post api_articles_summary_path(format: :json),
+         headers: authorization_header(@admin_token),
+         params: { body: '' }
+
+    assert_response :unprocessable_entity
+    assert_equal '本文が空です', response.parsed_body['error']
+  end
+
+  test 'returns internal server error when article summary generation fails' do
+    Article.stub(:agent_summary, { error: 'サマリー生成に失敗しました' }) do
+      post api_articles_summary_path(format: :json),
+           headers: authorization_header(@admin_token),
+           params: { body: '概要を生成する記事本文' }
+    end
+
+    assert_response :internal_server_error
+    assert_equal 'サマリー生成に失敗しました', response.parsed_body['error']
+  end
+
   private
 
   def create_access_token(application, user, scopes)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9998 

## 概要
Article（ブログ記事）を外部クライアントからJSON API経由で取得・作成・更新・削除できるようにしました。

既存のArticle画面で扱っている投稿者、タグ、WIP、公開日時、サムネイルなどの項目に対応しています。また、既存画面にあるAI概要生成、admin/mentor限定のWIP一覧、ログイン時限定のtoken付きプレビューもAPIから利用できるようにしました。

## 変更確認方法

1. `feature/article-api`をローカルに取り込む
2. 開発サーバーを起動
3. コンソールからread write tokenを取得し、返ってきた`token`を環境変数に入れる
```ruby
application = Doorkeeper::Application.find_or_create_by!(
  name: 'Article API Demo'
) do |app|
  app.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
end
```
```ruby
user = User.find_by!(login_name: 'komagata')
```
```ruby
access_token = Doorkeeper::AccessToken.create!(
  application:,
  resource_owner_id: user.id,
  scopes: 'read write'
)
```
```ruby
puts access_token.token
```
コンソールを終了しtokenを環境変数に入れる
```bash
$ TOKEN='返ってきたtoken'
```

4. 独自サムネイル付きのWIP記事を作成する
```bash
$ curl -s \
  -X POST http://localhost:3000/api/articles.json \
  -H "Authorization: Bearer $TOKEN" \
  -F 'article[title]=APIから作成した記事' \
  -F 'article[body]=APIから作成した記事の本文です。' \
  -F 'article[summary]=API動作確認用の記事です。' \
  -F 'article[tag_list]=API,動作確認' \
  -F 'article[thumbnail_type]=prepared_thumbnail' \
  -F 'article[display_thumbnail_in_body]=true' \
  -F 'article[target]=none' \
  -F 'article[wip]=true' \
  -F 'article[thumbnail]=@test/fixtures/files/articles/ogp_images/test.jpg' |
  jq
```
レスポンスから作成された記事のIDを取得し、環境変数に入れる
```bash
$ ARTICLE_ID='作成されたID'
```

5. ブラウザでkomagataでログインし、`http://localhost:3000/articles/wips`を開き、以下を確認する
- APIから作成したWIPが表示される
- タイトル、本文、タグが反映されている
- 独自サムネイルが表示される
- 本文内にもサムネイルが表示される

6. WIP一覧をAPIから取得する
```bash
$ curl -s \
  'http://localhost:3000/api/articles.json?wip=true' \
  -H "Authorization: Bearer $TOKEN" |
  jq
```
作成した記事が一覧に含まれることを確認する

7. WIPを公開する
```bash
$ curl -s \
  -X PATCH "http://localhost:3000/api/articles/$ARTICLE_ID.json" \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "article": {
      "wip": false
    }
  }' |
  jq
```
ブラウザで通常の記事一覧（`http://localhost:3000/articles`）と詳細（`http://localhost:3000/articles/{ARTICLE_ID}`）を確認する

8. Articleを更新する
```bash
$ curl -s \
  -X PATCH "http://localhost:3000/api/articles/$ARTICLE_ID.json" \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{
    "article": {
      "title": "APIから更新した記事",
      "body": "Ruby on Railsでは、Strong Parametersを使用してコントローラーが受け取る属性を制限できます。params.requireで対象を指定し、permitで更新を許可する属性を列挙します。これにより、意図しない属性の一括更新を防止できます。",
      "tag_list": ["API", "更新確認"]
    }
  }' |
  jq
```
ブラウザを再読み込みし、タイトルと本文とタグが反映されることを確認する

9. 概要を生成
作成した記事のbodyを取り出す
```bash
$ ARTICLE_BODY=$(
  curl -s \
    "http://localhost:3000/api/articles/${ARTICLE_ID}.json" \
    -H "Authorization: Bearer $TOKEN" |
  jq -r '.body'
)
```
概要をAI生成する
```bash
$ SUMMARY=$(
  jq -n --arg body "$ARTICLE_BODY" '{ body: $body }' |
  curl -s \
    -X POST http://localhost:3000/api/articles/summary.json \
    -H "Authorization: Bearer $TOKEN" \
    -H 'Content-Type: application/json' \
    --data-binary @- |
  jq -r '.summary'
)
```
概要を確認する
```bash
$ printf '%s\n' "$SUMMARY"
```
概要を更新する
```bash
$ jq -n --arg summary "$SUMMARY" \
  '{ article: { summary: $summary } }' |
curl -s \
  -X PATCH "http://localhost:3000/api/articles/$ARTICLE_ID.json" \
  -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  --data-binary @- |
jq
```
ブラウザの検証画面からmeta descriptionが生成したサマリーになっていることを確認する

10. 未ログイン時の拒否
```bash
$ curl -i http://localhost:3000/api/articles.json
```
`401 Unauthorized`になることを確認する

11. Articleを削除
```bash
$ curl -i \
  -X DELETE "http://localhost:3000/api/articles/$ARTICLE_ID.json" \
  -H "Authorization: Bearer $TOKEN"
```
`204 No Content`になり、画面をリロードすると記事が表示されなくなることを確認する

## Screenshot
画面の変更はありません。

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新機能**
  - 記事の一覧／詳細、作成、更新、削除に対応した記事APIを追加しました（タグ絞り込み・ページング対応）。
  - 下書き（WIP）管理や公開設定、サムネイル添付・置換、表示設定を反映したJSONを提供します。
  - 記事本文からサマリー生成を行うAPIを追加しました。
- **権限・品質改善**
  - 管理者／メンター向け操作権限と、WIP閲覧・トークン要件の制御を強化しました。
  - 入力不備や生成失敗時に適切なJSONエラーを返します。
- **テスト**
  - 記事API統合テストを追加し、主要シナリオを網羅しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30237842849/artifacts/8642392064" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10287-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
