### PR TITLE
Return bad request when creating an API comment without commentable_type

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -19,6 +19,8 @@ class API::CommentsController < API::BaseController
   end
 
   def create
+    return render_bad_request if params[:commentable_type].blank?
+
     @comment = Comment.new(comment_params)
     @comment.user = current_user
     @comment.commentable = commentable

--- a/test/integration/api/comments_test.rb
+++ b/test/integration/api/comments_test.rb
@@ -139,6 +139,16 @@ class API::CommentsTest < ActionDispatch::IntegrationTest
     assert response.parsed_body.dig('errors', 'description').present?
   end
 
+  test 'returns bad request when creating comment without commentable_type' do
+    assert_no_difference('Comment.count') do
+      post api_comments_url(format: :json, commentable_id: @comment.commentable_id),
+           headers: { Authorization: "Bearer #{@write_token.token}" },
+           params: { comment: { description: 'New comment' } }
+    end
+
+    assert_response :bad_request
+  end
+
   test 'can update comment with read, write scope' do
     patch api_comment_url(@comment.id, format: :json),
           headers: { Authorization: "Bearer #{@write_token.token}" },


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10068

## 概要

`API::CommentsController#create` は `commentable` ヘルパーで `params[:commentable_type].constantize` を呼び出しています。`commentable_type` を付けずに `POST /api/comments` を叩くと `params[:commentable_type]` が `nil` になり、`NoMethodError: undefined method 'constantize' for nil` が発生します。

`index` アクションはすでに `params[:commentable_type].present?` を確認して `render_bad_request` を返しているので、`create` でも同様に `commentable_type` が空のときは 400 を返すようにしました。

## 変更確認方法

1. {branch_name}をローカルに取り込む
2. `bin/rails test test/integration/api/comments_test.rb` を実行し、追加した `returns bad request when creating comment without commentable_type` が通ることを確認する

## Screenshot

### 変更前

（API のエラー処理の修正のため、画面のスクリーンショットはありません）

### 変更後


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * `commentable_type` が欠落したコメント作成リクエストを不正として即時に `bad_request` を返すようにしました。
  * 不正なリクエストではコメントが作成されないようになりました。
* **テスト**
  * `comment` は送るが `commentable_type` がない場合の `bad_request` と、`Comment` が増えないことを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->