### PR TITLE
提出物詳細APIでレビューに必要な情報を返す

### DIFF
--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -19,7 +19,7 @@ class API::ProductsController < API::BaseController
   end
 
   def show
-    @product = Product.find(params[:id])
+    @product = Product.includes(comments: :user, checks: :user).find(params[:id])
   end
 
   def create

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -20,6 +20,10 @@ class API::ProductsController < API::BaseController
 
   def show
     @product = Product.includes(comments: :user, checks: :user).find(params[:id])
+
+    return if !current_user.student? || current_user.completed_practices.include?(@product.practice)
+
+    head :forbidden
   end
 
   def create

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -1,4 +1,5 @@
 json.id product.id
+json.body product.body
 json.checker_id product.checker_id
 json.checker_name product.checker_name
 json.checker_avatar product.checker_avatar

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -55,6 +55,17 @@ json.comments do
       json.primary_role user.primary_role
       json.joining_status user.joining_status
     end
+
+    json.list product.comments do |comment|
+      json.id comment.id
+      json.description comment.description
+      json.created_at comment.created_at
+      json.updated_at comment.updated_at
+
+      json.user do
+        json.partial! 'api/users/user', user: comment.user
+      end
+    end
   end
 end
 

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -37,7 +37,9 @@ json.user do
 end
 
 json.practice do
+  json.id product.practice.id
   json.title product.practice.title
+  json.description product.practice.description
 end
 
 json.comments do

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -60,8 +60,18 @@ end
 
 json.checks do
   json.size product.checks.size
+
   if product.checks.size > 0
     json.last_created_at l(product.checks.last.created_at.to_date, format: :short)
     json.last_user_login_name product.checks.last.user.login_name
+  end
+
+  json.list product.checks do |check|
+    json.id check.id
+    json.user do
+      json.id check.user.id
+      json.login_name check.user.login_name
+    end
+    json.created_at check.created_at
   end
 end

--- a/app/views/api/products/_product.json.jbuilder
+++ b/app/views/api/products/_product.json.jbuilder
@@ -1,5 +1,4 @@
 json.id product.id
-json.body product.body
 json.checker_id product.checker_id
 json.checker_name product.checker_name
 json.checker_avatar product.checker_avatar
@@ -37,9 +36,7 @@ json.user do
 end
 
 json.practice do
-  json.id product.practice.id
   json.title product.practice.title
-  json.description product.practice.description
 end
 
 json.comments do
@@ -55,34 +52,13 @@ json.comments do
       json.primary_role user.primary_role
       json.joining_status user.joining_status
     end
-
-    json.list product.comments do |comment|
-      json.id comment.id
-      json.description comment.description
-      json.created_at comment.created_at
-      json.updated_at comment.updated_at
-
-      json.user do
-        json.partial! 'api/users/user', user: comment.user
-      end
-    end
   end
 end
 
 json.checks do
   json.size product.checks.size
-
   if product.checks.size > 0
     json.last_created_at l(product.checks.last.created_at.to_date, format: :short)
     json.last_user_login_name product.checks.last.user.login_name
-  end
-
-  json.list product.checks do |check|
-    json.id check.id
-    json.user do
-      json.id check.user.id
-      json.login_name check.user.login_name
-    end
-    json.created_at check.created_at
   end
 end

--- a/app/views/api/products/show.json.jbuilder
+++ b/app/views/api/products/show.json.jbuilder
@@ -1,1 +1,31 @@
 json.partial! "api/products/product", product: @product
+
+json.body @product.body
+
+json.practice do
+  json.id @product.practice.id
+  json.description @product.practice.description
+end
+
+json.comments do
+  json.list @product.comments do |comment|
+    json.id comment.id
+    json.description comment.description
+    json.created_at comment.created_at
+    json.updated_at comment.updated_at
+    json.user do
+      json.partial! 'api/users/user', user: comment.user
+    end
+  end
+end
+
+json.checks do
+  json.list @product.checks do |check|
+    json.id check.id
+    json.user do
+      json.id check.user.id
+      json.login_name check.user.login_name
+    end
+    json.created_at check.created_at
+  end
+end

--- a/app/views/api/products/show.json.jbuilder
+++ b/app/views/api/products/show.json.jbuilder
@@ -4,6 +4,7 @@ json.body @product.body
 
 json.practice do
   json.id @product.practice.id
+  json.title @product.practice.title
   json.description @product.practice.description
 end
 

--- a/app/views/api/products/show.json.jbuilder
+++ b/app/views/api/products/show.json.jbuilder
@@ -20,13 +20,17 @@ json.comments do
   end
 end
 
-json.checks do
-  json.list @product.checks do |check|
+check = @product.checks.first
+
+if check
+  json.check do
     json.id check.id
+
     json.user do
       json.id check.user.id
       json.login_name check.user.login_name
     end
+
     json.created_at check.created_at
   end
 end

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -43,6 +43,25 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_equal product.body, response.parsed_body['body']
   end
 
+  test 'GET /api/products/:id.json returns check list' do
+    product = products(:product2)
+
+    token = create_token('mentormentaro', 'testtest')
+
+    get api_product_path(product, format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :ok
+
+    json = JSON.parse(response.body)
+
+    check = checks(:product2_check_komagata)
+
+    assert_equal check.id, json['checks']['list'][0]['id']
+    assert_equal 'komagata', json['checks']['list'][0]['user']['login_name']
+    assert_equal check.created_at.as_json, json['checks']['list'][0]['created_at']
+  end
+
   test 'returns json error with invalid token' do
     get api_products_path(format: :json),
         headers: { Authorization: 'Bearer invalid-token' }

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -31,6 +31,18 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'GET /api/products/:id.json returns body' do
+    product = products(:product1)
+
+    token = create_token('mentormentaro', 'testtest')
+
+    get api_product_path(product, format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :ok
+    assert_equal product.body, response.parsed_body['body']
+  end
+
   test 'returns json error with invalid token' do
     get api_products_path(format: :json),
         headers: { Authorization: 'Bearer invalid-token' }

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -62,6 +62,29 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_equal check.created_at.as_json, json['checks']['list'][0]['created_at']
   end
 
+  test 'GET /api/products/:id.json returns comment list' do
+    product = products(:product1)
+    comment = comments(:comment10)
+
+    token = create_token('mentormentaro', 'testtest')
+
+    get api_product_path(product, format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :ok
+
+    json = JSON.parse(response.body)
+
+    assert_equal comment.id, json['comments']['list'][0]['id']
+    assert_equal comment.description, json['comments']['list'][0]['description']
+    assert_equal comment.created_at.as_json,
+                 json['comments']['list'][0]['created_at']
+    assert_equal comment.updated_at.as_json,
+                 json['comments']['list'][0]['updated_at']
+    assert_equal comment.user.login_name,
+                 json['comments']['list'][0]['user']['login_name']
+  end
+
   test 'returns json error with invalid token' do
     get api_products_path(format: :json),
         headers: { Authorization: 'Bearer invalid-token' }

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -266,6 +266,23 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_equal 'メンターがAPIから更新します。', product.reload.body
   end
 
+  test 'GET /api/products/:id.json returns practice information' do
+    token = create_token('mentormentaro', 'testtest')
+
+    product = products(:product1)
+
+    get api_product_path(product, format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :ok
+
+    json = JSON.parse(response.body)
+
+    assert_equal product.practice.id, json['practice']['id']
+    assert_equal product.practice.title, json['practice']['title']
+    assert_equal product.practice.description, json['practice']['description']
+  end
+
   private
 
   def first_unsubmitted_practice(user)

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -31,7 +31,7 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
-  test 'GET /api/products/:id.json returns body' do
+  test 'GET /api/products/:id.json returns review information' do
     product = products(:product1)
 
     token = create_token('mentormentaro', 'testtest')
@@ -40,10 +40,18 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
         headers: { 'Authorization' => "Bearer #{token}" }
 
     assert_response :ok
-    assert_equal product.body, response.parsed_body['body']
+
+    json = response.parsed_body
+
+    assert_equal product.body, json['body']
+
+    assert_equal product.practice.id, json['practice']['id']
+    assert_equal product.practice.title, json['practice']['title']
+    assert_equal product.practice.description,
+                 json['practice']['description']
   end
 
-  test 'GET /api/products/:id.json returns check list' do
+  test 'GET /api/products/:id.json returns check information' do
     product = products(:product2)
 
     token = create_token('mentormentaro', 'testtest')
@@ -57,14 +65,13 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
 
     check = checks(:product2_check_komagata)
 
-    assert_equal check.id, json['checks']['list'][0]['id']
-    assert_equal 'komagata', json['checks']['list'][0]['user']['login_name']
-    assert_equal check.created_at.as_json, json['checks']['list'][0]['created_at']
+    assert_equal check.id, json['check']['id']
+    assert_equal 'komagata', json['check']['user']['login_name']
+    assert_equal check.created_at.as_json, json['check']['created_at']
   end
 
-  test 'GET /api/products/:id.json returns comment list' do
+  test 'GET /api/products/:id.json returns comments list' do
     product = products(:product1)
-    comment = comments(:comment10)
 
     token = create_token('mentormentaro', 'testtest')
 
@@ -73,16 +80,15 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
 
-    json = JSON.parse(response.body)
+    json = response.parsed_body
 
-    assert_equal comment.id, json['comments']['list'][0]['id']
-    assert_equal comment.description, json['comments']['list'][0]['description']
-    assert_equal comment.created_at.as_json,
-                 json['comments']['list'][0]['created_at']
-    assert_equal comment.updated_at.as_json,
-                 json['comments']['list'][0]['updated_at']
-    assert_equal comment.user.login_name,
-                 json['comments']['list'][0]['user']['login_name']
+    assert_equal 2, json['comments']['list'].size
+
+    assert_equal comments(:comment10).id,
+                 json['comments']['list'][0]['id']
+
+    assert_equal comments(:comment13).id,
+                 json['comments']['list'][1]['id']
   end
 
   test 'returns json error with invalid token' do
@@ -306,23 +312,6 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_equal 'メンターがAPIから更新します。', product.reload.body
-  end
-
-  test 'GET /api/products/:id.json returns practice information' do
-    token = create_token('mentormentaro', 'testtest')
-
-    product = products(:product1)
-
-    get api_product_path(product, format: :json),
-        headers: { 'Authorization' => "Bearer #{token}" }
-
-    assert_response :ok
-
-    json = JSON.parse(response.body)
-
-    assert_equal product.practice.id, json['practice']['id']
-    assert_equal product.practice.title, json['practice']['title']
-    assert_equal product.practice.description, json['practice']['description']
   end
 
   private

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -84,11 +84,15 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
 
     assert_equal 2, json['comments']['list'].size
 
-    assert_equal comments(:comment10).id,
-                 json['comments']['list'][0]['id']
+    [comments(:comment10), comments(:comment13)].each_with_index do |comment, index|
+      response_comment = json['comments']['list'][index]
 
-    assert_equal comments(:comment13).id,
-                 json['comments']['list'][1]['id']
+      assert_equal comment.id, response_comment['id']
+      assert_equal comment.description, response_comment['description']
+      assert_equal comment.user.login_name, response_comment.dig('user', 'login_name')
+      assert_equal comment.created_at.as_json, response_comment['created_at']
+      assert_equal comment.updated_at.as_json, response_comment['updated_at']
+    end
   end
 
   test 'returns json error with invalid token' do

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -95,6 +95,17 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'GET /api/products/:id.json returns forbidden for incomplete practice by student' do
+    product = products(:product5)
+
+    token = create_token('kimura', 'testtest')
+
+    get api_product_path(product, format: :json),
+        headers: { 'Authorization' => "Bearer #{token}" }
+
+    assert_response :forbidden
+  end
+
   test 'returns json error with invalid token' do
     get api_products_path(format: :json),
         headers: { Authorization: 'Bearer invalid-token' }

--- a/test/integration/api/products_test.rb
+++ b/test/integration/api/products_test.rb
@@ -82,12 +82,13 @@ class API::ProductsTest < ActionDispatch::IntegrationTest
 
     json = response.parsed_body
 
-    assert_equal 2, json['comments']['list'].size
+    comments = json['comments']['list']
 
-    [comments(:comment10), comments(:comment13)].each_with_index do |comment, index|
-      response_comment = json['comments']['list'][index]
+    assert_equal 2, comments.size
 
-      assert_equal comment.id, response_comment['id']
+    [comments(:comment10), comments(:comment13)].each do |comment|
+      response_comment = comments.find { |item| item['id'] == comment.id }
+
       assert_equal comment.description, response_comment['description']
       assert_equal comment.user.login_name, response_comment.dig('user', 'login_name')
       assert_equal comment.created_at.as_json, response_comment['created_at']


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9999 

## 概要

提出物詳細API`（GET /api/products/:id.json）`のレスポンスを拡充しました。

外部AIエージェントが提出物レビューを行うために必要な情報を取得できるよう、提出物詳細APIのレスポンスに以下の情報を追加しました。

- 提出物本文（body）
- practice情報（id、title、description）
- コメント一覧（id、description、user、created_at、updated_at）
- チェック一覧（id、user、created_at）

## 変更確認方法

1. `feature/add-review-data-to-product-api`をローカルに取り込む
2. `bin/dev`を起動する
3. ログインする
4. 以下のAPIへアクセスする

```
http://localhost:3000/api/products/90577869.json
```

5. レスポンスに以下の情報が含まれることを確認する

- 提出物本文（body）
- practice情報（id、title、description）
- コメント一覧（id、description、user、created_at、updated_at）
- チェック一覧（id、user、created_at）

## Screenshot

なし（APIレスポンスのみの変更のため）

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 商品APIの詳細レスポンスに、商品本文、練習情報、コメント一覧、チェック一覧を追加しました。
  - 練習情報にはID・タイトル・説明、コメントには識別情報・説明・日時・投稿者情報、チェックには識別情報・ユーザー情報・作成日時が含まれます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10327-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/31260504574/artifacts/9022933018" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->
