### PR TITLE
【hotfix】元画像欠損時はデフォルトアイコンを表示

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -717,7 +717,7 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
     else
       image_url DEFAULT_IMAGE_PATH
     end
-  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, LoadError => e
+  rescue ActiveStorage::Error => e
     log_avatar_error('avatar_url', e)
     image_url DEFAULT_IMAGE_PATH
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -717,7 +717,7 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
     else
       image_url DEFAULT_IMAGE_PATH
     end
-  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error => e
+  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, LoadError => e
     log_avatar_error('avatar_url', e)
     image_url DEFAULT_IMAGE_PATH
   end
@@ -1009,8 +1009,6 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
       )
     end
     avatar.attach(custom_blob)
-  rescue ActiveStorage::FileNotFoundError, ActiveStorage::Error, LoadError => e
-    log_avatar_error('attach_custom_avatar', e)
   end
 
   def log_avatar_error(context, error)

--- a/test/integration/api/reactions_test.rb
+++ b/test/integration/api/reactions_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'supports/avatar_helper'
 
 class API::ReactionTest < ActionDispatch::IntegrationTest
+  include AvatarHelper
+
   setup do
     user = users(:komagata)
     @application = Doorkeeper::Application.create!(
@@ -73,6 +76,7 @@ class API::ReactionTest < ActionDispatch::IntegrationTest
   test 'GET /api/reactions returns reactions' do
     report = reports(:report4)
     komagata = users(:komagata)
+    reset_avatar(komagata)
 
     token = create_token('komagata', 'testtest')
     post api_reactions_path, params: { reactionable_gid: report.to_global_id.to_s, kind: 'thumbsup' },

--- a/test/models/searcher_test.rb
+++ b/test/models/searcher_test.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'supports/avatar_helper'
 
 class SearcherTest < ActiveSupport::TestCase
+  include AvatarHelper
   include SearchHelper
   SEARCHABLE_CLASSES = [Report, Page, Practice, Question, Announcement, Event, RegularEvent, Comment, Answer, CorrectAnswer, User].freeze
 
@@ -519,6 +521,7 @@ class SearcherTest < ActiveSupport::TestCase
   test 'search_thumbnail returns avatar_url for User and nil for others' do
     user = users(:komagata)
     report = reports(:report1)
+    reset_avatar(user)
 
     # User should return avatar_url
     user_thumbnail = user.search_thumbnail

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -113,11 +113,11 @@ class UserTest < ActiveSupport::TestCase
 
   test '#avatar_url returns the default image when the original avatar is missing' do
     user = users(:komagata)
-    reset_avatar(user)
-    user.update!(login_name: 'new-login-name')
-    FileUtils.rm(user.avatar.blob.service.send(:path_for, user.avatar.blob.key))
+    user.login_name = 'new-login-name'
 
-    assert_equal '/images/users/avatars/default.png', user.avatar_url
+    user.avatar.stub(:variant, ->(*) { raise ActiveStorage::FileNotFoundError }) do
+      assert_equal '/images/users/avatars/default.png', user.avatar_url
+    end
   end
 
   test '#generation' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -111,6 +111,15 @@ class UserTest < ActiveSupport::TestCase
     assert_equal custom_blob, user.reload.avatar.blob
   end
 
+  test '#avatar_url returns the default image when the original avatar is missing' do
+    user = users(:komagata)
+    reset_avatar(user)
+    user.update!(login_name: 'new-login-name')
+    FileUtils.rm(user.avatar.blob.service.send(:path_for, user.avatar.blob.key))
+
+    assert_equal '/images/users/avatars/default.png', user.avatar_url
+  end
+
   test '#generation' do
     assert_equal 1, User.new(created_at: '2013-03-25 00:00:00').generation
     assert_equal 2, User.new(created_at: '2013-05-05 00:00:00').generation


### PR DESCRIPTION
## 概要

ユーザーアイコンの元画像が欠損し、既存データから復旧できない場合に、画像切れではなくデフォルト画像を表示します。

PR #10458 のproduction反映後に判明した欠損ケースへの追加対応です。main向けPRは #10463 です。

## 確認

- `mise exec -- bin/rails test test/integration/api/reactions_test.rb test/models/searcher_test.rb test/models/user_test.rb test/integration/user_icons_test.rb`
- `mise exec -- bundle exec rubocop app/models/user.rb test/integration/api/reactions_test.rb test/models/searcher_test.rb test/models/user_test.rb`