### PR TITLE
未確認日報が100件を超えた際の警告アイコンが正しく表示されるよう修正

### DIFF
--- a/app/views/home/_unchecked_report_alert.html.slim
+++ b/app/views/home/_unchecked_report_alert.html.slim
@@ -5,7 +5,7 @@
         | 日報が100件を超えました。
     .unchecked-report-alert__inner
       .unchecked-report-alert__icon
-        i.fa-regular.fa-triangle-exclamation
+        i.fa-solid.fa-triangle-exclamation
       .unchecked-report-alert__message
         = link_to reports_unchecked_index_path, class: 'unchecked-report-alert__message-link' do
           | 未チェックの日報が


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/10415

## 概要

メンターまたは管理者でログインした際のダッシュボードにおいて、未確認日報が100件を超えた際の警告アイコンが正しく表示されていなかった。

https://github.com/fjordllc/bootcamp/blob/4d18be444b55f4af55884ca6323d878441adfec7/app/views/layouts/common/_common_head.html.slim#L10
上記の箇所でFont Awesome Freeを読み込んでいるが、`triangle-exclamation`のRegular版は利用中のFreeパッケージに含まれていないことが、正しく表示できていなかった原因。Solid版を使うように修正した。

## 変更確認方法

1. `bug/unchecked-report-alert-icon`ブランチをローカルに取り込む
2. ローカルサーバーが起動していないことを確認する
3. Railsコンソール上で以下を実行して未確認日報を101件以上にする

```rb
(101 - Report.unchecked.not_wip.count).times do |n|
  Report.create!(
    user: User.first,
    title: "sample title #{n}",
    description: "sample description #{n}",
    reported_on: Date.today - (n + 1).day
  )
end
```

4. ローカルサーバーを起動する
5. `komagata`など、任意のメンターまたは管理者でログインする
6. [ダッシュボード](http://localhost:3000/)にアクセスする
7. 「日報が100件を超えました。」という警告に三角形の警告アイコンが表示されていることを確認する

未確認日報の件数にはプロセス内のメモリキャッシュが使用されているため、データ作成前からローカルサーバーを起動していた場合、画面を再読み込みしても表示が更新されない。その場合は、ローカルサーバーの再起動が必要。

## Screenshot

### 変更前
<img width="618" height="303" alt="image" src="https://github.com/user-attachments/assets/22aea691-4793-48ee-9590-53a9b768b8a1" />

### 変更後
<img width="622" height="298" alt="image" src="https://github.com/user-attachments/assets/07a8d382-7c22-4473-86f6-101483e34793" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 未チェック日報アラートの警告アイコンを、通常アイコンから塗りつぶしアイコンに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10449-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/31934009390/artifacts/9260343151" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->
