### PR TITLE
oneshotで既存動画のサムネイルが生成されない不具合を修正

### DIFF
--- a/app/jobs/bulk_generate_movie_thumbnail_job.rb
+++ b/app/jobs/bulk_generate_movie_thumbnail_job.rb
@@ -3,7 +3,7 @@
 class BulkGenerateMovieThumbnailJob < ApplicationJob
   def perform
     Movie.where.missing(:thumbnail_attachment).find_each do |movie|
-      GenerateMovieThumbnailJob.perform_later(movie)
+      GenerateMovieThumbnailJob.perform_now(movie)
     end
   end
 end

--- a/test/jobs/bulk_generate_movie_thumbnail_job_test.rb
+++ b/test/jobs/bulk_generate_movie_thumbnail_job_test.rb
@@ -3,12 +3,17 @@
 require 'test_helper'
 
 class BulkGenerateMovieThumbnailJobTest < ActiveJob::TestCase
-  test 'enqueues GenerateMovieThumbnailJob for movies without a thumbnail' do
+  test 'generates thumbnails synchronously for movies without one' do
     movie = movies(:movie1)
     movie.thumbnail.purge
+    movie.movie_data.attach(
+      io: File.open(Rails.root.join('test/fixtures/files/movies/movie.mp4')),
+      filename: 'movie.mp4',
+      content_type: 'video/mp4'
+    )
 
-    assert_enqueued_with(job: GenerateMovieThumbnailJob, args: [movie]) do
-      BulkGenerateMovieThumbnailJob.perform_now
-    end
+    BulkGenerateMovieThumbnailJob.perform_now
+
+    assert movie.reload.thumbnail.attached?
   end
 end


### PR DESCRIPTION
perform_nowでコンテナ内で同期的にやり切るよう変更。
テストもエンキュー検証から実際のサムネイル生成検証へ変更。

<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/pull/10257

## Screenshot
<img width="1064" height="366" alt="image" src="https://github.com/user-attachments/assets/df89f4b4-d397-4efa-b418-41aab80a6c8c" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 映画のサムネイル一括生成が、処理完了時点で各映画に反映されるようになりました。
  - 一括処理後に、生成されたサムネイルをすぐ確認できるようになりました。

- **不具合修正**
  - サムネイル生成結果が一括処理の完了時に反映されない場合がある問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29640004700/artifacts/8428416871" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10307-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->