### PR TITLE
ステージングtaskに実行環境変数を明示する

### DIFF
--- a/.cloudbuild/cloudbuild-task.yaml
+++ b/.cloudbuild/cloudbuild-task.yaml
@@ -25,6 +25,15 @@ steps:
 - id: Task
   name: asia.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA
   automapSubstitutions: true
+  env:
+  - RAILS_ENV=production
+  - APP_HOST_NAME=bootcamp-staging.fjord.jp
+  - SECRET_KEY_BASE=dummy
+  - DB_HOST=/cloudsql/$_CLOUD_SQL_HOST
+  - DB_NAME=$_DB_NAME
+  - DB_USER=$_DB_USER
+  - DB_PASS=$_DB_PASS
+  - OPEN_AI_ACCESS_TOKEN=$_OPEN_AI_ACCESS_TOKEN
   waitFor:
   - Build
   volumes:
@@ -34,9 +43,6 @@ steps:
   - bash
   - "-c"
   - |-
-    eval "$(.cloudbuild/cloud-build-env exports)"
-    export APP_HOST_NAME="${APP_HOST_NAME:-bootcamp-staging.fjord.jp}"
-    export SECRET_KEY_BASE="${SECRET_KEY_BASE:-dummy}"
     bin/rails bootcamp:oneshot:cloudbuild
 - id: Kill_SqlProxy
   name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
## 概要

ステージング用one-shot taskのコンテナへ、RailsとDB接続に必要な環境変数を明示的に設定します。

## 背景

`automapSubstitutions` と `cloud-build-env exports` による変換後も `DB_HOST` が設定されず、Railsが `/var/run/postgresql/.s.PGSQL.5432` のローカルソケットへ接続して失敗していました。同じログで `OPEN_AI_ACCESS_TOKEN` も未設定だったため、taskに必要なCloud Build substitutionsをstepの `env` へ直接割り当てます。

これによりDB接続先はCloud SQL Proxyが公開する `/cloudsql/$_CLOUD_SQL_HOST` になります。

## 確認

- Cloud Build YAMLをパースし、Task stepの環境変数を確認
- production設定で `DB_HOST=/cloudsql/test` がDB設定へ反映されることを確認
- `bin/rails test test/lib/cloud_build_env_test.rb test/lib/deploy_cloud_run_test.rb`（7 runs, 72 assertions, 0 failures, 0 errors）
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 本番環境でのデプロイ時に、アプリケーション設定や各種接続情報がより確実に引き渡されるようになりました。
  * デプロイ処理が簡素化され、起動コマンドを直接実行する構成になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29591397008/artifacts/8411540104" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10304-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->