### PR TITLE
配信停止済みアドレスへの送信エラーでジョブを失敗させないようにする

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,6 +9,12 @@ class ApplicationMailer < ActionMailer::Base
   private
 
   def mailerror(exception)
-    Rails.logger.info(exception.recipients.to_s)
+    masked_recipients = exception.recipients.map { |email| mask_email(email) }
+    Rails.logger.info(masked_recipients.to_s)
+  end
+
+  def mask_email(email)
+    local, domain = email.split('@')
+    "#{local[0]}***@#{domain}"
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,4 +3,12 @@
 class ApplicationMailer < ActionMailer::Base
   default from: 'フィヨルドブートキャンプ <noreply@bootcamp.fjord.jp>'
   layout 'mailer'
+
+  rescue_from Postmark::InactiveRecipientError, with: :mailerror
+
+  private
+
+  def mailerror(exception)
+    Rails.logger.info(exception.recipients.to_s)
+  end
 end

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -17,7 +17,8 @@ class ApplicationMailerTest < ActionMailer::TestCase
       end
     end
 
-    assert_includes logs, [user.email].to_s
+    local, domain = user.email.split('@')
+    assert_includes logs, ["#{local[0]}***@#{domain}"].to_s
   end
 
   test 'Mail to inactive address via deliver_later' do
@@ -36,6 +37,7 @@ class ApplicationMailerTest < ActionMailer::TestCase
       end
     end
 
-    assert_includes logs, [user.email].to_s
+    local, domain = user.email.split('@')
+    assert_includes logs, ["#{local[0]}***@#{domain}"].to_s
   end
 end

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ApplicationMailerTest < ActionMailer::TestCase
+  test 'Mail to inactive address' do
+    user = users(:komagata)
+    logs = []
+
+    Rails.logger.stub(:info, ->(message) { logs << message }) do
+      Mail::TestMailer.stub_any_instance(:deliver!, lambda { |*|
+        raise Postmark::InactiveRecipientError.new(406, '', { 'Message' => "Found inactive addresses: #{user.email}. Inactive" })
+      }) do
+        assert_nothing_raised do
+          UserMailer.welcome(user).deliver_now
+        end
+      end
+    end
+
+    assert_includes logs, [user.email].to_s
+  end
+
+  test 'Mail to inactive address via deliver_later' do
+    user = users(:komagata)
+    logs = []
+
+    Rails.logger.stub(:info, ->(message) { logs << message }) do
+      Mail::TestMailer.stub_any_instance(:deliver!, lambda { |*|
+        raise Postmark::InactiveRecipientError.new(406, '', { 'Message' => "Found inactive addresses: #{user.email}. Inactive" })
+      }) do
+        perform_enqueued_jobs do
+          assert_nothing_raised do
+            UserMailer.welcome(user).deliver_later
+          end
+        end
+      end
+    end
+
+    assert_includes logs, [user.email].to_s
+  end
+end


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issue

#10116

## 概要
Postmarkで配信停止済みになったアドレスへ送信すると `Postmark::InactiveRecipientError` が発生し、バックグラウンドジョブが失敗扱いになりRollbar通知が発生していた。
`ApplicationMailer`に`rescue_from Postmark::InactiveRecipientError`を追加し、発生時はジョブを失敗扱いにせず、対象アドレスをinfoログに記録するようにした。

## 変更確認方法

1. fix/postmark-inactive-recipient-errorをローカルに取り込む
2. `bin/rails test test/mailers/application_mailer_test.rb`でテストが通ることを確認"

話が内部に関わることで、これまでのプラクティスのみではなかなか難しい話もございます。
以下の日報の前半にて、詳しく記載しましたので
参考になれば幸いです。（後半は自作サービスの話なのでスルーしてくださいませ）
https://bootcamp.fjord.jp/reports/127171

⭐️当方9月24日までに卒業を目指しておりまして、誠に勝手ながらレビュワーの受講生様におかれましては今週中にご確認いただけますと幸いです。

## Screenshot
内部変更のためなし

<!-- I want to review in Japanese. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **不具合修正**
  - 無効な宛先へのメール送信時、メールアドレスを一部マスキングしてログに記録するようになりました。
  - ログにはローカル部の先頭1文字とドメインのみが表示されます。
  - 同期・非同期配信のいずれでも、Postmarkの配信停止済みアドレスに関するログが記録されます。
  - 無効なメールリクエストが発生した場合、非同期配信でもエラーが通知されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10499-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->