### PR TITLE
元画像欠損時はデフォルトアイコンを表示

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -717,7 +717,7 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
     else
       image_url DEFAULT_IMAGE_PATH
     end
-  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, LoadError => e
+  rescue ActiveStorage::Error => e
     log_avatar_error('avatar_url', e)
     image_url DEFAULT_IMAGE_PATH
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -717,7 +717,7 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
     else
       image_url DEFAULT_IMAGE_PATH
     end
-  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error => e
+  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, LoadError => e
     log_avatar_error('avatar_url', e)
     image_url DEFAULT_IMAGE_PATH
   end
@@ -1009,8 +1009,6 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
       )
     end
     avatar.attach(custom_blob)
-  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, LoadError => e
-    log_avatar_error('attach_custom_avatar', e)
   end
 
   def log_avatar_error(context, error)

--- a/test/integration/api/reactions_test.rb
+++ b/test/integration/api/reactions_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'supports/avatar_helper'
 
 class API::ReactionTest < ActionDispatch::IntegrationTest
+  include AvatarHelper
+
   setup do
     user = users(:komagata)
     @application = Doorkeeper::Application.create!(
@@ -73,6 +76,7 @@ class API::ReactionTest < ActionDispatch::IntegrationTest
   test 'GET /api/reactions returns reactions' do
     report = reports(:report4)
     komagata = users(:komagata)
+    reset_avatar(komagata)
 
     token = create_token('komagata', 'testtest')
     post api_reactions_path, params: { reactionable_gid: report.to_global_id.to_s, kind: 'thumbsup' },

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'supports/avatar_helper'
 
 class SearcherTest < ActiveSupport::TestCase
+  include AvatarHelper
   include SearchHelper
   SEARCHABLE_CLASSES = [Report, Page, Practice, Question, Announcement, Event, RegularEvent, Comment, Answer, CorrectAnswer, User].freeze
 
@@ -519,6 +521,7 @@ class SearcherTest < ActiveSupport::TestCase
   test 'search_thumbnail returns avatar_url for User and nil for others' do
     user = users(:komagata)
     report = reports(:report1)
+    reset_avatar(user)
 
     # User should return avatar_url
     user_thumbnail = user.search_thumbnail

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -113,11 +113,11 @@ class UserTest < ActiveSupport::TestCase
 
   test '#avatar_url returns the default image when the original avatar is missing' do
     user = users(:komagata)
-    reset_avatar(user)
-    user.update!(login_name: 'new-login-name')
-    FileUtils.rm(user.avatar.blob.service.send(:path_for, user.avatar.blob.key))
+    user.login_name = 'new-login-name'
 
-    assert_equal '/images/users/avatars/default.png', user.avatar_url
+    user.avatar.stub(:variant, ->(*) { raise ActiveStorage::FileNotFoundError }) do
+      assert_equal '/images/users/avatars/default.png', user.avatar_url
+    end
   end
 
   test '#generation' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -111,6 +111,15 @@ class UserTest < ActiveSupport::TestCase
     assert_equal custom_blob, user.reload.avatar.blob
   end
 
+  test '#avatar_url returns the default image when the original avatar is missing' do
+    user = users(:komagata)
+    reset_avatar(user)
+    user.update!(login_name: 'new-login-name')
+    FileUtils.rm(user.avatar.blob.service.send(:path_for, user.avatar.blob.key))
+
+    assert_equal '/images/users/avatars/default.png', user.avatar_url
+  end
+
   test '#generation' do
     assert_equal 1, User.new(created_at: '2013-03-25 00:00:00').generation
     assert_equal 2, User.new(created_at: '2013-05-05 00:00:00').generation


### PR DESCRIPTION
## 概要

アバターの元画像が削除済みでカスタム画像を再生成できない場合、画像切れURLではなくデフォルト画像を返すようにしました。

## 原因

`attach_custom_avatar`が`ActiveStorage::FileNotFoundError`を内部で握り潰した後、`avatar_url`が削除済みblobのURLを返していました。例外処理を`avatar_url`に一本化しています。

## 確認

- `bin/rails test test/models/user_test.rb -n /avatar_url/`
- `bin/rails test test/integration/user_icons_test.rb`
- `bundle exec rubocop app/models/user.rb test/models/user_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 元のアバター画像が見つからない場合でもエラーにならず、デフォルト画像が表示されるようになりました。
  - アバター画像の読み込みエラーを既存のエラー処理で適切に扱うよう改善しました。

- **テスト**
  - 元アバター画像が存在しない場合に、デフォルト画像パスが返されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10463-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->