### PR TITLE
プラクティスとDocsの本文更新APIを追加

### DIFF
--- a/app/controllers/api/pages_controller.rb
+++ b/app/controllers/api/pages_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class API::PagesController < API::BaseController
+  before_action :require_write_scope, only: %i[update]
   before_action :set_page, only: %i[update]
 
   def update
+    @page.last_updated_user = current_user
     if @page.update(page_params)
       head :ok
     else
@@ -18,6 +20,12 @@ class API::PagesController < API::BaseController
   end
 
   def page_params
-    params.require(:page).permit(:tag_list)
+    params.require(:page).permit(:tag_list, :body)
+  end
+
+  def require_write_scope
+    return unless doorkeeper_token.present? || params[:page]&.key?(:body)
+
+    doorkeeper_authorize! :write
   end
 end

--- a/app/controllers/api/practices_controller.rb
+++ b/app/controllers/api/practices_controller.rb
@@ -4,7 +4,7 @@ class API::PracticesController < API::BaseController
   include Rails.application.routes.url_helpers
   before_action :require_mentor_login_for_api, only: %i[show update]
   before_action -> { doorkeeper_authorize! :mentor }, only: %i[show], if: -> { doorkeeper_token.present? }
-  before_action -> { doorkeeper_authorize! :write }, only: %i[update], if: -> { doorkeeper_token.present? }
+  before_action :require_write_scope, only: %i[update]
   before_action -> { doorkeeper_authorize! :mentor }, only: %i[update], if: -> { doorkeeper_token.present? }
   before_action :set_practice, only: %i[show update]
 
@@ -20,6 +20,7 @@ class API::PracticesController < API::BaseController
   end
 
   def update
+    @practice.last_updated_user = current_user
     if @practice.update(practice_params)
       head :ok
     else
@@ -34,6 +35,12 @@ class API::PracticesController < API::BaseController
   end
 
   def practice_params
-    params.require(:practice).permit(:memo)
+    params.require(:practice).permit(:memo, :description, :goal)
+  end
+
+  def require_write_scope
+    return unless doorkeeper_token.present? || params[:practice]&.slice(:description, :goal).present?
+
+    doorkeeper_authorize! :write
   end
 end

--- a/test/integration/api/pages_test.rb
+++ b/test/integration/api/pages_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class API::PagesTest < ActionDispatch::IntegrationTest
+  setup do
+    @application = Doorkeeper::Application.create!(
+      name: 'Sample Application',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
+  end
+
+  test 'PATCH /api/pages/1234.json updates content' do
+    page = pages(:page1)
+    user = users(:komagata)
+    token = Doorkeeper::AccessToken.create!(
+      application: @application,
+      resource_owner_id: user.id,
+      scopes: 'read write'
+    )
+
+    patch api_page_path(page, format: :json),
+          params: { page: { body: 'APIから更新した本文' } },
+          headers: { Authorization: "Bearer #{token.token}" }
+
+    assert_response :ok
+    assert_equal 'APIから更新した本文', page.reload.body
+    assert_equal user, page.last_updated_user
+  end
+
+  test 'PATCH /api/pages/1234.json requires write scope to update content' do
+    page = pages(:page1)
+    token = Doorkeeper::AccessToken.create!(
+      application: @application,
+      resource_owner_id: users(:komagata).id,
+      scopes: 'read'
+    )
+
+    patch api_page_path(page, format: :json),
+          params: { page: { body: '更新されない本文' } },
+          headers: { Authorization: "Bearer #{token.token}" }
+
+    assert_response :forbidden
+    assert_not_equal '更新されない本文', page.reload.body
+  end
+
+  test 'PATCH /api/pages/1234.json requires OAuth token to update content' do
+    page = pages(:page1)
+    token = create_token('komagata', 'testtest')
+
+    patch api_page_path(page, format: :json),
+          params: { page: { body: '更新されない本文' } },
+          headers: { Authorization: "Bearer #{token}" }
+
+    assert_response :unauthorized
+    assert_not_equal '更新されない本文', page.reload.body
+  end
+end

--- a/test/integration/api/practices_test.rb
+++ b/test/integration/api/practices_test.rb
@@ -5,6 +5,13 @@ require 'test_helper'
 class API::PracticesTest < ActionDispatch::IntegrationTest
   fixtures :practices
 
+  setup do
+    @application = Doorkeeper::Application.create!(
+      name: 'Sample Application',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'
+    )
+  end
+
   test 'GET /api/practices.json' do
     get api_practices_path(format: :json)
     assert_response :unauthorized
@@ -47,5 +54,52 @@ class API::PracticesTest < ActionDispatch::IntegrationTest
           params: { practice: { memo: 'test' } },
           headers: { 'Authorization' => "Bearer #{token}" }
     assert_response :ok
+  end
+
+  test 'PATCH /api/practices/1234.json updates content' do
+    practice = practices(:practice1)
+    mentor = users(:mentormentaro)
+    token = Doorkeeper::AccessToken.create!(
+      application: @application,
+      resource_owner_id: mentor.id,
+      scopes: 'read write mentor'
+    )
+
+    patch api_practice_path(practice, format: :json),
+          params: { practice: { description: 'APIから更新した内容', goal: 'APIから更新した目的' } },
+          headers: { Authorization: "Bearer #{token.token}" }
+
+    assert_response :ok
+    assert_equal 'APIから更新した内容', practice.reload.description
+    assert_equal 'APIから更新した目的', practice.goal
+    assert_equal mentor, practice.last_updated_user
+  end
+
+  test 'PATCH /api/practices/1234.json requires write scope to update content' do
+    practice = practices(:practice1)
+    token = Doorkeeper::AccessToken.create!(
+      application: @application,
+      resource_owner_id: users(:mentormentaro).id,
+      scopes: 'read mentor'
+    )
+
+    patch api_practice_path(practice, format: :json),
+          params: { practice: { description: '更新されない内容' } },
+          headers: { Authorization: "Bearer #{token.token}" }
+
+    assert_response :forbidden
+    assert_not_equal '更新されない内容', practice.reload.description
+  end
+
+  test 'PATCH /api/practices/1234.json requires OAuth token to update content' do
+    practice = practices(:practice1)
+    token = create_token('mentormentaro', 'testtest')
+
+    patch api_practice_path(practice, format: :json),
+          params: { practice: { description: '更新されない内容' } },
+          headers: { Authorization: "Bearer #{token}" }
+
+    assert_response :unauthorized
+    assert_not_equal '更新されない内容', practice.reload.description
   end
 end


### PR DESCRIPTION
## 概要

- プラクティスの `description` と `goal` をAPIから更新可能にする
- Docsの `body` をAPIから更新可能にする
- 本文更新にはOAuthの `write` スコープを必須にする
- API更新時の `last_updated_user` を記録する

## 確認

- [x] `bin/rails test test/integration/api`（197 runs, 780 assertions, 0 failures, 0 errors）
- [x] `bundle exec rubocop app/controllers/api/practices_controller.rb app/controllers/api/pages_controller.rb test/integration/api/practices_test.rb test/integration/api/pages_test.rb`
- [x] 別担当レビュー（指摘対応後、指摘なし）
- [ ] Claude Codeレビュー（ローカルで未ログインのため実行不可）

Closes #10391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ページ本文の更新に対応しました。
  - プラクティスの説明・目標を更新できるようになりました。
  - 更新時の最終更新者を記録します。

- **改善**
  - APIでの更新操作に書き込み権限の確認を追加しました。
  - 読み取り専用または認証なしの場合、更新を拒否して内容を保護します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10392-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30930943481/artifacts/8901847225" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->
