### PR TITLE
【Hotfix】本番環境にImageMagickを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
       git \
       ca-certificates \
       ffmpeg \
+      imagemagick \
       libvips && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## 概要

- 本番コンテナに`imagemagick`を追加し、MiniMagickが使用する`mogrify`を実行できるようにします。

## 発生理由

- 2024年2月のImageMagickからlibvipsへの移行時に、本番DockerイメージからImageMagickを削除していました。
- その後、画像投稿時のEXIF削除処理でMiniMagickを再び使用するようになりましたが、MiniMagick gem自体には`mogrify`実行ファイルは含まれないため、アプリケーションと本番コンテナの依存関係が不一致になっていました。
- 2026年7月13日の変更でEXIF削除が`Image#image=`から同期実行される構成になり、今回の画像投稿で潜在していた依存漏れが本番エラーとして顕在化しました。

## 確認

- [x] 本番stageのDockerイメージをビルド
- [x] ビルドしたコンテナ内で`/usr/bin/mogrify`が存在することを確認
- [x] コンテナ内で`mogrify -version`が成功することを確認
- [x] `bin/rails test test/models/image_test.rb test/integration/api/image_test.rb`（2 runs、9 assertions、0 failures）
- [x] 独立レビュアーによる差分レビュー（blocking指摘なし）

Closes #10316

