### PR TITLE
管理者がユーザーごとにメール配信を停止・再開できる機能の実装

### DIFF
--- a/app/controllers/stopped_mail_by_admin_controller.rb
+++ b/app/controllers/stopped_mail_by_admin_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class StoppedMailByAdminController < ApplicationController
+  skip_before_action :require_active_user_login, raise: false
+  before_action :set_user, only: %i[update]
+  before_action :set_redirect_url, only: %i[update]
+  before_action :require_admin_login, only: %i[update]
+
+  def update
+    mail_status = params[:stopped_mail_by_admin].present?
+    if @user.update(stopped_mail_by_admin: mail_status)
+      redirect_to @redirect_url, notice: 'ユーザー情報を更新しました。'
+    else
+      redirect_to @redirect_url, alert: 'ユーザー情報の更新に失敗しました'
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+
+  def set_redirect_url
+    @redirect_url = params[:redirect_url].presence || admin_users_url
+  end
+end

--- a/app/controllers/stopped_mail_by_admin_controller.rb
+++ b/app/controllers/stopped_mail_by_admin_controller.rb
@@ -22,6 +22,6 @@ class StoppedMailByAdminController < ApplicationController
   end
 
   def set_redirect_url
-    @redirect_url = params[:redirect_url].presence || admin_users_url
+    @redirect_url = url_from(params[:redirect_url]) || admin_users_url
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,8 +9,6 @@ class ApplicationMailer < ActionMailer::Base
   private
 
   def stopped_mail_by_admin
-    if @user&.stopped_mail_by_admin?
-      mail.perform_deliveries = false
-    end
+    mail.perform_deliveries = false if @user&.stopped_mail_by_admin?
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,4 +3,14 @@
 class ApplicationMailer < ActionMailer::Base
   default from: 'フィヨルドブートキャンプ <noreply@bootcamp.fjord.jp>'
   layout 'mailer'
+
+  after_action :stopped_mail_by_admin
+
+  private
+
+  def stopped_mail_by_admin
+    if @user&.stopped_mail_by_admin?
+      mail.perform_deliveries = false
+    end
+  end
 end

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -99,6 +99,17 @@
                         method: :patch,
                         data: { confirm: '本当によろしいですか？' },
                         class: 'a-button is-sm is-danger is-block'
+                  .user-statuses__item
+                    - if @user.stopped_mail_by_admin?
+                      = link_to 'メール配信を再開する', user_stopped_mail_by_admin_path(@user, redirect_url: "/users/#{@user.id}"),
+                        method: :patch,
+                        data: { confirm: '本当によろしいですか？' },
+                        class: 'a-button is-sm is-secondary is-block'
+                    - else
+                      = link_to 'メール配信を止める', user_stopped_mail_by_admin_path(@user, stopped_mail_by_admin: true, redirect_url: "/users/#{@user.id}"),
+                        method: :patch,
+                        data: { confirm: '本当によろしいですか？' },
+                        class: 'a-button is-sm is-secondary is-block'
                 - if @user != current_user
                   .user-statuses__delete
                     = link_to 'このユーザーを削除する', admin_user_path(@user), method: :delete, id: "delete-#{@user.id}", class: 'a-muted-text-link',

--- a/config/routes/users.rb
+++ b/config/routes/users.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     resources :regular_events, only: %i(index), controller: "users/regular_events"
     get "portfolio" => "users/works#index", as: :portfolio
     patch "graduation", to: "graduation#update", as: :graduation
+    patch "stopped_mail_by_admin", to: "stopped_mail_by_admin#update", as: :stopped_mail_by_admin
     resource :mail_notification, only: %i(edit update), controller: "users/mail_notification"
   end
 

--- a/db/migrate/20260802071524_add_stopped_mail_by_admin_to_users.rb
+++ b/db/migrate/20260802071524_add_stopped_mail_by_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddStoppedMailByAdminToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :stopped_mail_by_admin, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -277,6 +277,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_093000) do
     t.index ["course_id", "category_id"], name: "index_courses_categories_on_course_id_and_category_id", unique: true
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "discord_profiles", force: :cascade do |t|
     t.string "account_name"
     t.datetime "created_at", null: false
@@ -1148,6 +1151,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_093000) do
     t.boolean "sent_student_followup_message", default: false
     t.boolean "show_mentor_profile", default: true, null: false
     t.boolean "show_study_streak", default: false, null: false
+    t.boolean "stopped_mail_by_admin", default: false, null: false
     t.string "subdivision_code"
     t.string "subscription_id"
     t.boolean "trainee", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_28_164105) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_071524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -1147,6 +1147,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_28_164105) do
     t.boolean "sent_student_followup_message", default: false
     t.boolean "show_mentor_profile", default: true, null: false
     t.boolean "show_study_streak", default: false, null: false
+    t.boolean "stopped_mail_by_admin", default: false, null: false
     t.string "subdivision_code"
     t.string "subscription_id"
     t.boolean "trainee", default: false, null: false

--- a/test/mailers/activity_mailer_test.rb
+++ b/test/mailers/activity_mailer_test.rb
@@ -1057,6 +1057,20 @@ class ActivityMailerTest < ActionMailer::TestCase
     assert_empty ActionMailer::Base.deliveries
   end
 
+  test 'not send came_comment email to user with stopped_mail_by_admin on' do
+    comment = comments(:commentOfTalk)
+    receiver = comment.receiver
+    receiver.update(stopped_mail_by_admin: true)
+
+    ActivityMailer.came_comment(
+      comment:,
+      message: "相談部屋で#{comment.sender.login_name}さんからコメントがありました。",
+      receiver: comment.receiver
+    ).deliver_now
+
+    assert_empty ActionMailer::Base.deliveries
+  end
+
   test 'not send chose_correct_answer email to retired user' do
     answer = correct_answers(:correct_answer1)
     receiver = answer.user


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- #10116

## 概要

管理者がユーザーごとに「メール配信を停止する」フラグを設定できるようにし、メールを送信している箇所ではこのフラグを考慮して送信をスキップするようにしました。
ユーザー詳細画面の「ステータス変更」欄に、退会・卒業と同じ並びでフラグの変更ボタンを配置しています(komagataさんに相談し、既存の管理者操作との一貫性を優先してこの配置にしました)。

## 変更確認方法

1. feature/stopped_mail_by_adminをローカルに取り込む
2. `bin/rails db:migrate`を実行する
3. 管理者としてログインし、任意のユーザーの詳細ページを開く
4. 「ステータス変更」の「メール配信を止める」を押し、ボタンが「メール配信を再開する」に変わることを確認する
5. 再度押して「メール配信を止める」に戻ることを確認する
6. rails consoleで`User.find_by(login_name: "【3で選んだユーザー名】").stopped_mail_by_admin`を確認し、ボタンの動きを確認する
7. `bin/rails test test/mailers/activity_mailer_test.rb -n "/stopped_mail_by_admin/"` でテストが通ることを確認する

## 対象範囲
- `ApplicationMailer` を継承する全メーラーが対象です。パスワードリセットメールなども含め、issueの「メール送信している場所ではそのフラグを考慮して送らないようにする」という記載に基づき、一律で対象にしています。
- 配信エラーになっているユーザーの自動検出は今回のスコープ外です(komagataさんに確認済み。管理者はエラーメールやjob管理画面で失敗を確認できるため不要とのこと)。

## Screenshot

### 変更前
<img width="485" height="185" alt="image" src="https://github.com/user-attachments/assets/429b10ae-ce06-4bf1-8f38-64553936221f" />

### 変更後
<img width="485" height="185" alt="image" src="https://github.com/user-attachments/assets/0f10b6fd-5e01-4b8e-8af0-94fd4ade214f" />


<!-- I want to review in Japanese. -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10380-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30750925664/artifacts/8845624671" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 管理者がユーザーごとのメール配信を停止・再開できるようになりました。
  * 配信停止中のユーザーには、対象メールが送信されなくなります。
  * 現在の設定状態に応じて、停止または再開の操作を表示します。

* **改善**
  * 操作結果に応じて通知や警告を表示するようになりました。
  * メール配信停止状態をユーザー情報として管理できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
