### PR TITLE
AIモデルを用途に応じて最新版へ更新

### DIFF
--- a/app/agents/article_meta_description_agent.rb
+++ b/app/agents/article_meta_description_agent.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ArticleMetaDescriptionAgent < RubyLLM::Agent
-  model 'claude-sonnet-4-6'
+  model 'claude-sonnet-5'
 
   instructions
 end

--- a/app/agents/pjord/agent.rb
+++ b/app/agents/pjord/agent.rb
@@ -40,7 +40,7 @@ class Pjord::Agent < RubyLLM::Agent
     - URL先を見れば分かることを、ユーザーに質問しない
   PROMPT
 
-  model ENV.fetch('PJORD_LLM_MODEL', 'claude-sonnet-4-6')
+  model ENV.fetch('PJORD_LLM_MODEL', 'claude-sonnet-5')
   tools BootcampSearchTool, UserInfoTool, ExternalContentTool
   schema PjordResponse
   instructions

--- a/app/agents/pjord/product_review_agent.rb
+++ b/app/agents/pjord/product_review_agent.rb
@@ -4,6 +4,7 @@ class Pjord::ProductReviewAgent < Pjord::Agent
   OTHER_PRODUCTS_LIMIT = 10
   PROMPT_TEXT_LIMIT = 2_000
 
+  model ENV.fetch('PJORD_REVIEW_LLM_MODEL', 'claude-opus-5')
   schema PjordProductReviewResponse
   tools BootcampSearchTool, UserInfoTool, ExternalContentTool, GithubPullRequestReviewCommentTool
   instructions

--- a/app/agents/pjord/report_classifier_agent.rb
+++ b/app/agents/pjord/report_classifier_agent.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Pjord::ReportClassifierAgent < RubyLLM::Agent
-  model ENV.fetch('PJORD_LLM_MODEL', 'claude-sonnet-4-6')
+  model ENV.fetch('PJORD_LLM_MODEL', 'claude-sonnet-5')
   schema PjordReportIntent
   instructions
 

--- a/app/agents/pjord/report_comment_agent.rb
+++ b/app/agents/pjord/report_comment_agent.rb
@@ -2,6 +2,7 @@
 
 class Pjord::ReportCommentAgent < Pjord::Agent
   inputs :report, :intent
+  model ENV.fetch('PJORD_COMMENT_LLM_MODEL', 'claude-opus-5')
   instructions
 
   def self.comment(report, intent:)

--- a/test/agents/pjord/product_review_agent_test.rb
+++ b/test/agents/pjord/product_review_agent_test.rb
@@ -7,12 +7,12 @@ class Pjord::ProductReviewAgentTest < ActiveSupport::TestCase
     assert_operator Pjord::ProductReviewAgent, :<, Pjord::Agent
   end
 
-  test '.review asks latest Sonnet model with product review context' do
+  test '.review asks latest Opus model with product review context' do
     product = products(:product1)
     chat = ProductReviewChatFake.new
 
     RubyLLM.stub(:chat, lambda { |model:|
-      assert_equal 'claude-sonnet-4-6', model
+      assert_equal 'claude-opus-5', model
       chat
     }) do
       assert_equal 'レビュー本文', Pjord::ProductReviewAgent.review(product)

--- a/test/agents/pjord/question_answer_agent_test.rb
+++ b/test/agents/pjord/question_answer_agent_test.rb
@@ -11,7 +11,10 @@ class Pjord::QuestionAnswerAgentTest < ActiveSupport::TestCase
     question = questions(:question1)
     chat = AgentChatFake.new
 
-    RubyLLM.stub(:chat, chat) do
+    RubyLLM.stub(:chat, lambda { |model:|
+      assert_equal 'claude-sonnet-5', model
+      chat
+    }) do
       assert_equal '回答本文', Pjord::QuestionAnswerAgent.answer(question)
     end
 

--- a/test/agents/pjord/report_classifier_agent_test.rb
+++ b/test/agents/pjord/report_classifier_agent_test.rb
@@ -7,7 +7,10 @@ class Pjord::ReportClassifierAgentTest < ActiveSupport::TestCase
     report = reports(:report1)
     chat = ClassifierChatFake.new('{"intent":"general","reason":"通常の学習記録"}')
 
-    RubyLLM.stub(:chat, chat) do
+    RubyLLM.stub(:chat, lambda { |model:|
+      assert_equal 'claude-sonnet-5', model
+      chat
+    }) do
       result = Pjord::ReportClassifierAgent.classify(report)
 
       assert_equal 'general', result[:intent]

--- a/test/agents/pjord/report_comment_agent_test.rb
+++ b/test/agents/pjord/report_comment_agent_test.rb
@@ -7,7 +7,10 @@ class Pjord::ReportCommentAgentTest < ActiveSupport::TestCase
     report = reports(:report1)
     chat = AgentChatFake.new
 
-    RubyLLM.stub(:chat, chat) do
+    RubyLLM.stub(:chat, lambda { |model:|
+      assert_equal 'claude-opus-5', model
+      chat
+    }) do
       assert_equal 'コメント本文', Pjord::ReportCommentAgent.comment(report, intent: 'struggling')
     end
 


### PR DESCRIPTION
## 概要

AI機能で使用するClaudeモデルを用途に応じて更新しました。

- 通常の回答、日報分類、記事メタディスクリプションは Claude Sonnet 5 を使用
- 提出物レビューと日報コメントは Claude Opus 5 を使用
- レビューとコメントは、それぞれ `PJORD_REVIEW_LLM_MODEL` と `PJORD_COMMENT_LLM_MODEL` で個別に上書き可能
- 各処理が意図したモデルを選択するテストを追加・更新

## 目的

通常処理では速度と性能のバランスがよい最新Sonnetを使い、提出物へのレビューやコメントでは品質を優先して最新Opusを使うためです。

## 確認

- `bin/rails test test/agents`（15 runs, 164 assertions, 0 failures）
- 対象9ファイルのRuboCop（no offenses detected）
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * 記事メタデータ、レポート分類、質問回答などで使用するAIモデルを最新版へ更新しました。
  * 商品レビューおよびレポートコメント生成では、実行環境の設定に応じて使用モデルを切り替えられるようになりました。
  * 商品レビューとレポートコメント生成の既定モデルを更新しました。

* **テスト**
  * 各AI機能が想定したモデルを使用することを確認するテストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10349-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30337439485/artifacts/8680185667" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Flakewatch Report" width="150"></a>
<!-- flakewatch-report:end -->
