### PR TITLE
PDFアップロード時のundefinedを修正

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -7,7 +7,9 @@ class Image < ApplicationRecord
   validates :image, attached: true
 
   def image=(attachable)
-    MiniMagick::Image.new(attachable.tempfile.path).strip if attachable.respond_to?(:tempfile) && attachable.content_type&.start_with?('image/')
+    if attachable.respond_to?(:tempfile) && Marcel::MimeType.for(attachable.tempfile).start_with?('image/')
+      MiniMagick::Image.new(attachable.tempfile.path).strip
+    end
     super
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -7,7 +7,7 @@ class Image < ApplicationRecord
   validates :image, attached: true
 
   def image=(attachable)
-    MiniMagick::Image.new(attachable.tempfile.path).strip if attachable.respond_to?(:tempfile)
+    MiniMagick::Image.new(attachable.tempfile.path).strip if attachable.respond_to?(:tempfile) && attachable.content_type&.start_with?('image/')
     super
   end
 end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -3,6 +3,15 @@
 require 'test_helper'
 
 class ImageTest < ActiveSupport::TestCase
+  test 'does not process PDF with MiniMagick' do
+    pdf_path = Rails.root.join('test/fixtures/files/users/diplomas/diploma.pdf')
+    pdf = Rack::Test::UploadedFile.new(pdf_path, 'application/pdf')
+
+    MiniMagick::Image.stub(:new, ->(*) { raise 'MiniMagick should not process PDFs' }) do
+      assert Image.create!(user: users(:hajime), image: pdf).image.attached?
+    end
+  end
+
   test 'remove exif data when image is updated' do
     image_path = Rails.root.join('test/fixtures/files/articles/ogp_images/test.jpg')
     image = Image.create!(user: users(:hajime), image: Rack::Test::UploadedFile.new(image_path, 'image/jpeg'))

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -44,5 +44,6 @@ class TalksTest < ApplicationSystemTestCase
     find('.new-comment-file-input', visible: false).set(pdf_path)
 
     assert_field 'js-new-comment', with: /\[diploma\.pdf \(.+ KB\)\]\(http.+diploma\.pdf\)/
+    assert_no_field 'js-new-comment', with: /undefined/
   end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -35,4 +35,14 @@ class TalksTest < ApplicationSystemTestCase
     visit_with_auth "/talks/#{user.talk.id}", 'kimura'
     assert_no_selector '.page-tabs'
   end
+
+  test 'upload PDF to talk comment' do
+    user = users(:kimura)
+    visit_with_auth "/talks/#{user.talk.id}", 'kimura'
+
+    pdf_path = Rails.root.join('test/fixtures/files/users/diplomas/diploma.pdf')
+    find('.new-comment-file-input', visible: false).set(pdf_path)
+
+    assert_field 'js-new-comment', with: /\[diploma\.pdf \(.+ KB\)\]\(http.+diploma\.pdf\)/
+  end
 end


### PR DESCRIPTION
## 概要

PDFアップロード時の500エラーを修正するhotfixです。

`main` 向けPR: #10394

## 原因

添付ファイルを保存する `Image` モデルがPDFにもMiniMagickの画像処理を実行していたため、本番環境でアップロードAPIが500を返し、MarkdownリンクのURLが `undefined` になっていました。

## 変更内容

- Marcelでファイル内容からMIME typeを判定
- 画像の場合だけMiniMagickでEXIFを除去
- PDFをMiniMagickで処理しないモデルテストを追加
- 相談部屋でPDFをアップロードできるシステムテストを追加

## 確認

- 本番の `https://bootcamp.fjord.jp/talks/1758` で `~/Downloads/a.pdf` を使い、修正前にAPI 500と `[a.pdf (451.47 KB)](undefined)` を確認
- ローカル: 9 tests, 16 assertions, 0 failures, 0 errors
- RuboCop: offensesなし
- PR #10394:
  - GitHub Actions全8 test shard成功
  - CircleCI成功
  - build / check成功
  - CodeRabbit完了
