### PR TITLE
Review App cleanupの完了をポーリングする

### DIFF
--- a/.github/workflows/review-app-cleanup.yml
+++ b/.github/workflows/review-app-cleanup.yml
@@ -29,11 +29,40 @@ jobs:
 
       - name: Cleanup Review App via Cloud Build
         run: |
-          gcloud builds submit \
+          set +e
+          BUILD_OUTPUT=$(gcloud builds submit \
             --config=.cloudbuild/cloudbuild-review-cleanup.yaml \
             --substitutions="_PR_NUMBER=${PR_NUMBER},_CLOUD_SQL_HOST=bootcamp-224405:asia-northeast1:bootcamp,_DB_USER=review,_DB_PASS=${{ secrets.REVIEW_DB_PASS }}" \
             --project=bootcamp-224405 \
             --region=asia-northeast1 \
             --no-source \
-            --suppress-logs \
-            --quiet
+            --async \
+            --quiet 2>&1)
+          SUBMIT_STATUS=$?
+          set -e
+
+          echo "$BUILD_OUTPUT"
+          if [ "$SUBMIT_STATUS" -ne 0 ]; then
+            exit "$SUBMIT_STATUS"
+          fi
+          BUILD_ID=$(echo "$BUILD_OUTPUT" | grep -oP '(?<=builds/)[a-f0-9-]+')
+          if [ -z "$BUILD_ID" ]; then
+            echo "Failed to extract Build ID from output"
+            exit 1
+          fi
+
+          for i in $(seq 1 60); do
+            STATUS=$(gcloud builds describe "$BUILD_ID" \
+              --project=bootcamp-224405 \
+              --region=asia-northeast1 \
+              --format='value(status)' 2>/dev/null || true)
+            echo "[$i] Build status: $STATUS"
+            if [ "$STATUS" = "SUCCESS" ]; then
+              exit 0
+            elif [ "$STATUS" = "FAILURE" ] || [ "$STATUS" = "CANCELLED" ] || [ "$STATUS" = "TIMEOUT" ] || [ "$STATUS" = "INTERNAL_ERROR" ] || [ "$STATUS" = "EXPIRED" ]; then
+              exit 1
+            fi
+            sleep 30
+          done
+          echo "Timeout waiting for build"
+          exit 1

--- a/.github/workflows/review-app-cleanup.yml
+++ b/.github/workflows/review-app-cleanup.yml
@@ -55,7 +55,7 @@ jobs:
             STATUS=$(gcloud builds describe "$BUILD_ID" \
               --project=bootcamp-224405 \
               --region=asia-northeast1 \
-              --format='value(status)' 2>/dev/null || true)
+              --format='value(status)')
             echo "[$i] Build status: $STATUS"
             if [ "$STATUS" = "SUCCESS" ]; then
               exit 0

--- a/.github/workflows/review-app-cleanup.yml
+++ b/.github/workflows/review-app-cleanup.yml
@@ -45,24 +45,27 @@ jobs:
           if [ "$SUBMIT_STATUS" -ne 0 ]; then
             exit "$SUBMIT_STATUS"
           fi
-          BUILD_ID=$(echo "$BUILD_OUTPUT" | grep -oP '(?<=builds/)[a-f0-9-]+')
+          BUILD_ID=$(echo "$BUILD_OUTPUT" | grep -oP '(?<=builds/)[a-f0-9-]+' | head -n1 || true)
           if [ -z "$BUILD_ID" ]; then
             echo "Failed to extract Build ID from output"
             exit 1
           fi
 
-          for i in $(seq 1 60); do
+          DEADLINE=$((SECONDS + 3600))
+          while true; do
             STATUS=$(gcloud builds describe "$BUILD_ID" \
               --project=bootcamp-224405 \
               --region=asia-northeast1 \
               --format='value(status)')
-            echo "[$i] Build status: $STATUS"
+            echo "Build status: $STATUS"
             if [ "$STATUS" = "SUCCESS" ]; then
               exit 0
             elif [ "$STATUS" = "FAILURE" ] || [ "$STATUS" = "CANCELLED" ] || [ "$STATUS" = "TIMEOUT" ] || [ "$STATUS" = "INTERNAL_ERROR" ] || [ "$STATUS" = "EXPIRED" ]; then
               exit 1
             fi
+            if [ "$SECONDS" -ge "$DEADLINE" ]; then
+              echo "Timeout waiting for build"
+              exit 1
+            fi
             sleep 30
           done
-          echo "Timeout waiting for build"
-          exit 1


### PR DESCRIPTION
## 概要

`--suppress-logs`を指定してもCloud Buildのログ取得権限エラーが発生するため、ログ取得を使わずにcleanupの完了を待つよう修正します。

## 変更内容

- Cloud Buildを`--async`で開始
- build IDを取得し、`gcloud builds describe`で完了までポーリング
- 成功・失敗・タイムアウトをGitHub Actionsの終了状態へ反映

## 確認方法

- workflowのYAML構文チェック
- `run`ブロックのshell構文チェック
- `git diff --check`

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10465-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * クリーンアップ処理のビルド状態確認を改善しました。
  * ビルドの送信失敗、失敗ステータス、タイムアウトを正しく検知し、処理結果を終了ステータスに反映するようにしました。
  * 成功時は正常終了し、問題発生時はエラーとして終了します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->