### PR TITLE
リアクションボタンの + アイコンを大きくする

### DIFF
--- a/app/assets/stylesheets/application/blocks/reaction/_reaction.css
+++ b/app/assets/stylesheets/application/blocks/reaction/_reaction.css
@@ -146,8 +146,9 @@
 }
 
 .reactions__dropdown-toggle-plus {
-  font-size: .4em;
-  margin-right: .3em;
+  width: 0.55em;
+  font-size: 0.8em;
+  transform: translateY(-0.1em);
 }
 
 .reactions__actions {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10297

## 概要

リアクションボタンの + アイコンを大きくしました。

## 変更確認方法

1. chore/fix-reaction-button-icon}をローカルに取り込む
2. リアクションボタンを表示する画面を開く
3. `+`アイコンのサイズと位置が調整されていることを確認する

## Screenshot

### 変更前

<img width="102" height="48" alt="image" src="https://github.com/user-attachments/assets/3168b175-3e73-42e5-aa7d-750956dbefa0" />


### 変更後

<img width="105" height="46" alt="image" src="https://github.com/user-attachments/assets/859c6d33-ba60-499a-b7a8-d50da242cc85" />


<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - リアクションメニューの「＋」アイコンのサイズと配置を調整しました。
  - アイコンの縦位置を最適化し、表示バランスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30067818149/artifacts/8587047948" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10333-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->