### PR TITLE
ステージングtaskのAPP_HOST_NAME未設定エラーを修正

### DIFF
--- a/.cloudbuild/cloudbuild-task.yaml
+++ b/.cloudbuild/cloudbuild-task.yaml
@@ -35,6 +35,7 @@ steps:
   - "-c"
   - |-
     eval "$(.cloudbuild/cloud-build-env exports)"
+    export APP_HOST_NAME="${APP_HOST_NAME:-bootcamp-staging.fjord.jp}"
     bin/rails bootcamp:oneshot:cloudbuild
 - id: Kill_SqlProxy
   name: gcr.io/cloud-builders/docker
@@ -50,7 +51,7 @@ options:
   substitutionOption: ALLOW_LOOSE
   automapSubstitutions: true
 substitutions:
-  _APP_HOST_NAME: _
+  _APP_HOST_NAME: bootcamp-staging.fjord.jp
   _CLOUD_SQL_HOST: _
   _DB_NAME: _
   _DB_PASS: _


### PR DESCRIPTION
## 概要

ステージングのCloud Build task実行時に、`APP_HOST_NAME`が未設定または空でも`bootcamp-staging.fjord.jp`を使用するように修正します。

## 原因

Cloud Buildのsubstitutionから`APP_HOST_NAME`を生成していましたが、`_APP_HOST_NAME`が空の場合、そのまま空値が渡されてproduction環境の起動時チェックに失敗していました。

## 変更内容

- `_APP_HOST_NAME`の既定値をステージングのホスト名へ変更
- task実行直前にも空値をステージングのホスト名で補完

## 影響

ステージングのoneshot taskのみが対象です。明示的に空でない`APP_HOST_NAME`が渡された場合はその値を維持します。

## 確認

- `bin/rails test test/lib/cloud_build_env_test.rb`（4 runs, 53 assertions, 0 failures）
- YAML設定の構文・補完式・既定値を確認
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * アプリケーションのホスト名設定を追加し、既定値として `bootcamp-staging.fjord.jp` を使用するよう変更しました。
  * 設定が未指定の場合も、同じホスト名で安定して起動します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29563734795/artifacts/8400539856" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
