### PR TITLE
Pjordの日報コメント生成モデルを修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -666,7 +666,7 @@ GEM
       ffi (~> 1.12)
       logger
     ruby2_keywords (0.0.5)
-    ruby_llm (1.15.0)
+    ruby_llm (1.16.0)
       base64
       event_stream_parser (~> 1)
       faraday (>= 1.10.0)

--- a/app/agents/pjord/report_comment_agent.rb
+++ b/app/agents/pjord/report_comment_agent.rb
@@ -2,7 +2,7 @@
 
 class Pjord::ReportCommentAgent < Pjord::Agent
   inputs :report, :intent
-  model ENV.fetch('PJORD_COMMENT_LLM_MODEL', 'claude-opus-4-6')
+  model ENV.fetch('PJORD_COMMENT_LLM_MODEL', 'claude-opus-5'), provider: :anthropic, assume_model_exists: true
   instructions { Pjord::Agent.prompt_for('report_comment', Pjord::ReportCommentAgent.context_for(report, intent)) }
 
   def self.comment(report, intent:)

--- a/app/agents/pjord/report_comment_agent.rb
+++ b/app/agents/pjord/report_comment_agent.rb
@@ -2,7 +2,7 @@
 
 class Pjord::ReportCommentAgent < Pjord::Agent
   inputs :report, :intent
-  model ENV.fetch('PJORD_COMMENT_LLM_MODEL', 'claude-opus-5')
+  model ENV.fetch('PJORD_COMMENT_LLM_MODEL', 'claude-opus-4-6')
   instructions { Pjord::Agent.prompt_for('report_comment', Pjord::ReportCommentAgent.context_for(report, intent)) }
 
   def self.comment(report, intent:)

--- a/test/agents/pjord/report_comment_agent_test.rb
+++ b/test/agents/pjord/report_comment_agent_test.rb
@@ -7,8 +7,10 @@ class Pjord::ReportCommentAgentTest < ActiveSupport::TestCase
     report = reports(:report1)
     chat = AgentChatFake.new
 
-    RubyLLM.stub(:chat, lambda { |model:|
-      assert_equal 'claude-opus-4-6', model
+    RubyLLM.stub(:chat, lambda { |model:, provider:, assume_model_exists:|
+      assert_equal 'claude-opus-5', model
+      assert_equal :anthropic, provider
+      assert assume_model_exists
       chat
     }) do
       assert_equal 'コメント本文', Pjord::ReportCommentAgent.comment(report, intent: 'struggling')

--- a/test/agents/pjord/report_comment_agent_test.rb
+++ b/test/agents/pjord/report_comment_agent_test.rb
@@ -8,7 +8,7 @@ class Pjord::ReportCommentAgentTest < ActiveSupport::TestCase
     chat = AgentChatFake.new
 
     RubyLLM.stub(:chat, lambda { |model:|
-      assert_equal 'claude-opus-5', model
+      assert_equal 'claude-opus-4-6', model
       chat
     }) do
       assert_equal 'コメント本文', Pjord::ReportCommentAgent.comment(report, intent: 'struggling')


### PR DESCRIPTION
## 概要

- RubyLLMを1.16.0へ更新
- 日報コメント生成に正式な `claude-opus-5` を使用
- Anthropicプロバイダーと `assume_model_exists` を明示し、外部モデルレジストリの更新成否に依存せず利用

## 確認

- [x] `bin/rails test test/agents/pjord/report_comment_agent_test.rb`
- [x] `bundle exec rubocop app/agents/pjord/report_comment_agent.rb test/agents/pjord/report_comment_agent_test.rb`
- [x] RubyLLM 1.16.0で `claude-opus-5` をAnthropicモデルとして解決できることを確認

Closes #10410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * AIによるコメント生成でAnthropicプロバイダーを使用するようになりました。
  * 使用するモデルが存在することを前提に処理します。
  * モデル名の既定値および環境変数による上書き設定は変更ありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10411-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->