### PR TITLE
Cloud Buildから意味検索生成を除外

### DIFF
--- a/lib/tasks/bootcamp.rake
+++ b/lib/tasks/bootcamp.rake
@@ -63,7 +63,6 @@ namespace :bootcamp do
     task cloudbuild: :environment do
       puts '== START Cloud Build Task =='
 
-      Rake::Task['smart_search:generate_all'].invoke
       BulkGenerateMovieThumbnailJob.perform_now
 
       puts '== END   Cloud Build Task =='

--- a/test/tasks/bootcamp_test.rb
+++ b/test/tasks/bootcamp_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rake'
+
+class BootcampTaskTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('bootcamp:oneshot:cloudbuild')
+    Rake::Task['bootcamp:oneshot:cloudbuild'].reenable
+  end
+
+  test 'cloudbuild generates only movie thumbnails' do
+    thumbnail_generated = false
+    smart_search_task = Rake::Task['smart_search:generate_all']
+
+    smart_search_task.stub(:invoke, -> { flunk 'Smart search should not be generated' }) do
+      BulkGenerateMovieThumbnailJob.stub(:perform_now, -> { thumbnail_generated = true }) do
+        Rake::Task['bootcamp:oneshot:cloudbuild'].invoke
+      end
+    end
+
+    assert thumbnail_generated
+  end
+end


### PR DESCRIPTION
## 概要

- `bootcamp:oneshot:cloudbuild` から `smart_search:generate_all` の呼び出しを削除します。
- Cloud Buildでは動画サムネイル生成だけを実行します。
- 意味検索生成が呼ばれないことと、サムネイルJobが実行されることを確認するtaskテストを追加します。

## 確認

- [x] `bin/rails test test/tasks/bootcamp_test.rb`
- [x] `bundle exec rubocop lib/tasks/bootcamp.rake test/tasks/bootcamp_test.rb`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * Cloud Build の一括処理で、動画サムネイルを自動生成するようになりました。
  * Cloud Build 実行時に、不要なスマート検索データの生成は行われなくなりました。

* **テスト**
  * サムネイル生成のみが実行されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30001149183/artifacts/8561357243" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10324-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->