### PR TITLE
title, memoの文字列長のバリデーションを追加

### DIFF
--- a/app/models/buzz.rb
+++ b/app/models/buzz.rb
@@ -4,7 +4,8 @@ class Buzz < ApplicationRecord
   ROUTABLE_YEAR_RANGE = 1000..9999
   ROUTABLE_PUBLISHED_AT_RANGE = Date.new(ROUTABLE_YEAR_RANGE.begin, 1, 1)..Date.new(ROUTABLE_YEAR_RANGE.end, 12, 31)
 
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 120, message: 'は120文字以内で入力してください' }
+  validates :memo, length: { maximum: 500, message: 'は500文字以内で入力してください' }
   validates :published_at, presence: true
   validates :url, presence: true, uniqueness: { message: 'はすでに登録されています' }
   validate :url_format

--- a/test/models/buzz_test.rb
+++ b/test/models/buzz_test.rb
@@ -57,6 +57,31 @@ class BuzzTest < ActiveSupport::TestCase
     assert_includes buzz.errors[:published_at], 'は4桁の年で入力してください'
   end
 
+  test 'invalid when title exceeds maximum length' do
+    title = 'a' * 121
+    buzz = Buzz.new(
+      title: title,
+      url: 'https://www.example-too-long-title.com',
+      published_at: Date.new(2026, 8, 5)
+    )
+
+    assert_not buzz.valid?
+    assert_includes buzz.errors[:title], 'は120文字以内で入力してください'
+  end
+
+  test 'invalid when memo exceeds maximum length' do
+    memo = 'a' * 501
+    buzz = Buzz.new(
+      title: 'memoが長すぎる記事',
+      url: 'https://www.example-too-long-memo.com',
+      published_at: Date.new(2026, 8, 5),
+      memo: memo
+    )
+
+    assert_not buzz.valid?
+    assert_includes buzz.errors[:memo], 'は500文字以内で入力してください'
+  end
+
   test '.doc_from_url returns nokogori object when succeeded' do
     dummy_response = <<~BODY
       <title>buzz1</title>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue
#10371

## 概要
buzzのtitleカラム、memoカラムへの不正に長い文字列の入力に対応するため、それぞれ最大120文字、最大500文字の文字列長のバリデーションを追加した。

http://localhost:3000

## テスト
次のテストを実行し、通ることを確認。
```ruby
bin/rails test test/models/buzz_test.rb -n test_invalid_when_title_exceeds_maximum_length     
bin/rails test test/models/buzz_test.rb -n test_invalid_when_memo_exceeds_maximum_length      
```

## 動作確認

### 本番環境での確認について
次のいずれかの方法で確認をお願いします
- 下記のcurlコマンドを本番ドメイン(`https://bootcamp.fjord.jp`)に変更して実行し、それぞれ期待する結果が返ることを確認

- bootcampにログインし`/mentor/buzzes`にアクセスし:
  - フォームで120文字以上のtitleを入力し登録ボタンを押す。「titleは120文字以内で入力してください。」とエラーが表示されることを確認
  - 500文字以上のMemoを入力し登録ボタンを押す。「Memoは500文字以内で入力してください。」とエラーが表示されることを確認


### JTW tokenを取得
```bash
curl -X POST https://bootcamp.fjord.jp/api/session -H "Content-Type: application/json" -d '{"login_name": "komagata", "password": "testtest"}'

# 戻り値
{"token":"JWTトークン"}%

# 変数にセット
TOKEN="値"
```

### titleの文字列長バリデーションの確認

**正常系**
```bash
# 120文字のtitleを作成
VALID_TITLE=$(printf 'a%.0s' {1..120})

# エンドポイントにPOST
curl -i -X POST "https://bootcamp.fjord.jp/api/buzz" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d "{\"buzz\": {\"title\": \"$VALID_TITLE\", \"url\": \"https://example.com/valid-title\", \"published_at\": \"2026-08-05\"}}"

# 正常に登録ができることを確認
HTTP/1.1 201 Created
```

**異常系**
```bash
# 121文字のtitleを作成
LONG_TITLE=$(printf 'a%.0s' {1..121})

# エンドポイントにPOST
curl -i -X POST "https://bootcamp.fjord.jp/api/buzz" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d "{\"buzz\": {\"title\": \"$LONG_TITLE\", \"url\": \"https://example.com/long-title\", \"published_at\": \"2026-08-05\"}}"

# 422と、次のerrorsメッセージが返ることを確認
HTTP/1.1 422 Unprocessable Content
{"errors":["Titleは120文字以内で入力してください"]}%
```


### Memoの文字列長バリデーションの確認

**正常系**
```bash
# 500文字のmemoを作成
VALID_MEMO=$(printf 'a%.0s' {1..500})

# エンドポイントにPOST
curl -i -X POST "https://bootcamp.fjord.jp/api/buzz" \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $TOKEN" \
-d "{\"buzz\": {\"title\": \"memoが長すぎる検証用\", \"url\": \"https://example.com/valid-memo\", \"memo\": \"$VALID_MEMO\", \"published_at\": \"2026-08-05\"}}"

# 正常に登録できることを確認
HTTP/1.1 201 Created
```

**異常系**
```bash
# 501文字のmemoを作成
LONG_MEMO=$(printf 'a%.0s' {1..501})

# エンドポイントにPOST
curl -i -X POST "https://bootcamp.fjord.jp/api/buzz" \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $TOKEN" \
-d "{\"buzz\": {\"title\": \"memoが長すぎる検証用\", \"url\": \"https://example.com/long-memo\", \"memo\": \"$LONG_MEMO\", \"published_at\": \"2026-08-05\"}}"

# 422と、次のerrorsメッセージが返ることを確認
HTTP/1.1 422 Unprocessable Content
{"errors":["Memoは500文字以内で入力してください"]}%
```







<details>
<summary>
開発環境での動作確認
</summary>  

### JTW tokenを取得
```bash
curl -X POST http://localhost:3000/api/session -H "Content-Type: application/json" -d '{"login_name": "komagata", "password": "testtest"}'

# 戻り値
{"token":"JWTトークン"}%

# 変数にセット
TOKEN="値"
```

### titleの文字列長バリデーションの確認

**正常系**
```bash
# 120文字のtitleを作成
VALID_TITLE=$(printf 'a%.0s' {1..120})

# エンドポイントにPOST
curl -i -X POST "http://localhost:3000/api/buzz" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d "{\"buzz\": {\"title\": \"$VALID_TITLE\", \"url\": \"https://example.com/valid-title\", \"published_at\": \"2026-08-05\"}}"

# 正常に登録ができることを確認
HTTP/1.1 201 Created
```

**異常系**
```bash
# 121文字のtitleを作成
LONG_TITLE=$(printf 'a%.0s' {1..121})

# エンドポイントにPOST
curl -i -X POST "http://localhost:3000/api/buzz" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d "{\"buzz\": {\"title\": \"$LONG_TITLE\", \"url\": \"https://example.com/long-title\", \"published_at\": \"2026-08-05\"}}"

# 422と、次のerrorsメッセージが返ることを確認
HTTP/1.1 422 Unprocessable Content
{"errors":["Titleは120文字以内で入力してください"]}%
```


### Memoの文字列長バリデーションの確認

**正常系**
```bash
# 500文字のmemoを作成
VALID_MEMO=$(printf 'a%.0s' {1..500})

# エンドポイントにPOST
curl -i -X POST "http://localhost:3000/api/buzz" \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $TOKEN" \
-d "{\"buzz\": {\"title\": \"memoが長すぎる検証用\", \"url\": \"https://example.com/valid-memo\", \"memo\": \"$VALID_MEMO\", \"published_at\": \"2026-08-05\"}}"

# 正常に登録できることを確認
HTTP/1.1 201 Created
```

**異常系**
```bash
# 501文字のmemoを作成
LONG_MEMO=$(printf 'a%.0s' {1..501})

# エンドポイントにPOST
curl -i -X POST "http://localhost:3000/api/buzz" \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $TOKEN" \
-d "{\"buzz\": {\"title\": \"memoが長すぎる検証用\", \"url\": \"https://example.com/long-memo\", \"memo\": \"$LONG_MEMO\", \"published_at\": \"2026-08-05\"}}"

# 422と、次のerrorsメッセージが返ることを確認
HTTP/1.1 422 Unprocessable Content
{"errors":["Memoは500文字以内で入力してください"]}%
```

</details>



## 関連Issue
[フォームの各フィールドにバリデーションを追加する #15](https://github.com/fjordllc/bootcamp-buzz/issues/15)

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * タイトルを必須入力とし、120文字以内に制限しました。
  * メモを500文字以内に制限しました。
  * 入力エラー時の日本語メッセージを整備しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10402-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/30991327341/artifacts/8924952010" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->
