### PR TITLE
BootcampのCIからFlakewatchを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,24 +176,8 @@ jobs:
           ruby -e 'files = Dir["test/**/*_test.rb"].sort.each_with_index.select { |_, i| i % ENV.fetch("TEST_SHARDS").to_i == ENV.fetch("TEST_SHARD").to_i }.map(&:first); abort "No test files selected" if files.empty?; File.write("tmp/test_files.txt", files.join("\n") + "\n")'
           wc -l tmp/test_files.txt
 
-      - name: Run Rails tests with JUnit XML
-        run: |
-          mkdir -p test/reports
-          find test/reports -type f -delete
-          xargs bundle exec ruby -e '
-            require "minitest"
-            Minitest.const_set(:Reporter, Minitest::AbstractReporter) unless defined?(Minitest::Reporter)
-            require "minitest/ci"
-            load "bin/rails"
-          ' test < tmp/test_files.txt
-
-      - name: Upload JUnit XML
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: junit-xml-${{ matrix.shard }}
-          path: test/reports/**/*.xml
-          if-no-files-found: warn
+      - name: Run Rails tests
+        run: xargs bundle exec rails test < tmp/test_files.txt
 
       - name: Upload screenshots
         if: failure()
@@ -204,28 +188,3 @@ jobs:
             tmp/screenshots
             tmp/capybara
           if-no-files-found: ignore
-
-  flakewatch:
-    name: Flakewatch HTML report
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: test
-    if: ${{ always() && !cancelled() }}
-    permissions:
-      actions: read
-      contents: write
-      pull-requests: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Generate flakewatch HTML
-        # komagata/flakewatch v0.6.40
-        uses: komagata/flakewatch@v0.6.40
-        with:
-          junit-artifact-pattern: junit-xml-*
-          source-root: ${{ github.workspace }}
-          history-branch: flakewatch-data
-          history-write: auto
-          analysis-branch: main

--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,6 @@ group :test do
   gem 'capybara-playwright-driver', '~> 0.5.9'
   gem 'capybara-screenshot-diff', require: false
   gem 'minitest', '< 6.0'
-  gem 'minitest-ci'
   gem 'minitest-retry'
   gem 'minitest-stub_any_instance'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,8 +411,6 @@ GEM
       logger
     mini_mime (1.1.5)
     minitest (5.27.0)
-    minitest-ci (3.4.0)
-      minitest (>= 5.0.6)
     minitest-retry (0.3.0)
       minitest (>= 5.0)
     minitest-stub_any_instance (1.0.3)
@@ -852,7 +850,6 @@ DEPENDENCIES
   meta-tags
   mini_magick
   minitest (< 6.0)
-  minitest-ci
   minitest-retry
   minitest-stub_any_instance
   mission_control-jobs


### PR DESCRIPTION
## 概要

BootcampのGitHub ActionsからFlakewatchを削除します。

Flakewatch専用だった以下も合わせて削除します。

- JUnit XML形式でのテスト実行
- JUnit XML artifactのアップロード
- Flakewatch HTML reportジョブ

テストは従来の分割対象をそのまま`rails test`で実行します。

## 確認内容

- `git diff --check`
- RubyのYAMLパーサーによる`.github/workflows/ci.yml`の構文確認
- Flakewatch、JUnit artifact、`minitest/ci`の参照がworkflowに残っていないことを確認

ローカル環境には指定Ruby 3.4.3が未導入のため、RailsテストはCIで確認します。

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10434-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * テスト実行を標準のRailsテスト方式に変更しました。
  * テスト結果の処理を簡素化し、スクリーンショット成果物のアップロードは引き続き利用できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->