### PR TITLE
development用Stripeデータ作成taskを追加

### DIFF
--- a/lib/development_stripe_seeder.rb
+++ b/lib/development_stripe_seeder.rb
@@ -30,7 +30,10 @@ class DevelopmentStripeSeeder
   def find_or_create_customer(user)
     return [@card.create(user, 'tok_visa'), true] unless user.customer_id?
 
-    [@customer_gateway.retrieve(user.customer_id), false]
+    customer = @customer_gateway.retrieve(user.customer_id)
+    return [@card.create(user, 'tok_visa'), true] if customer.default_source.blank?
+
+    [customer, false]
   rescue Stripe::InvalidRequestError
     [@card.create(user, 'tok_visa'), true]
   end

--- a/lib/development_stripe_seeder.rb
+++ b/lib/development_stripe_seeder.rb
@@ -9,6 +9,7 @@ class DevelopmentStripeSeeder
   end
 
   def call
+    raise 'This seeder is only available in development.' unless Rails.env.development?
     raise 'Stripe test mode API key is required.' unless @api_key&.start_with?('sk_test_', 'rk_test_')
 
     User.where.not(subscription_id: nil).find_each do |user|
@@ -19,7 +20,12 @@ class DevelopmentStripeSeeder
 
   def seed(user)
     customer, customer_created = find_or_create_customer(user)
-    stripe_subscription = customer_created ? create_subscription(customer) : find_or_create_subscription(user, customer)
+    if customer_created
+      destroy_existing_subscription(user)
+      stripe_subscription = create_subscription(customer)
+    else
+      stripe_subscription = find_or_create_subscription(user, customer)
+    end
     @subscription.destroy(stripe_subscription.id) if user.hibernated?
 
     user.update_columns(customer_id: customer.id, subscription_id: stripe_subscription.id) # rubocop:disable Rails/SkipsModelValidations
@@ -46,5 +52,11 @@ class DevelopmentStripeSeeder
 
   def create_subscription(customer)
     @subscription.create(customer.id, trial: 0)
+  end
+
+  def destroy_existing_subscription(user)
+    @subscription.destroy(user.subscription_id) if user.subscription_id?
+  rescue Stripe::InvalidRequestError
+    nil
   end
 end

--- a/lib/development_stripe_seeder.rb
+++ b/lib/development_stripe_seeder.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class DevelopmentStripeSeeder
+  def initialize(customer_gateway: Stripe::Customer, card: Card.new, subscription: Subscription.new, api_key: Stripe.api_key)
+    @customer_gateway = customer_gateway
+    @card = card
+    @subscription = subscription
+    @api_key = api_key
+  end
+
+  def call
+    raise 'Stripe test mode API key is required.' unless @api_key&.start_with?('sk_test_', 'rk_test_')
+
+    User.where.not(subscription_id: nil).find_each do |user|
+      seed(user)
+      Rails.logger.info "Seeded Stripe data for #{user.login_name}"
+    end
+  end
+
+  def seed(user)
+    customer, customer_created = find_or_create_customer(user)
+    stripe_subscription = customer_created ? create_subscription(customer) : find_or_create_subscription(user, customer)
+    @subscription.destroy(stripe_subscription.id) if user.hibernated?
+
+    user.update_columns(customer_id: customer.id, subscription_id: stripe_subscription.id) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  private
+
+  def find_or_create_customer(user)
+    return [@card.create(user, 'tok_visa'), true] unless user.customer_id?
+
+    [@customer_gateway.retrieve(user.customer_id), false]
+  rescue Stripe::InvalidRequestError
+    [@card.create(user, 'tok_visa'), true]
+  end
+
+  def find_or_create_subscription(user, customer)
+    @subscription.retrieve(user.subscription_id)
+  rescue Stripe::InvalidRequestError
+    create_subscription(customer)
+  end
+
+  def create_subscription(customer)
+    @subscription.create(customer.id, trial: 0)
+  end
+end

--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -35,6 +35,13 @@ namespace :bootcamp do
     )
   end
 
+  desc 'Create Stripe test data for development seed users.'
+  task seed_stripe: :environment do
+    abort 'This task is only available in development.' unless Rails.env.development?
+
+    DevelopmentStripeSeeder.new.call
+  end
+
   desc 'Disconnect all DB user.'
   task disconnect_all_user: :environment do
     sql = "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'bootcamp_staging' and application_name = 'bin/rails'"

--- a/test/lib/development_stripe_seeder_test.rb
+++ b/test/lib/development_stripe_seeder_test.rb
@@ -53,4 +53,23 @@ class DevelopmentStripeSeederTest < ActiveSupport::TestCase
     assert_equal 'cus_test', user.reload.customer_id
     assert_equal 'sub_test', user.subscription_id
   end
+
+  test 'recreates a customer when its payment source was deleted' do
+    user = users(:hatsuno)
+    customer_without_card = Struct.new(:id, :default_source).new('cus_old', nil)
+    new_customer = Struct.new(:id).new('cus_new')
+    stripe_subscription = Struct.new(:id).new('sub_new')
+    customer_gateway = Object.new
+    customer_gateway.define_singleton_method(:retrieve) { |_id| customer_without_card }
+    card = Object.new
+    card.define_singleton_method(:create) { |_user, _token| new_customer }
+    subscription = Object.new
+    subscription.define_singleton_method(:retrieve) { |_id| Struct.new(:id).new('sub_old') }
+    subscription.define_singleton_method(:create) { |*, **| stripe_subscription }
+
+    DevelopmentStripeSeeder.new(customer_gateway:, card:, subscription:).seed(user)
+
+    assert_equal 'cus_new', user.reload.customer_id
+    assert_equal 'sub_new', user.subscription_id
+  end
 end

--- a/test/lib/development_stripe_seeder_test.rb
+++ b/test/lib/development_stripe_seeder_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DevelopmentStripeSeederTest < ActiveSupport::TestCase
+  test 'rejects a live mode API key' do
+    error = assert_raises(RuntimeError) do
+      DevelopmentStripeSeeder.new(api_key: 'sk_live_example').call
+    end
+
+    assert_equal 'Stripe test mode API key is required.', error.message
+  end
+
+  test 'creates Stripe resources for a hibernated seed user' do
+    assert defined?(DevelopmentStripeSeeder), 'DevelopmentStripeSeeder is not defined'
+
+    user = users(:kyuukai)
+    customer = Struct.new(:id).new('cus_test')
+    stripe_subscription = Struct.new(:id).new('sub_test')
+    customer_gateway = Object.new
+    customer_gateway.define_singleton_method(:retrieve) do |_id|
+      raise Stripe::InvalidRequestError.new('No such customer', 'id')
+    end
+    card = Object.new
+    card.define_singleton_method(:create) { |_user, _token| customer }
+    subscription = Object.new
+    subscription.define_singleton_method(:create) { |*, **| stripe_subscription }
+    subscription.define_singleton_method(:destroy) { |id| @destroyed_id = id }
+    subscription.define_singleton_method(:destroyed_id) { @destroyed_id }
+
+    DevelopmentStripeSeeder.new(customer_gateway:, card:, subscription:).seed(user)
+
+    assert_equal 'cus_test', user.reload.customer_id
+    assert_equal 'sub_test', user.subscription_id
+    assert_equal 'sub_test', subscription.destroyed_id
+  end
+
+  test 'creates Stripe resources when a seed user has no customer ID' do
+    user = users(:kimura)
+    customer = Struct.new(:id).new('cus_test')
+    stripe_subscription = Struct.new(:id).new('sub_test')
+    test_case = self
+    customer_gateway = Object.new
+    customer_gateway.define_singleton_method(:retrieve) { |_id| test_case.flunk 'Customer retrieval should be skipped' }
+    card = Object.new
+    card.define_singleton_method(:create) { |_user, _token| customer }
+    subscription = Object.new
+    subscription.define_singleton_method(:create) { |*, **| stripe_subscription }
+    subscription.define_singleton_method(:destroy) { test_case.flunk 'Active subscription should not be destroyed' }
+
+    DevelopmentStripeSeeder.new(customer_gateway:, card:, subscription:).seed(user)
+
+    assert_equal 'cus_test', user.reload.customer_id
+    assert_equal 'sub_test', user.subscription_id
+  end
+end

--- a/test/lib/development_stripe_seeder_test.rb
+++ b/test/lib/development_stripe_seeder_test.rb
@@ -3,9 +3,23 @@
 require 'test_helper'
 
 class DevelopmentStripeSeederTest < ActiveSupport::TestCase
+  test 'rejects non-development environments before querying users' do
+    user_query = ->(*) { raise 'User query reached' }
+
+    error = User.stub(:where, user_query) do
+      assert_raises(RuntimeError) do
+        DevelopmentStripeSeeder.new(api_key: 'sk_test_example').call
+      end
+    end
+
+    assert_equal 'This seeder is only available in development.', error.message
+  end
+
   test 'rejects a live mode API key' do
-    error = assert_raises(RuntimeError) do
-      DevelopmentStripeSeeder.new(api_key: 'sk_live_example').call
+    error = Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new('development')) do
+      assert_raises(RuntimeError) do
+        DevelopmentStripeSeeder.new(api_key: 'sk_live_example').call
+      end
     end
 
     assert_equal 'Stripe test mode API key is required.', error.message
@@ -37,8 +51,11 @@ class DevelopmentStripeSeederTest < ActiveSupport::TestCase
 
   test 'creates Stripe resources when a seed user has no customer ID' do
     user = users(:kimura)
+    user.update_columns(customer_id: nil, subscription_id: 'sub_old') # rubocop:disable Rails/SkipsModelValidations
+    old_subscription_id = user.subscription_id
     customer = Struct.new(:id).new('cus_test')
     stripe_subscription = Struct.new(:id).new('sub_test')
+    destroyed_subscription_ids = []
     test_case = self
     customer_gateway = Object.new
     customer_gateway.define_singleton_method(:retrieve) { |_id| test_case.flunk 'Customer retrieval should be skipped' }
@@ -46,30 +63,70 @@ class DevelopmentStripeSeederTest < ActiveSupport::TestCase
     card.define_singleton_method(:create) { |_user, _token| customer }
     subscription = Object.new
     subscription.define_singleton_method(:create) { |*, **| stripe_subscription }
-    subscription.define_singleton_method(:destroy) { test_case.flunk 'Active subscription should not be destroyed' }
+    subscription.define_singleton_method(:destroy) { |id| destroyed_subscription_ids << id }
 
     DevelopmentStripeSeeder.new(customer_gateway:, card:, subscription:).seed(user)
 
+    assert_equal [old_subscription_id], destroyed_subscription_ids
     assert_equal 'cus_test', user.reload.customer_id
     assert_equal 'sub_test', user.subscription_id
   end
 
   test 'recreates a customer when its payment source was deleted' do
     user = users(:hatsuno)
+    old_customer_id = user.customer_id
+    old_subscription_id = user.subscription_id
     customer_without_card = Struct.new(:id, :default_source).new('cus_old', nil)
     new_customer = Struct.new(:id).new('cus_new')
     stripe_subscription = Struct.new(:id).new('sub_new')
+    retrieved_customer_ids = []
+    destroyed_subscription_ids = []
     customer_gateway = Object.new
-    customer_gateway.define_singleton_method(:retrieve) { |_id| customer_without_card }
+    customer_gateway.define_singleton_method(:retrieve) do |id|
+      retrieved_customer_ids << id
+      customer_without_card
+    end
     card = Object.new
     card.define_singleton_method(:create) { |_user, _token| new_customer }
     subscription = Object.new
-    subscription.define_singleton_method(:retrieve) { |_id| Struct.new(:id).new('sub_old') }
     subscription.define_singleton_method(:create) { |*, **| stripe_subscription }
+    subscription.define_singleton_method(:destroy) { |id| destroyed_subscription_ids << id }
 
     DevelopmentStripeSeeder.new(customer_gateway:, card:, subscription:).seed(user)
 
+    assert_equal [old_customer_id], retrieved_customer_ids
+    assert_equal [old_subscription_id], destroyed_subscription_ids
     assert_equal 'cus_new', user.reload.customer_id
     assert_equal 'sub_new', user.subscription_id
+  end
+
+  test 'reuses an existing customer and subscription' do
+    user = users(:hatsuno)
+    existing_customer_id = user.customer_id
+    existing_subscription_id = user.subscription_id
+    customer = Struct.new(:id, :default_source).new(existing_customer_id, 'card_test')
+    stripe_subscription = Struct.new(:id).new(existing_subscription_id)
+    retrieved_customer_ids = []
+    retrieved_subscription_ids = []
+    test_case = self
+    customer_gateway = Object.new
+    customer_gateway.define_singleton_method(:retrieve) do |id|
+      retrieved_customer_ids << id
+      customer
+    end
+    card = Object.new
+    card.define_singleton_method(:create) { test_case.flunk 'Customer should be reused' }
+    subscription = Object.new
+    subscription.define_singleton_method(:retrieve) do |id|
+      retrieved_subscription_ids << id
+      stripe_subscription
+    end
+    subscription.define_singleton_method(:create) { test_case.flunk 'Subscription should be reused' }
+    subscription.define_singleton_method(:destroy) { test_case.flunk 'Active subscription should not be destroyed' }
+
+    DevelopmentStripeSeeder.new(customer_gateway:, card:, subscription:).seed(user)
+
+    assert_equal [existing_customer_id], retrieved_customer_ids
+    assert_equal [existing_subscription_id], retrieved_subscription_ids
   end
 end


### PR DESCRIPTION
## 概要

- developmentのseedユーザーに対応するCustomerとSubscriptionをStripe Test modeへ作成するtaskを追加します。
- fixtureのStripe IDが実在すれば再利用し、ダミーIDや欠損IDの場合は作成し直してローカルDBへ保存します。
- 休会中のseedユーザーは、Subscriptionを解約予約済みの状態にします。
- development環境かつTest modeのAPIキーでのみ実行できます。

## 実行方法

seed投入後、次のコマンドを実行します。

```bash
bin/rails bootcamp:seed_stripe
```

これにより、`kyuukai` を含む課金情報を持つseedユーザーについて、画面からStripe処理を含む動作確認ができます。

## 確認

- [x] `bin/rails test test/lib/development_stripe_seeder_test.rb test/models/subscription_test.rb`
- [x] `bundle exec rubocop lib/development_stripe_seeder.rb lib/tasks/bootcamp.rake test/lib/development_stripe_seeder_test.rb`
- [x] `bin/rails -T bootcamp`
- [x] `git diff --check`

Refs #10290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 開発環境で、既存ユーザー向けのStripeテストデータを作成・同期できるようになりました。
  - `bootcamp:seed_stripe` タスクを追加しました。
  - 支払い手段が欠落している場合や、顧客・サブスクリプション情報に不整合がある場合でも、Stripe側を再作成して反映します。
  - ハイバネート済みユーザーのサブスクリプションを適切に更新・破棄します。
- **安全性**
  - テストモードのAPIキーのみ受け付け、ライブモードは拒否します。
  - タスクは開発環境でのみ実行されます。
- **テスト**
  - `DevelopmentStripeSeeder` の主要シナリオに関するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/29976142238/artifacts/8551693732" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10323-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->