### PR TITLE
サムネイルのバックフィル処理をcloudbuildのoneshotタスク内で実行するよう変更

### DIFF
--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -57,13 +57,9 @@ namespace :bootcamp do
       puts '== START Cloud Build Task =='
 
       Rake::Task['smart_search:generate_all'].invoke
+      BulkGenerateMovieThumbnailJob.perform_now
 
       puts '== END   Cloud Build Task =='
-    end
-
-    desc 'Backfill thumbnails for existing movies'
-    task backfill_movie_thumbnails: :environment do
-      BulkGenerateMovieThumbnailJob.perform_now
     end
   end
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/pull/10257

## 概要
こちらのPRの追加修正です。
前回のPRで実装した処理を、既存のoneshotの処理に含めました。
<!-- I want to review in Japanese. -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29467500206/artifacts/8363667708" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10295-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * Cloud Buildタスクの実行時に、動画サムネイルを同期生成するようになりました。
  * サムネイル生成の完了後にタスクが終了するため、処理結果を確認しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->