### PR TITLE
Flakewatchでブランチ別履歴を記録

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -222,10 +221,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        # komagata/flakewatch v0.6.32
-        uses: komagata/flakewatch@v0.6.32
+        # komagata/flakewatch v0.6.35
+        uses: komagata/flakewatch@v0.6.35
         with:
           junit-artifact-pattern: junit-xml-*
           source-root: ${{ github.workspace }}
           history-branch: flakewatch-data
-          history-write: false
+          history-write: auto
+          analysis-branch: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,8 +222,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        # komagata/flakewatch v0.6.35
-        uses: komagata/flakewatch@v0.6.35
+        # komagata/flakewatch v0.6.36
+        uses: komagata/flakewatch@v0.6.36
         with:
           junit-artifact-pattern: junit-xml-*
           source-root: ${{ github.workspace }}


### PR DESCRIPTION
## 概要

- Flakewatchをv0.6.35へ更新
- mainへのpushと、main向けPRのテスト結果をブランチ名・commit SHA付きで履歴へ記録
- フレーク判定の対象をmainブランチの履歴に限定
- 同一リポジトリのPRでは履歴を書き込み、fork PRでは読み取りのみ実施
- push対象はmainのまま維持し、PRでpushイベントとpull_requestイベントのCIが二重起動することを回避

## 変更確認方法

1. GitHub ActionsのCIを実行する
2. Flakewatch HTML reportジョブが成功することを確認する
3. flakewatch-dataブランチにブランチ名・commit SHA付きの履歴が追加されることを確認する
4. レポートのフレーク判定がmainブランチの履歴を対象にしていることを確認する

## 検証

- YAML構文チェック
- actionlint .github/workflows/ci.yml
- Flakewatch v0.6.35リリースバイナリのインストールと--analysis-branchオプション確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * コード品質チェック機能を更新し、解析履歴が自動的に保存されるようになりました。
  * 継続的な品質分析結果を確認しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10351-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->