### PR TITLE
Active Storageのダイレクトアップロードを認証必須にする

### DIFF
--- a/app/controllers/concerns/direct_upload_authentication.rb
+++ b/app/controllers/concerns/direct_upload_authentication.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DirectUploadAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_direct_upload_login
+  end
+
+  private
+
+  def require_direct_upload_login
+    head :unauthorized unless logged_in?
+  end
+end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,4 +1,6 @@
 ActiveSupport::Reloader.to_prepare do
+  ActiveStorage::DirectUploadsController.include DirectUploadAuthentication
+
   Rails.application.configure do
     config.active_storage.variable_content_types << "image/heic"
     config.active_storage.variable_content_types << "image/heif"

--- a/test/controllers/active_storage/direct_uploads_controller_test.rb
+++ b/test/controllers/active_storage/direct_uploads_controller_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActiveStorage::DirectUploadsControllerTest < ActionDispatch::IntegrationTest
+  test 'direct upload requires login' do
+    assert_no_difference('ActiveStorage::Blob.count') do
+      post rails_direct_uploads_path, params: { blob: blob_params }, as: :json
+      assert_response :unauthorized
+    end
+  end
+
+  test 'logged in user can directly upload a file' do
+    sign_in
+
+    assert_difference('ActiveStorage::Blob.count') do
+      post rails_direct_uploads_path, params: { blob: blob_params }, as: :json
+      assert_response :success
+    end
+
+    upload = response.parsed_body
+    blob = ActiveStorage::Blob.find_signed!(upload.fetch('signed_id'))
+    assert_equal 'test.txt', blob.filename.to_s
+
+    put upload.fetch('direct_upload').fetch('url'),
+        params: 'test', headers: upload.fetch('direct_upload').fetch('headers')
+    assert_response :no_content
+    assert_equal 'test', blob.download
+  ensure
+    blob&.purge
+  end
+
+  test 'direct upload is rejected after logout' do
+    sign_in
+    get logout_path
+
+    assert_no_difference('ActiveStorage::Blob.count') do
+      post rails_direct_uploads_path, params: { blob: blob_params }, as: :json
+      assert_response :unauthorized
+    end
+  end
+
+  private
+
+  def sign_in
+    post user_sessions_path, params: { user: { login: users(:kimura).login_name, password: 'testtest' } }
+    assert_redirected_to root_url
+  end
+
+  def blob_params
+    {
+      filename: 'test.txt',
+      byte_size: 4,
+      checksum: Digest::MD5.base64digest('test'),
+      content_type: 'text/plain'
+    }
+  end
+end


### PR DESCRIPTION
## 概要

Active Storage標準のダイレクトアップロードにログインを必須とし、未認証のリクエストではBlobやアップロードURLを作成せず、`401 Unauthorized`を返すようにしました。

標準の`ActiveStorage::DirectUploadsController`は`ApplicationController`を継承しないため、アプリ側のログインチェックが適用されていませんでした。既存のActive Storage initializerで、このコントローラーにSorceryの`logged_in?`を使うConcernを組み込んでいます。

ログイン済みユーザーは、引き続き動画フォームなどからダイレクトアップロードできます。

対応元: https://github.com/fjordllc/bootcamp/pull/10514#issuecomment-5577307376

Refs #10513

## 確認

- [x] 修正前に、未ログイン・ログアウト後の2ケースが`401`ではなく`200`になることをテストで再現
- [x] 修正後に、新規の認証テストと既存の動画API・ユーザーアイコンのテストが成功（15 tests / 75 assertions）
- [x] ログイン済みユーザーでアップロードURL取得→ファイル送信→保存内容の読み出しを確認
- [x] RuboCop（1,237ファイル、違反なし）
- [x] Slim-Lint、`FAIL_ON_ERROR=1 bundle exec rake traceroute`
- [x] `rails zeitwerk:check`、`git diff --check`
- [x] 開発環境の再読み込みを繰り返しても、認証コールバックが1つだけ登録されることを確認
- [x] 独立レビューとClaude Codeレビュー。再読み込み時のコールバック重複の指摘を修正し、再レビューで解消を確認

- [x] [CI](https://github.com/fjordllc/bootcamp/actions/runs/34360458383)：全8テストジョブとLintが成功
- [x] Review Appのデプロイ成功
- [x] 最新コミットに対するCodeRabbitレビュー完了（修正を求める指摘なし、レビュースレッド0件）

テストコマンド:

```sh
bundle exec rails test test/controllers/active_storage/direct_uploads_controller_test.rb test/controllers/api/movies_controller_test.rb test/controllers/user_icons_controller_test.rb
```

ローカルでは専用のPostgreSQL 18.6と空のテストDBを用意し、リポジトリのスキーマとfixtureで検証しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 未ログイン状態での直接アップロードを拒否し、認証済みユーザーのみ利用できるようになりました。
  - 認証済みユーザーは、従来どおり直接アップロードを実行できます。

- **テスト**
  - 未ログイン時の拒否、ログイン後のアップロード、ログアウト後の再拒否を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-app-url:start -->
## Review App

- URL: https://bootcamp-pr-10524-fvlfu45apq-an.a.run.app
- Basic認証: fjord / (ステージングと同じ)
- PR更新時に自動で再デプロイされます。
<!-- review-app-url:end -->