### PR TITLE
ペアワークのスケジュール表で✕アイコンが表示されない不具合を修正 #10256

### DIFF
--- a/app/views/pair_works/_schedule.html.slim
+++ b/app/views/pair_works/_schedule.html.slim
@@ -48,4 +48,4 @@
                         i.fa-regular.fa-circle
             - else
               td(class='!p-0 !h-6 !bg-[var(--background-more-tint)] !text-[var(--muted-text)]')
-                i.fa-regular.fa-xmark
+                i.fa-solid.fa-xmark


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10256

## 概要

ペアワークのスケジュール表において、希望日時以外の時間セルに表示される `✕` アイコンが `fa-regular.fa-xmark` と指定されており、FontAwesome Free の仕様上アイコンが表示されない状態になっていました。
FontAwesome Free で定義されている `fa-solid.fa-xmark` に修正することで `✕` アイコンが正しく表示されるようにしました。

## 変更確認方法

1. `fix/pair-work-icon-#10256` をローカルに取り込む
2. `foreman start -f Procfile.dev` 等でローカルサーバーを起動する
3. ログイン後、ペアワーク詳細ページの希望日時表の未選択セルに `✕` アイコンが正しく表示されることを確認する

<!-- I want to review in Japanese. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 「予約不可」枠に表示される×アイコンのスタイルを変更しました。
  * 表示がより明確で統一されたデザインになります。
<img width="1429" height="877" alt="screenshot-2026-07-24_16-16-44" src="https://github.com/user-attachments/assets/30729c85-a327-4fb6-9fc4-58ed1dbac727" />
<!-- end of auto-generated comment: release notes by coderabbit.ai -->