### PR TITLE
AIピヨルドの日報コメントをユーザーが設定できるようにする

### DIFF
--- a/app/controllers/current_user_controller.rb
+++ b/app/controllers/current_user_controller.rb
@@ -28,7 +28,7 @@ class CurrentUserController < ApplicationController
       :job, :organization, :os,
       { experiences: [] }, :editor, :other_editor, :company_id,
       :nda, :avatar, :trainee,
-      :mail_notification, :job_seeker, :tag_list,
+      :mail_notification, :pjord_comment, :job_seeker, :tag_list,
       :after_graduation_hope, :training_ends_on, :profile_image,
       :show_mentor_profile,
       :profile_name, :profile_job, :profile_text, { authored_books_attributes: %i[id title url cover _destroy] },

--- a/app/models/pjord_report_commenter.rb
+++ b/app/models/pjord_report_commenter.rb
@@ -4,6 +4,7 @@ class PjordReportCommenter
   def call(name, _started, _finished, _unique_id, payload)
     report = payload[:report]
     return if report.wip
+    return unless report.user.pjord_comment?
 
     case name
     when 'report.create'

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -18,6 +18,7 @@
     = render 'users/form/email', f: f, user: user
     - if from == :edit
       = render 'users/form/mail_notification', f: f
+      = render 'users/form/pjord_comment', f: f
     = render 'users/form/name', f: f, user: user
     = render 'users/form/kana_name', f: f, user: user
     = render 'users/form/avatar', f: f, user: user

--- a/app/views/users/form/_pjord_comment.html.slim
+++ b/app/views/users/form/_pjord_comment.html.slim
@@ -1,0 +1,7 @@
+.form-item#pjord-comment
+  = f.label :pjord_comment, class: 'a-form-label'
+  label.a-on-off-checkbox.is-md
+    = f.check_box :pjord_comment
+    span
+  .a-form-help
+    p オフにすると、日報を投稿した際にAIピヨルドからコメントされなくなります。AIピヨルドにメンションした場合は返信されます。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -120,6 +120,7 @@ ja:
         satisfaction: 満足度
         opinion: ご意見
         mail_notification: メール通知
+        pjord_comment: AIピヨルドからのコメント
         job_seeker: 就職サポート
         github_collaborator: GitHubチーム
         tag_list: タグ

--- a/db/migrate/20260815093000_add_pjord_comment_to_users.rb
+++ b/db/migrate/20260815093000_add_pjord_comment_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPjordCommentToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :pjord_comment, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_28_164105) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_093000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -1129,6 +1129,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_28_164105) do
     t.integer "os"
     t.string "other_editor"
     t.text "other_referral_source"
+    t.boolean "pjord_comment", default: true, null: false
     t.string "profile_job"
     t.string "profile_name"
     t.text "profile_text"

--- a/test/integration/reports/pjord_report_comment_test.rb
+++ b/test/integration/reports/pjord_report_comment_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class Reports::PjordReportCommentTest < ActionDispatch::IntegrationTest
   test 'mentor can manually create report comment by Pjord' do
     report = reports(:report5)
+    report.user.update_column(:pjord_comment, false) # rubocop:disable Rails/SkipsModelValidations
 
     Pjord::ReportClassifierAgent.stub(:classify, { intent: 'general' }) do
       Pjord::ReportCommentAgent.stub(:comment, 'コメント本文') do

--- a/test/models/pjord_report_commenter_test.rb
+++ b/test/models/pjord_report_commenter_test.rb
@@ -24,6 +24,16 @@ class PjordReportCommenterTest < ActiveJob::TestCase
     end
   end
 
+  test 'does not enqueue when user disabled Pjord comments' do
+    report = reports(:report1)
+    report.user.update!(pjord_comment: false)
+    commenter = PjordReportCommenter.new
+
+    assert_no_enqueued_jobs(only: PjordReportCommentJob) do
+      commenter.call('report.create', Time.current, Time.current, 'unique_id', report: report)
+    end
+  end
+
   test 'does not enqueue when report is already published' do
     report = reports(:report1)
     report.update_column(:wip, false) # rubocop:disable Rails/SkipsModelValidations

--- a/test/system/current_user_test.rb
+++ b/test/system/current_user_test.rb
@@ -3,6 +3,15 @@
 require 'application_system_test_case'
 
 class CurrentUserTest < ApplicationSystemTestCase
+  test 'disable Pjord comments' do
+    user = users(:kimura)
+    visit_with_auth '/current_user/edit', user.login_name
+    uncheck 'AIピヨルドからのコメント', allow_label_click: true
+    click_on '更新する'
+
+    assert_not user.reload.pjord_comment?
+  end
+
   test 'update user' do
     visit_with_auth '/current_user/edit', 'komagata'
     within 'form[name=user]' do


### PR DESCRIPTION
## 概要

- ユーザー情報変更画面に「AIピヨルドからのコメント」のON/OFF設定を追加
- OFFの場合は日報投稿時のAIピヨルドによる自動コメントを停止
- メンションへの返信とメンター・管理者による手動コメントは従来どおり維持
- 既存ユーザーは従来の挙動を維持するため初期値をONに設定
- すでに削除済みの提出物レビュー機能は対象外

## 確認

- [x] 関連テスト（29件、96 assertions）
- [x] 変更対象RubyファイルのRuboCop
- [x] 追加SlimファイルのSlim-Lint
- [x] `git diff --check`
- [x] 1440px・390pxでユーザー情報変更画面を表示確認

Closes #10222

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10433-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/31877367850/artifacts/9245317134" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->

## スクリーンショット

### デスクトップ（1440px）

![ユーザー情報変更画面のAIピヨルドコメント設定（デスクトップ）](https://raw.githubusercontent.com/komagata/bootcamp/bcca3a32f180b268ec525d58498deb67390c4377/.github/pr-assets/10433-desktop.png)

### モバイル（390px）

<img src="https://raw.githubusercontent.com/komagata/bootcamp/bcca3a32f180b268ec525d58498deb67390c4377/.github/pr-assets/10433-mobile.png" alt="ユーザー情報変更画面のAIピヨルドコメント設定（モバイル）" width="390">