### PR TITLE
【hotfix】欠損したカスタムアバターをデフォルト表示にする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -713,6 +713,8 @@ class User < ApplicationRecord # rubocop:todo Metrics/ClassLength
     if avatar.attached? && avatar.blob.present?
       custom_key = "avatars/#{login_name}.#{AVATAR_FORMAT}"
       attach_custom_avatar if avatar.blob.key != custom_key
+      return image_url DEFAULT_IMAGE_PATH unless avatar.blob.service.exist?(avatar.blob.key)
+
       "#{avatar.url}?v=#{avatar.created_at.to_i}"
     else
       image_url DEFAULT_IMAGE_PATH

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -120,6 +120,21 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test '#avatar_url returns the default image when the custom avatar is missing' do
+    user = users(:komagata)
+    user.update!(login_name: 'missing-avatar')
+    user.avatar.attach(
+      io: StringIO.new('missing avatar'),
+      filename: 'missing-avatar.webp',
+      content_type: 'image/webp',
+      key: 'avatars/missing-avatar.webp'
+    )
+
+    user.avatar.blob.service.stub(:exist?, false) do
+      assert_equal '/images/users/avatars/default.png', user.avatar_url
+    end
+  end
+
   test '#generation' do
     assert_equal 1, User.new(created_at: '2013-03-25 00:00:00').generation
     assert_equal 2, User.new(created_at: '2013-05-05 00:00:00').generation


### PR DESCRIPTION
## 概要

GCS上のカスタムアバターファイルが欠損している場合、画像切れURLではなくデフォルト画像を返します。

URL生成だけではファイル欠損が例外にならないため、Active Storageサービス上の実在を確認します。

## 確認

- `mise exec -- bin/rails test test/integration/api/reactions_test.rb test/models/searcher_test.rb test/models/user_test.rb test/integration/user_icons_test.rb`
- `mise exec -- bundle exec rubocop app/models/user.rb test/models/user_test.rb`