### PR TITLE
oneshotで既存動画のサムネイルが生成されない不具合を修正

### DIFF
--- a/app/jobs/bulk_generate_movie_thumbnail_job.rb
+++ b/app/jobs/bulk_generate_movie_thumbnail_job.rb
@@ -3,7 +3,7 @@
 class BulkGenerateMovieThumbnailJob < ApplicationJob
   def perform
     Movie.where.missing(:thumbnail_attachment).find_each do |movie|
-      GenerateMovieThumbnailJob.perform_later(movie)
+      GenerateMovieThumbnailJob.perform_now(movie)
     end
   end
 end

--- a/test/jobs/bulk_generate_movie_thumbnail_job_test.rb
+++ b/test/jobs/bulk_generate_movie_thumbnail_job_test.rb
@@ -3,12 +3,17 @@
 require 'test_helper'
 
 class BulkGenerateMovieThumbnailJobTest < ActiveJob::TestCase
-  test 'enqueues GenerateMovieThumbnailJob for movies without a thumbnail' do
+  test 'generates thumbnails synchronously for movies without one' do
     movie = movies(:movie1)
     movie.thumbnail.purge
+    movie.movie_data.attach(
+      io: File.open(Rails.root.join('test/fixtures/files/movies/movie.mp4')),
+      filename: 'movie.mp4',
+      content_type: 'video/mp4'
+    )
 
-    assert_enqueued_with(job: GenerateMovieThumbnailJob, args: [movie]) do
-      BulkGenerateMovieThumbnailJob.perform_now
-    end
+    BulkGenerateMovieThumbnailJob.perform_now
+
+    assert movie.reload.thumbnail.attached?
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/pull/10257

## 概要
BulkGenerateMovieThumbnailJobが子ジョブをperform_laterで積むだけだったため、 Solid Queueワーカーを持たないoneshotの使い捨てコンテナでは一件も実行されず、ステージングで既存サムネイルが生成されなかった。

perform_nowですぐ実行されるように修正しました。
テストもエンキュー検証から実際のサムネイルが生成されたかを確認するように修正しました。

## Screenshot

<img width="1063" height="359" alt="image" src="https://github.com/user-attachments/assets/80b12af1-14cc-43ae-872b-20f333cc72b6" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * サムネイル一括生成時に、各ムービーのサムネイルが処理中に同期生成されるようになりました。
  * 処理完了時にサムネイルが確実に添付されていることを確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29640451963/artifacts/8428540411" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10308-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->