### PR TITLE
ペアワークの作成者が休会になったら、ペアワークを解消する

### DIFF
--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -14,6 +14,7 @@ class Hibernation < ApplicationRecord
     notify_to_mentors_and_admins
     user.clean_up_regular_events
     unmatch_pair_works(user)
+    destroy_pair_works(user)
   end
 
   def self.hibernate_by_admin(user:, scheduled_return_on:)
@@ -56,7 +57,12 @@ class Hibernation < ApplicationRecord
   def unmatch_pair_works(user)
     PairWork.where(buddy: user).find_each do |pair_work|
       next unless pair_work.unmatch
+
       ActiveSupport::Notifications.instrument('pair_work.cancel', pair_work: pair_work, sender: user)
     end
+  end
+
+  def destroy_pair_works(user)
+    PairWork.where(user: user, buddy: nil, reserved_at: nil).find_each(&:destroy)
   end
 end

--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -13,6 +13,7 @@ class Hibernation < ApplicationRecord
     notify_to_chat
     notify_to_mentors_and_admins
     user.clean_up_regular_events
+    unmatch_pair_works(user)
   end
 
   def self.hibernate_by_admin(user:, scheduled_return_on:)
@@ -50,5 +51,12 @@ class Hibernation < ApplicationRecord
 
   def notify_to_chat
     DiscordNotifier.with(sender: user).hibernated.notify_now
+  end
+
+  def unmatch_pair_works(user)
+    PairWork.where(buddy: user).find_each do |pair_work|
+      next unless pair_work.unmatch
+      ActiveSupport::Notifications.instrument('pair_work.cancel', pair_work: pair_work, sender: user)
+    end
   end
 end

--- a/test/models/hibernation_test.rb
+++ b/test/models/hibernation_test.rb
@@ -9,7 +9,6 @@ class HibernationTest < ActiveSupport::TestCase
 
   test 'publishes a cancellation notification for a future reservation' do
     hibernation = Hibernation.new
-    pair_work = pair_works(:pair_work2)
     buddy = users(:sotugyou)
     notification_count = 0
 
@@ -23,5 +22,20 @@ class HibernationTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, notification_count
+  end
+
+  test 'destroy the pair works by the user' do
+    hibernation = Hibernation.create!(
+      user: @user,
+      reason: '多忙のため',
+      scheduled_return_on: Date.current + 3.months
+    )
+    pair_work = pair_works(:pair_work1)
+
+    assert_difference 'PairWork.count', -2 do
+      hibernation.send(:destroy_pair_works, @user)
+    end
+
+    assert_not PairWork.exists?(pair_work.id)
   end
 end

--- a/test/models/hibernation_test.rb
+++ b/test/models/hibernation_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HibernationTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:kimura)
+  end
+
+  test 'publishes a cancellation notification for a future reservation' do
+    hibernation = Hibernation.new
+    pair_work = pair_works(:pair_work2)
+    buddy = users(:sotugyou)
+    notification_count = 0
+
+    travel_to Time.zone.local(2025, 1, 2, 0, 59, 59) do
+      ActiveSupport::Notifications.subscribed(
+        ->(*) { notification_count += 1 },
+        'pair_work.cancel'
+      ) do
+        hibernation.send(:unmatch_pair_works, buddy)
+      end
+    end
+
+    assert_equal 1, notification_count
+  end
+end

--- a/test/system/hibernation_test.rb
+++ b/test/system/hibernation_test.rb
@@ -39,4 +39,24 @@ class HibernationTest < ApplicationSystemTestCase
     end
     assert_text '復帰予定日を入力してください'
   end
+
+  test 'removed a pair_work by hibernate' do
+    pair_work = pair_works(:pair_work1)
+    visit_with_auth new_hibernation_path, 'kimura'
+    within('form[name=hibernation]') do
+      fill_in(
+        'hibernation[scheduled_return_on]',
+        with: (Date.current + 30)
+      )
+      fill_in('hibernation[reason]', with: 'test')
+    end
+
+    find('.check-box-to-read').click
+    accept_confirm do
+      click_on '休会する'
+    end
+
+    assert_text '休会手続きが完了しました'
+    assert_not PairWork.exists?(pair_work.id)
+  end
 end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- https://github.com/orgs/fjordllc/projects/7/views/1?pane=issue&itemId=192619643&issue=fjordllc%7Cbootcamp%7C10090

## 概要
ペアワークの作成者が退会になったら、ペアワークが削除されるが、休会の場合は何も起きないのでその場合も同様にペアワークが削除されるようにする。

## 変更確認方法

1. `feature/pairwork-user-suspended-pair-work-is-dissolved`をローカルに取り込む。
2.  `kyuukai`ユーザーでログインする。（休会している場合は復活させて下さい）
3.  [ペアワーク募集ページ](http://localhost:3000/pair_works/new)にて適当なペアワークを作成して下さい。
4. ペアワークを作成したら、[休会手続き](http://localhost:3000/hibernation/new)にて休会して下さい。
5. [ログイン画面](http://localhost:3000/login)にて他のユーザーでログインして下さい。
6. ペアワークページへ移動し先程作られたペアワークが削除されていることを確認して下さい。


## Screenshot

### 変更前



https://github.com/user-attachments/assets/e1592026-6f2b-498b-97f3-7a3f4d9b5521




### 変更後

https://github.com/user-attachments/assets/807b5254-cd4a-4960-a458-34b7d0bc0563







<!-- I want to review in Japanese. -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10483-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **機能改善**
  - 休会手続きの完了時、関連するペアワークを自動的に整理するようになりました。
  - 相手がいるペアワークは解除・キャンセルされ、相手へ通知されます。
  - 未割り当てで開始前のペアワークは自動的に削除されます。
- **テスト**
  - 休会時のペアワークの解除、通知、削除処理を確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->