### PR TITLE
Flakewatchのリリースビルドを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,8 +222,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        # komagata/flakewatch v0.6.36
-        uses: komagata/flakewatch@v0.6.36
+        # komagata/flakewatch v0.6.37
+        uses: komagata/flakewatch@v0.6.37
         with:
           junit-artifact-pattern: junit-xml-*
           source-root: ${{ github.workspace }}


### PR DESCRIPTION
## 概要

- Flakewatchをv0.6.36からv0.6.37へ更新
- Releaseビルドで使用するTyaをv0.72.12からv0.72.15へ更新したバイナリを利用
- #10351のFlakewatchジョブで発生したexit 143を修正

## 原因

FlakewatchのRelease CIが古いTya v0.72.12でバイナリをbuildしており、実際のBootcamp履歴ではピーク18.3GBを消費してGitHub runnerからSIGTERMを受けていました。v0.6.37はTya v0.72.15でbuildされ、同一入力でピーク810.2MB・正常終了を確認しています。

## 検証

- 公開済みv0.6.37バイナリをインストール
- Bootcamp CIのJUnit XML 550ファイルとflakewatch-data履歴を入力して正常終了
- ピークメモリ: 810.2MB
- YAML構文チェック
- actionlint .github/workflows/ci.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CIで使用しているコード品質チェックツールを最新バージョンに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30381883125/artifacts/8697966990" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10355-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->