### PR TITLE
AnyLoginに表示されるユーザー数の上限を10件から無制限に変更

### DIFF
--- a/config/initializers/any_login.rb
+++ b/config/initializers/any_login.rb
@@ -35,7 +35,7 @@ AnyLogin.setup do |config|
   # config.auto_show = false
 
   # # limit, integer or :none
-  # config.limit = 10
+  config.limit = :none
 
   # # Enable http basic authentication
   # config.http_basic_authentication_enabled = false


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

- なし

## 概要

AnyLogin gemでは、初期設定により表示されるユーザー数の上限が10件という制限がありました。さらにサーバー起動のたびに表示されるユーザーも異なるという問題が発生していました。
そのため、制限をなくして設定されているテストユーザーが全件表示されるように変更しました。

## 変更確認方法

軽微な変更のためなし。

## Screenshot

### 変更前

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c60f76ee-66fe-4b57-b873-5daf33d6c4f0" />

### 変更後

<img width="500" alt="image" src="https://github.com/user-attachments/assets/73927c39-c298-4348-92cf-6d1887e41871" />

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * ユーザー選択ドロップダウンの表示件数制限を撤廃しました。
  * これにより、すべてのユーザーを一覧から選択できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10485-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->