### PR TITLE
ステージングでSolid Queueを継続実行する

### DIFF
--- a/.cloudbuild/deploy-cloud-run
+++ b/.cloudbuild/deploy-cloud-run
@@ -54,6 +54,10 @@ case "$environment" in
   staging)
     export _MISSION_CONTROL_USERNAME="${_MISSION_CONTROL_USERNAME:-fjord}"
     export _PJORD_LLM_MODEL=claude-sonnet-5
+    cloud_run_args+=(
+      --min-instances=1
+      --no-cpu-throttling
+    )
     ;;
   review)
     export _DISCORD_NOTICE_WEBHOOK_URL=

--- a/test/lib/deploy_cloud_run_test.rb
+++ b/test/lib/deploy_cloud_run_test.rb
@@ -62,6 +62,20 @@ class DeployCloudRunTest < ActiveSupport::TestCase
     end
   end
 
+  test 'keeps a staging instance running with CPU for Solid Queue' do
+    Dir.mktmpdir do |dir|
+      gcloud_log = File.join(dir, 'gcloud.log')
+      stub_gcloud(dir, gcloud_log)
+
+      _stdout, stderr, status = Open3.capture3(deploy_env(dir), SCRIPT, 'staging')
+      assert_predicate status, :success?, stderr
+
+      commands = File.read(gcloud_log)
+      assert_includes commands, '--min-instances=1'
+      assert_includes commands, '--no-cpu-throttling'
+    end
+  end
+
   private
 
   def stub_gcloud(dir, gcloud_log)


### PR DESCRIPTION
## 概要

ステージング環境のCloud Runで最低1インスタンスを維持し、リクエスト外でもCPUを割り当てるようにしました。

## 背景

ステージングでもSolid Queueのworkerは起動していましたが、Cloud Runが最低0インスタンスかつリクエストベースのCPU割り当てだったため、アクセスがない時間帯にジョブが長時間遅延していました。

`--min-instances=1`と`--no-cpu-throttling`を指定することで、Puma内のSolid Queue workerが継続してジョブを処理できるようにします。

task専用のCloud Buildトリガーは使い捨てコンテナであり、この設定の対象外です。task内の処理は`perform_now`で同期実行されるため、Solid Queue workerには依存しません。

## 変更内容

- stagingのCloud Runを最低1インスタンスで実行
- stagingでリクエスト外にもCPUを割り当て
- デプロイ引数を検証するテストを追加

## 確認方法

```console
bin/rails test test/lib/deploy_cloud_run_test.rb test/lib/cloud_build_env_test.rb
```

- 8 runs
- 77 assertions
- 0 failures
- 0 errors

`bash -n .cloudbuild/deploy-cloud-run`と`git diff --check`も実行済みです。

## 影響

ステージングで最低1インスタンスを常時維持するため、Cloud Runの利用料金が増加します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ステージング環境のサービスを常時1インスタンス稼働にし、CPU処理を継続するよう改善しました。
  * ステージング環境でのバックグラウンド処理の安定性が向上します。

* **テスト**
  * 上記のデプロイ設定が正しく適用されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29763024677/artifacts/8469926990" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10314-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->