### PR TITLE
ステージングビルドのリージョン指定を修正

### DIFF
--- a/.cloudbuild/cloudbuild-staging.yaml
+++ b/.cloudbuild/cloudbuild-staging.yaml
@@ -12,14 +12,14 @@ steps:
     current_create_time="$(
       gcloud builds describe "$current_build_id" \
         --project="$PROJECT_ID" \
-        --region=global \
+        --region=asia-northeast1 \
         --format="value(createTime)"
     )"
 
     echo "Cancelling previous running staging builds..."
     gcloud builds list \
       --project="$PROJECT_ID" \
-      --region=global \
+      --region=asia-northeast1 \
       --filter="substitutions.TRIGGER_NAME=cloud-run-deploy-staging AND (status=QUEUED OR status=WORKING)" \
       --format="value(id,createTime)" |
       while read -r build_id create_time; do
@@ -27,7 +27,7 @@ steps:
           echo "Cancelling previous build: $build_id"
           gcloud builds cancel "$build_id" \
             --project="$PROJECT_ID" \
-            --region=global \
+            --region=asia-northeast1 \
             --quiet || true
         fi
       done
@@ -67,7 +67,7 @@ steps:
   - --build
   - "$PROJECT_ID"
   - "$BUILD_ID"
-  - global
+  - asia-northeast1
   waitFor:
   - Push
 - id: StopCloudRun

--- a/test/lib/cloudbuild_staging_test.rb
+++ b/test/lib/cloudbuild_staging_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'test_helper'
+
+class CloudbuildStagingTest < ActiveSupport::TestCase
+  CONFIG = Rails.root.join('.cloudbuild/cloudbuild-staging.yaml')
+  BUILD_REGION = 'asia-northeast1'
+
+  test 'uses the regional build location for build API calls' do
+    steps = YAML.safe_load_file(CONFIG).fetch('steps')
+    cancel_script = steps.find { |step| step['id'] == 'CancelPreviousBuilds' }.fetch('args').last
+    write_env_args = steps.find { |step| step['id'] == 'WriteSubstitutionEnv' }.fetch('args')
+
+    assert_includes cancel_script, "--region=#{BUILD_REGION}"
+    assert_not_includes cancel_script, '--region=global'
+    assert_equal BUILD_REGION, write_env_args.last
+  end
+end


### PR DESCRIPTION
## 概要

ステージングのCloud Buildがリージョナルビルドを`global`で参照し、`NOT_FOUND`になる問題を修正します。

## 変更内容

- `builds describe`、`list`、`cancel`のリージョンを`asia-northeast1`に統一
- ビルド置換値取得時のリージョンも`asia-northeast1`に変更
- リージョン指定の回帰テストを追加

## 確認方法

- `bin/rails test test/lib/cloudbuild_staging_test.rb test/lib/cloud_build_env_test.rb`
- `bundle exec rubocop test/lib/cloudbuild_staging_test.rb`
- YAMLの読み込み確認
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ステージング環境のビルド管理で、アジア北東部リージョンを正しく使用するよう修正しました。
  * 既存ビルドの検索・比較・キャンセル処理が、対象リージョンに対して実行されるようになりました。

* **テスト**
  * ステージング用ビルドが正しいリージョン設定を使用することを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29690916424/artifacts/8443664764" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10311-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->