### PR TITLE
キャンセル済みサブスクリプションの競合を処理

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -27,6 +27,10 @@ class Subscription
     return true if retrieve(subscription_id).status == 'canceled'
 
     Stripe::Subscription.update(subscription_id, cancel_at_period_end: true)
+  rescue Stripe::InvalidRequestError
+    raise unless retrieve(subscription_id).status == 'canceled'
+
+    true
   end
 
   def all

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -26,6 +26,20 @@ class SubscriptionTest < ActiveSupport::TestCase
     end
   end
 
+  test '#destroy succeeds if the subscription is canceled concurrently' do
+    statuses = %w[active canceled].map { |status| Struct.new(:status).new(status) }
+    error = Stripe::InvalidRequestError.new(
+      'A canceled subscription can only update its cancellation_details and metadata.',
+      'subscription'
+    )
+
+    Stripe::Subscription.stub(:retrieve, ->(*) { statuses.shift }) do
+      Stripe::Subscription.stub(:update, ->(*) { raise error }) do
+        assert Subscription.new.destroy('sub_12345678')
+      end
+    end
+  end
+
   test '#all' do
     VCR.use_cassette 'subscription/list' do
       subscriptions = Subscription.new.all


### PR DESCRIPTION
## 概要

サブスクリプション停止処理中に、別処理によって対象が先にキャンセル済みになった場合も正常終了するようにしました。

## 背景・原因

休会処理で `Stripe::Subscription.retrieve` により状態を確認してから `update` するまでの間に、対象サブスクリプションがキャンセルされると、Stripeから `Stripe::InvalidRequestError` が返り休会リクエストがエラーになっていました。

## 変更内容

- `Stripe::InvalidRequestError` 発生後にサブスクリプション状態を再取得
- 実際に `canceled` なら停止済みとして正常終了
- `canceled` 以外のエラーは従来どおり再送出
- 競合を再現する回帰テストを追加

## 影響

休会・退会など、共通の `Subscription#destroy` を利用する処理で同じ競合エラーを防ぎます。

## 確認

- `CLAUDE_WORKTREE_DB_SUFFIX=canceled_subscription_pr bin/rails test test/models/subscription_test.rb test/models/retirement_test.rb`
  - 11 runs, 14 assertions, 0 failures, 0 errors
- `bundle exec rubocop app/models/subscription.rb test/models/subscription_test.rb`
  - 2 files inspected, no offenses detected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - サブスクリプションの解約処理中に別の処理で先にキャンセルされた場合でも、エラーとして扱わず正常に完了できるようになりました。
  - それ以外の解約エラーは、従来どおり適切に通知されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10393-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30931244171/artifacts/8902292153" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->
