### PR TITLE
HTMLのセマンティック化（第一弾: reports/show・users/show）

### DIFF
--- a/app/views/admin/_admin_page_tabs.html.slim
+++ b/app/views/admin/_admin_page_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.page-tabs
+nav.page-tabs aria-label="管理者メニュー"
   .container
     ul.page-tabs__items
       li.page-tabs__item

--- a/app/views/admin/corporate_training_inquiries/_inquiries_item.html.slim
+++ b/app/views/admin/corporate_training_inquiries/_inquiries_item.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__rows
       .card-list-item__row

--- a/app/views/admin/corporate_training_inquiries/show.html.slim
+++ b/app/views/admin/corporate_training_inquiries/show.html.slim
@@ -26,7 +26,7 @@ main.page-main
   hr.a-border
   .page-body
     .container.is-md
-      .page-content
+      article.page-content
         header.page-content-header
           .page-content-header__end
             .page-content-header__row

--- a/app/views/admin/corporate_training_inquiries/show.html.slim
+++ b/app/views/admin/corporate_training_inquiries/show.html.slim
@@ -40,7 +40,7 @@ main.page-main
                       span.a-meta__label 受信日
                       span.a-meta__value = l @corporate_training_inquiry.created_at
         .page-content__body
-          .a-card
+          section.a-card
             header.card-header
               h2.card-header__title
                 | お問い合わせ元情報
@@ -58,7 +58,7 @@ main.page-main
                           | （担当者: #{@corporate_training_inquiry.name}様）
                           br
                           = @corporate_training_inquiry.email
-          .a-card
+          section.a-card
             header.card-header
               h2.card-header__title
                 | 研修打ち合わせ希望日時
@@ -85,7 +85,7 @@ main.page-main
                       .a-short-text
                         p
                           = l @corporate_training_inquiry.meeting_date3
-          .a-card
+          section.a-card
             header.card-header
               h2.card-header__title
                 | 現時点での研修の希望
@@ -120,7 +120,7 @@ main.page-main
                         = CorporateTrainingInquiry.human_attribute_name(:additional_information)
                       .a-short-text
                         = simple_format(@corporate_training_inquiry.additional_information)
-          .a-card
+          section.a-card
             header.card-header
               h2.card-header__title
                 | アンケート

--- a/app/views/admin/embedding_status/index.html.slim
+++ b/app/views/admin/embedding_status/index.html.slim
@@ -80,7 +80,7 @@ main.page-main
                 .completed-practices-progress__number
                   = "#{@total_stats[:with_embedding]} / #{@total_stats[:total]}"
 
-      .a-card.mt-8
+      section.a-card.mt-8
         header.card-header
           h2.card-header__title
             | Embedding生成コマンド

--- a/app/views/admin/faqs/_faq_tabs.html.slim
+++ b/app/views/admin/faqs/_faq_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="FAQ管理"
   .container
     ul.tab-nav__items
       li.tab-nav__item

--- a/app/views/admin/faqs/show.html.slim
+++ b/app/views/admin/faqs/show.html.slim
@@ -48,7 +48,7 @@ main.page-main
                         = link_to admin_faq_category_faqs_path(@faq.faq_category) do
                           = t("faq.#{FAQCategory.find_by(id: @faq.faq_category_id).name}")
 
-          .a-card
+          article.a-card
             .card-body
               .card-body__description
                 .a-long-text.js-markdown-view

--- a/app/views/admin/faqs/show.html.slim
+++ b/app/views/admin/faqs/show.html.slim
@@ -62,7 +62,7 @@ main.page-main
                       i.fa-solid.fa-pen
                       | 内容修正
 
-      nav.a-side-nav
+      nav.a-side-nav aria-label="同じカテゴリのFAQ"
         .a-side-nav__inner
           header.a-side-nav__header
             h2.a-side-nav__title

--- a/app/views/admin/faqs/show.html.slim
+++ b/app/views/admin/faqs/show.html.slim
@@ -54,7 +54,7 @@ main.page-main
                 .a-long-text.js-markdown-view
                   = @faq.answer
             hr.a-border-tint
-            .card-footer
+            footer.card-footer
               .card-main-actions
                 .card-main-actions__items
                   .card-main-actions__item

--- a/app/views/admin/faqs/show.html.slim
+++ b/app/views/admin/faqs/show.html.slim
@@ -26,7 +26,7 @@ main.page-main
   .page-body
     .page-body__inner.has-side-nav
       .container.is-md
-        .page-content
+        article.page-content
           header.page-content-header
             .page-content-header__end
               .page-content-header__row

--- a/app/views/admin/grant_course_applications/_grant_course_application.html.slim
+++ b/app/views/admin/grant_course_applications/_grant_course_application.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__rows
       .card-list-item__row

--- a/app/views/admin/grant_course_applications/show.html.slim
+++ b/app/views/admin/grant_course_applications/show.html.slim
@@ -24,7 +24,7 @@ main.page-main
   hr.a-border
   .page-body
     .container.is-md
-      .page-content
+      article.page-content
         header.page-content-header
           .page-content-header__end
             .page-content-header__row

--- a/app/views/admin/grant_course_applications/show.html.slim
+++ b/app/views/admin/grant_course_applications/show.html.slim
@@ -38,7 +38,7 @@ main.page-main
                       span.a-meta__label 受信日
                       span.a-meta__value = l @grant_course_application.created_at
         .page-content__body
-          .a-card
+          section.a-card
             .card-body
               .card-body__description
                 .a-long-text.is-md

--- a/app/views/admin/inquiries/_inquiries_item.html.slim
+++ b/app/views/admin/inquiries/_inquiries_item.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner.position-relative
     - if inquiry.action_completed?
       .stamp.stamp-approve

--- a/app/views/admin/inquiries/show.html.slim
+++ b/app/views/admin/inquiries/show.html.slim
@@ -25,7 +25,7 @@ main.page-main
   hr.a-border
   .page-body
     .container.is-md
-      .page-content
+      article.page-content
         header.page-content-header
           - if @inquiry.action_completed?
             .stamp.stamp-approve

--- a/app/views/admin/inquiries/show.html.slim
+++ b/app/views/admin/inquiries/show.html.slim
@@ -48,7 +48,7 @@ main.page-main
                       span.a-meta__label 受信日
                       span.a-meta__value = l @inquiry.created_at
         .page-content__body
-          .a-card
+          article.a-card
             .card-body
               .card-body__description
                 .a-long-text.is-md

--- a/app/views/admin/users/_table.html.slim
+++ b/app/views/admin/users/_table.html.slim
@@ -136,7 +136,7 @@
             = link_to edit_admin_user_path(user), id: "edit-#{user.id}", class: 'a-button is-sm is-secondary is-icon' do
               i.fa-solid.fa-pen
 
-.a-card
+section.a-card
   header.card-header
     h2.card-header__title
       | 全員のメアド

--- a/app/views/admin/users/_user_tabs.html.slim
+++ b/app/views/admin/users/_user_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="管理ユーザー絞り込み"
   .container
     ul.tab-nav__items
       li.tab-nav__item

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -20,7 +20,7 @@ header.page-header
     = render 'users/form', from: :edit, url: [:admin, @user], user: @user
   hr.a-border-tint
   footer.auth-form__footer
-    nav.auth-form-nav
+    nav.auth-form-nav aria-label="ユーザー管理関連リンク"
       ul.auth-form-nav__items
         li.auth-form-nav__item
           = link_to 'トップページ', root_path, class: 'auth-form-nav__item-link'

--- a/app/views/announcements/_announcement.html.slim
+++ b/app/views/announcements/_announcement.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: announcement.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'

--- a/app/views/announcements/_recent_announcements.html.slim
+++ b/app/views/announcements/_recent_announcements.html.slim
@@ -1,4 +1,4 @@
-.a-side-nav
+nav.a-side-nav aria-label="最新のお知らせ"
   .a-side-nav__inner
     header.a-side-nav__header
       h2.a-side-nav__title

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -58,7 +58,7 @@ hr.a-border
                   .page-content-header-actions__action
                     = link_to '複製', new_announcement_path(id: @announcement), class: 'a-button is-sm is-secondary is-block', id: 'copy'
 
-        .a-card
+        article.a-card
           .card-body
             .card-body__description
               .a-long-text.is-md.js-markdown-view

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -66,7 +66,7 @@ hr.a-border
           hr.a-border-tint
           = render 'reactions/reactions', reactionable: @announcement
           hr.a-border-tint
-          .card-footer
+          footer.card-footer
             .card-main-actions
               ul.card-main-actions__items(class="#{@announcement.published_at ? 'is-sub-actions' : ''}")
                 - if @announcement.published_at

--- a/app/views/application/_global_nav.slim
+++ b/app/views/application/_global_nav.slim
@@ -1,4 +1,4 @@
-nav.global-nav
+nav.global-nav aria-label="メインナビゲーション"
   .global-nav__inner
     .global-nav-links
       ul.global-nav-links__items

--- a/app/views/application/footer/_footer.html.slim
+++ b/app/views/application/footer/_footer.html.slim
@@ -2,7 +2,7 @@ hr.a-border
 footer.footer
   .container
     .footer__inner
-      nav.footer-nav
+      nav.footer-nav aria-label="フッターナビゲーション"
         ul.footer-nav__items
           li.footer-nav__item
             = link_to welcome_path, class: 'footer-nav__item-link', target: '_blank', rel: 'noopener' do

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -5,7 +5,7 @@ header.lp-page-header
         h1.lp-page-header__title
           = title
       .lp-page-header__end
-        nav.lp-page-header-nav
+        nav.lp-page-header-nav aria-label="ブログメニュー"
           ul.lp-page-header-nav__items
             - if current_user&.mentor?
               .lp-page-header-nav__item
@@ -27,7 +27,7 @@ header.lp-page-header
       hr.a-border
     .articles__body
       - if current_user&.admin_or_mentor_login?
-        nav.pill-nav.mb-8
+        nav.pill-nav.mb-8 aria-label="記事公開状態"
           .pill-nav__items
             .pill-nav__item
               = link_to articles_path, class: "pill-nav__item-link#{is_published ? ' is-active' : ''}" do

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -41,7 +41,7 @@ header.lp-page-header
           .row
             - articles.each do |article|
               .col-lg-4.col-md-6.col-xs-12
-                .thumbnail-card.a-card class=(article.wip? ? ' is-wip' : '')
+                article.thumbnail-card.a-card class=(article.wip? ? ' is-wip' : '')
                   = link_to article, class: 'thumbnail-card__inner' do
                     - if current_user&.admin_or_mentor_login? && feature_tag?(article)
                       .tags-highlight

--- a/app/views/articles/_articles.html.slim
+++ b/app/views/articles/_articles.html.slim
@@ -67,12 +67,14 @@ header.lp-page-header
                             = image_tag article.user.avatar_url
                             = article.user.login_name
                         .thumbnail-card__meta
-                          .thumbnail-card__date
-                            - if article.wip?
-                              = '執筆中'
-                            - elsif article.published_at.nil?
+                          - if article.wip?
+                            .thumbnail-card__date
+                              | 執筆中
+                          - elsif article.published_at.nil?
+                            time.thumbnail-card__date datetime=article.created_at.iso8601
                               = l(article.created_at)
-                            - else
+                          - else
+                            time.thumbnail-card__date datetime=article.published_at.iso8601
                               = l(article.published_at)
                     .thumbnail-card__row
                       .a-tags

--- a/app/views/articles/_recent_articles.html.slim
+++ b/app/views/articles/_recent_articles.html.slim
@@ -6,7 +6,7 @@ aside.a-card
   nav.card-list
     .card-list__items.is-md-only-2-items
       - @recent_articles.each do |recent_article|
-        .card-list-item
+        article.card-list-item
           = link_to recent_article, class: 'card-list-item__inner' do
             .card-list-item__thumbnail
               .card-list-item__thumbnail-inner

--- a/app/views/articles/_recent_articles.html.slim
+++ b/app/views/articles/_recent_articles.html.slim
@@ -3,7 +3,7 @@ aside.a-card
     h2.card-header__title
       | 最新記事
   hr.a-border-tint
-  nav.card-list
+  nav.card-list aria-label="最新記事"
     .card-list__items.is-md-only-2-items
       - @recent_articles.each do |recent_article|
         article.card-list-item

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -21,7 +21,7 @@ header.lp-page-header
         .lp-page-header__title
           | ブログ
       .lp-page-header__end
-        nav.lp-page-header-nav
+        nav.lp-page-header-nav aria-label="ブログメニュー"
           ul.lp-page-header-nav__items
             .lp-page-header-nav__item
               = link_to articles_path, class: 'a-button is-md is-secondary-border is-block is-back' do

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -100,7 +100,7 @@ hr.a-border-tint
                       | フィヨルドブートキャンプへ
             - if admin_or_mentor_login?
               hr.a-border
-              .card-footer
+              footer.card-footer
                 .card-main-actions
                   ul.card-main-actions__items
                     li.card-main-actions__item

--- a/app/views/books/_book.html.slim
+++ b/app/views/books/_book.html.slim
@@ -1,5 +1,5 @@
 .col-xxxl-2.col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .card-books-item.a-card
+  article.card-books-item.a-card
     .card-books-item__body
       .card-books-item__inner
         .card-books-item__start

--- a/app/views/books/index.html.slim
+++ b/app/views/books/index.html.slim
@@ -17,7 +17,7 @@ header.page-header
                   span
                     | 参考書籍登録
 hr.a-border
-nav.page-filter.form
+nav.page-filter.form aria-label="書籍絞り込み"
   .container.is-md
     = form_with url: books_path, local: true, method: 'get' do
       .form-item.is-inline-md-up

--- a/app/views/coding_tests/coding_test_submissions/_coding_test_submission.html.slim
+++ b/app/views/coding_tests/coding_test_submissions/_coding_test_submission.html.slim
@@ -1,7 +1,7 @@
 - cts = coding_test_submission
 - coding_test = cts.coding_test
 
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon',

--- a/app/views/coding_tests/coding_test_submissions/show.html.slim
+++ b/app/views/coding_tests/coding_test_submissions/show.html.slim
@@ -28,7 +28,7 @@ ruby:
   hr.a-border
 
   .page-body
-    .page-content
+    article.page-content
       .container.is-md
         header.page-content-header
           .page-content-header__start

--- a/app/views/coding_tests/coding_test_submissions/show.html.slim
+++ b/app/views/coding_tests/coding_test_submissions/show.html.slim
@@ -57,7 +57,7 @@ ruby:
                       time.a-meta__value datetime=cts.created_at.iso8601
                         = l cts.created_at
 
-        .a-card
+        article.a-card
           .card-body
             .card-body__description
               .a-long-text

--- a/app/views/coding_tests/show.html.slim
+++ b/app/views/coding_tests/show.html.slim
@@ -51,7 +51,7 @@ ruby:
                     h1.page-content-header__title
                       = @coding_test.title
 
-              .a-card
+              section.a-card
                 header.card-header
                   h2.card-header__title
                     = CodingTest.human_attribute_name :description
@@ -62,7 +62,7 @@ ruby:
                       = @coding_test.description
 
               - @coding_test.coding_test_cases.each_with_index do |coding_test_case, i|
-                .a-card.overflow-y-hidden
+                section.a-card.overflow-y-hidden
                   header.card-header.is-sm
                     h2.card-header__title
                       = "入力・出力例#{i + 1}"
@@ -89,7 +89,7 @@ ruby:
                                 = coding_test_case.output
 
               - if current_user.submitted?(@coding_test)
-                .a-card
+                section.a-card
                   header.card-header
                     h2.card-header__title
                       | 自分の回答
@@ -101,7 +101,7 @@ ruby:
                           code
                             = current_user.coding_test_submissions.find_by(coding_test: @coding_test).code
               - else
-                .a-card
+                section.a-card
                   header.card-header.is-sm
                     h2.card-header__title
                       | 回答を入力
@@ -121,7 +121,7 @@ ruby:
                           button#run.a-button.is-md.is-primary.is-block
                             | 実行
 
-                .a-card
+                section.a-card
                   header.card-header
                     h2.card-header__title
                       | 結果
@@ -130,7 +130,7 @@ ruby:
                       table.result-table#result
 
               - if current_user.admin_or_mentor?
-                .a-card.is-only-mentor
+                aside.a-card.is-only-mentor
                   header.card-header.is-sm
                     h2.card-header__title 管理者・メンター用メニュー
                   hr.a-border-tint

--- a/app/views/coding_tests/show.html.slim
+++ b/app/views/coding_tests/show.html.slim
@@ -147,7 +147,7 @@ ruby:
                             | みんなのコード
 
           .col-lg-3.col-xs-12
-            nav.page-nav.a-card
+            nav.page-nav.a-card aria-label="同じプラクティスのコーディングテスト"
               header.page-nav__header
                 h2.page-nav__title
                   = link_to @practice,

--- a/app/views/coding_tests/show.html.slim
+++ b/app/views/coding_tests/show.html.slim
@@ -27,7 +27,7 @@ ruby:
   hr.a-border
 
   .page-body
-    .page-content
+    article.page-content
 
       - if current_user.submitted?(@coding_test)
         .a-page-notice

--- a/app/views/comeback/new.html.slim
+++ b/app/views/comeback/new.html.slim
@@ -17,7 +17,7 @@
       = render 'form', user: @user
     hr.a-border-tint
     footer.auth-form__footer
-      nav.auth-form-nav
+      nav.auth-form-nav aria-label="休会復帰関連リンク"
         ul.auth-form-nav__items
           li.auth-form-nav__item
             = link_to 'トップページ', root_path,

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,4 +1,4 @@
-.thread-comment.comment.is-hidden class=" #{'is-latest' if latest_comment?(comment, latest_comment)}" id="comment_#{comment.id}" data-comment_id="#{comment.id}" data-comment_description="#{comment.description}"
+article.thread-comment.comment.is-hidden class=" #{'is-latest' if latest_comment?(comment, latest_comment)}" id="comment_#{comment.id}" data-comment_id="#{comment.id}" data-comment_description="#{comment.description}"
   #latest-comment
   .thread-comment__start
     a.thread-comment__user-link href="#{comment.user.url}"

--- a/app/views/companies/_company.html.slim
+++ b/app/views/companies/_company.html.slim
@@ -1,5 +1,5 @@
 .col-xxxl-2.col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .companies-item
+  article.companies-item
     .companies-item__inner.a-card
       header.companies-item__header
         .companies-item__header-inner

--- a/app/views/companies/_links.html.slim
+++ b/app/views/companies/_links.html.slim
@@ -1,4 +1,4 @@
-nav.company-links
+nav.company-links aria-label="企業関連リンク"
   ul.company-links__items
     - if company.website?
       li.company-links__item

--- a/app/views/companies/_tabs.html.slim
+++ b/app/views/companies/_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.page-tabs
+nav.page-tabs aria-label="企業情報"
   .container
     ul.page-tabs__items
       li.page-tabs__item

--- a/app/views/companies/products/_company-products.html.slim
+++ b/app/views/companies/products/_company-products.html.slim
@@ -8,10 +8,10 @@
           | #{data_title}はありません
   - else
     .container.is-md
-      nav.pagination
+      .pagination
         = paginate products
       .card-list.a-card
         .card-list__items
           = render products, commented_users:
-      nav.pagination
+      .pagination
         = paginate products

--- a/app/views/companies/products/_product.html.slim
+++ b/app/views/companies/products/_product.html.slim
@@ -1,4 +1,4 @@
-.card-list-item class="#{product.wip ? 'is-wip' : 'has-assigned'}"
+article.card-list-item class="#{product.wip ? 'is-wip' : 'has-assigned'}"
   .card-list-item__inner
     .card-list-item__rows
       .card-list-item__row

--- a/app/views/companies/users/_user.html.slim
+++ b/app/views/companies/users/_user.html.slim
@@ -1,5 +1,5 @@
 .col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .users-item
+  article.users-item
     .users-item__inner.a-card
       - if current_user.mentor || current_user.admin && user.student_or_trainee
         .users-item__inactive-message-container.is-only-mentor

--- a/app/views/companies/users/_users_tabs.html.slim
+++ b/app/views/companies/users/_users_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="企業ユーザー絞り込み"
   .container
     ul.tab-nav__items
         - Companies::UsersController::ALLOWED_TARGETS.each do |target|

--- a/app/views/corporate_training_inquiries/complete.html.slim
+++ b/app/views/corporate_training_inquiries/complete.html.slim
@@ -10,7 +10,7 @@ description: '企業研修のお申し込みありがとうございます。')
         | 企業研修のお申し込み
         br
         | ありがとうございます。
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           p

--- a/app/views/corporate_training_inquiries/created.html.slim
+++ b/app/views/corporate_training_inquiries/created.html.slim
@@ -21,7 +21,7 @@ ruby:
         | 企業研修のお申し込み
         br
         | ありがとうございます。
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           p

--- a/app/views/corporate_training_inquiries/new.html.slim
+++ b/app/views/corporate_training_inquiries/new.html.slim
@@ -11,7 +11,7 @@ ruby:
   .auth-form__body
     = render 'form', corporate_training_inquiry: @corporate_training_inquiry
   footer.auth-form__footer
-    nav.auth-form-nav
+    nav.auth-form-nav aria-label="企業研修問い合わせ関連リンク"
       ul.auth-form-nav__items
         li.auth-form-nav__item
           = link_to 'トップページ', welcome_path, class: 'auth-form-nav__item-link'

--- a/app/views/courses/_course.html.slim
+++ b/app/views/courses/_course.html.slim
@@ -1,5 +1,5 @@
 .col-xxxl-2.col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .courses-item(id="course_#{course.id}" class="#{course.published ? 'is-published' : 'is-closed'}")
+  article.courses-item(id="course_#{course.id}" class="#{course.published ? 'is-published' : 'is-closed'}")
     .courses-item__inner.a-card
       header.courses-item__header
         h3.courses-item__title

--- a/app/views/courses/books/index.html.slim
+++ b/app/views/courses/books/index.html.slim
@@ -21,7 +21,7 @@ header.page-header
 
 .page-body
   .container.is-md
-    nav.pill-nav
+    nav.pill-nav aria-label="書籍表示対象"
       .container
         ul.pill-nav__items
           li.pill-nav__item

--- a/app/views/courses/books/index.html.slim
+++ b/app/views/courses/books/index.html.slim
@@ -37,7 +37,7 @@ header.page-header
               .row
                 - @books.each do |book|
                   .col-xxxl-2.col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-                    .card-books-item.a-card
+                    article.card-books-item.a-card
                       .card-books-item__body
                         .card-books-item__inner
                           .card-books-item__start

--- a/app/views/courses/practices/_courses_practice.html.slim
+++ b/app/views/courses/practices/_courses_practice.html.slim
@@ -1,4 +1,4 @@
-.category-practices-item(class="#{skipped_practices.include?(practice.id) ? 'is-skip-on' : ''}")
+article.category-practices-item(class="#{skipped_practices.include?(practice.id) ? 'is-skip-on' : ''}")
   a.category-practices-item__anchor :id="practice_#{practice.id}"
   header.category-practices-item__header
     .category-practices-item__title

--- a/app/views/courses/practices/_courses_practices.html.slim
+++ b/app/views/courses/practices/_courses_practices.html.slim
@@ -22,7 +22,7 @@
                 - category.practices.each do |practice|
                   == render 'courses_practice', practice: practice, learnings: learnings, skipped_practices: skipped_practices
     .page-body__column.is-sub
-      nav.page-nav.a-card
+      nav.page-nav.a-card aria-label="プラクティスカテゴリー"
         ul.page-nav__items
           - categories.each do |category|
             - if category.practices.present?

--- a/app/views/current_user/bookmarks/_list.html.slim
+++ b/app/views/current_user/bookmarks/_list.html.slim
@@ -22,7 +22,7 @@ hr.a-border
     .card-list.a-card
       .card-list__items
         - bookmarks.each do |bookmark|
-          .card-list-item class="is-#{bookmark.bookmarkable_type.downcase}" id="bookmark-#{bookmark.id}"
+          article.card-list-item class="is-#{bookmark.bookmarkable_type.downcase}" id="bookmark-#{bookmark.id}"
             .card-list-item__inner
               - if bookmark.bookmarkable_type == 'Talk'
                 = image_tag bookmark.bookmarkable.user.avatar_url, class: 'card-list-item__user-icon a-user-icon'

--- a/app/views/current_user/edit.html.slim
+++ b/app/views/current_user/edit.html.slim
@@ -18,7 +18,7 @@ hr.a-border
       = render 'users/form', from: :edit, url: current_user_path, user: @user
     hr.a-border-tint
     footer.auth-form__footer
-      nav.auth-form-nav
+      nav.auth-form-nav aria-label="ユーザー情報変更関連リンク"
         ul.auth-form-nav__items
           li.auth-form-nav__item
             - if @user.trainee?

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -43,7 +43,7 @@ article.event.page-content
   = render('event_meta', event:)
 
   section.a-card
-    .card-header.is-sm
+    header.card-header.is-sm
       h2.card-header__title
         | イベント内容
     hr.a-border-tint
@@ -57,7 +57,7 @@ article.event.page-content
     = render 'reactions/reactions', reactionable: event
     - if event.user_id == current_user.id || admin_or_mentor_login?
       hr.a-border-tint
-      .card-footer
+      footer.card-footer
         .card-main-actions
           ul.card-main-actions__items
             li.card-main-actions__item

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -1,4 +1,4 @@
-.event.page-content
+article.event.page-content
   header.page-content-header
     .page-content-header__end
       a.a-count-badge(href='#comments')
@@ -42,7 +42,7 @@
 
   = render('event_meta', event:)
 
-  .a-card
+  section.a-card
     .card-header.is-sm
       h2.card-header__title
         | イベント内容
@@ -69,7 +69,7 @@
                 | 削除する
 
   - unless event.wip?
-    .a-card.participants
+    section.a-card.participants
       header.card-header.is-sm
         h2.card-header__title
           = event_participant_count(event)
@@ -91,7 +91,7 @@
                 | 参加者はまだいません。
 
   - if event.waitlist.count.positive?
-    .a-card.waitlist
+    section.a-card.waitlist
       header.card-header.is-sm
         h2.card-header__title
           = event_waitlist_count(event)

--- a/app/views/events/_event_meta.html.slim
+++ b/app/views/events/_event_meta.html.slim
@@ -1,4 +1,4 @@
-.event-meta.a-card
+aside.event-meta.a-card
   .event-meta__inner
     dl.event-meta__items
       .event-meta__item

--- a/app/views/events/_upcoming_event.html.slim
+++ b/app/views/events/_upcoming_event.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     - if event.held_on_scheduled_date?
       .card-list-item__label(class = event.label_style)

--- a/app/views/events/_upcoming_events_groups.html.slim
+++ b/app/views/events/_upcoming_events_groups.html.slim
@@ -1,4 +1,4 @@
-.a-side-nav.upcoming_events_groups
+nav.a-side-nav.upcoming_events_groups aria-label="近日開催のイベント"
   .a-side-nav__inner
     header.a-side-nav__header
       h2.a-side-nav__title

--- a/app/views/external_entries/_external_entry.html.slim
+++ b/app/views/external_entries/_external_entry.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render('users/icon', user: external_entry.user, image_class: 'card-list-item__user-icon')

--- a/app/views/generations/_user.html.slim
+++ b/app/views/generations/_user.html.slim
@@ -1,5 +1,5 @@
 .col-xxxl-2.col-xxl-3.col-xl-4.col-lg-4.col-md-6.col-xs-12
-  .users-item
+  article.users-item
     .users-item__inner.a-card
       - if current_user&.admin_or_mentor? && user.student_or_trainee?
         .users-item__inactive-message-container.is-only-mentor

--- a/app/views/generations/_users_tabs.html.slim
+++ b/app/views/generations/_users_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="期生別ユーザー絞り込み"
   .container
     ul.tab-nav__items
       - targets = %w[all trainee adviser graduate mentor]

--- a/app/views/generations/index.html.slim
+++ b/app/views/generations/index.html.slim
@@ -35,7 +35,7 @@ main.page-main
           - @generations.each do |generation|
             - users = Generation.new(generation.number).target_users(@target)
             - if !users.empty?
-              .a-card
+              article.a-card
                 .user-group
                   header.user-group__header
                     h2.user-group__title

--- a/app/views/grant_course_applications/created.html.slim
+++ b/app/views/grant_course_applications/created.html.slim
@@ -16,7 +16,7 @@ ruby:
     .thanks-message__header
       h1.thanks-message__title
         = title
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           p

--- a/app/views/grant_course_applications/new.html.slim
+++ b/app/views/grant_course_applications/new.html.slim
@@ -21,7 +21,7 @@ ruby:
     = render 'form', grant_course_application: @grant_course_application
   hr.a-border-tint
   footer.auth-form__footer
-    nav.auth-form-nav
+    nav.auth-form-nav aria-label="受講申請関連リンク"
       ul.auth-form-nav__items
         li.auth-form-nav__item
           = link_to 'トップページ', welcome_path, class: 'auth-form-nav__item-link'

--- a/app/views/hibernation/_message.html.slim
+++ b/app/views/hibernation/_message.html.slim
@@ -1,4 +1,4 @@
-.important-message
+aside.important-message
   header.important-message__header
     h2.important-message__title
       | 休会についての注意

--- a/app/views/hibernation/show.html.slim
+++ b/app/views/hibernation/show.html.slim
@@ -7,7 +7,7 @@ description: '休会手続きが完了しました。')
     .thanks-message__header
       h1.thanks-message__title
         | 休会手続きが完了しました。
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           p

--- a/app/views/home/_adviser_company_edit.html.slim
+++ b/app/views/home/_adviser_company_edit.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title 企業情報変更
   hr.a-border-tint

--- a/app/views/home/_adviser_help.html.slim
+++ b/app/views/home/_adviser_help.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title アドバイザーヘルプ
   hr.a-border-tint

--- a/app/views/home/_adviser_talk.html.slim
+++ b/app/views/home/_adviser_talk.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title FBC運営への連絡
   hr.a-border-tint

--- a/app/views/home/_after_graduation_hope.html.slim
+++ b/app/views/home/_after_graduation_hope.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 卒業後のゴール

--- a/app/views/home/_after_graduation_hope.html.slim
+++ b/app/views/home/_after_graduation_hope.html.slim
@@ -8,7 +8,7 @@ section.a-card
       .a-long-text.is-md
         = simple_format(user.after_graduation_hope)
   hr.a-border-tint
-  .card-footer
+  footer.card-footer
     .card-footer__footer-link
       = link_to edit_current_user_path(anchor: 'form-after-graduation-hope'), class: 'card-footer__footer-text-link' do
         | 内容を更新

--- a/app/views/home/_announcement.html.slim
+++ b/app/views/home/_announcement.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: announcement.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'

--- a/app/views/home/_announcements.html.slim
+++ b/app/views/home/_announcements.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 最新のお知らせ

--- a/app/views/home/_colleague.html.slim
+++ b/app/views/home/_colleague.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: user, image_class: 'card-list-item__user-icon'

--- a/app/views/home/_colleague_trainee.html.slim
+++ b/app/views/home/_colleague_trainee.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: user, image_class: 'card-list-item__user-icon'

--- a/app/views/home/_colleague_trainee_recent_report.html.slim
+++ b/app/views/home/_colleague_trainee_recent_report.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: report.user, image_class: 'card-list-item__user-icon'

--- a/app/views/home/_colleague_trainees.html.slim
+++ b/app/views/home/_colleague_trainees.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 研修生（#{colleague_trainees.count}）

--- a/app/views/home/_colleague_trainees_recent_reports.html.slim
+++ b/app/views/home/_colleague_trainees_recent_reports.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 研修生の最新の日報

--- a/app/views/home/_colleagues.html.slim
+++ b/app/views/home/_colleagues.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | ユーザー一覧（#{colleagues.count}）

--- a/app/views/home/_invite_adviser_link.html.slim
+++ b/app/views/home/_invite_adviser_link.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 社内メンターの招待

--- a/app/views/home/_invite_trainee_link.html.slim
+++ b/app/views/home/_invite_trainee_link.html.slim
@@ -1,5 +1,5 @@
 - if company.present?
-  .a-card
+  section.a-card
     header.card-header.is-sm
       h2.card-header__title
         | 新規研修をスタートする場合

--- a/app/views/home/_job_seeking_users.html.slim
+++ b/app/views/home/_job_seeking_users.html.slim
@@ -5,7 +5,7 @@
   hr.a-border-tint
   .card-list.has-scroll
     - users.each do |user|
-      .card-list-item
+      article.card-list-item
         .card-list-item__inner
           .card-list-item__user
             = render 'users/icon', user: user, image_class: 'card-list-item__user-icon'

--- a/app/views/home/_job_seeking_users.html.slim
+++ b/app/views/home/_job_seeking_users.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 就職活動中のユーザー

--- a/app/views/home/_recent_report.html.slim
+++ b/app/views/home/_recent_report.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: report.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'

--- a/app/views/home/_recent_reports.html.slim
+++ b/app/views/home/_recent_reports.html.slim
@@ -1,4 +1,4 @@
-.a-side-nav
+nav.a-side-nav aria-label="最新のみんなの日報"
   .a-side-nav__inner
     header.a-side-nav__header
       h2.a-side-nav__title

--- a/app/views/home/_unchecked_report_alert.html.slim
+++ b/app/views/home/_unchecked_report_alert.html.slim
@@ -1,5 +1,5 @@
 .dashboard-category__body
-  .a-card.is-danger.unchecked-report-alert
+  section.a-card.is-danger.unchecked-report-alert
     header.unchecked-report-alert__header
       h2.unchecked-report-alert__header-title
         | 日報が100件を超えました。

--- a/app/views/home/_upcoming_events_groups.html.slim
+++ b/app/views/home/_upcoming_events_groups.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm.has-no-border
     h2.card-header__title
       | 近日開催のイベント

--- a/app/views/home/_upcoming_pair_work.html.slim
+++ b/app/views/home/_upcoming_pair_work.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__label
       span ペア<br>ワーク

--- a/app/views/home/_upcoming_pair_works.html.slim
+++ b/app/views/home/_upcoming_pair_works.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm.has-no-border
     h2.card-header__title
       | ペアワークの予定があります！

--- a/app/views/home/_welcome_message.html.slim
+++ b/app/views/home/_welcome_message.html.slim
@@ -5,7 +5,7 @@
     .columns
       .container.is-md
         .welcome-message
-          .a-card
+          article.a-card
             .welcome-message__author
               = image_tag('pjord-face.svg', alt: 'プログラミングスクール', class: 'welcome-message__author-image')
             .welcome-message__inner

--- a/app/views/home/_welcome_message_for_adviser.html.slim
+++ b/app/views/home/_welcome_message_for_adviser.html.slim
@@ -3,7 +3,7 @@
     .columns.js-welcome-message
       .container.is-lg
         .welcome-message
-          .a-card
+          article.a-card
             .welcome-message__author
               = image_tag('pjord-face.svg', alt: 'プログラミングスクール', class: 'welcome-message__author-image')
             .welcome-message__inner

--- a/app/views/home/_wip_items.html.slim
+++ b/app/views/home/_wip_items.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | WIPで保存中

--- a/app/views/inquiries/created.html.slim
+++ b/app/views/inquiries/created.html.slim
@@ -19,7 +19,7 @@ ruby:
         | お問い合わせ
         br
         | ありがとうございます。
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           p

--- a/app/views/inquiries/new.html.slim
+++ b/app/views/inquiries/new.html.slim
@@ -18,7 +18,7 @@ ruby:
     = render 'form', inquiry: @inquiry
   hr.a-border-tint
   footer.auth-form__footer
-    nav.auth-form-nav
+    nav.auth-form-nav aria-label="問い合わせ関連リンク"
       ul.auth-form-nav__items
         li.auth-form-nav__item
           = link_to 'トップページ', welcome_path, class: 'auth-form-nav__item-link'

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,5 +1,5 @@
 = paginator.render do
-  nav.pagination
+  nav.pagination aria-label="ページネーション"
     .container
       ul.pagination__items
         == first_page_tag

--- a/app/views/layouts/lp/_lp_header.html.slim
+++ b/app/views/layouts/lp/_lp_header.html.slim
@@ -6,7 +6,7 @@ header.lp-header
           = link_to current_user ? welcome_path : root_path, class: 'lp-header__home-link' do
             = image_tag('shared/logo-horizontal.svg', alt: 'プログラミングスクール', class: 'lp-header__home-link-image')
         input.a-toggle-checkbox#welcome-mobile-nav(type='checkbox')
-        nav.lp-header-nav
+        nav.lp-header-nav aria-label="メインナビゲーション"
           ul.lp-header-nav__items
             li.lp-header-nav__item
               = link_to (current_user ? welcome_path : root_path), class: 'lp-header-nav__item-link' do

--- a/app/views/layouts/micro_report.html.slim
+++ b/app/views/layouts/micro_report.html.slim
@@ -8,7 +8,7 @@ html.is-micro-report lang='ja'
     = content_for(:head_last) if content_for?(:head_last)
   body.is-micro-report#body(class="#{body_class}")
     .mr-layout
-      nav.mr-sidebar
+      nav.mr-sidebar aria-label="分報ナビゲーション"
         .mr-sidebar__inner
           .mr-sidebar__logo
             = link_to root_path, class: 'mr-sidebar__logo-link' do

--- a/app/views/mentor/_mentor_page_tabs.html.slim
+++ b/app/views/mentor/_mentor_page_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.page-tabs
+nav.page-tabs aria-label="メンターメニュー"
   .container
     ul.page-tabs__items
       li.page-tabs__item

--- a/app/views/mentor/categories/show.html.slim
+++ b/app/views/mentor/categories/show.html.slim
@@ -68,7 +68,7 @@ header.page-header
                     li.card-main-actions__item.is-sub
                       = link_to '削除', mentor_category_path(@category), method: :delete, data: { confirm: '本当によろしいですか？' }, class: 'card-main-actions__muted-action'
 
-            .page-content-prev-next
+            nav.page-content-prev-next
               .page-content-prev-next__item
               .page-content-prev-next__item
                 = link_to mentor_categories_path, class: 'page-content-prev-next__item-link is-index' do

--- a/app/views/mentor/categories/show.html.slim
+++ b/app/views/mentor/categories/show.html.slim
@@ -84,7 +84,7 @@ header.page-header
             - if @category.practices.present?
               .card-list__items
                 - @category.practices.each do |practice|
-                  .card-list-item(id="practice_#{practice.id}")
+                  article.card-list-item(id="practice_#{practice.id}")
                     .card-list-item__inner
                       .card-list-item__rows
                         .card-list-item__row

--- a/app/views/mentor/categories/show.html.slim
+++ b/app/views/mentor/categories/show.html.slim
@@ -48,7 +48,7 @@ header.page-header
                             | URLスラッグ
                           .a-meta__value
                             = @category.slug
-            .a-card
+            section.a-card
               .card-header.is-sm
                 h2.card-header__title
                   | 説明
@@ -75,7 +75,7 @@ header.page-header
                   | カテゴリー一覧
               .page-content-prev-next__item
         .col-xl-5.col-xs-12
-          .card-list.a-card
+          section.card-list.a-card
             .card-header.is-sm
               h2.card-header__title
                 | プラクティス

--- a/app/views/mentor/categories/show.html.slim
+++ b/app/views/mentor/categories/show.html.slim
@@ -49,7 +49,7 @@ header.page-header
                           .a-meta__value
                             = @category.slug
             section.a-card
-              .card-header.is-sm
+              header.card-header.is-sm
                 h2.card-header__title
                   | 説明
               hr.a-border-tint
@@ -58,7 +58,7 @@ header.page-header
                   .a-long-text.is-md.js-markdown-view
                     = @category.description
               hr.a-border-tint
-              .card-footer
+              footer.card-footer
                 .card-main-actions
                   ul.card-main-actions__items
                     li.card-main-actions__item
@@ -76,7 +76,7 @@ header.page-header
               .page-content-prev-next__item
         .col-xl-5.col-xs-12
           section.card-list.a-card
-            .card-header.is-sm
+            header.card-header.is-sm
               h2.card-header__title
                 | プラクティス
                 | （#{@category.practices.count}）

--- a/app/views/mentor/categories/show.html.slim
+++ b/app/views/mentor/categories/show.html.slim
@@ -68,7 +68,7 @@ header.page-header
                     li.card-main-actions__item.is-sub
                       = link_to '削除', mentor_category_path(@category), method: :delete, data: { confirm: '本当によろしいですか？' }, class: 'card-main-actions__muted-action'
 
-            nav.page-content-prev-next
+            nav.page-content-prev-next aria-label="カテゴリーナビゲーション"
               .page-content-prev-next__item
               .page-content-prev-next__item
                 = link_to mentor_categories_path, class: 'page-content-prev-next__item-link is-index' do

--- a/app/views/movies/_movie_list.html.slim
+++ b/app/views/movies/_movie_list.html.slim
@@ -1,5 +1,5 @@
 .col-xxl-3.col-xl-3.col-lg-4.col-md-6.col-xs-12
-  .thumbnail-card.a-card
+  article.thumbnail-card.a-card
     .thumbnail-card__inner
       .thumbnail-card__row
         = link_to movie, class: 'thumbnail-card__image-link' do

--- a/app/views/movies/_movie_list.html.slim
+++ b/app/views/movies/_movie_list.html.slim
@@ -37,7 +37,7 @@
       .thumbnail-card__row
         .thumbnail-card__metas
           .thumbnail-card__meta
-            .thumbnail-card__date
+            time.thumbnail-card__date datetime=movie.created_at.iso8601
               = l(movie.created_at)
       - if movie.tag_list.present?
         .thumbnail-card__row

--- a/app/views/movies/index.html.slim
+++ b/app/views/movies/index.html.slim
@@ -48,7 +48,7 @@ main.page-main
                   = render partial: 'movie_list', collection: @movies, as: :movie
                 = paginate @movies
       - if @tags.any?
-        nav.a-side-nav
+        nav.a-side-nav aria-label="動画タグ一覧"
           .a-side-nav__inner
             header.a-side-nav__header
               h2.a-side-nav__title

--- a/app/views/movies/show.html.slim
+++ b/app/views/movies/show.html.slim
@@ -62,7 +62,7 @@ main.page-main
                           class: 'card-main-actions__muted-action' do
                           | 削除する
 
-          .page-content-prev-next
+          nav.page-content-prev-next
             .page-content-prev-next__item
               = link_to :movies,
                 class: 'page-content-prev-next__item-link is-index' do

--- a/app/views/movies/show.html.slim
+++ b/app/views/movies/show.html.slim
@@ -29,7 +29,7 @@ main.page-main
   .page-body.is-movie
     .page-body__inner
       .container.is-md
-        .page-content.is-movie
+        article.page-content.is-movie
           = render 'movie_header', movie: @movie
           .a-card
             .card-body

--- a/app/views/movies/show.html.slim
+++ b/app/views/movies/show.html.slim
@@ -62,7 +62,7 @@ main.page-main
                           class: 'card-main-actions__muted-action' do
                           | 削除する
 
-          nav.page-content-prev-next
+          nav.page-content-prev-next aria-label="動画ナビゲーション"
             .page-content-prev-next__item
               = link_to :movies,
                 class: 'page-content-prev-next__item-link is-index' do

--- a/app/views/notifications/_filter_button.html.slim
+++ b/app/views/notifications/_filter_button.html.slim
@@ -1,4 +1,4 @@
-nav.pill-nav
+nav.pill-nav aria-label="通知絞り込み"
   .container
     ul.pill-nav__items
       li.pill-nav__item

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,6 +1,6 @@
 - read_class = notification.read? ? 'is-read' : 'is-unread'
 
-.card-list-item class=read_class
+article.card-list-item class=read_class
   .card-list-item__inner
     .card-list-item__user
       = link_to user_path(notification.sender), class: 'card-list-item__user-link' do

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -54,7 +54,7 @@ main.page-main
       - else
         .page-content#notifications
           - if @notifications.total_pages > 1
-            nav.pagination
+            .pagination
               = paginate @notifications
           .card-list.a-card
             - @notifications.each do |notification|
@@ -64,5 +64,5 @@ main.page-main
             = render 'application/unconfirmed_links_open', label: '未読の通知を一括で開く'
 
           - if @notifications.total_pages > 1
-            nav.pagination
+            .pagination
               = paginate @notifications

--- a/app/views/pages/_page.html.slim
+++ b/app/views/pages/_page.html.slim
@@ -1,4 +1,4 @@
-.card-list-item(class="#{page.wip ? 'is-wip' : ''}")
+article.card-list-item(class="#{page.wip ? 'is-wip' : ''}")
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon',

--- a/app/views/pages/_tabs.html.slim
+++ b/app/views/pages/_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.page-tabs
+nav.page-tabs aria-label="学習コンテンツ"
   .container
     ul.page-tabs__items
       li.page-tabs__item

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -59,7 +59,7 @@ main.page-main
                       = render partial: 'page', collection: @pages
 
                 - if Page.all_tags.any?
-                  nav.a-side-nav
+                  nav.a-side-nav aria-label="Docsタグ一覧"
                     .a-side-nav__inner
                       header.a-side-nav__header
                         h2.a-side-nav__title

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -46,7 +46,7 @@ main.page-main
                     li.card-main-actions__item.is-sub
                       = link_to @page, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                         | 削除する
-          .page-content-prev-next
+          nav.page-content-prev-next
             .page-content-prev-next__item
               = link_to :pages, class: 'page-content-prev-next__item-link is-index' do
                 | 一覧に戻る

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -46,7 +46,7 @@ main.page-main
                     li.card-main-actions__item.is-sub
                       = link_to @page, data: { confirm: '本当によろしいですか？' }, method: :delete, class: 'card-main-actions__muted-action' do
                         | 削除する
-          nav.page-content-prev-next
+          nav.page-content-prev-next aria-label="ページナビゲーション"
             .page-content-prev-next__item
               = link_to :pages, class: 'page-content-prev-next__item-link is-index' do
                 | 一覧に戻る
@@ -54,7 +54,7 @@ main.page-main
         = render 'comments/comments', commentable: @page, commentable_type: 'Page'
 
       - if @page.practice
-        nav.a-side-nav
+        nav.a-side-nav aria-label="プラクティスのページ一覧"
           .a-side-nav__inner
             header.a-side-nav__header
               h2.a-side-nav__title

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -25,7 +25,7 @@ main.page-main
   .page-body
     .page-body__inner.has-side-nav
       .container.is-md
-        .doc.page-content
+        article.doc.page-content
           = render 'doc_header', page: @page
           .a-card
             .card-body

--- a/app/views/pair_works/_body.html.slim
+++ b/app/views/pair_works/_body.html.slim
@@ -1,4 +1,4 @@
-.a-card
+article.a-card
   .card-body
     - if pair_work.solved?
       - buddy = pair_work.buddy

--- a/app/views/pair_works/_pair_work.html.slim
+++ b/app/views/pair_works/_pair_work.html.slim
@@ -1,4 +1,4 @@
-.card-list-item(class="#{pair_work.wip ? 'is-wip' : ''}")
+article.card-list-item(class="#{pair_work.wip ? 'is-wip' : ''}")
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: pair_work.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'

--- a/app/views/practices/_books.html.slim
+++ b/app/views/practices/_books.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header
     h2.card-header__title
       | 参考書籍
@@ -7,7 +7,7 @@
     .practice-books__items
       - practice.practices_books.each do |practices_book|
         - book = practices_book.book
-        .practice-books-item
+        article.practice-books-item
           .practice-books-item__body
             = link_to book.page_url, target: '_blank', rel: 'noopener', class: 'practice-books-item__inner' do
               .practice-books-item__start

--- a/app/views/practices/_coding_tests.html.slim
+++ b/app/views/practices/_coding_tests.html.slim
@@ -1,4 +1,4 @@
-.a-card.coding-tests
+section.a-card.coding-tests
   header.card-header
     h2.card-header__title
       | コーディングテスト

--- a/app/views/practices/_coding_tests.html.slim
+++ b/app/views/practices/_coding_tests.html.slim
@@ -5,7 +5,7 @@
   hr.a-border-tint
   .card-list
     - coding_tests.order(:position).each do |coding_test|
-      .card-list-item
+      article.card-list-item
         .coding-tests-item
           - if coding_test.passed_by?(current_user)
             .coding-tests-item__passed

--- a/app/views/practices/_description.html.slim
+++ b/app/views/practices/_description.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header
     h2.card-header__title
       = Practice.human_attribute_name :description

--- a/app/views/practices/_memo.html.slim
+++ b/app/views/practices/_memo.html.slim
@@ -1,4 +1,4 @@
-.a-card.is-only-mentor
+section.a-card.is-only-mentor
   header.card-header
     h2.card-header__title
       = Practice.human_attribute_name :memo

--- a/app/views/practices/_summary.html.slim
+++ b/app/views/practices/_summary.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header
     h2.card-header__title
       = Practice.human_attribute_name :summary

--- a/app/views/practices/coding_tests/_coding_test.html.slim
+++ b/app/views/practices/coding_tests/_coding_test.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__rows
       .card-list-item__row

--- a/app/views/practices/pages/index.html.slim
+++ b/app/views/practices/pages/index.html.slim
@@ -10,7 +10,7 @@
 = practice_page_tabs(@practice, active_tab: 'Docs', include_source: @include_source)
 
 - if @practice.grant_course?
-  nav.pill-nav
+  nav.pill-nav aria-label="Docs表示対象"
     ul.pill-nav__items
       li.pill-nav__item
         = link_to '全て',

--- a/app/views/practices/questions/index.html.slim
+++ b/app/views/practices/questions/index.html.slim
@@ -9,7 +9,7 @@
 
 = practice_page_tabs(@practice, active_tab: '質問')
 
-nav.tab-nav
+nav.tab-nav aria-label="プラクティス関連コンテンツ"
   .container
     ul.tab-nav__items
       li.tab-nav__item
@@ -23,7 +23,7 @@ nav.tab-nav
           class: "tab-nav__item-link #{params[:target] == 'not_solved' ? 'is-active' : ''}"
 
 - if @practice.source_id.present?
-  nav.pill-nav
+  nav.pill-nav aria-label="質問表示対象"
     ul.pill-nav__items
       li.pill-nav__item
         = link_to '全て', practice_questions_path(@practice, target: params[:target]),

--- a/app/views/practices/reports/index.html.slim
+++ b/app/views/practices/reports/index.html.slim
@@ -10,7 +10,7 @@
 = practice_page_tabs(@practice, active_tab: '日報', include_source: @include_source)
 
 - if @practice.grant_course?
-  nav.pill-nav
+  nav.pill-nav aria-label="日報表示対象"
     ul.pill-nav__items
       li.pill-nav__item
         = link_to '全て',

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -18,7 +18,7 @@
     .row.is-gutter-width-32
       .col-lg-8.col-xs-12
         - if current_user.grant_course?
-          nav.pill-nav
+          nav.pill-nav aria-label="プラクティス表示"
             ul.pill-nav__items
               li.pill-nav__item
                 = link_to practice_path(@practice.source_practice || @practice),
@@ -171,7 +171,7 @@
                         i.fa-solid.fa-trash
                         | 削除する
       .col-lg-4.col-xs-12
-        nav.page-nav.a-card
+        nav.page-nav.a-card aria-label="同じカテゴリーのプラクティス"
           header.page-nav__header
             h2.page-nav__title
               = link_to course_practices_path(current_user.course, anchor: "category-#{category.id}"),

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -18,7 +18,7 @@
     .row.is-gutter-width-32
       .col-lg-8.col-xs-12
         - if current_user.grant_course?
-          nav.pill-nav
+          nav.pill-nav aria-label="プラクティス表示"
             ul.pill-nav__items
               li.pill-nav__item
                 = link_to practice_path(@practice.source_practice || @practice),
@@ -163,7 +163,7 @@
                         i.fa-solid.fa-trash
                         | 削除する
       .col-lg-4.col-xs-12
-        nav.page-nav.a-card
+        nav.page-nav.a-card aria-label="同じカテゴリーのプラクティス"
           header.page-nav__header
             h2.page-nav__title
               = link_to course_practices_path(current_user.course, anchor: "category-#{category.id}"),

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -110,7 +110,7 @@
             = render 'books', practice: @practice
 
           - unless skipped_practices.include?(@practice.id)
-            .a-card
+            section.a-card
               header.card-header
                 h2.card-header__title
                   = Practice.human_attribute_name :goal

--- a/app/views/practices/submission_answer/_admin_or_mentor_menu.html.slim
+++ b/app/views/practices/submission_answer/_admin_or_mentor_menu.html.slim
@@ -1,4 +1,4 @@
-.practice.page-content
+aside.practice.page-content
   .a-card.is-only-mentor
     header.card-header
       h2.card-header__title

--- a/app/views/practices/submission_answer/_description.html.slim
+++ b/app/views/practices/submission_answer/_description.html.slim
@@ -1,5 +1,5 @@
 - if submission_answer.present?
-  .a-card
+  section.a-card
     header.card-header
       h2.card-header__title
         = SubmissionAnswer.human_attribute_name :description

--- a/app/views/press_releases/_press_releases.html.slim
+++ b/app/views/press_releases/_press_releases.html.slim
@@ -15,7 +15,7 @@ hr.a-border-tint
           .row
             - press_releases.each do |press_release|
               .col-lg-4.col-md-6.col-xs-12
-                .thumbnail-card.a-card
+                article.thumbnail-card.a-card
                   = link_to press_release, class: 'thumbnail-card__inner' do
                     .thumbnail-card__row
                       - if press_release.prepared_thumbnail?

--- a/app/views/press_releases/_press_releases.html.slim
+++ b/app/views/press_releases/_press_releases.html.slim
@@ -32,6 +32,6 @@ hr.a-border-tint
                             = image_tag press_release.user.avatar_url
                             = press_release.user.login_name
                         .thumbnail-card__meta
-                          .thumbnail-card__date
-                              = l(press_release.published_at)
+                          time.thumbnail-card__date datetime=press_release.published_at.iso8601
+                            = l(press_release.published_at)
         = paginate press_releases

--- a/app/views/products/_completion_message.html.slim
+++ b/app/views/products/_completion_message.html.slim
@@ -1,4 +1,4 @@
-.a-completion-message
+section.a-completion-message
   .container
     .a-completion-message__inner
       .a-completion-message__inner-start

--- a/app/views/products/_elapsed_days_nav.html.slim
+++ b/app/views/products/_elapsed_days_nav.html.slim
@@ -3,7 +3,7 @@ ruby:
   products_grouped_by_elapsed_days ||= {}
   all_days = [product_deadline_day + 2] + (product_deadline_day + 1).downto(0).to_a
 
-nav.page-nav.a-card
+nav.page-nav.a-card aria-label="提出物の経過日数"
   ol.page-nav__items.elapsed-days
     - all_days.each do |elapsed_days|
       ruby:

--- a/app/views/products/_filter_buttons.html.slim
+++ b/app/views/products/_filter_buttons.html.slim
@@ -2,7 +2,7 @@
 - current_target ||= params[:target]
 - targets = selected_tab == 'self_assigned' ? %w[self_assigned_all self_assigned_no_replied] : %w[unchecked_all unchecked_no_replied]
 
-nav.pill-nav
+nav.pill-nav aria-label="提出物絞り込み"
   ul.pill-nav__items
     - targets.each do |target|
       li.pill-nav__item

--- a/app/views/products/_practice_memo.html.slim
+++ b/app/views/products/_practice_memo.html.slim
@@ -1,4 +1,4 @@
-.a-card.is-toggle.practice-memo.is-only-mentor(data-practice_id=practice_id)
+section.a-card.is-toggle.practice-memo.is-only-mentor(data-practice_id=practice_id)
   input.a-toggle-checkbox#toggle-mentor-memo-body(type='checkbox')
   label.card-header.is-sm(for="toggle-mentor-memo-body")
     h2.card-header__title

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -1,4 +1,4 @@
-.card-list-item(class="#{product.wip? ? 'is-wip' : ''} #{current_user.mentor? ? 'has-assigned' : ''}")
+article.card-list-item(class="#{product.wip? ? 'is-wip' : ''} #{current_user.mentor? ? 'has-assigned' : ''}")
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: product.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'

--- a/app/views/products/_product_body.html.slim
+++ b/app/views/products/_product_body.html.slim
@@ -35,7 +35,7 @@
 
     = render 'shared/check_actions', checkable: product, checkable_type: 'Product', checkable_label: Product.model_name.human
 
-.page-content-prev-next
+nav.page-content-prev-next
   .page-content-prev-next__item
     = link_to product.practice, class: 'page-content-prev-next__item-link is-index' do
       | プラクティスに戻る

--- a/app/views/products/_product_body.html.slim
+++ b/app/views/products/_product_body.html.slim
@@ -35,7 +35,7 @@
 
     = render 'shared/check_actions', checkable: product, checkable_type: 'Product', checkable_label: Product.model_name.human
 
-nav.page-content-prev-next
+nav.page-content-prev-next aria-label="提出物ナビゲーション"
   .page-content-prev-next__item
     = link_to product.practice, class: 'page-content-prev-next__item-link is-index' do
       | プラクティスに戻る

--- a/app/views/products/_product_body.html.slim
+++ b/app/views/products/_product_body.html.slim
@@ -12,7 +12,7 @@ section.a-card
 
   - if product.user == current_user || admin_or_mentor_login?
     hr.a-border-tint
-    .card-footer
+    footer.card-footer
       .card-main-actions
         ul.card-main-actions__items
           li.card-main-actions__item

--- a/app/views/products/_product_body.html.slim
+++ b/app/views/products/_product_body.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 提出物

--- a/app/views/products/_product_list_item.html.slim
+++ b/app/views/products/_product_list_item.html.slim
@@ -5,7 +5,7 @@ ruby:
   is_unassigned_page = request.path == '/products/unassigned'
   is_dashboard_page = request.path == '/'
 
-.card-list-item(class="#{product.wip? ? 'is-wip' : ''} has-assigned")
+article.card-list-item(class="#{product.wip? ? 'is-wip' : ''} has-assigned")
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: product.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon a-user-icon'

--- a/app/views/products/_tabs.html.slim
+++ b/app/views/products/_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.page-tabs
+nav.page-tabs aria-label="提出物"
   .container
     ul.page-tabs__items
       li.page-tabs__item

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -89,7 +89,7 @@ header.page-header
               type='radio'
               name='side-tabs-contents'
             )
-            nav.side-tabs-nav
+            nav.side-tabs-nav aria-label="ユーザー情報ナビゲーション"
               .side-tabs-nav__items
                 .side-tabs-nav__item
                   label.side-tabs-nav__item-link#side-tabs-nav-1(

--- a/app/views/products/show.html.slim
+++ b/app/views/products/show.html.slim
@@ -49,7 +49,7 @@ header.page-header
   .container.is-xxl
     .row.is-gutter-width-32.justify-center
       .col-xl-7.col-lg-9.col-md-11.col-xs-12
-        .page-content.is-product
+        article.page-content.is-product
           .page-body__rows
             .page-body__row
               = render 'product_header', product: @product
@@ -71,7 +71,7 @@ header.page-header
 
       .is-only-mentor class=current_user.product_sidebar_class
         - if current_user.mentor? || current_user.admin?
-          .side-tabs
+          aside.side-tabs
             input.a-toggle-checkbox#side-tabs-1(
               type='radio'
               name='side-tabs-contents'
@@ -89,7 +89,7 @@ header.page-header
               type='radio'
               name='side-tabs-contents'
             )
-            .side-tabs-nav
+            nav.side-tabs-nav
               .side-tabs-nav__items
                 .side-tabs-nav__item
                   label.side-tabs-nav__item-link#side-tabs-nav-1(
@@ -129,7 +129,7 @@ header.page-header
                         user_course_practice: @product.user_course_practice
                     - if @product.skipped_practices.present?
                       .user-data__row
-                        .user-metas.is-only-mentor
+                        section.user-metas.is-only-mentor
                           h2.user-metas__title
                             | スキップするプラクティス一覧
                           .user-metas__items

--- a/app/views/products/unassigned/index.html.slim
+++ b/app/views/products/unassigned/index.html.slim
@@ -28,7 +28,7 @@ header.page-header
                 .card-list
                   .card-list__items
                     = render partial: 'products/product_list_item', collection: products, as: :product, locals: { show_training_end_date: true, elapsed_days: elapsed_days }
-          nav.page-body__column.is-sub
+          aside.page-body__column.is-sub
             = render 'products/elapsed_days_nav', products_grouped_by_elapsed_days: @products_grouped_by_elapsed_days, product_deadline_day: @product_deadline_day
       - if @products.present?
         = render 'application/unconfirmed_links_open', label: unconfirmed_links_label(@target)

--- a/app/views/products/unassigned/index.html.slim
+++ b/app/views/products/unassigned/index.html.slim
@@ -23,7 +23,7 @@ header.page-header
           .page-body__column.is-main
             - sorted_groups = @products_grouped_by_elapsed_days.sort_by { |days, _| -days }
             - sorted_groups.each do |elapsed_days, products|
-              .a-card
+              section.a-card
                 = render 'products/elapsed_days_header', elapsed_days: elapsed_days, products_count: products.size, product_deadline_day: @product_deadline_day
                 .card-list
                   .card-list__items

--- a/app/views/questions/_answer.html.slim
+++ b/app/views/questions/_answer.html.slim
@@ -1,4 +1,4 @@
-.thread-comment.answer id="answer_#{answer.id}" data-question_id="#{question.id}" data-answer_id="#{answer.id}" data-answer_description="#{answer.description}"
+article.thread-comment.answer id="answer_#{answer.id}" data-question_id="#{question.id}" data-answer_id="#{answer.id}" data-answer_description="#{answer.description}"
   .thread-comment__start
     a.thread-comment__user-link href="#{answer.user.url}"
       span class="#{answer.user.user_icon_frame_class}"

--- a/app/views/questions/_question.html.slim
+++ b/app/views/questions/_question.html.slim
@@ -1,4 +1,4 @@
-.card-list-item.(class="#{(question.correct_answer.present? && 'is-solved') || (question.wip? && 'is-wip')}")
+article.card-list-item.(class="#{(question.correct_answer.present? && 'is-solved') || (question.wip? && 'is-wip')}")
   .card-list-item__inner
     .card-list-item__user
       = link_to question.user, class: 'card-list-item__user-link'

--- a/app/views/questions/_question_body.html.slim
+++ b/app/views/questions/_question_body.html.slim
@@ -1,4 +1,4 @@
-.a-card
+article.a-card
   .card-body
     .card-body__description
       .a-long-text.is-md.js-markdown-view

--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -7,11 +7,11 @@
       p.o-empty-message__text
         = empty_message
 - else
-  nav.pagination
+  .pagination
     = paginate questions
     .card-list.a-card
       .card-list__items
         - questions.each do |question|
           = render 'questions/question', question: question
-  nav.pagination
+  .pagination
     = paginate questions

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -10,7 +10,7 @@
   hr.a-border
   = questions_sub_tabs
 
-  nav.page-filter.form
+  nav.page-filter.form aria-label="質問絞り込み"
     .container.is-md
       = form_with url: questions_path, method: 'get', local: true
         .form-item.is-inline-md-up
@@ -43,7 +43,7 @@
           .page-body__column.is-main
             = render 'questions/questions', questions: @questions, empty_message: @questions_property.empty_message
       - if @tags.any?
-        nav.a-side-nav
+        nav.a-side-nav aria-label="質問タグ一覧"
           .a-side-nav__inner
             header.a-side-nav__header
               h2.a-side-nav__title

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -13,7 +13,7 @@
   .page-body
     .page-body__inner.has-side-nav
       .container.is-md
-        .question.page-content
+        article.question.page-content
           = render 'question_header', question: @question
           = render 'question_body', question: @question
         .loading-content

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -27,7 +27,7 @@
             - @answers.each do |answer|
               = render 'answer', question: @question, user: current_user, answer: answer
           = render 'new_answer', question: @question, user: current_user
-      nav.a-side-nav
+      nav.a-side-nav aria-label="関連する質問"
         .a-side-nav__inner
           header.a-side-nav__header
             h2.a-side-nav__title

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -40,7 +40,7 @@ article.page-content
 
   = render('regular_event_meta', regular_event:)
 
-  .a-card
+  section.a-card
     .card-header.is-sm
       h2.card-header__title
         | イベント内容
@@ -69,7 +69,7 @@ article.page-content
                 | 削除する
 
   - unless regular_event.wip? || regular_event.all
-    .a-card.participants
+    section.a-card.participants
       header.card-header.is-sm
         h2.card-header__title
           | 参加者（#{regular_event.participants.count}名）

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -1,4 +1,4 @@
-.page-content
+article.page-content
   header.page-content-header
     .page-content-header__start
       .page-content-header__category

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -41,7 +41,7 @@ article.page-content
   = render('regular_event_meta', regular_event:)
 
   section.a-card
-    .card-header.is-sm
+    header.card-header.is-sm
       h2.card-header__title
         | イベント内容
     hr.a-border-tint
@@ -57,7 +57,7 @@ article.page-content
     = render 'reactions/reactions', reactionable: regular_event
     - if admin_or_mentor_login? || regular_event.organizers.ids.include?(current_user.id)
       hr.a-border-tint
-      .card-footer
+      footer.card-footer
         .card-main-actions
           ul.card-main-actions__items
             li.card-main-actions__item

--- a/app/views/regular_events/_regular_event_meta.html.slim
+++ b/app/views/regular_events/_regular_event_meta.html.slim
@@ -1,4 +1,4 @@
-.event-meta.a-card
+aside.event-meta.a-card
   .event-meta__inner
     dl.event-meta__items
       .event-meta__item
@@ -28,7 +28,7 @@
             = regular_event.next_holding_date
 - upcoming_excluded_dates = regular_event.upcoming_excluded_dates
 - if !regular_event.finished? && upcoming_excluded_dates.present?
-  .a-card
+  section.a-card
     header.card-header.is-sm
       h2.card-header__title
         | 今後のイベント休み予定
@@ -44,7 +44,7 @@
 
 - out_of_rule_skip_dates = regular_event.out_of_repeat_rule_skip_dates
 - if !regular_event.finished? && (admin_or_mentor_login? || regular_event.organizers.include?(current_user)) && out_of_rule_skip_dates.present?
-  .a-card.is-out-of-rule-skip-dates.is-danger
+  section.a-card.is-out-of-rule-skip-dates.is-danger
     header.card-header.is-sm
       h2.card-header__title
         | 開催曜日と一致しない日がスキップ日として登録されています

--- a/app/views/regular_events/_regular_events.html.slim
+++ b/app/views/regular_events/_regular_events.html.slim
@@ -1,4 +1,4 @@
-nav.pill-nav.mb-8
+nav.pill-nav.mb-8 aria-label="定期イベント絞り込み"
   .pill-nav__items
     .pill-nav__item
       = link_to regular_events_path(target: :not_finished), class: "pill-nav__item-link#{params[:target] == 'not_finished' ? ' is-active' : ''}" do

--- a/app/views/reports/_product.html.slim
+++ b/app/views/reports/_product.html.slim
@@ -1,4 +1,4 @@
-.card-list-item(class="#{product.wip? ? 'is-wip' : ''}")
+article.card-list-item(class="#{product.wip? ? 'is-wip' : ''}")
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: product.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'

--- a/app/views/reports/_report.html.slim
+++ b/app/views/reports/_report.html.slim
@@ -1,4 +1,4 @@
-.card-list-item(class="#{report.wip? ? 'is-wip' : ''}")
+article.card-list-item(class="#{report.wip? ? 'is-wip' : ''}")
   .card-list-item__inner
     - if user_icon_display
       .card-list-item__user

--- a/app/views/reports/_report_body.html.slim
+++ b/app/views/reports/_report_body.html.slim
@@ -1,4 +1,4 @@
-.a-card
+article.a-card
   .card-header.is-sm
     = render 'reports/learning_times', report: report
   hr.a-border-tint

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -17,14 +17,14 @@ main.page-main
   hr.a-border
 
   - if admin_or_mentor_login?
-    nav.pill-nav
+    nav.pill-nav aria-label="日報表示対象"
       ul.pill-nav__items
         li.pill-nav__item
           = link_to '全て', reports_path, class: "pill-nav__item-link#{' is-active' if controller_path == 'reports'}"
         li.pill-nav__item
           = link_to '未チェック', reports_unchecked_index_path, class: "pill-nav__item-link#{' is-active' if controller_path == 'reports/unchecked'}"
   - if controller_path != 'reports/unchecked'
-    nav.page-filter.form.pb-0
+    nav.page-filter.form.pb-0 aria-label="日報絞り込み"
       .container.is-md
         = form_with url: reports_path, local: true, method: :get do
           .form-item.is-inline-md-up

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -22,11 +22,11 @@
   .container.is-xxl
     .row.justify-center.is-gutter-width-32
       .col-xl-7.col-xs-12
-        .report.page-content
+        article.report.page-content
           = render 'report_header', report: @report
           = render 'report_body', report: @report
 
-          .page-content-prev-next
+          nav.page-content-prev-next
             .page-content-prev-next__item
               - if @report.previous
                 = link_to @report.previous, class: 'page-content-prev-next__item-link is-prev' do
@@ -47,12 +47,12 @@
 
       .col-xl-5.col-xs-12
         - if current_user.mentor? || current_user.admin?
-          .side-tabs
+          aside.side-tabs
             input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
             input.a-toggle-checkbox#side-tabs-2 type='radio' name='side-tabs-contents'
             input.a-toggle-checkbox#side-tabs-3 type='radio' name='side-tabs-contents'
             input.a-toggle-checkbox#side-tabs-4 type='radio' name='side-tabs-contents'
-            .side-tabs-nav.is-only-mentor
+            nav.side-tabs-nav.is-only-mentor
               .side-tabs-nav__items
                 .side-tabs-nav__item
                   label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'
@@ -84,7 +84,7 @@
                         user_practices = @report.user.practices
                       - if skipped_practices.present?
                         .user-data__row
-                          .user-metas.is-only-mentor
+                          section.user-metas.is-only-mentor
                             h2.user-metas__title
                               | スキップするプラクティス一覧
                             .user-metas__items

--- a/app/views/reports/show.html.slim
+++ b/app/views/reports/show.html.slim
@@ -26,7 +26,7 @@
           = render 'report_header', report: @report
           = render 'report_body', report: @report
 
-          nav.page-content-prev-next
+          nav.page-content-prev-next aria-label="日報ナビゲーション"
             .page-content-prev-next__item
               - if @report.previous
                 = link_to @report.previous, class: 'page-content-prev-next__item-link is-prev' do
@@ -52,7 +52,7 @@
             input.a-toggle-checkbox#side-tabs-2 type='radio' name='side-tabs-contents'
             input.a-toggle-checkbox#side-tabs-3 type='radio' name='side-tabs-contents'
             input.a-toggle-checkbox#side-tabs-4 type='radio' name='side-tabs-contents'
-            nav.side-tabs-nav.is-only-mentor
+            nav.side-tabs-nav.is-only-mentor aria-label="ユーザー情報ナビゲーション"
               .side-tabs-nav__items
                 .side-tabs-nav__item
                   label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'

--- a/app/views/request_retirements/new.html.slim
+++ b/app/views/request_retirements/new.html.slim
@@ -29,7 +29,7 @@ header.page-header
       = render 'form', request_retirement: @request_retirement
     hr.a-border-tint
     footer.auth-form__footer
-      nav.auth-form-nav
+      nav.auth-form-nav aria-label="退会申請関連リンク"
         ul.auth-form-nav__items
           li.auth-form-nav__item
             = link_to 'ダッシュボード', root_path, class: 'auth-form-nav__item-link'

--- a/app/views/request_retirements/show.html.slim
+++ b/app/views/request_retirements/show.html.slim
@@ -7,7 +7,7 @@ description: '退会申請を受け付けました。')
     .thanks-message__header
       h1.thanks-message__title
         | 退会申請を受け付けました。
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           p

--- a/app/views/retirement/show.html.slim
+++ b/app/views/retirement/show.html.slim
@@ -7,7 +7,7 @@ description: '退会処理が完了しました。')
     .thanks-message__header
       h1.thanks-message__title
         | 退会処理が完了しました。
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           p

--- a/app/views/shared/_check_actions.html.slim
+++ b/app/views/shared/_check_actions.html.slim
@@ -1,6 +1,6 @@
 - if admin_or_mentor_login?
   hr.a-border-tint
-  .card-footer.is-only-mentor
+  footer.card-footer.is-only-mentor
     .card-main-actions
       ul.card-main-actions__items
         - check = checkable.checks.find_by(user: current_user)

--- a/app/views/shared/_not_logged_in_footer.html.slim
+++ b/app/views/shared/_not_logged_in_footer.html.slim
@@ -1,6 +1,6 @@
 footer.not-logged-in-footer
   .container.is-xl
-    nav.not-logged-in-footer__nav
+    nav.not-logged-in-footer__nav aria-label="フッターナビゲーション"
       ul.not-logged-in-footer__nav-items
         li.not-logged-in-footer__nav-item
           = link_to root_path, class: 'not-logged-in-footer__nav-item-link' do

--- a/app/views/tags/_tag.html.slim
+++ b/app/views/tags/_tag.html.slim
@@ -1,4 +1,4 @@
-.a-card
+article.a-card
   .user-group class="#{users_tags_gradation(tag.count, @top3_tags_counts[0])}"
     header.user-group__header
       h2.user-group__title.is-inline

--- a/app/views/talks/_nav.html.slim
+++ b/app/views/talks/_nav.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="相談部屋絞り込み"
   .container
     ul.tab-nav__items
       - TalksController::ALLOWED_TARGETS.each do |target|

--- a/app/views/talks/_talk.html.slim
+++ b/app/views/talks/_talk.html.slim
@@ -1,4 +1,4 @@
-.card-list-item
+article.card-list-item
   .card-list-item__inner
     .card-list-item__user
       = render 'users/icon', user: talk.user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -12,7 +12,7 @@
   .container.is-xxl
     .row(class='!justify-center')
       .col-xl-7.col-xs-12
-        .talk.page-content
+        article.talk.page-content
           header.page-content-header
             .page-content-header__start
               .page-content-header__user
@@ -65,10 +65,10 @@
 
       - if current_user.admin?
         .col-xl-5.col-xs-12
-          .side-tabs
+          aside.side-tabs
             input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
             input.a-toggle-checkbox#side-tabs-2 type='radio' name='side-tabs-contents'
-            .side-tabs-nav
+            nav.side-tabs-nav
               .side-tabs-nav__items
                 .side-tabs-nav__item
                   label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -44,7 +44,7 @@
                       | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
 
               section.a-card
-                .card-header.is-sm
+                header.card-header.is-sm
                   h2.page-content-members__title
                     | 相談部屋にアクセスできるメンバー
                 hr.a-border-tint

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -43,7 +43,7 @@
                       | ここは#{@user.login_name}さんと管理者のみが閲覧することのできる相談部屋です。
                       | 就職に関することや受講に関することなど、何か相談したいことがある場合にお気軽にコメントをしてください。
 
-              .a-card
+              section.a-card
                 .card-header.is-sm
                   h2.page-content-members__title
                     | 相談部屋にアクセスできるメンバー

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -68,7 +68,7 @@
           aside.side-tabs
             input.a-toggle-checkbox#side-tabs-1 type='radio' name='side-tabs-contents' checked='checked'
             input.a-toggle-checkbox#side-tabs-2 type='radio' name='side-tabs-contents'
-            nav.side-tabs-nav
+            nav.side-tabs-nav aria-label="ユーザー関連情報"
               .side-tabs-nav__items
                 .side-tabs-nav__item
                   label.side-tabs-nav__item-link#side-tabs-nav-1 for='side-tabs-1'

--- a/app/views/training_completion/show.html.slim
+++ b/app/views/training_completion/show.html.slim
@@ -7,7 +7,7 @@ description: '研修終了手続きが完了しました。')
     .thanks-message__header
       h1.thanks-message__title
         | 研修終了手続きが完了しました。
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           p

--- a/app/views/unauthorized/_join_us.html.slim
+++ b/app/views/unauthorized/_join_us.html.slim
@@ -1,4 +1,4 @@
-nav.join-us-nav
+nav.join-us-nav aria-label="参加案内"
   ul.join-us-nav__items
       li.join-us-nav__item.is-main
         = link_to 'もっと詳しく', root_path, class: 'join-us-nav__item-link a-button is-md is-primary is-block'

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -13,7 +13,7 @@ description: 'オンラインプログラミングスクールのフィヨルド
       = render 'form', user: @user
     hr.a-border-tint
     footer.auth-form__footer
-      nav.auth-form-nav
+      nav.auth-form-nav aria-label="ログイン関連リンク"
         ul.auth-form-nav__items
           li.auth-form-nav__item
             = link_to 'トップページ', root_path, class: 'auth-form-nav__item-link'

--- a/app/views/users/_event_nav.html.slim
+++ b/app/views/users/_event_nav.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="ユーザーのイベント"
   .container
     ul.tab-nav__items
       - event_navs(@user).each do |nav|

--- a/app/views/users/_github_grass.html.slim
+++ b/app/views/users/_github_grass.html.slim
@@ -1,5 +1,5 @@
 section.a-card
-  .card-header.is-sm
+  header.card-header.is-sm
     h2.card-header__title GitHub
   hr.a-border-tint
   .user-grass

--- a/app/views/users/_github_grass.html.slim
+++ b/app/views/users/_github_grass.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   .card-header.is-sm
     h2.card-header__title GitHub
   hr.a-border-tint

--- a/app/views/users/_hibernation_history.html.slim
+++ b/app/views/users/_hibernation_history.html.slim
@@ -1,4 +1,4 @@
-.a-card class=('is-only-mentor' unless user == current_user)
+section.a-card class=('is-only-mentor' unless user == current_user)
   header.card-header.is-sm
     h2.card-header__title
       |  休会履歴

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -6,7 +6,7 @@
   hr.a-border-tint
   .card-list.has-scroll
     - users.each do |user|
-      .card-list-item
+      article.card-list-item
         .card-list-item__inner
           .card-list-item__user
             = render 'users/icon', user: user, link_class: 'card-list-item__user-link', image_class: 'card-list-item__user-icon'

--- a/app/views/users/_inactive_users.html.slim
+++ b/app/views/users/_inactive_users.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 1ヶ月以上ログインのないユーザー

--- a/app/views/users/_learning_time_frames.html.slim
+++ b/app/views/users/_learning_time_frames.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   .card-header.is-sm
     h2.card-header__title
       | 主な活動予定時間

--- a/app/views/users/_learning_time_frames.html.slim
+++ b/app/views/users/_learning_time_frames.html.slim
@@ -1,5 +1,5 @@
 section.a-card
-  .card-header.is-sm
+  header.card-header.is-sm
     h2.card-header__title
       | 主な活動予定時間
   .a-table.is-sm(class='!text-center')

--- a/app/views/users/_nav.html.slim
+++ b/app/views/users/_nav.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="ユーザー絞り込み"
   .container
     ul.tab-nav__items
       - if params[:target] == 'followings'

--- a/app/views/users/_negative_emotion_report.html.slim
+++ b/app/views/users/_negative_emotion_report.html.slim
@@ -1,5 +1,5 @@
 - if reports.present?
-  .a-card.is-only-mentor
+  section.a-card.is-only-mentor
     header.card-header
       h2.card-header__title
         | 2回連続

--- a/app/views/users/_random_tags.html.slim
+++ b/app/views/users/_random_tags.html.slim
@@ -1,4 +1,4 @@
-.a-side-nav
+nav.a-side-nav aria-label="ユーザータグ"
   .a-side-nav__inner
     header.a-side-nav__header
       h2.a-side-nav__title

--- a/app/views/users/_reports.html.slim
+++ b/app/views/users/_reports.html.slim
@@ -1,7 +1,7 @@
 .user-reports
   .user-reports__items
     - reports.each do |report|
-      .user-reports-item
+      article.user-reports-item
         = link_to report, itemprop: 'url', class: 'user-reports-item__link' do
           h3.user-reports-item__title(itemprop='name') = report.title
           time.user-reports-item__updated-at(datetime="#{report.updated_at.iso8601}")

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -1,5 +1,5 @@
 .col-xxxl-2.col-xxl-3.col-xl-6.col-lg-6.col-md-6.col-xs-12
-  .users-item.is-rails
+  article.users-item.is-rails
     .users-item__inner.a-card
       .users-item__inactive-message-container.is-only-mentor
         - if (current_user.mentor || current_user.admin) && user.student_or_trainee?

--- a/app/views/users/announcements/_wip_announcements.html.slim
+++ b/app/views/users/announcements/_wip_announcements.html.slim
@@ -1,5 +1,5 @@
 - user.announcements.wip.each do |announcement|
-  .card-list-item.is-announcement
+  article.card-list-item.is-announcement
     .card-list-item__inner
       .card-list-item__label
         span.card-list-item__label-inner

--- a/app/views/users/answers/index.html.slim
+++ b/app/views/users/answers/index.html.slim
@@ -7,7 +7,7 @@
 .page-body
   .container.is-md
     - if @answers.total_pages > 1
-      nav.pagination
+      .pagination
         = paginate @answers
     - if @answers.present?
       .card-list.a-card
@@ -20,5 +20,5 @@
         p.o-empty-message__text
           | 回答はまだありません。
     - if @answers.total_pages > 1
-      nav.pagination
+      .pagination
         = paginate @answers

--- a/app/views/users/areas/_areas_menu.html.slim
+++ b/app/views/users/areas/_areas_menu.html.slim
@@ -1,5 +1,5 @@
 - number_of_users_by_region.each do |region, number_of_users_by_area|
-  nav.page-nav.a-card
+  nav.page-nav.a-card aria-label="#{region}の地域"
     header.page-nav__header
       h2.page-nav__title
         span.page-nav__title-inner = region

--- a/app/views/users/comments/_comment.html.slim
+++ b/app/views/users/comments/_comment.html.slim
@@ -1,5 +1,5 @@
 - commentable = comment.commentable
-.card-list-item(class="is-#{commentable.class.to_s.tableize.singularize}")
+article.card-list-item(class="is-#{commentable.class.to_s.tableize.singularize}")
   .card-list-item__inner
     .card-list-item__label
       - case commentable.class.to_s

--- a/app/views/users/companies/_company.html.slim
+++ b/app/views/users/companies/_company.html.slim
@@ -1,4 +1,4 @@
-.a-card.user-group
+article.a-card.user-group
   header.user-group__header
     h2.group-company-name
       a.group-company-name__link href=company_users_url(company)

--- a/app/views/users/companies/_users_tabs.html.slim
+++ b/app/views/users/companies/_users_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="企業別ユーザー絞り込み"
   .container
     ul.tab-nav__items
       - allowed_targets.each do |allowed_target|

--- a/app/views/users/courses/_users_tabs.html.slim
+++ b/app/views/users/courses/_users_tabs.html.slim
@@ -1,4 +1,4 @@
-nav.tab-nav
+nav.tab-nav aria-label="コース別ユーザー絞り込み"
   .container
     ul.tab-nav__items
       - Users::CoursesController::ALLOWED_TARGETS.each do |target|

--- a/app/views/users/created.html.slim
+++ b/app/views/users/created.html.slim
@@ -26,7 +26,7 @@ ruby:
     .thanks-message__header
       h1.thanks-message__title
         = title
-    .a-card
+  article.a-card
       .card-body.thanks-message__body
         .a-long-text
           - case @role

--- a/app/views/users/events/_wip_events.html.slim
+++ b/app/views/users/events/_wip_events.html.slim
@@ -1,5 +1,5 @@
 - user.events.wip.each do |event|
-  .card-list-item.is-event
+  article.card-list-item.is-event
     .card-list-item__inner
       .card-list-item__label
         .card-list-item__label-inner.is-sm

--- a/app/views/users/events/index.html.slim
+++ b/app/views/users/events/index.html.slim
@@ -15,7 +15,7 @@
             = paginate @events
           .card-list.a-card
             - @events.each do |event|
-              .card-list-item.is-event
+              article.card-list-item.is-event
                 .card-list-item__inner
                   .card-list-item__user
                     = render 'users/icon',

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -39,7 +39,7 @@
       = render 'form', from: :new, url: users_path, user: @user || user
     hr.a-border-tint
     footer.auth-form__footer
-      nav.auth-form-nav
+      nav.auth-form-nav aria-label="参加登録関連リンク"
         ul.auth-form-nav__items
           li.auth-form-nav__item
             = link_to 'トップページ', welcome_path, class: 'auth-form-nav__item-link'

--- a/app/views/users/pages/_wip_pages.html.slim
+++ b/app/views/users/pages/_wip_pages.html.slim
@@ -1,5 +1,5 @@
 - user.pages.wip.each do |page|
-  .card-list-item.is-page
+  article.card-list-item.is-page
     .card-list-item__inner
       .card-list-item__label
         span.card-list-item__label-inner

--- a/app/views/users/practices/_active_practices.html.slim
+++ b/app/views/users/practices/_active_practices.html.slim
@@ -5,7 +5,7 @@
   hr.a-border-tint
   .card-list
     - user.active_practices.each do |practice|
-      .card-list-item
+      article.card-list-item
         .card-list-item__inner
           .card-list-item__rows
             .card-list-item__row

--- a/app/views/users/practices/_active_practices.html.slim
+++ b/app/views/users/practices/_active_practices.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title
       | 進行中のプラクティス

--- a/app/views/users/practices/_completed_practices.html.slim
+++ b/app/views/users/practices/_completed_practices.html.slim
@@ -1,4 +1,4 @@
-.a-card
+section.a-card
   header.card-header.is-sm
     h2.card-header__title 修了したプラクティス
     .card-header__sub-title

--- a/app/views/users/practices/_completed_practices_list.html.slim
+++ b/app/views/users/practices/_completed_practices_list.html.slim
@@ -1,6 +1,6 @@
 .card-list.has-scroll
   - completed_learnings.each do |learning|
-    .card-list-item
+    article.card-list-item
       .card-list-item__rows
         .card-list-item__row
           .card-list-item-title

--- a/app/views/users/products/_wip_products.html.slim
+++ b/app/views/users/products/_wip_products.html.slim
@@ -1,5 +1,5 @@
 - user.products.wip.each do |product|
-  .card-list-item.is-product
+  article.card-list-item.is-product
     .card-list-item__inner
       .card-list-item__label
         span.card-list-item__label-inner

--- a/app/views/users/products/index.html.slim
+++ b/app/views/users/products/index.html.slim
@@ -5,7 +5,7 @@
 = user_page_tabs(@user, active_tab: '提出物')
 
 - if current_user.mentor?
-  nav.pill-nav
+  nav.pill-nav aria-label="ユーザーの提出物絞り込み"
     .container
       ul.pill-nav__items
         li.pill-nav__item

--- a/app/views/users/questions/_wip_questions.html.slim
+++ b/app/views/users/questions/_wip_questions.html.slim
@@ -1,5 +1,5 @@
 - user.questions.wip.each do |question|
-  .card-list-item.is-question
+  article.card-list-item.is-question
     .card-list-item__inner
       .card-list-item__label
         span.card-list-item__label-inner

--- a/app/views/users/regular_events/index.html.slim
+++ b/app/views/users/regular_events/index.html.slim
@@ -15,7 +15,7 @@
             = paginate @regular_events
           .card-list.a-card
             - @regular_events.each do |event|
-              .card-list-item.is-event
+              article.card-list-item.is-event
                 .card-list-item__inner
                   .card-list-item__label(class="is-#{event.category}")
                     = t("activerecord.enums.regular_event.category.#{event.category}")

--- a/app/views/users/reports/_wip_reports.html.slim
+++ b/app/views/users/reports/_wip_reports.html.slim
@@ -1,5 +1,5 @@
 - user.reports.wip.each do |report|
-  .card-list-item.is-report
+  article.card-list-item.is-report
     .card-list-item__inner
       .card-list-item__label
         span.card-list-item__label-inner

--- a/app/views/users/reports/index.html.slim
+++ b/app/views/users/reports/index.html.slim
@@ -5,7 +5,7 @@
 = user_page_tabs(@user, active_tab: '日報')
 
 - if admin_or_mentor_login?
-  nav.tab-nav(class="#{mentor_login? ? 'is-only-mentor' : ''}")
+  nav.tab-nav(class="#{mentor_login? ? 'is-only-mentor' : ''}" aria-label="ユーザーの日報")
     .container
       ul.tab-nav__items
         - targets = %w[all_reports unchecked_reports]
@@ -13,7 +13,7 @@
           li.tab-nav__item
             = link_to t("target.#{target}"), user_reports_path(@user, target:), class: (@target == target ? ['is-active'] : []) << 'tab-nav__item-link'
 
-nav.page-filter.form.pb-0
+nav.page-filter.form.pb-0 aria-label="ユーザーの日報絞り込み"
   .container.is-md
     = form_with url: user_reports_path(@user), local: true, method: :get do
       - if @target == 'unchecked_reports'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -34,7 +34,7 @@
     .container(class="#{visible_learning_time_frames?(@user) ? 'is-xxl' : 'is-xl'}")
       .row
         .col-xs-12(class="#{visible_learning_time_frames?(@user) ? 'col-lg-4 col-xxl-5' : 'col-lg-6 col-xxl-6'}")
-          .page-content.is-user
+          article.page-content.is-user
             = render 'users/profile', user: @user
             .card-counts.is-user
               = render 'users/activity_counts', user: @user

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -82,7 +82,7 @@
               = render '/users/practices/completed_practices', user: @user, completed_learnings: @completed_learnings
           - if admin_login?
             section.a-card.is-only-mentor
-              .card-header.is-sm
+              header.card-header.is-sm
                 h2.card-header__title
                   | ステータス変更
               hr.a-border-tint
@@ -105,7 +105,7 @@
                       data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }
           - if admin_login?
             section.a-card.is-only-mentor
-              .card-header.is-sm
+              header.card-header.is-sm
                 h2.card-header__title
                   | 卒業後の進路
                   | （#{t("activerecord.enums.user.career_path.#{@user.career_path}")}）

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -51,7 +51,7 @@
                   = render 'users/metas', user: @user, user_course_practice: UserCoursePractice.new(@user)
 
             - if admin_or_mentor_login?
-              .a-card.is-only-mentor
+              section.a-card.is-only-mentor
                 header.card-header.is-sm
                   h2.card-header__title
                     | ユーザー非公開情報
@@ -81,7 +81,7 @@
             - cache [@user, @completed_learnings] do
               = render '/users/practices/completed_practices', user: @user, completed_learnings: @completed_learnings
           - if admin_login?
-            .a-card.is-only-mentor
+            section.a-card.is-only-mentor
               .card-header.is-sm
                 h2.card-header__title
                   | ステータス変更
@@ -104,7 +104,7 @@
                     = link_to 'このユーザーを削除する', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: 'a-muted-text-link',
                       data: { confirm: '本当によろしいですか？この操作はデータを削除するため元に戻すことができません。' }
           - if admin_login?
-            .a-card.is-only-mentor
+            section.a-card.is-only-mentor
               .card-header.is-sm
                 h2.card-header__title
                   | 卒業後の進路

--- a/app/views/watches/_watch.html.slim
+++ b/app/views/watches/_watch.html.slim
@@ -1,5 +1,5 @@
 - watchable = watch.watchable
-.card-list-item.a_watch(id="#{watch.id}")
+article.card-list-item.a_watch(id="#{watch.id}")
   .card-list-item__inner
     .card-list-item__label
       - case watchable.class.to_s

--- a/app/views/welcome/_alumni_voices.html.slim
+++ b/app/views/welcome/_alumni_voices.html.slim
@@ -16,7 +16,7 @@ section.lp-content.is-lp-bg-1.is-top-title
 
                   - articles.each do |article|
                     .col-xs-6.col-md-4
-                      .thumbnail-card.a-card
+                      article.thumbnail-card.a-card
                         = link_to article_path(article), class: 'thumbnail-card__inner' do
                           = image_tag article.prepared_thumbnail_url, class: 'thumbnail-card__image', alt: "#{article.title}の記事のサムネイル"
                           .thumbnail-card__row

--- a/app/views/welcome/_articles.html.slim
+++ b/app/views/welcome/_articles.html.slim
@@ -47,7 +47,7 @@ section.lp-content.is-lp-bg-1.is-top-title.is-articles#articles
                                     = image_tag article.user.avatar_url
                                     = article.user.login_name
                                 .articles-item__meta
-                                  .articles-item__published-at
+                                  time.articles-item__published-at datetime=article.published_at.iso8601
                                     = l(article.published_at)
 
           .lp-content-stack__item

--- a/app/views/welcome/_articles.html.slim
+++ b/app/views/welcome/_articles.html.slim
@@ -24,7 +24,7 @@ section.lp-content.is-lp-bg-1.is-top-title.is-articles#articles
                   .row.is-gutter-width-32
                     - @featured_articles.each do |article|
                       .col-lg-4.col-md-6.col-xs-12
-                        .articles-item.a-card
+                        article.articles-item.a-card
                           = link_to article, class: 'articles-item__link' do
                             .articles-item__row
                               - if article.prepared_thumbnail?

--- a/app/views/welcome/buzzes.html.slim
+++ b/app/views/welcome/buzzes.html.slim
@@ -46,7 +46,7 @@ section.lp-content.is-lp-bg-1.is-top-title
 
                         - if admin_or_mentor_login?
                           hr.a-border-tint
-                          .card-footer
+                          footer.card-footer
                             .card-main-actions
                               ul.card-main-actions__items
                                 li.card-main-actions__item

--- a/app/views/welcome/certified_reskill_courses/rails_developer_course/_course_duration.html.slim
+++ b/app/views/welcome/certified_reskill_courses/rails_developer_course/_course_duration.html.slim
@@ -11,7 +11,7 @@ section.lp-content.is-lp-bg-1.is-top-title
             .l-cards.is-stacked
               .l-cards__item
                 .l-cards__item-inner
-                  .a-card
+                  section.a-card
                     .lp-left-image-section
                       .lp-left-image-section__inner
                         .lp-left-image-section__start.is-hidden-sm-down

--- a/app/views/welcome/certified_reskill_courses/rails_developer_course/_course_fees.html.slim
+++ b/app/views/welcome/certified_reskill_courses/rails_developer_course/_course_fees.html.slim
@@ -11,7 +11,7 @@ section.lp-content.is-lp-bg-2.is-top-title
             .l-cards.is-stacked
               .l-cards__item.is-wide
                 .l-cards__item-inner
-                  .a-card
+                  section.a-card
                     .flex
                       .lp-left-image-section
                         .lp-left-image-section__inner
@@ -37,7 +37,7 @@ section.lp-content.is-lp-bg-2.is-top-title
                                   | サブスクではなく、一括でお支払いいただく必要があります。
               .l-cards__item.is-wide
                 .l-cards__item-inner
-                  .a-card.is-danger
+                  section.a-card.is-danger
                     .lp-left-image-section
                       .lp-left-image-section__inner
                         .lp-left-image-section__start.is-hidden-sm-down

--- a/app/views/welcome/faq.html.slim
+++ b/app/views/welcome/faq.html.slim
@@ -12,7 +12,7 @@
             = title
         .lp-page-header__end
           - if current_user&.admin?
-            nav.lp-page-header-nav
+            nav.lp-page-header-nav aria-label="FAQメニュー"
               ul.lp-page-header-nav__items
                 li.lp-page-header-nav__item
                   = link_to new_admin_faq_path, class: 'a-button is-md is-secondary-border is-block' do

--- a/app/views/welcome/faqs/_faqs_pc_filter.html.slim
+++ b/app/views/welcome/faqs/_faqs_pc_filter.html.slim
@@ -1,4 +1,4 @@
-.side-filter
+nav.side-filter aria-label="FAQカテゴリーフィルター"
   .a-card
     ul.side-filter__items
       li.side-filter__item

--- a/app/views/welcome/press_kit.html.slim
+++ b/app/views/welcome/press_kit.html.slim
@@ -107,7 +107,7 @@ hr.a-border
                                   = image_tag press_release.user.avatar_url
                                   = press_release.user.login_name
                               .thumbnail-card__meta
-                                .thumbnail-card__date
+                                time.thumbnail-card__date datetime=press_release.published_at.iso8601
                                   = l(press_release.published_at)
               .lp-content-stack__item
                 .lp-actions

--- a/app/views/welcome/press_kit.html.slim
+++ b/app/views/welcome/press_kit.html.slim
@@ -90,7 +90,7 @@ hr.a-border
                 .row
                   - @press_releases.each do |press_release|
                     .col-lg-4.col-md-6.col-xs-12
-                      .thumbnail-card.a-card
+                      article.thumbnail-card.a-card
                         = link_to press_release, class: 'thumbnail-card__inner' do
                           .thumbnail-card__row
                             - if press_release.prepared_thumbnail?

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -55,7 +55,7 @@ hr.a-border
         hr.a-border-tint
           = render 'reactions/reactions', reactionable: @work
         hr.a-border-tint
-        .card-footer
+        footer.card-footer
           .card-main-actions
             ul.card-main-actions__items
               - if @work.url.present?
@@ -75,7 +75,7 @@ hr.a-border
                     | リリースブログ
         - if @work.user == current_user || admin_or_mentor_login?
           hr.a-border-tint
-          .card-footer
+          footer.card-footer
             .card-main-actions
               ul.card-main-actions__items
                 li.card-main-actions__item

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -44,7 +44,7 @@ hr.a-border
                     time.a-meta__value datetime=@work.created_at.iso8601
                       = l @work.created_at
 
-      .a-card
+      article.a-card
         .card-body
           - if @work.thumbnail.attached?
             .card-eyecatch

--- a/test/jobs/bulk_generate_movie_thumbnail_job_test.rb
+++ b/test/jobs/bulk_generate_movie_thumbnail_job_test.rb
@@ -5,6 +5,12 @@ require 'test_helper'
 class BulkGenerateMovieThumbnailJobTest < ActiveJob::TestCase
   test 'generates thumbnails synchronously for movies without one' do
     movie = movies(:movie1)
+    thumbnail_path = Rails.root.join('test/fixtures/files/articles/ogp_images/test.jpg')
+    Movie.where.not(id: movie.id).find_each do |other_movie|
+      File.open(thumbnail_path) do |thumbnail|
+        other_movie.thumbnail.attach(io: thumbnail, filename: 'test.jpg', content_type: 'image/jpeg')
+      end
+    end
     movie.thumbnail.purge
     movie.movie_data.attach(
       io: File.open(Rails.root.join('test/fixtures/files/movies/movie.mp4')),


### PR DESCRIPTION
## 概要

HTMLの負債返済として、`div` 主体だったビューを HTML5 のランドマーク要素に置き換えます。歴史的経緯で `div` が積み重なっていた箇所を、**クラス名・id・`js-`フック・Stimulus `data-*` は一切変えずに**、要素だけセマンティックにしています（＝スタイルと挙動は不変）。

全体対応の第一弾として、ビジュアルリグレッションテストで「見た目が変わっていないこと」を裏取りできるページから着手しました。

## 変更内容

### `reports/show`（`div` 49 / セマンティック要素 2 と、最も負債が大きいページ）
| 変更 | 意味 |
|---|---|
| `.report.page-content` → `<article>` | 日報本体 |
| `.page-content-prev-next` → `<nav>` | 前 / 一覧 / 次 のページャ |
| `.side-tabs` → `<aside>` | メンター用サイドパネル |
| `.side-tabs-nav` → `<nav>` | サイドパネルのタブナビ |
| `.user-metas`（見出しあり） → `<section>` | スキップするプラクティス一覧 |

### `users/show`
- プロフィール本体 `.page-content.is-user` → `<article>`（`reports/show` と揃える）

## 安全性の担保

- 変換先は **余白を持たないブロックのランドマーク要素**（`article/section/nav/aside`）に限定。`ul/li/p/h*` など既定マージンやリストスタイルを持つ要素へは変換していないので、レイアウトに影響しません。
- 対象クラスに **要素限定セレクタ（`div.foo`）や `> div` 子結合子の CSS が無いこと**を確認済み。クラスセレクタは要素非依存なのでスタイルは一致します。
- **ビジュアルリグレッションテストで before/after を実測**：
  - `report_show`: **0 diff（完全一致）**
  - `user_profile`: 41px（0.002%、アンチエイリアスのノイズ床内）
- `slim-lint` パス。テストのアサートセレクタ（`.page-content` 等）も維持。

## 補足・今後

- ビジュアルテスト対象の他ページ（`users/index`・ダッシュボード等）は既にほぼセマンティックだったため対象外。
- 負債の本体はビジュアルテスト外の `div` まみれページ（`welcome/*`・各種フォーム・`products`・`talks` など）。上記「要素のみ＋CSS安全チェック」方式で順次、別PRで対応予定。
- クラス名そのものの意味ベース化は、横断利用が多く影響範囲が広いため、コンポーネント単位で別途対応予定。
- 既存debt メモ: レイアウトの `main.page` 内に一部ページが `main.page-main` を入れており `main` が二重。全ページ横断のため別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor
* 複数ページで、本文・サイドタブ・ユーザーメタ・「前へ/次へ」などの領域を、より意味のあるHTML（`article` / `aside` / `nav` / `section`）へ整理しました。  
* カードリストやコメントなどの外側要素も、表示内容を維持したまま `article.card-list-item` に統一し、ページ構造のセマンティクスを改善しました。  
* 前後ナビを `nav` 化し、必要に応じてラベル（例：提出物ナビゲーション）を付与しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/31630152538/artifacts/9155521952" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10299-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
