### PR TITLE
watch_byメソッドをwatched_byに変更 #9979

### DIFF
--- a/app/controllers/events/participations_controller.rb
+++ b/app/controllers/events/participations_controller.rb
@@ -27,7 +27,7 @@ class Events::ParticipationsController < ApplicationController
   end
 
   def create_watch
-    return if @event.watch_by(current_user)
+    return if @event.watched_by(current_user)
 
     watch = Watch.new(
       user: current_user,

--- a/app/controllers/regular_events/participations_controller.rb
+++ b/app/controllers/regular_events/participations_controller.rb
@@ -27,7 +27,7 @@ class RegularEvents::ParticipationsController < ApplicationController
   end
 
   def create_watch
-    return if @regular_event.watch_by(current_user)
+    return if @regular_event.watched_by(current_user)
 
     watch = Watch.new(
       user: current_user,

--- a/app/models/concerns/watchable.rb
+++ b/app/models/concerns/watchable.rb
@@ -13,7 +13,7 @@ module Watchable
     watches.present?
   end
 
-  def watch_by(user)
+  def watched_by(user)
     watches.find_by(user_id: user.id)
   end
 

--- a/app/views/announcements/show.html.slim
+++ b/app/views/announcements/show.html.slim
@@ -51,7 +51,7 @@ hr.a-border
             .page-content-header__row
               .page-content-header-actions
                 .page-content-header-actions__start
-                  = render 'watches/watch_toggle', type: @announcement.class.to_s, id: @announcement.id, watch: @announcement.watch_by(current_user)
+                  = render 'watches/watch_toggle', type: @announcement.class.to_s, id: @announcement.id, watch: @announcement.watched_by(current_user)
                   .page-content-header-actions__action
                      = render 'bookmarks/button', bookmarkable: @announcement
                 .page-content-header-actions__end

--- a/app/views/events/_event.html.slim
+++ b/app/views/events/_event.html.slim
@@ -33,7 +33,7 @@
       .page-content-header__row
         .page-content-header-actions
           .page-content-header-actions__start
-            = render 'watches/watch_toggle', type: event.class.to_s, id: event.id, watch: event.watch_by(current_user)
+            = render 'watches/watch_toggle', type: event.class.to_s, id: event.id, watch: event.watched_by(current_user)
             .page-content-header-actions__action
               = render 'bookmarks/button', bookmarkable: event
           .page-content-header-actions__end

--- a/app/views/movies/_movie_header.html.slim
+++ b/app/views/movies/_movie_header.html.slim
@@ -62,7 +62,7 @@ header.page-content-header
     .page-content-header__row
       .page-content-header-actions
         .page-content-header-actions__start
-          = render 'watches/watch_toggle', type: movie.class.to_s, id: movie.id, watch: movie.watch_by(current_user)
+          = render 'watches/watch_toggle', type: movie.class.to_s, id: movie.id, watch: movie.watched_by(current_user)
           .page-content-header-actions__action
             = render 'bookmarks/button', bookmarkable: movie
           = render 'application/url_copy_button'

--- a/app/views/pages/_doc_header.html.slim
+++ b/app/views/pages/_doc_header.html.slim
@@ -65,7 +65,7 @@ header.page-content-header
     .page-content-header__row
       .page-content-header-actions
         .page-content-header-actions__start
-          = render 'watches/watch_toggle', type: page.class.to_s, id: page.id, watch: page.watch_by(current_user)
+          = render 'watches/watch_toggle', type: page.class.to_s, id: page.id, watch: page.watched_by(current_user)
           .page-content-header-actions__action
             = render 'bookmarks/button', bookmarkable: page
           = render 'application/url_copy_button'

--- a/app/views/pair_works/_header.html.slim
+++ b/app/views/pair_works/_header.html.slim
@@ -54,4 +54,4 @@ header.page-content-header
     .page-content-header__row
       .page-content-header-actions
         .page-content-header-actions__start
-          = render 'watches/watch_toggle', type: pair_work.class.to_s, id: pair_work.id, watch: pair_work.watch_by(current_user)
+          = render 'watches/watch_toggle', type: pair_work.class.to_s, id: pair_work.id, watch: pair_work.watched_by(current_user)

--- a/app/views/practices/show.html.slim
+++ b/app/views/practices/show.html.slim
@@ -99,7 +99,7 @@
                   - if current_user.mentor? && @practice.submission
                     .page-content-header-actions__end
                       .practice-first-actions__end.is-only-mentor
-                        = render 'watches/watch_toggle', type: @practice.class.to_s, id: @practice.id, watch: @practice.watch_by(current_user)
+                        = render 'watches/watch_toggle', type: @practice.class.to_s, id: @practice.id, watch: @practice.watched_by(current_user)
 
           - if @practice.summary?
             = render 'summary', practice: @practice

--- a/app/views/products/_product_header.html.slim
+++ b/app/views/products/_product_header.html.slim
@@ -77,7 +77,7 @@ header.page-content-header.is-product
     .page-content-header__row
       .page-content-header-actions
         .page-content-header-actions__start
-          = render 'watches/watch_toggle', type: product.class.to_s, id: product.id, watch: product.watch_by(current_user)
+          = render 'watches/watch_toggle', type: product.class.to_s, id: product.id, watch: product.watched_by(current_user)
           .page-content-header-actions__action
             = render 'bookmarks/button', bookmarkable: product
         .page-content-header-actions__end

--- a/app/views/questions/_question_header.html.slim
+++ b/app/views/questions/_question_header.html.slim
@@ -57,7 +57,7 @@ header.page-content-header
     .page-content-header__row
       .page-content-header-actions
         .page-content-header-actions__start
-          = render 'watches/watch_toggle', type: question.class.to_s, id: question.id, watch: question.watch_by(current_user)
+          = render 'watches/watch_toggle', type: question.class.to_s, id: question.id, watch: question.watched_by(current_user)
           .page-content-header-actions__action
             = render 'bookmarks/button', bookmarkable: question
           = render 'application/url_copy_button'

--- a/app/views/regular_events/_regular_event.html.slim
+++ b/app/views/regular_events/_regular_event.html.slim
@@ -31,7 +31,7 @@
       .page-content-header__row
         .page-content-header-actions
           .page-content-header-actions__start
-            = render 'watches/watch_toggle', type: regular_event.class.to_s, id: regular_event.id, watch: regular_event.watch_by(current_user)
+            = render 'watches/watch_toggle', type: regular_event.class.to_s, id: regular_event.id, watch: regular_event.watched_by(current_user)
             .page-content-header-actions__action
                 = render 'bookmarks/button', bookmarkable: regular_event
           .page-content-header-actions__end

--- a/app/views/reports/_report_header.html.slim
+++ b/app/views/reports/_report_header.html.slim
@@ -47,7 +47,7 @@ header.page-content-header.is-report
     .page-content-header__row
       .page-content-header-actions
         .page-content-header-actions__start
-          = render 'watches/watch_toggle', type: report.class.to_s, id: report.id, watch: report.watch_by(current_user)
+          = render 'watches/watch_toggle', type: report.class.to_s, id: report.id, watch: report.watched_by(current_user)
           .page-content-header-actions__action
               = render 'bookmarks/button', bookmarkable: report
           = render 'application/url_copy_button'


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9979

## 概要

`Watchable` concernの `watch_by` メソッドを、受動態の `watched_by` に変更しました。
英語的に正しい命名に統一するための修正です。

## 変更確認方法

1. `fix/rename-watch-by-to-watched-by-#9979` をローカルに取り込む
2. `foreman start -f Procfile.dev` 等でローカルサーバーを起動する
3. 各ページ（日報、提出物、Q&A、Docs、お知らせ、定期イベント、特別イベント、ペアワーク、プラクティス、動画）のWatchボタンが正しく動作することを確認する
4. 定期イベント・特別イベントの参加機能が正しく動作することを確認する

## 変更内容

- `app/models/concerns/watchable.rb`: `watch_by` → `watched_by` にメソッド名を変更
- 上記メソッドを呼び出している全てのView・Controller（13箇所）を更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 各種イベント、コンテンツ、ページのウォッチ状態表示を統一しました。
  * 既にウォッチ中の場合に、重複してウォッチ登録される問題を防止しました。
  * ウォッチ切り替えボタンの表示・操作が、現在のウォッチ状態を正しく反映するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->