### PR TITLE
RuboCopで複数行の構成要素を1行として数える

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,20 @@ Lint/MissingSuper:
   Exclude:
     - 'app/components/**/*'
 
+Metrics/ClassLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+    - method_call
+
+Metrics/ModuleLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+    - method_call
+
 AllCops:
   Exclude:
     - '**/templates/**/*'

--- a/app/controllers/api/users/support_contexts_controller.rb
+++ b/app/controllers/api/users/support_contexts_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class API::Users::SupportContextsController < API::BaseController # rubocop:todo Metrics/ClassLength
+class API::Users::SupportContextsController < API::BaseController
   SUPPORT_CONTEXT_LIMIT = 5
 
   before_action :require_admin_or_mentor

--- a/app/controllers/regular_events_controller.rb
+++ b/app/controllers/regular_events_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RegularEventsController < ApplicationController # rubocop:disable Metrics/ClassLength
+class RegularEventsController < ApplicationController
   before_action :set_regular_event, only: %i[edit update destroy]
 
   def index

--- a/app/models/pair_work.rb
+++ b/app/models/pair_work.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class PairWork < ApplicationRecord
   include Searchable
   include Commentable
@@ -132,4 +131,3 @@ class PairWork < ApplicationRecord
     errors.add(:reserved_at, 'は提案されたスケジュールに含まれていません') unless schedules.map(&:proposed_at).include?(reserved_at)
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Report < ApplicationRecord # rubocop:todo Metrics/ClassLength
+class Report < ApplicationRecord
   include Commentable
   include Checkable
   include Footprintable

--- a/app/notifiers/discord_notifier.rb
+++ b/app/notifiers/discord_notifier.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DiscordNotifier < ApplicationNotifier # rubocop:disable Metrics/ClassLength
+class DiscordNotifier < ApplicationNotifier
   self.driver = DiscordDriver.new
   self.async_adapter = DiscordAsyncAdapter.new
 


### PR DESCRIPTION
## 概要

`Metrics/ClassLength` と `Metrics/ModuleLength` の `CountAsOne` を設定しました。

配列、ハッシュ、ヒアドキュメント、メソッド呼び出しが複数行に整形されていても、それぞれ1行として数えます。コードの整形方法によってクラスやモジュールの行数評価が変わりにくくなります。

`MethodLength` には適用せず、長いメソッドの検出はこれまでどおり維持します。

新しい数え方で上限内になったクラスから、不要になった `Metrics/ClassLength` の無効化指定も削除しました。

## 確認方法

```console
$ bundle exec rubocop
1235 files inspected, no offenses detected
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **開発品質**
  * コード品質チェックのクラス・モジュール長計測を調整しました。
  * 複雑な配列、ハッシュ、ヒアドキュメント、メソッド呼び出しを適切にまとめて評価します。
  * 既存のクラス長チェック抑制を整理しました。
* **バグ修正**
  * 実行時の処理、APIレスポンス、通知、権限確認に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10487-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->