### PR TITLE
ブラウザ拡張由来のエラーをRollbarから除外

### DIFF
--- a/app/views/application/_rollbar.html.erb
+++ b/app/views/application/_rollbar.html.erb
@@ -3,6 +3,7 @@ var _rollbarConfig = {
     accessToken: "<%= ENV['ROLLBAR_CLIENT_TOKEN'] %>",
     captureUncaught: true,
     captureUnhandledRejections: true,
+    hostBlockList: ["^chrome-extension://"],
     payload: {
         environment: "production"
     }

--- a/test/views/application/rollbar_partial_test.rb
+++ b/test/views/application/rollbar_partial_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RollbarPartialTest < ActionView::TestCase
+  test 'does not report Chrome extension errors' do
+    render partial: 'application/rollbar'
+
+    assert_includes rendered, 'hostBlockList: ["^chrome-extension://"]'
+  end
+end


### PR DESCRIPTION
## 概要

- Rollbar.jsの`hostBlockList`に`chrome-extension://`を追加
- BootcampのコードではなくChrome拡張で発生した例外がRollbarへ送信されないように変更
- Rollbar設定を検証するview testを追加

## 確認

- [x] `bin/rails test test/views/application/rollbar_partial_test.rb`
- [x] `bundle exec rubocop test/views/application/rollbar_partial_test.rb`
- [x] `git diff --check`
- [ ] `./bin/lint`（今回と無関係な既存ファイルを含む1945件のRuboCop違反で失敗。自動修正はすべて戻しています）

Closes #10427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Chrome拡張機能に起因する不要なエラーを、エラー監視の対象外にしました。

* **テスト**
  * Chrome拡張機能由来のエラー除外設定が正しく適用されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10450-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/31926684653/artifacts/9258264401" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->
