### PR TITLE
未確認日報のアラート内の文章を折り返さないように修正

### DIFF
--- a/app/assets/stylesheets/application/blocks/dashboard/_unchecked-report-alert.css
+++ b/app/assets/stylesheets/application/blocks/dashboard/_unchecked-report-alert.css
@@ -14,7 +14,6 @@
   padding: 0.25rem 1rem;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
 }
 
 .unchecked-report-alert__icon {


### PR DESCRIPTION
## Issue

- #10478 

## 概要

メンターでログインした際のダッシュボードにおいて、未確認日報が100件を超えた際のアラート内の文章が折り返される問題を修正しました。

## 変更確認方法

1. `chore/remove-unchecked-report-alert-gap`ブランチをローカルに取り込む
2. ローカルサーバーが起動していないことを確認する
3. Railsコンソール上で以下を実行して未確認日報を101件以上にする

```rb
(101 - Report.unchecked.not_wip.count).times do |n|
  Report.create!(
    user: User.first,
    title: "sample title #{n}",
    description: "sample description #{n}",
    reported_on: Date.today - (n + 1).day
  )
end
```

4. ローカルサーバーを起動する
5. `komagata`など、任意のメンターでログインする
6. [ダッシュボード](http://localhost:3000/)にアクセスする
7. 「日報が100件を超えました。」というアラート内の文章が折り返されていないことを確認する。

未確認日報の件数にはプロセス内のメモリキャッシュが使用されているため、データ作成前からローカルサーバーを起動していた場合、画面を再読み込みしても表示が更新されない。その場合は、ローカルサーバーの再起動が必要。

## Screenshot

### 変更前
<img width="325" height="100" alt="image" src="https://github.com/user-attachments/assets/1a5188aa-c7c4-4dda-8c23-003ba3e3004e" />

### 変更後
<img width="330" height="108" alt="image" src="https://github.com/user-attachments/assets/088e8d9c-9504-4a01-b675-e8e32a4e6c06" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 未確認レポート通知内の要素間に設定されていた自動間隔を削除し、レイアウトの余白を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10481-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->