### PR TITLE
CodeRabbitのUnit Testルールをtest/**/*から**/*.rbへ移行 #10275

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,8 @@ reviews:
         - Viewにpartialを作る場合はViewComponentを使うことを検討する。
         - 複数のActiveRecordモデルを操作する１つの責務がある時や外部APIとやりとりする処理がある場合にはInteractorオブジェクトパターンを検討する。（interactor gemを導入しているのでそれを使う）
         - 複数のInteractorを実行するような処理がある場合Organizerオブジェクトパターンを検討する。（interactor gemを導入しており、その中にOrganizerの機能があるので使う）
+        # Unit Test
+        model, helper, decorator, view_componentについてはメソッドを追加した場合は必ず対応したUnit TestのTestCaseを1つは書く。
     - path: "**/*.js"
       instructions: |-
         - どうしても避けられない時以外に新規にVue.js, Reactのコードを追加しない。
@@ -24,5 +26,3 @@ reviews:
         - TestCase名は英語で書く。
         - どうしても避けられない時以外にsystem testでsleepは使わない。
         - 各テストケースの間には空行を設ける。
-        # Unit Test
-        model, helper, decorator, view_componentについてはメソッドを追加した場合は必ず対応したUnit TestのTestCaseを1つは書く。


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10275

## 概要

`.coderabbit.yaml`の`# Unit Test`ルール（model, helper, decorator, view_componentのメソッド追加時に対応するUnit Testを書くよう促すルール）が`test/**/*`パスに設定されており、`app/models`や`app/helpers`などの実装コード変更時に発火しない状態でした。

`path_instructions`は対象パスに一致するファイルをレビューするときに適用されるため、実装コードをレビューする`**/*.rb`パスへ移行しました。

## 変更内容

- `**/*.rb`の`instructions`に`# Unit Test`ルールを追加
- `test/**/*`の`instructions`から`# Unit Test`ルールを削除

## 変更確認方法

1. `chore/coderabbit-unit-test-rule-#10275` をローカルに取り込む
2. `.coderabbit.yaml` のYAML構文が正しいことを確認する（`python3 -c "import yaml; yaml.safe_load(open('.coderabbit.yaml'))"`）
3. `app/models/**/*.rb` などを変更したPRでCodeRabbitがUnit Test追加を促すレビューを行うことを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Rubyコードレビュー向けのテスト記述ルールを整理しました。
  * モデル、ヘルパー、デコレーター、ビューコンポーネントにメソッドを追加する際、対応するユニットテストを最低1件作成する規約を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->