### PR TITLE
メンター、アドバイザー用ダッシュボードの余分な右側の余白を削除

### DIFF
--- a/app/views/home/_welcome_message.html.slim
+++ b/app/views/home/_welcome_message.html.slim
@@ -1,6 +1,6 @@
 - trial_period = Campaign.user_trial_period(current_user.created_at)
 
-.page-body.is-dash-board
+.page-body
   .page-body__inner
     .columns
       .container.is-md

--- a/app/views/home/_welcome_message_for_adviser.html.slim
+++ b/app/views/home/_welcome_message_for_adviser.html.slim
@@ -1,4 +1,4 @@
-.page-body.is-dash-board
+.page-body
   .page-body__inner
     .columns.js-welcome-message
       .container.is-lg

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -11,7 +11,7 @@
   = render 'welcome_message_for_adviser'
 
 .page-body.is-dash-board
-  .page-body__inner.has-side-nav
+  .page-body__inner class=('has-side-nav' unless current_user.adviser_or_mentor?)
 
     - if @users_for_time_slot.present?
       = render Users::CurrentUserIconListComponent.new(users: @users_for_time_slot)

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -10,7 +10,7 @@
 - if @welcome_message_first_time.blank? && current_user.adviser?
   = render 'welcome_message_for_adviser'
 
-.page-body.is-dash-board
+.page-body
   .page-body__inner class=('has-side-nav' unless current_user.adviser_or_mentor?)
 
     - if @users_for_time_slot.present?


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/fjordllc/bootcamp/issues/10416

## 概要

メンターまたはアドバイザーでログインした場合のダッシュボード画面の右側に余白が表示されないように修正した。

## 変更確認方法

1. `bug/remove-extra-right-space-from-dashboard`ブランチをローカルに取り込む
2. ローカルサーバーを起動する
3. `mentormentaro`など、任意のメンターでログインする
4. [ダッシュボード](http://localhost:3000/)にアクセスして、ダッシュボードの右側に余分なスペースがないことを確認する
5. `advijirou`など、任意のアドバイザーでログインし直す
6. [ダッシュボード](http://localhost:3000/)にアクセスして、ダッシュボードの右側に余分なスペースがないことを確認する
7. `adminonly`など、任意の管理者でログインし直す
8. [ダッシュボード](http://localhost:3000/)にアクセスして、サイドナビゲーションとダッシュボードのコンテンツが重ならず、レイアウトが崩れていないことを確認する
9. `kimura`など、任意の受講生でログインし直す
10. [ダッシュボード](http://localhost:3000/)にアクセスして、サイドナビゲーションとダッシュボードのコンテンツが重ならず、レイアウトが崩れていないことを確認する

## Screenshot

| | 変更前 | 変更後 |
| --- | --- | --- |
| メンター (`mentormentaro`) | <img width="1917" height="1032" alt="image" src="https://github.com/user-attachments/assets/f981fb11-68da-495b-8457-e5f3dac9892c" /> | <img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/9f52010e-90de-4f55-ae1c-f4066826dbcb" /> |
| アドバイザー (`advijirou`) | <img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/8e5b0edf-752f-445b-8b3f-901a7fe2b78a" /> | <img width="1918" height="1033" alt="image" src="https://github.com/user-attachments/assets/1efd548d-fb6f-4141-ab4a-aa2242557613" /> |
| 管理者 (`adminonly`) | <img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/fb6cde4f-f9d4-42ad-95c1-2ee564269ed4" /> | <img width="1918" height="1033" alt="image" src="https://github.com/user-attachments/assets/97789800-f309-489c-817c-6d129d61e0bc" /> |
| 受講生 (`kimura`) | <img width="1918" height="1032" alt="image" src="https://github.com/user-attachments/assets/6d9244a6-aa05-4be1-93a1-de00bd40216a" /> | <img width="1917" height="1032" alt="image" src="https://github.com/user-attachments/assets/7c2422ab-e4b9-4af4-bce1-b1d91bdaf3cc" /> |

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ホーム画面のレイアウト表示を調整しました。
  * 管理者・メンター以外の画面で、サイドナビゲーションのスタイルが適切に適用されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10460-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- flakewatch-report:start -->
## Flakewatch Report

<a href="https://github.com/fjordllc/bootcamp/actions/runs/32338101089/artifacts/9395789896" target="_blank" rel="noopener noreferrer"><img src="https://raw.githubusercontent.com/komagata/flakewatch/main/assets/flakewatch-report.svg" alt="Open flakewatch.html" width="150"></a>
<!-- flakewatch-report:end -->
