### PR TITLE
PostgreSQLの匿名ボリューム生成を防止

### DIFF
--- a/bin/codex-issue-automation-docker
+++ b/bin/codex-issue-automation-docker
@@ -59,6 +59,7 @@ trap cleanup EXIT
 docker network create "$network" >/dev/null
 docker run --detach --rm \
   --name "$database_container" \
+  --tmpfs /var/lib/postgresql/data \
   --network "$network" \
   --network-alias db \
   -e POSTGRES_PASSWORD=postgres \

--- a/test/workflows/ai_issue_automation_test.rb
+++ b/test/workflows/ai_issue_automation_test.rb
@@ -77,6 +77,7 @@ class AiIssueAutomationTest < ActiveSupport::TestCase
     assert_includes docker_runner, 'CODEX_AUTOMATION_REPOSITORY'
     assert_includes docker_runner, 'SECONDS + 60'
     assert_includes docker_runner, 'postgres:16-alpine'
+    assert_includes docker_runner, '--tmpfs /var/lib/postgresql/data'
     assert_not_includes docker_runner, '/var/run/docker.sock'
     assert_includes dockerfile, 'npm install --global @openai/codex'
     assert_includes dockerfile, 'apt-get install'


### PR DESCRIPTION
## 概要

VPS上で5分ごとに起動するCodex Issue AutomationのPostgreSQLデータ領域をtmpfsに変更します。

## 背景

`postgres:16-alpine`が宣言するデータ用匿名ボリュームは、`docker run --rm`でコンテナを削除しても残ります。約40MBの匿名ボリュームが実行ごとに作られ、1,264個・約50GBまで増えてVPSのディスクを枯渇させました。

## 変更

- 一時的なテストDBのデータ領域へ`--tmpfs /var/lib/postgresql/data`を指定
- 設定を保証するテストを追加

## 確認

- `bundle exec rails test test/workflows/ai_issue_automation_test.rb`
- `bash -n bin/codex-issue-automation-docker`
- VPSで実行前後の匿名ボリューム数が0→0であることを確認

## ロールバック

該当の`--tmpfs`行を取り除きます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * PostgreSQLの一時データを一時ファイルシステム上で扱うようにし、実行時のデータ管理を改善しました。
  * Docker実行時に一時ファイルシステムが正しく設定されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->