### PR TITLE
日報作成画面に「直近の日報を複製」ボタンを追加した

### DIFF
--- a/app/controllers/api/reports/latest_controller.rb
+++ b/app/controllers/api/reports/latest_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class API::Reports::LatestController < API::BaseController
+  def show
+    @report = current_user
+              .reports
+              .order(reported_on: :desc)
+              .first
+  end
+end

--- a/app/controllers/api/reports/latest_controller.rb
+++ b/app/controllers/api/reports/latest_controller.rb
@@ -2,9 +2,12 @@
 
 class API::Reports::LatestController < API::BaseController
   def show
-    @report = current_user
-              .reports
-              .order(reported_on: :desc)
-              .first
+    report = current_user
+             .reports
+             .order(reported_on: :desc)
+             .first
+    return render_not_found('最新の日報が見つかりません。') unless report
+
+    render json: { title: report.title, practice_ids: report.practice_ids, description: report.description }
   end
 end

--- a/app/controllers/api/reports/latest_controller.rb
+++ b/app/controllers/api/reports/latest_controller.rb
@@ -8,6 +8,6 @@ class API::Reports::LatestController < API::BaseController
              .first
     return render_not_found('最新の日報が見つかりません。') unless report
 
-    render json: { title: report.title, practice_ids: report.practice_ids, description: report.description }
+    render json: { id: report.id, title: report.title, practice_ids: report.practice_ids, description: report.description }
   end
 end

--- a/app/javascript/choices-ui.js
+++ b/app/javascript/choices-ui.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'js-choices-multiple-select'
   )
   if (elementMultipleSelect) {
-    return new Choices(elementMultipleSelect, {
+    elementMultipleSelect.choices = new Choices(elementMultipleSelect, {
       removeItemButton: true,
       allowHTML: true,
       searchResultLimit: 20,
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
       resetScrollPosition: false,
       renderSelectedChoices: 'always'
     })
+    return
   }
 
   const elementsOfSingles = document.querySelectorAll('.js-choices-singles')

--- a/app/javascript/controllers/report_latest_controller.js
+++ b/app/javascript/controllers/report_latest_controller.js
@@ -3,6 +3,8 @@ import TextareaInitializer from 'textarea-initializer'
 import { toast } from 'vanillaToast'
 
 export default class extends Controller {
+  static targets = ['title', 'description']
+
   async replaceReport(e) {
     e.preventDefault()
 
@@ -19,5 +21,12 @@ export default class extends Controller {
       toast('最新の日報が見つかりませんでした。')
       return
     }
+
+    const data = await response.json()
+    this.titleTarget.value = data.title
+    this.descriptionTarget.value = data.description
+
+    TextareaInitializer.uninitialize('.js-report-content')
+    TextareaInitializer.initialize('.js-report-content')
   }
 }

--- a/app/javascript/controllers/report_latest_controller.js
+++ b/app/javascript/controllers/report_latest_controller.js
@@ -28,7 +28,7 @@ export default class extends Controller {
 
     const data = await response.json()
     this.practicesTarget.choices.removeActiveItems()
-    data.practice_ids.forEach(id => {
+    data.practice_ids.forEach((id) => {
       this.practicesTarget.choices.setChoiceByValue(String(id))
     })
     this.titleTarget.value = data.title

--- a/app/javascript/controllers/report_latest_controller.js
+++ b/app/javascript/controllers/report_latest_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import TextareaInitializer from 'textarea-initializer'
 import { toast } from 'vanillaToast'
+import { get } from '@rails/request.js'
 
 export default class extends Controller {
   static targets = ['title', 'description', 'practices']
@@ -8,14 +9,7 @@ export default class extends Controller {
   async replaceReport(e) {
     e.preventDefault()
 
-    const response = await fetch('/api/reports/latest.json', {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'X-Requested-With': 'XMLHttpRequest'
-      },
-      credentials: 'same-origin'
-    })
+    const response = await get('/api/reports/latest', { responseKind: 'json' })
 
     if (!response.ok) {
       toast('最新の日報が見つかりませんでした。')
@@ -26,7 +20,7 @@ export default class extends Controller {
       return
     }
 
-    const data = await response.json()
+    const data = await response.json
     this.practicesTarget.choices.removeActiveItems()
     data.practice_ids.forEach((id) => {
       this.practicesTarget.choices.setChoiceByValue(String(id))

--- a/app/javascript/controllers/report_latest_controller.js
+++ b/app/javascript/controllers/report_latest_controller.js
@@ -3,7 +3,7 @@ import TextareaInitializer from 'textarea-initializer'
 import { toast } from 'vanillaToast'
 
 export default class extends Controller {
-  static targets = ['title', 'description']
+  static targets = ['title', 'description', 'practices']
 
   async replaceReport(e) {
     e.preventDefault()
@@ -23,6 +23,10 @@ export default class extends Controller {
     }
 
     const data = await response.json()
+    this.practicesTarget.choices.removeActiveItems()
+    data.practice_ids.forEach(id => {
+      this.practicesTarget.choices.setChoiceByValue(String(id))
+    })
     this.titleTarget.value = data.title
     this.descriptionTarget.value = data.description
 

--- a/app/javascript/controllers/report_latest_controller.js
+++ b/app/javascript/controllers/report_latest_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from '@hotwired/stimulus'
+import TextareaInitializer from 'textarea-initializer'
+import { toast } from 'vanillaToast'
+
+export default class extends Controller {
+  replaceReport(e) {
+  }
+}

--- a/app/javascript/controllers/report_latest_controller.js
+++ b/app/javascript/controllers/report_latest_controller.js
@@ -22,6 +22,10 @@ export default class extends Controller {
       return
     }
 
+    if (!confirm('日報が上書きされますが、よろしいですか？')) {
+      return
+    }
+
     const data = await response.json()
     this.practicesTarget.choices.removeActiveItems()
     data.practice_ids.forEach(id => {

--- a/app/javascript/controllers/report_latest_controller.js
+++ b/app/javascript/controllers/report_latest_controller.js
@@ -3,6 +3,21 @@ import TextareaInitializer from 'textarea-initializer'
 import { toast } from 'vanillaToast'
 
 export default class extends Controller {
-  replaceReport(e) {
+  async replaceReport(e) {
+    e.preventDefault()
+
+    const response = await fetch('/api/reports/latest.json', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      credentials: 'same-origin'
+    })
+
+    if (!response.ok) {
+      toast('最新の日報が見つかりませんでした。')
+      return
+    }
   }
 }

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -5,7 +5,7 @@
       .form-item
         = f.label :practice, class: 'a-form-label'
         .select-practices
-          = f.select(:practice_ids, practice_options_within_course, { include_hidden: false }, { multiple: true, id: 'js-choices-multiple-select' })
+          = f.select(:practice_ids, practice_options_within_course, { include_hidden: false }, { multiple: true, id: 'js-choices-multiple-select', data: { 'report-latest-target': 'practices' } })
       .form-item
         = f.label :title, class: 'a-form-label'
         = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'display: inline-block の挙動の調査を進めた', data: { 'report-latest-target': 'title' }

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -1,5 +1,5 @@
 = render 'errors', object: report
-= form_with model: report, local: true, html: { name: 'report' } do |f|
+= form_with model: report, local: true, html: { name: 'report', data: { controller: 'report-latest' } } do |f|
   .form__items
     .form__items-inner
       .form-item
@@ -77,6 +77,14 @@
               editingValue: true,
               is_editing_template_valid: true,
               data: { 'registered-template-value': registered_preset }
+            .form-item-actions
+              ul.form-item-actions__items
+                li.form-item-actions__item
+                  button.a-button.is-sm.is-secondary(
+                    type='button'
+                    data-action='click->report-latest#replaceReport'
+                  )
+                    | 最新の日報を複製
           .form-textarea
             .form-textarea__body
               - value_option = report.description.blank? && registered_preset.present? ? { value: registered_preset } : {}

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -8,7 +8,7 @@
           = f.select(:practice_ids, practice_options_within_course, { include_hidden: false }, { multiple: true, id: 'js-choices-multiple-select' })
       .form-item
         = f.label :title, class: 'a-form-label'
-        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'display: inline-block の挙動の調査を進めた'
+        = f.text_field :title, class: 'a-text-input js-warning-form', placeholder: 'display: inline-block の挙動の調査を進めた', data: { 'report-latest-target': 'title' }
         .a-form-help
           p
             | 日報のタイトルはあとで振り返りやすいタイトルを付けてください。
@@ -91,7 +91,7 @@
               = f.text_area :description,
                 **value_option,
                 class: "a-text-input js-warning-form js-report-content markdown-form__text-area #{params[:action] == 'new' && params[:id].blank? ? '' : 'js-markdown'}",
-                data: { 'report-preset-target': 'report', 'preview': '.js-preview', 'input': '.file-input' }
+                data: { 'report-preset-target': 'report', 'preview': '.js-preview', 'input': '.file-input', 'report-latest-target': 'description' }
             .form-textarea__footer
               .form-textarea__insert
                 label.a-file-insert.a-button.is-xs.is-text-reversal.is-block

--- a/app/views/reports/_form.html.slim
+++ b/app/views/reports/_form.html.slim
@@ -77,14 +77,6 @@
               editingValue: true,
               is_editing_template_valid: true,
               data: { 'registered-template-value': registered_preset }
-            .form-item-actions
-              ul.form-item-actions__items
-                li.form-item-actions__item
-                  button.a-button.is-sm.is-secondary(
-                    type='button'
-                    data-action='click->report-latest#replaceReport'
-                  )
-                    | 最新の日報を複製
           .form-textarea
             .form-textarea__body
               - value_option = report.description.blank? && registered_preset.present? ? { value: registered_preset } : {}

--- a/app/views/reports/_report_preset.html.slim
+++ b/app/views/reports/_report_preset.html.slim
@@ -27,6 +27,13 @@ div(
           )
             | テンプレート登録
 
+      li.form-item-actions__item
+        button.a-button.is-sm.is-secondary.is-block(
+          type='button'
+          data-action='click->report-latest#replaceReport'
+        )
+          | 最新の日報を複製
+
   .a-overlay.is-js.is-hidden(
     data-report-preset-target='modal'
     data-action='click->report-preset#clickOutside'

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
         get 'counts', on: :collection
       end
       resources :recents, only: %i(index)
+      resource :latest, only: %i(show), controller: "latest"
     end
     post 'reports/checks', to: 'reports/checks#create', as: :reports_checks
     resources :reports, only: %i(index show create update destroy) do

--- a/test/integration/api/reports/latest_test.rb
+++ b/test/integration/api/reports/latest_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::Reports::LatestTest < ActionDispatch::IntegrationTest
+  fixtures :reports
+
+  test 'returns unauthorized when not logged in' do
+    get api_reports_latest_path(format: :json)
+    assert_response :unauthorized
+  end
+
+  test 'returns not found when no reports exist' do
+    token = create_token('sotugyou-with-job', 'testtest')
+    get api_reports_latest_path(format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :not_found
+    assert_equal '最新の日報が見つかりません。', response.parsed_body['message']
+  end
+
+  test 'returns own report even when other user has a more recent report' do
+    token = create_token('machida', 'testtest')
+    get api_reports_latest_path(format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+    assert_response :ok
+    assert_equal reports(:report4).id, response.parsed_body['id']
+  end
+end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10254

## 概要
日報の新規作成画面に「直近の日報を複製」ボタンを追加した。
このボタンをクリックすると、「プラクティス」「タイトル」「内容」に直近の日報(WIPを含む)を表示する。

## 変更確認方法

1. {feature/duplicate-latest-report-to-new-report}をローカルに取り込む
2. grant-courseユーザーでログインする
3. 日報作成ページ(http://localhost:3000/reports/new)を開く
4. 直近の日報を複製ボタンをクリックする
5. grant-courseユーザーの最新の日報が「プラクティス」「タイトル」「内容」に反映されることを確認する
6. hukkiユーザーでログインする
7. 直近の日報を複製ボタンをクリックする
8. 「最新の日報が見つかりませんでした。」とメッセージが表示されることを確認する。

## Screenshot

### 変更前
<img width="749" height="189" alt="image" src="https://github.com/user-attachments/assets/234ee7ec-4983-4579-878c-452e12e8155a" />

### 変更後
<img width="751" height="182" alt="image" src="https://github.com/user-attachments/assets/6343063d-da18-4155-b0f1-9230ae01e389" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 日報フォームに「最新の日報を複製」ボタンを追加し、取得した内容（タイトル・説明・習慣）をフォームへ反映します。
  - 自分の最新日報を取得するAPIエンドポイントを追加しました。
- **バグ修正**
  - 複数選択UI（Choices）の初期化結果を正しく反映するよう調整しました。
- **テスト**
  - 最新日報APIの統合テスト（未ログイン/未存在/他者より新しい日報がある場合）を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30583459549/artifacts/8775962333" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10312-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
