### PR TITLE
ステージングtaskのproduction起動に必要な環境変数を設定

### DIFF
--- a/.cloudbuild/cloudbuild-task.yaml
+++ b/.cloudbuild/cloudbuild-task.yaml
@@ -36,6 +36,7 @@ steps:
   - |-
     eval "$(.cloudbuild/cloud-build-env exports)"
     export APP_HOST_NAME="${APP_HOST_NAME:-bootcamp-staging.fjord.jp}"
+    export SECRET_KEY_BASE="${SECRET_KEY_BASE:-dummy}"
     bin/rails bootcamp:oneshot:cloudbuild
 - id: Kill_SqlProxy
   name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
## 概要

ステージング用one-shot taskのRails起動に必要な環境変数へ既定値を設定します。

- `APP_HOST_NAME` に `bootcamp-staging.fjord.jp` を設定
- `SECRET_KEY_BASE` にone-shot task用の `dummy` を設定

## 背景

Rails 8.1のproduction環境では、起動時に `APP_HOST_NAME` と `secret_key_base` が必要です。ステージングtaskではこれらが供給されず、`bootcamp:oneshot:cloudbuild` の実行前に起動エラーになっていました。

`SECRET_KEY_BASE=dummy` はone-shot taskコンテナ内だけで使用され、Cloud Runサービス本体の秘密鍵には影響しません。

## 確認

- `RAILS_ENV=production SECRET_KEY_BASE=dummy APP_HOST_NAME=bootcamp-staging.fjord.jp bin/rails runner`
- `bin/rails test test/lib/cloud_build_env_test.rb test/lib/deploy_cloud_run_test.rb`（7 runs, 72 assertions, 0 failures, 0 errors）
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `SECRET_KEY_BASE` が未設定の場合でも、ビルド処理を実行できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29574299184/artifacts/8404673455" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10303-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->