### PR TITLE
Flakewatchをv0.6.40に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,8 +222,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Generate flakewatch HTML
-        # komagata/flakewatch v0.6.37
-        uses: komagata/flakewatch@v0.6.37
+        # komagata/flakewatch v0.6.40
+        uses: komagata/flakewatch@v0.6.40
         with:
           junit-artifact-pattern: junit-xml-*
           source-root: ${{ github.workspace }}


### PR DESCRIPTION
## 概要

CIで利用するFlakewatchをv0.6.37からv0.6.40へ更新します。

v0.6.40にはピークメモリ使用量の削減が含まれており、Bootcampの実データを使った5回の検証では、いずれも約114MBで完了しています。

## 確認内容

- `git diff --check`
- RubyのYAMLパーサーによる `.github/workflows/ci.yml` の構文確認
- `komagata/flakewatch` v0.6.40が公開済みであることを確認

## 影響範囲

Flakewatch Actionの参照バージョンのみです。履歴保存先や分析対象ブランチなどの設定は変更していません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 継続的インテグレーション環境で使用するコード品質レポート生成ツールを更新しました。
  - これにより、レポート生成処理の安定性と最新環境への対応が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10370-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30471639322/artifacts/8732429337" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->
