### PR TITLE
secrets.ymlのStripeテスト鍵を環境変数へ移行 #10181

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,9 +23,9 @@ shared:
     all: <%= ENV['DISCORD_ALL_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/all' %>
     introduction: <%= ENV['DISCORD_INTRODUCTION_WEBHOOK_URL'] || 'https://discord.com/api/webhooks/0123456789/introduction' %>
   stripe:
-    public_key: pk_test_Je8A9BUHRC8oqsqx8wtfbKwg
-    secret_key: sk_test_XLP1Ajz1JvT9jUt5uKGvL0Wd
-    endpoint_secret: 'whsec_7bed86b552fc378b10af3cc11a371e8f3454c5817ba44ac9fc5092bf50056075'
+    public_key: <%= ENV['STRIPE_PUBLIC_KEY'] %>
+    secret_key: <%= ENV['STRIPE_SECRET_KEY'] %>
+    endpoint_secret: <%= ENV['STRIPE_ENDPOINT_SECRET'] %>
     tax_rate_id: <%= ENV['STRIPE_TAX_RATE_ID'] || 'txr_1Om0YyBpeWcLFd8fovSLFgXX' %>
   open_ai:
     access_token: <%= ENV['OPEN_AI_ACCESS_TOKEN'] || 'xxxxxxxx' %>

--- a/doc/parallel_worktree_dev.md
+++ b/doc/parallel_worktree_dev.md
@@ -40,8 +40,13 @@ worktree間で衝突するのは**ホストポート**と`COMPOSE_PROJECT_NAME`�
 cat > .env.local <<EOF
 WEB_PORT=3010
 COMPOSE_PROJECT_NAME=bootcamp_qa
+STRIPE_PUBLIC_KEY=<your_stripe_test_public_key>
+STRIPE_SECRET_KEY=<your_stripe_test_secret_key>
+STRIPE_ENDPOINT_SECRET=<your_stripe_test_endpoint_secret>
 EOF
 ```
+
+※ Stripe テスト鍵は `.env.local` (gitignore対象) 経由でコンテナに注入される。
 
 ※ `claude-launcher` 経由で worktree を作れば自動生成される (空きポート自動割当)。
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
     environment:
       BINDING: 0.0.0.0
       DATABASE_URL: postgres://postgres:postgres@db:5432
+      STRIPE_PUBLIC_KEY: ${STRIPE_PUBLIC_KEY:-}
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
+      STRIPE_ENDPOINT_SECRET: ${STRIPE_ENDPOINT_SECRET:-}
       HISTFILE: /workspace/log/.bash_history
     volumes:
       - .:/workspace


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10181

## 概要

`config/secrets.yml` の `shared.stripe` にハードコードされていたテスト鍵（`public_key` / `secret_key` / `endpoint_secret`）を環境変数へ移行しました。Docker Compose でのローカル開発体験を維持するため、テスト鍵は `docker-compose.yml` の `web.environment` 経由で注入します。

## 変更確認方法

1. `refactor/stripe-secrets-to-env-#10181` をローカルに取り込む
2. `docker compose up` でローカルサーバーを起動し、Stripe 関連機能が従来通り動作することを確認する
3. `bin/rails test test/models/webhook_test.rb test/lib/development_stripe_seeder_test.rb` が通ることを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ**
  * Stripeの認証情報を環境変数から取得する方式に変更しました。
  * リポジトリ内に固定されたStripeシークレットを保持しないよう改善しました。

* **設定**
  * コンテナ環境からStripeの公開鍵、秘密鍵、署名検証用シークレットを利用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->