### PR TITLE
ユーザー情報変更画面のスキップするプラクティスでアイコンが表示されない不具合を修正 #10253

### DIFF
--- a/app/components/skipped_practice_component.html.slim
+++ b/app/components/skipped_practice_component.html.slim
@@ -10,7 +10,7 @@
             | #{skipped_practices_count(category)}
         .skip-practices__end
           .skip-practices__category-angle-icon
-            i.fa-regular.fa-angle-down
+            i.fa-solid.fa-angle-down
       .skip-practices__body
         = @f.collection_check_boxes :practice_ids, category.practices, :id, :title, include_hidden: false, class: 'label-checkbox' do |b|
           .checkboxes

--- a/app/views/users/form/_avatar.html.slim
+++ b/app/views/users/form/_avatar.html.slim
@@ -2,11 +2,8 @@
   = f.label :avatar, class: 'a-form-label'
   .form-item-file-input.js-file-input.a-file-input.is-square
     label.js-file-input__preview
-      - if f.object.avatar.attached?
-        = image_tag f.object.avatar_url
-        p 画像を変更
-      - else
-        p 画像を選択
+      = image_tag user.avatar_url
+      p = user.avatar.attached? ? '画像を変更' : '画像を選択'
       = f.file_field :avatar
   - unless user.adviser? || user.mentor?
     .a-form-help


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10253

## 概要

ユーザー情報変更画面の「スキップするプラクティス」アコーディオンヘッダーにおいて、アングルアイコンが `fa-regular.fa-angle-down` と指定されており、FontAwesome Free の仕様上アイコンが表示されない状態になっていました。
FontAwesome Free で定義されている `fa-solid.fa-angle-down` に修正することで `angle-down` アイコンが正しく表示されるようにしました。

## 変更確認方法

1. `fix/user-edit-icon-#10253` をローカルに取り込む
2. ユーザー情報変更画面（`/current_user/edit`）にアクセスする
3. 「スキップするプラクティス」セクションの各カテゴリ名右側に `angle-down` アイコンが正しく表示されることを確認する

<!-- I want to review in Japanese. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * スキップ対象カテゴリの角度アイコンを、より視認性の高い表示に変更しました。
<img width="897" height="730" alt="screenshot-2026-07-24_16-45-51" src="https://github.com/user-attachments/assets/9e3adae5-965a-4a01-a571-7012b7551b04" />
<!-- end of auto-generated comment: release notes by coderabbit.ai -->