### PR TITLE
キャンペーン案内の表示を調整

### DIFF
--- a/app/assets/stylesheets/lp/blocks/lp/_lp-content-title.css
+++ b/app/assets/stylesheets/lp/blocks/lp/_lp-content-title.css
@@ -99,6 +99,7 @@
 }
 
 .lp-content-title.is-xs {
+  padding-bottom: 0;
   font-size: 1.25rem;
   line-height: 1.3;
   font-weight: 700;

--- a/app/assets/stylesheets/lp/blocks/lp/_lp-content.css
+++ b/app/assets/stylesheets/lp/blocks/lp/_lp-content.css
@@ -116,6 +116,10 @@
   flex-direction: column;
 }
 
+.lp-content.is-top-title.is-campaign .lp-content__inner {
+  gap: 1rem;
+}
+
 @media (width >= 80em) {
   .lp-content.is-top-title .lp-content__inner {
     gap: 3.5rem;

--- a/app/views/welcome/_campaign.html.slim
+++ b/app/views/welcome/_campaign.html.slim
@@ -2,7 +2,7 @@
 
 section.lp-content.is-top-title.is-campaign
   .l-container.is-lg
-    .lp-content__inner.gap-6
+    .lp-content__inner
       .lp-content__start
         header.lp-content__header
           h2.lp-content-title.text-center.is-xs
@@ -24,8 +24,7 @@ section.lp-content.is-top-title.is-campaign
               = trial_period
               | 日以内に退会すれば受講料はかかりません。
               | この機会にぜひフィヨルドブートキャンプをガッツリお試しください！！
-            p.font-semibold
-              = link_to 'https://bootcamp.fjord.jp/articles/190',
+              = link_to 'https://bootcamp.fjord.jp/articles/205',
               class: 'a-text-link is-warning',
               target: '_blank', rel: 'noopener' do
                 | キャンペーンについてくわしくはこちら

--- a/app/views/welcome/_welcome_top_info.html.slim
+++ b/app/views/welcome/_welcome_top_info.html.slim
@@ -1,5 +1,7 @@
 .welcome-top-info
   .l-container.is-xl
     p.welcome-top-info__inner
-      = link_to training_path, class: 'welcome-top-info__link', target: '_blank', rel: 'noopener' do
-        | 研修コストを最大75％削減！企業研修代行に助成金に強い社労士と提携をしました。
+      = link_to 'https://bootcamp.fjord.jp/articles/205',
+        class: 'welcome-top-info__link',
+        target: '_blank', rel: 'noopener' do
+        | 夏のプログラミング学習応援キャンペーン開催中！8月30日（日）まで


### PR DESCRIPTION
これをリリース後に
https://bootcamp.fjord.jp/articles/205/edit
この記事を公開する。

----

## 変更内容

- キャンペーン見出しと本文の間隔を16pxに縮小
- `.lp-content-title.is-xs` の不要な下paddingを削除
- welcome-top-infoの文言を夏のプログラミング学習応援キャンペーン向けに変更
- welcome-top-infoとキャンペーン詳細のリンク先を記事205へ変更
- キャンペーン詳細リンクを独立した段落から本文内のインラインリンクへ変更

## 変更理由

`.lp-content.is-top-title` のレスポンシブなgap指定と、`.lp-content-title.is-xs` に継承されていた下paddingが重なり、キャンペーン見出し下の余白が大きくなっていました。

キャンペーン向けのgapを明示し、装飾線を持たない `.is-xs` の下paddingをなくしています。

## 影響

トップページのキャンペーン案内とwelcome-top-infoの表示・リンクのみが変わります。

## 確認

- Stylelint: 成功
- Slim-Lint: 変更したwelcome-top-infoは成功
- `git diff --check`: 成功
- 1440px幅と390px幅で表示確認
  - gap: 16px
  - `.is-xs` の下padding: 0px
  - 記事205へのリンクと本文内インライン表示を確認

## テスト

`bin/rails test test/system/welcome_test.rb` を実行しましたが、既存のプロフィール表示切替テストが「ユーザー情報を更新しました。」を検出できず1件失敗しました。今回変更したLP部分とは無関係です。
