### PR TITLE
休会時に復帰せずに退会できる機能を実装

### DIFF
--- a/app/controllers/hibernated_retirement_controller.rb
+++ b/app/controllers/hibernated_retirement_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class HibernatedRetirementController < ApplicationController
+  skip_before_action :require_active_user_login, raise: false
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = login(params[:user][:email], params[:user][:password])
+    if @user
+      if @user&.hibernated?
+          retirement = Retirement.by_self(retire_reason_params, user: current_user)
+          if retirement.execute
+            logout
+            redirect_to retirement_url
+          else
+            current_user.retired_on = nil
+            @regular_events_without_finished = RegularEvent.organizer_event(current_user).exclude_finished
+            render :new
+          end
+      else
+        @user = User.new
+        flash.now[:alert] = '休会していないユーザーです。'
+        render 'new'
+      end
+    else
+      @user = User.new
+      flash.now[:alert] = 'メールアドレスかパスワードが違います。'
+      render 'new'
+    end
+  end
+
+  private
+
+  def retire_reason_params
+    params.require(:user).permit(:retire_reason, :satisfaction, :opinion, retire_reasons: [])
+  end
+
+end

--- a/app/controllers/hibernated_retirement_controller.rb
+++ b/app/controllers/hibernated_retirement_controller.rb
@@ -11,31 +11,32 @@ class HibernatedRetirementController < ApplicationController
     @user = login(params[:user][:email], params[:user][:password])
     if @user
       if @user&.hibernated?
-          retirement = Retirement.by_self(retire_reason_params, user: current_user)
-          if retirement.execute
-            logout
-            redirect_to retirement_url
-          else
-            current_user.retired_on = nil
-            @regular_events_without_finished = RegularEvent.organizer_event(current_user).exclude_finished
-            render :new
-          end
+        retirement = Retirement.by_self(retire_reason_params, user: current_user)
+        if retirement.execute
+          logout
+          redirect_to retirement_url
+        else
+          current_user.retired_on = nil
+          @regular_events_without_finished = RegularEvent.organizer_event(current_user).exclude_finished
+          render :new
+        end
       else
-        @user = User.new
-        flash.now[:alert] = '休会していないユーザーです。'
-        render 'new'
+        flash_message('休会していないユーザーです。')
       end
     else
-      @user = User.new
-      flash.now[:alert] = 'メールアドレスかパスワードが違います。'
-      render 'new'
+      flash_message('メールアドレスかパスワードが違います。')
     end
   end
 
   private
 
+  def flash_message(message)
+    @user = User.new
+    flash.now[:alert] = message
+    render 'new'
+  end
+
   def retire_reason_params
     params.require(:user).permit(:retire_reason, :satisfaction, :opinion, retire_reasons: [])
   end
-
 end

--- a/app/views/comeback/new.html.slim
+++ b/app/views/comeback/new.html.slim
@@ -30,3 +30,6 @@
               class: 'auth-form-nav__item-link',
               target: '_blank',
               rel: 'noopener'
+          li.auth-form-nav__item
+            = link_to '退会手続き', new_hibernated_retirement_path,
+              class: 'auth-form-nav__item-link'

--- a/app/views/hibernated_retirement/new.html.slim
+++ b/app/views/hibernated_retirement/new.html.slim
@@ -1,0 +1,58 @@
+- title '退会手続き'
+
+header.page-header
+  .container
+    .page-header__inner
+      .page-header__start
+        .page-header__title
+          = title
+hr.a-border
+.auth-form.is-lg
+  .a-card
+    header.auth-form__header
+      h1.auth-form__title 退会手続き
+    .auth-form__body
+      = form_with model: @user, local: true, url: hibernated_retirement_path, method: :post, class: 'form' do |f|
+        .form__items
+          - if @regular_events_without_finished.any?
+            .form-item
+              = render 'shared/regular_events_warning',
+                events: @regular_events_without_finished,
+                case_text: '退会をお考えの',
+                action_text: '退会'
+          .form-item
+            = f.label :email, 'メールアドレスをご記入ください', class: 'a-form-label'
+            = f.text_field :email
+          .form-item
+            = f.label :password, 'パスワードをご記入ください', class: 'a-form-label'
+            = f.password_field :password
+          .form-item
+            = f.label :retire_reasons, '退会の理由を教えてください（複数選択可）', class: 'a-form-label'
+            .checkboxes
+              ul.checkboxes__items
+                = f.collection_check_boxes :retire_reasons, User.retire_reasons.pairs, :second, :first, class: 'label-checkbox' do |b|
+                  li.checkboxes__item
+                    = b.check_box(class: 'a-toggle-checkbox')
+                    = b.label { b.text }
+          .form-item
+            = f.label :retire_reason, '上記を選んだ理由を教えてください。複数選んだ方は最も大きな理由を教えてください', class: 'a-form-label'
+            = f.text_area :retire_reason, class: 'a-text-input is-md', placeholder: '上記を選んだ理由を教えてください。複数選んだ方は最も大きな理由を教えてください'
+          .form-item
+            = f.label :satisfaction, '全体の満足度を教えてください', class: 'a-form-label is-required'
+            ul.block-checks.is-2-items
+              = f.collection_radio_buttons :satisfaction, User.satisfactions, :first, :first do |b|
+                li.block-checks__item
+                  .a-block-check.is-radio
+                    = b.radio_button(class: 'a-toggle-checkbox')
+                    label.a-block-check__label(for="user_satisfaction_#{b.value}")
+                      = t("activerecord.enums.user.satisfaction.#{b.text}")
+          .form-item
+            = f.label :opinion, 'ご意見や改善すべきと感じた点がございましたらご自由にご記載ください', class: 'a-form-label'
+            = f.text_area :opinion, class: 'a-text-input is-md', placeholder: 'ご意見や改善すべきと感じた点がございましたらご自由にご記載ください'
+
+        .form-actions
+          ul.form-actions__items
+            li.form-actions__item.is-main
+              = link_to 'キャンセル', :back, class: 'a-button is-md is-secondary is-block'
+            li.form-actions__item.is-main
+              = f.submit '退会する', class: 'a-button is-md is-danger is-block', data: { confirm: '本当によろしいですか？' }

--- a/app/views/hibernated_retirement/new.html.slim
+++ b/app/views/hibernated_retirement/new.html.slim
@@ -13,42 +13,35 @@ hr.a-border
       h1.auth-form__title 退会手続き
     .auth-form__body
       = form_with model: @user, local: true, url: hibernated_retirement_path, method: :post, class: 'form' do |f|
-        .form__items
-          - if @regular_events_without_finished.any?
-            .form-item
-              = render 'shared/regular_events_warning',
-                events: @regular_events_without_finished,
-                case_text: '退会をお考えの',
-                action_text: '退会'
-          .form-item
-            = f.label :email, 'メールアドレスをご記入ください', class: 'a-form-label'
-            = f.text_field :email
-          .form-item
-            = f.label :password, 'パスワードをご記入ください', class: 'a-form-label'
-            = f.password_field :password
-          .form-item
-            = f.label :retire_reasons, '退会の理由を教えてください（複数選択可）', class: 'a-form-label'
-            .checkboxes
-              ul.checkboxes__items
-                = f.collection_check_boxes :retire_reasons, User.retire_reasons.pairs, :second, :first, class: 'label-checkbox' do |b|
-                  li.checkboxes__item
-                    = b.check_box(class: 'a-toggle-checkbox')
-                    = b.label { b.text }
-          .form-item
-            = f.label :retire_reason, '上記を選んだ理由を教えてください。複数選んだ方は最も大きな理由を教えてください', class: 'a-form-label'
-            = f.text_area :retire_reason, class: 'a-text-input is-md', placeholder: '上記を選んだ理由を教えてください。複数選んだ方は最も大きな理由を教えてください'
-          .form-item
-            = f.label :satisfaction, '全体の満足度を教えてください', class: 'a-form-label is-required'
-            ul.block-checks.is-2-items
-              = f.collection_radio_buttons :satisfaction, User.satisfactions, :first, :first do |b|
-                li.block-checks__item
-                  .a-block-check.is-radio
-                    = b.radio_button(class: 'a-toggle-checkbox')
-                    label.a-block-check__label(for="user_satisfaction_#{b.value}")
-                      = t("activerecord.enums.user.satisfaction.#{b.text}")
-          .form-item
-            = f.label :opinion, 'ご意見や改善すべきと感じた点がございましたらご自由にご記載ください', class: 'a-form-label'
-            = f.text_area :opinion, class: 'a-text-input is-md', placeholder: 'ご意見や改善すべきと感じた点がございましたらご自由にご記載ください'
+        .form-item
+          = f.label :email, 'メールアドレスをご記入ください', class: 'a-form-label'
+          = f.text_field :email
+        .form-item
+          = f.label :password, 'パスワードをご記入ください', class: 'a-form-label'
+          = f.password_field :password
+        .form-item
+          = f.label :retire_reasons, '退会の理由を教えてください（複数選択可）', class: 'a-form-label'
+          .checkboxes
+            ul.checkboxes__items
+              = f.collection_check_boxes :retire_reasons, User.retire_reasons.pairs, :second, :first, class: 'label-checkbox' do |b|
+                li.checkboxes__item
+                  = b.check_box(class: 'a-toggle-checkbox')
+                  = b.label { b.text }
+        .form-item
+          = f.label :retire_reason, '上記を選んだ理由を教えてください。複数選んだ方は最も大きな理由を教えてください', class: 'a-form-label'
+          = f.text_area :retire_reason, class: 'a-text-input is-md', placeholder: '上記を選んだ理由を教えてください。複数選んだ方は最も大きな理由を教えてください'
+        .form-item
+          = f.label :satisfaction, '全体の満足度を教えてください', class: 'a-form-label is-required'
+          ul.block-checks.is-2-items
+            = f.collection_radio_buttons :satisfaction, User.satisfactions, :first, :first do |b|
+              li.block-checks__item
+                .a-block-check.is-radio
+                  = b.radio_button(class: 'a-toggle-checkbox')
+                  label.a-block-check__label(for="user_satisfaction_#{b.value}")
+                    = t("activerecord.enums.user.satisfaction.#{b.text}")
+        .form-item
+          = f.label :opinion, 'ご意見や改善すべきと感じた点がございましたらご自由にご記載ください', class: 'a-form-label'
+          = f.text_area :opinion, class: 'a-text-input is-md', placeholder: 'ご意見や改善すべきと感じた点がございましたらご自由にご記載ください'
 
         .form-actions
           ul.form-actions__items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
   resources :request_retirements, only: %i(show new create)
   resource :hibernation, only: %i(show new create), controller: "hibernation"
   resource :comeback, only: %i(new create), controller: "comeback"
+  resource :hibernated_retirement, only: %i(new create), controller: "hibernated_retirement"
   resource :current_user, only: %i(edit update), controller: "current_user" do
     resource :password, only: %i(edit update), controller: "current_user/password"
   end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10290

## 概要
休会時に復帰せずに退会できる機能
※CIチェックで、以下のエラーが出ます。
Google Cloudにログインするためのsecretを使おうとしますが、生徒のPRにはそのsecretが渡されないため、ログインの時点で失敗していると考えられます。これはfjordllc/bootcampメンターの皆様が同じ処理を実行すれば問題なく通る仕組みではないかと考えます。よって、エラーは一旦保留とします。それ以外はOKです。
```
Error: google-github-actions/auth failed with: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork. For more information, please see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
```

## 変更確認方法

1. {hibernated retirement}をローカルに取り込む
2. http://127.0.0.1:3000/comeback/new にアクセス、フッターメニュー下の大会手続きを行う

## Screenshot

### 変更前
<img width="1014" height="982" alt="image" src="https://github.com/user-attachments/assets/6aeb9cf9-22ff-4703-b7f4-a481edac8806" />


### 変更後
<img width="1014" height="982" alt="image" src="https://github.com/user-attachments/assets/a713aa0d-de58-4414-a965-f0ea55691cae" />

<img width="1804" height="3017" alt="image" src="https://github.com/user-attachments/assets/e1daa30a-2ee8-4547-ac31-5f21399bc7f0" />

### お金にまつわる課題
## 動作確認について
開発環境でkyuukaiユーザー(休会済みのfixtureデータ)を使って動作確認したところ、退会処理自体(DBの更新)は成功するのですが、直後の「Stripeサブスクリプション解約」処理で以下のエラーが発生し、トランザクション全体がロールバックされてしまう状態でした。


Failed to delete subscription: No such subscription: 'sub_12345678'
kyuukaiユーザーのfixtureに設定されているsubscription_id: sub_12345678が実在しないダミー値のためだと思われます。コード自体の不具合ではなく、開発環境のテストデータに起因するものと考えているのですが、認識に相違ないでしょうか。

<!-- I want to review in Japanese. -->
