### PR TITLE
ステージング環境でもgenerate_default_thumbnailが動くよう修正

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -57,9 +57,13 @@ class Movie < ApplicationRecord
   end
 
   def generate_default_thumbnail
-    GenerateMovieThumbnailJob.perform_later(self)
+    # ステージング環境ではSolid Queueワーカーが回らないため、リクエスト内で同期実行させる。
+    if ENV['DB_NAME'] == 'bootcamp_staging'
+      GenerateMovieThumbnailJob.perform_now(self)
+    else
+      GenerateMovieThumbnailJob.perform_later(self)
+    end
   rescue StandardError => e
-    Rails.logger.error("Failed to enqueue GenerateMovieThumbnailJob for Movie #{id}: #{e.message}")
-    raise
+    Rails.logger.error("Failed to generate default thumbnail for Movie #{id}: #{e.message}")
   end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

##  Issue
- https://github.com/fjordllc/bootcamp/issues/10213

関連PR
- https://github.com/fjordllc/bootcamp/pull/10257
- https://github.com/fjordllc/bootcamp/pull/10308
- https://github.com/fjordllc/bootcamp/pull/10310

## 概要

#10308 で、 ステージング環境では`perform_later`が動かないことがわかりました。
なので、`generate_default_thumbnail`もステージング環境では`perform_later`ではなく`perform_now`を使うように修正しました。
<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 一部の環境では、映画のデフォルトサムネイル生成を同期実行に切り替え、確実に生成されるよう改善しました。  
  * サムネイル生成中にエラーが発生しても、例外を再送出せず処理全体の停止を抑えるよう変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30062909973/artifacts/8585376016" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10313-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->
