### PR TITLE
相談部屋のコメントを段階的に読み込む

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -3,16 +3,23 @@
 class API::CommentsController < API::BaseController
   before_action :set_my_comment, only: %i[update destroy]
   before_action :set_available_emojis, only: %i[index create]
+  before_action :authorize_commentable, only: %i[index]
   before_action -> { doorkeeper_authorize! :write }, only: %i[create update destroy], if: -> { doorkeeper_token.present? }
+
+  COMMENT_LIMIT = 8
 
   def index
     if params[:commentable_type].present?
       return if commentable.comments.nil?
 
-      @comments = commentable.comments.order(created_at: :desc)
-      @comment_total_count = @comments.size
-      @comments = @comments.limit(params[:comment_limit])
-                           .offset(params[:comment_offset])
+      if request.format.html?
+        render_comments_page
+      else
+        @comments = commentable.comments.order(created_at: :desc)
+        @comment_total_count = @comments.size
+        @comments = @comments.limit(params[:comment_limit])
+                             .offset(params[:comment_offset])
+      end
     else
       render_bad_request
     end
@@ -44,12 +51,39 @@ class API::CommentsController < API::BaseController
 
   private
 
+  def render_comments_page
+    return head :bad_request unless params[:target] || params[:before]
+
+    if params[:target]
+      @comments = [commentable.comments.with_user_details.find(params[:target])]
+      comment_remaining = 0
+    else
+      before = commentable.comments.find(params[:before])
+      @comments = commentable.comments.with_user_details.before_comment(before)
+                             .order(created_at: :desc, id: :desc)
+                             .limit(COMMENT_LIMIT)
+                             .to_a
+                             .reverse
+      comment_remaining = @comments.empty? ? 0 : commentable.comments.before_comment(@comments.first).count
+    end
+    response.set_header('X-Comment-Remaining', comment_remaining.to_s)
+    render partial: 'comments/comment', collection: @comments, as: :comment,
+           locals: { user: current_user, latest_comment: nil }
+  end
+
+  def authorize_commentable
+    return if params[:commentable_type].blank?
+    return if Comment.new(commentable:).visible_to_user?(current_user)
+
+    head :forbidden
+  end
+
   def comment_params
     params.require(:comment).permit(:description)
   end
 
   def commentable
-    params[:commentable_type].constantize.find(params[:commentable_id])
+    @commentable ||= params[:commentable_type].constantize.find(params[:commentable_id])
   end
 
   def set_my_comment

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -2,12 +2,13 @@
 
 class TalksController < ApplicationController
   before_action :require_admin_login, only: %i[index]
-  before_action :set_talk, only: %i[show]
-  before_action :set_user, only: %i[show]
+  before_action :set_talk, only: %i[show comments]
+  before_action :set_user, only: %i[show comments]
   before_action :set_members, only: %i[show]
-  before_action :allow_show_talk_page_only_admin, only: %i[show]
+  before_action :allow_show_talk_page_only_admin, only: %i[show comments]
 
   ALLOWED_TARGETS = %w[all student_and_trainee mentor graduate adviser trainee retired].freeze
+  COMMENT_LIMIT = 8
 
   def index
     @target = params[:target]
@@ -30,8 +31,29 @@ class TalksController < ApplicationController
   end
 
   def show
-    @comments = @talk.comments.order(:created_at)
+    @comment_total_count = @talk.comments.count
+    @comments = comments_with_users.order(created_at: :desc, id: :desc).limit(COMMENT_LIMIT).to_a.reverse
     @reports = @user.reports.list.limit(20)
+  end
+
+  def comments
+    return head :bad_request unless params[:target] || params[:before]
+
+    if params[:target]
+      @comments = [comments_with_users.find(params[:target])]
+      comment_remaining = 0
+    else
+      before = @talk.comments.find(params[:before])
+      @comments = comments_before(before)
+                  .order(created_at: :desc, id: :desc)
+                  .limit(COMMENT_LIMIT)
+                  .to_a
+                  .reverse
+      comment_remaining = @comments.empty? ? 0 : comments_before(@comments.first).count
+    end
+    response.set_header('X-Comment-Remaining', comment_remaining.to_s)
+    render partial: 'comments/comment', collection: @comments, as: :comment,
+           locals: { user: current_user, latest_comment: nil }
   end
 
   private
@@ -39,7 +61,11 @@ class TalksController < ApplicationController
   def allow_show_talk_page_only_admin
     return if current_user.admin? || @talk.user == current_user
 
-    redirect_to talk_path(current_user.talk)
+    if action_name == 'comments'
+      head :forbidden
+    else
+      redirect_to talk_path(current_user.talk)
+    end
   end
 
   def set_talk
@@ -54,5 +80,18 @@ class TalksController < ApplicationController
     @members = User.with_attached_avatar
                    .where(id: User.admins.ids.push(@talk.user_id))
                    .order(:id)
+  end
+
+  def comments_with_users
+    @talk.comments.includes(user: [{ avatar_attachment: :blob }, { company: { logo_attachment: :blob } }])
+  end
+
+  def comments_before(comment)
+    comments_with_users.where(
+      'created_at < ? OR (created_at = ? AND id < ?)',
+      comment.created_at,
+      comment.created_at,
+      comment.id
+    )
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -2,10 +2,10 @@
 
 class TalksController < ApplicationController
   before_action :require_admin_login, only: %i[index]
-  before_action :set_talk, only: %i[show comments]
-  before_action :set_user, only: %i[show comments]
+  before_action :set_talk, only: %i[show]
+  before_action :set_user, only: %i[show]
   before_action :set_members, only: %i[show]
-  before_action :allow_show_talk_page_only_admin, only: %i[show comments]
+  before_action :allow_show_talk_page_only_admin, only: %i[show]
 
   ALLOWED_TARGETS = %w[all student_and_trainee mentor graduate adviser trainee retired].freeze
   COMMENT_LIMIT = 8
@@ -32,28 +32,8 @@ class TalksController < ApplicationController
 
   def show
     @comment_total_count = @talk.comments.count
-    @comments = comments_with_users.order(created_at: :desc, id: :desc).limit(COMMENT_LIMIT).to_a.reverse
+    @comments = @talk.comments.with_user_details.order(created_at: :desc, id: :desc).limit(COMMENT_LIMIT).to_a.reverse
     @reports = @user.reports.list.limit(20)
-  end
-
-  def comments
-    return head :bad_request unless params[:target] || params[:before]
-
-    if params[:target]
-      @comments = [comments_with_users.find(params[:target])]
-      comment_remaining = 0
-    else
-      before = @talk.comments.find(params[:before])
-      @comments = comments_before(before)
-                  .order(created_at: :desc, id: :desc)
-                  .limit(COMMENT_LIMIT)
-                  .to_a
-                  .reverse
-      comment_remaining = @comments.empty? ? 0 : comments_before(@comments.first).count
-    end
-    response.set_header('X-Comment-Remaining', comment_remaining.to_s)
-    render partial: 'comments/comment', collection: @comments, as: :comment,
-           locals: { user: current_user, latest_comment: nil }
   end
 
   private
@@ -61,11 +41,7 @@ class TalksController < ApplicationController
   def allow_show_talk_page_only_admin
     return if current_user.admin? || @talk.user == current_user
 
-    if action_name == 'comments'
-      head :forbidden
-    else
-      redirect_to talk_path(current_user.talk)
-    end
+    redirect_to talk_path(current_user.talk)
   end
 
   def set_talk
@@ -80,18 +56,5 @@ class TalksController < ApplicationController
     @members = User.with_attached_avatar
                    .where(id: User.admins.ids.push(@talk.user_id))
                    .order(:id)
-  end
-
-  def comments_with_users
-    @talk.comments.includes(user: [{ avatar_attachment: :blob }, { company: { logo_attachment: :blob } }])
-  end
-
-  def comments_before(comment)
-    comments_with_users.where(
-      'created_at < ? OR (created_at = ? AND id < ?)',
-      comment.created_at,
-      comment.created_at,
-      comment.id
-    )
   end
 end

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -1,4 +1,5 @@
 import { initializeComment } from 'initializeComment'
+import { get } from '@rails/request.js'
 
 document.addEventListener('DOMContentLoaded', async () => {
   const comments = document.querySelectorAll('.thread-comment:not(.loading)')
@@ -39,21 +40,35 @@ document.addEventListener('DOMContentLoaded', async () => {
     let beforeId =
       commentItems.querySelector('.thread-comment').dataset.comment_id
     const loadComments = async (parameter, updateRemaining = true) => {
-      const response = await fetch(
+      const response = await get(
         `${moreComments.dataset.commentsUrl}?${parameter}`
       )
       if (!response.ok) throw new Error(`HTTP ${response.status}`)
 
       const template = document.createElement('template')
-      template.innerHTML = await response.text()
+      template.innerHTML = await response.text
       const loadedComments = Array.from(
         template.content.querySelectorAll('.thread-comment')
       )
+      loadedComments.forEach((comment) => {
+        if (document.getElementById(comment.id)) comment.remove()
+      })
       commentItems.prepend(template.content)
-      setComments(loadedComments)
+      const uniqueComments = loadedComments.filter(
+        (comment) => comment.isConnected
+      )
+      setComments(uniqueComments)
+      Array.from(commentItems.querySelectorAll(':scope > .thread-comment'))
+        .sort(
+          (left, right) =>
+            Number(left.dataset.comment_created_at) -
+              Number(right.dataset.comment_created_at) ||
+            Number(left.dataset.comment_id) - Number(right.dataset.comment_id)
+        )
+        .forEach((comment) => commentItems.append(comment))
       if (!updateRemaining) return
 
-      beforeId = loadedComments[0]?.dataset.comment_id || beforeId
+      beforeId = uniqueComments[0]?.dataset.comment_id || beforeId
       commentRemaining = Number(response.headers.get('X-Comment-Remaining'))
       if (commentRemaining > 0) {
         moreComments.classList.remove('is-hidden')

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -1,6 +1,6 @@
 import { initializeComment } from 'initializeComment'
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const comments = document.querySelectorAll('.thread-comment:not(.loading)')
   const loadingContent = document.querySelector('.loading-content')
   if (!loadingContent) {
@@ -23,10 +23,73 @@ document.addEventListener('DOMContentLoaded', () => {
   const incrementSize = 8
   let commentRemaining = 0
   const nextCommentAmount = 0
-  const moreCommentButton = document.querySelector(
-    '.a-button.is-lg.is-text.is-block'
-  )
   const moreComments = document.querySelector('.thread-comments-more')
+  const moreCommentButton = moreComments?.querySelector('button')
+  if (!moreCommentButton || !moreComments) {
+    setComments(comments)
+    return
+  }
+
+  if (moreComments.dataset.commentsUrl) {
+    commentRemaining = Number(moreComments.dataset.commentRemaining)
+    setComments(comments)
+    displayMoreComments(commentRemaining, nextCommentAmount, moreCommentButton)
+
+    const commentItems = document.querySelector('.thread-comments__items')
+    let beforeId =
+      commentItems.querySelector('.thread-comment').dataset.comment_id
+    const loadComments = async (parameter, updateRemaining = true) => {
+      const response = await fetch(
+        `${moreComments.dataset.commentsUrl}?${parameter}`
+      )
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+
+      const template = document.createElement('template')
+      template.innerHTML = await response.text()
+      const loadedComments = Array.from(
+        template.content.querySelectorAll('.thread-comment')
+      )
+      commentItems.prepend(template.content)
+      setComments(loadedComments)
+      if (!updateRemaining) return
+
+      beforeId = loadedComments[0]?.dataset.comment_id || beforeId
+      commentRemaining = Number(response.headers.get('X-Comment-Remaining'))
+      if (commentRemaining > 0) {
+        moreComments.classList.remove('is-hidden')
+        displayMoreComments(
+          commentRemaining,
+          nextCommentAmount,
+          moreCommentButton
+        )
+      } else {
+        moreComments.classList.add('is-hidden')
+      }
+    }
+
+    const commentAnchor = location.hash
+    const anchorId = commentAnchor.match(/^#comment_(\d+)$/)?.[1]
+    if (anchorId && !document.getElementById(`comment_${anchorId}`)) {
+      try {
+        await loadComments(`target=${encodeURIComponent(anchorId)}`, false)
+        document.getElementById(`comment_${anchorId}`)?.scrollIntoView()
+      } catch (error) {
+        console.warn(error)
+      }
+    }
+
+    moreCommentButton.addEventListener('click', async () => {
+      moreCommentButton.disabled = true
+      try {
+        await loadComments(`before=${encodeURIComponent(beforeId)}`)
+      } catch (error) {
+        console.warn(error)
+      } finally {
+        moreCommentButton.disabled = false
+      }
+    })
+    return
+  }
 
   if (commentTotalCount <= initialLimit) {
     comments.forEach((comment) => {

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -40,8 +40,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     let beforeId =
       commentItems.querySelector('.thread-comment').dataset.comment_id
     const loadComments = async (parameter, updateRemaining = true) => {
+      const separator = moreComments.dataset.commentsUrl.includes('?')
+        ? '&'
+        : '?'
       const response = await get(
-        `${moreComments.dataset.commentsUrl}?${parameter}`
+        `${moreComments.dataset.commentsUrl}${separator}${parameter}`
       )
       if (!response.ok) throw new Error(`HTTP ${response.status}`)
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -19,6 +19,10 @@ class Comment < ApplicationRecord
   mentionable_as :description, hook_name: :after_commit
 
   scope :without_private_comment, -> { where.not(commentable_type: %w[Talk Inquiry CorporateTrainingInquiry]) }
+  scope :with_user_details, -> { includes(user: [{ avatar_attachment: :blob }, { company: { logo_attachment: :blob } }]) }
+  scope :before_comment, lambda { |comment|
+    where('created_at < ? OR (created_at = ? AND id < ?)', comment.created_at, comment.created_at, comment.id)
+  }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[description commentable_type commentable_id created_at updated_at user_id]

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,4 +1,10 @@
-article.thread-comment.comment.is-hidden class=" #{'is-latest' if latest_comment?(comment, latest_comment)}" id="comment_#{comment.id}" data-comment_id="#{comment.id}" data-comment_created_at="#{comment.created_at.to_f}" data-comment_description="#{comment.description}"
+article.thread-comment.comment.is-hidden(
+  class=" #{'is-latest' if latest_comment?(comment, latest_comment)}"
+  id="comment_#{comment.id}"
+  data-comment_id=comment.id
+  data-comment_created_at=comment.created_at.to_f
+  data-comment_description=comment.description
+)
   #latest-comment
   .thread-comment__start
     a.thread-comment__user-link href="#{comment.user.url}"

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,4 +1,4 @@
-article.thread-comment.comment.is-hidden class=" #{'is-latest' if latest_comment?(comment, latest_comment)}" id="comment_#{comment.id}" data-comment_id="#{comment.id}" data-comment_description="#{comment.description}"
+article.thread-comment.comment.is-hidden class=" #{'is-latest' if latest_comment?(comment, latest_comment)}" id="comment_#{comment.id}" data-comment_id="#{comment.id}" data-comment_created_at="#{comment.created_at.to_f}" data-comment_description="#{comment.description}"
   #latest-comment
   .thread-comment__start
     a.thread-comment__user-link href="#{comment.user.url}"

--- a/app/views/comments/_comments.html.slim
+++ b/app/views/comments/_comments.html.slim
@@ -2,11 +2,29 @@
   - 3.times do
     = render 'comments/comment_placeholder'
 #comments.thread-comments.loaded.is-hidden
-  .thread-comments-more.is-hidden
+  ruby:
+    paginated = local_assigns[:comments_url].present?
+    comment_total_count = local_assigns.fetch(
+      :comment_total_count, @comments.size
+    )
+    comment_remaining = comment_total_count - @comments.size
+    next_comment_amount = if comment_remaining > 8
+                            "8 / #{comment_remaining}"
+                          else
+                            comment_remaining
+                          end
+  .thread-comments-more(
+    class=('is-hidden' unless paginated && comment_remaining.positive?)
+    data-comments-url=local_assigns[:comments_url]
+    data-comment-remaining=comment_remaining
+  )
     .thread-comments-more__inner
       .thread-comments-more__action
         button.a-button.is-lg.is-text.is-block
-          | 前のコメント（  ）
+          - if paginated
+            | 前のコメント（ #{next_comment_amount} ）
+          - else
+            | 前のコメント（  ）
   header.thread-comments__header
     h2.thread-comments__title
       | コメント

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -62,7 +62,7 @@
         = render 'comments/comments',
           commentable: @talk,
           commentable_type: 'Talk',
-          comments_url: comments_talk_path(@talk),
+          comments_url: api_comments_path(commentable_type: 'Talk', commentable_id: @talk.id),
           comment_total_count: @comment_total_count
         - if current_user.admin?
           = render(ActionCompletedButtonComponent.new(is_initial_action_completed: @talk.action_completed, update_path: api_talk_path(@talk), model_name: 'talk'))

--- a/app/views/talks/show.html.slim
+++ b/app/views/talks/show.html.slim
@@ -59,7 +59,11 @@
                             image_class: 'page-content-members__user-icon'
                           = link_to user_path(member.id), class: 'a-user-name' do
                             = member.login_name
-        = render 'comments/comments', commentable: @talk, commentable_type: 'Talk'
+        = render 'comments/comments',
+          commentable: @talk,
+          commentable_type: 'Talk',
+          comments_url: comments_talk_path(@talk),
+          comment_total_count: @comment_total_count
         - if current_user.admin?
           = render(ActionCompletedButtonComponent.new(is_initial_action_completed: @talk.action_completed, update_path: api_talk_path(@talk), model_name: 'talk'))
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,9 @@ Rails.application.routes.draw do
   namespace :talks do
     resources :action_uncompleted, only: %i(index)
   end
-  resources :talks, only: %i(index show)
+  resources :talks, only: %i(index show) do
+    get :comments, on: :member
+  end
   resources :questions
   resources :courses, only: :index
   resource :inquiry, only: %i(new create) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,9 +87,7 @@ Rails.application.routes.draw do
   namespace :talks do
     resources :action_uncompleted, only: %i(index)
   end
-  resources :talks, only: %i(index show) do
-    get :comments, on: :member
-  end
+  resources :talks, only: %i(index show)
   resources :questions
   resources :courses, only: :index
   resource :inquiry, only: %i(new create) do

--- a/db/fixtures/comments.yml
+++ b/db/fixtures/comments.yml
@@ -148,6 +148,15 @@ commentOfTalk:
   description: "これは相談部屋の会話です。"
   updated_at: "2019-01-02 00:00:00 JST"
 
+<% 1.upto(300) do |i| %>
+talkPerformanceComment<%= i %>:
+  user: komagata
+  commentable: talk_komagata (Talk)
+  description: "相談部屋のパフォーマンス確認用コメント<%= i %>です。"
+  created_at: <%= Time.zone.parse('2026-01-01 00:00:00 JST') + i.minutes %>
+  updated_at: <%= Time.zone.parse('2026-01-01 00:00:00 JST') + i.minutes %>
+<% end %>
+
 comment45:
   user: kimura
   commentable: product77 (Product)

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -3,6 +3,12 @@
 require 'test_helper'
 
 class TalksControllerTest < ActionDispatch::IntegrationTest
+  test 'talks do not define their own comments route' do
+    assert_raises(ActionController::RoutingError) do
+      Rails.application.routes.recognize_path('/talks/1/comments')
+    end
+  end
+
   setup do
     @talk = talks(:talk1)
     @user = users(:komagata)
@@ -23,7 +29,7 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
   test 'comments renders the previous eight comments' do
     before_comment = @talk.comments.order(created_at: :desc).offset(7).first
 
-    get "/talks/#{@talk.id}/comments", params: { before: before_comment.id }
+    get api_comments_path, params: comment_params(before: before_comment.id)
 
     assert_response :success
     assert_select '.thread-comment.comment', count: 8
@@ -34,7 +40,7 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
   test 'comments renders a page containing the target comment' do
     target_comment = @talk.comments.order(:created_at, :id).first
 
-    get "/talks/#{@talk.id}/comments", params: { target: target_comment.id }
+    get api_comments_path, params: comment_params(target: target_comment.id)
 
     assert_response :success
     assert_includes response.body, target_comment.description
@@ -46,7 +52,7 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
       @talk.comments.create!(user: @user, description: "同時刻コメント#{index}", created_at:)
     end
 
-    get "/talks/#{@talk.id}/comments", params: { before: comments.last.id }
+    get api_comments_path, params: comment_params(before: comments.last.id)
 
     fragment = Nokogiri::HTML.fragment(response.body)
     rendered_ids = fragment.css('.thread-comment.comment').pluck('data-comment_id').map(&:to_i)
@@ -57,14 +63,20 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     get logout_path
     post user_sessions_path, params: { user: { login: 'kimura', password: 'testtest' } }
 
-    get "/talks/#{@talk.id}/comments", params: { before: @talk.comments.last.id }
+    get api_comments_path, params: comment_params(before: @talk.comments.last.id)
 
     assert_response :forbidden
   end
 
   test 'comments requires a cursor' do
-    get "/talks/#{@talk.id}/comments"
+    get api_comments_path, params: comment_params
 
     assert_response :bad_request
+  end
+
+  private
+
+  def comment_params(**params)
+    { commentable_type: 'Talk', commentable_id: @talk.id, **params }
   end
 end

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TalksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @talk = talks(:talk1)
+    @user = users(:komagata)
+    post user_sessions_path, params: { user: { login: @user.login_name, password: 'testtest' } }
+    16.times do |index|
+      @talk.comments.create!(user: @user, description: "相談コメント#{index}", created_at: index.minutes.ago)
+    end
+  end
+
+  test 'show renders only the latest eight comments' do
+    get talk_path(@talk)
+
+    assert_response :success
+    assert_select '.thread-comment.comment', count: 8
+    assert_select '.thread-comments-more', text: %r{前のコメント（ 8 / 9 ）}
+  end
+
+  test 'comments renders the previous eight comments' do
+    before_comment = @talk.comments.order(created_at: :desc).offset(7).first
+
+    get "/talks/#{@talk.id}/comments", params: { before: before_comment.id }
+
+    assert_response :success
+    assert_select '.thread-comment.comment', count: 8
+    assert_not_includes response.body, before_comment.description
+    assert_equal '1', response.headers['X-Comment-Remaining']
+  end
+
+  test 'comments renders a page containing the target comment' do
+    target_comment = @talk.comments.order(:created_at, :id).first
+
+    get "/talks/#{@talk.id}/comments", params: { target: target_comment.id }
+
+    assert_response :success
+    assert_includes response.body, target_comment.description
+  end
+
+  test 'comments uses the id as a cursor when timestamps are equal' do
+    created_at = 1.year.ago
+    comments = Array.new(9) do |index|
+      @talk.comments.create!(user: @user, description: "同時刻コメント#{index}", created_at:)
+    end
+
+    get "/talks/#{@talk.id}/comments", params: { before: comments.last.id }
+
+    fragment = Nokogiri::HTML.fragment(response.body)
+    rendered_ids = fragment.css('.thread-comment.comment').pluck('data-comment_id').map(&:to_i)
+    assert_equal comments.first(8).pluck(:id), rendered_ids
+  end
+
+  test 'comments forbids access to another users talk' do
+    get logout_path
+    post user_sessions_path, params: { user: { login: 'kimura', password: 'testtest' } }
+
+    get "/talks/#{@talk.id}/comments", params: { before: @talk.comments.last.id }
+
+    assert_response :forbidden
+  end
+
+  test 'comments requires a cursor' do
+    get "/talks/#{@talk.id}/comments"
+
+    assert_response :bad_request
+  end
+end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -46,4 +46,35 @@ class TalksTest < ApplicationSystemTestCase
     assert_field 'js-new-comment', with: /\[diploma\.pdf \(.+ KB\)\]\(http.+diploma\.pdf\)/
     assert_no_field 'js-new-comment', with: /undefined/
   end
+
+  test 'loads previous comments eight at a time' do
+    user = users(:kimura)
+    user.talk.comments.delete_all
+    17.times do |index|
+      user.talk.comments.create!(user:, description: "相談コメント#{index}", created_at: index.minutes.ago)
+    end
+
+    visit_with_auth talk_path(user.talk), 'komagata'
+
+    assert_text '相談コメント0'
+    assert_no_text '相談コメント15'
+    page.execute_script("document.querySelector('.thread-comments-more button').click()")
+    assert_text '相談コメント15'
+    assert_button '前のコメント（ 1 ）'
+  end
+
+  test 'loads an old comment linked by its anchor' do
+    user = users(:kimura)
+    user.talk.comments.delete_all
+    comments = Array.new(17) do |index|
+      user.talk.comments.create!(user:, description: "アンカーコメント#{index}", created_at: index.minutes.ago)
+    end
+
+    visit_with_auth "#{talk_path(user.talk)}#comment_#{comments.last.id}", 'komagata'
+
+    assert_text 'アンカーコメント16'
+    assert_text 'アンカーコメント0'
+    page.execute_script("document.querySelector('.thread-comments-more button').click()")
+    assert_text 'アンカーコメント15'
+  end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -77,6 +77,7 @@ class TalksTest < ApplicationSystemTestCase
     page.execute_script("document.querySelector('.thread-comments-more button').click()")
     assert_text 'アンカーコメント15'
     page.execute_script("document.querySelector('.thread-comments-more button').click()")
+    assert_selector '.thread-comments-more.is-hidden', visible: :hidden
     assert_selector "#comment_#{comments.last.id}", count: 1
     rendered_ids = page.all('.thread-comments__items > .thread-comment').map { |comment| comment[:id] }
     assert_equal comments.reverse.pluck(:id).map { |id| "comment_#{id}" }, rendered_ids

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -76,5 +76,9 @@ class TalksTest < ApplicationSystemTestCase
     assert_text 'アンカーコメント0'
     page.execute_script("document.querySelector('.thread-comments-more button').click()")
     assert_text 'アンカーコメント15'
+    page.execute_script("document.querySelector('.thread-comments-more button').click()")
+    assert_selector "#comment_#{comments.last.id}", count: 1
+    rendered_ids = page.all('.thread-comments__items > .thread-comment').map { |comment| comment[:id] }
+    assert_equal comments.reverse.pluck(:id).map { |id| "comment_#{id}" }, rendered_ids
   end
 end


### PR DESCRIPTION
## 概要

コメントが多い相談部屋で、全コメントと編集フォームを初期HTMLへ描画していたため表示が遅くなっていました。初期表示を最新8件に限定し、「前のコメント」から8件ずつ取得するカーソルページネーションへ変更します。

古いコメントへのアンカーURLは、対象コメントを追加取得して従来どおり表示します。

Closes #10471

## 実データでの確認

Cloud SQL Proxy経由で本番DBを隔離ローカルDBへコピーし、相談1690（285コメント）で確認しました。

- 変更前（本番）: DOM約43,620要素、HTML約3.31MB、コメントtextarea 287個、初回表示10秒超
- 変更後（ローカル）: DOM約3,109要素、HTML約0.325MB、コメントtextarea 8個、Navigation約1.24秒
- 「前のコメント」で8件ずつ追加表示されること
- 最古コメントのアンカーURLで対象コメントと最新8件が表示され、その後も過去コメントを読み込めること

計測後、本番スナップショットは削除済みです。

## テスト

- `rails test test/controllers/talks_controller_test.rb`
- `rails test test/system/talks_test.rb -n "/loads (previous|an old comment)/"`
- `rubocop app/controllers/talks_controller.rb test/controllers/talks_controller_test.rb test/system/talks_test.rb`
- `eslint app/javascript/comments.js --max-warnings=0`
- `prettier app/javascript/comments.js --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コメントを最大8件ずつ追加読み込みできるようになりました。
  * コメントの総数と残り件数を表示し、すべて読み込むと追加読み込みUIを非表示にします。
  * 古いコメントへのリンクから、対象コメントを含む位置まで自動表示できるようになりました。
  * コメントの重複を防ぎ、正しい時系列で表示します。

* **テスト**
  * コメントのページング、権限確認、対象コメント表示を追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10472-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->