### PR TITLE
休会中の退会手続きページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/application/blocks/auth-form/_auth-form.css
+++ b/app/assets/stylesheets/application/blocks/auth-form/_auth-form.css
@@ -38,6 +38,10 @@
   width: 34rem;
 }
 
+.auth-form-logo-image + .auth-form.is-lg {
+  margin-top: 0;
+}
+
 @media (width >= 48em) {
   .auth-form.is-lg {
     margin-top: 3rem;

--- a/app/controllers/hibernated_retirement_controller.rb
+++ b/app/controllers/hibernated_retirement_controller.rb
@@ -2,6 +2,7 @@
 
 class HibernatedRetirementController < ApplicationController
   skip_before_action :require_active_user_login, raise: false
+  before_action :redirect_logged_in_user, only: %i[new]
 
   def new
     @user = User.new
@@ -29,6 +30,10 @@ class HibernatedRetirementController < ApplicationController
   end
 
   private
+
+  def redirect_logged_in_user
+    redirect_to new_retirement_path if current_user
+  end
 
   def render_retirement_form
     current_user.retired_on = nil

--- a/app/views/hibernated_retirement/new.html.slim
+++ b/app/views/hibernated_retirement/new.html.slim
@@ -1,12 +1,8 @@
 - title '退会手続き'
+- content_for(:extra_body_classes, 'no-header no-footer no-global-nav')
 
-header.page-header
-  .container
-    .page-header__inner
-      .page-header__start
-        .page-header__title
-          = title
-hr.a-border
+= image_tag('logo-lg.svg', class: 'auth-form-logo-image')
+
 .auth-form.is-lg
   .a-card
     header.auth-form__header
@@ -15,10 +11,10 @@ hr.a-border
       = form_with model: @user, local: true, url: hibernated_retirement_path, method: :post, class: 'form' do |f|
         .form-item
           = f.label :email, 'メールアドレスをご記入ください', class: 'a-form-label'
-          = f.text_field :email
+          = f.text_field :email, class: 'a-text-input'
         .form-item
           = f.label :password, 'パスワードをご記入ください', class: 'a-form-label'
-          = f.password_field :password
+          = f.password_field :password, class: 'a-text-input'
         .form-item
           = f.label :retire_reasons, '退会の理由を教えてください（複数選択可）', class: 'a-form-label'
           .checkboxes
@@ -46,6 +42,6 @@ hr.a-border
         .form-actions
           ul.form-actions__items
             li.form-actions__item.is-main
-              = link_to 'キャンセル', :back, class: 'a-button is-md is-secondary is-block'
+              = link_to 'キャンセル', root_path, class: 'a-button is-md is-secondary is-block'
             li.form-actions__item.is-main
               = f.submit '退会する', class: 'a-button is-md is-danger is-block', data: { confirm: '本当によろしいですか？' }

--- a/test/system/hibernated_retirement_test.rb
+++ b/test/system/hibernated_retirement_test.rb
@@ -3,6 +3,12 @@
 require 'application_system_test_case'
 
 class HibernatedRetirementTest < ApplicationSystemTestCase
+  test 'redirect to retirement page when logged in' do
+    visit_with_auth new_hibernated_retirement_path, 'hatsuno'
+
+    assert_current_path new_retirement_path
+  end
+
   test 'retire as hibernated user' do
     visit new_hibernated_retirement_path
     fill_in 'user[email]', with: 'kyuukai@fjord.jp'


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ログイン済みの場合、休会退会フォームではなく通常の退会手続きページへ自動的に移動するようになりました。

* **改善**
  * 退会手続きページのレイアウトを見直し、入力欄やキャンセル操作を使いやすくしました。
  * 大型認証フォームのロゴ下の余白を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10474-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->