### PR TITLE
【hotfix】ユーザー名変更後のアイコン画像切れを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -994,13 +994,12 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   def attach_custom_avatar
     custom_key = "avatars/#{login_name}.#{AVATAR_FORMAT}"
-    variant_avatar = avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }, format: AVATAR_FORMAT).processed
-    io = StringIO.new(variant_avatar.download)
-
-    # Use ActiveStorage's create_and_upload! for proper checksum handling
     custom_blob = ActiveStorage::Blob.find_by(key: custom_key)
 
     unless custom_blob
+      variant_avatar = avatar.variant(resize_to_fill: AVATAR_SIZE, autorot: true, saver: { strip: true, quality: 60 }, format: AVATAR_FORMAT).processed
+      io = StringIO.new(variant_avatar.download)
+
       custom_blob = ActiveStorage::Blob.create_and_upload!(
         io:,
         filename: "#{login_name}.#{AVATAR_FORMAT}",
@@ -1008,8 +1007,8 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
         key: custom_key,
         identify: false
       )
-      avatar.attach(custom_blob)
     end
+    avatar.attach(custom_blob)
   rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, LoadError => e
     log_avatar_error('attach_custom_avatar', e)
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -94,6 +94,23 @@ class UserTest < ActiveSupport::TestCase
     assert_includes user_with_custom_avatar.avatar_url, "#{user_with_custom_avatar.login_name}.webp"
   end
 
+  test '#avatar_url attaches an existing custom avatar blob' do
+    user = users(:komagata)
+    reset_avatar(user)
+    user.login_name = 'new-login-name'
+    custom_blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new('existing avatar'),
+      filename: 'new-login-name.webp',
+      content_type: 'image/webp',
+      key: 'avatars/new-login-name.webp'
+    )
+    FileUtils.rm(user.avatar.blob.service.send(:path_for, user.avatar.blob.key))
+
+    user.avatar_url
+
+    assert_equal custom_blob, user.avatar.blob
+  end
+
   test '#generation' do
     assert_equal 1, User.new(created_at: '2013-03-25 00:00:00').generation
     assert_equal 2, User.new(created_at: '2013-05-05 00:00:00').generation

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -97,7 +97,7 @@ class UserTest < ActiveSupport::TestCase
   test '#avatar_url attaches an existing custom avatar blob' do
     user = users(:komagata)
     reset_avatar(user)
-    user.login_name = 'new-login-name'
+    user.update!(login_name: 'new-login-name')
     custom_blob = ActiveStorage::Blob.create_and_upload!(
       io: StringIO.new('existing avatar'),
       filename: 'new-login-name.webp',
@@ -108,7 +108,7 @@ class UserTest < ActiveSupport::TestCase
 
     user.avatar_url
 
-    assert_equal custom_blob, user.avatar.blob
+    assert_equal custom_blob, user.reload.avatar.blob
   end
 
   test '#generation' do


### PR DESCRIPTION
## 概要

ユーザー2434で発生しているアイコン画像切れを修正します。

ユーザー名変更後のカスタムアバターblobが既に存在する場合、そのblobをユーザーへ再添付します。これにより、変更前のユーザー名の欠損ファイルを参照し続ける状態を解消します。

## 確認

- `bin/rails test test/models/user_test.rb -n /avatar_url/`
- `bin/rails test test/integration/user_icons_test.rb`
- `bundle exec rubocop app/models/user.rb test/models/user_test.rb`