### PR TITLE
checks.ymlのproductのスペルミスを修正

### DIFF
--- a/db/fixtures/checks.yml
+++ b/db/fixtures/checks.yml
@@ -22,22 +22,22 @@ report7_check_machida:
   user: machida
   checkable: report7 (Report)
 
-procuct2_check_komagata:
+product2_check_komagata:
   user: komagata
   checkable: product2 (Product)
 
-procuct3_check_komagata:
+product3_check_komagata:
   user: komagata
   checkable: product3 (Product)
 
-procuct4_check_komagata:
+product4_check_komagata:
   user: komagata
   checkable: product4 (Product)
 
-procuct7_check_komagata:
+product7_check_komagata:
   user: komagata
   checkable: product7 (Product)
 
-procuct9_check_komagata:
+product9_check_komagata:
   user: komagata
   checkable: product9 (Product)

--- a/test/deliveries/activity_delivery_test.rb
+++ b/test/deliveries/activity_delivery_test.rb
@@ -40,7 +40,7 @@ class ActivityDeliveryTest < ActiveSupport::TestCase
   end
 
   test '.notify(:checked)' do
-    check = checks(:procuct2_check_komagata)
+    check = checks(:product2_check_komagata)
     params = {
       check:,
       receiver: check.receiver

--- a/test/fixtures/checks.yml
+++ b/test/fixtures/checks.yml
@@ -22,30 +22,30 @@ report7_check_machida:
   user: machida
   checkable: report7 (Report)
 
-procuct2_check_komagata:
+product2_check_komagata:
   user: komagata
   checkable: product2 (Product)
 
-procuct3_check_komagata:
+product3_check_komagata:
   user: komagata
   checkable: product3 (Product)
 
-procuct4_check_komagata:
+product4_check_komagata:
   user: komagata
   checkable: product4 (Product)
 
-procuct7_check_komagata:
+product7_check_komagata:
   user: komagata
   checkable: product7 (Product)
 
-procuct9_check_komagata:
+product9_check_komagata:
   user: komagata
   checkable: product9 (Product)
 
-procuct67_check_long-id-mentor:
+product67_check_long-id-mentor:
   user: long-id-mentor
   checkable: product67 (Product)
 
-procuct75_check_komagata:
+product75_check_komagata:
   user: komagata
   checkable: product75 (Product)

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -403,7 +403,7 @@ class ActivityMailerTest < ActionMailer::TestCase
   end
 
   test 'checked' do
-    check = checks(:procuct2_check_komagata)
+    check = checks(:product2_check_komagata)
 
     ActivityMailer.checked(
       sender: check.sender,
@@ -420,7 +420,7 @@ class ActivityMailerTest < ActionMailer::TestCase
   end
 
   test 'trainee and advisers receive different wording in their acceptance emails' do
-    check = checks(:procuct75_check_komagata)
+    check = checks(:product75_check_komagata)
 
     ActivityMailer.checked(
       sender: check.sender,
@@ -455,7 +455,7 @@ class ActivityMailerTest < ActionMailer::TestCase
   end
 
   test 'checked with params' do
-    check = checks(:procuct2_check_komagata)
+    check = checks(:product2_check_komagata)
 
     mailer = ActivityMailer.with(
       sender: check.sender,
@@ -476,7 +476,7 @@ class ActivityMailerTest < ActionMailer::TestCase
   end
 
   test 'checked with user who have been denied' do
-    check = checks(:procuct2_check_komagata)
+    check = checks(:product2_check_komagata)
     ActivityMailer.checked(
       sender: check.sender,
       receiver: users(:hajime),

--- a/test/mailers/previews/activity_mailer_preview.rb
+++ b/test/mailers/previews/activity_mailer_preview.rb
@@ -21,7 +21,7 @@ class ActivityMailerPreview < ActionMailer::Preview
   end
 
   def checked
-    check = Check.find(ActiveRecord::FixtureSet.identify(:procuct2_check_komagata))
+    check = Check.find(ActiveRecord::FixtureSet.identify(:product2_check_komagata))
     ActivityMailer.with(receiver: check.receiver, check:).checked
   end
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- [](https://github.com/orgs/fjordllc/projects/7/views/1?filterQuery=assignee%3Amikan-v7y&pane=issue&itemId=164315391&issue=fjordllc%7Cbootcamp%7C9775) #9775 

## 概要

`checks.yml` 内の `product` のスペルミスを修正しました。

## 変更確認方法

1. `chore/fix-product-typo`をローカルに取り込む
2. `checks.yml` を開く
3.  `product` のスペルが正しく修正されていることを確認する

## Screenshot

テストコードのみの変更のため、スクリーンショットは省略します。

### 変更前

```
procuct2_check_komagata:
```

### 変更後

```
product2_check_komagata:
```

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * プロダクト関連チェックの名称にあった綴りミス（`procuct` → `product`）を修正しました。
  * これにより、対象のチェック定義が正しい名称で認識され、関連する通知・メールのテストおよびプレビューで正しいデータが参照されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29470860764/artifacts/8364896982" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10296-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->