### PR TITLE
未解決のQ&Aがないときのアイコンをsmileに変更 #9220

### DIFF
--- a/app/views/questions/_questions.html.slim
+++ b/app/views/questions/_questions.html.slim
@@ -3,7 +3,7 @@
 - elsif questions.empty?
   .o-empty-message
       .o-empty-message__icon
-        i.fa-regular.fa-sad-tear
+        i.fa-regular.fa-smile
       p.o-empty-message__text
         = empty_message
 - else


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #9220

## 概要

未解決のQ&Aがないときに表示されるアイコンが `fa-regular.fa-sad-tear`（泣いている顔）になっており、「未解決のQ&Aがない＝良い状態」なのに悲しい印象を与えていました。
他の空状態（`products/unchecked`、`products/unassigned`、`pair_works/index` など）で使われている `fa-regular.fa-smile`（笑顔）に変更し、アイコンの表現を統一しました。

## 変更確認方法

1. `fix/qa-empty-icon-smile-#9220` をローカルに取り込む
2. `foreman start -f Procfile.dev` 等でローカルサーバーを起動する
3. ログイン後、Q&A一覧ページ（`/questions`）で `target=not_solved` かつ未解決のQ&Aが存在しない状態にする
4. 空状態メッセージと共に笑顔アイコン（`fa-smile`）が表示されることを確認する
<img width="1777" height="880" alt="screenshot-2026-07-27_16-55-34" src="https://github.com/user-attachments/assets/d6ce52db-3844-4738-8c0a-fdc6ec2d1b2a" />